### PR TITLE
Bug 1417659: L10N screenshot for tracking protection long-press-reload

### DIFF
--- a/Client/Frontend/ContentBlocker/ContentBlockerHelper.swift
+++ b/Client/Frontend/ContentBlocker/ContentBlockerHelper.swift
@@ -55,6 +55,17 @@ class ContentBlockerHelper {
             }
         }
 
+        static func accessibilityId(for state: EnabledState) -> String {
+            switch state {
+            case .on:
+                return "Settings.TrackingProtectionOption.OnLabel"
+            case .onInPrivateBrowsing:
+                return "Settings.TrackingProtectionOption.OnInPrivateBrowsingLabel"
+            case .off:
+                return "Settings.TrackingProtectionOption.OffLabel"
+            }
+        }
+
         static let allOptions: [EnabledState] = [.on, .onInPrivateBrowsing, .off]
     }
 
@@ -78,6 +89,15 @@ class ContentBlockerHelper {
                 return Strings.TrackingProtectionOptionBlockListTypeBasicDescription
             case .strict:
                 return Strings.TrackingProtectionOptionBlockListTypeStrictDescription
+            }
+        }
+
+        static func accessibilityId(for strength: BlockingStrength) -> String {
+            switch strength {
+            case .basic:
+                return "Settings.TrackingProtectionOption.BlockListBasic"
+            case .strict:
+                return "Settings.TrackingProtectionOption.BlockListStrict"
             }
         }
 

--- a/Client/Frontend/ContentBlocker/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/ContentBlocker/ContentBlockerSettingViewController.swift
@@ -61,7 +61,8 @@ class ContentBlockerSettingViewController: ContentBlockerSettingsTableView {
 
     override func generateSettings() -> [SettingSection] {
         let enabledSetting: [CheckmarkSetting] = EnabledStates.map { option in
-            return CheckmarkSetting(title: NSAttributedString(string: option.settingTitle), subtitle: nil, isEnabled: {
+            let id = ContentBlockerHelper.EnabledState.accessibilityId(for: option)
+            return CheckmarkSetting(title: NSAttributedString(string: option.settingTitle), subtitle: nil, accessibilityIdentifier: id, isEnabled: {
                 return option == self.currentEnabledState
             }, onChanged: {
                 self.currentEnabledState = option
@@ -74,7 +75,8 @@ class ContentBlockerSettingViewController: ContentBlockerSettingsTableView {
         }
 
         let strengthSetting: [CheckmarkSetting] = BlockingStrengths.map { option in
-            return CheckmarkSetting(title: NSAttributedString(string: option.settingTitle), subtitle: NSAttributedString(string: option.subtitle), isEnabled: {
+            let id = ContentBlockerHelper.BlockingStrength.accessibilityId(for: option)
+            return CheckmarkSetting(title: NSAttributedString(string: option.settingTitle), subtitle: NSAttributedString(string: option.subtitle), accessibilityIdentifier: id, isEnabled: {
                 return option == self.currentBlockingStrength
             }, onChanged: {
                 self.currentBlockingStrength = option

--- a/L10nSnapshotTests/L10nSnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSnapshotTests.swift
@@ -134,7 +134,7 @@ class L10nSnapshotTests: L10nBaseSnapshotTests {
     }
 
     func test13ReloadButtonContextMenu() {
-        navigator.performAction(Action.ToggleTrackingProtectionSettingAlwaysOn)
+        navigator.toggleOn(userState.trackingProtectionSetting == FxUserState.TrackingProtectionSetting.alwaysOn.rawValue, withAction: Action.ToggleTrackingProtectionSettingAlwaysOn)
         navigator.goto(BrowserTab)
 
         navigator.openURL(loremIpsumURL)
@@ -145,15 +145,11 @@ class L10nSnapshotTests: L10nBaseSnapshotTests {
         navigator.goto(ReloadLongPressMenu)
         snapshot("13ContextMenuReloadButton-02", waitForLoadingIndicator: false)
 
-        navigator.performAction(Action.ToggleTrackingProtectionPerTabEnabled)
+        navigator.toggleOff(userState.trackingProtectionPerTabEnabled, withAction: Action.ToggleTrackingProtectionPerTabEnabled)
         navigator.goto(ReloadLongPressMenu)
 
-        // Snapshot of 'Reload *with* tracking protection'
+        // Snapshot of 'Reload *with* tracking protection' label, because trackingProtectionPerTabEnabled is false.
         snapshot("13ContextMenuReloadButton-03", waitForLoadingIndicator: false)
-
-        // return to default
-        navigator.performAction(Action.ToggleTrackingProtectionSettingPrivateOnly)
-        navigator.goto(BrowserTab)
     }
 
     func test16PasscodeSettings() {

--- a/L10nSnapshotTests/L10nSnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSnapshotTests.swift
@@ -134,6 +134,9 @@ class L10nSnapshotTests: L10nBaseSnapshotTests {
     }
 
     func test13ReloadButtonContextMenu() {
+        navigator.performAction(Action.ToggleTrackingProtectionSettingAlwaysOn)
+        navigator.goto(BrowserTab)
+
         navigator.openURL(loremIpsumURL)
         navigator.toggleOff(userState.requestDesktopSite, withAction: Action.ToggleRequestDesktopSite)
         navigator.goto(ReloadLongPressMenu)
@@ -141,7 +144,16 @@ class L10nSnapshotTests: L10nBaseSnapshotTests {
         navigator.toggleOn(userState.requestDesktopSite, withAction: Action.ToggleRequestDesktopSite)
         navigator.goto(ReloadLongPressMenu)
         snapshot("13ContextMenuReloadButton-02", waitForLoadingIndicator: false)
-        navigator.back()
+
+        navigator.performAction(Action.ToggleTrackingProtectionPerTabEnabled)
+        navigator.goto(ReloadLongPressMenu)
+
+        // Snapshot of 'Reload *with* tracking protection'
+        snapshot("13ContextMenuReloadButton-03", waitForLoadingIndicator: false)
+
+        // return to default
+        navigator.performAction(Action.ToggleTrackingProtectionSettingPrivateOnly)
+        navigator.goto(BrowserTab)
     }
 
     func test16PasscodeSettings() {

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -167,9 +167,11 @@ class FxUserState: UserState {
 
     var numTabs: Int = 0
 
-    var trackingProtectionPerTabEnabled = true
+    var trackingProtectionPerTabEnabled = true // TP can be shut off on a per-tab basis
     enum TrackingProtectionSetting : Int { case alwaysOn; case privateOnly; case off }
     var trackingProtectionSetting = TrackingProtectionSetting.privateOnly.rawValue // NSPredicate doesn't work with enum
+    // Construct an NSPredicate with this condition to use it.
+    static let trackingProtectionIsOnCondition = "trackingProtectionSetting == \(FxUserState.TrackingProtectionSetting.alwaysOn.rawValue) || (trackingProtectionSetting == \(FxUserState.TrackingProtectionSetting.privateOnly.rawValue) && isPrivate == YES)"
 }
 
 fileprivate let defaultURL = "https://www.mozilla.org/en-US/book/"
@@ -563,8 +565,8 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> Scree
         }
 
         let trackingProtectionButton = app.sheets.element(boundBy: 0).buttons.element(boundBy: 1)
-        let tpIsOn = "trackingProtectionSetting == \(FxUserState.TrackingProtectionSetting.alwaysOn.rawValue) || (trackingProtectionSetting == \(FxUserState.TrackingProtectionSetting.privateOnly.rawValue) && isPrivate == YES)"
-        screenState.tap(trackingProtectionButton, forAction: Action.ToggleTrackingProtectionPerTabEnabled, if: tpIsOn) { userState in
+
+        screenState.tap(trackingProtectionButton, forAction: Action.ToggleTrackingProtectionPerTabEnabled, if: FxUserState.trackingProtectionIsOnCondition) { userState in
             userState.trackingProtectionPerTabEnabled = !userState.trackingProtectionPerTabEnabled
         }
     }

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -139,6 +139,9 @@ private var isTablet: Bool {
     return UIDevice.current.userInterfaceIdiom == .pad
 }
 
+// Matches the available options in app settings for enabling Tracking Protection
+fileprivate enum TrackingProtectionSetting : Int { case alwaysOn; case privateOnly; case off }
+
 class FxUserState: UserState {
     required init() {
         super.init()
@@ -170,10 +173,9 @@ class FxUserState: UserState {
     var numTabs: Int = 0
 
     var trackingProtectionPerTabEnabled = true // TP can be shut off on a per-tab basis
-    enum TrackingProtectionSetting : Int { case alwaysOn; case privateOnly; case off }
     var trackingProtectionSetting = TrackingProtectionSetting.privateOnly.rawValue // NSPredicate doesn't work with enum
     // Construct an NSPredicate with this condition to use it.
-    static let trackingProtectionIsOnCondition = "trackingProtectionSetting == \(FxUserState.TrackingProtectionSetting.alwaysOn.rawValue) || (trackingProtectionSetting == \(FxUserState.TrackingProtectionSetting.privateOnly.rawValue) && isPrivate == YES)"
+    static let trackingProtectionIsOnCondition = "trackingProtectionSetting == \(TrackingProtectionSetting.alwaysOn.rawValue) || (trackingProtectionSetting == \(TrackingProtectionSetting.privateOnly.rawValue) && isPrivate == YES)"
 }
 
 fileprivate let defaultURL = "https://www.mozilla.org/en-US/book/"
@@ -489,15 +491,15 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> Scree
         screenState.backAction = navigationControllerBackAction
 
         screenState.tap(app.cells["Settings.TrackingProtectionOption.OnLabel"], forAction: Action.ToggleTrackingProtectionSettingAlwaysOn) { userState in
-            userState.trackingProtectionSetting = FxUserState.TrackingProtectionSetting.alwaysOn.rawValue
+            userState.trackingProtectionSetting = TrackingProtectionSetting.alwaysOn.rawValue
         }
 
         screenState.tap(app.cells["Settings.TrackingProtectionOption.OnInPrivateBrowsingLabel"], forAction: Action.ToggleTrackingProtectionSettingPrivateOnly) { userState in
-            userState.trackingProtectionSetting = FxUserState.TrackingProtectionSetting.privateOnly.rawValue
+            userState.trackingProtectionSetting = TrackingProtectionSetting.privateOnly.rawValue
         }
 
         screenState.tap(app.cells["Settings.TrackingProtectionOption.OffLabel"], forAction: Action.ToggleTrackingProtectionSettingOff) { userState in
-            userState.trackingProtectionSetting = FxUserState.TrackingProtectionSetting.off.rawValue
+            userState.trackingProtectionSetting = TrackingProtectionSetting.off.rawValue
         }
     }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1417659

ContentBlockerHelper.swift and ContentBlockerSettingsViewController.swift needed to be updated for screengraph usage.