### PR TITLE
Bug 1349938 - Use non-pretty printing for rawString when encoding records for syncing

### DIFF
--- a/Account/FxAClient10.swift
+++ b/Account/FxAClient10.swift
@@ -260,7 +260,7 @@ open class FxAClient10 {
         mutableURLRequest.httpMethod = HTTPMethod.post.rawValue
 
         mutableURLRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        mutableURLRequest.httpBody = JSON(parameters).rawString()?.utf8EncodedData
+        mutableURLRequest.httpBody = JSON(parameters).stringValue()?.utf8EncodedData
 
         return makeRequest(mutableURLRequest, responseHandler: FxAClient10.loginResponse)
     }
@@ -296,7 +296,7 @@ open class FxAClient10 {
         mutableURLRequest.httpMethod = HTTPMethod.post.rawValue
 
         mutableURLRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        mutableURLRequest.httpBody = device.toJSON().rawString()?.utf8EncodedData
+        mutableURLRequest.httpBody = device.toJSON().stringValue()?.utf8EncodedData
 
         let salt: Data = Data()
         let contextInfo: Data = FxAClient10.KW("sessionToken")
@@ -373,7 +373,7 @@ extension FxAClient10: FxALoginClient {
         mutableURLRequest.httpMethod = HTTPMethod.post.rawValue
 
         mutableURLRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        mutableURLRequest.httpBody = JSON(parameters as NSDictionary).rawString()?.utf8EncodedData
+        mutableURLRequest.httpBody = JSON(parameters as NSDictionary).stringValue()?.utf8EncodedData
 
         let salt: Data = Data()
         let contextInfo: Data = FxAClient10.KW("sessionToken")

--- a/Account/FxADevice.swift
+++ b/Account/FxADevice.swift
@@ -59,9 +59,9 @@ public struct FxADevice {
         let isCurrentDevice = json["isCurrentDevice"].bool ?? false
 
         let push: FxADevicePushParams?
-        if let pushCallback = json["pushCallback"].rawString(),
-            let publicKey = json["pushPublicKey"].rawString(), publicKey != "",
-            let authKey   = json["pushAuthKey"].rawString(), authKey != "" {
+        if let pushCallback = json["pushCallback"].stringValue(),
+            let publicKey = json["pushPublicKey"].stringValue(), publicKey != "",
+            let authKey   = json["pushAuthKey"].stringValue(), authKey != "" {
             push = FxADevicePushParams(callback: pushCallback, publicKey: publicKey, authKey: authKey)
         } else {
             push = nil

--- a/Client/Frontend/Browser/LoginsHelper.swift
+++ b/Client/Frontend/Browser/LoginsHelper.swift
@@ -228,7 +228,7 @@ class LoginsHelper: TabHelper {
             }
 
             let json = JSON(jsonObj)
-            let src = "window.__firefox__.logins.inject(\(json.rawString()!))"
+            let src = "window.__firefox__.logins.inject(\(json.stringValue()!))"
             self.tab?.webView?.evaluateJavaScript(src, completionHandler: { (obj, err) -> Void in
             })
         }

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -191,7 +191,7 @@ class Tab: NSObject {
             var jsonDict = [String: AnyObject]()
             jsonDict["history"] = urls as AnyObject?
             jsonDict["currentPage"] = currentPage as AnyObject?
-            guard let json = JSON(jsonDict).rawString(.utf8, options: []) else {
+            guard let json = JSON(jsonDict).stringValue() else {
                 return
             }
             let escapedJSON = json.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!

--- a/Client/Frontend/Reader/ReaderMode.swift
+++ b/Client/Frontend/Reader/ReaderMode.swift
@@ -103,7 +103,7 @@ struct ReaderModeStyle {
 
     /// Encode the style to a JSON dictionary that can be passed to ReaderMode.js
     func encode() -> String {
-        return JSON(["theme": theme.rawValue, "fontType": fontType.rawValue, "fontSize": fontSize.rawValue]).rawString() ?? ""
+        return JSON(["theme": theme.rawValue, "fontType": fontType.rawValue, "fontSize": fontSize.rawValue]).stringValue() ?? ""
     }
 
     /// Encode the style to a dictionary that can be stored in the profile
@@ -201,7 +201,7 @@ struct ReadabilityResult {
     /// Encode to a JSON encoded string
     func encode() -> String {
         let dict: [String: Any] = self.encode()
-        return JSON(object: dict).rawString()!
+        return JSON(object: dict).stringValue()!
     }
 }
 

--- a/Client/Frontend/Settings/FxAContentViewController.swift
+++ b/Client/Frontend/Settings/FxAContentViewController.swift
@@ -86,7 +86,7 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
             "type": type,
             "content": content,
         ] as [String : Any]
-        let json = JSON(data).rawString(.utf8, options: []) ?? ""
+        let json = JSON(data).stringValue() ?? ""
         let script = "window.postMessage(\(json), '\(self.url.absoluteString)');"
         webView.evaluateJavaScript(script, completionHandler: nil)
     }

--- a/Client/Helpers/FxALoginHelper.swift
+++ b/Client/Helpers/FxALoginHelper.swift
@@ -91,7 +91,7 @@ class FxALoginHelper {
     // It manages the asking for user permission for notification and registration 
     // for APNS and WebPush notifications.
     func application(_ application: UIApplication, didReceiveAccountJSON data: JSON) {
-        if data["keyFetchToken"].rawString() == nil || data["unwrapBKey"].rawString() == nil {
+        if data["keyFetchToken"].stringValue() == nil || data["unwrapBKey"].stringValue() == nil {
             // The /settings endpoint sends a partial "login"; ignore it entirely.
             log.error("Ignoring didSignIn with keyFetchToken or unwrapBKey missing.")
             return self.loginDidFail()

--- a/Push/PushClient.swift
+++ b/Push/PushClient.swift
@@ -87,7 +87,7 @@ public extension PushClient {
 
         mutableURLRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         let parameters = ["token": apnsToken]
-        mutableURLRequest.httpBody = JSON(parameters).rawString()?.utf8EncodedData
+        mutableURLRequest.httpBody = JSON(parameters).stringValue()?.utf8EncodedData
 
         return send(request: mutableURLRequest) >>== { json in
             guard let response = PushRegistration.from(json: json) else {
@@ -108,7 +108,7 @@ public extension PushClient {
 
         mutableURLRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         let parameters = ["token": apnsToken]
-        mutableURLRequest.httpBody = JSON(parameters).rawString()?.utf8EncodedData
+        mutableURLRequest.httpBody = JSON(parameters).stringValue()?.utf8EncodedData
 
         return send(request: mutableURLRequest) >>== { json in
             guard let response = PushRegistration.from(json: json) else {

--- a/Push/PushRegistration.swift
+++ b/Push/PushRegistration.swift
@@ -41,11 +41,11 @@ public class PushRegistration: NSObject, NSCoding {
     //     protected final @NonNull Map<String, PushSubscription> subscriptions;
 
     public static func from(json: JSON) -> PushRegistration? {
-        guard let endpointString = json["endpoint"].rawString(),
+        guard let endpointString = json["endpoint"].stringValue(),
               let endpoint = NSURL(string: endpointString),
-              let secret = json["secret"].rawString(),
-              let uaid = json["uaid"].rawString(),
-              let channelID = json["channelID"].rawString() else {
+              let secret = json["secret"].stringValue(),
+              let uaid = json["uaid"].stringValue(),
+              let channelID = json["channelID"].stringValue() else {
             return nil
         }
 

--- a/Shared/Extensions/JSONExtensions.swift
+++ b/Shared/Extensions/JSONExtensions.swift
@@ -45,4 +45,11 @@ public extension JSON {
     func isDouble() -> Bool {
         return self.type == .number && self.double != nil
     }
+
+    // SwiftyJSON pretty prints the string value by default. Since all of our
+    // existing code required the string to not be pretty printed, this helper
+    // can be used as a shorthand for non-pretty printed strings.
+    func stringValue() -> String? {
+        return self.rawString(.utf8, options: [])
+    }
 }

--- a/Shared/KeychainCache.swift
+++ b/Shared/KeychainCache.swift
@@ -54,7 +54,7 @@ open class KeychainCache<T: JSONLiteralConvertible> {
         log.info("Storing \(self.branch) in Keychain with label \(self.branch).\(self.label).")
         // TODO: PII logging.
         if let value = value,
-            let jsonString = value.asJSON().rawString() {
+            let jsonString = value.asJSON().stringValue() {
             KeychainWrapper.sharedAppContainerKeychain.set(jsonString, forKey: "\(branch).\(label)")
         } else {
             KeychainWrapper.sharedAppContainerKeychain.removeObject(forKey: "\(branch).\(label)")

--- a/Storage/SyncQueue.swift
+++ b/Storage/SyncQueue.swift
@@ -42,7 +42,7 @@ public struct SyncCommand: Equatable {
             "command": "displayURI",
             "args": [shareItem.url, sender, shareItem.title ?? ""]
         ]
-        return SyncCommand(value: JSON(object: jsonObj).rawString()!)
+        return SyncCommand(value: JSON(object: jsonObj).stringValue()!)
     }
 
     public func withClientGUID(_ clientGUID: String?) -> SyncCommand {

--- a/StorageTests/SyncCommandsTests.swift
+++ b/StorageTests/SyncCommandsTests.swift
@@ -71,7 +71,7 @@ class SyncCommandsTests: XCTestCase {
             "command": "displayURI",
             "args": [shareItem.url, "abcdefghijkl", shareItem.title ?? ""]
         ]
-        XCTAssertEqual(JSON(object: jsonObj).rawString(), syncCommand.value)
+        XCTAssertEqual(JSON(object: jsonObj).stringValue(), syncCommand.value)
     }
 
     func testInsertWithNoURLOrTitle() {

--- a/Sync/EnvelopeJSON.swift
+++ b/Sync/EnvelopeJSON.swift
@@ -54,7 +54,7 @@ open class EnvelopeJSON {
     }
 
     open func toString() -> String {
-        return self.json.rawString()!
+        return self.json.stringValue()!
     }
 
     open func withModified(_ now: Timestamp) -> EnvelopeJSON {

--- a/Sync/KeyBundle.swift
+++ b/Sync/KeyBundle.swift
@@ -172,7 +172,7 @@ open class KeyBundle: Hashable {
     open func serializer<T: CleartextPayloadJSON>(_ f: @escaping (T) -> JSON) -> (Record<T>) -> JSON? {
         return { (record: Record<T>) -> JSON? in
             let json = f(record.payload)
-            let data = (json.rawString() ?? "").utf8EncodedData
+            let data = (json.stringValue() ?? "").utf8EncodedData
 
             // We pass a null IV, which means "generate me a new one".
             // We then include the generated IV in the resulting record.
@@ -186,7 +186,7 @@ open class KeyBundle: Hashable {
                     let iv = iv.base64EncodedString
 
                     // The payload is stringified JSON. Yes, I know.
-                    let payload: Any = JSON(object: ["ciphertext": ciphertext, "IV": iv, "hmac": hmac]).rawString()! as Any
+                    let payload: Any = JSON(object: ["ciphertext": ciphertext, "IV": iv, "hmac": hmac]).stringValue()! as Any
                     let obj = ["id": record.id, "sortindex": record.sortindex, "ttl": record.ttl as Any, "payload": payload]
                     return JSON(object: obj)
                 }

--- a/Sync/Record.swift
+++ b/Sync/Record.swift
@@ -56,7 +56,7 @@ open class Record<T: CleartextPayloadJSON> {
         }
 
         if !payload.isValid() {
-            log.warning("Invalid payload \(payload.json.rawString()).")
+            log.warning("Invalid payload \(payload.json.stringValue()).")
         }
 
         return Record<T>(envelope: envelope, payload: payload)

--- a/Sync/State.swift
+++ b/Sync/State.swift
@@ -489,7 +489,7 @@ open class Scratchpad {
         prefs.setInt(1, forKey: PrefVersion)
         if let global = global {
             prefs.setLong(global.timestamp, forKey: PrefGlobalTS)
-            prefs.setString(global.value.asPayload().json.rawString()!, forKey: PrefGlobal)
+            prefs.setString(global.value.asPayload().json.stringValue()!, forKey: PrefGlobal)
         } else {
             prefs.removeObjectForKey(PrefGlobal)
             prefs.removeObjectForKey(PrefGlobalTS)
@@ -498,7 +498,7 @@ open class Scratchpad {
         // We store the meat of your keys in the Keychain, using a random identifier that we persist in prefs.
         prefs.setString(self.keyLabel, forKey: PrefKeyLabel)
         if let keys = self.keys,
-            let payload = keys.value.asPayload().json.rawString() {
+            let payload = keys.value.asPayload().json.stringValue() {
             let label = "keys." + self.keyLabel
             log.debug("Storing keys in Keychain with label \(label).")
             prefs.setString(self.keyLabel, forKey: PrefKeyLabel)
@@ -514,11 +514,11 @@ open class Scratchpad {
         prefs.setString(clientName, forKey: PrefClientName)
         prefs.setString(clientGUID, forKey: PrefClientGUID)
 
-        let localCommands: [String] = Array(self.localCommands).map({$0.toJSON().rawString()!})
+        let localCommands: [String] = Array(self.localCommands).map({$0.toJSON().stringValue()!})
         prefs.setObject(localCommands, forKey: PrefLocalCommands)
 
         if let engineConfiguration = self.engineConfiguration {
-            prefs.setString(engineConfiguration.toJSON().rawString()!, forKey: PrefEngineConfiguration)
+            prefs.setString(engineConfiguration.toJSON().stringValue()!, forKey: PrefEngineConfiguration)
         } else {
             prefs.removeObjectForKey(PrefEngineConfiguration)
         }

--- a/Sync/StorageClient.swift
+++ b/Sync/StorageClient.swift
@@ -448,11 +448,11 @@ open class Sync15StorageClient {
     }
 
     func requestPUT(_ url: URL, body: JSON, ifUnmodifiedSince: Timestamp?) -> Request {
-        return self.requestWrite(url, method: URLRequest.Method.put.rawValue, body: body.rawString()!, contentType: "application/json;charset=utf-8", ifUnmodifiedSince: ifUnmodifiedSince)
+        return self.requestWrite(url, method: URLRequest.Method.put.rawValue, body: body.stringValue()!, contentType: "application/json;charset=utf-8", ifUnmodifiedSince: ifUnmodifiedSince)
     }
 
     func requestPOST(_ url: URL, body: JSON, ifUnmodifiedSince: Timestamp?) -> Request {
-        return self.requestWrite(url, method: URLRequest.Method.post.rawValue, body: body.rawString()!, contentType: "application/json;charset=utf-8", ifUnmodifiedSince: ifUnmodifiedSince)
+        return self.requestWrite(url, method: URLRequest.Method.post.rawValue, body: body.stringValue()!, contentType: "application/json;charset=utf-8", ifUnmodifiedSince: ifUnmodifiedSince)
     }
 
     func requestPOST(_ url: URL, body: [String], ifUnmodifiedSince: Timestamp?) -> Request {
@@ -461,7 +461,7 @@ open class Sync15StorageClient {
     }
 
     func requestPOST(_ url: URL, body: [JSON], ifUnmodifiedSince: Timestamp?) -> Request {
-        return self.requestPOST(url, body: body.map { $0.rawString()! }, ifUnmodifiedSince: ifUnmodifiedSince)
+        return self.requestPOST(url, body: body.map { $0.stringValue()! }, ifUnmodifiedSince: ifUnmodifiedSince)
     }
 
     /**
@@ -584,7 +584,7 @@ open class Sync15StorageClient {
             return Deferred(value: Maybe(failure: MalformedMetaGlobalError()))
         }
 
-        let record: JSON = JSON(object: ["payload": payload.json.rawString() ?? JSON.null as Any, "id": "global"])
+        let record: JSON = JSON(object: ["payload": payload.json.stringValue() ?? JSON.null as Any, "id": "global"])
         return putResource("storage/meta/global", body: record, ifUnmodifiedSince: ifUnmodifiedSince, parser: decimalSecondsStringToTimestamp)
     }
 
@@ -645,7 +645,7 @@ open class Sync15CollectionClient<T: CleartextPayloadJSON> {
 
     // Exposed so we can batch by size.
     open func serializeRecord(_ record: Record<T>) -> String? {
-        return self.encrypter.serializer(record)?.rawString(.utf8, options: [])
+        return self.encrypter.serializer(record)?.stringValue()
     }
 
     open func post(_ lines: [String], ifUnmodifiedSince: Timestamp?, queryParams: [URLQueryItem]? = nil) -> Deferred<Maybe<StorageResponse<POSTResult>>> {

--- a/Sync/StorageClient.swift
+++ b/Sync/StorageClient.swift
@@ -645,7 +645,7 @@ open class Sync15CollectionClient<T: CleartextPayloadJSON> {
 
     // Exposed so we can batch by size.
     open func serializeRecord(_ record: Record<T>) -> String? {
-        return self.encrypter.serializer(record)?.rawString()
+        return self.encrypter.serializer(record)?.rawString(.utf8, options: [])
     }
 
     open func post(_ lines: [String], ifUnmodifiedSince: Timestamp?, queryParams: [URLQueryItem]? = nil) -> Deferred<Maybe<StorageResponse<POSTResult>>> {

--- a/Sync/Synchronizers/TabsSynchronizer.swift
+++ b/Sync/Synchronizers/TabsSynchronizer.swift
@@ -41,7 +41,7 @@ open class TabsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchroniz
             "tabs": jsonTabs
         ])
         if Logger.logPII {
-            log.verbose("Sending tabs JSON \(tabsJSON.rawString())")
+            log.verbose("Sending tabs JSON \(tabsJSON.stringValue())")
         }
         let payload = TabsPayload(tabsJSON)
         return Record(id: guid, payload: payload, ttl: ThreeWeeksInSeconds)

--- a/SyncTests/BatchingClientTests.swift
+++ b/SyncTests/BatchingClientTests.swift
@@ -22,7 +22,7 @@ private func basicSerializer<T>(record: Record<T>) -> String {
     return JSON(object: [
         "id": record.id,
         "payload": record.payload.json.dictionaryObject as Any
-    ]).rawString()!
+        ]).stringValue()!
 }
 
 // Create a basic record with an ID and a title that is the `Site$ID`.
@@ -69,7 +69,7 @@ class Sync15BatchClientTests: XCTestCase {
 
     func testAddLargeRecordFails() {
         let uploader: BatchUploadFunction = { _ in deferEmptyResponse(lastModified: 10_000) }
-        let serializeRecord = { massivify($0)?.rawString() }
+        let serializeRecord = { massivify($0)?.stringValue() }
 
         let batch = Sync15BatchClient(config: miniConfig,
                                       ifUnmodifiedSince: nil,

--- a/SyncTests/LiveStorageClientTests.swift
+++ b/SyncTests/LiveStorageClientTests.swift
@@ -74,7 +74,7 @@ class LiveStorageClientTests: LiveAccountTest {
                 XCTAssert(rec.id == "keys", "GUID is correct.")
                 XCTAssert(rec.modified > 1000, "modified is sane.")
                 let payload: KeysPayload = rec.payload as KeysPayload
-                print("Body: \(payload.json.rawString())", terminator: "\n")
+                print("Body: \(payload.json.stringValue())", terminator: "\n")
                 XCTAssert(rec.id == "keys", "GUID inside is correct.")
                 if let keys = payload.defaultKeys {
                     // Extracting the token like this is not great, but...

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -57,7 +57,7 @@ class MetaGlobalTests: XCTestCase {
         let envelope = EnvelopeJSON(JSON(object: [
             "id": "global",
             "collection": "meta",
-            "payload": metaGlobal.asPayload().json.rawString()!,
+            "payload": metaGlobal.asPayload().json.stringValue()!,
             "modified": Double(Date.now())/1000]))
         server.storeRecords(records: [envelope], inCollection: "meta")
     }

--- a/SyncTests/MockSyncServer.swift
+++ b/SyncTests/MockSyncServer.swift
@@ -169,14 +169,14 @@ class MockSyncServer {
             "commands": [],
             "type": "mobile",
         ]
-        let clientBodyString = JSON(object: clientBody).rawString()!
+        let clientBodyString = JSON(object: clientBody).stringValue()!
         let clientRecord: [String : Any] = [
             "id": guid,
             "collection": "clients",
             "payload": clientBodyString,
             "modified": Double(modified) / 1000,
         ]
-        return EnvelopeJSON(JSON(object: clientRecord).rawString()!)
+        return EnvelopeJSON(JSON(object: clientRecord).stringValue()!)
     }
 
     class func withHeaders(response: GCDWebServerResponse, lastModified: Timestamp? = nil, records: Int? = nil, timestamp: Timestamp? = nil) -> GCDWebServerResponse {
@@ -280,14 +280,14 @@ class MockSyncServer {
     }
 
     private func recordResponse(record: EnvelopeJSON) -> GCDWebServerResponse {
-        let body = record.asJSON().rawString()!
+        let body = record.asJSON().stringValue()!
         let bodyData = body.utf8EncodedData
         let response = GCDWebServerDataResponse(data: bodyData, contentType: "application/json")
         return MockSyncServer.withHeaders(response: response!, lastModified: record.modified)
     }
 
     private func modifiedResponse(timestamp: Timestamp) -> GCDWebServerResponse {
-        let body = JSON(object: ["modified": timestamp]).rawString()
+        let body = JSON(object: ["modified": timestamp]).stringValue()
         let bodyData = body?.utf8EncodedData
         let response = GCDWebServerDataResponse(data: bodyData, contentType: "application/json")!
         return MockSyncServer.withHeaders(response: response)
@@ -318,7 +318,7 @@ class MockSyncServer {
                 }
 
             }
-            let body = JSON(object: ic).rawString()
+            let body = JSON(object: ic).stringValue()
             let bodyData = body?.utf8EncodedData
 
             let response = GCDWebServerDataResponse(data: bodyData, contentType: "application/json")!
@@ -430,7 +430,7 @@ class MockSyncServer {
             // TODO: TTL
             // TODO: X-I-U-S
 
-            let body = JSON(object: items.map { $0.asJSON() }).rawString()
+            let body = JSON(object: items.map { $0.asJSON() }).stringValue()
             let bodyData = body?.utf8EncodedData
             let response = GCDWebServerDataResponse(data: bodyData, contentType: "application/json")
 

--- a/SyncTests/RecordTests.swift
+++ b/SyncTests/RecordTests.swift
@@ -48,9 +48,9 @@ class RecordTests: XCTestCase {
         let emptyPayload = "{\"id\": \"abcdefghijkl\", \"collection\": \"clients\", \"payload\": \"{}\"}"
 
         let clientBody: [String: Any] = ["id": "abcdefghijkl", "name": "Foobar", "commands": [], "type": "mobile"]
-        let clientBodyString = JSON(object: clientBody).rawString()!
+        let clientBodyString = JSON(object: clientBody).stringValue()!
         let clientRecord: [String : Any] = ["id": "abcdefghijkl", "collection": "clients", "payload": clientBodyString]
-        let clientPayload = JSON(object: clientRecord).rawString()!
+        let clientPayload = JSON(object: clientRecord).stringValue()!
 
         let cleartextClientsFactory: (String) -> ClientPayload? = {
             (s: String) -> ClientPayload? in

--- a/Telemetry/Telemetry.swift
+++ b/Telemetry/Telemetry.swift
@@ -34,7 +34,7 @@ open class Telemetry {
     }
 
     open class func sendPing(_ ping: TelemetryPing) {
-        let payload = ping.payload.rawString()
+        let payload = ping.payload.stringValue()
 
         let docID = UUID().uuidString
         let docType = "core"

--- a/UITests/SessionRestoreTests.swift
+++ b/UITests/SessionRestoreTests.swift
@@ -28,7 +28,7 @@ class SessionRestoreTests: KIFTestCase {
         jsonDict["history"] = [url1, url2, url3]
         jsonDict["currentPage"] = -1 as Any?
         let json = JSON(jsonDict)
-        let escapedJSON = json.rawString()?.addingPercentEncoding(withAllowedCharacters: CharacterSet.URLAllowedCharacterSet())
+        let escapedJSON = json.stringValue()?.addingPercentEncoding(withAllowedCharacters: CharacterSet.URLAllowedCharacterSet())
         let webView = tester().waitForView(withAccessibilityLabel: "Web content") as! WKWebView
         let restoreURL = URL(string: "/about/sessionrestore?history=\(escapedJSON!)", relativeTo: webView.url!)
         


### PR DESCRIPTION
History syncs were returning 400 Bad Request - Malformed JSON when trying to upload history records. Turns out when we were serializing the records we were pushing out pretty-printed JSON lines instead of regular JSON which was causing the application/newlines to mess up the handling of the additional /n characters that the pretty printer generated.