### PR TITLE
Bug 1378399 - Enable (iTunes) filesharing on all non-Release channels

### DIFF
--- a/buddybuild_prebuild.sh
+++ b/buddybuild_prebuild.sh
@@ -16,6 +16,14 @@ elif [ "$BUDDYBUILD_SCHEME" == Firefox ]; then
 fi
 
 #
+# Enable File Sharing on all builds except release
+#
+
+if [ "$BUDDYBUILD_SCHEME" != "Firefox" ]; then
+  /usr/libexec/PlistBuddy -c "Add UIFileSharingEnabled bool true" "Client/Info.plist"
+fi
+
+#
 # Leanplum is set to production for all builds. Only Fennec locally will use
 # development settings, because those are not intended to ship to actual users.
 #


### PR DESCRIPTION
This patch sets `UIFileSharingEnabled` to `true` for all build channels except release. This allows us to access the shared file container on *Beta* and *FennecEnterprise*.

We already have a debug option to copy the databases to the file container. With this in place we can also do the same for the log files.
