### PR TITLE
Bug 1367809 - Have a better mechanism to configure the What's New page

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -598,9 +598,12 @@ class BrowserViewController: UIViewController {
         log.debug("BVC done.")
 
         if shouldShowWhatsNewTab() {
-            if let whatsNewURL = SupportUtils.URLForTopic("new-ios") {
-                self.openURLInNewTab(whatsNewURL, isPrivileged: false)
-                profile.prefs.setString(AppInfo.appVersion, forKey: LatestAppVersionProfileKey)
+            // Only display if the SUMO topic has been configured in the Info.plist (present and not empty)
+            if let whatsNewTopic = AppInfo.whatsNewTopic, whatsNewTopic != "" {
+                if let whatsNewURL = SupportUtils.URLForTopic(whatsNewTopic) {
+                    self.openURLInNewTab(whatsNewURL, isPrivileged: false)
+                    profile.prefs.setString(AppInfo.appVersion, forKey: LatestAppVersionProfileKey)
+                }
             }
         }
 

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -8,6 +8,8 @@
 	<string>$(ADJUST_ENVIRONMENT)</string>
 	<key>MozDevelopmentTeam</key>
 	<string>$(DEVELOPMENT_TEAM)</string>
+	<key>MozWhatsNewTopic</key>
+	<string></string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/Shared/AppInfo.swift
+++ b/Shared/AppInfo.swift
@@ -47,4 +47,9 @@ open class AppInfo {
         }
         return baseBundleIdentifier
     }
+
+    // Return the MozWhatsNewTopic key from the Info.plist
+    open static var whatsNewTopic: String? {
+        return Bundle.main.object(forInfoDictionaryKey: "MozWhatsNewTopic") as? String
+    }
 }


### PR DESCRIPTION
This patch moves the *SUMO* topic used for the *What's New* tab out of `BrowserViewController.swift` and into the `Info.plist`. This will make it simpler to change that topic and it also provides a mechanism to disable it on betas. With no value provided, no What's New page will be shown at all. Which is the default state, so no more accidental shipping with *What's New in Firefox for iOS 2.0* popping up.