### PR TITLE
Bug 1309571 - Fix visitDate ordering for history recommendation results

### DIFF
--- a/Storage/SQL/SQLiteHistoryRecommendations.swift
+++ b/Storage/SQL/SQLiteHistoryRecommendations.swift
@@ -29,6 +29,7 @@ extension SQLiteHistory: HistoryRecommendations {
             "       FROM \(TableVisits)" +
             "       WHERE date < ?" +
             "       GROUP BY siteID" +
+            "       ORDER BY visitDate DESC" +
             "   )" +
             "   LEFT JOIN \(TableHistory) ON \(TableHistory).id = s" +
             "   WHERE visitCount <= 3 AND title NOT NULL AND title != '' AND is_bookmarked == 0 AND url NOT IN" +


### PR DESCRIPTION
SQL was off for the highlights query which resulted in items being pulled in that were a month old!