### PR TITLE
Bug 1359746 - Make sure needsLayout is called on the cell so pagecontrol refreshes.

### DIFF
--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -334,7 +334,7 @@ extension ActivityStreamPanel {
     func configureTopSitesCell(_ cell: UICollectionViewCell, forIndexPath indexPath: IndexPath) -> UICollectionViewCell {
         let topSiteCell = cell as! ASHorizontalScrollCell
         topSiteCell.delegate = self.topSitesManager
-        topSiteCell.collectionView.setNeedsLayout()
+        topSiteCell.setNeedsLayout()
         topSiteCell.collectionView.reloadData()
         return cell
     }


### PR DESCRIPTION
This was a regression from [my last PR](https://github.com/mozilla-mobile/firefox-ios/commit/04aa407e19b6e0497f7e15f4bfb8a2c9e8bd61cd#diff-3339315d574375bd5569aaf99a36248f). I also double checked the old bug and made sure I didn't reintroduce it.

I had replaced a `cell.setNeedsLayout()` with a `cell.collectionView.setNeedsLayout()` 

Rookie mistake!