### PR TITLE
Bug 1444425 - Add new UI telemetry probes for v11.0

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -8,43 +8,53 @@ import Shared
 extension BrowserViewController {
 
     @objc private func reloadTabKeyCommand() {
+        UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "reload"])
         if let tab = tabManager.selectedTab, homePanelController == nil {
             tab.reload()
         }
     }
 
     @objc private func goBackKeyCommand() {
+        UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "go-back"])
         if let tab = tabManager.selectedTab, tab.canGoBack, homePanelController == nil {
             tab.goBack()
         }
     }
 
     @objc private func goForwardKeyCommand() {
+        UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "go-forward"])
         if let tab = tabManager.selectedTab, tab.canGoForward {
             tab.goForward()
         }
     }
 
-    @objc private func findOnPageKeyCommand() {
+    @objc private func findInPageKeyCommand() {
+        UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "find-in-page"])
         if let tab = tabManager.selectedTab, homePanelController == nil {
             self.tab(tab, didSelectFindInPageForSelection: "")
         }
     }
 
     @objc private func selectLocationBarKeyCommand() {
+        UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "select-location-bar"])
         scrollController.showToolbars(animated: true)
         urlBar.tabLocationViewDidTapLocation(urlBar.locationView)
     }
 
     @objc private func newTabKeyCommand() {
+        UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "new-tab"])
         openBlankNewTab(focusLocationField: true, isPrivate: false)
     }
 
     @objc private func newPrivateTabKeyCommand() {
+        // NOTE: We cannot and should not distinguish between "new-tab" and "new-private-tab"
+        // when recording telemetry for key commands.
+        UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "new-tab"])
         openBlankNewTab(focusLocationField: true, isPrivate: true)
     }
 
     @objc private func closeTabKeyCommand() {
+        UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "close-tab"])
         guard let currentTab = tabManager.selectedTab else {
             return
         }
@@ -52,6 +62,7 @@ extension BrowserViewController {
     }
 
     @objc private func nextTabKeyCommand() {
+        UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "next-tab"])
         guard let currentTab = tabManager.selectedTab else {
             return
         }
@@ -65,6 +76,7 @@ extension BrowserViewController {
     }
 
     @objc private func previousTabKeyCommand() {
+        UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "previous-tab"])
         guard let currentTab = tabManager.selectedTab else {
             return
         }
@@ -77,7 +89,8 @@ extension BrowserViewController {
         }
     }
 
-    @objc private func gotoTabTray() {
+    @objc private func showTabTrayKeyCommand() {
+        UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "show-tab-tray"])
         showTabTray()
     }
 
@@ -93,7 +106,7 @@ extension BrowserViewController {
             UIKeyCommand(input: "[", modifierFlags: .command, action: #selector(goBackKeyCommand), discoverabilityTitle: Strings.BackTitle),
             UIKeyCommand(input: "]", modifierFlags: .command, action: #selector(goForwardKeyCommand), discoverabilityTitle: Strings.ForwardTitle),
 
-            UIKeyCommand(input: "f", modifierFlags: .command, action: #selector(findOnPageKeyCommand), discoverabilityTitle: Strings.FindTitle),
+            UIKeyCommand(input: "f", modifierFlags: .command, action: #selector(findInPageKeyCommand), discoverabilityTitle: Strings.FindTitle),
             UIKeyCommand(input: "l", modifierFlags: .command, action: #selector(selectLocationBarKeyCommand), discoverabilityTitle: Strings.SelectLocationBarTitle),
             UIKeyCommand(input: "t", modifierFlags: .command, action: #selector(newTabKeyCommand), discoverabilityTitle: Strings.NewTabTitle),
             UIKeyCommand(input: "p", modifierFlags: [.command, .shift], action: #selector(newPrivateTabKeyCommand), discoverabilityTitle: Strings.NewPrivateTabTitle),
@@ -105,8 +118,8 @@ extension BrowserViewController {
             UIKeyCommand(input: "]", modifierFlags: [.command, .shift], action: #selector(nextTabKeyCommand)),
             UIKeyCommand(input: "[", modifierFlags: [.command, .shift], action: #selector(previousTabKeyCommand)),
 
-            UIKeyCommand(input: "\\", modifierFlags: [.command, .shift], action: #selector(gotoTabTray)), // Safari on macOS
-            UIKeyCommand(input: "\t", modifierFlags: [.command, .alternate], action: #selector(gotoTabTray), discoverabilityTitle: Strings.ShowTabTrayFromTabKeyCodeTitle)
+            UIKeyCommand(input: "\\", modifierFlags: [.command, .shift], action: #selector(showTabTrayKeyCommand)), // Safari on macOS
+            UIKeyCommand(input: "\t", modifierFlags: [.command, .alternate], action: #selector(showTabTrayKeyCommand), discoverabilityTitle: Strings.ShowTabTrayFromTabKeyCodeTitle)
         ]
 
         let isEditingText = tabManager.selectedTab?.isEditing ?? false

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+UIDropInteractionDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+UIDropInteractionDelegate.swift
@@ -21,6 +21,8 @@ extension BrowserViewController: UIDropInteractionDelegate {
     }
 
     func dropInteraction(_ interaction: UIDropInteraction, performDrop session: UIDropSession) {
+        UnifiedTelemetry.recordEvent(category: .action, method: .drop, object: .url, value: .browser)
+
         _ = session.loadObjects(ofClass: URL.self) { urls in
             guard let url = urls.first else {
                 return

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -318,6 +318,8 @@ extension TabLocationView: UIDragInteractionDelegate {
             return []
         }
 
+        UnifiedTelemetry.recordEvent(category: .action, method: .drag, object: .locationBar)
+
         let dragItem = UIDragItem(itemProvider: itemProvider)
         return [dragItem]
     }

--- a/Client/Frontend/Browser/TabTrayController+KeyCommands.swift
+++ b/Client/Frontend/Browser/TabTrayController+KeyCommands.swift
@@ -25,28 +25,34 @@ extension TabTrayController {
     }
 
     func didTogglePrivateModeKeyCommand() {
+        // NOTE: We cannot and should not capture telemetry here.
         didTogglePrivateMode()
     }
 
     func didCloseTabKeyCommand() {
+        UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "close-tab"])
         if let tab = tabManager.selectedTab {
             tabManager.removeTab(tab)
         }
     }
 
     func didCloseAllTabsKeyCommand() {
+        UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "close-all-tabs"])
         closeTabsForCurrentTray()
     }
 
     func didEnterTabKeyCommand() {
+        UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "enter-tab"])
         _ = self.navigationController?.popViewController(animated: true)
     }
 
     func didOpenNewTabKeyCommand() {
+        UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "new-tab"])
         openNewTab()
     }
 
     func didChangeSelectedTabKeyCommand(sender: UIKeyCommand) {
+        UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "select-tab"])
         let step: Int
         switch sender.input {
         case UIKeyInputLeftArrow:

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -845,6 +845,8 @@ extension TabManagerDataSource: UICollectionViewDragDelegate {
             itemProvider = NSItemProvider()
         }
 
+        UnifiedTelemetry.recordEvent(category: .action, method: .drag, object: .tab, value: .tabTray)
+
         let dragItem = UIDragItem(itemProvider: itemProvider)
         dragItem.localObject = tab
         return [dragItem]
@@ -857,6 +859,8 @@ extension TabManagerDataSource: UICollectionViewDropDelegate {
         guard isDragging, let destinationIndexPath = coordinator.destinationIndexPath, let dragItem = coordinator.items.first?.dragItem, let tab = dragItem.localObject as? Tab, let sourceIndex = tabs.index(of: tab) else {
             return
         }
+
+        UnifiedTelemetry.recordEvent(category: .action, method: .drop, object: .tab, value: .tabTray)
 
         coordinator.drop(dragItem, toItemAt: destinationIndexPath)
         isDragging = false

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -274,6 +274,8 @@ extension TopTabsViewController: UIDropInteractionDelegate {
     }
 
     func dropInteraction(_ interaction: UIDropInteraction, performDrop session: UIDropSession) {
+        UnifiedTelemetry.recordEvent(category: .action, method: .drop, object: .url, value: .topTabs)
+
         _ = session.loadObjects(ofClass: URL.self) { urls in
             guard let url = urls.first else {
                 return
@@ -401,6 +403,8 @@ extension TopTabsViewController: UICollectionViewDragDelegate {
             itemProvider = NSItemProvider()
         }
 
+        UnifiedTelemetry.recordEvent(category: .action, method: .drag, object: .tab, value: .topTabs)
+
         let dragItem = UIDragItem(itemProvider: itemProvider)
         dragItem.localObject = tab
         return [dragItem]
@@ -413,6 +417,8 @@ extension TopTabsViewController: UICollectionViewDropDelegate {
         guard let destinationIndexPath = coordinator.destinationIndexPath, let dragItem = coordinator.items.first?.dragItem, let tab = dragItem.localObject as? Tab, let sourceIndex = tabStore.index(of: tab) else {
             return
         }
+
+        UnifiedTelemetry.recordEvent(category: .action, method: .drop, object: .tab, value: .topTabs)
 
         coordinator.drop(dragItem, toItemAt: destinationIndexPath)
         isDragging = false

--- a/Client/Frontend/Home/ReaderPanel.swift
+++ b/Client/Frontend/Home/ReaderPanel.swift
@@ -466,6 +466,8 @@ extension ReadingListPanel: UITableViewDragDelegate {
             return []
         }
 
+        UnifiedTelemetry.recordEvent(category: .action, method: .drag, object: .url, value: .readingListPanel)
+
         let dragItem = UIDragItem(itemProvider: itemProvider)
         return [dragItem]
     }

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -92,6 +92,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     func handleKeyCommand(sender: UIKeyCommand) {
         switch sender.input {
         case UIKeyInputLeftArrow:
+            UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "autocomplete-left-arrow"])
             if isSelectionActive {
                 applyCompletion()
                 
@@ -109,6 +110,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
                 selectedTextRange = textRange(from: cursorPosition, to: cursorPosition)
             }
         case UIKeyInputRightArrow:
+            UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "autocomplete-right-arrow"])
             if isSelectionActive {
                 applyCompletion()
                 
@@ -126,6 +128,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
                 selectedTextRange = textRange(from: cursorPosition, to: cursorPosition)
             }
         case UIKeyInputEscape:
+            UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "autocomplete-cancel"])
             autocompleteDelegate?.autocompleteTextFieldDidCancel(self)
         default:
             break

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -302,13 +302,15 @@ extension PhotonActionSheetProtocol {
         let statList = [totalCount, adCount, analyticsCount, socialCount, contentCount]
 
         let addToWhitelist = PhotonActionSheetItem(title: Strings.TrackingProtectionDisableTitle, iconString: "menu-TrackingProtection-Off") { _ in
+            UnifiedTelemetry.recordEvent(category: .action, method: .add, object: .trackingProtectionWhitelist)
             ContentBlockerHelper.whitelist(enable: true, url: currentURL) { _ in
                 tab.reload()
             }
         }
         // when tracking protection is on and content was blocked
         let tpBlocking = PhotonActionSheetItem(title: Strings.SettingsTrackingProtectionSectionName, text: Strings.TPBlockingDescription, iconString: "menu-TrackingProtection", isEnabled: false, accessory: .Disclosure) { _ in
-          guard let bvc = self as? PresentableVC else { return }
+            guard let bvc = self as? PresentableVC else { return }
+            UnifiedTelemetry.recordEvent(category: .action, method: .view, object: .trackingProtectionStatistics)
             self.presentSheetWith(title: Strings.SettingsTrackingProtectionSectionName, actions: [statList, [addToWhitelist]], on: bvc, from: urlBar)
         }
         return [tpBlocking]

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -169,6 +169,8 @@ extension SiteTableViewController: UITableViewDragDelegate {
             return []
         }
 
+        UnifiedTelemetry.recordEvent(category: .action, method: .drag, object: .url, value: .homePanel)
+
         let dragItem = UIDragItem(itemProvider: itemProvider)
         return [dragItem]
     }

--- a/Client/Telemetry/UnifiedTelemetry.swift
+++ b/Client/Telemetry/UnifiedTelemetry.swift
@@ -49,6 +49,11 @@ class UnifiedTelemetry {
            let searchEngines = SearchEngines(prefs: profile.prefs, files: profile.files)
            settings["defaultSearchEngine"] = searchEngines.defaultEngine.engineID ?? "custom"
 
+           if let windowBounds = UIApplication.shared.keyWindow?.bounds {
+               settings["windowWidth"] = windowBounds.width
+               settings["windowHeight"] = windowBounds.height
+           }
+
            outputDict["settings"] = settings
            return outputDict
        }
@@ -74,8 +79,11 @@ extension UnifiedTelemetry {
         case background = "background"
         case change = "change"
         case delete = "delete"
+        case drag = "drag"
+        case drop = "drop"
         case foreground = "foreground"
         case open = "open"
+        case press = "press"
         case scan = "scan"
         case tap = "tap"
         case view = "view"
@@ -85,12 +93,18 @@ extension UnifiedTelemetry {
         case app = "app"
         case bookmark = "bookmark"
         case bookmarksPanel = "bookmarks-panel"
+        case keyCommand = "key-command"
+        case locationBar = "location-bar"
         case qrCodeText = "qr-code-text"
         case qrCodeURL = "qr-code-url"
         case readerModeCloseButton = "reader-mode-close-button"
         case readerModeOpenButton = "reader-mode-open-button"
         case readingListItem = "reading-list-item"
         case setting = "setting"
+        case tab = "tab"
+        case trackingProtectionStatistics = "tracking-protection-statistics"
+        case trackingProtectionWhitelist = "tracking-protection-whitelist"
+        case url = "url"
     }
 
     public enum EventValue: String {
@@ -98,6 +112,8 @@ extension UnifiedTelemetry {
         case appMenu = "app-menu"
         case awesomebarResults = "awesomebar-results"
         case bookmarksPanel = "bookmarks-panel"
+        case browser = "browser"
+        case homePanel = "home-panel"
         case homePanelTabButton = "home-panel-tab-button"
         case markAsRead = "mark-as-read"
         case markAsUnread = "mark-as-unread"
@@ -106,6 +122,8 @@ extension UnifiedTelemetry {
         case readingListPanel = "reading-list-panel"
         case shareExtension = "share-extension"
         case shareMenu = "share-menu"
+        case tabTray = "tab-tray"
+        case topTabs = "top-tabs"
     }
 
     public static func recordEvent(category: EventCategory, method: EventMethod, object: EventObject, value: EventValue, extras: [String : Any?]? = nil) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1444425

This PR adds new UI event telemetry for:
- Tracking Protection (view statistics, add whitelist)
- Drag and Drop (Tabs and URLs)
- Key Commands

It also adds the window width/height to the `settings` dictionary so we can gain insight into split-screen usage on iPad.

Also, requesting data-review? from @liuche (will update wiki with the new events after this lands). I will fill out the data-review questionnaire in Bugzilla.