### PR TITLE
Bug 1395547 — Clear remote-only tabs when disconnecting from FxA account.

### DIFF
--- a/Account/SyncAuthState.swift
+++ b/Account/SyncAuthState.swift
@@ -21,7 +21,7 @@ public struct SyncAuthStateCache {
 public protocol SyncAuthState {
     func invalidate()
     func token(_ now: Timestamp, canBeExpired: Bool) -> Deferred<Maybe<(token: TokenServerToken, forKey: Data)>>
-    var deviceRegistration: FxADeviceRegistration? { get }
+    var deviceID: String? { get }
 }
 
 public func syncAuthStateCachefromJSON(_ json: JSON) -> SyncAuthStateCache? {
@@ -54,8 +54,8 @@ extension SyncAuthStateCache: JSONLiteralConvertible {
 open class FirefoxAccountSyncAuthState: SyncAuthState {
     fileprivate let account: FirefoxAccount
     fileprivate let cache: KeychainCache<SyncAuthStateCache>
-    public var deviceRegistration: FxADeviceRegistration? {
-        return account.deviceRegistration
+    public var deviceID: String? {
+        return account.deviceRegistration?.id
     }
 
     init(account: FirefoxAccount, cache: KeychainCache<SyncAuthStateCache>) {

--- a/Account/SyncAuthState.swift
+++ b/Account/SyncAuthState.swift
@@ -21,6 +21,7 @@ public struct SyncAuthStateCache {
 public protocol SyncAuthState {
     func invalidate()
     func token(_ now: Timestamp, canBeExpired: Bool) -> Deferred<Maybe<(token: TokenServerToken, forKey: Data)>>
+    var deviceRegistration: FxADeviceRegistration? { get }
 }
 
 public func syncAuthStateCachefromJSON(_ json: JSON) -> SyncAuthStateCache? {
@@ -53,6 +54,9 @@ extension SyncAuthStateCache: JSONLiteralConvertible {
 open class FirefoxAccountSyncAuthState: SyncAuthState {
     fileprivate let account: FirefoxAccount
     fileprivate let cache: KeychainCache<SyncAuthStateCache>
+    public var deviceRegistration: FxADeviceRegistration? {
+        return account.deviceRegistration
+    }
 
     init(account: FirefoxAccount, cache: KeychainCache<SyncAuthStateCache>) {
         self.account = account

--- a/Client/Helpers/FxALoginHelper.swift
+++ b/Client/Helpers/FxALoginHelper.swift
@@ -97,10 +97,6 @@ class FxALoginHelper {
         // accountVerified is needed by delegates.
         accountVerified = account.actionNeeded != .needsVerification
 
-        // We should check if deviceRegistration has been performed, and 
-        // update the sync scratch pad (a proxy for our client record) accordingly.
-        // We do this here because this is effectively the upgrade path between 7 and 8.
-        updateSyncScratchpad()
 
         guard AppConstants.MOZ_FXA_PUSH else {
             return loginDidSucceed()
@@ -290,10 +286,6 @@ class FxALoginHelper {
         // The only way we can tell if the account has been verified is to 
         // start a sync. If it works, then yay,
         account.advance().upon { state in
-            if attemptsLeft == verificationMaxRetries {
-                self.updateSyncScratchpad()
-            }
-
             guard state.actionNeeded == .needsVerification else {
                 // Verification has occurred remotely, and we can proceed.
                 // The state machine will have told any listening UIs that 
@@ -321,16 +313,6 @@ class FxALoginHelper {
 
     fileprivate func loginDidFail() {
         delegate?.accountLoginDidFail()
-    }
-
-    fileprivate func updateSyncScratchpad() {
-        // We need to associate the fxaDeviceId with sync;
-        // We can do this anything after the first time we account.advance()
-        // but before the first time we sync.
-        if let deviceRegistration = account?.deviceRegistration,
-            let scratchpadPrefs = profile?.prefs.branch("sync.scratchpad") {
-            scratchpadPrefs.setString(deviceRegistration.toJSON().stringValue()!, forKey: PrefDeviceRegistration)
-        }
     }
 
     func performVerifiedSync(_ profile: Profile, account: FirefoxAccount) {

--- a/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
+++ b/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
@@ -553,7 +553,7 @@ extension SQLiteRemoteClientsAndTabs: ResettableSyncStorage {
 
     public func clear() -> Success {
         return self.doWipe { (conn, err: inout NSError?) -> Void in
-            if let error = conn.executeChange("DELETE FROM \(TableTabs)") {
+            if let error = conn.executeChange("DELETE FROM \(TableTabs) WHERE client_guid IS NOT NULL") {
                 err = error
             }
             if let error = conn.executeChange("DELETE FROM \(TableClients)") {

--- a/Sync/State.swift
+++ b/Sync/State.swift
@@ -473,8 +473,9 @@ open class Scratchpad {
                 if let id = json["id"].string {
                     return id
                 }
+                prefs.removeObjectForKey(PrefDeviceRegistration)
             }
-            // This is run first time we sync with a new account.
+            // This is run the first time we sync with a new account.
             // It will be replaced by a real fxaDeviceId, from account.deviceRegistration?.id.
             log.warning("No value found in prefs for fxaDeviceId! Will overwrite on first sync")
             return "unknown_fxaDeviceId"

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -136,6 +136,9 @@ open class SyncStateMachine {
 
             // Take the scratchpad and add the hashedUID from the token
             let b = Scratchpad.Builder(p: scratchpad)
+            if let deviceRegistration = authState.deviceRegistration {
+                b.fxaDeviceId = deviceRegistration.id
+            }
             b.hashedUID = token.hashedFxAUID
             scratchpad = b.build()
 

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -140,6 +140,15 @@ open class SyncStateMachine {
                 b.fxaDeviceId = deviceRegistration.id
             }
             b.hashedUID = token.hashedFxAUID
+
+            // Detect if the we've changed anything in our client record from the last time we synced,
+            let ourClientUnchanged = (b.fxaDeviceId == scratchpad.fxaDeviceId)
+
+            // and if so, trigger a reset of clients.
+            if !ourClientUnchanged {
+                b.localCommands.insert(LocalCommand.resetEngine(engine: "clients"))
+            }
+
             scratchpad = b.build()
 
             log.info("Advancing to InitialWithLiveToken.")

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -134,17 +134,21 @@ open class SyncStateMachine {
             }
             var scratchpad = prior ?? Scratchpad(b: KeyBundle.fromKB(kB), persistingTo: self.scratchpadPrefs)
 
-            // Take the scratchpad and add the hashedUID from the token
+            // Take the scratchpad and add the fxaDeviceId from the state, and hashedUID from the token
             let b = Scratchpad.Builder(p: scratchpad)
-            if let deviceRegistration = authState.deviceRegistration {
-                b.fxaDeviceId = deviceRegistration.id
+            if let deviceID = authState.deviceID {
+                b.fxaDeviceId = deviceID
+            } else {
+                // Either deviceRegistration hasn't occurred yet (our bug) or
+                // FxA has given us an UnknownDevice error.
+                log.warning("Device registration has not taken place before sync.")
             }
             b.hashedUID = token.hashedFxAUID
 
-            // Detect if the we've changed anything in our client record from the last time we synced,
+            // Detect if we've changed anything in our client record from the last time we synced…
             let ourClientUnchanged = (b.fxaDeviceId == scratchpad.fxaDeviceId)
 
-            // and if so, trigger a reset of clients.
+            // …and if so, trigger a reset of clients.
             if !ourClientUnchanged {
                 b.localCommands.insert(LocalCommand.resetEngine(engine: "clients"))
             }

--- a/Sync/Synchronizers/TabsSynchronizer.swift
+++ b/Sync/Synchronizers/TabsSynchronizer.swift
@@ -163,8 +163,8 @@ open class TabsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchroniz
 
             if !self.remoteHasChanges(info) {
                 // upload local tabs if they've changed or we're in a fresh start.
-                _ = uploadOurTabs(localTabs, toServer: tabsClient)
-                return deferMaybe(completedWithStats)
+                return uploadOurTabs(localTabs, toServer: tabsClient)
+                    >>> { deferMaybe(self.completedWithStats) }
             }
 
             return tabsClient.getSince(self.lastFetched)

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -20,8 +20,8 @@ class MockSyncAuthState: SyncAuthState {
     let serverRoot: String
     let kB: Data
 
-    var deviceRegistration: FxADeviceRegistration? {
-        return FxADeviceRegistration(id: "mock_device_id", version: 1, lastRegistered: 0)
+    var deviceID: String? {
+        return "mock_device_id"
     }
 
     init(serverRoot: String, kB: Data) {

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -20,6 +20,10 @@ class MockSyncAuthState: SyncAuthState {
     let serverRoot: String
     let kB: Data
 
+    var deviceRegistration: FxADeviceRegistration? {
+        return FxADeviceRegistration(id: "mock_device_id", version: 1, lastRegistered: 0)
+    }
+
     init(serverRoot: String, kB: Data) {
         self.serverRoot = serverRoot
         self.kB = kB


### PR DESCRIPTION
This PR rolls up a number of bug fixes found while investigating the difficult-to-characterize bug where tabs weren't being showing up on desktop _under certain circumstances_.

The two incidental fixes: 

 * setting the `fxaDeviceId` in the scratchpad is now moved to the `SyncStateMachine`. This is discussed in #3177. The similar work done there is now down here instead.
 * returning the correct stats from the `TabSynchronizer` when there were no new remote tabs to be synced.

The _certain circumstances_ are now clear: when the device is disconnected from the account, all tabs were wiped from the tabs table, even the open ones. This would account for why some people never saw the bug, others (with other usage patterns) always.

This PR obsoletes: #3192.

https://bugzilla.mozilla.org/show_bug.cgi?id=1395547