### PR TITLE
Bug 1373208 — Return the PushMessage to the NotificationService to modify the display behaviour of the alert.

### DIFF
--- a/Account/FxAPushMessageHandler.swift
+++ b/Account/FxAPushMessageHandler.swift
@@ -10,6 +10,7 @@ import Sync
 import XCGLogger
 
 private let log = Logger.syncLogger
+let PendingAccountDisconnectedKey = "PendingAccountDisconnect"
 
 /// This class provides handles push messages from FxA.
 /// For reference, the [message schema][0] and [Android implementation][1] are both useful resources.
@@ -25,10 +26,10 @@ class FxAPushMessageHandler {
 }
 
 extension FxAPushMessageHandler {
-    /// Accepts the raw Push message from Autopush. 
+    /// Accepts the raw Push message from Autopush.
     /// This method then decrypts it according to the content-encoding (aes128gcm or aesgcm)
     /// and then effects changes on the logged in account.
-    @discardableResult func handle(userInfo: [AnyHashable: Any]) -> Success {
+    @discardableResult func handle(userInfo: [AnyHashable: Any]) -> PushMessageResult {
         guard let subscription = profile.getAccount()?.pushRegistration?.defaultSubscription else {
             return deferMaybe(PushMessageError.notDecrypted)
         }
@@ -50,15 +51,19 @@ extension FxAPushMessageHandler {
             plaintext = nil
         }
 
-        guard let _ = plaintext else {
+        guard let string = plaintext else {
             return deferMaybe(PushMessageError.notDecrypted)
         }
 
-        return handle(message: JSON(parseJSON: plaintext!))
+        return handle(plaintext: string)
+    }
+
+    func handle(plaintext: String) -> PushMessageResult {
+        return handle(message: JSON(parseJSON: plaintext))
     }
 
     /// The main entry point to the handler for decrypted messages.
-    func handle(message json: JSON) -> Success {
+    func handle(message json: JSON) -> PushMessageResult {
         if !json.isDictionary() || json.isEmpty {
             return handleVerification()
         }
@@ -69,36 +74,36 @@ extension FxAPushMessageHandler {
             return deferMaybe(PushMessageError.messageIncomplete)
         }
 
-        let result: Success
+        let result: PushMessageResult
         switch command {
-            case .deviceConnected:
-                result = handleDeviceConnected(json["data"])
-            case .deviceDisconnected:
-                result = handleDeviceDisconnected(json["data"])
-            case .profileUpdated:
-                result = handleProfileUpdated()
-            case .passwordChanged:
-                result = handlePasswordChanged()
-            case .passwordReset:
-                result = handlePasswordReset()
-            case .collectionChanged:
-                result = handleCollectionChanged(json["data"])
-            case .accountVerified:
-                result = handleVerification()
+        case .deviceConnected:
+            result = handleDeviceConnected(json["data"])
+        case .deviceDisconnected:
+            result = handleDeviceDisconnected(json["data"])
+        case .profileUpdated:
+            result = handleProfileUpdated()
+        case .passwordChanged:
+            result = handlePasswordChanged()
+        case .passwordReset:
+            result = handlePasswordReset()
+        case .collectionChanged:
+            result = handleCollectionChanged(json["data"])
+        case .accountVerified:
+            result = handleVerification()
         }
         return result
     }
 }
 
 extension FxAPushMessageHandler {
-    func handleVerification() -> Success {
+    func handleVerification() -> PushMessageResult {
         guard let account = profile.getAccount(), account.actionNeeded == .needsVerification else {
             log.info("Account verified by server either doesn't exist or doesn't need verifying")
-            return succeed()
+            return deferMaybe(.accountVerified)
         }
 
         // Progress through the FxAStateMachine, then explicitly sync.
-        // We need a better solution than calling out to FxALoginHelper, because that class isn't 
+        // We need a better solution than calling out to FxALoginHelper, because that class isn't
         // available in NotificationService, where this class is also used.
         // Since verification via Push has never been seen to work, we can be comfortable
         // leaving this as unimplemented.
@@ -108,43 +113,57 @@ extension FxAPushMessageHandler {
 
 /// An extension to handle each of the messages.
 extension FxAPushMessageHandler {
-    func handleDeviceConnected(_ data: JSON?) -> Success {
+    func handleDeviceConnected(_ data: JSON?) -> PushMessageResult {
         guard let deviceName = data?["deviceName"].string else {
             return messageIncomplete(.deviceConnected)
         }
-        return unimplemented(.deviceConnected, with: deviceName)
+        let message = PushMessage.deviceConnected(deviceName)
+        return deferMaybe(message)
     }
 }
 
 extension FxAPushMessageHandler {
-    func handleDeviceDisconnected(_ data: JSON?) -> Success {
+    func handleDeviceDisconnected(_ data: JSON?) -> PushMessageResult {
         guard let deviceID = data?["id"].string else {
             return messageIncomplete(.deviceDisconnected)
         }
-        return unimplemented(.deviceDisconnected, with: deviceID)
+
+        if deviceID == getOurClientId() {
+            // We can't disconnect the device from the account until we have
+            // access to the application, so we'll handle this properly in the AppDelegate,
+            // by calling the FxALoginHelper.applicationDidDisonnect(application).
+            profile.prefs.setBool(true, forKey: PendingAccountDisconnectedKey)
+            return deferMaybe(PushMessage.thisDeviceDisconnected)
+        }
+
+        return deferMaybe(PushMessage.deviceDisconnected(nil))
+    }
+
+    fileprivate func getOurClientId() -> GUID {
+        return profile.clientID
     }
 }
 
 extension FxAPushMessageHandler {
-    func handleProfileUpdated() -> Success {
+    func handleProfileUpdated() -> PushMessageResult {
         return unimplemented(.profileUpdated)
     }
 }
 
 extension FxAPushMessageHandler {
-    func handlePasswordChanged() -> Success {
+    func handlePasswordChanged() -> PushMessageResult {
         return unimplemented(.passwordChanged)
     }
 }
 
 extension FxAPushMessageHandler {
-    func handlePasswordReset() -> Success {
+    func handlePasswordReset() -> PushMessageResult {
         return unimplemented(.passwordReset)
     }
 }
 
 extension FxAPushMessageHandler {
-    func handleCollectionChanged(_ data: JSON?) -> Success {
+    func handleCollectionChanged(_ data: JSON?) -> PushMessageResult {
         guard let collections = data?["collections"].arrayObject as? [String] else {
             log.warning("collections_changed received but incomplete: \(data ?? "nil")")
             return deferMaybe(PushMessageError.messageIncomplete)
@@ -152,13 +171,13 @@ extension FxAPushMessageHandler {
         // Possible values: "addons", "bookmarks", "history", "forms", "prefs", "tabs", "passwords", "clients"
 
         // syncManager will only do a subset; others will be ignored.
-        return profile.syncManager.syncNamedCollections(why: .push, names: collections)
+        return profile.syncManager.syncNamedCollections(why: .push, names: collections) >>== { deferMaybe(.collectionChanged(collections: collections)) }
     }
 }
 
 /// Some utility methods
 fileprivate extension FxAPushMessageHandler {
-    func unimplemented(_ messageType: PushMessageType, with param: String? = nil) -> Success {
+    func unimplemented(_ messageType: PushMessageType, with param: String? = nil) -> PushMessageResult {
         if let param = param {
             log.warning("\(messageType) message received with parameter = \(param), but unimplemented")
         } else {
@@ -167,7 +186,7 @@ fileprivate extension FxAPushMessageHandler {
         return deferMaybe(PushMessageError.unimplemented(messageType))
     }
 
-    func messageIncomplete(_ messageType: PushMessageType) -> Success {
+    func messageIncomplete(_ messageType: PushMessageType) -> PushMessageResult {
         log.info("\(messageType) message received, but incomplete")
         return deferMaybe(PushMessageError.messageIncomplete)
     }
@@ -185,16 +204,71 @@ enum PushMessageType: String {
     case accountVerified = "account_verified"
 }
 
+enum PushMessage: Equatable {
+    case deviceConnected(String)
+    case deviceDisconnected(String?)
+    case profileUpdated
+    case passwordChanged
+    case passwordReset
+    case collectionChanged(collections: [String])
+    case accountVerified
+
+    // This is returned when we detect that it is us that has been disconnected.
+    case thisDeviceDisconnected
+
+    var messageType: PushMessageType {
+        switch self {
+        case .deviceConnected(_):
+            return .deviceConnected
+        case .deviceDisconnected(_):
+            return .deviceDisconnected
+        case .thisDeviceDisconnected:
+            return .deviceDisconnected
+        case .profileUpdated:
+            return .profileUpdated
+        case .passwordChanged:
+            return .passwordChanged
+        case .passwordReset:
+            return .passwordReset
+        case .collectionChanged(collections: _):
+            return .collectionChanged
+        case .accountVerified:
+            return .accountVerified
+        }
+    }
+
+    public static func ==(lhs: PushMessage, rhs: PushMessage) -> Bool {
+        guard lhs.messageType == rhs.messageType else {
+            return false
+        }
+
+        switch (lhs, rhs) {
+        case (.deviceConnected(let lName), .deviceConnected(let rName)):
+            return lName == rName
+        case (.collectionChanged(let lList), .collectionChanged(let rList)):
+            return lList == rList
+        default:
+            return true
+        }
+    }
+}
+
+typealias PushMessageResult = Deferred<Maybe<PushMessage>>
+
 enum PushMessageError: MaybeErrorType {
     case notDecrypted
     case messageIncomplete
     case unimplemented(PushMessageType)
+    case timeout
+    case accountError
 
     public var description: String {
         switch self {
         case .notDecrypted: return "notDecrypted"
         case .messageIncomplete: return "messageIncomplete"
         case .unimplemented(let what): return "unimplemented=\(what)"
+        case .timeout: return "timeout"
+        case .accountError: return "accountError"
         }
     }
 }

--- a/ClientTests/FxAPushMessageTest.swift
+++ b/ClientTests/FxAPushMessageTest.swift
@@ -53,7 +53,7 @@ class FxAPushMessageTest: XCTestCase {
             AnyHashable("cryptokey"): "keyid=p256dh;dh=BNfUPK_8eUTZGOyXq07lthBfHeIxC2B7L_gF3cMGK1jVfDe9tlgxpHD_mbKrt3p12d7_O__wizhne2a1Eb7pZgk;p256ecdsa=BFSuld8S4PbRcgGe3OQPN9NyIOXx-ccUIMb0q6nIpH7Qf894wz0TIQTXQ7I7pWjZiN9KCdYVjNhyPtr1--37ois",
             AnyHashable("con"): "aesgcm",
             AnyHashable("ver"): "gAAAAABZLbG-m7EHhcMdrqs51SkESIZHsZjvw2QIu8LOeXxcKEy6wDVCprOKFAfJU44cinfJcDtCnO9EEyzpFt5e0HBDCLybGyThoZzmiod6zTLhTfAKZe-SyElSVCL0UDpJ_-U3UTUUHUaJXeRf0z6NvFM-uL39Jy-dwr3cuJoSDIcTPdChRPFiIS1hwokqMlxOn36azxOi",
-        ]
+            ]
 
         let profile = MockProfile()
 
@@ -75,9 +75,75 @@ class FxAPushMessageTest: XCTestCase {
         let expectation = XCTestExpectation()
         handler.handle(userInfo: userInfo).upon { maybe in
             XCTAssertTrue(maybe.isSuccess)
+            XCTAssertEqual(maybe.successValue!, PushMessage.collectionChanged(collections: ["clients", "tabs"]))
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 10)
     }
 
+    func createHandler(_ profile: Profile = MockProfile()) -> FxAPushMessageHandler {
+        let account = FirefoxAccount(
+            configuration: FirefoxAccountConfigurationLabel.production.toConfiguration(),
+            email: "testtest@test.com",
+            uid: "uid",
+            deviceRegistration: nil,
+            stateKeyLabel: "xxx",
+            state: SeparatedState())
+
+        profile.setAccount(account)
+
+        return FxAPushMessageHandler(with: profile)
+    }
+
+    func test_deviceConnected() {
+        let handler = createHandler()
+
+        let expectation = XCTestExpectation()
+        handler.handle(plaintext: "{\"command\":\"fxaccounts:device_connected\",\"data\":{\"deviceName\": \"Use Nightly on Desktop\"}}").upon { maybe in
+            XCTAssertTrue(maybe.isSuccess)
+            guard let message = maybe.successValue else {
+                return expectation.fulfill()
+            }
+            XCTAssertEqual(message, PushMessage.deviceConnected("Use Nightly on Desktop"))
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 10)
+    }
+
+    func test_deviceDisconnected() {
+        let profile = MockProfile()
+        let handler = createHandler(profile)
+        let prefs = profile.prefs
+
+        let expectation = XCTestExpectation()
+        handler.handle(plaintext: "{\"command\":\"fxaccounts:device_disconnected\",\"data\":{\"id\": \"not_this_device\"}}").upon { maybe in
+            XCTAssertTrue(maybe.isSuccess)
+            guard let message = maybe.successValue else {
+                return expectation.fulfill()
+            }
+            XCTAssertEqual(message.messageType, .deviceDisconnected)
+            XCTAssertFalse(prefs.boolForKey(PendingAccountDisconnectedKey) ?? false)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 10)
+
+    }
+
+    func test_thisDeviceDisconnected() {
+        let profile = MockProfile()
+        let handler = createHandler(profile)
+        let prefs = profile.prefs
+
+        let expectation = XCTestExpectation()
+        handler.handle(plaintext: "{\"command\":\"fxaccounts:device_disconnected\",\"data\":{\"id\": \"\(profile.clientID)\"}}").upon { maybe in
+            guard let message = maybe.successValue else {
+                return expectation.fulfill()
+            }
+            XCTAssertEqual(message, PushMessage.thisDeviceDisconnected)
+            XCTAssertTrue(prefs.boolForKey(PendingAccountDisconnectedKey) ?? false)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 10)
+        
+    }
 }


### PR DESCRIPTION
This PR changes the API of the `PushMessageHandler` to return a `Deferred<Maybe<PushMessage>>` instead of a `Success`.

This also implements the _display only_ of [`fxaccounts:device_disconnected`][1] and [`fxaccounts:device_connected`][2] push messages. The work to perform the work for those messages are in the linked bugs.

Special care should be taken when testing this: quite a lot of code to avoid empty send tab notifications has been moved, but should be otherwise untouched.

There may be regressions around receiving tabs, especially around the following case:

 1. this is where two tabs have been sent to the device in quick succession; 
 2. the first notification gets with two tabs. (don't dismiss this)
 3. the second notification gets none.
 4. when the empty second notification is detected, the notification service should find the last notification with tabs, copy it and delete it.

There are tests for the `FxAPushMessageHandler` which should do the heavy lifting of decrypting and decoding the message. 

 [1]: https://bugzilla.mozilla.org/show_bug.cgi?id=1333779
 [2]: https://bugzilla.mozilla.org/show_bug.cgi?id=1333780

https://bugzilla.mozilla.org/show_bug.cgi?id=1373208