### PR TITLE
Bug 1435135 - Enabled FxA leanplum A/B test for all users

### DIFF
--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -196,7 +196,7 @@ public struct AppConstants {
     ///  Toggle FxA Leanplum A/B test for prompting push permissions
     public static let MOZ_FXA_LEANPLUM_AB_PUSH_TEST: Bool = {
         #if MOZ_CHANNEL_RELEASE
-            return false
+            return true
         #elseif MOZ_CHANNEL_BETA
             return true
         #elseif MOZ_CHANNEL_FENNEC


### PR DESCRIPTION
This was landed for Beta users and we are tracking test results. Per team, we should open to all users.

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Bug 12345678 - This fixes something something`
