### PR TITLE
Bug 1409487 - Toolbar not respecting safe area on iPhone X

### DIFF
--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -77,7 +77,7 @@ private extension TrayToBrowserAnimator {
             bvc.tabTrayDidDismiss(tabTray)
             UIApplication.shared.windows.first?.backgroundColor = UIConstants.AppBackgroundColor
             tabTray.navigationController?.setNeedsStatusBarAppearanceUpdate()
-            tabTray.toolbar.transform = CGAffineTransform(translationX: 0, y: UIConstants.ToolbarHeight)
+            tabTray.toolbar.transform = CGAffineTransform(translationX: 0, y: UIConstants.BottomToolbarHeight)
             tabCollectionViewSnapshot.transform = CGAffineTransform(scaleX: 0.9, y: 0.9)
             tabCollectionViewSnapshot.alpha = 0
         }, completion: { finished in
@@ -163,7 +163,7 @@ private extension BrowserToTrayAnimator {
             tabTray.collectionView.isHidden = true
             let finalFrame = calculateCollapsedCellFrameUsingCollectionView(tabTray.collectionView,
                 atIndex: scrollToIndex)
-            tabTray.toolbar.transform = CGAffineTransform(translationX: 0, y: UIConstants.ToolbarHeight)
+            tabTray.toolbar.transform = CGAffineTransform(translationX: 0, y: UIConstants.BottomToolbarHeight)
 
             UIView.animate(withDuration: self.transitionDuration(using: transitionContext),
                 delay: 0, usingSpringWithDamping: 1,
@@ -256,7 +256,7 @@ private func calculateExpandedCellFrameFromBVC(_ bvc: BrowserViewController) -> 
     if !bvc.shouldShowFooterForTraitCollection(bvc.traitCollection) {
         return frame
     } else if let url = bvc.tabManager.selectedTab?.url, url.isAboutURL && bvc.toolbar == nil {
-        frame.size.height += UIConstants.ToolbarHeight
+        frame.size.height += UIConstants.BottomToolbarHeight
     }
 
     return frame

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -649,7 +649,7 @@ class BrowserViewController: UIViewController {
         // Setup the bottom toolbar
         toolbar?.snp.remakeConstraints { make in
             make.edges.equalTo(self.footer)
-            make.height.equalTo(UIConstants.ToolbarHeight)
+            make.height.equalTo(UIConstants.BottomToolbarHeight)
         }
 
         footer.snp.remakeConstraints { make in

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -1030,19 +1030,20 @@ class TrayToolbar: UIView {
         maskButton.accessibilityIdentifier = "TabTrayController.maskButton"
 
         buttonToCenter?.snp.makeConstraints { make in
-            make.center.equalTo(self)
+            make.centerX.equalTo(self)
+            make.top.equalTo(self)
             make.size.equalTo(toolbarButtonSize)
         }
 
         addTabButton.snp.makeConstraints { make in
-            make.centerY.equalTo(self)
+            make.top.equalTo(self)
             make.right.equalTo(self).offset(-sideOffset)
             make.size.equalTo(toolbarButtonSize)
         }
 
         addSubview(maskButton)
         maskButton.snp.makeConstraints { make in
-            make.centerY.equalTo(self)
+            make.top.equalTo(self)
             make.left.equalTo(self).offset(sideOffset)
             make.size.equalTo(toolbarButtonSize)
         }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -319,7 +319,7 @@ class TabTrayController: UIViewController {
 
         collectionView.dataSource = tabDataSource
         collectionView.delegate = tabLayoutDelegate
-        collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: UIConstants.ToolbarHeight, right: 0)
+        collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: UIConstants.BottomToolbarHeight, right: 0)
         collectionView.register(TabCell.self, forCellWithReuseIdentifier: TabCell.Identifier)
         collectionView.backgroundColor = TabTrayControllerUX.BackgroundColor
 
@@ -393,7 +393,7 @@ class TabTrayController: UIViewController {
 
         toolbar.snp.makeConstraints { make in
             make.left.right.bottom.equalTo(view)
-            make.height.equalTo(UIConstants.ToolbarHeight)
+            make.height.equalTo(UIConstants.BottomToolbarHeight)
         }
     }
 

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -50,8 +50,17 @@ public struct UIConstants {
     static let PrivateModeInputHighlightColor = UIColor(red: 120 / 255, green: 120 / 255, blue: 165 / 255, alpha: 1)
     static let PrivateModeAssistantToolbarBackgroundColor = UIColor(red: 89 / 255, green: 89 / 255, blue: 89 / 255, alpha: 1)
     static let PrivateModeToolbarTintColor = UIColor(red: 74 / 255, green: 74 / 255, blue: 74 / 255, alpha: 1)
-
-    static let ToolbarHeight: CGFloat = 46
+    static var ToolbarHeight: CGFloat {
+        get {
+            var bottomInset: CGFloat = 0.0
+            if #available(iOS 11, *) {
+                if let window = UIApplication.shared.keyWindow {
+                    bottomInset = window.safeAreaInsets.bottom
+                }
+            }
+            return 46 + bottomInset
+        }
+    }
     static let DefaultRowHeight: CGFloat = 58
     static let DefaultPadding: CGFloat = 10
     static let SnackbarButtonHeight: CGFloat = 48

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -50,7 +50,9 @@ public struct UIConstants {
     static let PrivateModeInputHighlightColor = UIColor(red: 120 / 255, green: 120 / 255, blue: 165 / 255, alpha: 1)
     static let PrivateModeAssistantToolbarBackgroundColor = UIColor(red: 89 / 255, green: 89 / 255, blue: 89 / 255, alpha: 1)
     static let PrivateModeToolbarTintColor = UIColor(red: 74 / 255, green: 74 / 255, blue: 74 / 255, alpha: 1)
-    static var ToolbarHeight: CGFloat {
+
+    static var ToolbarHeight: CGFloat = 46
+    static var BottomToolbarHeight: CGFloat {
         get {
             var bottomInset: CGFloat = 0.0
             if #available(iOS 11, *) {
@@ -58,7 +60,7 @@ public struct UIConstants {
                     bottomInset = window.safeAreaInsets.bottom
                 }
             }
-            return 46 + bottomInset
+            return ToolbarHeight + bottomInset
         }
     }
     static let DefaultRowHeight: CGFloat = 58

--- a/Client/Frontend/Widgets/Toolbar.swift
+++ b/Client/Frontend/Widgets/Toolbar.swift
@@ -76,9 +76,15 @@ class Toolbar: UIView {
                     make.left.equalTo(self)
                 }
                 prev = view
-
-                make.centerY.equalTo(self)
-                make.height.equalTo(UIConstants.ToolbarHeight)
+                
+                var bottomInset: CGFloat = 0.0
+                if #available(iOS 11, *) {
+                    if let window = UIApplication.shared.keyWindow {
+                        bottomInset = window.safeAreaInsets.bottom
+                    }
+                }
+                make.top.equalTo(self)
+                make.height.equalTo(UIConstants.ToolbarHeight - bottomInset)
                 make.width.equalTo(self).dividedBy(self.subviews.count)
             }
         }

--- a/Client/Frontend/Widgets/Toolbar.swift
+++ b/Client/Frontend/Widgets/Toolbar.swift
@@ -84,7 +84,7 @@ class Toolbar: UIView {
                     }
                 }
                 make.top.equalTo(self)
-                make.height.equalTo(UIConstants.ToolbarHeight - bottomInset)
+                make.height.equalTo(UIConstants.BottomToolbarHeight - bottomInset)
                 make.width.equalTo(self).dividedBy(self.subviews.count)
             }
         }


### PR DESCRIPTION
Take safe area into consideration when calculating toolbar size

https://bugzilla.mozilla.org/show_bug.cgi?id=1409487

Before:
<img width="300" alt="before" src="https://user-images.githubusercontent.com/782316/31687432-20997bb6-b381-11e7-90e9-30025109c431.png">

After:
<img width="300" alt="after" src="https://user-images.githubusercontent.com/782316/31687431-205bd860-b381-11e7-9d8f-7c2286fcfd7e.png">
