### PR TITLE
Bug 1387492 - Make buffer mobile bookmarks editable.

### DIFF
--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -401,7 +401,8 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
             return
         }
 
-        if let err = factory.removeByGUID(bookmark.guid).value.failureValue {
+        let specificFactory = factory.factoryForIndex(indexPath.row, inFolder: source.current)
+        if let err = specificFactory.removeByGUID(bookmark.guid).value.failureValue {
             log.debug("Failed to remove \(bookmark.guid).")
             self.onModelFailure(err)
             return

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -39,11 +39,21 @@ public struct AppConstants {
         return scheme
     }()
 
-    /// Should we try to sync (no merging) the Mobile Folder (if shouldMergeBookmarks is false)
-    public static var simpleBookmarksSyncing = false
-
-    /// Whether we just mirror (false) or actively merge and upload (true).
+    /// Whether we just mirror (false) or actively do a full bookmark merge and upload (true).
     public static var shouldMergeBookmarks = false
+
+    /// Should we try to sync (no merging) the Mobile Folder (if shouldMergeBookmarks is false).
+    public static let MOZ_SIMPLE_BOOKMARKS_SYNCING: Bool = {
+        #if MOZ_CHANNEL_RELEASE
+            return false
+        #elseif MOZ_CHANNEL_BETA
+            return false
+        #elseif MOZ_CHANNEL_FENNEC
+            return false
+        #else
+            return false
+        #endif
+    }()
 
     /// Flag indiciating if we are running in Debug mode or not.
     public static let isDebug: Bool = {

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -47,11 +47,11 @@ public struct AppConstants {
         #if MOZ_CHANNEL_RELEASE
             return false
         #elseif MOZ_CHANNEL_BETA
-            return false
+            return true
         #elseif MOZ_CHANNEL_FENNEC
-            return false
+            return true
         #else
-            return false
+            return true
         #endif
     }()
 

--- a/Storage/SQL/BrowserTable.swift
+++ b/Storage/SQL/BrowserTable.swift
@@ -121,7 +121,7 @@ private let log = Logger.syncLogger
  * We rely on SQLiteHistory having initialized the favicon table first.
  */
 open class BrowserTable: Table {
-    static let DefaultVersion = 29    // Bug 1386017.
+    static let DefaultVersion = 30    // Bug 1387492.
 
     // TableInfo fields.
     var name: String { return "BROWSER" }
@@ -499,8 +499,19 @@ open class BrowserTable: Table {
     "type = \(BookmarkNodeType.bookmark.rawValue) AND is_deleted IS 0 " +
     "UNION ALL " +
     "SELECT guid, bmkUri AS url, title, description, -1 AS faviconID FROM " +
-    "\(TableBookmarksBuffer) WHERE " +
-    "type = \(BookmarkNodeType.bookmark.rawValue) AND is_deleted IS 0"
+    "\(TableBookmarksBuffer) bb WHERE " +
+    "bb.type = \(BookmarkNodeType.bookmark.rawValue) AND bb.is_deleted IS 0 " +
+
+    // Exclude pending bookmark deletions.
+    "AND NOT EXISTS (SELECT 1 FROM \(TablePendingBookmarksDeletions) AS pd WHERE pd.id = bb.guid)"
+
+    // This exists only to allow upgrade from old versions. We have view dependencies, so
+    // we can't simply skip creating ViewAllBookmarks. Here's a stub.
+    fileprivate let oldAllBookmarksView =
+        "CREATE VIEW \(ViewAllBookmarks) AS " +
+            "SELECT guid, bmkUri AS url, title, description, faviconID FROM " +
+            "\(TableBookmarksMirror) WHERE " +
+            "type = \(BookmarkNodeType.bookmark.rawValue) AND is_overridden IS 0 AND is_deleted IS 0"
 
     // This smushes together remote and local visits. So it goes.
     fileprivate let historyVisitsView =
@@ -658,6 +669,7 @@ open class BrowserTable: Table {
             "ON \(TableBookmarksMirrorStructure) (child)"
 
         let queries: [String] = [
+            // Tables.
             self.domainsTableCreate,
             history,
             favicons,
@@ -669,23 +681,29 @@ open class BrowserTable: Table {
             bookmarksMirror,
             bookmarksMirrorStructure,
             self.pendingBookmarksDeletions,
-            indexBufferStructureParentIdx,
-            indexLocalStructureParentIdx,
-            indexMirrorStructureParentIdx,
-            indexMirrorStructureChild,
             faviconSites,
-            indexShouldUpload,
-            indexSiteIDDate,
             widestFavicons,
             historyIDsWithIcon,
             iconForURL,
             pageMetadataCreate,
             pinnedTopSitesTableCreate,
             highlightsCreate,
+            self.remoteDevices,
+            activityStreamBlocklistCreate,
             indexPageMetadataSiteURLCreate,
             indexPageMetadataCacheKeyCreate,
             self.queueTableCreate,
             self.topSitesTableCreate,
+
+            // Indices.
+            indexBufferStructureParentIdx,
+            indexLocalStructureParentIdx,
+            indexMirrorStructureParentIdx,
+            indexMirrorStructureChild,
+            indexShouldUpload,
+            indexSiteIDDate,
+
+            // Views.
             self.localBookmarksView,
             self.localBookmarksStructureView,
             self.bufferBookmarksView,
@@ -695,8 +713,6 @@ open class BrowserTable: Table {
             historyVisitsView,
             awesomebarBookmarksView,
             awesomebarBookmarksWithIconsView,
-            activityStreamBlocklistCreate,
-            self.remoteDevices
         ]
 
         assert(queries.count == AllTablesIndicesAndViews.count, "Did you forget to add your table, index, or view to the list?")
@@ -899,9 +915,9 @@ open class BrowserTable: Table {
 
         if from < 16 && to >= 16 {
             if !self.run(db, queries: [
-                allBookmarksView,
+                oldAllBookmarksView,         // Replaced in v30. The new one is not compatible here.
                 historyVisitsView,
-                awesomebarBookmarksView,
+                awesomebarBookmarksView,     // … but this depends on ViewAllBookmarks.
                 awesomebarBookmarksWithIconsView]) {
                 return false
             }
@@ -1028,6 +1044,17 @@ open class BrowserTable: Table {
         if from < 29 && to >= 29 {
             if !self.run(db, queries: [
                 self.remoteDevices
+            ]) {
+                return false
+            }
+        }
+
+        if from < 30 && to >= 30 {
+            // We changed this view as a follow-up to the above in order to exclude buffer
+            // deletions from the bookmarked set.
+            if !self.run(db, queries: [
+                "DROP VIEW IF EXISTS \(ViewAllBookmarks)",
+                allBookmarksView
             ]) {
                 return false
             }

--- a/Sync/Synchronizers/Bookmarks/BookmarksSynchronizer.swift
+++ b/Sync/Synchronizers/Bookmarks/BookmarksSynchronizer.swift
@@ -204,7 +204,7 @@ open class BufferingBookmarksSynchronizer: TimestampedSingleCollectionSynchroniz
                 }
                 return deferMaybe(result)
             } >>== { result in
-                guard AppConstants.simpleBookmarksSyncing else {
+                guard AppConstants.MOZ_SIMPLE_BOOKMARKS_SYNCING else {
                     return deferMaybe(result)
                 }
                 guard case .completed = result else {


### PR DESCRIPTION
Ready to go.

Note that we need a DB migration to rebuild a view, because the URL bar hits `ViewAllBookmarks`, which didn't exclude buffer deletions.