### PR TITLE
NoBug – Eliminate easy-to-fix swiftlint warnings.

### DIFF
--- a/Account/FxADeviceRegistration.swift
+++ b/Account/FxADeviceRegistration.swift
@@ -164,7 +164,7 @@ open class FxADeviceRegistrator {
 
     fileprivate static func recoverFromTokenError(_ account: FirefoxAccount, client: FxAClient10) -> Deferred<Maybe<FxADeviceRegistration>> {
         return client.status(forUID: account.uid) >>== { status in
-            let _ = account.makeDoghouse()
+            _ = account.makeDoghouse()
             if !status.exists {
                 // TODO: Should be in an "I have an iOS account, but the FxA is gone." state.
                 // This will do for now...

--- a/Client/Application/SentryIntegration.swift
+++ b/Client/Application/SentryIntegration.swift
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-
 import Foundation
 import Shared
 import KSCrash

--- a/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
+++ b/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
@@ -57,7 +57,7 @@ class SensitiveViewController: UIViewController {
             cancel: {
                 self.promptingForTouchID = false
                 self.authState = .notAuthenticating
-                let _ = self.navigationController?.popToRootViewController(animated: true)
+                _ = self.navigationController?.popToRootViewController(animated: true)
             },
             fallback: {
                 self.promptingForTouchID = false
@@ -68,7 +68,7 @@ class SensitiveViewController: UIViewController {
     }
 
     func hideLogins() {
-        let _ = self.navigationController?.popToRootViewController(animated: true)
+        _ = self.navigationController?.popToRootViewController(animated: true)
     }
 
     func blurContents() {
@@ -108,7 +108,7 @@ extension SensitiveViewController: PasscodeEntryDelegate {
     }
 
     func userDidCancelValidation() {
-        let _ = self.navigationController?.popToRootViewController(animated: false)
+        _ = self.navigationController?.popToRootViewController(animated: false)
         self.authState = .notAuthenticating
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1069,7 +1069,7 @@ class BrowserViewController: UIViewController {
         }
 
         switchToPrivacyMode(isPrivate: isPrivate)
-        let _ = tabManager.addTabAndSelect(request, isPrivate: isPrivate)
+        _ = tabManager.addTabAndSelect(request, isPrivate: isPrivate)
         if url == nil && NewTabAccessors.getNewTabPage(profile.prefs) == .blankPage {
             urlBar.tabLocationViewDidTapLocation(urlBar.locationView)
         }
@@ -1086,7 +1086,7 @@ class BrowserViewController: UIViewController {
         }
         currentViewController.dismiss(animated: true, completion: nil)
         if currentViewController != self {
-            let _ = self.navigationController?.popViewController(animated: true)
+            _ = self.navigationController?.popViewController(animated: true)
         } else if urlBar.inOverlayMode {
             urlBar.SELdidClickCancel()
         }
@@ -1888,10 +1888,8 @@ extension BrowserViewController: TabDelegate {
 
     fileprivate func findSnackbar(_ barToFind: SnackBar) -> Int? {
         let bars = snackBars.subviews
-        for (index, bar) in bars.enumerated() {
-            if bar === barToFind {
-                return index
-            }
+        for (index, bar) in bars.enumerated() where bar === barToFind {
+            return index
         }
         return nil
     }
@@ -2902,7 +2900,7 @@ extension BrowserViewController: IntroViewControllerDelegate {
     func introViewControllerDidFinish(_ introViewController: IntroViewController) {
         introViewController.dismiss(animated: true) { finished in
             if self.navigationController?.viewControllers.count ?? 0 > 1 {
-                let _ = self.navigationController?.popToRootViewController(animated: true)
+                _ = self.navigationController?.popToRootViewController(animated: true)
             }
         }
     }

--- a/Client/Frontend/Browser/ErrorPageHelper.swift
+++ b/Client/Frontend/Browser/ErrorPageHelper.swift
@@ -278,7 +278,7 @@ extension ErrorPageHelper: TabHelper {
                    let host = originalURL.host {
                     let origin = "\(host):\(originalURL.port ?? 443)"
                     ErrorPageHelper.certStore?.addCertificate(cert, forOrigin: origin)
-                    let _ = message.webView?.reload()
+                    _ = message.webView?.reload()
                 }
             default:
                 assertionFailure("Unknown error message")

--- a/Client/Frontend/Browser/LocalRequestHelper.swift
+++ b/Client/Frontend/Browser/LocalRequestHelper.swift
@@ -18,9 +18,9 @@ class LocalRequestHelper: TabHelper {
         if params["type"] == "load",
            let urlString = params["url"],
            let url = URL(string: urlString) {
-            let _ = message.webView?.load(PrivilegedRequest(url: url) as URLRequest)
+            _ = message.webView?.load(PrivilegedRequest(url: url) as URLRequest)
         } else if params["type"] == "reload" {
-            let _ = message.webView?.reload()
+            _ = message.webView?.reload()
         } else {
             assertionFailure("Invalid message: \(message.body)")
         }

--- a/Client/Frontend/Browser/LoginsHelper.swift
+++ b/Client/Frontend/Browser/LoginsHelper.swift
@@ -95,7 +95,7 @@ class LoginsHelper: TabHelper {
         attributes[NSForegroundColorAttributeName] = UIColor.darkGray
         let attr = NSMutableAttributedString(string: string, attributes: attributes)
         let font: UIFont = UIFont.systemFont(ofSize: 13, weight: UIFontWeightMedium)
-        for (_, range) in ranges.enumerated() {
+        for range in ranges {
             attr.addAttribute(NSFontAttributeName, value: font, range: range)
         }
         return attr

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -270,11 +270,9 @@ class Tab: NSObject {
     var displayFavicon: Favicon? {
         var width = 0
         var largest: Favicon?
-        for icon in favicons {
-            if icon.width! > width {
-                width = icon.width!
-                largest = icon
-            }
+        for icon in favicons where icon.width! > width {
+            width = icon.width!
+            largest = icon
         }
         return largest
     }
@@ -288,15 +286,15 @@ class Tab: NSObject {
     }
 
     func goBack() {
-        let _ = webView?.goBack()
+        _ = webView?.goBack()
     }
 
     func goForward() {
-        let _ = webView?.goForward()
+        _ = webView?.goForward()
     }
 
     func goToBackForwardListItem(_ item: WKBackForwardListItem) {
-        let _ = webView?.go(to: item)
+        _ = webView?.go(to: item)
     }
 
     @discardableResult func loadRequest(_ request: URLRequest) -> WKNavigation? {

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -148,10 +148,8 @@ class TabManager: NSObject {
     subscript(webView: WKWebView) -> Tab? {
         assert(Thread.isMainThread)
 
-        for tab in tabs {
-            if tab.webView === webView {
-                return tab
-            }
+        for tab in tabs where tab.webView === webView {
+            return tab
         }
 
         return nil
@@ -160,11 +158,10 @@ class TabManager: NSObject {
     func getTabFor(_ url: URL) -> Tab? {
         assert(Thread.isMainThread)
 
-        for tab in tabs {
-            if tab.webView?.url == url {
-                return tab
-            }
+        for tab in tabs where tab.webView?.url == url {
+            return tab
         }
+
         return nil
     }
 
@@ -500,10 +497,8 @@ class TabManager: NSObject {
     func getIndex(_ tab: Tab) -> Int? {
         assert(Thread.isMainThread)
 
-        for i in 0..<count {
-            if tabs[i] === tab {
-                return i
-            }
+        for i in 0..<count where tabs[i] === tab {
+            return i
         }
 
         assertionFailure("Tab not in tabs list")
@@ -691,7 +686,7 @@ extension TabManager {
         }
 
         var tabToSelect: Tab?
-        for (_, savedTab) in savedTabs.enumerated() {
+        for savedTab in savedTabs {
             // Provide an empty request to prevent a new tab from loading the home screen
             let tab = self.addTab(nil, configuration: nil, afterTab: nil, flushToDisk: false, zombie: true, isPrivate: savedTab.isPrivate)
 
@@ -753,7 +748,7 @@ extension TabManager {
 
         if count == 0 && !AppConstants.IsRunningTest && !DebugSettingsBundleOptions.skipSessionRestore {
             // This is wrapped in an Objective-C @try/@catch handler because NSKeyedUnarchiver may throw exceptions which Swift cannot handle
-            let _ = Try(
+            _ = Try(
                 withTry: { () -> Void in
                     self.restoreTabsInternal()
                 },

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -42,7 +42,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
             if !self.isInReadingList {
                 actions.append(UIPreviewAction(title: TabPeekViewController.PreviewActionAddToReadingList, style: .default) { previewAction, viewController in
                     guard let tab = self.tab else { return }
-                    let _ = self.delegate?.tabPeekDidAddToReadingList(tab)
+                    _ = self.delegate?.tabPeekDidAddToReadingList(tab)
                 })
             }
             if !self.isBookmarked {

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -630,7 +630,7 @@ class TabTrayController: UIViewController {
         }, completion: { finished in
             self.toolbar.isUserInteractionEnabled = true
             if finished {
-                let _ = self.navigationController?.popViewController(animated: true)
+                _ = self.navigationController?.popViewController(animated: true)
 
                 if request == nil && NewTabAccessors.getNewTabPage(self.profile.prefs) == .blankPage {
                     if let bvc = self.navigationController?.topViewController as? BrowserViewController {
@@ -676,7 +676,7 @@ extension TabTrayController: TabSelectionDelegate {
     func didSelectTabAtIndex(_ index: Int) {
         let tab = tabsToDisplay[index]
         tabManager.selectTab(tab)
-        let _ = self.navigationController?.popViewController(animated: true)
+        _ = self.navigationController?.popViewController(animated: true)
     }
 }
 
@@ -711,7 +711,7 @@ extension TabTrayController: TabManagerDelegate {
                 tabManager.selectTab(tab)
                 // don't pop the tab tray view controller if it is not in the foreground
                 if self.presentedViewController == nil {
-                    let _ = self.navigationController?.popViewController(animated: true)
+                    _ = self.navigationController?.popViewController(animated: true)
                 }
             }
         })
@@ -847,12 +847,10 @@ fileprivate class TabManagerDataSource: NSObject, UICollectionViewDataSource {
      */
     func removeTab(_ tabToRemove: Tab) -> Int {
         var index: Int = -1
-        for (i, tab) in tabs.enumerated() {
-            if tabToRemove === tab {
-                index = i
-                tabs.remove(at: index)
-                break
-            }
+        for (i, tab) in tabs.enumerated() where tabToRemove === tab {
+            index = i
+            tabs.remove(at: index)
+            break
         }
         return index
     }
@@ -1109,7 +1107,7 @@ extension TabTrayController: UIViewControllerPreviewingDelegate {
     func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
         guard let tpvc = viewControllerToCommit as? TabPeekViewController else { return }
         tabManager.selectTab(tpvc.tab)
-        let _ = self.navigationController?.popViewController(animated: true)
+        _ = self.navigationController?.popViewController(animated: true)
 
         delegate?.tabTrayDidDismiss(self)
 

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -396,7 +396,7 @@ private protocol BookmarkFolderTableViewHeaderDelegate {
 
 extension BookmarksPanel: BookmarkFolderTableViewHeaderDelegate {
     fileprivate func didSelectHeader() {
-        let _ = self.navigationController?.popViewController(animated: true)
+        _ = self.navigationController?.popViewController(animated: true)
     }
 }
 

--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -353,10 +353,8 @@ class HistoryPanel: SiteTableViewController, HomePanel {
 
     func numberOfSectionsInTableView(_ tableView: UITableView) -> Int {
         var count = 1
-        for category in self.categories {
-            if category.rows > 0 {
-                count += 1
-            }
+        for category in self.categories where category.rows > 0 {
+            count += 1
         }
         return count
     }

--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -231,12 +231,10 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
     }
 
     func SELtappedButton(_ sender: UIButton!) {
-        for (index, button) in buttons.enumerated() {
-            if button == sender {
-                selectedPanel = HomePanelType(rawValue: index)
-                delegate?.homePanelViewController(self, didSelectPanel: index)
-                break
-            }
+        for (index, button) in buttons.enumerated() where button == sender {
+            selectedPanel = HomePanelType(rawValue: index)
+            delegate?.homePanelViewController(self, didSelectPanel: index)
+            break
         }
     }
 

--- a/Client/Frontend/Home/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Home/RecentlyClosedTabsPanel.swift
@@ -73,7 +73,7 @@ class RecentlyClosedTabsPanel: UIViewController, HomePanel {
     }
 
     @objc fileprivate func historyBackButtonWasTapped(_ gestureRecognizer: UITapGestureRecognizer) {
-        let _ = self.navigationController?.popViewController(animated: true)
+        _ = self.navigationController?.popViewController(animated: true)
     }
 }
 

--- a/Client/Frontend/Home/RemoteTabsPanel.swift
+++ b/Client/Frontend/Home/RemoteTabsPanel.swift
@@ -110,7 +110,7 @@ class RemoteTabsPanel: UIViewController, HomePanel {
     }
 
     @objc fileprivate func historyBackButtonWasTapped(_ gestureRecognizer: UITapGestureRecognizer) {
-        let _ = self.navigationController?.popViewController(animated: true)
+        _ = self.navigationController?.popViewController(animated: true)
     }
 }
 

--- a/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -67,7 +67,7 @@ class CustomSearchViewController: SettingsTableViewController {
                 return
             }
             self.profile.searchEngines.addSearchEngine(engine)
-            let _ = self.navigationController?.popViewController(animated: true)
+            _ = self.navigationController?.popViewController(animated: true)
             SimpleToast().showAlertWithText(Strings.ThirdPartySearchEngineAdded)
         }
     }

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -303,7 +303,7 @@ extension LoginDetailViewController {
         profile.logins.hasSyncedLogins().uponQueue(DispatchQueue.main) { yes in
             self.deleteAlert = UIAlertController.deleteLoginAlertWithDeleteCallback({ [unowned self] _ in
                 self.profile.logins.removeLoginByGUID(self.login.guid).uponQueue(DispatchQueue.main) { _ in
-                    let _ = self.navigationController?.popViewController(animated: true)
+                    _ = self.navigationController?.popViewController(animated: true)
                 }
             }, hasSyncedLogins: yes.successValue ?? true)
 

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -193,10 +193,8 @@ class SearchSettingsTableViewController: UITableViewController {
     // Hide a thin vertical line that iOS renders between the accessoryView and the reordering control.
     override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         if cell.isEditing {
-            for v in cell.subviews {
-                if v.frame.width == 1.0 {
-                    v.backgroundColor = UIColor.clear
-                }
+            for v in cell.subviews where v.frame.width == 1.0 {
+                v.backgroundColor = UIColor.clear
             }
         }
     }
@@ -301,7 +299,7 @@ extension SearchSettingsTableViewController {
     }
 
     func cancel() {
-        let _ = navigationController?.popViewController(animated: true)
+        _ = navigationController?.popViewController(animated: true)
     }
 
     func dismissAnimated() {
@@ -323,6 +321,6 @@ extension SearchSettingsTableViewController: SearchEnginePickerDelegate {
             model.defaultEngine = engine
             self.tableView.reloadData()
         }
-        let _ = navigationController?.popViewController(animated: true)
+        _ = navigationController?.popViewController(animated: true)
     }
 }

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -105,23 +105,19 @@ class SettingSection: Setting {
 
     var count: Int {
         var count = 0
-        for setting in children {
-            if !setting.hidden {
-                count += 1
-            }
+        for setting in children where !setting.hidden {
+            count += 1
         }
         return count
     }
 
     subscript(val: Int) -> Setting? {
         var i = 0
-        for setting in children {
-            if !setting.hidden {
-                if i == val {
-                    return setting
-                }
-                i += 1
+        for setting in children where !setting.hidden {
+            if i == val {
+                return setting
             }
+            i += 1
         }
         return nil
     }
@@ -379,13 +375,13 @@ class AccountSetting: Setting, FxAContentViewControllerDelegate {
 
         // Dismiss the FxA content view if the account is verified.
         if flags.verified {
-            let _ = settings.navigationController?.popToRootViewController(animated: true)
+            _ = settings.navigationController?.popToRootViewController(animated: true)
         }
     }
 
     func contentViewControllerDidCancel(_ viewController: FxAContentViewController) {
         NSLog("didCancel")
-        let _ = settings.navigationController?.popToRootViewController(animated: true)
+        _ = settings.navigationController?.popToRootViewController(animated: true)
     }
 }
 

--- a/Extensions/ShareTo/InitialViewController.swift
+++ b/Extensions/ShareTo/InitialViewController.swift
@@ -68,7 +68,7 @@ class InitialViewController: UIViewController, ShareControllerDelegate {
             }
 
             if destinations.contains(ShareDestinationBookmarks) {
-                let _ = profile.bookmarks.shareItem(item).value // Blocks until database has settled
+                _ = profile.bookmarks.shareItem(item).value // Blocks until database has settled
             }
 
             profile.shutdown()

--- a/Mocking.swift
+++ b/Mocking.swift
@@ -28,8 +28,7 @@ class MockSyncCollectionClient<T: CleartextPayloadJSON>: Sync15CollectionClient<
          collection: String,
          encrypter: RecordEncrypter<T>,
          client: Sync15StorageClient = getClient(server: getServer(preStart: { _ in })),
-         serverURI: URL = URL(string: "http://localhost/collections")!)
-    {
+         serverURI: URL = URL(string: "http://localhost/collections")!) {
         self.uploader = uploader
         self.infoConfig = infoConfig
         super.init(client: client, serverURI: serverURI, collection: collection, encrypter: encrypter)

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -81,7 +81,7 @@ class CommandStoringSyncDelegate: SyncDelegate {
 
     public func displaySentTabForURL(_ URL: URL, title: String) {
         let item = ShareItem(url: URL.absoluteString, title: title, favicon: nil)
-        let _ = self.profile.queue.addToQueue(item)
+        _ = self.profile.queue.addToQueue(item)
     }
 }
 

--- a/PushTests/PushCryptoTests.swift
+++ b/PushTests/PushCryptoTests.swift
@@ -84,7 +84,7 @@ class PushCryptoTests: XCTestCase {
 
         for test in tests {
             do {
-                let _ = try push.aes128gcm(payload: test.payload,
+                _ = try push.aes128gcm(payload: test.payload,
                                            decryptWith: test.recvPrivKey,
                                            authenticateWith: test.authSecret)
 
@@ -201,7 +201,7 @@ class PushCryptoTests: XCTestCase {
 
         for test in tests {
             do {
-                let _ = try push.aesgcm(ciphertext: test.ciphertext,
+                _ = try push.aesgcm(ciphertext: test.ciphertext,
                                  decryptWith: test.recvPrivKey,
                                  authenticateWith: test.authSecret,
                                  encryptionHeader: test.encryption,

--- a/ReadingList/ReadingListFetchSpec.swift
+++ b/ReadingList/ReadingListFetchSpec.swift
@@ -75,12 +75,12 @@ class ReadingListFetchSpec {
         }
 
         func setMinAttribute(_ attribute: String, value: String) -> Builder {
-            let _ = qualifyAttribute(attribute, withQualifier: "min_", value: value)
+            _ = qualifyAttribute(attribute, withQualifier: "min_", value: value)
             return self
         }
 
         func setMaxAttribute(_ attribute: String, value: String) -> Builder {
-            let _ = qualifyAttribute(attribute, withQualifier: "max_", value: value)
+            _ = qualifyAttribute(attribute, withQualifier: "max_", value: value)
             return self
         }
     }

--- a/Shared/Accessibility.swift
+++ b/Shared/Accessibility.swift
@@ -31,7 +31,7 @@ extension AccessibleAction { // UIAccessibilityCustomAction
 extension AccessibleAction { // UIAlertAction
     private var alertActionHandler: (UIAlertAction!) -> Void {
         return { (_: UIAlertAction!) -> Void in
-            let _ = self.handler()
+            _ = self.handler()
         }
     }
 

--- a/Shared/DeferredUtils.swift
+++ b/Shared/DeferredUtils.swift
@@ -127,7 +127,7 @@ public func accumulate<T>(_ thunks: [() -> Deferred<Maybe<T>>]) -> Deferred<Mayb
  */
 public func effect<T, U>(_ f: @escaping (T) -> U) -> (T) -> Deferred<Maybe<T>> {
     return { t in
-        let _ = f(t)
+        _ = f(t)
         return deferMaybe(t)
     }
 }

--- a/Shared/KeyboardHelper.swift
+++ b/Shared/KeyboardHelper.swift
@@ -80,12 +80,10 @@ open class KeyboardHelper: NSObject {
      * Delegates are weakly held.
      */
     open func addDelegate(_ delegate: KeyboardHelperDelegate) {
-        for weakDelegate in delegates {
-            // Reuse any existing slots that have been deallocated.
-            if weakDelegate.delegate == nil {
-                weakDelegate.delegate = delegate
-                return
-            }
+        // Reuse any existing slots that have been deallocated.
+        for weakDelegate in delegates where weakDelegate.delegate == nil {
+            weakDelegate.delegate = delegate
+            return
         }
 
         delegates.append(WeakKeyboardDelegate(delegate))

--- a/Shared/SystemUtils.swift
+++ b/Shared/SystemUtils.swift
@@ -58,7 +58,7 @@ extension SystemUtils {
             return true
         }
         do {
-            let _ = try Data(contentsOf: lockFileURL, options: .mappedIfSafe)
+            _ = try Data(contentsOf: lockFileURL, options: .mappedIfSafe)
             return false
         } catch let err as NSError {
             return err.code == 257

--- a/Shared/WeakList.swift
+++ b/Shared/WeakList.swift
@@ -25,12 +25,10 @@ open class WeakList<T: AnyObject>: Sequence {
      * insertion is frequent.
      */
     open func insert(_ item: T) {
-        for wrapper in items {
-            // Reuse any existing slots that have been deallocated.
-            if wrapper.value == nil {
-                wrapper.value = item
-                return
-            }
+        // Reuse any existing slots that have been deallocated.
+        for wrapper in items where wrapper.value == nil {
+            wrapper.value = item
+            return
         }
 
         items.append(WeakRef(item))

--- a/Storage/PageMetadata.swift
+++ b/Storage/PageMetadata.swift
@@ -71,7 +71,7 @@ public struct PageMetadata {
 
     fileprivate func downloadAndCache(fromURL webUrl: URL) {
         let imageManager = SDWebImageManager.shared()
-        let _ = imageManager?.downloadImage(with: webUrl, options: SDWebImageOptions.continueInBackground, progress: nil) { (image, error, cacheType, success, url) in
+        _ = imageManager?.downloadImage(with: webUrl, options: SDWebImageOptions.continueInBackground, progress: nil) { (image, error, cacheType, success, url) in
             guard let image = image else {
                 return
             }

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -348,14 +348,14 @@ open class BrowserDB {
 extension BrowserDB {
     func vacuum() {
         log.debug("Vacuuming a BrowserDB.")
-        let _ = db.withConnection(SwiftData.Flags.readWriteCreate, synchronous: true) { connection in
+        _ = db.withConnection(SwiftData.Flags.readWriteCreate, synchronous: true) { connection in
             return connection.vacuum()
         }
     }
 
     func checkpoint() {
         log.debug("Checkpointing a BrowserDB.")
-        let _ = db.transaction(synchronous: true) { connection in
+        _ = db.transaction(synchronous: true) { connection in
             connection.checkpoint()
             return true
         }

--- a/Storage/SQL/DeferredDBOperation.swift
+++ b/Storage/SQL/DeferredDBOperation.swift
@@ -35,7 +35,7 @@ class DeferredDBOperation<T>: Deferred<Maybe<T>>, Cancellable {
             })
         }
         set {
-            let _ = cancelledLock.withWriteLock { cancelled -> T? in
+            _ = cancelledLock.withWriteLock { cancelled -> T? in
                 cancelled = newValue
                 return nil
             }
@@ -51,7 +51,7 @@ class DeferredDBOperation<T>: Deferred<Maybe<T>>, Cancellable {
             return nil
         }
         set {
-            let _ = connectionLock.withWriteLock { connection -> T? in
+            _ = connectionLock.withWriteLock { connection -> T? in
                 connection = newValue
                 return nil
             }

--- a/Storage/SQL/SQLiteBookmarksSyncing.swift
+++ b/Storage/SQL/SQLiteBookmarksSyncing.swift
@@ -229,7 +229,7 @@ extension SQLiteBookmarks {
             //   Overriding the parent involves copying the parent's structure, so that
             //   we can amend it, but also the parent's row itself so that we know it's
             //   changed.
-            let _ = overrideParentMirror()
+            _ = overrideParentMirror()
         } else {
             let (status, deleted) = localStatus!
             if deleted {
@@ -426,7 +426,7 @@ open class SQLiteBookmarkBufferStorage: BookmarkBufferStorage {
         let folders = records.filter { $0.type == BookmarkNodeType.folder }.map { $0.guid }
 
         var err: NSError?
-        let _ = self.db.transaction(&err) { (conn, err) -> Bool in
+        _ = self.db.transaction(&err) { (conn, err) -> Bool in
             // These have the same values in the same order.
             let update =
             "UPDATE \(TableBookmarksBuffer) SET " +
@@ -1006,7 +1006,7 @@ extension MergedSQLiteBookmarks {
                 }
 
                 let sqlMirror = "DELETE FROM \(TableBookmarksMirror) WHERE guid IN \(varlist)"
-                let _ = change(sqlMirror, args: args)
+                _ = change(sqlMirror, args: args)
             }
 
             if err != nil {
@@ -1030,7 +1030,7 @@ extension MergedSQLiteBookmarks {
                     "WHERE guid IN",
                     varlist
                     ].joined(separator: " ")
-                let _ = change(copySQL, args: args)
+                _ = change(copySQL, args: args)
             }
 
             if err != nil {
@@ -1053,7 +1053,7 @@ extension MergedSQLiteBookmarks {
                     "FROM \(TableBookmarksLocal) WHERE guid IN",
                     varlist
                     ].joined(separator: " ")
-               let _ = change(copySQL, args: args)
+               _ = change(copySQL, args: args)
             }
 
             op.modifiedTimes.forEach { (time, guids) in
@@ -1071,7 +1071,7 @@ extension MergedSQLiteBookmarks {
                     "WHERE guid IN",
                     varlist,
                 ].joined(separator: " ")
-                let _ = change(updateSQL, args: args)
+                _ = change(updateSQL, args: args)
             }
 
             if err != nil {
@@ -1097,7 +1097,7 @@ extension MergedSQLiteBookmarks {
 
                 // If the values change, we'll handle those elsewhere, but at least we need to mark these as non-overridden.
                 let sqlMirrorOverride = "UPDATE \(TableBookmarksMirror) SET is_overridden = 0 WHERE guid IN \(varlist)"
-                let _ = change(sqlMirrorOverride, args: args)
+                _ = change(sqlMirrorOverride, args: args)
             }
 
             if err != nil {
@@ -1120,7 +1120,7 @@ extension MergedSQLiteBookmarks {
                     guard err == nil else { return }
 
                     let args = mirrorItem.getUpdateOrInsertArgs()
-                    let _ = change(updateSQL, args: args)
+                    _ = change(updateSQL, args: args)
                 }
 
                 if err != nil {
@@ -1145,7 +1145,7 @@ extension MergedSQLiteBookmarks {
                     guard err == nil else { return }
 
                     let args = mirrorItem.getUpdateOrInsertArgs()
-                    let _ = change(insertSQL, args: args)
+                    _ = change(insertSQL, args: args)
                 }
 
                 if err != nil {

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -174,7 +174,7 @@ extension SQLiteHistory: BrowserHistory {
             return deferMaybe(IgnoredSiteError())
         }
 
-        let _ = db.withConnection(&error) { (conn, _) -> Int in
+        _ = db.withConnection(&error) { (conn, _) -> Int in
             let now = Date.now()
 
             let i = self.updateSite(site, atTime: now, withConnection: conn)
@@ -242,7 +242,7 @@ extension SQLiteHistory: BrowserHistory {
     // TODO: thread siteID into this to avoid the need to do the lookup.
     func addLocalVisitForExistingSite(_ visit: SiteVisit) -> Success {
         var error: NSError? = nil
-        let _ = db.withConnection(&error) { (conn, _) -> Int in
+        _ = db.withConnection(&error) { (conn, _) -> Int in
             // INSERT OR IGNORE because we *might* have a clock error that causes a timestamp
             // collision with an existing visit, and it would really suck to error out for that reason.
             let insert = "INSERT OR IGNORE INTO \(TableVisits) (siteID, date, type, is_local) VALUES (" +
@@ -704,7 +704,7 @@ extension SQLiteHistory: Favicons {
     public func clearAllFavicons() -> Success {
         var err: NSError? = nil
 
-        let _ = db.withConnection(&err) { (conn, err: inout NSError?) -> Int in
+        _ = db.withConnection(&err) { (conn, err: inout NSError?) -> Int in
             err = conn.executeChange("DELETE FROM \(TableFaviconSites)")
             if err == nil {
                 err = conn.executeChange("DELETE FROM \(TableFavicons)")
@@ -754,8 +754,8 @@ extension SQLiteHistory: Favicons {
                 // multiple bookmarks with a particular URI, and a mirror bookmark can be
                 // locally changed, so either or both of these statements can update multiple rows.
                 if let id = id {
-                    let _ = conn.executeChange("UPDATE \(TableBookmarksLocal) SET faviconID = ? WHERE bmkUri = ?", withArgs: [id, site.url])
-                    let _ = conn.executeChange("UPDATE \(TableBookmarksMirror) SET faviconID = ? WHERE bmkUri = ?", withArgs: [id, site.url])
+                    _ = conn.executeChange("UPDATE \(TableBookmarksLocal) SET faviconID = ? WHERE bmkUri = ?", withArgs: [id, site.url])
+                    _ = conn.executeChange("UPDATE \(TableBookmarksMirror) SET faviconID = ? WHERE bmkUri = ?", withArgs: [id, site.url])
                 }
 
                 return id ?? 0
@@ -1008,7 +1008,6 @@ extension SQLiteHistory: SyncableHistory {
         // We can do this in a single query, rather than the N+1 that desktop takes.
         // We then need to flatten the cursor. We do that by collecting
         // places as a side-effect of the factory, producing visits as a result, and merging in memory.
-
 
         // Turn our lazy collection of integers into a comma-seperated string for the IN clause.
         let historyIDs = Array(places.keys)

--- a/Storage/SQL/SQLiteLogins.swift
+++ b/Storage/SQL/SQLiteLogins.swift
@@ -121,7 +121,7 @@ open class SQLiteLogins: BrowserLogins {
 
     public init(db: BrowserDB) {
         self.db = db
-        let _ = db.createOrUpdate(LoginsTable())
+        _ = db.createOrUpdate(LoginsTable())
     }
 
     fileprivate class func populateLogin(_ login: Login, row: SDRow) {

--- a/Storage/SQL/SQLiteQueue.swift
+++ b/Storage/SQL/SQLiteQueue.swift
@@ -15,7 +15,7 @@ open class SQLiteQueue: TabQueue {
     public init(db: BrowserDB) {
         // BrowserTable exists only to perform create/update etc. operations -- it's not
         // a queryable thing that needs to stick around.
-        let _ = db.createOrUpdate(BrowserTable())
+        _ = db.createOrUpdate(BrowserTable())
         self.db = db
     }
 

--- a/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
+++ b/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
@@ -17,14 +17,14 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
 
     public init(db: BrowserDB) {
         self.db = db
-        let _ = self.db.createOrUpdate(clients, tabs, commands)
+        _ = self.db.createOrUpdate(clients, tabs, commands)
     }
 
     fileprivate func doWipe(_ f: @escaping (_ conn: SQLiteDBConnection, _ err: inout NSError?) -> Void) -> Deferred<Maybe<()>> {
         let deferred = Deferred<Maybe<()>>(defaultQueue: DispatchQueue.main)
 
         var err: NSError?
-        let _ = db.transaction(&err) { connection, _ in
+        _ = db.transaction(&err) { connection, _ in
             f(connection, &err)
             if let err = err {
                 let databaseError = DatabaseError(err: err)
@@ -41,7 +41,7 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
 
     open func wipeClients() -> Deferred<Maybe<()>> {
         return self.doWipe { (conn, err: inout NSError?) -> Void in
-            let _ = self.clients.delete(conn, item: nil, err: &err)
+            _ = self.clients.delete(conn, item: nil, err: &err)
         }
     }
 
@@ -55,7 +55,7 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
 
     open func wipeTabs() -> Deferred<Maybe<()>> {
         return self.doWipe { (conn, err: inout NSError?) -> Void in
-            let _ = self.tabs.delete(conn, item: nil, err: &err)
+            _ = self.tabs.delete(conn, item: nil, err: &err)
         }
     }
 
@@ -71,7 +71,7 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
 
         var err: NSError?
 
-        let _ = db.transaction(&err) { connection, _ in
+        _ = db.transaction(&err) { connection, _ in
             // Delete any existing tabs.
             if let _ = connection.executeChange(deleteQuery, withArgs: deleteArgs) {
                 log.warning("Deleting existing tabs failed.")
@@ -111,7 +111,7 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
 
         // TODO: insert multiple clients in a single query.
         // ORM systems are foolish.
-        let _ = db.transaction(&err) { connection, _ in
+        _ = db.transaction(&err) { connection, _ in
             var succeeded = 0
 
             // Update or insert client records.
@@ -119,7 +119,7 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
 
                 let updated = self.clients.update(connection, item: client, err: &err)
                 if err == nil && updated == 0 {
-                    let _ = self.clients.insert(connection, item: client, err: &err)
+                    _ = self.clients.insert(connection, item: client, err: &err)
                 }
 
                 if let err = err {
@@ -272,8 +272,8 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
 
     open func deleteCommands() -> Success {
         var err: NSError?
-        let _ = db.transaction(&err) { connection, _ in
-            let _ = self.commands.delete(connection, item: nil, err: &err)
+        _ = db.transaction(&err) { connection, _ in
+            _ = self.commands.delete(connection, item: nil, err: &err)
             if let _ = err {
                 return false
             }
@@ -285,8 +285,8 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
 
     open func deleteCommands(_ clientGUID: GUID) -> Success {
         var err: NSError?
-        let _ = db.transaction(&err) { connection, _ in
-            let _ = self.commands.delete(connection, item: SyncCommand(id: nil, value: "", clientGUID: clientGUID), err: &err)
+        _ = db.transaction(&err) { connection, _ in
+            _ = self.commands.delete(connection, item: SyncCommand(id: nil, value: "", clientGUID: clientGUID), err: &err)
             if let _ = err {
                 return false
             }
@@ -303,7 +303,7 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
     open func insertCommands(_ commands: [SyncCommand], forClients clients: [RemoteClient]) -> Deferred<Maybe<Int>> {
         var err: NSError?
         var numberOfInserts = 0
-        let _ = db.transaction(&err) { connection, _ in
+        _ = db.transaction(&err) { connection, _ in
             // Update or insert client records.
             for command in commands {
                 for client in clients {
@@ -365,8 +365,8 @@ extension SQLiteRemoteClientsAndTabs: ResettableSyncStorage {
 
     public func clear() -> Success {
         return self.doWipe { (conn, err: inout NSError?) -> Void in
-            let _ = self.tabs.delete(conn, item: nil, err: &err)
-            let _ = self.clients.delete(conn, item: nil, err: &err)
+            _ = self.tabs.delete(conn, item: nil, err: &err)
+            _ = self.clients.delete(conn, item: nil, err: &err)
         }
     }
 }

--- a/Sync/BatchingClient.swift
+++ b/Sync/BatchingClient.swift
@@ -220,7 +220,7 @@ open class Sync15BatchClient<T: CleartextPayloadJSON> {
     fileprivate func moveForward(_ response: StorageResponse<POSTResult>) {
         let lastModified = response.metadata.lastModifiedMilliseconds
         self.ifUnmodifiedSince = lastModified
-        let _ = self.onCollectionUploaded(response.value, lastModified)
+        _ = self.onCollectionUploaded(response.value, lastModified)
     }
 
     fileprivate func resetBatch() {

--- a/Sync/State.swift
+++ b/Sync/State.swift
@@ -415,7 +415,7 @@ open class Scratchpad {
         if let mg = prefs.stringForKey(PrefGlobal) {
             if let mgTS = prefs.unsignedLongForKey(PrefGlobalTS) {
                 if let global = MetaGlobal.fromJSON(JSON(parseJSON: mg)) {
-                    let _ = b.setGlobal(Fetched(value: global, timestamp: mgTS))
+                    _ = b.setGlobal(Fetched(value: global, timestamp: mgTS))
                 } else {
                     log.error("Malformed meta/global in prefs. Ignoring.")
                 }
@@ -433,7 +433,7 @@ open class Scratchpad {
                     let keys = Keys(payload: KeysPayload(keys))
                     if keys.valid {
                         log.debug("Read keys from Keychain with label \(keyLabel).")
-                        let _ = b.setKeys(Fetched(value: keys, timestamp: ckTS))
+                        _ = b.setKeys(Fetched(value: keys, timestamp: ckTS))
                     } else {
                         log.error("Invalid keys extracted from Keychain. Discarding.")
                     }

--- a/Sync/StorageClient.swift
+++ b/Sync/StorageClient.swift
@@ -508,7 +508,7 @@ open class Sync15StorageClient {
             deferred.fill(Maybe(failure: RecordParseError()))
         }
 
-        let _ = req.responseParsedJSON(true, completionHandler: handler)
+        _ = req.responseParsedJSON(true, completionHandler: handler)
         return deferred
     }
 
@@ -663,7 +663,7 @@ open class Sync15CollectionClient<T: CleartextPayloadJSON> {
         }
 
         let req = client.requestPOST(requestURI, body: lines, ifUnmodifiedSince: ifUnmodifiedSince) as! DataRequest
-        let _ = req.responsePartialParsedJSON(queue: collectionQueue, completionHandler: self.client.errorWrap(deferred) { (response: DataResponse<JSON>) in
+        _ = req.responsePartialParsedJSON(queue: collectionQueue, completionHandler: self.client.errorWrap(deferred) { (response: DataResponse<JSON>) in
             if let json: JSON = response.result.value,
                let result = POSTResult.fromJSON(json) {
                 let storageResponse = StorageResponse(value: result, response: response.response!)
@@ -700,7 +700,7 @@ open class Sync15CollectionClient<T: CleartextPayloadJSON> {
         }
 
         let req = client.requestGET(uriForRecord(guid))
-        let _ = req.responsePartialParsedJSON(queue:collectionQueue, completionHandler: self.client.errorWrap(deferred) { (response: DataResponse<JSON>) in
+        _ = req.responsePartialParsedJSON(queue:collectionQueue, completionHandler: self.client.errorWrap(deferred) { (response: DataResponse<JSON>) in
 
             if let json: JSON = response.result.value {
                 let envelope = EnvelopeJSON(json)
@@ -757,7 +757,7 @@ open class Sync15CollectionClient<T: CleartextPayloadJSON> {
         log.debug("Issuing GET with newer = \(since), offset = \(offset ??? "nil"), sort = \(sort ??? "nil").")
         let req = client.requestGET(self.collectionURI.withQueryParams(params))
 
-        let _ = req.responsePartialParsedJSON(queue: collectionQueue, completionHandler: self.client.errorWrap(deferred) { (response: DataResponse<JSON>) in
+        _ = req.responsePartialParsedJSON(queue: collectionQueue, completionHandler: self.client.errorWrap(deferred) { (response: DataResponse<JSON>) in
 
             log.verbose("Response is \(response).")
             guard let json: JSON = response.result.value else {

--- a/Sync/SyncTelemetry.swift
+++ b/Sync/SyncTelemetry.swift
@@ -93,7 +93,7 @@ public struct ValidationStats: Stats, DictionaryRepresentable {
     func asDictionary() -> [String: Any] {
         return [
             "problems": problems.map { $0.asDictionary() },
-            "took" : took
+            "took": took
         ]
     }
 }

--- a/Sync/Synchronizers/ClientsSynchronizer.swift
+++ b/Sync/Synchronizers/ClientsSynchronizer.swift
@@ -124,7 +124,7 @@ open class ClientsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchro
         super.init(scratchpad: scratchpad, delegate: delegate, basePrefs: basePrefs, collection: "clients")
     }
 
-    var localClients: RemoteClientsAndTabs? = nil
+    var localClients: RemoteClientsAndTabs?
 
     override var storageVersion: Int {
         return ClientsStorageVersion
@@ -363,8 +363,8 @@ open class ClientsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchro
                     >>> { self.uploadClientCommands(toLocalClients: localClients, withServer: storageClient) }
                     >>> {
                         log.debug("Running \(commands.count) commands.")
-                        for (command) in commands {
-                            let _ = command.run(self)
+                        for command in commands {
+                            _ = command.run(self)
                         }
                         self.lastFetched = responseTimestamp!
                         return succeed()

--- a/Sync/Synchronizers/TabsSynchronizer.swift
+++ b/Sync/Synchronizers/TabsSynchronizer.swift
@@ -163,7 +163,7 @@ open class TabsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchroniz
 
             if !self.remoteHasChanges(info) {
                 // upload local tabs if they've changed or we're in a fresh start.
-                let _ = uploadOurTabs(localTabs, toServer: tabsClient)
+                _ = uploadOurTabs(localTabs, toServer: tabsClient)
                 return deferMaybe(completedWithStats)
             }
 


### PR DESCRIPTION
This PR fixes 100 trivially fixed swiftlint issues.

```shell
swiftlint 2>/dev/null | jq 'map(select(.rule_id | test("force") | not) | {file: .file, line: .line, type: .type, reason: .reason}) | sort_by(.file, .line)'
```

These are mosty redundant `let _` and converting for loops with a single conditional into for…where loops.

This reduces from 103 to 2 warnings of these types.

Two remaining:

```json
[
  {
    "file": "…/Client/Application/AppDelegate.swift",
    "line": 139,
    "type": "Discarded Notification Center Observer",
    "reason": "When registing for a notification using a block, the opaque observer that is returned should be stored so it can be removed later."
  },
  {
    "file": "…/Client/Application/AppDelegate.swift",
    "line": 146,
    "type": "Discarded Notification Center Observer",
    "reason": "When registing for a notification using a block, the opaque observer that is returned should be stored so it can be removed later."
  }
]
```

Both require trivial, but not mechanical amounts of work.