### PR TITLE
Bug 1395664: Fix TP Settings so they apply on next page load,

### DIFF
--- a/Client/Frontend/ContentBlocker/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/ContentBlocker/ContentBlockerSettingViewController.swift
@@ -35,6 +35,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
                 self.currentEnabledState = option
                 self.prefs.setString(self.currentEnabledState.rawValue, forKey: ContentBlockerHelper.PrefKeyEnabledState)
                 self.tableView.reloadData()
+                ContentBlockerHelper.prefsChanged()
 
                 LeanplumIntegration.sharedInstance.track(eventName: .trackingProtectionSettings, withParameters: ["Enabled option": option.rawValue as AnyObject])
             })
@@ -47,6 +48,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
                 self.currentBlockingStrength = option
                 self.prefs.setString(self.currentBlockingStrength.rawValue, forKey: ContentBlockerHelper.PrefKeyStrength)
                 self.tableView.reloadData()
+                ContentBlockerHelper.prefsChanged()
 
                 LeanplumIntegration.sharedInstance.track(eventName: .trackingProtectionSettings, withParameters: ["Strength option": option.rawValue as AnyObject])
             })


### PR DESCRIPTION
instead of having to open a new tab (that was an accidental change I made in prev patch).

While in this code, do a cleanup of obvious items:
- rulestore is now non-optional (Apple API changed), and adding rules to tabs is simplified