### PR TITLE
1350861 - Crash in SendTo PlugInKit: [PKService run] + 848 / 0xdead10cc

### DIFF
--- a/Extensions/ShareTo/InitialViewController.swift
+++ b/Extensions/ShareTo/InitialViewController.swift
@@ -12,10 +12,6 @@ private let LastUsedShareDestinationsKey = "LastUsedShareDestinations"
 class InitialViewController: UIViewController, ShareControllerDelegate {
     var shareDialogController: ShareDialogController!
 
-    lazy var profile: Profile = {
-        return BrowserProfile(localName: "profile", app: nil)
-    }()
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = UIColor(white: 0.0, alpha: 0.66) // TODO: Is the correct color documented somewhere?
@@ -54,7 +50,6 @@ class InitialViewController: UIViewController, ShareControllerDelegate {
     }
 
     func finish() {
-        self.profile.shutdown()
         self.extensionContext!.completeRequest(returningItems: [], completionHandler: nil)
     }
 
@@ -66,15 +61,18 @@ class InitialViewController: UIViewController, ShareControllerDelegate {
         }, completion: { (Bool) -> Void in
             self.dismissShareDialog()
             
+            let profile = BrowserProfile(localName: "profile", app: nil)
+
             if destinations.contains(ShareDestinationReadingList) {
-                self.shareToReadingList(item)
-            }
-            
-            if destinations.contains(ShareDestinationBookmarks) {
-                self.shareToBookmarks(item)
+                profile.readingList?.createRecordWithURL(item.url, title: item.title ?? "", addedBy: UIDevice.current.name)
             }
 
-            self.extensionContext!.completeRequest(returningItems: [], completionHandler: nil)
+            if destinations.contains(ShareDestinationBookmarks) {
+                profile.bookmarks.shareItem(item) >>> {
+                    profile.shutdown()
+                    self.extensionContext!.completeRequest(returningItems: [], completionHandler: nil)
+                }
+            }
         })
     }
     
@@ -133,15 +131,5 @@ class InitialViewController: UIViewController, ShareControllerDelegate {
         shareDialogController.willMove(toParentViewController: nil)
         shareDialogController.view.removeFromSuperview()
         shareDialogController.removeFromParentViewController()
-    }
-    
-    //
-    
-    func shareToReadingList(_ item: ShareItem) {
-        profile.readingList?.createRecordWithURL(item.url, title: item.title ?? "", addedBy: UIDevice.current.name)
-    }
-    
-    func shareToBookmarks(_ item: ShareItem) {
-        profile.bookmarks.shareItem(item)
     }
 }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -181,7 +181,7 @@ protocol Profile: class {
 
     @discardableResult func storeTabs(_ tabs: [RemoteTab]) -> Deferred<Maybe<Int>>
 
-    func sendItems(_ items: [ShareItem], toClients clients: [RemoteClient])
+    func sendItems(_ items: [ShareItem], toClients clients: [RemoteClient]) -> Deferred<Maybe<SyncStatus>>
 
     var syncManager: SyncManager { get }
     var isChinaEdition: Bool { get }
@@ -484,12 +484,12 @@ open class BrowserProfile: Profile {
         return self.remoteClientsAndTabs.insertOrUpdateTabs(tabs)
     }
 
-    public func sendItems(_ items: [ShareItem], toClients clients: [RemoteClient]) {
+    public func sendItems(_ items: [ShareItem], toClients clients: [RemoteClient]) -> Deferred<Maybe<SyncStatus>> {
         let id = DeviceInfo.clientIdentifier(self.prefs)
         let commands = items.map { item in
             SyncCommand.displayURIFromShareItem(item, asClient: id)
         }
-        self.remoteClientsAndTabs.insertCommands(commands, forClients: clients) >>> { self.syncManager.syncClients() }
+        return self.remoteClientsAndTabs.insertCommands(commands, forClients: clients) >>> { self.syncManager.syncClients() }
     }
 
     lazy var logins: BrowserLogins & SyncableLogins & ResettableSyncStorage = {

--- a/Storage/Bookmarks/BookmarksModel.swift
+++ b/Storage/Bookmarks/BookmarksModel.swift
@@ -234,7 +234,7 @@ open class MemoryBookmarkFolder: BookmarkFolder, Sequence {
 open class MemoryBookmarksSink: ShareToDestination {
     var queue: [BookmarkNode] = []
     public init() { }
-    open func shareItem(_ item: ShareItem) {
+    open func shareItem(_ item: ShareItem) -> Success {
         let title = item.title == nil ? "Untitled" : item.title!
         func exists(_ e: BookmarkNode) -> Bool {
             if let bookmark = e as? BookmarkItem {
@@ -248,6 +248,7 @@ open class MemoryBookmarksSink: ShareToDestination {
         if !queue.contains(where: exists) {
             queue.append(BookmarkItem(guid: Bytes.generateGUID(), title: title, url: item.url))
         }
+        return succeed()
     }
 }
 
@@ -355,8 +356,8 @@ open class MockMemoryBookmarksStore: BookmarksModelFactory, ShareToDestination {
         return BookmarksModel(modelFactory: self, root: f)
     }
 
-    open func shareItem(_ item: ShareItem) {
-        self.sink.shareItem(item)
+    open func shareItem(_ item: ShareItem) -> Success {
+        return self.sink.shareItem(item)
     }
 
     open func isBookmarked(_ url: String) -> Deferred<Maybe<Bool>> {

--- a/Storage/SQL/SQLiteBookmarksHelpers.swift
+++ b/Storage/SQL/SQLiteBookmarksHelpers.swift
@@ -33,11 +33,12 @@ extension SQLiteBookmarks: ShareToDestination {
         }
     }
 
-    public func shareItem(_ item: ShareItem) {
+    public func shareItem(_ item: ShareItem) -> Success {
         // We parse here in anticipation of getting real URLs at some point.
         if let url = item.url.asURL {
             let title = item.title ?? url.absoluteString
-            let _ = self.addToMobileBookmarks(url, title: title, favicon: item.favicon)
+            return self.addToMobileBookmarks(url, title: title, favicon: item.favicon)
         }
+        return succeed()
     }
 }

--- a/Storage/SQL/SQLiteBookmarksSyncing.swift
+++ b/Storage/SQL/SQLiteBookmarksSyncing.swift
@@ -635,8 +635,8 @@ extension MergedSQLiteBookmarks: LocalItemSource {
 }
 
 extension MergedSQLiteBookmarks: ShareToDestination {
-    public func shareItem(_ item: ShareItem) {
-        self.local.shareItem(item)
+    public func shareItem(_ item: ShareItem) -> Success {
+        return self.local.shareItem(item)
     }
 }
 

--- a/Storage/Sharing.swift
+++ b/Storage/Sharing.swift
@@ -26,5 +26,5 @@ public struct ShareItem {
 }
 
 public protocol ShareToDestination {
-    func shareItem(_ item: ShareItem)
+    func shareItem(_ item: ShareItem) -> Success
 }


### PR DESCRIPTION
This patch makes sure that we do not leave the *Profile* open when the *SendTo* app extension goes into the background. It does this in two places:

- In the ShareTo extension, it removes the Profile as an instance variable and limits the scope where it is used (opened, used, closed) to absolute minimum.

- In the kjdkejdkjekdjekjde TODO