### PR TITLE
Bug 1357120 – Add 'FeatureSwitch' to enable AS for a partial audience.

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -219,6 +219,8 @@
 		39409A3F1C90E68300DAE683 /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288A2D861AB8B3260023ABC3 /* Shared.framework */; };
 		3943A81D1E9807C700D4F6DC /* FxAPushMessageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3943A81C1E9807C700D4F6DC /* FxAPushMessageTest.swift */; };
 		394CF6CF1BAA493C00906917 /* DefaultSuggestedSites.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394CF6CE1BAA493C00906917 /* DefaultSuggestedSites.swift */; };
+		3964B09A1EA8F06F00F2EEF4 /* FeatureSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3964B0991EA8F06F00F2EEF4 /* FeatureSwitch.swift */; };
+		3964B09C1EA8F32C00F2EEF4 /* FeatureSwitchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3964B09B1EA8F32C00F2EEF4 /* FeatureSwitchTests.swift */; };
 		39A359E41BFCCE94006B9E87 /* SpotlightHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A359E31BFCCE94006B9E87 /* SpotlightHelper.swift */; };
 		39A35AED1C0662A3006B9E87 /* SpotlightHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 39A35AEC1C0662A3006B9E87 /* SpotlightHelper.js */; };
 		39AC591A1CC574AB0042C2F5 /* HomePageSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39AC59191CC574AA0042C2F5 /* HomePageSettingsViewController.swift */; };
@@ -1414,6 +1416,8 @@
 		3943A81C1E9807C700D4F6DC /* FxAPushMessageTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxAPushMessageTest.swift; sourceTree = "<group>"; };
 		394CF6CE1BAA493C00906917 /* DefaultSuggestedSites.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultSuggestedSites.swift; sourceTree = "<group>"; };
 		395C8F201E796AD600A68E8C /* PushCrypto.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushCrypto.swift; sourceTree = "<group>"; };
+		3964B0991EA8F06F00F2EEF4 /* FeatureSwitch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeatureSwitch.swift; sourceTree = "<group>"; };
+		3964B09B1EA8F32C00F2EEF4 /* FeatureSwitchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeatureSwitchTests.swift; sourceTree = "<group>"; };
 		39A359E31BFCCE94006B9E87 /* SpotlightHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SpotlightHelper.swift; path = Helpers/SpotlightHelper.swift; sourceTree = "<group>"; };
 		39A35AEC1C0662A3006B9E87 /* SpotlightHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = SpotlightHelper.js; sourceTree = "<group>"; };
 		39AC59191CC574AA0042C2F5 /* HomePageSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomePageSettingsViewController.swift; sourceTree = "<group>"; };
@@ -3070,6 +3074,7 @@
 				E650756C1E37F7AB006961AC /* DeferredUtils.swift */,
 				E650756D1E37F7AB006961AC /* DeviceInfo.swift */,
 				E650756E1E37F7AB006961AC /* effective_tld_names.dat */,
+				3964B0991EA8F06F00F2EEF4 /* FeatureSwitch.swift */,
 				E65075811E37F7AB006961AC /* FSUtils.h */,
 				E65075821E37F7AB006961AC /* FSUtils.m */,
 				E65075831E37F7AB006961AC /* Functions.swift */,
@@ -3291,6 +3296,7 @@
 				3B4AA24A1D8B8C4C00A2E008 /* ArrayExtensionTests.swift */,
 				39E65D261CA5B92000C63CE3 /* AsyncReducerTests.swift */,
 				28786E541AB0F5FA009EA9EF /* DeferredTests.swift */,
+				3964B09B1EA8F32C00F2EEF4 /* FeatureSwitchTests.swift */,
 				E4E25CCA1CA99E7400D0F088 /* HexExtensionsTests.swift */,
 				E6F965411B2F25110034B023 /* NSMutableAttributedStringExtensionsTests.swift */,
 				E6F9653B1B2F1D5D0034B023 /* NSURLExtensionsTests.swift */,
@@ -4819,6 +4825,7 @@
 				E65075971E37F7AB006961AC /* AuthenticationKeychainInfo.swift in Sources */,
 				E65075A51E37F7AB006961AC /* NSFileManagerExtensions.swift in Sources */,
 				E65075A11E37F7AB006961AC /* HashExtensions.swift in Sources */,
+				3964B09A1EA8F06F00F2EEF4 /* FeatureSwitch.swift in Sources */,
 				E65075C91E37FBEF006961AC /* Telemetry.swift in Sources */,
 				E65075981E37F7AB006961AC /* Bytes.swift in Sources */,
 				E65075B11E37F7AB006961AC /* FSUtils.m in Sources */,
@@ -5147,6 +5154,7 @@
 				39E65D271CA5B92000C63CE3 /* AsyncReducerTests.swift in Sources */,
 				A826F0D21CBEB8160084CF9A /* PhoneNumberFormatterTests.swift in Sources */,
 				E4E7EB6D1C4AED5E0094275D /* SupportUtilsTests.swift in Sources */,
+				3964B09C1EA8F32C00F2EEF4 /* FeatureSwitchTests.swift in Sources */,
 				E4E25CCB1CA99E7400D0F088 /* HexExtensionsTests.swift in Sources */,
 				E6F965421B2F25110034B023 /* NSMutableAttributedStringExtensionsTests.swift in Sources */,
 				28532BE91C471FFB000072D9 /* ResultTests.swift in Sources */,

--- a/Client/Frontend/Home/HomePanels.swift
+++ b/Client/Frontend/Home/HomePanels.swift
@@ -20,7 +20,7 @@ class HomePanels {
     let enabledPanels = [
         HomePanelDescriptor(
             makeViewController: { profile in
-                if AppConstants.MOZ_AS_PANEL {
+                if FeatureSwitches.activityStream.isMember(profile.prefs) {
                     return ActivityStreamPanel(profile: profile)
                 } else {
                     return TopSitesPanel(profile: profile)

--- a/Shared/FeatureSwitch.swift
+++ b/Shared/FeatureSwitch.swift
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+/// Steadily growing set of feature switches controlling access to features by populations of Release users.
+open class FeatureSwitches {
+}
+
+/// Small class to allow a percentage of users to access a given feature.
+/// It is deliberately low tech, and is not remotely changeable.
+/// Randomized bucketing is only applied when the app's release build channel.
+open class FeatureSwitch {
+    let featureID: String
+    let buildChannel: AppBuildChannel
+    let nonChannelValue: Bool
+    let percentage: Int
+
+    init(named featureID: String, _ value: Bool = true, allowPercentage percentage: Int, buildChannel: AppBuildChannel = .release) {
+        self.featureID = featureID
+        self.percentage = percentage
+        self.buildChannel = buildChannel
+        self.nonChannelValue = value
+    }
+
+    /// Is this user a member of the bucket that is allowed to use this feature.
+    /// Bucketing is decided with the hash of a UUID, which is randomly generated and cached 
+    /// in the preferences.
+    /// This gives us stable properties across restarts and new releases.
+    open func isMember(_ prefs: Prefs) -> Bool {
+        // Only use bucketing if we're in the correct build channel, and feature flag is true.
+        guard buildChannel == AppConstants.BuildChannel, nonChannelValue else {
+            return nonChannelValue
+        }
+
+        // Use a branch of the prefs.
+        let uuidKey = "feature_switches/\(self.featureID)_uuid"
+
+        let uuidString: String
+        if let string = prefs.stringForKey(uuidKey) {
+            uuidString = string
+        } else {
+            uuidString = UUID().uuidString
+            prefs.setString(uuidString, forKey: uuidKey)
+        }
+
+        let hash = abs(uuidString.hashValue)
+        return hash % 100 < self.percentage
+    }
+}

--- a/Shared/FeatureSwitch.swift
+++ b/Shared/FeatureSwitch.swift
@@ -6,6 +6,8 @@ import Foundation
 
 /// Steadily growing set of feature switches controlling access to features by populations of Release users.
 open class FeatureSwitches {
+    open static let activityStream =
+        FeatureSwitch(named: "activity_stream", AppConstants.MOZ_AS_PANEL, allowPercentage: 10)
 }
 
 /// Small class to allow a percentage of users to access a given feature.

--- a/SharedTests/FeatureSwitchTests.swift
+++ b/SharedTests/FeatureSwitchTests.swift
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@testable import Shared
+import XCTest
+
+class FeatureSwitchTests: XCTestCase {
+    let buildChannel = AppConstants.BuildChannel
+
+    func testPersistent() {
+        let featureSwitch = FeatureSwitch(named: "test-persistent-over-restarts", allowPercentage: 50, buildChannel: buildChannel)
+        let prefs = MockProfilePrefs()
+        var membership = featureSwitch.isMember(prefs)
+        var changed = 0
+        for _ in 0..<100 {
+            if featureSwitch.isMember(prefs) != membership {
+                membership = !membership
+                changed += 1
+            }
+        }
+
+        XCTAssertEqual(changed, 0, "Users should get and keep the feature over restarts")
+    }
+
+    func testConsistentWhenChangingPercentage() {
+        let featureID = "test-persistent-over-releases"
+        let prefs = MockProfilePrefs()
+        var membership = false
+        var changed = 0
+        for percent in 0..<100 {
+            let featureSwitch = FeatureSwitch(named: featureID, allowPercentage: percent, buildChannel: buildChannel)
+            if featureSwitch.isMember(prefs) != membership {
+                membership = !membership
+                changed += 1
+            }
+        }
+
+        XCTAssertEqual(changed, 1, "Users should get and keep the feature if the feature is becoming successful")
+    }
+}
+
+extension FeatureSwitchTests {
+    func test0Percent() {
+        let featureSwitch = FeatureSwitch(named: "test-never", allowPercentage: 0, buildChannel: buildChannel)
+        testExactly(featureSwitch, expected: 0)
+        testApprox(featureSwitch, expected: 0)
+    }
+
+    func test100Percent() {
+        let featureSwitch = FeatureSwitch(named: "test-always", allowPercentage: 100, buildChannel: buildChannel)
+        testExactly(featureSwitch, expected: 100)
+        testApprox(featureSwitch, expected: 100)
+    }
+
+    func test50Percent() {
+        let featureSwitch = FeatureSwitch(named: "test-half-the-population", allowPercentage: 50, buildChannel: buildChannel)
+        testApprox(featureSwitch, expected: 50)
+    }
+
+    func test30Percent() {
+        let featureSwitch = FeatureSwitch(named: "test-30%-population", allowPercentage: 30, buildChannel: buildChannel)
+        testApprox(featureSwitch, expected: 30)
+    }
+
+    func testPerformance() {
+        let featureSwitch = FeatureSwitch(named: "test-30%-population", allowPercentage: 30, buildChannel: buildChannel)
+        let prefs = MockProfilePrefs()
+        measure {
+            for _ in 0..<1000 {
+                let _ = featureSwitch.isMember(prefs)
+            }
+        }
+    }
+
+    func testAppConstantsWin() {
+        // simulate in release channel, but switched off in AppConstants.
+        let featureFlaggedOff = FeatureSwitch(named: "test-release-flagged-off", false, allowPercentage: 100, buildChannel: buildChannel)
+        testExactly(featureFlaggedOff, expected: 0)
+
+        // simulate in non-release channel, but switched on in AppConstants.
+        let buildChannelAndFlaggedOn = FeatureSwitch(named: "test-flagged-on", true, allowPercentage: 0)
+        testExactly(buildChannelAndFlaggedOn, expected: 100)
+
+        // simulate in non-release channel, but switched off in AppConstants.
+        let buildChannelAndFlaggedOff = FeatureSwitch(named: "test-flagged-off", false, allowPercentage: 100)
+        testExactly(buildChannelAndFlaggedOff, expected: 0)
+    }
+}
+
+private extension FeatureSwitchTests {
+    func sampleN(_ featureSwitch: FeatureSwitch, testCount: Int = 1000) -> Int {
+        var count = 0
+        for _ in 0..<testCount {
+            let prefs = MockProfilePrefs()
+            if featureSwitch.isMember(prefs) {
+                count += 1
+            }
+        }
+        return count
+    }
+
+    func testExactly(_ featureSwitch: FeatureSwitch, expected: Int) {
+        let testCount = 10
+        let count = sampleN(featureSwitch, testCount: testCount)
+        let normalizedExpectedCount = (testCount * expected) / 100
+        XCTAssertEqual(count, normalizedExpectedCount)
+    }
+
+    func testApprox(_ featureSwitch: FeatureSwitch, expected: Int, epsilon: Int = 2) {
+        let testCount = 10000
+        let count = sampleN(featureSwitch, testCount: testCount)
+        let acceptableRange = Range(uncheckedBounds: (
+            lower: testCount * (expected - epsilon) / 100,
+            upper: testCount * (expected + epsilon) / 100))
+        
+        XCTAssertTrue(acceptableRange.contains(count), "\(count) in \(acceptableRange)?")
+    }
+}


### PR DESCRIPTION
This PR introduces a `FeatureSwitch`, which allows a feature to be switched on 
for a percentage of release users.

The switch is designed to be persitent across restarts and re-release of the app.

As the percentage of the population who have access to the feature grows, a given user's 
feature switch will only change once.

Its first use is for Activity Stream.

https://bugzilla.mozilla.org/show_bug.cgi?id=1357120