### PR TITLE
Bug 1413715 -- Make settings section titles respect to safe area

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -758,16 +758,20 @@ class SettingsTableSectionHeaderFooterView: UITableViewHeaderFooterView {
     }
 
     fileprivate func remakeTitleAlignmentConstraints() {
-        switch titleAlignment {
-        case .top:
-            titleLabel.snp.remakeConstraints { make in
+        titleLabel.snp.remakeConstraints { make in
+            if #available(iOS 11, *) {
+                make.left.equalTo(self.safeAreaLayoutGuide.snp.leftMargin).inset(SettingsTableSectionHeaderFooterViewUX.titleHorizontalPadding)
+                make.right.equalTo(self.safeAreaLayoutGuide.snp.rightMargin).inset(SettingsTableSectionHeaderFooterViewUX.titleHorizontalPadding)
+            } else {
                 make.left.right.equalTo(self).inset(SettingsTableSectionHeaderFooterViewUX.titleHorizontalPadding)
+            }
+
+            switch titleAlignment {
+            case .top:
                 make.top.equalTo(self).offset(SettingsTableSectionHeaderFooterViewUX.titleVerticalPadding)
                 make.bottom.equalTo(self).offset(-SettingsTableSectionHeaderFooterViewUX.titleVerticalLongPadding)
-            }
-        case .bottom:
-            titleLabel.snp.remakeConstraints { make in
-                make.left.right.equalTo(self).inset(SettingsTableSectionHeaderFooterViewUX.titleHorizontalPadding)
+
+            case .bottom:
                 make.bottom.equalTo(self).offset(-SettingsTableSectionHeaderFooterViewUX.titleVerticalPadding)
                 make.top.equalTo(self).offset(SettingsTableSectionHeaderFooterViewUX.titleVerticalLongPadding)
             }


### PR DESCRIPTION
## Why this PR needed?

It fixes "Bug 1413715" by making settings section titles respect to safe area layout guides.

It also seemed to me that makes sense to extract left & right constraint settings to out of switch statement since they does not depend on the title alignment.

## Screenshots

Before:

![simulator screen shot - iphone x - 2018-02-10 at 16 02 20](https://user-images.githubusercontent.com/1521998/36063368-3a05a8d0-0e7c-11e8-8102-3a4505bccc61.png)

After:

![simulator screen shot - iphone x - 2018-02-10 at 16 01 34](https://user-images.githubusercontent.com/1521998/36063367-39ecf920-0e7c-11e8-89c5-13561f1ebf7e.png)

## Notes for testing this patch

- Redirect to settings screen in landscape mode on iPhone X
