### PR TITLE
Bug 1397357 - Workaround: upload empty POST bodies as JSON, not newlines.

### DIFF
--- a/Sync/StorageClient.swift
+++ b/Sync/StorageClient.swift
@@ -480,6 +480,12 @@ open class Sync15StorageClient {
     }
 
     func requestPOST(_ url: URL, body: [String], ifUnmodifiedSince: Timestamp?) -> Request {
+        // Workaround for Bug 1397357 -- the Sync server rejects empty newlines POST payloads.
+        // Send them as empty JSON instead.
+        if body.isEmpty {
+            return self.requestWrite(url, method: URLRequest.Method.post.rawValue, body: "[]", contentType: "application/json", ifUnmodifiedSince: ifUnmodifiedSince)
+        }
+
         let content = body.joined(separator: "\n")
         return self.requestWrite(url, method: URLRequest.Method.post.rawValue, body: content, contentType: "application/newlines", ifUnmodifiedSince: ifUnmodifiedSince)
     }


### PR DESCRIPTION
Here's a trivial workaround that might be enough. @gkruglov and bobm didn't find any errors from Android empty uploads, which are sent as JSON, so we can try this.