### PR TITLE
Bug 1414232 — Make leanplum respect the user settings to disable sendUsageData.

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -169,7 +169,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
 
         let leanplum = LeanplumIntegration.sharedInstance
         leanplum.setup(profile: profile)
-        leanplum.setEnabled(true)
+
+        // We don't want to call LeanPlum if we really don't have to,
+        // so wrap it in a conditional.
+        if sendUsageData && !AppConstants.IsRunningTest {
+            leanplum.setEnabled(true)
+        }
 
         self.updateAuthenticationInfo()
         SystemUtils.onFirstRun()


### PR DESCRIPTION
This PR differentially enables LeanPlum at app start up. 

Two things to note: 

1. We really don't trust the `LeanPlumIntegration` logic of enabling the LeanPlum SDK, so let's not call `setEnabled(_ flag: Bool)` if we don't have to.
2. We disable LeanPlum for testing purposes, fixing [Bug 1414199][1] — this is the bug that caused this bug to be discovered, and it's the same line of code, so doing this here makes sense.

[1]: https://bugzilla.mozilla.org/show_bug.cgi?id=1414199

https://bugzilla.mozilla.org/show_bug.cgi?id=1414232