### PR TITLE
Bug 1433475 — Keyboard — enable up and down arrows in location bar.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1753,6 +1753,7 @@ extension BrowserViewController: SearchViewControllerDelegate {
     }
 
     func searchViewControllerDidFinishHighlighting(_ searchViewController: SearchViewController) {
+        searchViewController.resignFirstResponder()
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1753,7 +1753,9 @@ extension BrowserViewController: SearchViewControllerDelegate {
     }
 
     func searchViewControllerDidFinishHighlighting(_ searchViewController: SearchViewController) {
-        searchViewController.resignFirstResponder()
+        let text = searchViewController.searchQuery
+        self.urlBar.setLocation(text, search: false)
+        self.urlBar.enterOverlayMode(text, pasted: true, search: true)
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1752,9 +1752,7 @@ extension BrowserViewController: SearchViewControllerDelegate {
         self.urlBar.setLocation(text, search: search)
     }
 
-    func searchViewControllerDidFinishHighlighting(_ searchViewController: SearchViewController) {
-        let text = searchViewController.searchQuery
-        self.urlBar.setLocation(text, search: false)
+    func searchViewController(_ searchViewController: SearchViewController, didFinalizeText text: String) {
         self.urlBar.enterOverlayMode(text, pasted: true, search: true)
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1751,10 +1751,6 @@ extension BrowserViewController: SearchViewControllerDelegate {
     func searchViewController(_ searchViewController: SearchViewController, didHighlightText text: String, search: Bool) {
         self.urlBar.setLocation(text, search: search)
     }
-
-    func searchViewController(_ searchViewController: SearchViewController, didFinalizeText text: String) {
-        self.urlBar.enterOverlayMode(text, pasted: true, search: true)
-    }
 }
 
 extension BrowserViewController: TabManagerDelegate {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1747,6 +1747,13 @@ extension BrowserViewController: SearchViewControllerDelegate {
 
         self.present(navController, animated: true, completion: nil)
     }
+
+    func searchViewController(_ searchViewController: SearchViewController, didHighlightText text: String, search: Bool) {
+        self.urlBar.setLocation(text, search: search)
+    }
+
+    func searchViewControllerDidFinishHighlighting(_ searchViewController: SearchViewController) {
+    }
 }
 
 extension BrowserViewController: TabManagerDelegate {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -47,7 +47,7 @@ class BrowserViewController: UIViewController {
     let webViewContainerToolbar = UIView()
     var statusBarOverlay: UIView!
     fileprivate(set) var toolbar: TabToolbar?
-    fileprivate var searchController: SearchViewController?
+    var searchController: SearchViewController?
     fileprivate var screenshotHelper: ScreenshotHelper!
     fileprivate var homePanelIsInline = false
     fileprivate var searchLoader: SearchLoader?

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -81,7 +81,20 @@ extension BrowserViewController {
         showTabTray()
     }
 
+    @objc private func awesomeBarItemKeyCommand(sender: UIKeyCommand) {
+        guard let searchController = self.searchController else {
+            return
+        }
+
+        searchController.handleKeyCommands(sender: sender)
+    }
+
+
     override var keyCommands: [UIKeyCommand]? {
+        let overlayCommands = [
+            UIKeyCommand(input: UIKeyInputDownArrow, modifierFlags: [], action: #selector(awesomeBarItemKeyCommand(sender:))),
+            UIKeyCommand(input: UIKeyInputUpArrow, modifierFlags: [], action: #selector(awesomeBarItemKeyCommand(sender:))),
+        ]
         let overidesTextEditing = [
             UIKeyCommand(input: UIKeyInputRightArrow, modifierFlags: [.command, .shift], action: #selector(nextTabKeyCommand)),
             UIKeyCommand(input: UIKeyInputLeftArrow, modifierFlags: [.command, .shift], action: #selector(previousTabKeyCommand)),
@@ -111,7 +124,9 @@ extension BrowserViewController {
 
         let isEditingText = tabManager.selectedTab?.isEditing ?? false
 
-        if isEditingText || urlBar.inOverlayMode {
+        if urlBar.inOverlayMode {
+            return tabNavigation + overlayCommands
+        } else if isEditingText {
             return tabNavigation
         } else {
             return tabNavigation + overidesTextEditing

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -86,6 +86,7 @@ extension BrowserViewController {
             return
         }
 
+        searchController.becomeFirstResponder()
         searchController.handleKeyCommands(sender: sender)
     }
 
@@ -93,7 +94,6 @@ extension BrowserViewController {
     override var keyCommands: [UIKeyCommand]? {
         let overlayCommands = [
             UIKeyCommand(input: UIKeyInputDownArrow, modifierFlags: [], action: #selector(awesomeBarItemKeyCommand(sender:))),
-            UIKeyCommand(input: UIKeyInputUpArrow, modifierFlags: [], action: #selector(awesomeBarItemKeyCommand(sender:))),
         ]
         let overidesTextEditing = [
             UIKeyCommand(input: UIKeyInputRightArrow, modifierFlags: [.command, .shift], action: #selector(nextTabKeyCommand)),

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -81,7 +81,7 @@ extension BrowserViewController {
         showTabTray()
     }
 
-    @objc private func awesomeBarItemKeyCommand(sender: UIKeyCommand) {
+    @objc private func initiateLocationSelectionKeyCommand(sender: UIKeyCommand) {
         guard let searchController = self.searchController else {
             return
         }
@@ -92,7 +92,7 @@ extension BrowserViewController {
 
     override var keyCommands: [UIKeyCommand]? {
         let overlayCommands = [
-            UIKeyCommand(input: UIKeyInputDownArrow, modifierFlags: [], action: #selector(awesomeBarItemKeyCommand(sender:))),
+            UIKeyCommand(input: UIKeyInputDownArrow, modifierFlags: [], action: #selector(initiateLocationSelectionKeyCommand(sender:))),
         ]
         let overidesTextEditing = [
             UIKeyCommand(input: UIKeyInputRightArrow, modifierFlags: [.command, .shift], action: #selector(nextTabKeyCommand)),
@@ -123,7 +123,7 @@ extension BrowserViewController {
 
         let isEditingText = tabManager.selectedTab?.isEditing ?? false
 
-        if urlBar.inOverlayMode && searchController?.isCellHighlighted != true {
+        if urlBar.inOverlayMode {
             return tabNavigation + overlayCommands
         } else if !isEditingText {
             return tabNavigation + overidesTextEditing

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -90,7 +90,6 @@ extension BrowserViewController {
         searchController.handleKeyCommands(sender: sender)
     }
 
-
     override var keyCommands: [UIKeyCommand]? {
         let overlayCommands = [
             UIKeyCommand(input: UIKeyInputDownArrow, modifierFlags: [], action: #selector(awesomeBarItemKeyCommand(sender:))),
@@ -124,12 +123,11 @@ extension BrowserViewController {
 
         let isEditingText = tabManager.selectedTab?.isEditing ?? false
 
-        if urlBar.inOverlayMode {
+        if urlBar.inOverlayMode && searchController?.isCellHighlighted != true {
             return tabNavigation + overlayCommands
-        } else if isEditingText {
-            return tabNavigation
-        } else {
+        } else if !isEditingText {
             return tabNavigation + overidesTextEditing
         }
+        return tabNavigation
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -81,18 +81,18 @@ extension BrowserViewController {
         showTabTray()
     }
 
-    @objc private func initiateLocationSelectionKeyCommand(sender: UIKeyCommand) {
+    @objc private func moveURLCompletionKeyCommand(sender: UIKeyCommand) {
         guard let searchController = self.searchController else {
             return
         }
 
-        searchController.becomeFirstResponder()
         searchController.handleKeyCommands(sender: sender)
     }
 
     override var keyCommands: [UIKeyCommand]? {
-        let overlayCommands = [
-            UIKeyCommand(input: UIKeyInputDownArrow, modifierFlags: [], action: #selector(initiateLocationSelectionKeyCommand(sender:))),
+        let searchLocationCommands = [
+            UIKeyCommand(input: UIKeyInputDownArrow, modifierFlags: [], action: #selector(moveURLCompletionKeyCommand(sender:))),
+            UIKeyCommand(input: UIKeyInputUpArrow, modifierFlags: [], action: #selector(moveURLCompletionKeyCommand(sender:))),
         ]
         let overidesTextEditing = [
             UIKeyCommand(input: UIKeyInputRightArrow, modifierFlags: [.command, .shift], action: #selector(nextTabKeyCommand)),
@@ -124,7 +124,7 @@ extension BrowserViewController {
         let isEditingText = tabManager.selectedTab?.isEditing ?? false
 
         if urlBar.inOverlayMode {
-            return tabNavigation + overlayCommands
+            return tabNavigation + searchLocationCommands
         } else if !isEditingText {
             return tabNavigation + overidesTextEditing
         }

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -422,6 +422,56 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     }
 }
 
+extension SearchViewController {
+
+    override var canBecomeFirstResponder: Bool {
+        return true
+    }
+
+    func handleKeyCommands(sender: UIKeyCommand) {
+        guard let current = tableView.indexPathForSelectedRow else {
+            if sender.input == UIKeyInputDownArrow {
+                tableView.selectRow(at: IndexPath(item: 0, section: 0), animated: true, scrollPosition: .top)
+            }
+            return
+        }
+
+        let currentSectionItemsCount = tableView(tableView, numberOfRowsInSection: current.section)
+        var nextSection = current.section
+        var nextItem = current.item
+        if sender.input == UIKeyInputUpArrow {
+            // we're going down, we should check if we've reached the first item in this section.
+            if (current.item == 0) {
+                // We have, so check if we can decrement the section.
+                if current.section == 0 {
+                    // We've reached the first item in the first section.
+                    //
+                } else {
+                    nextSection -= 1
+                    nextItem = tableView(tableView, numberOfRowsInSection: nextSection) - 1
+                }
+            } else {
+                nextItem -= 1
+            }
+        } else if sender.input == UIKeyInputDownArrow {
+            if current.item == currentSectionItemsCount - 1 {
+                if current.section == tableView.numberOfSections - 1 {
+                    return
+                } else {
+                    nextSection += 1
+                    nextItem = 0
+                }
+            } else {
+                nextItem += 1
+            }
+        }
+        let next = IndexPath(item: nextItem, section: nextSection)
+        tableView.selectRow(at: next, animated: true, scrollPosition: .middle)
+    }
+
+    
+}
+
 extension SearchViewController: SuggestionCellDelegate {
     fileprivate func suggestionCell(_ suggestionCell: SuggestionCell, didSelectSuggestion suggestion: String) {
         // Assume that only the default search engine can provide search suggestions.

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -455,9 +455,10 @@ extension SearchViewController {
         }
 
         let currentSectionItemsCount = tableView(tableView, numberOfRowsInSection: current.section)
-        var nextSection = current.section
-        var nextItem = current.item
-        if sender.input == UIKeyInputUpArrow {
+        let nextSection: Int
+        let nextItem: Int
+        switch sender.input {
+        case UIKeyInputUpArrow:
             // we're going down, we should check if we've reached the first item in this section.
             if (current.item == 0) {
                 // We have, so check if we can decrement the section.
@@ -466,23 +467,29 @@ extension SearchViewController {
                     searchDelegate?.searchViewController(self, didFinalizeText: searchQuery)
                     return
                 } else {
-                    nextSection -= 1
+                    nextSection = current.section - 1
                     nextItem = tableView(tableView, numberOfRowsInSection: nextSection) - 1
                 }
             } else {
-                nextItem -= 1
+                nextSection = current.section
+                nextItem = current.item - 1
             }
-        } else if sender.input == UIKeyInputDownArrow {
+        case UIKeyInputDownArrow:
             if current.item == currentSectionItemsCount - 1 {
                 if current.section == tableView.numberOfSections - 1 {
+                    // We've reached the last item in the last section
                     return
                 } else {
-                    nextSection += 1
+                    // We can go to the next section.
+                    nextSection = current.section + 1
                     nextItem = 0
                 }
             } else {
-                nextItem += 1
+                nextSection = current.section
+                nextItem = current.item + 1
             }
+        default:
+            return
         }
         let next = IndexPath(item: nextItem, section: nextSection)
         self.tableView(tableView, didHighlightRowAt: next)

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -459,7 +459,9 @@ extension SearchViewController {
                 // We have, so check if we can decrement the section.
                 if current.section == initialSection {
                     // We've reached the first item in the first section.
+                    searchDelegate?.searchViewController(self, didHighlightText: searchQuery, search: true)
                     searchDelegate?.searchViewControllerDidFinishHighlighting(self)
+                    return
                 } else {
                     nextSection -= 1
                     nextItem = tableView(tableView, numberOfRowsInSection: nextSection) - 1

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -469,6 +469,14 @@ extension SearchViewController {
         tableView.selectRow(at: next, animated: true, scrollPosition: .middle)
     }
 
+    override var keyCommands: [UIKeyCommand]? {
+        let overlayCommands = [
+            UIKeyCommand(input: UIKeyInputDownArrow, modifierFlags: [], action: #selector(handleKeyCommands(sender:))),
+            UIKeyCommand(input: UIKeyInputUpArrow, modifierFlags: [], action: #selector(handleKeyCommands(sender:))),
+            UIKeyCommand(input: "\r", modifierFlags: [], action: #selector(didSelectTableCellKeyCommand)),
+        ]
+        return overlayCommands
+    }
     
 }
 

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -47,7 +47,7 @@ protocol SearchViewControllerDelegate: class {
     func searchViewController(_ searchViewController: SearchViewController, didLongPressSuggestion suggestion: String)
     func presentSearchSettingsController()
     func searchViewController(_ searchViewController: SearchViewController, didHighlightText text: String, search: Bool)
-    func searchViewControllerDidFinishHighlighting(_ searchViewController: SearchViewController)
+    func searchViewController(_ searchViewController: SearchViewController, didFinalizeText text: String)
 }
 
 class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, LoaderListener {
@@ -463,7 +463,7 @@ extension SearchViewController {
                 // We have, so check if we can decrement the section.
                 if current.section == initialSection {
                     // We've reached the first item in the first section.
-                    searchDelegate?.searchViewControllerDidFinishHighlighting(self)
+                    searchDelegate?.searchViewController(self, didFinalizeText: searchQuery)
                     return
                 } else {
                     nextSection -= 1

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -47,7 +47,6 @@ protocol SearchViewControllerDelegate: class {
     func searchViewController(_ searchViewController: SearchViewController, didLongPressSuggestion suggestion: String)
     func presentSearchSettingsController()
     func searchViewController(_ searchViewController: SearchViewController, didHighlightText text: String, search: Bool)
-    func searchViewController(_ searchViewController: SearchViewController, didFinalizeText text: String)
 }
 
 class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, LoaderListener {
@@ -70,10 +69,6 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     fileprivate let suggestionCell = SuggestionCell(style: .default, reuseIdentifier: nil)
 
     static var userAgent: String?
-
-    var isCellHighlighted: Bool {
-        return tableView.indexPathForSelectedRow != nil
-    }
 
     init(isPrivate: Bool) {
         self.isPrivate = isPrivate

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -71,6 +71,10 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
 
     static var userAgent: String?
 
+    var isCellHighlighted: Bool {
+        return tableView.indexPathForSelectedRow != nil
+    }
+
     init(isPrivate: Bool) {
         self.isPrivate = isPrivate
         super.init(nibName: nil, bundle: nil)

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -449,7 +449,6 @@ extension SearchViewController {
             return
         }
 
-        let currentSectionItemsCount = tableView(tableView, numberOfRowsInSection: current.section)
         let nextSection: Int
         let nextItem: Int
         switch sender.input {
@@ -459,7 +458,7 @@ extension SearchViewController {
                 // We have, so check if we can decrement the section.
                 if current.section == initialSection {
                     // We've reached the first item in the first section.
-                    searchDelegate?.searchViewController(self, didFinalizeText: searchQuery)
+                    searchDelegate?.searchViewController(self, didHighlightText: searchQuery, search: false)
                     return
                 } else {
                     nextSection = current.section - 1
@@ -470,6 +469,7 @@ extension SearchViewController {
                 nextItem = current.item - 1
             }
         case UIKeyInputDownArrow:
+            let currentSectionItemsCount = tableView(tableView, numberOfRowsInSection: current.section)
             if current.item == currentSectionItemsCount - 1 {
                 if current.section == tableView.numberOfSections - 1 {
                     // We've reached the last item in the last section

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -463,7 +463,6 @@ extension SearchViewController {
                 // We have, so check if we can decrement the section.
                 if current.section == initialSection {
                     // We've reached the first item in the first section.
-                    searchDelegate?.searchViewController(self, didHighlightText: searchQuery, search: true)
                     searchDelegate?.searchViewControllerDidFinishHighlighting(self)
                     return
                 } else {

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -443,8 +443,11 @@ extension SearchViewController {
     func handleKeyCommands(sender: UIKeyCommand) {
         let initialSection = SearchListSection.bookmarksAndHistory.rawValue
         guard let current = tableView.indexPathForSelectedRow else {
-            if sender.input == UIKeyInputDownArrow {
-                tableView.selectRow(at: IndexPath(item: 0, section: initialSection), animated: false, scrollPosition: .top)
+            let count = tableView(tableView, numberOfRowsInSection: initialSection)
+            if sender.input == UIKeyInputDownArrow, count > 0 {
+                let next = IndexPath(item: 0, section: initialSection)
+                self.tableView(tableView, didHighlightRowAt: next)
+                tableView.selectRow(at: next, animated: false, scrollPosition: .top)
             }
             return
         }
@@ -484,6 +487,9 @@ extension SearchViewController {
                 nextItem = current.item + 1
             }
         default:
+            return
+        }
+        guard nextItem >= 0 else {
             return
         }
         let next = IndexPath(item: nextItem, section: nextSection)

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -440,11 +440,6 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
 }
 
 extension SearchViewController {
-
-    override var canBecomeFirstResponder: Bool {
-        return true
-    }
-
     func handleKeyCommands(sender: UIKeyCommand) {
         let initialSection = SearchListSection.bookmarksAndHistory.rawValue
         guard let current = tableView.indexPathForSelectedRow else {
@@ -495,24 +490,6 @@ extension SearchViewController {
         self.tableView(tableView, didHighlightRowAt: next)
         tableView.selectRow(at: next, animated: false, scrollPosition: .middle)
     }
-
-    func didSelectTableCellKeyCommand() {
-        guard let current = tableView.indexPathForSelectedRow else {
-            return
-        }
-
-        tableView(tableView, didSelectRowAtIndexPath: current)
-    }
-
-    override var keyCommands: [UIKeyCommand]? {
-        let overlayCommands = [
-            UIKeyCommand(input: UIKeyInputDownArrow, modifierFlags: [], action: #selector(handleKeyCommands(sender:))),
-            UIKeyCommand(input: UIKeyInputUpArrow, modifierFlags: [], action: #selector(handleKeyCommands(sender:))),
-            UIKeyCommand(input: "\r", modifierFlags: [], action: #selector(didSelectTableCellKeyCommand)),
-        ]
-        return overlayCommands
-    }
-    
 }
 
 extension SearchViewController: SuggestionCellDelegate {

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -383,10 +383,16 @@ class URLBarView: UIView {
     }
 
     func setLocation(_ location: String?, search: Bool) {
-        locationTextField?.text = location
-        if search, let location = location, !location.isEmpty {
+        guard let text = location, !text.isEmpty else {
+            locationTextField?.text = location
+            return
+        }
+        if search {
+            locationTextField?.text = text
             // Not notifying when empty agrees with AutocompleteTextField.textDidChange.
-            delegate?.urlBar(self, didEnterText: location)
+            delegate?.urlBar(self, didEnterText: text)
+        } else {
+            locationTextField?.setTextWithoutSearching(text)
         }
     }
 

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -335,6 +335,10 @@ class URLBarView: UIView {
         locationTextField.applyTheme(currentTheme)
     }
 
+    override func becomeFirstResponder() -> Bool {
+        return self.locationTextField?.becomeFirstResponder() ?? false
+    }
+
     func removeLocationTextField() {
         locationTextField?.removeFromSuperview()
         locationTextField = nil

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -243,6 +243,12 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         super.setMarkedText(markedText, selectedRange: selectedRange)
     }
 
+    func setTextWithoutSearching(_ text: String) {
+        super.text = text
+        hideCursor = autocompleteTextLabel != nil
+        removeCompletion()
+    }
+
     func textDidChange(_ textField: UITextField) {
         hideCursor = autocompleteTextLabel != nil
         removeCompletion()

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -88,7 +88,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
             UIKeyCommand(input: UIKeyInputEscape, modifierFlags: [], action: #selector(self.handleKeyCommand(sender:))),
         ]
     }
-    
+
     func handleKeyCommand(sender: UIKeyCommand) {
         switch sender.input {
         case UIKeyInputLeftArrow:


### PR DESCRIPTION
This PR allows the user to select URL completions (from bookmarks and history) to be selected via the keyboard. 

Desktop leaves the cursor in the location field, which means than horizontal cursor movement is possible.

We aren't able to do this, given that the search suggestions for the query appear horizontally.

Please file follow up usability bugs.

r? for @farhan.

https://bugzilla.mozilla.org/show_bug.cgi?id=1433475