### PR TITLE
Bug 1396834 — Use tab manager to check if the clipboard url is already open.

### DIFF
--- a/Client/Extensions/UIPasteboardExtensions.swift
+++ b/Client/Extensions/UIPasteboardExtensions.swift
@@ -39,29 +39,27 @@ extension UIPasteboard {
     }
 
     /// Preferred method to get strings out of the clipboard.
-    /// The given queue defaults to the main thread.
     /// When iCloud pasteboards are enabled, the usually fast, synchronous calls
     /// become slow and synchronous causing very slow start up times.
-    func asyncString(queue: DispatchQueue = DispatchQueue.main) -> Deferred<Maybe<String?>> {
-        return fetchAsync(queue: queue) {
+    func asyncString() -> Deferred<Maybe<String?>> {
+        return fetchAsync() {
             return UIPasteboard.general.string
         }
     }
 
     /// Preferred method to get URLs out of the clipboard.
-    /// The given queue defaults to the main thread.
     /// We use Deferred<Maybe<T?>> to fit in to the rest of the Deferred<Maybe> tools
     /// we already use; but use optionals instead of errorTypes, because not having a URL
     /// on the clipboard isn't an error.
-    func asyncURL(queue: DispatchQueue = DispatchQueue.main) -> Deferred<Maybe<URL?>> {
-        return fetchAsync(queue: queue) {
+    func asyncURL() -> Deferred<Maybe<URL?>> {
+        return fetchAsync() {
             return self.syncURL
         }
     }
 
     // Converts the potentially long running synchronous operation into an asynchronous one.
-    private func fetchAsync<T>(queue: DispatchQueue, getter: @escaping () -> T) -> Deferred<Maybe<T>> {
-        let deferred = Deferred<Maybe<T>>(defaultQueue: queue)
+    private func fetchAsync<T>(getter: @escaping () -> T) -> Deferred<Maybe<T>> {
+        let deferred = Deferred<Maybe<T>>()
         DispatchQueue.global().async {
             let value = getter()
             deferred.fill(Maybe(success: value))

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -392,7 +392,7 @@ class BrowserViewController: UIViewController {
         self.view.addSubview(findInPageContainer)
 
         if AppConstants.MOZ_CLIPBOARD_BAR {
-            clipboardBarDisplayHandler = ClipboardBarDisplayHandler(prefs: profile.prefs)
+            clipboardBarDisplayHandler = ClipboardBarDisplayHandler(prefs: profile.prefs, tabManager: tabManager)
             clipboardBarDisplayHandler?.delegate = self
         }
         

--- a/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -42,7 +42,7 @@ class ClipboardBarDisplayHandler {
     
     @objc private func SELAppWillResignActive() {
         sessionStarted = true
-        UIPasteboard.general.asyncString().upon { res in
+        UIPasteboard.general.asyncString().uponQueue(.main) { res in
             if let value = res.successValue {
                 self.lastDisplayedURL = value
             }
@@ -79,7 +79,7 @@ class ClipboardBarDisplayHandler {
             // user has asked for it in settings.
             return
         }
-        UIPasteboard.general.asyncURL().upon { res in
+        UIPasteboard.general.asyncURL().uponQueue(.main) { res in
             guard let copiedURL: URL? = res.successValue,
                 let url = copiedURL else {
                 return


### PR DESCRIPTION
This PR adds checking of tab manager to check if a URL is already opened.

More importantly, it restores the concept of the lastDisplayedURL. 

a) the same URL is not offered more than once.
b) URLs copied from the browser aren't offered after app switching.
c) URLs that are loaded in opened tabs are not offered.

Overall, these two changes should make ClipboardBar less chatty.

https://bugzilla.mozilla.org/show_bug.cgi?id=1396834