### PR TITLE
Bug 1318516 - Allow all about scheme links.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2193,14 +2193,7 @@ extension BrowserViewController: WKNavigationDelegate {
             return
         }
 
-        // Fixes 1261457 - Rich text editor fails because requests to about:blank are blocked
-        if url.scheme == "about" && url.resourceSpecifier == "blank" {
-            decisionHandler(WKNavigationActionPolicy.Allow)
-            return
-        }
-
-        // Fixes 1312801 - Navigating to about:srcdoc throws a "Firefox cannot open the page" alert
-        if url.scheme == "about" && url.resourceSpecifier == "srcdoc" {
+        if url.scheme == "about" {
             decisionHandler(WKNavigationActionPolicy.Allow)
             return
         }


### PR DESCRIPTION
Instead of adding exceptions for each about url individually just allow them all. 

If someone types in a URL with the about scheme all it does is load a blank page.  But this should prevent errors from popping up on pages trying to load content from iframes. 