### PR TITLE
1312842 - Support the new iOS 10 Camera/Photos usage description

### DIFF
--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -54,6 +54,10 @@
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Websites you visit may request your location.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>This lets you save and upload photos.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>This lets you take and upload photos.</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>org.mozilla.ios.firefox.browsing</string>

--- a/Client/en.lproj/InfoPlist.strings
+++ b/Client/en.lproj/InfoPlist.strings
@@ -3,5 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 NSLocationWhenInUseUsageDescription = "Websites you visit may request your location.";
+NSPhotoLibraryUsageDescription = "This lets you save and upload photos.";
+NSCameraUsageDescription = "This lets you take and upload photos.";
 ShortcutItemTitleNewTab = "New Tab";
 ShortcutItemTitleNewPrivateTab = "New Private Tab";


### PR DESCRIPTION
This patch adds the `NSPhotoLibraryUsageDescription` and `NSCameraUsageDescription` items to our `Info.plist`. These are mandatory when linked against the iOS 10 SDK and running on iOS 10.

Because they are currently undefined, we crash when we try to save an image to the photo library or when a web page wants to access the camera.