### PR TITLE
Bug 1411930 - Add basic History XCUITests to have the test suite

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		28F657EA1ABFCA7A00A608BD /* LiveAccountTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA4363B1ABB8448008031D1 /* LiveAccountTest.swift */; };
 		28FDFF0C1C1F725800840F86 /* SeparatorTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FDFF0B1C1F725800840F86 /* SeparatorTableCell.swift */; };
 		2C2A5EF41E68469500F02659 /* PrivateBrowsingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2A5EF31E68469500F02659 /* PrivateBrowsingTest.swift */; };
+		2C2A91291FA2410D002E36BD /* HistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2A91281FA2410D002E36BD /* HistoryTests.swift */; };
 		2C31A7A91E8BFB2200DAC646 /* ReaderViewUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C31A7A81E8BFB2200DAC646 /* ReaderViewUITest.swift */; };
 		2C31A8471E8D447F00DAC646 /* HomePageSettingsUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C31A8461E8D447F00DAC646 /* HomePageSettingsUITest.swift */; };
 		2C3406C81E719F00000FD889 /* SettingsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3406C71E719F00000FD889 /* SettingsTest.swift */; };
@@ -1400,6 +1401,7 @@
 		28F596A01ACA13CA0071DDCC /* InfoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InfoTests.swift; path = SyncTests/InfoTests.swift; sourceTree = "<group>"; };
 		28FDFF0B1C1F725800840F86 /* SeparatorTableCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeparatorTableCell.swift; sourceTree = "<group>"; };
 		2C2A5EF31E68469500F02659 /* PrivateBrowsingTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingTest.swift; sourceTree = "<group>"; };
+		2C2A91281FA2410D002E36BD /* HistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryTests.swift; sourceTree = "<group>"; };
 		2C31A7A81E8BFB2200DAC646 /* ReaderViewUITest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderViewUITest.swift; sourceTree = "<group>"; };
 		2C31A8461E8D447F00DAC646 /* HomePageSettingsUITest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomePageSettingsUITest.swift; sourceTree = "<group>"; };
 		2C3406C71E719F00000FD889 /* SettingsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsTest.swift; sourceTree = "<group>"; };
@@ -2773,6 +2775,7 @@
 				2CEA6F781E93E3A600D4100E /* SearchSettingsUITest.swift */,
 				0B9D40781E8D5AC80059E664 /* XCUITests-Bridging-Header.h */,
 				D81127D71F84023B0050841D /* PhotonActionSheetTest.swift */,
+				2C2A91281FA2410D002E36BD /* HistoryTests.swift */,
 			);
 			path = XCUITests;
 			sourceTree = "<group>";
@@ -5270,6 +5273,7 @@
 				2C2A5EF41E68469500F02659 /* PrivateBrowsingTest.swift in Sources */,
 				3D71C89E1F5703A1008D8646 /* CopiedLinksTests.swift in Sources */,
 				2CF449A51E7BFE2C00FD7595 /* NavigationTest.swift in Sources */,
+				2C2A91291FA2410D002E36BD /* HistoryTests.swift in Sources */,
 				3BF4B8E91D38497A00493393 /* BaseTestCase.swift in Sources */,
 				3D9CAA1C1EFCD655002434DD /* ClipBoardTests.swift in Sources */,
 				0B3D670E1E09B90B00C1EFC7 /* AuthenticationTest.swift in Sources */,

--- a/XCUITests/HistoryTests.swift
+++ b/XCUITests/HistoryTests.swift
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import XCTest
+
+let webpage = ["url": "www.mozilla.org", "label": "Internet for people, not profit — Mozilla", "value": "mozilla.org"]
+
+class HistoryTests: BaseTestCase {
+    var navigator: Navigator!
+    var app: XCUIApplication!
+
+    override func setUp() {
+        super.setUp()
+        app = XCUIApplication()
+        navigator = createScreenGraph(app).navigator(self)
+    }
+
+    func testEmptyHistoryListFirstTime() {
+        // Go to History List from Top Sites and check it is empty
+        navigator.goto(HomePanel_History)
+        waitforExistence(app.tables.cells["HistoryPanel.recentlyClosedCell"])
+        XCTAssertTrue(app.tables.cells["HistoryPanel.recentlyClosedCell"].exists)
+        XCTAssertTrue(app.tables.cells["HistoryPanel.syncedDevicesCell"].exists)
+        XCTAssertFalse(app.tables.otherElements.staticTexts["Today"].exists)
+    }
+
+    func testOpenHistoryFromBrowserContextMenuOptions() {
+        navigator.openURL(urlString: webpage["url"]!)
+        navigator.browserPerformAction(.openHistoryOption)
+
+        // Go to History List from Browser context menu and there should be one entry
+        waitforExistence(app.tables.cells["HistoryPanel.recentlyClosedCell"])
+        XCTAssertTrue(app.tables.otherElements.staticTexts["Today"].exists)
+        XCTAssertTrue(app.tables.cells.staticTexts[webpage["label"]!].exists)
+    }
+
+    func testOpenSyncDevices() {
+        navigator.goto(HomePanel_History)
+        app.tables.cells["HistoryPanel.syncedDevicesCell"].tap()
+        waitforExistence(app.tables.cells.staticTexts["Firefox Sync"])
+        XCTAssertTrue(app.tables/*@START_MENU_TOKEN@*/.buttons["Sign in"]/*[[".cells.buttons[\"Sign in\"]",".buttons[\"Sign in\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.exists)
+    }
+}


### PR DESCRIPTION
There are not XCUITests checking this menu, how to get there and different scenarios that may be interesting to cover.

We could start by adding the test suite and not very complex tests that do not imply swiping or going back to previous UI, just easy checks until the new FxScreenGraph lands. Then more complex tests could be added