### PR TITLE
Bug 1308014 - Added chunking for history syncs and removed MaxVariableNumber assert limit

### DIFF
--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -1052,19 +1052,15 @@ extension SQLiteHistory: SyncableHistory {
         }
 
         log.debug("Wiping \(guids.count) deleted GUIDs.")
-        return self.db.run(chunk(guids, by: BrowserDB.MaxVariableNumber).flatMap { chunk in
-            return markAsDeletedStatementForGUIDS(chunk)
-        })
+        return self.db.run(chunk(guids, by: BrowserDB.MaxVariableNumber).flatMap(markAsDeletedStatementForGUIDs))
     }
 
-    private func markAsDeletedStatementForGUIDS(guids: ArraySlice<String>) -> (String, Args?) {
+    private func markAsDeletedStatementForGUIDs(guids: ArraySlice<String>) -> (String, Args?) {
         // We deliberately don't limit this to records marked as should_upload, just
         // in case a coding error leaves records with is_deleted=1 but not flagged for
         // upload -- this will catch those and throw them away.
         let inClause = BrowserDB.varlist(guids.count)
-        let sql =
-        "DELETE FROM \(TableHistory) WHERE " +
-        "is_deleted = 1 AND guid IN \(inClause)"
+        let sql = "DELETE FROM \(TableHistory) WHERE is_deleted = 1 AND guid IN \(inClause)"
 
         let args: Args = guids.map { $0 as AnyObject }
         return (sql, args)
@@ -1077,11 +1073,11 @@ extension SQLiteHistory: SyncableHistory {
 
         log.debug("Marking \(guids.count) GUIDs as synchronized. Returning timestamp \(modified).")
         return self.db.run(chunk(guids, by: BrowserDB.MaxVariableNumber).flatMap { chunk in
-            return markAsSynchronizedStatementForGUIDS(chunk, modified: modified)
+            return markAsSynchronizedStatementForGUIDs(chunk, modified: modified)
         }) >>> always(modified)
     }
 
-    private func markAsSynchronizedStatementForGUIDS(guids: ArraySlice<String>, modified: Timestamp) -> (String, Args?) {
+    private func markAsSynchronizedStatementForGUIDs(guids: ArraySlice<String>, modified: Timestamp) -> (String, Args?) {
         let inClause = BrowserDB.varlist(guids.count)
         let sql =
         "UPDATE \(TableHistory) SET " +

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -1047,15 +1047,17 @@ extension SQLiteHistory: SyncableHistory {
     }
 
     public func markAsDeleted(guids: [GUID]) -> Success {
-        // TODO: support longer GUID lists.
-        assert(guids.count < BrowserDB.MaxVariableNumber)
-
         if guids.isEmpty {
             return succeed()
         }
 
         log.debug("Wiping \(guids.count) deleted GUIDs.")
+        return self.db.run(chunk(guids, by: BrowserDB.MaxVariableNumber).flatMap { chunk in
+            return markAsDeletedStatementForGUIDS(chunk)
+        })
+    }
 
+    private func markAsDeletedStatementForGUIDS(guids: ArraySlice<String>) -> (String, Args?) {
         // We deliberately don't limit this to records marked as should_upload, just
         // in case a coding error leaves records with is_deleted=1 but not flagged for
         // upload -- this will catch those and throw them away.
@@ -1065,19 +1067,21 @@ extension SQLiteHistory: SyncableHistory {
         "is_deleted = 1 AND guid IN \(inClause)"
 
         let args: Args = guids.map { $0 as AnyObject }
-        return self.db.run(sql, withArgs: args)
+        return (sql, args)
     }
 
     public func markAsSynchronized(guids: [GUID], modified: Timestamp) -> Deferred<Maybe<Timestamp>> {
-        // TODO: support longer GUID lists.
-        assert(guids.count < 99)
-
         if guids.isEmpty {
             return deferMaybe(modified)
         }
 
         log.debug("Marking \(guids.count) GUIDs as synchronized. Returning timestamp \(modified).")
+        return self.db.run(chunk(guids, by: BrowserDB.MaxVariableNumber).flatMap { chunk in
+            return markAsSynchronizedStatementForGUIDS(chunk, modified: modified)
+        }) >>> always(modified)
+    }
 
+    private func markAsSynchronizedStatementForGUIDS(guids: ArraySlice<String>, modified: Timestamp) -> (String, Args?) {
         let inClause = BrowserDB.varlist(guids.count)
         let sql =
         "UPDATE \(TableHistory) SET " +
@@ -1085,7 +1089,7 @@ extension SQLiteHistory: SyncableHistory {
         "WHERE guid IN \(inClause)"
 
         let args: Args = guids.map { $0 as AnyObject }
-        return self.db.run(sql, withArgs: args) >>> always(modified)
+        return (sql, args)
     }
 
     public func doneApplyingRecordsAfterDownload() -> Success {


### PR DESCRIPTION
No longer need to assert if we have < 99 guids or not. Originally this was a bug and should have been BrowserDB.MaxNumberVariables but we can do better and chunk the GUIDs we want to send to make sure they all get sent.