### PR TITLE
Bug 1444365 - Fix Tracking Protection shield appearance issues. 

### DIFF
--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -51,7 +51,9 @@ class TabLocationView: UIView, TabEventHandler {
             }
             updateTextWithURL()
             pageOptionsButton.isHidden = (url == nil)
-            trackingProtectionView.isHidden = (url == nil)
+            if url == nil {
+                trackingProtectionView.isHidden = true
+            }
             setNeedsUpdateConstraints()
         }
     }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -842,8 +842,7 @@ extension TabManager: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
         UIApplication.shared.isNetworkActivityIndicatorVisible = true
 
-        if #available(iOS 11, *) {
-            guard let tab = self[webView], let blocker = tab.contentBlocker as? ContentBlockerHelper else { return }
+        if #available(iOS 11, *), let tab = self[webView], let blocker = tab.contentBlocker as? ContentBlockerHelper {
             blocker.clearPageStats()
         }
     }

--- a/Client/Frontend/ContentBlocker/ContentBlockerHelper+TabContentScript.swift
+++ b/Client/Frontend/ContentBlocker/ContentBlockerHelper+TabContentScript.swift
@@ -24,11 +24,15 @@ extension ContentBlockerHelper: TabContentScript {
         guard isEnabled,
             let body = message.body as? [String: String],
             let urlString = body["url"],
-            let mainDocumentUrl = tab?.webView?.url,
-            !ContentBlockerHelper.isWhitelisted(url: mainDocumentUrl) else {
+            let mainDocumentUrl = tab?.webView?.url else {
             return
         }
-
+        
+        // Reset the pageStats to make sure the trackingprotection shield icon knows that a page was whitelisted
+        guard !ContentBlockerHelper.isWhitelisted(url: mainDocumentUrl) else {
+            clearPageStats()
+            return
+        }
         guard var components = URLComponents(string: urlString) else { return }
         components.scheme = "http"
         guard let url = components.url else { return }

--- a/Client/Frontend/ContentBlocker/ContentBlockerHelper.swift
+++ b/Client/Frontend/ContentBlocker/ContentBlockerHelper.swift
@@ -67,7 +67,9 @@ class ContentBlockerHelper {
     var isUserEnabled: Bool? {
         didSet {
             setupTabTrackingProtection()
-            tab?.reload()
+            guard let tab = tab else { return }
+            TabEvent.post(.didChangeContentBlocking, for: tab)
+            tab.reload()
         }
     }
 
@@ -96,7 +98,7 @@ class ContentBlockerHelper {
     var stats: TPPageStats = TPPageStats() {
         didSet {
             guard let tab = self.tab else { return }
-            if (stats.total == 0 && oldValue.total != 0) || stats.total == 1 {
+            if stats.total <= 1 {
                 TabEvent.post(.didChangeContentBlocking, for: tab)
             }
         }

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -271,7 +271,12 @@ extension PhotonActionSheetProtocol {
     @available(iOS 11.0, *)
     private func menuActionsForTrackingProtectionDisabled(for tab: Tab, presentingOn urlBar: URLBarView) -> [PhotonActionSheetItem] {
         let enableTP = PhotonActionSheetItem(title: Strings.EnableTPBlocking, iconString: "menu-TrackingProtection") { _ in
-            ContentBlockerHelper.toggleTrackingProtectionMode(for: self.profile.prefs, tabManager: self.tabManager)
+            // When TP is off for the tab tapping enable in this menu should turn it back on for the Tab.
+            if let blocker = tab.contentBlocker as? ContentBlockerHelper, blocker.isUserEnabled == false {
+                blocker.isUserEnabled = true
+            } else {
+                ContentBlockerHelper.toggleTrackingProtectionMode(for: self.profile.prefs, tabManager: self.tabManager)
+            }
             tab.reload()
         }
 


### PR DESCRIPTION
There were a few different issues that I wanted to fix (this was just bad logic)
- When the url is not nil the should should not be enabled
- If that tab has Tracking protection turned off enabling TP from the TP submenu should toggle the per tab setting and not the global TP setting. 
- A whitelisted site should still report its blocker status to make sure the UI can update.