### PR TITLE
Bug 1446938 - XCUITest Update ThirdParty use custom search engine test

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
@@ -230,9 +230,6 @@
                   Identifier = "SiteLoadTest">
                </Test>
                <Test
-                  Identifier = "ThirdPartySearchTest/testCustomEngineFromCorrectTemplate()">
-               </Test>
-               <Test
                   Identifier = "ToolbarTests/testShowDoNotShowToolbarWhenScrollingLandscape()">
                </Test>
                <Test

--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests_iPad.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests_iPad.xcscheme
@@ -218,9 +218,6 @@
                   Identifier = "SiteLoadTest">
                </Test>
                <Test
-                  Identifier = "ThirdPartySearchTest/testCustomEngineFromCorrectTemplate()">
-               </Test>
-               <Test
                   Identifier = "ToolbarTests/testShowDoNotShowToolbarWhenScrollingLandscape()">
                </Test>
                <Test

--- a/XCUITests/ThirdPartySearchTest.swift
+++ b/XCUITests/ThirdPartySearchTest.swift
@@ -131,28 +131,20 @@ class ThirdPartySearchTest: BaseTestCase {
         app.tables.cells["customEngineViewButton"].tap()
 
         app.textViews["customEngineTitle"].tap()
-        app.typeText("Feeling Lucky")
+        app.typeText("Ask")
         app.textViews["customEngineUrl"].tap()
-        app.typeText("http://www.google.com/search?q=%s&btnI")
-
+        app.typeText("http://www.ask.com/web?q=%s")
         app.navigationBars.buttons["customEngineSaveButton"].tap()
 
         // Perform a search using a custom search engine
         navigator.goto(HomePanelsScreen)
         app.textFields["url"].tap()
         app.typeText("strange charm")
-        app.scrollViews.otherElements.buttons["Feeling Lucky search"].tap()
+        app.scrollViews.otherElements.buttons["Ask search"].tap()
 
         // Ensure that correct search is done
         let url = app.textFields["url"].value as! String
-        if (!url.hasSuffix("&btnI")) {
-            app.buttons["Back"].tap()
-            app.textFields["url"].tap()
-            app.typeText("strange charm")
-            app.scrollViews.otherElements.buttons["Feeling Lucky search"].tap()
-            XCTAssert(url.hasSuffix("&btnI"), "The URL should indicate that the search was performed using IFL")
-        }
-        XCTAssert(url.hasSuffix("&btnI"), "The URL should indicate that the search was performed using IFL")
+        XCTAssert(url.hasPrefix("www.ask.com"), "The URL should indicate that the search was performed using ask")
     }
 
     func testCustomEngineFromIncorrectTemplate() {


### PR DESCRIPTION
ThirdParty test: testCustomEngineFromCorrectTemplate()
Was failing intermittently because the custom search engine used and its behaviour. With this PR we have changed the search engine used to one that has a consistent behaviour when performing a search.
