### PR TITLE
Bug 1311007 - Prevent home panel from flickering on launch.

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -672,7 +672,8 @@ extension TabManager {
 
         var tabToSelect: Tab?
         for (_, savedTab) in savedTabs.enumerate() {
-            let tab = self.addTab(flushToDisk: false, zombie: true, isPrivate: savedTab.isPrivate)
+            // Provide an empty request to prevent a new tab from loading the home screen
+            let tab = self.addTab(NSURLRequest(), configuration: nil, afterTab: nil, flushToDisk: false, zombie: true, isPrivate: savedTab.isPrivate)
 
             if let faviconURL = savedTab.faviconURL {
                 let icon = Favicon(url: faviconURL, date: NSDate(), type: IconType.NoneFound)


### PR DESCRIPTION
This flickering was caused by the homepanel being created/destroyed when it didn't need to be. 

The home panel would be loaded because the default url for a new tab points to the home panel. Then when sessionrestore.html was called the homepanel was destroyed. Once session restore finished if it pointed to a home panel it would cause it to load again. 