### PR TITLE
Bug 1391692 - Send an event when the users bookmarks on the new tab page

### DIFF
--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -751,6 +751,7 @@ extension ActivityStreamPanel: HomePanelContextMenu {
                                                                                     toApplication: UIApplication.shared)
                 site.setBookmarked(true)
                 self.telemetry.reportEvent(.AddBookmark, source: pingSource, position: index)
+                LeanplumIntegration.sharedInstance.track(eventName: .savedBookmark)
             })
         }
 


### PR DESCRIPTION
This patch sends a .saveBookmark event when the user hits Add Bookmark from either the top site or a highlight context menu.

This patch does not make an effort to integrate these events in the Share extention. That is out of scope for the 8.3 release.