### PR TITLE
Bug 1310159 - Make sure top site colors are not reused incorrectly.

### DIFF
--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -121,14 +121,18 @@ class TopSiteItemCell: UICollectionViewCell {
     }
 
     private func setImageWithURL(url: NSURL) {
+        let title = self.titleLabel.text
         imageView.sd_setImageWithURL(url) { [unowned self] (img, err, type, url) -> Void in
             guard let img = img else {
                 self.contentView.backgroundColor = FaviconFetcher.getDefaultColor(url)
                 self.imageView.image = FaviconFetcher.getDefaultFavicon(url)
                 return
             }
-            img.getColors(CGSize(width: 25, height: 25)) { colors in
-                self.contentView.backgroundColor = colors.backgroundColor ?? UIColor.lightGrayColor()
+            img.getColors(CGSize(width: 25, height: 25)) {colors in
+                //sometimes the cell could be reused by the time we get here.
+                if title == self.titleLabel.text {
+                    self.contentView.backgroundColor = colors.backgroundColor ?? UIColor.lightGrayColor()
+                }
             }
         }
     }


### PR DESCRIPTION
Not the best fix. But the simplest I could think of.

What's happening is sometimes cells are reused before the closures that handle the image/color setting have finished. This usually happens to default cells which don't set their colors the same way. (Their colors arent set via a closure. So there is no closure that comes after it in the queue that overrides the old color)