### PR TITLE
Bug 1372498 - Remove viewCount from query as we dont actually need it

### DIFF
--- a/Storage/SQL/SQLiteHistoryRecommendations.swift
+++ b/Storage/SQL/SQLiteHistoryRecommendations.swift
@@ -109,7 +109,7 @@ extension SQLiteHistory: HistoryRecommendations {
     public func getRecentBookmarks(_ limit: Int = 3) -> Deferred<Maybe<Cursor<Site>>> {
         let fiveDaysAgo: UInt64 = Date.now() - (OneDayInMilliseconds * 5) // The data is joined with a millisecond not a microsecond one. (History)
 
-        let subQuerySiteProjection = "historyID, url, siteTitle, guid, visitCount, is_bookmarked"
+        let subQuerySiteProjection = "historyID, url, siteTitle, guid, is_bookmarked"
         let removeMultipleDomainsSubquery =
             " INNER JOIN (SELECT \(ViewHistoryVisits).domain_id AS domain_id" +
             " FROM \(ViewHistoryVisits)" +
@@ -117,14 +117,14 @@ extension SQLiteHistory: HistoryRecommendations {
 
         let bookmarkHighlights =
             "SELECT \(subQuerySiteProjection) FROM (" +
-                "   SELECT \(TableHistory).id AS historyID, \(TableHistory).url AS url, \(TableHistory).title AS siteTitle, guid, \(TableHistory).domain_id, NULL AS visitDate, (SELECT count(1) FROM visits WHERE \(TableVisits).siteID = \(TableHistory).id) as visitCount, 1 AS is_bookmarked" +
+                "   SELECT \(TableHistory).id AS historyID, \(TableHistory).url AS url, \(TableHistory).title AS siteTitle, guid, \(TableHistory).domain_id, NULL AS visitDate, 1 AS is_bookmarked" +
                 "   FROM (" +
                 "       SELECT bmkUri" +
                 "       FROM \(ViewBookmarksLocalOnMirror)" +
                 "       WHERE \(ViewBookmarksLocalOnMirror).server_modified > ? OR \(ViewBookmarksLocalOnMirror).local_modified > ?" +
                 "   )" +
                 "   LEFT JOIN \(TableHistory) ON \(TableHistory).url = bmkUri" + removeMultipleDomainsSubquery +
-                "   WHERE visitCount >= 2 AND \(TableHistory).title NOT NULL and \(TableHistory).title != '' AND url NOT IN" +
+                "   WHERE \(TableHistory).title NOT NULL and \(TableHistory).title != '' AND url NOT IN" +
                 "       (SELECT \(TableActivityStreamBlocklist).url FROM \(TableActivityStreamBlocklist))" +
                 "   LIMIT \(limit)" +
             ")"

--- a/StorageTests/TestSQLiteHistoryRecommendations.swift
+++ b/StorageTests/TestSQLiteHistoryRecommendations.swift
@@ -21,12 +21,14 @@ class TestSQLiteHistoryRecommendations: XCTestCase {
     var prefs: MockProfilePrefs!
     var history: SQLiteHistory!
     var bookmarks: MergedSQLiteBookmarks!
+    var metadata: SQLiteMetadata!
 
     override func setUp() {
         super.setUp()
 
         db = BrowserDB(filename: "browser.db", files: files)
         db.attachDB(filename: "metadata.db", as: AttachedDatabaseMetadata)
+        metadata = SQLiteMetadata(db: db)
         prefs = MockProfilePrefs()
         history = SQLiteHistory(db: db, prefs: prefs)
         bookmarks = MergedSQLiteBookmarks(db: db)
@@ -101,7 +103,6 @@ class TestSQLiteHistoryRecommendations: XCTestCase {
         XCTAssertEqual(highlights[0]!.title, "A")
         XCTAssertEqual(highlights[1]!.title, "C")
     }
-
 
     /*
      * Verify that we do not return a highlight if
@@ -188,14 +189,6 @@ class TestSQLiteHistoryRecommendations: XCTestCase {
     }
 
     func testBookmarkHighlights() {
-        let files = MockFiles()
-        let db = BrowserDB(filename: "browser.db", files: files)
-        db.attachDB(filename: "metadata.db", as: AttachedDatabaseMetadata)
-        let prefs = MockProfilePrefs()
-        let metadata = SQLiteMetadata(db: db)
-        let history = SQLiteHistory(db: db, prefs: prefs)
-        let bookmarks = MergedSQLiteBookmarks(db: db)
-
         history.clearHistory().succeeded()
         populateForRecommendationCalculations(history, bookmarks: bookmarks, metadata: metadata, historyCount: 10, bookmarkCount: 10)
 

--- a/StorageTests/TestSQLiteMetadata.swift
+++ b/StorageTests/TestSQLiteMetadata.swift
@@ -17,13 +17,14 @@ class TestSQLiteMetadata: XCTestCase {
     override func setUp() {
         super.setUp()
         self.db = BrowserDB(filename: "foo.db", files: self.files)
-        self.db.attachDB(filename: "metadata.db", as: AttachedDatabaseMetadata)
+        self.db.attachDB(filename: "metatest.db", as: AttachedDatabaseMetadata)
         XCTAssertTrue(db.createOrUpdate(BrowserTable()) == .success)
 
         self.metadata = SQLiteMetadata(db: db)
     }
 
     override func tearDown() {
+
         removeAllMetadata(self.db).succeeded()
         super.tearDown()
     }


### PR DESCRIPTION
Bryan requested we dont filter based on viewCount like we used to. I had written the test with the viewCount removed and then for some reason added viewCount back in after the test passed 🤷‍♂️ 

I've also renamed the name of the metadata db in the tests to prevent conflicts with other tests.