### PR TITLE
Bug 1405043 — Trivial speed optimizations for XCUITests.

### DIFF
--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -16,20 +16,23 @@ class TestAppDelegate: AppDelegate {
         }
 
         var profile: BrowserProfile
-        if ProcessInfo.processInfo.arguments.contains(LaunchArguments.ClearProfile) {
+        let launchArguments = ProcessInfo.processInfo.arguments
+        if launchArguments.contains(LaunchArguments.ClearProfile) {
             // Use a clean profile for each test session.
             log.debug("Deleting all files in 'Documents' directory to clear the profile")
             profile = BrowserProfile(localName: "testProfile", syncDelegate: application.syncDelegate, clear: true)
-
-            // Don't show the What's New page.
-            profile.prefs.setString(AppInfo.appVersion, forKey: LatestAppVersionProfileKey)
-
-            // Skip the intro when requested by for example tests or automation
-            if AppConstants.SkipIntro {
-                profile.prefs.setInt(1, forKey: IntroViewControllerSeenProfileKey)
-            }
         } else {
             profile = BrowserProfile(localName: "testProfile", syncDelegate: application.syncDelegate)
+        }
+
+        // Don't show the What's New page.
+        if launchArguments.contains(LaunchArguments.SkipWhatsNew) {
+            profile.prefs.setString(AppInfo.appVersion, forKey: LatestAppVersionProfileKey)
+        }
+
+        // Skip the intro when requested by for example tests or automation
+        if launchArguments.contains(LaunchArguments.SkipIntro) {
+            profile.prefs.setInt(1, forKey: IntroViewControllerSeenProfileKey)
         }
 
         self.profile = profile

--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -87,4 +87,10 @@ class TestAppDelegate: AppDelegate {
         }
     }
 
+    override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        // Speed up the animations to 100 times as fast.
+        defer { application.keyWindow?.layer.speed = 100.0 }
+        return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+
 }

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -12,9 +12,6 @@ public enum AppBuildChannel: String {
 
 public struct AppConstants {
     public static let IsRunningTest = NSClassFromString("XCTestCase") != nil || ProcessInfo.processInfo.arguments.contains(LaunchArguments.Test)
-
-    public static let SkipIntro = ProcessInfo.processInfo.arguments.contains(LaunchArguments.SkipIntro)
-    public static let ClearProfile = ProcessInfo.processInfo.arguments.contains(LaunchArguments.ClearProfile)
     
     public static let FxAiOSClientId = "1b1a3e44c54fbb58"
 

--- a/Shared/LaunchArguments.swift
+++ b/Shared/LaunchArguments.swift
@@ -7,5 +7,6 @@ import Foundation
 public struct LaunchArguments {
     public static let Test = "FIREFOX_TEST"
     public static let SkipIntro = "FIREFOX_SKIP_INTRO"
+    public static let SkipWhatsNew = "FIREFOX_SKIP_WHATS_NEW"
     public static let ClearProfile = "FIREFOX_CLEAR_PROFILE"
 }

--- a/XCUITests/BaseTestCase.swift
+++ b/XCUITests/BaseTestCase.swift
@@ -10,7 +10,8 @@ class BaseTestCase: XCTestCase {
         super.setUp()
         continueAfterFailure = false
         let app = XCUIApplication()
-        restart(app)
+        app.terminate()
+        restart(app, args: [LaunchArguments.ClearProfile, LaunchArguments.SkipIntro, LaunchArguments.SkipWhatsNew])
     }
 
     override func tearDown() {
@@ -18,12 +19,14 @@ class BaseTestCase: XCTestCase {
         super.tearDown()
     }
 
-    func restart(_ app: XCUIApplication) {
-        app.terminate()
-        app.launchArguments.append(LaunchArguments.Test)
-        app.launchArguments.append(LaunchArguments.ClearProfile)
-        app.launch()
-        sleep(1)
+    func restart(_ app: XCUIApplication, args: [String] = []) {
+        XCUIDevice.shared().press(.home)
+        var launchArguments = [LaunchArguments.Test]
+        args.forEach { arg in
+            launchArguments.append(arg)
+        }
+        app.launchArguments = launchArguments
+        app.activate()
     }
     
     //If it is a first run, first run window should be gone


### PR DESCRIPTION
This PR tidies up the `launchArguments` to just being used in the
`TestAppDelegate`, instead of spread around `AppConstants`. 

Each of SKIP_WHATSNEW, SKIP_INTRO and CLEAR_PROFILE can be used independently of
one another.

Additionally, this cleans up the `restart()` method to the home button
instead of `terminate()` and use `activate()` instead of `launch()`. This
does not affect test setUps, but does help with tests that require
restarts.

`app.activate()` will relaunch an existing app, however, `app.launch()` will effectively relaunch it.

Finally, to add a little bit more speed, this also speeds up the animations to 100 times their usual speed.

This is separated in to its own commit, as it may initially break a number of tests which rely on animation timings.

Unfortunately, since all the XCUITests are broken due to Photon work, it is difficult to test the time this has saved.

However, since everything is broken, now would be an ideal time to fix the tests that erroneously rely on animation timing.

https://bugzilla.mozilla.org/show_bug.cgi?id=1405043