### PR TITLE
Bug 1392303: iOS 11 tableview swipe delete incorrectly enabled

### DIFF
--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -344,7 +344,7 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         // Intentionally blank. Required to use UITableViewRowActions
     }
 
-    func tableView(_ tableView: UITableView, editingStyleForRowAtIndexPath indexPath: IndexPath) -> UITableViewCellEditingStyle {
+    private func editingStyleforRow(atIndexPath indexPath: IndexPath) -> UITableViewCellEditingStyle {
         guard let source = source else {
             return .none
         }
@@ -361,9 +361,14 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         return .none
     }
 
+    func tableView(_ tableView: UITableView, editingStyleForRowAtIndexPath indexPath: IndexPath) -> UITableViewCellEditingStyle {
+        return editingStyleforRow(atIndexPath: indexPath)
+    }
+
     func tableView(_ tableView: UITableView, editActionsForRowAtIndexPath indexPath: IndexPath) -> [AnyObject]? {
-        guard let source = self.source else {
-            return [AnyObject]()
+        let editingStyle = editingStyleforRow(atIndexPath: indexPath)
+        guard let source = self.source, editingStyle == .delete else {
+            return nil
         }
 
         let title = NSLocalizedString("Delete", tableName: "BookmarkPanel", comment: "Action button for deleting bookmarks in the bookmarks panel.")


### PR DESCRIPTION
The fix is trivial and logical, which is to have
editingStyleForRowAtIndexPath and editActionsForRowAtIndexPath share
their logic. Previously we assumed that one trumped the other, which seemed
fair because that is how it always worked.