### PR TITLE
Bug 1342788 - follow up - Make sure autocomplete is disabled when deleting characters.

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -269,6 +269,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     }
 
     override func deleteBackward() {
+        canAutocomplete = false
         removeCompletion()
         super.deleteBackward()
     }


### PR DESCRIPTION
This is a followup from https://github.com/mozilla-mobile/firefox-ios/pull/2946 