### PR TITLE
 Bug 1398924: CorePing: use single out["settings"] = dict-of-settings

### DIFF
--- a/Client/Telemetry/CorePing.swift
+++ b/Client/Telemetry/CorePing.swift
@@ -85,23 +85,27 @@ class CorePing: TelemetryPing {
             out["searches"] = searches
             SearchTelemetry.resetCount(profile.prefs)
         }
+        
+        var settingsDict = [String: Any]()
 
         if let newTabChoice = self.prefs.stringForKey(NewTabAccessors.PrefKey) {
-            out["defaultNewTabExperience"] = newTabChoice as AnyObject?
+            settingsDict["defaultNewTabExperience"] = newTabChoice as AnyObject?
         }
 
         if let chosenEmailClient = self.prefs.stringForKey(PrefsKeys.KeyMailToOption) {
-            out["defaultMailClient"] = chosenEmailClient as AnyObject?
+            settingsDict["defaultMailClient"] = chosenEmailClient as AnyObject?
         }
 
         if #available(iOS 11.0, *) {
             if let strength = prefs.stringForKey(ContentBlockerHelper.PrefKeyStrength) {
-                out["trackingProtectionStrength"] = strength as AnyObject?
+                settingsDict["trackingProtectionStrength"] = strength as AnyObject?
             }
             if let enabled = prefs.stringForKey(ContentBlockerHelper.PrefKeyEnabledState) {
-                out["trackingProtectionEnabled"] = enabled as AnyObject?
+                settingsDict["trackingProtectionEnabled"] = enabled as AnyObject?
             }
         }
+
+        out["settings"] = settingsDict
 
         payload = JSON(out)
     }


### PR DESCRIPTION
Telemetry peers recommend using this form as it requires
no schema change when new settings added to ping

https://bugzilla.mozilla.org/show_bug.cgi?id=1398924