### PR TITLE
Bug 1432114: Search text was set before setup call to SearchLoader

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1393,13 +1393,12 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBar(_ urlBar: URLBarView, didEnterText text: String) {
-        searchLoader?.query = text
-
         if text.isEmpty {
             hideSearchController()
         } else {
             showSearchController()
-            searchController!.searchQuery = text
+            searchController?.searchQuery = text
+            searchLoader?.query = text
         }
     }
 


### PR DESCRIPTION
... and was ignored as a result of that.

https://bugzilla.mozilla.org/show_bug.cgi?id=1432114
