### PR TITLE
Bug 1317096 - Allow roots to omit parentName

### DIFF
--- a/Sync/BookmarkPayload.swift
+++ b/Sync/BookmarkPayload.swift
@@ -497,8 +497,12 @@ public class BookmarkBasePayload: CleartextPayloadJSON, MirrorItemable {
         }
 
         if !(self["parentName"].isString || self.id == "places") {
-            log.warning("Not the places root and missing parent name.")
-            return false
+            if (self["parentid"].asString! == "places") {
+                log.debug("Accepting root with missing parent name.")
+            } else {
+                log.warning("Not the places root and missing parent name.")
+                return false
+            }
         }
 
         if !self.hasRequiredStringFields(BookmarkBasePayload.requiredStringFields) {


### PR DESCRIPTION
A desktop refactor made the children of the places root — the roots themselves — omit the parent name. That caused them to fail validation on our end.

Desktop is fixing it, but now we need to do this to handle bad data in the wild. Sigh.