### PR TITLE
Bug 1320911 only focus blank new tab

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -320,7 +320,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if let newURL = params.url {
             self.browserViewController.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate, isPrivileged: false)
         } else {
-            self.browserViewController.openBlankNewTabAndFocus(isPrivate: isPrivate)
+            self.browserViewController.openBlankNewTab(isPrivate: isPrivate)
         }
     }
 

--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -119,7 +119,7 @@ class QuickActions: NSObject {
     }
 
     private func handleOpenNewTab(withBrowserViewController bvc: BrowserViewController, isPrivate: Bool) {
-        bvc.openBlankNewTabAndFocus(isPrivate: isPrivate)
+        bvc.openBlankNewTab(isPrivate: isPrivate)
     }
 
     private func handleOpenURL(withBrowserViewController bvc: BrowserViewController, urlToOpen: NSURL) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1054,12 +1054,14 @@ class BrowserViewController: UIViewController {
 
         switchToPrivacyMode(isPrivate: isPrivate)
         tabManager.addTabAndSelect(request, isPrivate: isPrivate)
+        if url == nil && NewTabAccessors.getNewTabPage(profile.prefs) == .BlankPage {
+            urlBar.tabLocationViewDidTapLocation(urlBar.locationView)
+        }
     }
 
-    func openBlankNewTabAndFocus(isPrivate isPrivate: Bool = false) {
+    func openBlankNewTab(isPrivate isPrivate: Bool = false) {
         popToBVC()
         openURLInNewTab(nil, isPrivate: isPrivate, isPrivileged: true)
-        urlBar.tabLocationViewDidTapLocation(urlBar.locationView)
     }
 
     private func popToBVC() {
@@ -1217,10 +1219,10 @@ class BrowserViewController: UIViewController {
     }
 
     func newTab() {
-        openBlankNewTabAndFocus(isPrivate: false)
+        openBlankNewTab(isPrivate: false)
     }
     func newPrivateTab() {
-        openBlankNewTabAndFocus(isPrivate: true)
+        openBlankNewTab(isPrivate: true)
     }
 
     func closeTab() {
@@ -3398,7 +3400,7 @@ extension BrowserViewController: TopTabsDelegate {
     
     func topTabsDidPressNewTab() {
         let isPrivate = tabManager.selectedTab?.isPrivate ?? false
-        openBlankNewTabAndFocus(isPrivate: isPrivate)
+        openBlankNewTab(isPrivate: isPrivate)
     }
 
     func topTabsDidPressPrivateModeButton(cachedTab: Tab?) {
@@ -3421,7 +3423,7 @@ extension BrowserViewController: TopTabsDelegate {
             if let privateTab = tabManager.privateTabs.last {
                 tabManager.selectTab(privateTab)
             } else {
-                openBlankNewTabAndFocus(isPrivate: true)
+                openBlankNewTab(isPrivate: true)
             }
         }
     }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -632,6 +632,12 @@ class TabTrayController: UIViewController {
             self.toolbar.userInteractionEnabled = true
             if finished {
                 self.navigationController?.popViewControllerAnimated(true)
+
+                if request == nil && NewTabAccessors.getNewTabPage(self.profile.prefs) == .BlankPage {
+                    if let bvc = self.navigationController?.topViewController as? BrowserViewController {
+                        bvc.urlBar.tabLocationViewDidTapLocation(bvc.urlBar.locationView)
+                    }
+                }
             }
         })
     }


### PR DESCRIPTION
Ensures that the URLBar receives focus on a new tab only when the new tab settings are set to Blank Page, regardless of where the new tab was requested from - menu, tab tray, 3D touch or Today Widget.