### PR TITLE
Bug 1381836: Show confirmation when tapping on app store links

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -404,6 +404,8 @@
 		C4E398601D22C409004E89BA /* TopTabsLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E3985F1D22C409004E89BA /* TopTabsLayout.swift */; };
 		C4EFEECF1CEBB6F2009762A4 /* BackForwardTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4EFEECE1CEBB6F2009762A4 /* BackForwardTableViewCell.swift */; };
 		C4F3B29A1CFCF93A00966259 /* ButtonToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F3B2991CFCF93A00966259 /* ButtonToast.swift */; };
+		C8EB60C41F1FB12500F9B5B3 /* navigationDelegate.html in Resources */ = {isa = PBXBuildFile; fileRef = C8EB60C31F1FB12500F9B5B3 /* navigationDelegate.html */; };
+		C8EB60DC1F1FB9AD00F9B5B3 /* NavigationDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8EB60DB1F1FB9AD00F9B5B3 /* NavigationDelegateTests.swift */; };
 		CE564D8E1EB7BD7700BEDDDC /* BookmarksRepairRequestor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE564D8D1EB7BD7700BEDDDC /* BookmarksRepairRequestor.swift */; };
 		CEFC984B1EC0DCF5008A3E48 /* TestBookmarksRepairRequestor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFC983B1EC0DC60008A3E48 /* TestBookmarksRepairRequestor.swift */; };
 		D02816C21ECA5E2A00240CAA /* HistoryStateHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02816C11ECA5E2A00240CAA /* HistoryStateHelper.swift */; };
@@ -1650,6 +1652,8 @@
 		C4E3985F1D22C409004E89BA /* TopTabsLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopTabsLayout.swift; sourceTree = "<group>"; };
 		C4EFEECE1CEBB6F2009762A4 /* BackForwardTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackForwardTableViewCell.swift; sourceTree = "<group>"; };
 		C4F3B2991CFCF93A00966259 /* ButtonToast.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonToast.swift; sourceTree = "<group>"; };
+		C8EB60C31F1FB12500F9B5B3 /* navigationDelegate.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = navigationDelegate.html; sourceTree = "<group>"; };
+		C8EB60DB1F1FB9AD00F9B5B3 /* NavigationDelegateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationDelegateTests.swift; sourceTree = "<group>"; };
 		CE564D8D1EB7BD7700BEDDDC /* BookmarksRepairRequestor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksRepairRequestor.swift; sourceTree = "<group>"; };
 		CEFC983B1EC0DC60008A3E48 /* TestBookmarksRepairRequestor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestBookmarksRepairRequestor.swift; sourceTree = "<group>"; };
 		D02816C11ECA5E2A00240CAA /* HistoryStateHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HistoryStateHelper.swift; sourceTree = "<group>"; };
@@ -2997,6 +3001,7 @@
 				E6B4C3D71C68F55C001F97E8 /* JSPrompt.html */,
 				D31EC05E1CC57ED80096F4AB /* localhostLoad.html */,
 				D34E33021BA793C2006135F0 /* loginForm.html */,
+				C8EB60C31F1FB12500F9B5B3 /* navigationDelegate.html */,
 				0BF8F8D91AEFF1C900E90BC2 /* noTitle.html */,
 				0B6FBAB11AC1F830007EC669 /* numberedPage.html */,
 				0B5A93411B1EB572004F47A2 /* readablePage.html */,
@@ -3013,6 +3018,7 @@
 				4F514FD31ACD8F2C0022D7EA /* HistoryTests.swift */,
 				E6A92ADA1C52A8DA00743291 /* LoginInputTests.swift */,
 				E633E3791C2204BE001FFF6C /* LoginManagerTests.swift */,
+				C8EB60DB1F1FB9AD00F9B5B3 /* NavigationDelegateTests.swift */,
 				0B5A93211B1EB4C8004F47A2 /* ReadingListTest.swift */,
 				D3CFD3631CC5605B0064AB4A /* SecurityTests.swift */,
 				D3C3EB641B6FF44000388E9A /* SessionRestoreTests.swift */,
@@ -4776,6 +4782,7 @@
 				0BF8F8DA1AEFF1C900E90BC2 /* noTitle.html in Resources */,
 				E67422C51CFF2D39009E8373 /* youtube.ico in Resources */,
 				D3E171C21A841EAD00AB44CD /* KIFHelper.js in Resources */,
+				C8EB60C41F1FB12500F9B5B3 /* navigationDelegate.html in Resources */,
 				D31EC05F1CC57ED80096F4AB /* localhostLoad.html in Resources */,
 				4F97573B1AFA6F37006ECC24 /* readerContent.html in Resources */,
 			);
@@ -5335,6 +5342,7 @@
 				E6B4C4031C68F58B001F97E8 /* BrowserTests.swift in Sources */,
 				D39FA1811A83E84900EE869C /* Global.swift in Sources */,
 				4F514FD41ACD8F2C0022D7EA /* HistoryTests.swift in Sources */,
+				C8EB60DC1F1FB9AD00F9B5B3 /* NavigationDelegateTests.swift in Sources */,
 				E6A92ADB1C52A8DA00743291 /* LoginInputTests.swift in Sources */,
 				D375A9201AE71675001B30D5 /* ViewMemoryLeakTests.swift in Sources */,
 				D313BE981B2F5096009EF241 /* DomainAutocompleteTests.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2432,12 +2432,23 @@ extension BrowserViewController: WKNavigationDelegate {
         // instead of being loaded in the webview. Note that there is no point in calling canOpenURL() here, because
         // iOS will always say yes. TODO Is this the same as isWhitelisted?
 
-        if isAppleMapsURL(url) || isStoreURL(url) {
-            UIApplication.shared.openURL(url)
+       if isAppleMapsURL(url) {
+           UIApplication.shared.openURL(url)
+           decisionHandler(WKNavigationActionPolicy.cancel)
+           return
+       }
+
+        if let tab = tabManager.selectedTab, isStoreURL(url) {
             decisionHandler(WKNavigationActionPolicy.cancel)
+
+            let alreadyShowingSnackbarOnThisTab = tab.bars.count > 0
+            if !alreadyShowingSnackbarOnThisTab {
+                TimerSnackBar.showAppStoreConfirmationBar(forTab: tab, appStoreURL: url)
+            }
+            
             return
         }
-
+        
         // Handles custom mailto URL schemes.
         if url.scheme == "mailto" {
             if let mailToMetadata = url.mailToMetadata(), let mailScheme = self.profile.prefs.stringForKey(PrefsKeys.KeyMailToOption), mailScheme != "mailto" {

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -321,6 +321,11 @@ extension Strings {
     public static let AppMenuNoImageModeTurnOffLabel = NSLocalizedString("Menu.NoImageModeTurnOffAction.Label", value: "Show Images", comment: "Label for the button, displayed in the menu, used to turn no image mode off.")
 }
 
+// Snackbar shown when tapping app store link
+extension Strings {
+    public static let ExternalLinkToAppStore_ConfirmationTitle = NSLocalizedString("ExternalLink.ConfirmMessage", value: "Open this link in the App Store app?", comment: "Question shown to user when tapping a link that opens the App Store app")
+}
+
 // MARK: Deprecated Strings (to be removed in next version)
 private let logOut = NSLocalizedString("Log Out", comment: "Button in settings screen to disconnect from your account")
 private let logOutQuestion = NSLocalizedString("Log Out?", comment: "Title of the 'log out firefox account' alert")

--- a/Client/Frontend/Widgets/SnackBar.swift
+++ b/Client/Frontend/Widgets/SnackBar.swift
@@ -281,6 +281,23 @@ class TimerSnackBar: SnackBar {
         fatalError("init(coder:) has not been implemented")
     }
 
+    static func showAppStoreConfirmationBar(forTab tab: Tab, appStoreURL: URL) {
+        let msg =  NSAttributedString(string: Strings.ExternalLinkToAppStore_ConfirmationTitle, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+        let bar = TimerSnackBar(attrText: msg,
+                             img: UIImage(named: "defaultFavicon"),
+                             buttons: [
+                                SnackButton(title: UIConstants.OKString, accessibilityIdentifier: "ConfirmOpenInAppStore", callback: { bar in
+                                    tab.removeSnackbar(bar)
+                                    UIApplication.shared.openURL(appStoreURL)
+                                }),
+                                SnackButton(title: UIConstants.CancelString, accessibilityIdentifier: "CancelOpenInAppStore", callback: { bar in
+                                    tab.removeSnackbar(bar)
+                                })
+            ])
+        
+        tab.addSnackbar(bar)
+    }
+    
     override func show() {
         self.timer = Timer(timeInterval: timeout, target: self, selector: #selector(TimerSnackBar.SELTimerDone), userInfo: nil, repeats: false)
         RunLoop.current.add(self.timer!, forMode: RunLoopMode.defaultRunLoopMode)

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -457,6 +457,10 @@ class SimplePageServer {
         webServer.addHandler(forMethod: "GET", path: "/loginForm.html", request: GCDWebServerRequest.self) { _ in
             return GCDWebServerDataResponse(html: self.getPageData("loginForm"))
         }
+        
+        webServer.addHandler(forMethod: "GET", path: "/navigationDelegate.html", request: GCDWebServerRequest.self) { _ in
+            return GCDWebServerDataResponse(html: self.getPageData("navigationDelegate"))
+        }
 
         webServer.addHandler(forMethod: "GET", path: "/localhostLoad.html", request: GCDWebServerRequest.self) { _ in
             return GCDWebServerDataResponse(html: self.getPageData("localhostLoad"))

--- a/UITests/NavigationDelegateTests.swift
+++ b/UITests/NavigationDelegateTests.swift
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import EarlGrey
+@testable import Client
+
+// WKWebView's WKNavigationDelegate is used for custom URL handling
+// such as telephone links, app store links, etc.
+
+class NavigationDelegateTests: KIFTestCase {
+    fileprivate var webRoot: String!
+    fileprivate var profile: Profile!
+    
+    override func setUp() {
+        super.setUp()
+        profile = (UIApplication.shared.delegate as! AppDelegate).profile!
+        webRoot = SimplePageServer.start()
+        BrowserUtils.dismissFirstRunUI()
+    }
+    
+    override func tearDown() {
+        _ = profile.logins.removeAll().value
+        BrowserUtils.resetToAboutHome(tester())
+        BrowserUtils.clearPrivateData(tester: tester())
+        super.tearDown()
+    }
+    
+    func enterUrl(url: String) {
+        EarlGrey.select(elementWithMatcher: grey_accessibilityID("url")).perform(grey_tap())
+        EarlGrey.select(elementWithMatcher: grey_accessibilityID("address")).perform(grey_typeText("\(url)\n"))
+    }
+    
+    func testAppStoreLinkShowsConfirmation() {
+        let url = "\(webRoot!)/navigationDelegate.html"
+        enterUrl(url: url)
+        tester().tapWebViewElementWithAccessibilityLabel("link")
+        EarlGrey.select(elementWithMatcher: grey_accessibilityID("CancelOpenInAppStore")).perform(grey_tap())
+    }
+}

--- a/UITests/navigationDelegate.html
+++ b/UITests/navigationDelegate.html
@@ -1,0 +1,8 @@
+<html>
+    <head>
+        <title>Test navigation delegate</title>
+    </head>
+    <body>
+       <a href="https://itunes.apple.com/ca/app/twitter/id333903271">link</a>
+    </body>
+</html>


### PR DESCRIPTION
This shows a snackbar to ask the user to confirm before opening
app store links.
The test case is a UITest that loads a page with an itunes URL, and verifies the snackbar shows when the link is tapped.

I went with 'Open this link in the App Store app?' as the message. I thought itunes links could open a 3rd party app if it was installed, but I can't repro that (unless the URL scheme is custom like medium://some-thing).

Should we be handling the custom URL scheme case with a confirmation dialog also?