### PR TITLE
Bug 1398143: TP settings tableview now .grouped (fix footer pinning)

### DIFF
--- a/Client/Frontend/ContentBlocker/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/ContentBlocker/ContentBlockerSettingViewController.swift
@@ -18,7 +18,8 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
         currentEnabledState = ContentBlockerHelper.EnabledState(rawValue: prefs.stringForKey(ContentBlockerHelper.PrefKeyEnabledState) ?? "") ?? .onInPrivateBrowsing
         currentBlockingStrength = ContentBlockerHelper.BlockingStrength(rawValue: prefs.stringForKey(ContentBlockerHelper.PrefKeyStrength) ?? "") ?? .basic
         
-        super.init(nibName: nil, bundle: nil)
+        super.init(style: .grouped)
+
         self.title = Strings.SettingsTrackingProtectionSectionName
         hasSectionSeparatorLine = false
     }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1398143

The default .plain style will pin headers/footers as you scroll, we want them to behave more like regular cells. Table view .grouped style fixes this, and I see no other visual change.