### PR TITLE
Bug 1393301 - UIColor cleanup. Move all colors into UIConstants

### DIFF
--- a/Client/Extensions/NSAttributedStringExtensions.swift
+++ b/Client/Extensions/NSAttributedStringExtensions.swift
@@ -7,7 +7,7 @@ import Foundation
 // MARK: - Common UITableView text styling
 extension NSAttributedString {
     static func tableRowTitle(_ string: String, enabled: Bool) -> NSAttributedString {
-        let color = enabled ? [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor] : [NSForegroundColorAttributeName: UIConstants.TableViewDisabledRowTextColor]
+        let color = enabled ? [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor] : [NSForegroundColorAttributeName: SettingsUX.TableViewDisabledRowTextColor]
         return NSAttributedString(string: string, attributes: color)
     }
 }

--- a/Client/Frontend/AuthenticationManager/BasePasscodeViewController.swift
+++ b/Client/Frontend/AuthenticationManager/BasePasscodeViewController.swift
@@ -25,7 +25,7 @@ class BasePasscodeViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = UIConstants.TableViewHeaderBackgroundColor
+        view.backgroundColor = SettingsUX.TableViewHeaderBackgroundColor
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(self.dismissAnimated))
         automaticallyAdjustsScrollViewInsets = false
     }

--- a/Client/Frontend/AuthenticationManager/PasscodeViews.swift
+++ b/Client/Frontend/AuthenticationManager/PasscodeViews.swift
@@ -142,7 +142,7 @@ class PasscodePane: UIView {
     init(title: String? = nil, passcodeSize: Int = 4) {
         codeInputView = PasscodeInputView(passcodeSize: passcodeSize)
         super.init(frame: CGRect.zero)
-        backgroundColor = UIConstants.TableViewHeaderBackgroundColor
+        backgroundColor = SettingsUX.TableViewHeaderBackgroundColor
 
         titleLabel.text = title
         centerContainer.addSubview(titleLabel)

--- a/Client/Frontend/AuthenticationManager/RequirePasscodeIntervalViewController.swift
+++ b/Client/Frontend/AuthenticationManager/RequirePasscodeIntervalViewController.swift
@@ -35,9 +35,9 @@ class RequirePasscodeIntervalViewController: UITableViewController {
         tableView.accessibilityIdentifier = "AuthenticationManager.passcodeIntervalTableView"
 
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: BasicCheckmarkCell)
-        tableView.backgroundColor = UIConstants.TableViewHeaderBackgroundColor
+        tableView.backgroundColor = SettingsUX.TableViewHeaderBackgroundColor
 
-        let headerFooterFrame = CGRect(origin: CGPoint.zero, size: CGSize(width: self.view.frame.width, height: UIConstants.TableViewHeaderFooterHeight))
+        let headerFooterFrame = CGRect(origin: CGPoint.zero, size: CGSize(width: self.view.frame.width, height: SettingsUX.TableViewHeaderFooterHeight))
         let headerView = SettingsTableSectionHeaderFooterView(frame: headerFooterFrame)
         headerView.showTopBorder = false
         headerView.showBottomBorder = true

--- a/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -8,9 +8,9 @@ import WebKit
 import Storage
 import SnapKit
 
-struct BackForwardViewUX {
+private struct BackForwardViewUX {
     static let RowHeight: CGFloat = 50
-    static let BackgroundColor = UIColor(rgb: 0xf9f9fa).withAlphaComponent(0.4)
+    static let BackgroundColor = UIColor.Defaults.Grey10.withAlphaComponent(0.4)
 }
 
 class BackForwardListViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, UIGestureRecognizerDelegate {

--- a/Client/Frontend/Browser/BackForwardTableViewCell.swift
+++ b/Client/Frontend/Browser/BackForwardTableViewCell.swift
@@ -7,7 +7,7 @@ import Storage
 
 class BackForwardTableViewCell: UITableViewCell {
     
-    struct BackForwardViewCellUX {
+    private struct BackForwardViewCellUX {
         static let bgColor = UIColor.gray
         static let faviconWidth = 29
         static let faviconPadding: CGFloat = 20
@@ -16,6 +16,7 @@ class BackForwardTableViewCell: UITableViewCell {
         static let borderBold = 5
         static let IconSize = 23
         static let fontSize: CGFloat = 12.0
+        static let textColor = UIColor.Defaults.Grey80
     }
     
     lazy var faviconView: UIImageView = {
@@ -33,7 +34,7 @@ class BackForwardTableViewCell: UITableViewCell {
         let label = UILabel()
         label.text = " "
         label.font = label.font.withSize(BackForwardViewCellUX.fontSize)
-        label.textColor = UIColor(rgb: 0x272727)
+        label.textColor = BackForwardViewCellUX.textColor
         return label
     }()
 

--- a/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/Client/Frontend/Browser/BrowserPrompts.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import WebKit
+import Shared
 
 @objc protocol JSPromptAlertControllerDelegate: class {
     func promptAlertControllerDidDismiss(_ alertController: JSPromptAlertController)
@@ -45,7 +46,7 @@ struct MessageAlert: JSAlertInfo {
         let alertController = JSPromptAlertController(title: titleForJavaScriptPanelInitiatedByFrame(frame),
             message: message,
             preferredStyle: UIAlertControllerStyle.alert)
-        alertController.addAction(UIAlertAction(title: UIConstants.OKString, style: UIAlertActionStyle.default) { _ in
+        alertController.addAction(UIAlertAction(title: Strings.OKString, style: UIAlertActionStyle.default) { _ in
             self.completionHandler()
         })
         alertController.alertInfo = self
@@ -71,10 +72,10 @@ struct ConfirmPanelAlert: JSAlertInfo {
     func alertController() -> JSPromptAlertController {
         // Show JavaScript confirm dialogs.
         let alertController = JSPromptAlertController(title: titleForJavaScriptPanelInitiatedByFrame(frame), message: message, preferredStyle: UIAlertControllerStyle.alert)
-        alertController.addAction(UIAlertAction(title: UIConstants.OKString, style: UIAlertActionStyle.default) { _ in
+        alertController.addAction(UIAlertAction(title: Strings.OKString, style: UIAlertActionStyle.default) { _ in
             self.completionHandler(true)
         })
-        alertController.addAction(UIAlertAction(title: UIConstants.CancelString, style: UIAlertActionStyle.cancel) { _ in
+        alertController.addAction(UIAlertAction(title: Strings.CancelString, style: UIAlertActionStyle.cancel) { _ in
             self.cancel()
         })
         alertController.alertInfo = self
@@ -108,10 +109,10 @@ struct TextInputAlert: JSAlertInfo {
             input = textField
             input.text = self.defaultText
         })
-        alertController.addAction(UIAlertAction(title: UIConstants.OKString, style: UIAlertActionStyle.default) { _ in
+        alertController.addAction(UIAlertAction(title: Strings.OKString, style: UIAlertActionStyle.default) { _ in
             self.completionHandler(input.text)
         })
-        alertController.addAction(UIAlertAction(title: UIConstants.CancelString, style: UIAlertActionStyle.cancel) { _ in
+        alertController.addAction(UIAlertAction(title: Strings.CancelString, style: UIAlertActionStyle.cancel) { _ in
             self.cancel()
         })
         alertController.alertInfo = self

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -201,7 +201,7 @@ class BrowserViewController: UIViewController {
             toolbar = TabToolbar()
             footer.addSubview(toolbar!)
             toolbar?.tabToolbarDelegate = self
-            let theme = (tabManager.selectedTab?.isPrivate ?? false) ? Theme.PrivateMode : Theme.NormalMode
+            let theme = (tabManager.selectedTab?.isPrivate ?? false) ? Theme.Private : Theme.Normal
             toolbar?.applyTheme(theme)
             updateTabCountUsingTabManager(self.tabManager)
         }
@@ -258,7 +258,7 @@ class BrowserViewController: UIViewController {
         coordinator.animate(alongsideTransition: { context in
             self.scrollController.showToolbars(animated: false)
             if self.isViewLoaded {
-                self.statusBarOverlay.backgroundColor = self.shouldShowTopTabsForTraitCollection(self.traitCollection) ? UIColor(rgb: 0x272727) : self.urlBar.backgroundColor
+                self.statusBarOverlay.backgroundColor = self.shouldShowTopTabsForTraitCollection(self.traitCollection) ? UIColor.Defaults.Grey80 : self.urlBar.backgroundColor
                 self.setNeedsStatusBarAppearanceUpdate()
             }
             }, completion: nil)
@@ -702,7 +702,7 @@ class BrowserViewController: UIViewController {
             return
         }
         let isPrivate = tabManager.selectedTab?.isPrivate ?? false
-        homePanelController.applyTheme(isPrivate ? Theme.PrivateMode : Theme.NormalMode)
+        homePanelController.applyTheme(isPrivate ? Theme.Private : Theme.Normal)
         let panelNumber = tabManager.selectedTab?.url?.fragment
 
         // splitting this out to see if we can get better crash reports when this has a problem
@@ -1895,7 +1895,7 @@ extension BrowserViewController: TabManagerDelegate {
         if let tab = selected, let webView = tab.webView {
             updateURLBarDisplayURL(tab)
             if tab.isPrivate != previous?.isPrivate {
-                applyTheme(tab.isPrivate ? Theme.PrivateMode : Theme.NormalMode)
+                applyTheme(tab.isPrivate ? Theme.Private : Theme.Normal)
             }
             if tab.isPrivate {
                 readerModeCache = MemoryReaderModeCache.sharedInstance
@@ -2245,9 +2245,9 @@ extension BrowserViewController {
     func updateReaderModeBar() {
         if let readerModeBar = readerModeBar {
             if let tab = self.tabManager.selectedTab, tab.isPrivate {
-                readerModeBar.applyTheme(Theme.PrivateMode)
+                readerModeBar.applyTheme(.Private)
             } else {
-                readerModeBar.applyTheme(Theme.NormalMode)
+                readerModeBar.applyTheme(.Normal)
             }
             if let url = self.tabManager.selectedTab?.url?.displayURL?.absoluteString, let result = profile.readingList?.getRecordWithURL(url) {
                 if let successValue = result.successValue, let record = successValue {
@@ -2596,7 +2596,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                     }
                 } else {
                     let accessDenied = UIAlertController(title: NSLocalizedString("Firefox would like to access your Photos", comment: "See http://mzl.la/1G7uHo7"), message: NSLocalizedString("This allows you to save the image to your Camera Roll.", comment: "See http://mzl.la/1G7uHo7"), preferredStyle: UIAlertControllerStyle.alert)
-                    let dismissAction = UIAlertAction(title: UIConstants.CancelString, style: UIAlertActionStyle.default, handler: nil)
+                    let dismissAction = UIAlertAction(title: Strings.CancelString, style: UIAlertActionStyle.default, handler: nil)
                     accessDenied.addAction(dismissAction)
                     let settingsAction = UIAlertAction(title: NSLocalizedString("Open Settings", comment: "See http://mzl.la/1G7uHo7"), style: UIAlertActionStyle.default ) { (action: UIAlertAction!) -> Void in
                         UIApplication.shared.open(URL(string: UIApplicationOpenSettingsURLString)!, options: [:])
@@ -2649,7 +2649,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
         }
 
         actionSheetController.title = dialogTitle?.ellipsize(maxLength: ActionSheetTitleMaxLength)
-        let cancelAction = UIAlertAction(title: UIConstants.CancelString, style: UIAlertActionStyle.cancel, handler: nil)
+        let cancelAction = UIAlertAction(title: Strings.CancelString, style: UIAlertActionStyle.cancel, handler: nil)
         actionSheetController.addAction(cancelAction)
         self.present(actionSheetController, animated: true, completion: nil)
     }
@@ -2877,17 +2877,15 @@ extension BrowserViewController: TabTrayDelegate {
 // MARK: Browser Chrome Theming
 extension BrowserViewController: Themeable {
 
-    func applyTheme(_ themeName: String) {
+    func applyTheme(_ theme: Theme) {
         let ui: [Themeable?] = [urlBar, toolbar, readerModeBar, topTabsViewController]
-        ui.forEach { $0?.applyTheme(themeName) }
-        statusBarOverlay.backgroundColor = shouldShowTopTabsForTraitCollection(traitCollection) ? UIColor(rgb: 0x272727) : urlBar.backgroundColor
+        ui.forEach { $0?.applyTheme(theme) }
+        statusBarOverlay.backgroundColor = shouldShowTopTabsForTraitCollection(traitCollection) ? UIColor.Defaults.Grey80 : urlBar.backgroundColor
         setNeedsStatusBarAppearanceUpdate()
     }
 }
 
-protocol Themeable {
-    func applyTheme(_ themeName: String)
-}
+
 
 extension BrowserViewController: FindInPageBarDelegate, FindInPageHelperDelegate {
     func findInPage(_ findInPage: FindInPageBar, didTextChange text: String) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -146,7 +146,7 @@ extension BrowserViewController: WKNavigationDelegate {
             UIApplication.shared.open(url, options: [:]) { openedURL in
                 if !openedURL {
                     let alert = UIAlertController(title: Strings.UnableToOpenURLErrorTitle, message: Strings.UnableToOpenURLError, preferredStyle: .alert)
-                    alert.addAction(UIAlertAction(title: UIConstants.OKString, style: UIAlertActionStyle.default, handler: nil))
+                    alert.addAction(UIAlertAction(title: Strings.OKString, style: UIAlertActionStyle.default, handler: nil))
                     self.present(alert, animated: true, completion: nil)
                 }
             }

--- a/Client/Frontend/Browser/OpenInHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper.swift
@@ -16,7 +16,7 @@ private let log = Logger.browserLogger
 struct OpenInViewUX {
     static let ViewHeight: CGFloat = 40.0
     static let TextFont = UIFont.systemFont(ofSize: 16)
-    static let TextColor = UIColor(red: 74.0/255.0, green: 144.0/255.0, blue: 226.0/255.0, alpha: 1.0)
+    static let TextColor = UIColor.Defaults.Blue60
     static let TextOffset = -15
     static let OpenInString = NSLocalizedString("Open in…", comment: "String indicating that the file can be opened in another application on the device")
 }

--- a/Client/Frontend/Browser/OpenWithSettingsViewController.swift
+++ b/Client/Frontend/Browser/OpenWithSettingsViewController.swift
@@ -30,9 +30,9 @@ class OpenWithSettingsViewController: UITableViewController {
         tableView.accessibilityIdentifier = "OpenWithPage.Setting.Options"
 
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: BasicCheckmarkCell)
-        tableView.backgroundColor = UIConstants.TableViewHeaderBackgroundColor
+        tableView.backgroundColor = SettingsUX.TableViewHeaderBackgroundColor
 
-        let headerFooterFrame = CGRect(origin: CGPoint.zero, size: CGSize(width: self.view.frame.width, height: UIConstants.TableViewHeaderFooterHeight))
+        let headerFooterFrame = CGRect(origin: CGPoint.zero, size: CGSize(width: self.view.frame.width, height: SettingsUX.TableViewHeaderFooterHeight))
         let headerView = SettingsTableSectionHeaderFooterView(frame: headerFooterFrame)
         headerView.titleLabel.text = Strings.SettingsOpenWithPageTitle.uppercased()
         headerView.showTopBorder = false

--- a/Client/Frontend/Browser/ReaderModeBarView.swift
+++ b/Client/Frontend/Browser/ReaderModeBarView.swift
@@ -44,24 +44,6 @@ protocol ReaderModeBarViewDelegate {
     func readerModeBar(_ readerModeBar: ReaderModeBarView, didSelectButton buttonType: ReaderModeBarButtonType)
 }
 
-struct ReaderModeBarViewUX {
-
-    static let Themes: [String: Theme] = {
-        var themes = [String: Theme]()
-        var theme = Theme()
-        theme.backgroundColor = UIColor(rgb: 0x38383D)
-        theme.buttonTintColor = UIColor(rgb: 0xf9f9fA)
-        themes[Theme.PrivateMode] = theme
-
-        theme = Theme()
-        theme.backgroundColor = UIColor(rgb: 0xf9f9fA)
-        theme.buttonTintColor = UIColor(rgb: 0x272727)
-        themes[Theme.NormalMode] = theme
-
-        return themes
-    }()
-}
-
 class ReaderModeBarView: UIView {
     var delegate: ReaderModeBarViewDelegate?
 
@@ -158,13 +140,9 @@ class ReaderModeBarView: UIView {
 }
 
 extension ReaderModeBarView: Themeable {
-    func applyTheme(_ themeName: String) {
-        guard let theme = ReaderModeBarViewUX.Themes[themeName] else {
-            log.error("Unable to apply unknown theme \(themeName)")
-            return
-        }
 
-        backgroundColor = theme.backgroundColor
-        buttonTintColor = theme.buttonTintColor!
+    func applyTheme(_ theme: Theme) {
+        backgroundColor = UIColor.Browser.Background.colorFor(theme)
+        buttonTintColor = UIColor.Browser.Tint.colorFor(theme)
     }
 }

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -22,31 +22,11 @@ protocol TabLocationViewDelegate {
     func tabLocationViewLocationAccessibilityActions(_ tabLocationView: TabLocationView) -> [UIAccessibilityCustomAction]?
 }
 
-struct TabLocationViewUX {
+private struct TabLocationViewUX {
     static let HostFontColor = UIColor.black
     static let BaseURLFontColor = UIColor.gray
     static let LocationContentInset = 8
     static let URLBarPadding = 4
-
-    static let Themes: [String: Theme] = {
-        var themes = [String: Theme]()
-        var theme = Theme()
-        theme.URLFontColor = UIColor.lightGray
-        theme.textColor = UIColor(rgb: 0xf9f9fa)
-        theme.highlightButtonColor = UIConstants.PrivateModePurple
-        theme.buttonTintColor = UIColor(rgb: 0xADADb0)
-        theme.backgroundColor = UIColor(rgb: 0x636369)
-        themes[Theme.PrivateMode] = theme
-
-        theme = Theme()
-        theme.textColor = UIColor(rgb: 0x27)
-        theme.highlightButtonColor = UIColor(rgb: 0x00A2FE)
-        theme.buttonTintColor = UIColor(rgb: 0x737373)
-        theme.backgroundColor = .white
-        themes[Theme.NormalMode] = theme
-
-        return themes
-    }()
 }
 
 class TabLocationView: UIView {
@@ -129,7 +109,7 @@ class TabLocationView: UIView {
     fileprivate lazy var lockImageView: UIImageView = {
         let lockImageView = UIImageView(image: UIImage.templateImageNamed("lock_verified"))
         lockImageView.isHidden = true
-        lockImageView.tintColor = UIColor(rgb: 0x16DA00)
+        lockImageView.tintColor = UIColor.Defaults.LockGreen
         lockImageView.isAccessibilityElement = true
         lockImageView.contentMode = UIViewContentMode.center
         lockImageView.accessibilityLabel = NSLocalizedString("Secure connection", comment: "Accessibility label for the lock icon, which is only present if the connection is secure")
@@ -166,7 +146,6 @@ class TabLocationView: UIView {
     lazy var separatorLine: UIView = {
         let line = UIView()
         line.layer.cornerRadius = 2
-        line.backgroundColor = UIColor(rgb: 0xE5E5E5)
         line.isHidden = true
         return line
     }()
@@ -309,21 +288,16 @@ extension TabLocationView: AccessibilityActionsSource {
 }
 
 extension TabLocationView: Themeable {
-    func applyTheme(_ themeName: String) {
-        guard let theme = TabLocationViewUX.Themes[themeName] else {
-            log.error("Unable to apply unknown theme \(themeName)")
-            return
-        }
-        let isPrivate = themeName == Theme.PrivateMode
-        backgroundColor = theme.backgroundColor
-        urlTextField.textColor = theme.textColor
-        readerModeButton.selectedTintColor = theme.highlightButtonColor
-        readerModeButton.unselectedTintColor = theme.buttonTintColor
-        pageOptionsButton.selectedTintColor = theme.highlightButtonColor
-
-        pageOptionsButton.unselectedTintColor = isPrivate ? UIColor(rgb: 0xD2d2d4) : UIColor(rgb: 0x272727)
+    func applyTheme(_ theme: Theme) {
+        backgroundColor = UIColor.TextField.Background.colorFor(theme)
+        urlTextField.textColor = UIColor.Browser.Tint.colorFor(theme)
+        readerModeButton.selectedTintColor = UIColor.TextField.ReaderModeButtonSelected.colorFor(theme)
+        readerModeButton.unselectedTintColor = UIColor.TextField.ReaderModeButtonUnselected.colorFor(theme)
+        
+        pageOptionsButton.selectedTintColor = UIColor.TextField.PageOptionsSelected.colorFor(theme)
+        pageOptionsButton.unselectedTintColor = UIColor.TextField.PageOptionsUnselected.colorFor(theme)
         pageOptionsButton.tintColor = pageOptionsButton.unselectedTintColor
-        separatorLine.backgroundColor = isPrivate ? UIColor(rgb: 0x3f3f43) : UIColor(rgb: 0xE5E5E5)
+        separatorLine.backgroundColor = UIColor.TextField.Separator.colorFor(theme)
     }
 }
 

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -58,7 +58,7 @@ open class TabToolbarHelper: NSObject {
         }
     }
 
-    fileprivate func setTheme(theme: String, forButtons buttons: [Themeable]) {
+    fileprivate func setTheme(theme: Theme, forButtons buttons: [Themeable]) {
         buttons.forEach { $0.applyTheme(theme) }
     }
 
@@ -93,7 +93,7 @@ open class TabToolbarHelper: NSObject {
         toolbar.menuButton.accessibilityLabel = Strings.AppMenuButtonAccessibilityLabel
         toolbar.menuButton.addTarget(self, action: #selector(TabToolbarHelper.SELdidClickMenu), for: UIControlEvents.touchUpInside)
         toolbar.menuButton.accessibilityIdentifier = "TabToolbar.menuButton"
-        setTheme(theme: Theme.NormalMode, forButtons: toolbar.actionButtons)
+        setTheme(theme: .Normal, forButtons: toolbar.actionButtons)
     }
 
     func SELdidClickBack() {
@@ -148,23 +148,6 @@ open class TabToolbarHelper: NSObject {
 }
 
 class ToolbarButton: UIButton {
-    static let Themes: [String: Theme] = {
-        var themes = [String: Theme]()
-        var theme = Theme()
-        theme.buttonTintColor = UIColor(rgb: 0xd2d2d4)
-        theme.highlightButtonColor = UIColor(rgb: 0xAC39FF)
-        theme.disabledButtonColor = UIColor.gray
-        themes[Theme.PrivateMode] = theme
-        
-        theme = Theme()
-        theme.buttonTintColor = UIColor(rgb: 0x272727)
-        theme.highlightButtonColor = UIColor(rgb: 0x00A2FE)
-        theme.disabledButtonColor = UIColor.lightGray
-        themes[Theme.NormalMode] = theme
-        
-        return themes
-    }()
-    
     var selectedTintColor: UIColor!
     var unselectedTintColor: UIColor!
     var disabledTintColor: UIColor!
@@ -202,14 +185,10 @@ class ToolbarButton: UIButton {
 }
 
 extension ToolbarButton: Themeable {
-    func applyTheme(_ themeName: String) {
-        guard let theme = ToolbarButton.Themes[themeName] else {
-            log.error("Unable to apply unknown theme \(themeName)")
-            return
-        }
-        selectedTintColor = theme.highlightButtonColor
-        disabledTintColor = theme.disabledButtonColor
-        unselectedTintColor = theme.buttonTintColor
+    func applyTheme(_ theme: Theme) {
+        selectedTintColor = UIColor.ToolbarButton.SelectedTint.colorFor(theme)
+        disabledTintColor = UIColor.ToolbarButton.DisabledTint.colorFor(theme)
+        unselectedTintColor = UIColor.Browser.Tint.colorFor(theme)
         tintColor = isEnabled ? unselectedTintColor : disabledTintColor
         imageView?.tintColor = tintColor
     }
@@ -226,19 +205,6 @@ class TabToolbar: Toolbar, TabToolbarProtocol {
     let actionButtons: [Themeable & UIButton]
 
     var helper: TabToolbarHelper?
-
-    static let Themes: [String: Theme] = {
-        var themes = [String: Theme]()
-        var theme = Theme()
-        theme.backgroundColor = UIColor(rgb: 0x38383D)
-        themes[Theme.PrivateMode] = theme
-
-        theme = Theme()
-        theme.backgroundColor = UIConstants.AppBackgroundColor
-        themes[Theme.NormalMode] = theme
-
-        return themes
-    }()
 
     // This has to be here since init() calls it
     fileprivate override init(frame: CGRect) {
@@ -304,12 +270,8 @@ class TabToolbar: Toolbar, TabToolbarProtocol {
 }
 
 extension TabToolbar: Themeable {
-    func applyTheme(_ themeName: String) {
-        guard let theme = TabToolbar.Themes[themeName] else {
-            log.error("Unable to apply unknown theme \(themeName)")
-            return
-        }
-        backgroundColor = theme.backgroundColor!
-        helper?.setTheme(theme: themeName, forButtons: actionButtons)
+    func applyTheme(_ theme: Theme) {
+        backgroundColor = UIColor.Browser.Background.colorFor(theme)
+        helper?.setTheme(theme: theme, forButtons: actionButtons)
     }
 }

--- a/Client/Frontend/Browser/TabTrayButtonExtensions.swift
+++ b/Client/Frontend/Browser/TabTrayButtonExtensions.swift
@@ -9,10 +9,10 @@ class PrivateModeButton: ToggleButton, Themeable {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        self.accessibilityLabel = PrivateModeStrings.toggleAccessibilityLabel
-        self.accessibilityHint = PrivateModeStrings.toggleAccessibilityHint
+        accessibilityLabel = PrivateModeStrings.toggleAccessibilityLabel
+        accessibilityHint = PrivateModeStrings.toggleAccessibilityHint
         let maskImage = UIImage(named: "smallPrivateMask")?.withRenderingMode(.alwaysTemplate)
-        self.setImage(maskImage, for: UIControlState())
+        setImage(maskImage, for: UIControlState())
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -20,10 +20,10 @@ class PrivateModeButton: ToggleButton, Themeable {
     }
     
     func applyTheme(_ theme: Theme) {
-        self.tintColor = UIColor.Browser.Tint.colorFor(theme)
-        self.imageView?.tintColor = self.tintColor
-        self.isSelected = theme == .Private
-        self.accessibilityValue = self.isSelected ? PrivateModeStrings.toggleAccessibilityValueOn : PrivateModeStrings.toggleAccessibilityValueOff
+        tintColor = UIColor.Browser.Tint.colorFor(theme)
+        imageView?.tintColor = tintColor
+        isSelected = theme == .Private
+        accessibilityValue = isSelected ? PrivateModeStrings.toggleAccessibilityValueOn : PrivateModeStrings.toggleAccessibilityValueOff
     }
 }
 

--- a/Client/Frontend/Browser/TabTrayButtonExtensions.swift
+++ b/Client/Frontend/Browser/TabTrayButtonExtensions.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-class PrivateModeButton: ToggleButton {
+class PrivateModeButton: ToggleButton, Themeable {
     var light: Bool = false
     
     override init(frame: CGRect) {
@@ -19,11 +19,11 @@ class PrivateModeButton: ToggleButton {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func styleForMode(privateMode isPrivate: Bool) {
-        self.tintColor = isPrivate ? UIColor(rgb: 0xf9f9fa) : UIColor(rgb: 0x272727)
+    func applyTheme(_ theme: Theme) {
+        self.tintColor = UIColor.Browser.Tint.colorFor(theme)
         self.imageView?.tintColor = self.tintColor
-        self.isSelected = isPrivate
-        self.accessibilityValue = isPrivate ? PrivateModeStrings.toggleAccessibilityValueOn : PrivateModeStrings.toggleAccessibilityValueOff
+        self.isSelected = theme == .Private
+        self.accessibilityValue = self.isSelected ? PrivateModeStrings.toggleAccessibilityValueOn : PrivateModeStrings.toggleAccessibilityValueOff
     }
 }
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -11,8 +11,8 @@ import Shared
 
 struct TabTrayControllerUX {
     static let CornerRadius = CGFloat(6.0)
-    static let BackgroundColor = UIConstants.TabTrayBG
-    static let CellBackgroundColor = UIConstants.TabTrayBG
+    static let BackgroundColor = UIColor.TopTabs.Background
+    static let CellBackgroundColor = UIColor.TopTabs.Background
     static let TextBoxHeight = CGFloat(32.0)
     static let FaviconSize = CGFloat(20)
     static let Margin = CGFloat(15)
@@ -29,11 +29,11 @@ struct TabTrayControllerUX {
     static let MenuFixedWidth: CGFloat = 320
 }
 
-struct LightTabCellUX {
+private struct LightTabCellUX {
     static let TabTitleTextColor = UIColor.black
 }
 
-struct DarkTabCellUX {
+private struct DarkTabCellUX {
     static let TabTitleTextColor = UIColor.white
 }
 
@@ -254,7 +254,7 @@ class TabTrayController: UIViewController {
     fileprivate(set) internal var privateMode: Bool = false {
         didSet {
             tabDataSource.tabs = tabsToDisplay
-            toolbar.styleToolbar(privateMode)
+            toolbar.applyTheme(privateMode == true ? .Private : .Normal)
             collectionView?.reloadData()
         }
     }
@@ -834,7 +834,7 @@ fileprivate class TabLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayou
     }
 }
 
-struct EmptyPrivateTabsViewUX {
+private struct EmptyPrivateTabsViewUX {
     static let TitleColor = UIColor.white
     static let TitleFont = UIFont.systemFont(ofSize: 22, weight: UIFontWeightMedium)
     static let DescriptionColor = UIColor.white
@@ -1045,17 +1045,17 @@ class TrayToolbar: UIView {
             make.size.equalTo(toolbarButtonSize)
         }
 
-        styleToolbar(false)
+        applyTheme(.Normal)
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    fileprivate func styleToolbar(_ isPrivate: Bool) {
-        addTabButton.tintColor = isPrivate ? UIColor(rgb: 0xf9f9fa) : UIColor(rgb: 0x272727)
-        deleteButton.tintColor = isPrivate ? UIColor(rgb: 0xf9f9fa) : UIColor(rgb: 0x272727)
-        backgroundColor = isPrivate ? UIConstants.PrivateModeToolbarTintColor : UIColor(rgb: 0xf9f9fa)
-        maskButton.styleForMode(privateMode: isPrivate)
+    fileprivate func applyTheme(_ theme: Theme) {
+        addTabButton.tintColor = UIColor.Browser.Tint.colorFor(theme)
+        deleteButton.tintColor = UIColor.Browser.Tint.colorFor(theme)
+        backgroundColor = UIColor.TabTray.Background.colorFor(theme)
+        maskButton.applyTheme(theme)
     }
 }

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -8,16 +8,12 @@ import WebKit
 
 struct TopTabsUX {
     static let TopTabsViewHeight: CGFloat = 44
-    static let TopTabsBackgroundColor = UIColor(rgb: 0x2a2a2e)
-    static let TopTabsBackgroundPadding: CGFloat = 35
     static let TopTabsBackgroundShadowWidth: CGFloat = 12
     static let TabWidth: CGFloat = 190
-    static let CollectionViewPadding: CGFloat = 15
     static let FaderPading: CGFloat = 8
     static let SeparatorWidth: CGFloat = 1
     static let HighlightLineWidth: CGFloat = 3
     static let TabNudge: CGFloat = 1 // Nudge the favicon and close button by 1px
-    static let TabTitleWidth: CGFloat = 110
     static let TabTitlePadding: CGFloat = 10
     static let AnimationSpeed: TimeInterval = 0.1
     static let SeparatorYOffset: CGFloat = 7
@@ -156,10 +152,10 @@ class TopTabsViewController: UIViewController {
             make.edges.equalTo(topTabFader)
         }
 
-        view.backgroundColor = UIColor(rgb: 0x272727)
-        tabsButton.applyTheme(Theme.NormalMode)
+        view.backgroundColor = UIColor.Defaults.Grey80
+        tabsButton.applyTheme(.Normal)
         if let currentTab = tabManager.selectedTab {
-            applyTheme(currentTab.isPrivate ? Theme.PrivateMode : Theme.NormalMode)
+            applyTheme(currentTab.isPrivate ? .Private : .Normal)
         }
         updateTabCount(tabStore.count, animated: false)
     }
@@ -252,15 +248,16 @@ class TopTabsViewController: UIViewController {
 }
 
 extension TopTabsViewController: Themeable {
-    func applyTheme(_ themeName: String) {
-        tabsButton.applyTheme(themeName)
-        tabsButton.titleBackgroundColor = view.backgroundColor ?? UIColor(rgb: 0x272727)
-        tabsButton.textColor = UIColor(rgb: 0xb1b1b3)
-        isPrivate = (themeName == Theme.PrivateMode)
-        privateModeButton.styleForMode(privateMode: isPrivate)
-        privateModeButton.tintColor = isPrivate ? UIColor(rgb: 0xf9f9fa) : UIColor(rgb: 0xb1b1b3)
+    func applyTheme(_ theme: Theme) {
+        tabsButton.applyTheme(theme)
+        tabsButton.titleBackgroundColor = view.backgroundColor ?? UIColor.Defaults.Grey80
+        tabsButton.textColor = UIColor.Defaults.Grey40
+
+        isPrivate = (theme == Theme.Private)
+        privateModeButton.applyTheme(theme)
+        privateModeButton.tintColor = UIColor.TopTabs.PrivateModeTint.colorFor(theme)
         privateModeButton.imageView?.tintColor = privateModeButton.tintColor
-        newTab.tintColor = UIColor(rgb: 0xb1b1b3)
+        newTab.tintColor = UIColor.Defaults.Grey40
         collectionView.backgroundColor = view.backgroundColor
     }
 }

--- a/Client/Frontend/Browser/TopTabsViews.swift
+++ b/Client/Frontend/Browser/TopTabsViews.swift
@@ -6,7 +6,7 @@ import Foundation
 
 struct TopTabsSeparatorUX {
     static let Identifier = "Separator"
-    static let Color = UIColor(rgb: 0x3c3c3d)
+    static let Color = UIColor.Defaults.Grey70
     static let Width: CGFloat = 1
 }
 
@@ -78,15 +78,15 @@ class TopTabCell: UICollectionViewCell {
     
     var selectedTab = false {
         didSet {
-            backgroundColor = selectedTab ? UIColor(rgb: 0xf9f9fa) : UIColor(rgb: 0x272727)
-            titleText.textColor = selectedTab ? UIColor(rgb: 0x0c0c0d) : UIColor(rgb: 0xb1b1b3)
+            backgroundColor = selectedTab ? UIColor.Defaults.Grey10 : UIColor.Defaults.Grey80
+            titleText.textColor = selectedTab ? UIColor.Defaults.Grey90 : UIColor.Defaults.Grey40
             highlightLine.isHidden = !selectedTab
-            closeButton.tintColor = selectedTab ? UIColor(rgb: 0x272727) : UIColor(rgb: 0xb1b1b3)
+            closeButton.tintColor = selectedTab ? UIColor.Defaults.Grey80 : UIColor.Defaults.Grey40
             // restyle if we are in PBM
             if style == .dark && selectedTab {
-                backgroundColor =  UIColor(rgb: 0x38383D)
-                titleText.textColor = UIColor(rgb: 0xf9f9fa)
-                closeButton.tintColor = UIColor(rgb: 0xf9f9fa)
+                backgroundColor =  UIColor.Defaults.Grey70
+                titleText.textColor = UIColor.Defaults.Grey10
+                closeButton.tintColor = UIColor.Defaults.Grey10
             }
             closeButton.backgroundColor = backgroundColor
             closeButton.layer.shadowColor = backgroundColor?.cgColor
@@ -116,7 +116,7 @@ class TopTabCell: UICollectionViewCell {
     let closeButton: UIButton = {
         let closeButton = UIButton()
         closeButton.setImage(UIImage.templateImageNamed("menu-CloseTabs"), for: UIControlState())
-        closeButton.tintColor = UIColor(rgb: 0xb1b1b3)
+        closeButton.tintColor = UIColor.Defaults.Grey40
         closeButton.imageEdgeInsets = UIEdgeInsets(top: 15, left: TopTabsUX.TabTitlePadding, bottom: 15, right: TopTabsUX.TabTitlePadding)
         closeButton.layer.shadowOpacity = 0.8
         closeButton.layer.masksToBounds = false
@@ -126,7 +126,7 @@ class TopTabCell: UICollectionViewCell {
 
     let highlightLine: UIView = {
         let line = UIView()
-        line.backgroundColor = UIColor(rgb: 0x0066DC)
+        line.backgroundColor = UIColor.Defaults.Blue60
         line.isHidden = true
         return line
     }()
@@ -177,11 +177,11 @@ class TopTabCell: UICollectionViewCell {
         case Style.light:
             titleText.textColor = UIColor.darkText
             backgroundColor = UIConstants.AppBackgroundColor
-            highlightLine.backgroundColor = UIColor(rgb: 0x0066DC)
+            highlightLine.backgroundColor = UIColor.Defaults.Blue60
         case Style.dark:
             titleText.textColor = UIColor.lightText
-            backgroundColor = UIColor(rgb: 0x38383D)
-            highlightLine.backgroundColor = UIColor(rgb: 0x9400ff)
+            backgroundColor = UIColor.Defaults.Grey70
+            highlightLine.backgroundColor = UIColor.Defaults.Purple50
         }
     }
     

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -353,8 +353,8 @@ class URLBarView: UIView {
     }
 
     func updateAlphaForSubviews(_ alpha: CGFloat) {
-        self.locationContainer.alpha = alpha
-        self.alpha = alpha
+        locationContainer.alpha = alpha
+        alpha = alpha
     }
 
     func updateProgressBar(_ progress: Float) {
@@ -423,53 +423,53 @@ class URLBarView: UIView {
 
     func prepareOverlayAnimation() {
         // Make sure everything is showing during the transition (we'll hide it afterwards).
-        self.bringSubview(toFront: self.locationContainer)
-        self.cancelButton.isHidden = false
-        self.showQRScannerButton.isHidden = false
-        self.progressBar.isHidden = false
-        self.menuButton.isHidden = !self.toolbarIsShowing
-        self.forwardButton.isHidden = !self.toolbarIsShowing
-        self.backButton.isHidden = !self.toolbarIsShowing
-        self.tabsButton.isHidden = !self.toolbarIsShowing || topTabsIsShowing
-        self.stopReloadButton.isHidden = !self.toolbarIsShowing
+        bringSubview(toFront: self.locationContainer)
+        cancelButton.isHidden = false
+        showQRScannerButton.isHidden = false
+        progressBar.isHidden = false
+        menuButton.isHidden = !toolbarIsShowing
+        forwardButton.isHidden = !toolbarIsShowing
+        backButton.isHidden = !toolbarIsShowing
+        tabsButton.isHidden = !toolbarIsShowing || topTabsIsShowing
+        stopReloadButton.isHidden = !toolbarIsShowing
     }
 
     func transitionToOverlay(_ didCancel: Bool = false) {
-        self.cancelButton.alpha = inOverlayMode ? 1 : 0
-        self.showQRScannerButton.alpha = inOverlayMode ? 1 : 0
-        self.progressBar.alpha = inOverlayMode || didCancel ? 0 : 1
-        self.tabsButton.alpha = inOverlayMode ? 0 : 1
-        self.menuButton.alpha = inOverlayMode ? 0 : 1
-        self.forwardButton.alpha = inOverlayMode ? 0 : 1
-        self.backButton.alpha = inOverlayMode ? 0 : 1
-        self.stopReloadButton.alpha = inOverlayMode ? 0 : 1
+        cancelButton.alpha = inOverlayMode ? 1 : 0
+        showQRScannerButton.alpha = inOverlayMode ? 1 : 0
+        progressBar.alpha = inOverlayMode || didCancel ? 0 : 1
+        tabsButton.alpha = inOverlayMode ? 0 : 1
+        menuButton.alpha = inOverlayMode ? 0 : 1
+        forwardButton.alpha = inOverlayMode ? 0 : 1
+        backButton.alpha = inOverlayMode ? 0 : 1
+        stopReloadButton.alpha = inOverlayMode ? 0 : 1
 
         let borderColor = inOverlayMode ? locationActiveBorderColor : locationBorderColor
         locationContainer.layer.borderColor = borderColor.cgColor
 
         if inOverlayMode {
-            self.line.isHidden = inOverlayMode
+            line.isHidden = inOverlayMode
             // Make the editable text field span the entire URL bar, covering the lock and reader icons.
-            self.locationTextField?.snp.remakeConstraints { make in
+            locationTextField?.snp.remakeConstraints { make in
                 make.edges.equalTo(self.locationView)
             }
         } else {
             // Shrink the editable text field back to the size of the location view before hiding it.
-            self.locationTextField?.snp.remakeConstraints { make in
+            locationTextField?.snp.remakeConstraints { make in
                 make.edges.equalTo(self.locationView.urlTextField)
             }
         }
     }
 
     func updateViewsForOverlayModeAndToolbarChanges() {
-        self.cancelButton.isHidden = !inOverlayMode
-        self.showQRScannerButton.isHidden = !inOverlayMode
-        self.progressBar.isHidden = inOverlayMode
-        self.menuButton.isHidden = !self.toolbarIsShowing || inOverlayMode
-        self.forwardButton.isHidden = !self.toolbarIsShowing || inOverlayMode
-        self.backButton.isHidden = !self.toolbarIsShowing || inOverlayMode
-        self.tabsButton.isHidden = !self.toolbarIsShowing || inOverlayMode || topTabsIsShowing
-        self.stopReloadButton.isHidden = !self.toolbarIsShowing || inOverlayMode
+        cancelButton.isHidden = !inOverlayMode
+        showQRScannerButton.isHidden = !inOverlayMode
+        progressBar.isHidden = inOverlayMode
+        menuButton.isHidden = !toolbarIsShowing || inOverlayMode
+        forwardButton.isHidden = !toolbarIsShowing || inOverlayMode
+        backButton.isHidden = !toolbarIsShowing || inOverlayMode
+        tabsButton.isHidden = !toolbarIsShowing || inOverlayMode || topTabsIsShowing
+        stopReloadButton.isHidden = !toolbarIsShowing || inOverlayMode
     }
 
     func animateToOverlayState(overlayMode overlay: Bool, didCancel cancel: Bool = false) {
@@ -515,7 +515,7 @@ extension URLBarView: TabToolbarProtocol {
     }
 
     func updateTabCount(_ count: Int, animated: Bool = true) {
-        self.tabsButton.updateTabCount(count, animated: animated)
+        tabsButton.updateTabCount(count, animated: animated)
     }
 
     func updateReloadStatus(_ isLoading: Bool) {
@@ -639,7 +639,7 @@ extension URLBarView: Themeable {
     func applyTheme(_ theme: Theme) {
         locationView.applyTheme(theme)
         locationTextField?.applyTheme(theme)
-        self.actionButtons.forEach { $0.applyTheme(theme) }
+        actionButtons.forEach { $0.applyTheme(theme) }
         tabsButton.applyTheme(theme)
 
         progressBar.setGradientColors(startColor: UIColor.LoadingBar.Start.colorFor(theme), endColor: UIColor.LoadingBar.End.colorFor(theme))
@@ -650,7 +650,7 @@ extension URLBarView: Themeable {
         showQRButtonTintColor = UIColor.Browser.Tint.colorFor(theme)
         backgroundColor = UIColor.Browser.Background.colorFor(theme)
         line.backgroundColor = UIColor.Browser.URLBarDivider.colorFor(theme)
-        locationContainer.layer.shadowColor = self.locationBorderColor.cgColor
+        locationContainer.layer.shadowColor = locationBorderColor.cgColor
     }
 }
 

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -354,7 +354,7 @@ class URLBarView: UIView {
 
     func updateAlphaForSubviews(_ alpha: CGFloat) {
         locationContainer.alpha = alpha
-        alpha = alpha
+        self.alpha = alpha
     }
 
     func updateProgressBar(_ progress: Float) {

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -2,17 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import Foundation
-import UIKit
 import Shared
 import SnapKit
-import XCGLogger
 
-private let log = Logger.browserLogger
-
-struct URLBarViewUX {
+private struct URLBarViewUX {
     static let TextFieldBorderColor = UIColor(rgb: 0xBBBBBB)
     static let TextFieldActiveBorderColor = UIColor(rgb: 0xB0D5FB)
+
     static let LocationLeftPadding: CGFloat = 8
     static let Padding: CGFloat = 10
     static let LocationHeight: CGFloat = 40
@@ -21,40 +17,11 @@ struct URLBarViewUX {
     static let TextFieldCornerRadius: CGFloat = 8
     static let TextFieldBorderWidth: CGFloat = 1
     static let TextFieldBorderWidthSelected: CGFloat = 4
-    // offset from edge of tabs button
-    static let ProgressTintColor = UIColor(rgb: 0x00dcfc)
     static let ProgressBarHeight: CGFloat = 3
 
     static let TabsButtonRotationOffset: CGFloat = 1.5
     static let TabsButtonHeight: CGFloat = 18.0
-    static let ToolbarButtonInsets = UIEdgeInsets(top: Padding, left: Padding, bottom: Padding, right: Padding)
-
-    static let Themes: [String: Theme] = {
-        var themes = [String: Theme]()
-        var theme = Theme()
-        theme.borderColor = UIColor(rgb: 0x2D2D31)
-        theme.backgroundColor = UIColor(rgb: 0x38383D)
-        theme.activeBorderColor = UIColor(rgb: 0x4a4a4f)
-        theme.tintColor = UIColor(rgb: 0xf9f9fa)
-        theme.textColor = UIColor(rgb: 0xf9f9fa)
-        theme.buttonTintColor = UIColor(rgb: 0xD2d2d4)
-        theme.disabledButtonColor = UIColor.gray
-        theme.highlightButtonColor = UIColor(rgb: 0xAC39FF)
-        themes[Theme.PrivateMode] = theme
-
-        theme = Theme()
-        theme.borderColor =  UIColor(rgb: 0x737373).withAlphaComponent(0.3)
-        theme.activeBorderColor = TextFieldActiveBorderColor
-        theme.disabledButtonColor = UIColor.lightGray
-        theme.highlightButtonColor = UIColor(rgb: 0x00A2FE)
-        theme.tintColor = ProgressTintColor
-        theme.textColor = UIColor(rgb: 0x272727)
-        theme.backgroundColor = UIConstants.AppBackgroundColor
-        theme.buttonTintColor = UIColor(rgb: 0x272727)
-        themes[Theme.NormalMode] = theme
-
-        return themes
-    }()
+    static let ToolbarButtonInsets = UIEdgeInsets(equalInset: Padding)
 }
 
 protocol URLBarDelegate: class {
@@ -108,7 +75,7 @@ class URLBarView: UIView {
         }
     }
 
-    fileprivate var currentTheme: String = Theme.NormalMode
+    fileprivate var currentTheme: Theme = .Normal
 
     var toolbarIsShowing = false
     var topTabsIsShowing = false
@@ -668,27 +635,21 @@ extension URLBarView {
 }
 
 extension URLBarView: Themeable {
-    
-    func applyTheme(_ themeName: String) {
-        locationView.applyTheme(themeName)
-        locationTextField?.applyTheme(themeName)
 
-        guard let theme = URLBarViewUX.Themes[themeName] else {
-            fatalError("Theme not found")
-        }
-        
-        let isPrivate = themeName == Theme.PrivateMode
-        
-        progressBar.setGradientColors(startColor: UIConstants.LoadingStartColor.color(isPBM: isPrivate), endColor: UIConstants.LoadingEndColor.color(isPBM: isPrivate))
-        currentTheme = themeName
-        locationBorderColor = theme.borderColor!
-        locationActiveBorderColor = theme.activeBorderColor!
-        cancelTintColor = theme.buttonTintColor
-        showQRButtonTintColor = theme.buttonTintColor
-        backgroundColor = theme.backgroundColor
-        self.actionButtons.forEach { $0.applyTheme(themeName) }
-        tabsButton.applyTheme(themeName)
-        line.backgroundColor = UIConstants.URLBarDivider.color(isPBM: isPrivate)
+    func applyTheme(_ theme: Theme) {
+        locationView.applyTheme(theme)
+        locationTextField?.applyTheme(theme)
+        self.actionButtons.forEach { $0.applyTheme(theme) }
+        tabsButton.applyTheme(theme)
+
+        progressBar.setGradientColors(startColor: UIColor.LoadingBar.Start.colorFor(theme), endColor: UIColor.LoadingBar.End.colorFor(theme))
+        currentTheme = theme
+        locationBorderColor = UIColor.URLBar.Border.colorFor(theme).withAlphaComponent(0.3)
+        locationActiveBorderColor = UIColor.URLBar.ActiveBorder.colorFor(theme)
+        cancelTintColor = UIColor.Browser.Tint.colorFor(theme)
+        showQRButtonTintColor = UIColor.Browser.Tint.colorFor(theme)
+        backgroundColor = UIColor.Browser.Background.colorFor(theme)
+        line.backgroundColor = UIColor.Browser.URLBarDivider.colorFor(theme)
         locationContainer.layer.shadowColor = self.locationBorderColor.cgColor
     }
 }
@@ -697,7 +658,7 @@ extension URLBarView: Themeable {
 // This subclass creates a strong shadow on the URLBar
 class TabLocationContainerView: UIView {
     
-    struct LocationContainerUX {
+    private struct LocationContainerUX {
         static let CornerRadius: CGFloat = 4
         static let ShadowRadius: CGFloat = 2
         static let ShadowOpacity: Float = 1
@@ -729,23 +690,6 @@ class TabLocationContainerView: UIView {
 }
 
 class ToolbarTextField: AutocompleteTextField {
-    static let Themes: [String: Theme] = {
-        var themes = [String: Theme]()
-        var theme = Theme()
-        theme.backgroundColor = UIColor(rgb: 0x636369)
-        theme.textColor = UIColor.white
-        theme.buttonTintColor = UIColor.white
-        theme.highlightColor = UIConstants.PrivateModeInputHighlightColor
-        themes[Theme.PrivateMode] = theme
-
-        theme = Theme()
-        theme.backgroundColor = .white
-        theme.textColor = UIColor(rgb: 0x272727)
-        theme.highlightColor = AutocompleteTextFieldUX.HighlightColor
-        themes[Theme.NormalMode] = theme
-
-        return themes
-    }()
 
     dynamic var clearButtonTintColor: UIColor? {
         didSet {
@@ -813,14 +757,11 @@ class ToolbarTextField: AutocompleteTextField {
 }
 
 extension ToolbarTextField: Themeable {
-    func applyTheme(_ themeName: String) {
-        guard let theme = ToolbarTextField.Themes[themeName] else {
-            fatalError("Theme not found")
-        }
 
-        backgroundColor = theme.backgroundColor
-        textColor = theme.textColor
-        clearButtonTintColor = theme.buttonTintColor
-        highlightColor = theme.highlightColor!
+    func applyTheme(_ theme: Theme) {
+        backgroundColor = UIColor.TextField.Background.colorFor(theme)
+        textColor = UIColor.TextField.TextAndTint.colorFor(theme)
+        clearButtonTintColor = textColor
+        highlightColor = UIColor.TextField.Highlight.colorFor(theme)
     }
 }

--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -958,7 +958,7 @@ struct ActivityStreamTracker {
 
 // MARK: - Section Header View
 private struct ASHeaderViewUX {
-    static let SeperatorColor =  UIColor(rgb: 0xedecea) //random color
+    static let SeperatorColor =  UIColor(rgb: 0xedecea) //Color not found in Photon
     static let TextFont = DynamicFontHelper.defaultHelper.MediumSizeBoldFontAS
     static let SeperatorHeight = 1
     static let Insets: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? ASPanelUX.SectionInsetsForIpad + ASPanelUX.MinimumInsets : ASPanelUX.MinimumInsets

--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -957,8 +957,8 @@ struct ActivityStreamTracker {
 }
 
 // MARK: - Section Header View
-struct ASHeaderViewUX {
-    static let SeperatorColor =  UIColor(rgb: 0xedecea)
+private struct ASHeaderViewUX {
+    static let SeperatorColor =  UIColor(rgb: 0xedecea) //random color
     static let TextFont = DynamicFontHelper.defaultHelper.MediumSizeBoldFontAS
     static let SeperatorHeight = 1
     static let Insets: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? ASPanelUX.SectionInsetsForIpad + ASPanelUX.MinimumInsets : ASPanelUX.MinimumInsets

--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -7,9 +7,8 @@ import Shared
 import SDWebImage
 import Storage
 
-struct TopSiteCellUX {
+private struct TopSiteCellUX {
     static let TitleHeight: CGFloat = 20
-    static let TitleBackgroundColor = UIColor(red: 1, green: 1, blue: 1, alpha: 0.7)
     static let TitleTextColor = UIColor.black
     static let TitleFont = DynamicFontHelper.defaultHelper.SmallSizeRegularWeightAS
     static let SelectedOverlayColor = UIColor(white: 0.0, alpha: 0.25)
@@ -20,7 +19,7 @@ struct TopSiteCellUX {
     static let BorderColor = UIColor(white: 0, alpha: 0.1)
     static let BorderWidth: CGFloat = 0.5
     static let PinIconSize: CGFloat = 12
-    static let PinColor = UIColor(rgb: 0x272727)
+    static let PinColor = UIColor.Defaults.Grey60 //TODO //wrong
 }
 
 /*
@@ -191,7 +190,7 @@ class EmptyTopsiteDecorationCell: UICollectionReusableView {
     }
 }
 
-struct ASHorizontalScrollCellUX {
+private struct ASHorizontalScrollCellUX {
     static let TopSiteCellIdentifier = "TopSiteItemCell"
     static let TopSiteEmptyCellIdentifier = "TopSiteItemEmptyCell"
 
@@ -472,7 +471,7 @@ class HorizontalFlowLayout: UICollectionViewLayout {
 /*
     Defines the number of items to show in topsites for different size classes.
 */
-struct ASTopSiteSourceUX {
+private struct ASTopSiteSourceUX {
     static let verticalItemsForTraitSizes = [UIUserInterfaceSizeClass.compact: 1, UIUserInterfaceSizeClass.regular: 2, UIUserInterfaceSizeClass.unspecified: 0]
     static let maxNumberOfPages = 2
     static let CellIdentifier = "TopSiteItemCell"

--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -19,7 +19,7 @@ private struct TopSiteCellUX {
     static let BorderColor = UIColor(white: 0, alpha: 0.1)
     static let BorderWidth: CGFloat = 0.5
     static let PinIconSize: CGFloat = 12
-    static let PinColor = UIColor.Defaults.Grey60 //TODO //wrong
+    static let PinColor = UIColor.Defaults.Grey60
 }
 
 /*

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -23,12 +23,12 @@ let emptyBookmarksText = NSLocalizedString("Bookmarks you save will show up here
 
 // MARK: - UX constants.
 
-struct BookmarksPanelUX {
+private struct BookmarksPanelUX {
     static let BookmarkFolderHeaderViewChevronInset: CGFloat = 10
     static let BookmarkFolderChevronSize: CGFloat = 20
     static let BookmarkFolderChevronLineWidth: CGFloat = 2.0
     static let BookmarkFolderTextColor = UIColor(red: 92/255, green: 92/255, blue: 92/255, alpha: 1.0)
-    static let BookmarkFolderBGColor = UIColor(rgb: 0xf7f8f7).withAlphaComponent(0.3)
+    static let BookmarkFolderBGColor = UIColor.Defaults.Grey10.withAlphaComponent(0.3)
     static let WelcomeScreenPadding: CGFloat = 15
     static let WelcomeScreenItemTextColor = UIColor.gray
     static let WelcomeScreenItemWidth = 170

--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -59,23 +59,7 @@ enum HomePanelType: Int {
 }
 
 class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelDelegate {
-    static let Themes: [String: Theme] = {
-        var themes = [String: Theme]()
-        var theme = Theme()
-        theme.backgroundColor = UIConstants.AppBackgroundColor
-        theme.buttonTintColor = UIColor(rgb: 0x7e7e7f)
-        theme.highlightButtonColor = UIConstants.HighlightBlue
-        themes[Theme.PrivateMode] = theme
 
-        theme = Theme()
-        theme.backgroundColor = UIConstants.AppBackgroundColor
-        theme.buttonTintColor = UIColor(rgb: 0x7e7e7f)
-        theme.highlightButtonColor = UIConstants.HighlightBlue
-        themes[Theme.NormalMode] = theme
-        
-        return themes
-    }()
-    
     var profile: Profile!
     var notificationToken: NSObjectProtocol!
     var panels: [HomePanelDescriptor]!
@@ -305,16 +289,12 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
 
 // MARK: UIAppearance
 extension HomePanelViewController: Themeable {
-    func applyTheme(_ themeName: String) {
-        guard let theme = HomePanelViewController.Themes[themeName] else {
-            fatalError("Theme not found")
-        }
-        
-        highlightLine.backgroundColor = theme.highlightButtonColor
-        buttonContainerView.backgroundColor = theme.backgroundColor
-        self.view.backgroundColor = theme.backgroundColor
-        buttonTintColor = theme.buttonTintColor
-        buttonSelectedTintColor = theme.highlightButtonColor
+    func applyTheme(_ theme: Theme) {
+        buttonContainerView.backgroundColor = UIColor.HomePanel.ToolbarBackground.colorFor(theme)
+        self.view.backgroundColor = UIColor.HomePanel.ToolbarBackground.colorFor(theme)
+        buttonTintColor = UIColor.HomePanel.ToolbarTint.colorFor(theme)
+        buttonSelectedTintColor = UIColor.HomePanel.ToolbarHighlight.colorFor(theme)
+        highlightLine.backgroundColor = UIColor.HomePanel.ToolbarHighlight.colorFor(theme)
         updateButtonTints()
     }
 }

--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -291,7 +291,7 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
 extension HomePanelViewController: Themeable {
     func applyTheme(_ theme: Theme) {
         buttonContainerView.backgroundColor = UIColor.HomePanel.ToolbarBackground.colorFor(theme)
-        self.view.backgroundColor = UIColor.HomePanel.ToolbarBackground.colorFor(theme)
+        view.backgroundColor = UIColor.HomePanel.ToolbarBackground.colorFor(theme)
         buttonTintColor = UIColor.HomePanel.ToolbarTint.colorFor(theme)
         buttonSelectedTintColor = UIColor.HomePanel.ToolbarHighlight.colorFor(theme)
         highlightLine.backgroundColor = UIColor.HomePanel.ToolbarHighlight.colorFor(theme)

--- a/Client/Frontend/Home/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Home/RecentlyClosedTabsPanel.swift
@@ -11,7 +11,7 @@ import Deferred
 
 private let log = Logger.browserLogger
 
-struct RecentlyClosedPanelUX {
+private struct RecentlyClosedPanelUX {
     static let IconSize = CGSize(width: 23, height: 23)
     static let IconBorderColor = UIColor(white: 0, alpha: 0.1)
     static let IconBorderWidth: CGFloat = 0.5

--- a/Client/Frontend/Home/RemoteTabsPanel.swift
+++ b/Client/Frontend/Home/RemoteTabsPanel.swift
@@ -15,7 +15,7 @@ private let log = Logger.browserLogger
 private struct RemoteTabsPanelUX {
     static let HeaderHeight = SiteTableViewControllerUX.RowHeight // Not HeaderHeight!
     static let RowHeight = SiteTableViewControllerUX.RowHeight
-    static let HeaderBackgroundColor = UIColor(rgb: 0xf8f8f8)
+    static let HeaderBackgroundColor = UIColor.Defaults.Grey10
 
     static let EmptyStateTitleTextColor = UIColor.darkGray
 

--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -17,10 +17,10 @@ struct IntroViewControllerUX {
     static let PagerCenterOffsetFromScrollViewBottom = UIScreen.main.bounds.width <= 320 ? 20 : 30
 
     static let StartBrowsingButtonTitle = NSLocalizedString("Start Browsing", tableName: "Intro", comment: "See http://mzl.la/1T8gxwo")
-    static let StartBrowsingButtonColor = UIColor(rgb: 0x4990E2)
+    static let StartBrowsingButtonColor = UIColor.Defaults.Blue40
     static let StartBrowsingButtonHeight = 56
     static let SignInButtonTitle = NSLocalizedString("Sign in to Firefox", tableName: "Intro", comment: "See http://mzl.la/1T8gxwo")
-    static let SignInButtonColor = UIColor(rgb: 0x45A1FF)
+    static let SignInButtonColor = UIColor.Defaults.Blue40
     static let SignInButtonHeight = 60
     static let SignInButtonWidth = 290
 

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -32,7 +32,7 @@ class ConnectSetting: WithoutAccountSetting {
     override var accessoryType: UITableViewCellAccessoryType { return .disclosureIndicator }
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: Strings.FxASignIntoSync, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+        return NSAttributedString(string: Strings.FxASignIntoSync, attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor])
     }
 
     override var accessibilityIdentifier: String? { return "SignInToSync" }
@@ -123,13 +123,13 @@ class SyncNowSetting: WithAccountSetting {
         return NSAttributedString(
             string: NSLocalizedString("Sync Now", comment: "Sync Firefox Account"),
             attributes: [
-                NSForegroundColorAttributeName: self.enabled ? UIConstants.TableViewRowSyncTextColor : UIColor.gray,
+                NSForegroundColorAttributeName: self.enabled ? SettingsUX.TableViewRowSyncTextColor : UIColor.gray,
                 NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFont
             ]
         )
     }
 
-    fileprivate let syncingTitle = NSAttributedString(string: Strings.SyncingMessageWithEllipsis, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowSyncTextColor, NSFontAttributeName: UIFont.systemFont(ofSize: DynamicFontHelper.defaultHelper.DefaultStandardFontSize, weight: UIFontWeightRegular)])
+    fileprivate let syncingTitle = NSAttributedString(string: Strings.SyncingMessageWithEllipsis, attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowSyncTextColor, NSFontAttributeName: UIFont.systemFont(ofSize: DynamicFontHelper.defaultHelper.DefaultStandardFontSize, weight: UIFontWeightRegular)])
 
     func startRotateSyncIcon() {
         DispatchQueue.main.async {
@@ -172,9 +172,9 @@ class SyncNowSetting: WithAccountSetting {
         switch syncStatus {
         case .bad(let message):
             guard let message = message else { return syncNowTitle }
-            return NSAttributedString(string: message, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowErrorTextColor, NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFont])
+            return NSAttributedString(string: message, attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowErrorTextColor, NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFont])
         case .warning(let message):
-            return  NSAttributedString(string: message, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowWarningTextColor, NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFont])
+            return  NSAttributedString(string: message, attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowWarningTextColor, NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFont])
         case .inProgress:
             return syncingTitle
         default:
@@ -207,7 +207,7 @@ class SyncNowSetting: WithAccountSetting {
         let troubleshootButton = UIButton(type: UIButtonType.roundedRect)
         troubleshootButton.setTitle(Strings.FirefoxSyncTroubleshootTitle, for: .normal)
         troubleshootButton.addTarget(self, action: #selector(self.troubleshoot), for: .touchUpInside)
-        troubleshootButton.tintColor = UIConstants.TableViewRowActionAccessoryColor
+        troubleshootButton.tintColor = SettingsUX.TableViewRowActionAccessoryColor
         troubleshootButton.titleLabel?.font = DynamicFontHelper.defaultHelper.DefaultSmallFont
         troubleshootButton.sizeToFit()
         return troubleshootButton
@@ -371,14 +371,14 @@ class AccountStatusSetting: WithAccountSetting {
         if let account = profile.getAccount() {
             
             if let displayName = account.fxaProfile?.displayName {
-                return NSAttributedString(string: displayName, attributes: [NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFontBold, NSForegroundColorAttributeName: UIConstants.TableViewRowSyncTextColor])
+                return NSAttributedString(string: displayName, attributes: [NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFontBold, NSForegroundColorAttributeName: SettingsUX.TableViewRowSyncTextColor])
             }
             
             if let email = account.fxaProfile?.email {
-                return NSAttributedString(string: email, attributes: [NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFontBold, NSForegroundColorAttributeName: UIConstants.TableViewRowSyncTextColor])
+                return NSAttributedString(string: email, attributes: [NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFontBold, NSForegroundColorAttributeName: SettingsUX.TableViewRowSyncTextColor])
             }
             
-            return NSAttributedString(string: account.email, attributes: [NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFontBold, NSForegroundColorAttributeName: UIConstants.TableViewRowSyncTextColor])
+            return NSAttributedString(string: account.email, attributes: [NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFontBold, NSForegroundColorAttributeName: SettingsUX.TableViewRowSyncTextColor])
         }
         return nil
     }
@@ -463,7 +463,7 @@ class RequirePasswordDebugSetting: WithAccountSetting {
     }
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Debug: require password", comment: "Debug option"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+        return NSAttributedString(string: NSLocalizedString("Debug: require password", comment: "Debug option"), attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -485,7 +485,7 @@ class RequireUpgradeDebugSetting: WithAccountSetting {
     }
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Debug: require upgrade", comment: "Debug option"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+        return NSAttributedString(string: NSLocalizedString("Debug: require upgrade", comment: "Debug option"), attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -507,7 +507,7 @@ class ForgetSyncAuthStateDebugSetting: WithAccountSetting {
     }
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Debug: forget Sync auth state", comment: "Debug option"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+        return NSAttributedString(string: NSLocalizedString("Debug: forget Sync auth state", comment: "Debug option"), attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -519,7 +519,7 @@ class ForgetSyncAuthStateDebugSetting: WithAccountSetting {
 class DeleteExportedDataSetting: HiddenSetting {
     override var title: NSAttributedString? {
         // Not localized for now.
-        return NSAttributedString(string: "Debug: delete exported databases", attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+        return NSAttributedString(string: "Debug: delete exported databases", attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -541,7 +541,7 @@ class DeleteExportedDataSetting: HiddenSetting {
 class ExportBrowserDataSetting: HiddenSetting {
     override var title: NSAttributedString? {
         // Not localized for now.
-        return NSAttributedString(string: "Debug: copy databases to app container", attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+        return NSAttributedString(string: "Debug: copy databases to app container", attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -589,7 +589,7 @@ class FeatureSwitchSetting: BoolSetting {
 class EnableBookmarkMergingSetting: HiddenSetting {
     override var title: NSAttributedString? {
         // Not localized for now.
-        return NSAttributedString(string: "Enable Bidirectional Bookmark Sync ", attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+        return NSAttributedString(string: "Enable Bidirectional Bookmark Sync ", attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -599,7 +599,7 @@ class EnableBookmarkMergingSetting: HiddenSetting {
 
 class ForceCrashSetting: HiddenSetting {
     override var title: NSAttributedString? {
-        return NSAttributedString(string: "Debug: Force Crash", attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+        return NSAttributedString(string: "Debug: Force Crash", attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -619,7 +619,7 @@ class VersionSetting: Setting {
     override var title: NSAttributedString? {
         let appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
         let buildNumber = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as! String
-        return NSAttributedString(string: String(format: NSLocalizedString("Version %@ (%@)", comment: "Version number of Firefox shown in settings"), appVersion, buildNumber), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+        return NSAttributedString(string: String(format: NSLocalizedString("Version %@ (%@)", comment: "Version number of Firefox shown in settings"), appVersion, buildNumber), attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor])
     }
 
     override func onConfigureCell(_ cell: UITableViewCell) {
@@ -640,7 +640,7 @@ class VersionSetting: Setting {
 // Opens the the license page in a new tab
 class LicenseAndAcknowledgementsSetting: Setting {
     override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Licenses", comment: "Settings item that opens a tab containing the licenses. See http://mzl.la/1NSAWCG"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+        return NSAttributedString(string: NSLocalizedString("Licenses", comment: "Settings item that opens a tab containing the licenses. See http://mzl.la/1NSAWCG"), attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor])
     }
 
     override var url: URL? {
@@ -656,7 +656,7 @@ class LicenseAndAcknowledgementsSetting: Setting {
 class YourRightsSetting: Setting {
     override var title: NSAttributedString? {
         return NSAttributedString(string: NSLocalizedString("Your Rights", comment: "Your Rights settings section title"), attributes:
-            [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+            [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor])
     }
 
     override var url: URL? {
@@ -676,7 +676,7 @@ class ShowIntroductionSetting: Setting {
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
-        super.init(title: NSAttributedString(string: NSLocalizedString("Show Tour", comment: "Show the on-boarding screen again from the settings"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]))
+        super.init(title: NSAttributedString(string: NSLocalizedString("Show Tour", comment: "Show the on-boarding screen again from the settings"), attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -690,7 +690,7 @@ class ShowIntroductionSetting: Setting {
 
 class SendFeedbackSetting: Setting {
     override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Send Feedback", comment: "Menu item in settings used to open input.mozilla.org where people can submit feedback"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+        return NSAttributedString(string: NSLocalizedString("Send Feedback", comment: "Menu item in settings used to open input.mozilla.org where people can submit feedback"), attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor])
     }
 
     override var url: URL? {
@@ -719,7 +719,7 @@ class SendAnonymousUsageDataSetting: BoolSetting {
 
     private func createStatusText() -> NSAttributedString {
         let statusText = NSMutableAttributedString()
-        statusText.append(NSAttributedString(string: Strings.SendUsageSettingMessage, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewHeaderTextColor]))
+        statusText.append(NSAttributedString(string: Strings.SendUsageSettingMessage, attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewHeaderTextColor]))
         statusText.append(NSAttributedString(string: " "))
         statusText.append(NSAttributedString(string: Strings.SendUsageSettingLink, attributes: [NSForegroundColorAttributeName: UIConstants.HighlightBlue]))
         return statusText
@@ -737,7 +737,7 @@ class SendAnonymousUsageDataSetting: BoolSetting {
 // Opens the the SUMO page in a new tab
 class OpenSupportPageSetting: Setting {
     init(delegate: SettingsDelegate?) {
-        super.init(title: NSAttributedString(string: NSLocalizedString("Help", comment: "Show the SUMO support page from the Support section in the settings. see http://mzl.la/1dmM8tZ"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]),
+        super.init(title: NSAttributedString(string: NSLocalizedString("Help", comment: "Show the SUMO support page from the Support section in the settings. see http://mzl.la/1dmM8tZ"), attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor]),
             delegate: delegate)
     }
 
@@ -764,7 +764,7 @@ class SearchSetting: Setting {
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
-        super.init(title: NSAttributedString(string: NSLocalizedString("Search", comment: "Open search section of settings"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]))
+        super.init(title: NSAttributedString(string: NSLocalizedString("Search", comment: "Open search section of settings"), attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -787,7 +787,7 @@ class SyncSetting: Setting {
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
 
-        super.init(title: NSAttributedString(string: Strings.SettingsSyncSectionName, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]))
+        super.init(title: NSAttributedString(string: Strings.SettingsSyncSectionName, attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -814,7 +814,7 @@ class LoginsSetting: Setting {
         self.settings = settings as? AppSettingsTableViewController
 
         let loginsTitle = NSLocalizedString("Logins", comment: "Label used as an item in Settings. When touched, the user will be navigated to the Logins/Password manager.")
-        super.init(title: NSAttributedString(string: loginsTitle, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]),
+        super.init(title: NSAttributedString(string: loginsTitle, attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor]),
                    delegate: delegate)
     }
 
@@ -875,7 +875,7 @@ class TouchIDPasscodeSetting: Setting {
         } else {
             title = AuthenticationStrings.passcode
         }
-        super.init(title: NSAttributedString(string: title, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]),
+        super.init(title: NSAttributedString(string: title, attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor]),
                    delegate: delegate)
     }
 
@@ -896,7 +896,7 @@ class ContentBlockerSetting: Setting {
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
         self.tabManager = settings.tabManager
-        super.init(title: NSAttributedString(string: Strings.SettingsTrackingProtectionSectionName, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]))
+        super.init(title: NSAttributedString(string: Strings.SettingsTrackingProtectionSectionName, attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -920,7 +920,7 @@ class ClearPrivateDataSetting: Setting {
         self.tabManager = settings.tabManager
 
         let clearTitle = Strings.SettingsClearPrivateDataSectionName
-        super.init(title: NSAttributedString(string: clearTitle, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]))
+        super.init(title: NSAttributedString(string: clearTitle, attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -933,7 +933,7 @@ class ClearPrivateDataSetting: Setting {
 
 class PrivacyPolicySetting: Setting {
     override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Privacy Policy", comment: "Show Firefox Browser Privacy Policy page from the Privacy section in the settings. See https://www.mozilla.org/privacy/firefox/"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+        return NSAttributedString(string: NSLocalizedString("Privacy Policy", comment: "Show Firefox Browser Privacy Policy page from the Privacy section in the settings. See https://www.mozilla.org/privacy/firefox/"), attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor])
     }
 
     override var url: URL? {
@@ -951,11 +951,11 @@ class ChinaSyncServiceSetting: WithoutAccountSetting {
     let prefKey = "useChinaSyncService"
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: "本地同步服务", attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+        return NSAttributedString(string: "本地同步服务", attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor])
     }
 
     override var status: NSAttributedString? {
-        return NSAttributedString(string: "禁用后使用全球服务同步数据", attributes: [NSForegroundColorAttributeName: UIConstants.TableViewHeaderTextColor])
+        return NSAttributedString(string: "禁用后使用全球服务同步数据", attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewHeaderTextColor])
     }
 
     override func onConfigureCell(_ cell: UITableViewCell) {
@@ -990,7 +990,7 @@ class StageSyncServiceDebugSetting: WithoutAccountSetting {
     }
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Debug: use stage servers", comment: "Debug option"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+        return NSAttributedString(string: NSLocalizedString("Debug: use stage servers", comment: "Debug option"), attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor])
     }
 
     override var status: NSAttributedString? {
@@ -1006,7 +1006,7 @@ class StageSyncServiceDebugSetting: WithoutAccountSetting {
             configurationURL = StageFirefoxAccountConfiguration().authEndpointURL
         }
 
-        return NSAttributedString(string: configurationURL.absoluteString, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewHeaderTextColor])
+        return NSAttributedString(string: configurationURL.absoluteString, attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewHeaderTextColor])
     }
 
     override func onConfigureCell(_ cell: UITableViewCell) {
@@ -1037,7 +1037,7 @@ class HomePageSetting: Setting {
         self.profile = settings.profile
         self.tabManager = settings.tabManager
 
-        super.init(title: NSAttributedString(string: Strings.SettingsHomePageSectionName, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]))
+        super.init(title: NSAttributedString(string: Strings.SettingsHomePageSectionName, attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -1058,7 +1058,7 @@ class NewTabPageSetting: Setting {
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
 
-        super.init(title: NSAttributedString(string: Strings.SettingsNewTabSectionName, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]))
+        super.init(title: NSAttributedString(string: Strings.SettingsNewTabSectionName, attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -1078,7 +1078,7 @@ class OpenWithSetting: Setting {
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
 
-        super.init(title: NSAttributedString(string: Strings.SettingsOpenWithSectionName, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]))
+        super.init(title: NSAttributedString(string: Strings.SettingsOpenWithSectionName, attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -1095,7 +1095,7 @@ class AdvanceAccountSetting: HiddenSetting {
     override var accessibilityIdentifier: String? { return "AdvanceAccount.Setting" }
     
     override var title: NSAttributedString? {
-        return NSAttributedString(string: Strings.SettingsAdvanceAccountTitle, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+        return NSAttributedString(string: Strings.SettingsAdvanceAccountTitle, attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor])
     }
     
     override init(settings: SettingsTableViewController) {

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -53,9 +53,9 @@ class ClearPrivateDataTableViewController: UITableViewController {
 
         tableView.register(SettingsTableSectionHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: SectionHeaderFooterIdentifier)
 
-        tableView.separatorColor = UIConstants.TableViewSeparatorColor
-        tableView.backgroundColor = UIConstants.TableViewHeaderBackgroundColor
-        let footer = SettingsTableSectionHeaderFooterView(frame: CGRect(x: 0, y: 0, width: tableView.bounds.width, height: UIConstants.TableViewHeaderFooterHeight))
+        tableView.separatorColor = SettingsUX.TableViewSeparatorColor
+        tableView.backgroundColor = SettingsUX.TableViewHeaderBackgroundColor
+        let footer = SettingsTableSectionHeaderFooterView(frame: CGRect(x: 0, y: 0, width: tableView.bounds.width, height: SettingsUX.TableViewHeaderFooterHeight))
         footer.showBottomBorder = false
         tableView.tableFooterView = footer
     }
@@ -164,7 +164,7 @@ class ClearPrivateDataTableViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return UIConstants.TableViewHeaderFooterHeight
+        return SettingsUX.TableViewHeaderFooterHeight
     }
 
     @objc func switchValueChanged(_ toggle: UISwitch) {

--- a/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -241,7 +241,7 @@ class CustomSearchEngineTextView: Setting, UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
         placeholderLabel.isHidden = textField.text != ""
         settingDidChange?(textView.text)
-        let color = isValid(textField.text) ? UIConstants.TableViewRowTextColor : UIConstants.DestructiveRed
+        let color = isValid(textField.text) ? SettingsUX.TableViewRowTextColor : UIConstants.DestructiveRed
         textField.textColor = color
     }
 

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -90,8 +90,8 @@ class LoginDetailViewController: SensitiveViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        tableView.separatorColor = UIConstants.TableViewSeparatorColor
-        tableView.backgroundColor = UIConstants.TableViewHeaderBackgroundColor
+        tableView.separatorColor = SettingsUX.TableViewSeparatorColor
+        tableView.backgroundColor = SettingsUX.TableViewHeaderBackgroundColor
         tableView.accessibilityIdentifier = "Login Detail List"
         tableView.delegate = self
         tableView.dataSource = self
@@ -101,7 +101,7 @@ class LoginDetailViewController: SensitiveViewController {
 
         // Add a line on top of the table view so when the user pulls down it looks 'correct'.
         let topLine = UIView(frame: CGRect(origin: CGPoint.zero, size: CGSize(width: tableView.frame.width, height: 0.5)))
-        topLine.backgroundColor = UIConstants.TableViewSeparatorColor
+        topLine.backgroundColor = SettingsUX.TableViewSeparatorColor
         tableView.tableHeaderView = topLine
 
         // Normally UITableViewControllers handle responding to content inset changes from keyboard events when editing

--- a/Client/Frontend/Settings/NewTabChoiceViewController.swift
+++ b/Client/Frontend/Settings/NewTabChoiceViewController.swift
@@ -33,9 +33,9 @@ class NewTabChoiceViewController: UITableViewController {
         tableView.accessibilityIdentifier = "NewTabPage.Setting.Options"
 
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: BasicCheckmarkCell)
-        tableView.backgroundColor = UIConstants.TableViewHeaderBackgroundColor
+        tableView.backgroundColor = SettingsUX.TableViewHeaderBackgroundColor
 
-        let headerFooterFrame = CGRect(origin: CGPoint.zero, size: CGSize(width: self.view.frame.width, height: UIConstants.TableViewHeaderFooterHeight))
+        let headerFooterFrame = CGRect(origin: CGPoint.zero, size: CGSize(width: self.view.frame.width, height: SettingsUX.TableViewHeaderFooterHeight))
         let headerView = SettingsTableSectionHeaderFooterView(frame: headerFooterFrame)
         headerView.showTopBorder = false
         headerView.showBottomBorder = true

--- a/Client/Frontend/Settings/NewTabContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/NewTabContentSettingsViewController.swift
@@ -16,7 +16,7 @@ class CurrentTabSetting: Setting {
 
     init(profile: Profile) {
         self.profile = profile
-        super.init(title: NSAttributedString(string: NewTabAccessors.getNewTabPage(profile.prefs).settingTitle, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]))
+        super.init(title: NSAttributedString(string: NewTabAccessors.getNewTabPage(profile.prefs).settingTitle, attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -56,8 +56,8 @@ class SearchSettingsTableViewController: UITableViewController {
         footer.showBottomBorder = false
         tableView.tableFooterView = footer
 
-        tableView.separatorColor = UIConstants.TableViewSeparatorColor
-        tableView.backgroundColor = UIConstants.TableViewHeaderBackgroundColor
+        tableView.separatorColor = SettingsUX.TableViewSeparatorColor
+        tableView.backgroundColor = SettingsUX.TableViewHeaderBackgroundColor
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: Strings.SettingsSearchEditButton, style: .plain, target: self,
                                                                  action: #selector(SearchSettingsTableViewController.beginEditing))

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -6,6 +6,19 @@ import Account
 import Shared
 import UIKit
 
+struct SettingsUX {
+    static let TableViewHeaderBackgroundColor = UIConstants.AppBackgroundColor
+    static let TableViewHeaderTextColor = UIColor.Defaults.Grey50
+    static let TableViewRowTextColor = UIColor.Defaults.Grey90
+    static let TableViewDisabledRowTextColor = UIColor.lightGray
+    static let TableViewSeparatorColor = UIColor(rgb: 0xD1D1D4)
+    static let TableViewHeaderFooterHeight = CGFloat(44)
+    static let TableViewRowErrorTextColor = UIColor(red: 255/255, green: 0/255, blue: 26/255, alpha: 1.0)
+    static let TableViewRowWarningTextColor = UIColor(red: 245/255, green: 166/255, blue: 35/255, alpha: 1.0)
+    static let TableViewRowActionAccessoryColor = UIColor(red: 0.29, green: 0.56, blue: 0.89, alpha: 1.0)
+    static let TableViewRowSyncTextColor = UIColor(red: 51/255, green: 51/255, blue: 51/255, alpha: 1.0)
+}
+
 // A base setting class that shows a title. You probably want to subclass this, not use it directly.
 class Setting: NSObject {
     fileprivate var _title: NSAttributedString?
@@ -159,9 +172,9 @@ class BoolSetting: Setting {
     convenience init(prefs: Prefs, prefKey: String? = nil, defaultValue: Bool, titleText: String, statusText: String? = nil, settingDidChange: ((Bool) -> Void)? = nil) {
         var statusTextAttributedString: NSAttributedString?
         if let statusTextString = statusText {
-            statusTextAttributedString = NSAttributedString(string: statusTextString, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewHeaderTextColor])
+            statusTextAttributedString = NSAttributedString(string: statusTextString, attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewHeaderTextColor])
         }
-        self.init(prefs: prefs, prefKey: prefKey, defaultValue: defaultValue, attributedTitleText: NSAttributedString(string: titleText, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]), attributedStatusText: statusTextAttributedString, settingDidChange: settingDidChange)
+        self.init(prefs: prefs, prefKey: prefKey, defaultValue: defaultValue, attributedTitleText: NSAttributedString(string: titleText, attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor]), attributedStatusText: statusTextAttributedString, settingDidChange: settingDidChange)
     }
 
     override var status: NSAttributedString? {
@@ -279,7 +292,7 @@ class StringSetting: Setting, UITextFieldDelegate {
     }
 
     @objc func textFieldDidChange(_ textField: UITextField) {
-        let color = isValid(textField.text) ? UIConstants.TableViewRowTextColor : UIConstants.DestructiveRed
+        let color = isValid(textField.text) ? SettingsUX.TableViewRowTextColor : UIConstants.DestructiveRed
         textField.textColor = color
     }
 
@@ -357,7 +370,7 @@ class ButtonSetting: Setting {
         if isEnabled?() ?? true {
             cell.textLabel?.textColor = destructive ? UIConstants.DestructiveRed : UIConstants.HighlightBlue
         } else {
-            cell.textLabel?.textColor = UIConstants.TableViewDisabledRowTextColor
+            cell.textLabel?.textColor = SettingsUX.TableViewDisabledRowTextColor
         }
         cell.textLabel?.textAlignment = NSTextAlignment.center
         cell.accessibilityTraits = UIAccessibilityTraitButton
@@ -462,8 +475,8 @@ class SettingsTableViewController: UITableViewController {
         
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: Identifier)
         tableView.register(SettingsTableSectionHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: SectionHeaderIdentifier)
-        tableView.separatorColor = UIConstants.TableViewSeparatorColor
-        tableView.backgroundColor = UIConstants.TableViewHeaderBackgroundColor
+        tableView.separatorColor = SettingsUX.TableViewSeparatorColor
+        tableView.backgroundColor = SettingsUX.TableViewHeaderBackgroundColor
         tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: 30))
         tableView.estimatedRowHeight = 44
         tableView.estimatedSectionHeaderHeight = 44
@@ -632,7 +645,7 @@ class SettingsTableViewController: UITableViewController {
     }
 }
 
-struct SettingsTableSectionHeaderFooterViewUX {
+private struct SettingsTableSectionHeaderFooterViewUX {
     static let titleHorizontalPadding: CGFloat = 15
     static let titleVerticalPadding: CGFloat = 6
     static let titleVerticalLongPadding: CGFloat = 20
@@ -665,7 +678,7 @@ class SettingsTableSectionHeaderFooterView: UITableViewHeaderFooterView {
 
     lazy var titleLabel: UILabel = {
         var headerLabel = UILabel()
-        headerLabel.textColor = UIConstants.TableViewHeaderTextColor
+        headerLabel.textColor = SettingsUX.TableViewHeaderTextColor
         headerLabel.font = UIFont.systemFont(ofSize: 12.0, weight: UIFontWeightRegular)
         headerLabel.numberOfLines = 0
         return headerLabel
@@ -685,7 +698,7 @@ class SettingsTableSectionHeaderFooterView: UITableViewHeaderFooterView {
 
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
-        contentView.backgroundColor = UIConstants.TableViewHeaderBackgroundColor
+        contentView.backgroundColor = SettingsUX.TableViewHeaderBackgroundColor
         addSubview(titleLabel)
         addSubview(topBorder)
         addSubview(bottomBorder)

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -16,6 +16,11 @@ private func applicationBundle() -> Bundle {
     return Bundle(url: applicationBundleURL) ?? bundle
 }
 
+extension Strings {
+    public static let OKString = NSLocalizedString("OK", comment: "OK button")
+    public static let CancelString = NSLocalizedString("Cancel", comment: "Label for Cancel button")
+}
+
 // SendTo extension.
 extension Strings {
     public static let SendToCancelButton = NSLocalizedString("SendTo.Cancel.Button", bundle: applicationBundle(), value: "Cancel", comment: "Button title for cancelling SendTo screen")

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -7,50 +7,125 @@ import Shared
 
 // A browser color represents the color of UI in both Private browsing mode and normal mode
 struct BrowserColor {
-    let normalColor: Int
-    let PBMColor: Int
-    init(normal: Int, pbm: Int) {
+    let normalColor: UIColor
+    let PBMColor: UIColor
+    init(normal: UIColor, pbm: UIColor) {
         self.normalColor = normal
         self.PBMColor = pbm
     }
+
+    init(normal: Int, pbm: Int) {
+        self.normalColor = UIColor(rgb: normal)
+        self.PBMColor = UIColor(rgb: pbm)
+    }
+
     func color(isPBM: Bool) -> UIColor {
-        return UIColor(rgb: isPBM ? PBMColor : normalColor)
+        return isPBM ? PBMColor : normalColor
+    }
+
+    func colorFor(_ theme: Theme) -> UIColor {
+        return color(isPBM: theme == .Private)
+    }
+}
+
+extension UIColor {
+    // These are defaults from http://design.firefox.com/photon/visuals/color.html
+    struct Defaults {
+        static let Grey10 = UIColor(rgb: 0xf9f9fa)
+        static let Grey30 = UIColor(rgb: 0xd7d7db)
+        static let Grey40 = UIColor(rgb: 0xb1b1b3)
+        static let Grey50 = UIColor(rgb: 0x737373)
+        static let Grey60 = UIColor(rgb: 0x4a4a4f)
+        static let Grey70 = UIColor(rgb: 0x38383d)
+        static let Grey80 = UIColor(rgb: 0x272727) // Grey80 is actually #2a2a2e
+        static let Grey90 = UIColor(rgb: 0x0c0c0d)
+        static let Blue40 = UIColor(rgb: 0x45a1ff)
+        static let Blue50 = UIColor(rgb: 0x0a84ff)
+        static let Blue60 = UIColor(rgb: 0x0066DC) // Blue60 is actually #0060df
+        static let Purple50 = UIColor(rgb: 0x9400ff)
+        static let Magenta50 = UIColor(rgb: 0xff1ad9)
+        static let Red50 = UIColor(rgb: 0xff0039)
+        static let LockGreen = UIColor(rgb: 0x16DA00)
+
+        // Non-Photon design system colors. These are not in the design doc yet.
+        static let MobileGreyA = UIColor(rgb: 0xD2D2D4)
+        static let MobileGreyC = UIColor(rgb: 0xE4E4E4)
+        static let MobileGreyD = UIColor(rgb: 0x414146)
+        static let MobileGreyE = UIColor(rgb: 0x2D2D31)
+        static let MobileGreyF = UIColor(rgb: 0x636369)
+        static let MobileGreyH = UIColor(rgb: 0xADADb0)
+        static let MobileGreyI = UIColor(rgb: 0x3f3f43)
+        static let MobileGreyJ = UIColor(rgb: 0xE5E5E5)
+        static let MobileBlueA = UIColor(rgb: 0xB0D5FB)
+        static let MobileBlueB = UIColor(rgb: 0x00dcfc)
+        static let MobileBlueC = UIColor(rgb: 0xccdded)
+        static let MobileBlueD = UIColor(rgb: 0x00A2FE)
+        static let MobilePurple = UIColor(rgb: 0x7878a5)
+        static let MobilePurpleB = UIColor(rgb: 0xAC39FF)
+        static let MobilePrivatePurple = UIColor(rgb: 0xcf68ff)
+    }
+
+    struct Browser {
+        static let Background = BrowserColor(normal: Defaults.Grey10, pbm: Defaults.Grey70)
+        static let Text = BrowserColor(normal: .white, pbm: Defaults.MobileGreyD)
+        static let URLBarDivider = BrowserColor(normal: Defaults.MobileGreyC, pbm: Defaults.MobileGreyD)
+        static let LocationBarBackground = Defaults.Grey30
+        static let Tint = BrowserColor(normal: Defaults.Grey80, pbm: Defaults.MobileGreyA)
+    }
+
+    struct URLBar {
+        static let Border = BrowserColor(normal: Defaults.Grey50, pbm: Defaults.MobileGreyE)
+        static let ActiveBorder = BrowserColor(normal: Defaults.MobileBlueA, pbm: Defaults.Grey60)
+        static let Tint = BrowserColor(normal: Defaults.MobileBlueB, pbm: Defaults.Grey10)
+    }
+
+    struct TextField {
+        static let Background = BrowserColor(normal: .white, pbm: Defaults.MobileGreyF)
+        static let TextAndTint = BrowserColor(normal: Defaults.Grey80, pbm: .white)
+        static let Highlight = BrowserColor(normal: Defaults.MobileBlueC, pbm: Defaults.MobilePurple)
+        static let ReaderModeButtonSelected = BrowserColor(normal: Defaults.MobileBlueD, pbm: Defaults.MobilePrivatePurple)
+        static let ReaderModeButtonUnselected = BrowserColor(normal: Defaults.Grey50, pbm: Defaults.MobileGreyH)
+        static let PageOptionsSelected = ReaderModeButtonSelected
+        static let PageOptionsUnselected = UIColor.Browser.Tint
+        static let Separator = BrowserColor(normal: Defaults.MobileGreyJ, pbm: Defaults.MobileGreyI)
+    }
+
+    // The back/forward/refresh/menu button (bottom toolbar)
+    struct ToolbarButton {
+        static let SelectedTint = BrowserColor(normal: Defaults.MobileBlueD, pbm: Defaults.MobilePurpleB)
+        static let DisabledTint = BrowserColor(normal: UIColor.lightGray, pbm: UIColor.gray)
+    }
+
+    struct LoadingBar {
+        static let Start = BrowserColor(normal: Defaults.MobileBlueB, pbm: Defaults.Purple50)
+        static let End = BrowserColor(normal: Defaults.Blue50, pbm: Defaults.Magenta50)
+    }
+
+    struct TabTray {
+        static let Background = Browser.Background
+    }
+
+    struct TopTabs {
+        static let PrivateModeTint = BrowserColor(normal: Defaults.Grey10, pbm: Defaults.Grey40)
+        static let Background = UIColor.Defaults.Grey80
+    }
+
+    struct HomePanel {
+        // These values are the same for both private/normal.
+        // The homepanel toolbar needed to be able to theme, not anymore.
+        // Keep this just in case someone decides they want it to theme again
+        static let ToolbarBackground = BrowserColor(normal: Defaults.Grey10, pbm: Defaults.Grey10)
+        static let ToolbarHighlight = BrowserColor(normal: Defaults.Blue50, pbm: Defaults.Blue50)
+        static let ToolbarTint = BrowserColor(normal: Defaults.Grey50, pbm: Defaults.Grey50)
     }
 }
 
 public struct UIConstants {
     static let AboutHomePage = URL(string: "\(WebServer.sharedInstance.base)/about/home/")!
 
-    // Photon Colors. Remove old colors once we've completly transitioned
-    static let BrowserUI = BrowserColor(normal: 0xf9f9fa, pbm: 0x38383D)
-    static let TextColor = BrowserColor(normal: 0xffffff, pbm: 0x414146)
-    static let URLBarDivider = BrowserColor(normal: 0xE4E4E4, pbm: 0x414146)
-    static let TabTrayBG = UIColor(rgb: 0x272727)
-    static let locationBarBG = UIColor(rgb: 0xD7D7DB)
-    static let LoadingStartColor = BrowserColor(normal: 0x00DCFC, pbm: 0x9400ff)
-    static let LoadingEndColor = BrowserColor(normal: 0x0A84FF, pbm: 0xff1ad9)
-
-    //Photon UI sizes
+    static let DefaultPadding: CGFloat = 10
+    static let SnackbarButtonHeight: CGFloat = 48
     static let TopToolbarHeight: CGFloat = 56
-    // The loading bar starts with one color and then animates to the second one
-    static let LoadingBarStart = BrowserColor(normal: 0x00DCFC, pbm: 0x9f00ff)
-    static let LoadingBarEnd = BrowserColor(normal: 0x0A84FF, pbm: 0xff1ad9)
-
-    static let TextSelectionBG = UIColor(rgb: 0xE4E4E4)
-
-    static let TopTabsBG = TabTrayBG
-
-    static let AppBackgroundColor = UIColor(rgb: 0xf9f9fa)
-    static let SystemBlueColor = UIColor(rgb: 0x0297F8)
-    static let PrivateModePurple = UIColor(red: 207 / 255, green: 104 / 255, blue: 255 / 255, alpha: 1)
-    static let PrivateModeLocationBackgroundColor = UIColor(red: 31 / 255, green: 31 / 255, blue: 31 / 255, alpha: 1)
-    static let PrivateModeLocationBorderColor = UIColor(red: 255, green: 255, blue: 255, alpha: 0.15)
-    static let PrivateModeActionButtonTintColor = UIColor(red: 255, green: 255, blue: 255, alpha: 0.8)
-    static let PrivateModeTextHighlightColor = UIColor(red: 207 / 255, green: 104 / 255, blue: 255 / 255, alpha: 1)
-    static let PrivateModeInputHighlightColor = UIColor(red: 120 / 255, green: 120 / 255, blue: 165 / 255, alpha: 1)
-    static let PrivateModeAssistantToolbarBackgroundColor = UIColor(red: 89 / 255, green: 89 / 255, blue: 89 / 255, alpha: 1)
-    static let PrivateModeToolbarTintColor = UIColor(red: 74 / 255, green: 74 / 255, blue: 74 / 255, alpha: 1)
-
     static var ToolbarHeight: CGFloat = 46
     static var BottomToolbarHeight: CGFloat {
         get {
@@ -63,65 +138,34 @@ public struct UIConstants {
             return ToolbarHeight + bottomInset
         }
     }
-    static let DefaultRowHeight: CGFloat = 58
-    static let DefaultPadding: CGFloat = 10
-    static let SnackbarButtonHeight: CGFloat = 48
+
+    static let AppBackgroundColor = UIColor.Defaults.Grey10
+    static let SystemBlueColor = UIColor.Defaults.Blue50
+    static let ControlTintColor = UIColor.Defaults.Blue50
+    static let PasscodeDotColor = UIColor.Defaults.Grey60
+    static let PrivateModeAssistantToolbarBackgroundColor = UIColor.Defaults.Grey50
+    static let PrivateModeTextHighlightColor = UIColor.Defaults.Purple50
+    static let PrivateModePurple = UIColor.Defaults.MobilePrivatePurple
 
     // Static fonts
     static let DefaultChromeSize: CGFloat = 16
     static let DefaultChromeSmallSize: CGFloat = 11
     static let PasscodeEntryFontSize: CGFloat = 36
     static let DefaultChromeFont: UIFont = UIFont.systemFont(ofSize: DefaultChromeSize, weight: UIFontWeightRegular)
-    static let DefaultChromeBoldFont = UIFont.systemFont(ofSize: DefaultChromeSize, weight: UIFontWeightHeavy)
     static let DefaultChromeSmallFontBold = UIFont.boldSystemFont(ofSize: DefaultChromeSmallSize)
     static let PasscodeEntryFont = UIFont.systemFont(ofSize: PasscodeEntryFontSize, weight: UIFontWeightBold)
 
-    // These highlight colors are currently only used on Snackbar buttons when they're pressed
-    static let HighlightColor = UIColor(red: 205/255, green: 223/255, blue: 243/255, alpha: 0.9)
-    static let HighlightText = UIColor(red: 42/255, green: 121/255, blue: 213/255, alpha: 1.0)
-
     static let PanelBackgroundColor = UIColor.white
-    static let SeparatorColor = UIColor(rgb: 0xcccccc)
-    static let HighlightBlue = UIColor(red: 76/255, green: 158/255, blue: 255/255, alpha: 1)
-    static let DestructiveRed = UIColor(red: 255/255, green: 64/255, blue: 0/255, alpha: 1.0)
+    static let SeparatorColor = UIColor.Defaults.Grey30
+    static let HighlightBlue = UIColor.Defaults.Blue50
+    static let DestructiveRed = UIColor.Defaults.Red50
     static let BorderColor = UIColor.darkGray
     static let BackgroundColor = AppBackgroundColor
 
-    // These colours are used on the Menu
-    static let MenuToolbarBackgroundColorNormal = AppBackgroundColor
-    static let MenuToolbarBackgroundColorPrivate = UIColor(red: 74/255, green: 74/255, blue: 74/255, alpha: 1.0)
-    static let MenuToolbarTintColorNormal = BackgroundColor
-    static let MenuToolbarTintColorPrivate = UIColor.white
-    static let MenuBackgroundColorNormal = UIColor(red: 223/255, green: 223/255, blue: 223/255, alpha: 1.0)
-    static let MenuBackgroundColorPrivate = UIColor(red: 59/255, green: 59/255, blue: 59/255, alpha: 1.0)
-    static let MenuSelectedItemTintColor = UIColor(red: 0.30, green: 0.62, blue: 1.0, alpha: 1.0)
-    static let MenuDisabledItemTintColor = UIColor.lightGray
-
-    // settings
-    static let TableViewHeaderBackgroundColor = AppBackgroundColor
-    static let TableViewHeaderTextColor = UIColor(rgb: 0x737373)
-    static let TableViewRowTextColor = UIColor(rgb: 0x0c0c0d)
-    static let TableViewDisabledRowTextColor = UIColor.lightGray
-    static let TableViewSeparatorColor = UIColor(rgb: 0xD1D1D4)
-    static let TableViewHeaderFooterHeight = CGFloat(44)
-    static let TableViewRowErrorTextColor = UIColor(red: 255/255, green: 0/255, blue: 26/255, alpha: 1.0)
-    static let TableViewRowWarningTextColor = UIColor(red: 245/255, green: 166/255, blue: 35/255, alpha: 1.0)
-    static let TableViewRowActionAccessoryColor = UIColor(red: 0.29, green: 0.56, blue: 0.89, alpha: 1.0)
-    static let TableViewRowSyncTextColor = UIColor(red: 51/255, green: 51/255, blue: 51/255, alpha: 1.0)
-    
-    // Firefox Orange
-    static let ControlTintColor = SystemBlueColor
-
-    // List of Default colors to use for Favicon backgrounds
+    // Used as backgrounds for favicons
     static let DefaultColorStrings = ["2e761a", "399320", "40a624", "57bd35", "70cf5b", "90e07f", "b1eea5", "881606", "aa1b08", "c21f09", "d92215", "ee4b36", "f67964", "ffa792", "025295", "0568ba", "0675d3", "0996f8", "2ea3ff", "61b4ff", "95cdff", "00736f", "01908b", "01a39d", "01bdad", "27d9d2", "58e7e6", "89f4f5", "c84510", "e35b0f", "f77100", "ff9216", "ffad2e", "ffc446", "ffdf81", "911a2e", "b7223b", "cf2743", "ea385e", "fa526e", "ff7a8d", "ffa7b3" ]
-
-    // Passcode dot gray
-    static let PasscodeDotColor = UIColor(rgb: 0x4A4A4A)
 
     /// JPEG compression quality for persisted screenshots. Must be between 0-1.
     static let ScreenshotQuality: Float = 0.3
     static let ActiveScreenshotQuality: CGFloat = 0.5
-
-    static let OKString = NSLocalizedString("OK", comment: "OK button")
-    static let CancelString = NSLocalizedString("Cancel", comment: "Label for Cancel button")
 }

--- a/Client/Frontend/Widgets/ActivityStreamHighlightCell.swift
+++ b/Client/Frontend/Widgets/ActivityStreamHighlightCell.swift
@@ -6,7 +6,7 @@ import UIKit
 import Shared
 import Storage
 
-struct ActivityStreamHighlightCellUX {
+private struct ActivityStreamHighlightCellUX {
     static let LabelColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.black : UIColor(rgb: 0x353535)
     static let BorderWidth: CGFloat = 0.5
     static let CellSideOffset = 20
@@ -15,7 +15,7 @@ struct ActivityStreamHighlightCellUX {
     static let SiteImageViewSize: CGSize = UIDevice.current.userInterfaceIdiom == .pad ? CGSize(width: 99, height: 120) : CGSize(width: 99, height: 90)
     static let StatusIconSize = 12
     static let FaviconSize = CGSize(width: 45, height: 45)
-    static let DescriptionLabelColor = UIColor(rgb: 0x919191)
+    static let DescriptionLabelColor = UIColor(rgb: 0x919191) //random color
     static let SelectedOverlayColor = UIColor(white: 0.0, alpha: 0.25)
     static let CornerRadius: CGFloat = 3
     static let BorderColor = UIColor(white: 0, alpha: 0.1)
@@ -185,7 +185,7 @@ class ActivityStreamHighlightCell: UICollectionViewCell {
     }
 }
 
-struct HighlightIntroCellUX {
+private struct HighlightIntroCellUX {
     static let margin: CGFloat = 20
     static let foxImageWidth: CGFloat = 168
 }

--- a/Client/Frontend/Widgets/ActivityStreamHighlightCell.swift
+++ b/Client/Frontend/Widgets/ActivityStreamHighlightCell.swift
@@ -15,7 +15,7 @@ private struct ActivityStreamHighlightCellUX {
     static let SiteImageViewSize: CGSize = UIDevice.current.userInterfaceIdiom == .pad ? CGSize(width: 99, height: 120) : CGSize(width: 99, height: 90)
     static let StatusIconSize = 12
     static let FaviconSize = CGSize(width: 45, height: 45)
-    static let DescriptionLabelColor = UIColor(rgb: 0x919191) //random color
+    static let DescriptionLabelColor = UIColor(rgb: 0x919191) // Not found in Photon colors
     static let SelectedOverlayColor = UIColor(white: 0.0, alpha: 0.25)
     static let CornerRadius: CGFloat = 3
     static let BorderColor = UIColor(white: 0, alpha: 0.1)

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -16,8 +16,8 @@ protocol AutocompleteTextFieldDelegate: class {
     func autocompleteTextFieldDidBeginEditing(_ autocompleteTextField: AutocompleteTextField)
 }
 
-struct AutocompleteTextFieldUX {
-    static let HighlightColor = UIColor(rgb: 0xccdded)
+private struct AutocompleteTextFieldUX {
+       static let HighlightColor = UIColor(rgb: 0xccdded)
 }
 
 class AutocompleteTextField: UITextField, UITextFieldDelegate {

--- a/Client/Frontend/Widgets/LoginTableViewCell.swift
+++ b/Client/Frontend/Widgets/LoginTableViewCell.swift
@@ -16,7 +16,7 @@ protocol LoginTableViewCellDelegate: class {
 private struct LoginTableViewCellUX {
     static let highlightedLabelFont = UIFont.systemFont(ofSize: 12)
     static let highlightedLabelTextColor = UIConstants.SystemBlueColor
-    static let highlightedLabelEditingTextColor = UIConstants.TableViewHeaderTextColor
+    static let highlightedLabelEditingTextColor = SettingsUX.TableViewHeaderTextColor
 
     static let descriptionLabelFont = UIFont.systemFont(ofSize: 16)
     static let descriptionLabelTextColor = UIColor.black

--- a/Client/Frontend/Widgets/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet.swift
@@ -13,8 +13,7 @@ private struct PhotonActionSheetUX {
     static let SectionVerticalPadding: CGFloat = 13
     static let HeaderHeight: CGFloat = 80
     static let RowHeight: CGFloat = 44
-    static let LabelColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.black : UIColor(rgb: 0x353535)
-    static let DescriptionLabelColor = UIColor(rgb: 0x919191)
+    static let LabelColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.black : UIColor.Defaults.Grey70
     static let PlaceholderImage = UIImage(named: "defaultTopSiteIcon")
     static let BorderWidth: CGFloat = 0.5
     static let BorderColor = UIColor(white: 0, alpha: 0.1)
@@ -55,7 +54,7 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
         return self.style == .bottom && self.modalPresentationStyle != .popover
     }()
     var tableView = UITableView(frame: CGRect.zero, style: .grouped)
-    private var tintColor = UIColor(rgb: 0x272727)
+    private var tintColor = UIColor.Defaults.Grey80
     private var outerScrollView = UIScrollView()
     
     lazy var tapRecognizer: UITapGestureRecognizer = {

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -9,8 +9,8 @@ struct SiteTableViewControllerUX {
     static let HeaderHeight = CGFloat(32)
     static let RowHeight = CGFloat(44)
     static let HeaderBorderColor = UIColor(rgb: 0xCFD5D9).withAlphaComponent(0.8)
-    static let HeaderTextColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.black : UIColor(rgb: 0x232323)
-    static let HeaderBackgroundColor = UIColor(rgb: 0xf7f8f7)
+    static let HeaderTextColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.black : UIColor.Defaults.Grey80
+    static let HeaderBackgroundColor = UIColor.Defaults.Grey10
     static let HeaderFont = UIFont.systemFont(ofSize: 12, weight: UIFontWeightMedium)
     static let HeaderTextMargin = CGFloat(16)
 }

--- a/Client/Frontend/Widgets/SnackBar.swift
+++ b/Client/Frontend/Widgets/SnackBar.swift
@@ -8,6 +8,8 @@ import Shared
 
 class SnackBarUX {
     static var MaxWidth: CGFloat = 400
+    static let HighlightColor = UIColor(red: 205/255, green: 223/255, blue: 243/255, alpha: 0.9)
+    static let HighlightText = UIColor(red: 42/255, green: 121/255, blue: 213/255, alpha: 1.0)
 }
 
 /**
@@ -26,7 +28,7 @@ class SnackButton: UIButton {
      */
     lazy var highlightImg: UIImage = {
         let size = CGSize(width: 1, height: 1)
-        return UIImage.createWithColor(size, color: UIConstants.HighlightColor)
+        return UIImage.createWithColor(size, color: SnackBarUX.HighlightColor)
     }()
 
     init(title: String, accessibilityIdentifier: String, callback: @escaping (_ bar: SnackBar) -> Void) {
@@ -37,7 +39,7 @@ class SnackButton: UIButton {
         setTitle(title, for: UIControlState())
         titleLabel?.font = DynamicFontHelper.defaultHelper.DefaultMediumFont
         setBackgroundImage(highlightImg, for: .highlighted)
-        setTitleColor(UIConstants.HighlightText, for: .highlighted)
+        setTitleColor(SnackBarUX.HighlightText, for: .highlighted)
 
         addTarget(self, action: #selector(SnackButton.onClick), for: .touchUpInside)
 
@@ -282,15 +284,15 @@ class TimerSnackBar: SnackBar {
     }
 
     static func showAppStoreConfirmationBar(forTab tab: Tab, appStoreURL: URL) {
-        let msg =  NSAttributedString(string: Strings.ExternalLinkAppStoreConfirmationTitle, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+        let msg =  NSAttributedString(string: Strings.ExternalLinkAppStoreConfirmationTitle, attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor])
         let bar = TimerSnackBar(attrText: msg,
                              img: UIImage(named: "defaultFavicon"),
                              buttons: [
-                                SnackButton(title: UIConstants.OKString, accessibilityIdentifier: "ConfirmOpenInAppStore", callback: { bar in
+                                SnackButton(title: Strings.OKString, accessibilityIdentifier: "ConfirmOpenInAppStore", callback: { bar in
                                     tab.removeSnackbar(bar)
                                     UIApplication.shared.open(appStoreURL, options: [:])
                                 }),
-                                SnackButton(title: UIConstants.CancelString, accessibilityIdentifier: "CancelOpenInAppStore", callback: { bar in
+                                SnackButton(title: Strings.CancelString, accessibilityIdentifier: "CancelOpenInAppStore", callback: { bar in
                                     tab.removeSnackbar(bar)
                                 })
             ])

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -5,41 +5,13 @@
 import Foundation
 import SnapKit
 import Shared
-import XCGLogger
 
-private let log = Logger.browserLogger
-
-struct TabsButtonUX {
-    static let TitleColor: UIColor = UIColor(rgb: 0x272727)
+private struct TabsButtonUX {
+    static let TitleColor: UIColor = UIColor.Defaults.Grey80
     static let TitleBackgroundColor: UIColor = UIColor.white
     static let CornerRadius: CGFloat = 2
     static let TitleFont: UIFont = UIConstants.DefaultChromeSmallFontBold
     static let BorderStrokeWidth: CGFloat = 3
-    static let BorderColor: UIColor = UIColor.darkGray
-    static let TitleInsets = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
-
-    static let Themes: [String: Theme] = {
-        var themes = [String: Theme]()
-        var theme = Theme()
-        theme.borderColor = UIColor(rgb: 0xD2D2D4)
-        theme.backgroundColor = UIColor(rgb: 0x38383D)
-        theme.textColor = UIColor(rgb: 0xD2D2D4)
-        theme.highlightButtonColor = UIConstants.PrivateModePurple
-        theme.highlightTextColor = TabsButtonUX.TitleColor
-        theme.highlightBorderColor = UIConstants.PrivateModePurple
-        themes[Theme.PrivateMode] = theme
-
-        theme = Theme()
-        theme.borderColor = UIColor(rgb: 0x272727)
-        theme.backgroundColor = UIConstants.AppBackgroundColor
-        theme.textColor = UIColor(rgb: 0x272727)
-        theme.highlightButtonColor = TabsButtonUX.TitleColor
-        theme.highlightTextColor = TabsButtonUX.TitleBackgroundColor
-        theme.highlightBorderColor = TabsButtonUX.TitleColor
-        themes[Theme.NormalMode] = theme
-
-        return themes
-    }()
 }
 
 class TabsButton: UIButton {
@@ -239,17 +211,12 @@ class TabsButton: UIButton {
 }
 
 extension TabsButton: Themeable {
-    func applyTheme(_ themeName: String) {
-        guard let theme = TabsButtonUX.Themes[themeName] else {
-            fatalError("Theme not found")
-        }
-        titleBackgroundColor = theme.backgroundColor!
-        textColor = theme.textColor!
-
-        countLabel.textColor = textColor
-        borderView.color = textColor
-        labelBackground.backgroundColor = titleBackgroundColor
-
+    func applyTheme(_ theme: Theme) {
+        titleBackgroundColor = UIColor.Browser.Background.colorFor(theme)
+        textColor = UIColor.Browser.Tint.colorFor(theme)
+        countLabel.textColor = UIColor.Browser.Tint.colorFor(theme)
+        borderView.color = UIColor.Browser.Tint.colorFor(theme)
+        labelBackground.backgroundColor = UIColor.Browser.Background.colorFor(theme)
     }
 }
 

--- a/Client/Frontend/Widgets/Theme.swift
+++ b/Client/Frontend/Widgets/Theme.swift
@@ -3,21 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import Foundation
 
-struct Theme {
-    var URLFontColor: UIColor?
-    var hostFontColor: UIColor?
-    var backgroundColor: UIColor?
-    var textColor: UIColor?
-    var highlightColor: UIColor?
-    var tintColor: UIColor?
-    var buttonTintColor: UIColor?
-    var activeBorderColor: UIColor?
-    var borderColor: UIColor?
-    var highlightButtonColor: UIColor?
-    var highlightBorderColor: UIColor?
-    var highlightTextColor: UIColor?
-    var disabledButtonColor: UIColor?
+protocol Themeable {
+    func applyTheme(_ theme: Theme)
+}
 
-    static let PrivateMode = "Private"
-    static let NormalMode = "Normal"
+enum Theme: String {
+    case Private
+    case Normal
 }

--- a/Client/Frontend/Widgets/TwoLineCell.swift
+++ b/Client/Frontend/Widgets/TwoLineCell.swift
@@ -11,7 +11,7 @@ struct TwoLineCellUX {
     static let BadgeSize: CGFloat = 16
     static let BadgeMargin: CGFloat = 16
     static let BorderFrameSize: CGFloat = 32
-    static let TextColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.black : UIColor(rgb: 0x333333)
+    static let TextColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.black : UIColor.Defaults.Grey80
     static let DetailTextColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.darkGray : UIColor.gray
     static let DetailTextTopMargin: CGFloat = 0
 }

--- a/Extensions/SendTo/ClientPickerViewController.swift
+++ b/Extensions/SendTo/ClientPickerViewController.swift
@@ -12,7 +12,7 @@ protocol ClientPickerViewControllerDelegate {
     func clientPickerViewController(_ clientPickerViewController: ClientPickerViewController, didPickClients clients: [RemoteClient])
 }
 
-struct ClientPickerViewControllerUX {
+private struct ClientPickerViewControllerUX {
     static let TableHeaderRowHeight = CGFloat(50)
     static let TableHeaderTextFont = UIFont.systemFont(ofSize: 16)
     static let TableHeaderTextColor = UIColor.gray

--- a/Extensions/SendTo/InstructionsViewController.swift
+++ b/Extensions/SendTo/InstructionsViewController.swift
@@ -5,7 +5,7 @@
 import UIKit
 import SnapKit
 
-struct InstructionsViewControllerUX {
+private struct InstructionsViewControllerUX {
     static let TopPadding = CGFloat(20)
     static let TextFont = UIFont.systemFont(ofSize: UIFont.labelFontSize)
     static let TextColor = UIColor(rgb: 0x555555)

--- a/Extensions/ShareTo/ShareViewController.swift
+++ b/Extensions/ShareTo/ShareViewController.swift
@@ -28,8 +28,8 @@ protocol ShareControllerDelegate {
 
 private struct ShareDialogControllerUX {
     static let CornerRadius: CGFloat = 4                                                            // Corner radius of the dialog
-
-    static let NavigationBarTintColor = UIColor(rgb: 0xf37c00)                                      // Tint color changes the text color in the navigation bar
+    static let PhotonBlue50 = UIColor(rgb: 0x0a84ff)
+    static let NavigationBarTintColor = PhotonBlue50                                                // Tint color changes the text color in the navigation bar
     static let NavigationBarCancelButtonFont = UIFont.systemFont(ofSize: UIFont.buttonFontSize)     // System default
     static let NavigationBarAddButtonFont = UIFont.boldSystemFont(ofSize: UIFont.buttonFontSize)    // System default
     static let NavigationBarIconSize = 40                                                           // Width and height of the icon

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -16,7 +16,7 @@ struct TodayStrings {
     static let GoToCopiedLinkLabel = NSLocalizedString("TodayWidget.GoToCopiedLinkLabel", tableName: "Today", value: "Go to copied link", comment: "Go to link on clipboard")
 }
 
-struct TodayUX {
+private struct TodayUX {
     static let privateBrowsingColor = UIColor(rgb: 0xCE6EFC)
     static let backgroundHightlightColor = UIColor(white: 216.0/255.0, alpha: 44.0/255.0)
     static let linkTextSize: CGFloat = 10.0
@@ -25,7 +25,6 @@ struct TodayUX {
     static let copyLinkImageWidth: CGFloat = 23
     static let margin: CGFloat = 8
     static let buttonsHorizontalMarginPercentage: CGFloat = 0.1
-    static let iOS9LeftMargin: CGFloat = 40
 }
 
 @objc (TodayViewController)


### PR DESCRIPTION
I've moved all Photon related colors into UIConstants and refactored themes. 

I left ReadingList/Settings/FindInPage bar because we never touched those during the Photon rewrite.