### PR TITLE
Bug 1425933 - Call hasURLs before trying to access pasteboard URL

### DIFF
--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -60,7 +60,8 @@ class ShareExtensionHelper: NSObject {
             }
             // Bug 1392418 - When copying a url using the share extension there are 2 urls in the pasteboard.
             // Make sure the pasteboard only has one url.
-            if let url = UIPasteboard.general.urls?.first {
+            // pasteboard requires you use hasURLs to check for urls
+            if UIPasteboard.general.hasURLs, let url = UIPasteboard.general.urls?.first {
                 UIPasteboard.general.urls = [url]
             }
 

--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -59,8 +59,7 @@ class ShareExtensionHelper: NSObject {
                 return
             }
             // Bug 1392418 - When copying a url using the share extension there are 2 urls in the pasteboard.
-            // Make sure the pasteboard only has one url.
-            // pasteboard requires you use hasURLs to check for urls
+            // This is a iOS 11.0 bug. Fixed in 11.2
             if UIPasteboard.general.hasURLs, let url = UIPasteboard.general.urls?.first {
                 UIPasteboard.general.urls = [url]
             }


### PR DESCRIPTION
This is related to a crash we had that appeared in 10.3

According to the docs https://developer.apple.com/documentation/uikit/uipasteboard/1622097-urls
`Do not use this property to determine if a pasteboard contains URL data. Instead, use the hasURLs property.`