### PR TITLE
Bug 1314044 - Top Tab scrolling woes 😩

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -138,6 +138,7 @@ class BrowserViewController: UIViewController {
 
         coordinator.animateAlongsideTransition({context in
             self.scrollController.updateMinimumZoom()
+            self.topTabsViewController?.scrollToCurrentTab()
             if let popover = self.displayedPopoverController {
                 self.updateDisplayedPopoverProperties?()
                 self.presentViewController(popover, animated: true, completion: nil)

--- a/Client/Frontend/Browser/TopTabsLayout.swift
+++ b/Client/Frontend/Browser/TopTabsLayout.swift
@@ -12,7 +12,7 @@ class TopTabsLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout {
     }
     
     @objc func collectionView(collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAtIndexPath indexPath: NSIndexPath) -> CGSize {
-        return CGSizeMake(TopTabsUX.TabWidth, collectionView.frame.height)
+        return CGSizeMake(TopTabsUX.TabWidth, collectionView.frame.height - 2)
     }
     
     @objc func collectionView(collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAtIndex section: Int) -> UIEdgeInsets {

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -7,7 +7,7 @@ import Shared
 import WebKit
 
 struct TopTabsUX {
-    static let TopTabsViewHeight: CGFloat = 40
+    static let TopTabsViewHeight: CGFloat = 42
     static let TopTabsBackgroundNormalColor = UIColor(red: 235/255, green: 235/255, blue: 235/255, alpha: 1)
     static let TopTabsBackgroundPrivateColor = UIColor(red: 90/255, green: 90/255, blue: 90/255, alpha: 1)
     static let TopTabsBackgroundNormalColorInactive = UIColor(red: 178/255, green: 178/255, blue: 178/255, alpha: 1)


### PR DESCRIPTION
This fixes all the issues with Top Tabs not scrolling to the correct active tab. 

A lot of this achieved by simply reloading the entire table like savages 😅. We should be animating these changes like civilized people! 

Because tabs can be opened from outside of the TopTabsVC knowing when this is about to happen and then differentiating them from ones from inside the VC are tricky.

I think it might be smarter to anticipate changes to the dataStore (using didCreateTab) and diffing the tabStore. Then use the diff to perform animations. I have a sample branch of this working here.
https://github.com/farhanpatel/firefox-ios/commit/fe1ca43ae0284f39195eb3ba1b50557e1d33039f#diff-c153d78945c1fcbe11fe4266be80cd8aR196

 