### PR TITLE
Bug 1320907 - Make sure passcode requirement interval setting has the correct option selected.

### DIFF
--- a/Utils/AuthenticationKeychainInfo.swift
+++ b/Utils/AuthenticationKeychainInfo.swift
@@ -76,7 +76,9 @@ public class AuthenticationKeychainInfo: NSObject, NSCoding {
         self.passcode = aDecoder.decodeObjectForKey("passcode") as? String
         self.failedAttempts = aDecoder.decodeIntegerForKey("failedAttempts")
         self.useTouchID = aDecoder.decodeBoolForKey("useTouchID")
-        if let interval = aDecoder.decodeObjectForKey("requiredPasscodeInterval") as? NSNumber {
+        if var interval = aDecoder.decodeObjectForKey("requiredPasscodeInterval") as? NSNumber {
+            // We have updated the immediate lockout value to 2 from 0 due to timing issues with systemUptime()
+            interval = interval == 0 ? 2 : interval
             self.requiredPasscodeInterval = PasscodeInterval(rawValue: interval.integerValue)
         }
     }


### PR DESCRIPTION
Because I changed the Immediate passcode interval from 0 to 2. Those who had previously had 0 as their default no longer had a correct interval. 

I've added a basic migration check when decoding passcode settings from the preferences. 