### PR TITLE
Bug 1315115 - Add toast to "Switch to tab" to "Open in Tab". r?farhan

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2162,6 +2162,18 @@ extension BrowserViewController: TabManagerDelegate {
     func tabManagerDidRestoreTabs(tabManager: TabManager) {
         updateTabCountUsingTabManager(tabManager)
     }
+
+    func showButtonToast(buttonToast: ButtonToast, afterWaiting delay: Double = 0) {
+        let time = dispatch_time(dispatch_time_t(DISPATCH_TIME_NOW), Int64(delay * Double(NSEC_PER_SEC)))
+        dispatch_after(time, dispatch_get_main_queue()) {
+            self.view.addSubview(buttonToast)
+            buttonToast.snp_makeConstraints { make in
+                make.left.right.equalTo(self.view)
+                make.bottom.equalTo(self.webViewContainer)
+            }
+            buttonToast.showToast()
+        }
+    }
     
     func tabManagerDidRemoveAllTabs(tabManager: TabManager, toast: ButtonToast?) {
         guard !tabTrayController.privateMode else {
@@ -2169,15 +2181,7 @@ extension BrowserViewController: TabManagerDelegate {
         }
         
         if let undoToast = toast {
-            let time = dispatch_time(dispatch_time_t(DISPATCH_TIME_NOW), Int64(ButtonToastUX.ToastDelay * Double(NSEC_PER_SEC)))
-            dispatch_after(time, dispatch_get_main_queue()) {
-                self.view.addSubview(undoToast)
-                undoToast.snp_makeConstraints { make in
-                    make.left.right.equalTo(self.view)
-                    make.bottom.equalTo(self.webViewContainer)
-                }
-                undoToast.showToast()
-            }
+            showButtonToast(undoToast, afterWaiting: ButtonToastUX.ToastDelay)
         }
     }
 
@@ -2958,8 +2962,15 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                 let newTabTitle = NSLocalizedString("Open in New Tab", comment: "Context menu item for opening a link in a new tab")
                 let openNewTabAction =  UIAlertAction(title: newTabTitle, style: UIAlertActionStyle.Default) { (action: UIAlertAction) in
                     self.scrollController.showToolbars(animated: !self.scrollController.toolbarsShowing, completion: { _ in
-                        self.tabManager.addTab(NSURLRequest(URL: url), afterTab: currentTab)
+                        let tab = self.tabManager.addTab(NSURLRequest(URL: url), afterTab: currentTab)
+                        let toast = ButtonToast(labelText: NSLocalizedString("New Tab opened", comment: "Button toast label for switching to fresh New Tab"), buttonText: NSLocalizedString("Switch", comment: "Button toast button for switching to fresh New Tab"), completion: { buttonPressed in
+                            if (buttonPressed) {
+                                self.tabManager.selectTab(tab)
+                            }
+                        })
+                        self.showButtonToast(toast)
                     })
+
                 }
                 actionSheetController.addAction(openNewTabAction)
             }
@@ -2967,7 +2978,13 @@ extension BrowserViewController: ContextMenuHelperDelegate {
             let openNewPrivateTabTitle = NSLocalizedString("Open in New Private Tab", tableName: "PrivateBrowsing", comment: "Context menu option for opening a link in a new private tab")
             let openNewPrivateTabAction =  UIAlertAction(title: openNewPrivateTabTitle, style: UIAlertActionStyle.Default) { (action: UIAlertAction) in
                 self.scrollController.showToolbars(animated: !self.scrollController.toolbarsShowing, completion: { _ in
-                    self.tabManager.addTab(NSURLRequest(URL: url), afterTab: currentTab, isPrivate: true)
+                    let tab = self.tabManager.addTab(NSURLRequest(URL: url), afterTab: currentTab, isPrivate: true)
+                    let toast = ButtonToast(labelText: NSLocalizedString("New Private Tab opened", comment: "Button toast label for switching to fresh New Private Tab"), buttonText: NSLocalizedString("Switch", comment: "Button toast button for switching to fresh New Private Tab"), completion: { buttonPressed in
+                        if (buttonPressed) {
+                            self.tabManager.selectTab(tab)
+                        }
+                    })
+                    self.showButtonToast(toast)
                 })
             }
             actionSheetController.addAction(openNewPrivateTabAction)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2963,12 +2963,15 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                 let openNewTabAction =  UIAlertAction(title: newTabTitle, style: UIAlertActionStyle.Default) { (action: UIAlertAction) in
                     self.scrollController.showToolbars(animated: !self.scrollController.toolbarsShowing, completion: { _ in
                         let tab = self.tabManager.addTab(NSURLRequest(URL: url), afterTab: currentTab)
-                        let toast = ButtonToast(labelText: NSLocalizedString("New Tab opened", comment: "Button toast label for switching to fresh New Tab"), buttonText: NSLocalizedString("Switch", comment: "Button toast button for switching to fresh New Tab"), completion: { buttonPressed in
-                            if (buttonPressed) {
-                                self.tabManager.selectTab(tab)
-                            }
-                        })
-                        self.showButtonToast(toast)
+                        if self.topTabsViewController == nil {
+                            // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
+                            let toast = ButtonToast(labelText: Strings.ContextMenuButtonToastNewTabOpenedLabelText, buttonText: Strings.ContextMenuButtonToastNewTabOpenedButtonText, completion: { buttonPressed in
+                                if (buttonPressed) {
+                                    self.tabManager.selectTab(tab)
+                                }
+                            })
+                            self.showButtonToast(toast)
+                        }
                     })
 
                 }
@@ -2979,12 +2982,15 @@ extension BrowserViewController: ContextMenuHelperDelegate {
             let openNewPrivateTabAction =  UIAlertAction(title: openNewPrivateTabTitle, style: UIAlertActionStyle.Default) { (action: UIAlertAction) in
                 self.scrollController.showToolbars(animated: !self.scrollController.toolbarsShowing, completion: { _ in
                     let tab = self.tabManager.addTab(NSURLRequest(URL: url), afterTab: currentTab, isPrivate: true)
-                    let toast = ButtonToast(labelText: NSLocalizedString("New Private Tab opened", comment: "Button toast label for switching to fresh New Private Tab"), buttonText: NSLocalizedString("Switch", comment: "Button toast button for switching to fresh New Private Tab"), completion: { buttonPressed in
-                        if (buttonPressed) {
-                            self.tabManager.selectTab(tab)
-                        }
-                    })
-                    self.showButtonToast(toast)
+                    if self.topTabsViewController == nil {
+                        // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
+                        let toast = ButtonToast(labelText: Strings.ContextMenuButtonToastNewPrivateTabOpenedLabelText, buttonText: Strings.ContextMenuButtonToastNewPrivateTabOpenedButtonText, completion: { buttonPressed in
+                            if (buttonPressed) {
+                                self.tabManager.selectTab(tab)
+                            }
+                        })
+                        self.showButtonToast(toast)
+                    }
                 })
             }
             actionSheetController.addAction(openNewPrivateTabAction)

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -250,6 +250,14 @@ extension Strings {
     public static let SettingsAddCustomEngineSaveButtonText = NSLocalizedString("Settings.AddCustomEngine.SaveButtonText", value: "Save", comment: "The text on the Save button when saving a custom search engine")
 }
 
+// Context menu ButtonToast instances.
+extension Strings {
+    public static let ContextMenuButtonToastNewTabOpenedLabelText = NSLocalizedString("ContextMenu.ButtonToast.NewTabOpened.LabelText", value: "New Tab opened", comment: "The label text in the Button Toast for switching to a fresh New Tab.")
+    public static let ContextMenuButtonToastNewTabOpenedButtonText = NSLocalizedString("ContextMenu.ButtonToast.NewTabOpened.ButtonText", value: "Switch", comment: "The button text in the Button Toast for switching to a fresh New Tab.")
+    public static let ContextMenuButtonToastNewPrivateTabOpenedLabelText = NSLocalizedString("ContextMenu.ButtonToast.NewPrivateTabOpened.LabelText", value: "New Private Tab opened", comment: "The label text in the Button Toast for switching to a fresh New Private Tab.")
+    public static let ContextMenuButtonToastNewPrivateTabOpenedButtonText = NSLocalizedString("ContextMenu.ButtonToast.NewPrivateTabOpened.ButtonText", value: "Switch", comment: "The button text in the Button Toast for switching to a fresh New Private Tab.")
+}
+
 // MARK: Deprecated Strings (to be removed in next version)
 private let logOut = NSLocalizedString("Log Out", comment: "Button in settings screen to disconnect from your account")
 private let logOutQuestion = NSLocalizedString("Log Out?", comment: "Title of the 'log out firefox account' alert")


### PR DESCRIPTION
Open questions:
* Is there a danger keeping the reference to the Tab like this?  Can it disappear beneath me?
* Should I prepare and display the toast before waiting for the scroll controller to show the toolbars?  (I didn't in order to minimize the added code.)
* Is the ButtonToast display logic correct?  Is this registering the toast appropriately?
* Are the strings localized correctly?
* How hard is it to add tests for this functionality?