### PR TITLE
Bug 1194714 - Fix Autocomplete misbehaving when using Swype.

### DIFF
--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -86,8 +86,12 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
         }
 
         // If the pre-path component (including the scheme) starts with the query, just use it as is.
-        let prePathURL = (url as NSString).substring(with: match.rangeAt(0))
+        var prePathURL = (url as NSString).substring(with: match.rangeAt(0))
         if prePathURL.startsWith(query) {
+            // Trailing slashes in the autocompleteTextField cause issues with Swype keyboard. Bug 1194714
+            if prePathURL.endsWith("/") {
+                prePathURL.remove(at: prePathURL.index(before: prePathURL.endIndex))
+            }
             return prePathURL
         }
 
@@ -106,7 +110,7 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
             // so make sure the result includes at least one ".".
             let matchedDomain: String = domainWithDotPrefix.substring(from: domainWithDotPrefix.index(range.lowerBound, offsetBy: 1))
             if matchedDomain.contains(".") {
-                return matchedDomain + "/"
+                return matchedDomain
             }
         }
 


### PR DESCRIPTION
Thats it! 🤷‍♂️ 

The trailing slash messes with the text for some reason. By removing it a lot of our problems go away. 

For some reason  before when you had a search suggestion in the url bar the text after an update would be `github.comb` This was messing with the keyboard. I dont know why the slash was being turned into a `b` but it was.  