### PR TITLE
Bug 1444488 - TP stats perf fix: index the rules by base domain

### DIFF
--- a/Client/Frontend/ContentBlocker/TrackingProtectionPageStats.swift
+++ b/Client/Frontend/ContentBlocker/TrackingProtectionPageStats.swift
@@ -160,8 +160,11 @@ fileprivate class TPStatsBlocklists {
                     blockRules[baseDomain] = [Rule]()
                 }
 
-                guard var ruleList = blockRules[baseDomain] else {
-                    return
+                var ruleList: [Rule]
+                if let array = blockRules[baseDomain] {
+                    ruleList = array
+                } else {
+                    ruleList = [Rule]()
                 }
 
                 if AppConstants.BuildChannel != .release {
@@ -183,6 +186,7 @@ fileprivate class TPStatsBlocklists {
                 let resourceType = resourceTypes.contains("font") ? ResourceType.font : .all
 
                 ruleList.append(Rule(regex: filterRegex, loadType: loadType, resourceType: resourceType, domainExceptions: domainExceptionsRegex, list: blockList))
+                blockRules[baseDomain] = ruleList
             }
         }
     }
@@ -191,11 +195,11 @@ fileprivate class TPStatsBlocklists {
         let resourceString = url.absoluteString
         let resourceRange = NSRange(location: 0, length: resourceString.count)
 
-        guard let baseDomain = url.baseDomain, let blockRules = blockRules[baseDomain] else {
+        guard let baseDomain = url.baseDomain, let rules = blockRules[baseDomain] else {
             return nil
         }
 
-        domainSearch: for rule in blockRules {
+        domainSearch: for rule in rules {
             // First, test the top-level filters to see if this URL might be blocked.
             if rule.regex.firstMatch(in: resourceString, options: .anchored, range: resourceRange) != nil {
                 // Check the domain exceptions. If a domain exception matches, this filter does not apply.

--- a/Client/Frontend/ContentBlocker/TrackingProtectionPageStats.swift
+++ b/Client/Frontend/ContentBlocker/TrackingProtectionPageStats.swift
@@ -120,6 +120,9 @@ fileprivate class TPStatsBlocklists {
     }
 
     func load() {
+        // All rules have this prefix on the domain to match.
+        let standardPrefix = "^https?://([^/]+\\.)?"
+        
         for blockList in BlocklistName.all {
             let list: [[String: AnyObject]]
             do {
@@ -147,8 +150,6 @@ fileprivate class TPStatsBlocklists {
                         continue
                 }
 
-                // All rules have this prefix on the domain to match.
-                let standardPrefix = "^https?://([^/]+\\.)?"
                 guard let loc = filter.range(of: standardPrefix) else {
                     assert(false, "url-filter code needs updating for new list format")
                     return

--- a/Client/Frontend/ContentBlocker/TrackingProtectionPageStats.swift
+++ b/Client/Frontend/ContentBlocker/TrackingProtectionPageStats.swift
@@ -46,10 +46,11 @@ class TPStatsBlocklistChecker {
     private var blockLists: TPStatsBlocklists?
 
     func isBlocked(url: URL, isStrictMode: Bool) -> BlocklistName? {
-        guard let blockLists = blockLists else {
+        guard let blockLists = blockLists, let host = url.host, !host.isEmpty else {
             // TP Stats init isn't complete yet
             return nil
         }
+
         let enabledLists = BlocklistName.forStrictMode(isOn: isStrictMode)
         return blockLists.urlIsInList(url).flatMap { return enabledLists.contains($0) ? $0 : nil }
     }
@@ -106,7 +107,7 @@ fileprivate class TPStatsBlocklists {
         }
     }
 
-    private var blockRules = [Rule]()
+    private var blockRules = [String: [Rule]]()
 
     enum LoadType {
         case all
@@ -146,9 +147,31 @@ fileprivate class TPStatsBlocklists {
                         continue
                 }
 
-                let domainExceptionsRegex = (trigger["unless-domain"] as? [String])?.flatMap { domain in
-                        return wildcardContentBlockerDomainToRegex(domain: domain)
+                // All rules have this prefix on the domain to match.
+                let standardPrefix = "^https?://([^/]+\\.)?"
+                guard let loc = filter.range(of: standardPrefix) else {
+                    assert(false, "url-filter code needs updating for new list format")
+                    return
+                }
+                let baseDomain = filter.substring(from: loc.upperBound).replacingOccurrences(of: "\\.", with: ".")
+                assert(!baseDomain.isEmpty)
+                if blockRules[baseDomain] == nil {
+                    blockRules[baseDomain] = [Rule]()
+                }
+
+                guard var ruleList = blockRules[baseDomain] else {
+                    return
+                }
+
+                if AppConstants.BuildChannel != .release {
+                    ["*", "?", "+"].forEach { x in
+                        assert(!baseDomain.contains(x), "No wildcards allowed in baseDomain")
                     }
+                }
+
+                let domainExceptionsRegex = (trigger["unless-domain"] as? [String])?.flatMap { domain in
+                    return wildcardContentBlockerDomainToRegex(domain: domain)
+                }
 
                 // Only "third-party" is supported; other types are not used in our block lists.
                 let loadTypes = trigger["load-type"] as? [String] ?? []
@@ -158,7 +181,7 @@ fileprivate class TPStatsBlocklists {
                 let resourceTypes = trigger["resource-type"] as? [String] ?? []
                 let resourceType = resourceTypes.contains("font") ? ResourceType.font : .all
 
-                blockRules.append(Rule(regex: filterRegex, loadType: loadType, resourceType: resourceType, domainExceptions: domainExceptionsRegex, list: blockList))
+                ruleList.append(Rule(regex: filterRegex, loadType: loadType, resourceType: resourceType, domainExceptions: domainExceptionsRegex, list: blockList))
             }
         }
     }
@@ -166,6 +189,10 @@ fileprivate class TPStatsBlocklists {
     func urlIsInList(_ url: URL) -> BlocklistName? {
         let resourceString = url.absoluteString
         let resourceRange = NSRange(location: 0, length: resourceString.count)
+
+        guard let baseDomain = url.baseDomain, let blockRules = blockRules[baseDomain] else {
+            return nil
+        }
 
         domainSearch: for rule in blockRules {
             // First, test the top-level filters to see if this URL might be blocked.


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1444488

Can simply index the block rules by base domain, and for each base domain there are typically 1-2 rules, sometimes 4-5. So instead of 2300 rules checks per url, we do 1-5.