### PR TITLE
Bug 1407474 - Reduce padding at the top of the copy url toast. 

### DIFF
--- a/Client/Frontend/Browser/ButtonToast.swift
+++ b/Client/Frontend/Browser/ButtonToast.swift
@@ -106,7 +106,7 @@ class ButtonToast: UIView {
             label.adjustsFontSizeToFitWidth = true
             label.snp.makeConstraints { (make) in
                 make.leading.equalTo(toast).offset(ButtonToastUX.ToastPadding)
-                make.top.equalTo(toast).offset(ButtonToastUX.ToastButtonPadding)
+                make.top.equalTo(toast).offset(ButtonToastUX.TitleButtonPadding)
                 make.trailing.equalTo(button.snp.leading).offset(-ButtonToastUX.TitleButtonPadding)
             }
             description.snp.makeConstraints { (make) in


### PR DESCRIPTION
old padding was 10px. Now it is 5px. 

The old padding was assuming the height of the bar would be 56. It is actually 45