### PR TITLE
Bug 1392752: tracking protection status added to core ping

### DIFF
--- a/Client/Telemetry/CorePing.swift
+++ b/Client/Telemetry/CorePing.swift
@@ -94,6 +94,15 @@ class CorePing: TelemetryPing {
             out["defaultMailClient"] = chosenEmailClient as AnyObject?
         }
 
+        if #available(iOS 11.0, *) {
+            if let strength = prefs.stringForKey(ContentBlockerHelper.PrefKeyStrength) {
+                out["trackingProtectionStrength"] = strength as AnyObject?
+            }
+            if let enabled = prefs.stringForKey(ContentBlockerHelper.PrefKeyEnabledState) {
+                out["trackingProtectionEnabled"] = enabled as AnyObject?
+            }
+        }
+
         payload = JSON(out)
     }
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1392752

Most interesting thing will be to see how many users even touch this setting, so we can send an unchanged state to indicate this.