### PR TITLE
Bug 1389348 - Data races in DiskImageStore

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -681,7 +681,7 @@ extension TabManager {
         }
 
         // Clean up any screenshots that are no longer associated with a tab.
-        imageStore?.clearExcluding(savedUUIDs)
+        _ = imageStore?.clearExcluding(savedUUIDs)
 
         let tabStateData = NSMutableData()
         let archiver = NSKeyedArchiver(forWritingWith: tabStateData)

--- a/Storage/DiskImageStore.swift
+++ b/Storage/DiskImageStore.swift
@@ -23,7 +23,7 @@ private class DiskImageStoreErrorType: MaybeErrorType {
 open class DiskImageStore {
     fileprivate let files: FileAccessor
     fileprivate let filesDir: String
-    fileprivate let queue = DispatchQueue(label: "DiskImageStore", attributes: DispatchQueue.Attributes.concurrent)
+    fileprivate let queue = DispatchQueue(label: "DiskImageStore")
     fileprivate let quality: CGFloat
     fileprivate var keys: Set<String>
 
@@ -44,11 +44,11 @@ open class DiskImageStore {
 
     /// Gets an image for the given key if it is in the store.
     open func get(_ key: String) -> Deferred<Maybe<UIImage>> {
-        if !keys.contains(key) {
-            return deferMaybe(DiskImageStoreErrorType(description: "Image key not found"))
-        }
-
         return deferDispatchAsync(queue) { () -> Deferred<Maybe<UIImage>> in
+            if !self.keys.contains(key) {
+                return deferMaybe(DiskImageStoreErrorType(description: "Image key not found"))
+            }
+
             let imagePath = URL(fileURLWithPath: self.filesDir).appendingPathComponent(key)
             if let data = try? Data(contentsOf: imagePath),
                    let image = UIImage.imageFromDataThreadSafe(data) {
@@ -63,11 +63,11 @@ open class DiskImageStore {
     /// This put is asynchronous; the image is not recorded in the cache until the write completes.
     /// Does nothing if this key already exists in the store.
     @discardableResult open func put(_ key: String, image: UIImage) -> Success {
-        if keys.contains(key) {
-            return deferMaybe(DiskImageStoreErrorType(description: "Key already in store"))
-        }
-
         return deferDispatchAsync(queue) { () -> Success in
+            if self.keys.contains(key) {
+                return deferMaybe(DiskImageStoreErrorType(description: "Key already in store"))
+            }
+
             let imageURL = URL(fileURLWithPath: self.filesDir).appendingPathComponent(key)
             if let data = UIImageJPEGRepresentation(image, self.quality) {
                 do {
@@ -84,18 +84,22 @@ open class DiskImageStore {
     }
 
     /// Clears all images from the cache, excluding the given set of keys.
-    open func clearExcluding(_ keys: Set<String>) {
-        let keysToDelete = self.keys.subtracting(keys)
+    open func clearExcluding(_ keys: Set<String>) -> Success {
+        return deferDispatchAsync(queue) { () -> Success in
+            let keysToDelete = self.keys.subtracting(keys)
 
-        for key in keysToDelete {
-            let url = URL(fileURLWithPath: filesDir).appendingPathComponent(key)
-            do {
-                try FileManager.default.removeItem(at: url)
-            } catch {
-                log.warning("Failed to remove DiskImageStore item at \(url.absoluteString): \(error)")
+            for key in keysToDelete {
+                let url = URL(fileURLWithPath: self.filesDir).appendingPathComponent(key)
+                do {
+                    try FileManager.default.removeItem(at: url)
+                } catch {
+                    log.warning("Failed to remove DiskImageStore item at \(url.absoluteString): \(error)")
+                }
             }
-        }
 
-        self.keys = self.keys.intersection(keys)
+            self.keys = self.keys.intersection(keys)
+
+            return succeed()
+        }
     }
 }

--- a/StorageTests/DiskImageStoreTests.swift
+++ b/StorageTests/DiskImageStoreTests.swift
@@ -17,7 +17,7 @@ class DiskImageStoreTests: XCTestCase {
         files = MockFiles()
         store = DiskImageStore(files: files, namespace: "DiskImageStoreTests", quality: 1)
 
-        store.clearExcluding(Set())
+        _ = store.clearExcluding(Set()).value
     }
 
     func testStore() {
@@ -44,7 +44,7 @@ class DiskImageStoreTests: XCTestCase {
         success = putImage("blue", image: blueImage)
         XCTAssertFalse(success, "Blue image not added again")
 
-        store.clearExcluding(Set(["red"]))
+        _ = store.clearExcluding(Set(["red"])).value
         XCTAssertNotNil(getImage("red"), "Red image still exists")
         XCTAssertNil(getImage("blue"), "Blue image cleared")
     }


### PR DESCRIPTION
This patch deals with data races in DiskImageStore. These races are all around the `keys` property, which is not properly shielded for concurrent access. The concurrent access is real, since `DiskImageStore.queue` is a concurrent queue.

This patch does two things:

* It makes `DiskImageStore.queue` a serial queue.
* It makes sure that the full operation is executed on the queue. Previously, `keys` was both read and modified simultaneously.

> This patch possibly comes with a performance hit, since we do not process these images concurrently anymore. I realize this is the case, but instead of making this code more complicted, I first want to simply things, per this patch, look at the results, and then optimize of improve.
