### PR TITLE
Bug1420207-XCUITest iPad Access Private Mode directly from HomePanel

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
@@ -194,6 +194,12 @@
                   Identifier = "NavigationTest/testToggleBetweenMobileAndDesktopSiteFromSite()">
                </Test>
                <Test
+                  Identifier = "PrivateBrowsingTest/testiPadDirectAccessPrivateMode()">
+               </Test>
+               <Test
+                  Identifier = "PrivateBrowsingTest/testiPadDirectAccessPrivateModeBrowserTab()">
+               </Test>
+               <Test
                   Identifier = "SearchTests/testDismissPromptPresence()">
                </Test>
                <Test

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -115,6 +115,10 @@ class Action {
     static let ReloadURL = "ReloadURL"
 
     static let TogglePrivateMode = "TogglePrivateBrowing"
+    static let TogglePrivateModeFromTabBarHomePanel = "TogglePrivateModeFromTabBarHomePanel"
+    static let TogglePrivateModeFromTabBarBrowserTab = "TogglePrivateModeFromTabBarBrowserTab"
+    static let TogglePrivateModeFromTabBarNewTab = "TogglePrivateModeFromTabBarNewTab"
+
     static let ToggleRequestDesktopSite = "ToggleRequestDesktopSite"
     static let ToggleNightMode = "ToggleNightMode"
     static let ToggleNoImageMode = "ToggleNoImageMode"
@@ -265,6 +269,9 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> Scree
         screenState.noop(to: HomePanelsScreen)
         makeURLBarAvailable(screenState)
         screenState.tap(app.buttons["TabToolbar.menuButton"], to: BrowserTabMenu)
+        screenState.tap(app.buttons["Private Mode"], forAction: Action.TogglePrivateModeFromTabBarNewTab, if: "tablet == true") { userState in
+            userState.isPrivate = !userState.isPrivate
+        }
     }
 
     map.addScreenState(URLBarLongPressMenu) { screenState in
@@ -344,6 +351,10 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> Scree
         screenState.tap(app.buttons["HomePanels.Bookmarks"], to: HomePanel_Bookmarks)
         screenState.tap(app.buttons["HomePanels.History"], to: HomePanel_History)
         screenState.tap(app.buttons["HomePanels.ReadingList"], to: HomePanel_ReadingList)
+
+        screenState.tap(app.buttons["Private Mode"], forAction: Action.TogglePrivateModeFromTabBarHomePanel, if: "tablet == true") { userState in
+            userState.isPrivate = !userState.isPrivate
+        }
 
         // Workaround to bug Bug 1417522
         if isTablet {
@@ -642,6 +653,10 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> Scree
         let reloadButton = app.buttons["TabToolbar.stopReloadButton"]
         screenState.press(reloadButton, to: ReloadLongPressMenu)
         screenState.tap(reloadButton, forAction: Action.ReloadURL, transitionTo: WebPageLoading) { _ in }
+
+        screenState.tap(app.buttons["Private Mode"], forAction: Action.TogglePrivateModeFromTabBarBrowserTab) { userState in
+            userState.isPrivate = !userState.isPrivate
+        }
     }
 
     map.addScreenState(ReloadLongPressMenu) { screenState in

--- a/XCUITests/PrivateBrowsingTest.swift
+++ b/XCUITests/PrivateBrowsingTest.swift
@@ -142,4 +142,40 @@ class PrivateBrowsingTest: BaseTestCase {
         let numPrivTabsOpen = userState.numTabs
         XCTAssertEqual(numPrivTabsOpen, 1, "The number of tabs is not correct, there should be one private tab")
     }
+
+    func testiPadDirectAccessPrivateMode() {
+        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateModeFromTabBarHomePanel)
+
+        // A Tab opens directly in HomePanels view
+        XCTAssertFalse(app.staticTexts["Private Browsing"].exists, "Private Browsing screen is not shown")
+
+        // Open website and check it does not appear under history once going back to regular mode
+        navigator.openURL("http://example.com")
+        navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateModeFromTabBarHomePanel)
+        navigator.goto(HomePanel_History)
+        waitforExistence(app.tables["History List"])
+        // History without counting Recently Closed and Synced devices
+        let history = app.tables["History List"].cells.count - 2
+        XCTAssertEqual(history, 0, "History list should be empty")
+    }
+
+    func testiPadDirectAccessPrivateModeBrowserTab() {
+        navigator.openURL("www.mozilla.org")
+        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateModeFromTabBarBrowserTab)
+
+        // A Tab opens directly in HomePanels view
+        XCTAssertFalse(app.staticTexts["Private Browsing"].exists, "Private Browsing screen is not shown")
+
+        // Open website and check it does not appear under history once going back to regular mode
+        navigator.openURL("http://example.com")
+        navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateModeFromTabBarBrowserTab)
+        navigator.browserPerformAction(.openHistoryOption)
+        waitforExistence(app.tables["History List"])
+        // History without counting Recently Closed and Synced devices
+        let history = app.tables["History List"].cells.count - 2
+        XCTAssertEqual(history, 1, "There should be one entry in History")
+        let savedToHistory = app.tables["History List"].cells.staticTexts[url1Label]
+        waitforExistence(savedToHistory)
+        XCTAssertTrue(savedToHistory.exists)
+    }
 }


### PR DESCRIPTION
This PR aims to create a new XCUITest for iPad in order to check and verify the option that allows to enable the private mode from the home panels view
![private mode direct access](https://user-images.githubusercontent.com/1897507/33206673-47194292-d10b-11e7-8132-092b2b1f968a.png)
