### PR TITLE
Bug 1112228 - Fix tabbed browsing issues

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -28,10 +28,6 @@ class TabManager {
         return tabs[selectedIndex]
     }
 
-    func getTabs() -> [Browser] {
-        return tabs
-    }
-
     func getTab(index: Int) -> Browser {
         return tabs[index]
     }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -7,10 +7,8 @@ import UIKit
 
 private let StatusBarHeight = 20
 
-class TabTrayController: UIViewController, UITabBarDelegate {
-    var tabManager: TabManager?
-    private var tabDataSource: TabTableDataSource?
-    private var tabDelegate: TabTableDelegate?
+class TabTrayController: UIViewController, UITabBarDelegate, UITableViewDelegate, UITableViewDataSource {
+    var tabManager: TabManager!
 
     override func viewDidLoad() {
         let toolbar = UIToolbar()
@@ -22,21 +20,8 @@ class TabTrayController: UIViewController, UITabBarDelegate {
         toolbar.items = [doneItem, spacer, addTabItem]
 
         let tabTableView = UITableView()
-        if var tabs = tabManager?.getTabs() {
-            tabDataSource = TabTableDataSource(tabs: &tabs, selectedTab: tabManager!.selectedTab, { [unowned self] tab in
-                self.tabManager?.removeTab(tab)
-                self.tabDataSource?.selectedTab = self.tabManager?.selectedTab
-                return
-            })
-
-            tabDelegate = TabTableDelegate(tabs: &tabs, { [unowned self] tab in
-                self.tabManager?.selectTab(tab)
-                self.dismissViewControllerAnimated(true, completion: nil)
-            })
-
-            tabTableView.dataSource = tabDataSource
-            tabTableView.delegate = tabDelegate
-        }
+        tabTableView.dataSource = self
+        tabTableView.delegate = self
         view.addSubview(tabTableView)
 
         toolbar.snp_makeConstraints { make in
@@ -59,48 +44,28 @@ class TabTrayController: UIViewController, UITabBarDelegate {
         tabManager?.addTab()
         dismissViewControllerAnimated(true, completion: nil)
     }
-}
-
-private class TabTableDelegate: NSObject, UITableViewDelegate {
-    let tabs: [Browser]
-    let selectCallback: Browser -> ()
-
-    init (inout tabs: [Browser], selectCallback: Browser -> ()) {
-        self.tabs = tabs
-        self.selectCallback = selectCallback
-    }
 
     func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
-        selectCallback(tabs[indexPath.item])
-    }
-}
-
-private class TabTableDataSource: NSObject, UITableViewDataSource {
-    var tabs: [Browser]
-    var selectedTab: Browser?
-    let removeCallback: Browser -> ()
-
-    init (inout tabs: [Browser], selectedTab: Browser?, removeCallback: Browser -> ()) {
-        self.tabs = tabs
-        self.selectedTab = selectedTab
-        self.removeCallback = removeCallback
+        let tab = tabManager.getTab(indexPath.item)
+        tabManager.selectTab(tab)
+        dismissViewControllerAnimated(true, completion: nil)
     }
 
     func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return tabs.count
+        return tabManager.count
     }
 
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let tab = tabs[indexPath.item]
+        let tab = tabManager.getTab(indexPath.item)
         let cell = UITableViewCell()
         cell.textLabel?.text = tab.url?.absoluteString
-        cell.selected = (tab === selectedTab)
+        cell.selected = (tab === tabManager.selectedTab)
         return cell
     }
 
-    private func tableView(tableView: UITableView, commitEditingStyle editingStyle: UITableViewCellEditingStyle, forRowAtIndexPath indexPath: NSIndexPath) {
-        let tab = tabs.removeAtIndex(indexPath.item)
+    func tableView(tableView: UITableView, commitEditingStyle editingStyle: UITableViewCellEditingStyle, forRowAtIndexPath indexPath: NSIndexPath) {
+        let tab = tabManager.getTab(indexPath.item)
+        tabManager.removeTab(tab)
         tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: UITableViewRowAnimation.Automatic)
-        removeCallback(tab)
     }
 }


### PR DESCRIPTION
I'm still not quite used to Swift's copy-on-write behavior for arrays, and there are several bugs in TabTrayController that can cause the tabs arrays to get out-of-sync between the delegate and the data source. I got halfway there by using inout in the initializers, but then they end up getting copied immediately after that when the initializer assigns them [1]. That means the tabs arrays in the delegate/data source are still copies -- not references -- to the arrays given to them, so when the data source changes the array [2], that change isn't reflected in the delegate array.

I think the most straighforward fix to this is to implement all of the protocols in TabTrayController so they have access to the same shared data structures. I originally kept the delegate/data source classes separate since I was playing around with the BVC owning them, but there's no need for the separation now.

[1] https://github.com/mozilla/firefox-ios/blob/bdedf9ed54fa4ffdf2e696704019d379ef244fa1/Client/Frontend/Browser/TabTrayController.swift#L84
[2] https://github.com/mozilla/firefox-ios/blob/bdedf9ed54fa4ffdf2e696704019d379ef244fa1/Client/Frontend/Browser/TabTrayController.swift#L102
