### PR TITLE
Bug 1345597 – Auto start a sync on verify of a firefox account.

### DIFF
--- a/Account/FxALoginStateMachine.swift
+++ b/Account/FxALoginStateMachine.swift
@@ -128,6 +128,7 @@ class FxALoginStateMachine {
                 if let response = result.successValue {
                     if let kB = response.wrapkB.xoredWith(state.unwrapkB) {
                         log.info("Unwrapped keys response.  Transition to CohabitingBeforeKeyPair.")
+                        self.notifyAccountVerified()
                         let newState = CohabitingBeforeKeyPairState(sessionToken: state.sessionToken,
                             kA: response.kA, kB: kB)
                         return Deferred(value: newState)
@@ -173,5 +174,9 @@ class FxALoginStateMachine {
             log.warning("User interaction required; not transitioning.")
             return same
         }
+    }
+
+    fileprivate func notifyAccountVerified() {
+        NotificationCenter.default.post(name: NotificationFirefoxAccountVerified, object: nil, userInfo: nil)
     }
 }

--- a/Account/FxAPushMessageHandler.swift
+++ b/Account/FxAPushMessageHandler.swift
@@ -59,7 +59,7 @@ extension FxAPushMessageHandler {
 
     /// The main entry point to the handler for decrypted messages.
     func handle(message json: JSON) -> Success {
-        if !json.isDictionary() {
+        if !json.isDictionary() || json.isEmpty {
             return handleVerification()
         }
 
@@ -95,8 +95,10 @@ extension FxAPushMessageHandler {
             return succeed()
         }
 
-        // If we're verified, we can start syncing.
-        return account.advance().bind { _ in return succeed() }
+        // Progress through the FxAStateMachine, then explicitly sync.
+        return account.advance().bind { _ in
+            FxALoginHelper.performVerifiedSync(self.profile, account: account)
+        }
     }
 }
 

--- a/Client/Frontend/Settings/FxAContentViewController.swift
+++ b/Client/Frontend/Settings/FxAContentViewController.swift
@@ -40,7 +40,7 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
     init(profile: Profile) {
         self.profile = profile
         super.init(backgroundColor: UIColor(red: 242 / 255.0, green: 242 / 255.0, blue: 242 / 255.0, alpha: 1.0), title: NSAttributedString(string: "Firefox Accounts"))
-        NotificationCenter.default.addObserver(self, selector: #selector(FxAContentViewController.SELdidVerify(_:)), name: NotificationFirefoxAccountVerified, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(FxAContentViewController.userDidVerify(_:)), name: NotificationFirefoxAccountVerified, object: nil)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -123,7 +123,7 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
         helper.application(app, didReceiveAccountJSON: data)
     }
 
-    @objc fileprivate func SELdidVerify(_ notification: Notification) {
+    @objc fileprivate func userDidVerify(_ notification: Notification) {
         guard let account = profile.getAccount() else {
             return
         }

--- a/Client/Frontend/Settings/FxAContentViewController.swift
+++ b/Client/Frontend/Settings/FxAContentViewController.swift
@@ -40,10 +40,15 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
     init(profile: Profile) {
         self.profile = profile
         super.init(backgroundColor: UIColor(red: 242 / 255.0, green: 242 / 255.0, blue: 242 / 255.0, alpha: 1.0), title: NSAttributedString(string: "Firefox Accounts"))
+        NotificationCenter.default.addObserver(self, selector: #selector(FxAContentViewController.SELdidVerify(_:)), name: NotificationFirefoxAccountVerified, object: nil)
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: NotificationFirefoxAccountVerified, object: nil)
     }
 
     override func viewDidLoad() {
@@ -116,6 +121,21 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
         let helper = FxALoginHelper.sharedInstance
         helper.delegate = self
         helper.application(app, didReceiveAccountJSON: data)
+    }
+
+    @objc fileprivate func SELdidVerify(_ notification: Notification) {
+        guard let account = profile.getAccount() else {
+            return
+        }
+        // We can't verify against the actionNeeded of the account, 
+        // because of potential race conditions.
+        // However, we restrict visibility of this method, and make sure 
+        // we only Notify via the FxALoginStateMachine.
+        let flags = FxALoginFlags(pushEnabled: account.pushRegistration != nil,
+                                  verified: true)
+        DispatchQueue.main.async {
+            self.delegate?.contentViewControllerDidSignIn(self, withFlags: flags)
+        }
     }
 
     // The content server page is ready to be shown.

--- a/Shared/NotificationConstants.swift
+++ b/Shared/NotificationConstants.swift
@@ -20,5 +20,8 @@ public let NotificationOnPageMetadataFetched = Notification.Name("OnPageMetadata
 // Fired when the login synchronizer has finished applying remote changes
 public let NotificationDataRemoteLoginChangesWereApplied = Notification.Name("NotificationDataRemoteLoginChangesWereApplied")
 
+// Fired when the FxA account has been verified. This should only be fired by the FxALoginStateMachine.
+public let NotificationFirefoxAccountVerified = Notification.Name("FirefoxAccountVerifiedNotification")
+
 // MARK: Notification UserInfo Keys
 public let NotificationUserInfoKeyHasSyncableAccount = Notification.Name("NotificationUserInfoKeyHasSyncableAccount")


### PR DESCRIPTION
This PR detects email verification by polling the sync servers until a sync can start. 

The second mechanism to detect email verification is via WebPush. The testing of this code requires push servers properly configured. While this PR adds allows for this mechanism, WebPush verified first sync is unlikely to work in this manner (initial sync will likely be longer than the 30 seconds allowed to run in the push service extension).

This also:

 * dismisses any UI waiting for verification
 * prepares the ground for APNS enabled verification
 * performs an explicit sync.

We add a notification center notification, when an account becomes verified.

https://bugzilla.mozilla.org/show_bug.cgi?id=1345597