### PR TITLE
Bug 1403367 - Fix issues with the share sheet on iPad

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1317,7 +1317,7 @@ extension BrowserViewController: URLBarDelegate {
     func urlBarDidPressPageOptions(_ urlBar: URLBarView, from button: UIButton) {
         
         let actionMenuPresenter: (URL, Tab, UIView, UIPopoverArrowDirection) -> Void  = { (url, tab, view, _) in
-            self.presentActivityViewController(url, tab: tab, sourceView: view, sourceRect: view.frame, arrowDirection: .up)
+            self.presentActivityViewController(url, tab: tab, sourceView: view, sourceRect: view.bounds, arrowDirection: .up)
         }
         
         let findInPageAction = {
@@ -1528,7 +1528,6 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     }
 
     func tabToolbarDidLongPressReload(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
-        // TODO: Should this be a PhotonActionSheet?
         guard let tab = tabManager.selectedTab, tab.webView?.url != nil && (tab.getHelper(name: ReaderMode.name()) as? ReaderMode)?.state != .active else {
             return
         }

--- a/Client/Frontend/Widgets/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet.swift
@@ -54,7 +54,7 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
     private lazy var showCancelButton: Bool = {
         return self.style == .bottom && self.modalPresentationStyle != .popover
     }()
-    private var tableView = UITableView(frame: CGRect.zero, style: .grouped)
+    var tableView = UITableView(frame: CGRect.zero, style: .grouped)
     private var tintColor = UIColor(rgb: 0x272727)
     private var outerScrollView = UIScrollView()
     
@@ -130,13 +130,10 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
         tableView.tableFooterView = footer
         tableView.tableHeaderView = footer.clone()
         tableView.backgroundColor = UIConstants.AppBackgroundColor.withAlphaComponent(0.7)
-        // TODO: Remove once we remove support for 9.0 (which is before this ships)
-        if #available(iOS 10.0, *) {
-            let blurEffect = UIBlurEffect(style: .light)
-            let blurEffectView = UIVisualEffectView(effect: blurEffect)
-            tableView.backgroundView = blurEffectView
-        }
-        
+        let blurEffect = UIBlurEffect(style: .light)
+        let blurEffectView = UIVisualEffectView(effect: blurEffect)
+        tableView.backgroundView = blurEffectView
+
         var width = min(self.view.frame.size.width, PhotonActionSheetUX.MaxWidth) - (PhotonActionSheetUX.Padding * 2)
         width = UIDevice.current.userInterfaceIdiom == .pad ? width : (self.view.frame.width - (PhotonActionSheetUX.Padding * 2))
         let height = actionSheetHeight()
@@ -442,9 +439,6 @@ private class PhotonActionSheetCell: UITableViewCell {
     
     override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        
-        //        layer.shouldRasterize = true
-        //        layer.rasterizationScale = UIScreen.main.scale
         
         isAccessibilityElement = true
         

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -23,11 +23,14 @@ extension PhotonActionSheetProtocol {
         sheet.photonTransitionDelegate = PhotonActionSheetAnimator()
         
         if let popoverVC = sheet.popoverPresentationController {
-            popoverVC.backgroundColor = UIColor.clear
             popoverVC.delegate = viewController
             popoverVC.sourceView = view
             popoverVC.sourceRect = CGRect(x: view.frame.width/2, y: view.frame.size.height * 0.75, width: 1, height: 1)
             popoverVC.permittedArrowDirections = UIPopoverArrowDirection.up
+            // Style the popoverVC instead of the tableView. This makes sure that the popover arrow is style as well
+            sheet.tableView.backgroundView = nil
+            sheet.tableView.backgroundColor = .clear
+            popoverVC.backgroundColor = UIConstants.AppBackgroundColor.withAlphaComponent(0.7)
         }
         viewController.present(sheet, animated: true, completion: nil)
     }


### PR DESCRIPTION
- The sourceRect when presenting a modal should be the bounds of the button and not the frame
- Dont style the tableview when displaying in a popover. Instead style the popover, this allows the style of the arrow to match the tableview. 


