### PR TITLE
Bug 1311656 - Make sure pagination indicator is not visible when there is only one page.

### DIFF
--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -246,6 +246,7 @@ class ASHorizontalScrollCell: UITableViewCell {
         pageControl.progress = currentPage
         if currentPage == floor(currentPage) {
             UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil)
+            self.setNeedsLayout()
         }
     }
 


### PR DESCRIPTION
This took longer to find than it should have!