### PR TITLE
Bug 1223460 - resume search

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2169,6 +2169,10 @@ extension BrowserViewController: SearchViewControllerDelegate {
         finishEditingAndSubmit(url, visitType: VisitType.typed)
     }
 
+    func searchViewController(_ searchViewController: SearchViewController, didLongPressSuggestion suggestion: String) {
+        self.urlBar.setLocation(suggestion)
+    }
+
     func presentSearchSettingsController() {
         let settingsNavigationController = SearchSettingsTableViewController()
         settingsNavigationController.model = self.profile.searchEngines

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -402,9 +402,9 @@ class BrowserViewController: UIViewController {
         })
         pasteAction = AccessibleAction(name: NSLocalizedString("Paste", comment: "Paste the URL into the location bar"), handler: { () -> Bool in
             if let pasteboardContents = UIPasteboard.general.string {
-                // Enter overlay mode and fire the text entered callback to make the search controller appear.
-                self.urlBar.enterOverlayMode(pasteboardContents, pasted: true)
-                self.urlBar(self.urlBar, didEnterText: pasteboardContents)
+                // Enter overlay mode and make the search controller appear.
+                self.urlBar.enterOverlayMode(pasteboardContents, pasted: true, search: true)
+
                 return true
             }
             return false
@@ -1618,13 +1618,17 @@ extension BrowserViewController: URLBarDelegate {
         }
     }
 
-    func urlBarDisplayTextForURL(_ url: URL?) -> String? {
+    func urlBarDisplayTextForURL(_ url: URL?) -> (String?, Bool) {
         // use the initial value for the URL so we can do proper pattern matching with search URLs
         var searchURL = self.tabManager.selectedTab?.currentInitialURL
         if searchURL?.isErrorPageURL ?? true {
             searchURL = url
         }
-        return profile.searchEngines.queryForSearchURL(searchURL as URL?) ?? url?.absoluteString
+        if let query = profile.searchEngines.queryForSearchURL(searchURL as URL?) {
+            return (query, true)
+        } else {
+            return (url?.absoluteString, false)
+        }
     }
 
     func urlBarDidLongPressLocation(_ urlBar: URLBarView) {
@@ -2170,7 +2174,7 @@ extension BrowserViewController: SearchViewControllerDelegate {
     }
 
     func searchViewController(_ searchViewController: SearchViewController, didLongPressSuggestion suggestion: String) {
-        self.urlBar.setLocation(suggestion)
+        self.urlBar.setLocation(suggestion, search: true)
     }
 
     func presentSearchSettingsController() {

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -54,6 +54,7 @@ private struct SearchViewControllerUX {
 
 protocol SearchViewControllerDelegate: class {
     func searchViewController(_ searchViewController: SearchViewController, didSelectURL url: URL)
+    func searchViewController(_ searchViewController: SearchViewController, didLongPressSuggestion suggestion: String)
     func presentSearchSettingsController()
 }
 
@@ -579,6 +580,10 @@ extension SearchViewController: SuggestionCellDelegate {
             searchDelegate?.searchViewController(self, didSelectURL: url)
         }
     }
+
+    fileprivate func suggestionCell(_ suggestionCell: SuggestionCell, didLongPressSuggestion suggestion: String) {
+        searchDelegate?.searchViewController(self, didLongPressSuggestion: suggestion)
+    }
 }
 
 /**
@@ -604,6 +609,7 @@ fileprivate class ButtonScrollView: UIScrollView {
 
 fileprivate protocol SuggestionCellDelegate: class {
     func suggestionCell(_ suggestionCell: SuggestionCell, didSelectSuggestion suggestion: String)
+    func suggestionCell(_ suggestionCell: SuggestionCell, didLongPressSuggestion suggestion: String)
 }
 
 /**
@@ -642,6 +648,7 @@ fileprivate class SuggestionCell: UITableViewCell {
                 let button = SuggestionButton()
                 button.setTitle(suggestion, for: UIControlState())
                 button.addTarget(self, action: #selector(SuggestionCell.SELdidSelectSuggestion(_:)), for: UIControlEvents.touchUpInside)
+                button.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(SuggestionCell.SELdidLongPressSuggestion(_:))))
 
                 // If this is the first image, add the search icon.
                 if container.subviews.isEmpty {
@@ -660,6 +667,15 @@ fileprivate class SuggestionCell: UITableViewCell {
     @objc
     func SELdidSelectSuggestion(_ sender: UIButton) {
         delegate?.suggestionCell(self, didSelectSuggestion: sender.titleLabel!.text!)
+    }
+
+    @objc
+    func SELdidLongPressSuggestion(_ recognizer: UILongPressGestureRecognizer) {
+        if recognizer.state == UIGestureRecognizerState.began {
+            if let button = recognizer.view as! UIButton? {
+                delegate?.suggestionCell(self, didLongPressSuggestion: button.titleLabel!.text!)
+            }
+        }
     }
 
     fileprivate override func layoutSubviews() {

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -72,7 +72,8 @@ protocol URLBarDelegate: class {
     func urlBarDidPressScrollToTop(_ urlBar: URLBarView)
     func urlBar(_ urlBar: URLBarView, didEnterText text: String)
     func urlBar(_ urlBar: URLBarView, didSubmitText text: String)
-    func urlBarDisplayTextForURL(_ url: URL?) -> String?
+    // Returns either (search query, true) or (url, false).
+    func urlBarDisplayTextForURL(_ url: URL?) -> (String?, Bool)
 }
 
 class URLBarView: UIView {
@@ -439,11 +440,15 @@ class URLBarView: UIView {
         locationTextField?.setAutocompleteSuggestion(suggestion)
     }
 
-    func setLocation(_ location: String) {
+    func setLocation(_ location: String?, search: Bool) {
         locationTextField?.text = location
+        if search, let location = location, !location.isEmpty {
+            // Not notifying when empty agrees with AutocompleteTextField.textDidChange.
+            delegate?.urlBar(self, didEnterText: location)
+        }
     }
 
-    func enterOverlayMode(_ locationText: String?, pasted: Bool) {
+    func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {
         createLocationTextField()
 
         // Show the overlay mode UI, which includes hiding the locationView and replacing it
@@ -463,11 +468,11 @@ class URLBarView: UIView {
             self.locationTextField?.text = ""
             DispatchQueue.main.async {
                 self.locationTextField?.becomeFirstResponder()
-                self.locationTextField?.text = locationText
+                self.setLocation(locationText, search: search)
             }
         } else {
             // Copy the current URL to the editable text field, then activate it.
-            self.locationTextField?.text = locationText
+            self.setLocation(locationText, search: search)
             DispatchQueue.main.async {
                 self.locationTextField?.becomeFirstResponder()
             }
@@ -624,13 +629,13 @@ extension URLBarView: TabLocationViewDelegate {
     }
 
     func tabLocationViewDidTapLocation(_ tabLocationView: TabLocationView) {
-        var locationText = delegate?.urlBarDisplayTextForURL(locationView.url as URL?)
+        guard var (locationText, isSearchQuery) = delegate?.urlBarDisplayTextForURL(locationView.url as URL?) else { return }
 
         // Make sure to use the result from urlBarDisplayTextForURL as it is responsible for extracting out search terms when on a search page
         if let text = locationText, let url = URL(string: text), let host = url.host, AppConstants.MOZ_PUNYCODE {
             locationText = url.absoluteString.replacingOccurrences(of: host, with: host.asciiHostToUTF8())
         }
-        enterOverlayMode(locationText, pasted: false)
+        enterOverlayMode(locationText, pasted: false, search: isSearchQuery)
     }
 
     func tabLocationViewDidLongPressLocation(_ tabLocationView: TabLocationView) {

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -439,6 +439,10 @@ class URLBarView: UIView {
         locationTextField?.setAutocompleteSuggestion(suggestion)
     }
 
+    func setLocation(_ location: String) {
+        locationTextField?.text = location
+    }
+
     func enterOverlayMode(_ locationText: String?, pasted: Bool) {
         createLocationTextField()
 


### PR DESCRIPTION
@farhanpatel I didn't want to upgrade to the beta XCode, so I implemented this against v8.x.  I haven't tried to rebase but it'll probably be straightforward; I can try shortly.

The long pressing was easy.  Resuming the search still has a significant issue: the animation into and out of the overlay mode shows the home panel (in the simulator, I see this with animation out clearly).  It looks terrible, but I don't want to spend time trying to improve it.  Can you:

1) rebase and try to build on v9.x
2) comment on the approaches
3) suggest a path to improve the animations?

Thanks!