### PR TITLE
Bug 1373114 – Change local notification copy to match remote notification.

### DIFF
--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -122,7 +122,8 @@ class BrowserProfileSyncDelegate: SyncDelegate {
                 let notification = UILocalNotification()
                 notification.fireDate = Date()
                 notification.timeZone = NSTimeZone.default
-                notification.alertBody = String(format: NSLocalizedString("New tab: %@: %@", comment:"New tab [title] [url]"), title, URL.absoluteString)
+                notification.alertTitle = Strings.SentTab_TabArrivingNotificationNoDevice_title
+                notification.alertBody = URL.absoluteDisplayString
                 notification.userInfo = [TabSendURLKey: URL.absoluteString, TabSendTitleKey: title]
                 notification.alertAction = nil
                 notification.category = TabSendCategory


### PR DESCRIPTION
This adds no new strings to Strings.swift.

https://bugzilla.mozilla.org/show_bug.cgi?id=1373114