### PR TITLE
Bug 1404265: crash: tab needs to init content blocker before didCreateWebView

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1666,7 +1666,7 @@ extension BrowserViewController: TabDelegate {
         tab.addHelper(historyStateHelper, name: HistoryStateHelper.name())
         
         if #available(iOS 11, *) {
-            tab.contentBlocker = ContentBlockerHelper(tab: tab, profile: profile)
+            (tab.contentBlocker as? ContentBlockerHelper)?.setupForWebView()
         }
 
         let metadataHelper = MetadataParserHelper(tab: tab, profile: profile)

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -74,9 +74,8 @@ class Tab: NSObject {
                 return
             }
             _noImageMode = newValue
-            // Forced unwrap ok, a side effect of contentBlocker being iOS11+ var.
-            let helper = (contentBlocker as! ContentBlockerHelper)
-            helper.noImageMode(enabled: _noImageMode)
+            let helper = (contentBlocker as? ContentBlockerHelper)
+            helper?.noImageMode(enabled: _noImageMode)
         }
     }
 
@@ -111,14 +110,16 @@ class Tab: NSObject {
     /// tab instance, queue it for later until we become foregrounded.
     fileprivate var alertQueue = [JSAlertInfo]()
 
-    init(configuration: WKWebViewConfiguration) {
-        self.configuration = configuration
-    }
-
-    init(configuration: WKWebViewConfiguration, isPrivate: Bool) {
+    init(configuration: WKWebViewConfiguration, isPrivate: Bool = false) {
         self.configuration = configuration
         super.init()
         self.isPrivate = isPrivate
+
+        if #available(iOS 11, *) {
+            if let appDelegate = UIApplication.shared.delegate as? AppDelegate, let profile = appDelegate.profile {
+                contentBlocker = ContentBlockerHelper(tab: self, profile: profile)
+            }
+        }
     }
 
     class func toTab(_ tab: Tab) -> RemoteTab? {

--- a/Client/Frontend/ContentBlocker/ContentBlockerHelper.swift
+++ b/Client/Frontend/ContentBlocker/ContentBlockerHelper.swift
@@ -81,9 +81,6 @@ class ContentBlockerHelper {
         self.tab = tab
         self.profile = profile
 
-        NotificationCenter.default.addObserver(self, selector: #selector(ContentBlockerHelper.reloadTab), name: NSNotification.Name(rawValue: NotificationContentBlockerReloadNeeded), object: nil)
-        addActiveRulesToTab()
-
         if ContentBlockerHelper.heavyInitHasRunOnce {
             return
         }
@@ -101,6 +98,11 @@ class ContentBlockerHelper {
             assert(rule != nil && error == nil)
             ContentBlockerHelper.blockImagesRule = rule
         }
+    }
+
+    func setupForWebView() {
+        NotificationCenter.default.addObserver(self, selector: #selector(ContentBlockerHelper.reloadTab), name: NSNotification.Name(rawValue: NotificationContentBlockerReloadNeeded), object: nil)
+        addActiveRulesToTab()
     }
 
     deinit {


### PR DESCRIPTION
Remove the assumption that a Tab object will have helpers installed.
The ContentBlockerHelper now gets init'd in Tab init, and then installed to the
webview in didCreateWebView. This makes more sense in retrospect, not all of the
class function is a webview helper, unlike most of the other helpers.

https://bugzilla.mozilla.org/show_bug.cgi?id=1404265