### PR TITLE
Bug 1364855 SendTo crashes while updating top sites cache

### DIFF
--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -359,7 +359,9 @@ open class BrowserProfile: Profile {
     // These selectors run on which ever thread sent the notifications (not the main thread)
     @objc
     func onProfileDidFinishSyncing(notification: NSNotification) {
-        history.setTopSitesNeedsInvalidation()
+        if self.app != nil { // Do not run this when we were started from an app extension
+            history.setTopSitesNeedsInvalidation()
+        }
     }
 
     @objc


### PR DESCRIPTION
Looking at the stack trace attached to this bug, it seems like the *SendTo* app extension is triggering a history sync or at leat an update of the top sites cache. This should never happen in the app extension.

It only calls `syncClientsAndTabs` correctly, but when a sync is done, it triggers a `NotificationProfileDidFinishSyncing` notification and the `BrowserProfile` listens to this notification as follows:

```
func onProfileDidFinishSyncing(notification: NSNotification) {
    history.setTopSitesNeedsInvalidation()
}
```

This code is fine when running in Firefox. But it should never happen when running in an app extension.

There is no API to discover that we are running in an app extension, but the one thing we can check if wether `Profile.app` is set because `UIApplication` is not available in app extensions.

That is what this patch does. It only runs the code in `onProfileDidFinishSyncing` when `self.app` is not `nil`.
