### PR TITLE
Bug 1318330 - Missing NSMicrophoneUsageDescription

### DIFF
--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -66,6 +66,8 @@
 	<string>This lets you save and upload photos.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>This lets you take and upload photos.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>This lets you take and upload videos.</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>org.mozilla.ios.firefox.browsing</string>

--- a/Client/en.lproj/InfoPlist.strings
+++ b/Client/en.lproj/InfoPlist.strings
@@ -5,5 +5,6 @@
 NSLocationWhenInUseUsageDescription = "Websites you visit may request your location.";
 NSPhotoLibraryUsageDescription = "This lets you save and upload photos.";
 NSCameraUsageDescription = "This lets you take and upload photos.";
+NSMicrophoneUsageDescription = "This lets you take and upload videos.";
 ShortcutItemTitleNewTab = "New Tab";
 ShortcutItemTitleNewPrivateTab = "New Private Tab";


### PR DESCRIPTION
This adds NSMicrophoneUsageDescription to `Info.plist` and `InfoPlist.strings`. WIthout it the app can crash when a web page asks to upload a video.