### PR TITLE
Bug 1439372 - prevent crash in tabmanger by accessing array safely. 

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -418,7 +418,8 @@ class TabManager: NSObject {
             if tabIndex == viableTabs.count {
                 tabIndex -= 1
             }
-            if let currentTab = viableTabs[safe: tabIndex], tabIndex < viableTabs.count && !viableTabs.isEmpty {
+
+            if let currentTab = viableTabs[safe: tabIndex] {
                 _selectedIndex = tabs.index(of: currentTab) ?? -1
             } else {
                 _selectedIndex = -1

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -418,8 +418,8 @@ class TabManager: NSObject {
             if tabIndex == viableTabs.count {
                 tabIndex -= 1
             }
-            if tabIndex < viableTabs.count && !viableTabs.isEmpty {
-                _selectedIndex = tabs.index(of: viableTabs[tabIndex]) ?? -1
+            if let currentTab = viableTabs[safe: tabIndex], tabIndex < viableTabs.count && !viableTabs.isEmpty {
+                _selectedIndex = tabs.index(of: currentTab) ?? -1
             } else {
                 _selectedIndex = -1
             }

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -254,6 +254,24 @@ class TabManagerTests: XCTestCase {
         XCTAssertEqual(manager.privateTabs.count, 1, "If the flag is false then private tabs should still exist")
     }
 
+    func testTogglePBMDelete() {
+        let profile = TabManagerMockProfile()
+        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        profile.prefs.setBool(true, forKey: "settings.closePrivateTabs")
+
+        let tab = manager.addTab()
+        manager.selectTab(tab)
+        manager.selectTab(manager.addTab())
+        manager.selectTab(manager.addTab(isPrivate: true))
+
+        manager.willSwitchTabMode(leavingPBM: false)
+        XCTAssertEqual(manager.privateTabs.count, 1, "There should be 1 private tab")
+        manager.willSwitchTabMode(leavingPBM: true)
+        XCTAssertEqual(manager.privateTabs.count, 0, "There should be 0 private tab")
+        manager.removeTab(tab)
+        XCTAssertEqual(manager.normalTabs.count, 1, "There should be 1 normal tab")
+    }
+
     func testDeleteNonSelectedTab() {
         let profile = TabManagerMockProfile()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)


### PR DESCRIPTION
We've got a great extension to Array that lets us access elements safely. We can use it here to prevent a crash.