### PR TITLE
Bug 1417034 — Simplify SQL to find the most recent visits to the list of recently visited sites.

### DIFF
--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -206,6 +206,12 @@ open class BrowserDB {
         }
     }
 
+    func runQueryUnsafe<T>(_ sql: String, args: Args?, factory: @escaping (SDRow) -> T) -> Deferred<Maybe<Cursor<T>>> {
+        return withConnection { connection -> Cursor<T> in
+            connection.executeQueryUnsafe(sql, factory: factory, withArgs: args)
+        }
+    }
+
     func queryReturnsResults(_ sql: String, args: Args? = nil) -> Deferred<Maybe<Bool>> {
         return runQuery(sql, args: args, factory: { _ in true })
          >>== { deferMaybe($0[0] ?? false) }


### PR DESCRIPTION
This PR fixes an out of memory crash by eliminating a join in SQL. The SQL was solving a greatest-N-per-group problem, 
which involved joining a potentially very large table to itself.

The fix moves the grouping into swift, and uses a `LiveCursor` to ensure that only the minimum elements are in memory.

https://bugzilla.mozilla.org/show_bug.cgi?id=1417034