### PR TITLE
Bug 1376798 - Use staging push servers

### DIFF
--- a/Account/FirefoxAccountConfiguration.swift
+++ b/Account/FirefoxAccountConfiguration.swift
@@ -106,7 +106,17 @@ public struct StageFirefoxAccountConfiguration: FirefoxAccountConfiguration {
 
     public let sync15Configuration: Sync15Configuration = StageSync15Configuration()
 
-    public let pushConfiguration: PushConfiguration = FirefoxBetaPushConfiguration()
+    public var pushConfiguration: PushConfiguration {
+        get {
+            #if MOZ_CHANNEL_RELEASE
+                return FirefoxStagingPushConfiguration()
+            #elseif MOZ_CHANNEL_BETA
+                return FirefoxBetaStagingPushConfiguration()
+            #elseif MOZ_CHANNEL_FENNEC
+                return FennecStagingPushConfiguration()
+            #endif
+        }
+    }
 }
 
 public struct ProductionFirefoxAccountConfiguration: FirefoxAccountConfiguration {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -483,11 +483,7 @@ open class BrowserProfile: Profile {
 
     var accountConfiguration: FirefoxAccountConfiguration {
         if prefs.boolForKey("useStageSyncService") ?? false {
-            if AppConstants.BuildChannel == .developer {
-                return LatestDevFirefoxAccountConfiguration()
-            } else {
-                return StageFirefoxAccountConfiguration()
-            }
+            return StageFirefoxAccountConfiguration()
         }
         if prefs.boolForKey("useChinaSyncService") ?? isChinaEdition {
             return ChinaEditionFirefoxAccountConfiguration()

--- a/Push/PushConfiguration.swift
+++ b/Push/PushConfiguration.swift
@@ -39,6 +39,12 @@ public struct FennecPushConfiguration: PushConfiguration {
     public let endpointURL = NSURL(string: "https://updates.push.services.mozilla.com/v1/apns/fennec")!
 }
 
+public struct FennecStagingPushConfiguration: PushConfiguration {
+    public init() {}
+    public let label = PushConfigurationLabel.fennec
+    public let endpointURL = NSURL(string: "https://updates-autopush.stage.mozaws.net/v1/apns/fennec")!
+}
+
 public struct FennecEnterprisePushConfiguration: PushConfiguration {
     public init() {}
     public let label = PushConfigurationLabel.fennecEnterprise
@@ -51,6 +57,12 @@ public struct FirefoxBetaPushConfiguration: PushConfiguration {
     public let endpointURL = NSURL(string: "https://updates.push.services.mozilla.com/v1/apns/firefoxbeta")!
 }
 
+public struct FirefoxBetaStagingPushConfiguration: PushConfiguration {
+    public init() {}
+    public let label = PushConfigurationLabel.firefoxBeta
+    public let endpointURL = NSURL(string: "https://updates-autopush.stage.mozaws.net/v1/apns/firefoxbeta")!
+}
+
 public struct FirefoxNightlyEnterprisePushConfiguration: PushConfiguration {
     public init() {}
     public let label = PushConfigurationLabel.firefoxNightlyEnterprise
@@ -61,4 +73,10 @@ public struct FirefoxPushConfiguration: PushConfiguration {
     public init() {}
     public let label = PushConfigurationLabel.firefox
     public let endpointURL = NSURL(string: "https://updates.push.services.mozilla.com/v1/apns/firefox")!
+}
+
+public struct FirefoxStagingPushConfiguration: PushConfiguration {
+    public init() {}
+    public let label = PushConfigurationLabel.firefox
+    public let endpointURL = NSURL(string: "https://updates-autopush.stage.mozaws.net/v1/apns/firefox")!
 }


### PR DESCRIPTION
This patch selects the autopush staging servers if you enable the secret menu option. Before this patch we only used the staging servers for FxA and Sync. Now we also switch to AutoPush.

This will work on Firefox, Firefox Beta and Fennec.

This is a request from QA so that they test on a consistent staging environment for all services that we talk to.

*Note* - For consistency, Fennec will also switch to Staging Servers. Before this patch it would switch to the Development version. I don't think that was actively used, if it was, we can re-introduce that or not make that change.