### PR TITLE
Bug 1328584 - Make sure history items navigate to the correct URL.

### DIFF
--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -330,9 +330,7 @@ class HistoryPanelSiteTableViewController: SiteTableViewController {
 
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let cell = super.tableView(tableView, cellForRowAtIndexPath: indexPath)
-        let category = self.categories[indexPath.section]
-
-        if let site = data[indexPath.row + category.offset] {
+        if let site = siteForIndexPath(indexPath) {
             if let cell = cell as? TwoLineTableViewCell {
                 cell.setLines(site.title, detailText: site.url)
                 cell.imageView?.setIcon(site.icon, forURL: site.tileURL)


### PR DESCRIPTION
The `cellForRow` and `didSelectRow` were computing the offsets differently. There is a `siteForIndexPath` property that is suppose to make this easier. `didSelectRow` uses it but `cellForRow` doesnt.