### PR TITLE
Bug 1372404 - Allow opening about:reader?url=... URLs in ReaderMode

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -299,6 +299,17 @@ class Tab: NSObject {
 
     @discardableResult func loadRequest(_ request: URLRequest) -> WKNavigation? {
         if let webView = webView {
+            // Convert any about:reader?url=http://example.com URLs into local ReaderMode URLs.
+            // We do this here to avoid adding about:reader URLs into webView's navigation stack.
+            if let url = request.url,
+                let syncedReaderModeURL = url.decodeReaderModeURL,
+                let localReaderModeURL = syncedReaderModeURL.encodeReaderModeURL(
+                    WebServer.sharedInstance.baseReaderModeURL()
+                ) {
+                    let readerModeRequest = PrivilegedRequest(url: localReaderModeURL) as URLRequest
+                    lastRequest = readerModeRequest
+                    return webView.load(readerModeRequest)
+                }
             lastRequest = request
             return webView.load(request)
         }

--- a/Shared/Extensions/NSURLExtensions.swift
+++ b/Shared/Extensions/NSURLExtensions.swift
@@ -318,13 +318,27 @@ extension URL {
 // Extensions to deal with ReaderMode URLs
 
 extension URL {
+    // Is this an internal ReaderMode url?
     public var isReaderModeURL: Bool {
         let scheme = self.scheme, host = self.host, path = self.path
         return scheme == "http" && host == "localhost" && path == "/reader-mode/page"
     }
 
+    // Is this a synced ReaderMode url? about:reader?url=http://...
+    public var isSyncedReaderModeURL: Bool {
+        if self.scheme != "about" {
+            return false
+        }
+        let urlParts = self.absoluteString.components(separatedBy: "?url=")
+        if urlParts.isEmpty || urlParts.count == 1 {
+            return false
+        }
+        return urlParts[0] == "about:reader"
+    }
+
     public var decodeReaderModeURL: URL? {
-        if self.isReaderModeURL {
+        // Both types of ReaderMode URLs have a 'url' query parameter.
+        if self.isReaderModeURL || self.isSyncedReaderModeURL {
             if let components = URLComponents(url: self, resolvingAgainstBaseURL: false), let queryItems = components.queryItems, queryItems.count == 1 {
                 if let queryItem = queryItems.first, let value = queryItem.value {
                     return URL(string: value)

--- a/SharedTests/NSURLExtensionsTests.swift
+++ b/SharedTests/NSURLExtensionsTests.swift
@@ -257,12 +257,36 @@ class NSURLExtensionsTests: XCTestCase {
         badurls.forEach { XCTAssertFalse(URL(string:$0)!.isReaderModeURL, $0) }
     }
 
+    func testisSyncedReaderModeURL() {
+        let goodurls = [
+            "about:reader?url=http://example.com",
+            "about:reader?url=https%3A%2F%2Fen%2Em%2Ewikipedia%2Eorg%2Fwiki%2FMain%5FPage",
+            "about:reader?url="
+        ]
+        let badurls = [
+            "about:reader",
+            "about:reader?",
+            "about:reader?stuff=http://example.com",
+            "about:reader?stuff=",
+            "http://example.com",
+            "http://localhost:6571/reader-mode/page",
+            "http://localhost:6571/reader-mode/page?url=http://example.com",
+            "http://localhost:6571/reader-mode/page?url=https%3A%2F%2Fen%2Em%2Ewikipedia%2Eorg%2Fwiki%2FMain%5FPage"
+        ]
+
+        goodurls.forEach { XCTAssertTrue(URL(string:$0)!.isSyncedReaderModeURL, $0) }
+        badurls.forEach { XCTAssertFalse(URL(string:$0)!.isSyncedReaderModeURL, $0) }
+    }
+
     func testdecodeReaderModeURL() {
         let goodurls = [
-            ("http://localhost:6571/reader-mode/page?url=https%3A%2F%2Fen%2Em%2Ewikipedia%2Eorg%2Fwiki%2FMain%5FPage", URL(string: "https://en.m.wikipedia.org/wiki/Main_Page"))
+            ("http://localhost:6571/reader-mode/page?url=https%3A%2F%2Fen%2Em%2Ewikipedia%2Eorg%2Fwiki%2FMain%5FPage", URL(string: "https://en.m.wikipedia.org/wiki/Main_Page")),
+            ("about:reader?url=https%3A%2F%2Fen%2Em%2Ewikipedia%2Eorg%2Fwiki%2FMain%5FPage",
+                URL(string: "https://en.m.wikipedia.org/wiki/Main_Page"))
         ]
         let badurls = [
             "http://google.com",
+            "about:reader",
             "http://localhost:6571/sessionrestore.html",
             "http://localhost:1234/about/home/#panel=0",
             "http://localhost:6571/reader-mode/page"


### PR DESCRIPTION
My first stab at allowing viewing `about:reader?url=...` style of URLs in ReaderMode.

This is sub-optimal in a sense that ideally we shouldn't even let `about:reader?url=...` urls load to the point that webview fires a pageshow event - and then performing a reload dance. However, I wasn't sure how to intercept the load event earlier.