### PR TITLE
Bug 1304202 - Detect bookmarked state of highlights and update context menu accordingly

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -224,4 +224,5 @@ extension Strings {
     public static let BookmarkContextMenuTitle = NSLocalizedString("ActivityStream.ContextMenu.Bookmark", value: "Bookmark", comment: "The title for the Bookmark context menu action for Activity Stream")
     public static let DeleteFromHistoryContextMenuTitle = NSLocalizedString("ActivityStream.ContextMenu.DeleteFromHistory", value: "Delete from History", comment: "The title for the Delete from History context menu action for Activity Stream")
     public static let ShareContextMenuTitle = NSLocalizedString("ActivityStream.ContextMenu.Share", value: "Share", comment: "The title for the Share context menu action for Activity Stream")
+    public static let RemoveBookmarkContextMenuTitle = NSLocalizedString("ActivityStream.ContextMenu.RemoveBookmark", value: "Remove Bookmark", comment: "The title for the Remove Bookmark context menu action for Activity Stream")
 }

--- a/Storage/SQL/SQLiteHistoryRecommendations.swift
+++ b/Storage/SQL/SQLiteHistoryRecommendations.swift
@@ -18,12 +18,12 @@ extension SQLiteHistory: HistoryRecommendations {
         let thirtyMinutesAgo = NSNumber(unsignedLongLong: now - 30 * microsecondsPerMinute)
         let threeDaysAgo = NSNumber(unsignedLongLong: now - (60 * microsecondsPerMinute) * 24 * 3)
 
-        let siteProjection = "historyID, url, title, guid, visitCount, visitDate, isBookmarked"
+        let siteProjection = "historyID, url, title, guid, visitCount, visitDate, is_bookmarked"
         let nonRecentHistory =
             "SELECT \(siteProjection) FROM (" +
             "   SELECT \(TableHistory).id as historyID, url, title, guid, visitDate," +
             "       (SELECT COUNT(1) FROM \(TableVisits) WHERE s = \(TableVisits).siteID) AS visitCount," +
-            "       (SELECT COUNT(1) FROM \(ViewBookmarksLocalOnMirror) WHERE \(ViewBookmarksLocalOnMirror).bmkUri == url) AS isBookmarked" +
+            "       (SELECT COUNT(1) FROM \(ViewBookmarksLocalOnMirror) WHERE \(ViewBookmarksLocalOnMirror).bmkUri == url) AS is_bookmarked" +
             "   FROM (" +
             "       SELECT siteID AS s, max(date) AS visitDate" +
             "       FROM \(TableVisits)" +
@@ -31,13 +31,13 @@ extension SQLiteHistory: HistoryRecommendations {
             "       GROUP BY siteID" +
             "   )" +
             "   LEFT JOIN \(TableHistory) ON \(TableHistory).id = s" +
-            "   WHERE visitCount <= 3 AND title NOT NULL AND title != '' AND isBookmarked == 0" +
+            "   WHERE visitCount <= 3 AND title NOT NULL AND title != '' AND is_bookmarked == 0" +
             "   LIMIT \(historyLimit)" +
             ")"
 
         let bookmarkHighlights =
             "SELECT \(siteProjection) FROM (" +
-            "   SELECT \(TableHistory).id AS historyID, \(TableHistory).url AS url, \(TableHistory).title AS title, guid, NULL AS visitDate, (SELECT count(1) FROM visits WHERE \(TableVisits).siteID = \(TableHistory).id) as visitCount, 1 AS isBookmarked" +
+            "   SELECT \(TableHistory).id AS historyID, \(TableHistory).url AS url, \(TableHistory).title AS title, guid, NULL AS visitDate, (SELECT count(1) FROM visits WHERE \(TableVisits).siteID = \(TableHistory).id) as visitCount, 1 AS is_bookmarked" +
             "   FROM (" +
             "       SELECT bmkUri" +
             "       FROM \(ViewBookmarksLocalOnMirror)" +


### PR DESCRIPTION
Testing was done by switching out the getHighlights() algorithm with the topSites one because I didn't know how to keep bookmarks in the highlights section (they seemed to disappear once I bookmarked a page and they would never come back)