### PR TITLE
Bug 1315784 - Reorganize L10N Screenshot Tests

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -463,10 +463,13 @@
 		D3FA777B1A43B2990010CD32 /* SearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA777A1A43B2990010CD32 /* SearchTests.swift */; };
 		D3FEC38D1AC4B42F00494F45 /* AutocompleteTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC38C1AC4B42F00494F45 /* AutocompleteTextField.swift */; };
 		DD31E0FB1B382B520077078A /* TabPrintPageRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD31E0FA1B382B520077078A /* TabPrintPageRenderer.swift */; };
+		E40AFC541DD0E93300DA5651 /* L10nPermissionStringsSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFC531DD0E93300DA5651 /* L10nPermissionStringsSnapshotTests.swift */; };
+		E40AFC651DD0F25500DA5651 /* L10nBaseSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFC641DD0F25500DA5651 /* L10nBaseSnapshotTests.swift */; };
 		E40AFC671DD1199F00DA5651 /* LaunchArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFC661DD1199F00DA5651 /* LaunchArguments.swift */; };
 		E40AFC681DD1199F00DA5651 /* LaunchArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFC661DD1199F00DA5651 /* LaunchArguments.swift */; };
 		E40AFC691DD11A6F00DA5651 /* LaunchArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFC661DD1199F00DA5651 /* LaunchArguments.swift */; };
 		E40AFC6A1DD11C7300DA5651 /* LaunchArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFC661DD1199F00DA5651 /* LaunchArguments.swift */; };
+		E40AFC6C1DD128DA00DA5651 /* L10nIntroSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFC6B1DD128DA00DA5651 /* L10nIntroSnapshotTests.swift */; };
 		E40FAB0C1A7ABB77009CB80D /* WebServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40FAB0B1A7ABB77009CB80D /* WebServer.swift */; };
 		E418D0D91A251B3200CAE47A /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC84D1A16C40C00D49B7B /* Profile.swift */; };
 		E41A7D4B1A1BE04500245963 /* InitialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41A7D4A1A1BE04500245963 /* InitialViewController.swift */; };
@@ -1589,7 +1592,10 @@
 		D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenSearch.swift; sourceTree = "<group>"; };
 		D3FEC38C1AC4B42F00494F45 /* AutocompleteTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutocompleteTextField.swift; sourceTree = "<group>"; };
 		DD31E0FA1B382B520077078A /* TabPrintPageRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabPrintPageRenderer.swift; sourceTree = "<group>"; };
+		E40AFC531DD0E93300DA5651 /* L10nPermissionStringsSnapshotTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = L10nPermissionStringsSnapshotTests.swift; sourceTree = "<group>"; };
+		E40AFC641DD0F25500DA5651 /* L10nBaseSnapshotTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = L10nBaseSnapshotTests.swift; sourceTree = "<group>"; };
 		E40AFC661DD1199F00DA5651 /* LaunchArguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchArguments.swift; sourceTree = "<group>"; };
+		E40AFC6B1DD128DA00DA5651 /* L10nIntroSnapshotTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = L10nIntroSnapshotTests.swift; sourceTree = "<group>"; };
 		E40FAB0B1A7ABB77009CB80D /* WebServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebServer.swift; sourceTree = "<group>"; };
 		E41A7D4A1A1BE04500245963 /* InitialViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InitialViewController.swift; sourceTree = "<group>"; };
 		E41F0D971ADFFB5400FC7387 /* ReadingListService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ReadingListService.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -2569,6 +2575,9 @@
 			isa = PBXGroup;
 			children = (
 				7BEB644E1C7345600092C02E /* Info.plist */,
+				E40AFC641DD0F25500DA5651 /* L10nBaseSnapshotTests.swift */,
+				E40AFC6B1DD128DA00DA5651 /* L10nIntroSnapshotTests.swift */,
+				E40AFC531DD0E93300DA5651 /* L10nPermissionStringsSnapshotTests.swift */,
 				7B3632D31C2983F000D12AF9 /* L10nSnapshotTests.swift */,
 			);
 			path = L10nSnapshotTests;
@@ -4852,7 +4861,10 @@
 			files = (
 				7BEB64441C7345600092C02E /* L10nSnapshotTests.swift in Sources */,
 				7BEB64451C7345600092C02E /* SnapshotHelper.swift in Sources */,
+				E40AFC541DD0E93300DA5651 /* L10nPermissionStringsSnapshotTests.swift in Sources */,
+				E40AFC6C1DD128DA00DA5651 /* L10nIntroSnapshotTests.swift in Sources */,
 				E40AFC681DD1199F00DA5651 /* LaunchArguments.swift in Sources */,
+				E40AFC651DD0F25500DA5651 /* L10nBaseSnapshotTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/L10nSnapshotTests/L10nBaseSnapshotTests.swift
+++ b/L10nSnapshotTests/L10nBaseSnapshotTests.swift
@@ -1,9 +1,61 @@
-//
-//  L10nBaseSnapshotTests.swift
-//  Client
-//
-//  Created by Stefan Arentz on 2016-11-07.
-//  Copyright © 2016 Mozilla. All rights reserved.
-//
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import Foundation
+import XCTest
+
+class L10nBaseSnapshotTests: XCTestCase {
+    var skipIntro: Bool {
+        return true
+    }
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        let app = XCUIApplication()
+        setupSnapshot(app)
+        app.launchArguments = [LaunchArguments.Test, LaunchArguments.ClearProfile]
+        if skipIntro {
+            app.launchArguments.append(LaunchArguments.SkipIntro)
+        }
+        app.launch()
+    }
+
+    func loadWebPage(url: String, waitForOtherElementWithAriaLabel ariaLabel: String) {
+        let app = XCUIApplication()
+        UIPasteboard.generalPasteboard().string = url
+        app.textFields["url"].pressForDuration(2.0)
+        app.sheets.elementBoundByIndex(0).buttons.elementBoundByIndex(0).tap()
+
+        sleep(3) // TODO Otherwise we detect the body in the currently loaded document, before the new page has loaded
+
+        let webView = app.webViews.elementBoundByIndex(0)
+        let element = webView.otherElements[ariaLabel]
+        expectationForPredicate(NSPredicate(format: "exists == 1"), evaluatedWithObject: element, handler: nil)
+
+        waitForExpectationsWithTimeout(5.0) { (error) -> Void in
+            if error != nil {
+                XCTFail("Failed to detect element with ariaLabel=\(ariaLabel) on \(url): \(error)")
+            }
+        }
+    }
+
+    func loadWebPage(url: String, waitForLoadToFinish: Bool = true) {
+        let LoadingTimeout: NSTimeInterval = 60
+        let exists = NSPredicate(format: "exists = true")
+        let loaded = NSPredicate(format: "value BEGINSWITH '100'")
+
+        let app = XCUIApplication()
+
+        UIPasteboard.generalPasteboard().string = url
+        app.textFields["url"].pressForDuration(2.0)
+        app.sheets.elementBoundByIndex(0).buttons.elementBoundByIndex(0).tap()
+
+        if waitForLoadToFinish {
+            let progressIndicator = app.progressIndicators.elementBoundByIndex(0)
+            expectationForPredicate(exists, evaluatedWithObject: progressIndicator, handler: nil)
+            expectationForPredicate(loaded, evaluatedWithObject: progressIndicator, handler: nil)
+            waitForExpectationsWithTimeout(LoadingTimeout, handler: nil)
+        }
+    }
+}

--- a/L10nSnapshotTests/L10nIntroSnapshotTests.swift
+++ b/L10nSnapshotTests/L10nIntroSnapshotTests.swift
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import XCTest
+
+class L10nIntroSnapshotTests: L10nBaseSnapshotTests {
+    override var skipIntro: Bool {
+        return false
+    }
+
+    func testIntro() {
+        let app = XCUIApplication()
+        snapshot("Intro-1")
+        app.scrollViews["IntroViewController.scrollView"].swipeLeft()
+        sleep(2)
+        snapshot("Intro-2")
+        app.scrollViews["IntroViewController.scrollView"].swipeLeft()
+        sleep(2)
+        snapshot("Intro-3")
+        app.scrollViews["IntroViewController.scrollView"].swipeLeft()
+        sleep(2)
+        snapshot("Intro-4")
+        app.scrollViews["IntroViewController.scrollView"].swipeLeft()
+        sleep(2)
+        snapshot("01Intro-5")
+    }
+}

--- a/L10nSnapshotTests/L10nPermissionStringsSnapshotTests.swift
+++ b/L10nSnapshotTests/L10nPermissionStringsSnapshotTests.swift
@@ -1,9 +1,23 @@
-//
-//  L10nPermissionStringsSnapshotTests.swift
-//  Client
-//
-//  Created by Stefan Arentz on 2016-11-07.
-//  Copyright © 2016 Mozilla. All rights reserved.
-//
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import Foundation
+import XCTest
+
+class L10nPermissionStringsSnapshotTests: L10nBaseSnapshotTests {
+    func testNSLocationWhenInUseUsageDescription() {
+        loadWebPage("http://people.mozilla.org/~sarentz/fxios/testpages/geolocation.html", waitForOtherElementWithAriaLabel: "body")
+        snapshot("15LocationDialog-01")
+        loadWebPage("http://people.mozilla.org/~sarentz/fxios/testpages/index.html", waitForOtherElementWithAriaLabel: "body")
+    }
+
+    func testNSPhotoLibraryUsageDescription() {
+        addUIInterruptionMonitorWithDescription("Permission Alert") { (alert) -> Bool in
+            alert.buttons.elementBoundByIndex(0).tap()
+            return true
+        }
+        loadWebPage("http://people.mozilla.org/~sarentz/fxios/testpages/mediaAccess.html", waitForOtherElementWithAriaLabel: "body")
+        XCUIApplication().webViews.elementBoundByIndex(0).buttons["submitCameraUpload"].tap()
+        XCUIApplication().tables.staticTexts.elementBoundByIndex(0).tap() // Photo Library is the first cell
+    }
+}

--- a/L10nSnapshotTests/L10nSnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSnapshotTests.swift
@@ -4,81 +4,7 @@
 
 import XCTest
 
-/**
- * IMPORTANT THING TO NOTE WHEN WRITING TESTS IN THIS CLASS:
- * Does your test run in more than 1 language?
- * If your test will only run successfully in 1 language then this test WILL NOT WORK
- * for the l10n snapshots as they will be run in EVERY LANGUAGE we localise for.
- * When writing your test, run against at least 2 different languages before submitting for Code Review.
- * Thank You.
- */
-class L10nSnapshotTests: XCTestCase {
-    override func setUp() {
-        super.setUp()
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
-        continueAfterFailure = false
-
-        let app = XCUIApplication()
-        setupSnapshot(app)
-        app.launch()
-    }
-
-    func loadWebPage(url: String, waitForLoadToFinish: Bool = true) {
-        let LoadingTimeout: NSTimeInterval = 60
-        let exists = NSPredicate(format: "exists = true")
-        let loaded = NSPredicate(format: "value BEGINSWITH '100'")
-
-        let app = XCUIApplication()
-
-        UIPasteboard.generalPasteboard().string = url
-        app.textFields["url"].pressForDuration(2.0)
-        app.sheets.elementBoundByIndex(0).buttons.elementBoundByIndex(0).tap()
-
-        if waitForLoadToFinish {
-            let progressIndicator = app.progressIndicators.elementBoundByIndex(0)
-            expectationForPredicate(exists, evaluatedWithObject: progressIndicator, handler: nil)
-            expectationForPredicate(loaded, evaluatedWithObject: progressIndicator, handler: nil)
-            waitForExpectationsWithTimeout(LoadingTimeout, handler: nil)
-        }
-    }
-
-    func loadWebPage(url: String, waitForOtherElementWithAriaLabel ariaLabel: String) {
-        let app = XCUIApplication()
-        UIPasteboard.generalPasteboard().string = url
-        app.textFields["url"].pressForDuration(2.0)
-        app.sheets.elementBoundByIndex(0).buttons.elementBoundByIndex(0).tap()
-
-        sleep(3) // TODO Otherwise we detect the body in the currently loaded document, before the new page has loaded
-
-        let webView = app.webViews.elementBoundByIndex(0)
-        let element = webView.otherElements[ariaLabel]
-        expectationForPredicate(NSPredicate(format: "exists == 1"), evaluatedWithObject: element, handler: nil)
-
-        waitForExpectationsWithTimeout(5.0) { (error) -> Void in
-            if error != nil {
-                XCTFail("Failed to detect element with ariaLabel=\(ariaLabel) on \(url): \(error)")
-            }
-        }
-    }
-
-    func test01Intro() {
-        let app = XCUIApplication()
-        snapshot("01Intro-1")
-        app.scrollViews["IntroViewController.scrollView"].swipeLeft()
-        sleep(2)
-        snapshot("01Intro-2")
-        app.scrollViews["IntroViewController.scrollView"].swipeLeft()
-        sleep(2)
-        snapshot("01Intro-3")
-        app.scrollViews["IntroViewController.scrollView"].swipeLeft()
-        sleep(2)
-        snapshot("01Intro-4")
-        app.scrollViews["IntroViewController.scrollView"].swipeLeft()
-        sleep(2)
-        snapshot("01Intro-5")
-    }
-
+class L10nSnapshotTests: L10nBaseSnapshotTests {
     func test02DefaultTopSites() {
         snapshot("02DefaultTopSites-01")
     }
@@ -245,12 +171,6 @@ class L10nSnapshotTests: XCTestCase {
         snapshot("14SetHomepage-01", waitForLoadingIndicator: false)
     }
 
-    func test15LocationDialog() {
-        loadWebPage("http://people.mozilla.org/~sarentz/fxios/testpages/geolocation.html", waitForOtherElementWithAriaLabel: "body")
-        snapshot("15LocationDialog-01")
-        loadWebPage("http://people.mozilla.org/~sarentz/fxios/testpages/index.html", waitForOtherElementWithAriaLabel: "body")
-    }
-
     func test17PasswordSnackbar() {
         let app = XCUIApplication()
         loadWebPage("http://people.mozilla.org/~sarentz/fxios/testpages/password.html", waitForOtherElementWithAriaLabel: "body")
@@ -261,18 +181,5 @@ class L10nSnapshotTests: XCTestCase {
         loadWebPage("http://people.mozilla.org/~sarentz/fxios/testpages/password.html", waitForOtherElementWithAriaLabel: "body")
         app.webViews.elementBoundByIndex(0).buttons["submit"].tap()
         snapshot("17PasswordSnackbar-02")
-    }
-}
-
-extension XCUIElement {
-    func scrollToElement(element: XCUIElement) {
-        while !element.visible() {
-            swipeUp()
-        }
-    }
-    
-    func visible() -> Bool {
-        guard self.exists && !CGRectIsEmpty(self.frame) else { return false }
-        return CGRectContainsRect(XCUIApplication().windows.elementBoundByIndex(0).frame, self.frame)
     }
 }


### PR DESCRIPTION
This patch reorganizes the L10N Snapshot Tests. We now have a `BaseSnapshotTest` class. And a number of subclasses to make screenshots of specific parts of the app.