### PR TITLE
 Bug 1424413 - make sure webViewWebContentProcessDidTerminate is actually called

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -873,7 +873,6 @@ extension TabManager: WKNavigationDelegate {
 
     /// Called when the WKWebView's content process has gone away. If this happens for the currently selected tab
     /// then we immediately reload it.
-
     func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
         if let tab = selectedTab, tab.webView == webView {
             webView.reload()
@@ -924,6 +923,12 @@ class TabManagerNavDelegate: NSObject, WKNavigationDelegate {
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         for delegate in delegates {
             delegate.webView?(webView, didFinish: navigation)
+        }
+    }
+
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        for delegate in delegates {
+            delegate.webViewWebContentProcessDidTerminate?(webView)
         }
     }
 


### PR DESCRIPTION
This wasnt hooked up correctly. This isnt really critical though.
A user would have probably just refreshed manually if the page they are on crashed. 