### PR TITLE
Bug 1237407 - Add ability to specify custom FxA servers

### DIFF
--- a/Account/FirefoxAccount.swift
+++ b/Account/FirefoxAccount.swift
@@ -32,7 +32,7 @@ open class FirefoxAccount {
 
     open var deviceRegistration: FxADeviceRegistration?
 
-    open let configuration: FirefoxAccountConfiguration
+    open var configuration: FirefoxAccountConfiguration
 
     open var pushRegistration: PushRegistration?
 

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -378,6 +378,7 @@
 		7BEFC6801BFF68C30059C952 /* QuickActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BEFC67F1BFF68C30059C952 /* QuickActions.swift */; };
 		7BF5A1EA1B41640500EA9DD8 /* SyncQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5A1E91B41640500EA9DD8 /* SyncQueue.swift */; };
 		7BF5A1EE1B429B3100EA9DD8 /* SyncCommandsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5A1ED1B429B3100EA9DD8 /* SyncCommandsTests.swift */; };
+		8D8251811F4DE67F00780643 /* AdvanceAccountSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8251721F4DE67E00780643 /* AdvanceAccountSettingViewController.swift */; };
 		8DCD3BCD1ED5B7FA00446D38 /* FxADeepLinkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DCD3BCC1ED5B7FA00446D38 /* FxADeepLinkingTests.swift */; };
 		A826F0D21CBEB8160084CF9A /* PhoneNumberFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A826F0D11CBEB8160084CF9A /* PhoneNumberFormatterTests.swift */; };
 		A83E5AB71C1D993D0026D912 /* UIPasteboardExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83E5AB61C1D993D0026D912 /* UIPasteboardExtensions.swift */; };
@@ -1629,6 +1630,7 @@
 		7BEFC67F1BFF68C30059C952 /* QuickActions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuickActions.swift; sourceTree = "<group>"; };
 		7BF5A1E91B41640500EA9DD8 /* SyncQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncQueue.swift; sourceTree = "<group>"; };
 		7BF5A1ED1B429B3100EA9DD8 /* SyncCommandsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncCommandsTests.swift; sourceTree = "<group>"; };
+		8D8251721F4DE67E00780643 /* AdvanceAccountSettingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdvanceAccountSettingViewController.swift; sourceTree = "<group>"; };
 		8DCD3BCC1ED5B7FA00446D38 /* FxADeepLinkingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxADeepLinkingTests.swift; sourceTree = "<group>"; };
 		A826F0D11CBEB8160084CF9A /* PhoneNumberFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneNumberFormatterTests.swift; sourceTree = "<group>"; };
 		A83E5AB61C1D993D0026D912 /* UIPasteboardExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIPasteboardExtensions.swift; path = Extensions/UIPasteboardExtensions.swift; sourceTree = "<group>"; };
@@ -2491,6 +2493,7 @@
 		2F44FC551A9E83E200FD20CC /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				8D8251721F4DE67E00780643 /* AdvanceAccountSettingViewController.swift */,
 				3B39EDCA1E16E1AA00EF029F /* CustomSearchViewController.swift */,
 				E692E3361C46E86A009D1240 /* AppSettingsOptions.swift */,
 				E68E39BD1C46F42000B85F42 /* AppSettingsTableViewController.swift */,
@@ -3052,36 +3055,38 @@
 			children = (
 				0B3E7D931B27A7CE00E2E84D /* AboutHomeHandler.swift */,
 				D38F02D01C05127100175932 /* Authenticator.swift */,
+				C40046F91CF8E0B200B08303 /* BackForwardListAnimator.swift */,
 				C400467B1CF4E43E00B08303 /* BackForwardListViewController.swift */,
 				C4EFEECE1CEBB6F2009762A4 /* BackForwardTableViewCell.swift */,
-				C40046F91CF8E0B200B08303 /* BackForwardListAnimator.swift */,
 				E653422C1C5944F90039DD9E /* BrowserPrompts.swift */,
 				E6D8D5E61B569D70009E5A58 /* BrowserTrayAnimators.swift */,
-				D3A994951A3686BD008AD1AC /* BrowserViewController.swift */,
 				C8F457A61F1FD75A000CB895 /* BrowserViewController */,
-				C45F44681D087DB600CB7EF0 /* TopTabsViewController.swift */,
-				31ADB5D91E58CEC300E87909 /* ClipboardBarDisplayHandler.swift */,
-				C4E3985F1D22C409004E89BA /* TopTabsLayout.swift */,
-				C4E3983C1D21F1E7004E89BA /* TopTabsViews.swift */,
-				3BF56D261CDBBE1F00AC4D75 /* SimpleToast.swift */,
+				D3A994951A3686BD008AD1AC /* BrowserViewController.swift */,
 				C4F3B2991CFCF93A00966259 /* ButtonToast.swift */,
+				31ADB5D91E58CEC300E87909 /* ClipboardBarDisplayHandler.swift */,
 				D3BA7E0D1B0E934F00153782 /* ContextMenuHelper.swift */,
 				3BE7275C1CCFE8B60099189F /* CustomSearchHandler.swift */,
 				0BA1E02D1B046F1E007675AF /* ErrorPageHelper.swift */,
 				0BF42D361A7C0B8E00889E28 /* FaviconManager.swift */,
 				D3B6923C1B9F9444004B87A4 /* FindInPageBar.swift */,
 				D3B6923E1B9F9A58004B87A4 /* FindInPageHelper.swift */,
-				A93067E71D0FE18E00C49C6E /* NightModeHelper.swift */,
 				D02816C11ECA5E2A00240CAA /* HistoryStateHelper.swift */,
 				39DD030C1CD53E1900BC09B3 /* HomePageHelper.swift */,
-				A9072B7F1D07B34100459960 /* NoImageModeHelper.swift */,
 				D3C3696D1CC6B78800348A61 /* LocalRequestHelper.swift */,
 				0BB5B30A1AC0AD1F0052877D /* LoginsHelper.swift */,
+				7482205B1DBAB56300EEEA72 /* MailProviders.swift */,
+				744ED5601DBFEB8D00A2B5BE /* MailtoLinkHandler.swift */,
 				392ED6B61D06E85E009D9B62 /* NewTabChoiceViewController.swift */,
+				A93067E71D0FE18E00C49C6E /* NightModeHelper.swift */,
+				A9072B7F1D07B34100459960 /* NoImageModeHelper.swift */,
 				7BA8D1C61BA037F500C8AE9E /* OpenInHelper.swift */,
 				D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */,
+				74821FC41DB56A2500EEEA72 /* OpenWithSettingsViewController.swift */,
 				E47536EC1C85412C0022CC69 /* PrintHelper.swift */,
 				D31CF65B1CC1959A001D0BD0 /* PrivilegedRequest.swift */,
+				FA6B2AC11D41F02D00429414 /* Punycode.swift */,
+				FA9294001D6584A200AC8D33 /* QRCode.xcassets */,
+				FA9293D31D6580E100AC8D33 /* QRCodeViewController.swift */,
 				E47616C61AB74CA600E7DD25 /* ReaderModeBarView.swift */,
 				D31F95E81AC226CB005C9F3B /* ScreenshotHelper.swift */,
 				D308E4E31A5306F500842685 /* SearchEngines.swift */,
@@ -3089,6 +3094,9 @@
 				D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */,
 				59A68CCB63E2A565CB03F832 /* SearchViewController.swift */,
 				74C027441B2A348C001B1E88 /* SessionData.swift */,
+				F35B8D2E1D638408008E3D61 /* SessionRestoreHandler.swift */,
+				F35B8D2C1D6383E9008E3D61 /* SessionRestoreHelper.swift */,
+				3BF56D261CDBBE1F00AC4D75 /* SimpleToast.swift */,
 				E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */,
 				D3A994961A3686BD008AD1AC /* Tab.swift */,
 				E4CD9F2C1A6DC91200318571 /* TabLocationView.swift */,
@@ -3099,17 +3107,12 @@
 				D314E7F51A37B98700426A76 /* TabToolbar.swift */,
 				D301AAED1A3A55B70078DD1D /* TabTrayController.swift */,
 				3BCE6D3B1CEB9E4D0080928C /* ThirdPartySearchAlerts.swift */,
+				C4E3985F1D22C409004E89BA /* TopTabsLayout.swift */,
+				C45F44681D087DB600CB7EF0 /* TopTabsViewController.swift */,
+				C4E3983C1D21F1E7004E89BA /* TopTabsViews.swift */,
 				D3C744CC1A687D6C004CE85D /* URIFixup.swift */,
 				0BF0DB931A8545800039F300 /* URLBarView.swift */,
 				E4ECD0871B70FD4F00B90D22 /* WindowCloseHelper.swift */,
-				FA6B2AC11D41F02D00429414 /* Punycode.swift */,
-				F35B8D2C1D6383E9008E3D61 /* SessionRestoreHelper.swift */,
-				F35B8D2E1D638408008E3D61 /* SessionRestoreHandler.swift */,
-				74821FC41DB56A2500EEEA72 /* OpenWithSettingsViewController.swift */,
-				7482205B1DBAB56300EEEA72 /* MailProviders.swift */,
-				744ED5601DBFEB8D00A2B5BE /* MailtoLinkHandler.swift */,
-				FA9293D31D6580E100AC8D33 /* QRCodeViewController.swift */,
-				FA9294001D6584A200AC8D33 /* QRCode.xcassets */,
 			);
 			path = Browser;
 			sourceTree = "<group>";
@@ -5628,6 +5631,7 @@
 				E68E7ADA1CAC207400FDCA76 /* ChangePasscodeViewController.swift in Sources */,
 				E640E85E1C73A45A00C5F072 /* PasscodeEntryViewController.swift in Sources */,
 				7BC68CCE1CC152B70043562A /* MenuViewController.swift in Sources */,
+				8D8251811F4DE67F00780643 /* AdvanceAccountSettingViewController.swift in Sources */,
 				7BC68CC61CC152B70043562A /* MenuItem.swift in Sources */,
 				E633E2DA1C21EAF8001FFF6C /* LoginDetailViewController.swift in Sources */,
 				59A68B280D62462B85CF57A4 /* HistoryPanel.swift in Sources */,

--- a/Client/Frontend/Settings/AdvanceAccountSettingViewController.swift
+++ b/Client/Frontend/Settings/AdvanceAccountSettingViewController.swift
@@ -1,0 +1,177 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+import Shared
+import SnapKit
+import Foundation
+import FxA
+import Account
+
+class AdvanceAccountSettingViewController: SettingsTableViewController {
+    fileprivate let SectionHeaderIdentifier = "SectionHeaderIdentifier"
+    
+    fileprivate var customSyncUrl: String?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = Strings.SettingsAdvanceAccountSectionName
+        self.customSyncUrl = self.profile.prefs.stringForKey(PrefsKeys.KeyCustomSyncWeb)
+    }
+    
+    func clearCustomAccountPrefs() {
+        self.profile.prefs.setBool(false, forKey: PrefsKeys.KeyUseCustomSyncService)
+        self.profile.prefs.setString("", forKey: PrefsKeys.KeyCustomSyncToken)
+        self.profile.prefs.setString("", forKey: PrefsKeys.KeyCustomSyncProfile)
+        self.profile.prefs.setString("", forKey: PrefsKeys.KeyCustomSyncOauth)
+        self.profile.prefs.setString("", forKey: PrefsKeys.KeyCustomSyncAuth)
+        self.profile.prefs.setString("", forKey: PrefsKeys.KeyCustomSyncWeb)
+        
+        // To help prevent the account being in a strange state, we force it to
+        // log out when user clears their custom server preferences.
+        self.profile.removeAccount()
+    }
+    
+    func setCustomAccountPrefs(_ data: Data, url: URL) {        
+        guard let json = try? JSONSerialization.jsonObject(with: data, options: .allowFragments) as! [String:Any] else {
+            return
+        }
+        
+        self.profile.prefs.setBool(true, forKey: PrefsKeys.KeyUseCustomSyncService)
+        self.profile.prefs.setString(json["sync_tokenserver_base_url"] as! String, forKey: PrefsKeys.KeyCustomSyncToken)
+        self.profile.prefs.setString(json["profile_server_base_url"] as! String, forKey: PrefsKeys.KeyCustomSyncProfile)
+        self.profile.prefs.setString(json["oauth_server_base_url"] as! String, forKey: PrefsKeys.KeyCustomSyncOauth)
+        self.profile.prefs.setString(json["auth_server_base_url"] as! String, forKey: PrefsKeys.KeyCustomSyncAuth)
+        self.profile.prefs.setString(url.absoluteString, forKey: PrefsKeys.KeyCustomSyncWeb)
+        self.profile.removeAccount()
+        self.displaySuccessAlert()
+    }
+    
+    func setCustomAccountPrefs() {
+        guard let urlString = self.customSyncUrl, let url = URL(string: urlString) else {
+            // If the user attempts to set a nil url, clear all the custom service perferences
+            // and use default FxA servers.
+            self.displayNoServiceSetAlert()
+            return
+        }
+        
+        // FxA stores its server configuation under a well-known path. This attempts to download the configuration
+        // and save it into the users preferences.
+        let syncConfigureString = urlString + "/.well-known/fxa-client-configuration"
+        let syncConfigureURL = URL(string: syncConfigureString)!
+        
+        URLSession.shared.dataTask(with:syncConfigureURL, completionHandler: {(data, response, error) in
+            guard let data = data, error == nil else {
+                // Something went wrong while downloading or parsing the configuration.
+                self.displayErrorAlert()
+                return
+            }
+            self.setCustomAccountPrefs(data, url: url)
+        }).resume()
+    }
+    
+    func displaySuccessAlert() {
+        let alertController = UIAlertController(title: "", message: Strings.SettingsAdvanceAccountUrlUpdatedAlertMessage, preferredStyle: .alert)
+        let defaultAction = UIAlertAction(title: Strings.SettingsAdvanceAccountUrlUpdatedAlertOk, style: .default, handler: nil)
+        alertController.addAction(defaultAction)
+        self.present(alertController, animated: true)
+    }
+    
+    func displayErrorAlert() {
+        self.profile.prefs.setBool(false, forKey: PrefsKeys.KeyUseCustomSyncService)
+        DispatchQueue.main.async {
+            self.tableView.reloadRows(at: [IndexPath(row: 0, section: 0)], with: UITableViewRowAnimation.automatic)
+        }
+        let alertController = UIAlertController(title: Strings.SettingsAdvanceAccountUrlErrorAlertTitle, message: Strings.SettingsAdvanceAccountUrlErrorAlertMessage, preferredStyle: .alert)
+        let defaultAction = UIAlertAction(title: Strings.SettingsAdvanceAccountUrlErrorAlertOk, style: .default, handler: nil)
+        alertController.addAction(defaultAction)
+        self.present(alertController, animated: true)
+    }
+    
+    func displayNoServiceSetAlert() {
+        self.profile.prefs.setBool(false, forKey: PrefsKeys.KeyUseCustomSyncService)
+        DispatchQueue.main.async {
+            self.tableView.reloadRows(at: [IndexPath(row: 0, section: 0)], with: UITableViewRowAnimation.automatic)
+        }
+        let alertController = UIAlertController(title: Strings.SettingsAdvanceAccountUrlErrorAlertTitle, message: NSLocalizedString("Please enter a custom account url before enabling.", comment: "No custom service set."), preferredStyle: .alert)
+        let defaultAction = UIAlertAction(title: Strings.SettingsAdvanceAccountUrlUpdatedAlertOk, style: .default, handler: nil)
+        alertController.addAction(defaultAction)
+        self.present(alertController, animated: true)
+    }
+    
+    override func generateSettings() -> [SettingSection] {
+        let prefs = profile.prefs
+        let customSyncSetting = CustomSyncWebPageSetting(prefs: prefs,
+                                                         prefKey: PrefsKeys.KeyCustomSyncWeb,
+                                                         placeholder: Strings.SettingsAdvanceAccountUrlPlaceholder,
+                                                         accessibilityIdentifier: "CustomSyncSetting",
+                                                         settingDidChange: { fieldText in
+                                                            self.customSyncUrl = fieldText
+                                                            if let customSyncUrl = self.customSyncUrl, customSyncUrl.isEmpty {
+                                                                self.clearCustomAccountPrefs()
+                                                                return
+                                                            }
+        })
+        
+        var basicSettings: [Setting] = []
+        basicSettings += [
+            CustomSyncEnableSetting(
+                prefs: prefs,
+                settingDidChange: { result in
+                    if result == true {
+                        // Reload the table data to ensure that the updated custom url is set
+                        self.tableView?.reloadData()
+                        self.setCustomAccountPrefs()
+                    } 
+            }),
+            customSyncSetting
+        ]
+        
+        let settings: [SettingSection] = [
+            SettingSection(title: NSAttributedString(string: ""), children: basicSettings),
+            SettingSection(title: NSAttributedString(string: NSLocalizedString("To use a custom Firefox Account and sync servers, specify the root Url of the Firefox Account site. This will download the configuration and setup this device to use the new service. After the new service has been set, you will need to create a new Firefox Account or login with an existing one.", comment: "Details for using custom Firefox Account service.")), children: [])
+        ]
+        
+        return settings
+    }
+    
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: SectionHeaderIdentifier) as! SettingsTableSectionHeaderFooterView
+        let sectionSetting = settings[section]
+        headerView.titleLabel.text = sectionSetting.title?.string
+        
+        switch section {
+        // Hide the bottom border for the FxA custom server notes.
+        case 1:
+            headerView.titleAlignment = .top
+            headerView.titleLabel.numberOfLines = 0
+            headerView.showBottomBorder = false
+        default:
+            return super.tableView(tableView, viewForHeaderInSection: section)
+        }
+        return headerView
+    }
+}
+
+class CustomSyncEnableSetting: BoolSetting {
+    init(prefs: Prefs, settingDidChange: ((Bool?) -> Void)? = nil) {
+        super.init(
+            prefs: prefs, prefKey: PrefsKeys.KeyUseCustomSyncService, defaultValue: false,
+            attributedTitleText: NSAttributedString(string: NSLocalizedString("Use Custom Account Service", tableName: "UseCustomAccountService", comment: "Toggle switch to use custom FxA server")),
+            settingDidChange: settingDidChange
+        )
+    }
+}
+
+class CustomSyncWebPageSetting: WebPageSetting {
+    override init(prefs: Prefs, prefKey: String, defaultValue: String? = nil, placeholder: String, accessibilityIdentifier: String, settingDidChange: ((String?) -> Void)? = nil) {
+        super.init(prefs: prefs,
+                   prefKey: prefKey,
+                   defaultValue: defaultValue,
+                   placeholder: placeholder,
+                   accessibilityIdentifier: accessibilityIdentifier,
+                   settingDidChange: settingDidChange)
+        textField.clearButtonMode = UITextFieldViewMode.always
+    }
+}

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -77,6 +77,7 @@ class AppSettingsTableViewController: SettingsTableViewController {
             SettingSection(title: nil, children: [
                 // Without a Firefox Account:
                 ConnectSetting(settings: self),
+                AdvanceAccountSetting(settings: self),
                 // With a Firefox Account:
                 AccountStatusSetting(settings: self),
                 SyncNowSetting(settings: self)

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -201,6 +201,20 @@ extension Strings {
     public static let SettingsNewTabDescription = NSLocalizedString("Settings.NewTab.Description", value: "When you open a New Tab:", comment: "A description in settings of what the new tab choice means")
 }
 
+// Custom account settings
+extension Strings {
+    public static let SettingsAdvanceAccountSectionName = NSLocalizedString("Settings.AdvanceAccount.SectionName", value: "Account Settings", comment: "Label used as an item in Settings. When touched it will open a dialog to setup advance Firefox account settings.")
+    public static let SettingsAdvanceAccountTitle = NSLocalizedString("Settings.AdvanceAccount.SectionName", value: "Advance Account Settings", comment: "Title displayed in header of the setting panel.")
+    public static let SettingsAdvanceAccountUrlPlaceholder = NSLocalizedString("Settings.AdvanceAccount.UrlPlaceholder", value: "Custom Account Url", comment: "Title displayed in header of the setting panel.")
+    
+    public static let SettingsAdvanceAccountUrlUpdatedAlertMessage = NSLocalizedString("Settings.AdvanceAccount.UpdatedAlertMessage", value: "Firefox account service updated. To begin using custom server, please log out and re-login.", comment: "Messaged displayed when sync service has been successfully set.")
+    public static let SettingsAdvanceAccountUrlUpdatedAlertOk = NSLocalizedString("Settings.AdvanceAccount.UpdatedAlertOk", value: "OK", comment: "Ok button on custom sync service updated alert")
+    
+    public static let SettingsAdvanceAccountUrlErrorAlertTitle = NSLocalizedString("Settings.AdvanceAccount.ErrorAlertTitle", value: "Error", comment: "Error alert message title.")
+    public static let SettingsAdvanceAccountUrlErrorAlertMessage = NSLocalizedString("Settings.AdvanceAccount.ErrorAlertMessage", value: "There was an error while attempting to parse the url. Please make sure that it is a valid Firefox Account root url.", comment: "Messaged displayed when sync service has an error setting a custom sync url.")
+    public static let SettingsAdvanceAccountUrlErrorAlertOk = NSLocalizedString("Settings.AdvanceAccount.ErrorAlertOk", value: "OK", comment: "Ok button on custom sync service error alert.")
+}
+
 // Open With Settings
 extension Strings {
     public static let SettingsOpenWithSectionName = NSLocalizedString("Settings.OpenWith.SectionName", value: "Open With", comment: "Label used as an item in Settings. When touched it will open a dialog to configure the open with (mail links) behaviour.")

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -19,6 +19,13 @@ public struct PrefsKeys {
     public static let KeyMailToOption = "MailToOption"
     public static let HasFocusInstalled = "HasFocusInstalled"
     public static let HasPocketInstalled = "HasPocketInstalled"
+
+    public static let KeyUseCustomSyncService = "useCustomSyncService"
+    public static let KeyCustomSyncToken = "customSyncTokenServer"
+    public static let KeyCustomSyncProfile = "customSyncProfileServer"
+    public static let KeyCustomSyncOauth = "customSyncOauthServer"
+    public static let KeyCustomSyncAuth = "customSyncAuthServer"
+    public static let KeyCustomSyncWeb = "customSyncWebServer"
 }
 
 public struct PrefsDefaults {


### PR DESCRIPTION
This PR adds the ability to specify custom FxA servers and sync via debug option. To access click `Advance Account Settings` while in debug mode. To test, I used `https://latest.dev.lcip.org`. 

Some quick notes
 * Uses FxAs `/.well-known/fxa-client-configuration/` to pull in those servers configuration
 * Signs out the account whenever you change servers
 * Stores custom server configuration in user prefs

![screen shot 2017-08-23 at 1 32 08 pm](https://user-images.githubusercontent.com/1295288/29629618-80055f20-8807-11e7-811c-c6428c36df92.png)


Fixes https://github.com/mozilla/fxa-bugzilla-mirror/issues/332