### PR TITLE
Bug 13116990 - Disables back/cancel button in FxA view when we CanLinkAccount

### DIFF
--- a/FxAClient/Frontend/SignIn/FxAContentViewController.swift
+++ b/FxAClient/Frontend/SignIn/FxAContentViewController.swift
@@ -89,6 +89,8 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
     private func onCanLinkAccount(data: JSON) {
         //    // We need to confirm a relink - see shouldAllowRelink for more
         //    let ok = shouldAllowRelink(accountData.email);
+        self.navigationItem.setHidesBackButton(true, animated: false)
+        self.navigationItem.leftBarButtonItem = nil
         let ok = true
         injectData("message", content: ["status": "can_link_account", "data": ["ok": ok]]);
     }


### PR DESCRIPTION
We might be able to use CanLinkAccount for now to disable the Cancel/Back button and rely soley on the server sending us back the Login commend when it deems fit. In the case of an unknown device, this will force the user to wait the duration of the 'Confirm Email' screen while for known devices the user should be taken back soon after logging in.