### PR TITLE
Bug 1436797 - XCUITest iPad Setting not to hide toolbar when scrolling

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
@@ -206,6 +206,15 @@
                   Identifier = "SiteLoadTest">
                </Test>
                <Test
+                  Identifier = "ToolbarTests/testShowDoNotShowToolbarWhenScrollingLandscape()">
+               </Test>
+               <Test
+                  Identifier = "ToolbarTests/testShowDoNotShowToolbarWhenScrollingPortrait()">
+               </Test>
+               <Test
+                  Identifier = "ToolbarTests/testShowToolbarWhenScrollingDefaultOption()">
+               </Test>
+               <Test
                   Identifier = "TopTabsTest/testCloseTabFromPageOptionsMenu()">
                </Test>
             </SkippedTests>

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -152,6 +152,8 @@ class Action {
     static let ToggleTrackingProtectionSettingPrivateOnly = "ToggleTrackingProtectionSettingPrivateOnly"
     static let ToggleTrackingProtectionSettingOff = "ToggleTrackingProtectionSettingOff"
 
+    static let ToggleShowToolbarWhenScrolling = "ToggleShowToolbarWhenScrolling"
+
     static let CloseTab = "CloseTab"
     static let CloseTabFromPageOptions = "CloseTabFromPageOptions"
     static let CloseTabFromTabTrayLongPressMenu = "CloseTabFromTabTrayLongPressMenu"
@@ -456,6 +458,10 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.tap(table.cells["TrackingProtection"], to: TrackingProtectionSettings)
         screenState.tap(table.cells["ShowTour"], to: ShowTourInSettings)
 
+        screenState.gesture(forAction: Action.ToggleShowToolbarWhenScrolling, if: "tablet == true") { UserState in
+            app.cells.switches["AlwaysShowToolbar"].tap()
+            app.buttons["Done"].tap()
+        }
         screenState.backAction = navigationControllerBackAction
     }
 

--- a/XCUITests/ToolbarTest.swift
+++ b/XCUITests/ToolbarTest.swift
@@ -7,6 +7,8 @@ import XCTest
 let website1: [String: String] = ["url": "www.mozilla.org", "label": "Internet for people, not profit — Mozilla", "value": "mozilla.org"]
 let website2 = "example.com"
 
+let PDFWebsite = ["url": "http://www.pdf995.com/samples/pdf.pdf"]
+
 class ToolbarTests: BaseTestCase {
     override func setUp() {
         super.setUp()
@@ -85,5 +87,65 @@ class ToolbarTests: BaseTestCase {
 
         let value = app.textFields["address"].value
         XCTAssertEqual(value as? String, "", "The url has not been removed correctly")
+    }
+
+    func testShowToolbarWhenScrollingDefaultOption() {
+        navigator.goto(SettingsScreen)
+        // Check that the setting is off by default
+        XCTAssertFalse(app.cells.switches["AlwaysShowToolbar"].isSelected)
+    }
+
+    func testShowDoNotShowToolbarWhenScrollingPortrait() {
+        XCUIDevice.shared().orientation = UIDeviceOrientation.portrait
+        // The toolbar should dissapear when scrolling up
+        navigator.openURL(PDFWebsite["url"]!)
+        waitUntilPageLoad()
+
+        // Swipe Up and check that the toolbar is not available and Down and it is available again
+        let toolbarElement = app.buttons["TopTabsViewController.tabsButton"]
+        let element = app/*@START_MENU_TOKEN@*/.webViews/*[[".otherElements[\"Web content\"].webViews",".otherElements[\"contentView\"].webViews",".webViews"],[[[-1,2],[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.children(matching: .other).element.children(matching: .other).element(boundBy: 0)
+        element.swipeUp()
+        XCTAssertFalse(toolbarElement.isHittable)
+
+        element.swipeDown()
+        XCTAssertTrue(toolbarElement.isHittable)
+
+        // Change the setting
+        navigator.goto(SettingsScreen)
+        navigator.performAction(Action.ToggleShowToolbarWhenScrolling)
+        XCTAssertTrue(toolbarElement.isHittable)
+
+        // The toolbar should not dissapear when scrolling up
+        element.swipeUp()
+        XCTAssertTrue(toolbarElement.isHittable)
+        element.swipeDown()
+        XCTAssertTrue(toolbarElement.isHittable)
+    }
+
+    func testShowDoNotShowToolbarWhenScrollingLandscape() {
+        // The toolbar should dissapear when scrolling up
+        navigator.openURL(PDFWebsite["url"]!)
+        waitUntilPageLoad()
+
+        // Swipe Up and check that the toolbar is not available and Down and it is available again
+        let toolbarElement = app.buttons["TopTabsViewController.tabsButton"]
+        let element = app/*@START_MENU_TOKEN@*/.webViews/*[[".otherElements[\"Web content\"].webViews",".otherElements[\"contentView\"].webViews",".webViews"],[[[-1,2],[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.children(matching: .other).element.children(matching: .other).element(boundBy: 0)
+        element.swipeUp()
+        XCTAssertFalse(toolbarElement.isHittable)
+
+        element.swipeDown()
+        XCTAssertTrue(toolbarElement.isHittable)
+
+        // Change the setting
+        navigator.goto(SettingsScreen)
+        navigator.performAction(Action.ToggleShowToolbarWhenScrolling)
+        XCTAssertTrue(toolbarElement.isHittable)
+        XCTAssertTrue(toolbarElement.isHittable)
+
+        // The toolbar should not dissapear when scrolling up
+        element.swipeUp()
+        XCTAssertTrue(toolbarElement.isHittable)
+        element.swipeDown()
+        XCTAssertTrue(toolbarElement.isHittable)
     }
 }


### PR DESCRIPTION
This PR is to add XCUITests that cover the new setting available for iPad, [Always Show Toolbar when Scrolling.](https://bugzilla.mozilla.org/show_bug.cgi?id=1299322)

