### PR TITLE
Bug 1317536 - Choose a Topsite url correctly

### DIFF
--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -586,7 +586,10 @@ extension SQLiteHistory: BrowserHistory {
         ") ORDER BY frecency DESC" +
         " LIMIT 1000"                                 // Don't even look at a huge set. This avoids work.
 
-        // Next: merge by domain and sum frecency, ordering by that sum and reducing to a (typically much lower) limit.
+        // Next: merge by domain and select the url with the max frecency of a domain, ordering by that sum frecency and reducing to a (typically much lower) limit.
+        // NOTE: When using GROUP BY we need to be explicit about which url to use when merging. By using "max(frecency)" the result row
+        //       for that domain will contain the url with the max frecency https://sqlite.org/lang_select.html#resultset
+        //       This is the behavior we want in order to ensure that the most popular url for a domain is used as the Topsite.
         // TODO: make is_bookmarked here accurate by joining against ViewAllBookmarks.
         // TODO: ensure that the same URL doesn't appear twice in the list, either from duplicate
         //       bookmarks or from being in both bookmarks and history.

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -596,6 +596,7 @@ extension SQLiteHistory: BrowserHistory {
             "max(remoteVisitDate) AS remoteVisitDate,",
             "sum(localVisitCount) AS localVisitCount,",
             "sum(remoteVisitCount) AS remoteVisitCount,",
+            "max(frecency),",
             "sum(frecency) AS frecencies,",
             "0 AS is_bookmarked",
             "FROM (", frecenciedSQL, ") ",

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -586,10 +586,10 @@ extension SQLiteHistory: BrowserHistory {
         ") ORDER BY frecency DESC" +
         " LIMIT 1000"                                 // Don't even look at a huge set. This avoids work.
 
-        // Next: merge by domain and select the url with the max frecency of a domain, ordering by that sum frecency and reducing to a (typically much lower) limit.
-        // NOTE: When using GROUP BY we need to be explicit about which url to use when merging. By using "max(frecency)" the result row
-        //       for that domain will contain the url with the max frecency https://sqlite.org/lang_select.html#resultset
-        //       This is the behavior we want in order to ensure that the most popular url for a domain is used as the Topsite.
+        // Next: merge by domain and select the URL with the max frecency of a domain, ordering by that sum frecency and reducing to a (typically much lower) limit.
+        // NOTE: When using GROUP BY we need to be explicit about which URL to use when grouping. By using "max(frecency)" the result row
+        //       for that domain will contain the projected URL corresponding to the history item with the max frecency, https://sqlite.org/lang_select.html#resultset
+        //       This is the behavior we want in order to ensure that the most popular URL for a domain is used for the top sites tile.
         // TODO: make is_bookmarked here accurate by joining against ViewAllBookmarks.
         // TODO: ensure that the same URL doesn't appear twice in the list, either from duplicate
         //       bookmarks or from being in both bookmarks and history.

--- a/StorageTests/TestSQLiteHistory.swift
+++ b/StorageTests/TestSQLiteHistory.swift
@@ -1236,6 +1236,7 @@ class TestSQLiteHistory: XCTestCase {
 
     func testTopSitesFrecencyOrder() {
         let db = BrowserDB(filename: "browser.db", files: files)
+        db.attachDB(filename: "metadata.db", as: AttachedDatabaseMetadata)
         let prefs = MockProfilePrefs()
         let history = SQLiteHistory(db: db, prefs: prefs)
 

--- a/StorageTests/TestSQLiteHistory.swift
+++ b/StorageTests/TestSQLiteHistory.swift
@@ -1248,7 +1248,7 @@ class TestSQLiteHistory: XCTestCase {
         populateHistoryForFrecencyCalculations(history, siteCount: 100)
 
         // Add extra visits to the 5th site to bubble it to the top of the top sites cache
-        let site = Site(url: "http://s\(5)ite\(5)/foo", title: "A \(5)")
+        let site = Site(url: "http://s\(5)ite\(5).com/foo", title: "A \(5)")
         site.guid = "abc\(5)def"
         for i in 0...20 {
             addVisitForSite(site, intoHistory: history, from: .local, atTime: advanceTimestamp(baseInstantInMicros, by: 1000000 * i))
@@ -1283,7 +1283,7 @@ class TestSQLiteHistory: XCTestCase {
         }
 
         func addVisitsToZerothSite() -> Success {
-            let site = Site(url: "http://s\(0)ite\(0)/foo", title: "A \(0)")
+            let site = Site(url: "http://s\(0)ite\(0).com/foo", title: "A \(0)")
             site.guid = "abc\(0)def"
             for i in 0...20 {
                 addVisitForSite(site, intoHistory: history, from: .local, atTime: advanceTimestamp(baseInstantInMicros, by: 1000000 * i))
@@ -1401,7 +1401,7 @@ enum VisitOrigin {
 
 private func populateHistoryForFrecencyCalculations(_ history: SQLiteHistory, siteCount count: Int) {
     for i in 0...count {
-        let site = Site(url: "http://s\(i)ite\(i)/foo", title: "A \(i)")
+        let site = Site(url: "http://s\(i)ite\(i).com/foo", title: "A \(i)")
         site.guid = "abc\(i)def"
 
         let baseMillis: UInt64 = baseInstantInMillis - 20000

--- a/StorageTests/TestSQLiteHistory.swift
+++ b/StorageTests/TestSQLiteHistory.swift
@@ -1410,7 +1410,7 @@ private func populateHistoryForFrecencyCalculations(_ history: SQLiteHistory, si
         for j in 0...20 {
             let visitTime = advanceMicrosecondTimestamp(baseInstantInMicros, by: (1000000 * i) + (1000 * j))
             addVisitForSite(site, intoHistory: history, from: .local, atTime: visitTime)
-            addVisitForSite(site, intoHistory: history, from: .remote, atTime: visitTime)
+            addVisitForSite(site, intoHistory: history, from: .remote, atTime: visitTime - 100)
         }
     }
 }

--- a/StorageTests/TestSQLiteHistory.swift
+++ b/StorageTests/TestSQLiteHistory.swift
@@ -1243,7 +1243,6 @@ class TestSQLiteHistory: XCTestCase {
         history.clearTopSitesCache().value
         history.clearHistory().value
 
-
         // Lets create some history. This will create 100 sites that will have 21 local and 21 remote visits
         populateHistoryForFrecencyCalculations(history, siteCount: 100)
 
@@ -1282,7 +1281,6 @@ class TestSQLiteHistory: XCTestCase {
             return
         }
     }
-
 
     func testTopSitesCache() {
         let db = BrowserDB(filename: "browser.db", files: files)


### PR DESCRIPTION
When grouping by domain during the Topsite calculation, make sure to choose the url with the highest frecency as the topsite for that domain.

What was happening before was that if a Topsite had even 1 remote visit it would be nominated as the Topsite for that domain regardless of its actual frecency score. 

I had to make some changes to the tests.
- Turns out that "addRemoteVisit" in the Test class wasnt actually working (probably because the timestamp was the same as a local visit?)
