### PR TITLE
Bug 1325492 - Set highlighted image to prevent the wrong image from loading when selected.

### DIFF
--- a/Client/Extensions/UIImageViewExtensions.swift
+++ b/Client/Extensions/UIImageViewExtensions.swift
@@ -32,6 +32,7 @@ public extension UIImageView {
             self.image = FaviconFetcher.defaultFavicon
             self.backgroundColor = UIColor.whiteColor()
         }
+        self.highlightedImage = self.image
     }
 }
 


### PR DESCRIPTION
A small oversight. 😄 