### PR TITLE
Fix 3D Touch quick actions.

### DIFF
--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -9,9 +9,9 @@ import Shared
 import XCGLogger
 
 enum ShortcutType: String {
-    case newTab
-    case newPrivateTab
-    case openLastBookmark
+    case newTab = "NewTab"
+    case newPrivateTab = "NewPrivateTab"
+    case openLastBookmark = "OpenLastBookmark"
 
     init?(fullType: String) {
         guard let last = fullType.components(separatedBy: ".").last else { return nil }


### PR DESCRIPTION
The actions are called with capital letters as the shortcut type. So we need to define the enums here as starting with an uppercase letter. 