### PR TITLE
Bug #2481 Could not access window created using window.open('about:blank' .... code

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2491,7 +2491,7 @@ extension BrowserViewController: WKNavigationDelegate {
 }
 
 /// List of schemes that are allowed to open a popup window
-private let SchemesAllowedToOpenPopups = ["http", "https", "javascript", "data"]
+private let SchemesAllowedToOpenPopups = ["http", "https", "javascript", "data", "about"]
 
 extension BrowserViewController: WKUIDelegate {
     func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {


### PR DESCRIPTION
ISSUE https://github.com/mozilla-mobile/firefox-ios/issues/2481

[Reason]
about: url scheme was going to ignore and consider as not valid url scheme for open model/tab in browser.

[Solution]
Add about in array of valid url scheme for open model/tab

[Test url]
https://bhavnapanchal.github.io/firefoxpopuptest.github.io/

[Side note]
I could not understand why other schemes are not added into list or why
that list is added here.

I think we should remove that logic or reconfirm valid url scheme list (SchemesAllowedToOpenPopups).