### PR TITLE
Bug 1365252 - Add loading indicator after sending a tab

### DIFF
--- a/Extensions/SendTo/ClientPickerViewController.swift
+++ b/Extensions/SendTo/ClientPickerViewController.swift
@@ -215,6 +215,14 @@ class ClientPickerViewController: UITableViewController {
             clients.append(self.clients[(indexPath as AnyObject).row])
         }
         clientPickerDelegate?.clientPickerViewController(self, didPickClients: clients)
+
+        // Replace the Send button with a loading indicator since it takes a while to sync
+        // up our changes to the server.
+        let loadingIndicator = UIActivityIndicatorView(frame: CGRect(x: 0, y: 0, width: 25, height: 25))
+        loadingIndicator.color = .darkGray
+        loadingIndicator.startAnimating()
+        let customBarButton = UIBarButtonItem(customView: loadingIndicator)
+        self.navigationItem.rightBarButtonItem = customBarButton
     }
 }
 


### PR DESCRIPTION
Due to the nature of extensions on iOS, we need the sending of the client to the server to complete before we can close down the modal. I think once we use push for sending tabs this won't be that much of an issue but for now I've added some code that replaces the send button with a loading indicator to give the user feedback that something is happening.