### PR TITLE
Bug 1333767 – Generate key material and register it with FxA servers.

### DIFF
--- a/Account/FxADeviceRegistration.swift
+++ b/Account/FxADeviceRegistration.swift
@@ -77,7 +77,8 @@ open class FxADeviceRegistrator {
 
         let pushParams: FxADevicePushParams?
         if AppConstants.MOZ_FXA_PUSH, let pushRegistration = account.pushRegistration {
-            pushParams = FxADevicePushParams(callback: pushRegistration.endpoint.absoluteString!, publicKey: "", authKey: "")
+            let subscription = pushRegistration.defaultSubscription
+            pushParams = FxADevicePushParams(callback: subscription.endpoint.absoluteString, publicKey: subscription.p256dhPublicKey, authKey: subscription.authKey)
         } else {
             pushParams = nil
         }

--- a/AccountTests/FirefoxAccountTests.swift
+++ b/AccountTests/FirefoxAccountTests.swift
@@ -15,13 +15,19 @@ class FirefoxAccountTests: XCTestCase {
     }
 
     func testSerialization() {
+        let ogPushSub = PushSubscription(channelID: "channel-id",
+                                       endpoint: URL(string: "https://mozilla.com")!,
+                                       p256dhPrivateKey: "private-key",
+                                       p256dhPublicKey: "public-key",
+                                       authKey: "auth-key")
+
         let d: [String: Any] = [
             "version": 1,
             "configurationLabel": FirefoxAccountConfigurationLabel.production.rawValue,
             "email": "testtest@test.com",
             "uid": "uid",
             "deviceRegistration": FxADeviceRegistration(id: "bogus-device", version: 0, lastRegistered: Date.now()),
-            "pushRegistration": PushRegistration(uaid: "bogus-device-uaid", secret: "secret", endpoint: NSURL(string: "https://mozilla.com")!, channelID: "channelID"),
+            "pushRegistration": PushRegistration(uaid: "bogus-device-uaid", secret: "secret", subscription: ogPushSub),
         ]
 
         let account1 = FirefoxAccount(
@@ -46,6 +52,12 @@ class FirefoxAccountTests: XCTestCase {
                 XCTAssertEqual(s, d1[k] as? String, "Value for '\(k)' does not agree for manually created account.")
                 XCTAssertEqual(s, d2[k] as? String, "Value for '\(k)' does not agree for deserialized account.")
             }
+        }
+
+        if let pubSub = account2?.pushRegistration?.defaultSubscription {
+            XCTAssertEqual(pubSub, ogPushSub)
+        } else {
+            XCTFail("PushSubscription did not get decoded")
         }
     }
 }

--- a/Push/PushClient.swift
+++ b/Push/PushClient.swift
@@ -111,10 +111,7 @@ public extension PushClient {
         mutableURLRequest.httpBody = JSON(parameters).stringValue()?.utf8EncodedData
 
         return send(request: mutableURLRequest) >>== { json in
-            guard let response = PushRegistration.from(json: json) else {
-                return deferMaybe(PushClientError.Local(PushClientUnknownError))
-            }
-            return deferMaybe(response)
+            return deferMaybe(creds)
         }
     }
 

--- a/Push/PushConfiguration.swift
+++ b/Push/PushConfiguration.swift
@@ -38,7 +38,7 @@ public struct DeveloperPushConfiguration: PushConfiguration {
 public struct StagePushConfiguration: PushConfiguration {
     public init() {}
     public let label = PushConfigurationLabel.Stage
-    public let endpointURL = NSURL(string: "https://updates-autopush.dev.mozaws.net/v1/apns/stage")!
+    public let endpointURL = NSURL(string: "https://updates-autopush.stage.mozaws.net/v1/apns/stage")!
 }
 
 public struct ProductionPushConfiguration: PushConfiguration {

--- a/Push/PushRegistration.swift
+++ b/Push/PushRegistration.swift
@@ -7,58 +7,91 @@ import Shared
 import SwiftyJSON
 
 public class PushRegistration: NSObject, NSCoding {
-    let endpoint: NSURL
     let uaid: String
     let secret: String
-    let channelID: String
+    var subscriptions: [String: PushSubscription]
 
-    public init(uaid: String, secret: String, endpoint: NSURL, channelID: String) {
+    var defaultSubscription: PushSubscription {
+        return subscriptions[defaultSubscriptionID]!
+    }
+
+    public init(uaid: String, secret: String, subscriptions: [String: PushSubscription] = [:]) {
         self.uaid = uaid
         self.secret = secret
-        self.endpoint = endpoint
-        self.channelID = channelID
+
+        self.subscriptions = subscriptions
     }
 
     @objc public convenience required init?(coder aDecoder: NSCoder) {
         guard let uaid = aDecoder.decodeObject(forKey: "uaid") as? String,
             let secret = aDecoder.decodeObject(forKey: "secret") as? String,
-            let urlString = aDecoder.decodeObject(forKey: "endpoint") as? String,
-            let endpoint = NSURL(string: urlString),
-            let channelID = aDecoder.decodeObject(forKey: "channelID") as? String else {
+            let subscriptions = aDecoder.decodeObject(forKey: "subscriptions") as? [String: PushSubscription] else {
                 fatalError("Cannot decode registration")
         }
-        self.init(uaid: uaid, secret: secret, endpoint: endpoint, channelID: channelID)
+        self.init(uaid: uaid, secret: secret, subscriptions: subscriptions)
     }
 
     @objc public func encode(with aCoder: NSCoder) {
         aCoder.encode(uaid, forKey: "uaid")
         aCoder.encode(secret, forKey: "secret")
-        aCoder.encode(endpoint.absoluteString, forKey: "endpoint")
-        aCoder.encode(channelID, forKey: "channelID")
+        aCoder.encode(subscriptions, forKey: "subscriptions")
     }
-
-    // TODO ???
-    //     protected final @NonNull Map<String, PushSubscription> subscriptions;
 
     public static func from(json: JSON) -> PushRegistration? {
         guard let endpointString = json["endpoint"].stringValue(),
-              let endpoint = NSURL(string: endpointString),
+              let endpoint = URL(string: endpointString),
               let secret = json["secret"].stringValue(),
               let uaid = json["uaid"].stringValue(),
               let channelID = json["channelID"].stringValue() else {
             return nil
         }
 
-        return PushRegistration(uaid: uaid, secret: secret, endpoint: endpoint, channelID: channelID)
+        let defaultSubscription = PushSubscription(channelID: channelID, endpoint: endpoint)
+
+        return PushRegistration(uaid: uaid, secret: secret, subscriptions: [defaultSubscriptionID: defaultSubscription])
+    }
+}
+
+fileprivate let defaultSubscriptionID = "defaultSubscription"
+public class PushSubscription: NSObject, NSCoding {
+
+    let channelID: String
+    let endpoint: URL
+
+    let p256dhPublicKey: String
+    let p256dhPrivateKey: String
+    let authKey: String
+
+    init(channelID: String, endpoint: URL, p256dhPrivateKey: String, p256dhPublicKey: String, authKey: String) {
+        self.channelID =  channelID
+        self.endpoint = endpoint
+        self.p256dhPrivateKey = p256dhPrivateKey
+        self.p256dhPublicKey = p256dhPublicKey
+        self.authKey = authKey
     }
 
-    func toJSON() -> JSON {
-        var parameters = [String: String]()
-        parameters["endpoint"] = endpoint.absoluteString!
-        parameters["uaid"] = uaid
-        parameters["secret"] = secret
-        parameters["channelID"] = channelID
+    convenience init(channelID: String, endpoint: URL) {
+        self.init(channelID: channelID, endpoint: endpoint, p256dhPrivateKey: "", p256dhPublicKey: "", authKey: "")
+    }
 
-        return JSON(parameters)
+    @objc public convenience required init?(coder aDecoder: NSCoder) {
+        guard let channelID = aDecoder.decodeObject(forKey: "channelID") as? String,
+            let urlString = aDecoder.decodeObject(forKey: "endpoint") as? String,
+            let endpoint = URL(string: urlString),
+            let p256dhPrivateKey = aDecoder.decodeObject(forKey: "p256dhPrivateKey") as? String,
+            let p256dhPublicKey = aDecoder.decodeObject(forKey: "p256dhPublicKey") as? String,
+            let authKey = aDecoder.decodeObject(forKey: "authKey") as? String else {
+            return nil
+        }
+
+        self.init(channelID: channelID, endpoint: endpoint, p256dhPrivateKey: p256dhPrivateKey, p256dhPublicKey: p256dhPublicKey, authKey: authKey)
+    }
+
+    @objc public func encode(with aCoder: NSCoder) {
+        aCoder.encode(channelID, forKey: "channelID")
+        aCoder.encode(endpoint.absoluteString, forKey: "endpoint")
+        aCoder.encode(p256dhPrivateKey, forKey: "p256dhPrivateKey")
+        aCoder.encode(p256dhPublicKey, forKey: "p256dhPublicKey")
+        aCoder.encode(authKey, forKey: "authKey")
     }
 }


### PR DESCRIPTION
This uses `PushCrypto` to generate keys for a `PushSubscription`. This is stored as part of the `PushRegistration` in the account.

https://bugzilla.mozilla.org/show_bug.cgi?id=1333767