### PR TITLE
Bug 1339383 - Batching downloader now fetches the most recent batch first then backfills from oldest

### DIFF
--- a/Sync/StorageClient.swift
+++ b/Sync/StorageClient.swift
@@ -753,7 +753,7 @@ open class Sync15CollectionClient<T: CleartextPayloadJSON> {
      *
      * Only non-JSON and malformed envelopes will be dropped.
      */
-    open func getSince(_ since: Timestamp, sort: SortOption?=nil, limit: Int?=nil, offset: String?=nil) -> Deferred<Maybe<StorageResponse<[Record<T>]>>> {
+    open func getSince(_ since: Timestamp, sort: SortOption?=nil, limit: Int?=nil, offset: String?=nil, directionQuery: String = "newer") -> Deferred<Maybe<StorageResponse<[Record<T>]>>> {
         let deferred = Deferred<Maybe<StorageResponse<[Record<T>]>>>(defaultQueue: client.resultQueue)
 
         // Fills the Deferred for us.
@@ -763,7 +763,7 @@ open class Sync15CollectionClient<T: CleartextPayloadJSON> {
 
         var params: [URLQueryItem] = [
             URLQueryItem(name: "full", value: "1"),
-            URLQueryItem(name: "newer", value: millisecondsToDecimalSeconds(since)),
+            URLQueryItem(name: directionQuery, value: millisecondsToDecimalSeconds(since)),
         ]
 
         if let offset = offset {

--- a/SyncTests/DownloadTests.swift
+++ b/SyncTests/DownloadTests.swift
@@ -61,10 +61,12 @@ class DownloadTests: XCTestCase {
         XCTAssertEqual(1, records1.count)
         XCTAssertEqual(guid1, records1[0].id)
         batcher.advance()
+        // Don't advance the base timestamp if we're only pulling in the first, recent batch.
+        XCTAssertNotEqual(0, batcher.baseTimestamp)
 
         // Fetching again yields nothing, because the collection hasn't
         // changed.
-        XCTAssertEqual(batcher.go(ic1, limit: 1).value.successValue, DownloadEndState.complete)
+        XCTAssertEqual(batcher.go(ic1, limit: 1).value.successValue, DownloadEndState.noNewData)
 
         // More records. Start again.
         let _ = batcher.reset().value
@@ -76,14 +78,14 @@ class DownloadTests: XCTestCase {
         XCTAssertEqual(fetch2.successValue, DownloadEndState.incomplete)
         let records2 = batcher.retrieve()
         XCTAssertEqual(1, records2.count)
-        XCTAssertEqual(guid1, records2[0].id)
+        XCTAssertEqual(guid2, records2[0].id)
         batcher.advance()
 
         let fetch3 = batcher.go(ic2, limit: 1).value
         XCTAssertEqual(fetch3.successValue, DownloadEndState.complete)
         let records3 = batcher.retrieve()
         XCTAssertEqual(1, records3.count)
-        XCTAssertEqual(guid2, records3[0].id)
+        XCTAssertEqual(guid1, records3[0].id)
         batcher.advance()
 
         let fetch4 = batcher.go(ic2, limit: 1).value

--- a/SyncTests/DownloadTests.swift
+++ b/SyncTests/DownloadTests.swift
@@ -61,11 +61,10 @@ class DownloadTests: XCTestCase {
         XCTAssertEqual(1, records1.count)
         XCTAssertEqual(guid1, records1[0].id)
         batcher.advance()
-        XCTAssertNotEqual(0, batcher.baseTimestamp)
 
         // Fetching again yields nothing, because the collection hasn't
         // changed.
-        XCTAssertEqual(batcher.go(ic1, limit: 1).value.successValue, DownloadEndState.noNewData)
+        XCTAssertEqual(batcher.go(ic1, limit: 1).value.successValue, DownloadEndState.complete)
 
         // More records. Start again.
         let _ = batcher.reset().value


### PR DESCRIPTION
A non-intrusive way of making sure we download the most recent batch of records first then backfilling from the oldest.