### PR TITLE
Bug 1350144 - (v7.x) Remove unicode characters from app name

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -6798,7 +6798,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DISPLAY_NAME = "Firefox α";
+				DISPLAY_NAME = Nightly;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -7295,7 +7295,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon_Beta;
-				DISPLAY_NAME = "Firefox β ";
+				DISPLAY_NAME = "Firefox Beta";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
Unicode characters in the user agent causes a lot of issues with web servers so this patch removes them with the word 'Beta' in place of the beta character and 'Nightly' instead of 'Firefox alpha'.