### PR TITLE
 Bug 1413638 - Check both the footer and header height when setting the toolbar state

### DIFF
--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -190,7 +190,7 @@ private extension TabScrollingController {
                     scrollWithDelta(delta)
                 }
 
-                if headerTopOffset == -topScrollHeight {
+                if headerTopOffset == -topScrollHeight && footerBottomOffset == bottomScrollHeight {
                     toolbarState = .collapsed
                 } else if headerTopOffset == 0 {
                     toolbarState = .visible


### PR DESCRIPTION
Before, the header/footer was the same height so checking one was enough. But now with safe area insets at the bottom of the page we need to check both.