### PR TITLE
Bug 1326564 - Improved speed of getHighlights query by avoiding full history table scan

### DIFF
--- a/Storage/SQL/SQLiteHistoryRecommendations.swift
+++ b/Storage/SQL/SQLiteHistoryRecommendations.swift
@@ -31,10 +31,19 @@ extension SQLiteHistory: HistoryRecommendations {
         ]
 
         let allProjection = highlightsProjection + faviconsProjection + metadataProjections
+
+        let highlightsHistoryIDs =
+        "SELECT historyID FROM \(AttachedTableHighlights)"
+
+        // Search the history/favicon view with our limited set of highlight IDs
+        // to avoid doing a full table scan on history
+        let faviconSearch =
+        "SELECT * FROM \(ViewHistoryIDsWithWidestFavicons) WHERE id IN (\(highlightsHistoryIDs))"
+
         let sql =
         "SELECT \(allProjection.joined(separator: ",")) " +
         "FROM \(AttachedTableHighlights) " +
-        "LEFT JOIN \(ViewHistoryIDsWithWidestFavicons) ON \(ViewHistoryIDsWithWidestFavicons).id = historyID " +
+        "LEFT JOIN (\(faviconSearch)) AS f1 ON f1.id = historyID " +
         "LEFT OUTER JOIN \(AttachedTablePageMetadata) ON " +
         "\(AttachedTablePageMetadata).cache_key = \(AttachedTableHighlights).cache_key"
 


### PR DESCRIPTION
Part of the slowness we're seeing is due to the sluggish getHighlights query. This speeds this up by constraining the history data set we're joining to instead of doing a full table scan on history. The query is now much faster but the UI is still slow which I think is being caused by the UICollectionView rendering.