### PR TITLE
Bug 1386653 Throttle Sentry Logging

### DIFF
--- a/Shared/SentryIntegration.swift
+++ b/Shared/SentryIntegration.swift
@@ -69,7 +69,7 @@ public class SentryIntegration {
     }
     
     public func send(message: String, tag: String = "general", severity: SentrySeverity = .info, completion: SentryRequestFinished? = nil) {
-        if !enabled {
+        if !enabled || tag == "SwiftData" || tag == "BrowserDB" {
             if let completion = completion {
                 completion(nil)
             }
@@ -84,7 +84,7 @@ public class SentryIntegration {
     }
 
     public func sendWithStacktrace(message: String, tag: String = "general", severity: SentrySeverity = .info, completion: SentryRequestFinished? = nil) {
-        if !enabled {
+        if !enabled || tag == "SwiftData" || tag == "BrowserDB" {
             if let completion = completion {
                 completion(nil)
             }


### PR DESCRIPTION
This patch disables logging for SwiftData. This is a temporary measure for 8.1.1 until we have a better mechanism in place for 8.2