### PR TITLE
Bug 1331418 - automigrate Account code to Swift 3.0

### DIFF
--- a/Account/FirefoxAccount.swift
+++ b/Account/FirefoxAccount.swift
@@ -20,31 +20,31 @@ let AccountSchemaVersion = 1
 ///
 /// Non-sensitive but persistent data should be maintained outside of
 /// the account itself.
-public class FirefoxAccount {
+open class FirefoxAccount {
     /// The email address identifying the account.  A Firefox Account is uniquely identified on a particular server
     /// (auth endpoint) by its email address.
-    public let email: String
+    open let email: String
 
     /// The auth endpoint user identifier identifying the account.  A Firefox Account is uniquely identified on a
     /// particular server (auth endpoint) by its assigned uid.
-    public let uid: String
+    open let uid: String
 
-    public var deviceRegistration: FxADeviceRegistration?
+    open var deviceRegistration: FxADeviceRegistration?
 
-    public let configuration: FirefoxAccountConfiguration
+    open let configuration: FirefoxAccountConfiguration
 
-    private let stateCache: KeychainCache<FxAState>
-    public var syncAuthState: SyncAuthState! // We can't give a reference to self if this is a let.
+    fileprivate let stateCache: KeychainCache<FxAState>
+    open var syncAuthState: SyncAuthState! // We can't give a reference to self if this is a let.
 
     // To prevent advance() consumers racing, we maintain a shared advance() deferred (`advanceDeferred`).  If an
     // advance() is in progress, the shared deferred will be returned.  (Multiple consumers can chain off a single
     // deferred safely.)  If no advance() is in progress, a new shared deferred will be scheduled and returned.  To
     // prevent data races against the shared deferred, advance() locks accesses to `advanceDeferred` using
     // `advanceLock`.
-    private var advanceLock = OSSpinLock()
-    private var advanceDeferred: Deferred<FxAState>? = nil
+    fileprivate var advanceLock = OSSpinLock()
+    fileprivate var advanceDeferred: Deferred<FxAState>? = nil
 
-    public var actionNeeded: FxAActionNeeded {
+    open var actionNeeded: FxAActionNeeded {
         return stateCache.value!.actionNeeded
     }
 
@@ -63,7 +63,7 @@ public class FirefoxAccount {
             cache: KeychainCache.fromBranch("account.syncAuthState", withLabel: self.stateCache.label, factory: syncAuthStateCachefromJSON))
     }
 
-    public class func fromConfigurationAndJSON(configuration: FirefoxAccountConfiguration, data: JSON) -> FirefoxAccount? {
+    open class func fromConfigurationAndJSON(_ configuration: FirefoxAccountConfiguration, data: JSON) -> FirefoxAccount? {
         guard let email = data["email"].asString ,
             let uid = data["uid"].asString,
             let sessionToken = data["sessionToken"].asString?.hexDecodedData,
@@ -78,19 +78,19 @@ public class FirefoxAccount {
             sessionToken: sessionToken, keyFetchToken: keyFetchToken, unwrapkB: unwrapkB)
     }
 
-    public class func fromConfigurationAndLoginResponse(configuration: FirefoxAccountConfiguration,
-            response: FxALoginResponse, unwrapkB: NSData) -> FirefoxAccount {
+    open class func fromConfigurationAndLoginResponse(_ configuration: FirefoxAccountConfiguration,
+            response: FxALoginResponse, unwrapkB: Data) -> FirefoxAccount {
         return FirefoxAccount.fromConfigurationAndParameters(configuration,
             email: response.remoteEmail, uid: response.uid, deviceRegistration: nil, verified: response.verified,
-            sessionToken: response.sessionToken, keyFetchToken: response.keyFetchToken, unwrapkB: unwrapkB)
+            sessionToken: response.sessionToken as Data, keyFetchToken: response.keyFetchToken as Data, unwrapkB: unwrapkB)
     }
 
-    private class func fromConfigurationAndParameters(configuration: FirefoxAccountConfiguration,
+    fileprivate class func fromConfigurationAndParameters(_ configuration: FirefoxAccountConfiguration,
             email: String, uid: String, deviceRegistration: FxADeviceRegistration?, verified: Bool,
-            sessionToken: NSData, keyFetchToken: NSData, unwrapkB: NSData) -> FirefoxAccount {
+            sessionToken: Data, keyFetchToken: Data, unwrapkB: Data) -> FirefoxAccount {
         var state: FxAState! = nil
         if !verified {
-            let now = NSDate.now()
+            let now = Date.now()
             state = EngagedBeforeVerifiedState(knownUnverifiedAt: now,
                 lastNotifiedUserAt: now,
                 sessionToken: sessionToken,
@@ -116,18 +116,18 @@ public class FirefoxAccount {
         return account
     }
 
-    public func asDictionary() -> [String: AnyObject] {
+    open func asDictionary() -> [String: AnyObject] {
         var dict: [String: AnyObject] = [:]
-        dict["version"] = AccountSchemaVersion
-        dict["email"] = email
-        dict["uid"] = uid
+        dict["version"] = AccountSchemaVersion as AnyObject?
+        dict["email"] = email as AnyObject?
+        dict["uid"] = uid as AnyObject?
         dict["deviceRegistration"] = deviceRegistration
-        dict["configurationLabel"] = configuration.label.rawValue
+        dict["configurationLabel"] = configuration.label.rawValue as AnyObject?
         dict["stateKeyLabel"] = stateCache.label
         return dict
     }
 
-    public class func fromDictionary(dictionary: [String: AnyObject]) -> FirefoxAccount? {
+    open class func fromDictionary(_ dictionary: [String: AnyObject]) -> FirefoxAccount? {
         if let version = dictionary["version"] as? Int {
             if version == AccountSchemaVersion {
                 return FirefoxAccount.fromDictionaryV1(dictionary)
@@ -136,15 +136,15 @@ public class FirefoxAccount {
         return nil
     }
 
-    private class func fromDictionaryV1(dictionary: [String: AnyObject]) -> FirefoxAccount? {
+    fileprivate class func fromDictionaryV1(_ dictionary: [String: AnyObject]) -> FirefoxAccount? {
         var configurationLabel: FirefoxAccountConfigurationLabel? = nil
         if let rawValue = dictionary["configurationLabel"] as? String {
             configurationLabel = FirefoxAccountConfigurationLabel(rawValue: rawValue)
         }
         if let
             configurationLabel = configurationLabel,
-            email = dictionary["email"] as? String,
-            uid = dictionary["uid"] as? String {
+            let email = dictionary["email"] as? String,
+            let uid = dictionary["uid"] as? String {
                 let deviceRegistration = dictionary["deviceRegistration"] as? FxADeviceRegistration
                 let stateCache = KeychainCache.fromBranch("account.state", withLabel: dictionary["stateKeyLabel"] as? String, withDefault: SeparatedState(), factory: stateFromJSON)
                 return FirefoxAccount(
@@ -157,16 +157,16 @@ public class FirefoxAccount {
     }
 
     public enum AccountError: MaybeErrorType {
-        case NotMarried
+        case notMarried
 
         public var description: String {
             switch self {
-            case NotMarried: return "Not married."
+            case .notMarried: return "Not married."
             }
         }
     }
 
-    public func advance() -> Deferred<FxAState> {
+    open func advance() -> Deferred<FxAState> {
         OSSpinLockLock(&advanceLock)
         if let deferred = advanceDeferred {
             // We already have an advance() in progress.  This consumer can chain from it.
@@ -205,7 +205,7 @@ public class FirefoxAccount {
         deferred.upon { _ in
             // This advance() is complete.  Clear the shared deferred.
             OSSpinLockLock(&self.advanceLock)
-            if let existingDeferred = self.advanceDeferred where existingDeferred === deferred {
+            if let existingDeferred = self.advanceDeferred, existingDeferred === deferred {
                 // The guard should not be needed, but should prevent trampling racing consumers.
                 self.advanceDeferred = nil
                 log.debug("advance() completed and shared deferred is existing deferred; clearing shared deferred.")
@@ -217,7 +217,7 @@ public class FirefoxAccount {
         return deferred
     }
 
-    public func marriedState() -> Deferred<Maybe<MarriedState>> {
+    open func marriedState() -> Deferred<Maybe<MarriedState>> {
         return advance().map { newState in
             if newState.label == FxAStateLabel.Married {
                 if let married = newState as? MarriedState {
@@ -228,19 +228,19 @@ public class FirefoxAccount {
         }
     }
 
-    public func makeSeparated() -> Bool {
+    open func makeSeparated() -> Bool {
         log.info("Making Account State be Separated.")
         self.stateCache.value = SeparatedState()
         return true
     }
 
-    public func makeDoghouse() -> Bool {
+    open func makeDoghouse() -> Bool {
         log.info("Making Account State be Doghouse.")
         self.stateCache.value = DoghouseState()
         return true
     }
 
-    public func makeCohabitingWithoutKeyPair() -> Bool {
+    open func makeCohabitingWithoutKeyPair() -> Bool {
         if let married = self.stateCache.value as? MarriedState {
             log.info("Making Account State be CohabitingWithoutKeyPair.")
             self.stateCache.value = married.withoutKeyPair()

--- a/Account/FirefoxAccountConfiguration.swift
+++ b/Account/FirefoxAccountConfiguration.swift
@@ -12,10 +12,10 @@ public enum FirefoxAccountConfigurationLabel: String {
 
     public func toConfiguration() -> FirefoxAccountConfiguration {
         switch self {
-        case LatestDev: return LatestDevFirefoxAccountConfiguration()
-        case StableDev: return StableDevFirefoxAccountConfiguration()
-        case Production: return ProductionFirefoxAccountConfiguration()
-        case ChinaEdition: return ChinaEditionFirefoxAccountConfiguration()
+        case .LatestDev: return LatestDevFirefoxAccountConfiguration()
+        case .StableDev: return StableDevFirefoxAccountConfiguration()
+        case .Production: return ProductionFirefoxAccountConfiguration()
+        case .ChinaEdition: return ChinaEditionFirefoxAccountConfiguration()
         }
     }
 }
@@ -31,19 +31,19 @@ public protocol FirefoxAccountConfiguration {
 
     /// A Firefox Account exists on a particular server.  The auth endpoint should speak the protocol documented at
     /// https://github.com/mozilla/fxa-auth-server/blob/02f88502700b0c5ef5a4768a8adf332f062ad9bf/docs/api.md
-    var authEndpointURL: NSURL { get }
+    var authEndpointURL: URL { get }
 
     /// The associated oauth server should speak the protocol documented at
     /// https://github.com/mozilla/fxa-oauth-server/blob/6cc91e285fc51045a365dbacb3617ef29093dbc3/docs/api.md
-    var oauthEndpointURL: NSURL { get }
+    var oauthEndpointURL: URL { get }
 
-    var profileEndpointURL: NSURL { get }
+    var profileEndpointURL: URL { get }
 
     /// The associated content server should speak the protocol implemented (but not yet documented) at
     /// https://github.com/mozilla/fxa-content-server/blob/161bff2d2b50bac86ec46c507e597441c8575189/app/scripts/models/auth_brokers/fx-desktop.js
-    var signInURL: NSURL { get }
-    var settingsURL: NSURL { get }
-    var forceAuthURL: NSURL { get }
+    var signInURL: URL { get }
+    var settingsURL: URL { get }
+    var forceAuthURL: URL { get }
 
     var sync15Configuration: Sync15Configuration { get }
 }
@@ -54,13 +54,13 @@ public struct LatestDevFirefoxAccountConfiguration: FirefoxAccountConfiguration 
 
     public let label = FirefoxAccountConfigurationLabel.LatestDev
 
-    public let authEndpointURL = NSURL(string: "https://latest.dev.lcip.org/auth/v1")!
-    public let oauthEndpointURL = NSURL(string: "https://oauth-latest.dev.lcip.org")!
-    public let profileEndpointURL = NSURL(string: "https://latest.dev.lcip.org/profile")!
+    public let authEndpointURL = URL(string: "https://latest.dev.lcip.org/auth/v1")!
+    public let oauthEndpointURL = URL(string: "https://oauth-latest.dev.lcip.org")!
+    public let profileEndpointURL = URL(string: "https://latest.dev.lcip.org/profile")!
 
-    public let signInURL = NSURL(string: "https://latest.dev.lcip.org/signin?service=sync&context=fx_ios_v1")!
-    public let settingsURL = NSURL(string: "https://latest.dev.lcip.org/settings?context=fx_ios_v1")!
-    public let forceAuthURL = NSURL(string: "https://latest.dev.lcip.org/force_auth?service=sync&context=fx_ios_v1")!
+    public let signInURL = URL(string: "https://latest.dev.lcip.org/signin?service=sync&context=fx_ios_v1")!
+    public let settingsURL = URL(string: "https://latest.dev.lcip.org/settings?context=fx_ios_v1")!
+    public let forceAuthURL = URL(string: "https://latest.dev.lcip.org/force_auth?service=sync&context=fx_ios_v1")!
 
     public let sync15Configuration: Sync15Configuration = StageSync15Configuration()
 }
@@ -71,13 +71,13 @@ public struct StableDevFirefoxAccountConfiguration: FirefoxAccountConfiguration 
 
     public let label = FirefoxAccountConfigurationLabel.StableDev
 
-    public let authEndpointURL = NSURL(string: "https://stable.dev.lcip.org/auth/v1")!
-    public let oauthEndpointURL = NSURL(string: "https://oauth-stable.dev.lcip.org")!
-    public let profileEndpointURL = NSURL(string: "https://stable.dev.lcip.org/profile")!
+    public let authEndpointURL = URL(string: "https://stable.dev.lcip.org/auth/v1")!
+    public let oauthEndpointURL = URL(string: "https://oauth-stable.dev.lcip.org")!
+    public let profileEndpointURL = URL(string: "https://stable.dev.lcip.org/profile")!
 
-    public let signInURL = NSURL(string: "https://stable.dev.lcip.org/signin?service=sync&context=fx_ios_v1")!
-    public let settingsURL = NSURL(string: "https://stable.dev.lcip.org/settings?context=fx_ios_v1")!
-    public let forceAuthURL = NSURL(string: "https://stable.dev.lcip.org/force_auth?service=sync&context=fx_ios_v1")!
+    public let signInURL = URL(string: "https://stable.dev.lcip.org/signin?service=sync&context=fx_ios_v1")!
+    public let settingsURL = URL(string: "https://stable.dev.lcip.org/settings?context=fx_ios_v1")!
+    public let forceAuthURL = URL(string: "https://stable.dev.lcip.org/force_auth?service=sync&context=fx_ios_v1")!
 
     public let sync15Configuration: Sync15Configuration = StageSync15Configuration()
 }
@@ -88,13 +88,13 @@ public struct StageFirefoxAccountConfiguration: FirefoxAccountConfiguration {
 
     public let label = FirefoxAccountConfigurationLabel.Production
 
-    public let authEndpointURL = NSURL(string: "https://api.accounts.firefox.com/v1")!
-    public let oauthEndpointURL = NSURL(string: "https://oauth.accounts.firefox.com/v1")!
-    public let profileEndpointURL = NSURL(string: "https://profile.accounts.firefox.com/v1")!
+    public let authEndpointURL = URL(string: "https://api.accounts.firefox.com/v1")!
+    public let oauthEndpointURL = URL(string: "https://oauth.accounts.firefox.com/v1")!
+    public let profileEndpointURL = URL(string: "https://profile.accounts.firefox.com/v1")!
 
-    public let signInURL = NSURL(string: "https://accounts.firefox.com/signin?service=sync&context=fx_ios_v1")!
-    public let settingsURL = NSURL(string: "https://accounts.firefox.com/settings?context=fx_ios_v1")!
-    public let forceAuthURL = NSURL(string: "https://accounts.firefox.com/force_auth?service=sync&context=fx_ios_v1")!
+    public let signInURL = URL(string: "https://accounts.firefox.com/signin?service=sync&context=fx_ios_v1")!
+    public let settingsURL = URL(string: "https://accounts.firefox.com/settings?context=fx_ios_v1")!
+    public let forceAuthURL = URL(string: "https://accounts.firefox.com/force_auth?service=sync&context=fx_ios_v1")!
 
     public let sync15Configuration: Sync15Configuration = StageSync15Configuration()
 }
@@ -105,13 +105,13 @@ public struct ProductionFirefoxAccountConfiguration: FirefoxAccountConfiguration
 
     public let label = FirefoxAccountConfigurationLabel.Production
 
-    public let authEndpointURL = NSURL(string: "https://api.accounts.firefox.com/v1")!
-    public let oauthEndpointURL = NSURL(string: "https://oauth.accounts.firefox.com/v1")!
-    public let profileEndpointURL = NSURL(string: "https://profile.accounts.firefox.com/v1")!
+    public let authEndpointURL = URL(string: "https://api.accounts.firefox.com/v1")!
+    public let oauthEndpointURL = URL(string: "https://oauth.accounts.firefox.com/v1")!
+    public let profileEndpointURL = URL(string: "https://profile.accounts.firefox.com/v1")!
 
-    public let signInURL = NSURL(string: "https://accounts.firefox.com/signin?service=sync&context=fx_ios_v1")!
-    public let settingsURL = NSURL(string: "https://accounts.firefox.com/settings?context=fx_ios_v1")!
-    public let forceAuthURL = NSURL(string: "https://accounts.firefox.com/force_auth?service=sync&context=fx_ios_v1")!
+    public let signInURL = URL(string: "https://accounts.firefox.com/signin?service=sync&context=fx_ios_v1")!
+    public let settingsURL = URL(string: "https://accounts.firefox.com/settings?context=fx_ios_v1")!
+    public let forceAuthURL = URL(string: "https://accounts.firefox.com/force_auth?service=sync&context=fx_ios_v1")!
 
     public let sync15Configuration: Sync15Configuration = ProductionSync15Configuration()
 }
@@ -122,13 +122,13 @@ public struct ChinaEditionFirefoxAccountConfiguration: FirefoxAccountConfigurati
 
     public let label = FirefoxAccountConfigurationLabel.ChinaEdition
 
-    public let authEndpointURL = NSURL(string: "https://api-accounts.firefox.com.cn/v1")!
-    public let oauthEndpointURL = NSURL(string: "https://oauth.firefox.com.cn/v1")!
-    public let profileEndpointURL = NSURL(string: "https://profile.firefox.com.cn/v1")!
+    public let authEndpointURL = URL(string: "https://api-accounts.firefox.com.cn/v1")!
+    public let oauthEndpointURL = URL(string: "https://oauth.firefox.com.cn/v1")!
+    public let profileEndpointURL = URL(string: "https://profile.firefox.com.cn/v1")!
 
-    public let signInURL = NSURL(string: "https://accounts.firefox.com.cn/signin?service=sync&context=fx_ios_v1")!
-    public let settingsURL = NSURL(string: "https://accounts.firefox.com.cn/settings?context=fx_ios_v1")!
-    public let forceAuthURL = NSURL(string: "https://accounts.firefox.com.cn/force_auth?service=sync&context=fx_ios_v1")!
+    public let signInURL = URL(string: "https://accounts.firefox.com.cn/signin?service=sync&context=fx_ios_v1")!
+    public let settingsURL = URL(string: "https://accounts.firefox.com.cn/settings?context=fx_ios_v1")!
+    public let forceAuthURL = URL(string: "https://accounts.firefox.com.cn/force_auth?service=sync&context=fx_ios_v1")!
 
     public let sync15Configuration: Sync15Configuration = ChinaEditionSync15Configuration()
 }
@@ -137,24 +137,24 @@ public struct ChinaEditionSync15Configuration: Sync15Configuration {
     public init() {
     }
 
-    public let tokenServerEndpointURL = NSURL(string: "https://sync.firefox.com.cn/token/1.0/sync/1.5")!
+    public let tokenServerEndpointURL = URL(string: "https://sync.firefox.com.cn/token/1.0/sync/1.5")!
 }
 
 public protocol Sync15Configuration {
     init()
-    var tokenServerEndpointURL: NSURL { get }
+    var tokenServerEndpointURL: URL { get }
 }
 
 public struct ProductionSync15Configuration: Sync15Configuration {
     public init() {
     }
 
-    public let tokenServerEndpointURL = NSURL(string: "https://token.services.mozilla.com/1.0/sync/1.5")!
+    public let tokenServerEndpointURL = URL(string: "https://token.services.mozilla.com/1.0/sync/1.5")!
 }
 
 public struct StageSync15Configuration: Sync15Configuration {
     public init() {
     }
 
-    public let tokenServerEndpointURL = NSURL(string: "https://token.stage.mozaws.net/1.0/sync/1.5")!
+    public let tokenServerEndpointURL = URL(string: "https://token.stage.mozaws.net/1.0/sync/1.5")!
 }

--- a/Account/FxAClient10.swift
+++ b/Account/FxAClient10.swift
@@ -18,8 +18,8 @@ public struct FxALoginResponse {
     public let remoteEmail: String
     public let uid: String
     public let verified: Bool
-    public let sessionToken: NSData
-    public let keyFetchToken: NSData
+    public let sessionToken: Data
+    public let keyFetchToken: Data
 }
 
 public struct FxAccountRemoteError {
@@ -35,8 +35,8 @@ public struct FxAccountRemoteError {
 }
 
 public struct FxAKeysResponse {
-    let kA: NSData
-    let wrapkB: NSData
+    let kA: Data
+    let wrapkB: Data
 }
 
 public struct FxASignResponse {
@@ -61,19 +61,19 @@ public struct FxADevicesResponse {
 //        }
 
 public enum FxAClientError {
-    case Remote(RemoteError)
-    case Local(NSError)
+    case remote(RemoteError)
+    case local(NSError)
 }
 
 // Be aware that string interpolation doesn't work: rdar://17318018, much good that it will do.
 extension FxAClientError: MaybeErrorType {
     public var description: String {
         switch self {
-        case let .Remote(error):
+        case let .remote(error):
             let errorString = error.error ?? NSLocalizedString("Missing error", comment: "Error for a missing remote error number")
             let messageString = error.message ?? NSLocalizedString("Missing message", comment: "Error for a missing remote error message")
             return "<FxAClientError.Remote \(error.code)/\(error.errno): \(errorString) (\(messageString))>"
-        case let .Local(error):
+        case let .local(error):
             return "<FxAClientError.Local Error Domain=\(error.domain) Code=\(error.code) \"\(error.localizedDescription)\">"
         }
     }
@@ -102,14 +102,14 @@ public struct RemoteError {
     }
 }
 
-public class FxAClient10 {
-    let URL: NSURL
+open class FxAClient10 {
+    let URL: Foundation.URL
 
-    public init(endpoint: NSURL? = nil) {
-        self.URL = endpoint ?? ProductionFirefoxAccountConfiguration().authEndpointURL
+    public init(endpoint: Foundation.URL? = nil) {
+        self.URL = endpoint ?? ProductionFirefoxAccountConfiguration().authEndpointURL as URL
     }
 
-    public class func KW(kw: String) -> NSData {
+    open class func KW(_ kw: String) -> Data {
         return ("identity.mozilla.com/picl/v1/" + kw).utf8EncodedData
     }
 
@@ -118,28 +118,28 @@ public class FxAClient10 {
      * lowercase-hex-encoded first 16 bytes of the SHA-256 hash of the
      * bytes of kB.
      */
-    public class func computeClientState(kB: NSData) -> String? {
-        if kB.length != 32 {
+    open class func computeClientState(_ kB: Data) -> String? {
+        if kB.count != 32 {
             return nil
         }
         return kB.sha256.subdataWithRange(NSRange(location: 0, length: 16)).hexEncodedString
     }
 
-    public class func quickStretchPW(email: NSData, password: NSData) -> NSData {
-        let salt: NSMutableData = NSMutableData(data: KW("quickStretch"))
+    open class func quickStretchPW(_ email: Data, password: Data) -> Data {
+        let salt: NSMutableData = NSData(data: KW("quickStretch")) as Data as Data
         salt.appendData(":".utf8EncodedData)
-        salt.appendData(email)
-        return password.derivePBKDF2HMACSHA256KeyWithSalt(salt, iterations: 1000, length: 32)
+        salt.append(email)
+        return (password as NSData).derivePBKDF2HMACSHA256Key(withSalt: salt as Data!, iterations: 1000, length: 32)
     }
 
-    public class func computeUnwrapKey(stretchedPW: NSData) -> NSData {
-        let salt: NSData = NSData()
-        let contextInfo: NSData = KW("unwrapBkey")
-        let bytes = stretchedPW.deriveHKDFSHA256KeyWithSalt(salt, contextInfo: contextInfo, length: UInt(KeyLength))
-        return bytes
+    open class func computeUnwrapKey(_ stretchedPW: Data) -> Data {
+        let salt: Data = Data()
+        let contextInfo: Data = KW("unwrapBkey")
+        let bytes = (stretchedPW as NSData).deriveHKDFSHA256Key(withSalt: salt, contextInfo: contextInfo, length: UInt(KeyLength))
+        return bytes!
     }
 
-    private class func remoteErrorFromJSON(json: JSON, statusCode: Int) -> RemoteError? {
+    fileprivate class func remoteErrorFromJSON(_ json: JSON, statusCode: Int) -> RemoteError? {
         if json.isError || 200 <= statusCode && statusCode <= 299 {
             return nil
         }
@@ -155,7 +155,7 @@ public class FxAClient10 {
         return nil
     }
 
-    private class func loginResponseFromJSON(json: JSON) -> FxALoginResponse? {
+    fileprivate class func loginResponseFromJSON(_ json: JSON) -> FxALoginResponse? {
         guard !json.isError,
             let uid = json["uid"].asString,
             let verified = json["verified"].asBool,
@@ -168,7 +168,7 @@ public class FxAClient10 {
             sessionToken: sessionToken.hexDecodedData, keyFetchToken: keyFetchToken.hexDecodedData)
     }
 
-    private class func keysResponseFromJSON(keyRequestKey: NSData, json: JSON) -> FxAKeysResponse? {
+    fileprivate class func keysResponseFromJSON(_ keyRequestKey: Data, json: JSON) -> FxAKeysResponse? {
         guard !json.isError,
             let bundle = json["bundle"].asString else {
                 return nil
@@ -182,11 +182,11 @@ public class FxAClient10 {
         let ciphertext = data.subdataWithRange(NSMakeRange(0 * KeyLength, 2 * KeyLength))
         let MAC = data.subdataWithRange(NSMakeRange(2 * KeyLength, 1 * KeyLength))
 
-        let salt: NSData = NSData()
-        let contextInfo: NSData = KW("account/keys")
-        let bytes = keyRequestKey.deriveHKDFSHA256KeyWithSalt(salt, contextInfo: contextInfo, length: UInt(3 * KeyLength))
-        let respHMACKey = bytes.subdataWithRange(NSMakeRange(0 * KeyLength, 1 * KeyLength))
-        let respXORKey = bytes.subdataWithRange(NSMakeRange(1 * KeyLength, 2 * KeyLength))
+        let salt: Data = Data()
+        let contextInfo: Data = KW("account/keys")
+        let bytes = (keyRequestKey as NSData).deriveHKDFSHA256Key(withSalt: salt, contextInfo: contextInfo, length: UInt(3 * KeyLength))
+        let respHMACKey = bytes?.subdata(in: NSMakeRange(0 * KeyLength, 1 * KeyLength))
+        let respXORKey = bytes?.subdata(in: NSMakeRange(1 * KeyLength, 2 * KeyLength))
 
         guard ciphertext.hmacSha256WithKey(respHMACKey) == MAC else {
             NSLog("Bad HMAC in /keys response!")
@@ -202,7 +202,7 @@ public class FxAClient10 {
         return FxAKeysResponse(kA: kA, wrapkB: wrapkB)
     }
 
-    private class func signResponseFromJSON(json: JSON) -> FxASignResponse? {
+    fileprivate class func signResponseFromJSON(_ json: JSON) -> FxASignResponse? {
         guard !json.isError,
             let cert = json["cert"].asString else {
                 return nil
@@ -211,7 +211,7 @@ public class FxAClient10 {
         return FxASignResponse(certificate: cert)
     }
 
-    private class func statusResponseFromJSON(json: JSON) -> FxAStatusResponse? {
+    fileprivate class func statusResponseFromJSON(_ json: JSON) -> FxAStatusResponse? {
         guard !json.isError,
             let exists = json["exists"].asBool else {
                 return nil
@@ -220,7 +220,7 @@ public class FxAClient10 {
         return FxAStatusResponse(exists: exists)
     }
 
-    private class func devicesResponseFromJSON(json: JSON) -> FxADevicesResponse? {
+    fileprivate class func devicesResponseFromJSON(_ json: JSON) -> FxADevicesResponse? {
         guard !json.isError,
             let jsonDevices = json.asArray else {
                 return nil
@@ -233,27 +233,27 @@ public class FxAClient10 {
         return FxADevicesResponse(devices: devices)
     }
 
-    lazy private var alamofire: Alamofire.Manager = {
+    lazy fileprivate var alamofire: Alamofire.Manager = {
         let ua = UserAgent.fxaUserAgent
         let configuration = NSURLSessionConfiguration.ephemeralSessionConfiguration()
         return Alamofire.Manager.managerWithUserAgent(ua, configuration: configuration)
     }()
 
-    public func login(emailUTF8: NSData, quickStretchedPW: NSData, getKeys: Bool) -> Deferred<Maybe<FxALoginResponse>> {
-        let authPW = quickStretchedPW.deriveHKDFSHA256KeyWithSalt(NSData(), contextInfo: FxAClient10.KW("authPW"), length: 32)
+    open func login(_ emailUTF8: NSData, quickStretchedPW: NSData, getKeys: Bool) -> Deferred<Maybe<FxALoginResponse>> {
+        let authPW = quickStretchedPW.deriveHKDFSHA256KeyWithSalt(Data(), contextInfo: FxAClient10.KW("authPW"), length: 32)
 
         let parameters = [
-            "email": NSString(data: emailUTF8, encoding: NSUTF8StringEncoding)!,
+            "email": NSString(data: emailUTF8, encoding: String.Encoding.utf8)!,
             "authPW": authPW.base16EncodedStringWithOptions(NSDataBase16EncodingOptions.LowerCase),
         ]
 
-        var URL: NSURL = self.URL.URLByAppendingPathComponent("/account/login")!
+        var URL: Foundation.URL = self.URL.appendingPathComponent("/account/login")
         if getKeys {
-            let components = NSURLComponents(URL: URL, resolvingAgainstBaseURL: false)!
+            var components = URLComponents(url: URL, resolvingAgainstBaseURL: false)!
             components.query = "keys=true"
-            URL = components.URL!
+            URL = components.url!
         }
-        let mutableURLRequest = NSMutableURLRequest(URL: URL)
+        let mutableURLRequest = NSMutableURLRequest(url: URL)
         mutableURLRequest.HTTPMethod = Method.POST.rawValue
 
         mutableURLRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -262,13 +262,13 @@ public class FxAClient10 {
         return makeRequest(mutableURLRequest, responseHandler: FxAClient10.loginResponseFromJSON)
     }
 
-    public func keys(keyFetchToken: NSData) -> Deferred<Maybe<FxAKeysResponse>> {
-        let URL = self.URL.URLByAppendingPathComponent("/account/keys")
-        let mutableURLRequest = NSMutableURLRequest(URL: URL!)
+    open func keys(_ keyFetchToken: NSData) -> Deferred<Maybe<FxAKeysResponse>> {
+        let URL = self.URL.appendingPathComponent("/account/keys")
+        let mutableURLRequest = NSMutableURLRequest(url: URL)
         mutableURLRequest.HTTPMethod = Method.GET.rawValue
 
-        let salt: NSData = NSData()
-        let contextInfo: NSData = FxAClient10.KW("keyFetchToken")
+        let salt: Data = Data()
+        let contextInfo: Data = FxAClient10.KW("keyFetchToken")
         let key = keyFetchToken.deriveHKDFSHA256KeyWithSalt(salt, contextInfo: contextInfo, length: UInt(3 * KeyLength))
         mutableURLRequest.addAuthorizationHeader(forHKDFSHA256Key: key)
 
@@ -277,28 +277,28 @@ public class FxAClient10 {
         return makeRequest(mutableURLRequest) { FxAClient10.keysResponseFromJSON(keyRequestKey, json: $0) }
     }
 
-    public func sign(sessionToken: NSData, publicKey: PublicKey) -> Deferred<Maybe<FxASignResponse>> {
+    open func sign(_ sessionToken: NSData, publicKey: PublicKey) -> Deferred<Maybe<FxASignResponse>> {
         let parameters = [
             "publicKey": publicKey.JSONRepresentation(),
             "duration": NSNumber(unsignedLongLong: OneDayInMilliseconds), // The maximum the server will allow.
         ]
 
-        let URL = self.URL.URLByAppendingPathComponent("/certificate/sign")
-        let mutableURLRequest = NSMutableURLRequest(URL: URL!)
+        let URL = self.URL.appendingPathComponent("/certificate/sign")
+        let mutableURLRequest = NSMutableURLRequest(url: URL)
         mutableURLRequest.HTTPMethod = Method.POST.rawValue
 
         mutableURLRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         mutableURLRequest.HTTPBody = JSON(parameters).toString(false).utf8EncodedData
 
-        let salt: NSData = NSData()
-        let contextInfo: NSData = FxAClient10.KW("sessionToken")
+        let salt: Data = Data()
+        let contextInfo: Data = FxAClient10.KW("sessionToken")
         let key = sessionToken.deriveHKDFSHA256KeyWithSalt(salt, contextInfo: contextInfo, length: UInt(2 * KeyLength))
         mutableURLRequest.addAuthorizationHeader(forHKDFSHA256Key: key)
 
         return makeRequest(mutableURLRequest, responseHandler: FxAClient10.signResponseFromJSON)
     }
 
-    public func status(uid: String) -> Deferred<Maybe<FxAStatusResponse>> {
+    open func status(_ uid: String) -> Deferred<Maybe<FxAStatusResponse>> {
         let statusURL = self.URL.URLByAppendingPathComponent("/account/status")!.withQueryParam("uid", value: uid)
         let mutableURLRequest = NSMutableURLRequest(URL: statusURL)
         mutableURLRequest.HTTPMethod = Method.GET.rawValue
@@ -308,38 +308,38 @@ public class FxAClient10 {
         return makeRequest(mutableURLRequest, responseHandler: FxAClient10.statusResponseFromJSON)
     }
 
-    public func devices(sessionToken: NSData) -> Deferred<Maybe<FxADevicesResponse>> {
-        let URL = self.URL.URLByAppendingPathComponent("/account/devices")
-        let mutableURLRequest = NSMutableURLRequest(URL: URL!)
+    open func devices(_ sessionToken: NSData) -> Deferred<Maybe<FxADevicesResponse>> {
+        let URL = self.URL.appendingPathComponent("/account/devices")
+        let mutableURLRequest = NSMutableURLRequest(url: URL)
         mutableURLRequest.HTTPMethod = Method.GET.rawValue
 
         mutableURLRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        let salt: NSData = NSData()
-        let contextInfo: NSData = FxAClient10.KW("sessionToken")
+        let salt: Data = Data()
+        let contextInfo: Data = FxAClient10.KW("sessionToken")
         let key = sessionToken.deriveHKDFSHA256KeyWithSalt(salt, contextInfo: contextInfo, length: UInt(2 * KeyLength))
         mutableURLRequest.addAuthorizationHeader(forHKDFSHA256Key: key)
 
         return makeRequest(mutableURLRequest, responseHandler: FxAClient10.devicesResponseFromJSON)
     }
 
-    public func registerOrUpdateDevice(sessionToken: NSData, device: FxADevice) -> Deferred<Maybe<FxADevice>> {
-        let URL = self.URL.URLByAppendingPathComponent("/account/device")
-        let mutableURLRequest = NSMutableURLRequest(URL: URL!)
+    open func registerOrUpdateDevice(_ sessionToken: NSData, device: FxADevice) -> Deferred<Maybe<FxADevice>> {
+        let URL = self.URL.appendingPathComponent("/account/device")
+        let mutableURLRequest = NSMutableURLRequest(url: URL)
         mutableURLRequest.HTTPMethod = Method.POST.rawValue
 
         mutableURLRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         mutableURLRequest.HTTPBody = device.toJSON().toString(false).utf8EncodedData
 
-        let salt: NSData = NSData()
-        let contextInfo: NSData = FxAClient10.KW("sessionToken")
+        let salt: Data = Data()
+        let contextInfo: Data = FxAClient10.KW("sessionToken")
         let key = sessionToken.deriveHKDFSHA256KeyWithSalt(salt, contextInfo: contextInfo, length: UInt(2 * KeyLength))
         mutableURLRequest.addAuthorizationHeader(forHKDFSHA256Key: key)
 
         return makeRequest(mutableURLRequest, responseHandler: FxADevice.fromJSON)
     }
 
-    private func makeRequest<T>(request: NSMutableURLRequest, responseHandler: JSON -> T?) -> Deferred<Maybe<T>> {
+    fileprivate func makeRequest<T>(_ request: NSMutableURLRequest, responseHandler: (JSON) -> T?) -> Deferred<Maybe<T>> {
         let deferred = Deferred<Maybe<T>>()
 
         alamofire.request(request)

--- a/Account/FxADevice.swift
+++ b/Account/FxADevice.swift
@@ -11,18 +11,18 @@ public struct FxADevice {
     let type: String?
     let isCurrentDevice: Bool
 
-    private init(name: String, id: String?, type: String?, isCurrentDevice: Bool = false) {
+    fileprivate init(name: String, id: String?, type: String?, isCurrentDevice: Bool = false) {
         self.name = name
         self.id = id
         self.type = type
         self.isCurrentDevice = isCurrentDevice
     }
 
-    static func forRegister(name: String, type: String) -> FxADevice {
+    static func forRegister(_ name: String, type: String) -> FxADevice {
         return FxADevice(name: name, id: nil, type: type)
     }
 
-    static func forUpdate(name: String, id: String) -> FxADevice {
+    static func forUpdate(_ name: String, id: String) -> FxADevice {
         return FxADevice(name: name, id: id, type: nil)
     }
 
@@ -35,7 +35,7 @@ public struct FxADevice {
         return JSON(parameters)
     }
 
-    static func fromJSON(json: JSON) -> FxADevice? {
+    static func fromJSON(_ json: JSON) -> FxADevice? {
         guard !json.isError,
             let id = json["id"].asString,
             let name = json["name"].asString,

--- a/Account/FxADeviceRegistration.swift
+++ b/Account/FxADeviceRegistration.swift
@@ -13,28 +13,28 @@ private let log = Logger.syncLogger
 private let DeviceRegistrationVersion = 1
 
 public enum FxADeviceRegistrationResult {
-    case Registered
-    case Updated
-    case AlreadyRegistered
+    case registered
+    case updated
+    case alreadyRegistered
 }
 
 public enum FxADeviceRegistratorError: MaybeErrorType {
-    case AccountDeleted
-    case CurrentDeviceNotFound
-    case InvalidSession
-    case UnknownDevice
+    case accountDeleted
+    case currentDeviceNotFound
+    case invalidSession
+    case unknownDevice
 
     public var description: String {
         switch self {
-        case AccountDeleted: return "Account no longer exists."
-        case CurrentDeviceNotFound: return "Current device not found."
-        case InvalidSession: return "Session token was invalid."
-        case UnknownDevice: return "Unknown device."
+        case .accountDeleted: return "Account no longer exists."
+        case .currentDeviceNotFound: return "Current device not found."
+        case .invalidSession: return "Session token was invalid."
+        case .unknownDevice: return "Unknown device."
         }
     }
 }
 
-public class FxADeviceRegistration: NSObject, NSCoding {
+open class FxADeviceRegistration: NSObject, NSCoding {
     /// The device identifier identifying this device.  A device is uniquely identified
     /// across the lifetime of a Firefox Account.
     let id: String
@@ -53,26 +53,25 @@ public class FxADeviceRegistration: NSObject, NSCoding {
     }
 
     public convenience required init(coder: NSCoder) {
-        let id = coder.decodeObjectForKey("id") as! String
-        let version = coder.decodeObjectForKey("version") as! Int
-        let lastRegistered = (coder.decodeObjectForKey("lastRegistered") as! NSNumber).unsignedLongLongValue
+        let id = coder.decodeObject(forKey: "id") as! String
+        let version = coder.decodeObject(forKey: "version") as! Int
+        let lastRegistered = (coder.decodeObject(forKey: "lastRegistered") as! NSNumber).uint64Value
         self.init(id: id, version: version, lastRegistered: lastRegistered)
     }
 
-    public func encodeWithCoder(aCoder: NSCoder) {
-        aCoder.encodeObject(id, forKey: "id")
-        aCoder.encodeObject(version, forKey: "version")
+    open func encode(with aCoder: NSCoder) {
+        aCoder.encode(id, forKey: "id")
+        aCoder.encode(version, forKey: "version")
         aCoder.encodeObject(NSNumber(unsignedLongLong: lastRegistered), forKey: "lastRegistered")
     }
 }
 
-public class FxADeviceRegistrator {
-    public static func registerOrUpdateDevice(account: FirefoxAccount, sessionToken: NSData, client: FxAClient10? = nil) -> Deferred<Maybe<FxADeviceRegistrationResult>> {
+open class FxADeviceRegistrator {
+    open static func registerOrUpdateDevice(_ account: FirefoxAccount, sessionToken: NSData, client: FxAClient10? = nil) -> Deferred<Maybe<FxADeviceRegistrationResult>> {
         // If we've already registered, the registration version is up-to-date, *and* we've (re-)registered
         // within the last week, do nothing. We re-register weekly as a sanity check.
-        if let registration = account.deviceRegistration
-            where registration.version == DeviceRegistrationVersion &&
-            NSDate.now() < registration.lastRegistered + OneWeekInMilliseconds {
+        if let registration = account.deviceRegistration, registration.version == DeviceRegistrationVersion &&
+            Date.now() < registration.lastRegistered + OneWeekInMilliseconds {
                 return deferMaybe(FxADeviceRegistrationResult.AlreadyRegistered)
         }
 
@@ -82,10 +81,10 @@ public class FxADeviceRegistrator {
         let registrationResult: FxADeviceRegistrationResult
         if let registration = account.deviceRegistration {
             device = FxADevice.forUpdate(name, id: registration.id)
-            registrationResult = FxADeviceRegistrationResult.Updated
+            registrationResult = FxADeviceRegistrationResult.updated
         } else {
             device = FxADevice.forRegister(name, type: "mobile")
-            registrationResult = FxADeviceRegistrationResult.Registered
+            registrationResult = FxADeviceRegistrationResult.registered
         }
 
         let registeredDevice = client.registerOrUpdateDevice(sessionToken, device: device)
@@ -128,7 +127,7 @@ public class FxADeviceRegistrator {
         }
     }
 
-    private static func recoverFromDeviceSessionConflict(account: FirefoxAccount, client: FxAClient10, sessionToken: NSData) -> Deferred<Maybe<FxADeviceRegistration>> {
+    fileprivate static func recoverFromDeviceSessionConflict(_ account: FirefoxAccount, client: FxAClient10, sessionToken: NSData) -> Deferred<Maybe<FxADeviceRegistration>> {
         // FxA has already associated this session with a different device id.
         // Perhaps we were beaten in a race to register. Handle the conflict:
         //   1. Fetch the list of devices for the current user from FxA.
@@ -146,7 +145,7 @@ public class FxADeviceRegistrator {
         }
     }
 
-    private static func recoverFromTokenError(account: FirefoxAccount, client: FxAClient10) -> Deferred<Maybe<FxADeviceRegistration>> {
+    fileprivate static func recoverFromTokenError(_ account: FirefoxAccount, client: FxAClient10) -> Deferred<Maybe<FxADeviceRegistration>> {
         return client.status(account.uid) >>== { status in
             if !status.exists {
                 // TODO: Should be in an "I have an iOS account, but the FxA is gone." state.
@@ -160,7 +159,7 @@ public class FxADeviceRegistrator {
         }
     }
 
-    private static func recoverFromUnknownDevice(account: FirefoxAccount) -> Deferred<Maybe<FxADeviceRegistration>> {
+    fileprivate static func recoverFromUnknownDevice(_ account: FirefoxAccount) -> Deferred<Maybe<FxADeviceRegistration>> {
         // FxA did not recognize the device ID. Handle it by clearing the registration on the account data.
         // At next sync or next sign-in, registration is retried and should succeed.
         log.warning("Unknown device ID. Clearing the local device data.")

--- a/Account/FxALoginStateMachine.swift
+++ b/Account/FxALoginStateMachine.swift
@@ -16,13 +16,13 @@ private let KeyUnwrappingError = NSError(domain: "org.mozilla", code: 1, userInf
 
 protocol FxALoginClient {
     func keyPair() -> Deferred<Maybe<KeyPair>>
-    func keys(keyFetchToken: NSData) -> Deferred<Maybe<FxAKeysResponse>>
-    func sign(sessionToken: NSData, publicKey: PublicKey) -> Deferred<Maybe<FxASignResponse>>
+    func keys(_ keyFetchToken: Data) -> Deferred<Maybe<FxAKeysResponse>>
+    func sign(_ sessionToken: Data, publicKey: PublicKey) -> Deferred<Maybe<FxASignResponse>>
 }
 
 extension FxAClient10: FxALoginClient {
     func keyPair() -> Deferred<Maybe<KeyPair>> {
-        let result = RSAKeyPair.generateKeyPairWithModulusSize(2048) // TODO: debate key size and extract this constant.
+        let result = RSAKeyPair.generate(withModulusSize: 2048) // TODO: debate key size and extract this constant.
         return Deferred(value: Maybe(success: result))
     }
 }
@@ -37,7 +37,7 @@ class FxALoginStateMachine {
         self.client = client
     }
 
-    func advanceFromState(state: FxAState, now: Timestamp) -> Deferred<FxAState> {
+    func advanceFromState(_ state: FxAState, now: Timestamp) -> Deferred<FxAState> {
         stateLabelsSeen.updateValue(true, forKey: state.label)
         return self.advanceOneState(state, now: now).bind { (newState: FxAState) in
             let labelAlreadySeen = self.stateLabelsSeen.updateValue(true, forKey: newState.label) != nil
@@ -49,7 +49,7 @@ class FxALoginStateMachine {
         }
     }
 
-    private func advanceOneState(state: FxAState, now: Timestamp) -> Deferred<FxAState> {
+    fileprivate func advanceOneState(_ state: FxAState, now: Timestamp) -> Deferred<FxAState> {
         // For convenience.  Without type annotation, Swift complains about types not being exact.
         let separated: Deferred<FxAState> = Deferred(value: SeparatedState())
         let doghouse: Deferred<FxAState> = Deferred(value: DoghouseState())

--- a/Account/FxAState.swift
+++ b/Account/FxAState.swift
@@ -34,13 +34,13 @@ public enum FxAStateLabel: String {
 }
 
 public enum FxAActionNeeded {
-    case None
-    case NeedsVerification
-    case NeedsPassword
-    case NeedsUpgrade
+    case none
+    case needsVerification
+    case needsPassword
+    case needsUpgrade
 }
 
-func stateFromJSON(json: JSON) -> FxAState? {
+func stateFromJSON(_ json: JSON) -> FxAState? {
     if json.isError {
         return nil
     }
@@ -52,17 +52,17 @@ func stateFromJSON(json: JSON) -> FxAState? {
     return nil
 }
 
-func stateFromJSONV1(json: JSON) -> FxAState? {
+func stateFromJSONV1(_ json: JSON) -> FxAState? {
     if let labelString = json["label"].asString {
         if let label = FxAStateLabel(rawValue:  labelString) {
             switch label {
             case .EngagedBeforeVerified:
                 if let
                     sessionToken = json["sessionToken"].asString?.hexDecodedData,
-                    keyFetchToken = json["keyFetchToken"].asString?.hexDecodedData,
-                    unwrapkB = json["unwrapkB"].asString?.hexDecodedData,
-                    knownUnverifiedAt = json["knownUnverifiedAt"].asInt64,
-                    lastNotifiedUserAt = json["lastNotifiedUserAt"].asInt64 {
+                    let keyFetchToken = json["keyFetchToken"].asString?.hexDecodedData,
+                    let unwrapkB = json["unwrapkB"].asString?.hexDecodedData,
+                    let knownUnverifiedAt = json["knownUnverifiedAt"].asInt64,
+                    let lastNotifiedUserAt = json["lastNotifiedUserAt"].asInt64 {
                     return EngagedBeforeVerifiedState(
                         knownUnverifiedAt: UInt64(knownUnverifiedAt), lastNotifiedUserAt: UInt64(lastNotifiedUserAt),
                         sessionToken: sessionToken, keyFetchToken: keyFetchToken, unwrapkB: unwrapkB)
@@ -71,27 +71,27 @@ func stateFromJSONV1(json: JSON) -> FxAState? {
             case .EngagedAfterVerified:
                 if let
                     sessionToken = json["sessionToken"].asString?.hexDecodedData,
-                    keyFetchToken = json["keyFetchToken"].asString?.hexDecodedData,
-                    unwrapkB = json["unwrapkB"].asString?.hexDecodedData {
+                    let keyFetchToken = json["keyFetchToken"].asString?.hexDecodedData,
+                    let unwrapkB = json["unwrapkB"].asString?.hexDecodedData {
                     return EngagedAfterVerifiedState(sessionToken: sessionToken, keyFetchToken: keyFetchToken, unwrapkB: unwrapkB)
                 }
 
             case .CohabitingBeforeKeyPair:
                 if let
                     sessionToken = json["sessionToken"].asString?.hexDecodedData,
-                    kA = json["kA"].asString?.hexDecodedData,
-                    kB = json["kB"].asString?.hexDecodedData {
+                    let kA = json["kA"].asString?.hexDecodedData,
+                    let kB = json["kB"].asString?.hexDecodedData {
                     return CohabitingBeforeKeyPairState(sessionToken: sessionToken, kA: kA, kB: kB)
                 }
 
             case .CohabitingAfterKeyPair:
                 if let
                     sessionToken = json["sessionToken"].asString?.hexDecodedData,
-                    kA = json["kA"].asString?.hexDecodedData,
-                    kB = json["kB"].asString?.hexDecodedData,
-                    keyPairJSON = JSON.unwrap(json["keyPair"]) as? [String: AnyObject],
-                    keyPair = RSAKeyPair(JSONRepresentation: keyPairJSON),
-                    keyPairExpiresAt = json["keyPairExpiresAt"].asInt64 {
+                    let kA = json["kA"].asString?.hexDecodedData,
+                    let kB = json["kB"].asString?.hexDecodedData,
+                    let keyPairJSON = JSON.unwrap(json["keyPair"]) as? [String: AnyObject],
+                    let keyPair = RSAKeyPair(JSONRepresentation: keyPairJSON),
+                    let keyPairExpiresAt = json["keyPairExpiresAt"].asInt64 {
                         return CohabitingAfterKeyPairState(sessionToken: sessionToken, kA: kA, kB: kB,
                             keyPair: keyPair, keyPairExpiresAt: UInt64(keyPairExpiresAt))
                 }
@@ -99,13 +99,13 @@ func stateFromJSONV1(json: JSON) -> FxAState? {
             case .Married:
                 if let
                     sessionToken = json["sessionToken"].asString?.hexDecodedData,
-                    kA = json["kA"].asString?.hexDecodedData,
-                    kB = json["kB"].asString?.hexDecodedData,
-                    keyPairJSON = JSON.unwrap(json["keyPair"]) as? [String: AnyObject],
-                    keyPair = RSAKeyPair(JSONRepresentation: keyPairJSON),
-                    keyPairExpiresAt = json["keyPairExpiresAt"].asInt64,
-                    certificate = json["certificate"].asString,
-                    certificateExpiresAt = json["certificateExpiresAt"].asInt64 {
+                    let kA = json["kA"].asString?.hexDecodedData,
+                    let kB = json["kB"].asString?.hexDecodedData,
+                    let keyPairJSON = JSON.unwrap(json["keyPair"]) as? [String: AnyObject],
+                    let keyPair = RSAKeyPair(JSONRepresentation: keyPairJSON),
+                    let keyPairExpiresAt = json["keyPairExpiresAt"].asInt64,
+                    let certificate = json["certificate"].asString,
+                    let certificateExpiresAt = json["certificateExpiresAt"].asInt64 {
                     return MarriedState(sessionToken: sessionToken, kA: kA, kB: kB,
                         keyPair: keyPair, keyPairExpiresAt: UInt64(keyPairExpiresAt),
                         certificate: certificate, certificateExpiresAt: UInt64(certificateExpiresAt))
@@ -123,23 +123,23 @@ func stateFromJSONV1(json: JSON) -> FxAState? {
 }
 
 // Not an externally facing state!
-public class FxAState: JSONLiteralConvertible {
-    public var label: FxAStateLabel { return FxAStateLabel.Separated } // This is bogus, but we have to do something!
+open class FxAState: JSONLiteralConvertible {
+    open var label: FxAStateLabel { return FxAStateLabel.Separated } // This is bogus, but we have to do something!
 
-    public var actionNeeded: FxAActionNeeded {
+    open var actionNeeded: FxAActionNeeded {
         // Kind of nice to have this in one place.
         switch label {
-        case .EngagedBeforeVerified: return .NeedsVerification
-        case .EngagedAfterVerified: return .None
-        case .CohabitingBeforeKeyPair: return .None
-        case .CohabitingAfterKeyPair: return .None
-        case .Married: return .None
-        case .Separated: return .NeedsPassword
-        case .Doghouse: return .NeedsUpgrade
+        case .EngagedBeforeVerified: return .needsVerification
+        case .EngagedAfterVerified: return .none
+        case .CohabitingBeforeKeyPair: return .none
+        case .CohabitingAfterKeyPair: return .none
+        case .Married: return .none
+        case .Separated: return .needsPassword
+        case .Doghouse: return .needsUpgrade
         }
     }
 
-    public func asJSON() -> JSON {
+    open func asJSON() -> JSON {
         return JSON([
             "version": StateSchemaVersion,
             "label": self.label.rawValue,
@@ -147,8 +147,8 @@ public class FxAState: JSONLiteralConvertible {
     }
 }
 
-public class SeparatedState: FxAState {
-    override public var label: FxAStateLabel { return FxAStateLabel.Separated }
+open class SeparatedState: FxAState {
+    override open var label: FxAStateLabel { return FxAStateLabel.Separated }
 
     override public init() {
         super.init()
@@ -156,15 +156,15 @@ public class SeparatedState: FxAState {
 }
 
 // Not an externally facing state!
-public class TokenState: FxAState {
-    let sessionToken: NSData
+open class TokenState: FxAState {
+    let sessionToken: Data
 
-    init(sessionToken: NSData) {
+    init(sessionToken: Data) {
         self.sessionToken = sessionToken
         super.init()
     }
 
-    public override func asJSON() -> JSON {
+    open override func asJSON() -> JSON {
         var d: [String: JSON] = super.asJSON().asDictionary!
         d["sessionToken"] = JSON(sessionToken.hexEncodedString)
         return JSON(d)
@@ -172,17 +172,17 @@ public class TokenState: FxAState {
 }
 
 // Not an externally facing state!
-public class ReadyForKeys: TokenState {
-    let keyFetchToken: NSData
-    let unwrapkB: NSData
+open class ReadyForKeys: TokenState {
+    let keyFetchToken: Data
+    let unwrapkB: Data
 
-    init(sessionToken: NSData, keyFetchToken: NSData, unwrapkB: NSData) {
+    init(sessionToken: Data, keyFetchToken: Data, unwrapkB: Data) {
         self.keyFetchToken = keyFetchToken
         self.unwrapkB = unwrapkB
         super.init(sessionToken: sessionToken)
     }
 
-    public override func asJSON() -> JSON {
+    open override func asJSON() -> JSON {
         var d: [String: JSON] = super.asJSON().asDictionary!
         d["keyFetchToken"] = JSON(keyFetchToken.hexEncodedString)
         d["unwrapkB"] = JSON(unwrapkB.hexEncodedString)
@@ -190,58 +190,58 @@ public class ReadyForKeys: TokenState {
     }
 }
 
-public class EngagedBeforeVerifiedState: ReadyForKeys {
-    override public var label: FxAStateLabel { return FxAStateLabel.EngagedBeforeVerified }
+open class EngagedBeforeVerifiedState: ReadyForKeys {
+    override open var label: FxAStateLabel { return FxAStateLabel.EngagedBeforeVerified }
 
     // Timestamp, in milliseconds after the epoch, when we first knew the account was unverified.
     // Use this to avoid nagging the user to verify her account immediately after connecting.
     let knownUnverifiedAt: Timestamp
     let lastNotifiedUserAt: Timestamp
 
-    public init(knownUnverifiedAt: Timestamp, lastNotifiedUserAt: Timestamp, sessionToken: NSData, keyFetchToken: NSData, unwrapkB: NSData) {
+    public init(knownUnverifiedAt: Timestamp, lastNotifiedUserAt: Timestamp, sessionToken: Data, keyFetchToken: Data, unwrapkB: Data) {
         self.knownUnverifiedAt = knownUnverifiedAt
         self.lastNotifiedUserAt = lastNotifiedUserAt
         super.init(sessionToken: sessionToken, keyFetchToken: keyFetchToken, unwrapkB: unwrapkB)
     }
 
-    public override func asJSON() -> JSON {
+    open override func asJSON() -> JSON {
         var d = super.asJSON().asDictionary!
         d["knownUnverifiedAt"] = JSON(NSNumber(unsignedLongLong: knownUnverifiedAt))
         d["lastNotifiedUserAt"] = JSON(NSNumber(unsignedLongLong: lastNotifiedUserAt))
         return JSON(d)
     }
 
-    func withUnwrapKey(unwrapkB: NSData) -> EngagedBeforeVerifiedState {
+    func withUnwrapKey(_ unwrapkB: Data) -> EngagedBeforeVerifiedState {
         return EngagedBeforeVerifiedState(
             knownUnverifiedAt: knownUnverifiedAt, lastNotifiedUserAt: lastNotifiedUserAt,
             sessionToken: sessionToken, keyFetchToken: keyFetchToken, unwrapkB: unwrapkB)
     }
 }
 
-public class EngagedAfterVerifiedState: ReadyForKeys {
-    override public var label: FxAStateLabel { return FxAStateLabel.EngagedAfterVerified }
+open class EngagedAfterVerifiedState: ReadyForKeys {
+    override open var label: FxAStateLabel { return FxAStateLabel.EngagedAfterVerified }
 
-    override public init(sessionToken: NSData, keyFetchToken: NSData, unwrapkB: NSData) {
+    override public init(sessionToken: Data, keyFetchToken: Data, unwrapkB: Data) {
         super.init(sessionToken: sessionToken, keyFetchToken: keyFetchToken, unwrapkB: unwrapkB)
     }
 
-    func withUnwrapKey(unwrapkB: NSData) -> EngagedAfterVerifiedState {
+    func withUnwrapKey(_ unwrapkB: Data) -> EngagedAfterVerifiedState {
         return EngagedAfterVerifiedState(sessionToken: sessionToken, keyFetchToken: keyFetchToken, unwrapkB: unwrapkB)
     }
 }
 
 // Not an externally facing state!
-public class TokenAndKeys: TokenState {
-    public let kA: NSData
-    public let kB: NSData
+open class TokenAndKeys: TokenState {
+    open let kA: Data
+    open let kB: Data
 
-    init(sessionToken: NSData, kA: NSData, kB: NSData) {
+    init(sessionToken: Data, kA: Data, kB: Data) {
         self.kA = kA
         self.kB = kB
         super.init(sessionToken: sessionToken)
     }
 
-    public override func asJSON() -> JSON {
+    open override func asJSON() -> JSON {
         var d = super.asJSON().asDictionary!
         d["kA"] = JSON(kA.hexEncodedString)
         d["kB"] = JSON(kB.hexEncodedString)
@@ -249,58 +249,58 @@ public class TokenAndKeys: TokenState {
     }
 }
 
-public class CohabitingBeforeKeyPairState: TokenAndKeys {
-    override public var label: FxAStateLabel { return FxAStateLabel.CohabitingBeforeKeyPair }
+open class CohabitingBeforeKeyPairState: TokenAndKeys {
+    override open var label: FxAStateLabel { return FxAStateLabel.CohabitingBeforeKeyPair }
 }
 
 // Not an externally facing state!
-public class TokenKeysAndKeyPair: TokenAndKeys {
+open class TokenKeysAndKeyPair: TokenAndKeys {
     let keyPair: KeyPair
     // Timestamp, in milliseconds after the epoch, when keyPair expires.  After this time, generate a new keyPair.
     let keyPairExpiresAt: Timestamp
 
-    init(sessionToken: NSData, kA: NSData, kB: NSData, keyPair: KeyPair, keyPairExpiresAt: Timestamp) {
+    init(sessionToken: Data, kA: Data, kB: Data, keyPair: KeyPair, keyPairExpiresAt: Timestamp) {
         self.keyPair = keyPair
         self.keyPairExpiresAt = keyPairExpiresAt
         super.init(sessionToken: sessionToken, kA: kA, kB: kB)
     }
 
-    public override func asJSON() -> JSON {
+    open override func asJSON() -> JSON {
         var d = super.asJSON().asDictionary!
         d["keyPair"] = JSON(keyPair.JSONRepresentation())
         d["keyPairExpiresAt"] = JSON(NSNumber(unsignedLongLong: keyPairExpiresAt))
         return JSON(d)
     }
 
-    func isKeyPairExpired(now: Timestamp) -> Bool {
+    func isKeyPairExpired(_ now: Timestamp) -> Bool {
         return keyPairExpiresAt < now
     }
 }
 
-public class CohabitingAfterKeyPairState: TokenKeysAndKeyPair {
-    override public var label: FxAStateLabel { return FxAStateLabel.CohabitingAfterKeyPair }
+open class CohabitingAfterKeyPairState: TokenKeysAndKeyPair {
+    override open var label: FxAStateLabel { return FxAStateLabel.CohabitingAfterKeyPair }
 }
 
-public class MarriedState: TokenKeysAndKeyPair {
-    override public var label: FxAStateLabel { return FxAStateLabel.Married }
+open class MarriedState: TokenKeysAndKeyPair {
+    override open var label: FxAStateLabel { return FxAStateLabel.Married }
 
     let certificate: String
     let certificateExpiresAt: Timestamp
 
-    init(sessionToken: NSData, kA: NSData, kB: NSData, keyPair: KeyPair, keyPairExpiresAt: Timestamp, certificate: String, certificateExpiresAt: Timestamp) {
+    init(sessionToken: Data, kA: Data, kB: Data, keyPair: KeyPair, keyPairExpiresAt: Timestamp, certificate: String, certificateExpiresAt: Timestamp) {
         self.certificate = certificate
         self.certificateExpiresAt = certificateExpiresAt
         super.init(sessionToken: sessionToken, kA: kA, kB: kB, keyPair: keyPair, keyPairExpiresAt: keyPairExpiresAt)
     }
 
-    public override func asJSON() -> JSON {
+    open override func asJSON() -> JSON {
         var d = super.asJSON().asDictionary!
         d["certificate"] = JSON(certificate)
         d["certificateExpiresAt"] = JSON(NSNumber(unsignedLongLong: certificateExpiresAt))
         return JSON(d)
     }
 
-    func isCertificateExpired(now: Timestamp) -> Bool {
+    func isCertificateExpired(_ now: Timestamp) -> Bool {
         return certificateExpiresAt < now
     }
 
@@ -317,7 +317,7 @@ public class MarriedState: TokenKeysAndKeyPair {
         return newState
     }
 
-    public func generateAssertionForAudience(audience: String, now: Timestamp) -> String {
+    open func generateAssertionForAudience(_ audience: String, now: Timestamp) -> String {
         let assertion = JSONWebTokenUtils.createAssertionWithPrivateKeyToSignWith(keyPair.privateKey,
             certificate: certificate,
             audience: audience,
@@ -328,8 +328,8 @@ public class MarriedState: TokenKeysAndKeyPair {
     }
 }
 
-public class DoghouseState: FxAState {
-    override public var label: FxAStateLabel { return FxAStateLabel.Doghouse }
+open class DoghouseState: FxAState {
+    override open var label: FxAStateLabel { return FxAStateLabel.Doghouse }
 
     override public init() {
         super.init()

--- a/Account/HawkHelper.swift
+++ b/Account/HawkHelper.swift
@@ -6,42 +6,42 @@ import Foundation
 import FxA
 import Shared
 
-public class HawkHelper {
-    private let NonceLengthInBytes: UInt = 8
+open class HawkHelper {
+    fileprivate let NonceLengthInBytes: UInt = 8
 
     let id: String
-    let key: NSData
+    let key: Data
 
-    public init(id: String, key: NSData) {
+    public init(id: String, key: Data) {
         self.id = id
         self.key = key
     }
 
     // Produce a HAWK value suitable for an "Authorization: value" header, timestamped now.
-    public func getAuthorizationValueFor(request: NSURLRequest) -> String {
-        let timestampInSeconds: Int64 = Int64(NSDate().timeIntervalSince1970)
+    open func getAuthorizationValueFor(_ request: URLRequest) -> String {
+        let timestampInSeconds: Int64 = Int64(Date().timeIntervalSince1970)
         return getAuthorizationValueFor(request, at: timestampInSeconds)
     }
 
     // Produce a HAWK value suitable for an "Authorization: value" header.
-    func getAuthorizationValueFor(request: NSURLRequest, at timestampInSeconds: Int64) -> String {
-        let nonce = NSData.randomOfLength(NonceLengthInBytes)!.base64EncodedString
+    func getAuthorizationValueFor(_ request: URLRequest, at timestampInSeconds: Int64) -> String {
+        let nonce = Data.randomOfLength(NonceLengthInBytes)!.base64EncodedString
         let extra = ""
         return getAuthorizationValueFor(request, at: timestampInSeconds, nonce: nonce, extra: extra)
     }
 
-    func getAuthorizationValueFor(request: NSURLRequest, at timestampInSeconds: Int64, nonce: String, extra: String) -> String {
+    func getAuthorizationValueFor(_ request: URLRequest, at timestampInSeconds: Int64, nonce: String, extra: String) -> String {
         let timestampString = String(timestampInSeconds)
         let hashString = HawkHelper.getPayloadHashFor(request)
         let requestString = HawkHelper.getRequestStringFor(request, timestampString: timestampString, nonce: nonce, hash: hashString, extra: extra)
         let macString = HawkHelper.getSignatureFor(requestString.utf8EncodedData, key: self.key)
 
         let s = NSMutableString(string: "Hawk ")
-        func append(key: String, value: String) -> Void {
-            s.appendString(key)
-            s.appendString("=\"")
-            s.appendString(value)
-            s.appendString("\", ")
+        func append(_ key: String, value: String) -> Void {
+            s.append(key)
+            s.append("=\"")
+            s.append(value)
+            s.append("\", ")
         }
         append("id", value: id)
         append("ts", value: timestampString)
@@ -54,38 +54,38 @@ public class HawkHelper {
         }
         append("mac", value: macString)
         // Drop the trailing "\",".
-        return s.substringToIndex(s.length - 2)
+        return s.substring(to: s.length - 2)
     }
 
-    class func getSignatureFor(input: NSData, key: NSData) -> String {
+    class func getSignatureFor(_ input: Data, key: Data) -> String {
         return input.hmacSha256WithKey(key).base64EncodedString
     }
 
-    class func getRequestStringFor(request: NSURLRequest, timestampString: String, nonce: String, hash: String, extra: String) -> String {
+    class func getRequestStringFor(_ request: URLRequest, timestampString: String, nonce: String, hash: String, extra: String) -> String {
         let s = NSMutableString(string: "hawk.1.header\n")
-        func append(line: String) -> Void {
-            s.appendString(line)
-            s.appendString("\n")
+        func append(_ line: String) -> Void {
+            s.append(line)
+            s.append("\n")
         }
         append(timestampString)
         append(nonce)
-        append(request.HTTPMethod?.uppercaseString ?? "GET")
-        let url = request.URL!
-        s.appendString(url.path!)
+        append((request as NSURLRequest).httpMethod?.uppercased() ?? "GET")
+        let url = request.url!
+        s.append(url.path)
         if let query = url.query {
-            s.appendString("?")
-            s.appendString(query)
+            s.append("?")
+            s.append(query)
         }
         if let fragment = url.fragment {
-            s.appendString("#")
-            s.appendString(fragment)
+            s.append("#")
+            s.append(fragment)
         }
-        s.appendString("\n")
+        s.append("\n")
         append(url.host!)
-        if let port = url.port {
+        if let port = (url as NSURL).port {
             append(port.stringValue)
         } else {
-            if url.scheme?.lowercaseString == "https" {
+            if url.scheme?.lowercased() == "https" {
                 append("443")
             } else {
                 append("80")
@@ -100,17 +100,17 @@ public class HawkHelper {
         return s as String
     }
 
-    class func getPayloadHashFor(request: NSURLRequest) -> String {
-        if let body = request.HTTPBody {
+    class func getPayloadHashFor(_ request: URLRequest) -> String {
+        if let body = request.httpBody {
             let d = NSMutableData()
-            func append(s: String) {
+            func append(_ s: String) {
                 let data = s.utf8EncodedData
                 d.appendBytes(data.bytes, length: data.length)
             }
             append("hawk.1.payload\n")
-            append(getBaseContentTypeFor(request.valueForHTTPHeaderField("Content-Type")))
+            append(getBaseContentTypeFor(request.value(forHTTPHeaderField: "Content-Type")))
             append("\n") // Trailing newline is specified by Hawk.
-            d.appendBytes(body.bytes, length: body.length)
+            d.append((body as NSData).bytes, length: body.count)
             append("\n") // Trailing newline is specified by Hawk.
             return d.sha256.base64EncodedString
         } else {
@@ -118,31 +118,31 @@ public class HawkHelper {
         }
     }
 
-    class func getBaseContentTypeFor(contentType: String?) -> String {
+    class func getBaseContentTypeFor(_ contentType: String?) -> String {
         if let contentType = contentType {
-            if let index = contentType.characters.indexOf(";") {
-                return contentType.substringToIndex(index).stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet())
+            if let index = contentType.characters.index(of: ";") {
+                return contentType.substring(to: index).trimmingCharacters(in: CharacterSet.whitespaces)
             } else {
-                return contentType.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet())
+                return contentType.trimmingCharacters(in: CharacterSet.whitespaces)
             }
         } else {
             return "text/plain"
         }
     }
 
-    class func escapeExtraHeaderAttribute(extra: String) -> String {
-        return extra.stringByReplacingOccurrencesOfString("\\", withString: "\\\\").stringByReplacingOccurrencesOfString("\"", withString: "\\\"")
+    class func escapeExtraHeaderAttribute(_ extra: String) -> String {
+        return extra.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
     }
 
-    class func escapeExtraString(extra: String) -> String {
-        return extra.stringByReplacingOccurrencesOfString("\\", withString: "\\\\").stringByReplacingOccurrencesOfString("\n", withString: "\\n")
+    class func escapeExtraString(_ extra: String) -> String {
+        return extra.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\n", with: "\\n")
     }
 }
 
 extension NSMutableURLRequest {
-    func addAuthorizationHeader(forHKDFSHA256Key bytes: NSData) {
-        let tokenId = bytes.subdataWithRange(NSMakeRange(0 * KeyLength, KeyLength))
-        let reqHMACKey = bytes.subdataWithRange(NSMakeRange(1 * KeyLength, KeyLength))
+    func addAuthorizationHeader(forHKDFSHA256Key bytes: Data) {
+        let tokenId = bytes.subdata(in: NSMakeRange(0 * KeyLength, KeyLength))
+        let reqHMACKey = bytes.subdata(in: NSMakeRange(1 * KeyLength, KeyLength))
         let hawkHelper = HawkHelper(id: tokenId.hexEncodedString, key: reqHMACKey)
         let hawkValue = hawkHelper.getAuthorizationValueFor(self)
         setValue(hawkValue, forHTTPHeaderField: "Authorization")

--- a/Account/TokenServerClient.swift
+++ b/Account/TokenServerClient.swift
@@ -8,7 +8,7 @@ import Foundation
 import Deferred
 
 let TokenServerClientErrorDomain = "org.mozilla.token.error"
-let TokenServerClientUnknownError = TokenServerError.Local(
+let TokenServerClientUnknownError = TokenServerError.local(
     NSError(domain: TokenServerClientErrorDomain, code: 999,
     userInfo: [NSLocalizedDescriptionKey: "Invalid server response"]))
 
@@ -24,19 +24,19 @@ public struct TokenServerToken {
     /**
      * Return true if this token points to the same place as the other token.
      */
-    public func sameDestination(other: TokenServerToken) -> Bool {
+    public func sameDestination(_ other: TokenServerToken) -> Bool {
         return self.uid == other.uid &&
                self.api_endpoint == other.api_endpoint
     }
 
-    public static func fromJSON(json: JSON) -> TokenServerToken? {
+    public static func fromJSON(_ json: JSON) -> TokenServerToken? {
         if let
             id = json["id"].asString,
-            key = json["key"].asString,
-            api_endpoint = json["api_endpoint"].asString,
-            uid = json["uid"].asInt64,
-            durationInSeconds = json["duration"].asInt64,
-            remoteTimestamp = json["remoteTimestamp"].asInt64 {
+            let key = json["key"].asString,
+            let api_endpoint = json["api_endpoint"].asString,
+            let uid = json["uid"].asInt64,
+            let durationInSeconds = json["duration"].asInt64,
+            let remoteTimestamp = json["remoteTimestamp"].asInt64 {
                 return TokenServerToken(id: id, key: key, api_endpoint: api_endpoint, uid: UInt64(uid),
                     durationInSeconds: UInt64(durationInSeconds), remoteTimestamp: Timestamp(remoteTimestamp))
         }
@@ -45,11 +45,11 @@ public struct TokenServerToken {
 
     public func asJSON() -> JSON {
         let D: [String: AnyObject] = [
-            "id": id,
-            "key": key,
-            "api_endpoint": api_endpoint,
-            "uid": NSNumber(unsignedLongLong: uid),
-            "duration": NSNumber(unsignedLongLong: durationInSeconds),
+            "id": id as AnyObject,
+            "key": key as AnyObject,
+            "api_endpoint": api_endpoint as AnyObject,
+            "uid": NSNumber(value: uid as UInt64),
+            "duration": NSNumber(value: durationInSeconds as UInt64),
             "remoteTimestamp": NSNumber(unsignedLongLong: remoteTimestamp),
         ]
         return JSON(D)
@@ -59,8 +59,8 @@ public struct TokenServerToken {
 enum TokenServerError {
     // A Remote error definitely has a status code, but we may not have a well-formed JSON response
     // with a status; and we could have an unhealthy server that is not reporting its timestamp.
-    case Remote(code: Int32, status: String?, remoteTimestamp: Timestamp?)
-    case Local(NSError)
+    case remote(code: Int32, status: String?, remoteTimestamp: Timestamp?)
+    case local(NSError)
 }
 
 extension TokenServerError: MaybeErrorType {
@@ -72,28 +72,28 @@ extension TokenServerError: MaybeErrorType {
             } else {
                 return "<TokenServerError.Remote \(code)>"
             }
-        case let .Local(error):
+        case let .local(error):
             return "<TokenServerError.Local Error Domain=\(error.domain) Code=\(error.code) \"\(error.localizedDescription)\">"
         }
     }
 }
 
-public class TokenServerClient {
-    let URL: NSURL
+open class TokenServerClient {
+    let URL: Foundation.URL
 
-    public init(URL: NSURL? = nil) {
-        self.URL = URL ?? ProductionSync15Configuration().tokenServerEndpointURL
+    public init(URL: Foundation.URL? = nil) {
+        self.URL = URL ?? ProductionSync15Configuration().tokenServerEndpointURL as URL
     }
 
-    public class func getAudienceForURL(URL: NSURL) -> String {
-        if let port = URL.port {
+    open class func getAudienceForURL(_ URL: Foundation.URL) -> String {
+        if let port = (URL as NSURL).port {
             return "\(URL.scheme!)://\(URL.host!):\(port)"
         } else {
             return "\(URL.scheme!)://\(URL.host!)"
         }
     }
 
-    private class func parseTimestampHeader(header: String?) -> Timestamp? {
+    fileprivate class func parseTimestampHeader(_ header: String?) -> Timestamp? {
         if let timestampString = header {
             return decimalSecondsStringToTimestamp(timestampString)
         } else {
@@ -101,7 +101,7 @@ public class TokenServerClient {
         }
     }
 
-    private class func remoteErrorFromJSON(json: JSON, statusCode: Int, remoteTimestampHeader: String?) -> TokenServerError? {
+    fileprivate class func remoteErrorFromJSON(_ json: JSON, statusCode: Int, remoteTimestampHeader: String?) -> TokenServerError? {
         if json.isError {
             return nil
         }
@@ -112,34 +112,33 @@ public class TokenServerClient {
             remoteTimestamp: parseTimestampHeader(remoteTimestampHeader))
     }
 
-    private class func tokenFromJSON(json: JSON, remoteTimestampHeader: String?) -> TokenServerToken? {
+    fileprivate class func tokenFromJSON(_ json: JSON, remoteTimestampHeader: String?) -> TokenServerToken? {
         if json.isError {
             return nil
         }
         if let
             remoteTimestamp = parseTimestampHeader(remoteTimestampHeader), // A token server that is not providing its timestamp is not healthy.
-            id = json["id"].asString,
-            key = json["key"].asString,
-            api_endpoint = json["api_endpoint"].asString,
-            uid = json["uid"].asInt,
-            durationInSeconds = json["duration"].asInt64
-            where durationInSeconds > 0 {
+            let id = json["id"].asString,
+            let key = json["key"].asString,
+            let api_endpoint = json["api_endpoint"].asString,
+            let uid = json["uid"].asInt,
+            let durationInSeconds = json["duration"].asInt64, durationInSeconds > 0 {
             return TokenServerToken(id: id, key: key, api_endpoint: api_endpoint, uid: UInt64(uid),
                 durationInSeconds: UInt64(durationInSeconds), remoteTimestamp: remoteTimestamp)
         }
         return nil
     }
 
-    lazy private var alamofire: Alamofire.Manager = {
+    lazy fileprivate var alamofire: Alamofire.Manager = {
         let ua = UserAgent.tokenServerClientUserAgent
         let configuration = NSURLSessionConfiguration.ephemeralSessionConfiguration()
         return Alamofire.Manager.managerWithUserAgent(ua, configuration: configuration)
     }()
 
-    public func token(assertion: String, clientState: String? = nil) -> Deferred<Maybe<TokenServerToken>> {
+    open func token(_ assertion: String, clientState: String? = nil) -> Deferred<Maybe<TokenServerToken>> {
         let deferred = Deferred<Maybe<TokenServerToken>>()
 
-        let mutableURLRequest = NSMutableURLRequest(URL: URL)
+        let mutableURLRequest = NSMutableURLRequest(url: URL)
         mutableURLRequest.setValue("BrowserID " + assertion, forHTTPHeaderField: "Authorization")
         if let clientState = clientState {
             mutableURLRequest.setValue(clientState, forHTTPHeaderField: "X-Client-State")

--- a/AccountTests/FirefoxAccountTests.swift
+++ b/AccountTests/FirefoxAccountTests.swift
@@ -20,7 +20,7 @@ class FirefoxAccountTests: XCTestCase {
             "configurationLabel": FirefoxAccountConfigurationLabel.Production.rawValue,
             "email": "testtest@test.com",
             "uid": "uid",
-            "deviceRegistration": FxADeviceRegistration(id: "bogus-device", version: 0, lastRegistered: NSDate.now())
+            "deviceRegistration": FxADeviceRegistration(id: "bogus-device", version: 0, lastRegistered: Date.now())
         ]
 
         let account1 = FirefoxAccount(

--- a/AccountTests/FxAClient10Tests.swift
+++ b/AccountTests/FxAClient10Tests.swift
@@ -47,7 +47,7 @@ class FxAClient10Tests: LiveAccountTest {
 
     func testLoginSuccess() {
         withVerifiedAccount { emailUTF8, quickStretchedPW in
-            let e = self.expectationWithDescription("")
+            let e = self.expectation(description: "")
 
             let client = FxAClient10()
             let result = client.login(emailUTF8, quickStretchedPW: quickStretchedPW, getKeys: true)
@@ -63,12 +63,12 @@ class FxAClient10Tests: LiveAccountTest {
                 e.fulfill()
             }
         }
-        self.waitForExpectationsWithTimeout(10, handler: nil)
+        self.waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testLoginFailure() {
         withVerifiedAccount { emailUTF8, _ in
-            let e = self.expectationWithDescription("")
+            let e = self.expectation(description: "")
 
             let badPassword = FxAClient10.quickStretchPW(emailUTF8, password: "BAD PASSWORD".utf8EncodedData)
 
@@ -93,12 +93,12 @@ class FxAClient10Tests: LiveAccountTest {
                 e.fulfill()
             }
         }
-        self.waitForExpectationsWithTimeout(10, handler: nil)
+        self.waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testKeysSuccess() {
         withVerifiedAccount { emailUTF8, quickStretchedPW in
-            let e = self.expectationWithDescription("")
+            let e = self.expectation(description: "")
 
             let client = FxAClient10()
             let login: Deferred<Maybe<FxALoginResponse>> = client.login(emailUTF8, quickStretchedPW: quickStretchedPW, getKeys: true)
@@ -120,12 +120,12 @@ class FxAClient10Tests: LiveAccountTest {
                 e.fulfill()
             }
         }
-        self.waitForExpectationsWithTimeout(10, handler: nil)
+        self.waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testSignSuccess() {
         withVerifiedAccount { emailUTF8, quickStretchedPW in
-            let e = self.expectationWithDescription("")
+            let e = self.expectation(description: "")
 
             let client = FxAClient10()
             let login: Deferred<Maybe<FxALoginResponse>> = client.login(emailUTF8, quickStretchedPW: quickStretchedPW, getKeys: true)
@@ -149,6 +149,6 @@ class FxAClient10Tests: LiveAccountTest {
                 e.fulfill()
             }
         }
-        self.waitForExpectationsWithTimeout(10, handler: nil)
+        self.waitForExpectations(timeout: 10, handler: nil)
     }
 }

--- a/AccountTests/FxALoginStateMachineTests.swift
+++ b/AccountTests/FxALoginStateMachineTests.swift
@@ -12,20 +12,20 @@ import XCTest
 
 class MockFxALoginClient: FxALoginClient {
     // Fixed per mock client, for testing.
-    let kA = NSData.randomOfLength(UInt(KeyLength))!
-    let wrapkB = NSData.randomOfLength(UInt(KeyLength))!
+    let kA = Data.randomOfLength(UInt(KeyLength))!
+    let wrapkB = Data.randomOfLength(UInt(KeyLength))!
 
     func keyPair() -> Deferred<Maybe<KeyPair>> {
-        let keyPair: KeyPair = RSAKeyPair.generateKeyPairWithModulusSize(512)
+        let keyPair: KeyPair = RSAKeyPair.generate(withModulusSize: 512)
         return Deferred(value: Maybe(success: keyPair))
     }
 
-    func keys(keyFetchToken: NSData) -> Deferred<Maybe<FxAKeysResponse>> {
+    func keys(_ keyFetchToken: NSData) -> Deferred<Maybe<FxAKeysResponse>> {
         let response = FxAKeysResponse(kA: kA, wrapkB: wrapkB)
         return Deferred(value: Maybe(success: response))
     }
 
-    func sign(sessionToken: NSData, publicKey: PublicKey) -> Deferred<Maybe<FxASignResponse>> {
+    func sign(_ sessionToken: NSData, publicKey: PublicKey) -> Deferred<Maybe<FxASignResponse>> {
         let response = FxASignResponse(certificate: "certificate")
         return Deferred(value: Maybe(success: response))
     }
@@ -33,12 +33,12 @@ class MockFxALoginClient: FxALoginClient {
 
 // A mock client that fails locally (i.e., cannot connect to the network).
 class MockFxALoginClientWithoutNetwork: MockFxALoginClient {
-    override func keys(keyFetchToken: NSData) -> Deferred<Maybe<FxAKeysResponse>> {
+    override func keys(_ keyFetchToken: NSData) -> Deferred<Maybe<FxAKeysResponse>> {
         // Fail!
         return Deferred(value: Maybe(failure: FxAClientError.Local(NSError(domain: NSURLErrorDomain, code: -1000, userInfo: nil))))
     }
 
-    override func sign(sessionToken: NSData, publicKey: PublicKey) -> Deferred<Maybe<FxASignResponse>> {
+    override func sign(_ sessionToken: NSData, publicKey: PublicKey) -> Deferred<Maybe<FxASignResponse>> {
         // Fail!
         return Deferred(value: Maybe(failure: FxAClientError.Local(NSError(domain: NSURLErrorDomain, code: -1000, userInfo: nil))))
     }
@@ -46,12 +46,12 @@ class MockFxALoginClientWithoutNetwork: MockFxALoginClient {
 
 // A mock client that responds to keys and sign with 401 errors.
 class MockFxALoginClientAfterPasswordChange: MockFxALoginClient {
-    override func keys(keyFetchToken: NSData) -> Deferred<Maybe<FxAKeysResponse>> {
+    override func keys(_ keyFetchToken: NSData) -> Deferred<Maybe<FxAKeysResponse>> {
         let response = FxAClientError.Remote(RemoteError(code: 401, errno: 103, error: "Bad auth", message: "Bad auth message", info: "Bad auth info"))
         return Deferred(value: Maybe(failure: response))
     }
 
-    override func sign(sessionToken: NSData, publicKey: PublicKey) -> Deferred<Maybe<FxASignResponse>> {
+    override func sign(_ sessionToken: NSData, publicKey: PublicKey) -> Deferred<Maybe<FxASignResponse>> {
         let response = FxAClientError.Remote(RemoteError(code: 401, errno: 103, error: "Bad auth", message: "Bad auth message", info: "Bad auth info"))
         return Deferred(value: Maybe(failure: response))
     }
@@ -59,7 +59,7 @@ class MockFxALoginClientAfterPasswordChange: MockFxALoginClient {
 
 // A mock client that responds to keys with 400/104 (needs verification responses).
 class MockFxALoginClientBeforeVerification: MockFxALoginClient {
-    override func keys(keyFetchToken: NSData) -> Deferred<Maybe<FxAKeysResponse>> {
+    override func keys(_ keyFetchToken: NSData) -> Deferred<Maybe<FxAKeysResponse>> {
         let response = FxAClientError.Remote(RemoteError(code: 400, errno: 104,
             error: "Unverified", message: "Unverified message", info: "Unverified info"))
         return Deferred(value: Maybe(failure: response))
@@ -68,7 +68,7 @@ class MockFxALoginClientBeforeVerification: MockFxALoginClient {
 
 // A mock client that responds to sign with 503/999 (unknown server error).
 class MockFxALoginClientDuringOutage: MockFxALoginClient {
-    override func sign(sessionToken: NSData, publicKey: PublicKey) -> Deferred<Maybe<FxASignResponse>> {
+    override func sign(_ sessionToken: NSData, publicKey: PublicKey) -> Deferred<Maybe<FxASignResponse>> {
         let response = FxAClientError.Remote(RemoteError(code: 503, errno: 999,
             error: "Unknown", message: "Unknown error", info: "Unknown err info"))
         return Deferred(value: Maybe(failure: response))
@@ -83,12 +83,12 @@ class FxALoginStateMachineTests: XCTestCase {
         self.continueAfterFailure = false
     }
 
-    func withMachine(client: FxALoginClient, callback: (FxALoginStateMachine) -> Void) {
+    func withMachine(_ client: FxALoginClient, callback: (FxALoginStateMachine) -> Void) {
         let stateMachine = FxALoginStateMachine(client: client)
         callback(stateMachine)
     }
 
-    func withMachineAndClient(callback: (FxALoginStateMachine, MockFxALoginClient) -> Void) {
+    func withMachineAndClient(_ callback: (FxALoginStateMachine, MockFxALoginClient) -> Void) {
         let client = MockFxALoginClient()
         withMachine(client) { stateMachine in
             callback(stateMachine, client)
@@ -108,12 +108,12 @@ class FxALoginStateMachineTests: XCTestCase {
                 }
             }
         }
-        self.waitForExpectationsWithTimeout(10, handler: nil)
+        self.waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testAdvanceFromEngagedBeforeVerified() {
         // Advancing from engaged before verified stays put.
-        let e = self.expectationWithDescription("Wait for login state machine.")
+        let e = self.expectation(description: "Wait for login state machine.")
         let engagedState = (FxAStateTests.stateForLabel(.EngagedBeforeVerified) as! EngagedBeforeVerifiedState)
         withMachine(MockFxALoginClientBeforeVerification()) { stateMachine in
             stateMachine.advanceFromState(engagedState, now: engagedState.knownUnverifiedAt).upon { newState in
@@ -121,7 +121,7 @@ class FxALoginStateMachineTests: XCTestCase {
                 e.fulfill()
             }
         }
-        self.waitForExpectationsWithTimeout(10, handler: nil)
+        self.waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testAdvanceFromEngagedAfterVerified() {
@@ -143,7 +143,7 @@ class FxALoginStateMachineTests: XCTestCase {
                 e.fulfill()
             }
         }
-        self.waitForExpectationsWithTimeout(10, handler: nil)
+        self.waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testAdvanceFromEngagedAfterVerifiedWithoutNetwork() {
@@ -157,12 +157,12 @@ class FxALoginStateMachineTests: XCTestCase {
                 e.fulfill()
             }
         }
-        self.waitForExpectationsWithTimeout(10, handler: nil)
+        self.waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testAdvanceFromCohabitingAfterVerifiedDuringOutage() {
         // Advancing from engaged after verified, but during outage, stays put.
-        let e = self.expectationWithDescription("Wait for login state machine.")
+        let e = self.expectation(description: "Wait for login state machine.")
         let state = (FxAStateTests.stateForLabel(.CohabitingAfterKeyPair) as! CohabitingAfterKeyPairState)
         withMachine(MockFxALoginClientDuringOutage()) { stateMachine in
             stateMachine.advanceFromState(state, now: 0).upon { newState in
@@ -170,12 +170,12 @@ class FxALoginStateMachineTests: XCTestCase {
                 e.fulfill()
             }
         }
-        self.waitForExpectationsWithTimeout(10, handler: nil)
+        self.waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testAdvanceFromCohabitingAfterVerifiedWithoutNetwork() {
         // Advancing from cohabiting after verified, but when the network is not available, stays put.
-        let e = self.expectationWithDescription("Wait for login state machine.")
+        let e = self.expectation(description: "Wait for login state machine.")
         let state = (FxAStateTests.stateForLabel(.CohabitingAfterKeyPair) as! CohabitingAfterKeyPairState)
         withMachine(MockFxALoginClientWithoutNetwork()) { stateMachine in
             stateMachine.advanceFromState(state, now: 0).upon { newState in
@@ -183,24 +183,24 @@ class FxALoginStateMachineTests: XCTestCase {
                 e.fulfill()
             }
         }
-        self.waitForExpectationsWithTimeout(10, handler: nil)
+        self.waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testAdvanceFromMarried() {
         // Advancing from a healthy Married state is easy.
-        let e = self.expectationWithDescription("Wait for login state machine.")
+        let e = self.expectation(description: "Wait for login state machine.")
         withMachineAndClient { stateMachine, _ in
             stateMachine.advanceFromState(self.marriedState, now: 0).upon { newState in
                 XCTAssertEqual(newState.label, FxAStateLabel.Married)
                 e.fulfill()
             }
         }
-        self.waitForExpectationsWithTimeout(10, handler: nil)
+        self.waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testAdvanceFromMarriedWithExpiredCertificate() {
         // Advancing from a Married state with an expired certificate gets back to Married.
-        let e = self.expectationWithDescription("Wait for login state machine.")
+        let e = self.expectation(description: "Wait for login state machine.")
         let now = self.marriedState.certificateExpiresAt + OneWeekInMilliseconds + 1
         withMachineAndClient { stateMachine, _ in
             stateMachine.advanceFromState(self.marriedState, now: now).upon { newState in
@@ -213,12 +213,12 @@ class FxALoginStateMachineTests: XCTestCase {
                 e.fulfill()
             }
         }
-        self.waitForExpectationsWithTimeout(10, handler: nil)
+        self.waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testAdvanceFromMarriedWithExpiredKeyPair() {
         // Advancing from a Married state with an expired keypair gets back to Married too.
-        let e = self.expectationWithDescription("Wait for login state machine.")
+        let e = self.expectation(description: "Wait for login state machine.")
         let now = self.marriedState.certificateExpiresAt + OneMonthInMilliseconds + 1
         withMachineAndClient { stateMachine, _ in
             stateMachine.advanceFromState(self.marriedState, now: now).upon { newState in
@@ -231,12 +231,12 @@ class FxALoginStateMachineTests: XCTestCase {
                 e.fulfill()
             }
         }
-        self.waitForExpectationsWithTimeout(10, handler: nil)
+        self.waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testAdvanceFromMarriedAfterPasswordChange() {
         // Advancing from a Married state with a 401 goes to Separated if it needs a new certificate.
-        let e = self.expectationWithDescription("Wait for login state machine.")
+        let e = self.expectation(description: "Wait for login state machine.")
         let now = self.marriedState.certificateExpiresAt + OneDayInMilliseconds + 1
         withMachine(MockFxALoginClientAfterPasswordChange()) { stateMachine in
             stateMachine.advanceFromState(self.marriedState, now: now).upon { newState in
@@ -244,6 +244,6 @@ class FxALoginStateMachineTests: XCTestCase {
                 e.fulfill()
             }
         }
-        self.waitForExpectationsWithTimeout(10, handler: nil)
+        self.waitForExpectations(timeout: 10, handler: nil)
     }
 }

--- a/AccountTests/FxAStateTests.swift
+++ b/AccountTests/FxAStateTests.swift
@@ -9,9 +9,9 @@ import Shared
 import XCTest
 
 class FxAStateTests: XCTestCase {
-    class func stateForLabel(label: FxAStateLabel) -> FxAState {
+    class func stateForLabel(_ label: FxAStateLabel) -> FxAState {
         let keyLength = UInt(KeyLength) // Ah, Swift.
-        let now = NSDate.now()
+        let now = Date.now()
 
         switch label {
         case .EngagedBeforeVerified:
@@ -32,13 +32,13 @@ class FxAStateTests: XCTestCase {
                 kA: NSData.randomOfLength(keyLength)!, kB: NSData.randomOfLength(keyLength)!)
 
         case .CohabitingAfterKeyPair:
-            let keyPair = RSAKeyPair.generateKeyPairWithModulusSize(512)
+            let keyPair = RSAKeyPair.generate(withModulusSize: 512)
             return CohabitingAfterKeyPairState(sessionToken: NSData.randomOfLength(keyLength)!,
                 kA: NSData.randomOfLength(keyLength)!, kB: NSData.randomOfLength(keyLength)!,
                 keyPair: keyPair, keyPairExpiresAt: now + 1)
 
         case .Married:
-            let keyPair = RSAKeyPair.generateKeyPairWithModulusSize(512)
+            let keyPair = RSAKeyPair.generate(withModulusSize: 512)
             return MarriedState(sessionToken: NSData.randomOfLength(keyLength)!,
                 kA: NSData.randomOfLength(keyLength)!, kB: NSData.randomOfLength(keyLength)!,
                 keyPair: keyPair, keyPairExpiresAt: now + 1,

--- a/AccountTests/HawkHelperTests.swift
+++ b/AccountTests/HawkHelperTests.swift
@@ -29,7 +29,7 @@ class HawkHelperTests: XCTestCase {
         let timestamp = Int64(1353832234)
         let nonce = "j4h3g2"
         let extra = "some-app-ext-data"
-        let req = Alamofire.request(.GET, NSURL(string: "http://example.com:8000/resource/1?b=1&a=2")!)
+        let req = Alamofire.request(.GET, URL(string: "http://example.com:8000/resource/1?b=1&a=2")!)
         let expected = "hawk.1.header\n" +
             "1353832234\n" +
             "j4h3g2\n" +
@@ -46,7 +46,7 @@ class HawkHelperTests: XCTestCase {
     func testSpecWithoutPayloadExample() {
         let helper = HawkHelper(id: "dh37fgj492je",
             key: "werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn".utf8EncodedData)
-        let req = Alamofire.request(.GET, NSURL(string: "http://example.com:8000/resource/1?b=1&a=2")!)
+        let req = Alamofire.request(.GET, URL(string: "http://example.com:8000/resource/1?b=1&a=2")!)
         let timestamp = Int64(1353832234)
         let nonce = "j4h3g2"
         let extra = "some-app-ext-data"
@@ -59,7 +59,7 @@ class HawkHelperTests: XCTestCase {
         let helper = HawkHelper(id: "dh37fgj492je",
             key: "werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn".utf8EncodedData)
         let body = "Thank you for flying Hawk"
-        let req = Alamofire.request(.POST, NSURL(string: "http://example.com:8000/resource/1?b=1&a=2")!,
+        let req = Alamofire.request(.POST, URL(string: "http://example.com:8000/resource/1?b=1&a=2")!,
             parameters: [:], encoding: .Custom({ convertible, params in
                 // This just makes a POST with a body string.
                 let mutableRequest = convertible.URLRequest.copy() as! NSMutableURLRequest

--- a/AccountTests/LiveAccountTest.swift
+++ b/AccountTests/LiveAccountTest.swift
@@ -15,9 +15,9 @@ import XCTest
 /*
  * A base test type for tests that need a live Firefox Account.
  */
-public class LiveAccountTest: XCTestCase {
+open class LiveAccountTest: XCTestCase {
     lazy var signedInUser: JSON? = {
-        if let path = NSBundle(forClass: self.dynamicType).pathForResource("signedInUser.json", ofType: nil) {
+        if let path = NSBundle(forClass: type(of: self)).pathForResource("signedInUser.json", ofType: nil) {
             if let contents = try? String(contentsOfFile: path, encoding: NSUTF8StringEncoding) {
                 let json = JSON.parse(contents)
                 if json.isError {
@@ -39,10 +39,10 @@ public class LiveAccountTest: XCTestCase {
     // If signedInUser.json contains an email address, we use that email address.
     // Since there's no way to get the corresponding password (from any client!), we assume that any
     // test account has password identical to its email address.
-    private func withExistingAccount(mustBeVerified: Bool, completion: (NSData, NSData) -> Void) {
+    fileprivate func withExistingAccount(_ mustBeVerified: Bool, completion: (Data, Data) -> Void) {
         // If we don't create at least one expectation, waitForExpectations fails.
         // So we unconditionally create one, even though the callback may not execute.
-        self.expectationWithDescription("withExistingAccount").fulfill()
+        self.expectation(description: "withExistingAccount").fulfill()
         if let json = self.signedInUser {
             if mustBeVerified {
                 XCTAssertTrue(json["verified"].asBool ?? false)
@@ -58,15 +58,15 @@ public class LiveAccountTest: XCTestCase {
         }
     }
 
-    func withVerifiedAccount(completion: (NSData, NSData) -> Void) {
+    func withVerifiedAccount(_ completion: (Data, Data) -> Void) {
         withExistingAccount(true, completion: completion)
     }
 
-    func withCertificate(completion: (XCTestExpectation, NSData, KeyPair, String) -> Void) {
+    func withCertificate(_ completion: @escaping (XCTestExpectation, Data, KeyPair, String) -> Void) {
         withVerifiedAccount { emailUTF8, quickStretchedPW in
-            let expectation = self.expectationWithDescription("withCertificate")
+            let expectation = self.expectation(description: "withCertificate")
 
-            let keyPair = RSAKeyPair.generateKeyPairWithModulusSize(1024)
+            let keyPair = RSAKeyPair.generate(withModulusSize: 1024)
             let client = FxAClient10()
             let login: Deferred<Maybe<FxALoginResponse>> = client.login(emailUTF8, quickStretchedPW: quickStretchedPW, getKeys: true)
             let sign: Deferred<Maybe<FxASignResponse>> = login.bind { (result: Maybe<FxALoginResponse>) in
@@ -91,21 +91,21 @@ public class LiveAccountTest: XCTestCase {
     }
 
     public enum AccountError: MaybeErrorType {
-        case BadParameters
-        case NoSignedInUser
-        case UnverifiedSignedInUser
+        case badParameters
+        case noSignedInUser
+        case unverifiedSignedInUser
 
         public var description: String {
             switch self {
-            case BadParameters: return "Bad account parameters (email, password, or a derivative thereof)."
-            case NoSignedInUser: return "No signedInUser.json (missing, no email, etc)."
-            case UnverifiedSignedInUser: return "signedInUser.json describes an unverified account."
+            case .badParameters: return "Bad account parameters (email, password, or a derivative thereof)."
+            case .noSignedInUser: return "No signedInUser.json (missing, no email, etc)."
+            case .unverifiedSignedInUser: return "signedInUser.json describes an unverified account."
             }
         }
     }
 
     // Internal helper.
-    func account(email: String, password: String, configuration: FirefoxAccountConfiguration) -> Deferred<Maybe<FirefoxAccount>> {
+    func account(_ email: String, password: String, configuration: FirefoxAccountConfiguration) -> Deferred<Maybe<FirefoxAccount>> {
         let client = FxAClient10(endpoint: configuration.authEndpointURL)
         let emailUTF8 = email.utf8EncodedData
         let passwordUTF8 = password.utf8EncodedData
@@ -127,7 +127,7 @@ public class LiveAccountTest: XCTestCase {
             configuration: ProductionFirefoxAccountConfiguration())
     }
 
-    public func getAuthState(now: Timestamp) -> Deferred<Maybe<SyncAuthState>> {
+    open func getAuthState(_ now: Timestamp) -> Deferred<Maybe<SyncAuthState>> {
         let account = self.getTestAccount()
         print("Got test account.")
         return account.map { result in
@@ -139,7 +139,7 @@ public class LiveAccountTest: XCTestCase {
         }
     }
 
-    public func syncAuthState(now: Timestamp) -> Deferred<Maybe<(token: TokenServerToken, forKey: NSData)>> {
+    open func syncAuthState(_ now: Timestamp) -> Deferred<Maybe<(token: TokenServerToken, forKey: NSData)>> {
         return getAuthState(now).bind { result in
             if let authState = result.successValue {
                 return authState.token(now, canBeExpired: false)

--- a/AccountTests/SyncAuthStateTests.swift
+++ b/AccountTests/SyncAuthStateTests.swift
@@ -12,8 +12,8 @@ import XCTest
 
 class SyncAuthStateTests: LiveAccountTest {
     func testLive() {
-        let e = self.expectationWithDescription("Wait for token.")
-        syncAuthState(NSDate.now()).upon { result in
+        let e = self.expectation(description: "Wait for token.")
+        syncAuthState(Date.now()).upon { result in
             if let (token, forKey) = result.successValue {
                 let uidString = NSNumber(unsignedLongLong: token.uid).stringValue
                 XCTAssertTrue(token.api_endpoint.endsWith(uidString))
@@ -27,6 +27,6 @@ class SyncAuthStateTests: LiveAccountTest {
             }
             e.fulfill()
         }
-        self.waitForExpectationsWithTimeout(10, handler: nil)
+        self.waitForExpectations(timeout: 10, handler: nil)
     }
 }

--- a/AccountTests/TokenServerClientTests.swift
+++ b/AccountTests/TokenServerClientTests.swift
@@ -23,8 +23,8 @@ class TokenServerClientTests: LiveAccountTest {
     }
 
     func testAudienceForEndpoint() {
-        func audienceFor(endpoint: String) -> String {
-            return TokenServerClient.getAudienceForURL(NSURL(string: endpoint)!)
+        func audienceFor(_ endpoint: String) -> String {
+            return TokenServerClient.getAudienceForURL(URL(string: endpoint)!)
         }
 
         // Sub-domains and path components.
@@ -71,13 +71,13 @@ class TokenServerClientTests: LiveAccountTest {
                 expectation.fulfill()
             }
         }
-        self.waitForExpectationsWithTimeout(100, handler: nil)
+        self.waitForExpectations(timeout: 100, handler: nil)
     }
 
     func testTokenFailure() {
         withVerifiedAccount { _, _ in
             // Account details aren't used, but we want to skip when we're not running live tests.
-            let e = self.expectationWithDescription("")
+            let e = self.expectation(description: "")
 
             let assertion = "BAD ASSERTION"
 
@@ -103,6 +103,6 @@ class TokenServerClientTests: LiveAccountTest {
                 e.fulfill()
             }
         }
-        self.waitForExpectationsWithTimeout(10, handler: nil)
+        self.waitForExpectations(timeout: 10, handler: nil)
     }
 }

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -4290,12 +4290,12 @@
 					2FA435FA1ABB83B4008031D1 = {
 						CreatedOnToolsVersion = 6.2;
 						DevelopmentTeam = 43AQ936H96;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0820;
 					};
 					2FA436041ABB83B4008031D1 = {
 						CreatedOnToolsVersion = 6.2;
 						DevelopmentTeam = 43AQ936H96;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0820;
 						TestTargetID = F84B21BD1A090F8100AAB793;
 					};
 					2FCAE2191ABB51F800877008 = {
@@ -4337,7 +4337,7 @@
 					};
 					D39FA15E1A83E0EC00EE869C = {
 						CreatedOnToolsVersion = 6.1.1;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0800;
 						TestTargetID = F84B21BD1A090F8100AAB793;
 					};
@@ -5891,7 +5891,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Account/Account-Bridging-Header.h";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Fennec;
 		};
@@ -5908,7 +5908,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.mozilla.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Account/Account-Bridging-Header.h";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
 			};
 			name = Fennec;
@@ -6700,7 +6700,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Account/Account-Bridging-Header.h";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Firefox;
 		};
@@ -6719,7 +6719,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.mozilla.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Account/Account-Bridging-Header.h";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
 			};
 			name = Firefox;
@@ -7303,7 +7303,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Account/Account-Bridging-Header.h";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = FirefoxNightly;
 		};
@@ -7449,7 +7449,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.mozilla.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Account/Account-Bridging-Header.h";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
 			};
 			name = FirefoxNightly;
@@ -7791,7 +7791,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Account/Account-Bridging-Header.h";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = FennecEnterprise;
 		};
@@ -7930,7 +7930,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.mozilla.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Account/Account-Bridging-Header.h";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
 			};
 			name = FennecEnterprise;
@@ -8452,7 +8452,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Account/Account-Bridging-Header.h";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = FirefoxBeta;
 		};
@@ -8471,7 +8471,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.mozilla.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Account/Account-Bridging-Header.h";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
 			};
 			name = FirefoxBeta;


### PR DESCRIPTION
The following automigrations were noted as incomplete or incorrect

FirefoxAccount:
* function names not Swift 3.0 style guide compliant
* migration did not update use of `AnyObject` to `Any` in `asDictionary()` and `fromDictionary()`

FirefoxAccountConfigurationLabels:
* case names were not lowercased

FxAClient10:
* Use of `Foundation.URL` rather than simply `URL`
* function names not Swift 3.0 style guide compliant
* use of `NSMutableURLRequest` in `login` should move to using `URLRequest`

FxADevice:
* function names not Swift 3.0 style guide compliant

FxALoginStateMachine:
* function names not Swift 3.0 style guide compliant

FxAState:
* function names not Swift 3.0 style guide compliant

FxAStateLabel:
* case names were not lowercased

HawkHelper
* class constants should be lowerCamelCase

TokenServerClient:
* function names not Swift 3.0 style guide compliant
* Use of `Foundation.URL` rather than simply `URL`
* in `init` there is no need to cast result of call to `ProductionSync15Configuration().tokenServerEndpointURL` to `URL`

