### PR TITLE
Bug 1373202 – Match behaviours between local and remote notifications for Sent Tabs.

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -850,6 +850,13 @@ class AppSyncDelegate: SyncDelegate {
     }
 
     open func displaySentTab(for url: URL, title: String, from deviceName: String?) {
+        if let appDelegate = app.delegate as? AppDelegate, app.applicationState == .active {
+            DispatchQueue.main.async {
+                appDelegate.browserViewController.switchToTabForURLOrOpen(url, isPrivileged: false)
+            }
+            return
+        }
+
         // check to see what the current notification settings are and only try and send a notification if
         // the user has agreed to them
         if let currentSettings = app.currentUserNotificationSettings {

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -304,7 +304,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         if let profile = self.profile {
             return profile
         }
-        let p = BrowserProfile(localName: "profile", syncDelegate: application.syncDelegate())
+        let p = BrowserProfile(localName: "profile", syncDelegate: application.syncDelegate)
         self.profile = p
         return p
     }
@@ -832,13 +832,13 @@ struct LaunchParams {
 }
 
 extension UIApplication {
+    var syncDelegate: SyncDelegate {
+        return AppSyncDelegate(app: self)
+    }
+
     static var isInPrivateMode: Bool {
         let appDelegate = UIApplication.shared.delegate as? AppDelegate
         return appDelegate?.browserViewController.tabManager.selectedTab?.isPrivate ?? false
-    }
-
-    func syncDelegate() -> SyncDelegate {
-        return AppSyncDelegate(app: self)
     }
 }
 

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -878,7 +878,9 @@ class AppSyncDelegate: SyncDelegate {
                 notification.alertBody = url.absoluteDisplayString
                 notification.userInfo = [TabSendURLKey: url.absoluteString, TabSendTitleKey: title]
                 notification.alertAction = nil
-                notification.category = TabSendCategory
+
+                // Restore this when we fix Bug 1364420.
+                // notification.category = TabSendCategory
 
                 app.presentLocalNotificationNow(notification)
             }

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -12,6 +12,7 @@ import SwiftKeychainWrapper
 import LocalAuthentication
 import Telemetry
 import SwiftRouter
+import Sync
 
 private let log = Logger.browserLogger
 
@@ -303,7 +304,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         if let profile = self.profile {
             return profile
         }
-        let p = BrowserProfile(localName: "profile", app: application)
+        let p = BrowserProfile(localName: "profile", syncDelegate: application.syncDelegate())
         self.profile = p
         return p
     }
@@ -834,5 +835,46 @@ extension UIApplication {
     static var isInPrivateMode: Bool {
         let appDelegate = UIApplication.shared.delegate as? AppDelegate
         return appDelegate?.browserViewController.tabManager.selectedTab?.isPrivate ?? false
+    }
+
+    func syncDelegate() -> SyncDelegate {
+        return AppSyncDelegate(app: self)
+    }
+}
+
+class AppSyncDelegate: SyncDelegate {
+    let app: UIApplication
+
+    init(app: UIApplication) {
+        self.app = app
+    }
+
+    open func displaySentTab(for url: URL, title: String, from deviceName: String?) {
+        // check to see what the current notification settings are and only try and send a notification if
+        // the user has agreed to them
+        if let currentSettings = app.currentUserNotificationSettings {
+            if currentSettings.types.rawValue & UIUserNotificationType.alert.rawValue != 0 {
+                if Logger.logPII {
+                    log.info("Displaying notification for URL \(url.absoluteString)")
+                }
+
+                let notification = UILocalNotification()
+                notification.fireDate = Date()
+                notification.timeZone = NSTimeZone.default
+                let title: String
+                if let deviceName = deviceName {
+                    title = String(format: Strings.SentTab_TabArrivingNotification_WithDevice_title, deviceName)
+                } else {
+                    title = Strings.SentTab_TabArrivingNotification_NoDevice_title
+                }
+                notification.alertTitle = title
+                notification.alertBody = url.absoluteDisplayString
+                notification.userInfo = [TabSendURLKey: url.absoluteString, TabSendTitleKey: title]
+                notification.alertAction = nil
+                notification.category = TabSendCategory
+
+                app.presentLocalNotificationNow(notification)
+            }
+        }
     }
 }

--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -19,16 +19,7 @@ class TestAppDelegate: AppDelegate {
         if ProcessInfo.processInfo.arguments.contains(LaunchArguments.ClearProfile) {
             // Use a clean profile for each test session.
             log.debug("Deleting all files in 'Documents' directory to clear the profile")
-            let fileManager = FileManager.default
-            let documentsPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
-            if let files = try? fileManager.contentsOfDirectory(atPath: documentsPath) {
-                for file in files {
-                    try? fileManager.removeItem(atPath: URL(fileURLWithPath: documentsPath).appendingPathComponent(file).path)
-                }
-            }
-
-            profile = BrowserProfile(localName: "testProfile", app: application)
-            profile.prefs.clearAll()
+            profile = BrowserProfile(localName: "testProfile", syncDelegate: application.syncDelegate(), clear: true)
 
             // Don't show the What's New page.
             profile.prefs.setString(AppInfo.appVersion, forKey: LatestAppVersionProfileKey)

--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -29,7 +29,7 @@ class TestAppDelegate: AppDelegate {
                 profile.prefs.setInt(1, forKey: IntroViewControllerSeenProfileKey)
             }
         } else {
-            profile = BrowserProfile(localName: "testProfile", app: application)
+            profile = BrowserProfile(localName: "testProfile", syncDelegate: application.syncDelegate())
         }
 
         self.profile = profile

--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -19,7 +19,7 @@ class TestAppDelegate: AppDelegate {
         if ProcessInfo.processInfo.arguments.contains(LaunchArguments.ClearProfile) {
             // Use a clean profile for each test session.
             log.debug("Deleting all files in 'Documents' directory to clear the profile")
-            profile = BrowserProfile(localName: "testProfile", syncDelegate: application.syncDelegate(), clear: true)
+            profile = BrowserProfile(localName: "testProfile", syncDelegate: application.syncDelegate, clear: true)
 
             // Don't show the What's New page.
             profile.prefs.setString(AppInfo.appVersion, forKey: LatestAppVersionProfileKey)
@@ -29,7 +29,7 @@ class TestAppDelegate: AppDelegate {
                 profile.prefs.setInt(1, forKey: IntroViewControllerSeenProfileKey)
             }
         } else {
-            profile = BrowserProfile(localName: "testProfile", syncDelegate: application.syncDelegate())
+            profile = BrowserProfile(localName: "testProfile", syncDelegate: application.syncDelegate)
         }
 
         self.profile = profile

--- a/ClientTests/ProfileTest.swift
+++ b/ClientTests/ProfileTest.swift
@@ -22,7 +22,7 @@ class ProfileTest: XCTestCase {
         let authInfo = AuthenticationKeychainInfo(passcode: "1234")
         KeychainWrapper.sharedAppContainerKeychain.setAuthenticationInfo(authInfo)
         XCTAssertNotNil(KeychainWrapper.sharedAppContainerKeychain.authenticationInfo())
-        let _ = BrowserProfile(localName: "my_profile", app: nil, clear: true)
+        let _ = BrowserProfile(localName: "my_profile", clear: true)
         XCTAssertNil(KeychainWrapper.sharedAppContainerKeychain.authenticationInfo())
     }
 }

--- a/Extensions/NotificationService/ExtensionProfile.swift
+++ b/Extensions/NotificationService/ExtensionProfile.swift
@@ -12,8 +12,6 @@ import Sync
 // This will only ever be used in the NotificationService extension.
 // It allows us to customize the SyncDelegate, and later the SyncManager.
 class ExtensionProfile: BrowserProfile {
-    var syncDelegate: SyncDelegate!
-
     override var logins: BrowserLogins & SyncableLogins & ResettableSyncStorage {
         get {
             fatalError("Cannot use logins.db in extension")
@@ -22,12 +20,8 @@ class ExtensionProfile: BrowserProfile {
     }
 
     init(localName: String) {
-        super.init(localName: localName, app: nil, clear: false)
+        super.init(localName: localName, clear: false)
         syncManager = ExtensionSyncManager(profile: self)
-    }
-
-    override func getSyncDelegate() -> SyncDelegate {
-        return syncDelegate
     }
 }
 

--- a/Extensions/SendTo/ActionViewController.swift
+++ b/Extensions/SendTo/ActionViewController.swift
@@ -54,7 +54,7 @@ class ActionViewController: UIViewController, ClientPickerViewControllerDelegate
             return finish()
         }
 
-        let profile = BrowserProfile(localName: "profile", app: nil)
+        let profile = BrowserProfile(localName: "profile")
         profile.sendItems([item], toClients: clients).uponQueue(DispatchQueue.main) { result in
             profile.shutdown()
             self.finish()
@@ -70,7 +70,7 @@ class ActionViewController: UIViewController, ClientPickerViewControllerDelegate
     }
 
     private func hasAccount() -> Bool {
-        let profile = BrowserProfile(localName: "profile", app: nil)
+        let profile = BrowserProfile(localName: "profile")
         defer {
             profile.shutdown()
         }

--- a/Extensions/ShareTo/InitialViewController.swift
+++ b/Extensions/ShareTo/InitialViewController.swift
@@ -61,7 +61,7 @@ class InitialViewController: UIViewController, ShareControllerDelegate {
         }, completion: { (Bool) -> Void in
             self.dismissShareDialog()
             
-            let profile = BrowserProfile(localName: "profile", app: nil)
+            let profile = BrowserProfile(localName: "profile")
 
             if destinations.contains(ShareDestinationReadingList) {
                 profile.readingList?.createRecordWithURL(item.url, title: item.title ?? "", addedBy: UIDevice.current.name)

--- a/Extensions/ViewLater/ActionRequestHandler.swift
+++ b/Extensions/ViewLater/ActionRequestHandler.swift
@@ -13,7 +13,7 @@ class ActionRequestHandler: NSObject, NSExtensionRequestHandling {
     public func beginRequest(with context: NSExtensionContext) {
         ExtensionUtils.extractSharedItemFromExtensionContext(context, completionHandler: { (item, error) -> Void in
             if let item = item, error == nil && item.isShareable {
-                let profile = BrowserProfile(localName: "profile", app: nil)
+                let profile = BrowserProfile(localName: "profile")
                 profile.queue.addToQueue(item).uponQueue(DispatchQueue.main) { _ in
                     profile.shutdown()
                     context.completeRequest(returningItems: [], completionHandler: nil)

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -103,43 +103,6 @@ enum SentTabAction: String {
     case readingList = "TabSendReadingListAction"
 }
 
-class BrowserProfileSyncDelegate: SyncDelegate {
-    let app: UIApplication
-
-    init(app: UIApplication) {
-        self.app = app
-    }
-
-    open func displaySentTab(for url: URL, title: String, from deviceName: String?) {
-        // check to see what the current notification settings are and only try and send a notification if
-        // the user has agreed to them
-        if let currentSettings = app.currentUserNotificationSettings {
-            if currentSettings.types.rawValue & UIUserNotificationType.alert.rawValue != 0 {
-                if Logger.logPII {
-                    log.info("Displaying notification for URL \(url.absoluteString)")
-                }
-
-                let notification = UILocalNotification()
-                notification.fireDate = Date()
-                notification.timeZone = NSTimeZone.default
-                let title: String
-                if let deviceName = deviceName {
-                    title = String(format: Strings.SentTab_TabArrivingNotification_WithDevice_title, deviceName)
-                } else {
-                    title = Strings.SentTab_TabArrivingNotification_NoDevice_title
-                }
-                notification.alertTitle = title
-                notification.alertBody = url.absoluteDisplayString
-                notification.userInfo = [TabSendURLKey: url.absoluteString, TabSendTitleKey: title]
-                notification.alertAction = nil
-                notification.category = TabSendCategory
-
-                app.presentLocalNotificationNow(notification)
-            }
-        }
-    }
-}
-
 /**
  * A Profile manages access to the user's data.
  */
@@ -234,6 +197,8 @@ open class BrowserProfile: Profile {
         return secret
     }
 
+    var syncDelegate: SyncDelegate?
+
     /**
      * N.B., BrowserProfile is used from our extensions, often via a pattern like
      *
@@ -242,13 +207,17 @@ open class BrowserProfile: Profile {
      * This can break if BrowserProfile's initializer does async work that
      * subsequently — and asynchronously — expects the profile to stick around:
      * see Bug 1218833. Be sure to only perform synchronous actions here.
+     *
+     * A SyncDelegate can be provided in this initializer, or once the profile is initialized. 
+     * However, if we provide it here, it's assumed that we're initializing it from the application, 
+     * and initialize the logins.db.
      */
-    init(localName: String, app: UIApplication?, clear: Bool = false) {
+    init(localName: String, syncDelegate: SyncDelegate? = nil, clear: Bool = false) {
         log.debug("Initing profile \(localName) on thread \(Thread.current).")
         self.name = localName
         self.files = ProfileFileAccessor(localName: localName)
-        self.app = app
         self.keychain = KeychainWrapper.sharedAppContainerKeychain
+        self.syncDelegate = syncDelegate
 
         if clear {
             do {
@@ -267,7 +236,7 @@ open class BrowserProfile: Profile {
 
         // We almost certainly don't want to be accessing the logins.db when in an extension, so let's avoid
         // corrupting it by not opening it at all.
-        self.loginsDB = app != nil ? BrowserDB(filename: "logins.db", secretKey: BrowserProfile.loginsKey, files: files) : nil
+        self.loginsDB = syncDelegate != nil ? BrowserDB(filename: "logins.db", secretKey: BrowserProfile.loginsKey, files: files) : nil
 
         self.db = BrowserDB(filename: "browser.db", files: files)
         self.db.attachDB(filename: "metadata.db", as: AttachedDatabaseMetadata)
@@ -308,11 +277,6 @@ open class BrowserProfile: Profile {
             // just the behaviour when there is no homepage.
             prefs.removeObjectForKey(PrefsKeys.KeyDefaultHomePageURL)
         }
-    }
-
-    // Extensions don't have a UIApplication.
-    convenience init(localName: String) {
-        self.init(localName: localName, app: nil)
     }
 
     func reopen() {
@@ -478,10 +442,7 @@ open class BrowserProfile: Profile {
     }()
 
     open func getSyncDelegate() -> SyncDelegate {
-        if let app = self.app {
-            return BrowserProfileSyncDelegate(app: app)
-        }
-        return CommandStoringSyncDelegate(profile: self)
+        return syncDelegate ?? CommandStoringSyncDelegate(profile: self)
     }
 
     public func getClients() -> Deferred<Maybe<[RemoteClient]>> {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -252,7 +252,8 @@ open class BrowserProfile: Profile {
 
         if clear {
             do {
-                try FileManager.default.removeItem(atPath: self.files.rootPath as String)
+                try self.files.removeFilesInDirectory()
+                try self.files.remove("")
             } catch {
                 log.info("Cannot clear profile: \(error)")
             }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -221,7 +221,9 @@ open class BrowserProfile: Profile {
 
         if clear {
             do {
+                // Remove the contents of the directory…
                 try self.files.removeFilesInDirectory()
+                // …then remove the directory itself.
                 try self.files.remove("")
             } catch {
                 log.info("Cannot clear profile: \(error)")


### PR DESCRIPTION
This PR moves the `BrowserProfileSyncDelegate` from `BrowserProfile` to the `AppDelegate`, to allow it access to the `AppDelegate` without polluting any extensions which shouldn't have access to it.

When a timed synced of the `clients` collection occurs and a tab is received, it checks that the application is active, and if so, opens the tab immediately, just as when a remote notification is recieved.

Secondly, it removes the notification category, which is not implemented in the remote notification. This bit is a one line removal, which should be added back in as part of [this bug][1].

https://bugzilla.mozilla.org/show_bug.cgi?id=1373202

[1]: https://bugzilla.mozilla.org/show_bug.cgi?id=1364420