### PR TITLE
Bug 1346573 – Clear Spotlight search when history is cleared.

### DIFF
--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -44,6 +44,7 @@ class HistoryClearable: Clearable {
             SDImageCache.shared().clearDisk()
             SDImageCache.shared().clearMemory()
             self.profile.recentlyClosedTabs.clearTabs()
+            SpotlightHelper.clearSearchIndex()
             NotificationCenter.default.post(name: NotificationPrivateDataClearedHistory, object: nil)
             log.debug("HistoryClearable succeeded: \(success).")
             return Deferred(value: success)

--- a/Client/Helpers/SpotlightHelper.swift
+++ b/Client/Helpers/SpotlightHelper.swift
@@ -131,3 +131,9 @@ extension SpotlightHelper: TabHelper {
         }
     }
 }
+
+extension SpotlightHelper {
+    class func clearSearchIndex(completionHandler: ((Error?) -> Void)? = nil) {
+        CSSearchableIndex.default().deleteAllSearchableItems(completionHandler: completionHandler)
+    }
+}


### PR DESCRIPTION
This was a bit of research that turned in to a pull request.

This PR clears the spotlight search index when the user clears the History.

https://bugzilla.mozilla.org/show_bug.cgi?id=1346573