### PR TITLE
Bug 1331984 - Don't crash when faced with invalid Base64 Sync record payloads.

### DIFF
--- a/Sync/KeyBundle.swift
+++ b/Sync/KeyBundle.swift
@@ -31,12 +31,16 @@ public class KeyBundle: Hashable {
     }
 
     public class var invalid: KeyBundle {
-        return KeyBundle(encKeyB64: "deadbeef", hmacKeyB64: "deadbeef")
+        return KeyBundle(encKeyB64: "deadbeef", hmacKeyB64: "deadbeef")!
     }
 
-    public init(encKeyB64: String, hmacKeyB64: String) {
-        self.encKey = Bytes.decodeBase64(encKeyB64)
-        self.hmacKey = Bytes.decodeBase64(hmacKeyB64)
+    public init?(encKeyB64: String, hmacKeyB64: String) {
+        guard let e = Bytes.decodeBase64(encKeyB64),
+              let h = Bytes.decodeBase64(hmacKeyB64) else {
+            return nil
+        }
+        self.encKey = e
+        self.hmacKey = h
     }
 
     public init(encKey: NSData, hmacKey: NSData) {

--- a/SyncTests/CryptoTests.swift
+++ b/SyncTests/CryptoTests.swift
@@ -13,9 +13,10 @@ class CryptoTests: XCTestCase {
     let hmacB16 = "b1e6c18ac30deb70236bc0d65a46f7a4dce3b8b0e02cf92182b914e3afa5eebc"
     let ivB64 = "GX8L37AAb2FZJMzIoXlX8w=="
 
-    let hmacKey = Bytes.decodeBase64("MMntEfutgLTc8FlTLQFms8/xMPmCldqPlq/QQXEjx70=")
-    let encKey = Bytes.decodeBase64("9K/wLdXdw+nrTtXo4ZpECyHFNr4d7aYHqeg3KW9+m6Q=")
+    let hmacKey = Bytes.decodeBase64("MMntEfutgLTc8FlTLQFms8/xMPmCldqPlq/QQXEjx70=")!
+    let encKey = Bytes.decodeBase64("9K/wLdXdw+nrTtXo4ZpECyHFNr4d7aYHqeg3KW9+m6Q=")!
 
+    let invalidB64 = "NMsdnRulLwQsVcwxKW9XwaUe7ouJk5~~~~~~~~~~~~~~~"
 
     let ciphertextB64 = "NMsdnRulLwQsVcwxKW9XwaUe7ouJk5Wn80QhbD80l0HEcZGCynh45qIbeYBik0lgcHbKmlIxTJNwU+OeqipN+/j7MqhjKOGIlvbpiPQQLC6/ffF2vbzL0nzMUuSyvaQzyGGkSYM2xUFt06aNivoQTvU2GgGmUK6MvadoY38hhW2LCMkoZcNfgCqJ26lO1O0sEO6zHsk3IVz6vsKiJ2Hq6VCo7hu123wNegmujHWQSGyf8JeudZjKzfi0OFRRvvm4QAKyBWf0MgrW1F8SFDnVfkq8amCB7NhdwhgLWbN+21NitNwWYknoEWe1m6hmGZDgDT32uxzWxCV8QqqrpH/ZggViEr9uMgoy4lYaWqP7G5WKvvechc62aqnsNEYhH26A5QgzmlNyvB+KPFvPsYzxDnSCjOoRSLx7GG86wT59QZw="
 
@@ -46,24 +47,28 @@ class CryptoTests: XCTestCase {
     func testDecrypt() {
         let keyBundle = KeyBundle(encKey: encKey, hmacKey: hmacKey)
         // Decryption is done against raw bytes.
-        let ciphertext = Bytes.decodeBase64(ciphertextB64)
-        let iv = Bytes.decodeBase64(ivB64)
+        let ciphertext = Bytes.decodeBase64(ciphertextB64)!
+        let iv = Bytes.decodeBase64(ivB64)!
         let s = keyBundle.decrypt(ciphertext, iv: iv)
-        let cleartext = NSString(data: Bytes.decodeBase64(cleartextB64),
+        let cleartext = NSString(data: Bytes.decodeBase64(cleartextB64)!,
                                  encoding: NSUTF8StringEncoding)
         XCTAssertTrue(cleartext!.isEqualToString(s!))
     }
 
+    func testBadBase64() {
+        XCTAssertNil(Bytes.decodeBase64(invalidB64))
+    }
+
     func testEncrypt() {
         let keyBundle = KeyBundle(encKey: encKey, hmacKey: hmacKey)
-        let cleartext = Bytes.decodeBase64(cleartextB64)
+        let cleartext = Bytes.decodeBase64(cleartextB64)!
 
         // With specified IV.
-        let iv = Bytes.decodeBase64(ivB64)
+        let iv = Bytes.decodeBase64(ivB64)!
         if let (b, ivOut) = keyBundle.encrypt(cleartext, iv: iv) {
             // The output IV should be the input.
             XCTAssertEqual(ivOut, iv)
-            XCTAssertEqual(b, Bytes.decodeBase64(ciphertextB64))
+            XCTAssertEqual(b, Bytes.decodeBase64(ciphertextB64)!)
         } else {
             XCTFail("Encrypt failed.")
         }
@@ -75,7 +80,7 @@ class CryptoTests: XCTestCase {
             XCTAssertNotEqual(ivOut, iv)
 
             // The result will not match the ciphertext for which a different IV was used.
-            XCTAssertNotEqual(b, Bytes.decodeBase64(ciphertextB64))
+            XCTAssertNotEqual(b, Bytes.decodeBase64(ciphertextB64)!)
         } else {
             XCTFail("Encrypt failed.")
         }

--- a/SyncTests/RecordTests.swift
+++ b/SyncTests/RecordTests.swift
@@ -87,7 +87,7 @@ class RecordTests: XCTestCase {
 
         let inputString = "{\"sortindex\": 131, \"payload\": \"{\\\"ciphertext\\\":\\\"YJB4dr0vZEIWPirfU2FCJvfzeSLiOP5QWasol2R6ILUxdHsJWuUuvTZVhxYQfTVNou6hVV67jfAvi5Cs+bqhhQsv7icZTiZhPTiTdVGt+uuMotxauVA5OryNGVEZgCCTvT3upzhDFdDbJzVd9O3/gU/b7r/CmAHykX8bTlthlbWeZ8oz6gwHJB5tPRU15nM/m/qW1vyKIw5pw/ZwtAy630AieRehGIGDk+33PWqsfyuT4EUFY9/Ly+8JlnqzxfiBCunIfuXGdLuqTjJOxgrK8mI4wccRFEdFEnmHvh5x7fjl1ID52qumFNQl8zkB75C8XK25alXqwvRR6/AQSP+BgQ==\\\",\\\"IV\\\":\\\"v/0BFgicqYQsd70T39rraA==\\\",\\\"hmac\\\":\\\"59605ed696f6e0e6e062a03510cff742bf6b50d695c042e8372a93f4c2d37dac\\\"}\", \"id\": \"0-P9fabp9vJD\", \"modified\": 1326254123.65}"
 
-        let keyBundle = KeyBundle(encKeyB64: b64E, hmacKeyB64: b64H)
+        let keyBundle = KeyBundle(encKeyB64: b64E, hmacKeyB64: b64H)!
         let decryptClient = keyBundle.factory({ CleartextPayloadJSON($0) })
         let encryptClient = keyBundle.serializer({ $0 })   // It's already a JSON.
 
@@ -120,6 +120,12 @@ class RecordTests: XCTestCase {
         } else {
             XCTFail("No record.")
         }
+
+        // Test invalid Base64.
+        let badInputString =  "{\"sortindex\": 131, \"payload\": \"{\\\"ciphertext\\\":\\\"~~~YJB4dr0vZEIWPirfU2FCJvfzeSLiOP5QWasol2R6ILUxdHsJWuUuvTZVhxYQfTVNou6hVV67jfAvi5Cs+bqhhQsv7icZTiZhPTiTdVGt+uuMotxauVA5OryNGVEZgCCTvT3upzhDFdDbJzVd9O3/gU/b7r/CmAHykX8bTlthlbWeZ8oz6gwHJB5tPRU15nM/m/qW1vyKIw5pw/ZwtAy630AieRehGIGDk+33PWqsfyuT4EUFY9/Ly+8JlnqzxfiBCunIfuXGdLuqTjJOxgrK8mI4wccRFEdFEnmHvh5x7fjl1ID52qumFNQl8zkB75C8XK25alXqwvRR6/AQSP+BgQ==\\\",\\\"IV\\\":\\\"v/0BFgicqYQsd70T39rraA==\\\",\\\"hmac\\\":\\\"59605ed696f6e0e6e062a03510cff742bf6b50d695c042e8372a93f4c2d37dac\\\"}\", \"id\": \"0-P9fabp9vJD\", \"modified\": 1326254123.65}"
+        let badEnvelope = EnvelopeJSON(badInputString)
+        XCTAssertTrue(badEnvelope.isValid())      // It's a valid envelope containing nonsense ciphertext.
+        XCTAssertNil(toRecord(badEnvelope))       // Even though the envelope is valid, the payload is invalid, so we can't construct a record.
     }
 
     func testMeta() {

--- a/Utils/Bytes.swift
+++ b/Utils/Bytes.swift
@@ -28,9 +28,9 @@ public class Bytes {
             .stringByReplacingOccurrencesOfString("+", withString: "-", options: NSStringCompareOptions(), range: nil)
     }
 
-    public class func decodeBase64(b64: String) -> NSData {
+    public class func decodeBase64(b64: String) -> NSData? {
         return NSData(base64EncodedString: b64,
-                      options: NSDataBase64DecodingOptions())!
+                      options: NSDataBase64DecodingOptions())
     }
 
     /**


### PR DESCRIPTION
To avoid chaining optionals or `throws` everywhere, I opted to make base64 validation part of the existing validation step, pre-decoding the base64 string at the end of validation.

Any caller that correctly validates before use of the force-unwrapping accessors — which they all do — will see a validation failure instead of a crash, and follow the existing error handling flows.

Added a test for assumptions about `NSData`, and a test that a malformed payload can't construct a `Record` instance.

Depending on the root cause of the bug — truly malformed b64, or incorrect parsing on our part — there might be a follow-up, but this will certainly avoid the crash.

Tests pass, but I haven't run this manually with real data.