### PR TITLE
Bug 1377097 - Make sure Today widget uses open-url scheme correctly

### DIFF
--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -185,7 +185,7 @@ class TodayViewController: UIViewController, NCWidgetProviding {
     }
 
     fileprivate func openContainingApp(_ urlSuffix: String = "") {
-        let urlString = "\(scheme)://\(urlSuffix)"
+        let urlString = "\(scheme)://open-url\(urlSuffix)"
         self.extensionContext?.open(URL(string: urlString)!) { success in
             log.info("Extension opened containing app: \(success)")
         }


### PR DESCRIPTION
I've updated Today widget to open urls similar to how third-party apps open urls. 