### PR TITLE
Bug 1385986 — Tell FxA that we've signed out.

### DIFF
--- a/Account/FirefoxAccount.swift
+++ b/Account/FirefoxAccount.swift
@@ -327,6 +327,18 @@ open class FirefoxAccount {
         }
     }
 
+    @discardableResult open func destroyDevice() -> Success {
+        guard let session = stateCache.value as? TokenState else {
+            return deferMaybe(NotATokenStateError(state: stateCache.value))
+        }
+        guard let ownDeviceId = self.deviceRegistration?.id else {
+            return deferMaybe(FxAClientError.local(NSError()))
+        }
+        let client = FxAClient10(authEndpoint: self.configuration.authEndpointURL)
+
+        return client.destroyDevice(ownDeviceId: ownDeviceId, withSessionToken: session.sessionToken as NSData) >>> succeed
+    }
+
     @discardableResult open func advance() -> Deferred<FxAState> {
         OSSpinLockLock(&advanceLock)
         if let deferred = advanceDeferred {

--- a/Client/Helpers/FxALoginHelper.swift
+++ b/Client/Helpers/FxALoginHelper.swift
@@ -336,7 +336,11 @@ extension FxALoginHelper {
             _ = pushClient.unregister(pushRegistration)
         }
 
-        // TODO: fix https://bugzilla.mozilla.org/show_bug.cgi?id=1300641 , to tell Sync and FxA we're no longer attached.
+        // TODO: fix Bug 1168690, to tell Sync to delete this client and its tabs.
+        // i.e. upload a {deleted: true} client record.
+
+        // Tell FxA we're no longer attached.
+        self.account.destroyDevice()
 
         // Cleanup the database.
         self.profile?.removeAccount()


### PR DESCRIPTION
In pursuit of fixing [the bug about device_disconnected not working between iOS devices][device_disconnected], this PR hits the /account/device/destroy endpoint to tell FxA that you've signed out. This in turn notifies other devices.

Thus, we should see a tidied list in the [settings/clients][settings_screenshot] page.

Regrettably, [Synced Tabs will still continue to show the device in desktop][client_record]. 

[device_disconnected]: https://bugzilla.mozilla.org/show_bug.cgi?id=1398186
[settings_screenshot]: https://screenshots.firefox.com/HR9RWgPk43sUuiO9/accounts.firefox.com
[client_record]: https://bugzilla.mozilla.org/show_bug.cgi?id=1168690

https://bugzilla.mozilla.org/show_bug.cgi?id=1385986