### PR TITLE
Bug 1364418 – Add a sync delegate to NotificationService…

### DIFF
--- a/Account/FxAPushMessageHandler.swift
+++ b/Account/FxAPushMessageHandler.swift
@@ -83,6 +83,8 @@ extension FxAPushMessageHandler {
                 result = handlePasswordReset()
             case .collectionChanged:
                 result = handleCollectionChanged(json["data"])
+            case .accountVerified:
+                result = handleVerification()
         }
         return result
     }
@@ -96,9 +98,11 @@ extension FxAPushMessageHandler {
         }
 
         // Progress through the FxAStateMachine, then explicitly sync.
-        return account.advance().bind { _ in
-            FxALoginHelper.performVerifiedSync(self.profile, account: account)
-        }
+        // We need a better solution than calling out to FxALoginHelper, because that class isn't 
+        // available in NotificationService, where this class is also used.
+        // Since verification via Push has never been seen to work, we can be comfortable
+        // leaving this as unimplemented.
+        return unimplemented(.accountVerified)
     }
 }
 
@@ -176,6 +180,9 @@ enum PushMessageType: String {
     case passwordChanged = "fxaccounts:password_changed"
     case passwordReset = "fxaccounts:password_reset"
     case collectionChanged = "sync:collection_changed"
+
+    // This isn't a real message type, just the absence of one.
+    case accountVerified = "account_verified"
 }
 
 enum PushMessageError: MaybeErrorType {

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -214,7 +214,6 @@
 		3905274C1C874D35007E0BB7 /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3905274B1C874D35007E0BB7 /* NotificationCenter.framework */; };
 		3905274F1C874D35007E0BB7 /* TodayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3905274E1C874D35007E0BB7 /* TodayViewController.swift */; };
 		390527561C874D35007E0BB7 /* Today.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 3905274A1C874D35007E0BB7 /* Today.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		3905B4E41E8E8C2F0027D953 /* FxAPushMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3905B4D41E8E7A6B0027D953 /* FxAPushMessageHandler.swift */; };
 		39098DC41CAD5ACB00AE87F3 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 391AEFD11C8F11ED00691F84 /* Images.xcassets */; };
 		392ED6B71D06E85E009D9B62 /* NewTabChoiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392ED6B61D06E85E009D9B62 /* NewTabChoiceViewController.swift */; };
 		392ED7E41D0AEF56009D9B62 /* NewTabAccessors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392ED7E31D0AEF56009D9B62 /* NewTabAccessors.swift */; };
@@ -224,6 +223,21 @@
 		394CF6CF1BAA493C00906917 /* DefaultSuggestedSites.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394CF6CE1BAA493C00906917 /* DefaultSuggestedSites.swift */; };
 		3964B09A1EA8F06F00F2EEF4 /* FeatureSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3964B0991EA8F06F00F2EEF4 /* FeatureSwitch.swift */; };
 		3964B09C1EA8F32C00F2EEF4 /* FeatureSwitchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3964B09B1EA8F32C00F2EEF4 /* FeatureSwitchTests.swift */; };
+		396E38CC1EE0816C00CC180F /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC84D1A16C40C00D49B7B /* Profile.swift */; };
+		396E38DD1EE081DA00CC180F /* SyncStatusResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60D03171D511398002FE3F6 /* SyncStatusResolver.swift */; };
+		396E38DE1EE081F500CC180F /* SearchEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = D308E4E31A5306F500842685 /* SearchEngines.swift */; };
+		396E38DF1EE0820400CC180F /* PanelDataObservers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68F36971EA694000048CF44 /* PanelDataObservers.swift */; };
+		396E38E01EE0821B00CC180F /* NSUserDefaultsPrefs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BD19A661A25309B0084FBA7 /* NSUserDefaultsPrefs.swift */; };
+		396E38E11EE0823100CC180F /* OpenSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */; };
+		396E38E31EE083A400CC180F /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288A2D861AB8B3260023ABC3 /* Shared.framework */; };
+		396E38E41EE083A400CC180F /* FxA.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28CE83D01A1D1D5100576538 /* FxA.framework */; };
+		396E38E51EE0843500CC180F /* ReadingList.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4D567181ADECE2700F1EFE7 /* ReadingList.framework */; };
+		396E38E61EE0843500CC180F /* Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FCAE21A1ABB51F800877008 /* Storage.framework */; };
+		396E38ED1EE0C63500CC180F /* Sync.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2827315E1ABC9BE600AA1954 /* Sync.framework */; };
+		396E38EE1EE0C6ED00CC180F /* ExtensionProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396E38DB1EE0818800CC180F /* ExtensionProfile.swift */; };
+		396E38F11EE0C8EC00CC180F /* FxAPushMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3905B4D41E8E7A6B0027D953 /* FxAPushMessageHandler.swift */; };
+		396E38F21EE0C8ED00CC180F /* FxAPushMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3905B4D41E8E7A6B0027D953 /* FxAPushMessageHandler.swift */; };
+		396E38F31EE0C90D00CC180F /* FxALoginHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F99FED1E3A71F800F353B4 /* FxALoginHelper.swift */; };
 		397848DE1ED86605004C0C0B /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397848DD1ED86605004C0C0B /* NotificationService.swift */; };
 		397848E21ED86605004C0C0B /* NotificationService.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 397848DB1ED86605004C0C0B /* NotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		39A359E41BFCCE94006B9E87 /* SpotlightHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A359E31BFCCE94006B9E87 /* SpotlightHelper.swift */; };
@@ -241,7 +255,6 @@
 		39F99FE41E3A6F1700F353B4 /* PushClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F99FD91E3A6DE300F353B4 /* PushClient.swift */; };
 		39F99FE51E3A6F1700F353B4 /* PushConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F99FDA1E3A6DE300F353B4 /* PushConfiguration.swift */; };
 		39F99FE61E3A6F1700F353B4 /* PushRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F99FDB1E3A6DE300F353B4 /* PushRegistration.swift */; };
-		39F99FEE1E3A71F800F353B4 /* FxALoginHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F99FED1E3A71F800F353B4 /* FxALoginHelper.swift */; };
 		3B0943811D6CC4FC004F24E1 /* FilledPageControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0943801D6CC4FC004F24E1 /* FilledPageControl.swift */; };
 		3B39EDBA1E16E18900EF029F /* CustomSearchEnginesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B39EDB91E16E18900EF029F /* CustomSearchEnginesTest.swift */; };
 		3B39EDCB1E16E1AA00EF029F /* CustomSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B39EDCA1E16E1AA00EF029F /* CustomSearchViewController.swift */; };
@@ -941,6 +954,20 @@
 			remoteGlobalIDString = 390527491C874D35007E0BB7;
 			remoteInfo = Today;
 		};
+		396E38E91EE0C48A00CC180F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2FCAE2191ABB51F800877008;
+			remoteInfo = Storage;
+		};
+		396E38EB1EE0C48A00CC180F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2FA435FA1ABB83B4008031D1;
+			remoteInfo = Account;
+		};
 		397848E01ED86605004C0C0B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
@@ -1482,6 +1509,7 @@
 		395C8F201E796AD600A68E8C /* PushCrypto.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushCrypto.swift; sourceTree = "<group>"; };
 		3964B0991EA8F06F00F2EEF4 /* FeatureSwitch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeatureSwitch.swift; sourceTree = "<group>"; };
 		3964B09B1EA8F32C00F2EEF4 /* FeatureSwitchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeatureSwitchTests.swift; sourceTree = "<group>"; };
+		396E38DB1EE0818800CC180F /* ExtensionProfile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionProfile.swift; sourceTree = "<group>"; };
 		397848DB1ED86605004C0C0B /* NotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		397848DD1ED86605004C0C0B /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		397848DF1ED86605004C0C0B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -2110,6 +2138,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				396E38ED1EE0C63500CC180F /* Sync.framework in Frameworks */,
+				396E38E51EE0843500CC180F /* ReadingList.framework in Frameworks */,
+				396E38E61EE0843500CC180F /* Storage.framework in Frameworks */,
+				396E38E31EE083A400CC180F /* Shared.framework in Frameworks */,
+				396E38E41EE083A400CC180F /* FxA.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2689,6 +2722,7 @@
 			children = (
 				397848DF1ED86605004C0C0B /* Info.plist */,
 				397848DD1ED86605004C0C0B /* NotificationService.swift */,
+				396E38DB1EE0818800CC180F /* ExtensionProfile.swift */,
 			);
 			path = NotificationService;
 			sourceTree = "<group>";
@@ -4014,6 +4048,8 @@
 			buildRules = (
 			);
 			dependencies = (
+				396E38EC1EE0C48A00CC180F /* PBXTargetDependency */,
+				396E38EA1EE0C48A00CC180F /* PBXTargetDependency */,
 			);
 			name = NotificationService;
 			productName = NotificationService;
@@ -5300,7 +5336,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				396E38DF1EE0820400CC180F /* PanelDataObservers.swift in Sources */,
 				397848DE1ED86605004C0C0B /* NotificationService.swift in Sources */,
+				396E38DE1EE081F500CC180F /* SearchEngines.swift in Sources */,
+				396E38CC1EE0816C00CC180F /* Profile.swift in Sources */,
+				396E38E01EE0821B00CC180F /* NSUserDefaultsPrefs.swift in Sources */,
+				396E38DD1EE081DA00CC180F /* SyncStatusResolver.swift in Sources */,
+				396E38F21EE0C8ED00CC180F /* FxAPushMessageHandler.swift in Sources */,
+				396E38E11EE0823100CC180F /* OpenSearch.swift in Sources */,
+				396E38EE1EE0C6ED00CC180F /* ExtensionProfile.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5503,12 +5547,14 @@
 				7B3631EA1C244FEE00D12AF9 /* Theme.swift in Sources */,
 				7BC68D321CC153920043562A /* AppMenuItem.swift in Sources */,
 				7BC68CCD1CC152B70043562A /* MenuView.swift in Sources */,
+				396E38F11EE0C8EC00CC180F /* FxAPushMessageHandler.swift in Sources */,
 				E66C5B481BDA81050051AA93 /* UIImage+ImageEffects.m in Sources */,
 				E4CD9F6D1A77DD2800318571 /* ReaderModeStyleViewController.swift in Sources */,
 				E4A960061ABB9C450069AD6F /* ReaderModeUtils.swift in Sources */,
 				E68F36981EA694000048CF44 /* PanelDataObservers.swift in Sources */,
 				31ADB5DA1E58CEC300E87909 /* ClipboardBarDisplayHandler.swift in Sources */,
 				745DAB3F1CDAB09E00D44181 /* HistoryBackButton.swift in Sources */,
+				396E38F31EE0C90D00CC180F /* FxALoginHelper.swift in Sources */,
 				D3B6923F1B9F9A58004B87A4 /* FindInPageHelper.swift in Sources */,
 				D3C3696E1CC6B78800348A61 /* LocalRequestHelper.swift in Sources */,
 				E4B423DD1ABA0318007E66C8 /* ReaderModeHandlers.swift in Sources */,
@@ -5569,7 +5615,6 @@
 				742A56391D80B54A00BDB803 /* ActionOverlayTableViewController.swift in Sources */,
 				C4EFEECF1CEBB6F2009762A4 /* BackForwardTableViewCell.swift in Sources */,
 				E689C7301E0C7617008BAADB /* NSAttributedStringExtensions.swift in Sources */,
-				3905B4E41E8E8C2F0027D953 /* FxAPushMessageHandler.swift in Sources */,
 				E64ED8FA1BC55AE300DAF864 /* UIAlertControllerExtensions.swift in Sources */,
 				282DA4731A68C1E700A406E2 /* OpenSearch.swift in Sources */,
 				F35B8D2F1D638408008E3D61 /* SessionRestoreHandler.swift in Sources */,
@@ -5613,7 +5658,6 @@
 				A9072B801D07B34100459960 /* NoImageModeHelper.swift in Sources */,
 				E660BDD91BB06521009AC090 /* TabsButton.swift in Sources */,
 				2F44FCCB1A9E972E00FD20CC /* SearchEnginePicker.swift in Sources */,
-				39F99FEE1E3A71F800F353B4 /* FxALoginHelper.swift in Sources */,
 				D02816C21ECA5E2A00240CAA /* HistoryStateHelper.swift in Sources */,
 				E68E7ACB1CAC1D4500FDCA76 /* PagingPasscodeViewController.swift in Sources */,
 				D34DC8531A16C40C00D49B7B /* Profile.swift in Sources */,
@@ -5880,6 +5924,16 @@
 			isa = PBXTargetDependency;
 			target = 390527491C874D35007E0BB7 /* Today */;
 			targetProxy = 390527541C874D35007E0BB7 /* PBXContainerItemProxy */;
+		};
+		396E38EA1EE0C48A00CC180F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2FCAE2191ABB51F800877008 /* Storage */;
+			targetProxy = 396E38E91EE0C48A00CC180F /* PBXContainerItemProxy */;
+		};
+		396E38EC1EE0C48A00CC180F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2FA435FA1ABB83B4008031D1 /* Account */;
+			targetProxy = 396E38EB1EE0C48A00CC180F /* PBXContainerItemProxy */;
 		};
 		397848E11ED86605004C0C0B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -6257,6 +6311,7 @@
 				CODE_SIGN_ENTITLEMENTS = "$(SRCROOT)/Extensions/Entitlements/FennecEnterprise.entitlements";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = "";
+				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Extensions/NotificationService/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.FennecEnterprise.NotificationService;
@@ -6294,6 +6349,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 43AQ936H96;
+				ENABLE_BITCODE = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -6355,6 +6411,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
+				ENABLE_BITCODE = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -6408,6 +6465,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
+				ENABLE_BITCODE = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -782,11 +782,12 @@ extension AppDelegate {
                 return URL(string: tabURL)
             }
 
-            for url in receivedURLs {
-                browserViewController.switchToTabForURLOrOpen(url, isPrivileged: false)
-            }
-
             if receivedURLs.count > 0 {
+                DispatchQueue.main.async {
+                    for url in receivedURLs {
+                        self.browserViewController.switchToTabForURLOrOpen(url, isPrivileged: false)
+                    }
+                }
                 return completionHandler(.newData)
             }
         }

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -758,10 +758,45 @@ extension AppDelegate {
     func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
         NSLog("APNS NOTIFICATION \(userInfo)")
 
+        // At this point, we know that NotificationService has been run.
+        // We get to this point if the notification was received while the app was in the foreground
+        // OR the app was backgrounded and now the user has tapped on the notification.
+        // Either way, if this method is being run, then the app is foregrounded.
+
+        // Either way, we should zero the badge number.
+        application.applicationIconBadgeNumber = 0
+
         guard let profile = self.profile else {
             return completionHandler(.noData)
         }
 
+        // NotificationService will have decrypted the push message, and done some syncing 
+        // activity. If the `client` collection was synced, and there are `displayURI` commands (i.e. sent tabs)
+        // NotificationService will have collected them for us in the userInfo.
+        if let serializedTabs = userInfo["sentTabs"] as? [[String: String]] {
+            // Let's go ahead and open those.
+            let receivedURLs = serializedTabs.flatMap { item -> URL? in
+                guard let tabURL = item["url"] else {
+                    return nil
+                }
+                return URL(string: tabURL)
+            }
+
+            for url in receivedURLs {
+                browserViewController.switchToTabForURLOrOpen(url, isPrivileged: false)
+            }
+
+            if receivedURLs.count > 0 {
+                return completionHandler(.newData)
+            }
+        }
+
+        // So we've got here, and there are no sent tabs.
+        // There are a number of possibilities here: 
+        // a) we started syncing in the NotificationService, but aborted once we reached the end.
+        // b) we did some non-displayURI commands which finished properly.
+        // 
+        // For now, we should just re-process the message handling.
         let handler = FxAPushMessageHandler(with: profile)
         handler.handle(userInfo: userInfo).upon { res in
             completionHandler(res.isSuccess ? .newData : .failed)
@@ -769,13 +804,8 @@ extension AppDelegate {
     }
 
     func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any]) {
-        log.info("APNS NOTIFICATION \(userInfo)")
-        guard let profile = self.profile else {
-            return
-        }
-
-        let handler = FxAPushMessageHandler(with: profile)
-        handler.handle(userInfo: userInfo)
+        let completionHandler: (UIBackgroundFetchResult) -> Void = { _ in }
+        self.application(application, didReceiveRemoteNotification: userInfo, fetchCompletionHandler: completionHandler)
     }
 }
 

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -451,6 +451,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         // We could load these here, but then we have to futz with the tab counter
         // and making NSURLRequests.
         self.browserViewController.loadQueuedTabs()
+        application.applicationIconBadgeNumber = 0
 
         // handle quick actions is available
         let quickActions = QuickActions.sharedInstance

--- a/Extensions/NotificationService/ExtensionProfile.swift
+++ b/Extensions/NotificationService/ExtensionProfile.swift
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Sync
+
+// This is a cut down version of the Profile. 
+// This will only ever be used in the NotificationService extension.
+// It allows us to customize the SyncDelegate, and later the SyncManager.
+class ExtensionProfile: BrowserProfile {
+    let syncDelegate: SyncDelegate
+
+    init(localName: String, delegate: SyncDelegate) {
+        syncDelegate = delegate
+        super.init(localName: localName, app: nil, clear: false)
+    }
+
+    override func getSyncDelegate() -> SyncDelegate {
+        return syncDelegate
+    }
+}

--- a/Extensions/NotificationService/ExtensionProfile.swift
+++ b/Extensions/NotificationService/ExtensionProfile.swift
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import Shared
+import Storage
 import Sync
 
 // This is a cut down version of the Profile. 
@@ -10,6 +12,14 @@ import Sync
 // It allows us to customize the SyncDelegate, and later the SyncManager.
 class ExtensionProfile: BrowserProfile {
     var syncDelegate: SyncDelegate!
+
+    override var logins: BrowserLogins & SyncableLogins & ResettableSyncStorage {
+        get {
+            fatalError("Cannot use logins.db in extension")
+        }
+        set {}
+    }
+
 
     init(localName: String) {
         super.init(localName: localName, app: nil, clear: false)
@@ -19,8 +29,9 @@ class ExtensionProfile: BrowserProfile {
     override func getSyncDelegate() -> SyncDelegate {
         return syncDelegate
     }
-
 }
+
+fileprivate let extensionSafeNames = Set(["clients"])
 
 class ExtensionSyncManager: BrowserProfile.BrowserSyncManager {
 
@@ -28,7 +39,14 @@ class ExtensionSyncManager: BrowserProfile.BrowserSyncManager {
         super.init(profile: profile)
     }
 
+    // We don't want to send ping data at all while we're in the extension.
     override func canSendUsageData() -> Bool {
         return false
+    }
+
+    // We should probably only want to sync client commands while we're in the extension.
+    override func syncNamedCollections(why: SyncReason, names: [String]) -> Success {
+        let names = names.filter { extensionSafeNames.contains($0) }
+        return super.syncNamedCollections(why: why, names: names)
     }
 }

--- a/Extensions/NotificationService/ExtensionProfile.swift
+++ b/Extensions/NotificationService/ExtensionProfile.swift
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import Deferred
 import Foundation
 import Shared
 import Storage
@@ -48,5 +49,9 @@ class ExtensionSyncManager: BrowserProfile.BrowserSyncManager {
     override func syncNamedCollections(why: SyncReason, names: [String]) -> Success {
         let names = names.filter { extensionSafeNames.contains($0) }
         return super.syncNamedCollections(why: why, names: names)
+    }
+
+    override func takeActionsOnEngineStateChanges<T: EngineStateChanges>(_ changes: T) -> Deferred<Maybe<T>> {
+        return deferMaybe(changes)
     }
 }

--- a/Extensions/NotificationService/ExtensionProfile.swift
+++ b/Extensions/NotificationService/ExtensionProfile.swift
@@ -21,7 +21,6 @@ class ExtensionProfile: BrowserProfile {
         set {}
     }
 
-
     init(localName: String) {
         super.init(localName: localName, app: nil, clear: false)
         syncManager = ExtensionSyncManager(profile: self)

--- a/Extensions/NotificationService/ExtensionProfile.swift
+++ b/Extensions/NotificationService/ExtensionProfile.swift
@@ -9,14 +9,26 @@ import Sync
 // This will only ever be used in the NotificationService extension.
 // It allows us to customize the SyncDelegate, and later the SyncManager.
 class ExtensionProfile: BrowserProfile {
-    let syncDelegate: SyncDelegate
+    var syncDelegate: SyncDelegate!
 
-    init(localName: String, delegate: SyncDelegate) {
-        syncDelegate = delegate
+    init(localName: String) {
         super.init(localName: localName, app: nil, clear: false)
+        syncManager = ExtensionSyncManager(profile: self)
     }
 
     override func getSyncDelegate() -> SyncDelegate {
         return syncDelegate
+    }
+
+}
+
+class ExtensionSyncManager: BrowserProfile.BrowserSyncManager {
+
+    init(profile: ExtensionProfile) {
+        super.init(profile: profile)
+    }
+
+    override func canSendUsageData() -> Bool {
+        return false
     }
 }

--- a/Extensions/NotificationService/Info.plist
+++ b/Extensions/NotificationService/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>MozDevelopmentTeam</key>
+	<string>$(DEVELOPMENT_TEAM)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/Extensions/NotificationService/NotificationService.swift
+++ b/Extensions/NotificationService/NotificationService.swift
@@ -66,7 +66,7 @@ class SyncDataDisplay {
         let serializedTabs = sentTabs.flatMap { t -> NSDictionary? in
             return [
                 "title": t.title,
-                "url": t.url,
+                "url": t.url.absoluteString,
                 ] as NSDictionary
             } as NSArray
         userInfo["sentTabs"] = serializedTabs
@@ -82,20 +82,20 @@ class SyncDataDisplay {
 
         switch sentTabs.count {
         case 0:
-            notificationContent.title = "Firefox Accounts"
-            notificationContent.body = "Tap to begin"
+            notificationContent.title = Strings.SentTab_NoTabArrivingNotification_title
+            notificationContent.body = Strings.SentTab_NoTabArrivingNotification_body
         case 1:
             if SystemUtils.isDeviceLocked() {
-                notificationContent.title = "Received \(sentTabs.count) tab"
-                notificationContent.body = "Tap to open"
+                notificationContent.title = Strings.SentTab_UnnamedTabArrivingNotification_title
+                notificationContent.body = String(format: Strings.SentTab_UnnamedTabArrivingNotificationNoDevice_body, 1)
             } else {
                 let tab = sentTabs[0]
-                notificationContent.title = "Tap to open \(tab.title)"
-                notificationContent.body = "\(tab.url)"
+                notificationContent.title = Strings.SentTab_TabArrivingNotificationNoDevice_title
+                notificationContent.body = tab.url.absoluteDisplayString
             }
         default:
-            notificationContent.title = "Received \(sentTabs.count) tabs"
-            notificationContent.body = "Tap to open"
+            notificationContent.title = Strings.SentTab_TabsArrivingNotification_title
+            notificationContent.body = String(format: Strings.SentTab_TabsArrivingNotificationNoDevice_body, sentTabs.count)
         }
 
         contentHandler(notificationContent)
@@ -105,12 +105,12 @@ class SyncDataDisplay {
 extension SyncDataDisplay: SyncDelegate {
     func displaySentTabForURL(_ URL: URL, title: String) {
         if URL.isWebPage() {
-            sentTabs.append(SentTab(url: URL.absoluteString, title: title))
+            sentTabs.append(SentTab(url: URL, title: title))
         }
     }
 }
 
 struct SentTab {
-    let url: String
+    let url: URL
     let title: String
 }

--- a/Extensions/NotificationService/NotificationService.swift
+++ b/Extensions/NotificationService/NotificationService.swift
@@ -9,7 +9,10 @@ import UserNotifications
 
 class NotificationService: UNNotificationServiceExtension {
     var display: SyncDataDisplay!
-    var profile: Profile!
+    lazy var profile: ExtensionProfile = {
+        NSLog("APNS ExtensionProfile being created")
+        return ExtensionProfile(localName: "profile")
+    }()
 
     override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
 
@@ -21,7 +24,7 @@ class NotificationService: UNNotificationServiceExtension {
         NSLog("NotificationService APNS NOTIFICATION \(userInfo)")
 
         self.display = SyncDataDisplay(content: content, contentHandler: contentHandler)
-        self.profile = ExtensionProfile(localName: "profile", delegate: display)
+        self.profile.syncDelegate = display
 
         let handler = FxAPushMessageHandler(with: profile)
 

--- a/Extensions/NotificationService/NotificationService.swift
+++ b/Extensions/NotificationService/NotificationService.swift
@@ -2,34 +2,96 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import Storage
+import Sync
 import UserNotifications
 
 class NotificationService: UNNotificationServiceExtension {
-
-    var contentHandler: ((UNNotificationContent) -> Void)?
-    var bestAttemptContent: UNMutableNotificationContent?
+    var display: SyncDataDisplay!
+    var profile: Profile!
 
     override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
-        self.contentHandler = contentHandler
-        bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
 
-        var userInfo = request.content.userInfo
-        userInfo["url"] = "https://mozilla.org"
+        guard let content = (request.content.mutableCopy() as? UNMutableNotificationContent) else {
+            return
+        }
+
+        let userInfo = request.content.userInfo
         NSLog("NotificationService APNS NOTIFICATION \(userInfo)")
-        if let bestAttemptContent = bestAttemptContent {
-            // Modify the notification content here...
-            bestAttemptContent.title = "\(bestAttemptContent.title) [modified]"
-            bestAttemptContent.userInfo = userInfo
-            contentHandler(bestAttemptContent)
+
+        self.display = SyncDataDisplay(content: content, contentHandler: contentHandler)
+        self.profile = ExtensionProfile(localName: "profile", delegate: display)
+
+        let handler = FxAPushMessageHandler(with: profile)
+
+        handler.handle(userInfo: userInfo).upon {_ in
+            self.display.displayNotification(true)
         }
     }
     
     override func serviceExtensionTimeWillExpire() {
         // Called just before the extension will be terminated by the system.
         // Use this as an opportunity to deliver your "best attempt" at modified content, otherwise the original push payload will be used.
-        if let contentHandler = contentHandler, let bestAttemptContent =  bestAttemptContent {
-            contentHandler(bestAttemptContent)
-        }
+        display?.displayNotification(false)
+    }
+}
+
+class SyncDataDisplay {
+    var contentHandler: ((UNNotificationContent) -> Void)
+    var notificationContent: UNMutableNotificationContent
+    var sentTabs: [ShareItem]
+
+    init(content: UNMutableNotificationContent, contentHandler: @escaping (UNNotificationContent) -> Void) {
+        self.contentHandler = contentHandler
+        self.notificationContent = content
+        self.sentTabs = []
     }
 
+    func displayNotification(_ didFinish: Bool) {
+        var userInfo = notificationContent.userInfo
+
+        // Add the tabs we've found to userInfo, so that the AppDelegate 
+        // doesn't have to do it again.
+        let serializedTabs = sentTabs.flatMap { shareItem in
+            return [
+                "title": shareItem.title,
+                "url": shareItem.url,
+            ]
+        }
+
+        userInfo["sentTabs"] = serializedTabs
+
+        userInfo["didFinish"] = didFinish
+
+        // Increment the badges. This may cause us to find bugs with multiple 
+        // notifications in the future.
+        let badge = (notificationContent.badge?.intValue ?? 0) + sentTabs.count
+        notificationContent.badge = NSNumber(value: badge)
+
+        notificationContent.userInfo = userInfo
+
+        switch sentTabs.count {
+        case 0:
+            notificationContent.title = "Firefox Accounts"
+            notificationContent.body = "Tap to begin"
+        case 1:
+            let tab = sentTabs[0]
+            let title = tab.title ?? "a tab"
+            notificationContent.title = "Tap to open \(title)"
+            notificationContent.body = "\(tab.url)"
+        default:
+            notificationContent.title = "Received \(sentTabs.count) tabs"
+            notificationContent.body = "Tap to open"
+        }
+
+        contentHandler(notificationContent)
+    }
+}
+
+extension SyncDataDisplay: SyncDelegate {
+    func displaySentTabForURL(_ URL: URL, title: String) {
+        if URL.isWebPage() {
+            sentTabs.append(ShareItem(url: URL.absoluteString, title: title, favicon: nil))
+        }
+    }
 }

--- a/Extensions/NotificationService/NotificationService.swift
+++ b/Extensions/NotificationService/NotificationService.swift
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import Shared
 import Storage
 import Sync
 import UserNotifications
@@ -75,10 +76,15 @@ class SyncDataDisplay {
             notificationContent.title = "Firefox Accounts"
             notificationContent.body = "Tap to begin"
         case 1:
-            let tab = sentTabs[0]
-            let title = tab.title ?? "a tab"
-            notificationContent.title = "Tap to open \(title)"
-            notificationContent.body = "\(tab.url)"
+            if SystemUtils.isDeviceLocked() {
+                notificationContent.title = "Received \(sentTabs.count) tab"
+                notificationContent.body = "Tap to open"
+            } else {
+                let tab = sentTabs[0]
+                let title = tab.title ?? "a tab"
+                notificationContent.title = "Tap to open \(title)"
+                notificationContent.body = "\(tab.url)"
+            }
         default:
             notificationContent.title = "Received \(sentTabs.count) tabs"
             notificationContent.body = "Tap to open"

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -584,7 +584,7 @@ open class BrowserProfile: Profile {
     }
 
     // Extends NSObject so we can use timers.
-    class BrowserSyncManager: NSObject, SyncManager {
+    public class BrowserSyncManager: NSObject, SyncManager {
         // We shouldn't live beyond our containing BrowserProfile, either in the main app or in
         // an extension.
         // But it's possible that we'll finish a side-effect sync after we've ditched the profile
@@ -599,12 +599,12 @@ open class BrowserProfile: Profile {
         fileprivate var syncTimer: Timer?
 
         fileprivate var backgrounded: Bool = true
-        func applicationDidEnterBackground() {
+        public func applicationDidEnterBackground() {
             self.backgrounded = true
             self.endTimedSyncs()
         }
 
-        func applicationDidBecomeActive() {
+        public func applicationDidBecomeActive() {
             self.backgrounded = false
 
             guard self.profile.hasSyncableAccount() else {
@@ -634,13 +634,13 @@ open class BrowserProfile: Profile {
          */
         fileprivate let syncLock = NSRecursiveLock()
 
-        var isSyncing: Bool {
+        public var isSyncing: Bool {
             syncLock.lock()
             defer { syncLock.unlock() }
             return syncDisplayState != nil && syncDisplayState! == .inProgress
         }
 
-        var syncDisplayState: SyncDisplayState?
+        public var syncDisplayState: SyncDisplayState?
 
         // The dispatch queue for coordinating syncing and resetting the database.
         fileprivate let syncQueue = DispatchQueue(label: "com.mozilla.firefox.sync")
@@ -673,7 +673,7 @@ open class BrowserProfile: Profile {
             syncReducer = nil
         }
 
-        fileprivate func canSendUsageData() -> Bool {
+        func canSendUsageData() -> Bool {
             return profile.prefs.boolForKey("settings.sendUsageData") ?? true
         }
 
@@ -839,7 +839,7 @@ open class BrowserProfile: Profile {
             }
         }
 
-        var lastSyncFinishTime: Timestamp? {
+        public var lastSyncFinishTime: Timestamp? {
             get {
                 return self.prefs.timestampForKey(PrefsKeys.KeyLastSyncFinishTime)
             }
@@ -871,7 +871,7 @@ open class BrowserProfile: Profile {
             return self.prefs.branch("sync")
         }
 
-        func onAddedAccount() -> Success {
+        public func onAddedAccount() -> Success {
             // Only sync if we're green lit. This makes sure that we don't sync unverified accounts.
             guard self.profile.hasSyncableAccount() else { return succeed() }
 
@@ -915,11 +915,11 @@ open class BrowserProfile: Profile {
             }
         }
 
-        func onNewProfile() {
+        public func onNewProfile() {
             SyncStateMachine.clearStateFromPrefs(self.prefsForSync)
         }
 
-        func onRemovedAccount(_ account: FirefoxAccount?) -> Success {
+        public func onRemovedAccount(_ account: FirefoxAccount?) -> Success {
             let profile = self.profile
 
             // Run these in order, because they might write to the same DB!
@@ -950,7 +950,7 @@ open class BrowserProfile: Profile {
             return Timer.scheduledTimer(timeInterval: interval, target: self, selector: selector, userInfo: nil, repeats: true)
         }
 
-        func beginTimedSyncs() {
+        public func beginTimedSyncs() {
             if self.syncTimer != nil {
                 log.debug("Already running sync timer.")
                 return
@@ -966,7 +966,7 @@ open class BrowserProfile: Profile {
          * The caller is responsible for calling this on the same thread on which it called
          * beginTimedSyncs.
          */
-        func endTimedSyncs() {
+        public func endTimedSyncs() {
             if let t = self.syncTimer {
                 log.debug("Stopping sync timer.")
                 self.syncTimer = nil
@@ -1126,7 +1126,7 @@ open class BrowserProfile: Profile {
             }
         }
 
-        @discardableResult func syncEverything(why: SyncReason) -> Success {
+        @discardableResult public func syncEverything(why: SyncReason) -> Success {
             return self.syncSeveral(
                 why: why,
                 synchronizers:
@@ -1182,20 +1182,20 @@ open class BrowserProfile: Profile {
             self.syncEverything(why: .scheduled)
         }
 
-        func hasSyncedHistory() -> Deferred<Maybe<Bool>> {
+        public func hasSyncedHistory() -> Deferred<Maybe<Bool>> {
             return self.profile.history.hasSyncedHistory()
         }
 
-        func hasSyncedLogins() -> Deferred<Maybe<Bool>> {
+        public func hasSyncedLogins() -> Deferred<Maybe<Bool>> {
             return self.profile.logins.hasSyncedLogins()
         }
 
-        func syncClients() -> SyncResult {
+        public func syncClients() -> SyncResult {
             // TODO: recognize .NotStarted.
             return self.sync("clients", function: syncClientsWithDelegate)
         }
 
-        func syncClientsThenTabs() -> SyncResult {
+        public func syncClientsThenTabs() -> SyncResult {
             return self.syncSeveral(
                 why: .user,
                 synchronizers:
@@ -1206,11 +1206,11 @@ open class BrowserProfile: Profile {
             }
         }
 
-        @discardableResult func syncLogins() -> SyncResult {
+        @discardableResult public func syncLogins() -> SyncResult {
             return self.sync("logins", function: syncLoginsWithDelegate)
         }
 
-        func syncHistory() -> SyncResult {
+        public func syncHistory() -> SyncResult {
             // TODO: recognize .NotStarted.
             return self.sync("history", function: syncHistoryWithDelegate)
         }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -465,7 +465,7 @@ open class BrowserProfile: Profile {
         return ClosedTabsStore(prefs: self.prefs)
     }()
 
-    fileprivate func getSyncDelegate() -> SyncDelegate {
+    open func getSyncDelegate() -> SyncDelegate {
         if let app = self.app {
             return BrowserProfileSyncDelegate(app: app)
         }

--- a/Shared/Extensions/NSURLExtensions.swift
+++ b/Shared/Extensions/NSURLExtensions.swift
@@ -168,7 +168,7 @@ extension URL {
         return nil
     }
 
-    public var absoluteDisplayString: String? {
+    public var absoluteDisplayString: String {
         var urlString = self.absoluteString
         // For http URLs, get rid of the trailing slash if the path is empty or '/'
         if (self.scheme == "http" || self.scheme == "https") && (self.path == "/") && urlString.endsWith("/") {


### PR DESCRIPTION
… and handle the push notification as received. 

This is the minimal effort to achieve sent tabs.

It is not localized, it is not optimized for very large collections, and does not reject any collections because we're syncing in the background.

It does handle multiple tabs being sent. Once the notification is tapped on (when backgrounded), the app will foreground and then open the tab(s).

If no tabs have been sent, then the app will re-decrypt and parse the message.

https://bugzilla.mozilla.org/show_bug.cgi?id=1364418