### PR TITLE
Bug 1442758 - SiteTableViewHeader alignment should be natural

### DIFF
--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -35,7 +35,6 @@ class SiteTableViewHeader: UITableViewHeaderFooterView {
 
         titleLabel.font = DynamicFontHelper.defaultHelper.DeviceFontMediumBold
         titleLabel.textColor = SiteTableViewControllerUX.HeaderTextColor
-        titleLabel.textAlignment = .left
 
         addSubview(topBorder)
         addSubview(bottomBorder)


### PR DESCRIPTION
This leaves the alignment of the SiteTableViewHeader to default, which is `.natural`. This will do the right thing on either LTR or RTL.