### PR TITLE
Bug 1413713 - "Start Browsing" button on the Onboarding screen should respect Safe Area Insets on the iPhone X

### DIFF
--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -94,7 +94,11 @@ class IntroViewController: UIViewController, UIScrollViewDelegate {
 
         view.addSubview(startBrowsingButton)
         startBrowsingButton.snp.makeConstraints { (make) -> Void in
-            make.left.right.bottom.equalTo(self.view)
+            if #available(iOS 11.0, *) {
+                make.left.right.bottom.equalTo(self.view.safeAreaLayoutGuide)
+            } else {
+                make.left.right.bottom.equalTo(self.view)
+            }
             make.height.equalTo(IntroViewControllerUX.StartBrowsingButtonHeight)
         }
 


### PR DESCRIPTION
See: https://bugzilla.mozilla.org/show_bug.cgi?id=1413713