### PR TITLE
Bug 1304398 - Cleanup unused feature flags from AppConstants.swift

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -762,8 +762,7 @@ class BrowserViewController: UIViewController {
     private func updateInContentHomePanel(url: NSURL?) {
         if !urlBar.inOverlayMode {
             if AboutUtils.isAboutHomeURL(url) {
-                let showInline = AppConstants.MOZ_MENU || ((tabManager.selectedTab?.canGoForward ?? false || tabManager.selectedTab?.canGoBack ?? false))
-                showHomePanelController(inline: showInline)
+                showHomePanelController(inline: true)
             } else {
                 hideHomePanelController()
             }
@@ -839,15 +838,6 @@ class BrowserViewController: UIViewController {
         if let tab = tabManager.getTabForURL(url) {
             tab.isBookmarked = true
         }
-
-        if !AppConstants.MOZ_MENU {
-            // Dispatch to the main thread to update the UI
-            dispatch_async(dispatch_get_main_queue()) { _ in
-                self.animateBookmarkStar()
-                self.toolbar?.updateBookmarkStatus(true)
-                self.urlBar.updateBookmarkStatus(true)
-            }
-        }
     }
 
     private func animateBookmarkStar() {
@@ -874,10 +864,6 @@ class BrowserViewController: UIViewController {
                     if let tab = self.tabManager.getTabForURL(url) {
                         tab.isBookmarked = false
                     }
-                    if !AppConstants.MOZ_MENU {
-                        self.toolbar?.updateBookmarkStatus(false)
-                        self.urlBar.updateBookmarkStatus(false)
-                    }
                 }
             }
         }
@@ -890,10 +876,6 @@ class BrowserViewController: UIViewController {
                     if let added = userInfo["added"] {
                         if let tab = self.tabManager.getTabForURL(urlBar.currentURL!) {
                             tab.isBookmarked = false
-                        }
-                        if !AppConstants.MOZ_MENU {
-                            self.toolbar?.updateBookmarkStatus(added)
-                            self.urlBar.updateBookmarkStatus(added)
                         }
                     }
                 }
@@ -1009,9 +991,6 @@ class BrowserViewController: UIViewController {
                     return
                 }
                 tab?.isBookmarked = bookmarked
-                if !AppConstants.MOZ_MENU {
-                    self.navigationToolbar.updateBookmarkStatus(bookmarked)
-                }
             }
         }
     }
@@ -1323,9 +1302,7 @@ class BrowserViewController: UIViewController {
 extension BrowserViewController: AppStateDelegate {
 
     func appDidUpdateState(appState: AppState) {
-        if AppConstants.MOZ_MENU {
-            menuViewController?.appState = appState
-        }
+        menuViewController?.appState = appState
         toolbar?.appDidUpdateState(appState)
         urlBar?.appDidUpdateState(appState)
     }
@@ -2061,12 +2038,6 @@ extension BrowserViewController: TabManagerDelegate {
                             }
 
                             tab?.isBookmarked = isBookmarked
-
-
-                            if !AppConstants.MOZ_MENU {
-                                self.toolbar?.updateBookmarkStatus(isBookmarked)
-                                self.urlBar.updateBookmarkStatus(isBookmarked)
-                            }
                         }
                     }
                 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1691,9 +1691,6 @@ extension BrowserViewController: TabToolbarDelegate {
     }
     
     func showBackForwardList() {
-        guard AppConstants.MOZ_BACK_FORWARD_LIST else {
-            return
-        }
         if let backForwardList = tabManager.selectedTab?.webView?.backForwardList {
             let backForwardViewController = BackForwardListViewController(profile: profile, backForwardList: backForwardList, isPrivate: tabManager.selectedTab?.isPrivate ?? false)
             backForwardViewController.tabManager = tabManager

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -418,10 +418,6 @@ class TabManager: NSObject {
     }
     
     func removeTabsWithUndoToast(tabs: [Tab]) {
-        guard AppConstants.MOZ_UNDO_DELETE_TABS_TOAST else {
-            removeTabs(tabs)
-            return
-        }
         tempTabs = tabs
         var tabsCopy = tabs
         

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -116,21 +116,10 @@ public class TabToolbarHelper: NSObject {
         toolbar.homePageButton.accessibilityLabel = NSLocalizedString("Toolbar.OpenHomePage.AccessibilityLabel", value: "Homepage", comment: "Accessibility Label for the tab toolbar Homepage button")
         toolbar.homePageButton.addTarget(self, action: #selector(TabToolbarHelper.SELdidClickHomePage), forControlEvents: UIControlEvents.TouchUpInside)
 
-        if AppConstants.MOZ_MENU {
-            toolbar.menuButton.contentMode = UIViewContentMode.Center
-            toolbar.menuButton.setImage(UIImage.templateImageNamed("bottomNav-menu"), forState: .Normal)
-            toolbar.menuButton.accessibilityLabel = AppMenuConfiguration.MenuButtonAccessibilityLabel
-            toolbar.menuButton.addTarget(self, action: #selector(TabToolbarHelper.SELdidClickMenu), forControlEvents: UIControlEvents.TouchUpInside)
-        } else {
-            toolbar.bookmarkButton.contentMode = UIViewContentMode.Center
-            toolbar.bookmarkButton.setImage(UIImage(named: "bookmark"), forState: .Normal)
-            toolbar.bookmarkButton.setImage(UIImage(named: "bookmarked"), forState: UIControlState.Selected)
-            toolbar.bookmarkButton.setImage(UIImage(named: "bookmarkHighlighted"), forState: UIControlState.Highlighted)
-            toolbar.bookmarkButton.accessibilityLabel = NSLocalizedString("Bookmark", comment: "Accessibility Label for the tab toolbar Bookmark button")
-            let longPressGestureBookmarkButton = UILongPressGestureRecognizer(target: self, action: #selector(TabToolbarHelper.SELdidLongPressBookmark(_:)))
-            toolbar.bookmarkButton.addGestureRecognizer(longPressGestureBookmarkButton)
-            toolbar.bookmarkButton.addTarget(self, action: #selector(TabToolbarHelper.SELdidClickBookmark), forControlEvents: UIControlEvents.TouchUpInside)
-        }
+        toolbar.menuButton.contentMode = UIViewContentMode.Center
+        toolbar.menuButton.setImage(UIImage.templateImageNamed("bottomNav-menu"), forState: .Normal)
+        toolbar.menuButton.accessibilityLabel = AppMenuConfiguration.MenuButtonAccessibilityLabel
+        toolbar.menuButton.addTarget(self, action: #selector(TabToolbarHelper.SELdidClickMenu), forControlEvents: UIControlEvents.TouchUpInside)
 
         setTintColor(buttonTintColor, forButtons: toolbar.actionButtons)
     }
@@ -240,21 +229,13 @@ class TabToolbar: Toolbar, TabToolbarProtocol {
         menuButton.accessibilityIdentifier = "TabToolbar.menuButton"
         homePageButton = UIButton()
         menuButton.accessibilityIdentifier = "TabToolbar.homePageButton"
-        if AppConstants.MOZ_MENU {
-            actionButtons = [backButton, forwardButton, menuButton, stopReloadButton, shareButton, homePageButton]
-        } else {
-            actionButtons = [backButton, forwardButton, stopReloadButton, shareButton, bookmarkButton]
-        }
+        actionButtons = [backButton, forwardButton, menuButton, stopReloadButton, shareButton, homePageButton]
 
         super.init(frame: frame)
 
         self.helper = TabToolbarHelper(toolbar: self)
 
-        if AppConstants.MOZ_MENU {
-            addButtons(backButton, forwardButton, menuButton, stopReloadButton, shareButton, homePageButton)
-        } else {
-            addButtons(backButton, forwardButton, stopReloadButton, shareButton, bookmarkButton)
-        }
+        addButtons(backButton, forwardButton, menuButton, stopReloadButton, shareButton, homePageButton)
 
         accessibilityNavigationStyle = .Combined
         accessibilityLabel = NSLocalizedString("Navigation Toolbar", comment: "Accessibility label for the navigation toolbar displayed at the bottom of the screen.")
@@ -281,9 +262,6 @@ class TabToolbar: Toolbar, TabToolbarProtocol {
     }
 
     func updatePageStatus(isWebPage isWebPage: Bool) {
-        if !AppConstants.MOZ_MENU {
-            bookmarkButton.enabled = isWebPage
-        }
         stopReloadButton.enabled = isWebPage
         shareButton.enabled = isWebPage
     }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -275,12 +275,7 @@ class TabTrayController: UIViewController {
     lazy var toolbar: TrayToolbar = {
         let toolbar = TrayToolbar()
         toolbar.addTabButton.addTarget(self, action: #selector(TabTrayController.SELdidClickAddTab), forControlEvents: .TouchUpInside)
-
-        if AppConstants.MOZ_MENU {
-            toolbar.menuButton.addTarget(self, action: #selector(TabTrayController.didTapMenu), forControlEvents: .TouchUpInside)
-        } else {
-            toolbar.settingsButton.addTarget(self, action: #selector(TabTrayController.SELdidClickSettingsItem), forControlEvents: .TouchUpInside)
-        }
+        toolbar.menuButton.addTarget(self, action: #selector(TabTrayController.didTapMenu), forControlEvents: .TouchUpInside)
 
         if #available(iOS 9, *) {
             toolbar.maskButton.addTarget(self, action: #selector(TabTrayController.SELdidTogglePrivateMode), forControlEvents: .TouchUpInside)
@@ -1252,13 +1247,8 @@ class TrayToolbar: UIView {
         addSubview(addTabButton)
 
         var buttonToCenter: UIButton?
-        if AppConstants.MOZ_MENU {
-            addSubview(menuButton)
-            buttonToCenter = menuButton
-        } else {
-            addSubview(settingsButton)
-            buttonToCenter = settingsButton
-        }
+        addSubview(menuButton)
+        buttonToCenter = menuButton
 
         buttonToCenter?.snp_makeConstraints { make in
             make.center.equalTo(self)
@@ -1289,11 +1279,7 @@ class TrayToolbar: UIView {
 
     private func styleToolbar(isPrivate isPrivate: Bool) {
         addTabButton.tintColor = isPrivate ? .whiteColor() : .darkGrayColor()
-        if AppConstants.MOZ_MENU {
-            menuButton.tintColor = isPrivate ? .whiteColor() : .darkGrayColor()
-        } else {
-            settingsButton.tintColor = isPrivate ? .whiteColor() : .darkGrayColor()
-        }
+        menuButton.tintColor = isPrivate ? .whiteColor() : .darkGrayColor()
         backgroundColor = isPrivate ? UIConstants.PrivateModeToolbarTintColor : .whiteColor()
         maskButton.styleForMode(privateMode: isPrivate)
     }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -249,7 +249,7 @@ class URLBarView: UIView {
     lazy var homePageButton: UIButton = { return UIButton() }()
 
     lazy var actionButtons: [UIButton] = {
-        return AppConstants.MOZ_MENU ? [self.shareButton, self.menuButton, self.forwardButton, self.backButton, self.stopReloadButton, self.homePageButton] : [self.shareButton, self.bookmarkButton, self.forwardButton, self.backButton, self.stopReloadButton]
+        return [self.shareButton, self.menuButton, self.forwardButton, self.backButton, self.stopReloadButton, self.homePageButton]
     }()
 
     private var rightBarConstraint: Constraint?
@@ -285,12 +285,8 @@ class URLBarView: UIView {
         addSubview(cancelButton)
 
         addSubview(shareButton)
-        if AppConstants.MOZ_MENU {
-            addSubview(menuButton)
-            addSubview(homePageButton)
-        } else {
-            addSubview(bookmarkButton)
-        }
+        addSubview(menuButton)
+        addSubview(homePageButton)
         addSubview(forwardButton)
         addSubview(backButton)
         addSubview(stopReloadButton)
@@ -355,35 +351,21 @@ class URLBarView: UIView {
             make.size.equalTo(backButton)
         }
 
-        if AppConstants.MOZ_MENU {
-            shareButton.snp_makeConstraints { make in
-                make.right.equalTo(self.menuButton.snp_left)
-                make.centerY.equalTo(self)
-                make.size.equalTo(backButton)
-            }
+        shareButton.snp_makeConstraints { make in
+            make.right.equalTo(self.menuButton.snp_left)
+            make.centerY.equalTo(self)
+            make.size.equalTo(backButton)
+        }
 
-            homePageButton.snp_makeConstraints { make in
-                make.center.equalTo(shareButton)
-                make.size.equalTo(shareButton)
-            }
+        homePageButton.snp_makeConstraints { make in
+            make.center.equalTo(shareButton)
+            make.size.equalTo(shareButton)
+        }
 
-            menuButton.snp_makeConstraints { make in
-                make.right.equalTo(self.tabsButton.snp_left).offset(URLBarViewUX.URLBarCurveOffsetLeft)
-                make.centerY.equalTo(self)
-                make.size.equalTo(backButton)
-            }
-        } else {
-            shareButton.snp_makeConstraints { make in
-                make.right.equalTo(self.bookmarkButton.snp_left)
-                make.centerY.equalTo(self)
-                make.size.equalTo(backButton)
-            }
-
-            bookmarkButton.snp_makeConstraints { make in
-                make.right.equalTo(self.tabsButton.snp_left).offset(URLBarViewUX.URLBarCurveOffsetLeft)
-                make.centerY.equalTo(self)
-                make.size.equalTo(backButton)
-            }
+        menuButton.snp_makeConstraints { make in
+            make.right.equalTo(self.tabsButton.snp_left).offset(URLBarViewUX.URLBarCurveOffsetLeft)
+            make.centerY.equalTo(self)
+            make.size.equalTo(backButton)
         }
     }
 
@@ -547,11 +529,7 @@ class URLBarView: UIView {
         self.bringSubviewToFront(self.locationContainer)
         self.cancelButton.hidden = false
         self.progressBar.hidden = false
-        if AppConstants.MOZ_MENU {
-            self.menuButton.hidden = !self.toolbarIsShowing
-        } else {
-            self.bookmarkButton.hidden = !self.toolbarIsShowing
-        }
+        self.menuButton.hidden = !self.toolbarIsShowing
         self.forwardButton.hidden = !self.toolbarIsShowing
         self.backButton.hidden = !self.toolbarIsShowing
         self.stopReloadButton.hidden = !self.toolbarIsShowing
@@ -561,11 +539,7 @@ class URLBarView: UIView {
         self.cancelButton.alpha = inOverlayMode ? 1 : 0
         self.progressBar.alpha = inOverlayMode || didCancel ? 0 : 1
         self.shareButton.alpha = inOverlayMode ? 0 : 1
-        if AppConstants.MOZ_MENU {
-            self.menuButton.alpha = inOverlayMode ? 0 : 1
-        } else {
-            self.bookmarkButton.alpha = inOverlayMode ? 0 : 1
-        }
+        self.menuButton.alpha = inOverlayMode ? 0 : 1
         self.forwardButton.alpha = inOverlayMode ? 0 : 1
         self.backButton.alpha = inOverlayMode ? 0 : 1
         self.stopReloadButton.alpha = inOverlayMode ? 0 : 1
@@ -599,11 +573,7 @@ class URLBarView: UIView {
     func updateViewsForOverlayModeAndToolbarChanges() {
         self.cancelButton.hidden = !inOverlayMode
         self.progressBar.hidden = inOverlayMode
-        if AppConstants.MOZ_MENU {
-            self.menuButton.hidden = !self.toolbarIsShowing || inOverlayMode
-        } else {
-            self.bookmarkButton.hidden = !self.toolbarIsShowing || inOverlayMode
-        }
+        self.menuButton.hidden = !self.toolbarIsShowing || inOverlayMode
         self.forwardButton.hidden = !self.toolbarIsShowing || inOverlayMode
         self.backButton.hidden = !self.toolbarIsShowing || inOverlayMode
         self.stopReloadButton.hidden = !self.toolbarIsShowing || inOverlayMode
@@ -663,9 +633,6 @@ extension URLBarView: TabToolbarProtocol {
     }
 
     func updatePageStatus(isWebPage isWebPage: Bool) {
-        if !AppConstants.MOZ_MENU {
-            bookmarkButton.enabled = isWebPage
-        }
         stopReloadButton.enabled = isWebPage
         shareButton.enabled = isWebPage
     }
@@ -677,7 +644,7 @@ extension URLBarView: TabToolbarProtocol {
                 return [locationTextField, cancelButton]
             } else {
                 if toolbarIsShowing {
-                    return AppConstants.MOZ_MENU ? [backButton, forwardButton, stopReloadButton, locationView, shareButton, menuButton, tabsButton, progressBar] : [backButton, forwardButton, stopReloadButton, locationView, shareButton, bookmarkButton, tabsButton, progressBar]
+                    return [backButton, forwardButton, stopReloadButton, locationView, shareButton, menuButton, tabsButton, progressBar]
                 } else {
                     return [locationView, tabsButton, progressBar]
                 }

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -41,11 +41,9 @@ class AppSettingsTableViewController: SettingsTableViewController {
         }
 
         let prefs = profile.prefs
-        var generalSettings: [Setting] = [SearchSetting(settings: self)]
-        if AppConstants.MOZ_NEW_TAB_CHOICES {
-            generalSettings += [NewTabPageSetting(settings: self)]
-        }
-        generalSettings += [
+        var generalSettings: [Setting] = [
+            SearchSetting(settings: self),
+            NewTabPageSetting(settings: self),
             HomePageSetting(settings: self),
             BoolSetting(prefs: prefs, prefKey: "blockPopups", defaultValue: true,
                 titleText: NSLocalizedString("Block Pop-up Windows", comment: "Block pop-up windows setting")),

--- a/Client/Frontend/Settings/HomePageSettingsViewController.swift
+++ b/Client/Frontend/Settings/HomePageSettingsViewController.swift
@@ -66,19 +66,14 @@ class HomePageSettingsViewController: SettingsTableViewController {
 
         var settings: [SettingSection] = [
             SettingSection(title: NSAttributedString(string: Strings.SettingsHomePageURLSectionTitle), children: basicSettings),
-            ]
-
-        if AppConstants.MOZ_MENU {
-            settings += [
-                SettingSection(children: [
-                    BoolSetting(prefs: prefs,
-                        prefKey: HomePageConstants.HomePageButtonIsInMenuPrefKey,
-                        defaultValue: true,
-                        titleText: Strings.SettingsHomePageUIPositionTitle,
-                        statusText: Strings.SettingsHomePageUIPositionSubtitle),
-                    ]),
-                ]
-        }
+            SettingSection(children: [
+                BoolSetting(prefs: prefs,
+                    prefKey: HomePageConstants.HomePageButtonIsInMenuPrefKey,
+                    defaultValue: true,
+                    titleText: Strings.SettingsHomePageUIPositionTitle,
+                    statusText: Strings.SettingsHomePageUIPositionSubtitle),
+            ])
+        ]
 
         return settings
     }

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -603,11 +603,11 @@ extension SQLiteHistory: BrowserHistory {
         "INNER JOIN \(TableDomains) ON \(TableDomains).id = \(TableHistory).domain_id " +
         "INNER JOIN \(TableVisits) ON \(TableVisits).siteID = \(TableHistory).id "
 
-        if includeBookmarks && AppConstants.MOZ_AWESOMEBAR_DUPES {
+        if includeBookmarks {
             ungroupedSQL.appendContentsOf("LEFT JOIN \(ViewAllBookmarks) on \(ViewAllBookmarks).url = \(TableHistory).url ")
         }
         ungroupedSQL.appendContentsOf(whereClause.stringByReplacingOccurrencesOfString("url", withString: "\(TableHistory).url").stringByReplacingOccurrencesOfString("title", withString: "\(TableHistory).title"))
-        if includeBookmarks && AppConstants.MOZ_AWESOMEBAR_DUPES {
+        if includeBookmarks {
             ungroupedSQL.appendContentsOf(" AND \(ViewAllBookmarks).url IS NULL")
         }
         ungroupedSQL.appendContentsOf(" GROUP BY historyID")
@@ -672,7 +672,7 @@ extension SQLiteHistory: BrowserHistory {
                 "1 AS is_bookmarked",
                 "FROM", ViewAwesomebarBookmarksWithIcons,
                 whereClause,                  // The columns match, so we can reuse this.
-                AppConstants.MOZ_AWESOMEBAR_DUPES ? "GROUP BY url" : "",
+                "GROUP BY url",
                 "ORDER BY visitDate DESC LIMIT \(bookmarksLimit)",
             ].joinWithSeparator(" ")
 

--- a/Utils/AppConstants.swift
+++ b/Utils/AppConstants.swift
@@ -63,24 +63,7 @@ public struct AppConstants {
         #endif
     }()
 
-
-    /// Enables/disables the choice of new tab behavior.
-    public static let MOZ_NEW_TAB_CHOICES: Bool = {
-        #if MOZ_CHANNEL_RELEASE
-            return true
-        #elseif MOZ_CHANNEL_BETA
-            return true
-        #elseif MOZ_CHANNEL_NIGHTLY
-            return true
-        #elseif MOZ_CHANNEL_FENNEC
-            return true
-        #elseif MOZ_CHANNEL_AURORA
-            return true
-        #else
-            return true
-        #endif
-    }()
-
+    
     /// Enables/disables the availability of No Image Mode.
     public static let MOZ_NO_IMAGE_MODE: Bool = {
         #if MOZ_CHANNEL_RELEASE

--- a/Utils/AppConstants.swift
+++ b/Utils/AppConstants.swift
@@ -63,23 +63,6 @@ public struct AppConstants {
         #endif
     }()
 
-    
-    ///  Enables/disables the back/forward list from long pressing the back/forward button
-    public static let MOZ_BACK_FORWARD_LIST: Bool = {
-        #if MOZ_CHANNEL_RELEASE
-            return true
-        #elseif MOZ_CHANNEL_BETA
-            return true
-        #elseif MOZ_CHANNEL_NIGHTLY
-            return true
-        #elseif MOZ_CHANNEL_FENNEC
-            return true
-        #elseif MOZ_CHANNEL_AURORA
-            return true
-        #else
-            return true
-        #endif
-    }()
 
     ///  Enables/disables the undo toast for the delete all tabs
     public static let MOZ_UNDO_DELETE_TABS_TOAST: Bool = {

--- a/Utils/AppConstants.swift
+++ b/Utils/AppConstants.swift
@@ -45,22 +45,6 @@ public struct AppConstants {
         #endif
     }()
 
-    /// Enables/disables the new Menu functionality
-    public static let MOZ_MENU: Bool = {
-        #if MOZ_CHANNEL_RELEASE
-            return false
-        #elseif MOZ_CHANNEL_BETA
-            return false
-        #elseif MOZ_CHANNEL_NIGHTLY
-            return true
-        #elseif MOZ_CHANNEL_FENNEC
-            return true
-        #elseif MOZ_CHANNEL_AURORA
-            return true
-        #else
-            return true
-        #endif
-    }()
 
     ///  Enables/disables the notification bar that appears on the status bar area
     public static let MOZ_STATUS_BAR_NOTIFICATION: Bool = {

--- a/Utils/AppConstants.swift
+++ b/Utils/AppConstants.swift
@@ -63,25 +63,7 @@ public struct AppConstants {
         #endif
     }()
 
-
-
-    /// Enables/disables the de-duplication of awesomebar seach results functionality
-    public static let MOZ_AWESOMEBAR_DUPES: Bool = {
-        #if MOZ_CHANNEL_RELEASE
-            return true
-        #elseif MOZ_CHANNEL_BETA
-            return true
-        #elseif MOZ_CHANNEL_NIGHTLY
-            return true
-        #elseif MOZ_CHANNEL_FENNEC
-            return true
-        #elseif MOZ_CHANNEL_AURORA
-            return true
-        #else
-            return true
-        #endif
-    }()
-
+    
     ///  Enables/disables the back/forward list from long pressing the back/forward button
     public static let MOZ_BACK_FORWARD_LIST: Bool = {
         #if MOZ_CHANNEL_RELEASE

--- a/Utils/AppConstants.swift
+++ b/Utils/AppConstants.swift
@@ -64,23 +64,6 @@ public struct AppConstants {
     }()
 
 
-    ///  Enables/disables the undo toast for the delete all tabs
-    public static let MOZ_UNDO_DELETE_TABS_TOAST: Bool = {
-        #if MOZ_CHANNEL_RELEASE
-            return true
-        #elseif MOZ_CHANNEL_BETA
-            return true
-        #elseif MOZ_CHANNEL_NIGHTLY
-            return true
-        #elseif MOZ_CHANNEL_FENNEC
-            return true
-        #elseif MOZ_CHANNEL_AURORA
-            return true
-        #else
-            return true
-        #endif
-    }()
-
     /// Enables/disables the choice of new tab behavior.
     public static let MOZ_NEW_TAB_CHOICES: Bool = {
         #if MOZ_CHANNEL_RELEASE


### PR DESCRIPTION
We have a bunch of feature flags we don't need anymore for features that have shipped, are stable, and don't risk being backed out. This patch removes them from our AppConstants.swift file and their uses.