### PR TITLE
[nobug, beta-only] Re-add sentry logging for unified telemetry

### DIFF
--- a/Client/Telemetry/UnifiedTelemetry.swift
+++ b/Client/Telemetry/UnifiedTelemetry.swift
@@ -40,7 +40,7 @@ class UnifiedTelemetry {
 
     @objc func uploadError(notification: NSNotification) {
         guard let error = notification.userInfo?["error"] as? NSError else { return }
-        SentryIntegration.shared.send(message: error.localizedDescription, tag: "UnifiedTelemetry", severity: .info)
+        SentryIntegration.shared.send(message: "Upload Error", tag: "UnifiedTelemetry", severity: .info, extra: ["Error": error.localizedDescription])
     }
 }
 


### PR DESCRIPTION
We were getting spammed with upload error messages, this should ensure these are aggregated in Sentry. 
I hope.