### PR TITLE
Bug 1419942 - Sync settings screen enhancements

### DIFF
--- a/Account/FirefoxAccount.swift
+++ b/Account/FirefoxAccount.swift
@@ -39,6 +39,9 @@ open class FirefoxAccount {
     // Only set one time in the Choose What to Sync FxA screen shown during registration.
     open var declinedEngines: [String]?
 
+    // Use updateDeviceName() to set the device name and update the device registration.
+    private(set) open var deviceName: String
+
     open var configuration: FirefoxAccountConfiguration
 
     open var pushRegistration: PushRegistration?
@@ -58,11 +61,11 @@ open class FirefoxAccount {
         return stateCache.value!.actionNeeded
     }
 
-    public convenience init(configuration: FirefoxAccountConfiguration, email: String, uid: String, deviceRegistration: FxADeviceRegistration?, declinedEngines: [String]?, stateKeyLabel: String, state: FxAState) {
-        self.init(configuration: configuration, email: email, uid: uid, deviceRegistration: deviceRegistration, declinedEngines: declinedEngines, stateCache: KeychainCache(branch: "account.state", label: stateKeyLabel, value: state))
+    public convenience init(configuration: FirefoxAccountConfiguration, email: String, uid: String, deviceRegistration: FxADeviceRegistration?, declinedEngines: [String]?, stateKeyLabel: String, state: FxAState, deviceName: String) {
+        self.init(configuration: configuration, email: email, uid: uid, deviceRegistration: deviceRegistration, declinedEngines: declinedEngines, stateCache: KeychainCache(branch: "account.state", label: stateKeyLabel, value: state), deviceName: deviceName)
     }
 
-    public init(configuration: FirefoxAccountConfiguration, email: String, uid: String, deviceRegistration: FxADeviceRegistration?, declinedEngines: [String]?, stateCache: KeychainCache<FxAState>) {
+    public init(configuration: FirefoxAccountConfiguration, email: String, uid: String, deviceRegistration: FxADeviceRegistration?, declinedEngines: [String]?, stateCache: KeychainCache<FxAState>, deviceName: String) {
         self.email = email
         self.uid = uid
         self.deviceRegistration = deviceRegistration
@@ -71,6 +74,7 @@ open class FirefoxAccount {
         self.stateCache = stateCache
         self.stateCache.checkpoint()
         self.fxaProfile = nil
+        self.deviceName = deviceName
         self.syncAuthState = FirefoxAccountSyncAuthState(account: self,
             cache: KeychainCache.fromBranch("account.syncAuthState", withLabel: self.stateCache.label, factory: syncAuthStateCachefromJSON))
     }
@@ -84,19 +88,20 @@ open class FirefoxAccount {
                 return nil
         }
         let declinedEngines = data["declinedSyncEngines"].array?.flatMap { $0.string }
+        let deviceName = DeviceInfo.defaultClientName()
 
         let verified = data["verified"].bool ?? false
         return FirefoxAccount.from(configuration: configuration,
             andParametersWithEmail: email, uid: uid, deviceRegistration: nil, declinedEngines: declinedEngines, verified: verified,
-            sessionToken: sessionToken, keyFetchToken: keyFetchToken, unwrapkB: unwrapkB)
+            sessionToken: sessionToken, keyFetchToken: keyFetchToken, unwrapkB: unwrapkB, deviceName: deviceName)
     }
 
     open class func from(_ configuration: FirefoxAccountConfiguration,
                          andLoginResponse response: FxALoginResponse,
-                         unwrapkB: Data) -> FirefoxAccount {
+                         unwrapkB: Data, deviceName: String) -> FirefoxAccount {
         return FirefoxAccount.from(configuration: configuration,
                                    andParametersWithEmail: response.remoteEmail, uid: response.uid, deviceRegistration: nil, declinedEngines: nil, verified: response.verified,
-            sessionToken: response.sessionToken as Data, keyFetchToken: response.keyFetchToken as Data, unwrapkB: unwrapkB)
+                                   sessionToken: response.sessionToken as Data, keyFetchToken: response.keyFetchToken as Data, unwrapkB: unwrapkB, deviceName: deviceName)
     }
 
     fileprivate class func from(configuration: FirefoxAccountConfiguration,
@@ -107,7 +112,8 @@ open class FirefoxAccount {
                                 verified: Bool,
                                 sessionToken: Data,
                                 keyFetchToken: Data,
-                                unwrapkB: Data) -> FirefoxAccount {
+                                unwrapkB: Data,
+                                deviceName: String) -> FirefoxAccount {
         var state: FxAState! = nil
         if !verified {
             let now = Date.now()
@@ -132,7 +138,8 @@ open class FirefoxAccount {
             deviceRegistration: deviceRegistration,
             declinedEngines: declinedEngines,
             stateKeyLabel: Bytes.generateGUID(),
-            state: state
+            state: state,
+            deviceName: deviceName
         )
         return account
     }
@@ -147,6 +154,7 @@ open class FirefoxAccount {
         dict["pushRegistration"] = pushRegistration
         dict["configurationLabel"] = configuration.label.rawValue
         dict["stateKeyLabel"] = stateCache.label
+        dict["deviceName"] = deviceName
         return dict
     }
 
@@ -173,13 +181,15 @@ open class FirefoxAccount {
             let uid = dictionary["uid"] as? String {
                 let deviceRegistration = dictionary["deviceRegistration"] as? FxADeviceRegistration
                 let declinedEngines = dictionary["declinedEngines"] as? [String]
+                let deviceName = dictionary["deviceName"] as? String ?? DeviceInfo.defaultClientName() // Upgrading clients may not have this key!
                 let stateCache = KeychainCache.fromBranch("account.state", withLabel: dictionary["stateKeyLabel"] as? String, withDefault: SeparatedState(), factory: state)
                 let account = FirefoxAccount(
                     configuration: configurationLabel.toConfiguration(),
                     email: email, uid: uid,
                     deviceRegistration: deviceRegistration,
                     declinedEngines: declinedEngines,
-                    stateCache: stateCache)
+                    stateCache: stateCache,
+                    deviceName: deviceName)
                 account.pushRegistration = dictionary["pushRegistration"] as? PushRegistration
                 return account
         }
@@ -277,6 +287,19 @@ open class FirefoxAccount {
             }
         }
     }
+
+    // Don't forget to call Profile.flushAccount() to persist this change!
+    open func updateDeviceName(_ newName: String) {
+        self.deviceName = newName
+        if let registration = self.deviceRegistration {
+            // Reset the registration version/ts to make sure we'll do it again if we fail now.
+            self.deviceRegistration = FxADeviceRegistration(id: registration.id, version: 0, lastRegistered: 0)
+        }
+        if let session = stateCache.value as? TokenState {
+            // Update the device registration in the background.
+            _ = self.registerOrUpdateDevice(session: session)
+        }
+    }
     
     // Fetch current user's FxA profile. It contains the most updated email, displayName and avatar. This
     // emits two `NotificationFirefoxAccountProfileChanged`, once when the profile has been downloaded and
@@ -349,6 +372,16 @@ open class FirefoxAccount {
         return client.destroyDevice(ownDeviceId: ownDeviceId, withSessionToken: session.sessionToken as NSData) >>> succeed
     }
 
+    fileprivate func registerOrUpdateDevice(session: TokenState) -> Success {
+        let d = FxADeviceRegistrator.registerOrUpdateDevice(self, sessionToken: session.sessionToken as NSData)
+        d.upon { result in
+            if result.successValue != FxADeviceRegistrationResult.alreadyRegistered {
+                NotificationCenter.default.post(name: NotificationFirefoxAccountDeviceRegistrationUpdated, object: nil)
+            }
+        }
+        return d >>> succeed
+    }
+
     @discardableResult open func advance() -> Deferred<FxAState> {
         os_unfair_lock_lock(&advanceLock)
         if let deferred = advanceDeferred {
@@ -360,16 +393,12 @@ open class FirefoxAccount {
 
         // Alright, we haven't an advance() in progress.  Schedule a new deferred to chain from.
         let cachedState = stateCache.value!
-        var registration = succeed()
+        let registration: Success
         if let session = cachedState as? TokenState {
-            registration = FxADeviceRegistrator.registerOrUpdateDevice(self, sessionToken: session.sessionToken as NSData).bind { result in
-                if result.successValue != FxADeviceRegistrationResult.alreadyRegistered {
-                    NotificationCenter.default.post(name: NotificationFirefoxAccountDeviceRegistrationUpdated, object: nil)
-                }
-                return succeed()
-            }
+            registration = self.registerOrUpdateDevice(session: session)
+        } else {
+            registration = succeed()
         }
-
         let deferred: Deferred<FxAState> = registration.bind { _ in
             let client = FxAClient10(authEndpoint: self.configuration.authEndpointURL, oauthEndpoint: self.configuration.oauthEndpointURL, profileEndpoint: self.configuration.profileEndpointURL)
             let stateMachine = FxALoginStateMachine(client: client)

--- a/Account/FxADeviceRegistration.swift
+++ b/Account/FxADeviceRegistration.swift
@@ -93,14 +93,13 @@ open class FxADeviceRegistrator {
         }
 
         let client = client ?? FxAClient10(authEndpoint: account.configuration.authEndpointURL, oauthEndpoint: account.configuration.oauthEndpointURL, profileEndpoint: account.configuration.profileEndpointURL)
-        let name = DeviceInfo.defaultClientName()
         let device: FxADevice
         let registrationResult: FxADeviceRegistrationResult
         if let registration = account.deviceRegistration {
-            device = FxADevice.forUpdate(name, id: registration.id, push: pushParams)
+            device = FxADevice.forUpdate(account.deviceName, id: registration.id, push: pushParams)
             registrationResult = FxADeviceRegistrationResult.updated
         } else {
-            device = FxADevice.forRegister(name, type: "mobile", push: pushParams)
+            device = FxADevice.forRegister(account.deviceName, type: "mobile", push: pushParams)
             registrationResult = FxADeviceRegistrationResult.registered
         }
 

--- a/Account/SyncAuthState.swift
+++ b/Account/SyncAuthState.swift
@@ -23,6 +23,7 @@ public protocol SyncAuthState {
     func token(_ now: Timestamp, canBeExpired: Bool) -> Deferred<Maybe<(token: TokenServerToken, forKey: Data)>>
     var deviceID: String? { get }
     var enginesEnablements: [String: Bool]? { get set }
+    var clientName: String? { get set }
 }
 
 public func syncAuthStateCachefromJSON(_ json: JSON) -> SyncAuthStateCache? {
@@ -58,15 +59,8 @@ open class FirefoxAccountSyncAuthState: SyncAuthState {
     public var deviceID: String? {
         return account.deviceRegistration?.id
     }
-    var _engineEnablements: [String: Bool]?
-    public var enginesEnablements: [String : Bool]? {
-        get {
-            return _engineEnablements
-        }
-        set(val) {
-            _engineEnablements = val
-        }
-    }
+    public var enginesEnablements: [String : Bool]?
+    public var clientName: String?
 
     init(account: FirefoxAccount, cache: KeychainCache<SyncAuthStateCache>) {
         self.account = account

--- a/AccountTests/FirefoxAccountTests.swift
+++ b/AccountTests/FirefoxAccountTests.swift
@@ -37,7 +37,8 @@ class FirefoxAccountTests: XCTestCase {
                 deviceRegistration: (d["deviceRegistration"] as! FxADeviceRegistration),
                 declinedEngines: nil,
                 stateKeyLabel: Bytes.generateGUID(),
-                state: SeparatedState())
+                state: SeparatedState(),
+                deviceName: "my iphone")
 
         account1.pushRegistration = d["pushRegistration"] as? PushRegistration
 

--- a/AccountTests/LiveAccountTest.swift
+++ b/AccountTests/LiveAccountTest.swift
@@ -113,7 +113,7 @@ open class LiveAccountTest: XCTestCase {
     }
 
     // Internal helper.
-    func account(_ email: String, password: String, configuration: FirefoxAccountConfiguration) -> Deferred<Maybe<FirefoxAccount>> {
+    func account(_ email: String, password: String, deviceName: String, configuration: FirefoxAccountConfiguration) -> Deferred<Maybe<FirefoxAccount>> {
         let client = FxAClient10(authEndpoint: configuration.authEndpointURL)
         let emailUTF8 = email.utf8EncodedData
         let passwordUTF8 = password.utf8EncodedData
@@ -122,7 +122,7 @@ open class LiveAccountTest: XCTestCase {
         return login.bind { result in
             if let response = result.successValue {
                 let unwrapkB = FxAClient10.computeUnwrapKey(quickStretchedPW)
-                return Deferred(value: Maybe(success: FirefoxAccount.from(configuration, andLoginResponse: response, unwrapkB: unwrapkB)))
+                return Deferred(value: Maybe(success: FirefoxAccount.from(configuration, andLoginResponse: response, unwrapkB: unwrapkB, deviceName: deviceName)))
             } else {
                 return Deferred(value: Maybe(failure: result.failureValue!))
             }
@@ -131,7 +131,7 @@ open class LiveAccountTest: XCTestCase {
 
     func getTestAccount() -> Deferred<Maybe<FirefoxAccount>> {
         // TODO: Use signedInUser.json here.  It's hard to include the same resource file in two Xcode targets.
-        return self.account("998797987.sync@restmail.net", password: "998797987.sync@restmail.net",
+        return self.account("998797987.sync@restmail.net", password: "998797987.sync@restmail.net", deviceName: "My iPhone",
             configuration: ProductionFirefoxAccountConfiguration())
     }
 

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -88,11 +88,10 @@ class AppSettingsTableViewController: SettingsTableViewController {
                 AdvanceAccountSetting(settings: self),
                 // With a Firefox Account:
                 AccountStatusSetting(settings: self),
-                SyncNowSetting(settings: self),
-                SyncSetting(settings: self)
+                SyncNowSetting(settings: self)
             ] + accountChinaSyncSetting + accountDebugSettings)]
 
-        settings += [ SettingSection(title: NSAttributedString(string: NSLocalizedString("General", comment: "General settings section title")), children: generalSettings)]
+        settings += [ SettingSection(title: NSAttributedString(string: Strings.SettingsGeneralSectionTitle), children: generalSettings)]
 
         var privacySettings = [Setting]()
         privacySettings.append(LoginsSetting(settings: self, delegate: settingsDelegate))
@@ -133,10 +132,6 @@ class AppSettingsTableViewController: SettingsTableViewController {
                 EnableBookmarkMergingSetting(settings: self),
                 ForceCrashSetting(settings: self)
             ])]
-    
-            if profile.hasAccount() {
-                settings += [SettingSection(title: nil, footerTitle: NSAttributedString(string: ""), children: [DisconnectSetting(settings: self)])]
-            }
 
         return settings
     }

--- a/Client/Frontend/Settings/HomePageSettingsViewController.swift
+++ b/Client/Frontend/Settings/HomePageSettingsViewController.swift
@@ -68,7 +68,7 @@ class HomePageSettingsViewController: SettingsTableViewController {
     }
 }
 
-class WebPageSetting: StringSetting {
+class WebPageSetting: StringPrefSetting {
     init(prefs: Prefs, prefKey: String, defaultValue: String? = nil, placeholder: String, accessibilityIdentifier: String, settingDidChange: ((String?) -> Void)? = nil) {
         super.init(prefs: prefs,
                    prefKey: prefKey,

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -230,7 +230,7 @@ class BoolSetting: Setting {
 class StringSetting: Setting, UITextFieldDelegate {
 
     let prefKey: String
-    fileprivate let Padding: CGFloat = 8
+    var Padding: CGFloat = 8
 
     fileprivate let prefs: Prefs
     fileprivate let defaultValue: String?

--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -66,6 +66,42 @@ class DisconnectSetting: Setting {
     }
 }
 
+class DeviceNamePersister: SettingValuePersister {
+    let profile: Profile
+
+    init(profile: Profile) {
+        self.profile = profile
+    }
+
+    func readPersistedValue() -> String? {
+        return self.profile.getAccount()?.deviceName
+    }
+
+    func writePersistedValue(value: String?) {
+    }
+}
+
+class DeviceNameSetting: StringSetting {
+
+    override var Padding: CGFloat {
+        get { return 16 }
+        set { super.Padding = newValue }
+    }
+
+    init(settings: SettingsTableViewController) {
+        super.init(defaultValue: DeviceInfo.defaultClientName(), placeholder: "", accessibilityIdentifier: "DeviceNameSetting", persister: DeviceNamePersister(profile: settings.profile), settingIsValid: self.settingIsValid)
+    }
+
+    override func onConfigureCell(_ cell: UITableViewCell) {
+        super.onConfigureCell(cell)
+        textField.textAlignment = .left
+    }
+
+    func settingIsValid(value: String?) -> Bool {
+        return !(value?.isEmpty ?? true)
+    }
+}
+
 class SyncContentSettingsViewController: SettingsTableViewController {
     fileprivate var enginesToSyncOnExit: Set<String> = Set()
 
@@ -112,9 +148,12 @@ class SyncContentSettingsViewController: SettingsTableViewController {
 
         let enginesSection = SettingSection(title: NSAttributedString(string: Strings.FxASettingsSyncSettings), footerTitle: nil, children: [bookmarks, history, tabs, passwords])
 
+        let deviceName = DeviceNameSetting(settings: self)
+        let deviceNameSection = SettingSection(title: NSAttributedString(string: Strings.FxASettingsDeviceName), footerTitle: nil, children: [deviceName])
+
         let disconnect = DisconnectSetting(settings: self)
         let disconnectSection = SettingSection(title: nil, footerTitle: nil, children: [disconnect])
 
-        return [manageSection, enginesSection, disconnectSection]
+        return [manageSection, enginesSection, deviceNameSection, disconnectSection]
     }
 }

--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -6,13 +6,73 @@ import Foundation
 import Shared
 import Sync
 
+class ManageSetting: Setting {
+    let profile: Profile
+
+    override var accessoryType: UITableViewCellAccessoryType { return .disclosureIndicator }
+
+    override var accessibilityIdentifier: String? { return "Manage" }
+
+    init(settings: SettingsTableViewController) {
+        self.profile = settings.profile
+
+        super.init(title: NSAttributedString(string: Strings.FxAManageAccount, attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewRowTextColor]))
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        let viewController = FxAContentViewController(profile: profile)
+
+        if let account = profile.getAccount() {
+            var cs = URLComponents(url: account.configuration.settingsURL, resolvingAgainstBaseURL: false)
+            cs?.queryItems?.append(URLQueryItem(name: "email", value: account.email))
+            if let url = try? cs?.asURL() {
+                viewController.url = url
+            }
+        }
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
+class DisconnectSetting: Setting {
+    let profile: Profile
+    override var accessoryType: UITableViewCellAccessoryType { return .none }
+    override var textAlignment: NSTextAlignment { return .center }
+
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: Strings.SettingsDisconnectSyncButton, attributes: [NSForegroundColorAttributeName: UIConstants.DestructiveRed])
+    }
+    init(settings: SettingsTableViewController) {
+        self.profile = settings.profile
+    }
+
+    override var accessibilityIdentifier: String? { return "SignOut" }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        let alertController = UIAlertController(
+            title: Strings.SettingsDisconnectSyncAlertTitle,
+            message: Strings.SettingsDisconnectSyncAlertBody,
+            preferredStyle: UIAlertControllerStyle.alert)
+        alertController.addAction(
+            UIAlertAction(title: Strings.SettingsDisconnectCancelAction, style: .cancel) { (action) in
+                // Do nothing.
+        })
+        alertController.addAction(
+            UIAlertAction(title: Strings.SettingsDisconnectDestructiveAction, style: .destructive) { (action) in
+                FxALoginHelper.sharedInstance.applicationDidDisconnect(UIApplication.shared)
+                LeanPlumClient.shared.set(attributes: [LPAttributeKey.signedInSync: self.profile.hasAccount()])
+                _ = navigationController?.popViewController(animated: true)
+        })
+        navigationController?.present(alertController, animated: true, completion: nil)
+    }
+}
+
 class SyncContentSettingsViewController: SettingsTableViewController {
     fileprivate var enginesToSyncOnExit: Set<String> = Set()
 
     init() {
         super.init(style: .grouped)
 
-        self.title = Strings.SettingsSyncTitle
+        self.title = Strings.FxASettingsTitle
         hasSectionSeparatorLine = false
     }
 
@@ -42,13 +102,19 @@ class SyncContentSettingsViewController: SettingsTableViewController {
     }
 
     override func generateSettings() -> [SettingSection] {
+        let manage = ManageSetting(settings: self)
+        let manageSection = SettingSection(title: nil, footerTitle: nil, children: [manage])
+
         let bookmarks = BoolSetting(prefs: profile.prefs, prefKey: "sync.engine.bookmarks.enabled", defaultValue: true, attributedTitleText: NSAttributedString(string: Strings.FirefoxSyncBookmarksEngine), attributedStatusText: nil, settingDidChange: engineSettingChanged("bookmarks"))
         let history = BoolSetting(prefs: profile.prefs, prefKey: "sync.engine.history.enabled", defaultValue: true, attributedTitleText: NSAttributedString(string: Strings.FirefoxSyncHistoryEngine), attributedStatusText: nil, settingDidChange: engineSettingChanged("history"))
         let tabs = BoolSetting(prefs: profile.prefs, prefKey: "sync.engine.tabs.enabled", defaultValue: true, attributedTitleText: NSAttributedString(string: Strings.FirefoxSyncTabsEngine), attributedStatusText: nil, settingDidChange: engineSettingChanged("tabs"))
         let passwords = BoolSetting(prefs: profile.prefs, prefKey: "sync.engine.passwords.enabled", defaultValue: true, attributedTitleText: NSAttributedString(string: Strings.FirefoxSyncLoginsEngine), attributedStatusText: nil, settingDidChange: engineSettingChanged("passwords"))
 
-        let syncOptions = SettingSection(title: NSAttributedString(string: Strings.SettingsSyncSectionName), footerTitle: nil, children: [bookmarks, history, tabs, passwords])
+        let enginesSection = SettingSection(title: NSAttributedString(string: Strings.FxASettingsSyncSettings), footerTitle: nil, children: [bookmarks, history, tabs, passwords])
 
-        return [syncOptions]
+        let disconnect = DisconnectSetting(settings: self)
+        let disconnectSection = SettingSection(title: nil, footerTitle: nil, children: [disconnect])
+
+        return [manageSection, enginesSection, disconnectSection]
     }
 }

--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -78,6 +78,12 @@ class DeviceNamePersister: SettingValuePersister {
     }
 
     func writePersistedValue(value: String?) {
+        guard let newName = value,
+              let account = self.profile.getAccount() else {
+            return
+        }
+        account.updateDeviceName(newName)
+        self.profile.flushAccount()
     }
 }
 

--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -84,6 +84,7 @@ class DeviceNamePersister: SettingValuePersister {
         }
         account.updateDeviceName(newName)
         self.profile.flushAccount()
+        _ = self.profile.syncManager.syncNamedCollections(why: .clientNameChanged, names: ["clients"])
     }
 }
 

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -180,6 +180,7 @@ extension Strings {
     public static let FxANoInternetConnection = NSLocalizedString("FxA.NoInternetConnection", value: "No Internet Connection", comment: "Label when no internet is present")
     public static let FxASettingsTitle = NSLocalizedString("Settings.FxA.Title", value: "Firefox Account", comment: "Title displayed in header of the FxA settings panel.")
     public static let FxASettingsSyncSettings = NSLocalizedString("Settings.FxA.Sync.SectionName", value: "Sync Settings", comment: "Label used as an section title in the Firefox Accounts Settings screen.")
+    public static let FxASettingsDeviceName = NSLocalizedString("Settings.FxA.DeviceName", value: "Device Name", comment: "Label used for the device name settings section.")
     
     // Surface error strings
     public static let FxAAccountVerificationRequiredSurface = NSLocalizedString("FxA.AccountVerificationRequiredSurface", value: "You need to verify %@. Check your email for the verification link from Firefox.", comment: "Message explaining that user needs to check email for Firefox Account verfication link.")

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -76,11 +76,14 @@ extension Strings {
 
 // Settings.
 extension Strings {
+    public static let SettingsGeneralSectionTitle = NSLocalizedString("Settings.General.SectionName", value: "General", comment: "General settings section title")
     public static let SettingsClearPrivateDataClearButton = NSLocalizedString("Settings.ClearPrivateData.Clear.Button", value: "Clear Private Data", comment: "Button in settings that clears private data for the selected items.")
     public static let SettingsClearPrivateDataSectionName = NSLocalizedString("Settings.ClearPrivateData.SectionName", value: "Clear Private Data", comment: "Label used as an item in Settings. When touched it will open a dialog prompting the user to make sure they want to clear all of their private data.")
     public static let SettingsClearPrivateDataTitle = NSLocalizedString("Settings.ClearPrivateData.Title", value: "Clear Private Data", comment: "Title displayed in header of the setting panel.")
     public static let SettingsDisconnectSyncAlertTitle = NSLocalizedString("Settings.Disconnect.Title", value: "Disconnect Sync?", comment: "Title of the alert when prompting the user asking to disconnect.")
+    public static let SettingsDisconnectSyncAlertBody = NSLocalizedString("Settings.Disconnect.Body", value: "Firefox will stop syncing with your account, but won’t delete any of your browsing data on this device.", comment: "Body of the alert when prompting the user asking to disconnect.")
     public static let SettingsDisconnectSyncButton = NSLocalizedString("Settings.Disconnect.Button", value: "Disconnect Sync", comment: "Button displayed at the bottom of settings page allowing users to Disconnect from FxA")
+    public static let SettingsDisconnectCancelAction = NSLocalizedString("Settings.Disconnect.CancelButton", value: "Cancel", comment: "Cancel action button in alert when user is prompted for disconnect")
     public static let SettingsDisconnectDestructiveAction = NSLocalizedString("Settings.Disconnect.DestructiveButton", value: "Disconnect", comment: "Destructive action button in alert when user is prompted for disconnect")
     public static let SettingsSearchDoneButton = NSLocalizedString("Settings.Search.Done.Button", value: "Done", comment: "Button displayed at the top of the search settings.")
     public static let SettingsSearchEditButton = NSLocalizedString("Settings.Search.Edit.Button", value: "Edit", comment: "Button displayed at the top of the search settings.")
@@ -172,11 +175,11 @@ extension Strings {
     public static let FxASyncUsageDetails = NSLocalizedString("FxA.SyncExplain", value: "Get your tabs, bookmarks, and passwords from your other devices.", comment: "Label explaining what sync does")
     public static let FxAAccountVerificationRequired = NSLocalizedString("FxA.AccountVerificationRequired", value: "Account Verification Required", comment: "Label stating your account is not verified")
     public static let FxAAccountVerificationDetails = NSLocalizedString("FxA.AccountVerificationDetails", value: "Wrong email? Disconnect below to start over.", comment: "Label stating how to disconnect account")
-    public static let FxAManageAccount = NSLocalizedString("FxA.ManageAccount", value: "Manage Account", comment: "Button label to goto Firefox Account settings")
+    public static let FxAManageAccount = NSLocalizedString("FxA.ManageAccount", value: "Manage Account & Devices", comment: "Button label to goto Firefox Account settings")
     public static let FxASyncNow = NSLocalizedString("FxA.SyncNow", value: "Sync Now", comment: "Button label to Sync your Firefox Account")
     public static let FxANoInternetConnection = NSLocalizedString("FxA.NoInternetConnection", value: "No Internet Connection", comment: "Label when no internet is present")
-    public static let SettingsSyncSectionName = NSLocalizedString("Settings.Sync.SectionName", value: "Sync Options", comment: "Label used as an item in Settings. When touched it will open a dialog to configure the sync options.")
-    public static let SettingsSyncTitle = NSLocalizedString("Settings.Sync.Title", value: "Sync Options", comment: "Title displayed in header of the sync setting panel.")
+    public static let FxASettingsTitle = NSLocalizedString("Settings.FxA.Title", value: "Firefox Account", comment: "Title displayed in header of the FxA settings panel.")
+    public static let FxASettingsSyncSettings = NSLocalizedString("Settings.FxA.Sync.SectionName", value: "Sync Settings", comment: "Label used as an section title in the Firefox Accounts Settings screen.")
     
     // Surface error strings
     public static let FxAAccountVerificationRequiredSurface = NSLocalizedString("FxA.AccountVerificationRequiredSurface", value: "You need to verify %@. Check your email for the verification link from Firefox.", comment: "Message explaining that user needs to check email for Firefox Account verfication link.")

--- a/ClientTests/FxAPushMessageTest.swift
+++ b/ClientTests/FxAPushMessageTest.swift
@@ -64,7 +64,8 @@ class FxAPushMessageTest: XCTestCase {
             deviceRegistration: nil,
             declinedEngines: nil,
             stateKeyLabel: "xxx",
-            state: SeparatedState())
+            state: SeparatedState(),
+            deviceName: "My iPhone")
 
         let registration = PushRegistration(uaid: "uaid", secret: "secret", subscription: subscription)
 
@@ -90,7 +91,8 @@ class FxAPushMessageTest: XCTestCase {
             deviceRegistration: nil,
             declinedEngines: nil,
             stateKeyLabel: "xxx",
-            state: SeparatedState())
+            state: SeparatedState(),
+            deviceName: "My iPhone")
 
         profile.setAccount(account)
 

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -1132,6 +1132,8 @@ open class BrowserProfile: Profile {
                 log.debug("engines to disable: \(enginesEnablements.flatMap { !$0.value ? $0.key : nil })")
             }
 
+            authState?.clientName = account.deviceName
+
             let readyDeferred = SyncStateMachine(prefs: self.prefsForSync).toReady(authState!)
 
             let function: (SyncDelegate, Prefs, Ready) -> Deferred<Maybe<[EngineStatus]>> = { delegate, syncPrefs, ready in

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -170,6 +170,10 @@ open class SyncStateMachine {
                 b.enginesEnablements = enginesEnablements
             }
 
+            if let clientName = authState.clientName {
+                b.clientName = clientName
+            }
+
             // Detect if we've changed anything in our client record from the last time we synced…
             let ourClientUnchanged = (b.fxaDeviceId == scratchpad.fxaDeviceId)
 

--- a/Sync/SyncTelemetryUtils.swift
+++ b/Sync/SyncTelemetryUtils.swift
@@ -23,6 +23,7 @@ public enum SyncReason: String {
     case didLogin = "didLogin"
     case push = "push"
     case engineEnabled = "engineEnabled"
+    case clientNameChanged = "clientNameChanged"
 }
 
 public enum SyncPingReason: String {

--- a/Sync/Synchronizers/ClientsSynchronizer.swift
+++ b/Sync/Synchronizers/ClientsSynchronizer.swift
@@ -373,7 +373,8 @@ open class ClientsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchro
             >>== { self.processCommandsFromRecord(ours, withServer: storageClient) }
             >>== { (shouldUpload, commands) in
                 let isFirstSync = self.lastFetched == 0
-                return self.maybeUploadOurRecord(shouldUpload || self.why == .didLogin, ifUnmodifiedSince: ours?.modified, toServer: storageClient)
+                let ourRecordDidChange = self.why == .didLogin || self.why == .clientNameChanged
+                return self.maybeUploadOurRecord(shouldUpload || ourRecordDidChange, ifUnmodifiedSince: ours?.modified, toServer: storageClient)
                     >>> { self.uploadClientCommands(toLocalClients: localClients, withServer: storageClient) }
                     >>> {
                         log.debug("Running \(commands.count) commands.")

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -16,6 +16,8 @@ import SwiftyJSON
 private let log = Logger.syncLogger
 
 class MockSyncAuthState: SyncAuthState {
+    var clientName: String?
+
     var enginesEnablements: [String : Bool]?
 
     let serverRoot: String


### PR DESCRIPTION
This PR does two things:

- Moves the "Manage"/"Disconnect" buttons under a single "Firefox Account" settings screen.
- Adds a "Device Name" section.
<img width="551" alt="screen shot 2017-11-22 at 5 23 24 pm" src="https://user-images.githubusercontent.com/6424575/33152276-e3424ca8-cfa9-11e7-9eca-bfb23836df76.png">
