### PR TITLE
Bug 1427992: Add negative size check to PDF scrollview crash guard

### DIFF
--- a/Client/UIScrollViewSwizzled.swift
+++ b/Client/UIScrollViewSwizzled.swift
@@ -27,7 +27,14 @@ extension UIScrollView {
     func swizzle_setBounds(bounds: CGRect) {
         [bounds.origin.x, bounds.origin.y, bounds.size.width, bounds.size.height].forEach() { val in
             if val.isNaN || val.isInfinite {
-                Sentry.shared.send(message: "Bad scrollview bounds detected.")
+                Sentry.shared.send(message: "Bad scrollview bounds detected [infinite/nan].")
+                return
+            }
+        }
+
+        [bounds.size.width, bounds.size.height].forEach() { val in
+            if val < 0 {
+                Sentry.shared.send(message: "Bad scrollview bounds detected [negative size].")
                 return
             }
         }


### PR DESCRIPTION
In theory, it should be possible to stop this internal crash by blocking
the cases where bad values are passed up through the view hierarchy.
The only case left I can see is the size is negative,  so I added a guard for that case.

https://bugzilla.mozilla.org/show_bug.cgi?id=1427992
  