### PR TITLE
Bug 1403684 - Reader mode has too much padding. Reduce padding by using vw units.

### DIFF
--- a/Client/Frontend/Reader/Reader.css
+++ b/Client/Frontend/Reader/Reader.css
@@ -62,7 +62,7 @@ html {
 }
 
 body {
-  padding: 24px;
+  padding: 2vw;
   transition-property: background-color, color;
   transition-duration: 0.4s;
   margin-left: auto;
@@ -344,7 +344,7 @@ body {
 }
 
 .content * {
-  max-width: 98% !important;
+  max-width: 100% !important;
   height: auto !important;
 }
 


### PR DESCRIPTION
The contents 98 percent width also applies multiple times. Multiple divs inside a body of text will have the selector `content` each one would cut off 2%. Sometimes cutting off about 8% from the view width.  This plus the default padding would create a pretty bad experience