### PR TITLE
Bug 1381623 - A new Photon menu. Behind a feature flag. Disabled by default

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -258,6 +258,7 @@
 		3B0943811D6CC4FC004F24E1 /* FilledPageControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0943801D6CC4FC004F24E1 /* FilledPageControl.swift */; };
 		3B39EDBA1E16E18900EF029F /* CustomSearchEnginesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B39EDB91E16E18900EF029F /* CustomSearchEnginesTest.swift */; };
 		3B39EDCB1E16E1AA00EF029F /* CustomSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B39EDCA1E16E1AA00EF029F /* CustomSearchViewController.swift */; };
+		3B400E521F1ED5C4005194DD /* PhotonActionSheetProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B400E431F1ED5C3005194DD /* PhotonActionSheetProtocol.swift */; };
 		3B4262E51E538EC400CA681C /* MetadataHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 3B4262E21E538EC400CA681C /* MetadataHelper.js */; };
 		3B4262E61E538EC400CA681C /* MetadataParserHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4262E31E538EC400CA681C /* MetadataParserHelper.swift */; };
 		3B4262E71E538EC400CA681C /* page-metadata-parser.js in Resources */ = {isa = PBXBuildFile; fileRef = 3B4262E41E538EC400CA681C /* page-metadata-parser.js */; };
@@ -1516,6 +1517,7 @@
 		3B0943801D6CC4FC004F24E1 /* FilledPageControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FilledPageControl.swift; path = ThirdParty/FilledPageControl.swift; sourceTree = "<group>"; };
 		3B39EDB91E16E18900EF029F /* CustomSearchEnginesTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomSearchEnginesTest.swift; sourceTree = "<group>"; };
 		3B39EDCA1E16E1AA00EF029F /* CustomSearchViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomSearchViewController.swift; sourceTree = "<group>"; };
+		3B400E431F1ED5C3005194DD /* PhotonActionSheetProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhotonActionSheetProtocol.swift; sourceTree = "<group>"; };
 		3B4262E21E538EC400CA681C /* MetadataHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = MetadataHelper.js; path = "Metadata Parsing/MetadataHelper.js"; sourceTree = "<group>"; };
 		3B4262E31E538EC400CA681C /* MetadataParserHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MetadataParserHelper.swift; path = "Metadata Parsing/MetadataParserHelper.swift"; sourceTree = "<group>"; };
 		3B4262E41E538EC400CA681C /* page-metadata-parser.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = "page-metadata-parser.js"; path = "Metadata Parsing/page-metadata-parser.js"; sourceTree = "<group>"; };
@@ -2965,6 +2967,7 @@
 				D30B0F2F1AA7D66300C01CA3 /* ThumbnailCell.swift */,
 				E663D5771BB341C4001EF30E /* ToggleButton.swift */,
 				7B844E3C1BBDDB9D00E733A2 /* ChevronView.swift */,
+				3B400E431F1ED5C3005194DD /* PhotonActionSheetProtocol.swift */,
 				E65607601C08B4E200534B02 /* SearchInputView.swift */,
 				E63ED7D71BFCD9990097D08E /* LoginTableViewCell.swift */,
 				C4E3984B1D21F2FD004E89BA /* TabTrayButtonExtensions.swift */,
@@ -5608,6 +5611,7 @@
 				19DE1F671EC13B6400428B8C /* LeanplumIntegration.swift in Sources */,
 				7BC68CCF1CC152B70043562A /* MenuToolbarItem.swift in Sources */,
 				E65D89181C8647420006EA35 /* AppAuthenticator.swift in Sources */,
+				3B400E521F1ED5C4005194DD /* PhotonActionSheetProtocol.swift in Sources */,
 				28FDFF0C1C1F725800840F86 /* SeparatorTableCell.swift in Sources */,
 				E69DB0BE1E97E301008A67E6 /* ClientTelemetry.swift in Sources */,
 				C400467C1CF4E43E00B08303 /* BackForwardListViewController.swift in Sources */,

--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Fennec"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference
@@ -138,6 +139,7 @@
       buildConfiguration = "Fennec"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1792,7 +1792,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
             })
             actions.append(tabActions)
 
-            let actionMenuPresenter: (URL, Tab, UIView, UIPopoverArrowDirection) -> ()  = { (url, tab, view, direction) in
+            let actionMenuPresenter: (URL, Tab, UIView, UIPopoverArrowDirection) -> Void  = { (url, tab, view, direction) in
                 self.presentActivityViewController(url, tab: tab, sourceView: view, sourceRect: view.frame, arrowDirection: .up)
             }
 
@@ -1804,14 +1804,9 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
                 let systemActions = self.getOtherPanelActions(vcDelegate: self)
                 actions.append(systemActions)
             }
-
-
             self.presentSheetWith(actions: actions, on: self, from: button)
-
-
             return
         }
-
 
         // check the trait collection
         // open as modal if portrait\

--- a/Client/Frontend/Browser/HomePageHelper.swift
+++ b/Client/Frontend/Browser/HomePageHelper.swift
@@ -50,15 +50,15 @@ class HomePageHelper {
         tab.loadRequest(URLRequest(url: url))
     }
 
-    func openHomePage(inTab tab: Tab, withNavigationController navigationController: UINavigationController?) {
+    func openHomePage(inTab tab: Tab, presentAlertOn viewController: UIViewController?) {
         if isHomePageAvailable {
             openHomePage(tab)
         } else {
-            setHomePage(toTab: tab, withNavigationController: navigationController)
+            setHomePage(toTab: tab, presentAlertOn: viewController)
         }
     }
 
-    func setHomePage(toTab tab: Tab, withNavigationController navigationController: UINavigationController?) {
+    func setHomePage(toTab tab: Tab, presentAlertOn viewController: UIViewController?) {
         let alertController = UIAlertController(
             title: Strings.SetHomePageDialogTitle,
             message: Strings.SetHomePageDialogMessage,
@@ -66,7 +66,7 @@ class HomePageHelper {
         alertController.addAction(UIAlertAction(title: Strings.SetHomePageDialogNo, style: .cancel, handler: nil))
         alertController.addAction(UIAlertAction(title: Strings.SetHomePageDialogYes, style: .default) { _ in
             self.currentURL = tab.url as URL?
-            })
-        navigationController?.present(alertController, animated: true, completion: nil)
+        })
+        viewController?.present(alertController, animated: true, completion: nil)
     }
 }

--- a/Client/Frontend/Browser/NightModeHelper.swift
+++ b/Client/Frontend/Browser/NightModeHelper.swift
@@ -59,6 +59,11 @@ class NightModeHelper: TabHelper {
             }
         }
     }
+
+    static func toggle(_ prefs: Prefs, tabManager: TabManager) {
+        let isActive = prefs.boolForKey(NoImageModePrefsKey.NoImageModeStatus) ?? false
+        setNightMode(prefs, tabManager: tabManager, enabled: !isActive)
+    }
     
     static func setNightMode(_ prefs: Prefs, tabManager: TabManager, enabled: Bool) {
         prefs.setBool(enabled, forKey: PrefsKeys.KeyNightModeStatus)
@@ -66,6 +71,10 @@ class NightModeHelper: TabHelper {
             tab.setNightMode(enabled)
         }
         NightModeHelper.setNightModeBrightness(prefs, enabled: enabled)
+    }
+
+    static func isActivated(_ prefs: Prefs) -> Bool {
+        return prefs.boolForKey(NightModePrefsKey.NightModeStatus) ?? false
     }
 }
 

--- a/Client/Frontend/Browser/NoImageModeHelper.swift
+++ b/Client/Frontend/Browser/NoImageModeHelper.swift
@@ -35,10 +35,24 @@ class NoImageModeHelper: TabHelper {
     }
 
     static func isNoImageModeAvailable(_ state: AppState) -> Bool {
+        // TODO: Doesnt look like anyone actually uses NoImageModePrefsKey.NoImageModeButtonIsInMenu
+        // was this added in the case that this feature might only launch in China?
         return state.prefs.boolForKey(NoImageModePrefsKey.NoImageModeButtonIsInMenu) ?? AppConstants.MOZ_NO_IMAGE_MODE
     }
 
     static func isNoImageModeActivated(_ state: AppState) -> Bool {
         return state.prefs.boolForKey(NoImageModePrefsKey.NoImageModeStatus) ?? false
+    }
+
+    static func isActivated(_ prefs: Prefs) -> Bool {
+        return prefs.boolForKey(NoImageModePrefsKey.NoImageModeStatus) ?? false
+    }
+
+    static func toggle(profile: Profile, tabManager: TabManager) {
+        let enabled = isActivated(profile.prefs)
+
+        profile.prefs.setBool(!enabled, forKey: PrefsKeys.KeyNoImageModeStatus)
+        tabManager.tabs.forEach { $0.setNoImageMode(!enabled, force: true) }
+        tabManager.selectedTab?.reload()
     }
 }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -448,6 +448,17 @@ class EnableActivtyStreamSetting: FeatureSwitchSetting {
 
 }
 
+class EnablePhotonMenuSetting: FeatureSwitchSetting {
+    let profile: Profile
+
+    init(settings: SettingsTableViewController) {
+        self.profile = settings.profile
+        let title = NSAttributedString(string: "Enable the Photon Menu", attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+        super.init(prefs: settings.profile.prefs, featureSwitch: FeatureSwitches.photonMenu, with: title)
+    }
+
+}
+
 class EnableBookmarkMergingSetting: HiddenSetting {
     override var title: NSAttributedString? {
         // Not localized for now.

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -118,7 +118,8 @@ class AppSettingsTableViewController: SettingsTableViewController {
                 DeleteExportedDataSetting(settings: self),
                 EnableBookmarkMergingSetting(settings: self),
                 ForceCrashSetting(settings: self),
-                EnableActivtyStreamSetting(settings: self)
+                EnableActivtyStreamSetting(settings: self),
+                EnablePhotonMenuSetting(settings: self)
             ])]
             
             if profile.hasAccount() {

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -1,0 +1,168 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import Storage
+
+protocol PhotonActionSheetProtocol  {
+    var tabManager: TabManager { get }
+    var profile: Profile { get }
+}
+
+extension PhotonActionSheetProtocol {
+    typealias PresentableVC = UIViewController & UIPopoverPresentationControllerDelegate
+
+    func presentSheetWith(actions: [[PhotonActionSheetItem]], on viewController: PresentableVC, from view: UIView) {
+        let sheet = PhotonActionSheet(actions: actions)
+        sheet.modalPresentationStyle =  UIDevice.current.userInterfaceIdiom == .pad ? .popover : .overFullScreen
+        sheet.modalTransitionStyle = .crossDissolve
+
+        if let popoverVC = sheet.popoverPresentationController {
+            popoverVC.backgroundColor = UIColor.clear
+            popoverVC.delegate = viewController
+            popoverVC.sourceView = view
+            popoverVC.sourceRect = CGRect(x: view.frame.width/2, y: view.frame.size.height * 0.75, width: 1, height: 1)
+            popoverVC.permittedArrowDirections = UIPopoverArrowDirection.up
+        }
+
+        viewController.present(sheet, animated: true, completion: nil)
+    }
+
+    //Returns a list of actions which is used to build a menu
+    //parameter OpenURL is a clousre that can open a given URL in some view controller. It is up to the class using the menu to know how to open the url
+    func getHomePanelActions(openURL: @escaping (URL) -> ()) -> [PhotonActionSheetItem] {
+        let openTopSites = PhotonActionSheetItem(title: Strings.AppMenuTopSitesTitleString, iconString: "menupanel-TopSites") { action in
+            openURL(HomePanelType.topSites.localhostURL)
+        }
+
+        let openBookmarks = PhotonActionSheetItem(title: Strings.AppMenuBookmarksTitleString, iconString: "menupanel-Bookmarks") { action in
+            openURL(HomePanelType.bookmarks.localhostURL)
+        }
+
+        let openHistory = PhotonActionSheetItem(title: Strings.AppMenuHistoryTitleString, iconString: "menupanel-History") { action in
+            openURL(HomePanelType.history.localhostURL)
+        }
+
+        let openReadingList = PhotonActionSheetItem(title: Strings.AppMenuReadingListTitleString, iconString: "menupanel-ReadingList") { action in
+            openURL(HomePanelType.readingList.localhostURL)
+        }
+
+        return [openTopSites, openBookmarks, openHistory, openReadingList]
+    }
+
+    /*
+    Returns a list of actions which is used to build the general browser menu
+    These items repersent global options that are presented in the menu
+    TODO: These icons should all have the icons and use Strings.swift
+    */
+
+    typealias PageOptionsVC = QRCodeViewControllerDelegate & SettingsDelegate & PresentingModalViewControllerDelegate & UIViewController
+
+    func getOtherPanelActions(vcDelegate: PageOptionsVC) -> [PhotonActionSheetItem] {
+        let openQR = PhotonActionSheetItem(title: "QR Scanner", iconString: "menu-ScanQRCode") { action in
+            let qrCodeViewController = QRCodeViewController()
+            qrCodeViewController.qrCodeDelegate = vcDelegate
+            let controller = UINavigationController(rootViewController: qrCodeViewController)
+            vcDelegate.present(controller, animated: true, completion: nil)
+        }
+
+        let openSettings = PhotonActionSheetItem(title: "Settings", iconString: "menu-Settings") { action in
+            let settingsTableViewController = AppSettingsTableViewController()
+            settingsTableViewController.profile = self.profile
+            settingsTableViewController.tabManager = self.tabManager
+            settingsTableViewController.settingsDelegate = vcDelegate
+
+            let controller = SettingsNavigationController(rootViewController: settingsTableViewController)
+            controller.popoverDelegate = vcDelegate
+            controller.modalPresentationStyle = UIModalPresentationStyle.formSheet
+            vcDelegate.present(controller, animated: true, completion: nil)
+        }
+
+        let noImageText = NoImageModeHelper.isActivated(profile.prefs) ? "Hide Images" : "Show Images"
+        let noImageMode = PhotonActionSheetItem(title: noImageText, iconString: "menu-NoImageMode") { action in
+            NoImageModeHelper.toggle(profile: self.profile, tabManager: self.tabManager)
+        }
+
+        let nightModeText = NightModeHelper.isActivated(profile.prefs) ? "Turn off Night Mode" : "Turn on Night Mode"
+        let nightMode = PhotonActionSheetItem(title: nightModeText, iconString: "menu-NightMode") { action in
+            NightModeHelper.toggle(self.profile.prefs, tabManager: self.tabManager)
+        }
+
+        return [openSettings, openQR, noImageMode, nightMode]
+    }
+
+
+    func getTabActions(tab: Tab, buttonView: UIView,   presentShareMenu: @escaping (URL, Tab, UIView, UIPopoverArrowDirection) -> ()) -> [PhotonActionSheetItem] {
+
+        let toggleActionTitle = tab.desktopSite ? Strings.AppMenuViewMobileSiteTitleString : Strings.AppMenuViewDesktopSiteTitleString
+        let toggleDesktopSite = PhotonActionSheetItem(title: toggleActionTitle, iconString: "menu-RequestDesktopSite") { action in
+            tab.toggleDesktopSite()
+        }
+
+        let setHomePage = PhotonActionSheetItem(title: Strings.AppMenuSetHomePageTitleString, iconString: "menu-Home") { action in
+            //TODO: pass a VC. this doesnt _need_ to be a HomePageHelper
+            HomePageHelper(prefs: self.profile.prefs).setHomePage(toTab: tab, presentAlertOn: nil)
+        }
+
+        //TODO: Add to pocket
+
+        let bookmarkPage = PhotonActionSheetItem(title: Strings.AppMenuAddBookmarkTitleString, iconString: "menu-Bookmark") { action in
+            //TODO: can all this logic go somewhere else?
+            guard let url = tab.url else { return }
+            let absoluteString = url.absoluteString
+            let shareItem = ShareItem(url: absoluteString, title: tab.title, favicon: tab.displayFavicon)
+            _ = self.profile.bookmarks.shareItem(shareItem)
+            var userData = [QuickActions.TabURLKey: shareItem.url]
+            if let title = shareItem.title {
+                userData[QuickActions.TabTitleKey] = title
+            }
+            QuickActions.sharedInstance.addDynamicApplicationShortcutItemOfType(.openLastBookmark,
+                                                                                withUserData: userData,
+                                                                                toApplication: UIApplication.shared)
+            tab.isBookmarked = true
+        }
+
+        let removeBookmark = PhotonActionSheetItem(title: Strings.AppMenuRemoveBookmarkTitleString, iconString: "menu-Bookmark") { action in
+            //TODO: can all this logic go somewhere else?
+            guard let url = tab.url else { return }
+            let absoluteString = url.absoluteString
+            self.profile.bookmarks.modelFactory >>== {
+                $0.removeByURL(absoluteString).uponQueue(DispatchQueue.main) { res in
+                    if res.isSuccess {
+                        tab.isBookmarked = false
+                    }
+                }
+            }
+        }
+
+        let share = PhotonActionSheetItem(title: "Share", iconString: "") { action in
+            guard let url = self.tabManager.selectedTab?.url else { return }
+            guard let tab = self.tabManager.selectedTab else { return }
+            presentShareMenu(url, tab, buttonView, .up)
+        }
+
+
+        let bookmarkAction = tab.isBookmarked ? removeBookmark : bookmarkPage
+        return [toggleDesktopSite, bookmarkAction, setHomePage, share]
+    }
+
+    func getTabMenuActions(openURL: @escaping (URL?, Bool) -> ()) -> [PhotonActionSheetItem] {
+        let openTab = PhotonActionSheetItem(title: "Open new Tab", iconString: "menu-NewTab") { action in
+            openURL(nil, false)
+        }
+
+        let openPrivateTab = PhotonActionSheetItem(title: "Open private Tab", iconString: "menu-NewTab") { action in
+            openURL(nil, true)
+
+        }
+
+        let openTabTray = PhotonActionSheetItem(title: "Show Tabs", iconString: "") { action in
+            //TODO: This has its own bug
+        }
+
+        return [openTab, openPrivateTab, openTabTray]
+    }
+
+}

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -32,7 +32,7 @@ extension PhotonActionSheetProtocol {
 
     //Returns a list of actions which is used to build a menu
     //parameter OpenURL is a clousre that can open a given URL in some view controller. It is up to the class using the menu to know how to open the url
-    func getHomePanelActions(openURL: @escaping (URL) -> ()) -> [PhotonActionSheetItem] {
+    func getHomePanelActions(openURL: @escaping (URL) -> Void) -> [PhotonActionSheetItem] {
         let openTopSites = PhotonActionSheetItem(title: Strings.AppMenuTopSitesTitleString, iconString: "menupanel-TopSites") { action in
             openURL(HomePanelType.topSites.localhostURL)
         }
@@ -93,8 +93,7 @@ extension PhotonActionSheetProtocol {
         return [openSettings, openQR, noImageMode, nightMode]
     }
 
-
-    func getTabActions(tab: Tab, buttonView: UIView,   presentShareMenu: @escaping (URL, Tab, UIView, UIPopoverArrowDirection) -> ()) -> [PhotonActionSheetItem] {
+    func getTabActions(tab: Tab, buttonView: UIView,   presentShareMenu: @escaping (URL, Tab, UIView, UIPopoverArrowDirection) -> Void) -> [PhotonActionSheetItem] {
 
         let toggleActionTitle = tab.desktopSite ? Strings.AppMenuViewMobileSiteTitleString : Strings.AppMenuViewDesktopSiteTitleString
         let toggleDesktopSite = PhotonActionSheetItem(title: toggleActionTitle, iconString: "menu-RequestDesktopSite") { action in
@@ -143,12 +142,11 @@ extension PhotonActionSheetProtocol {
             presentShareMenu(url, tab, buttonView, .up)
         }
 
-
         let bookmarkAction = tab.isBookmarked ? removeBookmark : bookmarkPage
         return [toggleDesktopSite, bookmarkAction, setHomePage, share]
     }
 
-    func getTabMenuActions(openURL: @escaping (URL?, Bool) -> ()) -> [PhotonActionSheetItem] {
+    func getTabMenuActions(openURL: @escaping (URL?, Bool) -> Void) -> [PhotonActionSheetItem] {
         let openTab = PhotonActionSheetItem(title: "Open new Tab", iconString: "menu-NewTab") { action in
             openURL(nil, false)
         }

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -6,7 +6,7 @@ import Foundation
 import Shared
 import Storage
 
-protocol PhotonActionSheetProtocol  {
+protocol PhotonActionSheetProtocol {
     var tabManager: TabManager { get }
     var profile: Profile { get }
 }
@@ -93,7 +93,7 @@ extension PhotonActionSheetProtocol {
         return [openSettings, openQR, noImageMode, nightMode]
     }
 
-    func getTabActions(tab: Tab, buttonView: UIView,   presentShareMenu: @escaping (URL, Tab, UIView, UIPopoverArrowDirection) -> Void) -> [PhotonActionSheetItem] {
+    func getTabActions(tab: Tab, buttonView: UIView, presentShareMenu: @escaping (URL, Tab, UIView, UIPopoverArrowDirection) -> Void) -> [PhotonActionSheetItem] {
 
         let toggleActionTitle = tab.desktopSite ? Strings.AppMenuViewMobileSiteTitleString : Strings.AppMenuViewDesktopSiteTitleString
         let toggleDesktopSite = PhotonActionSheetItem(title: toggleActionTitle, iconString: "menu-RequestDesktopSite") { action in

--- a/Shared/FeatureSwitch.swift
+++ b/Shared/FeatureSwitch.swift
@@ -6,8 +6,8 @@ import Foundation
 
 /// Steadily growing set of feature switches controlling access to features by populations of Release users.
 open class FeatureSwitches {
-    open static let activityStream =
-        FeatureSwitch(named: "activity_stream", AppConstants.MOZ_AS_PANEL, allowPercentage: 50)
+    open static let activityStream = FeatureSwitch(named: "activity_stream", AppConstants.MOZ_AS_PANEL, allowPercentage: 50)
+    open static let photonMenu = FeatureSwitch(named: "photon_menu", false, allowPercentage: 0)
 }
 
 /// Small class to allow a percentage of users to access a given feature.
@@ -32,15 +32,15 @@ open class FeatureSwitch {
     /// in the preferences.
     /// This gives us stable properties across restarts and new releases.
     open func isMember(_ prefs: Prefs) -> Bool {
-        // Only use bucketing if we're in the correct build channel, and feature flag is true.
-        guard buildChannel == AppConstants.BuildChannel, nonChannelValue else {
-            return nonChannelValue
-        }
-
         // Check if this feature has been enabled by the user
         let key = "\(self.switchKey).enabled"
         if let isEnabled = prefs.boolForKey(key) {
             return isEnabled
+        }
+
+        // Only use bucketing if we're in the correct build channel, and feature flag is true.
+        guard buildChannel == AppConstants.BuildChannel, nonChannelValue else {
+            return nonChannelValue
         }
 
         return lowerCaseS(prefs) < self.percentage

--- a/SharedTests/FeatureSwitchTests.swift
+++ b/SharedTests/FeatureSwitchTests.swift
@@ -59,6 +59,16 @@ class FeatureSwitchTests: XCTestCase {
         XCTAssertFalse(featureSwitch.isMember(prefs), "The feature should be disabled again")
     }
 
+    func testUserEnabledEvenWhenDefaultFalse() {
+        let prefs = MockProfilePrefs()
+        let featureSwitch = FeatureSwitch(named: "test-user-enabled", false, allowPercentage: 0, buildChannel: buildChannel)
+        XCTAssertFalse(featureSwitch.isMember(prefs), "The feature should be disabled")
+        featureSwitch.setMembership(true, for: prefs) // enable the feature
+        XCTAssertTrue(featureSwitch.isMember(prefs), "The feature should be enabled")
+        featureSwitch.setMembership(false, for: prefs) // disable the feature
+        XCTAssertFalse(featureSwitch.isMember(prefs), "The feature should be disabled again")
+    }
+
     func testForceDisabled() {
         let prefs = MockProfilePrefs()
         let featureSwitch = FeatureSwitch(named: "test-user-disabled", allowPercentage: 100, buildChannel: buildChannel)


### PR DESCRIPTION
This is a new menu to replace the current grid menu we use in the app. The UI is nowhere near final but functionally this is how the menu is going to be. I want to land the menu early and then iterate on the UI. 
![screen shot 2017-07-18 at 1 36 44 pm](https://user-images.githubusercontent.com/522281/28393502-f209e10e-6c9b-11e7-8be5-d1e0f0efa12b.png)

You can enable the menu by going to the debug menu and turning on "Photon Menu". This is nowhere near done so it is also disabled for nightly/debug. Everyone should continue to see the current menu design. 

### About the structure of the code. 
- I opted to create a PhotonActionSheetProtocol which defines all the functionality of the menu. Both BVC and TabTrayController should be able to conform to this protocol. This removes the giant `performMenuAction` from BVC and TabTray.  I want to remove as much code out of the BVC as possible. 
- I decided to not use AppState and once we remove the current menu I'll remove appState. The state of the menu is computed when it is opened and it cannot change once it has opened. 

ps: I had to fix a bug in FeatureSwitches in order to make sure that features that are disabled to all audiences can still be enabled manually. Allowing us to land features like this behind a flag.