### PR TITLE
Bug 1344994 - Support bitwarden password manager app extension

### DIFF
--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -124,6 +124,7 @@ private extension ShareExtensionHelper {
         return (activityType?.range(of: "password") != nil)
             || (activityType == "com.lastpass.ilastpass.LastPassExt")
             || (activityType == "in.sinew.Walletx.WalletxExt")
+            || (activityType == "com.8bit.bitwarden.find-login-action-extension")
 
     }
 


### PR DESCRIPTION
This PR adds support for bitwarden's auto-fill app extension so that it can be used from the share menu.

Learn more about bitwarden at https://bitwarden.com

https://bugzilla.mozilla.org/show_bug.cgi?id=1344994