### PR TITLE
Bug 1403757 - Dont destroy the homepanels if we are loading pages from LocalHost

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -778,9 +778,13 @@ class BrowserViewController: UIViewController {
 
     fileprivate func updateInContentHomePanel(_ url: URL?) {
         if !urlBar.inOverlayMode {
-            if let url = url, url.isAboutHomeURL {
+            guard let url = url else {
+                hideHomePanelController()
+                return
+            }
+            if url.isAboutHomeURL {
                 showHomePanelController(inline: true)
-            } else {
+            } else if !url.isLocal {
                 hideHomePanelController()
             }
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -784,7 +784,7 @@ class BrowserViewController: UIViewController {
             }
             if url.isAboutHomeURL {
                 showHomePanelController(inline: true)
-            } else if !url.isLocal {
+            } else if !url.isLocal || url.isReaderModeURL {
                 hideHomePanelController()
             }
         }


### PR DESCRIPTION
When restoring a session what would happen is the TabManager would set the tabs url to the last URL (in this case homepanel). Then we would trigger the `selectedTabChanged` delegate method which would setup the home panel. 
Later, when we create the webview, we run sessionRestore which changes the URL to /about/sessionRestore this will destroy the homepanel. Then when sessionRestore finishes it'll create the homepanel again. 

This PR prevents `/sessionRestore` and `/error` from destroying the page.