### PR TITLE
No Bug - Update sentry-swift to 2.1.10

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,7 +1,7 @@
 # These two have to be specified explicitely otherwise
 # Carthage complains about a dependency cycle.
 github "kstenerud/KSCrash"                  "1.15.8"
-github "getsentry/sentry-swift"             "2.1.9"
+github "getsentry/sentry-swift"             "2.1.10"
 
 github "Alamofire/Alamofire"                ~> 4.0
 github "sleroux/Deferred"                   "Swift3.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "kstenerud/KSCrash" "1.15.8"
-github "getsentry/sentry-swift" "2.1.9"
+github "getsentry/sentry-swift" "2.1.10"
 github "Alamofire/Alamofire" "4.3.0"
 github "sleroux/Deferred" "35b8927c1b94ce074e10793c57e1f80d0e2227fa"
 github "cezheng/Fuzi" "1.0.1"


### PR DESCRIPTION
This patch updates the Sentry client to 2.1.10.