### PR TITLE
Bug 1322121 - Make sure the bookmarks panel is setup even if viewWillAppear is not called.

### DIFF
--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -208,14 +208,18 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
     private func hideCurrentPanel() {
         if let panel = childViewControllers.first {
             panel.willMoveToParentViewController(nil)
+            panel.beginAppearanceTransition(false, animated: false)
             panel.view.removeFromSuperview()
+            panel.endAppearanceTransition()
             panel.removeFromParentViewController()
         }
     }
 
     private func showPanel(panel: UIViewController) {
         addChildViewController(panel)
+        panel.beginAppearanceTransition(true, animated: false)
         controllerContainerView.addSubview(panel.view)
+        panel.endAppearanceTransition()
         panel.view.snp_makeConstraints { make in
             make.top.equalTo(self.buttonContainerView.snp_bottom)
             make.left.right.bottom.equalTo(self.view)


### PR DESCRIPTION
ViewWillAppear is not always called. So we need to make sure that the bookmarks model is setup in Viewdidload. 

That explains why this bug only happens with the Bookmarks panel and not the other panels. 