### PR TITLE
Bug 1363747 -  Prevent share action from crashing on iPad

### DIFF
--- a/ClientTests/ActivityStreamTests.swift
+++ b/ClientTests/ActivityStreamTests.swift
@@ -104,7 +104,7 @@ extension ActivityStreamTests {
 
     func testContextMenuOnTopSiteEmitsRemoveEvent() {
         let mockSite = Site(url: "http://mozilla.org", title: "Mozilla")
-        let topSitesContextMenu = panel.contextMenuForSite(mockSite, atIndex: 0, forSection: .topSites)
+        let topSitesContextMenu = panel.contextMenu(for: mockSite, atIndex: 0, forSection: .topSites, with: nil)
 
         let removeAction = topSitesContextMenu?.actions.find { $0.title == Strings.RemoveFromASContextMenuTitle }
         removeAction?.handler?(removeAction!)
@@ -117,7 +117,7 @@ extension ActivityStreamTests {
 
     func testContextMenuOnHighlightsEmitsRemoveDismissEvents() {
         let mockSite = Site(url: "http://mozilla.org", title: "Mozilla")
-        let highlightsContextMenu = panel.contextMenuForSite(mockSite, atIndex: 0, forSection: .highlights)
+        let highlightsContextMenu = panel.contextMenu(for: mockSite, atIndex: 0, forSection: .highlights, with: nil)
 
         let dismiss = highlightsContextMenu?.actions.find { $0.title == Strings.RemoveFromASContextMenuTitle }
         let delete = highlightsContextMenu?.actions.find { $0.title == Strings.DeleteFromHistoryContextMenuTitle }


### PR DESCRIPTION
I spent a few hours on this and I couldn't find a solution I liked that kept the share menu. 

The ideal solution would be to have the share menu appear in the center of the screen in the same space as the ActivtyStream context menu. But the share menu (UIActivityController) doesn't allow you to customize its presentationStyle forcing you to present it as a popover. 

You must present it with a directionArrow and pass a reference to the sourceView from where the tap originated. Because this is the second modal on the screen this becomes tricky. 
And that still doesnt cover all the issues with rotation and backgrounding the app (we've had all these issues with the modals in Menu/Share in BVC) 

If you'd like to share something. You can always open the page and then access the share menu. It requires an extra step but for the MVP I think this is fine. If we see user feedback that users are missing this then its worth adding back in. 

For some context on this issue. This is a good read https://pspdfkit.com/blog/2016/popovers-on-popovers/ It isnt the exact same issue but touches on some of the details. 