### PR TITLE
Bug 1427903: Tapping the Statusbar should first show the toolbar (if hidden) and then scroll to the top

### DIFF
--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -337,8 +337,13 @@ extension TabScrollingController: UIScrollViewDelegate {
     }
 
     func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {
-        showToolbars(animated: true)
-        webViewContainerToolbar?.isHidden = false
+        if let webViewContainerToolbar = webViewContainerToolbar {
+            if webViewContainerToolbar.isHidden {
+                showToolbars(animated: true)
+                webViewContainerToolbar.isHidden = false
+                return false
+            }
+        }
         return true
     }
 }

--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -337,12 +337,10 @@ extension TabScrollingController: UIScrollViewDelegate {
     }
 
     func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {
-        if let webViewContainerToolbar = webViewContainerToolbar {
-            if webViewContainerToolbar.isHidden {
-                showToolbars(animated: true)
-                webViewContainerToolbar.isHidden = false
-                return false
-            }
+        if toolbarState == .collapsed {
+            showToolbars(animated: true)
+            webViewContainerToolbar?.isHidden = false
+            return false
         }
         return true
     }


### PR DESCRIPTION
This patch modifies the browser's behavior on status bar taps to more closely match that of Safari. 

Previous behavior: When user the status bar, the browser scrolls to the top of the page and shows the navigation toolbar at the same time

New Behavior: Upon the first tap on the status bar, the browser shows the navigation toolbar, if it's hidden. If the user taps the status bar while the toolbar is showing, then the browser scrolls to the top of the page.