### PR TITLE
Bug 1315627, 1303322 - Another rework of Top Tabs.

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -734,13 +734,12 @@ extension TabManager {
                 }
             )
         }
+        isRestoring = false
 
         if count == 0 {
             let tab = addTab()
             selectTab(tab)
         }
-
-        isRestoring = false
     }
     
     func restoreTabs(_ savedTabs: [Tab]) {

--- a/XCUITests/BookmarkingTests.swift
+++ b/XCUITests/BookmarkingTests.swift
@@ -1,10 +1,6 @@
-//
-//  BookmarkingTests.swift
-//  Client
-//
-//  Created by mozilla on 1/26/17.
-//  Copyright © 2017 Mozilla. All rights reserved.
-//
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import XCTest
 


### PR DESCRIPTION
I've opted to maintain a separate array of tabs within the TopTabs VC. Using the data store in Tabmanager causes crashes because it can change underneath TopTabs while it is animating.

I understand this is still pretty tricky code and not all of the crashes are probably fixed. There are 2 issues that makes this more complicated that hopefully I can fix
1. It's hard to know when we are about to enter/leave private mode. This makes it tricky to know how to animate and which tab to select. 
2. The diffing code cannot detect when a tab has its selected state changed. This is why I need to have the `needsReload` array. This is because my array of `oldTabs` holds references to tabs instead of copying the tabs. This is more tricky to fix so if the `needsReload` array works I'm just going to continue using that. 
