### PR TITLE
Bug 1437830 - UITest BB Failure due to timing check ListSelectAndDele…

### DIFF
--- a/UITests/LoginManagerTests.swift
+++ b/UITests/LoginManagerTests.swift
@@ -426,6 +426,7 @@ class LoginManagerTests: KIFTestCase {
         openLoginManager()
         
         var list = tester().waitForView(withAccessibilityIdentifier: "Login List") as! UITableView
+        tester().waitForAnimationsToFinish()
         let oldLoginCount = countOfRowsInTableView(list)
         
         tester().tapView(withAccessibilityLabel: "Edit")


### PR DESCRIPTION
…te test

The test is failing on BB only due to what seems a timing issue when doing the assertion because the variables do not have the correct value. 