### PR TITLE
Bug 1409610 - Limit the width of the Photon menu when in landscape mode.

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet.swift
@@ -8,7 +8,7 @@ import SnapKit
 import Shared
 
 private struct PhotonActionSheetUX {
-    static let MaxWidth: CGFloat = 375
+    static let MaxWidth: CGFloat = 414
     static let Padding: CGFloat = 10
     static let SectionVerticalPadding: CGFloat = 13
     static let HeaderHeight: CGFloat = 80
@@ -142,8 +142,7 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
             tableView.backgroundColor = .clear
         }
 
-        var width = min(self.view.frame.size.width, PhotonActionSheetUX.MaxWidth) - (PhotonActionSheetUX.Padding * 2)
-        width = self.modalPresentationStyle == .popover ? width : (self.view.frame.width - (PhotonActionSheetUX.Padding * 2))
+        let width = min(self.view.frame.size.width, PhotonActionSheetUX.MaxWidth) - (PhotonActionSheetUX.Padding * 2)
         let height = actionSheetHeight()
         
         if self.modalPresentationStyle == .popover {


### PR DESCRIPTION
* Increased the maxWidth to 414 to match the plus sized devices. 
This makes sure that when in portrait mode the menu always uses all the space available and it also makes the menu larger on iPad providing more room for localization. 