### PR TITLE
Bug 1278470 - Prevent gboard's predictive text from ruining url bar text

### DIFF
--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -86,8 +86,12 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
         }
 
         // If the pre-path component (including the scheme) starts with the query, just use it as is.
-        let prePathURL = (url as NSString).substring(with: match.rangeAt(0))
+        var prePathURL = (url as NSString).substring(with: match.rangeAt(0))
         if prePathURL.startsWith(query) {
+            // Trailing slashes in the autocompleteTextField cause issues with Swype keyboard. Bug 1194714
+            if prePathURL.endsWith("/") {
+                prePathURL.removeLast()
+            }
             return prePathURL
         }
 
@@ -106,7 +110,7 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
             // so make sure the result includes at least one ".".
             let matchedDomain: String = domainWithDotPrefix.substring(from: domainWithDotPrefix.index(range.lowerBound, offsetBy: 1))
             if matchedDomain.contains(".") {
-                return matchedDomain + "/"
+                return matchedDomain
             }
         }
 

--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -90,7 +90,7 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
         if prePathURL.startsWith(query) {
             // Trailing slashes in the autocompleteTextField cause issues with Swype keyboard. Bug 1194714
             if prePathURL.endsWith("/") {
-                prePathURL.removeLast()
+                prePathURL.remove(at: prePathURL.index(before: prePathURL.endIndex))
             }
             return prePathURL
         }

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -72,7 +72,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         super.addTarget(self, action: #selector(AutocompleteTextField.textDidChange(_:)), for: UIControlEvents.editingChanged)
         notifyTextChanged = debounce(0.1, action: {
             if self.isEditing {
-                self.autocompleteDelegate?.autocompleteTextField(self, didEnterText: self.text ?? "")
+                self.autocompleteDelegate?.autocompleteTextField(self, didEnterText: self.normalizeString(self.text ?? ""))
             }
         })
     }
@@ -135,7 +135,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     }
 
     fileprivate func normalizeString(_ string: String) -> String {
-        return string.lowercased()
+        return string.lowercased().stringByTrimmingLeadingCharactersInSet(CharacterSet.whitespaces)
     }
 
     /// Commits the completion by setting the text and removing the highlight.

--- a/UITests/DomainAutocompleteTests.swift
+++ b/UITests/DomainAutocompleteTests.swift
@@ -19,14 +19,14 @@ class DomainAutocompleteTests: KIFTestCase {
 
         // Multiple subdomains.
         tester().enterText(intoCurrentFirstResponder: "f")
-        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "f", completion: "oo.bar.baz.org/")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "f", completion: "oo.bar.baz.org")
         tester().clearTextFromFirstResponder()
         tester().enterText(intoCurrentFirstResponder: "b")
-        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "b", completion: "ar.baz.org/")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "b", completion: "ar.baz.org")
         tester().enterText(intoCurrentFirstResponder: "a")
-        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "ba", completion: "r.baz.org/")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "ba", completion: "r.baz.org")
         tester().enterText(intoCurrentFirstResponder: "z")
-        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "baz", completion: ".org/")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "baz", completion: ".org")
     }
 
     override func tearDown() {

--- a/XCUITests/DomainAutocompleteTest.swift
+++ b/XCUITests/DomainAutocompleteTest.swift
@@ -4,7 +4,7 @@
 
 import XCTest
 
-let website = ["url": "www.mozilla.org", "value": "www.mozilla.org/", "subDomain": "https://www.mozilla.org/en-US/firefox/products"]
+let website = ["url": "www.mozilla.org", "value": "www.mozilla.org", "subDomain": "https://www.mozilla.org/en-US/firefox/products"]
 
 class DomainAutocompleteTest: BaseTestCase {
     var navigator: Navigator!
@@ -79,7 +79,7 @@ class DomainAutocompleteTest: BaseTestCase {
         app.textFields["address"].typeText("https")
         waitForValueContains(app.textFields["address"], value: "mozilla")
         let value = app.textFields["address"].value
-        XCTAssertEqual(value as? String, "https://www.mozilla.org/", "Wrong autocompletion")
+        XCTAssertEqual(value as? String, "https://www.mozilla.org", "Wrong autocompletion")
     }
     // Non-matches.
     func testNoMatches() {
@@ -132,19 +132,19 @@ class DomainAutocompleteTest: BaseTestCase {
         app.textFields["address"].typeText("a")
         waitForValueContains(app.textFields["address"], value: ".com")
         let value = app.textFields["address"].value
-        XCTAssertEqual(value as? String, "amazon.com/", "Wrong autocompletion")
+        XCTAssertEqual(value as? String, "amazon.com", "Wrong autocompletion")
 
         app.buttons["Clear text"].tap()
         app.textFields["address"].typeText("an")
         waitForValueContains(app.textFields["address"], value: ".com")
         let value2 = app.textFields["address"].value
-        XCTAssertEqual(value2 as? String, "answers.com/", "Wrong autocompletion")
+        XCTAssertEqual(value2 as? String, "answers.com", "Wrong autocompletion")
 
         app.buttons["Clear text"].tap()
         app.textFields["address"].typeText("anc")
         waitForValueContains(app.textFields["address"], value: ".com")
         let value3 = app.textFields["address"].value
-        XCTAssertEqual(value3 as? String, "ancestry.com/", "Wrong autocompletion")
+        XCTAssertEqual(value3 as? String, "ancestry.com", "Wrong autocompletion")
     }
     // Test mixed case autocompletion.
     func testMixedCaseAutocompletion() {
@@ -153,14 +153,14 @@ class DomainAutocompleteTest: BaseTestCase {
         app.textFields["address"].typeText("MoZ")
         waitForValueContains(app.textFields["address"], value: ".org")
         let value = app.textFields["address"].value
-        XCTAssertEqual(value as? String, "MoZilla.org/", "Wrong autocompletion")
+        XCTAssertEqual(value as? String, "MoZilla.org", "Wrong autocompletion")
 
         // Test that leading spaces still show suggestions.
         app.buttons["Clear text"].tap()
         app.textFields["address"].typeText("    moz")
         waitForValueContains(app.textFields["address"], value: ".org")
         let value2 = app.textFields["address"].value
-        XCTAssertEqual(value2 as? String, "    mozilla.org/", "Wrong autocompletion")
+        XCTAssertEqual(value2 as? String, "    mozilla.org", "Wrong autocompletion")
 
         // Test that trailing spaces do *not* show suggestions.
         app.buttons["Clear text"].tap()

--- a/XCUITests/SearchTest.swift
+++ b/XCUITests/SearchTest.swift
@@ -113,7 +113,7 @@ class SearchTests: BaseTestCase {
         app.typeText("\r")
         
         // Check that the website is loaded
-        waitForValueContains(app.textFields["url"], value: "https://www.mozilla.org/")
+        waitForValueContains(app.textFields["url"], value: "https://www.mozilla.org")
         
         // Go back, write part of moz, check the autocompletion
         app.buttons["TabToolbar.backButton"].tap()
@@ -121,7 +121,7 @@ class SearchTests: BaseTestCase {
         typeOnSearchBar(text: "moz")
         waitForValueContains(app.textFields["address"], value: "mozilla.org")
         let value = app.textFields["address"].value
-        XCTAssertEqual(value as? String, "mozilla.org/")
+        XCTAssertEqual(value as? String, "mozilla.org")
     }
 
     private func changeSearchEngine(searchEngine: String) {


### PR DESCRIPTION
I also have the PR from https://github.com/mozilla-mobile/firefox-ios/pull/2954 here. I'll merge that branch separately. 

Trying to understand the changes to AutocompleteTextfield is basically impossible. Your best bet is to check out the changes and try using a few third party keyboards. This mainly fixes issues with gboard and some smaller issues with predictive text in swypekey. There still might be some cases where predictive text still doesn't work but its not as bad as before where `final` is replaced with `ffinal` 

These changes are based off of mozilla-mobile/AutoCompleteTextField in Focus. I couldn't just drop it in because of how auto-completions are queried by the backend. 