### PR TITLE
Bug 1377646 - Create BrowserSyncManager before opening DBs.

### DIFF
--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -99,6 +99,9 @@ open class MockProfile: Profile {
     public var places: BrowserHistory & Favicons & SyncableHistory & ResettableSyncStorage & HistoryRecommendations
     public var files: FileAccessor
     public var history: BrowserHistory & SyncableHistory & ResettableSyncStorage
+    public var logins: BrowserLogins & SyncableLogins & ResettableSyncStorage
+    public var syncManager: SyncManager!
+
     public lazy var panelDataObservers: PanelDataObservers = {
         return MockPanelDataObservers(profile: self)
     }()
@@ -109,6 +112,8 @@ open class MockProfile: Profile {
 
     init() {
         files = MockFiles()
+        syncManager = MockSyncManager()
+        logins = MockLogins(files: files)
         db = BrowserDB(filename: "mock.db", files: files)
         db.attachDB(filename: "metadata.db", as: AttachedDatabaseMetadata)
         places = SQLiteHistory(db: self.db, prefs: MockProfilePrefs())
@@ -142,10 +147,6 @@ open class MockProfile: Profile {
 
     lazy public var isChinaEdition: Bool = {
         return Locale.current.identifier == "zh_CN"
-    }()
-
-    lazy public var syncManager: SyncManager = {
-        return MockSyncManager()
     }()
 
     lazy public var certStore: CertStore = {
@@ -182,10 +183,6 @@ open class MockProfile: Profile {
 
     fileprivate lazy var syncCommands: SyncCommands = {
         return SQLiteRemoteClientsAndTabs(db: self.db)
-    }()
-
-    lazy public var logins: BrowserLogins & SyncableLogins & ResettableSyncStorage = {
-        return MockLogins(files: self.files)
     }()
 
     public let accountConfiguration: FirefoxAccountConfiguration = ProductionFirefoxAccountConfiguration()


### PR DESCRIPTION
One more lazy var down…

This commit:

- Separates database opening from database init. Actual DB work has always been a side-effect of first use, so we simply split out the `createOrUpdate` of the schema table to occur in a later call to `firstOpen`.
- Makes `loginsDB` non-optional (again) — we now just choose not to open it from an extension.
- Makes `Profile.syncManager` implicitly unwrapped, 'cos we need to refer to the profile itself in order to init `BrowserSyncManager`.
- Initializes `profile.syncManager` before calling `firstOpen` on the two BrowserDB instances, fixing the bug.

Flagging @jhugman for review 'cos he was working around `loginsDB`, and @justindarc 'cos he was looking at some related problems.

This doesn't affect the actual rate of DB corruption (which is Bug 1368719), but it should be enough to make our database recover-via-Sync code run again!