### PR TITLE
Bug 1357185 - Make sure share menu is presented in AS.

### DIFF
--- a/Client/Frontend/Widgets/ActionOverlayTableViewController.swift
+++ b/Client/Frontend/Widgets/ActionOverlayTableViewController.swift
@@ -128,14 +128,13 @@ class ActionOverlayTableViewController: UIViewController, UITableViewDelegate, U
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        defer {
-            self.dismiss(nil)
-        }
 
         let action = actions[indexPath.row]
         guard let handler = actions[indexPath.row].handler else {
+            self.dismiss(nil)
             return
         }
+        self.dismiss(nil)
         return handler(action)
     }
 


### PR DESCRIPTION
Dismiss needs to be called _before_ we call the handler because sometimes the handler action requires presenting a vc (share menu) which cant happen if the context menu (ActionOverlayVC) is present. 
