### PR TITLE
Bug 1362980 - SendTo Extension crashes when calling sendSyncPing

### DIFF
--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -648,7 +648,7 @@ open class BrowserProfile: Profile {
 
             syncDisplayState = SyncStatusResolver(engineResults: result.engineResults).resolveResults()
 
-            if let account = profile.account, canSendUsageData() {
+            if profile.app != nil, let account = profile.account, canSendUsageData() {
                 sendSyncPing(account: account, result: result)
             } else {
                 log.debug("Profile isn't sending usage data. Not sending sync status event.")


### PR DESCRIPTION
We should not be calling `sendSyncPing` when running outside of the application. This patch checks if `profile.app` is set to find out if we are in the app or an extension. This is not ideal but there is no other good way to discover this at runtime it seems.