### PR TITLE
Bug 1409343 - Re-enable ThirdPartySearchXCUITest

### DIFF
--- a/XCUITests/ThirdPartySearchTest.swift
+++ b/XCUITests/ThirdPartySearchTest.swift
@@ -139,40 +139,28 @@ class ThirdPartySearchTest: BaseTestCase {
         XCTAssertFalse(app.scrollViews.otherElements.buttons["developer.mozilla.org search"].exists)
 
     }
-    // Test failing in 10.3 due to timing issue when doing the last assert, it is done later than expected and so the text is different and fails
-    /*func testCustomEngineFromCorrectTemplate() {
-     let app = XCUIApplication()
-     
-     app.buttons["Menu"].tap()
-     app.collectionViews.cells["Settings"].tap()
-     let tablesQuery = app.tables
-     tablesQuery.cells["Search"].tap()
-     app.tables.cells["customEngineViewButton"].tap()
-     app.textViews["customEngineTitle"].tap()
-     app.typeText("Feeling Lucky")
-     app.textViews["customEngineUrl"].tap()
-     app.typeText("http://www.google.com/search?q=%s&btnI")
-     
-     app.navigationBars.buttons["customEngineSaveButton"].tap()
-     
-     waitforExistence(app.navigationBars["Search"])
-     XCTAssert(app.navigationBars["Search"].buttons["Settings"].exists)
-     
-     app.navigationBars["Search"].buttons["Settings"].tap()
-     app.navigationBars["Settings"].buttons["AppSettingsTableViewController.navigationItem.leftBarButtonItem"].tap()
-     
-     // Perform a search using a custom search engine
-     tabTrayButton(forApp: app).tap()
-     app.buttons["TabTrayController.addTabButton"].tap()
-     app.textFields["url"].tap()
-     
-     app.typeText("strange charm")
-     app.scrollViews.otherElements.buttons["Feeling Lucky search"].tap()
-     // Ensure that correct search is done
-     let url = app.textFields["url"].value as! String
-     XCTAssert(url.hasSuffix("&btnI"), "The URL should indicate that the search was performed using IFL")
-     }
-     */
+
+    func testCustomEngineFromCorrectTemplate() {
+        navigator.goto(SearchSettings)
+        app.tables.cells["customEngineViewButton"].tap()
+
+        app.textViews["customEngineTitle"].tap()
+        app.typeText("Feeling Lucky")
+        app.textViews["customEngineUrl"].tap()
+        app.typeText("http://www.google.com/search?q=%s&btnI")
+
+        app.navigationBars.buttons["customEngineSaveButton"].tap()
+
+        // Perform a search using a custom search engine
+        navigator.goto(HomePanelsScreen)
+        app.textFields["url"].tap()
+        app.typeText("strange charm")
+        app.scrollViews.otherElements.buttons["Feeling Lucky search"].tap()
+
+        // Ensure that correct search is done
+        let url = app.textFields["url"].value as! String
+        XCTAssert(url.hasSuffix("&btnI"), "The URL should indicate that the search was performed using IFL")
+    }
 
     func testCustomEngineFromIncorrectTemplate() {
         navigator.goto(SearchSettings)


### PR DESCRIPTION
This test was disabled due to a timing issue on 10.3, now that tests run on 11, the test is always passing locally, lets see if it also passes on BB so that we can enable it