### PR TITLE
Bug 1354939 - Crash in TabManager.tabsToRestore() -> [SavedTab]?

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -637,6 +637,7 @@ extension TabManager {
     static func tabsToRestore() -> [SavedTab]? {
         if let tabData = tabArchiveData() {
             let unarchiver = NSKeyedUnarchiver(forReadingWith: tabData)
+            unarchiver.decodingFailurePolicy = .setErrorAndReturn
             return unarchiver.decodeObject(forKey: "tabs") as? [SavedTab]
         } else {
             return nil


### PR DESCRIPTION
This is an absolute minimal approach to make `NSUnarchiver.decodeObject()` stop raising exceptions that we cannot catch. With this `decodingFailurePolicy` it will simply return `nil` if the tabs could not be decoded.