### PR TITLE
Bug 1444992 - Fix Intermittent XCUITest AddTabFromContextMenu

### DIFF
--- a/XCUITests/TopTabsTest.swift
+++ b/XCUITests/TopTabsTest.swift
@@ -63,7 +63,14 @@ class TopTabsTest: BaseTestCase {
         // Open tab tray to check that both tabs are there
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
         waitforExistence(app.collectionViews.cells["Example Domain"])
-        waitforExistence(app.collectionViews.cells["IANA — IANA-managed Reserved Domains"])
+        if !app.collectionViews.cells["IANA — IANA-managed Reserved Domains"].exists {
+            navigator.goto(TabTray)
+            app.collectionViews.cells["Example Domain"].tap()
+            waitUntilPageLoad()
+            navigator.nowAt(BrowserTab)
+            navigator.goto(TabTray)
+            waitforExistence(app.collectionViews.cells["IANA — IANA-managed Reserved Domains"])
+        }
     }
 
     // This test only runs for iPhone see bug 1409750


### PR DESCRIPTION
TopTab test AddTabFromContextMenu is failing intermittently on iPhone sim because when checking the tab title it is not displayed yet. A workaround have been implemented to try to avoid this failure
