### PR TITLE
Bug 1362046 - Integrate Sentry for Crash Reporting

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,16 +1,18 @@
+# These two have to be specified explicitely otherwise
+# Carthage complains about a dependency cycle.
+github "kstenerud/KSCrash"                  "1.15.8"
+github "getsentry/sentry-swift"             "2.1.9"
+
 github "Alamofire/Alamofire"                ~> 4.0
 github "sleroux/Deferred"                   "Swift3.0"
 github "SnapKit/SnapKit"                    "3.1.2"
-
 github "rs/SDWebImage"                      "3.7.4"
 github "swisspol/GCDWebServer"              "3.3.2"
 github "kif-framework/KIF"                  "v3.5.1"
 github "adjust/ios_sdk"                     "v4.10.2"
 github "AgileBits/onepassword-extension"    "new/carthage+ios10"
 github "iziz/libPhoneNumber-iOS"            "0.9.2"
-
 github "mozilla/readability"                "master"
-
 github "jrendel/SwiftKeychainWrapper"       "3.0.1"
 github "DaveWoodCom/XCGLogger"              "Version_4.0.0"
 github "cezheng/Fuzi"                       "1.0.1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,5 @@
+github "kstenerud/KSCrash" "1.15.8"
+github "getsentry/sentry-swift" "2.1.9"
 github "Alamofire/Alamofire" "4.3.0"
 github "sleroux/Deferred" "35b8927c1b94ce074e10793c57e1f80d0e2227fa"
 github "cezheng/Fuzi" "1.0.1"
@@ -13,4 +15,4 @@ github "AgileBits/onepassword-extension" "a614e290396346e3cb69e4951656eb8033390f
 github "mozilla/readability" "ccc8e9bf4c5400814d9b7a3ea83c21540da4c76f"
 github "SwiftyJSON/SwiftyJSON" "3.1.4"
 github "farhanpatel/JSONSchema.swift" "1c052b83baa8c497e12cde6a8afca0f54574612f"
-github "google/EarlGrey"                    "1.9.0"
+github "google/EarlGrey" "1.9.0"

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -476,6 +476,9 @@
 		E444F7E51B4B1CB600FEB19B /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B8E0FF31A932BD500161DC3 /* ImageIO.framework */; };
 		E444F8271B4C1E8800FEB19B /* Sync.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2827315E1ABC9BE600AA1954 /* Sync.framework */; };
 		E4483B5A1ADED63300B485A7 /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288A2D861AB8B3260023ABC3 /* Shared.framework */; };
+		E46175F31EBB73A10021AE8A /* KSCrash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E46175F11EBB73A10021AE8A /* KSCrash.framework */; };
+		E46175F41EBB73A10021AE8A /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E46175F21EBB73A10021AE8A /* Sentry.framework */; };
+		E46175F61EBB74390021AE8A /* SentryIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46175F51EBB74390021AE8A /* SentryIntegration.swift */; };
 		E47536ED1C85412C0022CC69 /* PrintHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47536EC1C85412C0022CC69 /* PrintHelper.swift */; };
 		E47536FC1C85415F0022CC69 /* PrintHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = E47536FB1C85415E0022CC69 /* PrintHelper.js */; };
 		E47616C71AB74CA600E7DD25 /* ReaderModeBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47616C61AB74CA600E7DD25 /* ReaderModeBarView.swift */; };
@@ -1684,6 +1687,9 @@
 		E42736061EA858CF009C428E /* TabsPayloadTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TabsPayloadTests.swift; path = SyncTests/TabsPayloadTests.swift; sourceTree = "<group>"; };
 		E4424B1F1AC6EBE100F44C38 /* ReaderSettings.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ReaderSettings.xcassets; sourceTree = "<group>"; };
 		E4424B3B1AC71FB400F44C38 /* FiraSans-Book.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "FiraSans-Book.ttf"; sourceTree = "<group>"; };
+		E46175F11EBB73A10021AE8A /* KSCrash.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = KSCrash.framework; path = Carthage/Build/iOS/KSCrash.framework; sourceTree = "<group>"; };
+		E46175F21EBB73A10021AE8A /* Sentry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sentry.framework; path = Carthage/Build/iOS/Sentry.framework; sourceTree = "<group>"; };
+		E46175F51EBB74390021AE8A /* SentryIntegration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SentryIntegration.swift; sourceTree = "<group>"; };
 		E47536EC1C85412C0022CC69 /* PrintHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrintHelper.swift; sourceTree = "<group>"; };
 		E47536FB1C85415E0022CC69 /* PrintHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = PrintHelper.js; sourceTree = "<group>"; };
 		E47616C61AB74CA600E7DD25 /* ReaderModeBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderModeBarView.swift; sourceTree = "<group>"; };
@@ -1990,6 +1996,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E46175F31EBB73A10021AE8A /* KSCrash.framework in Frameworks */,
+				E46175F41EBB73A10021AE8A /* Sentry.framework in Frameworks */,
 				7B8A47F61D01D3B400C07734 /* PassKit.framework in Frameworks */,
 				E6B6DCA21CD3D370009CF713 /* CrashReporter.framework in Frameworks */,
 				E69DB08A1E97DEAA008A67E6 /* Telemetry.framework in Frameworks */,
@@ -2754,6 +2762,8 @@
 		7B604FC11C496005006EEEC3 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				E46175F11EBB73A10021AE8A /* KSCrash.framework */,
+				E46175F21EBB73A10021AE8A /* Sentry.framework */,
 				3B4988CD1E42B01800A12FDA /* SwiftyJSON.framework */,
 				E6231C041B90A472005ABB0D /* libxml2.2.tbd */,
 				E6231C021B90A466005ABB0D /* libstdc++.6.0.9.tbd */,
@@ -3552,6 +3562,7 @@
 				E6639F171BF11E17002D0853 /* Settings.bundle */,
 				7BEFC67F1BFF68C30059C952 /* QuickActions.swift */,
 				7B72E8211CAEC78100FB1D1C /* AppState.swift */,
+				E46175F51EBB74390021AE8A /* SentryIntegration.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -4864,6 +4875,8 @@
 				"$(SRCROOT)/Carthage/Build/iOS/Fuzi.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/JSONSchema.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/SwiftyJSON.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/KSCrash.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/Sentry.framework",
 			);
 			name = "Copy Carthage Dependencies";
 			outputPaths = (
@@ -5407,6 +5420,7 @@
 				E650755C1E37F747006961AC /* Swizzling.m in Sources */,
 				74821FC51DB56A2500EEEA72 /* OpenWithSettingsViewController.swift in Sources */,
 				D3B6923D1B9F9444004B87A4 /* FindInPageBar.swift in Sources */,
+				E46175F61EBB74390021AE8A /* SentryIntegration.swift in Sources */,
 				2F44FC721A9E840300FD20CC /* SettingsNavigationController.swift in Sources */,
 				74821F8E1DAD8F1400EEEA72 /* ActivityStreamHighlightCell.swift in Sources */,
 				E69E06BA1C76173D00D0F926 /* RequirePasscodeIntervalViewController.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -89,6 +89,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         let profile = getProfile(application)
         appStateStore = AppStateStore(prefs: profile.prefs)
 
+        log.debug("Initializing Sentry…")
+        SentryIntegration.shared.setup(profile: profile)
+
         log.debug("Initializing telemetry…")
         Telemetry.initWithPrefs(profile.prefs)
 

--- a/Client/Application/SentryIntegration.swift
+++ b/Client/Application/SentryIntegration.swift
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+import Foundation
+import Shared
+import KSCrash
+import Sentry
+
+class SentryIntegration {
+    static let shared = SentryIntegration()
+
+    private let SentryDSNKey = "SentryDSN"
+
+    var enabled = false
+
+    func setup(profile: Profile) {
+        assert(!enabled, "SentryIntegration.setup() should only be called once")
+
+        if !(profile.prefs.boolForKey("settings.sendUsageData") ?? true) {
+            Logger.browserLogger.error("Not enabling Sentry; Not enabled by user choice")
+            return
+        }
+
+        guard let dsn = Bundle.main.object(forInfoDictionaryKey: SentryDSNKey) as? String, !dsn.isEmpty else {
+            Logger.browserLogger.error("Not enabling Sentry; Not configured in Info.plist")
+            return
+        }
+
+        Logger.browserLogger.error("Enabling Sentry crash handler")
+        SentryClient.shared = SentryClient(dsnString: dsn)
+        SentryClient.shared?.startCrashHandler()
+    }
+
+    var crashedLastLaunch: Bool {
+        return KSCrash.sharedInstance().crashedLastLaunch
+    }
+}

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -134,6 +134,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>SentryDSN</key>
+	<string>$(SENTRY_DSN)</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
 	<key>UTImportedTypeDeclarations</key>

--- a/buddybuild_prebuild.sh
+++ b/buddybuild_prebuild.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Add our Adjust keys to the build depending on the scheme
+if [ "$BUDDYBUILD_SCHEME" == FirefoxBeta ]; then
+  echo "Setting Adjust environment to SANDBOX for $BUDDYBUILD_SCHEME"
+  /usr/libexec/PlistBuddy -c "Set AdjustAppToken $ADJUST_KEY_SANDBOX" "Client/Info.plist"
+  /usr/libexec/PlistBuddy -c "Set AdjustEnvironment sandbox" "Client/Info.plist"
+elif [ "$BUDDYBUILD_SCHEME" == Firefox ]; then
+  echo "Setting Adjust environment to PRODUCTION for $BUDDYBUILD_SCHEME"
+  /usr/libexec/PlistBuddy -c "Set AdjustAppToken $ADJUST_KEY_PRODUCTION" "Client/Info.plist"
+  /usr/libexec/PlistBuddy -c "Set AdjustEnvironment production" "Client/Info.plist"
+fi
+
+echo "Setting Sentry DSN to $SENTRY_DSN"
+/usr/libexec/PlistBuddy -c "Set SentryDSN $SENTRY_DSN" "Client/Info.plist"
+
+# Set the build number to match the Buddybuild number
+agvtool new-version -all $BUDDYBUILD_BUILD_NUMBER


### PR DESCRIPTION
This patch includes Sentry crash reporting to the application. It depends on a SENTRY_DSN environment variable that contains the Sentry DSN for our instance. This is configured by BuddyBuild and the `buddybuild_prebuild.sh` script.