### PR TITLE
DO NOT MERGE YET - Bug 1416088 - Allow Leanplum to be tested in Development Mode

### DIFF
--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -139,15 +139,15 @@ class LeanplumIntegration {
             return
         }
 
-        switch settings.environment {
-        case .development:
+        if settings.environment == .development || UIDevice.current.name.contains("MozMMADev") {
             log.info("LeanplumIntegration - Setting up for Development")
             Leanplum.setDeviceId(UIDevice.current.identifierForVendor?.uuidString)
             Leanplum.setAppId(settings.appId, withDevelopmentKey: settings.key)
-        case .production:
+        } else {
             log.info("LeanplumIntegration - Setting up for Production")
             Leanplum.setAppId(settings.appId, withProductionKey: settings.key)
         }
+
         Leanplum.syncResourcesAsync(true)
 
         if profile?.prefs.boolForKey(PrefsKeys.HasFocusInstalled) == nil {

--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -7,9 +7,9 @@ import AdSupport
 import Shared
 import Leanplum
 
-private let LeanplumEnvironmentKey = "LeanplumEnvironment"
 private let LeanplumAppIdKey = "LeanplumAppId"
-private let LeanplumKeyKey = "LeanplumKey"
+private let LeanplumProductionKeyKey = "LeanplumProductionKey"
+private let LeanplumDevelopmentKeyKey = "LeanplumDevelopmentKey"
 private let applicationDidRequestUserNotificationPermissionPrefKey = "applicationDidRequestUserNotificationPermissionPrefKey"
 
 // FxA Custom Leanplum message template for A/B testing
@@ -32,11 +32,6 @@ let LpmtDefaultOkButtonText = NSLocalizedString("Enable Push", comment: "Default
 let LpmtDefaultLaterButtonText = NSLocalizedString("Don't Enable", comment: "Default push alert cancel button text")
 
 private let log = Logger.browserLogger
-
-private enum LeanplumEnvironment: String {
-    case development = "development"
-    case production = "production"
-}
 
 enum LeanplumEventName: String {
     case firstRun = "E_First_Run"
@@ -91,9 +86,9 @@ private enum SupportedLocales: String {
 }
 
 private struct LeanplumSettings {
-    var environment: LeanplumEnvironment
     var appId: String
-    var key: String
+    var productionKey: String
+    var developmentKey: String
 }
 
 class LeanplumIntegration {
@@ -139,13 +134,17 @@ class LeanplumIntegration {
             return
         }
 
-        if settings.environment == .development || UIDevice.current.name.contains("MozMMADev") {
-            log.info("LeanplumIntegration - Setting up for Development")
+        if UIDevice.current.name.contains("MozMMADev") {
+            NSLog("LeanplumIntegration - Setting up for Development")
             Leanplum.setDeviceId(UIDevice.current.identifierForVendor?.uuidString)
-            Leanplum.setAppId(settings.appId, withDevelopmentKey: settings.key)
+            Leanplum.setAppId(settings.appId, withDevelopmentKey: settings.developmentKey)
         } else {
-            log.info("LeanplumIntegration - Setting up for Production")
-            Leanplum.setAppId(settings.appId, withProductionKey: settings.key)
+            NSLog("LeanplumIntegration - Setting up for Production")
+            Leanplum.setAppId(settings.appId, withProductionKey: settings.productionKey)
+        }
+
+        if let deviceId = Leanplum.deviceId() {
+            NSLog("LeanplumIntegration - Device ID is \(deviceId)")
         }
 
         Leanplum.syncResourcesAsync(true)
@@ -271,7 +270,9 @@ class LeanplumIntegration {
         guard let environmentString = bundle.object(forInfoDictionaryKey: LeanplumEnvironmentKey) as? String,
               let environment = LeanplumEnvironment(rawValue: environmentString),
               let appId = bundle.object(forInfoDictionaryKey: LeanplumAppIdKey) as? String,
-              let key = bundle.object(forInfoDictionaryKey: LeanplumKeyKey) as? String else {
+              let productionKey = bundle.object(forInfoDictionaryKey: LeanplumProductionKeyKey) as? String,
+              let developmentKey = bundle.object(forInfoDictionaryKey: LeanplumDevelopmentKeyKey) as? String,
+            else {
             return nil
         }
         return LeanplumSettings(environment: environment, appId: appId, key: key)

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -8,12 +8,14 @@
 	<string>$(ADJUST_ENVIRONMENT)</string>
 	<key>MozDevelopmentTeam</key>
 	<string>$(DEVELOPMENT_TEAM)</string>
-	<key>LeanplumEnvironment</key>
-	<string>$(LEANPLUM_ENVIRONMENT)</string>
 	<key>LeanplumAppId</key>
 	<string>$(LEANPLUM_APP_ID</string>
-	<key>LeanplumKey</key>
-	<string>$(LEANPLUM_KEY)</string>
+	<key>LeanplumProductionKey</key>
+	<string>$(LEANPLUM_PRODUCTION_KEY)</string>
+	<key>LeanplumDevelopmentKey</key>
+	<string>$(LEANPLUM_DEVELOPMENT_KEY)</string>
+	<key>LSApplicationCategoryType</key>
+	<string></string>
 	<key>AppIdentifierPrefix</key>
 	<string>$(APP_IDENTIFIER_PREFIX)</string>
 	<key>PocketEnvironmentAPIKey</key>


### PR DESCRIPTION
*DO NOT MERGE*

This patch changes how we decide that we should start Leanplum in Development Mode. This change will make it simpler for QA to verify that Leanplum works correctly on a Release or Beta build.

* If the `Info.plist` has a `LeanplumEnvironment=development` entry
* If the *Device Name* contains the the string `MozMMADev`

Using the device name is a bit of a hack but the nice thing about it is that it will not require any settings in the application and it will also be possible to start Leanplum in Development Mode on first start of the application, which may be useful for testing onboarding campaigns.
