### PR TITLE
Bug 1403958 — Don't rely on push notifications to verify the account by email.

### DIFF
--- a/Account/FxAPushMessageHandler.swift
+++ b/Account/FxAPushMessageHandler.swift
@@ -107,7 +107,13 @@ extension FxAPushMessageHandler {
     // doesn't tap on the notification), but that's okay because:
     // We'll naturally be syncing shortly after startup.
     func postVerification() -> Success {
-        return profile.syncManager?.syncEverything(why: .didLogin) ?? succeed()
+        if let account = profile.getAccount(),
+            let syncManager = profile.syncManager {
+            return account.advance().bind { _ in
+                return syncManager.syncEverything(why: .didLogin)
+            } >>> succeed
+        }
+        return succeed()
     }
 }
 

--- a/Client/Helpers/FxALoginHelper.swift
+++ b/Client/Helpers/FxALoginHelper.swift
@@ -293,12 +293,6 @@ class FxALoginHelper {
                 return self.performVerifiedSync(profile, account: account)
             }
 
-            if account.pushRegistration != nil {
-                // Verification hasn't occurred yet, but we've registered for push 
-                // so we can wait for a push notification in FxAPushMessageHandler.
-                return
-            }
-
             let queue = DispatchQueue.global(qos: DispatchQoS.background.qosClass)
             queue.asyncAfter(deadline: DispatchTime.now() + verificationPollingInterval) {
                 self.awaitVerification(attemptsLeft - 1)


### PR DESCRIPTION
This PR fixes two paths to syncing after verification that are only available on the device.

1. push notifications need to be lead through the account.advance() once the account has been actually verified.
2. the fallback doesn't assume that push notifications are available.

https://bugzilla.mozilla.org/show_bug.cgi?id=1403958