### PR TITLE
Bug 1410229 - Improvements to Sentry logging

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -86,7 +86,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         // Need to get "settings.sendUsageData" this way so that Sentry can be initialized
         // before getting the Profile.
         let sendUsageData = NSUserDefaultsPrefs(prefix: "profile").boolForKey(AppConstants.PrefSendUsageData) ?? true
-        SentryIntegration.shared.setup(sendUsageData: sendUsageData)
+        Sentry.shared.setup(sendUsageData: sendUsageData)
         
         // Set the Firefox UA for browsing.
         setUserAgent()

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2969,7 +2969,7 @@ extension BrowserViewController: ClientPickerViewControllerDelegate, Instruction
     func clientPickerViewController(_ clientPickerViewController: ClientPickerViewController, didPickClients clients: [RemoteClient]) {
         guard let tab = tabManager.selectedTab,
             let url = tab.canonicalURL?.displayURL?.absoluteString else { return }
-        let shareItem = ShareItem.init(url: url, title: tab.title, favicon: tab.displayFavicon)
+        let shareItem = ShareItem(url: url, title: tab.title, favicon: tab.displayFavicon)
         guard shareItem.isShareable else {
             let alert = UIAlertController(title: Strings.SendToErrorTitle, message: Strings.SendToErrorMessage, preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: Strings.SendToErrorOKButton, style: .default) { _ in self.popToBVC()})

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -506,7 +506,6 @@ class BrowserViewController: UIViewController {
         }
 
         if !displayedRestoreTabsAlert && !cleanlyBackgrounded() && crashedLastLaunch() {
-            SentryIntegration.shared.send(message: "Asking to restore tabs", tag: "BrowserViewController", severity: .info, completion: nil)
             displayedRestoreTabsAlert = true
             showRestoreTabsAlert()
         } else {
@@ -518,7 +517,7 @@ class BrowserViewController: UIViewController {
     }
 
     fileprivate func crashedLastLaunch() -> Bool {
-        return SentryIntegration.crashedLastLaunch
+        return Sentry.crashedLastLaunch
     }
 
     fileprivate func cleanlyBackgrounded() -> Bool {

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -665,7 +665,7 @@ extension TabManager {
             let unarchiver = NSKeyedUnarchiver(forReadingWith: tabData)
             unarchiver.decodingFailurePolicy = .setErrorAndReturn
             guard let tabs = unarchiver.decodeObject(forKey: "tabs") as? [SavedTab] else {
-                SentryIntegration.shared.send(message: "Failed to restore tabs: \(unarchiver.error ??? "nil")", tag: "TabManager", severity: .error)
+                Sentry.shared.send(message: "Failed to restore tabs", tag: SentryTag.tabManager, severity: .error, description: "\(unarchiver.error ??? "nil")")
                 return nil
             }
             return tabs
@@ -709,8 +709,7 @@ extension TabManager {
         _ = Try(withTry: { () -> Void in
             self.preserveTabsInternal()
             }) { (exception) -> Void in
-            print("Failed to preserve tabs: \(exception ??? "nil")")
-            SentryIntegration.shared.send(message: "Failed to preserve tabs: \(exception ??? "nil")", tag: "TabManager", severity: .error)
+            Sentry.shared.send(message: "Failed to preserve tabs", tag: SentryTag.tabManager, severity: .error, description: "\(exception ??? "nil")")
         }
     }
 
@@ -785,8 +784,7 @@ extension TabManager {
                     self.restoreTabsInternal()
                 },
                 catch: { exception in
-                    print("Failed to restore tabs: \(exception ??? "nil")")
-                    SentryIntegration.shared.send(message: "Failed to restore tabs: \(exception ??? "nil")", tag: "TabManager", severity: .error)
+                    Sentry.shared.send(message: "Failed to restore tabs: ", tag: SentryTag.tabManager, severity: .error, description: "\(exception ??? "nil")")
                 }
             )
         }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -611,7 +611,7 @@ class ForceCrashSetting: HiddenSetting {
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        SentryIntegration.shared.crash()
+        Sentry.shared.crash()
     }
 }
 

--- a/Client/Telemetry/UnifiedTelemetry.swift
+++ b/Client/Telemetry/UnifiedTelemetry.swift
@@ -40,7 +40,7 @@ class UnifiedTelemetry {
 
     @objc func uploadError(notification: NSNotification) {
         guard !DeviceInfo.isSimulator(), let error = notification.userInfo?["error"] as? NSError else { return }
-        SentryIntegration.shared.send(message: "Upload Error", tag: "UnifiedTelemetry", severity: .info, extra: ["Error": error.debugDescription])
+        Sentry.shared.send(message: "Upload Error", tag: SentryTag.unifiedTelemetry, severity: .info, description: error.debugDescription)
     }
 }
 

--- a/Extensions/NotificationService/NotificationService.swift
+++ b/Extensions/NotificationService/NotificationService.swift
@@ -11,7 +11,6 @@ private let log = Logger.browserLogger
 
 private let CategorySentTab = "org.mozilla.ios.SentTab.placeholder"
 
-private let sentryTag = "NotificationService"
 
 class NotificationService: UNNotificationServiceExtension {
     var display: SyncDataDisplay!
@@ -33,7 +32,7 @@ class NotificationService: UNNotificationServiceExtension {
         }
 
         guard let content = (request.content.mutableCopy() as? UNMutableNotificationContent) else {
-            SentryIntegration.shared.sendWithStacktrace(message: "No notification content", tag: sentryTag)
+            Sentry.shared.sendWithStacktrace(message: "No notification content", tag: SentryTag.notificationService)
             return self.didFinish(PushMessage.accountVerified)
         }
 
@@ -57,8 +56,8 @@ class NotificationService: UNNotificationServiceExtension {
         display.messageDelivered = false
         display.displayNotification(what, with: error)
         if !display.messageDelivered {
-            let string = "Empty notification: message=\(what?.messageType.rawValue ?? "nil"), error=\(error?.description ?? "nil")"
-            SentryIntegration.shared.send(message: string, tag: sentryTag)
+            let string = ["message": "\(what?.messageType.rawValue ?? "nil"), error=\(error?.description ?? "nil")"]
+            Sentry.shared.send(message: "Empty notification", tag: SentryTag.notificationService, extra: string)
             display.displayUnknownMessageNotification()
         }
     }
@@ -87,11 +86,7 @@ class SyncDataDisplay {
 
     func displayNotification(_ message: PushMessage? = nil, with error: PushMessageError? = nil) {
         guard let message = message, error == nil else {
-            if let error = error {
-                SentryIntegration.shared.send(message: "PushMessageError: \(error.description)", tag: sentryTag)
-            } else {
-                SentryIntegration.shared.send(message: "PushMessage: nil message", tag: sentryTag)
-            }
+            Sentry.shared.send(message: "PushMessageError", tag: SentryTag.notificationService, description: "\(error?.description ??? "nil")")
             return displayUnknownMessageNotification()
         }
 
@@ -153,7 +148,7 @@ extension SyncDataDisplay {
         } else {
             presentNotification(title: Strings.SentTab_NoTabArrivingNotification_title, body: Strings.SentTab_NoTabArrivingNotification_body)
         }
-        SentryIntegration.shared.sendWithStacktrace(message: "Unknown notification message", tag: sentryTag)
+        Sentry.shared.sendWithStacktrace(message: "Unknown notification message", tag: SentryTag.notificationService)
     }
 }
 
@@ -187,8 +182,8 @@ extension SyncDataDisplay {
 
         let center = UNUserNotificationCenter.current()
         center.getDeliveredNotifications { notifications in
-
-            SentryIntegration.shared.send(message: "deliveredNotification count = \(notifications.count)", tag: sentryTag)
+            let extra = ["notificationCount": "\(notifications.count)"]
+            Sentry.shared.send(message: "deliveredNotification count", tag: SentryTag.notificationService, extra: extra)
 
             // Let's deal with sent-tab-notifications
             let sentTabNotifications = notifications.filter {

--- a/Extensions/NotificationService/NotificationService.swift
+++ b/Extensions/NotificationService/NotificationService.swift
@@ -8,9 +8,7 @@ import Sync
 import UserNotifications
 
 private let log = Logger.browserLogger
-
 private let CategorySentTab = "org.mozilla.ios.SentTab.placeholder"
-
 
 class NotificationService: UNNotificationServiceExtension {
     var display: SyncDataDisplay!

--- a/Shared/SentryIntegration.swift
+++ b/Shared/SentryIntegration.swift
@@ -5,8 +5,18 @@
 import Foundation
 import Sentry
 
-public class SentryIntegration {
-    public static let shared = SentryIntegration()
+public enum SentryTag: String {
+    case swiftData
+    case browserDB
+    case notificationService
+    case unifiedTelemetry
+    case general
+    case tabManager
+    case bookmarks
+}
+
+public class Sentry {
+    public static let shared = Sentry()
 
     public static var crashedLastLaunch: Bool {
         return Client.shared?.crashedLastLaunch() ?? false
@@ -22,24 +32,24 @@ public class SentryIntegration {
     private var attributes: [String: Any] = [:]
 
     public func setup(sendUsageData: Bool) {
-        assert(!enabled, "SentryIntegration.setup() should only be called once")
+        assert(!enabled, "Sentry.setup() should only be called once")
 
         if DeviceInfo.isSimulator() {
-            Logger.browserLogger.error("Not enabling Sentry; Running in Simulator")
+            Logger.browserLogger.debug("Not enabling Sentry; Running in Simulator")
             return
         }
 
         if !sendUsageData {
-            Logger.browserLogger.error("Not enabling Sentry; Not enabled by user choice")
+            Logger.browserLogger.debug("Not enabling Sentry; Not enabled by user choice")
             return
         }
 
         guard let dsn = Bundle.main.object(forInfoDictionaryKey: SentryDSNKey) as? String, !dsn.isEmpty else {
-            Logger.browserLogger.error("Not enabling Sentry; Not configured in Info.plist")
+            Logger.browserLogger.debug("Not enabling Sentry; Not configured in Info.plist")
             return
         }
 
-        Logger.browserLogger.error("Enabling Sentry crash handler")
+        Logger.browserLogger.debug("Enabling Sentry crash handler")
         
         do {
             Client.shared = try Client(dsn: dsn)
@@ -84,22 +94,33 @@ public class SentryIntegration {
         return event
     }
 
-    public func send(message: String, tag: String = "general", severity: SentrySeverity = .info, extra: [String: Any]? = nil, completion: SentryRequestFinished? = nil) {
+    public func send(message: String, tag: SentryTag = .general, severity: SentrySeverity = .info, extra: [String: Any]? = nil, description: String? = nil, completion: SentryRequestFinished? = nil) {
         // Do not send messages from SwiftData or BrowserDB unless this is the Beta channel
-        if !enabled || (AppConstants.BuildChannel != .beta && (tag == "SwiftData" || tag == "BrowserDB" || tag == "NotificationService")) {
+
+        if !enabled || (AppConstants.BuildChannel != .beta && (tag.rawValue == "SwiftData" || tag.rawValue == "BrowserDB" || tag.rawValue == "NotificationService")) {
             if let completion = completion {
                 completion(nil)
             }
             return
         }
 
-        let event = makeEvent(message: message, tag: tag, severity: severity, extra: extra)
+        // Build the dictionary
+        var extraEvents: [String: Any] = [:]
+        if let paramEvents = extra {
+            extraEvents.merge(with: paramEvents)
+        }
+        if let extraString = description {
+            extraEvents.merge(with: ["errorDescription": extraString])
+        }
+
+        let event = makeEvent(message: message, tag: tag.rawValue, severity: severity, extra: extraEvents)
         Client.shared?.send(event: event, completion: completion)
     }
 
-    public func sendWithStacktrace(message: String, tag: String = "general", severity: SentrySeverity = .info, extra: [String: Any]? = nil, completion: SentryRequestFinished? = nil) {
+
+    public func sendWithStacktrace(message: String, tag: SentryTag = .general, severity: SentrySeverity = .info, extra: [String: Any]? = nil, description: String? = nil, completion: SentryRequestFinished? = nil) {
         // Do not send messages from SwiftData or BrowserDB unless this is the Beta channel
-        if !enabled || (AppConstants.BuildChannel != .beta && (tag == "SwiftData" || tag == "BrowserDB" || tag == "NotificationService")) {
+        if !enabled || (AppConstants.BuildChannel != .beta && (tag.rawValue == "SwiftData" || tag.rawValue == "BrowserDB" || tag.rawValue == "NotificationService")) {
             if let completion = completion {
                 completion(nil)
             }
@@ -107,7 +128,7 @@ public class SentryIntegration {
         }
 
         Client.shared?.snapshotStacktrace {
-            let event = self.makeEvent(message: message, tag: tag, severity: severity, extra: extra)
+            let event = self.makeEvent(message: message, tag: tag.rawValue, severity: severity, extra: extra)
             Client.shared?.appendStacktrace(to: event)
             event.debugMeta = nil
             Client.shared?.send(event: event, completion: completion)
@@ -116,5 +137,13 @@ public class SentryIntegration {
 
     public func addAttributes(_ attributes: [String: Any]) {
         self.attributes.merge(with: attributes)
+    }
+
+    private func printMessage(message: String, extra: [String: Any]? = nil) {
+        let string = extra?.reduce("") { (result: String, arg1) in
+            let (key, value) = arg1
+            return "\(result), \(key): \(value)"
+        }
+        Logger.browserLogger.debug("Sentry: \(message) \(string ??? "")")
     }
 }

--- a/Shared/SentryIntegration.swift
+++ b/Shared/SentryIntegration.swift
@@ -6,13 +6,13 @@ import Foundation
 import Sentry
 
 public enum SentryTag: String {
-    case swiftData
-    case browserDB
-    case notificationService
-    case unifiedTelemetry
-    case general
-    case tabManager
-    case bookmarks
+    case swiftData = "SwiftData"
+    case browserDB = "BrowserDB"
+    case notificationService = "NotificationService"
+    case unifiedTelemetry = "UnifiedTelemetry"
+    case general = "General"
+    case tabManager = "TabManager"
+    case bookmarks = "Bookmarks"
 }
 
 public class Sentry {
@@ -137,7 +137,6 @@ public class Sentry {
         printMessage(message: message, extra: extraEvents)
 
         // Do not send messages to Sentry if disabled OR if we are not on beta and the severity isnt severe
-        //true && true
         if shouldNotSendEventFor(severity) {
             completion?(nil)
             return

--- a/Shared/SentryIntegration.swift
+++ b/Shared/SentryIntegration.swift
@@ -126,8 +126,6 @@ public class Sentry {
         Client.shared?.send(event: event, completion: completion)
     }
 
-
-
     public func sendWithStacktrace(message: String, tag: SentryTag = .general, severity: SentrySeverity = .info, extra: [String: Any]? = nil, description: String? = nil, completion: SentryRequestFinished? = nil) {
         var extraEvents: [String: Any] = [:]
         if let paramEvents = extra {

--- a/Storage/SQL/BrowserSchema.swift
+++ b/Storage/SQL/BrowserSchema.swift
@@ -1236,8 +1236,7 @@ open class BrowserSchema: Schema {
         do {
             try db.executeChange(sql)
         } catch let err as NSError {
-            log.error("Error dropping tableList table: \(err.localizedDescription)")
-            SentryIntegration.shared.sendWithStacktrace(message: "Error dropping tableList table: \(err.localizedDescription)", tag: "BrowserDB", severity: .error)
+            Sentry.shared.sendWithStacktrace(message: "Error dropping tableList table", tag: SentryTag.browserDB, severity: .error, description: "\(err.localizedDescription)")
             return false
         }
 
@@ -1246,8 +1245,7 @@ open class BrowserSchema: Schema {
         do {
             try db.setVersion(previousVersion)
         } catch let err as NSError {
-            log.error("Error setting database version: \(err.localizedDescription)")
-            SentryIntegration.shared.sendWithStacktrace(message: "Error setting database version: \(err.localizedDescription)", tag: "BrowserDB", severity: .error)
+            Sentry.shared.sendWithStacktrace(message: "Error setting database version", tag: SentryTag.browserDB, severity: .error, description: "\(err.localizedDescription)")
             return false
         }
         
@@ -1291,7 +1289,8 @@ open class BrowserSchema: Schema {
                 try db.executeChange(sql)
             } catch let err as NSError {
                 log.error("Error altering \(TableClients) table: \(err.localizedDescription); SQL was \(sql)")
-                SentryIntegration.shared.sendWithStacktrace(message: "Error altering \(TableClients) table: \(err.localizedDescription); SQL was \(sql)", tag: "BrowserDB", severity: .error)
+                let extra = ["table": "\(TableClients)", "errorDescription": "\(err.localizedDescription)", "sql": "\(sql)"]
+                Sentry.shared.sendWithStacktrace(message: "Error altering table", tag: SentryTag.browserDB, severity: .error, extra: extra)
                 return .failure
             }
         }
@@ -1302,7 +1301,8 @@ open class BrowserSchema: Schema {
                 try db.executeChange(sql)
             } catch let err as NSError {
                 log.error("Error altering \(TableClients) table: \(err.localizedDescription); SQL was \(sql)")
-                SentryIntegration.shared.sendWithStacktrace(message: "Error altering \(TableClients) table: \(err.localizedDescription); SQL was \(sql)", tag: "BrowserDB", severity: .error)
+                let extra = ["table": "\(TableClients)", "errorDescription": "\(err.localizedDescription)", "sql": "\(sql)"]
+                Sentry.shared.sendWithStacktrace(message: "Error altering table", tag: SentryTag.browserDB, severity: .error, extra: extra)
                 return .failure
             }
         }

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -418,7 +418,8 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         // into using a `FailedSQLiteDBConnection` so we can retry opening again later.
         if !doOpen() {
             log.error("Cannot open a database connection to \(filename).")
-            SentryIntegration.shared.sendWithStacktrace(message: "Cannot open a database connection to \(filename).", tag: "SwiftData", severity: .error)
+            let extra = ["filename" : "\(filename)"]
+            Sentry.shared.sendWithStacktrace(message: "Cannot open a database connection.", tag: SentryTag.swiftData, severity: .error, extra: extra)
             return nil
         }
 
@@ -434,20 +435,17 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         case .success:
             log.debug("Database succesfully created or updated.")
         case .failure:
-            log.error("Failed to create or update the database schema.")
-            SentryIntegration.shared.sendWithStacktrace(message: "Failed to create or update the database schema.", tag: "SwiftData", severity: .error)
+            Sentry.shared.sendWithStacktrace(message: "Failed to create or update the database schema.", tag: SentryTag.swiftData, severity: .error)
             return nil
         case .needsRecovery:
-            log.error("Database schema cannot be created or updated due to an unrecoverable error.")
-            SentryIntegration.shared.sendWithStacktrace(message: "Database schema cannot be created or updated due to an unrecoverable error.", tag: "SwiftData", severity: .error)
+            Sentry.shared.sendWithStacktrace(message: "Database schema cannot be created or updated due to an unrecoverable error.", tag: SentryTag.swiftData, severity: .error)
 
             // We need to close this new connection before we can move the database file to
             // its backup location. If we cannot even close the connection, something has
             // gone really wrong. In that case, bail out and return `nil` to force SwiftData
             // into using a `FailedSQLiteDBConnection` so we can retry again later.
             if let error = self.closeCustomConnection(immediately: true) {
-                log.error("Cannot close the database connection to begin recovery. \(error.localizedDescription)")
-                SentryIntegration.shared.sendWithStacktrace(message: "Cannot close the database connection to begin recovery. \(error.localizedDescription)", tag: "SwiftData", severity: .error)
+                Sentry.shared.sendWithStacktrace(message: "Cannot close the database connection to begin recovery.", tag: SentryTag.swiftData, severity: .error, description: "\(error.localizedDescription)")
                 return nil
             }
 
@@ -459,7 +457,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             // retry opening again later.
             if !doOpen() {
                 log.error("Cannot re-open a database connection to the new database file to begin recovery.")
-                SentryIntegration.shared.sendWithStacktrace(message: "Cannot re-open a database connection to the new database file to begin recovery.", tag: "SwiftData", severity: .error)
+                Sentry.shared.sendWithStacktrace(message: "Cannot re-open a database connection to the new database file to begin recovery.", tag: SentryTag.swiftData, severity: .error)
                 return nil
             }
 
@@ -476,7 +474,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             // again later.
             if self.prepareSchema() != .success {
                 log.error("Cannot re-create the schema in the new database file to complete recovery.")
-                SentryIntegration.shared.sendWithStacktrace(message: "Cannot re-create the schema in the new database file to complete recovery.", tag: "SwiftData", severity: .error)
+                Sentry.shared.sendWithStacktrace(message: "Cannot re-create the schema in the new database file to complete recovery.", tag: SentryTag.swiftData, severity: .error)
                 return nil
             }
         }
@@ -549,14 +547,12 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
                 throw err
             }
             if let err = openWithFlags(flags) {
-                log.error("Error opening database with flags. Error code: \(err.code), \(err)")
-                SentryIntegration.shared.sendWithStacktrace(message: "Error opening database with flags. Error code: \(err.code), \(err)", tag: "SwiftData", severity: .error)
+                Sentry.shared.sendWithStacktrace(message: "Error opening database with flags.", tag: SentryTag.swiftData, severity: .error, description: "\(err.code), \(err)")
                 throw err
             }
             if let err = reKey(prevKey, newKey: key) {
                 // Note: Don't log the error here as it may contain sensitive data.
-                log.error("Unable to encrypt database.")
-                SentryIntegration.shared.sendWithStacktrace(message: "Unable to encrypt database.", tag: "SwiftData", severity: .error)
+                Sentry.shared.sendWithStacktrace(message: "Unable to encrypt database.", tag: SentryTag.swiftData, severity: .error)
                 throw err
             }
         }
@@ -695,7 +691,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
     // Calls to this function will be serialized to prevent race conditions when
     // creating or updating the schema.
     fileprivate func prepareSchema() -> SQLiteDBConnectionCreatedResult {
-        SentryIntegration.shared.addAttributes(["dbSchema.\(schema.name).version": schema.version])
+        Sentry.shared.addAttributes(["dbSchema.\(schema.name).version": schema.version])
         
         // Get the current schema version for the database.
         let currentVersion = self.version
@@ -711,13 +707,13 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         
         // Set an attribute for Sentry to include with any future error/crash
         // logs to indicate what schema version we're coming from and going to.
-        SentryIntegration.shared.addAttributes(["dbUpgrade.\(self.schema.name).from": currentVersion, "dbUpgrade.\(self.schema.name).to": self.schema.version])
+        Sentry.shared.addAttributes(["dbUpgrade.\(self.schema.name).from": currentVersion, "dbUpgrade.\(self.schema.name).to": self.schema.version])
         
         // This should not ever happen since the schema version should always be
         // increasing whenever a structural change is made in an app update.
         guard currentVersion <= schema.version else {
-            log.error("Schema \(self.schema.name) cannot be downgraded from version \(currentVersion) to \(self.schema.version).")
-            SentryIntegration.shared.sendWithStacktrace(message: "Schema \(self.schema.name) cannot be downgraded from version \(currentVersion) to \(self.schema.version).", tag: "SwiftData", severity: .error)
+            let errorString = "\(self.schema.name) cannot be downgraded from version \(currentVersion) to \(self.schema.version)."
+            Sentry.shared.sendWithStacktrace(message: "Schema cannot be downgraded.", tag: SentryTag.swiftData, severity: .error, description: errorString)
             return .failure
         }
         
@@ -747,9 +743,8 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
                         return success
                     }
                 }
-                
-                log.info("Attempting to update schema from version \(currentVersion) to \(self.schema.version).")
-                SentryIntegration.shared.send(message: "Attempting to update schema from version \(currentVersion) to \(self.schema.version).", tag: "SwiftData", severity: .info)
+
+                Sentry.shared.send(message: "Attempting to update schema from version", tag: SentryTag.swiftData, severity: .info, description: "\(currentVersion) to \(self.schema.version).")
 
                 // If we can't create a brand new schema from scratch, we must
                 // call `updateSchema()` to go through the update process.
@@ -762,14 +757,12 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
                 // If we failed to update the schema, we'll drop everything from the DB
                 // and create everything again from scratch. Assuming our schema upgrade
                 // code is correct, this *shouldn't* happen. If it does, log it to Sentry.
-                log.error("Update failed for schema \(self.schema.name) from version \(currentVersion) to \(self.schema.version). Dropping and re-creating.")
-                SentryIntegration.shared.sendWithStacktrace(message: "Update failed for schema \(self.schema.name) from version \(currentVersion) to \(self.schema.version). Dropping and re-creating.", tag: "SwiftData", severity: .error)
+                Sentry.shared.sendWithStacktrace(message: "Update failed for schema. Dropping and re-creating.", tag: SentryTag.swiftData, severity: .error, description: "\(self.schema.name) from version \(currentVersion) to \(self.schema.version)")
 
                 // If we can't even drop the schema here, something has gone really wrong, so
                 // return `false` which should force us into recovery.
                 if !self.dropSchema() {
-                    log.error("Unable to drop schema \(self.schema.name) from version \(currentVersion).")
-                    SentryIntegration.shared.sendWithStacktrace(message: "Unable to drop schema \(self.schema.name) from version \(currentVersion).", tag: "SwiftData", severity: .error)
+                    Sentry.shared.sendWithStacktrace(message: "Unable to drop schema.", tag: SentryTag.swiftData, severity: .error, description: "\(self.schema.name) from version \(currentVersion).")
                     success = false
                     return success
                 }
@@ -783,8 +776,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             // If we got an error trying to get a transaction, then we either bail out early and return
             // `.failure` if we think we can retry later or return `.needsRecovery` if the error is not
             // recoverable.
-            log.error("Unable to get a transaction: \(error.localizedDescription)")
-            SentryIntegration.shared.sendWithStacktrace(message: "Unable to get a transaction: \(error.localizedDescription)", tag: "SwiftData", severity: .error)
+            Sentry.shared.sendWithStacktrace(message: "Unable to get a transaction", tag: SentryTag.swiftData, severity: .error, description: "\(error.localizedDescription)")
 
             // Check if the error we got is recoverable (e.g. SQLITE_BUSY, SQLITE_LOCK, SQLITE_FULL).
             // If so, just return `.failure` so we can retry preparing the schema again later.
@@ -812,8 +804,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
 
         // Attempt to make a backup as long as the database file still exists.
         if files.exists(baseFilename) {
-            log.warning("Couldn't create or update schema \(self.schema.name). Attempting to move \(baseFilename) to another location.")
-            SentryIntegration.shared.sendWithStacktrace(message: "Couldn't create or update schema \(self.schema.name). Attempting to move \(baseFilename) to another location.", tag: "SwiftData", severity: .warning)
+            Sentry.shared.sendWithStacktrace(message: "Couldn't create or update schema. Attempted to move db to another location.", tag: SentryTag.swiftData, severity: .warning, description: "\(self.schema.name). Attempting to move \(baseFilename)")
             
             // Note that a backup file might already exist! We append a counter to avoid this.
             var bakCounter = 0
@@ -840,13 +831,11 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
                 
                 log.debug("Finished moving database \(baseFilename) successfully.")
             } catch let error as NSError {
-                log.error("Unable to move \(baseFilename) to another location. \(error)")
-                SentryIntegration.shared.sendWithStacktrace(message: "Unable to move \(baseFilename) to another location. \(error)", tag: "SwiftData", severity: .error)
+                Sentry.shared.sendWithStacktrace(message: "Unable to move db to another location", tag: SentryTag.swiftData, severity: .error, description: "\(baseFilename) to another location. \(error)")
             }
         } else {
             // No backup was attempted since the database file did not exist.
-            log.error("The database file \(baseFilename) has been deleted while previously in use.")
-            SentryIntegration.shared.sendWithStacktrace(message: "The database file \(baseFilename) has been deleted while previously in use.", tag: "SwiftData", severity: .info)
+            Sentry.shared.sendWithStacktrace(message: "The database file has been deleted while previously in use.", tag: SentryTag.swiftData, description: "filename \(baseFilename)")
         }
     }
     
@@ -917,9 +906,8 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         var status = sqlite3_close(db)
 
         if status != SQLITE_OK {
-            log.error("Got status \(status) while attempting to close.")
-            SentryIntegration.shared.sendWithStacktrace(message: "Got status \(status) while attempting to close.", tag: "SwiftData", severity: .error)
-            
+            Sentry.shared.sendWithStacktrace(message: "Got error status while attempting to close.", tag: SentryTag.swiftData, severity: .error, description: "error status: \(status)")
+
             if immediately {
                 return createErr("During: closing database with flags", status: Int(status))
             }
@@ -931,8 +919,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             if status != SQLITE_OK {
                 
                 // Based on the above comment regarding sqlite3_close_v2, this shouldn't happen.
-                log.error("Got status \(status) while attempting to close_v2.")
-                SentryIntegration.shared.sendWithStacktrace(message: "Got status \(status) while attempting to close_v2.", tag: "SwiftData", severity: .error)
+                Sentry.shared.sendWithStacktrace(message: "Got error status while attempting to close_v2.", tag: SentryTag.swiftData, severity: .error, description: "error status: \(status)")
                 return createErr("During: closing database with flags", status: Int(status))
             }
         }
@@ -963,13 +950,11 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             // Special case: Write additional info to the database log in the case of a database corruption.
             if error.code == Int(SQLITE_CORRUPT) {
                 writeCorruptionInfoForDBNamed(filename, toLogger: Logger.corruptLogger)
-
-                SentryIntegration.shared.sendWithStacktrace(message: "SQLITE_CORRUPT for DB \(filename), \(error)", tag: "SwiftData", severity: .error)
+                Sentry.shared.sendWithStacktrace(message: "SQLITE_CORRUPT", tag: SentryTag.swiftData, severity: .error, description: "for DB \(filename), \(error)")
             }
 
-            let message = "SQL error. Error code: \(error.code), \(error) for SQL \(String(sqlStr.characters.prefix(500)))."
-            log.error(message)
-            SentryIntegration.shared.sendWithStacktrace(message: message, tag: "SwiftData", severity: .error)
+            let message = "Error code: \(error.code), \(error) for SQL \(String(sqlStr.characters.prefix(500)))."
+            Sentry.shared.sendWithStacktrace(message: "SQL error", tag: SentryTag.swiftData, severity: .error, description: message)
 
             throw error
         }
@@ -1005,13 +990,9 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             // Special case: Write additional info to the database log in the case of a database corruption.
             if error.code == Int(SQLITE_CORRUPT) {
                 writeCorruptionInfoForDBNamed(filename, toLogger: Logger.corruptLogger)
-                
-                SentryIntegration.shared.sendWithStacktrace(message: "SQLITE_CORRUPT for DB \(filename), \(error)", tag: "SwiftData", severity: .error)
+                Sentry.shared.sendWithStacktrace(message: "SQLITE_CORRUPT", tag: SentryTag.swiftData, severity: .error, description: "DB \(filename), \(error)")
             }
-
-            let message = "SQL error. Error code: \(error.code), \(error) for SQL \(String(sqlStr.characters.prefix(500)))."
-            log.error(message)
-            SentryIntegration.shared.sendWithStacktrace(message: message, tag: "SwiftData", severity: .error)
+            Sentry.shared.sendWithStacktrace(message: "SQL error", tag: SentryTag.swiftData, severity: .error, description: "Error code: \(error.code), \(error) for SQL \(String(sqlStr.characters.prefix(500))).")
 
             return Cursor<T>(err: error)
         }
@@ -1087,8 +1068,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         do {
             try executeChange("BEGIN EXCLUSIVE")
         } catch let err as NSError {
-            log.error("BEGIN EXCLUSIVE failed. Error code: \(err.code), \(err)")
-            SentryIntegration.shared.sendWithStacktrace(message: "BEGIN EXCLUSIVE failed. Error code: \(err.code), \(err)", tag: "SwiftData", severity: .error)
+            Sentry.shared.sendWithStacktrace(message: "BEGIN EXCLUSIVE failed.", tag: SentryTag.swiftData, severity: .error, description: "\(err.code), \(err)")
             throw err
         }
 
@@ -1098,13 +1078,12 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             result = try transactionClosure(self)
         } catch let err as NSError {
             log.error("Op in transaction threw an error. Rolling back.")
-            SentryIntegration.shared.sendWithStacktrace(message: "Op in transaction threw an error. Rolling back.", tag: "SwiftData", severity: .error)
+            Sentry.shared.sendWithStacktrace(message: "Op in transaction threw an error. Rolling back.", tag: SentryTag.swiftData, severity: .error)
 
             do {
                 try executeChange("ROLLBACK")
             } catch let err as NSError {
-                log.error("ROLLBACK after errored op in transaction failed. Error code: \(err.code), \(err)")
-                SentryIntegration.shared.sendWithStacktrace(message: "ROLLBACK after errored op in transaction failed. Error code: \(err.code), \(err)", tag: "SwiftData", severity: .error)
+                Sentry.shared.sendWithStacktrace(message: "ROLLBACK after errored op in transaction failed", tag: SentryTag.swiftData, severity: .error, description: "\(err.code), \(err)")
                 throw err
             }
 
@@ -1116,14 +1095,12 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         do {
             try executeChange("COMMIT")
         } catch let err as NSError {
-            log.error("COMMIT failed. Rolling back. Error code: \(err.code), \(err)")
-            SentryIntegration.shared.sendWithStacktrace(message: "COMMIT failed. Rolling back. Error code: \(err.code), \(err)", tag: "SwiftData", severity: .error)
+            Sentry.shared.sendWithStacktrace(message: "COMMIT failed. Rolling back.", tag: SentryTag.swiftData, severity: .error, description: "\(err.code), \(err)")
 
             do {
                 try executeChange("ROLLBACK")
             } catch let err as NSError {
-                log.error("ROLLBACK after failed COMMIT failed. Error code: \(err.code), \(err)")
-                SentryIntegration.shared.sendWithStacktrace(message: "ROLLBACK after failed COMMIT failed. Error code: \(err.code), \(err)", tag: "SwiftData", severity: .error)
+                Sentry.shared.sendWithStacktrace(message: "ROLLBACK after failed COMMIT failed.", tag: SentryTag.swiftData, severity: .error, description: "\(err.code), \(err)")
                 throw err
             }
 

--- a/Sync/Synchronizers/Bookmarks/BookmarksSynchronizer.swift
+++ b/Sync/Synchronizers/Bookmarks/BookmarksSynchronizer.swift
@@ -230,8 +230,7 @@ open class BufferingBookmarksSynchronizer: TimestampedSingleCollectionSynchroniz
                         return self.uploadSomeLocalRecords(storage, mirrorer, bookmarksClient, mobileRootRecord: mobileRootRecord, childrenRecords: childrenRecords)
                     }
                 }).bind { simpleSyncingResult in
-                    if let failure = simpleSyncingResult.failureValue,
-                       AppConstants.BuildChannel != .release {
+                    if let failure = simpleSyncingResult.failureValue {
                         let description = failure is RecordTooLargeError ? "Record too large" : failure.description
                         Sentry.shared.send(message: "Failed to simple sync bookmarks", tag: SentryTag.bookmarks, severity: .error, description: description)
                     }

--- a/Sync/Synchronizers/Bookmarks/BookmarksSynchronizer.swift
+++ b/Sync/Synchronizers/Bookmarks/BookmarksSynchronizer.swift
@@ -233,7 +233,7 @@ open class BufferingBookmarksSynchronizer: TimestampedSingleCollectionSynchroniz
                     if let failure = simpleSyncingResult.failureValue,
                        AppConstants.BuildChannel != .release {
                         let description = failure is RecordTooLargeError ? "Record too large" : failure.description
-                        SentryIntegration.shared.send(message: "Failed to simple sync bookmarks: " + description, tag: "BookmarksSyncing", severity: .error)
+                        Sentry.shared.send(message: "Failed to simple sync bookmarks", tag: SentryTag.bookmarks, severity: .error, description: description)
                     }
                     return deferMaybe(result)
                 }
@@ -282,9 +282,9 @@ open class BufferingBookmarksSynchronizer: TimestampedSingleCollectionSynchroniz
         let repairer = BookmarksRepairRequestor(scratchpad: self.scratchpad, basePrefs: self.basePrefs, remoteClients: remoteClientsAndTabs)
         return repairer.startRepairs(validationInfo: error.inconsistencies).bind { result in
             if let repairFailure = result.failureValue {
-                SentryIntegration.shared.send(message: "Bookmarks repair failure: " + repairFailure.description, tag: "BookmarksRepair", severity: .error)
+                Sentry.shared.send(message: "Bookmarks repair failure", tag: SentryTag.bookmarks, severity: .error, description: repairFailure.description)
             } else {
-                SentryIntegration.shared.send(message: "Bookmarks repair succeeded", tag: "BookmarksRepair", severity: .debug)
+                Sentry.shared.send(message: "Bookmarks repair succeeded", tag: SentryTag.bookmarks, severity: .debug)
             }
             return succeed()
         }


### PR DESCRIPTION
- Rename SentryIntegration to Sentry
- Add a new SentryTag enum to prevent typos
- Add a new description field which adds a parameter errorDescription to the extra dict
- make sure the message in a sentry event is always the same. Push error info into the extra field
- remove all logging that happens alongside Sentry. Instead just log sentry events in the console
- Only log .fatal events on release. 