### PR TITLE
Bug 1341626 - ‘Go to copy link' toast is displayed for 1 second and it gets dismissed

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -737,6 +737,9 @@ class BrowserViewController: UIViewController {
             addChildViewController(homePanelController)
             view.addSubview(homePanelController.view)
             homePanelController.didMove(toParentViewController: self)
+            if let toast = clipboardBarDisplayHandler.clipboardToast {
+                view.bringSubview(toFront: toast)
+            }
         }
         guard let homePanelController = self.homePanelController else {
             assertionFailure("homePanelController is still nil after assignment.")


### PR DESCRIPTION
Bug link:https://bugzilla.mozilla.org/show_bug.cgi?id=1341626

This was happening because `showHomePanelController` is called multiple times to render the home screen (Maybe this can be improved?), and when this happens the subview hierarchy is changed.

The fix just checks if the toast is being displayed, and brings it to front if necessary.