### PR TITLE
Bug 1350861 SendTo Crash

### DIFF
--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -209,6 +209,7 @@ open class MockProfile: Profile {
         return deferMaybe(0)
     }
 
-    public func sendItems(_ items: [ShareItem], toClients clients: [RemoteClient]) {
+    public func sendItems(_ items: [ShareItem], toClients clients: [RemoteClient]) -> Deferred<Maybe<SyncStatus>> {
+        return deferMaybe(SyncStatus.notStarted(.offline))
     }
 }

--- a/Extensions/SendTo/ActionViewController.swift
+++ b/Extensions/SendTo/ActionViewController.swift
@@ -49,10 +49,17 @@ class ActionViewController: UIViewController, ClientPickerViewControllerDelegate
     }
 
     func clientPickerViewController(_ clientPickerViewController: ClientPickerViewController, didPickClients clients: [RemoteClient]) {
-        // TODO
-        finish()
+        guard let item = sharedItem else {
+            return finish()
+        }
+
+        let profile = BrowserProfile(localName: "profile", app: nil) // TODO Will this be owned?
+        profile.sendItems([item], toClients: clients).uponQueue(DispatchQueue.main) { result in
+            profile.shutdown()
+            self.finish()
+        }
     }
-    
+
     func clientPickerViewControllerDidCancel(_ clientPickerViewController: ClientPickerViewController) {
         finish()
     }

--- a/Extensions/SendTo/ActionViewController.swift
+++ b/Extensions/SendTo/ActionViewController.swift
@@ -39,6 +39,7 @@ class ActionViewController: UIViewController, ClientPickerViewControllerDelegate
             self.sharedItem = item
             let clientPickerViewController = ClientPickerViewController()
             clientPickerViewController.clientPickerDelegate = self
+            clientPickerViewController.profile = nil // This means the picker will open and close the default profile
             let navigationController = UINavigationController(rootViewController: clientPickerViewController)
             self.present(navigationController, animated: false, completion: nil)
         })

--- a/Extensions/SendTo/ActionViewController.swift
+++ b/Extensions/SendTo/ActionViewController.swift
@@ -54,7 +54,7 @@ class ActionViewController: UIViewController, ClientPickerViewControllerDelegate
             return finish()
         }
 
-        let profile = BrowserProfile(localName: "profile", app: nil) // TODO Will this be owned?
+        let profile = BrowserProfile(localName: "profile", app: nil)
         profile.sendItems([item], toClients: clients).uponQueue(DispatchQueue.main) { result in
             profile.shutdown()
             self.finish()

--- a/Extensions/SendTo/ActionViewController.swift
+++ b/Extensions/SendTo/ActionViewController.swift
@@ -13,16 +13,14 @@ import SnapKit
 
 @objc(ActionViewController)
 class ActionViewController: UIViewController, ClientPickerViewControllerDelegate, InstructionsViewControllerDelegate {
-    private lazy var profile: Profile = { return BrowserProfile(localName: "profile", app: nil) }()
     private var sharedItem: ShareItem?
 
     override func viewDidLoad() {
         view.backgroundColor = UIColor.white
 
         super.viewDidLoad()
-        profile.reopen()
 
-        guard profile.hasAccount() else {
+        if !hasAccount() {
             let instructionsViewController = InstructionsViewController()
             instructionsViewController.delegate = self
             let navigationController = UINavigationController(rootViewController: instructionsViewController)
@@ -41,23 +39,17 @@ class ActionViewController: UIViewController, ClientPickerViewControllerDelegate
             self.sharedItem = item
             let clientPickerViewController = ClientPickerViewController()
             clientPickerViewController.clientPickerDelegate = self
-            clientPickerViewController.profile = self.profile
             let navigationController = UINavigationController(rootViewController: clientPickerViewController)
             self.present(navigationController, animated: false, completion: nil)
         })
     }
 
     func finish() {
-        self.profile.shutdown()
         self.extensionContext!.completeRequest(returningItems: nil, completionHandler: nil)
     }
 
     func clientPickerViewController(_ clientPickerViewController: ClientPickerViewController, didPickClients clients: [RemoteClient]) {
-        // TODO: hook up Send Tab via Sync.
-        // profile?.clients.sendItem(self.sharedItem!, toClients: clients)
-        if let item = sharedItem {
-            self.profile.sendItems([item], toClients: clients)
-        }
+        // TODO
         finish()
     }
     
@@ -67,5 +59,13 @@ class ActionViewController: UIViewController, ClientPickerViewControllerDelegate
 
     func instructionsViewControllerDidClose(_ instructionsViewController: InstructionsViewController) {
         finish()
+    }
+
+    private func hasAccount() -> Bool {
+        let profile = BrowserProfile(localName: "profile", app: nil)
+        defer {
+            profile.shutdown()
+        }
+        return profile.hasAccount()
     }
 }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -181,7 +181,7 @@ protocol Profile: class {
 
     @discardableResult func storeTabs(_ tabs: [RemoteTab]) -> Deferred<Maybe<Int>>
 
-    func sendItems(_ items: [ShareItem], toClients clients: [RemoteClient])
+    func sendItems(_ items: [ShareItem], toClients clients: [RemoteClient]) -> Deferred<Maybe<SyncStatus>>
 
     var syncManager: SyncManager { get }
     var isChinaEdition: Bool { get }
@@ -485,12 +485,12 @@ open class BrowserProfile: Profile {
         return self.remoteClientsAndTabs.insertOrUpdateTabs(tabs)
     }
 
-    public func sendItems(_ items: [ShareItem], toClients clients: [RemoteClient]) {
+    public func sendItems(_ items: [ShareItem], toClients clients: [RemoteClient]) -> Deferred<Maybe<SyncStatus>> {
         let id = DeviceInfo.clientIdentifier(self.prefs)
         let commands = items.map { item in
             SyncCommand.displayURIFromShareItem(item, asClient: id)
         }
-        self.remoteClientsAndTabs.insertCommands(commands, forClients: clients) >>> { self.syncManager.syncClients() }
+        return self.remoteClientsAndTabs.insertCommands(commands, forClients: clients) >>> { self.syncManager.syncClients() }
     }
 
     lazy var logins: BrowserLogins & SyncableLogins & ResettableSyncStorage = {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -75,8 +75,8 @@ class ProfileFileAccessor: FileAccessor {
 class CommandStoringSyncDelegate: SyncDelegate {
     let profile: Profile
 
-    init() {
-        profile = BrowserProfile(localName: "profile", app: nil)
+    init(profile: Profile) {
+        self.profile = profile
     }
 
     public func displaySentTabForURL(_ URL: URL, title: String) {
@@ -464,7 +464,7 @@ open class BrowserProfile: Profile {
         if let app = self.app {
             return BrowserProfileSyncDelegate(app: app)
         }
-        return CommandStoringSyncDelegate()
+        return CommandStoringSyncDelegate(profile: self)
     }
 
     public func getClients() -> Deferred<Maybe<[RemoteClient]>> {


### PR DESCRIPTION
This patch deals with the crashes reported for the SendTo extension.

All these crashes happen because the extension keeps the profile open and iOS kills processes that go into the background with open files.

We deal with that by having a simple strategy, only open the profile temporary. There are three cases in SendTo where we do that now:

- In `ActionViewController` we open and close the profile just to call `hasAccount()`
- In `ActionViewController` we open and close the profile to call `sendItems()`
- In `ClientPickerViewController` we open and close the profile to call `getClients `

With these changes, the chances that the profile (and specifically, the databases) are kept open are now minimal.

As a nice side effect, `sendItems()` now waits for completion. It will only return if the item has been uploaded to the Sync server. I think this used to work by accident and lucky timing. Now it works by design.
