### PR TITLE
bug 1345887: Focus URL bar after 3DTouch 'new tab'.

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -220,7 +220,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
                 case "history":
                     self.browserViewController.openURLInNewTab(HomePanelType.history.localhostURL, isPrivileged: true)
                 case "new-private-tab":
-                    self.browserViewController.openBlankNewTab(isPrivate: true)
+                    self.browserViewController.openBlankNewTab(focusLocationField: false, isPrivate: true)
             default:
                 break
             }
@@ -423,7 +423,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         if let newURL = params.url {
             self.browserViewController.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate, isPrivileged: false)
         } else {
-            self.browserViewController.openBlankNewTab(isPrivate: isPrivate)
+            self.browserViewController.openBlankNewTab(focusLocationField: true, isPrivate: isPrivate)
         }
 
         LeanplumIntegration.sharedInstance.track(eventName: .openedNewTab, withParameters: ["Source":"External App or Extension" as AnyObject])

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -207,14 +207,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         let router = Router.shared
         let rootNav = rootViewController as! UINavigationController
 
-        router.map("homepanel/:page", handler: { (params:[String: String]?) -> (Bool) in
+        router.map("homepanel/:page", handler: { (params: [String: String]?) -> (Bool) in
             guard let page = params?["page"] else {
                 return false
             }
 
             assert(Thread.isMainThread, "Opening homepanels requires being invoked on the main thread")
 
-            switch (page) {
+            switch page {
                 case "bookmarks":
                     self.browserViewController.openURLInNewTab(HomePanelType.bookmarks.localhostURL, isPrivileged: true)
                 case "history":
@@ -229,7 +229,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         })
 
         // Route to general settings page like this: "...settings/general"
-        router.map("settings/:page", handler: { (params:[String: String]?) -> (Bool) in
+        router.map("settings/:page", handler: { (params: [String: String]?) -> (Bool) in
             guard let page = params?["page"] else {
                 return false
             }
@@ -247,7 +247,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
 
             rootNav.present(controller, animated: true, completion: nil)
 
-            switch (page) {
+            switch page {
                 case "newtab":
                     let viewController = NewTabChoiceViewController(prefs: self.getProfile(application).prefs)
                     controller.pushViewController(viewController, animated: true)
@@ -426,7 +426,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             self.browserViewController.openBlankNewTab(focusLocationField: true, isPrivate: isPrivate)
         }
 
-        LeanplumIntegration.sharedInstance.track(eventName: .openedNewTab, withParameters: ["Source":"External App or Extension" as AnyObject])
+        LeanplumIntegration.sharedInstance.track(eventName: .openedNewTab, withParameters: ["Source": "External App or Extension" as AnyObject])
     }
 
     func application(_ application: UIApplication, shouldAllowExtensionPointIdentifier extensionPointIdentifier: UIApplicationExtensionPointIdentifier) -> Bool {
@@ -772,7 +772,6 @@ extension AppDelegate {
         if Logger.logPII && log.isEnabledFor(level: .info) {
             NSLog("APNS NOTIFICATION \(userInfo)")
         }
-
 
         // At this point, we know that NotificationService has been run.
         // We get to this point if the notification was received while the app was in the foreground

--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -117,7 +117,7 @@ class QuickActions: NSObject {
     }
 
     fileprivate func handleOpenNewTab(withBrowserViewController bvc: BrowserViewController, isPrivate: Bool) {
-        bvc.openBlankNewTab(isPrivate: isPrivate)
+        bvc.openBlankNewTab(focusLocationField: true, isPrivate: isPrivate)
     }
 
     fileprivate func handleOpenURL(withBrowserViewController bvc: BrowserViewController, urlToOpen: URL) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1110,9 +1110,16 @@ class BrowserViewController: UIViewController {
         }
     }
 
-    func openBlankNewTab(isPrivate: Bool = false) {
+    func openBlankNewTab(focusLocationField: Bool, isPrivate: Bool = false) {
         popToBVC()
         openURLInNewTab(nil, isPrivate: isPrivate, isPrivileged: true)
+        
+        if focusLocationField {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                // Without a delay, the text field fails to become first responder
+                self.urlBar.tabLocationViewDidTapLocation(self.urlBar.locationView)
+            }
+        }
     }
 
     fileprivate func popToBVC() {
@@ -1438,7 +1445,7 @@ extension BrowserViewController: MenuActionDelegate {
 
 extension BrowserViewController: QRCodeViewControllerDelegate {
     func scanSuccessOpenNewTabWithData(data: String) {
-        self.openBlankNewTab()
+        self.openBlankNewTab(focusLocationField: false)
         self.urlBar(self.urlBar, didSubmitText: data)
     }
 }
@@ -3229,7 +3236,7 @@ extension BrowserViewController: TopTabsDelegate {
     }
     
     func topTabsDidPressNewTab(_ isPrivate: Bool) {
-        openBlankNewTab(isPrivate: isPrivate)
+        openBlankNewTab(focusLocationField: false, isPrivate: isPrivate)
     }
 
     func topTabsDidTogglePrivateMode() {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -35,11 +35,11 @@ extension BrowserViewController {
     }
 
     @objc private func newTab() {
-        openBlankNewTab(isPrivate: false)
+        openBlankNewTab(focusLocationField: false, isPrivate: false)
     }
 
     @objc private func newPrivateTab() {
-        openBlankNewTab(isPrivate: true)
+        openBlankNewTab(focusLocationField: false, isPrivate: true)
     }
 
     @objc private func closeTab() {


### PR DESCRIPTION
The requires setting the location field to be the first responder after
creating a new blank tab.