### PR TITLE
Bug 1434695 - Load cached clients when showing the client picker in Send Tab.

### DIFF
--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -217,6 +217,10 @@ open class MockProfile: Profile {
         return deferMaybe([])
     }
 
+    public func getCachedClients() -> Deferred<Maybe<[RemoteClient]>> {
+        return deferMaybe([])
+    }
+
     public func getClientsAndTabs() -> Deferred<Maybe<[ClientAndTabs]>> {
         return deferMaybe([])
     }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -141,6 +141,7 @@ protocol Profile: class {
     func flushAccount()
 
     func getClients() -> Deferred<Maybe<[RemoteClient]>>
+    func getCachedClients()-> Deferred<Maybe<[RemoteClient]>>
     func getClientsAndTabs() -> Deferred<Maybe<[ClientAndTabs]>>
     func getCachedClientsAndTabs() -> Deferred<Maybe<[ClientAndTabs]>>
 
@@ -416,6 +417,10 @@ open class BrowserProfile: Profile {
     public func getClients() -> Deferred<Maybe<[RemoteClient]>> {
         return self.syncManager.syncClients()
            >>> { self.remoteClientsAndTabs.getClients() }
+    }
+
+    public func getCachedClients()-> Deferred<Maybe<[RemoteClient]>> {
+        return self.remoteClientsAndTabs.getClients()
     }
 
     public func getClientsAndTabs() -> Deferred<Maybe<[ClientAndTabs]>> {

--- a/Storage/RemoteTabs.swift
+++ b/Storage/RemoteTabs.swift
@@ -39,8 +39,6 @@ public protocol RemoteClientsAndTabs: SyncCommands {
     func getClients() -> Deferred<Maybe<[RemoteClient]>>
     func getClient(guid: GUID) -> Deferred<Maybe<RemoteClient?>>
     func getClient(fxaDeviceId: String) -> Deferred<Maybe<RemoteClient?>>
-    @available(*, deprecated, message: "use getClient(guid:) instead")
-    func getClientWithId(_ clientID: GUID) -> Deferred<Maybe<RemoteClient?>>
     func getClientsAndTabs() -> Deferred<Maybe<[ClientAndTabs]>>
     func getTabsForClientWithGUID(_ guid: GUID?) -> Deferred<Maybe<[RemoteTab]>>
     func insertOrUpdateClient(_ client: RemoteClient) -> Deferred<Maybe<Int>>

--- a/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
+++ b/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
@@ -181,10 +181,6 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
         return self.db.runQuery("SELECT * FROM \(TableClients) WHERE fxaDeviceId = ?", args: [fxaDeviceId], factory: factory) >>== { deferMaybe($0[0]) }
     }
 
-    open func getClientWithId(_ clientID: GUID) -> Deferred<Maybe<RemoteClient?>> {
-        return self.getClient(guid: clientID)
-    }
-
     open func getClients() -> Deferred<Maybe<[RemoteClient]>> {
         return db.withConnection { connection -> [RemoteClient] in
             let cursor = connection.executeQuery("SELECT * FROM \(TableClients) WHERE EXISTS (SELECT 1 FROM \(TableRemoteDevices) rd WHERE rd.guid = fxaDeviceId) ORDER BY modified DESC", factory: SQLiteRemoteClientsAndTabs.remoteClientFactory)

--- a/StorageTests/TestSQLiteRemoteClientsAndTabs.swift
+++ b/StorageTests/TestSQLiteRemoteClientsAndTabs.swift
@@ -94,10 +94,6 @@ open class MockRemoteClientsAndTabs: RemoteClientsAndTabs {
             }?.client)
     }
 
-    open func getClientWithId(_ clientID: GUID) -> Deferred<Maybe<RemoteClient?>> {
-        return getClient(guid: clientID)
-    }
-
     open func getClientGUIDs() -> Deferred<Maybe<Set<GUID>>> {
         return deferMaybe(Set<GUID>(optFilter(self.clientsAndTabs.map { $0.client.guid })))
     }

--- a/Sync/Synchronizers/Bookmarks/BookmarksRepairRequestor.swift
+++ b/Sync/Synchronizers/Bookmarks/BookmarksRepairRequestor.swift
@@ -295,7 +295,7 @@ class BookmarksRepairRequestor {
                 // So we've sent a request - and don't yet have a response. See if the
                 // client we sent it to has removed it from its list (ie, whether it
                 // has synced since we wrote the request.)
-                return self.remoteClients.getClientWithId(clientID) >>== { client in
+                return self.remoteClients.getClient(guid: clientID) >>== { client in
                     guard let client = client else {
                         // hrmph - the client has disappeared.
                         log.info("previously requested client \(clientID) has vanished - moving to next step")

--- a/Sync/Synchronizers/ClientsSynchronizer.swift
+++ b/Sync/Synchronizers/ClientsSynchronizer.swift
@@ -77,11 +77,11 @@ open class DisplayURICommand: Command {
             return succeed()
         }
 
-        guard let getClientWithId = synchronizer.localClients?.getClientWithId(sender) else {
+        guard let sender = synchronizer.localClients?.getClient(guid: sender) else {
             return display()
         }
 
-        return getClientWithId >>== { client in
+        return sender >>== { client in
             return display(client?.name)
         }
     }

--- a/SyncTests/TestBookmarksRepairRequestor.swift
+++ b/SyncTests/TestBookmarksRepairRequestor.swift
@@ -463,10 +463,6 @@ open class MockRemoteClientsAndTabs: RemoteClientsAndTabs {
         return deferMaybe(self.clientsAndTabs.map { $0.client })
     }
 
-    open func getClientWithId(_ clientID: GUID) -> Deferred<Maybe<RemoteClient?>> {
-        return self.getClient(guid: clientID)
-    }
-
     open func getClient(fxaDeviceId: String) -> Deferred<Maybe<RemoteClient?>> {
         return deferMaybe(self.clientsAndTabs.find { clientAndTabs in
             return clientAndTabs.client.fxaDeviceId == fxaDeviceId


### PR DESCRIPTION
This has been bugging me for years, so I thought I'd just fix it.

The one thing I haven't verified is the empty state for when you're signed in but there are no other clients. I saw a blank screen, but that doesn't seem right.

---

Previously we would kick off a refresh spinner, do a full sync of clients, then fetch them from the DB. Only then would we display clients to choose.

Most users' client lists will almost never change — certainly not multiple times a day. The clients synchronizer will debounce a little, but it still does an extraordinary amount of work to even get to that point.

With this PR, we **first** fetch the client list from the DB. If there are no clients, we kick off a regular refresh with spinner. If there are clients, we silently run a client sync (no spinner) and update the displayed list if it changes.

Pull-to-refresh is unaffected.

Test plan:

* Create a new mobile profile.
* Attempt to send a tab. You should see the empty state, prompting you to create an account.
* Cancel.
* Create and verify a new account on the device.
* Attempt to send a tab. You should see a useful empty state after a visible refresh. I don't know if this behavior has changed with my patch.
* Cancel.
* Sign in to the new account on a new desktop profile.
* Back on the iOS device, attempt to send a tab. You should see a visible refresh, then the desktop device will appear in the list.
* Cancel.
* Attempt to send a tab again. You should see no visible refresh, and an almost instant display of the desktop device.
* Cancel.
* On the desktop device, change the device name.
* On iOS, attempt to send a tab again. You should see no visible refresh. The list will appear with the old desktop device name, then a moment later will be replaced with the altered device name. No refresh indicator will show at any point.
* Pull to refresh should work, showing no change in results.
* Change the desktop device name again.
* Back on iOS, pull to refresh should work, showing the changed name.

