### PR TITLE
Bug 1404089 - When using defer deep link load FxA signin first

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2405,9 +2405,10 @@ extension BrowserViewController: ReaderModeBarViewDelegate {
 }
 
 extension BrowserViewController: IntroViewControllerDelegate {
-    @discardableResult func presentIntroViewController(_ force: Bool = false) -> Bool {
+    @discardableResult func presentIntroViewController(_ force: Bool = false, animated: Bool = true) -> Bool {
         if let deeplink = self.profile.prefs.stringForKey("AdjustDeeplinkKey"), let url = URL(string: deeplink) {
             self.launchFxAFromDeeplinkURL(url)
+            return true
         }
         
         if force || profile.prefs.intForKey(IntroViewControllerSeenProfileKey) == nil {
@@ -2418,7 +2419,7 @@ extension BrowserViewController: IntroViewControllerDelegate {
                 introViewController.preferredContentSize = CGSize(width: IntroViewControllerUX.Width, height: IntroViewControllerUX.Height)
                 introViewController.modalPresentationStyle = UIModalPresentationStyle.formSheet
             }
-            present(introViewController, animated: true) {
+            present(introViewController, animated: animated) {
                 // On first run (and forced) open up the homepage in the background.
                 if let homePageURL = HomePageAccessors.getHomePage(self.profile.prefs), let tab = self.tabManager.selectedTab, DeviceInfo.hasConnectivity() {
                     tab.loadRequest(URLRequest(url: homePageURL))

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2406,6 +2406,10 @@ extension BrowserViewController: ReaderModeBarViewDelegate {
 
 extension BrowserViewController: IntroViewControllerDelegate {
     @discardableResult func presentIntroViewController(_ force: Bool = false) -> Bool {
+        if let deeplink = self.profile.prefs.stringForKey("AdjustDeeplinkKey"), let url = URL(string: deeplink) {
+            self.launchFxAFromDeeplinkURL(url)
+        }
+        
         if force || profile.prefs.intForKey(IntroViewControllerSeenProfileKey) == nil {
             let introViewController = IntroViewController()
             introViewController.delegate = self
@@ -2429,7 +2433,8 @@ extension BrowserViewController: IntroViewControllerDelegate {
     
     func launchFxAFromDeeplinkURL(_ url: URL) {
         self.profile.prefs.removeObjectForKey("AdjustDeeplinkKey")
-        let query = url.getQuery()
+        var query = url.getQuery()
+        query["entrypoint"] = "adjust_deepklink_ios"
         let fxaParams: FxALaunchParams
         fxaParams = FxALaunchParams(query: query)
         self.presentSignInViewController(fxaParams)
@@ -2442,10 +2447,6 @@ extension BrowserViewController: IntroViewControllerDelegate {
                 _ = self.navigationController?.popToRootViewController(animated: true)
             }
             
-            if let deeplink = self.profile.prefs.stringForKey("AdjustDeeplinkKey"), let url = URL(string: deeplink) {
-                self.launchFxAFromDeeplinkURL(url)
-                return
-            }
             if requestToLogin {
                 self.presentSignInViewController()
             }

--- a/Client/Frontend/Settings/FxAContentViewController.swift
+++ b/Client/Frontend/Settings/FxAContentViewController.swift
@@ -67,6 +67,13 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
         if AppConstants.MOZ_SHOW_FXA_AVATAR {
             profile.getAccount()?.updateProfile()
         }
+        
+        // If the FxAContentViewController was launched from a FxA deferred link
+        // onboarding might not have been shown. Check to see if it needs to be
+        // displayed and don't animate.
+        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+            appDelegate.browserViewController.presentIntroViewController(false, animated: false)
+        }
     }
 
     override func makeWebView() -> WKWebView {


### PR DESCRIPTION
To help troubleshoot iOS Adjust deeplink woes, wanted to try having FxA signin (prefilled with email) appear before onboarding.