### PR TITLE
Bug 1339678 - wait until the progressIndicator disappears

### DIFF
--- a/XCUITests/BaseTestCase.swift
+++ b/XCUITests/BaseTestCase.swift
@@ -58,19 +58,15 @@ class BaseTestCase: XCTestCase {
     }
 
     func loadWebPage(_ url: String, waitForLoadToFinish: Bool = true) {
-        let loaded = NSPredicate(format: "value BEGINSWITH '100'")
-
         let app = XCUIApplication()
-
         UIPasteboard.general.string = url
         app.textFields["url"].press(forDuration: 2.0)
         app.sheets.element(boundBy: 0).buttons.element(boundBy: 0).tap()
 
         if waitForLoadToFinish {
             let finishLoadingTimeout: TimeInterval = 30
-            
             let progressIndicator = app.progressIndicators.element(boundBy: 0)
-            expectation(for: loaded, evaluatedWith: progressIndicator, handler: nil)
+            expectation(for: NSPredicate(format: "exists = false"), evaluatedWith: progressIndicator, handler: nil)
             waitForExpectations(timeout: finishLoadingTimeout, handler: nil)
         }
     }


### PR DESCRIPTION
loaded predicate is not fullfilled, because the progressindicator object just disappears once it's done loading. I think it's safer to wait until the progressindicator is gone, rather than waiting for it to display 100%. (which I don't think it does anymore)