### PR TITLE
Bug 1364416 – Added optimistic sync mode to SyncStateMachine.

### DIFF
--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -77,8 +77,10 @@ open class SyncStateMachine {
 
     let scratchpadPrefs: Prefs
 
-    /// Use this set of states to constrain the state machine to making a minimal 
-    /// number of HTTP requests. This is suitable for extension uses.
+    /// Use this set of states to constrain the state machine to attempt the barest 
+    /// minimum to get to Ready. This is suitable for extension uses. If it is not possible,
+    /// then no destructive or expensive actions are taken (e.g. total HTTP requests, 
+    /// duration, records processed, database writes, fsyncs, blanking any local collections)
     public static let OptimisticStates = Set(SyncStateLabel.optimisticValues)
 
     /// The default set of states that the state machine is allowed to use.
@@ -196,8 +198,9 @@ public enum SyncStateLabel: String {
         ClientUpgradeRequired,
     ]
 
-    // This is the list of states that gets us to ready with the minimal 
-    // number of HTTP requests.
+    // This is the list of states needed to get to Ready, or failing.
+    // This is useful in circumstances where it is important to conserve time and/or battery, and failure 
+    // to timely sync is acceptable.
     static let optimisticValues: [SyncStateLabel] = [
         InitialWithLiveToken,
         InitialWithLiveTokenAndInfo,

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -106,7 +106,7 @@ class MetaGlobalTests: XCTestCase {
 
         let expectation = self.expectation(description: "Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "clientUpgradeRequired"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "needsFreshMetaGlobal", "resolveMetaGlobalVersion", "clientUpgradeRequired"])
             XCTAssertNotNil(result.failureValue as? ClientUpgradeRequiredError)
             XCTAssertNil(result.successValue)
             expectation.fulfill()
@@ -124,8 +124,8 @@ class MetaGlobalTests: XCTestCase {
         let afterStores = Date.now()
         let expectation = self.expectation(description: "Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "remoteUpgradeRequired",
-                "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "needsFreshMetaGlobal", "resolveMetaGlobalVersion", "remoteUpgradeRequired",
+                "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "needsFreshMetaGlobal", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             self.assertFreshStart(ready: result.successValue, after: afterStores)
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
@@ -142,8 +142,8 @@ class MetaGlobalTests: XCTestCase {
         let afterStores = Date.now()
         let expectation = self.expectation(description: "Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "missingMetaGlobal",
-                "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "needsFreshMetaGlobal", "missingMetaGlobal",
+                "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "needsFreshMetaGlobal", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             self.assertFreshStart(ready: result.successValue, after: afterStores)
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
@@ -162,7 +162,7 @@ class MetaGlobalTests: XCTestCase {
         let afterStores = Date.now()
         let expectation = self.expectation(description: "Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "missingCryptoKeys", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "needsFreshMetaGlobal", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "missingCryptoKeys", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "needsFreshMetaGlobal", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             self.assertFreshStart(ready: result.successValue, after: afterStores)
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
@@ -183,7 +183,7 @@ class MetaGlobalTests: XCTestCase {
 
         let expectation = self.expectation(description: "Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "needsFreshMetaGlobal", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
             guard let ready = result.successValue else {
                 return
@@ -244,7 +244,7 @@ class MetaGlobalTests: XCTestCase {
 
         let expectation = self.expectation(description: "Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "needsFreshMetaGlobal", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
             guard let ready = result.successValue else {
                 return
@@ -381,7 +381,7 @@ class MetaGlobalTests: XCTestCase {
 
         let expectation = self.expectation(description: "Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "needsFreshMetaGlobal", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
             guard let ready = result.successValue else {
                 return
@@ -409,7 +409,7 @@ class MetaGlobalTests: XCTestCase {
         // Now, run through the state machine again.  We should produce and upload a meta/global reflecting our engine configuration.
         let secondExpectation = self.expectation(description: "Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "missingMetaGlobal", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "needsFreshMetaGlobal", "missingMetaGlobal", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "needsFreshMetaGlobal", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
             guard let ready = result.successValue else {
                 return
@@ -448,7 +448,7 @@ class MetaGlobalTests: XCTestCase {
 
         let expectation = self.expectation(description: "Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "needsFreshMetaGlobal", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
             guard let ready = result.successValue else {
                 return
@@ -481,7 +481,7 @@ class MetaGlobalTests: XCTestCase {
         // Now, run through the state machine again.
         let secondExpectation = self.expectation(description: "Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "needsFreshMetaGlobal", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
             guard let ready = result.successValue else {
                 return
@@ -524,7 +524,7 @@ class MetaGlobalTests: XCTestCase {
         // Now, run through the state machine again.
         let thirdExpectation = self.expectation(description: "Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "needsFreshMetaGlobal", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
             guard let ready = result.successValue else {
                 return

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -240,13 +240,13 @@ class MetaGlobalTests: XCTestCase {
         storeMetaGlobal(metaGlobal: metaGlobal)
         storeCryptoKeys(keys: cryptoKeys)
 
-        stateMachine = SyncStateMachine(prefs: syncPrefs, optimistic: true)
+        stateMachine = SyncStateMachine(prefs: syncPrefs, allowingStates: SyncStateMachine.OptimisticStates)
 
         let expectation = self.expectation(description: "Waiting on value.")
         stateMachine.toReady(authState).upon { result in
             XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "needsFreshMetaGlobal"])
             XCTAssertNotNil(result.failureValue)
-            if let failure = result.failureValue as? ExcludedStateError {
+            if let failure = result.failureValue as? DisallowedStateError {
                 XCTAssertEqual(failure.state, SyncStateLabel.NeedsFreshMetaGlobal)
             } else {
                 XCTFail("SyncStatus failed, but with a different error")
@@ -260,7 +260,7 @@ class MetaGlobalTests: XCTestCase {
     }
 
     func testHappyOptimisticStateMachine() {
-        // When encountering a valid meta/global and crypto/keys, advance smoothly.
+        // We should be able to quickly progress through a constrained (a.k.a. optimistic) state machine
         let metaGlobal = MetaGlobal(syncID: "id", storageVersion: 5, engines: [String: EngineMeta](), declined: [])
         let cryptoKeys = Keys.random()
         storeMetaGlobal(metaGlobal: metaGlobal)
@@ -277,29 +277,15 @@ class MetaGlobalTests: XCTestCase {
             XCTAssertNil(error, "Error: \(error ??? "nil")")
         }
 
-        let afterFirstSync = Date.now()
-
         // Now, run through the state machine again.  Nothing's changed remotely, so we should advance quickly.
         // We should be able to use this 'optimistic' path in an extension.
-        stateMachine = SyncStateMachine(prefs: syncPrefs, optimistic: true)
+        stateMachine = SyncStateMachine(prefs: syncPrefs, allowingStates: SyncStateMachine.OptimisticStates)
 
         let secondExpectation = self.expectation(description: "Waiting on value.")
 
         stateMachine.toReady(authState).upon { result in
             XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "hasMetaGlobal", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
-            guard let ready = result.successValue else {
-                return
-            }
-            // And we should have not downloaded a fresh meta/global or crypto/keys.
-            XCTAssertLessThan(ready.scratchpad.global?.timestamp ?? Timestamp.max, afterFirstSync)
-            XCTAssertLessThan(ready.scratchpad.keys?.timestamp ?? Timestamp.max, afterFirstSync)
-
-            // We should not have marked any local engines for reset.
-            XCTAssertEqual(ready.collectionsThatNeedLocalReset(), [])
-
-            XCTAssertTrue(result.isSuccess)
-            XCTAssertNil(result.failureValue)
             secondExpectation.fulfill()
         }
 

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -234,7 +234,8 @@ class MetaGlobalTests: XCTestCase {
     }
 
     func testFailingOptimisticStateMachine() {
-        // When encountering a valid meta/global and crypto/keys, advance smoothly.
+        // We test only the optimistic state machine, knowing it will need to go through 
+        // needsFreshMetaGlobal, and fail.
         let metaGlobal = MetaGlobal(syncID: "id", storageVersion: 5, engines: [String: EngineMeta](), declined: [])
         let cryptoKeys = Keys.random()
         storeMetaGlobal(metaGlobal: metaGlobal)


### PR DESCRIPTION
This PR implements an optimistic mode for the `SyncStateMachine`. 

Under normal operation, the sync state machine can cause many HTTP requests. In pathological cases, this can be more than a dozen.

It's not clear the maximum HTTP requests we're allowed to use in an APNS extension, though there is a time and battery pressure to minimise the number before push notifications are throttled.

This state machine will attempt to get to `Ready` with only one HTTP request. If it can't get to ready, then it bails with an error.

We introduce a new state `NeedsFreshMetaGlobal`, as `InitialWithLiveTokenAndInfo` was automatically requesting a fresh MetaGlobal.

https://bugzilla.mozilla.org/show_bug.cgi?id=1364416