### PR TITLE
Bug 1364583 - Update Private browsing mode colors

### DIFF
--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -310,9 +310,8 @@ private func createTransitionCellFromTab(_ tab: Tab?, withFrame frame: CGRect) -
     if let favIcon = tab?.displayFavicon {
         cell.favicon.sd_setImage(with: URL(string: favIcon.url)!)
     } else {
-        var defaultFavicon = UIImage(named: "defaultFavicon")
+        let defaultFavicon = UIImage(named: "defaultFavicon")
         if tab?.isPrivate ?? false {
-            defaultFavicon = defaultFavicon?.withRenderingMode(.alwaysTemplate)
             cell.favicon.image = defaultFavicon
             cell.favicon.tintColor = (tab?.isPrivate ?? false) ? UIColor.white : UIColor.darkGray
         } else {

--- a/Client/Frontend/Browser/ReaderModeBarView.swift
+++ b/Client/Frontend/Browser/ReaderModeBarView.swift
@@ -49,13 +49,13 @@ struct ReaderModeBarViewUX {
     static let Themes: [String: Theme] = {
         var themes = [String: Theme]()
         var theme = Theme()
-        theme.backgroundColor = UIConstants.PrivateModeAssistantToolbarBackgroundColor
-        theme.buttonTintColor = UIColor.white
+        theme.backgroundColor = UIColor(rgb: 0x38383D)
+        theme.buttonTintColor = UIColor(rgb: 0xf9f9fA)
         themes[Theme.PrivateMode] = theme
 
         theme = Theme()
-        theme.backgroundColor = UIColor.white
-        theme.buttonTintColor = UIColor.darkGray
+        theme.backgroundColor = UIColor(rgb: 0xf9f9fA)
+        theme.buttonTintColor = UIColor(rgb: 0x272727)
         themes[Theme.NormalMode] = theme
 
         return themes

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -307,13 +307,16 @@ extension TabLocationView: Themeable {
             log.error("Unable to apply unknown theme \(themeName)")
             return
         }
+        let isPrivate = themeName == Theme.PrivateMode
         self.backgroundColor = theme.backgroundColor
         self.urlTextField.textColor = theme.textColor
         self.readerModeButton.selectedTintColor = theme.highlightButtonColor
         self.readerModeButton.unselectedTintColor = theme.buttonTintColor
         self.pageOptionsButton.selectedTintColor = theme.highlightButtonColor
-        self.pageOptionsButton.unselectedTintColor = theme.buttonTintColor
-        self.pageOptionsButton.tintColor = theme.buttonTintColor
+
+        self.pageOptionsButton.unselectedTintColor = isPrivate ? UIColor(rgb: 0xD2d2d4) : UIColor(rgb: 0x272727)
+        self.pageOptionsButton.tintColor = self.pageOptionsButton.unselectedTintColor
+        separatorLine.backgroundColor = isPrivate ? UIColor(rgb: 0x3f3f43) : UIColor(rgb: 0xE5E5E5)
     }
 }
 

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -308,14 +308,14 @@ extension TabLocationView: Themeable {
             return
         }
         let isPrivate = themeName == Theme.PrivateMode
-        self.backgroundColor = theme.backgroundColor
-        self.urlTextField.textColor = theme.textColor
-        self.readerModeButton.selectedTintColor = theme.highlightButtonColor
-        self.readerModeButton.unselectedTintColor = theme.buttonTintColor
-        self.pageOptionsButton.selectedTintColor = theme.highlightButtonColor
+        backgroundColor = theme.backgroundColor
+        urlTextField.textColor = theme.textColor
+        readerModeButton.selectedTintColor = theme.highlightButtonColor
+        readerModeButton.unselectedTintColor = theme.buttonTintColor
+        pageOptionsButton.selectedTintColor = theme.highlightButtonColor
 
-        self.pageOptionsButton.unselectedTintColor = isPrivate ? UIColor(rgb: 0xD2d2d4) : UIColor(rgb: 0x272727)
-        self.pageOptionsButton.tintColor = self.pageOptionsButton.unselectedTintColor
+        pageOptionsButton.unselectedTintColor = isPrivate ? UIColor(rgb: 0xD2d2d4) : UIColor(rgb: 0x272727)
+        pageOptionsButton.tintColor = pageOptionsButton.unselectedTintColor
         separatorLine.backgroundColor = isPrivate ? UIColor(rgb: 0x3f3f43) : UIColor(rgb: 0xE5E5E5)
     }
 }

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -33,7 +33,7 @@ struct TabLocationViewUX {
         theme.URLFontColor = UIColor.lightGray
         theme.textColor = UIColor(rgb: 0xf9f9fa)
         theme.highlightButtonColor = UIConstants.PrivateModePurple
-        theme.buttonTintColor = UIColor(rgb: 0xf9f9fa)
+        theme.buttonTintColor = UIColor(rgb: 0xADADb0)
         theme.backgroundColor = UIColor(rgb: 0x636369)
         themes[Theme.PrivateMode] = theme
 
@@ -322,7 +322,8 @@ class ReaderModeButton: UIButton {
     var unselectedTintColor: UIColor?
     override init(frame: CGRect) {
         super.init(frame: frame)
-        setImage(UIImage.templateImageNamed("reader"), for: UIControlState())
+        adjustsImageWhenHighlighted = false
+        setImage(UIImage.templateImageNamed("reader"), for: .normal)
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -331,7 +332,19 @@ class ReaderModeButton: UIButton {
     
     override var isSelected: Bool {
         didSet {
-            self.tintColor = isSelected ? selectedTintColor : unselectedTintColor
+            self.tintColor = (isHighlighted || isSelected) ? selectedTintColor : unselectedTintColor
+        }
+    }
+
+    override open var isHighlighted: Bool {
+        didSet {
+            self.tintColor = (isHighlighted || isSelected) ? selectedTintColor : unselectedTintColor
+        }
+    }
+
+    override var tintColor: UIColor! {
+        didSet {
+            self.imageView?.tintColor = self.tintColor
         }
     }
     

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -144,7 +144,7 @@ class ToolbarButton: UIButton {
     static let Themes: [String: Theme] = {
         var themes = [String: Theme]()
         var theme = Theme()
-        theme.buttonTintColor = UIConstants.PrivateModeActionButtonTintColor
+        theme.buttonTintColor = UIColor(rgb: 0xf9f9fa)
         theme.highlightButtonColor = UIColor(rgb: 0xAC39FF)
         theme.disabledButtonColor = UIColor.gray
         themes[Theme.PrivateMode] = theme
@@ -223,7 +223,7 @@ class TabToolbar: Toolbar, TabToolbarProtocol {
     static let Themes: [String: Theme] = {
         var themes = [String: Theme]()
         var theme = Theme()
-        theme.backgroundColor = UIColor(rgb: 0x4A4A4F)
+        theme.backgroundColor = UIColor(rgb: 0x38383D)
         themes[Theme.PrivateMode] = theme
 
         theme = Theme()

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -144,7 +144,7 @@ class ToolbarButton: UIButton {
     static let Themes: [String: Theme] = {
         var themes = [String: Theme]()
         var theme = Theme()
-        theme.buttonTintColor = UIColor(rgb: 0xf9f9fa)
+        theme.buttonTintColor = UIColor(rgb: 0xd2d2d4)
         theme.highlightButtonColor = UIColor(rgb: 0xAC39FF)
         theme.disabledButtonColor = UIColor.gray
         themes[Theme.PrivateMode] = theme

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -1013,7 +1013,7 @@ class TrayToolbar: UIView {
         let button = UIButton()
         button.setImage(UIImage.templateImageNamed("action_delete"), for: .normal)
         button.accessibilityLabel = Strings.TabTrayDeleteMenuButtonAccessibilityLabel
-        button.accessibilityIdentifier = "TabTrayController.remoteTabsButton"
+        button.accessibilityIdentifier = "TabTrayController.removeTabsButton"
         return button
     }()
 

--- a/Client/Frontend/Browser/TopTabsLayout.swift
+++ b/Client/Frontend/Browser/TopTabsLayout.swift
@@ -41,6 +41,7 @@ class TopTabsViewLayout: UICollectionViewFlowLayout {
     var decorationAttributeArr: [Int : UICollectionViewLayoutAttributes?] = [:]
     let separatorYOffset = TopTabsUX.SeparatorYOffset
     let separatorSize = TopTabsUX.SeparatorHeight
+    let SeparatorZIndex = -2 ///Prevent the header/footer from appearing above the Tabs
     
     override var collectionViewContentSize: CGSize {
         let tabsWidth = ((CGFloat(collectionView!.numberOfItems(inSection: 0))) * (TopTabsUX.TabWidth + TopTabsUX.SeparatorWidth)) - TopTabsUX.SeparatorWidth
@@ -64,7 +65,7 @@ class TopTabsViewLayout: UICollectionViewFlowLayout {
         guard indexPath.row < self.collectionView!.numberOfItems(inSection: 0) else {
             let separatorAttr = UICollectionViewLayoutAttributes(forDecorationViewOfKind: TopTabsSeparatorUX.Identifier, with: indexPath)
             separatorAttr.frame = CGRect.zero
-            separatorAttr.zIndex = -2 //Prevent the header/footer from appearing above the Tabs
+            separatorAttr.zIndex = SeparatorZIndex
             return separatorAttr
         }
 
@@ -75,14 +76,14 @@ class TopTabsViewLayout: UICollectionViewFlowLayout {
             let separatorAttr = UICollectionViewLayoutAttributes(forDecorationViewOfKind: TopTabsSeparatorUX.Identifier, with: indexPath)
             let x = TopTabsUX.TopTabsBackgroundShadowWidth + ((CGFloat(indexPath.row) * (TopTabsUX.TabWidth + TopTabsUX.SeparatorWidth)) - TopTabsUX.SeparatorWidth)
             separatorAttr.frame = CGRect(x: x, y: separatorYOffset, width: TopTabsUX.SeparatorWidth, height: separatorSize)
-            separatorAttr.zIndex = -2 //Prevent the header/footer from appearing above the Tabs
+            separatorAttr.zIndex = SeparatorZIndex
             return separatorAttr
         }
     }
 
     override func layoutAttributesForSupplementaryView(ofKind elementKind: String, at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
         let attributes = super.layoutAttributesForSupplementaryView(ofKind: elementKind, at: indexPath)
-        attributes?.zIndex = -2
+        attributes?.zIndex = SeparatorZIndex
         return attributes
     }
 
@@ -92,12 +93,12 @@ class TopTabsViewLayout: UICollectionViewFlowLayout {
         // Create attributes for the Tab Separator.
         for i in attributes {
             guard i.representedElementKind != UICollectionElementKindSectionHeader && i.representedElementKind != UICollectionElementKindSectionFooter else {
-                i.zIndex = -2 //Prevent the header/footer from appearing above the Tabs
+                i.zIndex = SeparatorZIndex
                 continue
             }
             let sep = UICollectionViewLayoutAttributes(forDecorationViewOfKind: TopTabsSeparatorUX.Identifier, with: i.indexPath)
             sep.frame = CGRect(x: i.frame.origin.x - TopTabsUX.SeparatorWidth, y: separatorYOffset, width: TopTabsUX.SeparatorWidth, height: separatorSize)
-            sep.zIndex = -2
+            sep.zIndex = SeparatorZIndex
             i.zIndex = 10
 
             // Only add the seperator if it will be shown.

--- a/Client/Frontend/Browser/TopTabsLayout.swift
+++ b/Client/Frontend/Browser/TopTabsLayout.swift
@@ -80,6 +80,12 @@ class TopTabsViewLayout: UICollectionViewFlowLayout {
         }
     }
 
+    override func layoutAttributesForSupplementaryView(ofKind elementKind: String, at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+        let attributes = super.layoutAttributesForSupplementaryView(ofKind: elementKind, at: indexPath)
+        attributes?.zIndex = -2
+        return attributes
+    }
+
     override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
         var attributes = super.layoutAttributesForElements(in: rect)!
 

--- a/Client/Frontend/Browser/TopTabsLayout.swift
+++ b/Client/Frontend/Browser/TopTabsLayout.swift
@@ -64,7 +64,7 @@ class TopTabsViewLayout: UICollectionViewFlowLayout {
         guard indexPath.row < self.collectionView!.numberOfItems(inSection: 0) else {
             let separatorAttr = UICollectionViewLayoutAttributes(forDecorationViewOfKind: TopTabsSeparatorUX.Identifier, with: indexPath)
             separatorAttr.frame = CGRect.zero
-            separatorAttr.zIndex = -2
+            separatorAttr.zIndex = -2 //Prevent the header/footer from appearing above the Tabs
             return separatorAttr
         }
 
@@ -75,7 +75,7 @@ class TopTabsViewLayout: UICollectionViewFlowLayout {
             let separatorAttr = UICollectionViewLayoutAttributes(forDecorationViewOfKind: TopTabsSeparatorUX.Identifier, with: indexPath)
             let x = TopTabsUX.TopTabsBackgroundShadowWidth + ((CGFloat(indexPath.row) * (TopTabsUX.TabWidth + TopTabsUX.SeparatorWidth)) - TopTabsUX.SeparatorWidth)
             separatorAttr.frame = CGRect(x: x, y: separatorYOffset, width: TopTabsUX.SeparatorWidth, height: separatorSize)
-            separatorAttr.zIndex = -2
+            separatorAttr.zIndex = -2 //Prevent the header/footer from appearing above the Tabs
             return separatorAttr
         }
     }

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -8,7 +8,7 @@ import WebKit
 
 struct TopTabsUX {
     static let TopTabsViewHeight: CGFloat = 44
-    static let TopTabsBackgroundColor = UIColor(rgb: 0x272727)
+    static let TopTabsBackgroundColor = UIColor(rgb: 0x2a2a2e)
     static let TopTabsBackgroundPadding: CGFloat = 35
     static let TopTabsBackgroundShadowWidth: CGFloat = 12
     static let TabWidth: CGFloat = 190

--- a/Client/Frontend/Browser/TopTabsViews.swift
+++ b/Client/Frontend/Browser/TopTabsViews.swift
@@ -80,7 +80,7 @@ class TopTabCell: UICollectionViewCell {
             closeButton.tintColor = selectedTab ? UIColor(rgb: 0x272727) : UIColor(rgb: 0xb1b1b3)
             // restyle if we are in PBM
             if style == .dark && selectedTab {
-                backgroundColor =  UIColor(rgb: 0x4A4A4F)
+                backgroundColor =  UIColor(rgb: 0x38383D)
                 titleText.textColor = UIColor(rgb: 0xf9f9fa)
                 closeButton.tintColor = UIColor(rgb: 0xf9f9fa)
             }
@@ -176,7 +176,7 @@ class TopTabCell: UICollectionViewCell {
             highlightLine.backgroundColor = UIColor(rgb:0x0066DC)
         case Style.dark:
             titleText.textColor = UIColor.lightText
-            backgroundColor = UIColor(rgb: 0x4A4A4F)
+            backgroundColor = UIColor(rgb: 0x38383D)
             highlightLine.backgroundColor = UIColor(rgb: 0x9400ff)
         }
     }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -32,12 +32,12 @@ struct URLBarViewUX {
     static let Themes: [String: Theme] = {
         var themes = [String: Theme]()
         var theme = Theme()
-        theme.borderColor = UIColor(rgb: 0x39393e)
-        theme.backgroundColor = UIColor(rgb: 0x4A4A4F)
-        theme.activeBorderColor = UIColor(rgb: 0x440071)
+        theme.borderColor = UIColor(rgb: 0x2D2D31)
+        theme.backgroundColor = UIColor(rgb: 0x38383D)
+        theme.activeBorderColor = UIColor(rgb: 0x4a4a4f)
         theme.tintColor = UIColor(rgb: 0xf9f9fa)
         theme.textColor = UIColor(rgb: 0xf9f9fa)
-        theme.buttonTintColor = UIConstants.PrivateModeActionButtonTintColor
+        theme.buttonTintColor = UIColor(rgb: 0xD2d2d4)
         theme.disabledButtonColor = UIColor.gray
         theme.highlightButtonColor = UIColor(rgb: 0xAC39FF)
         themes[Theme.PrivateMode] = theme
@@ -663,8 +663,8 @@ extension URLBarView: Themeable {
         currentTheme = themeName
         locationBorderColor = theme.borderColor!
         locationActiveBorderColor = theme.activeBorderColor!
-        cancelTintColor = theme.textColor
-        showQRButtonTintColor = theme.textColor
+        cancelTintColor = theme.buttonTintColor
+        showQRButtonTintColor = theme.buttonTintColor
         backgroundColor = theme.backgroundColor
         self.actionButtons.forEach { $0.applyTheme(themeName) }
         tabsButton.applyTheme(themeName)

--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -62,14 +62,14 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
     static let Themes: [String: Theme] = {
         var themes = [String: Theme]()
         var theme = Theme()
-        theme.backgroundColor = UIColor(rgb: 0x4A4A4F)
+        theme.backgroundColor = UIConstants.AppBackgroundColor
         theme.buttonTintColor = UIColor(rgb: 0x7e7e7f)
-        theme.highlightButtonColor = UIColor(rgb: 0x9400ff)
+        theme.highlightButtonColor = UIConstants.HighlightBlue
         themes[Theme.PrivateMode] = theme
 
         theme = Theme()
         theme.backgroundColor = UIConstants.AppBackgroundColor
-        theme.buttonTintColor = HomePanelViewControllerUX.ToolbarButtonDeselectedColorNormalMode
+        theme.buttonTintColor = UIColor(rgb: 0x7e7e7f)
         theme.highlightButtonColor = UIConstants.HighlightBlue
         themes[Theme.NormalMode] = theme
         

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -204,6 +204,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         label.font = self.font
         label.accessibilityIdentifier = "autocomplete"
         label.backgroundColor = self.backgroundColor
+        label.textColor = self.textColor
 
         let enteredTextSize = self.attributedText?.boundingRect(with: self.frame.size, options: NSStringDrawingOptions.usesLineFragmentOrigin, context: nil)
         frame.origin.x = (enteredTextSize?.width.rounded() ?? 0)

--- a/Client/Frontend/Widgets/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet.swift
@@ -129,10 +129,17 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
         let footer = UIView(frame: CGRect(origin: CGPoint.zero, size: CGSize(width: tableView.frame.width, height: PhotonActionSheetUX.TablePadding)))
         tableView.tableFooterView = footer
         tableView.tableHeaderView = footer.clone()
-        tableView.backgroundColor = UIConstants.AppBackgroundColor.withAlphaComponent(0.7)
-        let blurEffect = UIBlurEffect(style: .light)
-        let blurEffectView = UIVisualEffectView(effect: blurEffect)
-        tableView.backgroundView = blurEffectView
+
+        // In a popover the popover provides the blur background
+        // Not using a background color allows the view to style correctly with the popover arrow
+        if self.popoverPresentationController == nil {
+            tableView.backgroundColor = UIConstants.AppBackgroundColor.withAlphaComponent(0.7)
+            let blurEffect = UIBlurEffect(style: .light)
+            let blurEffectView = UIVisualEffectView(effect: blurEffect)
+            tableView.backgroundView = blurEffectView
+        } else {
+            tableView.backgroundColor = .clear
+        }
 
         var width = min(self.view.frame.size.width, PhotonActionSheetUX.MaxWidth) - (PhotonActionSheetUX.Padding * 2)
         width = UIDevice.current.userInterfaceIdiom == .pad ? width : (self.view.frame.width - (PhotonActionSheetUX.Padding * 2))

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -27,9 +27,6 @@ extension PhotonActionSheetProtocol {
             popoverVC.sourceView = view
             popoverVC.sourceRect = CGRect(x: view.frame.width/2, y: view.frame.size.height * 0.75, width: 1, height: 1)
             popoverVC.permittedArrowDirections = UIPopoverArrowDirection.up
-            // Style the popoverVC instead of the tableView. This makes sure that the popover arrow is style as well
-            sheet.tableView.backgroundView = nil
-            sheet.tableView.backgroundColor = .clear
             popoverVC.backgroundColor = UIConstants.AppBackgroundColor.withAlphaComponent(0.7)
         }
         viewController.present(sheet, animated: true, completion: nil)

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -22,7 +22,7 @@ struct TabsButtonUX {
         var themes = [String: Theme]()
         var theme = Theme()
         theme.borderColor = UIConstants.AppBackgroundColor
-        theme.backgroundColor = UIColor(rgb: 0x4A4A4F)
+        theme.backgroundColor = UIColor(rgb: 0x38383D)
         theme.textColor = UIConstants.AppBackgroundColor
         theme.highlightButtonColor = UIConstants.PrivateModePurple
         theme.highlightTextColor = TabsButtonUX.TitleColor

--- a/Client/Frontend/Widgets/TwoLineCell.swift
+++ b/Client/Frontend/Widgets/TwoLineCell.swift
@@ -196,7 +196,7 @@ private class TwoLineCellHelper {
 
     func setupDynamicFonts() {
         textLabel.font = DynamicFontHelper.defaultHelper.DeviceFontHistoryPanel
-        detailTextLabel.font = DynamicFontHelper.defaultHelper.DeviceFontSmallHistoryPanel
+        detailTextLabel.font = DynamicFontHelper.defaultHelper.SmallSizeRegularWeightAS
     }
 
     func layoutSubviews() {


### PR DESCRIPTION
This also includes some general UI fixes from both Anthony and bbell
- The font size in history is now slightly smaller
- The page options menu button color now matches toolbar buttons instead of readermode button (helps users notice it more)
- The popover arrow styles correctly with the rest of the Photon menu (I had a fix for this but it was intermittent)
- The defaultfavicon in the browserToTrayAnimator is no longer templated. Remove `renderWithTemplate`
 - accessibilityIdentifier for button had a typo

I think the colors are finally starting to stabalize. I think if there are no more color nits I'll start organizing all the colors. Right now everything is all over the place.  