### PR TITLE
Bug1432441 - SearchXCUITest Change Suggested Site Label

### DIFF
--- a/XCUITests/SearchTest.swift
+++ b/XCUITests/SearchTest.swift
@@ -5,7 +5,7 @@
 import XCTest
 
 private let LabelPrompt: String = "Turn on search suggestions?"
-private let SuggestedSite: String = "foobar2000"
+private let SuggestedSite: String = "foobar meaning"
 
 class SearchTests: BaseTestCase {
     private func typeOnSearchBar(text: String) {


### PR DESCRIPTION
There are two tests failing on Search XCUI Test Suite:
- testDoNotShowSuggestionsWhenEnteringURL() 	
- testPromptPresence() 	

The suggested site labe used do not appear anymore on BB so we have created this PR to change it.