### PR TITLE
Bug 1410185 - Browser action sheet not respecting safe area for iPhone X

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet.swift
@@ -156,7 +156,11 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
                 make.centerX.equalTo(self.view.snp.centerX)
                 make.width.equalTo(width)
                 make.height.equalTo(PhotonActionSheetUX.CancelButtonHeight)
-                make.bottom.equalTo(self.view.snp.bottom).offset(-PhotonActionSheetUX.Padding)
+                if #available(iOS 11, *) {
+                    make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom)
+                } else {
+                    make.bottom.equalTo(self.view.snp.bottom).offset(-PhotonActionSheetUX.Padding)
+                }
             }
         }
         


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1410185

Bottom bar action before:
<img width="200" alt="bottombar_action_before" src="https://user-images.githubusercontent.com/782316/31786740-5f9d0e0a-b501-11e7-8473-6e6aef645947.png">

Bottom bar action after
<img width="200" alt="bottombar_action_after" src="https://user-images.githubusercontent.com/782316/31786739-5f7f4294-b501-11e7-8b83-c2827389a1c2.png">

Topbar action before:
<img width="200" alt="topbar_action_before" src="https://user-images.githubusercontent.com/782316/31786742-5fd9be90-b501-11e7-97af-54304f96398d.png">

Topbar action after:
<img width="200" alt="topbar_action_after" src="https://user-images.githubusercontent.com/782316/31786741-5fb771b4-b501-11e7-9365-590cfd93d9b4.png">

The offset `offset(-PhotonActionSheetUX.Padding)` was removed on iPhone X because I checked native action sheet and the offset was actually making it taller than it should be on this case.
As you can see here:

Native sheet:
<img width="200" alt="native" src="https://user-images.githubusercontent.com/782316/31786872-d7c2d978-b501-11e7-8b37-972d9c8cd198.png">

PhotonActionSheet + Padding == Too much padding.
<img width="200" alt="withpadding" src="https://user-images.githubusercontent.com/782316/31786870-d638b5b4-b501-11e7-8327-9c658ba53af1.png">




