### PR TITLE
Bug 1304716 - The selected row remains highlighted (e.g. 'Logins') wh…

### DIFF
--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -584,6 +584,12 @@ class LoginsSetting: Setting {
         super.init(title: NSAttributedString(string: loginsTitle, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]),
                    delegate: delegate)
     }
+    
+    func deselectRow () {
+        if let selectedRow = self.settings?.tableView.indexPathForSelectedRow {
+            self.settings?.tableView.deselectRowAtIndexPath(selectedRow, animated: true)
+        }
+    }
 
     override func onClick(_: UINavigationController?) {
         guard let authInfo = KeychainWrapper.defaultKeychainWrapper().authenticationInfo() else {
@@ -598,12 +604,11 @@ class LoginsSetting: Setting {
                 self.settings?.navigateToLoginsList()
             },
             cancel: {
-                if let selectedRow = self.settings?.tableView.indexPathForSelectedRow {
-                    self.settings?.tableView.deselectRowAtIndexPath(selectedRow, animated: true)
-                }
+                self.deselectRow()
             },
             fallback: {
                 AppAuthenticator.presentPasscodeAuthentication(self.navigationController, delegate: self.settings)
+                self.deselectRow()
             })
         } else {
             settings?.navigateToLoginsList()


### PR DESCRIPTION
…en Canceling the Passcode request prompt

Bugzilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1304716

The reason why this was happening on iPad (And also on iPhone 6/7+ on landspace) and not on iPhones is because when a modal is dismissed it will call “viewWillAppear:” on “SettingsTableViewController” which calls “reloadData” on the tableView.

But on iPads this is not true since the modal is being called on a FormSheet factor, therefore the presenting controller's view never disappears, so “viewWillAppear:” is not called after the dismissal.