### PR TITLE
Bug 1316349 - Fix search term re-extraction in the url bar.

### DIFF
--- a/Client/Frontend/Browser/OpenSearch.swift
+++ b/Client/Frontend/Browser/OpenSearch.swift
@@ -89,11 +89,10 @@ class OpenSearchEngine: NSObject, NSCoding {
      * check that the URL host contains the name of the search engine somewhere inside it
      **/
     private func isSearchURLForEngine(url: NSURL?) -> Bool {
-        guard let urlHost = url?.host,
+        guard let urlHost = url?.hostSLD,
             let queryEndIndex = searchTemplate.rangeOfString("?")?.startIndex,
-            let templateURL = NSURL(string: searchTemplate.substringToIndex(queryEndIndex)),
-            let templateURLHost = templateURL.host else { return false }
-        return urlHost.localizedCaseInsensitiveContainsString(templateURLHost)
+            let templateURL = NSURL(string: searchTemplate.substringToIndex(queryEndIndex)) else { return false }
+        return urlHost == templateURL.hostSLD
     }
 
     /**

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -620,8 +620,10 @@ extension URLBarView: TabLocationViewDelegate {
 
     func tabLocationViewDidTapLocation(tabLocationView: TabLocationView) {
         var locationText = delegate?.urlBarDisplayTextForURL(locationView.url)
-        if let host = locationView.url?.host {
-            locationText = locationView.url?.absoluteString?.stringByReplacingOccurrencesOfString(host, withString: host.asciiHostToUTF8())
+
+        // Make sure to use the result from urlBarDisplayTextForURL as it is responsible for extracting out search terms when on a search page
+        if let text = locationText, let url = NSURL(string: text), let host = url.host {
+            locationText = url.absoluteString?.stringByReplacingOccurrencesOfString(host, withString: host.asciiHostToUTF8())
         }
         enterOverlayMode(locationText, pasted: false)
     }

--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -281,12 +281,12 @@ extension ActivityStreamPanel {
 
                 // Merge default topsites with a user's topsites.
                 let mergedSites = mySites.union(defaultSites, f: { (site) -> String in
-                    return NSURL(string: site.url)?.extractDomainName() ?? ""
+                    return NSURL(string: site.url)?.hostSLD ?? ""
                 })
 
                 // Favour topsites from defaultSites as they have better favicons.
                 let newSites = mergedSites.map { site -> Site in
-                    let domain = NSURL(string: site.url)?.extractDomainName() ?? ""
+                    let domain = NSURL(string: site.url)?.hostSLD
                     return defaultSites.find { $0.title.lowercaseString == domain } ?? site
                 }
 

--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -138,7 +138,7 @@ class TopSiteItemCell: UICollectionViewCell {
     }
 
     func configureWithTopSiteItem(site: Site) {
-        titleLabel.text = site.tileURL.extractDomainName()
+        titleLabel.text = site.tileURL.hostSLD
         accessibilityLabel = titleLabel.text
         if let suggestedSite = site as? SuggestedSite {
             let img = UIImage(named: suggestedSite.faviconImagePath!)

--- a/Client/Frontend/Widgets/AlternateSimpleHighlightCell.swift
+++ b/Client/Frontend/Widgets/AlternateSimpleHighlightCell.swift
@@ -179,7 +179,7 @@ class AlternateSimpleHighlightCell: UITableViewCell {
             self.siteImageView.image = FaviconFetcher.getDefaultFavicon(url)
             self.siteImageView.backgroundColor = FaviconFetcher.getDefaultColor(url)
         }
-        self.domainLabel.text = site.tileURL.extractDomainName()
+        self.domainLabel.text = site.tileURL.hostSLD
         self.titleLabel.text = site.title.characters.count <= 1 ? site.url : site.title
 
         if let bookmarked = site.bookmarked where bookmarked {

--- a/Utils/Extensions/NSURLExtensions.swift
+++ b/Utils/Extensions/NSURLExtensions.swift
@@ -147,7 +147,19 @@ extension NSURL {
 
         return "\(scheme)://\(hostPort)"
     }
-    
+
+    /**
+     * Returns the second level domain (SLD) of a url. It removes any subdomain/TLD
+     *
+     * E.g., https://m.foo.com/bar/baz?noo=abc#123  => foo
+     **/
+    public var hostSLD: String {
+        guard let publicSuffix = self.publicSuffix(), let baseDomain = self.baseDomain() else {
+            return self.normalizedHost() ?? self.URLString
+        }
+        return baseDomain.stringByReplacingOccurrencesOfString(".\(publicSuffix)", withString: "")
+    }
+
     public func normalizedHostAndPath() -> String? {
         if let normalizedHost = self.normalizedHost() {
             return normalizedHost + (self.path ?? "/")
@@ -205,16 +217,6 @@ extension NSURL {
             return components.URL ?? self
         }
         return self
-    }
-
-    public func extractDomainName() -> String {
-        let urlString =  self.normalizedHost() ?? self.URLString
-        var arr = urlString.componentsSeparatedByString(".")
-        if (arr.count >= 2) {
-            arr.popLast()
-            return arr.joinWithSeparator(".")
-        }
-        return urlString
     }
 
     public func normalizedHost() -> String? {


### PR DESCRIPTION
Support for punycode had broken the search term re-extraction.
I've also made modifications to the search term extraction to only check the domain name and not the TLD. google.com likes to redirect to the local TLD eg. google.ca which breaks search term extraction for people in Canada.