### PR TITLE
Bug 1345067 - use image metadata

### DIFF
--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -127,7 +127,7 @@ class TopSiteItemCell: UICollectionViewCell {
     }
 
     func configureWithTopSiteItem(_ site: Site) {
-        if let provider = site.provider {
+        if let provider = site.metadata?.providerName {
             titleLabel.text = provider.lowercased()
         } else {
             titleLabel.text = site.tileURL.hostSLD

--- a/Client/Frontend/Widgets/AlternateSimpleHighlightCell.swift
+++ b/Client/Frontend/Widgets/AlternateSimpleHighlightCell.swift
@@ -146,10 +146,16 @@ class AlternateSimpleHighlightCell: UITableViewCell {
     }
 
     func configureWithSite(_ site: Site) {
-        self.siteImageView.setFavicon(forSite: site, onCompletion: { [weak self] (color, url)  in
-            self?.siteImageView.image = self?.siteImageView.image?.createScaled(AlternateSimpleHighlightCellUX.FaviconSize)
-        })
-        self.siteImageView.contentMode = .center
+        if let mediaURLStr = site.metadata?.mediaURL,
+            let mediaURL = URL(string: mediaURLStr) {
+            self.siteImageView.sd_setImage(with: mediaURL)
+            self.siteImageView.contentMode = .scaleAspectFill
+        } else {
+            self.siteImageView.setFavicon(forSite: site, onCompletion: { [weak self] (color, url)  in
+                self?.siteImageView.image = self?.siteImageView.image?.createScaled(AlternateSimpleHighlightCellUX.FaviconSize)
+            })
+            self.siteImageView.contentMode = .center
+        }
 
         self.domainLabel.text = site.tileURL.hostSLD
         self.titleLabel.text = site.title.characters.count <= 1 ? site.url : site.title

--- a/Storage/PageMetadata.swift
+++ b/Storage/PageMetadata.swift
@@ -55,11 +55,12 @@ public struct PageMetadata {
             let url = URL(string: urlString) {
             if let dataURI = dataURI,
                 let dataURL = URL(string: dataURI),
+                !SDWebImageManager.shared().cachedImageExists(for: dataURL),
                 let data = try? Data(contentsOf: dataURL),
                 let image = UIImage(data: data) {
 
                 self.cache(image: image, forURL: url)
-            } else {
+            } else if !SDWebImageManager.shared().cachedImageExists(for: url) {
                 // download image direct from URL
                 self.downloadAndCache(fromURL: url)
             }

--- a/Storage/PageMetadata.swift
+++ b/Storage/PageMetadata.swift
@@ -28,7 +28,7 @@ public struct PageMetadata {
     public let type: String?
     public let providerName: String?
 
-    public init(id: Int?, siteURL: String, mediaURL: String?, title: String?, description: String?, type: String?, providerName: String?, mediaDataURI: String?) {
+    public init(id: Int?, siteURL: String, mediaURL: String?, title: String?, description: String?, type: String?, providerName: String?, mediaDataURI: String?, cacheImages: Bool = true) {
         self.id = id
         self.siteURL = siteURL
         self.mediaURL = mediaURL
@@ -37,7 +37,9 @@ public struct PageMetadata {
         self.type = type
         self.providerName = providerName
 
-        self.cacheImage(fromDataURI: mediaDataURI, forURL: mediaURL)
+        if cacheImages {
+            self.cacheImage(fromDataURI: mediaDataURI, forURL: mediaURL)
+        }
     }
 
     public static func fromDictionary(_ dict: [String: Any]) -> PageMetadata? {

--- a/Storage/SQL/BrowserTable.swift
+++ b/Storage/SQL/BrowserTable.swift
@@ -52,6 +52,7 @@ let IndexBookmarksLocalStructureParentIdx = "idx_bookmarksLocalStructure_parent_
 let IndexBookmarksBufferStructureParentIdx = "idx_bookmarksBufferStructure_parent_idx"   // Added in v12.
 let IndexBookmarksMirrorStructureChild = "idx_bookmarksMirrorStructure_child"            // Added in v14.
 let IndexPageMetadataCacheKey = "idx_page_metadata_cache_key_uniqueindex" // Added in v19
+let IndexPageMetadataSiteURL = "idx_page_metadata_site_url_uniqueindex" // Added in v19
 
 private let AllTables: [String] = [
     TableDomains,
@@ -95,7 +96,8 @@ private let AllIndices: [String] = [
     IndexBookmarksLocalStructureParentIdx,
     IndexBookmarksMirrorStructureParentIdx,
     IndexBookmarksMirrorStructureChild,
-    IndexPageMetadataCacheKey
+    IndexPageMetadataCacheKey,
+    IndexPageMetadataSiteURL
 ]
 
 private let AllTablesIndicesAndViews: [String] = AllViews + AllIndices + AllTables
@@ -262,8 +264,11 @@ open class BrowserTable: Table {
             "expired_at LONG" +
         ") "
 
-    let indexPageMetadataCreate =
-        "CREATE UNIQUE INDEX IF NOT EXISTS \(IndexPageMetadataCacheKey) ON page_metadata (cache_key)"
+    let indexPageMetadataCacheKeyCreate =
+    "CREATE UNIQUE INDEX IF NOT EXISTS \(IndexPageMetadataCacheKey) ON page_metadata (cache_key)"
+
+    let indexPageMetadataSiteURLCreate =
+    "CREATE UNIQUE INDEX IF NOT EXISTS \(IndexPageMetadataSiteURL) ON page_metadata (site_url)"
 
     let iconColumns = ", faviconID INTEGER REFERENCES \(TableFavicons)(id) ON DELETE SET NULL"
     let mirrorColumns = ", is_overridden TINYINT NOT NULL DEFAULT 0"
@@ -577,7 +582,8 @@ open class BrowserTable: Table {
             historyIDsWithIcon,
             iconForURL,
             pageMetadataCreate,
-            indexPageMetadataCreate,
+            indexPageMetadataCacheKeyCreate,
+            indexPageMetadataSiteURLCreate,
             self.queueTableCreate,
             self.topSitesTableCreate,
             self.localBookmarksView,
@@ -822,7 +828,8 @@ open class BrowserTable: Table {
 
                 // Adds tables/indicies for metadata content
                 pageMetadataCreate,
-                indexPageMetadataCreate]) {
+                indexPageMetadataCacheKeyCreate,
+                indexPageMetadataSiteURLCreate]) {
                 return false
             }
         }

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -276,7 +276,7 @@ extension SQLiteHistory: BrowserHistory {
     }
 
     public func getTopSitesWithLimit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>> {
-        return self.db.runQuery(topSitesQuery, args: [limit], factory: SQLiteHistory.iconHistoryColumnFactory)
+        return self.db.runQuery(topSitesQuery, args: [limit], factory: SQLiteHistory.iconHistoryMetadataColumnFactory)
     }
 
     public func setTopSitesNeedsInvalidation() {

--- a/Storage/SQL/SQLiteHistoryFactories.swift
+++ b/Storage/SQL/SQLiteHistoryFactories.swift
@@ -23,9 +23,6 @@ extension SQLiteHistory {
         site.guid = guid
         site.id = id
 
-        if let provider = row["provider_name"] as? String {
-            site.provider = provider
-        }
         // Find the most recent visit, regardless of which column it might be in.
         let local = row.getTimestamp("localVisitDate") ?? 0
         let remote = row.getTimestamp("remoteVisitDate") ?? 0
@@ -50,9 +47,29 @@ extension SQLiteHistory {
         return nil
     }
 
+    class func pageMetadataColumnFactory(_ row: SDRow) -> PageMetadata? {
+        guard let siteURL = row["url"] as? String else {
+            return nil
+        }
+
+        return PageMetadata(id: row["metadata_id"] as? Int, siteURL: siteURL, mediaURL: row["media_url"] as? String, title: row["metadata_title"] as? String, description: row["description"] as? String, type: row["type"] as? String, providerName: row["provider_name"] as? String, mediaDataURI: nil)
+    }
+
     class func iconHistoryColumnFactory(_ row: SDRow) -> Site {
         let site = basicHistoryColumnFactory(row)
         site.icon = iconColumnFactory(row)
+        return site
+    }
+
+    class func iconHistoryMetadataColumnFactory(_ row: SDRow) -> Site {
+        let site = iconHistoryColumnFactory(row)
+        site.metadata = pageMetadataColumnFactory(row)
+        return site
+    }
+
+    class func basicHistoryMetadataColumnFactory(_ row: SDRow) -> Site {
+        let site = basicHistoryColumnFactory(row)
+        site.metadata = pageMetadataColumnFactory(row)
         return site
     }
 }

--- a/Storage/Site.swift
+++ b/Storage/Site.swift
@@ -71,6 +71,7 @@ open class Site: Identifiable {
 
     open let url: String
     open let title: String
+    open var metadata: PageMetadata?
     open var provider: String?
      // Sites may have multiple favicons. We'll return the largest.
     open var icon: Favicon?

--- a/Storage/Site.swift
+++ b/Storage/Site.swift
@@ -72,7 +72,6 @@ open class Site: Identifiable {
     open let url: String
     open let title: String
     open var metadata: PageMetadata?
-    open var provider: String?
      // Sites may have multiple favicons. We'll return the largest.
     open var icon: Favicon?
     open var latestVisit: Visit?

--- a/StorageTests/TestSQLiteMetadata.swift
+++ b/StorageTests/TestSQLiteMetadata.swift
@@ -31,7 +31,7 @@ class TestSQLiteMetadata: XCTestCase {
         let site = "http://test.com"
 
         let page = PageMetadata(id: nil, siteURL: site, mediaURL: "http://image.com",
-                                title: "Test", description: "Test Description", type: nil, providerName: nil, mediaDataURI: nil)
+                                title: "Test", description: "Test Description", type: nil, providerName: nil, mediaDataURI: nil, cacheImages: false)
         self.metadata.storeMetadata(page, forPageURL: site.asURL!, expireAt: Date.now() + 3000).succeeded()
         let results = metadataFromDB(self.db).value.successValue!
         XCTAssertEqual(results.count, 1)
@@ -44,11 +44,11 @@ class TestSQLiteMetadata: XCTestCase {
         let siteB = "http://test.com/site/B"
 
         let metadataA1 = PageMetadata(id: nil, siteURL: siteA, mediaURL: nil,
-                                      title: "First Visit", description: "", type: nil, providerName: nil, mediaDataURI: nil)
+                                      title: "First Visit", description: "", type: nil, providerName: nil, mediaDataURI: nil, cacheImages: false)
         let metadataB = PageMetadata(id: nil, siteURL: siteB, mediaURL: "http://image.com",
-                                     title: "Test", description: "Test Description", type: nil, providerName: nil, mediaDataURI: nil)
+                                     title: "Test", description: "Test Description", type: nil, providerName: nil, mediaDataURI: nil, cacheImages: false)
         let metadataA2 = PageMetadata(id: nil, siteURL: siteA, mediaURL: "http://image.com",
-                                      title: "Second Visit", description: "A new description", type: nil, providerName: nil, mediaDataURI: nil)
+                                      title: "Second Visit", description: "A new description", type: nil, providerName: nil, mediaDataURI: nil, cacheImages: false)
 
         self.metadata.storeMetadata(metadataA1, forPageURL: siteA.asURL!, expireAt: Date.now() + 3000).succeeded()
 
@@ -84,7 +84,7 @@ class TestSQLiteMetadata: XCTestCase {
         let baseTime = Date.now()
         let siteA = "http://test.com/site/A"
         let metadataA = PageMetadata(id: nil, siteURL: siteA, mediaURL: nil,
-                                     title: "Test", description: "Test Description", type: nil, providerName: nil, mediaDataURI: nil)
+                                     title: "Test", description: "Test Description", type: nil, providerName: nil, mediaDataURI: nil, cacheImages: false)
         // Set expiration to base
         self.metadata.storeMetadata(metadataA, forPageURL: siteA.asURL!, expireAt: baseTime - 1000).succeeded()
         self.metadata.deleteExpiredMetadata().succeeded()
@@ -95,7 +95,7 @@ class TestSQLiteMetadata: XCTestCase {
 }
 
 private func metadataFromDB(_ db: BrowserDB) -> Deferred<Maybe<Cursor<PageMetadata>>> {
-    let sql = "SELECT * FROM page_metadata"
+    let sql = "SELECT * FROM \(TablePageMetadata)"
     return db.runQuery(sql, args: nil, factory: pageMetadataFactory)
 }
 
@@ -112,5 +112,5 @@ private func pageMetadataFactory(_ row: SDRow) -> PageMetadata {
     let type = row["type"] as? String
     let providerName = row["provider_name"] as? String
     return PageMetadata(id: id, siteURL: siteURL, mediaURL: mediaURL, title: title,
-                        description: description, type: type, providerName: providerName, mediaDataURI: nil)
+                        description: description, type: type, providerName: providerName, mediaDataURI: nil, cacheImages: false)
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1345067

* Fetch metadata for a site when fetching highlights
* Create `PageMetadata` property of `Site` and populate if metadata is present in `SDRow` with a new factory
* Use `mediaURL` image if present, otherwise default to `Favicon` when displaying Highlights
* Update Top Sites to use `providerName` from metadata inside `Site` rather than property.
* Add test to ensure that we are properly fetching metadata for highlights