### PR TITLE
Bug 1337769 - sync issues swift 3

### DIFF
--- a/Account/FxADeviceRegistration.swift
+++ b/Account/FxADeviceRegistration.swift
@@ -54,7 +54,7 @@ open class FxADeviceRegistration: NSObject, NSCoding {
 
     public convenience required init(coder: NSCoder) {
         let id = coder.decodeObject(forKey: "id") as! String
-        let version: Int = coder.decodeObject(forKey: "version") as! Int? ?? 0
+        let version: Int = coder.decodeInteger(forKey: "version")
         let lastRegistered = (coder.decodeObject(forKey: "lastRegistered") as! NSNumber).uint64Value
         self.init(id: id, version: version, lastRegistered: lastRegistered)
     }

--- a/Account/FxADeviceRegistration.swift
+++ b/Account/FxADeviceRegistration.swift
@@ -54,7 +54,7 @@ open class FxADeviceRegistration: NSObject, NSCoding {
 
     public convenience required init(coder: NSCoder) {
         let id = coder.decodeObject(forKey: "id") as! String
-        let version = coder.decodeObject(forKey: "version") as! Int
+        let version: Int = coder.decodeObject(forKey: "version") as! Int? ?? 0
         let lastRegistered = (coder.decodeObject(forKey: "lastRegistered") as! NSNumber).uint64Value
         self.init(id: id, version: version, lastRegistered: lastRegistered)
     }

--- a/Account/TokenServerClient.swift
+++ b/Account/TokenServerClient.swift
@@ -158,7 +158,7 @@ open class TokenServerClient {
 
                         if let data = response.result.value as AnyObject? { // Declaring the type quiets a Swift warning about inferring AnyObject.
                             let json = JSON(data)
-                            let remoteTimestampHeader = response.response?.allHeaderFields["x-timestamp"] as? String
+                            let remoteTimestampHeader = response.response?.allHeaderFields["X-Timestamp"] as? String
 
                             if let remoteError = TokenServerClient.remoteError(fromJSON: json, statusCode: response.response!.statusCode,
                                 remoteTimestampHeader: remoteTimestampHeader) {

--- a/Sync/Synchronizers/TabsSynchronizer.swift
+++ b/Sync/Synchronizers/TabsSynchronizer.swift
@@ -50,8 +50,8 @@ open class TabsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchroniz
     fileprivate func uploadOurTabs(_ localTabs: RemoteClientsAndTabs, toServer tabsClient: Sync15CollectionClient<TabsPayload>) -> Success {
         // check to see if our tabs have changed or we're in a fresh start
         let lastUploadTime: Timestamp? = (self.tabsRecordLastUpload == 0) ? nil : self.tabsRecordLastUpload
-        let expired = lastUploadTime! < (Date.now() - (OneMinuteInMilliseconds))
-        if !expired {
+        if let lastUploadTime = lastUploadTime,
+            lastUploadTime >= (Date.now() - (OneMinuteInMilliseconds)) {
             log.debug("Not uploading tabs: already did so at \(lastUploadTime).")
             return succeed()
         }


### PR DESCRIPTION
I encountered a number of issues when trying to Sync using the Swift 3 branch. Here are the fixes:

Missing version field for first sync on new device after sign in
Fetching an incorrect header for the remote timestamp field
Force unwrapping a potentialy nil value when synchronizing tabs