### PR TITLE
Bug 1394469 – Prevent reregistering with autopush if we're already registered

### DIFF
--- a/Client/Helpers/FxALoginHelper.swift
+++ b/Client/Helpers/FxALoginHelper.swift
@@ -272,6 +272,14 @@ class FxALoginHelper {
             return pushRegistrationDidFail()
         }
 
+        if let pushRegistration = account.pushRegistration {
+            // Currently, we don't support routine changing of push subscriptions
+            // then we can assume that if we've already registered with the
+            // push server, then we don't need to do it again.
+            _ = pushClient.updateUAID(apnsToken, withRegistration: pushRegistration)
+            return
+        }
+
         pushClient.register(apnsToken).upon { res in
             guard let pushRegistration = res.successValue else {
                 return self.pushRegistrationDidFail()


### PR DESCRIPTION
This PR fixes the problem where Leanplum and FxA race to register for APNS tokens.

When FxA gets there first, then the key material sent to the FxA is saved in the key chain. 

When LeanPlum (or subsequent tokens from Apple) comes again, then the stored key material is overwritten, but not given to the FxA servers.

This is fix changes the APNS token at the autopush end and then bails.

https://bugzilla.mozilla.org/show_bug.cgi?id=1394469