### PR TITLE
Bug 1343848 - Make sure on device restart a user isn't locked out of their logins when a passcode is set.

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -237,6 +237,7 @@
 		3BA9A0321D2C2C0500BD418C /* Fuzi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3BA9A0221D2C208C00BD418C /* Fuzi.framework */; };
 		3BB50E111D6274CD004B33DF /* ActivityStreamTopSitesCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB50E101D6274CD004B33DF /* ActivityStreamTopSitesCell.swift */; };
 		3BB50E201D627539004B33DF /* ActivityStreamPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB50E1F1D627539004B33DF /* ActivityStreamPanel.swift */; };
+		3BB54B311E68EB2B0021DAC4 /* AuthenticationKeychainInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB54B301E68EB2B0021DAC4 /* AuthenticationKeychainInfoTests.swift */; };
 		3BC659491E5BA4AE006D560F /* TopSites in Resources */ = {isa = PBXBuildFile; fileRef = 3BC659481E5BA4AE006D560F /* TopSites */; };
 		3BC659591E5BA505006D560F /* top_sites.json in Resources */ = {isa = PBXBuildFile; fileRef = 3BC659581E5BA505006D560F /* top_sites.json */; };
 		3BCE6D3C1CEB9E4D0080928C /* ThirdPartySearchAlerts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCE6D3B1CEB9E4D0080928C /* ThirdPartySearchAlerts.swift */; };
@@ -1408,6 +1409,7 @@
 		3BA9A0221D2C208C00BD418C /* Fuzi.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Fuzi.framework; path = Carthage/Build/iOS/Fuzi.framework; sourceTree = "<group>"; };
 		3BB50E101D6274CD004B33DF /* ActivityStreamTopSitesCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityStreamTopSitesCell.swift; sourceTree = "<group>"; };
 		3BB50E1F1D627539004B33DF /* ActivityStreamPanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityStreamPanel.swift; sourceTree = "<group>"; };
+		3BB54B301E68EB2B0021DAC4 /* AuthenticationKeychainInfoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationKeychainInfoTests.swift; sourceTree = "<group>"; };
 		3BC659481E5BA4AE006D560F /* TopSites */ = {isa = PBXFileReference; lastKnownFileType = folder; path = TopSites; sourceTree = "<group>"; };
 		3BC659581E5BA505006D560F /* top_sites.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = top_sites.json; sourceTree = "<group>"; };
 		3BCE6D3B1CEB9E4D0080928C /* ThirdPartySearchAlerts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThirdPartySearchAlerts.swift; sourceTree = "<group>"; };
@@ -3232,6 +3234,7 @@
 				E61453BD1B750A1700C3F9D7 /* RollingFileLoggerTests.swift */,
 				E4E7EB6C1C4AED5E0094275D /* SupportUtilsTests.swift */,
 				28A6CE891AC082E200C1A2D4 /* UtilsTests.swift */,
+				3BB54B301E68EB2B0021DAC4 /* AuthenticationKeychainInfoTests.swift */,
 			);
 			path = SharedTests;
 			sourceTree = "<group>";
@@ -5052,6 +5055,7 @@
 				28532BEB1C472015000072D9 /* UtilsTests.swift in Sources */,
 				28532BEA1C472008000072D9 /* DeferredTests.swift in Sources */,
 				E61453BE1B750A1700C3F9D7 /* RollingFileLoggerTests.swift in Sources */,
+				3BB54B311E68EB2B0021DAC4 /* AuthenticationKeychainInfoTests.swift in Sources */,
 				39E65D271CA5B92000C63CE3 /* AsyncReducerTests.swift in Sources */,
 				A826F0D21CBEB8160084CF9A /* PhoneNumberFormatterTests.swift in Sources */,
 				E4E7EB6D1C4AED5E0094275D /* SupportUtilsTests.swift in Sources */,

--- a/Shared/AuthenticationKeychainInfo.swift
+++ b/Shared/AuthenticationKeychainInfo.swift
@@ -72,7 +72,9 @@ open class AuthenticationKeychainInfo: NSObject, NSCoding {
 
     public required init?(coder aDecoder: NSCoder) {
         self.lastPasscodeValidationInterval = aDecoder.decodeAsDouble(forKey: "lastPasscodeValidationInterval")
-        self.lockOutInterval = aDecoder.decodeAsDouble(forKey: "lockOutInterval")
+        if let lockOutInterval = aDecoder.decodeObject(forKey: "lockOutInterval") as? NSNumber {
+            self.lockOutInterval = lockOutInterval.doubleValue
+        }
         self.passcode = aDecoder.decodeObject(forKey: "passcode") as? String
         self.failedAttempts = aDecoder.decodeAsInt(forKey: "failedAttempts")
         self.useTouchID = aDecoder.decodeAsBool(forKey: "useTouchID")

--- a/SharedTests/AuthenticationKeychainInfoTests.swift
+++ b/SharedTests/AuthenticationKeychainInfoTests.swift
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import XCTest
+import SwiftKeychainWrapper
+
+class AuthenticationKeychainInfoTests: XCTestCase {
+
+    func testEncodingAndDecoding() {
+        let passcode = "1234"
+        let authInfo = AuthenticationKeychainInfo(passcode: passcode)
+        authInfo.updateRequiredPasscodeInterval(.fiveMinutes)
+        authInfo.recordValidation()
+        authInfo.recordFailedAttempt() // failed attempt should be 1
+        authInfo.lockOutUser() //lock out a user so a lockoutInterval is set.
+        authInfo.useTouchID = true
+
+        let savedInterval = authInfo.lockOutInterval
+        let savedValidation = authInfo.lastPasscodeValidationInterval
+
+        KeychainWrapper.sharedAppContainerKeychain.setAuthenticationInfo(authInfo) //Save to disk
+        let decodedAuthInfo = KeychainWrapper.sharedAppContainerKeychain.authenticationInfo()! //Fetch from disk
+
+        XCTAssertEqual(savedInterval, decodedAuthInfo.lockOutInterval)
+        XCTAssertEqual(passcode, decodedAuthInfo.passcode)
+        XCTAssertEqual(1, decodedAuthInfo.failedAttempts, "We performed a recordFailedAttempt. This should be 1.")
+        XCTAssertTrue(decodedAuthInfo.useTouchID)
+        XCTAssertEqual(savedValidation, decodedAuthInfo.lastPasscodeValidationInterval)
+        XCTAssertEqual(PasscodeInterval.fiveMinutes, decodedAuthInfo.requiredPasscodeInterval)
+    }
+
+    func testNilIntervalsArentZero() {
+        let passcode = "1234"
+        let authInfo = AuthenticationKeychainInfo(passcode: passcode)
+
+        KeychainWrapper.sharedAppContainerKeychain.setAuthenticationInfo(authInfo) //Save to disk
+        let decodedAuthInfo = KeychainWrapper.sharedAppContainerKeychain.authenticationInfo()! //Fetch from disk
+
+        XCTAssertNil(decodedAuthInfo.lockOutInterval, "The lockoutInterval was never used. It should be nil")
+    }
+
+}


### PR DESCRIPTION
The decodeAsDouble will return a default 0 even if the value doesn't exist.
Later we check on the existence of lockoutInterval in the `isLocked()` method. Before that was enough because when decoding lockoutInterval if no value was found it would be nil. Now because its 0 the `isLocked` method returns true.

We can fix this one of 2 ways. Either by checking if lockedInterval is 0 or by decoding lockedInterval correctly on creation. I opted for the latter. Also I added some tests 😄 