### PR TITLE
Convert int64s from sqlite into Ints.

### DIFF
--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -798,7 +798,8 @@ class SDRow: Sequence {
 
         switch type {
         case SQLITE_NULL, SQLITE_INTEGER:
-            ret = Int(sqlite3_column_int64(statement.pointer, i))
+            //Everyone expects this to be an Int. On Ints larger than 2^31 this will lose information.
+            ret = Int(truncatingBitPattern: sqlite3_column_int64(statement.pointer, i))
         case SQLITE_TEXT:
             if let text = sqlite3_column_text(statement.pointer, i) {
                 return String(cString: text)


### PR DESCRIPTION
Trying to put an Int64 into an Int before would crash sometimes. This prevents that from happening by truncating bits. 