### PR TITLE
Bug 1387616: Stop toolbar from showing at bottom

### DIFF
--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -40,7 +40,7 @@ class TabScrollingController: NSObject {
     var footerBottomConstraint: Constraint?
     var headerTopConstraint: Constraint?
     var toolbarsShowing: Bool { return headerTopOffset == 0 }
-    fileprivate var suppressToolbarHiding: Bool = false
+
     fileprivate var isZoomedOut: Bool = false
     fileprivate var lastZoomedScale: CGFloat = 0
     fileprivate var isUserZoom: Bool = false
@@ -157,6 +157,11 @@ private extension TabScrollingController {
         return tab?.loading ?? true
     }
 
+    func isBouncingAtBottom() -> Bool {
+        guard let scrollView = scrollView else { return false }
+        return scrollView.contentOffset.y > (scrollView.contentSize.height - scrollView.frame.size.height) && scrollView.contentSize.height > scrollView.frame.size.height
+    }
+
     @objc func handlePan(_ gesture: UIPanGestureRecognizer) {
         if tabIsLoading() {
             return
@@ -209,6 +214,7 @@ private extension TabScrollingController {
         var updatedOffset = headerTopOffset - delta
         headerTopOffset = clamp(updatedOffset, min: -topScrollHeight, max: 0)
         if isHeaderDisplayedForGivenOffset(updatedOffset) {
+            print("isHeaderDisplayedForGivenOffset true")
             scrollView?.contentOffset = CGPoint(x: contentOffset.x, y: contentOffset.y - delta)
         }
 
@@ -270,27 +276,18 @@ extension TabScrollingController: UIGestureRecognizerDelegate {
 }
 
 extension TabScrollingController: UIScrollViewDelegate {
-    func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-        if targetContentOffset.pointee.y + scrollView.frame.size.height >= scrollView.contentSize.height {
-            suppressToolbarHiding = true
-            showToolbars(animated: true)
-        }
-    }
-
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-        if tabIsLoading() {
+        if tabIsLoading() || isBouncingAtBottom() {
             return
         }
 
         if (decelerate || (toolbarState == .animating && !decelerate)) && checkScrollHeightIsLargeEnoughForScrolling() {
             if scrollDirection == .up {
                 showToolbars(animated: true)
-            } else if scrollDirection == .down && !suppressToolbarHiding {
+            } else if scrollDirection == .down {
                 hideToolbars(animated: true)
             }
         }
-
-        suppressToolbarHiding = false
     }
 
     func scrollViewDidZoom(_ scrollView: UIScrollView) {

--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -214,7 +214,6 @@ private extension TabScrollingController {
         var updatedOffset = headerTopOffset - delta
         headerTopOffset = clamp(updatedOffset, min: -topScrollHeight, max: 0)
         if isHeaderDisplayedForGivenOffset(updatedOffset) {
-            print("isHeaderDisplayedForGivenOffset true")
             scrollView?.contentOffset = CGPoint(x: contentOffset.x, y: contentOffset.y - delta)
         }
 


### PR DESCRIPTION
This behaviour matches Focus iOS and Chrome iOS.

I think we tried to match Safari here however our toolbar show/hide has no other matching behaviour to Safari (which has different scroll up logic, also has a tap-at-bottom to show bottom toolbar).

I suspect this class is in need of a cleanup, for instance `scrollViewWillEndDragging` was being used which is for modifying the drag completion target (otherwise didEnd is the one to use). 