### PR TITLE
Bug 1345508 - Use `Done` instead of `Cancel` in FxA

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2728,7 +2728,7 @@ extension BrowserViewController: IntroViewControllerDelegate {
         } else {
             let signInVC = FxAContentViewController(profile: profile, fxaOptions: fxaOptions)
             signInVC.delegate = self            
-            signInVC.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: UIBarButtonSystemItem.cancel, target: self, action: #selector(BrowserViewController.dismissSignInViewController))
+            signInVC.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: UIBarButtonSystemItem.done, target: self, action: #selector(BrowserViewController.dismissSignInViewController))
             vcToPresent = signInVC
         }
 


### PR DESCRIPTION
Per https://bugzilla.mozilla.org/show_bug.cgi?id=1345508#c13, this uses the `Done` label for FxA view controller.

![screen shot 2017-07-31 at 2 54 24 pm](https://user-images.githubusercontent.com/1295288/28793184-2f099780-7600-11e7-956d-07a4498d6080.png)

Fixes https://github.com/mozilla/fxa-bugzilla-mirror/issues/316