### PR TITLE
Bug 1323993 - Refactor favicons to move logic into one place.

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -260,6 +260,7 @@
 		3BE7275D1CCFE8B60099189F /* CustomSearchHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE7275C1CCFE8B60099189F /* CustomSearchHandler.swift */; };
 		3BF4B8E91D38497A00493393 /* BaseTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF4B8E81D38497A00493393 /* BaseTestCase.swift */; };
 		3BF56D271CDBBE1F00AC4D75 /* SimpleToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF56D261CDBBE1F00AC4D75 /* SimpleToast.swift */; };
+		3BFCBF201E04B1C50070C042 /* UIImageViewExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BFCBF1F1E04B1C50070C042 /* UIImageViewExtensionsTests.swift */; };
 		3BFE4B501D34673D00DDF53F /* ThirdPartySearchTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BFE4B4F1D34673D00DDF53F /* ThirdPartySearchTest.swift */; };
 		4A59B58AD11B5EE1F80BBDEB /* TestHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A59BF410BBD9B3BE71F4C7C /* TestHistory.swift */; };
 		4F514FD41ACD8F2C0022D7EA /* HistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F514FD31ACD8F2C0022D7EA /* HistoryTests.swift */; };
@@ -1412,6 +1413,7 @@
 		3BF4B8E81D38497A00493393 /* BaseTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseTestCase.swift; sourceTree = "<group>"; };
 		3BF56D261CDBBE1F00AC4D75 /* SimpleToast.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimpleToast.swift; sourceTree = "<group>"; };
 		3BF7CDBF1E02712800BFB347 /* AboutUtilsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AboutUtilsTests.swift; sourceTree = "<group>"; };
+		3BFCBF1F1E04B1C50070C042 /* UIImageViewExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageViewExtensionsTests.swift; sourceTree = "<group>"; };
 		3BFE4B071D342FB800DDF53F /* XCUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XCUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3BFE4B0B1D342FB900DDF53F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3BFE4B4F1D34673D00DDF53F /* ThirdPartySearchTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThirdPartySearchTest.swift; sourceTree = "<group>"; };
@@ -3324,6 +3326,7 @@
 				2F44FA1A1A9D426A00FD20CC /* TestHashExtensions.swift */,
 				4A59BF410BBD9B3BE71F4C7C /* TestHistory.swift */,
 				A83E5B1C1C1DA8D80026D912 /* UIPasteboardExtensionsTests.swift */,
+				3BFCBF1F1E04B1C50070C042 /* UIImageViewExtensionsTests.swift */,
 				E4CD9F1C1A6D9C2800318571 /* WebServerTests.swift */,
 				D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */,
 				F84B21D71A090F8100AAB793 /* Supporting Files */,
@@ -5226,6 +5229,7 @@
 				D3FA777B1A43B2990010CD32 /* SearchTests.swift in Sources */,
 				D3BA41681BD82F2200DA5457 /* XCTestCaseExtensions.swift in Sources */,
 				554867231DC3935A00183DAA /* HomePageTests.swift in Sources */,
+				3BFCBF201E04B1C50070C042 /* UIImageViewExtensionsTests.swift in Sources */,
 				E60D032A1D5118DB002FE3F6 /* SyncStatusResolverTests.swift in Sources */,
 				7BBFEEA01BB409F300A305AA /* AboutUtils.swift in Sources */,
 				A83E5B1E1C1DAAAA0026D912 /* UIPasteboardExtensions.swift in Sources */,

--- a/Client/Extensions/UIImageViewExtensions.swift
+++ b/Client/Extensions/UIImageViewExtensions.swift
@@ -7,13 +7,31 @@ import Storage
 import WebImage
 
 public extension UIImageView {
-    public func setIcon(icon: Favicon?, withPlaceholder placeholder: UIImage) {
-        if let icon = icon {
-            let imageURL = NSURL(string: icon.url)
-            self.sd_setImageWithURL(imageURL, placeholderImage: placeholder)
+
+    public func setIcon(icon: Favicon?, forURL url: NSURL?) {
+        self.backgroundColor = UIColor.clearColor()
+        setDefaultIcon(url)
+        guard let icon = icon else {
             return
         }
-        self.image = placeholder
+        let imageURL = NSURL(string: icon.url)
+        self.sd_setHighlightedImageWithURL(imageURL) { (img, error, type, url) in
+            guard let image = img else {
+                return
+            }
+            self.image = image
+            self.backgroundColor = UIColor.whiteColor()
+        }
+    }
+
+    private func setDefaultIcon(url: NSURL?) {
+        if let url = url {
+            self.image = FaviconFetcher.getDefaultFavicon(url)
+            self.backgroundColor = FaviconFetcher.getDefaultColor(url)
+        } else {
+            self.image = FaviconFetcher.defaultFavicon
+            self.backgroundColor = UIColor.whiteColor()
+        }
     }
 }
 

--- a/Client/Frontend/Browser/BackForwardTableViewCell.swift
+++ b/Client/Frontend/Browser/BackForwardTableViewCell.swift
@@ -54,7 +54,7 @@ class BackForwardTableViewCell: UITableViewCell {
     var site: Site? {
         didSet {
             if let s = site {
-                faviconView.setIcon(s.icon, withPlaceholder: FaviconFetcher.getDefaultFavicon(s.tileURL))
+                faviconView.setIcon(s.icon, forURL: s.tileURL)
                 var title = s.title
                 if title.isEmpty {
                     title = s.url

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -533,7 +533,7 @@ extension SearchViewController {
                     let isBookmark = site.bookmarked ?? false
                     cell.setLines(site.title, detailText: site.url)
                     cell.setRightBadge(isBookmark ? self.bookmarkedBadge : nil)
-                    cell.imageView?.setIcon(site.icon, withPlaceholder: FaviconFetcher.getDefaultFavicon(site.tileURL))
+                    cell.imageView?.setIcon(site.icon, forURL: site.tileURL)
                 }
             }
             return cell

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -195,10 +195,8 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
             }
             if let url = bookmark.favicon?.url.asURL where url.scheme == "asset" {
                 cell.imageView?.image = UIImage(named: url.host!)
-            } else if let bookmarkURL = NSURL(string: item.url) {
-                cell.imageView?.setIcon(bookmark.favicon, withPlaceholder: FaviconFetcher.getDefaultFavicon(bookmarkURL))
             } else {
-                cell.imageView?.setIcon(bookmark.favicon, withPlaceholder: FaviconFetcher.defaultFavicon)
+                cell.imageView?.setIcon(bookmark.favicon, forURL: NSURL(string: item.url))
             }
             return cell
         case is BookmarkSeparator:

--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -335,7 +335,7 @@ class HistoryPanelSiteTableViewController: SiteTableViewController {
         if let site = data[indexPath.row + category.offset] {
             if let cell = cell as? TwoLineTableViewCell {
                 cell.setLines(site.title, detailText: site.url)
-                cell.imageView?.setIcon(site.icon, withPlaceholder: FaviconFetcher.getDefaultFavicon(site.tileURL))
+                cell.imageView?.setIcon(site.icon, forURL: site.tileURL)
             }
         }
 

--- a/Client/Frontend/Home/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Home/RecentlyClosedTabsPanel.swift
@@ -92,17 +92,13 @@ class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {
 
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let cell = super.tableView(tableView, cellForRowAtIndexPath: indexPath)
-        if let cell = cell as? TwoLineTableViewCell {
-            cell.setLines(recentlyClosedTabs[indexPath.row].title ?? "", detailText: recentlyClosedTabs[indexPath.row].url.absoluteString)
-            cell.imageView?.sd_setImageWithURL((recentlyClosedTabs[indexPath.row].faviconURL ?? "").asURL) { (img, err, type, url) -> Void in
-                guard img != nil else {
-                    if let url = NSURL(string: self.recentlyClosedTabs[indexPath.row].faviconURL ?? "") {
-                        cell.imageView?.setIcon(nil, withPlaceholder: FaviconFetcher.getDefaultFavicon(url))
-                    }
-                    return
-                }
-            }
+        guard let twoLineCell = cell as? TwoLineTableViewCell else {
+            return cell
         }
+        let tab = recentlyClosedTabs[indexPath.row]
+        twoLineCell.setLines(tab.title, detailText: tab.url.absoluteString)
+        let site: Favicon? = (tab.faviconURL != nil) ? Favicon(url: tab.faviconURL!, type: .Guess) : nil
+        cell.imageView?.setIcon(site, forURL: tab.url)
 
         return cell
     }

--- a/ClientTests/UIImageViewExtensionsTests.swift
+++ b/ClientTests/UIImageViewExtensionsTests.swift
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import UIKit
+import XCTest
+import Storage
+import WebImage
+import GCDWebServers
+
+@testable import Client
+
+
+class UIImageViewExtensionsTests: XCTestCase {
+
+    override func setUp() {
+        SDWebImageDownloader.sharedDownloader().urlCredential = WebServer.sharedInstance.credentials
+    }
+
+    func testsetIcon() {
+        let url = NSURL(string: "http://mozilla.com")
+        let imageView = UIImageView()
+
+        let goodIcon = FaviconFetcher.getDefaultFavicon(url!)
+        let correctColor = FaviconFetcher.getDefaultColor(url!)
+        imageView.setIcon(nil, forURL: url)
+        XCTAssertEqual(imageView.image!, goodIcon, "The correct default favicon should be applied")
+        XCTAssertEqual(imageView.backgroundColor, correctColor, "The correct default color should be applied")
+
+        imageView.setIcon(nil, forURL: NSURL(string: "http://mozilla.com/blahblah"))
+        XCTAssertEqual(imageView.image!, goodIcon, "The same icon should be applied to all urls with the same domain")
+
+        imageView.setIcon(nil, forURL: NSURL(string: "b"))
+        XCTAssertEqual(imageView.image, FaviconFetcher.defaultFavicon, "The default favicon should be applied when no information is given about the icon")
+    }
+
+    func testAsyncSetIcon() {
+        let imageData = UIImagePNGRepresentation(UIImage(named: "fxLogo")!)
+        WebServer.sharedInstance.registerHandlerForMethod("GET", module: "favicon", resource: "icon") { (request) -> GCDWebServerResponse! in
+            return GCDWebServerDataResponse(data: imageData, contentType: "image/png")
+        }
+
+        let favImageView = UIImageView()
+        favImageView.setIcon(Favicon(url: "http://localhost:6571/favicon/icon", type: .Guess), forURL: NSURL(string: "http://localhost:6571"))
+
+        let expect = expectationWithDescription("UIImageView async load")
+        let time = Int64(2 * Double(NSEC_PER_SEC))
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, time), dispatch_get_main_queue()) {
+            let a = UIImagePNGRepresentation(favImageView.image!)
+            XCTAssertEqual(imageData, a, "The correct favicon should be applied to the UIImageView")
+            expect.fulfill()
+        }
+        waitForExpectationsWithTimeout(5, handler: nil)
+    }
+
+    func testAsyncSetIconFail() {
+        let favImageView = UIImageView()
+
+        let gFavURL = NSURL(string: "https://www.google.com/noicon.ico")
+        let gURL = NSURL(string: "http://google.com")
+        let correctImage = FaviconFetcher.getDefaultFavicon(gURL!)
+
+        favImageView.setIcon(Favicon(url: gFavURL!.absoluteString!, type: .Guess), forURL: gURL)
+
+        let expect = expectationWithDescription("UIImageView async load")
+        let time = Int64(2 * Double(NSEC_PER_SEC))
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, time), dispatch_get_main_queue()) {
+            let b = UIImagePNGRepresentation(correctImage) // we need to convert to png in order to compare
+            let a = UIImagePNGRepresentation(favImageView.image!)
+            XCTAssertEqual(b, a, "The correct default favicon should be applied to the UIImageView")
+            expect.fulfill()
+        }
+        waitForExpectationsWithTimeout(5, handler: nil)
+    }
+}

--- a/Utils/FaviconFetcher.swift
+++ b/Utils/FaviconFetcher.swift
@@ -229,7 +229,6 @@ public class FaviconFetcher: NSObject, NSXMLParserDelegate {
         faviconLabel.textAlignment = .Center
         faviconLabel.font = UIFont.systemFontOfSize(18, weight: UIFontWeightMedium)
         faviconLabel.textColor = UIColor.whiteColor()
-        faviconLabel.backgroundColor = getDefaultColor(url)
         UIGraphicsBeginImageContextWithOptions(faviconLabel.bounds.size, false, 0.0)
         faviconLabel.layer.renderInContext(UIGraphicsGetCurrentContext()!)
         faviconImage = UIGraphicsGetImageFromCurrentImageContext()!


### PR DESCRIPTION

There was a lot of logic scattered all over the place related to how favicons handle cases where an image isnt found. I've moved it all into a UIImageView extension. 
This also fixes the issue where incorrect background colors were being applied to the ActivityStream topsites.