### PR TITLE
Bug 1364087 - Tabs are not persisted after Undo for Close All Tabs

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -450,6 +450,7 @@ class TabManager: NSObject {
             toast = ButtonToast(labelText: String.localizedStringWithFormat(Strings.TabsDeleteAllUndoTitle, numberOfTabs), buttonText: Strings.TabsDeleteAllUndoAction, completion: { buttonPressed in
                 if buttonPressed {
                     self.undoCloseTabs()
+                    self.storeChanges()
                     for delegate in self.delegates {
                         delegate.get()?.tabManagerDidAddTabs(self)
                     }


### PR DESCRIPTION
Tabs are not persisted when we restore them after the user hits *Undo* after *Close All Tabs*. This means that when you quick the app, you lose your tabs.

This patch fixes that by simply calling `storeChanges()` after `undoCloseTabs()`.

(This was difficult to reproduce on iPhone because we call `storeChanges()` there more often. But if there is an edge case where we did not after *Undo*, this patch should cover it.)