### PR TITLE
 Bug 1391265: test content blocker code (aka tracking protection)

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -750,6 +750,7 @@
 		EB2A633E1F3B514A004EF8B0 /* disconnect-content.json in Resources */ = {isa = PBXBuildFile; fileRef = EB2A63371F3B5135004EF8B0 /* disconnect-content.json */; };
 		EB2A633F1F3B514B004EF8B0 /* disconnect-social.json in Resources */ = {isa = PBXBuildFile; fileRef = EB2A63391F3B5135004EF8B0 /* disconnect-social.json */; };
 		EB2A63401F3B515C004EF8B0 /* web-fonts.json in Resources */ = {isa = PBXBuildFile; fileRef = EB2A63351F3B4EA7004EF8B0 /* web-fonts.json */; };
+		EB5A5B961F5471150036E1BB /* ContentBlockerSettingsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB5A5B871F5471150036E1BB /* ContentBlockerSettingsTest.swift */; };
 		EBC17F8B1F511A16000EEEB7 /* ContentBlockerInitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBC17F7C1F511A15000EEEB7 /* ContentBlockerInitTest.swift */; };
 		F35B8D2B1D6380EA008E3D61 /* SessionRestore.html in Resources */ = {isa = PBXBuildFile; fileRef = F35B8D2A1D6380EA008E3D61 /* SessionRestore.html */; };
 		F35B8D2D1D6383E9008E3D61 /* SessionRestoreHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F35B8D2C1D6383E9008E3D61 /* SessionRestoreHelper.swift */; };
@@ -1982,6 +1983,7 @@
 		EB2A63371F3B5135004EF8B0 /* disconnect-content.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "disconnect-content.json"; sourceTree = "<group>"; };
 		EB2A63381F3B5135004EF8B0 /* disconnect-advertising.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "disconnect-advertising.json"; sourceTree = "<group>"; };
 		EB2A63391F3B5135004EF8B0 /* disconnect-social.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "disconnect-social.json"; sourceTree = "<group>"; };
+		EB5A5B871F5471150036E1BB /* ContentBlockerSettingsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentBlockerSettingsTest.swift; sourceTree = "<group>"; };
 		EBC17F7C1F511A15000EEEB7 /* ContentBlockerInitTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentBlockerInitTest.swift; sourceTree = "<group>"; };
 		F35B8D2A1D6380EA008E3D61 /* SessionRestore.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = SessionRestore.html; sourceTree = "<group>"; };
 		F35B8D2C1D6383E9008E3D61 /* SessionRestoreHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreHelper.swift; sourceTree = "<group>"; };
@@ -3007,6 +3009,7 @@
 		D39FA1601A83E0EC00EE869C /* UITests */ = {
 			isa = PBXGroup;
 			children = (
+				EB5A5B871F5471150036E1BB /* ContentBlockerSettingsTest.swift */,
 				0BEF44621E31165700187C32 /* EarlGrey.swift */,
 				D39FA16F1A83E62600EE869C /* UITests-Bridging-Header.h */,
 				D343DCFD1C446BDB00D7EEE8 /* findPage.html */,
@@ -5370,6 +5373,7 @@
 				D313BE981B2F5096009EF241 /* DomainAutocompleteTests.swift in Sources */,
 				D3CFD3641CC5605B0064AB4A /* SecurityTests.swift in Sources */,
 				D3C3EB651B6FF44000388E9A /* SessionRestoreTests.swift in Sources */,
+				EB5A5B961F5471150036E1BB /* ContentBlockerSettingsTest.swift in Sources */,
 				7B24DC9C1B67B3590005766B /* ClearPrivateDataTests.swift in Sources */,
 				E633E37A1C2204BE001FFF6C /* LoginManagerTests.swift in Sources */,
 				744B0FFE1B4F172E00100422 /* ToolbarTests.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -750,6 +750,7 @@
 		EB2A633E1F3B514A004EF8B0 /* disconnect-content.json in Resources */ = {isa = PBXBuildFile; fileRef = EB2A63371F3B5135004EF8B0 /* disconnect-content.json */; };
 		EB2A633F1F3B514B004EF8B0 /* disconnect-social.json in Resources */ = {isa = PBXBuildFile; fileRef = EB2A63391F3B5135004EF8B0 /* disconnect-social.json */; };
 		EB2A63401F3B515C004EF8B0 /* web-fonts.json in Resources */ = {isa = PBXBuildFile; fileRef = EB2A63351F3B4EA7004EF8B0 /* web-fonts.json */; };
+		EBC17F8B1F511A16000EEEB7 /* ContentBlockerInitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBC17F7C1F511A15000EEEB7 /* ContentBlockerInitTest.swift */; };
 		F35B8D2B1D6380EA008E3D61 /* SessionRestore.html in Resources */ = {isa = PBXBuildFile; fileRef = F35B8D2A1D6380EA008E3D61 /* SessionRestore.html */; };
 		F35B8D2D1D6383E9008E3D61 /* SessionRestoreHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F35B8D2C1D6383E9008E3D61 /* SessionRestoreHelper.swift */; };
 		F35B8D2F1D638408008E3D61 /* SessionRestoreHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F35B8D2E1D638408008E3D61 /* SessionRestoreHandler.swift */; };
@@ -1981,6 +1982,7 @@
 		EB2A63371F3B5135004EF8B0 /* disconnect-content.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "disconnect-content.json"; sourceTree = "<group>"; };
 		EB2A63381F3B5135004EF8B0 /* disconnect-advertising.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "disconnect-advertising.json"; sourceTree = "<group>"; };
 		EB2A63391F3B5135004EF8B0 /* disconnect-social.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "disconnect-social.json"; sourceTree = "<group>"; };
+		EBC17F7C1F511A15000EEEB7 /* ContentBlockerInitTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentBlockerInitTest.swift; sourceTree = "<group>"; };
 		F35B8D2A1D6380EA008E3D61 /* SessionRestore.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = SessionRestore.html; sourceTree = "<group>"; };
 		F35B8D2C1D6383E9008E3D61 /* SessionRestoreHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreHelper.swift; sourceTree = "<group>"; };
 		F35B8D2E1D638408008E3D61 /* SessionRestoreHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreHandler.swift; sourceTree = "<group>"; };
@@ -3574,6 +3576,7 @@
 		F84B21D61A090F8100AAB793 /* ClientTests */ = {
 			isa = PBXGroup;
 			children = (
+				EBC17F7C1F511A15000EEEB7 /* ContentBlockerInitTest.swift */,
 				8DCD3BCC1ED5B7FA00446D38 /* FxADeepLinkingTests.swift */,
 				3B6F40171DC7849C00656CC6 /* ActivityStreamTests.swift */,
 				E696FE501C47F86E00EC007C /* AuthenticatorTests.swift */,
@@ -5690,6 +5693,7 @@
 				0BF42D4F1A7CD09600889E28 /* TestFavicons.swift in Sources */,
 				7BBFEE741BB405D900A305AA /* TabManagerTests.swift in Sources */,
 				0BA8964C1A250E6500C1010C /* TestBookmarks.swift in Sources */,
+				EBC17F8B1F511A16000EEEB7 /* ContentBlockerInitTest.swift in Sources */,
 				2F13E79B1AC0C02700D75081 /* StringExtensionsTests.swift in Sources */,
 				2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */,
 				4A59B58AD11B5EE1F80BBDEB /* TestHistory.swift in Sources */,

--- a/ClientTests/ContentBlockerInitTest.swift
+++ b/ClientTests/ContentBlockerInitTest.swift
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+import GCDWebServers
+import XCTest
+import WebKit
+@testable import Client
+
+class ContentBlockerInitTest: XCTestCase {
+    @available(iOS 11, *)
+    func testInit() {
+        let tab = Tab(configuration: WKWebViewConfiguration())
+        let profile = TabManagerMockProfile()
+        let expect = expectation(description: "content blocker compiled lists")
+        let cb = ContentBlockerHelper(tab: tab, profile: profile)
+        cb.removeAllRulesInStore {
+            cb.compileListsNotInStore { success in
+                XCTAssert(success)
+                expect.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+}

--- a/UITests/ContentBlockerSettingsTest.swift
+++ b/UITests/ContentBlockerSettingsTest.swift
@@ -1,0 +1,88 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import EarlGrey
+import Deferred
+@testable import Client
+
+class ContentBlockerSettingsTests: KIFTestCase {
+    var tab: Tab!
+    var delegate: AppDelegate!
+    var testDone: XCTestExpectation!
+
+    // A convenience function for static or instance usage.
+    func tapInTable(_ label: String) {
+        ContentBlockerSettingsTests.tapInTable(label)
+    }
+
+    class func tapInTable(_ label: String) {
+        EarlGrey.select(elementWithMatcher:grey_accessibilityLabel(label)).using(searchAction: grey_scrollInDirection(GREYDirection.down, 600), onElementWithMatcher: grey_kindOfClass(UITableView.self)).perform(grey_tap())
+    }
+
+    override class func setUp() {
+        super.setUp()
+        // Called once before all tests are run
+        BrowserUtils.dismissFirstRunUI()
+        EarlGrey.select(elementWithMatcher: grey_accessibilityLabel("Menu")).perform(grey_tap())
+        EarlGrey.select(elementWithMatcher: grey_accessibilityID("SettingsMenuItem")).perform(grey_tap())
+        tapInTable("Tracking Protection")
+    }
+
+    override class func tearDown() {
+        let delegate = UIApplication.shared.delegate as! AppDelegate
+        delegate.tabManager.removeAll()
+    }
+
+    override func setUp() {
+        testDone = expectation(description: "wait for test")
+        delegate = UIApplication.shared.delegate as! AppDelegate
+        tab = delegate.tabManager.addTab()
+    }
+
+    @available(iOS 11, *)
+    func testStrict() {
+        let blocker = tab.contentBlocker as! ContentBlockerHelper
+        tapInTable("Always On")
+        tapInTable("Strict")
+        blocker.addActiveRulesToTab().uponQueue(.main) { result in
+            let list = blocker.blocklistStrict + blocker.blocklistBasic
+            XCTAssert(result.sorted() == list.sorted())
+            self.testDone.fulfill()
+        }
+        waitForExpectations(timeout: 5.0) { _ in }
+    }
+
+    @available(iOS 11, *)
+    func testNever() {
+        let blocker = tab.contentBlocker as! ContentBlockerHelper
+        tapInTable("Never")
+        blocker.addActiveRulesToTab().uponQueue(.main) { result in
+            XCTAssert(result.count < 1)
+            self.testDone.fulfill()
+        }
+        waitForExpectations(timeout: 5.0) { _ in }
+    }
+
+    @available(iOS 11, *)
+    func testPrivateModeOnly() {
+        let blocker = tab.contentBlocker as! ContentBlockerHelper
+        tapInTable("Private Browsing Mode Only")
+        tapInTable("Basic (Recommended)")
+        
+        let _ = blocker.addActiveRulesToTab().bindQueue(.main) { result -> Deferred<Void> in
+            XCTAssert(result.count < 1)
+            return Deferred(value: ())
+        }.bindQueue(.main) { result -> Deferred<[String]> in
+            let tab = self.delegate.tabManager.addTab(isPrivate: true)
+            let blocker = tab.contentBlocker as! ContentBlockerHelper
+            return blocker.addActiveRulesToTab()
+        }.uponQueue(.main) { result in
+            XCTAssert(result.sorted() == blocker.blocklistBasic.sorted())
+            self.testDone.fulfill()
+        }
+        waitForExpectations(timeout: 5.0) { _ in }
+    }
+}
+


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1391265

Adds a XCTestCase for parsing, and a UITest for the various options

UPDATE: Once https://github.com/mozilla-mobile/firefox-ios/pull/3118 lands, rebase and cleanup this patch for resubmission.

SEE ALSO: https://github.com/mozilla-mobile/firefox-ios/pull/3109, an XCUITest to ensure settings UI is properly 'sticky'.