### PR TITLE
Bug 1362073 - Ask to restore tabs after a crash

### DIFF
--- a/Client/Application/SentryIntegration.swift
+++ b/Client/Application/SentryIntegration.swift
@@ -36,4 +36,8 @@ class SentryIntegration {
     var crashedLastLaunch: Bool {
         return KSCrash.sharedInstance().crashedLastLaunch
     }
+
+    func crash() {
+        SentryClient.shared?.crash()
+    }
 }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -418,6 +418,16 @@ class EnableBookmarkMergingSetting: HiddenSetting {
     }
 }
 
+class ForceCrashSetting: HiddenSetting {
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: "Debug: Force Crash", attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        SentryIntegration.shared.crash()
+    }
+}
+
 // Show the current version of Firefox
 class VersionSetting: Setting {
     unowned let settings: SettingsTableViewController

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -116,7 +116,8 @@ class AppSettingsTableViewController: SettingsTableViewController {
                 YourRightsSetting(),
                 ExportBrowserDataSetting(settings: self),
                 DeleteExportedDataSetting(settings: self),
-                EnableBookmarkMergingSetting(settings: self)
+                EnableBookmarkMergingSetting(settings: self),
+                ForceCrashSetting(settings: self),
             ])]
             
             if profile.hasAccount() {


### PR DESCRIPTION
This patch does three things:

- It implements `BrowserViewController.hasPendingCrashReport()` so that the application can detect that we previously crashed.
- It adds a hidden `Force Crash` setting, that can be used by QA to test session restore.
- It replaces `shouldRestoreTabs()` with a simpler `canRestoreTabs()`.

The last change needs a bit more explanation:

The logic in `shouldRestoreTabs()` would always evaluate to `false`, even if the user really had tabs to restore. I think the code makes an attempt to not restore if there are only `about:home` tabs.

I simplified this with `canRestoreTabs()` by having simpler logic: can we unarchive the tabs stored to disk and if so, were there any tabs in the archive. We don't look at the tabs anymore, or if they have history or `about:` URLs.

This simplifies things and I think this is ok because the user will get exactly back what they had before the crash. If that two empty `about:home` tabs, then that is what they will see again.