### PR TITLE
Bug 1383407 - Add universal applinks to Firefox entitlements

### DIFF
--- a/Client/Entitlements/FirefoxApplication.entitlements
+++ b/Client/Entitlements/FirefoxApplication.entitlements
@@ -8,6 +8,11 @@
 	<array>
 		<string>group.org.mozilla.ios.Firefox</string>
 	</array>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:rzte.adj.st</string>
+		<string>applinks:nn8g.adj.st</string>
+	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)org.mozilla.ios.Firefox</string>


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1383407