### PR TITLE
Bug 1409068: use error.debugDescription for internal Sentry logging

### DIFF
--- a/Client/Telemetry/UnifiedTelemetry.swift
+++ b/Client/Telemetry/UnifiedTelemetry.swift
@@ -40,7 +40,7 @@ class UnifiedTelemetry {
 
     @objc func uploadError(notification: NSNotification) {
         guard let error = notification.userInfo?["error"] as? NSError else { return }
-        SentryIntegration.shared.send(message: "Upload Error", tag: "UnifiedTelemetry", severity: .info, extra: ["Error": error.localizedDescription])
+        SentryIntegration.shared.send(message: "Upload Error", tag: "UnifiedTelemetry", severity: .info, extra: ["Error": error.debugDescription])
     }
 }
 


### PR DESCRIPTION
I confirmed this outputs all NSError fields, this should be much more useful.
Looks like
```
Error Domain=NSURLErrorDomain Code=-1009 \"The Internet connection appears to be offline.\" UserInfo={NSUnderlyingError=0x1c0257340 {Error Domain=kCFErrorDomainCFNetwork Code=-1009 \"(null)\" UserInfo={_kCFStreamErrorCodeKey=50, _kCFStreamErrorDomainKey=1}}, NSErrorFailingURLStringKey=https://incoming.telemetry.mozilla.org/submit/telemetry/C30CC0DB-1605-4F9C-8909-52A42F09C791/core/AppInfo.displayName/1.0/unknown/1?v=4, NSErrorFailingURLKey=https://incoming.telemetry.mozilla.org/submit/telemetry/C30CC0DB-1605-4F9C-8909-52A42F09C791/core/AppInfo.displayName/1.0/unknown/1?v=4, _kCFStreamErrorDomainKey=1, _kCFStreamErrorCodeKey=50, NSLocalizedDescription=The Internet connection appears to be offline.}
```

https://bugzilla.mozilla.org/show_bug.cgi?id=1409068