### PR TITLE
Bug 1434545 - Make sure private tabs are closed even if private tab is not selected when leaving PBM.

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -209,8 +209,8 @@ class TabManager: NSObject {
 
     //Called by other classes to signal that they are entering/exiting private mode
     //This is called by TabTrayVC when the private mode button is pressed and BEFORE we've switched to the new mode
-    func willSwitchTabMode() {
-        if shouldClearPrivateTabs() && (selectedTab?.isPrivate ?? false) {
+    func willSwitchTabMode(force: Bool = false) {
+        if shouldClearPrivateTabs() && ((selectedTab?.isPrivate ?? false) || force)  {
             removeAllPrivateTabs()
         }
     }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -209,6 +209,7 @@ class TabManager: NSObject {
 
     //Called by other classes to signal that they are entering/exiting private mode
     //This is called by TabTrayVC when the private mode button is pressed and BEFORE we've switched to the new mode
+    //The force flag is used to make sure that when exiting PBM without selecting a private tab we still remove tabs
     func willSwitchTabMode(force: Bool = false) {
         if shouldClearPrivateTabs() && ((selectedTab?.isPrivate ?? false) || force)  {
             removeAllPrivateTabs()

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -446,7 +446,6 @@ class TabTrayController: UIViewController {
             fromView = emptyPrivateTabsView
         }
 
-        // when toggling PBM 
         tabManager.willSwitchTabMode(force: privateMode)
         privateMode = !privateMode
         // If we are exiting private mode and we have the close private tabs option selected, make sure

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -446,7 +446,8 @@ class TabTrayController: UIViewController {
             fromView = emptyPrivateTabsView
         }
 
-        tabManager.willSwitchTabMode()
+        // when toggling PBM 
+        tabManager.willSwitchTabMode(force: privateMode)
         privateMode = !privateMode
         // If we are exiting private mode and we have the close private tabs option selected, make sure
         // we clear out all of the private tabs


### PR DESCRIPTION
We use the selectedTab to check if we should removeallprivate tabs which works well unless someone is simply toggling via the tabs tray. 

When toggling via the tabs tray no tab is selected so if there are private tabs they are never deleted. This PR adds a `force` flag which will make sure private tabs are removed when leaving regardless of the selected tab.