### PR TITLE
Bug 1300499 - Prevent tab resize animation when returning to tabs tray from settings.

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -411,8 +411,9 @@ class TabTrayController: UIViewController {
 
         // Update the trait collection we reference in our layout delegate
         tabLayoutDelegate.traitCollection = traitCollection
+        self.collectionView.collectionViewLayout.invalidateLayout()
     }
-    
+
     private func cancelExistingGestures() {
         if let visibleCells = self.collectionView.visibleCells() as? [TabCell] {
             for cell in visibleCells {


### PR DESCRIPTION
Invalidate the layout when the traits change. The regular `viewWillTransitionToSize` isn't called if tabtray isn't visible when the size changes (which is the case here).