### PR TITLE
Bug 1355378 - Enable remaining Toolbar UI Tests

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/FirefoxNightly.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/FirefoxNightly.xcscheme
@@ -174,9 +174,6 @@
                   Identifier = "SettingsTests">
                </Test>
                <Test
-                  Identifier = "ToolbarTests">
-               </Test>
-               <Test
                   Identifier = "TopSitesTests">
                </Test>
                <Test

--- a/UITests/ToolbarTests.swift
+++ b/UITests/ToolbarTests.swift
@@ -46,8 +46,7 @@ class ToolbarTests: KIFTestCase, UITextFieldDelegate {
     func testUserInfoRemovedFromURL() {
         let hostWithUsername = webRoot.replacingOccurrences(of: "127.0.0.1", with: "username:password@127.0.0.1", options: NSString.CompareOptions(), range: nil)
         let urlWithUserInfo = "\(hostWithUsername)/numberedPage.html?page=1"
-        let url = "\(webRoot)/numberedPage.html?page=1"
-
+        let url = "\(webRoot!)/numberedPage.html?page=1"
         _ = tester().waitForView(withAccessibilityIdentifier: "url") as! UITextField
         tester().tapView(withAccessibilityIdentifier: "url")
         tester().enterText(intoCurrentFirstResponder: urlWithUserInfo+"\n")


### PR DESCRIPTION
All Toolbar UI Tests were converted to XCUITests except for two that can be re-enabled as UI Tests