### PR TITLE
Bug 1385969 - Add FxA domains for universal linking

### DIFF
--- a/Client/Entitlements/FennecApplication.entitlements
+++ b/Client/Entitlements/FennecApplication.entitlements
@@ -6,6 +6,10 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
+		<string>applinks:accounts.firefox.com</string>
+		<string>applinks:accounts.stage.mozaws.net</string>
+		<string>applinks:latest.dev.lcip.org</string>
+		<string>applinks:nightly.dev.lcip.org</string>
 		<string>applinks:rzte.adj.st</string>
 		<string>applinks:nn8g.adj.st</string>
 	</array>

--- a/Client/Entitlements/FirefoxApplication.entitlements
+++ b/Client/Entitlements/FirefoxApplication.entitlements
@@ -2,16 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:accounts.firefox.com</string>
+		<string>applinks:accounts.stage.mozaws.net</string>
+		<string>applinks:latest.dev.lcip.org</string>
+		<string>applinks:nightly.dev.lcip.org</string>
+		<string>applinks:rzte.adj.st</string>
+		<string>applinks:nn8g.adj.st</string>
+	</array>
 	<key>aps-environment</key>
 	<string>production</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.mozilla.ios.Firefox</string>
-	</array>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:rzte.adj.st</string>
-		<string>applinks:nn8g.adj.st</string>
 	</array>
 	<key>keychain-access-groups</key>
 	<array>

--- a/Client/Entitlements/FirefoxBetaApplication.entitlements
+++ b/Client/Entitlements/FirefoxBetaApplication.entitlements
@@ -2,6 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:accounts.firefox.com</string>
+		<string>applinks:accounts.stage.mozaws.net</string>
+		<string>applinks:latest.dev.lcip.org</string>
+		<string>applinks:nightly.dev.lcip.org</string>
+		<string>applinks:rzte.adj.st</string>
+		<string>applinks:nn8g.adj.st</string>
+	</array>
 	<key>aps-environment</key>
 	<string>production</string>
 	<key>com.apple.security.application-groups</key>


### PR DESCRIPTION
This PR adds the FxA domain for production, stage, nightly and latest to the Firefox, FirefoxBeta and Fennec entitlements. The combination of this and https://github.com/mozilla/fxa-content-server/pull/5287 will allow Firefox to open FxA verification links directly in the FxiOS application.

Ref: https://github.com/mozilla/fxa-bugzilla-mirror/issues/337