### PR TITLE
Fix TestSwiftddta: testFilledCursor

### DIFF
--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -661,7 +661,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
     }
 
     func executeQuery<T>(_ sqlStr: String, factory: @escaping ((SDRow) -> T)) -> Cursor<T> {
-        return self.executeQuery(sqlStr, factory: factory)
+        return self.executeQuery(sqlStr, factory: factory, withArgs: nil)
     }
 
     /// Queries the database.


### PR DESCRIPTION
Ensure we don't enter a recursive loop when executing queries with no args

Fixes 

* TestSwiftData: testFilledCursor

https://bugzilla.mozilla.org/show_bug.cgi?id=1336056