### PR TITLE
Bug 1398924: CorePing: single prefs dict, not each pref at top-level

### DIFF
--- a/Client/Telemetry/CorePing.swift
+++ b/Client/Telemetry/CorePing.swift
@@ -85,23 +85,27 @@ class CorePing: TelemetryPing {
             out["searches"] = searches
             SearchTelemetry.resetCount(profile.prefs)
         }
+        
+        var prefsDict = [String: Any]()
 
         if let newTabChoice = self.prefs.stringForKey(NewTabAccessors.PrefKey) {
-            out["defaultNewTabExperience"] = newTabChoice as AnyObject?
+            prefsDict["defaultNewTabExperience"] = newTabChoice as AnyObject?
         }
 
         if let chosenEmailClient = self.prefs.stringForKey(PrefsKeys.KeyMailToOption) {
-            out["defaultMailClient"] = chosenEmailClient as AnyObject?
+            prefsDict["defaultMailClient"] = chosenEmailClient as AnyObject?
         }
 
         if #available(iOS 11.0, *) {
             if let strength = prefs.stringForKey(ContentBlockerHelper.PrefKeyStrength) {
-                out["trackingProtectionStrength"] = strength as AnyObject?
+                prefsDict["trackingProtectionStrength"] = strength as AnyObject?
             }
             if let enabled = prefs.stringForKey(ContentBlockerHelper.PrefKeyEnabledState) {
-                out["trackingProtectionEnabled"] = enabled as AnyObject?
+                prefsDict["trackingProtectionEnabled"] = enabled as AnyObject?
             }
         }
+
+        out["preferences"] = prefsDict
 
         payload = JSON(out)
     }


### PR DESCRIPTION
Telemetry peers recommend using this form as it requires
no schema change when new settings added to ping