### PR TITLE
Bug 1374642 – Remove plurals from SentTab strings

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -275,19 +275,12 @@ extension Strings {
     public static let SentTab_NoTabArrivingNotification_body =
         NSLocalizedString("SentTab.NoTabArrivingNotification.body", value: "Tap to begin", comment: "Body of notification received after a spurious message from FxA has been received.")
 
-    // one tab, but on lockscreen
-    public static let SentTab_UnnamedTabArrivingNotification_title = NSLocalizedString("SentTab.UnnamedTabArrivingNotification.title", value: "Tab received", comment: "Title of notification received after an unnamed tab has been sent from an unnamed connected device. This is likely to be displayed on the device lock screen.")
-    public static let SentTab_UnnamedTabArrivingNotificationNoDevice_body = NSLocalizedString("SentTab.UnnamedTabArrivingNotificationNoDevice.body", value: "%1$i tab has arrived", comment: "Body of notification received after one tab has been received. %1$i is the number of tabs (1).")
+    // one or more tabs
+    public static let SentTab_TabArrivingNotification_NoDevice_title = NSLocalizedString("SentTab_TabArrivingNotification_NoDevice_title", value: "Tab received", comment: "Title of notification shown when the device is sent one or more tabs from an unnamed device.")
+    public static let SentTab_TabArrivingNotification_NoDevice_body = NSLocalizedString("SentTab_TabArrivingNotification_NoDevice_body", value: "New tab arrived from another device.", comment: "Body of notification shown when the device is sent one or more tabs from an unnamed device.")
+    public static let SentTab_TabArrivingNotification_WithDevice_title = NSLocalizedString("SentTab_TabArrivingNotification_WithDevice_title", value: "Tab received from %@", comment: "Title of notification shown when the device is sent one or more tabs from the named device. %@ is the placeholder for the device name. This device name will be localized by that device.")
+    public static let SentTab_TabArrivingNotification_WithDevice_body = NSLocalizedString("SentTab_TabArrivingNotification_WithDevice_body", value: "New tab arrived in %@", comment: "Body of notification shown when the device is sent one or more tabs from the named device. %@ is the placeholder for the app name.")
 
-    // one tab, on home screen
-    public static let SentTab_TabArrivingNotificationNoDevice_title = NSLocalizedString("SentTab.TabArrivingNotification.title", value: "Tab received", comment: "Title of notification received after a tab has been sent from an unnamed connected device")
-    public static let SentTab_TabArrivingNotificationWithDevice_title = NSLocalizedString("SentTab.TabArrivingNotificationWithDevice.title", value: "Tab from %@", comment: "Title of notification received after a tab has been sent from a named connected device. %@ is the name of the named device.")
-    // body is the URL
-
-    // multiple tabs.
-    public static let SentTab_TabsArrivingNotification_title = NSLocalizedString("SentTab.TabsArrivingNotification.title", value: "Tabs received", comment: "Title of notification received after multiple tab have been sent from an unnamed connected device")
-    public static let SentTab_TabsArrivingNotificationMultiple2_body = NSLocalizedString("SentTab.UnnamedTabsArrivingNotificationMultiple2.body", value: "%1$i tabs have arrived from your connected devices", comment: "Body of notification received after multiple tabs have been sent from an unnamed connected device. %1$i is the number of tabs.")
-    public static let SentTab_TabsArrivingNotificationNoDevice_body = NSLocalizedString("SentTab.UnnamedTabsArrivingNotificationNoDevice.body", value: "%1$i tabs have arrived", comment: "Body of notification received after multiple tabs has been received. %1$i is the number of tabs.")
 }
 
 // Reader Mode.

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -124,9 +124,9 @@ class BrowserProfileSyncDelegate: SyncDelegate {
                 notification.timeZone = NSTimeZone.default
                 let title: String
                 if let deviceName = deviceName {
-                    title = String(format: Strings.SentTab_TabArrivingNotificationWithDevice_title, deviceName)
+                    title = String(format: Strings.SentTab_TabArrivingNotification_WithDevice_title, deviceName)
                 } else {
-                    title = Strings.SentTab_TabArrivingNotificationNoDevice_title
+                    title = Strings.SentTab_TabArrivingNotification_NoDevice_title
                 }
                 notification.alertTitle = title
                 notification.alertBody = url.absoluteDisplayString


### PR DESCRIPTION
This PR removes plurals from SentTab strings, and implements the rules needed to select which variant to use.

https://bugzilla.mozilla.org/show_bug.cgi?id=1374642