### PR TITLE
Bug 1447918 - XCUITest Disable Third Party Intermittent Failing Test

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
@@ -230,6 +230,9 @@
                   Identifier = "SiteLoadTest">
                </Test>
                <Test
+                  Identifier = "ThirdPartySearchTest/testCustomEngineFromCorrectTemplate()">
+               </Test>
+               <Test
                   Identifier = "ToolbarTests/testShowDoNotShowToolbarWhenScrollingLandscape()">
                </Test>
                <Test

--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests_iPad.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests_iPad.xcscheme
@@ -218,6 +218,9 @@
                   Identifier = "SiteLoadTest">
                </Test>
                <Test
+                  Identifier = "ThirdPartySearchTest/testCustomEngineFromCorrectTemplate()">
+               </Test>
+               <Test
                   Identifier = "ToolbarTests/testShowDoNotShowToolbarWhenScrollingLandscape()">
                </Test>
                <Test


### PR DESCRIPTION
This PR is to disable this test, ThirdParty test suite:
-testCustomEngineFromCorrectTemplate

While we investigate how to re-write it so that it does not intermittently fail