### PR TITLE
Bug 1394786: action extension UTI needs to be public.url

### DIFF
--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -107,12 +107,7 @@ extension ShareExtensionHelper: UIActivityItemSource {
     }
 
     func activityViewController(_ activityViewController: UIActivityViewController, dataTypeIdentifierForActivityType activityType: UIActivityType?) -> String {
-        //for these customDataID's load the default public.url because they don't seem to work properly with the 1Password UTI.
-        if let type = activityType, customDataTypeIdentifers.contains(type.rawValue) {
-            return "public.url"
-        }
-        // Because of our UTI declaration, this UTI now satisfies both the 1Password Extension and the usual NSURL for Share extensions.
-        return "org.appextension.fill-browser-action"
+        return "public.url"
     }
 }
 


### PR DESCRIPTION
As of iOS11 we are getting this error reported when tapping extensions that
share the URL:
`Cannot load representation of type org.appextension.fill-browser-action`
There are 2 types of UTI we report: `org.appextension.fill-browser-action` and
`public.url`.
For some reason we returned the former in nearly all cases (not sure why, maybe
a legacy reason). I expect just 3rd party password manager extensions would need that.
If itemForActivityType is changed to always return public.url, it works on iOS
10 and 11, and pw extensions still work ok.