### PR TITLE
Bug 1380063 - Root of tableview shows local and non-local mobile bookmarks

### DIFF
--- a/Storage/Bookmarks/BookmarksModel.swift
+++ b/Storage/Bookmarks/BookmarksModel.swift
@@ -296,6 +296,35 @@ open class PrependedBookmarkFolder: BookmarkFolder {
     }
 }
 
+open class ConcatenatedBookmarkFolder: BookmarkFolder {
+    fileprivate let main: BookmarkFolder
+    fileprivate let append: BookmarkFolder
+
+    init(main: BookmarkFolder, append: BookmarkFolder) {
+        self.main = main
+        self.append = append
+        super.init(guid: main.guid, title: main.title)
+    }
+
+    override open var count: Int {
+        return main.count + append.count
+    }
+
+    override open subscript(index: Int) -> BookmarkNode? {
+        return index < main.count ? main[index] : append[index - main.count]
+    }
+
+    override open func itemIsEditableAtIndex(_ index: Int) -> Bool {
+        return index < main.count ? main.itemIsEditableAtIndex(index) : append.itemIsEditableAtIndex(index - main.count)
+    }
+
+    override open func removeItemWithGUID(_ guid: GUID) -> BookmarkFolder? {
+        let newMain = main.removeItemWithGUID(guid) ?? main
+        let newAppend = append.removeItemWithGUID(guid) ?? append
+        return ConcatenatedBookmarkFolder(main: newMain, append: newAppend)
+    }
+}
+
 /**
  * A trivial offline model factory that represents a simple hierarchy.
  */

--- a/Storage/SQL/SQLiteBookmarksModel.swift
+++ b/Storage/SQL/SQLiteBookmarksModel.swift
@@ -189,10 +189,8 @@ open class SQLiteBookmarksModelFactory: BookmarksModelFactory {
 
     func getDesktopRoots() -> Deferred<Maybe<Cursor<BookmarkNode>>> {
         if self.direction == .buffer {
-            // The buffer never includes the Places root, so we look one level deeper.
-            // Because this is a special-case overlay, we include Mobile Bookmarks here --
-            // that'll show bookmarks from other mobile devices.
-            return self.bookmarks.getRecordsWithGUIDs(BookmarkRoots.RootChildren, direction: self.direction, includeIcon: false)
+            // DesktopRoots excludes the Mobile folder, local and non-local mobile are aggregated
+            return self.bookmarks.getRecordsWithGUIDs(BookmarkRoots.DesktopRoots, direction: self.direction, includeIcon: false)
         }
 
         // We deliberately exclude the mobile folder, because we're inverting the containment
@@ -797,12 +795,19 @@ open class UnsyncedBookmarksFallbackModelFactory: BookmarksModelFactory {
         log.debug("Getting model for fallback root.")
         // Return a virtual model containing "Desktop bookmarks" prepended to the local mobile bookmarks.
         return self.localFactory.folderForGUID(BookmarkRoots.MobileFolderGUID, title: BookmarksFolderTitleMobile)
-            >>== { folder in
-            return self.bufferFactory.getDesktopRoots() >>== { cursor in
-                let desktop = self.bufferFactory.folderForDesktopBookmarksCursor(cursor)
-                let prepended = PrependedBookmarkFolder(main: folder, prepend: desktop)
-                return deferMaybe(BookmarksModel(modelFactory: self, root: prepended))
-            }
+            >>== {
+                localMobileFolder in
+                
+                self.bufferFactory.folderForGUID(BookmarkRoots.MobileFolderGUID, title: BookmarksFolderTitleMobile) >>== {
+                    bufferMobileFolder in
+
+                    self.bufferFactory.getDesktopRoots() >>== { cursor in
+                        let bufferAndLocalMobile = ConcatenatedBookmarkFolder(main: bufferMobileFolder, append: localMobileFolder)
+                        let desktop = self.bufferFactory.folderForDesktopBookmarksCursor(cursor)
+                        let withDesktopPrepended = PrependedBookmarkFolder(main: bufferAndLocalMobile, prepend: desktop)
+                        return deferMaybe(BookmarksModel(modelFactory: self, root: withDesktopPrepended))
+                    }
+                }
         }
     }
 


### PR DESCRIPTION
Current root view is Desktop BMs and local mobile BMs, instead of this,
move mobile non-local BMs out of Desktop folder and show alongside local mobile BMs at root.