### PR TITLE
Bug 1414251 - Do not call didRemoveAllTabs when wiping private tabs on exit

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -448,7 +448,6 @@ class TabManager: NSObject {
     /// Removes all private tabs from the manager without notifying delegates.
     private func removeAllPrivateTabs() {
         tabs = tabs.filter { !$0.isPrivate }
-        delegates.forEach { $0.get()?.tabManagerDidRemoveAllTabs(self, toast: nil) }
     }
 
     func removeTabsWithUndoToast(_ tabs: [Tab]) {


### PR DESCRIPTION
The bug says this only happens on 10.3 but this also causes full reloads of the toptabs on iOS11

`removeAllPrivateTabs` is called from `selectTab()` if the delete private tabs on exit is selected. That means we end up refreshing the entire tabstray everytime we change the selectedtab. 

`didRemoveAllTabs` is used by delegate methods to show UI to restore tabs. In this case dont think we need to so we are okay just removing it completely. 