### PR TITLE
Bug 1304035 - correctly detect whether current page is web page

### DIFF
--- a/Utils/Extensions/NSURLExtensions.swift
+++ b/Utils/Extensions/NSURLExtensions.swift
@@ -244,15 +244,13 @@ extension NSURL {
     }
 
     public func isWebPage(includeDataURIs includeDataURIs: Bool = true) -> Bool {
+        guard let scheme = self.scheme else {
+            return false
+        }
         let httpSchemes = ["http", "https"]
         let dataSchemes = ["data"]
 
-        if let scheme = scheme,
-           _ = httpSchemes.indexOf(scheme) where includeDataURIs && dataSchemes.contains(scheme) {
-            return true
-        }
-
-        return false
+        return httpSchemes.indexOf(scheme) != nil || (includeDataURIs && dataSchemes.contains(scheme))
     }
 
     public var isLocal: Bool {


### PR DESCRIPTION
Recent changes amended the test to determine whether a current scheme is a web page from isHttpOrHttps || isDataURI to isHttpOrHttps where isDataURi, which could never be satisfied as the scheme cannot be both http && data at the same time.
Returning the test to OR instead of AND reenables the share button (and the reload button which was also disabled).
