### PR TITLE
Bug 1300527 - Make sure the menu bar is shown when opening a tab via 3d touch.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -615,6 +615,7 @@ class BrowserViewController: UIViewController {
     func resetBrowserChrome() {
         // animate and reset transform for tab chrome
         urlBar.updateAlphaForSubviews(1)
+        footer.alpha = 1
 
         [header,
             footer,


### PR DESCRIPTION
Looks like resetBrowserChrome forgot something!