### PR TITLE
Bug 1439825 - Fix ThirdParty Intermittent XCUITest

### DIFF
--- a/XCUITests/ThirdPartySearchTest.swift
+++ b/XCUITests/ThirdPartySearchTest.swift
@@ -145,6 +145,13 @@ class ThirdPartySearchTest: BaseTestCase {
 
         // Ensure that correct search is done
         let url = app.textFields["url"].value as! String
+        if (!url.hasSuffix("&btnI")) {
+            app.buttons["Back"].tap()
+            app.textFields["url"].tap()
+            app.typeText("strange charm")
+            app.scrollViews.otherElements.buttons["Feeling Lucky search"].tap()
+            XCTAssert(url.hasSuffix("&btnI"), "The URL should indicate that the search was performed using IFL")
+        }
         XCTAssert(url.hasSuffix("&btnI"), "The URL should indicate that the search was performed using IFL")
     }
 


### PR DESCRIPTION
This XCUITest is failing lately on iPhone and sometimes on iPad sims:
- testCustomEngineFromCorrectTemplate

Lets add a double check before failing it to see if we can avoid the timing issue