### PR TITLE
Bug 1320139 - Make sure default favicons have background colors.

### DIFF
--- a/Utils/FaviconFetcher.swift
+++ b/Utils/FaviconFetcher.swift
@@ -229,6 +229,7 @@ public class FaviconFetcher: NSObject, NSXMLParserDelegate {
         faviconLabel.textAlignment = .Center
         faviconLabel.font = UIFont.systemFontOfSize(18, weight: UIFontWeightMedium)
         faviconLabel.textColor = UIColor.whiteColor()
+        faviconLabel.backgroundColor = getDefaultColor(url)
         UIGraphicsBeginImageContextWithOptions(faviconLabel.bounds.size, false, 0.0)
         faviconLabel.layer.renderInContext(UIGraphicsGetCurrentContext()!)
         faviconImage = UIGraphicsGetImageFromCurrentImageContext()!


### PR DESCRIPTION
The background color of the default favicons was blank. That was okay before when the text was gray. But now that the text is white a background color is required for the letter to be visible. 
