### PR TITLE
Bug 1379463 - On upgrade the device registration is not refreshed

### DIFF
--- a/Account/FxADeviceRegistration.swift
+++ b/Account/FxADeviceRegistration.swift
@@ -11,7 +11,7 @@ private let log = Logger.syncLogger
 
 /// The current version of the device registration. We use this to re-register
 /// devices after we update what we send on device registration.
-private let DeviceRegistrationVersion = 1
+private let DeviceRegistrationVersion = 2
 
 public enum FxADeviceRegistrationResult {
     case registered


### PR DESCRIPTION
This patch increments `DeviceRegistrationVersion` to force an update of the device registration with FxA. This registration will then include the required AutoPush fields. After this upgrade, other devices will be able to send push notifications to us.