### PR TITLE
Bug 1404335 - check if the tab animation completed sucessfully before doing any cleanup.

### DIFF
--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -162,7 +162,7 @@ class TopTabsViewController: UIViewController {
         if let currentTab = tabManager.selectedTab {
             applyTheme(currentTab.isPrivate ? Theme.PrivateMode : Theme.NormalMode)
         }
-        updateTabCount(tabStore.count)
+        updateTabCount(tabStore.count, animated: false)
     }
     
     func switchForegroundStatus(isInForeground reveal: Bool) {

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -214,12 +214,12 @@ class TabsButton: UIButton {
                 self.insideButton.layer.opacity = 0
             }
             
-            let completion: (Bool) -> Void = { _ in
-                // Remove the clone and setup the actual tab button
-                newTabsButton.removeFromSuperview()
-                
-                self.insideButton.layer.opacity = 1
-                self.insideButton.layer.transform = CATransform3DIdentity
+            let completion: (Bool) -> Void = { completed in
+                if completed {
+                    newTabsButton.removeFromSuperview()
+                    self.insideButton.layer.opacity = 1
+                    self.insideButton.layer.transform = CATransform3DIdentity
+                }
                 self.accessibilityLabel = NSLocalizedString("Show Tabs", comment: "Accessibility label for the tabs button in the (top) tab toolbar")
                 self.countLabel.text = countToBe
                 self.accessibilityValue = countToBe


### PR DESCRIPTION
-  The animation is pretty long (1.5 seconds) so if you swapped between private/normal too fast you would have completion blocks being called at the wrong time.