### PR TITLE
Bug 1368953 - Make sure private tabs are closed when pref to remove tabs on exit is on.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -3499,12 +3499,6 @@ extension BrowserViewController: TopTabsDelegate {
             return
         }
         urlBar.leaveOverlayMode()
-        
-        if selectedTab.isPrivate {
-            if profile.prefs.boolForKey("settings.closePrivateTabs") ?? false {
-                tabManager.removeAllPrivateTabsAndNotify(false)
-            }
-        }
     }
     
     func topTabsDidChangeTab() {

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -173,6 +173,11 @@ class TabManager: NSObject {
             return
         }
 
+        // Make sure to wipe the private tabs if the user has the pref turned on
+        if shouldClearPrivateTabs(), !(tab?.isPrivate ?? false) {
+            removeAllPrivateTabsAndNotify(false)
+        }
+
         if let tab = tab {
             _selectedIndex = tabs.index(of: tab) ?? -1
         } else {
@@ -185,6 +190,10 @@ class TabManager: NSObject {
         selectedTab?.createWebview()
 
         delegates.forEach { $0.get()?.tabManager(self, didSelectedTabChange: tab, previous: previous) }
+    }
+
+    func shouldClearPrivateTabs() -> Bool {
+        return prefs.boolForKey("settings.closePrivateTabs") ?? false
     }
 
     func expireSnackbars() {
@@ -410,7 +419,7 @@ class TabManager: NSObject {
     /// Removes all private tabs from the manager.
     /// - Parameter notify: if set to true, the delegate is called when a tab is
     ///   removed.
-    func removeAllPrivateTabsAndNotify(_ notify: Bool) {
+    private func removeAllPrivateTabsAndNotify(_ notify: Bool) {
         // if there is a selected tab, it needs to be closed last
         // this is important for TopTabs as otherwise the selection of the new tab
         // causes problems as it may no longer be present.

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -196,6 +196,14 @@ class TabManager: NSObject {
         return prefs.boolForKey("settings.closePrivateTabs") ?? false
     }
 
+    //Called by other classes to signal that they are entering/exiting private mode
+    //This is called by TabTrayVC when the private mode button is pressed and BEFORE we've switched to the new mode
+    func willSwitchTabMode() {
+        if shouldClearPrivateTabs() && (selectedTab?.isPrivate ?? false) {
+            removeAllPrivateTabsAndNotify(false)
+        }
+    }
+
     func expireSnackbars() {
         assert(Thread.isMainThread)
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -567,9 +567,6 @@ class TabTrayController: UIViewController {
         // If we are exiting private mode and we have the close private tabs option selected, make sure
         // we clear out all of the private tabs
         let exitingPrivateMode = !privateMode && profile.prefs.boolForKey("settings.closePrivateTabs") ?? false
-        if exitingPrivateMode {
-            tabManager.removeAllPrivateTabsAndNotify(false)
-        }
 
         toolbar.maskButton.setSelected(privateMode, animated: true)
         collectionView.layoutSubviews()

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -563,6 +563,7 @@ class TabTrayController: UIViewController {
             fromView = emptyPrivateTabsView
         }
 
+        tabManager.willSwitchTabMode()
         privateMode = !privateMode
         // If we are exiting private mode and we have the close private tabs option selected, make sure
         // we clear out all of the private tabs

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -567,7 +567,7 @@ class TabTrayController: UIViewController {
         privateMode = !privateMode
         // If we are exiting private mode and we have the close private tabs option selected, make sure
         // we clear out all of the private tabs
-        let exitingPrivateMode = !privateMode && profile.prefs.boolForKey("settings.closePrivateTabs") ?? false
+        let exitingPrivateMode = !privateMode && tabManager.shouldClearPrivateTabs()
 
         toolbar.maskButton.setSelected(privateMode, animated: true)
         collectionView.layoutSubviews()

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -217,6 +217,26 @@ class TabManagerTests: XCTestCase {
         delegate.verify("Not all delegate methods were called")
     }
 
+
+    func testDeletePrivateTabsOnExit() {
+        let profile = TabManagerMockProfile()
+        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        profile.prefs.setBool(true, forKey: "settings.closePrivateTabs")
+
+        //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
+        let tab = manager.addTab()
+        manager.selectTab(tab)
+        let privateTab = manager.addTab(isPrivate: true)
+        manager.selectTab(privateTab)
+
+        XCTAssertEqual(manager.selectedTab?.isPrivate, true)
+        XCTAssertEqual(manager.privateTabs.count, 1)
+
+        manager.selectTab(tab)
+
+        XCTAssertEqual(manager.privateTabs.count, 0)
+    }
+
     func testDeleteNonSelectedTab() {
         let profile = TabManagerMockProfile()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -219,23 +219,43 @@ class TabManagerTests: XCTestCase {
 
 
     func testDeletePrivateTabsOnExit() {
+        //setup
         let profile = TabManagerMockProfile()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         profile.prefs.setBool(true, forKey: "settings.closePrivateTabs")
 
-        //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
+        // create one private and one normal tab
         let tab = manager.addTab()
         manager.selectTab(tab)
-        let privateTab = manager.addTab(isPrivate: true)
-        manager.selectTab(privateTab)
+        manager.selectTab(manager.addTab(isPrivate: true))
 
-        XCTAssertEqual(manager.selectedTab?.isPrivate, true)
-        XCTAssertEqual(manager.privateTabs.count, 1)
+        XCTAssertEqual(manager.selectedTab?.isPrivate, true, "The selected tab should be the private tab")
+        XCTAssertEqual(manager.privateTabs.count, 1, "There should only be one private tab")
 
         manager.selectTab(tab)
+        XCTAssertEqual(manager.privateTabs.count, 0, "If the normal tab is selected the private tab should have been deleted")
+        XCTAssertEqual(manager.normalTabs.count, 1, "The regular tab should stil be around")
 
-        XCTAssertEqual(manager.privateTabs.count, 0)
+        manager.selectTab(manager.addTab(isPrivate: true))
+        XCTAssertEqual(manager.privateTabs.count, 1, "There should be one new private tab")
+        manager.willSwitchTabMode()
+        XCTAssertEqual(manager.privateTabs.count, 0, "After willSwitchTabMode there should be no more private tabs")
+
+        manager.selectTab(manager.addTab(isPrivate: true))
+        manager.selectTab(manager.addTab(isPrivate: true))
+        XCTAssertEqual(manager.privateTabs.count, 2, "Private tabs should not be deleted when another one is added")
+        manager.selectTab(manager.addTab())
+        XCTAssertEqual(manager.privateTabs.count, 0, "But once we add a normal tab we've switched out of private mode. Private tabs should be deleted")
+        XCTAssertEqual(manager.normalTabs.count, 2, "The original normal tab and the new one should both still exist")
+
+        profile.prefs.setBool(false, forKey: "settings.closePrivateTabs")
+        manager.selectTab(manager.addTab(isPrivate: true))
+        manager.selectTab(tab)
+        XCTAssertEqual(manager.selectedTab?.isPrivate, false, "The selected tab should not be private")
+        XCTAssertEqual(manager.privateTabs.count, 1, "If the flag is false then private tabs should still exist")
     }
+
+
 
     func testDeleteNonSelectedTab() {
         let profile = TabManagerMockProfile()

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -217,7 +217,6 @@ class TabManagerTests: XCTestCase {
         delegate.verify("Not all delegate methods were called")
     }
 
-
     func testDeletePrivateTabsOnExit() {
         //setup
         let profile = TabManagerMockProfile()
@@ -254,8 +253,6 @@ class TabManagerTests: XCTestCase {
         XCTAssertEqual(manager.selectedTab?.isPrivate, false, "The selected tab should not be private")
         XCTAssertEqual(manager.privateTabs.count, 1, "If the flag is false then private tabs should still exist")
     }
-
-
 
     func testDeleteNonSelectedTab() {
         let profile = TabManagerMockProfile()


### PR DESCRIPTION
I found this feedback in the AppBot reviews. Did some research and looks like this wasnt actually working. 


This is related to the TDES #2759  proposal I had. Moving this logic into tabManager was one of the things I suggested.