### PR TITLE
Bug 1403142 — Instrumenting notifications with sentry.

### DIFF
--- a/Shared/SentryIntegration.swift
+++ b/Shared/SentryIntegration.swift
@@ -73,10 +73,10 @@ public class SentryIntegration {
     public func crash() {
         Client.shared?.crash()
     }
-    
+
     public func send(message: String, tag: String = "general", severity: SentrySeverity = .info, completion: SentryRequestFinished? = nil) {
         // Do not send messages from SwiftData or BrowserDB unless this is the Beta channel
-        if !enabled || (AppConstants.BuildChannel != .beta && (tag == "SwiftData" || tag == "BrowserDB")) {
+        if !enabled || (AppConstants.BuildChannel != .beta && (tag == "SwiftData" || tag == "BrowserDB" || tag == "NotificationService")) {
             if let completion = completion {
                 completion(nil)
             }
@@ -92,7 +92,7 @@ public class SentryIntegration {
 
     public func sendWithStacktrace(message: String, tag: String = "general", severity: SentrySeverity = .info, completion: SentryRequestFinished? = nil) {
         // Do not send messages from SwiftData or BrowserDB unless this is the Beta channel
-        if !enabled || (AppConstants.BuildChannel != .beta && (tag == "SwiftData" || tag == "BrowserDB")) {
+        if !enabled || (AppConstants.BuildChannel != .beta && (tag == "SwiftData" || tag == "BrowserDB" || tag == "NotificationService")) {
             if let completion = completion {
                 completion(nil)
             }


### PR DESCRIPTION
This PR adds instrumentation to the NotificationService, in an effort to find shake out blank notifications (not caused by Entitlements problems) and Tap To Begin notifications.

https://bugzilla.mozilla.org/show_bug.cgi?id=1403142