### PR TITLE
Bug 1397887 - Fix 1Password support.

### DIFF
--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -14,7 +14,6 @@ class ShareExtensionHelper: NSObject {
     fileprivate let selectedURL: URL
     fileprivate var onePasswordExtensionItem: NSExtensionItem!
     // Wechat share extension doesn't like our default data ID which is a modified to support password managers.
-    fileprivate let customDataTypeIdentifers = ["com.tencent.xin.sharetimeline"]
     fileprivate let browserFillIdentifier = "org.appextension.fill-browser-action"
 
     init(url: URL, tab: Tab?) {
@@ -54,7 +53,6 @@ class ShareExtensionHelper: NSObject {
         // activityViewController(activityViewController:, activityType:) is called,
         // which is after the user taps the button. So a million cycles away.
         findLoginExtensionItem()
-
 
         activityViewController.completionWithItemsHandler = { activityType, completed, returnedItems, activityError in
             if !completed {

--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -15,6 +15,7 @@ class ShareExtensionHelper: NSObject {
     fileprivate var onePasswordExtensionItem: NSExtensionItem!
     // Wechat share extension doesn't like our default data ID which is a modified to support password managers.
     fileprivate let customDataTypeIdentifers = ["com.tencent.xin.sharetimeline"]
+    fileprivate let browserFillIdentifier = "org.appextension.fill-browser-action"
 
     init(url: URL, tab: Tab?) {
         self.selectedURL = tab?.canonicalURL?.displayURL ?? url
@@ -52,9 +53,8 @@ class ShareExtensionHelper: NSObject {
         // This needs to be ready by the time the share menu has been displayed and
         // activityViewController(activityViewController:, activityType:) is called,
         // which is after the user taps the button. So a million cycles away.
-        if ShareExtensionHelper.isPasswordManagerExtensionAvailable() {
-            findLoginExtensionItem()
-        }
+        findLoginExtensionItem()
+
 
         activityViewController.completionWithItemsHandler = { activityType, completed, returnedItems, activityError in
             if !completed {
@@ -99,19 +99,16 @@ extension ShareExtensionHelper: UIActivityItemSource {
     }
 
     func activityViewController(_ activityViewController: UIActivityViewController, dataTypeIdentifierForActivityType activityType: UIActivityType?) -> String {
-        return "public.url"
+        if let type = activityType, isPasswordManagerActivityType(type.rawValue) {
+            return browserFillIdentifier
+        }
+        return activityType == nil ? browserFillIdentifier : kUTTypeURL as String
     }
 }
 
 private extension ShareExtensionHelper {
-    static func isPasswordManagerExtensionAvailable() -> Bool {
-        return OnePasswordExtension.shared().isAppExtensionAvailable()
-    }
 
     func isPasswordManagerActivityType(_ activityType: String?) -> Bool {
-        if !ShareExtensionHelper.isPasswordManagerExtensionAvailable() {
-            return false
-        }
         // A 'password' substring covers the most cases, such as pwsafe and 1Password.
         // com.agilebits.onepassword-ios.extension
         // com.app77.ios.pwsafe2.find-login-action-password-actionExtension

--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -13,7 +13,6 @@ class ShareExtensionHelper: NSObject {
 
     fileprivate let selectedURL: URL
     fileprivate var onePasswordExtensionItem: NSExtensionItem!
-    // Wechat share extension doesn't like our default data ID which is a modified to support password managers.
     fileprivate let browserFillIdentifier = "org.appextension.fill-browser-action"
 
     init(url: URL, tab: Tab?) {


### PR DESCRIPTION
I just removed the `isPasswordManagerExtensionAvailable` check we had. Pretty sure this had nothing do with it though. I just dont think we need it. 

The key is to return `org.appextension.fill-browser-action` at the right time. You still need to return public.url to things like notes/messages in order for them to work. (thats probably what changed in iOS11) 