### PR TITLE
Bug 1367924 - Finding a leak in DeferredUtils.Accumulate

### DIFF
--- a/SharedTests/DeferredTests.swift
+++ b/SharedTests/DeferredTests.swift
@@ -68,4 +68,60 @@ class DeferredTests: XCTestCase {
 
         waitForExpectations(timeout: 10, handler: nil)
     }
+
+    func testPassAccumulate() {
+        let leak = self.expectation(description: "deinit")
+
+        class TestClass {
+            let end: XCTestExpectation
+            init(e: XCTestExpectation) {
+                end = e
+                accumulate([self.aSimpleFunction]).upon { _ in
+
+                }
+            }
+
+            func aSimpleFunction() -> Success {
+                return succeed()
+            }
+            deinit {
+                end.fulfill()
+            }
+        }
+
+        var myclass: TestClass? = TestClass(e: leak)
+        myclass = nil
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+
+    func testFailAccumulate() {
+        let leak = self.expectation(description: "deinit")
+
+        class TestError: MaybeErrorType {
+            var description = "Error"
+        }
+
+        class TestClass {
+            let end: XCTestExpectation
+            init(e: XCTestExpectation) {
+                end = e
+                accumulate([self.aSimpleFunction]).upon { _ in
+
+                }
+            }
+
+            func aSimpleFunction() -> Success {
+                return Deferred(value: Maybe(failure: TestError()))
+            }
+            deinit {
+                end.fulfill()
+            }
+        }
+
+        var myclass: TestClass? = TestClass(e: leak)
+        myclass = nil
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
 }


### PR DESCRIPTION
`onValue` holds a reference to `onResult`. Which holds a reference to onValue creating a reference cycle. 

This wouldn't be so bad but onValue also holds a reference to `thunks` which will never be set to 0. So any methods passed to `accumulate` are never released

On an account with sync enabled. This reduces the number of leaks on launch from 136-> 60. A lot of these were very small to begin with but still good! And when switching between activity stream this brings the leaks down from 192 down to 1! 🕺 

Thanks to @alexpopov for all the help debugging. 
