### PR TITLE
Bug 1258273 - Allow inline videos to be played in Firefox for iOS

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -151,6 +151,9 @@ class Tab: NSObject {
             configuration!.userContentController = WKUserContentController()
             configuration!.preferences = WKPreferences()
             configuration!.preferences.javaScriptCanOpenWindowsAutomatically = false
+            configuration!.allowsInlineMediaPlayback = true
+            configuration!.allowsPictureInPictureMediaPlayback = true
+            configuration!.allowsAirPlayForMediaPlayback = true
             let webView = TabWebView(frame: CGRect.zero, configuration: configuration!)
             webView.delegate = self
             configuration = nil


### PR DESCRIPTION
Bug 1258273 - Allow inline videos to be played in Firefox for iOS [https://bugzilla.mozilla.org/show_bug.cgi?id=1258273](url)

Enables inline media playback, picture in picture and airplay for media to accommodate iOS 10 media configuration changes.