### PR TITLE
Bug 1352124 - Fixed ambiguous method error for reader mode in Swift 3.1

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2665,7 +2665,7 @@ extension BrowserViewController: UIAdaptivePresentationControllerDelegate {
 extension BrowserViewController: ReaderModeStyleViewControllerDelegate {
     func readerModeStyleViewController(_ readerModeStyleViewController: ReaderModeStyleViewController, didConfigureStyle style: ReaderModeStyle) {
         // Persist the new style to the profile
-        let encodedStyle: [String:Any] = style.encode()
+        let encodedStyle: [String:Any] = style.encodeAsDictionary()
         profile.prefs.setObject(encodedStyle, forKey: ReaderModeProfileKeyStyle)
         // Change the reader mode style on all tabs that have reader mode active
         for tabIndex in 0..<tabManager.count {

--- a/Client/Frontend/Reader/ReaderMode.swift
+++ b/Client/Frontend/Reader/ReaderMode.swift
@@ -107,7 +107,7 @@ struct ReaderModeStyle {
     }
 
     /// Encode the style to a dictionary that can be stored in the profile
-    func encode() -> [String:Any] {
+    func encodeAsDictionary() -> [String:Any] {
         return ["theme": theme.rawValue, "fontType": fontType.rawValue, "fontSize": fontSize.rawValue]
     }
 


### PR DESCRIPTION
Clears up some ambiguity that the Swift 3.1 compiler was having w.r.t the ReaderMode encode methods.