### PR TITLE
Bug1421352 - Fix UITests different acc.id and EarlGrey timeout to tap on element on iPad

### DIFF
--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -229,7 +229,11 @@ class BrowserUtils {
         EarlGrey.select(elementWithMatcher: grey_accessibilityLabel("Cancel")).perform(grey_tap(), error: &error)
         error = nil
 
-        EarlGrey.select(elementWithMatcher: grey_accessibilityID("TabToolbar.tabsButton")).perform(grey_tap())
+        if iPad() {
+            EarlGrey.select(elementWithMatcher: grey_accessibilityID("TopTabsViewController.tabsButton")).perform(grey_tap())
+        } else {
+            EarlGrey.select(elementWithMatcher: grey_accessibilityID("TabToolbar.tabsButton")).perform(grey_tap())
+        }
 
         let goPrivateModeBtn = grey_allOf([grey_accessibilityID("TabTrayController.maskButton"), grey_accessibilityValue("Off")])
         let goNormalModeBtn = grey_allOf([grey_accessibilityID("TabTrayController.maskButton"), grey_accessibilityValue("On")])
@@ -318,7 +322,7 @@ class BrowserUtils {
         EarlGrey.select(elementWithMatcher:settings_button).perform(grey_tap())
         EarlGrey.select(elementWithMatcher: grey_accessibilityLabel("Clear Private Data"))
             .using(searchAction: grey_scrollInDirection(.down, 200),
-                   onElementWithMatcher: grey_kindOfClass(UITableView.self))
+                   onElementWithMatcher: grey_accessibilityID("AppSettingsTableViewController.tableView"))
             .assert(grey_notNil())
         EarlGrey.select(elementWithMatcher:grey_accessibilityLabel("Clear Private Data")).perform(grey_tap())
     }

--- a/UITests/ToolbarTests.swift
+++ b/UITests/ToolbarTests.swift
@@ -19,7 +19,7 @@ class ToolbarTests: KIFTestCase, UITextFieldDelegate {
         let textField = tester().waitForView(withAccessibilityIdentifier: "url") as! UITextField
         EarlGrey.select(elementWithMatcher: grey_accessibilityID("url")).perform(grey_tap())
         EarlGrey.select(elementWithMatcher: grey_accessibilityID("address")).perform(grey_typeText("foobar"))
-        EarlGrey.select(elementWithMatcher: grey_accessibilityID("goBack")).perform(grey_tap())
+        tester().tapView(withAccessibilityIdentifier: "goBack")
         XCTAssertNotEqual(textField.text, "foobar", "Verify that the URL bar text clears on about:home")
 
         // 127.0.0.1 doesn't cause http:// to be hidden. localhost does. Both will work.
@@ -38,7 +38,7 @@ class ToolbarTests: KIFTestCase, UITextFieldDelegate {
 
         EarlGrey.select(elementWithMatcher: grey_accessibilityID("url")).perform(grey_tap())
         EarlGrey.select(elementWithMatcher: grey_accessibilityID("address")).perform(grey_typeText("foobar"))
-        EarlGrey.select(elementWithMatcher: grey_accessibilityID("goBack")).perform(grey_tap())
+        tester().tapView(withAccessibilityIdentifier: "goBack")
         tester().waitForAnimationsToFinish()
         XCTAssertEqual(textField.text, displayURL, "Verify that text reverts to page URL after entering text")
 


### PR DESCRIPTION
UITests are failing in master on the iPad sim. It is not possible to tap on an element which is different than on iPhone.
This PR tries to fix that.