### PR TITLE
Bug 1380063 - Follow-up: show both buffer and local bookmarks at the top level.

### DIFF
--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -328,7 +328,8 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
                     // Nothing we can do.
                     return
                 }
-                nextController.source = BookmarksModel(modelFactory: factory, root: folder)
+                let specificFactory = factory.factoryForIndex(indexPath.row, inFolder: source.current)
+                nextController.source = BookmarksModel(modelFactory: specificFactory, root: folder)
                 self.navigationController?.pushViewController(nextController, animated: true)
             }
             break

--- a/Storage/Bookmarks/BookmarksModel.swift
+++ b/Storage/Bookmarks/BookmarksModel.swift
@@ -140,6 +140,7 @@ public protocol BookmarksModelFactorySource {
 }
 
 public protocol BookmarksModelFactory {
+    func factoryForIndex(_ index: Int, inFolder folder: BookmarkFolder) -> BookmarksModelFactory
     func modelForFolder(_ folder: BookmarkFolder) -> Deferred<Maybe<BookmarksModel>>
     func modelForFolder(_ guid: GUID) -> Deferred<Maybe<BookmarksModel>>
     func modelForFolder(_ guid: GUID, title: String) -> Deferred<Maybe<BookmarksModel>>
@@ -262,7 +263,7 @@ private extension SuggestedSite {
 }
 
 open class PrependedBookmarkFolder: BookmarkFolder {
-    fileprivate let main: BookmarkFolder
+    let main: BookmarkFolder
     fileprivate let prepend: BookmarkNode
 
     init(main: BookmarkFolder, prepend: BookmarkNode) {
@@ -306,6 +307,10 @@ open class ConcatenatedBookmarkFolder: BookmarkFolder {
         super.init(guid: main.guid, title: main.title)
     }
 
+    var pivot: Int {
+        return main.count
+    }
+
     override open var count: Int {
         return main.count + append.count
     }
@@ -344,6 +349,10 @@ open class MockMemoryBookmarksStore: BookmarksModelFactory, ShareToDestination {
         sink = MemoryBookmarksSink()
 
         root = MemoryBookmarkFolder(guid: BookmarkRoots.RootGUID, title: "Root", children: [mobile, unsorted])
+    }
+
+    public func factoryForIndex(_ index: Int, inFolder folder: BookmarkFolder) -> BookmarksModelFactory {
+        return self
     }
 
     open func modelForFolder(_ folder: BookmarkFolder) -> Deferred<Maybe<BookmarksModel>> {


### PR DESCRIPTION
You can test this by opening `browser.db` in SQLite and running:

```
INSERT INTO bookmarksBuffer
(guid, type, parentid, parentName, title, description, bmkUri, tags, server_modified)
VALUES
('root________', 2, 'root________', 'Root',             'Root',             null,          null, '[]', 12345678900),
('mobile______', 2, 'root________', 'Root',             'Mobile Bookmarks', null,          null, '[]', 12345678900),
('abcabcabcabc', 2, 'mobile______', 'Mobile Bookmarks', 'Folder ABC',       'Some folder', null, '[]', 12345678900),
('defdefdefdef', 1, 'abcabcabcabc', 'Folder ABC',       'Item DEF',         '',            'http://foo.com/', '[]', 12345678900);

INSERT INTO bookmarksBufferStructure
(parent, child, idx)
VALUES
('root________', 'menu________', 0),
('root________', 'toolbar_____', 1),
('root________', 'unfiled_____', 2),
('root________', 'mobile______', 3),
('mobile______', 'abcabcabcabc', 0),
('abcabcabcabc', 'defdefdefdef', 0);


INSERT INTO bookmarksBuffer
(guid, type, parentid, parentName, title, description, bmkUri, tags, server_modified)
VALUES
('ghghghghghgh', 2, 'abcabcabcabc', 'Folder ABC',       'Folder GHGH',         '',            null, '[]', 12345678900),
('barbarbarbar', 1, 'ghghghghghgh', 'Folder GHGH',      'Item BAR',         '',            'http://bar.com/', '[]', 12345678900);

INSERT INTO bookmarksBufferStructure
(parent, child, idx)
VALUES
('abcabcabcabc', 'ghghghghghgh', 1),
('ghghghghghgh', 'barbarbarbar', 0);

```