### PR TITLE
Bug 1425927 - Eliminate KVO usage within clipboard bar. (#3551) r=farhan

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -369,7 +369,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             if AppConstants.MOZ_FXA_DEEP_LINK_FORM_FILL {
                 // FxA form filling requires a `signin` query param and host = fxa-signin
                 // Ex. firefox://fxa-signin?signin=<token>&someQuery=<data>...
-                guard let signinQuery = query["signin"] else {
+                guard query["signin"] != nil else {
                     break
                 }
                 let fxaParams: FxALaunchParams
@@ -384,9 +384,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
     }
 
     func launchFxAFromURL(_ params: FxALaunchParams) {
-        guard params.query != nil else {
-            return
-        }
         self.browserViewController.presentSignInViewController(params)
     }
 

--- a/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -13,7 +13,7 @@ protocol ClipboardBarDisplayHandlerDelegate: class {
     func shouldDisplay(clipboardBar bar: ButtonToast)
 }
 
-class ClipboardBarDisplayHandler: NSObject {
+class ClipboardBarDisplayHandler: NSObject, URLChangeDelegate {
     weak var delegate: (ClipboardBarDisplayHandlerDelegate & SettingsDelegate)?
     weak var settingsDelegate: SettingsDelegate?
     weak var tabManager: TabManager?
@@ -35,15 +35,9 @@ class ClipboardBarDisplayHandler: NSObject {
         NotificationCenter.default.addObserver(self, selector: #selector(SELAppWillEnterForegroundNotification), name: NSNotification.Name.UIApplicationWillEnterForeground, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(SELDidRestoreSession), name: NotificationDidRestoreSession, object: nil)
     }
-
-    deinit {
-        if !firstTabLoaded {
-            firstTab?.webView?.removeObserver(self, forKeyPath: "URL")
-        }
-    }
     
     @objc private func SELUIPasteboardChanged() {
-        // UIPasteboardChanged gets triggered when callng UIPasteboard.general
+        // UIPasteboardChanged gets triggered when calling UIPasteboard.general.
          NotificationCenter.default.removeObserver(self, name: NSNotification.Name.UIPasteboardChanged, object: nil)
 
         UIPasteboard.general.asyncURL().uponQueue(.main) { res in
@@ -64,13 +58,21 @@ class ClipboardBarDisplayHandler: NSObject {
         checkIfShouldDisplayBar()
     }
 
+    private func observeURLForFirstTab(firstTab: Tab) {
+        if firstTab.webView == nil {
+            // Nothing to do; bail out.
+            firstTabLoaded = true
+            return
+        }
+        self.firstTab = firstTab
+        firstTab.observeURLChanges(delegate: self)
+    }
+
     @objc private func SELDidRestoreSession() {
         DispatchQueue.main.sync {
             if let tabManager = self.tabManager,
-                let firstTab = tabManager.selectedTab,
-                let webView = firstTab.webView {
-                self.firstTab = firstTab
-                webView.addObserver(self, forKeyPath: "URL", options: .new, context: nil)
+                let firstTab = tabManager.selectedTab {
+                self.observeURLForFirstTab(firstTab: firstTab)
             } else {
                 firstTabLoaded = true
             }
@@ -82,21 +84,15 @@ class ClipboardBarDisplayHandler: NSObject {
         }
     }
 
-    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
+    func tab(_ tab: Tab, urlDidChangeTo url: URL) {
         // Ugly hack to ensure we wait until we're finished restoring the session on the first tab
         // before checking if we should display the clipboard bar.
         guard sessionRestored,
-            let path = keyPath,
-            path == "URL",
-            let firstTab = self.firstTab,
-            let webView = firstTab.webView,
-            let url = firstTab.url?.absoluteString,
-            !url.startsWith("\(WebServer.sharedInstance.base)/about/sessionrestore?history=") else {
+            !url.absoluteString.startsWith("\(WebServer.sharedInstance.base)/about/sessionrestore?history=") else {
             return
         }
 
-        webView.removeObserver(self, forKeyPath: "URL")
-
+        tab.removeURLChangeObserver(delegate: self)
         firstTabLoaded = true
         checkIfShouldDisplayBar()
     }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -498,7 +498,7 @@ class TabTrayController: UIViewController {
         // We're only doing one update here, but using a batch update lets us delay selecting the tab
         // until after its insert animation finishes.
         self.collectionView.performBatchUpdates({ _ in
-            let tab = self.tabManager.addTab(request, isPrivate: self.privateMode)
+            _ = self.tabManager.addTab(request, isPrivate: self.privateMode)
         }, completion: { finished in
             // The addTab delegate method will pop to the BVC no need to do anything here.
             self.toolbar.isUserInteractionEnabled = true
@@ -974,7 +974,7 @@ extension TabTrayController: ClientPickerViewControllerDelegate {
 
     func clientPickerViewController(_ clientPickerViewController: ClientPickerViewController, didPickClients clients: [RemoteClient]) {
         if let item = clientPickerViewController.shareItem {
-            self.profile.sendItems([item], toClients: clients)
+            _ = self.profile.sendItems([item], toClients: clients)
         }
         clientPickerViewController.dismiss(animated: true, completion: nil)
     }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -587,13 +587,14 @@ extension URLBarView: TabLocationViewDelegate {
     }
 
     func tabLocationViewDidTapLocation(_ tabLocationView: TabLocationView) {
-        guard var (locationText, isSearchQuery) = delegate?.urlBarDisplayTextForURL(locationView.url as URL?) else { return }
+        guard let (locationText, isSearchQuery) = delegate?.urlBarDisplayTextForURL(locationView.url as URL?) else { return }
 
+        var overlayText = locationText
         // Make sure to use the result from urlBarDisplayTextForURL as it is responsible for extracting out search terms when on a search page
         if let text = locationText, let url = URL(string: text), let host = url.host, AppConstants.MOZ_PUNYCODE {
-            locationText = url.absoluteString.replacingOccurrences(of: host, with: host.asciiHostToUTF8())
+            overlayText = url.absoluteString.replacingOccurrences(of: host, with: host.asciiHostToUTF8())
         }
-        enterOverlayMode(locationText, pasted: false, search: isSearchQuery)
+        enterOverlayMode(overlayText, pasted: false, search: isSearchQuery)
     }
 
     func tabLocationViewDidLongPressLocation(_ tabLocationView: TabLocationView) {

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -10,6 +10,16 @@ public enum AppBuildChannel: String {
     case developer = "developer"
 }
 
+public enum KVOConstants: String {
+    case loading = "loading"
+    case estimatedProgress = "estimatedProgress"
+    case URL = "URL"
+    case title = "title"
+    case canGoBack = "canGoBack"
+    case canGoForward = "canGoForward"
+    case contentSize = "contentSize"
+}
+
 public struct AppConstants {
     public static let IsRunningTest = NSClassFromString("XCTestCase") != nil || ProcessInfo.processInfo.arguments.contains(LaunchArguments.Test)
     


### PR DESCRIPTION
* Pre: use KVOConstants for KVO paths.
* Pre: fix some warnings.
* Introduce a trivial URL change delegate on Tab, using that instead of direct observation of TabWebView.