### PR TITLE
Bug 1418103 - Make sure autocomplete suggestions update when removing text

### DIFF
--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -74,9 +74,10 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
                     // First, see if the query matches any URLs from the user's search history.
                     self.load(cursor)
                     for site in cursor {
-                        if let url = site?.url,
-                               let completion = self.completionForURL(url) {
-                            self.urlBar.setAutocompleteSuggestion(completion)
+                        if let url = site?.url, let completion = self.completionForURL(url) {
+                            if oldValue.count < self.query.count {
+                                self.urlBar.setAutocompleteSuggestion(completion)
+                            }
                             return
                         }
                     }
@@ -84,7 +85,9 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
                     // If there are no search history matches, try matching one of the Alexa top domains.
                     for domain in self.topDomains {
                         if let completion = self.completionForDomain(domain) {
-                            self.urlBar.setAutocompleteSuggestion(completion)
+                            if oldValue.count < self.query.count {
+                                self.urlBar.setAutocompleteSuggestion(completion)
+                            }
                             return
                         }
                     }

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -247,8 +247,8 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         removeCompletion()
 
         let isAtEnd = selectedTextRange?.start == endOfDocument
-        let isEmpty = lastReplacement?.isEmpty ?? true
-        if !isEmpty, isAtEnd, markedTextRange == nil {
+        let isKeyboardReplacingText = lastReplacement != nil
+        if isKeyboardReplacingText, isAtEnd, markedTextRange == nil {
             notifyTextChanged?()
         } else {
             hideCursor = false
@@ -264,7 +264,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     }
 
     override func deleteBackward() {
-        lastReplacement = nil
+        lastReplacement = ""
         hideCursor = false
         if isSelectionActive {
             removeCompletion()


### PR DESCRIPTION
This will also show the home panels once all the text is removed. 

@justindarc This is the same patch as https://github.com/mozilla-mobile/firefox-ios/pull/3470 I just did some cleanup based on your comments. 