### PR TITLE
Bug 1395547 – Empty synced tabs on desktop.

### DIFF
--- a/Account/SyncAuthState.swift
+++ b/Account/SyncAuthState.swift
@@ -21,6 +21,7 @@ public struct SyncAuthStateCache {
 public protocol SyncAuthState {
     func invalidate()
     func token(_ now: Timestamp, canBeExpired: Bool) -> Deferred<Maybe<(token: TokenServerToken, forKey: Data)>>
+    var deviceRegistration: FxADeviceRegistration? { get }
 }
 
 public func syncAuthStateCachefromJSON(_ json: JSON) -> SyncAuthStateCache? {
@@ -53,6 +54,9 @@ extension SyncAuthStateCache: JSONLiteralConvertible {
 open class FirefoxAccountSyncAuthState: SyncAuthState {
     fileprivate let account: FirefoxAccount
     fileprivate let cache: KeychainCache<SyncAuthStateCache>
+    public var deviceRegistration: FxADeviceRegistration? {
+        return account.deviceRegistration
+    }
 
     init(account: FirefoxAccount, cache: KeychainCache<SyncAuthStateCache>) {
         self.account = account

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -400,14 +400,13 @@ class AccountSetting: Setting, FxAContentViewControllerDelegate {
     override var accessoryType: UITableViewCellAccessoryType { return .none }
 
     func contentViewControllerDidSignIn(_ viewController: FxAContentViewController, withFlags flags: FxALoginFlags) {
-        // Reload the data to reflect the new Account immediately.
-        settings.tableView.reloadData()
-        // And start advancing the Account state in the background as well.
-        settings.SELrefresh()
-
         // Dismiss the FxA content view if the account is verified.
         if flags.verified {
             _ = settings.navigationController?.popToRootViewController(animated: true)
+            // Reload the data to reflect the new Account immediately.
+            settings.tableView.reloadData()
+            // And start advancing the Account state in the background as well.
+            settings.SELrefresh()
         }
     }
 

--- a/Client/Helpers/FxALoginHelper.swift
+++ b/Client/Helpers/FxALoginHelper.swift
@@ -97,10 +97,6 @@ class FxALoginHelper {
         // accountVerified is needed by delegates.
         accountVerified = account.actionNeeded != .needsVerification
 
-        // We should check if deviceRegistration has been performed, and 
-        // update the sync scratch pad (a proxy for our client record) accordingly.
-        // We do this here because this is effectively the upgrade path between 7 and 8.
-        updateSyncScratchpad()
 
         guard AppConstants.MOZ_FXA_PUSH else {
             return loginDidSucceed()
@@ -285,10 +281,6 @@ class FxALoginHelper {
         // The only way we can tell if the account has been verified is to 
         // start a sync. If it works, then yay,
         account.advance().upon { state in
-            if attemptsLeft == verificationMaxRetries {
-                self.updateSyncScratchpad()
-            }
-
             guard state.actionNeeded == .needsVerification else {
                 // Verification has occurred remotely, and we can proceed.
                 // The state machine will have told any listening UIs that 
@@ -316,16 +308,6 @@ class FxALoginHelper {
 
     fileprivate func loginDidFail() {
         delegate?.accountLoginDidFail()
-    }
-
-    fileprivate func updateSyncScratchpad() {
-        // We need to associate the fxaDeviceId with sync;
-        // We can do this anything after the first time we account.advance()
-        // but before the first time we sync.
-        if let deviceRegistration = account?.deviceRegistration,
-            let scratchpadPrefs = profile?.prefs.branch("sync.scratchpad") {
-            scratchpadPrefs.setString(deviceRegistration.toJSON().stringValue()!, forKey: PrefDeviceRegistration)
-        }
     }
 
     func performVerifiedSync(_ profile: Profile, account: FirefoxAccount) {

--- a/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
+++ b/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
@@ -509,7 +509,7 @@ extension SQLiteRemoteClientsAndTabs: ResettableSyncStorage {
 
     public func clear() -> Success {
         return self.doWipe { (conn, err: inout NSError?) -> Void in
-            if let error = conn.executeChange("DELETE FROM \(TableTabs)") {
+            if let error = conn.executeChange("DELETE FROM \(TableTabs) WHERE client_guid IS NOT NULL") {
                 err = error
             }
             if let error = conn.executeChange("DELETE FROM \(TableClients)") {

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -136,6 +136,9 @@ open class SyncStateMachine {
 
             // Take the scratchpad and add the hashedUID from the token
             let b = Scratchpad.Builder(p: scratchpad)
+            if let deviceRegistration = authState.deviceRegistration {
+                b.fxaDeviceId = deviceRegistration.id
+            }
             b.hashedUID = token.hashedFxAUID
 
             // Detect if the we've changed anything in our client record from the last time we synced,

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -137,6 +137,15 @@ open class SyncStateMachine {
             // Take the scratchpad and add the hashedUID from the token
             let b = Scratchpad.Builder(p: scratchpad)
             b.hashedUID = token.hashedFxAUID
+
+            // Detect if the we've changed anything in our client record from the last time we synced,
+            let ourClientUnchanged = (b.fxaDeviceId == scratchpad.fxaDeviceId)
+
+            // and if so, trigger a reset of clients.
+            if !ourClientUnchanged {
+                b.localCommands.insert(LocalCommand.resetEngine(engine: "clients"))
+            }
+
             scratchpad = b.build()
 
             log.info("Advancing to InitialWithLiveToken.")

--- a/Sync/Synchronizers/TabsSynchronizer.swift
+++ b/Sync/Synchronizers/TabsSynchronizer.swift
@@ -163,8 +163,8 @@ open class TabsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchroniz
 
             if !self.remoteHasChanges(info) {
                 // upload local tabs if they've changed or we're in a fresh start.
-                _ = uploadOurTabs(localTabs, toServer: tabsClient)
-                return deferMaybe(completedWithStats)
+                return uploadOurTabs(localTabs, toServer: tabsClient)
+                    >>> { deferMaybe(self.completedWithStats) }
             }
 
             return tabsClient.getSince(self.lastFetched)

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -20,6 +20,10 @@ class MockSyncAuthState: SyncAuthState {
     let serverRoot: String
     let kB: Data
 
+    var deviceRegistration: FxADeviceRegistration? {
+        return FxADeviceRegistration(id: "mock_device_id", version: 1, lastRegistered: 0)
+    }
+
     init(serverRoot: String, kB: Data) {
         self.serverRoot = serverRoot
         self.kB = kB


### PR DESCRIPTION
This PR attempts to fix issues that result in tabs not being synced on first sign in to FxA.

This is not landing on master yet, and will need to be cherry-picked since it exposes [a crash to do with Avatars][1]. 

https://bugzilla.mozilla.org/show_bug.cgi?id=1395547

[1]: https://bugzilla.mozilla.org/show_bug.cgi?id=1400883