### PR TITLE
Bug 1270940 - AutocompleteTextField RTL Compatibility

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -235,6 +235,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             shouldPerformAdditionalDelegateHandling = false
         }
 
+        // Force the ToolbarTextField in LTR mode - without this change the UITextField's clear
+        // button will be in the incorrect position and overlap with the input text. Not clear if
+        // that is an iOS bug or not.
+        AutocompleteTextField.appearance().semanticContentAttribute = .forceLeftToRight
+
         return shouldPerformAdditionalDelegateHandling
     }
 

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -322,6 +322,7 @@ class URLBarView: UIView {
         locationTextField.autocapitalizationType = .none
         locationTextField.returnKeyType = .go
         locationTextField.clearButtonMode = .whileEditing
+        locationTextField.textAlignment = .left
         locationTextField.font = UIConstants.DefaultChromeFont
         locationTextField.accessibilityIdentifier = "address"
         locationTextField.accessibilityLabel = NSLocalizedString("Address and Search", comment: "Accessibility label for address and search field, both words (Address, Search) are therefore nouns.")

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -207,6 +207,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         label.accessibilityIdentifier = "autocomplete"
         label.backgroundColor = self.backgroundColor
         label.textColor = self.textColor
+        label.textAlignment = .left
 
         let enteredTextSize = self.attributedText?.boundingRect(with: self.frame.size, options: NSStringDrawingOptions.usesLineFragmentOrigin, context: nil)
         frame.origin.x = (enteredTextSize?.width.rounded() ?? 0)


### PR DESCRIPTION
This patch gives us Safari parity for RTL input in our location text field:

- When not in edit mode, the text is aligned right
- When in edit mode, the field works as in LTR mode, even if an RTL language is used to enter text
- The clear button stays on the right side
- Our autocomplete works as expected

I have only tested this throughly on iOS 11. In the bug i've asked QA to test this on iOS 10 too. Should be good 🤞 


![screen shot 2018-03-04 at 11 19 22 am](https://user-images.githubusercontent.com/28052/36947748-156f6fbe-1f9e-11e8-9ec4-3847e8a2848f.png)

![screen shot 2018-03-04 at 11 19 34 am](https://user-images.githubusercontent.com/28052/36947749-19015f52-1f9e-11e8-8f24-97ea1ac17cb9.png)

![screen shot 2018-03-04 at 11 19 41 am](https://user-images.githubusercontent.com/28052/36947751-1b52a48c-1f9e-11e8-9ef7-3027d7a06891.png)

![screen shot 2018-03-04 at 11 19 51 am](https://user-images.githubusercontent.com/28052/36947752-1d8d95e0-1f9e-11e8-906e-aa40ffe789b2.png)

![screen shot 2018-03-04 at 11 20 17 am](https://user-images.githubusercontent.com/28052/36947753-1fc0d6f6-1f9e-11e8-83aa-8c64d2a8f6f0.png)
