### PR TITLE
Bug 1302970 - Opening via the today widget now selects the right default home panel.

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -326,6 +326,7 @@ class TabManager: NSObject {
                 // one of the about:home pages.
                 if let url = newTabChoice.url {
                     tab.loadRequest(PrivilegedRequest(URL: url))
+                    tab.url = url
                 }
             }
         }


### PR DESCRIPTION
Simple enough! 

The reason why this specifically doesn't work when opening from a widget is because the widget opens a new tab and also focuses the URL bar.

Usually, the URL is set via the `didCommitNavigation` method. That method isn't called until after the URLBar is selected. When the URLbar is selected it calls `selectHomePanel`. That is when it checks what panel it should use but the URL isn't set so it just sets TopSites. 