### PR TITLE
Bug 1308854 - Prevent layout issues with menu when resuming from background

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1702,6 +1702,12 @@ extension BrowserViewController: MenuViewControllerDelegate {
             return false
         }
 
+        // Dismiss the menu if we are going into the background.
+        let state = UIApplication.sharedApplication().applicationState
+        if state != .Active {
+            return true
+        }
+
         func orientationForSize(size: CGSize) -> UIInterfaceOrientation {
             return size.height < size.width ? .LandscapeLeft : .Portrait
         }

--- a/Client/Frontend/Widgets/Menu/MenuViewController.swift
+++ b/Client/Frontend/Widgets/Menu/MenuViewController.swift
@@ -33,8 +33,7 @@ class MenuViewController: UIViewController {
 
     var appState: AppState {
         didSet {
-            let state = UIApplication.sharedApplication().applicationState
-            if !self.isBeingDismissed() && state == .Active {
+            if !self.isBeingDismissed() {
                 menuConfig = menuConfig.menuForState(appState)
                 self.reloadView()
             }


### PR DESCRIPTION
This also reverts https://github.com/mozilla-mobile/firefox-ios/commit/d78c4790d57597f0f6354150a11a13be68c4ec6d

As this fix covers both cases. 