### PR TITLE
Bug 1395174: new tab setting default state not shown

### DIFF
--- a/Client/Frontend/Browser/NewTabChoiceViewController.swift
+++ b/Client/Frontend/Browser/NewTabChoiceViewController.swift
@@ -52,6 +52,10 @@ class NewTabChoiceViewController: UITableViewController {
         super.viewWillAppear(animated)
         self.currentChoice = NewTabAccessors.getNewTabPage(prefs)
         self.hasHomePage = HomePageAccessors.getHomePage(prefs) != nil
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         tableView.reloadData()
     }
 


### PR DESCRIPTION
A table reload moved later in the setup will reflect the default state correctly