### PR TITLE
Bug 1389875 - Add Scan QR Code to quick actions menu

### DIFF
--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -12,6 +12,7 @@ enum ShortcutType: String {
     case newTab = "NewTab"
     case newPrivateTab = "NewPrivateTab"
     case openLastBookmark = "OpenLastBookmark"
+    case qrCode = "QRCode"
 
     init?(fullType: String) {
         guard let last = fullType.components(separatedBy: ".").last else { return nil }
@@ -113,6 +114,8 @@ class QuickActions: NSObject {
             if let urlToOpen = (userData?[QuickActions.TabURLKey] as? String)?.asURL {
                 handleOpenURL(withBrowserViewController: browserViewController, urlToOpen: urlToOpen)
             }
+        case .qrCode:
+            handleQRCode(withBrowserViewController: browserViewController)
         }
     }
 
@@ -128,5 +131,9 @@ class QuickActions: NSObject {
         // if so, open to that tab,
         // otherwise, create a new tab with the bookmarked URL
         bvc.switchToTabForURLOrOpen(urlToOpen, isPrivileged: true)
+    }
+    
+    fileprivate func handleQRCode(withBrowserViewController bvc: BrowserViewController) {
+        bvc.openQRReader()
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1131,6 +1131,10 @@ class BrowserViewController: UIViewController {
             }
         }
     }
+    
+    func openQRReader() {
+        self.scanQRCode()
+    }
 
     fileprivate func popToBVC() {
         guard let currentViewController = navigationController?.topViewController else {

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -121,6 +121,14 @@
 			<key>UIApplicationShortcutItemType</key>
 			<string>$(PRODUCT_BUNDLE_IDENTIFIER).NewPrivateTab</string>
 		</dict>
+		<dict>
+			<key>UIApplicationShortcutItemIconFile</key>
+			<string>menu-ScanQRCode</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>ShortcutItemTitleQRCode</string>
+			<key>UIApplicationShortcutItemType</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER).QRCode</string>
+		</dict>
 	</array>
 	<key>UIBackgroundModes</key>
 	<array>

--- a/Client/en.lproj/InfoPlist.strings
+++ b/Client/en.lproj/InfoPlist.strings
@@ -8,3 +8,4 @@ NSCameraUsageDescription = "This lets you take and upload photos.";
 NSMicrophoneUsageDescription = "This lets you take and upload videos.";
 ShortcutItemTitleNewTab = "New Tab";
 ShortcutItemTitleNewPrivateTab = "New Private Tab";
+ShortcutItemTitleQRCode = "Scan QR Code";


### PR DESCRIPTION
Add "Scan QR Code" to quick actions menu.

Notes:
 - The Scan menu item is always there, even if there isn't a camera - is this an issue on any supported devices outside the iOS Simulator?
 - To fully test, run on simulator