### PR TITLE
Bug 1304030 - Prevent screen flicker of the Reader mode toolbar.

### DIFF
--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -34,6 +34,9 @@ private extension TrayToBrowserAnimator {
         toggleWebViewVisibility(show: false, usingTabManager: bvc.tabManager)
         bvc.homePanelController?.view.hidden = true
         bvc.webViewContainerBackdrop.hidden = true
+        if let url = selectedTab.url where ReaderModeUtils.isReaderModeURL(url) == false {
+            bvc.hideReaderModeBar(animated: false)
+        }
 
         // Take a snapshot of the collection view that we can scale/fade out. We don't need to wait for screen updates since it's already rendered on the screen
         let tabCollectionViewSnapshot = tabTray.collectionView.snapshotViewAfterScreenUpdates(false)!


### PR DESCRIPTION
The transform of the view causes the view to flicker in. I've changed the resetTransformsForViews to only happen for views that are in the view hierarchy. I'm not quite 100% sure what CGAffineTransformIdentity does. But the issue is caused by this. Specifically https://github.com/mozilla-mobile/firefox-ios/blob/master/Client/Frontend/Browser/BrowserTrayAnimators.swift#L61