### PR TITLE
Bug 1373204 – Add device name to send tab alert copy.

### DIFF
--- a/Extensions/NotificationService/NotificationService.swift
+++ b/Extensions/NotificationService/NotificationService.swift
@@ -111,7 +111,7 @@ class SyncDataDisplay {
 }
 
 extension SyncDataDisplay: SyncDelegate {
-    func displaySentTab(for url: URL, title: String, from deviceName: String) {
+    func displaySentTab(for url: URL, title: String, from deviceName: String?) {
         if url.isWebPage() {
             sentTabs.append(SentTab(url: url, title: title, deviceName: deviceName))
 
@@ -124,5 +124,5 @@ extension SyncDataDisplay: SyncDelegate {
 struct SentTab {
     let url: URL
     let title: String
-    let deviceName: String
+    let deviceName: String?
 }

--- a/Extensions/NotificationService/NotificationService.swift
+++ b/Extensions/NotificationService/NotificationService.swift
@@ -93,20 +93,15 @@ class SyncDataDisplay {
             notificationContent.title = Strings.SentTab_NoTabArrivingNotification_title
             notificationContent.body = Strings.SentTab_NoTabArrivingNotification_body
         case 1:
-            if SystemUtils.isDeviceLocked() {
-                notificationContent.title = Strings.SentTab_UnnamedTabArrivingNotification_title
-                notificationContent.body = String(format: Strings.SentTab_UnnamedTabArrivingNotificationNoDevice_body, 1)
+            let tab = sentTabs[0]
+            let title: String
+            if let deviceName = tab.deviceName {
+                title = String(format: Strings.SentTab_TabArrivingNotificationWithDevice_title, deviceName)
             } else {
-                let tab = sentTabs[0]
-                let title: String
-                if let deviceName = tab.deviceName  {
-                    title = String(format: Strings.SentTab_TabArrivingNotificationWithDevice_title, deviceName)
-                } else {
-                    title = Strings.SentTab_TabArrivingNotificationNoDevice_title
-                }
-                notificationContent.title = title
-                notificationContent.body = tab.url.absoluteDisplayString
+                title = Strings.SentTab_TabArrivingNotificationNoDevice_title
             }
+            notificationContent.title = title
+            notificationContent.body = tab.url.absoluteDisplayString
         default:
             notificationContent.title = Strings.SentTab_TabsArrivingNotification_title
             notificationContent.body = String(format: Strings.SentTab_TabsArrivingNotification_title, sentTabs.count)

--- a/Extensions/NotificationService/NotificationService.swift
+++ b/Extensions/NotificationService/NotificationService.swift
@@ -111,11 +111,11 @@ class SyncDataDisplay {
 }
 
 extension SyncDataDisplay: SyncDelegate {
-    func displaySentTabForURL(_ URL: URL, title: String) {
-        if URL.isWebPage() {
-            sentTabs.append(SentTab(url: URL, title: title))
+    func displaySentTab(for url: URL, title: String, from deviceName: String) {
+        if url.isWebPage() {
+            sentTabs.append(SentTab(url: url, title: title, deviceName: deviceName))
 
-            let item = ShareItem(url: URL.absoluteString, title: title, favicon: nil)
+            let item = ShareItem(url: url.absoluteString, title: title, favicon: nil)
             _ = tabQueue?.addToQueue(item)
         }
     }
@@ -124,4 +124,5 @@ extension SyncDataDisplay: SyncDelegate {
 struct SentTab {
     let url: URL
     let title: String
+    let deviceName: String
 }

--- a/Extensions/NotificationService/NotificationService.swift
+++ b/Extensions/NotificationService/NotificationService.swift
@@ -98,12 +98,18 @@ class SyncDataDisplay {
                 notificationContent.body = String(format: Strings.SentTab_UnnamedTabArrivingNotificationNoDevice_body, 1)
             } else {
                 let tab = sentTabs[0]
-                notificationContent.title = Strings.SentTab_TabArrivingNotificationNoDevice_title
+                let title: String
+                if let deviceName = tab.deviceName  {
+                    title = String(format: Strings.SentTab_TabArrivingNotificationWithDevice_title, deviceName)
+                } else {
+                    title = Strings.SentTab_TabArrivingNotificationNoDevice_title
+                }
+                notificationContent.title = title
                 notificationContent.body = tab.url.absoluteDisplayString
             }
         default:
             notificationContent.title = Strings.SentTab_TabsArrivingNotification_title
-            notificationContent.body = String(format: Strings.SentTab_TabsArrivingNotificationNoDevice_body, sentTabs.count)
+            notificationContent.body = String(format: Strings.SentTab_TabsArrivingNotification_title, sentTabs.count)
         }
 
         contentHandler(notificationContent)

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -122,7 +122,14 @@ class BrowserProfileSyncDelegate: SyncDelegate {
                 let notification = UILocalNotification()
                 notification.fireDate = Date()
                 notification.timeZone = NSTimeZone.default
-                notification.alertBody = String(format: NSLocalizedString("New tab: %@: %@", comment:"New tab [title] [url]"), title, url.absoluteString)
+                let title: String
+                if let deviceName = deviceName {
+                    title = String(format: Strings.SentTab_TabArrivingNotificationWithDevice_title, deviceName)
+                } else {
+                    title = Strings.SentTab_TabArrivingNotificationNoDevice_title
+                }
+                notification.alertTitle = title
+                notification.alertBody = url.absoluteDisplayString
                 notification.userInfo = [TabSendURLKey: url.absoluteString, TabSendTitleKey: title]
                 notification.alertAction = nil
                 notification.category = TabSendCategory

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -79,7 +79,7 @@ class CommandStoringSyncDelegate: SyncDelegate {
         self.profile = profile
     }
 
-    public func displaySentTab(for url: URL, title: String, from deviceName: String) {
+    public func displaySentTab(for url: URL, title: String, from deviceName: String?) {
         let item = ShareItem(url: url.absoluteString, title: title, favicon: nil)
         _ = self.profile.queue.addToQueue(item)
     }
@@ -110,7 +110,7 @@ class BrowserProfileSyncDelegate: SyncDelegate {
         self.app = app
     }
 
-    open func displaySentTab(for url: URL, title: String, from deviceName: String) {
+    open func displaySentTab(for url: URL, title: String, from deviceName: String?) {
         // check to see what the current notification settings are and only try and send a notification if
         // the user has agreed to them
         if let currentSettings = app.currentUserNotificationSettings {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -79,8 +79,8 @@ class CommandStoringSyncDelegate: SyncDelegate {
         self.profile = profile
     }
 
-    public func displaySentTabForURL(_ URL: URL, title: String) {
-        let item = ShareItem(url: URL.absoluteString, title: title, favicon: nil)
+    public func displaySentTab(for url: URL, title: String, from deviceName: String) {
+        let item = ShareItem(url: url.absoluteString, title: title, favicon: nil)
         _ = self.profile.queue.addToQueue(item)
     }
 }
@@ -110,20 +110,20 @@ class BrowserProfileSyncDelegate: SyncDelegate {
         self.app = app
     }
 
-    open func displaySentTabForURL(_ URL: URL, title: String) {
+    open func displaySentTab(for url: URL, title: String, from deviceName: String) {
         // check to see what the current notification settings are and only try and send a notification if
         // the user has agreed to them
         if let currentSettings = app.currentUserNotificationSettings {
             if currentSettings.types.rawValue & UIUserNotificationType.alert.rawValue != 0 {
                 if Logger.logPII {
-                    log.info("Displaying notification for URL \(URL.absoluteString)")
+                    log.info("Displaying notification for URL \(url.absoluteString)")
                 }
 
                 let notification = UILocalNotification()
                 notification.fireDate = Date()
                 notification.timeZone = NSTimeZone.default
-                notification.alertBody = String(format: NSLocalizedString("New tab: %@: %@", comment:"New tab [title] [url]"), title, URL.absoluteString)
-                notification.userInfo = [TabSendURLKey: URL.absoluteString, TabSendTitleKey: title]
+                notification.alertBody = String(format: NSLocalizedString("New tab: %@: %@", comment:"New tab [title] [url]"), title, url.absoluteString)
+                notification.userInfo = [TabSendURLKey: url.absoluteString, TabSendTitleKey: title]
                 notification.alertAction = nil
                 notification.category = TabSendCategory
 

--- a/Sync/Synchronizers/ClientsSynchronizer.swift
+++ b/Sync/Synchronizers/ClientsSynchronizer.swift
@@ -72,8 +72,18 @@ open class DisplayURICommand: Command {
     }
 
     open func run(_ synchronizer: ClientsSynchronizer) -> Success {
-        synchronizer.delegate.displaySentTab(for: uri, title: title, from: sender)
-        return succeed()
+        func display(_ deviceName: String? = nil) -> Success {
+            synchronizer.delegate.displaySentTab(for: uri, title: title, from: deviceName)
+            return succeed()
+        }
+
+        guard let getClientWithId = synchronizer.localClients?.getClientWithId(sender) else {
+            return display()
+        }
+
+        return getClientWithId >>== { client in
+            return display(client?.name)
+        }
     }
 
     open static func commandFromSyncCommand(_ syncCommand: SyncCommand) -> Command? {

--- a/Sync/Synchronizers/ClientsSynchronizer.swift
+++ b/Sync/Synchronizers/ClientsSynchronizer.swift
@@ -50,12 +50,15 @@ open class WipeCommand: Command {
 open class DisplayURICommand: Command {
     let uri: URL
     let title: String
+    let sender: String
 
     public init?(command: String, args: [JSON]) {
         if let uri = args[0].string?.asURL,
+            let sender = args[1].string,
             let title = args[2].string {
-                self.uri = uri
-                self.title = title
+            self.uri = uri
+            self.sender = sender
+            self.title = title
         } else {
             // Oh, Swift.
             self.uri = "http://localhost/".asURL!
@@ -69,7 +72,7 @@ open class DisplayURICommand: Command {
     }
 
     open func run(_ synchronizer: ClientsSynchronizer) -> Success {
-        synchronizer.delegate.displaySentTabForURL(uri, title: title)
+        synchronizer.delegate.displaySentTab(for: uri, title: title, from: sender)
         return succeed()
     }
 

--- a/Sync/Synchronizers/Synchronizer.swift
+++ b/Sync/Synchronizers/Synchronizer.swift
@@ -15,7 +15,7 @@ private let log = Logger.syncLogger
  * expose notification functionality in this way.
  */
 public protocol SyncDelegate {
-    func displaySentTabForURL(_ URL: URL, title: String)
+    func displaySentTab(for url: URL, title: String, from deviceName: String)
     // TODO: storage.
 }
 

--- a/Sync/Synchronizers/Synchronizer.swift
+++ b/Sync/Synchronizers/Synchronizer.swift
@@ -15,7 +15,7 @@ private let log = Logger.syncLogger
  * expose notification functionality in this way.
  */
 public protocol SyncDelegate {
-    func displaySentTab(for url: URL, title: String, from deviceName: String)
+    func displaySentTab(for url: URL, title: String, from deviceName: String?)
     // TODO: storage.
 }
 

--- a/SyncTests/HistorySynchronizerTests.swift
+++ b/SyncTests/HistorySynchronizerTests.swift
@@ -14,7 +14,7 @@ import SwiftyJSON
 private let log = Logger.syncLogger
 
 class MockSyncDelegate: SyncDelegate {
-    func displaySentTab(for url: URL, title: String, from deviceName: String) {
+    func displaySentTab(for url: URL, title: String, from deviceName: String?) {
     }
 }
 

--- a/SyncTests/HistorySynchronizerTests.swift
+++ b/SyncTests/HistorySynchronizerTests.swift
@@ -14,7 +14,7 @@ import SwiftyJSON
 private let log = Logger.syncLogger
 
 class MockSyncDelegate: SyncDelegate {
-    func displaySentTabForURL(_ URL: URL, title: String) {
+    func displaySentTab(for url: URL, title: String, from deviceName: String) {
     }
 }
 


### PR DESCRIPTION
This bug adds a parameter to the `SyncDelegate` for the device name that was used to send the tab.

It also changes the alert title for the notification to include that device name.

Where no device name is available, the existing message is used. 

Because it is changing the alert, this bug also necessarily obsoletes the work in [Bug 1373114][1].

For convenience, the patch also removes lock screen special casing (very close in the code) detailed in [Bug 1373113][2]. 

[1]: https://bugzilla.mozilla.org/show_bug.cgi?id=1373114
[2]: https://bugzilla.mozilla.org/show_bug.cgi?id=1373113

https://bugzilla.mozilla.org/show_bug.cgi?id=1373204