### PR TITLE
Bug 1415531 — Fix up test to show error.

### DIFF
--- a/ClientTests/RelativeDatesTests.swift
+++ b/ClientTests/RelativeDatesTests.swift
@@ -10,38 +10,31 @@ class RelativeDatesTests: XCTestCase {
         let dateOrig = Date()
         var date = Date(timeInterval: 0, since: dateOrig)
         
-        XCTAssertTrue(date.toRelativeTimeString() == "just now")
+        XCTAssertEqual(date.toRelativeTimeString(), "just now")
         
-        date = Date(timeInterval: 0, since: dateOrig)
-        date = date.addingTimeInterval(-10)
-        XCTAssertTrue(date.toRelativeTimeString() == "just now")
+        date = Date(timeInterval: -10, since: dateOrig)
+        XCTAssertEqual(date.toRelativeTimeString(), "just now")
+
+        date = Date(timeInterval: -60, since: dateOrig)
+        XCTAssertEqual(date.toRelativeTimeString(), ("today at " + DateFormatter.localizedString(from: date, dateStyle: DateFormatter.Style.none, timeStyle: DateFormatter.Style.short)))
+
+        let calendar = Calendar.autoupdatingCurrent
+        date = calendar.date(byAdding: .day, value: -1, to: dateOrig)!
+        XCTAssertEqual(date.toRelativeTimeString(), "yesterday")
+
+        date = calendar.date(byAdding: .day, value: -2, to: dateOrig)!
+        XCTAssertEqual(date.toRelativeTimeString(), "this week")
+
+        date = calendar.date(byAdding: .day, value: -7, to: dateOrig)!
+        XCTAssertEqual(date.toRelativeTimeString(), "more than a week ago")
         
-        date = Date(timeInterval: 0, since: dateOrig)
-        date = date.addingTimeInterval(-60)
-        XCTAssertTrue(date.toRelativeTimeString() == ("today at " + DateFormatter.localizedString(from: date, dateStyle: DateFormatter.Style.none, timeStyle: DateFormatter.Style.short)))
+        date = calendar.date(byAdding: .day, value: -7 * 5, to: dateOrig)!
+        XCTAssertEqual(date.toRelativeTimeString(), "more than a month ago")
         
-        date = Date(timeInterval: 0, since: dateOrig)
-        date = date.addingTimeInterval(-60 * 60 * 24)
-        XCTAssertTrue(date.toRelativeTimeString() == "yesterday")
+        date = Date(timeInterval: -60 * 60 * 24 * 7 * 5 * 2, since: dateOrig)
+        XCTAssertEqual(date.toRelativeTimeString(), DateFormatter.localizedString(from: date, dateStyle: DateFormatter.Style.short, timeStyle: DateFormatter.Style.short))
         
-        date = Date(timeInterval: 0, since: dateOrig)
-        date = date.addingTimeInterval(-60 * 60 * 24 * 2)
-        XCTAssertTrue(date.toRelativeTimeString() == "this week")
-        
-        date = Date(timeInterval: 0, since: dateOrig)
-        date = date.addingTimeInterval(-60 * 60 * 24 * 7)
-        XCTAssertTrue(date.toRelativeTimeString() == "more than a week ago")
-        
-        date = Date(timeInterval: 0, since: dateOrig)
-        date = date.addingTimeInterval(-60 * 60 * 24 * 7 * 5)
-        XCTAssertTrue(date.toRelativeTimeString() == "more than a month ago")
-        
-        date = Date(timeInterval: 0, since: dateOrig)
-        date = date.addingTimeInterval(-60 * 60 * 24 * 7 * 5 * 2)
-        XCTAssertTrue(date.toRelativeTimeString() == DateFormatter.localizedString(from: date, dateStyle: DateFormatter.Style.short, timeStyle: DateFormatter.Style.short))
-        
-        date = Date(timeInterval: 0, since: dateOrig)
-        date = date.addingTimeInterval(-60 * 60 * 24 * 7 * 5 * 12 * 2)
-        XCTAssertTrue(date.toRelativeTimeString() == DateFormatter.localizedString(from: date, dateStyle: DateFormatter.Style.short, timeStyle: DateFormatter.Style.short))
+        date = Date(timeInterval: -60 * 60 * 24 * 7 * 5 * 12 * 2, since: dateOrig)
+        XCTAssertEqual(date.toRelativeTimeString(), DateFormatter.localizedString(from: date, dateStyle: DateFormatter.Style.short, timeStyle: DateFormatter.Style.short))
     }
 }


### PR DESCRIPTION
This PR fixes a test that assumes that days are exactly 24 hours long.

This assumption does not hold for DST changes.

The fix is to move date arithmetic to use date components instead of just adding a caculated-in-seconds duration.

This _should_ fix the problem for the spring DST changes as well as the autumn one.

https://bugzilla.mozilla.org/show_bug.cgi?id=1415531