### PR TITLE
Bug 1343231 — After closing a tab, go to the most recently loaded.

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -384,10 +384,26 @@ class TabManager: NSObject {
 
         let viableTabs: [Tab] = tab.isPrivate ? privateTabs : normalTabs
 
-        //If the last item was deleted then select the last tab. Otherwise the _selectedIndex is already correct
+        // Let's select the tab to be selected next.
         if let oldTab = oldSelectedTab, tab !== oldTab {
+            // If it wasn't the selected tab we removed, then keep it like that.
+            // It might have changed index, so we look it up again.
             _selectedIndex = tabs.index(of: oldTab) ?? -1
+        } else if let newTab = viableTabs.reduce(viableTabs.first, { currentBestTab, tab2 in
+            if let tab1 = currentBestTab, let time1 = tab1.lastExecutedTime {
+                if let time2 = tab2.lastExecutedTime {
+                    return time1 <= time2 ? tab2 : tab1
+                }
+                return tab1
+            } else {
+                return tab2
+            }
+        }), tab !== newTab, newTab.lastExecutedTime != nil {
+            // Next we look for the most recently loaded one. It might not exist, of course.
+            _selectedIndex = tabs.index(of: newTab) ?? -1
         } else {
+            // By now, we've just removed the selected one, and no previously loaded
+            // tabs. So let's load the final one in the tab tray.
             if tabIndex == viableTabs.count {
                 tabIndex -= 1
             }

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -272,6 +272,46 @@ class TabManagerTests: XCTestCase {
         delegate.verify("Not all delegate methods were called")
     }
 
+    func testDeleteSelectedTab() {
+        let profile = TabManagerMockProfile()
+        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let delegate = MockTabManagerDelegate()
+
+        func addTab(_ load: Bool) -> Tab {
+            let tab = manager.addTab()
+            if load {
+                tab.lastExecutedTime = Date.now()
+            }
+            return tab
+        }
+
+        let tab0 = addTab(false) // not loaded
+        let tab1 = addTab(true)
+        let tab2 = addTab(true)
+        let tab3 = addTab(false) // not loaded
+        let tab4 = addTab(true)
+
+        // starting at tab2, we should be selecting
+        // [ tab4, tab1, tab3, tab0 ]
+
+        manager.selectTab(tab2)
+        manager.removeTab(manager.selectedTab!)
+        // Rule: most recently loaded.
+        XCTAssertEqual(manager.selectedTab, tab4)
+
+        manager.removeTab(manager.selectedTab!)
+        // Rule: most recently loaded.
+        XCTAssertEqual(manager.selectedTab, tab1)
+
+        manager.removeTab(manager.selectedTab!)
+        // Rule: next to the right.
+        XCTAssertEqual(manager.selectedTab, tab3)
+
+        manager.removeTab(manager.selectedTab!)
+        // Rule: last one left.
+        XCTAssertEqual(manager.selectedTab, tab0)
+    }
+
     func testDeleteLastTab() {
         let profile = TabManagerMockProfile()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)


### PR DESCRIPTION
This uses `lastExecutedTime`, but falls back to the previous behavior if no tab with `lastExecutedTime` is available.

https://bugzilla.mozilla.org/show_bug.cgi?id=1343231