### PR TITLE
Bug 1433430 - New XCUITests Check History Recently Closed Options

### DIFF
--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -41,6 +41,7 @@ let DisablePasscodeSettings = "DisablePasscodeSettings"
 let ChangePasscodeSettings = "ChangePasscodeSettings"
 let LockedLoginsSettings = "LockedLoginsSettings"
 let TabTrayLongPressMenu = "TabTrayLongPressMenu"
+let HistoryRecentlyClosed = "HistoryRecentlyClosed"
 
 // These are in the exact order they appear in the settings
 // screen. XCUIApplication loses them on small screens.
@@ -402,11 +403,17 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     map.addScreenState(HomePanel_History) { screenState in
         screenState.press(app.tables["History List"].cells.element(boundBy: 2), to: HistoryPanelContextMenu)
+        screenState.tap(app.cells["HistoryPanel.recentlyClosedCell"], to: HistoryRecentlyClosed)
         screenState.noop(to: HomePanelsScreen)
     }
 
     map.addScreenState(HomePanel_ReadingList) { screenState in
         screenState.noop(to: HomePanelsScreen)
+    }
+
+    map.addScreenState(HistoryRecentlyClosed) { screenState in
+        screenState.dismissOnUse = true
+        screenState.backAction = dismissContextMenuAction
     }
 
     map.addScreenState(HistoryPanelContextMenu) { screenState in

--- a/XCUITests/HistoryTests.swift
+++ b/XCUITests/HistoryTests.swift
@@ -5,6 +5,8 @@
 import XCTest
 
 let webpage = ["url": "www.mozilla.org", "label": "Internet for people, not profit — Mozilla", "value": "mozilla.org"]
+// This is part of the info the user will see in recent closed tabs once the default visited website (https://www.mozilla.org/en-US/book/) is closed
+let closedWebPageLabel = "The Book of Mozilla"
 
 class HistoryTests: BaseTestCase {
     func testEmptyHistoryListFirstTime() {
@@ -47,5 +49,130 @@ class HistoryTests: BaseTestCase {
         navigator.goto(HomePanel_History)
         waitforExistence(app.tables.cells["HistoryPanel.recentlyClosedCell"])
         XCTAssertFalse(app.tables.cells.staticTexts[webpage["label"]!].exists)
+    }
+
+    func testRecentlyClosedOptionAvailable() {
+        navigator.goto(HistoryRecentlyClosed)
+        waitforNoExistence(app.tables["Recently Closed Tabs List"])
+
+        // Go to the default web site  and check whether the option is enabled
+        navigator.goto(BrowserTab)
+        waitUntilPageLoad()
+        navigator.goto(BrowserTabMenu)
+        navigator.goto(HistoryRecentlyClosed)
+        waitforNoExistence(app.tables["Recently Closed Tabs List"])
+
+        // Now go back to default website close it and check whether the option is enabled
+        navigator.goto(BrowserTab)
+        navigator.goto(TabTray)
+        navigator.closeAllTabs()
+        navigator.goto(HistoryRecentlyClosed)
+
+        // The Closed Tabs list should contain the info of the website just closed
+        waitforExistence(app.tables["Recently Closed Tabs List"])
+        XCTAssertTrue(app.tables.cells.staticTexts[closedWebPageLabel].exists)
+
+        // This option should be enabled on private mode too
+        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        navigator.goto(HistoryRecentlyClosed)
+        waitforExistence(app.tables["Recently Closed Tabs List"])
+    }
+
+    func testClearRecentlyClosedHistory() {
+        // Open the default website
+        navigator.goto(BrowserTab)
+        navigator.goto(TabTray)
+        navigator.closeAllTabs()
+        navigator.goto(HomePanel_History)
+        navigator.goto(HistoryRecentlyClosed)
+        // Once the website is visited and closed it will appear in Recently Closed Tabs list
+        waitforExistence(app.tables["Recently Closed Tabs List"])
+        XCTAssertTrue(app.tables.cells.staticTexts[closedWebPageLabel].exists)
+
+        // Go to settings and clear private data
+        navigator.performAction(Action.AcceptClearPrivateData)
+
+        // Back on History panel view check that there is not any item
+        navigator.goto(HistoryRecentlyClosed)
+        waitforNoExistence(app.tables["Recently Closed Tabs List"])
+    }
+
+    func testLongTapOptionsRecentlyClosedItem() {
+        // Open the default website
+        navigator.goto(BrowserTab)
+        navigator.goto(TabTray)
+        navigator.closeAllTabs()
+
+        navigator.goto(BrowserTabMenu)
+        navigator.goto(HistoryRecentlyClosed)
+        waitforExistence(app.tables["Recently Closed Tabs List"])
+        XCTAssertTrue(app.tables.cells.staticTexts[closedWebPageLabel].exists)
+        app.tables.cells.staticTexts[closedWebPageLabel].press(forDuration: 1)
+        waitforExistence(app.tables["Context Menu"])
+        XCTAssertTrue(app.tables.cells["quick_action_new_tab"].exists)
+        XCTAssertTrue(app.tables.cells["quick_action_new_private_tab"].exists)
+    }
+
+    func testOpenInNewTabRecentlyClosedItem() {
+        // Open the default website
+        navigator.goto(BrowserTab)
+        navigator.goto(TabTray)
+        navigator.closeAllTabs()
+
+        navigator.goto(HistoryRecentlyClosed)
+        waitforExistence(app.tables["Recently Closed Tabs List"])
+        XCTAssertTrue(app.tables.cells.staticTexts[closedWebPageLabel].exists)
+        let numTabsOpen = userState.numTabs
+        XCTAssertEqual(numTabsOpen, 1)
+        app.tables.cells.staticTexts[closedWebPageLabel].press(forDuration: 1)
+        waitforExistence(app.tables["Context Menu"])
+        app.tables.cells["quick_action_new_tab"].tap()
+        navigator.goto(TabTray)
+        let numTabsOpen2 = userState.numTabs
+        XCTAssertEqual(numTabsOpen2, 2)
+    }
+
+    func testOpenInNewPrivateTabRecentlyClosedItem() {
+        // Open the default website
+        navigator.goto(BrowserTab)
+        navigator.goto(TabTray)
+        navigator.closeAllTabs()
+        navigator.goto(HistoryRecentlyClosed)
+        waitforExistence(app.tables["Recently Closed Tabs List"])
+        XCTAssertTrue(app.tables.cells.staticTexts[closedWebPageLabel].exists)
+
+        app.tables.cells.staticTexts[closedWebPageLabel].press(forDuration: 1)
+        waitforExistence(app.tables["Context Menu"])
+        app.tables.cells["quick_action_new_private_tab"].tap()
+
+        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        navigator.goto(TabTray)
+        let numTabsOpen = userState.numTabs
+        XCTAssertEqual(numTabsOpen, 1)
+    }
+
+    func testPrivateClosedSiteDoesNotAppearOnRecentlyClosed() {
+        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        // Open the default website
+        navigator.goto(BrowserTab)
+        // It is necessary to open two sites so that when one is closed private mode is not closed
+        navigator.openNewURL(urlString: "mozilla.org")
+        if iPad() {
+            navigator.goto(BrowserTab)
+            navigator.goto(TabTray)
+            waitforExistence(app.collectionViews.cells[webpage["label"]!])
+            // 'x' button to close the tab is not visible, so closing by swiping the tab
+            app.collectionViews.cells[webpage["label"]!].swipeRight()
+        } else {
+            navigator.performAction(Action.CloseTabFromPageOptions)
+        }
+        navigator.goto(BrowserTabMenu)
+        navigator.goto(HistoryRecentlyClosed)
+        waitforNoExistence(app.tables["Recently Closed Tabs List"])
+
+        // Now verify that on regular mode the recently closed list is empty too
+        navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        navigator.goto(HistoryRecentlyClosed)
+        waitforNoExistence(app.tables["Recently Closed Tabs List"])
     }
 }


### PR DESCRIPTION
With this PR the idea is to increase the coverage for the History XCUITest suite. For that new tests covering the option "Recently Closed" have been added:
-testRecentlyClosedOptionAvailable()
-testClearRecentlyClosedHistory()
-testLongTapOptionsRecentlyClosedItem()
-testOpenInNewTabRecentlyClosedItem()
-testOpenInNewPrivateTabRecentlyClosedItem()
-testPrivateClosedSiteDoesNotAppearOnRecentlyClosed()