### PR TITLE
Bug 1398151: Tracking Protection settings: 2nd footer to a More Info link

### DIFF
--- a/Client/Frontend/ContentBlocker/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/ContentBlocker/ContentBlockerSettingViewController.swift
@@ -6,7 +6,38 @@ import Foundation
 import Shared
 
 @available(iOS 11.0, *)
-class ContentBlockerSettingViewController: SettingsTableViewController {
+class ContentBlockerSettingsTableView : SettingsTableViewController {
+    // The first section header gets a More Info link
+    override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        if section == 0 {
+            return super.tableView(tableView, viewForFooterInSection: section)
+        }
+
+        // TODO: Get a dedicated string for this.
+        let title = NSLocalizedString("More Info…", tableName: "SendAnonymousUsageData", comment: "Re-using more info label from 'anonymous usage data' item for showing a 'More Info' link on the Tracking Protection settings screen.")
+
+        var attributes = [String: AnyObject]()
+        attributes[NSFontAttributeName] = UIFont.systemFont(ofSize: 12, weight: UIFontWeightRegular)
+        attributes[NSForegroundColorAttributeName] = UIConstants.HighlightBlue
+
+        let button = UIButton()
+        button.setAttributedTitle(NSAttributedString(string: title, attributes: attributes), for: .normal)
+        button.contentHorizontalAlignment = .left
+        // Top and left insets are needed to match the table row style.
+        button.contentEdgeInsets = UIEdgeInsetsMake(8, 16, 0, 0)
+        button.addTarget(self, action: #selector(ContentBlockerSettingsTableView.moreInfoTapped), for: .touchUpInside)
+        return button
+    }
+
+    func moreInfoTapped() {
+        let viewController = SettingsContentViewController()
+        viewController.url = SupportUtils.URLForTopic("tracking-protection-ios")
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
+@available(iOS 11.0, *)
+class ContentBlockerSettingViewController: ContentBlockerSettingsTableView {
     let prefs: Prefs
     let EnabledStates = ContentBlockerHelper.EnabledState.allOptions
     let BlockingStrengths = ContentBlockerHelper.BlockingStrength.allOptions
@@ -57,8 +88,10 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
 
         let firstSection = SettingSection(title: NSAttributedString(string: Strings.TrackingProtectionOptionOnOffHeader), footerTitle: NSAttributedString(string: Strings.TrackingProtectionOptionOnOffFooter), children: enabledSetting)
 
+        // The bottom of the block lists section has a More Info button, implemented as a custom footer view,
+        // SettingSection needs footerTitle set to create a footer, which we then override the view for.
         let blockListsTitle = Strings.TrackingProtectionOptionBlockListsTitle
-        let secondSection = SettingSection(title: NSAttributedString(string: blockListsTitle), footerTitle: NSAttributedString(string: Strings.TrackingProtectionOptionFooter), children: strengthSetting)
+        let secondSection = SettingSection(title: NSAttributedString(string: blockListsTitle), footerTitle: NSAttributedString(string: "placeholder replaced with UIButton"), children: strengthSetting)
         return [firstSection, secondSection]
     }
 }

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -385,8 +385,6 @@ extension Strings {
     public static let TrackingProtectionOptionBlockListTypeBasicDescription = NSLocalizedString("Settings.TrackingProtectionOption.BlockListBasicDescription", value: "Allows some trackers so websites function properly.", comment: "Tracking protection settings option description for using the basic blocklist.")
     public static let TrackingProtectionOptionBlockListTypeStrict = NSLocalizedString("Settings.TrackingProtectionOption.BlockListStrict", value: "Strict", comment: "Tracking protection settings option for using the strict blocklist.")
     public static let TrackingProtectionOptionBlockListTypeStrictDescription = NSLocalizedString("Settings.TrackingProtectionOption.BlockListStrictDescription", value: "Blocks known trackers. Some websites may not function properly.", comment: "Tracking protection settings option description for using the strict blocklist.")
-
-    public static let TrackingProtectionOptionFooter = NSLocalizedString("Settings.TrackingProtectionOption.BlockListTypeFooter", value: "You can choose which list Firefox will use to block Web elements that may track your browsing activity.", comment: "Description label shown at bottom of tracking protection options for which Block List to use")
 }
 
 // Do not track 


### PR DESCRIPTION
We have no dedicated More Info string for this view, however
there is an existing More Info label we can steal until we add
strings for 9.1.

https://bugzilla.mozilla.org/show_bug.cgi?id=1398151