### PR TITLE
Bug 1311629 - add highlighted state to undo close all tabs button

### DIFF
--- a/Client/Frontend/Browser/ButtonToast.swift
+++ b/Client/Frontend/Browser/ButtonToast.swift
@@ -15,6 +15,18 @@ struct ButtonToastUX {
     static let ToastButtonBorderWidth: CGFloat = 1
 }
 
+private class CustomButton : UIButton {
+    override var highlighted: Bool {
+        didSet {
+            if highlighted {
+                self.backgroundColor = UIColor.whiteColor()
+            } else  {
+                self.backgroundColor = UIColor.clearColor()
+            }
+        }
+    }
+}
+
 class ButtonToast: UIView {
     
     private var dismissed = false
@@ -60,11 +72,12 @@ class ButtonToast: UIView {
         label.numberOfLines = 0
         toast.addSubview(label)
         
-        let button = UIButton()
+        let button = CustomButton()
         button.layer.cornerRadius = ButtonToastUX.ToastButtonBorderRadius
         button.layer.borderWidth = ButtonToastUX.ToastButtonBorderWidth
         button.layer.borderColor = UIColor.whiteColor().CGColor
         button.setTitle(buttonText, forState: .Normal)
+        button.setTitleColor(self.toast.backgroundColor, forState: .Highlighted)
         button.titleLabel?.font = SimpleToastUX.ToastFont
         
         let recognizer = UITapGestureRecognizer(target: self, action:#selector(ButtonToast.buttonPressed(_:)))

--- a/Client/Frontend/Browser/ButtonToast.swift
+++ b/Client/Frontend/Browser/ButtonToast.swift
@@ -15,7 +15,7 @@ struct ButtonToastUX {
     static let ToastButtonBorderWidth: CGFloat = 1
 }
 
-private class CustomButton : UIButton {
+private class HighlightableButton : UIButton {
     override var highlighted: Bool {
         didSet {
             if highlighted {
@@ -72,7 +72,7 @@ class ButtonToast: UIView {
         label.numberOfLines = 0
         toast.addSubview(label)
         
-        let button = CustomButton()
+        let button = HighlightableButton()
         button.layer.cornerRadius = ButtonToastUX.ToastButtonBorderRadius
         button.layer.borderWidth = ButtonToastUX.ToastButtonBorderWidth
         button.layer.borderColor = UIColor.whiteColor().CGColor


### PR DESCRIPTION
Used the toast background color for the highlight label color to create a pleasing inverse look. 
Tried using the white background and clear color text suggested in the bug description but it wasn't readable.