### PR TITLE
Bug 1313317 - History list overlaps the spinner when pull to refresh …

### DIFF
--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -170,7 +170,7 @@ class HistoryPanel: SiteTableViewController, HomePanel {
         let refresh = UIRefreshControl()
         refresh.addTarget(self, action: #selector(HistoryPanel.refresh), for: UIControlEvents.valueChanged)
         self.refreshControl = refresh
-        self.tableView.addSubview(refresh)
+        self.tableView.refreshControl = refresh
     }
 
     func removeRefreshControl() {

--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -174,7 +174,7 @@ class HistoryPanel: SiteTableViewController, HomePanel {
     }
 
     func removeRefreshControl() {
-        self.refreshControl?.removeFromSuperview()
+        self.tableView.refreshControl = nil
         self.refreshControl = nil
     }
 


### PR DESCRIPTION
…then scroll down.

*  Corrected the refresh control assignment to the tableview controller.

Corrected refresh control behavior can be seen here: https://youtu.be/5wgEyUtSin8