### PR TITLE
Bug 1321576 - Removes isUserZoom and caching of zoomScale

### DIFF
--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -42,8 +42,6 @@ class TabScrollingController: NSObject {
     var toolbarsShowing: Bool { return headerTopOffset == 0 }
     private var suppressToolbarHiding: Bool = false
     private var isZoomedOut: Bool = false
-    private var lastZoomedScale: CGFloat = 0
-    private var isUserZoom: Bool = false
 
     private var headerTopOffset: CGFloat = 0 {
         didSet {
@@ -129,7 +127,6 @@ class TabScrollingController: NSObject {
             return
         }
         self.isZoomedOut = roundNum(scrollView.zoomScale) == roundNum(scrollView.minimumZoomScale)
-        self.lastZoomedScale = self.isZoomedOut ? 0 : scrollView.zoomScale
     }
 
     func setMinimumZoom() {
@@ -143,7 +140,6 @@ class TabScrollingController: NSObject {
 
     func resetZoomState() {
         self.isZoomedOut = false
-        self.lastZoomedScale = 0
     }
 
     private func roundNum(num: CGFloat) -> CGFloat {
@@ -294,29 +290,7 @@ extension TabScrollingController: UIScrollViewDelegate {
         suppressToolbarHiding = false
     }
 
-    func scrollViewDidZoom(scrollView: UIScrollView) {
-        // Only mess with the zoom level if the user did not initate the zoom via a zoom gesture
-        if self.isUserZoom {
-            return
-        }
-
-        //scrollViewDidZoom will be called multiple times when a rotation happens.
-        // In that case ALWAYS reset to the minimum zoom level if the previous state was zoomed out (isZoomedOut=true)
-        if isZoomedOut {
-            scrollView.zoomScale = scrollView.minimumZoomScale
-        } else if roundNum(scrollView.zoomScale) > roundNum(self.lastZoomedScale) {
-            //When we have manually zoomed in we want to preserve that scale. 
-            //But sometimes when we rotate a larger zoomScale is appled. In that case apply the lastZoomedScale
-            scrollView.zoomScale = self.lastZoomedScale
-        }
-    }
-
-    func scrollViewWillBeginZooming(scrollView: UIScrollView, withView view: UIView?) {
-        self.isUserZoom = true
-    }
-
     func scrollViewDidEndZooming(scrollView: UIScrollView, withView view: UIView?, atScale scale: CGFloat) {
-        self.isUserZoom = false
         showOrHideWebViewContainerToolbar()
     }
 


### PR DESCRIPTION
One issue with assigning the zoomScale inside scrollViewDidZoom is that the WKWebView will invoke this method when it changes it's own scale such as requesting a page in Desktop Mode. Removing the handling of this and keeping the update minimum scaling logic on rotation seems to resolve this and the frictionless page issue that was caused by incorrect page scaling.