### PR TITLE
Bug 1413616 - Reuse SendTab string to land feature in v10

### DIFF
--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -19,7 +19,6 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
 
     fileprivate static let PreviewActionAddToBookmarks = NSLocalizedString("Add to Bookmarks", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to add current tab to Bookmarks")
     fileprivate static let PreviewActionAddToReadingList = NSLocalizedString("Add to Reading List", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to add current tab to Reading List")
-    fileprivate static let PreviewActionSendToDevice = NSLocalizedString("Send to Device", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to send the current tab to another device")
     fileprivate static let PreviewActionCopyURL = NSLocalizedString("Copy URL", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to copy the URL of the current tab to clipboard")
     fileprivate static let PreviewActionCloseTab = NSLocalizedString("Close Tab", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to close the current tab")
 
@@ -55,7 +54,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
                     })
             }
             if self.hasRemoteClients {
-                actions.append(UIPreviewAction(title: TabPeekViewController.PreviewActionSendToDevice, style: .default) { previewAction, viewController in
+                actions.append(UIPreviewAction(title: Strings.SendToDeviceTitle, style: .default) { previewAction, viewController in
                     guard let clientPicker = self.clientPicker else { return }
                     self.delegate?.tabPeekRequestsPresentationOf(clientPicker)
                     })

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -412,7 +412,7 @@ extension Strings {
     public static let AppMenuAddBookmarkConfirmMessage = NSLocalizedString("Menu.AddBookmark.Confirm", value: "Bookmark Added", comment: "Toast displayed to the user after a bookmark has been added.")
     public static let AppMenuRemoveBookmarkConfirmMessage = NSLocalizedString("Menu.RemoveBookmark.Confirm", value: "Bookmark Removed", comment: "Toast displayed to the user after a bookmark has been removed.")
     public static let AppMenuAddToReadingListConfirmMessage = NSLocalizedString("Menu.AddToReadingList.Confirm", value: "Added To Reading List", comment: "Toast displayed to the user after adding the item to their reading list.")
-    public static let AppMenuSendToDeviceTitleString = NSLocalizedString("Menu.SendToDeviceAction.Title", value: "Send to Device", comment: "Label for the button, displayed in the menu, used to open the Send to Device flow.")
+    public static let SendToDeviceTitle = NSLocalizedString("Send to Device", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to send the current tab to another device")
 }
 
 // Snackbar shown when tapping app store link

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -177,7 +177,7 @@ extension PhotonActionSheetProtocol {
             }
         }
 
-        let sendToDevice = PhotonActionSheetItem(title: Strings.AppMenuSendToDeviceTitleString, iconString: "menu-Send-to-Device") { action in
+        let sendToDevice = PhotonActionSheetItem(title: Strings.SendToDeviceTitle, iconString: "menu-Send-to-Device") { action in
             guard let bvc = presentableVC as? PresentableVC & InstructionsViewControllerDelegate & ClientPickerViewControllerDelegate else { return }
             if !self.profile.hasAccount() {
                 let instructionsViewController = InstructionsViewController()
@@ -216,12 +216,7 @@ extension PhotonActionSheetProtocol {
             }
         }
 
-        var middleActions = [copyURL, findInPageAction, toggleDesktopSite, pinToTopSites]
-        if AppConstants.MOZ_SENDTAB_IN_PAGE_ACTIONS {
-            middleActions.append(sendToDevice)
-        }
-        
-        return [topActions, middleActions, [share]]
+        return [topActions, [copyURL, findInPageAction, toggleDesktopSite, pinToTopSites, sendToDevice], [share]]
     }
 }
 

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -196,19 +196,6 @@ public struct AppConstants {
         #endif
     }()
 
-    /// Toggle the feature that adds 'Send to Device' to the page actions menu
-    public static let MOZ_SENDTAB_IN_PAGE_ACTIONS: Bool = {
-        #if MOZ_CHANNEL_RELEASE
-            return true
-        #elseif MOZ_CHANNEL_BETA
-            return true
-        #elseif MOZ_CHANNEL_FENNEC
-            return true
-        #else
-            return true
-        #endif
-    }()
-
     /// The maximum length of a URL stored by Firefox. Shared with Places on desktop.
     public static let DB_URL_LENGTH_MAX = 65536
 


### PR DESCRIPTION
We can reuse the string "Send to Device" from the 3D Touch actions menu in the Page Actions menu. 

I removed the feature flag because the only reason we added the flag was because of the string.