### PR TITLE
Bug 1364584 - Updates to the Tab Tray for Photon

### DIFF
--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -300,7 +300,7 @@ private func transformToolbarsToFrame(_ toolbars: [UIView?], toRect endRect: CGR
 
 private func createTransitionCellFromTab(_ tab: Tab?, withFrame frame: CGRect) -> TabCell {
     let cell = TabCell(frame: frame)
-    cell.background.image = tab?.screenshot
+    cell.screenshotView.image = tab?.screenshot
     cell.titleText.text = tab?.displayTitle
 
     if let tab = tab, tab.isPrivate {

--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -132,7 +132,6 @@ private extension BrowserToTrayAnimator {
         let expandedFrame = calculateExpandedCellFrameFromBVC(bvc)
         let cell = createTransitionCellFromTab(bvc.tabManager.selectedTab, withFrame: expandedFrame)
         cell.backgroundHolder.layer.cornerRadius = TabTrayControllerUX.CornerRadius
-        cell.innerStroke.isHidden = true
 
         // Take a snapshot of the collection view to perform the scaling/alpha effect
         let tabCollectionViewSnapshot = tabTray.collectionView.snapshotView(afterScreenUpdates: true)!

--- a/Client/Frontend/Browser/SwipeAnimator.swift
+++ b/Client/Frontend/Browser/SwipeAnimator.swift
@@ -28,7 +28,6 @@ protocol SwipeAnimatorDelegate: class {
 
 class SwipeAnimator: NSObject {
     weak var delegate: SwipeAnimatorDelegate?
-    weak var container: UIView!
     weak var animatingView: UIView!
     
     fileprivate var prevOffset: CGPoint!
@@ -37,18 +36,17 @@ class SwipeAnimator: NSObject {
     fileprivate var panGestureRecogniser: UIPanGestureRecognizer!
 
     var containerCenter: CGPoint {
-        return CGPoint(x: container.frame.width / 2, y: container.frame.height / 2)
+        return CGPoint(x: animatingView.frame.width / 2, y: animatingView.frame.height / 2)
     }
 
-    init(animatingView: UIView, container: UIView, params: SwipeAnimationParameters = DefaultParameters) {
+    init(animatingView: UIView, params: SwipeAnimationParameters = DefaultParameters) {
         self.animatingView = animatingView
-        self.container = container
         self.params = params
 
         super.init()
 
         self.panGestureRecogniser = UIPanGestureRecognizer(target: self, action: #selector(SwipeAnimator.didPan(_:)))
-        container.addGestureRecognizer(self.panGestureRecogniser)
+        animatingView.addGestureRecognizer(self.panGestureRecogniser)
         self.panGestureRecogniser.delegate = self
     }
 
@@ -69,7 +67,7 @@ extension SwipeAnimator {
 
     fileprivate func animateAwayWithVelocity(_ velocity: CGPoint, speed: CGFloat) {
         // Calculate the edge to calculate distance from
-        let translation = velocity.x >= 0 ? container.frame.width : -container.frame.width
+        let translation = velocity.x >= 0 ? animatingView.frame.width : -animatingView.frame.width
         let timeStep = TimeInterval(abs(translation) / speed)
         self.delegate?.swipeAnimator(self, viewWillExitContainerBounds: self.animatingView)
         UIView.animate(withDuration: timeStep, animations: {
@@ -83,7 +81,7 @@ extension SwipeAnimator {
     }
 
     fileprivate func transformForTranslation(_ translation: CGFloat) -> CGAffineTransform {
-        let swipeWidth = container.frame.size.width
+        let swipeWidth = animatingView.frame.size.width
         let totalRotationInRadians = CGFloat(params.totalRotationInDegrees / 180.0 * Double.pi)
 
         // Determine rotation / scaling amounts by the distance to the edge
@@ -97,7 +95,7 @@ extension SwipeAnimator {
     }
 
     fileprivate func alphaForDistanceFromCenter(_ distance: CGFloat) -> CGFloat {
-        let swipeWidth = container.frame.size.width
+        let swipeWidth = animatingView.frame.size.width
         return 1 - (distance / swipeWidth) * (1 - params.totalAlpha)
     }
 }
@@ -105,7 +103,7 @@ extension SwipeAnimator {
 //MARK: Selectors
 extension SwipeAnimator {
     @objc func didPan(_ recognizer: UIPanGestureRecognizer!) {
-        let translation = recognizer.translation(in: container)
+        let translation = recognizer.translation(in: animatingView)
 
         switch recognizer.state {
         case .began:
@@ -117,7 +115,7 @@ extension SwipeAnimator {
         case .cancelled:
             animateBackToCenter()
         case .ended:
-            let velocity = recognizer.velocity(in: container)
+            let velocity = recognizer.velocity(in: animatingView)
             // Bounce back if the velocity is too low or if we have not reached the threshold yet
             let speed = max(abs(velocity.x), params.minExitVelocity)
             if speed < params.minExitVelocity || abs(prevOffset.x) < params.deleteThreshold {

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -99,7 +99,7 @@ class TabCell: UICollectionViewCell {
 
         super.init(frame: frame)
         
-        self.animator = SwipeAnimator(animatingView: self.backgroundHolder, container: self)
+        self.animator = SwipeAnimator(animatingView: self)
         self.closeButton.addTarget(self, action: #selector(TabCell.close), for: UIControlEvents.touchUpInside)
 
         contentView.addSubview(backgroundHolder)
@@ -666,7 +666,7 @@ extension TabTrayController: UIScrollViewAccessibilityDelegate {
 
 extension TabTrayController: SwipeAnimatorDelegate {
     func swipeAnimator(_ animator: SwipeAnimator, viewWillExitContainerBounds: UIView) {
-        let tabCell = animator.container as! TabCell
+        let tabCell = animator.animatingView as! TabCell
         if let indexPath = collectionView.indexPath(for: tabCell) {
             let tab = tabsToDisplay[indexPath.item]
             tabManager.removeTab(tab)

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -48,6 +48,7 @@ class TabCell: UICollectionViewCell {
     }
 
     static let Identifier = "TabCellIdentifier"
+    static let BorderWidth: CGFloat = 3
 
     var style: Style = .light {
         didSet {
@@ -141,6 +142,18 @@ class TabCell: UICollectionViewCell {
         self.title = title
     }
 
+    func setTabSelected(_ isPrivate: Bool) {
+        // This creates a border around a tabcell. Using the shadow craetes a border _outside_ of the tab frame.
+        layer.shadowColor = (isPrivate ? UIConstants.PrivateModePurple : UIConstants.SystemBlueColor).cgColor
+        layer.shadowOpacity = 1
+        layer.shadowRadius = 0 // A 0 radius creates a solid border instead of a gradient blur
+        layer.masksToBounds = false
+        // create a frame that is "BorderWidth" size bigger than the cell
+        layer.shadowOffset = CGSize(width: -TabCell.BorderWidth, height: -TabCell.BorderWidth)
+        let shadowPath = CGRect(x: 0, y: 0, width: layer.frame.width + (TabCell.BorderWidth * 2), height: layer.frame.height + (TabCell.BorderWidth * 2))
+        layer.shadowPath = UIBezierPath(roundedRect: shadowPath, cornerRadius: TabTrayControllerUX.CornerRadius).cgPath
+    }
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -188,6 +201,9 @@ class TabCell: UICollectionViewCell {
         backgroundHolder.transform = CGAffineTransform.identity
         backgroundHolder.alpha = 1
         self.titleText.font = DynamicFontHelper.defaultHelper.DefaultSmallFontBold
+        layer.shadowOffset = CGSize.zero
+        layer.shadowPath = nil
+        layer.shadowOpacity = 0
     }
 
     override func accessibilityScroll(_ direction: UIAccessibilityScrollDirection) -> Bool {
@@ -757,6 +773,9 @@ fileprivate class TabManagerDataSource: NSObject, UICollectionViewDataSource {
             } else {
                 tabCell.favicon.image = defaultFavicon
             }
+        }
+        if tab == tabManager.selectedTab {
+            tabCell.setTabSelected(tab.isPrivate)
         }
         tabCell.background.image = tab.screenshot
         return tabCell

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -10,7 +10,7 @@ import ReadingList
 import Shared
 
 struct TabTrayControllerUX {
-    static let CornerRadius = CGFloat(4.0)
+    static let CornerRadius = CGFloat(6.0)
     static let BackgroundColor = UIConstants.TabTrayBG
     static let CellBackgroundColor = UIConstants.TabTrayBG
     static let TextBoxHeight = CGFloat(32.0)
@@ -121,7 +121,6 @@ class TabCell: UICollectionViewCell {
         case .light:
             title = UIVisualEffectView(effect: UIBlurEffect(style: .extraLight))
             self.titleText.textColor = LightTabCellUX.TabTitleTextColor
-            //self.closeButton
         case .dark:
             title = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
             self.titleText.textColor = DarkTabCellUX.TabTitleTextColor
@@ -146,7 +145,7 @@ class TabCell: UICollectionViewCell {
         // create a frame that is "BorderWidth" size bigger than the cell
         layer.shadowOffset = CGSize(width: -TabCell.BorderWidth, height: -TabCell.BorderWidth)
         let shadowPath = CGRect(x: 0, y: 0, width: layer.frame.width + (TabCell.BorderWidth * 2), height: layer.frame.height + (TabCell.BorderWidth * 2))
-        layer.shadowPath = UIBezierPath(roundedRect: shadowPath, cornerRadius: TabTrayControllerUX.CornerRadius).cgPath
+        layer.shadowPath = UIBezierPath(roundedRect: shadowPath, cornerRadius: TabTrayControllerUX.CornerRadius+TabCell.BorderWidth).cgPath
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -57,7 +57,7 @@ class TabCell: UICollectionViewCell {
     }
 
     let backgroundHolder = UIView()
-    let background = UIImageViewAligned()
+    let screenshotView = UIImageViewAligned()
     let titleText: UILabel
     let favicon: UIImageView = UIImageView()
     let closeButton: UIButton
@@ -76,11 +76,11 @@ class TabCell: UICollectionViewCell {
         self.backgroundHolder.clipsToBounds = true
         self.backgroundHolder.backgroundColor = TabTrayControllerUX.CellBackgroundColor
 
-        self.background.contentMode = UIViewContentMode.scaleAspectFill
-        self.background.clipsToBounds = true
-        self.background.isUserInteractionEnabled = false
-        self.background.alignLeft = true
-        self.background.alignTop = true
+        self.screenshotView.contentMode = UIViewContentMode.scaleAspectFill
+        self.screenshotView.clipsToBounds = true
+        self.screenshotView.isUserInteractionEnabled = false
+        self.screenshotView.alignLeft = true
+        self.screenshotView.alignTop = true
 
         self.favicon.backgroundColor = UIColor.clear
         self.favicon.layer.cornerRadius = 2.0
@@ -103,7 +103,7 @@ class TabCell: UICollectionViewCell {
         self.closeButton.addTarget(self, action: #selector(TabCell.close), for: UIControlEvents.touchUpInside)
 
         contentView.addSubview(backgroundHolder)
-        backgroundHolder.addSubview(self.background)
+        backgroundHolder.addSubview(self.screenshotView)
 
         // Default style is light
         applyStyle(style)
@@ -162,7 +162,7 @@ class TabCell: UICollectionViewCell {
             y: margin,
             width: w,
             height: h)
-        background.frame = CGRect(origin: CGPoint(x: 0, y: 0), size: backgroundHolder.frame.size)
+        screenshotView.frame = CGRect(origin: CGPoint(x: 0, y: 0), size: backgroundHolder.frame.size)
 
         title.frame = CGRect(x: 0,
             y: 0,
@@ -770,7 +770,7 @@ fileprivate class TabManagerDataSource: NSObject, UICollectionViewDataSource {
         if tab == tabManager.selectedTab {
             tabCell.setTabSelected(tab.isPrivate)
         }
-        tabCell.background.image = tab.screenshot
+        tabCell.screenshotView.image = tab.screenshot
         return tabCell
     }
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -803,11 +803,9 @@ fileprivate class TabLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayou
     fileprivate var traitCollection: UITraitCollection
     fileprivate var profile: Profile
     fileprivate var numberOfColumns: Int {
-        let compactLayout = profile.prefs.boolForKey("CompactTabLayout") ?? true
-
         // iPhone 4-6+ portrait
         if traitCollection.horizontalSizeClass == .compact && traitCollection.verticalSizeClass == .regular {
-            return compactLayout ? TabTrayControllerUX.CompactNumberOfColumnsThin : TabTrayControllerUX.NumberOfColumnsThin
+            return TabTrayControllerUX.CompactNumberOfColumnsThin
         } else {
             return TabTrayControllerUX.NumberOfColumnsWide
         }
@@ -820,8 +818,7 @@ fileprivate class TabLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayou
     }
 
     fileprivate func cellHeightForCurrentDevice() -> CGFloat {
-        let compactLayout = profile.prefs.boolForKey("CompactTabLayout") ?? true
-        let shortHeight = (compactLayout ? TabTrayControllerUX.TextBoxHeight * 6 : TabTrayControllerUX.TextBoxHeight * 5)
+        let shortHeight = TabTrayControllerUX.TextBoxHeight * 6
 
         if self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClass.compact {
             return shortHeight

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -81,6 +81,7 @@ class TabCell: UICollectionViewCell {
         self.screenshotView.isUserInteractionEnabled = false
         self.screenshotView.alignLeft = true
         self.screenshotView.alignTop = true
+        screenshotView.backgroundColor = UIConstants.AppBackgroundColor
 
         self.favicon.backgroundColor = UIColor.clear
         self.favicon.layer.cornerRadius = 2.0
@@ -507,7 +508,6 @@ class TabTrayController: UIViewController {
         // until after its insert animation finishes.
         self.collectionView.performBatchUpdates({ _ in
             let tab = self.tabManager.addTab(request, isPrivate: self.privateMode)
-            self.tabManager.selectTab(tab)
         }, completion: { finished in
             self.toolbar.isUserInteractionEnabled = true
             if finished {

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -59,7 +59,6 @@ class TabCell: UICollectionViewCell {
     let backgroundHolder = UIView()
     let background = UIImageViewAligned()
     let titleText: UILabel
-    let innerStroke: InnerStrokedView
     let favicon: UIImageView = UIImageView()
     let closeButton: UIButton
 
@@ -98,9 +97,6 @@ class TabCell: UICollectionViewCell {
         self.closeButton.tintColor = UIColor.lightGray
         self.closeButton.imageEdgeInsets = UIEdgeInsets(equalInset: TabTrayControllerUX.CloseButtonEdgeInset)
 
-        self.innerStroke = InnerStrokedView(frame: self.backgroundHolder.frame)
-        self.innerStroke.layer.backgroundColor = UIColor.clear.cgColor
-
         super.init(frame: frame)
         
         self.animator = SwipeAnimator(animatingView: self.backgroundHolder, container: self)
@@ -108,7 +104,6 @@ class TabCell: UICollectionViewCell {
 
         contentView.addSubview(backgroundHolder)
         backgroundHolder.addSubview(self.background)
-        backgroundHolder.addSubview(innerStroke)
 
         // Default style is light
         applyStyle(style)
@@ -184,8 +179,6 @@ class TabCell: UICollectionViewCell {
             y: 0,
             width: title.frame.width - titleTextLeft - margin  - TabTrayControllerUX.CloseButtonSize - TabTrayControllerUX.CloseButtonMargin * 2,
             height: title.frame.height)
-
-        innerStroke.frame = background.frame
 
         closeButton.snp.makeConstraints { make in
             make.size.equalTo(title.snp.height)

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -66,12 +66,6 @@ class AppSettingsTableViewController: SettingsTableViewController {
         // There is nothing to show in the Customize section if we don't include the compact tab layout
         // setting on iPad. When more options are added that work on both device types, this logic can
         // be changed.
-        if UIDevice.current.userInterfaceIdiom == .phone {
-            generalSettings +=  [
-                BoolSetting(prefs: prefs, prefKey: "CompactTabLayout", defaultValue: true,
-                    titleText: NSLocalizedString("Use Compact Tabs", comment: "Setting to enable compact tabs in the tab overview"))
-            ]
-        }
 
         generalSettings += [
             BoolSetting(prefs: prefs, prefKey: "showClipboardBar", defaultValue: false,


### PR DESCRIPTION
- A new tab highlight that helps users know which tab they were last on.
- Remove the unused InnerStrokeView. I did a screenshot diff and I couldn't see what this view was doing.
- Remove the compact tab setting. This makes our settings have one less option.