### PR TITLE
Bug 1415720 - Separate onboarding view from configuration. This will allow us to customize onboarding via LP.

### DIFF
--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -139,7 +139,7 @@ class LeanPlumClient {
 
             // We need to check if the app is a clean install to use for
             // preventing the What's New URL from appearing.
-            if self.prefs?.intForKey(IntroViewControllerSeenProfileKey) == nil {
+            if self.prefs?.intForKey(PrefsKeys.IntroSeen) == nil {
                 self.prefs?.setString(AppInfo.appVersion, forKey: LatestAppVersionProfileKey)
                 self.track(event: .firstRun)
             } else if self.prefs?.boolForKey("SecondRun") == nil {

--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -32,7 +32,7 @@ class TestAppDelegate: AppDelegate {
 
         // Skip the intro when requested by for example tests or automation
         if launchArguments.contains(LaunchArguments.SkipIntro) {
-            profile.prefs.setInt(1, forKey: IntroViewControllerSeenProfileKey)
+            profile.prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
         }
 
         self.profile = profile

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -490,7 +490,7 @@ class BrowserViewController: UIViewController {
         // not flash before we present. This change of alpha also participates in the animation when
         // the intro view is dismissed.
         if UIDevice.current.userInterfaceIdiom == .phone {
-            self.view.alpha = (profile.prefs.intForKey(IntroViewControllerSeenProfileKey) != nil) ? 1.0 : 0.0
+            self.view.alpha = (profile.prefs.intForKey(PrefsKeys.IntroSeen) != nil) ? 1.0 : 0.0
         }
 
         if !displayedRestoreTabsAlert && !cleanlyBackgrounded() && crashedLastLaunch() {
@@ -2287,12 +2287,12 @@ extension BrowserViewController: IntroViewControllerDelegate {
             return true
         }
         
-        if force || profile.prefs.intForKey(IntroViewControllerSeenProfileKey) == nil {
+        if force || profile.prefs.intForKey(PrefsKeys.IntroSeen) == nil {
             let introViewController = IntroViewController()
             introViewController.delegate = self
             // On iPad we present it modally in a controller
             if topTabsVisible {
-                introViewController.preferredContentSize = CGSize(width: IntroViewControllerUX.Width, height: IntroViewControllerUX.Height)
+                introViewController.preferredContentSize = CGSize(width: IntroUX.Width, height: IntroUX.Height)
                 introViewController.modalPresentationStyle = .formSheet
             }
             present(introViewController, animated: animated) {
@@ -2318,7 +2318,9 @@ extension BrowserViewController: IntroViewControllerDelegate {
     }
 
     func introViewControllerDidFinish(_ introViewController: IntroViewController, requestToLogin: Bool) {
-        self.profile.prefs.setInt(1, forKey: IntroViewControllerSeenProfileKey)
+        self.profile.prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
+        LeanPlumClient.shared.track(event: .dismissedOnboarding)
+
         introViewController.dismiss(animated: true) { finished in
             if self.navigationController?.viewControllers.count ?? 0 > 1 {
                 _ = self.navigationController?.popToRootViewController(animated: true)

--- a/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -102,7 +102,7 @@ class ClipboardBarDisplayHandler: NSObject, URLChangeDelegate {
             !sessionRestored ||
             !firstTabLoaded ||
             isClipboardURLAlreadyDisplayed(copiedURL) ||
-            self.prefs.intForKey(IntroViewControllerSeenProfileKey) == nil {
+            self.prefs.intForKey(PrefsKeys.IntroSeen) == nil {
             return false
         }
         sessionStarted = false

--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -207,7 +207,7 @@ extension IntroViewController {
 extension IntroViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        NotificationCenter.default.addObserver(self, selector: #selector(SELDynamicFontChanged), name: NotificationDynamicFontChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(dynamicFontChanged), name: NotificationDynamicFontChanged, object: nil)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -215,12 +215,7 @@ extension IntroViewController {
         NotificationCenter.default.removeObserver(self, name: NotificationDynamicFontChanged, object: nil)
     }
 
-    func SELDynamicFontChanged(_ notification: Notification) {
-        guard notification.name == NotificationDynamicFontChanged else { return }
-        setupDynamicFonts()
-    }
-
-    func DynamicFontChanged(_ notification: Notification) {
+    func dynamicFontChanged(_ notification: Notification) {
         guard notification.name == NotificationDynamicFontChanged else { return }
         setupDynamicFonts()
     }
@@ -257,8 +252,6 @@ extension IntroViewController: UIScrollViewDelegate {
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        let page = Int(scrollView.contentOffset.x / scrollView.frame.size.width)
-
         let maximumHorizontalOffset = scrollView.frame.width
         let currentHorizontalOffset = scrollView.contentOffset.x
 
@@ -338,8 +331,7 @@ class CardView: UIView {
             button.setTitle(buttonText, for: .normal)
             addSubview(button)
             button.snp.makeConstraints { make in
-                make.bottom.equalTo(self)
-                make.centerX.equalTo(self)
+                make.bottom.centerX.equalTo(self)
             }
         }
     }

--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -4,261 +4,186 @@
 
 import UIKit
 import SnapKit
+import Shared
 
-struct IntroViewControllerUX {
+struct IntroUX {
     static let Width = 375
     static let Height = 667
-    static let SyncButtonTopPadding = 5
     static let MinimumFontScale: CGFloat = 0.5
-
-    static let CardSlides = ["tour-Welcome", "tour-Search", "tour-Private", "tour-Mail", "tour-Sync"]
-    static let NumberOfCards = CardSlides.count
-
     static let PagerCenterOffsetFromScrollViewBottom = UIScreen.main.bounds.width <= 320 ? 20 : 30
-
-    static let StartBrowsingButtonTitle = NSLocalizedString("Start Browsing", tableName: "Intro", comment: "See http://mzl.la/1T8gxwo")
     static let StartBrowsingButtonColor = UIColor.Defaults.Blue40
     static let StartBrowsingButtonHeight = 56
-    static let SignInButtonTitle = NSLocalizedString("Sign in to Firefox", tableName: "Intro", comment: "See http://mzl.la/1T8gxwo")
     static let SignInButtonColor = UIColor.Defaults.Blue40
     static let SignInButtonHeight = 60
+    static let PageControlHeight = 40
+    static let HorizontalPadding = 20
     static let SignInButtonWidth = 290
 
-    static let CardTextLineHeight = UIScreen.main.bounds.width <= 320 ? CGFloat(2) : CGFloat(6)
     static let CardTextWidth = UIScreen.main.bounds.width <= 320 ? 240 : 280
     static let CardTitleHeight = 50
-    
-    static let CardTitleWelcome = NSLocalizedString("Intro.Slides.Welcome.Title", tableName: "Intro", value: "Thanks for choosing Firefox!", comment: "Title for the first panel 'Welcome' in the First Run tour.")
-    static let CardTitleSearch = NSLocalizedString("Intro.Slides.Search.Title", tableName: "Intro", value: "Your search, your way", comment: "Title for the second  panel 'Search' in the First Run tour.")
-    static let CardTitlePrivate = NSLocalizedString("Intro.Slides.Private.Title", tableName: "Intro", value: "Browse like no one’s watching", comment: "Title for the third panel 'Private Browsing' in the First Run tour.")
-    static let CardTitleMail = NSLocalizedString("Intro.Slides.Mail.Title", tableName: "Intro", value: "You’ve got mail… options", comment: "Title for the fourth panel 'Mail' in the First Run tour.")
-    static let CardTitleSync = NSLocalizedString("Intro.Slides.Sync.Title", tableName: "Intro", value: "Pick up where you left off", comment: "Title for the fifth panel 'Sync' in the First Run tour.")
-    
-    static let CardTextWelcome = NSLocalizedString("Intro.Slides.Welcome.Description", tableName: "Intro", value: "A modern mobile browser from Mozilla, the non-profit committed to a free and open web.", comment: "Description for the 'Welcome' panel in the First Run tour.")
-    static let CardTextSearch = NSLocalizedString("Intro.Slides.Search.Description", tableName: "Intro", value: "Searching for something different? Choose another default search engine (or add your own) in Settings.", comment: "Description for the 'Favorite Search Engine' panel in the First Run tour.")
-    static let CardTextPrivate = NSLocalizedString("Intro.Slides.Private.Description", tableName: "Intro", value: "Tap the mask icon to slip into Private Browsing mode.", comment: "Description for the 'Private Browsing' panel in the First Run tour.")
-    static let CardTextMail = NSLocalizedString("Intro.Slides.Mail.Description", tableName: "Intro", value: "Use any email app — not just Mail — with Firefox.", comment: "Description for the 'Mail' panel in the First Run tour.")
-    static let CardTextSync = NSLocalizedString("Intro.Slides.Sync.Description", tableName: "Intro", value: "Use Sync to find the bookmarks, passwords, and other things you save to Firefox on all your devices.", comment: "Description for the 'Sync' panel in the First Run tour.")
-
     static let FadeDuration = 0.25
 }
-
-let IntroViewControllerSeenProfileKey = "IntroViewControllerSeen"
 
 protocol IntroViewControllerDelegate: class {
     func introViewControllerDidFinish(_ introViewController: IntroViewController, requestToLogin: Bool)
 }
 
-class IntroViewController: UIViewController, UIScrollViewDelegate {
+class IntroViewController: UIViewController {
     weak var delegate: IntroViewControllerDelegate?
 
-    var slides = [UIImage]()
-    var cards = [UIImageView]()
-    var introViews = [UIView]()
-    var titleLabels = [UILabel]()
-    var textLabels = [UILabel]()
+    // We need to hang on to views so we can animate and change constraints as we scroll
+    var cardViews = [CardView]()
+    var cards = IntroCard.defaultCards()
 
-    var startBrowsingButton: UIButton!
-    var introView: UIView?
-    var slideContainer: UIView!
-    var pageControl: UIPageControl!
-    var backButton: UIButton!
-    var forwardButton: UIButton!
-    var signInButton: UIButton!
+    lazy fileprivate var startBrowsingButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = UIColor.clear
+        button.setTitle(Strings.StartBrowsingButtonTitle, for: UIControlState())
+        button.setTitleColor(IntroUX.StartBrowsingButtonColor, for: UIControlState())
+        button.addTarget(self, action: #selector(IntroViewController.startBrowsing), for: UIControlEvents.touchUpInside)
+        button.accessibilityIdentifier = "IntroViewController.startBrowsingButton"
+        return button
+    }()
 
-    fileprivate var scrollView: IntroOverlayScrollView!
+    lazy var pageControl: UIPageControl = {
+        let pc = UIPageControl()
+        pc.pageIndicatorTintColor = UIColor.black.withAlphaComponent(0.3)
+        pc.currentPageIndicatorTintColor = UIColor.black
+        pc.accessibilityIdentifier = "IntroViewController.pageControl"
+        pc.addTarget(self, action: #selector(IntroViewController.changePage), for: UIControlEvents.valueChanged)
+        return pc
+    }()
 
-    var slideVerticalScaleFactor: CGFloat = 1.0
+    lazy fileprivate var scrollView: UIScrollView = {
+        let sc = UIScrollView()
+        sc.backgroundColor = UIColor.clear
+        sc.accessibilityLabel = NSLocalizedString("Intro Tour Carousel", comment: "Accessibility label for the introduction tour carousel")
+        sc.delegate = self
+        sc.bounces = false
+        sc.isPagingEnabled = true
+        sc.showsHorizontalScrollIndicator = false
+        sc.accessibilityIdentifier = "IntroViewController.scrollView"
+        return sc
+    }()
+
+
+    lazy fileprivate var imageViewContainer: UIStackView = {
+        let sv = UIStackView()
+        sv.axis = .horizontal
+        sv.distribution = .fillEqually
+        return sv
+    }()
+
+    // Because a stackview cannot have a background color
+    fileprivate var imagesBackgroundView = UIView()
 
     override func viewDidLoad() {
+        assert(cards.count > 0, "Intro is empty. At least 1 card is required")
         view.backgroundColor = UIColor.white
 
-        // scale the slides down for iPhone 4S
-        if view.frame.height <=  480 {
-            slideVerticalScaleFactor = 1.33
-            slideVerticalScaleFactor = 1.33 //4S
-        } else if view.frame.height <= 568 {
-            slideVerticalScaleFactor = 1.15 //SE
-        }
-
-        for slideName in IntroViewControllerUX.CardSlides {
-            slides.append(UIImage(named: slideName)!)
-        }
-
-        startBrowsingButton = UIButton()
-        startBrowsingButton.backgroundColor = UIColor.clear
-        startBrowsingButton.setTitle(IntroViewControllerUX.StartBrowsingButtonTitle, for: [])
-        startBrowsingButton.setTitleColor(IntroViewControllerUX.StartBrowsingButtonColor, for: [])
-        startBrowsingButton.addTarget(self, action: #selector(SELstartBrowsing), for: .touchUpInside)
-        startBrowsingButton.accessibilityIdentifier = "IntroViewController.startBrowsingButton"
-
+        // Add Views
+        view.addSubview(pageControl)
+        view.addSubview(scrollView)
         view.addSubview(startBrowsingButton)
-        startBrowsingButton.snp.makeConstraints { (make) -> Void in
+        scrollView.addSubview(imagesBackgroundView)
+        scrollView.addSubview(imageViewContainer)
+
+        // Setup constraints
+        imagesBackgroundView.snp.makeConstraints { make in
+            make.edges.equalTo(imageViewContainer)
+        }
+        imageViewContainer.snp.makeConstraints { make in
+            make.top.equalTo(self.view)
+        }
+        startBrowsingButton.snp.makeConstraints { make in
             make.left.right.equalTo(self.view)
             make.bottom.equalTo(self.view.safeArea.bottom)
-            make.height.equalTo(IntroViewControllerUX.StartBrowsingButtonHeight)
+            make.height.equalTo(IntroUX.StartBrowsingButtonHeight)
         }
-
-        scrollView = IntroOverlayScrollView()
-        scrollView.backgroundColor = UIColor.clear
-        scrollView.accessibilityLabel = NSLocalizedString("Intro Tour Carousel", comment: "Accessibility label for the introduction tour carousel")
-        scrollView.delegate = self
-        scrollView.bounces = false
-        scrollView.isPagingEnabled = true
-        scrollView.showsHorizontalScrollIndicator = false
-        scrollView.contentSize = CGSize(width: scaledWidthOfSlide * CGFloat(IntroViewControllerUX.NumberOfCards), height: scaledHeightOfSlide)
-        scrollView.accessibilityIdentifier = "IntroViewController.scrollView"
-        view.addSubview(scrollView)
-
-        slideContainer = UIView()
-        for i in 0..<IntroViewControllerUX.NumberOfCards {
-            let imageView = UIImageView(frame: CGRect(x: CGFloat(i)*scaledWidthOfSlide, y: 0, width: scaledWidthOfSlide, height: scaledHeightOfSlide))
-            imageView.image = slides[i]
-            slideContainer.addSubview(imageView)
-        }
-
-        scrollView.addSubview(slideContainer)
-        scrollView.snp.makeConstraints { (make) -> Void in
+        scrollView.snp.makeConstraints { make in
             make.left.right.top.equalTo(self.view)
             make.bottom.equalTo(startBrowsingButton.snp.top)
         }
-        self.view.layoutIfNeeded()
-        self.scrollView.layoutIfNeeded()
-        
-        pageControl = UIPageControl()
-        pageControl.pageIndicatorTintColor = UIColor.black.withAlphaComponent(0.3)
-        pageControl.currentPageIndicatorTintColor = UIColor.black
-        pageControl.numberOfPages = IntroViewControllerUX.NumberOfCards
-        pageControl.accessibilityIdentifier = "IntroViewController.pageControl"
+      
+        pageControl.snp.makeConstraints { make in
+            make.centerX.equalTo(self.scrollView)
+            make.centerY.equalTo(self.startBrowsingButton.snp.top).offset(-IntroUX.PagerCenterOffsetFromScrollViewBottom)
+        }
+
+        cardViews = cards.flatMap { addIntro(card: $0) }
+        pageControl.numberOfPages = cardViews.count
         pageControl.addTarget(self, action: #selector(changePage), for: .valueChanged)
 
-        view.addSubview(pageControl)
-        pageControl.snp.makeConstraints { (make) -> Void in
-            make.centerX.equalTo(self.scrollView)
-            make.centerY.equalTo(self.startBrowsingButton.snp.top).offset(-IntroViewControllerUX.PagerCenterOffsetFromScrollViewBottom)
+        if let firstCard = cardViews.first {
+            setActive(firstCard, forPage: 0)
         }
-
-        func addCard(title: String, text: String, introView: UIView) {
-            self.introViews.append(introView)
-            
-            let titleLabel = UILabel()
-            titleLabel.numberOfLines = 2
-            titleLabel.adjustsFontSizeToFitWidth = true
-            titleLabel.minimumScaleFactor = IntroViewControllerUX.MinimumFontScale
-            titleLabel.textAlignment = .center
-            titleLabel.text = title
-            titleLabels.append(titleLabel)
-            introView.addSubview(titleLabel)
-            titleLabel.snp.makeConstraints { (make ) -> Void in
-                make.top.equalTo(introView).offset(20)
-                make.centerX.equalTo(introView)
-                make.height.equalTo(IntroViewControllerUX.CardTitleHeight)
-                make.width.equalTo(IntroViewControllerUX.CardTextWidth)
-            }
-            
-            let textLabel = UILabel()
-            textLabel.numberOfLines = 5
-            textLabel.attributedText = attributedStringForLabel(text)
-            textLabel.adjustsFontSizeToFitWidth = true
-            textLabel.minimumScaleFactor = IntroViewControllerUX.MinimumFontScale
-            textLabel.lineBreakMode = .byTruncatingTail
-            textLabels.append(textLabel)
-            introView.addSubview(textLabel)
-            textLabel.snp.makeConstraints({ (make) -> Void in
-                make.top.equalTo(titleLabel.snp.bottom).offset(20)
-                make.centerX.equalTo(introView)
-                make.width.equalTo(IntroViewControllerUX.CardTextWidth)
-            })
-        }
-        addCard(title: IntroViewControllerUX.CardTitleWelcome, text: IntroViewControllerUX.CardTextWelcome, introView: UIView())
-        addCard(title: IntroViewControllerUX.CardTitleSearch, text: IntroViewControllerUX.CardTextSearch, introView: UIView())
-        addCard(title: IntroViewControllerUX.CardTitlePrivate, text: IntroViewControllerUX.CardTextPrivate, introView: UIView())
-        addCard(title: IntroViewControllerUX.CardTitleMail, text: IntroViewControllerUX.CardTextMail, introView: UIView())
-
-        // Sync card, with sign in to sync button.
-        signInButton = UIButton()
-        signInButton.backgroundColor = IntroViewControllerUX.SignInButtonColor
-        signInButton.setTitle(IntroViewControllerUX.SignInButtonTitle, for: [])
-        signInButton.setTitleColor(UIColor.white, for: [])
-        signInButton.clipsToBounds = true
-        signInButton.addTarget(self, action: #selector(SELlogin), for: .touchUpInside)
-        signInButton.snp.makeConstraints { (make) -> Void in
-            make.height.equalTo(IntroViewControllerUX.SignInButtonHeight)
-        }
-        
-        let syncCardView = UIView()
-        addCard(title: IntroViewControllerUX.CardTitleSync, text: IntroViewControllerUX.CardTextSync, introView: syncCardView)
-
-        syncCardView.addSubview(signInButton)
-        syncCardView.bringSubview(toFront: signInButton)
-        signInButton.snp.makeConstraints { (make) -> Void in
-            make.centerX.equalTo(syncCardView)
-            make.width.equalTo(IntroViewControllerUX.CardTextWidth) // TODO Talk to UX about small screen sizes
-            make.bottom.equalTo(syncCardView)
-        }
-
-        // We need a reference to the sync pages textlabel so we can adjust the constraints
-        if let index = introViews.index(of: syncCardView), index < textLabels.count {
-            let syncTextLabel = textLabels[index]
-            syncTextLabel.snp.makeConstraints { make in
-                make.bottom.equalTo(signInButton.snp.top).offset(-IntroViewControllerUX.SyncButtonTopPadding)
-            }
-        }
-        // Add all the cards to the view, make them invisible with zero alpha
-        for introView in introViews {
-            introView.alpha = 0
-            self.view.addSubview(introView)
-            introView.snp.makeConstraints { (make) -> Void in
-                make.top.equalTo(self.slideContainer.snp.bottom)
-                make.bottom.equalTo(self.startBrowsingButton.snp.top)
-                make.left.right.equalTo(self.view)
-            }
-        }
-
-        // Make whole screen scrollable by bringing the scrollview to the top
-        view.bringSubview(toFront: scrollView)
-        view.sendSubview(toBack: pageControl)
-        scrollView?.bringSubview(toFront: syncCardView)
-        signInButton.superview?.bringSubview(toFront: signInButton)
-
-        // Activate the first card
-        setActiveIntroView(introViews[0], forPage: 0)
-        setupDynamicFonts()
-    }
-  
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        NotificationCenter.default.addObserver(self, selector: #selector(SELDynamicFontChanged), name: .DynamicFontChanged, object: nil)
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        NotificationCenter.default.removeObserver(self)
-    }
-
-    func SELDynamicFontChanged(_ notification: Notification) {
-        guard notification.name == .DynamicFontChanged else { return }
         setupDynamicFonts()
     }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-
-        scrollView.snp.remakeConstraints { (make) -> Void in
-            make.left.right.top.equalTo(self.view)
-            make.bottom.equalTo(self.startBrowsingButton.snp.top)
-        }
-
-        for i in 0..<IntroViewControllerUX.NumberOfCards {
-            if let imageView = slideContainer.subviews[i] as? UIImageView {
-                imageView.frame = CGRect(x: CGFloat(i)*scaledWidthOfSlide, y: 0, width: scaledWidthOfSlide, height: scaledHeightOfSlide)
-                imageView.contentMode = .scaleAspectFit
-            }
-        }
-        slideContainer.frame = CGRect(width: scaledWidthOfSlide * CGFloat(IntroViewControllerUX.NumberOfCards), height: scaledHeightOfSlide)
-        scrollView.contentSize = CGSize(width: slideContainer.frame.width, height: slideContainer.frame.height)
+        scrollView.contentSize = imageViewContainer.frame.size
     }
 
+    func addIntro(card: IntroCard) -> CardView? {
+        guard let image = UIImage(named: card.imageName) else {
+            return nil
+        }
+        let imageView = UIImageView(image: image)
+        // If the image is bigger than the frame width of the view we'll need constraints. Otherwise the stackview will take care of the constraints
+        if image.size.width > view.frame.width {
+            imageView.snp.makeConstraints { make in
+                make.size.equalTo(self.view.frame.width)
+            }
+        }
+
+        imageViewContainer.addArrangedSubview(imageView)
+
+        let cardView = CardView()
+        cardView.configureWith(card: card)
+        if let selector = card.buttonSelector {
+            cardView.button.addTarget(self, action: selector, for: .touchUpInside)
+            cardView.button.snp.makeConstraints { make in
+                make.width.equalTo(IntroUX.CardTextWidth)
+                make.height.equalTo(IntroUX.SignInButtonHeight)
+            }
+        }
+        self.view.addSubview(cardView)
+        cardView.snp.makeConstraints { make in
+            make.top.equalTo(self.imageViewContainer.snp.bottom).offset(IntroUX.HorizontalPadding)
+            make.bottom.equalTo(self.startBrowsingButton.snp.top)
+            make.left.right.equalTo(self.view).inset(IntroUX.HorizontalPadding)
+        }
+        return cardView
+    }
+
+    func startBrowsing() {
+        delegate?.introViewControllerDidFinish(self, requestToLogin: false)
+    }
+
+    func login() {
+        delegate?.introViewControllerDidFinish(self, requestToLogin: true)
+    }
+
+    func changePage() {
+        let swipeCoordinate = CGFloat(pageControl.currentPage) * scrollView.frame.size.width
+        scrollView.setContentOffset(CGPoint(x: swipeCoordinate, y: 0), animated: true)
+    }
+
+    fileprivate func setActive(_ introView: UIView, forPage page: Int) {
+        guard introView.alpha != 1 else {
+            return
+        }
+
+        UIView.animate(withDuration: IntroUX.FadeDuration, animations: { _ in
+            self.cardViews.forEach { $0.alpha = 0.0 }
+            introView.alpha = 1.0
+        }, completion: nil)
+    }
+}
+
+// UIViewController setup
+extension IntroViewController {
     override var prefersStatusBarHidden: Bool {
         return true
     }
@@ -270,36 +195,50 @@ class IntroViewController: UIViewController, UIScrollViewDelegate {
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         // This actually does the right thing on iPad where the modally
         // presented version happily rotates with the iPad orientation.
-        return UIInterfaceOrientationMask.portrait
+        return .portrait
+    }
+}
+
+// Dynamic Font Helper
+extension IntroViewController {
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        NotificationCenter.default.addObserver(self, selector: #selector(SELDynamicFontChanged), name: NotificationDynamicFontChanged, object: nil)
     }
 
-    func SELstartBrowsing() {
-        LeanPlumClient.shared.track(event: .dismissedOnboarding)
-        delegate?.introViewControllerDidFinish(self, requestToLogin: false)
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        NotificationCenter.default.removeObserver(self, name: NotificationDynamicFontChanged, object: nil)
     }
 
-    func SELlogin() {
-        delegate?.introViewControllerDidFinish(self, requestToLogin: true)
+    func SELDynamicFontChanged(_ notification: Notification) {
+        guard notification.name == NotificationDynamicFontChanged else { return }
+        setupDynamicFonts()
     }
 
-    fileprivate var accessibilityScrollStatus: String {
-        let number = NSNumber(value: pageControl.currentPage + 1)
-        return String(format: NSLocalizedString("Introductory slide %@ of %@", tableName: "Intro", comment: "String spoken by assistive technology (like VoiceOver) stating on which page of the intro wizard we currently are. E.g. Introductory slide 1 of 3"), NumberFormatter.localizedString(from: number, number: .decimal), NumberFormatter.localizedString(from: NSNumber(value: IntroViewControllerUX.NumberOfCards), number: .decimal))
+    func DynamicFontChanged(_ notification: Notification) {
+        guard notification.name == NotificationDynamicFontChanged else { return }
+        setupDynamicFonts()
     }
 
-    func changePage() {
-        let swipeCoordinate = CGFloat(pageControl.currentPage) * scrollView.frame.size.width
-        scrollView.setContentOffset(CGPoint(x: swipeCoordinate, y: 0), animated: true)
+    fileprivate func setupDynamicFonts() {
+        startBrowsingButton.titleLabel?.font = UIFont(name: "FiraSans-Regular", size: DynamicFontHelper.defaultHelper.IntroStandardFontSize)
+        cardViews.forEach { cardView in
+            cardView.titleLabel.font = UIFont(name: "FiraSans-Medium", size: DynamicFontHelper.defaultHelper.IntroBigFontSize)
+            cardView.textLabel.font = UIFont(name: "FiraSans-UltraLight", size: DynamicFontHelper.defaultHelper.IntroStandardFontSize)
+        }
     }
-    
+}
+
+extension IntroViewController: UIScrollViewDelegate {
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
         // Need to add this method so that when forcibly dragging, instead of letting deceleration happen, should also calculate what card it's on.
-        // This especially affects sliding to the last or first slides.
+        // This especially affects sliding to the last or first cards.
         if !decelerate {
             scrollViewDidEndDecelerating(scrollView)
         }
     }
-    
+
     func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
         // Need to add this method so that tapping the pageControl will also change the card texts.
         // scrollViewDidEndDecelerating waits until the end of the animation to calculate what card it's on.
@@ -308,10 +247,15 @@ class IntroViewController: UIViewController, UIScrollViewDelegate {
 
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         let page = Int(scrollView.contentOffset.x / scrollView.frame.size.width)
-        setActiveIntroView(introViews[page], forPage: page)
+        if let cardView = cardViews[safe: page] {
+            setActive(cardView, forPage: page)
+        }
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let page = Int(scrollView.contentOffset.x / scrollView.frame.size.width)
+        pageControl.currentPage = page
+
         let maximumHorizontalOffset = scrollView.frame.width
         let currentHorizontalOffset = scrollView.contentOffset.x
 
@@ -319,82 +263,106 @@ class IntroViewController: UIViewController, UIScrollViewDelegate {
         percentageOfScroll = percentageOfScroll > 1.0 ? 1.0 : percentageOfScroll
         let whiteComponent = UIColor.white.components
         let grayComponent = UIColor(rgb: 0xF2F2F2).components
-        
-        let page = Int(scrollView.contentOffset.x / scrollView.frame.size.width)
-        pageControl.currentPage = page
-        
         let newRed   = (1.0 - percentageOfScroll) * whiteComponent.red   + percentageOfScroll * grayComponent.red
         let newGreen = (1.0 - percentageOfScroll) * whiteComponent.green + percentageOfScroll * grayComponent.green
         let newBlue  = (1.0 - percentageOfScroll) * whiteComponent.blue  + percentageOfScroll * grayComponent.blue
-        let newColor =  UIColor(red: newRed, green: newGreen, blue: newBlue, alpha: 1.0)
-        slideContainer.backgroundColor = newColor
-    }
-
-    fileprivate func setActiveIntroView(_ newIntroView: UIView, forPage page: Int) {
-        if introView != newIntroView {
-            UIView.animate(withDuration: IntroViewControllerUX.FadeDuration, animations: { () -> Void in
-                self.introView?.alpha = 0
-                self.introView = newIntroView
-                newIntroView.alpha = 1.0
-                if page == 0 {
-                    self.startBrowsingButton.alpha = 0
-                } else {
-                    self.startBrowsingButton.alpha = 1
-                }
-            }, completion: { _ in
-                if page == (IntroViewControllerUX.NumberOfCards - 1) {
-                    self.scrollView.signinButton = self.signInButton
-                } else {
-                    self.scrollView.signinButton = nil
-                }
-            })
-        }
-    }
-
-    fileprivate var scaledWidthOfSlide: CGFloat {
-        return view.frame.width
-    }
-
-    fileprivate var scaledHeightOfSlide: CGFloat {
-        return (view.frame.width / slides[0].size.width) * slides[0].size.height / slideVerticalScaleFactor
-    }
-
-    fileprivate func attributedStringForLabel(_ text: String) -> NSMutableAttributedString {
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineSpacing = IntroViewControllerUX.CardTextLineHeight
-        paragraphStyle.alignment = .center
-
-        let string = NSMutableAttributedString(string: text)
-        string.addAttribute(NSParagraphStyleAttributeName, value: paragraphStyle, range: NSRange(location: 0, length: string.length))
-        return string
-    }
-    
-    fileprivate func setupDynamicFonts() {
-        startBrowsingButton.titleLabel?.font = UIFont(name: "FiraSans-Regular", size: DynamicFontHelper.defaultHelper.IntroStandardFontSize)
-        signInButton.titleLabel?.font = UIFont(name: "FiraSans-Regular", size: DynamicFontHelper.defaultHelper.IntroBigFontSize)
-
-        for titleLabel in titleLabels {
-            titleLabel.font = UIFont(name: "FiraSans-Medium", size: DynamicFontHelper.defaultHelper.IntroBigFontSize)
-        }
-
-        for label in textLabels {
-            label.font = UIFont(name: "FiraSans-UltraLight", size: DynamicFontHelper.defaultHelper.IntroStandardFontSize)
-        }
+        imagesBackgroundView.backgroundColor = UIColor(red: newRed, green: newGreen, blue: newBlue, alpha: 1.0)
     }
 }
 
-fileprivate class IntroOverlayScrollView: UIScrollView {
-    weak var signinButton: UIButton?
+// A cardView repersents the text for each page of the intro. It does not include the image.
+class CardView: UIStackView {
 
-    fileprivate override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-        if let signinFrame = signinButton?.frame {
-            let convertedFrame = convert(signinFrame, from: signinButton?.superview)
-            if convertedFrame.contains(point) {
-                return false
+    lazy var titleLabel: UILabel = {
+        let titleLabel = UILabel()
+        titleLabel.numberOfLines = 2
+        titleLabel.adjustsFontSizeToFitWidth = true
+        titleLabel.minimumScaleFactor = IntroUX.MinimumFontScale
+        titleLabel.textAlignment = .center
+        return titleLabel
+    }()
+
+    lazy var textLabel: UILabel = {
+        let textLabel = UILabel()
+        textLabel.numberOfLines = 5
+        textLabel.adjustsFontSizeToFitWidth = true
+        textLabel.minimumScaleFactor = IntroUX.MinimumFontScale
+        textLabel.textAlignment = .center
+        textLabel.lineBreakMode = .byTruncatingTail
+        return textLabel
+    }()
+
+    lazy var button: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = IntroUX.SignInButtonColor
+        button.setTitle(Strings.SignInButtonTitle, for: [])
+        button.setTitleColor(.white, for: [])
+        button.clipsToBounds = true
+        return button
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        axis = .vertical
+        distribution = .equalSpacing
+        alignment = .center
+        spacing = 10
+        addArrangedSubview(titleLabel)
+        addArrangedSubview(textLabel)
+        alpha = 0
+    }
+
+    func configureWith(card: IntroCard) {
+        titleLabel.text = card.title
+        textLabel.text = card.text
+        if let buttonText = card.buttonText, card.buttonSelector != nil {
+            addArrangedSubview(button)
+            button.setTitle(buttonText, for: .normal)
+        } else {
+            // We need a blank view to make sure the page controls dont get hidden by autolayout
+            let blankView = UIView()
+            blankView.snp.makeConstraints { make in
+                make.size.equalTo(IntroUX.PageControlHeight)
             }
+            addArrangedSubview(blankView)
         }
+    }
 
-        return CGRect(origin: self.frame.origin, size: CGSize(width: self.contentSize.width, height: self.frame.size.height)).contains(point)
+    // Allows the scrollView to scroll while the CardView is in front
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        if let buttonSV = button.superview {
+            return convert(button.frame, from: buttonSV).contains(point)
+        }
+        return false
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+struct IntroCard {
+    let title: String
+    let text: String
+    let buttonText: String?
+    let buttonSelector: Selector?
+    let imageName: String
+
+    init(title: String, text: String, imageName: String, buttonText: String? = nil, buttonSelector: Selector? = nil) {
+        self.title = title
+        self.text = text
+        self.imageName = imageName
+        self.buttonText = buttonText
+        self.buttonSelector = buttonSelector
+    }
+
+    static func defaultCards() -> [IntroCard] {
+        let welcome = IntroCard(title: Strings.CardTitleWelcome, text: Strings.CardTextWelcome, imageName: "tour-Welcome")
+        let search = IntroCard(title: Strings.CardTitleSearch, text: Strings.CardTextSearch, imageName: "tour-Search")
+        let privateBrowsing = IntroCard(title: Strings.CardTitlePrivate, text: Strings.CardTextPrivate, imageName: "tour-Private")
+        let mailTo = IntroCard(title: Strings.CardTitleMail, text: Strings.CardTextMail, imageName: "tour-Mail")
+        let sync = IntroCard(title: Strings.CardTitleSync, text: Strings.CardTextSync, imageName: "tour-Sync", buttonText: Strings.SignInButtonTitle, buttonSelector: #selector(IntroViewController.login))
+        return [welcome, search, privateBrowsing, mailTo, sync]
     }
 }
 

--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -207,16 +207,16 @@ extension IntroViewController {
 extension IntroViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        NotificationCenter.default.addObserver(self, selector: #selector(dynamicFontChanged), name: NotificationDynamicFontChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(dynamicFontChanged), name: .DynamicFontChanged, object: nil)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        NotificationCenter.default.removeObserver(self, name: NotificationDynamicFontChanged, object: nil)
+        NotificationCenter.default.removeObserver(self, name: .DynamicFontChanged, object: nil)
     }
 
     func dynamicFontChanged(_ notification: Notification) {
-        guard notification.name == NotificationDynamicFontChanged else { return }
+        guard notification.name == .DynamicFontChanged else { return }
         setupDynamicFonts()
     }
 

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -489,6 +489,23 @@ extension Strings {
     public static let SettingsDoNotTrackOptionAlwaysOn = NSLocalizedString("Settings.DNT.OptionAlwaysOn", value: "Always", comment: "DNT Settings option for always on")
 }
 
+// Intro Onboarding slides
+extension Strings {
+    public static let CardTitleWelcome = NSLocalizedString("Intro.Slides.Welcome.Title", tableName: "Intro", value: "Thanks for choosing Firefox!", comment: "Title for the first panel 'Welcome' in the First Run tour.")
+    public static let CardTitleSearch = NSLocalizedString("Intro.Slides.Search.Title", tableName: "Intro", value: "Your search, your way", comment: "Title for the second  panel 'Search' in the First Run tour.")
+    public static let CardTitlePrivate = NSLocalizedString("Intro.Slides.Private.Title", tableName: "Intro", value: "Browse like no one’s watching", comment: "Title for the third panel 'Private Browsing' in the First Run tour.")
+    public static let CardTitleMail = NSLocalizedString("Intro.Slides.Mail.Title", tableName: "Intro", value: "You’ve got mail… options", comment: "Title for the fourth panel 'Mail' in the First Run tour.")
+    public static let CardTitleSync = NSLocalizedString("Intro.Slides.Sync.Title", tableName: "Intro", value: "Pick up where you left off", comment: "Title for the fifth panel 'Sync' in the First Run tour.")
+
+    public static let CardTextWelcome = NSLocalizedString("Intro.Slides.Welcome.Description", tableName: "Intro", value: "A modern mobile browser from Mozilla, the non-profit committed to a free and open web.", comment: "Description for the 'Welcome' panel in the First Run tour.")
+    public static let CardTextSearch = NSLocalizedString("Intro.Slides.Search.Description", tableName: "Intro", value: "Searching for something different? Choose another default search engine (or add your own) in Settings.", comment: "Description for the 'Favorite Search Engine' panel in the First Run tour.")
+    public static let CardTextPrivate = NSLocalizedString("Intro.Slides.Private.Description", tableName: "Intro", value: "Tap the mask icon to slip into Private Browsing mode.", comment: "Description for the 'Private Browsing' panel in the First Run tour.")
+    public static let CardTextMail = NSLocalizedString("Intro.Slides.Mail.Description", tableName: "Intro", value: "Use any email app — not just Mail — with Firefox.", comment: "Description for the 'Mail' panel in the First Run tour.")
+    public static let CardTextSync = NSLocalizedString("Intro.Slides.Sync.Description", tableName: "Intro", value: "Use Sync to find the bookmarks, passwords, and other things you save to Firefox on all your devices.", comment: "Description for the 'Sync' panel in the First Run tour.")
+    public static let SignInButtonTitle = NSLocalizedString("Sign in to Firefox", tableName: "Intro", comment: "See http://mzl.la/1T8gxwo")
+    public static let StartBrowsingButtonTitle = NSLocalizedString("Start Browsing", tableName: "Intro", comment: "See http://mzl.la/1T8gxwo")
+}
+
 // MARK: Deprecated Strings (to be removed in next version)
 private let logOut = NSLocalizedString("Log Out", comment: "Button in settings screen to disconnect from your account")
 private let logOutQuestion = NSLocalizedString("Log Out?", comment: "Title of the 'log out firefox account' alert")

--- a/Shared/Extensions/ArrayExtensions.swift
+++ b/Shared/Extensions/ArrayExtensions.swift
@@ -68,3 +68,11 @@ public extension Sequence {
         return true
     }
 }
+
+
+public extension Collection {
+    /// Returns the element at the specified index iff it is within bounds, otherwise nil.
+    subscript (safe index: Index) -> Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -14,6 +14,7 @@ public struct PrefsKeys {
     public static let KeyMailToOption = "MailToOption"
     public static let HasFocusInstalled = "HasFocusInstalled"
     public static let HasPocketInstalled = "HasPocketInstalled"
+    public static let IntroSeen = "IntroViewControllerSeen"
 
     //Activity Stream
     public static let KeyTopSitesCacheIsValid = "topSitesCacheIsValid"


### PR DESCRIPTION
The introViewController was very tightly coupled to our current intro slides. I've abstracted out the slides into `IntroCard`s that can be created on initialization of the ViewController. This will allow us to A/B test our onboarding. 

I haven't made the necessary LP changes. I will probably need to clarify with the MMA team first exactly what it is they want to test and how that will be represented in the LP backend. 