### PR TITLE
Bug 1315755 - Added FailedSQLiteHistory class in situations the DB is closed

### DIFF
--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -93,7 +93,7 @@ public class MockProfile: Profile {
      * collection of tables.
      */
     private lazy var places: protocol<BrowserHistory, Favicons, SyncableHistory, ResettableSyncStorage, HistoryRecommendations> = {
-        return SQLiteHistory(db: self.db, prefs: MockProfilePrefs())!
+        return SQLiteHistory(db: self.db, prefs: MockProfilePrefs())
     }()
 
     var favicons: Favicons {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -382,7 +382,7 @@ public class BrowserProfile: Profile {
      * that this is initialized first.
      */
     private lazy var places: protocol<BrowserHistory, Favicons, SyncableHistory, ResettableSyncStorage, HistoryRecommendations> = {
-        return SQLiteHistory(db: self.db, prefs: self.prefs)!
+        return SQLiteHistory(db: self.db, prefs: self.prefs)
     }()
 
     var favicons: Favicons {

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -74,7 +74,7 @@ public class BrowserDB {
         case .Closed:
             log.info("Database not created as the SQLiteConnection is closed.")
         case .Success:
-            log.debug("db: \(file) with secret = \(secretKey) has been created")
+            log.debug("db: \(file) has been created")
         }
     }
 

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -116,6 +116,11 @@ public class BrowserDB {
     // Utility for table classes. They should call this when they're initialized to force
     // creation of the table in the database.
     func createOrUpdate(tables: Table...) -> Bool {
+        guard !db.closed else {
+            log.info("Database is closed - skipping schema create/updates")
+            return false
+        }
+        
         var success = true
 
         let doCreate = { (table: Table, connection: SQLiteDBConnection) -> () in

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -24,6 +24,12 @@ protocol Queryable {
     func runQuery<T>(sql: String, args: Args?, factory: SDRow -> T) -> Deferred<Maybe<Cursor<T>>>
 }
 
+public enum DatabaseOpResult {
+    case Success
+    case Failure
+    case Closed
+}
+
 // Version 1 - Basic history table.
 // Version 2 - Added a visits table, refactored the history table to be a GenericTable.
 // Version 3 - Added a favicons table.
@@ -61,7 +67,15 @@ public class BrowserDB {
         }
 
         // Create or update will also delete and create the database if our key was incorrect.
-        self.createOrUpdate(self.schemaTable)
+        switch self.createOrUpdate(self.schemaTable) {
+        case .Failure:
+            log.error("Failed to create/update the scheme table. Aborting.")
+            fatalError()
+        case .Closed:
+            log.info("Database not created as the SQLiteConnection is closed.")
+        case .Success:
+            log.debug("db: \(file) with secret = \(secretKey) has been created")
+        }
     }
 
     // Creates a table and writes its table info into the table-table database.
@@ -115,10 +129,10 @@ public class BrowserDB {
 
     // Utility for table classes. They should call this when they're initialized to force
     // creation of the table in the database.
-    func createOrUpdate(tables: Table...) -> Bool {
+    func createOrUpdate(tables: Table...) -> DatabaseOpResult {
         guard !db.closed else {
             log.info("Database is closed - skipping schema create/updates")
-            return false
+            return .Closed
         }
         
         var success = true
@@ -244,7 +258,7 @@ public class BrowserDB {
             }
         }
 
-        return success
+        return success ? .Success : .Failure
     }
 
     typealias IntCallback = (connection: SQLiteDBConnection, inout err: NSError?) -> Int

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -107,7 +107,7 @@ public class SQLiteHistory {
     let favicons: FaviconsTable<Favicon>
     let prefs: Prefs
 
-    required public init?(db: BrowserDB, prefs: Prefs) {
+    required public init(db: BrowserDB, prefs: Prefs) {
         self.db = db
         self.favicons = FaviconsTable<Favicon>()
         self.prefs = prefs
@@ -115,7 +115,7 @@ public class SQLiteHistory {
         // BrowserTable exists only to perform create/update etc. operations -- it's not
         // a queryable thing that needs to stick around.
         if !db.createOrUpdate(BrowserTable()) {
-            return nil
+            log.error("Unable to create or update browser table!")
         }
     }
 }

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -116,7 +116,7 @@ public class SQLiteHistory {
         // a queryable thing that needs to stick around.
         switch db.createOrUpdate(BrowserTable()) {
         case .Failure:
-            log.error("Failed to create/update the scheme table. Aborting.")
+            log.error("Failed to create/update DB schema!")
             fatalError()
         case .Closed:
             log.info("Database not created as the SQLiteConnection is closed.")

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -114,8 +114,14 @@ public class SQLiteHistory {
 
         // BrowserTable exists only to perform create/update etc. operations -- it's not
         // a queryable thing that needs to stick around.
-        if !db.createOrUpdate(BrowserTable()) {
-            log.error("Unable to create or update browser table!")
+        switch db.createOrUpdate(BrowserTable()) {
+        case .Failure:
+            log.error("Failed to create/update the scheme table. Aborting.")
+            fatalError()
+        case .Closed:
+            log.info("Database not created as the SQLiteConnection is closed.")
+        case .Success:
+            log.debug("Database succesfully created/updated")
         }
     }
 }

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -67,7 +67,7 @@ public class SwiftData {
     /// A simple state flag to track whether we should accept new connection requests.
     /// If a connection request is made while the database is closed, a
     /// FailedSQLiteDBConnection will be returned.
-    private var closed = false
+    private(set) var closed = false
 
     init(filename: String, key: String? = nil, prevKey: String? = nil) {
         self.filename = filename

--- a/StoragePerfTests/StoragePerfTests.swift
+++ b/StoragePerfTests/StoragePerfTests.swift
@@ -37,7 +37,7 @@ class TestSQLiteHistoryFrecencyPerf: XCTestCase {
         let files = MockFiles()
         let db = BrowserDB(filename: "browser.db", files: files)
         let prefs = MockProfilePrefs()
-        let history = SQLiteHistory(db: db, prefs: prefs)!
+        let history = SQLiteHistory(db: db, prefs: prefs)
 
         let count = 500
 
@@ -58,7 +58,7 @@ class TestSQLiteHistoryTopSitesCachePref: XCTestCase {
         let files = MockFiles()
         let db = BrowserDB(filename: "browser.db", files: files)
         let prefs = MockProfilePrefs()
-        let history = SQLiteHistory(db: db, prefs: prefs)!
+        let history = SQLiteHistory(db: db, prefs: prefs)
 
         let count = 500
 

--- a/StorageTests/TestBrowserDB.swift
+++ b/StorageTests/TestBrowserDB.swift
@@ -58,7 +58,7 @@ class TestBrowserDB: XCTestCase {
 
     func testMovesDB() {
         let db = BrowserDB(filename: "foo.db", files: self.files)
-        XCTAssertTrue(db.createOrUpdate(BrowserTable()))
+        XCTAssertTrue(db.createOrUpdate(BrowserTable()) == .Success)
 
         db.run("CREATE TABLE foo (bar TEXT)").value      // Just so we have writes in the WAL.
 
@@ -83,7 +83,7 @@ class TestBrowserDB: XCTestCase {
         // It'll still fail, but it moved our old DB.
         // Our current observation is that closing the DB deletes the .shm file and also
         // checkpoints the WAL.
-        XCTAssertFalse(db.createOrUpdate(MockFailingTable()))
+        XCTAssertFalse(db.createOrUpdate(MockFailingTable()) == .Success)
         db.run("CREATE TABLE foo (bar TEXT)").value      // Just so we have writes in the WAL.
 
         XCTAssertTrue(files.exists("foo.db"))

--- a/StorageTests/TestFaviconsTable.swift
+++ b/StorageTests/TestFaviconsTable.swift
@@ -69,7 +69,7 @@ class TestFaviconsTable: XCTestCase {
     func testFaviconsTable() {
         let files = MockFiles()
         db = BrowserDB(filename: "test.db", files: files)
-        XCTAssertTrue(db.createOrUpdate(BrowserTable()))
+        XCTAssertTrue(db.createOrUpdate(BrowserTable()) == .Success)
         let f = FaviconsTable<Favicon>()
 
         var err: NSError?

--- a/StorageTests/TestSQLiteBookmarks.swift
+++ b/StorageTests/TestSQLiteBookmarks.swift
@@ -13,7 +13,7 @@ private func getBrowserDB(filename: String, files: FileAccessor) -> BrowserDB? {
 
     // BrowserTable exists only to perform create/update etc. operations -- it's not
     // a queryable thing that needs to stick around.
-    if !db.createOrUpdate(BrowserTable()) {
+    if db.createOrUpdate(BrowserTable()) != .Success {
         return nil
     }
     return db

--- a/StorageTests/TestSQLiteHistory.swift
+++ b/StorageTests/TestSQLiteHistory.swift
@@ -839,7 +839,7 @@ class TestSQLiteHistory: XCTestCase {
     func testHistoryLocalAndRemoteVisits() {
         let db = BrowserDB(filename: "browser.db", files: files)
         let prefs = MockProfilePrefs()
-        let history = SQLiteHistory(db: db, prefs: prefs)!
+        let history = SQLiteHistory(db: db, prefs: prefs)
 
         let siteL = Site(url: "http://url1/", title: "title local only")
         let siteR = Site(url: "http://url2/", title: "title remote only")
@@ -932,7 +932,7 @@ class TestSQLiteHistory: XCTestCase {
     func testUpgradesWithData() {
         let db = BrowserDB(filename: "browser-v6-data.db", files: files)
 
-        XCTAssertTrue(db.createOrUpdate(BrowserTableV6()), "Creating browser table version 6")
+        XCTAssertTrue(db.createOrUpdate(BrowserTableV6()) == .Success, "Creating browser table version 6")
 
         // Insert some data.
         let queries = [
@@ -947,11 +947,11 @@ class TestSQLiteHistory: XCTestCase {
         XCTAssertTrue(db.run(queries).value.isSuccess)
 
         // And we can upgrade to the current version.
-        XCTAssertTrue(db.createOrUpdate(BrowserTable()), "Upgrading browser table from version 6")
+        XCTAssertTrue(db.createOrUpdate(BrowserTable()) == .Success, "Upgrading browser table from version 6")
 
         let prefs = MockProfilePrefs()
         let history = SQLiteHistory(db: db, prefs: prefs)
-        let results = history?.getSitesByLastVisit(10).value.successValue
+        let results = history.getSitesByLastVisit(10).value.successValue
         XCTAssertNotNil(results)
         XCTAssertEqual(results![0]?.url, "http://www.example.com")
 
@@ -961,7 +961,7 @@ class TestSQLiteHistory: XCTestCase {
     func testDomainUpgrade() {
         let db = BrowserDB(filename: "browser.db", files: files)
         let prefs = MockProfilePrefs()
-        let history = SQLiteHistory(db: db, prefs: prefs)!
+        let history = SQLiteHistory(db: db, prefs: prefs)
 
         let site = Site(url: "http://www.example.com/test1.1", title: "title one")
         var err: NSError? = nil
@@ -990,7 +990,7 @@ class TestSQLiteHistory: XCTestCase {
     func testDomains() {
         let db = BrowserDB(filename: "browser.db", files: files)
         let prefs = MockProfilePrefs()
-        let history = SQLiteHistory(db: db, prefs: prefs)!
+        let history = SQLiteHistory(db: db, prefs: prefs)
 
         let initialGuid = Bytes.generateGUID()
         let site11 = Site(url: "http://www.example.com/test1.1", title: "title one")
@@ -1027,7 +1027,7 @@ class TestSQLiteHistory: XCTestCase {
     func testHistoryIsSynced() {
         let db = BrowserDB(filename: "historysynced.db", files: files)
         let prefs = MockProfilePrefs()
-        let history = SQLiteHistory(db: db, prefs: prefs)!
+        let history = SQLiteHistory(db: db, prefs: prefs)
 
         let initialGUID = Bytes.generateGUID()
         let site = Place(guid: initialGUID, url: "http://www.example.com/test1.3", title: "title")
@@ -1044,7 +1044,7 @@ class TestSQLiteHistory: XCTestCase {
     func testHistoryTable() {
         let db = BrowserDB(filename: "browser.db", files: files)
         let prefs = MockProfilePrefs()
-        let history = SQLiteHistory(db: db, prefs: prefs)!
+        let history = SQLiteHistory(db: db, prefs: prefs)
         let bookmarks = SQLiteBookmarks(db: db)
 
         let site1 = Site(url: "http://url1/", title: "title one")
@@ -1167,7 +1167,7 @@ class TestSQLiteHistory: XCTestCase {
     func testFaviconTable() {
         let db = BrowserDB(filename: "browser.db", files: files)
         let prefs = MockProfilePrefs()
-        let history = SQLiteHistory(db: db, prefs: prefs)!
+        let history = SQLiteHistory(db: db, prefs: prefs)
         let bookmarks = SQLiteBookmarks(db: db)
 
         let expectation = self.expectationWithDescription("First.")
@@ -1230,7 +1230,7 @@ class TestSQLiteHistory: XCTestCase {
     func testTopSitesCache() {
         let db = BrowserDB(filename: "browser.db", files: files)
         let prefs = MockProfilePrefs()
-        let history = SQLiteHistory(db: db, prefs: prefs)!
+        let history = SQLiteHistory(db: db, prefs: prefs)
 
         history.setTopSitesCacheSize(20)
         history.clearTopSitesCache().value
@@ -1317,7 +1317,7 @@ class TestSQLiteHistoryTransactionUpdate: XCTestCase {
         let files = MockFiles()
         let db = BrowserDB(filename: "browser.db", files: files)
         let prefs = MockProfilePrefs()
-        let history = SQLiteHistory(db: db, prefs: prefs)!
+        let history = SQLiteHistory(db: db, prefs: prefs)
 
         history.clearHistory().value
         let site = Site(url: "http://site/foo", title: "AA")
@@ -1336,7 +1336,7 @@ class TestSQLiteHistoryFilterSplitting: XCTestCase {
         let files = MockFiles()
         let db = BrowserDB(filename: "browser.db", files: files)
         let prefs = MockProfilePrefs()
-        return SQLiteHistory(db: db, prefs: prefs)!
+        return SQLiteHistory(db: db, prefs: prefs)
     }()
 
     func testWithSingleWord() {

--- a/StorageTests/TestSQLiteHistoryRecommendations.swift
+++ b/StorageTests/TestSQLiteHistoryRecommendations.swift
@@ -28,7 +28,7 @@ class TestSQLiteHistoryRecommendations: XCTestCase {
     func testHistoryHighlights() {
         let db = BrowserDB(filename: "browser.db", files: files)
         let prefs = MockProfilePrefs()
-        let history = SQLiteHistory(db: db, prefs: prefs)!
+        let history = SQLiteHistory(db: db, prefs: prefs)
 
         let startTime = NSDate.nowMicroseconds()
         let oneHourAgo = startTime - oneHourInMicroseconds
@@ -88,7 +88,7 @@ class TestSQLiteHistoryRecommendations: XCTestCase {
     func testBookmarkHighlights() {
         let db = BrowserDB(filename: "browser.db", files: files)
         let prefs = MockProfilePrefs()
-        let history = SQLiteHistory(db: db, prefs: prefs)!
+        let history = SQLiteHistory(db: db, prefs: prefs)
         let bookmarks = SQLiteBookmarkBufferStorage(db: db)
 
         let startTime = NSDate.nowMicroseconds()
@@ -141,7 +141,7 @@ class TestSQLiteHistoryRecommendationsPerf: XCTestCase {
         let files = MockFiles()
         let db = BrowserDB(filename: "browser.db", files: files)
         let prefs = MockProfilePrefs()
-        let history = SQLiteHistory(db: db, prefs: prefs)!
+        let history = SQLiteHistory(db: db, prefs: prefs)
         let bookmarks = SQLiteBookmarkBufferStorage(db: db)
 
         let count = 500

--- a/StorageTests/TestSQLiteMetadata.swift
+++ b/StorageTests/TestSQLiteMetadata.swift
@@ -17,7 +17,7 @@ class TestSQLiteMetadata: XCTestCase {
     override func setUp() {
         super.setUp()
         self.db = BrowserDB(filename: "foo.db", files: self.files)
-        XCTAssertTrue(db.createOrUpdate(BrowserTable()))
+        XCTAssertTrue(db.createOrUpdate(BrowserTable()) == .Success)
         
         self.metadata = SQLiteMetadata(db: db)
     }

--- a/SyncTests/TestBookmarkModel.swift
+++ b/SyncTests/TestBookmarkModel.swift
@@ -15,7 +15,7 @@ private func getBrowserDBForFile(filename: String, files: FileAccessor) -> Brows
 
     // BrowserTable exists only to perform create/update etc. operations -- it's not
     // a queryable thing that needs to stick around.
-    if !db.createOrUpdate(BrowserTable()) {
+    if db.createOrUpdate(BrowserTable()) != .Success {
         return nil
     }
     return db

--- a/SyncTests/TestBookmarkTreeMerging.swift
+++ b/SyncTests/TestBookmarkTreeMerging.swift
@@ -125,7 +125,7 @@ private func getBrowserDBForFile(filename: String, files: FileAccessor) -> Brows
 
     // BrowserTable exists only to perform create/update etc. operations -- it's not
     // a queryable thing that needs to stick around.
-    if !db.createOrUpdate(BrowserTable()) {
+    if db.createOrUpdate(BrowserTable()) != .Success {
         return nil
     }
     return db


### PR DESCRIPTION
With the recent changes to closing the database when we're in the background, there are times when we try to grab an instance of SQLiteHistory and it returns nil. At the moment, this is force-unwrapped which is causing crashes. Instead of modifying the API to return an optional, I've created a FailedSQLiteHistory class to swap in for the real one when we are not able to open the database.