### PR TITLE
Bug 1323745 - Moved profile.reopen to DidBecomeActive

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -336,6 +336,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return
         }
 
+        profile?.reopen()
+
         NightModeHelper.restoreNightModeBrightness((self.profile?.prefs)!, toForeground: true)
         self.profile?.syncManager.applicationDidBecomeActive()
 
@@ -393,8 +395,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         if profile.hasSyncableAccount() {
-            let backgroundQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)
-            profile.syncManager.syncEverything().uponQueue(backgroundQueue) { _ in
+            profile.syncManager.syncEverything().uponQueue(dispatch_get_main_queue()) { _ in
                 self.shutdownProfileWhenNotActive(application)
                 application.endBackgroundTask(taskId)
             }
@@ -425,7 +426,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         resetForegroundStartTime()
 
-        profile?.reopen()
     }
 
     private func resetForegroundStartTime() {


### PR DESCRIPTION
This was simplier than I expected. There is a potential race window between willBecomeActive and a background sync ending then closing the database. We want to make sure we always reopen on DidBecomeActive to prevent this.