### PR TITLE
Bug 1426307 - Store only derived keys instead of storing kB/kA.

### DIFF
--- a/Account/FxAClient10.swift
+++ b/Account/FxAClient10.swift
@@ -142,11 +142,15 @@ open class FxAClient10 {
      * lowercase-hex-encoded first 16 bytes of the SHA-256 hash of the
      * bytes of kB.
      */
-    open class func computeClientState(_ kB: Data) -> String? {
-        if kB.count != 32 {
-            return nil
-        }
+    open class func computeClientState(_ kB: Data) -> String {
         return kB.sha256.subdata(in: 0..<16).hexEncodedString
+    }
+
+    open class func deriveKSync(_ kB: Data) -> Data {
+        let salt = Data()
+        let contextInfo = FxAClient10.KW("oldsync")
+        let len: UInt = 64               // KeyLength + KeyLength, without type nonsense.
+        return (kB as NSData).deriveHKDFSHA256Key(withSalt: salt, contextInfo: contextInfo, length: len)!
     }
 
     open class func quickStretchPW(_ email: Data, password: Data) -> Data {

--- a/Account/FxALoginStateMachine.swift
+++ b/Account/FxALoginStateMachine.swift
@@ -72,7 +72,7 @@ class FxALoginStateMachine {
                 if let keyPair = result.successValue {
                     log.info("Generated key pair!  Transitioning to CohabitingAfterKeyPair.")
                     let newState = CohabitingAfterKeyPairState(sessionToken: state.sessionToken,
-                        kA: state.kA, kB: state.kB,
+                        kSync: state.kSync, kXCS: state.kXCS,
                         keyPair: keyPair, keyPairExpiresAt: now + OneMonthInMilliseconds)
                     return Deferred(value: newState)
                 } else {
@@ -88,7 +88,7 @@ class FxALoginStateMachine {
                 if let response = result.successValue {
                     log.info("Signed public key!  Transitioning to Married.")
                     let newState = MarriedState(sessionToken: state.sessionToken,
-                        kA: state.kA, kB: state.kB,
+                        kSync: state.kSync, kXCS: state.kXCS,
                         keyPair: state.keyPair, keyPairExpiresAt: state.keyPairExpiresAt,
                         certificate: response.certificate, certificateExpiresAt: now + OneDayInMilliseconds)
                     return Deferred(value: newState)
@@ -129,8 +129,10 @@ class FxALoginStateMachine {
                     if let kB = response.wrapkB.xoredWith(state.unwrapkB) {
                         log.info("Unwrapped keys response.  Transition to CohabitingBeforeKeyPair.")
                         self.notifyAccountVerified()
+                        let kSync = FxAClient10.deriveKSync(kB)
+                        let kXCS = FxAClient10.computeClientState(kB)
                         let newState = CohabitingBeforeKeyPairState(sessionToken: state.sessionToken,
-                            kA: response.kA, kB: kB)
+                            kSync: kSync, kXCS: kXCS)
                         return Deferred(value: newState)
                     } else {
                         log.error("Failed to unwrap keys response!  Transitioning to Separated in order to fetch new initial datum.")

--- a/Account/FxAState.swift
+++ b/Account/FxAState.swift
@@ -8,7 +8,7 @@ import Shared
 import SwiftyJSON
 
 // The version of the state schema we persist.
-let StateSchemaVersion = 1
+let StateSchemaVersion = 2
 
 // We want an enum because the set of states is closed.  However, each state has state-specific
 // behaviour, and the state's behaviour accumulates, so each state is a class.  Switch on the
@@ -46,14 +46,31 @@ func state(fromJSON json: JSON) -> FxAState? {
         return nil
     }
     if let version = json["version"].int {
-        if version == StateSchemaVersion {
+        if version == 1 {
             return stateV1(fromJSON: json)
+        } else if version == 2 {
+            return stateV2(fromJSON: json)
         }
     }
     return nil
 }
 
 func stateV1(fromJSON json: JSON) -> FxAState? {
+    var json = json
+    json["version"] = 2
+    if let kB = json["kB"].string?.hexDecodedData {
+        let kSync = FxAClient10.deriveKSync(kB)
+        let kXCS = FxAClient10.computeClientState(kB)
+        json["kSync"] = JSON(kSync.hexEncodedString as NSString)
+        json["kXCS"] = JSON(kXCS as NSString)
+        json["kA"] = JSON.null
+        json["kB"] = JSON.null
+    }
+    return stateV2(fromJSON: json)
+}
+
+// Identical to V1 except `(kA, kB)` have been replaced with `(kSync, kXCS)` throughout.
+func stateV2(fromJSON json: JSON) -> FxAState? {
     if let labelString = json["label"].string {
         if let label = FxAStateLabel(rawValue: labelString) {
             switch label {
@@ -80,36 +97,36 @@ func stateV1(fromJSON json: JSON) -> FxAState? {
             case .cohabitingBeforeKeyPair:
                 if let
                     sessionToken = json["sessionToken"].string?.hexDecodedData,
-                    let kA = json["kA"].string?.hexDecodedData,
-                    let kB = json["kB"].string?.hexDecodedData {
-                    return CohabitingBeforeKeyPairState(sessionToken: sessionToken, kA: kA, kB: kB)
+                    let kSync = json["kSync"].string?.hexDecodedData,
+                    let kXCS = json["kXCS"].string {
+                    return CohabitingBeforeKeyPairState(sessionToken: sessionToken, kSync: kSync, kXCS: kXCS)
                 }
 
             case .cohabitingAfterKeyPair:
                 if let
                     sessionToken = json["sessionToken"].string?.hexDecodedData,
-                    let kA = json["kA"].string?.hexDecodedData,
-                    let kB = json["kB"].string?.hexDecodedData,
+                    let kSync = json["kSync"].string?.hexDecodedData,
+                    let kXCS = json["kXCS"].string,
                     let keyPairJSON = json["keyPair"].dictionaryObject,
                     let keyPair = RSAKeyPair(jsonRepresentation: keyPairJSON),
                     let keyPairExpiresAt = json["keyPairExpiresAt"].int64 {
-                        return CohabitingAfterKeyPairState(sessionToken: sessionToken, kA: kA, kB: kB,
-                            keyPair: keyPair, keyPairExpiresAt: UInt64(keyPairExpiresAt))
+                    return CohabitingAfterKeyPairState(sessionToken: sessionToken, kSync: kSync, kXCS: kXCS,
+                                                       keyPair: keyPair, keyPairExpiresAt: UInt64(keyPairExpiresAt))
                 }
 
             case .married:
                 if let
                     sessionToken = json["sessionToken"].string?.hexDecodedData,
-                    let kA = json["kA"].string?.hexDecodedData,
-                    let kB = json["kB"].string?.hexDecodedData,
+                    let kSync = json["kSync"].string?.hexDecodedData,
+                    let kXCS = json["kXCS"].string,
                     let keyPairJSON = json["keyPair"].dictionaryObject,
                     let keyPair = RSAKeyPair(jsonRepresentation: keyPairJSON),
                     let keyPairExpiresAt = json["keyPairExpiresAt"].int64,
                     let certificate = json["certificate"].string,
                     let certificateExpiresAt = json["certificateExpiresAt"].int64 {
-                    return MarriedState(sessionToken: sessionToken, kA: kA, kB: kB,
-                        keyPair: keyPair, keyPairExpiresAt: UInt64(keyPairExpiresAt),
-                        certificate: certificate, certificateExpiresAt: UInt64(certificateExpiresAt))
+                    return MarriedState(sessionToken: sessionToken, kSync: kSync, kXCS: kXCS,
+                                        keyPair: keyPair, keyPairExpiresAt: UInt64(keyPairExpiresAt),
+                                        certificate: certificate, certificateExpiresAt: UInt64(certificateExpiresAt))
                 }
 
             case .separated:
@@ -233,19 +250,19 @@ open class EngagedAfterVerifiedState: ReadyForKeys {
 
 // Not an externally facing state!
 open class TokenAndKeys: TokenState {
-    open let kA: Data
-    open let kB: Data
+    open let kSync: Data
+    open let kXCS: String
 
-    init(sessionToken: Data, kA: Data, kB: Data) {
-        self.kA = kA
-        self.kB = kB
+    init(sessionToken: Data, kSync: Data, kXCS: String) {
+        self.kSync = kSync
+        self.kXCS = kXCS
         super.init(sessionToken: sessionToken)
     }
 
     open override func asJSON() -> JSON {
         var d = super.asJSON().dictionary!
-        d["kA"] = JSON(kA.hexEncodedString as NSString)
-        d["kB"] = JSON(kB.hexEncodedString as NSString)
+        d["kSync"] = JSON(kSync.hexEncodedString as NSString)
+        d["kXCS"] = JSON(kXCS as NSString)
         return JSON(d)
     }
 }
@@ -260,10 +277,10 @@ open class TokenKeysAndKeyPair: TokenAndKeys {
     // Timestamp, in milliseconds after the epoch, when keyPair expires.  After this time, generate a new keyPair.
     let keyPairExpiresAt: Timestamp
 
-    init(sessionToken: Data, kA: Data, kB: Data, keyPair: KeyPair, keyPairExpiresAt: Timestamp) {
+    init(sessionToken: Data, kSync: Data, kXCS: String, keyPair: KeyPair, keyPairExpiresAt: Timestamp) {
         self.keyPair = keyPair
         self.keyPairExpiresAt = keyPairExpiresAt
-        super.init(sessionToken: sessionToken, kA: kA, kB: kB)
+        super.init(sessionToken: sessionToken, kSync: kSync, kXCS: kXCS)
     }
 
     open override func asJSON() -> JSON {
@@ -288,10 +305,10 @@ open class MarriedState: TokenKeysAndKeyPair {
     let certificate: String
     let certificateExpiresAt: Timestamp
 
-    init(sessionToken: Data, kA: Data, kB: Data, keyPair: KeyPair, keyPairExpiresAt: Timestamp, certificate: String, certificateExpiresAt: Timestamp) {
+    init(sessionToken: Data, kSync: Data, kXCS: String, keyPair: KeyPair, keyPairExpiresAt: Timestamp, certificate: String, certificateExpiresAt: Timestamp) {
         self.certificate = certificate
         self.certificateExpiresAt = certificateExpiresAt
-        super.init(sessionToken: sessionToken, kA: kA, kB: kB, keyPair: keyPair, keyPairExpiresAt: keyPairExpiresAt)
+        super.init(sessionToken: sessionToken, kSync: kSync, kXCS: kXCS, keyPair: keyPair, keyPairExpiresAt: keyPairExpiresAt)
     }
 
     open override func asJSON() -> JSON {
@@ -307,13 +324,13 @@ open class MarriedState: TokenKeysAndKeyPair {
 
     func withoutKeyPair() -> CohabitingBeforeKeyPairState {
         let newState = CohabitingBeforeKeyPairState(sessionToken: sessionToken,
-            kA: kA, kB: kB)
+            kSync: kSync, kXCS: kXCS)
         return newState
     }
 
     func withoutCertificate() -> CohabitingAfterKeyPairState {
         let newState = CohabitingAfterKeyPairState(sessionToken: sessionToken,
-            kA: kA, kB: kB,
+            kSync: kSync, kXCS: kXCS,
             keyPair: keyPair, keyPairExpiresAt: keyPairExpiresAt)
         return newState
     }

--- a/Account/SyncAuthState.swift
+++ b/Account/SyncAuthState.swift
@@ -131,7 +131,7 @@ open class FirefoxAccountSyncAuthState: SyncAuthState {
                 let tokenServerEndpointURL = self.account.configuration.sync15Configuration.tokenServerEndpointURL
                 let audience = TokenServerClient.getAudience(forURL: tokenServerEndpointURL)
                 let client = TokenServerClient(URL: tokenServerEndpointURL)
-                let clientState = FxAClient10.computeClientState(married.kB)
+                let clientState = married.kXCS
                 log.debug("Fetching token server token.")
                 let deferred = self.generateAssertionAndFetchTokenAt(audience, client: client, clientState: clientState, married: married, now: now, retryCount: 1)
                 deferred.upon { result in
@@ -139,13 +139,13 @@ open class FirefoxAccountSyncAuthState: SyncAuthState {
                     // One racer will win -- that's fine, presumably she has the freshest token.
                     // If not, that's okay, 'cuz the slightly dated token is still a valid token.
                     if let token = result.successValue {
-                        let newCache = SyncAuthStateCache(token: token, forKey: married.kB,
+                        let newCache = SyncAuthStateCache(token: token, forKey: married.kSync,
                             expiresAt: now + 1000 * token.durationInSeconds)
                         log.debug("Fetched token server token!  Token expires at \(newCache.expiresAt).")
                         self.cache.value = newCache
                     }
                 }
-                return chain(deferred, f: { (token: $0, forKey: married.kB) })
+                return chain(deferred, f: { (token: $0, forKey: married.kSync) })
             }
             return deferMaybe(result.failureValue!)
         }

--- a/AccountTests/FxAClient10Tests.swift
+++ b/AccountTests/FxAClient10Tests.swift
@@ -19,8 +19,14 @@ class FxAClient10Tests: LiveAccountTest {
 
     func testClientState() {
         let kB = "fd5c747806c07ce0b9d69dcfea144663e630b65ec4963596a22f24910d7dd15d".hexDecodedData
-        let clientState = FxAClient10.computeClientState(kB)!
+        let clientState = FxAClient10.computeClientState(kB)
         XCTAssertEqual(clientState, "6ae94683571c7a7c54dab4700aa3995f")
+    }
+
+    func testDeriveKSync() {
+        let kB = "fd5c747806c07ce0b9d69dcfea144663e630b65ec4963596a22f24910d7dd15d".hexDecodedData
+        let kSyncHex = FxAClient10.deriveKSync(kB).hexEncodedString
+        XCTAssertEqual(kSyncHex, "ad501a50561be52b008878b2e0d8a73357778a712255f7722f497b5d4df14b05dc06afb836e1521e882f521eb34691d172337accdbf6e2a5b968b05a7bbb9885")
     }
 
     func testErrorOutput() {

--- a/AccountTests/FxALoginStateMachineTests.swift
+++ b/AccountTests/FxALoginStateMachineTests.swift
@@ -135,10 +135,8 @@ class FxALoginStateMachineTests: XCTestCase {
             stateMachine.advance(fromState: engagedState, now: 0).upon { newState in
                 XCTAssertEqual(newState.label.rawValue, FxAStateLabel.married.rawValue)
                 if let newState = newState as? MarriedState {
-                    // We get kA from the client directly.
-                    XCTAssertEqual(newState.kA.hexEncodedString, client.kA.hexEncodedString)
-                    // We unwrap kB by XORing.  The result is KeyLength (32) 0s.
-                    XCTAssertEqual(newState.kB.hexEncodedString, "0000000000000000000000000000000000000000000000000000000000000000")
+                    XCTAssertEqual(newState.kSync.hexEncodedString, "ec830aefab7dc43c66fb56acc16ed3b723f090ae6f50d6e610b55f4675dcbefba1351b80de8cbeff3c368949c34e8f5520ec7f1d4fa24a0970b437684259f946")
+                    XCTAssertEqual(newState.kXCS, "66687aadf862bd776c8fc18b8e9f8e20")
                 }
                 e.fulfill()
             }

--- a/Sync/KeyBundle.swift
+++ b/Sync/KeyBundle.swift
@@ -14,13 +14,9 @@ open class KeyBundle: Hashable {
     let encKey: Data
     let hmacKey: Data
 
-    open class func fromKB(_ kB: Data) -> KeyBundle {
-        let salt = Data()
-        let contextInfo = FxAClient10.KW("oldsync")
-        let len: UInt = 64               // KeyLength + KeyLength, without type nonsense.
-        let derived = (kB as NSData).deriveHKDFSHA256Key(withSalt: salt, contextInfo: contextInfo, length: len)!
-        return KeyBundle(encKey: derived.subdata(in: 0..<KeyLength),
-                         hmacKey: derived.subdata(in: KeyLength..<(2 * KeyLength)))
+    open class func fromKSync(_ kSync: Data) -> KeyBundle {
+        return KeyBundle(encKey: kSync.subdata(in: 0..<KeyLength),
+                         hmacKey: kSync.subdata(in: KeyLength..<(2 * KeyLength)))
     }
 
     open class func random() -> KeyBundle {

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -143,16 +143,16 @@ open class SyncStateMachine {
 
     open func toReady(_ authState: SyncAuthState) -> ReadyDeferred {
         let token = authState.token(Date.now(), canBeExpired: false)
-        return chainDeferred(token, f: { (token, kB) in
+        return chainDeferred(token, f: { (token, kSync) in
             log.debug("Got token from auth state.")
             if Logger.logPII {
                 log.debug("Server is \(token.api_endpoint).")
             }
-            let prior = Scratchpad.restoreFromPrefs(self.scratchpadPrefs, syncKeyBundle: KeyBundle.fromKB(kB))
+            let prior = Scratchpad.restoreFromPrefs(self.scratchpadPrefs, syncKeyBundle: KeyBundle.fromKSync(kSync))
             if prior == nil {
                 log.info("No persisted Sync state. Starting over.")
             }
-            var scratchpad = prior ?? Scratchpad(b: KeyBundle.fromKB(kB), persistingTo: self.scratchpadPrefs)
+            var scratchpad = prior ?? Scratchpad(b: KeyBundle.fromKSync(kSync), persistingTo: self.scratchpadPrefs)
 
             // Take the scratchpad and add the fxaDeviceId from the state, and hashedUID from the token
             let b = Scratchpad.Builder(p: scratchpad)

--- a/Sync/SyncTelemetryUtils.swift
+++ b/Sync/SyncTelemetryUtils.swift
@@ -251,9 +251,9 @@ public struct SyncPing: SyncTelemetryPing {
                             why: SyncPingReason) -> Deferred<Maybe<SyncPing>> {
         // Grab our token so we can use the hashed_fxa_uid and clientGUID from our scratchpad for
         // our ping's identifiers
-        return account.syncAuthState.token(Date.now(), canBeExpired: false) >>== { (token, kB) in
+        return account.syncAuthState.token(Date.now(), canBeExpired: false) >>== { (token, kSync) in
             let scratchpadPrefs = prefs.branch("sync.scratchpad")
-            guard let scratchpad = Scratchpad.restoreFromPrefs(scratchpadPrefs, syncKeyBundle: KeyBundle.fromKB(kB)) else {
+            guard let scratchpad = Scratchpad.restoreFromPrefs(scratchpadPrefs, syncKeyBundle: KeyBundle.fromKSync(kSync)) else {
                 return deferMaybe(SyncPingError.failedToRestoreScratchpad)
             }
 

--- a/SyncTests/LiveStorageClientTests.swift
+++ b/SyncTests/LiveStorageClientTests.swift
@@ -19,7 +19,7 @@ private class KeyFetchError: MaybeErrorType {
 }
 
 class LiveStorageClientTests: LiveAccountTest {
-    func getKeys(kB: Data, token: TokenServerToken) -> Deferred<Maybe<Record<KeysPayload>>> {
+    func getKeys(kSync: Data, token: TokenServerToken) -> Deferred<Maybe<Record<KeysPayload>>> {
         let endpoint = token.api_endpoint
         XCTAssertTrue(endpoint.range(of: "services.mozilla.com") != nil, "We got a Sync server.")
 
@@ -32,7 +32,7 @@ class LiveStorageClientTests: LiveAccountTest {
             return request
         }
 
-        let keyBundle: KeyBundle = KeyBundle.fromKB(kB as Data)
+        let keyBundle: KeyBundle = KeyBundle.fromKSync(kSync)
         let encoder = RecordEncoder<KeysPayload>(decode: { KeysPayload($0) }, encode: { $0.json })
         let encrypter = Keys(defaultBundle: keyBundle).encrypter("crypto", encoder: encoder)
 
@@ -62,7 +62,7 @@ class LiveStorageClientTests: LiveAccountTest {
 
         let keysPayload: Deferred<Maybe<Record<KeysPayload>>> = authState.bind { tokenResult in
             if let (token, forKey) = tokenResult.successValue {
-                return self.getKeys(kB: forKey, token: token)
+                return self.getKeys(kSync: forKey, token: token)
             }
             XCTAssertEqual(tokenResult.failureValue!.description, "")
             return Deferred(value: Maybe(failure: KeyFetchError()))

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -21,15 +21,15 @@ class MockSyncAuthState: SyncAuthState {
     var enginesEnablements: [String : Bool]?
 
     let serverRoot: String
-    let kB: Data
+    let kSync: Data
 
     var deviceID: String? {
         return "mock_device_id"
     }
 
-    init(serverRoot: String, kB: Data) {
+    init(serverRoot: String, kSync: Data) {
         self.serverRoot = serverRoot
-        self.kB = kB
+        self.kSync = kSync
     }
 
     func invalidate() {
@@ -38,25 +38,25 @@ class MockSyncAuthState: SyncAuthState {
     func token(_ now: Timestamp, canBeExpired: Bool) -> Deferred<Maybe<(token: TokenServerToken, forKey: Data)>> {
         let token = TokenServerToken(id: "id", key: "key", api_endpoint: serverRoot, uid: UInt64(0), hashedFxAUID: "",
             durationInSeconds: UInt64(5 * 60), remoteTimestamp: Timestamp(now - 1))
-        return deferMaybe((token, self.kB))
+        return deferMaybe((token, self.kSync))
     }
 }
 
 class MetaGlobalTests: XCTestCase {
     var server: MockSyncServer!
     var serverRoot: String!
-    var kB: Data!
+    var kSync: Data!
     var syncPrefs: Prefs!
     var authState: SyncAuthState!
     var stateMachine: SyncStateMachine!
 
     override func setUp() {
-        kB = Data.randomOfLength(32)!
+        kSync = Data.randomOfLength(64)!
         server = MockSyncServer(username: "1234567")
         server.start()
         serverRoot = server.baseURL
         syncPrefs = MockProfilePrefs()
-        authState = MockSyncAuthState(serverRoot: serverRoot, kB: kB)
+        authState = MockSyncAuthState(serverRoot: serverRoot, kSync: kSync)
         stateMachine = SyncStateMachine(prefs: syncPrefs)
     }
 
@@ -70,7 +70,7 @@ class MetaGlobalTests: XCTestCase {
     }
 
     func storeCryptoKeys(keys: Keys) {
-        let keyBundle = KeyBundle.fromKB(kB)
+        let keyBundle = KeyBundle.fromKSync(kSync)
         let record = Record(id: "keys", payload: keys.asPayload())
         let envelope = EnvelopeJSON(keyBundle.serializer({ $0.json })(record)!)
         server.storeRecords(records: [envelope], inCollection: "crypto")

--- a/SyncTests/StateTests.swift
+++ b/SyncTests/StateTests.swift
@@ -47,7 +47,7 @@ class StateTests: XCTestCase {
     }
 
     func baseScratchpad() -> Scratchpad {
-        let syncKeyBundle = KeyBundle.fromKB(Bytes.generateRandomBytes(32))
+        let syncKeyBundle = KeyBundle.fromKSync(Bytes.generateRandomBytes(64))
         let keys = Fetched(value: Keys(defaultBundle: syncKeyBundle), timestamp: 1001)
         let b = Scratchpad(b: syncKeyBundle, persistingTo: MockProfilePrefs()).evolve()
         let _ = b.setKeys(keys)


### PR DESCRIPTION
We derive the keys right after we unwrap kB.