### PR TITLE
Bug 1400883 - Move update profile into view will disappear function

### DIFF
--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -315,7 +315,7 @@ class AccountStatusSetting: WithAccountSetting {
     
     func updateAccount(notification: Notification) {
         DispatchQueue.main.async {
-            self.settings.tableView.reloadRows(at: [IndexPath(row: 0, section: 0)], with: UITableViewRowAnimation.automatic)
+            self.settings.tableView.reloadData()
         }
     }
     

--- a/Client/Frontend/Settings/FxAContentViewController.swift
+++ b/Client/Frontend/Settings/FxAContentViewController.swift
@@ -54,15 +54,19 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
     }
 
     deinit {
-        NotificationCenter.default.removeObserver(self, name: NotificationFirefoxAccountVerified, object: nil)
-        
-        if AppConstants.MOZ_SHOW_FXA_AVATAR {
-            profile.getAccount()?.updateProfile()
-        }
+        NotificationCenter.default.removeObserver(self, name: NotificationFirefoxAccountVerified, object: nil)        
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        if AppConstants.MOZ_SHOW_FXA_AVATAR {
+            profile.getAccount()?.updateProfile()
+        }
     }
 
     override func makeWebView() -> WKWebView {

--- a/Client/Frontend/Settings/FxAContentViewController.swift
+++ b/Client/Frontend/Settings/FxAContentViewController.swift
@@ -61,8 +61,8 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
         super.viewDidLoad()
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         
         if AppConstants.MOZ_SHOW_FXA_AVATAR {
             profile.getAccount()?.updateProfile()


### PR DESCRIPTION
This PR moves the `account.updateProfile` method into the `viewWillDisappear` method and out of the `deinit` function.

I was not able to reproduce the crash associated with the bug, however, this is a low risk change because the profile update is still being performed and from the user's perspective it still functions as expected.

@jhugman r?