### PR TITLE
Bug 1344610 - Improvements to TopTab animation speed. 

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1240,30 +1240,35 @@ class BrowserViewController: UIViewController {
     }
 
     func closeTab() {
-        if tabManager.tabs.count > 1 {
-            tabManager.removeTab(tabManager.selectedTab!)
-        } else {
-            //need to close the last tab and show the favorites screen thing
+        guard let currentTab = tabManager.selectedTab else {
+            return
         }
+        tabManager.removeTab(currentTab)
     }
 
     func nextTab() {
-        if tabManager.selectedIndex < (tabManager.tabs.count - 1) {
-            tabManager.selectTab(tabManager.tabs[tabManager.selectedIndex+1])
-        } else {
-            if tabManager.tabs.count > 1 {
-                tabManager.selectTab(tabManager.tabs[0])
-            }
+        guard let currentTab = tabManager.selectedTab else {
+            return
+        }
+
+        let tabs = currentTab.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
+        if let index = tabs.index(of: currentTab), index + 1 < tabs.count {
+            tabManager.selectTab(tabs[index + 1])
+        } else if let firstTab = tabs.first {
+            tabManager.selectTab(firstTab)
         }
     }
 
     func previousTab() {
-        if tabManager.selectedIndex > 0 {
-            tabManager.selectTab(tabManager.tabs[tabManager.selectedIndex-1])
-        } else {
-            if tabManager.tabs.count > 1 {
-                tabManager.selectTab(tabManager.tabs[tabManager.count-1])
-            }
+        guard let currentTab = tabManager.selectedTab else {
+            return
+        }
+
+        let tabs = currentTab.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
+        if let index = tabs.index(of: currentTab), index - 1 < tabs.count && index != 0 {
+            tabManager.selectTab(tabs[index - 1])
+        } else if let lastTab = tabs.last {
+            tabManager.selectTab(lastTab)
         }
     }
 

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -111,7 +111,9 @@ class TopTabsViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        self.reloadData()
+        if self.tabsToDisplay != self.tabStore {
+            self.reloadData()
+        }
     }
 
     override func viewDidLoad() {

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -269,7 +269,7 @@ extension TopTabsViewController: Themeable {
 extension TopTabsViewController: TopTabCellDelegate {
     func tabCellDidClose(_ cell: TopTabCell) {
         // Trying to remove tabs while animating can lead to crashes as indexes change. If updates are happening don't allow tabs to be removed.
-        guard let index = collectionView.indexPath(for: cell)?.item, !isUpdating else {
+        guard let index = collectionView.indexPath(for: cell)?.item else {
             return
         }
         let tab = tabStore[index]
@@ -422,8 +422,7 @@ extension TopTabsViewController {
 
             // There can be pending animations. Run update again to clear them.
             let tabs = self.oldTabs ?? self.tabStore
-            let toTabs = self.tabsToDisplay.count >= self.tabStore.count ? self.tabsToDisplay : self.tabStore
-            self.updateTabsFrom(tabs, to: toTabs, on: {
+            self.updateTabsFrom(tabs, to: self.tabsToDisplay, on: {
                 if !update.inserts.isEmpty || !update.reloads.isEmpty {
                     self.scrollToCurrentTab()
                 }
@@ -474,6 +473,10 @@ extension TopTabsViewController: TabManagerDelegate {
     }
 
     func performTabUpdates() {
+        guard !isUpdating else {
+            return
+        }
+
         let fromTabs = !self.pendingUpdatesToTabs.isEmpty ? self.pendingUpdatesToTabs : self.oldTabs
         self.oldTabs = fromTabs ?? self.tabStore
         if self.pendingReloadData && !isUpdating {

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -21,6 +21,7 @@ struct TopTabsUX {
     static let SeparatorWidth: CGFloat = 1
     static let TabTitleWidth: CGFloat = 110
     static let TabTitlePadding: CGFloat = 10
+    static let AnimationSpeed: TimeInterval = 0.1
 }
 
 protocol TopTabsDelegate: class {
@@ -235,7 +236,13 @@ class TopTabsViewController: UIViewController {
             } else {
                 // Padding is added to ensure the tab is completely visible (none of the tab is under the fader)
                 let padFrame = frame.insetBy(dx: -(TopTabsUX.TopTabsBackgroundShadowWidth+TopTabsUX.FaderPading), dy: 0)
-                collectionView.scrollRectToVisible(padFrame, animated: animated)
+                if animated {
+                    UIView.animate(withDuration: TopTabsUX.AnimationSpeed, animations: { 
+                        self.collectionView.scrollRectToVisible(padFrame, animated: true)
+                    })
+                } else {
+                    collectionView.scrollRectToVisible(padFrame, animated: false)
+                }
             }
         }
     }
@@ -401,7 +408,9 @@ extension TopTabsViewController {
         self.pendingUpdatesToTabs = newTabs // This var helps other mutations that might happen while updating.
 
         // The actual update
-        self.collectionView.performBatchUpdates(updateBlock) { (_) in
+        UIView.animate(withDuration: TopTabsUX.AnimationSpeed, animations: {
+            self.collectionView.performBatchUpdates(updateBlock)
+        }) { (_) in
             self.isUpdating = false
             self.pendingUpdatesToTabs = []
             // Sometimes there might be a pending reload. Lets do that.
@@ -437,7 +446,7 @@ extension TopTabsViewController {
         self.tabStore = self.tabsToDisplay
         self.newTab.isUserInteractionEnabled = false
         self.flushPendingChanges()
-        UIView.animate(withDuration: 0.2, animations: {
+        UIView.animate(withDuration: TopTabsUX.AnimationSpeed, animations: {
             self.collectionView.reloadData()
             self.collectionView.collectionViewLayout.invalidateLayout()
             self.collectionView.layoutIfNeeded()


### PR DESCRIPTION
I've done a few things here and combined them into one PR. 
- I've wrapped all the animations (inserts/deletes/scrolling to current tab) in an animation block and set it to a very fast animation time. This makes things feel very snappy. 
- I've fixed issues where the tab state would not update because the diff was being calculated from the wrong set of tabs. 
- I've removed a check to see if we are updating when deleting a tab to allow faster deletes. 
- In the viewDidAppear I've added a simple check to see if the tabStore is current to avoid flickers when going from TabTray to browser.