### PR TITLE
Bug 1358929 - Browser does not recognize schemes like tel: anymore

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2273,7 +2273,7 @@ extension BrowserViewController: WKNavigationDelegate {
         // gives us the exact same behaviour as Safari.
 
         if url.scheme == "tel" || url.scheme == "facetime" || url.scheme == "facetime-audio" {
-            if let phoneNumber = url.path.removingPercentEncoding, !phoneNumber.isEmpty {
+            if let components = NSURLComponents(url: url, resolvingAgainstBaseURL: false), let phoneNumber = components.path, !phoneNumber.isEmpty {
                 let formatter = PhoneNumberFormatter()
                 let formattedPhoneNumber = formatter.formatPhoneNumber(phoneNumber)
                 let alert = UIAlertController(title: formattedPhoneNumber, message: nil, preferredStyle: UIAlertControllerStyle.alert)


### PR DESCRIPTION
It seems that in newer iOS SDK versions, `NSURL.path` does not return return the *resource* part of URLs like `tel:1234` or `mailto:example@example.com` anymore.

There is a bug on file on the Swift project tracker for this: https://bugs.swift.org/browse/SR-2252

This patch works around this problem by using `NSURLComponents`. That API does make the resource available via `NSURLComponents.path`.

> Note: this may not be a problem anymore in Xcode 8.3.2, but v7.x is still using 8.2.1.
