### PR TITLE
Bug 1351310 – Rewrite LivePushClientTests so as not to deadlock.

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/FirefoxNightly.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/FirefoxNightly.xcscheme
@@ -48,9 +48,6 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "LivePushClientTests">
-               </Test>
-               <Test
                   Identifier = "SyncAuthStateTests/testLive()">
                </Test>
             </SkippedTests>


### PR DESCRIPTION
Re-enable it on FirefoxNightly.

https://bugzilla.mozilla.org/show_bug.cgi?id=1351310