### PR TITLE
Bug 1370273 - Include a separate Adjust profile in Firefox Beta

### DIFF
--- a/buddybuild_prebuild.sh
+++ b/buddybuild_prebuild.sh
@@ -7,8 +7,8 @@
 
 if [ "$BUDDYBUILD_SCHEME" == FirefoxBeta ]; then
   echo "Setting Adjust environment to SANDBOX for $BUDDYBUILD_SCHEME"
-  /usr/libexec/PlistBuddy -c "Set AdjustAppToken $ADJUST_KEY_SANDBOX" "Client/Info.plist"
-  /usr/libexec/PlistBuddy -c "Set AdjustEnvironment sandbox" "Client/Info.plist"
+  /usr/libexec/PlistBuddy -c "Set AdjustAppToken $ADJUST_KEY_BETA" "Client/Info.plist"
+  /usr/libexec/PlistBuddy -c "Set AdjustEnvironment production" "Client/Info.plist"
 elif [ "$BUDDYBUILD_SCHEME" == Firefox ]; then
   echo "Setting Adjust environment to PRODUCTION for $BUDDYBUILD_SCHEME"
   /usr/libexec/PlistBuddy -c "Set AdjustAppToken $ADJUST_KEY_PRODUCTION" "Client/Info.plist"


### PR DESCRIPTION
This bug just sets a separate Beta token for *Firefox Beta*. Previously it was using the *Sandbox* for the *Release* token.