### PR TITLE
Bug 1311399 - download and store image metadata

### DIFF
--- a/Client/Frontend/Metadata Parsing/MetadataHelper.js
+++ b/Client/Frontend/Metadata Parsing/MetadataHelper.js
@@ -27,58 +27,22 @@ var MetadataWrapper = function () {
         }
 
         var metadata = metadataparser.getMetadata(window.document, window.location.href, metadataparser.metadataRules);
-
-        var iconURL = metadata["icon_url"];
         var imageURL = metadata["image_url"];
-        var iconLoaded = false, imageLoaded = false
-        if (iconURL) {
-            if (isDataURI(iconURL)) {
-                metadata["icon_data_uri"] = iconURL;
-                if (imageLoaded) {
-                    metadataCallback(metadata);
-                } else {
-                    iconLoaded = true
-                }
-            } else {
-                getDataUri(iconURL, function(dataURI) {
-                    if (dataURI) {
-                        metadata["icon_data_uri"] = dataURI;
-                    }
-                    if (imageLoaded) {
-                        metadataCallback(metadata);
-                    } else {
-                        iconLoaded = true
-                    }
-                });
-            }
-        } 
-        else { 
-            iconLoaded = true; 
-        }
 
         if (imageURL) {
             if (isDataURI(imageURL)) {
                 metadata["image_data_uri"] = imageURL;
-                if (imageLoaded) {
-                    metadataCallback(metadata);
-                } else {
-                    imageLoaded = true
-                }
+                metadataCallback(metadata);
             } else {
                 getDataUri(imageURL, function(dataURI) {
                     if (dataURI) {
                         metadata["image_data_uri"] = dataURI;
                     }
-                    if (iconLoaded) {
-                        metadataCallback(metadata);
-                    } else {
-                        imageLoaded = true
-                    }
+                    metadataCallback(metadata);
                 });
             }
         } 
-        else if (iconLoaded) { 
-            imageLoaded = true; 
+        else { 
             metadataCallback(metadata);
         }
 

--- a/Client/Frontend/Metadata Parsing/MetadataHelper.js
+++ b/Client/Frontend/Metadata Parsing/MetadataHelper.js
@@ -16,9 +16,74 @@ var MetadataWrapper = function () {
             return;
         }
 
+        var metadataCallback = function(metadata) {
+            window.__firefox__.pageMetadata = metadata;
+            webkit.messageHandlers.metadataMessageHandler.postMessage(metadata);
+        }
+
         var metadata = metadataparser.getMetadata(window.document, window.location.href, metadataparser.metadataRules);
-        window.__firefox__.pageMetadata = metadata;
-        webkit.messageHandlers.metadataMessageHandler.postMessage(metadata);
+
+        var iconURL = metadata["icon_url"];
+        var imageURL = metadata["image_url"];
+        var iconLoaded = false, imageLoaded = false
+        if (iconURL) {
+            getDataUri(iconURL, function(dataURI) {
+                if (dataURI) {
+                    metadata["icon_data_url"] = dataURI;
+                }
+                if (imageLoaded) {
+                    metadataCallback(metadata);
+                } else {
+                    iconLoaded = true
+                }
+            });
+        } 
+        else { 
+            iconLoaded = true; 
+        }
+
+        if (imageURL) {
+            getDataUri(imageURL, function(dataURI) {
+                if (dataURI) {
+                    metadata["image_data_url"] = dataURI;
+                }
+                if (iconLoaded) {
+                    metadataCallback(metadata);
+                } else {
+                    imageLoaded = true
+                }
+            });
+        } 
+        else if (iconLoaded) { 
+            imageLoaded = true; 
+            metadataCallback(metadata);
+        }
+
+    }
+
+    return {
+        extractMetadata: extractMetadata
+    };
+
+    function getDataUri(url, callback) {
+        var image = new Image();
+
+        image.onload = function () {
+            try {
+                var canvas = document.createElement('canvas');
+                canvas.width = this.naturalWidth; // or 'width' if you want a special/scaled size
+                canvas.height = this.naturalHeight; // or 'height' if you want a special/scaled size
+
+                canvas.getContext('2d').drawImage(this, 0, 0);
+
+                var dataURI = canvas.toDataURL();
+                callback(dataURI);
+            } catch (exception) {
+                callback(false)
+            }
+        };
+
+        image.src = url;
     }
 
     return {

--- a/Client/Frontend/Metadata Parsing/MetadataHelper.js
+++ b/Client/Frontend/Metadata Parsing/MetadataHelper.js
@@ -29,7 +29,7 @@ var MetadataWrapper = function () {
         if (iconURL) {
             getDataUri(iconURL, function(dataURI) {
                 if (dataURI) {
-                    metadata["icon_data_url"] = dataURI;
+                    metadata["icon_data_uri"] = dataURI;
                 }
                 if (imageLoaded) {
                     metadataCallback(metadata);
@@ -45,7 +45,7 @@ var MetadataWrapper = function () {
         if (imageURL) {
             getDataUri(imageURL, function(dataURI) {
                 if (dataURI) {
-                    metadata["image_data_url"] = dataURI;
+                    metadata["image_data_uri"] = dataURI;
                 }
                 if (iconLoaded) {
                     metadataCallback(metadata);

--- a/Client/Frontend/Metadata Parsing/MetadataParserHelper.swift
+++ b/Client/Frontend/Metadata Parsing/MetadataParserHelper.swift
@@ -30,7 +30,7 @@ class MetadataParserHelper: TabHelper {
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
-        guard let dict = message.body as? [String: AnyObject] else {
+        guard let dict = message.body as? [String: Any] else {
             return
         }
         

--- a/Storage/PageMetadata.swift
+++ b/Storage/PageMetadata.swift
@@ -7,8 +7,6 @@ import UIKit
 import WebImage
 
 enum MetadataKeys: String {
-    case iconURL = "icon_url"
-    case iconDataURI = "icon_data_uri"
     case imageURL = "image_url"
     case imageDataURI = "image_data_uri"
     case pageURL = "url"
@@ -25,23 +23,20 @@ public struct PageMetadata {
     public let id: Int?
     public let siteURL: String
     public let mediaURL: String?
-    public let iconURL: String?
     public let title: String?
     public let description: String?
     public let type: String?
     public let providerName: String?
 
-    public init(id: Int?, siteURL: String, mediaURL: String?, iconURL: String?, title: String?, description: String?, type: String?, providerName: String?, iconDataURI: String?, mediaDataURI: String?) {
+    public init(id: Int?, siteURL: String, mediaURL: String?, title: String?, description: String?, type: String?, providerName: String?, mediaDataURI: String?) {
         self.id = id
         self.siteURL = siteURL
         self.mediaURL = mediaURL
-        self.iconURL = iconURL
         self.title = title
         self.description = description
         self.type = type
         self.providerName = providerName
 
-        self.cacheImage(fromDataURI: iconDataURI, forURL: iconURL)
         self.cacheImage(fromDataURI: mediaDataURI, forURL: mediaURL)
     }
 
@@ -50,10 +45,9 @@ public struct PageMetadata {
             return nil
         }
 
-        return PageMetadata(id: nil, siteURL: siteURL, mediaURL: dict[MetadataKeys.imageURL.rawValue] as? String, iconURL: dict[MetadataKeys.iconURL.rawValue] as? String,
+        return PageMetadata(id: nil, siteURL: siteURL, mediaURL: dict[MetadataKeys.imageURL.rawValue] as? String,
                             title: dict[MetadataKeys.title.rawValue] as? String, description: dict[MetadataKeys.description.rawValue] as? String,
-                            type: dict[MetadataKeys.type.rawValue] as? String, providerName: dict[MetadataKeys.provider.rawValue] as? String,
-                            iconDataURI: dict[MetadataKeys.iconDataURI.rawValue] as? String, mediaDataURI: dict[MetadataKeys.imageDataURI.rawValue] as? String)
+                            type: dict[MetadataKeys.type.rawValue] as? String, providerName: dict[MetadataKeys.provider.rawValue] as? String, mediaDataURI: dict[MetadataKeys.imageDataURI.rawValue] as? String)
     }
 
     fileprivate func cacheImage(fromDataURI dataURI: String?, forURL urlString: String?) {

--- a/Storage/PageMetadata.swift
+++ b/Storage/PageMetadata.swift
@@ -3,10 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import UIKit
 
 enum MetadataKeys: String {
     case iconURL = "icon_url"
+    case iconDataURI = "icon_data_uri"
     case imageURL = "image_url"
+    case imageDataURI = "image_data_uri"
     case pageURL = "url"
     case title = "title"
     case description = "description"
@@ -26,8 +29,10 @@ public struct PageMetadata {
     public let description: String?
     public let type: String?
     public let providerName: String?
+    public let iconImage: UIImage?
+    public let mediaImage: UIImage?
 
-    public init(id: Int?, siteURL: String, mediaURL: String?, iconURL: String?, title: String?, description: String?, type: String?, providerName: String?) {
+    public init(id: Int?, siteURL: String, mediaURL: String?, iconURL: String?, title: String?, description: String?, type: String?, providerName: String?, iconDataURI: String?, mediaDataURI: String?) {
         self.id = id
         self.siteURL = siteURL
         self.mediaURL = mediaURL
@@ -36,6 +41,18 @@ public struct PageMetadata {
         self.description = description
         self.type = type
         self.providerName = providerName
+
+        if let dataURI = iconDataURI,
+            let dataURL = URL(string: dataURI),
+            let data = try? Data(contentsOf: dataURL){
+            self.iconImage = UIImage(data: data)
+        } else { self.iconImage = nil }
+
+        if let dataURI = mediaDataURI,
+            let dataURL = URL(string: dataURI),
+            let data = try? Data(contentsOf: dataURL){
+            self.mediaImage = UIImage(data: data)
+        } else { self.mediaImage = nil }
     }
 
     public static func fromDictionary(_ dict: [String: Any]) -> PageMetadata? {
@@ -45,6 +62,7 @@ public struct PageMetadata {
 
         return PageMetadata(id: nil, siteURL: siteURL, mediaURL: dict[MetadataKeys.imageURL.rawValue] as? String, iconURL: dict[MetadataKeys.iconURL.rawValue] as? String,
                             title: dict[MetadataKeys.title.rawValue] as? String, description: dict[MetadataKeys.description.rawValue] as? String,
-                            type: dict[MetadataKeys.type.rawValue] as? String, providerName: dict[MetadataKeys.provider.rawValue] as? String)
+                            type: dict[MetadataKeys.type.rawValue] as? String, providerName: dict[MetadataKeys.provider.rawValue] as? String,
+                            iconDataURI: dict[MetadataKeys.iconDataURI.rawValue] as? String, mediaDataURI: dict[MetadataKeys.imageDataURI.rawValue] as? String)
     }
 }

--- a/Storage/PageMetadata.swift
+++ b/Storage/PageMetadata.swift
@@ -4,6 +4,16 @@
 
 import Foundation
 
+enum MetadataKeys: String {
+    case iconURL = "icon_url"
+    case imageURL = "image_url"
+    case pageURL = "url"
+    case title = "title"
+    case description = "description"
+    case type = "type"
+    case provider = "provider"
+}
+
 /*
  * Value types representing a page's metadata
  */
@@ -11,15 +21,17 @@ public struct PageMetadata {
     public let id: Int?
     public let siteURL: String
     public let mediaURL: String?
+    public let iconURL: String?
     public let title: String?
     public let description: String?
     public let type: String?
     public let providerName: String?
 
-    public init(id: Int?, siteURL: String, mediaURL: String?, title: String?, description: String?, type: String?, providerName: String?) {
+    public init(id: Int?, siteURL: String, mediaURL: String?, iconURL: String?, title: String?, description: String?, type: String?, providerName: String?) {
         self.id = id
         self.siteURL = siteURL
         self.mediaURL = mediaURL
+        self.iconURL = iconURL
         self.title = title
         self.description = description
         self.type = type
@@ -27,12 +39,12 @@ public struct PageMetadata {
     }
 
     public static func fromDictionary(_ dict: [String: Any]) -> PageMetadata? {
-        guard let siteURL = dict["url"] as? String else {
+        guard let siteURL = dict[MetadataKeys.pageURL.rawValue] as? String else {
             return nil
         }
 
-        return PageMetadata(id: nil, siteURL: siteURL, mediaURL: dict["image_url"] as? String,
-                            title: dict["title"] as? String, description: dict["description"] as? String,
-                            type: dict["type"] as? String, providerName: dict["provider_name"] as? String)
+        return PageMetadata(id: nil, siteURL: siteURL, mediaURL: dict[MetadataKeys.imageURL.rawValue] as? String, iconURL: dict[MetadataKeys.iconURL.rawValue] as? String,
+                            title: dict[MetadataKeys.title.rawValue] as? String, description: dict[MetadataKeys.description.rawValue] as? String,
+                            type: dict[MetadataKeys.type.rawValue] as? String, providerName: dict[MetadataKeys.provider.rawValue] as? String)
     }
 }

--- a/Storage/PageMetadata.swift
+++ b/Storage/PageMetadata.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import UIKit
+import WebImage
 
 enum MetadataKeys: String {
     case iconURL = "icon_url"
@@ -29,8 +30,6 @@ public struct PageMetadata {
     public let description: String?
     public let type: String?
     public let providerName: String?
-    public let iconImage: UIImage?
-    public let mediaImage: UIImage?
 
     public init(id: Int?, siteURL: String, mediaURL: String?, iconURL: String?, title: String?, description: String?, type: String?, providerName: String?, iconDataURI: String?, mediaDataURI: String?) {
         self.id = id
@@ -44,15 +43,19 @@ public struct PageMetadata {
 
         if let dataURI = iconDataURI,
             let dataURL = URL(string: dataURI),
-            let data = try? Data(contentsOf: dataURL){
-            self.iconImage = UIImage(data: data)
-        } else { self.iconImage = nil }
+            let data = try? Data(contentsOf: dataURL),
+            let iconImage = UIImage(data: data) {
+
+            self.cacheImage(image: iconImage, forURL: iconURL!)
+        }
 
         if let dataURI = mediaDataURI,
             let dataURL = URL(string: dataURI),
-            let data = try? Data(contentsOf: dataURL){
-            self.mediaImage = UIImage(data: data)
-        } else { self.mediaImage = nil }
+            let data = try? Data(contentsOf: dataURL),
+            let mediaImage = UIImage(data: data) {
+            
+            self.cacheImage(image: mediaImage, forURL: mediaURL!)
+        }
     }
 
     public static func fromDictionary(_ dict: [String: Any]) -> PageMetadata? {
@@ -64,5 +67,10 @@ public struct PageMetadata {
                             title: dict[MetadataKeys.title.rawValue] as? String, description: dict[MetadataKeys.description.rawValue] as? String,
                             type: dict[MetadataKeys.type.rawValue] as? String, providerName: dict[MetadataKeys.provider.rawValue] as? String,
                             iconDataURI: dict[MetadataKeys.iconDataURI.rawValue] as? String, mediaDataURI: dict[MetadataKeys.imageDataURI.rawValue] as? String)
+    }
+
+    fileprivate func cacheImage(image: UIImage, forURL url: String) {
+        let imageManager = SDWebImageManager.shared()
+        imageManager?.saveImage(toCache: image, for: URL(string: url)!)
     }
 }


### PR DESCRIPTION
So, I added the image data URI fetching to `MetadataHelper.js` and not to `page-metadata-parser.js` as I felt that it didn't really belong in a ruleset, but if that was the wrong assumption then I should be able to add it as a kind of rule instead.

Also, images are being stored inside the Image Cache in `SDWebImageManager`, keyed  by their URL, which means we are not adding any further rows to the DB, or needing to add a new table to store images.

This was built on top of @farhanpatel's unmerged metadata parsing bug. I don't think anything got screwed when I rebased, but who knows.

https://bugzilla.mozilla.org/show_bug.cgi?id=1311399