### PR TITLE
 Bug 1421226 - make sure to reset selectedIndex when force removing private tabs

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -446,6 +446,10 @@ class TabManager: NSObject {
 
     /// Removes all private tabs from the manager without notifying delegates.
     private func removeAllPrivateTabs() {
+        // reset the selectedTabIndex if we are on a private tab because we will be removing it.
+        if selectedTab?.isPrivate ?? false {
+            _selectedIndex = -1
+        }
         tabs.forEach { tab in
             if tab.isPrivate {
                 removeAllBrowsingDataForTab(tab)


### PR DESCRIPTION
Normally when we remove tabs we call` TabManger.removeTab()` which will also nil out the selectedTab. But when the "close private tabs when leaving PBM" is checked we dont use `TabMangager.removeTab()` for other reasons. In that case we need to make sure we actually reset the selectedIndex.