### PR TITLE
Bug 1382777 - Fix unverified account not going to verify screen

### DIFF
--- a/Client/Helpers/FxALoginHelper.swift
+++ b/Client/Helpers/FxALoginHelper.swift
@@ -132,12 +132,6 @@ class FxALoginHelper {
     // It manages the asking for user permission for notification and registration 
     // for APNS and WebPush notifications.
     func application(_ application: UIApplication, didReceiveAccountJSON data: JSON) {
-        if data["keyFetchToken"].stringValue() == nil || data["unwrapBKey"].stringValue() == nil {
-            // The /settings endpoint sends a partial "login"; ignore it entirely.
-            log.error("Ignoring didSignIn with keyFetchToken or unwrapBKey missing.")
-            return self.loginDidFail()
-        }
-
         assert(profile != nil, "Profile should still exist and be loaded into this FxAPushLoginStateMachine")
 
         guard let profile = profile,


### PR DESCRIPTION
This PR fixes an issue where tapping an unverified account in the FxA iOS settings would not transition to the FxA webview.

Connects with https://github.com/mozilla/fxa-bugzilla-mirror/issues/338