### PR TITLE
(nobug, cleanup) NavigationDelegateTests: remove unused profile access

### DIFF
--- a/UITests/NavigationDelegateTests.swift
+++ b/UITests/NavigationDelegateTests.swift
@@ -11,17 +11,14 @@ import EarlGrey
 
 class NavigationDelegateTests: KIFTestCase {
     fileprivate var webRoot: String!
-    fileprivate var profile: Profile!
-    
+
     override func setUp() {
         super.setUp()
-        profile = (UIApplication.shared.delegate as! AppDelegate).profile!
         webRoot = SimplePageServer.start()
         BrowserUtils.dismissFirstRunUI()
     }
     
     override func tearDown() {
-        _ = profile.logins.removeAll().value
         BrowserUtils.resetToAboutHome(tester())
         BrowserUtils.clearPrivateData(tester: tester())
         super.tearDown()


### PR DESCRIPTION
I was copying from an existing test case, and left in code that shouldn't be there.
Also, I got an test crash locally on profile creation due to this unnecessary code, so I *really* want it out.