### PR TITLE
Bug 1388408 - Save deferred deep link to be launched from FxA Signin

### DIFF
--- a/Client/Application/AdjustIntegration.swift
+++ b/Client/Application/AdjustIntegration.swift
@@ -180,4 +180,14 @@ extension AdjustIntegration: AdjustDelegate {
     static func setEnabled(_ enabled: Bool) {
         Adjust.setEnabled(enabled)
     }
+    
+    /// Store the deeplink url from Adjust SDK. Per Adjust documentation, any interstitial view launched could interfere
+    /// with launching the deeplink. We let the interstial view decide what to do with deeplink.
+    /// Ref: https://github.com/adjust/ios_sdk#deferred-deep-linking-scenario
+    
+    func adjustDeeplinkResponse(_ deeplink: URL!) -> Bool {
+        profile.prefs.setString("\(deeplink)", forKey: "AdjustDeeplinkKey")
+        return true
+    }
+
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2708,12 +2708,25 @@ extension BrowserViewController: IntroViewControllerDelegate {
 
         return false
     }
+    
+    func launchFxAFromDeeplinkURL(_ url: URL) {
+        self.profile.prefs.removeObjectForKey("AdjustDeeplinkKey")
+        let query = url.getQuery()
+        let fxaParams: FxALaunchParams
+        fxaParams = FxALaunchParams(query: query)
+        self.presentSignInViewController(fxaParams)
+    }
 
     func introViewControllerDidFinish(_ introViewController: IntroViewController) {
         introViewController.dismiss(animated: true) { finished in
             if self.navigationController?.viewControllers.count ?? 0 > 1 {
                 _ = self.navigationController?.popToRootViewController(animated: true)
             }
+            
+            guard let deeplink = self.profile.prefs.stringForKey("AdjustDeeplinkKey"), let url = URL(string: deeplink) else {
+                return
+            }
+            self.launchFxAFromDeeplinkURL(url)
         }
     }
 
@@ -2743,7 +2756,11 @@ extension BrowserViewController: IntroViewControllerDelegate {
 
     func introViewControllerDidRequestToLogin(_ introViewController: IntroViewController) {
         introViewController.dismiss(animated: true, completion: { () -> Void in
-            self.presentSignInViewController()
+            guard let deeplink = self.profile.prefs.stringForKey("AdjustDeeplinkKey"), let url = URL(string: deeplink) else {
+                self.presentSignInViewController()
+                return
+            }
+            self.launchFxAFromDeeplinkURL(url)
         })
     }
 }


### PR DESCRIPTION
This fixes https://github.com/mozilla/fxa-bugzilla-mirror/issues/354 and https://github.com/mozilla/fxa-bugzilla-mirror/issues/346.

Deferred deeplinking had inconsistent results. This was because any interstitial view launched before the deeplink, would cause Adjust not to process the link. This PR allows the `IntroViewController` to correctly handle these scenarios.