### PR TITLE
Bug 1416820 — Add a close button to page menu and long press tabs tray menu.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1589,6 +1589,11 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         controller.addAction(UIAlertAction(title: Strings.NewPrivateTabTitle, style: .default, handler: { _ in
             self.tabManager.addTabAndSelect(isPrivate: true)
         }))
+        controller.addAction(UIAlertAction(title: Strings.CloseTabTitle, style: .destructive, handler: { _ in
+            if let tab = self.tabManager.selectedTab {
+                self.tabManager.removeTab(tab)
+            }
+        }))
         controller.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: "Label for Cancel button"), style: .cancel, handler: nil))
         controller.popoverPresentationController?.sourceView = toolbar ?? urlBar
         controller.popoverPresentationController?.sourceRect = button.frame

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -200,6 +200,10 @@ extension PhotonActionSheetProtocol {
             presentShareMenu(url, tab, buttonView, .up)
         }
 
+        let closeTab = PhotonActionSheetItem(title: Strings.CloseTabTitle, iconString: "action_remove") { action in
+            self.tabManager.removeTab(tab)
+        }
+
         let copyURL = PhotonActionSheetItem(title: Strings.AppMenuCopyURLTitleString, iconString: "menu-Copy-Link") { _ in
             UIPasteboard.general.url = tab.canonicalURL?.displayURL
             success(Strings.AppMenuCopyURLConfirmMessage)
@@ -216,7 +220,7 @@ extension PhotonActionSheetProtocol {
             }
         }
 
-        return [topActions, [copyURL, findInPageAction, toggleDesktopSite, pinToTopSites, sendToDevice], [share]]
+        return [topActions, [copyURL, findInPageAction, toggleDesktopSite, pinToTopSites, sendToDevice, closeTab], [share]]
     }
 }
 


### PR DESCRIPTION
This PR adds a close menu option to the page action menu and the long press tab tray menu.

A followup bug is needed for tests, as we'd like to get this on to the v10.x branch soon.

There is a new string, although this could easily be recycled.

https://bugzilla.mozilla.org/show_bug.cgi?id=1416820