### PR TITLE
Bug 1416157 - Update Private Mode related XCUITests to new FxScreenGraph

### DIFF
--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -192,9 +192,10 @@ class ActivityStreamTest: BaseTestCase {
         selectOptionFromContextMenu(option: "Open in New Private Tab")
 
         // Check that two tabs are open and one of them is the default top site one
-        navigator.goto(PrivateTabTray)
+        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+
         waitforExistence(app.collectionViews.cells[defaultTopSite["bookmarkLabel"]!])
-        let numTabsOpen = app.collectionViews.cells.count
+        let numTabsOpen = userState.numTabs
         XCTAssertEqual(numTabsOpen, 1, "New tab not open")
     }
 

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -159,6 +159,8 @@ class FxUserState: UserState {
 
     var fxaUsername: String? = nil
     var fxaPassword: String? = nil
+
+    var numTabs: Int = 0
 }
 
 fileprivate let defaultURL = "https://www.mozilla.org/en-US/book/"
@@ -476,6 +478,10 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> Scree
             userState.isPrivate = !userState.isPrivate
         }
         screenState.tap(app.buttons["TabTrayController.removeTabsButton"], to: CloseTabMenu)
+
+        screenState.onEnter { userState in
+            userState.numTabs = Int(app.collectionViews.cells.count)
+        }
     }
 
     map.addScreenState(CloseTabMenu) { screenState in
@@ -615,7 +621,7 @@ extension Navigator where T == FxUserState {
         let app = XCUIApplication()
         self.goto(TabTray)
         app.buttons["TabTrayController.addTabButton"].tap()
-        self.nowAt(HomePanelsScreen)
+        self.nowAt(NewTabScreen)
     }
 
     // Add Tab(s) from the Tab Tray

--- a/XCUITests/PrivateBrowsingTest.swift
+++ b/XCUITests/PrivateBrowsingTest.swift
@@ -12,7 +12,7 @@ let url2Label = "Facebook - Log In or Sign Up"
 
 class PrivateBrowsingTest: BaseTestCase {
     func testPrivateTabDoesNotTrackHistory() {
-        navigator.openURL(urlString: url1)
+        navigator.openURL(url1)
         navigator.goto(BrowserTabMenu)
         // Go to History screen
         waitforExistence(app.tables.cells["History"])
@@ -27,9 +27,9 @@ class PrivateBrowsingTest: BaseTestCase {
         XCTAssertEqual(history, 1, "History entries in regular browsing do not match")
 
         // Go to Private browsing to open a website and check if it appears on History
-        navigator.goto(PrivateTabTray)
-        navigator.openURL(urlString: url2)
-        navigator.nowAt(PrivateBrowserTab)
+        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+
+        navigator.openURL(url2)
         waitForValueContains(app.textFields["url"], value: "facebook")
         navigator.goto(BrowserTabMenu)
         waitforExistence(app.tables.cells["History"])
@@ -48,34 +48,30 @@ class PrivateBrowsingTest: BaseTestCase {
         navigator.openNewURL(urlString: url1)
         waitUntilPageLoad()
         navigator.goto(TabTray)
-        navigator.goto(BrowserTab)
-        navigator.goto(TabTray)
 
         waitforExistence(app.collectionViews.cells[url1Label])
-        let numTabs = app.collectionViews.cells.count
-        XCTAssertEqual(numTabs, 3, "The number of regular tabs is not correct")
+        let numTabs = userState.numTabs
+        XCTAssertEqual(numTabs, 2, "The number of regular tabs is not correct")
 
         // Open one tab in private browsing and check the total number of tabs
-        navigator.goto(PrivateTabTray)
+        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+
         navigator.goto(URLBarOpen)
         waitUntilPageLoad()
-        navigator.openURL(urlString: url2)
-        waitUntilPageLoad()
-        navigator.nowAt(PrivateBrowserTab)
+        navigator.openURL(url2)
         waitForValueContains(app.textFields["url"], value: "facebook")
-
-        navigator.goto(PrivateTabTray)
-
+        navigator.goto(TabTray)
         waitforExistence(app.collectionViews.cells[url2Label])
-        let numPrivTabs = app.collectionViews.cells.count
+        let numPrivTabs = userState.numTabs
         XCTAssertEqual(numPrivTabs, 1, "The number of private tabs is not correct")
 
         // Go back to regular mode and check the total number of tabs
-        navigator.goto(TabTray)
+        navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
+
         waitforExistence(app.collectionViews.cells[url1Label])
         waitforNoExistence(app.collectionViews.cells[url2Label])
-        let numRegularTabs = app.collectionViews.cells.count
-        XCTAssertEqual(numRegularTabs, 3, "The number of regular tabs is not correct")
+        let numRegularTabs = userState.numTabs
+        XCTAssertEqual(numRegularTabs, 2, "The number of regular tabs is not correct")
     }
 
     func testClosePrivateTabsOptionClosesPrivateTabs() {
@@ -92,61 +88,58 @@ class PrivateBrowsingTest: BaseTestCase {
         XCTAssertFalse(closePrivateTabsSwitch.isSelected)
 
         //  Open a Private tab
-        navigator.goto(PrivateTabTray)
-        navigator.openURL(urlString: url1)
-        //Wait until the page loads
-        waitUntilPageLoad()
-        navigator.nowAt(PrivateBrowserTab)
-        navigator.goto(PrivateTabTray)
+        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        navigator.openURL(url1)
 
         // Go back to regular browser
-        navigator.goto(TabTray)
+        navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
         // Go back to private browsing and check that the tab has not been closed
-        navigator.goto(PrivateTabTray)
+        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+
         waitforExistence(app.collectionViews.cells[url1Label])
-        let numPrivTabs = app.collectionViews.cells.count
+        let numPrivTabs = userState.numTabs
         XCTAssertEqual(numPrivTabs, 1, "The number of tabs is not correct, the private tab should not have been closed")
 
-        app.collectionViews.cells[url1Label].tap()
-        navigator.nowAt(PrivateBrowserTab)
         // Now the enable the Close Private Tabs when closing the Private Browsing Button
+        app.collectionViews.cells[url1Label].tap()
+        navigator.nowAt(BrowserTab)
         navigator.goto(SettingsScreen)
         closePrivateTabsSwitch.tap()
-        navigator.goto(PrivateBrowserTab)
+        navigator.goto(BrowserTab)
+
         // Go back to regular browsing and check that the private tab has been closed and that the initial Private Browsing message appears when going back to Private Browsing
-        navigator.goto(PrivateTabTray)
-        navigator.goto(TabTray)
-        navigator.goto(PrivateTabTray)
+        navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
+
+        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+
         waitforNoExistence(app.collectionViews.cells[url1Label])
-        let numPrivTabsAfterClosing = app.collectionViews.cells.count
+        let numPrivTabsAfterClosing = userState.numTabs
         XCTAssertEqual(numPrivTabsAfterClosing, 0, "The number of tabs is not correct, the private tab should have been closed")
         XCTAssertTrue(app.staticTexts["Private Browsing"].exists, "Private Browsing screen is not shown")
     }
 
     func testPrivateBrowserPanelView() {
         // If no private tabs are open, there should be a initial screen with label Private Browsing
-        navigator.goto(PrivateTabTray)
+        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
         XCTAssertTrue(app.staticTexts["Private Browsing"].exists, "Private Browsing screen is not shown")
-        let numPrivTabsFirstTime = app.collectionViews.cells.count
+        let numPrivTabsFirstTime = userState.numTabs
         XCTAssertEqual(numPrivTabsFirstTime, 0, "The number of tabs is not correct, there should not be any private tab yet")
 
         // If a private tab is open Private Browsing screen is not shown anymore
-        navigator.goto(PrivateBrowserTab)
-        //Wait until the page loads
+        navigator.goto(BrowserTab)
+
+        //Wait until the page loads and go to regular browser
         waitUntilPageLoad()
-        navigator.goto(PrivateTabTray)
+        navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
-        // Go to regular browsing
-        navigator.goto(TabTray)
-
-        // Go back to private brosing
-        navigator.goto(PrivateTabTray)
+        // Go back to private browsing
+        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
         waitforNoExistence(app.staticTexts["Private Browsing"])
         XCTAssertFalse(app.staticTexts["Private Browsing"].exists, "Private Browsing screen is shown")
-        let numPrivTabsOpen = app.collectionViews.cells.count
+        let numPrivTabsOpen = userState.numTabs
         XCTAssertEqual(numPrivTabsOpen, 1, "The number of tabs is not correct, there should be one private tab")
     }
 }


### PR DESCRIPTION
This PR attemps to fix these XCUI tests, related to Private Mode, due to the changes in the FxScreenGraph: 
-testPrivateTabDoesNotTrackHistory()
-testTabCountShowsOnlyNormalOrPrivateTabCount()
-testClosePrivateTabsOptionClosesPrivateTabs()
-testPrivateBrowserPanelView()

iPad tests were failing with an error: 

> Cannot route from HomePanels to LoadURL

Changed one line in FxScreenGraph and Private Tests on iPad now work and test in other test suites may also be fixed with this





