### PR TITLE
Bug 1368479 - Fix iPad split view on Activity Stream.

### DIFF
--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -20,7 +20,7 @@ struct ASPanelUX {
     static let rowSpacing: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 30 : 20
     static let highlightCellHeight: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 250 : 195
     static let sectionInsetsForSizeClass = UXSizeClasses(compact: 0, regular: 101, other: 14)
-    static let numberOfItemsPerRowForSizeClsssIpad = UXSizeClasses(compact: 3, regular: 4, other: 2)
+    static let numberOfItemsPerRowForSizeClassIpad = UXSizeClasses(compact: 3, regular: 4, other: 2)
     static let SectionInsetsForIpad: CGFloat = 101
     static let SectionInsetsForIphone: CGFloat = 14
     static let MinimumInsets: CGFloat = 14
@@ -216,7 +216,7 @@ extension ActivityStreamPanel {
         func numberOfItemsForRow(_ traits: UITraitCollection) -> CGFloat {
             switch self {
             case .highlights:
-                var numItems: CGFloat = ASPanelUX.numberOfItemsPerRowForSizeClsssIpad[traits.horizontalSizeClass]
+                var numItems: CGFloat = ASPanelUX.numberOfItemsPerRowForSizeClassIpad[traits.horizontalSizeClass]
                 if UIInterfaceOrientationIsPortrait(UIApplication.shared.statusBarOrientation) {
                     numItems = numItems - 1
                 }

--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -24,12 +24,13 @@ struct ASPanelUX {
     static let SectionInsetsForIpad: CGFloat = 101
     static let SectionInsetsForIphone: CGFloat = 14
     static let MinimumInsets: CGFloat = 14
+    static let BookmarkHighlights = 2
 
 }
 
 /*
  Size classes are the way Apple requires us to specify our UI.
- Split view on iPad can make a lanscape app appear with the demensions of an iPhone app
+ Split view on iPad can make a landscape app appear with the demensions of an iPhone app
  Use UXSizeClasses to specify things like offsets/itemsizes with respect to size classes
  For a primer on size classes https://useyourloaf.com/blog/size-classes/
  */
@@ -463,7 +464,8 @@ extension ActivityStreamPanel: DataObserverDelegate {
     }
 
     func getHighlights() -> Success {
-        return self.profile.recommendations.getHighlights().both(self.profile.recommendations.getRecentBookmarks(2)).bindQueue(.main) { (highlights, bookmarks) in
+        let count = ASPanelUX.BookmarkHighlights // Fetch 2 bookmarks
+        return self.profile.recommendations.getHighlights().both(self.profile.recommendations.getRecentBookmarks(count)).bindQueue(.main) { (highlights, bookmarks) in
             guard let highlights = highlights.successValue?.asArray(), let bookmarks = bookmarks.successValue?.asArray() else {
                 return succeed()
             }
@@ -896,7 +898,7 @@ class ASHeaderView: UICollectionReusableView {
     }
 
     var constraint: Constraint?
-     var titleInsets: CGFloat {
+    var titleInsets: CGFloat {
         get {
             return UIScreen.main.bounds.size.width == self.frame.size.width && UIDevice.current.userInterfaceIdiom == .pad ? ASHeaderViewUX.Insets : ASPanelUX.MinimumInsets
         }
@@ -917,7 +919,6 @@ class ASHeaderView: UICollectionReusableView {
         super.layoutSubviews()
         print(UIScreen.main.bounds.size.width)
         print(self.frame.size.width)
-        print(titleInsets)
         constraint?.update(offset: titleInsets)
     }
     

--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -109,6 +109,12 @@ class TopSiteItemCell: UICollectionViewCell {
     override func layoutSubviews() {
         super.layoutSubviews()
         titleBorder.frame = CGRect(x: 0, y: frame.height - TopSiteCellUX.TitleHeight -  TopSiteCellUX.BorderWidth, width: frame.width, height: TopSiteCellUX.BorderWidth)
+
+        imageView.snp.remakeConstraints { make in
+            make.size.equalTo(floor(self.frame.width * TopSiteCellUX.IconSizePercent))
+            make.centerX.equalTo(self)
+            make.centerY.equalTo(self).inset(-TopSiteCellUX.TitleHeight/2)
+        }
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -425,7 +431,7 @@ class HorizontalFlowLayout: UICollectionViewLayout {
         cachedAttributes = nil
         // Sometimes when the topsiteCell isnt on the screen the newbounds that it tries to layout in is very tiny
         // Resulting in incorrect layouts. So only layout when the width is greater than 320.
-        return newBounds.width >= 320
+        return newBounds.width > 0
     }
 
     func computeLayoutAttributesForCellAtIndexPath(_ indexPath: IndexPath) -> UICollectionViewLayoutAttributes {
@@ -490,14 +496,24 @@ class ASHorizontalScrollCellManager: NSObject, UICollectionViewDelegate, UIColle
     }
 
     func numberOfHorizontalItems() -> Int {
-        // The number of items to show per row.
-        if UIDevice.current.orientation == .landscapeLeft || UIDevice.current.orientation == .landscapeRight {
-            return 8
-        } else if UIDevice.current.userInterfaceIdiom == .pad {
-            return 6
-        } else {
-            return 4
+        guard let traits = currentTraits else {
+            return 0
         }
+        let isLandscape = UIInterfaceOrientationIsLandscape(UIApplication.shared.statusBarOrientation)
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            if isLandscape {
+                return 8
+            } else {
+                return 4
+            }
+        }
+        // On iPad
+        // The number of items in a row is equal to the number of highlights in a row * 2
+        var numItems: Int = Int(ASPanelUX.numberOfItemsPerRowForSizeClsssIpad[traits.horizontalSizeClass])
+        if UIInterfaceOrientationIsPortrait(UIApplication.shared.statusBarOrientation) || (traits.horizontalSizeClass == .compact && isLandscape) {
+            numItems = numItems - 1
+        }
+        return numItems * 2
     }
 
     func numberOfSections(in collectionView: UICollectionView) -> Int {

--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -509,7 +509,7 @@ class ASHorizontalScrollCellManager: NSObject, UICollectionViewDelegate, UIColle
         }
         // On iPad
         // The number of items in a row is equal to the number of highlights in a row * 2
-        var numItems: Int = Int(ASPanelUX.numberOfItemsPerRowForSizeClsssIpad[traits.horizontalSizeClass])
+        var numItems: Int = Int(ASPanelUX.numberOfItemsPerRowForSizeClassIpad[traits.horizontalSizeClass])
         if UIInterfaceOrientationIsPortrait(UIApplication.shared.statusBarOrientation) || (traits.horizontalSizeClass == .compact && isLandscape) {
             numItems = numItems - 1
         }

--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -429,8 +429,8 @@ class HorizontalFlowLayout: UICollectionViewLayout {
 
     override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
         cachedAttributes = nil
-        // Sometimes when the topsiteCell isnt on the screen the newbounds that it tries to layout in is very tiny
-        // Resulting in incorrect layouts. So only layout when the width is greater than 320.
+        // Sometimes when the topsiteCell isnt on the screen the newbounds that it tries to layout in is 0
+        // Resulting in incorrect layouts. Only layout when a valid width is given
         return newBounds.width > 0
     }
 


### PR DESCRIPTION
This ended up being trickier than I would have liked. 

Apple's Size classes work well when you have only 2 different view modes (compact/regular) For example how messages looks on an iPad vs iPhone. 

But on Activity Stream we'd like to be able to customize the layout further. Being able to do things like show 3 highlights per row in portrait vs 4 in landscape. But also show 2 in portrait on a phone. 

Once split screen is added to the mix simply knowing the orientation and device type no longer works. As Firefox might be in a phone sized screen in split view while the user is in landscape. Furthermore, sizeclasses aren't expressive enough. If an app takes up 66 percent of the screen it is still technically considered regular sized even though it is missing a third of the display. 

