### PR TITLE
Bug 1315776 - Clean up usage of launch arguments for testing

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -463,6 +463,10 @@
 		D3FA777B1A43B2990010CD32 /* SearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA777A1A43B2990010CD32 /* SearchTests.swift */; };
 		D3FEC38D1AC4B42F00494F45 /* AutocompleteTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC38C1AC4B42F00494F45 /* AutocompleteTextField.swift */; };
 		DD31E0FB1B382B520077078A /* TabPrintPageRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD31E0FA1B382B520077078A /* TabPrintPageRenderer.swift */; };
+		E40AFC671DD1199F00DA5651 /* LaunchArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFC661DD1199F00DA5651 /* LaunchArguments.swift */; };
+		E40AFC681DD1199F00DA5651 /* LaunchArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFC661DD1199F00DA5651 /* LaunchArguments.swift */; };
+		E40AFC691DD11A6F00DA5651 /* LaunchArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFC661DD1199F00DA5651 /* LaunchArguments.swift */; };
+		E40AFC6A1DD11C7300DA5651 /* LaunchArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFC661DD1199F00DA5651 /* LaunchArguments.swift */; };
 		E40FAB0C1A7ABB77009CB80D /* WebServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40FAB0B1A7ABB77009CB80D /* WebServer.swift */; };
 		E418D0D91A251B3200CAE47A /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC84D1A16C40C00D49B7B /* Profile.swift */; };
 		E41A7D4B1A1BE04500245963 /* InitialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41A7D4A1A1BE04500245963 /* InitialViewController.swift */; };
@@ -1584,6 +1588,7 @@
 		D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenSearch.swift; sourceTree = "<group>"; };
 		D3FEC38C1AC4B42F00494F45 /* AutocompleteTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutocompleteTextField.swift; sourceTree = "<group>"; };
 		DD31E0FA1B382B520077078A /* TabPrintPageRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabPrintPageRenderer.swift; sourceTree = "<group>"; };
+		E40AFC661DD1199F00DA5651 /* LaunchArguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchArguments.swift; sourceTree = "<group>"; };
 		E40FAB0B1A7ABB77009CB80D /* WebServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebServer.swift; sourceTree = "<group>"; };
 		E41A7D4A1A1BE04500245963 /* InitialViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InitialViewController.swift; sourceTree = "<group>"; };
 		E41F0D971ADFFB5400FC7387 /* ReadingListService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ReadingListService.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -2905,6 +2910,7 @@
 				E46C51C21B41ADD800EB349F /* Try.m */,
 				B729F0691B75CBEF00745F7A /* UserAgent.swift */,
 				D3ACB4381AD33EBA00748D50 /* WeakList.swift */,
+				E40AFC661DD1199F00DA5651 /* LaunchArguments.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -4645,6 +4651,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2FDE87531ABA3EB4005317B1 /* UIColorExtensions.swift in Sources */,
+				E40AFC691DD11A6F00DA5651 /* LaunchArguments.swift in Sources */,
 				E6E4A9631BF0FA85008162D5 /* NSFileManagerExtensions.swift in Sources */,
 				D3ACB4541AD33F2200748D50 /* WeakList.swift in Sources */,
 				28E8BE7F1B792A89002CC733 /* AppInfo.swift in Sources */,
@@ -4829,6 +4836,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3B546EC01D95ECAE00BDBE36 /* ActivityStreamTest.swift in Sources */,
+				E40AFC6A1DD11C7300DA5651 /* LaunchArguments.swift in Sources */,
 				3BFE4B501D34673D00DDF53F /* ThirdPartySearchTest.swift in Sources */,
 				3BF4B8E91D38497A00493393 /* BaseTestCase.swift in Sources */,
 			);
@@ -4840,6 +4848,7 @@
 			files = (
 				7BEB64441C7345600092C02E /* L10nSnapshotTests.swift in Sources */,
 				7BEB64451C7345600092C02E /* SnapshotHelper.swift in Sources */,
+				E40AFC681DD1199F00DA5651 /* LaunchArguments.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5087,6 +5096,7 @@
 				E6FF6AC21D8705110070C294 /* MetadataParserHelper.swift in Sources */,
 				D38A1BEE1A9FA2CA00F6A386 /* SiteTableViewController.swift in Sources */,
 				7BA0601B1C0F4DE200DFADB6 /* TabPeekViewController.swift in Sources */,
+				E40AFC671DD1199F00DA5651 /* LaunchArguments.swift in Sources */,
 				D3994A4A1C22813200E2A03C /* FindInPageActivity.swift in Sources */,
 				E6D8D5E71B569D70009E5A58 /* BrowserTrayAnimators.swift in Sources */,
 				E63ED7D81BFCD9990097D08E /* LoginTableViewCell.swift in Sources */,

--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -16,7 +16,7 @@ class TestAppDelegate: AppDelegate {
         }
 
         let profile = BrowserProfile(localName: "testProfile", app: application)
-        if NSProcessInfo.processInfo().arguments.contains("RESET_FIREFOX") {
+        if NSProcessInfo.processInfo().arguments.contains(LaunchArguments.ClearProfile) {
             // Use a clean profile for each test session.
             _ = try? profile.files.removeFilesInDirectory()
             profile.prefs.clearAll()
@@ -24,8 +24,8 @@ class TestAppDelegate: AppDelegate {
             // Don't show the What's New page.
             profile.prefs.setString(AppInfo.appVersion, forKey: LatestAppVersionProfileKey)
 
-            // Skip the first run UI except when we are running Fastlane Snapshot tests
-            if !AppConstants.IsRunningFastlaneSnapshot {
+            // Skip the intro when requested by for example tests or automation
+            if AppConstants.SkipIntro {
                 profile.prefs.setInt(1, forKey: IntroViewControllerSeenProfileKey)
             }
         }
@@ -36,7 +36,7 @@ class TestAppDelegate: AppDelegate {
 
     override func application(application: UIApplication, willFinishLaunchingWithOptions launchOptions: [NSObject : AnyObject]?) -> Bool {
         // If the app is running from a XCUITest reset all settings in the app
-        if NSProcessInfo.processInfo().arguments.contains("RESET_FIREFOX") {
+        if NSProcessInfo.processInfo().arguments.contains(LaunchArguments.ClearProfile) {
             resetApplication()
         }
 

--- a/Client/Application/main.swift
+++ b/Client/Application/main.swift
@@ -6,7 +6,7 @@ import Shared
 
 private var appDelegate: AppDelegate.Type
 
-if AppConstants.IsRunningTest || AppConstants.IsRunningFastlaneSnapshot {
+if AppConstants.IsRunningTest {
     appDelegate = TestAppDelegate.self
 } else {
     switch AppConstants.BuildChannel {

--- a/L10nSnapshotTests/L10nBaseSnapshotTests.swift
+++ b/L10nSnapshotTests/L10nBaseSnapshotTests.swift
@@ -1,0 +1,9 @@
+//
+//  L10nBaseSnapshotTests.swift
+//  Client
+//
+//  Created by Stefan Arentz on 2016-11-07.
+//  Copyright © 2016 Mozilla. All rights reserved.
+//
+
+import Foundation

--- a/L10nSnapshotTests/L10nPermissionStringsSnapshotTests.swift
+++ b/L10nSnapshotTests/L10nPermissionStringsSnapshotTests.swift
@@ -1,0 +1,9 @@
+//
+//  L10nPermissionStringsSnapshotTests.swift
+//  Client
+//
+//  Created by Stefan Arentz on 2016-11-07.
+//  Copyright © 2016 Mozilla. All rights reserved.
+//
+
+import Foundation

--- a/Utils/AppConstants.swift
+++ b/Utils/AppConstants.swift
@@ -13,10 +13,10 @@ public enum AppBuildChannel {
 }
 
 public struct AppConstants {
-    public static let IsRunningTest = NSClassFromString("XCTestCase") != nil || NSProcessInfo.processInfo().arguments.contains("FIREFOX_TESTS")
+    public static let IsRunningTest = NSClassFromString("XCTestCase") != nil || NSProcessInfo.processInfo().arguments.contains(LaunchArguments.Test)
 
-    // True if this process is executed as part of a Fastlane Snapshot test
-    public static let IsRunningFastlaneSnapshot = NSProcessInfo.processInfo().arguments.contains("FASTLANE_SNAPSHOT")
+    public static let SkipIntro = NSProcessInfo.processInfo().arguments.contains(LaunchArguments.SkipIntro)
+    public static let ClearProfile = NSProcessInfo.processInfo().arguments.contains(LaunchArguments.ClearProfile)
 
     /// Build Channel.
     public static let BuildChannel: AppBuildChannel = {

--- a/Utils/LaunchArguments.swift
+++ b/Utils/LaunchArguments.swift
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+public struct LaunchArguments {
+    public static let Test = "FIREFOX_TEST"
+    public static let SkipIntro = "FIREFOX_SKIP_INTRO"
+    public static let ClearProfile = "FIREFOX_CLEAR_PROFILE"
+}

--- a/XCUITests/BaseTestCase.swift
+++ b/XCUITests/BaseTestCase.swift
@@ -19,8 +19,8 @@ class BaseTestCase: XCTestCase {
 
     func restart(app: XCUIApplication) {
         app.terminate()
-        app.launchArguments.append("FIREFOX_TESTS")
-        app.launchArguments.append("RESET_FIREFOX")
+        app.launchArguments.append(LaunchArguments.Test)
+        app.launchArguments.append(LaunchArguments.ClearProfile)
         app.launch()
         sleep(1)
     }


### PR DESCRIPTION
This patch does the following:

* Introduce `LaunchArguments.swift` with constants for the launch arguments that Fennec takes. Currently: `.Test`, `.ClearProfile` and `.SkipIntro`.
* Use those constants in all the places where we used to have strings like `"FIREFOX_RESET"`
* Fennec does not know about *Fastlane* anymore. It makes no UI choices based on specific test cases. Instead the tests can simply tell Fennec what they want to change.

This is the base work needed to make the L10N Screenshot Tests request the right things per test case. For example, all test cases want to clear the profile, but only one wants to see the intro. These options now allow that.