### PR TITLE
Bug 1272658 - 'Sync devices' screen is displayed in portrait while de…

### DIFF
--- a/Client/Frontend/Home/RemoteTabsPanel.swift
+++ b/Client/Frontend/Home/RemoteTabsPanel.swift
@@ -432,7 +432,7 @@ class RemoteTabsNotLoggedInCell: UITableViewCell {
     }
 
     override func updateConstraints() {
-        if UIDeviceOrientationIsLandscape(UIDevice.currentDevice().orientation) && !(DeviceInfo.deviceModel().rangeOfString("iPad") != nil) {
+        if UIInterfaceOrientationIsLandscape(UIApplication.sharedApplication().statusBarOrientation) && !(DeviceInfo.deviceModel().rangeOfString("iPad") != nil) {
             instructionsLabel.snp_remakeConstraints { make in
                 make.top.equalTo(titleLabel.snp_bottom).offset(RemoteTabsPanelUX.EmptyStateTopPaddingInBetweenItems)
                 make.width.equalTo(RemoteTabsPanelUX.EmptyStateInstructionsWidth)


### PR DESCRIPTION
…vice is in landscape

Bugzilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1272658

The interface orientation can be different than the device orientation. You typically call this function in your view controller code to check the current orientation.
https://developer.apple.com/reference/uikit/1623001-uiinterfaceorientationislandscap