### PR TITLE
Bug 1375602 - Make sure favicons set their background colors correctly.

### DIFF
--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -537,8 +537,11 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
                     cell.imageView!.layer.borderColor = SearchViewControllerUX.IconBorderColor.cgColor
                     cell.imageView!.layer.borderWidth = SearchViewControllerUX.IconBorderWidth
                     cell.imageView?.setIcon(site.icon, forURL: site.tileURL, completed: { (color, url) in
-                        cell.imageView?.image = cell.imageView?.image?.createScaled(CGSize(width: SearchViewControllerUX.IconSize, height: SearchViewControllerUX.IconSize))
-                        cell.imageView?.contentMode = .center
+                        if site.tileURL == url {
+                            cell.imageView?.image = cell.imageView?.image?.createScaled(CGSize(width: SearchViewControllerUX.IconSize, height: SearchViewControllerUX.IconSize))
+                            cell.imageView?.contentMode = .center
+                            cell.imageView?.backgroundColor = color
+                        }
                     })
                 }
             }

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -221,9 +221,14 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
             } else {
                 cell.imageView?.layer.borderColor = BookmarksPanelUX.IconBorderColor.cgColor
                 cell.imageView?.layer.borderWidth = BookmarksPanelUX.IconBorderWidth
-                cell.imageView?.setIcon(bookmark.favicon, forURL: URL(string: item.url))
-                cell.imageView?.image = cell.imageView?.image?.createScaled(CGSize(width: BookmarksPanelUX.IconSize, height: BookmarksPanelUX.IconSize))
-                cell.imageView?.contentMode = .center
+                let bookmarkURL = URL(string: item.url)
+                cell.imageView?.setIcon(bookmark.favicon, forURL: bookmarkURL, completed: { (color, url) in
+                    if bookmarkURL == url {
+                        cell.imageView?.image = cell.imageView?.image?.createScaled(CGSize(width: BookmarksPanelUX.IconSize, height: BookmarksPanelUX.IconSize))
+                        cell.imageView?.backgroundColor = color
+                        cell.imageView?.contentMode = .center
+                    }
+                })
             }
             return cell
         case is BookmarkSeparator:

--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -365,8 +365,11 @@ class HistoryPanel: SiteTableViewController, HomePanel {
             cell.imageView!.layer.borderColor = HistoryPanelUX.IconBorderColor.cgColor
             cell.imageView!.layer.borderWidth = HistoryPanelUX.IconBorderWidth
             cell.imageView?.setIcon(site.icon, forURL: site.tileURL, completed: { (color, url) in
-                cell.imageView?.image = cell.imageView?.image?.createScaled(CGSize(width: HistoryPanelUX.IconSize, height: HistoryPanelUX.IconSize))
-                cell.imageView?.contentMode = .center
+                if site.tileURL == url {
+                    cell.imageView?.image = cell.imageView?.image?.createScaled(CGSize(width: HistoryPanelUX.IconSize, height: HistoryPanelUX.IconSize))
+                    cell.imageView?.backgroundColor = color
+                    cell.imageView?.contentMode = .center
+                }
             })
         }
         return cell

--- a/Client/Frontend/Home/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Home/RecentlyClosedTabsPanel.swift
@@ -126,8 +126,11 @@ class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {
         cell.imageView!.layer.borderColor = RecentlyClosedPanelUX.IconBorderColor.cgColor
         cell.imageView!.layer.borderWidth = RecentlyClosedPanelUX.IconBorderWidth
         cell.imageView?.setIcon(site, forURL: displayURL, completed: { (color, url) in
-            cell.imageView?.image = cell.imageView?.image?.createScaled(RecentlyClosedPanelUX.IconSize)
-            cell.imageView?.contentMode = .center
+            if url == displayURL {
+                cell.imageView?.image = cell.imageView?.image?.createScaled(RecentlyClosedPanelUX.IconSize)
+                cell.imageView?.contentMode = .center
+                cell.imageView?.backgroundColor = color
+            }
         })
         return cell
     }

--- a/Client/Frontend/Widgets/ActivityStreamHighlightCell.swift
+++ b/Client/Frontend/Widgets/ActivityStreamHighlightCell.swift
@@ -151,8 +151,12 @@ class ActivityStreamHighlightCell: UICollectionViewCell {
             self.siteImageView.sd_setImage(with: mediaURL)
             self.siteImageView.contentMode = .scaleAspectFill
         } else {
+            let itemURL = site.tileURL
             self.siteImageView.setFavicon(forSite: site, onCompletion: { [weak self] (color, url)  in
-                self?.siteImageView.image = self?.siteImageView.image?.createScaled(ActivityStreamHighlightCellUX.FaviconSize)
+                if itemURL == url {
+                    self?.siteImageView.image = self?.siteImageView.image?.createScaled(ActivityStreamHighlightCellUX.FaviconSize)
+                    self?.siteImageView.backgroundColor = color
+                }
             })
             self.siteImageView.contentMode = .center
         }


### PR DESCRIPTION
This makes sure favicons are set similar to how they are set in the Topsites. There were 2 problems with how I was setting favicons and their backgrounds before. 

1. In the case where a background color for a favicon was not found in the cache it needs to be set in the callback of the ImageView. 
2. make sure to check the url that is returned in the callback before setting the background color. When handling reuse, sometimes the callback could be referencing a cell that has already been reused. 

This was all done for Topsites. But never for the other places I used `setFavicon` https://github.com/mozilla-mobile/firefox-ios/blob/master/Client/Frontend/Home/ActivityStreamTopSitesCell.swift#L151


