### PR TITLE
Bug 1406894 & 1406916 - Fix display issues with SimpleToast and ButtonToast

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1300,11 +1300,16 @@ extension BrowserViewController: URLBarDelegate {
             self.updateFindInPageVisibility(visible: true)
         }
         
+        let successCallback: (String) -> Void = { (successMessage) in
+            SimpleToast().showAlertWithText(successMessage, bottomContainer:self.webViewContainer)
+        }
+        
         guard let tab = tabManager.selectedTab, tab.url != nil else { return }
         
         // The logic of which actions appear when isnt final.
         let pageActions = getTabActions(tab: tab, buttonView: button, presentShareMenu: actionMenuPresenter,
-                                        findInPage: findInPageAction, presentableVC: self)
+                                        findInPage: findInPageAction, presentableVC: self, success: successCallback)
+
         presentSheetWith(actions: pageActions, on: self, from: button)
     }
     
@@ -2753,7 +2758,7 @@ extension BrowserViewController {
 
                 self.profile.searchEngines.addSearchEngine(OpenSearchEngine(engineID: nil, shortName: shortName, image: image, searchTemplate: searchQuery, suggestTemplate: nil, isCustomEngine: true))
                 let Toast = SimpleToast()
-                Toast.showAlertWithText(Strings.ThirdPartySearchEngineAdded)
+                Toast.showAlertWithText(Strings.ThirdPartySearchEngineAdded, bottomContainer:self.webViewContainer)
             }
         }
 

--- a/Client/Frontend/Browser/SimpleToast.swift
+++ b/Client/Frontend/Browser/SimpleToast.swift
@@ -20,16 +20,12 @@ struct SimpleToast {
     func showAlertWithText(_ text: String, bottomContainer: UIView) {
         guard let window = UIApplication.shared.windows.first else { return }
         
-        var keyboardHeight = KeyboardHelper.defaultHelper.currentState?.intersectionHeightForView(window) ?? SimpleToastUX.BottomToolbarHeight
-        if keyboardHeight == 0 {
-            keyboardHeight = SimpleToastUX.BottomToolbarHeight
-        }
-        
         let toast = self.createView()
         toast.text = text
         window.addSubview(toast)
         toast.snp.makeConstraints { (make) in
-            make.width.equalTo(window.snp.width)
+            make.width.equalTo(bottomContainer)
+            make.left.equalTo(bottomContainer)
             make.height.equalTo(SimpleToastUX.ToastHeight)
             make.bottom.equalTo(bottomContainer)
         }

--- a/Client/Frontend/Browser/SimpleToast.swift
+++ b/Client/Frontend/Browser/SimpleToast.swift
@@ -17,7 +17,7 @@ struct SimpleToastUX {
 
 struct SimpleToast {
 
-     func showAlertWithText(_ text: String) {
+    func showAlertWithText(_ text: String, bottomContainer: UIView) {
         guard let window = UIApplication.shared.windows.first else { return }
         
         var keyboardHeight = KeyboardHelper.defaultHelper.currentState?.intersectionHeightForView(window) ?? SimpleToastUX.BottomToolbarHeight
@@ -31,7 +31,7 @@ struct SimpleToast {
         toast.snp.makeConstraints { (make) in
             make.width.equalTo(window.snp.width)
             make.height.equalTo(SimpleToastUX.ToastHeight)
-            make.bottom.equalTo(window.snp.bottom).offset(-keyboardHeight)
+            make.bottom.equalTo(bottomContainer)
         }
         animate(toast)
     }

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -63,7 +63,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
                 actions.append(UIPreviewAction(title: TabPeekViewController.PreviewActionCopyURL, style: .default) { previewAction, viewController in
                     guard let url = self.tab?.canonicalURL else { return }
                     UIPasteboard.general.url = url
-                    SimpleToast().showAlertWithText(Strings.AppMenuCopyURLConfirmMessage)
+                    SimpleToast().showAlertWithText(Strings.AppMenuCopyURLConfirmMessage, bottomContainer:self.view)
                 })
             }
         }

--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -71,7 +71,7 @@ class TabScrollingController: NSObject {
     fileprivate var contentSize: CGSize { return scrollView?.contentSize ?? CGSize.zero }
     fileprivate var scrollViewHeight: CGFloat { return scrollView?.frame.height ?? 0 }
     fileprivate var topScrollHeight: CGFloat { return header?.frame.height ?? 0 }
-    fileprivate var bottomScrollHeight: CGFloat { return urlBar?.frame.height ?? 0 }
+    fileprivate var bottomScrollHeight: CGFloat { return footer?.frame.height ?? 0 }
     fileprivate var snackBarsFrame: CGRect { return snackBars?.frame ?? CGRect.zero }
 
     fileprivate var lastContentOffset: CGFloat = 0

--- a/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -46,6 +46,8 @@ class CustomSearchViewController: SettingsTableViewController {
             make.center.equalTo(self.view.snp.center)
         }
     }
+    
+    var successCallback: (() -> Void)?
 
     fileprivate func addSearchEngine(_ searchQuery: String, title: String) {
         spinnerView.startAnimating()
@@ -67,8 +69,11 @@ class CustomSearchViewController: SettingsTableViewController {
                 return
             }
             self.profile.searchEngines.addSearchEngine(engine)
+            
+            CATransaction.begin() // Use transaction to call callback after animation has been completed
+            CATransaction.setCompletionBlock(self.successCallback)
             _ = self.navigationController?.popViewController(animated: true)
-            SimpleToast().showAlertWithText(Strings.ThirdPartySearchEngineAdded)
+            CATransaction.commit()
         }
     }
 

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -170,6 +170,9 @@ class SearchSettingsTableViewController: UITableViewController {
         } else if indexPath.item + 1 == model.orderedEngines.count {
             let customSearchEngineForm = CustomSearchViewController()
             customSearchEngineForm.profile = self.profile
+            customSearchEngineForm.successCallback = {
+                SimpleToast().showAlertWithText(Strings.ThirdPartySearchEngineAdded, bottomContainer: self.view)
+            }
             navigationController?.pushViewController(customSearchEngineForm, animated: true)
         }
         return nil

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -171,7 +171,8 @@ class SearchSettingsTableViewController: UITableViewController {
             let customSearchEngineForm = CustomSearchViewController()
             customSearchEngineForm.profile = self.profile
             customSearchEngineForm.successCallback = {
-                SimpleToast().showAlertWithText(Strings.ThirdPartySearchEngineAdded, bottomContainer: self.view)
+                guard let window = self.view.window else { return }
+                SimpleToast().showAlertWithText(Strings.ThirdPartySearchEngineAdded, bottomContainer: window)
             }
             navigationController?.pushViewController(customSearchEngineForm, animated: true)
         }

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -112,7 +112,8 @@ extension PhotonActionSheetProtocol {
     func getTabActions(tab: Tab, buttonView: UIView,
                        presentShareMenu: @escaping (URL, Tab, UIView, UIPopoverArrowDirection) -> Void,
                        findInPage:  @escaping () -> Void,
-                       presentableVC: PresentableVC) -> Array<[PhotonActionSheetItem]> {
+                       presentableVC: PresentableVC,
+                       success: @escaping (String) -> Void) -> Array<[PhotonActionSheetItem]> {
         
         let toggleActionTitle = tab.desktopSite ? Strings.AppMenuViewMobileSiteTitleString : Strings.AppMenuViewDesktopSiteTitleString
         let toggleDesktopSite = PhotonActionSheetItem(title: toggleActionTitle, iconString: "menu-RequestDesktopSite") { action in
@@ -128,7 +129,7 @@ extension PhotonActionSheetProtocol {
             guard let url = tab.url?.displayURL else { return }
 
             self.profile.readingList?.createRecordWithURL(url.absoluteString, title: tab.title ?? "", addedBy: UIDevice.current.name)
-            self.showToast(text: Strings.AppMenuAddToReadingListConfirmMessage)
+            success(Strings.AppMenuAddToReadingListConfirmMessage)
         }
 
         let findInPageAction = PhotonActionSheetItem(title: Strings.AppMenuFindInPageTitleString, iconString: "menu-FindInPage") { action in
@@ -149,7 +150,7 @@ extension PhotonActionSheetProtocol {
                                                                                 withUserData: userData,
                                                                                 toApplication: UIApplication.shared)
             tab.isBookmarked = true
-            self.showToast(text: Strings.AppMenuAddBookmarkConfirmMessage)
+            success(Strings.AppMenuAddBookmarkConfirmMessage)
         }
         
         let removeBookmark = PhotonActionSheetItem(title: Strings.AppMenuRemoveBookmarkTitleString, iconString: "menu-Bookmark-Remove") { action in
@@ -160,7 +161,7 @@ extension PhotonActionSheetProtocol {
                 $0.removeByURL(absoluteString).uponQueue(.main) { res in
                     if res.isSuccess {
                         tab.isBookmarked = false
-                        self.showToast(text: Strings.AppMenuRemoveBookmarkConfirmMessage)
+                        success(Strings.AppMenuRemoveBookmarkConfirmMessage)
                     }
                 }
             }
@@ -189,7 +190,7 @@ extension PhotonActionSheetProtocol {
 
         let copyURL = PhotonActionSheetItem(title: Strings.AppMenuCopyURLTitleString, iconString: "menu-Copy-Link") { _ in
             UIPasteboard.general.url = self.tabManager.selectedTab?.canonicalURL?.displayURL
-            self.showToast(text: Strings.AppMenuCopyURLConfirmMessage)
+            success(Strings.AppMenuCopyURLConfirmMessage)
         }
         
         let bookmarkAction = tab.isBookmarked ? removeBookmark : bookmarkPage
@@ -199,10 +200,6 @@ extension PhotonActionSheetProtocol {
         }
         
         return [topActions, [copyURL, findInPageAction, toggleDesktopSite, pinToTopSites, setHomePage], [share]]
-    }
-    
-    private func showToast(text:String) {
-        SimpleToast().showAlertWithText(text)
     }
 }
 


### PR DESCRIPTION
Fixes two display bugs with SimpleToast and ButtonToast. Scrolling enough to remove the Toolbar while the Toast was being displayed would result in the toast floating in the screen instead of attached to the bottom. This PR ties SimpleToast to the bottom of a view similar to how ButtonToast works. It also updates the height constraint on the toast was incorrect.

Screencast: http://recordit.co/TMDs9e90VK