### PR TITLE
Bug 1439716 - Update UIConstants to refer to Photon colors

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		2C31A7A91E8BFB2200DAC646 /* ReaderViewUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C31A7A81E8BFB2200DAC646 /* ReaderViewUITest.swift */; };
 		2C31A8471E8D447F00DAC646 /* HomePageSettingsUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C31A8461E8D447F00DAC646 /* HomePageSettingsUITest.swift */; };
 		2C3406C81E719F00000FD889 /* SettingsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3406C71E719F00000FD889 /* SettingsTest.swift */; };
+		2C49854E206173C800893DAE /* photon-colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C49854D206173C800893DAE /* photon-colors.swift */; };
 		2C4A07DC20246EAD0083E320 /* DragAndDropTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4A07DB20246EAD0083E320 /* DragAndDropTests.swift */; };
 		2C4B6BF320349EB800A009C2 /* FirstRunTourTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4B6BF220349EB800A009C2 /* FirstRunTourTests.swift */; };
 		2C8C07771E7800EA00DC1237 /* FindInPageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C8C07761E7800EA00DC1237 /* FindInPageTest.swift */; };
@@ -1514,6 +1515,7 @@
 		2C31A7A81E8BFB2200DAC646 /* ReaderViewUITest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderViewUITest.swift; sourceTree = "<group>"; };
 		2C31A8461E8D447F00DAC646 /* HomePageSettingsUITest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomePageSettingsUITest.swift; sourceTree = "<group>"; };
 		2C3406C71E719F00000FD889 /* SettingsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsTest.swift; sourceTree = "<group>"; };
+		2C49854D206173C800893DAE /* photon-colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "photon-colors.swift"; sourceTree = "<group>"; };
 		2C4A07DB20246EAD0083E320 /* DragAndDropTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragAndDropTests.swift; sourceTree = "<group>"; };
 		2C4B6BF220349EB800A009C2 /* FirstRunTourTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstRunTourTests.swift; sourceTree = "<group>"; };
 		2C8C07761E7800EA00DC1237 /* FindInPageTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FindInPageTest.swift; sourceTree = "<group>"; };
@@ -3864,6 +3866,7 @@
 				D3972BF01C22412B00035B87 /* Share */,
 				D0FCF7EE1FE44E15004A7995 /* UserContent */,
 				D38A1BEB1A9FA2CA00F6A386 /* Widgets */,
+				2C49854D206173C800893DAE /* photon-colors.swift */,
 			);
 			path = Frontend;
 			sourceTree = "<group>";
@@ -5759,6 +5762,7 @@
 				74E36D781B71323500D69DA1 /* SettingsContentViewController.swift in Sources */,
 				742A56391D80B54A00BDB803 /* PhotonActionSheet.swift in Sources */,
 				C4EFEECF1CEBB6F2009762A4 /* BackForwardTableViewCell.swift in Sources */,
+				2C49854E206173C800893DAE /* photon-colors.swift in Sources */,
 				E689C7301E0C7617008BAADB /* NSAttributedStringExtensions.swift in Sources */,
 				D0C95E0E200FD3B200E4E51C /* PrintHelper.swift in Sources */,
 				E64ED8FA1BC55AE300DAF864 /* UIAlertControllerExtensions.swift in Sources */,

--- a/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -10,7 +10,7 @@ import SnapKit
 
 private struct BackForwardViewUX {
     static let RowHeight: CGFloat = 50
-    static let BackgroundColor = UIColor.Defaults.Grey10.withAlphaComponent(0.4)
+    static let BackgroundColor = UIColor.Photon.Grey10.withAlphaComponent(0.4)
 }
 
 class BackForwardListViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, UIGestureRecognizerDelegate {

--- a/Client/Frontend/Browser/BackForwardTableViewCell.swift
+++ b/Client/Frontend/Browser/BackForwardTableViewCell.swift
@@ -16,7 +16,7 @@ class BackForwardTableViewCell: UITableViewCell {
         static let borderBold = 5
         static let IconSize = 23
         static let fontSize: CGFloat = 12.0
-        static let textColor = UIColor.Defaults.Grey80
+        static let textColor = UIColor.Photon.Grey80
     }
     
     lazy var faviconView: UIImageView = {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -249,7 +249,7 @@ class BrowserViewController: UIViewController {
         coordinator.animate(alongsideTransition: { context in
             self.scrollController.showToolbars(animated: false)
             if self.isViewLoaded {
-                self.statusBarOverlay.backgroundColor = self.shouldShowTopTabsForTraitCollection(self.traitCollection) ? UIColor.Defaults.Grey80 : self.urlBar.backgroundColor
+                self.statusBarOverlay.backgroundColor = self.shouldShowTopTabsForTraitCollection(self.traitCollection) ? UIColor.Photon.Grey80 : self.urlBar.backgroundColor
                 self.setNeedsStatusBarAppearanceUpdate()
             }
             }, completion: nil)
@@ -2765,7 +2765,7 @@ extension BrowserViewController: Themeable {
     func applyTheme(_ theme: Theme) {
         let ui: [Themeable?] = [urlBar, toolbar, readerModeBar, topTabsViewController]
         ui.forEach { $0?.applyTheme(theme) }
-        statusBarOverlay.backgroundColor = shouldShowTopTabsForTraitCollection(traitCollection) ? UIColor.Defaults.Grey80 : urlBar.backgroundColor
+        statusBarOverlay.backgroundColor = shouldShowTopTabsForTraitCollection(traitCollection) ? UIColor.Photon.Grey80 : urlBar.backgroundColor
         setNeedsStatusBarAppearanceUpdate()
     }
 }

--- a/Client/Frontend/Browser/OpenInHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper.swift
@@ -16,7 +16,7 @@ private let log = Logger.browserLogger
 struct OpenInViewUX {
     static let ViewHeight: CGFloat = 40.0
     static let TextFont = UIFont.systemFont(ofSize: 16)
-    static let TextColor = UIColor.Defaults.Blue60
+    static let TextColor = UIColor.Photon.Blue60
     static let TextOffset = -15
     static let OpenInString = NSLocalizedString("Open in…", comment: "String indicating that the file can be opened in another application on the device")
 }

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -173,7 +173,7 @@ class TopTabsViewController: UIViewController {
             make.edges.equalTo(topTabFader)
         }
 
-        view.backgroundColor = UIColor.Defaults.Grey80
+        view.backgroundColor = UIColor.Photon.Grey80
         tabsButton.applyTheme(.Normal)
         if let currentTab = tabManager.selectedTab {
             applyTheme(currentTab.isPrivate ? .Private : .Normal)
@@ -289,14 +289,14 @@ extension TopTabsViewController: UIDropInteractionDelegate {
 extension TopTabsViewController: Themeable {
     func applyTheme(_ theme: Theme) {
         tabsButton.applyTheme(theme)
-        tabsButton.titleBackgroundColor = view.backgroundColor ?? UIColor.Defaults.Grey80
-        tabsButton.textColor = UIColor.Defaults.Grey40
+        tabsButton.titleBackgroundColor = view.backgroundColor ?? UIColor.Photon.Grey80
+        tabsButton.textColor = UIColor.Photon.Grey40
 
         isPrivate = (theme == Theme.Private)
         privateModeButton.applyTheme(theme)
         privateModeButton.tintColor = UIColor.TopTabs.PrivateModeTint.colorFor(theme)
         privateModeButton.imageView?.tintColor = privateModeButton.tintColor
-        newTab.tintColor = UIColor.Defaults.Grey40
+        newTab.tintColor = UIColor.Photon.Grey40
         collectionView.backgroundColor = view.backgroundColor
     }
 }

--- a/Client/Frontend/Browser/TopTabsViews.swift
+++ b/Client/Frontend/Browser/TopTabsViews.swift
@@ -6,7 +6,7 @@ import Foundation
 
 struct TopTabsSeparatorUX {
     static let Identifier = "Separator"
-    static let Color = UIColor.Defaults.Grey70
+    static let Color = UIColor.Photon.Grey70
     static let Width: CGFloat = 1
 }
 
@@ -79,15 +79,15 @@ class TopTabCell: UICollectionViewCell {
     
     var selectedTab = false {
         didSet {
-            backgroundColor = selectedTab ? UIColor.Defaults.Grey10 : UIColor.Defaults.Grey80
-            titleText.textColor = selectedTab ? UIColor.Defaults.Grey90 : UIColor.Defaults.Grey40
+            backgroundColor = selectedTab ? UIColor.Photon.Grey10 : UIColor.Photon.Grey80
+            titleText.textColor = selectedTab ? UIColor.Photon.Grey90 : UIColor.Photon.Grey40
             highlightLine.isHidden = !selectedTab
-            closeButton.tintColor = selectedTab ? UIColor.Defaults.Grey80 : UIColor.Defaults.Grey40
+            closeButton.tintColor = selectedTab ? UIColor.Photon.Grey80 : UIColor.Photon.Grey40
             // restyle if we are in PBM
             if style == .dark && selectedTab {
-                backgroundColor =  UIColor.Defaults.Grey70
-                titleText.textColor = UIColor.Defaults.Grey10
-                closeButton.tintColor = UIColor.Defaults.Grey10
+                backgroundColor =  UIColor.Photon.Grey70
+                titleText.textColor = UIColor.Photon.Grey10
+                closeButton.tintColor = UIColor.Photon.Grey10
             }
             closeButton.backgroundColor = backgroundColor
             closeButton.layer.shadowColor = backgroundColor?.cgColor
@@ -119,7 +119,7 @@ class TopTabCell: UICollectionViewCell {
     let closeButton: UIButton = {
         let closeButton = UIButton()
         closeButton.setImage(UIImage.templateImageNamed("menu-CloseTabs"), for: [])
-        closeButton.tintColor = UIColor.Defaults.Grey40
+        closeButton.tintColor = UIColor.Photon.Grey40
         closeButton.imageEdgeInsets = UIEdgeInsets(top: 15, left: TopTabsUX.TabTitlePadding, bottom: 15, right: TopTabsUX.TabTitlePadding)
         closeButton.layer.shadowOpacity = 0.8
         closeButton.layer.masksToBounds = false
@@ -130,7 +130,7 @@ class TopTabCell: UICollectionViewCell {
 
     let highlightLine: UIView = {
         let line = UIView()
-        line.backgroundColor = UIColor.Defaults.Blue60
+        line.backgroundColor = UIColor.Photon.Blue60
         line.isHidden = true
         line.semanticContentAttribute = .forceLeftToRight
         return line
@@ -182,11 +182,11 @@ class TopTabCell: UICollectionViewCell {
         case Style.light:
             titleText.textColor = UIColor.darkText
             backgroundColor = UIConstants.AppBackgroundColor
-            highlightLine.backgroundColor = UIColor.Defaults.Blue60
+            highlightLine.backgroundColor = UIColor.Photon.Blue60
         case Style.dark:
             titleText.textColor = UIColor.lightText
-            backgroundColor = UIColor.Defaults.Grey70
-            highlightLine.backgroundColor = UIColor.Defaults.Purple50
+            backgroundColor = UIColor.Photon.Grey70
+            highlightLine.backgroundColor = UIColor.Photon.Purple50
         }
     }
     

--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -19,7 +19,7 @@ private struct TopSiteCellUX {
     static let BorderColor = UIColor(white: 0, alpha: 0.1)
     static let BorderWidth: CGFloat = 0.5
     static let PinIconSize: CGFloat = 12
-    static let PinColor = UIColor.Defaults.Grey60
+    static let PinColor = UIColor.Photon.Grey60
 }
 
 /*

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -26,7 +26,7 @@ private struct BookmarksPanelUX {
     static let BookmarkFolderChevronSize: CGFloat = 20
     static let BookmarkFolderChevronLineWidth: CGFloat = 2.0
     static let BookmarkFolderTextColor = UIColor(red: 92/255, green: 92/255, blue: 92/255, alpha: 1.0)
-    static let BookmarkFolderBGColor = UIColor.Defaults.Grey10.withAlphaComponent(0.3)
+    static let BookmarkFolderBGColor = UIColor.Photon.Grey10.withAlphaComponent(0.3)
     static let WelcomeScreenPadding: CGFloat = 15
     static let WelcomeScreenItemTextColor = UIColor.gray
     static let WelcomeScreenItemWidth = 170

--- a/Client/Frontend/Home/RemoteTabsPanel.swift
+++ b/Client/Frontend/Home/RemoteTabsPanel.swift
@@ -15,7 +15,7 @@ private let log = Logger.browserLogger
 private struct RemoteTabsPanelUX {
     static let HeaderHeight = SiteTableViewControllerUX.RowHeight // Not HeaderHeight!
     static let RowHeight = SiteTableViewControllerUX.RowHeight
-    static let HeaderBackgroundColor = UIColor.Defaults.Grey10
+    static let HeaderBackgroundColor = UIColor.Photon.Grey10
 
     static let EmptyStateTitleTextColor = UIColor.darkGray
 

--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -11,9 +11,9 @@ struct IntroUX {
     static let Height = 667
     static let MinimumFontScale: CGFloat = 0.5
     static let PagerCenterOffsetFromScrollViewBottom = UIScreen.main.bounds.width <= 320 ? 20 : 30
-    static let StartBrowsingButtonColor = UIColor.Defaults.Blue40
+    static let StartBrowsingButtonColor = UIColor.Photon.Blue40
     static let StartBrowsingButtonHeight = 56
-    static let SignInButtonColor = UIColor.Defaults.Blue40
+    static let SignInButtonColor = UIColor.Photon.Blue40
     static let SignInButtonHeight = 60
     static let PageControlHeight = 40
     static let SignInButtonWidth = 290

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -8,8 +8,8 @@ import UIKit
 
 struct SettingsUX {
     static let TableViewHeaderBackgroundColor = UIConstants.AppBackgroundColor
-    static let TableViewHeaderTextColor = UIColor.Defaults.Grey50
-    static let TableViewRowTextColor = UIColor.Defaults.Grey90
+    static let TableViewHeaderTextColor = UIColor.Photon.Grey50
+    static let TableViewRowTextColor = UIColor.Photon.Grey90
     static let TableViewDisabledRowTextColor = UIColor.lightGray
     static let TableViewSeparatorColor = UIColor(rgb: 0xD1D1D4)
     static let TableViewHeaderFooterHeight = CGFloat(44)

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -31,23 +31,8 @@ struct BrowserColor {
 extension UIColor {
     // These are defaults from http://design.firefox.com/photon/visuals/color.html
     struct Defaults {
-        static let Grey10 = UIColor(rgb: 0xf9f9fa)
-        static let Grey30 = UIColor(rgb: 0xd7d7db)
-        static let Grey40 = UIColor(rgb: 0xb1b1b3)
-        static let Grey50 = UIColor(rgb: 0x737373)
-        static let Grey60 = UIColor(rgb: 0x4a4a4f)
-        static let Grey70 = UIColor(rgb: 0x38383d)
-        static let Grey80 = UIColor(rgb: 0x272727) // Grey80 is actually #2a2a2e
-        static let Grey90 = UIColor(rgb: 0x0c0c0d)
-        static let Blue40 = UIColor(rgb: 0x45a1ff)
-        static let Blue50 = UIColor(rgb: 0x0a84ff)
-        static let Blue60 = UIColor(rgb: 0x0066DC) // Blue60 is actually #0060df
-        static let Purple50 = UIColor(rgb: 0x9400ff)
-        static let Magenta50 = UIColor(rgb: 0xff1ad9)
-        static let Red50 = UIColor(rgb: 0xff0039)
-        static let LockGreen = UIColor(rgb: 0x16DA00)
-
         // Non-Photon design system colors. These are not in the design doc yet.
+        static let LockGreen = UIColor(rgb: 0x16DA00)
         static let MobileGreyA = UIColor(rgb: 0xD2D2D4)
         static let MobileGreyC = UIColor(rgb: 0xE4E4E4)
         static let MobileGreyD = UIColor(rgb: 0x414146)
@@ -66,25 +51,25 @@ extension UIColor {
     }
 
     struct Browser {
-        static let Background = BrowserColor(normal: Defaults.Grey10, pbm: Defaults.Grey70)
+        static let Background = BrowserColor(normal: Photon.Grey10, pbm: Photon.Grey70)
         static let Text = BrowserColor(normal: .white, pbm: Defaults.MobileGreyD)
         static let URLBarDivider = BrowserColor(normal: Defaults.MobileGreyC, pbm: Defaults.MobileGreyD)
-        static let LocationBarBackground = Defaults.Grey30
-        static let Tint = BrowserColor(normal: Defaults.Grey80, pbm: Defaults.MobileGreyA)
+        static let LocationBarBackground = Photon.Grey30
+        static let Tint = BrowserColor(normal: Photon.Grey80, pbm: Defaults.MobileGreyA)
     }
 
     struct URLBar {
-        static let Border = BrowserColor(normal: Defaults.Grey50, pbm: Defaults.MobileGreyE)
-        static let ActiveBorder = BrowserColor(normal: Defaults.MobileBlueA, pbm: Defaults.Grey60)
-        static let Tint = BrowserColor(normal: Defaults.MobileBlueB, pbm: Defaults.Grey10)
+        static let Border = BrowserColor(normal: Photon.Grey50, pbm: Defaults.MobileGreyE)
+        static let ActiveBorder = BrowserColor(normal: Defaults.MobileBlueA, pbm: Photon.Grey60)
+        static let Tint = BrowserColor(normal: Defaults.MobileBlueB, pbm: Photon.Grey10)
     }
 
     struct TextField {
         static let Background = BrowserColor(normal: .white, pbm: Defaults.MobileGreyF)
-        static let TextAndTint = BrowserColor(normal: Defaults.Grey80, pbm: .white)
+        static let TextAndTint = BrowserColor(normal: Photon.Grey80, pbm: .white)
         static let Highlight = BrowserColor(normal: Defaults.MobileBlueC, pbm: Defaults.MobilePurple)
         static let ReaderModeButtonSelected = BrowserColor(normal: Defaults.MobileBlueD, pbm: Defaults.MobilePrivatePurple)
-        static let ReaderModeButtonUnselected = BrowserColor(normal: Defaults.Grey50, pbm: Defaults.MobileGreyH)
+        static let ReaderModeButtonUnselected = BrowserColor(normal: Photon.Grey50, pbm: Defaults.MobileGreyH)
         static let PageOptionsSelected = ReaderModeButtonSelected
         static let PageOptionsUnselected = UIColor.Browser.Tint
         static let Separator = BrowserColor(normal: Defaults.MobileGreyJ, pbm: Defaults.MobileGreyI)
@@ -97,8 +82,8 @@ extension UIColor {
     }
 
     struct LoadingBar {
-        static let Start = BrowserColor(normal: Defaults.MobileBlueB, pbm: Defaults.Purple50)
-        static let End = BrowserColor(normal: Defaults.Blue50, pbm: Defaults.Magenta50)
+        static let Start = BrowserColor(normal: Defaults.MobileBlueB, pbm: Photon.Purple50)
+        static let End = BrowserColor(normal: Photon.Blue50, pbm: Photon.Magenta50)
     }
 
     struct TabTray {
@@ -106,17 +91,17 @@ extension UIColor {
     }
 
     struct TopTabs {
-        static let PrivateModeTint = BrowserColor(normal: Defaults.Grey10, pbm: Defaults.Grey40)
-        static let Background = UIColor.Defaults.Grey80
+        static let PrivateModeTint = BrowserColor(normal: Photon.Grey10, pbm: Photon.Grey40)
+        static let Background = UIColor.Photon.Grey80
     }
 
     struct HomePanel {
         // These values are the same for both private/normal.
         // The homepanel toolbar needed to be able to theme, not anymore.
         // Keep this just in case someone decides they want it to theme again
-        static let ToolbarBackground = BrowserColor(normal: Defaults.Grey10, pbm: Defaults.Grey10)
-        static let ToolbarHighlight = BrowserColor(normal: Defaults.Blue50, pbm: Defaults.Blue50)
-        static let ToolbarTint = BrowserColor(normal: Defaults.Grey50, pbm: Defaults.Grey50)
+        static let ToolbarBackground = BrowserColor(normal: Photon.Grey10, pbm: Photon.Grey10)
+        static let ToolbarHighlight = BrowserColor(normal: Photon.Blue50, pbm: Photon.Blue50)
+        static let ToolbarTint = BrowserColor(normal: Photon.Grey50, pbm: Photon.Grey50)
     }
 }
 
@@ -139,12 +124,12 @@ public struct UIConstants {
         }
     }
 
-    static let AppBackgroundColor = UIColor.Defaults.Grey10
-    static let SystemBlueColor = UIColor.Defaults.Blue50
-    static let ControlTintColor = UIColor.Defaults.Blue50
-    static let PasscodeDotColor = UIColor.Defaults.Grey60
-    static let PrivateModeAssistantToolbarBackgroundColor = UIColor.Defaults.Grey50
-    static let PrivateModeTextHighlightColor = UIColor.Defaults.Purple50
+    static let AppBackgroundColor = UIColor.Photon.Grey10
+    static let SystemBlueColor = UIColor.Photon.Blue50
+    static let ControlTintColor = UIColor.Photon.Blue50
+    static let PasscodeDotColor = UIColor.Photon.Grey60
+    static let PrivateModeAssistantToolbarBackgroundColor = UIColor.Photon.Grey50
+    static let PrivateModeTextHighlightColor = UIColor.Photon.Purple50
     static let PrivateModePurple = UIColor.Defaults.MobilePrivatePurple
 
     // Static fonts
@@ -156,9 +141,9 @@ public struct UIConstants {
     static let PasscodeEntryFont = UIFont.systemFont(ofSize: PasscodeEntryFontSize, weight: UIFontWeightBold)
 
     static let PanelBackgroundColor = UIColor.white
-    static let SeparatorColor = UIColor.Defaults.Grey30
-    static let HighlightBlue = UIColor.Defaults.Blue50
-    static let DestructiveRed = UIColor.Defaults.Red50
+    static let SeparatorColor = UIColor.Photon.Grey30
+    static let HighlightBlue = UIColor.Photon.Blue50
+    static let DestructiveRed = UIColor.Photon.Red50
     static let BorderColor = UIColor.darkGray
     static let BackgroundColor = AppBackgroundColor
 

--- a/Client/Frontend/Widgets/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet.swift
@@ -56,7 +56,7 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
     
     private var site: Site?
     private let style: PresentationStyle
-    private var tintColor = UIColor.Defaults.Grey80
+    private var tintColor = UIColor.Photon.Grey80
     private lazy var showCloseButton: Bool = {
         return self.style == .bottom && self.modalPresentationStyle != .popover
     }()

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -9,8 +9,8 @@ struct SiteTableViewControllerUX {
     static let HeaderHeight = CGFloat(32)
     static let RowHeight = CGFloat(44)
     static let HeaderBorderColor = UIColor(rgb: 0xCFD5D9).withAlphaComponent(0.8)
-    static let HeaderTextColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.black : UIColor.Defaults.Grey80
-    static let HeaderBackgroundColor = UIColor.Defaults.Grey10
+    static let HeaderTextColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.black : UIColor.Photon.Grey80
+    static let HeaderBackgroundColor = UIColor.Photon.Grey10
     static let HeaderFont = UIFont.systemFont(ofSize: 12, weight: UIFontWeightMedium)
     static let HeaderTextMargin = CGFloat(16)
 }

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -7,7 +7,7 @@ import SnapKit
 import Shared
 
 private struct TabsButtonUX {
-    static let TitleColor: UIColor = UIColor.Defaults.Grey80
+    static let TitleColor: UIColor = UIColor.Photon.Grey80
     static let TitleBackgroundColor: UIColor = UIColor.white
     static let CornerRadius: CGFloat = 2
     static let TitleFont: UIFont = UIConstants.DefaultChromeSmallFontBold

--- a/Client/Frontend/Widgets/TwoLineCell.swift
+++ b/Client/Frontend/Widgets/TwoLineCell.swift
@@ -11,7 +11,7 @@ struct TwoLineCellUX {
     static let BadgeSize: CGFloat = 16
     static let BadgeMargin: CGFloat = 16
     static let BorderFrameSize: CGFloat = 32
-    static let TextColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.black : UIColor.Defaults.Grey80
+    static let TextColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.black : UIColor.Photon.Grey80
     static let DetailTextColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.darkGray : UIColor.gray
     static let DetailTextTopMargin: CGFloat = 0
 }

--- a/Client/Frontend/photon-colors.swift
+++ b/Client/Frontend/photon-colors.swift
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* Photon Colors iOS Variables v3.0.1
+ From https://github.com/FirefoxUX/design-tokens/tree/master/photon-colors#readme */
+
+extension UIColor {
+    struct Photon {
+        static let Magenta50 = UIColor(rgb: 0xff1ad9)
+        static let Magenta60 = UIColor(rgb: 0xed00b5)
+        static let Magenta70 = UIColor(rgb: 0xb5007f)
+        static let Magenta80 = UIColor(rgb: 0x7d004f)
+        static let Magenta90 = UIColor(rgb: 0x440027)
+
+        static let Purple50 = UIColor(rgb: 0x9400ff)
+        static let Purple60 = UIColor(rgb: 0x8000d7)
+        static let Purple70 = UIColor(rgb: 0x6200a4)
+        static let Purple80 = UIColor(rgb: 0x440071)
+        static let Purple90 = UIColor(rgb: 0x25003e)
+
+        static let Blue40 = UIColor(rgb: 0x45a1ff)
+        static let Blue50 = UIColor(rgb: 0x0a84ff)
+        static let Blue50A30 = UIColor(rgba: 0x0a84ff4c)
+        static let Blue60 = UIColor(rgb: 0x0060df)
+        static let Blue70 = UIColor(rgb: 0x003eaa)
+        static let Blue80 = UIColor(rgb: 0x002275)
+        static let Blue90 = UIColor(rgb: 0x000f40)
+
+        static let Teal50 = UIColor(rgb: 0x00feff)
+        static let Teal60 = UIColor(rgb: 0x00c8d7)
+        static let Teal70 = UIColor(rgb: 0x008ea4)
+        static let Teal80 = UIColor(rgb: 0x005a71)
+        static let Teal90 = UIColor(rgb: 0x002d3e)
+
+        static let Green50 = UIColor(rgb: 0x30e60b)
+        static let Green60 = UIColor(rgb: 0x12bc00)
+        static let Green70 = UIColor(rgb: 0x058b00)
+        static let Green80 = UIColor(rgb: 0x006504)
+        static let Green90 = UIColor(rgb: 0x003706)
+
+        static let Yellow50 = UIColor(rgb: 0xffe900)
+        static let Yellow60 = UIColor(rgb: 0xd7b600)
+        static let Yellow70 = UIColor(rgb: 0xa47f00)
+        static let Yellow80 = UIColor(rgb: 0x715100)
+        static let Yellow90 = UIColor(rgb: 0x3e2800)
+
+        static let Red50 = UIColor(rgb: 0xff0039)
+        static let Red60 = UIColor(rgb: 0xd70022)
+        static let Red70 = UIColor(rgb: 0xa4000f)
+        static let Red80 = UIColor(rgb: 0x5a0002)
+        static let Red90 = UIColor(rgb: 0x3e0200)
+
+        static let Orange50 = UIColor(rgb: 0xff9400)
+        static let Orange60 = UIColor(rgb: 0xd76e00)
+        static let Orange70 = UIColor(rgb: 0xa44900)
+        static let Orange80 = UIColor(rgb: 0x712b00)
+        static let Orange90 = UIColor(rgb: 0x3e1300)
+
+        static let Grey10 = UIColor(rgb: 0xf9f9fa)
+        static let Grey20 = UIColor(rgb: 0xededf0)
+        static let Grey30 = UIColor(rgb: 0xd7d7db)
+        static let Grey40 = UIColor(rgb: 0xb1b1b3)
+        static let Grey50 = UIColor(rgb: 0x737373)
+        static let Grey60 = UIColor(rgb: 0x4a4a4f)
+        static let Grey70 = UIColor(rgb: 0x38383d)
+        static let Grey80 = UIColor(rgb: 0x2a2a2e)
+        static let Grey90 = UIColor(rgb: 0x0c0c0d)
+        static let Grey90A05 = UIColor(rgba: 0x0c0c0d0c)
+        static let Grey90A10 = UIColor(rgba: 0x0c0c0d19)
+        static let Grey90A20 = UIColor(rgba: 0x0c0c0d33)
+        static let Grey90A30 = UIColor(rgba: 0x0c0c0d4c)
+        static let Grey90A40 = UIColor(rgba: 0x0c0c0d66)
+        static let Grey90A50 = UIColor(rgba: 0x0c0c0d7f)
+        static let Grey90A60 = UIColor(rgba: 0x0c0c0d99)
+        static let Grey90A70 = UIColor(rgba: 0x0c0c0db2)
+        static let Grey90A80 = UIColor(rgba: 0x0c0c0dcc)
+        static let Grey90A90 = UIColor(rgba: 0x0c0c0de5)
+
+        static let Ink70 = UIColor(rgb: 0x363959)
+        static let Ink80 = UIColor(rgb: 0x202340)
+        static let Ink90 = UIColor(rgb: 0x0f1126)
+
+        static let White100 = UIColor(rgb: 0xffffff)
+
+    }
+}

--- a/Shared/Extensions/UIColorExtensions.swift
+++ b/Shared/Extensions/UIColorExtensions.swift
@@ -22,6 +22,15 @@ extension UIColor {
             alpha: 1)
     }
 
+    public convenience init(rgba: Int) {
+        self.init(
+            red: CGFloat((rgba & 0xFF000000) >> 24) / 255.0,
+            green: CGFloat((rgba & 0x00FF0000) >> 16)  / 255.0,
+            blue: CGFloat((rgba & 0x0000FF00) >> 8)  / 255.0,
+            alpha: CGFloat((rgba & 0x000000FF) >> 0) / 255.0
+        )
+    }
+
     public convenience init(colorString: String) {
         var colorInt: UInt32 = 0
         Scanner(string: colorString).scanHexInt32(&colorInt)


### PR DESCRIPTION

## Notes for testing this patch

- This makes use of the auto-generated file from the photon-colors node module.
- I also updated various files where it was referencing for example: `Defaults.Grey10` to `Photon.Grey10`.
-  added a convenience function for `rgba` to UIColor

Should the file `photon-colors.swift` be checked in to git?

