### PR TITLE
Bug 1414812 - Fix overlapping icons in Send Tab page on iPad. 

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -183,6 +183,7 @@ extension PhotonActionSheetProtocol {
                 let instructionsViewController = InstructionsViewController()
                 instructionsViewController.delegate = bvc
                 let navigationController = UINavigationController(rootViewController: instructionsViewController)
+                navigationController.modalPresentationStyle = .formSheet
                 bvc.present(navigationController, animated: true, completion: nil)
                 return
             }
@@ -192,6 +193,7 @@ extension PhotonActionSheetProtocol {
             clientPickerViewController.profile = self.profile
             clientPickerViewController.profileNeedsShutdown = false
             let navigationController = UINavigationController(rootViewController: clientPickerViewController)
+            navigationController.modalPresentationStyle = .formSheet
             bvc.present(navigationController, animated: true, completion: nil)
         }
         


### PR DESCRIPTION
Simply use a presentation style that forces the VC to be smaller. It looks better and fits what we do with Settings as well. 