### PR TITLE
Bug 1437500 - Make sure that the IntroVC does its initial setup before the slides are created

### DIFF
--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -168,6 +168,10 @@ class IntroViewController: UIViewController {
     }
 
     func createSlides() {
+        // Make sure the scrollView has been setup before setting up the slides
+        guard scrollView.superview != nil else {
+            return
+        }
         // Wipe any existing slides
         imageViewContainer.subviews.forEach { $0.removeFromSuperview() }
         cardViews.forEach { $0.removeFromSuperview() }


### PR DESCRIPTION
Sometimes, When Leanplum is super quick (Its already loaded, when you access via settings for example) we can try creating slides before the inital setup of the scrollView has been done. 

Simply check to make sure the scrollView has been setup, once it has `createSlides` will be called again