### PR TITLE
Bug 1442807 - TwoLineCell needs RTL Layout

### DIFF
--- a/Client/Frontend/Widgets/TwoLineCell.swift
+++ b/Client/Frontend/Widgets/TwoLineCell.swift
@@ -51,7 +51,7 @@ class TwoLineTableViewCell: UITableViewCell {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        twoLineHelper.layoutSubviews()
+        twoLineHelper.layoutSubviews(accessoryWidth: self.contentView.frame.origin.x)
     }
 
     override func prepareForReuse() {
@@ -199,7 +199,7 @@ private class TwoLineCellHelper {
         detailTextLabel.font = DynamicFontHelper.defaultHelper.SmallSizeRegularWeightAS
     }
 
-    func layoutSubviews() {
+    func layoutSubviews(accessoryWidth: CGFloat = 0) {
         guard let container = self.container else {
             return
         }
@@ -214,11 +214,28 @@ private class TwoLineCellHelper {
 
         let textRightInset: CGFloat = hasRightBadge ? (TwoLineCellUX.BadgeSize + TwoLineCellUX.BadgeMargin) : 0
 
-        imageView.frame = CGRect(x: TwoLineCellUX.BorderViewMargin, y: (height - TwoLineCellUX.ImageSize) / 2, width: TwoLineCellUX.ImageSize, height: TwoLineCellUX.ImageSize)
         textLabel.frame = CGRect(x: textLeft, y: (height - contentHeight) / 2,
-            width: container.frame.width - textLeft - TwoLineCellUX.BorderViewMargin - textRightInset, height: textLabelHeight)
+                                 width: container.frame.width - textLeft - TwoLineCellUX.BorderViewMargin - textRightInset, height: textLabelHeight)
         detailTextLabel.frame = CGRect(x: textLeft, y: textLabel.frame.maxY + TwoLineCellUX.DetailTextTopMargin,
-            width: container.frame.width - textLeft - TwoLineCellUX.BorderViewMargin - textRightInset, height: detailTextLabelHeight)
+                                       width: container.frame.width - textLeft - TwoLineCellUX.BorderViewMargin - textRightInset, height: detailTextLabelHeight)
+
+        // Like the comment above, this is not ideal. This code should probably be refactored to use autolayout. That will remove a lot of the pixel math and remove code duplication.
+
+        if UIApplication.shared.userInterfaceLayoutDirection == .leftToRight {
+            imageView.frame = CGRect(x: TwoLineCellUX.BorderViewMargin, y: (height - TwoLineCellUX.ImageSize) / 2, width: TwoLineCellUX.ImageSize, height: TwoLineCellUX.ImageSize)
+        } else {
+            imageView.frame = CGRect(x: container.frame.width - TwoLineCellUX.ImageSize - TwoLineCellUX.BorderViewMargin, y: (height - TwoLineCellUX.ImageSize) / 2, width: TwoLineCellUX.ImageSize, height: TwoLineCellUX.ImageSize)
+
+            textLabel.frame = textLabel.frame.offsetBy(dx: -(TwoLineCellUX.ImageSize + TwoLineCellUX.BorderViewMargin), dy: 0)
+            detailTextLabel.frame = detailTextLabel.frame.offsetBy(dx: -(TwoLineCellUX.ImageSize + TwoLineCellUX.BorderViewMargin), dy: 0)
+
+            // If the cell has an accessory, shift them all to the left even more. Only required on RTL.
+            if accessoryWidth != 0 {
+                imageView.frame = imageView.frame.offsetBy(dx: -accessoryWidth, dy: 0)
+                textLabel.frame = textLabel.frame.offsetBy(dx: -accessoryWidth, dy: 0)
+                detailTextLabel.frame = detailTextLabel.frame.offsetBy(dx: -accessoryWidth, dy: 0)
+            }
+        }
     }
 
     func setLines(_ text: String?, detailText: String?) {


### PR DESCRIPTION
I'm the first to admit that these RTL fixes are not the greatest. Ideally we do not have conditional code to do LTR vs RTL layouts, but because the way the TwoLineCell and TwoLineCellHelper are setup currently, it is hard to avoid. It is strongly suggested that we clean up this code in a later version, ideally replacing the manual calculations with autolayout.

Below you can see the result of these changes. Both regular cells and cells with a disclosure accessory render properly now.

![screen shot 2018-03-02 at 7 04 53 pm](https://user-images.githubusercontent.com/28052/36927627-a0fcdb96-1e4c-11e8-8f9c-c4b6dab55bc3.png)
