### PR TITLE
Bug 1411297 - Fix FxA account confirm page under navigation bar

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2495,6 +2495,7 @@ extension BrowserViewController: IntroViewControllerDelegate {
 
         let settingsNavigationController = SettingsNavigationController(rootViewController: vcToPresent)
 		settingsNavigationController.modalPresentationStyle = .formSheet
+        settingsNavigationController.navigationBar.isTranslucent = false
         self.present(settingsNavigationController, animated: true, completion: nil)
     }
 


### PR DESCRIPTION
Fixes an issue where after clicking `Sign-in` on onboarding, then creating FxA account, the confirmation page would appear under the navigation bar.

Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1411297

![simulator screen shot - iphone se - 2017-10-24 at 21 44 15](https://user-images.githubusercontent.com/1295288/31976275-7d5b0f58-b904-11e7-8c3a-2f3ab5f116f0.png)
