### PR TITLE
Bug 1404920 — Use UIPasteboard.general.asyncURL() in Today widget.

### DIFF
--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -31,6 +31,8 @@ struct TodayUX {
 @objc (TodayViewController)
 class TodayViewController: UIViewController, NCWidgetProviding {
 
+    var copiedURL: URL?
+
     fileprivate lazy var newTabButton: ImageButtonWithLabel = {
         let imageButton = ImageButtonWithLabel()
         imageButton.addTarget(self, action: #selector(onPressNewTab), forControlEvents: .touchUpInside)
@@ -151,12 +153,17 @@ class TodayViewController: UIViewController, NCWidgetProviding {
     }
 
     func updateCopiedLink() {
-        if let url = UIPasteboard.general.copiedURL {
-            self.openCopiedLinkButton.isHidden = false
-            self.openCopiedLinkButton.subtitleLabel.isHidden = SystemUtils.isDeviceLocked()
-            self.openCopiedLinkButton.subtitleLabel.text = url.absoluteString
-        } else {
-            self.openCopiedLinkButton.isHidden = true
+        UIPasteboard.general.asyncURL().uponQueue(.main) { res in
+            if let copiedURL: URL? = res.successValue,
+                let url = copiedURL {
+                self.openCopiedLinkButton.isHidden = false
+                self.openCopiedLinkButton.subtitleLabel.isHidden = SystemUtils.isDeviceLocked()
+                self.openCopiedLinkButton.subtitleLabel.text = url.absoluteDisplayString
+                self.copiedURL = url
+            } else {
+                self.openCopiedLinkButton.isHidden = true
+                self.copiedURL = nil
+            }
         }
     }
 
@@ -177,9 +184,8 @@ class TodayViewController: UIViewController, NCWidgetProviding {
     }
 
     @objc func onPressOpenClibpoard(_ view: UIView) {
-        if let urlString = UIPasteboard.general.string,
-            let _ = URL(string: urlString),
-            let encodedString = urlString.escape() {
+        if let url = copiedURL,
+            let encodedString = url.absoluteString.escape() {
             openContainingApp("?url=\(encodedString)")
         }
     }


### PR DESCRIPTION
This PR changes the today widget to use asyncURL instead of the now deprecated `.copiedURL`.

https://bugzilla.mozilla.org/show_bug.cgi?id=1404920