### PR TITLE
Bug 1317380 - Make the request passcode immediately option less strict.

### DIFF
--- a/Utils/AuthenticationKeychainInfo.swift
+++ b/Utils/AuthenticationKeychainInfo.swift
@@ -10,7 +10,7 @@ public let AllowedPasscodeFailedAttempts = 3
 
 // Passcode intervals with rawValue in seconds.
 public enum PasscodeInterval: Int {
-    case Immediately    = 0
+    case Immediately    = 2
     case OneMinute      = 60
     case FiveMinutes    = 300
     case TenMinutes     = 600


### PR DESCRIPTION
The time reported by `SystemUtils.systemUptime` can be off by 1 sometimes between calls. This can sometimes cause loops where it keeps asking you to authenticate (if you have required passcode = immediately)

I've set immediately to now be 5 seconds. I can lower this to about 2 seconds to make this tighter. Anywhere between 2-5 seconds I think should fix this issue. I'll bring this up in triage tomorrow 