### PR TITLE
Bug 1403551 - The statusbar should style correctly when opening settings

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1860,8 +1860,7 @@ extension BrowserViewController: SearchViewControllerDelegate {
         let settingsNavigationController = SearchSettingsTableViewController()
         settingsNavigationController.model = self.profile.searchEngines
         settingsNavigationController.profile = self.profile
-
-        let navController = UINavigationController(rootViewController: settingsNavigationController)
+        let navController = ModalSettingsNavigationController(rootViewController: settingsNavigationController)
 
         self.present(navController, animated: true, completion: nil)
     }

--- a/Client/Frontend/Settings/SettingsNavigationController.swift
+++ b/Client/Frontend/Settings/SettingsNavigationController.swift
@@ -23,3 +23,9 @@ class SettingsNavigationController: UINavigationController {
 protocol PresentingModalViewControllerDelegate {
     func dismissPresentedModalViewController(_ modalViewController: UIViewController, animated: Bool)
 }
+
+class ModalSettingsNavigationController: UINavigationController {
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return UIStatusBarStyle.default
+    }
+}


### PR DESCRIPTION
The statusbar would be white on a white background when opening settings from the autocomplete view. 

