### PR TITLE
Bug 1400339 - Make sure the progress bar animates correctly.

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -388,15 +388,9 @@ class URLBarView: UIView {
     }
 
     func updateProgressBar(_ progress: Float) {
-        if progress == 0 {
-            progressBar.animateGradient()
-        }
-        if progress == 1.0 {
-            progressBar.setProgress(progress, animated: !isTransitioning)
-            progressBar.hideProgressBar()
-        } else {
-            progressBar.setProgress(progress, animated: (progress > progressBar.progress) && !isTransitioning)
-        }
+        progressBar.alpha = 1
+        progressBar.isHidden = false
+        progressBar.setProgress(progress, animated: !isTransitioning)
     }
 
     func updateReaderModeState(_ state: ReaderModeState) {


### PR DESCRIPTION
This is actually 2 bugs but I'm too lazy to create the other one. 

The actual bug in bugzilla 
 - UITests check to see if the progressbar disappears from the view hierarchy as a way of detecting when the page is done loading. Make sure to set `progressbar.ishidden=true` when we finish the animation. Because their are multiple animation blocks and we only want to hide when they all finish this happens in the ProgressBar class itself. 

@antlam also wanted me to fix the animation 
- There is a pulsing animation that is pretty subtle but was not actually happening before. Its hard to see but if you try loading a large page you can notice it.
