### PR TITLE
String extensions tests

### DIFF
--- a/ClientTests/StringExtensionsTests.swift
+++ b/ClientTests/StringExtensionsTests.swift
@@ -55,6 +55,7 @@ class StringExtensionsTests: XCTestCase {
         XCTAssertEqual("foo", "foo".stringSplitWithNewline())
         XCTAssertEqual("aaa\n bbb", "aaa bbb".stringSplitWithNewline())
         XCTAssertEqual("Mark as\n Read", "Mark as Read".stringSplitWithNewline())
+        XCTAssertEqual("aa\n bbbbbb", "aa bbbbbb".stringSplitWithNewline())
     }
 
 }

--- a/ClientTests/StringExtensionsTests.swift
+++ b/ClientTests/StringExtensionsTests.swift
@@ -6,15 +6,6 @@ import Foundation
 import XCTest
 
 class StringExtensionsTests: XCTestCase {
-    func testContains() {
-        XCTAssertTrue("abcde".contains("abcde"))
-        XCTAssertTrue("abcde".contains(""))
-        XCTAssertTrue("abcde".contains("a"))
-        XCTAssertTrue("abcde".contains("e"))
-        XCTAssertFalse("abcde".contains("f"))
-        XCTAssertFalse("abcde".contains("fa"))
-        XCTAssertFalse("abcde".contains("ef"))
-    }
 
     func testStartsWith() {
         XCTAssertTrue("abcde".startsWith("abcde"))

--- a/Shared/Extensions/StringExtensions.swift
+++ b/Shared/Extensions/StringExtensions.swift
@@ -90,13 +90,14 @@ public extension String {
     public func stringSplitWithNewline() -> String {
         let mid = self.characters.count/2
 
-        let arr = self.characters.indices.flatMap { (index) -> Int? in
-            if let i = Int("\(index)"), self.characters[index] == " " {
-                return i
+        let arr: [Int] = self.characters.indices.flatMap {
+            if self.characters[$0] == " " {
+                return self.distance(from: startIndex, to: $0)
             }
+
             return nil
         }
-        guard let closest = arr.enumerated().min(by: { abs($0.1 - mid) < abs($1.1 - mid)}) else {
+        guard let closest = arr.enumerated().min(by: { abs($0.1 - mid) < abs($1.1 - mid) }) else {
             return self
         }
         var newString = self


### PR DESCRIPTION
Fixing failing tests for StringExtensionsTests in ClientTests

1. Remove test for `contains` that now refers to String standard API func
2. Update `stringSplitWithNewline` to properly convert `String.Index` to `Int` and add test for missing test case when ideal insertion point is before midpoint