### PR TITLE
Bug 1375990 — Change application name in Sent Tab notification.

### DIFF
--- a/Extensions/NotificationService/Info.plist
+++ b/Extensions/NotificationService/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>NotificationService</string>
+	<string>$(MOZ_BUNDLE_DISPLAY_NAME)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1375990