### PR TITLE
Bug 1347082 - Fix double loading of restored tabs

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -694,6 +694,9 @@ extension TabManager {
             // Provide an empty request to prevent a new tab from loading the home screen
             let tab = self.addTab(nil, configuration: nil, afterTab: nil, flushToDisk: false, zombie: true, isPrivate: savedTab.isPrivate)
 
+            // Since this is a restored tab, reset the URL to be loaded as that will be handled by the SessionRestoreHandler
+            tab.url = nil;
+            
             if let faviconURL = savedTab.faviconURL {
                 let icon = Favicon(url: faviconURL, date: Date(), type: IconType.noneFound)
                 icon.width = 1

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -695,7 +695,7 @@ extension TabManager {
             let tab = self.addTab(nil, configuration: nil, afterTab: nil, flushToDisk: false, zombie: true, isPrivate: savedTab.isPrivate)
 
             // Since this is a restored tab, reset the URL to be loaded as that will be handled by the SessionRestoreHandler
-            tab.url = nil;
+            tab.url = nil
             
             if let faviconURL = savedTab.faviconURL {
                 let icon = Favicon(url: faviconURL, date: Date(), type: IconType.noneFound)


### PR DESCRIPTION
This fix does not attack the root cause of this error, but I think that
will require significant refactoring.

I haven’t included any automated tests for this but I’m happy to be
asked to though I may need some direction as to the best place.