### PR TITLE
Bug 1372570 – Make NightMode affect the whole screen.

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -42,8 +42,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
 
     var openInFirefoxParams: LaunchParams?
 
-    var systemBrightness: CGFloat = UIScreen.main.brightness
-    
     var receivedURLs: [URL]?
 
     @discardableResult func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {

--- a/Client/Assets/NightModeHelper.js
+++ b/Client/Assets/NightModeHelper.js
@@ -24,7 +24,7 @@ Object.defineProperty(window.__firefox__, 'NightMode', {
 var className = "__firefox__NightMode";
 
 function initializeStyleSheet() {
-  var nightCSS = 'html{-webkit-filter:brightness(50%) !important;}';
+  var nightCSS = 'html{-webkit-filter:contrast(200%) !important;}';
   var newCss = document.getElementById(className);
   if (!newCss) {
     var cssStyle = document.createElement("style");

--- a/Client/Frontend/Browser/NightModeHelper.swift
+++ b/Client/Frontend/Browser/NightModeHelper.swift
@@ -15,6 +15,8 @@ class NightModeHelper: TabHelper {
 
     fileprivate weak var tab: Tab?
 
+    static var systemBrightness = UIScreen.main.brightness
+
     required init(tab: Tab) {
         self.tab = tab
         if let path = Bundle.main.path(forResource: "NightModeHelper", ofType: "js"), let source = try? NSString(contentsOfFile: path, encoding: String.Encoding.utf8.rawValue) as String {
@@ -36,17 +38,16 @@ class NightModeHelper: TabHelper {
     }
 
     static func setNightModeBrightness(_ prefs: Prefs, enabled: Bool) {
-        let nightModeBrightness: CGFloat = min(0.2, CGFloat(UIScreen.main.brightness))
+        let nightModeBrightness: CGFloat
         if enabled {
-            if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-                appDelegate.systemBrightness = CGFloat(UIScreen.main.brightness)
-            }
-            UIScreen.main.brightness = nightModeBrightness
+            systemBrightness = CGFloat(UIScreen.main.brightness)
+            nightModeBrightness = min(0.1, CGFloat(UIScreen.main.brightness))
         } else {
-            if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-                UIScreen.main.brightness = appDelegate.systemBrightness
-            }
+            nightModeBrightness = systemBrightness
         }
+        UIView.animate(withDuration: 1.0, animations: {
+            UIScreen.main.brightness = nightModeBrightness
+        })
     }
 
     static func restoreNightModeBrightness(_ prefs: Prefs, toForeground: Bool) {
@@ -54,9 +55,7 @@ class NightModeHelper: TabHelper {
         if isNightMode {
             NightModeHelper.setNightModeBrightness(prefs, enabled: toForeground)
         } else {
-            if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-                appDelegate.systemBrightness = UIScreen.main.brightness
-            }
+            systemBrightness = UIScreen.main.brightness
         }
     }
 


### PR DESCRIPTION
This PR tidies up NightMode, and moves the tab un-brightening to the main Screen.

At the same time, it increases the contrast in the tab to 200%.

It does not work on the simulator, so proposes that we remove the option from the menu, or better yet, grey it out.

Follow up bugs 

 – integrate night mode in to the photon themes.
 – animate the screen brightening and unbrightening.

https://bugzilla.mozilla.org/show_bug.cgi?id=1372570