### PR TITLE
Bug 1304394 - Prevent Menu from reloading itself when the app is in the Background.

### DIFF
--- a/Client/Frontend/Widgets/Menu/MenuViewController.swift
+++ b/Client/Frontend/Widgets/Menu/MenuViewController.swift
@@ -33,7 +33,8 @@ class MenuViewController: UIViewController {
 
     var appState: AppState {
         didSet {
-            if !self.isBeingDismissed() {
+            let state = UIApplication.sharedApplication().applicationState
+            if !self.isBeingDismissed() && state == .Active {
                 menuConfig = menuConfig.menuForState(appState)
                 self.reloadView()
             }


### PR DESCRIPTION
The damage stemmed from the fact that changes to the appState were happening while the app was in the background. Probably some user prefs being saved or something. Simply checking if the app is Active when listening to changes on AppState makes sure that we don't reload needlessly. 

This actually prevents a few issues that were not yet found. For example, if you have the menu open on the second page and background the app. Once you come back to the app the pageControl dot is on the wrong page. 