### PR TITLE
Bug 1372093 - Update UIImageColor dependency and fix same color issues with favicons

### DIFF
--- a/Client/Extensions/UIImageViewExtensions.swift
+++ b/Client/Extensions/UIImageViewExtensions.swift
@@ -43,8 +43,14 @@ public extension UIImageView {
             completionBlock?(color, url)
         } else {
             image.getColors(scaleDownSize: CGSize(width: 25, height: 25)) {colors in
-                completionBlock?(colors.backgroundColor, url)
-                FaviconFetcher.colors[domain] = colors.backgroundColor
+                let isSame = [colors.primary, colors.secondary, colors.detail].every { $0 == colors.primary }
+                if isSame {
+                    completionBlock?(UIColor.white, url)
+                    FaviconFetcher.colors[domain] = UIColor.white
+                } else {
+                    completionBlock?(colors.background, url)
+                    FaviconFetcher.colors[domain] = colors.background
+                }
             }
         }
     }


### PR DESCRIPTION
The UIImageColors dependency has been updated with a fix for transparent icons. Sites like google.com would end up with weird black/white background for favicons because UIImageColors would use the transparent pixels in the favicons to calculate background colors. 

https://github.com/jathu/UIImageColors

I've also fixed a bug with sites like bloomberg.com that consisted of a single color. Sites like that would end up with a background color that matched the favicon resulting in not being able to see the favicon.


Sites like drive.google.com and bloomberg.com have better favicons now 😄 