### PR TITLE
Bug 1335760 - Moved dispatch_once database logic to instance properties

### DIFF
--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -210,6 +210,9 @@ open class BrowserProfile: Profile {
 
     weak fileprivate var app: UIApplication?
 
+    let db: BrowserDB
+    let loginsDB: BrowserDB
+
     /**
      * N.B., BrowserProfile is used from our extensions, often via a pattern like
      *
@@ -226,6 +229,10 @@ open class BrowserProfile: Profile {
         self.app = app
 
         self.keychain = KeychainWrapper.sharedAppContainerKeychain
+
+        // Setup our database handles
+        self.loginsDB = BrowserDB(filename: "logins.db", secretKey: "sqlcipher.key.logins.db", files: files)
+        self.db = BrowserDB(filename: "browser.db", files: files)
 
         if clear {
             do {
@@ -283,26 +290,16 @@ open class BrowserProfile: Profile {
         log.debug("Reopening profile.")
         isShutdown = false
         
-        if BrowserProfile.dbCreated {
-            db.reopenIfClosed()
-        }
-
-        if BrowserProfile.loginsDBCreated {
-            loginsDB.reopenIfClosed()
-        }
+        db.reopenIfClosed()
+        loginsDB.reopenIfClosed()
     }
 
     func shutdown() {
         log.debug("Shutting down profile.")
         isShutdown = true
 
-        if BrowserProfile.dbCreated {
-            db.forceClose()
-        }
-
-        if BrowserProfile.loginsDBCreated {
-            loginsDB.forceClose()
-        }
+        db.forceClose()
+        loginsDB.forceClose()
     }
 
     @objc
@@ -363,6 +360,9 @@ open class BrowserProfile: Profile {
         NotificationCenter.default.removeObserver(self, name: NotificationOnPageMetadataFetched, object: nil)
         NotificationCenter.default.removeObserver(self, name: NotificationProfileDidFinishSyncing, object: nil)
         NotificationCenter.default.removeObserver(self, name: NotificationPrivateDataClearedHistory, object: nil)
+
+        // Shutdown any handles we have open to our databases
+        shutdown()
     }
 
     func localName() -> String {
@@ -373,22 +373,6 @@ open class BrowserProfile: Profile {
         withExtendedLifetime(self.history) {
             return SQLiteQueue(db: self.db)
         }
-    }()
-
-    /**
-     * For safety and efficiency, we only allow each database to be opened once. It
-     * looks like you can create multiple Profile instances, each pointing to a
-     * different database, but that's not currently the case.
-     *
-     * These `dbCreated` flags are an implementation detail to avoid opening a DB
-     * only to immediately close it -- they reflect whether the singleton DB instances
-     * have been assigned.
-     */
-    fileprivate static var dbCreated = false
-    lazy var db: BrowserDB = {
-        let db = BrowserDB(filename: "browser.db", files: self.files)
-        BrowserProfile.dbCreated = true
-        return db
     }()
 
     /**
@@ -498,21 +482,6 @@ open class BrowserProfile: Profile {
 
     lazy var logins: BrowserLogins & SyncableLogins & ResettableSyncStorage = {
         return SQLiteLogins(db: self.loginsDB)
-    }()
-
-    // This is currently only used within the dispatch_once block in loginsDB, so we don't
-    // have to worry about races giving us two keys. But if this were ever to be used
-    // elsewhere, it'd be unsafe, so we wrap this in a dispatch_once, too.
-    lazy fileprivate var loginsKey: String? = {
-        let key = "sqlcipher.key.logins.db"
-        return key
-    }()
-
-    fileprivate static var loginsDBCreated = false
-    fileprivate lazy var loginsDB: BrowserDB = {
-        let db = BrowserDB(filename: "logins.db", secretKey: self.loginsKey, files: self.files)
-        BrowserProfile.loginsDBCreated = true
-        return db
     }()
 
     lazy var isChinaEdition: Bool = {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -217,14 +217,13 @@ open class BrowserProfile: Profile {
         let key = "sqlcipher.key.logins.db"
         let keychain = KeychainWrapper.sharedAppContainerKeychain
         if keychain.hasValue(forKey: key) {
-            let value = keychain.string(forKey: key)
-            return value
-        } else {
-            let Length: UInt = 256
-            let secret = Bytes.generateRandomBytes(Length).base64EncodedString
-            keychain.set(secret, forKey: key)
-            return secret
+            return keychain.string(forKey: key)
         }
+
+        let Length: UInt = 256
+        let secret = Bytes.generateRandomBytes(Length).base64EncodedString
+        keychain.set(secret, forKey: key)
+        return secret
     }
 
     /**


### PR DESCRIPTION
This patch removes our use of `dispatch_once` and replaces it with simple instance variables for accessing our database. The running theory I have is that it's OK for us to have multiple instances of BrowserDB (one per a profile) since BrowserDB/SwiftData is just a handle to the DB on disk. I feel like I'm overlooking something because this patch seems pretty thin.