### PR TITLE
Bug 1396923 - Cache the FaviconFetcher's multi region domain list.

### DIFF
--- a/Client/Utils/FaviconFetcher.swift
+++ b/Client/Utils/FaviconFetcher.swift
@@ -40,14 +40,15 @@ open class FaviconFetcher: NSObject, XMLParserDelegate {
         return FaviconFetcher.getDefaultIcons()
     }()
 
-    static var multiRegionDomains: [String] = []
+    static let multiRegionDomains = ["craigslist", "google", "amazon"]
 
     class func getDefaultIconForURL(url: URL) -> (color: UIColor, url: String)? {
+        
         // Problem: Sites like amazon exist with .ca/.de and many other tlds.
         // Solution: They are stored in the default icons list as "amazon" instead of "amazon.com" this allows us to have favicons for every tld."
         // Here, If the site is in the multiRegionDomain array look it up via its second level domain (amazon) instead of its baseDomain (amazon.com)
         let hostName = url.hostSLD
-        if FaviconFetcher.multiRegionDomains.contains(hostName), let icon = defaultIcons[hostName] {
+        if multiRegionDomains.contains(hostName), let icon = defaultIcons[hostName] {
             return icon
         }
         if let name = url.baseDomain, let icon = defaultIcons[name] {
@@ -300,9 +301,6 @@ open class FaviconFetcher: NSObject, XMLParserDelegate {
         json.forEach({
             guard let url = $0.1["domain"].string, let color = $0.1["background_color"].string, var path = $0.1["image_url"].string else {
                 return
-            }
-            if $0.1["is_multi_region_domain"].string == "true" {
-                FaviconFetcher.multiRegionDomains.append(url)
             }
             path = path.replacingOccurrences(of: ".png", with: "")
             let filePath = Bundle.main.path(forResource: "TopSites/" + path, ofType: "png")


### PR DESCRIPTION
The list of default favicons is based off of the Alexa top 500. This list doesn't change often. And from this list the number of sites with multiple domains are small. Instead lets just use a static list. 

This fixes a intermittent test failure because we now always have the list of `multiRegionDomains`