### PR TITLE
Bug 1326564 - Instant AS Panel

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -672,6 +672,10 @@
 		E68E7ADA1CAC207400FDCA76 /* ChangePasscodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68E7AD91CAC207400FDCA76 /* ChangePasscodeViewController.swift */; };
 		E68E7ADC1CAC208200FDCA76 /* SetupPasscodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68E7ADB1CAC208200FDCA76 /* SetupPasscodeViewController.swift */; };
 		E68E7ADE1CAC208A00FDCA76 /* RemovePasscodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68E7ADD1CAC208A00FDCA76 /* RemovePasscodeViewController.swift */; };
+		E68F36981EA694000048CF44 /* PanelDataObservers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68F36971EA694000048CF44 /* PanelDataObservers.swift */; };
+		E68F36AB1EA698610048CF44 /* PanelDataObservers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68F36971EA694000048CF44 /* PanelDataObservers.swift */; };
+		E68F36AC1EA698610048CF44 /* PanelDataObservers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68F36971EA694000048CF44 /* PanelDataObservers.swift */; };
+		E68F36AD1EA698650048CF44 /* PanelDataObservers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68F36971EA694000048CF44 /* PanelDataObservers.swift */; };
 		E6927EC01C7B6FB800D03F75 /* ErrorToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6927EBF1C7B6FB800D03F75 /* ErrorToast.swift */; };
 		E692E3291C46E62D009D1240 /* AuthenticationSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E692E3281C46E62D009D1240 /* AuthenticationSettingsViewController.swift */; };
 		E692E3371C46E86A009D1240 /* AppSettingsOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E692E3361C46E86A009D1240 /* AppSettingsOptions.swift */; };
@@ -1880,6 +1884,7 @@
 		E68E7AD91CAC207400FDCA76 /* ChangePasscodeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChangePasscodeViewController.swift; sourceTree = "<group>"; };
 		E68E7ADB1CAC208200FDCA76 /* SetupPasscodeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SetupPasscodeViewController.swift; sourceTree = "<group>"; };
 		E68E7ADD1CAC208A00FDCA76 /* RemovePasscodeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemovePasscodeViewController.swift; sourceTree = "<group>"; };
+		E68F36971EA694000048CF44 /* PanelDataObservers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PanelDataObservers.swift; path = ../Client/Frontend/Home/PanelDataObservers.swift; sourceTree = "<group>"; };
 		E6927EBF1C7B6FB800D03F75 /* ErrorToast.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorToast.swift; sourceTree = "<group>"; };
 		E692E3281C46E62D009D1240 /* AuthenticationSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationSettingsViewController.swift; sourceTree = "<group>"; };
 		E692E3361C46E86A009D1240 /* AppSettingsOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppSettingsOptions.swift; sourceTree = "<group>"; };
@@ -2869,6 +2874,7 @@
 		D34DC84C1A16C40C00D49B7B /* Providers */ = {
 			isa = PBXGroup;
 			children = (
+				E68F36971EA694000048CF44 /* PanelDataObservers.swift */,
 				E60D03171D511398002FE3F6 /* SyncStatusResolver.swift */,
 				D34DC84D1A16C40C00D49B7B /* Profile.swift */,
 				0BD19A661A25309B0084FBA7 /* NSUserDefaultsPrefs.swift */,
@@ -5244,6 +5250,7 @@
 				E444F7E01B4B1C1A00FEB19B /* NSUserDefaultsPrefs.swift in Sources */,
 				E4BA8AA81B4B15EF00BC2E95 /* ActionRequestHandler.swift in Sources */,
 				E60D03281D511555002FE3F6 /* SyncStatusResolver.swift in Sources */,
+				E68F36AB1EA698610048CF44 /* PanelDataObservers.swift in Sources */,
 				E444F7E21B4B1C6800FEB19B /* SearchEngines.swift in Sources */,
 				E444F7DF1B4B1C1200FEB19B /* Profile.swift in Sources */,
 				E444F7E31B4B1C8000FEB19B /* OpenSearch.swift in Sources */,
@@ -5355,6 +5362,7 @@
 				E66C5B481BDA81050051AA93 /* UIImage+ImageEffects.m in Sources */,
 				E4CD9F6D1A77DD2800318571 /* ReaderModeStyleViewController.swift in Sources */,
 				E4A960061ABB9C450069AD6F /* ReaderModeUtils.swift in Sources */,
+				E68F36981EA694000048CF44 /* PanelDataObservers.swift in Sources */,
 				31ADB5DA1E58CEC300E87909 /* ClipboardBarDisplayHandler.swift in Sources */,
 				745DAB3F1CDAB09E00D44181 /* HistoryBackButton.swift in Sources */,
 				D3B6923F1B9F9A58004B87A4 /* FindInPageHelper.swift in Sources */,
@@ -5581,6 +5589,7 @@
 				D38B2D8C1A8D98D90040E6B5 /* OpenSearch.swift in Sources */,
 				E418D0D91A251B3200CAE47A /* Profile.swift in Sources */,
 				F8708D321A0970B70051AB07 /* ShareViewController.swift in Sources */,
+				E68F36AD1EA698650048CF44 /* PanelDataObservers.swift in Sources */,
 				28CDA55C1A43C37C005C318C /* NSUserDefaultsPrefs.swift in Sources */,
 				E60D03271D511554002FE3F6 /* SyncStatusResolver.swift in Sources */,
 				E41A7D4B1A1BE04500245963 /* InitialViewController.swift in Sources */,
@@ -5597,6 +5606,7 @@
 				D38B2D8D1A8D98DA0040E6B5 /* OpenSearch.swift in Sources */,
 				E4BCAAB91B0537E300855D82 /* InstructionsViewController.swift in Sources */,
 				E42CCDE81A23A73D00B794D3 /* Profile.swift in Sources */,
+				E68F36AC1EA698610048CF44 /* PanelDataObservers.swift in Sources */,
 				E4BCAAD91B05380B00855D82 /* ClientPickerViewController.swift in Sources */,
 				FA6B2AC31D41F02D00429414 /* Punycode.swift in Sources */,
 				F8708D2A1A0970B40051AB07 /* ActionViewController.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -571,6 +571,7 @@
 		E60D032A1D5118DB002FE3F6 /* SyncStatusResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60D03291D5118DB002FE3F6 /* SyncStatusResolverTests.swift */; };
 		E6108FF91C84E91C005D25E8 /* BasePasscodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6108FF81C84E91C005D25E8 /* BasePasscodeViewController.swift */; };
 		E61453BE1B750A1700C3F9D7 /* RollingFileLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61453BD1B750A1700C3F9D7 /* RollingFileLoggerTests.swift */; };
+		E61D11681EAF8F43008A305B /* PanelDataObserversTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61D11671EAF8F43008A305B /* PanelDataObserversTests.swift */; };
 		E6231C011B90A44F005ABB0D /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E6231C001B90A44F005ABB0D /* libz.tbd */; };
 		E6231C031B90A466005ABB0D /* libstdc++.6.0.9.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E6231C021B90A466005ABB0D /* libstdc++.6.0.9.tbd */; };
 		E6231C051B90A472005ABB0D /* libxml2.2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E6231C041B90A472005ABB0D /* libxml2.2.tbd */; };
@@ -1771,6 +1772,7 @@
 		E6108FF81C84E91C005D25E8 /* BasePasscodeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasePasscodeViewController.swift; sourceTree = "<group>"; };
 		E61453BD1B750A1700C3F9D7 /* RollingFileLoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RollingFileLoggerTests.swift; sourceTree = "<group>"; };
 		E619FB2F1E292BE100882B20 /* signedInUser.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = signedInUser.json; sourceTree = "<group>"; };
+		E61D11671EAF8F43008A305B /* PanelDataObserversTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PanelDataObserversTests.swift; sourceTree = "<group>"; };
 		E6231C001B90A44F005ABB0D /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		E6231C021B90A466005ABB0D /* libstdc++.6.0.9.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libstdc++.6.0.9.tbd"; path = "usr/lib/libstdc++.6.0.9.tbd"; sourceTree = SDKROOT; };
 		E6231C041B90A472005ABB0D /* libxml2.2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxml2.2.tbd; path = usr/lib/libxml2.2.tbd; sourceTree = SDKROOT; };
@@ -3504,6 +3506,7 @@
 				7BC7B4BD1C904BF90046E9D2 /* MenuTests.swift */,
 				281B2BE91ADF4D90002917DC /* MockProfile.swift */,
 				E683F0A51E92E0820035D990 /* MockableHistory.swift */,
+				E61D11671EAF8F43008A305B /* PanelDataObserversTests.swift */,
 				E6C70E811E28314700F8DB57 /* PingCentreTests.swift */,
 				2FDB10921A9FBEC5006CF312 /* PrefsTests.swift */,
 				0BA896491A250E6500C1010C /* ProfileTest.swift */,
@@ -5573,6 +5576,7 @@
 				2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */,
 				4A59B58AD11B5EE1F80BBDEB /* TestHistory.swift in Sources */,
 				A83E5B1D1C1DA8D80026D912 /* UIPasteboardExtensionsTests.swift in Sources */,
+				E61D11681EAF8F43008A305B /* PanelDataObserversTests.swift in Sources */,
 				28D52E2F1BCDF53900187A1D /* ResetTests.swift in Sources */,
 				E696FE511C47F86E00EC007C /* AuthenticatorTests.swift in Sources */,
 				3B6F40181DC7849C00656CC6 /* ActivityStreamTests.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -181,6 +181,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         let fxaLoginHelper = FxALoginHelper.sharedInstance
         fxaLoginHelper.application(application, didLoadProfile: profile)
 
+        // Run an invalidate when we come back into the app.
+        profile.panelDataObservers.activityStream.invalidate()
+
         log.debug("Done with setting up the application.")
         return true
     }

--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -376,9 +376,12 @@ extension ActivityStreamPanel: ActivityStreamDataDelegate {
     }
 
     func getHighlights() -> Success {
-        return self.profile.recommendations.getHighlights() >>== { cursor in
+        return self.profile.recommendations.getHighlights().bindQueue(.main) { result in
             // Scan through the fetched highlights and report on anything that might be missing.
-            let highlights = cursor.asArray()
+            guard let highlights = result.successValue?.asArray() else {
+                return succeed()
+            }
+            
             self.reportMissingData(sites: highlights, source: .Highlights)
             self.highlights = highlights
             return succeed()
@@ -386,8 +389,11 @@ extension ActivityStreamPanel: ActivityStreamDataDelegate {
     }
 
     func getTopSites() -> Success {
-        return self.profile.history.getTopSitesWithLimit(16) >>== { topSites in
-            let mySites = topSites.asArray()
+        return self.profile.history.getTopSitesWithLimit(16).bindQueue(.main) { result in
+            guard let mySites = result.successValue?.asArray() else {
+                return succeed()
+            }
+            
             let defaultSites = self.defaultTopSites()
 
             // Merge default topsites with a user's topsites.

--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -371,6 +371,7 @@ extension ActivityStreamPanel: ActivityStreamDataDelegate {
     // See ActivityStreamDataObserver for invalidation logic.
     func reloadAll() {
         accumulate([self.getHighlights, self.getTopSites]).uponQueue(DispatchQueue.main) { _ in
+            self.isInitialLoad = false
             self.collectionView?.reloadData()
         }
     }

--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -354,7 +354,7 @@ extension ActivityStreamPanel {
 }
 
 // MARK: - Data Management
-extension ActivityStreamPanel: ActivityStreamDataDelegate {
+extension ActivityStreamPanel: DataObserverDelegate {
     fileprivate func reportMissingData(sites: [Site], source: ASPingSource) {
         sites.forEach { site in
             if site.metadata?.mediaURL == nil {

--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -16,7 +16,6 @@ private let DefaultSuggestedSitesKey = "topSites.deletedSuggestedSites"
 // MARK: -  Lifecycle
 struct ASPanelUX {
     static let backgroundColor = UIColor(white: 1.0, alpha: 0.5)
-    static let topSitesCacheSize = 16
     static let historySize = 10
     static let rowSpacing: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 30 : 20
     static let highlightCellHeight: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 250 : 195
@@ -35,8 +34,6 @@ class ActivityStreamPanel: UICollectionViewController, HomePanel {
 
     fileprivate let topSitesManager = ASHorizontalScrollCellManager()
     fileprivate var isInitialLoad = true //Prevents intro views from flickering while content is loading
-    fileprivate let events = [NotificationFirefoxAccountChanged, NotificationProfileDidFinishSyncing, NotificationPrivateDataClearedHistory, NotificationDynamicFontChanged]
-
     fileprivate var sessionStart: Timestamp?
 
     lazy var longPressRecognizer: UILongPressGestureRecognizer = {
@@ -61,12 +58,16 @@ class ActivityStreamPanel: UICollectionViewController, HomePanel {
         self.collectionView?.dataSource = self
 
         collectionView?.addGestureRecognizer(longPressRecognizer)
-        self.profile.history.setTopSitesCacheSize(Int32(ASPanelUX.topSitesCacheSize))
-        events.forEach { NotificationCenter.default.addObserver(self, selector: #selector(self.notificationReceived(_:)), name: $0, object: nil) }
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(didChangeFontSize(notification:)),
+                                               name: NotificationDynamicFontChanged,
+                                               object: nil)
+        
     }
 
     deinit {
-        events.forEach { NotificationCenter.default.removeObserver(self, name: $0, object: nil) }
+        NotificationCenter.default.removeObserver(self, name: NotificationDynamicFontChanged, object: nil)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -81,16 +82,14 @@ class ActivityStreamPanel: UICollectionViewController, HomePanel {
 
         collectionView?.backgroundColor = ASPanelUX.backgroundColor
         collectionView?.keyboardDismissMode = .onDrag
+        
+        self.profile.panelDataObservers.activityStream.delegate = self
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         sessionStart = Date.now()
-
-        all([invalidateTopSites(), invalidateHighlights()]).uponQueue(DispatchQueue.main) { _ in
-            self.isInitialLoad = false
-            self.collectionView?.reloadData()
-        }
+        reloadAll()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -110,6 +109,11 @@ class ActivityStreamPanel: UICollectionViewController, HomePanel {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         self.topSitesManager.currentTraits = self.traitCollection
+    }
+
+    func didChangeFontSize(notification: Notification) {
+        // Don't need to invalidate the data for a font change. Just reload the UI.
+        reloadAll()
     }
 }
 
@@ -350,21 +354,7 @@ extension ActivityStreamPanel {
 }
 
 // MARK: - Data Management
-extension ActivityStreamPanel {
-
-    func notificationReceived(_ notification: Notification) {
-        switch notification.name {
-        case NotificationProfileDidFinishSyncing, NotificationFirefoxAccountChanged, NotificationPrivateDataClearedHistory, NotificationDynamicFontChanged:
-            DispatchQueue.main.async {
-                all([self.invalidateTopSites(), self.invalidateHighlights()]).uponQueue(DispatchQueue.main) { _ in
-                    self.collectionView?.reloadData()
-                }
-            }
-        default:
-            log.warning("Received unexpected notification \(notification.name)")
-        }
-    }
-
+extension ActivityStreamPanel: ActivityStreamDataDelegate {
     fileprivate func reportMissingData(sites: [Site], source: ASPingSource) {
         sites.forEach { site in
             if site.metadata?.mediaURL == nil {
@@ -377,53 +367,64 @@ extension ActivityStreamPanel {
         }
     }
 
-    func invalidateHighlights() -> Success {
-        return self.profile.recommendations.getHighlights().bindQueue(DispatchQueue.main) { result in
-            if let newHighlights = result.successValue?.asArray() {
-                // Scan through the fetched highlights and report on anything that might be missing.
-                self.reportMissingData(sites: newHighlights, source: .Highlights)
-                self.highlights = newHighlights
-            }
+    // Reloads both highlights and top sites data from their respective caches. Does not invalidate the cache.
+    // See ActivityStreamDataObserver for invalidation logic.
+    func reloadAll() {
+        accumulate([self.getHighlights, self.getTopSites]).uponQueue(DispatchQueue.main) { _ in
+            self.collectionView?.reloadData()
+        }
+    }
+
+    func getHighlights() -> Success {
+        return self.profile.recommendations.getHighlights() >>== { cursor in
+            // Scan through the fetched highlights and report on anything that might be missing.
+            let highlights = cursor.asArray()
+            self.reportMissingData(sites: highlights, source: .Highlights)
+            self.highlights = highlights
             return succeed()
         }
     }
 
-    func invalidateTopSites() -> Success {
-        let frecencyLimit = ASPanelUX.topSitesCacheSize
-        // Update our top sites cache if it's been invalidated
-        return self.profile.history.updateTopSitesCacheIfInvalidated() >>== { _ in
-            return self.profile.history.getTopSitesWithLimit(frecencyLimit).bindQueue(DispatchQueue.main) { result in
-                guard let topSites = result.successValue else {
-                    return succeed()
-                }
-                let mySites = topSites.asArray()
-                let defaultSites = self.defaultTopSites()
+    func getTopSites() -> Success {
+        return self.profile.history.getTopSitesWithLimit(16) >>== { topSites in
+            let mySites = topSites.asArray()
+            let defaultSites = self.defaultTopSites()
 
-                // Merge default topsites with a user's topsites.
-                let mergedSites = mySites.union(defaultSites, f: { (site) -> String in
-                    return URL(string: site.url)?.hostSLD ?? ""
-                })
+            // Merge default topsites with a user's topsites.
+            let mergedSites = mySites.union(defaultSites, f: { (site) -> String in
+                return URL(string: site.url)?.hostSLD ?? ""
+            })
 
-                // Favour topsites from defaultSites as they have better favicons.
-                let newSites = mergedSites.map { site -> Site in
-                    let domain = URL(string: site.url)?.hostSLD
-                    return defaultSites.find { $0.title.lowercased() == domain } ?? site
-                }
-
-                // Don't report bad states for default sites we provide
-                self.reportMissingData(sites: mySites, source: .TopSites)
-
-                self.topSitesManager.currentTraits = self.view.traitCollection
-                self.topSitesManager.content = newSites.count > ASPanelUX.topSitesCacheSize ? Array(newSites[0..<ASPanelUX.topSitesCacheSize]) : newSites
-                self.topSitesManager.urlPressedHandler = { [unowned self] url, indexPath in
-                    self.longPressRecognizer.isEnabled = false
-                    self.telemetry.reportEvent(.Click, source: .TopSites, position: indexPath.item)
-                    self.showSiteWithURLHandler(url as URL)
-                }
-
-                return succeed()
+            // Favour topsites from defaultSites as they have better favicons.
+            let newSites = mergedSites.map { site -> Site in
+                let domain = URL(string: site.url)?.hostSLD
+                return defaultSites.find { $0.title.lowercased() == domain } ?? site
             }
+
+            // Don't report bad states for default sites we provide
+            self.reportMissingData(sites: mySites, source: .TopSites)
+
+            self.topSitesManager.currentTraits = self.view.traitCollection
+
+            if newSites.count > Int(ActivityStreamTopSiteCacheSize) {
+                self.topSitesManager.content = Array(newSites[0..<Int(ActivityStreamTopSiteCacheSize)])
+            } else {
+                self.topSitesManager.content = newSites
+            }
+
+            self.topSitesManager.urlPressedHandler = { [unowned self] url, indexPath in
+                self.longPressRecognizer.isEnabled = false
+                self.telemetry.reportEvent(.Click, source: .TopSites, position: indexPath.item)
+                self.showSiteWithURLHandler(url as URL)
+            }
+
+            return succeed()
         }
+    }
+
+    // Invoked by the ActivityStreamDataObserver when highlights/top sites invalidation is complete.
+    func didInvalidateDataSources() {
+        reloadAll()
     }
 
     func hideURLFromTopSites(_ siteURL: URL) {
@@ -437,18 +438,14 @@ extension ActivityStreamPanel {
         }
         profile.history.removeHostFromTopSites(host).uponQueue(DispatchQueue.main) { result in
             guard result.isSuccess else { return }
-            self.invalidateTopSites().uponQueue(DispatchQueue.main) { _ in
-                self.collectionView?.reloadData()
-            }
+            self.profile.panelDataObservers.activityStream.invalidate()
         }
     }
 
     func hideFromHighlights(_ site: Site) {
         profile.recommendations.removeHighlightForURL(site.url).uponQueue(DispatchQueue.main) { result in
             guard result.isSuccess else { return }
-            self.invalidateHighlights().uponQueue(DispatchQueue.main) { _ in
-                self.collectionView?.reloadData()
-            }
+            self.profile.panelDataObservers.activityStream.invalidate()
         }
     }
 

--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -142,6 +142,9 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
         let dismissKeyboardGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(HomePanelViewController.SELhandleDismissKeyboardGestureRecognizer(_:)))
         dismissKeyboardGestureRecognizer.cancelsTouchesInView = false
         buttonContainerView.addGestureRecognizer(dismissKeyboardGestureRecognizer)
+
+        // Invalidate our activity stream data sources whenever we open up the home panels
+        self.profile.panelDataObservers.activityStream.invalidate()
     }
 
     fileprivate func updateAppState() {

--- a/Client/Frontend/Home/PanelDataObservers.swift
+++ b/Client/Frontend/Home/PanelDataObservers.swift
@@ -11,21 +11,28 @@ public let ActivityStreamTopSiteCacheSize: Int32 = 16
 
 private let log = Logger.browserLogger
 
-class PanelDataObservers {
-    let activityStream: ActivityStreamDataObserver
+protocol DataObserver {
+    var profile: Profile { get }
+    weak var delegate: DataObserverDelegate? { get set }
+    
+    func invalidate()
+}
+
+@objc protocol DataObserverDelegate: class {
+    func didInvalidateDataSources()
+}
+
+open class PanelDataObservers {
+    var activityStream: DataObserver
 
     init(profile: Profile) {
         self.activityStream = ActivityStreamDataObserver(profile: profile)
     }
 }
 
-@objc protocol ActivityStreamDataDelegate: class {
-    func didInvalidateDataSources()
-}
-
-class ActivityStreamDataObserver {
+class ActivityStreamDataObserver: DataObserver {
     let profile: Profile
-    weak var delegate: ActivityStreamDataDelegate?
+    weak var delegate: DataObserverDelegate?
 
     fileprivate let events = [NotificationFirefoxAccountChanged, NotificationProfileDidFinishSyncing, NotificationPrivateDataClearedHistory]
 

--- a/Client/Frontend/Home/PanelDataObservers.swift
+++ b/Client/Frontend/Home/PanelDataObservers.swift
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Deferred
+import Shared
+
+public let NotificationASPanelDataInvalidated = Notification.Name("NotificationASPanelDataInvalidated")
+private let log = Logger.browserLogger
+
+struct PanelDataObservers {
+    let activityStream: ActivityStreamDataObserver
+}
+
+protocol ActivityStreamDataDelegate: class {
+    func didInvalidateDataSources()
+}
+
+class ActivityStreamDataObserver {
+    let profile: Profile
+    weak var delegate: ActivityStreamDataDelegate?
+
+    fileprivate let events = [NotificationFirefoxAccountChanged, NotificationProfileDidFinishSyncing, NotificationPrivateDataClearedHistory, NotificationDynamicFontChanged]
+
+    init(profile: Profile) {
+        self.profile = profile
+        events.forEach { NotificationCenter.default.addObserver(self, selector: #selector(self.notificationReceived(_:)), name: $0, object: nil) }
+    }
+
+    deinit {
+        events.forEach { NotificationCenter.default.removeObserver(self, name: $0, object: nil) }
+    }
+    
+    func invalidate() {
+        let notify = {
+            self.delegate?.didInvalidateDataSources()
+        }
+        
+        let invalidateTopSites: () -> Success = {
+            self.profile.history.setTopSitesNeedsInvalidation()
+            return self.profile.history.updateTopSitesCacheIfInvalidated() >>> succeed
+        }
+
+        accumulate([self.profile.recommendations.invalidateHighlights, invalidateTopSites]) >>> effect(notify)
+    }
+    
+    @objc func notificationReceived(_ notification: Notification) {
+        switch notification.name {
+        case NotificationProfileDidFinishSyncing, NotificationFirefoxAccountChanged, NotificationPrivateDataClearedHistory, NotificationDynamicFontChanged:
+            invalidate()
+        default:
+            log.warning("Received unexpected notification \(notification.name)")
+        }
+    }
+}

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -399,7 +399,7 @@ class ExportBrowserDataSetting: HiddenSetting {
             let log = Logger.syncLogger
             try self.settings.profile.files.copyMatching(fromRelativeDirectory: "", toAbsoluteDirectory: documentsPath) { file in
                 log.debug("Matcher: \(file)")
-                return file.startsWith("browser.") || file.startsWith("logins.")
+                return file.startsWith("browser.") || file.startsWith("logins.") || file.startsWith("metadata.")
             }
         } catch {
             print("Couldn't export browser data: \(error).")

--- a/ClientTests/ActivityStreamTests.swift
+++ b/ClientTests/ActivityStreamTests.swift
@@ -170,7 +170,7 @@ extension ActivityStreamTests {
         // simply call .value on this to block since the app will dead lock when
         // trying to call back onto a blocked main thread.
         let expect = XCTestExpectation(description: "Sent bad highlight pings")
-        panel.invalidateHighlights() >>> {
+        panel.getHighlights() >>> {
             expect.fulfill()
         }
 
@@ -201,7 +201,7 @@ extension ActivityStreamTests {
         // simply call .value on this to block since the app will dead lock when
         // trying to call back onto a blocked main thread.
         let expect = XCTestExpectation(description: "Sent bad top site pings")
-        panel.invalidateTopSites() >>> {
+        panel.getTopSites() >>> {
             expect.fulfill()
         }
 
@@ -226,6 +226,11 @@ class MockPingClient: PingCentreClient {
 }
 
 fileprivate class MockRecommender: HistoryRecommendations {
+    func invalidateHighlights() -> Success {
+        // no-op since we don't need to purge a cache for our mock recommender
+        return succeed()
+    }
+
     var highlights: [Site]
 
     init(highlights: [Site]) {

--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -73,12 +73,35 @@ open class MockTabQueue: TabQueue {
     }
 }
 
+open class MockPanelDataObservers: PanelDataObservers {
+    override init(profile: Profile) {
+        super.init(profile: profile)
+        self.activityStream = MockActivityStreamDataObserver(profile: profile)
+    }
+}
+
+open class MockActivityStreamDataObserver: DataObserver {
+    public var profile: Profile
+    public weak var delegate: DataObserverDelegate?
+
+    init(profile: Profile) {
+        self.profile = profile
+    }
+    
+    public func invalidate() {
+        // no-op
+    }
+}
+
 open class MockProfile: Profile {
     // Read/Writeable properties for mocking
     public var recommendations: HistoryRecommendations
     public var places: BrowserHistory & Favicons & SyncableHistory & ResettableSyncStorage & HistoryRecommendations
     public var files: FileAccessor
     public var history: BrowserHistory & SyncableHistory & ResettableSyncStorage
+    public lazy var panelDataObservers: PanelDataObservers = {
+        return MockPanelDataObservers(profile: self)
+    }()
 
     var db: BrowserDB
 

--- a/ClientTests/PanelDataObserversTests.swift
+++ b/ClientTests/PanelDataObserversTests.swift
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import XCTest
+@testable import Client
+
+private class MockDataObserverDelegate: DataObserverDelegate {
+    var delegateCalledCount = 0
+
+    func didInvalidateDataSources() {
+        delegateCalledCount += 1
+    }
+}
+
+class PanelDataObserversTests: XCTestCase {
+    func testActivityStreamDelegates() {
+        let profile = MockProfile()
+        let observer = ActivityStreamDataObserver(profile: profile)
+        let delegate = MockDataObserverDelegate()
+        observer.delegate = delegate
+
+        NotificationCenter.default.post(name: NotificationFirefoxAccountChanged,
+                                        object: nil)
+        NotificationCenter.default.post(name: NotificationProfileDidFinishSyncing,
+                                        object: nil)
+        NotificationCenter.default.post(name: NotificationPrivateDataClearedHistory,
+                                        object: nil)
+
+        waitForCondition(timeout: 5) { delegate.delegateCalledCount == 3 }
+    }
+}

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -151,6 +151,7 @@ protocol Profile: class {
     var logins: BrowserLogins & SyncableLogins & ResettableSyncStorage { get }
     var certStore: CertStore { get }
     var recentlyClosedTabs: ClosedTabsStore { get }
+    var panelDataObservers: PanelDataObservers { get }
 
     var isShutdown: Bool { get }
     
@@ -406,6 +407,10 @@ open class BrowserProfile: Profile {
     var history: BrowserHistory & SyncableHistory & ResettableSyncStorage {
         return self.places
     }
+
+    lazy var panelDataObservers: PanelDataObservers = {
+        return PanelDataObservers(profile: self)
+    }()
 
     lazy var metadata: Metadata = {
         return SQLiteMetadata(db: self.db)

--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -45,6 +45,7 @@ public protocol BrowserHistory {
 public protocol HistoryRecommendations {
     func getHighlights() -> Deferred<Maybe<Cursor<Site>>>
     func removeHighlightForURL(_ url: String) -> Success
+    func invalidateHighlights() -> Success
 }
 
 /**

--- a/Storage/SQL/BrowserTable.swift
+++ b/Storage/SQL/BrowserTable.swift
@@ -293,17 +293,7 @@ open class BrowserTable: Table {
             "guid TEXT," +
             "visitCount INTEGER," +
             "visitDate DATETIME," +
-            "is_bookmarked INTEGER," +
-            "iconID INTEGER," +
-            "iconURL TEXT," +
-            "iconType INTEGER," +
-            "iconDate DATETIME," +
-            "iconWidth INTEGER," +
-            "metadata_title TEXT," +
-            "media_url TEXT," +
-            "type INTEGER," +
-            "description TEXT," +
-            "provider_name TEXT" +
+            "is_bookmarked INTEGER" +
     ") "
 
     let indexPageMetadataCacheKeyCreate =

--- a/Storage/SQL/BrowserTable.swift
+++ b/Storage/SQL/BrowserTable.swift
@@ -305,7 +305,6 @@ open class BrowserTable: Table {
             "description TEXT," +
             "provider_name TEXT" +
     ") "
-    
 
     let indexPageMetadataCacheKeyCreate =
     "CREATE UNIQUE INDEX IF NOT EXISTS \(IndexPageMetadataCacheKey) ON page_metadata (cache_key)"

--- a/Storage/SQL/SQLiteHistoryRecommendations.swift
+++ b/Storage/SQL/SQLiteHistoryRecommendations.swift
@@ -47,7 +47,7 @@ extension SQLiteHistory: HistoryRecommendations {
         return self.db.run([("INSERT INTO \(TableActivityStreamBlocklist) (url) VALUES (?)", [url])])
     }
 
-    private func clearHighlights() -> Success {
+    public func clearHighlights() -> Success {
         return self.db.run("DELETE FROM \(AttachedTableHighlights)", withArgs: nil)
     }
 

--- a/StorageTests/TestSQLiteHistoryRecommendations.swift
+++ b/StorageTests/TestSQLiteHistoryRecommendations.swift
@@ -293,7 +293,7 @@ class TestSQLiteHistoryRecommendationsPerf: XCTestCase {
         let history = SQLiteHistory(db: db, prefs: prefs)
         let bookmarks = SQLiteBookmarkBufferStorage(db: db)
 
-        let count = 500
+        let count = 5000
 
         history.clearHistory().succeeded()
         populateForRecommendationCalculations(history, bookmarks: bookmarks, historyCount: count, bookmarkCount: count)

--- a/StorageTests/TestSQLiteHistoryRecommendations.swift
+++ b/StorageTests/TestSQLiteHistoryRecommendations.swift
@@ -72,6 +72,7 @@ class TestSQLiteHistoryRecommendations: XCTestCase {
         history.addLocalVisit(siteVisitD3).succeeded()
         history.addLocalVisit(siteVisitD4).succeeded()
 
+        history.invalidateHighlights().succeeded()
         let highlights = history.getHighlights().value.successValue!
         XCTAssertEqual(highlights.count, 2)
         XCTAssertEqual(highlights[0]!.title, "A")
@@ -132,6 +133,7 @@ class TestSQLiteHistoryRecommendations: XCTestCase {
         history.addLocalVisit(bookmarkVisitB3).succeeded()
         history.addLocalVisit(bookmarkVisitB4).succeeded()
 
+        history.invalidateHighlights().succeeded()
         let highlights = history.getHighlights().value.successValue!
         XCTAssertEqual(highlights.count, 1)
         XCTAssertEqual(highlights[0]!.title, "A Bookmark")
@@ -189,6 +191,7 @@ class TestSQLiteHistoryRecommendations: XCTestCase {
         history.addLocalVisit(siteVisitD3).succeeded()
         history.addLocalVisit(siteVisitD4).succeeded()
 
+        history.invalidateHighlights().succeeded()
         let highlights = history.getHighlights().value.successValue!
         XCTAssertEqual(highlights.count, 0)
     }
@@ -224,6 +227,7 @@ class TestSQLiteHistoryRecommendations: XCTestCase {
         history.addLocalVisit(siteVisitC1).succeeded()
         history.addLocalVisit(siteVisitC2).succeeded()
 
+        history.invalidateHighlights().succeeded()
         let highlights = history.getHighlights().value.successValue!
         XCTAssertEqual(highlights.count, 1)
         XCTAssertEqual(highlights[0]!.title, "A")
@@ -270,6 +274,7 @@ class TestSQLiteHistoryRecommendations: XCTestCase {
                                  title: siteC.title, description: "Test Description", type: nil, providerName: nil, mediaDataURI: nil, cacheImages: false)
         metadata.storeMetadata(pageC, forPageURL: siteC.url.asURL!, expireAt: Date.now() + 3000).succeeded()
 
+        history.invalidateHighlights().succeeded()
         let highlights = history.getHighlights().value.successValue!
         XCTAssertEqual(highlights.count, 3)
 


### PR DESCRIPTION
This patch addresses the issue of slow rendering times when populating the top sites and highlights on the Activity Stream panel. By their design, the queries for generating highlights and top sites are complex. Instead of trying to optimize or pare down the query, a highlights table is introduced which caches the results of the highlights algorithm instead of generating the highlights set on demand. 

With the cache in place, the logic for fetching highlights/top sites can be decoupled from the actual generation of highlights. To handle this decoupling, I've moved out the timing/logic for invalidating the cache data from the panel into a `DataObserver` class which is attached to the profile. This has a few benefits:

1. Instead of the panel being responsible for responding to invalidation events, the observer funnels all possible events into a single `didInvalidateDataSources` delegate invocation.
2. The invalidation of the data is no longer tied to the view controller life cycle of the panel. This let's us invalidate ahead of time allowing the wait time for getting a new set of highlights to occur behind the scenes.

I don't see this as an overall data strategy for the app - just something that we can use for now to resolve the timing issue on the panel. It kind of feels shoehorned in but seems to work pretty well for what it needs to do!