### PR TITLE
Bug 1349564 - Adds missing image events for AS and addn test harnessing

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -659,6 +659,7 @@
 		E677F0451D9423FB00ECF1FB /* SQLiteMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = E677F0441D9423FB00ECF1FB /* SQLiteMetadata.swift */; };
 		E677F0541D94247300ECF1FB /* Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = E677F0531D94247300ECF1FB /* Metadata.swift */; };
 		E67D57031D527449003917B1 /* BatchingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67D57021D527449003917B1 /* BatchingClient.swift */; };
+		E683F0A61E92E0820035D990 /* MockableHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E683F0A51E92E0820035D990 /* MockableHistory.swift */; };
 		E689C6F81E0C6E72008BAADB /* FxASignIn.js in Resources */ = {isa = PBXBuildFile; fileRef = E689C6F71E0C6E72008BAADB /* FxASignIn.js */; };
 		E689C6FA1E0C6E98008BAADB /* FxAContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E689C6F91E0C6E98008BAADB /* FxAContentViewController.swift */; };
 		E689C6FE1E0C6FE0008BAADB /* ClientTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = E689C6FB1E0C6FD0008BAADB /* ClientTelemetry.swift */; };
@@ -1815,6 +1816,7 @@
 		E677F0441D9423FB00ECF1FB /* SQLiteMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLiteMetadata.swift; sourceTree = "<group>"; };
 		E677F0531D94247300ECF1FB /* Metadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Metadata.swift; sourceTree = "<group>"; };
 		E67D57021D527449003917B1 /* BatchingClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BatchingClient.swift; sourceTree = "<group>"; };
+		E683F0A51E92E0820035D990 /* MockableHistory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockableHistory.swift; sourceTree = "<group>"; };
 		E689C6F71E0C6E72008BAADB /* FxASignIn.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = FxASignIn.js; sourceTree = "<group>"; };
 		E689C6F91E0C6E98008BAADB /* FxAContentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxAContentViewController.swift; sourceTree = "<group>"; };
 		E689C6FB1E0C6FD0008BAADB /* ClientTelemetry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ClientTelemetry.swift; path = Telemetry/ClientTelemetry.swift; sourceTree = "<group>"; };
@@ -3367,6 +3369,7 @@
 				D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */,
 				7BC7B4BD1C904BF90046E9D2 /* MenuTests.swift */,
 				281B2BE91ADF4D90002917DC /* MockProfile.swift */,
+				E683F0A51E92E0820035D990 /* MockableHistory.swift */,
 				E6C70E811E28314700F8DB57 /* PingCentreTests.swift */,
 				2FDB10921A9FBEC5006CF312 /* PrefsTests.swift */,
 				0BA896491A250E6500C1010C /* ProfileTest.swift */,
@@ -5325,6 +5328,7 @@
 				554867231DC3935A00183DAA /* HomePageTests.swift in Sources */,
 				3BFCBF201E04B1C50070C042 /* UIImageViewExtensionsTests.swift in Sources */,
 				E60D032A1D5118DB002FE3F6 /* SyncStatusResolverTests.swift in Sources */,
+				E683F0A61E92E0820035D990 /* MockableHistory.swift in Sources */,
 				A83E5B1E1C1DAAAA0026D912 /* UIPasteboardExtensions.swift in Sources */,
 				0BF42D4F1A7CD09600889E28 /* TestFavicons.swift in Sources */,
 				7BBFEE741BB405D900A305AA /* TabManagerTests.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -660,6 +660,7 @@
 		E677F0541D94247300ECF1FB /* Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = E677F0531D94247300ECF1FB /* Metadata.swift */; };
 		E67D57031D527449003917B1 /* BatchingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67D57021D527449003917B1 /* BatchingClient.swift */; };
 		E683F0A61E92E0820035D990 /* MockableHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E683F0A51E92E0820035D990 /* MockableHistory.swift */; };
+		E683F0C21E93D4E90035D990 /* DictionaryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E683F0C11E93D4E90035D990 /* DictionaryExtensions.swift */; };
 		E689C6F81E0C6E72008BAADB /* FxASignIn.js in Resources */ = {isa = PBXBuildFile; fileRef = E689C6F71E0C6E72008BAADB /* FxASignIn.js */; };
 		E689C6FA1E0C6E98008BAADB /* FxAContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E689C6F91E0C6E98008BAADB /* FxAContentViewController.swift */; };
 		E689C6FE1E0C6FE0008BAADB /* ClientTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = E689C6FB1E0C6FD0008BAADB /* ClientTelemetry.swift */; };
@@ -1817,6 +1818,7 @@
 		E677F0531D94247300ECF1FB /* Metadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Metadata.swift; sourceTree = "<group>"; };
 		E67D57021D527449003917B1 /* BatchingClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BatchingClient.swift; sourceTree = "<group>"; };
 		E683F0A51E92E0820035D990 /* MockableHistory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockableHistory.swift; sourceTree = "<group>"; };
+		E683F0C11E93D4E90035D990 /* DictionaryExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryExtensions.swift; sourceTree = "<group>"; };
 		E689C6F71E0C6E72008BAADB /* FxASignIn.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = FxASignIn.js; sourceTree = "<group>"; };
 		E689C6F91E0C6E98008BAADB /* FxAContentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxAContentViewController.swift; sourceTree = "<group>"; };
 		E689C6FB1E0C6FD0008BAADB /* ClientTelemetry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ClientTelemetry.swift; path = Telemetry/ClientTelemetry.swift; sourceTree = "<group>"; };
@@ -3118,6 +3120,7 @@
 			children = (
 				E65075701E37F7AB006961AC /* AlamofireExtensions.swift */,
 				E65075711E37F7AB006961AC /* ArrayExtensions.swift */,
+				E683F0C11E93D4E90035D990 /* DictionaryExtensions.swift */,
 				E65075721E37F7AB006961AC /* HashExtensions.swift */,
 				E65075731E37F7AB006961AC /* HexExtensions.swift */,
 				E65075741E37F7AB006961AC /* KeychainWrapperExtensions.swift */,
@@ -4795,6 +4798,7 @@
 				E65075B81E37F7AB006961AC /* NotificationConstants.swift in Sources */,
 				E65075AC1E37F7AB006961AC /* StringExtensions.swift in Sources */,
 				E65075951E37F7AB006961AC /* AssertionUtils.swift in Sources */,
+				E683F0C21E93D4E90035D990 /* DictionaryExtensions.swift in Sources */,
 				E650759B1E37F7AB006961AC /* CrashSimulator.m in Sources */,
 				288A2DB51AB8B38D0023ABC3 /* Error.swift in Sources */,
 				E65075A91E37F7AB006961AC /* NSURLExtensions.swift in Sources */,

--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -631,17 +631,22 @@ struct ActivityStreamTracker {
     let eventsTracker: PingCentreClient
     let sessionsTracker: PingCentreClient
 
-    func reportBadState(badState: ASPingBadStateEvent, source: ASPingSource) {
-        var eventPing: [String: Any] = [
-            "event": badState.rawValue,
-            "page": "NEW_TAB",
-            "source": source.rawValue,
+    private var baseASPing: [String: Any] {
+        return [
             "app_version": AppInfo.appVersion,
             "build": AppInfo.buildNumber,
             "locale": Locale.current.identifier,
             "release_channel": AppConstants.BuildChannel.rawValue
         ]
+    }
 
+    func reportBadState(badState: ASPingBadStateEvent, source: ASPingSource) {
+        var eventPing: [String: Any] = [
+            "event": badState.rawValue,
+            "page": "NEW_TAB",
+            "source": source.rawValue,
+        ]
+        eventPing.merge(with: baseASPing)
         eventsTracker.sendPing(eventPing as [String : AnyObject], validate: true)
     }
 
@@ -651,16 +656,13 @@ struct ActivityStreamTracker {
             "page": "NEW_TAB",
             "source": source.rawValue,
             "action_position": position,
-            "app_version": AppInfo.appVersion,
-            "build": AppInfo.buildNumber,
-            "locale": Locale.current.identifier,
-            "release_channel": AppConstants.BuildChannel.rawValue
         ]
 
         if let provider = shareProvider {
             eventPing["share_provider"] = provider
         }
 
+        eventPing.merge(with: baseASPing)
         eventsTracker.sendPing(eventPing as [String : AnyObject], validate: true)
     }
 

--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -358,14 +358,30 @@ extension ActivityStreamPanel {
         }
     }
 
-    fileprivate func invalidateHighlights() -> Success {
+    fileprivate func reportMissingData(sites: [Site], source: ASPingSource) {
+        sites.forEach { site in
+            if site.metadata?.mediaURL == nil {
+                self.telemetry.reportBadState(badState: .MissingMetadataImage, source: source)
+            }
+
+            if site.icon == nil {
+                self.telemetry.reportBadState(badState: .MissingFavicon, source: source)
+            }
+        }
+    }
+
+    func invalidateHighlights() -> Success {
         return self.profile.recommendations.getHighlights().bindQueue(DispatchQueue.main) { result in
-            self.highlights = result.successValue?.asArray() ?? self.highlights
+            if let newHighlights = result.successValue?.asArray() {
+                // Scan through the fetched highlights and report on anything that might be missing.
+                self.reportMissingData(sites: newHighlights, source: .Highlights)
+                self.highlights = newHighlights
+            }
             return succeed()
         }
     }
 
-    fileprivate func invalidateTopSites() -> Success {
+    func invalidateTopSites() -> Success {
         let frecencyLimit = ASPanelUX.topSitesCacheSize
 
         // Update our top sites cache if it's been invalidated
@@ -384,6 +400,9 @@ extension ActivityStreamPanel {
                     let domain = URL(string: site.url)?.hostSLD
                     return defaultSites.find { $0.title.lowercased() == domain } ?? site
                 }
+
+                // Don't report bad states for default sites we provide
+                self.reportMissingData(sites: mySites, source: .TopSites)
 
                 self.topSitesManager.currentTraits = self.view.traitCollection
                 self.topSitesManager.content = newSites.count > ASPanelUX.topSitesCacheSize ? Array(newSites[0..<ASPanelUX.topSitesCacheSize]) : newSites
@@ -597,6 +616,11 @@ enum ASPingEvent: String {
     case Share = "SHARE"
 }
 
+enum ASPingBadStateEvent: String {
+    case MissingMetadataImage = "MISSING_METADATA_IMAGE"
+    case MissingFavicon = "MISSING_FAVICON"
+}
+
 enum ASPingSource: String {
     case Highlights = "HIGHLIGHTS"
     case TopSites = "TOP_SITES"
@@ -606,6 +630,20 @@ enum ASPingSource: String {
 struct ActivityStreamTracker {
     let eventsTracker: PingCentreClient
     let sessionsTracker: PingCentreClient
+
+    func reportBadState(badState: ASPingBadStateEvent, source: ASPingSource) {
+        var eventPing: [String: Any] = [
+            "event": badState.rawValue,
+            "page": "NEW_TAB",
+            "source": source.rawValue,
+            "app_version": AppInfo.appVersion,
+            "build": AppInfo.buildNumber,
+            "locale": Locale.current.identifier,
+            "release_channel": AppConstants.BuildChannel.rawValue
+        ]
+
+        eventsTracker.sendPing(eventPing as [String : AnyObject], validate: true)
+    }
 
     func reportEvent(_ event: ASPingEvent, source: ASPingSource, position: Int, shareProvider: String? = nil) {
         var eventPing: [String: Any] = [

--- a/ClientTests/ActivityStreamTests.swift
+++ b/ClientTests/ActivityStreamTests.swift
@@ -7,9 +7,10 @@ import XCTest
 @testable import Client
 import Shared
 import Storage
+import Deferred
 
 class ActivityStreamTests: XCTestCase {
-    var profile: Profile!
+    var profile: MockProfile!
     var panel: ActivityStreamPanel!
     var mockPingClient: MockPingClient!
     var telemetry: ActivityStreamTracker!
@@ -55,6 +56,18 @@ extension ActivityStreamTests {
             "page": "NEW_TAB",
             "source": source,
             "action_position": position,
+            "app_version": AppInfo.appVersion,
+            "build": AppInfo.buildNumber,
+            "locale": Locale.current.identifier,
+            "release_channel": AppConstants.BuildChannel.rawValue
+        ]
+    }
+
+    fileprivate func expectedBadStatePayload(state: String, source: String) -> [String: Any] {
+        return [
+            "event": state,
+            "page": "NEW_TAB",
+            "source": source,
             "app_version": AppInfo.appVersion,
             "build": AppInfo.buildNumber,
             "locale": Locale.current.identifier,
@@ -137,6 +150,68 @@ extension ActivityStreamTests {
         let eventPing = pingsSent[0]
         XCTAssertNotNil(eventPing["session_duration"])
     }
+
+    func testBadStateEventsForHighlights() {
+        let goodSite = Site(url: "http://mozilla.org", title: "Mozilla")
+        goodSite.icon = Favicon(url: "http://image", date: Date(), type: .local)
+        goodSite.metadata = PageMetadata(id: nil,
+                                         siteURL: "http://mozilla.org",
+                                         mediaURL: "http://image",
+                                         title: "Mozilla",
+                                         description: "Web",
+                                         type: nil,
+                                         providerName: nil,
+                                         mediaDataURI: nil)
+        let badSite = Site(url: "http://mozilla.org", title: "Mozilla")
+        profile.recommendations = MockRecommender(highlights: [goodSite, badSite])
+
+        // Since invalidateHighlights calls back into the main thread, we can't 
+        // simply call .value on this to block since the app will dead lock when
+        // trying to call back onto a blocked main thread.
+        let expect = XCTestExpectation(description: "Sent bad highlight pings")
+        panel.invalidateHighlights() >>> {
+            expect.fulfill()
+        }
+
+        wait(for: [expect], timeout: 3)
+        let pingsSent = (self.telemetry.eventsTracker as! MockPingClient).pingsReceived
+        XCTAssertEqual(pingsSent.count, 2)
+        assertPayload(pingsSent[0],
+                      matches: expectedBadStatePayload(state: "MISSING_METADATA_IMAGE", source: "HIGHLIGHTS"))
+        assertPayload(pingsSent[1],
+                      matches: expectedBadStatePayload(state: "MISSING_FAVICON", source: "HIGHLIGHTS"))
+    }
+
+    func testBadStateEventsForTopSites() {
+        let goodSite = Site(url: "http://mozilla.org", title: "Mozilla")
+        goodSite.icon = Favicon(url: "http://image", date: Date(), type: .local)
+        goodSite.metadata = PageMetadata(id: nil,
+                                         siteURL: "http://mozilla.org",
+                                         mediaURL: "http://image",
+                                         title: "Mozilla",
+                                         description: "Web",
+                                         type: nil,
+                                         providerName: nil,
+                                         mediaDataURI: nil)
+        let badSite = Site(url: "http://mozilla.org", title: "Mozilla")
+        profile.history = MockTopSitesHistory(sites: [goodSite, badSite])
+
+        // Since invalidateHighlights calls back into the main thread, we can't 
+        // simply call .value on this to block since the app will dead lock when
+        // trying to call back onto a blocked main thread.
+        let expect = XCTestExpectation(description: "Sent bad top site pings")
+        panel.invalidateTopSites() >>> {
+            expect.fulfill()
+        }
+
+        wait(for: [expect], timeout: 3)
+        let pingsSent = (self.telemetry.eventsTracker as! MockPingClient).pingsReceived
+        XCTAssertEqual(pingsSent.count, 2)
+        assertPayload(pingsSent[0],
+                      matches: expectedBadStatePayload(state: "MISSING_METADATA_IMAGE", source: "TOP_SITES"))
+        assertPayload(pingsSent[1],
+                      matches: expectedBadStatePayload(state: "MISSING_FAVICON", source: "TOP_SITES"))
+    }
 }
 
 class MockPingClient: PingCentreClient {
@@ -146,5 +221,42 @@ class MockPingClient: PingCentreClient {
     public func sendPing(_ data: [String : Any], validate: Bool) -> Success {
         pingsReceived.append(data)
         return succeed()
+    }
+}
+
+fileprivate class MockRecommender: HistoryRecommendations {
+    var highlights: [Site]
+
+    init(highlights: [Site]) {
+        self.highlights = highlights
+    }
+
+    func getHighlights() -> Deferred<Maybe<Cursor<Site>>> {
+        return deferMaybe(ArrayCursor(data: highlights))
+    }
+    
+    func removeHighlightForURL(_ url: String) -> Success {
+        guard let foundSite = highlights.filter({ $0.url == url }).first else {
+            return succeed()
+        }
+        let foundIndex = highlights.index(of: foundSite)!
+        highlights.remove(at: foundIndex)
+        return succeed()
+    }
+}
+
+fileprivate class MockTopSitesHistory: MockableHistory {
+    let mockTopSites: [Site]
+
+    init(sites: [Site]) {
+        mockTopSites = sites
+    }
+
+    override func getTopSitesWithLimit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>> {
+        return deferMaybe(ArrayCursor(data: mockTopSites))
+    }
+
+    override func updateTopSitesCacheIfInvalidated() -> Deferred<Maybe<Bool>> {
+        return deferMaybe(true)
     }
 }

--- a/ClientTests/MockableHistory.swift
+++ b/ClientTests/MockableHistory.swift
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Storage
+import Deferred
+import Shared
+
+/* 
+ * A class that adheres to all the requirements for a profile's history property
+ * with all of the methods set to fatalError. Use this class if you're looking to
+ * mock out parts of the history API
+ */
+class MockableHistory: BrowserHistory, SyncableHistory, ResettableSyncStorage {
+    func getTopSitesWithLimit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>> { fatalError()}
+    func addLocalVisit(_ visit: SiteVisit) -> Success { fatalError() }
+    func clearHistory() -> Success { fatalError() }
+    func removeHistoryForURL(_ url: String) -> Success { fatalError() }
+    func removeSiteFromTopSites(_ site: Site) -> Success { fatalError() }
+    func removeHostFromTopSites(_ host: String) -> Success { fatalError() }
+    func clearTopSitesCache() -> Success { fatalError() }
+    func refreshTopSitesCache() -> Success { fatalError() }
+    func getSitesByFrecencyWithHistoryLimit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>> { fatalError() }
+    func getSitesByFrecencyWithHistoryLimit(_ limit: Int, whereURLContains filter: String) -> Deferred<Maybe<Cursor<Site>>> { fatalError() }
+    func getSitesByFrecencyWithHistoryLimit(_ limit: Int, bookmarksLimit: Int, whereURLContains filter: String) -> Deferred<Maybe<Cursor<Site>>> { fatalError() }
+    func getSitesByLastVisit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>> { fatalError() }
+    func setTopSitesNeedsInvalidation() { fatalError() }
+    func updateTopSitesCacheIfInvalidated() -> Deferred<Maybe<Bool>> { fatalError() }
+    func setTopSitesCacheSize(_ size: Int32) { fatalError() }
+    func areTopSitesDirty(withLimit limit: Int) -> Deferred<Maybe<Bool>> { fatalError() }
+    func onRemovedAccount() -> Success { fatalError() }
+    func ensurePlaceWithURL(_ url: String, hasGUID guid: GUID) -> Success { fatalError() }
+    func deleteByGUID(_ guid: GUID, deletedAt: Timestamp) -> Success { fatalError() }
+    func storeRemoteVisits(_ visits: [Visit], forGUID guid: GUID) -> Success { fatalError() }
+    func insertOrUpdatePlace(_ place: Place, modified: Timestamp) -> Deferred<Maybe<GUID>> { fatalError() }
+    func getModifiedHistoryToUpload() -> Deferred<Maybe<[(Place, [Visit])]>> { fatalError() }
+    func getDeletedHistoryToUpload() -> Deferred<Maybe<[GUID]>> { fatalError() }
+    func markAsSynchronized(_: [GUID], modified: Timestamp) -> Deferred<Maybe<Timestamp>> { fatalError() }
+    func markAsDeleted(_ guids: [GUID]) -> Success { fatalError() }
+    func doneApplyingRecordsAfterDownload() -> Success { fatalError() }
+    func doneUpdatingMetadataAfterUpload() -> Success { fatalError() }
+    func hasSyncedHistory() -> Deferred<Maybe<Bool>> { fatalError() }
+    func resetClient() -> Success { fatalError() }
+}
+

--- a/Shared/Extensions/DictionaryExtensions.swift
+++ b/Shared/Extensions/DictionaryExtensions.swift
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extension Dictionary {
+    public mutating func merge(with dictionary: Dictionary) {
+        dictionary.forEach { updateValue($1, forKey: $0) }
+    }
+}


### PR DESCRIPTION
Adds tracking for the MISSING_METADATA_IMAGE and MISSING_FAVICON events
for top sites and highlights downloaded on the activity stream panel.
Also adds a new class, MockableHistory, to make mocking the history API
easier.