### PR TITLE
Bug 1395003 - Add a 4px highlight when the URL bar is active

### DIFF
--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -231,9 +231,8 @@ class TabLocationView: UIView {
             urlTextField.text = url?.absoluteString
         }
         // remove https:// (the scheme) from the url when displaying
-        if let scheme = url?.scheme {
-            let schemeString = "\(scheme)://"
-            urlTextField.text = url?.absoluteString.replacingOccurrences(of: schemeString, with: "")
+        if let scheme = url?.scheme, let range = url?.absoluteString.range(of: "\(scheme)://") {
+            urlTextField.text = url?.absoluteString.replacingCharacters(in: range, with: "")
         }
     }
 }

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -23,6 +23,7 @@ struct TabLocationViewUX {
     static let HostFontColor = UIColor.black
     static let BaseURLFontColor = UIColor.gray
     static let LocationContentInset = 8
+    static let URLBarPadding = 4
 
     static let Themes: [String: Theme] = {
         var themes = [String: Theme]()
@@ -31,14 +32,14 @@ struct TabLocationViewUX {
         theme.textColor = UIColor(rgb: 0xf9f9fa)
         theme.highlightButtonColor = UIConstants.PrivateModePurple
         theme.buttonTintColor = UIColor(rgb: 0xf9f9fa)
-        theme.backgroundColor = UIConstants.PrivateModeLocationBackgroundColor
+        theme.backgroundColor = UIColor(rgb: 0x636369)
         themes[Theme.PrivateMode] = theme
 
         theme = Theme()
         theme.textColor = UIColor(rgb: 0x27)
         theme.highlightButtonColor = UIColor(rgb: 0x00A2FE)
-        theme.buttonTintColor = UIColor(rgb: 0x272727)
-        theme.backgroundColor = UIConstants.locationBarBG
+        theme.buttonTintColor = UIColor(rgb: 0x737373)
+        theme.backgroundColor = .white
         themes[Theme.NormalMode] = theme
 
         return themes
@@ -186,13 +187,13 @@ class TabLocationView: UIView {
             if lockImageView.isHidden {
                 make.leading.equalTo(self).offset(TabLocationViewUX.LocationContentInset)
             } else {
-                make.leading.equalTo(self.lockImageView.snp.trailing).offset(9)
+                make.leading.equalTo(self.lockImageView.snp.trailing).offset(TabLocationViewUX.URLBarPadding)
             }
 
             if readerModeButton.isHidden {
-                make.trailing.equalTo(self).offset(-TabLocationViewUX.LocationContentInset)
+                make.trailing.equalTo(self).inset(TabLocationViewUX.LocationContentInset)
             } else {
-                make.trailing.equalTo(self.readerModeButton.snp.leading)
+                make.trailing.equalTo(self.readerModeButton.snp.leading).inset(TabLocationViewUX.URLBarPadding)
             }
         }
 
@@ -228,6 +229,11 @@ class TabLocationView: UIView {
             urlTextField.text = url?.absoluteString.replacingOccurrences(of: host, with: host.asciiHostToUTF8())
         } else {
             urlTextField.text = url?.absoluteString
+        }
+        // remove https:// (the scheme) from the url when displaying
+        if let scheme = url?.scheme {
+            let schemeString = "\(scheme)://"
+            urlTextField.text = url?.absoluteString.replacingOccurrences(of: schemeString, with: "")
         }
     }
 }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -342,7 +342,7 @@ class URLBarView: UIView {
         locationTextField = ToolbarTextField()
 
         guard let locationTextField = locationTextField else { return }
-        
+
         locationTextField.translatesAutoresizingMaskIntoConstraints = false
         locationTextField.autocompleteDelegate = self
         locationTextField.keyboardType = UIKeyboardType.webSearch
@@ -358,7 +358,7 @@ class URLBarView: UIView {
         locationTextField.snp.remakeConstraints { make in
             make.edges.equalTo(self.locationView)
         }
-        
+
         locationTextField.applyTheme(currentTheme)
     }
 


### PR DESCRIPTION
Also 
- I removed the url scheme (http) when displaying the urlBar. (The lock lets you know if its secure)
- Added a 1px border to the urlbar when not active. 
- A new subtle shadow that appears outside of the textfield.

This is more complicated than it needs to be because the border needs to be drawn _outside_ the urlbar. So simply using view.borderwidth = 4 doesn't work. 🤷‍♂️ 
I'm using a containerview outside of the textfield and then insetting the textfield by the borderwidth.

ps: The UIColors are all over the place. There is a separate bug for that. I want to land all the colors and then figure out how I can abstract away the UIColor code from the views.