### PR TITLE
Revert Bug 1392752: tracking protection status added to core ping 

### DIFF
--- a/Client/Telemetry/CorePing.swift
+++ b/Client/Telemetry/CorePing.swift
@@ -94,15 +94,6 @@ class CorePing: TelemetryPing {
             out["defaultMailClient"] = chosenEmailClient as AnyObject?
         }
 
-        if #available(iOS 11.0, *) {
-            if let strength = prefs.stringForKey(ContentBlockerHelper.PrefKeyStrength) {
-                out["trackingProtectionStrength"] = strength as AnyObject?
-            }
-            if let enabled = prefs.stringForKey(ContentBlockerHelper.PrefKeyEnabledState) {
-                out["trackingProtectionEnabled"] = enabled as AnyObject?
-            }
-        }
-
         payload = JSON(out)
     }
 }


### PR DESCRIPTION
This reverts commit 587b386fd434084a3f96567fe36656197c9fd933.