### PR TITLE
Bug 1415746 - Fix sync ping recording failed outgoing records under the "sentFailed" property.

### DIFF
--- a/StorageTests/SyncTelemetryTests.swift
+++ b/StorageTests/SyncTelemetryTests.swift
@@ -114,5 +114,7 @@ extension SyncTelemetryTests {
         let uploadStats = synchronizer.statsSession.uploadStats
         XCTAssertEqual(uploadStats.sent, 1)
         XCTAssertEqual(uploadStats.sentFailed, 1)
+        
+        XCTAssertEqual(uploadStats.asDictionary()["failed"] as? Int, 1)
     }
 }

--- a/Sync/SyncTelemetryUtils.swift
+++ b/Sync/SyncTelemetryUtils.swift
@@ -52,7 +52,7 @@ extension SyncUploadStats: DictionaryRepresentable {
     func asDictionary() -> [String: Any] {
         return [
             "sent": sent,
-            "sentFailed": sentFailed
+            "failed": sentFailed
         ]
     }
 }


### PR DESCRIPTION
Context is described in [the bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1415746).