### PR TITLE
Bug 1365799 - Make sure highlights refresh when deleting item from history

### DIFF
--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -594,7 +594,10 @@ extension ActivityStreamPanel: DataObserverDelegate {
 
         let deleteFromHistoryAction = ActionOverlayTableViewAction(title: Strings.DeleteFromHistoryContextMenuTitle, iconString: "action_delete", handler: { action in
             self.telemetry.reportEvent(.Delete, source: pingSource, position: index)
-            self.profile.history.removeHistoryForURL(site.url)
+            self.profile.history.removeHistoryForURL(site.url).uponQueue(.main) { result in
+                guard result.isSuccess else { return }
+                self.profile.panelDataObservers.activityStream.invalidate(highlights: true)
+            }
         })
 
         let shareAction = ActionOverlayTableViewAction(title: Strings.ShareContextMenuTitle, iconString: "action_share", handler: { action in


### PR DESCRIPTION
This only happens when using the  "Delete from History" option in the context menu. 