### PR TITLE
Bug 1418493 - remove unnecessary check in  UITests/ClearPrivateDataTests.swift

### DIFF
--- a/UITests/ClearPrivateDataTests.swift
+++ b/UITests/ClearPrivateDataTests.swift
@@ -112,11 +112,18 @@ class ClearPrivateDataTests: KIFTestCase, UITextFieldDelegate {
 
         let url1 = urls[0].url
         let url2 = urls[1].url
-        EarlGrey.select(elementWithMatcher: grey_accessibilityLabel("History")).perform(grey_tap())
-        tester().waitForView(withAccessibilityLabel: url1)
-        tester().waitForView(withAccessibilityLabel: url2)
         BrowserUtils.clearPrivateData(BrowserUtils.AllClearables.subtracting([BrowserUtils.Clearable.History]), swipe: false, tester: tester())
-        
+        EarlGrey.select(elementWithMatcher: grey_accessibilityLabel("History")).perform(grey_tap())
+
+        let historyListShown = GREYCondition(name: "Wait for history to appear", block: { _ in
+            var errorOrNil: NSError?
+            EarlGrey.select(elementWithMatcher: grey_accessibilityLabel(url1))
+                .assert(grey_notNil(), error: &errorOrNil)
+            let success = errorOrNil == nil
+            return success
+        }).wait(withTimeout: 20)
+        GREYAssertTrue(historyListShown, reason: "Failed to display history list")
+
         EarlGrey.select(elementWithMatcher: grey_accessibilityLabel(url1))
             .assert(grey_notNil(), error: &errorOrNil)
         EarlGrey.select(elementWithMatcher: grey_accessibilityLabel(url2))


### PR DESCRIPTION
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [ ] My patch has a standard commit message that looks like `Bug 12345678 - This fixes something something`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
