### PR TITLE
The toptabs PR to end all PRs!

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -252,6 +252,7 @@
 		3B546EC01D95ECAE00BDBE36 /* ActivityStreamTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B546EBF1D95ECAE00BDBE36 /* ActivityStreamTest.swift */; };
 		3B6889C51D66950E002AC85E /* UIImageColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6889C41D66950E002AC85E /* UIImageColors.swift */; };
 		3B6F40181DC7849C00656CC6 /* ActivityStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6F40171DC7849C00656CC6 /* ActivityStreamTests.swift */; };
+		3B8351FF1E26F03900818081 /* TopTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B8351FE1E26F03900818081 /* TopTabsTests.swift */; };
 		3BA9A0231D2C208C00BD418C /* Fuzi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3BA9A0221D2C208C00BD418C /* Fuzi.framework */; };
 		3BA9A0311D2C2C0400BD418C /* Fuzi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3BA9A0221D2C208C00BD418C /* Fuzi.framework */; };
 		3BA9A0321D2C2C0500BD418C /* Fuzi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3BA9A0221D2C208C00BD418C /* Fuzi.framework */; };
@@ -1430,6 +1431,7 @@
 		3B546EBF1D95ECAE00BDBE36 /* ActivityStreamTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityStreamTest.swift; sourceTree = "<group>"; };
 		3B6889C41D66950E002AC85E /* UIImageColors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIImageColors.swift; path = ThirdParty/UIImageColors.swift; sourceTree = "<group>"; };
 		3B6F40171DC7849C00656CC6 /* ActivityStreamTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityStreamTests.swift; sourceTree = "<group>"; };
+		3B8351FE1E26F03900818081 /* TopTabsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopTabsTests.swift; sourceTree = "<group>"; };
 		3BA9A0221D2C208C00BD418C /* Fuzi.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Fuzi.framework; path = Carthage/Build/iOS/Fuzi.framework; sourceTree = "<group>"; };
 		3BB50E101D6274CD004B33DF /* ActivityStreamTopSitesCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityStreamTopSitesCell.swift; sourceTree = "<group>"; };
 		3BB50E1F1D627539004B33DF /* ActivityStreamPanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityStreamPanel.swift; sourceTree = "<group>"; };
@@ -3601,6 +3603,7 @@
 				0BF42D4E1A7CD09600889E28 /* TestFavicons.swift */,
 				2F44FA1A1A9D426A00FD20CC /* TestHashExtensions.swift */,
 				4A59BF410BBD9B3BE71F4C7C /* TestHistory.swift */,
+				3B8351FE1E26F03900818081 /* TopTabsTests.swift */,
 				A83E5B1C1C1DA8D80026D912 /* UIPasteboardExtensionsTests.swift */,
 				3BFCBF1F1E04B1C50070C042 /* UIImageViewExtensionsTests.swift */,
 				E4CD9F1C1A6D9C2800318571 /* WebServerTests.swift */,
@@ -5519,6 +5522,7 @@
 				7FB63CEF1C08D4910047F9A4 /* DynamicFontHelper.swift in Sources */,
 				3B39EDBA1E16E18900EF029F /* CustomSearchEnginesTest.swift in Sources */,
 				7BC7B4BE1C904BF90046E9D2 /* MenuTests.swift in Sources */,
+				3B8351FF1E26F03900818081 /* TopTabsTests.swift in Sources */,
 				D3FA777B1A43B2990010CD32 /* SearchTests.swift in Sources */,
 				D3BA41681BD82F2200DA5457 /* XCTestCaseExtensions.swift in Sources */,
 				554867231DC3935A00183DAA /* HomePageTests.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -231,7 +231,6 @@ class BrowserViewController: UIViewController {
                     make.height.equalTo(TopTabsUX.TopTabsViewHeight)
                 }
                 self.topTabsViewController = topTabsViewController
-                tabManager.addNavigationDelegate(topTabsViewController)
             }
             topTabsContainer.snp_updateConstraints { make in
                 make.height.equalTo(TopTabsUX.TopTabsViewHeight)
@@ -2035,6 +2034,7 @@ extension BrowserViewController: SearchViewControllerDelegate {
 }
 
 extension BrowserViewController: TabManagerDelegate {
+
     func tabManager(tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?) {
         // Remove the old accessibilityLabel. Since this webview shouldn't be visible, it doesn't need it
         // and having multiple views with the same label confuses tests.
@@ -2049,7 +2049,6 @@ extension BrowserViewController: TabManagerDelegate {
 
         if let tab = selected, webView = tab.webView {
             updateURLBarDisplayURL(tab)
-
             if tab.isPrivate {
                 readerModeCache = MemoryReaderModeCache.sharedInstance
                 applyTheme(Theme.PrivateMode)
@@ -3239,7 +3238,6 @@ extension BrowserViewController: TabTrayDelegate {
         self.addBookmark(tab.tabState)
     }
 
-
     func tabTrayDidAddToReadingList(tab: Tab) -> ReadingListClientRecord? {
         guard let url = tab.url?.absoluteString where url.characters.count > 0 else { return nil }
         return profile.readingList?.createRecordWithURL(url, title: tab.title ?? url, addedBy: UIDevice.currentDevice().name).successValue
@@ -3257,6 +3255,7 @@ extension BrowserViewController: Themeable {
         urlBar.applyTheme(themeName)
         toolbar?.applyTheme(themeName)
         readerModeBar?.applyTheme(themeName)
+
         topTabsViewController?.applyTheme(themeName)
 
         switch(themeName) {
@@ -3402,12 +3401,11 @@ extension BrowserViewController: TopTabsDelegate {
         self.urlBarDidPressTabs(urlBar)
     }
     
-    func topTabsDidPressNewTab() {
-        let isPrivate = tabManager.selectedTab?.isPrivate ?? false
+    func topTabsDidPressNewTab(isPrivate: Bool) {
         openBlankNewTab(isPrivate: isPrivate)
     }
 
-    func topTabsDidPressPrivateModeButton(cachedTab: Tab?) {
+    func topTabsDidPressPrivateModeButton() {
         guard let selectedTab = tabManager.selectedTab else {
             return
         }
@@ -3416,18 +3414,6 @@ extension BrowserViewController: TopTabsDelegate {
         if selectedTab.isPrivate {
             if profile.prefs.boolForKey("settings.closePrivateTabs") ?? false {
                 tabManager.removeAllPrivateTabsAndNotify(false)
-            }
-        }
-        
-        if let tab = cachedTab {
-            tabManager.selectTab(tab)
-        } else if selectedTab.isPrivate {
-            tabManager.selectTab(tabManager.normalTabs.last)
-        } else {
-            if let privateTab = tabManager.privateTabs.last {
-                tabManager.selectTab(privateTab)
-            } else {
-                openBlankNewTab(isPrivate: true)
             }
         }
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2127,7 +2127,7 @@ extension BrowserViewController: TabManagerDelegate {
         updateInContentHomePanel(selected?.url)
     }
 
-    func tabManager(tabManager: TabManager, didCreateTab tab: Tab) {
+    func tabManager(tabManager: TabManager, willAddTab tab: Tab) {
     }
 
     func tabManager(tabManager: TabManager, didAddTab tab: Tab) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2139,6 +2139,9 @@ extension BrowserViewController: TabManagerDelegate {
         tab.appStateDelegate = self
     }
 
+    func tabManager(tabManager: TabManager, willRemoveTab tab: Tab) {
+    }
+
     func tabManager(tabManager: TabManager, didRemoveTab tab: Tab) {
         updateTabCountUsingTabManager(tabManager)
         // tabDelegate is a weak ref (and the tab's webView may not be destroyed yet)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -138,6 +138,7 @@ class BrowserViewController: UIViewController {
 
         coordinator.animateAlongsideTransition({context in
             self.scrollController.updateMinimumZoom()
+            self.topTabsViewController?.scrollToCurrentTab(false, centerCell: false)
             if let popover = self.displayedPopoverController {
                 self.updateDisplayedPopoverProperties?()
                 self.presentViewController(popover, animated: true, completion: nil)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -3405,7 +3405,7 @@ extension BrowserViewController: TopTabsDelegate {
         openBlankNewTab(isPrivate: isPrivate)
     }
 
-    func topTabsDidPressPrivateModeButton() {
+    func topTabsDidTogglePrivateMode() {
         guard let selectedTab = tabManager.selectedTab else {
             return
         }

--- a/Client/Frontend/Browser/FaviconManager.swift
+++ b/Client/Frontend/Browser/FaviconManager.swift
@@ -118,7 +118,7 @@ class FaviconManager: TabHelper {
                         self.noFaviconAvailable(tab, atURL: currentURL)
                     }
                 }
-                NSNotificationCenter.defaultCenter().postNotificationName(FaviconManager.FaviconDidLoad, object: nil)
+                NSNotificationCenter.defaultCenter().postNotificationName(FaviconManager.FaviconDidLoad, object: tab)
             }
         }
     }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -187,10 +187,7 @@ class TabManager: NSObject {
         assert(tab === selectedTab, "Expected tab is selected")
         selectedTab?.createWebview()
 
-        for delegate in delegates {
-            delegate.get()?.tabManager(self, didSelectedTabChange: tab, previous: previous)
-        }
-
+        delegates.forEach { $0.get()?.tabManager(self, didSelectedTabChange: tab, previous: previous) }
     }
 
     func expireSnackbars() {
@@ -241,9 +238,7 @@ class TabManager: NSObject {
         self.selectTab(tab)
 
         // Notify that we bulk-loaded so we can adjust counts.
-        for delegate in delegates {
-            delegate.get()?.tabManagerDidAddTabs(self)
-        }
+        delegates.forEach { $0.get()?.tabManagerDidAddTabs(self) }
     }
 
     private func addTab(request: NSURLRequest? = nil, configuration: WKWebViewConfiguration? = nil, afterTab: Tab? = nil, flushToDisk: Bool, zombie: Bool, isPrivate: Bool) -> Tab {
@@ -371,7 +366,6 @@ class TabManager: NSObject {
             if tabIndex == viableTabs.count {
                 tabIndex -= 1
             }
-            // 7 < 8
             if tabIndex < viableTabs.count && !viableTabs.isEmpty {
                 _selectedIndex = tabs.indexOf(viableTabs[tabIndex]) ?? -1
             } else {
@@ -440,9 +434,8 @@ class TabManager: NSObject {
                 self.eraseUndoCache()
             })
         }
-        for delegate in delegates {
-            delegate.get()?.tabManagerDidRemoveAllTabs(self, toast: toast)
-        }
+
+        delegates.forEach { $0.get()?.tabManagerDidRemoveAllTabs(self, toast: toast) }
     }
     
     func undoCloseTabs() {
@@ -460,9 +453,7 @@ class TabManager: NSObject {
         }
         selectTab(tempTabs.first)
         self.isRestoring = false
-        for delegate in delegates {
-            delegate.get()?.tabManagerDidRestoreTabs(self)
-        }
+        delegates.forEach { $0.get()?.tabManagerDidRestoreTabs(self) }
         self.tempTabs?.removeAll()
         tabs.first?.createWebview()
     }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -13,7 +13,9 @@ protocol TabManagerDelegate: class {
     func tabManager(tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?)
     func tabManager(tabManager: TabManager, willAddTab tab: Tab)
     func tabManager(tabManager: TabManager, didAddTab tab: Tab)
+    func tabManager(tabManager: TabManager, willRemoveTab tab: Tab)
     func tabManager(tabManager: TabManager, didRemoveTab tab: Tab)
+
     func tabManagerDidRestoreTabs(tabManager: TabManager)
     func tabManagerDidAddTabs(tabManager: TabManager)
     func tabManagerDidRemoveAllTabs(tabManager: TabManager, toast: ButtonToast?)
@@ -166,14 +168,13 @@ class TabManager: NSObject {
         return nil
     }
 
-    func selectTab(tab: Tab?) {
+    func selectTab(tab: Tab?, previous: Tab? = nil) {
         assert(NSThread.isMainThread())
+        let previous = previous ?? selectedTab
 
-        if selectedTab === tab {
+        if previous === tab {
             return
         }
-
-        let previous = selectedTab
 
         if let tab = tab {
             _selectedIndex = tabs.indexOf(tab) ?? -1
@@ -189,6 +190,7 @@ class TabManager: NSObject {
         for delegate in delegates {
             delegate.get()?.tabManager(self, didSelectedTabChange: tab, previous: previous)
         }
+
     }
 
     func expireSnackbars() {
@@ -341,57 +343,60 @@ class TabManager: NSObject {
     ///   is removed.
     private func removeTab(tab: Tab, flushToDisk: Bool, notify: Bool) {
         assert(NSThread.isMainThread())
-        // If the removed tab was selected, find the new tab to select.
-        if tab === selectedTab {
-            let viableTabs: [Tab] = tab.isPrivate ? privateTabs : normalTabs
-            if let index = viableTabs.indexOf(tab) {
-                if index + 1 < viableTabs.count {
-                    selectTab(viableTabs[index + 1])
-                } else if index - 1 >= 0 {
-                    selectTab(viableTabs[index - 1])
-                } else {
-                    assert(viableTabs.count == 1, "Removing last tab")
-                    selectTab(nil)
-                }
-            }
+
+        let oldSelectedTab = selectedTab
+
+        if notify {
+            delegates.forEach { $0.get()?.tabManager(self, willRemoveTab: tab) }
         }
+
+        // The index of the tab in its respective tab grouping. Used to figure out which tab is next
+        var tabIndex: Int = -1
+        if let oldTab = oldSelectedTab {
+            tabIndex = (tab.isPrivate ? privateTabs.indexOf(oldTab) : normalTabs.indexOf(oldTab)) ?? -1
+        }
+
 
         let prevCount = count
-        var removeIndex = -1
-        for i in 0..<count {
-            if tabs[i] === tab {
-                removeIndex = i
-                tabs.removeAtIndex(i)
-                break
+        if let removalIndex = tabs.indexOf({ $0 === tab }) {
+            tabs.removeAtIndex(removalIndex)
+        }
+
+        let viableTabs: [Tab] = tab.isPrivate ? privateTabs : normalTabs
+
+        //If the last item was deleted then select the last tab. Otherwise the _selectedIndex is already correct
+        if let oldTab = oldSelectedTab where tab !== oldTab {
+            _selectedIndex = tabs.indexOf(oldTab) ?? -1
+        } else {
+            if tabIndex == viableTabs.count {
+                tabIndex -= 1
+            }
+            // 7 < 8
+            if tabIndex < viableTabs.count && !viableTabs.isEmpty {
+                _selectedIndex = tabs.indexOf(viableTabs[tabIndex]) ?? -1
+            } else {
+                _selectedIndex = -1
             }
         }
-        if _selectedIndex > removeIndex && _selectedIndex > 0 {
-            _selectedIndex -= 1
-        }
-        assert(count == prevCount - 1, "Tab removed")
 
-        if tab != selectedTab {
-            _selectedIndex = selectedTab == nil ? -1 : tabs.indexOf(selectedTab!) ?? 0
-        }
+        assert(count == prevCount - 1, "Make sure the tab count was actually removed")
 
-        // There's still some time between this and the webView being destroyed.
-        // We don't want to pick up any stray events.
+        // There's still some time between this and the webView being destroyed. We don't want to pick up any stray events.
         tab.webView?.navigationDelegate = nil
 
         if notify {
-            for delegate in delegates {
-                delegate.get()?.tabManager(self, didRemoveTab: tab)
-            }
+            delegates.forEach { $0.get()?.tabManager(self, didRemoveTab: tab) }
         }
 
-        // Make sure we never reach 0 normal tabs
-        let viableTabs: [Tab] = tab.isPrivate ? privateTabs : normalTabs
-        if viableTabs.count == 0 {
-            if !tab.isPrivate {
-                addTab()
-            } else {
-                selectTab(tabs.last)
-            }
+        if !tab.isPrivate && viableTabs.isEmpty {
+            addTab()
+        }
+
+        // If the removed tab was selected, find the new tab to select.
+        if selectedTab != nil {
+            selectTab(selectedTab, previous: oldSelectedTab)
+        } else {
+            selectTab(tabs.last, previous: oldSelectedTab)
         }
 
         if flushToDisk {

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -449,9 +449,9 @@ class TabManager: NSObject {
         guard let tempTabs = self.tempTabs where tempTabs.count ?? 0 > 0 else {
             return
         }
-        
         let tabsCopy = normalTabs
         restoreTabs(tempTabs)
+        self.isRestoring = true
         for tab in tempTabs {
             tab.showContent(true)
         }
@@ -459,6 +459,10 @@ class TabManager: NSObject {
             removeTabs(tabsCopy)
         }
         selectTab(tempTabs.first)
+        self.isRestoring = false
+        for delegate in delegates {
+            delegate.get()?.tabManagerDidRestoreTabs(self)
+        }
         self.tempTabs?.removeAll()
         tabs.first?.createWebview()
     }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -11,7 +11,7 @@ private let log = Logger.browserLogger
 
 protocol TabManagerDelegate: class {
     func tabManager(tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?)
-    func tabManager(tabManager: TabManager, didCreateTab tab: Tab)
+    func tabManager(tabManager: TabManager, willAddTab tab: Tab)
     func tabManager(tabManager: TabManager, didAddTab tab: Tab)
     func tabManager(tabManager: TabManager, didRemoveTab tab: Tab)
     func tabManagerDidRestoreTabs(tabManager: TabManager)
@@ -284,9 +284,7 @@ class TabManager: NSObject {
     func configureTab(tab: Tab, request: NSURLRequest?, afterTab parent: Tab? = nil, flushToDisk: Bool, zombie: Bool) {
         assert(NSThread.isMainThread())
 
-        for delegate in delegates {
-            delegate.get()?.tabManager(self, didCreateTab: tab)
-        }
+        delegates.forEach { $0.get()?.tabManager(self, willAddTab: tab) }
 
         if parent == nil || parent?.isPrivate != tab.isPrivate {
             tabs.append(tab)
@@ -299,9 +297,7 @@ class TabManager: NSObject {
             tabs.insert(tab, atIndex: insertIndex)
         }
 
-        for delegate in delegates {
-            delegate.get()?.tabManager(self, didAddTab: tab)
-        }
+        delegates.forEach { $0.get()?.tabManager(self, didAddTab: tab) }
 
         if !zombie {
             tab.createWebview()

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -691,6 +691,8 @@ extension TabTrayController: TabManagerDelegate {
 
     func tabManager(tabManager: TabManager, willAddTab tab: Tab) {
     }
+
+    func tabManager(tabManager: TabManager, willRemoveTab tab: Tab) {
     }
 
     func tabManager(tabManager: TabManager, didAddTab tab: Tab) {

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -689,7 +689,8 @@ extension TabTrayController: TabManagerDelegate {
     func tabManager(tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?) {
     }
 
-    func tabManager(tabManager: TabManager, didCreateTab tab: Tab) {
+    func tabManager(tabManager: TabManager, willAddTab tab: Tab) {
+    }
     }
 
     func tabManager(tabManager: TabManager, didAddTab tab: Tab) {

--- a/Client/Frontend/Browser/TopTabsLayout.swift
+++ b/Client/Frontend/Browser/TopTabsLayout.swift
@@ -16,7 +16,7 @@ class TopTabsLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout {
     }
     
     @objc func collectionView(collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAtIndex section: Int) -> UIEdgeInsets {
-        return UIEdgeInsetsMake(1, TopTabsUX.TopTabsBackgroundShadowWidth, 1, TopTabsUX.TopTabsBackgroundShadowWidth)
+        return UIEdgeInsetsMake(0, TopTabsUX.TopTabsBackgroundShadowWidth, 0, TopTabsUX.TopTabsBackgroundShadowWidth)
     }
     
     @objc func collectionView(collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAtIndex section: Int) -> CGFloat {

--- a/Client/Frontend/Browser/TopTabsLayout.swift
+++ b/Client/Frontend/Browser/TopTabsLayout.swift
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 import Foundation
 
 class TopTabsLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout {
@@ -42,7 +41,7 @@ class TopTabsViewLayout: UICollectionViewFlowLayout {
         self.minimumLineSpacing = 2
         scrollDirection = UICollectionViewScrollDirection.Horizontal
         registerClass(TopTabsBackgroundDecorationView.self, forDecorationViewOfKind: TopTabsBackgroundDecorationView.Identifier)
-        registerClass(Seperator.self, forDecorationViewOfKind: "Seperator")
+        registerClass(TopTabsSeparator.self, forDecorationViewOfKind: TopTabsSeparatorUX.Identifier)
     }
     
     override func shouldInvalidateLayoutForBoundsChange(newBounds: CGRect) -> Bool {
@@ -54,11 +53,11 @@ class TopTabsViewLayout: UICollectionViewFlowLayout {
         if let attr = self.decorationAttributeArr[indexPath.row] {
             return attr
         } else {
-            // Sometimes decoration views will be requested for rows that might not exist. Just show an empty seperator.
-            let seperatorAttr = UICollectionViewLayoutAttributes(forDecorationViewOfKind: "Seperator", withIndexPath: indexPath)
-            seperatorAttr.frame = CGRect.zero
-            seperatorAttr.zIndex = -1
-            return seperatorAttr
+            // Sometimes decoration views will be requested for rows that might not exist. Just show an empty separator.
+            let separatorAttr = UICollectionViewLayoutAttributes(forDecorationViewOfKind: TopTabsSeparatorUX.Identifier, withIndexPath: indexPath)
+            separatorAttr.frame = CGRect.zero
+            separatorAttr.zIndex = -1
+            return separatorAttr
         }
     }
 
@@ -73,19 +72,19 @@ class TopTabsViewLayout: UICollectionViewFlowLayout {
         decorationAttributes.zIndex = -1
         decorationAttributes.themeColor = self.themeColor
 
-        // Create attributes for the Tab Seperator.
-        var seperatorArr: [Int: UICollectionViewLayoutAttributes] = [:]
+        // Create attributes for the Tab Separator.
+        var separatorArr: [Int: UICollectionViewLayoutAttributes] = [:]
         for i in attributes {
             if i.indexPath.item > 0 {
-                let sep = UICollectionViewLayoutAttributes(forDecorationViewOfKind: "Seperator", withIndexPath: i.indexPath)
-                sep.frame = CGRect(x: i.frame.origin.x - 2, y: i.frame.size.height / 4 , width: 1, height: i.frame.size.height / 2)
+                let sep = UICollectionViewLayoutAttributes(forDecorationViewOfKind: TopTabsSeparatorUX.Identifier, withIndexPath: i.indexPath)
+                sep.frame = CGRect(x: i.frame.origin.x - 2, y: i.frame.size.height / 4, width: TopTabsSeparatorUX.Width, height: i.frame.size.height / 2)
                 sep.zIndex = -1
-                seperatorArr[i.indexPath.row] = sep
+                separatorArr[i.indexPath.row] = sep
                 attributes.append(sep)
             }
         }
 
-        self.decorationAttributeArr = seperatorArr
+        self.decorationAttributeArr = separatorArr
         attributes.append(decorationAttributes)
         return attributes
     }

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -25,8 +25,9 @@ struct TopTabsUX {
 
 protocol TopTabsDelegate: class {
     func topTabsDidPressTabs()
-    func topTabsDidPressNewTab()
-    func topTabsDidPressPrivateModeButton(cachedTab: Tab?)
+    func topTabsDidPressNewTab(isPrivate: Bool)
+
+    func topTabsDidPressPrivateModeButton()
     func topTabsDidChangeTab()
 }
 
@@ -37,7 +38,8 @@ protocol TopTabCellDelegate: class {
 class TopTabsViewController: UIViewController {
     let tabManager: TabManager
     weak var delegate: TopTabsDelegate?
-    var isPrivate = false
+    private var isPrivate = false
+
     lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: CGRectZero, collectionViewLayout: TopTabsViewLayout())
         collectionView.registerClass(TopTabCell.self, forCellWithReuseIdentifier: TopTabCell.Identifier)
@@ -46,7 +48,6 @@ class TopTabsViewController: UIViewController {
         collectionView.bounces = false
         collectionView.clipsToBounds = false
         collectionView.accessibilityIdentifier = "Top Tabs View"
-        
         return collectionView
     }()
     
@@ -75,18 +76,24 @@ class TopTabsViewController: UIViewController {
         delegate.tabSelectionDelegate = self
         return delegate
     }()
-    
-    private weak var lastNormalTab: Tab?
-    private weak var lastPrivateTab: Tab?
-    
+
     private var tabsToDisplay: [Tab] {
         return self.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
     }
-    
+
+    // Used for diffing collection view updates (animations)
+    private var isUpdating = false
+    private var pendingReloadData = false
+    private var _oldTabs: [Tab] = []
+    private weak var _oldSelectedTab: Tab?
+    private var inserts: [NSIndexPath] = []
+    private var pendingUpdates: [tableUpdate] = []
+
+
     init(tabManager: TabManager) {
         self.tabManager = tabManager
         super.init(nibName: nil, bundle: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(TopTabsViewController.reloadFavicons), name: FaviconManager.FaviconDidLoad, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(TopTabsViewController.reloadFavicons(_:)), name: FaviconManager.FaviconDidLoad, object: nil)
     }
     
     deinit {
@@ -102,16 +109,13 @@ class TopTabsViewController: UIViewController {
         super.viewWillAppear(animated)
         collectionView.dataSource = self
         collectionView.delegate = tabLayoutDelegate
-        collectionView.reloadData()
-        dispatch_async(dispatch_get_main_queue()) { 
-             self.scrollToCurrentTab(false, centerCell: true)
-        }
+        self.scrollToCurrentTab(false, centerCell: true)
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         tabManager.addDelegate(self)
-        
+
         let topTabFader = TopTabFader()
         
         view.addSubview(tabsButton)
@@ -174,42 +178,47 @@ class TopTabsViewController: UIViewController {
     }
     
     func newTabTapped() {
-        if let currentTab = tabManager.selectedTab, let index = tabsToDisplay.indexOf(currentTab),
-            let cell  = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: index, inSection: 0)) as? TopTabCell {
-            cell.selectedTab = false
-            if index > 0 {
-                cell.seperatorLine = true
+        dispatch_async(dispatch_get_main_queue()) {
+            self.delegate?.topTabsDidPressNewTab(self.isPrivate)
+        }
+    }
+
+    func togglePrivateModeTapped() {
+        if isUpdating || pendingReloadData {
+            return
+        }
+        delegate?.topTabsDidPressPrivateModeButton()
+        self.pendingReloadData = true
+        let oldSelectedTab = self._oldSelectedTab
+        self._oldSelectedTab = tabManager.selectedTab
+        self.privateModeButton.setSelected(isPrivate, animated: true)
+
+        //if private tabs is empty and we are transitioning to it add a tab
+        if tabManager.privateTabs.isEmpty  && !isPrivate {
+            tabManager.addTab(isPrivate: true)
+        }
+
+        //get the tabs from which we will select which one to nominate for tribute (selection)
+        //the isPrivate boolean still hasnt been flipped. (It'll be flipped in the BVC didSelectedTabChange method)
+        let tabs = !isPrivate ? tabManager.privateTabs : tabManager.normalTabs
+        if let tab = oldSelectedTab where tabs.indexOf(tab) != nil {
+            tabManager.selectTab(tab)
+        } else {
+            tabManager.selectTab(tabs.last)
+        }
+    }
+
+    func reloadFavicons(notification: NSNotification) {
+        dispatch_async(dispatch_get_main_queue()) {
+            if let tab = notification.object as? Tab {
+                self.updateTabsFrom(self.tabsToDisplay, to: self.tabsToDisplay, reloadTabs: [tab])
             }
         }
-        delegate?.topTabsDidPressNewTab()
-        self.privateModeButton.enabled = false
-        collectionView.performBatchUpdates({ _ in
-            let count = self.collectionView.numberOfItemsInSection(0)
-            self.collectionView.insertItemsAtIndexPaths([NSIndexPath(forItem: count, inSection: 0)])
-            }, completion: { finished in
-                if finished {
-                    self.privateModeButton.enabled = true
-                    self.scrollToCurrentTab()
-                }
-        })
-    }
-    
-    func togglePrivateModeTapped() {
-        delegate?.topTabsDidPressPrivateModeButton(isPrivate ? lastNormalTab : lastPrivateTab)
-        self.privateModeButton.setSelected(isPrivate, animated: true)
-        self.collectionView.reloadData()
-        self.scrollToCurrentTab(false, centerCell: true)
-    }
-    
-    func closeTab() {
-        delegate?.topTabsDidPressTabs()
-    }
-    
-    func reloadFavicons() {
-        self.collectionView.reloadData()
     }
     
     func scrollToCurrentTab(animated: Bool = true, centerCell: Bool = false) {
+        assertIsMainThread("Only animate on the main thread")
+
         guard let currentTab = tabManager.selectedTab, let index = tabsToDisplay.indexOf(currentTab) where !collectionView.frame.isEmpty else {
             return
         }
@@ -243,37 +252,11 @@ extension TopTabsViewController: Themeable {
 
 extension TopTabsViewController: TopTabCellDelegate {
     func tabCellDidClose(cell: TopTabCell) {
-        guard let indexPath = collectionView.indexPathForCell(cell) else {
+        guard let index = collectionView.indexPathForCell(cell)?.item else {
             return
         }
-        let tab = tabsToDisplay[indexPath.item]
-        var selectedTab = false
-        if tab == tabManager.selectedTab {
-            selectedTab = true
-            delegate?.topTabsDidChangeTab()
-        }
-        if tabsToDisplay.count == 1 {
-            tabManager.removeTab(tab)
-            tabManager.selectTab(tabsToDisplay.first)
-            collectionView.reloadData()
-        } else {
-            var nextTab: Tab
-            let currentIndex = indexPath.item
-            if tabsToDisplay.count-1 > currentIndex {
-                nextTab = tabsToDisplay[currentIndex+1]
-            } else {
-                nextTab = tabsToDisplay[currentIndex-1]
-            }
-            tabManager.removeTab(tab)
-            if selectedTab {
-                tabManager.selectTab(nextTab)
-            }
-            self.collectionView.performBatchUpdates({
-                self.collectionView.deleteItemsAtIndexPaths([indexPath])
-                }, completion: { finished in
-                    self.collectionView.reloadData()
-            })
-        }
+        let tab = tabsToDisplay[index]
+        tabManager.removeTab(tab)
     }
 }
 
@@ -328,44 +311,192 @@ extension TopTabsViewController: TabSelectionDelegate {
     func didSelectTabAtIndex(index: Int) {
         let tab = tabsToDisplay[index]
         tabManager.selectTab(tab)
-        collectionView.reloadData()
-        collectionView.setNeedsDisplay()
-        delegate?.topTabsDidChangeTab()
-        scrollToCurrentTab()
     }
 }
 
-extension TopTabsViewController : WKNavigationDelegate {
-    func webView(webView: WKWebView, didFinishNavigation navigation: WKNavigation!) {
-        collectionView.reloadData()
+// Collection Diff (animations)
+extension TopTabsViewController {
+
+    struct tableUpdate {
+        let reloads: Set<NSIndexPath>
+        let inserts: Set<NSIndexPath>
+        let deletes: Set<NSIndexPath>
+
+        init(updates: [tableUpdate]) {
+            reloads = Set(updates.flatMap { $0.reloads })
+            inserts = Set(updates.flatMap { $0.inserts })
+            deletes = Set(updates.flatMap { $0.deletes })
+        }
+
+        init(reloadArr: [NSIndexPath], insertArr: [NSIndexPath], deleteArr: [NSIndexPath]) {
+            reloads = Set(reloadArr)
+            inserts = Set(insertArr)
+            deletes = Set(deleteArr)
+        }
+
+        func isEmpty() -> Bool {
+            return inserts.isEmpty && reloads.isEmpty && deletes.isEmpty
+        }
     }
-    
-    func webView(webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
-        collectionView.reloadData()
+
+    // create a tableUpdate which is a snapshot of updates to perfrom on a collectionView
+    func calculateDiffWith(oldTabs: [Tab], to newTabs: [Tab], and reloadTabs: [Tab?]) -> tableUpdate {
+        let reloads: [NSIndexPath] = reloadTabs.flatMap { tab in
+            guard let tab = tab where newTabs.indexOf(tab) != nil else {
+                return nil
+            }
+            return NSIndexPath(forRow: newTabs.indexOf(tab)!, inSection: 0)
+        }
+
+        let inserts: [NSIndexPath] = newTabs.enumerate().flatMap { index, tab in
+            if oldTabs.indexOf(tab) == nil {
+                return NSIndexPath(forRow: index, inSection: 0)
+            }
+            return nil
+        }
+
+        let deletes: [NSIndexPath] = oldTabs.enumerate().flatMap { index, tab in
+            if newTabs.indexOf(tab) == nil {
+                return NSIndexPath(forRow: index, inSection: 0)
+            }
+            return nil
+        }
+        return tableUpdate(reloadArr: reloads, insertArr: inserts, deleteArr: deletes)
+    }
+
+    func updateTabsFrom(oldTabs: [Tab], to newTabs: [Tab], reloadTabs: [Tab?]) {
+        assertIsMainThread("Updates can only be performed from the main thread")
+
+        self.pendingUpdates.append(self.calculateDiffWith(oldTabs, to: newTabs, and: reloadTabs))
+        if self.isUpdating || self.pendingReloadData {
+            return
+        }
+
+        self.isUpdating = true
+        let updates = self.pendingUpdates
+        self.flushPendingChanges()
+        let update = tableUpdate(updates: updates)
+
+        performUpdateWithChanges(update) { (_) in
+            // This handles the edge case where, during the animation we've toggled private mode
+            // Because we dont have a proper way of knowing when this transition is about to happen we have to do this check here
+            print("number of items in datastore AFTER UPDATE \(self.tabsToDisplay.count)")
+            if  !self.tabsMatchDisplayGroup(newTabs.first, b: self.tabsToDisplay.first) || self.pendingReloadData {
+                self.reloadData()
+            } else if self.pendingUpdates.isEmpty && !self.isUpdating && !update.inserts.isEmpty {
+                self.scrollToCurrentTab()
+            }
+        }
+    }
+
+    func performUpdateWithChanges(update: tableUpdate, completion: (Bool)-> Void) {
+        //Speed up the animation a bit to make it feel snappier
+        let newUpdates = update.reloads.filter { self.tabsToDisplay.count  > $0.row }
+        UIView.animateWithDuration(0.1) {
+            self.collectionView.performBatchUpdates({
+                self.collectionView.deleteItemsAtIndexPaths(Array(update.deletes))
+                self.collectionView.reloadItemsAtIndexPaths(Array(newUpdates))
+                self.collectionView.insertItemsAtIndexPaths(Array(update.inserts))
+                self.isUpdating = false
+                }, completion: completion)
+        }
+    }
+
+    private func flushPendingChanges() {
+        _oldTabs.removeAll()
+        pendingUpdates.removeAll()
+    }
+
+    private func reloadData() {
+        assertIsMainThread("reloadData must only be called from main thread")
+
+        if self.isUpdating {
+            self.pendingReloadData = true
+            return
+        }
+
+        isUpdating = true
+        self.newTab.userInteractionEnabled = false
+        UIView.animateWithDuration(0.2, animations: {
+            self.collectionView.reloadData()
+            self.collectionView.collectionViewLayout.invalidateLayout()
+            self.collectionView.layoutIfNeeded()
+            self.scrollToCurrentTab(true, centerCell: true)
+        }) { (_) in
+            self.flushPendingChanges()
+            self.isUpdating = false
+            self.pendingReloadData = false
+            self.newTab.userInteractionEnabled = true
+        }
     }
 }
 
 extension TopTabsViewController: TabManagerDelegate {
+
+    // Because we don't know when we are about to transition to private mode
+    // check to make sure that the tab we are trying to add is being added to the right tab group
+    private func tabsMatchDisplayGroup(a: Tab?, b: Tab?) -> Bool {
+        if let a = a, let b = b where a.isPrivate == b.isPrivate {
+            return true
+        }
+        return false
+    }
+
+    // This helps make sure animations don't happen before the view is loaded.
+    private var isRestoring: Bool {
+        return self.tabManager.isRestoring || self.collectionView.frame == CGRect.zero
+    }
+
     func tabManager(tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?) {
-        if selected?.isPrivate ?? false {
-            lastPrivateTab = selected
+        if isRestoring {
+            return
+        }
+
+        if !tabsMatchDisplayGroup(selected, b: previous) {
+            self.reloadData()
         } else {
-            lastNormalTab = selected
+            print("about to update \(#function)")
+            self.updateTabsFrom(self.tabsToDisplay, to: self.tabsToDisplay, reloadTabs: [selected, previous])
+            delegate?.topTabsDidChangeTab()
         }
     }
-    func tabManager(tabManager: TabManager, didCreateTab tab: Tab) {}
-    func tabManager(tabManager: TabManager, didAddTab tab: Tab) {}
-    func tabManager(tabManager: TabManager, didRemoveTab tab: Tab) {}
-    func tabManagerDidRestoreTabs(tabManager: TabManager) {}
-    func tabManagerDidAddTabs(tabManager: TabManager) {
-        collectionView.reloadData()
+
+    func tabManager(tabManager: TabManager, willAddTab tab: Tab) {
+        self._oldTabs = tabsToDisplay
     }
-    func tabManagerDidRemoveAllTabs(tabManager: TabManager, toast: ButtonToast?) {
-        if let privateTab = lastPrivateTab where !tabManager.tabs.contains(privateTab) {
-            lastPrivateTab = nil
+
+    func tabManager(tabManager: TabManager, didAddTab tab: Tab) {
+        if isRestoring || (tabManager.selectedTab != nil && !tabsMatchDisplayGroup(tab, b: tabManager.selectedTab)) {
+            return
         }
-        if let normalTab = lastNormalTab where !tabManager.tabs.contains(normalTab) {
-            lastNormalTab = nil
-        }
+
+        let oldTabs = _oldTabs
+        _oldTabs = []
+
+        print("about to update \(#function)")
+        self.updateTabsFrom(oldTabs, to: self.tabsToDisplay, reloadTabs: [self.tabManager.selectedTab])
     }
+
+    func tabManager(tabManager: TabManager, willRemoveTab tab: Tab) {
+        self._oldTabs = tabsToDisplay
+    }
+
+    func tabManager(tabManager: TabManager, didRemoveTab tab: Tab) {
+        if isRestoring {
+            return
+        }
+        let oldTabs = _oldTabs
+        if tab === _oldSelectedTab {
+            _oldSelectedTab = nil
+        }
+        _oldTabs = []
+        self.updateTabsFrom(oldTabs, to: self.tabsToDisplay, reloadTabs: [])
+    }
+
+    func tabManagerDidRestoreTabs(tabManager: TabManager) {
+        self.collectionView.reloadData()
+    }
+
+    func tabManagerDidAddTabs(tabManager: TabManager) {}
+    func tabManagerDidRemoveAllTabs(tabManager: TabManager, toast: ButtonToast?) {}
 }

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -301,13 +301,7 @@ extension TopTabsViewController: UICollectionViewDataSource {
         }
 
         tabCell.selectedTab = (tab == tabManager.selectedTab)
-        
-        if index > 0 && index < tabsToDisplay.count && tabsToDisplay[index] != tabManager.selectedTab && tabsToDisplay[index-1] != tabManager.selectedTab {
-            tabCell.seperatorLine = true
-        } else {
-            tabCell.seperatorLine = false
-        }
-        
+
         if let favIcon = tab.displayFavicon,
            let url = NSURL(string: favIcon.url) {
             tabCell.favicon.sd_setImageWithURL(url)

--- a/Client/Frontend/Browser/TopTabsViews.swift
+++ b/Client/Frontend/Browser/TopTabsViews.swift
@@ -4,6 +4,17 @@
 
 import Foundation
 
+class Seperator: UICollectionReusableView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.backgroundColor = UIColor.whiteColor().colorWithAlphaComponent(0.2)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 class TopTabCell: UICollectionViewCell {
     enum Style {
         case Light
@@ -16,14 +27,6 @@ class TopTabCell: UICollectionViewCell {
         didSet {
             if style != oldValue {
                 applyStyle(style)
-            }
-        }
-    }
-    
-    var seperatorLine: Bool = false {
-        didSet {
-            if seperatorLine != oldValue {
-                setNeedsDisplay()
             }
         }
     }
@@ -136,22 +139,7 @@ class TopTabCell: UICollectionViewCell {
     func closeTab() {
         delegate?.tabCellDidClose(self)
     }
-    
-    override func drawRect(rect: CGRect) {
-        super.drawRect(rect)
-        guard seperatorLine else {
-            return
-        }
-        guard let context = UIGraphicsGetCurrentContext() else { return }
-        CGContextSaveGState(context)
-        CGContextSetLineCap(context, CGLineCap.Square)
-        CGContextSetStrokeColorWithColor(context, UIColor.whiteColor().colorWithAlphaComponent(0.2).CGColor)
-        CGContextSetLineWidth(context, 1.0)
-        CGContextMoveToPoint(context, 0, TopTabsUX.BackgroundSeparatorLinePadding)
-        CGContextAddLineToPoint(context, 0, frame.size.height-TopTabsUX.BackgroundSeparatorLinePadding)
-        CGContextStrokePath(context)
-        CGContextRestoreGState(context)
-    }
+
 }
 
 private class BezierView: UIView {

--- a/Client/Frontend/Browser/TopTabsViews.swift
+++ b/Client/Frontend/Browser/TopTabsViews.swift
@@ -85,7 +85,7 @@ class TopTabCell: UICollectionViewCell {
         bezierView.snp_makeConstraints { make in
             make.centerY.centerX.equalTo(self)
             make.height.equalTo(self)
-            make.width.equalTo(frame.width+TopTabsUX.TopTabsBackgroundPadding)
+            make.width.equalTo(frame.width + TopTabsUX.TopTabsBackgroundPadding + 3)
         }
         favicon.snp_makeConstraints { make in
             make.centerY.equalTo(self)
@@ -274,6 +274,7 @@ class TopTabsBackgroundDecorationView: UICollectionReusableView {
         init(right: Bool) {
             self.right = right
             super.init(frame: CGRectZero)
+            self.backgroundColor = UIColor.clearColor()
         }
         
         required init?(coder aDecoder: NSCoder) {
@@ -282,10 +283,8 @@ class TopTabsBackgroundDecorationView: UICollectionReusableView {
         
         override func drawRect(rect: CGRect) {
             super.drawRect(rect)
-            
             let bezierPath = UIBezierPath.topTabsCurve(frame.width, height: frame.height, direction: right ? .Right : .Left)
-            
-            self.themeColor.setFill()
+            themeColor.setFill()
             bezierPath.fill()
         }
     }

--- a/Client/Frontend/Browser/TopTabsViews.swift
+++ b/Client/Frontend/Browser/TopTabsViews.swift
@@ -4,10 +4,15 @@
 
 import Foundation
 
-class Seperator: UICollectionReusableView {
+struct TopTabsSeparatorUX {
+    static let Identifier = "Separator"
+    static let Color = UIColor.whiteColor().colorWithAlphaComponent(0.2)
+    static let Width: CGFloat = 1
+}
+class TopTabsSeparator: UICollectionReusableView {
     override init(frame: CGRect) {
         super.init(frame: frame)
-        self.backgroundColor = UIColor.whiteColor().colorWithAlphaComponent(0.2)
+        self.backgroundColor = TopTabsSeparatorUX.Color
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -84,11 +89,14 @@ class TopTabCell: UICollectionViewCell {
         contentView.addSubview(self.closeButton)
         contentView.addSubview(self.titleText)
         contentView.addSubview(self.favicon)
-        
+
+        // The tab needs to be slightly bigger in order for the background view not to appear underneath
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1320135
+        let bezierOffset: CGFloat = 3
         bezierView.snp_makeConstraints { make in
             make.centerY.centerX.equalTo(self)
             make.height.equalTo(self)
-            make.width.equalTo(frame.width + TopTabsUX.TopTabsBackgroundPadding + 3)
+            make.width.equalTo(frame.width + TopTabsUX.TopTabsBackgroundPadding + bezierOffset)
         }
         favicon.snp_makeConstraints { make in
             make.centerY.equalTo(self)

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -222,7 +222,7 @@ class TabsButton: UIControl {
             }
             
             if animated {
-                UIView.animateWithDuration(1.5, delay: 0, usingSpringWithDamping: 0.5, initialSpringVelocity: 0.0, options: UIViewAnimationOptions.CurveEaseInOut, animations: animate, completion: completion)
+                UIView.animateWithDuration(0.5, delay: 0, usingSpringWithDamping: 0.5, initialSpringVelocity: 0.0, options: UIViewAnimationOptions.CurveEaseInOut, animations: animate, completion: completion)
             } else {
                 completion(true)
             }

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -222,7 +222,7 @@ class TabsButton: UIControl {
             }
             
             if animated {
-                UIView.animateWithDuration(0.5, delay: 0, usingSpringWithDamping: 0.5, initialSpringVelocity: 0.0, options: UIViewAnimationOptions.CurveEaseInOut, animations: animate, completion: completion)
+                UIView.animateWithDuration(1.5, delay: 0, usingSpringWithDamping: 0.5, initialSpringVelocity: 0.0, options: UIViewAnimationOptions.CurveEaseInOut, animations: animate, completion: completion)
             } else {
                 completion(true)
             }

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -27,6 +27,78 @@ public class MockTabManagerStateDelegate: TabManagerStateDelegate {
     }
 }
 
+struct methodSpy {
+    let functionName: String
+    let method: ((tabs: [Tab?]) -> Void)?
+
+    init(functionName: String) {
+        self.functionName = functionName
+        self.method = nil
+    }
+
+    init(functionName: String, method: ((tabs: [Tab?]) -> Void)?) {
+        self.functionName = functionName
+        self.method = method
+    }
+}
+
+public class MockTabManagerDelegate: TabManagerDelegate {
+
+    //this array represents the order in which delegate methods should be called.
+    //each delegate method will pop the first struct from the array. If the method name doesn't match the struct then the order is incorrect
+    //Then it evaluates the method closure which will return true/false depending on if the tabs are correct
+    var methodCatchers: [methodSpy] = []
+
+    func testDelegateMethodWithName(name: String, tabs: [Tab?]) {
+        guard let spy = self.methodCatchers.first else {
+            XCTAssert(false, "No method was availible in the queue. For the delegate method \(name) to use")
+            return
+        }
+        XCTAssertEqual(spy.functionName, name)
+        if let methodCheck = spy.method {
+            methodCheck(tabs: tabs)
+        }
+        methodCatchers.removeFirst()
+    }
+
+    func tabManager(tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?) {
+        testDelegateMethodWithName(#function, tabs: [selected, previous])
+    }
+
+    func tabManager(tabManager: TabManager, didCreateTab tab: Tab) {
+        testDelegateMethodWithName(#function, tabs: [tab])
+    }
+
+    func tabManager(tabManager: TabManager, didAddTab tab: Tab) {
+        testDelegateMethodWithName(#function, tabs: [tab])
+    }
+
+    func tabManager(tabManager: TabManager, didRemoveTab tab: Tab) {
+        testDelegateMethodWithName(#function, tabs: [tab])
+    }
+
+    func tabManagerDidRestoreTabs(tabManager: TabManager) {
+        testDelegateMethodWithName(#function, tabs: [])
+    }
+
+    func tabManager(tabManager: TabManager, willRemoveTab tab: Tab) {
+
+    }
+
+    func tabManager(tabManager: TabManager, willAddTab tab: Tab) {
+        testDelegateMethodWithName(#function, tabs: [tab])
+    }
+
+    func tabManagerDidAddTabs(tabManager: TabManager) {
+        testDelegateMethodWithName(#function, tabs: [])
+    }
+
+    func tabManagerDidRemoveAllTabs(tabManager: TabManager, toast: ButtonToast?) {
+        testDelegateMethodWithName(#function, tabs: [])
+    }
+}
+
+
 class TabManagerTests: XCTestCase {
 
     override func setUp() {
@@ -78,5 +150,197 @@ class TabManagerTests: XCTestCase {
 
         XCTAssertEqual(stateDelegate.numberOfTabsStored, 0, "Expected state delegate to have been called with 3 tabs, but called with \(stateDelegate.numberOfTabsStored)")
     }
-    
+
+    func testAddTab() {
+        let profile = TabManagerMockProfile()
+        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let delegate = MockTabManagerDelegate()
+        manager.addDelegate(delegate)
+
+        let willCreate = methodSpy(functionName: "tabManager(_:willAddTab:)")
+        let didAdd = methodSpy(functionName: "tabManager(_:didAddTab:)")
+        delegate.methodCatchers = [willCreate, didAdd]
+        manager.addTab()
+        XCTAssertTrue(delegate.methodCatchers.isEmpty, "Not all delegate methods were called")
+    }
+
+    func testDidDeleteLastTab() {
+        let profile = TabManagerMockProfile()
+        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let delegate = MockTabManagerDelegate()
+
+        //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
+        let tab = manager.addTab()
+        manager.selectTab(tab)
+        manager.addDelegate(delegate)
+
+        let didRemove = methodSpy(functionName: "tabManager(_:didRemoveTab:)")
+        let didCreate = methodSpy(functionName: "tabManager(_:willAddTab:)")
+        let didAdd = methodSpy(functionName: "tabManager(_:didAddTab:)")
+        let didSelect = methodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
+            let next = tabs[0]!
+            let previous = tabs[1]!
+            XCTAssertTrue(previous != next)
+            XCTAssertTrue(previous == tab)
+            XCTAssertFalse(next.isPrivate)
+        }
+        delegate.methodCatchers = [didRemove, didCreate, didAdd, didSelect]
+        manager.removeTab(tab)
+        XCTAssertTrue(delegate.methodCatchers.isEmpty, "Not all delegate methods were called")
+    }
+
+
+    func testDidDeleteLastPrivateTab() {
+        let profile = TabManagerMockProfile()
+        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let delegate = MockTabManagerDelegate()
+
+        //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
+        let tab = manager.addTab()
+        manager.selectTab(tab)
+        let privateTab = manager.addTab(isPrivate: true)
+        manager.selectTab(privateTab)
+        manager.addDelegate(delegate)
+
+        let didRemove = methodSpy(functionName: "tabManager(_:didRemoveTab:)")
+        let didSelect = methodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
+            let next = tabs[0]!
+            let previous = tabs[1]!
+            XCTAssertTrue(previous != next)
+            XCTAssertTrue(previous == privateTab)
+            XCTAssertTrue(next == tab)
+            XCTAssertTrue(previous.isPrivate)
+            XCTAssertTrue(manager.selectedTab == next)
+        }
+        delegate.methodCatchers = [didRemove, didSelect]
+        manager.removeTab(privateTab)
+        XCTAssertTrue(delegate.methodCatchers.isEmpty, "Not all delegate methods were called")
+    }
+
+    func testDeleteNonSelectedTab() {
+        let profile = TabManagerMockProfile()
+        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let delegate = MockTabManagerDelegate()
+
+        //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
+        let tab = manager.addTab()
+        manager.selectTab(tab)
+        manager.addTab()
+        let deleteTab = manager.addTab()
+        manager.addDelegate(delegate)
+
+        let didRemove = methodSpy(functionName: "tabManager(_:didRemoveTab:)")
+        delegate.methodCatchers = [didRemove]
+        manager.removeTab(deleteTab)
+
+        XCTAssertTrue(delegate.methodCatchers.isEmpty, "Not all delegate methods were called")
+    }
+
+    func testDeleteLastTab() {
+        let profile = TabManagerMockProfile()
+        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let delegate = MockTabManagerDelegate()
+
+        //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
+        (0..<10).forEach {_ in manager.addTab() }
+        manager.selectTab(manager.tabs.last)
+        let deleteTab = manager.tabs.last
+        let newSelectedTab = manager.tabs[8]
+        manager.addDelegate(delegate)
+
+        let didRemove = methodSpy(functionName: "tabManager(_:didRemoveTab:)")
+        let didSelect = methodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
+            let next = tabs[0]!
+            let previous = tabs[1]!
+            XCTAssertEqual(deleteTab, previous)
+            XCTAssertEqual(next, newSelectedTab)
+        }
+        delegate.methodCatchers = [didRemove, didSelect]
+        manager.removeTab(manager.tabs.last!)
+
+        XCTAssertTrue(delegate.methodCatchers.isEmpty, "Not all delegate methods were called")
+    }
+
+
+    func testDeleteFirstTab() {
+        let profile = TabManagerMockProfile()
+        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let delegate = MockTabManagerDelegate()
+
+        //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
+        (0..<10).forEach {_ in manager.addTab() }
+        manager.selectTab(manager.tabs.first)
+        let deleteTab = manager.tabs.first
+        let newSelectedTab = manager.tabs[1]
+        manager.addDelegate(delegate)
+
+        let didRemove = methodSpy(functionName: "tabManager(_:didRemoveTab:)")
+        let didSelect = methodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
+            let next = tabs[0]!
+            let previous = tabs[1]!
+            XCTAssertEqual(deleteTab, previous)
+            XCTAssertEqual(next, newSelectedTab)
+        }
+        delegate.methodCatchers = [didRemove, didSelect]
+        manager.removeTab(manager.tabs.first!)
+
+        XCTAssertTrue(delegate.methodCatchers.isEmpty, "Not all delegate methods were called")
+    }
+
+    // Private tabs and regular tabs are in the same tabs array.
+    // Make sure that when a private tab is added inbetween regular tabs it isnt accidently selected when removing a regular tab
+    func testTabsIndex() {
+        let profile = TabManagerMockProfile()
+        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let delegate = MockTabManagerDelegate()
+
+        // We add 2 tabs. Then a private one before adding another normal tab and selecting it.
+        // Make sure that when the last one is deleted we dont switch to the private tab
+        manager.addTab()
+        let newSelected = manager.addTab()
+        manager.addTab(isPrivate: true)
+        let deleted = manager.addTab()
+        manager.selectTab(manager.tabs.last)
+        manager.addDelegate(delegate)
+
+        let didRemove = methodSpy(functionName: "tabManager(_:didRemoveTab:)")
+        let didSelect = methodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
+            let next = tabs[0]!
+            let previous = tabs[1]!
+            XCTAssertEqual(deleted, previous)
+            XCTAssertEqual(next, newSelected)
+        }
+        delegate.methodCatchers = [didRemove, didSelect]
+        manager.removeTab(manager.tabs.last!)
+
+        XCTAssertTrue(delegate.methodCatchers.isEmpty, "Not all delegate methods were called")
+    }
+
+    func testTabsIndexClosingFirst() {
+        let profile = TabManagerMockProfile()
+        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let delegate = MockTabManagerDelegate()
+
+        // We add 2 tabs. Then a private one before adding another normal tab and selecting the first.
+        // Make sure that when the last one is deleted we dont switch to the private tab
+        let deleted = manager.addTab()
+        let newSelected = manager.addTab()
+        manager.addTab(isPrivate: true)
+        manager.addTab()
+        manager.selectTab(manager.tabs.first)
+        manager.addDelegate(delegate)
+
+        let didRemove = methodSpy(functionName: "tabManager(_:didRemoveTab:)")
+        let didSelect = methodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
+            let next = tabs[0]!
+            let previous = tabs[1]!
+            XCTAssertEqual(deleted, previous)
+            XCTAssertEqual(next, newSelected)
+        }
+        delegate.methodCatchers = [didRemove, didSelect]
+        manager.removeTab(manager.tabs.first!)
+
+        XCTAssertTrue(delegate.methodCatchers.isEmpty, "Not all delegate methods were called")
+    }
+
 }

--- a/ClientTests/TopTabsTests.swift
+++ b/ClientTests/TopTabsTests.swift
@@ -1,0 +1,130 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@testable import Client
+import Foundation
+import Shared
+import Storage
+
+import XCTest
+
+class TestTopTabs: XCTestCase {
+
+    var window: UIWindow!
+    var manager: TabManager!
+    var tabVC: TopTabsViewController!
+    var bvc: BrowserViewController! //Needed because of delegates dawg
+
+    //Give some time for animations to finish
+    func verifyAfter(block: () -> Void) {
+        let seconds: Double = 1
+        let dispatchTime: dispatch_time_t = dispatch_time(DISPATCH_TIME_NOW, Int64(seconds * Double(NSEC_PER_SEC)))
+        dispatch_after(dispatchTime, dispatch_get_main_queue(), block)
+    }
+
+    override func setUp() {
+        super.setUp()
+        window = UIWindow(frame: CGRect(x: 0, y: 0, width: 500, height: 500))
+        let profile = TabManagerMockProfile()
+        //This prevent the "whats new" tab from opening. Tests dont care 👯
+        profile.prefs.setString(AppInfo.appVersion, forKey: LatestAppVersionProfileKey)
+        self.manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        self.bvc = BrowserViewController(profile: profile, tabManager: manager)
+        window.addSubview(bvc.view)
+    }
+
+    // We do this AFTER we've setup the TabManger with the state we want
+    //This is a way of tricking TopTabs from not animating while I setup the correct state
+    private func createTopTabsVC() {
+        tabVC = TopTabsViewController(tabManager: manager)
+        tabVC.delegate = bvc
+        bvc.topTabsViewController = tabVC
+        window.addSubview(tabVC.view)
+        tabVC.collectionView.reloadData()
+        tabVC.collectionView.layoutIfNeeded()
+    }
+
+
+    func testAddingTab() {
+        createTopTabsVC()
+
+        let countBefore = tabVC.collectionView.numberOfItemsInSection(0)
+        XCTAssertEqual(1, countBefore, "Make sure only one tab is open.")
+        tabVC.newTabTapped()
+        let expectation = expectationWithDescription("A single tab is Added")
+
+        verifyAfter { 
+            let countAfter = self.tabVC.collectionView.numberOfItemsInSection(0)
+            XCTAssertEqual(countBefore + 1, countAfter, "There should be one more tab after the newTab button is tapped")
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(5, handler: nil)
+    }
+
+    func testRemoveTab() {
+        manager.selectTab(manager.addTab())
+        createTopTabsVC()
+
+        let countBefore = tabVC.collectionView.numberOfItemsInSection(0)
+        let cell = tabVC.collectionView.cellForItemAtIndexPath(NSIndexPath(forRow: 1, inSection: 0)) as! TopTabCell
+        XCTAssertNotNil(cell)
+        cell.closeTab()
+        let expectation = expectationWithDescription("A single tab is removed")
+
+        verifyAfter {
+            let countAfter = self.tabVC.collectionView.numberOfItemsInSection(0)
+            XCTAssertEqual(countBefore - 1, countAfter, "There should be one less tab after the newTab button is tapped")
+            expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(5, handler: nil)
+    }
+
+    func testRemoveLastNormalTab() {
+        createTopTabsVC()
+
+        let countBefore = tabVC.collectionView.numberOfItemsInSection(0)
+        XCTAssertEqual(countBefore, 1)
+        let cell = tabVC.collectionView.cellForItemAtIndexPath(NSIndexPath(forRow: 0, inSection: 0)) as! TopTabCell
+        XCTAssertNotNil(cell)
+        cell.closeTab()
+        let expectation = expectationWithDescription("A single tab is removed")
+
+        verifyAfter {
+            let countAfter = self.tabVC.collectionView.numberOfItemsInSection(0)
+            XCTAssertEqual(countBefore, countAfter, "A new tab should have been added.")
+            expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(5, handler: nil)
+    }
+
+
+    // We should keep the tab state while toggling private mode
+    func testCorrectTabSelectedWhileTogglingPrivateMode() {
+        (0..<10).forEach {_ in manager.addTab() }
+        let normalSelectedTab = manager.normalTabs[3]
+        manager.selectTab(normalSelectedTab)
+        createTopTabsVC()
+
+        tabVC.togglePrivateModeTapped()
+        let expectation = expectationWithDescription("Private Mode is selected.")
+
+        verifyAfter {
+            XCTAssertTrue(self.manager.selectedTab!.isPrivate, "We should have created and selected a private tab")
+            expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(5, handler: nil)
+
+        tabVC.togglePrivateModeTapped()
+        let normalModeExpectation = expectationWithDescription("Normal mode selected")
+        verifyAfter {
+            XCTAssertTrue(!self.manager.selectedTab!.isPrivate, "We should have created and selected a private tab")
+            XCTAssertEqual(normalSelectedTab, self.manager.selectedTab, "The selectedtab should be equal to the previous normal tab")
+            normalModeExpectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(5, handler: nil)
+    }
+    
+
+}

--- a/UITests/TopTabsTests.swift
+++ b/UITests/TopTabsTests.swift
@@ -62,10 +62,9 @@ class TopTabsTests: KIFTestCase {
     
     private func AddTab() {
         tester().waitForTappableViewWithAccessibilityLabel("Show Tabs", value: "1", traits: UIAccessibilityTraitButton)
-        
-        tester().tapViewWithAccessibilityIdentifier("url")
-        
+
         for i in 0..<numberOfTabs {
+            tester().tapViewWithAccessibilityIdentifier("url")
             let url = "\(webRoot)/numberedPage.html?page=\(i)"
             tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("\(url)\n")
             tester().waitForWebViewElementWithAccessibilityLabel("Page \(i)")


### PR DESCRIPTION
Well, I sure hope so!  🤞

I've split it up into sizeable chunks. The last commit is the major one. The rest are all small changes to fix bugs.

Please make sure to run it and let me know what you think.

I wasn't able to make it as snappy as I wanted. A lot of that has to do with toggling private mode while animations are happening. Sometimes TopTabs might display the wrong theme for tabs when in private mode. I'll need to rework TabManager a bit to fix this. Basically right now BVC/TabTray/TopTabs all store the logic of how to switch to private mode. Instead, that logic should live in TabManger so that TabManger can let the delegates know the change is going to happen and act accordingly. I'm going to have to think this through a bit more before I fix it. So for now, I'd like to get this merged so to avoid making it any bigger. 

All of this lives behind a FeatureFlag. The only thing that might have any adverse effects on the app is the changes related to TabManager. 