### PR TITLE
Bug 1439714 - Testing: Enable Debug Menu Option Use Stage Server by d…

### DIFF
--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -53,6 +53,10 @@ class TestAppDelegate: AppDelegate {
             profile.prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
         }
 
+        if launchArguments.contains(LaunchArguments.StageServer) {
+            profile.prefs.setInt(1, forKey: PrefsKeys.UseStageServer)
+        }
+
         self.profile = profile
         return profile
     }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -583,6 +583,8 @@ class ForceCrashSetting: HiddenSetting {
 class VersionSetting: Setting {
     unowned let settings: SettingsTableViewController
 
+     override var accessibilityIdentifier: String? { return "FxVersion" }
+
     init(settings: SettingsTableViewController) {
         self.settings = settings
         super.init(title: nil)
@@ -928,6 +930,8 @@ class StageSyncServiceDebugSetting: WithoutAccountSetting {
     var prefs: Prefs { return settings.profile.prefs }
 
     var prefKey: String = "useStageSyncService"
+
+    override var accessibilityIdentifier: String? { return "DebugStageSync" }
 
     override var hidden: Bool {
         if !ShowDebugSettings {

--- a/Shared/LaunchArguments.swift
+++ b/Shared/LaunchArguments.swift
@@ -9,6 +9,7 @@ public struct LaunchArguments {
     public static let SkipIntro = "FIREFOX_SKIP_INTRO"
     public static let SkipWhatsNew = "FIREFOX_SKIP_WHATS_NEW"
     public static let ClearProfile = "FIREFOX_CLEAR_PROFILE"
+    public static let StageServer = "FIREFOX_USE_STAGE_SERVER"
     
     // After the colon, put the name of the file to load from test bundle
     public static let LoadDatabasePrefix = "FIREFOX_LOAD_DB_NAMED:"

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -31,6 +31,7 @@ public struct PrefsKeys {
     public static let KeyCustomSyncOauth = "customSyncOauthServer"
     public static let KeyCustomSyncAuth = "customSyncAuthServer"
     public static let KeyCustomSyncWeb = "customSyncWebServer"
+    public static let UseStageServer = "useStageSyncService"
     
 }
 


### PR DESCRIPTION
…efault using LaunchArguments

This PR is to implement LaunchArguments so that it debug options can be enabled by default when launching XCUITests. In particular this PR is for enabling the Stage Server option

Also, there are two new accessibility identifiers added.
- for the Version option in Settings menu so that it can be easy access de debug menu 
- for the Use Stage Server toggle so that it can be disabled if needed too easily