### PR TITLE
Bug 1344735 – Import ecec, and build as part of FxA against OpenSSL.

### DIFF
--- a/FxA/FxA.xcodeproj/project.pbxproj
+++ b/FxA/FxA.xcodeproj/project.pbxproj
@@ -116,6 +116,13 @@
 		2FF8264B19D3CAFF003ED08E /* NSData+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FF825E819D3CAFF003ED08E /* NSData+Utils.m */; };
 		2FF8264C19D3CAFF003ED08E /* NSString+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FF825E919D3CAFF003ED08E /* NSString+Utils.h */; };
 		2FF8264D19D3CAFF003ED08E /* NSString+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FF825EA19D3CAFF003ED08E /* NSString+Utils.m */; };
+		395C8E271E71826200A68E8C /* ece.h in Headers */ = {isa = PBXBuildFile; fileRef = 395C8E261E71826200A68E8C /* ece.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		395C8E2E1E71827200A68E8C /* aesgcm-header.c in Sources */ = {isa = PBXBuildFile; fileRef = 395C8E281E71827200A68E8C /* aesgcm-header.c */; };
+		395C8E2F1E71827200A68E8C /* base64url.c in Sources */ = {isa = PBXBuildFile; fileRef = 395C8E291E71827200A68E8C /* base64url.c */; };
+		395C8E301E71827200A68E8C /* buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = 395C8E2A1E71827200A68E8C /* buffer.c */; };
+		395C8E311E71827200A68E8C /* decrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 395C8E2B1E71827200A68E8C /* decrypt.c */; };
+		395C8E321E71827200A68E8C /* keys.c in Sources */ = {isa = PBXBuildFile; fileRef = 395C8E2C1E71827200A68E8C /* keys.c */; };
+		395C8E331E71827200A68E8C /* keys.h in Headers */ = {isa = PBXBuildFile; fileRef = 395C8E2D1E71827200A68E8C /* keys.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -242,6 +249,13 @@
 		2FF825E819D3CAFF003ED08E /* NSData+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+Utils.m"; sourceTree = "<group>"; };
 		2FF825E919D3CAFF003ED08E /* NSString+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+Utils.h"; sourceTree = "<group>"; };
 		2FF825EA19D3CAFF003ED08E /* NSString+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+Utils.m"; sourceTree = "<group>"; };
+		395C8E261E71826200A68E8C /* ece.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ece.h; path = include/ece.h; sourceTree = "<group>"; };
+		395C8E281E71827200A68E8C /* aesgcm-header.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = "aesgcm-header.c"; path = "src/aesgcm-header.c"; sourceTree = "<group>"; };
+		395C8E291E71827200A68E8C /* base64url.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = base64url.c; path = src/base64url.c; sourceTree = "<group>"; };
+		395C8E2A1E71827200A68E8C /* buffer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = buffer.c; path = src/buffer.c; sourceTree = "<group>"; };
+		395C8E2B1E71827200A68E8C /* decrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = decrypt.c; path = src/decrypt.c; sourceTree = "<group>"; };
+		395C8E2C1E71827200A68E8C /* keys.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = keys.c; path = src/keys.c; sourceTree = "<group>"; };
+		395C8E2D1E71827200A68E8C /* keys.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = keys.h; path = src/keys.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -267,6 +281,7 @@
 		28F951F119D0F9FA00DCE892 = {
 			isa = PBXGroup;
 			children = (
+				395C8E251E7181FD00A68E8C /* ecec */,
 				28F951FD19D0F9FA00DCE892 /* FxA */,
 				28F9520719D0F9FB00DCE892 /* FxATests */,
 				28F951FC19D0F9FA00DCE892 /* Products */,
@@ -447,6 +462,21 @@
 			path = lib;
 			sourceTree = "<group>";
 		};
+		395C8E251E7181FD00A68E8C /* ecec */ = {
+			isa = PBXGroup;
+			children = (
+				395C8E281E71827200A68E8C /* aesgcm-header.c */,
+				395C8E291E71827200A68E8C /* base64url.c */,
+				395C8E2A1E71827200A68E8C /* buffer.c */,
+				395C8E2B1E71827200A68E8C /* decrypt.c */,
+				395C8E261E71826200A68E8C /* ece.h */,
+				395C8E2C1E71827200A68E8C /* keys.c */,
+				395C8E2D1E71827200A68E8C /* keys.h */,
+			);
+			name = ecec;
+			path = ../ThirdParty/ecec;
+			sourceTree = SOURCE_ROOT;
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -460,6 +490,7 @@
 				2FF8264419D3CAFF003ED08E /* NSData+Base32.h in Headers */,
 				2FA1801B19D3D32300F3D844 /* x509_vfy.h in Headers */,
 				2FA1801419D3D32300F3D844 /* tls1.h in Headers */,
+				395C8E271E71826200A68E8C /* ece.h in Headers */,
 				28F9520119D0F9FA00DCE892 /* FxA.h in Headers */,
 				2FA1801D19D3D32300F3D844 /* JSONWebTokenUtils.h in Headers */,
 				2FA1801A19D3D32300F3D844 /* x509.h in Headers */,
@@ -489,6 +520,7 @@
 				2FA1801319D3D32300F3D844 /* symhacks.h in Headers */,
 				2FA1800B19D3D32300F3D844 /* sha.h in Headers */,
 				2FA17FE719D3D32300F3D844 /* dtls1.h in Headers */,
+				395C8E331E71827200A68E8C /* keys.h in Headers */,
 				2FA17FD819D3D32300F3D844 /* bn.h in Headers */,
 				2FA17FE019D3D32300F3D844 /* conf_api.h in Headers */,
 				2FA1801519D3D32300F3D844 /* ts.h in Headers */,
@@ -649,10 +681,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				395C8E2E1E71827200A68E8C /* aesgcm-header.c in Sources */,
 				2FF825F219D3CAFF003ED08E /* CHNumber.m in Sources */,
 				2FF824E119D3C6D8003ED08E /* KeyPair.m in Sources */,
+				395C8E321E71827200A68E8C /* keys.c in Sources */,
 				2FF8264519D3CAFF003ED08E /* NSData+Base32.m in Sources */,
+				395C8E301E71827200A68E8C /* buffer.c in Sources */,
+				395C8E2F1E71827200A68E8C /* base64url.c in Sources */,
 				2FF824E319D3C6D8003ED08E /* PrivateKey.m in Sources */,
+				395C8E311E71827200A68E8C /* decrypt.c in Sources */,
 				2FF8264319D3CAFF003ED08E /* NSData+Base16.m in Sources */,
 				2FA1801E19D3D32300F3D844 /* JSONWebTokenUtils.m in Sources */,
 				2FF824E719D3C6D8003ED08E /* RSAKeyPair.m in Sources */,

--- a/FxA/FxA/FxA.h
+++ b/FxA/FxA/FxA.h
@@ -28,3 +28,4 @@ FOUNDATION_EXPORT const unsigned char FxAVersionString[];
 // Some are commented out because they rely on openssl/bn.h, which we can't find
 // when we try the import. *shrug*
 #include "ASNUtils.h"
+#include <FxA/ece.h>

--- a/ThirdParty/ecec/CMakeLists.txt
+++ b/ThirdParty/ecec/CMakeLists.txt
@@ -1,0 +1,60 @@
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+project(ece VERSION 0.0.1 LANGUAGES C)
+
+set(CMAKE_BUILD_TYPE Debug)
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_EXTENSIONS OFF)
+set(C_STANDARD_REQUIRED ON)
+
+include(GNUInstallDirs)
+
+find_package(OpenSSL 1.1.0 REQUIRED)
+
+enable_testing()
+
+set(ECE_SOURCES
+  src/aesgcm-header.c
+  src/base64url.c
+  src/buffer.c
+  src/decrypt.c
+  src/keys.c)
+add_library(ece ${ECE_SOURCES})
+set_target_properties(ece PROPERTIES
+  OUTPUT_NAME ece
+  VERSION "${ECE_VERSION}")
+target_include_directories(ece
+  PUBLIC include
+  PRIVATE src
+  PRIVATE ${OPENSSL_INCLUDE_DIR})
+target_link_libraries(ece PRIVATE ${OPENSSL_LIBRARIES})
+if(DEFINED ENV{COVERAGE})
+  target_compile_options(ece PUBLIC "-fprofile-arcs;-ftest-coverage")
+  target_link_libraries(ece PUBLIC --coverage)
+endif()
+
+set(ECE_DECRYPT_SOURCES
+  tools/ece-decrypt/ece-decrypt.c)
+add_executable(ece-decrypt ${ECE_DECRYPT_SOURCES})
+set_target_properties(ece-decrypt PROPERTIES EXCLUDE_FROM_ALL 1)
+target_include_directories(ece-decrypt PRIVATE tools/ece-decrypt)
+target_link_libraries(ece-decrypt PRIVATE ece)
+
+set(ECE_TEST_SOURCES
+  test/aes128gcm.c
+  test/aesgcm.c
+  test/base64url.c
+  test/test.c)
+add_executable(ece-test ${ECE_TEST_SOURCES})
+set_target_properties(ece-test PROPERTIES EXCLUDE_FROM_ALL 1)
+target_include_directories(ece-test PRIVATE test)
+target_link_libraries(ece-test PRIVATE ece)
+add_test(NAME ece-test COMMAND ece-test)
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} "--output-on-failure")
+add_dependencies(check ece-test)
+
+if(MSVC)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4 /WX")
+  target_compile_definitions(ece PUBLIC "_CRT_SECURE_NO_WARNINGS")
+else()
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -pedantic -Werror")
+endif()

--- a/ThirdParty/ecec/LICENSE
+++ b/ThirdParty/ecec/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Kit Cambridge
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ThirdParty/ecec/README.md
+++ b/ThirdParty/ecec/README.md
@@ -1,0 +1,231 @@
+# ecec
+
+[![Build Status](https://travis-ci.org/kitcambridge/ecec.svg?branch=master)](https://travis-ci.org/kitcambridge/ecec)
+[![Coverage](https://img.shields.io/codecov/c/github/kitcambridge/ecec/master.svg)](https://codecov.io/github/kitcambridge/ecec)
+
+**ecec** is a C implementation of the [HTTP Encrypted Content-Encoding](http://httpwg.org/http-extensions/draft-ietf-httpbis-encryption-encoding.html) draft. It's a port of the reference [JavaScript implementation](https://github.com/martinthomson/encrypted-content-encoding).
+
+Currently, **ecec** only implements enough to support decrypting [Web Push messages](http://webpush-wg.github.io/webpush-encryption/), which use a shared secret derived using elliptic-curve Diffie-Hellman.
+
+Encryption and usage without ECDH are planned for future releases. In the meantime, please have a look at `tools/ece-decrypt` for an example of how to use the library, or read on.
+
+## Table of Contents
+
+- [Usage](#usage)
+  * [Generating subscription keys](#generating-subscription-keys)
+  * [`aes128gcm`](#aes128gcm)
+  * [`aesgcm`](#aesgcm)
+- [Building](#building)
+  * [Dependencies](#dependencies)
+  * [macOS and \*nix](#macos-and-nix)
+  * [Windows](#windows)
+- [What is encrypted content-coding?](#what-is-encrypted-content-coding)
+  * [Web Push](#web-push)
+  * [`aes128gcm`](#aes128gcm-1)
+  * [`aesgcm`](#aesgcm-1)
+- [License](#license)
+
+## Usage
+
+### Generating subscription keys
+
+```c
+#include <ece.h>
+#include <openssl/ec.h>
+#include <openssl/ecdh.h>
+#include <openssl/rand.h>
+
+// Generate a public-private ECDH key pair for the push subscription.
+EC_KEY* subKey = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
+assert(subKey);
+assert(EC_KEY_generate_key(subKey) > 0);
+
+// Export the generated private key. The private key should never be sent to
+// the app server. It should be persisted with the endpoint and auth secret,
+// and used to decrypt all messages sent to the subscription.
+size_t subPrivKeyLen = EC_KEY_priv2oct(subKey, NULL, 0);
+assert(subPrivKeyLen);
+ece_buf_t rawSubPrivKey;
+assert(ece_buf_alloc(&rawSubPrivKey, subPrivKeyLen));
+assert(EC_KEY_priv2oct(subKey, rawSubPrivKey.bytes, rawSubPrivKey.length) ==
+       rawSubPrivKey.length);
+
+// Export the subscription public key in uncompressed form. The public key
+// should be sent to the app server, and used to encrypt messages.
+ece_buf_t rawSubPubKey;
+const EC_GROUP* subGrp = EC_KEY_get0_group(subKey);
+const EC_POINT* subPubKeyPt = EC_KEY_get0_public_key(subKey);
+size_t subPubKeyLen = EC_POINT_point2oct(subGrp, subPubKeyPt,
+                                         POINT_CONVERSION_UNCOMPRESSED, NULL,
+                                         0);
+assert(subPubKeyLen);
+assert(ece_buf_alloc(&rawSubPubKey, subPubKeyLen));
+assert(EC_POINT_point2oct(subGrp, subPubKeyPt, POINT_CONVERSION_UNCOMPRESSED,
+                          rawSubPubKey.bytes,
+                          rawSubPubKey.length) == rawSubPubKey.length);
+
+// Release the key once we're finished with it.
+EC_KEY_free(subKey);
+
+// Generate the authentication secret. The auth secret should be persisted
+// with the subscription information, and sent to the app server.
+ece_buf_t authSecret;
+assert(ece_buf_alloc(&authSecret, 16));
+assert(RAND_bytes(authSecret.bytes, authSecret.length) > 0);
+```
+
+### `aes128gcm`
+
+This is the scheme from the latest version of the encrypted content-coding draft. It's not currently supported by any encryption library or browser, but will eventually replace `aesgcm`. This scheme removes the `Crypto-Key` and `Encryption` headers. Instead, the salt, record size, and sender public key are included in the payload as a binary header block.
+
+```c
+ece_buf_t payload;
+// Set `bytes` and `length` to the contents of the encrypted payload.
+// ecec does not take ownership of the contents; it's safe for the caller to
+// free the contents after decryption.
+payload.bytes = NULL;
+payload.length = 0;
+
+// The plaintext is reset before decryption, and freed on error. If decryption
+// succeeds, we take ownership of the contents. The contents are allocated with
+// `malloc`, so it's safe to transfer ownership to functions that call
+// `free(plaintext.bytes)`.
+ece_buf_t plaintext;
+
+int err =
+  ece_aes128gcm_decrypt(&rawSubPrivKey, &authSecret, &payload, &plaintext);
+
+assert(!err);
+ece_buf_free(&plaintext);
+```
+
+### `aesgcm`
+
+All [Web Push libraries](https://github.com/web-push-libs) support the "aesgcm" scheme, as well as Firefox 46+ and Chrome 50+. The app server includes its public key in the `Crypto-Key` HTTP header, the salt and record size in the `Encryption` header, and the encrypted payload in the body of the `POST` request.
+
+* The `Crypto-Key` header comprises one or more comma-delimited parameters. The first parameter must include a `dh` name-value pair, containing the sender's Base64url-encoded public key.
+* The `Encryption` header must include a `salt` name-value pair containing the sender's Base64url-encoded salt, and an optional `rs` pair specifying the record size.
+
+If the `Crypto-Key` header contains multiple keys, the sender must also include a `keyid` to match the encryption parameters to the key. The drafts have examples for [a single key without a `keyid`](https://tools.ietf.org/html/draft-ietf-webpush-encryption-04#section-5), and [multiple keys with `keyid`s](https://tools.ietf.org/html/draft-ietf-httpbis-encryption-encoding-02#section-5.6).
+
+**ecec** will extract the relevant parameters from the `Crypto-Key` and `Encryption` headers before decrypting the message. You don't need to parse the headers yourself.
+
+```c
+const char* cryptoKeyHeader = "dh=...";
+const char* encryptionHeader = "salt=...; rs=...";
+
+// The same ownership rules apply as for `ece_aes128gcm_decrypt`.
+ece_buf_t ciphertext;
+ciphertext.bytes = NULL;
+ciphertext.length = 0;
+
+ece_buf_t plaintext;
+
+int err = ece_aesgcm_decrypt(&rawSubPrivKey, &authSecret, cryptoKeyHeader,
+                             encryptionHeader, &ciphertext, &plaintext);
+
+assert(!err);
+ece_buf_free(&plaintext);
+```
+
+## Building
+
+### Dependencies
+
+* [OpenSSL](https://www.openssl.org/) 1.1.0 or higher
+* [CMake](https://cmake.org/) 3.1 or higher
+* A C99-capable compiler, like [Clang](https://clang.llvm.org/) 3.4, [GCC](https://gcc.gnu.org/) 4.6, or [Visual Studio](https://www.visualstudio.com/vs/community/) 2015
+
+### macOS and \*nix
+
+OpenSSL 1.1.0 is new, and backward-incompatible with 1.0.x. If your package manager ([MacPorts](https://www.macports.org/), [Homebrew](https://brew.sh/), [APT](https://help.ubuntu.com/community/AptGet/Howto), [DNF](https://dnf.readthedocs.io/en/latest/), [yum](http://yum.baseurl.org/)) doesn't have 1.1.0 yet, you'll need to compile it yourself. **ecec** does this to run its tests on [Travis CI](https://docs.travis-ci.com/user/ci-environment/); please see `.travis.yml` for the commands.
+
+In particular, you'll need to set the `OPENSSL_ROOT_DIR` cache entry for CMake to find your compiled version. To build the library:
+
+```shell
+> mkdir build
+> cd build
+> cmake -DOPENSSL_ROOT_DIR=/usr/local ..
+> make
+```
+
+To build the decryption tool:
+
+```shell
+> make ece-decrypt
+> ./ece-decrypt
+```
+
+To run the tests:
+
+```shell
+> make check
+```
+
+### Windows
+
+[Shining Light](https://slproweb.com/products/Win32OpenSSL.html) provides OpenSSL binaries for Windows. The installer will ask if you want to copy the OpenSSL DLLs into the system directory, or the OpenSSL binaries directory. If you choose the binaries directory, you'll need to add it to your `Path`.
+
+To do so, right-click the Start button, navigate to "System" > "Advanced system settings" > "Environment Variables...", find `Path` under "System variables", click "Edit" > "New", and enter the directory name. This will be `C:\OpenSSL-Win64\bin` if you've installed the 64-bit version in the default location.
+
+You can then build the library like so:
+
+```powershell
+> mkdir build
+> cd build
+> cmake -G "Visual Studio 14 2015 Win64" -DOPENSSL_ROOT_DIR=C:\OpenSSL-Win64 ..
+> cmake --build .
+```
+
+To build the decryption tool:
+
+```powershell
+> cmake --build . --target ece-decrypt
+> .\Debug\ece-decrypt
+```
+
+To run the tests:
+
+```powershell
+> cmake --build . --target check
+```
+
+## What is encrypted content-coding?
+
+Like [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security), encrypted content-coding uses Diffie-Hellman key exchange to derive a shared secret, which, in turn, is used to derive a symmetric encryption key for a block cipher. This encoding uses [ECDH](https://en.wikipedia.org/wiki/Elliptic_curve_Diffie-Hellman) for key exchange, and [AES](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard) [GCM](https://en.wikipedia.org/wiki/Galois/Counter_Mode) for the block cipher.
+
+Key exchange is a process where a sender and a receiver generate public-private key pairs, then exchange public keys. The sender combines the receiver's public key with its own private key to obtain a secret. Meanwhile, the receiver combines the sender's public key with its private key to obtain the same secret. [Wikipedia](https://en.wikipedia.org/wiki/Diffie–Hellman_key_exchange) has a good visual explanation.
+
+The shared ECDH secret isn't directly usable as an encryption key. Instead, both the sender and receiver combine the shared ECDH secret with an [authentication secret](https://tools.ietf.org/html/draft-ietf-webpush-encryption-08#section-3.2), to produce a 32-byte pseudorandom key (PRK). The auth secret is a random 16-byte array generated by the receiver, and shared with the sender along with the receiver's public key. Both parties use [HKDF](https://tools.ietf.org/html/rfc5869) to derive the PRK from the ECDH secret, using the formula `PRK = HKDF-Expand(HKDF-Extract(authSecret, sharedSecret), prkInfo, 32)`. RFC 5869 describes the inputs to `HKDF-Expand` and `HKDF-Extract`, and how they work. `prkInfo` is different depending on the encryption scheme used; more on that later.
+
+Next, the sender and receiver combine the PRK with a random 16-byte salt. The salt is generated by the sender, and shared with the receiver as part of the message payload. The PRK undergoes two rounds of HKDF to derive the symmetric key and nonce: `key = HKDF-Expand(HKDF-Extract(salt, PRK), keyInfo, 16)`, and `nonce = HKDF-Expand(HKDF-Extract(salt, PRK), nonceInfo, 12)`. As with `prkInfo` above, `keyInfo` and `nonceInfo` are different depending on the exact scheme.
+
+Finally, the sender chunks the plaintext into fixed-size records, and includes this size in the message payload as the `rs`. The chunks are numbered 0 to N; this is called the sequence number (SEQ), and is used to derive the [IV](https://en.wikipedia.org/wiki/Initialization_vector). All chunks should be `rs` bytes long, but the final chunk can be smaller if needed.
+
+Each plaintext chunk is padded, then encrypted with AES using the 16-byte symmetric key and a 12-byte IV. The IV is [generated](https://tools.ietf.org/html/draft-ietf-httpbis-encryption-encoding-07#section-2.3) from the nonce by [XOR-ing](https://en.wikipedia.org/wiki/Exclusive_or) the last 6 bytes of the 12-byte nonce with the sequence number. Afterward, the sender appends the GCM authentication tag to the encrypted chunk, producing the final encrypted record.
+
+To decrypt the message, the receiver chunks the ciphertext into N encrypted records, decrypts each chunk, validates the auth tag, and removes the padding.
+
+### Web Push
+
+In Web Push, the app server is the sender, and the browser ("user agent") is the receiver. The browser generates a public-private ECDH key pair and 16-byte auth secret for each push subscription. These keys are static; they're used to decrypt all messages sent to this subscription. The browser exposes the subscription endpoint, public key, and auth secret to the web app via the [Push DOM API](https://w3c.github.io/push-api/). The web app then delivers the endpoint and keys to the app server.
+
+When the app server wants to send a push message, it generates its own public-private key pair, and computes the shared ECDH secret using the subscription public key. This key pair is ephemeral: it should be discarded after the message is sent, and a new key pair used for the next message. The app server encrypts the payload using the process outlined above, and includes the salt, sender public key, and ciphertext in a `POST` request to the endpoint. The push endpoint relays the encrypted payload to the browser. Finally, the browser decrypts the payload with the subscription private key, and delivers the plaintext to the web app. Because the endpoint doesn't know the private key, it can't decrypt or tamper with the message.
+
+### `aes128gcm`
+
+* `prkInfo` is the string `"WebPush: info\0"`, followed by the receiver and sender public keys in uncompressed form. Unlike `aesgcm`, these are not length-prefixed.
+* `keyInfo` is the static string `"Content-Encoding: aes128gcm\0"`.
+* `nonceInfo` is the static string `"Content-Encoding: nonce\0"`.
+* Padding is at the end of each plaintext chunk. The padding block comprises the delimiter, which is `0x02` for the last chunk, and `0x01` for the other chunks. Up to `rs - 16` bytes of `0x0` padding can follow the delimiter.
+
+### `aesgcm`
+
+* `prkInfo` is the static string `"Content-Encoding: auth\0"`.
+* `keyInfo` is `"Content-Encoding: aesgcm\0P-256\0"`, followed by the length-prefixed (unsigned 16-bit integers) receiver and sender public keys in uncompressed form.
+* `nonceInfo` is `"Content-Encoding: nonce\0P-256\0"`, followed by the length-prefixed public keys in the same form as `keyInfo`.
+* Padding is at the beginning of each plaintext chunk. The padding block comprises the number (unsigned 16-bit integer) of padding bytes, followed by that many `0x0`-valued bytes.
+
+## License
+
+MIT.

--- a/ThirdParty/ecec/include/ece.h
+++ b/ThirdParty/ecec/include/ece.h
@@ -1,0 +1,149 @@
+#ifndef ECE_H
+#define ECE_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define ECE_TAG_LENGTH 16
+#define ECE_KEY_LENGTH 16
+#define ECE_NONCE_LENGTH 12
+#define ECE_SHA_256_LENGTH 32
+
+#define ECE_AES128GCM_HEADER_SIZE 21
+#define ECE_AESGCM_PAD_SIZE 2
+#define ECE_AESGCM_KEY_LENGTH_SIZE 2
+
+// HKDF info strings for the "aesgcm" scheme.
+#define ECE_AESGCM_WEB_PUSH_PRK_INFO "Content-Encoding: auth\0"
+#define ECE_AESGCM_WEB_PUSH_PRK_INFO_LENGTH 23
+#define ECE_AESGCM_WEB_PUSH_KEY_INFO_PREFIX "Content-Encoding: aesgcm\0P-256\0"
+#define ECE_AESGCM_WEB_PUSH_KEY_INFO_PREFIX_LENGTH 31
+#define ECE_AESGCM_WEB_PUSH_NONCE_INFO_PREFIX "Content-Encoding: nonce\0P-256\0"
+#define ECE_AESGCM_WEB_PUSH_NONCE_INFO_PREFIX_LENGTH 30
+
+// HKDF info strings for the shared secret, encryption key, and nonce for the
+// "aes128gcm" scheme. Note that the length includes the NUL terminator.
+#define ECE_AES128GCM_WEB_PUSH_PRK_INFO_PREFIX "WebPush: info\0"
+#define ECE_AES128GCM_WEB_PUSH_PRK_INFO_PREFIX_LENGTH 14
+#define ECE_AES128GCM_KEY_INFO "Content-Encoding: aes128gcm\0"
+#define ECE_AES128GCM_KEY_INFO_LENGTH 28
+#define ECE_AES128GCM_NONCE_INFO "Content-Encoding: nonce\0"
+#define ECE_AES128GCM_NONCE_INFO_LENGTH 24
+
+#define ECE_OK 0
+#define ECE_ERROR_OUT_OF_MEMORY -1
+#define ECE_INVALID_RECEIVER_PRIVATE_KEY -2
+#define ECE_INVALID_SENDER_PUBLIC_KEY -3
+#define ECE_ERROR_COMPUTE_SECRET -4
+#define ECE_ERROR_ENCODE_RECEIVER_PUBLIC_KEY -5
+#define ECE_ERROR_ENCODE_SENDER_PUBLIC_KEY -6
+#define ECE_ERROR_DECRYPT -7
+#define ECE_ERROR_DECRYPT_PADDING -8
+#define ECE_ERROR_ZERO_PLAINTEXT -9
+#define ECE_ERROR_SHORT_BLOCK -10
+#define ECE_ERROR_SHORT_HEADER -11
+#define ECE_ERROR_ZERO_CIPHERTEXT -12
+#define ECE_ERROR_HKDF -14
+#define ECE_ERROR_INVALID_ENCRYPTION_HEADER -15
+#define ECE_ERROR_INVALID_CRYPTO_KEY_HEADER -16
+#define ECE_ERROR_INVALID_RS -17
+#define ECE_ERROR_INVALID_SALT -18
+#define ECE_ERROR_INVALID_DH -19
+#define ECE_ERROR_INVALID_BASE64URL -20
+
+// Annotates a variable or parameter as unused to avoid compiler warnings.
+#define ECE_UNUSED(x) (void) (x)
+
+// A buffer data type, inspired by libuv's `uv_buf_t`.
+typedef struct ece_buf_s {
+  uint8_t* bytes;
+  size_t length;
+} ece_buf_t;
+
+// The policy for handling trailing "=" characters in Base64url-encoded input.
+typedef enum ece_base64url_decode_policy_e {
+  // Fails decoding if the input is unpadded. RFC 4648, section 3.2 requires
+  // padding, unless the referring specification prohibits it.
+  ECE_BASE64URL_REQUIRE_PADDING,
+
+  // Tolerates padded and unpadded input.
+  ECE_BASE64URL_IGNORE_PADDING,
+
+  // Fails decoding if the input is padded. This follows the strict Base64url
+  // variant used in JWS (RFC 7515, Appendix C) and Web Push Message Encryption.
+  ECE_BASE64URL_REJECT_PADDING,
+} ece_base64url_decode_policy_t;
+
+// Decrypts a payload encrypted with the "aes128gcm" scheme.
+int
+ece_aes128gcm_decrypt(
+  // The ECDH private key for the push subscription, encoded as an octet
+  // string.
+  const ece_buf_t* rawRecvPrivKey,
+  // The 16-byte shared authentication secret.
+  const ece_buf_t* authSecret,
+  // The encrypted payload.
+  const ece_buf_t* payload,
+  // An in-out parameter to hold the plaintext. The buffer is reset before
+  // decryption, and freed if an error occurs. If decryption succeeds, the
+  // caller takes ownership of the buffer, and should free it when it's done.
+  ece_buf_t* plaintext);
+
+// Decrypts a payload encrypted with the "aesgcm" scheme.
+int
+ece_aesgcm_decrypt(
+  // The ECDH private key for the push subscription, encoded as an octet
+  // string.
+  const ece_buf_t* rawRecvPrivKey,
+  // The 16-byte shared authentication secret.
+  const ece_buf_t* authSecret,
+  // The value of the sender's `Crypto-Key` HTTP header.
+  const char* cryptoKeyHeader,
+  // The value of the sender's `Encryption` HTTP header.
+  const char* encryptionHeader,
+  // The encrypted message.
+  const ece_buf_t* ciphertext,
+  // An in-out parameter to hold the plaintext. The same ownership rules apply
+  // as for `ece_aes128gcm_decrypt`.
+  ece_buf_t* plaintext);
+
+// Extracts the ephemeral public key, salt, and record size from the sender's
+// `Crypto-Key` and `Encryption` headers. The caller takes ownership of `salt`
+// and `rawSenderPubKey` if parsing succeeds.
+int
+ece_header_extract_aesgcm_crypto_params(const char* cryptoKeyHeader,
+                                        const char* encryptionHeader,
+                                        uint32_t* rs, ece_buf_t* salt,
+                                        ece_buf_t* rawSenderPubKey);
+
+// Initializes a buffer with the requested length.
+bool
+ece_buf_alloc(ece_buf_t* buf, size_t length);
+
+// Resets a buffer's byte array and length to zero. This does not automatically
+// free the backing array if one was set before.
+void
+ece_buf_reset(ece_buf_t* buf);
+
+// Creates and returns a slice of an existing buffer. Freeing the backing memory
+// will invalidate all its slices.
+void
+ece_buf_slice(const ece_buf_t* buf, size_t start, size_t end, ece_buf_t* slice);
+
+// Frees a buffer's backing memory and resets its length.
+void
+ece_buf_free(ece_buf_t* buf);
+
+// Decodes a Base64url-encoded (RFC 4648) string into `binary`.
+int
+ece_base64url_decode(const char* base64, size_t base64Len,
+                     ece_base64url_decode_policy_t policy, ece_buf_t* binary);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* ECE_H */

--- a/ThirdParty/ecec/src/aesgcm-header.c
+++ b/ThirdParty/ecec/src/aesgcm-header.c
@@ -1,0 +1,458 @@
+#include "ece.h"
+
+// This file implements a parser for the `Crypto-Key` and `Encryption` HTTP
+// headers, used by the older "aesgcm" encoding. The newer "aes128gcm" encoding
+// includes the relevant information in a binary header, directly in the
+// payload.
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define ECE_HEADER_STATE_BEGIN_PARAM 1
+#define ECE_HEADER_STATE_BEGIN_NAME 2
+#define ECE_HEADER_STATE_NAME 3
+#define ECE_HEADER_STATE_END_NAME 4
+#define ECE_HEADER_STATE_BEGIN_VALUE 5
+#define ECE_HEADER_STATE_VALUE 6
+#define ECE_HEADER_STATE_BEGIN_QUOTED_VALUE 7
+#define ECE_HEADER_STATE_QUOTED_VALUE 8
+#define ECE_HEADER_STATE_END_VALUE 9
+#define ECE_HEADER_STATE_INVALID_HEADER 10
+
+// A linked list that holds name-value pairs for a parameter in a header
+// value. For example, if the parameter is `a=b; c=d; e=f`, the parser will
+// allocate three `ece_header_pairs_t` structures, one for each ;-delimited
+// pair. "=" separates the name and value.
+typedef struct ece_header_pairs_s {
+  // The name and value are pointers into the backing header value; the parser
+  // doesn't allocate new strings. Freeing the backing string will invalidate
+  // all `name` and `value` references. Also, because these are not true C
+  // strings, it's important to use them with functions that take a length, like
+  // `strncmp`. Functions that assume a NUL-terminated string will read until
+  // the end of the backing string.
+  const char* name;
+  size_t nameLen;
+  const char* value;
+  size_t valueLen;
+  struct ece_header_pairs_s* next;
+} ece_header_pairs_t;
+
+// Initializes a name-value pair node at the head of the pair list. `head` may
+// be `NULL`.
+static ece_header_pairs_t*
+ece_header_pairs_alloc(ece_header_pairs_t* head) {
+  ece_header_pairs_t* pairs =
+    (ece_header_pairs_t*) malloc(sizeof(ece_header_pairs_t));
+  if (!pairs) {
+    return NULL;
+  }
+  pairs->name = NULL;
+  pairs->nameLen = 0;
+  pairs->value = NULL;
+  pairs->valueLen = 0;
+  pairs->next = head;
+  return pairs;
+}
+
+// Indicates whether a name-value pair node matches the `name`.
+static inline bool
+ece_header_pairs_has_name(ece_header_pairs_t* pair, const char* name) {
+  return !strncmp(pair->name, name, pair->nameLen);
+}
+
+// Indicates whether a name-value pair node matches the `value`.
+static inline bool
+ece_header_pairs_has_value(ece_header_pairs_t* pair, const char* value) {
+  return !strncmp(pair->value, value, pair->valueLen);
+}
+
+// Copies a pair node's value into a C string.
+static char*
+ece_header_pairs_value_to_str(ece_header_pairs_t* pair) {
+  char* value = (char*) malloc(pair->valueLen + 1);
+  strncpy(value, pair->value, pair->valueLen);
+  value[pair->valueLen] = '\0';
+  return value;
+}
+
+// Frees a name-value pair list and all its nodes.
+static void
+ece_header_pairs_free(ece_header_pairs_t* pairs) {
+  ece_header_pairs_t* pair = pairs;
+  while (pair) {
+    ece_header_pairs_t* next = pair->next;
+    free(pair);
+    pair = next;
+  }
+}
+
+// A linked list that holds parameters extracted from a header value. For
+// example, if the header value is `a=b; c=d, e=f; g=h`, the parser will
+// allocate two `ece_header_params_t` structures: one to hold the parameter
+// `a=b; c=d`, and the other to hold `e=f; g=h`.
+typedef struct ece_header_params_s {
+  ece_header_pairs_t* pairs;
+  struct ece_header_params_s* next;
+} ece_header_params_t;
+
+// Initializes a parameter node at the head of the parameter list. `head` may be
+// `NULL`.
+static ece_header_params_t*
+ece_header_params_alloc(ece_header_params_t* head) {
+  ece_header_params_t* params =
+    (ece_header_params_t*) malloc(sizeof(ece_header_params_t));
+  if (!params) {
+    return NULL;
+  }
+  params->pairs = NULL;
+  params->next = head;
+  return params;
+}
+
+// Reverses a parameter list in-place and returns a pointer to the new head.
+static ece_header_params_t*
+ece_header_params_reverse(ece_header_params_t* params) {
+  ece_header_params_t* sibling = NULL;
+  while (params) {
+    ece_header_params_t* next = params->next;
+    params->next = sibling;
+    sibling = params;
+    params = next;
+  }
+  return sibling;
+}
+
+// Frees a parameter list and all its nodes.
+static void
+ece_header_params_free(ece_header_params_t* params) {
+  ece_header_params_t* param = params;
+  while (param) {
+    ece_header_pairs_free(param->pairs);
+    ece_header_params_t* next = param->next;
+    free(param);
+    param = next;
+  }
+}
+
+// Indicates whether `c` is whitespace, per `WSP` in RFC 5234, Appendix B.1.
+static inline bool
+ece_header_is_space(char c) {
+  return c == ' ' || c == '\t';
+}
+
+// Indicates whether `c` can appear in a pair name. Only lowercase letters and
+// numbers are allowed.
+static inline bool
+ece_header_is_valid_pair_name(char c) {
+  return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
+}
+
+// Indicates whether `c` can appear in a pair value. This includes all
+// characters in the Base64url alphabet.
+static inline bool
+ece_header_is_valid_pair_value(char c) {
+  return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+         (c >= '0' && c <= '9') || c == '-' || c == '_';
+}
+
+// A header parameter parser.
+typedef struct ece_header_parser_s {
+  int state;
+  ece_header_params_t* params;
+} ece_header_parser_t;
+
+// Parses the next token in `input` and updates the parser state. Returns true
+// if the caller should advance to the next character; false otherwise.
+static bool
+ece_header_parse(ece_header_parser_t* parser, const char* input) {
+  switch (parser->state) {
+  case ECE_HEADER_STATE_BEGIN_PARAM: {
+    ece_header_params_t* param = ece_header_params_alloc(parser->params);
+    if (!param) {
+      break;
+    }
+    parser->params = param;
+    parser->state = ECE_HEADER_STATE_BEGIN_NAME;
+    return false;
+  }
+
+  case ECE_HEADER_STATE_BEGIN_NAME:
+    if (ece_header_is_space(*input)) {
+      return true;
+    }
+    if (ece_header_is_valid_pair_name(*input)) {
+      ece_header_pairs_t* pair = ece_header_pairs_alloc(parser->params->pairs);
+      if (!pair) {
+        break;
+      }
+      parser->params->pairs = pair;
+      pair->name = input;
+      parser->state = ECE_HEADER_STATE_NAME;
+      return false;
+    }
+    break;
+
+  case ECE_HEADER_STATE_NAME:
+    if (ece_header_is_valid_pair_name(*input)) {
+      parser->params->pairs->nameLen++;
+      return true;
+    }
+    if (ece_header_is_space(*input) || *input == '=') {
+      parser->state = ECE_HEADER_STATE_END_NAME;
+      return false;
+    }
+    break;
+
+  case ECE_HEADER_STATE_END_NAME:
+    if (ece_header_is_space(*input)) {
+      return true;
+    }
+    if (*input == '=') {
+      parser->state = ECE_HEADER_STATE_BEGIN_VALUE;
+      return true;
+    }
+    break;
+
+  case ECE_HEADER_STATE_BEGIN_VALUE:
+    if (ece_header_is_space(*input)) {
+      return true;
+    }
+    if (ece_header_is_valid_pair_value(*input)) {
+      parser->params->pairs->value = input;
+      parser->state = ECE_HEADER_STATE_VALUE;
+      return false;
+    }
+    if (*input == '"') {
+      parser->state = ECE_HEADER_STATE_BEGIN_QUOTED_VALUE;
+      return true;
+    }
+    break;
+
+  case ECE_HEADER_STATE_VALUE:
+    if (ece_header_is_space(*input) || *input == ';' || *input == ',') {
+      parser->state = ECE_HEADER_STATE_END_VALUE;
+      return false;
+    }
+    if (ece_header_is_valid_pair_value(*input)) {
+      parser->params->pairs->valueLen++;
+      return true;
+    }
+    break;
+
+  case ECE_HEADER_STATE_BEGIN_QUOTED_VALUE:
+    if (ece_header_is_valid_pair_value(*input)) {
+      // Quoted strings allow spaces and escapes, but neither `Crypto-Key` nor
+      // `Encryption` accept them. We keep the parser simple by rejecting
+      // non-Base64url characters here. We also disallow empty quoted strings.
+      parser->params->pairs->value = input;
+      parser->params->pairs->valueLen++;
+      parser->state = ECE_HEADER_STATE_QUOTED_VALUE;
+      return true;
+    }
+    break;
+
+  case ECE_HEADER_STATE_QUOTED_VALUE:
+    if (ece_header_is_valid_pair_value(*input)) {
+      parser->params->pairs->valueLen++;
+      return true;
+    }
+    if (*input == '"') {
+      parser->state = ECE_HEADER_STATE_END_VALUE;
+      return true;
+    }
+    break;
+
+  case ECE_HEADER_STATE_END_VALUE:
+    if (ece_header_is_space(*input)) {
+      return true;
+    }
+    if (*input == ';') {
+      // New name-value pair for the same parameter. Advance the parser;
+      // `ECE_HEADER_STATE_BEGIN_NAME` will prepend a new node to the pairs
+      // list.
+      parser->state = ECE_HEADER_STATE_BEGIN_NAME;
+      return true;
+    }
+    if (*input == ',') {
+      // New parameter. Advance the parser; `ECE_HEADER_STATE_BEGIN_PARAM` will
+      // prepend a new node to the parameters list and begin parsing its pairs.
+      parser->state = ECE_HEADER_STATE_BEGIN_PARAM;
+      return true;
+    }
+    break;
+
+  default:
+    // Unexpected parser state.
+    assert(false);
+  }
+  parser->state = ECE_HEADER_STATE_INVALID_HEADER;
+  return false;
+}
+
+// Parses a `header` value of the form `a=b; c=d; e=f, g=h, i=j` into a
+// parameter list.
+static ece_header_params_t*
+ece_header_extract_params(const char* header) {
+  ece_header_parser_t parser;
+  parser.state = ECE_HEADER_STATE_BEGIN_PARAM;
+  parser.params = NULL;
+
+  const char* input = header;
+  while (*input) {
+    if (ece_header_parse(&parser, input)) {
+      input++;
+    }
+    if (parser.state == ECE_HEADER_STATE_INVALID_HEADER) {
+      goto error;
+    }
+  }
+  if (parser.state != ECE_HEADER_STATE_END_VALUE) {
+    // If the header ends with an unquoted value, the parser might still be in a
+    // non-terminal state. Try to parse an extra space to reach the terminal
+    // state.
+    ece_header_parse(&parser, " ");
+    if (parser.state != ECE_HEADER_STATE_END_VALUE) {
+      // If we're still in a non-terminal state, the header is incomplete.
+      goto error;
+    }
+  }
+  return ece_header_params_reverse(parser.params);
+
+error:
+  ece_header_params_free(parser.params);
+  return NULL;
+}
+
+int
+ece_header_extract_aesgcm_crypto_params(const char* cryptoKeyHeader,
+                                        const char* encryptionHeader,
+                                        uint32_t* rs, ece_buf_t* salt,
+                                        ece_buf_t* rawSenderPubKey) {
+  int err = ECE_OK;
+
+  ece_buf_reset(salt);
+  ece_buf_reset(rawSenderPubKey);
+
+  ece_header_params_t* encryptionParams = NULL;
+  ece_header_params_t* cryptoKeyParams = NULL;
+  char* keyId = NULL;
+
+  // The record size defaults to 4096 if unspecified.
+  *rs = 4096;
+
+  // First, extract the key ID, salt, and record size from the first key in the
+  // `Encryption` header.
+  encryptionParams = ece_header_extract_params(encryptionHeader);
+  if (!encryptionParams) {
+    err = ECE_ERROR_INVALID_ENCRYPTION_HEADER;
+    goto error;
+  }
+  for (ece_header_pairs_t* pair = encryptionParams->pairs; pair;
+       pair = pair->next) {
+    if (ece_header_pairs_has_name(pair, "keyid")) {
+      keyId = ece_header_pairs_value_to_str(pair);
+      if (!keyId) {
+        // The key ID is optional, and is used to identify the public key in the
+        // `Crypto-Key` header if multiple encryption keys are specified.
+        err = ECE_ERROR_OUT_OF_MEMORY;
+        goto error;
+      }
+      continue;
+    }
+    if (ece_header_pairs_has_name(pair, "rs")) {
+      // The record size is optional.
+      char* value = ece_header_pairs_value_to_str(pair);
+      if (!value) {
+        err = ECE_ERROR_INVALID_RS;
+        goto error;
+      }
+      int result = sscanf(value, "%" SCNu32, rs);
+      free(value);
+      if (result <= 0 || !*rs) {
+        err = ECE_ERROR_INVALID_RS;
+        goto error;
+      }
+      continue;
+    }
+    if (ece_header_pairs_has_name(pair, "salt")) {
+      // The salt is required, and must be Base64url-encoded without padding.
+      if (ece_base64url_decode(pair->value, pair->valueLen,
+                               ECE_BASE64URL_REJECT_PADDING, salt)) {
+        err = ECE_ERROR_INVALID_SALT;
+        goto error;
+      }
+      continue;
+    }
+  }
+  if (!salt) {
+    err = ECE_ERROR_INVALID_SALT;
+    goto error;
+  }
+
+  // Next, find the ephemeral public key in the `Crypto-Key` header.
+  cryptoKeyParams = ece_header_extract_params(cryptoKeyHeader);
+  if (!cryptoKeyParams) {
+    err = ECE_ERROR_INVALID_CRYPTO_KEY_HEADER;
+    goto error;
+  }
+  ece_header_params_t* cryptoKeyParam = cryptoKeyParams;
+  if (keyId) {
+    // If the sender specified a key ID in the `Encryption` header, find the
+    // matching parameter in the `Crypto-Key` header. Otherwise, we assume
+    // there's only one key, and use the first one we see.
+    while (cryptoKeyParam) {
+      bool keyIdMatches = false;
+      for (ece_header_pairs_t* pair = cryptoKeyParam->pairs; pair;
+           pair = pair->next) {
+        if (!ece_header_pairs_has_name(pair, "keyid")) {
+          continue;
+        }
+        keyIdMatches = ece_header_pairs_has_value(pair, keyId);
+        if (keyIdMatches) {
+          break;
+        }
+      }
+      if (keyIdMatches) {
+        break;
+      }
+      cryptoKeyParam = cryptoKeyParam->next;
+    }
+    if (!cryptoKeyParam) {
+      // We don't have a matching key ID with a `dh` name-value pair.
+      err = ECE_ERROR_INVALID_DH;
+      goto error;
+    }
+  }
+  for (ece_header_pairs_t* pair = cryptoKeyParam->pairs; pair;
+       pair = pair->next) {
+    if (!ece_header_pairs_has_name(pair, "dh")) {
+      continue;
+    }
+    // The sender's public key must be Base64url-encoded without padding.
+    if (ece_base64url_decode(pair->value, pair->valueLen,
+                             ECE_BASE64URL_REJECT_PADDING, rawSenderPubKey)) {
+      err = ECE_ERROR_INVALID_DH;
+      goto error;
+    }
+    break;
+  }
+  if (!rawSenderPubKey) {
+    err = ECE_ERROR_INVALID_DH;
+    goto error;
+  }
+  goto end;
+
+error:
+  *rs = 0;
+  ece_buf_free(salt);
+  ece_buf_free(rawSenderPubKey);
+
+end:
+  ece_header_params_free(encryptionParams);
+  ece_header_params_free(cryptoKeyParams);
+  free(keyId);
+  return err;
+}

--- a/ThirdParty/ecec/src/base64url.c
+++ b/ThirdParty/ecec/src/base64url.c
@@ -1,0 +1,141 @@
+#include "ece.h"
+
+// This file implements a Base64url decoder per RFC 4648. Originally implemented
+// in https://bugzilla.mozilla.org/show_bug.cgi?id=1256488; ported from Firefox
+// with minimal changes.
+
+#include <assert.h>
+#include <stdbool.h>
+
+// Maps an encoded character to a value in the Base64 URL alphabet, per
+// RFC 4648, Table 2. Invalid input characters map to UINT8_MAX.
+static const uint8_t ece_base64url_decode_table[] = {
+  255, 255, 255, 255, 255,        255, 255, 255, 255, 255,        255, 255,
+  255, 255, 255, 255, 255,        255, 255, 255, 255, 255,        255, 255,
+  255, 255, 255, 255, 255,        255, 255, 255, 255, 255,        255, 255,
+  255, 255, 255, 255, 255,        255, 255, 255, 255, 62 /* - */, 255, 255,
+  52,  53,  54,  55,  56,         57,  58,  59,  60,  61, /* 0 - 9 */
+  255, 255, 255, 255, 255,        255, 255, 0,   1,   2,          3,   4,
+  5,   6,   7,   8,   9,          10,  11,  12,  13,  14,         15,  16,
+  17,  18,  19,  20,  21,         22,  23,  24,  25, /* A - Z */
+  255, 255, 255, 255, 63 /* _ */, 255, 26,  27,  28,  29,         30,  31,
+  32,  33,  34,  35,  36,         37,  38,  39,  40,  41,         42,  43,
+  44,  45,  46,  47,  48,         49,  50,  51, /* a - z */
+  255, 255, 255, 255,
+};
+
+static inline bool
+ece_base64url_decode_lookup(char c, uint8_t* b) {
+  uint8_t index = (uint8_t) c;
+  *b = ece_base64url_decode_table[index & 0x7f];
+  return (*b != 255) && !(*b & ~0x7f);
+}
+
+int
+ece_base64url_decode(const char* base64, size_t base64Len,
+                     ece_base64url_decode_policy_t paddingPolicy,
+                     ece_buf_t* result) {
+  int err = ECE_OK;
+
+  ece_buf_reset(result);
+
+  // Don't decode empty strings.
+  if (!base64Len) {
+    goto end;
+  }
+
+  // Check for overflow.
+  if (base64Len > UINT32_MAX / 3) {
+    err = ECE_ERROR_OUT_OF_MEMORY;
+    goto error;
+  }
+
+  // The decoded length may be 1-2 bytes over, depending on the final quantum.
+  size_t binaryLen = (base64Len * 3) / 4;
+
+  // Determine whether to check for and ignore trailing padding.
+  bool maybePadded = false;
+  switch (paddingPolicy) {
+  case ECE_BASE64URL_REQUIRE_PADDING:
+    if (base64Len % 4) {
+      // Padded input length must be a multiple of 4.
+      err = ECE_ERROR_INVALID_BASE64URL;
+      goto error;
+    }
+    maybePadded = true;
+    break;
+
+  case ECE_BASE64URL_IGNORE_PADDING:
+    // Check for padding only if the length is a multiple of 4.
+    maybePadded = !(base64Len % 4);
+    break;
+
+  // If we're expecting unpadded input, no need for additional checks.
+  // `=` isn't in the decode table, so padded strings will fail to decode.
+  default:
+    // Invalid decode padding policy.
+    assert(false);
+  case ECE_BASE64URL_REJECT_PADDING:
+    break;
+  }
+  if (maybePadded && base64[base64Len - 1] == '=') {
+    if (base64[base64Len - 2] == '=') {
+      base64Len -= 2;
+    } else {
+      base64Len -= 1;
+    }
+  }
+
+  if (!ece_buf_alloc(result, binaryLen)) {
+    err = ECE_ERROR_OUT_OF_MEMORY;
+    goto error;
+  }
+  uint8_t* binary = result->bytes;
+
+  for (; base64Len >= 4; base64Len -= 4) {
+    uint8_t w, x, y, z;
+    if (!ece_base64url_decode_lookup(*base64++, &w) ||
+        !ece_base64url_decode_lookup(*base64++, &x) ||
+        !ece_base64url_decode_lookup(*base64++, &y) ||
+        !ece_base64url_decode_lookup(*base64++, &z)) {
+      err = ECE_ERROR_INVALID_BASE64URL;
+      goto error;
+    }
+    *binary++ = w << 2 | x >> 4;
+    *binary++ = x << 4 | y >> 2;
+    *binary++ = y << 6 | z;
+  }
+
+  if (base64Len == 3) {
+    uint8_t w, x, y;
+    if (!ece_base64url_decode_lookup(*base64++, &w) ||
+        !ece_base64url_decode_lookup(*base64++, &x) ||
+        !ece_base64url_decode_lookup(*base64++, &y)) {
+      err = ECE_ERROR_INVALID_BASE64URL;
+      goto error;
+    }
+    *binary++ = w << 2 | x >> 4;
+    *binary++ = x << 4 | y >> 2;
+  } else if (base64Len == 2) {
+    uint8_t w, x;
+    if (!ece_base64url_decode_lookup(*base64++, &w) ||
+        !ece_base64url_decode_lookup(*base64++, &x)) {
+      err = ECE_ERROR_INVALID_BASE64URL;
+      goto error;
+    }
+    *binary++ = w << 2 | x >> 4;
+  } else if (base64Len) {
+    err = ECE_ERROR_INVALID_BASE64URL;
+    goto error;
+  }
+
+  // Set the length to the actual number of decoded bytes.
+  result->length = binary - result->bytes;
+  goto end;
+
+error:
+  ece_buf_free(result);
+
+end:
+  return err;
+}

--- a/ThirdParty/ecec/src/buffer.c
+++ b/ThirdParty/ecec/src/buffer.c
@@ -1,0 +1,42 @@
+#include "ece.h"
+
+// This file implements a buffer data type. Each buffer is backed by a byte
+// array, and knows its own length. By convention, functions take buffers as
+// `const` in parameters. It's safe for the caller to free the buffer after
+// the function returns. Functions that take buffers as out parameters will
+// reset the buffer; it's not necessary to call `ece_buf_reset` beforehand.
+// Freeing a buffer resets it, so it's safe to call `ece_buf_free` multiple
+// times on the same buffer. This simplifies error handling paths. It's also
+// possible to take a slice of an existing buffer. However, since all slices
+// share the same backing array, it's not safe for a slice to outlive its
+// parent, or to free a slice.
+
+#include <assert.h>
+#include <stdlib.h>
+
+bool
+ece_buf_alloc(ece_buf_t* buf, size_t len) {
+  assert(!buf->bytes && !buf->length);
+  buf->bytes = (uint8_t*) malloc(len * sizeof(uint8_t));
+  buf->length = buf->bytes ? len : 0;
+  return buf->length;
+}
+
+void
+ece_buf_slice(const ece_buf_t* buf, size_t start, size_t end,
+              ece_buf_t* slice) {
+  slice->bytes = &buf->bytes[start];
+  slice->length = end - start;
+}
+
+void
+ece_buf_reset(ece_buf_t* buf) {
+  buf->bytes = NULL;
+  buf->length = 0;
+}
+
+void
+ece_buf_free(ece_buf_t* buf) {
+  free(buf->bytes);
+  ece_buf_reset(buf);
+}

--- a/ThirdParty/ecec/src/decrypt.c
+++ b/ThirdParty/ecec/src/decrypt.c
@@ -1,0 +1,266 @@
+#include "keys.h"
+
+#include <string.h>
+
+#include <openssl/evp.h>
+
+typedef int (*derive_key_and_nonce_t)(EC_KEY* recvPrivKey, EC_KEY* senderPubKey,
+                                      const ece_buf_t* authSecret,
+                                      const ece_buf_t* salt, ece_buf_t* key,
+                                      ece_buf_t* nonce);
+
+typedef int (*unpad_t)(ece_buf_t* block, bool isLastRecord);
+
+// Extracts an unsigned 16-bit integer in network byte order.
+static inline uint16_t
+ece_read_uint16_be(uint8_t* bytes) {
+  return bytes[1] | (bytes[0] << 8);
+}
+
+// Extracts an unsigned 32-bit integer in network byte order.
+static inline uint32_t
+ece_read_uint32_be(uint8_t* bytes) {
+  return bytes[3] | (bytes[2] << 8) | (bytes[1] << 16) | (bytes[0] << 24);
+}
+
+// Converts an encrypted record to a decrypted block.
+static int
+ece_decrypt_record(const ece_buf_t* key, const ece_buf_t* nonce, size_t counter,
+                   const ece_buf_t* record, ece_buf_t* block) {
+  int err = ECE_OK;
+
+  EVP_CIPHER_CTX* ctx = NULL;
+  if (record->length > INT_MAX) {
+    err = ECE_ERROR_DECRYPT;
+    goto end;
+  }
+  ctx = EVP_CIPHER_CTX_new();
+  if (!ctx) {
+    err = ECE_ERROR_OUT_OF_MEMORY;
+    goto end;
+  }
+  // Generate the IV for this record using the nonce.
+  uint8_t iv[ECE_NONCE_LENGTH];
+  ece_generate_iv(nonce->bytes, counter, iv);
+  if (EVP_DecryptInit_ex(ctx, EVP_aes_128_gcm(), NULL, key->bytes, iv) <= 0) {
+    err = ECE_ERROR_DECRYPT;
+    goto end;
+  }
+  // The authentication tag is included at the end of the encrypted record.
+  if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, ECE_TAG_LENGTH,
+                          &record->bytes[record->length - ECE_TAG_LENGTH]) <=
+      0) {
+    err = ECE_ERROR_DECRYPT;
+    goto end;
+  }
+  int blockLen = 0;
+  if (EVP_DecryptUpdate(ctx, block->bytes, &blockLen, record->bytes,
+                        (int) record->length - ECE_TAG_LENGTH) <= 0 ||
+      blockLen < 0) {
+    err = ECE_ERROR_DECRYPT;
+    goto end;
+  }
+  int finalLen = 0;
+  if (EVP_DecryptFinal_ex(ctx, &block->bytes[blockLen], &finalLen) <= 0 ||
+      finalLen < 0) {
+    err = ECE_ERROR_DECRYPT;
+    goto end;
+  }
+  block->length = blockLen + finalLen;
+
+end:
+  EVP_CIPHER_CTX_free(ctx);
+  return err;
+}
+
+// A generic decryption function shared by "aesgcm" and "aes128gcm".
+// `deriveKeyAndNonce` and `unpad` are function pointers that change based on
+// the scheme.
+static int
+ece_decrypt(const ece_buf_t* rawRecvPrivKey, const ece_buf_t* rawSenderPubKey,
+            const ece_buf_t* authSecret, const ece_buf_t* salt, uint32_t rs,
+            const ece_buf_t* ciphertext,
+            derive_key_and_nonce_t deriveKeyAndNonce, unpad_t unpad,
+            ece_buf_t* plaintext) {
+  int err = ECE_OK;
+
+  ece_buf_reset(plaintext);
+
+  EC_KEY* recvPrivKey = NULL;
+  EC_KEY* senderPubKey = NULL;
+
+  ece_buf_t key;
+  ece_buf_reset(&key);
+  ece_buf_t nonce;
+  ece_buf_reset(&nonce);
+
+  recvPrivKey = ece_import_private_key(rawRecvPrivKey);
+  if (!recvPrivKey) {
+    err = ECE_INVALID_RECEIVER_PRIVATE_KEY;
+    goto end;
+  }
+  senderPubKey = ece_import_public_key(rawSenderPubKey);
+  if (!senderPubKey) {
+    err = ECE_INVALID_SENDER_PUBLIC_KEY;
+    goto end;
+  }
+
+  err = deriveKeyAndNonce(recvPrivKey, senderPubKey, authSecret, salt, &key,
+                          &nonce);
+  if (err) {
+    goto error;
+  }
+
+  // For simplicity, we allocate a buffer equal to the encrypted record size,
+  // even though the decrypted block will be smaller. `ece_decrypt_record`
+  // will set the actual length.
+  if (!ece_buf_alloc(plaintext, ciphertext->length)) {
+    err = ECE_ERROR_OUT_OF_MEMORY;
+    goto error;
+  }
+  size_t start = 0;
+  size_t offset = 0;
+  for (size_t counter = 0; start < ciphertext->length; counter++) {
+    size_t end = start + rs;
+    if (end > ciphertext->length) {
+      end = ciphertext->length;
+    }
+    if (end - start <= ECE_TAG_LENGTH) {
+      err = ECE_ERROR_SHORT_BLOCK;
+      goto error;
+    }
+    ece_buf_t record;
+    ece_buf_slice(ciphertext, start, end, &record);
+    ece_buf_t block;
+    ece_buf_slice(plaintext, offset, end - start, &block);
+    err = ece_decrypt_record(&key, &nonce, counter, &record, &block);
+    if (err) {
+      goto error;
+    }
+    err = unpad(&block, end >= ciphertext->length);
+    if (err) {
+      goto error;
+    }
+    start = end;
+    offset += block.length;
+  }
+  plaintext->length = offset;
+  goto end;
+
+error:
+  ece_buf_free(plaintext);
+
+end:
+  EC_KEY_free(recvPrivKey);
+  EC_KEY_free(senderPubKey);
+  ece_buf_free(&key);
+  ece_buf_free(&nonce);
+  return err;
+}
+
+// Removes padding from a decrypted "aesgcm" block.
+static int
+ece_aesgcm_unpad(ece_buf_t* block, bool isLastRecord) {
+  ECE_UNUSED(isLastRecord);
+  if (block->length < ECE_AESGCM_PAD_SIZE) {
+    return ECE_ERROR_DECRYPT_PADDING;
+  }
+  uint16_t pad = ece_read_uint16_be(block->bytes);
+  if (pad > block->length) {
+    return ECE_ERROR_DECRYPT_PADDING;
+  }
+  // In "aesgcm", the content is offset by the pad size and padding.
+  size_t offset = ECE_AESGCM_PAD_SIZE + pad;
+  uint8_t* content = &block->bytes[ECE_AESGCM_PAD_SIZE];
+  while (content < &block->bytes[offset]) {
+    if (*content) {
+      // All padding bytes must be zero.
+      return ECE_ERROR_DECRYPT_PADDING;
+    }
+    content++;
+  }
+  // Move the unpadded contents to the start of the block.
+  block->length -= offset;
+  memmove(block->bytes, content, block->length);
+  return ECE_OK;
+}
+
+// Removes padding from a decrypted "aes128gcm" block.
+static int
+ece_aes128gcm_unpad(ece_buf_t* block, bool isLastRecord) {
+  if (!block->length) {
+    return ECE_ERROR_ZERO_PLAINTEXT;
+  }
+  // Remove trailing padding.
+  while (block->length > 0) {
+    block->length--;
+    if (!block->bytes[block->length]) {
+      continue;
+    }
+    uint8_t recordPad = isLastRecord ? 2 : 1;
+    if (block->bytes[block->length] != recordPad) {
+      // Last record needs to start padding with a 2; preceding records need
+      // to start padding with a 1.
+      return ECE_ERROR_DECRYPT_PADDING;
+    }
+    return ECE_OK;
+  }
+  // All zero plaintext.
+  return ECE_ERROR_ZERO_PLAINTEXT;
+}
+
+int
+ece_aes128gcm_decrypt(const ece_buf_t* rawRecvPrivKey,
+                      const ece_buf_t* authSecret, const ece_buf_t* payload,
+                      ece_buf_t* plaintext) {
+  if (payload->length < ECE_AES128GCM_HEADER_SIZE) {
+    return ECE_ERROR_SHORT_HEADER;
+  }
+  ece_buf_t salt;
+  ece_buf_slice(payload, 0, ECE_KEY_LENGTH, &salt);
+  uint32_t rs = ece_read_uint32_be(&payload->bytes[ECE_KEY_LENGTH]);
+  uint8_t keyIdLen = payload->bytes[ECE_KEY_LENGTH + 4];
+  if (payload->length < ECE_AES128GCM_HEADER_SIZE + keyIdLen) {
+    return ECE_ERROR_SHORT_HEADER;
+  }
+  ece_buf_t rawSenderPubKey;
+  ece_buf_slice(payload, ECE_AES128GCM_HEADER_SIZE,
+                ECE_AES128GCM_HEADER_SIZE + keyIdLen, &rawSenderPubKey);
+  ece_buf_t ciphertext;
+  ece_buf_slice(payload, ECE_AES128GCM_HEADER_SIZE + keyIdLen, payload->length,
+                &ciphertext);
+  if (!ciphertext.length) {
+    return ECE_ERROR_ZERO_CIPHERTEXT;
+  }
+  return ece_decrypt(rawRecvPrivKey, &rawSenderPubKey, authSecret, &salt, rs,
+                     &ciphertext, &ece_aes128gcm_derive_key_and_nonce,
+                     &ece_aes128gcm_unpad, plaintext);
+}
+
+int
+ece_aesgcm_decrypt(const ece_buf_t* rawRecvPrivKey, const ece_buf_t* authSecret,
+                   const char* cryptoKeyHeader, const char* encryptionHeader,
+                   const ece_buf_t* ciphertext, ece_buf_t* plaintext) {
+  int err = ECE_OK;
+
+  ece_buf_t rawSenderPubKey;
+  ece_buf_reset(&rawSenderPubKey);
+  ece_buf_t salt;
+  ece_buf_reset(&salt);
+
+  uint32_t rs;
+  err = ece_header_extract_aesgcm_crypto_params(
+    cryptoKeyHeader, encryptionHeader, &rs, &salt, &rawSenderPubKey);
+  if (err) {
+    goto end;
+  }
+  rs += ECE_TAG_LENGTH;
+  err = ece_decrypt(rawRecvPrivKey, &rawSenderPubKey, authSecret, &salt, rs,
+                    ciphertext, &ece_aesgcm_derive_key_and_nonce,
+                    &ece_aesgcm_unpad, plaintext);
+
+end:
+  ece_buf_free(&rawSenderPubKey);
+  ece_buf_free(&salt);
+  return err;
+}

--- a/ThirdParty/ecec/src/keys.c
+++ b/ThirdParty/ecec/src/keys.c
@@ -1,0 +1,438 @@
+#include "keys.h"
+
+#include <string.h>
+
+#include <openssl/evp.h>
+#include <openssl/kdf.h>
+
+// Writes an unsigned 16-bit integer in network byte order.
+static inline void
+ece_write_uint16_be(uint8_t* bytes, uint16_t value) {
+  bytes[0] = (value >> 8) & 0xff;
+  bytes[1] = value & 0xff;
+}
+
+// Extracts an unsigned 48-bit integer in network byte order.
+static inline uint64_t
+ece_read_uint48_be(uint8_t* bytes) {
+  return bytes[5] | (bytes[4] << 8) | (bytes[3] << 16) |
+         ((uint64_t) bytes[2] << 24) | ((uint64_t) bytes[1] << 32) |
+         ((uint64_t) bytes[0] << 40);
+}
+
+// Writes an unsigned 48-bit integer in network byte order.
+static inline void
+ece_write_uint48_be(uint8_t* bytes, uint64_t value) {
+  bytes[0] = (value >> 40) & 0xff;
+  bytes[1] = (value >> 32) & 0xff;
+  bytes[2] = (value >> 24) & 0xff;
+  bytes[3] = (value >> 16) & 0xff;
+  bytes[4] = (value >> 8) & 0xff;
+  bytes[5] = value & 0xff;
+}
+
+void
+ece_generate_iv(uint8_t* nonce, uint64_t counter, uint8_t* iv) {
+  // Copy the first 6 bytes as-is, since `(x ^ 0) == x`.
+  size_t offset = ECE_NONCE_LENGTH - 6;
+  memcpy(iv, nonce, offset);
+  // Combine the remaining 6 bytes (an unsigned 48-bit integer) with the
+  // record sequence number using XOR. See the "nonce derivation" section
+  // of the draft.
+  uint64_t mask = ece_read_uint48_be(&nonce[offset]);
+  ece_write_uint48_be(&iv[offset], mask ^ counter);
+}
+
+EC_KEY*
+ece_import_private_key(const ece_buf_t* rawKey) {
+  EC_KEY* key = NULL;
+  EC_POINT* pubKeyPt = NULL;
+
+  key = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
+  if (!key) {
+    goto error;
+  }
+  if (EC_KEY_oct2priv(key, rawKey->bytes, rawKey->length) <= 0) {
+    goto error;
+  }
+  const EC_GROUP* group = EC_KEY_get0_group(key);
+  pubKeyPt = EC_POINT_new(group);
+  if (!pubKeyPt) {
+    goto error;
+  }
+  const BIGNUM* privKey = EC_KEY_get0_private_key(key);
+  if (EC_POINT_mul(group, pubKeyPt, privKey, NULL, NULL, NULL) <= 0) {
+    goto error;
+  }
+  if (EC_KEY_set_public_key(key, pubKeyPt) <= 0) {
+    goto error;
+  }
+  goto end;
+
+error:
+  EC_KEY_free(key);
+  key = NULL;
+
+end:
+  EC_POINT_free(pubKeyPt);
+  return key;
+}
+
+EC_KEY*
+ece_import_public_key(const ece_buf_t* rawKey) {
+  EC_KEY* key = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
+  if (!key) {
+    return NULL;
+  }
+  if (!EC_KEY_oct2key(key, rawKey->bytes, rawKey->length, NULL)) {
+    EC_KEY_free(key);
+    return NULL;
+  }
+  return key;
+}
+
+// HKDF from RFC 5869: `HKDF-Expand(HKDF-Extract(salt, ikm), info, length)`.
+// This function does not reset or free `result` on error; its callers already
+// handle that.
+static int
+ece_hkdf_sha256(const ece_buf_t* salt, const ece_buf_t* ikm,
+                const ece_buf_t* info, size_t outputLen, ece_buf_t* result) {
+  int err = ECE_OK;
+
+  EVP_PKEY_CTX* ctx = NULL;
+  if (salt->length > INT_MAX || ikm->length > INT_MAX ||
+      info->length > INT_MAX) {
+    err = ECE_ERROR_HKDF;
+    goto end;
+  }
+  ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, NULL);
+  if (!ctx) {
+    err = ECE_ERROR_HKDF;
+    goto end;
+  }
+  if (EVP_PKEY_derive_init(ctx) <= 0) {
+    err = ECE_ERROR_HKDF;
+    goto end;
+  }
+  if (EVP_PKEY_CTX_set_hkdf_md(ctx, EVP_sha256()) <= 0) {
+    err = ECE_ERROR_HKDF;
+    goto end;
+  }
+  if (EVP_PKEY_CTX_set1_hkdf_salt(ctx, salt->bytes, (int) salt->length) <= 0) {
+    err = ECE_ERROR_HKDF;
+    goto end;
+  }
+  if (EVP_PKEY_CTX_set1_hkdf_key(ctx, ikm->bytes, (int) ikm->length) <= 0) {
+    err = ECE_ERROR_HKDF;
+    goto end;
+  }
+  if (EVP_PKEY_CTX_add1_hkdf_info(ctx, info->bytes, (int) info->length) <= 0) {
+    err = ECE_ERROR_HKDF;
+    goto end;
+  }
+  if (!ece_buf_alloc(result, outputLen)) {
+    err = ECE_ERROR_OUT_OF_MEMORY;
+    goto end;
+  }
+  if (EVP_PKEY_derive(ctx, result->bytes, &result->length) <= 0 ||
+      result->length != outputLen) {
+    err = ECE_ERROR_HKDF;
+    goto end;
+  }
+
+end:
+  EVP_PKEY_CTX_free(ctx);
+  return err;
+}
+
+// Computes the ECDH shared secret, used as the input key material (IKM) for
+// HKDF.
+static int
+ece_compute_secret(EC_KEY* recvPrivKey, EC_KEY* senderPubKey,
+                   ece_buf_t* sharedSecret) {
+  int err = ECE_OK;
+
+  const EC_GROUP* recvGrp = EC_KEY_get0_group(recvPrivKey);
+  const EC_POINT* senderPubKeyPt = EC_KEY_get0_public_key(senderPubKey);
+  int fieldSize = EC_GROUP_get_degree(recvGrp);
+  if (fieldSize <= 0) {
+    err = ECE_ERROR_COMPUTE_SECRET;
+    goto error;
+  }
+  if (!ece_buf_alloc(sharedSecret, (fieldSize + 7) / 8)) {
+    err = ECE_ERROR_OUT_OF_MEMORY;
+    goto error;
+  }
+  if (ECDH_compute_key(sharedSecret->bytes, sharedSecret->length,
+                       senderPubKeyPt, recvPrivKey, NULL) <= 0) {
+    err = ECE_ERROR_COMPUTE_SECRET;
+    goto error;
+  }
+  goto end;
+
+error:
+  ece_buf_free(sharedSecret);
+
+end:
+  return err;
+}
+
+// The "aes128gcm" info string is "WebPush: info\0", followed by the receiver
+// and sender public keys.
+static int
+ece_aes128gcm_generate_info(EC_KEY* recvPrivKey, EC_KEY* senderPubKey,
+                            const char* prefix, size_t prefixLen,
+                            ece_buf_t* info) {
+  int err = ECE_OK;
+
+  // Build up the HKDF info string: "WebPush: info\0", followed by the receiver
+  // and sender public keys. First, we determine the lengths of the two keys.
+  // Then, we allocate a buffer large enough to hold the prefix and keys, and
+  // write them to the buffer.
+  const EC_GROUP* recvGrp = EC_KEY_get0_group(recvPrivKey);
+  const EC_POINT* recvPubKeyPt = EC_KEY_get0_public_key(recvPrivKey);
+  const EC_GROUP* senderGrp = EC_KEY_get0_group(senderPubKey);
+  const EC_POINT* senderPubKeyPt = EC_KEY_get0_public_key(senderPubKey);
+
+  // First, we determine the lengths of the two keys.
+  size_t recvPubKeyLen = EC_POINT_point2oct(
+    recvGrp, recvPubKeyPt, POINT_CONVERSION_UNCOMPRESSED, NULL, 0, NULL);
+  if (!recvPubKeyLen) {
+    err = ECE_ERROR_ENCODE_RECEIVER_PUBLIC_KEY;
+    goto error;
+  }
+  size_t senderPubKeyLen = EC_POINT_point2oct(
+    senderGrp, senderPubKeyPt, POINT_CONVERSION_UNCOMPRESSED, NULL, 0, NULL);
+  if (!senderPubKeyLen) {
+    err = ECE_ERROR_ENCODE_SENDER_PUBLIC_KEY;
+    goto error;
+  }
+
+  // Next, we allocate a buffer large enough to hold the prefix and keys.
+  size_t infoLen = prefixLen + recvPubKeyLen + senderPubKeyLen;
+  if (!ece_buf_alloc(info, infoLen)) {
+    err = ECE_ERROR_OUT_OF_MEMORY;
+    goto error;
+  }
+
+  // Copy the prefix.
+  memcpy(info->bytes, prefix, prefixLen);
+
+  // Copy the receiver public key.
+  if (EC_POINT_point2oct(recvGrp, recvPubKeyPt, POINT_CONVERSION_UNCOMPRESSED,
+                         &info->bytes[prefixLen], recvPubKeyLen,
+                         NULL) != recvPubKeyLen) {
+    err = ECE_ERROR_ENCODE_RECEIVER_PUBLIC_KEY;
+    goto error;
+  }
+
+  // Copy the sender public key.
+  if (EC_POINT_point2oct(senderGrp, senderPubKeyPt,
+                         POINT_CONVERSION_UNCOMPRESSED,
+                         &info->bytes[prefixLen + recvPubKeyLen],
+                         senderPubKeyLen, NULL) != senderPubKeyLen) {
+    err = ECE_ERROR_ENCODE_SENDER_PUBLIC_KEY;
+    goto error;
+  }
+  goto end;
+
+error:
+  ece_buf_free(info);
+
+end:
+  return err;
+}
+
+int
+ece_aes128gcm_derive_key_and_nonce(EC_KEY* recvPrivKey, EC_KEY* senderPubKey,
+                                   const ece_buf_t* authSecret,
+                                   const ece_buf_t* salt, ece_buf_t* key,
+                                   ece_buf_t* nonce) {
+  int err = ECE_OK;
+
+  ece_buf_t sharedSecret;
+  ece_buf_reset(&sharedSecret);
+  ece_buf_t prkInfo;
+  ece_buf_reset(&prkInfo);
+  ece_buf_t prk;
+  ece_buf_reset(&prk);
+
+  err = ece_compute_secret(recvPrivKey, senderPubKey, &sharedSecret);
+  if (err) {
+    goto end;
+  }
+
+  // The new "aes128gcm" scheme includes the sender and receiver public keys in
+  // the info string when deriving the Web Push PRK.
+  err = ece_aes128gcm_generate_info(
+    recvPrivKey, senderPubKey, ECE_AES128GCM_WEB_PUSH_PRK_INFO_PREFIX,
+    ECE_AES128GCM_WEB_PUSH_PRK_INFO_PREFIX_LENGTH, &prkInfo);
+  if (err) {
+    goto end;
+  }
+  err = ece_hkdf_sha256(authSecret, &sharedSecret, &prkInfo, ECE_SHA_256_LENGTH,
+                        &prk);
+  if (err) {
+    goto end;
+  }
+
+  // Next, derive the AES decryption key and nonce. We use static info strings.
+  // These buffers are stack-allocated, so they shouldn't be freed.
+  uint8_t keyInfoBytes[ECE_AES128GCM_KEY_INFO_LENGTH];
+  memcpy(keyInfoBytes, ECE_AES128GCM_KEY_INFO, ECE_AES128GCM_KEY_INFO_LENGTH);
+  ece_buf_t keyInfo;
+  keyInfo.bytes = keyInfoBytes;
+  keyInfo.length = ECE_AES128GCM_KEY_INFO_LENGTH;
+  err = ece_hkdf_sha256(salt, &prk, &keyInfo, ECE_KEY_LENGTH, key);
+  if (err) {
+    goto end;
+  }
+  uint8_t nonceInfoBytes[ECE_AES128GCM_NONCE_INFO_LENGTH];
+  memcpy(nonceInfoBytes, ECE_AES128GCM_NONCE_INFO,
+         ECE_AES128GCM_NONCE_INFO_LENGTH);
+  ece_buf_t nonceInfo;
+  nonceInfo.bytes = nonceInfoBytes;
+  nonceInfo.length = ECE_AES128GCM_NONCE_INFO_LENGTH;
+  err = ece_hkdf_sha256(salt, &prk, &nonceInfo, ECE_NONCE_LENGTH, nonce);
+
+end:
+  ece_buf_free(&sharedSecret);
+  ece_buf_free(&prkInfo);
+  ece_buf_free(&prk);
+  return err;
+}
+
+// The "aesgcm" info string is "Content-Encoding: <aesgcm | nonce>\0P-256\0",
+// followed by the length-prefixed (unsigned 16-bit integers) receiver and
+// sender public keys.
+static int
+ece_aesgcm_generate_info(EC_KEY* recvPrivKey, EC_KEY* senderPubKey,
+                         const char* prefix, size_t prefixLen,
+                         ece_buf_t* info) {
+  int err = ECE_OK;
+
+  const EC_GROUP* recvGrp = EC_KEY_get0_group(recvPrivKey);
+  const EC_POINT* recvPubKeyPt = EC_KEY_get0_public_key(recvPrivKey);
+  const EC_GROUP* senderGrp = EC_KEY_get0_group(senderPubKey);
+  const EC_POINT* senderPubKeyPt = EC_KEY_get0_public_key(senderPubKey);
+
+  // First, we determine the lengths of the two keys.
+  size_t recvPubKeyLen = EC_POINT_point2oct(
+    recvGrp, recvPubKeyPt, POINT_CONVERSION_UNCOMPRESSED, NULL, 0, NULL);
+  if (!recvPubKeyLen || recvPubKeyLen > UINT16_MAX) {
+    err = ECE_ERROR_ENCODE_RECEIVER_PUBLIC_KEY;
+    goto error;
+  }
+  size_t senderPubKeyLen = EC_POINT_point2oct(
+    senderGrp, senderPubKeyPt, POINT_CONVERSION_UNCOMPRESSED, NULL, 0, NULL);
+  if (!senderPubKeyLen || senderPubKeyLen > UINT16_MAX) {
+    err = ECE_ERROR_ENCODE_SENDER_PUBLIC_KEY;
+    goto error;
+  }
+
+  // Next, we allocate a buffer large enough to hold the prefix, lengths,
+  // and keys.
+  size_t infoLen = prefixLen + recvPubKeyLen + senderPubKeyLen +
+                   ECE_AESGCM_KEY_LENGTH_SIZE * 2;
+  if (!ece_buf_alloc(info, infoLen)) {
+    err = ECE_ERROR_OUT_OF_MEMORY;
+    goto error;
+  }
+
+  // Copy the prefix to the buffer.
+  memcpy(info->bytes, prefix, prefixLen);
+
+  // Copy the length-prefixed receiver public key.
+  ece_write_uint16_be(&info->bytes[prefixLen], (uint16_t) recvPubKeyLen);
+  if (EC_POINT_point2oct(recvGrp, recvPubKeyPt, POINT_CONVERSION_UNCOMPRESSED,
+                         &info->bytes[prefixLen + ECE_AESGCM_KEY_LENGTH_SIZE],
+                         recvPubKeyLen, NULL) != recvPubKeyLen) {
+    err = ECE_ERROR_ENCODE_RECEIVER_PUBLIC_KEY;
+    goto error;
+  }
+
+  // Copy the length-prefixed sender public key.
+  ece_write_uint16_be(
+    &info->bytes[prefixLen + recvPubKeyLen + ECE_AESGCM_KEY_LENGTH_SIZE],
+    (uint16_t) senderPubKeyLen);
+  if (EC_POINT_point2oct(
+        senderGrp, senderPubKeyPt, POINT_CONVERSION_UNCOMPRESSED,
+        &info
+           ->bytes[prefixLen + recvPubKeyLen + ECE_AESGCM_KEY_LENGTH_SIZE * 2],
+        senderPubKeyLen, NULL) != senderPubKeyLen) {
+    err = ECE_ERROR_ENCODE_SENDER_PUBLIC_KEY;
+    goto error;
+  }
+  goto end;
+
+error:
+  ece_buf_free(info);
+
+end:
+  return err;
+}
+
+// Derives the "aesgcm" decryption key and nonce given the receiver private key,
+// sender public key, authentication secret, and sender salt.
+int
+ece_aesgcm_derive_key_and_nonce(EC_KEY* recvPrivKey, EC_KEY* senderPubKey,
+                                const ece_buf_t* authSecret,
+                                const ece_buf_t* salt, ece_buf_t* key,
+                                ece_buf_t* nonce) {
+  int err = ECE_OK;
+
+  ece_buf_t sharedSecret;
+  ece_buf_reset(&sharedSecret);
+  ece_buf_t prk;
+  ece_buf_reset(&prk);
+  ece_buf_t keyInfo;
+  ece_buf_reset(&keyInfo);
+  ece_buf_t nonceInfo;
+  ece_buf_reset(&nonceInfo);
+
+  err = ece_compute_secret(recvPrivKey, senderPubKey, &sharedSecret);
+  if (err) {
+    goto end;
+  }
+
+  // The old "aesgcm" scheme uses a static info string to derive the Web Push
+  // PRK. This buffer is stack-allocated, so it shouldn't be freed.
+  uint8_t prkInfoBytes[ECE_AESGCM_WEB_PUSH_PRK_INFO_LENGTH];
+  memcpy(prkInfoBytes, ECE_AESGCM_WEB_PUSH_PRK_INFO,
+         ECE_AESGCM_WEB_PUSH_PRK_INFO_LENGTH);
+  ece_buf_t prkInfo;
+  prkInfo.bytes = prkInfoBytes;
+  prkInfo.length = ECE_AESGCM_WEB_PUSH_PRK_INFO_LENGTH;
+  err = ece_hkdf_sha256(authSecret, &sharedSecret, &prkInfo, ECE_SHA_256_LENGTH,
+                        &prk);
+  if (err) {
+    goto end;
+  }
+
+  // Next, derive the AES decryption key and nonce. We include the sender and
+  // receiver public keys in the info strings.
+  err = ece_aesgcm_generate_info(
+    recvPrivKey, senderPubKey, ECE_AESGCM_WEB_PUSH_KEY_INFO_PREFIX,
+    ECE_AESGCM_WEB_PUSH_KEY_INFO_PREFIX_LENGTH, &keyInfo);
+  if (err) {
+    goto end;
+  }
+  err = ece_hkdf_sha256(salt, &prk, &keyInfo, ECE_KEY_LENGTH, key);
+  if (err) {
+    goto end;
+  }
+  err = ece_aesgcm_generate_info(
+    recvPrivKey, senderPubKey, ECE_AESGCM_WEB_PUSH_NONCE_INFO_PREFIX,
+    ECE_AESGCM_WEB_PUSH_NONCE_INFO_PREFIX_LENGTH, &nonceInfo);
+  if (err) {
+    goto end;
+  }
+  err = ece_hkdf_sha256(salt, &prk, &nonceInfo, ECE_NONCE_LENGTH, nonce);
+
+end:
+  ece_buf_free(&sharedSecret);
+  ece_buf_free(&prk);
+  ece_buf_free(&keyInfo);
+  ece_buf_free(&nonceInfo);
+  return err;
+}

--- a/ThirdParty/ecec/src/keys.h
+++ b/ThirdParty/ecec/src/keys.h
@@ -1,0 +1,44 @@
+#ifndef ECE_KEYS_H
+#define ECE_KEYS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ece.h"
+
+#include <openssl/ec.h>
+
+// Generates a 96-bit IV for decryption, 48 bits of which are populated.
+void
+ece_generate_iv(uint8_t* nonce, uint64_t counter, uint8_t* iv);
+
+// Inflates a raw ECDH private key into an OpenSSL `EC_KEY` containing a
+// private and public key pair. Returns `NULL` on error.
+EC_KEY*
+ece_import_private_key(const ece_buf_t* rawKey);
+
+// Inflates a raw ECDH public key into an `EC_KEY` containing a public key.
+// Returns `NULL` on error.
+EC_KEY*
+ece_import_public_key(const ece_buf_t* rawKey);
+
+// Derives the "aes128gcm" decryption key and nonce given the receiver private
+// key, sender public key, authentication secret, and sender salt.
+int
+ece_aes128gcm_derive_key_and_nonce(EC_KEY* recvPrivKey, EC_KEY* senderPubKey,
+                                   const ece_buf_t* authSecret,
+                                   const ece_buf_t* salt, ece_buf_t* key,
+                                   ece_buf_t* nonce);
+
+// Derives the "aesgcm" decryption key and nonce given the receiver private key,
+// sender public key, authentication secret, and sender salt.
+int
+ece_aesgcm_derive_key_and_nonce(EC_KEY* recvPrivKey, EC_KEY* senderPubKey,
+                                const ece_buf_t* authSecret,
+                                const ece_buf_t* salt, ece_buf_t* key,
+                                ece_buf_t* nonce);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* ECE_KEYS_H */

--- a/ThirdParty/ecec/test/aes128gcm.c
+++ b/ThirdParty/ecec/test/aes128gcm.c
@@ -1,0 +1,77 @@
+#include "test.h"
+
+#include <string.h>
+
+typedef struct valid_payload_test_s {
+  const char* desc;
+  const char* plaintext;
+  const char* recvPrivKey;
+  const char* authSecret;
+  const char* payload;
+} valid_payload_test_t;
+
+static valid_payload_test_t valid_payload_tests[] = {
+  {
+    .desc = "rs = 24",
+    .plaintext = "I am the walrus",
+    .recvPrivKey = "yJnRHTLit-b-dJh4b1DyO5is5Tl60mHeObpkSezBLK0",
+    .authSecret = "mW-ti1CqLQK4PyZBKy4q7g",
+    .payload = "SVzmyN6TpFOehi6GNJk8uwAAABhBBDwzeKLAq5VOFJhxjoXwi7cj-"
+               "30l4TWmY_44WITrgZIza_"
+               "kKVO1yDxwEXAtAXpu8OiFCsWyJCGc0w3Trr3CZ5kJ-"
+               "LTLIraUBhwPFSxC0geECfXIJ2Ma0NVP6Ezr6WX8t3EWluoFAlE5kkLuNbZm"
+               "6HQLmDZX0jOZER3wXIx2VuXpPld0",
+  },
+  {
+    .desc = "Example from draft-ietf-webpush-encryption-latest",
+    .plaintext = "When I grow up, I want to be a watermelon",
+    .recvPrivKey = "q1dXpw3UpT5VOmu_cf_v6ih07Aems3njxI-JWgLcM94",
+    .authSecret = "BTBZMqHH6r4Tts7J_aSIgg",
+    .payload = "DGv6ra1nlYgDCS1FRnbzlwAAEABBBP4z9KsN6nGRTbVYI_"
+               "c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru"
+               "3jl7A_"
+               "yl95bQpu6cVPTpK4Mqgkf1CXztLVBSt2Ks3oZwbuwXPXLWyouBWLVWGNWQexSgS"
+               "xsj_Qulcy4a-fN",
+  },
+};
+
+void
+test_aes128gcm_valid_payloads() {
+  size_t tests = sizeof(valid_payload_tests) / sizeof(valid_payload_test_t);
+  for (size_t i = 0; i < tests; i++) {
+    valid_payload_test_t t = valid_payload_tests[i];
+
+    ece_buf_t rawRecvPrivKey;
+    int err =
+      ece_base64url_decode(t.recvPrivKey, strlen(t.recvPrivKey),
+                           ECE_BASE64URL_REJECT_PADDING, &rawRecvPrivKey);
+    ece_assert(!err, "Got %d decoding private key for `%s`", err, t.desc);
+
+    ece_buf_t authSecret;
+    err = ece_base64url_decode(t.authSecret, strlen(t.authSecret),
+                               ECE_BASE64URL_REJECT_PADDING, &authSecret);
+    ece_assert(!err, "Got %d decoding auth secret for `%s`", err, t.desc);
+
+    ece_buf_t payload;
+    err = ece_base64url_decode(t.payload, strlen(t.payload),
+                               ECE_BASE64URL_REJECT_PADDING, &payload);
+    ece_assert(!err, "Got %d decoding payload for `%s`", err, t.desc);
+
+    ece_buf_t plaintext;
+    err =
+      ece_aes128gcm_decrypt(&rawRecvPrivKey, &authSecret, &payload, &plaintext);
+    ece_assert(!err, "Got %d decrypting payload for `%s`", err, t.desc);
+
+    size_t expectedLen = strlen(t.plaintext);
+    ece_assert(plaintext.length == expectedLen,
+               "Got plaintext length %zu for `%s`; want %zu", plaintext.length,
+               t.desc, expectedLen);
+    ece_assert(!memcmp(t.plaintext, plaintext.bytes, plaintext.length),
+               "Wrong plaintext for `%s`", t.desc);
+
+    ece_buf_free(&rawRecvPrivKey);
+    ece_buf_free(&authSecret);
+    ece_buf_free(&payload);
+    ece_buf_free(&plaintext);
+  }
+}

--- a/ThirdParty/ecec/test/aesgcm.c
+++ b/ThirdParty/ecec/test/aesgcm.c
@@ -1,0 +1,390 @@
+#include "test.h"
+
+#include <inttypes.h>
+#include <string.h>
+
+#include <ece.h>
+
+typedef struct valid_param_test_s {
+  const char* desc;
+  const char* cryptoKey;
+  const char* encryption;
+  const char* salt;
+  const char* rawSenderPubKey;
+  uint32_t rs;
+} valid_param_test_t;
+
+typedef struct invalid_param_test_s {
+  const char* desc;
+  const char* cryptoKey;
+  const char* encryption;
+  int err;
+} invalid_param_test_t;
+
+typedef struct valid_ciphertext_test_s {
+  const char* desc;
+  const char* plaintext;
+  const char* recvPrivKey;
+  const char* authSecret;
+  const char* ciphertext;
+  const char* cryptoKey;
+  const char* encryption;
+} valid_ciphertext_test_t;
+
+static valid_param_test_t valid_param_tests[] = {
+  {
+    .desc = "Multiple keys in Crypto-Key header",
+    .cryptoKey = "keyid=p256dh;dh=Iy1Je2Kv11A,p256ecdsa=o2M8QfiEKuI",
+    .encryption = "keyid=p256dh;salt=upk1yFkp1xI",
+    .salt = "\xba\x99\x35\xc8\x59\x29\xd7\x12",
+    .rawSenderPubKey = "\x23\x2d\x49\x7b\x62\xaf\xd7\x50",
+    .rs = 4096,
+  },
+  {
+    .desc = "Multiple keys in both headers",
+    .cryptoKey = "keyid=a;dh=bX0VbuZy8HQ,dh=Iy1Je2Kv11A;keyid=p256dh",
+    .encryption =
+      "salt=upk1yFkp1xI;rs=48;keyid=p256dh,salt=U0DM1JsdIbU;keyid=a",
+    .salt = "\xba\x99\x35\xc8\x59\x29\xd7\x12",
+    .rawSenderPubKey = "\x23\x2d\x49\x7b\x62\xaf\xd7\x50",
+    .rs = 48,
+  },
+  {
+    .desc = "Quoted key param",
+    .cryptoKey = "dh=\"byfHbUffc-k\"",
+    .encryption = "salt=C11AvAsp6Gc",
+    .salt = "\x0b\x5d\x40\xbc\x0b\x29\xe8\x67",
+    .rawSenderPubKey = "\x6f\x27\xc7\x6d\x47\xdf\x73\xe9",
+    .rs = 4096,
+  },
+  {
+    .desc = "Quoted salt param and rs = 24",
+    .cryptoKey = "dh=ybuT4VDz-Bg",
+    .encryption = "salt=\"H7U7wcIoIKs\"; rs=24",
+    .salt = "\x1f\xb5\x3b\xc1\xc2\x28\x20\xab",
+    .rawSenderPubKey = "\xc9\xbb\x93\xe1\x50\xf3\xf8\x18",
+    .rs = 24,
+  },
+  {
+    .desc = "Multiple keys, extra whitespace, strange key ID",
+    .cryptoKey = " dh= \"ujIToeKunCY\" ,keyid = hello ; dh = I7p5M0yyP8A ",
+    .encryption = "salt=ie_oYLhw7SI; keyid=\"hello\"; rs =6 , salt = "
+                  "6NAh50bfJZc ;keyid=ujIToeKunCY ",
+    .salt = "\x89\xef\xe8\x60\xb8\x70\xed\x22",
+    .rawSenderPubKey = "\x23\xba\x79\x33\x4c\xb2\x3f\xc0",
+    .rs = 6,
+  },
+};
+
+static invalid_param_test_t invalid_param_tests[] = {
+  {
+    .desc = "Invalid record size",
+    .cryptoKey = "dh=pbmv1QkcEDY",
+    .encryption = "salt=Esao8aTBfIk;rs=bad",
+    .err = ECE_ERROR_INVALID_RS,
+  },
+  {
+    .desc = "Blank Crypto-Key header",
+    .cryptoKey = " \t ",
+    .encryption = "salt=Esao8aTBfIk",
+    .err = ECE_ERROR_INVALID_CRYPTO_KEY_HEADER,
+  },
+  {
+    .desc = "Empty Encryption header",
+    .cryptoKey = "dh=pbmv1QkcEDY",
+    .encryption = "",
+    .err = ECE_ERROR_INVALID_ENCRYPTION_HEADER,
+  },
+  {
+    .desc = "Crypto-Key missing param value",
+    .cryptoKey = "dh=",
+    .encryption = "dh=Esao8aTBfIk",
+    .err = ECE_ERROR_INVALID_CRYPTO_KEY_HEADER,
+  },
+  {
+    .desc = "Encryption missing param value with trailing whitespace",
+    .cryptoKey = "dh=pbmv1QkcEDY",
+    .encryption = "salt= ",
+    .err = ECE_ERROR_INVALID_ENCRYPTION_HEADER,
+  },
+  {
+    .desc = "Crypto-Key param without value",
+    .cryptoKey = "dh=pbmv1QkcEDY; keyid, dh=rqowftPcCVo",
+    .encryption = "salt=Esao8aTBfIk",
+    .err = ECE_ERROR_INVALID_CRYPTO_KEY_HEADER,
+  },
+  {
+    .desc = "Encryption param without value",
+    .cryptoKey = "dh=pbmv1QkcEDY",
+    .encryption = "rs; salt=Esao8aTBfIk",
+    .err = ECE_ERROR_INVALID_ENCRYPTION_HEADER,
+  },
+  {
+    .desc = "Crypto-Key missing param name",
+    .cryptoKey = "dh=pbmv1QkcEDY; =rqowftPcCVo",
+    .encryption = "salt=Esao8aTBfIk",
+    .err = ECE_ERROR_INVALID_CRYPTO_KEY_HEADER,
+  },
+  {
+    .desc = "Encryption missing param name",
+    .cryptoKey = "dh=pbmv1QkcEDY",
+    .encryption = "=Esao8aTBfIk",
+    .err = ECE_ERROR_INVALID_ENCRYPTION_HEADER,
+  },
+  {
+    .desc = "Whitespace in quoted value in Crypto-Key header",
+    .cryptoKey = "dh=byfHbUffc-k; param=\" \"",
+    .encryption = "salt=C11AvAsp6Gc",
+    .err = ECE_ERROR_INVALID_CRYPTO_KEY_HEADER,
+  },
+  {
+    .desc = "Empty quoted value in Encryption header",
+    .cryptoKey = "dh=byfHbUffc-k",
+    .encryption = "salt=\"\"; rs=6",
+    .err = ECE_ERROR_INVALID_ENCRYPTION_HEADER,
+  },
+  {
+    .desc = "Invalid character in Crypto-Key param value",
+    .cryptoKey = "dh==byfHbUffc-k",
+    .encryption = "salt=C11AvAsp6Gc",
+    .err = ECE_ERROR_INVALID_CRYPTO_KEY_HEADER,
+  },
+  {
+    .desc = "Invalid character in Encryption param name",
+    .cryptoKey = "dh=byfHbUffc-k",
+    .encryption = "sa!t=C11AvAsp6Gc",
+    .err = ECE_ERROR_INVALID_ENCRYPTION_HEADER,
+  },
+  {
+    .desc = "Leading , in Crypto-Key header",
+    .cryptoKey = ",dh=byfHbUffc-k",
+    .encryption = "salt=C11AvAsp6Gc",
+    .err = ECE_ERROR_INVALID_CRYPTO_KEY_HEADER,
+  },
+  {
+    .desc = "Trailing ; in Crypto-Key header",
+    .cryptoKey = "dh=byfHbUffc-k;",
+    .encryption = "salt=C11AvAsp6Gc",
+    .err = ECE_ERROR_INVALID_CRYPTO_KEY_HEADER,
+  },
+  {
+    .desc = "Leading ; in Encryption header",
+    .cryptoKey = "dh=byfHbUffc-k",
+    .encryption = "; salt=C11AvAsp6Gc",
+    .err = ECE_ERROR_INVALID_ENCRYPTION_HEADER,
+  },
+  {
+    .desc = "Trailing , in Encryption header",
+    .cryptoKey = "dh=byfHbUffc-k",
+    .encryption = "salt=C11AvAsp6Gc,",
+    .err = ECE_ERROR_INVALID_ENCRYPTION_HEADER,
+  },
+  {
+    .desc = "Unterminated quoted value in Encryption header",
+    .cryptoKey = "dh=byfHbUffc-k",
+    .encryption = "rs=6; salt=\"C11AvAsp6Gc",
+    .err = ECE_ERROR_INVALID_ENCRYPTION_HEADER,
+  },
+  {
+    .desc = "Invalid quoted name in Crypto-Key header",
+    .cryptoKey = "\"dh\"=\"byfHbUffc-k\"",
+    .encryption = "salt=C11AvAsp6Gc",
+    .err = ECE_ERROR_INVALID_CRYPTO_KEY_HEADER,
+  },
+  {
+    .desc = "Invalid quoted name in Encryption header",
+    .cryptoKey = "dh=byfHbUffc-k",
+    .encryption = "\"salt\"=C11AvAsp6Gc",
+    .err = ECE_ERROR_INVALID_ENCRYPTION_HEADER,
+  },
+  {
+    .desc = "Mismatched key IDs",
+    .cryptoKey = "keyid=p256dh;dh=pbmv1QkcEDY",
+    .encryption = "keyid=different;salt=Esao8aTBfIk",
+    .err = ECE_ERROR_INVALID_DH,
+  },
+  {
+    .desc = "Multiple mismatched key IDs",
+    .cryptoKey = "keyid=a;dh=bX0VbuZy8HQ,dh=Iy1Je2Kv11A;keyid=b",
+    .encryption = "salt=upk1yFkp1xI;rs=48;keyid=c,salt=U0DM1JsdIbU;keyid=d",
+    .err = ECE_ERROR_INVALID_DH,
+  },
+  {
+    .desc = "Key ID with wrong param name",
+    .cryptoKey = "p256dh=p256dh;dh=pbmv1QkcEDY",
+    .encryption = "keyid=p256dh;salt=Esao8aTBfIk",
+    .err = ECE_ERROR_INVALID_DH,
+  },
+  {
+    .desc = "Invalid Base64url-encoded salt",
+    .cryptoKey = "dh=pbmv1QkcEDY",
+    .encryption = "salt=99999",
+    .err = ECE_ERROR_INVALID_SALT,
+  },
+  {
+    .desc = "Invalid Base64url-encoded dh param",
+    .cryptoKey = "dh=zzzzz",
+    .encryption = "salt=Esao8aTBfIk",
+    .err = ECE_ERROR_INVALID_DH,
+  },
+};
+
+static valid_ciphertext_test_t valid_ciphertext_tests[] = {
+  {
+    .desc = "padSize = 2, rs = 24, pad = 0",
+    .plaintext = "Some message",
+    .recvPrivKey = "4h23G_KkXC9TvBSK2v0Q7ImpS2YAuRd8hQyN0rFAwBg",
+    .authSecret = "aTDc6JebzR6eScy2oLo4RQ",
+    .ciphertext = "Oo34w2F9VVnTMFfKtdx48AZWQ9Li9M6DauWJVgXU",
+    .cryptoKey = "dh="
+                 "BCHFVrflyxibGLlgztLwKelsRZp4gqX3tNfAKFaxAcBhpvYeN1yIUMrxa"
+                 "DKiLh4LNKPtj0BOXGdr-IQ-QP82Wjo",
+    .encryption = "salt=zCU18Rw3A5aB_Xi-vfixmA; rs=24",
+  },
+  {
+    .desc = "padSize = 2, rs = 8, pad = 16",
+    .plaintext = "Yet another message",
+    .recvPrivKey = "4h23G_KkXC9TvBSK2v0Q7ImpS2YAuRd8hQyN0rFAwBg",
+    .authSecret = "6plwZnSpVUbF7APDXus3UQ",
+    .ciphertext = "uEC5B_tR-fuQ3delQcrzrDCp40W6ipMZjGZ78USDJ5sMj-"
+                  "6bAOVG3AK6JqFl9E6AoWiBYYvMZfwThVxmDnw6RHtVeLKFM5DWgl1Ewk"
+                  "OohwH2EhiDD0gM3io-d79WKzOPZE9rDWUSv64JstImSfX_"
+                  "ADQfABrvbZkeaWxh53EG59QMOElFJqHue4dMURpsMXg",
+    .cryptoKey = "dh=BEaA4gzA3i0JDuirGhiLgymS4hfFX7TNTdEhSk_"
+                 "HBlLpkjgCpjPL5c-GL9uBGIfa_fhGNKKFhXz1k9Kyens2ZpQ",
+    .encryption = "salt=ZFhzj0S-n29g9P2p4-I7tA; rs=8",
+  },
+  {
+    .desc = "padSize = 2, rs = 3, pad = 0",
+    .plaintext = "Small record size",
+    .recvPrivKey = "4h23G_KkXC9TvBSK2v0Q7ImpS2YAuRd8hQyN0rFAwBg",
+    .authSecret = "g2rWVHUCpUxgcL9Tz7vyeQ",
+    .ciphertext = "oY4e5eDatDVt2fpQylxbPJM-3vrfhDasfPc8Q1PWt4tPfMVbz_sDNL_"
+                  "cvr0DXXkdFzS1lxsJsj550USx4MMl01ihjImXCjrw9R5xFgFrCAqJD3G"
+                  "wXA1vzS4T5yvGVbUp3SndMDdT1OCcEofTn7VC6xZ-"
+                  "zP8rzSQfDCBBxmPU7OISzr8Z4HyzFCGJeBfqiZ7yUfNlKF1x5UaZ4X6i"
+                  "U_TXx5KlQy_"
+                  "toV1dXZ2eEAMHJUcSdArvB6zRpFdEIxdcHcJyo1BIYgAYTDdAIy__"
+                  "IJVCPY_b2CE5W_"
+                  "6ohlYKB7xDyH8giNuWWXAgBozUfScLUVjPC38yJTpAUi6w6pXgXUWffe"
+                  "nde5FreQpnMFL1L4G-38wsI_-"
+                  "ISIOzdO8QIrXHxmtc1S5xzYu8bMqSgCinvCEwdeGFCmighRjj8t1zRWo"
+                  "0D14rHbQLPR_b1P5SvEeJTtS9Nm3iibM",
+    .cryptoKey = "dh=BCg6ZIGuE2ZNm2ti6Arf4CDVD_8--"
+                 "aLXAGLYhpghwjl1xxVjTLLpb7zihuEOGGbyt8Qj0_"
+                 "fYHBP4ObxwJNl56bk",
+    .encryption = "salt=5LIDBXbvkBvvb7ZdD-T4PQ; rs=3",
+  },
+  {
+    .desc = "Example from draft-ietf-httpbis-encryption-encoding-02",
+    .plaintext = "I am the walrus",
+    .recvPrivKey = "9FWl15_QUQAWDaD3k3l50ZBZQJ4au27F1V4F0uLSD_M",
+    .authSecret = "R29vIGdvbyBnJyBqb29iIQ",
+    .ciphertext = "6nqAQUME8hNqw5J3kl8cpVVJylXKYqZOeseZG8UueKpA",
+    .cryptoKey = "keyid=\"dhkey\"; "
+                 "dh="
+                 "\"BNoRDbb84JGm8g5Z5CFxurSqsXWJ11ItfXEWYVLE85Y7CYkDjXsIEc4"
+                 "aqxYaQ1G8BqkXCJ6DPpDrWtdWj_mugHU\"",
+    .encryption = "keyid=\"dhkey\"; salt=\"lngarbyKfMoi9Z75xYXmkg\"",
+  },
+};
+
+void
+test_aesgcm_valid_crypto_params() {
+  size_t length = sizeof(valid_param_tests) / sizeof(valid_param_test_t);
+  for (size_t i = 0; i < length; i++) {
+    valid_param_test_t t = valid_param_tests[i];
+
+    uint32_t rs;
+    ece_buf_t salt;
+    ece_buf_t rawSenderPubKey;
+
+    int err = ece_header_extract_aesgcm_crypto_params(
+      t.cryptoKey, t.encryption, &rs, &salt, &rawSenderPubKey);
+
+    ece_assert(!err, "Got %d extracting params for `%s`", err, t.desc);
+    ece_assert(rs == t.rs, "Got rs = %" PRIu32 " for `%s`; want %" PRIu32, rs,
+               t.desc, t.rs);
+
+    size_t saltLen = strlen(t.salt);
+    ece_assert(salt.length == saltLen, "Got salt length %zu for `%s`; want %zu",
+               salt.length, t.desc, saltLen);
+    ece_assert(!memcmp(salt.bytes, t.salt, saltLen), "Wrong salt for `%s`",
+               t.desc);
+
+    size_t rawSenderPubKeyLen = strlen(t.rawSenderPubKey);
+    ece_assert(rawSenderPubKey.length == rawSenderPubKeyLen,
+               "Got public key length %zu for `%s`; want %zu",
+               rawSenderPubKey.length, t.desc, rawSenderPubKeyLen);
+    ece_assert(
+      !memcmp(rawSenderPubKey.bytes, t.rawSenderPubKey, rawSenderPubKeyLen),
+      "Wrong public key for `%s`", t.desc);
+
+    ece_buf_free(&salt);
+    ece_buf_free(&rawSenderPubKey);
+  }
+}
+
+void
+test_aesgcm_invalid_crypto_params() {
+  size_t length = sizeof(invalid_param_tests) / sizeof(invalid_param_test_t);
+  for (size_t i = 0; i < length; i++) {
+    invalid_param_test_t t = invalid_param_tests[i];
+
+    uint32_t rs;
+    ece_buf_t salt;
+    ece_buf_t rawSenderPubKey;
+
+    int err = ece_header_extract_aesgcm_crypto_params(
+      t.cryptoKey, t.encryption, &rs, &salt, &rawSenderPubKey);
+    ece_assert(err == t.err, "Got %d extracting params for `%s`; want %d", err,
+               t.desc, t.err);
+    ece_assert(rs == 0, "Got rs = %" PRIu32 " for `%s`; want 0", rs, t.desc);
+    ece_assert(!salt.bytes, "Got salt %p for `%s`; want NULL", salt.bytes,
+               t.desc);
+    ece_assert(!rawSenderPubKey.bytes, "Got key %p for `%s`; want NULL",
+               rawSenderPubKey.bytes, t.desc);
+  }
+}
+
+void
+test_aesgcm_valid_ciphertexts() {
+  size_t length =
+    sizeof(valid_ciphertext_tests) / sizeof(valid_ciphertext_test_t);
+  for (size_t i = 0; i < length; i++) {
+    valid_ciphertext_test_t t = valid_ciphertext_tests[i];
+
+    ece_buf_t rawRecvPrivKey;
+    int err =
+      ece_base64url_decode(t.recvPrivKey, strlen(t.recvPrivKey),
+                           ECE_BASE64URL_REJECT_PADDING, &rawRecvPrivKey);
+    ece_assert(!err, "Got %d decoding private key for `%s`", err, t.desc);
+
+    ece_buf_t authSecret;
+    err = ece_base64url_decode(t.authSecret, strlen(t.authSecret),
+                               ECE_BASE64URL_REJECT_PADDING, &authSecret);
+    ece_assert(!err, "Got %d decoding auth secret for `%s`", err, t.desc);
+
+    ece_buf_t ciphertext;
+    err = ece_base64url_decode(t.ciphertext, strlen(t.ciphertext),
+                               ECE_BASE64URL_REJECT_PADDING, &ciphertext);
+    ece_assert(!err, "Got %d decoding ciphertext for `%s`", err, t.desc);
+
+    ece_buf_t plaintext;
+    err = ece_aesgcm_decrypt(&rawRecvPrivKey, &authSecret, t.cryptoKey,
+                             t.encryption, &ciphertext, &plaintext);
+    ece_assert(!err, "Got %d decrypting ciphertext for `%s`", err, t.desc);
+
+    size_t expectedLen = strlen(t.plaintext);
+    ece_assert(plaintext.length == expectedLen,
+               "Got plaintext length %zu for `%s`; want %zu", plaintext.length,
+               t.desc, expectedLen);
+    ece_assert(!memcmp(plaintext.bytes, t.plaintext, plaintext.length),
+               "Wrong plaintext for `%s`", t.desc);
+
+    ece_buf_free(&rawRecvPrivKey);
+    ece_buf_free(&authSecret);
+    ece_buf_free(&ciphertext);
+    ece_buf_free(&plaintext);
+  }
+}

--- a/ThirdParty/ecec/test/base64url.c
+++ b/ThirdParty/ecec/test/base64url.c
@@ -1,0 +1,81 @@
+#include "test.h"
+
+#include <string.h>
+
+typedef struct base64url_test_s {
+  const char* encoded;
+  const char* decoded;
+} base64url_test_t;
+
+static base64url_test_t base64url_tests[] = {
+  // Test vectors from RFC 4648, section 10.
+  {"", ""},
+  {"Zg", "f"},
+  {"Zg==", "f"},
+  {"Zm8", "fo"},
+  {"Zm8=", "fo"},
+  {"Zm9v", "foo"},
+  {"Zm9vYg", "foob"},
+  {"Zm9vYg==", "foob"},
+  {"Zm9vYmE", "fooba"},
+  {"Zm9vYmE=", "fooba"},
+  {"Zm9vYmFy", "foobar"},
+
+  // Examples from RFC 4648, section 9.g
+  {"FPucA9l-", "\x14\xfb\x9c\x03\xd9\x7e"},
+  {"FPucA9k", "\x14\xfb\x9c\x03\xd9"},
+  {"FPucA9k=", "\x14\xfb\x9c\x03\xd9"},
+  {"FPucAw", "\x14\xfb\x9c\x03"},
+  {"FPucAw==", "\x14\xfb\x9c\x03"},
+};
+
+void
+test_base64url_decode() {
+  size_t tests = sizeof(base64url_tests) / sizeof(base64url_test_t);
+  for (size_t i = 0; i < tests; i++) {
+    base64url_test_t t = base64url_tests[i];
+
+    ece_buf_t decoded;
+    size_t encodedLen = strlen(t.encoded);
+    size_t decodedLen = strlen(t.decoded);
+
+    int err = ece_base64url_decode(t.encoded, encodedLen,
+                                   ECE_BASE64URL_IGNORE_PADDING, &decoded);
+    ece_assert(!err, "Got %d decoding `%s` with padding ignored", err,
+               t.encoded);
+    ece_assert(decoded.length == decodedLen,
+               "Got length %zu for `%s` with padding ignored; want %zu",
+               decoded.length, t.encoded, decodedLen);
+    ece_assert(!memcmp(decoded.bytes, t.decoded, decodedLen),
+               "Wrong output for `%s` with padding ignored", t.encoded);
+    ece_buf_free(&decoded);
+
+    const char* padStart = strchr(t.encoded, '=');
+    if (padStart) {
+      err = ece_base64url_decode(t.encoded, encodedLen,
+                                 ECE_BASE64URL_REJECT_PADDING, &decoded);
+      ece_assert(err == ECE_ERROR_INVALID_BASE64URL,
+                 "Got %d decoding `%s` with padding rejected", err, t.encoded);
+
+      size_t unpaddedLen = padStart - t.encoded;
+      err = ece_base64url_decode(t.encoded, unpaddedLen,
+                                 ECE_BASE64URL_REQUIRE_PADDING, &decoded);
+      ece_assert(err == ECE_ERROR_INVALID_BASE64URL,
+                 "Got %d decoding `%s` with required padding trimmed", err,
+                 t.encoded);
+    }
+
+    if (padStart || !(encodedLen % 4)) {
+      err = ece_base64url_decode(t.encoded, encodedLen,
+                                 ECE_BASE64URL_REQUIRE_PADDING, &decoded);
+      ece_assert(!err, "Got %d decoding `%s` with padding required", err,
+                 t.encoded);
+      ece_assert(decoded.length == decodedLen,
+                 "Got length %zu for `%s` with padding required; want %zu",
+                 decoded.length, t.encoded, decodedLen);
+      ece_assert(!memcmp(decoded.bytes, t.decoded, decodedLen),
+                 "Wrong output for `%s` with padding required", t.encoded);
+      ece_buf_free(&decoded);
+    }
+  }
+}

--- a/ThirdParty/ecec/test/test.c
+++ b/ThirdParty/ecec/test/test.c
@@ -1,0 +1,51 @@
+#include "test.h"
+
+#include <inttypes.h>
+#include <stdarg.h>
+#include <stdio.h>
+
+int
+main() {
+  test_aesgcm_valid_crypto_params();
+  test_aesgcm_invalid_crypto_params();
+  test_aesgcm_valid_ciphertexts();
+
+  test_aes128gcm_valid_payloads();
+
+  test_base64url_decode();
+
+  return 0;
+}
+
+void
+ece_log(const char* funcName, int line, const char* expr, const char* format,
+        ...) {
+  char* message = NULL;
+  va_list args;
+  va_start(args, format);
+
+  // Determine the size of the formatted message, then allocate and write to a
+  // buffer large enough to hold the message. `vsnprintf` mutates its argument
+  // list, so we make a copy for calculating the size.
+  va_list sizeArgs;
+  va_copy(sizeArgs, args);
+  int size = vsnprintf(NULL, 0, format, sizeArgs);
+  va_end(sizeArgs);
+  if (size < 0) {
+    goto error;
+  }
+  message = (char*) malloc(size + 1);
+  if (!message || vsprintf(message, format, args) != size) {
+    goto error;
+  }
+  message[size] = '\0';
+  fprintf(stderr, "[%s:%d] (%s): %s\n", funcName, line, expr, message);
+  goto end;
+
+error:
+  fprintf(stderr, "[%s:%d]: %s\n", funcName, line, expr);
+
+end:
+  va_end(args);
+  free(message);
+}

--- a/ThirdParty/ecec/test/test.h
+++ b/ThirdParty/ecec/test/test.h
@@ -1,0 +1,34 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <ece.h>
+
+// This macro is similar to the standard `assert`, but accepts a format string
+// with an informative failure message.
+#define ece_assert(cond, format, ...)                                          \
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      ece_log(__func__, __LINE__, #cond, format, __VA_ARGS__);                 \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+// Logs an assertion failure to standard error.
+void
+ece_log(const char* funcName, int line, const char* expr, const char* format,
+        ...);
+
+void
+test_aesgcm_valid_crypto_params();
+
+void
+test_aesgcm_invalid_crypto_params();
+
+void
+test_aesgcm_valid_ciphertexts();
+
+void
+test_aes128gcm_valid_payloads();
+
+void
+test_base64url_decode();

--- a/ThirdParty/ecec/tools/ece-decrypt/ece-decrypt.c
+++ b/ThirdParty/ecec/tools/ece-decrypt/ece-decrypt.c
@@ -1,0 +1,65 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <ece.h>
+
+int
+main(int argc, char** argv) {
+  if (argc < 4) {
+    fprintf(stderr, "Usage: %s <auth-secret> <receiver-private> <message>",
+            argv[0]);
+    return 2;
+  }
+  int err = ECE_OK;
+
+  ece_buf_t authSecret;
+  ece_buf_reset(&authSecret);
+  ece_buf_t rawRecvPrivKey;
+  ece_buf_reset(&rawRecvPrivKey);
+  ece_buf_t payload;
+  ece_buf_reset(&payload);
+  ece_buf_t plaintext;
+  ece_buf_reset(&plaintext);
+
+  err = ece_base64url_decode(argv[1], strlen(argv[1]),
+                             ECE_BASE64URL_REJECT_PADDING, &authSecret);
+  if (err) {
+    fprintf(stderr, "Error: Failed to Base64url-decode auth secret: %d\n", err);
+    goto end;
+  }
+  err = ece_base64url_decode(argv[2], strlen(argv[2]),
+                             ECE_BASE64URL_REJECT_PADDING, &rawRecvPrivKey);
+  if (err) {
+    fprintf(stderr, "Error: Failed to Base64url-decode private key: %d\n", err);
+    goto end;
+  }
+  err = ece_base64url_decode(argv[3], strlen(argv[3]),
+                             ECE_BASE64URL_REJECT_PADDING, &payload);
+  if (err) {
+    fprintf(stderr, "Error: Failed to Base64url-decode message: %d\n", err);
+    goto end;
+  }
+  err =
+    ece_aes128gcm_decrypt(&rawRecvPrivKey, &authSecret, &payload, &plaintext);
+  if (err) {
+    fprintf(stderr, "Error: Failed to decrypt message: %d\n", err);
+    goto end;
+  }
+  char* text = (char*) malloc(plaintext.length + 1);
+  if (!text) {
+    err = ECE_ERROR_OUT_OF_MEMORY;
+    goto end;
+  }
+  memcpy(text, plaintext.bytes, plaintext.length);
+  text[plaintext.length] = '\0';
+  printf("Decrypted message: %s\n", text);
+  free(text);
+
+end:
+  ece_buf_free(&authSecret);
+  ece_buf_free(&rawRecvPrivKey);
+  ece_buf_free(&payload);
+  ece_buf_free(&plaintext);
+  return err;
+}


### PR DESCRIPTION
With this PR, [ecec][1] is now available from `FxA` via the `ece.h` header.

https://bugzilla.mozilla.org/show_bug.cgi?id=1344735

[1]: https://github.com/kitcambridge/ecec