### PR TITLE
Bug 1433474 — Hotkey — Escape from location bar.

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -618,6 +618,10 @@ extension URLBarView: AutocompleteTextFieldDelegate {
         delegate?.urlBar(self, didEnterText: "")
         return true
     }
+
+    func autocompleteTextFieldDidCancel(_ autocompleteTextField: AutocompleteTextField) {
+        leaveOverlayMode(didCancel: true)
+    }
 }
 
 // MARK: UIAppearance

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -83,8 +83,8 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
 
     override var keyCommands: [UIKeyCommand]? {
         return [
-            UIKeyCommand(input: UIKeyInputLeftArrow, modifierFlags: .init(rawValue: 0), action: #selector(self.handleKeyCommand(sender:))),
-            UIKeyCommand(input: UIKeyInputRightArrow, modifierFlags: .init(rawValue: 0), action: #selector(self.handleKeyCommand(sender:)))
+            UIKeyCommand(input: UIKeyInputLeftArrow, modifierFlags: [], action: #selector(self.handleKeyCommand(sender:))),
+            UIKeyCommand(input: UIKeyInputRightArrow, modifierFlags: [], action: #selector(self.handleKeyCommand(sender:))),
             UIKeyCommand(input: UIKeyInputEscape, modifierFlags: [], action: #selector(self.handleKeyCommand(sender:))),
         ]
     }
@@ -99,16 +99,15 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
                 selectedTextRange = textRange(from: beginningOfDocument, to: beginningOfDocument)
             } else if let range = selectedTextRange {
                 if range.start == beginningOfDocument {
-                    return
+                    break
                 }
                 
                 guard let cursorPosition = position(from: range.start, offset: -1) else {
-                    return
+                    break
                 }
                 
                 selectedTextRange = textRange(from: cursorPosition, to: cursorPosition)
             }
-            return
         case UIKeyInputRightArrow:
             if isSelectionActive {
                 applyCompletion()
@@ -117,11 +116,11 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
                 selectedTextRange = textRange(from: endOfDocument, to: endOfDocument)
             } else if let range = selectedTextRange {
                 if range.end == endOfDocument {
-                    return
+                    break
                 }
                 
                 guard let cursorPosition = position(from: range.end, offset: 1) else {
-                    return
+                    break
                 }
 
                 selectedTextRange = textRange(from: cursorPosition, to: cursorPosition)
@@ -129,7 +128,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         case UIKeyInputEscape:
             autocompleteDelegate?.autocompleteTextFieldDidCancel(self)
         default:
-            return
+            break
         }
     }
     

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -14,6 +14,7 @@ protocol AutocompleteTextFieldDelegate: class {
     func autocompleteTextFieldShouldReturn(_ autocompleteTextField: AutocompleteTextField) -> Bool
     func autocompleteTextFieldShouldClear(_ autocompleteTextField: AutocompleteTextField) -> Bool
     func autocompleteTextFieldDidBeginEditing(_ autocompleteTextField: AutocompleteTextField)
+    func autocompleteTextFieldDidCancel(_ autocompleteTextField: AutocompleteTextField)
 }
 
 private struct AutocompleteTextFieldUX {
@@ -84,6 +85,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         return [
             UIKeyCommand(input: UIKeyInputLeftArrow, modifierFlags: .init(rawValue: 0), action: #selector(self.handleKeyCommand(sender:))),
             UIKeyCommand(input: UIKeyInputRightArrow, modifierFlags: .init(rawValue: 0), action: #selector(self.handleKeyCommand(sender:)))
+            UIKeyCommand(input: UIKeyInputEscape, modifierFlags: [], action: #selector(self.handleKeyCommand(sender:))),
         ]
     }
     
@@ -124,7 +126,8 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
 
                 selectedTextRange = textRange(from: cursorPosition, to: cursorPosition)
             }
-            return
+        case UIKeyInputEscape:
+            autocompleteDelegate?.autocompleteTextFieldDidCancel(self)
         default:
             return
         }


### PR DESCRIPTION
Once in the location bar, escape should cancel; duplicating the tapping of the button next to the location bar.

https://bugzilla.mozilla.org/show_bug.cgi?id=1433474