### PR TITLE
Bug 1324557 - Collect stats for sync engines for telemetry (excluding bookmarks)

### DIFF
--- a/Account/FxADeviceRegistration.swift
+++ b/Account/FxADeviceRegistration.swift
@@ -37,7 +37,7 @@ public enum FxADeviceRegistratorError: MaybeErrorType {
 open class FxADeviceRegistration: NSObject, NSCoding {
     /// The device identifier identifying this device.  A device is uniquely identified
     /// across the lifetime of a Firefox Account.
-    let id: String
+    public let id: String
 
     /// The version of the device registration. We use this to re-register
     /// devices after we update what we send on device registration.

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -673,6 +673,7 @@
 		E6C70E821E28314700F8DB57 /* PingCentreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C70E811E28314700F8DB57 /* PingCentreTests.swift */; };
 		E6C9EB6B1E2FBFC300D5CE80 /* signedInUser.json in Resources */ = {isa = PBXBuildFile; fileRef = E6C9EB6A1E2FBFC300D5CE80 /* signedInUser.json */; };
 		E6CF28E71CB43B7900151AB3 /* SensitiveViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CF28E61CB43B7900151AB3 /* SensitiveViewController.swift */; };
+		E6D60FE31E0B08A000674605 /* SyncTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D60FE21E0B08A000674605 /* SyncTelemetry.swift */; };
 		E6D7C32B1CF4E86C00E746BA /* TestBookmarkModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D7C31C1CF4E68D00E746BA /* TestBookmarkModel.swift */; };
 		E6D8D5E71B569D70009E5A58 /* BrowserTrayAnimators.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D8D5E61B569D70009E5A58 /* BrowserTrayAnimators.swift */; };
 		E6EAC5961B29CB3A00E1DE1E /* scrollablePage.html in Resources */ = {isa = PBXBuildFile; fileRef = E6EAC5951B29CB3A00E1DE1E /* scrollablePage.html */; };
@@ -1814,6 +1815,7 @@
 		E6C70E811E28314700F8DB57 /* PingCentreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PingCentreTests.swift; sourceTree = "<group>"; };
 		E6C9EB6A1E2FBFC300D5CE80 /* signedInUser.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = signedInUser.json; sourceTree = "<group>"; };
 		E6CF28E61CB43B7900151AB3 /* SensitiveViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SensitiveViewController.swift; sourceTree = "<group>"; };
+		E6D60FE21E0B08A000674605 /* SyncTelemetry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncTelemetry.swift; sourceTree = "<group>"; };
 		E6D7C31C1CF4E68D00E746BA /* TestBookmarkModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestBookmarkModel.swift; path = SyncTests/TestBookmarkModel.swift; sourceTree = "<group>"; };
 		E6D8D5E61B569D70009E5A58 /* BrowserTrayAnimators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserTrayAnimators.swift; sourceTree = "<group>"; };
 		E6DCC1ED1DCBB6AA00CEC4B7 /* FennecEnterprise.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = FennecEnterprise.xcconfig; path = Configuration/FennecEnterprise.xcconfig; sourceTree = "<group>"; };
@@ -2265,6 +2267,7 @@
 				2F3724E31ABF3C19007607FA /* StorageClient.swift */,
 				28E91E741B443AD5009DF274 /* SyncConstants.swift */,
 				2885023E1AC117A500E7F670 /* SyncStateMachine.swift */,
+				E6D60FE21E0B08A000674605 /* SyncTelemetry.swift */,
 				288501DD1AC0F61D00E7F670 /* RequestExtensions.swift */,
 			);
 			path = Sync;
@@ -4631,6 +4634,7 @@
 				2827319D1ABC9C2F00AA1954 /* SyncMeta.swift in Sources */,
 				2894C1661AE89DD200F1F92F /* TabsSynchronizer.swift in Sources */,
 				282731991ABC9C2F00AA1954 /* ClientPayload.swift in Sources */,
+				E6D60FE31E0B08A000674605 /* SyncTelemetry.swift in Sources */,
 				E67D57031D527449003917B1 /* BatchingClient.swift in Sources */,
 				2894C1431AE89D8900F1F92F /* HistorySynchronizer.swift in Sources */,
 				28E23C121AC5A5EE00F5AC85 /* State.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -638,6 +638,7 @@
 		E663D5781BB341C4001EF30E /* ToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E663D5771BB341C4001EF30E /* ToggleButton.swift */; };
 		E664B45A1CD7ECDB0045A6A4 /* NotificationRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E664B4591CD7ECDB0045A6A4 /* NotificationRootViewController.swift */; };
 		E66C5B481BDA81050051AA93 /* UIImage+ImageEffects.m in Sources */ = {isa = PBXBuildFile; fileRef = E66C5B471BDA81050051AA93 /* UIImage+ImageEffects.m */; };
+		E67035EE1E538B500037AB83 /* Mocking.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67035ED1E538B500037AB83 /* Mocking.swift */; };
 		E67422C51CFF2D39009E8373 /* youtube.ico in Resources */ = {isa = PBXBuildFile; fileRef = E67422C41CFF2D39009E8373 /* youtube.ico */; };
 		E677F0451D9423FB00ECF1FB /* SQLiteMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = E677F0441D9423FB00ECF1FB /* SQLiteMetadata.swift */; };
 		E677F0541D94247300ECF1FB /* Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = E677F0531D94247300ECF1FB /* Metadata.swift */; };
@@ -666,6 +667,7 @@
 		E6B4C3D81C68F55C001F97E8 /* JSPrompt.html in Resources */ = {isa = PBXBuildFile; fileRef = E6B4C3D71C68F55C001F97E8 /* JSPrompt.html */; };
 		E6B4C4031C68F58B001F97E8 /* BrowserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B4C4021C68F58B001F97E8 /* BrowserTests.swift */; };
 		E6B6DCA21CD3D370009CF713 /* CrashReporter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6B6DC941CD3D35A009CF713 /* CrashReporter.framework */; };
+		E6BA20211E52170E00697F9C /* SyncTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BA20111E52165800697F9C /* SyncTelemetryTests.swift */; };
 		E6BE53CD1D9177B10074909A /* TestSQLiteHistoryRecommendations.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BE53CC1D9177B10074909A /* TestSQLiteHistoryRecommendations.swift */; };
 		E6C191F11E38F810000A213B /* libPhoneNumberiOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6C191F01E38F7EE000A213B /* libPhoneNumberiOS.framework */; };
 		E6C70E171E2830CC00F8DB57 /* PingCentre.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C70E151E2830CC00F8DB57 /* PingCentre.swift */; };
@@ -1777,6 +1779,7 @@
 		E664B4591CD7ECDB0045A6A4 /* NotificationRootViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NotificationRootViewController.swift; path = Notifications/NotificationRootViewController.swift; sourceTree = "<group>"; };
 		E66C5B461BDA81050051AA93 /* UIImage+ImageEffects.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+ImageEffects.h"; sourceTree = "<group>"; };
 		E66C5B471BDA81050051AA93 /* UIImage+ImageEffects.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+ImageEffects.m"; sourceTree = "<group>"; };
+		E67035ED1E538B500037AB83 /* Mocking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mocking.swift; sourceTree = "<group>"; };
 		E67422C41CFF2D39009E8373 /* youtube.ico */ = {isa = PBXFileReference; lastKnownFileType = image.ico; path = youtube.ico; sourceTree = "<group>"; };
 		E677F0441D9423FB00ECF1FB /* SQLiteMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLiteMetadata.swift; sourceTree = "<group>"; };
 		E677F0531D94247300ECF1FB /* Metadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Metadata.swift; sourceTree = "<group>"; };
@@ -1806,6 +1809,7 @@
 		E6B4C3D71C68F55C001F97E8 /* JSPrompt.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = JSPrompt.html; sourceTree = "<group>"; };
 		E6B4C4021C68F58B001F97E8 /* BrowserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserTests.swift; sourceTree = "<group>"; };
 		E6B6DC941CD3D35A009CF713 /* CrashReporter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CrashReporter.framework; sourceTree = "<group>"; };
+		E6BA20111E52165800697F9C /* SyncTelemetryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SyncTelemetryTests.swift; path = StorageTests/SyncTelemetryTests.swift; sourceTree = "<group>"; };
 		E6BE53CC1D9177B10074909A /* TestSQLiteHistoryRecommendations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSQLiteHistoryRecommendations.swift; sourceTree = "<group>"; };
 		E6C191D41E38F7B7000A213B /* Cartfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
 		E6C191D51E38F7B7000A213B /* Cartfile.resolved */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.resolved; sourceTree = "<group>"; };
@@ -2234,10 +2238,12 @@
 				2F3724C41ABF3C01007607FA /* LiveStorageClientTests.swift */,
 				2F67C5251BB0CB4E00E7B73A /* MetaGlobalTests.swift */,
 				2F8C76561BC32F3C00D5E4E0 /* MockSyncServerTests.swift */,
+				E67035ED1E538B500037AB83 /* Mocking.swift */,
 				28C0779D1A3B066000834FE5 /* RecordTests.swift */,
 				50027345B49B967409DDA348 /* StateTests.swift */,
 				E6EDE81D1D524475007A0732 /* BatchingClientTests.swift */,
 				2F3724C51ABF3C01007607FA /* StorageClientTests.swift */,
+				E6BA20111E52165800697F9C /* SyncTelemetryTests.swift */,
 			);
 			name = SyncTests;
 			sourceTree = "<group>";
@@ -4666,6 +4672,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E6BA20211E52170E00697F9C /* SyncTelemetryTests.swift in Sources */,
 				28ECD97A1BA1EA2200D829DA /* MockSyncServer.swift in Sources */,
 				285D37E31ABCA69E000E1CF9 /* CryptoTests.swift in Sources */,
 				28F596A11ACA13CA0071DDCC /* InfoTests.swift in Sources */,
@@ -4674,6 +4681,7 @@
 				2F3724C61ABF3C01007607FA /* LiveStorageClientTests.swift in Sources */,
 				E6EDE82C1D5244AF007A0732 /* BatchingClientTests.swift in Sources */,
 				28D980231C47149000277055 /* TestBookmarkTreeMerging.swift in Sources */,
+				E67035EE1E538B500037AB83 /* Mocking.swift in Sources */,
 				289A4C141C4EB90600A460E3 /* StorageTestUtils.swift in Sources */,
 				28532CC11C473977000072D9 /* MockFiles.swift in Sources */,
 				E6D7C32B1CF4E86C00E746BA /* TestBookmarkModel.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -396,7 +396,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         })
 
         if profile.hasSyncableAccount() {
-            profile.syncManager.syncEverything().uponQueue(DispatchQueue.main) { _ in
+            profile.syncManager.syncEverything(why: .backgrounded).uponQueue(DispatchQueue.main) { _ in
                 self.shutdownProfileWhenNotActive(application)
                 application.endBackgroundTask(taskId)
             }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -218,7 +218,7 @@ class SyncNowSetting: WithAccountSetting {
 
     override func onClick(_ navigationController: UINavigationController?) {
         NotificationCenter.default.post(name: Notification.Name(rawValue: SyncNowSetting.NotificationUserInitiatedSyncManually), object: nil)
-        profile.syncManager.syncEverything()
+        profile.syncManager.syncEverything(why: .user)
     }
 }
 

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -218,7 +218,7 @@ class SyncNowSetting: WithAccountSetting {
 
     override func onClick(_ navigationController: UINavigationController?) {
         NotificationCenter.default.post(name: Notification.Name(rawValue: SyncNowSetting.NotificationUserInitiatedSyncManually), object: nil)
-        profile.syncManager.syncEverything(why: .user)
+        profile.syncManager.syncEverything(why: .syncNow)
     }
 }
 

--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -25,10 +25,10 @@ open class MockSyncManager: SyncManager {
         return deferMaybe(SyncStatus.completed(SyncEngineStatsSession(collection: collection)))
     }
     
-    open func syncClients() -> SyncResult { return completedWithStats("clients") }
-    open func syncClientsThenTabs() -> SyncResult { return completedWithStats("clientsandtabs") }
-    open func syncHistory() -> SyncResult { return completedWithStats("history") }
-    open func syncLogins() -> SyncResult { return completedWithStats("logins") }
+    open func syncClients() -> SyncResult { return completedWithStats("mock_clients") }
+    open func syncClientsThenTabs() -> SyncResult { return completedWithStats("mock_clientsandtabs") }
+    open func syncHistory() -> SyncResult { return completedWithStats("mock_history") }
+    open func syncLogins() -> SyncResult { return completedWithStats("mock_logins") }
     open func syncEverything(why: SyncReason) -> Success {
         return succeed()
     }

--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -21,11 +21,15 @@ open class MockSyncManager: SyncManager {
         return deferMaybe(true)
     }
 
-    open func syncClients() -> SyncResult { return deferMaybe(.completed) }
-    open func syncClientsThenTabs() -> SyncResult { return deferMaybe(.completed) }
-    open func syncHistory() -> SyncResult { return deferMaybe(.completed) }
-    open func syncLogins() -> SyncResult { return deferMaybe(.completed) }
-    open func syncEverything() -> Success {
+    private func completedWithStats(collection: String) -> Deferred<Maybe<SyncStatus>> {
+        return deferMaybe(SyncStatus.completed(SyncEngineStatsSession(collection: collection)))
+    }
+    
+    open func syncClients() -> SyncResult { return completedWithStats("clients") }
+    open func syncClientsThenTabs() -> SyncResult { return completedWithStats("clientsandtabs") }
+    open func syncHistory() -> SyncResult { return completedWithStats("history") }
+    open func syncLogins() -> SyncResult { return completedWithStats("logins") }
+    open func syncEverything(why: SyncReason) -> Success {
         return succeed()
     }
 

--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -25,10 +25,10 @@ open class MockSyncManager: SyncManager {
         return deferMaybe(SyncStatus.completed(SyncEngineStatsSession(collection: collection)))
     }
     
-    open func syncClients() -> SyncResult { return completedWithStats("mock_clients") }
-    open func syncClientsThenTabs() -> SyncResult { return completedWithStats("mock_clientsandtabs") }
-    open func syncHistory() -> SyncResult { return completedWithStats("mock_history") }
-    open func syncLogins() -> SyncResult { return completedWithStats("mock_logins") }
+    open func syncClients() -> SyncResult { return completedWithStats(collection: "mock_clients") }
+    open func syncClientsThenTabs() -> SyncResult { return completedWithStats(collection: "mock_clientsandtabs") }
+    open func syncHistory() -> SyncResult { return completedWithStats(collection: "mock_history") }
+    open func syncLogins() -> SyncResult { return completedWithStats(collection: "mock_logins") }
     open func syncEverything(why: SyncReason) -> Success {
         return succeed()
     }

--- a/ClientTests/SyncStatusResolverTests.swift
+++ b/ClientTests/SyncStatusResolverTests.swift
@@ -15,10 +15,14 @@ private class RandomError: MaybeErrorType {
 
 class SyncStatusResolverTests: XCTestCase {
 
+    private func mockStatsForCollection(collection: String) -> SyncEngineStatsSession {
+        return SyncEngineStatsSession(collection: collection)
+    }
+
     func testAllCompleted() {
         let results: EngineResults = [
-            ("tabs", .completed),
-            ("clients", .completed)
+            ("tabs", .completed(mockStatsForCollection("tabs"))),
+            ("clients", .completed(mockStatsForCollection("clients")))
         ]
         let maybeResults = Maybe(success: results)
 
@@ -28,7 +32,7 @@ class SyncStatusResolverTests: XCTestCase {
 
     func testAllCompletedExceptOneDisabledRemotely() {
         let results: EngineResults = [
-            ("tabs", .completed),
+            ("tabs", .completed(mockStatsForCollection("tabs"))),
             ("clients", .notStarted(.engineRemotelyNotEnabled(collection: "clients")))
         ]
         let maybeResults = Maybe(success: results)
@@ -39,7 +43,7 @@ class SyncStatusResolverTests: XCTestCase {
 
     func testAllCompletedExceptNotStartedBecauseNoAccount() {
         let results: EngineResults = [
-            ("tabs", .completed),
+            ("tabs", .completed(mockStatsForCollection("tabs"))),
             ("clients", .notStarted(.noAccount))
         ]
         let maybeResults = Maybe(success: results)
@@ -50,7 +54,7 @@ class SyncStatusResolverTests: XCTestCase {
 
     func testAllCompletedExceptNotStartedBecauseOffline() {
         let results: EngineResults = [
-            ("tabs", .completed),
+            ("tabs", .completed(mockStatsForCollection("tabs"))),
             ("clients", .notStarted(.offline))
         ]
         let maybeResults = Maybe(success: results)

--- a/ClientTests/SyncStatusResolverTests.swift
+++ b/ClientTests/SyncStatusResolverTests.swift
@@ -21,8 +21,8 @@ class SyncStatusResolverTests: XCTestCase {
 
     func testAllCompleted() {
         let results: EngineResults = [
-            ("tabs", .completed(mockStatsForCollection("tabs"))),
-            ("clients", .completed(mockStatsForCollection("clients")))
+            ("tabs", .completed(mockStatsForCollection(collection: "tabs"))),
+            ("clients", .completed(mockStatsForCollection(collection: "clients")))
         ]
         let maybeResults = Maybe(success: results)
 
@@ -32,7 +32,7 @@ class SyncStatusResolverTests: XCTestCase {
 
     func testAllCompletedExceptOneDisabledRemotely() {
         let results: EngineResults = [
-            ("tabs", .completed(mockStatsForCollection("tabs"))),
+            ("tabs", .completed(mockStatsForCollection(collection: "tabs"))),
             ("clients", .notStarted(.engineRemotelyNotEnabled(collection: "clients")))
         ]
         let maybeResults = Maybe(success: results)
@@ -43,7 +43,7 @@ class SyncStatusResolverTests: XCTestCase {
 
     func testAllCompletedExceptNotStartedBecauseNoAccount() {
         let results: EngineResults = [
-            ("tabs", .completed(mockStatsForCollection("tabs"))),
+            ("tabs", .completed(mockStatsForCollection(collection: "tabs"))),
             ("clients", .notStarted(.noAccount))
         ]
         let maybeResults = Maybe(success: results)
@@ -54,7 +54,7 @@ class SyncStatusResolverTests: XCTestCase {
 
     func testAllCompletedExceptNotStartedBecauseOffline() {
         let results: EngineResults = [
-            ("tabs", .completed(mockStatsForCollection("tabs"))),
+            ("tabs", .completed(mockStatsForCollection(collection: "tabs"))),
             ("clients", .notStarted(.offline))
         ]
         let maybeResults = Maybe(success: results)

--- a/Mocking.swift
+++ b/Mocking.swift
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import SwiftyJSON
+@testable import Sync
+
+class MockBackoffStorage: BackoffStorage {
+    var serverBackoffUntilLocalTimestamp: Timestamp?
+
+    func clearServerBackoff() {
+        serverBackoffUntilLocalTimestamp = nil
+    }
+
+    func isInBackoff(_ now: Timestamp) -> Timestamp? {
+        return nil
+    }
+}
+
+class MockSyncCollectionClient<T: CleartextPayloadJSON>: Sync15CollectionClient<T> {
+    let uploader: BatchUploadFunction
+    let infoConfig: InfoConfiguration
+
+    init(uploader: @escaping BatchUploadFunction,
+         infoConfig: InfoConfiguration,
+         collection: String,
+         encrypter: RecordEncrypter<T>,
+         client: Sync15StorageClient = getClient(server: getServer(preStart: { _ in })),
+         serverURI: URL = URL(string: "http://localhost/collections")!)
+    {
+        self.uploader = uploader
+        self.infoConfig = infoConfig
+        super.init(client: client, serverURI: serverURI, collection: collection, encrypter: encrypter)
+    }
+    
+    override func newBatch(ifUnmodifiedSince: Timestamp? = nil, onCollectionUploaded: @escaping (POSTResult, Timestamp?) -> DeferredTimestamp) -> Sync15BatchClient<T> {
+        let infoConfig = InfoConfiguration(maxRequestBytes: 1000,
+                                           maxPostRecords: 10,
+                                           maxPostBytes: 1000,
+                                           maxTotalRecords: 10,
+                                           maxTotalBytes: 1000)
+        return Sync15BatchClient(config: infoConfig,
+                                 ifUnmodifiedSince: ifUnmodifiedSince,
+                                 serializeRecord: self.serializeRecord,
+                                 uploader: self.uploader,
+                                 onCollectionUploaded: onCollectionUploaded)
+    }
+}
+
+// MARK: Various mocks
+
+// Non-encrypting 'encrypter'.
+func getEncrypter() -> RecordEncrypter<CleartextPayloadJSON> {
+    let serializer: (Record<CleartextPayloadJSON>) -> JSON? = { $0.payload.json }
+    let factory: (String) -> CleartextPayloadJSON = { CleartextPayloadJSON($0) }
+    return RecordEncrypter(serializer: serializer, factory: factory)
+}
+
+func getClient(server: MockSyncServer) -> Sync15StorageClient {
+    let url = server.baseURL.asURL!
+    let authorizer: Authorizer = identity
+    let queue = DispatchQueue.global(qos: DispatchQoS.background.qosClass)
+    
+    return Sync15StorageClient(serverURI: url, authorizer: authorizer, workQueue: queue, resultQueue: queue, backoff: MockBackoffStorage())
+}
+
+func getServer(username: String = "1234567", preStart: (MockSyncServer) -> Void) -> MockSyncServer {
+    let server = MockSyncServer(username: username)
+    preStart(server)
+    server.start()
+    return server
+}

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -1202,8 +1202,7 @@ open class BrowserProfile: Profile {
             }
             
             return readyDeferred >>== self.takeActionsOnEngineStateChanges >>== { ready in
-                // Once we are ready and have a server timestamp to begin our session, start recording
-                statsSession.start(time: ready.infoMetadata.timestampMilliseconds)
+                statsSession.start()
                 return function(delegate, self.prefsForSync, ready)
             }
         }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -701,20 +701,7 @@ open class BrowserProfile: Profile {
         }
 
         fileprivate func reportSyncPingForResult(opResult: SyncOperationResult) {
-            if let opStats = opResult.stats {
-                print("operation: \(opStats)")
-            }
-            
-            if let engineResults = opResult.engineResults.successValue {
-                engineResults.forEach { collection, status in
-                    switch status {
-                    case .completed(let stats):
-                        print("collection: \(collection), stats: \(stats)")
-                    default:
-                        break
-                    }
-                }
-            }
+            // TODO: Send sync report to telemetry client for storage/sending
         }
 
         fileprivate func reportAdHocEndSyncingStatus(displayState: SyncDisplayState?, engineResults: Maybe<EngineResults>?) {

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -199,4 +199,21 @@ public struct AppConstants {
             return true
         #endif
     }()
+
+    /// Toggles reporting our ad-hoc bookmark sync ping
+    public static let MOZ_ADHOC_SYNC_REPORTING: Bool = {
+        #if MOZ_CHANNEL_RELEASE
+            return false
+        #elseif MOZ_CHANNEL_BETA
+            return false
+        #elseif MOZ_CHANNEL_NIGHTLY
+            return true
+        #elseif MOZ_CHANNEL_FENNEC
+            return true
+        #elseif MOZ_CHANNEL_AURORA
+            return true
+        #else
+            return true
+        #endif
+    }()
 }

--- a/Storage/RemoteTabs.swift
+++ b/Storage/RemoteTabs.swift
@@ -39,8 +39,8 @@ public protocol RemoteClientsAndTabs: SyncCommands {
     func getClients() -> Deferred<Maybe<[RemoteClient]>>
     func getClientsAndTabs() -> Deferred<Maybe<[ClientAndTabs]>>
     func getTabsForClientWithGUID(_ guid: GUID?) -> Deferred<Maybe<[RemoteTab]>>
-    func insertOrUpdateClient(_ client: RemoteClient) -> Deferred<Maybe<()>>
-    func insertOrUpdateClients(_ clients: [RemoteClient]) -> Deferred<Maybe<()>>
+    func insertOrUpdateClient(_ client: RemoteClient) -> Deferred<Maybe<Int>>
+    func insertOrUpdateClients(_ clients: [RemoteClient]) -> Deferred<Maybe<Int>>
 
     // Returns number of tabs inserted.
     func insertOrUpdateTabs(_ tabs: [RemoteTab]) -> Deferred<Maybe<Int>> // Insert into the local client.

--- a/Storage/SQL/GenericTable.swift
+++ b/Storage/SQL/GenericTable.swift
@@ -6,7 +6,7 @@ import Foundation
 import XCGLogger
 import Shared
 
-fileprivate let log = Logger.syncLogger
+private let log = Logger.syncLogger
 
 // A protocol for information about a particular table. This is used as a type to be stored by TableTable.
 protocol TableInfo {

--- a/Storage/SQL/GenericTable.swift
+++ b/Storage/SQL/GenericTable.swift
@@ -6,7 +6,7 @@ import Foundation
 import XCGLogger
 import Shared
 
-private let log = Logger.syncLogger
+fileprivate let log = Logger.syncLogger
 
 // A protocol for information about a particular table. This is used as a type to be stored by TableTable.
 protocol TableInfo {

--- a/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
+++ b/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
@@ -104,14 +104,16 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
         return deferred
     }
 
-    open func insertOrUpdateClients(_ clients: [RemoteClient]) -> Deferred<Maybe<()>> {
-        let deferred = Deferred<Maybe<()>>(defaultQueue: DispatchQueue.main)
+    open func insertOrUpdateClients(_ clients: [RemoteClient]) -> Deferred<Maybe<Int>> {
+        let deferred = Deferred<Maybe<Int>>(defaultQueue: DispatchQueue.main)
 
         var err: NSError?
 
         // TODO: insert multiple clients in a single query.
         // ORM systems are foolish.
         let _ = db.transaction(&err) { connection, _ in
+            var succeeded = 0
+
             // Update or insert client records.
             for client in clients {
 
@@ -125,17 +127,19 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
                     log.warning("insertOrUpdateClients failed: \(databaseError)")
                     deferred.fill(Maybe(failure: databaseError))
                     return false
+                } else {
+                    succeeded += 1
                 }
             }
 
-            deferred.fill(Maybe(success: ()))
+            deferred.fill(Maybe(success: succeeded))
             return true
         }
 
         return deferred
     }
 
-    open func insertOrUpdateClient(_ client: RemoteClient) -> Deferred<Maybe<()>> {
+    open func insertOrUpdateClient(_ client: RemoteClient) -> Deferred<Maybe<Int>> {
         return insertOrUpdateClients([client])
     }
 

--- a/StorageTests/SyncTelemetryTests.swift
+++ b/StorageTests/SyncTelemetryTests.swift
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import SwiftyJSON
+@testable import Sync
+
+import XCTest
+
+fileprivate class MockFailure<T: CleartextPayloadJSON>: MaybeErrorType {
+    let record: Record<T>
+
+    var description: String {
+        return "Failed to store or upload record: \(record)"
+    }
+
+    init(record: Record<T>) {
+        self.record = record
+    }
+}
+
+class SyncTelemetryTests: XCTestCase {
+}
+
+// MARK: IndependentRecordSynchronizer
+extension SyncTelemetryTests {
+    private func getMockedIndependentRecordSynchronizer() -> IndependentRecordSynchronizer {
+        let prefs = MockProfilePrefs()
+        let scratchpad = Scratchpad(b: KeyBundle.random(), persistingTo: prefs)
+        let delegate = MockSyncDelegate()
+
+        return IndependentRecordSynchronizer(scratchpad: scratchpad, delegate: delegate, basePrefs: prefs, collection: "mockHistory")
+    }
+
+    func testApplyIncomingRecordsReportsDownloadStats() {
+        let synchronizer = getMockedIndependentRecordSynchronizer()
+        synchronizer.statsSession.start()
+
+        // Fake remote records for incoming changes
+        let payloadA = CleartextPayloadJSON("{\"id\":\"A\",\"title\": \"A\"}")
+        let A = Record<CleartextPayloadJSON>(id: "A", payload: payloadA)
+
+        let payloadB = CleartextPayloadJSON("{\"id\":\"B\",\"title\": \"B\"}")
+        let B = Record<CleartextPayloadJSON>(id: "B", payload: payloadB)
+
+        let remoteRecords = [A, B]
+
+        let _ = synchronizer.applyIncomingRecords(remoteRecords) { record in
+            return record.id == "B" ? deferMaybe(MockFailure(record: record)) : succeed()
+        }.value
+
+        let session = synchronizer.statsSession.end()
+
+        let downloadStats = session.downloadStats
+        XCTAssertEqual(downloadStats.applied, 2)
+        XCTAssertEqual(downloadStats.succeeded, 1)
+        XCTAssertEqual(downloadStats.failed, 1)
+    }
+
+    func testApplyIncomingRecordsToStorageReportsDownloadStats() {
+        let synchronizer = getMockedIndependentRecordSynchronizer()
+        synchronizer.statsSession.start()
+
+        // Fake remote records for incoming changes
+        let payloadA = CleartextPayloadJSON("{\"id\":\"A\",\"title\": \"A\"}")
+        let A = Record<CleartextPayloadJSON>(id: "A", payload: payloadA)
+
+        let payloadB = CleartextPayloadJSON("{\"id\":\"B\",\"title\": \"B\"}")
+        let B = Record<CleartextPayloadJSON>(id: "B", payload: payloadB)
+
+        let records = [A, B]
+
+        let _ = synchronizer.applyIncomingToStorage(records, fetched: Date.now()) { record in
+            return record.id == "B" ? deferMaybe(MockFailure(record: record)) : succeed()
+        }.value
+
+        let session = synchronizer.statsSession.end()
+
+        let downloadStats = session.downloadStats
+        XCTAssertEqual(downloadStats.applied, 2)
+        XCTAssertEqual(downloadStats.succeeded, 1)
+        XCTAssertEqual(downloadStats.failed, 1)
+    }
+
+    func testUploadRecordsReportsUploadStats() {
+        let synchronizer = getMockedIndependentRecordSynchronizer()
+        synchronizer.statsSession.start()
+
+        let now = Date.now()
+
+        // Fake local records for outgoing changes
+        let payloadC = CleartextPayloadJSON("{\"id\":\"C\",\"title\": \"C\"}")
+        let C = Record<CleartextPayloadJSON>(id: "C", payload: payloadC)
+
+        let payloadD = CleartextPayloadJSON("{\"id\":\"D\", \"title\": \"D\"}")
+        let D = Record<CleartextPayloadJSON>(id: "D", payload: payloadD)
+        let records = [C, D]
+
+        // Mock out a response for the uploader
+        let uploader: BatchUploadFunction = { _, _, _ in
+            let result = POSTResult(success: [C.id], failed: [D.id: "Invalid GUID"])
+            let response = StorageResponse<POSTResult>(value: result, metadata: ResponseMetadata(status: 200, headers: [:]))
+            return deferMaybe(response)
+        }
+
+        let miniConfig = InfoConfiguration(maxRequestBytes: 1_048_576, maxPostRecords: 2, maxPostBytes: 1_048_576, maxTotalRecords: 10, maxTotalBytes: 104_857_600)
+        let collectionClient = MockSyncCollectionClient(uploader: uploader, infoConfig: miniConfig, collection: "mockdata", encrypter: getEncrypter())
+        let _ = synchronizer.uploadRecords(records, lastTimestamp: now, storageClient: collectionClient) { _, _ in
+            return deferMaybe(now)
+        }.value
+
+        let uploadStats = synchronizer.statsSession.uploadStats
+        XCTAssertEqual(uploadStats.sent, 1)
+        XCTAssertEqual(uploadStats.sentFailed, 1)
+    }
+}

--- a/StorageTests/TestSQLiteRemoteClientsAndTabs.swift
+++ b/StorageTests/TestSQLiteRemoteClientsAndTabs.swift
@@ -58,12 +58,12 @@ open class MockRemoteClientsAndTabs: RemoteClientsAndTabs {
         return succeed()
     }
 
-    open func insertOrUpdateClients(_ clients: [RemoteClient]) -> Success {
-        return succeed()
+    open func insertOrUpdateClients(_ clients: [RemoteClient]) -> Deferred<Maybe<Int>> {
+        return deferMaybe(0)
     }
 
-    open func insertOrUpdateClient(_ client: RemoteClient) -> Success {
-        return succeed()
+    open func insertOrUpdateClient(_ client: RemoteClient) -> Deferred<Maybe<Int>> {
+        return deferMaybe(0)
     }
 
     open func insertOrUpdateTabs(_ tabs: [RemoteTab]) -> Deferred<Maybe<Int>> {

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -220,10 +220,8 @@ open class BaseSyncState: SyncState {
     var scratchpad: Scratchpad
 
     // TODO: 304 for i/c.
-    open func getInfoCollections() -> Deferred<Maybe<InfoCollections>> {
-        return chain(self.client.getInfoCollections(), f: {
-            return $0.value
-        })
+    open func getInfoCollectionResponse() -> Deferred<Maybe<StorageResponse<InfoCollections>>> {
+        return self.client.getInfoCollections()
     }
 
     public init(client: Sync15StorageClient, scratchpad: Scratchpad, token: TokenServerToken) {
@@ -255,15 +253,23 @@ open class BaseSyncState: SyncState {
 }
 
 open class BaseSyncStateWithInfo: BaseSyncState {
-    open let info: InfoCollections
+    open var info: InfoCollections {
+        return infoCollectionsResponse.value
+    }
 
-    init(client: Sync15StorageClient, scratchpad: Scratchpad, token: TokenServerToken, info: InfoCollections) {
-        self.info = info
+    open var infoMetadata: ResponseMetadata {
+        return infoCollectionsResponse.metadata
+    }
+
+    fileprivate let infoCollectionsResponse: StorageResponse<InfoCollections>
+
+    init(client: Sync15StorageClient, scratchpad: Scratchpad, token: TokenServerToken, infoCollectionsResponse: StorageResponse<InfoCollections>) {
+        self.infoCollectionsResponse = infoCollectionsResponse
         super.init(client: client, scratchpad: scratchpad, token: token)
     }
 
-    init(scratchpad: Scratchpad, token: TokenServerToken, info: InfoCollections) {
-        self.info = info
+    init(scratchpad: Scratchpad, token: TokenServerToken, infoCollectionsResponse: StorageResponse<InfoCollections>) {
+        self.infoCollectionsResponse = infoCollectionsResponse
         super.init(scratchpad: scratchpad, token: token)
     }
 }
@@ -377,7 +383,7 @@ open class SyncIDChangedError: RecoverableSyncState {
     open func advance() -> Deferred<Maybe<SyncState>> {
         // TODO: mutate local storage to allow for a fresh start.
         let s = self.previousState.scratchpad.evolve().setGlobal(self.newMetaGlobal).setKeys(nil).build().checkpoint()
-        let state = HasMetaGlobal(client: self.previousState.client, scratchpad: s, token: self.previousState.token, info: self.previousState.info)
+        let state = HasMetaGlobal(client: self.previousState.client, scratchpad: s, token: self.previousState.token, infoCollectionsResponse: self.previousState.infoCollectionsResponse)
         return deferMaybe(state)
     }
 }
@@ -509,12 +515,12 @@ open class InitialWithLiveToken: BaseSyncState {
         super.init(client: client, scratchpad: scratchpad, token: token)
     }
 
-    func advanceWithInfo(_ info: InfoCollections) -> SyncState {
-        return InitialWithLiveTokenAndInfo(scratchpad: self.scratchpad, token: self.token, info: info)
+    func advanceWithInfo(_ infoCollectionsResponse: StorageResponse<InfoCollections>) -> SyncState {
+        return InitialWithLiveTokenAndInfo(scratchpad: self.scratchpad, token: self.token, infoCollectionsResponse: infoCollectionsResponse)
     }
 
     override open func advance() -> Deferred<Maybe<SyncState>> {
-        return chain(getInfoCollections(), f: self.advanceWithInfo)
+        return chain(getInfoCollectionResponse(), f: self.advanceWithInfo)
     }
 }
 
@@ -537,14 +543,16 @@ open class InitialWithLiveToken: BaseSyncState {
 open class ResolveMetaGlobalVersion: BaseSyncStateWithInfo {
     let fetched: Fetched<MetaGlobal>
 
-    init(fetched: Fetched<MetaGlobal>, client: Sync15StorageClient, scratchpad: Scratchpad, token: TokenServerToken, info: InfoCollections) {
+    init(fetched: Fetched<MetaGlobal>, client: Sync15StorageClient, scratchpad: Scratchpad,
+         token: TokenServerToken, infoCollectionsResponse: StorageResponse<InfoCollections>) {
         self.fetched = fetched
-        super.init(client: client, scratchpad: scratchpad, token: token, info: info)
+        super.init(client: client, scratchpad: scratchpad, token: token, infoCollectionsResponse: infoCollectionsResponse)
     }
+
     open override var label: SyncStateLabel { return SyncStateLabel.ResolveMetaGlobalVersion }
 
     class func fromState(_ state: BaseSyncStateWithInfo, fetched: Fetched<MetaGlobal>) -> ResolveMetaGlobalVersion {
-        return ResolveMetaGlobalVersion(fetched: fetched, client: state.client, scratchpad: state.scratchpad, token: state.token, info: state.info)
+        return ResolveMetaGlobalVersion(fetched: fetched, client: state.client, scratchpad: state.scratchpad, token: state.token, infoCollectionsResponse: state.infoCollectionsResponse)
     }
 
     override open func advance() -> Deferred<Maybe<SyncState>> {
@@ -569,14 +577,16 @@ open class ResolveMetaGlobalVersion: BaseSyncStateWithInfo {
 open class ResolveMetaGlobalContent: BaseSyncStateWithInfo {
     let fetched: Fetched<MetaGlobal>
 
-    init(fetched: Fetched<MetaGlobal>, client: Sync15StorageClient, scratchpad: Scratchpad, token: TokenServerToken, info: InfoCollections) {
+    init(fetched: Fetched<MetaGlobal>, client: Sync15StorageClient, scratchpad: Scratchpad,
+         token: TokenServerToken, infoCollectionsResponse: StorageResponse<InfoCollections>) {
         self.fetched = fetched
-        super.init(client: client, scratchpad: scratchpad, token: token, info: info)
+        super.init(client: client, scratchpad: scratchpad, token: token, infoCollectionsResponse: infoCollectionsResponse)
     }
+
     open override var label: SyncStateLabel { return SyncStateLabel.ResolveMetaGlobalContent }
 
     class func fromState(_ state: BaseSyncStateWithInfo, fetched: Fetched<MetaGlobal>) -> ResolveMetaGlobalContent {
-        return ResolveMetaGlobalContent(fetched: fetched, client: state.client, scratchpad: state.scratchpad, token: state.token, info: state.info)
+        return ResolveMetaGlobalContent(fetched: fetched, client: state.client, scratchpad: state.scratchpad, token: state.token, infoCollectionsResponse: state.infoCollectionsResponse)
     }
 
     override open func advance() -> Deferred<Maybe<SyncState>> {
@@ -708,11 +718,11 @@ open class HasMetaGlobal: BaseSyncStateWithInfo {
     open override var label: SyncStateLabel { return SyncStateLabel.HasMetaGlobal }
 
     class func fromState(_ state: BaseSyncStateWithInfo) -> HasMetaGlobal {
-        return HasMetaGlobal(client: state.client, scratchpad: state.scratchpad, token: state.token, info: state.info)
+        return HasMetaGlobal(client: state.client, scratchpad: state.scratchpad, token: state.token, infoCollectionsResponse: state.infoCollectionsResponse)
     }
 
     class func fromState(_ state: BaseSyncStateWithInfo, scratchpad: Scratchpad) -> HasMetaGlobal {
-        return HasMetaGlobal(client: state.client, scratchpad: scratchpad, token: state.token, info: state.info)
+        return HasMetaGlobal(client: state.client, scratchpad: scratchpad, token: state.token, infoCollectionsResponse: state.infoCollectionsResponse)
     }
 
     override open func advance() -> Deferred<Maybe<SyncState>> {
@@ -752,12 +762,12 @@ open class NeedsFreshCryptoKeys: BaseSyncStateWithInfo {
     let staleCollectionKeys: Keys?
 
     class func fromState(_ state: BaseSyncStateWithInfo, scratchpad: Scratchpad, staleCollectionKeys: Keys?) -> NeedsFreshCryptoKeys {
-        return NeedsFreshCryptoKeys(client: state.client, scratchpad: scratchpad, token: state.token, info: state.info, keys: staleCollectionKeys)
+        return NeedsFreshCryptoKeys(client: state.client, scratchpad: scratchpad, token: state.token, infoCollectionsResponse: state.infoCollectionsResponse, keys: staleCollectionKeys)
     }
 
-    public init(client: Sync15StorageClient, scratchpad: Scratchpad, token: TokenServerToken, info: InfoCollections, keys: Keys?) {
+    public init(client: Sync15StorageClient, scratchpad: Scratchpad, token: TokenServerToken, infoCollectionsResponse: StorageResponse<InfoCollections>, keys: Keys?) {
         self.staleCollectionKeys = keys
-        super.init(client: client, scratchpad: scratchpad, token: token, info: info)
+        super.init(client: client, scratchpad: scratchpad, token: token, infoCollectionsResponse: infoCollectionsResponse)
     }
 
     override open func advance() -> Deferred<Maybe<SyncState>> {
@@ -794,16 +804,16 @@ open class HasFreshCryptoKeys: BaseSyncStateWithInfo {
     let collectionKeys: Keys
 
     class func fromState(_ state: BaseSyncStateWithInfo, scratchpad: Scratchpad, collectionKeys: Keys) -> HasFreshCryptoKeys {
-        return HasFreshCryptoKeys(client: state.client, scratchpad: scratchpad, token: state.token, info: state.info, keys: collectionKeys)
+        return HasFreshCryptoKeys(client: state.client, scratchpad: scratchpad, token: state.token, infoCollectionsResponse: state.infoCollectionsResponse, keys: collectionKeys)
     }
 
-    public init(client: Sync15StorageClient, scratchpad: Scratchpad, token: TokenServerToken, info: InfoCollections, keys: Keys) {
+    public init(client: Sync15StorageClient, scratchpad: Scratchpad, token: TokenServerToken, infoCollectionsResponse: StorageResponse<InfoCollections>, keys: Keys) {
         self.collectionKeys = keys
-        super.init(client: client, scratchpad: scratchpad, token: token, info: info)
+        super.init(client: client, scratchpad: scratchpad, token: token, infoCollectionsResponse: infoCollectionsResponse)
     }
 
     override open func advance() -> Deferred<Maybe<SyncState>> {
-        return deferMaybe(Ready(client: self.client, scratchpad: self.scratchpad, token: self.token, info: self.info, keys: self.collectionKeys))
+        return deferMaybe(Ready(client: self.client, scratchpad: self.scratchpad, token: self.token, infoCollectionsResponse: self.infoCollectionsResponse, keys: self.collectionKeys))
     }
 }
 
@@ -818,9 +828,9 @@ open class Ready: BaseSyncStateWithInfo {
     open override var label: SyncStateLabel { return SyncStateLabel.Ready }
     let collectionKeys: Keys
 
-    public init(client: Sync15StorageClient, scratchpad: Scratchpad, token: TokenServerToken, info: InfoCollections, keys: Keys) {
+    public init(client: Sync15StorageClient, scratchpad: Scratchpad, token: TokenServerToken, infoCollectionsResponse: StorageResponse<InfoCollections>, keys: Keys) {
         self.collectionKeys = keys
-        super.init(client: client, scratchpad: scratchpad, token: token, info: info)
+        super.init(client: client, scratchpad: scratchpad, token: token, infoCollectionsResponse: infoCollectionsResponse)
     }
 }
 

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -220,7 +220,7 @@ open class BaseSyncState: SyncState {
     var scratchpad: Scratchpad
 
     // TODO: 304 for i/c.
-    open func getInfoCollectionResponse() -> Deferred<Maybe<StorageResponse<InfoCollections>>> {
+    open func getInfoCollectionsResponse() -> Deferred<Maybe<StorageResponse<InfoCollections>>> {
         return self.client.getInfoCollections()
     }
 
@@ -520,7 +520,7 @@ open class InitialWithLiveToken: BaseSyncState {
     }
 
     override open func advance() -> Deferred<Maybe<SyncState>> {
-        return chain(getInfoCollectionResponse(), f: self.advanceWithInfo)
+        return chain(getInfoCollectionsResponse(), f: self.advanceWithInfo)
     }
 }
 

--- a/Sync/SyncTelemetry.swift
+++ b/Sync/SyncTelemetry.swift
@@ -1,0 +1,113 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import Account
+
+public enum SyncReason: String {
+    case Startup = "startup"
+    case Scheduled = "scheduled"
+    case Backgrounded = "backgrounded"
+    case User = "user"
+    case DidLogin = "didLogin"
+}
+
+public protocol Stats {
+    func hasData() -> Bool
+}
+
+public struct SyncUploadStats: Stats {
+    var sent: Int = 0
+    var sentFailed: Int = 0
+
+    public func hasData() -> Bool {
+        return sent > 0 || sentFailed > 0
+    }
+}
+
+public struct SyncDownloadStats: Stats {
+    var applied: Int = 0
+    var succeeded: Int = 0
+    var failed: Int = 0
+    var newFailed: Int = 0
+    var reconciled: Int = 0
+
+    public func hasData() -> Bool {
+        return applied > 0 ||
+               succeeded > 0 ||
+               failed > 0 ||
+               newFailed > 0 ||
+               reconciled > 0
+    }
+}
+
+// TODO(sleroux): Implement various bookmark validation issues we can run into
+public struct ValidationStats: Stats {
+    public func hasData() -> Bool {
+        return false
+    }
+}
+
+public class StatsSession {
+    private var took: UInt64 = 0
+    private var startTime: Timestamp?
+
+    public func start(startTime: Timestamp = NSDate.now()) {
+        self.startTime = startTime
+    }
+
+    public func end() -> Self {
+        guard let startTime = startTime else {
+            assertionFailure("SyncOperationStats called end without first calling start!")
+            return self
+        }
+
+        took = NSDate.now() - startTime
+        return self
+    }
+}
+
+// Stats about a single engine's sync
+public class SyncEngineStatsSession: StatsSession {
+    public let collection: String
+    public var failureReason: AnyObject?
+    public var validationStats: ValidationStats?
+
+    private(set) var uploadStats: SyncUploadStats
+    private(set) var downloadStats: SyncDownloadStats
+
+    public init(collection: String) {
+        self.collection = collection
+        self.uploadStats = SyncUploadStats()
+        self.downloadStats = SyncDownloadStats()
+    }
+
+    public func recordDownloadStats(stats: SyncDownloadStats) {
+        self.downloadStats.applied += stats.applied
+        self.downloadStats.succeeded += stats.succeeded
+        self.downloadStats.failed += stats.failed
+        self.downloadStats.newFailed += stats.newFailed
+        self.downloadStats.reconciled += stats.reconciled
+    }
+
+    public func recordUploadStats(stats: SyncUploadStats) {
+        self.uploadStats.sent += stats.sent
+        self.uploadStats.sentFailed += stats.sentFailed
+    }
+}
+
+// Stats and metadata for a sync operation
+public class SyncOperationStatsSession: StatsSession {
+    public let why: SyncReason
+    public var uid: String?
+    public var deviceID: String?
+
+    private let didLogin: Bool
+
+    public init(why: SyncReason) {
+        self.why = why
+        self.didLogin = why == .DidLogin
+    }
+}

--- a/Sync/SyncTelemetry.swift
+++ b/Sync/SyncTelemetry.swift
@@ -46,7 +46,7 @@ public struct SyncDownloadStats: Stats {
     }
 }
 
-// TODO(sleroux): Implement various bookmark validation issues we can run into
+// TODO(sleroux): Implement various bookmark validation issues we can run into.
 public struct ValidationStats: Stats {
     public func hasData() -> Bool {
         return false
@@ -84,7 +84,7 @@ public class StatsSession {
     }
 }
 
-// Stats about a single engine's sync
+// Stats about a single engine's sync.
 public class SyncEngineStatsSession: StatsSession {
     public let collection: String
     public var failureReason: Any?
@@ -113,7 +113,7 @@ public class SyncEngineStatsSession: StatsSession {
     }
 }
 
-// Stats and metadata for a sync operation
+// Stats and metadata for a sync operation.
 public class SyncOperationStatsSession: StatsSession {
     public let why: SyncReason
     public var uid: String?

--- a/Sync/SyncTelemetry.swift
+++ b/Sync/SyncTelemetry.swift
@@ -7,11 +7,11 @@ import Shared
 import Account
 
 public enum SyncReason: String {
-    case Startup = "startup"
-    case Scheduled = "scheduled"
-    case Backgrounded = "backgrounded"
-    case User = "user"
-    case DidLogin = "didLogin"
+    case startup = "startup"
+    case scheduled = "scheduled"
+    case backgrounded = "backgrounded"
+    case user = "user"
+    case didLogin = "didLogin"
 }
 
 public protocol Stats {
@@ -54,8 +54,8 @@ public class StatsSession {
     private var took: UInt64 = 0
     private var startTime: Timestamp?
 
-    public func start(startTime: Timestamp = Date.now()) {
-        self.startTime = startTime
+    public func start(time: Timestamp = Date.now()) {
+        self.startTime = time
     }
 
     public func end() -> Self {
@@ -84,7 +84,7 @@ public class SyncEngineStatsSession: StatsSession {
         self.downloadStats = SyncDownloadStats()
     }
 
-    public func recordDownloadStats(stats: SyncDownloadStats) {
+    public func recordDownload(stats: SyncDownloadStats) {
         self.downloadStats.applied += stats.applied
         self.downloadStats.succeeded += stats.succeeded
         self.downloadStats.failed += stats.failed
@@ -92,7 +92,7 @@ public class SyncEngineStatsSession: StatsSession {
         self.downloadStats.reconciled += stats.reconciled
     }
 
-    public func recordUploadStats(stats: SyncUploadStats) {
+    public func recordUpload(stats: SyncUploadStats) {
         self.uploadStats.sent += stats.sent
         self.uploadStats.sentFailed += stats.sentFailed
     }
@@ -108,6 +108,6 @@ public class SyncOperationStatsSession: StatsSession {
 
     public init(why: SyncReason) {
         self.why = why
-        self.didLogin = why == .DidLogin
+        self.didLogin = (why == .didLogin)
     }
 }

--- a/Sync/SyncTelemetry.swift
+++ b/Sync/SyncTelemetry.swift
@@ -59,6 +59,10 @@ public class StatsSession {
         self.startTime = time
     }
 
+    public func hasStarted() -> Bool {
+        return startTime != nil
+    }
+
     public func end() -> Self {
         guard let startTime = startTime else {
             assertionFailure("SyncOperationStats called end without first calling start!")

--- a/Sync/SyncTelemetry.swift
+++ b/Sync/SyncTelemetry.swift
@@ -54,7 +54,7 @@ public class StatsSession {
     private var took: UInt64 = 0
     private var startTime: Timestamp?
 
-    public func start(startTime: Timestamp = NSDate.now()) {
+    public func start(startTime: Timestamp = Date.now()) {
         self.startTime = startTime
     }
 
@@ -64,7 +64,7 @@ public class StatsSession {
             return self
         }
 
-        took = NSDate.now() - startTime
+        took = Date.now() - startTime
         return self
     }
 }

--- a/Sync/SyncTelemetry.swift
+++ b/Sync/SyncTelemetry.swift
@@ -54,11 +54,13 @@ public struct ValidationStats: Stats {
 }
 
 public class StatsSession {
-    private var took: UInt64 = 0
+    private var took: Int64 = 0
+    private var when: UInt64?
     private var startUptime: UInt64?
 
-    public func start(uptime: UInt64 = DispatchTime.now().uptimeNanoseconds) {
-        self.startUptime = uptime
+    public func start(when: UInt64 = Date.now()) {
+        self.when = when
+        self.startUptime = DispatchTime.now().uptimeNanoseconds
     }
 
     public func hasStarted() -> Bool {
@@ -71,15 +73,8 @@ public class StatsSession {
             return self
         }
 
-        // Check for potential clock issues to prevent an overflow if our end time is before our start time.
-        let (diff, overflowed) = UInt64.subtractWithOverflow(DispatchTime.now().uptimeNanoseconds, startUptime)
-        if overflowed {
-            log.error("Start uptime is less than end uptime! Setting took to 0.")
-            took = 0
-        } else {
-            // Round to milleseconds
-            took = diff / 1000000
-        }
+        // Casting to Int64 should be safe since we're using uptime since boot in both cases.
+        took = Int64(DispatchTime.now().uptimeNanoseconds) - Int64(startUptime)
         return self
     }
 }

--- a/Sync/SyncTelemetry.swift
+++ b/Sync/SyncTelemetry.swift
@@ -77,7 +77,7 @@ public class StatsSession {
 // Stats about a single engine's sync
 public class SyncEngineStatsSession: StatsSession {
     public let collection: String
-    public var failureReason: AnyObject?
+    public var failureReason: Any?
     public var validationStats: ValidationStats?
 
     private(set) var uploadStats: SyncUploadStats

--- a/Sync/SyncTelemetry.swift
+++ b/Sync/SyncTelemetry.swift
@@ -11,6 +11,7 @@ public enum SyncReason: String {
     case scheduled = "scheduled"
     case backgrounded = "backgrounded"
     case user = "user"
+    case syncNow = "syncNow"
     case didLogin = "didLogin"
 }
 
@@ -106,8 +107,10 @@ public class SyncOperationStatsSession: StatsSession {
 
     private let didLogin: Bool
 
-    public init(why: SyncReason) {
+    public init(why: SyncReason, uid: String, deviceID: String?) {
         self.why = why
+        self.uid = uid
+        self.deviceID = deviceID
         self.didLogin = (why == .didLogin)
     }
 }

--- a/Sync/Synchronizers/ClientsSynchronizer.swift
+++ b/Sync/Synchronizers/ClientsSynchronizer.swift
@@ -324,7 +324,7 @@ open class ClientsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchro
             >>== { succeeded in
                 downloadStats.succeeded += succeeded
                 downloadStats.failed += (toInsert.count - succeeded)
-                self.statsSession.recordDownloadStats(downloadStats)
+                self.statsSession.recordDownloadStats(stats: downloadStats)
                 return succeed()
             }
             >>== { self.processCommandsFromRecord(ours, withServer: storageClient) }

--- a/Sync/Synchronizers/ClientsSynchronizer.swift
+++ b/Sync/Synchronizers/ClientsSynchronizer.swift
@@ -278,7 +278,7 @@ open class ClientsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchro
                 } else {
                     uploadStats.sentFailed += 1
                 }
-                self.statsSession.recordUploadStats(uploadStats)
+                self.statsSession.recordUpload(stats: uploadStats)
                 return succeed()
         }
     }
@@ -324,7 +324,7 @@ open class ClientsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchro
             >>== { succeeded in
                 downloadStats.succeeded += succeeded
                 downloadStats.failed += (toInsert.count - succeeded)
-                self.statsSession.recordDownloadStats(stats: downloadStats)
+                self.statsSession.recordDownload(stats: downloadStats)
                 return succeed()
             }
             >>== { self.processCommandsFromRecord(ours, withServer: storageClient) }

--- a/Sync/Synchronizers/HistorySynchronizer.swift
+++ b/Sync/Synchronizers/HistorySynchronizer.swift
@@ -138,7 +138,7 @@ open class HistorySynchronizer: IndependentRecordSynchronizer, Synchronizer {
             })
     }
 
-    fileprivate func uploadModifiedPlaces(_ places: [(Place, [Visit])], lastTimestamp: Timestamp, fromStorage storage: SyncableHistory, withServer storageClient: Sync15CollectionClient<HistoryPayload>, inout stats: SyncUploadStats) -> DeferredTimestamp {
+    fileprivate func uploadModifiedPlaces(_ places: [(Place, [Visit])], lastTimestamp: Timestamp, fromStorage storage: SyncableHistory, withServer storageClient: Sync15CollectionClient<HistoryPayload>, stats: inout SyncUploadStats) -> DeferredTimestamp {
         log.info("Preparing upload…")
 
         // Build sequences of 1000 history items, sequence by sequence
@@ -160,7 +160,7 @@ open class HistorySynchronizer: IndependentRecordSynchronizer, Synchronizer {
         return walk(toUpload, start: start, f: perChunk)
     }
 
-    fileprivate func uploadDeletedPlaces(_ guids: [GUID], lastTimestamp: Timestamp, fromStorage storage: SyncableHistory, withServer storageClient: Sync15CollectionClient<HistoryPayload>, inout stats: SyncUploadStats) -> DeferredTimestamp {
+    fileprivate func uploadDeletedPlaces(_ guids: [GUID], lastTimestamp: Timestamp, fromStorage storage: SyncableHistory, withServer storageClient: Sync15CollectionClient<HistoryPayload>, stats: inout SyncUploadStats) -> DeferredTimestamp {
         let records = guids.map(makeDeletedHistoryRecord)
         stats.sent += records.count
         

--- a/Sync/Synchronizers/HistorySynchronizer.swift
+++ b/Sync/Synchronizers/HistorySynchronizer.swift
@@ -108,7 +108,7 @@ open class HistorySynchronizer: IndependentRecordSynchronizer, Synchronizer {
             }
 
             let placeThenVisits = storage.insertOrUpdatePlace(place, modified: modified)
-                >>> { storage.storeRemoteVisits(payload.visits, forGUID: guid) }
+                              >>> { storage.storeRemoteVisits(payload.visits, forGUID: guid) }
             return placeThenVisits.map({ result in
                 if result.isFailure {
                     let reason = result.failureValue?.description ?? "unknown reason"
@@ -142,16 +142,18 @@ open class HistorySynchronizer: IndependentRecordSynchronizer, Synchronizer {
     }
 
     fileprivate func uploadDeletedPlaces(_ guids: [GUID], lastTimestamp: Timestamp, fromStorage storage: SyncableHistory, withServer storageClient: Sync15CollectionClient<HistoryPayload>) -> DeferredTimestamp {
+
         let records = guids.map(makeDeletedHistoryRecord)
 
         // Deletions are smaller, so upload 100 at a time.
         return self.uploadRecords(records, lastTimestamp: lastTimestamp, storageClient: storageClient) { result, lastModified in
-            return storage.markAsDeleted(result.success) >>> always(lastModified ?? lastTimestamp)
+            storage.markAsDeleted(result.success) >>> always(lastModified ?? lastTimestamp)
         }
     }
 
     fileprivate func uploadOutgoingFromStorage(_ storage: SyncableHistory, lastTimestamp: Timestamp, withServer storageClient: Sync15CollectionClient<HistoryPayload>) -> Success {
         var workWasDone = false
+
         let uploadDeleted: (Timestamp) -> DeferredTimestamp = { timestamp in
             storage.getDeletedHistoryToUpload()
             >>== { guids in

--- a/Sync/Synchronizers/IndependentRecordSynchronizer.swift
+++ b/Sync/Synchronizers/IndependentRecordSynchronizer.swift
@@ -39,9 +39,9 @@ class Uploader {
 open class IndependentRecordSynchronizer: TimestampedSingleCollectionSynchronizer {
     private func reportApplyStatsWrap<T>(apply: @escaping (T) -> Success) -> (T) -> Success {
         return { record in
-            var stats = SyncDownloadStats()
-            stats.applied = 1
             return apply(record).bind({ result in
+                var stats = SyncDownloadStats()
+                stats.applied = 1
                 if result.isSuccess {
                     stats.succeeded = 1
                 } else {

--- a/Sync/Synchronizers/IndependentRecordSynchronizer.swift
+++ b/Sync/Synchronizers/IndependentRecordSynchronizer.swift
@@ -41,7 +41,6 @@ open class IndependentRecordSynchronizer: TimestampedSingleCollectionSynchronize
         return { record in
             var stats = SyncDownloadStats()
             stats.applied = 1
-
             return apply(record).bind({ result in
                 if result.isSuccess {
                     stats.succeeded = 1

--- a/Sync/Synchronizers/LoginsSynchronizer.swift
+++ b/Sync/Synchronizers/LoginsSynchronizer.swift
@@ -110,6 +110,7 @@ open class LoginsSynchronizer: IndependentRecordSynchronizer, Synchronizer {
     }
 
     fileprivate func uploadChangedRecords<T>(_ deleted: Set<GUID>, modified: Set<GUID>, records: [Record<T>], lastTimestamp: Timestamp, storage: SyncableLogins, withServer storageClient: Sync15CollectionClient<T>) -> Success {
+
         let onUpload: (POSTResult, Timestamp?) -> DeferredTimestamp = { result, lastModified in
             let uploaded = Set(result.success)
             return storage.markAsDeleted(uploaded.intersection(deleted)) >>> { storage.markAsSynchronized(uploaded.intersection(modified), modified: lastModified ?? lastTimestamp) }

--- a/Sync/Synchronizers/LoginsSynchronizer.swift
+++ b/Sync/Synchronizers/LoginsSynchronizer.swift
@@ -90,36 +90,49 @@ open class LoginsSynchronizer: IndependentRecordSynchronizer, Synchronizer {
     }
 
     func applyIncomingToStorage(_ storage: SyncableLogins, records: [Record<LoginPayload>], fetched: Timestamp) -> Success {
+        var stats = SyncDownloadStats()
+
         return self.applyIncomingToStorage(records, fetched: fetched) { rec in
+            let recordApplyResult: (Maybe<()>) -> Success = { result in
+                result.isSuccess ? (stats.succeeded += 1) : (stats.failed += 1)
+                return Deferred(value: result)
+            }
+
             let guid = rec.id
             let payload = rec.payload
 
             guard payload.isValid() else {
                 log.warning("Login record \(guid) is invalid. Skipping.")
+                stats.failed += 1
                 return succeed()
             }
 
             // We apply deletions immediately. That might not be exactly what we want -- perhaps you changed
             // a password locally after deleting it remotely -- but it's expedient.
             if payload.deleted {
-                return storage.deleteByGUID(guid, deletedAt: rec.modified)
+                return storage.deleteByGUID(guid, deletedAt: rec.modified).bind(recordApplyResult)
             }
 
-            return storage.applyChangedLogin(self.getLogin(rec))
+            stats.applied += 1
+            return storage.applyChangedLogin(self.getLogin(rec)).bind(recordApplyResult)
+                >>> effect({ self.statsSession.recordDownloadStats(stats) })
         }
     }
 
     fileprivate func uploadChangedRecords<T>(_ deleted: Set<GUID>, modified: Set<GUID>, records: [Record<T>], lastTimestamp: Timestamp, storage: SyncableLogins, withServer storageClient: Sync15CollectionClient<T>) -> Success {
 
+        var stats = SyncUploadStats()
         let onUpload: (POSTResult, Timestamp?) -> DeferredTimestamp = { result, lastModified in
+            stats.sentFailed += result.failed.count
             let uploaded = Set(result.success)
             return storage.markAsDeleted(uploaded.intersection(deleted)) >>> { storage.markAsSynchronized(uploaded.intersection(modified), modified: lastModified ?? lastTimestamp) }
         }
-
+        stats.sent += records.count
         return uploadRecords(records,
                              lastTimestamp: lastTimestamp,
                              storageClient: storageClient,
-                             onUpload: onUpload) >>> succeed
+                             onUpload: onUpload)
+            >>> effect({ self.statsSession.recordUploadStats(stats) })
     }
 
     // Find any records for which a local overlay exists. If we want to be really precise,
@@ -177,12 +190,14 @@ open class LoginsSynchronizer: IndependentRecordSynchronizer, Synchronizer {
                 NotificationCenter.default.post(name: NotificationDataRemoteLoginChangesWereApplied, object: nil)
             }
         }
+
+        statsSession.start()
         return passwordsClient.getSince(since)
             >>== applyIncomingToStorage
             // TODO: If we fetch sorted by date, we can bump the lastFetched timestamp
             // to the last successfully applied record timestamp, no matter where we fail.
             // There's no need to do the upload before bumping -- the storage of local changes is stable.
             >>> { self.uploadOutgoingFromStorage(logins, lastTimestamp: 0, withServer: passwordsClient) }
-            >>> { return deferMaybe(.completed) }
+            >>> { return deferMaybe(self.completedWithStats) }
     }
 }

--- a/Sync/Synchronizers/LoginsSynchronizer.swift
+++ b/Sync/Synchronizers/LoginsSynchronizer.swift
@@ -114,7 +114,7 @@ open class LoginsSynchronizer: IndependentRecordSynchronizer, Synchronizer {
             let uploaded = Set(result.success)
             return storage.markAsDeleted(uploaded.intersection(deleted)) >>> { storage.markAsSynchronized(uploaded.intersection(modified), modified: lastModified ?? lastTimestamp) }
         }
-        
+
         return uploadRecords(records,
                              lastTimestamp: lastTimestamp,
                              storageClient: storageClient,

--- a/Sync/Synchronizers/LoginsSynchronizer.swift
+++ b/Sync/Synchronizers/LoginsSynchronizer.swift
@@ -115,7 +115,7 @@ open class LoginsSynchronizer: IndependentRecordSynchronizer, Synchronizer {
 
             stats.applied += 1
             return storage.applyChangedLogin(self.getLogin(rec)).bind(recordApplyResult)
-                >>> effect({ self.statsSession.recordDownloadStats(stats) })
+                >>> effect({ self.statsSession.recordDownload(stats: stats) })
         }
     }
 
@@ -132,7 +132,7 @@ open class LoginsSynchronizer: IndependentRecordSynchronizer, Synchronizer {
                              lastTimestamp: lastTimestamp,
                              storageClient: storageClient,
                              onUpload: onUpload)
-            >>> effect({ self.statsSession.recordUploadStats(stats) })
+            >>> effect({ self.statsSession.recordUpload(stats: stats) })
     }
 
     // Find any records for which a local overlay exists. If we want to be really precise,

--- a/Sync/Synchronizers/TabsSynchronizer.swift
+++ b/Sync/Synchronizers/TabsSynchronizer.swift
@@ -68,6 +68,9 @@ open class TabsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchroniz
             let tabsRecord = self.createOwnTabsRecord(tabs)
             log.debug("Uploading our tabs: \(tabs.count).")
 
+            var uploadStats = SyncUploadStats()
+            uploadStats.sent += 1
+
             // We explicitly don't send If-Unmodified-Since, because we always
             // want our upload to succeed -- we own the record.
             return tabsClient.put(tabsRecord, ifUnmodifiedSince: nil) >>== { resp in
@@ -75,9 +78,11 @@ open class TabsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchroniz
                     // Protocol says this should always be present for success responses.
                     log.debug("Tabs record upload succeeded. New timestamp: \(ts).")
                     self.tabsRecordLastUpload = ts
+                } else {
+                    uploadStats.sentFailed += 1
                 }
                 return succeed()
-            }
+            } >>== effect({ self.statsSession.recordUploadStats(uploadStats) })
         }
     }
 
@@ -85,14 +90,23 @@ open class TabsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchroniz
         func onResponseReceived(_ response: StorageResponse<[Record<TabsPayload>]>) -> Success {
 
             func afterWipe() -> Success {
+                var downloadStats = SyncDownloadStats()
+
                 let doInsert: (Record<TabsPayload>) -> Deferred<Maybe<(Int)>> = { record in
                     let remotes = record.payload.isValid() ? record.payload.remoteTabs : []
                     let ins = localTabs.insertOrUpdateTabsForClientGUID(record.id, tabs: remotes)
+
+                    // Since tabs are all sent within a single record, we don't count number of tabs applied
+                    // but number of records. In this case it's just one.
+                    downloadStats.applied += 1
                     ins.upon() { res in
                         if let inserted = res.successValue {
                             if inserted != remotes.count {
                                 log.warning("Only inserted \(inserted) tabs, not \(remotes.count). Malformed or missing client?")
                             }
+                            downloadStats.applied += 1
+                        } else {
+                            downloadStats.failed += 1
                         }
                     }
                     return ins
@@ -124,7 +138,7 @@ open class TabsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchroniz
                             self.lastFetched = responseTimestamp!
                             return succeed()
                         }
-                }
+                } >>== effect({ self.statsSession.downloadStats })
             }
 
             // If this is a fresh start, do a wipe.
@@ -146,16 +160,18 @@ open class TabsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchroniz
         if let encrypter = keys?.encrypter(self.collection, encoder: encoder) {
             let tabsClient = storageClient.clientForCollection(self.collection, encrypter: encrypter)
 
+            statsSession.start()
+
             if !self.remoteHasChanges(info) {
                 // upload local tabs if they've changed or we're in a fresh start.
                 let _ = uploadOurTabs(localTabs, toServer: tabsClient)
-                return deferMaybe(.completed)
+                return deferMaybe(completedWithStats)
             }
 
             return tabsClient.getSince(self.lastFetched)
                 >>== onResponseReceived
                 >>> { self.uploadOurTabs(localTabs, toServer: tabsClient) }
-                >>> { deferMaybe(.completed) }
+                >>> { deferMaybe(self.completedWithStats) }
         }
 
         log.error("Couldn't make tabs factory.")

--- a/Sync/Synchronizers/TabsSynchronizer.swift
+++ b/Sync/Synchronizers/TabsSynchronizer.swift
@@ -82,7 +82,7 @@ open class TabsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchroniz
                     uploadStats.sentFailed += 1
                 }
                 return succeed()
-            } >>== effect({ self.statsSession.recordUploadStats(uploadStats) })
+            } >>== effect({ self.statsSession.recordUpload(stats: uploadStats) })
         }
     }
 

--- a/SyncTests/LiveStorageClientTests.swift
+++ b/SyncTests/LiveStorageClientTests.swift
@@ -18,21 +18,6 @@ private class KeyFetchError: MaybeErrorType {
     }
 }
 
-private class MockBackoffStorage: BackoffStorage {
-    var serverBackoffUntilLocalTimestamp: Timestamp?
-
-    func clearServerBackoff() {
-        self.serverBackoffUntilLocalTimestamp = nil
-    }
-
-    func isInBackoff(_ now: Timestamp) -> Timestamp? {
-        if let ts = self.serverBackoffUntilLocalTimestamp, now < ts {
-            return ts
-        }
-        return nil
-    }
-}
-
 class LiveStorageClientTests: LiveAccountTest {
     func getKeys(kB: Data, token: TokenServerToken) -> Deferred<Maybe<Record<KeysPayload>>> {
         let endpoint = token.api_endpoint

--- a/SyncTests/MockSyncServerTests.swift
+++ b/SyncTests/MockSyncServerTests.swift
@@ -9,18 +9,6 @@ import UIKit
 
 import XCTest
 
-private class MockBackoffStorage: BackoffStorage {
-    var serverBackoffUntilLocalTimestamp: Timestamp?
-
-    func clearServerBackoff() {
-        serverBackoffUntilLocalTimestamp = nil
-    }
-
-    func isInBackoff(_ now: Timestamp) -> Timestamp? {
-        return nil
-    }
-}
-
 class MockSyncServerTests: XCTestCase {
     var server: MockSyncServer!
     var client: Sync15StorageClient!

--- a/SyncTests/StorageClientTests.swift
+++ b/SyncTests/StorageClientTests.swift
@@ -17,20 +17,6 @@ func massivify(record: Record<CleartextPayloadJSON>) -> JSON? {
     ])
 }
 
-private class MockBackoffStorage: BackoffStorage {
-    var serverBackoffUntilLocalTimestamp: Timestamp? { get { return 0 } set(value) {} }
-
-    func clearServerBackoff() {
-    }
-
-    func isInBackoff(_ now: Timestamp) -> Timestamp? {
-        return nil
-    }
-
-    init() {
-    }
-}
-
 class StorageClientTests: XCTestCase {
     func testPartialJSON() {
         let body = "0"

--- a/SyncTests/TestBookmarkTreeMerging.swift
+++ b/SyncTests/TestBookmarkTreeMerging.swift
@@ -158,6 +158,12 @@ class TestBookmarkTreeMerging: FailFastTestCase {
         return getBrowserDBForFile(filename: file, files: self.files)
     }
 
+    private func mockStatsSessionForBookmarks() -> SyncEngineStatsSession {
+        let session = SyncEngineStatsSession(collection: "bookmarks")
+        session.start()
+        return session
+    }
+
     func getSyncableBookmarks(name: String) -> MergedSQLiteBookmarks? {
         guard let db = self.getBrowserDB(name: name) else {
             XCTFail("Couldn't get prepared DB.")
@@ -308,7 +314,7 @@ class TestBookmarkTreeMerging: FailFastTestCase {
 
         let uploader = MockUploader()
         let storer = uploader.getStorer()
-        let applier = MergeApplier(buffer: bookmarks, storage: bookmarks, client: storer, greenLight: { true })
+        let applier = MergeApplier(buffer: bookmarks, storage: bookmarks, client: storer, statsSession: mockStatsSessionForBookmarks(), greenLight: { true })
         applier.go().succeeded()
 
         // Now the local contents are replicated into the mirror, and both the buffer and local are empty.
@@ -721,7 +727,7 @@ class TestBookmarkTreeMerging: FailFastTestCase {
 
         let uploader = MockUploader()
         let storer = uploader.getStorer()
-        let applier = MergeApplier(buffer: bookmarks, storage: bookmarks, client: storer, greenLight: { true })
+        let applier = MergeApplier(buffer: bookmarks, storage: bookmarks, client: storer, statsSession: mockStatsSessionForBookmarks(), greenLight: { true })
         applier.applyResult(result).succeeded()
 
         guard let mirror = bookmarks.treeForMirror().value.successValue else {
@@ -797,7 +803,7 @@ class TestBookmarkTreeMerging: FailFastTestCase {
 
         let uploader = MockUploader()
         let storer = uploader.getStorer()
-        let applier = MergeApplier(buffer: bookmarks, storage: bookmarks, client: storer, greenLight: { true })
+        let applier = MergeApplier(buffer: bookmarks, storage: bookmarks, client: storer, statsSession: mockStatsSessionForBookmarks(), greenLight: { true })
         applier.go().succeeded()
 
         guard let mirror = bookmarks.treeForMirror().value.successValue else {
@@ -864,7 +870,7 @@ class TestBookmarkTreeMerging: FailFastTestCase {
 
         let uploader = MockUploader()
         let storer = uploader.getStorer()
-        let applier = MergeApplier(buffer: bookmarks, storage: bookmarks, client: storer, greenLight: { true })
+        let applier = MergeApplier(buffer: bookmarks, storage: bookmarks, client: storer, statsSession: mockStatsSessionForBookmarks(), greenLight: { true })
         applier.go().succeeded()
 
         // After merge, the buffer and local are empty.
@@ -923,7 +929,7 @@ class TestBookmarkTreeMerging: FailFastTestCase {
 
         let uploader = MockUploader()
         let storer = uploader.getStorer()
-        let applier = MergeApplier(buffer: bookmarks, storage: bookmarks, client: storer, greenLight: { true })
+        let applier = MergeApplier(buffer: bookmarks, storage: bookmarks, client: storer, statsSession: mockStatsSessionForBookmarks(), greenLight: { true })
         applier.go().succeeded()
 
         guard let _ = bookmarks.treeForMirror().value.successValue else {
@@ -956,7 +962,7 @@ class TestBookmarkTreeMerging: FailFastTestCase {
 
         let uu = MockUploader()
         let ss = uu.getStorer()
-        let changeApplier = MergeApplier(buffer: bookmarks, storage: bookmarks, client: ss, greenLight: { true })
+        let changeApplier = MergeApplier(buffer: bookmarks, storage: bookmarks, client: ss, statsSession: mockStatsSessionForBookmarks(), greenLight: { true })
         changeApplier.go().succeeded()
 
         // The title changed.


### PR DESCRIPTION
First pass at adding a way of collection telemetry information from our sync engines. From a high level,

A `SyncStatsReport` contains all of the telemetry information related to a single sync operation. Within the report, there are many `SyncEngineStats` which contain information about each of our sync engines. 

A report is started when a sync operation starts. For each engine, a `SyncEngineStatsObserver` is passed to each engine which acts as the engine's `SyncStatsDelegate`. During the course of the engine's operations, the relevant data is passed to the delegate through lifecycle events (willBegin/didUpload/didDownload/DidFinished). As each engine completes, the `SyncEngineStats` appended to the in-progress report.

When the syncing operation has completed, the report is finalized and broadcasted using an `NSNotification` and closed.

This patch contains adding the abstractions for storing sync information, report creation, and collecting stats for each engine except for bookmarks. Adding the stats delegate into the merger seems a bit hairy so before I move forward I'd like to know if @rnewman has any thoughts on the WIP patch as well as threading in the stats collection into bookmarks.

