### PR TITLE
Bug 1304691 - Don't show keyboard when trying to reset password if maximum failed attempts have been reached.

### DIFF
--- a/Client/Frontend/AuthenticationManager/PagingPasscodeViewController.swift
+++ b/Client/Frontend/AuthenticationManager/PagingPasscodeViewController.swift
@@ -36,6 +36,9 @@ class PagingPasscodeViewController: BasePasscodeViewController {
         }
         pager.contentSize = CGSize(width: CGFloat(panes.count) * pager.frame.width, height: pager.frame.height)
         scrollToPaneAtIndex(currentPaneIndex)
+        if self.authenticationInfo?.isLocked() ?? false {
+            return
+        }
         panes[currentPaneIndex].codeInputView.becomeFirstResponder()
     }
 


### PR DESCRIPTION
LayoutSubviews was letting the keyboard become a first responder without checking if the user was locked out or not.

