### PR TITLE
Bug 1363144 Tabs may not restore after crash

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -543,7 +543,7 @@ class BrowserViewController: UIViewController {
     }
 
     fileprivate func showRestoreTabsAlert() {
-        guard shouldRestoreTabs() else {
+        if !canRestoreTabs() {
             self.tabManager.addTabAndSelect()
             return
         }
@@ -562,17 +562,9 @@ class BrowserViewController: UIViewController {
         self.present(alert, animated: true, completion: nil)
     }
 
-    fileprivate func shouldRestoreTabs() -> Bool {
+    fileprivate func canRestoreTabs() -> Bool {
         guard let tabsToRestore = TabManager.tabsToRestore() else { return false }
-        let onlyNoHistoryTabs = !tabsToRestore.every {
-            if $0.sessionData?.urls.count ?? 0 > 1 {
-                if let url = $0.sessionData?.urls.first {
-                    return !url.isAboutHomeURL
-                }
-            }
-            return false
-        }
-        return !onlyNoHistoryTabs && !DebugSettingsBundleOptions.skipSessionRestore
+        return tabsToRestore.count > 0
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -418,6 +418,16 @@ class EnableBookmarkMergingSetting: HiddenSetting {
     }
 }
 
+class ForceCrashSetting: HiddenSetting {
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: "Debug: Force Crash", attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        fatalError("Crashing on user request")
+    }
+}
+
 // Show the current version of Firefox
 class VersionSetting: Setting {
     unowned let settings: SettingsTableViewController

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -120,7 +120,8 @@ class AppSettingsTableViewController: SettingsTableViewController {
                 YourRightsSetting(),
                 ExportBrowserDataSetting(settings: self),
                 DeleteExportedDataSetting(settings: self),
-                EnableBookmarkMergingSetting(settings: self)
+                EnableBookmarkMergingSetting(settings: self),
+                ForceCrashSetting(settings: self),
             ])]
             
             if profile.hasAccount() {


### PR DESCRIPTION
This patch is essentially the same as https://github.com/mozilla-mobile/firefox-ios/pull/2707 minus the Sentry specific bits.