### PR TITLE
Bug 1403862 - remove homepage button swap pref. It no longer works in photon.

### DIFF
--- a/Client/Frontend/Accessors/HomePageAccessors.swift
+++ b/Client/Frontend/Accessors/HomePageAccessors.swift
@@ -10,9 +10,6 @@ import XCGLogger
 /// These are pure functions, so it's quite ok to have them
 /// as static.
 class HomePageAccessors {
-    static func isButtonInMenu(_ prefs: Prefs) -> Bool {
-        return prefs.boolForKey(HomePageConstants.HomePageButtonIsInMenuPrefKey) ?? true
-    }
 
     static func getHomePage(_ prefs: Prefs) -> URL? {
         let string = prefs.stringForKey(HomePageConstants.HomePageURLPrefKey) ?? getDefaultHomePageString(prefs)

--- a/Client/Frontend/Browser/HomePageHelper.swift
+++ b/Client/Frontend/Browser/HomePageHelper.swift
@@ -11,7 +11,6 @@ private let log = Logger.browserLogger
 struct HomePageConstants {
     static let HomePageURLPrefKey = "HomePageURLPref"
     static let DefaultHomePageURLPrefKey = PrefsKeys.KeyDefaultHomePageURL
-    static let HomePageButtonIsInMenuPrefKey = PrefsKeys.KeyHomePageButtonIsInMenu
 }
 
 class HomePageHelper {

--- a/Client/Frontend/Settings/HomePageSettingsViewController.swift
+++ b/Client/Frontend/Settings/HomePageSettingsViewController.swift
@@ -64,18 +64,7 @@ class HomePageSettingsViewController: SettingsTableViewController {
                 onClick: setHomePage(nil)),
             ]
 
-        let settings: [SettingSection] = [
-            SettingSection(title: NSAttributedString(string: Strings.SettingsHomePageURLSectionTitle), children: basicSettings),
-            SettingSection(children: [
-                BoolSetting(prefs: prefs,
-                    prefKey: HomePageConstants.HomePageButtonIsInMenuPrefKey,
-                    defaultValue: true,
-                    titleText: Strings.SettingsHomePageUIPositionTitle,
-                    statusText: Strings.SettingsHomePageUIPositionSubtitle),
-            ])
-        ]
-
-        return settings
+        return [SettingSection(title: NSAttributedString(string: Strings.SettingsHomePageURLSectionTitle), children: basicSettings)]
     }
 }
 

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -179,8 +179,6 @@ extension Strings {
 extension Strings {
     public static let SettingsHomePageSectionName = NSLocalizedString("Settings.HomePage.SectionName", value: "Homepage", comment: "Label used as an item in Settings. When touched it will open a dialog to configure the home page and its uses.")
     public static let SettingsHomePageTitle = NSLocalizedString("Settings.HomePage.Title", value: "Homepage Settings", comment: "Title displayed in header of the setting panel.")
-    public static let SettingsHomePageUIPositionTitle = NSLocalizedString("Settings.HomePage.UI.Toggle.Title", value: "Show Homepage Icon In Menu", comment: "Label used as an item in Settings. User can toggle this setting to show the home page button in menu, or on toolbar.")
-    public static let SettingsHomePageUIPositionSubtitle = NSLocalizedString("Settings.HomePage.UI.Toggle.Subtitle", value: "Otherwise show in the toolbar", comment: "Label displayed under the 'Show Homepage Icon In Menu' option. It describes the effect of this setting when disabled.")
     public static let SettingsHomePageURLSectionTitle = NSLocalizedString("Settings.HomePage.URL.Title", value: "Current Homepage", comment: "Title of the setting section containing the URL of the current home page.")
     public static let SettingsHomePageUseCurrentPage = NSLocalizedString("Settings.HomePage.UseCurrent.Button", value: "Use Current Page", comment: "Button in settings to use the current page as home page.")
     public static let SettingsHomePagePlaceholder = NSLocalizedString("Settings.HomePage.URL.Placeholder", value: "Enter a webpage", comment: "Placeholder text in the homepage setting when no homepage has been set.")

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -262,10 +262,6 @@ open class BrowserProfile: Profile {
         prefs.setBool(false, forKey: PrefsKeys.KeyTopSitesCacheIsValid)
 
         if isChinaEdition {
-            // On first run, set the Home button to be in the toolbar.
-            if prefs.boolForKey(PrefsKeys.KeyHomePageButtonIsInMenu) == nil {
-                prefs.setBool(false, forKey: PrefsKeys.KeyHomePageButtonIsInMenu)
-            }
             // Set the default homepage.
             prefs.setString(PrefsDefaults.ChineseHomePageURL, forKey: PrefsKeys.KeyDefaultHomePageURL)
 

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -10,7 +10,6 @@ public struct PrefsKeys {
     public static let KeyTopSitesCacheIsValid = "topSitesCacheIsValid"
     public static let KeyTopSitesCacheSize = "topSitesCacheSize"
     public static let KeyDefaultHomePageURL = "KeyDefaultHomePageURL"
-    public static let KeyHomePageButtonIsInMenu = "HomePageButtonIsInMenuPrefKey"
     public static let KeyNoImageModeStatus = "NoImageModeStatus"
     public static let KeyNewTab = "NewTabPrefKey"
     public static let KeyNightModeButtonIsInMenu = "NightModeButtonIsInMenuPrefKey"


### PR DESCRIPTION
Robin has mentioned that they want to look into a different way of surfacing this feature. 

When it does come back it will probably have new strings so it makes sense to remove the strings as well.