### PR TITLE
Bug 1344703 – Register for Sync notifications with autopush and APNS

### DIFF
--- a/Account/FirefoxAccount.swift
+++ b/Account/FirefoxAccount.swift
@@ -34,6 +34,8 @@ open class FirefoxAccount {
 
     open let configuration: FirefoxAccountConfiguration
 
+    open var pushRegistration: PushRegistration?
+
     fileprivate let stateCache: KeychainCache<FxAState>
     open var syncAuthState: SyncAuthState! // We can't give a reference to self if this is a let.
 
@@ -129,8 +131,10 @@ open class FirefoxAccount {
         dict["email"] = email
         dict["uid"] = uid
         dict["deviceRegistration"] = deviceRegistration
+        dict["pushRegistration"] = pushRegistration
         dict["configurationLabel"] = configuration.label.rawValue
         dict["stateKeyLabel"] = stateCache.label
+        dict["pushRegistration"] = pushRegistration
         return dict
     }
 
@@ -154,11 +158,13 @@ open class FirefoxAccount {
             let uid = dictionary["uid"] as? String {
                 let deviceRegistration = dictionary["deviceRegistration"] as? FxADeviceRegistration
                 let stateCache = KeychainCache.fromBranch("account.state", withLabel: dictionary["stateKeyLabel"] as? String, withDefault: SeparatedState(), factory: state)
-                return FirefoxAccount(
+                let account = FirefoxAccount(
                     configuration: configurationLabel.toConfiguration(),
                     email: email, uid: uid,
                     deviceRegistration: deviceRegistration,
                     stateCache: stateCache)
+                account.pushRegistration = dictionary["pushRegistration"] as? PushRegistration
+                return account
         }
         return nil
     }

--- a/Account/FirefoxAccount.swift
+++ b/Account/FirefoxAccount.swift
@@ -134,7 +134,6 @@ open class FirefoxAccount {
         dict["pushRegistration"] = pushRegistration
         dict["configurationLabel"] = configuration.label.rawValue
         dict["stateKeyLabel"] = stateCache.label
-        dict["pushRegistration"] = pushRegistration
         return dict
     }
 

--- a/Account/FirefoxAccountConfiguration.swift
+++ b/Account/FirefoxAccountConfiguration.swift
@@ -48,6 +48,8 @@ public protocol FirefoxAccountConfiguration {
     var forceAuthURL: URL { get }
 
     var sync15Configuration: Sync15Configuration { get }
+
+    var pushConfiguration: PushConfiguration { get }
 }
 
 public struct LatestDevFirefoxAccountConfiguration: FirefoxAccountConfiguration {
@@ -65,6 +67,8 @@ public struct LatestDevFirefoxAccountConfiguration: FirefoxAccountConfiguration 
     public let forceAuthURL = URL(string: "https://latest.dev.lcip.org/force_auth?service=sync&context=fx_ios_v1")!
 
     public let sync15Configuration: Sync15Configuration = StageSync15Configuration()
+
+    public let pushConfiguration: PushConfiguration = DeveloperPushConfiguration()
 }
 
 public struct StableDevFirefoxAccountConfiguration: FirefoxAccountConfiguration {
@@ -82,6 +86,8 @@ public struct StableDevFirefoxAccountConfiguration: FirefoxAccountConfiguration 
     public let forceAuthURL = URL(string: "https://stable.dev.lcip.org/force_auth?service=sync&context=fx_ios_v1")!
 
     public let sync15Configuration: Sync15Configuration = StageSync15Configuration()
+
+    public let pushConfiguration: PushConfiguration = DeveloperPushConfiguration()
 }
 
 public struct StageFirefoxAccountConfiguration: FirefoxAccountConfiguration {
@@ -99,6 +105,8 @@ public struct StageFirefoxAccountConfiguration: FirefoxAccountConfiguration {
     public let forceAuthURL = URL(string: "https://accounts.stage.mozaws.net/force_auth?service=sync&context=fx_ios_v1")!
 
     public let sync15Configuration: Sync15Configuration = StageSync15Configuration()
+
+    public let pushConfiguration: PushConfiguration = StagePushConfiguration()
 }
 
 public struct ProductionFirefoxAccountConfiguration: FirefoxAccountConfiguration {
@@ -116,6 +124,8 @@ public struct ProductionFirefoxAccountConfiguration: FirefoxAccountConfiguration
     public let forceAuthURL = URL(string: "https://accounts.firefox.com/force_auth?service=sync&context=fx_ios_v1")!
 
     public let sync15Configuration: Sync15Configuration = ProductionSync15Configuration()
+
+    public let pushConfiguration: PushConfiguration = ProductionPushConfiguration()
 }
 
 public struct ChinaEditionFirefoxAccountConfiguration: FirefoxAccountConfiguration {
@@ -133,6 +143,8 @@ public struct ChinaEditionFirefoxAccountConfiguration: FirefoxAccountConfigurati
     public let forceAuthURL = URL(string: "https://accounts.firefox.com.cn/force_auth?service=sync&context=fx_ios_v1")!
 
     public let sync15Configuration: Sync15Configuration = ChinaEditionSync15Configuration()
+
+    public let pushConfiguration: PushConfiguration = ProductionPushConfiguration()
 }
 
 public struct ChinaEditionSync15Configuration: Sync15Configuration {

--- a/Account/FxADeviceRegistration.swift
+++ b/Account/FxADeviceRegistration.swift
@@ -75,15 +75,22 @@ open class FxADeviceRegistrator {
                 return deferMaybe(FxADeviceRegistrationResult.alreadyRegistered)
         }
 
+        let pushParams: FxADevicePushParams?
+        if AppConstants.MOZ_FXA_PUSH, let pushRegistration = account.pushRegistration {
+            pushParams = FxADevicePushParams(callback: pushRegistration.endpoint.absoluteString!, publicKey: "", authKey: "")
+        } else {
+            pushParams = nil
+        }
+
         let client = client ?? FxAClient10(endpoint: account.configuration.authEndpointURL)
         let name = DeviceInfo.defaultClientName()
         let device: FxADevice
         let registrationResult: FxADeviceRegistrationResult
         if let registration = account.deviceRegistration {
-            device = FxADevice.forUpdate(name, id: registration.id)
+            device = FxADevice.forUpdate(name, id: registration.id, push: pushParams)
             registrationResult = FxADeviceRegistrationResult.updated
         } else {
-            device = FxADevice.forRegister(name, type: "mobile")
+            device = FxADevice.forRegister(name, type: "mobile", push: pushParams)
             registrationResult = FxADeviceRegistrationResult.registered
         }
 

--- a/AccountTests/FirefoxAccountTests.swift
+++ b/AccountTests/FirefoxAccountTests.swift
@@ -20,7 +20,8 @@ class FirefoxAccountTests: XCTestCase {
             "configurationLabel": FirefoxAccountConfigurationLabel.production.rawValue,
             "email": "testtest@test.com",
             "uid": "uid",
-            "deviceRegistration": FxADeviceRegistration(id: "bogus-device", version: 0, lastRegistered: Date.now())
+            "deviceRegistration": FxADeviceRegistration(id: "bogus-device", version: 0, lastRegistered: Date.now()),
+            "pushRegistration": PushRegistration(uaid: "bogus-device-uaid", secret: "secret", endpoint: NSURL(string: "https://mozilla.com")!, channelID: "channelID"),
         ]
 
         let account1 = FirefoxAccount(
@@ -30,6 +31,9 @@ class FirefoxAccountTests: XCTestCase {
                 deviceRegistration: (d["deviceRegistration"] as! FxADeviceRegistration),
                 stateKeyLabel: Bytes.generateGUID(),
                 state: SeparatedState())
+
+        account1.pushRegistration = d["pushRegistration"] as? PushRegistration
+
         let d1 = account1.dictionary()
 
         let account2 = FirefoxAccount.fromDictionary(d1)

--- a/AccountTests/LivePushClientTests.swift
+++ b/AccountTests/LivePushClientTests.swift
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@testable import Account
+import Foundation
+import Shared
+import XCTest
+
+class LivePushClientTests: XCTestCase {
+
+    var endpointURL: NSURL {
+        return DeveloperPushConfiguration().endpointURL
+    }
+    
+    func testClientRegistration() {
+        let num = arc4random_uniform(1 << 31)
+        let deviceID = "test-id-deadbeef-\(num)"
+        let client = PushClient(endpointURL: endpointURL)
+
+        let maybeReg = client.register(deviceID).value
+        XCTAssert(maybeReg.isSuccess, "Registered OK - deviceID = \(deviceID)")
+
+        guard let registration = maybeReg.successValue else {
+            return XCTFail("Registration failed – \(maybeReg.failureValue)")
+        }
+
+        let maybeVoid = client.unregister(registration).value
+        XCTAssert(maybeVoid.isSuccess, "Unregistered OK - deviceID = \(deviceID), registration.uaid = \(registration.uaid)")
+    }
+}

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -224,6 +224,11 @@
 		39EB46991E26DDB4006346E8 /* ScreenGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EB46971E26DDB4006346E8 /* ScreenGraph.swift */; };
 		39EB469A1E26DDB4006346E8 /* FxScreenGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EB46981E26DDB4006346E8 /* FxScreenGraph.swift */; };
 		39F6D0701CD3B0770055D949 /* HomePageSettingsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F6D06F1CD3B0770055D949 /* HomePageSettingsUITests.swift */; };
+		39F99FE21E3A6F0600F353B4 /* LivePushClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F99FDF1E3A6ED400F353B4 /* LivePushClientTests.swift */; };
+		39F99FE41E3A6F1700F353B4 /* PushClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F99FD91E3A6DE300F353B4 /* PushClient.swift */; };
+		39F99FE51E3A6F1700F353B4 /* PushConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F99FDA1E3A6DE300F353B4 /* PushConfiguration.swift */; };
+		39F99FE61E3A6F1700F353B4 /* PushRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F99FDB1E3A6DE300F353B4 /* PushRegistration.swift */; };
+		39F99FEE1E3A71F800F353B4 /* FxALoginHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F99FED1E3A71F800F353B4 /* FxALoginHelper.swift */; };
 		3B0943811D6CC4FC004F24E1 /* FilledPageControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0943801D6CC4FC004F24E1 /* FilledPageControl.swift */; };
 		3B39EDBA1E16E18900EF029F /* CustomSearchEnginesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B39EDB91E16E18900EF029F /* CustomSearchEnginesTest.swift */; };
 		3B39EDCB1E16E1AA00EF029F /* CustomSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B39EDCA1E16E1AA00EF029F /* CustomSearchViewController.swift */; };
@@ -1396,6 +1401,11 @@
 		39EB46971E26DDB4006346E8 /* ScreenGraph.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenGraph.swift; sourceTree = "<group>"; };
 		39EB46981E26DDB4006346E8 /* FxScreenGraph.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxScreenGraph.swift; sourceTree = "<group>"; };
 		39F6D06F1CD3B0770055D949 /* HomePageSettingsUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomePageSettingsUITests.swift; sourceTree = "<group>"; };
+		39F99FD91E3A6DE300F353B4 /* PushClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushClient.swift; path = Push/PushClient.swift; sourceTree = "<group>"; };
+		39F99FDA1E3A6DE300F353B4 /* PushConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushConfiguration.swift; path = Push/PushConfiguration.swift; sourceTree = "<group>"; };
+		39F99FDB1E3A6DE300F353B4 /* PushRegistration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushRegistration.swift; path = Push/PushRegistration.swift; sourceTree = "<group>"; };
+		39F99FDF1E3A6ED400F353B4 /* LivePushClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LivePushClientTests.swift; sourceTree = "<group>"; };
+		39F99FED1E3A71F800F353B4 /* FxALoginHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FxALoginHelper.swift; path = Helpers/FxALoginHelper.swift; sourceTree = "<group>"; };
 		3B0943801D6CC4FC004F24E1 /* FilledPageControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FilledPageControl.swift; path = ThirdParty/FilledPageControl.swift; sourceTree = "<group>"; };
 		3B39EDB91E16E18900EF029F /* CustomSearchEnginesTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomSearchEnginesTest.swift; sourceTree = "<group>"; };
 		3B39EDCA1E16E1AA00EF029F /* CustomSearchViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomSearchViewController.swift; sourceTree = "<group>"; };
@@ -2395,6 +2405,7 @@
 				2FFC4D371ABE3C420081D675 /* FxAStateTests.swift */,
 				2FA4363A1ABB8448008031D1 /* HawkHelperTests.swift */,
 				2FA4363B1ABB8448008031D1 /* LiveAccountTest.swift */,
+				39F99FDF1E3A6ED400F353B4 /* LivePushClientTests.swift */,
 				2FDBCF9A1AC0ADB500AFF7F0 /* SyncAuthStateTests.swift */,
 				2FA4363C1ABB8448008031D1 /* TokenServerClientTests.swift */,
 				E6C9EB6A1E2FBFC300D5CE80 /* signedInUser.json */,
@@ -2548,9 +2559,20 @@
 			children = (
 				E65075531E37F6FC006961AC /* DynamicFontHelper.swift */,
 				E65075601E37F77D006961AC /* MenuHelper.swift */,
+				39F99FED1E3A71F800F353B4 /* FxALoginHelper.swift */,
 				39A359E31BFCCE94006B9E87 /* SpotlightHelper.swift */,
 			);
 			name = Helpers;
+			sourceTree = "<group>";
+		};
+		39F99FC71E3A6DB700F353B4 /* Push */ = {
+			isa = PBXGroup;
+			children = (
+				39F99FD91E3A6DE300F353B4 /* PushClient.swift */,
+				39F99FDA1E3A6DE300F353B4 /* PushConfiguration.swift */,
+				39F99FDB1E3A6DE300F353B4 /* PushRegistration.swift */,
+			);
+			name = Push;
 			sourceTree = "<group>";
 		};
 		3B4262D31E538EB100CA681C /* Metadata Parsing */ = {
@@ -3260,6 +3282,7 @@
 				7B604FC11C496005006EEEC3 /* Frameworks */,
 				F84B21BF1A090F8100AAB793 /* Products */,
 				D34DC84C1A16C40C00D49B7B /* Providers */,
+				39F99FC71E3A6DB700F353B4 /* Push */,
 				E4D567191ADECE2700F1EFE7 /* ReadingList */,
 				E4D567281ADECE2800F1EFE7 /* ReadingListTests */,
 				E4E0BB141AFBC9E4008D6260 /* Shared */,
@@ -4048,7 +4071,7 @@
 					};
 					2FA436041ABB83B4008031D1 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 						TestTargetID = F84B21BD1A090F8100AAB793;
 					};
@@ -4078,7 +4101,7 @@
 					};
 					3BFE4B061D342FB800DDF53F = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = 9G8J6YA743;
+						DevelopmentTeam = 43AQ936H96;
 						LastSwiftMigration = 0820;
 						TestTargetID = F84B21BD1A090F8100AAB793;
 					};
@@ -4114,7 +4137,7 @@
 					};
 					E4D567211ADECE2700F1EFE7 = {
 						CreatedOnToolsVersion = 6.3;
-						DevelopmentTeam = 9G8J6YA743;
+						DevelopmentTeam = 43AQ936H96;
 						LastSwiftMigration = 0820;
 						TestTargetID = F84B21BD1A090F8100AAB793;
 					};
@@ -4126,7 +4149,7 @@
 					};
 					E6F9650B1B2F1CF20034B023 = {
 						CreatedOnToolsVersion = 6.3.2;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 					};
 					F84B21BD1A090F8100AAB793 = {
@@ -4790,7 +4813,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				2FA4362B1ABB8436008031D1 /* FirefoxAccountConfiguration.swift in Sources */,
+				39F99FE41E3A6F1700F353B4 /* PushClient.swift in Sources */,
+				39F99FE51E3A6F1700F353B4 /* PushConfiguration.swift in Sources */,
 				D32A350E1D6530D80066DAE9 /* FxADevice.swift in Sources */,
+				39F99FE61E3A6F1700F353B4 /* PushRegistration.swift in Sources */,
 				2F1A3DE11ABE3C90002F1E15 /* FxALoginStateMachine.swift in Sources */,
 				D3DBE6E51D6516FE00033FFF /* FxADeviceRegistration.swift in Sources */,
 				2FA436291ABB8436008031D1 /* FirefoxAccount.swift in Sources */,
@@ -4807,6 +4833,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2FA4363E1ABB8448008031D1 /* FxAClient10Tests.swift in Sources */,
+				39F99FE21E3A6F0600F353B4 /* LivePushClientTests.swift in Sources */,
 				2FDBCF9B1AC0ADB500AFF7F0 /* SyncAuthStateTests.swift in Sources */,
 				2FA436421ABB8448008031D1 /* TokenServerClientTests.swift in Sources */,
 				2FFC4D381ABE3C420081D675 /* FxAStateTests.swift in Sources */,
@@ -5190,6 +5217,7 @@
 				A9072B801D07B34100459960 /* NoImageModeHelper.swift in Sources */,
 				E660BDD91BB06521009AC090 /* TabsButton.swift in Sources */,
 				2F44FCCB1A9E972E00FD20CC /* SearchEnginePicker.swift in Sources */,
+				39F99FEE1E3A71F800F353B4 /* FxALoginHelper.swift in Sources */,
 				E68E7ACB1CAC1D4500FDCA76 /* PagingPasscodeViewController.swift in Sources */,
 				D34DC8531A16C40C00D49B7B /* Profile.swift in Sources */,
 				392ED6B71D06E85E009D9B62 /* NewTabChoiceViewController.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -4167,6 +4167,9 @@
 							com.apple.Keychain = {
 								enabled = 1;
 							};
+							com.apple.Push = {
+								enabled = 1;
+							};
 						};
 					};
 					F84B21D21A090F8100AAB793 = {

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -178,7 +178,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         }
 
         let fxaLoginHelper = FxALoginHelper.createSharedInstance(application, profile: profile)
-        fxaLoginHelper.applicationDidLoadProfile()
+        let _ = fxaLoginHelper.applicationDidLoadProfile()
 
         log.debug("Done with setting up the application.")
         return true
@@ -651,7 +651,7 @@ extension AppDelegate {
 }
 
 extension AppDelegate {
-    func application(application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: NSData) {
+    func application(application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         let apnsToken = deviceToken.hexEncodedString
         FxALoginHelper.sharedInstance?.apnsRegisterDidSucceed(apnsToken: apnsToken)
     }
@@ -663,7 +663,7 @@ extension AppDelegate {
 
     func application(application: UIApplication, didReceiveRemoteNotification userInfo: [NSObject : AnyObject], fetchCompletionHandler completionHandler: (UIBackgroundFetchResult) -> Void) {
         print("APNS NOTIFICATION \(userInfo)")
-        completionHandler(.NoData)
+        completionHandler(.noData)
     }
 
     func application(application: UIApplication, didReceiveRemoteNotification userInfo: [NSObject : AnyObject]) {

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -660,6 +660,15 @@ extension AppDelegate {
         print("failed to register. \(error.description)")
         FxALoginHelper.sharedInstance?.apnsRegisterDidFail()
     }
+
+    func application(application: UIApplication, didReceiveRemoteNotification userInfo: [NSObject : AnyObject], fetchCompletionHandler completionHandler: (UIBackgroundFetchResult) -> Void) {
+        print("APNS NOTIFICATION \(userInfo)")
+        completionHandler(.NoData)
+    }
+
+    func application(application: UIApplication, didReceiveRemoteNotification userInfo: [NSObject : AnyObject]) {
+        print("APNS NOTIFICATION \(userInfo)")
+    }
 }
 
 struct FxALaunchParams {

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -177,6 +177,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             sendCorePing()
         }
 
+        let fxaLoginHelper = FxALoginHelper.createSharedInstance(application, profile: profile)
+        fxaLoginHelper.applicationDidLoadProfile()
+
         log.debug("Done with setting up the application.")
         return true
     }

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -641,6 +641,24 @@ extension AppDelegate: MFMailComposeViewControllerDelegate {
     }
 }
 
+extension AppDelegate {
+    func application(application: UIApplication, didRegisterUserNotificationSettings notificationSettings: UIUserNotificationSettings) {
+        FxALoginHelper.sharedInstance?.userDidRegister(notificationSettings: notificationSettings)
+    }
+}
+
+extension AppDelegate {
+    func application(application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: NSData) {
+        let apnsToken = deviceToken.hexEncodedString
+        FxALoginHelper.sharedInstance?.apnsRegisterDidSucceed(apnsToken: apnsToken)
+    }
+
+    func application(application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: NSError) {
+        print("failed to register. \(error.description)")
+        FxALoginHelper.sharedInstance?.apnsRegisterDidFail()
+    }
+}
+
 struct FxALaunchParams {
     var view: String?
     var email: String?

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -177,8 +177,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             sendCorePing()
         }
 
-        let fxaLoginHelper = FxALoginHelper.createSharedInstance(application, profile: profile)
-        let _ = fxaLoginHelper.applicationDidLoadProfile()
+        let fxaLoginHelper = FxALoginHelper.sharedInstance
+        fxaLoginHelper.application(application, didLoadProfile: profile)
 
         log.debug("Done with setting up the application.")
         return true
@@ -646,19 +646,19 @@ extension AppDelegate: MFMailComposeViewControllerDelegate {
 
 extension AppDelegate {
     func application(application: UIApplication, didRegisterUserNotificationSettings notificationSettings: UIUserNotificationSettings) {
-        FxALoginHelper.sharedInstance?.userDidRegister(notificationSettings: notificationSettings)
+        FxALoginHelper.sharedInstance.application(application, didRegisterUserNotificationSettings: notificationSettings)
     }
 }
 
 extension AppDelegate {
     func application(application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         let apnsToken = deviceToken.hexEncodedString
-        FxALoginHelper.sharedInstance?.apnsRegisterDidSucceed(apnsToken: apnsToken)
+        FxALoginHelper.sharedInstance.apnsRegisterDidSucceed(apnsToken: apnsToken)
     }
 
     func application(application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: NSError) {
         print("failed to register. \(error.description)")
-        FxALoginHelper.sharedInstance?.apnsRegisterDidFail()
+        FxALoginHelper.sharedInstance.apnsRegisterDidFail()
     }
 
     func application(application: UIApplication, didReceiveRemoteNotification userInfo: [NSObject : AnyObject], fetchCompletionHandler completionHandler: (UIBackgroundFetchResult) -> Void) {

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -662,12 +662,12 @@ extension AppDelegate {
     }
 
     func application(application: UIApplication, didReceiveRemoteNotification userInfo: [NSObject : AnyObject], fetchCompletionHandler completionHandler: (UIBackgroundFetchResult) -> Void) {
-        print("APNS NOTIFICATION \(userInfo)")
+        log.info("APNS NOTIFICATION \(userInfo)")
         completionHandler(.noData)
     }
 
     func application(application: UIApplication, didReceiveRemoteNotification userInfo: [NSObject : AnyObject]) {
-        print("APNS NOTIFICATION \(userInfo)")
+        log.info("APNS NOTIFICATION \(userInfo)")
     }
 }
 

--- a/Client/Entitlements/Client.entitlements
+++ b/Client/Entitlements/Client.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.$(MOZ_BUNDLE_ID)</string>

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2941,7 +2941,7 @@ extension BrowserViewController: IntroViewControllerDelegate {
 }
 
 extension BrowserViewController: FxAContentViewControllerDelegate {
-    func contentViewControllerDidSignIn(_ viewController: FxAContentViewController, data: JSON) {
+    func contentViewControllerDidSignIn(_ viewController: FxAContentViewController) {
         self.dismiss(animated: true, completion: nil)
     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2941,7 +2941,7 @@ extension BrowserViewController: IntroViewControllerDelegate {
 }
 
 extension BrowserViewController: FxAContentViewControllerDelegate {
-    func contentViewControllerDidSignIn(_ viewController: FxAContentViewController) {
+    func contentViewControllerDidSignIn(_ viewController: FxAContentViewController, withFlags: FxALoginFlags) {
         self.dismiss(animated: true, completion: nil)
     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2941,8 +2941,10 @@ extension BrowserViewController: IntroViewControllerDelegate {
 }
 
 extension BrowserViewController: FxAContentViewControllerDelegate {
-    func contentViewControllerDidSignIn(_ viewController: FxAContentViewController, withFlags: FxALoginFlags) {
-        self.dismiss(animated: true, completion: nil)
+    func contentViewControllerDidSignIn(_ viewController: FxAContentViewController, withFlags flags: FxALoginFlags) {
+        if flags.verified {
+            self.dismiss(animated: true, completion: nil)
+        }
     }
 
     func contentViewControllerDidCancel(_ viewController: FxAContentViewController) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2915,7 +2915,7 @@ extension BrowserViewController: IntroViewControllerDelegate {
             settingsTableViewController.tabManager = tabManager
             vcToPresent = settingsTableViewController
         } else {
-            let signInVC = FxAContentViewController()
+            let signInVC = FxAContentViewController(profile: profile)
             signInVC.delegate = self
             signInVC.url = profile.accountConfiguration.signInURL
             signInVC.fxaOptions = fxaOptions
@@ -2942,23 +2942,7 @@ extension BrowserViewController: IntroViewControllerDelegate {
 
 extension BrowserViewController: FxAContentViewControllerDelegate {
     func contentViewControllerDidSignIn(_ viewController: FxAContentViewController, data: JSON) {
-        if data["keyFetchToken"].string == nil || data["unwrapBKey"].string == nil {
-            // The /settings endpoint sends a partial "login"; ignore it entirely.
-            log.debug("Ignoring didSignIn with keyFetchToken or unwrapBKey missing.")
-            return
-        }
-
-        // TODO: Error handling.
-        let account = FirefoxAccount.from(profile.accountConfiguration, andJSON: data)!
-        profile.setAccount(account)
-        if let account = self.profile.getAccount() {
-            account.advance()
-        }
-
-        // Dismiss the FxA content view if the account is verified.
-        if let verified = data["verified"].bool, verified {
-            self.dismiss(animated: true, completion: nil)
-        }
+        self.dismiss(animated: true, completion: nil)
     }
 
     func contentViewControllerDidCancel(_ viewController: FxAContentViewController) {

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -38,7 +38,7 @@ class ConnectSetting: WithoutAccountSetting {
     override var accessibilityIdentifier: String? { return "SignInToFirefox" }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        let viewController = FxAContentViewController()
+        let viewController = FxAContentViewController(profile: profile)
         viewController.delegate = self
         viewController.url = settings.profile.accountConfiguration.signInURL
         navigationController?.pushViewController(viewController, animated: true)
@@ -277,7 +277,7 @@ class AccountStatusSetting: WithAccountSetting {
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        let viewController = FxAContentViewController()
+        let viewController = FxAContentViewController(profile: profile)
         viewController.delegate = self
 
         if let account = profile.getAccount() {

--- a/Client/Frontend/Settings/FxAContentViewController.swift
+++ b/Client/Frontend/Settings/FxAContentViewController.swift
@@ -113,8 +113,8 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
         injectData("message", content: ["status": "login"])
 
         let app = UIApplication.shared
-        let helper = FxALoginHelper.createSharedInstance(application: app, profile: profile)
-        helper.userDidLogin(data).uponQueue(dispatch_get_main_queue()) { res in
+        let helper = FxALoginHelper.createSharedInstance(app, profile: profile)
+        helper.userDidLogin(data).uponQueue(DispatchQueue.main) { res in
             if res.isSuccess {
                 self.delegate?.contentViewControllerDidSignIn(self, data: data)
             } else {

--- a/Client/Frontend/Settings/FxAContentViewController.swift
+++ b/Client/Frontend/Settings/FxAContentViewController.swift
@@ -113,7 +113,7 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
         injectData("message", content: ["status": "login"])
 
         let app = UIApplication.shared
-        let helper = FxALoginHelper.createSharedInstance(app, profile: profile)
+        let helper = FxALoginHelper.createSharedInstance(application: app, profile: profile)
         helper.userDidLogin(data).uponQueue(dispatch_get_main_queue()) { res in
             if res.isSuccess {
                 self.delegate?.contentViewControllerDidSignIn(self, data: data)

--- a/Client/Frontend/Settings/FxAContentViewController.swift
+++ b/Client/Frontend/Settings/FxAContentViewController.swift
@@ -10,7 +10,7 @@ import WebKit
 import SwiftyJSON
 
 protocol FxAContentViewControllerDelegate: class {
-    func contentViewControllerDidSignIn(_ viewController: FxAContentViewController)
+    func contentViewControllerDidSignIn(_ viewController: FxAContentViewController, withFlags: FxALoginFlags)
     func contentViewControllerDidCancel(_ viewController: FxAContentViewController)
 }
 
@@ -196,9 +196,9 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
 }
 
 extension FxAContentViewController: FxAPushLoginDelegate {
-    func accountLoginDidSucceed(withPushRegistration: Bool) {
+    func accountLoginDidSucceed(withFlags flags: FxALoginFlags) {
         DispatchQueue.main.async {
-            self.delegate?.contentViewControllerDidSignIn(self)
+            self.delegate?.contentViewControllerDidSignIn(self, withFlags: flags)
         }
     }
 

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -357,16 +357,6 @@ class AccountSetting: Setting, FxAContentViewControllerDelegate {
     override var accessoryType: UITableViewCellAccessoryType { return .none }
 
     func contentViewControllerDidSignIn(_ viewController: FxAContentViewController, data: JSON) {
-        if data["keyFetchToken"].string == nil || data["unwrapBKey"].string == nil {
-            // The /settings endpoint sends a partial "login"; ignore it entirely.
-            NSLog("Ignoring didSignIn with keyFetchToken or unwrapBKey missing.")
-            return
-        }
-
-        // TODO: Error handling.
-        let account = FirefoxAccount.from(profile.accountConfiguration, andJSON: data)!
-        profile.setAccount(account)
-
         // Reload the data to reflect the new Account immediately.
         settings.tableView.reloadData()
         // And start advancing the Account state in the background as well.

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -356,7 +356,7 @@ class AccountSetting: Setting, FxAContentViewControllerDelegate {
 
     override var accessoryType: UITableViewCellAccessoryType { return .none }
 
-    func contentViewControllerDidSignIn(_ viewController: FxAContentViewController, data: JSON) {
+    func contentViewControllerDidSignIn(_ viewController: FxAContentViewController) {
         // Reload the data to reflect the new Account immediately.
         settings.tableView.reloadData()
         // And start advancing the Account state in the background as well.

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -356,14 +356,14 @@ class AccountSetting: Setting, FxAContentViewControllerDelegate {
 
     override var accessoryType: UITableViewCellAccessoryType { return .none }
 
-    func contentViewControllerDidSignIn(_ viewController: FxAContentViewController) {
+    func contentViewControllerDidSignIn(_ viewController: FxAContentViewController, withFlags flags: FxALoginFlags) {
         // Reload the data to reflect the new Account immediately.
         settings.tableView.reloadData()
         // And start advancing the Account state in the background as well.
         settings.SELrefresh()
 
         // Dismiss the FxA content view if the account is verified.
-        if let verified = data["verified"].bool, verified {
+        if flags.verified {
             let _ = settings.navigationController?.popToRootViewController(animated: true)
         }
     }

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -268,7 +268,7 @@ extension Strings {
 
 // Receiving tabs sent from other devices.
 extension Strings {
-    public static let SentTabViewActionTitle = NSLocalizedString("SentTab.ViewPage", value: "View",  comment: "Button title displayed in a notification when a sent tab has been received. Tapping on the button will open the URL.")
+    public static let SentTabViewActionTitle = NSLocalizedString("SentTab.ViewPage", value: "View", comment: "Button title displayed in a notification when a sent tab has been received. Tapping on the button will open the URL.")
     public static let SentTabBookmarkActionTitle = NSLocalizedString("SentTab.BookmarkPage", value: "Bookmark", comment: "Button title displayed in a notification when a sent tab has been received. Tapping on the button will add the URL as a bookmark.")
     public static let SentTabAddToReadingListActionTitle = NSLocalizedString("SentTab.AddToReadingList", value: "Add to Reading List", comment: "Button title displayed in a notification when a sent tab has been received. Tapping on the button will add the page to the reading list.")
 }

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -266,6 +266,12 @@ extension Strings {
     public static let ContextMenuButtonToastNewPrivateTabOpenedButtonText = NSLocalizedString("ContextMenu.ButtonToast.NewPrivateTabOpened.ButtonText", value: "Switch", comment: "The button text in the Button Toast for switching to a fresh New Private Tab.")
 }
 
+extension Strings {
+    public static let SentTabViewActionTitle = NSLocalizedString("View", comment: "View a URL - https://bugzilla.mozilla.org/attachment.cgi?id=8624438, https://bug1157303.bugzilla.mozilla.org/attachment.cgi?id=8624440")
+    public static let SentTabBookmarkActionTitle = NSLocalizedString("Bookmark", comment: "Bookmark a URL - https://bugzilla.mozilla.org/attachment.cgi?id=8624438, https://bug1157303.bugzilla.mozilla.org/attachment.cgi?id=8624440")
+    public static let SentTabAddToReadingListActionTitle = NSLocalizedString("Add to Reading List", comment: "Add URL to the reading list - https://bugzilla.mozilla.org/attachment.cgi?id=8624438, https://bug1157303.bugzilla.mozilla.org/attachment.cgi?id=8624440")
+}
+
 // Reader Mode.
 extension Strings {
     public static let ReaderModeAvailableVoiceOverAnnouncement = NSLocalizedString("ReaderMode.Available.VoiceOverAnnouncement", value: "Reader Mode available", comment: "Accessibility message e.g. spoken by VoiceOver when Reader Mode becomes available.")

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -266,10 +266,11 @@ extension Strings {
     public static let ContextMenuButtonToastNewPrivateTabOpenedButtonText = NSLocalizedString("ContextMenu.ButtonToast.NewPrivateTabOpened.ButtonText", value: "Switch", comment: "The button text in the Button Toast for switching to a fresh New Private Tab.")
 }
 
+// Receiving tabs sent from other devices.
 extension Strings {
-    public static let SentTabViewActionTitle = NSLocalizedString("View", comment: "View a URL - https://bugzilla.mozilla.org/attachment.cgi?id=8624438, https://bug1157303.bugzilla.mozilla.org/attachment.cgi?id=8624440")
-    public static let SentTabBookmarkActionTitle = NSLocalizedString("Bookmark", comment: "Bookmark a URL - https://bugzilla.mozilla.org/attachment.cgi?id=8624438, https://bug1157303.bugzilla.mozilla.org/attachment.cgi?id=8624440")
-    public static let SentTabAddToReadingListActionTitle = NSLocalizedString("Add to Reading List", comment: "Add URL to the reading list - https://bugzilla.mozilla.org/attachment.cgi?id=8624438, https://bug1157303.bugzilla.mozilla.org/attachment.cgi?id=8624440")
+    public static let SentTabViewActionTitle = NSLocalizedString("SentTab.ViewPage", value: "View",  comment: "Button title displayed in a notification when a sent tab has been received. Tapping on the button will open the URL.")
+    public static let SentTabBookmarkActionTitle = NSLocalizedString("SentTab.BookmarkPage", value: "Bookmark", comment: "Button title displayed in a notification when a sent tab has been received. Tapping on the button will add the URL as a bookmark.")
+    public static let SentTabAddToReadingListActionTitle = NSLocalizedString("SentTab.AddToReadingList", value: "Add to Reading List", comment: "Button title displayed in a notification when a sent tab has been received. Tapping on the button will add the page to the reading list.")
 }
 
 // Reader Mode.

--- a/Client/Helpers/FxALoginHelper.swift
+++ b/Client/Helpers/FxALoginHelper.swift
@@ -11,15 +11,24 @@ import Shared
 /// asking the user for notification permissions, registering for 
 /// remote push notifications (APNS), registering for WebPush notifcations
 /// then creating an account and storing it in the profile.
-public class FxALoginHelper {
+class FxALoginHelper {
     private let deferred = Success()
 
     private let pushClient: PushClient
 
     private weak var application: UIApplication?
-    private weak var profile: BrowserProfile?
+    private weak var profile: Profile?
 
-    public init(application: UIApplication, profile: BrowserProfile) {
+    private var data: JSON!
+
+    static private(set) var sharedInstance: FxALoginHelper?
+
+    class func createSharedInstance(application: UIApplication?, profile: Profile?) -> FxALoginHelper {
+        sharedInstance = FxALoginHelper(application: application, profile: profile)
+        return sharedInstance!
+    }
+
+    init(application: UIApplication?, profile: Profile?) {
         let configuration = StagePushConfiguration()
         let client = PushClient(endpointURL: configuration.endpointURL)
 
@@ -28,19 +37,61 @@ public class FxALoginHelper {
         self.profile = profile
     }
 
-    public func userDidLogin() -> Success {
+    func userDidLogin(data: JSON) -> Success {
+        if data["keyFetchToken"].asString == nil || data["unwrapBKey"].asString == nil {
+            // The /settings endpoint sends a partial "login"; ignore it entirely.
+            NSLog("Ignoring didSignIn with keyFetchToken or unwrapBKey missing.")
+            self.loginDidFail()
+            return deferred
+        }
+
+        self.data = data
+
+        requestUserNotifications()
         return deferred
     }
 
-    public func userDidAcceptUserNotifications() {
-        
+    private func requestUserNotifications() {
+        let viewAction = UIMutableUserNotificationAction()
+        viewAction.identifier = SentTabAction.View.rawValue
+        viewAction.title = NSLocalizedString("View", comment: "View a URL - https://bugzilla.mozilla.org/attachment.cgi?id=8624438, https://bug1157303.bugzilla.mozilla.org/attachment.cgi?id=8624440")
+        viewAction.activationMode = UIUserNotificationActivationMode.Foreground
+        viewAction.destructive = false
+        viewAction.authenticationRequired = false
+
+        let bookmarkAction = UIMutableUserNotificationAction()
+        bookmarkAction.identifier = SentTabAction.Bookmark.rawValue
+        bookmarkAction.title = NSLocalizedString("Bookmark", comment: "Bookmark a URL - https://bugzilla.mozilla.org/attachment.cgi?id=8624438, https://bug1157303.bugzilla.mozilla.org/attachment.cgi?id=8624440")
+        bookmarkAction.activationMode = UIUserNotificationActivationMode.Foreground
+        bookmarkAction.destructive = false
+        bookmarkAction.authenticationRequired = false
+
+        let readingListAction = UIMutableUserNotificationAction()
+        readingListAction.identifier = SentTabAction.ReadingList.rawValue
+        readingListAction.title = NSLocalizedString("Add to Reading List", comment: "Add URL to the reading list - https://bugzilla.mozilla.org/attachment.cgi?id=8624438, https://bug1157303.bugzilla.mozilla.org/attachment.cgi?id=8624440")
+        readingListAction.activationMode = UIUserNotificationActivationMode.Foreground
+        readingListAction.destructive = false
+        readingListAction.authenticationRequired = false
+
+        let sentTabsCategory = UIMutableUserNotificationCategory()
+        sentTabsCategory.identifier = TabSendCategory
+        sentTabsCategory.setActions([readingListAction, bookmarkAction, viewAction], forContext: UIUserNotificationActionContext.Default)
+
+        sentTabsCategory.setActions([bookmarkAction, viewAction], forContext: UIUserNotificationActionContext.Minimal)
+
+        application?.registerUserNotificationSettings(UIUserNotificationSettings(forTypes: UIUserNotificationType.Alert, categories: [sentTabsCategory]))
     }
 
-    public func userDidRejectUserNotifications() {
+    func userDidRegister(notificationSettings notificationSettings: UIUserNotificationSettings) {
+        guard notificationSettings.types != .None else {
+            return readyForSyncing()
+        }
 
+        application?.registerForRemoteNotifications()
     }
 
-    public func apnsRegisterDidSucceed(apnsToken apnsToken: String) {
+
+    func apnsRegisterDidSucceed(apnsToken apnsToken: String) {
         pushClient.register(apnsToken).upon { res in
             if let pushRegistration = res.successValue {
                 return self.pushRegistrationDidSucceed(apnsToken: apnsToken, pushRegistration: pushRegistration)
@@ -49,17 +100,35 @@ public class FxALoginHelper {
         }
     }
 
-    public func apnsRegisterDidFail() {
+    func apnsRegisterDidFail() {
+        self.readyForSyncing()
+    }
+
+    func pushRegistrationDidSucceed(apnsToken apnsToken: String, pushRegistration: PushRegistration) {
 
     }
 
-    public func pushRegistrationDidSucceed(apnsToken apnsToken: String, pushRegistration: PushRegistration) {
+    func pushRegistrationDidFail() {
 
     }
 
-    public func pushRegistrationDidFail() {
-
+    func readyForSyncing() {
+        if let profile = self.profile, let data = data {
+            // TODO: Error handling.
+            let account = FirefoxAccount.fromConfigurationAndJSON(profile.accountConfiguration, data: data)!
+            
+            profile.setAccount(account)
+            // account.advance is idempotent.
+            if let account = profile.getAccount() {
+                account.advance()
+            }
+        }
+        FxALoginHelper.sharedInstance = nil
+        deferred.fill(Maybe(success: ()))
     }
 
-
+    func loginDidFail() {
+        FxALoginHelper.sharedInstance = nil
+        deferred.fill(Maybe(failure: FxADeviceRegistratorError.InvalidSession))
+    }
 }

--- a/Client/Helpers/FxALoginHelper.swift
+++ b/Client/Helpers/FxALoginHelper.swift
@@ -103,32 +103,32 @@ class FxALoginHelper {
     private func requestUserNotifications() {
         let viewAction = UIMutableUserNotificationAction()
         viewAction.identifier = SentTabAction.view.rawValue
-        viewAction.activationMode = UIUserNotificationActivationMode.foreground
         viewAction.title = Strings.SentTabViewActionTitle
+        viewAction.activationMode = .foreground
         viewAction.isDestructive = false
         viewAction.isAuthenticationRequired = false
 
         let bookmarkAction = UIMutableUserNotificationAction()
         bookmarkAction.identifier = SentTabAction.bookmark.rawValue
-        bookmarkAction.activationMode = UIUserNotificationActivationMode.foreground
         bookmarkAction.title = Strings.SentTabBookmarkActionTitle
+        bookmarkAction.activationMode = .foreground
         bookmarkAction.isDestructive = false
         bookmarkAction.isAuthenticationRequired = false
 
         let readingListAction = UIMutableUserNotificationAction()
         readingListAction.identifier = SentTabAction.readingList.rawValue
-        readingListAction.activationMode = UIUserNotificationActivationMode.foreground
         readingListAction.title = Strings.SentTabAddToReadingListActionTitle
+        readingListAction.activationMode = .foreground
         readingListAction.isDestructive = false
         readingListAction.isAuthenticationRequired = false
 
         let sentTabsCategory = UIMutableUserNotificationCategory()
         sentTabsCategory.identifier = TabSendCategory
-        sentTabsCategory.setActions([readingListAction, bookmarkAction, viewAction], for: UIUserNotificationActionContext.default)
+        sentTabsCategory.setActions([readingListAction, bookmarkAction, viewAction], for: .default)
 
-        sentTabsCategory.setActions([bookmarkAction, viewAction], for: UIUserNotificationActionContext.minimal)
+        sentTabsCategory.setActions([bookmarkAction, viewAction], for: .minimal)
 
-        let settings = UIUserNotificationSettings(types: UIUserNotificationType.alert, categories: [sentTabsCategory])
+        let settings = UIUserNotificationSettings(types: .alert, categories: [sentTabsCategory])
 
         application?.registerUserNotificationSettings(settings)
     }

--- a/Client/Helpers/FxALoginHelper.swift
+++ b/Client/Helpers/FxALoginHelper.swift
@@ -103,22 +103,22 @@ class FxALoginHelper {
     private func requestUserNotifications() {
         let viewAction = UIMutableUserNotificationAction()
         viewAction.identifier = SentTabAction.view.rawValue
-        viewAction.title = NSLocalizedString("View", comment: "View a URL - https://bugzilla.mozilla.org/attachment.cgi?id=8624438, https://bug1157303.bugzilla.mozilla.org/attachment.cgi?id=8624440")
         viewAction.activationMode = UIUserNotificationActivationMode.foreground
+        viewAction.title = Strings.SentTabViewActionTitle
         viewAction.isDestructive = false
         viewAction.isAuthenticationRequired = false
 
         let bookmarkAction = UIMutableUserNotificationAction()
         bookmarkAction.identifier = SentTabAction.bookmark.rawValue
-        bookmarkAction.title = NSLocalizedString("Bookmark", comment: "Bookmark a URL - https://bugzilla.mozilla.org/attachment.cgi?id=8624438, https://bug1157303.bugzilla.mozilla.org/attachment.cgi?id=8624440")
         bookmarkAction.activationMode = UIUserNotificationActivationMode.foreground
+        bookmarkAction.title = Strings.SentTabBookmarkActionTitle
         bookmarkAction.isDestructive = false
         bookmarkAction.isAuthenticationRequired = false
 
         let readingListAction = UIMutableUserNotificationAction()
         readingListAction.identifier = SentTabAction.readingList.rawValue
-        readingListAction.title = NSLocalizedString("Add to Reading List", comment: "Add URL to the reading list - https://bugzilla.mozilla.org/attachment.cgi?id=8624438, https://bug1157303.bugzilla.mozilla.org/attachment.cgi?id=8624440")
         readingListAction.activationMode = UIUserNotificationActivationMode.foreground
+        readingListAction.title = Strings.SentTabAddToReadingListActionTitle
         readingListAction.isDestructive = false
         readingListAction.isAuthenticationRequired = false
 

--- a/Client/Helpers/FxALoginHelper.swift
+++ b/Client/Helpers/FxALoginHelper.swift
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Account
+import Deferred
+import Foundation
+import Shared
+
+/// This class manages the from successful login for FxAccounts to 
+/// asking the user for notification permissions, registering for 
+/// remote push notifications (APNS), registering for WebPush notifcations
+/// then creating an account and storing it in the profile.
+public class FxALoginHelper {
+    private let deferred = Success()
+
+    private let pushClient: PushClient
+
+    private weak var application: UIApplication?
+    private weak var profile: BrowserProfile?
+
+    public init(application: UIApplication, profile: BrowserProfile) {
+        let configuration = StagePushConfiguration()
+        let client = PushClient(endpointURL: configuration.endpointURL)
+
+        self.application = application
+        self.pushClient = client
+        self.profile = profile
+    }
+
+    public func userDidLogin() -> Success {
+        return deferred
+    }
+
+    public func userDidAcceptUserNotifications() {
+        
+    }
+
+    public func userDidRejectUserNotifications() {
+
+    }
+
+    public func apnsRegisterDidSucceed(apnsToken apnsToken: String) {
+        pushClient.register(apnsToken).upon { res in
+            if let pushRegistration = res.successValue {
+                return self.pushRegistrationDidSucceed(apnsToken: apnsToken, pushRegistration: pushRegistration)
+            }
+            self.apnsRegisterDidFail()
+        }
+    }
+
+    public func apnsRegisterDidFail() {
+
+    }
+
+    public func pushRegistrationDidSucceed(apnsToken apnsToken: String, pushRegistration: PushRegistration) {
+
+    }
+
+    public func pushRegistrationDidFail() {
+
+    }
+
+
+}

--- a/Client/Helpers/FxALoginHelper.swift
+++ b/Client/Helpers/FxALoginHelper.swift
@@ -32,7 +32,7 @@ class FxALoginHelper {
     }
 
     init(application: UIApplication?, profile: Profile?) {
-        let configuration = StagePushConfiguration()
+        let configuration = DeveloperPushConfiguration()
         let client = PushClient(endpointURL: configuration.endpointURL)
 
         self.application = application

--- a/Client/Helpers/FxALoginHelper.swift
+++ b/Client/Helpers/FxALoginHelper.swift
@@ -108,7 +108,6 @@ class FxALoginHelper {
         requestUserNotifications(application)
     }
 
-
     fileprivate func requestUserNotifications(_ application: UIApplication) {
         let viewAction = UIMutableUserNotificationAction()
         viewAction.identifier = SentTabAction.view.rawValue

--- a/Client/Helpers/FxALoginHelper.swift
+++ b/Client/Helpers/FxALoginHelper.swift
@@ -28,8 +28,8 @@ struct FxALoginFlags {
 
 /// This class manages the from successful login for FxAccounts to 
 /// asking the user for notification permissions, registering for 
-/// remote push notifications (APNS), registering for WebPush notifcations
-/// then creating an account and storing it in the profile.
+/// remote push notifications (APNS), then creating an account and 
+/// storing it in the profile.
 class FxALoginHelper {
     static var sharedInstance: FxALoginHelper = {
         return FxALoginHelper()

--- a/Client/Helpers/FxALoginHelper.swift
+++ b/Client/Helpers/FxALoginHelper.swift
@@ -161,7 +161,11 @@ class FxALoginHelper {
     }
 
     func apnsRegisterDidSucceed(apnsToken: String) {
-        let configuration = DeveloperPushConfiguration()
+        guard let configuration = self.profile?.accountConfiguration.pushConfiguration else {
+            log.error("Push server endpoint could not be found")
+            return pushRegistrationDidFail()
+        }
+
         let client = PushClient(endpointURL: configuration.endpointURL)
         client.register(apnsToken).upon { res in
             guard let pushRegistration = res.successValue else {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -556,9 +556,6 @@ open class BrowserProfile: Profile {
         self.account = account
 
         flushAccount()
-
-        // register for notifications for the account
-        registerForNotifications()
         
         // tell any observers that our account has changed
         let userInfo = [NotificationUserInfoKeyHasSyncableAccount: hasSyncableAccount()]
@@ -572,38 +569,6 @@ open class BrowserProfile: Profile {
             // Will this cause issues with people migrating?
             self.keychain.set(account.dictionary() as NSCoding, forKey: name + ".account")
         }
-    }
-
-    func registerForNotifications() {
-        let viewAction = UIMutableUserNotificationAction()
-        viewAction.identifier = SentTabAction.view.rawValue
-        viewAction.title = NSLocalizedString("View", comment: "View a URL - https://bugzilla.mozilla.org/attachment.cgi?id=8624438, https://bug1157303.bugzilla.mozilla.org/attachment.cgi?id=8624440")
-        viewAction.activationMode = UIUserNotificationActivationMode.foreground
-        viewAction.isDestructive = false
-        viewAction.isAuthenticationRequired = false
-
-        let bookmarkAction = UIMutableUserNotificationAction()
-        bookmarkAction.identifier = SentTabAction.bookmark.rawValue
-        bookmarkAction.title = NSLocalizedString("Bookmark", comment: "Bookmark a URL - https://bugzilla.mozilla.org/attachment.cgi?id=8624438, https://bug1157303.bugzilla.mozilla.org/attachment.cgi?id=8624440")
-        bookmarkAction.activationMode = UIUserNotificationActivationMode.foreground
-        bookmarkAction.isDestructive = false
-        bookmarkAction.isAuthenticationRequired = false
-
-        let readingListAction = UIMutableUserNotificationAction()
-        readingListAction.identifier = SentTabAction.readingList.rawValue
-        readingListAction.title = NSLocalizedString("Add to Reading List", comment: "Add URL to the reading list - https://bugzilla.mozilla.org/attachment.cgi?id=8624438, https://bug1157303.bugzilla.mozilla.org/attachment.cgi?id=8624440")
-        readingListAction.activationMode = UIUserNotificationActivationMode.foreground
-        readingListAction.isDestructive = false
-        readingListAction.isAuthenticationRequired = false
-
-        let sentTabsCategory = UIMutableUserNotificationCategory()
-        sentTabsCategory.identifier = TabSendCategory
-        sentTabsCategory.setActions([readingListAction, bookmarkAction, viewAction], for: UIUserNotificationActionContext.default)
-
-        sentTabsCategory.setActions([bookmarkAction, viewAction], for: UIUserNotificationActionContext.minimal)
-
-        let _ = UIUserNotificationSettings(types: UIUserNotificationType.alert, categories: [sentTabsCategory])
-        app?.registerForRemoteNotifications()
     }
 
     // Extends NSObject so we can use timers.

--- a/Push/PushClient.swift
+++ b/Push/PushClient.swift
@@ -1,0 +1,164 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Alamofire
+import Deferred
+import Shared
+
+//public struct PushRemoteError {
+//    static let MissingNecessaryCryptoKeys: Int32 = 101
+//    static let InvalidURLEndpoint: Int32         = 102
+//    static let ExpiredURLEndpoint: Int32         = 103
+//    static let DataPayloadTooLarge: Int32        = 104
+//    static let EndpointBecameUnavailable: Int32  = 105
+//    static let InvalidSubscription: Int32        = 106
+//    static let RouterTypeIsInvalid: Int32        = 108
+//    static let InvalidAuthentication: Int32      = 109
+//    static let InvalidCryptoKeysSpecified: Int32 = 110
+//    static let MissingRequiredHeader: Int32      = 111
+//    static let InvalidTTLHeaderValue: Int32      = 112
+//    static let UnknownError: Int32               = 999
+//}
+
+public let PushClientErrorDomain = "org.mozilla.push.error"
+private let PushClientUnknownError = NSError(domain: PushClientErrorDomain, code: 999,
+                                             userInfo: [NSLocalizedDescriptionKey: "Invalid server response"])
+private let log = Logger.browserLogger
+
+public struct PushRemoteError {
+    let code: Int
+    let errno: Int
+    let error: String
+    let message: String?
+
+    public static func fromJSON(json: JSON) -> PushRemoteError? {
+        guard let code = json["code"].asInt,
+              let errno = json["errno"].asInt,
+              let error = json["error"].asString else {
+            return nil
+        }
+
+        let message = json["message"].asString
+        return PushRemoteError(code: code, errno: errno, error: error, message: message)
+    }
+}
+
+public enum PushClientError: MaybeErrorType {
+    case Remote(PushRemoteError)
+    case Local(NSError)
+
+    public var description: String {
+        switch self {
+        case let .Remote(error):
+            let errorString = error.error
+            let messageString = error.message ?? ""
+            return "<FxAClientError.Remote \(error.code)/\(error.errno): \(errorString) (\(messageString))>"
+        case let .Local(error):
+            return "<FxAClientError.Local Error Domain=\(error.domain) Code=\(error.code) \"\(error.localizedDescription)\">"
+        }
+    }
+}
+
+public class PushClient {
+    let endpointURL: NSURL
+
+    lazy private var alamofire: Alamofire.Manager = {
+        // TODO: User Agent?
+        let ua = UserAgent.fxaUserAgent
+        let configuration = NSURLSessionConfiguration.ephemeralSessionConfiguration()
+        return Alamofire.Manager.managerWithUserAgent(ua, configuration: configuration)
+    }()
+
+    public init(endpointURL: NSURL) {
+        self.endpointURL = endpointURL
+    }
+
+}
+
+public extension PushClient {
+    public func register(apnsToken: String) -> Deferred<Maybe<PushRegistration>> {
+        //  POST /v1/{type}/{app_id}/registration
+        let registerURL = endpointURL.URLByAppendingPathComponent("registration")!
+
+        let mutableURLRequest = NSMutableURLRequest(URL: registerURL)
+        mutableURLRequest.HTTPMethod = Method.POST.rawValue
+
+        mutableURLRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let parameters = ["token": apnsToken]
+        mutableURLRequest.HTTPBody = JSON(parameters).toString().utf8EncodedData
+
+        return sendRequest(mutableURLRequest) >>== { json in
+            guard let response = PushRegistration.fromJSON(json) else {
+                return deferMaybe(PushClientError.Local(PushClientUnknownError))
+            }
+
+            return deferMaybe(response)
+        }
+    }
+
+    public func updateUAID(apnsToken: String, creds: PushRegistration) -> Deferred<Maybe<PushRegistration>> {
+        //  PUT /v1/{type}/{app_id}/registration/{uaid}
+        let registerURL = endpointURL.URLByAppendingPathComponent("registration/\(creds.uaid)")!
+        let mutableURLRequest = NSMutableURLRequest(URL: registerURL)
+
+        mutableURLRequest.HTTPMethod = Method.PUT.rawValue
+        mutableURLRequest.addValue("Bearer \(creds.secret)", forHTTPHeaderField: "Authorization")
+
+        mutableURLRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let parameters = ["token": apnsToken]
+        mutableURLRequest.HTTPBody = JSON(parameters).toString().utf8EncodedData
+
+        return sendRequest(mutableURLRequest) >>== { json in
+            guard let response = PushRegistration.fromJSON(json) else {
+                return deferMaybe(PushClientError.Local(PushClientUnknownError))
+            }
+            return deferMaybe(response)
+        }
+    }
+
+    public func unregister(creds: PushRegistration) -> Success {
+        //  DELETE /v1/{type}/{app_id}/registration/{uaid}
+        let unregisterURL = endpointURL.URLByAppendingPathComponent("registration/\(creds.uaid)")
+
+        let mutableURLRequest = NSMutableURLRequest(URL: unregisterURL!)
+        mutableURLRequest.HTTPMethod = Method.DELETE.rawValue
+        mutableURLRequest.addValue("Bearer \(creds.secret)", forHTTPHeaderField: "Authorization")
+
+        return sendRequest(mutableURLRequest) >>> succeed
+    }
+}
+
+/// Utilities
+extension PushClient {
+    private func sendRequest(request: NSURLRequest) -> Deferred<Maybe<JSON>> {
+        log.info("\(request.HTTPMethod!) \(request.URLString)")
+        let deferred = Deferred<Maybe<JSON>>()
+        alamofire.request(request)
+            .validate(contentType: ["application/json"])
+            .responseJSON { response in
+                // Don't cancel requests just because our client is deallocated.
+                withExtendedLifetime(self.alamofire) {
+                    let result = response.result
+                    if let error = result.error {
+                        return deferred.fill(Maybe(failure: PushClientError.Local(error)))
+                    }
+
+                    guard let data = response.data else {
+                        return deferred.fill(Maybe(failure: PushClientError.Local(PushClientUnknownError)))
+                    }
+
+                    let json = JSON(data: data)
+                    
+                    if let remoteError = PushRemoteError.fromJSON(json) {
+                        return deferred.fill(Maybe(failure: PushClientError.Remote(remoteError)))
+                    }
+
+                    deferred.fill(Maybe(success: json))
+                }
+        }
+
+        return deferred
+    }
+}

--- a/Push/PushClient.swift
+++ b/Push/PushClient.swift
@@ -98,7 +98,7 @@ public extension PushClient {
         }
     }
 
-    public func updateUAID(apnsToken: String, creds: PushRegistration) -> Deferred<Maybe<PushRegistration>> {
+    public func updateUAID(_ apnsToken: String, withRegistration creds: PushRegistration) -> Deferred<Maybe<PushRegistration>> {
         //  PUT /v1/{type}/{app_id}/registration/{uaid}
         let registerURL = endpointURL.appendingPathComponent("registration/\(creds.uaid)")!
         var mutableURLRequest = URLRequest(url: registerURL)
@@ -118,7 +118,7 @@ public extension PushClient {
         }
     }
 
-    public func unregister(creds: PushRegistration) -> Success {
+    public func unregister(_ creds: PushRegistration) -> Success {
         //  DELETE /v1/{type}/{app_id}/registration/{uaid}
         let unregisterURL = endpointURL.appendingPathComponent("registration/\(creds.uaid)")
 

--- a/Push/PushConfiguration.swift
+++ b/Push/PushConfiguration.swift
@@ -11,9 +11,9 @@ public enum PushConfigurationLabel: String {
 
     public func toConfiguration() -> PushConfiguration {
         switch self {
-        case Stage: return StagePushConfiguration()
-        case Production: return ProductionPushConfiguration()
-        case Developer: return DeveloperPushConfiguration()
+        case .Stage: return StagePushConfiguration()
+        case .Production: return ProductionPushConfiguration()
+        case .Developer: return DeveloperPushConfiguration()
         }
     }
 }

--- a/Push/PushConfiguration.swift
+++ b/Push/PushConfiguration.swift
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+public enum PushConfigurationLabel: String {
+    case Developer = "Developer"
+    case Stage = "Stage"
+    case Production = "Production"
+
+    public func toConfiguration() -> PushConfiguration {
+        switch self {
+        case Stage: return StagePushConfiguration()
+        case Production: return ProductionPushConfiguration()
+        case Developer: return DeveloperPushConfiguration()
+        }
+    }
+}
+
+public protocol PushConfiguration {
+    var label: PushConfigurationLabel { get }
+
+    /// The associated autopush server should speak the protocol documented at
+    /// http://autopush.readthedocs.io/en/latest/http.html#push-service-http-api
+    /// /v1/{type}/{app_id}
+    /// type == apns
+    /// app_id == the “platform” or “channel” of development (e.g. “firefox”, “beta”, “gecko”, etc.)
+    var endpointURL: NSURL { get }
+}
+
+public struct DeveloperPushConfiguration: PushConfiguration {
+    public init() {}
+    public let label = PushConfigurationLabel.Developer
+    public let endpointURL = NSURL(string: "https://updates-autopush.dev.mozaws.net/v1/apns/dev")!
+}
+
+public struct StagePushConfiguration: PushConfiguration {
+    public init() {}
+    public let label = PushConfigurationLabel.Stage
+    public let endpointURL = NSURL(string: "https://updates-autopush.dev.mozaws.net/v1/apns/stage")!
+}
+
+public struct ProductionPushConfiguration: PushConfiguration {
+    public init() {}
+    public let label = PushConfigurationLabel.Production
+    public let endpointURL = NSURL(string: "https://updates.push.services.mozilla.com/v1/apns/firefox")!
+}

--- a/Push/PushRegistration.swift
+++ b/Push/PushRegistration.swift
@@ -5,11 +5,36 @@
 import Foundation
 import Shared
 
-public struct PushRegistration {
+public class PushRegistration: NSObject, NSCoding {
     let endpoint: NSURL
     let uaid: String
     let secret: String
     let channelID: String
+
+    public init(uaid: String, secret: String, endpoint: NSURL, channelID: String) {
+        self.uaid = uaid
+        self.secret = secret
+        self.endpoint = endpoint
+        self.channelID = channelID
+    }
+
+    @objc public convenience required init?(coder aDecoder: NSCoder) {
+        guard let uaid = aDecoder.decodeObjectForKey("uaid") as? String,
+            let secret = aDecoder.decodeObjectForKey("secret") as? String,
+            let urlString = aDecoder.decodeObjectForKey("endpoint") as? String,
+            let endpoint = NSURL(string: urlString),
+            let channelID = aDecoder.decodeObjectForKey("channelID") as? String else {
+                fatalError("Cannot decode registration")
+        }
+        self.init(uaid: uaid, secret: secret, endpoint: endpoint, channelID: channelID)
+    }
+
+    @objc public func encodeWithCoder(aCoder: NSCoder) {
+        aCoder.encodeObject(uaid, forKey: "uaid")
+        aCoder.encodeObject(secret, forKey: "secret")
+        aCoder.encodeObject(endpoint.absoluteString, forKey: "endpoint")
+        aCoder.encodeObject(channelID, forKey: "channelID")
+    }
 
     // TODO ???
     //     protected final @NonNull Map<String, PushSubscription> subscriptions;
@@ -23,7 +48,7 @@ public struct PushRegistration {
             return nil
         }
 
-        return PushRegistration(endpoint: endpoint, uaid: uaid, secret: secret, channelID: channelID)
+        return PushRegistration(uaid: uaid, secret: secret, endpoint: endpoint, channelID: channelID)
     }
 
     func toJSON() -> JSON {

--- a/Push/PushRegistration.swift
+++ b/Push/PushRegistration.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Shared
+import SwiftyJSON
 
 public class PushRegistration: NSObject, NSCoding {
     let endpoint: NSURL
@@ -19,32 +20,32 @@ public class PushRegistration: NSObject, NSCoding {
     }
 
     @objc public convenience required init?(coder aDecoder: NSCoder) {
-        guard let uaid = aDecoder.decodeObjectForKey("uaid") as? String,
-            let secret = aDecoder.decodeObjectForKey("secret") as? String,
-            let urlString = aDecoder.decodeObjectForKey("endpoint") as? String,
+        guard let uaid = aDecoder.decodeObject(forKey: "uaid") as? String,
+            let secret = aDecoder.decodeObject(forKey: "secret") as? String,
+            let urlString = aDecoder.decodeObject(forKey: "endpoint") as? String,
             let endpoint = NSURL(string: urlString),
-            let channelID = aDecoder.decodeObjectForKey("channelID") as? String else {
+            let channelID = aDecoder.decodeObject(forKey: "channelID") as? String else {
                 fatalError("Cannot decode registration")
         }
         self.init(uaid: uaid, secret: secret, endpoint: endpoint, channelID: channelID)
     }
 
-    @objc public func encodeWithCoder(aCoder: NSCoder) {
-        aCoder.encodeObject(uaid, forKey: "uaid")
-        aCoder.encodeObject(secret, forKey: "secret")
-        aCoder.encodeObject(endpoint.absoluteString, forKey: "endpoint")
-        aCoder.encodeObject(channelID, forKey: "channelID")
+    @objc public func encode(with aCoder: NSCoder) {
+        aCoder.encode(uaid, forKey: "uaid")
+        aCoder.encode(secret, forKey: "secret")
+        aCoder.encode(endpoint.absoluteString, forKey: "endpoint")
+        aCoder.encode(channelID, forKey: "channelID")
     }
 
     // TODO ???
     //     protected final @NonNull Map<String, PushSubscription> subscriptions;
 
-    public static func fromJSON(json: JSON) -> PushRegistration? {
-        guard let endpointString = json["endpoint"].asString,
+    public static func from(json: JSON) -> PushRegistration? {
+        guard let endpointString = json["endpoint"].rawString(),
               let endpoint = NSURL(string: endpointString),
-              let secret = json["secret"].asString,
-              let uaid = json["uaid"].asString,
-              let channelID = json["channelID"].asString else {
+              let secret = json["secret"].rawString(),
+              let uaid = json["uaid"].rawString(),
+              let channelID = json["channelID"].rawString() else {
             return nil
         }
 

--- a/Push/PushRegistration.swift
+++ b/Push/PushRegistration.swift
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+
+public struct PushRegistration {
+    let endpoint: NSURL
+    let uaid: String
+    let secret: String
+    let channelID: String
+
+    // TODO ???
+    //     protected final @NonNull Map<String, PushSubscription> subscriptions;
+
+    public static func fromJSON(json: JSON) -> PushRegistration? {
+        guard let endpointString = json["endpoint"].asString,
+              let endpoint = NSURL(string: endpointString),
+              let secret = json["secret"].asString,
+              let uaid = json["uaid"].asString,
+              let channelID = json["channelID"].asString else {
+            return nil
+        }
+
+        return PushRegistration(endpoint: endpoint, uaid: uaid, secret: secret, channelID: channelID)
+    }
+
+    func toJSON() -> JSON {
+        var parameters = [String: String]()
+        parameters["endpoint"] = endpoint.absoluteString!
+        parameters["uaid"] = uaid
+        parameters["secret"] = secret
+        parameters["channelID"] = channelID
+
+        return JSON(parameters)
+    }
+}

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -233,4 +233,21 @@ public struct AppConstants {
             return true
         #endif
     }()
+
+    ///  Enables/disables push notificatuibs for FxA
+    public static let MOZ_FXA_PUSH: Bool = {
+        #if MOZ_CHANNEL_RELEASE
+            return false
+        #elseif MOZ_CHANNEL_BETA
+            return false
+        #elseif MOZ_CHANNEL_NIGHTLY
+            return false
+        #elseif MOZ_CHANNEL_FENNEC
+            return true
+        #elseif MOZ_CHANNEL_AURORA
+            return true
+        #else
+            return true
+        #endif
+    }()
 }


### PR DESCRIPTION
*Assumption*: WebPush will not be possible to be implement on iOS.

This PR refactors the various different versions of: 

 * get logged in
 * set and store the account 
 * ask for user permissions
 * start syncing
 * move the user to the correct screen

In addition, it:

 * register for APNS push notifications
 * associates the device with a WebPush server
 * associates the WebPush channel with FxAccount server.
 * handles APNS push notifications from the FxAccount service.

These bugs are documented in this [bug tree](https://bugzilla.mozilla.org/showdependencytree.cgi?id=1344703&hide_resolved=0).

https://bugzilla.mozilla.org/show_bug.cgi?id=1344703