### PR TITLE
Bug 1330894 - Enable Enpass Password Manager Support

### DIFF
--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -114,6 +114,7 @@ private extension ShareExtensionHelper {
         // If your extension's bundle identifier does not contain "password", simply submit a pull request by adding your bundle identifier.
         return (activityType?.rangeOfString("password") != nil)
             || (activityType == "com.lastpass.ilastpass.LastPassExt")
+            || (activityType == "in.sinew.Walletx.WalletxExt")
 
     }
 


### PR DESCRIPTION
Add Enpass Extension bundle identifier to support auto filling
passwords from Enpass Password Manager, because its bundle identifier
doesn’t contain string 'password'.

Enpass was previously known as Walletx.
One can more info about Enpass here [www.enpass.io](url)
