### PR TITLE
Bug 1384098 - This fixes _all_ the autocomplete bugs!

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -13,7 +13,6 @@ private let log = Logger.browserLogger
 struct URLBarViewUX {
     static let TextFieldBorderColor = UIColor(rgb: 0xBBBBBB)
     static let TextFieldActiveBorderColor = UIColor(rgb: 0x4A90E2)
-    static let TextFieldContentInset = UIOffsetMake(9, 5)
     static let LocationLeftPadding = 5
     static let LocationHeight = 28
     static let LocationContentOffset: CGFloat = 8

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -23,6 +23,9 @@ struct AutocompleteTextFieldUX {
 class AutocompleteTextField: UITextField, UITextFieldDelegate {
     var autocompleteDelegate: AutocompleteTextFieldDelegate?
 
+    // AutocompleteTextLabel repersents the actual autocomplete text.
+    // The textfields "text" property only contains the entered text, while this label holds the autocomplete text
+    // This makes sure that the autocomplete doesnt mess with keyboard suggestions provided by third party keyboards.
     private var autocompleteTextLabel: UILabel?
     private var hideCursor: Bool = false
 

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -23,11 +23,11 @@ struct AutocompleteTextFieldUX {
 class AutocompleteTextField: UITextField, UITextFieldDelegate {
     var autocompleteDelegate: AutocompleteTextFieldDelegate?
 
-    private var selectionLabel: UILabel?
+    private var autocompleteTextLabel: UILabel?
     private var hideCursor: Bool = false
 
     var isSelectionActive: Bool {
-        return selectionLabel != nil
+        return autocompleteTextLabel != nil
     }
 
     // This variable is a solution to get the right behavior for refocusing
@@ -50,7 +50,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
 
     override var accessibilityValue: String? {
         get {
-            return (self.text ?? "") + (self.selectionLabel?.text ?? "")
+            return (self.text ?? "") + (self.autocompleteTextLabel?.text ?? "")
         }
         set(value) {
             super.accessibilityValue = value
@@ -142,7 +142,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     fileprivate func applyCompletion() {
 
         // Clear the current completion, then set the text without the attributed style.
-        let text = (self.text ?? "") + (self.selectionLabel?.text ?? "")
+        let text = (self.text ?? "") + (self.autocompleteTextLabel?.text ?? "")
         removeCompletion()
         self.text = text
         hideCursor = false
@@ -152,8 +152,8 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
 
     /// Removes the autocomplete-highlighted
     fileprivate func removeCompletion() {
-        selectionLabel?.removeFromSuperview()
-        selectionLabel = nil
+        autocompleteTextLabel?.removeFromSuperview()
+        autocompleteTextLabel = nil
     }
 
     // `shouldChangeCharactersInRange` is called before the text changes, and textDidChange is called after.
@@ -181,9 +181,9 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         let suggestionText = suggestion.substring(from: suggestion.characters.index(suggestion.startIndex, offsetBy: normalized.characters.count))
         let autocompleteText = NSMutableAttributedString(string: suggestionText)
         autocompleteText.addAttribute(NSBackgroundColorAttributeName, value: highlightColor, range: NSRange(location: 0, length: suggestionText.characters.count))
-        selectionLabel?.removeFromSuperview() // should be nil. But just in case
-        selectionLabel = createSelectionLabelWith(autocompleteText)
-        if let l = selectionLabel {
+        autocompleteTextLabel?.removeFromSuperview() // should be nil. But just in case
+        autocompleteTextLabel = createAutocompleteLabelWith(autocompleteText)
+        if let l = autocompleteTextLabel {
             addSubview(l)
             hideCursor = true
             forceResetCursor()
@@ -194,7 +194,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         return hideCursor ? CGRect.zero : super.caretRect(for: position)
     }
 
-    func createSelectionLabelWith(_ autocompleteText: NSAttributedString) -> UILabel {
+    private func createAutocompleteLabelWith(_ autocompleteText: NSAttributedString) -> UILabel {
         let label = UILabel()
         var frame = self.bounds
         label.attributedText = autocompleteText
@@ -237,7 +237,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     }
 
     func textDidChange(_ textField: UITextField) {
-        hideCursor = selectionLabel != nil
+        hideCursor = autocompleteTextLabel != nil
         removeCompletion()
 
         let isAtEnd = selectedTextRange?.start == endOfDocument

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -390,36 +390,16 @@ class BrowserUtils {
         // searches are async (and debounced), so we have to wait for the results to appear.
         tester.waitForViewWithAccessibilityValue(prefix + completion)
 
-        var range = NSRange()
-        var attribute: AnyObject?
-        let textLength = textField.text!.characters.count
+        let autocompleteFieldlabel = textField.subviews.filter { $0.accessibilityIdentifier == "autocomplete" }.first as? UILabel
 
-        attribute = textField.attributedText!.attribute(NSBackgroundColorAttributeName, at: 0, effectiveRange: &range) as AnyObject?
-
-        if attribute != nil {
-            // If the background attribute exists for the first character, the entire string is highlighted.
-            XCTAssertEqual(prefix, "")
-            XCTAssertEqual(completion, textField.text)
+        if completion == "" {
+            XCTAssertTrue(autocompleteFieldlabel == nil, "The autocomplete was empty but the label still exists.")
             return
         }
 
-        let prefixLength = range.length
+        XCTAssertTrue(autocompleteFieldlabel != nil, "The autocomplete was not found")
+        XCTAssertEqual(completion, autocompleteFieldlabel!.text, "Expected prefix matches actual prefix")
 
-        attribute = textField.attributedText!.attribute(NSBackgroundColorAttributeName, at: textLength - 1, effectiveRange: &range) as AnyObject?
-
-        if attribute == nil {
-            // If the background attribute exists for the last character, the entire string is not highlighted.
-            XCTAssertEqual(prefix, textField.text)
-            XCTAssertEqual(completion, "")
-            return
-        }
-
-        let completionStartIndex = textField.text!.characters.index(textField.text!.startIndex, offsetBy: prefixLength)
-        let actualPrefix = textField.text!.substring(to: completionStartIndex)
-        let actualCompletion = textField.text!.substring(from: completionStartIndex)
-
-        XCTAssertEqual(prefix, actualPrefix, "Expected prefix matches actual prefix")
-        XCTAssertEqual(completion, actualCompletion, "Expected completion matches actual completion")
     }
 }
 


### PR DESCRIPTION
Now instead of having the autocomplete text be a part of the UItextfield text. I create a new UILabel and add it above the Uitextfield. This basically fixes everything because we no longer mess with the text as its being edited. 

You can try it with a few of the third party keyboard bugs as well if you like 
https://bugzilla.mozilla.org/show_bug.cgi?id=1278470
https://bugzilla.mozilla.org/show_bug.cgi?id=1384066 
