### PR TITLE
Bug 1338503 - Properly reset data on disk when creating a new profile

### DIFF
--- a/ClientTests/ProfileTest.swift
+++ b/ClientTests/ProfileTest.swift
@@ -22,7 +22,7 @@ class ProfileTest: XCTestCase {
         let authInfo = AuthenticationKeychainInfo(passcode: "1234")
         KeychainWrapper.sharedAppContainerKeychain.setAuthenticationInfo(authInfo)
         XCTAssertNotNil(KeychainWrapper.sharedAppContainerKeychain.authenticationInfo())
-        let _ = BrowserProfile(localName: "my_profile")
+        let _ = BrowserProfile(localName: "my_profile", app: nil, clear: true)
         XCTAssertNil(KeychainWrapper.sharedAppContainerKeychain.authenticationInfo())
     }
 }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -252,7 +252,7 @@ open class BrowserProfile: Profile {
 
         // If the profile dir doesn't exist yet, this is first run (for this profile). The check is made here
         // since the DB handles will create new DBs under the new profile folder.
-        let isNewProfile = files.exists("")
+        let isNewProfile = !files.exists("")
 
         // Setup our database handles
         self.loginsDB = BrowserDB(filename: "logins.db", secretKey: BrowserProfile.loginsKey, files: files)


### PR DESCRIPTION
Flips the boolean check which was incorrect before from the Swift
migration. Additionally, since DBs are now not lazy, we need to force
clear the profile when opening in a test because they now have a
presence on disk immediately where as before they never did until the DB
was used.