### PR TITLE
Bug 1364901 - Add 'devices' to the Sync Ping

### DIFF
--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -674,8 +674,11 @@ open class BrowserProfile: Profile {
         }
 
         private func sendSyncPing(account: FirefoxAccount, result: SyncOperationResult) {
-            SyncPing.from(result: result, account: account, prefs: self.prefs, why: .schedule)
-                >>== { Telemetry.send(ping: $0, docType: .sync) }
+            SyncPing.from(result: result,
+                          account: account,
+                          remoteClientsAndTabs: self.profile.remoteClientsAndTabs,
+                          prefs: self.prefs,
+                          why: .schedule) >>== { Telemetry.send(ping: $0, docType: .sync) }
         }
 
         private func notifySyncing(notification: Notification.Name) {

--- a/Storage/Clients.swift
+++ b/Storage/Clients.swift
@@ -11,11 +11,11 @@ public struct RemoteClient: Equatable {
 
     public let name: String
     public let type: String?
-
+    public let os: String?
     public let version: String?
+    
     let protocols: [String]?
 
-    let os: String?
     let appPackage: String?
     let application: String?
     let formfactor: String?


### PR DESCRIPTION
Adds the 'devices' field to the sync ping which tells us what deviceds a user has connected to their FxA account.