### PR TITLE
Bug 1334997 - 'Add Search Engine' option not displayed after adding a custom search engine

### DIFF
--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -68,6 +68,7 @@ class SearchSettingsTableViewController: UITableViewController {
         // Only show the Edit button if custom search engines are in the list.
         // Otherwise, there is nothing to delete.
         navigationItem.rightBarButtonItem?.isEnabled = isEditable
+        tableView.reloadData()
     }
 
     override func viewDidDisappear(_ animated: Bool) {


### PR DESCRIPTION
When a new Search Engine was added `SearchSettingsTableViewController` was not notified about the changes, this made the 'Add Search Engine' option to disappear. Hence adding a delegate to notify the `SearchSettingsTableViewController` when a new search engine is added.