### PR TITLE
Bug 1331970 - Cleaned up use of explicit unwraps in MenuAnimator

### DIFF
--- a/Client/Frontend/Menu/MenuPresentationAnimator.swift
+++ b/Client/Frontend/Menu/MenuPresentationAnimator.swift
@@ -97,23 +97,17 @@ extension MenuPresentationAnimator {
         }
 
         let minimisedFrame = CGRect(origin: vanishingPoint, size: CGSize.zero)
-        let menuViewSnapshot: UIView
+        guard let menuViewSnapshot = menuView.snapshotView(afterScreenUpdates: presenting) else {
+            transitionContext.completeTransition(true)
+            return
+        }
+
         if presenting {
-            guard let snapshot = menuView.snapshotView(afterScreenUpdates: true) else {
-                transitionContext.completeTransition(true)
-                return
-            }
-            menuViewSnapshot = snapshot
             menuViewSnapshot.frame = minimisedFrame
             menuViewSnapshot.alpha = 0
             menuView.backgroundColor = menuView.backgroundColor?.withAlphaComponent(0.0)
             menuView.addSubview(menuViewSnapshot)
         } else {
-            guard let snapshot = menuView.snapshotView(afterScreenUpdates: false) else {
-                transitionContext.completeTransition(true)
-                return
-            }
-            menuViewSnapshot = snapshot
             menuViewSnapshot.frame = menuView.frame
             container.insertSubview(menuViewSnapshot, aboveSubview: menuView)
             menuView.isHidden = true


### PR DESCRIPTION
The crash was being caused on L100 where we force unwrapped the screenshot of the menu view. In the case that the menu view is nil this will always fail. It might also fail if the system just wasn't able to get a screenshot at that time. I've gone ahead and cleaned up all the explicit unwrapping we do throughout this method to prevent any future issues.