### PR TITLE
Bug 1355825 - Fix up all new warnings from Swift 3.1 migration

### DIFF
--- a/Account/Account-Bridging-Header.h
+++ b/Account/Account-Bridging-Header.h
@@ -2,5 +2,6 @@
 #define Client_Account_Bridging_Header_h
 
 #import <Foundation/Foundation.h>
+#import "Shared-Bridging-Header.h"
 
 #endif

--- a/Account/FirefoxAccount.swift
+++ b/Account/FirefoxAccount.swift
@@ -257,7 +257,8 @@ open class FirefoxAccount {
             self.stateCache.value = married.withoutKeyPair()
             return true
         }
-        log.info("Cannot make Account State be CohabitingWithoutKeyPair from state with label \(self.stateCache.value?.label).")
+
+        log.info("Cannot make Account State be CohabitingWithoutKeyPair from state with label \(self.stateCache.value?.label ??? "nil").")
         return false
     }
 }

--- a/Account/FxAState.swift
+++ b/Account/FxAState.swift
@@ -90,7 +90,7 @@ func stateV1(fromJSON json: JSON) -> FxAState? {
                     sessionToken = json["sessionToken"].string?.hexDecodedData,
                     let kA = json["kA"].string?.hexDecodedData,
                     let kB = json["kB"].string?.hexDecodedData,
-                    let keyPairJSON = json["keyPair"].dictionaryObject as? [String: AnyObject],
+                    let keyPairJSON = json["keyPair"].dictionaryObject,
                     let keyPair = RSAKeyPair(jsonRepresentation: keyPairJSON),
                     let keyPairExpiresAt = json["keyPairExpiresAt"].int64 {
                         return CohabitingAfterKeyPairState(sessionToken: sessionToken, kA: kA, kB: kB,
@@ -102,7 +102,7 @@ func stateV1(fromJSON json: JSON) -> FxAState? {
                     sessionToken = json["sessionToken"].string?.hexDecodedData,
                     let kA = json["kA"].string?.hexDecodedData,
                     let kB = json["kB"].string?.hexDecodedData,
-                    let keyPairJSON = json["keyPair"].dictionaryObject as? [String: AnyObject],
+                    let keyPairJSON = json["keyPair"].dictionaryObject,
                     let keyPair = RSAKeyPair(jsonRepresentation: keyPairJSON),
                     let keyPairExpiresAt = json["keyPairExpiresAt"].int64,
                     let certificate = json["certificate"].string,

--- a/Client-Bridging-Header.h
+++ b/Client-Bridging-Header.h
@@ -13,4 +13,7 @@
 #import <CrashReporter/CrashReporter.h>
 #import <BuddyBuildSDK/BuddyBuildSDK.h>
 
+#import "Shared-Bridging-Header.h"
+#import "Storage-Bridging-Header.h"
+
 #endif

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -700,6 +700,13 @@
 		E6ECF2381C974E0F00B0DC93 /* KIF.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D30EBB6A1C75503800105AE9 /* KIF.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E6EDE82C1D5244AF007A0732 /* BatchingClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6EDE81D1D524475007A0732 /* BatchingClientTests.swift */; };
 		E6F368291D7F594F008CDD67 /* SQLiteHistoryRecommendations.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F368281D7F594F008CDD67 /* SQLiteHistoryRecommendations.swift */; };
+		E6F6D6A31E9E6B2A0012072B /* DeferredTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F6D6A11E9E6AF90012072B /* DeferredTestUtils.swift */; };
+		E6F6D6A41E9E6B2B0012072B /* DeferredTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F6D6A11E9E6AF90012072B /* DeferredTestUtils.swift */; };
+		E6F6D6A51E9E6B2B0012072B /* DeferredTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F6D6A11E9E6AF90012072B /* DeferredTestUtils.swift */; };
+		E6F6D6A61E9E6B2C0012072B /* DeferredTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F6D6A11E9E6AF90012072B /* DeferredTestUtils.swift */; };
+		E6F6D6A71E9E6B2D0012072B /* DeferredTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F6D6A11E9E6AF90012072B /* DeferredTestUtils.swift */; };
+		E6F6D6AA1E9E6B300012072B /* DeferredTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F6D6A11E9E6AF90012072B /* DeferredTestUtils.swift */; };
+		E6F6D6AB1E9E6B330012072B /* DeferredTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F6D6A11E9E6AF90012072B /* DeferredTestUtils.swift */; };
 		E6F965121B2F1CF20034B023 /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288A2D861AB8B3260023ABC3 /* Shared.framework */; };
 		E6F9653C1B2F1D5D0034B023 /* NSURLExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F9653B1B2F1D5D0034B023 /* NSURLExtensionsTests.swift */; };
 		E6F965421B2F25110034B023 /* NSMutableAttributedStringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F965411B2F25110034B023 /* NSMutableAttributedStringExtensionsTests.swift */; };
@@ -1860,6 +1867,7 @@
 		E6EAC5951B29CB3A00E1DE1E /* scrollablePage.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = scrollablePage.html; sourceTree = "<group>"; };
 		E6EDE81D1D524475007A0732 /* BatchingClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BatchingClientTests.swift; path = SyncTests/BatchingClientTests.swift; sourceTree = "<group>"; };
 		E6F368281D7F594F008CDD67 /* SQLiteHistoryRecommendations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLiteHistoryRecommendations.swift; sourceTree = "<group>"; };
+		E6F6D6A11E9E6AF90012072B /* DeferredTestUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeferredTestUtils.swift; sourceTree = "<group>"; };
 		E6F9650C1B2F1CF20034B023 /* SharedTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SharedTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E6F9650F1B2F1CF20034B023 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E6F9653B1B2F1D5D0034B023 /* NSURLExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSURLExtensionsTests.swift; sourceTree = "<group>"; };
@@ -3258,6 +3266,14 @@
 			path = Telemetry/PingCentre;
 			sourceTree = "<group>";
 		};
+		E6F6D6921E9E6AC20012072B /* TestUtils */ = {
+			isa = PBXGroup;
+			children = (
+				E6F6D6A11E9E6AF90012072B /* DeferredTestUtils.swift */,
+			);
+			name = TestUtils;
+			sourceTree = "<group>";
+		};
 		E6F9650D1B2F1CF20034B023 /* SharedTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -3312,6 +3328,7 @@
 				28CE83B91A1D1D3200576538 /* Sync */,
 				28C077911A3B05C200834FE5 /* SyncTests */,
 				28BFA7101C8E5C1A0017C2BD /* Telemetry */,
+				E6F6D6921E9E6AC20012072B /* TestUtils */,
 				28CE83EF1A1D246900576538 /* Third-Party Source */,
 				D39FA1601A83E0EC00EE869C /* UITests */,
 				3BFE4B081D342FB900DDF53F /* XCUITests */,
@@ -4751,6 +4768,7 @@
 				28ECD9F41BA1F59800D829DA /* DownloadTests.swift in Sources */,
 				2F3724C61ABF3C01007607FA /* LiveStorageClientTests.swift in Sources */,
 				E6EDE82C1D5244AF007A0732 /* BatchingClientTests.swift in Sources */,
+				E6F6D6A51E9E6B2B0012072B /* DeferredTestUtils.swift in Sources */,
 				28D980231C47149000277055 /* TestBookmarkTreeMerging.swift in Sources */,
 				E67035EE1E538B500037AB83 /* Mocking.swift in Sources */,
 				289A4C141C4EB90600A460E3 /* StorageTestUtils.swift in Sources */,
@@ -4855,6 +4873,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E6F6D6A41E9E6B2B0012072B /* DeferredTestUtils.swift in Sources */,
 				2FA4363E1ABB8448008031D1 /* FxAClient10Tests.swift in Sources */,
 				2FDBCF9B1AC0ADB500AFF7F0 /* SyncAuthStateTests.swift in Sources */,
 				2FA436421ABB8448008031D1 /* TokenServerClientTests.swift in Sources */,
@@ -4932,6 +4951,7 @@
 				E63F71881DB7FBE200A995C9 /* TestSQLiteMetadata.swift in Sources */,
 				2FCAE2851ABB533A00877008 /* TestSQLiteRemoteClientsAndTabs.swift in Sources */,
 				0B5A93081B1E64F3004F47A2 /* TestDeferredSqlite.swift in Sources */,
+				E6F6D6A31E9E6B2A0012072B /* DeferredTestUtils.swift in Sources */,
 				E6BE53CD1D9177B10074909A /* TestSQLiteHistoryRecommendations.swift in Sources */,
 				289A4C131C4EB90600A460E3 /* StorageTestUtils.swift in Sources */,
 				28D158CC1AFDBCC000F9C065 /* TestFaviconsTable.swift in Sources */,
@@ -4959,6 +4979,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E6F6D6AA1E9E6B300012072B /* DeferredTestUtils.swift in Sources */,
 				3B43E3D31D95C48D00BBA9DB /* StoragePerfTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -5083,6 +5104,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E4D567A51ADECEB800F1EFE7 /* ReadingListStorageTestCase.swift in Sources */,
+				E6F6D6A61E9E6B2C0012072B /* DeferredTestUtils.swift in Sources */,
 				E4D5679F1ADECEB800F1EFE7 /* ReadingListClientRecordTestCase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -5105,6 +5127,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E6F6D6A71E9E6B2D0012072B /* DeferredTestUtils.swift in Sources */,
 				28532BEB1C472015000072D9 /* UtilsTests.swift in Sources */,
 				28532BEA1C472008000072D9 /* DeferredTests.swift in Sources */,
 				E61453BE1B750A1700C3F9D7 /* RollingFileLoggerTests.swift in Sources */,
@@ -5325,6 +5348,7 @@
 				03CCC9181AF05E7300DBF30D /* RelativeDatesTests.swift in Sources */,
 				F84B21DA1A090F8100AAB793 /* ClientTests.swift in Sources */,
 				281B2BEA1ADF4D90002917DC /* MockProfile.swift in Sources */,
+				E6F6D6AB1E9E6B330012072B /* DeferredTestUtils.swift in Sources */,
 				2F697F7E1A9FD22D009E03AE /* SearchEnginesTests.swift in Sources */,
 				2F44FA1B1A9D426A00FD20CC /* TestHashExtensions.swift in Sources */,
 				3B39EDBA1E16E18900EF029F /* CustomSearchEnginesTest.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -145,7 +145,7 @@
 		2CA16FDE1E5F089100332277 /* SearchTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA16FDD1E5F089100332277 /* SearchTest.swift */; };
 		2CB56E3F1E926BFB00AF7586 /* ToolbarTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB56E3E1E926BFB00AF7586 /* ToolbarTest.swift */; };
 		2CC1B3F01E9B861400814EEC /* DomainAutocompleteTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC1B3EF1E9B861400814EEC /* DomainAutocompleteTest.swift */; };
-               2CEA6F791E93E3A600D4100E /* SearchSettingsUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CEA6F781E93E3A600D4100E /* SearchSettingsUITest.swift */; };
+		2CEA6F791E93E3A600D4100E /* SearchSettingsUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CEA6F781E93E3A600D4100E /* SearchSettingsUITest.swift */; };
 		2F13E79B1AC0C02700D75081 /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F13E79A1AC0C02700D75081 /* StringExtensionsTests.swift */; };
 		2F14E13A1ABB890800FF98DB /* Account-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F14E1391ABB890800FF98DB /* Account-Bridging-Header.h */; };
 		2F1A3DE11ABE3C90002F1E15 /* FxALoginStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1A3DE01ABE3C90002F1E15 /* FxALoginStateMachine.swift */; };
@@ -674,6 +674,7 @@
 		E6927EC01C7B6FB800D03F75 /* ErrorToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6927EBF1C7B6FB800D03F75 /* ErrorToast.swift */; };
 		E692E3291C46E62D009D1240 /* AuthenticationSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E692E3281C46E62D009D1240 /* AuthenticationSettingsViewController.swift */; };
 		E692E3371C46E86A009D1240 /* AppSettingsOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E692E3361C46E86A009D1240 /* AppSettingsOptions.swift */; };
+		E693F0D91E9D64BD0086DC17 /* OptionalExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E693F0D81E9D64BD0086DC17 /* OptionalExtensions.swift */; };
 		E696FE511C47F86E00EC007C /* AuthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E696FE501C47F86E00EC007C /* AuthenticatorTests.swift */; };
 		E698FFDA1B4AADF40001F623 /* TabScrollController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E698FFD91B4AADF40001F623 /* TabScrollController.swift */; };
 		E69922171B94E3EF007C480D /* Licenses.html in Resources */ = {isa = PBXBuildFile; fileRef = E69922121B94E3EF007C480D /* Licenses.html */; };
@@ -1324,7 +1325,7 @@
 		2CA16FDD1E5F089100332277 /* SearchTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchTest.swift; sourceTree = "<group>"; };
 		2CB56E3E1E926BFB00AF7586 /* ToolbarTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolbarTest.swift; sourceTree = "<group>"; };
 		2CC1B3EF1E9B861400814EEC /* DomainAutocompleteTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainAutocompleteTest.swift; sourceTree = "<group>"; };
-               2CEA6F781E93E3A600D4100E /* SearchSettingsUITest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSettingsUITest.swift; sourceTree = "<group>"; };
+		2CEA6F781E93E3A600D4100E /* SearchSettingsUITest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSettingsUITest.swift; sourceTree = "<group>"; };
 		2F13E79A1AC0C02700D75081 /* StringExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringExtensionsTests.swift; sourceTree = "<group>"; };
 		2F14E1391ABB890800FF98DB /* Account-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Account-Bridging-Header.h"; sourceTree = "<group>"; };
 		2F1A3DE01ABE3C90002F1E15 /* FxALoginStateMachine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = FxALoginStateMachine.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -1832,6 +1833,7 @@
 		E6927EBF1C7B6FB800D03F75 /* ErrorToast.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorToast.swift; sourceTree = "<group>"; };
 		E692E3281C46E62D009D1240 /* AuthenticationSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationSettingsViewController.swift; sourceTree = "<group>"; };
 		E692E3361C46E86A009D1240 /* AppSettingsOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppSettingsOptions.swift; sourceTree = "<group>"; };
+		E693F0D81E9D64BD0086DC17 /* OptionalExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionalExtensions.swift; sourceTree = "<group>"; };
 		E696FE501C47F86E00EC007C /* AuthenticatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticatorTests.swift; sourceTree = "<group>"; };
 		E698FFD91B4AADF40001F623 /* TabScrollController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabScrollController.swift; sourceTree = "<group>"; };
 		E69922121B94E3EF007C480D /* Licenses.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = Licenses.html; sourceTree = "<group>"; };
@@ -2636,7 +2638,7 @@
 				2C31A8461E8D447F00DAC646 /* HomePageSettingsUITest.swift */,
 				2CB56E3E1E926BFB00AF7586 /* ToolbarTest.swift */,
 				2CC1B3EF1E9B861400814EEC /* DomainAutocompleteTest.swift */,
-                               2CEA6F781E93E3A600D4100E /* SearchSettingsUITest.swift */,
+				2CEA6F781E93E3A600D4100E /* SearchSettingsUITest.swift */,
 			);
 			path = XCUITests;
 			sourceTree = "<group>";
@@ -3137,6 +3139,7 @@
 				7B10AABA1E3A1F650002DD08 /* URLRequestExtensions.swift */,
 				7B9BF91B1E43472E00CB24F4 /* JSONExtensions.swift */,
 				7B3D9E641E4CBFDB007A50DA /* NSCoderExtensions.swift */,
+				E693F0D81E9D64BD0086DC17 /* OptionalExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -4773,6 +4776,7 @@
 				E65075B41E37F7AB006961AC /* KeychainCache.swift in Sources */,
 				E65075BA1E37F7AB006961AC /* Prefs.swift in Sources */,
 				7B10AABB1E3A1F650002DD08 /* URLRequestExtensions.swift in Sources */,
+				E693F0D91E9D64BD0086DC17 /* OptionalExtensions.swift in Sources */,
 				E65075A01E37F7AB006961AC /* ArrayExtensions.swift in Sources */,
 				288A2DAA1AB8B3700023ABC3 /* Box.swift in Sources */,
 				E65075A31E37F7AB006961AC /* KeychainWrapperExtensions.swift in Sources */,
@@ -4977,7 +4981,7 @@
 				2CC1B3F01E9B861400814EEC /* DomainAutocompleteTest.swift in Sources */,
 				0B729D371E047D6A008E6859 /* HomePageSettingsTest.swift in Sources */,
 				2C31A8471E8D447F00DAC646 /* HomePageSettingsUITest.swift in Sources */,
-                               2CEA6F791E93E3A600D4100E /* SearchSettingsUITest.swift in Sources */,
+				2CEA6F791E93E3A600D4100E /* SearchSettingsUITest.swift in Sources */,
 				55A747171DC46FC400CE1B57 /* HomePageUITest.swift in Sources */,
 				2C8C07771E7800EA00DC1237 /* FindInPageTest.swift in Sources */,
 				2CB56E3F1E926BFB00AF7586 /* ToolbarTest.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -266,7 +266,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         }
 
         guard let scheme = components.scheme, urlSchemes.contains(scheme) else {
-            log.warning("Cannot handle \(components.scheme) URL scheme")
+            log.warning("Cannot handle \(components.scheme ?? "nil") URL scheme")
             return false
         }
 

--- a/Client/Frontend/Animators/JumpAndSpinAnimator.swift
+++ b/Client/Frontend/Animators/JumpAndSpinAnimator.swift
@@ -20,7 +20,7 @@ class JumpAndSpinAnimator: Animatable {
         UIView.animate(withDuration: AnimationDuration, delay: 0.0, usingSpringWithDamping: 0.6, initialSpringVelocity: 2.0, options: [], animations: { () -> Void in
             viewToAnimate.transform = offToolbar
             let rotation = CABasicAnimation(keyPath: "transform.rotation")
-            rotation.toValue = CGFloat(M_PI * 2.0)
+            rotation.toValue = CGFloat(2.0 * Double.pi)
             rotation.isCumulative = true
             rotation.duration = self.AnimationDuration + 0.075
             rotation.repeatCount = 1.0

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -933,7 +933,7 @@ class BrowserViewController: UIViewController {
 
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
         let webView = object as! WKWebView
-        guard let path = keyPath else { assertionFailure("Unhandled KVO key: \(keyPath)"); return }
+        guard let path = keyPath else { assertionFailure("Unhandled KVO key: \(keyPath ?? "nil")"); return }
         switch path {
         case KVOEstimatedProgress:
             guard webView == tabManager.selectedTab?.webView,
@@ -974,7 +974,7 @@ class BrowserViewController: UIViewController {
 
             navigationToolbar.updateForwardStatus(canGoForward)
         default:
-            assertionFailure("Unhandled KVO key: \(keyPath)")
+            assertionFailure("Unhandled KVO key: \(keyPath ?? "nil")")
         }
     }
 
@@ -1027,7 +1027,7 @@ class BrowserViewController: UIViewController {
         profile.bookmarks.modelFactory >>== {
             $0.isBookmarked(url).uponQueue(DispatchQueue.main) { [weak tab] result in
                 guard let bookmarked = result.successValue else {
-                    log.error("Error getting bookmark status: \(result.failureValue).")
+                    log.error("Error getting bookmark status: \(result.failureValue ??? "nil").")
                     return
                 }
                 tab?.isBookmarked = bookmarked
@@ -2101,7 +2101,7 @@ extension BrowserViewController: TabManagerDelegate {
                         $0.isBookmarked(absoluteString)
                             .uponQueue(DispatchQueue.main) {
                             guard let isBookmarked = $0.successValue else {
-                                log.error("Error getting bookmark status: \($0.failureValue).")
+                                log.error("Error getting bookmark status: \($0.failureValue ??? "nil").")
                                 return
                             }
 
@@ -2277,7 +2277,6 @@ extension BrowserViewController: WKNavigationDelegate {
         }
 
         if !navigationAction.isAllowed && navigationAction.navigationType != .backForward {
-            print("\(navigationAction.isAllowed) \(navigationAction.navigationType == .backForward) \(navigationAction.request.url)")
             log.warning("Denying unprivileged request: \(navigationAction.request)")
             decisionHandler(WKNavigationActionPolicy.cancel)
             return

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -486,9 +486,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         self.data = data
         tableView.reloadData()
     }
-}
 
-extension SearchViewController {
     func tableView(_ tableView: UITableView, didSelectRowAtIndexPath indexPath: IndexPath) {
         let section = SearchListSection(rawValue: indexPath.section)!
         if section == SearchListSection.bookmarksAndHistory {
@@ -519,9 +517,7 @@ extension SearchViewController {
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return 0
     }
-}
 
-extension SearchViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         switch SearchListSection(rawValue: indexPath.section)! {
         case .searchSuggestions:

--- a/Client/Frontend/Browser/SwipeAnimator.swift
+++ b/Client/Frontend/Browser/SwipeAnimator.swift
@@ -84,7 +84,7 @@ extension SwipeAnimator {
 
     fileprivate func transformForTranslation(_ translation: CGFloat) -> CGAffineTransform {
         let swipeWidth = container.frame.size.width
-        let totalRotationInRadians = CGFloat(params.totalRotationInDegrees / 180.0 * M_PI)
+        let totalRotationInRadians = CGFloat(params.totalRotationInDegrees / 180.0 * Double.pi)
 
         // Determine rotation / scaling amounts by the distance to the edge
         let rotation = (translation / swipeWidth) * totalRotationInRadians

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -201,7 +201,7 @@ class Tab: NSObject {
         } else if let request = lastRequest {
             webView.load(request)
         } else {
-            log.error("creating webview with no lastRequest and no session data: \(self.url)")
+            log.error("creating webview with no lastRequest and no session data: \(self.url?.description ?? "nil")")
         }
     }
 
@@ -424,7 +424,7 @@ class Tab: NSObject {
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
         guard let webView = object as? WKWebView, webView == self.webView,
             let path = keyPath, path == "URL" else {
-            return assertionFailure("Unhandled KVO key: \(keyPath)")
+            return assertionFailure("Unhandled KVO key: \(keyPath ?? "nil")")
         }
 
         updateAppState()

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -678,7 +678,7 @@ extension TabManager {
         _ = Try(withTry: { () -> Void in
             self.preserveTabsInternal()
             }) { (exception) -> Void in
-            print("Failed to preserve tabs: \(exception)")
+            print("Failed to preserve tabs: \(exception ??? "nil")")
         }
     }
 
@@ -757,7 +757,7 @@ extension TabManager {
                     self.restoreTabsInternal()
                 },
                 catch: { exception in
-                    print("Failed to restore tabs: \(exception)")
+                    print("Failed to restore tabs: \(exception ??? "nil")")
                 }
             )
         }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -754,7 +754,7 @@ private let H_M4 = 0.961
 /* Code for drawing the urlbar curve */
 private class CurveView: UIView {
     fileprivate lazy var leftCurvePath: UIBezierPath = {
-        var leftArc = UIBezierPath(arcCenter: CGPoint(x: 5, y: 5), radius: CGFloat(5), startAngle: CGFloat(-M_PI), endAngle: CGFloat(-M_PI_2), clockwise: true)
+        var leftArc = UIBezierPath(arcCenter: CGPoint(x: 5, y: 5), radius: CGFloat(5), startAngle: CGFloat(-Double.pi), endAngle: CGFloat(-(Double.pi / 2)), clockwise: true)
         leftArc.addLine(to: CGPoint(x: 0, y: 0))
         leftArc.addLine(to: CGPoint(x: 0, y: 5))
         leftArc.close()

--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -496,7 +496,7 @@ extension ActivityStreamPanel {
         profile.bookmarks.modelFactory >>== {
             $0.isBookmarked(site.url).uponQueue(DispatchQueue.main) { result in
                 guard let isBookmarked = result.successValue else {
-                    log.error("Error getting bookmark status: \(result.failureValue).")
+                    log.error("Error getting bookmark status: \(result.failureValue ??? "nil").")
                     return
                 }
                 site.setBookmarked(isBookmarked)

--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -469,13 +469,13 @@ class HistoryPanel: SiteTableViewController, HomePanel {
 
                                     // 1. add a new section if the section didn't previously exist
                                     if oldCategory.section == nil && category.section != oldCategory.section {
-                                        log.debug("adding section \(category.section)")
+                                        log.debug("adding section \(category.section ?? 0)")
                                         sectionsToAdd.add(category.section!)
                                     }
 
                                     // 2. add a new row if there are more rows now than there were before
                                     if oldCategory.rows < category.rows {
-                                        log.debug("adding row to \(category.section) at \(category.rows-1)")
+                                        log.debug("adding row to \(category.section ?? 0)) at \(category.rows-1)")
                                         rowsToAdd.append(IndexPath(row: category.rows-1, section: category.section!))
                                     }
 
@@ -489,10 +489,10 @@ class HistoryPanel: SiteTableViewController, HomePanel {
                                             sectionsToDelete.add(indexPath.section)
                                         } else if oldCategory.section == category.section {
                                             if oldCategory.rows > category.rows {
-                                                log.debug("deleting row from \(category.section) at \(indexPath.row)")
+                                                log.debug("deleting row from \(category.section ?? 0) at \(indexPath.row)")
                                                 rowsToDelete.append(indexPath)
                                             } else if category.rows == oldCategory.rows {
-                                                log.debug("in section \(category.section), removing row at \(indexPath.row) and inserting row at \(category.rows-1)")
+                                                log.debug("in section \(category.section ?? 0), removing row at \(indexPath.row) and inserting row at \(category.rows-1)")
                                                 rowsToDelete.append(indexPath)
                                                 rowsToAdd.append(IndexPath(row: category.rows-1, section: indexPath.section))
                                             }

--- a/Client/Frontend/Settings/FxAContentViewController.swift
+++ b/Client/Frontend/Settings/FxAContentViewController.swift
@@ -170,7 +170,7 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
         // https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/WebChannel.jsm
         let origin = message.frameInfo.securityOrigin
         guard origin.`protocol` == url.scheme && origin.host == url.host && origin.port == (url.port ?? 0) else {
-            print("Ignoring message - \(origin) does not match expected origin \(url.origin)")
+            print("Ignoring message - \(origin) does not match expected origin: \(url.origin ?? "nil")")
             return
         }
 

--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -143,7 +143,7 @@ private extension ShareExtensionHelper {
         // Add 1Password to share sheet
         OnePasswordExtension.shared().createExtensionItem(forWebView: selectedWebView, completion: {(extensionItem, error) -> Void in
             if extensionItem == nil {
-                log.error("Failed to create the password manager extension item: \(error).")
+                log.error("Failed to create the password manager extension item: \(error.debugDescription).")
                 return
             }
 
@@ -159,7 +159,7 @@ private extension ShareExtensionHelper {
 
         OnePasswordExtension.shared().fillReturnedItems(returnedItems, intoWebView: selectedWebView, completion: { (success, returnedItemsError) -> Void in
             if !success {
-                log.error("Failed to fill item into webview: \(returnedItemsError).")
+                log.error("Failed to fill item into webview: \(returnedItemsError ??? "nil").")
             }
         })
     }

--- a/Client/Frontend/Widgets/AuralProgressBar.swift
+++ b/Client/Frontend/Widgets/AuralProgressBar.swift
@@ -142,7 +142,7 @@ class AuralProgressBar {
                     // TODO: consider some attack-sustain-release to make the tones sound little less "sharp" and robotic
                     var val = 0.0
                     if frame < pitchFrames {
-                        val = volume * sin(pitch*Double(frame)*2*M_PI/format.sampleRate)
+                        val = volume * sin(pitch*Double(frame)*2*Double.pi/format.sampleRate)
                     }
                     channelData?[i] = Float(val)
                     i += buffer.stride

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -196,13 +196,13 @@ class TabsButton: UIControl {
             var newFlipTransform = CATransform3DIdentity
             newFlipTransform = CATransform3DTranslate(newFlipTransform, 0, halfTitleHeight, 0)
             newFlipTransform.m34 = -1.0 / 200.0 // add some perspective
-            newFlipTransform = CATransform3DRotate(newFlipTransform, CGFloat(-M_PI_2), 1.0, 0.0, 0.0)
+            newFlipTransform = CATransform3DRotate(newFlipTransform, CGFloat(-(Double.pi / 2)), 1.0, 0.0, 0.0)
             newTabsButton.insideButton.layer.transform = newFlipTransform
             
             var oldFlipTransform = CATransform3DIdentity
             oldFlipTransform = CATransform3DTranslate(oldFlipTransform, 0, halfTitleHeight, 0)
             oldFlipTransform.m34 = -1.0 / 200.0 // add some perspective
-            oldFlipTransform = CATransform3DRotate(oldFlipTransform, CGFloat(M_PI_2), 1.0, 0.0, 0.0)
+            oldFlipTransform = CATransform3DRotate(oldFlipTransform, CGFloat(-(Double.pi / 2)), 1.0, 0.0, 0.0)
             
             let animate = {
                 newTabsButton.insideButton.layer.transform = CATransform3DIdentity

--- a/ClientTests/AuthenticatorTests.swift
+++ b/ClientTests/AuthenticatorTests.swift
@@ -73,11 +73,11 @@ class AuthenticatorTests: XCTestCase {
         super.setUp()
         self.db = BrowserDB(filename: "testsqlitelogins.db", files: MockFiles())
         self.logins = SQLiteLogins(db: self.db)
-        self.logins.removeAll().value
+        self.logins.removeAll().succeeded()
     }
 
     override func tearDown() {
-        self.logins.removeAll().value
+        self.logins.removeAll().succeeded()
     }
 
     fileprivate func mockChallengeForURL(_ url: URL, username: String, password: String) -> URLAuthenticationChallenge {
@@ -117,7 +117,7 @@ class AuthenticatorTests: XCTestCase {
 
     func testChallengeMatchesLoginEntry() {
         let login = Login.createWithHostname("https://securesite.com", username: "username", password: "password", formSubmitURL: "https://submit.me")
-        logins.addLogin(login).value
+        logins.addLogin(login).succeeded()
         let challenge = mockChallengeForURL(URL(string: "https://securesite.com")!, username: "username", password: "password")
         let result = Authenticator.findMatchingCredentialsForChallenge(challenge, fromLoginsProvider: logins).value.successValue!
         XCTAssertNotNil(result)
@@ -128,7 +128,7 @@ class AuthenticatorTests: XCTestCase {
     func testChallengeMatchesSingleMalformedLoginEntry() {
         // Since Login has been updated to not store schemeless URL, write directly to simulate a malformed URL
         let malformedLogin = MockMalformableLogin.createWithHostname("malformed.com", username: "username", password: "password", formSubmitURL: "https://submit.me")
-        logins.addLogin(malformedLogin).value
+        logins.addLogin(malformedLogin).succeeded()
 
         // Pre-condition: Check that the hostname is malformed
         let oldHostname = rawQueryForAllLogins().value.successValue![0]
@@ -148,10 +148,10 @@ class AuthenticatorTests: XCTestCase {
     func testChallengeMatchesDuplicateLoginEntries() {
         // Since Login has been updated to not store schemeless URL, write directly to simulate a malformed URL
         let malformedLogin = MockMalformableLogin.createWithHostname("malformed.com", username: "malformed_username", password: "malformed_password", formSubmitURL: "https://submit.me")
-        logins.addLogin(malformedLogin).value
+        logins.addLogin(malformedLogin).succeeded()
 
         let login = Login.createWithHostname("https://malformed.com", username: "good_username", password: "good_password", formSubmitURL: "https://submit.me")
-        logins.addLogin(login).value
+        logins.addLogin(login).succeeded()
 
         // Pre-condition: Verify that both logins were stored
         let hostnames = rawQueryForAllLogins().value.successValue!

--- a/ClientTests/PingCentreTests.swift
+++ b/ClientTests/PingCentreTests.swift
@@ -82,22 +82,3 @@ class PingCentreTests: XCTestCase {
         XCTAssertTrue(receivedNetworkRequests.count == 1)
     }
 }
-
-// Borrowed from StorageTestUtils...
-private protocol Succeedable {
-    var isSuccess: Bool { get }
-    var isFailure: Bool { get }
-}
-
-extension Maybe: Succeedable {
-}
-
-private extension Deferred where T: Succeedable {
-    func succeeded() {
-        XCTAssertTrue(self.value.isSuccess)
-    }
-
-    func failed() {
-        XCTAssertTrue(self.value.isFailure)
-    }
-}

--- a/ClientTests/SearchTests.swift
+++ b/ClientTests/SearchTests.swift
@@ -67,7 +67,7 @@ class SearchTests: XCTestCase {
         client.query("foo", callback: { response, error in
             withExtendedLifetime(client) {
                 if error != nil {
-                    XCTFail("Error: \(error?.description)")
+                    XCTFail("Error: \(error?.description ?? "nil")")
                 }
 
                 XCTAssertEqual(response![0], "foo")
@@ -83,7 +83,7 @@ class SearchTests: XCTestCase {
         client.query("foo bar", callback: { response, error in
             withExtendedLifetime(client) {
                 if error != nil {
-                    XCTFail("Error: \(error?.description)")
+                    XCTFail("Error: \(error?.description ?? "nil")")
                 }
 
                 XCTAssertEqual(response![0], "foo bar soap")

--- a/DeferredTestUtils.swift
+++ b/DeferredTestUtils.swift
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Shared
+import Deferred
+import XCTest
+
+protocol Succeedable {
+    var isSuccess: Bool { get }
+    var isFailure: Bool { get }
+}
+
+extension Maybe: Succeedable {}
+
+extension Deferred where T: Succeedable {
+    func succeeded() {
+        XCTAssertTrue(self.value.isSuccess)
+    }
+
+    func failed() {
+        XCTAssertTrue(self.value.isFailure)
+    }
+}
+

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -821,7 +821,8 @@ open class BrowserProfile: Profile {
             let loginsCollections = ["passwords"]
             let browserCollections = ["bookmarks", "history", "tabs"]
 
-            switch name ?? "<all>" {
+            let dbName = name ?? "<all>"
+            switch dbName {
             case "<all>":
                 return self.locallyResetCollections(loginsCollections + browserCollections)
             case "logins.db":
@@ -829,7 +830,7 @@ open class BrowserProfile: Profile {
             case "browser.db":
                 return self.locallyResetCollections(browserCollections)
             default:
-                log.debug("Unknown database \(name).")
+                log.debug("Unknown database \(dbName).")
                 return succeed()
             }
         }
@@ -844,7 +845,7 @@ open class BrowserProfile: Profile {
         func onDatabaseWasRecreated(notification: NSNotification) {
             log.debug("Database was recreated.")
             let name = notification.object as? String
-            log.debug("Database was \(name).")
+            log.debug("Database was \(name ?? "nil").")
 
             // We run this in the background after a few hundred milliseconds;
             // it doesn't really matter when it runs, so long as it doesn't
@@ -852,7 +853,7 @@ open class BrowserProfile: Profile {
 
             let resetDatabase = {
                 return self.handleRecreationOfDatabaseNamed(name: name) >>== {
-                    log.debug("Reset of \(name) done")
+                    log.debug("Reset of \(name ?? "nil") done")
                 }
             }
 

--- a/Push/PushClient.swift
+++ b/Push/PushClient.swift
@@ -130,7 +130,7 @@ public extension PushClient {
 /// Utilities
 extension PushClient {
     fileprivate func send(request: URLRequest) -> Deferred<Maybe<JSON>> {
-        log.info("\(request.httpMethod!) \(request.url?.absoluteString)")
+        log.info("\(request.httpMethod!) \(request.url?.absoluteString ?? "nil")")
         let deferred = Deferred<Maybe<JSON>>()
         alamofire.request(request)
             .validate(contentType: ["application/json"])

--- a/PushTests/LivePushClientTests.swift
+++ b/PushTests/LivePushClientTests.swift
@@ -22,7 +22,7 @@ class LivePushClientTests: XCTestCase {
         XCTAssert(maybeReg.isSuccess, "Registered OK - deviceID = \(deviceID)")
 
         guard let registration = maybeReg.successValue else {
-            return XCTFail("Registration failed – \(maybeReg.failureValue)")
+            return XCTFail("Registration failed – \(maybeReg.failureValue ??? "nil")")
         }
 
         let maybeVoid = client.unregister(registration).value

--- a/Shared/DeferredUtils.swift
+++ b/Shared/DeferredUtils.swift
@@ -25,7 +25,7 @@ infix operator >>> : MonadicDoPrecedence
 }
 
 // A termination case.
-@discardableResult public func >>== <T>(x: Deferred<Maybe<T>>, f: @escaping (T) -> Void) {
+public func >>== <T>(x: Deferred<Maybe<T>>, f: @escaping (T) -> Void) {
     return x.upon { result in
         if let v = result.successValue {
             f(v)
@@ -44,7 +44,7 @@ infix operator >>> : MonadicDoPrecedence
 }
 
 // Another termination case.
-@discardableResult public func >>> <T>(x: Deferred<Maybe<T>>, f: @escaping () -> Void) {
+public func >>> <T>(x: Deferred<Maybe<T>>, f: @escaping () -> Void) {
     return x.upon { res in
         if res.isSuccess {
             f()

--- a/Shared/Extensions/OptionalExtensions.swift
+++ b/Shared/Extensions/OptionalExtensions.swift
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+/* A smarter ?? operator which allows the left hand/right hand arguments to not be
+ * the same type. This is useful where we want to print the string representation
+ * of an optional value that is not a string but want to return a string value when
+ * a value is absent.
+ *
+ * For more informatin, check out Oleb's post:
+ * https://oleb.net/blog/2016/12/optionals-string-interpolation/ */
+
+infix operator ???: NilCoalescingPrecedence
+public func ???<T>(optional: T?, defaultValue: @autoclosure () -> String) -> String {
+    return optional.map { String(describing: $0) } ?? defaultValue()
+}

--- a/Shared/Extensions/StringExtensions.swift
+++ b/Shared/Extensions/StringExtensions.swift
@@ -37,9 +37,10 @@ public extension String {
     }
 
     func unescape() -> String {
-        let raw: NSString = self as NSString
-        let str = CFURLCreateStringByReplacingPercentEscapes(kCFAllocatorDefault, raw, "[]." as CFString!)
-        return str as! String
+        return CFURLCreateStringByReplacingPercentEscapes(
+            kCFAllocatorDefault,
+            self as CFString,
+            "[]." as CFString) as String
     }
 
     /**

--- a/SharedTests/AsyncReducerTests.swift
+++ b/SharedTests/AsyncReducerTests.swift
@@ -65,7 +65,7 @@ class AsyncReducerTests: XCTestCase {
 
         delay(0.1) {
             do {
-                try reducer.append(6, 7, 8)
+                let _ = try reducer.append(6, 7, 8)
                 XCTFail("Can't append to a reducer that's already finished")
             } catch let error {
                 XCTAssert(true, "Properly received error on finished reducer \(error)")
@@ -86,7 +86,7 @@ class AsyncReducerTests: XCTestCase {
 
             // Pretend that some new work arrived while we were handling this.
             if let nextUp = addDuring.popLast() {
-                try! reducer.append(nextUp)
+                let _ = try! reducer.append(nextUp)
             }
 
             return deferMaybe(out)
@@ -94,7 +94,7 @@ class AsyncReducerTests: XCTestCase {
 
         // Start with 'foo'.
         reducer = AsyncReducer(initialValue: deferMaybe([:]), combine: combine)
-        try! reducer.append("foo")
+        let _ = try! reducer.append("foo")
 
         // Wait for the result. We should have handled all three by the time this returns.
         let result = reducer.terminal.value
@@ -134,7 +134,7 @@ extension AsyncReducerTests {
 
     func append(_ reducer: AsyncReducer<Int, Int>, items: Int...) {
         do {
-            try reducer.append(items)
+            let _ = try reducer.append(items)
         } catch let error {
             XCTFail("Append failed with \(error)")
         }

--- a/SharedTests/DeferredTests.swift
+++ b/SharedTests/DeferredTests.swift
@@ -20,7 +20,7 @@ class DeferredTests: XCTestCase {
 
         d.fill(5)
         waitForExpectations(timeout: 10) { (error) in
-            XCTAssertNil(error, "\(error)")
+            XCTAssertNil(error, "\(error.debugDescription)")
         }
 
         XCTAssertEqual(5, d.peek()!, "Value is filled.")

--- a/SharedTests/RollingFileLoggerTests.swift
+++ b/SharedTests/RollingFileLoggerTests.swift
@@ -55,7 +55,7 @@ class RollingFileLoggerTests: XCTestCase {
         XCTAssertGreaterThan(directorySize, Int64(sizeLimit), "Log folder should be larger than size limit")
 
         let exceedsSmaller = try! manager.allocatedSizeOfDirectoryAtURL(dirURL, forFilesPrefixedWith: prefix, isLargerThanBytes: directorySize - 1)
-        let doesNotExceedLarger = try! manager.allocatedSizeOfDirectoryAtURL(dirURL, forFilesPrefixedWith: prefix, isLargerThanBytes: sizeLimit + 2)
+        let doesNotExceedLarger = try! manager.allocatedSizeOfDirectoryAtURL(dirURL, forFilesPrefixedWith: prefix, isLargerThanBytes: Int64(sizeLimit + 2))
         XCTAssertTrue(exceedsSmaller)
         XCTAssertTrue(doesNotExceedLarger)
 

--- a/Storage/Clients.swift
+++ b/Storage/Clients.swift
@@ -65,6 +65,6 @@ public func ==(lhs: RemoteClient, rhs: RemoteClient) -> Bool {
 
 extension RemoteClient: CustomStringConvertible {
     public var description: String {
-        return "<RemoteClient GUID: \(guid), name: \(name), modified: \(modified), type: \(type), formfactor: \(formfactor), OS: \(os)>"
+        return "<RemoteClient GUID: \(guid ?? "nil"), name: \(name), modified: \(modified), type: \(type ?? "nil"), formfactor: \(formfactor ?? "nil"), OS: \(os ?? "nil")>"
     }
 }

--- a/Storage/RemoteTabs.swift
+++ b/Storage/RemoteTabs.swift
@@ -11,7 +11,7 @@ public struct ClientAndTabs: Equatable, CustomStringConvertible {
     public let tabs: [RemoteTab]
 
     public var description: String {
-        return "<Client \(client.guid), \(tabs.count) tabs.>"
+        return "<Client guid: \(client.guid ?? "nil"), \(tabs.count) tabs.>"
     }
 
     // See notes in RemoteTabsPanel.swift.
@@ -98,6 +98,6 @@ public func ==(lhs: RemoteTab, rhs: RemoteTab) -> Bool {
 
 extension RemoteTab: CustomStringConvertible {
     public var description: String {
-        return "<RemoteTab clientGUID: \(clientGUID), URL: \(URL), title: \(title), lastUsed: \(lastUsed)>"
+        return "<RemoteTab clientGUID: \(clientGUID ?? "nil"), URL: \(URL), title: \(title), lastUsed: \(lastUsed)>"
     }
 }

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -90,7 +90,7 @@ open class BrowserDB {
         self.db = SwiftData(filename: file, key: secretKey, prevKey: nil)
 
         if AppConstants.BuildChannel == .developer && secretKey != nil {
-            log.debug("Creating db: \(file) with secret = \(secretKey)")
+            log.debug("Creating db: \(file) with secret = \(secretKey!)")
         }
 
         // Create or update will also delete and create the database if our key was incorrect.

--- a/Storage/SQL/BrowserTable.swift
+++ b/Storage/SQL/BrowserTable.swift
@@ -133,7 +133,7 @@ open class BrowserTable: Table {
     func run(_ db: SQLiteDBConnection, sql: String, args: Args? = nil) -> Bool {
         let err = db.executeChange(sql, withArgs: args)
         if err != nil {
-            log.error("Error running SQL in BrowserTable. \(err?.localizedDescription)")
+            log.error("Error running SQL in BrowserTable: \(err?.localizedDescription ?? "nil")")
             log.error("SQL was \(sql)")
         }
         return err == nil

--- a/Storage/SQL/GenericTable.swift
+++ b/Storage/SQL/GenericTable.swift
@@ -146,7 +146,7 @@ class GenericTable<T>: BaseTable {
         let args =  Args()
         let err = db.executeChange(sqlStr, withArgs: args)
         if err != nil {
-            log.error("Error dropping \(self.name): \(err)")
+            log.error("Error dropping \(self.name): \(err.debugDescription)")
         }
         return err == nil
     }
@@ -219,6 +219,6 @@ class GenericTable<T>: BaseTable {
                 return c
             }
         }
-        return Cursor(status: CursorStatus.failure, msg: "Invalid query: \(options?.filter)")
+        return Cursor(status: CursorStatus.failure, msg: "Invalid query: \(options?.filter ?? "nil")")
     }
 }

--- a/Storage/SQL/SQLiteBookmarksSyncing.swift
+++ b/Storage/SQL/SQLiteBookmarksSyncing.swift
@@ -158,7 +158,7 @@ extension SQLiteBookmarks {
             faviconID = nil
         }
 
-        log.debug("Inserting bookmark with GUID \(newGUID) and specified icon \(faviconID).")
+        log.debug("Inserting bookmark with GUID \(newGUID) and specified icon \(faviconID ??? "nil").")
 
         // If the caller didn't provide an icon (and they usually don't!),
         // do a reverse lookup in history. We use a view to make this simple.

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -205,7 +205,7 @@ extension SQLiteHistory: BrowserHistory {
             }
             let error = conn.executeChange(update, withArgs: updateArgs)
             if error != nil {
-                log.warning("Update failed with \(error?.localizedDescription)")
+                log.warning("Update failed with error: \(error?.localizedDescription ?? "nil")")
                 return 0
             }
             return conn.numberOfRowsModified

--- a/Storage/SQL/SQLiteLogins.swift
+++ b/Storage/SQL/SQLiteLogins.swift
@@ -28,7 +28,7 @@ private class LoginsTable: Table {
     func run(_ db: SQLiteDBConnection, sql: String, args: Args? = nil) -> Bool {
         let err = db.executeChange(sql, withArgs: args)
         if err != nil {
-            log.error("Error running SQL in LoginsTable. \(err?.localizedDescription)")
+            log.error("Error running SQL in LoginsTable: \(err?.localizedDescription ?? "nil")")
             log.error("SQL was \(sql)")
         }
         return err == nil
@@ -305,7 +305,7 @@ open class SQLiteLogins: BrowserLogins {
         }
 
         if Logger.logPII {
-            log.debug("Looking for login: \(username), \(args[0])")
+            log.debug("Looking for login with username: \(username ?? "nil"), first arg: \(args[0] ?? "nil")")
         }
 
         let sql =

--- a/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
+++ b/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
@@ -180,10 +180,10 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
             clientArgs = nil
         }
 
-        log.debug("Looking for tabs for client with guid: \(guid)")
+        log.debug("Looking for tabs for client with guid: \(guid ?? "nil")")
         return db.runQuery(tabsSQL, args: clientArgs, factory: tabs.factory!) >>== {
             let tabs = $0.asArray()
-            log.debug("Found \(tabs.count) tabs for client with guid: \(guid)")
+            log.debug("Found \(tabs.count) tabs for client with guid: \(guid ?? "nil")")
             return deferMaybe(tabs)
         }
     }
@@ -229,7 +229,7 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
                     acc[guid]!.append(tab)
                 }
             } else {
-                log.error("Couldn't cast tab \(tab) to RemoteTab.")
+                log.error("Couldn't cast tab (\(tab ??? "nil")) to RemoteTab.")
             }
         }
 

--- a/Storage/Storage-Bridging-Header.h
+++ b/Storage/Storage-Bridging-Header.h
@@ -3,6 +3,7 @@
 
 #define SQLITE_HAS_CODEC 1
 
+#import "Shared-Bridging-Header.h"
 #import <Foundation/Foundation.h>
 #import "ThirdParty/sqlcipher/sqlite3.h"
 

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -396,7 +396,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
     fileprivate func pragma<T: Equatable>(_ pragma: String, expected: T?, factory: @escaping (SDRow) -> T, message: String) throws {
         let cursorResult = self.pragma(pragma, factory: factory)
         if cursorResult != expected {
-            log.error("\(message): \(cursorResult), \(expected)")
+            log.error("\(message): \(cursorResult.debugDescription), \(expected.debugDescription)")
             throw NSError(domain: "mozilla", code: 0, userInfo: [NSLocalizedDescriptionKey: "PRAGMA didn't return expected output: \(message)."])
         }
     }
@@ -463,7 +463,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             try pragma("page_size=\(desiredPageSize)", expected: nil,
                        factory: IntFactory, message: "Page size set")
 
-            log.info("Vacuuming to alter database page size from \(currentPageSize) to \(desiredPageSize).")
+            log.info("Vacuuming to alter database page size from \(currentPageSize ?? 0) to \(desiredPageSize).")
             if let err = self.vacuum() {
                 log.error("Vacuuming failed: \(err).")
             } else {

--- a/StoragePerfTests/StoragePerfTests.swift
+++ b/StoragePerfTests/StoragePerfTests.swift
@@ -42,12 +42,12 @@ class TestSQLiteHistoryFrecencyPerf: XCTestCase {
 
         let count = 500
 
-        history.clearHistory().value
+        history.clearHistory().succeeded()
         populateHistoryForFrecencyCalculations(history, siteCount: count)
 
         self.measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true) {
             for _ in 0...5 {
-                history.getSitesByFrecencyWithHistoryLimit(10, includeIcon: false).value
+                history.getSitesByFrecencyWithHistoryLimit(10, includeIcon: false).succeeded()
             }
             self.stopMeasuring()
         }
@@ -64,12 +64,12 @@ class TestSQLiteHistoryTopSitesCachePref: XCTestCase {
 
         let count = 500
 
-        history.clearHistory().value
+        history.clearHistory().succeeded()
         populateHistoryForFrecencyCalculations(history, siteCount: count)
 
         history.setTopSitesNeedsInvalidation()
         self.measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true) {
-            history.updateTopSitesCacheIfInvalidated().value
+            history.updateTopSitesCacheIfInvalidated().succeeded()
             self.stopMeasuring()
         }
     }
@@ -88,7 +88,7 @@ private func populateHistoryForFrecencyCalculations(_ history: SQLiteHistory, si
         site.guid = "abc\(i)def"
 
         let baseMillis: UInt64 = baseInstantInMillis - 20000
-        history.insertOrUpdatePlace(site.asPlace(), modified: baseMillis).value
+        history.insertOrUpdatePlace(site.asPlace(), modified: baseMillis).succeeded()
 
         for j in 0...20 {
             let visitTime = advanceMicrosecondTimestamp(baseInstantInMicros, by: (1000000 * i) + (1000 * j))
@@ -102,8 +102,8 @@ private func addVisitForSite(_ site: Site, intoHistory history: SQLiteHistory, f
     let visit = SiteVisit(site: site, date: atTime, type: VisitType.link)
     switch from {
     case .local:
-        history.addLocalVisit(visit).value
+        history.addLocalVisit(visit).succeeded()
     case .remote:
-        history.storeRemoteVisits([visit], forGUID: site.guid!).value
+        history.storeRemoteVisits([visit], forGUID: site.guid!).succeeded()
     }
 }

--- a/StorageTests/StorageTestUtils.swift
+++ b/StorageTests/StorageTestUtils.swift
@@ -10,26 +10,6 @@ import Shared
 @testable import Storage
 import XCTest
 
-// MARK: - The messy way to extend non-protocol generics.
-
-protocol Succeedable {
-    var isSuccess: Bool { get }
-    var isFailure: Bool { get }
-}
-
-extension Maybe: Succeedable {
-}
-
-extension Deferred where T: Succeedable {
-    func succeeded() {
-        XCTAssertTrue(self.value.isSuccess)
-    }
-
-    func failed() {
-        XCTAssertTrue(self.value.isFailure)
-    }
-}
-
 extension BrowserDB {
     func assertQueryReturns(_ query: String, int: Int) {
         XCTAssertEqual(int, self.runQuery(query, args: nil, factory: IntFactory).value.successValue![0])

--- a/StorageTests/SyncCommandsTests.swift
+++ b/StorageTests/SyncCommandsTests.swift
@@ -47,7 +47,7 @@ class SyncCommandsTests: XCTestCase {
         self.clients.append(RemoteClient(guid: client2GUID, name: "Test client 2", modified: (now - OneHourInMilliseconds), type: "desktop", formfactor: "laptop", os: "Darwin"))
         self.clients.append(RemoteClient(guid: client3GUID, name: "Test local client", modified: (now - OneMinuteInMilliseconds), type: "mobile", formfactor: "largetablet", os: "iOS"))
         clientsAndTabs = SQLiteRemoteClientsAndTabs(db: db)
-        clientsAndTabs.insertOrUpdateClients(clients)
+        clientsAndTabs.insertOrUpdateClients(clients).succeeded()
 
         shareItems.append(ShareItem(url: "http://mozilla.com", title: "Mozilla", favicon: nil))
         shareItems.append(ShareItem(url: "http://slashdot.org", title: "Slashdot", favicon: nil))
@@ -58,8 +58,8 @@ class SyncCommandsTests: XCTestCase {
     }
 
     override func tearDown() {
-        clientsAndTabs.deleteCommands()
-        clientsAndTabs.clear()
+        clientsAndTabs.deleteCommands().succeeded()
+        clientsAndTabs.clear().succeeded()
     }
 
     func testCreateSyncCommandFromShareItem() {
@@ -142,7 +142,7 @@ class SyncCommandsTests: XCTestCase {
         let syncCommands = shareItems.map { item in
             return SyncCommand.displayURIFromShareItem(item, asClient: "abcdefghijkl")
         }.sorted(by: byValue)
-        clientsAndTabs.insertCommands(syncCommands, forClients: clients)
+        clientsAndTabs.insertCommands(syncCommands, forClients: clients).succeeded()
 
         let b = self.expectation(description: "Get for invalid client.")
         clientsAndTabs.getCommands().upon({ result in

--- a/StorageTests/TestBrowserDB.swift
+++ b/StorageTests/TestBrowserDB.swift
@@ -61,7 +61,7 @@ class TestBrowserDB: XCTestCase {
         db.attachDB(filename: "metadata.db", as: AttachedDatabaseMetadata)
         XCTAssertTrue(db.createOrUpdate(BrowserTable()) == .success)
 
-        db.run("CREATE TABLE foo (bar TEXT)").value      // Just so we have writes in the WAL.
+        db.run("CREATE TABLE foo (bar TEXT)").succeeded() // Just so we have writes in the WAL.
 
         XCTAssertTrue(files.exists("foo.db"))
         XCTAssertTrue(files.exists("foo.db-shm"))
@@ -85,7 +85,7 @@ class TestBrowserDB: XCTestCase {
         // Our current observation is that closing the DB deletes the .shm file and also
         // checkpoints the WAL.
         XCTAssertFalse(db.createOrUpdate(MockFailingTable()) == .success)
-        db.run("CREATE TABLE foo (bar TEXT)").value      // Just so we have writes in the WAL.
+        db.run("CREATE TABLE foo (bar TEXT)").succeeded() // Just so we have writes in the WAL.
 
         XCTAssertTrue(files.exists("foo.db"))
         XCTAssertTrue(files.exists("foo.db-shm"))

--- a/StorageTests/TestDeferredSqlite.swift
+++ b/StorageTests/TestDeferredSqlite.swift
@@ -25,7 +25,7 @@ class TestDeferredSqlite: XCTestCase {
         })
 
         deferred.cancel()
-        deferred.start()
+        let _ = deferred.start()
 
         waitForExpectations(timeout: 10, handler: nil)
     }

--- a/StorageTests/TestFaviconsTable.swift
+++ b/StorageTests/TestFaviconsTable.swift
@@ -10,11 +10,12 @@ import XCTest
 class TestFaviconsTable: XCTestCase {
     var db: BrowserDB!
 
+    @discardableResult
     fileprivate func addIcon(_ favicons: FaviconsTable<Favicon>, url: String, s: Bool = true) -> Favicon {
         var inserted: Int? = -1
         var icon: Favicon!
         var err: NSError?
-        self.db.withConnection(flags: SwiftData.Flags.readWrite, err: &err) { (connection, err) -> Int? in
+        let _ = self.db.withConnection(flags: SwiftData.Flags.readWrite, err: &err) { (connection, err) -> Int? in
             XCTAssertNil(err)
             icon = Favicon(url: url, type: IconType.icon)
             var error: NSError? = nil
@@ -32,7 +33,7 @@ class TestFaviconsTable: XCTestCase {
 
     fileprivate func checkIcons(_ favicons: FaviconsTable<Favicon>, options: QueryOptions?, urls: [String], s: Bool = true) {
         var err: NSError?
-        self.db.withConnection(flags: SwiftData.Flags.readOnly, err: &err) { (connection, err) -> Bool in
+        let _ = self.db.withConnection(flags: SwiftData.Flags.readOnly, err: &err) { (connection, err) -> Bool in
             XCTAssertNil(err)
             let cursor = favicons.query(connection, options: options)
             XCTAssertEqual(cursor.status, CursorStatus.success, "returned success \(cursor.statusMessage)")
@@ -54,7 +55,7 @@ class TestFaviconsTable: XCTestCase {
     fileprivate func clear(_ favicons: FaviconsTable<Favicon>, icon: Favicon? = nil, s: Bool = true) {
         var deleted = -1
         var err: NSError?
-        self.db.withConnection(flags: SwiftData.Flags.readWriteCreate, err: &err) { (db, err) -> Int in
+        let _ = self.db.withConnection(flags: SwiftData.Flags.readWriteCreate, err: &err) { (db, err) -> Int in
             deleted = favicons.delete(db, item: icon, err: &err)
             return deleted
         }
@@ -75,7 +76,7 @@ class TestFaviconsTable: XCTestCase {
         let f = FaviconsTable<Favicon>()
 
         var err: NSError?
-        self.db.withConnection(flags: SwiftData.Flags.readWriteCreate, err: &err) { (db, err) -> Bool in
+        let _ = self.db.withConnection(flags: SwiftData.Flags.readWriteCreate, err: &err) { (db, err) -> Bool in
             let result = f.create(db)
             XCTAssertTrue(result)
             return result

--- a/StorageTests/TestLogins.swift
+++ b/StorageTests/TestLogins.swift
@@ -73,16 +73,16 @@ class TestSQLiteLogins: XCTestCase {
         let loginD = Login.createWithHostname("candle.com", username: "username4", password: "password4", formSubmitURL: formSubmitURL)
 
         func addLogins() -> Success {
-            addLogin(loginA).value
-            addLogin(loginB).value
-            addLogin(loginC).value
-            addLogin(loginD).value
+            addLogin(loginA).succeeded()
+            addLogin(loginB).succeeded()
+            addLogin(loginC).succeeded()
+            addLogin(loginD).succeeded()
             return succeed()
         }
 
-        addLogins().value
+        addLogins().succeeded()
         let guids = [loginA.guid, loginB.guid]
-        logins.removeLoginsWithGUIDs(guids).value
+        logins.removeLoginsWithGUIDs(guids).succeeded()
         let result = logins.getAllLogins().value.successValue!
         XCTAssertEqual(result.count, 2)
     }
@@ -95,9 +95,9 @@ class TestSQLiteLogins: XCTestCase {
             if i <= 1000 {
                 guids += [login.guid]
             }
-            addLogin(login).value
+            addLogin(login).succeeded()
         }
-        logins.removeLoginsWithGUIDs(guids).value
+        logins.removeLoginsWithGUIDs(guids).succeeded()
         let result = logins.getAllLogins().value.successValue!
         XCTAssertEqual(result.count, 999)
     }
@@ -147,7 +147,7 @@ class TestSQLiteLogins: XCTestCase {
         let updated = Login.createWithHostname("hostname1", username: "username1", password: "", formSubmitURL: formSubmitURL)
         updated.guid = self.login.guid
 
-        addLogin(login).value
+        addLogin(login).succeeded()
         var result = logins.updateLoginByGUID(login.guid, new: updated, significant: true).value
         XCTAssertNil(result.successValue)
         XCTAssertNotNil(result.failureValue)
@@ -185,10 +185,10 @@ class TestSQLiteLogins: XCTestCase {
         let loginD = Login.createWithHostname("candle.com", username: "username4", password: "password4", formSubmitURL: formSubmitURL)
 
         func addLogins() -> Success {
-            addLogin(loginA).value
-            addLogin(loginB).value
-            addLogin(loginC).value
-            addLogin(loginD).value
+            addLogin(loginA).succeeded()
+            addLogin(loginB).succeeded()
+            addLogin(loginC).succeeded()
+            addLogin(loginD).succeeded()
             return succeed()
         }
 
@@ -348,7 +348,7 @@ class TestSQLiteLoginsPerf: XCTestCase {
         // Measure time to find one entry amongst the 1000 of them
         self.measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true) {
             for _ in 0...5 {
-                self.logins.searchLoginsWithQuery("username500").value
+                self.logins.searchLoginsWithQuery("username500").succeeded()
             }
             self.stopMeasuring()
         }
@@ -362,7 +362,7 @@ class TestSQLiteLoginsPerf: XCTestCase {
         // Measure time to find all matching results
         self.measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true) {
             for _ in 0...5 {
-                self.logins.searchLoginsWithQuery("username").value
+                self.logins.searchLoginsWithQuery("username").succeeded()
             }
             self.stopMeasuring()
         }
@@ -376,7 +376,7 @@ class TestSQLiteLoginsPerf: XCTestCase {
         // Measure time to find all matching results
         self.measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true) {
             for _ in 0...5 {
-                self.logins.getAllLogins().value
+                self.logins.getAllLogins().succeeded()
             }
             self.stopMeasuring()
         }
@@ -387,7 +387,7 @@ class TestSQLiteLoginsPerf: XCTestCase {
     func populateTestLogins() {
         for i in 0..<1000 {
             let login = Login.createWithHostname("website\(i).com", username: "username\(i)", password: "password\(i)")
-            addLogin(login).value
+            addLogin(login).succeeded()
         }
     }
 
@@ -733,9 +733,9 @@ class TestSyncableLogins: XCTestCase {
         let serverLoginA = ServerLogin(guid: loginA.guid, hostname: "alpha.com", username: "username1", password: "password1", modified: Date.now())
 
         XCTAssertFalse(logins.hasSyncedLogins().value.successValue ?? true)
-        logins.addLogin(loginA).value
+        let _ = logins.addLogin(loginA).value
         XCTAssertFalse(logins.hasSyncedLogins().value.successValue ?? false)
-        logins.applyChangedLogin(serverLoginA).value
+        let _ = logins.applyChangedLogin(serverLoginA).value
         XCTAssertTrue(logins.hasSyncedLogins().value.successValue ?? false)
     }
 }

--- a/StorageTests/TestSQLiteHistoryRecommendations.swift
+++ b/StorageTests/TestSQLiteHistoryRecommendations.swift
@@ -295,11 +295,11 @@ class TestSQLiteHistoryRecommendationsPerf: XCTestCase {
 
         let count = 500
 
-        history.clearHistory().value
+        history.clearHistory().succeeded()
         populateForRecommendationCalculations(history, bookmarks: bookmarks, historyCount: count, bookmarkCount: count)
         self.measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true) {
             for _ in 0...5 {
-                history.getHighlights().value
+                history.getHighlights().succeeded()
             }
             self.stopMeasuring()
         }
@@ -313,7 +313,7 @@ private func populateForRecommendationCalculations(_ history: SQLiteHistory, boo
         let site = Site(url: "http://s\(i)ite\(i)/foo", title: "A \(i)")
         site.guid = "abc\(i)def"
 
-        history.insertOrUpdatePlace(site.asPlace(), modified: baseMillis).value
+        history.insertOrUpdatePlace(site.asPlace(), modified: baseMillis).succeeded()
 
         for j in 0...20 {
             let visitTime = advanceMicrosecondTimestamp(baseInstantInMicros, by: (1000000 * i) + (1000 * j))

--- a/StorageTests/TestSQLiteRemoteClientsAndTabs.swift
+++ b/StorageTests/TestSQLiteRemoteClientsAndTabs.swift
@@ -136,7 +136,7 @@ class SQLRemoteClientsAndTabsTests: XCTestCase {
                 XCTAssertTrue($0.isSuccess)
                 e.fulfill()
             }
-            clientsAndTabs.insertOrUpdateTabsForClientGUID(c.client.guid, tabs: c.tabs)
+            clientsAndTabs.insertOrUpdateTabsForClientGUID(c.client.guid, tabs: c.tabs).succeeded()
         }
 
         let f = self.expectation(description: "Get after insert.")
@@ -163,7 +163,7 @@ class SQLRemoteClientsAndTabsTests: XCTestCase {
         ].sorted(by: byGUID)
 
         func doUpdate(_ guid: String?, tabs: [RemoteTab]) {
-            let g0 = self.expectation(description: "Update client \(guid).")
+            let g0 = self.expectation(description: "Update client: \(guid ?? "nil").")
             clientsAndTabs.insertOrUpdateTabsForClientGUID(guid, tabs: tabs).upon {
                 if let rowID = $0.successValue {
                     XCTAssertTrue(rowID > -1)
@@ -216,7 +216,7 @@ class SQLRemoteClientsAndTabsTests: XCTestCase {
                 XCTAssertTrue($0.isSuccess)
                 e.fulfill()
             }
-            clientsAndTabs.insertOrUpdateTabsForClientGUID(c.client.guid, tabs: c.tabs)
+            clientsAndTabs.insertOrUpdateTabsForClientGUID(c.client.guid, tabs: c.tabs).succeeded()
         }
 
         let e = self.expectation(description: "Get after insert.")

--- a/StorageTests/TestSwiftData.swift
+++ b/StorageTests/TestSwiftData.swift
@@ -28,10 +28,10 @@ class TestSwiftData: XCTestCase {
         XCTAssert(SwiftData.ReuseConnections, "Reusing database connections")
         XCTAssert(SwiftData.EnableWAL, "WAL enabled")
 
-        swiftData!.withConnection(SwiftData.Flags.readWriteCreate) { db in
+        let _ = swiftData!.withConnection(SwiftData.Flags.readWriteCreate) { db in
             let f = FaviconsTable<Favicon>()
-            f.create(db)    // Because BrowserTable needs it.
-            table.create(db)
+            let _ = f.create(db)    // Because BrowserTable needs it.
+            let _ = table.create(db)
             return nil
         }
 
@@ -105,7 +105,7 @@ class TestSwiftData: XCTestCase {
 
         // If we have a live cursor, this will step to the first result.
         // Stepping through a prepared statement without resetting it will lock the connection.
-        c[0]
+        let _ = c[0]
 
         // Close the cursor after a delay if there's a close timeout set.
         if let closeTimeout = closeTimeout {
@@ -194,7 +194,7 @@ class TestSwiftData: XCTestCase {
         // Test that generator doesn't work with failed cursors
         var ran = false
         for s in t2 {
-            print("Got \(s)", terminator: "\n")
+            print("Got \(s ?? "nil")", terminator: "\n")
             ran = true
         }
         XCTAssertFalse(ran, "for...in didn't run for failed cursor")

--- a/StorageTests/TestTableTable.swift
+++ b/StorageTests/TestTableTable.swift
@@ -16,7 +16,7 @@ class TestSchemaTable: XCTestCase {
 
         // Test creating a table
         var testTable = getCreateTable()
-        db.createOrUpdate(testTable)
+        XCTAssertTrue(db.createOrUpdate(testTable) == .success)
 
         // Now make sure the item is in the table-table
         var err: NSError? = nil
@@ -32,7 +32,7 @@ class TestSchemaTable: XCTestCase {
 
         // Now test updating the table
         testTable = getUpgradeTable()
-        db.createOrUpdate(testTable)
+        XCTAssertTrue(db.createOrUpdate(testTable) == .success)
         cursor = db.withConnection(&err) { (connection, err) -> Cursor<TableInfo> in
             return table.query(connection, options: QueryOptions(filter: testTable.name))
         }
@@ -43,7 +43,7 @@ class TestSchemaTable: XCTestCase {
 
         // Now try updating it again to the same version. This shouldn't call create or upgrade
         testTable = getNoOpTable()
-        db.createOrUpdate(testTable)
+        XCTAssertTrue(db.createOrUpdate(testTable) == .success)
 
         do {
             // Cleanup
@@ -100,7 +100,7 @@ class TestSchemaTable: XCTestCase {
 
         func create(_ db: SQLiteDBConnection) -> Bool {
             // BrowserDB uses a different query to determine if a table exists, so we need to ensure it actually happens
-            db.executeChange("CREATE TABLE IF NOT EXISTS \(name) (ID INTEGER PRIMARY KEY AUTOINCREMENT)")
+            let _ = db.executeChange("CREATE TABLE IF NOT EXISTS \(name) (ID INTEGER PRIMARY KEY AUTOINCREMENT)")
             return createCallback()
         }
 

--- a/Sync/Record.swift
+++ b/Sync/Record.swift
@@ -56,7 +56,7 @@ open class Record<T: CleartextPayloadJSON> {
         }
 
         if !payload.isValid() {
-            log.warning("Invalid payload \(payload.json.stringValue()).")
+            log.warning("Invalid payload \(payload.json.stringValue() ?? "nil").")
         }
 
         return Record<T>(envelope: envelope, payload: payload)

--- a/Sync/StorageClient.swift
+++ b/Sync/StorageClient.swift
@@ -340,7 +340,7 @@ open class Sync15StorageClient {
 
     func errorWrap<T, U>(_ deferred: Deferred<Maybe<T>>, handler: @escaping (DataResponse<U>) -> Void) -> (DataResponse<U>) -> Void {
         return { response in
-            log.verbose("Response is \(response.response).")
+            log.verbose("Response is \(response.response ??? "nil").")
 
             /**
              * Returns true if handled.
@@ -386,7 +386,7 @@ open class Sync15StorageClient {
 
             // Check for an error from the request processor.
             if response.result.isFailure {
-                log.error("Response: \(response.response?.statusCode ?? 0). Got error \(response.result.error).")
+                log.error("Response: \(response.response?.statusCode ?? 0). Got error \(response.result.error ??? "nil").")
 
                 // If we got one, we don't want to hit the response nil case above and
                 // return a RecordParseError, because a RequestError is more fitting.
@@ -754,7 +754,7 @@ open class Sync15CollectionClient<T: CleartextPayloadJSON> {
             params.append(URLQueryItem(name: "sort", value: sort.rawValue))
         }
 
-        log.debug("Issuing GET with newer = \(since), offset = \(offset), sort = \(sort).")
+        log.debug("Issuing GET with newer = \(since), offset = \(offset ??? "nil"), sort = \(sort ??? "nil").")
         let req = client.requestGET(self.collectionURI.withQueryParams(params))
 
         let _ = req.responsePartialParsedJSON(queue: collectionQueue, completionHandler: self.client.errorWrap(deferred) { (response: DataResponse<JSON>) in

--- a/Sync/Sync-Bridging-Header.h
+++ b/Sync/Sync-Bridging-Header.h
@@ -2,5 +2,7 @@
 #define Client_Sync_Bridging_Header_h
 
 #import <Foundation/Foundation.h>
+#import "Shared-Bridging-Header.h"
+#import "Storage-Bridging-Header.h"
 
 #endif

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -643,7 +643,7 @@ private func processFailure(_ failure: MaybeErrorType?) -> MaybeErrorType {
         return failure
     }
 
-    log.error("Unexpected failure. \(failure?.description)")
+    log.error("Unexpected failure. \(failure?.description ?? "nil")")
     return failure ?? UnknownError()
 }
 

--- a/Sync/Synchronizers/Bookmarks/BookmarksSynchronizer.swift
+++ b/Sync/Synchronizers/Bookmarks/BookmarksSynchronizer.swift
@@ -64,7 +64,7 @@ class TrivialBookmarkStorer: BookmarkStorer {
                 failed[guid] = message
             }
 
-            log.debug("Uploaded records got timestamp \(lastModified).")
+            log.debug("Uploaded records got timestamp \(lastModified ??? "nil").")
             let modified = lastModified ?? 0
             local.setModifiedTime(modified, guids: result.success)
             return deferMaybe(modified)

--- a/Sync/Synchronizers/Bookmarks/BookmarksSynchronizer.swift
+++ b/Sync/Synchronizers/Bookmarks/BookmarksSynchronizer.swift
@@ -52,7 +52,7 @@ class TrivialBookmarkStorer: BookmarkStorer {
             try accumulateFromAmendMap(op.amendChildrenFromMirror, fetch: { itemSources.mirror.getMirrorItemsWithGUIDs($0.keys).value })
             try accumulateFromAmendMap(op.amendChildrenFromLocal, fetch: { itemSources.local.getLocalItemsWithGUIDs($0.keys).value })
         } catch {
-            return deferMaybe(error as! MaybeErrorType)
+            return deferMaybe(error as MaybeErrorType)
         }
 
         var success: [GUID] = []

--- a/Sync/Synchronizers/Bookmarks/Merging.swift
+++ b/Sync/Synchronizers/Bookmarks/Merging.swift
@@ -80,7 +80,7 @@ open class BookmarksMergeError: MaybeErrorType {
     }
 
     open var description: String {
-        return "Merge error: \(self.error)"
+        return "Merge error: \(self.error ??? "nil")"
     }
 }
 

--- a/Sync/Synchronizers/Bookmarks/ThreeWayTreeMerger.swift
+++ b/Sync/Synchronizers/Bookmarks/ThreeWayTreeMerger.swift
@@ -441,7 +441,7 @@ class ThreeWayTreeMerger {
                         if localParentGUID != result.guid {
                             log.debug("Local child \(guid) is in folder \(localParentGUID), but remotely is in \(result.guid).")
                             if mirrorParentGUID != localParentGUID {
-                                log.debug("… and locally it has changed since our last sync, moving from \(mirrorParentGUID) to \(localParentGUID).")
+                                log.debug("… and locally it has changed since our last sync, moving from \(mirrorParentGUID ?? "nil") to \(localParentGUID).")
 
                                 // Find out which parent is most recent.
                                 if let localRecords = self.itemSources.local.getLocalItemsWithGUIDs([localParentGUID, guid]).value.successValue,
@@ -459,7 +459,7 @@ class ThreeWayTreeMerger {
                                     log.debug("Taking remote, because it's later. Merging now.")
                                 }
                             } else {
-                                log.debug("\(guid) didn't move from \(mirrorParentGUID) since our last sync. Taking remote parent.")
+                                log.debug("\(guid) didn't move from \(mirrorParentGUID ?? "nil") since our last sync. Taking remote parent.")
                             }
                         } else {
                             log.debug("\(guid) is locally in \(localParentGUID) and remotely in \(result.guid). Easy.")
@@ -605,7 +605,7 @@ class ThreeWayTreeMerger {
                     return MergeState.remote
                 }
 
-                log.debug("Comparing local (\(local.localModified)) to remote (\(remote.serverModified)) clock for two-way value merge of \(guid).")
+                log.debug("Comparing local (\(local.localModified ??? "nil")) to remote (\(remote.serverModified)) clock for two-way value merge of \(guid).")
                 if local.localModified! > remote.serverModified {
                     return MergeState.local
                 }

--- a/Sync/Synchronizers/Downloader.swift
+++ b/Sync/Synchronizers/Downloader.swift
@@ -53,7 +53,7 @@ class BatchingDownloader<T: CleartextPayloadJSON> {
 
         let lm = prefs.timestampForKey("lastModified")
         let bt = prefs.timestampForKey("baseTimestamp")
-        log.debug("Resetting downloader prefs \(prefs.getBranchPrefix()). Previous values: \(lm), \(bt).")
+        log.debug("Resetting downloader prefs \(prefs.getBranchPrefix()). Previous values: \(lm ??? "nil"), \(bt ??? "nil").")
 
         prefs.removeObjectForKey("nextOffset")
         prefs.removeObjectForKey("offsetNewer")
@@ -154,7 +154,7 @@ class BatchingDownloader<T: CleartextPayloadJSON> {
 
     func downloadNextBatchWithLimit(_ limit: Int, infoModified: Timestamp) -> Deferred<Maybe<DownloadEndState>> {
         let (offset, since) = self.fetchParameters()
-        log.debug("Fetching newer=\(since), offset=\(offset).")
+        log.debug("Fetching newer=\(since), offset=\(offset ?? "nil").")
 
         let fetch = self.client.getSince(since, sort: SortOption.OldestFirst, limit: limit, offset: offset)
 
@@ -201,7 +201,7 @@ class BatchingDownloader<T: CleartextPayloadJSON> {
                     // value, we'll simply redownload some records.
                     // All bets are off if we hit this case and are filtering somehow… don't do that.
                     let lm = response.metadata.lastModifiedMilliseconds
-                    log.debug("Advancing lastModified to \(lm) ?? \(infoModified).")
+                    log.debug("Advancing lastModified to \(String(describing: lm)) ?? \(infoModified).")
                     self.lastModified = lm ?? infoModified
                 }
             }

--- a/Sync/Synchronizers/LoginsSynchronizer.swift
+++ b/Sync/Synchronizers/LoginsSynchronizer.swift
@@ -172,7 +172,7 @@ open class LoginsSynchronizer: IndependentRecordSynchronizer, Synchronizer {
             let ts = response.metadata.timestampMilliseconds
             let lm = response.metadata.lastModifiedMilliseconds!
             log.debug("Applying incoming password records from response timestamped \(ts), last modified \(lm).")
-            log.debug("Records header hint: \(response.metadata.records)")
+            log.debug("Records header hint: \(response.metadata.records ??? "nil")")
             return self.applyIncomingToStorage(logins, records: response.value, fetched: lm) >>> effect {
                 NotificationCenter.default.post(name: NotificationDataRemoteLoginChangesWereApplied, object: nil)
             }

--- a/Sync/Synchronizers/TabsSynchronizer.swift
+++ b/Sync/Synchronizers/TabsSynchronizer.swift
@@ -41,7 +41,7 @@ open class TabsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchroniz
             "tabs": jsonTabs
         ])
         if Logger.logPII {
-            log.verbose("Sending tabs JSON \(tabsJSON.stringValue())")
+            log.verbose("Sending tabs JSON \(tabsJSON.stringValue() ?? "nil")")
         }
         let payload = TabsPayload(tabsJSON)
         return Record(id: guid, payload: payload, ttl: ThreeWeeksInSeconds)

--- a/SyncTests/HistorySynchronizerTests.swift
+++ b/SyncTests/HistorySynchronizerTests.swift
@@ -117,7 +117,7 @@ extension MockSyncableHistory: SyncableHistory {
                 if let existingLocal = self.places[place.guid] {
                     if existingLocal.shouldUpload {
                         log.debug("Record \(existingLocal.guid) modified locally and remotely.")
-                        log.debug("Local modified: \(existingLocal.localModified); remote: \(modified).")
+                        log.debug("Local modified: \(existingLocal.localModified ??? "nil"); remote: \(modified).")
 
                         // Should always be a value if marked as changed.
                         if existingLocal.localModified! > modified {

--- a/SyncTests/HistorySynchronizerTests.swift
+++ b/SyncTests/HistorySynchronizerTests.swift
@@ -211,7 +211,7 @@ class HistorySynchronizerTests: XCTestCase {
         let noRecords = [Record<HistoryPayload>]()
 
         // Apply no records.
-        self.applyRecords(records: noRecords, toStorage: empty)
+        let _ = self.applyRecords(records: noRecords, toStorage: empty)
 
         // Hey look! Nothing changed.
         XCTAssertTrue(empty.places.isEmpty)

--- a/SyncTests/LiveStorageClientTests.swift
+++ b/SyncTests/LiveStorageClientTests.swift
@@ -74,7 +74,7 @@ class LiveStorageClientTests: LiveAccountTest {
                 XCTAssert(rec.id == "keys", "GUID is correct.")
                 XCTAssert(rec.modified > 1000, "modified is sane.")
                 let payload: KeysPayload = rec.payload as KeysPayload
-                print("Body: \(payload.json.stringValue())", terminator: "\n")
+                print("Body: \(payload.json.stringValue() ?? "nil")", terminator: "\n")
                 XCTAssert(rec.id == "keys", "GUID inside is correct.")
                 if let keys = payload.defaultKeys {
                     // Extracting the token like this is not great, but...
@@ -102,7 +102,7 @@ class LiveStorageClientTests: LiveAccountTest {
 
         // client: mgWl22CIzHiE
         waitForExpectations(timeout: 20) { (error) in
-            XCTAssertNil(error, "\(error)")
+            XCTAssertNil(error, "Error: \(error ??? "nil")")
         }
     }
 
@@ -125,7 +125,7 @@ class LiveStorageClientTests: LiveAccountTest {
         }
 
         waitForExpectations(timeout: 20) { (error) in
-            XCTAssertNil(error, "\(error)")
+            XCTAssertNil(error, "Error: \(error ??? "nil")")
         }
     }
 }

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -113,7 +113,7 @@ class MetaGlobalTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 2000) { (error) in
-            XCTAssertNil(error, "\(error)")
+            XCTAssertNil(error, "Error: \(error ??? "nil")")
         }
     }
 
@@ -133,7 +133,7 @@ class MetaGlobalTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 2000) { (error) in
-            XCTAssertNil(error, "\(error)")
+            XCTAssertNil(error, "Error: \(error ??? "nil")")
         }
     }
 
@@ -151,7 +151,7 @@ class MetaGlobalTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 2000) { (error) in
-            XCTAssertNil(error, "\(error)")
+            XCTAssertNil(error, "Error: \(error ??? "nil")")
         }
     }
 
@@ -170,7 +170,7 @@ class MetaGlobalTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 2000) { (error) in
-            XCTAssertNil(error, "\(error)")
+            XCTAssertNil(error, "Error: \(error ??? "nil")")
         }
     }
 
@@ -203,7 +203,7 @@ class MetaGlobalTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 2000) { (error) in
-            XCTAssertNil(error, "\(error)")
+            XCTAssertNil(error, "Error: \(error ??? "nil")")
         }
 
         let afterFirstSync = Date.now()
@@ -229,7 +229,7 @@ class MetaGlobalTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 2000) { (error) in
-            XCTAssertNil(error, "\(error)")
+            XCTAssertNil(error, "Error: \(error ??? "nil")")
         }
     }
 
@@ -264,7 +264,7 @@ class MetaGlobalTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 2000) { (error) in
-            XCTAssertNil(error, "\(error)")
+            XCTAssertNil(error, "Error: \(error ??? "nil")")
         }
 
         let afterFirstSync = Date.now()
@@ -297,7 +297,7 @@ class MetaGlobalTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 2000) { (error) in
-            XCTAssertNil(error, "\(error)")
+            XCTAssertNil(error, "Error: \(error ??? "nil")")
         }
 
         let afterSecondSync = Date.now()
@@ -330,7 +330,7 @@ class MetaGlobalTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 2000) { (error) in
-            XCTAssertNil(error, "\(error)")
+            XCTAssertNil(error, "Error: \(error ??? "nil")")
         }
 
         let afterThirdSync = Date.now()
@@ -361,7 +361,7 @@ class MetaGlobalTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 2000) { (error) in
-            XCTAssertNil(error, "\(error)")
+            XCTAssertNil(error, "Error: \(error ??? "nil")")
         }
     }
 
@@ -400,7 +400,7 @@ class MetaGlobalTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 2000) { (error) in
-            XCTAssertNil(error, "\(error)")
+            XCTAssertNil(error, "Error: \(error ??? "nil")")
         }
 
         // Wipe meta/global.
@@ -435,7 +435,7 @@ class MetaGlobalTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 2000) { (error) in
-            XCTAssertNil(error, "\(error)")
+            XCTAssertNil(error, "Error: \(error ??? "nil")")
         }
     }
 
@@ -469,7 +469,7 @@ class MetaGlobalTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 2000) { (error) in
-            XCTAssertNil(error, "\(error)")
+            XCTAssertNil(error, "Error: \(error ??? "nil")")
         }
 
         let afterFirstSync = Date.now()
@@ -507,7 +507,7 @@ class MetaGlobalTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 2000) { (error) in
-            XCTAssertNil(error, "\(error)")
+            XCTAssertNil(error, "Error: \(error ??? "nil")")
         }
 
         // Now store a meta/global with a changed engine syncID, a new engine, and a new declined entry.
@@ -551,7 +551,7 @@ class MetaGlobalTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 2000) { (error) in
-            XCTAssertNil(error, "\(error)")
+            XCTAssertNil(error, "Error: \(error ??? "nil")")
         }
     }
 }

--- a/SyncTests/RecordTests.swift
+++ b/SyncTests/RecordTests.swift
@@ -529,29 +529,30 @@ class RecordTests: XCTestCase {
         XCTAssertTrue(bookmark is BookmarkPayload)
 
         let query = JSON(parseJSON: "{\"id\":\"ShCZLGEFQMam\",\"type\":\"query\",\"title\":\"Downloads\",\"parentName\":\"\",\"bmkUri\":\"place:transition=7&sort=4\",\"tags\":[],\"keyword\":null,\"description\":null,\"loadInSidebar\":false,\"parentid\":\"T6XK5oJMU8ih\"}")
-        let q = BookmarkType.payloadFromJSON(query)
-        XCTAssertTrue(q is BookmarkQueryPayload)
-        XCTAssertTrue(q is MirrorItemable)
-        guard let item = (q as? MirrorItemable)?.toMirrorItem(Date.now()) else {
-            XCTFail("Not mirrorable!")
-            return
+
+        guard let q = BookmarkType.payloadFromJSON(query) else {
+            XCTFail("Failed to generate payload from json: \(query)")
+            return 
         }
 
+        XCTAssertTrue(q is BookmarkQueryPayload)
+
+        let item = q.toMirrorItem(Date.now())
         XCTAssertEqual(6, item.type.rawValue)
         XCTAssertEqual("ShCZLGEFQMam", item.guid)
 
         let places = JSON(parseJSON: "{\"id\":\"places\",\"type\":\"folder\",\"title\":\"\",\"description\":null,\"children\":[\"menu________\",\"toolbar_____\",\"tags________\",\"unfiled_____\",\"jKnyPDrBQSDg\",\"T6XK5oJMU8ih\"],\"parentid\":\"2hYxKgBwvkEH\"}")
-        let p = BookmarkType.payloadFromJSON(places)
-        XCTAssertTrue(p is FolderPayload)
-        XCTAssertTrue(p is MirrorItemable)
-
-        // Items keep their GUID until they're written into the mirror table.
-        XCTAssertEqual("places", p!.id)
-
-        guard let pMirror = (p as? MirrorItemable)?.toMirrorItem(Date.now()) else {
-            XCTFail("Not mirrorable!")
+        guard let p = BookmarkType.payloadFromJSON(places) else {
+            XCTFail("Failed to generate payload from json: \(places)")
             return
         }
+
+        XCTAssertTrue(p is FolderPayload)
+
+        // Items keep their GUID until they're written into the mirror table.
+        XCTAssertEqual("places", p.id)
+
+        let pMirror = p.toMirrorItem(Date.now())
 
         XCTAssertEqual(2, pMirror.type.rawValue)
 

--- a/SyncTests/StateTests.swift
+++ b/SyncTests/StateTests.swift
@@ -32,7 +32,7 @@ func compareScratchpads(tuple: (lhs: Scratchpad, rhs: Scratchpad)) {
 
 func roundtrip(s: Scratchpad) -> (Scratchpad, rhs: Scratchpad) {
     let prefs = MockProfilePrefs()
-    s.pickle(prefs)
+    let _ = s.pickle(prefs)
     return (s, rhs: Scratchpad.restoreFromPrefs(prefs, syncKeyBundle: s.syncKeyBundle)!)
 }
 
@@ -50,7 +50,7 @@ class StateTests: XCTestCase {
         let syncKeyBundle = KeyBundle.fromKB(Bytes.generateRandomBytes(32))
         let keys = Fetched(value: Keys(defaultBundle: syncKeyBundle), timestamp: 1001)
         let b = Scratchpad(b: syncKeyBundle, persistingTo: MockProfilePrefs()).evolve()
-        b.setKeys(keys)
+        let _ = b.setKeys(keys)
         b.localCommands = Set([
             .enableEngine(engine: "tabs"),
             .disableEngine(engine: "passwords"),

--- a/SyncTests/SyncTests-Bridging-Header.h
+++ b/SyncTests/SyncTests-Bridging-Header.h
@@ -2,5 +2,8 @@
 #define Client_SyncTests_Bridging_Header_h
 
 #import <Foundation/Foundation.h>
+#import "Shared-Bridging-Header.h"
+#import "Storage-Bridging-Header.h"
+#import "Sync-Bridging-Header.h"
 
 #endif

--- a/Telemetry/PingCentre/PingCentre.swift
+++ b/Telemetry/PingCentre/PingCentre.swift
@@ -107,7 +107,7 @@ class DefaultPingCentreImpl: PingCentreClient {
             .response(queue: DispatchQueue.global()) { (response) in
                 if let e = response.error {
                     NSLog("Failed to send ping to ping centre -- topic: \(self.topic.name), error: \(e)")
-                    deferred.fill(Maybe(failure: e as! MaybeErrorType))
+                    deferred.fill(Maybe(failure: e as MaybeErrorType))
                     return
                 }
                 deferred.fill(Maybe(success: ()))

--- a/Telemetry/Telemetry.swift
+++ b/Telemetry/Telemetry.swift
@@ -54,7 +54,12 @@ open class Telemetry {
         var request = URLRequest(url: url)
 
         log.debug("Ping URL: \(url)")
-        log.debug("Ping payload: \(payload)")
+        if let payload = payload {
+            log.debug("Ping payload: \(payload)")
+        } else {
+            log.warning("Warning: Payload being sent for \(url) is empty!")
+        }
+        
 
         guard let body = payload?.data(using: String.Encoding.utf8) else {
             log.error("Invalid data!")

--- a/Telemetry/Telemetry.swift
+++ b/Telemetry/Telemetry.swift
@@ -60,7 +60,6 @@ open class Telemetry {
             log.warning("Warning: Payload being sent for \(url) is empty!")
         }
         
-
         guard let body = payload?.data(using: String.Encoding.utf8) else {
             log.error("Invalid data!")
             assertionFailure()


### PR DESCRIPTION
This series of patches resolves all of the warnings that were introduced in Swift 3.1 along with some others that have been around for a while. For the most part the warnings fell into a few groups:

1. String interpolation on optional values: This was resolved by unwrapping using ?? if the optional's wrapped type is a string. If the wrapped type is not a string, ?? doesn't work since the operator assumes the same type on both sides. For this, I've introduced the ??? operator which will return a string value when unwrapping non-string values.

2. Unused result: Most of these were resolved by changing `.value` to `.succeeded()` through the test cases since that method will not only use the value but use it for a boolean check using XCAssertTrue. I've also included a non-related patch to move the duplicated code for succeeded/failed into a new file that is linked with all relevant test targets.

3. Implicit briding header will no longer be imported across modules: Just needed to add the bridging header for dependencies explicitly to the target's own bridging header.

4. M_PI -> Double.pi