### PR TITLE
Bug 1350144 - Remove unicode beta from Firefox Beta title

### DIFF
--- a/Client/Configuration/FirefoxBeta.xcconfig
+++ b/Client/Configuration/FirefoxBeta.xcconfig
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-MOZ_BUNDLE_DISPLAY_NAME = Firefox β
+MOZ_BUNDLE_DISPLAY_NAME = Firefox Beta
 
 // Bundle Identifier
 MOZ_BUNDLE_ID = org.mozilla.ios.FirefoxBeta


### PR DESCRIPTION
Removes the beta character from the display name which wrecks havoc on web servers.