### PR TITLE
Bug 1436716 - New XCUITest to cover more scenarios when leaving PM wi…

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
@@ -215,6 +215,9 @@
                   Identifier = "NavigationTest/testToggleBetweenMobileAndDesktopSiteFromSite()">
                </Test>
                <Test
+                  Identifier = "PrivateBrowsingTest/testClosePrivateTabsOptionClosesPrivateTabsShortCutiPad()">
+               </Test>
+               <Test
                   Identifier = "PrivateBrowsingTest/testiPadDirectAccessPrivateMode()">
                </Test>
                <Test


### PR DESCRIPTION
…th close private tabs option enabled

This PR is to add more tests to cover different scenarios when leaving PrivateMode with Close Private Tabs option enabled because there were some bugs in the past around this feature ([Bug 434545](https://bugzilla.mozilla.org/show_bug.cgi?id=1434545))