### PR TITLE
Bug 1335677 - Reset TopSite content offset when changing view size to prevent misalignment.

### DIFF
--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -285,6 +285,9 @@ class HorizontalFlowLayout: UICollectionViewLayout {
 
     override func prepare() {
         super.prepare()
+        if boundsSize != self.collectionView?.frame.size {
+            self.collectionView?.setContentOffset(CGPoint.zero, animated: false)
+        }
         boundsSize = self.collectionView?.frame.size ?? CGSize.zero
     }
 


### PR DESCRIPTION
Easy peasy. Basically when calculating the flow layout make sure the content offset is 0 if the bounds of the layout is changing.