### PR TITLE
Bug 1442832 - SiteTableViewCell overflows in RTL

### DIFF
--- a/Client/Frontend/Widgets/TwoLineCell.swift
+++ b/Client/Frontend/Widgets/TwoLineCell.swift
@@ -105,7 +105,7 @@ class SiteTableViewCell: TwoLineTableViewCell {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        twoLineHelper.layoutSubviews()
+        twoLineHelper.layoutSubviews(accessoryWidth: self.contentView.frame.origin.x)
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
This patch makes sure that the `SiteTableViewCell` takes the optional `accessoryView` into account. It is unfortunate that we have to pass this in via `TwoLineCellHelper.layoutSubviews(accessoryWidth:)` but at time of creation of the `TwoLineCellHelper` is is not clear yet that a `accessoryView` is set on the `UITableViewCell` and the `TwoLineCellHelper` has no way to figure it out by itself since it has no access to the `UITableViewCell` that it is going to layout.

This whole `TwoLineCellHelper` thing needs to be dumped. I think it will be much cleaner to simply have that logic in our `UITableViewCell` implementations. Even if that means a little bit of code duplication.

This patch affects the top two rows in the screenshot below:

 
![screen shot 2018-03-02 at 9 55 35 pm](https://user-images.githubusercontent.com/28052/36929840-820f6646-1e64-11e8-82ff-ceb095332a56.png)
