### PR TITLE
Bug 1442806 - BookmarkFolderTableViewHeader needs RTL layout

### DIFF
--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -555,14 +555,14 @@ fileprivate class BookmarkFolderTableViewHeader: UITableViewHeaderFooterView {
         contentView.addSubview(titleLabel)
 
         chevron.snp.makeConstraints { make in
-            make.left.equalTo(contentView).offset(BookmarksPanelUX.BookmarkFolderHeaderViewChevronInset)
+            make.leading.equalTo(contentView).offset(BookmarksPanelUX.BookmarkFolderHeaderViewChevronInset)
             make.centerY.equalTo(contentView)
             make.size.equalTo(BookmarksPanelUX.BookmarkFolderChevronSize)
         }
 
         titleLabel.snp.makeConstraints { make in
-            make.left.equalTo(chevron.snp.right).offset(BookmarksPanelUX.BookmarkFolderHeaderViewChevronInset)
-            make.right.greaterThanOrEqualTo(contentView).offset(-BookmarksPanelUX.BookmarkFolderHeaderViewChevronInset)
+            make.leading.equalTo(chevron.snp.trailing).offset(BookmarksPanelUX.BookmarkFolderHeaderViewChevronInset)
+            make.trailing.greaterThanOrEqualTo(contentView).offset(-BookmarksPanelUX.BookmarkFolderHeaderViewChevronInset)
             make.centerY.equalTo(contentView)
         }
 


### PR DESCRIPTION
Small constraint tweaks to get the title and chevron in the right order/alignment.

This is about the top blue header:

![screen shot 2018-03-02 at 6 54 59 pm](https://user-images.githubusercontent.com/28052/36927492-edd57fb4-1e4b-11e8-9efa-1d544e116a37.png)
