### PR TITLE
Bug 1342889 - Check if a tab is pending a restore when selecting a titles

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -246,8 +246,9 @@ class Tab: NSObject {
             }
         }
 
-        // Don't expose localhost urls.
-        if let url = self.url, url.isLocal {
+        // When picking a display title. Tabs with sessionData are pending a restore so show their old title.
+        // To prevent flickering of the display title. If a tab is restoring make sure to use its lastTitle.
+        if let url = self.url, url.isAboutHomeURL, sessionData == nil, !restoring {
             return ""
         }
 


### PR DESCRIPTION
Before a tab is restored its url internally is /about/home. So the old check would break titles for pages that had not yet been restored. This PR checks to see if sessionData is nil. If it is then a localhost URL is okay to be displayed as `""`