### PR TITLE
Revert "Bug 1299322 - iPad-only setting to always show the toolbars (#3638)

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -549,8 +549,6 @@ class BrowserViewController: UIViewController {
         screenshotHelper.viewIsVisible = true
         screenshotHelper.takePendingScreenshots(tabManager.tabs)
 
-        scrollController.updateAlwaysShowToolbarsSetting(prefs: profile.prefs)
-
         super.viewDidAppear(animated)
 
         if shouldShowWhatsNewTab() {

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -74,15 +74,6 @@ class AppSettingsTableViewController: SettingsTableViewController {
             ]
         }
 
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            generalSettings += [
-                BoolSetting(prefs: prefs, prefKey: PrefsKeys.AlwaysShowToolbar, defaultValue: false, titleText: Strings.SettingsAlwaysShowToolbar, settingDidChange: { _ in
-                    let appDelegate = UIApplication.shared.delegate as? AppDelegate
-                    appDelegate?.browserViewController.scrollController.updateAlwaysShowToolbarsSetting(prefs: prefs)
-                })
-            ]
-        }
-
         var accountSectionTitle: NSAttributedString?
         if AppConstants.MOZ_SHOW_FXA_AVATAR {
             accountSectionTitle = NSAttributedString(string: Strings.FxAFirefoxAccount)

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -89,7 +89,6 @@ extension Strings {
     public static let SettingsSearchEditButton = NSLocalizedString("Settings.Search.Edit.Button", value: "Edit", comment: "Button displayed at the top of the search settings.")
     public static let UseTouchID = NSLocalizedString("Use Touch ID", tableName: "AuthenticationManager", comment: "List section title for when to use Touch ID")
     public static let UseFaceID = NSLocalizedString("Use Face ID", tableName: "AuthenticationManager", comment: "List section title for when to use Face ID")
-    public static let SettingsAlwaysShowToolbar = NSLocalizedString("Settings.General.AlwaysShowToolbar", value: "Always Show Toolbars When Scrolling", comment: "iPad-only settings on/off option to never hide the toolbars when scrolling a web page.")
 }
 
 // Error pages.

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -15,7 +15,6 @@ public struct PrefsKeys {
     public static let HasFocusInstalled = "HasFocusInstalled"
     public static let HasPocketInstalled = "HasPocketInstalled"
     public static let IntroSeen = "IntroViewControllerSeen"
-    public static let AlwaysShowToolbar = "AlwaysShowToolbar"
 
     //Activity Stream
     public static let KeyTopSitesCacheIsValid = "topSitesCacheIsValid"


### PR DESCRIPTION
#3638

This reverts commit 9e0c46607a5f6c24f64fc59d01dd9742e0c3419e.

https://bugzilla.mozilla.org/show_bug.cgi?id=1299322
