### PR TITLE
Bug 1414831: iPad tabs separator line misaligned

### DIFF
--- a/Client/Frontend/Browser/TopTabsViews.swift
+++ b/Client/Frontend/Browser/TopTabsViews.swift
@@ -31,19 +31,9 @@ class TopTabsHeaderFooter: UICollectionReusableView {
 
     func arrangeLine(_ kind: String) {
         line.snp.removeConstraints()
-        switch kind {
-            case UICollectionElementKindSectionHeader:
-                line.snp.makeConstraints { make in
-                    make.trailing.equalTo(self)
-                }
-            case UICollectionElementKindSectionFooter:
-                line.snp.makeConstraints { make in
-                    make.leading.equalTo(self)
-                }
-            default:
-                break
-        }
+
         line.snp.makeConstraints { make in
+            make.centerX.equalTo(self)
             make.height.equalTo(TopTabsUX.SeparatorHeight)
             make.width.equalTo(TopTabsUX.SeparatorWidth)
             make.top.equalTo(self).offset(TopTabsUX.SeparatorYOffset)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1414831

Fix looks like this:
<img width="571" alt="screen shot 2017-11-06 at 10 12 21 am" src="https://user-images.githubusercontent.com/5495083/32447931-7ff9c05c-c2db-11e7-9c4a-503c734ae388.png">
