### PR TITLE
Bug 1408031 - Strings cleanup

### DIFF
--- a/Client/Frontend/Settings/AdvanceAccountSettingViewController.swift
+++ b/Client/Frontend/Settings/AdvanceAccountSettingViewController.swift
@@ -94,12 +94,12 @@ class AdvanceAccountSettingViewController: SettingsTableViewController {
         DispatchQueue.main.async {
             self.tableView.reloadRows(at: [IndexPath(row: 0, section: 0)], with: UITableViewRowAnimation.automatic)
         }
-        let alertController = UIAlertController(title: Strings.SettingsAdvanceAccountUrlErrorAlertTitle, message: NSLocalizedString("Please enter a custom account url before enabling.", comment: "No custom service set."), preferredStyle: .alert)
+        let alertController = UIAlertController(title: Strings.SettingsAdvanceAccountUrlErrorAlertTitle, message: Strings.SettingsAdvanceAccountEmptyUrlErrorAlertMessage, preferredStyle: .alert)
         let defaultAction = UIAlertAction(title: Strings.SettingsAdvanceAccountUrlUpdatedAlertOk, style: .default, handler: nil)
         alertController.addAction(defaultAction)
         self.present(alertController, animated: true)
     }
-    
+
     override func generateSettings() -> [SettingSection] {
         let prefs = profile.prefs
         let customSyncSetting = CustomSyncWebPageSetting(prefs: prefs,
@@ -130,9 +130,9 @@ class AdvanceAccountSettingViewController: SettingsTableViewController {
         
         let settings: [SettingSection] = [
             SettingSection(title: NSAttributedString(string: ""), children: basicSettings),
-            SettingSection(title: NSAttributedString(string: NSLocalizedString("To use a custom Firefox Account and sync servers, specify the root Url of the Firefox Account site. This will download the configuration and setup this device to use the new service. After the new service has been set, you will need to create a new Firefox Account or login with an existing one.", comment: "Details for using custom Firefox Account service.")), children: [])
+            SettingSection(title: NSAttributedString(string: Strings.SettingsAdvanceAccountSectionFooter), children: [])
         ]
-        
+
         return settings
     }
     
@@ -158,7 +158,7 @@ class CustomSyncEnableSetting: BoolSetting {
     init(prefs: Prefs, settingDidChange: ((Bool?) -> Void)? = nil) {
         super.init(
             prefs: prefs, prefKey: PrefsKeys.KeyUseCustomSyncService, defaultValue: false,
-            attributedTitleText: NSAttributedString(string: NSLocalizedString("Use Custom Account Service", tableName: "UseCustomAccountService", comment: "Toggle switch to use custom FxA server")),
+            attributedTitleText: NSAttributedString(string: Strings.SettingsAdvanceAccountUseCustomAccountsServiceTitle),
             settingDidChange: settingDidChange
         )
     }

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -14,7 +14,7 @@ class AppSettingsTableViewController: SettingsTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        navigationItem.title = NSLocalizedString("Settings", comment: "Settings")
+        navigationItem.title = NSLocalizedString("Settings", comment: "Title in the settings view controller title bar")
         navigationItem.leftBarButtonItem = UIBarButtonItem(
             title: NSLocalizedString("Done", comment: "Done button on left side of the Settings view controller title bar"),
             style: UIBarButtonItemStyle.done,

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -441,10 +441,9 @@ extension Strings {
 
 // Settings Home
 extension Strings {
-    public static let SendUsageSettingTitle = NSLocalizedString("Send Usage Data", tableName: "SendAnonymousUsageData", comment: "The title for the setting to send usage data.")
-    public static let SendUsageSettingLink = NSLocalizedString("Learn More.", tableName: "SendAnonymousUsageData", comment: "title for a link that explains how mozilla collects telemetry")
-    public static let SendUsageSettingMessage = NSLocalizedString("Mozilla strives to only collect what we need to provide and improve Firefox for everyone.", tableName: "SendAnonymousUsageData", comment: "A short description that explains why mozilla collects usage data.")
-
+    public static let SendUsageSettingTitle = NSLocalizedString("Settings.SendUsage.Title", value: "Send Usage Data", comment: "The title for the setting to send usage data.")
+    public static let SendUsageSettingLink = NSLocalizedString("Settings.SendUsage.Link", value: "Learn More.", comment: "title for a link that explains how mozilla collects telemetry")
+    public static let SendUsageSettingMessage = NSLocalizedString("Settings.SendUsage.Message", value: "Mozilla strives to only collect what we need to provide and improve Firefox for everyone.", comment: "A short description that explains why mozilla collects usage data.")
 }
 
 // Do not track 

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -46,7 +46,7 @@ extension Strings {
     public static let ASTopSitesTitle =  NSLocalizedString("ActivityStream.TopSites.SectionTitle", value: "Top Sites", comment: "Section title label for Top Sites")
     public static let HighlightVistedText = NSLocalizedString("ActivityStream.Highlights.Visited", value: "Visited", comment: "The description of a highlight if it is a site the user has visited")
     public static let HighlightBookmarkText = NSLocalizedString("ActivityStream.Highlights.Bookmark", value: "Bookmarked", comment: "The description of a highlight if it is a site the user has bookmarked")
-    public static let PocketTrendingText = NSLocalizedString("ActivitySream.Pocket.Trending", value: "Trending", comment: "The description of a Pocket Story")
+    public static let PocketTrendingText = NSLocalizedString("ActivityStream.Pocket.Trending", value: "Trending", comment: "The description of a Pocket Story")
 }
 
 // Home Panel Context Menu.

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -211,18 +211,52 @@ extension Strings {
     public static let SettingsNewTabHighlightsBookmarks = NSLocalizedString("Settings.NewTab.Option.HighlightsBookmarks", value: "Recent Bookmarks", comment: "Option in the settings to turn off recent bookmarks in the Highlights section")
 }
 
-// Custom account settings
+// Custom account settings - These strings did not make it for the v10 l10n deadline so we have turned them into regular strings. These strings will come back localized in a next version.
+
 extension Strings {
-    public static let SettingsAdvanceAccountSectionName = NSLocalizedString("Settings.AdvanceAccount.SectionName", value: "Account Settings", comment: "Label used as an item in Settings. When touched it will open a dialog to setup advance Firefox account settings.")
-    public static let SettingsAdvanceAccountTitle = NSLocalizedString("Settings.AdvanceAccount.SectionName", value: "Advance Account Settings", comment: "Title displayed in header of the setting panel.")
-    public static let SettingsAdvanceAccountUrlPlaceholder = NSLocalizedString("Settings.AdvanceAccount.UrlPlaceholder", value: "Custom Account Url", comment: "Title displayed in header of the setting panel.")
-    
-    public static let SettingsAdvanceAccountUrlUpdatedAlertMessage = NSLocalizedString("Settings.AdvanceAccount.UpdatedAlertMessage", value: "Firefox account service updated. To begin using custom server, please log out and re-login.", comment: "Messaged displayed when sync service has been successfully set.")
-    public static let SettingsAdvanceAccountUrlUpdatedAlertOk = NSLocalizedString("Settings.AdvanceAccount.UpdatedAlertOk", value: "OK", comment: "Ok button on custom sync service updated alert")
-    
-    public static let SettingsAdvanceAccountUrlErrorAlertTitle = NSLocalizedString("Settings.AdvanceAccount.ErrorAlertTitle", value: "Error", comment: "Error alert message title.")
-    public static let SettingsAdvanceAccountUrlErrorAlertMessage = NSLocalizedString("Settings.AdvanceAccount.ErrorAlertMessage", value: "There was an error while attempting to parse the url. Please make sure that it is a valid Firefox Account root url.", comment: "Messaged displayed when sync service has an error setting a custom sync url.")
-    public static let SettingsAdvanceAccountUrlErrorAlertOk = NSLocalizedString("Settings.AdvanceAccount.ErrorAlertOk", value: "OK", comment: "Ok button on custom sync service error alert.")
+    // Settings.AdvanceAccount.SectionName
+    // Label used as an item in Settings. When touched it will open a dialog to setup advance Firefox account settings.
+    public static let SettingsAdvanceAccountSectionName = "Account Settings"
+
+    // Settings.AdvanceAccount.SectionFooter
+    // Details for using custom Firefox Account service.
+    public static let SettingsAdvanceAccountSectionFooter = "To use a custom Firefox Account and sync servers, specify the root Url of the Firefox Account site. This will download the configuration and setup this device to use the new service. After the new service has been set, you will need to create a new Firefox Account or login with an existing one."
+
+    // Settings.AdvanceAccount.SectionName
+    // Title displayed in header of the setting panel.
+    public static let SettingsAdvanceAccountTitle = "Advance Account Settings"
+
+    // Settings.AdvanceAccount.UrlPlaceholder
+    // Title displayed in header of the setting panel.
+    public static let SettingsAdvanceAccountUrlPlaceholder = "Custom Account Url"
+
+    // Settings.AdvanceAccount.UpdatedAlertMessage
+    // Messaged displayed when sync service has been successfully set.
+    public static let SettingsAdvanceAccountUrlUpdatedAlertMessage = "Firefox account service updated. To begin using custom server, please log out and re-login."
+
+    // Settings.AdvanceAccount.UpdatedAlertOk
+    // Ok button on custom sync service updated alert
+    public static let SettingsAdvanceAccountUrlUpdatedAlertOk = "OK"
+
+    // Settings.AdvanceAccount.ErrorAlertTitle
+    // Error alert message title.
+    public static let SettingsAdvanceAccountUrlErrorAlertTitle = "Error"
+
+    // Settings.AdvanceAccount.ErrorAlertMessage
+    // Messaged displayed when sync service has an error setting a custom sync url.
+    public static let SettingsAdvanceAccountUrlErrorAlertMessage = "There was an error while attempting to parse the url. Please make sure that it is a valid Firefox Account root url."
+
+    // Settings.AdvanceAccount.ErrorAlertOk
+    // Ok button on custom sync service error alert.
+    public static let SettingsAdvanceAccountUrlErrorAlertOk = "OK"
+
+    // Settings.AdvanceAccount.UseCustomAccountsServiceTitle
+    // Toggle switch to use custom FxA server
+    public static let SettingsAdvanceAccountUseCustomAccountsServiceTitle = "Use Custom Account Service"
+
+    // Settings.AdvanceAccount.UrlEmptyErrorAlertMessage
+    // No custom service set.
+    public static let SettingsAdvanceAccountEmptyUrlErrorAlertMessage = "Please enter a custom account url before enabling."
 }
 
 // Open With Settings

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -385,7 +385,7 @@ extension Strings {
 extension Strings {
     public static let AppMenuAddToReadingListTitleString = NSLocalizedString("Menu.AddToReadingList.Title", tableName: "Menu", value: "Add to Reading List", comment: "Label for the button, displayed in the menu, used to add a page to the reading list.")
     public static let AppMenuShowTabsTitleString = NSLocalizedString("Menu.ShowTabs.Title", tableName: "Menu", value: "Show Tabs", comment: "Label for the button, displayed in the menu, used to open the tabs tray")
-    public static let AppMenuSharePageTitleString = NSLocalizedString("Menu.SharePageAction.Title", tableName: "Menu", value: "Share Page With...", comment: "Label for the button, displayed in the menu, used to open the share dialog.")
+    public static let AppMenuSharePageTitleString = NSLocalizedString("Menu.SharePageAction.Title", tableName: "Menu", value: "Share Page With…", comment: "Label for the button, displayed in the menu, used to open the share dialog.")
     public static let AppMenuCopyURLTitleString = NSLocalizedString("Menu.CopyURL.Title", tableName: "Menu", value: "Copy URL", comment: "Label for the button, displayed in the menu, used to copy the page url to the clipboard.")
     public static let AppMenuNewTabTitleString = NSLocalizedString("Menu.NewTabAction.Title", tableName: "Menu", value: "Open New Tab", comment: "Label for the button, displayed in the menu, used to open a new tab")
     public static let AppMenuNewPrivateTabTitleString = NSLocalizedString("Menu.NewPrivateTabAction.Title", tableName: "Menu", value: "Open New Private Tab", comment: "Label for the button, displayed in the menu, used to open a new private tab.")


### PR DESCRIPTION
```
6d6e93bd3 Bug 1408031 - Better comment for the Settings VC Title
20a32b771 Bug 1408031 - Update Menu.SharePageAction.Title to use ellipsis
8403f59e6 Bug 1408031 - Update IDs for SendUsage strings
499929316 Bug 1408031 - Unexport Advanced Account Settings
f640900d5 Bug 1408031 - Correct spelling mistake in Strings.PocketTrendingText
```
