### PR TITLE
Bug 1438128 - Fix XCUITest testDatabaseFixture failure on BB

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests_iPad.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests_iPad.xcscheme
@@ -176,43 +176,103 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "ActivityStreamTest">
+               </Test>
+               <Test
+                  Identifier = "AuthenticationTest">
+               </Test>
+               <Test
+                  Identifier = "BaseTestCase">
+               </Test>
+               <Test
+                  Identifier = "BookmarkingTests">
+               </Test>
+               <Test
+                  Identifier = "BrowsingPDFTests">
+               </Test>
+               <Test
+                  Identifier = "ClipBoardTests">
+               </Test>
+               <Test
+                  Identifier = "CopiedLinksTests">
+               </Test>
+               <Test
+                  Identifier = "DomainAutocompleteTest">
+               </Test>
+               <Test
+                  Identifier = "DragAndDropTests">
+               </Test>
+               <Test
+                  Identifier = "FindInPageTests">
+               </Test>
+               <Test
+                  Identifier = "FxScreenGraphTests">
+               </Test>
+               <Test
+                  Identifier = "HistoryTests">
+               </Test>
+               <Test
+                  Identifier = "HomePageSettingsTest">
+               </Test>
+               <Test
+                  Identifier = "HomePageSettingsUITests">
+               </Test>
+               <Test
                   Identifier = "HomePageUITest">
                </Test>
                <Test
-                  Identifier = "NavigationTest/testNavigationPreservesDesktopSiteOnSameHost()">
+                  Identifier = "MailAppSettingsTests">
                </Test>
                <Test
-                  Identifier = "NavigationTest/testReloadPreservesMobileOrDesktopSite()">
+                  Identifier = "NavigationTest">
                </Test>
                <Test
-                  Identifier = "NavigationTest/testScrollsToTopWithMultipleTabs()">
+                  Identifier = "NewTabSettingsTest">
                </Test>
                <Test
-                  Identifier = "NavigationTest/testToggleBetweenMobileAndDesktopSiteFromSite()">
+                  Identifier = "NightModeTests">
                </Test>
                <Test
-                  Identifier = "SearchTests/testDismissPromptPresence()">
+                  Identifier = "NoImageTests">
+               </Test>
+               <Test
+                  Identifier = "PhotonActionSheetTest">
+               </Test>
+               <Test
+                  Identifier = "PrivateBrowsingTest">
+               </Test>
+               <Test
+                  Identifier = "ReaderViewTest">
+               </Test>
+               <Test
+                  Identifier = "ScreenGraphTest">
+               </Test>
+               <Test
+                  Identifier = "SearchSettingsUITests">
+               </Test>
+               <Test
+                  Identifier = "SearchTests">
+               </Test>
+               <Test
+                  Identifier = "SettingsTest">
                </Test>
                <Test
                   Identifier = "SiteLoadTest">
                </Test>
                <Test
-                  Identifier = "TopTabsTest/testAddPrivateTabByLongPressTabsButton()">
+                  Identifier = "SyncUITests">
                </Test>
                <Test
-                  Identifier = "TopTabsTest/testAddTabByLongPressTabsButton()">
+                  Identifier = "ThirdPartySearchTest">
                </Test>
                <Test
-                  Identifier = "TopTabsTest/testCloseTabFromLongPressTabsButton()">
+                  Identifier = "ToolbarTests">
                </Test>
                <Test
-                  Identifier = "TopTabsTest/testCloseTabFromPageOptionsMenu()">
+                  Identifier = "TopTabsTest">
                </Test>
                <Test
-                  Identifier = "TopTabsTest/testSwitchBetweenTabsNoPrivatePrivateToastButton()">
-               </Test>
-               <Test
-                  Identifier = "TopTabsTest/testSwitchBetweenTabsToastButton()">
+                  Identifier = "TrackingProtectionTests">
                </Test>
             </SkippedTests>
          </TestableReference>

--- a/XCUITests/DatabaseFixtureTest.swift
+++ b/XCUITests/DatabaseFixtureTest.swift
@@ -12,8 +12,10 @@ class DatabaseFixtureTest: BaseTestCase {
         restart(app, args: [LaunchArguments.SkipIntro, LaunchArguments.SkipWhatsNew, arg])
 
         // app will now start with prepopulated database
-
+        navigator.nowAt(HomePanelsScreen)
+        waitforExistence(app.collectionViews.cells["TopSitesCell"])
         navigator.browserPerformAction(.openBookMarksOption)
+        waitforExistence(app.tables["Bookmarks List"])
         let list = app.tables["Bookmarks List"].cells.count
         XCTAssertEqual(list, 1, "There should be an entry in the bookmarks list")
     }


### PR DESCRIPTION
This test: testDatabaseFixture is failing only on BB
It might be a timing issue since we close the app and launch it again to continue with the checks that would be solved with this PR