### PR TITLE
Bug 1427911 — Remove Close Tab from Page Action Menu for iPad.

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -206,13 +206,23 @@ extension PhotonActionSheetProtocol {
             presentShareMenu(url, tab, buttonView, .up)
         }
 
-        let closeTab = PhotonActionSheetItem(title: Strings.CloseTabTitle, iconString: "action_remove") { action in
-            self.tabManager.removeTab(tab)
-        }
-
         let copyURL = PhotonActionSheetItem(title: Strings.AppMenuCopyURLTitleString, iconString: "menu-Copy-Link") { _ in
             UIPasteboard.general.url = tab.canonicalURL?.displayURL
             success(Strings.AppMenuCopyURLConfirmMessage)
+        }
+
+        var mainActions = [copyURL, findInPageAction, toggleDesktopSite, pinToTopSites, sendToDevice]
+
+        if let bvc = presentableVC as? BrowserViewController, bvc.topTabsVisible {
+            // If top tabs is visible (not just being on an iPad), then we should
+            // not show the "close tab" option.
+        } else {
+            // We do want to show Top Tabs when the user has this on a phone or
+            // in split view mode.
+            let closeTab = PhotonActionSheetItem(title: Strings.CloseTabTitle, iconString: "action_remove") { action in
+                self.tabManager.removeTab(tab)
+            }
+            mainActions.append(closeTab)
         }
 
         var topActions: [PhotonActionSheetItem] = []
@@ -226,7 +236,7 @@ extension PhotonActionSheetProtocol {
             }
         }
 
-        return [topActions, [copyURL, findInPageAction, toggleDesktopSite, pinToTopSites, sendToDevice, closeTab], [share]]
+        return [topActions, mainActions, [share]]
     }
 
     func fetchBookmarkStatus(for url: String) -> Deferred<Maybe<Bool>> {


### PR DESCRIPTION
This removes the close tab menu when top tabs are visible. 

In the case of iPad, where the top tab is not visible — e.g. split view, then the option is still shown.

https://bugzilla.mozilla.org/show_bug.cgi?id=1427911