### PR TITLE
Bug 1427886 — Open location bar by default on Cmd T.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -981,11 +981,16 @@ class BrowserViewController: UIViewController {
     func openBlankNewTab(focusLocationField: Bool, isPrivate: Bool = false) {
         popToBVC()
         openURLInNewTab(nil, isPrivate: isPrivate, isPrivileged: true)
+        let freshTab = tabManager.selectedTab
         
         if focusLocationField {
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(300)) {
                 // Without a delay, the text field fails to become first responder
-                self.urlBar.tabLocationViewDidTapLocation(self.urlBar.locationView)
+                // Check that the newly created tab is still selected.
+                // This let's the user spam the Cmd+T button without lots of responder changes.
+                if freshTab == self.tabManager.selectedTab {
+                    self.urlBar.tabLocationViewDidTapLocation(self.urlBar.locationView)
+                }
             }
         }
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -38,11 +38,11 @@ extension BrowserViewController {
     }
 
     @objc private func newTabKeyCommand() {
-        openBlankNewTab(focusLocationField: false, isPrivate: false)
+        openBlankNewTab(focusLocationField: true, isPrivate: false)
     }
 
     @objc private func newPrivateTabKeyCommand() {
-        openBlankNewTab(focusLocationField: false, isPrivate: true)
+        openBlankNewTab(focusLocationField: true, isPrivate: true)
     }
 
     @objc private func closeTabKeyCommand() {


### PR DESCRIPTION
This PR modifies the behaviours of Cmd T and Cmd-Shift-P to open the location bar by default. 

Some effort is made to ensure that the user can [Daley Thompson][1] the keys and it still focus on the location bar.

https://bugzilla.mozilla.org/show_bug.cgi?id=1427886

[1]: https://en.wikipedia.org/wiki/Daley_Thompson%27s_Decathlon