### PR TITLE
Bug 1413896 — Hide URLs displayed in a notification from iOS' data detectors.

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -861,7 +861,7 @@ class AppSyncDelegate: SyncDelegate {
                         title = Strings.SentTab_TabArrivingNotification_NoDevice_title
                     }
                     notification.alertTitle = title
-                    notification.alertBody = url.absoluteDisplayString
+                    notification.alertBody = url.absoluteDisplayExternalString
                     notification.userInfo = [TabSendURLKey: url.absoluteString, TabSendTitleKey: title]
                     notification.alertAction = nil
 

--- a/Extensions/NotificationService/NotificationService.swift
+++ b/Extensions/NotificationService/NotificationService.swift
@@ -165,7 +165,7 @@ extension SyncDataDisplay {
             return [
                 "title": t.title,
                 "url": t.url.absoluteString,
-                "displayURL": t.url.absoluteDisplayString,
+                "displayURL": t.url.absoluteDisplayExternalString,
                 "deviceName": t.deviceName as Any,
                 ] as NSDictionary
         }

--- a/Shared/Extensions/NSURLExtensions.swift
+++ b/Shared/Extensions/NSURLExtensions.swift
@@ -182,6 +182,12 @@ extension URL {
         }
     }
 
+    /// String suitable for displaying outside of the app, for example in notifications, were Data Detectors will
+    /// linkify the text and make it into a openable-in-Safari link.
+    public var absoluteDisplayExternalString: String {
+        return self.absoluteDisplayString.replacingOccurrences(of: ".", with: "\u{2024}")
+    }
+
     public var displayURL: URL? {
         if self.isReaderModeURL {
             return self.decodeReaderModeURL?.havingRemovedAuthorisationComponents()

--- a/SharedTests/NSURLExtensionsTests.swift
+++ b/SharedTests/NSURLExtensionsTests.swift
@@ -467,4 +467,31 @@ class NSURLExtensionsTests: XCTestCase {
         XCTAssertEqual("http://foo.com/bar/?ppp=123&rrr=aaa", urlE.absoluteString)
     }
 
+    func testHidingFromDataDetectors() {
+        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
+            XCTFail()
+            return
+        }
+
+        let urls = ["https://example.com", "example.com", "http://example.com"]
+        for u in urls {
+            let url = URL(string: u)!
+
+            let original = url.absoluteDisplayString
+            let matches = detector.matches(in: original, options: [], range: NSMakeRange(0, original.count))
+            guard matches.count > 0 else {
+                print("\(url) doesn't match as a URL")
+                continue
+            }
+
+            let modified = url.absoluteDisplayExternalString
+            XCTAssertNotEqual(original, modified)
+            
+            let newMatches = detector.matches(in: modified, options: [], range: NSMakeRange(0, modified.count))
+
+            XCTAssertEqual(0, newMatches.count, "\(modified) is not a valid URL")
+        }
+
+    }
+
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1413896