### PR TITLE
Bug 1345231 - Cast nils to NSNull to properly stringify our JSON payloads

### DIFF
--- a/Shared/Extensions/JSONExtensions.swift
+++ b/Shared/Extensions/JSONExtensions.swift
@@ -50,6 +50,6 @@ public extension JSON {
     // existing code required the string to not be pretty printed, this helper
     // can be used as a shorthand for non-pretty printed strings.
     func stringValue() -> String? {
-        return self.rawString(.utf8, options: [])
+        return self.rawString([writtingOptionsKeys.castNilToNSNull: true])
     }
 }


### PR DESCRIPTION
Mirror of https://github.com/mozilla-mobile/firefox-ios/pull/2557 for the master branch.