### PR TITLE
Bug 1383632 - Re-add decodingFailurePolicy to tabsToRestore.

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -649,7 +649,12 @@ extension TabManager {
     static func tabsToRestore() -> [SavedTab]? {
         if let tabData = tabArchiveData() {
             let unarchiver = NSKeyedUnarchiver(forReadingWith: tabData)
-            return unarchiver.decodeObject(forKey: "tabs") as? [SavedTab]
+            unarchiver.decodingFailurePolicy = .setErrorAndReturn
+            guard let tabs = unarchiver.decodeObject(forKey: "tabs") as? [SavedTab] else {
+                SentryIntegration.shared.send(message: "Failed to restore tabs: \(unarchiver.error ??? "nil")", tag: "TabManager", severity: .error)
+                return nil
+            }
+            return tabs
         } else {
             return nil
         }


### PR DESCRIPTION
I also added some sentry logging to see what error the unarchiver returns. 
We added this PR to 7.x via https://github.com/mozilla-mobile/firefox-ios/pull/2642 but never added it to master. 