### PR TITLE
Bug 1350589 – Ensure getFavicons is executable.

### DIFF
--- a/Client/Assets/Favicons.js
+++ b/Client/Assets/Favicons.js
@@ -16,7 +16,7 @@ Object.defineProperty(window.__firefox__, 'favicons', {
   enumerable: false,
   configurable: false,
   writable: false,
-  value: function() {
+  value: (() => {
     // These integers should be kept in sync with the IconType raw-values
     var ICON = 0;
     var APPLE = 1;
@@ -53,8 +53,6 @@ Object.defineProperty(window.__firefox__, 'favicons', {
       webkit.messageHandlers.faviconsMessageHandler.postMessage(favicons);
     }
   
-    return {
-      getFavicons: getFavicons
-    };
-  }
+    return Object.freeze({ getFavicons });
+  })(),
 });


### PR DESCRIPTION
`Object.defineProperty(obj, prop, { value })` defines the actual value, not a getter.

The answer isn't going to change, so we can immediately execute the getter, and `Object.freeze` it too.

https://bugzilla.mozilla.org/show_bug.cgi?id=1350589