### PR TITLE
Bug 1317536 - Make sure TopSites always go to the domain home page rather than specific pages.

### DIFF
--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -331,7 +331,7 @@ extension ActivityStreamPanel {
                 self.topSitesManager.urlPressedHandler = { [unowned self] url, indexPath in
                     let event = ASInfo(actionPosition: indexPath.item, source: .topSites)
                     ASOnyxPing.reportTapEvent(event)
-                    self.showSiteWithURLHandler(url)
+                    self.showSiteWithURLHandler(url.withoutPath)
                 }
                 
                 return succeed()
@@ -403,8 +403,12 @@ extension ActivityStreamPanel {
         let siteBGColor = topSiteItemCell.contentView.backgroundColor
 
         let site = self.topSitesManager.content[indexPath.item]
+        let domainURL = NSURL(string: site.url)?.withoutPath.absoluteString ?? site.url
+
+        //construct a new site so we can use a modified url for the menu
+        let newSite = Site(url: domainURL, title: site.title, bookmarked: site.bookmarked)
         let eventSource = ASInfo(actionPosition: indexPath.item, source: .topSites)
-        presentContextMenu(site, eventInfo: eventSource, siteImage: siteImage, siteBGColor: siteBGColor)
+        presentContextMenu(newSite, eventInfo: eventSource, siteImage: siteImage, siteBGColor: siteBGColor)
     }
 
     private func contextMenuForHighlightCellWithIndexPath(indexPath: NSIndexPath) {

--- a/SharedTests/NSURLExtensionsTests.swift
+++ b/SharedTests/NSURLExtensionsTests.swift
@@ -289,6 +289,16 @@ class NSURLExtensionsTests: XCTestCase {
         goodurls.forEach { XCTAssertEqual(NSURL(string:$0.0)!.havingRemovedAuthorisationComponents().absoluteString, $0.1) }
     }
 
+    func testwithoutPath() {
+        let urls = [
+            ("https://mail.mymail.com/inbox", "https://mail.mymail.com/"),
+            ("http://www.mymail.com/", "http://www.mymail.com/"),
+            ("https://www.example.com/longurlwithquery?item=1&item2=2", "https://www.example.com/")
+        ]
+
+        urls.forEach { XCTAssertEqual(NSURL(string:$0.0)!.withoutPath.absoluteString, $0.1) }
+    }
+
     func testschemeIsValid() {
         let goodurls = [
             "http://localhost:6571/reader-mode/page",

--- a/Utils/Extensions/NSURLExtensions.swift
+++ b/Utils/Extensions/NSURLExtensions.swift
@@ -251,6 +251,18 @@ extension NSURL {
     }
 
     /**
+     For example for the url http://www.bbc.co.uk/some/article.html, It would return http://www.bbc.co.uk/
+     :returns: Returns the url with the path removed
+     */
+    public var withoutPath: NSURL {
+        let newURL = NSURLComponents()
+        newURL.scheme = self.scheme
+        newURL.host = self.host
+        newURL.path = "/"
+        return newURL.URL ?? self
+    }
+
+    /**
     Returns the public portion of the host name determined by the public suffix list found here: https://publicsuffix.org/list/. 
     For example for the url www.bbc.co.uk, based on the entries in the TLD list, the public suffix would return co.uk.
 


### PR DESCRIPTION
Use the domainURL instead of the full URL. 