### PR TITLE
 Bug 1415720 - Improvements to how Intro slides change during Leanplum A/B tests

### DIFF
--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -58,6 +58,7 @@ enum LPEvent: String {
     case useReaderView = "E_User_Used_Reader_View"
     case trackingProtectionSettings = "E_Tracking_Protection_Settings_Changed"
     case fxaSyncedNewDevice = "E_FXA_Synced_New_Device"
+    case onboardingTestLoadedTooSlow = "E_Onboarding_Was_Swiped_Before_AB_Test_Could_Start"
 }
 
 struct LPAttributeKey {

--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -126,7 +126,8 @@ class IntroViewController: UIViewController {
 
 
     func syncViaLP() {
-        LeanPlumClient.shared.introScreenVars?.onValueChanged({
+        let startTime = Date.now()
+        LeanPlumClient.shared.introScreenVars?.onValueChanged({ [weak self] in
             guard let newIntro = LeanPlumClient.shared.introScreenVars?.object(forKey: nil) as? [[String: Any]] else {
                 return
             }
@@ -137,22 +138,29 @@ class IntroViewController: UIViewController {
                 }
                 let card = try? decoder.decode(IntroCard.self, from: object)
                 // Make sure the selector actually goes somewhere. Otherwise dont show that slide
-                if let selectorString = card?.buttonSelector {
-                    return self.responds(to: NSSelectorFromString(selectorString)) ? card : nil
+                if let selectorString = card?.buttonSelector, let wself = self {
+                    return wself.responds(to: NSSelectorFromString(selectorString)) ? card : nil
                 } else {
                     return card
                 }
             }
-            // We need at least 2 cards
-            if newCards.count > 1 {
-                self.cards = newCards
-                /*
-                 Note: This wipes the slides and recreates them. If the user is already swiping by the time LP syncs this will probably confuse the user.
-                 I'm deciding to leave this and let the LP team decide what to do after they get some time to play with this
-                */
-                self.createSlides()
-                self.viewDidLayoutSubviews()
+
+            guard newCards != IntroCard.defaultCards(), newCards.count > 1 else {
+                return
             }
+
+            // We need to still be on the first page otherwise the content will change underneath the user's finger
+            // We also need to let LP know this happened so we can track when a A/B test was not run
+            guard self?.pageControl.currentPage == 0 else {
+                let totalTime = Date.now() - startTime
+                LeanPlumClient.shared.track(event: .onboardingTestLoadedTooSlow, withParameters: ["Total time": "\(totalTime) ms" as AnyObject])
+                return
+            }
+
+            self?.cards = newCards
+            self?.createSlides()
+            self?.viewDidLayoutSubviews()
+
         })
     }
 
@@ -424,6 +432,13 @@ struct IntroCard: Codable {
         guard let data = try? JSONEncoder().encode(self) else { return nil }
         return (try? JSONSerialization.jsonObject(with: data, options: .allowFragments)).flatMap { $0 as? [String: Any] }
     }
+}
+
+extension IntroCard: Equatable {}
+
+func == (lhs: IntroCard, rhs: IntroCard) -> Bool {
+    return lhs.buttonText == rhs.buttonText && lhs.buttonSelector == rhs.buttonSelector
+        && lhs.imageName == rhs.imageName && lhs.text == rhs.text && lhs.title == rhs.title
 }
 
 extension UIColor {

--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -123,8 +123,6 @@ class IntroViewController: UIViewController {
         pageControl.addTarget(self, action: #selector(changePage), for: .valueChanged)
     }
 
-
-
     func syncViaLP() {
         let startTime = Date.now()
         LeanPlumClient.shared.introScreenVars?.onValueChanged({ [weak self] in


### PR DESCRIPTION
After the last MMA meeting here are some improvements we can make to the onboarding slides. 

Our main concern is making sure that the slides dont change while a user is viewing the default intro slides. Now, if the user has already moved away from the first slide we no longer apply changes to the Intro slides. 

When the slides do fail to change we should send an LP event to make sure we know that the test failed to run. In the future we can use this to see if we need to revisit how this campaign works. 