### PR TITLE
   Bug 1394850: Tracking Protection screen telemetry

### DIFF
--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -38,6 +38,7 @@ enum LeanplumEventName: String {
     case userSharedWebpage = "E_User_Tapped_Share_Button"
     case signsInFxa = "E_User_Signed_In_To_FxA"
     case useReaderView = "E_User_Used_Reader_View"
+    case trackingProtectionSettings = "E_Tracking_Protection_Settings_Changed"
 }
 
 enum UserAttributeKeyName: String {

--- a/Client/Frontend/ContentBlocker/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/ContentBlocker/ContentBlockerSettingViewController.swift
@@ -35,6 +35,8 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
                 self.currentEnabledState = option
                 self.prefs.setString(self.currentEnabledState.rawValue, forKey: ContentBlockerHelper.PrefKeyEnabledState)
                 self.tableView.reloadData()
+
+                LeanplumIntegration.sharedInstance.track(eventName: .trackingProtectionSettings, withParameters: ["Enabled option": option.rawValue as AnyObject])
             })
         }
 
@@ -45,6 +47,8 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
                 self.currentBlockingStrength = option
                 self.prefs.setString(self.currentBlockingStrength.rawValue, forKey: ContentBlockerHelper.PrefKeyStrength)
                 self.tableView.reloadData()
+
+                LeanplumIntegration.sharedInstance.track(eventName: .trackingProtectionSettings, withParameters: ["Strength option": option.rawValue as AnyObject])
             })
         }
 


### PR DESCRIPTION
I assume I am using LeanPlum correctly. This screen has 2 options, one for the enabled state, and another for the blocking strength. I want events (and the user's option choice) for when either of those are changed.