### PR TITLE
Bug 1407443 - The LocalAuthContext should be reused.

### DIFF
--- a/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
+++ b/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
@@ -241,9 +241,10 @@ class AuthenticationSettingsViewController: SettingsTableViewController {
     }
 
     fileprivate func updateTitleForTouchIDState() {
-        if LAContext().canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) {
+        let localAuthContext = LAContext()
+        if localAuthContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) {
             let title: String
-            if #available(iOS 11.0, *), LAContext().biometryType == .typeFaceID {
+            if #available(iOS 11.0, *), localAuthContext.biometryType == .typeFaceID {
                 title = AuthenticationStrings.faceIDPasscodeSetting
             } else {
                 title = AuthenticationStrings.touchIDPasscodeSetting

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -849,10 +849,11 @@ class TouchIDPasscodeSetting: Setting {
     init(settings: SettingsTableViewController, delegate: SettingsDelegate? = nil) {
         self.profile = settings.profile
         self.tabManager = settings.tabManager
+        let localAuthContext = LAContext()
 
         let title: String
-        if LAContext().canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) {
-            if #available(iOS 11.0, *), LAContext().biometryType == .typeFaceID {
+        if localAuthContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) {
+            if #available(iOS 11.0, *), localAuthContext.biometryType == .typeFaceID {
                 title = AuthenticationStrings.faceIDPasscodeSetting
             } else {
                 title = AuthenticationStrings.touchIDPasscodeSetting


### PR DESCRIPTION
I'm not sure why. But the LAContext needs to be reused, otherwise in XCode 9.0.1 the iPhone X simulator still shows "Touch ID"