### PR TITLE
Bug 1381660 - Fixing XCUITests, KIFTests, EarlGrey Tests, and FxScreenGraph

### DIFF
--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -272,7 +272,9 @@ class BrowserUtils {
     //If it is a first run, first run window should be gone
     class func dismissFirstRunUI(_ tester: KIFUITestActor) {
         do {
-            try tester.tryFindingTappableView(withAccessibilityLabel: "Start Browsing")
+            try tester.tryFindingView(withAccessibilityLabel: "Intro Tour Carousel")
+            tester.swipeView(withAccessibilityLabel: "Intro Tour Carousel", in: KIFSwipeDirection.left)
+            tester.waitForTappableView(withAccessibilityLabel: "Start Browsing")
             tester.tapView(withAccessibilityLabel: "Start Browsing")
         } catch {
             //First run dialog did not appear
@@ -283,12 +285,20 @@ class BrowserUtils {
 		var error: NSError?
         
 		let matcher = grey_allOf([
-			grey_accessibilityID("IntroViewController.startBrowsingButton"), grey_sufficientlyVisible()])
+			grey_accessibilityID("IntroViewController.scrollView"), grey_sufficientlyVisible()])
 		
         EarlGrey.select(elementWithMatcher: matcher).assert(grey_notNil(), error: &error)
 		
 		if error == nil {
-            EarlGrey.select(elementWithMatcher: matcher).perform(grey_tap())
+            EarlGrey.select(elementWithMatcher: matcher).perform(grey_swipeFastInDirection(GREYDirection.left))
+            let buttonMatcher = grey_allOf([
+                grey_accessibilityID("IntroViewController.startBrowsingButton"), grey_sufficientlyVisible()])
+            
+            EarlGrey.select(elementWithMatcher: buttonMatcher).assert(grey_notNil(), error: &error)
+        
+            if error == nil {
+                EarlGrey.select(elementWithMatcher: buttonMatcher).perform(grey_tap())
+            }
 		}
 	}
 

--- a/XCUITests/BaseTestCase.swift
+++ b/XCUITests/BaseTestCase.swift
@@ -28,10 +28,11 @@ class BaseTestCase: XCTestCase {
     
     //If it is a first run, first run window should be gone
     func dismissFirstRunUI() {
-        let firstRunUI = XCUIApplication().buttons["Start Browsing"]
+        let firstRunUI = XCUIApplication().scrollViews["IntroViewController.scrollView"]
         
         if firstRunUI.exists {
-            firstRunUI.tap()
+            firstRunUI.swipeLeft()
+            XCUIApplication().buttons["Start Browsing"].tap()
         }
     }
     

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -38,17 +38,17 @@ let allSettingsScreens = [
     OpenWithSettings,
 ]
 
-let Intro_Organize = "Intro.Organize"
-let Intro_Customize = "Intro.Customize"
-let Intro_Share = "Intro.Share"
-let Intro_Choose = "Intro.Choose"
+let Intro_Welcome = "Intro.Welcome"
+let Intro_Search = "Intro.Search"
+let Intro_Private = "Intro.Private"
+let Intro_Mail = "Intro.Mail"
 let Intro_Sync = "Intro.Sync"
 
 let allIntroPages = [
-    Intro_Organize,
-    Intro_Customize,
-    Intro_Share,
-    Intro_Choose,
+    Intro_Welcome,
+    Intro_Search,
+    Intro_Private,
+    Intro_Mail,
     Intro_Sync,
 ]
 
@@ -71,9 +71,14 @@ func createScreenGraph(_ app: XCUIApplication, url: String = "https://www.mozill
     let map = ScreenGraph()
 
     let startBrowsingButton = app.buttons["IntroViewController.startBrowsingButton"]
+    let introScrollView = app.scrollViews["IntroViewController.scrollView"]
     map.createScene(FirstRun) { scene in
+        // We don't yet have conditional edges, so we declare an edge from this node
+        // to NewTabScreen, and then just make it work.
         scene.gesture(to: NewTabScreen) {
-            if startBrowsingButton.exists {
+            if introScrollView.exists {
+                // go find the startBrowsing button on the second page of the intro.
+                introScrollView.swipeLeft()
                 startBrowsingButton.tap()
             }
         }
@@ -98,7 +103,9 @@ func createScreenGraph(_ app: XCUIApplication, url: String = "https://www.mozill
                 scene.swipeLeft(introPager, to: next)
             }
 
-            scene.tap(startBrowsingButton, to: NewTabScreen)
+            if i > 0 {
+                scene.tap(startBrowsingButton, to: NewTabScreen)
+            }
         }
 
         i += 1
@@ -172,7 +179,7 @@ func createScreenGraph(_ app: XCUIApplication, url: String = "https://www.mozill
         scene.tap(table.cells["Logins"], to: LoginsSettings)
         scene.tap(table.cells["ClearPrivateData"], to: ClearPrivateDataSettings)
         scene.tap(table.cells["OpenWith.Setting"], to: OpenWithSettings)
-        scene.tap(table.cells["ShowTour"], to: Intro_Organize)
+        scene.tap(table.cells["ShowTour"], to: Intro_Welcome)
 
         scene.backAction = navigationControllerBackAction
     }


### PR DESCRIPTION
This PR fixes the UITests that were broken due to the new onboarding experience - specifically, the fact that there is no longer an accessible "Start Browsing" button on the first page to exit the onboarding overlay.

The XCUI/UITests were very simply addressed by first swiping left before attempting to tap the "Start Browsing" button.

FxScreenGraph was similar as above, as well as having the intro-cards re-named.

https://bugzilla.mozilla.org/show_bug.cgi?id=1381660