### PR TITLE
Bug 1392761 - Pull Down in Bookmarks to Trigger a Bookmark Sync Refresh

### DIFF
--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -89,6 +89,11 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         loadData()
     }
     
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        refreshControl?.removeTarget(self, action: #selector(BookmarksPanel.refreshBookmarks), for: .valueChanged)
+    }
+    
     func loadData() {
         // If we've not already set a source for this panel, fetch a new model from
         // the root; otherwise, just use the existing source to select a folder.

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -43,6 +43,7 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
     var source: BookmarksModel?
     var parentFolders = [BookmarkFolder]()
     var bookmarkFolder: BookmarkFolder?
+    var refreshControl: UIRefreshControl?
 
     fileprivate lazy var longPressRecognizer: UILongPressGestureRecognizer = {
         return UILongPressGestureRecognizer(target: self, action: #selector(BookmarksPanel.longPress(_:)))
@@ -75,11 +76,20 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         tableView.addGestureRecognizer(longPressRecognizer)
 
         self.tableView.accessibilityIdentifier = "Bookmarks List"
+        
+        self.refreshControl = UIRefreshControl()
+        self.tableView.addSubview(refreshControl!)
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        
+        refreshControl?.addTarget(self, action: #selector(BookmarksPanel.refreshBookmarks), for: .valueChanged)
 
+        loadData()
+    }
+    
+    func loadData() {
         // If we've not already set a source for this panel, fetch a new model from
         // the root; otherwise, just use the existing source to select a folder.
         guard let source = self.source else {
@@ -91,7 +101,7 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
             }
             return
         }
-
+        
         if let bookmarkFolder = bookmarkFolder {
             source.selectFolder(bookmarkFolder).upon(onModelFetched)
         } else {
@@ -108,6 +118,15 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
             // no need to do anything at all
             log.warning("Received unexpected notification \(notification.name)")
             break
+        }
+    }
+    
+    @objc fileprivate func refreshBookmarks() {
+        profile.syncManager.mirrorBookmarks().upon { (_) in
+            DispatchQueue.main.async {
+                self.loadData()
+                self.refreshControl?.endRefreshing()
+            }
         }
     }
 

--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -29,6 +29,7 @@ open class MockSyncManager: SyncManager {
     open func syncClientsThenTabs() -> SyncResult { return completedWithStats(collection: "mock_clientsandtabs") }
     open func syncHistory() -> SyncResult { return completedWithStats(collection: "mock_history") }
     open func syncLogins() -> SyncResult { return completedWithStats(collection: "mock_logins") }
+    open func mirrorBookmarks() -> SyncResult { return completedWithStats(collection: "mock_bookmarks") }
     open func syncEverything(why: SyncReason) -> Success {
         return succeed()
     }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -34,6 +34,7 @@ public protocol SyncManager {
     func syncClientsThenTabs() -> SyncResult
     func syncHistory() -> SyncResult
     func syncLogins() -> SyncResult
+    func mirrorBookmarks() -> SyncResult
     @discardableResult func syncEverything(why: SyncReason) -> Success
     func syncNamedCollections(why: SyncReason, names: [String]) -> Success
 
@@ -1207,7 +1208,7 @@ open class BrowserProfile: Profile {
             return self.sync("history", function: syncHistoryWithDelegate)
         }
 
-        func mirrorBookmarks() -> SyncResult {
+        public func mirrorBookmarks() -> SyncResult {
             return self.sync("bookmarks", function: mirrorBookmarksWithDelegate)
         }
 

--- a/UITests/BookmarksPanelTests.swift
+++ b/UITests/BookmarksPanelTests.swift
@@ -144,4 +144,28 @@ class BookmarksPanelTests: KIFTestCase {
         navigateFolder(withTitle: "remote-subfolder")
         assertRowExists(withTitle: "item-in-remote-subfolder")
     }
+    
+    func testRefreshBookmarks() {
+        createSomeBufferBookmarks()
+        guard let bookmarks = getAppBookmarkStorage() else {
+            return
+        }
+        let applyResult = bookmarks.applyRecords([
+            makeBookmark(guid: "bm-guid0", parentID: BookmarkRoots.MobileFolderGUID, title: "xyz"),
+            makeFolder(guid: BookmarkRoots.MobileFolderGUID, parentID: BookmarkRoots.RootGUID, title: "", childrenGuids: ["bm-guid0"])
+            ])
+        XCTAssert(applyResult.value.isSuccess)
+        EarlGrey.select(elementWithMatcher: grey_accessibilityLabel("Bookmarks")).perform(grey_tap())
+        
+        // Add a bookmark
+        let isAdded = (bookmarks as! MergedSQLiteBookmarks).local.addToMobileBookmarks(URL(string: "http://new-bookmark")!, title: "NewBookmark", favicon: nil)
+        XCTAssert(isAdded.value.isSuccess)
+        
+        // Pull to refresh
+        assertRowExists(withTitle: "xyz")
+        EarlGrey.select(elementWithMatcher: grey_accessibilityLabel("xyz")).inRoot(grey_kindOfClass(NSClassFromString("UITableView")!)).perform(grey_swipeSlowInDirectionWithStartPoint(.down, 0.7, 0.7))
+        
+        // Verify new bookmark exists
+        assertRowExists(withTitle: "NewBookmark")
+    }
 }


### PR DESCRIPTION
This PR adds pull to refresh to the Bookmarks screen. If the account is synced this triggers a sync and reloads the data from the local database.

Here is the screenshot gif: http://g.recordit.co/lg4EsHknpL.gif

This is a clone of PR #3136, that BuddyBuild couldn't build — because it came from a third party repo.

Closes #3136.

https://bugzilla.mozilla.org/show_bug.cgi?id=1392761