### PR TITLE
Bug 1341627 - Go to copy link' toast should not be displayed on first run

### DIFF
--- a/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -36,7 +36,10 @@ class ClipboardBarDisplayHandler {
     }
     
     private func shouldDisplayBar() -> Bool {
-        if !sessionStarted || UIPasteboard.general.copiedURL == nil || wasClipboardURLAlreadyDisplayed() {
+        if !sessionStarted ||
+            UIPasteboard.general.copiedURL == nil ||
+            wasClipboardURLAlreadyDisplayed() ||
+            self.prefs.intForKey(IntroViewControllerSeenProfileKey) == nil {
             return false
         }
         sessionStarted = false


### PR DESCRIPTION
Check if the IntroViewController was seen before presenting the clipboard bar.
https://bugzilla.mozilla.org/show_bug.cgi?id=1341627