### PR TITLE
Bug 1371284 - Add support for universal links for FxA

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -4488,6 +4488,9 @@
 							com.apple.Push = {
 								enabled = 1;
 							};
+							com.apple.SafariKeychain = {
+								enabled = 1;
+							};
 						};
 					};
 					F84B21D21A090F8100AAB793 = {

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -662,6 +662,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
 
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
         if let url = userActivity.webpageURL {
+            
+            // Per Adjust documenation, https://docs.adjust.com/en/universal-links/#running-campaigns-through-universal-links,
+            // it is recommended that links contain the `deep_link` query parameter. This link will also
+            // be url encoded.
+            let query = url.getQuery()
+            if let deepLink = query["deep_link"]?.removingPercentEncoding, let url = URL(string: deepLink) {
+                browserViewController.switchToTabForURLOrOpen(url, isPrivileged: true)
+                return true
+            }
+            
             browserViewController.switchToTabForURLOrOpen(url, isPrivileged: true)
             return true
         }

--- a/Client/Entitlements/FennecApplication.entitlements
+++ b/Client/Entitlements/FennecApplication.entitlements
@@ -4,6 +4,11 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:rzte.adj.st</string>
+		<string>applinks:nn8g.adj.st</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.mozilla.ios.Fennec</string>


### PR DESCRIPTION
This PR adds support for launching FxA from an Universal Link. It reuses the launch params specified in [deep linking](https://bugzilla.mozilla.org/show_bug.cgi?id=1317580).

@st3fan Would the production applinks go into this as well? Or is there a different build step for that? I added the one for the test environment in the Fennec project.