### PR TITLE
Bug 1357946 - Time waits for no tab

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -464,6 +464,7 @@
 		E41A7D4B1A1BE04500245963 /* InitialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41A7D4A1A1BE04500245963 /* InitialViewController.swift */; };
 		E41F0D981ADFFB5400FC7387 /* ReadingListService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41F0D971ADFFB5400FC7387 /* ReadingListService.swift */; };
 		E41F0D9B1ADFFC5600FC7387 /* ReadingListError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41F0D9A1ADFFC5600FC7387 /* ReadingListError.swift */; };
+		E42736071EA858CF009C428E /* TabsPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42736061EA858CF009C428E /* TabsPayloadTests.swift */; };
 		E42CCDE81A23A73D00B794D3 /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC84D1A16C40C00D49B7B /* Profile.swift */; };
 		E4424B201AC6EBE100F44C38 /* ReaderSettings.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4424B1F1AC6EBE100F44C38 /* ReaderSettings.xcassets */; };
 		E4424B3C1AC71FB400F44C38 /* FiraSans-Book.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E4424B3B1AC71FB400F44C38 /* FiraSans-Book.ttf */; };
@@ -1640,6 +1641,7 @@
 		E41A7D4A1A1BE04500245963 /* InitialViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InitialViewController.swift; sourceTree = "<group>"; };
 		E41F0D971ADFFB5400FC7387 /* ReadingListService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ReadingListService.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		E41F0D9A1ADFFC5600FC7387 /* ReadingListError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadingListError.swift; sourceTree = "<group>"; };
+		E42736061EA858CF009C428E /* TabsPayloadTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TabsPayloadTests.swift; path = SyncTests/TabsPayloadTests.swift; sourceTree = "<group>"; };
 		E4424B1F1AC6EBE100F44C38 /* ReaderSettings.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ReaderSettings.xcassets; sourceTree = "<group>"; };
 		E4424B3B1AC71FB400F44C38 /* FiraSans-Book.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "FiraSans-Book.ttf"; sourceTree = "<group>"; };
 		E47536EC1C85412C0022CC69 /* PrintHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrintHelper.swift; sourceTree = "<group>"; };
@@ -2291,6 +2293,7 @@
 				E6EDE81D1D524475007A0732 /* BatchingClientTests.swift */,
 				2F3724C51ABF3C01007607FA /* StorageClientTests.swift */,
 				E6BA20111E52165800697F9C /* SyncTelemetryTests.swift */,
+				E42736061EA858CF009C428E /* TabsPayloadTests.swift */,
 			);
 			name = SyncTests;
 			sourceTree = "<group>";
@@ -2652,7 +2655,7 @@
 				2C31A8461E8D447F00DAC646 /* HomePageSettingsUITest.swift */,
 				2CB56E3E1E926BFB00AF7586 /* ToolbarTest.swift */,
 				2CC1B3EF1E9B861400814EEC /* DomainAutocompleteTest.swift */,
-                2CEA6F781E93E3A600D4100E /* SearchSettingsUITest.swift */,
+				2CEA6F781E93E3A600D4100E /* SearchSettingsUITest.swift */,
 				0B9D40781E8D5AC80059E664 /* XCUITests-Bridging-Header.h */,
 			);
 			path = XCUITests;
@@ -4093,7 +4096,7 @@
 				TargetAttributes = {
 					2827315D1ABC9BE600AA1954 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = 9G8J6YA743;
+						DevelopmentTeam = 43AQ936H96;
 						LastSwiftMigration = 0820;
 					};
 					282731671ABC9BE700AA1954 = {
@@ -4104,23 +4107,23 @@
 					};
 					288A2D851AB8B3260023ABC3 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = 9G8J6YA743;
+						DevelopmentTeam = 43AQ936H96;
 						LastSwiftMigration = 0820;
 					};
 					2FA435FA1ABB83B4008031D1 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = 9G8J6YA743;
+						DevelopmentTeam = 43AQ936H96;
 						LastSwiftMigration = 0820;
 					};
 					2FA436041ABB83B4008031D1 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = 9G8J6YA743;
+						DevelopmentTeam = 43AQ936H96;
 						LastSwiftMigration = 0820;
 						TestTargetID = F84B21BD1A090F8100AAB793;
 					};
 					2FCAE2191ABB51F800877008 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = 9G8J6YA743;
+						DevelopmentTeam = 43AQ936H96;
 						LastSwiftMigration = 0820;
 					};
 					2FCAE2231ABB51F800877008 = {
@@ -4131,7 +4134,7 @@
 					};
 					390527491C874D35007E0BB7 = {
 						CreatedOnToolsVersion = 7.2.1;
-						DevelopmentTeam = 9G8J6YA743;
+						DevelopmentTeam = 43AQ936H96;
 						LastSwiftMigration = 0820;
 						ProvisioningStyle = Automatic;
 					};
@@ -4164,7 +4167,7 @@
 					};
 					E4BA8A2A1B4B0A1600BC2E95 = {
 						CreatedOnToolsVersion = 6.4;
-						DevelopmentTeam = 9G8J6YA743;
+						DevelopmentTeam = 43AQ936H96;
 						LastSwiftMigration = 0820;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -4175,7 +4178,7 @@
 					};
 					E4D567171ADECE2700F1EFE7 = {
 						CreatedOnToolsVersion = 6.3;
-						DevelopmentTeam = 9G8J6YA743;
+						DevelopmentTeam = 43AQ936H96;
 						LastSwiftMigration = 0820;
 					};
 					E4D567211ADECE2700F1EFE7 = {
@@ -4197,7 +4200,7 @@
 					};
 					F84B21BD1A090F8100AAB793 = {
 						CreatedOnToolsVersion = 6.1;
-						DevelopmentTeam = 9G8J6YA743;
+						DevelopmentTeam = 43AQ936H96;
 						LastSwiftMigration = 0820;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -4223,7 +4226,7 @@
 					};
 					F84B22481A0920C600AAB793 = {
 						CreatedOnToolsVersion = 6.1;
-						DevelopmentTeam = 9G8J6YA743;
+						DevelopmentTeam = 43AQ936H96;
 						LastSwiftMigration = 0820;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -4237,7 +4240,7 @@
 					};
 					F84B225B1A09210A00AAB793 = {
 						CreatedOnToolsVersion = 6.1;
-						DevelopmentTeam = 9G8J6YA743;
+						DevelopmentTeam = 43AQ936H96;
 						LastSwiftMigration = 0820;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -4776,6 +4779,7 @@
 				28ECD9F41BA1F59800D829DA /* DownloadTests.swift in Sources */,
 				2F3724C61ABF3C01007607FA /* LiveStorageClientTests.swift in Sources */,
 				E6EDE82C1D5244AF007A0732 /* BatchingClientTests.swift in Sources */,
+				E42736071EA858CF009C428E /* TabsPayloadTests.swift in Sources */,
 				E6F6D6A51E9E6B2B0012072B /* DeferredTestUtils.swift in Sources */,
 				28D980231C47149000277055 /* TestBookmarkTreeMerging.swift in Sources */,
 				E67035EE1E538B500037AB83 /* Mocking.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -4096,7 +4096,7 @@
 				TargetAttributes = {
 					2827315D1ABC9BE600AA1954 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 					};
 					282731671ABC9BE700AA1954 = {
@@ -4107,23 +4107,23 @@
 					};
 					288A2D851AB8B3260023ABC3 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 					};
 					2FA435FA1ABB83B4008031D1 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 					};
 					2FA436041ABB83B4008031D1 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 						TestTargetID = F84B21BD1A090F8100AAB793;
 					};
 					2FCAE2191ABB51F800877008 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 					};
 					2FCAE2231ABB51F800877008 = {
@@ -4134,7 +4134,7 @@
 					};
 					390527491C874D35007E0BB7 = {
 						CreatedOnToolsVersion = 7.2.1;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 						ProvisioningStyle = Automatic;
 					};
@@ -4167,7 +4167,7 @@
 					};
 					E4BA8A2A1B4B0A1600BC2E95 = {
 						CreatedOnToolsVersion = 6.4;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -4178,7 +4178,7 @@
 					};
 					E4D567171ADECE2700F1EFE7 = {
 						CreatedOnToolsVersion = 6.3;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 					};
 					E4D567211ADECE2700F1EFE7 = {
@@ -4200,7 +4200,7 @@
 					};
 					F84B21BD1A090F8100AAB793 = {
 						CreatedOnToolsVersion = 6.1;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -4226,7 +4226,7 @@
 					};
 					F84B22481A0920C600AAB793 = {
 						CreatedOnToolsVersion = 6.1;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -4240,7 +4240,7 @@
 					};
 					F84B225B1A09210A00AAB793 = {
 						CreatedOnToolsVersion = 6.1;
-						DevelopmentTeam = 43AQ936H96;
+						DevelopmentTeam = 9G8J6YA743;
 						LastSwiftMigration = 0820;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {

--- a/Shared/TimeConstants.swift
+++ b/Shared/TimeConstants.swift
@@ -90,6 +90,11 @@ let MaxTimestampAsDouble: Double = Double(UInt64.max)
 public func someKindOfTimestampStringToTimestamp(_ input: String) -> Timestamp? {
     var double = 0.0
     if Scanner(string: input).scanDouble(&double) {
+        // This should never happen. Hah!
+        if double.isNaN || double.isInfinite {
+            return nil
+        }
+
         // `double` will be either huge or negatively huge on overflow, and 0 on underflow.
         // We clamp to reasonable ranges.
         if double < 0 {
@@ -120,6 +125,11 @@ public func someKindOfTimestampStringToTimestamp(_ input: String) -> Timestamp? 
 public func decimalSecondsStringToTimestamp(_ input: String) -> Timestamp? {
     var double = 0.0
     if Scanner(string: input).scanDouble(&double) {
+        // This should never happen. Hah!
+        if double.isNaN || double.isInfinite {
+            return nil
+        }
+
         // `double` will be either huge or negatively huge on overflow, and 0 on underflow.
         // We clamp to reasonable ranges.
         if double < 0 {

--- a/Shared/TimeConstants.swift
+++ b/Shared/TimeConstants.swift
@@ -81,10 +81,58 @@ extension Date {
     }
 }
 
+let MaxTimestampAsDouble: Double = Double(UInt64.max)
+
+/** This is just like decimalSecondsStringToTimestamp, but it looks for values that seem to be
+ *  milliseconds and fixes them. That's necessary because Firefox for iOS <= 7.3 uploaded millis
+ *  when seconds were expected.
+ */
+public func someKindOfTimestampStringToTimestamp(_ input: String) -> Timestamp? {
+    var double = 0.0
+    if Scanner(string: input).scanDouble(&double) {
+        // `double` will be either huge or negatively huge on overflow, and 0 on underflow.
+        // We clamp to reasonable ranges.
+        if double < 0 {
+            return nil
+        }
+
+        if double >= MaxTimestampAsDouble {
+            // Definitely not representable as a timestamp if the seconds are this large!
+            return nil
+        }
+
+        if double > 1000000000000 {
+            // Oh, this was in milliseconds.
+            return Timestamp(double)
+        }
+
+        let millis = double * 1000
+        if millis >= MaxTimestampAsDouble {
+            // Not representable as a timestamp.
+            return nil
+        }
+
+        return Timestamp(millis)
+    }
+    return nil
+}
+
 public func decimalSecondsStringToTimestamp(_ input: String) -> Timestamp? {
     var double = 0.0
     if Scanner(string: input).scanDouble(&double) {
-        return Timestamp(double * 1000)
+        // `double` will be either huge or negatively huge on overflow, and 0 on underflow.
+        // We clamp to reasonable ranges.
+        if double < 0 {
+            return nil
+        }
+
+        let millis = double * 1000
+        if millis >= MaxTimestampAsDouble {
+            // Not representable as a timestamp.
+            return nil
+        }
+
+        return Timestamp(millis)
     }
     return nil
 }

--- a/SharedTests/UtilsTests.swift
+++ b/SharedTests/UtilsTests.swift
@@ -61,4 +61,29 @@ class UtilsTests: XCTestCase {
             XCTAssertEqual(expected as NSArray, actual as NSArray) //wtf. why is XCTAssert being so weeird
         }
     }
+
+    func testParseTimestamps() {
+        let millis = "1492316843992"        // Firefox for iOS produced millisecond timestamps. Oops.
+        let decimal = "1492316843.99"
+        let truncated = "1492316843"
+        let huge = "1844674407370955161512"
+
+        XCTAssertNil(decimalSecondsStringToTimestamp(""))
+        XCTAssertNil(decimalSecondsStringToTimestamp(huge))
+        XCTAssertNil(decimalSecondsStringToTimestamp("foo"))
+
+        XCTAssertNil(someKindOfTimestampStringToTimestamp(""))
+        XCTAssertNil(someKindOfTimestampStringToTimestamp(huge))
+        XCTAssertNil(someKindOfTimestampStringToTimestamp("foo"))
+
+        XCTAssertEqual(decimalSecondsStringToTimestamp(decimal) ?? 0, Timestamp(1492316843990))
+        XCTAssertEqual(someKindOfTimestampStringToTimestamp(decimal) ?? 0, Timestamp(1492316843990))
+
+        XCTAssertEqual(decimalSecondsStringToTimestamp(truncated) ?? 0, Timestamp(1492316843000))
+        XCTAssertEqual(someKindOfTimestampStringToTimestamp(truncated) ?? 0, Timestamp(1492316843000))
+
+        XCTAssertEqual(decimalSecondsStringToTimestamp(millis) ?? 0, Timestamp(1492316843992000))  // Oops.
+        XCTAssertEqual(someKindOfTimestampStringToTimestamp(millis) ?? 0, Timestamp(1492316843992))
+
+    }
 }

--- a/Sync/Synchronizers/TabsSynchronizer.swift
+++ b/Sync/Synchronizers/TabsSynchronizer.swift
@@ -199,7 +199,7 @@ extension RemoteTab {
                 "title": title,
                 "icon": icon?.absoluteString as Any? ?? NSNull(),
                 "urlHistory": tabHistory,
-                "lastUsed": lastUsed.description,
+                "lastUsed": millisecondsToDecimalSeconds(lastUsed),
                 ])
         }
         return nil

--- a/Sync/Synchronizers/TabsSynchronizer.swift
+++ b/Sync/Synchronizers/TabsSynchronizer.swift
@@ -34,7 +34,7 @@ open class TabsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchroniz
     fileprivate func createOwnTabsRecord(_ tabs: [RemoteTab]) -> Record<TabsPayload> {
         let guid = self.scratchpad.clientGUID
 
-        let jsonTabs: [JSON] = optFilter(tabs.map { $0.toJSON() })
+        let jsonTabs: [JSON] = tabs.flatMap { $0.toJSON() }
         let tabsJSON = JSON([
             "id": guid,
             "clientName": self.scratchpad.clientName,

--- a/Sync/TabsPayload.swift
+++ b/Sync/TabsPayload.swift
@@ -9,8 +9,8 @@ import XCGLogger
 import SwiftyJSON
 
 // Int64.max / 1000.
-private let MaxSecondsToConvertInt64: Int64 = 9223372036854775;
-private let MaxSecondsToConvertDouble: Double = Double(9223372036854775);
+private let MaxSecondsToConvertInt64: Int64 = 9223372036854775
+private let MaxSecondsToConvertDouble: Double = Double(9223372036854775)
 
 private let log = Logger.browserLogger
 

--- a/Sync/TabsPayload.swift
+++ b/Sync/TabsPayload.swift
@@ -119,7 +119,7 @@ open class TabsPayload: CleartextPayloadJSON {
     }
 
     var tabs: [Tab] {
-        return self["tabs"].arrayValue.flatMap(Tab.fromJSON))
+        return self["tabs"].arrayValue.flatMap(Tab.fromJSON)
     }
 
     var clientName: String {

--- a/Sync/TabsPayload.swift
+++ b/Sync/TabsPayload.swift
@@ -8,6 +8,7 @@ import Storage
 import XCGLogger
 import SwiftyJSON
 
+private let MaxSecondsToConvert: Int64 = 9223372036854775;
 private let log = Logger.browserLogger
 
 open class TabsPayload: CleartextPayloadJSON {
@@ -25,7 +26,7 @@ open class TabsPayload: CleartextPayloadJSON {
         }
 
         func toRemoteTabForClient(_ guid: GUID) -> RemoteTab? {
-            let urls = optFilter(urlHistory.map({ $0.asURL }))
+            let urls = urlHistory.flatMap({ $0.asURL })
             if urls.isEmpty {
                 log.debug("Bug 1201875 - Discarding tab as history has no conforming URLs.")
                 return nil
@@ -83,7 +84,7 @@ open class TabsPayload: CleartextPayloadJSON {
     var remoteTabs: [RemoteTab] {
         if let clientGUID = self["id"].string {
             let payloadTabs = self["tabs"].arrayValue
-            let remoteTabs = optFilter(payloadTabs.map({ Tab.remoteTabFromJSON($0, clientGUID: clientGUID) }))
+            let remoteTabs = payloadTabs.flatMap({ Tab.remoteTabFromJSON($0, clientGUID: clientGUID) })
             if payloadTabs.count != remoteTabs.count {
                 log.debug("Bug 1201875 - Missing remote tabs from sync")
             }
@@ -94,7 +95,7 @@ open class TabsPayload: CleartextPayloadJSON {
     }
 
     var tabs: [Tab] {
-        return optFilter(self["tabs"].arrayValue.map(Tab.fromJSON))
+        return self["tabs"].arrayValue.flatMap(Tab.fromJSON))
     }
 
     var clientName: String {

--- a/Sync/TabsPayload.swift
+++ b/Sync/TabsPayload.swift
@@ -45,6 +45,9 @@ open class TabsPayload: CleartextPayloadJSON {
         class func fromJSON(_ json: JSON) -> Tab? {
             func getLastUsed(_ json: JSON) -> Timestamp? {
                 let lastUsed = json["lastUsed"]
+                if lastUsed.isBool() {
+                    return nil
+                }
                 // This might be a string or a number.
                 if let num = lastUsed.int64 {
                     if num < 0 {

--- a/SyncTests/TabsPayloadTests.swift
+++ b/SyncTests/TabsPayloadTests.swift
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import XCTest
+@testable import Sync
+
+class TabsPayloadTests: XCTestCase {
+
+    func testFromInvalidJSON() {
+        let tabsPayload1 = TabsPayload("")
+        XCTAssertFalse(tabsPayload1.isValid())
+
+        let tabsPayload2 = TabsPayload("null")
+        XCTAssertFalse(tabsPayload2.isValid())
+
+        let tabsPayload3 = TabsPayload("{}")
+        XCTAssertFalse(tabsPayload3.isValid())
+
+        let tabsPayload4 = TabsPayload("{\"id\": \"abc\"}")
+        XCTAssertFalse(tabsPayload4.isValid())
+    }
+
+    func testFromJSON() {
+        let tabsPayload = TabsPayload("{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": []}")
+        XCTAssertTrue(tabsPayload.isValid())
+    }
+
+    func testFromJSONWithInvalidRecord() {
+        let tabsPayload = TabsPayload("{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": null}")
+        XCTAssertFalse(tabsPayload.isValid())
+
+        let tabsPayload2 = TabsPayload("{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": 1}")
+        XCTAssertFalse(tabsPayload2.isValid())
+
+        let tabsPayload3 = TabsPayload("{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": {}}")
+        XCTAssertFalse(tabsPayload3.isValid())
+
+        let tabsPayload4 = TabsPayload("{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": true}")
+        XCTAssertFalse(tabsPayload4.isValid())
+    }
+
+    func testTabWithBadTabs() {
+        let tabsPayload1 = TabsPayload("{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": [{}]}")
+        XCTAssertTrue(tabsPayload1.isValid())
+        let tabs1 = tabsPayload1.tabs
+        XCTAssert(tabs1.count == 0)
+
+        let tabsPayload2 = TabsPayload("{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": [null, {}, [], 123, false, true, \"\"]}")
+        XCTAssertTrue(tabsPayload2.isValid())
+        let tabs2 = tabsPayload2.tabs
+        XCTAssert(tabs2.count == 0)
+    }
+
+    func testTabWithCorrectTabLastUsed() {
+        let payloads = [
+            "{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": [{\"title\": \"Some Title\", \"urlHistory\": [\"http://www.example.com\"], \"icon\": null, \"lastUsed\": 1492649651}]}",
+            "{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": [{\"title\": \"Some Title\", \"urlHistory\": [\"http://www.example.com\"], \"icon\": null, \"lastUsed\": \"1492316843992\"}]}"
+        ]
+
+        for payload in payloads {
+            let tabsPayload = TabsPayload(payload)
+            XCTAssertTrue(tabsPayload.isValid())
+            let tabs = tabsPayload.tabs
+            XCTAssert(tabs.count == 1)
+        }
+    }
+
+    func testTabWithBadTabLastUsed() {
+        let payloads = [
+            "{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": [{\"title\": \"Some Title\", \"urlHistory\": [\"http://www.example.com\"], \"icon\": null, \"lastUsed\": null}]}",
+            "{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": [{\"title\": \"Some Title\", \"urlHistory\": [\"http://www.example.com\"], \"icon\": null, \"lastUsed\": \"\"}]}",
+            "{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": [{\"title\": \"Some Title\", \"urlHistory\": [\"http://www.example.com\"], \"icon\": null, \"lastUsed\": \"cheese\"}]}",
+            "{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": [{\"title\": \"Some Title\", \"urlHistory\": [\"http://www.example.com\"], \"icon\": null, \"lastUsed\": true}]}",
+            "{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": [{\"title\": \"Some Title\", \"urlHistory\": [\"http://www.example.com\"], \"icon\": null, \"lastUsed\": false}]}",
+            "{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": [{\"title\": \"Some Title\", \"urlHistory\": [\"http://www.example.com\"], \"icon\": null, \"lastUsed\": 9223372036854775807}]}",
+            "{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": [{\"title\": \"Some Title\", \"urlHistory\": [\"http://www.example.com\"], \"icon\": null, \"lastUsed\": 123456789012345678901234567890}]}",
+            "{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": [{\"title\": \"Some Title\", \"urlHistory\": [\"http://www.example.com\"], \"icon\": null, \"lastUsed\": -1}]}",
+            "{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": [{\"title\": \"Some Title\", \"urlHistory\": [\"http://www.example.com\"], \"icon\": null, \"lastUsed\": \"9223372036854775807\"}]}",
+            "{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": [{\"title\": \"Some Title\", \"urlHistory\": [\"http://www.example.com\"], \"icon\": null, \"lastUsed\": \"123456789012345678901234567890\"}]}",
+            "{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": [{\"title\": \"Some Title\", \"urlHistory\": [\"http://www.example.com\"], \"icon\": null, \"lastUsed\": \"-1\"}]}"
+        ]
+
+        for payload in payloads {
+            let tabsPayload = TabsPayload(payload)
+            XCTAssertTrue(tabsPayload.isValid(), "Should not be valid: \(payload)")
+            let tabs = tabsPayload.tabs
+            XCTAssert(tabs.count == 0, "Should not have valid tabs: \(payload)")
+        }
+    }
+}

--- a/SyncTests/TabsPayloadTests.swift
+++ b/SyncTests/TabsPayloadTests.swift
@@ -76,7 +76,6 @@ class TabsPayloadTests: XCTestCase {
             "{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": [{\"title\": \"Some Title\", \"urlHistory\": [\"http://www.example.com\"], \"icon\": null, \"lastUsed\": 9223372036854775807}]}",
             "{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": [{\"title\": \"Some Title\", \"urlHistory\": [\"http://www.example.com\"], \"icon\": null, \"lastUsed\": 123456789012345678901234567890}]}",
             "{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": [{\"title\": \"Some Title\", \"urlHistory\": [\"http://www.example.com\"], \"icon\": null, \"lastUsed\": -1}]}",
-            "{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": [{\"title\": \"Some Title\", \"urlHistory\": [\"http://www.example.com\"], \"icon\": null, \"lastUsed\": \"9223372036854775807\"}]}",
             "{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": [{\"title\": \"Some Title\", \"urlHistory\": [\"http://www.example.com\"], \"icon\": null, \"lastUsed\": \"123456789012345678901234567890\"}]}",
             "{\"id\": \"abc\", \"deleted\": false, \"clientName\": \"Foo\", \"tabs\": [{\"title\": \"Some Title\", \"urlHistory\": [\"http://www.example.com\"], \"icon\": null, \"lastUsed\": \"-1\"}]}"
         ]


### PR DESCRIPTION
On the face of it, this code was safe. But that cast to `Timestamp` — which is the same as `UInt64` — would fail for negative numbers or very large numbers. This PR tightens that up a lot, handles our own mis-generated millisecond timestamps, handles doubles in records, and correctly produces decimal seconds.