### PR TITLE
Bug 1362980 - SendTo Extension crashes when calling sendSyncPing

### DIFF
--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -650,10 +650,12 @@ open class BrowserProfile: Profile {
 
             syncDisplayState = SyncStatusResolver(engineResults: result.engineResults).resolveResults()
 
-            if profile.app != nil, let account = profile.account, canSendUsageData() {
-                sendSyncPing(account: account, result: result)
-            } else {
-                log.debug("Profile isn't sending usage data. Not sending sync status event.")
+            if AppInfo.isApplication {
+                if let account = profile.account, canSendUsageData() {
+                    sendSyncPing(account: account, result: result)
+                } else {
+                    log.debug("Profile isn't sending usage data. Not sending sync status event.")
+                }
             }
 
             notifySyncing(notification: NotificationProfileDidFinishSyncing)

--- a/Shared/AppInfo.swift
+++ b/Shared/AppInfo.swift
@@ -64,4 +64,9 @@ open class AppInfo {
     open static var whatsNewTopic: String? {
         return Bundle.main.object(forInfoDictionaryKey: "MozWhatsNewTopic") as? String
     }
+
+    // Return whether the currently executing code is running in an Application
+    open static var isApplication: Bool {
+        return Bundle.main.object(forInfoDictionaryKey: "CFBundlePackageType") as! String == "APPL"
+    }
 }


### PR DESCRIPTION
This patch introduces an `AppInfo.isApplication` computed property that will tell us if we are running as part of an UIApplication. This is used to decide if we need to collect sync ping info.