### PR TITLE
Bug 1354934 crash get unordered bundled engines

### DIFF
--- a/Client/Frontend/Browser/SearchEngines.swift
+++ b/Client/Frontend/Browser/SearchEngines.swift
@@ -5,6 +5,9 @@
 import Foundation
 import Shared
 import Storage
+import XCGLogger
+
+private let log = Logger.browserLogger
 
 private let OrderedEngineNames = "search.orderedEngineNames"
 private let DisabledEngineNames = "search.disabledEngineNames"
@@ -262,10 +265,11 @@ class SearchEngines {
             }
             assert(FileManager.default.fileExists(atPath: fullPath), "\(fullPath) exists")
 
-            let engine = parser.parse(fullPath, engineID: engineName)
-            assert(engine != nil, "Engine at \(fullPath) successfully parsed")
-
-            engines.append(engine!)
+            guard let engine = parser.parse(fullPath, engineID: engineName) else {
+                log.error("Failed to parse search engine ID \(engineName) at \(fullPath)")
+                continue
+            }
+            engines.append(engine)
         }
 
         let defaultEngineFile = (searchDirectory as NSString).appendingPathComponent("default.txt")


### PR DESCRIPTION
This makes the code a bit more robust, not trying to add search engines that failed to parse.