### PR TITLE
Bug 1379144 - Fix private tab not opening from Today widget.

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -372,21 +372,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
 
         switch host {
         case "open-url":
-            var url: String?
-            var isPrivate: Bool = false
+            let url = query["url"]?.unescape() ?? ""
+            let isPrivate = NSString(string: query["private"] ?? "false").boolValue
 
-            if let queryUrl = query["url"]?.unescape() {
-                url = queryUrl
-                isPrivate = NSString(string: query["private"] ?? "false").boolValue
-            }
-
-            let params: LaunchParams
-
-            if let url = url, let newURL = URL(string: url) {
-                params = LaunchParams(url: newURL, isPrivate: isPrivate)
-            } else {
-                params = LaunchParams(url: nil, isPrivate: isPrivate)
-            }
+            let params = LaunchParams(url: URL(string: url), isPrivate: isPrivate)
 
             if application.applicationState == .active {
                 // If we are active then we can ask the BVC to open the new tab right away.
@@ -395,7 +384,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             } else {
                 openInFirefoxParams = params
             }
-
             return true
         case "deep-link":
             guard let url = query["url"], Bundle.main.bundleIdentifier == sourceApplication else {


### PR DESCRIPTION
The bug was caused by the fact that the old L380 was inside the if block. Even if a URL isnt present we should check if the query passed `isPrivate` 

Along the way I refactored this a bit. Creating `URL(string:"")` returns nil anyways and launchparams is okay with `nil`. Then there is no need for if blocks. 