### PR TITLE
Bug 1393466 - Make sure LP event for newTab is fired from TabTray.

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -1151,6 +1151,7 @@ extension TabTrayController: MenuActionDelegate {
                         self.SELdidTogglePrivateMode()
                     }
                     self.openNewTab()
+                    LeanplumIntegration.sharedInstance.track(eventName: .openedNewTab, withParameters: ["Source":"Tab Tray Menu" as AnyObject])
                 }
             case .openNewPrivateTab:
                 DispatchQueue.main.async {


### PR DESCRIPTION
@Sdaswani I changed the name for this event to "Tab Tray Menu" to differentiate between a regular "+" button new tab. 