### PR TITLE
No Bug - Set Codecov token as env var

### DIFF
--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-bash <(curl -s https://codecov.io/bash) -t ec35cfc1-81ac-4819-bb66-0c4ef2ce6602
+bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
If this works too is better to save the token as an env var in bb 