### PR TITLE
Bug 1272231 - The logins are displayed as deselected after screen lock

### DIFF
--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -267,10 +267,17 @@ private extension LoginListViewController {
 // MARK: - LoginDataSourceObserver
 extension LoginListViewController: LoginDataSourceObserver {
     func loginSectionsDidUpdate() {
-        self.loadingStateView.hidden = true
-        self.tableView.reloadData()
-        self.activeLoginQuery = nil
-        self.navigationItem.rightBarButtonItem?.enabled = self.loginDataSource.count > 0
+        loadingStateView.hidden = true
+        tableView.reloadData()
+        activeLoginQuery = nil
+        navigationItem.rightBarButtonItem?.enabled = loginDataSource.count > 0
+        restoreSelectedRows()
+    }
+    
+    func restoreSelectedRows() {
+        for path in self.loginSelectionController.selectedIndexPaths {
+            tableView.selectRowAtIndexPath(path, animated: false, scrollPosition: .None)
+        }
     }
 }
 


### PR DESCRIPTION
Bugzilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1272231

The issue was happening because the `loginSectionsDidUpdate` was being called after the user typed the password and the screen refreshed, and this method calls `reloadData` which cleans the selections.

The fix is done by looping on all selected indexPaths stored on `loginSelectionController` and selecting them again.

Some `self` references were also removed since they are not required, as described on the style guide: https://github.com/raywenderlich/swift-style-guide#use-of-self