### PR TITLE
Bug 1377145 - Update Dynamic font support for ActivityStream.

### DIFF
--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -18,7 +18,7 @@ private let DefaultSuggestedSitesKey = "topSites.deletedSuggestedSites"
 struct ASPanelUX {
     static let backgroundColor = UIColor(white: 1.0, alpha: 0.5)
     static let rowSpacing: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 30 : 20
-    static let highlightCellHeight: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 250 : 195
+    static let highlightCellHeight: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 250 : 200
     static let sectionInsetsForSizeClass = UXSizeClasses(compact: 0, regular: 101, other: 14)
     static let numberOfItemsPerRowForSizeClassIpad = UXSizeClasses(compact: 3, regular: 4, other: 2)
     static let SectionInsetsForIpad: CGFloat = 101
@@ -854,7 +854,7 @@ struct ActivityStreamTracker {
 // MARK: - Section Header View
 struct ASHeaderViewUX {
     static let SeperatorColor =  UIColor(rgb: 0xedecea)
-    static let TextFont = DynamicFontHelper.defaultHelper.DefaultMediumBoldFont
+    static let TextFont = DynamicFontHelper.defaultHelper.MediumSizeBoldFontAS
     static let SeperatorHeight = 1
     static let Insets: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? ASPanelUX.SectionInsetsForIpad + ASPanelUX.MinimumInsets : ASPanelUX.MinimumInsets
     static let TitleTopInset: CGFloat = 5

--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -11,7 +11,7 @@ struct TopSiteCellUX {
     static let TitleHeight: CGFloat = 20
     static let TitleBackgroundColor = UIColor(colorLiteralRed: 1, green: 1, blue: 1, alpha: 0.7)
     static let TitleTextColor = UIColor.black
-    static let TitleFont = DynamicFontHelper.defaultHelper.DefaultSmallFont
+    static let TitleFont = DynamicFontHelper.defaultHelper.SmallSizeRegularWeightAS
     static let SelectedOverlayColor = UIColor(white: 0.0, alpha: 0.25)
     static let CellCornerRadius: CGFloat = 4
     static let TitleOffset: CGFloat = 5

--- a/Client/Frontend/Widgets/ActionOverlayTableViewCell.swift
+++ b/Client/Frontend/Widgets/ActionOverlayTableViewCell.swift
@@ -20,7 +20,7 @@ struct ActionOverlayTableViewCellUX {
 class ActionOverlayTableViewCell: UITableViewCell {
     lazy var titleLabel: UILabel = {
         let titleLabel = UILabel()
-        titleLabel.font = DynamicFontHelper.defaultHelper.DeviceFontLarge
+        titleLabel.font = DynamicFontHelper.defaultHelper.LargeSizeRegularWeightAS
         titleLabel.minimumScaleFactor = 0.8 // Scale the font if we run out of space
         titleLabel.textColor = ActionOverlayTableViewCellUX.LabelColor
         titleLabel.textAlignment = .left

--- a/Client/Frontend/Widgets/ActionOverlayTableViewController.swift
+++ b/Client/Frontend/Widgets/ActionOverlayTableViewController.swift
@@ -180,7 +180,7 @@ class ActionOverlayTableViewHeader: UITableViewHeaderFooterView {
 
     lazy var titleLabel: UILabel = {
         let titleLabel = UILabel()
-        titleLabel.font = DynamicFontHelper.defaultHelper.DeviceFontLargeBold
+        titleLabel.font = DynamicFontHelper.defaultHelper.MediumSizeBoldFontAS
         titleLabel.textColor = ActionOverlayTableViewUX.LabelColor
         titleLabel.textAlignment = .left
         titleLabel.numberOfLines = 2
@@ -189,7 +189,7 @@ class ActionOverlayTableViewHeader: UITableViewHeaderFooterView {
 
     lazy var descriptionLabel: UILabel = {
         let titleLabel = UILabel()
-        titleLabel.font = DynamicFontHelper.defaultHelper.DeviceFontMedium
+        titleLabel.font = DynamicFontHelper.defaultHelper.MediumSizeRegularWeightAS
         titleLabel.textColor = ActionOverlayTableViewUX.DescriptionLabelColor
         titleLabel.textAlignment = .left
         titleLabel.numberOfLines = 1

--- a/Client/Frontend/Widgets/ActivityStreamHighlightCell.swift
+++ b/Client/Frontend/Widgets/ActivityStreamHighlightCell.swift
@@ -25,7 +25,7 @@ class ActivityStreamHighlightCell: UICollectionViewCell {
 
     fileprivate lazy var titleLabel: UILabel = {
         let titleLabel = UILabel()
-        titleLabel.font = DynamicFontHelper.defaultHelper.DeviceFontMediumBoldActivityStream
+        titleLabel.font = DynamicFontHelper.defaultHelper.MediumSizeHeavyWeightAS
         titleLabel.textColor = ActivityStreamHighlightCellUX.LabelColor
         titleLabel.textAlignment = .left
         titleLabel.numberOfLines = 3
@@ -34,7 +34,7 @@ class ActivityStreamHighlightCell: UICollectionViewCell {
 
     fileprivate lazy var descriptionLabel: UILabel = {
         let descriptionLabel = UILabel()
-        descriptionLabel.font = DynamicFontHelper.defaultHelper.DeviceFontDescriptionActivityStream
+        descriptionLabel.font = DynamicFontHelper.defaultHelper.SmallSizeRegularWeightAS
         descriptionLabel.textColor = ActivityStreamHighlightCellUX.DescriptionLabelColor
         descriptionLabel.textAlignment = .left
         descriptionLabel.numberOfLines = 1
@@ -43,7 +43,7 @@ class ActivityStreamHighlightCell: UICollectionViewCell {
 
     fileprivate lazy var domainLabel: UILabel = {
         let descriptionLabel = UILabel()
-        descriptionLabel.font = DynamicFontHelper.defaultHelper.DeviceFontDescriptionActivityStream
+        descriptionLabel.font = DynamicFontHelper.defaultHelper.SmallSizeRegularWeightAS
         descriptionLabel.textColor = ActivityStreamHighlightCellUX.DescriptionLabelColor
         descriptionLabel.textAlignment = .left
         descriptionLabel.numberOfLines = 1
@@ -184,7 +184,7 @@ class HighlightIntroCell: UICollectionViewCell {
 
     lazy var titleLabel: UILabel = {
         let textLabel = UILabel()
-        textLabel.font = DynamicFontHelper.defaultHelper.DeviceFontMediumBold
+        textLabel.font = DynamicFontHelper.defaultHelper.MediumSizeBoldFontAS
         textLabel.textColor = UIColor.black
         textLabel.numberOfLines = 1
         textLabel.adjustsFontSizeToFitWidth = true
@@ -200,7 +200,7 @@ class HighlightIntroCell: UICollectionViewCell {
 
     lazy var descriptionLabel: UILabel = {
         let label = UILabel()
-        label.font = DynamicFontHelper.defaultHelper.DeviceFontDescriptionActivityStream
+        label.font = DynamicFontHelper.defaultHelper.MediumSizeRegularWeightAS
         label.textColor = UIColor.darkGray
         label.numberOfLines = 0
         return label

--- a/Client/Helpers/DynamicFontHelper.swift
+++ b/Client/Helpers/DynamicFontHelper.swift
@@ -79,14 +79,40 @@ class DynamicFontHelper: NSObject {
     var DeviceFontMediumBold: UIFont {
         return UIFont.boldSystemFont(ofSize: deviceFontSize + 1)
     }
-    var DeviceFontMediumBoldActivityStream: UIFont {
-        return UIFont.systemFont(ofSize: deviceFontSize + 2, weight: UIFontWeightHeavy)
+
+    /*
+     Activity Stream supports dynamic fonts up to a certain point. Large fonts dont work.
+     Max out the supported font size.
+     Small = 14, medium = 18, larger = 20
+     */
+
+    var MediumSizeRegularWeightAS: UIFont {
+        let size = min(deviceFontSize, 18)
+        return UIFont.systemFont(ofSize: size)
     }
-    var DeviceFontSmallActivityStream: UIFont {
-        return UIFont.systemFont(ofSize: deviceFontSize - 2, weight: UIFontWeightMedium)
+
+    var LargeSizeRegularWeightAS: UIFont {
+        let size = min(deviceFontSize + 3, 20)
+        return UIFont.systemFont(ofSize: size)
     }
-    var DeviceFontDescriptionActivityStream: UIFont {
-        return UIFont.systemFont(ofSize: deviceFontSize - 2, weight: UIFontWeightRegular)
+
+    var MediumSizeHeavyWeightAS: UIFont {
+        let size = min(deviceFontSize + 2, 18)
+        return UIFont.systemFont(ofSize: size, weight: UIFontWeightHeavy)
+    }
+    var SmallSizeMediumWeightAS: UIFont {
+        let size = min(defaultSmallFontSize, 14)
+        return UIFont.systemFont(ofSize: size, weight: UIFontWeightMedium)
+    }
+
+    var MediumSizeBoldFontAS: UIFont {
+        let size = min(deviceFontSize, 18)
+        return UIFont.boldSystemFont(ofSize: size)
+    }
+
+    var SmallSizeRegularWeightAS: UIFont {
+        let size = min(defaultSmallFontSize, 14)
+        return UIFont.systemFont(ofSize: size, weight: UIFontWeightRegular)
     }
 
     /**

--- a/Client/Helpers/DynamicFontHelper.swift
+++ b/Client/Helpers/DynamicFontHelper.swift
@@ -112,7 +112,7 @@ class DynamicFontHelper: NSObject {
 
     var SmallSizeRegularWeightAS: UIFont {
         let size = min(defaultSmallFontSize, 14)
-        return UIFont.systemFont(ofSize: size, weight: UIFontWeightRegular)
+        return UIFont.systemFont(ofSize: size)
     }
 
     /**


### PR DESCRIPTION
Clean up the usage of dynamic fonts inside Activity Stream. 

I've maxed out how much dynamicFonts can resize the views. The layout isnt really designed to support insanely large text and doing so just breaks everything. 

I haven't completely disabled dynamic fonts and users with larger default fonts will still see larger text but just not as large as before.