### PR TITLE
Bug 1331120 – Share XCUITest navigation actions between tests and screenshotting.

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -239,6 +239,8 @@
 		39E65D191CA455A900C63CE3 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 391AEFD11C8F11ED00691F84 /* Images.xcassets */; };
 		39E65D271CA5B92000C63CE3 /* AsyncReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E65D261CA5B92000C63CE3 /* AsyncReducerTests.swift */; };
 		39E65D371CA5CB0E00C63CE3 /* AsyncReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E65D351CA5CAF200C63CE3 /* AsyncReducer.swift */; };
+		39EB46991E26DDB4006346E8 /* ScreenGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EB46971E26DDB4006346E8 /* ScreenGraph.swift */; };
+		39EB469A1E26DDB4006346E8 /* FxScreenGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EB46981E26DDB4006346E8 /* FxScreenGraph.swift */; };
 		39F6D0701CD3B0770055D949 /* HomePageSettingsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F6D06F1CD3B0770055D949 /* HomePageSettingsUITests.swift */; };
 		3B0943811D6CC4FC004F24E1 /* FilledPageControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0943801D6CC4FC004F24E1 /* FilledPageControl.swift */; };
 		3B39EDBA1E16E18900EF029F /* CustomSearchEnginesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B39EDB91E16E18900EF029F /* CustomSearchEnginesTest.swift */; };
@@ -1387,6 +1389,8 @@
 		39DD030C1CD53E1900BC09B3 /* HomePageHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomePageHelper.swift; sourceTree = "<group>"; };
 		39E65D261CA5B92000C63CE3 /* AsyncReducerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncReducerTests.swift; sourceTree = "<group>"; };
 		39E65D351CA5CAF200C63CE3 /* AsyncReducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncReducer.swift; sourceTree = "<group>"; };
+		39EB46971E26DDB4006346E8 /* ScreenGraph.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenGraph.swift; sourceTree = "<group>"; };
+		39EB46981E26DDB4006346E8 /* FxScreenGraph.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxScreenGraph.swift; sourceTree = "<group>"; };
 		39F6D06F1CD3B0770055D949 /* HomePageSettingsUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomePageSettingsUITests.swift; sourceTree = "<group>"; };
 		3B0943801D6CC4FC004F24E1 /* FilledPageControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FilledPageControl.swift; path = ThirdParty/FilledPageControl.swift; sourceTree = "<group>"; };
 		3B39EDB91E16E18900EF029F /* CustomSearchEnginesTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomSearchEnginesTest.swift; sourceTree = "<group>"; };
@@ -2544,6 +2548,8 @@
 		3BF4B8DA1D38493300493393 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				39EB46971E26DDB4006346E8 /* ScreenGraph.swift */,
+				39EB46981E26DDB4006346E8 /* FxScreenGraph.swift */,
 				3BF4B8E81D38497A00493393 /* BaseTestCase.swift */,
 			);
 			name = Utils;
@@ -4827,10 +4833,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				3B546EC01D95ECAE00BDBE36 /* ActivityStreamTest.swift in Sources */,
+				39EB46991E26DDB4006346E8 /* ScreenGraph.swift in Sources */,
 				E40AFC6A1DD11C7300DA5651 /* LaunchArguments.swift in Sources */,
 				3BFE4B501D34673D00DDF53F /* ThirdPartySearchTest.swift in Sources */,
 				3BF4B8E91D38497A00493393 /* BaseTestCase.swift in Sources */,
 				0B3D670E1E09B90B00C1EFC7 /* AuthenticationTest.swift in Sources */,
+				39EB469A1E26DDB4006346E8 /* FxScreenGraph.swift in Sources */,
 				0B729D371E047D6A008E6859 /* HomePageSettingsTest.swift in Sources */,
 				55A747171DC46FC400CE1B57 /* HomePageUITest.swift in Sources */,
 			);

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -15,9 +15,24 @@ let FirstRun = "OptionalFirstRun"
 let HomePageSettings = "HomePageSettings"
 let PasscodeSettings = "PasscodeSettings"
 let PasscodeIntervalSettings = "PasscodeIntervalSettings"
+let SearchSettings = "SearchSettings"
+let NewTabSettings = "NewTabSettings"
+let ClearPrivateDataSettings = "ClearPrivateDataSettings"
 let LoginsSettings = "LoginsSettings"
+let OpenWithSettings = "OpenWithSettings"
 let NewTabScreen = "NewTabScreen"
 let NewTabMenu = "NewTabMenu"
+
+let allSettingsScreens = [
+    SettingsScreen,
+    HomePageSettings,
+    PasscodeSettings,
+    SearchSettings,
+    NewTabSettings,
+    ClearPrivateDataSettings,
+    LoginsSettings,
+    OpenWithSettings,
+]
 
 func createScreenGraph(app: XCUIApplication, url: String = "https://www.mozilla.org/en-US/book/") -> ScreenGraph {
     let map = ScreenGraph(app)
@@ -38,37 +53,53 @@ func createScreenGraph(app: XCUIApplication, url: String = "https://www.mozilla.
         }
 
         scene.tap(app.buttons["TabToolbar.menuButton"], to: NewTabMenu)
+        scene.gesture(to: TabTray) {
+            app.buttons["URLBarView.tabsButton"].tap()
+        }
     }
 
     map.createScene(NewTabMenu) { scene in
         scene.gesture(to: SettingsScreen) {
-            let collectionViewsQuery = app.collectionViews
-            collectionViewsQuery.cells["SettingsMenuItem"].tap()
+            app.collectionViews.cells["SettingsMenuItem"].tap()
         }
         scene.tap(app.buttons["Close Menu"], to: NewTabScreen)
         scene.dismissOnUse = true
     }
 
+    let navigationControllerBackAction = {
+        app.navigationBars.elementBoundByIndex(0).buttons.elementBoundByIndex(0).tap()
+    }
+
     map.createScene(SettingsScreen) { scene in
         let table = app.tables["AppSettingsTableViewController.tableView"]
 
-        scene.tap(table.staticTexts["Homepage"], to: HomePageSettings)
+        scene.tap(table.cells["Search"], to: SearchSettings)
+        scene.tap(table.cells["NewTab"], to: NewTabSettings)
+        scene.tap(table.cells["Homepage"], to: HomePageSettings)
         scene.tap(table.cells["TouchIDPasscode"], to: PasscodeSettings)
         scene.tap(table.cells["Logins"], to: LoginsSettings)
+        scene.tap(table.cells["ClearPrivateData"], to: ClearPrivateDataSettings)
+        scene.tap(table.cells["OpenWith.Setting"], to: OpenWithSettings)
 
-        scene.backAction = {
-            app.navigationBars["Settings"].buttons["AppSettingsTableViewController.navigationItem.leftBarButtonItem"].tap()
-        }
+        scene.tap(table.cells.staticTexts["Show Tour"], to: FirstRun)
+
+        scene.backAction = navigationControllerBackAction
+    }
+
+    map.createScene(SearchSettings) { scene in
+        scene.backAction = navigationControllerBackAction
+    }
+
+    map.createScene(NewTabSettings) { scene in
+        scene.backAction = navigationControllerBackAction
     }
 
     map.createScene(HomePageSettings) { scene in
-        scene.backAction = {
-            app.navigationBars["Homepage Settings"].buttons["Settings"].tap()
-        }
+        scene.backAction = navigationControllerBackAction
     }
 
     map.createScene(PasscodeSettings) { scene in
-        scene.tap(app.navigationBars["Passcode"].buttons["Settings"], to: SettingsScreen)
+        scene.backAction = navigationControllerBackAction
 
         scene.tap(app.tables["AuthenticationManager.settingsTableView"].staticTexts["Require Passcode"], to: PasscodeIntervalSettings)
     }
@@ -98,22 +129,41 @@ func createScreenGraph(app: XCUIApplication, url: String = "https://www.mozilla.
         }
     }
 
+    map.createScene(ClearPrivateDataSettings) { scene in
+        scene.backAction = navigationControllerBackAction
+    }
+
+    map.createScene(OpenWithSettings) { scene in
+        scene.backAction = navigationControllerBackAction
+    }
+
     map.createScene(TabTray) { scene in
+        scene.gesture(to: TabTrayMenu) {
+            app.buttons["TabTrayController.menuButton"].tap()
+        }
     }
 
     map.createScene(TabTrayMenu) { scene in
+        scene.gesture(to: SettingsScreen) {
+            let collectionViewsQuery = app.collectionViews
+            collectionViewsQuery.cells["SettingsMenuItem"].tap()
+        }
         scene.tap(app.buttons["Close Menu"], to: TabTray)
+        scene.dismissOnUse = true
     }
 
     map.createScene(BrowserTab) { scene in
         scene.tap(app.buttons["TabToolbar.menuButton"], to: BrowserTabMenu)
-
-        scene.tap(app.buttons["Show Tabs"], to: TabTray)
+        scene.gesture(to: TabTray) {
+            app.buttons["URLBarView.tabsButton"].tap()
+        }
     }
 
     map.createScene(BrowserTabMenu) { scene in
         scene.tap(app.buttons["Close Menu"], to: BrowserTab)
-        scene.tap(app.pageIndicators["page 1 of 2"], to: BrowserTabMenu2)
+        scene.gesture(to: BrowserTabMenu2) {
+            app.otherElements["MenuViewController.menuView"].swipeLeft()
+        }
         scene.dismissOnUse = true
     }
 

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -1,0 +1,131 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import XCTest
+
+let SettingsScreen = "SettingsScreen"
+let TabTray = "TabTray"
+let TabTrayMenu = "TabTrayMenu"
+let BrowserTab = "BrowserTab"
+let BrowserTabMenu = "BrowserTabMenu"
+let BrowserTabMenu2 = "BrowserTabMenu2"
+let FirstRun = "OptionalFirstRun"
+let HomePageSettings = "HomePageSettings"
+let PasscodeSettings = "PasscodeSettings"
+let PasscodeIntervalSettings = "PasscodeIntervalSettings"
+let LoginsSettings = "LoginsSettings"
+let NewTabScreen = "NewTabScreen"
+let NewTabMenu = "NewTabMenu"
+
+func createScreenGraph(app: XCUIApplication, url: String = "https://www.mozilla.org/en-US/book/") -> ScreenGraph {
+    let map = ScreenGraph(app)
+
+    map.createScene(FirstRun) { scene in
+        scene.gesture(to: NewTabScreen) {
+            let firstRunUI = app.buttons["Start Browsing"]
+            if (firstRunUI.exists) {
+                firstRunUI.tap()
+            }
+        }
+    }
+
+    map.createScene(NewTabScreen) { scene in
+        scene.gesture(to: BrowserTab) {
+            app.textFields["url"].tap()
+            app.textFields["address"].typeText(url + "\r")
+        }
+
+        scene.tap(app.buttons["TabToolbar.menuButton"], to: NewTabMenu)
+    }
+
+    map.createScene(NewTabMenu) { scene in
+        scene.gesture(to: SettingsScreen) {
+            let collectionViewsQuery = app.collectionViews
+            collectionViewsQuery.cells["SettingsMenuItem"].tap()
+        }
+        scene.tap(app.buttons["Close Menu"], to: NewTabScreen)
+        scene.dismissOnUse = true
+    }
+
+    map.createScene(SettingsScreen) { scene in
+        let table = app.tables["AppSettingsTableViewController.tableView"]
+
+        scene.tap(table.staticTexts["Homepage"], to: HomePageSettings)
+        scene.tap(table.cells["TouchIDPasscode"], to: PasscodeSettings)
+        scene.tap(table.cells["Logins"], to: LoginsSettings)
+
+        scene.backAction = {
+            app.navigationBars["Settings"].buttons["AppSettingsTableViewController.navigationItem.leftBarButtonItem"].tap()
+        }
+    }
+
+    map.createScene(HomePageSettings) { scene in
+        scene.backAction = {
+            app.navigationBars["Homepage Settings"].buttons["Settings"].tap()
+        }
+    }
+
+    map.createScene(PasscodeSettings) { scene in
+        scene.tap(app.navigationBars["Passcode"].buttons["Settings"], to: SettingsScreen)
+
+        scene.tap(app.tables["AuthenticationManager.settingsTableView"].staticTexts["Require Passcode"], to: PasscodeIntervalSettings)
+    }
+
+    map.createScene(PasscodeIntervalSettings) { scene in
+        // The test is likely to know what it needs to do here.
+        // This screen is protected by a passcode and is essentially modal.
+        scene.gesture(to: PasscodeSettings) {
+            if app.navigationBars["Require Passcode"].exists {
+                // Go back, accepting modifications
+                app.navigationBars["Require Passcode"].buttons["Passcode"].tap()
+            } else {
+                // Cancel
+                app.navigationBars["Enter Passcode"].buttons["Cancel"].tap()
+            }
+        }
+    }
+
+    map.createScene(LoginsSettings) { scene in
+        scene.gesture(to: SettingsScreen) {
+            let loginList = app.tables["Login List"]
+            if loginList.exists {
+                app.navigationBars["Logins"].buttons["Settings"].tap()
+            } else {
+                app.navigationBars["Enter Passcode"].buttons["Cancel"].tap()
+            }
+        }
+    }
+
+    map.createScene(TabTray) { scene in
+    }
+
+    map.createScene(TabTrayMenu) { scene in
+        scene.tap(app.buttons["Close Menu"], to: TabTray)
+    }
+
+    map.createScene(BrowserTab) { scene in
+        scene.tap(app.buttons["TabToolbar.menuButton"], to: BrowserTabMenu)
+
+        scene.tap(app.buttons["Show Tabs"], to: TabTray)
+    }
+
+    map.createScene(BrowserTabMenu) { scene in
+        scene.tap(app.buttons["Close Menu"], to: BrowserTab)
+        scene.tap(app.pageIndicators["page 1 of 2"], to: BrowserTabMenu2)
+        scene.dismissOnUse = true
+    }
+
+    map.createScene(BrowserTabMenu2) { scene in
+        scene.gesture(to: SettingsScreen) {
+            let collectionViewsQuery = app.collectionViews
+            collectionViewsQuery.cells["SettingsMenuItem"].tap()
+        }
+        scene.dismissOnUse = true
+    }
+
+    map.initialSceneName = FirstRun
+
+    return map
+}

--- a/XCUITests/HomePageSettingsTest.swift
+++ b/XCUITests/HomePageSettingsTest.swift
@@ -6,10 +6,13 @@
 import XCTest
 
 class HomePageSettingsTest: BaseTestCase {
-        
+    var navigator: Navigator!
+    var app: XCUIApplication!
+
     override func setUp() {
         super.setUp()
-        dismissFirstRunUI()
+        app = XCUIApplication()
+        navigator = createScreenGraph(app, url: "www.mozilla.com").navigator(self)
     }
     
     override func tearDown() {
@@ -19,21 +22,13 @@ class HomePageSettingsTest: BaseTestCase {
     
     // This test has moved from KIF UITest - accesses google.com instead of local webserver instance
     func testCurrentPage() {
-        
-        let app = XCUIApplication()
-        app.textFields["url"].tap()
-        app.textFields["address"].typeText("www.google.com\r")
-        
+        navigator.goto(BrowserTab)
+
         // Accessing https means that it is routed
-        waitForValueContains(app.textFields["url"], value: "https://www.google")
+        waitForValueContains(app.textFields["url"], value: "https://www.mozilla")
         let currentURL = app.textFields["url"].value as! String
-        app.buttons["TabToolbar.menuButton"].tap()
-        app.pageIndicators["page 1 of 2"].tap()
-        
-        let collectionViewsQuery = app.collectionViews
-        collectionViewsQuery.cells["SettingsMenuItem"].tap()
-        app.tables["AppSettingsTableViewController.tableView"].staticTexts["Homepage"].tap()
-        
+
+        navigator.goto(HomePageSettings)
         let tablesQuery = app.tables
         tablesQuery.staticTexts["Use Current Page"].tap()
         
@@ -45,24 +40,13 @@ class HomePageSettingsTest: BaseTestCase {
     
     // Check whether the toolbar/menu shows homepage icon
     func testShowHomePageIcon() {
-        
-        let app = XCUIApplication()
-        
-        // Go to google website
-        app.textFields["url"].tap()
-        app.textFields["address"].typeText("www.google.com\r")
-        waitForValueContains(app.textFields["url"], value: "https://www.google")
-        
         // Check the Homepage icon is present in menu by default
-        let tabtoolbarMenubuttonButton = app.buttons["TabToolbar.menuButton"]
-        tabtoolbarMenubuttonButton.tap()
+        navigator.goto(BrowserTabMenu)
         let collectionViewsQuery = app.collectionViews
         waitforExistence(collectionViewsQuery.cells["SetHomePageMenuItem"])
         
         // Go to settings, and disable the homepage icon switch
-        app.pageIndicators["page 1 of 2"].tap()
-        collectionViewsQuery.cells["SettingsMenuItem"].tap()
-        app.tables["AppSettingsTableViewController.tableView"].staticTexts["Homepage"].tap()
+        navigator.goto(HomePageSettings)
         
         let value = app.tables.cells.switches["Show Homepage Icon In Menu, Otherwise show in the toolbar"].value
         XCTAssertEqual(value as? String, "1")
@@ -70,18 +54,11 @@ class HomePageSettingsTest: BaseTestCase {
         app.tables.switches["Show Homepage Icon In Menu, Otherwise show in the toolbar"].tap()
         let newValue = app.tables.cells.switches["Show Homepage Icon In Menu, Otherwise show in the toolbar"].value
         XCTAssertEqual(newValue as? String, "0")
-        
-        // Exit and check the icon does not show up in menu, but on toolbar
-        app.navigationBars["Homepage Settings"].buttons["Settings"].tap()
-        app.navigationBars["Settings"].buttons["AppSettingsTableViewController.navigationItem.leftBarButtonItem"].tap()
-        
-        // it is located properly under Nav toolbar
-        waitforExistence(app.otherElements["Navigation Toolbar"].buttons["Homepage"])
-        
+
         // Both pages do not show Homepage icon
-        tabtoolbarMenubuttonButton.tap()
+        navigator.goto(BrowserTabMenu)
         waitforNoExistence(collectionViewsQuery.cells["SetHomePageMenuItem"])
-        app.pageIndicators["page 1 of 2"].tap()
+        navigator.goto(BrowserTabMenu2)
         waitforNoExistence(collectionViewsQuery.cells["SetHomePageMenuItem"])
     }
 }

--- a/XCUITests/ScreenGraph.swift
+++ b/XCUITests/ScreenGraph.swift
@@ -1,0 +1,392 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * ScreenGraph helps you get rid of the navigation boiler plate found in a lot of whole-application UI testing.
+ *
+ * You create a shared graph of UI 'screens' or 'scenes' for your app, and use it for every test.
+ *
+ * In your tests, you use a navigator which does the job of getting your tests from place to place in your application,
+ * leaving you to concentrate on testing, rather than maintaining brittle and duplicated navigation code.
+ * 
+ * The shared graph may also have other uses, such as generating screen shots for the App Store or L10n translators.
+ *
+ * Under the hood, the ScreenGraph is using GameplayKit's path finding to do the heavy lifting.
+ */
+
+import Foundation
+import GameplayKit
+import XCTest
+
+typealias Edge = (XCTestCase, String, UInt) -> ()
+typealias SceneBuilder = (ScreenGraphNode) -> ()
+typealias NodeVisitor = (String) -> ()
+
+/**
+ * ScreenGraph
+ * This is the main interface to building a graph of screens/app states and how to navigate between them.
+ * The ScreenGraph will be used as a map to navigate the test agent around the app.
+ */
+public class ScreenGraph {
+    let app: XCUIApplication
+    var initialSceneName: String?
+
+    var namedScenes: [String: ScreenGraphNode] = [:]
+    var nodedScenes: [GKGraphNode: ScreenGraphNode] = [:]
+
+    var isReady: Bool = false
+
+    let gkGraph: GKGraph
+
+    init(_ app: XCUIApplication) {
+        self.app = app
+        self.gkGraph = GKGraph()
+    }
+}
+
+extension ScreenGraph {
+    /**
+     * Method for creating a ScreenGraphNode in the graph. The node should be accompanied by a closure 
+     * used to document the exits out of this node to other nodes.
+     */
+    func createScene(name: String, file: String = #file, line: UInt = #line, builder: (ScreenGraphNode) -> ()){
+        let scene = ScreenGraphNode(map: self, name: name, builder: builder)
+        scene.file = file
+        scene.line = line
+        namedScenes[name] = scene
+        nodedScenes[scene.gkNode] = scene
+    }
+}
+
+extension ScreenGraph {
+    /**
+     * Create a new navigator object. Navigator objects are the main way of getting around the app.
+     * Typically, you'll do this in `TestCase.setUp()`
+     */
+    func navigator(xcTest: XCTestCase, startingAt: String? = nil, file: String = #file, line: UInt = #line) -> Navigator {
+        buildGkGraph()
+        var current: ScreenGraphNode?
+        if let name = startingAt ?? initialSceneName {
+            current = namedScenes[name]
+        }
+
+        if current == nil {
+            xcTest.recordFailureWithDescription("The app's initial state couldn't be established.",
+                inFile: file, atLine: line, expected: false)
+        }
+        return Navigator(self, xcTest: xcTest, initialScene: current!)
+    }
+
+    private func buildGkGraph() {
+        if isReady {
+            return
+        }
+
+        isReady = true
+
+        // Construct all the GKGraphNodes, and add them to the GKGraph.
+        let scenes = namedScenes.values
+        gkGraph.addNodes(scenes.map { $0.gkNode })
+
+        // Now, use the scene builders to collect edge actions and destinations.
+        scenes.forEach { scene in
+            scene.builder(scene)
+        }
+
+        scenes.forEach { scene in
+            let gkNodes = scene.edges.keys.flatMap { self.namedScenes[$0]?.gkNode } as [GKGraphNode]
+            scene.gkNode.addConnectionsToNodes(gkNodes, bidirectional: false)
+        }
+    }
+}
+
+typealias Gesture = () -> ()
+
+/**
+ * The ScreenGraph is made up of nodes. It is not possible to init these directly, only by creating 
+ * screen nodes from the ScreenGraph object.
+ * 
+ * The ScreenGraphNode has all the methods needed to define edges from this node to another node, using the usual
+ * XCUIElement method of moving about.
+ */
+class ScreenGraphNode {
+    let name: String
+    private let builder: SceneBuilder
+    private let gkNode: GKGraphNode
+    private var edges: [String: Edge] = [:]
+
+    private weak var map: ScreenGraph?
+
+    // Iff this node has a backAction, this store temporarily stores 
+    // the node we were at before we got to this one. This becomes the node we return to when the backAction is 
+    // invoked.
+    private weak var returnNode: ScreenGraphNode?
+
+    private var hasBack: Bool {
+        return backAction != nil
+    }
+
+    /**
+     * This is an action that will cause us to go back from where we came from.
+     * This is most useful when the same screen is accessible from multiple places, 
+     * and we have a back button to return to where we came from.
+     */
+    var backAction: Gesture?
+
+    /**
+     * This flag indicates that once we've moved on from this node, we can't come back to 
+     * it via `backAction`. This is especially useful for Menus, and dialogs.
+     */
+    var dismissOnUse: Bool = false
+
+    var existsWhen: XCUIElement? = nil
+
+    private var line: UInt!
+
+    private var file: String!
+
+    private init(map: ScreenGraph, name: String, builder: SceneBuilder) {
+        self.map = map
+        self.name = name
+        self.gkNode = GKGraphNode()
+        self.builder = builder
+    }
+
+    private func addEdge(dest: String, by edge: Edge) {
+        edges[dest] = edge
+        // by this time, we should've added all nodes in to the gkGraph.
+
+        assert(map?.namedScenes[dest] != nil, "Destination scene '\(dest)' has not been created anywhere")
+    }
+}
+
+private let existsPredicate = NSPredicate(format: "exists == true")
+private let enabledPredicate = NSPredicate(format: "enabled == true")
+private let hittablePredicate = NSPredicate(format: "hittable == true")
+private let noopNodeVisitor: NodeVisitor = { _ in }
+
+extension ScreenGraphNode {
+    private func waitForElement(element: XCUIElement, withTest xcTest: XCTestCase, handler: XCWaitCompletionHandler) {
+        if element.exists {
+            return
+        }
+        // TODO I'm not satisfied that this is working as expected.
+        xcTest.expectationForPredicate(existsPredicate,
+                                       evaluatedWithObject: element, handler: nil)
+        xcTest.waitForExpectationsWithTimeout(5, handler: handler)
+    }
+}
+
+// Public methods for defining edges out of this node.
+extension ScreenGraphNode {
+    /**
+     * Declare that by performing the given action/gesture, then we can navigate from this node to the next.
+     * 
+     * @param withElement – optional, but if provided will attempt to verify it is there before performing the action.
+     * @param to – the destination node.
+     */
+    func gesture(withElement element: XCUIElement? = nil, to nodeName: String, file declFile: String = #file, line declLine: UInt = #line, g: () -> ()) {
+        addEdge(nodeName) { xcTest, file, line in
+            if let el = element {
+                self.waitForElement(el, withTest: xcTest) { _ in
+                    xcTest.recordFailureWithDescription("Cannot find \(el)", inFile: declFile, atLine: declLine, expected: false)
+                    xcTest.recordFailureWithDescription("Cannot get from \(self.name) to \(nodeName). See \(declFile)", inFile: file, atLine: line, expected: false)
+                }
+            }
+            g()
+        }
+    }
+
+    func noop(to nodeName: String, file: String = #file, line: UInt = #line) {
+        self.gesture(to: nodeName, file: file, line: line) {
+            // NOOP.
+        }
+    }
+
+    /**
+     * Declare that by tapping a given element, we should be able to navigate from this node to another.
+     *
+     * @param element - the element to tap
+     * @param to – the destination node.
+     */
+    func tap(element: XCUIElement, to nodeName: String, file: String = #file, line: UInt = #line) {
+        self.gesture(withElement: element, to: nodeName, file: file, line: line) {
+            // TODO check if this element is enabled
+            element.tap()
+        }
+    }
+
+    func doubleTap(element: XCUIElement, to nodeName: String, file: String = #file, line: UInt = #line) {
+        self.gesture(withElement: element, to: nodeName, file: file, line: line) {
+            element.doubleTap()
+        }
+    }
+
+    func typeText(text: String, into element: XCUIElement, to nodeName: String, file: String = #file, line: UInt = #line) {
+        self.gesture(withElement: element, to: nodeName, file: file, line: line) {
+            element.typeText(text)
+        }
+    }
+
+    func swipeLeft(element: XCUIElement, to nodeName: String, file: String = #file, line: UInt = #line) {
+        self.gesture(withElement: element, to: nodeName, file: file, line: line) {
+            element.swipeLeft()
+        }
+    }
+
+    func swipeRight(element: XCUIElement, to nodeName: String, file: String = #file, line: UInt = #line) {
+        self.gesture(withElement: element, to: nodeName, file: file, line: line) {
+            element.swipeRight()
+        }
+    }
+
+    func swipeUp(element: XCUIElement, to nodeName: String, file: String = #file, line: UInt = #line) {
+        self.gesture(withElement: element, to: nodeName, file: file, line: line) {
+            element.swipeUp()
+        }
+    }
+
+    func swipeDown(element: XCUIElement, to nodeName: String, file: String = #file, line: UInt = #line) {
+        self.gesture(withElement: element, to: nodeName, file: file, line: line) {
+            element.swipeDown()
+        }
+    }
+}
+
+/**
+ * The Navigator provides a set of methods to navigate around the app. You can `goto` nodes, `visit` multiple nodes,
+ * or visit all nodes, but mostly you just goto. If you take actions that move around the app outside of the
+ * navigator, you can re-sync app with navigator my telling it which node it is now at, using the `nowAt` method.
+ */
+class Navigator {
+    private let map: ScreenGraph
+    private var currentScene: ScreenGraphNode
+    private var returnToRecentScene: ScreenGraphNode
+    private let xcTest: XCTestCase
+
+    private init(_ map: ScreenGraph, xcTest: XCTestCase, initialScene: ScreenGraphNode) {
+        self.map = map
+        self.xcTest = xcTest
+        self.currentScene = initialScene
+        self.returnToRecentScene = initialScene
+    }
+
+    /**
+     * Move the application to the named node.
+     */
+    func goto(nodeName: String, file: String = #file, line: UInt = #line) {
+        goto(nodeName, file: file, line: line, visitWith: noopNodeVisitor)
+    }
+
+    /**
+     * Move the application to the named node, wth an optional node visitor closure, which is called each time the
+     * node changes.
+     */
+    func goto(nodeName: String, file: String = #file, line: UInt = #line, visitWith nodeVisitor: NodeVisitor) {
+        let gkSrc = currentScene.gkNode
+        guard let gkDest = map.namedScenes[nodeName]?.gkNode else {
+            xcTest.recordFailureWithDescription("Cannot route to \(nodeName), because it doesn't exist", inFile: file, atLine: line, expected: false)
+            return
+        }
+
+        var gkPath = map.gkGraph.findPathFromNode(gkSrc, toNode: gkDest)
+        guard gkPath.count > 0 else {
+            xcTest.recordFailureWithDescription("Cannot route from \(currentScene.name) to \(nodeName)", inFile: file, atLine: line, expected: false)
+            return
+        }
+
+        gkPath.removeFirst()
+        gkPath.forEach { gkNext in
+            if !currentScene.dismissOnUse {
+                returnToRecentScene = currentScene
+            }
+
+            let nextScene = map.nodedScenes[gkNext]!
+            let action = currentScene.edges[nextScene.name]!
+
+            // We definitely have an action, so it's save to unbox.
+            action(xcTest, file, line)
+
+            if let testElement = nextScene.existsWhen {
+                nextScene.waitForElement(testElement, withTest: xcTest) { _ in
+                    // TODO report error in the correct place in the graph.
+                    self.xcTest.recordFailureWithDescription("Cannot find \(testElement) in \(nextScene.name)",
+                        inFile: nextScene.file,
+                        atLine: nextScene.line,
+                        expected: false)
+                }
+            }
+
+            if nextScene.hasBack {
+                if nextScene.returnNode == nil {
+                    nextScene.returnNode = returnToRecentScene
+                    nextScene.gkNode.addConnectionsToNodes([ returnToRecentScene.gkNode ], bidirectional: false)
+                    nextScene.gesture(to: returnToRecentScene.name, g: nextScene.backAction!)
+                }
+            }
+
+            if currentScene.hasBack {
+                if nextScene.name == currentScene.returnNode?.name {
+                    currentScene.returnNode = nil
+                    currentScene.gkNode.removeConnectionsToNodes([ nextScene.gkNode ], bidirectional: false)
+                }
+            }
+            nodeVisitor(currentScene.name)
+            currentScene = nextScene
+        }
+    }
+
+    /**
+     * Helper method when the navigator gets out of sync with the actual app.
+     * This should not be used too often, as it indicates you should probably have another node in your graph,
+     * or you should be using `scene.dismissOnUse = true`.
+     * Also useful if you're using XCUIElement taps directly to navigate from one node to another.
+     */
+    func nowAt(nodeName: String, file: String = #file, line: UInt = #line) {
+        guard let newScene = map.namedScenes[nodeName] else {
+            xcTest.recordFailureWithDescription("Cannot force to unknown \(nodeName). Currently at \(currentScene.name)", inFile: file, atLine: line, expected: false)
+            return
+        }
+        currentScene = newScene
+    }
+
+    /**
+     * Visit the named nodes, calling the NodeVisitor the first time it is encountered.
+     */
+    func visitNodes(nodes: [String], file: String = #file, line: UInt = #line, f: NodeVisitor) {
+        var visitedNodes = Set<String>()
+        let desiredNodes = Set<String>(nodes)
+        nodes.forEach { node in
+            if visitedNodes.contains(node) {
+                return
+            }
+            self.goto(node, file: file, line: line) { visitedNode in
+                if desiredNodes.contains(visitedNode) && !visitedNodes.contains(visitedNode) {
+                    f(visitedNode)
+                }
+                visitedNodes.insert(visitedNode)
+            }
+        }
+    }
+
+    /**
+     * Visit all nodes, calling the NodeVisitor the first time it is encountered.
+     * 
+     * Some nodes may not be immediately available, depending on the state of the app.
+     */
+    func visitAll(file: String = #file, line: UInt = #line, f: NodeVisitor) {
+        let nodes: [String] = self.map.namedScenes.keys.map { $0 } // keys can't be coerced into a [String]
+        self.visitNodes(nodes, file: file, line: line, f: f)
+    }
+
+    /**
+     * Move the app back to its initial state.
+     * This may not be possible.
+     */
+    func revert(file: String = #file, line: UInt = #line) {
+        if let initial = self.map.initialSceneName {
+            self.goto(initial, file: file, line: line)
+        }
+    }
+}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1331120

ScreenGraph helps you get rid of the navigation boiler plate found in a lot of whole-application UI testing.

You create a shared graph of UI 'screens' or 'scenes' for your app, and use it for every test.

In your tests, you use a navigator which does the job of getting your tests from place to place in your application,
leaving you to concentrate on testing, rather than maintaining brittle and duplicated navigation code.

The shared graph may also have other uses, such as generating screen shots for the App Store or L10n translators.

Under the hood, the ScreenGraph is using GameplayKit's path finding to do the heavy lifting.

The graph for Firefox for iOS is configured in `FxScreenGraph` and the Firefox independent code is in `ScreenGraph`.