### PR TITLE
Bug 1378187 - Make context menu icons 24px.

### DIFF
--- a/Client/Frontend/Widgets/ActionOverlayTableViewCell.swift
+++ b/Client/Frontend/Widgets/ActionOverlayTableViewCell.swift
@@ -12,7 +12,7 @@ struct ActionOverlayTableViewCellUX {
     static let CellSideOffset = 20
     static let TitleLabelOffset = 10
     static let CellTopBottomOffset = 12
-    static let StatusIconSize = 28
+    static let StatusIconSize = 24
     static let SelectedOverlayColor = UIColor(white: 0.0, alpha: 0.25)
     static let CornerRadius: CGFloat = 3
 }


### PR DESCRIPTION
The assets were actually 24px but were being stretched in the code to 28px. 

good catch by Bryan Bell. 