### PR TITLE
Bug 1362467 – Add fxaDeviceId to our client record.

### DIFF
--- a/Account/FxADeviceRegistration.swift
+++ b/Account/FxADeviceRegistration.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Deferred
 import Shared
+import SwiftyJSON
 
 private let log = Logger.syncLogger
 
@@ -63,6 +64,14 @@ open class FxADeviceRegistration: NSObject, NSCoding {
         aCoder.encode(id, forKey: "id")
         aCoder.encode(version, forKey: "version")
         aCoder.encode(NSNumber(value: lastRegistered), forKey: "lastRegistered")
+    }
+
+    open func toJSON() -> JSON {
+        return JSON(object: [
+            "id": id,
+            "version": version,
+            "lastRegistered": lastRegistered,
+        ])
     }
 }
 

--- a/Sync/Synchronizers/ClientsSynchronizer.swift
+++ b/Sync/Synchronizers/ClientsSynchronizer.swift
@@ -123,6 +123,7 @@ open class ClientsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchro
         
         let json = JSON(object: [
             "id": guid,
+            "fxaDeviceId": self.scratchpad.fxaDeviceId,
             "version": AppInfo.appVersion,
             "protocols": ["1.5"],
             "name": self.scratchpad.clientName,


### PR DESCRIPTION
I am nervous about putting a device registration outside of KeychainWrapper into a prefs object, though see other GUIDs also in scratchpad.

https://bugzilla.mozilla.org/show_bug.cgi?id=1362467