### PR TITLE
Sync mock server wipe storage

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Sync.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Sync.xcscheme
@@ -42,6 +42,24 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "282731671ABC9BE700AA1954"
+               BuildableName = "SyncTests.xctest"
+               BlueprintName = "SyncTests"
+               ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "LiveAccountTest">
+               </Test>
+               <Test
+                  Identifier = "LiveStorageClientTests">
+               </Test>
+            </SkippedTests>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/SyncTests/MockSyncServerTests.swift
+++ b/SyncTests/MockSyncServerTests.swift
@@ -151,7 +151,9 @@ class MockSyncServerTests: XCTestCase {
             let after = decimalSecondsStringToTimestamp(millisecondsToDecimalSeconds(Date.now()))!
 
             // JSON contents: should be the empty object.
-            XCTAssertEqual(response.value.rawString(), "{}")
+            let jsonData = try! response.value.rawData()
+            let jsonString = String(data: jsonData, encoding: String.Encoding.utf8)!
+            XCTAssertEqual(jsonString, "{}")
 
             // X-Weave-Timestamp.
             XCTAssertLessThanOrEqual(before, response.metadata.timestampMilliseconds)


### PR DESCRIPTION
Grab json as string with no newline characters.
Also includes some changes to SyncTests scheme to enable tests on scheme and disable live tests

Fixes
* MockSyncServerTests: testWipeStorage