### PR TITLE
Bug 1396006 – Add MOZ_ENABLE_LEANPLUM feature flag.

### DIFF
--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -170,9 +170,6 @@ class LeanplumIntegration {
     // Events
 
     func track(eventName: LeanplumEventName) {
-        guard enabled else {
-            return
-        }
         DispatchQueue.main.async(execute: {
             if self.shouldSendToLP() {
                 Leanplum.track(eventName.rawValue)
@@ -181,9 +178,6 @@ class LeanplumIntegration {
     }
 
     func track(eventName: LeanplumEventName, withParameters parameters: [String: AnyObject]) {
-        guard enabled else {
-            return
-        }
         DispatchQueue.main.async(execute: {
             if self.shouldSendToLP() {
                 Leanplum.track(eventName.rawValue, withParameters: parameters)
@@ -232,9 +226,6 @@ class LeanplumIntegration {
     }
 
     func setUserAttributes(attributes: [AnyHashable : Any]) {
-        guard enabled else {
-            return
-        }
         DispatchQueue.main.async(execute: {
             if self.shouldSendToLP() {
                 Leanplum.setUserAttributes(attributes)

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -168,4 +168,17 @@ public struct AppConstants {
             return true
         #endif
     }()
+
+    /// Toggle the use of Leanplum.
+    public static let MOZ_ENABLE_LEANPLUM: Bool = {
+        #if MOZ_CHANNEL_RELEASE
+            return false
+        #elseif MOZ_CHANNEL_BETA
+            return false
+        #elseif MOZ_CHANNEL_FENNEC
+            return false
+        #else
+            return false
+        #endif
+    }()
 }


### PR DESCRIPTION
This PR introduces a feature flag to toggle Leanplum data collection. It is currently set to false, disabling the Leanplum feature.

This very deliberately is minimally invasive, so does not attempt to remove the Leanplum SDK. However, it prevents the Leanplum SDK from a) starting b) receiving user events c) reporting events to the server.

https://bugzilla.mozilla.org/show_bug.cgi?id=1396006