### PR TITLE
Bug 1094317 - Make the Settings page work

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -10,8 +10,24 @@
 		0B4599A81A0AB0180020771C /* Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4599A61A0AB0180020771C /* Bookmarks.swift */; };
 		0B4599A91A0AB0180020771C /* RestAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4599A71A0AB0180020771C /* RestAPI.swift */; };
 		0BA6506A1A131EF2001B04A0 /* AccountManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D6BEBE1A09353A00F538BD /* AccountManager.swift */; };
-		0BE592A51A118B6600FED5E2 /* Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4599A61A0AB0180020771C /* Bookmarks.swift */; };
-		0BE592A81A118B9F00FED5E2 /* RestAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4599A71A0AB0180020771C /* RestAPI.swift */; };
+		0BB90AC01A13EBA5004B76CB /* AccountManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D6BEBE1A09353A00F538BD /* AccountManager.swift */; };
+		0BB90AC31A13EBA8004B76CB /* Panels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCB73FE1A1295DB00466DAE /* Panels.swift */; };
+		0BB90AC41A13EC16004B76CB /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84B21FC1A0910F600AAB793 /* SettingsViewController.swift */; };
+		0BB90AC51A13EC1C004B76CB /* TabsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84B22011A0910F600AAB793 /* TabsViewController.swift */; };
+		0BB90AC61A13EC21004B76CB /* HistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84B221B1A0911BF00AAB793 /* HistoryViewController.swift */; };
+		0BB90AC71A13EC25004B76CB /* BookmarksViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84B22171A0911B500AAB793 /* BookmarksViewController.swift */; };
+		0BB90ACA1A13EC6C004B76CB /* Tabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84B22001A0910F600AAB793 /* Tabs.swift */; };
+		0BB90ACB1A13EC7D004B76CB /* SiteTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84B21FA1A0910F600AAB793 /* SiteTableViewController.swift */; };
+		0BB90ACC1A13EC84004B76CB /* Site.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84B21F91A0910F600AAB793 /* Site.swift */; };
+		0BB90ACD1A13EC95004B76CB /* ReaderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84B21F71A0910F600AAB793 /* ReaderViewController.swift */; };
+		0BB90ACF1A13ED34004B76CB /* AccountPrefs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB90ACE1A13ED34004B76CB /* AccountPrefs.swift */; };
+		0BB90AD01A13F0C2004B76CB /* AccountPrefs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB90ACE1A13ED34004B76CB /* AccountPrefs.swift */; };
+		0BB90AE51A13F764004B76CB /* Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4599A61A0AB0180020771C /* Bookmarks.swift */; };
+		0BB90AE81A13F765004B76CB /* Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4599A61A0AB0180020771C /* Bookmarks.swift */; };
+		0BB90AE91A13F771004B76CB /* RestAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4599A71A0AB0180020771C /* RestAPI.swift */; };
+		0BB90AEA1A13F771004B76CB /* RestAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4599A71A0AB0180020771C /* RestAPI.swift */; };
+		0BB90AEC1A14102E004B76CB /* TestPanels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB90AEB1A14102E004B76CB /* TestPanels.swift */; };
+		0BCB73FF1A1295DB00466DAE /* Panels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCB73FE1A1295DB00466DAE /* Panels.swift */; };
 		0BE592B41A11914C00FED5E2 /* Favicons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BE592B31A11914C00FED5E2 /* Favicons.swift */; };
 		0BE592B61A11921600FED5E2 /* Cursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BE592B51A11921600FED5E2 /* Cursor.swift */; };
 		0BE592B91A11EE1700FED5E2 /* Favicons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BE592B31A11914C00FED5E2 /* Favicons.swift */; };
@@ -158,6 +174,9 @@
 /* Begin PBXFileReference section */
 		0B4599A61A0AB0180020771C /* Bookmarks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bookmarks.swift; sourceTree = "<group>"; };
 		0B4599A71A0AB0180020771C /* RestAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RestAPI.swift; sourceTree = "<group>"; };
+		0BB90ACE1A13ED34004B76CB /* AccountPrefs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountPrefs.swift; sourceTree = "<group>"; };
+		0BB90AEB1A14102E004B76CB /* TestPanels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestPanels.swift; sourceTree = "<group>"; };
+		0BCB73FE1A1295DB00466DAE /* Panels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Panels.swift; sourceTree = "<group>"; };
 		0BE592B31A11914C00FED5E2 /* Favicons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Favicons.swift; sourceTree = "<group>"; };
 		0BE592B51A11921600FED5E2 /* Cursor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cursor.swift; sourceTree = "<group>"; };
 		E4D6BEA51A092A4700F538BD /* Login.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Login.xcassets; sourceTree = "<group>"; };
@@ -250,6 +269,8 @@
 				0B4599A71A0AB0180020771C /* RestAPI.swift */,
 				0BE592B31A11914C00FED5E2 /* Favicons.swift */,
 				0BE592B51A11921600FED5E2 /* Cursor.swift */,
+				0BCB73FE1A1295DB00466DAE /* Panels.swift */,
+				0BB90ACE1A13ED34004B76CB /* AccountPrefs.swift */,
 			);
 			path = Database;
 			sourceTree = "<group>";
@@ -304,6 +325,7 @@
 			children = (
 				F84B21D91A090F8100AAB793 /* ClientTests.swift */,
 				F84B21D71A090F8100AAB793 /* Supporting Files */,
+				0BB90AEB1A14102E004B76CB /* TestPanels.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -735,11 +757,13 @@
 				0B4599A91A0AB0180020771C /* RestAPI.swift in Sources */,
 				F84B22141A0910F600AAB793 /* TabsViewController.swift in Sources */,
 				0BE592BA1A11EE1A00FED5E2 /* Cursor.swift in Sources */,
+				0BCB73FF1A1295DB00466DAE /* Panels.swift in Sources */,
 				F84B22041A0910F600AAB793 /* AppDelegate.swift in Sources */,
 				F84B22241A09122500AAB793 /* TabBarViewController.swift in Sources */,
 				0BA6506A1A131EF2001B04A0 /* AccountManager.swift in Sources */,
 				F84B220F1A0910F600AAB793 /* Site.swift in Sources */,
 				F84B22111A0910F600AAB793 /* SettingsViewController.swift in Sources */,
+				0BB90ACF1A13ED34004B76CB /* AccountPrefs.swift in Sources */,
 				0B4599A81A0AB0180020771C /* Bookmarks.swift in Sources */,
 				0BE592B91A11EE1700FED5E2 /* Favicons.swift in Sources */,
 				F84B221D1A0911BF00AAB793 /* HistoryViewController.swift in Sources */,
@@ -753,11 +777,23 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0BB90AE91A13F771004B76CB /* RestAPI.swift in Sources */,
 				0BE592B41A11914C00FED5E2 /* Favicons.swift in Sources */,
-				0BE592A81A118B9F00FED5E2 /* RestAPI.swift in Sources */,
 				F84B21DA1A090F8100AAB793 /* ClientTests.swift in Sources */,
-				0BE592A51A118B6600FED5E2 /* Bookmarks.swift in Sources */,
 				0BE592B61A11921600FED5E2 /* Cursor.swift in Sources */,
+				0BB90AC71A13EC25004B76CB /* BookmarksViewController.swift in Sources */,
+				0BB90AC01A13EBA5004B76CB /* AccountManager.swift in Sources */,
+				0BB90AEC1A14102E004B76CB /* TestPanels.swift in Sources */,
+				0BB90ACB1A13EC7D004B76CB /* SiteTableViewController.swift in Sources */,
+				0BB90ACA1A13EC6C004B76CB /* Tabs.swift in Sources */,
+				0BB90ACD1A13EC95004B76CB /* ReaderViewController.swift in Sources */,
+				0BB90AC31A13EBA8004B76CB /* Panels.swift in Sources */,
+				0BB90AC61A13EC21004B76CB /* HistoryViewController.swift in Sources */,
+				0BB90AC51A13EC1C004B76CB /* TabsViewController.swift in Sources */,
+				0BB90AE51A13F764004B76CB /* Bookmarks.swift in Sources */,
+				0BB90ACC1A13EC84004B76CB /* Site.swift in Sources */,
+				0BB90AD01A13F0C2004B76CB /* AccountPrefs.swift in Sources */,
+				0BB90AC41A13EC16004B76CB /* SettingsViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -765,8 +801,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0BB90AEA1A13F771004B76CB /* RestAPI.swift in Sources */,
 				F8708D321A0970B70051AB07 /* ShareViewController.swift in Sources */,
 				E4D6BEC01A09355C00F538BD /* AccountManager.swift in Sources */,
+				0BB90AE81A13F765004B76CB /* Bookmarks.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -19,13 +19,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate
         let loginViewController = LoginViewController()
         loginViewController.accountManager = accountManager
 
-        let tabBarViewController = TabBarViewController(nibName: "TabBarViewController", bundle: nil)
-        tabBarViewController.accountManager = accountManager
+        let tabBarViewController = TabBarViewController(nibName: "TabBarViewController", bundle: nil, accountManager: accountManager)
 
         accountManager.loginCallback = {
             // Show the tab controller once the user logs in.
             self.window.rootViewController = tabBarViewController
         }
+
         accountManager.logoutCallback = {
             // Show the login controller once the user logs out.
             self.window.rootViewController = loginViewController

--- a/Client/Frontend/Bookmarks/BookmarksViewController.swift
+++ b/Client/Frontend/Bookmarks/BookmarksViewController.swift
@@ -18,7 +18,7 @@ func createMockFavicon(icon: UIImage) -> UIImage {
     return image
 }
 
-class BookmarksViewController: UITableViewController
+class BookmarksViewController: ToolbarTableViewController 
 {
     var bookmarks: [Bookmark] = [];
     // TODO: Move this to the authenticator when its available.

--- a/Client/Frontend/History/HistoryViewController.swift
+++ b/Client/Frontend/History/HistoryViewController.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-class HistoryViewController: UIViewController {
+class HistoryViewController: ToolbarViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Client/Frontend/Login/AccountManager.swift
+++ b/Client/Frontend/Login/AccountManager.swift
@@ -13,9 +13,11 @@ struct Credentials {
     var password: NSString!
 }
 
+var ACCOUNT_MANAGER_KEY: String = "ACCOUNT_MANAGER_KEY";
+
 class AccountManager: NSObject {
-    var loginCallback: (() -> ())!
-    var logoutCallback: (() -> ())!
+    var loginCallback = { () -> Void in }
+    var logoutCallback = { () -> Void in }
 
     func isLoggedIn() -> Bool {
         var isLoggedIn: Bool = false

--- a/Client/Frontend/Reader/ReaderViewController.xib
+++ b/Client/Frontend/Reader/ReaderViewController.xib
@@ -4,7 +4,7 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ReaderViewController" customModule="ToolbarExperiment" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ReaderViewController" customModule="Client" customModuleProvider="target">
             <connections>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
                 <outlet property="webView" destination="Vwm-ub-fUV" id="Uxz-4s-K30"/>

--- a/Client/Frontend/Reader/SiteTableViewController.swift
+++ b/Client/Frontend/Reader/SiteTableViewController.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-class SiteTableViewController: UITableViewController
+class SiteTableViewController: ToolbarTableViewController
 {
     // TODO: Move this to the authenticator when its available.
     var favicons: Favicons = BasicFavicons();

--- a/Client/Frontend/Settings/SettingsViewController.xib
+++ b/Client/Frontend/Settings/SettingsViewController.xib
@@ -17,7 +17,7 @@
         </mutableArray>
     </customFonts>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SettingsViewController" customModule="ToolbarExperiment" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SettingsViewController" customModule="Client" customModuleProvider="target">
             <connections>
                 <outlet property="avatarImageView" destination="MEi-ax-1qK" id="QJ3-0P-66u"/>
                 <outlet property="emailLabel" destination="42Z-bf-iCM" id="mpl-qo-W7f"/>

--- a/Client/Frontend/Tabs/TabsViewController.swift
+++ b/Client/Frontend/Tabs/TabsViewController.swift
@@ -5,7 +5,7 @@
 import UIKit
 import Alamofire
 
-class TabsViewController: UITableViewController
+class TabsViewController: ToolbarTableViewController
 {
     var tabsResponse: TabsResponse?
     // TODO: Move this to the authenticator when its available.

--- a/ClientTests/ClientTests.swift
+++ b/ClientTests/ClientTests.swift
@@ -92,3 +92,7 @@ class ClientTests: XCTestCase {
         XCTAssertFalse(ran, "for...in didn't run for failed cursor");
     }
 }
+
+
+
+

--- a/ClientTests/TestPanels.swift
+++ b/ClientTests/TestPanels.swift
@@ -1,0 +1,115 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import XCTest
+
+class TestPanels: XCTestCase {
+    var account: AccountManager?
+
+    override func setUp() {
+        self.account = AccountManager()
+        self.account!.login("2000testUser", password: "testPassword")
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        let prefs = AccountPrefs(accountManager: account!)!
+        prefs.setObject(nil, forKey: "PANELS_ENABLED");
+        prefs.setObject(nil, forKey: "PANELS_ORDER");
+        validatePrefs(nil, expectEnabled: nil);
+        account!.logout();
+
+        super.tearDown()
+    }
+
+    
+    func testPanels() {
+        validatePrefs(nil, expectEnabled: nil);
+        
+        var panels = Panels(accountManager: account!)
+        XCTAssertEqual(panels.count, 5, "Right number of panels found");
+        
+        // Test moving an item
+        var a = panels[0];
+        var b = panels[1];
+        expectNotification("Moving an item should notify us") { () -> Void in
+            panels.moveItem(1, to: 0);
+        }
+        validatePrefs(["Bookmarks", "Tabs", "History", "Reader", "Settings"],
+                      expectEnabled: [true, true, true, true, true]);
+        
+        XCTAssertNotEqual(a.title, panels[0].title, "Original panel is not in place any more")
+        XCTAssertEqual(a.title, panels[1].title, "Original panel was moved")
+        XCTAssertEqual(b.title, panels[0].title, "Second panel was moved")
+        expectNotification("Moving an item should notify us") { () -> Void in
+            panels.moveItem(1, to: 0);
+        }
+        validatePrefs(["Tabs", "Bookmarks", "History", "Reader", "Settings"],
+                      expectEnabled: [true, true, true, true, true]);
+
+        // Tests enabling/disabling items
+        var enabledPanels = panels.enabledItems;
+        // XCTAssertEqual(enabledPanels.count, 5, "Right number of enabled panels found");
+        expectNotification("Disabling a panel should fire a notification") { () -> Void in
+            panels.enablePanelAt(false, position: 0);
+        }
+        validatePrefs(["Tabs", "Bookmarks", "History", "Reader", "Settings"],
+                      expectEnabled: [false, true, true, true, true]);
+        
+        XCTAssertEqual(enabledPanels.count, 5, "Right number of enabled panels found"); // Still holding a old reference
+        enabledPanels = panels.enabledItems;
+        XCTAssertEqual(enabledPanels.count, 4, "Right number of enabled panels found");
+        XCTAssertEqual(panels.count, 5, "Total panels shouldn't change");
+        expectNotification("Enabling a panel should fire a notification") { () -> Void in
+            panels.enablePanelAt(true, position: 0);
+        }
+        validatePrefs(["Tabs", "Bookmarks", "History", "Reader", "Settings"],
+                      expectEnabled: [true, true, true, true, true]);
+    }
+
+    private func expectNotification(description: String, method: () -> Void) {
+        var expectation = expectationWithDescription(description)
+        var fulfilled = false;
+        var token :AnyObject?;
+        token = NSNotificationCenter.defaultCenter().addObserverForName(PanelsNotificationName, object: nil, queue: nil) { notif in
+            if (token != nil) {
+                fulfilled = true;
+                expectation.fulfill();
+                NSNotificationCenter.defaultCenter().removeObserver(token!)
+            } else {
+                XCTAssert(false, "notification before observer was even added?");
+            }
+        }
+        method();
+        waitForExpectationsWithTimeout(10.0, handler:nil)
+        XCTAssertTrue(fulfilled, "Received notification of change")
+    }
+    
+    private func validatePrefs<T : AnyObject>(prefs: AccountPrefs, data: [T]?, key: String) {
+        if var data2 = prefs.arrayForKey(key) as? [T] {
+            if (data != nil) {
+                XCTAssertTrue(true, "Should find \(key) prefs");
+            } else {
+                XCTAssertTrue(false, "Should not find \(key) prefs but did");
+            }
+        } else {
+            if (data != nil) {
+                XCTAssertTrue(false, "Should find \(key) prefs but didn't");
+            } else {
+                XCTAssertTrue(true, "Should not find \(key) prefs");
+            }
+        }
+    }
+    
+    private func validatePrefs(expectOrder: [String]?, expectEnabled: [Bool]?) {
+        let prefs = AccountPrefs(accountManager: account!)!
+        validatePrefs(prefs, data: expectOrder, key: "PANELS_ORDER");
+        validatePrefs(prefs, data: expectEnabled, key: "PANELS_ENABLED");
+    }
+}
+
+
+
+

--- a/Database/AccountPrefs.swift
+++ b/Database/AccountPrefs.swift
@@ -1,0 +1,102 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+class AccountPrefs : NSUserDefaults {
+    private let accountManager:AccountManager
+
+    init?(accountManager: AccountManager) {
+        self.accountManager = accountManager
+        super.init(suiteName: SuiteName)
+    }
+
+    private func qualifyKey(key:String) -> String {
+        return self.accountManager.getUsername() + key
+    }
+    
+    override func setBool(value: Bool, forKey defaultName: String) {
+        super.setBool(value, forKey: qualifyKey(defaultName))
+    }
+
+    override func setDouble(value: Double, forKey defaultName: String) {
+        super.setDouble(value, forKey: qualifyKey(defaultName))
+    }
+
+    override func setInteger(value: Int, forKey defaultName: String) {
+        super.setInteger(value, forKey: qualifyKey(defaultName))
+    }
+
+    override func setFloat(value: Float, forKey defaultName: String) {
+        super.setFloat(value, forKey: qualifyKey(defaultName))
+    }
+
+    override func setNilValueForKey(key: String) {
+        super.setNilValueForKey(qualifyKey(key))
+    }
+
+    override func setObject(value: AnyObject?, forKey defaultName: String) {
+        super.setObject(value, forKey: qualifyKey(defaultName))
+    }
+
+    override func setPersistentDomain(domain: [NSObject : AnyObject], forName domainName: String) {
+        super.setPersistentDomain(domain, forName: qualifyKey(domainName))
+    }
+
+    override func setURL(url: NSURL, forKey defaultName: String) {
+        super.setURL(url, forKey: qualifyKey(defaultName))
+    }
+
+    override func setValue(value: AnyObject?, forKey key: String) {
+        super.setValue(value, forKey: qualifyKey(key))
+    }
+
+    override func setValue(value: AnyObject?, forKeyPath keyPath: String) {
+        super.setValue(value, forKeyPath: qualifyKey(keyPath))
+    }
+
+    override func setValue(value: AnyObject?, forUndefinedKey key: String) {
+        super.setValue(value, forUndefinedKey: qualifyKey(key))
+    }
+
+    override func boolForKey(defaultName: String) -> Bool {
+        return super.boolForKey(qualifyKey(defaultName))
+    }
+
+    override func stringForKey(defaultName: String) -> String? {
+        return super.stringForKey(qualifyKey(defaultName))
+    }
+
+    override func integerForKey(defaultName: String) -> Int {
+        return super.integerForKey(qualifyKey(defaultName))
+    }
+
+    override func doubleForKey(defaultName: String) -> Double {
+        return super.doubleForKey(qualifyKey(defaultName))
+    }
+
+    override func floatForKey(defaultName: String) -> Float {
+        return super.floatForKey(qualifyKey(defaultName))
+    }
+
+    override func stringArrayForKey(defaultName: String) -> [AnyObject]? {
+        return super.stringArrayForKey(qualifyKey(defaultName))
+    }
+
+    override func arrayForKey(defaultName: String) -> [AnyObject]? {
+        return super.arrayForKey(qualifyKey(defaultName))
+    }
+
+    override func dictionaryForKey(defaultName: String) -> [NSObject : AnyObject]? {
+        return super.dictionaryForKey(qualifyKey(defaultName))
+    }
+
+    override func URLForKey(defaultName: String) -> NSURL? {
+        return super.URLForKey(qualifyKey(defaultName))
+    }
+    
+    override func removeObjectForKey(defaultName: String) {
+        super.removeObjectForKey(qualifyKey(defaultName));
+    }
+}

--- a/Database/Panels.swift
+++ b/Database/Panels.swift
@@ -1,0 +1,215 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import UIKit
+
+/*
+ * This protocol is used for instantiating new tab panels. It ensures
+ * they all have the same constructor which includes an AccountManager params
+ */
+protocol ToolbarViewProtocol {
+    init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?, accountManager: AccountManager);
+}
+
+/*
+ * This is a stub implementation of the ToolbarViewProtocol for normal UIViewControllers
+ */
+class ToolbarViewController: UIViewController, ToolbarViewProtocol {
+    let accountManager: AccountManager;
+    
+    required init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?, accountManager: AccountManager) {
+        self.accountManager = accountManager;
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil);
+    }
+
+    required init(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+/*
+ * This is a stub implementation of the ToolbarViewProtocol for normal UITableViewControllers
+ */
+class ToolbarTableViewController: UITableViewController, ToolbarViewProtocol {
+    let accountManager: AccountManager!
+    
+    required init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?, accountManager: AccountManager) {
+        self.accountManager = accountManager;
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil);
+    }
+
+    required init(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+/*
+ * This struct holds basic data about the tabs shown in our UI.
+ */
+struct ToolbarItem {
+    let title: String /* We use title all over the palce as a unique identifier. Be careful not to have duplicates */
+    let imageName: String
+    let generator: (accountManager: AccountManager) -> UIViewController
+    var enabled : Bool
+}
+
+/*
+ * A list of tabs to show. Order is important here. The order (and enabled state) listed here represent the defaults for the app.
+ * This will be rearranged on startup to make the order stored/enabled-states set in NSUserDefaults.
+ */
+private var Controllers: [ToolbarItem] = [
+    ToolbarItem(title: "Tabs", imageName: "tabs", generator: { (accountManager: AccountManager) -> UIViewController in
+        return TabsViewController(nibName: nil, bundle: nil, accountManager: accountManager)
+    }, enabled: true),
+    ToolbarItem(title: "Bookmarks", imageName: "bookmarks", generator: { (accountManager: AccountManager) -> UIViewController in
+        return BookmarksViewController(nibName: nil, bundle: nil, accountManager: accountManager)
+    }, enabled: true),
+    ToolbarItem(title: "History", imageName: "history", generator: { (accountManager: AccountManager) -> UIViewController in
+        return HistoryViewController(nibName: "HistoryViewController", bundle: nil, accountManager: accountManager)
+    }, enabled: true),
+    ToolbarItem(title: "Reader", imageName: "reader", generator: { (accountManager: AccountManager) -> UIViewController in
+        return SiteTableViewController(nibName: nil, bundle: nil, accountManager: accountManager)
+    }, enabled: true),
+    ToolbarItem(title: "Settings", imageName: "settings",  generator: { (accountManager: AccountManager) -> UIViewController in
+        return SettingsViewController(nibName: "SettingsViewController", bundle: nil, accountManager: accountManager)
+    }, enabled: true),
+]
+
+private var setup: Bool = false // True if we've already loaded the order/enabled prefs once and the Controllers array has been updated
+let PanelsNotificationName = "PANELS_NOTIFICATION_NAME" // A constant to use for Notifications of changes to the panel dataset
+
+// A helper function for finding the index of a ToolbarItem with a particular title in Controllers. This isn't going to be fast, but assuming
+// controllers isn't ever huge, it shouldn't matter.
+private func indexOf(val: String) -> Int {
+    var i = 0;
+    for controller in Controllers {
+        if (controller.title == val) {
+            return i
+        }
+        i++
+    }
+    return -1
+}
+
+/*
+ * The main object people wanting to interact with panels should use.
+ */
+class Panels : SequenceType {
+    // Keys for prefs where we store panel data
+    private let PanelsOrderKey : String = "PANELS_ORDER"
+    private let PanelsEnabledKey : String = "PANELS_ENABLED"
+
+    private let accountManager : AccountManager
+
+    /*
+     * Returns a list of enabled items. This list isn't live. If you're using it,
+     * you should also register for notifications of changes so that you can obtain a more
+     * up-to-date dataset.
+     */
+    var enabledItems : [ToolbarItem] {
+        var res : [ToolbarItem] = []
+        for controller in Controllers {
+            if (controller.enabled) {
+                res.append(controller)
+            }
+        }
+
+        return res
+    }
+
+    /* 
+     * Moves an item in the list..
+     */
+    func moveItem(from: Int, to: Int) {
+        if (from == to) {
+            return
+        }
+
+        let a = Controllers.removeAtIndex(from);
+        Controllers.insert(a, atIndex: to)
+
+        saveConfig() { self.notifyChange() }
+    }
+
+    private func notifyChange() {
+        let notif = NSNotification(name: PanelsNotificationName, object: nil);
+        NSNotificationCenter.defaultCenter().postNotification(notif)
+    }
+    
+    /*
+     * Enables or disables the panel at an index
+     * TODO: This would be nicer if just calling panel.enabled = X; did the same thing
+     */
+    func enablePanelAt(enabled: Bool, position: Int) {
+        if (Controllers[position].enabled == enabled) {
+            return
+        }
+
+        Controllers[position].enabled = enabled;
+        saveConfig() { self.notifyChange() }
+    }
+
+    /*
+     * Saves an updated order and enabled dataset to UserDefaults
+     */
+    private func saveConfig(callback: () -> Void) {
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
+            var order = [String]()
+            var enabled = [Bool]()
+
+            for controller in Controllers {
+                order.append(controller.title)
+                enabled.append(controller.enabled)
+            }
+
+            let prefs = AccountPrefs(accountManager: self.accountManager)!
+            prefs.setObject(order, forKey: self.PanelsOrderKey)
+            prefs.setObject(enabled, forKey: self.PanelsEnabledKey)
+
+            dispatch_async(dispatch_get_main_queue()) {
+                callback();
+            }
+        }
+    }
+
+    init(accountManager : AccountManager) {
+        self.accountManager = accountManager;
+
+        if (!setup) {
+            let prefs = AccountPrefs(accountManager: accountManager)!
+            if let enabled = prefs.arrayForKey(PanelsEnabledKey) as? [Bool] {
+                if let order = prefs.arrayForKey(PanelsOrderKey) as? [String] {
+                    for (index:Int, title:String) in enumerate(order) {
+                        var i = indexOf(title)
+                        if (i >= 0) {
+                            var a = Controllers.removeAtIndex(i)
+                            a.enabled = enabled[index]
+                            Controllers.insert(a, atIndex: index)
+                        }
+                    }
+                }
+            }
+            setup = true;
+        }
+    }
+
+    var count: Int {
+        return Controllers.count;
+    }
+    
+    subscript(index: Int) -> ToolbarItem {
+        return Controllers[index]
+    }
+
+    func generate() -> GeneratorOf<ToolbarItem> {
+        var nextIndex = 0;
+        return GeneratorOf<ToolbarItem>() {
+            if (nextIndex >= Controllers.count) {
+                return nil
+            }
+            return Controllers[nextIndex++]
+        }
+    }
+}


### PR DESCRIPTION
This implements a Panels class that handles most of the questions of "What panels exist? Which ones are enabled?" questions, as well as allowing some basic reordering/enabling/disabling. It fires notifications when its dataset changes, and we use those to update the UI. The UI updates aren't animated (yet...)

I wanted to store this configuration in UserDefaults (because that's easy), but there wasn't a clear way to make tie those prefs to a Firefox Account, so I wrote a little wrapper around it as well. 
