### PR TITLE
Bug 1447023 - Opening a tab from tabs tray does not automatically focus on the tab after using 3DT

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1248,9 +1248,9 @@ extension BrowserViewController: URLBarDelegate {
     func showTabTray() {
         webViewContainerToolbar.isHidden = true
         updateFindInPageVisibility(visible: false)
-        
-        let tabTrayController = TabTrayController(tabManager: tabManager, profile: profile, tabTrayDelegate: self)
-        
+
+        let tabTrayController = self.tabTrayController ?? TabTrayController(tabManager: tabManager, profile: profile, tabTrayDelegate: self)
+
         if let tab = tabManager.selectedTab {
             screenshotHelper.takeScreenshot(tab)
         }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -358,6 +358,7 @@ class TabTrayController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        collectionView.reloadData()
     }
 
     override func viewDidDisappear(_ animated: Bool) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1447023