### PR TITLE
Bug 1305895 - Include sender client GUID in sent displayURI commands.

### DIFF
--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -476,8 +476,9 @@ public class BrowserProfile: Profile {
     }
 
     public func sendItems(items: [ShareItem], toClients clients: [RemoteClient]) {
+        let id = DeviceInfo.clientIdentifier(self.prefs)
         let commands = items.map { item in
-            SyncCommand.fromShareItem(item, withAction: "displayURI")
+            SyncCommand.displayURIFromShareItem(item, asClient: id)
         }
         self.remoteClientsAndTabs.insertCommands(commands, forClients: clients) >>> { self.syncManager.syncClients() }
     }

--- a/Storage/SyncQueue.swift
+++ b/Storage/SyncQueue.swift
@@ -33,11 +33,13 @@ public struct SyncCommand: Equatable {
         self.commandID = id
     }
 
-
-    public static func fromShareItem(shareItem: ShareItem, withAction action: String) -> SyncCommand {
+    /**
+     * Sent displayURI commands include the sender client GUID.
+     */
+    public static func displayURIFromShareItem(shareItem: ShareItem, asClient sender: GUID) -> SyncCommand {
         let jsonObj: [String: AnyObject] = [
-            "command": action,
-            "args": [shareItem.url, "", shareItem.title ?? ""]
+            "command": "displayURI",
+            "args": [shareItem.url, sender, shareItem.title ?? ""]
         ]
         return SyncCommand(value: JSON.stringify(jsonObj, pretty: false))
     }

--- a/StorageTests/SyncCommandsTests.swift
+++ b/StorageTests/SyncCommandsTests.swift
@@ -62,14 +62,13 @@ class SyncCommandsTests: XCTestCase {
     }
 
     func testCreateSyncCommandFromShareItem() {
-        let action = "testcommand"
         let shareItem = shareItems[0]
-        let syncCommand = SyncCommand.fromShareItem(shareItem, withAction: action)
+        let syncCommand = SyncCommand.displayURIFromShareItem(shareItem, asClient: "abcdefghijkl")
         XCTAssertNil(syncCommand.commandID)
         XCTAssertNotNil(syncCommand.value)
         let jsonObj: [String: AnyObject] = [
-            "command": action,
-            "args": [shareItem.url, "", shareItem.title ?? ""]
+            "command": "displayURI",
+            "args": [shareItem.url, "abcdefghijkl", shareItem.title ?? ""]
         ]
         XCTAssertEqual(JSON.stringify(jsonObj, pretty: false), syncCommand.value)
     }
@@ -95,9 +94,8 @@ class SyncCommandsTests: XCTestCase {
     }
 
     func testInsertWithURLOnly() {
-        let action = "testcommand"
         let shareItem = shareItems[3]
-        let syncCommand = SyncCommand.fromShareItem(shareItem, withAction: action)
+        let syncCommand = SyncCommand.displayURIFromShareItem(shareItem, asClient: "abcdefghijkl")
 
         let e = self.expectationWithDescription("Insert.")
         clientsAndTabs.insertCommand(syncCommand, forClients: clients).upon {
@@ -118,10 +116,9 @@ class SyncCommandsTests: XCTestCase {
     }
 
     func testInsertWithMultipleCommands() {
-        let action = "testcommand"
         let e = self.expectationWithDescription("Insert.")
         let syncCommands = shareItems.map { item in
-            return SyncCommand.fromShareItem(item, withAction: action)
+            return SyncCommand.displayURIFromShareItem(item, asClient: "abcdefghijkl")
         }
         clientsAndTabs.insertCommands(syncCommands, forClients: clients).upon {
             XCTAssertTrue($0.isSuccess)
@@ -141,9 +138,8 @@ class SyncCommandsTests: XCTestCase {
     }
 
     func testGetForAllClients() {
-        let action = "testcommand"
         let syncCommands = shareItems.map { item in
-            return SyncCommand.fromShareItem(item, withAction: action)
+            return SyncCommand.displayURIFromShareItem(item, asClient: "abcdefghijkl")
         }.sort(byValue)
         clientsAndTabs.insertCommands(syncCommands, forClients: clients)
 
@@ -164,9 +160,8 @@ class SyncCommandsTests: XCTestCase {
     }
 
     func testDeleteForValidClient() {
-        let action = "testcommand"
         let syncCommands = shareItems.map { item in
-            return SyncCommand.fromShareItem(item, withAction: action)
+            return SyncCommand.displayURIFromShareItem(item, asClient: "abcdefghijkl")
         }.sort(byValue)
 
         var client = self.clients[0]
@@ -206,9 +201,8 @@ class SyncCommandsTests: XCTestCase {
     }
 
     func testDeleteForAllClients() {
-        let action = "testcommand"
         let syncCommands = shareItems.map { item in
-            return SyncCommand.fromShareItem(item, withAction: action)
+            return SyncCommand.displayURIFromShareItem(item, asClient: "abcdefghijkl")
         }
 
         let a = self.expectationWithDescription("Wipe for all clients.")


### PR DESCRIPTION
This passes the test, but I haven't manually tested. Figured it was worth throwing up the PR anyway… @sleroux, take a look?
