### PR TITLE
Bug 1440728 - Remove the Tools menu from the Page Actions menu. 

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -451,7 +451,6 @@ extension Strings {
     public static let AppMenuRemoveBookmarkConfirmMessage = NSLocalizedString("Menu.RemoveBookmark.Confirm", value: "Bookmark Removed", comment: "Toast displayed to the user after a bookmark has been removed.")
     public static let AppMenuAddToReadingListConfirmMessage = NSLocalizedString("Menu.AddToReadingList.Confirm", value: "Added To Reading List", comment: "Toast displayed to the user after adding the item to their reading list.")
     public static let SendToDeviceTitle = NSLocalizedString("Send to Device", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to send the current tab to another device")
-    public static let AppMenuToolsTitleString = NSLocalizedString("Menu.ToolsAction.Title", value: "Tools", comment: "Label for the button, displayed in the menu, used to navigate to the tools sub-menu")
 }
 
 // Snackbar shown when tapping app store link

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -213,10 +213,6 @@ extension PhotonActionSheetProtocol {
 
         var mainActions = [share]
 
-        let toolsAction = PhotonActionSheetItem(title: Strings.AppMenuToolsTitleString, iconString: "menu-Tools", accessory: .Disclosure) { _ in
-            self.presentSheetWith(title: Strings.AppMenuToolsTitleString, actions: [[findInPageAction, toggleDesktopSite, pinToTopSites]], on: presentableVC, from: buttonView)
-        }
-
         // Disable bookmarking and reading list if the URL is too long.
         if !tab.urlIsTooLong {
             mainActions.append(isBookmarked ? removeBookmark : bookmarkPage)
@@ -228,7 +224,7 @@ extension PhotonActionSheetProtocol {
 
         mainActions.append(contentsOf: [sendToDevice, copyURL])
 
-        return [mainActions, [toolsAction]]
+        return [mainActions, [findInPageAction, toggleDesktopSite, pinToTopSites]]
     }
 
     func fetchBookmarkStatus(for url: String) -> Deferred<Maybe<Bool>> {


### PR DESCRIPTION
The menu didnt seem very useful. we can bring it back later if we add more items to the Page Actions Menu. 