### PR TITLE
Bug1435970 - Fix XCUITests according to new PAM with Tools Option

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
@@ -205,6 +205,9 @@
                <Test
                   Identifier = "SiteLoadTest">
                </Test>
+               <Test
+                  Identifier = "TopTabsTest/testCloseTabFromPageOptionsMenu()">
+               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -159,6 +159,8 @@ class Action {
     static let FxATypeEmail = "FxATypeEmail"
     static let FxATypePassword = "FxATypePassword"
     static let FxATapOnSignInButton = "FxATapOnSignInButton"
+
+    static let PinToTopSitesPAM = "PinToTopSitesPAM"
 }
 
 private var isTablet: Bool {
@@ -785,6 +787,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     map.addScreenState(ToolsMenu) { screenState in
         screenState.tap(app.tables.cells["menu-FindInPage"], to: FindInPage)
+        screenState.tap(app.tables.cells["action_pin"], forAction: Action.PinToTopSitesPAM)
         screenState.backAction = cancelBackAction
         screenState.dismissOnUse = true
     }

--- a/XCUITests/HistoryTests.swift
+++ b/XCUITests/HistoryTests.swift
@@ -157,21 +157,19 @@ class HistoryTests: BaseTestCase {
         navigator.goto(BrowserTab)
         // It is necessary to open two sites so that when one is closed private mode is not closed
         navigator.openNewURL(urlString: "mozilla.org")
-        if iPad() {
-            navigator.goto(BrowserTab)
-            navigator.goto(TabTray)
-            waitforExistence(app.collectionViews.cells[webpage["label"]!])
-            // 'x' button to close the tab is not visible, so closing by swiping the tab
-            app.collectionViews.cells[webpage["label"]!].swipeRight()
-        } else {
-            navigator.performAction(Action.CloseTabFromPageOptions)
-        }
-        navigator.goto(BrowserTabMenu)
+        waitUntilPageLoad()
+        navigator.goto(TabTray)
+        waitforExistence(app.collectionViews.cells[webpage["label"]!])
+        // 'x' button to close the tab is not visible, so closing by swiping the tab
+        app.collectionViews.cells[webpage["label"]!].swipeRight()
+
+        navigator.goto(HomePanelsScreen)
         navigator.goto(HistoryRecentlyClosed)
         waitforNoExistence(app.tables["Recently Closed Tabs List"])
 
         // Now verify that on regular mode the recently closed list is empty too
         navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        navigator.goto(HomePanelsScreen)
         navigator.goto(HistoryRecentlyClosed)
         waitforNoExistence(app.tables["Recently Closed Tabs List"])
     }

--- a/XCUITests/NavigationTest.swift
+++ b/XCUITests/NavigationTest.swift
@@ -201,13 +201,15 @@ class NavigationTest: BaseTestCase {
     }
 
     private func checkMobileSite() {
-        app.buttons["TabLocationView.pageOptionsButton"].tap()
+        navigator.nowAt(BrowserTab)
+        navigator.goto(ToolsMenu)
         waitforExistence(app.tables.cells["menu-RequestDesktopSite"].staticTexts[requestDesktopSiteLabel])
         navigator.goto(BrowserTab)
     }
     
     private func checkDesktopSite() {
-        app.buttons["TabLocationView.pageOptionsButton"].tap()
+        navigator.nowAt(BrowserTab)
+        navigator.goto(ToolsMenu)
         waitforExistence(app.tables.cells["menu-RequestDesktopSite"].staticTexts[requestMobileSiteLabel])
         navigator.goto(BrowserTab)
     }

--- a/XCUITests/PhotonActionSheetTest.swift
+++ b/XCUITests/PhotonActionSheetTest.swift
@@ -8,19 +8,11 @@ class PhotonActionSheetTest: BaseTestCase {
     func testPinToTop() {
         navigator.openURL("http://example.com")
         waitUntilPageLoad()
-        // Open Action Sheet
-        app.buttons["TabLocationView.pageOptionsButton"].tap()
+        // Open Page Action Menu Sheet and Pin the site
+        navigator.performAction(Action.PinToTopSitesPAM)
 
-        // Pin the site
-        app.cells["Pin to Top Sites"].tap()
-
-        // Verify that the site has been pinned
-        // Open menu
-        app.buttons["Menu"].tap()
-
-        // Navigate to top sites
-        app.cells["Top Sites"].tap()
-        waitforExistence(app.cells["TopSite"].firstMatch)
+        // Navigate to topsites to verify that the site has been pinned
+        navigator.goto(NewTabScreen)
 
         // Verify that the site is pinned to top
         let cell = app.cells["TopSite"].firstMatch


### PR DESCRIPTION
Once [PR](https://github.com/mozilla-mobile/firefox-ios/pull/3624/files) Bug 1434012 - Page action menu refactor: add Tools section landed there were some XCUITests failing due to the changes:

-testPrivateClosedSiteDoesNotAppearOnRecentlyClosed
-testToggleBetweenMobileAndDesktopSiteFromMenu()
-testPinToTop()
-testCloseTabFromPageOptionsMenu() -> Close tab from PAM has been removed, test disabled

This PR is to fix those tests according to the new changes implemented