### PR TITLE
Bug 1347076 plugin kit crash

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -141,15 +141,15 @@ class BrowserViewController: UIViewController {
             self.displayedPopoverController = nil
         }
 
-        coordinator.animate(alongsideTransition: {context in
+        coordinator.animate(alongsideTransition: { context in
             self.scrollController.updateMinimumZoom()
             self.topTabsViewController?.scrollToCurrentTab(false, centerCell: false)
             if let popover = self.displayedPopoverController {
                 self.updateDisplayedPopoverProperties?()
                 self.present(popover, animated: true, completion: nil)
             }
-            }, completion: { _ in
-                self.scrollController.setMinimumZoom()
+        }, completion: { _ in
+            self.scrollController.setMinimumZoom()
         })
     }
 
@@ -1142,20 +1142,11 @@ class BrowserViewController: UIViewController {
             }
         })
 
-        let setupPopover = { [unowned self] in
-            if let popoverPresentationController = controller.popoverPresentationController {
-                popoverPresentationController.sourceView = sourceView
-                popoverPresentationController.sourceRect = sourceRect
-                popoverPresentationController.permittedArrowDirections = arrowDirection
-                popoverPresentationController.delegate = self
-            }
-        }
-
-        setupPopover()
-
-        if controller.popoverPresentationController != nil {
-            displayedPopoverController = controller
-            updateDisplayedPopoverProperties = setupPopover
+        if let popoverPresentationController = controller.popoverPresentationController {
+            popoverPresentationController.sourceView = sourceView
+            popoverPresentationController.sourceRect = sourceRect
+            popoverPresentationController.permittedArrowDirections = arrowDirection
+            popoverPresentationController.delegate = self
         }
 
         self.present(controller, animated: true, completion: nil)


### PR DESCRIPTION
Fix crash in Plugin Kit on rotation with extension displayed

Once upon a time, iOS seemed incapable of properly redisplaying modally presented views on rotation. We would therefore have to remember which view controllers were presented and then re-present them after rotation.

Now this seems to have been fixed, but the old code led to us trying to present modally a view controller that was already presented modally and therefore iOS threw a tantrum and quit.

This seems to be only a problem with UIActivityViewControllers, so we no longer remember the share menu when we display it so we don't try and re-add on rotation.

Tested with iPad Air 2 on iOS 10 & 9.3, iPhone 7 Plus and iPhone 6S Plus 10 & 9.3. The fact that we don't need to have separate code for iOS 10 and iOS 9.x suggests that this was a fix brought in in Swift 3.

https://bugzilla.mozilla.org/show_bug.cgi?id=1347076