### PR TITLE
Bug 1256470 – Enable Passcode/Touch ID for Private Browsing Mode

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -641,6 +641,8 @@
 		E6F965421B2F25110034B023 /* NSMutableAttributedStringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F965411B2F25110034B023 /* NSMutableAttributedStringExtensionsTests.swift */; };
 		E6F9659C1B2F5F800034B023 /* effective_tld_names.dat in Resources */ = {isa = PBXBuildFile; fileRef = E6F9659B1B2F5F800034B023 /* effective_tld_names.dat */; };
 		E6F9659E1B2F63A20034B023 /* NSStringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F9659D1B2F63A20034B023 /* NSStringExtensions.swift */; };
+		F33EBF691D59243500D312EA /* PrivateModeAuthenticationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F33EBF681D59243500D312EA /* PrivateModeAuthenticationTests.swift */; };
+		F398E1541D5A8D70009803C5 /* pageWithLink.html in Resources */ = {isa = PBXBuildFile; fileRef = F398E1531D5A8D70009803C5 /* pageWithLink.html */; };
 		F84B21DA1A090F8100AAB793 /* ClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84B21D91A090F8100AAB793 /* ClientTests.swift */; };
 		F84B22041A0910F600AAB793 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84B21E51A0910F600AAB793 /* AppDelegate.swift */; };
 		F84B220B1A0910F600AAB793 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F84B21EF1A0910F600AAB793 /* Images.xcassets */; };
@@ -1498,7 +1500,7 @@
 		D3C744CC1A687D6C004CE85D /* URIFixup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URIFixup.swift; sourceTree = "<group>"; };
 		D3CFD3631CC5605B0064AB4A /* SecurityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecurityTests.swift; sourceTree = "<group>"; };
 		D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileAccessorTests.swift; sourceTree = "<group>"; };
-		D3E171C11A841EAD00AB44CD /* KIFHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = KIFHelper.js; sourceTree = "<group>"; };
+		D3E171C11A841EAD00AB44CD /* KIFHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = KIFHelper.js; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.c; };
 		D3E8EEE71B97A87A001900FB /* ClearPrivateDataTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClearPrivateDataTableViewController.swift; sourceTree = "<group>"; };
 		D3FA777A1A43B2990010CD32 /* SearchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchTests.swift; sourceTree = "<group>"; };
 		D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenSearch.swift; sourceTree = "<group>"; };
@@ -1699,6 +1701,8 @@
 		E6F9659B1B2F5F800034B023 /* effective_tld_names.dat */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = effective_tld_names.dat; path = ../effective_tld_names.dat; sourceTree = "<group>"; };
 		E6F9659D1B2F63A20034B023 /* NSStringExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSStringExtensions.swift; sourceTree = "<group>"; };
 		E6FCC43C1C40565200DF6113 /* FirefoxBeta.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = FirefoxBeta.xcconfig; path = Configuration/FirefoxBeta.xcconfig; sourceTree = "<group>"; };
+		F33EBF681D59243500D312EA /* PrivateModeAuthenticationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateModeAuthenticationTests.swift; sourceTree = "<group>"; };
+		F398E1531D5A8D70009803C5 /* pageWithLink.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = pageWithLink.html; sourceTree = "<group>"; };
 		F84B21BE1A090F8100AAB793 /* Client.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Client.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F84B21D31A090F8100AAB793 /* ClientTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ClientTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F84B21D81A090F8100AAB793 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -2630,6 +2634,7 @@
 				D34E33021BA793C2006135F0 /* loginForm.html */,
 				0BF8F8D91AEFF1C900E90BC2 /* noTitle.html */,
 				0B6FBAB11AC1F830007EC669 /* numberedPage.html */,
+				F398E1531D5A8D70009803C5 /* pageWithLink.html */,
 				0B5A93411B1EB572004F47A2 /* readablePage.html */,
 				4F9757391AFA6F37006ECC24 /* readerContent.html */,
 				E6EAC5951B29CB3A00E1DE1E /* scrollablePage.html */,
@@ -2637,6 +2642,7 @@
 				D3E171C11A841EAD00AB44CD /* KIFHelper.js */,
 				E640E86F1C73BCF500C5F072 /* AuthenticationManagerTests.swift */,
 				D38F036F1C06387900175932 /* AuthenticationTests.swift */,
+				F33EBF681D59243500D312EA /* PrivateModeAuthenticationTests.swift */,
 				0BB5B35F1AC0D6360052877D /* BookmarkingTests.swift */,
 				28C8B7841C852535006D8318 /* BookmarksPanelTests.swift */,
 				E6B4C4021C68F58B001F97E8 /* BrowserTests.swift */,
@@ -4156,6 +4162,7 @@
 				E6B4C3D81C68F55C001F97E8 /* JSPrompt.html in Resources */,
 				D343DCFE1C446BDB00D7EEE8 /* findPage.html in Resources */,
 				0BF8F8DA1AEFF1C900E90BC2 /* noTitle.html in Resources */,
+				F398E1541D5A8D70009803C5 /* pageWithLink.html in Resources */,
 				E67422C51CFF2D39009E8373 /* youtube.ico in Resources */,
 				D3E171C21A841EAD00AB44CD /* KIFHelper.js in Resources */,
 				D31EC05F1CC57ED80096F4AB /* localhostLoad.html in Resources */,
@@ -4600,6 +4607,7 @@
 				E6A92ADB1C52A8DA00743291 /* LoginInputTests.swift in Sources */,
 				C4B1E8451D25AEDC008DA51B /* TopTabsTests.swift in Sources */,
 				D375A9201AE71675001B30D5 /* ViewMemoryLeakTests.swift in Sources */,
+				F33EBF691D59243500D312EA /* PrivateModeAuthenticationTests.swift in Sources */,
 				D313BE981B2F5096009EF241 /* DomainAutocompleteTests.swift in Sources */,
 				4F97573C1AFA6F37006ECC24 /* ReaderViewUITests.swift in Sources */,
 				7BB20B6D1B71160200F1657F /* TopSitesTests.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -421,7 +421,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func updateAuthenticationInfo() {
         if let authInfo = KeychainWrapper.authenticationInfo() {
             if !LAContext().canEvaluatePolicy(.DeviceOwnerAuthenticationWithBiometrics, error: nil) {
-                authInfo.useTouchID = false
                 KeychainWrapper.setAuthenticationInfo(authInfo)
             }
         }

--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -125,7 +125,7 @@ class QuickActions: NSObject {
         }
     }
 
-    private func handleOpenNewTab(withBrowserViewController bvc: BrowserViewController, isPrivate: Bool) {
+    func handleOpenNewTab(withBrowserViewController bvc: BrowserViewController, isPrivate: Bool) {
         bvc.openBlankNewTabAndFocus(isPrivate: isPrivate)
     }
 

--- a/Client/Frontend/AuthenticationManager/AuthenticationManagerConstants.swift
+++ b/Client/Frontend/AuthenticationManager/AuthenticationManagerConstants.swift
@@ -29,6 +29,12 @@ struct AuthenticationStrings {
 
     static let requirePasscode =
         NSLocalizedString("Require Passcode", tableName: "AuthenticationManager", comment: "Text displayed in the 'Interval' section, followed by the current interval setting, e.g. 'Immediately'")
+    
+    static let authenticateFeaturesWithTouchIDPasscode =
+        NSLocalizedString("Use Touch ID & Passcode to access:", tableName: "AuthenticationManager", comment: "Label for the list of features for which security can be enabled in Settings, with Touch ID enabled")
+    
+    static let authenticateFeaturesWithPasscode =
+        NSLocalizedString("Use Passcode to access:", tableName: "AuthenticationManager", comment: "Label for the list of features for which security can be enabled in Settings, with Touch ID disabled")
 
     static let enterAPasscode =
         NSLocalizedString("Enter a passcode", tableName: "AuthenticationManager", comment: "Text displayed above the input field when entering a new passcode")
@@ -77,6 +83,9 @@ struct AuthenticationStrings {
 
     static let loginsTouchReason =
         NSLocalizedString("Use your fingerprint to access Logins now.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when accessing logins")
+    
+    static let privateModeReason =
+        NSLocalizedString("Use your fingerprint to start browsing privately.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when entering private mode")
 
     static let requirePasscodeTouchReason =
         NSLocalizedString("touchid.require.passcode.reason.label",
@@ -84,9 +93,9 @@ struct AuthenticationStrings {
                           tableName: "AuthenticationManager",
                           comment: "Touch ID prompt subtitle when accessing the require passcode setting")
 
-    static let disableTouchReason =
-        NSLocalizedString("touchid.disable.reason.label",
-                          value: "Use your fingerprint to disable Touch ID.",
+    static let disableAuthenticationReason =
+        NSLocalizedString("authentication.disable.reason.label",
+                          value: "Use your fingerprint to disable authentication for this action.",
                           tableName: "AuthenticationManager",
                           comment: "Touch ID prompt subtitle when disabling Touch ID")
 

--- a/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
+++ b/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
@@ -7,15 +7,10 @@ import SnapKit
 import Shared
 import SwiftKeychainWrapper
 
-/// Delegate available for PasscodeEntryViewController consumers to be notified of the validation of a passcode.
-@objc protocol PasscodeEntryDelegate: class {
-    func passcodeValidationDidSucceed()
-    optional func userDidCancelValidation()
-}
-
 /// Presented to the to user when asking for their passcode to validate entry into a part of the app.
 class PasscodeEntryViewController: BasePasscodeViewController {
-    weak var delegate: PasscodeEntryDelegate?
+    var success: (() -> Void)?
+    var cancel: (() -> Void)?
     private let passcodePane = PasscodePane()
 
     override func viewDidLoad() {
@@ -47,7 +42,7 @@ class PasscodeEntryViewController: BasePasscodeViewController {
     }
 
     override func dismiss() {
-        delegate?.userDidCancelValidation?()
+        cancel?()
         super.dismiss()
     }
 }
@@ -57,7 +52,7 @@ extension PasscodeEntryViewController: PasscodeInputViewDelegate {
         if let passcode = authenticationInfo?.passcode where passcode == code {
             authenticationInfo?.recordValidation()
             KeychainWrapper.setAuthenticationInfo(authenticationInfo)
-            delegate?.passcodeValidationDidSucceed()
+            success?()
         } else {
             passcodePane.shakePasscode()
             failIncorrectPasscode(inputView: inputView)

--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -125,7 +125,12 @@ private extension BrowserToTrayAnimator {
 
         // Build a tab cell that we will use to animate the scaling of the browser to the tab
         let expandedFrame = calculateExpandedCellFrameFromBVC(bvc)
-        let cell = createTransitionCellFromTab(bvc.tabManager.selectedTab, withFrame: expandedFrame)
+        let cell = createTransitionCellFromTab(selectedTab, withFrame: expandedFrame)
+        if !tabManager.isInPrivateMode && selectedTab.isPrivate {
+            // Hide the screenshot if the tab is being minimised in order to escape private browsing mode
+            cell.background.image = nil
+            cell.titleText.alpha = 0
+        }
         cell.backgroundHolder.layer.cornerRadius = TabTrayControllerUX.CornerRadius
         cell.innerStroke.hidden = true
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -42,6 +42,7 @@ class BrowserViewController: UIViewController {
     var urlBar: URLBarView!
     var readerModeBar: ReaderModeBarView?
     var readerModeCache: ReaderModeCache
+    private var currentTheme = ""
     private var statusBarOverlay: UIView!
     private(set) var toolbar: TabToolbar?
     private var searchController: SearchViewController?
@@ -1065,8 +1066,8 @@ class BrowserViewController: UIViewController {
             completion?(false)
             return
         }
-        
-        tabManager.authorisePrivateMode(navigationController) { success in
+
+        self.tabManager.authorisePrivateMode(navigationController) { success in
             guard success else {
                 completion?(false)
                 return
@@ -3279,12 +3280,19 @@ extension BrowserViewController: TabTrayDelegate {
 
 // MARK: Browser Chrome Theming
 extension BrowserViewController: Themeable {
-
     func applyTheme(themeName: String) {
+        // We should be able to simply return if a duplicate theme is being assigned, but
+        // the themes are a complex system that encourages subtle bugs, so it's safer not to,
+        // and only disable it for those objects that it actually causes an issue with.
+        let refreshTheme = self.currentTheme == themeName
+        self.currentTheme = themeName
+
         urlBar.applyTheme(themeName)
         toolbar?.applyTheme(themeName)
         readerModeBar?.applyTheme(themeName)
-        topTabsViewController?.applyTheme(themeName)
+        if !refreshTheme {
+            topTabsViewController?.applyTheme(themeName)
+        }
 
         switch(themeName) {
         case Theme.NormalMode:

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -326,7 +326,7 @@ class BrowserViewController: UIViewController {
 
     func SELappDidBecomeActiveNotification() {
         if let navigationController = self.navigationController {
-            if self.tabTrayController == nil {
+            if self.tabTrayController == nil && !self.tabManager.isAuthenticating {
                 tabManager.authorisePrivateMode(navigationController, toRemainInPrivateMode: true) { success in
                     guard success else {
                         if #available(iOS 9, *) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -290,7 +290,7 @@ class BrowserViewController: UIViewController {
         scrollController.showToolbars(animated: true)
     }
 
-    private func concealPrivateContents() {
+    private func concealPrivateContent() {
         // If we are displying a private tab, hide any elements in the tab that we wouldn't want shown
         // when the app is in the home switcher
         webViewContainerBackdrop.alpha = 1
@@ -298,7 +298,9 @@ class BrowserViewController: UIViewController {
         urlBar.locationContainer.alpha = 0
         topTabsViewController?.switchForegroundStatus(isInForeground: false)
         presentedViewController?.popoverPresentationController?.containerView?.alpha = 0
-        presentedViewController?.view.alpha = 0
+        if !((presentedViewController as? UINavigationController)?.topViewController is PasscodeEntryViewController) {
+            presentedViewController?.view.alpha = 0
+        }
     }
 
     private func revealPrivateContent() {
@@ -321,7 +323,7 @@ class BrowserViewController: UIViewController {
             return
         }
         tabManager.needsAuthentication = true
-        concealPrivateContents()
+        concealPrivateContent()
     }
 
     func SELappDidBecomeActiveNotification() {
@@ -2199,7 +2201,7 @@ extension BrowserViewController: TabManagerDelegate {
     func tabManagerDidRestoreTabs(tabManager: TabManager) {
         updateTabCountUsingTabManager(tabManager)
         if tabManager.isInPrivateMode {
-            concealPrivateContents()
+            concealPrivateContent()
         }
         SELappDidBecomeActiveNotification()
     }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -6,6 +6,7 @@ import Foundation
 import WebKit
 import Storage
 import Shared
+import SwiftKeychainWrapper
 
 private let log = Logger.browserLogger
 
@@ -85,6 +86,14 @@ class TabManager: NSObject {
     private let prefs: Prefs
     var selectedIndex: Int { return _selectedIndex }
     var tempTabs: [Tab]?
+    
+    var isInPrivateMode = false {
+        didSet {
+            if oldValue != isInPrivateMode {
+                self.setAppStateForTabTray()
+            }
+        }
+    }
 
     var normalTabs: [Tab] {
         assert(NSThread.isMainThread())
@@ -158,6 +167,45 @@ class TabManager: NSObject {
         }
 
         return nil
+    }
+    
+    weak var appStateDelegate: AppStateDelegate?
+    
+    private func setAppStateForTabTray() {
+        let state = mainStore.updateState(.TabTray(tabTrayState: TabTrayState(isPrivate: self.isInPrivateMode)))
+        self.appStateDelegate?.appDidUpdateState(state)
+    }
+    
+    func authorisePrivateMode(navigationController: UINavigationController, toRemainInPrivateMode reverseAuthorisationRequirement: Bool = false) -> Success {
+        if self.isInPrivateMode != reverseAuthorisationRequirement {
+            return succeed()
+        }
+        guard let authInfo = KeychainWrapper.authenticationInfo() else {
+            return succeed()
+        }
+        let success = Success()
+        if authInfo.requiresValidation(.PrivateBrowsing) {
+            let cancelAction = { success.fill(Maybe(failure: AuthorisationError(description: "User cancelled authorisation action."))) }
+            AppAuthenticator.presentTouchAuthenticationUsingInfo(authInfo,
+                touchIDReason: AuthenticationStrings.privateModeReason,
+                success: {
+                    success.fill(Maybe(success: ()))
+                },
+                cancel: cancelAction,
+                fallback: {
+                    AppAuthenticator.presentPasscodeAuthentication(navigationController,
+                        success: {
+                            navigationController.dismissViewControllerAnimated(true) {
+                                success.fill(Maybe(success: ()))
+                            }
+                        },
+                    cancel: cancelAction)
+                }
+            )
+        } else {
+            return succeed()
+        }
+        return success
     }
 
     func getTabFor(url: NSURL) -> Tab? {
@@ -721,6 +769,8 @@ extension TabManager {
         if tabToSelect == nil {
             tabToSelect = tabs.first
         }
+        
+        self.isInPrivateMode = tabToSelect?.isPrivate ?? false
 
         log.debug("Done adding tabs.")
 
@@ -930,5 +980,12 @@ class TabManagerNavDelegate: NSObject, WKNavigationDelegate {
             }
 
             decisionHandler(res)
+    }
+}
+
+public class AuthorisationError: MaybeErrorType {
+    public let description: String
+    public init(description: String) {
+        self.description = description
     }
 }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -683,7 +683,9 @@ extension TabTrayController {
     private func concealPrivateContent() {
         collectionView.alpha = 0
         presentedViewController?.popoverPresentationController?.containerView?.alpha = 0
-        presentedViewController?.view.alpha = 0
+        if !((presentedViewController as? UINavigationController)?.topViewController is PasscodeEntryViewController) {
+            presentedViewController?.view.alpha = 0
+        }
     }
     
     private func revealPrivateContent() {

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -705,17 +705,19 @@ extension TabTrayController {
 
     func SELappDidBecomeActiveNotification() {
         if let navigationController = self.navigationController {
-            tabManager.authorisePrivateMode(navigationController, toRemainInPrivateMode: true) { success in
-                guard success else {
-                    if #available(iOS 9, *) {
-                        self.transitionBetweenModes(withAnimation: false)
+            if !self.tabManager.isAuthenticating {
+                self.tabManager.authorisePrivateMode(navigationController, toRemainInPrivateMode: true) { success in
+                    guard success else {
+                        if #available(iOS 9, *) {
+                            self.transitionBetweenModes(withAnimation: false)
+                        }
+                        return
                     }
-                    return
+                    self.revealPrivateContent()
                 }
-                self.revealPrivateContent()
             }
         } else {
-            revealPrivateContent()
+            self.revealPrivateContent()
         }
         
     }

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -24,7 +24,7 @@ struct TopTabsUX {
 protocol TopTabsDelegate: class {
     func topTabsDidPressTabs()
     func topTabsDidPressNewTab()
-    func didTogglePrivateMode(cachedTab: Tab?)
+    func didAttemptToTogglePrivateMode(cachedTab: Tab?) -> Success
     func topTabsDidChangeTab()
 }
 
@@ -190,7 +190,7 @@ class TopTabsViewController: UIViewController {
     }
     
     func togglePrivateModeTapped() {
-        delegate?.didTogglePrivateMode(isPrivate ? lastNormalTab : lastPrivateTab)
+        delegate?.didAttemptToTogglePrivateMode(isPrivate ? lastNormalTab : lastPrivateTab)
         self.collectionView.reloadData()
         self.scrollToCurrentTab(false, centerCell: true)
     }

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -32,12 +32,18 @@ protocol TopTabCellDelegate: class {
     func tabCellDidClose(cell: TopTabCell)
 }
 
+class XUICollectionView: UICollectionView {
+    override func reloadData() {
+        super.reloadData()
+    }
+}
+
 class TopTabsViewController: UIViewController {
     let tabManager: TabManager
     weak var delegate: TopTabsDelegate?
     var isPrivate = false
     lazy var collectionView: UICollectionView = {
-        let collectionView = UICollectionView(frame: CGRectZero, collectionViewLayout: TopTabsViewLayout())
+        let collectionView = XUICollectionView(frame: CGRectZero, collectionViewLayout: TopTabsViewLayout())
         collectionView.registerClass(TopTabCell.self, forCellWithReuseIdentifier: TopTabCell.Identifier)
         collectionView.showsVerticalScrollIndicator = false
         collectionView.showsHorizontalScrollIndicator = false
@@ -179,6 +185,8 @@ class TopTabsViewController: UIViewController {
             }
         }
         delegate?.topTabsDidPressNewTab()
+        // If this causes a crash, it's probably because self.collectionView's data is being reloaded between the new tab
+        // being added to the data source and the batch updates being performed, to animate the new tab's appearance.
         collectionView.performBatchUpdates({ _ in
             let count = self.collectionView.numberOfItemsInSection(0)
             self.collectionView.insertItemsAtIndexPaths([NSIndexPath(forItem: count, inSection: 0)])

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -226,6 +226,7 @@ extension TopTabsViewController: Themeable {
     func applyTheme(themeName: String) {
         tabsButton.applyTheme(themeName)
         isPrivate = (themeName == Theme.PrivateMode)
+        collectionView.reloadData()
     }
 }
 

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -591,8 +591,8 @@ class LoginsSetting: Setting {
             return
         }
 
-        if authInfo.requiresValidation() {
-            AppAuthenticator.presentAuthenticationUsingInfo(authInfo,
+        if authInfo.requiresValidation(.Logins) {
+            AppAuthenticator.presentTouchAuthenticationUsingInfo(authInfo,
             touchIDReason: AuthenticationStrings.loginsTouchReason,
             success: {
                 self.settings?.navigateToLoginsList()
@@ -603,7 +603,11 @@ class LoginsSetting: Setting {
                 }
             },
             fallback: {
-                AppAuthenticator.presentPasscodeAuthentication(self.navigationController, delegate: self.settings)
+                AppAuthenticator.presentPasscodeAuthentication(self.navigationController, success: {
+                    self.navigationController?.dismissViewControllerAnimated(true) {
+                        self.settings?.navigateToLoginsList()
+                    }
+                }, cancel: nil)
             })
         } else {
             settings?.navigateToLoginsList()

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -174,11 +174,3 @@ extension AppSettingsTableViewController {
         navigationController?.pushViewController(viewController, animated: true)
     }
 }
-
-extension AppSettingsTableViewController: PasscodeEntryDelegate {
-    @objc func passcodeValidationDidSucceed() {
-        navigationController?.dismissViewControllerAnimated(true) {
-            self.navigateToLoginsList()
-        }
-    }
-}

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -48,6 +48,9 @@ class Setting: NSObject {
         cell.textLabel?.attributedText = title
         cell.textLabel?.textAlignment = textAlignment
         cell.textLabel?.numberOfLines = 0
+        if !enabled {
+            cell.textLabel?.textColor = UIConstants.TableViewDisabledRowTextColor
+        }
         cell.accessoryType = accessoryType
         cell.accessoryView = nil
         cell.selectionStyle = enabled ? .Default : .None

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -66,6 +66,7 @@ public struct UIConstants {
 
     // Firefox Orange
     static let ControlTintColor = UIColor(red: 240.0 / 255, green: 105.0 / 255, blue: 31.0 / 255, alpha: 1)
+    static let ControlDisabledColor = UIColor(white: 0.8, alpha: 1)
 
     // Passcode dot gray
     static let PasscodeDotColor = UIColor(rgb: 0x4A4A4A)

--- a/UITests/KIFHelper.js
+++ b/UITests/KIFHelper.js
@@ -57,4 +57,25 @@ var KIFHelper = {
     }
     return false;
   },
+    
+  /**
+   * Long presses an element with the given accessibility label, for a given duration.
+   * @return True if successful
+   */
+  longPressElementWithAccessibilityLabel: function (label, duration) {
+    var found = this._getElementWithAccessibilityLabel(document.body, label);
+    var touches = [new Touch()];
+    if (found) {
+      var event = new Event("touchstart");
+      event.touches = touches;
+      found.dispatchEvent(event);
+      setTimeout(function () {
+        var event = new Event("touchend");
+        event.touches = touches;
+        found.dispatchEvent(event);
+      }, duration);
+      return true;
+    }
+    return false;
+  },
 };

--- a/UITests/PrivateModeAuthenticationTests.swift
+++ b/UITests/PrivateModeAuthenticationTests.swift
@@ -98,7 +98,9 @@ class PrivateModeAuthenticationTests: KIFTestCase {
     }
 
     func testPasscodeAuthenticationForNewPrivateTab() {
+        tester().waitForAnimationsToFinish()
         tester().tapViewWithAccessibilityLabel("Menu")
+        tester().waitForAnimationsToFinish()
         checkActionEnablesPrivateBrowsingMode {
             self.tester().tapViewWithAccessibilityLabel("New Private Tab")
         }

--- a/UITests/PrivateModeAuthenticationTests.swift
+++ b/UITests/PrivateModeAuthenticationTests.swift
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import SwiftKeychainWrapper
+@testable import Client
+
+@available(iOS 9, *)
+class PrivateModeAuthenticationTests: KIFTestCase {
+
+    private var webRoot: String!
+    private static let passcode = "0000"
+    private static let incorrectPasscode = String(PrivateModeAuthenticationTests.passcode.characters.map { Character("\(9 - Int(String($0))!)") })
+    
+    override func setUp() {
+        super.setUp()
+        webRoot = SimplePageServer.start()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        PasscodeUtils.resetPasscode()
+        BrowserUtils.resetToAboutHome(tester())
+    }
+    
+    private func getAppDelegate() -> AppDelegate {
+        return UIApplication.sharedApplication().delegate as! AppDelegate
+    }
+
+    private func getBrowserViewController() -> BrowserViewController {
+        return getAppDelegate().browserViewController
+    }
+
+    private func enablePasscodeAuthentication() {
+        PasscodeUtils.setPasscode(PrivateModeAuthenticationTests.passcode, interval: .Immediately)
+    }
+
+    private func checkBrowsingMode(isPrivate isPrivate: Bool) {
+        let bvc = getBrowserViewController()
+        tester().waitForAnimationsToFinish()
+        XCTAssertTrue(isPrivate ? bvc.tabManager.isInPrivateMode : !bvc.tabManager.isInPrivateMode)
+    }
+
+    private func enterPasscode(passcode: String) {
+        checkBrowsingMode(isPrivate: false)
+        tester().waitForViewWithAccessibilityLabel("Enter Passcode")
+        tester().enterTextIntoCurrentFirstResponder(passcode)
+        tester().waitForAnimationsToFinish()
+    }
+
+    private func enterCorrectPasscode(andExpectToEnterPrivateMode enterPrivateMode: Bool = true) {
+        enterPasscode(PrivateModeAuthenticationTests.passcode)
+        checkBrowsingMode(isPrivate: enterPrivateMode)
+    }
+    
+    private func enterIncorrectPasscode() {
+        enterPasscode(PrivateModeAuthenticationTests.incorrectPasscode)
+        checkBrowsingMode(isPrivate: false)
+    }
+    
+    private func checkActionEnablesPrivateBrowsingMode(action: () -> ()) {
+        enablePasscodeAuthentication()
+        checkBrowsingMode(isPrivate: false)
+        action()
+        enterIncorrectPasscode()
+        enterCorrectPasscode()
+    }
+
+    func testPasscodeAuthenticationFromTabTray() {
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
+        checkActionEnablesPrivateBrowsingMode() {
+            self.tester().tapViewWithAccessibilityLabel("Private Mode")
+        }
+    }
+    
+    func testRepeatedPasscodeAuthentications() {
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
+        checkActionEnablesPrivateBrowsingMode() {
+            self.tester().tapViewWithAccessibilityLabel("Private Mode")
+        }
+        self.tester().tapViewWithAccessibilityLabel("Private Mode")
+        checkBrowsingMode(isPrivate: false)
+        checkActionEnablesPrivateBrowsingMode() {
+            self.tester().tapViewWithAccessibilityLabel("Private Mode")
+        }
+        
+    }
+
+    func testPasscodeAuthenticationFromTopTabs() {
+        let bvc = getBrowserViewController()
+        guard bvc.shouldShowTopTabsForTraitCollection(bvc.traitCollection) else {
+            return
+        }
+        checkActionEnablesPrivateBrowsingMode {
+            self.tester().tapViewWithAccessibilityLabel("Private Tab")
+        }
+    }
+
+    func testPasscodeAuthenticationForNewPrivateTab() {
+        tester().tapViewWithAccessibilityLabel("Menu")
+        checkActionEnablesPrivateBrowsingMode {
+            self.tester().tapViewWithAccessibilityLabel("New Private Tab")
+        }
+    }
+    
+    func testPasscodeAuthenticationForNewPrivateTabFromTabTray() {
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
+        tester().tapViewWithAccessibilityLabel("Menu")
+        checkActionEnablesPrivateBrowsingMode {
+            self.tester().tapViewWithAccessibilityLabel("New Private Tab")
+        }
+    }
+    
+    func testPasscodeAuthenticationForNewPrivateTabFromTodayView() {
+        checkActionEnablesPrivateBrowsingMode {
+            self.getAppDelegate().launchFromURL(LaunchParams(url: NSURL(string: "\(self.webRoot)/pageWithLink.html"), isPrivate: true))
+        }
+    }
+    
+    func testPasscodeAuthenticationForNewPrivateTabFrom3DTouchQuickAction() {
+        checkActionEnablesPrivateBrowsingMode() {
+            QuickActions.sharedInstance.handleOpenNewTab(withBrowserViewController: self.getBrowserViewController(), isPrivate: true)
+        }
+    }
+
+    func testPasscodeAuthenticationWhenOpeningLinkInPrivateTab() {
+        let url = "\(self.webRoot)/pageWithLink.html"
+        tester().tapViewWithAccessibilityIdentifier("url")
+        tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("\(url)\n")
+        let longPressDuration: NSTimeInterval = 0.5
+        tester().longPressWebViewElementWithAccessibilityLabel("Reflexive Link", duration: longPressDuration)
+        enablePasscodeAuthentication()
+        checkBrowsingMode(isPrivate: false)
+        tester().tapViewWithAccessibilityLabel("Open in New Private Tab")
+        enterIncorrectPasscode()
+        enterCorrectPasscode(andExpectToEnterPrivateMode: false)
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
+        tester().waitForTimeInterval(5)
+        checkActionEnablesPrivateBrowsingMode {
+            self.tester().tapViewWithAccessibilityLabel("Private Mode")
+        }
+        let tabsView = tester().waitForViewWithAccessibilityLabel("Tabs Tray").subviews.first as! UICollectionView
+        XCTAssertEqual(tabsView.numberOfItemsInSection(0), 1)
+    }
+}

--- a/UITests/pageWithLink.html
+++ b/UITests/pageWithLink.html
@@ -1,0 +1,9 @@
+<html>
+    <head>
+        <link rel="icon" href="image.png"></link>
+        <title>Page with Link</title>
+    </head>
+    <body>
+        <a href="pageWithLink.html">Reflexive Link</a>
+    </body>
+</html>

--- a/Utils/AuthenticationKeychainInfo.swift
+++ b/Utils/AuthenticationKeychainInfo.swift
@@ -18,6 +18,13 @@ public enum PasscodeInterval: Int {
     case OneHour        = 3600
 }
 
+public enum AuthenticationPurpose {
+    case ModifyAuthenticationSettings
+    case PrivateBrowsing
+    case Logins
+    case Other
+}
+
 // MARK: - Helper methods for accessing Authentication information from the Keychain
 public extension KeychainWrapper {
     class func authenticationInfo() -> AuthenticationKeychainInfo? {
@@ -41,7 +48,8 @@ public class AuthenticationKeychainInfo: NSObject, NSCoding {
     private(set) public var requiredPasscodeInterval: PasscodeInterval?
     private(set) public var lockOutInterval: NSTimeInterval?
     private(set) public var failedAttempts: Int
-    public var useTouchID: Bool
+    public var useAuthenticationForPrivateBrowsing: Bool
+    public var useAuthenticationForLogins: Bool
 
     // Timeout period before user can retry entering passcodes
     public var lockTimeInterval: NSTimeInterval = 15 * 60
@@ -50,7 +58,8 @@ public class AuthenticationKeychainInfo: NSObject, NSCoding {
         self.passcode = passcode
         self.requiredPasscodeInterval = .Immediately
         self.failedAttempts = 0
-        self.useTouchID = false
+        self.useAuthenticationForPrivateBrowsing = true
+        self.useAuthenticationForLogins = true
     }
 
     public func encodeWithCoder(aCoder: NSCoder) {
@@ -67,7 +76,8 @@ public class AuthenticationKeychainInfo: NSObject, NSCoding {
         aCoder.encodeObject(passcode, forKey: "passcode")
         aCoder.encodeObject(requiredPasscodeInterval?.rawValue, forKey: "requiredPasscodeInterval")
         aCoder.encodeInteger(failedAttempts, forKey: "failedAttempts")
-        aCoder.encodeBool(useTouchID, forKey: "useTouchID")
+        aCoder.encodeBool(useAuthenticationForPrivateBrowsing, forKey: "useAuthenticationForPrivateBrowsing")
+        aCoder.encodeBool(useAuthenticationForLogins, forKey: "useAuthenticationForLogins")
     }
 
     public required init?(coder aDecoder: NSCoder) {
@@ -75,7 +85,8 @@ public class AuthenticationKeychainInfo: NSObject, NSCoding {
         self.lockOutInterval = (aDecoder.decodeObjectForKey("lockOutInterval") as? NSNumber)?.doubleValue
         self.passcode = aDecoder.decodeObjectForKey("passcode") as? String
         self.failedAttempts = aDecoder.decodeIntegerForKey("failedAttempts")
-        self.useTouchID = aDecoder.decodeBoolForKey("useTouchID")
+        self.useAuthenticationForPrivateBrowsing = aDecoder.decodeBoolForKey("useAuthenticationForPrivateBrowsing")
+        self.useAuthenticationForLogins = aDecoder.decodeBoolForKey("useAuthenticationForLogins")
         if let interval = aDecoder.decodeObjectForKey("requiredPasscodeInterval") as? NSNumber {
             self.requiredPasscodeInterval = PasscodeInterval(rawValue: interval.integerValue)
         }
@@ -131,13 +142,19 @@ public extension AuthenticationKeychainInfo {
         return (SystemUtils.systemUptime() - (self.lockOutInterval ?? 0)) < lockTimeInterval
     }
 
-    func requiresValidation() -> Bool {
+    func requiresValidation(purpose: AuthenticationPurpose) -> Bool {
         // If there isn't a passcode, don't need validation.
         guard let _ = passcode else {
             return false
         }
+        
+        // If the user hasn't turned on authentication for the action they are attempting, don't need validation.
+        if purpose == .PrivateBrowsing && !useAuthenticationForPrivateBrowsing
+            || purpose == .Logins && !useAuthenticationForLogins {
+            return false
+        }
 
-        // Need to make sure we've validated in the past. If not, its a definite yes.
+        // Need to make sure we've validated in the past. If not, it's a definite yes.
         guard let lastValidationInterval = lastPasscodeValidationInterval,
                   requireInterval = requiredPasscodeInterval
         else {


### PR DESCRIPTION
Hopefully this time, we’ve got it right.
This addresses all the problems with the previous version of the feature, as well as quite a number that we didn’t come across previously.
Unit tests are all passing, including new ones that catch problems that the previous patch was failing.
Localization issues should also be sorted out.
