### PR TITLE
Bug 1169322: Use a temp table to speed up frecency query.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1451,6 +1451,12 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBarDidEnterOverlayMode(_ urlBar: URLBarView) {
+        guard let profile = profile as? BrowserProfile else {
+            return
+        }
+
+        searchLoader.searchStateEntered()
+        
         if .blankPage == NewTabAccessors.getNewTabPage(profile.prefs) {
             UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil)
         } else {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -50,7 +50,7 @@ class BrowserViewController: UIViewController {
     fileprivate var searchController: SearchViewController?
     fileprivate var screenshotHelper: ScreenshotHelper!
     fileprivate var homePanelIsInline = false
-    fileprivate var searchLoader: SearchLoader!
+    fileprivate var searchLoader: SearchLoader?
     fileprivate let alertStackView = UIStackView() // All content that appears above the footer should be added to this view. (Find In Page/SnackBars)
     fileprivate var findInPageBar: FindInPageBar?
 
@@ -367,8 +367,6 @@ class BrowserViewController: UIViewController {
             }
             return true
         })
-
-        searchLoader = SearchLoader(profile: profile, urlBar: urlBar)
 
         view.addSubview(alertStackView)
         footer = UIView()
@@ -763,7 +761,8 @@ class BrowserViewController: UIViewController {
         searchController!.searchDelegate = self
         searchController!.profile = self.profile
 
-        searchLoader.addListener(searchController!)
+        searchLoader = SearchLoader(profile: profile, urlBar: urlBar)
+        searchLoader?.addListener(searchController!)
 
         addChildViewController(searchController!)
         view.addSubview(searchController!.view)
@@ -1393,7 +1392,7 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBar(_ urlBar: URLBarView, didEnterText text: String) {
-        searchLoader.query = text
+        searchLoader?.query = text
 
         if text.isEmpty {
             hideSearchController()
@@ -1454,8 +1453,6 @@ extension BrowserViewController: URLBarDelegate {
         guard let profile = profile as? BrowserProfile else {
             return
         }
-
-        searchLoader.searchStateEntered()
         
         if .blankPage == NewTabAccessors.getNewTabPage(profile.prefs) {
             UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -784,6 +784,7 @@ class BrowserViewController: UIViewController {
             searchController.removeFromParentViewController()
             self.searchController = nil
             homePanelController?.view?.isHidden = false
+            searchLoader = nil
         }
     }
 

--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -23,7 +23,7 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
     fileprivate let profile: Profile
     fileprivate let urlBar: URLBarView
 
-    private var optimizedFrecency: OptimizedFrecency?
+    private var frecentHistory: FrecentHistory?
 
     init(profile: Profile, urlBar: URLBarView) {
         self.profile = profile
@@ -39,7 +39,7 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
     // Call every time the UI is in a mode where searching is performed.
     // A temp table is created which speeds up conscutive queries, but 'freezes' the db state.
     public func searchStateEntered() {
-        optimizedFrecency = profile.history.getOptimizedFrecency()
+        frecentHistory = profile.history.getFrecentHistory()
     }
 
     // `weak` usage here allows deferred queue to be the owner. The deferred is always filled and this set to nil,
@@ -62,13 +62,13 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
                 profile.db.cancel(databaseOperation: WeakRef(currentDbQuery))
             }
 
-            if optimizedFrecency == nil {
+            if frecentHistory == nil {
                 assertionFailure("SearchLoader setup not called.")
                 Sentry.shared.send(message: "SearchLoader setup not called", severity: .error)
             }
-            guard let optimizedFrecency = optimizedFrecency else { return }
+            guard let frecentHistory = frecentHistory else { return }
 
-            let deferred = optimizedFrecency.getSites(historyLimit: 100, bookmarksLimit: 5, whereURLContains: query)
+            let deferred = frecentHistory.getSites(historyLimit: 100, bookmarksLimit: 5, whereURLContains: query)
             currentDbQuery = deferred as? Cancellable
 
             deferred.uponQueue(.main) { result in

--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -65,12 +65,10 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
             if optimizedFrecency == nil {
                 assertionFailure("SearchLoader setup not called.")
                 Sentry.shared.send(message: "SearchLoader setup not called", severity: .error)
-                searchStateEntered()
             }
             guard let optimizedFrecency = optimizedFrecency else { return }
 
-            // When search mode is entered the requisite temp table is generated to speed up repeated queries, see BrowserViewController.urlBarDidEnterOverlayMode()
-            let deferred = optimizedFrecency.getSites(historyLimit: 100, bookmarksLimit: 5, whereURLContains: query)
+            let deferred = optimizedFrecency.getSites(historyLimit: 100, bookmarksLimit: 5, whereURLContains: query, groupClause: "", whereData: nil)
             currentDbQuery = deferred as? Cancellable
 
             deferred.uponQueue(.main) { result in

--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -68,7 +68,7 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
             }
             guard let optimizedFrecency = optimizedFrecency else { return }
 
-            let deferred = optimizedFrecency.getSites(historyLimit: 100, bookmarksLimit: 5, whereURLContains: query, groupClause: "", whereData: nil)
+            let deferred = optimizedFrecency.getSites(historyLimit: 100, bookmarksLimit: 5, whereURLContains: query)
             currentDbQuery = deferred as? Cancellable
 
             deferred.uponQueue(.main) { result in

--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -57,7 +57,7 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
                 profile.db.cancel(databaseOperation: WeakRef(currentDbQuery))
             }
 
-            let deferred = frecentHistory.getSites(historyLimit: 100, bookmarksLimit: 5, whereURLContains: query)
+            let deferred = frecentHistory.getSites(whereURLContains: query, historyLimit: 100, bookmarksLimit: 5)
             currentDbQuery = deferred as? Cancellable
 
             deferred.uponQueue(.main) { result in

--- a/ClientTests/MockableHistory.swift
+++ b/ClientTests/MockableHistory.swift
@@ -13,7 +13,7 @@ import Shared
  * mock out parts of the history API
  */
 class MockableHistory: BrowserHistory, SyncableHistory, ResettableSyncStorage {
-    func getOptimizedFrecency() -> OptimizedFrecency { fatalError() }
+    func getFrecentHistory() -> FrecentHistory { fatalError() }
     func getTopSitesWithLimit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>> { fatalError() }
     func addLocalVisit(_ visit: SiteVisit) -> Success { fatalError() }
     func clearHistory() -> Success { fatalError() }

--- a/ClientTests/MockableHistory.swift
+++ b/ClientTests/MockableHistory.swift
@@ -13,7 +13,8 @@ import Shared
  * mock out parts of the history API
  */
 class MockableHistory: BrowserHistory, SyncableHistory, ResettableSyncStorage {
-    func getTopSitesWithLimit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>> { fatalError()}
+    func getOptimizedFrecency() -> OptimizedFrecency { fatalError() }
+    func getTopSitesWithLimit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>> { fatalError() }
     func addLocalVisit(_ visit: SiteVisit) -> Success { fatalError() }
     func clearHistory() -> Success { fatalError() }
     func removeHistoryForURL(_ url: String) -> Success { fatalError() }
@@ -23,8 +24,6 @@ class MockableHistory: BrowserHistory, SyncableHistory, ResettableSyncStorage {
     func removeFromPinnedTopSites(_ site: Site) -> Success { fatalError() }
     func addPinnedTopSite(_ site: Site) -> Success { fatalError() }
     func getPinnedTopSites() -> Deferred<Maybe<Cursor<Site>>> { fatalError() }
-    func getSitesByFrecencyWithHistoryLimit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>> { fatalError() }
-    func getSitesByFrecencyWithHistoryLimit(_ limit: Int, bookmarksLimit: Int = 0, whereURLContains filter: String) -> Deferred<Maybe<Cursor<Site>>> { fatalError() }
     func getSitesByLastVisit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>> { fatalError() }
     func setTopSitesNeedsInvalidation() { fatalError() }
     func updateTopSitesCacheIfInvalidated() -> Deferred<Maybe<Bool>> { fatalError() }

--- a/ClientTests/TestHistory.swift
+++ b/ClientTests/TestHistory.swift
@@ -49,7 +49,7 @@ class TestHistory: ProfileTest {
         let expectation = self.expectation(description: "Wait for history")
         history.getSitesByLastVisit(100).upon { result in
             XCTAssertTrue(result.isSuccess)
-            history.getFrecentHistory().getSites(historyLimit: 100, bookmarksLimit: 0, whereURLContains: url).upon { result in
+            history.getFrecentHistory().getSites(whereURLContains: url, historyLimit: 100, bookmarksLimit: 0).upon { result in
                 XCTAssertTrue(result.isSuccess)
                 let cursor = result.successValue!
                 XCTAssertEqual(cursor.status, CursorStatus.success, "returned success \(cursor.statusMessage)")

--- a/ClientTests/TestHistory.swift
+++ b/ClientTests/TestHistory.swift
@@ -49,7 +49,7 @@ class TestHistory: ProfileTest {
         let expectation = self.expectation(description: "Wait for history")
         history.getSitesByLastVisit(100).upon { result in
             XCTAssertTrue(result.isSuccess)
-            history.getSitesByFrecencyWithHistoryLimit(100, bookmarksLimit: 0, whereURLContains: url, usePregeneratedTempTable: false).upon { result in
+            history.getFrecentHistory().getSites(historyLimit: 100, bookmarksLimit: 0, whereURLContains: url).upon { result in
                 XCTAssertTrue(result.isSuccess)
                 let cursor = result.successValue!
                 XCTAssertEqual(cursor.status, CursorStatus.success, "returned success \(cursor.statusMessage)")

--- a/ClientTests/TestHistory.swift
+++ b/ClientTests/TestHistory.swift
@@ -49,7 +49,7 @@ class TestHistory: ProfileTest {
         let expectation = self.expectation(description: "Wait for history")
         history.getSitesByLastVisit(100).upon { result in
             XCTAssertTrue(result.isSuccess)
-            history.getSitesByFrecencyWithHistoryLimit(100, bookmarksLimit: 0, whereURLContains: url).upon { result in
+            history.getSitesByFrecencyWithHistoryLimit(100, bookmarksLimit: 0, whereURLContains: url, usePregeneratedTempTable: false).upon { result in
                 XCTAssertTrue(result.isSuccess)
                 let cursor = result.successValue!
                 XCTAssertEqual(cursor.status, CursorStatus.success, "returned success \(cursor.statusMessage)")

--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -24,7 +24,7 @@ public protocol BrowserHistory {
     @discardableResult func removeHistoryForURL(_ url: String) -> Success
     func removeSiteFromTopSites(_ site: Site) -> Success
     func removeHostFromTopSites(_ host: String) -> Success
-    func getOptimizedFrecency() -> OptimizedFrecency
+    func getFrecentHistory() -> FrecentHistory
     func getSitesByLastVisit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>>
     func getTopSitesWithLimit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>>
     func setTopSitesNeedsInvalidation()
@@ -38,7 +38,7 @@ public protocol BrowserHistory {
 }
 
 /** An interface for fast repeated frecency queries. */
-public protocol OptimizedFrecency {
+public protocol FrecentHistory {
     func getSites(historyLimit limit: Int, bookmarksLimit: Int, whereURLContains filter: String?) -> Deferred<Maybe<Cursor<Site>>>
 }
 

--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -39,7 +39,7 @@ public protocol BrowserHistory {
 
 /** An interface for fast repeated frecency queries. */
 public protocol OptimizedFrecency {
-    func getSites(historyLimit limit: Int, bookmarksLimit: Int, whereURLContains filter: String?, groupClause: String, whereData: String?) -> Deferred<Maybe<Cursor<Site>>>
+    func getSites(historyLimit limit: Int, bookmarksLimit: Int, whereURLContains filter: String?) -> Deferred<Maybe<Cursor<Site>>>
 }
 
 /**

--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -37,6 +37,11 @@ public protocol BrowserHistory {
     func getPinnedTopSites() -> Deferred<Maybe<Cursor<Site>>>
 }
 
+/** An interface for fast repeated frecency queries. */
+public protocol OptimizedFrecency {
+    func getSites(historyLimit limit: Int, bookmarksLimit: Int, whereURLContains filter: String?, groupClause: String, whereData: String?) -> Deferred<Maybe<Cursor<Site>>>
+}
+
 /**
  * An interface for accessing recommendation content from Storage
  */

--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -37,7 +37,9 @@ public protocol BrowserHistory {
     func getPinnedTopSites() -> Deferred<Maybe<Cursor<Site>>>
 }
 
-/** An interface for fast repeated frecency queries. */
+/**
+ * An interface for fast repeated frecency queries.
+ */
 public protocol FrecentHistory {
     func getSites(whereURLContains filter: String?, historyLimit limit: Int, bookmarksLimit: Int) -> Deferred<Maybe<Cursor<Site>>>
     func updateTopSitesCacheQuery() -> (String, Args?)

--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -40,6 +40,7 @@ public protocol BrowserHistory {
 /** An interface for fast repeated frecency queries. */
 public protocol FrecentHistory {
     func getSites(historyLimit limit: Int, bookmarksLimit: Int, whereURLContains filter: String?) -> Deferred<Maybe<Cursor<Site>>>
+    func updateTopSitesCacheQuery() -> (String, Args?)
 }
 
 /**

--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -39,7 +39,7 @@ public protocol BrowserHistory {
 
 /** An interface for fast repeated frecency queries. */
 public protocol FrecentHistory {
-    func getSites(historyLimit limit: Int, bookmarksLimit: Int, whereURLContains filter: String?) -> Deferred<Maybe<Cursor<Site>>>
+    func getSites(whereURLContains filter: String?, historyLimit limit: Int, bookmarksLimit: Int) -> Deferred<Maybe<Cursor<Site>>>
     func updateTopSitesCacheQuery() -> (String, Args?)
 }
 

--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -24,11 +24,8 @@ public protocol BrowserHistory {
     @discardableResult func removeHistoryForURL(_ url: String) -> Success
     func removeSiteFromTopSites(_ site: Site) -> Success
     func removeHostFromTopSites(_ host: String) -> Success
-
-    func getSitesByFrecencyWithHistoryLimit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>>
-    func getSitesByFrecencyWithHistoryLimit(_ limit: Int, bookmarksLimit: Int, whereURLContains filter: String) -> Deferred<Maybe<Cursor<Site>>>
+    func getOptimizedFrecency() -> OptimizedFrecency
     func getSitesByLastVisit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>>
-
     func getTopSitesWithLimit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>>
     func setTopSitesNeedsInvalidation()
     func setTopSitesCacheSize(_ size: Int32)

--- a/Storage/SQL/BrowserSchema.swift
+++ b/Storage/SQL/BrowserSchema.swift
@@ -47,7 +47,7 @@ let ViewBookmarksLocalOnMirror = "view_bookmarksLocal_on_mirror"
 let ViewBookmarksLocalStructureOnMirror = "view_bookmarksLocalStructure_on_mirror"
 let ViewAllBookmarks = "view_all_bookmarks"
 let ViewAwesomebarBookmarks = "view_awesomebar_bookmarks"
-let AwesomebarBookmarksTempTable = "awesomebar_bookmarks_temp_table"
+let TempTableAwesomebarBookmarks = "awesomebar_bookmarks_temp_table"
 let ViewAwesomebarBookmarksWithIcons = "view_awesomebar_bookmarks_with_favicons"
 
 let ViewHistoryVisits = "view_history_visits"

--- a/Storage/SQL/BrowserSchema.swift
+++ b/Storage/SQL/BrowserSchema.swift
@@ -47,6 +47,7 @@ let ViewBookmarksLocalOnMirror = "view_bookmarksLocal_on_mirror"
 let ViewBookmarksLocalStructureOnMirror = "view_bookmarksLocalStructure_on_mirror"
 let ViewAllBookmarks = "view_all_bookmarks"
 let ViewAwesomebarBookmarks = "view_awesomebar_bookmarks"
+let AwesomebarBookmarksTempTable = "awesomebar_bookmarks_temp_table"
 let ViewAwesomebarBookmarksWithIcons = "view_awesomebar_bookmarks_with_favicons"
 
 let ViewHistoryVisits = "view_history_visits"

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -174,7 +174,7 @@ fileprivate struct FrecentHistoryImpl : FrecentHistory {
         "LEFT JOIN \(ViewHistoryVisits) h ON b.url = h.url"
 
         db.withConnection { connection in
-            let existsQuery = "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' and name = '\(AwesomebarBookmarksTempTable)'"
+            let existsQuery = "SELECT COUNT(*) FROM sqlite_temp_master WHERE type = 'table' and name = '\(AwesomebarBookmarksTempTable)'"
             let tableExists = 1 == connection.executeQuery(existsQuery, factory: IntFactory).asArray().first
             if tableExists {
                 try connection.executeChange("DELETE FROM \(AwesomebarBookmarksTempTable)")

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -148,124 +148,22 @@ open class SQLiteHistory {
 
 private let topSitesQuery = "SELECT \(TableCachedTopSites).*, \(TablePageMetadata).provider_name FROM \(TableCachedTopSites) LEFT OUTER JOIN \(TablePageMetadata) ON \(TableCachedTopSites).url = \(TablePageMetadata).site_url ORDER BY frecencies DESC LIMIT (?)"
 
-fileprivate func getFrecencyQuery(historyLimit: Int, bookmarksLimit: Int, whereURLContains filter: String? = nil, groupClause: String = "GROUP BY historyID ", whereData: String? = nil) -> (String, Args?) {
-    let includeBookmarks = bookmarksLimit > 0
-    let localFrecencySQL = getLocalFrecencySQL()
-    let remoteFrecencySQL = getRemoteFrecencySQL()
-    let sixMonthsInMicroseconds: UInt64 = 15_724_800_000_000      // 182 * 1000 * 1000 * 60 * 60 * 24
-    let sixMonthsAgo = Date.nowMicroseconds() - sixMonthsInMicroseconds
-
-    let args: Args
-    let whereClause: String
-    let whereFragment = (whereData == nil) ? "" : " AND (\(whereData!))"
-
-    if let filter = filter?.trimmingCharacters(in: .whitespaces), !filter.isEmpty {
-        let perWordFragment = "((url LIKE ?) OR (title LIKE ?))"
-        let perWordArgs: (String) -> Args = { ["%\($0)%", "%\($0)%"] }
-        let (filterFragment, filterArgs) = computeWhereFragmentWithFilter(filter, perWordFragment: perWordFragment, perWordArgs: perWordArgs)
-
-        // No deleted item has a URL, so there is no need to explicitly add that here.
-        whereClause = "WHERE (\(filterFragment))\(whereFragment)"
-
-        if includeBookmarks {
-            // We'll need them twice: once to filter history, and once to filter bookmarks.
-            args = filterArgs + filterArgs
-        } else {
-            args = filterArgs
-        }
-    } else {
-        whereClause = " WHERE (\(TableHistory).is_deleted = 0)\(whereFragment)"
-        args = []
-    }
-
-    // Innermost: grab history items and basic visit/domain metadata.
-    var ungroupedSQL =
-        "SELECT \(TableHistory).id AS historyID, \(TableHistory).url AS url, \(TableHistory).title AS title, \(TableHistory).guid AS guid, domain_id, domain" +
-            ", COALESCE(max(case \(TableVisits).is_local when 1 then \(TableVisits).date else 0 end), 0) AS localVisitDate" +
-            ", COALESCE(max(case \(TableVisits).is_local when 0 then \(TableVisits).date else 0 end), 0) AS remoteVisitDate" +
-            ", COALESCE(sum(\(TableVisits).is_local), 0) AS localVisitCount" +
-            ", COALESCE(sum(case \(TableVisits).is_local when 1 then 0 else 1 end), 0) AS remoteVisitCount" +
-            " FROM \(TableHistory) " +
-            "INNER JOIN \(TableDomains) ON \(TableDomains).id = \(TableHistory).domain_id " +
-    "INNER JOIN \(TableVisits) ON \(TableVisits).siteID = \(TableHistory).id "
-
-    if includeBookmarks {
-        ungroupedSQL.append("LEFT JOIN \(ViewAllBookmarks) on \(ViewAllBookmarks).url = \(TableHistory).url ")
-    }
-    ungroupedSQL.append(whereClause.replacingOccurrences(of: "url", with: "\(TableHistory).url").replacingOccurrences(of: "title", with: "\(TableHistory).title"))
-    if includeBookmarks {
-        ungroupedSQL.append(" AND \(ViewAllBookmarks).url IS NULL")
-    }
-    ungroupedSQL.append(" GROUP BY historyID")
-
-    // Next: limit to only those that have been visited at all within the last six months.
-    // (Don't do that in the innermost: we want to get the full count, even if some visits are older.)
-    // Discard all but the 1000 most frecent.
-    // Compute and return the frecency for all 1000 URLs.
-    let frecenciedSQL =
-        "SELECT *, (\(localFrecencySQL) + \(remoteFrecencySQL)) AS frecency" +
-            " FROM (" + ungroupedSQL + ")" +
-            " WHERE (" +
-            "((localVisitCount > 0) OR (remoteVisitCount > 0)) AND " +                         // Eliminate dead rows from coalescing.
-            "((localVisitDate > \(sixMonthsAgo)) OR (remoteVisitDate > \(sixMonthsAgo)))" +    // Exclude really old items.
-            ") ORDER BY frecency DESC" +
-    " LIMIT 1000"                                 // Don't even look at a huge set. This avoids work.
-
-    // Next: merge by domain and select the URL with the max frecency of a domain, ordering by that sum frecency and reducing to a (typically much lower) limit.
-    // NOTE: When using GROUP BY we need to be explicit about which URL to use when grouping. By using "max(frecency)" the result row
-    //       for that domain will contain the projected URL corresponding to the history item with the max frecency, https://sqlite.org/lang_select.html#resultset
-    //       This is the behavior we want in order to ensure that the most popular URL for a domain is used for the top sites tile.
-    // TODO: make is_bookmarked here accurate by joining against ViewAllBookmarks.
-    // TODO: ensure that the same URL doesn't appear twice in the list, either from duplicate
-    //       bookmarks or from being in both bookmarks and history.
-    let historySQL = [
-        "SELECT historyID, url, title, guid, domain_id, domain,",
-        "max(localVisitDate) AS localVisitDate,",
-        "max(remoteVisitDate) AS remoteVisitDate,",
-        "sum(localVisitCount) AS localVisitCount,",
-        "sum(remoteVisitCount) AS remoteVisitCount,",
-        "max(frecency) AS maxFrecency,",
-        "sum(frecency) AS frecencies,",
-        "0 AS is_bookmarked",
-        "FROM (", frecenciedSQL, ") ",
-        groupClause,
-        "ORDER BY frecencies DESC",
-        "LIMIT \(historyLimit)",
-        ].joined(separator: " ")
-
-    let bookmarksSQL = [
-        "SELECT NULL AS historyID, url, title, guid, NULL AS domain_id, NULL AS domain,",
-        "visitDate AS localVisitDate, 0 AS remoteVisitDate, 0 AS localVisitCount,",
-        "0 AS remoteVisitCount,",
-        "visitDate AS frecencies,",  // Fake this for ordering purposes.
-        "0 as maxFrecency,", // Need this column for UNION
-        "1 AS is_bookmarked",
-        "FROM \(AwesomebarBookmarksTempTable)",
-        whereClause,                  // The columns match, so we can reuse this.
-        "GROUP BY url",
-        "ORDER BY visitDate DESC LIMIT \(bookmarksLimit)",
-        ].joined(separator: " ")
-
-    if !includeBookmarks {
-        return (historySQL, args)
-    }
-
-    let allSQL = "SELECT * FROM (SELECT * FROM (\(historySQL)) UNION SELECT * FROM (\(bookmarksSQL))) ORDER BY is_bookmarked DESC, frecencies DESC"
-    return (allSQL, args)
-}
-
 /* The init for this will perform the heaviest part of the frecency query
  and create a temporary table that can be queried quickly. Currently this accounts for
  >75% of the query time.
  The scope/lifetime of this object is important as the data is 'frozen' until a new instance is created.
  */
-public struct OptimizedFrecencyImpl : OptimizedFrecency {
+fileprivate struct OptimizedFrecencyImpl : OptimizedFrecency {
     private let db: BrowserDB
 
     init(db: BrowserDB) {
         self.db = db
-        let create_awesomebarBookmarksTempTable =
-            "CREATE TEMP TABLE \(AwesomebarBookmarksTempTable) AS " +
+        let create =
+            "CREATE TEMP TABLE \(AwesomebarBookmarksTempTable) (" +
+                "guid TEXT, url TEXT, title TEXT, description TEXT, " +
+        "faviconID INT, visitDate DATE)"
+        let insert =
+            "INSERT INTO \(AwesomebarBookmarksTempTable) " +
                 "SELECT b.guid AS guid, b.url AS url, b.title AS title, " +
                 "b.description AS description, b.faviconID AS faviconID, " +
                 "h.visitDate AS visitDate " +
@@ -278,23 +176,130 @@ public struct OptimizedFrecencyImpl : OptimizedFrecency {
             if tableExists {
                 try connection.executeChange("DELETE FROM \(AwesomebarBookmarksTempTable)")
             } else {
-                try connection.executeChange(create_awesomebarBookmarksTempTable)
+                try connection.executeChange(create)
             }
+            try connection.executeChange(insert)
         }
     }
 
-    public func getSites(historyLimit limit: Int, bookmarksLimit: Int, whereURLContains filter: String? = nil, groupClause: String = "GROUP BY historyID ", whereData: String? = nil) -> Deferred<Maybe<Cursor<Site>>> {
+    func getSites(historyLimit limit: Int, bookmarksLimit: Int, whereURLContains filter: String? = nil) -> Deferred<Maybe<Cursor<Site>>> {
         let factory = SQLiteHistory.basicHistoryColumnFactory
 
         let (query, args) = getFrecencyQuery(
             historyLimit: limit,
             bookmarksLimit: bookmarksLimit,
             whereURLContains: filter,
-            groupClause: groupClause,
-            whereData: whereData
+            groupClause: "GROUP BY historyID ",
+            whereData: nil
         )
 
         return db.runQuery(query, args: args, factory: factory)
+    }
+
+    func getFrecencyQuery(historyLimit: Int, bookmarksLimit: Int, whereURLContains filter: String? = nil, groupClause: String = "GROUP BY historyID ", whereData: String? = nil) -> (String, Args?) {
+        let includeBookmarks = bookmarksLimit > 0
+        let localFrecencySQL = getLocalFrecencySQL()
+        let remoteFrecencySQL = getRemoteFrecencySQL()
+        let sixMonthsInMicroseconds: UInt64 = 15_724_800_000_000      // 182 * 1000 * 1000 * 60 * 60 * 24
+        let sixMonthsAgo = Date.nowMicroseconds() - sixMonthsInMicroseconds
+
+        let args: Args
+        let whereClause: String
+        let whereFragment = (whereData == nil) ? "" : " AND (\(whereData!))"
+
+        if let filter = filter?.trimmingCharacters(in: .whitespaces), !filter.isEmpty {
+            let perWordFragment = "((url LIKE ?) OR (title LIKE ?))"
+            let perWordArgs: (String) -> Args = { ["%\($0)%", "%\($0)%"] }
+            let (filterFragment, filterArgs) = computeWhereFragmentWithFilter(filter, perWordFragment: perWordFragment, perWordArgs: perWordArgs)
+
+            // No deleted item has a URL, so there is no need to explicitly add that here.
+            whereClause = "WHERE (\(filterFragment))\(whereFragment)"
+
+            if includeBookmarks {
+                // We'll need them twice: once to filter history, and once to filter bookmarks.
+                args = filterArgs + filterArgs
+            } else {
+                args = filterArgs
+            }
+        } else {
+            whereClause = " WHERE (\(TableHistory).is_deleted = 0)\(whereFragment)"
+            args = []
+        }
+
+        // Innermost: grab history items and basic visit/domain metadata.
+        var ungroupedSQL =
+            "SELECT \(TableHistory).id AS historyID, \(TableHistory).url AS url, \(TableHistory).title AS title, \(TableHistory).guid AS guid, domain_id, domain" +
+                ", COALESCE(max(case \(TableVisits).is_local when 1 then \(TableVisits).date else 0 end), 0) AS localVisitDate" +
+                ", COALESCE(max(case \(TableVisits).is_local when 0 then \(TableVisits).date else 0 end), 0) AS remoteVisitDate" +
+                ", COALESCE(sum(\(TableVisits).is_local), 0) AS localVisitCount" +
+                ", COALESCE(sum(case \(TableVisits).is_local when 1 then 0 else 1 end), 0) AS remoteVisitCount" +
+                " FROM \(TableHistory) " +
+                "INNER JOIN \(TableDomains) ON \(TableDomains).id = \(TableHistory).domain_id " +
+        "INNER JOIN \(TableVisits) ON \(TableVisits).siteID = \(TableHistory).id "
+
+        if includeBookmarks {
+            ungroupedSQL.append("LEFT JOIN \(ViewAllBookmarks) on \(ViewAllBookmarks).url = \(TableHistory).url ")
+        }
+        ungroupedSQL.append(whereClause.replacingOccurrences(of: "url", with: "\(TableHistory).url").replacingOccurrences(of: "title", with: "\(TableHistory).title"))
+        if includeBookmarks {
+            ungroupedSQL.append(" AND \(ViewAllBookmarks).url IS NULL")
+        }
+        ungroupedSQL.append(" GROUP BY historyID")
+
+        // Next: limit to only those that have been visited at all within the last six months.
+        // (Don't do that in the innermost: we want to get the full count, even if some visits are older.)
+        // Discard all but the 1000 most frecent.
+        // Compute and return the frecency for all 1000 URLs.
+        let frecenciedSQL =
+            "SELECT *, (\(localFrecencySQL) + \(remoteFrecencySQL)) AS frecency" +
+                " FROM (" + ungroupedSQL + ")" +
+                " WHERE (" +
+                "((localVisitCount > 0) OR (remoteVisitCount > 0)) AND " +                         // Eliminate dead rows from coalescing.
+                "((localVisitDate > \(sixMonthsAgo)) OR (remoteVisitDate > \(sixMonthsAgo)))" +    // Exclude really old items.
+                ") ORDER BY frecency DESC" +
+        " LIMIT 1000"                                 // Don't even look at a huge set. This avoids work.
+
+        // Next: merge by domain and select the URL with the max frecency of a domain, ordering by that sum frecency and reducing to a (typically much lower) limit.
+        // NOTE: When using GROUP BY we need to be explicit about which URL to use when grouping. By using "max(frecency)" the result row
+        //       for that domain will contain the projected URL corresponding to the history item with the max frecency, https://sqlite.org/lang_select.html#resultset
+        //       This is the behavior we want in order to ensure that the most popular URL for a domain is used for the top sites tile.
+        // TODO: make is_bookmarked here accurate by joining against ViewAllBookmarks.
+        // TODO: ensure that the same URL doesn't appear twice in the list, either from duplicate
+        //       bookmarks or from being in both bookmarks and history.
+        let historySQL = [
+            "SELECT historyID, url, title, guid, domain_id, domain,",
+            "max(localVisitDate) AS localVisitDate,",
+            "max(remoteVisitDate) AS remoteVisitDate,",
+            "sum(localVisitCount) AS localVisitCount,",
+            "sum(remoteVisitCount) AS remoteVisitCount,",
+            "max(frecency) AS maxFrecency,",
+            "sum(frecency) AS frecencies,",
+            "0 AS is_bookmarked",
+            "FROM (", frecenciedSQL, ") ",
+            groupClause,
+            "ORDER BY frecencies DESC",
+            "LIMIT \(historyLimit)",
+            ].joined(separator: " ")
+
+        let bookmarksSQL = [
+            "SELECT NULL AS historyID, url, title, guid, NULL AS domain_id, NULL AS domain,",
+            "visitDate AS localVisitDate, 0 AS remoteVisitDate, 0 AS localVisitCount,",
+            "0 AS remoteVisitCount,",
+            "visitDate AS frecencies,",  // Fake this for ordering purposes.
+            "0 as maxFrecency,", // Need this column for UNION
+            "1 AS is_bookmarked",
+            "FROM \(AwesomebarBookmarksTempTable)",
+            whereClause,                  // The columns match, so we can reuse this.
+            "GROUP BY url",
+            "ORDER BY visitDate DESC LIMIT \(bookmarksLimit)",
+            ].joined(separator: " ")
+
+        if !includeBookmarks {
+            return (historySQL, args)
+        }
+
+        let allSQL = "SELECT * FROM (SELECT * FROM (\(historySQL)) UNION SELECT * FROM (\(bookmarksSQL))) ORDER BY is_bookmarked DESC, frecencies DESC"
+        return (allSQL, args)
     }
 }
 
@@ -491,7 +496,8 @@ extension SQLiteHistory: BrowserHistory {
         let limit = Int(prefs.intForKey(PrefsKeys.KeyTopSitesCacheSize) ?? TopSiteCacheSize)
 
         let (whereData, groupBy) = self.topSiteClauses()
-        let (frecencyQuery, args) = getFrecencyQuery(historyLimit: limit, bookmarksLimit: 0, groupClause: groupBy, whereData: whereData)
+        // Force unwrap to change from protocol to known implementation to access fileprivate method
+        let (frecencyQuery, args) = (getOptimizedFrecency() as! OptimizedFrecencyImpl).getFrecencyQuery(historyLimit: limit, bookmarksLimit: 0, groupClause: groupBy, whereData: whereData)
 
         // We must project, because we get bookmarks in these results.
         let insertQuery = [
@@ -1042,3 +1048,4 @@ extension SQLiteHistory: AccountRemovalDelegate {
         return self.db.run(discard) >>> self.resetClient
     }
 }
+

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -153,7 +153,7 @@ private let topSitesQuery = "SELECT \(TableCachedTopSites).*, \(TablePageMetadat
  >75% of the query time.
  The scope/lifetime of this object is important as the data is 'frozen' until a new instance is created.
  */
-fileprivate struct OptimizedFrecencyImpl : OptimizedFrecency {
+fileprivate struct FrecentHistoryImpl : FrecentHistory {
     private let db: BrowserDB
 
     init(db: BrowserDB) {
@@ -472,8 +472,8 @@ extension SQLiteHistory: BrowserHistory {
          >>> { self.addLocalVisitForExistingSite(visit) }
     }
 
-    public func getOptimizedFrecency() -> OptimizedFrecency {
-        return OptimizedFrecencyImpl(db: db)
+    public func getFrecentHistory() -> FrecentHistory {
+        return FrecentHistoryImpl(db: db)
     }
 
     public func getTopSitesWithLimit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>> {
@@ -497,7 +497,7 @@ extension SQLiteHistory: BrowserHistory {
 
         let (whereData, groupBy) = self.topSiteClauses()
         // Force unwrap to change from protocol to known implementation to access fileprivate method
-        let (frecencyQuery, args) = (getOptimizedFrecency() as! OptimizedFrecencyImpl).getFrecencyQuery(historyLimit: limit, bookmarksLimit: 0, groupClause: groupBy, whereData: whereData)
+        let (frecencyQuery, args) = (getFrecentHistory() as! FrecentHistoryImpl).getFrecencyQuery(historyLimit: limit, bookmarksLimit: 0, groupClause: groupBy, whereData: whereData)
 
         // We must project, because we get bookmarks in these results.
         let insertQuery = [

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -74,6 +74,49 @@ func getLocalFrecencySQL() -> String {
     return "\(visitCountExpression) * max(2, 100 * 225 / (\(ageDays) * \(ageDays) + 225))"
 }
 
+fileprivate func computeWordsWithFilter(_ filter: String) -> [String] {
+    // Split filter on whitespace.
+    let words = filter.components(separatedBy: .whitespaces)
+
+    // Remove substrings and duplicates.
+    // TODO: this can probably be improved.
+    return words.enumerated().filter({ (index: Int, word: String) in
+        if word.isEmpty {
+            return false
+        }
+
+        for i in words.indices where i != index {
+            if words[i].range(of: word) != nil && (words[i].characters.count != word.characters.count || i < index) {
+                return false
+            }
+        }
+
+        return true
+    }).map({ $0.1 })
+}
+
+/**
+ * Take input like "foo bar" and a template fragment and produce output like
+ *
+ *   ((x.y LIKE ?) OR (x.z LIKE ?)) AND ((x.y LIKE ?) OR (x.z LIKE ?))
+ *
+ * with args ["foo", "foo", "bar", "bar"].
+ */
+internal func computeWhereFragmentWithFilter(_ filter: String, perWordFragment: String, perWordArgs: (String) -> Args) -> (fragment: String, args: Args) {
+    precondition(!filter.isEmpty)
+
+    let words = computeWordsWithFilter(filter)
+    return computeWhereFragmentForWords(words, perWordFragment: perWordFragment, perWordArgs: perWordArgs)
+}
+
+internal func computeWhereFragmentForWords(_ words: [String], perWordFragment: String, perWordArgs: (String) -> Args) -> (fragment: String, args: Args) {
+    assert(!words.isEmpty)
+
+    let fragment = Array(repeating: perWordFragment, count: words.count).joined(separator: " AND ")
+    let args = words.flatMap(perWordArgs)
+    return (fragment, args)
+}
+
 extension SDRow {
     func getTimestamp(_ column: String) -> Timestamp? {
         return (self[column] as? NSNumber)?.uint64Value
@@ -104,6 +147,157 @@ open class SQLiteHistory {
 }
 
 private let topSitesQuery = "SELECT \(TableCachedTopSites).*, \(TablePageMetadata).provider_name FROM \(TableCachedTopSites) LEFT OUTER JOIN \(TablePageMetadata) ON \(TableCachedTopSites).url = \(TablePageMetadata).site_url ORDER BY frecencies DESC LIMIT (?)"
+
+/* The init for this will perform the heaviest part of the frecency query
+ and create a temporary table that can be queried quickly. Currently this accounts for
+ >75% of the query time.
+ The scope/lifetime of this object is important as the data is 'frozen' until a new instance is created.
+ */
+public struct OptimizedFrecency {
+    private let db: BrowserDB
+
+    init(db: BrowserDB) {
+        self.db = db
+        let create_awesomebarBookmarksTempTable =
+            "CREATE TEMP TABLE \(AwesomebarBookmarksTempTable) AS " +
+                "SELECT b.guid AS guid, b.url AS url, b.title AS title, " +
+                "b.description AS description, b.faviconID AS faviconID, " +
+                "h.visitDate AS visitDate " +
+                "FROM \(ViewAwesomebarBookmarks) b " +
+        "LEFT JOIN \(ViewHistoryVisits) h ON b.url = h.url"
+
+        db.withConnection { connection in
+            let existsQuery = "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' and name = '\(AwesomebarBookmarksTempTable)'"
+            let tableExists = 1 == connection.executeQuery(existsQuery, factory: IntFactory).asArray().first
+            if tableExists {
+                try connection.executeChange("DELETE FROM \(AwesomebarBookmarksTempTable)")
+            } else {
+                try connection.executeChange(create_awesomebarBookmarksTempTable)
+            }
+        }
+    }
+
+    public func getSites(historyLimit limit: Int, bookmarksLimit: Int, whereURLContains filter: String? = nil, groupClause: String = "GROUP BY historyID ", whereData: String? = nil) -> Deferred<Maybe<Cursor<Site>>> {
+        let factory = SQLiteHistory.basicHistoryColumnFactory
+
+        let (query, args) = getQuery(
+            historyLimit: limit,
+            bookmarksLimit: bookmarksLimit,
+            whereURLContains: filter,
+            groupClause: groupClause,
+            whereData: whereData
+        )
+
+        return db.runQuery(query, args: args, factory: factory)
+    }
+
+
+    fileprivate func getQuery(historyLimit: Int, bookmarksLimit: Int, whereURLContains filter: String? = nil,groupClause: String = "GROUP BY historyID ", whereData: String? = nil) -> (String, Args?) {
+        let includeBookmarks = bookmarksLimit > 0
+        let localFrecencySQL = getLocalFrecencySQL()
+        let remoteFrecencySQL = getRemoteFrecencySQL()
+        let sixMonthsInMicroseconds: UInt64 = 15_724_800_000_000      // 182 * 1000 * 1000 * 60 * 60 * 24
+        let sixMonthsAgo = Date.nowMicroseconds() - sixMonthsInMicroseconds
+
+        let args: Args
+        let whereClause: String
+        let whereFragment = (whereData == nil) ? "" : " AND (\(whereData!))"
+
+        if let filter = filter?.trimmingCharacters(in: .whitespaces), !filter.isEmpty {
+            let perWordFragment = "((url LIKE ?) OR (title LIKE ?))"
+            let perWordArgs: (String) -> Args = { ["%\($0)%", "%\($0)%"] }
+            let (filterFragment, filterArgs) = computeWhereFragmentWithFilter(filter, perWordFragment: perWordFragment, perWordArgs: perWordArgs)
+
+            // No deleted item has a URL, so there is no need to explicitly add that here.
+            whereClause = "WHERE (\(filterFragment))\(whereFragment)"
+
+            if includeBookmarks {
+                // We'll need them twice: once to filter history, and once to filter bookmarks.
+                args = filterArgs + filterArgs
+            } else {
+                args = filterArgs
+            }
+        } else {
+            whereClause = " WHERE (\(TableHistory).is_deleted = 0)\(whereFragment)"
+            args = []
+        }
+
+        // Innermost: grab history items and basic visit/domain metadata.
+        var ungroupedSQL =
+            "SELECT \(TableHistory).id AS historyID, \(TableHistory).url AS url, \(TableHistory).title AS title, \(TableHistory).guid AS guid, domain_id, domain" +
+                ", COALESCE(max(case \(TableVisits).is_local when 1 then \(TableVisits).date else 0 end), 0) AS localVisitDate" +
+                ", COALESCE(max(case \(TableVisits).is_local when 0 then \(TableVisits).date else 0 end), 0) AS remoteVisitDate" +
+                ", COALESCE(sum(\(TableVisits).is_local), 0) AS localVisitCount" +
+                ", COALESCE(sum(case \(TableVisits).is_local when 1 then 0 else 1 end), 0) AS remoteVisitCount" +
+                " FROM \(TableHistory) " +
+                "INNER JOIN \(TableDomains) ON \(TableDomains).id = \(TableHistory).domain_id " +
+        "INNER JOIN \(TableVisits) ON \(TableVisits).siteID = \(TableHistory).id "
+
+        if includeBookmarks {
+            ungroupedSQL.append("LEFT JOIN \(ViewAllBookmarks) on \(ViewAllBookmarks).url = \(TableHistory).url ")
+        }
+        ungroupedSQL.append(whereClause.replacingOccurrences(of: "url", with: "\(TableHistory).url").replacingOccurrences(of: "title", with: "\(TableHistory).title"))
+        if includeBookmarks {
+            ungroupedSQL.append(" AND \(ViewAllBookmarks).url IS NULL")
+        }
+        ungroupedSQL.append(" GROUP BY historyID")
+
+        // Next: limit to only those that have been visited at all within the last six months.
+        // (Don't do that in the innermost: we want to get the full count, even if some visits are older.)
+        // Discard all but the 1000 most frecent.
+        // Compute and return the frecency for all 1000 URLs.
+        let frecenciedSQL =
+            "SELECT *, (\(localFrecencySQL) + \(remoteFrecencySQL)) AS frecency" +
+                " FROM (" + ungroupedSQL + ")" +
+                " WHERE (" +
+                "((localVisitCount > 0) OR (remoteVisitCount > 0)) AND " +                         // Eliminate dead rows from coalescing.
+                "((localVisitDate > \(sixMonthsAgo)) OR (remoteVisitDate > \(sixMonthsAgo)))" +    // Exclude really old items.
+                ") ORDER BY frecency DESC" +
+        " LIMIT 1000"                                 // Don't even look at a huge set. This avoids work.
+
+        // Next: merge by domain and select the URL with the max frecency of a domain, ordering by that sum frecency and reducing to a (typically much lower) limit.
+        // NOTE: When using GROUP BY we need to be explicit about which URL to use when grouping. By using "max(frecency)" the result row
+        //       for that domain will contain the projected URL corresponding to the history item with the max frecency, https://sqlite.org/lang_select.html#resultset
+        //       This is the behavior we want in order to ensure that the most popular URL for a domain is used for the top sites tile.
+        // TODO: make is_bookmarked here accurate by joining against ViewAllBookmarks.
+        // TODO: ensure that the same URL doesn't appear twice in the list, either from duplicate
+        //       bookmarks or from being in both bookmarks and history.
+        let historySQL = [
+            "SELECT historyID, url, title, guid, domain_id, domain,",
+            "max(localVisitDate) AS localVisitDate,",
+            "max(remoteVisitDate) AS remoteVisitDate,",
+            "sum(localVisitCount) AS localVisitCount,",
+            "sum(remoteVisitCount) AS remoteVisitCount,",
+            "max(frecency) AS maxFrecency,",
+            "sum(frecency) AS frecencies,",
+            "0 AS is_bookmarked",
+            "FROM (", frecenciedSQL, ") ",
+            groupClause,
+            "ORDER BY frecencies DESC",
+            "LIMIT \(historyLimit)",
+            ].joined(separator: " ")
+
+        let bookmarksSQL = [
+            "SELECT NULL AS historyID, url, title, guid, NULL AS domain_id, NULL AS domain,",
+            "visitDate AS localVisitDate, 0 AS remoteVisitDate, 0 AS localVisitCount,",
+            "0 AS remoteVisitCount,",
+            "visitDate AS frecencies,",  // Fake this for ordering purposes.
+            "0 as maxFrecency,", // Need this column for UNION
+            "1 AS is_bookmarked",
+            "FROM \(AwesomebarBookmarksTempTable)",
+            whereClause,                  // The columns match, so we can reuse this.
+            "GROUP BY url",
+            "ORDER BY visitDate DESC LIMIT \(bookmarksLimit)",
+            ].joined(separator: " ")
+
+        if !includeBookmarks {
+            return (historySQL, args)
+        }
+
+        let allSQL = "SELECT * FROM (SELECT * FROM (\(historySQL)) UNION SELECT * FROM (\(bookmarksSQL))) ORDER BY is_bookmarked DESC, frecencies DESC"
+        return (allSQL, args)
+    }
+}
 
 extension SQLiteHistory: BrowserHistory {
     public func removeSiteFromTopSites(_ site: Site) -> Success {
@@ -274,18 +468,8 @@ extension SQLiteHistory: BrowserHistory {
          >>> { self.addLocalVisitForExistingSite(visit) }
     }
 
-    public func getSitesByFrecencyWithHistoryLimit(_ limit: Int, bookmarksLimit: Int = 0, whereURLContains filter: String) -> Deferred<Maybe<Cursor<Site>>> {
-        return self.getFilteredSitesByFrecencyWithHistoryLimit(limit, bookmarksLimit: bookmarksLimit, whereURLContains: filter, includeIcon: true)
-    }
-
-    public func getSitesByFrecencyWithHistoryLimit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>> {
-        return self.getSitesByFrecencyWithHistoryLimit(limit, includeIcon: true)
-    }
-
-    public func getSitesByFrecencyWithHistoryLimit(_ limit: Int, includeIcon: Bool) -> Deferred<Maybe<Cursor<Site>>> {
-        // Exclude redirect domains. Bug 1194852.
-        let (whereData, groupBy) = self.topSiteClauses()
-        return self.getFilteredSitesByFrecencyWithHistoryLimit(limit, bookmarksLimit: 0, groupClause: groupBy, whereData: whereData, includeIcon: includeIcon)
+    public func getOptimizedFrecency() -> OptimizedFrecency {
+        return OptimizedFrecency(db: db)
     }
 
     public func getTopSitesWithLimit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>> {
@@ -308,16 +492,23 @@ extension SQLiteHistory: BrowserHistory {
         let limit = Int(prefs.intForKey(PrefsKeys.KeyTopSitesCacheSize) ?? TopSiteCacheSize)
 
         let (whereData, groupBy) = self.topSiteClauses()
-        let (query, args) = self.filteredSitesByFrecencyQueryWithHistoryLimit(limit, bookmarksLimit: 0, groupClause: groupBy, whereData: whereData)
+        let (frecencyQuery, args) = getOptimizedFrecency().getQuery(historyLimit: limit, bookmarksLimit: 0, groupClause: groupBy, whereData: whereData)
 
         // We must project, because we get bookmarks in these results.
         let insertQuery = [
+            "WITH siteFrecency AS (\(frecencyQuery))",
             "INSERT INTO \(TableCachedTopSites)",
             "SELECT historyID, url, title, guid, domain_id, domain,",
             "localVisitDate, remoteVisitDate, localVisitCount, remoteVisitCount,",
             "iconID, iconURL, iconDate, iconWidth, frecencies",
-            "FROM (", query, ")"
+            "FROM (SELECT * FROM",
+            "siteFrecency LEFT JOIN view_history_id_favicon ON",
+            "siteFrecency.historyID = view_history_id_favicon.id)"
             ].joined(separator: " ")
+
+        // @TODO: remove the LEFT JOIN to fill in the icon columns, it is just there because the code has been doing this historically.
+        // Those favicon data columns are not used, and view_history_id_favicon appears to only contain null data.
+
         return (insertQuery, args)
     }
 
@@ -340,49 +531,6 @@ extension SQLiteHistory: BrowserHistory {
         let whereData = "(\(TableDomains).showOnTopSites IS 1) AND (\(TableDomains).domain NOT LIKE 'r.%') AND (\(TableDomains).domain NOT LIKE 'google.%') "
         let groupBy = "GROUP BY domain_id "
         return (whereData, groupBy)
-    }
-
-    fileprivate func computeWordsWithFilter(_ filter: String) -> [String] {
-        // Split filter on whitespace.
-        let words = filter.components(separatedBy: .whitespaces)
-
-        // Remove substrings and duplicates.
-        // TODO: this can probably be improved.
-        return words.enumerated().filter({ (index: Int, word: String) in
-            if word.isEmpty {
-                return false
-            }
-
-            for i in words.indices where i != index {
-                if words[i].range(of: word) != nil && (words[i].count != word.count || i < index) {
-                    return false
-                }
-            }
-
-            return true
-        }).map({ $0.1 })
-    }
-
-    /**
-     * Take input like "foo bar" and a template fragment and produce output like
-     *
-     *   ((x.y LIKE ?) OR (x.z LIKE ?)) AND ((x.y LIKE ?) OR (x.z LIKE ?))
-     *
-     * with args ["foo", "foo", "bar", "bar"].
-     */
-    internal func computeWhereFragmentWithFilter(_ filter: String, perWordFragment: String, perWordArgs: (String) -> Args) -> (fragment: String, args: Args) {
-        precondition(!filter.isEmpty)
-
-        let words = computeWordsWithFilter(filter)
-        return self.computeWhereFragmentForWords(words, perWordFragment: perWordFragment, perWordArgs: perWordArgs)
-    }
-
-    internal func computeWhereFragmentForWords(_ words: [String], perWordFragment: String, perWordArgs: (String) -> Args) -> (fragment: String, args: Args) {
-        assert(!words.isEmpty)
-
-        let fragment = Array(repeating: perWordFragment, count: words.count).joined(separator: " AND ")
-        let args = words.flatMap(perWordArgs)
-        return (fragment, args)
     }
 
     fileprivate func getFilteredSitesByVisitDateWithLimit(_ limit: Int,
@@ -426,179 +574,6 @@ extension SQLiteHistory: BrowserHistory {
         return db.runQuery(sql, args: args, factory: factory)
     }
 
-    fileprivate func getFilteredSitesByFrecencyWithHistoryLimit(_ limit: Int,
-                                                                bookmarksLimit: Int,
-                                                                whereURLContains filter: String? = nil,
-                                                                groupClause: String = "GROUP BY historyID ",
-                                                                whereData: String? = nil,
-                                                                includeIcon: Bool = true) -> Deferred<Maybe<Cursor<Site>>> {
-        let factory: (SDRow) -> Site
-        if includeIcon {
-            factory = SQLiteHistory.iconHistoryColumnFactory
-        } else {
-            factory = SQLiteHistory.basicHistoryColumnFactory
-        }
-
-        let (query, args) = filteredSitesByFrecencyQueryWithHistoryLimit(
-            limit,
-            bookmarksLimit: bookmarksLimit,
-            whereURLContains: filter,
-            groupClause: groupClause,
-            whereData: whereData,
-            includeIcon: includeIcon
-        )
-
-        return db.runQuery(query, args: args, factory: factory)
-    }
-
-    fileprivate func filteredSitesByFrecencyQueryWithHistoryLimit(_ historyLimit: Int,
-                                                                  bookmarksLimit: Int,
-                                                                  whereURLContains filter: String? = nil,
-                                                                  groupClause: String = "GROUP BY historyID ",
-                                                                  whereData: String? = nil,
-                                                                  includeIcon: Bool = true) -> (String, Args?) {
-        let includeBookmarks = bookmarksLimit > 0
-        let localFrecencySQL = getLocalFrecencySQL()
-        let remoteFrecencySQL = getRemoteFrecencySQL()
-        let sixMonthsInMicroseconds: UInt64 = 15_724_800_000_000      // 182 * 1000 * 1000 * 60 * 60 * 24
-        let sixMonthsAgo = Date.nowMicroseconds() - sixMonthsInMicroseconds
-
-        let args: Args
-        let whereClause: String
-        let whereFragment = (whereData == nil) ? "" : " AND (\(whereData!))"
-
-        if let filter = filter?.trimmingCharacters(in: .whitespaces), !filter.isEmpty {
-            let perWordFragment = "((url LIKE ?) OR (title LIKE ?))"
-            let perWordArgs: (String) -> Args = { ["%\($0)%", "%\($0)%"] }
-            let (filterFragment, filterArgs) = computeWhereFragmentWithFilter(filter, perWordFragment: perWordFragment, perWordArgs: perWordArgs)
-
-            // No deleted item has a URL, so there is no need to explicitly add that here.
-            whereClause = "WHERE (\(filterFragment))\(whereFragment)"
-
-            if includeBookmarks {
-                // We'll need them twice: once to filter history, and once to filter bookmarks.
-                args = filterArgs + filterArgs
-            } else {
-                args = filterArgs
-            }
-        } else {
-            whereClause = " WHERE (\(TableHistory).is_deleted = 0)\(whereFragment)"
-            args = []
-        }
-
-        // Innermost: grab history items and basic visit/domain metadata.
-        var ungroupedSQL =
-        "SELECT \(TableHistory).id AS historyID, \(TableHistory).url AS url, \(TableHistory).title AS title, \(TableHistory).guid AS guid, domain_id, domain" +
-        ", COALESCE(max(case \(TableVisits).is_local when 1 then \(TableVisits).date else 0 end), 0) AS localVisitDate" +
-        ", COALESCE(max(case \(TableVisits).is_local when 0 then \(TableVisits).date else 0 end), 0) AS remoteVisitDate" +
-        ", COALESCE(sum(\(TableVisits).is_local), 0) AS localVisitCount" +
-        ", COALESCE(sum(case \(TableVisits).is_local when 1 then 0 else 1 end), 0) AS remoteVisitCount" +
-        " FROM \(TableHistory) " +
-        "INNER JOIN \(TableDomains) ON \(TableDomains).id = \(TableHistory).domain_id " +
-        "INNER JOIN \(TableVisits) ON \(TableVisits).siteID = \(TableHistory).id "
-
-        if includeBookmarks {
-            ungroupedSQL.append("LEFT JOIN \(ViewAllBookmarks) on \(ViewAllBookmarks).url = \(TableHistory).url ")
-        }
-        ungroupedSQL.append(whereClause.replacingOccurrences(of: "url", with: "\(TableHistory).url").replacingOccurrences(of: "title", with: "\(TableHistory).title"))
-        if includeBookmarks {
-            ungroupedSQL.append(" AND \(ViewAllBookmarks).url IS NULL")
-        }
-        ungroupedSQL.append(" GROUP BY historyID")
-
-        // Next: limit to only those that have been visited at all within the last six months.
-        // (Don't do that in the innermost: we want to get the full count, even if some visits are older.)
-        // Discard all but the 1000 most frecent.
-        // Compute and return the frecency for all 1000 URLs.
-        let frecenciedSQL =
-        "SELECT *, (\(localFrecencySQL) + \(remoteFrecencySQL)) AS frecency" +
-        " FROM (" + ungroupedSQL + ")" +
-        " WHERE (" +
-        "((localVisitCount > 0) OR (remoteVisitCount > 0)) AND " +                         // Eliminate dead rows from coalescing.
-        "((localVisitDate > \(sixMonthsAgo)) OR (remoteVisitDate > \(sixMonthsAgo)))" +    // Exclude really old items.
-        ") ORDER BY frecency DESC" +
-        " LIMIT 1000"                                 // Don't even look at a huge set. This avoids work.
-
-        // Next: merge by domain and select the URL with the max frecency of a domain, ordering by that sum frecency and reducing to a (typically much lower) limit.
-        // NOTE: When using GROUP BY we need to be explicit about which URL to use when grouping. By using "max(frecency)" the result row
-        //       for that domain will contain the projected URL corresponding to the history item with the max frecency, https://sqlite.org/lang_select.html#resultset
-        //       This is the behavior we want in order to ensure that the most popular URL for a domain is used for the top sites tile.
-        // TODO: make is_bookmarked here accurate by joining against ViewAllBookmarks.
-        // TODO: ensure that the same URL doesn't appear twice in the list, either from duplicate
-        //       bookmarks or from being in both bookmarks and history.
-        let historySQL = [
-            "SELECT historyID, url, title, guid, domain_id, domain,",
-            "max(localVisitDate) AS localVisitDate,",
-            "max(remoteVisitDate) AS remoteVisitDate,",
-            "sum(localVisitCount) AS localVisitCount,",
-            "sum(remoteVisitCount) AS remoteVisitCount,",
-            "max(frecency),",
-            "sum(frecency) AS frecencies,",
-            "0 AS is_bookmarked",
-            "FROM (", frecenciedSQL, ") ",
-            groupClause,
-            "ORDER BY frecencies DESC",
-            "LIMIT \(historyLimit)",
-        ].joined(separator: " ")
-
-        if includeIcon {
-            // We select the history items then immediately join to get the largest icon.
-            // We do this so that we limit and filter *before* joining against icons.
-            let historyWithIconsSQL = [
-                "SELECT historyID, url, title, guid, domain_id, domain,",
-                "localVisitDate, remoteVisitDate, localVisitCount, remoteVisitCount,",
-                "iconID, iconURL, iconDate, iconWidth, frecencies, is_bookmarked",
-                "FROM (", historySQL, ") LEFT OUTER JOIN",
-                "view_history_id_favicon ON historyID = view_history_id_favicon.id",
-                "ORDER BY frecencies DESC",
-            ].joined(separator: " ")
-
-            if !includeBookmarks {
-                return (historyWithIconsSQL, args)
-            }
-
-            // Find bookmarks, too.
-            // This isn't required by the protocol we're implementing, but we're able to do
-            // it because we share storage with bookmarks.
-            // Note that this is part-duplicated below.
-            let bookmarksWithIconsSQL = [
-                "SELECT NULL AS historyID, url, title, guid, NULL AS domain_id, NULL AS domain,",
-                "visitDate AS localVisitDate, 0 AS remoteVisitDate, 0 AS localVisitCount,",
-                "0 AS remoteVisitCount,",
-                "iconID, iconURL, iconDate, iconWidth,",
-                "visitDate AS frecencies,",  // Fake this for ordering purposes.
-                "1 AS is_bookmarked",
-                "FROM", ViewAwesomebarBookmarksWithIcons,
-                whereClause,                  // The columns match, so we can reuse this.
-                "GROUP BY url",
-                "ORDER BY visitDate DESC LIMIT \(bookmarksLimit)",
-            ].joined(separator: " ")
-
-            let sql =
-            "SELECT * FROM (SELECT * FROM (\(historyWithIconsSQL)) UNION SELECT * FROM (\(bookmarksWithIconsSQL))) ORDER BY is_bookmarked DESC, frecencies DESC"
-            return (sql, args)
-        }
-
-        if !includeBookmarks {
-            return (historySQL, args)
-        }
-
-        // Note that this is part-duplicated above.
-        let bookmarksSQL = [
-            "SELECT NULL AS historyID, url, title, guid, NULL AS domain_id, NULL AS domain,",
-            "visitDate AS localVisitDate, 0 AS remoteVisitDate, 0 AS localVisitCount,",
-            "0 AS remoteVisitCount,",
-            "visitDate AS frecencies,",  // Fake this for ordering purposes.
-            "1 AS is_bookmarked",
-            "FROM", ViewAwesomebarBookmarks,
-            whereClause,                  // The columns match, so we can reuse this.
-            "GROUP BY url",
-            "ORDER BY visitDate DESC LIMIT \(bookmarksLimit)",
-        ].joined(separator: " ")
-
-        let allSQL = "SELECT * FROM (SELECT * FROM (\(historySQL)) UNION SELECT * FROM (\(bookmarksSQL))) ORDER BY is_bookmarked DESC, frecencies DESC"
-        return (allSQL, args)
-    }
 }
 
 extension SQLiteHistory: Favicons {
@@ -1068,3 +1043,4 @@ extension SQLiteHistory: AccountRemovalDelegate {
         return self.db.run(discard) >>> self.resetClient
     }
 }
+

--- a/StoragePerfTests/StoragePerfTests.swift
+++ b/StoragePerfTests/StoragePerfTests.swift
@@ -46,7 +46,7 @@ class TestSQLiteHistoryFrecencyPerf: XCTestCase {
 
         self.measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true) {
             for _ in 0...5 {
-                history.getFrecentHistory().getSites(historyLimit: 10, bookmarksLimit: 0, whereURLContains: nil).succeeded()
+                history.getFrecentHistory().getSites(whereURLContains: nil, historyLimit: 10, bookmarksLimit: 0).succeeded()
             }
             self.stopMeasuring()
         }

--- a/StoragePerfTests/StoragePerfTests.swift
+++ b/StoragePerfTests/StoragePerfTests.swift
@@ -46,7 +46,7 @@ class TestSQLiteHistoryFrecencyPerf: XCTestCase {
 
         self.measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true) {
             for _ in 0...5 {
-                history.getSitesByFrecencyWithHistoryLimit(10, includeIcon: false).succeeded()
+                history.getFrecentHistory().getSites(historyLimit: 10, bookmarksLimit: 0, whereURLContains: nil).succeeded()
             }
             self.stopMeasuring()
         }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1169322

Multiple views are recalculated on every keystroke, but one can assume
the database is unchanging while in the autocomplete view state.
Thus, create a temporary table when the autocomplete state is entered to
reduce the number of queries.
Also, joining result sets with favicon tables is adding 15-20% more time
to the query, and the client code never uses this data in the result
table. The client view that shows the favicons (correctly) looks up the
favicon for a site as needed.

iPhone5 queries are 2.5-3 sec per keystroke, with this patch they are
0.4 sec consistently. There will be some overhead to create the temp
  table, however it is off main, and the overall perf is so much better
I don't notice any issues.

The next thing to do is to remove the favicon sql joins from the code.
I think it is a valuable cleanup task.
  