### PR TITLE
Bug 1238971 – Session navigation history (per tab) lost on session restoration

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -641,6 +641,9 @@
 		E6F965421B2F25110034B023 /* NSMutableAttributedStringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F965411B2F25110034B023 /* NSMutableAttributedStringExtensionsTests.swift */; };
 		E6F9659C1B2F5F800034B023 /* effective_tld_names.dat in Resources */ = {isa = PBXBuildFile; fileRef = E6F9659B1B2F5F800034B023 /* effective_tld_names.dat */; };
 		E6F9659E1B2F63A20034B023 /* NSStringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F9659D1B2F63A20034B023 /* NSStringExtensions.swift */; };
+		F35B8D2B1D6380EA008E3D61 /* SessionRestore.html in Resources */ = {isa = PBXBuildFile; fileRef = F35B8D2A1D6380EA008E3D61 /* SessionRestore.html */; };
+		F35B8D2D1D6383E9008E3D61 /* SessionRestoreHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F35B8D2C1D6383E9008E3D61 /* SessionRestoreHelper.swift */; };
+		F35B8D2F1D638408008E3D61 /* SessionRestoreHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F35B8D2E1D638408008E3D61 /* SessionRestoreHandler.swift */; };
 		F84B21DA1A090F8100AAB793 /* ClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84B21D91A090F8100AAB793 /* ClientTests.swift */; };
 		F84B22041A0910F600AAB793 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84B21E51A0910F600AAB793 /* AppDelegate.swift */; };
 		F84B220B1A0910F600AAB793 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F84B21EF1A0910F600AAB793 /* Images.xcassets */; };
@@ -1699,6 +1702,9 @@
 		E6F9659B1B2F5F800034B023 /* effective_tld_names.dat */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = effective_tld_names.dat; path = ../effective_tld_names.dat; sourceTree = "<group>"; };
 		E6F9659D1B2F63A20034B023 /* NSStringExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSStringExtensions.swift; sourceTree = "<group>"; };
 		E6FCC43C1C40565200DF6113 /* FirefoxBeta.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = FirefoxBeta.xcconfig; path = Configuration/FirefoxBeta.xcconfig; sourceTree = "<group>"; };
+		F35B8D2A1D6380EA008E3D61 /* SessionRestore.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = SessionRestore.html; sourceTree = "<group>"; };
+		F35B8D2C1D6383E9008E3D61 /* SessionRestoreHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreHelper.swift; sourceTree = "<group>"; };
+		F35B8D2E1D638408008E3D61 /* SessionRestoreHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreHandler.swift; sourceTree = "<group>"; };
 		F84B21BE1A090F8100AAB793 /* Client.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Client.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F84B21D31A090F8100AAB793 /* ClientTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ClientTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F84B21D81A090F8100AAB793 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -2726,6 +2732,8 @@
 				D3C744CC1A687D6C004CE85D /* URIFixup.swift */,
 				0BF0DB931A8545800039F300 /* URLBarView.swift */,
 				E4ECD0871B70FD4F00B90D22 /* WindowCloseHelper.swift */,
+				F35B8D2C1D6383E9008E3D61 /* SessionRestoreHelper.swift */,
+				F35B8D2E1D638408008E3D61 /* SessionRestoreHandler.swift */,
 			);
 			path = Browser;
 			sourceTree = "<group>";
@@ -3202,6 +3210,7 @@
 				F84B21EF1A0910F600AAB793 /* Images.xcassets */,
 				E699220D1B94E3EF007C480D /* About */,
 				F84B22391A0914A300AAB793 /* Fonts */,
+				F35B8D2A1D6380EA008E3D61 /* SessionRestore.html */,
 			);
 			path = Assets;
 			sourceTree = "<group>";
@@ -4207,6 +4216,7 @@
 				0BA1E0301B051A07007675AF /* NetError.css in Resources */,
 				E4B7B77E1A793CF20022C5E0 /* FiraSans-SemiBold.ttf in Resources */,
 				F84B220B1A0910F600AAB793 /* Images.xcassets in Resources */,
+				F35B8D2B1D6380EA008E3D61 /* SessionRestore.html in Resources */,
 				7B42406E1CA04CAC009B5C28 /* Menu.xcassets in Resources */,
 				E49943F71AE69EDD00BF9DE4 /* Intro.xcassets in Resources */,
 				E4B7B7631A793CF20022C5E0 /* CharisSILI.ttf in Resources */,
@@ -4775,6 +4785,7 @@
 				C4EFEECF1CEBB6F2009762A4 /* BackForwardTableViewCell.swift in Sources */,
 				E64ED8FA1BC55AE300DAF864 /* UIAlertControllerExtensions.swift in Sources */,
 				282DA4731A68C1E700A406E2 /* OpenSearch.swift in Sources */,
+				F35B8D2F1D638408008E3D61 /* SessionRestoreHandler.swift in Sources */,
 				E63ED8E11BFD25580097D08E /* LoginListViewController.swift in Sources */,
 				2F44FCC71A9E8CF500FD20CC /* SearchSettingsTableViewController.swift in Sources */,
 				0BF42D371A7C0B8E00889E28 /* FaviconManager.swift in Sources */,
@@ -4862,6 +4873,7 @@
 				28FDFF0C1C1F725800840F86 /* SeparatorTableCell.swift in Sources */,
 				C400467C1CF4E43E00B08303 /* BackForwardListViewController.swift in Sources */,
 				D3972BF31C22412B00035B87 /* ShareExtensionHelper.swift in Sources */,
+				F35B8D2D1D6383E9008E3D61 /* SessionRestoreHelper.swift in Sources */,
 				59A68E0B4ABBF55E14819668 /* BookmarksPanel.swift in Sources */,
 				7B0B1B791C1B69C900DF4AB5 /* ClientPickerViewController.swift in Sources */,
 				7B844E3D1BBDDB9D00E733A2 /* ChevronView.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -433,6 +433,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         ErrorPageHelper.register(server, certStore: profile.certStore)
         AboutHomeHandler.register(server)
         AboutLicenseHandler.register(server)
+        SessionRestoreHandler.register(server)
 
         // Bug 1223009 was an issue whereby CGDWebserver crashed when moving to a background task
         // catching and handling the error seemed to fix things, but we're not sure why.

--- a/Client/Assets/SessionRestore.html
+++ b/Client/Assets/SessionRestore.html
@@ -1,0 +1,52 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<!DOCTYPE html>
+<html>
+<head>
+  <meta name="referrer" content="never">
+</head>
+<body>
+<script>
+  /**
+   * This file is responsible for restoring session history.
+   * It uses the DOM history API to push pages onto the back/forward stack. Since that API
+   * is bound by same origin restrictions, we're only able to push pages with the current origin
+   * (which is a page hosted on localhost). As a workaround, push all to-be-restored URLs as
+   * error pages so that they will redirect to the correct URLs when loaded.
+   */
+  (function () {
+      function getRestoreURL(url) {
+          // If the URL is already an internally hosted page, we can restore it directly.
+          if (url.indexOf(document.location.origin) === 0) {
+              return url;
+          }
+          // Otherwise, push an error page to trigger a redirect when loaded.
+          return '/errors/error.html?url=' + escape(url);
+      }
+      var index = document.location.href.search("history");
+      // Pull the session out of the history query argument. 
+      // The session is a JSON-stringified array of all URLs to restore for this tab, plus the last active index.
+      var sessionRestoreComponents = JSON.parse(unescape(document.location.href.substring(index + "history=".length)));
+      var urlList = sessionRestoreComponents['history'];
+      var currentPage = sessionRestoreComponents['currentPage'];
+      // First, replace the session restore page (this page) with the first URL to be restored.
+      history.replaceState({}, "", getRestoreURL(urlList[0]));
+      // Then push the remaining pages to be restored.
+      for (var i = 1; i < urlList.length; i++) {
+          history.pushState({}, '', getRestoreURL(urlList[i]));
+      }
+      // We'll end up at the last page pushed, so set the selected index to the current index in the session history.
+      history.go(currentPage);
+   
+      // Finally, reload the page to trigger the error redirection, which will load the actual URL. 
+      // For some reason (maybe a WebKit bug?), document.location still points to SessionRestore.html at this point, 
+      // so wait until the next tick when the location points to the correct index and URL.
+      setTimeout(function () {
+          webkit.messageHandlers.localRequestHelper.postMessage({ type: "reload" });
+          webkit.messageHandlers.sessionRestoreHelper.postMessage({ name: "didRestoreSession" });
+      }, 0);
+  }) ();
+</script>
+</body>
+</html>

--- a/Client/Frontend/Browser/SessionRestoreHandler.swift
+++ b/Client/Frontend/Browser/SessionRestoreHandler.swift
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import WebKit
+import GCDWebServers
+
+/// Handles requests to /about/sessionrestore to restore session history.
+struct SessionRestoreHandler {
+    static func register(webServer: WebServer) {
+        // Register the handler that accepts /about/sessionrestore?history=...&currentpage=... requests.
+        webServer.registerHandlerForMethod("GET", module: "about", resource: "sessionrestore") { _ in
+            if let sessionRestorePath = NSBundle.mainBundle().pathForResource("SessionRestore", ofType: "html") {
+                do {
+                    let sessionRestoreString = try String(contentsOfFile: sessionRestorePath)
+                    return GCDWebServerDataResponse(HTML: sessionRestoreString)
+                } catch _ {}
+            }
+            
+            return GCDWebServerResponse(statusCode: 404)
+        }
+    }
+}

--- a/Client/Frontend/Browser/SessionRestoreHelper.swift
+++ b/Client/Frontend/Browser/SessionRestoreHelper.swift
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import WebKit
+
+protocol SessionRestoreHelperDelegate: class {
+    func sessionRestoreHelper(helper: SessionRestoreHelper, didRestoreSessionForTab tab: Tab)
+}
+
+class SessionRestoreHelper: TabHelper {
+    weak var delegate: SessionRestoreHelperDelegate?
+    private weak var tab: Tab?
+    
+    required init(tab: Tab) {
+        self.tab = tab
+    }
+    
+    func scriptMessageHandlerName() -> String? {
+        return "sessionRestoreHelper"
+    }
+    
+    func userContentController(userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+        if let tab = tab, params = message.body as? [String: AnyObject] {
+            if params["name"] as! String == "didRestoreSession" {
+                dispatch_async(dispatch_get_main_queue()) {
+                    self.delegate?.sessionRestoreHelper(self, didRestoreSessionForTab: tab)
+                }
+            }
+        }
+    }
+    
+    class func name() -> String {
+        return "SessionRestoreHelper"
+    }
+}


### PR DESCRIPTION
This restores an earlier method of preserving tab history in order to test to see whether it still causes crashes upon startup, or whether it can be safely reïntegrated.