### PR TITLE
Bug 1353490 - Crash after Handoff to Mac

### DIFF
--- a/Client/Helpers/SpotlightHelper.swift
+++ b/Client/Helpers/SpotlightHelper.swift
@@ -16,9 +16,6 @@ class SpotlightHelper: NSObject {
         willSet {
             activity?.invalidate()
         }
-        didSet {
-            activity?.delegate = self
-        }
     }
 
     fileprivate var urlForThumbnail: URL?
@@ -103,14 +100,6 @@ class SpotlightHelper: NSObject {
 
     func createUserActivity() -> NSUserActivity {
         return NSUserActivity(activityType: browsingActivityType)
-    }
-}
-
-extension SpotlightHelper: NSUserActivityDelegate {
-    @objc func userActivityWasContinued(_ userActivity: NSUserActivity) {
-        if let url = userActivity.webpageURL {
-            createNewTab?(url)
-        }
     }
 }
 


### PR DESCRIPTION
This patch fixes a crash that happens after you Handoff a page to Desktop.

The crash is in the`userActivityWasContinued` delegate method because that is called from a non-Main thread and we have an assertion in there to check for that.

But that is not actually the real problem here. The description of this delegate method says:

> Notifies the delegate that the user activity was continued on another device.

We don't care about that, there is nothing actionable for us to do. We actually try to open the URL that was transferred to Desktop. That makes no sense, since we provided it, it is already open in the last tab that you saw.

So I simply removed the whole delegate because I don't think we need it.