### PR TITLE
Bug 1357737 - Improve the highlights algorithm to be closer to the current AS

### DIFF
--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -377,7 +377,7 @@ class DeleteExportedDataSetting: HiddenSetting {
         do {
             let files = try fileManager.contentsOfDirectory(atPath: documentsPath)
             for file in files {
-                if file.startsWith("browser.") || file.startsWith("logins.") {
+                if file.startsWith("browser.") || file.startsWith("logins.") || file.startsWith("metadata.") {
                     try fileManager.removeItemInDirectory(documentsPath, named: file)
                 }
             }
@@ -399,7 +399,7 @@ class ExportBrowserDataSetting: HiddenSetting {
             let log = Logger.syncLogger
             try self.settings.profile.files.copyMatching(fromRelativeDirectory: "", toAbsoluteDirectory: documentsPath) { file in
                 log.debug("Matcher: \(file)")
-                return file.startsWith("browser.") || file.startsWith("logins.")
+                return file.startsWith("browser.") || file.startsWith("logins.") || file.startsWith("metadata.")
             }
         } catch {
             print("Couldn't export browser data: \(error).")

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -136,7 +136,7 @@ public struct AppConstants {
         #if MOZ_CHANNEL_RELEASE
             return false
         #elseif MOZ_CHANNEL_BETA
-            return false
+            return true
         #elseif MOZ_CHANNEL_NIGHTLY
             return true
         #elseif MOZ_CHANNEL_FENNEC


### PR DESCRIPTION
Our old highlights algo was pretty outdated. Desktop now fetches the last 500 sites and then ranks each site based on a few different pieces of information (last visit, metadata available) etc.

This isn't exactly like desktop but gets us closer to that. It fetches the last 100 recently visited that doesn't appear in topsites with fewer than 3 visits and then ranks them based on metadata.

I haven't updated the tests yet. But if the SQL makes sense I'll go ahead and do that. 

ps: In rewriting the original query I completely forgot about the original bug :P This PR prevents highlights from dropping right away but it could be better. 

Here is how desktop scores a link https://github.com/mozilla/activity-stream/blob/master/common/recommender/Baseline.js#L75