### PR TITLE
Bug 1302815 - Use a master JSON file for locale search engines instead of list.txt

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -451,6 +451,10 @@
 		D3FA777B1A43B2990010CD32 /* SearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA777A1A43B2990010CD32 /* SearchTests.swift */; };
 		D3FEC38D1AC4B42F00494F45 /* AutocompleteTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC38C1AC4B42F00494F45 /* AutocompleteTextField.swift */; };
 		DD31E0FB1B382B520077078A /* TabPrintPageRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD31E0FA1B382B520077078A /* TabPrintPageRenderer.swift */; };
+		DDF6791A1D83643B009264AB /* SearchEnginesJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF679191D83643B009264AB /* SearchEnginesJSON.swift */; };
+		DDF6791B1D83643B009264AB /* SearchEnginesJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF679191D83643B009264AB /* SearchEnginesJSON.swift */; };
+		DDF6791C1D83643B009264AB /* SearchEnginesJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF679191D83643B009264AB /* SearchEnginesJSON.swift */; };
+		DDF6791D1D83643B009264AB /* SearchEnginesJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF679191D83643B009264AB /* SearchEnginesJSON.swift */; };
 		E40FAB0C1A7ABB77009CB80D /* WebServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40FAB0B1A7ABB77009CB80D /* WebServer.swift */; };
 		E418D0D91A251B3200CAE47A /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC84D1A16C40C00D49B7B /* Profile.swift */; };
 		E41A7D4B1A1BE04500245963 /* InitialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41A7D4A1A1BE04500245963 /* InitialViewController.swift */; };
@@ -1525,6 +1529,7 @@
 		D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenSearch.swift; sourceTree = "<group>"; };
 		D3FEC38C1AC4B42F00494F45 /* AutocompleteTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutocompleteTextField.swift; sourceTree = "<group>"; };
 		DD31E0FA1B382B520077078A /* TabPrintPageRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabPrintPageRenderer.swift; sourceTree = "<group>"; };
+		DDF679191D83643B009264AB /* SearchEnginesJSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEnginesJSON.swift; sourceTree = "<group>"; };
 		E40FAB0B1A7ABB77009CB80D /* WebServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebServer.swift; sourceTree = "<group>"; };
 		E41A7D4A1A1BE04500245963 /* InitialViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InitialViewController.swift; sourceTree = "<group>"; };
 		E41F0D971ADFFB5400FC7387 /* ReadingListService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ReadingListService.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -2741,6 +2746,7 @@
 				E47616C61AB74CA600E7DD25 /* ReaderModeBarView.swift */,
 				D31F95E81AC226CB005C9F3B /* ScreenshotHelper.swift */,
 				D308E4E31A5306F500842685 /* SearchEngines.swift */,
+				DDF679191D83643B009264AB /* SearchEnginesJSON.swift */,
 				D34510871ACF415700EC27F0 /* SearchLoader.swift */,
 				D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */,
 				59A68CCB63E2A565CB03F832 /* SearchViewController.swift */,
@@ -4661,6 +4667,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E444F7E01B4B1C1A00FEB19B /* NSUserDefaultsPrefs.swift in Sources */,
+				DDF6791D1D83643B009264AB /* SearchEnginesJSON.swift in Sources */,
 				E4BA8AA81B4B15EF00BC2E95 /* ActionRequestHandler.swift in Sources */,
 				E60D03281D511555002FE3F6 /* SyncStatusResolver.swift in Sources */,
 				E444F7E21B4B1C6800FEB19B /* SearchEngines.swift in Sources */,
@@ -4775,6 +4782,7 @@
 				FA6B2AC21D41F02D00429414 /* Punycode.swift in Sources */,
 				7BC68CC71CC152B70043562A /* MenuItemImageView.swift in Sources */,
 				D301AAEE1A3A55B70078DD1D /* TabTrayController.swift in Sources */,
+				DDF6791A1D83643B009264AB /* SearchEnginesJSON.swift in Sources */,
 				0B3E7D951B27A7CE00E2E84D /* AboutHomeHandler.swift in Sources */,
 				D331DFCA1CB6E9EE009B5DA2 /* OldStrings.swift in Sources */,
 				D3BE7B461B054F8600641031 /* TestAppDelegate.swift in Sources */,
@@ -4972,6 +4980,7 @@
 				28CDA55C1A43C37C005C318C /* NSUserDefaultsPrefs.swift in Sources */,
 				E60D03271D511554002FE3F6 /* SyncStatusResolver.swift in Sources */,
 				E41A7D4B1A1BE04500245963 /* InitialViewController.swift in Sources */,
+				DDF6791C1D83643B009264AB /* SearchEnginesJSON.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4984,6 +4993,7 @@
 				E60D03261D511554002FE3F6 /* SyncStatusResolver.swift in Sources */,
 				D38B2D8D1A8D98DA0040E6B5 /* OpenSearch.swift in Sources */,
 				E4BCAAB91B0537E300855D82 /* InstructionsViewController.swift in Sources */,
+				DDF6791B1D83643B009264AB /* SearchEnginesJSON.swift in Sources */,
 				E42CCDE81A23A73D00B794D3 /* Profile.swift in Sources */,
 				E4BCAAD91B05380B00855D82 /* ClientPickerViewController.swift in Sources */,
 				FA6B2AC31D41F02D00429414 /* Punycode.swift in Sources */,

--- a/Client/Assets/Search/SearchPlugins/list.json
+++ b/Client/Assets/Search/SearchPlugins/list.json
@@ -1,0 +1,687 @@
+{
+  "default": {
+    "visibleDefaultEngines": [
+      "amazondotcom", "google", "twitter", "wikipedia", "yahoo", "bing", "duckduckgo"
+    ]
+  },
+  "locales": {
+    "an": {
+      "default": {
+        "visibleDefaultEngines": [
+          "bing", "google", "twitter", "wikipedia-an", "yahoo-es"
+        ]
+      }
+    },
+    "as": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-in", "bing", "google", "wikipedia-as", "yahoo-in"
+        ]
+      }
+      
+    },
+    "az": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazondotcom", "azerdict", "bing", "duckduckgo", "google", "wikipedia-az"
+        ]
+      }
+    },
+    "be": {
+      "default": {
+        "visibleDefaultEngines": [
+          "be.wikipedia.org", "bing", "google", "tut.by", "yahoo", "yandex.by"
+        ]
+      },
+      "BY": {
+        "visibleDefaultEngines": [
+          "be.wikipedia.org", "bing", "google-nocodes", "tut.by", "yahoo", "yandex.by"
+        ]
+      },
+      "KZ": {
+        "visibleDefaultEngines": [
+          "be.wikipedia.org", "bing", "google-nocodes", "tut.by", "yahoo", "yandex.by"
+        ]
+      },
+      "RU": {
+        "visibleDefaultEngines": [
+          "be.wikipedia.org", "bing", "google-nocodes", "tut.by", "yahoo", "yandex.by"
+        ]
+      },
+      "TR": {
+        "visibleDefaultEngines": [
+          "be.wikipedia.org", "bing", "google-nocodes", "tut.by", "yahoo", "yandex.by"
+        ]
+      },
+      "UA": {
+        "visibleDefaultEngines": [
+          "be.wikipedia.org", "bing", "google-nocodes", "tut.by", "yahoo", "yandex.by"
+        ]
+      }
+    },
+    "bn-IN": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazondotcom", "bing", "google", "rediff", "wikipedia-bn", "yahoo-in"
+        ]
+      }
+    },
+    "br": {
+      "default": {
+        "visibleDefaultEngines": [
+          "bing", "google", "twitter", "wikipedia-br", "yahoo-france"
+        ]
+      }
+    },
+    "ca": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google", "twitter", "wikipedia-ca", "diec2"
+        ]
+      }
+    },
+    "cak": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazondotcom", "duckduckgo", "google", "wikipedia-es", "yahoo-espanol"
+        ]
+      }
+    },
+    "cs": {
+      "default": {
+        "visibleDefaultEngines": [
+          "duckduckgo", "google", "heureka-cz", "mapy-cz", "seznam-cz", "twitter", "wikipedia-cz"
+        ]
+      }
+    },
+    "cy": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-en-GB", "bing", "duckduckgo", "google", "wikipedia-cy", "yahoo-en-GB"
+        ]
+      }
+    },
+    "da": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-co-uk", "google", "twitter", "wikipedia-da"
+        ]
+      }
+    },
+    "de": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-de", "bing", "duckduckgo", "google", "qwant", "twitter", "wikipedia-de", "yahoo-de"
+        ]
+      }
+    },
+    "dsb": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-de", "bing", "google", "twitter", "wikipedia-dsb", "yahoo-de"
+        ]
+      }
+    },
+    "en-GB": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-en-GB", "bing", "duckduckgo", "google", "qwant", "twitter", "wikipedia", "yahoo-en-GB"
+        ]
+      }
+    },
+    "en-US": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazondotcom", "google", "twitter", "wikipedia", "yahoo", "bing", "duckduckgo"
+        ]
+      },
+      "US": {
+        "visibleDefaultEngines": [
+          "amazondotcom", "google-nocodes", "twitter", "wikipedia", "yahoo", "bing", "duckduckgo"
+        ]
+      }
+    },
+    "en-ZA": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google", "twitter", "wikipedia"
+        ]
+      }
+    },
+    "eo": {
+      "default": {
+        "visibleDefaultEngines": [
+          "bing", "duckduckgo", "google", "reta-vortaro", "twitter", "wikipedia-eo", "yahoo"
+        ]
+      }
+    },
+    "es-AR": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google", "mercadolibre-ar", "twitter", "wikipedia-es"
+        ]
+      }
+    },
+    "es-CL": {
+      "default": {
+        "visibleDefaultEngines": [
+          "bing", "drae", "google", "mercadolibre-cl", "twitter", "wikipedia-es", "yahoo-cl"
+        ]
+      }
+    },
+    "es-ES": {
+      "default": {
+        "visibleDefaultEngines": [
+          "bing", "duckduckgo", "google", "twitter", "wikipedia-es", "yahoo-es"
+        ]
+      }
+    },
+    "es-MX": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazondotcom", "bing", "duckduckgo", "google", "mercadolibre-mx", "twitter", "wikipedia-es", "yahoo-mx"
+        ]
+      }
+    },
+    "et": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-co-uk", "google", "twitter", "wikipedia-et"
+        ]
+      }
+    },
+    "eu": {
+      "default": {
+        "visibleDefaultEngines": [
+          "bing", "elebila", "google", "wikipedia-eu", "yahoo-es"
+        ]
+      }
+    },
+    "ff": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-france", "bing", "google", "wikipedia-fr", "yahoo-france"
+        ]
+      }
+    },
+    "fi": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google", "twitter", "wikipedia-fi", "yahoo-fi", "amazondotcom"
+        ]
+      }
+    },
+    "fr": {
+      "default": {
+        "visibleDefaultEngines": [
+          "bing", "duckduckgo", "google", "qwant", "twitter", "wikipedia-fr", "yahoo-france"
+        ]
+      }
+    },
+    "fy-NL": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google", "wikipedia-fy-NL", "bolcom-fy-NL"
+        ]
+      }
+    },
+    "ga-IE": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-en-GB", "google", "tearma", "twitter", "wikipedia-ga-IE"
+        ]
+      }
+    },
+    "gd": {
+      "default": {
+        "visibleDefaultEngines": [
+          "bing", "duckduckgo", "faclair-beag", "google", "wikipedia-gd", "yahoo-en-GB"
+        ]
+      }
+    },
+    "gl": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazondotcom", "bing", "google", "twitter", "wikipedia-gl", "yahoo-es"
+        ]
+      }
+    },
+    "gu-IN": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-in", "bing", "google", "wikipedia-gu", "yahoo-in"
+        ]
+      }
+    },
+    "hi-IN": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-in", "bing", "google", "twitter", "wikipedia-hi", "yahoo-in"
+        ]
+      }
+    },
+    "hr": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-en-GB", "bing", "duckduckgo", "google", "twitter", "wikipedia-hr", "yahoo"
+        ]
+      }
+    },
+    "hsb": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-de", "bing", "google", "twitter", "wikipedia-hsb", "yahoo-de"
+        ]
+      }
+    },
+    "hu": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google", "sztaki-en-hu", "vatera", "twitter", "wikipedia-hu"
+        ]
+      }
+    },
+    "hy-AM": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazondotcom", "bing", "google", "list-am", "wikipedia-hy-AM", "yahoo"
+        ]
+      }
+    },
+    "id": {
+      "default": {
+        "visibleDefaultEngines": [
+          "bing", "google", "twitter", "wikipedia-id", "yahoo-id"
+        ]
+      }
+    },
+    "is": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazondotcom", "bing", "google", "leit-is", "wikipedia-is", "yahoo"
+        ]
+      }
+    },
+    "it": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google", "twitter", "wikipedia-it"
+        ]
+      }
+    },
+    "ja": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-jp", "bing", "google", "twitter-ja", "wikipedia-ja", "yahoo-jp"
+        ]
+      }
+    },
+    "kk": {
+      "default": {
+        "visibleDefaultEngines": [
+          "bing", "google", "twitter", "wikipedia-kk", "yahoo", "yandex"
+        ]
+      },
+      "BY": {
+        "visibleDefaultEngines": [
+          "bing", "google-nocodes", "twitter", "wikipedia-kk", "yahoo", "yandex"
+        ]
+      },
+      "KZ": {
+        "visibleDefaultEngines": [
+          "bing", "google-nocodes", "twitter", "wikipedia-kk", "yahoo", "yandex"
+        ]
+      },
+      "RU": {
+        "visibleDefaultEngines": [
+          "bing", "google-nocodes", "twitter", "wikipedia-kk", "yahoo", "yandex"
+        ]
+      },
+      "TR": {
+        "visibleDefaultEngines": [
+          "bing", "google-nocodes", "twitter", "wikipedia-kk", "yahoo", "yandex"
+        ]
+      },
+      "UA": {
+        "visibleDefaultEngines": [
+          "bing", "google-nocodes", "twitter", "wikipedia-kk", "yahoo", "yandex"
+        ]
+      }
+    },
+    "kn": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-in", "bing", "google", "twitter", "wikipedia-kn", "wiktionary-kn", "yahoo-in"
+        ]
+      }
+    },
+    "ko": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google", "danawa-kr", "twitter", "daum-kr", "naver-kr"
+        ]
+      }
+    },
+    "lt": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google", "twitter", "wikipedia-lt"
+        ]
+      }
+    },
+    "lv": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google", "salidzinilv", "sslv", "twitter", "wikipedia-lv"
+        ]
+      }
+    },
+    "mai": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-in", "bing", "google", "twitter", "wikipedia-hi", "yahoo-in"
+        ]
+      }
+    },
+    "ml": {
+      "default": {
+        "visibleDefaultEngines": [
+          "bing", "duckduckgo", "google", "twitter", "wikipedia-ml", "yahoo-in"
+        ]
+      }
+    },
+    "mr": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-in", "bing", "google", "rediff", "wikipedia-mr", "yahoo-in"
+        ]
+      }
+    },
+    "ms": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazondotcom", "bing", "google", "twitter", "wikipedia-ms", "yahoo"
+        ]
+      }
+    },
+    "my": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazondotcom", "bing", "google", "twitter", "wikipedia-my", "yahoo"
+        ]
+      }
+    },
+    "nb-NO": {
+      "default": {
+        "visibleDefaultEngines": [
+          "duckduckgo", "google", "gulesider-mobile-NO", "twitter", "wikipedia-NO"
+        ]
+      }
+    },
+    "nl": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google", "wikipedia-nl", "bolcom-nl"
+        ]
+      }
+    },
+    "nn-NO": {
+      "default": {
+        "visibleDefaultEngines": [
+          "duckduckgo", "google", "gulesider-mobile-NO", "twitter", "wikipedia-NN"
+        ]
+      }
+    },
+    "or": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-in", "bing", "google", "wikipedia-or", "wiktionary-or", "yahoo-in"
+        ]
+      }
+    },
+    "pa-IN": {
+      "default": {
+        "visibleDefaultEngines": [
+          "bing", "google", "wikipedia-pa", "yahoo-in"
+        ]
+      }
+    },
+    "pl": {
+      "default": {
+        "visibleDefaultEngines": [
+          "bing", "duckduckgo", "google", "twitter", "wikipedia-pl"
+        ]
+      }
+    },
+    "pt-BR": {
+      "default": {
+        "visibleDefaultEngines": [
+          "bing", "google", "twitter", "wikipedia-br", "yahoo-br"
+        ]
+      }
+    },
+    "pt-PT": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google", "wikipedia-ptpt"
+        ]
+      }
+    },
+    "rm": {
+      "default": {
+        "visibleDefaultEngines": [
+          "bing", "duckduckgo", "google", "leo_ende_de", "pledarigrond", "wikipedia-rm", "yahoo-ch"
+        ]
+      }
+    },
+    "ro": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google", "twitter", "wikipedia-ro"
+        ]
+      }
+    },
+    "ru": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google", "twitter", "wikipedia-ru", "yandex-ru"
+        ]
+      },
+      "BY": {
+        "visibleDefaultEngines": [
+          "google-nocodes", "twitter", "wikipedia-ru", "yandex-ru"
+        ]
+      },
+      "KZ": {
+        "visibleDefaultEngines": [
+          "google-nocodes", "twitter", "wikipedia-ru", "yandex-ru"
+        ]
+      },
+      "RU": {
+        "visibleDefaultEngines": [
+          "google-nocodes", "twitter", "wikipedia-ru", "yandex-ru"
+        ]
+      },
+      "TR": {
+        "visibleDefaultEngines": [
+          "google-nocodes", "twitter", "wikipedia-ru", "yandex-ru"
+        ]
+      },
+      "UA": {
+        "visibleDefaultEngines": [
+          "google-nocodes", "twitter", "wikipedia-ru", "yandex-ru"
+        ]
+      }
+    },
+    "sk": {
+      "default": {
+        "visibleDefaultEngines": [
+          "azet-sk", "google", "slovnik-sk", "twitter", "wikipedia-sk"
+        ]
+      }
+    },
+    "sl": {
+      "default": {
+        "visibleDefaultEngines": [
+          "ceneje", "google", "odpiralni", "twitter", "wikipedia-sl"
+        ]
+      }
+    },
+    "son": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-fr", "bing", "google", "twitter", "wikipedia-fr", "yahoo-france"
+        ]
+      }
+    },
+    "sq": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-en-GB", "bing", "google", "twitter", "wikipedia-sq", "yahoo"
+        ]
+      }
+    },
+    "sr": {
+      "default": {
+        "visibleDefaultEngines": [
+          "bing", "duckduckgo", "google", "twitter", "wikipedia-sr", "yahoo"
+        ]
+      }
+    },
+    "sv-SE": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google", "prisjakt-sv-SE", "twitter", "wikipedia-sv-SE"
+        ]
+      }
+    },
+    "ta": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-in", "bing", "duckduckgo", "google", "wikipedia-ta", "wiktionary-ta", "yahoo-in"
+        ]
+      }
+    },
+    "te": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-in", "bing", "google", "wikipedia-te", "wiktionary-te", "yahoo-in"
+        ]
+      }
+    },
+    "th": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google", "twitter", "wikipedia-th"
+        ]
+      }
+    },
+    "tr": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google", "yandex-tr", "twitter", "wikipedia-tr"
+        ]
+      },
+      "BY": {
+        "visibleDefaultEngines": [
+          "google-nocodes", "yandex-tr", "twitter", "wikipedia-tr"
+        ]
+      },
+      "KZ": {
+        "visibleDefaultEngines": [
+          "google-nocodes", "yandex-tr", "twitter", "wikipedia-tr"
+        ]
+      },
+      "RU": {
+        "visibleDefaultEngines": [
+          "google-nocodes", "yandex-tr", "twitter", "wikipedia-tr"
+        ]
+      },
+      "TR": {
+        "visibleDefaultEngines": [
+          "google-nocodes", "yandex-tr", "twitter", "wikipedia-tr"
+        ]
+      },
+      "UA": {
+        "visibleDefaultEngines": [
+          "google-nocodes", "yandex-tr", "twitter", "wikipedia-tr"
+        ]
+      }
+    },
+    "uk": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google", "twitter", "wikipedia-uk", "yandex-market"
+        ]
+      },
+      "BY": {
+        "visibleDefaultEngines": [
+          "google-nocodes", "twitter", "wikipedia-uk", "yandex-market"
+        ]
+      },
+      "KZ": {
+        "visibleDefaultEngines": [
+          "google-nocodes", "twitter", "wikipedia-uk", "yandex-market"
+        ]
+      },
+      "RU": {
+        "visibleDefaultEngines": [
+          "google-nocodes", "twitter", "wikipedia-uk", "yandex-market"
+        ]
+      },
+      "TR": {
+        "visibleDefaultEngines": [
+          "google-nocodes", "twitter", "wikipedia-uk", "yandex-market"
+        ]
+      },
+      "UA": {
+        "visibleDefaultEngines": [
+          "google-nocodes", "twitter", "wikipedia-uk", "yandex-market"
+        ]
+      }
+    },
+    "uz": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazondotcom", "bing", "google", "twitter", "wikipedia-uz", "yahoo"
+        ]
+      }
+    },
+    "xh": {
+      "default": {
+        "visibleDefaultEngines": [
+          "bing", "google", "twitter", "wikipedia", "yahoo"
+        ]
+      }
+    },
+    "zh-CN": {
+      "default": {
+        "visibleDefaultEngines": [
+          "baidu", "bing", "google", "taobao", "wikipedia-zh-CN"
+        ]
+      },
+      "CN": {
+        "visibleDefaultEngines": [
+          "baidu", "bing", "google-nocodes", "taobao", "wikipedia-zh-CN"
+        ]
+      }
+    },
+    "zh-TW": {
+      "default": {
+        "visibleDefaultEngines": [
+          "bing", "duckduckgo", "google", "wikipedia-zh-TW"
+        ]
+      },
+      "HK": {
+        "visibleDefaultEngines": [
+          "bing", "duckduckgo", "google-nocodes", "wikipedia-zh-TW"
+        ]
+      },
+      "TW": {
+        "visibleDefaultEngines": [
+          "bing", "duckduckgo", "google-nocodes", "wikipedia-zh-TW"
+        ]
+      }
+    }
+  }
+}

--- a/Client/Assets/Search/SearchPlugins/list.json
+++ b/Client/Assets/Search/SearchPlugins/list.json
@@ -5,10 +5,10 @@
     ]
   },
   "locales": {
-    "an": {
+    "ar": {
       "default": {
         "visibleDefaultEngines": [
-          "bing", "google", "twitter", "wikipedia-an", "yahoo-es"
+          "google", "wikipedia-ar", "twitter"
         ]
       }
     },
@@ -80,13 +80,6 @@
         ]
       }
     },
-    "cak": {
-      "default": {
-        "visibleDefaultEngines": [
-          "amazondotcom", "duckduckgo", "google", "wikipedia-es", "yahoo-espanol"
-        ]
-      }
-    },
     "cs": {
       "default": {
         "visibleDefaultEngines": [
@@ -122,14 +115,14 @@
         ]
       }
     },
-    "en-GB": {
+    "el": {
       "default": {
         "visibleDefaultEngines": [
-          "amazon-en-GB", "bing", "duckduckgo", "google", "qwant", "twitter", "wikipedia", "yahoo-en-GB"
+          "google", "twitter", "wikipedia-el", "skroutz"
         ]
       }
     },
-    "en-US": {
+    "en": {
       "default": {
         "visibleDefaultEngines": [
           "amazondotcom", "google", "twitter", "wikipedia", "yahoo", "bing", "duckduckgo"
@@ -138,6 +131,13 @@
       "US": {
         "visibleDefaultEngines": [
           "amazondotcom", "google-nocodes", "twitter", "wikipedia", "yahoo", "bing", "duckduckgo"
+        ]
+      }
+    },
+    "en-GB": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-en-GB", "bing", "duckduckgo", "google", "qwant", "twitter", "wikipedia", "yahoo-en-GB"
         ]
       }
     },
@@ -197,6 +197,13 @@
         ]
       }
     },
+    "fa": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google", "wikipedia-fa", "yahoo"
+        ]
+      }
+    },
     "ff": {
       "default": {
         "visibleDefaultEngines": [
@@ -250,6 +257,13 @@
       "default": {
         "visibleDefaultEngines": [
           "amazon-in", "bing", "google", "wikipedia-gu", "yahoo-in"
+        ]
+      }
+    },
+    "he": {
+      "default": {
+        "visibleDefaultEngines": [
+          "google", "twitter", "wikipedia-he"
         ]
       }
     },
@@ -316,6 +330,13 @@
         ]
       }
     },
+    "ka": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazondotcom", "bing", "duckduckgo", "google", "wikipedia-ka", "yahoo"
+        ]
+      }
+    },
     "kk": {
       "default": {
         "visibleDefaultEngines": [
@@ -362,6 +383,13 @@
         ]
       }
     },
+    "lo": {
+      "default": {
+        "visibleDefaultEngines": [
+          "bing", "google", "twitter", "wikipedia-lo", "yahoo"
+        ]
+      }
+    },
     "lt": {
       "default": {
         "visibleDefaultEngines": [
@@ -373,13 +401,6 @@
       "default": {
         "visibleDefaultEngines": [
           "google", "salidzinilv", "sslv", "twitter", "wikipedia-lv"
-        ]
-      }
-    },
-    "mai": {
-      "default": {
-        "visibleDefaultEngines": [
-          "amazon-in", "bing", "google", "twitter", "wikipedia-hi", "yahoo-in"
         ]
       }
     },
@@ -436,13 +457,6 @@
       "default": {
         "visibleDefaultEngines": [
           "amazon-in", "bing", "google", "wikipedia-or", "wiktionary-or", "yahoo-in"
-        ]
-      }
-    },
-    "pa-IN": {
-      "default": {
-        "visibleDefaultEngines": [
-          "bing", "google", "wikipedia-pa", "yahoo-in"
         ]
       }
     },
@@ -524,13 +538,6 @@
       "default": {
         "visibleDefaultEngines": [
           "ceneje", "google", "odpiralni", "twitter", "wikipedia-sl"
-        ]
-      }
-    },
-    "son": {
-      "default": {
-        "visibleDefaultEngines": [
-          "amazon-fr", "bing", "google", "twitter", "wikipedia-fr", "yahoo-france"
         ]
       }
     },
@@ -637,6 +644,13 @@
       "UA": {
         "visibleDefaultEngines": [
           "google-nocodes", "twitter", "wikipedia-uk", "yandex-market"
+        ]
+      }
+    },
+    "ur": {
+      "default": {
+        "visibleDefaultEngines": [
+          "amazon-in", "bing", "duckduckgo", "google", "twitter", "wikipedia-ur", "yahoo-in"
         ]
       }
     },

--- a/Client/Frontend/Browser/SearchEngines.swift
+++ b/Client/Frontend/Browser/SearchEngines.swift
@@ -275,7 +275,11 @@ class SearchEngines {
             if !NSFileManager.defaultManager().fileExistsAtPath(fullPath) {
                 fullPath = fallbackDirectory.stringByAppendingPathComponent("\(engineName).xml")
             }
-            assert(NSFileManager.defaultManager().fileExistsAtPath(fullPath), "\(fullPath) exists")
+            // If a search engine doesn't exist, just ignore it. We might have entries in
+            // list.json where the files don't exist yet.
+            if (!NSFileManager.defaultManager().fileExistsAtPath(fullPath)) {
+                continue
+            }
 
             let engine = parser.parse(fullPath, engineID: engineName)
             assert(engine != nil, "Engine at \(fullPath) successfully parsed")

--- a/Client/Frontend/Browser/SearchEngines.swift
+++ b/Client/Frontend/Browser/SearchEngines.swift
@@ -250,15 +250,23 @@ class SearchEngines {
             return []
         }
 
-        let index = (searchDirectory as NSString).stringByAppendingPathComponent("list.json")
-        let listFile = try? String(contentsOfFile: index, encoding: NSUTF8StringEncoding)
-        assert(listFile != nil, "Read the list of search engines")
-
-        let engineJSON = SearchEnginesJSON(listFile!)
-        let region = regionIdentifierForSearchEngines();
-        var engineNames = engineJSON.visibleDefaultEngines(region)
-        if (engineNames.count == 0) {
-            engineNames = engineJSON.visibleDefaultEngines("default")
+        var index = (searchDirectory as NSString).stringByAppendingPathComponent("list.json")
+        var listFile = try? String(contentsOfFile: index, encoding: NSUTF8StringEncoding)
+        var engineNames = [String]()
+        if (listFile == nil) {
+            index = (searchDirectory as NSString).stringByAppendingPathComponent("list.txt")
+            listFile = try? String(contentsOfFile: index, encoding: NSUTF8StringEncoding)
+            assert(listFile != nil, "Read the list of search engines")
+            engineNames = listFile!
+                .stringByTrimmingCharactersInSet(NSCharacterSet.newlineCharacterSet())
+                .componentsSeparatedByCharactersInSet(NSCharacterSet.newlineCharacterSet())
+        } else {
+            let engineJSON = SearchEnginesJSON(listFile!)
+            let region = regionIdentifierForSearchEngines();
+            engineNames = engineJSON.visibleDefaultEngines(region)
+            if (engineNames.count == 0) {
+                engineNames = engineJSON.visibleDefaultEngines("default")
+            }
         }
         var engines = [OpenSearchEngine]()
         let parser = OpenSearchParser(pluginMode: true)

--- a/Client/Frontend/Browser/SearchEngines.swift
+++ b/Client/Frontend/Browser/SearchEngines.swift
@@ -258,11 +258,11 @@ class SearchEngines {
         }
 
         let index = (pluginBasePath as NSString).stringByAppendingPathComponent("list.json")
-        let listFile = try? String(contentsOfFile: index, encoding: NSUTF8StringEncoding)
-        let engineJSON = SearchEnginesJSON(listFile!)
+        let listFile = try! String(contentsOfFile: index, encoding: NSUTF8StringEncoding)
+        let engineJSON = SearchEnginesJSON(listFile)
 
         let possibilities = possibilitiesForLanguageIdentifier(languageIdentifier)
-        let region = regionIdentifierForSearchEngines();
+        let region = regionIdentifierForSearchEngines()
         let engineNames = engineJSON.visibleDefaultEngines(possibilities, region: region)
         assert(engineNames.count > 0, "No search engines")
 

--- a/Client/Frontend/Browser/SearchEnginesJSON.swift
+++ b/Client/Frontend/Browser/SearchEnginesJSON.swift
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+
+public class SearchEnginesJSON {
+    private let json: JSON
+
+    public init(_ jsonString: String) {
+        self.json = JSON.parse(jsonString)
+    }
+
+    public init(_ json: JSON) {
+        self.json = json
+    }
+
+    public func visibleDefaultEngines(region: String) -> [String] {
+        let engineNames = json[region]["visibleDefaultEngines"].asArray;
+        if (engineNames == nil) {
+            return []
+        } else {
+            return jsonsToStrings(engineNames)!
+        }
+    }
+}
+
+extension SearchEnginesJSON {
+    func asJSON() -> JSON {
+        return self.json
+    }
+}

--- a/Client/Frontend/Browser/SearchEnginesJSON.swift
+++ b/Client/Frontend/Browser/SearchEnginesJSON.swift
@@ -16,13 +16,20 @@ public class SearchEnginesJSON {
         self.json = json
     }
 
-    public func visibleDefaultEngines(region: String) -> [String] {
-        let engineNames = json[region]["visibleDefaultEngines"].asArray;
-        if (engineNames == nil) {
-            return []
-        } else {
-            return jsonsToStrings(engineNames)!
+    public func visibleDefaultEngines(possibilities: [String], region: String) -> [String] {
+        var engineNames: [JSON]? = nil
+        for possibility in possibilities {
+            if (json["locales"][possibility].asDictionary != nil) {
+                engineNames = json["locales"][possibility][region]["visibleDefaultEngines"].asArray
+                if (engineNames == nil) {
+                    engineNames = json["locales"][possibility]["default"]["visibleDefaultEngines"].asArray
+                }
+            }
         }
+        if (engineNames == nil) {
+            engineNames = json["default"]["visibleDefaultEngines"].asArray
+        }
+        return jsonsToStrings(engineNames)!
     }
 }
 

--- a/Client/Frontend/Browser/SearchEnginesJSON.swift
+++ b/Client/Frontend/Browser/SearchEnginesJSON.swift
@@ -18,15 +18,18 @@ public class SearchEnginesJSON {
 
     public func visibleDefaultEngines(possibilities: [String], region: String) -> [String] {
         var engineNames: [JSON]? = nil
-        for possibility in possibilities {
-            if (json["locales"][possibility].asDictionary != nil) {
-                engineNames = json["locales"][possibility][region]["visibleDefaultEngines"].asArray
-                if (engineNames == nil) {
-                    engineNames = json["locales"][possibility]["default"]["visibleDefaultEngines"].asArray
+        for possibleLocale in possibilities {
+            if let regions = json["locales"][possibleLocale].asDictionary {
+                if regions[region] == nil {
+                    engineNames = regions["default"]!["visibleDefaultEngines"].asArray
+                    // We keep looping through just in case
+                    // another possible locale gets us more specific
+                } else {
+                    engineNames = regions[region]!["visibleDefaultEngines"].asArray
                 }
             }
         }
-        if (engineNames == nil) {
+        if engineNames == nil {
             engineNames = json["default"]["visibleDefaultEngines"].asArray
         }
         return jsonsToStrings(engineNames)!

--- a/Client/Frontend/Browser/SearchEnginesJSON.swift
+++ b/Client/Frontend/Browser/SearchEnginesJSON.swift
@@ -26,6 +26,8 @@ public class SearchEnginesJSON {
                     // another possible locale gets us more specific
                 } else {
                     engineNames = regions[region]!["visibleDefaultEngines"].asArray
+                    // This match was very specific, so we should always use it
+                    break;
                 }
             }
         }

--- a/Client/Frontend/Browser/SearchEnginesJSON.swift
+++ b/Client/Frontend/Browser/SearchEnginesJSON.swift
@@ -22,13 +22,10 @@ public class SearchEnginesJSON {
             if let regions = json["locales"][possibleLocale].asDictionary {
                 if regions[region] == nil {
                     engineNames = regions["default"]!["visibleDefaultEngines"].asArray
-                    // We keep looping through just in case
-                    // another possible locale gets us more specific
                 } else {
                     engineNames = regions[region]!["visibleDefaultEngines"].asArray
-                    // This match was very specific, so we should always use it
-                    break;
                 }
+                break;
             }
         }
         if engineNames == nil {


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1302815

This patches moves Firefox iOS to use a single JSON file for all information about search locales.
