### PR TITLE
Bug 1311945 - The menu should not be displayed when foregrounding the app on iPads

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -291,6 +291,9 @@ class BrowserViewController: UIViewController {
             self.displayedPopoverController = nil
         }
 
+        // Dismiss menu if presenting
+        menuViewController?.dismissViewControllerAnimated(true, completion: nil)
+
         // If we are displying a private tab, hide any elements in the tab that we wouldn't want shown
         // when the app is in the home switcher
         guard let privateTab = tabManager.selectedTab where privateTab.isPrivate else {


### PR DESCRIPTION
Menu now dismisses on the app preparing to resign active, which is consistent with other iOS behaviors.

As per discussion, implemented on both form factors, not just iPad.