### PR TITLE
Turn on 2 UI Tests

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/FirefoxNightly.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/FirefoxNightly.xcscheme
@@ -141,9 +141,6 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "AuthenticationTests">
-               </Test>
-               <Test
                   Identifier = "BookmarkingTests">
                </Test>
                <Test
@@ -175,9 +172,6 @@
                </Test>
                <Test
                   Identifier = "SearchTests">
-               </Test>
-               <Test
-                  Identifier = "SecurityTests/testWindowExploit()">
                </Test>
                <Test
                   Identifier = "SettingsTests">


### PR DESCRIPTION
enable UITest/AuthenticationTests.swift which is fixed,
enable UITests/SecurityTests/testWindowExploit() that currently crashes. Buddybuild will fix their system so it will appear on the Test log