### PR TITLE
Bug 1436025 — Keyboard: enable goForward from the home panels.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -9,26 +9,26 @@ import Shared
 extension BrowserViewController {
 
     @objc private func reloadTabKeyCommand() {
-        if homePanelController == nil {
-            tabManager.selectedTab?.reload()
+        if let tab = tabManager.selectedTab, homePanelController == nil {
+            tab.reload()
         }
     }
 
     @objc private func goBackKeyCommand() {
-        if tabManager.selectedTab?.canGoBack == true && homePanelController == nil {
-            tabManager.selectedTab?.goBack()
+        if let tab = tabManager.selectedTab, tab.canGoBack, homePanelController == nil {
+            tab.goBack()
         }
     }
 
     @objc private func goForwardKeyCommand() {
-        if tabManager.selectedTab?.canGoForward == true && homePanelController == nil {
-            tabManager.selectedTab?.goForward()
+        if let tab = tabManager.selectedTab, tab.canGoForward {
+            tab.goForward()
         }
     }
 
     @objc private func findOnPageKeyCommand() {
-        if homePanelController == nil {
-            tab( (tabManager.selectedTab)!, didSelectFindInPageForSelection: "")
+        if let tab = tabManager.selectedTab, homePanelController == nil {
+            self.tab(tab, didSelectFindInPageForSelection: "")
         }
     }
 


### PR DESCRIPTION
This PR re-enables the forward button from the keyboard when the user is on the home panel.

https://bugzilla.mozilla.org/show_bug.cgi?id=1436025