### PR TITLE
Bug 1403140 — Ensure we can open URLs ending in index.html from today widget.

### DIFF
--- a/ClientTests/StringExtensionsTests.swift
+++ b/ClientTests/StringExtensionsTests.swift
@@ -58,4 +58,17 @@ class StringExtensionsTests: XCTestCase {
         XCTAssertEqual("aa\n bbbbbb", "aa bbbbbb".stringSplitWithNewline())
     }
 
+    func testPercentEscaping() {
+        func roundtripTest(_ input: String, _ expected: String, file: StaticString = #file, line: UInt = #line) {
+            let observed = input.escape()!
+            XCTAssertEqual(observed, expected, "input is \(input)", file: file, line: line)
+            let roundtrip = observed.unescape()
+            XCTAssertEqual(roundtrip, input, "encoded is \(observed)", file: file, line: line)
+        }
+
+        roundtripTest("https://mozilla.com", "https://mozilla.com")
+        roundtripTest("http://www.cnn.com/2017/09/25/politics/north-korea-fm-us-bombers/index.html", "http://www.cnn.com/2017/09/25/politics/north-korea-fm-us-bombers/index.html")
+        roundtripTest("http://mozilla.com/?a=foo&b=bar", "http://mozilla.com/%3Fa%3Dfoo%26b%3Dbar")
+    }
+
 }

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -178,9 +178,8 @@ class TodayViewController: UIViewController, NCWidgetProviding {
 
     @objc func onPressOpenClibpoard(_ view: UIView) {
         if let urlString = UIPasteboard.general.string,
-            let _ = URL(string: urlString) {
-            let encodedString =
-                urlString.escape()
+            let _ = URL(string: urlString),
+            let encodedString = urlString.escape() {
             openContainingApp("?url=\(encodedString)")
         }
     }

--- a/Shared/Extensions/StringExtensions.swift
+++ b/Shared/Extensions/StringExtensions.swift
@@ -29,18 +29,17 @@ public extension String {
         return false
     }
 
-    func escape() -> String {
-        let raw: NSString = self as NSString
-        let allowedEscapes = CharacterSet(charactersIn: ":/?&=;+!@#$()',*")
-        let str = raw.addingPercentEncoding(withAllowedCharacters: allowedEscapes)
-        return str as String!
+    func escape() -> String? {
+        // We can't guaruntee that strings have a valid string encoding, as this is an entry point for tainted data,
+        // we should be very careful about forcefully dereferencing optional types.
+        // https://stackoverflow.com/questions/33558933/why-is-the-return-value-of-string-addingpercentencoding-optional#33558934
+        let queryItemDividers = CharacterSet(charactersIn: "?=&")
+        let allowedEscapes = CharacterSet.urlQueryAllowed.symmetricDifference(queryItemDividers)
+        return self.addingPercentEncoding(withAllowedCharacters: allowedEscapes)
     }
 
-    func unescape() -> String {
-        return CFURLCreateStringByReplacingPercentEscapes(
-            kCFAllocatorDefault,
-            self as CFString,
-            "[]." as CFString) as String
+    func unescape() -> String? {
+        return self.removingPercentEncoding
     }
 
     /**


### PR DESCRIPTION
This PR fixes a long standing bug such that URLs containing some characters could either open an incorrect URL or crash the browser. The URLs need to be on the pasteboard, or coming from a different app via the firefox:// custom scheme.

https://bugzilla.mozilla.org/show_bug.cgi?id=1403140