### PR TITLE
Bug 1323373 - Don't upload tens of thousands of history items at once.

### DIFF
--- a/Storage/Bookmarks/Bookmarks.swift
+++ b/Storage/Bookmarks/Bookmarks.swift
@@ -331,7 +331,7 @@ public struct BookmarkMirrorItem: Equatable {
         // TODO: this should never be nil!
         if let parentID = self.parentID {
             out["parentid"] = BookmarkRoots.translateOutgoingRootGUID(parentID)
-            take("parentName", titleForSpecialGUID(parentID) ?? self.parentName)
+            take("parentName", titleForSpecialGUID(parentID) ?? self.parentName ?? "")
         }
 
         func takeBookmarkFields() {
@@ -432,7 +432,7 @@ public struct BookmarkMirrorItem: Equatable {
             faviconID: nil, localModified: nil, syncStatus: nil)
     }
 
-    public static func separator(guid: GUID, modified: Timestamp, hasDupe: Bool, parentID: GUID, parentName: String, pos: Int) -> BookmarkMirrorItem {
+    public static func separator(guid: GUID, modified: Timestamp, hasDupe: Bool, parentID: GUID, parentName: String?, pos: Int) -> BookmarkMirrorItem {
         let id = BookmarkRoots.translateIncomingRootGUID(guid)
         let parent = BookmarkRoots.translateIncomingRootGUID(parentID)
 
@@ -447,7 +447,7 @@ public struct BookmarkMirrorItem: Equatable {
             faviconID: nil, localModified: nil, syncStatus: nil)
     }
 
-    public static func bookmark(guid: GUID, modified: Timestamp, hasDupe: Bool, parentID: GUID, parentName: String, title: String, description: String?, URI: String, tags: String, keyword: String?) -> BookmarkMirrorItem {
+    public static func bookmark(guid: GUID, modified: Timestamp, hasDupe: Bool, parentID: GUID, parentName: String?, title: String, description: String?, URI: String, tags: String, keyword: String?) -> BookmarkMirrorItem {
         let id = BookmarkRoots.translateIncomingRootGUID(guid)
         let parent = BookmarkRoots.translateIncomingRootGUID(parentID)
 
@@ -462,7 +462,7 @@ public struct BookmarkMirrorItem: Equatable {
             faviconID: nil, localModified: nil, syncStatus: nil)
     }
 
-    public static func query(guid: GUID, modified: Timestamp, hasDupe: Bool, parentID: GUID, parentName: String, title: String, description: String?, URI: String, tags: String, keyword: String?, folderName: String?, queryID: String?) -> BookmarkMirrorItem {
+    public static func query(guid: GUID, modified: Timestamp, hasDupe: Bool, parentID: GUID, parentName: String?, title: String, description: String?, URI: String, tags: String, keyword: String?, folderName: String?, queryID: String?) -> BookmarkMirrorItem {
         let id = BookmarkRoots.translateIncomingRootGUID(guid)
         let parent = BookmarkRoots.translateIncomingRootGUID(parentID)
 

--- a/Storage/SQL/SQLiteBookmarksSyncing.swift
+++ b/Storage/SQL/SQLiteBookmarksSyncing.swift
@@ -324,7 +324,7 @@ private extension BookmarkMirrorItem {
             self.isDeleted ? 1 : 0,
             self.hasDupe ? 1 : 0,
             self.parentID,
-            self.parentName,
+            self.parentName ?? "",     // Workaround for dirty data before Bug 1318414.
             self.feedURI,
             self.siteURI,
             self.pos,

--- a/Storage/SQL/SQLiteBookmarksSyncing.swift
+++ b/Storage/SQL/SQLiteBookmarksSyncing.swift
@@ -438,8 +438,11 @@ public class SQLiteBookmarkBufferStorage: BookmarkBufferStorage {
             "folderName = ?, queryId = ? " +
             "WHERE guid = ?"
 
+            // We used to use INSERT OR IGNORE here, but it muffles legitimate errors. The only
+            // real use for that is/was to catch duplicates, but the UPDATE we run first should
+            // serve that purpose just as well.
             let insert =
-            "INSERT OR IGNORE INTO \(TableBookmarksBuffer) " +
+            "INSERT INTO \(TableBookmarksBuffer) " +
             "(type, server_modified, is_deleted, hasDupe, parentid, parentName, " +
              "feedUri, siteUri, pos, title, description, bmkUri, tags, keyword, folderName, queryId, guid) " +
             "VALUES " +

--- a/Sync/BookmarkPayload.swift
+++ b/Sync/BookmarkPayload.swift
@@ -202,7 +202,7 @@ public class SeparatorPayload: BookmarkBasePayload {
             hasDupe: self.hasDupe,
             // TODO: these might need to be weakened if real-world data is dirty.
             parentID: self["parentid"].asString!,
-            parentName: self["parentName"].asString!,
+            parentName: self["parentName"].asString,
             pos: self["pos"].asInt!
         )
     }
@@ -368,7 +368,7 @@ public class BookmarkPayload: BookmarkBasePayload {
             hasDupe: self.hasDupe,
             // TODO: these might need to be weakened if real-world data is dirty.
             parentID: self["parentid"].asString!,
-            parentName: self["parentName"].asString!,
+            parentName: self["parentName"].asString,
             title: self["title"].asString ?? "",
             description: self["description"].asString,
             URI: self["bmkUri"].asString!,
@@ -426,7 +426,7 @@ public class BookmarkQueryPayload: BookmarkPayload {
             modified: modified,
             hasDupe: self.hasDupe,
             parentID: self["parentid"].asString!,
-            parentName: self["parentName"].asString!,
+            parentName: self["parentName"].asString,
             title: self["title"].asString ?? "",
             description: self["description"].asString,
             URI: self["bmkUri"].asString!,
@@ -500,8 +500,8 @@ public class BookmarkBasePayload: CleartextPayloadJSON, MirrorItemable {
             if (self["parentid"].asString! == "places") {
                 log.debug("Accepting root with missing parent name.")
             } else {
-                log.warning("Not the places root and missing parent name.")
-                return false
+                // Bug 1318414.
+                log.warning("Accepting bookmark with missing parent name.")
             }
         }
 

--- a/Utils/DeferredUtils.swift
+++ b/Utils/DeferredUtils.swift
@@ -124,7 +124,7 @@ public func effect<T, U>(f: T -> U) -> T -> Deferred<Maybe<T>> {
  * Return a single Deferred that represents the sequential chaining of
  * f over the provided items, with the return value chained through.
  */
-public func walk<T, U>(items: [T], start: Deferred<Maybe<U>>, f: (T, U) -> Deferred<Maybe<U>>) -> Deferred<Maybe<U>> {
+public func walk<T, U, S: SequenceType where S.Generator.Element == T>(items: S, start: Deferred<Maybe<U>>, f: (T, U) -> Deferred<Maybe<U>>) -> Deferred<Maybe<U>> {
     let fs = items.map { item in
         return { val in
             f(item, val)


### PR DESCRIPTION
We can't simply pull every row from the DB, turn it into a record, and dump it on the upload batcher — we rapidly end up with hundreds of thousands of allocated objects, as we create JSON blobs for each visit, and a Record and a Payload, as well as retaining all of the original
data pulled from the DB.

This commit has us chunk the data from the DB, processing only 1000 records at a time. Each batch contains no more than 1000 records, with timestamps chained through. Each POST will still include no more than 100 records, thanks to existing limitations.

Uploading 80,000 records will still take 800 POSTs — we just won't die with a memory error in the attempt.