### PR TITLE
Bug 1414831 - Make sure header in toptabs appears underneath the selected tab

### DIFF
--- a/Client/Frontend/Browser/TopTabsViews.swift
+++ b/Client/Frontend/Browser/TopTabsViews.swift
@@ -208,6 +208,10 @@ class TopTabCell: UICollectionViewCell {
         self.layer.shadowPath = UIBezierPath(roundedRect: CGRect(x: 0, y: 0, width: self.frame.size.width + (TopTabCell.ShadowOffsetSize * 2), height: self.frame.size.height), cornerRadius: 0).cgPath
         self.layer.shadowOffset = CGSize(width: -TopTabCell.ShadowOffsetSize, height: 0)
     }
+
+    override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
+        layer.zPosition = CGFloat(layoutAttributes.zIndex)
+    }
 }
 
 class TopTabFader: UIView {

--- a/Client/Frontend/Browser/TopTabsViews.swift
+++ b/Client/Frontend/Browser/TopTabsViews.swift
@@ -50,6 +50,10 @@ class TopTabsHeaderFooter: UICollectionReusableView {
         }
     }
 
+    override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
+        layer.zPosition = CGFloat(layoutAttributes.zIndex)
+    }
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }


### PR DESCRIPTION
The separator is needed because when the tab isn't selected we'd like to show a separator. 

I had setup the zIndex correctly but I guess it just wasnt being applied 🤷‍♂️ 