### PR TITLE
Bug 1321363 - Enable the Whats New page for 6.0

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -577,7 +577,7 @@ class BrowserViewController: UIViewController {
         log.debug("BVC done.")
 
         if shouldShowWhatsNewTab() {
-            if let whatsNewURL = SupportUtils.URLForTopic("new-ios") {
+            if let whatsNewURL = SupportUtils.URLForTopic("new-ios-6") {
                 self.openURLInNewTab(whatsNewURL, isPrivileged: false)
                 profile.prefs.setString(AppInfo.appVersion, forKey: LatestAppVersionProfileKey)
             }


### PR DESCRIPTION
Updated the url to show the new page for 6.0