### PR TITLE
No Bug - New Danger rules. Making the mozillabot smarter!

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,2 +1,52 @@
-# Lint files with Swiftlint. Check .swiftlint.yml for config
+
+
+# Add a link to the Bugzilla bug
+
+# for debugging uncomment out these 2 lines
+# require 'pry'
+# binding.pry
+
+# Run swiftlint
 swiftlint.lint_files
+
+# Localized Strings check
+changedFiles = (git.added_files + git.modified_files).select{|file| file.end_with?(".swift")}
+changedFiles.select{|file| file != "Client/Frontend/Strings.swift" }.each do |changed_file|
+  addedLines = git.diff_for_file(changed_file).patch.lines.select{ |line| line.start_with?("+") }
+  if addedLines.select{ |line| line.include?("NSLocalizedString") }.count != 0
+    warn("NSLocalizedString should only be added to Strings.swift")
+    break # We only need to show the warning once
+  end
+end
+
+# Add a friendly reminder for Sentry
+changedFiles.each do |changed_file|
+  addedLines = git.diff_for_file(changed_file).patch.lines.select{ |line| line.start_with?("+") }
+  if addedLines.select{ |line| line.include?("Sentry.shared.send") }.count != 0 
+    markdown("### Sentry check list")
+    markdown("- [ ] I understand that only .fatal events will be reported on release")
+    markdown("- [ ] The message param contains a string that will not create multiple events")
+    break
+  end
+end
+
+# Add a friendly reminder for LeanPlum
+changedFiles.each do |changed_file|
+  addedLines = git.diff_for_file(changed_file).patch.lines.select{ |line| line.start_with?("+") }
+  if addedLines.select{ |line| line.include?("LeanplumIntegration.sharedInstance.track") }.count != 0 
+    markdown("### LeanPlum checklist")
+    markdown("- [ ] I have updated the MMA.md doc")
+    markdown("- [ ] I have gone through the data privacy review")
+    break
+  end
+end
+
+# Fail if diff contains !try or as!
+changedFiles.each do |changed_file|
+  # filter out only the lines that were added
+  addedLines = git.diff_for_file(changed_file).patch.lines.select{ |line| line.start_with?("+") }
+  fail("No new force try! or as!") if addedLines.select{ |line| (line.include?("as!") || line.include?("try!")) }.count != 0 
+end
+
+
+#limit the number of new lines added to BVC to less than 10

--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -1,6 +1,2 @@
 #!/usr/bin/env bash
-chruby 2.3.1
-bundle install  
-bundle exec danger --fail-on-errors=false  
-
 bash <(curl -s https://codecov.io/bash)

--- a/buddybuild_prebuild.sh
+++ b/buddybuild_prebuild.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+chruby 2.3.1
+bundle install  
+bundle exec danger --fail-on-errors=false  
+
 #
 # Add our Adjust keys to the build depending on the scheme. We use the sandbox for beta so
 # that we have some insight in beta usage.


### PR DESCRIPTION
There are a lot of decisions that need to be remembered when commiting in code. Some more important than others. Can we capture these in our DangerFile. Even if its something as simple as creating a message asking the contributor to make sure they thought about XYZ

I've added the following rules
- A checklist when adding new Sentry events
- A checklist when adding new LeanPlum events
- A warning when adding NSLocalizedStrings outside of Strings.swift
- An error when adding a new `try!` or `as!`