### PR TITLE
Bug 1442838 - Awesomebar results with (bookmark) badge overflow

### DIFF
--- a/Client/Frontend/Widgets/TwoLineCell.swift
+++ b/Client/Frontend/Widgets/TwoLineCell.swift
@@ -224,7 +224,7 @@ private class TwoLineCellHelper {
         if UIApplication.shared.userInterfaceLayoutDirection == .leftToRight {
             imageView.frame = CGRect(x: TwoLineCellUX.BorderViewMargin, y: (height - TwoLineCellUX.ImageSize) / 2, width: TwoLineCellUX.ImageSize, height: TwoLineCellUX.ImageSize)
         } else {
-            imageView.frame = CGRect(x: container.frame.width - TwoLineCellUX.ImageSize - TwoLineCellUX.BorderViewMargin, y: (height - TwoLineCellUX.ImageSize) / 2, width: TwoLineCellUX.ImageSize, height: TwoLineCellUX.ImageSize)
+            imageView.frame = CGRect(x: container.frame.width - TwoLineCellUX.ImageSize - TwoLineCellUX.BorderViewMargin - textRightInset, y: (height - TwoLineCellUX.ImageSize) / 2, width: TwoLineCellUX.ImageSize, height: TwoLineCellUX.ImageSize)
 
             textLabel.frame = textLabel.frame.offsetBy(dx: -(TwoLineCellUX.ImageSize + TwoLineCellUX.BorderViewMargin), dy: 0)
             detailTextLabel.frame = detailTextLabel.frame.offsetBy(dx: -(TwoLineCellUX.ImageSize + TwoLineCellUX.BorderViewMargin), dy: 0)


### PR DESCRIPTION
Forgot to take the badge (bookmark star) into account for the image offset.

Before

![screen shot 2018-03-05 at 11 10 13 am](https://user-images.githubusercontent.com/28052/36986022-c77631c0-2066-11e8-9e3c-da9759dc64cb.png)

After RTL

![screen shot 2018-03-05 at 11 13 18 am](https://user-images.githubusercontent.com/28052/36986023-c789bb32-2066-11e8-90d9-b9c5bcdd0bc6.png)

After LTR 

![screen shot 2018-03-05 at 11 13 57 am](https://user-images.githubusercontent.com/28052/36986025-c797f918-2066-11e8-9318-97a8d8bbbb16.png)
