### PR TITLE
Bug 1417152: Attempted workaround for PDF crash, don't hide toolbar

### DIFF
--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -105,7 +105,8 @@ class TabScrollingController: NSObject {
     }
 
     func hideToolbars(animated: Bool, completion: ((_ finished: Bool) -> Void)? = nil) {
-        if toolbarState == .collapsed {
+        // Due to bug 1417152, when a PDF is showing, don't hide toolbar
+        if toolbarState == .collapsed || isTabShowingPDF {
             completion?(true)
             return
         }
@@ -180,6 +181,11 @@ private extension TabScrollingController {
                 scrollDirection = .down
             } else if delta < 0 {
                 scrollDirection = .up
+            }
+
+            // Due to bug 1417152, when a PDF is showing, don't hide toolbar (.down is hide toolbar gesture BTW).
+            if isTabShowingPDF && scrollDirection == .down {
+                return
             }
 
             lastContentOffset = translation.y

--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -4,6 +4,7 @@
 
 import UIKit
 import SnapKit
+import Shared
 
 private let ToolbarBaseAnimationDuration: CGFloat = 0.2
 
@@ -105,8 +106,8 @@ class TabScrollingController: NSObject {
     }
 
     func hideToolbars(animated: Bool, completion: ((_ finished: Bool) -> Void)? = nil) {
-        // Due to bug 1417152, when a PDF is showing, don't hide toolbar
-        if toolbarState == .collapsed || isTabShowingPDF {
+        // Due to bug 1417152, when a PDF is showing, don't hide toolbar. The is a beta-only experiment.
+        if AppConstants.BuildChannel != .release, toolbarState == .collapsed || isTabShowingPDF {
             completion?(true)
             return
         }
@@ -183,8 +184,8 @@ private extension TabScrollingController {
                 scrollDirection = .up
             }
 
-            // Due to bug 1417152, when a PDF is showing, don't hide toolbar (.down is hide toolbar gesture BTW).
-            if isTabShowingPDF && scrollDirection == .down {
+            // Due to bug 1417152, when a PDF is showing, don't hide toolbar (.down is hide toolbar gesture BTW). Beta-only experiment.
+            if isTabShowingPDF && scrollDirection == .down && AppConstants.BuildChannel != .release {
                 return
             }
 


### PR DESCRIPTION
If hide/show toolbars (and the resulting autolayout refresh) correlates with this crash, this should reveal that.

https://bugzilla.mozilla.org/show_bug.cgi?id=1417152

EDIT: I want to wrap this in Beta-only. The workaround for release I want to be https://github.com/mozilla-mobile/firefox-ios/pull/3488
