### PR TITLE
Bug 1321576 - Fix issues with scrolling inertia on iPad.

### DIFF
--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -304,7 +304,7 @@ extension TabScrollingController: UIScrollViewDelegate {
         // In that case ALWAYS reset to the minimum zoom level if the previous state was zoomed out (isZoomedOut=true)
         if isZoomedOut {
             scrollView.zoomScale = scrollView.minimumZoomScale
-        } else if roundNum(scrollView.zoomScale) > roundNum(self.lastZoomedScale) {
+        } else if roundNum(scrollView.zoomScale) > roundNum(self.lastZoomedScale) && self.lastZoomedScale != 0 {
             //When we have manually zoomed in we want to preserve that scale. 
             //But sometimes when we rotate a larger zoomScale is appled. In that case apply the lastZoomedScale
             scrollView.zoomScale = self.lastZoomedScale


### PR DESCRIPTION
The zoom scale was being applied to the scrollview even though it was 0. This makes sure that it never happens. 