### PR TITLE
Bug 1433470 - New XCUITest Switch between tabs using the toast menu b…

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests_iPad.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests_iPad.xcscheme
@@ -208,6 +208,12 @@
                <Test
                   Identifier = "TopTabsTest/testCloseTabFromPageOptionsMenu()">
                </Test>
+               <Test
+                  Identifier = "TopTabsTest/testSwitchBetweenTabsNoPrivatePrivateToastButton()">
+               </Test>
+               <Test
+                  Identifier = "TopTabsTest/testSwitchBetweenTabsToastButton()">
+               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>

--- a/XCUITests/TopTabsTest.swift
+++ b/XCUITests/TopTabsTest.swift
@@ -100,6 +100,61 @@ class TopTabsTest: BaseTestCase {
         waitForValueContains(app.textFields["url"], value: urlValueExample)
     }
 
+    // This test is disabled for iPad because the toast menu is not shown there
+    func testSwitchBetweenTabsToastButton() {
+        navigator.openURL(url)
+        waitUntilPageLoad()
+        app.webViews.links["Rust"].press(forDuration: 1)
+        waitforExistence(app.sheets.buttons["Open in New Tab"])
+        app.sheets.buttons["Open in New Tab"].press(forDuration: 1)
+        waitforExistence(app.buttons["Switch"])
+        app.buttons["Switch"].tap()
+
+        // Check that the tab has changed
+        waitUntilPageLoad()
+        waitForValueContains(app.textFields["url"], value: "rust")
+        XCTAssertTrue(app.staticTexts["Rust language"].exists)
+        let numTab = app.buttons["Show Tabs"].value as? String
+        XCTAssertEqual("2", numTab)
+
+
+        // Go to Private mode and do the same
+        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        navigator.openURL(url)
+        waitUntilPageLoad()
+        app.webViews.links["Rust"].press(forDuration: 1)
+        waitforExistence(app.sheets.buttons["Open in New Private Tab"])
+        app.sheets.buttons["Open in New Private Tab"].press(forDuration: 1)
+        waitforExistence(app.buttons["Switch"])
+        app.buttons["Switch"].tap()
+
+        // Check that the tab has changed
+        waitUntilPageLoad()
+        waitForValueContains(app.textFields["url"], value: "rust")
+        XCTAssertTrue(app.staticTexts["Rust language"].exists)
+        let numPrivTab = app.buttons["Show Tabs"].value as? String
+        XCTAssertEqual("2", numPrivTab)
+    }
+
+    // This test is disabled for iPad because the toast menu is not shown there
+    func testSwitchBetweenTabsNoPrivatePrivateToastButton() {
+        navigator.openURL(url)
+        waitUntilPageLoad()
+
+        app.webViews.links["Rust"].press(forDuration: 1)
+        waitforExistence(app.sheets.buttons["Open in New Tab"])
+        app.sheets.buttons["Open in New Private Tab"].press(forDuration: 1)
+        waitforExistence(app.buttons["Switch"])
+        app.buttons["Switch"].tap()
+
+        // Check that the tab has changed to the new open one and that the user is in private mode
+        waitUntilPageLoad()
+        waitForValueContains(app.textFields["url"], value: "rust")
+        XCTAssertTrue(app.staticTexts["Rust language"].exists)
+        navigator.goto(TabTray)
+        XCTAssertTrue(app.buttons["TabTrayController.maskButton"].isEnabled)
+    }
+
     func testCloseOneTab() {
         navigator.openURL(url)
         waitUntilPageLoad()


### PR DESCRIPTION
…utton

This PR includes two new XCUITests to the TopTabs Test Suite for the iPhone case since the menu is not available on iPad.
-testSwitchBetweenTabsToastButton()
-testSwitchBetweenTabsNoPrivatePrivateToastButton()

There was not any test yet to check the Switch button in the toast menu when long pressing on a link and Open New or Private New Page option is selected.
