### PR TITLE
Bug 1386653 - Enable full Sentry logging only for Firefox Beta

### DIFF
--- a/Shared/SentryIntegration.swift
+++ b/Shared/SentryIntegration.swift
@@ -69,7 +69,8 @@ public class SentryIntegration {
     }
     
     public func send(message: String, tag: String = "general", severity: SentrySeverity = .info, completion: SentryRequestFinished? = nil) {
-        if !enabled || tag == "SwiftData" || tag == "BrowserDB" {
+        // Do not send messages from SwiftData or BrowserDB unless this is the Beta channel
+        if !enabled || (AppConstants.BuildChannel != .beta && (tag == "SwiftData" || tag == "BrowserDB")) {
             if let completion = completion {
                 completion(nil)
             }
@@ -84,7 +85,8 @@ public class SentryIntegration {
     }
 
     public func sendWithStacktrace(message: String, tag: String = "general", severity: SentrySeverity = .info, completion: SentryRequestFinished? = nil) {
-        if !enabled || tag == "SwiftData" || tag == "BrowserDB" {
+        // Do not send messages from SwiftData or BrowserDB unless this is the Beta channel
+        if !enabled || (AppConstants.BuildChannel != .beta && (tag == "SwiftData" || tag == "BrowserDB")) {
             if let completion = completion {
                 completion(nil)
             }


### PR DESCRIPTION
This patch enables the Sentry logging for SwiftData and BrowserDB, but only on the Beta channel.