### PR TITLE
Bug 1329807 - Make sure selectedTabDidChange is called only once when a tab is removed.

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -166,14 +166,13 @@ class TabManager: NSObject {
         return nil
     }
 
-    func selectTab(tab: Tab?) {
+    func selectTab(tab: Tab?, previous: Tab? = nil) {
         assert(NSThread.isMainThread())
+        let previous = previous ?? selectedTab
 
-        if selectedTab === tab {
+        if previous === tab {
             return
         }
-
-        let previous = selectedTab
 
         if let tab = tab {
             _selectedIndex = tabs.indexOf(tab) ?? -1
@@ -299,9 +298,7 @@ class TabManager: NSObject {
             tabs.insert(tab, atIndex: insertIndex)
         }
 
-        for delegate in delegates {
-            delegate.get()?.tabManager(self, didAddTab: tab)
-        }
+        delegates.forEach { $0.get()?.tabManager(self, didAddTab: tab) }
 
         if !zombie {
             tab.createWebview()
@@ -345,57 +342,41 @@ class TabManager: NSObject {
     ///   is removed.
     private func removeTab(tab: Tab, flushToDisk: Bool, notify: Bool) {
         assert(NSThread.isMainThread())
-        // If the removed tab was selected, find the new tab to select.
-        if tab === selectedTab {
-            let viableTabs: [Tab] = tab.isPrivate ? privateTabs : normalTabs
-            if let index = viableTabs.indexOf(tab) {
-                if index + 1 < viableTabs.count {
-                    selectTab(viableTabs[index + 1])
-                } else if index - 1 >= 0 {
-                    selectTab(viableTabs[index - 1])
-                } else {
-                    assert(viableTabs.count == 1, "Removing last tab")
-                    selectTab(nil)
-                }
-            }
-        }
+
+        let oldSelectedTab = selectedTab
 
         let prevCount = count
-        var removeIndex = -1
-        for i in 0..<count {
-            if tabs[i] === tab {
-                removeIndex = i
-                tabs.removeAtIndex(i)
-                break
-            }
+        if let removalIndex = tabs.indexOf({ $0 === tab }) {
+            tabs.removeAtIndex(removalIndex)
         }
-        if _selectedIndex > removeIndex && _selectedIndex > 0 {
+
+        //If the last item was deleted then select the last tab. Otherwise the _selectedIndex is already correct
+        if let oldTab = oldSelectedTab where tab !== oldTab {
+            _selectedIndex = tabs.indexOf(oldTab) ?? -1
+        } else if _selectedIndex == count {
             _selectedIndex -= 1
         }
-        assert(count == prevCount - 1, "Tab removed")
 
-        if tab != selectedTab {
-            _selectedIndex = selectedTab == nil ? -1 : tabs.indexOf(selectedTab!) ?? 0
-        }
+        assert(count == prevCount - 1, "Make sure the tab count was actually removed")
 
-        // There's still some time between this and the webView being destroyed.
-        // We don't want to pick up any stray events.
+        // There's still some time between this and the webView being destroyed. We don't want to pick up any stray events.
         tab.webView?.navigationDelegate = nil
 
         if notify {
-            for delegate in delegates {
-                delegate.get()?.tabManager(self, didRemoveTab: tab)
-            }
+            delegates.forEach { $0.get()?.tabManager(self, didRemoveTab: tab) }
         }
 
-        // Make sure we never reach 0 normal tabs
         let viableTabs: [Tab] = tab.isPrivate ? privateTabs : normalTabs
-        if viableTabs.count == 0 {
-            if !tab.isPrivate {
-                addTab()
-            } else {
-                selectTab(tabs.last)
-            }
+
+        if !tab.isPrivate && viableTabs.isEmpty {
+            addTab()
+        }
+
+        // If the removed tab was selected, find the new tab to select.
+        if selectedTab != nil {
+            selectTab(selectedTab, previous: oldSelectedTab)
+        } else {
+            selectTab(tabs.last, previous: oldSelectedTab)
         }
 
         if flushToDisk {

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -27,6 +27,70 @@ public class MockTabManagerStateDelegate: TabManagerStateDelegate {
     }
 }
 
+struct methodSpy {
+    let functionName: String
+    let method: ((tabs: [Tab?]) -> Void)?
+
+    init(functionName: String) {
+        self.functionName = functionName
+        self.method = nil
+    }
+
+    init(functionName: String, method: ((tabs: [Tab?]) -> Void)?) {
+        self.functionName = functionName
+        self.method = method
+    }
+}
+
+public class MockTabManagerDelegate: TabManagerDelegate {
+
+    //this array represents the order in which delegate methods should be called.
+    //each delegate method will pop the first struct from the array. If the method name doesn't match the struct then the order is incorrect
+    //Then it evaluates the method closure which will return true/false depending on if the tabs are correct
+    var methodCatchers: [methodSpy] = []
+
+    func testDelegateMethodWithName(name: String, tabs: [Tab?]) {
+        guard let spy = self.methodCatchers.first else {
+            XCTAssert(false, "No method was availible in the queue. For the delegate method \(name) to use")
+            return
+        }
+        XCTAssertEqual(spy.functionName, name)
+        if let methodCheck = spy.method {
+            methodCheck(tabs: tabs)
+        }
+        methodCatchers.removeFirst()
+    }
+
+    func tabManager(tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?) {
+        testDelegateMethodWithName(#function, tabs: [selected, previous])
+    }
+
+    func tabManager(tabManager: TabManager, didCreateTab tab: Tab) {
+        testDelegateMethodWithName(#function, tabs: [tab])
+    }
+
+    func tabManager(tabManager: TabManager, didAddTab tab: Tab) {
+        testDelegateMethodWithName(#function, tabs: [tab])
+    }
+
+    func tabManager(tabManager: TabManager, didRemoveTab tab: Tab) {
+        testDelegateMethodWithName(#function, tabs: [tab])
+    }
+
+    func tabManagerDidRestoreTabs(tabManager: TabManager) {
+        testDelegateMethodWithName(#function, tabs: [])
+    }
+
+    func tabManagerDidAddTabs(tabManager: TabManager) {
+        testDelegateMethodWithName(#function, tabs: [])
+    }
+
+    func tabManagerDidRemoveAllTabs(tabManager: TabManager, toast: ButtonToast?) {
+        testDelegateMethodWithName(#function, tabs: [])
+    }
+}
+
+
 class TabManagerTests: XCTestCase {
 
     override func setUp() {
@@ -78,5 +142,141 @@ class TabManagerTests: XCTestCase {
 
         XCTAssertEqual(stateDelegate.numberOfTabsStored, 0, "Expected state delegate to have been called with 3 tabs, but called with \(stateDelegate.numberOfTabsStored)")
     }
-    
+
+    func testAddTab() {
+        let profile = TabManagerMockProfile()
+        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let delegate = MockTabManagerDelegate()
+        manager.addDelegate(delegate)
+
+        let willCreate = methodSpy(functionName: "tabManager(_:didCreateTab:)")
+        let didAdd = methodSpy(functionName: "tabManager(_:didAddTab:)")
+        delegate.methodCatchers = [willCreate, didAdd]
+        manager.addTab()
+        XCTAssertTrue(delegate.methodCatchers.isEmpty, "Not all delegate methods were called")
+    }
+
+    func testDidDeleteLastTab() {
+        let profile = TabManagerMockProfile()
+        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let delegate = MockTabManagerDelegate()
+
+        //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
+        let tab = manager.addTab()
+        manager.selectTab(tab)
+        manager.addDelegate(delegate)
+
+        let didRemove = methodSpy(functionName: "tabManager(_:didRemoveTab:)")
+        let didCreate = methodSpy(functionName: "tabManager(_:didCreateTab:)")
+        let didAdd = methodSpy(functionName: "tabManager(_:didAddTab:)")
+        let didSelect = methodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
+            let next = tabs[0]!
+            let previous = tabs[1]!
+            XCTAssertTrue(previous != next)
+            XCTAssertTrue(previous == tab)
+            XCTAssertFalse(next.isPrivate)
+        }
+        delegate.methodCatchers = [didRemove, didCreate, didAdd, didSelect]
+        manager.removeTab(tab)
+        XCTAssertTrue(delegate.methodCatchers.isEmpty, "Not all delegate methods were called")
+    }
+
+
+    func testDidDeleteLastPrivateTab() {
+        let profile = TabManagerMockProfile()
+        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let delegate = MockTabManagerDelegate()
+
+        //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
+        let tab = manager.addTab()
+        manager.selectTab(tab)
+        let privateTab = manager.addTab(isPrivate: true)
+        manager.selectTab(privateTab)
+        manager.addDelegate(delegate)
+
+        let didRemove = methodSpy(functionName: "tabManager(_:didRemoveTab:)")
+        let didSelect = methodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
+            let next = tabs[0]!
+            let previous = tabs[1]!
+            XCTAssertTrue(previous != next)
+            XCTAssertTrue(previous == privateTab)
+            XCTAssertTrue(next == tab)
+            XCTAssertTrue(previous.isPrivate)
+            XCTAssertTrue(manager.selectedTab == next)
+        }
+        delegate.methodCatchers = [didRemove, didSelect]
+        manager.removeTab(privateTab)
+        XCTAssertTrue(delegate.methodCatchers.isEmpty, "Not all delegate methods were called")
+    }
+
+    func testDeleteNonSelectedTab() {
+        let profile = TabManagerMockProfile()
+        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let delegate = MockTabManagerDelegate()
+
+        //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
+        let tab = manager.addTab()
+        manager.selectTab(tab)
+        manager.addTab()
+        let deleteTab = manager.addTab()
+        manager.addDelegate(delegate)
+
+        let didRemove = methodSpy(functionName: "tabManager(_:didRemoveTab:)")
+        delegate.methodCatchers = [didRemove]
+        manager.removeTab(deleteTab)
+
+        XCTAssertTrue(delegate.methodCatchers.isEmpty, "Not all delegate methods were called")
+    }
+
+    func testDeleteLastTab() {
+        let profile = TabManagerMockProfile()
+        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let delegate = MockTabManagerDelegate()
+
+        //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
+        (0..<10).forEach {_ in manager.addTab() }
+        manager.selectTab(manager.tabs.last)
+        let deleteTab = manager.tabs.last
+        let newSelectedTab = manager.tabs[8]
+        manager.addDelegate(delegate)
+
+        let didRemove = methodSpy(functionName: "tabManager(_:didRemoveTab:)")
+        let didSelect = methodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
+            let next = tabs[0]!
+            let previous = tabs[1]!
+            XCTAssertEqual(deleteTab, previous)
+            XCTAssertEqual(next, newSelectedTab)
+        }
+        delegate.methodCatchers = [didRemove, didSelect]
+        manager.removeTab(manager.tabs.last!)
+
+        XCTAssertTrue(delegate.methodCatchers.isEmpty, "Not all delegate methods were called")
+    }
+
+
+    func testDeleteFirstTab() {
+        let profile = TabManagerMockProfile()
+        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let delegate = MockTabManagerDelegate()
+
+        //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
+        (0..<10).forEach {_ in manager.addTab() }
+        manager.selectTab(manager.tabs.first)
+        let deleteTab = manager.tabs.first
+        let newSelectedTab = manager.tabs[1]
+        manager.addDelegate(delegate)
+
+        let didRemove = methodSpy(functionName: "tabManager(_:didRemoveTab:)")
+        let didSelect = methodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
+            let next = tabs[0]!
+            let previous = tabs[1]!
+            XCTAssertEqual(deleteTab, previous)
+            XCTAssertEqual(next, newSelectedTab)
+        }
+        delegate.methodCatchers = [didRemove, didSelect]
+        manager.removeTab(manager.tabs.first!)
+
+        XCTAssertTrue(delegate.methodCatchers.isEmpty, "Not all delegate methods were called")
+    }
+
 }


### PR DESCRIPTION
I've edited selectTab() to take in a previousTab parameter. This allows removeTab to remove a tab and still have selectTab correctly show what the previous tab was. So before we'd have 

```selectTab(oldTab,nil) -> didRemoveTab(oldTab) -> selectTab(nil,newTab)```
now we'll have 
```didRemoveTab(oldTab) -> selectTab(oldTab,newTab)```

This is especially helpful in figuring out if we've exited private mode. We can check the isPrivate property of oldtab/newTab and can easily figure it out. Before this was very tricky. Imagine if a private tab is opened via the Today Widget. 

I've rearranged removeTab to call selectTab last. This simplifies some of the index logic. 