### PR TITLE
Bug 1316324 - Shutdown profile only if we are actually backgrounded

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -365,14 +365,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         var taskId: UIBackgroundTaskIdentifier = 0
         taskId = application.beginBackgroundTaskWithExpirationHandler { _ in
             log.warning("Running out of background time, but we have a profile shutdown pending.")
-            self.shutdownProfileIfBackgrounded(application)
+            self.shutdownProfileWhenNotActive(application)
             application.endBackgroundTask(taskId)
         }
 
         if profile.hasSyncableAccount() {
             let backgroundQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)
             profile.syncManager.syncEverything().uponQueue(backgroundQueue) { _ in
-                self.shutdownProfileIfBackgrounded(application)
+                self.shutdownProfileWhenNotActive(application)
                 application.endBackgroundTask(taskId)
             }
         } else {
@@ -381,11 +381,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
     }
 
-    private func shutdownProfileIfBackgrounded(application: UIApplication) {
-        // Only shutdown the profile if we are still in the background
-        if application.applicationState == UIApplicationState.Background {
-            profile?.shutdown()
+    private func shutdownProfileWhenNotActive(application: UIApplication) {
+        // Only shutdown the profile if we are not in the foreground
+        guard application.applicationState != UIApplicationState.Active else {
+            return
         }
+
+        profile?.shutdown()
     }
 
     func applicationWillResignActive(application: UIApplication) {

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -365,19 +365,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         var taskId: UIBackgroundTaskIdentifier = 0
         taskId = application.beginBackgroundTaskWithExpirationHandler { _ in
             log.warning("Running out of background time, but we have a profile shutdown pending.")
-            profile.shutdown()
+            self.shutdownProfileIfBackgrounded(application)
             application.endBackgroundTask(taskId)
         }
 
         if profile.hasSyncableAccount() {
             let backgroundQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)
             profile.syncManager.syncEverything().uponQueue(backgroundQueue) { _ in
-                profile.shutdown()
+                self.shutdownProfileIfBackgrounded(application)
                 application.endBackgroundTask(taskId)
             }
         } else {
             profile.shutdown()
             application.endBackgroundTask(taskId)
+        }
+    }
+
+    private func shutdownProfileIfBackgrounded(application: UIApplication) {
+        // Only shutdown the profile if we are still in the background
+        if application.applicationState == UIApplicationState.Background {
+            profile?.shutdown()
         }
     }
 


### PR DESCRIPTION
I was messing around with SwiftData and making the reopen/close tasks cancellable and stuff until I realized that the krux of the problem here is that the upon block after syncEverything from the app delegate is async and will fire if the app is foregrounded. I've made the shutdown logic more considered by respecting the application state instead of blindly shutting down. I feel like AppDelegate is probably the best place to check this since its close to the application lifecycle instead of inside Profile.swift but I'm open for feedback.