### PR TITLE
Bug 1309571 - Don't upload history (and fast-forward timestamp) if we're not done downloading

### DIFF
--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -1278,8 +1278,8 @@ public class BrowserProfile: Profile {
         func greenLight() -> () -> Bool {
             let start = NSDate.now()
 
-            // Give it one minute to run before we stop.
-            let stopBy = start + OneMinuteInMilliseconds
+            // Give it two minutes to run before we stop.
+            let stopBy = start + (2 * OneMinuteInMilliseconds)
             log.debug("Checking green light. Backgrounded: \(self.backgrounded).")
             return {
                 NSDate.now() < stopBy &&

--- a/Sync/StorageClient.swift
+++ b/Sync/StorageClient.swift
@@ -756,7 +756,7 @@ public class Sync15CollectionClient<T: CleartextPayloadJSON> {
             params.append(NSURLQueryItem(name: "sort", value: sort.rawValue))
         }
 
-        log.debug("Issuing GET with newer = \(since).")
+        log.debug("Issuing GET with newer = \(since), offset = \(offset), sort = \(sort).")
         let req = client.requestGET(self.collectionURI.withQueryParams(params))
 
         req.responsePartialParsedJSON(queue: collectionQueue, completionHandler: self.client.errorWrap(deferred) { (response: Response<JSON, JSONSerializeError>) in

--- a/Sync/Synchronizers/Downloader.swift
+++ b/Sync/Synchronizers/Downloader.swift
@@ -206,7 +206,7 @@ class BatchingDownloader<T: CleartextPayloadJSON> {
                 }
             }
 
-            log.debug("Got success response with \(response.metadata.records) records.")
+            log.debug("Got success response with \(response.metadata.records ?? 0) records.")
 
             // Store the incoming records for collection.
             self.store(response.value)

--- a/Sync/Synchronizers/HistorySynchronizer.swift
+++ b/Sync/Synchronizers/HistorySynchronizer.swift
@@ -54,7 +54,7 @@ public class HistorySynchronizer: IndependentRecordSynchronizer, Synchronizer {
         return HistoryStorageVersion
     }
 
-    private let batchSize: Int = 500  // A balance between number of requests and per-request size.
+    private let batchSize: Int = 1000  // A balance between number of requests and per-request size.
 
     private func mask(maxFailures: Int) -> Maybe<()> -> Success {
         var failures = 0

--- a/Sync/Synchronizers/HistorySynchronizer.swift
+++ b/Sync/Synchronizers/HistorySynchronizer.swift
@@ -175,11 +175,16 @@ public class HistorySynchronizer: IndependentRecordSynchronizer, Synchronizer {
            >>> effect({ log.debug("Done.") })
     }
 
-    private func go(info: InfoCollections, greenLight: () -> Bool, downloader: BatchingDownloader<HistoryPayload>, history: SyncableHistory) -> Success {
+    /**
+     * If the green light turns red, we don't want to continue to upload -- doing
+     * so would cause us to fast-forward our last sync timestamp and skip whatever
+     * we hadn't yet downloaded.
+     */
+    private func go(info: InfoCollections, greenLight: () -> Bool, downloader: BatchingDownloader<HistoryPayload>, history: SyncableHistory) -> SyncResult {
 
         if !greenLight() {
             log.info("Green light turned red. Stopping history download.")
-            return succeed()
+            return deferMaybe(.Partial)
         }
 
         func applyBatched() -> Success {
@@ -187,10 +192,10 @@ public class HistorySynchronizer: IndependentRecordSynchronizer, Synchronizer {
                >>> effect(downloader.advance)
         }
 
-        func onBatchResult(result: Maybe<DownloadEndState>) -> Success {
+        func onBatchResult(result: Maybe<DownloadEndState>) -> SyncResult {
             guard let end = result.successValue else {
                 log.warning("Got failure: \(result.failureValue!)")
-                return succeed()
+                return deferMaybe(.Completed)
             }
 
             switch end {
@@ -198,6 +203,7 @@ public class HistorySynchronizer: IndependentRecordSynchronizer, Synchronizer {
                 log.info("Done with batched mirroring.")
                 return applyBatched()
                    >>> history.doneApplyingRecordsAfterDownload
+                   >>> { deferMaybe(.Completed) }
             case .Incomplete:
                 log.debug("Running another batch.")
                 // This recursion is fine because Deferred always pushes callbacks onto a queue.
@@ -205,11 +211,11 @@ public class HistorySynchronizer: IndependentRecordSynchronizer, Synchronizer {
                    >>> { self.go(info, greenLight: greenLight, downloader: downloader, history: history) }
             case .Interrupted:
                 log.info("Interrupted. Aborting batching this time.")
-                return succeed()
+                return deferMaybe(.Partial)
             case .NoNewData:
                 log.info("No new data. No need to continue batching.")
                 downloader.advance()
-                return succeed()
+                return deferMaybe(.Completed)
             }
         }
 
@@ -242,7 +248,24 @@ public class HistorySynchronizer: IndependentRecordSynchronizer, Synchronizer {
         }
 
         return self.go(info, greenLight: greenLight, downloader: downloader, history: history)
-           >>> { self.uploadOutgoingFromStorage(history, lastTimestamp: 0, withServer: historyClient) }
-           >>> { return deferMaybe(.Completed) }
+            >>== { syncResult in
+                switch syncResult {
+                case .Completed:
+                    // When we're done downloading, we can upload.
+                    return self.uploadOutgoingFromStorage(history,
+                                                          lastTimestamp: 0,
+                                                          withServer: historyClient)
+                       >>> { deferMaybe(.Completed) }
+
+                // If we didn't finish downloading, do nothing further -- just pass
+                // through the download result.
+                case .NotStarted(_):
+                    return deferMaybe(syncResult)
+
+                case .Partial:
+                    log.debug("Didn't finish downloading history; not uploading yet.")
+                    return deferMaybe(syncResult)
+                }
+        }
     }
 }


### PR DESCRIPTION
This also bumps our limits a little.

To go faster we'd need to avoid looping over each record doing one insert each.

I tested this on my own Sync account, which has lots of history.

Steph, take a look?

Notably, with all of my history — tens of thousands — the history panel takes two seconds to load.