### PR TITLE
Bug 1315971, 1318434 - Fix issues with session restore

### DIFF
--- a/Client/Assets/SessionRestore.html
+++ b/Client/Assets/SessionRestore.html
@@ -17,10 +17,6 @@
    */
   (function () {
       function getRestoreURL(url) {
-          // If the URL is already an internally hosted page, we can restore it directly.
-          if (url.indexOf(document.location.origin) === 0) {
-              return url;
-          }
           // Otherwise, push an error page to trigger a redirect when loaded.
           return '/errors/error.html?url=' + escape(url);
       }

--- a/Client/Assets/SessionRestore.html
+++ b/Client/Assets/SessionRestore.html
@@ -17,6 +17,10 @@
    */
   (function () {
       function getRestoreURL(url) {
+          // If the url already points to an error page just return the url as is
+          if (url.indexOf(document.location.origin + '/errors/error.html') === 0) {
+               return url;
+           }
           // Otherwise, push an error page to trigger a redirect when loaded.
           return '/errors/error.html?url=' + escape(url);
       }

--- a/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -114,7 +114,8 @@ class BackForwardListViewController: UIViewController, UITableViewDataSource, UI
         self.currentItem = bfList.currentItem
 
         //error url's are OK as they are used to populate history on session restore.
-        listData = items.filter({ return !($0.URL.isLocal && $0.URL.path != "/errors/error.html")})
+        listData = items.filter({return !($0.URL.isLocal && (ErrorPageHelper.originalURLFromQuery($0.URL)?.isLocal ?? true))})
+
     }
     
     func scrollTableViewToIndex(index: Int) {


### PR DESCRIPTION
I did some general refactoring in the BackForwardList and fixed the bugs while I was at it. 

The `/errors/error.html` urls were being parsed out of the backfoward list which was causing issues. 
We use the error.html to do redirects to actual webpages because of webkit's restrictions with push state. 

The change in `SessionRestore.html` was necessary because if you navigated back to the home page and then restarted the browser (so you have some history). Your history would be available but when you went forward the page would not load. I have no freaking clue why. Webkit would just refuse to load `error/error.html` with no errors or callbacks 😕 

