### PR TITLE
Bug 1324558 - Report bookmark validation errors through the sync ping

### DIFF
--- a/ClientTests/SyncStatusResolverTests.swift
+++ b/ClientTests/SyncStatusResolverTests.swift
@@ -93,8 +93,8 @@ class SyncStatusResolverTests: XCTestCase {
         XCTAssertTrue(resolver.resolveResults() == expected)
     }
 
-    func testBookmarksDatabaseError() {
-        let maybeResults: Maybe<EngineResults> = Maybe(failure: BookmarksDatabaseError(err: nil))
+    func testBufferInvalidError() {
+        let maybeResults: Maybe<EngineResults> = Maybe(failure: BufferInvalidError(inconsistencies: [:], validationDuration: 0))
         let resolver = SyncStatusResolver(engineResults: maybeResults)
         let expected = SyncDisplayState.warning(message: String(format: Strings.FirefoxSyncPartialTitle, Strings.localizedStringForSyncComponent("bookmarks") ?? ""))
         XCTAssertTrue(resolver.resolveResults() == expected)

--- a/Providers/SyncStatusResolver.swift
+++ b/Providers/SyncStatusResolver.swift
@@ -61,7 +61,7 @@ public struct SyncStatusResolver {
     public func resolveResults() -> SyncDisplayState {
         guard let results = engineResults.successValue else {
             switch engineResults.failureValue {
-            case _ as BookmarksMergeError, _ as BookmarksDatabaseError:
+            case _ as BookmarksMergeError, _ as BufferInvalidError:
                 return SyncDisplayState.warning(message: String(format: Strings.FirefoxSyncPartialTitle, Strings.localizedStringForSyncComponent("bookmarks") ?? ""))
             default:
                 return SyncDisplayState.bad(message: nil)

--- a/Storage/Bookmarks/Bookmarks.swift
+++ b/Storage/Bookmarks/Bookmarks.swift
@@ -31,7 +31,6 @@ public protocol BookmarkBufferStorage: class {
     func doneApplyingRecordsAfterDownload() -> Success
 
     func validate() -> Success
-    func repairValidation() -> Deferred<Maybe<[(type: String, ids: [String])]>>
     func getBufferedDeletions() -> Deferred<Maybe<[(GUID, Timestamp)]>>
     func applyBufferCompletionOp(_ op: BufferCompletionOp, itemSources: ItemSources) -> Success
 

--- a/Sync/SyncTelemetry.swift
+++ b/Sync/SyncTelemetry.swift
@@ -81,10 +81,28 @@ extension SyncDownloadStats: DictionaryRepresentable {
     }
 }
 
-// TODO(sleroux): Implement various bookmark validation issues we can run into.
-public struct ValidationStats: Stats {
+public struct ValidationStats: Stats, DictionaryRepresentable {
+    let problems: [ValidationProblem]
+    let took: Int64
+
     public func hasData() -> Bool {
-        return false
+        return !problems.isEmpty
+    }
+
+    func asDictionary() -> [String: Any] {
+        return [
+            "problems": problems.map { $0.asDictionary() },
+            "took" : took
+        ]
+    }
+}
+
+public struct ValidationProblem: DictionaryRepresentable {
+    let name: String
+    let count: Int
+
+    func asDictionary() -> [String: Any] {
+        return ["name": name, "count": count]
     }
 }
 
@@ -155,6 +173,10 @@ extension SyncEngineStatsSession: DictionaryRepresentable {
 
         if uploadStats.hasData() {
             dict["outgoing"] = uploadStats.asDictionary()
+        }
+
+        if let validation = self.validationStats, validation.hasData() {
+            dict["validation"] = validation.asDictionary()
         }
 
         return dict

--- a/Sync/Synchronizers/Bookmarks/BookmarksRepairRequestor.swift
+++ b/Sync/Synchronizers/Bookmarks/BookmarksRepairRequestor.swift
@@ -129,7 +129,7 @@ class BookmarksRepairRequestor {
      *
      * - returns: true if a repair was started and false otherwise.
      */
-    func startRepairs(validationInfo: [(type: String, ids: [String])], flowID: String = Bytes.generateGUID()) -> Deferred<Maybe<Bool>> {
+    func startRepairs(validationInfo: [BufferInconsistency: [GUID]], flowID: String = Bytes.generateGUID()) -> Deferred<Maybe<Bool>> {
         guard self.currentState == .notRepairing else {
             log.info("Can't start a repair - repair with ID \(self.flowID) is already in progress")
             return deferMaybe(false)
@@ -450,8 +450,8 @@ class BookmarksRepairRequestor {
         return false
     }
 
-    private func getProblemIDs(_ validations: [(type: String, ids: [String])]) -> [String] {
-        return Array(Set<String>(validations.flatMap { $0.ids.map { BookmarkRoots.translateOutgoingRootGUID($0) } }))
+    private func getProblemIDs(_ validations: [BufferInconsistency: [GUID]]) -> [GUID] {
+        return validations.reduce([]) { acc, pair in acc + pair.value }
     }
 
     private func anyClientsRepairing(flowID: String? = nil) -> Deferred<Maybe<Bool>> {

--- a/TestBookmarksRepairRequestor.swift
+++ b/TestBookmarksRepairRequestor.swift
@@ -19,7 +19,7 @@ class TestBookmarksRepairRequestor: XCTestCase {
         let scratchpad = Scratchpad(b: KeyBundle.random(), persistingTo: prefs)
         let localClient = RemoteClient(guid: nil, name: "Test local client", modified: (Date.now() - OneMinuteInMilliseconds), type: "mobile", formfactor: "largetablet", os: "iOS", version: nil)
         let remoteClients = MockRemoteClientsAndTabs([ClientAndTabs(client: localClient, tabs: [])])
-        let validationInfo = [(type: "missingvalues", ids: ["mock-guid1", "mock-guid2"])]
+        let validationInfo = [BufferInconsistency.missingValues: ["mock-guid1", "mock-guid2"]]
 
         let requestor = BookmarksRepairRequestor(scratchpad: scratchpad, basePrefs: prefs, remoteClients: remoteClients)
         requestor.startRepairs(validationInfo: validationInfo) >>== { result in
@@ -39,7 +39,7 @@ class TestBookmarksRepairRequestor: XCTestCase {
         let localClient = RemoteClient(guid: nil, name: "Test local client", modified: (Date.now() - OneMinuteInMilliseconds), type: "mobile", formfactor: "largetablet", os: "iOS", version: nil)
         let remoteClient = RemoteClient(guid: "client-a", name: "Test remote client", modified: (Date.now() - OneMinuteInMilliseconds), type: "desktop", formfactor: nil, os: nil, version: "55.0.1")
         let remoteClients = MockRemoteClientsAndTabs([ClientAndTabs(client: localClient, tabs: []), ClientAndTabs(client: remoteClient, tabs: [])])
-        let validationInfo = [(type: "missingvalues", ids: ["mock-guid1", "mock-guid2"])]
+        let validationInfo = [BufferInconsistency.missingValues: ["mock-guid1", "mock-guid2"]]
 
         let requestor = BookmarksRepairRequestor(scratchpad: scratchpad, basePrefs: prefs, remoteClients: remoteClients)
         requestor.startRepairs(validationInfo: validationInfo) >>== { result -> Deferred<Maybe<Bool>> in
@@ -81,7 +81,7 @@ class TestBookmarksRepairRequestor: XCTestCase {
         let localClient = RemoteClient(guid: nil, name: "Test local client", modified: (Date.now() - OneMinuteInMilliseconds), type: "mobile", formfactor: "largetablet", os: "iOS", version: nil)
         let remoteClient = RemoteClient(guid: "client-a", name: "Test remote client", modified: (Date.now() - OneMinuteInMilliseconds), type: "desktop", formfactor: nil, os: nil, version: "55.0.1")
         let remoteClients = MockRemoteClientsAndTabs([ClientAndTabs(client: localClient, tabs: []), ClientAndTabs(client: remoteClient, tabs: [])])
-        let validationInfo = [(type: "missingvalues", ids: ["mock-guid1", "mock-guid2"])]
+        let validationInfo = [BufferInconsistency.missingValues: ["mock-guid1", "mock-guid2"]]
 
         let requestor = BookmarksRepairRequestor(scratchpad: scratchpad, basePrefs: prefs, remoteClients: remoteClients)
         requestor.startRepairs(validationInfo: validationInfo) >>== { result -> Deferred<Maybe<Bool>> in
@@ -109,7 +109,7 @@ class TestBookmarksRepairRequestor: XCTestCase {
         let clientEarly = RemoteClient(guid: "client-early", name: "Test remote client", modified: (Date.now() - OneWeekInMilliseconds), type: "desktop", formfactor: nil, os: nil, version: "55.0.1")
         let clientLate = RemoteClient(guid: "client-late", name: "Test remote client", modified: (Date.now() - OneMinuteInMilliseconds), type: "desktop", formfactor: nil, os: nil, version: "55.0.1")
         let remoteClients = MockRemoteClientsAndTabs([ClientAndTabs(client: localClient, tabs: []), ClientAndTabs(client: clientEarly, tabs: []), ClientAndTabs(client: clientLate, tabs: [])])
-        let validationInfo = [(type: "missingvalues", ids: ["mock-guid1", "mock-guid2"])]
+        let validationInfo = [BufferInconsistency.missingValues: ["mock-guid1", "mock-guid2"]]
 
         let requestor = BookmarksRepairRequestor(scratchpad: scratchpad, basePrefs: prefs, remoteClients: remoteClients)
         requestor.startRepairs(validationInfo: validationInfo) >>== { result in
@@ -131,7 +131,7 @@ class TestBookmarksRepairRequestor: XCTestCase {
         let remoteClientA = RemoteClient(guid: "client-a", name: "Test remote client", modified: Date.now(), type: "desktop", formfactor: nil, os: nil, version: "55.0.1")
         let remoteClientB = RemoteClient(guid: "client-b", name: "Test remote client", modified: (Date.now() - OneMinuteInMilliseconds), type: "desktop", formfactor: nil, os: nil, version: "55.0.1")
         let remoteClients = MockRemoteClientsAndTabs([ClientAndTabs(client: remoteClientA, tabs: []), ClientAndTabs(client: localClient, tabs: []), ClientAndTabs(client: remoteClientB, tabs: [])])
-        let validationInfo = [(type: "missingvalues", ids: ["mock-guid1", "mock-guid2"])]
+        let validationInfo = [BufferInconsistency.missingValues: ["mock-guid1", "mock-guid2"]]
         let flowID = Bytes.generateGUID()
 
         let requestor = BookmarksRepairRequestor(scratchpad: scratchpad, basePrefs: prefs, remoteClients: remoteClients)
@@ -179,7 +179,8 @@ class TestBookmarksRepairRequestor: XCTestCase {
         let remoteClientA = RemoteClient(guid: "client-a", name: "Test remote client", modified: Date.now(), type: "desktop", formfactor: nil, os: nil, version: "55.0.1")
         let remoteClientB = RemoteClient(guid: "client-b", name: "Test remote client", modified: (Date.now() - OneMinuteInMilliseconds), type: "desktop", formfactor: nil, os: nil, version: "55.0.1")
         let remoteClients = MockRemoteClientsAndTabs([ClientAndTabs(client: remoteClientA, tabs: []), ClientAndTabs(client: localClient, tabs: []), ClientAndTabs(client: remoteClientB, tabs: [])])
-        let validationInfo = [(type: "missingvalues", ids: ["mock-guid1", "mock-guid2", "mock-guid3"])]
+        let validationInfo = [BufferInconsistency.missingValues: ["mock-guid1", "mock-guid2",
+            "mock-guid3"]]
         let flowID = Bytes.generateGUID()
 
         let requestor = BookmarksRepairRequestor(scratchpad: scratchpad, basePrefs: prefs, remoteClients: remoteClients)
@@ -228,7 +229,8 @@ class TestBookmarksRepairRequestor: XCTestCase {
         let remoteClientA = RemoteClient(guid: "client-a", name: "Test remote client", modified: Date.now(), type: "desktop", formfactor: nil, os: nil, version: "55.0.1")
         let remoteClientB = RemoteClient(guid: "client-b", name: "Test remote client", modified: (Date.now() - OneMinuteInMilliseconds), type: "desktop", formfactor: nil, os: nil, version: "55.0.1")
         let remoteClients = MockRemoteClientsAndTabs([ClientAndTabs(client: remoteClientA, tabs: []), ClientAndTabs(client: localClient, tabs: []), ClientAndTabs(client: remoteClientB, tabs: [])])
-        let validationInfo = [(type: "missingvalues", ids: ["mock-guid1", "mock-guid2", "mock-guid3"])]
+        let validationInfo = [BufferInconsistency.missingValues: ["mock-guid1", "mock-guid2", "mock-guid3"]]
+
         let flowID = Bytes.generateGUID()
 
         let requestor = BookmarksRepairRequestor(scratchpad: scratchpad, basePrefs: prefs, remoteClients: remoteClients)


### PR DESCRIPTION
Contains a slight refactor of how we call validate on the buffer and passes any validation errors to the sync ping.