### PR TITLE
Bug 1390126 – Make FxALoginHelper work without an account. (#3049) r=farhan

### DIFF
--- a/Client/Helpers/FxALoginHelper.swift
+++ b/Client/Helpers/FxALoginHelper.swift
@@ -237,7 +237,7 @@ class FxALoginHelper {
         profile?.prefs.setBool(true, forKey: applicationDidRequestUserNotificationPermissionPrefKey)
 
         guard #available(iOS 10, *) else {
-            apnsTokenDeferred?.fill(Maybe.failure(PushNotificationError.wrongOSVersion))
+            apnsTokenDeferred?.fillIfUnfilled(Maybe.failure(PushNotificationError.wrongOSVersion))
             return readyForSyncing()
         }
 
@@ -257,7 +257,7 @@ class FxALoginHelper {
 
     func apnsRegisterDidSucceed(_ deviceToken: Data) {
         let apnsToken = deviceToken.hexEncodedString
-        self.apnsTokenDeferred?.fill(Maybe(success: apnsToken))
+        self.apnsTokenDeferred?.fillIfUnfilled(Maybe(success: apnsToken))
         self.apnsRegisterDidSucceed(apnsToken)
     }
 
@@ -281,7 +281,7 @@ class FxALoginHelper {
     }
 
     func apnsRegisterDidFail() {
-        self.apnsTokenDeferred?.fill(Maybe(failure: PushNotificationError.registrationFailed))
+        self.apnsTokenDeferred?.fillIfUnfilled(Maybe(failure: PushNotificationError.registrationFailed))
         readyForSyncing()
     }
 


### PR DESCRIPTION
This also includes Bug 1391295 — Fixup double APNS registration.

This has already been r+'d as part of PR #3049.

The function of this PR is that the patch was originally merged against `v8.x`, and we can't downlift(?)/cherry-pick onto master.

This does not need further review.

https://bugzilla.mozilla.org/show_bug.cgi?id=1390126
https://bugzilla.mozilla.org/show_bug.cgi?id=1391295