### PR TITLE
Bug 1438630 - Disable XCUITests Show Toolbar Setting

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests_iPad.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests_iPad.xcscheme
@@ -218,6 +218,15 @@
                   Identifier = "SiteLoadTest">
                </Test>
                <Test
+                  Identifier = "ToolbarTests/testShowDoNotShowToolbarWhenScrollingLandscape()">
+               </Test>
+               <Test
+                  Identifier = "ToolbarTests/testShowDoNotShowToolbarWhenScrollingPortrait()">
+               </Test>
+               <Test
+                  Identifier = "ToolbarTests/testShowToolbarWhenScrollingDefaultOption()">
+               </Test>
+               <Test
                   Identifier = "TopTabsTest/testAddPrivateTabByLongPressTabsButton()">
                </Test>
                <Test


### PR DESCRIPTION
This PR is for disabling tests related to the iPad option in settings Always show toolbar that has been removed