### PR TITLE
Bug 1424742 - UITests EarlGrey Timeout error

### DIFF
--- a/UITests/AuthenticationTests.swift
+++ b/UITests/AuthenticationTests.swift
@@ -11,6 +11,7 @@ class AuthenticationTests: KIFTestCase {
     override func setUp() {
         super.setUp()
         webRoot = SimplePageServer.start()
+        BrowserUtils.configEarlGrey()
 		BrowserUtils.dismissFirstRunUI()
 	}
 	

--- a/UITests/BookmarksPanelTests.swift
+++ b/UITests/BookmarksPanelTests.swift
@@ -13,6 +13,7 @@ class BookmarksPanelTests: KIFTestCase {
     
     override func setUp() {
         super.setUp()
+        BrowserUtils.configEarlGrey()
         BrowserUtils.dismissFirstRunUI()
 	}
 	

--- a/UITests/ClearPrivateDataTests.swift
+++ b/UITests/ClearPrivateDataTests.swift
@@ -16,6 +16,7 @@ class ClearPrivateDataTests: KIFTestCase, UITextFieldDelegate {
     override func setUp() {
         super.setUp()
         webRoot = SimplePageServer.start()
+        BrowserUtils.configEarlGrey()
         BrowserUtils.dismissFirstRunUI()
     }
 

--- a/UITests/DomainAutocompleteTests.swift
+++ b/UITests/DomainAutocompleteTests.swift
@@ -10,6 +10,7 @@ class DomainAutocompleteTests: KIFTestCase {
     override func setUp() {
 
         super.setUp()
+        BrowserUtils.configEarlGrey()
         BrowserUtils.dismissFirstRunUI()
     }
     

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -264,7 +264,15 @@ class BrowserUtils {
 
         GREYAssertTrue(topsiteAppeared, reason: "Failed to return to topsite view")
     }
-	
+
+    class func configEarlGrey() {
+        GREYConfiguration.sharedInstance().setValue(2, forConfigKey: kGREYConfigKeyCALayerMaxAnimationDuration)
+        GREYConfiguration.sharedInstance().setValue(false, forConfigKey: kGREYConfigKeyActionConstraintsEnabled)
+        GREYConfiguration.sharedInstance().setValue(2, forConfigKey: kGREYConfigKeyDelayedPerformMaxTrackableDuration)
+        GREYConfiguration.sharedInstance().setValue(100, forConfigKey: kGREYConfigKeyInteractionTimeoutDuration)
+        GREYConfiguration.sharedInstance().setValue(["."], forConfigKey: kGREYConfigKeyURLBlacklistRegex)
+    }
+
 	class func dismissFirstRunUI() {
 		var error: NSError?
         

--- a/UITests/HistoryTests.swift
+++ b/UITests/HistoryTests.swift
@@ -12,6 +12,7 @@ class HistoryTests: KIFTestCase {
     override func setUp() {
         super.setUp()
         webRoot = SimplePageServer.start()
+        BrowserUtils.configEarlGrey()
         BrowserUtils.dismissFirstRunUI()
     }
     

--- a/UITests/LoginInputTests.swift
+++ b/UITests/LoginInputTests.swift
@@ -14,6 +14,7 @@ class LoginInputTests: KIFTestCase {
         super.setUp()
         profile = (UIApplication.shared.delegate as! AppDelegate).profile!
         webRoot = SimplePageServer.start()
+        BrowserUtils.configEarlGrey()
         BrowserUtils.dismissFirstRunUI()
     }
     

--- a/UITests/LoginManagerTests.swift
+++ b/UITests/LoginManagerTests.swift
@@ -17,6 +17,7 @@ class LoginManagerTests: KIFTestCase {
         webRoot = SimplePageServer.start()
         generateLogins()
         BrowserUtils.dismissFirstRunUI()
+        BrowserUtils.configEarlGrey()
     }
     
     override func tearDown() {
@@ -151,7 +152,8 @@ class LoginManagerTests: KIFTestCase {
         list = tester().waitForView(withAccessibilityIdentifier: "Login List") as! UITableView
         tester().waitForView(withAccessibilityLabel: "d9@email.com")
         XCTAssertEqual(list.numberOfRows(inSection: 0), 1)
-        
+
+        tester().wait(forTimeInterval: 2)
         tester().tapView(withAccessibilityLabel: "Clear Search")
         // Filter by something that doesn't match anything
         tester().waitForView(withAccessibilityLabel: "a0@email.com, http://a0.com")
@@ -226,7 +228,7 @@ class LoginManagerTests: KIFTestCase {
         // Tap the 'Open & Fill' menu option  just checks to make sure we navigate to the web page
         EarlGrey.select(elementWithMatcher: grey_accessibilityID("websiteField")).perform(grey_tap())
         waitForMatcher(name: "Open & Fill")
-        
+
         tester().wait(forTimeInterval: 2)
         tester().waitForViewWithAccessibilityValue("a0.com/")
         XCTAssertEqual(UIPasteboard.general.string, "http://a0.com")

--- a/UITests/NavigationDelegateTests.swift
+++ b/UITests/NavigationDelegateTests.swift
@@ -15,6 +15,7 @@ class NavigationDelegateTests: KIFTestCase {
     override func setUp() {
         super.setUp()
         webRoot = SimplePageServer.start()
+        BrowserUtils.configEarlGrey()
         BrowserUtils.dismissFirstRunUI()
     }
     

--- a/UITests/NoImageModeTests.swift
+++ b/UITests/NoImageModeTests.swift
@@ -13,6 +13,7 @@ class NoImageModeTests: KIFTestCase {
     override func setUp() {
         super.setUp()
         webRoot = SimplePageServer.start()
+        BrowserUtils.configEarlGrey()
         BrowserUtils.dismissFirstRunUI()
     }
 

--- a/UITests/ReadingListTest.swift
+++ b/UITests/ReadingListTest.swift
@@ -14,6 +14,7 @@ class ReadingListTests: KIFTestCase, UITextFieldDelegate {
         // We undo the localhost/127.0.0.1 switch in order to get 'localhost' in accessibility labels.
         webRoot = SimplePageServer.start()
             .replacingOccurrences(of: "127.0.0.1", with: "localhost", options: NSString.CompareOptions(), range: nil)
+        BrowserUtils.configEarlGrey()
         BrowserUtils.dismissFirstRunUI()
     }
     

--- a/UITests/SecurityTests.swift
+++ b/UITests/SecurityTests.swift
@@ -11,6 +11,7 @@ class SecurityTests: KIFTestCase {
     
     override func setUp() {
         webRoot = SimplePageServer.start()
+        BrowserUtils.configEarlGrey()
         BrowserUtils.dismissFirstRunUI()
         super.setUp()
     }

--- a/UITests/ToolbarTests.swift
+++ b/UITests/ToolbarTests.swift
@@ -12,6 +12,7 @@ class ToolbarTests: KIFTestCase, UITextFieldDelegate {
 
     override func setUp() {
         webRoot = SimplePageServer.start()
+        BrowserUtils.configEarlGrey()
         BrowserUtils.dismissFirstRunUI()
     }
 

--- a/UITests/TrackingProtectionTests.swift
+++ b/UITests/TrackingProtectionTests.swift
@@ -14,6 +14,7 @@ class TrackingProtectionTests: KIFTestCase {
     override func setUp() {
         super.setUp()
         webRoot = SimplePageServer.start()
+        BrowserUtils.configEarlGrey()
         BrowserUtils.dismissFirstRunUI()
     }
     


### PR DESCRIPTION
UITests are failing due to timing issues. This PR investigates the options to change the GREYConf values in order to prevent the timing issues