### PR TITLE
Bug 1415687 - make sure toolbars only show after the page has changed. 

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -923,7 +923,6 @@ class BrowserViewController: UIViewController {
 
     func updateUIForReaderHomeStateForTab(_ tab: Tab) {
         updateURLBarDisplayURL(tab)
-        scrollController.showToolbars(animated: false)
 
         if let url = tab.url {
             if url.isReaderModeURL {
@@ -1135,6 +1134,7 @@ class BrowserViewController: UIViewController {
 
     func navigateInTab(tab: Tab, to navigation: WKNavigation? = nil) {
         tabManager.expireSnackbars()
+        scrollController.showToolbars(animated: false)
 
         guard let webView = tab.webView else {
             print("Cannot navigate in tab without a webView")


### PR DESCRIPTION
`updateUIForReaderHomeStateForTab` is called from the title changed KVO. That is a bit too quick. The content on the webpage is still the old content. Better to call it from `navigateInTab` this is after the webpage has changed.

