### PR TITLE
Bug 1432468 - New XCUITest FxAccount/Sync UI Tests

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		2CB56E3F1E926BFB00AF7586 /* ToolbarTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB56E3E1E926BFB00AF7586 /* ToolbarTest.swift */; };
 		2CC1B3F01E9B861400814EEC /* DomainAutocompleteTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC1B3EF1E9B861400814EEC /* DomainAutocompleteTest.swift */; };
 		2CEA6F791E93E3A600D4100E /* SearchSettingsUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CEA6F781E93E3A600D4100E /* SearchSettingsUITest.swift */; };
+		2CEDADA220207EC400223A89 /* SyncFAUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CEDADA120207EC400223A89 /* SyncFAUITests.swift */; };
 		2CF449A51E7BFE2C00FD7595 /* NavigationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF449A41E7BFE2C00FD7595 /* NavigationTest.swift */; };
 		2CF9D9AA20067FA10083DF2A /* BrowsingPDFTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF9D9A920067FA10083DF2A /* BrowsingPDFTests.swift */; };
 		2F13E79B1AC0C02700D75081 /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F13E79A1AC0C02700D75081 /* StringExtensionsTests.swift */; };
@@ -1521,6 +1522,7 @@
 		2CB56E3E1E926BFB00AF7586 /* ToolbarTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolbarTest.swift; sourceTree = "<group>"; };
 		2CC1B3EF1E9B861400814EEC /* DomainAutocompleteTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainAutocompleteTest.swift; sourceTree = "<group>"; };
 		2CEA6F781E93E3A600D4100E /* SearchSettingsUITest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSettingsUITest.swift; sourceTree = "<group>"; };
+		2CEDADA120207EC400223A89 /* SyncFAUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncFAUITests.swift; sourceTree = "<group>"; };
 		2CF449A41E7BFE2C00FD7595 /* NavigationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationTest.swift; sourceTree = "<group>"; };
 		2CF9D9A920067FA10083DF2A /* BrowsingPDFTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowsingPDFTests.swift; sourceTree = "<group>"; };
 		2F13E79A1AC0C02700D75081 /* StringExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringExtensionsTests.swift; sourceTree = "<group>"; };
@@ -2902,6 +2904,7 @@
 				2CF9D9A920067FA10083DF2A /* BrowsingPDFTests.swift */,
 				39C261CB2018DE20009D97BD /* FxScreenGraphTests.swift */,
 				2C28F96B201B2D4C00ABA8A5 /* MailAppSettingsTests.swift */,
+				2CEDADA120207EC400223A89 /* SyncFAUITests.swift */,
 			);
 			path = XCUITests;
 			sourceTree = "<group>";
@@ -5480,6 +5483,7 @@
 				0B729D371E047D6A008E6859 /* HomePageSettingsTest.swift in Sources */,
 				39C261CC2018DE21009D97BD /* FxScreenGraphTests.swift in Sources */,
 				3DEFED081F55EBE300F8620C /* TrackingProtectionTests.swift in Sources */,
+				2CEDADA220207EC400223A89 /* SyncFAUITests.swift in Sources */,
 				3D9CA9A81EF84D04002434DD /* NoImageTests.swift in Sources */,
 				2C31A8471E8D447F00DAC646 /* HomePageSettingsUITest.swift in Sources */,
 				2CEA6F791E93E3A600D4100E /* SearchSettingsUITest.swift in Sources */,

--- a/XCUITests/SyncFAUITests.swift
+++ b/XCUITests/SyncFAUITests.swift
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import XCTest
+
+class SyncUITests: BaseTestCase {
+    func testUIFromSettings () {
+        navigator.goto(FxASigninScreen)
+        waitforExistence(app.webViews.staticTexts["Sign in"])
+        XCTAssertTrue(app.navigationBars["Client.FxAContentView"].exists)
+        XCTAssertTrue(app.webViews.textFields["Email"].exists)
+        XCTAssertTrue(app.webViews.secureTextFields["Password"].exists)
+        XCTAssertTrue(app.webViews.buttons["Sign in"].exists)
+    }
+
+    func testPlaceholderValues () {
+        navigator.goto(FxASigninScreen)
+        waitforExistence(app.webViews.staticTexts["Sign in"])
+        let mailPlaceholder = "Email"
+        let passwordPlaceholder = "Password"
+
+        let defaultMailPlaceholder = app.webViews.textFields["Email"].placeholderValue!
+        let defaultPasswordPlaceholder = app.webViews.secureTextFields["Password"].placeholderValue!
+        XCTAssertEqual(mailPlaceholder, defaultMailPlaceholder, "The mail placeholder does not show the correct value")
+        XCTAssertEqual(passwordPlaceholder, defaultPasswordPlaceholder, "The password placeholder does not show the correct value")
+    }
+
+    func testTypeOnGivenFields() {
+        navigator.goto(FxASigninScreen)
+        waitforExistence(app.webViews.staticTexts["Sign in"])
+
+        // Tap Sign in without any value in email Password focus on Email
+        navigator.performAction(Action.FxATapOnSignInButton)
+        waitforExistence(app.webViews.staticTexts["Valid email required"])
+
+        // Enter only email, wrong and correct and tap sign in
+        userState.fxaUsername = "bademail"
+        navigator.performAction(Action.FxATypeEmail)
+        navigator.performAction(Action.FxATapOnSignInButton)
+        waitforExistence(app.webViews.staticTexts["Valid email required"])
+
+        userState.fxaUsername = "valid@email.com"
+        navigator.performAction(Action.FxATypeEmail)
+        navigator.performAction(Action.FxATapOnSignInButton)
+        waitforExistence(app.webViews.staticTexts["Valid password required"])
+
+        // Enter invalid (too short, it should be at least 8 chars) and incorrect password
+        userState.fxaPassword = "foo"
+        navigator.performAction(Action.FxATypePassword)
+        navigator.performAction(Action.FxATapOnSignInButton)
+        waitforExistence(app.webViews.staticTexts["Must be at least 8 characters"])
+
+        // Enter valid but incorrect, it does not exists, password
+        userState.fxaPassword = "atleasteight"
+        navigator.performAction(Action.FxATypePassword)
+        navigator.performAction(Action.FxATapOnSignInButton)
+        waitforExistence(app.webViews.staticTexts["Unknown account."])
+        XCTAssertTrue(app.webViews.links["Sign up"].exists)
+    }
+
+    func testCreateAnAccountLink() {
+        navigator.goto(FxASigninScreen)
+        waitforExistence(app.webViews.links["Create an account"])
+        navigator.goto(FxCreateAccount)
+        waitforExistence(app.webViews.buttons["Create account"])
+    }
+
+    func testShowPassword() {
+        // The aim of this test is to check if the option to show password is shown when user starts typing and dissapears when no password is typed
+        navigator.goto(FxASigninScreen)
+        waitforNoExistence(app.webViews.staticTexts["Show"])
+        // Typing on Email should not show Show (password) option
+        userState.fxaUsername = "email"
+        navigator.performAction(Action.FxATypeEmail)
+        waitforNoExistence(app.webViews.staticTexts["Show"])
+        // Typing on Password should show Show (password) option
+        userState.fxaPassword = "foo"
+        navigator.performAction(Action.FxATypePassword)
+        waitforExistence(app.webViews.staticTexts["Show"])
+        // Long press delete key to remove the password typed, Show (password) option should not be shown
+        app.keys["delete"].press(forDuration: 2)
+        waitforNoExistence(app.webViews.staticTexts["Show"])
+    }
+}


### PR DESCRIPTION
This PR is for  adding a few tests to check the User Interface of the Sync option and how it behaves under basic scenarios (not possible to create an E2E scenario due the account creation and confirmation)

-testUIFromSettings ()
-testPlaceholderValues ()
-testTypeOnGivenFields()
-testCreateAnAccountLink()
-testShowPassword()

https://bugzilla.mozilla.org/show_bug.cgi?id=1432468