### PR TITLE
Bug 1352691 - UI nits in Activity Stream

### DIFF
--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -21,7 +21,7 @@ struct ASPanelUX {
     static let highlightCellHeight: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 250 : 195
 
     static let PageControlOffsetSize: CGFloat = 40
-    static let SectionInsetsForIpad: CGFloat = 100
+    static let SectionInsetsForIpad: CGFloat = 101
     static let SectionInsetsForIphone: CGFloat = 14
     static let CompactWidth: CGFloat = 320
 }
@@ -164,13 +164,15 @@ extension ActivityStreamPanel {
 
             switch self {
             case .highlights:
+                var numItems: CGFloat = 0
                 if UIDevice.current.orientation == .landscapeLeft || UIDevice.current.orientation == .landscapeRight {
-                    return CGSize(width: (frameWidth - inset) / 4 - 10, height: height)
+                    numItems = 4
                 } else if UIDevice.current.userInterfaceIdiom == .pad {
-                    return CGSize(width: (frameWidth - inset) / 3 - 10, height: height)
+                    numItems = 3
                 } else {
-                    return CGSize(width: (frameWidth - inset) / 2 - 10, height: height)
+                    numItems = 2
                 }
+                return CGSize(width: floor(((frameWidth - inset) - (ASHorizontalScrollCellUX.MinimumInsets * (numItems - 1))) / numItems), height: height)
             case .topSites:
                 return CGSize(width: frameWidth - inset, height: height)
             case .highlightIntro:

--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -15,7 +15,7 @@ private let DefaultSuggestedSitesKey = "topSites.deletedSuggestedSites"
 // MARK: -  Lifecycle
 struct ASPanelUX {
     static let backgroundColor = UIColor(white: 1.0, alpha: 0.5)
-    static let topSitesCacheSize = 12
+    static let topSitesCacheSize = 16
     static let historySize = 10
     static let rowSpacing: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 30 : 20
     static let highlightCellHeight: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 250 : 195

--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -160,7 +160,7 @@ struct ASHorizontalScrollCellUX {
     static let PageControlRadius: CGFloat = 3
     static let PageControlSize = CGSize(width: 30, height: 15)
     static let PageControlOffset: CGFloat = 12
-    static let MinimumInsets: CGFloat = 15
+    static let MinimumInsets: CGFloat = 14
 }
 
 /*
@@ -354,7 +354,7 @@ class HorizontalFlowLayout: UICollectionViewLayout {
     func maxHorizontalItemsCount(width: CGFloat) -> Int {
         let horizontalItemsCount =  Int(floor(width / (ASHorizontalScrollCellUX.TopSiteItemSize.width + insets.left)))
         if let delegate = self.collectionView?.delegate as? ASHorizontalLayoutDelegate {
-            return delegate.numberOfHorizontalItems() > horizontalItemsCount ? horizontalItemsCount : delegate.numberOfHorizontalItems()
+            return delegate.numberOfHorizontalItems()
         } else {
             return horizontalItemsCount
         }
@@ -415,7 +415,6 @@ class HorizontalFlowLayout: UICollectionViewLayout {
 */
 struct ASTopSiteSourceUX {
     static let verticalItemsForTraitSizes = [UIUserInterfaceSizeClass.compact: 1, UIUserInterfaceSizeClass.regular: 2, UIUserInterfaceSizeClass.unspecified: 0]
-    static let horizontalItemsForTraitSizes = [UIUserInterfaceSizeClass.compact: 4, UIUserInterfaceSizeClass.regular: 8, UIUserInterfaceSizeClass.unspecified: 0]
     static let maxNumberOfPages = 2
     static let CellIdentifier = "TopSiteItemCell"
 }
@@ -449,14 +448,14 @@ class ASHorizontalScrollCellManager: NSObject, UICollectionViewDelegate, UIColle
     }
 
     func numberOfHorizontalItems() -> Int {
-        guard let traits = currentTraits else {
-            return 0
+        // The number of items to show per row.
+        if UIDevice.current.orientation == .landscapeLeft || UIDevice.current.orientation == .landscapeRight {
+            return 8
+        } else if UIDevice.current.userInterfaceIdiom == .pad {
+            return 6
+        } else {
+            return 4
         }
-        // An iPhone 5 in both landscape/portrait is considered compactWidth which means we need to let the layout determine how many items to show based on actual width.
-        if traits.horizontalSizeClass == .compact && traits.verticalSizeClass == .compact {
-            return ASTopSiteSourceUX.horizontalItemsForTraitSizes[.regular]!
-        }
-        return ASTopSiteSourceUX.horizontalItemsForTraitSizes[traits.horizontalSizeClass]!
     }
 
     func numberOfSections(in collectionView: UICollectionView) -> Int {

--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -319,7 +319,7 @@ class HorizontalFlowLayout: UICollectionViewLayout {
         // We want a minimum inset to make things not look crowded. We also don't want uneven spacing.
         // If we dont have this. Set a minimum inset and recalculate the size of a cell
         var estimatedItemSize = itemSize
-        if horizontalInsets < ASHorizontalScrollCellUX.MinimumInsets || horizontalInsets != verticalInsets {
+        if horizontalInsets != ASHorizontalScrollCellUX.MinimumInsets {
             verticalInsets = ASHorizontalScrollCellUX.MinimumInsets
             horizontalInsets = ASHorizontalScrollCellUX.MinimumInsets
             estimatedItemSize.width = floor((width - (CGFloat(horizontalItemsCount + 1) * horizontalInsets)) / CGFloat(horizontalItemsCount))

--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -16,7 +16,7 @@ struct TopSiteCellUX {
     static let CellCornerRadius: CGFloat = 4
     static let TitleOffset: CGFloat = 5
     static let OverlayColor = UIColor(white: 0.0, alpha: 0.25)
-    static let IconSize = CGSize(width: 50, height: 50)
+    static let IconSizePercent: CGFloat = 0.8
     static let BorderColor = UIColor(white: 0, alpha: 0.1)
     static let BorderWidth: CGFloat = 0.5
 }
@@ -90,7 +90,7 @@ class TopSiteItemCell: UICollectionViewCell {
         }
 
         imageView.snp.makeConstraints { make in
-            make.size.equalTo(TopSiteCellUX.IconSize)
+            make.size.equalTo(floor(frame.width * TopSiteCellUX.IconSizePercent))
             make.centerX.equalTo(self)
             make.centerY.equalTo(self).inset(-TopSiteCellUX.TitleHeight/2)
         }

--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -16,7 +16,7 @@ struct TopSiteCellUX {
     static let CellCornerRadius: CGFloat = 4
     static let TitleOffset: CGFloat = 5
     static let OverlayColor = UIColor(white: 0.0, alpha: 0.25)
-    static let IconSize = CGSize(width: 40, height: 40)
+    static let IconSize = CGSize(width: 50, height: 50)
     static let BorderColor = UIColor(white: 0, alpha: 0.1)
     static let BorderWidth: CGFloat = 0.5
 }


### PR DESCRIPTION
- Favicons are not large enough. 
- Make iPhone SE sized devices also have 4 TopSites in each row instead of the current 3. 
- Empty TopSite icon silhouettes when only a few icons are available.
- Topsites/Highlights are not perfectly aligned. Each highlight should be the _exact_ width of 2 topsites.