### PR TITLE
Bug 1386017 - Fetch and use the FxA devices list to filter clients.

### DIFF
--- a/Account/FxADevice.swift
+++ b/Account/FxADevice.swift
@@ -12,27 +12,20 @@ public struct FxADevicePushParams {
     let authKey: String
 }
 
-public struct FxADevice {
-    let name: String
-    let id: String?
-    let type: String?
+public class FxADevice: RemoteDevice {
     let pushParams: FxADevicePushParams?
-    let isCurrentDevice: Bool
 
-    fileprivate init(name: String, id: String?, type: String?, isCurrentDevice: Bool = false, push: FxADevicePushParams?) {
-        self.name = name
-        self.id = id
-        self.type = type
-        self.isCurrentDevice = isCurrentDevice
+    fileprivate init(name: String, id: String?, type: String?, isCurrentDevice: Bool = false, push: FxADevicePushParams?, lastAccessTime: Timestamp?) {
         self.pushParams = push
+        super.init(id: id, name: name, type: type, isCurrentDevice: isCurrentDevice, lastAccessTime: lastAccessTime)
     }
 
     static func forRegister(_ name: String, type: String, push: FxADevicePushParams?) -> FxADevice {
-        return FxADevice(name: name, id: nil, type: type, push: push)
+        return FxADevice(name: name, id: nil, type: type, push: push, lastAccessTime: nil)
     }
 
     static func forUpdate(_ name: String, id: String, push: FxADevicePushParams?) -> FxADevice {
-        return FxADevice(name: name, id: id, type: nil, push: push)
+        return FxADevice(name: name, id: id, type: nil, push: push, lastAccessTime: nil)
     }
 
     func toJSON() -> JSON {
@@ -57,6 +50,7 @@ public struct FxADevice {
         }
 
         let isCurrentDevice = json["isCurrentDevice"].bool ?? false
+        let lastAccessTime = json["lastAccessTime"].uInt64
 
         let push: FxADevicePushParams?
         if let pushCallback = json["pushCallback"].stringValue(),
@@ -67,6 +61,6 @@ public struct FxADevice {
             push = nil
         }
 
-        return FxADevice(name: name, id: id, type: type, isCurrentDevice: isCurrentDevice, push: push)
+        return FxADevice(name: name, id: id, type: type, isCurrentDevice: isCurrentDevice, push: push, lastAccessTime: lastAccessTime)
     }
 }

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -410,6 +410,7 @@
 		C8F457AA1F1FDD9B000CB895 /* BrowserViewController+KeyCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F457A91F1FDD9B000CB895 /* BrowserViewController+KeyCommands.swift */; };
 		CE339EE61F2507C0009BE0E6 /* TestBookmarksSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE339ED61F2507A1009BE0E6 /* TestBookmarksSynchronizer.swift */; };
 		CE564D8E1EB7BD7700BEDDDC /* BookmarksRepairRequestor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE564D8D1EB7BD7700BEDDDC /* BookmarksRepairRequestor.swift */; };
+		CE7F11941F3CEEC800ABFC0B /* RemoteDevices.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F115E1F3CCEF900ABFC0B /* RemoteDevices.swift */; };
 		CEFC984B1EC0DCF5008A3E48 /* TestBookmarksRepairRequestor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFC983B1EC0DC60008A3E48 /* TestBookmarksRepairRequestor.swift */; };
 		D02816C21ECA5E2A00240CAA /* HistoryStateHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02816C11ECA5E2A00240CAA /* HistoryStateHelper.swift */; };
 		D02816D21ECA60DF00240CAA /* HistoryStateHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = D02816D11ECA60DF00240CAA /* HistoryStateHelper.js */; };
@@ -1657,6 +1658,7 @@
 		C8F457A91F1FDD9B000CB895 /* BrowserViewController+KeyCommands.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BrowserViewController+KeyCommands.swift"; sourceTree = "<group>"; };
 		CE339ED61F2507A1009BE0E6 /* TestBookmarksSynchronizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestBookmarksSynchronizer.swift; path = SyncTests/TestBookmarksSynchronizer.swift; sourceTree = "<group>"; };
 		CE564D8D1EB7BD7700BEDDDC /* BookmarksRepairRequestor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksRepairRequestor.swift; sourceTree = "<group>"; };
+		CE7F115E1F3CCEF900ABFC0B /* RemoteDevices.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteDevices.swift; sourceTree = "<group>"; };
 		CEFC983B1EC0DC60008A3E48 /* TestBookmarksRepairRequestor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestBookmarksRepairRequestor.swift; path = SyncTests/TestBookmarksRepairRequestor.swift; sourceTree = "<group>"; };
 		D02816C11ECA5E2A00240CAA /* HistoryStateHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HistoryStateHelper.swift; sourceTree = "<group>"; };
 		D02816D11ECA60DF00240CAA /* HistoryStateHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = HistoryStateHelper.js; sourceTree = "<group>"; };
@@ -3230,6 +3232,7 @@
 				E65075891E37F7AB006961AC /* NotificationConstants.swift */,
 				E650758A1E37F7AB006961AC /* PhoneNumberFormatter.swift */,
 				E650758B1E37F7AB006961AC /* Prefs.swift */,
+				CE7F115E1F3CCEF900ABFC0B /* RemoteDevices.swift */,
 				E650758C1E37F7AB006961AC /* RollingFileLogger.swift */,
 				D02818601EF056C800240CAA /* SentryIntegration.swift */,
 				E650758D1E37F7AB006961AC /* SupportUtils.swift */,
@@ -5097,6 +5100,7 @@
 				3964B09A1EA8F06F00F2EEF4 /* FeatureSwitch.swift in Sources */,
 				E65075981E37F7AB006961AC /* Bytes.swift in Sources */,
 				E65075B11E37F7AB006961AC /* FSUtils.m in Sources */,
+				CE7F11941F3CEEC800ABFC0B /* RemoteDevices.swift in Sources */,
 				D3A14C221CB3145E00253BC6 /* Strings.swift in Sources */,
 				7B10AA9F1E3A15020002DD08 /* DataExtensions.swift in Sources */,
 				7B3D9E651E4CBFDB007A50DA /* NSCoderExtensions.swift in Sources */,

--- a/ClientTests/ResetTests.swift
+++ b/ClientTests/ResetTests.swift
@@ -4,7 +4,7 @@
 
 @testable import Client
 import Shared
-import Storage
+@testable import Storage
 import Sync
 import UIKit
 
@@ -53,9 +53,13 @@ class ResetTests: XCTestCase {
     func testResetting() {
         let profile = MockBrowserProfile(localName: "testResetTests")
 
+        // Workaround: the remote devices table is created in BrowserTable, not in SQLiteRemoteClientsAndTabs.
+        _ = profile.db.createOrUpdate(BrowserTable())
+
         // Add a client.
         let tabs = profile.peekTabs
-        XCTAssertTrue(tabs.insertOrUpdateClient(RemoteClient(guid: "abcdefghijkl", name: "Remote", modified: Date.now(), type: "mobile", formfactor: "tablet", os: "Windows", version: "55.0.1a", fxaDeviceId: nil)).value.isSuccess)
+        XCTAssertTrue(tabs.insertOrUpdateClient(RemoteClient(guid: "abcdefghijkl", name: "Remote", modified: Date.now(), type: "mobile", formfactor: "tablet", os: "Windows", version: "55.0.1a", fxaDeviceId: "fxa1")).value.isSuccess)
+        _ = tabs.replaceRemoteDevices([RemoteDevice(id: "fxa1", name: "Device 1", type: "desktop", isCurrentDevice: false, lastAccessTime: 123)]).succeeded()
 
         // Verify that it's there.
         assertClientsHaveGUIDsFromStorage(tabs, expected: ["abcdefghijkl"])

--- a/Shared/RemoteDevices.swift
+++ b/Shared/RemoteDevices.swift
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+public protocol RemoteDevices {
+    func replaceRemoteDevices(_ remoteDevices: [RemoteDevice]) -> Success
+}
+
+open class RemoteDevice {
+    public let id: String?
+    public let name: String
+    public let type: String?
+    public let isCurrentDevice: Bool
+    public let lastAccessTime: Timestamp?
+
+    public init(id: String?, name: String, type: String?, isCurrentDevice: Bool, lastAccessTime: Timestamp?) {
+        self.id = id
+        self.name = name
+        self.type = type
+        self.isCurrentDevice = isCurrentDevice
+        self.lastAccessTime = lastAccessTime
+    }
+}

--- a/Storage/SQL/RemoteTabsTable.swift
+++ b/Storage/SQL/RemoteTabsTable.swift
@@ -80,7 +80,7 @@ class RemoteClientsTable<T>: GenericTable<RemoteClient> {
     }
 
     override func getQueryAndArgs(_ options: QueryOptions?) -> (String, Args)? {
-        return ("SELECT * FROM \(name) ORDER BY modified DESC", [])
+        return ("SELECT * FROM \(name) WHERE EXISTS (SELECT 1 FROM \(TableRemoteDevices) rd WHERE rd.guid = fxaDeviceId) ORDER BY modified DESC", [])
     }
 
     override func updateTable(_ db: SQLiteDBConnection, from: Int) -> Bool {


### PR DESCRIPTION
Before every Sync of the clients collection, update our `remote_devices` table: download the FxA devices list, drop the table, insert, just like on Android.
If any of these operations fail, we still go on with the clients collection syncing.

When retrieving clients for the send tab/remote tabs panels, we filter clients using the remote_devices table.

This assumes that every client record has a `fxadeviceid` field (with newer clients this is true on the 3 platforms we support).