### PR TITLE
Bug 1395124 - Fix issue with first run and second run events in LP.

### DIFF
--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -131,9 +131,7 @@ class LeanplumIntegration {
         userAttributesDict[UserAttributeKeyName.pocketInstalled.rawValue] = !canInstallPocket()
         userAttributesDict[UserAttributeKeyName.signedInSync.rawValue] = profile?.hasAccount()
 
-        Leanplum.start(userAttributes: userAttributesDict)
-
-        Leanplum.onStartResponse({ _ in
+        Leanplum.start(withUserId: nil, userAttributes: userAttributesDict, responseHandler: { _ in
             self.track(eventName: LeanplumEventName.openedApp)
 
             // We need to check if the app is a clean install to use for

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2690,7 +2690,6 @@ extension BrowserViewController: IntroViewControllerDelegate {
                 introViewController.modalPresentationStyle = UIModalPresentationStyle.formSheet
             }
             present(introViewController, animated: true) {
-                self.profile.prefs.setInt(1, forKey: IntroViewControllerSeenProfileKey)
                 // On first run (and forced) open up the homepage in the background.
                 let state = self.getCurrentAppState()
                 if let homePageURL = HomePageAccessors.getHomePage(state), let tab = self.tabManager.selectedTab, DeviceInfo.hasConnectivity() {
@@ -2712,16 +2711,20 @@ extension BrowserViewController: IntroViewControllerDelegate {
         self.presentSignInViewController(fxaParams)
     }
 
-    func introViewControllerDidFinish(_ introViewController: IntroViewController) {
+    func introViewControllerDidFinish(_ introViewController: IntroViewController, requestToLogin: Bool) {
+        self.profile.prefs.setInt(1, forKey: IntroViewControllerSeenProfileKey)
         introViewController.dismiss(animated: true) { finished in
             if self.navigationController?.viewControllers.count ?? 0 > 1 {
                 _ = self.navigationController?.popToRootViewController(animated: true)
             }
             
-            guard let deeplink = self.profile.prefs.stringForKey("AdjustDeeplinkKey"), let url = URL(string: deeplink) else {
+            if let deeplink = self.profile.prefs.stringForKey("AdjustDeeplinkKey"), let url = URL(string: deeplink) {
+                self.launchFxAFromDeeplinkURL(url)
                 return
             }
-            self.launchFxAFromDeeplinkURL(url)
+            if requestToLogin {
+                self.presentSignInViewController()
+            }
         }
     }
 
@@ -2749,15 +2752,6 @@ extension BrowserViewController: IntroViewControllerDelegate {
         self.dismiss(animated: true, completion: nil)
     }
 
-    func introViewControllerDidRequestToLogin(_ introViewController: IntroViewController) {
-        introViewController.dismiss(animated: true, completion: { () -> Void in
-            guard let deeplink = self.profile.prefs.stringForKey("AdjustDeeplinkKey"), let url = URL(string: deeplink) else {
-                self.presentSignInViewController()
-                return
-            }
-            self.launchFxAFromDeeplinkURL(url)
-        })
-    }
 }
 
 extension BrowserViewController: FxAContentViewControllerDelegate {

--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -45,8 +45,7 @@ struct IntroViewControllerUX {
 let IntroViewControllerSeenProfileKey = "IntroViewControllerSeen"
 
 protocol IntroViewControllerDelegate: class {
-    func introViewControllerDidFinish(_ introViewController: IntroViewController)
-    func introViewControllerDidRequestToLogin(_ introViewController: IntroViewController)
+    func introViewControllerDidFinish(_ introViewController: IntroViewController, requestToLogin: Bool)
 }
 
 class IntroViewController: UIViewController, UIScrollViewDelegate {
@@ -271,7 +270,7 @@ class IntroViewController: UIViewController, UIScrollViewDelegate {
 
     func SELstartBrowsing() {
         LeanplumIntegration.sharedInstance.track(eventName: .dismissedOnboarding)
-        delegate?.introViewControllerDidFinish(self)
+        delegate?.introViewControllerDidFinish(self, requestToLogin: false)
     }
 
     func SELback() {
@@ -299,7 +298,7 @@ class IntroViewController: UIViewController, UIScrollViewDelegate {
     }
 
     func SELlogin() {
-		delegate?.introViewControllerDidRequestToLogin(self)
+        delegate?.introViewControllerDidFinish(self, requestToLogin: true)
     }
 
     fileprivate var accessibilityScrollStatus: String {


### PR DESCRIPTION
I think there are one of 2 issues happening here (maybe both)

1) Weird async issues with the LP start response block. Instead of calling `start` and then setting `onStartResponse` separately, call the initializer that lets you set both.
2) We set the Intro key to 1 as soon as we present the IntroController which is probably a few 100 ms before LP calls  `onStartResponse`. did a bit of refactoring here to make sure we set the `IntroIsShown` key to 1 after the intro has been dismissed.