### PR TITLE
Bug 1429006: stackview parent of find-in-page needs to be set full BVC width

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -661,7 +661,7 @@ class BrowserViewController: UIViewController {
 
         alertStackView.snp.remakeConstraints { make in
             make.centerX.equalTo(self.view)
-            make.width.lessThanOrEqualTo(self.view.snp.width)
+            make.width.equalTo(self.view.snp.width)
             make.width.lessThanOrEqualTo(SnackBarUX.MaxWidth)
             if let keyboardHeight = keyboardState?.intersectionHeightForView(self.view), keyboardHeight > 0 {
                 make.bottom.equalTo(self.view).offset(-keyboardHeight)
@@ -1046,7 +1046,6 @@ class BrowserViewController: UIViewController {
 
                 findInPageBar.snp.makeConstraints { make in
                     make.height.equalTo(UIConstants.ToolbarHeight)
-                    make.leading.trailing.equalTo(self.view)
                 }
 
                 updateViewConstraints()


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1429006

The red box is the parent stackview of the find-in-page bar:
<img width="512" alt="screen shot 2018-01-15 at 10 35 55 am" src="https://user-images.githubusercontent.com/5495083/34950785-22fe05fa-f9e2-11e7-8891-826f76fd6ece.png">
