### PR TITLE
Bug 1331327 - Show correct menu on blank new tab

### DIFF
--- a/Client/Application/AppState.swift
+++ b/Client/Application/AppState.swift
@@ -19,6 +19,7 @@ enum UIState {
     case HomePanels(homePanelState: HomePanelState)
     case TabTray(tabTrayState: TabTrayState)
     case Loading
+    case EmptyTab
 
     func isPrivate() -> Bool {
         switch self {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1284,6 +1284,9 @@ class BrowserViewController: UIViewController {
         guard let tab = tabManager.selectedTab else {
             return .Loading
         }
+        if tab.url == nil {
+            return .EmptyTab
+        }
         return .Tab(tabState: tab.tabState)
     }
 

--- a/Client/Frontend/Menu/AppMenuConfiguration.swift
+++ b/Client/Frontend/Menu/AppMenuConfiguration.swift
@@ -136,7 +136,7 @@ struct AppMenuConfiguration: MenuConfiguration {
                 }
             }
             menuItems.append(AppMenuConfiguration.SettingsMenuItem)
-        case .HomePanels, .Loading:
+        case .HomePanels:
             menuItems.append(AppMenuConfiguration.NewTabMenuItem)
             menuItems.append(AppMenuConfiguration.NewPrivateTabMenuItem)
             if HomePageAccessors.isButtonInMenu(appState) && HomePageAccessors.hasHomePage(appState) {
@@ -148,6 +148,20 @@ struct AppMenuConfiguration: MenuConfiguration {
                 } else {
                     menuItems.append(AppMenuConfiguration.HideImageModeMenuItem)
                 }
+            }
+            if NightModeAccessors.isNightModeAvailable(appState) {
+                if NightModeAccessors.isNightModeActivated(appState) {
+                    menuItems.append(AppMenuConfiguration.ShowNightModeItem)
+                } else {
+                    menuItems.append(AppMenuConfiguration.HideNightModeItem)
+                }
+            }
+            menuItems.append(AppMenuConfiguration.SettingsMenuItem)
+        case .EmptyTab, .Loading:
+            menuItems.append(AppMenuConfiguration.NewTabMenuItem)
+            menuItems.append(AppMenuConfiguration.NewPrivateTabMenuItem)
+            if HomePageAccessors.isButtonInMenu(appState) && HomePageAccessors.hasHomePage(appState) {
+                menuItems.append(AppMenuConfiguration.OpenHomePageMenuItem)
             }
             if NightModeAccessors.isNightModeAvailable(appState) {
                 if NightModeAccessors.isNightModeActivated(appState) {


### PR DESCRIPTION
* Create new AppState of EmptyTab and use if there is a tab with no URL.
* Create new menu configuration with no "No Images" option for EmptyTab
* Move Loading state to also use this menu configuration