### PR TITLE
Bug 1223660 — Add a setting to toggle the availability of the Clipboard bar.

### DIFF
--- a/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -51,7 +51,7 @@ class ClipboardBarDisplayHandler {
         }
         sessionStarted = false
         lastDisplayedURL = UIPasteboard.general.copiedURL?.absoluteString
-        return true
+        return self.prefs.boolForKey("showClipboardBar") ?? true
     }
     
     //If we already displayed this URL on the previous session

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -67,6 +67,12 @@ class AppSettingsTableViewController: SettingsTableViewController {
             ]
         }
 
+        generalSettings += [
+            BoolSetting(prefs: prefs, prefKey: "showClipboardBar", defaultValue: true,
+                        titleText: Strings.Settings_OfferClipboardBar_title,
+                        statusText: Strings.Settings_OfferClipboardBar_status)
+        ]
+
         settings += [
             SettingSection(title: nil, children: [
                 // Without a Firefox Account:

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -222,6 +222,9 @@ extension Strings {
 extension Strings {
     public static let GoToCopiedLink = NSLocalizedString("ClipboardToast.GoToCopiedLink.Title", value: "Go to copied link?", comment: "Message displayed when the user has a copied link on the clipboard")
     public static let GoButtonTittle = NSLocalizedString("ClipboardToast.GoToCopiedLink.Button", value: "Go", comment: "The button to open a new tab with the copied link")
+
+    public static let Settings_OfferClipboardBar_title = NSLocalizedString("Settings_OfferClipboardBar_title", value: "Offer to open copied links", comment: "Title of setting to enable the Go to Copied URL feature")
+    public static let Settings_OfferClipboardBar_status = NSLocalizedString("Setting_OfferClipboardBar_status", value: "When opening Firefox", comment: "Status text of setting to enable the Go to Copied URL feature")
 }
 
 // errors


### PR DESCRIPTION
This defaults to `true` (show the clipboard bar at start up).

https://bugzilla.mozilla.org/show_bug.cgi?id=1223660