### PR TITLE
Bug 1374987 – Remove badge number for sent tabs.

### DIFF
--- a/Extensions/NotificationService/NotificationService.swift
+++ b/Extensions/NotificationService/NotificationService.swift
@@ -88,11 +88,6 @@ class SyncDataDisplay {
 
         userInfo["didFinish"] = didFinish
 
-        // Increment the badges. This may cause us to find bugs with multiple 
-        // notifications in the future.
-        let badge = (notificationContent.badge?.intValue ?? 0) + sentTabs.count
-        notificationContent.badge = NSNumber(value: badge)
-
         notificationContent.userInfo = userInfo
 
         let title: String


### PR DESCRIPTION
This PR removes the setting of a badge to show how many received tabs have been received by Firefox.

This is because the feature behaviour is under-specified for the release and the implementation (our code) is buggy.

https://bugzilla.mozilla.org/show_bug.cgi?id=1374987