### PR TITLE
Bug 1378878 - Notification Service Extension incorrectly updates appPackage in the client record

### DIFF
--- a/Sync/Synchronizers/ClientsSynchronizer.swift
+++ b/Sync/Synchronizers/ClientsSynchronizer.swift
@@ -172,7 +172,7 @@ open class ClientsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchro
             "os": "iOS",
             "commands": [JSON](),
             "type": "mobile",
-            "appPackage": Bundle.main.bundleIdentifier ?? "org.mozilla.ios.FennecUnknown",
+            "appPackage": AppInfo.baseBundleIdentifier,
             "application": DeviceInfo.appName(),
             "device": DeviceInfo.deviceModel(),
             "formfactor": formfactor])


### PR DESCRIPTION
This patch sets the appPackage to the main application bundle identifier. This prevents extensions to write their own bundle identifier.