### PR TITLE
Bug 1440989 - XCUITests Adapt tests to Tools menu deletion

### DIFF
--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -105,8 +105,7 @@ class ActivityStreamTest: BaseTestCase {
 
     func testTopSitesRemoveAllExceptPinnedClearPrivateData() {
         navigator.goto(BrowserTab)
-        navigator.browserPerformAction(.pinToTopSitesOption)
-        navigator.nowAt(BrowserTab)
+        navigator.performAction(Action.PinToTopSitesPAM)
         navigator.goto(HomePanelsScreen)
         waitforExistence(app.collectionViews.cells[newTopSite["topSiteLabel"]!])
         XCTAssertTrue(app.collectionViews.cells[newTopSite["topSiteLabel"]!].exists)

--- a/XCUITests/BrowsingPDFTests.swift
+++ b/XCUITests/BrowsingPDFTests.swift
@@ -91,8 +91,7 @@ class BrowsingPDFTests: BaseTestCase {
     func testPinPDFtoTopSites() {
         navigator.openURL(PDF_website["url"]!)
         waitUntilPageLoad()
-        navigator.browserPerformAction(.pinToTopSitesOption)
-        navigator.nowAt(BrowserTab)
+        navigator.performAction(Action.PinToTopSitesPAM)
         navigator.goto(NewTabScreen)
         waitforExistence(app.collectionViews.cells["TopSitesCell"].cells["pdf995"])
         XCTAssertTrue(app.collectionViews.cells["TopSitesCell"].cells["pdf995"].exists)

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -788,15 +788,9 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     // make sure after the menu action, navigator.nowAt() is used to set the current state
     map.addScreenState(PageOptionsMenu) {screenState in
-        screenState.tap(app.tables["Context Menu"].cells["menu-Tools"], to: ToolsMenu)
+        screenState.tap(app.tables["Context Menu"].cells["menu-FindInPage"], to: FindInPage)
         screenState.tap(app.tables["Context Menu"].cells["menu-Bookmark"], forAction: Action.BookmarkThreeDots, Action.Bookmark)
         screenState.tap(app.tables["Context Menu"].cells["action_remove"], forAction: Action.CloseTabFromPageOptions, Action.CloseTab, transitionTo: HomePanelsScreen, if: "tablet != true")
-        screenState.backAction = cancelBackAction
-        screenState.dismissOnUse = true
-    }
-
-    map.addScreenState(ToolsMenu) { screenState in
-        screenState.tap(app.tables.cells["menu-FindInPage"], to: FindInPage)
         screenState.tap(app.tables.cells["action_pin"], forAction: Action.PinToTopSitesPAM)
         screenState.backAction = cancelBackAction
         screenState.dismissOnUse = true
@@ -871,17 +865,13 @@ extension MMNavigator where T == FxUserState {
     }
 
     func browserPerformAction(_ view: BrowserPerformAction) {
-        let PageMenuOptions = [.shareOption, .toggleBookmarkOption, .addReadingListOption, .findInPageOption, .sendToDeviceOption, BrowserPerformAction.copyURLOption]
-        let ToolsMenuOptions = [.findInPageOption, .toggleDesktopOption, BrowserPerformAction.pinToTopSitesOption]
+        let PageMenuOptions = [.shareOption, .toggleBookmarkOption, .addReadingListOption, .findInPageOption, .sendToDeviceOption, .toggleDesktopOption, BrowserPerformAction.copyURLOption]
         let BrowserMenuOptions = [.openTopSitesOption, .openBookMarksOption, .openReadingListOption, .openHistoryOption, .toggleHideImages, .toggleNightMode, BrowserPerformAction.openSettingsOption]
 
         let app = XCUIApplication()
 
         if PageMenuOptions.contains(view) {
             self.goto(PageOptionsMenu)
-            app.tables["Context Menu"].cells[view.rawValue].tap()
-        } else if ToolsMenuOptions.contains(view) {
-            self.goto(ToolsMenu)
             app.tables["Context Menu"].cells[view.rawValue].tap()
         } else if BrowserMenuOptions.contains(view) {
             self.goto(BrowserTabMenu)

--- a/XCUITests/NavigationTest.swift
+++ b/XCUITests/NavigationTest.swift
@@ -202,14 +202,14 @@ class NavigationTest: BaseTestCase {
 
     private func checkMobileSite() {
         navigator.nowAt(BrowserTab)
-        navigator.goto(ToolsMenu)
+        navigator.goto(PageOptionsMenu)
         waitforExistence(app.tables.cells["menu-RequestDesktopSite"].staticTexts[requestDesktopSiteLabel])
         navigator.goto(BrowserTab)
     }
     
     private func checkDesktopSite() {
         navigator.nowAt(BrowserTab)
-        navigator.goto(ToolsMenu)
+        navigator.goto(PageOptionsMenu)
         waitforExistence(app.tables.cells["menu-RequestDesktopSite"].staticTexts[requestMobileSiteLabel])
         navigator.goto(BrowserTab)
     }


### PR DESCRIPTION
Tests that covered or used the tool menu are failing due to its deletion. This PR is to fix those:
-ActivityStreamTets:
testTopSitesRemoveAllExceptPinnedClearPrivateData
-BrowsingPDFTests:
testPinPDFtoTopSites()
-FindInPageTests
testBarDissapearsWhenOpeningTabsTr
testBarDissapearsWhenReloading()
testFindFromMenu()
testQueryWithNoMatches()
-NavigationTest
testToggleBetweenMobileAndDesktopSi
-PhotonActionSheetTest
testPinToTop()