### PR TITLE
Bug 1337389 - Fixes FxA sign in issues from Swift 3 migration

### DIFF
--- a/Account/FxAClient10.swift
+++ b/Account/FxAClient10.swift
@@ -180,14 +180,14 @@ open class FxAClient10 {
             return nil
         }
 
-        let ciphertext = data.subdata(in: Range(uncheckedBounds: (lower: 0 * KeyLength, upper:  2 * KeyLength)))
-        let MAC = data.subdata(in: Range(uncheckedBounds: (lower: 1 * KeyLength, upper: 2 * KeyLength)))
+        let ciphertext = data.subdata(in: 0..<(2 * KeyLength))
+        let MAC = data.subdata(in: (2 * KeyLength)..<(3 * KeyLength))
 
         let salt: Data = Data()
         let contextInfo: Data = KW("account/keys")
         let bytes = (keyRequestKey as NSData).deriveHKDFSHA256Key(withSalt: salt, contextInfo: contextInfo, length: UInt(3 * KeyLength))
-        let respHMACKey = bytes?.subdata(in: Range(uncheckedBounds: (lower: 0 * KeyLength, upper: 1 * KeyLength)))
-        let respXORKey = bytes?.subdata(in: Range(uncheckedBounds: (lower: 1 * KeyLength, upper: 2 * KeyLength)))
+        let respHMACKey = bytes?.subdata(in: 0..<KeyLength)
+        let respXORKey = bytes?.subdata(in: KeyLength..<(3 * KeyLength))
 
         guard let hmacKey = respHMACKey,
             ciphertext.hmacSha256WithKey(hmacKey) == MAC else {
@@ -200,8 +200,8 @@ open class FxAClient10 {
             return nil
         }
 
-        let kA = xoredBytes.subdata(in: Range(uncheckedBounds: (lower: 0 * KeyLength, upper: 1 * KeyLength)))
-        let wrapkB = xoredBytes.subdata(in: Range(uncheckedBounds: (lower: 1 * KeyLength, upper: 1 * KeyLength)))
+        let kA = xoredBytes.subdata(in: 0..<KeyLength)
+        let wrapkB = xoredBytes.subdata(in: KeyLength..<(2 * KeyLength))
         return FxAKeysResponse(kA: kA, wrapkB: wrapkB)
     }
 
@@ -356,7 +356,8 @@ extension FxAClient10: FxALoginClient {
         let key = (keyFetchToken as NSData).deriveHKDFSHA256Key(withSalt: salt, contextInfo: contextInfo, length: UInt(3 * KeyLength))!
         mutableURLRequest.addAuthorizationHeader(forHKDFSHA256Key: key)
 
-        let keyRequestKey = key.subdata(in: Range(uncheckedBounds:(lower:KeyLength, upper: 2 * KeyLength)))
+        let rangeStart = 2 * KeyLength
+        let keyRequestKey = key.subdata(in: rangeStart..<(rangeStart + KeyLength))
 
         return makeRequest(mutableURLRequest) { FxAClient10.keysResponse(fromJSON: keyRequestKey, json: $0) }
     }

--- a/Account/HawkHelper.swift
+++ b/Account/HawkHelper.swift
@@ -141,8 +141,8 @@ open class HawkHelper {
 
 extension URLRequest {
     mutating func addAuthorizationHeader(forHKDFSHA256Key bytes: Data) {
-        let tokenId = bytes.subdata(in: Range(uncheckedBounds:(lower: 0 * KeyLength, upper: KeyLength)))
-        let reqHMACKey = bytes.subdata(in:Range(uncheckedBounds:(lower: 1 * KeyLength, upper: KeyLength)))
+        let tokenId = bytes.subdata(in: 0..<KeyLength)
+        let reqHMACKey = bytes.subdata(in: KeyLength..<(2 * KeyLength))
         let hawkHelper = HawkHelper(id: tokenId.hexEncodedString, key: reqHMACKey)
         let hawkValue = hawkHelper.getAuthorizationValueFor(self)
         setValue(hawkValue, forHTTPHeaderField: "Authorization")

--- a/Client/Frontend/Settings/FxAContentViewController.swift
+++ b/Client/Frontend/Settings/FxAContentViewController.swift
@@ -82,8 +82,8 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
             "type": type,
             "content": content,
         ] as [String : Any]
-        let json = JSON(data).rawString() ?? ""
-        let script = "window.postMessage(\(json), '\(self.url)');"
+        let json = JSON(data).rawString(.utf8, options: []) ?? ""
+        let script = "window.postMessage(\(json), '\(self.url.absoluteString)');"
         webView.evaluateJavaScript(script, completionHandler: nil)
     }
 


### PR DESCRIPTION
The first issue was caused by the improper use of `rawString` to grab a stringified version of the JSON object we pass through to the FxA web view. By passing in no options, the string won't be pretty printed and not include newlines. After that was resolved, the second issue was caused by incorrect conversions of our uses of NSMakeRange throughout the FxA authentication process which was causing the server to return `Unauthorized 401/109`.