### PR TITLE
Bug  1445586 - Passcode screen notification unhooked on viewDidDisappear

### DIFF
--- a/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
+++ b/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
@@ -240,10 +240,6 @@ class AuthenticationSettingsViewController: SettingsTableViewController {
         tableView.accessibilityIdentifier = "AuthenticationManager.settingsTableView"
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     override func generateSettings() -> [SettingSection] {
         if let _ = KeychainWrapper.sharedAppContainerKeychain.authenticationInfo() {
             return passcodeEnabledSettings()

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -529,7 +529,7 @@ class SettingsTableViewController: UITableViewController {
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        NotificationCenter.default.removeObserver(self)    }
+    }
 
     // Override to provide settings in subclasses
     func generateSettings() -> [SettingSection] {

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -515,6 +515,7 @@ class SettingsTableViewController: UITableViewController {
 
         settings = generateSettings()
 
+        // Because these are added in viewWillAppear, unhook in viewDidDisappear for symmetry.
         NotificationCenter.default.addObserver(self, selector: #selector(SELsyncDidChangeState), name: .ProfileDidStartSyncing, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(SELsyncDidChangeState), name: .ProfileDidFinishSyncing, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(SELfirefoxAccountDidChange), name: .FirefoxAccountChanged, object: nil)
@@ -529,6 +530,10 @@ class SettingsTableViewController: UITableViewController {
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
+
+        [Notification.Name.ProfileDidStartSyncing, Notification.Name.ProfileDidFinishSyncing, Notification.Name.FirefoxAccountChanged].forEach { name in
+            NotificationCenter.default.removeObserver(self, name: name, object: nil)
+        }
     }
 
     // Override to provide settings in subclasses


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1445586

SettingsTableViewController has notifications observers for sync which update the UI. In older code these were unhooked (by removeObserver) in the disappear. This is not needed. There is no harm in updating the view while it is not visible. SettingsViewController will get a `NotificationCenter.default.removeObserver(self)` called automatically by iOS during deinit  (which happens after the settings dialog is dismissed).