### PR TITLE
Bug 1417152: guard against NaN bounds being set on the scrollview

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -381,6 +381,7 @@
 		C4E398601D22C409004E89BA /* TopTabsLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E3985F1D22C409004E89BA /* TopTabsLayout.swift */; };
 		C4EFEECF1CEBB6F2009762A4 /* BackForwardTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4EFEECE1CEBB6F2009762A4 /* BackForwardTableViewCell.swift */; };
 		C4F3B29A1CFCF93A00966259 /* ButtonToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F3B2991CFCF93A00966259 /* ButtonToast.swift */; };
+		C817B34D1FC609500086018E /* UIScrollViewSwizzled.swift in Sources */ = {isa = PBXBuildFile; fileRef = C817B34C1FC609500086018E /* UIScrollViewSwizzled.swift */; };
 		C8611C8E1F71904C00C3DE7D /* DiskImageStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BF8CBC1B7472FA0007AFE6 /* DiskImageStoreTests.swift */; };
 		C8611CB01F71AEBA00C3DE7D /* NoImageModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8611CA11F71AEB900C3DE7D /* NoImageModeTests.swift */; };
 		C88601C61F4228AD00BBDE4F /* ContentBlockerSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88601B71F4228AD00BBDE4F /* ContentBlockerSettingViewController.swift */; };
@@ -1722,6 +1723,7 @@
 		C4E3985F1D22C409004E89BA /* TopTabsLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopTabsLayout.swift; sourceTree = "<group>"; };
 		C4EFEECE1CEBB6F2009762A4 /* BackForwardTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackForwardTableViewCell.swift; sourceTree = "<group>"; };
 		C4F3B2991CFCF93A00966259 /* ButtonToast.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonToast.swift; sourceTree = "<group>"; };
+		C817B34C1FC609500086018E /* UIScrollViewSwizzled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScrollViewSwizzled.swift; sourceTree = "<group>"; };
 		C8611CA11F71AEB900C3DE7D /* NoImageModeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoImageModeTests.swift; sourceTree = "<group>"; };
 		C88601B71F4228AD00BBDE4F /* ContentBlockerSettingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentBlockerSettingViewController.swift; sourceTree = "<group>"; };
 		C8EB60C31F1FB12500F9B5B3 /* navigationDelegate.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = navigationDelegate.html; sourceTree = "<group>"; };
@@ -2568,6 +2570,7 @@
 				A83E5AB61C1D993D0026D912 /* UIPasteboardExtensions.swift */,
 				E650754F1E37F6D1006961AC /* NSURLExtensionsMailTo.swift */,
 				E65075501E37F6D1006961AC /* UIViewExtensions.swift */,
+				C817B34C1FC609500086018E /* UIScrollViewSwizzled.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -5569,6 +5572,7 @@
 				745DAB301CDAAFAA00D44181 /* RecentlyClosedTabsPanel.swift in Sources */,
 				C45F44691D087DB600CB7EF0 /* TopTabsViewController.swift in Sources */,
 				0BF0DB941A8545800039F300 /* URLBarView.swift in Sources */,
+				C817B34D1FC609500086018E /* UIScrollViewSwizzled.swift in Sources */,
 				E65607611C08B4E200534B02 /* SearchInputView.swift in Sources */,
 				EB2A63341F3B49A7004EF8B0 /* ContentBlockerHelper.swift in Sources */,
 				FA6B2AC21D41F02D00429414 /* Punycode.swift in Sources */,

--- a/Client/UIScrollViewSwizzled.swift
+++ b/Client/UIScrollViewSwizzled.swift
@@ -5,6 +5,7 @@
 import Shared
 
 // Workaround for bug 1417152, whereby NaN bounds are being set on the scrollview when viewing PDFs in the web view.
+// Is fixed in WebKit, remove this file when the fix arrives in iOS release.
 
 private let swizzling: (UIScrollView.Type) -> Void = { obj in
     let originalSelector = #selector(setter: UIView.bounds)
@@ -16,11 +17,6 @@ private let swizzling: (UIScrollView.Type) -> Void = { obj in
 
 extension UIScrollView {
     open override class func initialize() {
-        // This code will mask the problem, so disable it in Beta in order that we can research it further.
-        guard AppConstants.BuildChannel == .release else {
-            return
-        }
-
         // make sure this isn't a subclass
         guard self === UIScrollView.self else {
             return

--- a/Client/UIScrollViewSwizzled.swift
+++ b/Client/UIScrollViewSwizzled.swift
@@ -1,0 +1,30 @@
+import Shared
+
+// Workaround for bug 1417152, whereby NaN bounds are being set on the scrollview when viewing PDFs in the web view.
+
+private let swizzling: (UIScrollView.Type) -> () = { obj in
+    let originalSelector = #selector(setter: UIView.bounds)
+    let swizzledSelector = #selector(obj.swizzle_setBounds(bounds:))
+    let originalMethod = class_getInstanceMethod(obj, originalSelector)
+    let swizzledMethod = class_getInstanceMethod(obj, swizzledSelector)
+    method_exchangeImplementations(originalMethod, swizzledMethod)
+}
+
+extension UIScrollView {
+    open override class func initialize() {
+        // make sure this isn't a subclass
+        guard self === UIScrollView.self else { return }
+        swizzling(self)
+    }
+
+    func swizzle_setBounds(bounds: CGRect) {
+        [bounds.origin.x, bounds.origin.y, bounds.size.width, bounds.size.height].forEach() { val in
+            if val.isNaN || val.isInfinite {
+                Sentry.shared.send(message: "Bad scrollview bounds detected.")
+                return
+            }
+        }
+
+        self.swizzle_setBounds(bounds: bounds)
+    }
+}

--- a/Client/UIScrollViewSwizzled.swift
+++ b/Client/UIScrollViewSwizzled.swift
@@ -1,8 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import Shared
 
 // Workaround for bug 1417152, whereby NaN bounds are being set on the scrollview when viewing PDFs in the web view.
 
-private let swizzling: (UIScrollView.Type) -> () = { obj in
+private let swizzling: (UIScrollView.Type) -> Void = { obj in
     let originalSelector = #selector(setter: UIView.bounds)
     let swizzledSelector = #selector(obj.swizzle_setBounds(bounds:))
     let originalMethod = class_getInstanceMethod(obj, originalSelector)
@@ -12,8 +16,15 @@ private let swizzling: (UIScrollView.Type) -> () = { obj in
 
 extension UIScrollView {
     open override class func initialize() {
+        // This code will mask the problem, so disable it in Beta in order that we can research it further.
+        guard AppConstants.BuildChannel == .release else {
+            return
+        }
+
         // make sure this isn't a subclass
-        guard self === UIScrollView.self else { return }
+        guard self === UIScrollView.self else {
+            return
+        }
         swizzling(self)
     }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1417152

See also https://github.com/mozilla-mobile/firefox-ios/pull/3484, which I want to wrap as Beta-only.
This patch I want to wrap as release only.