### PR TITLE
Bug 1344736 – Make ECE accessible from Swift.

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -214,9 +214,11 @@
 		39409A3F1C90E68300DAE683 /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288A2D861AB8B3260023ABC3 /* Shared.framework */; };
 		39409A841C90EF2000DAE683 /* Today.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 39409A831C90EF2000DAE683 /* Today.entitlements */; };
 		394CF6CF1BAA493C00906917 /* DefaultSuggestedSites.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394CF6CE1BAA493C00906917 /* DefaultSuggestedSites.swift */; };
+		395C8F211E796AD600A68E8C /* PushDecrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395C8F201E796AD600A68E8C /* PushDecrypt.swift */; };
 		39A359E41BFCCE94006B9E87 /* SpotlightHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A359E31BFCCE94006B9E87 /* SpotlightHelper.swift */; };
 		39A35AED1C0662A3006B9E87 /* SpotlightHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 39A35AEC1C0662A3006B9E87 /* SpotlightHelper.js */; };
 		39AC591A1CC574AB0042C2F5 /* HomePageSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39AC59191CC574AA0042C2F5 /* HomePageSettingsViewController.swift */; };
+		39B0647D1E7ADAC2000BE173 /* PushDecryptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39B0647C1E7ADAC2000BE173 /* PushDecryptTests.swift */; };
 		39D9E6851C89E9690071FADA /* SnapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B604FA11C495268006EEEC3 /* SnapKit.framework */; };
 		39DD030D1CD53E1900BC09B3 /* HomePageHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39DD030C1CD53E1900BC09B3 /* HomePageHelper.swift */; };
 		39E65D191CA455A900C63CE3 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 391AEFD11C8F11ED00691F84 /* Images.xcassets */; };
@@ -1393,17 +1395,19 @@
 		392ED7E51D0AEFEF009D9B62 /* HomePageAccessors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HomePageAccessors.swift; path = Accessors/HomePageAccessors.swift; sourceTree = "<group>"; };
 		39409A831C90EF2000DAE683 /* Today.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = Today.entitlements; sourceTree = "<group>"; };
 		394CF6CE1BAA493C00906917 /* DefaultSuggestedSites.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultSuggestedSites.swift; sourceTree = "<group>"; };
+		395C8F201E796AD600A68E8C /* PushDecrypt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushDecrypt.swift; sourceTree = "<group>"; };
 		39A359E31BFCCE94006B9E87 /* SpotlightHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SpotlightHelper.swift; path = Helpers/SpotlightHelper.swift; sourceTree = "<group>"; };
 		39A35AEC1C0662A3006B9E87 /* SpotlightHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = SpotlightHelper.js; sourceTree = "<group>"; };
 		39AC59191CC574AA0042C2F5 /* HomePageSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomePageSettingsViewController.swift; sourceTree = "<group>"; };
+		39B0647C1E7ADAC2000BE173 /* PushDecryptTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushDecryptTests.swift; path = PushTests/PushDecryptTests.swift; sourceTree = "<group>"; };
 		39DD030C1CD53E1900BC09B3 /* HomePageHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomePageHelper.swift; sourceTree = "<group>"; };
 		39E65D261CA5B92000C63CE3 /* AsyncReducerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncReducerTests.swift; sourceTree = "<group>"; };
 		39EB46971E26DDB4006346E8 /* ScreenGraph.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenGraph.swift; sourceTree = "<group>"; };
 		39EB46981E26DDB4006346E8 /* FxScreenGraph.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxScreenGraph.swift; sourceTree = "<group>"; };
 		39F6D06F1CD3B0770055D949 /* HomePageSettingsUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomePageSettingsUITests.swift; sourceTree = "<group>"; };
-		39F99FD91E3A6DE300F353B4 /* PushClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushClient.swift; path = Push/PushClient.swift; sourceTree = "<group>"; };
-		39F99FDA1E3A6DE300F353B4 /* PushConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushConfiguration.swift; path = Push/PushConfiguration.swift; sourceTree = "<group>"; };
-		39F99FDB1E3A6DE300F353B4 /* PushRegistration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushRegistration.swift; path = Push/PushRegistration.swift; sourceTree = "<group>"; };
+		39F99FD91E3A6DE300F353B4 /* PushClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushClient.swift; sourceTree = "<group>"; };
+		39F99FDA1E3A6DE300F353B4 /* PushConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushConfiguration.swift; sourceTree = "<group>"; };
+		39F99FDB1E3A6DE300F353B4 /* PushRegistration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushRegistration.swift; sourceTree = "<group>"; };
 		39F99FDF1E3A6ED400F353B4 /* LivePushClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LivePushClientTests.swift; sourceTree = "<group>"; };
 		39F99FED1E3A71F800F353B4 /* FxALoginHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FxALoginHelper.swift; path = Helpers/FxALoginHelper.swift; sourceTree = "<group>"; };
 		3B0943801D6CC4FC004F24E1 /* FilledPageControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FilledPageControl.swift; path = ThirdParty/FilledPageControl.swift; sourceTree = "<group>"; };
@@ -2565,14 +2569,23 @@
 			name = Helpers;
 			sourceTree = "<group>";
 		};
+		39B0646D1E7ADA4B000BE173 /* PushTests */ = {
+			isa = PBXGroup;
+			children = (
+				39B0647C1E7ADAC2000BE173 /* PushDecryptTests.swift */,
+			);
+			name = PushTests;
+			sourceTree = "<group>";
+		};
 		39F99FC71E3A6DB700F353B4 /* Push */ = {
 			isa = PBXGroup;
 			children = (
 				39F99FD91E3A6DE300F353B4 /* PushClient.swift */,
 				39F99FDA1E3A6DE300F353B4 /* PushConfiguration.swift */,
+				395C8F201E796AD600A68E8C /* PushDecrypt.swift */,
 				39F99FDB1E3A6DE300F353B4 /* PushRegistration.swift */,
 			);
-			name = Push;
+			path = Push;
 			sourceTree = "<group>";
 		};
 		3B4262D31E538EB100CA681C /* Metadata Parsing */ = {
@@ -3283,6 +3296,7 @@
 				F84B21BF1A090F8100AAB793 /* Products */,
 				D34DC84C1A16C40C00D49B7B /* Providers */,
 				39F99FC71E3A6DB700F353B4 /* Push */,
+				39B0646D1E7ADA4B000BE173 /* PushTests */,
 				E4D567191ADECE2700F1EFE7 /* ReadingList */,
 				E4D567281ADECE2800F1EFE7 /* ReadingListTests */,
 				E4E0BB141AFBC9E4008D6260 /* Shared */,
@@ -4050,23 +4064,23 @@
 				TargetAttributes = {
 					2827315D1ABC9BE600AA1954 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 					};
 					282731671ABC9BE700AA1954 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = 9G8J6YA743;
+						DevelopmentTeam = 43AQ936H96;
 						LastSwiftMigration = 0820;
 						TestTargetID = F84B21BD1A090F8100AAB793;
 					};
 					288A2D851AB8B3260023ABC3 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 					};
 					2FA435FA1ABB83B4008031D1 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 					};
 					2FA436041ABB83B4008031D1 = {
@@ -4077,31 +4091,31 @@
 					};
 					2FCAE2191ABB51F800877008 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 					};
 					2FCAE2231ABB51F800877008 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = 9G8J6YA743;
+						DevelopmentTeam = 43AQ936H96;
 						LastSwiftMigration = 0820;
 						TestTargetID = F84B21BD1A090F8100AAB793;
 					};
 					390527491C874D35007E0BB7 = {
 						CreatedOnToolsVersion = 7.2.1;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 						ProvisioningStyle = Automatic;
 					};
 					3B43E3CF1D95C48D00BBA9DB = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = 9G8J6YA743;
+						DevelopmentTeam = 43AQ936H96;
 						LastSwiftMigration = 0820;
 						ProvisioningStyle = Automatic;
 						TestTargetID = F84B21BD1A090F8100AAB793;
 					};
 					3BFE4B061D342FB800DDF53F = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 						TestTargetID = F84B21BD1A090F8100AAB793;
 					};
@@ -4121,7 +4135,7 @@
 					};
 					E4BA8A2A1B4B0A1600BC2E95 = {
 						CreatedOnToolsVersion = 6.4;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -4132,7 +4146,7 @@
 					};
 					E4D567171ADECE2700F1EFE7 = {
 						CreatedOnToolsVersion = 6.3;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 					};
 					E4D567211ADECE2700F1EFE7 = {
@@ -4149,12 +4163,12 @@
 					};
 					E6F9650B1B2F1CF20034B023 = {
 						CreatedOnToolsVersion = 6.3.2;
-						DevelopmentTeam = 9G8J6YA743;
+						DevelopmentTeam = 43AQ936H96;
 						LastSwiftMigration = 0820;
 					};
 					F84B21BD1A090F8100AAB793 = {
 						CreatedOnToolsVersion = 6.1;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -4180,7 +4194,7 @@
 					};
 					F84B22481A0920C600AAB793 = {
 						CreatedOnToolsVersion = 6.1;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -4194,7 +4208,7 @@
 					};
 					F84B225B1A09210A00AAB793 = {
 						CreatedOnToolsVersion = 6.1;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -5246,6 +5260,7 @@
 				D3A9949D1A3686BD008AD1AC /* Tab.swift in Sources */,
 				741258A61D90B43E0064FC2A /* ActionOverlayTableViewAction.swift in Sources */,
 				A93067E81D0FE18E00C49C6E /* NightModeHelper.swift in Sources */,
+				395C8F211E796AD600A68E8C /* PushDecrypt.swift in Sources */,
 				3B39EDCB1E16E1AA00EF029F /* CustomSearchViewController.swift in Sources */,
 				E65075571E37F714006961AC /* FaviconFetcher.swift in Sources */,
 				D3C744CD1A687D6C004CE85D /* URIFixup.swift in Sources */,
@@ -5304,6 +5319,7 @@
 				03CCC9181AF05E7300DBF30D /* RelativeDatesTests.swift in Sources */,
 				F84B21DA1A090F8100AAB793 /* ClientTests.swift in Sources */,
 				281B2BEA1ADF4D90002917DC /* MockProfile.swift in Sources */,
+				39B0647D1E7ADAC2000BE173 /* PushDecryptTests.swift in Sources */,
 				2F697F7E1A9FD22D009E03AE /* SearchEnginesTests.swift in Sources */,
 				2F44FA1B1A9D426A00FD20CC /* TestHashExtensions.swift in Sources */,
 				3B39EDBA1E16E18900EF029F /* CustomSearchEnginesTest.swift in Sources */,

--- a/Push/PushDecrypt.swift
+++ b/Push/PushDecrypt.swift
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import FxA
+
+/// Class to wrap ece.c which does the decryption with OpenSSL.
+/// This supports aes128gcm and aesgcm.
+/// This will also support the generation of keys to register with a push server.
+class PushDecrypt {
+    func aes128gcm(payload data: String, decryptWith privateKey: String, authenticateWith authKey: String) throws -> String {
+        var authSecret = try stringToBuffer(authKey)
+        var rawRecvPrivKey = try stringToBuffer(privateKey)
+        var plaintext = emptyBuffer()
+        var payload = try stringToBuffer(data)
+
+        defer {
+            ece_buf_free(&authSecret)
+            ece_buf_free(&rawRecvPrivKey)
+            ece_buf_free(&payload)
+            ece_buf_free(&plaintext)
+        }
+
+        let err =
+            ece_aes128gcm_decrypt(&rawRecvPrivKey, &authSecret, &payload, &plaintext)
+        if (err != 0) {
+            throw PushDecryptError.cantDecrypt
+        }
+        
+        return try bufferToString(plaintext)
+    }
+
+    func aesgcm(ciphertext data: String, decryptWith privateKey: String, authenticateWith authKey: String, encryptionHeader: String, cryptoKeyHeader: String) throws -> String {
+
+        var authSecret = try stringToBuffer(authKey)
+        var rawRecvPrivKey = try stringToBuffer(privateKey)
+        var plaintext = emptyBuffer()
+        var ciphertext = try stringToBuffer(data)
+
+        defer {
+            ece_buf_free(&authSecret)
+            ece_buf_free(&rawRecvPrivKey)
+            ece_buf_free(&ciphertext)
+            ece_buf_free(&plaintext)
+        }
+
+        let err = ece_aesgcm_decrypt(&rawRecvPrivKey, &authSecret, cryptoKeyHeader,
+                           encryptionHeader, &ciphertext, &plaintext)
+        if (err != 0) {
+            throw PushDecryptError.cantDecrypt
+        }
+
+        return try bufferToString(plaintext)
+    }
+}
+
+/// Some utility methods that make package up dealing with the C API a little easier.
+extension PushDecrypt {
+    func emptyBuffer() -> ece_buf_t {
+        var bytes = [UInt8]()
+        return ece_buf_t(bytes: &bytes, length: 0)
+    }
+
+    /// Converts a Swift string into a ece_buf_t. It assumes that the String is base64 encoded.
+    func stringToBuffer(_ string: String) throws -> ece_buf_t {
+        var cstring = [UInt8](string.utf8).map { Int8($0) }
+        var buffer = emptyBuffer()
+        // Using ece_base64url_decode with REJECT_PADDING
+        // is a quicker way to get to ece_buf_t than using Data(base64Encoded:,options:)
+        ece_base64url_decode(&cstring, cstring.count, ECE_BASE64URL_REJECT_PADDING, &buffer)
+
+        return buffer
+    }
+
+    func bufferToString(_ buffer: ece_buf_t) throws -> String {
+        guard let bytes = buffer.bytes else {
+            throw PushDecryptError.zeroBytes
+        }
+        let data = Data(bytes: bytes, count: buffer.length)
+        return data.utf8EncodedString!
+    }
+
+    func dataToBuffer(_ data: Data) -> ece_buf_t {
+        var bytes = data.getBytes()
+        return ece_buf_t(bytes: &bytes, length: bytes.count)
+    }
+}
+
+enum PushDecryptError: Error {
+    case cantBase64Decode
+    case cantDecrypt
+    case zeroBytes
+}

--- a/PushTests/PushDecryptTests.swift
+++ b/PushTests/PushDecryptTests.swift
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@testable import Client
+import XCTest
+
+
+class PushDecryptTests: XCTestCase {
+
+    let push = PushDecrypt()
+
+    func testStringToBuffer() {
+        guard let buffer = try? push.stringToBuffer("SSBhbSB0aGUgd2FscnVz") else {
+            return XCTFail("stringToBuffer failed")
+        }
+
+        guard let string = try? push.bufferToString(buffer) else {
+            return XCTFail("bufferToString failed")
+        }
+
+        XCTAssertEqual(string, "I am the walrus")
+    }
+
+    func testDecrypt_aes128gcm() {
+        struct Aes128GcmTest {
+            let payload: String
+            let recvPrivKey: String
+            let authSecret: String
+            let plaintext: String
+        }
+
+        let tests = [
+            Aes128GcmTest(
+                payload: "SVzmyN6TpFOehi6GNJk8uwAAABhBBDwzeKLAq5VOFJhxjoXwi7cj-30l4TWmY_44WITrgZIza_kKVO1yDxwEXAtAXpu8OiFCsWyJCGc0w3Trr3CZ5kJ-LTLIraUBhwPFSxC0geECfXIJ2Ma0NVP6Ezr6WX8t3EWluoFAlE5kkLuNbZm6HQLmDZX0jOZER3wXIx2VuXpPld0",
+                recvPrivKey: "yJnRHTLit-b-dJh4b1DyO5is5Tl60mHeObpkSezBLK0",
+                authSecret: "mW-ti1CqLQK4PyZBKy4q7g",
+                plaintext: "I am the walrus"
+            ),
+            Aes128GcmTest(
+                payload: "DGv6ra1nlYgDCS1FRnbzlwAAEABBBP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A_yl95bQpu6cVPTpK4Mqgkf1CXztLVBSt2Ks3oZwbuwXPXLWyouBWLVWGNWQexSgSxsj_Qulcy4a-fN",
+                recvPrivKey: "q1dXpw3UpT5VOmu_cf_v6ih07Aems3njxI-JWgLcM94",
+                authSecret: "BTBZMqHH6r4Tts7J_aSIgg",
+                plaintext: "When I grow up, I want to be a watermelon"
+            ),
+        ]
+
+        for test in tests {
+            if let deciphered = try? push.aes128gcm(payload: test.payload,
+                                                    decryptWith: test.recvPrivKey,
+                                                    authenticateWith: test.authSecret) {
+                XCTAssertEqual(deciphered, test.plaintext)
+            } else {
+                XCTFail("Failed to decipher \(test.plaintext)")
+            }
+        }
+    }
+
+    func testDecrypt_aesgcm() {
+        struct AesGcmTest {
+            let plaintext: String
+            let recvPrivKey: String
+            let authSecret: String
+            let ciphertext: String
+            let cryptoKey: String
+            let encryption: String
+        }
+
+        let tests = [
+            AesGcmTest(
+                plaintext: "I am the walrus",
+                recvPrivKey: "9FWl15_QUQAWDaD3k3l50ZBZQJ4au27F1V4F0uLSD_M",
+                authSecret: "R29vIGdvbyBnJyBqb29iIQ",
+                ciphertext: "6nqAQUME8hNqw5J3kl8cpVVJylXKYqZOeseZG8UueKpA",
+                cryptoKey: "keyid=\"dhkey\"; dh=\"BNoRDbb84JGm8g5Z5CFxurSqsXWJ11ItfXEWYVLE85Y7CYkDjXsIEc4aqxYaQ1G8BqkXCJ6DPpDrWtdWj_mugHU\"",
+                encryption: "keyid=\"dhkey\"; salt=\"lngarbyKfMoi9Z75xYXmkg\""
+            ),
+            AesGcmTest(
+                plaintext: "Small record size",
+                recvPrivKey: "4h23G_KkXC9TvBSK2v0Q7ImpS2YAuRd8hQyN0rFAwBg",
+                authSecret: "g2rWVHUCpUxgcL9Tz7vyeQ",
+                ciphertext: "oY4e5eDatDVt2fpQylxbPJM-3vrfhDasfPc8Q1PWt4tPfMVbz_sDNL_cvr0DXXkdFzS1lxsJsj550USx4MMl01ihjImXCjrw9R5xFgFrCAqJD3GwXA1vzS4T5yvGVbUp3SndMDdT1OCcEofTn7VC6xZ-zP8rzSQfDCBBxmPU7OISzr8Z4HyzFCGJeBfqiZ7yUfNlKF1x5UaZ4X6iU_TXx5KlQy_toV1dXZ2eEAMHJUcSdArvB6zRpFdEIxdcHcJyo1BIYgAYTDdAIy__IJVCPY_b2CE5W_6ohlYKB7xDyH8giNuWWXAgBozUfScLUVjPC38yJTpAUi6w6pXgXUWffende5FreQpnMFL1L4G-38wsI_-ISIOzdO8QIrXHxmtc1S5xzYu8bMqSgCinvCEwdeGFCmighRjj8t1zRWo0D14rHbQLPR_b1P5SvEeJTtS9Nm3iibM",
+                cryptoKey: "dh=BCg6ZIGuE2ZNm2ti6Arf4CDVD_8--aLXAGLYhpghwjl1xxVjTLLpb7zihuEOGGbyt8Qj0_fYHBP4ObxwJNl56bk",
+                encryption: "salt=5LIDBXbvkBvvb7ZdD-T4PQ; rs=3"
+            ),
+            AesGcmTest(
+                plaintext: "Yet another message",
+                recvPrivKey: "4h23G_KkXC9TvBSK2v0Q7ImpS2YAuRd8hQyN0rFAwBg",
+                authSecret: "6plwZnSpVUbF7APDXus3UQ",
+                ciphertext: "uEC5B_tR-fuQ3delQcrzrDCp40W6ipMZjGZ78USDJ5sMj-6bAOVG3AK6JqFl9E6AoWiBYYvMZfwThVxmDnw6RHtVeLKFM5DWgl1EwkOohwH2EhiDD0gM3io-d79WKzOPZE9rDWUSv64JstImSfX_ADQfABrvbZkeaWxh53EG59QMOElFJqHue4dMURpsMXg",
+                cryptoKey: "dh=BEaA4gzA3i0JDuirGhiLgymS4hfFX7TNTdEhSk_HBlLpkjgCpjPL5c-GL9uBGIfa_fhGNKKFhXz1k9Kyens2ZpQ",
+                encryption: "salt=ZFhzj0S-n29g9P2p4-I7tA; rs=8"
+            ),
+            AesGcmTest(
+                plaintext: "Some message",
+                recvPrivKey: "4h23G_KkXC9TvBSK2v0Q7ImpS2YAuRd8hQyN0rFAwBg",
+                authSecret: "aTDc6JebzR6eScy2oLo4RQ",
+                ciphertext: "Oo34w2F9VVnTMFfKtdx48AZWQ9Li9M6DauWJVgXU",
+                cryptoKey: "dh=BCHFVrflyxibGLlgztLwKelsRZp4gqX3tNfAKFaxAcBhpvYeN1yIUMrxaDKiLh4LNKPtj0BOXGdr-IQ-QP82Wjo",
+                encryption: "salt=zCU18Rw3A5aB_Xi-vfixmA; rs=24"
+            )
+        ]
+
+        for test in tests {
+            if let deciphered = try? push.aesgcm(ciphertext: test.ciphertext,
+                                                 decryptWith: test.recvPrivKey,
+                                                 authenticateWith: test.authSecret,
+                                                 encryptionHeader: test.encryption,
+                                                 cryptoKeyHeader: test.cryptoKey) {
+                XCTAssertEqual(deciphered, test.plaintext)
+            } else {
+                XCTFail("Failed to decipher \(test.plaintext)")
+            }
+
+        }
+    }
+
+}


### PR DESCRIPTION
This introduces a new file, `PushDecrypt` which makes available the ecec to Swift. 

This supports the two push encryption standards `aes128gcm` and `aesgcm`.

It also ports the happy case tests from ecec, which is as much demonstrating that the plumbing works as showing that we can decrypt.

https://bugzilla.mozilla.org/show_bug.cgi?id=1344736