### PR TITLE
Bug 1364899 - Include failureReason string in sync ping if the sync engine blows up

### DIFF
--- a/Sync/BatchingClient.swift
+++ b/Sync/BatchingClient.swift
@@ -8,8 +8,12 @@ import Shared
 import XCGLogger
 import Deferred
 
-open class SerializeRecordFailure<T: CleartextPayloadJSON>: MaybeErrorType {
+open class SerializeRecordFailure<T: CleartextPayloadJSON>: MaybeErrorType, SyncPingFailureFormattable {
     open let record: Record<T>
+
+    open var failureReasonName: SyncPingFailureReasonName {
+        return .otherError
+    }
 
     open var description: String {
         return "Failed to serialize record: \(record)"

--- a/Sync/StorageClient.swift
+++ b/Sync/StorageClient.swift
@@ -14,8 +14,12 @@ private let log = Logger.syncLogger
 
 // Not an error that indicates a server problem, but merely an
 // error that encloses a StorageResponse.
-open class StorageResponseError<T>: MaybeErrorType {
+open class StorageResponseError<T>: MaybeErrorType, SyncPingFailureFormattable {
     open let response: StorageResponse<T>
+
+    open var failureReasonName: SyncPingFailureReasonName {
+        return .httpError
+    }
 
     public init(_ response: StorageResponse<T>) {
         self.response = response
@@ -26,7 +30,11 @@ open class StorageResponseError<T>: MaybeErrorType {
     }
 }
 
-open class RequestError: MaybeErrorType {
+open class RequestError: MaybeErrorType, SyncPingFailureFormattable {
+    open var failureReasonName: SyncPingFailureReasonName {
+        return .httpError
+    }
+
     open var description: String {
         return "Request error."
     }
@@ -65,21 +73,33 @@ open class NotFound<T>: StorageResponseError<T> {
     }
 }
 
-open class RecordParseError: MaybeErrorType {
+open class RecordParseError: MaybeErrorType, SyncPingFailureFormattable {
     open var description: String {
         return "Failed to parse record."
     }
-}
 
-open class MalformedMetaGlobalError: MaybeErrorType {
-    open var description: String {
-        return "Supplied meta/global for upload did not serialize to valid JSON."
+    open var failureReasonName: SyncPingFailureReasonName {
+        return .otherError
     }
 }
 
-open class RecordTooLargeError: MaybeErrorType {
+open class MalformedMetaGlobalError: MaybeErrorType, SyncPingFailureFormattable {
+    open var description: String {
+        return "Supplied meta/global for upload did not serialize to valid JSON."
+    }
+
+    open var failureReasonName: SyncPingFailureReasonName {
+        return .otherError
+    }
+}
+
+open class RecordTooLargeError: MaybeErrorType, SyncPingFailureFormattable {
     open let guid: GUID
     open let size: ByteCount
+
+    open var failureReasonName: SyncPingFailureReasonName {
+        return .otherError
+    }
 
     public init(size: ByteCount, guid: GUID) {
         self.size = size
@@ -97,8 +117,12 @@ open class RecordTooLargeError: MaybeErrorType {
  * If you want to bypass this, remove the backoff from the BackoffStorage that
  * the storage client is using.
  */
-open class ServerInBackoffError: MaybeErrorType {
+open class ServerInBackoffError: MaybeErrorType, SyncPingFailureFormattable {
     fileprivate let until: Timestamp
+
+    open var failureReasonName: SyncPingFailureReasonName {
+        return .otherError
+    }
 
     open var description: String {
         let formatter = DateFormatter()

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -300,7 +300,13 @@ open class BaseSyncStateWithInfo: BaseSyncState {
 /*
  * Error types.
  */
-public protocol SyncError: MaybeErrorType {}
+public protocol SyncError: MaybeErrorType, SyncPingFailureFormattable {}
+
+extension SyncError {
+    public var failureReasonName: SyncPingFailureReasonName {
+        return .unexpectedError
+    }
+}
 
 open class UnknownError: SyncError {
     open var description: String {

--- a/Sync/SyncTelemetry.swift
+++ b/Sync/SyncTelemetry.swift
@@ -119,7 +119,6 @@ public class StatsSession {
 
 // Stats about a single engine's sync.
 public class SyncEngineStatsSession: StatsSession {
-    public var failureReason: Any?
     public var validationStats: ValidationStats?
 
     private(set) var uploadStats: SyncUploadStats
@@ -200,6 +199,17 @@ public enum SyncPingError: MaybeErrorType {
     }
 }
 
+public enum SyncPingFailureReasonName: String {
+    case httpError = "httperror"
+    case unexpectedError = "unexpectederror"
+    case sqlError = "sqlerror"
+    case otherError = "othererror"
+}
+
+public protocol SyncPingFailureFormattable {
+    var failureReasonName: SyncPingFailureReasonName { get }
+}
+
 public struct SyncPing: TelemetryPing {
     public private(set) var payload: JSON
 
@@ -243,7 +253,20 @@ public struct SyncPing: TelemetryPing {
             var dict = stats.asDictionary()
             if let engineResults = result.engineResults.successValue {
                 dict["engines"] = SyncPing.enginePingDataFrom(engineResults: engineResults)
+            } else if let failure = result.engineResults.failureValue {
+                var errorName: SyncPingFailureReasonName
+                if let formattableFailure = failure as? SyncPingFailureFormattable {
+                    errorName = formattableFailure.failureReasonName
+                } else {
+                    errorName = .unexpectedError
+                }
+
+                dict["failureReason"] = [
+                    "name": errorName.rawValue,
+                    "error": "\(type(of: failure))",
+                ]
             }
+
             dict["devices"] = devices
             return deferMaybe(dict)
         }

--- a/Sync/Synchronizers/Bookmarks/Merging.swift
+++ b/Sync/Synchronizers/Bookmarks/Merging.swift
@@ -72,7 +72,7 @@ open class BookmarksMergeResult: PerhapsNoOp {
 
 // MARK: - Errors.
 
-open class BookmarksMergeError: MaybeErrorType {
+open class BookmarksMergeError: MaybeErrorType, SyncPingFailureFormattable {
     fileprivate let error: Error?
 
     init(error: Error?=nil) {
@@ -81,6 +81,10 @@ open class BookmarksMergeError: MaybeErrorType {
 
     open var description: String {
         return "Merge error: \(self.error ??? "nil")"
+    }
+
+    open var failureReasonName: SyncPingFailureReasonName {
+        return .otherError
     }
 }
 


### PR DESCRIPTION
From what I can tell, all actual errors that happen get filtered through the engine and passed to the syncReducer's terminal when the error has occurred. The syncReducer short circuits the rest of the engines and returns immediately passing through the error. This code simply takes the fatal error that was thrown and adds it to a 'failureReason' field to the sync ping. Note that this doesn't follow the same structure of ping as desktop is sending (they put a dictionary in place of failureReason) but the iOS code doesn't use the same terminology and error handling as desktop.