### PR TITLE
Bug 1410337 - Fix NightMode and NoImage XCUITests iPad

### DIFF
--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -300,9 +300,13 @@ class ActivityStreamTest: BaseTestCase {
         XCTAssertFalse(pagecontrolButton.exists, "The Page Control button must not exist. Only 5 elements should be on the page")
 
         navigator.openURL(urlString: "http://example.com")
+        waitUntilPageLoad()
         navigator.openURL(urlString: "http://mozilla.org")
+        waitUntilPageLoad()
         navigator.openURL(urlString: "http://apple.com")
+        waitUntilPageLoad()
         navigator.openURL(urlString: "http://yahoo.com")
+        waitUntilPageLoad()
 
         if iPad() {
             // Test timeout on BB when loading these pages

--- a/XCUITests/BookmarkingTests.swift
+++ b/XCUITests/BookmarkingTests.swift
@@ -97,6 +97,7 @@ class BookmarkingTests: BaseTestCase {
         //First time there is not any bookmark
         navigator.browserPerformAction(.openBookMarksOption)
         checkEmptyBookmarkList()
+        navigator.nowAt(BrowserTab)
 
         //Add a bookmark
         navigator.createNewTab()

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -374,8 +374,9 @@ func createScreenGraph(_ app: XCUIApplication, url: String = "https://www.mozill
     }
 
     map.createScene(BrowserTabMenu) { scene in
-        scene.backAction = closeMenuAction
+        scene.backAction = cancelBackAction
         scene.tap(app.tables.cells["Settings"], to: SettingsScreen)
+
 
         scene.dismissOnUse = true
     }


### PR DESCRIPTION
Those tests were failing because once the BrowserTabMenu was open, it was not closed and so not accessible the next time it was required.

Also, adding waitUntilPageLoad() for ActivityStream test that intermintently fails on iPad
Bookmark test has been modified because it failed after changing FxScreenGraph to fix the previous tests