### PR TITLE
Bug 1378725 — Unregister from APNS and Autopush on logout.

### DIFF
--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -67,7 +67,7 @@ class DisconnectSetting: WithAccountSetting {
             })
         alertController.addAction(
             UIAlertAction(title: Strings.SettingsSignOutDestructiveAction, style: .destructive) { (action) in
-                self.settings.profile.removeAccount()
+                FxALoginHelper.sharedInstance.applicationDidDisconnect(UIApplication.shared)
                 self.settings.settings = self.settings.generateSettings()
                 self.settings.SELfirefoxAccountDidChange()
 

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -179,8 +179,6 @@ open class BrowserProfile: Profile {
 
     internal let files: FileAccessor
 
-    weak fileprivate var app: UIApplication?
-
     let db: BrowserDB
     let loginsDB: BrowserDB
     var syncManager: SyncManager!
@@ -553,9 +551,6 @@ open class BrowserProfile: Profile {
         // Trigger cleanup. Pass in the account in case we want to try to remove
         // client-specific data from the server.
         self.syncManager.onRemovedAccount(old)
-
-        // Deregister for remote notifications.
-        app?.unregisterForRemoteNotifications()
     }
 
     func setAccount(_ account: FirefoxAccount) {


### PR DESCRIPTION
This PR introduces an `applicationDidDisconnect` method to `FxALoginHelper`, to manage the sign out logic.

Not all of that logic is implemented yet (see [Bug 1300641][1] for the stuff that's missing).

The method:

 * unregisters the device from APNS, and 
 * unregisters the profile from autopush.

As part of the moving APNS unregistering from `BrowserProfile`, we also remove `UIApplication` entirely from `BrowserProfile` (most was refactored out as part of sending tabs).

https://bugzilla.mozilla.org/show_bug.cgi?id=1378725

[1]: https://bugzilla.mozilla.org/show_bug.cgi?id=1300641