### PR TITLE
Bug 1407455 - Long Press Actions similar to Safari

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1597,10 +1597,6 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
             self.present(backForwardViewController, animated: true, completion: nil)
         }
     }
-    
-    private func showActionMenu() {
-        
-    }
 }
 
 extension BrowserViewController: WindowCloseHelperDelegate {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1320,6 +1320,12 @@ extension BrowserViewController: URLBarDelegate {
         presentSheetWith(actions: pageActions, on: self, from: button)
     }
     
+    func urlBarDidLongPressPageOptions(_ urlBar: URLBarView, from button: UIButton) {
+        guard let tab = tabManager.selectedTab else { return }
+        guard let url = tab.canonicalURL?.displayURL else { return }
+        presentActivityViewController(url, tab: tab, sourceView: button, sourceRect: button.bounds, arrowDirection: .up)
+    }
+    
     func urlBarDidPressStop(_ urlBar: URLBarView) {
         tabManager.selectedTab?.stop()
     }
@@ -1566,6 +1572,20 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     func tabToolbarDidPressTabs(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
         showTabTray()
     }
+    
+    func tabToolbarDidLongPressTabs(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
+        let controller = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        controller.addAction(UIAlertAction(title: Strings.NewTabTitle, style: .default, handler: { _ in
+            self.tabManager.addTabAndSelect(isPrivate: false)
+        }))
+        controller.addAction(UIAlertAction(title: Strings.NewPrivateTabTitle, style: .default, handler: { _ in
+            self.tabManager.addTabAndSelect(isPrivate: true)
+        }))
+        controller.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: "Label for Cancel button"), style: .cancel, handler: nil))
+        controller.popoverPresentationController?.sourceView = toolbar ?? urlBar
+        controller.popoverPresentationController?.sourceRect = button.frame
+        present(controller, animated: true, completion: nil)
+    }
 
     func showBackForwardList() {
         if let backForwardList = tabManager.selectedTab?.webView?.backForwardList {
@@ -1576,6 +1596,10 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
             backForwardViewController.backForwardTransitionDelegate = BackForwardListAnimator()
             self.present(backForwardViewController, animated: true, completion: nil)
         }
+    }
+    
+    private func showActionMenu() {
+        
     }
 }
 

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -15,6 +15,7 @@ protocol TabLocationViewDelegate {
     func tabLocationViewDidLongPressLocation(_ tabLocationView: TabLocationView)
     func tabLocationViewDidTapReaderMode(_ tabLocationView: TabLocationView)
     func tabLocationViewDidTapPageOptions(_ tabLocationView: TabLocationView, from button: UIButton)
+    func tabLocationViewDidLongPressPageOptions(_ tabLocationVIew: TabLocationView)
     
     /// - returns: whether the long-press was handled by the delegate; i.e. return `false` when the conditions for even starting handling long-press were not satisfied
     @discardableResult func tabLocationViewDidLongPressReaderMode(_ tabLocationView: TabLocationView) -> Bool
@@ -157,6 +158,8 @@ class TabLocationView: UIView {
         pageOptionsButton.imageView?.contentMode = .center
         pageOptionsButton.accessibilityLabel = NSLocalizedString("Page Options Menu", comment: "Accessibility label for the Page Options menu button")
         pageOptionsButton.accessibilityIdentifier = "TabLocationView.pageOptionsButton"
+        let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(TabLocationView.SELDidLongPressPageOptionsButton))
+        pageOptionsButton.addGestureRecognizer(longPressGesture)
         return pageOptionsButton
     }()
     
@@ -252,6 +255,10 @@ class TabLocationView: UIView {
     
     func SELDidPressPageOptionsButton(_ button: UIButton) {
         delegate?.tabLocationViewDidTapPageOptions(self, from: button)
+    }
+    
+    func SELDidLongPressPageOptionsButton(_ recognizer: UILongPressGestureRecognizer) {
+        delegate?.tabLocationViewDidLongPressPageOptions(self)
     }
 
     func SELlongPressLocation(_ recognizer: UITapGestureRecognizer) {

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -36,6 +36,7 @@ protocol TabToolbarDelegate: class {
     func tabToolbarDidPressStop(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressMenu(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressTabs(_ tabToolbar: TabToolbarProtocol, button: UIButton)
+    func tabToolbarDidLongPressTabs(_ tabToolbar: TabToolbarProtocol, button: UIButton)
 }
 
 @objc
@@ -84,6 +85,8 @@ open class TabToolbarHelper: NSObject {
         toolbar.stopReloadButton.addTarget(self, action: #selector(TabToolbarHelper.SELdidClickStopReload), for: UIControlEvents.touchUpInside)
 
         toolbar.tabsButton.addTarget(self, action: #selector(TabToolbarHelper.SELdidClickTabs), for: .touchUpInside)
+        let longPressGestureTabsButton = UILongPressGestureRecognizer(target: self, action: #selector(TabToolbarHelper.SELdidLongPressTabs(_:)))
+        toolbar.tabsButton.addGestureRecognizer(longPressGestureTabsButton)
 
         toolbar.menuButton.contentMode = UIViewContentMode.center
         toolbar.menuButton.setImage(UIImage.templateImageNamed("nav-menu"), for: .normal)
@@ -105,6 +108,10 @@ open class TabToolbarHelper: NSObject {
 
     func SELdidClickTabs() {
         toolbar.tabToolbarDelegate?.tabToolbarDidPressTabs(toolbar, button: toolbar.tabsButton)
+    }
+    
+    func SELdidLongPressTabs(_ recognizer: UILongPressGestureRecognizer) {
+        toolbar.tabToolbarDelegate?.tabToolbarDidLongPressTabs(toolbar, button: toolbar.tabsButton)
     }
 
     func SELdidClickForward() {

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -75,6 +75,7 @@ protocol URLBarDelegate: class {
     func urlBar(_ urlBar: URLBarView, didSubmitText text: String)
     // Returns either (search query, true) or (url, false).
     func urlBarDisplayTextForURL(_ url: URL?) -> (String?, Bool)
+    func urlBarDidLongPressPageOptions(_ urlBar: URLBarView, from button: UIButton)
 }
 
 class URLBarView: UIView {
@@ -614,6 +615,10 @@ extension URLBarView: TabLocationViewDelegate {
     
     func tabLocationViewDidTapPageOptions(_ tabLocationView: TabLocationView, from button: UIButton) {
         delegate?.urlBarDidPressPageOptions(self, from: tabLocationView.pageOptionsButton)
+    }
+    
+    func tabLocationViewDidLongPressPageOptions(_ tabLocationView: TabLocationView) {
+        delegate?.urlBarDidLongPressPageOptions(self, from: tabLocationView.pageOptionsButton)
     }
 
     func tabLocationViewLocationAccessibilityActions(_ tabLocationView: TabLocationView) -> [UIAccessibilityCustomAction]? {


### PR DESCRIPTION
Long press on the page actions button opens the share sheet. Long press on the tabs button presents an action sheet with the options to open the new tabs.

Screencast: http://recordit.co/79kvtDedRw