### PR TITLE
Bug 1419057: FaviconManager closure strongly captures Tab, make weak

### DIFF
--- a/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -22,7 +22,7 @@ class ClipboardBarDisplayHandler: NSObject {
     private var firstTabLoaded = false
     private var prefs: Prefs
     private var lastDisplayedURL: String?
-    private var firstTab: Tab?
+    private weak var firstTab: Tab?
     var clipboardToast: ButtonToast?
     
     init(prefs: Prefs, tabManager: TabManager) {

--- a/Shared/WeakList.swift
+++ b/Shared/WeakList.swift
@@ -4,6 +4,17 @@
 
 import Foundation
 
+// Holds object member weakly. Swift weak keyword has limited scope,
+// for instance returning a weak var or passing a weak var to a function will
+// make it strongly referenced.  
+public struct Weak<T> where T: AnyObject {
+    public weak var object: T?
+
+    public init(_ object: T?) {
+        self.object = object
+    }
+}
+
 /**
  * A list that weakly holds references to its items.
  * Note that while the references themselves are cleared, their wrapper objects


### PR DESCRIPTION
This closure has long lifetime, thus closing a tab doesn't destroy the Tab
properly.

https://bugzilla.mozilla.org/show_bug.cgi?id=1419057
