### PR TITLE
Bug 1305208 - Protect the local Web server with a random session token

### DIFF
--- a/Client/Application/WebServer.swift
+++ b/Client/Application/WebServer.swift
@@ -58,17 +58,4 @@ class WebServer {
     func URLForResource(resource: String, module: String) -> String {
         return "\(base)/\(module)/\(resource)"
     }
-
-    /// Return a full url, as an NSURL, for a resource in a module. No check is done to find out if the resource actually exist.
-    func URLForResource(resource: String, module: String) -> NSURL {
-        return NSURL(string: "\(base)/\(module)/\(resource)")!
-    }
-
-    func updateLocalURL(url: NSURL) -> NSURL? {
-        let components = NSURLComponents(URL: url, resolvingAgainstBaseURL: false)
-        if components?.host == "localhost" && components?.scheme == "http" {
-            components?.port = WebServer.sharedInstance.server.port
-        }
-        return components?.URL
-    }
 }

--- a/Client/Application/WebServer.swift
+++ b/Client/Application/WebServer.swift
@@ -18,9 +18,27 @@ class WebServer {
         return "http://localhost:\(server.port)"
     }
 
+    /// The private credentials for accessing resources on this Web server.
+    let credentials: NSURLCredential
+
+    /// A random, transient token used for authenticating requests.
+    /// Other apps are able to make requests to our local Web server,
+    /// so this prevents them from accessing any resources.
+    private let sessionToken = NSUUID().UUIDString
+
+    init() {
+        credentials = NSURLCredential(user: sessionToken, password: "", persistence: .ForSession)
+    }
+
     func start() throws -> Bool {
         if !server.running {
-            try server.startWithOptions([GCDWebServerOption_Port: 6571, GCDWebServerOption_BindToLocalhost: true, GCDWebServerOption_AutomaticallySuspendInBackground: true])
+            try server.startWithOptions([
+                GCDWebServerOption_Port: 6571,
+                GCDWebServerOption_BindToLocalhost: true,
+                GCDWebServerOption_AutomaticallySuspendInBackground: true,
+                GCDWebServerOption_AuthenticationMethod: GCDWebServerAuthenticationMethod_Basic,
+                GCDWebServerOption_AuthenticationAccounts: [sessionToken: ""]
+            ])
         }
         return server.running
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2307,6 +2307,12 @@ extension BrowserViewController: WKNavigationDelegate {
             return
         }
 
+        // If this is a request to our local web server, use our private credentials.
+        if challenge.protectionSpace.host == "localhost" && challenge.protectionSpace.port == Int(WebServer.sharedInstance.server.port) {
+            completionHandler(.UseCredential, WebServer.sharedInstance.credentials)
+            return
+        }
+
         // The challenge may come from a background tab, so ensure it's the one visible.
         tabManager.selectTab(tab)
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -181,20 +181,19 @@ class Tab: NSObject {
         if let sessionData = self.sessionData {
             restoring = true
 
-            var updatedURLs = [String]()
+            var urls = [String]()
             for url in sessionData.urls {
-                guard let updatedURL = WebServer.sharedInstance.updateLocalURL(url),
-                      let urlString = updatedURL.absoluteString else {
+                guard let urlString = url.absoluteString else {
                     assertionFailure("Invalid session URL: \(url)")
                     continue
                 }
-                updatedURLs.append(urlString)
+                urls.append(urlString)
             }
 
             let currentPage = sessionData.currentPage
             self.sessionData = nil
             var jsonDict = [String: AnyObject]()
-            jsonDict["history"] = updatedURLs
+            jsonDict["history"] = urls
             jsonDict["currentPage"] = currentPage
             let escapedJSON = JSON.stringify(jsonDict, pretty: false).stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLQueryAllowedCharacterSet())!
             let restoreURL = NSURL(string: "\(WebServer.sharedInstance.base)/about/sessionrestore?history=\(escapedJSON)")


### PR DESCRIPTION
I don't think there's a way to make our Web server accessible only to Firefox, so we can lock it down using HTTP authentication.