### PR TITLE
Bug 1359339 - Use UIInterfaceOrientation instead of UIDevice.current.orientation.

### DIFF
--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -477,7 +477,7 @@ class ASHorizontalScrollCellManager: NSObject, UICollectionViewDelegate, UIColle
 
     func numberOfHorizontalItems() -> Int {
         // The number of items to show per row.
-        if UIDevice.current.orientation == .landscapeLeft || UIDevice.current.orientation == .landscapeRight {
+        if UIInterfaceOrientationIsLandscape(UIApplication.shared.statusBarOrientation) {
             return 8
         } else if UIDevice.current.userInterfaceIdiom == .pad {
             return 6


### PR DESCRIPTION
I couldn't reproduce this bug on the simulator. Which has led me to think that this has to do with the .faceUp / .faceDown orientations in UIDeviceOrientation. 

I don't have a plus sized device but I'm pretty sure this should fix the issue. 