### PR TITLE
Bug 1399056: TP Settings cells appear selected after tap

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -327,6 +327,7 @@ class CheckmarkSetting: Setting {
     override func onConfigureCell(_ cell: UITableViewCell) {
         super.onConfigureCell(cell)
         cell.accessoryType = isEnabled() ? .checkmark : .none
+        cell.selectionStyle = .none
     }
 
     override func onClick(_ navigationController: UINavigationController?) {


### PR DESCRIPTION
Set the selection style to none

https://bugzilla.mozilla.org/show_bug.cgi?id=1399056