### PR TITLE
Bug 1278262 - Invalidate BookmarkPanel's source prior to removing to keep consistent with whats on disk

### DIFF
--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -64,6 +64,11 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.tableView.accessibilityIdentifier = "Bookmarks List"
+    }
+
+    override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
 
         // If we've not already set a source for this panel, fetch a new model from
         // the root; otherwise, just use the existing source to select a folder.
@@ -82,7 +87,6 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         } else {
             source.selectFolder(BookmarkRoots.MobileFolderGUID).upon(onModelFetched)
         }
-        self.tableView.accessibilityIdentifier = "Bookmarks List"
     }
 
     func notificationReceived(notification: NSNotification) {
@@ -366,13 +370,8 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
                 return
             }
 
-            guard let reloaded = source.reloadData().value.successValue else {
-                log.debug("Failed to reload model.")
-                return
-            }
-
             self.tableView.beginUpdates()
-            self.source = reloaded
+            self.source = source.removeGUIDFromCurrent(bookmark.guid)
             self.tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: UITableViewRowAnimation.Left)
             self.tableView.endUpdates()
             self.updateEmptyPanelState()

--- a/Storage/Bookmarks/BookmarksModel.swift
+++ b/Storage/Bookmarks/BookmarksModel.swift
@@ -6,7 +6,7 @@ import Deferred
 import Foundation
 import Shared
 
-private let log = Logger.syncLogger;
+private let log = Logger.syncLogger
 
 /**
  * The kinda-immutable base interface for bookmarks and folders.

--- a/Storage/Bookmarks/BookmarksModel.swift
+++ b/Storage/Bookmarks/BookmarksModel.swift
@@ -119,7 +119,7 @@ public class BookmarksModel: BookmarksModelFactorySource {
             return BookmarksModel(modelFactory: self.factory, root: removedRoot)
         }
         log.warning("BookmarksModel.removeGUIDFromCurrent did not remove anything. Check to make sure you're not using the abstract BookmarkFolder class.")
-        return BookmarksModel(modelFactory: self.factory, root: current)
+        return self
     }
 
     /**

--- a/Storage/Bookmarks/BookmarksModel.swift
+++ b/Storage/Bookmarks/BookmarksModel.swift
@@ -63,8 +63,9 @@ public class BookmarkFolder: BookmarkNode {
         return false
     }
 
-    public func removeItemWithGUID(guid: GUID) -> BookmarkFolder {
-        return self
+    public func removeItemWithGUID(guid: GUID) -> MemoryBookmarkFolder {
+        let without = (0..<count).flatMap { self[$0]?.guid != guid ? self[$0] : nil }
+        return MemoryBookmarkFolder(guid: self.guid, title: self.title, children: without)
     }
 }
 
@@ -113,8 +114,7 @@ public class BookmarksModel: BookmarksModelFactorySource {
      * Produce a new model with a memory-backed root with the given GUID removed from the current folder
      */
     public func removeGUIDFromCurrent(guid: GUID) -> BookmarksModel {
-        let memoryBackedFolder = MemoryBookmarkFolder.fromBookmarkFolder(self.current)
-        return BookmarksModel(modelFactory: self.factory, root: memoryBackedFolder.removeItemWithGUID(guid))
+        return BookmarksModel(modelFactory: self.factory, root: self.current.removeItemWithGUID(guid))
     }
 
     /**
@@ -218,29 +218,6 @@ public class MemoryBookmarkFolder: BookmarkFolder, SequenceType {
             return self
         }
         return MemoryBookmarkFolder(guid: self.guid, title: self.title, children: self.children + items)
-    }
-
-    /**
-     * Returns a new immutable folder with the given GUID removed
-     */
-    override public func removeItemWithGUID(guid: GUID) -> MemoryBookmarkFolder {
-        var mutableChildren = children
-        if let foundIndex = self.children.indexOf({ $0.guid == guid }) {
-            mutableChildren.removeAtIndex(foundIndex)
-        }
-        return MemoryBookmarkFolder(guid: self.guid, title: self.title, children: mutableChildren)
-    }
-}
-
-private extension MemoryBookmarkFolder {
-    static func fromBookmarkFolder(folder: BookmarkFolder) -> MemoryBookmarkFolder {
-        var children = [BookmarkNode]()
-        for childIndex in 0..<folder.count {
-            if let child = folder[childIndex] {
-                children.append(child)
-            }
-        }
-        return MemoryBookmarkFolder(guid: folder.guid, title: folder.title, children: children)
     }
 }
 

--- a/Storage/SQL/SQLiteBookmarksModel.swift
+++ b/Storage/SQL/SQLiteBookmarksModel.swift
@@ -545,6 +545,11 @@ class SQLiteBookmarkFolder: BookmarkFolder {
         self.cursor = children
         super.init(guid: guid, title: title)
     }
+
+    override func removeItemWithGUID(guid: GUID) -> BookmarkFolder? {
+        let without = cursor.asArray().filter { $0.guid != guid }
+        return MemoryBookmarkFolder(guid: self.guid, title: self.title, children: without)
+    }
 }
 
 class BookmarkFactory {


### PR DESCRIPTION
Crash occurs while syncing because when we go to delete the bookmark, we assume that the only thing that has changed when we go to reload the bookmark folder is our removal. If we're syncing, the state of whats in the folder is in flux so the panel's view of becomes stale. This patch forces the reload of the source just before removing it to greatly reduce the chance of an inconsistent model when deleting.
