### PR TITLE
Bug 1404089 - checks for a sign-in code query param and launches fxa

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -600,11 +600,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         // If the `NSUserActivity` has a `webpageURL`, it is either a deep link or an old history item
         // reached via a "Spotlight" search before we began indexing visited pages via CoreSpotlight.
         if let url = userActivity.webpageURL {
-
+            let query = url.getQuery()
+            
+            // Check for fxa sign-in code and launch the login screen directly
+            if query["signin"] != nil {
+                browserViewController.launchFxAFromDeeplinkURL(url)
+                return true
+            }
+            
             // Per Adjust documenation, https://docs.adjust.com/en/universal-links/#running-campaigns-through-universal-links,
             // it is recommended that links contain the `deep_link` query parameter. This link will also
             // be url encoded.
-            let query = url.getQuery()
             if let deepLink = query["deep_link"]?.removingPercentEncoding, let url = URL(string: deepLink) {
                 browserViewController.switchToTabForURLOrOpen(url, isPrivileged: true)
                 return true


### PR DESCRIPTION
This PR is part of the ongoing process to debug why FxA sign-in codes are not working as expected on iOS. When the `signin` query param is detected we will launch the FxA login view with this code.

## Pull Request Checklist

- [x] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Bug 12345678 - This fixes something something`
- [x] I have marked the bug with `[needsuplift]`

## Screenshots
NA

## Notes for testing this patch
NA
