### PR TITLE
Bug 1374331 – Fixup intermittently failing FeatureSwitchTests.

### DIFF
--- a/Shared/FeatureSwitch.swift
+++ b/Shared/FeatureSwitch.swift
@@ -43,6 +43,25 @@ open class FeatureSwitch {
             return isEnabled
         }
 
+        return lowerCaseS(prefs) < self.percentage
+    }
+
+    /// Is this user always a member of the test set, whatever the percentage probability?
+    /// This _only_ tests the probabilities, not the other conditions.
+    open func alwaysMembership(_ prefs: Prefs) -> Bool {
+        return lowerCaseS(prefs) == 99
+    }
+
+    /// Reset the random component of this switch (`lowerCaseS`). This is primarily useful for testing.
+    open func resetMembership(_ prefs: Prefs) {
+        let uuidKey = "\(self.switchKey).uuid"
+        prefs.removeObjectForKey(uuidKey)
+    }
+
+    // If the set of all possible values the switch can be in is `S` (integers between 0 and 99)
+    // then the specific value is `s`.
+    // We use this to compare with the probability of membership.
+    fileprivate func lowerCaseS(_ prefs: Prefs) -> Int {
         // Use a branch of the prefs.
         let uuidKey = "\(self.switchKey).uuid"
 
@@ -55,7 +74,8 @@ open class FeatureSwitch {
         }
 
         let hash = abs(uuidString.hashValue)
-        return hash % 100 < self.percentage
+
+        return hash % 100
     }
 
     open func setMembership(_ isEnabled: Bool, for prefs: Prefs) {

--- a/SharedTests/FeatureSwitchTests.swift
+++ b/SharedTests/FeatureSwitchTests.swift
@@ -34,11 +34,9 @@ class FeatureSwitchTests: XCTestCase {
         var changed = 0
         for percent in 0..<100 {
             let featureSwitch = FeatureSwitch(named: featureID, allowPercentage: percent, buildChannel: buildChannel)
-            print(membership)
             if featureSwitch.isMember(prefs) != membership {
                 membership = !membership
                 changed += 1
-                print("CHANGED")
             }
         }
 

--- a/SharedTests/FeatureSwitchTests.swift
+++ b/SharedTests/FeatureSwitchTests.swift
@@ -26,17 +26,29 @@ class FeatureSwitchTests: XCTestCase {
     func testConsistentWhenChangingPercentage() {
         let featureID = "test-persistent-over-releases"
         let prefs = MockProfilePrefs()
+        let guardFeatureSwitch = FeatureSwitch(named: featureID, allowPercentage: 50, buildChannel: buildChannel)
+        while guardFeatureSwitch.alwaysMembership(prefs) {
+            guardFeatureSwitch.resetMembership(prefs)
+        }
         var membership = false
         var changed = 0
         for percent in 0..<100 {
             let featureSwitch = FeatureSwitch(named: featureID, allowPercentage: percent, buildChannel: buildChannel)
+            print(membership)
             if featureSwitch.isMember(prefs) != membership {
                 membership = !membership
                 changed += 1
+                print("CHANGED")
             }
         }
 
         XCTAssertEqual(changed, 1, "Users should get and keep the feature if the feature is becoming successful")
+    }
+
+    func testReallyConsistentWhenChangingPercentage() {
+        for _ in 0..<1000 {
+            testConsistentWhenChangingPercentage()
+        }
     }
 
     func testUserEnabled() {
@@ -86,7 +98,7 @@ extension FeatureSwitchTests {
         let prefs = MockProfilePrefs()
         measure {
             for _ in 0..<1000 {
-                let _ = featureSwitch.isMember(prefs)
+                _ = featureSwitch.isMember(prefs)
             }
         }
     }
@@ -119,7 +131,7 @@ private extension FeatureSwitchTests {
     }
 
     func testExactly(_ featureSwitch: FeatureSwitch, expected: Int) {
-        let testCount = 10
+        let testCount = 1000
         let count = sampleN(featureSwitch, testCount: testCount)
         let normalizedExpectedCount = (testCount * expected) / 100
         XCTAssertEqual(count, normalizedExpectedCount)


### PR DESCRIPTION
This PR fixes an intermittent test failure: the test was checking that when the probability of a given user (`allowedPercentage`) monotonically increases or decreases (over subsequent releases), the given user does not get the feature then lose the feature, then get it again. The test was checking that a user's access to the feature only changed once from not having it to having it.

The bug _with the test_ was such that some users would get the feature immediately, then never not have it, which meant that the access changes were always 0.

Because this only happened when 1% of the time, I ran the test multiple times in order force the intermittently failing test to fail every time.

I thought this was a problem with the always having access to the feature, or never having the feature, (as in the production code), so upped the test count, from 10 to 1000. 

The fix was to only test users who aren't always members of the test set. This `alwaysMembership()` test is only ever used in unit tests.

https://bugzilla.mozilla.org/show_bug.cgi?id=1374331