### PR TITLE
Bug 1317580 - Add additional deeplink support for FxA

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -301,10 +301,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func launchFxAFromURL(params: FxALaunchParams) {
-        let view = params.view ?? nil
-        if (view != nil) {
-            self.browserViewController.presentSignInViewController(params)
+        guard params.view != nil else {
+            return
         }
+        self.browserViewController.presentSignInViewController(params)
     }
 
     func launchFromURL(params: LaunchParams) {

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -263,7 +263,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let fxaParams: FxALaunchParams
         fxaParams = FxALaunchParams(view: fxaQuery["fxa"], email: fxaQuery["email"], access_code: fxaQuery["access_code"])
         
-        if(fxaParams.view != nil){
+        if fxaParams.view != nil {
             launchFxAFromURL(fxaParams)
             return true
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1968,13 +1968,13 @@ extension BrowserViewController: HomePanelViewControllerDelegate {
     }
 
     func homePanelViewControllerDidRequestToCreateAccount(homePanelViewController: HomePanelViewController) {
-        let fxaParams: [String: String] = ["view" : "signup"]
-        presentSignInViewController(fxaParams) // TODO UX Right now the flow for sign in and create account is the same
+        let fxaOptions = FxALaunchParams(view: "signup", email: nil, access_code: nil)
+        presentSignInViewController(fxaOptions) // TODO UX Right now the flow for sign in and create account is the same
     }
 
     func homePanelViewControllerDidRequestToSignIn(homePanelViewController: HomePanelViewController) {
-        let fxaParams: [String: String] = ["view" : "signin"]
-        presentSignInViewController(fxaParams) // TODO UX Right now the flow for sign in and create account is the same
+        let fxaOptions = FxALaunchParams(view: "signin", email: nil, access_code: nil)
+        presentSignInViewController(fxaOptions) // TODO UX Right now the flow for sign in and create account is the same
     }
     
     func homePanelViewControllerDidRequestToOpenInNewTab(url: NSURL, isPrivate: Bool) {
@@ -2839,7 +2839,7 @@ extension BrowserViewController: IntroViewControllerDelegate {
         }
     }
 
-    func presentSignInViewController(fxaOptions: NSDictionary) {
+    func presentSignInViewController(fxaOptions: FxALaunchParams) {
         // Show the settings page if we have already signed in. If we haven't then show the signin page
         let vcToPresent: UIViewController
         if profile.hasAccount() {
@@ -2851,7 +2851,7 @@ extension BrowserViewController: IntroViewControllerDelegate {
             let signInVC = FxAContentViewController()
             signInVC.delegate = self
             signInVC.url = profile.accountConfiguration.signInURL
-            signInVC.fxaOptions = fxaOptions as! [String : String]
+            signInVC.fxaOptions = fxaOptions
             signInVC.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: UIBarButtonSystemItem.Cancel, target: self, action: #selector(BrowserViewController.dismissSignInViewController))
             vcToPresent = signInVC
         }
@@ -2867,7 +2867,7 @@ extension BrowserViewController: IntroViewControllerDelegate {
 
     func introViewControllerDidRequestToLogin(introViewController: IntroViewController) {
         introViewController.dismissViewControllerAnimated(true, completion: { () -> Void in
-            let fxaOptions: [String: String] = ["view" : "signin"]
+            let fxaOptions = FxALaunchParams(view: "signup", email: nil, access_code: nil)
             self.presentSignInViewController(fxaOptions)
         })
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1968,11 +1968,13 @@ extension BrowserViewController: HomePanelViewControllerDelegate {
     }
 
     func homePanelViewControllerDidRequestToCreateAccount(homePanelViewController: HomePanelViewController) {
-        presentSignInViewController() // TODO UX Right now the flow for sign in and create account is the same
+        let fxaParams: [String: String] = ["view" : "signup"]
+        presentSignInViewController(fxaParams) // TODO UX Right now the flow for sign in and create account is the same
     }
 
     func homePanelViewControllerDidRequestToSignIn(homePanelViewController: HomePanelViewController) {
-        presentSignInViewController() // TODO UX Right now the flow for sign in and create account is the same
+        let fxaParams: [String: String] = ["view" : "signin"]
+        presentSignInViewController(fxaParams) // TODO UX Right now the flow for sign in and create account is the same
     }
     
     func homePanelViewControllerDidRequestToOpenInNewTab(url: NSURL, isPrivate: Bool) {
@@ -2837,7 +2839,7 @@ extension BrowserViewController: IntroViewControllerDelegate {
         }
     }
 
-    func presentSignInViewController() {
+    func presentSignInViewController(fxaOptions: NSDictionary) {
         // Show the settings page if we have already signed in. If we haven't then show the signin page
         let vcToPresent: UIViewController
         if profile.hasAccount() {
@@ -2849,6 +2851,7 @@ extension BrowserViewController: IntroViewControllerDelegate {
             let signInVC = FxAContentViewController()
             signInVC.delegate = self
             signInVC.url = profile.accountConfiguration.signInURL
+            signInVC.fxaOptions = fxaOptions as! [String : String]
             signInVC.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: UIBarButtonSystemItem.Cancel, target: self, action: #selector(BrowserViewController.dismissSignInViewController))
             vcToPresent = signInVC
         }
@@ -2864,7 +2867,8 @@ extension BrowserViewController: IntroViewControllerDelegate {
 
     func introViewControllerDidRequestToLogin(introViewController: IntroViewController) {
         introViewController.dismissViewControllerAnimated(true, completion: { () -> Void in
-            self.presentSignInViewController()
+            let fxaOptions: [String: String] = ["view" : "signin"]
+            self.presentSignInViewController(fxaOptions)
         })
     }
 }

--- a/FxAClient/Frontend/SignIn/FxAContentViewController.swift
+++ b/FxAClient/Frontend/SignIn/FxAContentViewController.swift
@@ -22,6 +22,12 @@ protocol FxAContentViewControllerDelegate: class {
  * fxa-content-server git repository.
  */
 class FxAContentViewController: SettingsContentViewController, WKScriptMessageHandler {
+    var fxaOptions: [String: String] = [
+        "view": "",
+        "email": "",
+        "access_code": ""
+    ]
+
     private enum RemoteCommand: String {
         case CanLinkAccount = "can_link_account"
         case Loaded = "loaded"
@@ -112,6 +118,20 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
         self.timer?.invalidate()
         self.timer = nil
         self.isLoaded = true
+        
+        fillField("email", value: self.fxaOptions["email"])
+        fillField("access_code", value: self.fxaOptions["access_code"])
+    }
+    
+    // Attempt to fill out a field in content view
+    private func fillField(className: String?, value: String?){
+        if(className == nil || value == nil){
+            return
+        }
+        let script = "$('.\(className!)').val('\(value!)');";
+        webView.evaluateJavaScript(script, completionHandler: { (res, error) -> Void in
+            return
+        })
     }
 
     // Handle a message coming from the content server.

--- a/FxAClient/Frontend/SignIn/FxAContentViewController.swift
+++ b/FxAClient/Frontend/SignIn/FxAContentViewController.swift
@@ -121,13 +121,11 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
     
     // Attempt to fill out a field in content view
     private func fillField(className: String?, value: String?){
-        if(className == nil || value == nil){
+        guard let name = className, let val = value else {
             return
         }
-        let script = "$('.\(className!)').val('\(value!)');";
-        webView.evaluateJavaScript(script, completionHandler: { (res, error) -> Void in
-            return
-        })
+        let script = "$('.\(name)').val('\(val)');";
+        webView.evaluateJavaScript(script, completionHandler: nil)
     }
 
     // Handle a message coming from the content server.

--- a/FxAClient/Frontend/SignIn/FxAContentViewController.swift
+++ b/FxAClient/Frontend/SignIn/FxAContentViewController.swift
@@ -22,11 +22,7 @@ protocol FxAContentViewControllerDelegate: class {
  * fxa-content-server git repository.
  */
 class FxAContentViewController: SettingsContentViewController, WKScriptMessageHandler {
-    var fxaOptions: [String: String] = [
-        "view": "",
-        "email": "",
-        "access_code": ""
-    ]
+    var fxaOptions = FxALaunchParams()
 
     private enum RemoteCommand: String {
         case CanLinkAccount = "can_link_account"
@@ -119,8 +115,8 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
         self.timer = nil
         self.isLoaded = true
         
-        fillField("email", value: self.fxaOptions["email"])
-        fillField("access_code", value: self.fxaOptions["access_code"])
+        fillField("email", value: self.fxaOptions.email)
+        fillField("access_code", value: self.fxaOptions.access_code)
     }
     
     // Attempt to fill out a field in content view


### PR DESCRIPTION
This PR adds some custom deep linking support for Firefox Accounts. Specifically, this allows accounts to launch the `FxAContentViewController` directly and prefill the form with an email and access_code.

The updated deeplink scheme looks like this.

`firefox://?fxa=signin&email=test@email.com&access_code=12345`

This update does not change previous deeplinking functionality. If FxA options are not specified, it will work as previously expected.