### PR TITLE
Bug 1322224 - Fix SendTab populating clients on subsequent launches

### DIFF
--- a/Extensions/SendTo/ActionViewController.swift
+++ b/Extensions/SendTo/ActionViewController.swift
@@ -20,6 +20,7 @@ class ActionViewController: UIViewController, ClientPickerViewControllerDelegate
         view.backgroundColor = UIColor.whiteColor()
 
         super.viewDidLoad()
+        profile.reopen()
 
         guard profile.hasAccount() else {
             let instructionsViewController = InstructionsViewController()

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -269,11 +269,11 @@ public class BrowserProfile: Profile {
         log.debug("Reopening profile.")
         isShutdown = false
         
-        if dbCreated {
+        if BrowserProfile.dbCreated {
             db.reopenIfClosed()
         }
 
-        if loginsDBCreated {
+        if BrowserProfile.loginsDBCreated {
             loginsDB.reopenIfClosed()
         }
     }
@@ -282,11 +282,11 @@ public class BrowserProfile: Profile {
         log.debug("Shutting down profile.")
         isShutdown = true
 
-        if self.dbCreated {
+        if BrowserProfile.dbCreated {
             db.forceClose()
         }
 
-        if self.loginsDBCreated {
+        if BrowserProfile.loginsDBCreated {
             loginsDB.forceClose()
         }
     }
@@ -361,7 +361,7 @@ public class BrowserProfile: Profile {
         }
     }()
 
-    private var dbCreated = false
+    private static var dbCreated = false
     var db: BrowserDB {
         struct Singleton {
             static var token: dispatch_once_t = 0
@@ -369,7 +369,7 @@ public class BrowserProfile: Profile {
         }
         dispatch_once(&Singleton.token) {
             Singleton.instance = BrowserDB(filename: "browser.db", files: self.files)
-            self.dbCreated = true
+            BrowserProfile.dbCreated = true
         }
         return Singleton.instance
     }
@@ -506,7 +506,7 @@ public class BrowserProfile: Profile {
         return Singleton.instance
     }
 
-    private var loginsDBCreated = false
+    private static var loginsDBCreated = false
     private lazy var loginsDB: BrowserDB = {
         struct Singleton {
             static var token: dispatch_once_t = 0
@@ -514,7 +514,7 @@ public class BrowserProfile: Profile {
         }
         dispatch_once(&Singleton.token) {
             Singleton.instance = BrowserDB(filename: "logins.db", secretKey: self.loginsKey, files: self.files)
-            self.loginsDBCreated = true
+            BrowserProfile.loginsDBCreated = true
         }
         return Singleton.instance
     }()

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -361,6 +361,15 @@ public class BrowserProfile: Profile {
         }
     }()
 
+    /**
+     * For safety and efficiency, we only allow each database to be opened once. It
+     * looks like you can create multiple Profile instances, each pointing to a
+     * different database, but that's not currently the case.
+     *
+     * These `dbCreated` flags are an implementation detail to avoid opening a DB
+     * only to immediately close it -- they reflect whether the singleton DB instances
+     * have been assigned.
+     */
     private static var dbCreated = false
     var db: BrowserDB {
         struct Singleton {


### PR DESCRIPTION
Removes dbCreated/loginDBCreated flags to avoid their state being reset
whenever the profile is recreated when using the SendTo extension. The
state is now implicit when access the DB properties since they are
initialized upon access from the computed properties.