### PR TITLE
Bug 1391245 — Disable ClipboardBar by default

### DIFF
--- a/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -51,7 +51,7 @@ class ClipboardBarDisplayHandler {
         }
         sessionStarted = false
         lastDisplayedURL = UIPasteboard.general.copiedURL?.absoluteString
-        return self.prefs.boolForKey("showClipboardBar") ?? true
+        return self.prefs.boolForKey("showClipboardBar") ?? false
     }
     
     //If we already displayed this URL on the previous session

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -68,7 +68,7 @@ class AppSettingsTableViewController: SettingsTableViewController {
         }
 
         generalSettings += [
-            BoolSetting(prefs: prefs, prefKey: "showClipboardBar", defaultValue: true,
+            BoolSetting(prefs: prefs, prefKey: "showClipboardBar", defaultValue: false,
                         titleText: Strings.SettingsOfferClipboardBarTitle,
                         statusText: Strings.SettingsOfferClipboardBarStatus)
         ]


### PR DESCRIPTION
This PR flips the default for the new show clipboard bar setting to be `false`.

https://bugzilla.mozilla.org/show_bug.cgi?id=1391245