### PR TITLE
Bug 1353095 - Adds telemetry for measuring performance of AS new tab invalidation

### DIFF
--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -657,9 +657,17 @@ struct ActivityStreamTracker {
     private func collectStorageStats() -> Deferred<Maybe<[String: Int]>> {
         // Dispatch some deferreds to gather up some information about the
         // various souces of data that power Activity Stream
+        let bookmarkSourceTypes: [BookmarkNodeType] = [
+            .bookmark,
+            .livemark,
+            .separator,
+            .dynamicContainer,
+            .query
+        ]
+
         return accumulate([
             profile.history.numberOfHistoryEntries,
-            profile.bookmarks.numberOfBookmarks
+            { self.profile.bookmarks.countAllItems(matchingTypes: bookmarkSourceTypes) }
         ]) >>== { results in
             return deferMaybe([
                 "total_history_size": results[0],

--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -665,10 +665,13 @@ struct ActivityStreamTracker {
             .query
         ]
 
-        return accumulate([
-            profile.history.numberOfHistoryEntries,
-            { self.profile.bookmarks.countAllItems(matchingTypes: bookmarkSourceTypes) }
-        ]) >>== { results in
+        let collectOps = [
+            profile.history.numberOfHistoryEntries, {
+                self.profile.bookmarks.countAllItems(matchingTypes: bookmarkSourceTypes)
+            }
+        ]
+
+        return accumulate(collectOps) >>== { results in
             return deferMaybe([
                 "total_history_size": results[0],
                 "total_bookmarks_size": results[1],

--- a/ClientTests/ActivityStreamTests.swift
+++ b/ClientTests/ActivityStreamTests.swift
@@ -18,7 +18,7 @@ class ActivityStreamTests: XCTestCase {
     override func setUp() {
         super.setUp()
         self.profile = MockProfile()
-        self.telemetry = ActivityStreamTracker(eventsTracker: MockPingClient(), sessionsTracker: MockPingClient())
+        self.telemetry = ActivityStreamTracker(profile: profile, eventsTracker: MockPingClient(), sessionsTracker: MockPingClient())
         self.panel = ActivityStreamPanel(profile: profile, telemetry: self.telemetry)
     }
 

--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -127,7 +127,7 @@ open class MockProfile: Profile {
         return CertStore()
     }()
 
-    lazy public var bookmarks: BookmarksModelFactorySource & KeywordSearchSource & SyncableBookmarks & LocalItemSource & MirrorItemSource & ShareToDestination = {
+    lazy public var bookmarks: BookmarksModelFactorySource & KeywordSearchSource & SyncableBookmarks & LocalItemSource & MirrorItemSource & ShareToDestination & CountableBookmarks = {
         // Make sure the rest of our tables are initialized before we try to read them!
         // This expression is for side-effects only.
         let p = self.places

--- a/ClientTests/MockableHistory.swift
+++ b/ClientTests/MockableHistory.swift
@@ -13,6 +13,7 @@ import Shared
  * mock out parts of the history API
  */
 class MockableHistory: BrowserHistory, SyncableHistory, ResettableSyncStorage {
+    func numberOfHistoryEntries() -> Deferred<Maybe<Int>> { fatalError() }
     func getTopSitesWithLimit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>> { fatalError()}
     func addLocalVisit(_ visit: SiteVisit) -> Success { fatalError() }
     func clearHistory() -> Success { fatalError() }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -139,7 +139,7 @@ class BrowserProfileSyncDelegate: SyncDelegate {
  * A Profile manages access to the user's data.
  */
 protocol Profile: class {
-    var bookmarks: BookmarksModelFactorySource & KeywordSearchSource & ShareToDestination & SyncableBookmarks & LocalItemSource & MirrorItemSource { get }
+    var bookmarks: BookmarksModelFactorySource & KeywordSearchSource & ShareToDestination & SyncableBookmarks & LocalItemSource & MirrorItemSource & CountableBookmarks { get }
     // var favicons: Favicons { get }
     var prefs: Prefs { get }
     var queue: TabQueue { get }
@@ -417,7 +417,7 @@ open class BrowserProfile: Profile {
         return self.places
     }
 
-    lazy var bookmarks: BookmarksModelFactorySource & KeywordSearchSource & ShareToDestination & SyncableBookmarks & LocalItemSource & MirrorItemSource = {
+    lazy var bookmarks: BookmarksModelFactorySource & KeywordSearchSource & ShareToDestination & SyncableBookmarks & LocalItemSource & MirrorItemSource & CountableBookmarks = {
         // Make sure the rest of our tables are initialized before we try to read them!
         // This expression is for side-effects only.
         withExtendedLifetime(self.places) {

--- a/Storage/Bookmarks/Bookmarks.swift
+++ b/Storage/Bookmarks/Bookmarks.swift
@@ -14,6 +14,10 @@ public protocol SearchableBookmarks: class {
     func bookmarksByURL(_ url: URL) -> Deferred<Maybe<Cursor<BookmarkItem>>>
 }
 
+public protocol CountableBookmarks: class {
+    func numberOfBookmarks() -> Deferred<Maybe<Int>>
+}
+
 public protocol SyncableBookmarks: class, ResettableSyncStorage, AccountRemovalDelegate {
     // TODO
     func isUnchanged() -> Deferred<Maybe<Bool>>

--- a/Storage/Bookmarks/Bookmarks.swift
+++ b/Storage/Bookmarks/Bookmarks.swift
@@ -15,7 +15,9 @@ public protocol SearchableBookmarks: class {
 }
 
 public protocol CountableBookmarks: class {
-    func numberOfBookmarks() -> Deferred<Maybe<Int>>
+    // Counts all of the bookmark items matching the given types across all of the
+    // non-structure bookmarks tables (local, mirror, buffer)
+    func countAllItems(matchingTypes: [BookmarkNodeType]) -> Deferred<Maybe<Int>>
 }
 
 public protocol SyncableBookmarks: class, ResettableSyncStorage, AccountRemovalDelegate {

--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -37,6 +37,7 @@ public protocol BrowserHistory {
     func clearTopSitesCache() -> Success
     @discardableResult func refreshTopSitesCache() -> Success
     func areTopSitesDirty(withLimit limit: Int) -> Deferred<Maybe<Bool>>
+    func numberOfHistoryEntries() -> Deferred<Maybe<Int>>
 }
 
 /**

--- a/Storage/SQL/SQLiteBookmarksBase.swift
+++ b/Storage/SQL/SQLiteBookmarksBase.swift
@@ -18,7 +18,7 @@ class NoSuchSearchKeywordError: MaybeErrorType {
     }
 }
 
-open class SQLiteBookmarks: BookmarksModelFactorySource, KeywordSearchSource {
+open class SQLiteBookmarks: BookmarksModelFactorySource, KeywordSearchSource, CountableBookmarks {
     let db: BrowserDB
     let favicons: FaviconsTable<Favicon>
 
@@ -61,5 +61,13 @@ open class SQLiteBookmarks: BookmarksModelFactorySource, KeywordSearchSource {
 
                 return deferMaybe(NoSuchSearchKeywordError(keyword: keyword))
         }
+    }
+
+    // Doesn't factor in bookmark structure. Used for telemetry purposes on 
+    // bookmarks the user can actually see.
+    open func numberOfBookmarks() -> Deferred<Maybe<Int>> {
+        let sql = "SELECT COUNT(*) FROM \(ViewBookmarksLocalOnMirror)"
+        return self.db.runQuery(sql, args: nil, factory: { $0[0] as! Int })
+            >>== { deferMaybe($0[0]!) }
     }
 }

--- a/Storage/SQL/SQLiteBookmarksModel.swift
+++ b/Storage/SQL/SQLiteBookmarksModel.swift
@@ -855,7 +855,7 @@ open class MergedSQLiteBookmarks: BookmarksModelFactorySource, KeywordSearchSour
         return self.local.getURLForKeywordSearch(keyword)
     }
 
-    open func numberOfBookmarks() -> Deferred<Maybe<Int>> {
-        return self.local.numberOfBookmarks()
+    open func countAllItems(matchingTypes: [BookmarkNodeType]) -> Deferred<Maybe<Int>> {
+        return local.countAllItems(matchingTypes: matchingTypes)
     }
 }

--- a/Storage/SQL/SQLiteBookmarksModel.swift
+++ b/Storage/SQL/SQLiteBookmarksModel.swift
@@ -828,7 +828,7 @@ open class UnsyncedBookmarksFallbackModelFactory: BookmarksModelFactory {
     }
 }
 
-open class MergedSQLiteBookmarks: BookmarksModelFactorySource, KeywordSearchSource {
+open class MergedSQLiteBookmarks: BookmarksModelFactorySource, KeywordSearchSource, CountableBookmarks {
     let local: SQLiteBookmarks
     let buffer: SQLiteBookmarkBufferStorage
 
@@ -853,5 +853,9 @@ open class MergedSQLiteBookmarks: BookmarksModelFactorySource, KeywordSearchSour
 
     open func getURLForKeywordSearch(_ keyword: String) -> Deferred<Maybe<String>> {
         return self.local.getURLForKeywordSearch(keyword)
+    }
+
+    open func numberOfBookmarks() -> Deferred<Maybe<Int>> {
+        return self.local.numberOfBookmarks()
     }
 }

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -662,6 +662,12 @@ extension SQLiteHistory: BrowserHistory {
         let allSQL = "SELECT * FROM (SELECT * FROM (\(historySQL)) UNION SELECT * FROM (\(bookmarksSQL))) ORDER BY is_bookmarked DESC, frecencies DESC"
         return (allSQL, args)
     }
+
+    public func numberOfHistoryEntries() -> Deferred<Maybe<Int>> {
+        let sql = "SELECT COUNT(*) FROM \(TableHistory)"
+        return self.db.runQuery(sql, args: nil, factory: { $0[0] as! Int })
+            >>== { deferMaybe($0[0]!) }
+    }
 }
 
 extension SQLiteHistory: Favicons {

--- a/StorageTests/TestSQLiteBookmarks.swift
+++ b/StorageTests/TestSQLiteBookmarks.swift
@@ -741,31 +741,31 @@ class TestSQLiteBookmarks: XCTestCase {
 
         let bookmarks = SQLiteBookmarks(db: db)
         var expectedCount = BookmarkRoots.Real.count
-        var count = bookmarks.numberOfBookmarks().value.successValue!
-        XCTAssertEqual(count, BookmarkRoots.Real.count)
+        var count = bookmarks.countAllItems(matchingTypes: [.bookmark]).value.successValue!
+        XCTAssertEqual(count, 0)
 
         // Check that adding a local bookmark increases the count
         bookmarks.insertBookmark("http://getfirefox.com".asURL!, title: "AAA", favicon: nil, intoFolder: BookmarkRoots.MobileFolderGUID, withTitle: "Mobile Bookmarks").succeeded()
         expectedCount += 1
-        count = bookmarks.numberOfBookmarks().value.successValue!
-        XCTAssertEqual(count, expectedCount)
+        count = bookmarks.countAllItems(matchingTypes: [.bookmark]).value.successValue!
+        XCTAssertEqual(count, 1)
 
         // Check that bookmarks in the mirror also count
         db.moveLocalToMirrorForTesting()
-        count = bookmarks.numberOfBookmarks().value.successValue!
-        XCTAssertEqual(count, expectedCount)
+        count = bookmarks.countAllItems(matchingTypes: [.bookmark]).value.successValue!
+        XCTAssertEqual(count, 1)
 
         // Check that bookmarks in local and mirror are both counted
         bookmarks.insertBookmark("http://deleteme.com".asURL!, title: "BBB", favicon: nil, intoFolder: BookmarkRoots.MobileFolderGUID, withTitle: "Mobile Bookmarks").succeeded()
         expectedCount += 1
-        count = bookmarks.numberOfBookmarks().value.successValue!
-        XCTAssertEqual(count, expectedCount)
+        count = bookmarks.countAllItems(matchingTypes: [.bookmark]).value.successValue!
+        XCTAssertEqual(count, 2)
 
         // Check that a deleted bookmark doesn't count
         let bookmarkToRemove = bookmarks.bookmarksByURL("http://deleteme.com".asURL!).value.successValue![0]!
         bookmarks.removeGUIDs([bookmarkToRemove.guid]).succeeded()
         expectedCount -= 1
-        count = bookmarks.numberOfBookmarks().value.successValue!
-        XCTAssertEqual(count, expectedCount)
+        count = bookmarks.countAllItems(matchingTypes: [.bookmark]).value.successValue!
+        XCTAssertEqual(count, 1)
     }
 }

--- a/StorageTests/TestSQLiteBookmarks.swift
+++ b/StorageTests/TestSQLiteBookmarks.swift
@@ -44,6 +44,7 @@ class TestSQLiteBookmarks: XCTestCase {
         self.remove("TSQLBtestRecursiveAndURLDelete.db")
         self.remove("TSQLBtestUnrooted.db")
         self.remove("TSQLBtestTreeBuilding.db")
+        self.remove("TSQLBtestBookmarkCounting.db")
         super.tearDown()
     }
 
@@ -730,5 +731,41 @@ class TestSQLiteBookmarks: XCTestCase {
 
         // We no longer have children.
         XCTAssertEqual(0, childCount("UjAHxFOGEqU8"))
+    }
+
+    func testBookmarkCounting() {
+        guard let db = getBrowserDB("TSQLBtestBookmarkCounting.db", files: self.files) else {
+            XCTFail("Unable to create browser DB.")
+            return
+        }
+
+        let bookmarks = SQLiteBookmarks(db: db)
+        var expectedCount = BookmarkRoots.Real.count
+        var count = bookmarks.numberOfBookmarks().value.successValue!
+        XCTAssertEqual(count, BookmarkRoots.Real.count)
+
+        // Check that adding a local bookmark increases the count
+        bookmarks.insertBookmark("http://getfirefox.com".asURL!, title: "AAA", favicon: nil, intoFolder: BookmarkRoots.MobileFolderGUID, withTitle: "Mobile Bookmarks").succeeded()
+        expectedCount += 1
+        count = bookmarks.numberOfBookmarks().value.successValue!
+        XCTAssertEqual(count, expectedCount)
+
+        // Check that bookmarks in the mirror also count
+        db.moveLocalToMirrorForTesting()
+        count = bookmarks.numberOfBookmarks().value.successValue!
+        XCTAssertEqual(count, expectedCount)
+
+        // Check that bookmarks in local and mirror are both counted
+        bookmarks.insertBookmark("http://deleteme.com".asURL!, title: "BBB", favicon: nil, intoFolder: BookmarkRoots.MobileFolderGUID, withTitle: "Mobile Bookmarks").succeeded()
+        expectedCount += 1
+        count = bookmarks.numberOfBookmarks().value.successValue!
+        XCTAssertEqual(count, expectedCount)
+
+        // Check that a deleted bookmark doesn't count
+        let bookmarkToRemove = bookmarks.bookmarksByURL("http://deleteme.com".asURL!).value.successValue![0]!
+        bookmarks.removeGUIDs([bookmarkToRemove.guid]).succeeded()
+        expectedCount -= 1
+        count = bookmarks.numberOfBookmarks().value.successValue!
+        XCTAssertEqual(count, expectedCount)
     }
 }

--- a/StorageTests/TestSQLiteHistory.swift
+++ b/StorageTests/TestSQLiteHistory.swift
@@ -1318,6 +1318,19 @@ class TestSQLiteHistory: XCTestCase {
             return
         }
     }
+
+    func testHistoryCounting() {
+        let db = BrowserDB(filename: "browser.db", files: files)
+        let prefs = MockProfilePrefs()
+        let history = SQLiteHistory(db: db, prefs: prefs)
+
+        XCTAssertEqual(history.numberOfHistoryEntries().value.successValue!, 0)
+
+        let site = Site(url: "http://getfirefox.com", title: "Get Firefox")
+        history.addLocalVisit(SiteVisit(site: site, date: Date.nowMicroseconds())).succeeded()
+
+        XCTAssertEqual(history.numberOfHistoryEntries().value.successValue!, 1)
+    }
 }
 
 class TestSQLiteHistoryTransactionUpdate: XCTestCase {

--- a/StorageTests/TestSQLiteHistory.swift
+++ b/StorageTests/TestSQLiteHistory.swift
@@ -1321,6 +1321,8 @@ class TestSQLiteHistory: XCTestCase {
 
     func testHistoryCounting() {
         let db = BrowserDB(filename: "browser.db", files: files)
+        db.attachDB(filename: "metadata.db", as: AttachedDatabaseMetadata)
+
         let prefs = MockProfilePrefs()
         let history = SQLiteHistory(db: db, prefs: prefs)
 

--- a/Telemetry/PingCentre/Topics.swift
+++ b/Telemetry/PingCentre/Topics.swift
@@ -26,6 +26,10 @@ extension PingCentreTopic {
                 "source": ["type": "string"],
                 "action_position": ["type": "number"],
                 "share_provider": ["type": "string"],
+                "total_bookmarks_size": ["type": "number"],
+                "total_history_size": ["type": "number"],
+                "highlights_count": ["type": "number"],
+                "top_sites_count": ["type": "number"],
 
                 // Application metadata
                 "app_version": ["type": "string"],


### PR DESCRIPTION
Adds a ping to tell us how long it takes for the entire new tab page to be invalidated along with related information sucn as the total number of bookmarks, history, highlights and top sites.