### PR TITLE
Bug 1395174: iOS 11 table cell text color can conflict with NSAttributedString color

### DIFF
--- a/Client/Extensions/NSAttributedStringExtensions.swift
+++ b/Client/Extensions/NSAttributedStringExtensions.swift
@@ -6,11 +6,8 @@ import Foundation
 
 // MARK: - Common UITableView text styling
 extension NSAttributedString {
-    static func tableRowTitle(_ string: String) -> NSAttributedString {
-        return NSAttributedString(string: string, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
-    }
-
-    static func disabledTableRowTitle(_ string: String) -> NSAttributedString {
-        return NSAttributedString(string: string, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewDisabledRowTextColor])
+    static func tableRowTitle(_ string: String, enabled: Bool) -> NSAttributedString {
+        let color = enabled ? [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor] : [NSForegroundColorAttributeName: UIConstants.TableViewDisabledRowTextColor]
+        return NSAttributedString(string: string, attributes: color)
     }
 }

--- a/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
+++ b/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
@@ -24,7 +24,7 @@ class TurnPasscodeOnSetting: Setting {
 
     init(settings: SettingsTableViewController, delegate: SettingsDelegate? = nil) {
         self.settings = settings as? AuthenticationSettingsViewController
-        super.init(title: NSAttributedString.tableRowTitle(AuthenticationStrings.turnOnPasscode),
+        super.init(title: NSAttributedString.tableRowTitle(AuthenticationStrings.turnOnPasscode, enabled: true),
                    delegate: delegate)
     }
 
@@ -40,7 +40,7 @@ class TurnPasscodeOffSetting: Setting {
 
     init(settings: SettingsTableViewController, delegate: SettingsDelegate? = nil) {
         self.settings = settings as? AuthenticationSettingsViewController
-        super.init(title: NSAttributedString.tableRowTitle(AuthenticationStrings.turnOffPasscode),
+        super.init(title: NSAttributedString.tableRowTitle(AuthenticationStrings.turnOffPasscode, enabled: true),
                    delegate: delegate)
     }
 
@@ -57,9 +57,7 @@ class ChangePasscodeSetting: Setting {
     init(settings: SettingsTableViewController, delegate: SettingsDelegate? = nil, enabled: Bool) {
         self.settings = settings as? AuthenticationSettingsViewController
 
-        let attributedTitle: NSAttributedString = enabled ?
-            NSAttributedString.tableRowTitle(AuthenticationStrings.changePasscode) :
-            NSAttributedString.disabledTableRowTitle(AuthenticationStrings.changePasscode)
+        let attributedTitle: NSAttributedString = NSAttributedString.tableRowTitle(AuthenticationStrings.changePasscode, enabled: enabled)
 
         super.init(title: attributedTitle,
                    delegate: delegate,
@@ -86,7 +84,7 @@ class RequirePasscodeSetting: Setting {
         // Only show the interval if we are enabled and have an interval set.
         let authenticationInterval = KeychainWrapper.sharedAppContainerKeychain.authenticationInfo()
         if let interval = authenticationInterval?.requiredPasscodeInterval, enabled {
-            return NSAttributedString.disabledTableRowTitle(interval.settingTitle)
+            return NSAttributedString.tableRowTitle(interval.settingTitle, enabled: false)
         }
         return NSAttributedString(string: "")
     }
@@ -96,7 +94,7 @@ class RequirePasscodeSetting: Setting {
         self.settings = settings as? AuthenticationSettingsViewController
 
         let title = AuthenticationStrings.requirePasscode
-        let attributedTitle = (enabled ?? true) ? NSAttributedString.tableRowTitle(title) : NSAttributedString.disabledTableRowTitle(title)
+        let attributedTitle = NSAttributedString.tableRowTitle(title, enabled: enabled ?? true)
         super.init(title: attributedTitle,
                    delegate: delegate,
                    enabled: enabled)
@@ -265,7 +263,7 @@ class AuthenticationSettingsViewController: SettingsTableViewController {
             requirePasscodeSectionChildren.append(
                 TouchIDSetting(
                     title: NSAttributedString.tableRowTitle(
-                        NSLocalizedString("Use Touch ID", tableName:  "AuthenticationManager", comment: "List section title for when to use Touch ID")
+                        NSLocalizedString("Use Touch ID", tableName:  "AuthenticationManager", comment: "List section title for when to use Touch ID"), enabled: true
                     ),
                     navigationController: self.navigationController,
                     delegate: nil,

--- a/Client/Frontend/AuthenticationManager/RequirePasscodeIntervalViewController.swift
+++ b/Client/Frontend/AuthenticationManager/RequirePasscodeIntervalViewController.swift
@@ -59,7 +59,7 @@ class RequirePasscodeIntervalViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: BasicCheckmarkCell, for: indexPath)
         let option = intervalOptions[indexPath.row]
-        let intervalTitle = NSAttributedString.tableRowTitle(option.settingTitle)
+        let intervalTitle = NSAttributedString.tableRowTitle(option.settingTitle, enabled: true)
         cell.textLabel?.attributedText = intervalTitle
         cell.accessoryType = authenticationInfo?.requiredPasscodeInterval == option ? .checkmark : .none
         return cell

--- a/Client/Frontend/Browser/NewTabChoiceViewController.swift
+++ b/Client/Frontend/Browser/NewTabChoiceViewController.swift
@@ -64,13 +64,10 @@ class NewTabChoiceViewController: UITableViewController {
         let cell = tableView.dequeueReusableCell(withIdentifier: BasicCheckmarkCell, for: indexPath)
 
         let option = newTabOptions[indexPath.row]
-        cell.textLabel?.attributedText = NSAttributedString.tableRowTitle(option.settingTitle)
-
-        cell.accessoryType = (currentChoice == option) ? .checkmark : .none
-
         let enabled = (option != .homePage) || hasHomePage
 
-        cell.textLabel?.textColor = enabled ? UIConstants.TableViewRowTextColor : UIConstants.TableViewDisabledRowTextColor
+        cell.accessoryType = (currentChoice == option) ? .checkmark : .none
+        cell.textLabel?.attributedText = NSAttributedString.tableRowTitle(option.settingTitle, enabled: enabled)
         cell.isUserInteractionEnabled = enabled
 
         return cell

--- a/Client/Frontend/Browser/OpenWithSettingsViewController.swift
+++ b/Client/Frontend/Browser/OpenWithSettingsViewController.swift
@@ -105,10 +105,8 @@ class OpenWithSettingsViewController: UITableViewController {
 
         let option = mailProviderSource[indexPath.row]
 
-        cell.textLabel?.attributedText = NSAttributedString.tableRowTitle(option.name)
+        cell.textLabel?.attributedText = NSAttributedString.tableRowTitle(option.name, enabled: option.enabled)
         cell.accessoryType = (currentChoice == option.scheme && option.enabled) ? .checkmark : .none
-
-        cell.textLabel?.textColor = option.enabled ? UIConstants.TableViewRowTextColor : UIConstants.TableViewDisabledRowTextColor
         cell.isUserInteractionEnabled = option.enabled
 
         return cell


### PR DESCRIPTION
In cellForRowAt we are setting the cell.textLabel.color and the color attribute on NSAttributedString in some cases, and because of enabled/disabled styling we are setting them differently. 
On iOS 11 we see that the latter is trumping during first creation, and then on cell reuse the former is applied.

The fix is easy. But to protect against future misuse, I am changing our utility function for getting
table row text to force the developer to decide if you want the enabled or disabled color.
If they then go and combine this with cell.textLabel.color, well, good luck to them.