### PR TITLE
Bug 1393729 - Change locale for germany in Leanplum to de_DE.

### DIFF
--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -51,7 +51,7 @@ enum UserAttributeKeyName: String {
 
 private enum SupportedLocales: String {
     case US = "en_US"
-    case DE = "de"
+    case DE = "de_DE"
     case UK = "en_GB"
     case CA_EN = "en_CA"
     case AU = "en_AU"


### PR DESCRIPTION
The key thing in the bug report is that both the region AND the language were changed. Resulting in a locale of `de_DE`