### PR TITLE
Bug 1303734 - Store textual page metadata

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -585,6 +585,7 @@
 		E63ED7D81BFCD9990097D08E /* LoginTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63ED7D71BFCD9990097D08E /* LoginTableViewCell.swift */; };
 		E63ED8091BFCF9770097D08E /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65C5B9A1BEA4E7100D28BEF /* SwiftSupport.swift */; };
 		E63ED8E11BFD25580097D08E /* LoginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63ED8E01BFD25580097D08E /* LoginListViewController.swift */; };
+		E63F71881DB7FBE200A995C9 /* TestSQLiteMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63F71871DB7FBE200A995C9 /* TestSQLiteMetadata.swift */; };
 		E640E85E1C73A45A00C5F072 /* PasscodeEntryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E640E85D1C73A45A00C5F072 /* PasscodeEntryViewController.swift */; };
 		E640E86A1C73A47C00C5F072 /* PasscodeViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = E640E8691C73A47C00C5F072 /* PasscodeViews.swift */; };
 		E640E8701C73BCF500C5F072 /* AuthenticationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E640E86F1C73BCF500C5F072 /* AuthenticationManagerTests.swift */; };
@@ -1680,6 +1681,7 @@
 		E63ED7B31BFCD9800097D08E /* LoginTableViewCellRefTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginTableViewCellRefTests.swift; sourceTree = "<group>"; };
 		E63ED7D71BFCD9990097D08E /* LoginTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginTableViewCell.swift; sourceTree = "<group>"; };
 		E63ED8E01BFD25580097D08E /* LoginListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginListViewController.swift; sourceTree = "<group>"; };
+		E63F71871DB7FBE200A995C9 /* TestSQLiteMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSQLiteMetadata.swift; sourceTree = "<group>"; };
 		E640E85D1C73A45A00C5F072 /* PasscodeEntryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasscodeEntryViewController.swift; sourceTree = "<group>"; };
 		E640E8691C73A47C00C5F072 /* PasscodeViews.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasscodeViews.swift; sourceTree = "<group>"; };
 		E640E86F1C73BCF500C5F072 /* AuthenticationManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationManagerTests.swift; sourceTree = "<group>"; };
@@ -2423,6 +2425,7 @@
 				28D158AC1AFD90E500F9C065 /* TestSQLiteBookmarks.swift */,
 				2FCAE27D1ABB533A00877008 /* TestSQLiteHistory.swift */,
 				E6BE53CC1D9177B10074909A /* TestSQLiteHistoryRecommendations.swift */,
+				E63F71871DB7FBE200A995C9 /* TestSQLiteMetadata.swift */,
 				2FCAE27A1ABB533A00877008 /* TestSQLiteRemoteClientsAndTabs.swift */,
 				D32CACEC1AE04DA1000658EB /* TestSwiftData.swift */,
 				2FCAE2821ABB533A00877008 /* TestTableTable.swift */,
@@ -4747,6 +4750,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				28D158AD1AFD90E500F9C065 /* TestSQLiteBookmarks.swift in Sources */,
+				E63F71881DB7FBE200A995C9 /* TestSQLiteMetadata.swift in Sources */,
 				2FCAE2851ABB533A00877008 /* TestSQLiteRemoteClientsAndTabs.swift in Sources */,
 				0B5A93081B1E64F3004F47A2 /* TestDeferredSqlite.swift in Sources */,
 				E6BE53CD1D9177B10074909A /* TestSQLiteHistoryRecommendations.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -614,6 +614,8 @@
 		E664B45A1CD7ECDB0045A6A4 /* NotificationRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E664B4591CD7ECDB0045A6A4 /* NotificationRootViewController.swift */; };
 		E66C5B481BDA81050051AA93 /* UIImage+ImageEffects.m in Sources */ = {isa = PBXBuildFile; fileRef = E66C5B471BDA81050051AA93 /* UIImage+ImageEffects.m */; };
 		E67422C51CFF2D39009E8373 /* youtube.ico in Resources */ = {isa = PBXBuildFile; fileRef = E67422C41CFF2D39009E8373 /* youtube.ico */; };
+		E677F0451D9423FB00ECF1FB /* SQLiteMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = E677F0441D9423FB00ECF1FB /* SQLiteMetadata.swift */; };
+		E677F0541D94247300ECF1FB /* Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = E677F0531D94247300ECF1FB /* Metadata.swift */; };
 		E679FDBB1B99CF10008C220A /* PrivateBrowsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E679FDBA1B99CF10008C220A /* PrivateBrowsingTests.swift */; };
 		E67D57031D527449003917B1 /* BatchingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67D57021D527449003917B1 /* BatchingClient.swift */; };
 		E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */; };
@@ -1718,6 +1720,8 @@
 		E66C5B461BDA81050051AA93 /* UIImage+ImageEffects.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+ImageEffects.h"; sourceTree = "<group>"; };
 		E66C5B471BDA81050051AA93 /* UIImage+ImageEffects.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+ImageEffects.m"; sourceTree = "<group>"; };
 		E67422C41CFF2D39009E8373 /* youtube.ico */ = {isa = PBXFileReference; lastKnownFileType = image.ico; path = youtube.ico; sourceTree = "<group>"; };
+		E677F0441D9423FB00ECF1FB /* SQLiteMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLiteMetadata.swift; sourceTree = "<group>"; };
+		E677F0531D94247300ECF1FB /* Metadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Metadata.swift; sourceTree = "<group>"; };
 		E679FDBA1B99CF10008C220A /* PrivateBrowsingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingTests.swift; sourceTree = "<group>"; };
 		E67D57021D527449003917B1 /* BatchingClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BatchingClient.swift; sourceTree = "<group>"; };
 		E682F53C1C89E72600ECB6B2 /* FennecAurora.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = FennecAurora.xcconfig; path = Configuration/FennecAurora.xcconfig; sourceTree = "<group>"; };
@@ -2376,6 +2380,7 @@
 				2FCAE2431ABB531100877008 /* FileAccessor.swift */,
 				2FCAE2441ABB531100877008 /* History.swift */,
 				0BDA56B11B26B1E4008C9B96 /* Logins.swift */,
+				E677F0531D94247300ECF1FB /* Metadata.swift */,
 				0B3E7DB91B27AB4C00E2E84D /* MockLogins.swift */,
 				285D3B671B4380B70035FD22 /* Queue.swift */,
 				E6FF6AC91D873CFF0070C294 /* PageMetadata.swift */,
@@ -2454,6 +2459,7 @@
 				E64F1C9C1D80AADC0034A9A5 /* SQLiteHistoryFactories.swift */,
 				E6F368281D7F594F008CDD67 /* SQLiteHistoryRecommendations.swift */,
 				0BDA56B31B26B203008C9B96 /* SQLiteLogins.swift */,
+				E677F0441D9423FB00ECF1FB /* SQLiteMetadata.swift */,
 				285D3B8F1B4386520035FD22 /* SQLiteQueue.swift */,
 				2FCAE2581ABB531100877008 /* SQLiteRemoteClientsAndTabs.swift */,
 			);
@@ -4701,6 +4707,7 @@
 				2FCAE26F1ABB531100877008 /* RemoteTabsTable.swift in Sources */,
 				7BF5A1EA1B41640500EA9DD8 /* SyncQueue.swift in Sources */,
 				2852B8441C51996B00591EAC /* Trees.swift in Sources */,
+				E677F0541D94247300ECF1FB /* Metadata.swift in Sources */,
 				28E08C991AF44EF9009BA2FA /* SQLiteHistory.swift in Sources */,
 				285D3B901B4386520035FD22 /* SQLiteQueue.swift in Sources */,
 				7BF5A1CA1B4160EA00EA9DD8 /* SyncCommandsTable.swift in Sources */,
@@ -4714,6 +4721,7 @@
 				2FCAE2611ABB531100877008 /* FileAccessor.swift in Sources */,
 				28126F481C2F948E006466CC /* SQLiteBookmarksHelpers.swift in Sources */,
 				2FCAE2691ABB531100877008 /* FaviconsTable.swift in Sources */,
+				E677F0451D9423FB00ECF1FB /* SQLiteMetadata.swift in Sources */,
 				D37DE2831CA2047500A5EC69 /* CertStore.swift in Sources */,
 				2829D37A1C2F0A7F00DCF931 /* BookmarksModel.swift in Sources */,
 				2FCAE2661ABB531100877008 /* Site.swift in Sources */,

--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
@@ -326,6 +326,13 @@
             ReferencedContainer = "container:Client.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/Client/Frontend/Browser/MetadataParserHelper.swift
+++ b/Client/Frontend/Browser/MetadataParserHelper.swift
@@ -41,21 +41,13 @@ class MetadataParserHelper: TabHelper {
     }
 
     func userContentController(userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
-        guard let dict = message.body as? [String: AnyObject],
-              let url = (dict["url"] as? String)?.asURL else {
+        guard let dict = message.body as? [String: AnyObject] else {
             return
         }
-
-        // Pull out what we need and pass to a notification
+        
         var userInfo = [String: AnyObject]()
-        userInfo["isPrivate"] = tab?.isPrivate ?? true
-        userInfo["metadata_url"] = url
-        userInfo["metadata_title"] = dict["title"] as? String
-        userInfo["metadata_description"] = dict["description"] as? String
-        userInfo["metadata_image_url"] = (dict["image_url"] as? String)?.asURL
-        userInfo["metadata_type"] = dict["type"] as? String
-        userInfo["metadata_icon_url"] = (dict["icon_url"] as? String)?.asURL
-
+        userInfo["isPrivate"] = self.tab?.isPrivate ?? true
+        userInfo["metadata"] = dict
         NSNotificationCenter.defaultCenter().postNotificationName(NotificationOnPageMetadataFetched, object: nil, userInfo: userInfo)
     }
 }

--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -79,7 +79,7 @@ class ActivityStreamPanel: UITableViewController, HomePanel {
         tableView.sectionHeaderHeight = UITableViewAutomaticDimension
 
         reloadTopSites()
-        reloadRecentHistory()
+        reloadHighlights()
     }
 
     override func viewWillAppear(animated: Bool) {
@@ -260,7 +260,7 @@ extension ActivityStreamPanel {
         }
     }
 
-    private func reloadRecentHistory() {
+    private func reloadHighlights() {
         fetchHighlights().uponQueue(dispatch_get_main_queue()) { result in
             self.highlights = result.successValue?.asArray() ?? self.highlights
             self.tableView.reloadData()
@@ -382,7 +382,7 @@ extension ActivityStreamPanel {
 
         let dismissAction = ActionOverlayTableViewAction(title: Strings.DismissContextMenuTitle, iconString: "action_close", handler: { action in
             self.profile.recommendations.removeHighlightForURL(site.url).uponQueue(dispatch_get_main_queue()) { _ in
-                    self.history.removeAtIndex(indexPath.row)
+                    self.highlights.removeAtIndex(indexPath.row)
                     self.tableView.beginUpdates()
                     self.tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Right)
                     self.tableView.endUpdates()

--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -38,7 +38,7 @@ class ActivityStreamPanel: UITableViewController, HomePanel {
         return UILongPressGestureRecognizer(target: self, action: #selector(ActivityStreamPanel.longPress(_:)))
     }()
 
-    var history: [Site] = []
+    var highlights: [Site] = []
 
     init(profile: Profile) {
         self.profile = profile
@@ -197,8 +197,7 @@ extension ActivityStreamPanel {
         switch Section(indexPath.section) {
         case .Highlights:
             ASOnyxPing.reportTapEvent(actionPosition: indexPath.item, source: .highlights)
-
-            let site = self.history[indexPath.row]
+            let site = self.highlights[indexPath.row]
             showSiteWithURLHandler(NSURL(string:site.url)!)
         case .TopSites:
             return
@@ -218,7 +217,7 @@ extension ActivityStreamPanel {
             case .TopSites:
                 return topSitesManager.content.isEmpty ? 0 : 1
             case .Highlights:
-                 return self.history.count
+                 return self.highlights.count
         }
     }
 
@@ -242,7 +241,7 @@ extension ActivityStreamPanel {
 
     func configureHistoryItemCell(cell: UITableViewCell, forIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let simpleHighlightCell = cell as! SimpleHighlightCell
-        let site = history[indexPath.row]
+        let site = highlights[indexPath.row]
         simpleHighlightCell.configureWithSite(site)
         return simpleHighlightCell
     }
@@ -263,7 +262,7 @@ extension ActivityStreamPanel {
 
     private func reloadRecentHistory() {
         fetchHighlights().uponQueue(dispatch_get_main_queue()) { result in
-            self.history = result.successValue?.asArray() ?? self.history
+            self.highlights = result.successValue?.asArray() ?? self.highlights
             self.tableView.reloadData()
         }
     }
@@ -347,7 +346,7 @@ extension ActivityStreamPanel {
             let touchPoint = longPressGestureRecognizer.locationInView(self.view)
             if let indexPath = tableView.indexPathForRowAtPoint(touchPoint) {
                 if Section(indexPath.section) == .Highlights {
-                    presentContextMenu(history[indexPath.row], indexPath: indexPath)
+                    presentContextMenu(highlights[indexPath.row], indexPath: indexPath)
                 }
             }
         }

--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -111,7 +111,7 @@ public class MockProfile: Profile {
     }
 
     lazy var metadata: Metadata = {
-        return SQLitePageMetadata(db: self.db)
+        return SQLiteMetadata(db: self.db)
     }()
 
     lazy var isChinaEdition: Bool = {

--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -110,6 +110,10 @@ public class MockProfile: Profile {
         return self.places
     }
 
+    lazy var metadata: Metadata = {
+        return SQLitePageMetadata(db: self.db)
+    }()
+
     lazy var isChinaEdition: Bool = {
         return NSLocale.currentLocale().localeIdentifier == "zh_CN"
     }()

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -326,7 +326,8 @@ public class BrowserProfile: Profile {
             return
         }
 
-        self.metadata.storeMetadata(pageMetadata, forPageURL: pageURL)
+        let defaultMetadataTTL: UInt64 = 3 * 24 * 60 * 60 * 1000 // 3 days for the metadata to live
+        self.metadata.storeMetadata(pageMetadata, forPageURL: pageURL, expireAt: defaultMetadataTTL)
     }
 
     // These selectors run on which ever thread sent the notifications (not the main thread)

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -317,25 +317,6 @@ public class BrowserProfile: Profile {
             log.debug("Private mode - Ignoring page metadata.")
             return
         }
-
-        if let metadata = metadataFromNotification(notification) {
-            // TODO: Store metadata content into database.
-        }
-    }
-
-    private func metadataFromNotification(notification: NSNotification) -> PageMetadata? {
-        guard let url = notification.userInfo?["metadata_url"] as? NSURL else {
-            return nil
-        }
-
-        return PageMetadata(
-            url: url,
-            title: notification.userInfo?["metadata_title"] as? String,
-            description: notification.userInfo?["metadata_description"] as? String,
-            imageURL: notification.userInfo?["metadata_image_url"] as? NSURL,
-            type: notification.userInfo?["metadata_type"] as? String,
-            iconURL: notification.userInfo?["metadata_icon_url"] as? NSURL
-        )
     }
 
     // These selectors run on which ever thread sent the notifications (not the main thread)

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -394,7 +394,7 @@ public class BrowserProfile: Profile {
     }
 
     lazy var metadata: Metadata = {
-        return SQLitePageMetadata(db: self.db)
+        return SQLiteMetadata(db: self.db)
     }()
 
     var recommendations: HistoryRecommendations {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -327,7 +327,7 @@ public class BrowserProfile: Profile {
         }
 
         let defaultMetadataTTL: UInt64 = 3 * 24 * 60 * 60 * 1000 // 3 days for the metadata to live
-        self.metadata.storeMetadata(pageMetadata, forPageURL: pageURL, expireAt: defaultMetadataTTL)
+        self.metadata.storeMetadata(pageMetadata, forPageURL: pageURL, expireAt: defaultMetadataTTL + NSDate.now())
     }
 
     // These selectors run on which ever thread sent the notifications (not the main thread)

--- a/Storage/Metadata.swift
+++ b/Storage/Metadata.swift
@@ -6,8 +6,8 @@ import Foundation
 import Deferred
 import Shared
 
+/// Interface for saving and retrieving metadata web content
 public protocol Metadata {
-    func metadataForSites(sites: [Site]) -> Deferred<Maybe<[PageMetadata]>>
-    func metadataForURLs(urls: [NSURL]) -> Deferred<Maybe<[PageMetadata]>>
-    func storeMetadata(metadata: PageMetadata, forPageURL: NSURL) -> Success
+    func storeMetadata(metadata: PageMetadata, forPageURL: NSURL, expireAt: UInt64) -> Success
+    func deleteExpiredMetadata() -> Success
 }

--- a/Storage/Metadata.swift
+++ b/Storage/Metadata.swift
@@ -1,0 +1,9 @@
+//
+//  SiteMetadata.swift
+//  Client
+//
+//  Created by Steph Leroux on 2016-09-22.
+//  Copyright © 2016 Mozilla. All rights reserved.
+//
+
+import Foundation

--- a/Storage/Metadata.swift
+++ b/Storage/Metadata.swift
@@ -8,4 +8,6 @@ import Shared
 
 public protocol Metadata {
     func metadataForSites(sites: [Site]) -> Deferred<Maybe<[PageMetadata]>>
+    func metadataForURLs(urls: [NSURL]) -> Deferred<Maybe<[PageMetadata]>>
+    func storeMetadata(metadata: PageMetadata, forPageURL: NSURL) -> Success
 }

--- a/Storage/Metadata.swift
+++ b/Storage/Metadata.swift
@@ -1,9 +1,11 @@
-//
-//  SiteMetadata.swift
-//  Client
-//
-//  Created by Steph Leroux on 2016-09-22.
-//  Copyright © 2016 Mozilla. All rights reserved.
-//
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import Deferred
+import Shared
+
+public protocol Metadata {
+    func metadataForSites(sites: [Site]) -> Deferred<Maybe<[PageMetadata]>>
+}

--- a/Storage/PageMetadata.swift
+++ b/Storage/PageMetadata.swift
@@ -5,23 +5,25 @@
 import Foundation
 
 /*
- * Value types representing a page's metadata and associated images
+ * Value types representing a page's metadata
  */
 public struct PageMetadata {
     public let id: Int?
     public let siteURL: String
+    public let mediaURL: String?
     public let title: String?
     public let description: String?
     public let type: String?
-    public let images: [PageMetadataImage]
+    public let providerName: String?
 
-    public init(id: Int?, siteURL: String, title: String?, description: String?, type: String?, images: [PageMetadataImage] = []) {
+    public init(id: Int?, siteURL: String, mediaURL: String?, title: String?, description: String?, type: String?, providerName: String?) {
         self.id = id
         self.siteURL = siteURL
+        self.mediaURL = mediaURL
         self.title = title
         self.description = description
         self.type = type
-        self.images = images
+        self.providerName = providerName
     }
 
     public static func fromDictionary(dict: [String: AnyObject]) -> PageMetadata? {
@@ -29,21 +31,8 @@ public struct PageMetadata {
             return nil
         }
 
-        return PageMetadata(id: nil, siteURL: siteURL, title: dict["title"] as? String,
-                            description: dict["description"] as? String, type: dict["type"] as? String)
+        return PageMetadata(id: nil, siteURL: siteURL, mediaURL: dict["image_url"] as? String,
+                            title: dict["title"] as? String, description: dict["description"] as? String,
+                            type: dict["type"] as? String, providerName: dict["provider_name"] as? String)
     }
-}
-
-public enum MetadataImageType: Int {
-    case Favicon = 1
-    case RichFavicon = 2
-    case Preview = 3
-}
-
-public struct PageMetadataImage {
-    public let imageURL: String
-    public let type: MetadataImageType
-    public let height: Int
-    public let width: Int
-    public let color: String
 }

--- a/Storage/PageMetadata.swift
+++ b/Storage/PageMetadata.swift
@@ -8,20 +8,29 @@ import Foundation
  * Value types representing a page's metadata and associated images
  */
 public struct PageMetadata {
-    public let id: Int
+    public let id: Int?
     public let siteURL: String
     public let title: String?
     public let description: String?
     public let type: String?
     public let images: [PageMetadataImage]
 
-    public init(id: Int, siteURL: String, title: String?, description: String?, type: String?, images: [PageMetadataImage] = []) {
+    public init(id: Int?, siteURL: String, title: String?, description: String?, type: String?, images: [PageMetadataImage] = []) {
         self.id = id
         self.siteURL = siteURL
         self.title = title
         self.description = description
         self.type = type
         self.images = images
+    }
+
+    public static func fromDictionary(dict: [String: AnyObject]) -> PageMetadata? {
+        guard let siteURL = dict["url"] as? String else {
+            return nil
+        }
+
+        return PageMetadata(id: nil, siteURL: siteURL, title: dict["title"] as? String,
+                            description: dict["description"] as? String, type: dict["type"] as? String)
     }
 }
 

--- a/Storage/PageMetadata.swift
+++ b/Storage/PageMetadata.swift
@@ -4,20 +4,37 @@
 
 import Foundation
 
+/*
+ * Value types representing a page's metadata and associated images
+ */
 public struct PageMetadata {
-    public let url: NSURL
+    public let id: Int
+    public let siteURL: String
     public let title: String?
     public let description: String?
-    public let imageURL: NSURL?
     public let type: String?
-    public let iconURL: NSURL?
+    public let images: [PageMetadataImage]
 
-    public init(url: NSURL, title: String?, description: String?, imageURL: NSURL?, type: String?, iconURL: NSURL?) {
-        self.url = url
+    public init(id: Int, siteURL: String, title: String?, description: String?, type: String?, images: [PageMetadataImage] = []) {
+        self.id = id
+        self.siteURL = siteURL
         self.title = title
         self.description = description
-        self.imageURL = imageURL
         self.type = type
-        self.iconURL = iconURL
+        self.images = images
     }
+}
+
+public enum MetadataImageType: Int {
+    case Favicon = 1
+    case RichFavicon = 2
+    case Preview = 3
+}
+
+public struct PageMetadataImage {
+    public let imageURL: String
+    public let type: MetadataImageType
+    public let height: Int
+    public let width: Int
+    public let color: String
 }

--- a/Storage/SQL/BrowserTable.swift
+++ b/Storage/SQL/BrowserTable.swift
@@ -45,7 +45,6 @@ let ViewHistoryVisits = "view_history_visits"
 let ViewWidestFaviconsForSites = "view_favicons_widest"
 let ViewHistoryIDsWithWidestFavicons = "view_history_id_favicon"
 let ViewIconForURL = "view_icon_for_url"
-let ViewHistoryPageMetadata = "view_history_page_metadata"
 
 let IndexHistoryShouldUpload = "idx_history_should_upload"
 let IndexVisitsSiteIDDate = "idx_visits_siteID_date"                   // Removed in v6.

--- a/Storage/SQL/SQLiteMetadata.swift
+++ b/Storage/SQL/SQLiteMetadata.swift
@@ -3,7 +3,94 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import Deferred
+import Shared
 
-class SQLitePageMetadata {
+/**
+ * The sqlite-backed implementation of the metadata protocol containing images and content for pages.
+ */
+public class SQLitePageMetadata {
+    let db: BrowserDB
 
+    required public init(db: BrowserDB) {
+        self.db = db
+    }
+}
+
+extension SQLitePageMetadata: Metadata {
+    private typealias CacheKey = String
+
+    // TODO: Theres probably a better query here. Currently, this grabs all of the metadata rows then
+    //       performs a query _per_each_object_ to grab it's associated images. To work around the immutable
+    //       object returned from the SDRow factory, there's some hackery to assign the images to the
+    //       metadata object (see extension defined below).
+    public func metadataForSites(sites: [Site]) -> Deferred<Maybe<[PageMetadata]>> {
+        let cacheKeys = sites.flatMap(cacheKeyForSite)
+
+        let args: Args = cacheKeys
+        let query =
+        "SELECT pi.* " +
+        "FROM \(TablePageMetadata) as pm" +
+        "JOIN \(TablePageMetadataImages) AS pmi ON pm.id = pmi.metadata_id " +
+        "JOIN \(TablePageImages) AS pi ON pi.id = pmi.image_id" +
+        "WHERE id IN \(BrowserDB.varlist(cacheKeys.count))"
+
+        return self.db.runQuery(query, args: args, factory: SQLitePageMetadata.pageMetadataFactory) >>== { metadatas in
+            var processedMetadatas: [PageMetadata] = []
+            return walk(metadatas.asArray(), f: { metadata in
+                return self.imagesForMetadata(metadata) >>== { images in
+                    processedMetadatas.append(metadata.setImages(images.asArray()))
+                    return succeed()
+                }
+            }) >>> { return deferMaybe(processedMetadatas) }
+        }
+    }
+
+    private func imagesForMetadata(metadata: PageMetadata) -> Deferred<Maybe<Cursor<PageMetadataImage>>> {
+        let args: Args = [metadata.id]
+        let query =
+        "SELECT pi.* " +
+        "FROM \(TablePageMetadata) as pm" +
+        "JOIN \(TablePageMetadataImages) AS pmi ON pm.id = pmi.metadata_id " +
+        "JOIN \(TablePageImages) AS pi ON pi.id = pmi.image_id" +
+        "WHERE id = ?"
+        
+        return self.db.runQuery(query, args: args, factory: SQLitePageMetadata.pageMetadataImageFactory)
+    }
+
+    // A cache key is a conveninent, readable identifier for a site in the metadata database which helps 
+    // with deduping entries for the same page.
+    private func cacheKeyForSite(site: Site) -> CacheKey? {
+        guard let url = site.url.asURL else {
+            return nil
+        }
+
+        var key = url.normalizedHost() ?? ""
+        key = key + (url.path ?? "") + (url.query ?? "")
+        return key
+    }
+
+    private class func pageMetadataFactory(row: SDRow) -> PageMetadata {
+        let id = row["id"] as! Int
+        let siteURL = row["site_url"] as! String
+        let title = row["title"] as? String
+        let description = row["description"] as? String
+        let type = row["type"] as? String
+        return PageMetadata(id: id, siteURL: siteURL, title: title, description: description, type: type, images: [])
+    }
+
+    private class func pageMetadataImageFactory(row: SDRow) -> PageMetadataImage {
+        let imageURL = row["image_url"] as! String
+        let type = MetadataImageType(rawValue: row["type"] as! Int)!
+        let height = row["height"] as! Int
+        let width = row["width"] as! Int
+        let color = row["color"] as! String
+        return PageMetadataImage(imageURL: imageURL, type: type, height: height, width: width, color: color)
+    }
+}
+
+private extension PageMetadata {
+    func setImages(images: [PageMetadataImage]) -> PageMetadata {
+        return PageMetadata(id: id, siteURL: siteURL, title: title, description: description, type: type, images: images)
+    }
 }

--- a/Storage/SQL/SQLiteMetadata.swift
+++ b/Storage/SQL/SQLiteMetadata.swift
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+class SQLitePageMetadata {
+
+}

--- a/StorageTests/TestSQLiteMetadata.swift
+++ b/StorageTests/TestSQLiteMetadata.swift
@@ -1,0 +1,115 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+@testable import Storage
+import Deferred
+
+import XCTest
+
+class TestSQLiteMetadata: XCTestCase {
+    let files = MockFiles()
+    var db: BrowserDB!
+    var metadata: SQLiteMetadata!
+
+    override func setUp() {
+        super.setUp()
+        self.db = BrowserDB(filename: "foo.db", files: self.files)
+        XCTAssertTrue(db.createOrUpdate(BrowserTable()))
+        
+        self.metadata = SQLiteMetadata(db: db)
+    }
+
+    override func tearDown() {
+        removeAllMetadata(self.db).succeeded()
+        super.tearDown()
+    }
+
+    func testInsertMetadata() {
+        let site = "http://test.com"
+        let page = PageMetadata(id: nil, siteURL: site, mediaURL: "http://image.com",
+                                title: "Test", description: "Test Description", type: nil, providerName: nil)
+        self.metadata.storeMetadata(page, forPageURL: site.asURL!, expireAt: NSDate.now() + 3000).succeeded()
+        let results = metadataFromDB(self.db).value.successValue!
+        XCTAssertEqual(results.count, 1)
+        let metadata = results[0]!
+        XCTAssertEqual(metadata.siteURL, site)
+    }
+
+    func testDuplicateCacheKeyInsert() {
+        let siteA = "http://test.com/site/A"
+        let siteB = "http://test.com/site/B"
+
+        let metadataA1 = PageMetadata(id: nil, siteURL: siteA, mediaURL: nil,
+                                      title: "First Visit", description: "", type: nil, providerName: nil)
+        let metadataB = PageMetadata(id: nil, siteURL: siteB, mediaURL: "http://image.com",
+                                     title: "Test", description: "Test Description", type: nil, providerName: nil)
+        let metadataA2 = PageMetadata(id: nil, siteURL: siteA, mediaURL: "http://image.com",
+                                      title: "Second Visit", description: "A new description", type: nil, providerName: nil)
+
+        self.metadata.storeMetadata(metadataA1, forPageURL: siteA.asURL!, expireAt: NSDate.now() + 3000).succeeded()
+
+        let initialResults = metadataFromDB(self.db).value.successValue!
+        XCTAssertEqual(initialResults.count, 1)
+
+        let initialA = initialResults[0]!
+        XCTAssertEqual(initialA.siteURL, siteA)
+        XCTAssertEqual(initialA.title, "First Visit")
+        XCTAssertEqual(initialA.description, "")
+        XCTAssertNil(initialA.mediaURL)
+        
+        self.metadata.storeMetadata(metadataB, forPageURL: siteB.asURL!, expireAt: NSDate.now() + 3000).succeeded()
+        self.metadata.storeMetadata(metadataA2, forPageURL: siteA.asURL!, expireAt: NSDate.now() + 3000).succeeded()
+        
+        let results = metadataFromDB(self.db).value.successValue!
+
+        // Should only have 2 since we upsert
+        XCTAssertEqual(results.count, 2)
+
+        let resultA = results[1]!
+        let resultB = results[0]!
+
+        XCTAssertEqual(resultA.siteURL, siteA)
+        XCTAssertEqual(resultB.siteURL, siteB)
+
+        XCTAssertEqual(resultA.title, "Second Visit")
+        XCTAssertEqual(resultA.description, "A new description")
+        XCTAssertEqual(resultA.mediaURL!, "http://image.com")
+    }
+
+    func testExpirationPurging() {
+        let baseTime = NSDate.now()
+        let siteA = "http://test.com/site/A"
+        let metadataA = PageMetadata(id: nil, siteURL: siteA, mediaURL: nil,
+                                     title: "Test", description: "Test Description", type: nil, providerName: nil)
+        // Set expiration to base
+        self.metadata.storeMetadata(metadataA, forPageURL: siteA.asURL!, expireAt: baseTime - 1000).succeeded()
+        self.metadata.deleteExpiredMetadata().succeeded()
+
+        let results = metadataFromDB(self.db).value.successValue!
+        XCTAssertEqual(results.count, 0)
+    }
+}
+
+private func metadataFromDB(db: BrowserDB) -> Deferred<Maybe<Cursor<PageMetadata>>> {
+    let sql = "SELECT * FROM page_metadata"
+    return db.runQuery(sql, args: nil, factory: pageMetadataFactory)
+}
+
+private func removeAllMetadata(db: BrowserDB) -> Success {
+    return db.run("DELETE FROM \(TablePageMetadata)")
+}
+
+private func pageMetadataFactory(row: SDRow) -> PageMetadata {
+    let id = row["id"] as! Int
+    let siteURL = row["site_url"] as! String
+    let mediaURL = row["media_url"] as? String
+    let title = row["title"] as? String
+    let description = row["description"] as? String
+    let type = row["type"] as? String
+    let providerName = row["provider_name"] as? String
+    return PageMetadata(id: id, siteURL: siteURL, mediaURL: mediaURL, title: title,
+                        description: description, type: type, providerName: providerName)
+}


### PR DESCRIPTION
Adds a new Metadata storage interface and page_metadata table for storing metadata we get back from the page-metadata-parser. This doesn't include an API for fetching or a mechanism for routinely expiring metadata but that will come in a future patch.

Note: The commit history is a bit muddy since I started first with lumping in image storage with text storage but decided to focus only on text for this patch. There are some some small things that changed that are no related.