### PR TITLE
Bug 1350146 - Add build number, device, and system version to user agent

### DIFF
--- a/ClientTests/ClientTests.swift
+++ b/ClientTests/ClientTests.swift
@@ -15,7 +15,7 @@ class ClientTests: XCTestCase {
 
     func testSyncUA() {
         let ua = UserAgent.syncUserAgent
-        let loc = ua.range(of: "^Firefox-iOS-Sync/[0-9\\.]+ \\([-_A-Za-z0-9= \\(\\)]+\\)$", options: NSString.CompareOptions.regularExpression)
+        let loc = ua.range(of: "^Firefox-iOS-Sync/[0-9]\\.[0-9]b*[0-9] \\([-_A-Za-z0-9= \\(\\)]+\\)$", options: NSString.CompareOptions.regularExpression)
         XCTAssertTrue(loc != nil, "Sync UA is as expected. Was \(ua)")
     }
 
@@ -24,7 +24,7 @@ class ClientTests: XCTestCase {
         let appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
 
         let compare: (String) -> Bool = { ua in
-            let range = ua.range(of: "^Mozilla/5\\.0 \\(.+\\) AppleWebKit/[0-9\\.]+ \\(KHTML, like Gecko\\) FxiOS/\(appVersion) Mobile/[A-Za-z0-9]+ Safari/[0-9\\.]+$", options: NSString.CompareOptions.regularExpression)
+            let range = ua.range(of: "^Mozilla/5\\.0 \\(.+\\) AppleWebKit/[0-9\\.]+ \\(KHTML, like Gecko\\) FxiOS/\(appVersion)b*[0-9] Mobile/[A-Za-z0-9]+ Safari/[0-9\\.]+$", options: NSString.CompareOptions.regularExpression)
             return range != nil
         }
 

--- a/ClientTests/ClientTests.swift
+++ b/ClientTests/ClientTests.swift
@@ -15,7 +15,10 @@ class ClientTests: XCTestCase {
 
     func testSyncUA() {
         let ua = UserAgent.syncUserAgent
-        let loc = ua.range(of: "^Firefox-iOS-Sync/[0-9]\\.[0-9]b*[0-9] \\([-_A-Za-z0-9= \\(\\)]+\\)$", options: NSString.CompareOptions.regularExpression)
+        let device = DeviceInfo.deviceModel()
+        let systemVersion = UIDevice.current.systemVersion
+        let expectedRegex = "^Firefox-iOS-Sync/[0-9]\\.[0-9]b*[0-9] \\(\(device); iPhone OS \(systemVersion)\\) \\([-_A-Za-z0-9= \\(\\)]+\\)$"
+        let loc = ua.range(of: expectedRegex, options: NSString.CompareOptions.regularExpression)
         XCTAssertTrue(loc != nil, "Sync UA is as expected. Was \(ua)")
     }
 

--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -10,33 +10,38 @@ open class UserAgent {
 
     open static var syncUserAgent: String {
         let appName = DeviceInfo.appName()
-        return "Firefox-iOS-Sync/\(AppInfo.appVersion) (\(appName))"
+        return "Firefox-iOS-Sync/\(AppInfo.appVersion)b\(AppInfo.buildNumber) (\(appName))"
     }
 
     open static var tokenServerClientUserAgent: String {
         let appName = DeviceInfo.appName()
-        return "Firefox-iOS-Token/\(AppInfo.appVersion) (\(appName))"
+        return "Firefox-iOS-Token/\(AppInfo.appVersion)b\(AppInfo.buildNumber) (\(appName))"
     }
 
     open static var fxaUserAgent: String {
         let appName = DeviceInfo.appName()
-        return "Firefox-iOS-FxA/\(AppInfo.appVersion) (\(appName))"
+        return "Firefox-iOS-FxA/\(AppInfo.appVersion)b\(AppInfo.buildNumber) (\(appName))"
     }
 
     /**
      * Use this if you know that a value must have been computed before your
      * code runs, or you don't mind failure.
      */
-    open static func cachedUserAgent(checkiOSVersion: Bool = true, checkFirefoxVersion: Bool = true) -> String? {
+    open static func cachedUserAgent(checkiOSVersion: Bool = true,
+                                     checkFirefoxVersion: Bool = true,
+                                     checkFirefoxBuildNumber: Bool = true) -> String? {
         let currentiOSVersion = UIDevice.current.systemVersion
         let lastiOSVersion = defaults.string(forKey: "LastDeviceSystemVersionNumber")
 
+        let currentFirefoxBuildNumber = AppInfo.buildNumber
         let currentFirefoxVersion = AppInfo.appVersion
         let lastFirefoxVersion = defaults.string(forKey: "LastFirefoxVersionNumber")
-
+        let lastFirefoxBuildNumber = defaults.string(forKey: "LastFirefoxBuildNumber")
+        
         if let firefoxUA = defaults.string(forKey: "UserAgent") {
             if (!checkiOSVersion || (lastiOSVersion == currentiOSVersion))
-                && (!checkFirefoxVersion || (lastFirefoxVersion == currentFirefoxVersion)) {
+                && (!checkFirefoxVersion || (lastFirefoxVersion == currentFirefoxVersion)
+                && (!checkFirefoxBuildNumber || (lastFirefoxBuildNumber == currentFirefoxBuildNumber))) {
                 return firefoxUA
             }
         }
@@ -58,9 +63,12 @@ open class UserAgent {
         let webView = UIWebView()
 
         let appVersion = AppInfo.appVersion
+        let buildNumber = AppInfo.buildNumber
         let currentiOSVersion = UIDevice.current.systemVersion
         defaults.set(currentiOSVersion, forKey: "LastDeviceSystemVersionNumber")
         defaults.set(appVersion, forKey: "LastFirefoxVersionNumber")
+        defaults.set(buildNumber, forKey: "LastFirefoxBuildNumber")
+
         let userAgent = webView.stringByEvaluatingJavaScript(from: "navigator.userAgent")!
 
         // Extract the WebKit version and use it as the Safari version.
@@ -84,7 +92,7 @@ open class UserAgent {
         }
 
         let mutableUA = NSMutableString(string: userAgent)
-        mutableUA.insert("FxiOS/\(appVersion) ", at: mobileRange.location)
+        mutableUA.insert("FxiOS/\(appVersion)b\(AppInfo.buildNumber) ", at: mobileRange.location)
 
         let firefoxUA = "\(mutableUA) Safari/\(webKitVersion)"
 

--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -8,19 +8,21 @@ import UIKit
 open class UserAgent {
     private static var defaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier())!
 
+    private static func clientUserAgent(prefix: String) -> String {
+        return "\(prefix)/\(AppInfo.appVersion)b\(AppInfo.buildNumber) " +
+               "(\(DeviceInfo.deviceModel()); iPhone OS \(UIDevice.current.systemVersion)) (\(DeviceInfo.appName()))"
+    }
+
     open static var syncUserAgent: String {
-        let appName = DeviceInfo.appName()
-        return "Firefox-iOS-Sync/\(AppInfo.appVersion)b\(AppInfo.buildNumber) (\(appName))"
+        return clientUserAgent(prefix: "Firefox-iOS-Sync")
     }
 
     open static var tokenServerClientUserAgent: String {
-        let appName = DeviceInfo.appName()
-        return "Firefox-iOS-Token/\(AppInfo.appVersion)b\(AppInfo.buildNumber) (\(appName))"
+        return clientUserAgent(prefix: "Firefox-iOS-Token")
     }
 
     open static var fxaUserAgent: String {
-        let appName = DeviceInfo.appName()
-        return "Firefox-iOS-FxA/\(AppInfo.appVersion)b\(AppInfo.buildNumber) (\(appName))"
+        return clientUserAgent(prefix: "Firefox-iOS-FxA")
     }
 
     /**


### PR DESCRIPTION
* Added build number to all of our existing user agents (Sync/FxA/Web Requests)

Question: Do we want to also include the release channel in our web UA? We have it as part of the sync/FxA ones. If we want to add it, how do we add it to the existing UA? Just wondering how sites will interpret the new UA. The build number is pretty minor since it's after the version number but I can see sites having issues with changes to FxiOS.