### PR TITLE
Bug 1373022 - FennecPushConfiguration points to wrong endpoint

### DIFF
--- a/Push/PushConfiguration.swift
+++ b/Push/PushConfiguration.swift
@@ -36,8 +36,7 @@ public protocol PushConfiguration {
 public struct FennecPushConfiguration: PushConfiguration {
     public init() {}
     public let label = PushConfigurationLabel.fennec
-//    public let endpointURL = NSURL(string: "https://updates.push.services.mozilla.com/v1/apns/fennec")!
-    public let endpointURL = NSURL(string: "https://updates-autopush.dev.mozaws.net/v1/apns/dev")!
+    public let endpointURL = NSURL(string: "https://updates.push.services.mozilla.com/v1/apns/fennec")!
 }
 
 public struct FennecEnterprisePushConfiguration: PushConfiguration {


### PR DESCRIPTION
This patch changes the push endpoint for `org.mozilla.ios.Fennec` to `https://updates.push.services.mozilla.com/v1/apns/fennec`.
