### PR TITLE
Bug 1444109 - startup perf of Tracking Protection stats

### DIFF
--- a/Client/Frontend/ContentBlocker/ContentBlockerHelper.swift
+++ b/Client/Frontend/ContentBlocker/ContentBlockerHelper.swift
@@ -148,6 +148,8 @@ class ContentBlockerHelper {
             ContentBlockerHelper.whitelistedDomains.domainSet = Set(list)
         }
 
+        TPStatsBlocklistChecker.shared.startup()
+
         ContentBlockerHelper.removeOldListsByDateFromStore(prefs: prefs) {
             ContentBlockerHelper.removeOldListsByNameFromStore(prefs: prefs) {
                 ContentBlockerHelper.compileListsNotInStore {

--- a/Client/Frontend/ContentBlocker/TrackingProtectionPageStats.swift
+++ b/Client/Frontend/ContentBlocker/TrackingProtectionPageStats.swift
@@ -54,6 +54,11 @@ class TPStatsBlocklistChecker {
 
 // The 'unless-domain' and 'if-domain' rules use wildcard expressions, convert this to regex.
 func wildcardContentBlockerDomainToRegex(domain: String) -> NSRegularExpression? {
+    struct Memo { static var domains =  [String: NSRegularExpression]() }
+    if let memoized = Memo.domains[domain] {
+        return memoized
+    }
+
     // Convert the domain exceptions into regular expressions.
     var regex = domain + "$"
     if regex.first == "*" {
@@ -61,7 +66,9 @@ func wildcardContentBlockerDomainToRegex(domain: String) -> NSRegularExpression?
     }
     regex = regex.replacingOccurrences(of: ".", with: "\\.")
     do {
-        return try NSRegularExpression(pattern: regex, options: [])
+        let result = try NSRegularExpression(pattern: regex, options: [])
+        Memo.domains[domain] = result
+        return result
     } catch {
         assertionFailure("Blocklists: \(error.localizedDescription)")
         return nil


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1444109

Memoize NSRegularExpression creation code to increase perf from 1s to 0.25s.
Move off-main thread, and just ignore any TP stats until it is ready.