### PR TITLE
Bug 1311169 - Use provider name from metadata if available

### DIFF
--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -143,7 +143,11 @@ class TopSiteItemCell: UICollectionViewCell {
     }
 
     func configureWithTopSiteItem(_ site: Site) {
-        titleLabel.text = site.tileURL.hostSLD
+        if let provider = site.provider {
+            titleLabel.text = provider.lowercased()
+        } else {
+            titleLabel.text = site.tileURL.hostSLD
+        }
         accessibilityLabel = titleLabel.text
         if let suggestedSite = site as? SuggestedSite {
             let img = UIImage(named: suggestedSite.faviconImagePath!)

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -126,7 +126,7 @@ open class SQLiteHistory {
     }
 }
 
-private let topSitesQuery = "SELECT * FROM \(TableCachedTopSites) ORDER BY frecencies DESC LIMIT (?)"
+private let topSitesQuery = "SELECT \(TableCachedTopSites).*, \(TablePageMetadata).provider_name FROM \(TableCachedTopSites) LEFT OUTER JOIN \(TablePageMetadata) ON \(TableCachedTopSites).url = \(TablePageMetadata).site_url ORDER BY frecencies DESC LIMIT (?)"
 
 extension SQLiteHistory: BrowserHistory {
     public func removeSiteFromTopSites(_ site: Site) -> Success {

--- a/Storage/SQL/SQLiteHistoryFactories.swift
+++ b/Storage/SQL/SQLiteHistoryFactories.swift
@@ -23,6 +23,9 @@ extension SQLiteHistory {
         site.guid = guid
         site.id = id
 
+        if let provider = row["provider_name"] as? String {
+            site.provider = provider
+        }
         // Find the most recent visit, regardless of which column it might be in.
         let local = row.getTimestamp("localVisitDate") ?? 0
         let remote = row.getTimestamp("remoteVisitDate") ?? 0

--- a/Storage/Site.swift
+++ b/Storage/Site.swift
@@ -71,6 +71,7 @@ open class Site: Identifiable {
 
     open let url: String
     open let title: String
+    open var provider: String?
      // Sites may have multiple favicons. We'll return the largest.
     open var icon: Favicon?
     open var latestVisit: Visit?


### PR DESCRIPTION
* fetch provider from metadata when performing top sites query
* create new provider field for `Site`
* check for presence of provider when displaying top sites in Activity Stream
* display provider as lower case if present