### PR TITLE
Bug 1378347 - Only dismiss the context menu on rotation.

### DIFF
--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -134,7 +134,10 @@ class ActivityStreamPanel: UICollectionViewController, HomePanel {
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         coordinator.animate(alongsideTransition: {context in
-            self.presentedViewController?.dismiss(animated: true, completion: nil)
+            //The AS context menu does not behave correctly. Dismiss it when rotating.
+            if let _ = self.presentedViewController as? ActionOverlayTableViewController {
+                self.presentedViewController?.dismiss(animated: true, completion: nil)
+            }
             self.collectionViewLayout.invalidateLayout()
             self.collectionView?.reloadData()
         }, completion: nil)

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -111,12 +111,6 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         }
     }
 
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        coordinator.animate(alongsideTransition: { context in
-            self.presentedViewController?.dismiss(animated: true, completion: nil)
-        }, completion: nil)
-    }
-
     fileprivate func createEmptyStateOverlayView() -> UIView {
         let overlayView = UIView()
         overlayView.backgroundColor = UIColor.white

--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -94,12 +94,6 @@ class HistoryPanel: SiteTableViewController, HomePanel {
         }
     }
 
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        coordinator.animate(alongsideTransition: { context in
-            self.presentedViewController?.dismiss(animated: true, completion: nil)
-        }, completion: nil)
-    }
-
     @objc fileprivate func longPress(_ longPressGestureRecognizer: UILongPressGestureRecognizer) {
         guard longPressGestureRecognizer.state == UIGestureRecognizerState.began else { return }
         let touchPoint = longPressGestureRecognizer.location(in: tableView)

--- a/Client/Frontend/Home/ReaderPanel.swift
+++ b/Client/Frontend/Home/ReaderPanel.swift
@@ -235,12 +235,6 @@ class ReadingListPanel: UITableViewController, HomePanel {
         NotificationCenter.default.removeObserver(self, name: NotificationDynamicFontChanged, object: nil)
     }
 
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        coordinator.animate(alongsideTransition: { context in
-            self.presentedViewController?.dismiss(animated: true, completion: nil)
-        }, completion: nil)
-    }
-
     func notificationReceived(_ notification: Notification) {
         switch notification.name {
         case NotificationFirefoxAccountChanged:

--- a/Client/Frontend/Home/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Home/RecentlyClosedTabsPanel.swift
@@ -76,11 +76,6 @@ class RecentlyClosedTabsPanel: UIViewController, HomePanel {
         _ = self.navigationController?.popViewController(animated: true)
     }
 
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        coordinator.animate(alongsideTransition: { context in
-            self.presentedViewController?.dismiss(animated: true, completion: nil)
-        }, completion: nil)
-    }
 }
 
 class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {

--- a/Client/Frontend/Home/RemoteTabsPanel.swift
+++ b/Client/Frontend/Home/RemoteTabsPanel.swift
@@ -513,12 +513,6 @@ fileprivate class RemoteTabsTableViewController: UITableViewController {
         refreshControl?.removeTarget(self, action: #selector(RemoteTabsTableViewController.refreshTabs), for: .valueChanged)
     }
 
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        coordinator.animate(alongsideTransition: { context in
-            self.presentedViewController?.dismiss(animated: true, completion: nil)
-        }, completion: nil)
-    }
-
     fileprivate func startRefreshing() {
         if let refreshControl = self.refreshControl {
             let height = -refreshControl.bounds.size.height

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -55,7 +55,6 @@ class TopSitesPanel: UIViewController, HomePanel {
         if UIApplication.shared.applicationState != .background {
             coordinator.animate(alongsideTransition: { context in
                 self.collection?.reloadData()
-                self.presentedViewController?.dismiss(animated: true, completion: nil)
             }, completion: nil)
         }
     }

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -113,6 +113,15 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
         tableView.delegate = nil
     }
 
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        coordinator.animate(alongsideTransition: { context in
+            //The AS context menu does not behave correctly. Dismiss it when rotating.
+            if let _ = self.presentedViewController as? ActionOverlayTableViewController {
+                self.presentedViewController?.dismiss(animated: true, completion: nil)
+            }
+        }, completion: nil)
+    }
+
     func reloadData() {
         if data.status != .success {
             print("Err: \(data.statusMessage)", terminator: "\n")


### PR DESCRIPTION
I had applied a fix to dismiss the context menu on rotation but the fix was incorrectly being applied to the settings panel.

Now, make sure to check if the presentedVC is the context menu before dismissing on rotation.