### PR TITLE
Bug 1258273 - Allow inline videos to be played in Firefox for iOS

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -11,6 +11,30 @@ import XCGLogger
 
 private let log = Logger.browserLogger
 
+public extension WKWebViewConfiguration {
+    public func setPlaybackPref(property: String, value: Bool) {
+        if property == "allowsInlineMediaPlayback" {
+            self.allowsInlineMediaPlayback = value
+        } else if property == "allowsAirPlayForMediaPlayback" {
+            if #available(iOS 9, *) {
+                self.allowsAirPlayForMediaPlayback = value
+            } else {
+                self.mediaPlaybackAllowsAirPlay = value
+            }
+        } else if property == "allowsPictureInPictureMediaPlayback" {
+            if #available(iOS 9, *) {
+                self.allowsPictureInPictureMediaPlayback = value
+            }
+        } else if property == "requiresUserActionForMediaPlayback" {
+            if #available(iOS 9, *) {
+                self.requiresUserActionForMediaPlayback = value
+            } else {
+                self.mediaPlaybackRequiresUserAction = value
+            }
+        }
+    }
+}
+
 protocol TabHelper {
     static func name() -> String
     func scriptMessageHandlerName() -> String?
@@ -151,6 +175,10 @@ class Tab: NSObject {
             configuration!.userContentController = WKUserContentController()
             configuration!.preferences = WKPreferences()
             configuration!.preferences.javaScriptCanOpenWindowsAutomatically = false
+            configuration!.setPlaybackPref(property: "allowsInlineMediaPlayback", value: true)
+            configuration!.setPlaybackPref(property: "allowsAirPlayForMediaPlayback", value: true)
+            configuration!.setPlaybackPref(property: "allowsPictureInPictureMediaPlayback", value: true)
+
             let webView = TabWebView(frame: CGRect.zero, configuration: configuration!)
             webView.delegate = self
             configuration = nil

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -69,6 +69,7 @@ class TabManager: NSObject {
         let configuration = WKWebViewConfiguration()
         configuration.processPool = WKProcessPool()
         configuration.preferences.javaScriptCanOpenWindowsAutomatically = !(self.prefs.boolForKey("blockPopups") ?? true)
+        configuration.setPlaybackPref(property: "requiresUserActionForMediaPlayback", value: !(self.prefs.boolForKey("allowAutoplay") ?? true))
         return configuration
     }()
 
@@ -77,6 +78,7 @@ class TabManager: NSObject {
         let configuration = WKWebViewConfiguration()
         configuration.processPool = WKProcessPool()
         configuration.preferences.javaScriptCanOpenWindowsAutomatically = !(self.prefs.boolForKey("blockPopups") ?? true)
+        configuration.setPlaybackPref(property: "requiresUserActionForMediaPlayback", value: !(self.prefs.boolForKey("allowAutoplay") ?? true))
         configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
         return configuration
     }()
@@ -324,7 +326,7 @@ class TabManager: NSObject {
             }
         }
         if flushToDisk {
-        	storeChanges()
+            storeChanges()
         }
     }
 
@@ -525,13 +527,18 @@ class TabManager: NSObject {
     func prefsDidChange() {
         DispatchQueue.main.async {
             let allowPopups = !(self.prefs.boolForKey("blockPopups") ?? true)
+            let allowAutoplay = !(self.prefs.boolForKey("allowAutoplay") ?? true)
             // Each tab may have its own configuration, so we should tell each of them in turn.
             for tab in self.tabs {
                 tab.webView?.configuration.preferences.javaScriptCanOpenWindowsAutomatically = allowPopups
+                tab.webView?.configuration.setPlaybackPref(property: "requiresUserActionForMediaPlayback", value: allowAutoplay)
             }
             // The default tab configurations also need to change.
             self.configuration.preferences.javaScriptCanOpenWindowsAutomatically = allowPopups
+            self.configuration.setPlaybackPref(property: "requiresUserActionForMediaPlayback", value: allowAutoplay)
+
             self.privateConfiguration.preferences.javaScriptCanOpenWindowsAutomatically = allowPopups
+            self.privateConfiguration.setPlaybackPref(property: "requiresUserActionForMediaPlayback", value: allowAutoplay)
         }
     }
 

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -52,6 +52,8 @@ class AppSettingsTableViewController: SettingsTableViewController {
                         titleText: NSLocalizedString("Save Logins", comment: "Setting to enable the built-in password manager")),
             BoolSetting(prefs: prefs, prefKey: AllowThirdPartyKeyboardsKey, defaultValue: false,
                         titleText: NSLocalizedString("Allow Third-Party Keyboards", comment: "Setting to enable third-party keyboards"), statusText: NSLocalizedString("Firefox needs to reopen for this change to take effect.", comment: "Setting value prop to enable third-party keyboards")),
+            BoolSetting(prefs: prefs, prefKey: "allowAutoplay", defaultValue: true,
+                        titleText: NSLocalizedString("Allow Autoplay", comment: "Setting to enable media autoplay"), statusText: NSLocalizedString("Control if websites can autoplay videos and other media content.", comment: "Setting value prop to enable media autoplay")),
             ]        
         
         let accountChinaSyncSetting: [Setting]


### PR DESCRIPTION
modifies permissions on tab creation to allow inline video and autoplay, recreation of https://github.com/mozilla-mobile/firefox-ios/pull/1651 with minor swift 3.0 adjustment.