### PR TITLE
Bug 1372590 - Disable Sentry on Simulator builds

### DIFF
--- a/Shared/DeviceInfo.swift
+++ b/Shared/DeviceInfo.swift
@@ -63,7 +63,7 @@ open class DeviceInfo {
     }
 
     open class func isSimulator() -> Bool {
-        return UIDevice.current.model.contains("Simulator")
+        return ProcessInfo.processInfo.environment["SIMULATOR_ROOT"] != nil
     }
 
     open class func isBlurSupported() -> Bool {

--- a/Shared/SentryIntegration.swift
+++ b/Shared/SentryIntegration.swift
@@ -19,6 +19,11 @@ public class SentryIntegration {
     public func setup(sendUsageData: Bool) {
         assert(!enabled, "SentryIntegration.setup() should only be called once")
 
+        if DeviceInfo.isSimulator() {
+            Logger.browserLogger.error("Not enabling Sentry; Running in Simulator")
+            return
+        }
+
         if !sendUsageData {
             Logger.browserLogger.error("Not enabling Sentry; Not enabled by user choice")
             return


### PR DESCRIPTION
This patch does two things:

- Add a more reliable check for `DeviceInfo.isSimulator`
- Don't setup Sentry if we are on the Simulator

