### PR TITLE
Bug 1413338 - Intermittent tests failures in BB - part1

### DIFF
--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -195,7 +195,6 @@ class ActivityStreamTest: BaseTestCase {
         TopSiteCellgroup.cells[defaultTopSite["topSiteLabel"]!]
             .press(forDuration: 1)
         selectOptionFromContextMenu(option: "Open in New Private Tab")
-        waitUntilPageLoad()
 
         // Check that two tabs are open and one of them is the default top site one
         navigator.goto(PrivateTabTray)
@@ -301,6 +300,7 @@ class ActivityStreamTest: BaseTestCase {
 
          // Go to a website
          navigator.openURL(urlString: newTopSite["url"]!)
+         waitUntilPageLoad()
 
          // Go back to Top Sites from context menu
          navigator.browserPerformAction(.openTopSitesOption)
@@ -313,25 +313,34 @@ class ActivityStreamTest: BaseTestCase {
 
         navigator.openURL(urlString: "http://example.com")
         waitUntilPageLoad()
+        waitForValueContains(app.textFields["url"], value: "example.com")
         navigator.openURL(urlString: "http://mozilla.org")
         waitUntilPageLoad()
+        waitForValueContains(app.textFields["url"], value: "mozilla.org")
         navigator.openURL(urlString: "http://apple.com")
         waitUntilPageLoad()
-        navigator.openURL(urlString: "http://yahoo.com")
+        waitForValueContains(app.textFields["url"], value: "apple.com")
+        navigator.openURL(urlString: "http://slack.com")
         waitUntilPageLoad()
+        waitForValueContains(app.textFields["url"], value: "slack.com")
 
         if iPad() {
             // Test timeout on BB when loading these pages
             navigator.openURL(urlString: "http://cvs.com")
             waitUntilPageLoad()
-            navigator.openURL(urlString: "http://walmart.com")
+            waitForValueContains(app.textFields["url"], value: "cvs.com")
+            navigator.openURL(urlString: "http://linkedin.com")
             waitUntilPageLoad()
+            waitForValueContains(app.textFields["url"], value: "linkedin.com")
             navigator.openURL(urlString: "http://zara.com")
             waitUntilPageLoad()
+            waitForValueContains(app.textFields["url"], value: "zara.com")
             navigator.openURL(urlString: "http://twitter.com")
             waitUntilPageLoad()
+            waitForValueContains(app.textFields["url"], value: "twitter.com")
             navigator.openURL(urlString: "http://instagram.com")
             waitUntilPageLoad()
+            waitForValueContains(app.textFields["url"], value: "instagram.com")
         }
         navigator.goto(URLBarOpen)
         waitforExistence(pagecontrolButton)
@@ -350,6 +359,7 @@ class ActivityStreamTest: BaseTestCase {
         XCUIDevice.shared().orientation = .landscapeLeft
 
         navigator.openURL(urlString: "http://example.com")
+        waitUntilPageLoad()
         if app.buttons["URLBarView.backButton"].isEnabled {
             app.buttons["URLBarView.backButton"].tap()
         } else {

--- a/XCUITests/FindInPageTest.swift
+++ b/XCUITests/FindInPageTest.swift
@@ -105,6 +105,7 @@ class FindInPageTests: BaseTestCase {
         let textToFind = "from"
 
         // Long press on the word to be found
+        waitUntilPageLoad()
         waitforExistence(app.webViews.staticTexts[textToFind])
         let stringToFind = app.webViews.staticTexts.matching(identifier: textToFind)
         let firstStringToFind = stringToFind.element(boundBy: 0)

--- a/XCUITests/NavigationTest.swift
+++ b/XCUITests/NavigationTest.swift
@@ -5,7 +5,7 @@
 import XCTest
 
 let website_1 = ["url": "www.mozilla.org", "label": "Internet for people, not profit — Mozilla", "value": "mozilla.org"]
-let website_2 = ["url": "www.yahoo.com", "label": "Yahoo", "value": "yahoo"]
+let website_2 = ["url": "www.example.com", "label": "Example", "value": "example"]
 
 let urlAddOns = "addons.mozilla.org"
 
@@ -46,6 +46,7 @@ class NavigationTest: BaseTestCase {
 
         // Once an url has been open, the back button is enabled but not the forward button
         navigator.openURL(urlString: website_1["url"]!)
+        waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: website_1["value"]!)
         if iPad() {
             XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
@@ -57,6 +58,7 @@ class NavigationTest: BaseTestCase {
 
         // Once a second url is open, back button is enabled but not the forward one till we go back to url_1
         navigator.openURL(urlString:  website_2["url"]!)
+        waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: website_2["value"]!)
         if iPad() {
             XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
@@ -69,7 +71,7 @@ class NavigationTest: BaseTestCase {
             // Go back to previous visited web site
             app.buttons["TabToolbar.backButton"].tap()
         }
-
+        waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: website_1["value"]!)
 
         if iPad() {
@@ -78,6 +80,7 @@ class NavigationTest: BaseTestCase {
             // Go forward to next visited web site
             app.buttons["TabToolbar.forwardButton"].tap()
         }
+        waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: website_2["value"]!)
     }
 
@@ -172,21 +175,25 @@ class NavigationTest: BaseTestCase {
         let goToDesktopFromMobile = app.webViews.links.staticTexts["View classic desktop site"]
         // Open URL by default in mobile view
         navigator.openURL(urlString: urlAddOns)
+        waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: urlAddOns)
         waitforExistence(goToDesktopFromMobile)
 
         // From the website go to Desktop view
         goToDesktopFromMobile.tap()
+        waitUntilPageLoad()
         checkDesktopView()
 
         // From the website go back to Mobile view
         app.webViews.links.staticTexts["View Mobile Site"].tap()
+        waitUntilPageLoad()
         checkMobileView()
     }
 
     func testToggleBetweenMobileAndDesktopSiteFromMenu() {
         clearData()
         navigator.openURL(urlString: urlAddOns)
+        waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: urlAddOns)
         
         // Mobile view by default, desktop view should be available
@@ -218,17 +225,20 @@ class NavigationTest: BaseTestCase {
 
         // Mobile view by default, desktop view should be available
         navigator.browserPerformAction(.toggleDesktopOption)
+        waitforNoExistence(app.tables["Context Menu"])
         checkDesktopView()
 
         // Select any link to navigate to another site and check if the view is kept in desktop view
         waitforExistence(app.webViews.links["Featured ›"])
         app.webViews.links["Featured ›"].tap()
+        waitUntilPageLoad()
         checkDesktopView()
     }
 
     func testReloadPreservesMobileOrDesktopSite() {
         clearData()
         navigator.openURL(urlString: urlAddOns)
+        waitUntilPageLoad()
 
         // Mobile view by default, desktop view should be available
         navigator.browserPerformAction(.toggleDesktopOption)
@@ -245,8 +255,8 @@ class NavigationTest: BaseTestCase {
         // From desktop view it is posible to change to mobile view again
         navigator.nowAt(BrowserTab)
         navigator.browserPerformAction(.toggleDesktopOption)
-        waitForValueContains(app.textFields["url"], value: urlAddOns)
         waitUntilPageLoad()
+        waitForValueContains(app.textFields["url"], value: urlAddOns)
 
         // After reloading a website the mobile view should be kept
         if iPad() {

--- a/XCUITests/PhotonActionSheetTest.swift
+++ b/XCUITests/PhotonActionSheetTest.swift
@@ -15,7 +15,7 @@ class PhotonActionSheetTest: BaseTestCase {
     }
 
     func testPinToTop() {
-        navigator.openURL(urlString: "http://www.yahoo.com")
+        navigator.openURL(urlString: "http://example.com")
         waitUntilPageLoad()
         // Open Action Sheet
         app.buttons["TabLocationView.pageOptionsButton"].tap()
@@ -35,11 +35,11 @@ class PhotonActionSheetTest: BaseTestCase {
 
         // Verify that the site is pinned to top
         let cell = app.cells["TopSite"].firstMatch
-        XCTAssertEqual(cell.label, "yahoo")
+        XCTAssertEqual(cell.label, "example")
 
         // Remove pin
         cell.press(forDuration: 2)
-        app.cells["Remove Pinned Site"].tap()
+        app.cells["Remove"].tap()
     }
 
     func testShareOptionIsShown() {
@@ -72,8 +72,8 @@ class PhotonActionSheetTest: BaseTestCase {
         app.collectionViews.cells/*@START_MENU_TOKEN@*/.collectionViews.containing(.button, identifier:"Copy")/*[[".collectionViews.containing(.button, identifier:\"Create PDF\")",".collectionViews.containing(.button, identifier:\"Print\")",".collectionViews.containing(.button, identifier:\"Copy\")"],[[[-1,2],[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.buttons["More"].tap()
 
         // Enable Send Tab
-        waitforExistence(app.tables.children(matching: .cell).matching(identifier: "0").element(boundBy: 0).switches["Send Tab"])
-        app.tables.children(matching: .cell).matching(identifier: "0").element(boundBy: 0).switches["Send Tab"].tap()
+        let sendTabButton = app.tables.cells.switches["Send Tab"]
+        sendTabButton.tap()
         app.navigationBars["Activities"].buttons["Done"].tap()
 
         // Send Tab option appears on the Share options sheet

--- a/XCUITests/SettingsTest.swift
+++ b/XCUITests/SettingsTest.swift
@@ -29,6 +29,7 @@ class SettingsTest: BaseTestCase {
         XCTAssertTrue(helpMenu.isEnabled)
         helpMenu.tap()
 
+        waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: "support.mozilla.org")
         waitforExistence(app.webViews.staticTexts["Firefox for iOS"])
         XCTAssertTrue(app.webViews.staticTexts["Firefox for iOS"].exists)

--- a/XCUITests/ToolbarTest.swift
+++ b/XCUITests/ToolbarTest.swift
@@ -46,8 +46,8 @@ class ToolbarTests: BaseTestCase {
         XCTAssertTrue(app.buttons["Reload"].isEnabled)
 
         navigator.openURL(urlString: website2)
-        waitForValueContains(app.textFields["url"], value: website2)
         waitUntilPageLoad()
+        waitForValueContains(app.textFields["url"], value: website2)
         XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
         XCTAssertFalse(app.buttons["Forward"].isEnabled)
 

--- a/XCUITests/TopTabsTest.swift
+++ b/XCUITests/TopTabsTest.swift
@@ -41,6 +41,7 @@ class TopTabsTest: BaseTestCase {
     func testAddTabFromTabTray() {
         navigator.goto(TabTray)
         navigator.openURL(urlString: url)
+        waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: urlValue)
         // The tabs counter shows the correct number
         let tabsOpen = app.buttons["Show Tabs"].value


### PR DESCRIPTION
Trying a fix for these tests:
- testHelpOpensSUMOInTab
- testReloadPreservesMobileOrDesktopSite
- testNavigation
- testActivityStreamPages
- testLandscapeNavigationWithTabSwitch