### PR TITLE
Bug 1415720 - Add Intro screen custom variables to LP.

### DIFF
--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -38,6 +38,7 @@ enum LPEvent: String {
     case secondRun = "E_Second_Run"
     case openedApp = "E_Opened_App"
     case dismissedOnboarding = "E_Dismissed_Onboarding"
+    case dismissedOnboardingShowLogin = "E_Dismissed_Onboarding_Showed_Login"
     case openedLogins = "Opened Login Manager"
     case openedBookmark = "E_Opened_Bookmark"
     case openedNewTab = "E_Opened_New_Tab"
@@ -93,6 +94,7 @@ class LeanPlumClient {
     // The primary result is having a feature flag controlled by Leanplum, and falling back
     // to prompting with native push permissions.
     private var useFxAPrePush: LPVar = LPVar.define("useFxAPrePush", with: false)
+    var introScreenVars = LPVar.define("IntroScreen", with: IntroCard.defaultCards().flatMap({ $0.asDictonary() }))
 
     private func isPrivateMode() -> Bool {
         // Need to be run on main thread since isInPrivateMode requires to be on the main thread.

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2337,7 +2337,6 @@ extension BrowserViewController: IntroViewControllerDelegate {
 
     func introViewControllerDidFinish(_ introViewController: IntroViewController, requestToLogin: Bool) {
         self.profile.prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
-        LeanPlumClient.shared.track(event: .dismissedOnboarding)
 
         introViewController.dismiss(animated: true) { finished in
             if self.navigationController?.viewControllers.count ?? 0 > 1 {

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -170,6 +170,19 @@ public struct AppConstants {
             return false
         #endif
     }()
+
+    ///  Toggle configuring Intro slides via LP
+    public static let MOZ_LP_INTRO: Bool = {
+        #if MOZ_CHANNEL_RELEASE
+            return true
+        #elseif MOZ_CHANNEL_BETA
+            return true
+        #elseif MOZ_CHANNEL_FENNEC
+            return true
+        #else
+            return true
+        #endif
+    }()
     
     ///  Toggle the feature that shows updated FxA preferences cell
     public static let MOZ_SHOW_FXA_AVATAR: Bool = {


### PR DESCRIPTION
This sets up the default IntroSlides as LeanPlum custom variables allowing customizing of the text and in the future buttons and images. 

I've also modified the onboarding LP event that is fired when the onboarding is dismissed. Now as an extra parameter the current page of the intro is passed to LP. Allowing the LP team to see where people exit the intro flow. 

