### PR TITLE
Bug 1382561 — Start syncing after verification

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -404,14 +404,19 @@ class AccountSetting: Setting, FxAContentViewControllerDelegate {
     override var accessoryType: UITableViewCellAccessoryType { return .none }
 
     func contentViewControllerDidSignIn(_ viewController: FxAContentViewController, withFlags flags: FxALoginFlags) {
-        // Reload the data to reflect the new Account immediately.
-        settings.tableView.reloadData()
-        // And start advancing the Account state in the background as well.
-        settings.SELrefresh()
-
-        // Dismiss the FxA content view if the account is verified.
+        // This method will get called twice: once when the user signs in, and once
+        // when the account is verified by email – on this device or another.
+        // If the user hasn't dismissed the fxa content view controller,
+        // then we should only do that (thus finishing the sign in/verification process)
+        // once the account is verified.
+        // By the time we get to here, we should be syncing or just about to sync in the
+        // background, most likely from FxALoginHelper.
         if flags.verified {
             _ = settings.navigationController?.popToRootViewController(animated: true)
+            // Reload the data to reflect the new Account immediately.
+            settings.tableView.reloadData()
+            // And start advancing the Account state in the background as well.
+            settings.SELrefresh()
         }
     }
 


### PR DESCRIPTION
This PR dismisses the `FxAContentController` correctly after a successful verification.

Initially, this PR had some work which eventually moved to a thought-to-be-related [Bug 1395547][1].

https://bugzilla.mozilla.org/show_bug.cgi?id=1382561

[1]: https://bugzilla.mozilla.org/show_bug.cgi?id=1395547
[2]: https://bugzilla.mozilla.org/show_bug.cgi?id=1400883