### PR TITLE
Bug 1414010 - Reenable FxA Leanplum A/B test

### DIFF
--- a/Client/Helpers/FxALoginHelper.swift
+++ b/Client/Helpers/FxALoginHelper.swift
@@ -18,7 +18,7 @@ private let log = Logger.browserLogger
 private let verificationPollingInterval = DispatchTimeInterval.seconds(3)
 private let verificationMaxRetries = 100 // Poll every 3 seconds for 5 minutes.
 
-protocol FxAPushLoginDelegate : class {
+protocol FxAPushLoginDelegate: class {
     func accountLoginDidFail()
 
     func accountLoginDidSucceed(withFlags flags: FxALoginFlags)
@@ -153,7 +153,8 @@ class FxALoginHelper {
             account.updateProfile()
         }
         
-        if AppConstants.MOZ_ENABLE_LEANPLUM && AppConstants.MOZ_FXA_LEANPLUM_AB_PUSH_TEST {
+        let leanplum = LeanPlumClient.shared
+        if leanplum.isLPEnabled() && leanplum.isFxAPrePushEnabled() {
             // If Leanplum A/B push notification tests are enabled, defer to them for
             // displaying the pre-push permission dialog. If user dismisses it, we will still have
             // another chance to prompt them. Afterwards, Leanplum calls `apnsRegisterDidSucceed` or

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -198,9 +198,9 @@ public struct AppConstants {
         #if MOZ_CHANNEL_RELEASE
             return false
         #elseif MOZ_CHANNEL_BETA
-            return false
+            return true
         #elseif MOZ_CHANNEL_FENNEC
-            return false
+            return true
         #else
             return false
         #endif

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -30,7 +30,7 @@ public struct PrefsKeys {
     public static let KeyCustomSyncOauth = "customSyncOauthServer"
     public static let KeyCustomSyncAuth = "customSyncAuthServer"
     public static let KeyCustomSyncWeb = "customSyncWebServer"
-
+    
 }
 
 public struct PrefsDefaults {


### PR DESCRIPTION
This PR re-enables FxA Leanplum support. To do this ,it exposes two functions `getEnabled()`, which checks to see if Leanplum has started and if it is enabled for the given locale. And it exposes `isFxAPrePushEnabled()`, which checks an external Leanplum variable `useFxAPrePush` to determine with we should use pre permissions dialog.

Reference https://bugzilla.mozilla.org/show_bug.cgi?id=1414010#c0
Leanplum A/B test: https://www.leanplum.com/dashboard#/6554650862157824/experiments/5724582465241088

## Pull Request Checklist

- [x] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Bug 12345678 
- [ ] I have marked the bug with `[needsuplift]`

## Notes for testing this patch

This PR requires you to use the development iOS Leanplum API keys.
