### PR TITLE
Bug 1391299 - Fix search suggestions formatting for iOS11.

### DIFF
--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -720,8 +720,8 @@ fileprivate class SuggestionCell: UITableViewCell {
         }
 
         frame.size.height = height + 2 * SearchViewControllerUX.SuggestionCellVerticalPadding
-        contentView.frame = frame
-        container.frame = frame
+        contentView.frame = bounds
+        container.frame = bounds
 
         let imageX = (48 - imageSize) / 2
         let imageY = (frame.size.height - imageSize) / 2


### PR DESCRIPTION
Easy. Peasy 😄 

The internal subviews of a cell should use bounds and not the frame. Not sure how this worked before. 