### PR TITLE
Bug 1260765: Single tap instead of long press on login item to show menu

### DIFF
--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -7,7 +7,7 @@ import Storage
 import Shared
 import SwiftKeychainWrapper
 
-private enum InfoItem: Int {
+enum InfoItem: Int {
     case websiteItem = 0
     case usernameItem = 1
     case passwordItem = 2
@@ -63,9 +63,7 @@ class LoginDetailViewController: SensitiveViewController {
         self.login = login
         self.profile = profile
         super.init(nibName: nil, bundle: nil)
-
-        NotificationCenter.default.addObserver(self, selector: #selector(LoginDetailViewController.SELwillShowMenuController), name: NSNotification.Name.UIMenuControllerWillShowMenu, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(LoginDetailViewController.SELwillHideMenuController), name: NSNotification.Name.UIMenuControllerWillHideMenu, object: nil)
+        
         NotificationCenter.default.addObserver(self, selector: #selector(LoginDetailViewController.dismissAlertController), name: NSNotification.Name.UIApplicationDidEnterBackground, object: nil)
     }
 
@@ -113,8 +111,6 @@ class LoginDetailViewController: SensitiveViewController {
     deinit {
         let notificationCenter = NotificationCenter.default
         notificationCenter.removeObserver(self, name: NotificationProfileDidFinishSyncing, object: nil)
-        notificationCenter.removeObserver(self, name: NSNotification.Name.UIMenuControllerWillShowMenu, object: nil)
-        notificationCenter.removeObserver(self, name: NSNotification.Name.UIMenuControllerWillHideMenu, object: nil)
         notificationCenter.removeObserver(self, name: NSNotification.Name.UIApplicationDidEnterBackground, object: nil)
     }
 
@@ -220,11 +216,28 @@ extension LoginDetailViewController: UITableViewDataSource {
 
 // MARK: - UITableViewDelegate
 extension LoginDetailViewController: UITableViewDelegate {
+    private func showMenuOnSingleTap(forIndexPath indexPath: IndexPath) {
+        guard let item = InfoItem(rawValue: indexPath.row) else { return }
+        if ![InfoItem.passwordItem, InfoItem.websiteItem, InfoItem.usernameItem].contains(item) {
+            return
+        }
+        
+        guard let cell = tableView.cellForRow(at: indexPath) as? LoginTableViewCell else { return }
+        
+        cell.becomeFirstResponder()
+        
+        let menu = UIMenuController.shared
+        menu.setTargetRect(cell.frame, in: self.tableView)
+        menu.setMenuVisible(true, animated: true)
+    }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if indexPath == InfoItem.deleteItem.indexPath {
             deleteLogin()
+        } else if !editingInfo {
+            showMenuOnSingleTap(forIndexPath: indexPath)
         }
+        tableView.deselectRow(at: indexPath, animated: true)
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -236,43 +249,6 @@ extension LoginDetailViewController: UITableViewDelegate {
         case .deleteItem:
             return LoginDetailUX.DeleteRowHeight
         }
-    }
-
-    func tableView(_ tableView: UITableView, shouldShowMenuForRowAt indexPath: IndexPath) -> Bool {
-        let item = InfoItem(rawValue: indexPath.row)!
-        if item == .passwordItem || item == .websiteItem || item == .usernameItem {
-            menuControllerCell = tableView.cellForRow(at: indexPath) as? LoginTableViewCell
-            return true
-        }
-
-        return false
-    }
-
-    func tableView(_ tableView: UITableView, canPerformAction action: Selector, forRowAt indexPath: IndexPath, withSender sender: Any?) -> Bool {
-        let item = InfoItem(rawValue: indexPath.row)!
-
-        // Menu actions for password
-        if item == .passwordItem {
-            let loginCell = tableView.cellForRow(at: indexPath) as! LoginTableViewCell
-            let showRevealOption = loginCell.descriptionLabel.isSecureTextEntry ? (action == MenuHelper.SelectorReveal) : (action == MenuHelper.SelectorHide)
-            return action == MenuHelper.SelectorCopy || showRevealOption
-        }
-
-        // Menu actions for Website
-        if item == .websiteItem {
-            return action == MenuHelper.SelectorCopy || action == MenuHelper.SelectorOpenAndFill
-        }
-
-        // Menu actions for Username
-        if item == .usernameItem {
-            return action == MenuHelper.SelectorCopy
-        }
-
-        return false
-    }
-
-    func tableView(_ tableView: UITableView, performAction action: Selector, forRowAt indexPath: IndexPath, withSender sender: Any?) {
-        // No-op. Needs to be overridden for custom menu action selectors to work.
     }
 }
 
@@ -332,7 +308,12 @@ extension LoginDetailViewController {
     func SELdoneEditing() {
         editingInfo = false
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .edit, target: self, action: #selector(LoginDetailViewController.SELedit))
-
+        
+        defer {
+            // Required to get UI to reload with changed state
+            tableView.reloadData()
+        }
+        
         // We only care to update if we changed something
         guard let username = usernameField?.text,
                   let password = passwordField?.text, username != login.username || password != login.password else {
@@ -349,37 +330,6 @@ extension LoginDetailViewController {
         } else if let oldUsername = oldUsername {
             login.update(password: oldPassword, username: oldUsername)
         }
-    }
-
-    func SELwillShowMenuController() {
-        NotificationCenter.default.removeObserver(self, name: NSNotification.Name.UIMenuControllerWillShowMenu, object: nil)
-
-        let menuController = UIMenuController.shared
-        guard let cell = menuControllerCell,
-              let textSize = cell.descriptionTextSize else {
-            return
-        }
-
-        // The description label constraints are such that it extends full width of the cell instead of only
-        // the size of its text. The reason is because when the description is used as a password, the dots
-        // are slightly larger characters than the font size which causes the password text to be truncated
-        // even though the revealed text fits. Since the label is actually full width, the menu controller will
-        // display in its center by default which looks weird with small passwords. To prevent this,
-        // the actual size of the text is used to determine where to correctly place the menu.
-
-        var descriptionFrame = passwordField?.frame ?? CGRect.zero
-        descriptionFrame.size = textSize
-
-        menuController.arrowDirection = .up
-        menuController.setTargetRect(descriptionFrame, in: cell)
-        menuController.setMenuVisible(true, animated: true)
-    }
-
-    func SELwillHideMenuController() {
-        menuControllerCell = nil
-
-        // Re-add observer
-        NotificationCenter.default.addObserver(self, selector: #selector(LoginDetailViewController.SELwillShowMenuController), name: NSNotification.Name.UIMenuControllerWillShowMenu, object: nil)
     }
 }
 
@@ -409,5 +359,13 @@ extension LoginDetailViewController: LoginTableViewCellDelegate {
         }
 
         return false
+    }
+    
+    func infoItemForCell(_ cell: LoginTableViewCell) -> InfoItem? {
+        if let index = tableView.indexPath(for: cell),
+            let item = InfoItem(rawValue: index.row) {
+            return item
+        }
+        return nil
     }
 }

--- a/Client/Frontend/Widgets/LoginTableViewCell.swift
+++ b/Client/Frontend/Widgets/LoginTableViewCell.swift
@@ -7,10 +7,10 @@ import UIKit
 import SnapKit
 import Storage
 
-@objc
 protocol LoginTableViewCellDelegate: class {
     func didSelectOpenAndFillForCell(_ cell: LoginTableViewCell)
     func shouldReturnAfterEditingDescription(_ cell: LoginTableViewCell) -> Bool
+    func infoItemForCell(_ cell: LoginTableViewCell) -> InfoItem?
 }
 
 private struct LoginTableViewCellUX {
@@ -41,6 +41,35 @@ class LoginTableViewCell: UITableViewCell {
     fileprivate let labelContainer = UIView()
 
     weak var delegate: LoginTableViewCellDelegate?
+
+    // In order for context menu handling, this is required
+    override var canBecomeFirstResponder: Bool {
+        return true
+    }
+
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        guard let item = delegate?.infoItemForCell(self) else {
+            return false
+        }
+
+        // Menu actions for password
+        if item == .passwordItem {
+            let showRevealOption = self.descriptionLabel.isSecureTextEntry ? (action == MenuHelper.SelectorReveal) : (action == MenuHelper.SelectorHide)
+            return action == MenuHelper.SelectorCopy || showRevealOption
+        }
+
+        // Menu actions for Website
+        if item == .websiteItem {
+            return action == MenuHelper.SelectorCopy || action == MenuHelper.SelectorOpenAndFill
+        }
+
+        // Menu actions for Username
+        if item == .usernameItem {
+            return action == MenuHelper.SelectorCopy
+        }
+        
+        return false
+    }
 
     lazy var descriptionLabel: UITextField = {
         let label = UITextField()

--- a/UITests/LoginManagerTests.swift
+++ b/UITests/LoginManagerTests.swift
@@ -165,13 +165,13 @@ class LoginManagerTests: KIFTestCase {
         let list = tester().waitForView(withAccessibilityIdentifier: "Login Detail List") as! UITableView
         var passwordCell = list.cellForRow(at: IndexPath(row: 2, section: 0)) as! LoginTableViewCell
         
-        // longPressViewWithAcessibilityLabel fails when called directly because the cell is not a descendant in the
-        // responder chain since it's a cell so instead use the underlying longPressAtPoint method.
+        // tapViewWithAcessibilityLabel fails when called directly because the cell is not a descendant in the
+        // responder chain since it's a cell so instead use the underlying tapAtPoint method.
         let centerOfCell = CGPoint(x: passwordCell.frame.width / 2, y: passwordCell.frame.height / 2)
         XCTAssertTrue(passwordCell.descriptionLabel.isSecureTextEntry)
 
         // Tap the 'Reveal' menu option
-        passwordCell.longPress(at: centerOfCell, duration: 1)
+        passwordCell.tap(at: centerOfCell)
         tester().waitForView(withAccessibilityLabel: "Reveal")
         tester().tapView(withAccessibilityLabel: "Reveal")
 
@@ -179,7 +179,7 @@ class LoginManagerTests: KIFTestCase {
         XCTAssertFalse(passwordCell.descriptionLabel.isSecureTextEntry)
 
         // Tap the 'Hide' menu option
-        passwordCell.longPress(at: centerOfCell, duration: 2)
+        passwordCell.tap(at: centerOfCell)
         tester().waitForView(withAccessibilityLabel: "Hide")
         tester().tapView(withAccessibilityLabel: "Hide")
 
@@ -187,7 +187,7 @@ class LoginManagerTests: KIFTestCase {
         XCTAssertTrue(passwordCell.descriptionLabel.isSecureTextEntry)
 
         // Tap the 'Copy' menu option
-        passwordCell.longPress(at: centerOfCell, duration: 2)
+        passwordCell.tap(at: centerOfCell)
         tester().waitForView(withAccessibilityLabel: "Copy")
         tester().tapView(withAccessibilityLabel: "Copy")
 
@@ -208,20 +208,20 @@ class LoginManagerTests: KIFTestCase {
         let list = tester().waitForView(withAccessibilityIdentifier: "Login Detail List") as! UITableView
         let websiteCell = list.cellForRow(at: IndexPath(row: 0, section: 0)) as! LoginTableViewCell
 
-        // longPressViewWithAcessibilityLabel fails when called directly because the cell is not a descendant in the
-        // responder chain since it's a cell so instead use the underlying longPressAtPoint method.
+        // tapViewWithAcessibilityLabel fails when called directly because the cell is not a descendant in the
+        // responder chain since it's a cell so instead use the underlying tapAtPoint method.
         let centerOfCell = CGPoint(x: websiteCell.frame.width / 2, y: websiteCell.frame.height / 2)
 
         // Tap the 'Copy' menu option
-        websiteCell.longPress(at: centerOfCell, duration: 1)
-        websiteCell.longPress(at: centerOfCell, duration: 1)
+        websiteCell.tap(at: centerOfCell)
+        websiteCell.tap(at: centerOfCell)
         tester().waitForView(withAccessibilityLabel: "Copy")
         tester().tapView(withAccessibilityLabel: "Copy")
 
         XCTAssertEqual(UIPasteboard.general.string, "http://a0.com")
 
         // Tap the 'Open & Fill' menu option  just checks to make sure we navigate to the web page
-        websiteCell.longPress(at: centerOfCell, duration: 1)
+        websiteCell.tap(at: centerOfCell)
         tester().waitForView(withAccessibilityLabel: "Open & Fill")
         tester().tapView(withAccessibilityLabel: "Open & Fill")
 
@@ -241,13 +241,13 @@ class LoginManagerTests: KIFTestCase {
         let list = tester().waitForView(withAccessibilityIdentifier: "Login Detail List") as! UITableView
         let websiteCell = list.cellForRow(at: IndexPath(row: 0, section: 0)) as! LoginTableViewCell
 
-        // longPressViewWithAcessibilityLabel fails when called directly because the cell is not a descendant in the
-        // responder chain since it's a cell so instead use the underlying longPressAtPoint method.
+        // tapViewWithAcessibilityLabel fails when called directly because the cell is not a descendant in the
+        // responder chain since it's a cell so instead use the underlying tapAtPoint method.
         let centerOfCell = CGPoint(x: websiteCell.frame.width / 2, y: websiteCell.frame.height / 2)
 
         // Tap the 'Open & Fill' menu option  just checks to make sure we navigate to the web page
-        websiteCell.longPress(at: centerOfCell, duration: 2)
-        websiteCell.longPress(at: centerOfCell, duration: 2)
+        websiteCell.tap(at: centerOfCell)
+        websiteCell.tap(at: centerOfCell)
         tester().waitForView(withAccessibilityLabel: "Open & Fill")
         tester().tapView(withAccessibilityLabel: "Open & Fill")
 
@@ -273,13 +273,13 @@ class LoginManagerTests: KIFTestCase {
         let list = tester().waitForView(withAccessibilityIdentifier: "Login Detail List") as! UITableView
         let websiteCell = list.cellForRow(at: IndexPath(row: 0, section: 0)) as! LoginTableViewCell
 
-        // longPressViewWithAcessibilityLabel fails when called directly because the cell is not a descendant in the
-        // responder chain since it's a cell so instead use the underlying longPressAtPoint method.
+        // tapViewWithAcessibilityLabel fails when called directly because the cell is not a descendant in the
+        // responder chain since it's a cell so instead use the underlying tapAtPoint method.
         let centerOfCell = CGPoint(x: websiteCell.frame.width / 2, y: websiteCell.frame.height / 2)
 
         // Tap the 'Open & Fill' menu option  just checks to make sure we navigate to the web page
-        websiteCell.longPress(at: centerOfCell, duration: 1)
-        websiteCell.longPress(at: centerOfCell, duration: 1)
+        websiteCell.tap(at: centerOfCell)
+        websiteCell.tap(at: centerOfCell)
         tester().waitForView(withAccessibilityLabel: "Open & Fill")
         tester().tapView(withAccessibilityLabel: "Open & Fill")
 
@@ -298,13 +298,13 @@ class LoginManagerTests: KIFTestCase {
         let list = tester().waitForView(withAccessibilityIdentifier: "Login Detail List") as! UITableView
         let usernameCell = list.cellForRow(at: IndexPath(row: 1, section: 0)) as! LoginTableViewCell
 
-        // longPressViewWithAcessibilityLabel fails when called directly because the cell is not a descendant in the
-        // responder chain since it's a cell so instead use the underlying longPressAtPoint method.
+        // tapViewWithAcessibilityLabel fails when called directly because the cell is not a descendant in the
+        // responder chain since it's a cell so instead use the underlying tapAtPoint method.
         let centerOfCell = CGPoint(x: usernameCell.frame.width / 2, y: usernameCell.frame.height / 2)
 
         // Tap the 'Copy' menu option
-        usernameCell.longPress(at: centerOfCell, duration: 1)
-        usernameCell.longPress(at: centerOfCell, duration: 1)
+        usernameCell.tap(at: centerOfCell)
+        usernameCell.tap(at: centerOfCell)
         tester().waitForView(withAccessibilityLabel: "Copy")
         tester().tapView(withAccessibilityLabel: "Copy")
 
@@ -602,14 +602,13 @@ class LoginManagerTests: KIFTestCase {
         tester().clearTextFromAndThenEnterText(intoCurrentFirstResponder: "changedpassword")
         tester().tapView(withAccessibilityLabel: "Done")
 
-        // longPressViewWithAcessibilityLabel fails when called directly because the cell is not a descendant in the
-        // responder chain since it's a cell so instead use the underlying longPressAtPoint method.
+        // tapViewWithAcessibilityLabel fails when called directly because the cell is not a descendant in the
+        // responder chain since it's a cell so instead use the underlying tapAtPoint method.
         let centerOfCell = CGPoint(x: passwordCell.frame.width / 2, y: passwordCell.frame.height / 2)
         XCTAssertTrue(passwordCell.descriptionLabel.isSecureTextEntry)
 
         // Tap the 'Reveal' menu option
-        passwordCell.longPress(at: centerOfCell, duration: 1)
-        passwordCell.longPress(at: centerOfCell, duration: 1)
+        passwordCell.tap(at: centerOfCell)
         tester().waitForView(withAccessibilityLabel: "Reveal")
         tester().tapView(withAccessibilityLabel: "Reveal")
 


### PR DESCRIPTION
Also removed `SELwillShowMenuController` which set the menu popup origin to match the size of the text more closely, which also makes the menu popup hidden by my finger initially on tap. 
Now it pops up using the center of the UITableViewCell's frame, I don't see why this wouldn't be expected behaviour on single tap (and doesn't need any additional code).
I was refactoring this code anyway because of changes to how/where UIMenuController.setMenuVisible() is performed, and the behaviour I saw prior to incorporating the old menu positioning logic seemed correct.

