### PR TITLE
Bug 1403589 - Remove a constraint that was added twice. This lets the bottom bar scroll again.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -677,7 +677,6 @@ class BrowserViewController: UIViewController {
 
         footer.snp.remakeConstraints { make in
             scrollController.footerBottomConstraint = make.bottom.equalTo(self.view.snp.bottom).constraint
-            make.bottom.equalTo(self.view.snp.bottom)
             make.leading.trailing.equalTo(self.view)
         }
 


### PR DESCRIPTION
Regression from https://github.com/mozilla-mobile/firefox-ios/pull/3215/files

The constraint I removed (`make.top.equalTo(snackbars.snp.bottom`) used to be one that pinned the top of the footer to the bottom of the snackbar. I dont think its needed because the snackbar already pins to the top of the footer. (`make.bottom.equalTo(footer.snp.top)`)

