### PR TITLE
Bug 1305245 - Update Repository Location in Documentation and Scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This branch
 
 This branch is for mainline development that will eventually ship as v6.0.
 
-This branch works with Xcode 8, and supports iOS 8.2 (soon to be deprecated) and 9.x and 10.
+This branch works with Xcode 8, and supports iOS 9.x and 10.
 
 Please make sure you aim your pull requests in the right direction.
 
@@ -46,7 +46,7 @@ Building the code
 1. Clone the repository:
 
   ```shell
-  git clone https://github.com/mozilla/firefox-ios
+  git clone https://github.com/mozilla-mobile/firefox-ios
   ```
 
 1. Pull in the project dependencies:


### PR DESCRIPTION
This branch is about changing the repository location to `https://github.com/mozilla-mobile/firefox-ios` in all our scripts and documentation.