### PR TITLE
Bug 1374760 - Include os information in sync ping

### DIFF
--- a/StorageTests/SyncTelemetryTests.swift
+++ b/StorageTests/SyncTelemetryTests.swift
@@ -115,4 +115,23 @@ extension SyncTelemetryTests {
         XCTAssertEqual(uploadStats.sent, 1)
         XCTAssertEqual(uploadStats.sentFailed, 1)
     }
+
+    func testCommonData() {
+        let data = SyncPing.pingCommonData(why: SyncPingReason.schedule, hashedUID: "fake-uid", hashedDeviceID: "fake-device-id")
+        XCTAssertEqual(data["version"] as? Int, 1)
+        XCTAssertEqual(data["why"] as? String, "schedule")
+        XCTAssertEqual(data["uid"] as? String, "fake-uid")
+        XCTAssertEqual(data["deviceID"] as? String, "fake-device-id")
+
+        guard let os = data["os"] as? [String: Any] else {
+            XCTFail("Ping common data should have os property.")
+            return
+        }
+
+        XCTAssertEqual(os["name"] as? String, "iOS")
+        // Just check they exist and have sane types.
+        XCTAssertTrue(os["version"] is String)
+        XCTAssertTrue(os["locale"] is String)
+    }
+
 }

--- a/Sync/SyncTelemetryUtils.swift
+++ b/Sync/SyncTelemetryUtils.swift
@@ -256,12 +256,11 @@ public struct SyncPing: SyncTelemetryPing {
                 return deferMaybe(SyncPingError.failedToRestoreScratchpad)
             }
 
-            var ping: [String: Any] = [
-                "version": 1,
-                "why": why.rawValue,
-                "uid": token.hashedFxAUID,
-                "deviceID": (scratchpad.clientGUID + token.hashedFxAUID).sha256.hexEncodedString
-            ]
+            var ping: [String: Any] = pingCommonData(
+                why: why,
+                hashedUID: token.hashedFxAUID,
+                hashedDeviceID: (scratchpad.clientGUID + token.hashedFxAUID).sha256.hexEncodedString
+            )
 
             // TODO: We don't cache our sync pings so if it fails, it fails. Once we add
             // some kind of caching we'll want to make sure we don't dump the events if
@@ -277,6 +276,20 @@ public struct SyncPing: SyncTelemetryPing {
                 return deferMaybe(SyncPing(payload: JSON(ping)))
             }
         }
+    }
+
+    static func pingCommonData(why: SyncPingReason, hashedUID: String, hashedDeviceID: String) -> [String: Any] {
+         return [
+            "version": 1,
+            "why": why.rawValue,
+            "uid": hashedUID,
+            "deviceID": hashedDeviceID,
+            "os": [
+                "name": "iOS",
+                "version": UIDevice.current.systemVersion,
+                "locale": Locale.current.identifier
+            ]
+        ]
     }
 
     // Generates a single sync ping payload that is stored in the 'syncs' list in the sync ping.


### PR DESCRIPTION
Context in https://bugzilla.mozilla.org/show_bug.cgi?id=1374760, but also that we have to do some really gross stuff in redash with app_version and app_name to distinguish between desktop, android, and ios. It would be nice not to have to do that at some point in the future.

The test is a bit imperfect, but the amount of mocking needed for a less imperfect test is not trivial.