### PR TITLE
Bug 1409644 - Fix iPad XCUITests

### DIFF
--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -305,11 +305,17 @@ class ActivityStreamTest: BaseTestCase {
         navigator.openURL(urlString: "http://yahoo.com")
 
         if iPad() {
+            // Test timeout on BB when loading these pages
             navigator.openURL(urlString: "http://cvs.com")
+            waitUntilPageLoad()
             navigator.openURL(urlString: "http://walmart.com")
+            waitUntilPageLoad()
             navigator.openURL(urlString: "http://zara.com")
+            waitUntilPageLoad()
             navigator.openURL(urlString: "http://twitter.com")
+            waitUntilPageLoad()
             navigator.openURL(urlString: "http://instagram.com")
+            waitUntilPageLoad()
         }
         navigator.goto(URLBarOpen)
         waitforExistence(pagecontrolButton)

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -212,7 +212,12 @@ func createScreenGraph(_ app: XCUIApplication, url: String = "https://www.mozill
     }
 
     let cancelBackAction = {
-        app.buttons["PhotonMenu.cancel"].tap()
+        if map.isiPad() {
+            // There is not Cancel option in iPad this way it is closed
+            app/*@START_MENU_TOKEN@*/.otherElements["PopoverDismissRegion"]/*[[".otherElements[\"dismiss popup\"]",".otherElements[\"PopoverDismissRegion\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        } else {
+            app.buttons["PhotonMenu.cancel"].tap()
+        }
     }
 
     let backBtnBackAction = {

--- a/XCUITests/NavigationTest.swift
+++ b/XCUITests/NavigationTest.swift
@@ -214,6 +214,7 @@ class NavigationTest: BaseTestCase {
     func testNavigationPreservesDesktopSiteOnSameHost() {
         clearData()
         navigator.openURL(urlString: urlAddOns)
+        waitUntilPageLoad()
 
         // Mobile view by default, desktop view should be available
         navigator.browserPerformAction(.toggleDesktopOption)
@@ -233,7 +234,11 @@ class NavigationTest: BaseTestCase {
         navigator.browserPerformAction(.toggleDesktopOption)
 
         // After reloading a website the desktop view should be kept
-        app.buttons["TabToolbar.stopReloadButton"].tap()
+        if iPad() {
+                app.buttons["Reload"].tap()
+        } else {
+                app.buttons["TabToolbar.stopReloadButton"].tap()
+        }
         waitForValueContains(app.textFields["url"], value: urlAddOns)
         checkDesktopView()
 
@@ -241,9 +246,14 @@ class NavigationTest: BaseTestCase {
         navigator.nowAt(BrowserTab)
         navigator.browserPerformAction(.toggleDesktopOption)
         waitForValueContains(app.textFields["url"], value: urlAddOns)
+        waitUntilPageLoad()
 
         // After reloading a website the mobile view should be kept
-        app.buttons["TabToolbar.stopReloadButton"].tap()
+        if iPad() {
+            app.buttons["Reload"].tap()
+        } else {
+            app.buttons["TabToolbar.stopReloadButton"].tap()
+        }
         checkMobileView()
     }
 

--- a/XCUITests/ToolbarTest.swift
+++ b/XCUITests/ToolbarTest.swift
@@ -47,11 +47,13 @@ class ToolbarTests: BaseTestCase {
 
         navigator.openURL(urlString: website2)
         waitForValueContains(app.textFields["url"], value: website2)
+        waitUntilPageLoad()
         XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
         XCTAssertFalse(app.buttons["Forward"].isEnabled)
 
         app.buttons["URLBarView.backButton"].tap()
         waitForValueContains(app.textFields["url"], value: website1["value"]!)
+        waitUntilPageLoad()
         XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
         XCTAssertTrue(app.buttons["Forward"].isEnabled)
 
@@ -62,6 +64,7 @@ class ToolbarTests: BaseTestCase {
         waitForValueContains(app.textFields["url"], value: website1["value"]!)
 
         // Test to see if all the buttons are enabled then close tab.
+        waitUntilPageLoad()
         XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
         XCTAssertTrue(app.buttons["Forward"].isEnabled)
 
@@ -72,7 +75,7 @@ class ToolbarTests: BaseTestCase {
         app.collectionViews.cells[website1["label"]!].swipeRight()
 
         // Go Back to other tab to see if all buttons are disabled.
-
+        navigator.nowAt(BrowserTab)
         XCTAssertFalse(app.buttons["URLBarView.backButton"].isEnabled)
         XCTAssertFalse(app.buttons["Forward"].isEnabled)
     }


### PR DESCRIPTION
There a a few tests failing on iPad. This PR is to try to fix them.

- ActivityStreamTest	 
testActivityStreamPages() -> need to wait till the page is loaded to continue	
- NavigationTest 
	testNavigationPreservesDesktopSiteOnSameHost() 	-> works locally, check if it is intermittent
	testReloadPreservesMobileOrDesktopSite() 	-> reload button has a different id on mobile 
	testToggleBetweenMobileAndDesktopSiteFromMenu() -> Cancel option is missing from Photon Menu UI in iPad
- ToolBarTest
testLandscapeNavigationWithTabSwitch() -> needs to be on BrowserTab to do the checks
