### PR TITLE
Bug 1406021 - fix split screen related bugs on the iPad.

### DIFF
--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -1001,7 +1001,7 @@ class ASHeaderView: UICollectionReusableView {
         moreButton.setContentCompressionResistancePriority(UILayoutPriorityRequired, for: UILayoutConstraintAxis.horizontal)
         titleLabel.snp.makeConstraints { make in
             self.leftConstraint = make.leading.equalTo(self).inset(titleInsets).constraint
-            make.trailing.equalTo(moreButton.snp.leading).inset(-ASHeaderViewUX.Insets)
+            make.trailing.equalTo(moreButton.snp.leading).inset(-ASHeaderViewUX.TitleTopInset)
             make.top.equalTo(self).inset(ASHeaderViewUX.TitleTopInset)
             make.bottom.equalTo(self)
         }

--- a/Client/Frontend/Widgets/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet.swift
@@ -142,7 +142,7 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
         }
 
         var width = min(self.view.frame.size.width, PhotonActionSheetUX.MaxWidth) - (PhotonActionSheetUX.Padding * 2)
-        width = UIDevice.current.userInterfaceIdiom == .pad ? width : (self.view.frame.width - (PhotonActionSheetUX.Padding * 2))
+        width = self.modalPresentationStyle == .popover ? width : (self.view.frame.width - (PhotonActionSheetUX.Padding * 2))
         let height = actionSheetHeight()
         
         if self.modalPresentationStyle == .popover {
@@ -159,7 +159,7 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
             }
         }
         
-        if style == .bottom && UIDevice.current.userInterfaceIdiom == .pad {
+        if style == .bottom && self.modalPresentationStyle == .popover {
             // We are showing the menu in a popOver
             self.actions = actions.map({ $0.reversed() }).reversed()
             tableView.frame = CGRect(origin: CGPoint.zero, size: self.preferredContentSize)

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -17,12 +17,12 @@ extension PhotonActionSheetProtocol {
     typealias IsPrivateTab = Bool
     typealias URLOpenAction = (URL?, IsPrivateTab) -> Void
     
-    func presentSheetWith(actions: [[PhotonActionSheetItem]], on viewController: PresentableVC, from view: UIView) {
+    func presentSheetWith(actions: [[PhotonActionSheetItem]], on viewController: PresentableVC, from view: UIView, supressPopover: Bool = false) {
         let sheet = PhotonActionSheet(actions: actions)
-        sheet.modalPresentationStyle =  UIDevice.current.userInterfaceIdiom == .pad ? .popover : .overCurrentContext
+        sheet.modalPresentationStyle =  (UIDevice.current.userInterfaceIdiom == .pad && !supressPopover) ? .popover : .overCurrentContext
         sheet.photonTransitionDelegate = PhotonActionSheetAnimator()
         
-        if let popoverVC = sheet.popoverPresentationController {
+        if let popoverVC = sheet.popoverPresentationController, sheet.modalPresentationStyle == .popover {
             popoverVC.delegate = viewController
             popoverVC.sourceView = view
             popoverVC.sourceRect = CGRect(x: view.frame.width/2, y: view.frame.size.height * 0.75, width: 1, height: 1)


### PR DESCRIPTION
There were a lot of cases in the PhotonMenu where I check if the app is running on a iPad. This was incorrect as when the app is running in split screen it basically shows the same UI as an iPhone. 

Instead do what the rest of the app does. Use the traitcollection and toptabs to detect if we should show parts of the UI.

This patch also fixes 2 other issues in split screen. 
- The "recommended by pocket" text was truncated
- Statusbar style was incorrect