### PR TITLE
Bug 1347853 - Investigate fix for intermittent XCUITests failures

### DIFF
--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -87,13 +87,35 @@ func createScreenGraph(_ app: XCUIApplication, url: String = "https://www.mozill
     map.createScene(SettingsScreen) { scene in
         let table = app.tables["AppSettingsTableViewController.tableView"]
 
-        scene.tap(table.cells["Search"], to: SearchSettings)
+        /*scene.tap(table.cells["Search"], to: SearchSettings)
         scene.tap(table.cells["NewTab"], to: NewTabSettings)
         scene.tap(table.cells["Homepage"], to: HomePageSettings)
         scene.tap(table.cells["TouchIDPasscode"], to: PasscodeSettings)
         scene.tap(table.cells["Logins"], to: LoginsSettings)
         scene.tap(table.cells["ClearPrivateData"], to: ClearPrivateDataSettings)
-        scene.tap(table.cells["OpenWith.Setting"], to: OpenWithSettings)
+        scene.tap(table.cells["OpenWith.Setting"], to: OpenWithSettings)*/
+
+        scene.gesture(to: SearchSettings) {
+            table.cells["Search"].tap()
+        }
+        scene.gesture(to: NewTabSettings) {
+            table.cells["NewTab"].tap()
+        }
+        scene.gesture(to: HomePageSettings) {
+            table.cells["Homepage"].tap()
+        }
+        scene.gesture(to: PasscodeSettings) {
+            table.cells["TouchIDPasscode"].tap()
+        }
+        scene.gesture(to: LoginsSettings) {
+            table.cells["Logins"].tap()
+        }
+        scene.gesture(to: ClearPrivateDataSettings) {
+            table.cells["ClearPrivateData"].tap()
+        }
+        scene.gesture(to: OpenWithSettings) {
+            table.cells["OpenWith.Setting"].tap()
+        }
 
         scene.backAction = navigationControllerBackAction
     }

--- a/XCUITests/ScreenGraph.swift
+++ b/XCUITests/ScreenGraph.swift
@@ -212,7 +212,7 @@ extension ScreenGraphNode {
      */
     func tap(_ element: XCUIElement, to nodeName: String, file: String = #file, line: UInt = #line) {
         self.gesture(withElement: element, to: nodeName, file: file, line: line) {
-            element.tap()
+            element.tap(force:true)
         }
     }
 

--- a/XCUITests/ThirdPartySearchTest.swift
+++ b/XCUITests/ThirdPartySearchTest.swift
@@ -56,7 +56,7 @@ class ThirdPartySearchTest: BaseTestCase {
         loadWebPage("https://developer.mozilla.org/en-US/search", waitForLoadToFinish: true)
 
         app.webViews.searchFields.element(boundBy: 0).tap()
-        app.buttons["AddSearch"].tap()
+        app.buttons["AddSearch"].tap(force: true)
         app.alerts["Add Search Provider?"].buttons["OK"].tap()
         XCTAssertFalse(app.buttons["AddSearch"].isEnabled)
         dismissKeyboardAssistant(forApp: app)


### PR DESCRIPTION
As commented in [previous PR](https://github.com/mozilla-mobile/firefox-ios/pull/2508) there are some intermittent failures happening occasionally. 
Summary of comments to take into account to try to fix those intermittent: 
- In some situations there might be a timing issue [here](https://github.com/mozilla-mobile/firefox-ios/blob/master/XCUITests/FxScreenGraph.swift#L93) when looking for a field in Settings menu, at the time Settings menu was just responding to the touch
- Looks like we need some kind of waiting call on [here](https://github.com/mozilla-mobile/firefox-ios/blob/master/XCUITests/ScreenGraph.swift#L215)  or other UI actions as well, to make sure the element is visible, and if not wait for a few seconds or so.
- Also on waitForElement: there may forcing with a coordinate might be helpful. ([see here](https://github.com/mozilla-mobile/firefox-ios/blob/master/XCUITests/ScreenGraph.swift#L170))