### PR TITLE
Bug 1313073 - Disable the Today Widget on the Home Screen

### DIFF
--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -119,6 +119,8 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>UIApplicationShortcutWidget</key>
+	<string>nil</string>
 	<key>UTImportedTypeDeclarations</key>
 	<array>
 		<dict>


### PR DESCRIPTION
This patch disabled our Today Widget on the Home Screen (3D Touch on our app icon) by setting the `UIApplicationShortcutWidget` to `nil`.