### PR TITLE
Bug 1345231 - Cast nils to NSNull to properly stringify our JSON payloads (v7.x)

### DIFF
--- a/Shared/Extensions/JSONExtensions.swift
+++ b/Shared/Extensions/JSONExtensions.swift
@@ -50,6 +50,6 @@ public extension JSON {
     // existing code required the string to not be pretty printed, this helper
     // can be used as a shorthand for non-pretty printed strings.
     func stringValue() -> String? {
-        return self.rawString(.utf8, options: [])
+        return self.rawString([writtingOptionsKeys.castNilToNSNull: true])
     }
 }


### PR DESCRIPTION
SwiftyJSON was failing to parse valid JSON here [1] because it was unable to properly handle the icon being nil. Specifically, SwiftyJSON uses JSONSerialization.isValidJSON to check if the JSON is valid when using the `rawString(encoding:options)` API. Instead, we want to _not_ use JSONSerialization and use SwiftyJSON's custom handling of JSON so it can properly handle these nil values.

The reason the tabs were never being sent is because the payload was empty which resulted in the Desktop not being able to parse the JSON.

[1] https://github.com/mozilla-mobile/firefox-ios/blob/master/Sync/KeyBundle.swift#L175