### PR TITLE
Bug 1310300 - Re-add deprecated strings for string export and use new Strings.swift format for SignOut string

### DIFF
--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -51,14 +51,14 @@ class DisconnectSetting: WithAccountSetting {
     override var textAlignment: NSTextAlignment { return .Center }
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Sign Out", comment: "Button in settings screen to disconnect from your account"), attributes: [NSForegroundColorAttributeName: UIConstants.DestructiveRed])
+        return NSAttributedString(string: Strings.SettingsSignOutButton, attributes: [NSForegroundColorAttributeName: UIConstants.DestructiveRed])
     }
 
     override var accessibilityIdentifier: String? { return "SignOut" }
 
     override func onClick(navigationController: UINavigationController?) {
         let alertController = UIAlertController(
-            title: NSLocalizedString("Sign Out?", comment: "Title of the 'sign out firefox account' alert"),
+            title: Strings.SettingsSignOutAlertTitle,
             message: NSLocalizedString("Firefox will stop syncing with your account, but won’t delete any of your browsing data on this device.", comment: "Text of the 'sign out firefox account' alert"),
             preferredStyle: UIAlertControllerStyle.Alert)
         alertController.addAction(
@@ -66,7 +66,7 @@ class DisconnectSetting: WithAccountSetting {
                 // Do nothing.
             })
         alertController.addAction(
-            UIAlertAction(title: NSLocalizedString("Sign Out", comment: "Disconnect button in the 'sign out firefox account' alert"), style: .Destructive) { (action) in
+            UIAlertAction(title: Strings.SettingsSignOutDestructiveAction, style: .Destructive) { (action) in
                 self.settings.profile.removeAccount()
                 self.settings.settings = self.settings.generateSettings()
                 self.settings.SELfirefoxAccountDidChange()

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -51,6 +51,9 @@ extension Strings {
     public static let SettingsClearPrivateDataTitle = NSLocalizedString("Settings.ClearPrivateData.Title", value: "Clear Private Data", comment: "Title displayed in header of the setting panel.")
     public static let SettingsSearchDoneButton = NSLocalizedString("Settings.Search.Done.Button", value: "Done", comment: "Button displayed at the top of the search settings.")
     public static let SettingsSearchEditButton = NSLocalizedString("Settings.Search.Edit.Button", value: "Edit", comment: "Button displayed at the top of the search settings.")
+    public static let SettingsSignOutButton = NSLocalizedString("Settings.SignOut.Button", value: "Sign Out", comment: "Button displayed at the bottom of settings page allowing users to Sign Out of FxA")
+    public static let SettingsSignOutDestructiveAction = NSLocalizedString("Settings.SignOut.DestructiveButton", value: "Sign Out", comment: "Destructive action button in alert when user is prompted for signing out")
+    public static let SettingsSignOutAlertTitle = NSLocalizedString("Settings.SignOut.Title", value: "Sign Out?", comment: "Title of the alert when prompting the user asking to sign out.")
 }
 
 // Error pages.
@@ -211,7 +214,6 @@ extension Strings {
 }
 
 // open in
-
 extension Strings {
     public static let OpenInDownloadHelperAlertTitle = NSLocalizedString("Downloads.Alert.Title", value: "Firefox Downloads", comment: "The title of the alert box asking the user if they want to use another app to open a file.")
     public static let OpenInDownloadHelperAlertMessage = NSLocalizedString("Downloads.Alert.Message", value: "Firefox is unable to download or display this file. Would you like to open it in another app?", comment: "The message of the alert box asking the user if they want to use another app to open a file.")
@@ -227,3 +229,8 @@ extension Strings {
     public static let RemoveBookmarkContextMenuTitle = NSLocalizedString("ActivityStream.ContextMenu.RemoveBookmark", value: "Remove Bookmark", comment: "The title for the Remove Bookmark context menu action for Activity Stream")
     public static let DismissContextMenuTitle = NSLocalizedString("ActivityStream.ContextMenu.Dismiss", value: "Dismiss", comment: "The title for the Dismiss context menu action for Activity Stream")
 }
+
+// MARK: Deprecated Strings (to be removed in next version)
+private let logOut = NSLocalizedString("Log Out", comment: "Button in settings screen to disconnect from your account")
+private let logOutQuestion = NSLocalizedString("Log Out?", comment: "Title of the 'log out firefox account' alert")
+private let logOutDestructive = NSLocalizedString("Log Out", comment: "Disconnect button in the 'log out firefox account' alert")


### PR DESCRIPTION
Re-added deprecated strings for export; Added new strings into Strings.swift instead of inline with AppSettingsOption