### PR TITLE
Bug 1429733 - Adapt iPad XCUITests to the deletion of the Close Tab B…

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests_iPad.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests_iPad.xcscheme
@@ -205,6 +205,9 @@
                <Test
                   Identifier = "TopTabsTest/testCloseTabFromLongPressTabsButton()">
                </Test>
+               <Test
+                  Identifier = "TopTabsTest/testCloseTabFromPageOptionsMenu()">
+               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -755,7 +755,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> Scree
     map.addScreenState(PageOptionsMenu) {screenState in
         screenState.tap(app.tables["Context Menu"].cells["menu-FindInPage"], to: FindInPage)
         screenState.tap(app.tables["Context Menu"].cells["menu-Bookmark"], forAction: Action.BookmarkThreeDots, Action.Bookmark)
-        screenState.tap(app.tables["Context Menu"].cells["action_remove"], forAction: Action.CloseTabFromPageOptions, Action.CloseTab, transitionTo: HomePanelsScreen)
+        screenState.tap(app.tables["Context Menu"].cells["action_remove"], forAction: Action.CloseTabFromPageOptions, Action.CloseTab, transitionTo: HomePanelsScreen, if: "tablet != true")
         screenState.backAction = cancelBackAction
         screenState.dismissOnUse = true
     }


### PR DESCRIPTION
…utton from PAM

Since that Close Tab button has been removed from the PAM, tests have to be modified so they do not fail. In theory these are the tests affected:

-Activity Stream tests (ver en iPhone)
testTopSitesRemoveAllExceptDefaultClearPrivateData()
testTopSitesRemoveAllExceptPinnedClearPrivateData()

-Private Browser tests
testiPadDirectAccessPrivateMode()

-Reading View tests
testAddToReadingList()
testAddToReadingListPrivateMode()
testRemoveFromReadingView()
testMarkAsReadAndUnreadFromReadingList()
testRemoveFromReadingList()

-Top Tabs tests
testCloseTabFromPageOptionsMenu()

With this fix they should work, except for the last one that is deactivated since it will not make sense now without that button