### PR TITLE
Bug 1377577 - Keychain items unavailable when device is locked

### DIFF
--- a/Account/FirefoxAccount.swift
+++ b/Account/FirefoxAccount.swift
@@ -36,7 +36,7 @@ open class FirefoxAccount {
 
     open var pushRegistration: PushRegistration?
 
-    fileprivate let stateCache: KeychainCache<FxAState>
+    open let stateCache: KeychainCache<FxAState>
     open var syncAuthState: SyncAuthState! // We can't give a reference to self if this is a let.
 
     // To prevent advance() consumers racing, we maintain a shared advance() deferred (`advanceDeferred`).  If an

--- a/Account/FirefoxAccount.swift
+++ b/Account/FirefoxAccount.swift
@@ -36,7 +36,7 @@ open class FirefoxAccount {
 
     open var pushRegistration: PushRegistration?
 
-    open let stateCache: KeychainCache<FxAState>
+    fileprivate let stateCache: KeychainCache<FxAState>
     open var syncAuthState: SyncAuthState! // We can't give a reference to self if this is a let.
 
     // To prevent advance() consumers racing, we maintain a shared advance() deferred (`advanceDeferred`).  If an

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -187,13 +187,14 @@ open class BrowserProfile: Profile {
     private static var loginsKey: String? {
         let key = "sqlcipher.key.logins.db"
         let keychain = KeychainWrapper.sharedAppContainerKeychain
+        keychain.ensureStringItemAccessibility(.afterFirstUnlock, forKey: key)
         if keychain.hasValue(forKey: key) {
             return keychain.string(forKey: key)
         }
 
         let Length: UInt = 256
         let secret = Bytes.generateRandomBytes(Length).base64EncodedString
-        keychain.set(secret, forKey: key)
+        keychain.set(secret, forKey: key, withAccessibility: .afterFirstUnlock)
         return secret
     }
 
@@ -492,7 +493,9 @@ open class BrowserProfile: Profile {
     }
 
     fileprivate lazy var account: FirefoxAccount? = {
-        if let dictionary = self.keychain.object(forKey: self.name + ".account") as? [String: AnyObject] {
+        let key = self.name + ".account"
+        self.keychain.ensureObjectItemAccessibility(.afterFirstUnlock, forKey: key)
+        if let dictionary = self.keychain.object(forKey: key) as? [String: AnyObject] {
             return FirefoxAccount.fromDictionary(dictionary)
         }
         return nil
@@ -549,8 +552,7 @@ open class BrowserProfile: Profile {
 
     func flushAccount() {
         if let account = account {
-            // Will this cause issues with people migrating?
-            self.keychain.set(account.dictionary() as NSCoding, forKey: name + ".account")
+            self.keychain.set(account.dictionary() as NSCoding, forKey: name + ".account", withAccessibility: .afterFirstUnlock)
         }
     }
 

--- a/Shared/Extensions/KeychainWrapperExtensions.swift
+++ b/Shared/Extensions/KeychainWrapperExtensions.swift
@@ -3,7 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import XCGLogger
 import SwiftKeychainWrapper
+
+private let log = Logger.keychainLogger
 
 public extension KeychainWrapper {
     static var sharedAppContainerKeychain: KeychainWrapper {
@@ -11,5 +14,49 @@ public extension KeychainWrapper {
         let accessGroupPrefix = Bundle.main.object(forInfoDictionaryKey: "MozDevelopmentTeam") as! String
         let accessGroupIdentifier = AppInfo.keychainAccessGroupWithPrefix(accessGroupPrefix)
         return KeychainWrapper(serviceName: baseBundleIdentifier, accessGroup: accessGroupIdentifier)
+    }
+}
+
+public extension KeychainWrapper {
+    func ensureStringItemAccessibility(_ accessibility: SwiftKeychainWrapper.KeychainItemAccessibility, forKey key: String) {
+        if self.hasValue(forKey: key) {
+            if self.accessibilityOfKey(key) != .afterFirstUnlock {
+                log.debug("updating item \(key) with \(accessibility)")
+
+                guard let value = self.string(forKey: key) else {
+                    log.error("failed to get item \(key)")
+                    return
+                }
+
+                if !self.removeObject(forKey: key) {
+                    log.warning("failed to remove item \(key)")
+                }
+
+                if !self.set(value, forKey: key, withAccessibility: accessibility) {
+                    log.warning("failed to update item \(key)")
+                }
+            }
+        }
+    }
+
+    func ensureObjectItemAccessibility(_ accessibility: SwiftKeychainWrapper.KeychainItemAccessibility, forKey key: String) {
+        if self.hasValue(forKey: key) {
+            if self.accessibilityOfKey(key) != .afterFirstUnlock {
+                log.debug("updating item \(key) with \(accessibility)")
+
+                guard let value = self.object(forKey: key) else {
+                    log.error("failed to get item \(key)")
+                    return
+                }
+
+                if !self.removeObject(forKey: key) {
+                    log.warning("failed to remove item \(key)")
+                }
+
+                if !self.set(value, forKey: key, withAccessibility: accessibility) {
+                    log.warning("failed to update item \(key)")
+                }
+            }
+        }
     }
 }

--- a/Shared/KeychainCache.swift
+++ b/Shared/KeychainCache.swift
@@ -31,7 +31,9 @@ open class KeychainCache<T: JSONLiteralConvertible> {
 
     open class func fromBranch(_ branch: String, withLabel label: String?, withDefault defaultValue: T? = nil, factory: (JSON) -> T?) -> KeychainCache<T> {
         if let l = label {
-            if let s = KeychainWrapper.sharedAppContainerKeychain.string(forKey: "\(branch).\(l)") {
+            let key = "\(branch).\(l)"
+            KeychainWrapper.sharedAppContainerKeychain.ensureStringItemAccessibility(.afterFirstUnlock, forKey: key)
+            if let s = KeychainWrapper.sharedAppContainerKeychain.string(forKey: key) {
                 if let t = factory(JSON(parseJSON: s)) {
                     log.info("Read \(branch) from Keychain with label \(branch).\(l).")
                     return KeychainCache(branch: branch, label: l, value: t)
@@ -55,7 +57,7 @@ open class KeychainCache<T: JSONLiteralConvertible> {
         // TODO: PII logging.
         if let value = value,
             let jsonString = value.asJSON().stringValue() {
-            KeychainWrapper.sharedAppContainerKeychain.set(jsonString, forKey: "\(branch).\(label)")
+            KeychainWrapper.sharedAppContainerKeychain.set(jsonString, forKey: "\(branch).\(label)", withAccessibility: .afterFirstUnlock)
         } else {
             KeychainWrapper.sharedAppContainerKeychain.removeObject(forKey: "\(branch).\(label)")
         }

--- a/Sync/State.swift
+++ b/Sync/State.swift
@@ -444,7 +444,9 @@ open class Scratchpad {
         if let keyLabel = prefs.stringForKey(PrefKeyLabel) {
             b.keyLabel = keyLabel
             if let ckTS = prefs.unsignedLongForKey(PrefKeysTS) {
-                if let keys = KeychainWrapper.sharedAppContainerKeychain.string(forKey: "keys." + keyLabel) {
+                let key = "keys." + keyLabel
+                KeychainWrapper.sharedAppContainerKeychain.ensureStringItemAccessibility(.afterFirstUnlock, forKey: key)
+                if let keys = KeychainWrapper.sharedAppContainerKeychain.string(forKey: key) {
                     // We serialize as JSON.
                     let keys = Keys(payload: KeysPayload(keys))
                     if keys.valid {
@@ -540,9 +542,7 @@ open class Scratchpad {
             log.debug("Storing keys in Keychain with label \(label).")
             prefs.setString(self.keyLabel, forKey: PrefKeyLabel)
             prefs.setLong(keys.timestamp, forKey: PrefKeysTS)
-
-            // TODO: I could have sworn that we could specify kSecAttrAccessibleAfterFirstUnlock here.
-            KeychainWrapper.sharedAppContainerKeychain.set(payload, forKey: label)
+            KeychainWrapper.sharedAppContainerKeychain.set(payload, forKey: label, withAccessibility: .afterFirstUnlock)
         } else {
             log.debug("Removing keys from Keychain.")
             KeychainWrapper.sharedAppContainerKeychain.removeObject(forKey: self.keyLabel)


### PR DESCRIPTION
When the *NotificationService* receives an incoming remote notification when the device is locked, it is unable to sync, because items stored in the Keychain cannot be accessed when the device is locked.

**The result of this bug is that notifications that you receive when your phone is locked, always show  the *Tap to Begin* message.**

This patch fixes that with the following two changes:

- it makes sure that *new* Keychain items, used by Sync and FxA, are always created with the `.afterFirstUnlock` option.
- it makes sure that before an *existing* Keychain item is used, its options are checked and updated to include the `.afterFirstUnlock` option

New installation of the application are immediately good since all items are created properly. Existing installations of the app will be fixed when they sync. I chose to repair the Keychain items ad-hoc instead of at application startup because some of them have dynamically generated IDs in their name.

**For testing, it is recommended to also try the upgrade path.**

Steps to reproduce:

- Install version of the application that does not include this patch
- Sign in to sync
- Lock your device
- Send yourself a tab

Expected: You receive a notification that says Tab received from ... with the URL in the message.
Actual: Tap to Begin

Steps to reproduce the fix:

- Upgrade to a version of the app with this patch included
- Start the app, make sure it syncs once
- Send yourself a tab

Expected: You receive a notification that says Tab received from ... with the URL in the message.
