### PR TITLE
Bug 1445172 - Fix XCUI First Run Tests

### DIFF
--- a/XCUITests/FirstRunTourTests.swift
+++ b/XCUITests/FirstRunTourTests.swift
@@ -14,7 +14,7 @@ class FirstRunTourTests: BaseTestCase {
         // Check that the first's tour screen is shown as well as all the elements in there
         waitforExistence(app.scrollViews["IntroViewController.scrollView"])
         waitforExistence(app.staticTexts["Thanks for choosing Firefox!"])
-        XCTAssertTrue(app.buttons["IntroViewController.startBrowsingButton"].exists)
+        XCTAssertFalse(app.buttons["IntroViewController.startBrowsingButton"].exists)
         XCTAssertTrue(app.images["tour-Welcome"].exists)
         XCTAssertTrue(app.pageIndicators["IntroViewController.pageControl"].exists)
         XCTAssertEqual(app.pageIndicators["IntroViewController.pageControl"].value as? String, "page 1 of 5")
@@ -63,11 +63,6 @@ class FirstRunTourTests: BaseTestCase {
         waitforExistence(topSites)
     }
 
-   func testStartBrowsingFromFirstScreen() {
-        navigator.goto(FirstRun)
-        tapStartBrowsingButton()
-    }
-
     func testStartBrowsingFromSecondScreen() {
         navigator.goto(FirstRun)
         goToNextScreen(swipe: 1)
@@ -93,6 +88,7 @@ class FirstRunTourTests: BaseTestCase {
     }
 
     func testShowTourFromSettings() {
+        goToNextScreen(swipe: 1)
         tapStartBrowsingButton()
         navigator.goto(ShowTourInSettings)
         waitforExistence(app.scrollViews["IntroViewController.scrollView"])


### PR DESCRIPTION
According to previous [PR](https://github.com/mozilla-mobile/firefox-ios/commit/8f3f4716ef3556b9e759bef1e1d00e4f7ffcfbc0), Start Browsing button should not be shown on the first screen. XCUITests are updated in this PR to work accordingly.