### PR TITLE
Bug 1443796 - Reduce spacing between the title and description in the Intro slides

### DIFF
--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -389,6 +389,8 @@ class CardView: UIView {
             button.snp.makeConstraints { make in
                 make.bottom.centerX.equalTo(self)
             }
+            // When there is a button reduce the spacing to make more room for text
+            stackView.spacing = stackView.spacing / 2
         }
     }
 


### PR DESCRIPTION
The description text on a intro slide was being truncated because there wasnt enough space on a slide where there is a button. 

This PR reduces spacing only when there is a button creating more room for the text.