### PR TITLE
Bug 1382328 - Fix crash on "Close all tabs" on the iPad

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -239,19 +239,18 @@ class TabManager: NSObject {
         if urls.isEmpty {
             return
         }
-
+        // When bulk adding tabs don't notify delegates until we are done
+        self.isRestoring = true
         var tab: Tab!
         for url in urls {
             tab = self.addTab(URLRequest(url: url), flushToDisk: false, zombie: zombie)
         }
-
         // Flush.
         storeChanges()
-
         // Select the most recent.
         self.selectTab(tab)
-
-        // Notify that we bulk-loaded so we can adjust counts.
+        self.isRestoring = false
+        // Okay now notify that we bulk-loaded so we can adjust counts and animate changes.
         delegates.forEach { $0.get()?.tabManagerDidAddTabs(self) }
     }
 

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -450,8 +450,6 @@ extension TopTabsViewController {
         self.flushPendingChanges()
         UIView.animate(withDuration: TopTabsUX.AnimationSpeed, animations: {
             self.collectionView.reloadData()
-            // Workaround - reloadData() is not triggering collectionView(_:cellForItemAt:)
-            self.collectionView.reloadItems(at: self.collectionView.indexPathsForVisibleItems)
             self.collectionView.collectionViewLayout.invalidateLayout()
             self.collectionView.layoutIfNeeded()
             self.scrollToCurrentTab(true, centerCell: true)


### PR DESCRIPTION
A regression from https://bugzilla.mozilla.org/show_bug.cgi?id=1346820

Animating changes is difficult especially when we call methods like `addTab` in loops. The topTabs manager tries to animate the insertion but cant keep up. 

In these cases, its better to simply hold off from notifying delegates until we are done all our changes. This is what we do when adding multiple tabs while restoring.