### PR TITLE
Bug 1434195 - Followup, Fix Locale.preferredLanguages call. 

### DIFF
--- a/Client/Frontend/Browser/SearchEngines.swift
+++ b/Client/Frontend/Browser/SearchEngines.swift
@@ -176,7 +176,7 @@ class SearchEngines {
     /// Get all bundled (not custom) search engines, with the default search engine first,
     /// but the others in no particular order.
     class func getUnorderedBundledEnginesFor(locale: Locale) -> [OpenSearchEngine] {
-        let languageIdentifier = Locale.preferredLanguages.first ?? locale.identifier
+        let languageIdentifier = locale.identifier
         let region = locale.regionCode ?? "US"
         let parser = OpenSearchParser(pluginMode: true)
 
@@ -202,7 +202,8 @@ class SearchEngines {
 
     /// Get all known search engines, possibly as ordered by the user.
     fileprivate func getOrderedEngines() -> [OpenSearchEngine] {
-        let unorderedEngines = customEngines + SearchEngines.getUnorderedBundledEnginesFor(locale: Locale.current)
+        let locale = Locale(identifier: Locale.preferredLanguages.first ?? Locale.current.identifier)
+        let unorderedEngines = customEngines + SearchEngines.getUnorderedBundledEnginesFor(locale: locale)
 
         // might not work to change the default.
         guard let orderedEngineNames = prefs.stringArrayForKey(OrderedEngineNames) else {


### PR DESCRIPTION
The Locale Identifier was changed in the wrong place in commit https://github.com/mozilla-mobile/firefox-ios/commit/6d18f74e3732d3e591e9e2a0428eb157d3f6fb5b

Because tests didnt run in mkaply's branch I never caught it 😢 

