### PR TITLE
Bug 1422421 - Remove bookmark status from tab.

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -645,7 +645,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
     fileprivate func addBookmark(_ notification: UNNotification) {
         if let alertURL = notification.request.content.userInfo[TabSendURLKey] as? String,
             let title = notification.request.content.userInfo[TabSendTitleKey] as? String {
-            let tabState = TabState(isPrivate: false, desktopSite: false, isBookmarked: false, url: URL(string: alertURL), title: title, favicon: nil)
+            let tabState = TabState(isPrivate: false, desktopSite: false, url: URL(string: alertURL), title: title, favicon: nil)
                 browserViewController.addBookmark(tabState)
 
                 let userData = [QuickActions.TabURLKey: alertURL,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1263,7 +1263,8 @@ extension BrowserViewController: URLBarDelegate {
         
         guard let tab = tabManager.selectedTab, let urlString = tab.url?.absoluteString else { return }
 
-        self.fetchBookmarkStatus(for: urlString) { (isBookmarked) in
+        fetchBookmarkStatus(for: urlString).uponQueue(.main) {
+            let isBookmarked = $0.successValue ?? false
             let pageActions = self.getTabActions(tab: tab, buttonView: button, presentShareMenu: actionMenuPresenter,
                                                  findInPage: findInPageAction, presentableVC: self, isBookmarked: isBookmarked,
                                                  success: successCallback)

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -27,7 +27,6 @@ protocol TabDelegate {
 struct TabState {
     var isPrivate: Bool = false
     var desktopSite: Bool = false
-    var isBookmarked: Bool = false
     var url: URL?
     var title: String?
     var favicon: Favicon?
@@ -47,7 +46,7 @@ class Tab: NSObject {
     }
 
     var tabState: TabState {
-        return TabState(isPrivate: _isPrivate, desktopSite: desktopSite, isBookmarked: isBookmarked, url: url, title: displayTitle, favicon: displayFavicon)
+        return TabState(isPrivate: _isPrivate, desktopSite: desktopSite, url: url, title: displayTitle, favicon: displayFavicon)
     }
 
     // PageMetadata is derived from the page content itself, and as such lags behind the
@@ -107,7 +106,6 @@ class Tab: NSObject {
     /// Whether or not the desktop site was requested with the last request, reload or navigation. Note that this property needs to
     /// be managed by the web view's navigation delegate.
     var desktopSite: Bool = false
-    var isBookmarked: Bool = false
     
     var readerModeAvailableOrActive: Bool {
         if let readerMode = self.getHelper(name: "ReaderMode") as? ReaderMode {

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -9,8 +9,6 @@ import XCGLogger
 
 private let log = Logger.browserLogger
 
-let BookmarkStatusChangedNotification = "BookmarkStatusChangedNotification"
-
 // MARK: - Placeholder strings for Bug 1232810.
 
 let deleteWarningTitle = NSLocalizedString("This folder isn’t empty.", tableName: "BookmarkPanelDeleteConfirm", comment: "Title of the confirmation alert when the user tries to delete a folder that still contains bookmarks and/or folders.")
@@ -438,9 +436,6 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         self.tableView.deleteRows(at: [indexPath], with: UITableViewRowAnimation.left)
         self.tableView.endUpdates()
         self.updateEmptyPanelState()
-
-        NotificationCenter.default.post(name: NSNotification.Name(rawValue: BookmarkStatusChangedNotification), object: bookmark, userInfo: ["added": false]
-        )
     }
 }
 

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Shared
 import Storage
+import Deferred
 
 protocol PhotonActionSheetProtocol {
     var tabManager: TabManager { get }
@@ -224,11 +225,12 @@ extension PhotonActionSheetProtocol {
         return [topActions, [copyURL, findInPageAction, toggleDesktopSite, pinToTopSites, sendToDevice, closeTab], [share]]
     }
 
-    func fetchBookmarkStatus(for url: String, completionHandler: @escaping (Bool) -> Void) {
-        self.profile.bookmarks.modelFactory >>== {
-            $0.isBookmarked(url).uponQueue(.main) { result in
-                completionHandler(result.successValue ?? false)
+    func fetchBookmarkStatus(for url: String) -> Deferred<Maybe<Bool>> {
+        return self.profile.bookmarks.modelFactory.bind {
+            guard let factory = $0.successValue else {
+                return deferMaybe(false)
             }
+            return factory.isBookmarked(url)
         }
     }
 }

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -113,6 +113,7 @@ extension PhotonActionSheetProtocol {
                        presentShareMenu: @escaping (URL, Tab, UIView, UIPopoverArrowDirection) -> Void,
                        findInPage:  @escaping () -> Void,
                        presentableVC: PresentableVC,
+                       isBookmarked: Bool,
                        success: @escaping (String) -> Void) -> Array<[PhotonActionSheetItem]> {
         
         let toggleActionTitle = tab.desktopSite ? Strings.AppMenuViewMobileSiteTitleString : Strings.AppMenuViewDesktopSiteTitleString
@@ -144,7 +145,6 @@ extension PhotonActionSheetProtocol {
             QuickActions.sharedInstance.addDynamicApplicationShortcutItemOfType(.openLastBookmark,
                                                                                 withUserData: userData,
                                                                                 toApplication: UIApplication.shared)
-            tab.isBookmarked = true
             success(Strings.AppMenuAddBookmarkConfirmMessage)
         }
         
@@ -155,7 +155,6 @@ extension PhotonActionSheetProtocol {
             self.profile.bookmarks.modelFactory >>== {
                 $0.removeByURL(absoluteString).uponQueue(.main) { res in
                     if res.isSuccess {
-                        tab.isBookmarked = false
                         success(Strings.AppMenuRemoveBookmarkConfirmMessage)
                     }
                 }
@@ -215,7 +214,7 @@ extension PhotonActionSheetProtocol {
 
         // Disable bookmarking and reading list if the URL is too long.
         if !tab.urlIsTooLong {
-            topActions.append(tab.isBookmarked ? removeBookmark : bookmarkPage)
+            topActions.append(isBookmarked ? removeBookmark : bookmarkPage)
 
             if tab.readerModeAvailableOrActive {
                 topActions.append(addReadingList)
@@ -223,6 +222,14 @@ extension PhotonActionSheetProtocol {
         }
 
         return [topActions, [copyURL, findInPageAction, toggleDesktopSite, pinToTopSites, sendToDevice, closeTab], [share]]
+    }
+
+    func fetchBookmarkStatus(for url: String, completionHandler: @escaping (Bool) -> Void) {
+        self.profile.bookmarks.modelFactory >>== {
+            $0.isBookmarked(url).uponQueue(.main) { result in
+                completionHandler(result.successValue ?? false)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
We were doing a DB query every time we select a tab or load a new URL. We can defer this query until we are about to open the menu instead because we actually dont use the bookmark status until then. 

We already do this in the HomePanel context menu so this shouldnt be much different.