### PR TITLE
Bug 1294056 - Make sure login credentials are not visible when unlocking the phone.

### DIFF
--- a/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
+++ b/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
@@ -22,6 +22,8 @@ class SensitiveViewController: UIViewController {
         notificationCenter.addObserver(self, selector: #selector(SensitiveViewController.checkIfUserRequiresValidation), name: UIApplicationWillEnterForegroundNotification, object: nil)
         notificationCenter.addObserver(self, selector: #selector(SensitiveViewController.checkIfUserRequiresValidation), name: UIApplicationDidBecomeActiveNotification, object: nil)
         notificationCenter.addObserver(self, selector: #selector(SensitiveViewController.blurContents), name: UIApplicationWillResignActiveNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(SensitiveViewController.hideLogins), name: UIApplicationDidEnterBackgroundNotification, object: nil)
+
     }
 
     override func viewWillDisappear(animated: Bool) {
@@ -30,6 +32,7 @@ class SensitiveViewController: UIViewController {
         notificationCenter.removeObserver(self, name: UIApplicationWillEnterForegroundNotification, object: nil)
         notificationCenter.removeObserver(self, name: UIApplicationWillResignActiveNotification, object: nil)
         notificationCenter.removeObserver(self, name: UIApplicationDidBecomeActiveNotification, object: nil)
+        notificationCenter.removeObserver(self, name: UIApplicationDidEnterBackgroundNotification, object: nil)
     }
 
     func checkIfUserRequiresValidation() {
@@ -62,6 +65,10 @@ class SensitiveViewController: UIViewController {
             }
         )
         authState = .Presenting
+    }
+
+    func hideLogins() {
+        self.navigationController?.popToRootViewControllerAnimated(true)
     }
 
     func blurContents() {


### PR DESCRIPTION
The blur was not being applied when the screen was locked with the Logins window open. 
I couldn't figure out why this behavior was happening. I felt it was safer and simpler to just pop to the settings page when the screen is locked.  

The reason why I decided to return to the settings page in DidEnterBackgroundNotification instead of WillResignActiveNotification is to avoid the pop animation being visible to the user. And also to prevent it from popping back to settings when someone swipes to the notification bar.
![1cvpdr](https://cloud.githubusercontent.com/assets/522281/19644438/a8b4dcfa-9a2a-11e6-8e6d-bb2a25e297e1.jpg)
