### PR TITLE
 Bug 1443882, 1443638 - Make sure urlbar placeholder text is left aligned. Make sure TP shield does not appear on a new tab.

### DIFF
--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -194,7 +194,7 @@ class TabLocationView: UIView, TabEventHandler {
         addSubview(contentView)
 
         contentView.snp.makeConstraints { make in
-            make.edges.equalTo(self).inset(UIEdgeInsetsMake(0, 0, 0, 0))
+            make.edges.equalTo(self)
         }
 
         lockImageView.snp.makeConstraints { make in

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -51,6 +51,7 @@ class TabLocationView: UIView, TabEventHandler {
             }
             updateTextWithURL()
             pageOptionsButton.isHidden = (url == nil)
+            trackingProtectionView.isHidden = (url == nil)
             setNeedsUpdateConstraints()
         }
     }
@@ -177,18 +178,23 @@ class TabLocationView: UIView, TabEventHandler {
         longPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(SELlongPressLocation))
         tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(SELtapLocation))
 
+        let spaceView = UIView()
+        spaceView.snp.makeConstraints { make in
+            make.width.equalTo(TabLocationViewUX.Spacing)
+        }
         // The lock and TP icons have custom spacing.
         // TODO: Once we cut ios10 support we can use UIstackview.setCustomSpacing
-        let iconStack = UIStackView(arrangedSubviews: [lockImageView, trackingProtectionView])
+        let iconStack = UIStackView(arrangedSubviews: [spaceView, lockImageView, trackingProtectionView])
         iconStack.spacing = TabLocationViewUX.Spacing / 2
 
         let subviews = [iconStack, urlTextField, readerModeButton, separatorLine, pageOptionsButton]
         contentView = UIStackView(arrangedSubviews: subviews)
+        contentView.distribution = .fill
         contentView.alignment = .center
         addSubview(contentView)
 
         contentView.snp.makeConstraints { make in
-            make.edges.equalTo(self).inset(UIEdgeInsetsMake(0, TabLocationViewUX.Spacing, 0, 0))
+            make.edges.equalTo(self).inset(UIEdgeInsetsMake(0, 0, 0, 0))
         }
 
         lockImageView.snp.makeConstraints { make in


### PR DESCRIPTION
Turns out the issue wasn't contentHugging priorities but rather the nested stackview. 

The iconStack when empty messes up autolayout. I needed to add a view to the iconStack that would always be visible so autolayout wouldnt break. The main stackview was inset a few pixels so I removed the inset from the contentView and instead added the spacing to the iconStack via a "spaceView" This is a bit hacky but this makes sure there is always a visible view in the inner iconstack. Thankfully once we can use `setCustomSpacing` we can get rid of all of this.

There are 2 other ways this could be fixed but all of them are compromises. 
1. get custom images from bbell that include spacing built in. (hard to reason about spacing once we do this)
2. Create nested views around the lock/shield (like a UIbutton) that allows us to center the image but still do custom spacing on the left/right. 