### PR TITLE
Bug 1400690 - change menu button to a trash can. Swap the new tabs and PBM button.

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -187,6 +187,8 @@ class TabCell: UICollectionViewCell {
 
         let top = (TabTrayControllerUX.TextBoxHeight - titleText.bounds.height) / 2.0
         titleText.frame.origin = CGPoint(x: titleText.frame.origin.x, y: max(0, top))
+        let shadowPath = CGRect(x: 0, y: 0, width: layer.frame.width + (TabCell.BorderWidth * 2), height: layer.frame.height + (TabCell.BorderWidth * 2))
+        layer.shadowPath = UIBezierPath(roundedRect: shadowPath, cornerRadius: TabTrayControllerUX.CornerRadius+TabCell.BorderWidth).cgPath
     }
 
     override func prepareForReuse() {

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -245,7 +245,7 @@ class TabTrayController: UIViewController {
         let toolbar = TrayToolbar()
         toolbar.addTabButton.addTarget(self, action: #selector(TabTrayController.didClickAddTab), for: .touchUpInside)
         toolbar.maskButton.addTarget(self, action: #selector(TabTrayController.didTogglePrivateMode), for: .touchUpInside)
-        toolbar.menuButton.addTarget(self, action: #selector(TabTrayController.didTapMenu), for: .touchUpInside)
+        toolbar.deleteButton.addTarget(self, action: #selector(TabTrayController.didTapDelete(_:)), for: .touchUpInside)
         return toolbar
     }()
 
@@ -690,11 +690,13 @@ extension TabTrayController: SettingsDelegate {
 }
 
 extension TabTrayController: PhotonActionSheetProtocol {
-    func didTapMenu() {
-        let closeAllTabs = PhotonActionSheetItem(title: "Close All Tabs", iconString: "action_remove") { _ in
-            self.closeTabsForCurrentTray()
-        }
-        self.presentSheetWith(actions: [[closeAllTabs]], on: self, from: self.view)
+    func didTapDelete(_ sender: UIButton) {
+        let controller = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        controller.addAction(UIAlertAction(title: Strings.AppMenuCloseAllTabsTitleString, style: .default, handler: { _ in self.closeTabsForCurrentTray() }))
+        controller.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment:"Label for Cancel button"), style: .cancel, handler: nil))
+        controller.popoverPresentationController?.sourceView = sender
+        controller.popoverPresentationController?.sourceRect = sender.frame
+        present(controller, animated: true, completion: nil)
     }
 }
 
@@ -1015,11 +1017,11 @@ class TrayToolbar: UIView {
         return button
     }()
 
-    lazy var menuButton: UIButton = {
+    lazy var deleteButton: UIButton = {
         let button = UIButton()
-        button.setImage(UIImage.templateImageNamed("menu-More-Options"), for: .normal)
-        button.accessibilityLabel = Strings.AppMenuButtonAccessibilityLabel
-        button.accessibilityIdentifier = "TabTrayController.menuButton"
+        button.setImage(UIImage.templateImageNamed("action_delete"), for: .normal)
+        button.accessibilityLabel = Strings.TabTrayDeleteMenuButtonAccessibilityLabel
+        button.accessibilityIdentifier = "TabTrayController.remoteTabsButton"
         return button
     }()
 
@@ -1032,8 +1034,8 @@ class TrayToolbar: UIView {
         addSubview(addTabButton)
 
         var buttonToCenter: UIButton?
-        addSubview(menuButton)
-        buttonToCenter = menuButton
+        addSubview(deleteButton)
+        buttonToCenter = deleteButton
         
         maskButton.accessibilityIdentifier = "TabTrayController.maskButton"
 
@@ -1044,14 +1046,14 @@ class TrayToolbar: UIView {
 
         addTabButton.snp.makeConstraints { make in
             make.centerY.equalTo(self)
-            make.left.equalTo(self).offset(sideOffset)
+            make.right.equalTo(self).offset(-sideOffset)
             make.size.equalTo(toolbarButtonSize)
         }
 
         addSubview(maskButton)
         maskButton.snp.makeConstraints { make in
             make.centerY.equalTo(self)
-            make.right.equalTo(self).offset(-sideOffset)
+            make.left.equalTo(self).offset(sideOffset)
             make.size.equalTo(toolbarButtonSize)
         }
 
@@ -1064,7 +1066,7 @@ class TrayToolbar: UIView {
 
     fileprivate func styleToolbar(_ isPrivate: Bool) {
         addTabButton.tintColor = isPrivate ? .white : .darkGray
-        menuButton.tintColor = isPrivate ? .white : .darkGray
+        deleteButton.tintColor = isPrivate ? .white : .darkGray
         backgroundColor = isPrivate ? UIConstants.PrivateModeToolbarTintColor : .white
         maskButton.styleForMode(privateMode: isPrivate)
     }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -697,7 +697,7 @@ extension TabTrayController: PhotonActionSheetProtocol {
         controller.addAction(UIAlertAction(title: Strings.AppMenuCloseAllTabsTitleString, style: .default, handler: { _ in self.closeTabsForCurrentTray() }))
         controller.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment:"Label for Cancel button"), style: .cancel, handler: nil))
         controller.popoverPresentationController?.sourceView = sender
-        controller.popoverPresentationController?.sourceRect = sender.frame
+        controller.popoverPresentationController?.sourceRect = sender.bounds
         present(controller, animated: true, completion: nil)
     }
 }

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -369,6 +369,8 @@ extension Strings {
     public static let AppMenuNightModeIsOffLabel = NSLocalizedString("Menu.NightModeIsOffAction.Label", value: "Night Mode: Off", comment: "Label for the button, displayed in the menu, shows the current state of night mode which is currently OFF")
     public static let AppMenuNoImageModeIsOnLabel = NSLocalizedString("Menu.NoImageModeIsOnAction.Label", value: "Hide Images: On", comment: "Label for the button, displayed in the menu, shows the current state of Hide Images mode which is currently ON")
     public static let AppMenuNoImageModeIsOffLabel = NSLocalizedString("Menu.NoImageModeIsOffAction.Label", value: "Hide Images: Off", comment: "Label for the button, displayed in the menu, shows the current state of Hide Images which is currently OFF")
+    public static let TabTrayDeleteMenuButtonAccessibilityLabel = NSLocalizedString("Toolbar.Menu.CloseAllTabs", value: "Close All Tabs", comment: "Accessibility label for the Close All Tabs menu button.")
+
 }
 
 // Snackbar shown when tapping app store link


### PR DESCRIPTION
Because of https://github.com/mozilla-mobile/firefox-ios/pull/3195 lets swap the buttons to make sure that your finger doesnt need to travel to the other side when opening a new tab. 


