### PR TITLE
Bug 1408956 - Disable HomePageXCUITests from PageOptionsMenu

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
@@ -181,6 +181,9 @@
                <Test
                   Identifier = "SiteLoadTest">
                </Test>
+               <Test
+                   Identifier = "HomePageUITest">
+               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>

--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests_iPad.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests_iPad.xcscheme
@@ -178,6 +178,9 @@
                <Test
                   Identifier = "SiteLoadTest">
                </Test>
+               <Test
+                   Identifier = "HomePageUITest">
+               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>

--- a/XCUITests/HomePageSettingsTest.swift
+++ b/XCUITests/HomePageSettingsTest.swift
@@ -48,6 +48,7 @@ class HomePageSettingsTest: BaseTestCase {
         }
     }
 
+    /* Disabled due to new Photon UI
     // Check whether the toolbar/menu shows homepage icon
     func testShowHomePageIcon() {
         // Check the Homepage icon is present in menu by default
@@ -70,4 +71,5 @@ class HomePageSettingsTest: BaseTestCase {
         XCTAssertEqual(value, currentURL,
                        "The webpage typed does not match with the one saved")
     }
+     */
 }


### PR DESCRIPTION
Due to the new UI implementation these tests are no longer needed.
One of them has been moved to skipped tess and the other since it belongs to a test suite with other valid tests has been commented.
If you prefer a different approach, please let me know