### PR TITLE
Bug 1262566 - Disable sync when offline

### DIFF
--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -102,6 +102,16 @@ class SyncNowSetting: WithAccountSetting {
     }()
 
     fileprivate var syncNowTitle: NSAttributedString {
+        if !DeviceInfo.hasConnectivity() {
+            return NSAttributedString(
+                string: Strings.FxANoInternetConnection,
+                attributes: [
+                    NSForegroundColorAttributeName: UIColor.red,
+                    NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultMediumFont
+                ]
+            )
+        }
+        
         return NSAttributedString(
             string: NSLocalizedString("Sync Now", comment: "Sync Firefox Account"),
             attributes: [
@@ -177,6 +187,10 @@ class SyncNowSetting: WithAccountSetting {
     }
 
     override var enabled: Bool {
+        if !DeviceInfo.hasConnectivity() {
+            return false
+        }
+
         return profile.hasSyncableAccount()
     }
 
@@ -243,7 +257,7 @@ class SyncNowSetting: WithAccountSetting {
             cell.accessoryView = nil
         }
         cell.accessoryType = accessoryType
-        cell.isUserInteractionEnabled = !profile.syncManager.isSyncing
+        cell.isUserInteractionEnabled = !profile.syncManager.isSyncing && DeviceInfo.hasConnectivity()
         
         if AppConstants.MOZ_SHOW_FXA_AVATAR {
             // Animation that loops continously until stopped
@@ -278,6 +292,10 @@ class SyncNowSetting: WithAccountSetting {
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
+        if !DeviceInfo.hasConnectivity() {
+            return
+        }
+        
         NotificationCenter.default.post(name: Notification.Name(rawValue: SyncNowSetting.NotificationUserInitiatedSyncManually), object: nil)
         profile.syncManager.syncEverything(why: .syncNow)
     }


### PR DESCRIPTION
From https://bugzilla.mozilla.org/show_bug.cgi?id=1262566, this PR gives the user an indication that they are offline and can not sync.


<img width="333" alt="screen shot 2017-09-12 at 3 35 54 pm" src="https://user-images.githubusercontent.com/1295288/30345377-da877c82-97d2-11e7-98fe-c15ebaf874a4.png">

Connects with https://github.com/mozilla/fxa-bugzilla-mirror/issues/306