### PR TITLE
[NO BUG] boostrap.sh is clearing Carthage dir without --force

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,10 +14,7 @@
 
 if [ "$1" == "--force" ]; then
     rm -rf Carthage/*
-fi
-
-if ! cmp -s Cartfile.resolved Carthage/Cartfile.resolved; then
-  rm -rf Carthage/*
+    rm -rf ~/Library/Caches/org.carthage.CarthageKit
 fi
 
 # Only enable this on the Xcode Server because it times out if it does not


### PR DESCRIPTION
We have a left-over from the old caching logic that is clearing the Carthage dir.
Also, the flag `--force` should clear the carthage cache.