### PR TITLE
Bug 1390871 - Remove FindInPage option from default UIMenuController

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -155,8 +155,7 @@ class Tab: NSObject {
             configuration!.preferences = WKPreferences()
             configuration!.preferences.javaScriptCanOpenWindowsAutomatically = false
             configuration!.allowsInlineMediaPlayback = true
-            let webView = TabWebView(frame: CGRect.zero, configuration: configuration!)
-            webView.delegate = self
+            let webView = WKWebView(frame: CGRect.zero, configuration: configuration!)
             configuration = nil
 
             webView.accessibilityLabel = NSLocalizedString("Web content", comment: "Accessibility label for the main web content view")
@@ -465,11 +464,7 @@ class Tab: NSObject {
     }
 }
 
-extension Tab: TabWebViewDelegate {
-    fileprivate func tabWebView(_ tabWebView: TabWebView, didSelectFindInPageForSelection selection: String) {
-        tabDelegate?.tab(self, didSelectFindInPageForSelection: selection)
-    }
-}
+
 
 private class HelperManager: NSObject, WKScriptMessageHandler {
     fileprivate var helpers = [String: TabHelper]()
@@ -506,31 +501,5 @@ private class HelperManager: NSObject, WKScriptMessageHandler {
 
     func getHelper(_ name: String) -> TabHelper? {
         return helpers[name]
-    }
-}
-
-private protocol TabWebViewDelegate: class {
-    func tabWebView(_ tabWebView: TabWebView, didSelectFindInPageForSelection selection: String)
-}
-
-private class TabWebView: WKWebView, MenuHelperInterface {
-    fileprivate weak var delegate: TabWebViewDelegate?
-
-    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-        return action == MenuHelper.SelectorFindInPage
-    }
-
-    @objc func menuHelperFindInPage() {
-        evaluateJavaScript("getSelection().toString()") { result, _ in
-            let selection = result as? String ?? ""
-            self.delegate?.tabWebView(self, didSelectFindInPageForSelection: selection)
-        }
-    }
-
-    fileprivate override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        // The find-in-page selection menu only appears if the webview is the first responder.
-        becomeFirstResponder()
-
-        return super.hitTest(point, with: event)
     }
 }

--- a/Client/Helpers/MenuHelper.swift
+++ b/Client/Helpers/MenuHelper.swift
@@ -9,7 +9,6 @@ import Foundation
     @objc optional func menuHelperOpenAndFill()
     @objc optional func menuHelperReveal()
     @objc optional func menuHelperSecure()
-    @objc optional func menuHelperFindInPage()
 }
 
 open class MenuHelper: NSObject {
@@ -17,7 +16,6 @@ open class MenuHelper: NSObject {
     open static let SelectorHide: Selector = #selector(MenuHelperInterface.menuHelperSecure)
     open static let SelectorOpenAndFill: Selector = #selector(MenuHelperInterface.menuHelperOpenAndFill)
     open static let SelectorReveal: Selector = #selector(MenuHelperInterface.menuHelperReveal)
-    open static let SelectorFindInPage: Selector = #selector(MenuHelperInterface.menuHelperFindInPage)
 
     open class var defaultHelper: MenuHelper {
         struct Singleton {
@@ -39,9 +37,6 @@ open class MenuHelper: NSObject {
         let openAndFillTitle = NSLocalizedString("Open & Fill", tableName: "LoginManager", comment: "Open and Fill website text selection menu item")
         let openAndFillItem = UIMenuItem(title: openAndFillTitle, action: MenuHelper.SelectorOpenAndFill)
 
-        let findInPageTitle = NSLocalizedString("Find in Page", tableName: "FindInPage", comment: "Text selection menu item")
-        let findInPageItem = UIMenuItem(title: findInPageTitle, action: MenuHelper.SelectorFindInPage)
-
-        UIMenuController.shared.menuItems = [copyItem, revealPasswordItem, hidePasswordItem, openAndFillItem, findInPageItem]
+        UIMenuController.shared.menuItems = [copyItem, revealPasswordItem, hidePasswordItem, openAndFillItem]
     }
 }


### PR DESCRIPTION
 In iOS11 the menu item sends the event to WKContentView instead of the parent WKWebview which causes a crash.

I tried everything I could think of to get this to work. Even finding the WKContentView and getting it to resignFirstResponder and forcing WKWebview to becomeFirstResponder doesnt work. 

Its very odd because the canPerformAction bubbles up correctly. But the selectors are not passed up correctly. 

We can leave this PR until the last beta in case it gets fixed between then.