### PR TITLE
Bug 1430537 - Fix assertion issue in PDFBrowsing Test

### DIFF
--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -108,13 +108,15 @@ class ActivityStreamTest: BaseTestCase {
         navigator.browserPerformAction(.pinToTopSitesOption)
         navigator.nowAt(BrowserTab)
         navigator.goto(HomePanelsScreen)
-        XCTAssertTrue(app.collectionViews.cells["mozilla"].exists)
+        waitforExistence(app.collectionViews.cells[newTopSite["topSiteLabel"]!])
+        XCTAssertTrue(app.collectionViews.cells[newTopSite["topSiteLabel"]!].exists)
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
 
         navigator.goto(ClearPrivateDataSettings)
         navigator.performAction(Action.AcceptClearPrivateData)
         navigator.goto(HomePanelsScreen)
-        XCTAssertTrue(app.collectionViews.cells["mozilla"].exists)
+        waitforExistence(app.collectionViews.cells[newTopSite["topSiteLabel"]!])
+        XCTAssertTrue(app.collectionViews.cells[newTopSite["topSiteLabel"]!].exists)
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
     }
 

--- a/XCUITests/BrowsingPDFTests.swift
+++ b/XCUITests/BrowsingPDFTests.swift
@@ -87,6 +87,7 @@ class BrowsingPDFTests: BaseTestCase {
         navigator.browserPerformAction(.pinToTopSitesOption)
         navigator.nowAt(BrowserTab)
         navigator.goto(NewTabScreen)
+        waitforExistence(app.collectionViews.cells["TopSitesCell"].cells["pdf995"])
         XCTAssertTrue(app.collectionViews.cells["TopSitesCell"].cells["pdf995"].exists)
 
         // Open pdf from pinned site


### PR DESCRIPTION
This test (testPinPDFtoTopSites()) is failing in the assertion sometimes because it tries to check the existence of an element and on BB where tests run slower the element is not always present.
We have added a waiting for existence so that we assure that the element is present before doing the assertion