### PR TITLE
Bug 1417117 - Make DB handle acquisition off-main, add back Cancellation 

### DIFF
--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -22,7 +22,6 @@ typealias SearchLoader = _SearchLoader<AnyObject, AnyObject>
 class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController> {
     fileprivate let profile: Profile
     fileprivate let urlBar: URLBarView
-    fileprivate var inProgress: Cancellable?
 
     init(profile: Profile, urlBar: URLBarView) {
         self.profile = profile
@@ -51,13 +50,8 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
                 return
             }
 
-            if let inProgress = inProgress {
-                inProgress.cancel()
-                self.inProgress = nil
-            }
-
             if let currentDbQuery = currentDbQuery {
-                profile.db.cancel({ [weak currentDbQuery] in return currentDbQuery})
+                profile.db.cancel(databaseOperation: WeakRef(currentDbQuery))
             }
 
             let deferred = self.profile.history.getSitesByFrecencyWithHistoryLimit(100, bookmarksLimit: 5, whereURLContains: query)

--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -35,7 +35,7 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
         return try! String(contentsOfFile: filePath!).components(separatedBy: "\n")
     }()
 
-    private weak var currentDbQuery: Cancellable?
+    private var currentDbQuery: Cancellable?
 
     var query: String = "" {
         didSet {
@@ -62,6 +62,10 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
             currentDbQuery = deferred as? Cancellable
 
             deferred.uponQueue(DispatchQueue.main) { result in
+                defer {
+                    self.currentDbQuery = nil
+                }
+
                 guard let deferred = deferred as? Cancellable, !deferred.cancelled else {
                     return
                 }

--- a/Shared/Cancellable.swift
+++ b/Shared/Cancellable.swift
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-public protocol Cancellable {
+public protocol Cancellable : class {
     func cancel()
     var cancelled: Bool { get }
+    var running: Bool { get set }
 }

--- a/Shared/Cancellable.swift
+++ b/Shared/Cancellable.swift
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-public protocol Cancellable : class {
+public protocol Cancellable: class {
     func cancel()
     var cancelled: Bool { get }
     var running: Bool { get set }

--- a/Shared/WeakList.swift
+++ b/Shared/WeakList.swift
@@ -55,10 +55,10 @@ open class WeakList<T: AnyObject>: Sequence {
     }
 }
 
-private class WeakRef<T: AnyObject> {
-    weak var value: T?
+open class WeakRef<T: AnyObject> {
+    public weak var value: T?
 
-    init(_ value: T) {
+    public init(_ value: T) {
         self.value = value
     }
 }

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -34,8 +34,9 @@ open class BrowserDB {
 
     // Remove the DB op from the queue (by marking it cancelled), and if it is already running tell sqlite to cancel it.
     // At any point the operation could complete on another thread, so it is held weakly.
-    public func cancel(_ weakDBOperationGetter: () -> Cancellable?) {
-        weak var databaseOperation = weakDBOperationGetter()
+    // Swift compiler bug: failing to compile WeakRef<Cancellable> here.
+    public func cancel(databaseOperation: WeakRef<AnyObject>) {
+        weak var databaseOperation = databaseOperation.value as? Cancellable
         databaseOperation?.cancel()
         if databaseOperation?.running ?? false {
             db.cancel()

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -33,9 +33,11 @@ open class BrowserDB {
     }
 
     // Remove the DB op from the queue (by marking it cancelled), and if it is already running tell sqlite to cancel it.
-    public func cancel(databaseOperation: Cancellable) {
-        databaseOperation.cancel()
-        if databaseOperation.running {
+    // At any point the operation could complete on another thread, so it is held weakly.
+    public func cancel(_ weakDBOperationGetter: () -> Cancellable?) {
+        weak var databaseOperation = weakDBOperationGetter()
+        databaseOperation?.cancel()
+        if databaseOperation?.running ?? false {
             db.cancel()
         }
     }

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -32,6 +32,14 @@ open class BrowserDB {
         self.db = SwiftData(filename: file, key: secretKey, prevKey: nil, schema: schema, files: files)
     }
 
+    // Remove the DB op from the queue (by marking it cancelled), and if it is already running tell sqlite to cancel it.
+    public func cancel(databaseOperation: Cancellable) {
+        databaseOperation.cancel()
+        if databaseOperation.running {
+            db.cancel()
+        }
+    }
+
     // For testing purposes or other cases where we want to ensure that this `BrowserDB`
     // instance has been initialized (schema is created/updated).
     public func touch() -> Success {

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -37,6 +37,12 @@ open class BrowserDB {
     // Swift compiler bug: failing to compile WeakRef<Cancellable> here.
     public func cancel(databaseOperation: WeakRef<AnyObject>) {
         weak var databaseOperation = databaseOperation.value as? Cancellable
+
+        db.suspendQueue()
+        defer {
+            db.resumeQueue()
+        }
+
         databaseOperation?.cancel()
         if databaseOperation?.running ?? false {
             db.cancel()

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -134,25 +134,6 @@ open class SwiftData {
         assert(sqlite3_threadsafe() == 2)
     }
 
-    fileprivate func getSharedConnection() -> ConcreteSQLiteDBConnection? {
-        var connection: ConcreteSQLiteDBConnection?
-
-        sharedConnectionQueue.sync {
-            if self.closed {
-                log.warning(">>> Database is closed for \(self.filename)")
-                return
-            }
-
-            if self.sharedConnection == nil {
-                log.debug(">>> Creating shared SQLiteDBConnection for \(self.filename) on thread \(Thread.current).")
-                self.sharedConnection = ConcreteSQLiteDBConnection(filename: self.filename, flags: SwiftData.Flags.readWriteCreate.toSQL(), key: self.key, prevKey: self.prevKey, schema: self.schema, files: self.files)
-            }
-            connection = self.sharedConnection
-        }
-
-        return connection
-    }
-
     /**
      * The real meat of all the execute methods. This is used internally to open and
      * close a database connection and run a block of code inside it.
@@ -160,15 +141,8 @@ open class SwiftData {
     func withConnection<T>(_ flags: SwiftData.Flags, synchronous: Bool = false, _ callback: @escaping (_ connection: SQLiteDBConnection) throws -> T) -> Deferred<Maybe<T>> {
         let deferred = DeferredDBOperation<Maybe<T>>()
 
-        /**
-         * We use a weak reference here instead of strongly retaining the connection because we don't want
-         * any control over when the connection deallocs. If the only owner of the connection (SwiftData)
-         * decides to dealloc it, we should respect that since the deinit method of the connection is tied
-         * to the app lifecycle. This is to prevent background disk access causing springboard crashes.
-         */
-        weak var conn = getSharedConnection()
         let queue = self.sharedConnectionQueue
-        
+
         func doWork() {
             if deferred.cancelled {
                 return
@@ -179,14 +153,17 @@ open class SwiftData {
                 deferred.running = false
             }
 
+            if !self.closed && self.sharedConnection == nil {
+                self.sharedConnection = ConcreteSQLiteDBConnection(filename: self.filename, flags: SwiftData.Flags.readWriteCreate.toSQL(), key: self.key, prevKey: self.prevKey, schema: self.schema, files: self.files)
+            }
 
             // By the time this dispatch block runs, it is possible the user has backgrounded the
             // app and the connection has been dealloc'ed since we last grabbed the reference
-            guard let connection = SwiftData.ReuseConnections ? conn :
-                ConcreteSQLiteDBConnection(filename: filename, flags: flags.toSQL(), key: self.key, prevKey: self.prevKey, schema: self.schema, files: self.files) else {
+            guard let connection = SwiftData.ReuseConnections ? self.sharedConnection :
+                ConcreteSQLiteDBConnection(filename: self.filename, flags: flags.toSQL(), key: self.key, prevKey: self.prevKey, schema: self.schema, files: self.files) else {
                     do {
                         _ = try callback(FailedSQLiteDBConnection())
-                        
+
                         deferred.fill(Maybe(failure: NSError(domain: "mozilla", code: 0, userInfo: [NSLocalizedDescriptionKey: "Could not create a connection"])))
                     } catch let err as NSError {
                         deferred.fill(Maybe(failure: DatabaseError(err: err)))
@@ -204,7 +181,6 @@ open class SwiftData {
 
         let work = DispatchWorkItem { doWork() }
         deferred.dispatchWorkItem = work
-
 
         if synchronous {
             queue.sync(execute: work)
@@ -225,8 +201,9 @@ open class SwiftData {
         }
     }
 
-    /// Don't use this unless you know what you're doing. The deinitializer
-    /// should be used to achieve refcounting semantics.
+    /// Don't use this unless you know what you're doing. The deinitializer should be used to achieve refcounting semantics.
+    /// The shutdown is *sync*, meaning the queue will complete the current db operations before closing.
+    /// If an operation is queued with an open connection, it will execute before this runs.
     func forceClose() {
         sharedConnectionQueue.sync {
             self.closed = true
@@ -239,6 +216,14 @@ open class SwiftData {
     func reopenIfClosed() {
         sharedConnectionQueue.sync {
             self.closed = false
+        }
+    }
+
+    public func cancel() {
+        sharedConnectionQueue.async {
+            if let c = self.sharedConnection, let db = c.sqliteDB {
+                sqlite3_interrupt(db)
+            }
         }
     }
 
@@ -255,14 +240,6 @@ open class SwiftData {
                 return SQLITE_OPEN_READWRITE
             case .readWriteCreate:
                 return SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
-            }
-        }
-    }
-
-    public func cancel() {
-        sharedConnectionQueue.async {
-            if let c = self.sharedConnection, let db = c.sqliteDB {
-                sqlite3_interrupt(db)
             }
         }
     }

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -230,6 +230,14 @@ open class SwiftData {
         }
     }
 
+    public func suspendQueue() {
+        sharedConnectionQueue.suspend()
+    }
+
+    public func resumeQueue() {
+        sharedConnectionQueue.resume()
+    }
+
     public enum Flags {
         case readOnly
         case readWrite

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -157,8 +157,6 @@ open class SwiftData {
                 self.sharedConnection = ConcreteSQLiteDBConnection(filename: self.filename, flags: SwiftData.Flags.readWriteCreate.toSQL(), key: self.key, prevKey: self.prevKey, schema: self.schema, files: self.files)
             }
 
-            // By the time this dispatch block runs, it is possible the user has backgrounded the
-            // app and the connection has been dealloc'ed since we last grabbed the reference
             guard let connection = SwiftData.ReuseConnections ? self.sharedConnection :
                 ConcreteSQLiteDBConnection(filename: self.filename, flags: flags.toSQL(), key: self.key, prevKey: self.prevKey, schema: self.schema, files: self.files) else {
                     do {
@@ -220,10 +218,8 @@ open class SwiftData {
     }
 
     public func cancel() {
-        sharedConnectionQueue.async {
-            if let c = self.sharedConnection, let db = c.sqliteDB {
-                sqlite3_interrupt(db)
-            }
+        if let db = sharedConnection?.sqliteDB, !closed {
+            sqlite3_interrupt(db)
         }
     }
 

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -41,6 +41,12 @@ import XCGLogger
 private let DatabaseBusyTimeout: Int32 = 3 * 1000
 private let log = Logger.syncLogger
 
+public class DBOperationCancelled : MaybeErrorType {
+    public var description: String {
+        return "Database operation cancelled"
+    }
+}
+
 class DeferredDBOperation<T>: Deferred<T>, Cancellable {
     fileprivate var dispatchWorkItem: DispatchWorkItem?
     private var _running = false
@@ -145,6 +151,7 @@ open class SwiftData {
 
         func doWork() {
             if deferred.cancelled {
+                deferred.fill(Maybe(failure: DBOperationCancelled()))
                 return
             }
 

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -41,6 +41,36 @@ import XCGLogger
 private let DatabaseBusyTimeout: Int32 = 3 * 1000
 private let log = Logger.syncLogger
 
+class DeferredDBOperation<T>: Deferred<T>, Cancellable {
+    fileprivate var dispatchWorkItem: DispatchWorkItem?
+    private var _running = false
+
+    func cancel() {
+        objc_sync_enter(self)
+        defer { objc_sync_exit(self) }
+        dispatchWorkItem?.cancel()
+    }
+
+    var cancelled: Bool {
+        objc_sync_enter(self)
+        defer { objc_sync_exit(self) }
+        return dispatchWorkItem?.isCancelled ?? false
+    }
+
+    var running: Bool {
+        get {
+            objc_sync_enter(self)
+            defer { objc_sync_exit(self) }
+            return _running
+        }
+        set {
+            objc_sync_enter(self)
+            defer { objc_sync_exit(self) }
+            _running = newValue
+        }
+    }
+}
+
 enum SQLiteDBConnectionCreatedResult {
     case success
     case failure
@@ -128,7 +158,7 @@ open class SwiftData {
      * close a database connection and run a block of code inside it.
      */
     func withConnection<T>(_ flags: SwiftData.Flags, synchronous: Bool = false, _ callback: @escaping (_ connection: SQLiteDBConnection) throws -> T) -> Deferred<Maybe<T>> {
-        let deferred = Deferred<Maybe<T>>()
+        let deferred = DeferredDBOperation<Maybe<T>>()
 
         /**
          * We use a weak reference here instead of strongly retaining the connection because we don't want
@@ -140,6 +170,16 @@ open class SwiftData {
         let queue = self.sharedConnectionQueue
         
         func doWork() {
+            if deferred.cancelled {
+                return
+            }
+
+            deferred.running = true
+            defer {
+                deferred.running = false
+            }
+
+
             // By the time this dispatch block runs, it is possible the user has backgrounded the
             // app and the connection has been dealloc'ed since we last grabbed the reference
             guard let connection = SwiftData.ReuseConnections ? conn :
@@ -161,15 +201,15 @@ open class SwiftData {
                 deferred.fill(Maybe(failure: DatabaseError(err: err)))
             }
         }
-        
+
+        let work = DispatchWorkItem { doWork() }
+        deferred.dispatchWorkItem = work
+
+
         if synchronous {
-            queue.sync {
-                doWork()
-            }
+            queue.sync(execute: work)
         } else {
-            queue.async {
-                doWork()
-            }
+            queue.async(execute: work)
         }
         
         return deferred
@@ -215,6 +255,14 @@ open class SwiftData {
                 return SQLITE_OPEN_READWRITE
             case .readWriteCreate:
                 return SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
+            }
+        }
+    }
+
+    public func cancel() {
+        sharedConnectionQueue.async {
+            if let c = self.sharedConnection, let db = c.sqliteDB {
+                sqlite3_interrupt(db)
             }
         }
     }


### PR DESCRIPTION
This supersedes the PR https://github.com/mozilla-mobile/firefox-ios/pull/3504

It is simplified into 2 commits, the first for cancel logic, the second for DB handle off-main.

The rest of the changes in 3504 are unnecessary, since:
- instrumenting was noisy with lots of db code hitting main, and I was initially using time profiler and not system trace
- I wasn't aware the cursor being returned was a filled cursor (I am not sure it is a *database cursor* at all since it doesn't seem to hit the database and is pre-populated from what I can tell.)
- minor optimizations that aren't critical path.

I am working on a test case for the shutdown. We can wait for that, or land this as-is and I can file a follow-up.