### PR TITLE
Bug 1109647 Add progress loading

### DIFF
--- a/Client/Frontend/Browser/BrowserToolbar.swift
+++ b/Client/Frontend/Browser/BrowserToolbar.swift
@@ -21,6 +21,7 @@ class BrowserToolbar: UIView, UITextFieldDelegate {
     private var backButton: UIButton!
     private var toolbarTextButton: UIButton!
     private var tabsButton: UIButton!
+    private var progressBar: UIProgressView!
 
     private var longPressGestureBackButton: UILongPressGestureRecognizer!
     private var longPressGestureForwardButton: UILongPressGestureRecognizer!
@@ -69,6 +70,10 @@ class BrowserToolbar: UIView, UITextFieldDelegate {
         toolbarTextButton.addTarget(self, action: "SELdidClickToolbar", forControlEvents: UIControlEvents.TouchUpInside)
         self.addSubview(toolbarTextButton)
 
+        progressBar = UIProgressView()
+        self.progressBar.trackTintColor = self.backgroundColor
+        self.addSubview(progressBar)
+
         tabsButton = UIButton()
         tabsButton.setTitleColor(UIColor.blackColor(), forState: UIControlState.Normal)
         tabsButton.titleLabel?.layer.borderColor = UIColor.blackColor().CGColor
@@ -106,6 +111,11 @@ class BrowserToolbar: UIView, UITextFieldDelegate {
             make.width.height.equalTo(44)
             make.right.equalTo(self).offset(-8)
         }
+
+        self.progressBar.snp_remakeConstraints { make in
+            make.centerY.equalTo(self.snp_bottom)
+            make.width.equalTo(self)
+        }
     }
 
     func updateURL(url: NSURL?) {
@@ -138,5 +148,16 @@ class BrowserToolbar: UIView, UITextFieldDelegate {
 
     func SELdidClickToolbar() {
         browserToolbarDelegate?.didBeginEditing()
+    }
+
+    func updateProgressBar(progress: Float) {
+        if progress == 1.0 {
+            self.progressBar.setProgress(progress, animated: true)
+            UIView.animateWithDuration(1.5, animations: {self.progressBar.alpha = 0.0},
+                completion: {_ in self.progressBar.setProgress(0.0, animated: false)})
+        } else {
+            self.progressBar.alpha = 1.0
+            self.progressBar.setProgress(progress, animated: true)
+        }
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -78,6 +78,7 @@ class BrowserViewController: UIViewController, BrowserToolbarDelegate, TabManage
         previous?.webView.navigationDelegate = nil
         selected?.webView.navigationDelegate = self
         toolbar.updateURL(selected?.url)
+        toolbar.updateProgressBar(0.0)
     }
 
     func didAddTab(tab: Browser) {
@@ -89,16 +90,28 @@ class BrowserViewController: UIViewController, BrowserToolbarDelegate, TabManage
             make.top.equalTo(self.toolbar.snp_bottom)
             make.leading.trailing.bottom.equalTo(self.view)
         }
+        tab.webView.addObserver(self, forKeyPath: "estimatedProgress", options: .New, context: nil)
         tab.loadRequest(NSURLRequest(URL: NSURL(string: "http://www.mozilla.org")!))
     }
 
     func didRemoveTab(tab: Browser) {
         toolbar.updateTabCount(tabManager.count)
 
+        tab.webView.removeObserver(self, forKeyPath: "estimatedProgress")
         tab.webView.removeFromSuperview()
     }
 
     func webView(webView: WKWebView, didCommitNavigation navigation: WKNavigation!) {
         toolbar.updateURL(webView.URL);
+    }
+
+    override func observeValueForKeyPath(keyPath: String, ofObject object:
+        AnyObject, change:[NSObject: AnyObject], context:
+        UnsafeMutablePointer<Void>) {
+            if keyPath == "estimatedProgress" && object as? WKWebView == tabManager.selectedTab?.webView {
+                if let progress = change[NSKeyValueChangeNewKey] as Float? {
+                    toolbar.updateProgressBar(progress)
+                }
+            }
     }
 }


### PR DESCRIPTION
Here is a simple implementation of the browser loading progress. Not sure if later down the road we should be trying to keep only one KVO each time we switch tabs? Anyways I hope this points us in the right direction.

As always I appreciate the team's thoughts.

Thanks
