### PR TITLE
Bug 1393859 - Make sure page actions menu uses the displayURL

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -74,7 +74,7 @@ class Tab: NSObject {
     var desktopSite: Bool = false
     var isBookmarked: Bool = false
     
-    var readerModeAvailable: Bool {
+    var readerModeAvailableOrActive: Bool {
         if let readerMode = self.getHelper(name: "ReaderMode") as? ReaderMode {
             return readerMode.state != .unavailable
         }

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -76,7 +76,7 @@ class Tab: NSObject {
     
     var readerModeAvailable: Bool {
         if let readerMode = self.getHelper(name: "ReaderMode") as? ReaderMode {
-            return readerMode.state == .available
+            return readerMode.state != .unavailable
         }
         return false
     }

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -107,8 +107,8 @@ extension PhotonActionSheetProtocol {
         
         let addReadingList = PhotonActionSheetItem(title: Strings.AppMenuAddToReadingListTitleString, iconString: "addToReadingList") { action in
             guard let tab = self.tabManager.selectedTab else { return }
-            guard let url = tab.url?.decodeReaderModeURL ?? tab.url else { return }
-            
+            guard let url = tab.url?.displayURL else { return }
+
             self.profile.readingList?.createRecordWithURL(url.absoluteString, title: tab.title ?? "", addedBy: UIDevice.current.name)
         }
         
@@ -118,7 +118,7 @@ extension PhotonActionSheetProtocol {
         
         let bookmarkPage = PhotonActionSheetItem(title: Strings.AppMenuAddBookmarkTitleString, iconString: "menu-Bookmark") { action in
             //TODO: can all this logic go somewhere else?
-            guard let url = tab.url else { return }
+            guard let url = tab.url?.displayURL else { return }
             let absoluteString = url.absoluteString
             let shareItem = ShareItem(url: absoluteString, title: tab.title, favicon: tab.displayFavicon)
             _ = self.profile.bookmarks.shareItem(shareItem)
@@ -134,7 +134,7 @@ extension PhotonActionSheetProtocol {
         
         let removeBookmark = PhotonActionSheetItem(title: Strings.AppMenuRemoveBookmarkTitleString, iconString: "menu-Bookmark-Remove") { action in
             //TODO: can all this logic go somewhere else?
-            guard let url = tab.url else { return }
+            guard let url = tab.url?.displayURL else { return }
             let absoluteString = url.absoluteString
             self.profile.bookmarks.modelFactory >>== {
                 $0.removeByURL(absoluteString).uponQueue(.main) { res in
@@ -146,12 +146,13 @@ extension PhotonActionSheetProtocol {
         }
         
         let share = PhotonActionSheetItem(title: Strings.AppMenuSharePageTitleString, iconString: "action_share") { action in
-            guard let url = self.tabManager.selectedTab?.url else { return }
             guard let tab = self.tabManager.selectedTab else { return }
+            guard let url = self.tabManager.selectedTab?.url?.displayURL else { return }
             presentShareMenu(url, tab, buttonView, .up)
         }
+
         let copyURL = PhotonActionSheetItem(title: Strings.AppMenuCopyURLTitleString, iconString: "menu-Copy-Link") { _ in
-            UIPasteboard.general.string = self.tabManager.selectedTab?.url?.absoluteString ?? ""
+            UIPasteboard.general.string = self.tabManager.selectedTab?.url?.displayURL?.absoluteString ?? ""
         }
         
         let bookmarkAction = tab.isBookmarked ? removeBookmark : bookmarkPage

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -107,7 +107,8 @@ extension PhotonActionSheetProtocol {
         
         let addReadingList = PhotonActionSheetItem(title: Strings.AppMenuAddToReadingListTitleString, iconString: "addToReadingList") { action in
             guard let tab = self.tabManager.selectedTab else { return }
-            guard let url = tab.url else { return }
+            guard let url = tab.url?.decodeReaderModeURL ?? tab.url else { return }
+            
             self.profile.readingList?.createRecordWithURL(url.absoluteString, title: tab.title ?? "", addedBy: UIDevice.current.name)
         }
         

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -157,7 +157,7 @@ extension PhotonActionSheetProtocol {
         
         let bookmarkAction = tab.isBookmarked ? removeBookmark : bookmarkPage
         var topActions = [bookmarkAction]
-        if let tab = self.tabManager.selectedTab, tab.readerModeAvailable {
+        if let tab = self.tabManager.selectedTab, tab.readerModeAvailableOrActive {
             topActions.append(addReadingList)
         }
         return [topActions, [findInPageAction, toggleDesktopSite, setHomePage], [share, copyURL]]


### PR DESCRIPTION
Internal URLs like (localhost://reader-mode) could be exposed if we directly use tab.url. Instead use tab.url.displayURL.