### PR TITLE
Bug 1447677: history DB fixture test requires setting launch args properly

### DIFF
--- a/XCUITests/BaseTestCase.swift
+++ b/XCUITests/BaseTestCase.swift
@@ -7,21 +7,32 @@ import XCTest
 
 class BaseTestCase: XCTestCase {
     var navigator: MMNavigator<FxUserState>!
-    var app: XCUIApplication!
+    let app =  XCUIApplication()
     var userState: FxUserState!
 
-    override func setUp() {
-        super.setUp()
-        continueAfterFailure = false
-        app = XCUIApplication()
-        app.terminate()
-        restart(app, args: [LaunchArguments.ClearProfile, LaunchArguments.SkipIntro, LaunchArguments.SkipWhatsNew])
+    // These are used during setUp(). Change them prior to setUp() for the app to launch with different args,
+    // or, use restart() to re-launch with custom args.
+    var launchArguments = [LaunchArguments.ClearProfile, LaunchArguments.SkipIntro, LaunchArguments.SkipWhatsNew]
+
+    func setUpScreenGraph() {
         navigator = createScreenGraph(for: self, with: app).navigator()
         userState = navigator.userState
     }
 
+    func setUpApp() {
+        app.launchArguments = [LaunchArguments.Test] + launchArguments
+        app.launch()
+    }
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        setUpApp()
+        setUpScreenGraph()
+    }
+
     override func tearDown() {
-        XCUIApplication().terminate()
+        app.terminate()
         super.tearDown()
     }
 
@@ -116,3 +127,4 @@ extension XCUIElement {
         }
     }
 }
+

--- a/XCUITests/DatabaseFixtureTest.swift
+++ b/XCUITests/DatabaseFixtureTest.swift
@@ -5,25 +5,24 @@
 import XCTest
 
 class DatabaseFixtureTest: BaseTestCase {
-    func testDatabaseFixture() {
-        let file = "testDatabaseFixture-browser.db"
-        let arg = LaunchArguments.LoadDatabasePrefix + file
-        app.terminate()
-        restart(app, args: [LaunchArguments.SkipIntro, LaunchArguments.SkipWhatsNew, arg])
+    let fixtures = ["testOneBookmark": "testDatabaseFixture-browser.db", "testHistoryDatabaseFixture": "testHistoryDatabase4000-browser.db"]
 
-        // app will now start with prepopulated database
+    override func setUp() {
+        // Test name looks like: "[Class testFunc]", parse out the function name
+        let parts = name!.replacingOccurrences(of: "]", with: "").split(separator: " ")
+        let key = String(parts[1])
+        // for the current test name, add the db fixture used
+        launchArguments = [LaunchArguments.SkipIntro, LaunchArguments.SkipWhatsNew, LaunchArguments.LoadDatabasePrefix + fixtures[key]!]
+        super.setUp()
+    }
+
+    func testOneBookmark() {
         navigator.browserPerformAction(.openBookMarksOption)
         let list = app.tables["Bookmarks List"].cells.count
         XCTAssertEqual(list, 1, "There should be an entry in the bookmarks list")
     }
 
     func testHistoryDatabaseFixture() {
-        let file = "testHistoryDatabase4000-browser.db"
-        let arg = LaunchArguments.LoadDatabasePrefix + file
-        app.terminate()
-        restart(app, args: [LaunchArguments.SkipIntro, LaunchArguments.SkipWhatsNew, arg])
-
-        // app will now start with prepopulated database
         navigator.goto(HomePanel_History)
         //History list has two cells that are for recently closed and synced devices that should not count as history items
         let historyList = app.tables["History List"].cells.count-2

--- a/XCUITests/FirstRunTourTests.swift
+++ b/XCUITests/FirstRunTourTests.swift
@@ -4,9 +4,8 @@ import XCTest
 class FirstRunTourTests: BaseTestCase {
 
     override func setUp() {
-        app = XCUIApplication()
-        restart(app, args: [LaunchArguments.ClearProfile])
-        navigator = createScreenGraph(for: self, with: app).navigator()
+        launchArguments = [LaunchArguments.ClearProfile]
+        super.setUp()
     }
 
     func testFirstRunTour() {


### PR DESCRIPTION
We need to set the args without launching and immediately restarting as -for reasons
unknown- the DB doesn't load properly (ONLY on-device, works in sim) if done that way.

This work is part of: https://bugzilla.mozilla.org/show_bug.cgi?id=1447677