### PR TITLE
Bug 1425823 - Fix XCUI Photon Action Sheet Tests

### DIFF
--- a/XCUITests/PhotonActionSheetTest.swift
+++ b/XCUITests/PhotonActionSheetTest.swift
@@ -35,7 +35,6 @@ class PhotonActionSheetTest: BaseTestCase {
 
     func testShareOptionIsShown() {
         navigator.browserPerformAction(.shareOption)
-        app.buttons["TabLocationView.pageOptionsButton"].press(forDuration: 1)
 
         // Wait to see the Share options sheet
         waitforExistence(app.buttons["Copy"])
@@ -43,6 +42,7 @@ class PhotonActionSheetTest: BaseTestCase {
 
     func testShareOptionIsShownFromShortCut() {
         navigator.goto(BrowserTab)
+        waitUntilPageLoad()
         app.buttons["TabLocationView.pageOptionsButton"].press(forDuration: 1)
         // Wait to see the Share options sheet
         waitforExistence(app.buttons["Copy"])


### PR DESCRIPTION
Two Photon Action Sheet tests appear to fail sometimes.
This PR tries to solve those failures.