### PR TITLE
Bug 1358432 - Add to Bookmarks does not work from Share Extension

### DIFF
--- a/Extensions/ShareTo/InitialViewController.swift
+++ b/Extensions/ShareTo/InitialViewController.swift
@@ -66,14 +66,14 @@ class InitialViewController: UIViewController, ShareControllerDelegate {
             if destinations.contains(ShareDestinationReadingList) {
                 profile.readingList?.createRecordWithURL(item.url, title: item.title ?? "", addedBy: UIDevice.current.name)
             }
-            
+
             if destinations.contains(ShareDestinationBookmarks) {
-                profile.bookmarks.shareItem(item)
+                let _ = profile.bookmarks.shareItem(item).value // Blocks until database has settled
             }
 
             profile.shutdown()
 
-            self.extensionContext!.completeRequest(returningItems: [], completionHandler: nil)
+            self.finish()
         })
     }
     

--- a/Storage/Bookmarks/BookmarksModel.swift
+++ b/Storage/Bookmarks/BookmarksModel.swift
@@ -234,7 +234,7 @@ open class MemoryBookmarkFolder: BookmarkFolder, Sequence {
 open class MemoryBookmarksSink: ShareToDestination {
     var queue: [BookmarkNode] = []
     public init() { }
-    open func shareItem(_ item: ShareItem) {
+    open func shareItem(_ item: ShareItem) -> Success {
         let title = item.title == nil ? "Untitled" : item.title!
         func exists(_ e: BookmarkNode) -> Bool {
             if let bookmark = e as? BookmarkItem {
@@ -248,6 +248,8 @@ open class MemoryBookmarksSink: ShareToDestination {
         if !queue.contains(where: exists) {
             queue.append(BookmarkItem(guid: Bytes.generateGUID(), title: title, url: item.url))
         }
+
+        return succeed()
     }
 }
 
@@ -355,8 +357,8 @@ open class MockMemoryBookmarksStore: BookmarksModelFactory, ShareToDestination {
         return BookmarksModel(modelFactory: self, root: f)
     }
 
-    open func shareItem(_ item: ShareItem) {
-        self.sink.shareItem(item)
+    open func shareItem(_ item: ShareItem) -> Success {
+        return self.sink.shareItem(item)
     }
 
     open func isBookmarked(_ url: String) -> Deferred<Maybe<Bool>> {

--- a/Storage/SQL/SQLiteBookmarksHelpers.swift
+++ b/Storage/SQL/SQLiteBookmarksHelpers.swift
@@ -33,11 +33,12 @@ extension SQLiteBookmarks: ShareToDestination {
         }
     }
 
-    public func shareItem(_ item: ShareItem) {
+    public func shareItem(_ item: ShareItem) -> Success {
         // We parse here in anticipation of getting real URLs at some point.
         if let url = item.url.asURL {
             let title = item.title ?? url.absoluteString
-            let _ = self.addToMobileBookmarks(url, title: title, favicon: item.favicon)
+            return self.addToMobileBookmarks(url, title: title, favicon: item.favicon)
         }
+        return succeed()
     }
 }

--- a/Storage/SQL/SQLiteBookmarksSyncing.swift
+++ b/Storage/SQL/SQLiteBookmarksSyncing.swift
@@ -635,8 +635,8 @@ extension MergedSQLiteBookmarks: LocalItemSource {
 }
 
 extension MergedSQLiteBookmarks: ShareToDestination {
-    public func shareItem(_ item: ShareItem) {
-        self.local.shareItem(item)
+    public func shareItem(_ item: ShareItem) -> Success {
+        return self.local.shareItem(item)
     }
 }
 

--- a/Storage/Sharing.swift
+++ b/Storage/Sharing.swift
@@ -26,5 +26,5 @@ public struct ShareItem {
 }
 
 public protocol ShareToDestination {
-    func shareItem(_ item: ShareItem)
+    func shareItem(_ item: ShareItem) -> Success
 }


### PR DESCRIPTION
This patch makes `shareItem` return a `Success` (which is a `Deferred<Maybe<Void>>`) so that the caller can wait for asynchronous database operations to finish. Currently we just call `shareItem()` and then immediately `profile.shutdown()`, which is bad since we are still in the process of adding the bookmark. This patch makes it possible to properly wait.