### PR TITLE
Bug 1434444, 1434445 - New LP attributes to measure verified fxa accounts and number of synced devices.

### DIFF
--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -127,7 +127,7 @@ class LeanPlumClient {
                 self.track(event: .fxaSyncedNewDevice)
             }
             self.prefs?.setInt(Int32(clients.count), forKey: "FxaDevicesCount")
-            Leanplum.setUserAttributes([LPAttributeKey.fxaDeviceCounts: clients.count])
+            Leanplum.setUserAttributes([LPAttributeKey.fxaDeviceCount: clients.count])
         }
     }
 

--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -56,6 +56,7 @@ enum LPEvent: String {
     case signsInFxa = "E_User_Signed_In_To_FxA"
     case useReaderView = "E_User_Used_Reader_View"
     case trackingProtectionSettings = "E_Tracking_Protection_Settings_Changed"
+    case fxaSyncedNewDevice = "E_FXA_Synced_New_Device"
 }
 
 struct LPAttributeKey {
@@ -121,6 +122,11 @@ class LeanPlumClient {
             return
         }
         profile.remoteClientsAndTabs.getClients() >>== { clients in
+            let oldCount = self.prefs?.intForKey("FxaDevicesCount") ?? 0
+            if clients.count > oldCount {
+                self.track(event: .fxaSyncedNewDevice)
+            }
+            self.prefs?.setInt(Int32(clients.count), forKey: "FxaDevicesCount")
             Leanplum.setUserAttributes([LPAttributeKey.fxaDeviceCount : clients.count])
         }
     }

--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -11,6 +11,7 @@ private let LPAppIdKey = "LeanplumAppId"
 private let LPProductionKeyKey = "LeanplumProductionKey"
 private let LPDevelopmentKeyKey = "LeanplumDevelopmentKey"
 private let AppRequestedUserNotificationsPrefKey = "applicationDidRequestUserNotificationPermissionPrefKey"
+private let FxaDevicesCountPrefKey = "FxaDevicesCount"
 
 // FxA Custom Leanplum message template for A/B testing push notifications.
 private struct LPMessage {
@@ -117,16 +118,16 @@ class LeanPlumClient {
         self.profile = profile
     }
 
-    func syncedClients(with profile: Profile?) {
+    func recordSyncedClients(with profile: Profile?) {
         guard let profile = profile as? BrowserProfile else {
             return
         }
         profile.remoteClientsAndTabs.getClients() >>== { clients in
-            let oldCount = self.prefs?.intForKey("FxaDevicesCount") ?? 0
+            let oldCount = self.prefs?.intForKey(FxaDevicesCountPrefKey) ?? 0
             if clients.count > oldCount {
                 self.track(event: .fxaSyncedNewDevice)
             }
-            self.prefs?.setInt(Int32(clients.count), forKey: "FxaDevicesCount")
+            self.prefs?.setInt(Int32(clients.count), forKey: FxaDevicesCountPrefKey)
             Leanplum.setUserAttributes([LPAttributeKey.fxaDeviceCount: clients.count])
         }
     }

--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -127,7 +127,7 @@ class LeanPlumClient {
                 self.track(event: .fxaSyncedNewDevice)
             }
             self.prefs?.setInt(Int32(clients.count), forKey: "FxaDevicesCount")
-            Leanplum.setUserAttributes([LPAttributeKey.fxaDeviceCount : clients.count])
+            Leanplum.setUserAttributes([LPAttributeKey.fxaDeviceCounts: clients.count])
         }
     }
 

--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -176,7 +176,7 @@ class LeanPlumClient {
 
             self.checkIfAppWasInstalled(key: PrefsKeys.HasFocusInstalled, isAppInstalled: self.focusInstalled(), lpEvent: .downloadedFocus)
             self.checkIfAppWasInstalled(key: PrefsKeys.HasPocketInstalled, isAppInstalled: self.pocketInstalled(), lpEvent: .downloadedPocket)
-            self.syncedClients(with: self.profile)
+            self.recordSyncedClients(with: self.profile)
         })
     }
 


### PR DESCRIPTION
The number of synced clients is fetched via the DB so it happens in an async fashion. 

According to the LP docs user attributes are not overridden and only the ones updated via `setUserAttributes` are actually changed. So calling `setUserAttributes` after start is safe.