### PR TITLE
Bug 1447629 - Size PhotonActionSheet correctly. 

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet.swift
@@ -57,6 +57,7 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
     private var site: Site?
     private let style: PresentationStyle
     private var tintColor = UIColor.Photon.Grey80
+    private var heightConstraint: Constraint?
     private lazy var showCloseButton: Bool = {
         return self.style == .bottom && self.modalPresentationStyle != .popover
     }()
@@ -182,7 +183,8 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
         tableView.register(UITableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: "EmptyHeader")
         tableView.estimatedRowHeight = PhotonActionSheetUX.RowHeight
         tableView.estimatedSectionFooterHeight = PhotonActionSheetUX.HeaderFooterHeight
-        tableView.estimatedSectionHeaderHeight = PhotonActionSheetUX.HeaderFooterHeight
+        // When the menu style is centered the header is much bigger than default. Set a larger estimated height to make sure autolayout sizes the view correctly
+        tableView.estimatedSectionHeaderHeight = (style == .centered) ? PhotonActionSheetUX.RowHeight : PhotonActionSheetUX.HeaderFooterHeight
         tableView.isScrollEnabled = true
         tableView.showsVerticalScrollIndicator = false
         tableView.layer.cornerRadius = PhotonActionSheetUX.CornerRadius
@@ -198,8 +200,9 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
         super.viewDidLayoutSubviews()
         let maxHeight = self.view.frame.height - (self.showCloseButton ? PhotonActionSheetUX.CloseButtonHeight : 0)
         tableView.snp.makeConstraints { make in
+            heightConstraint?.deactivate()
             // The height of the menu should be no more than 80 percent of the screen
-            make.height.equalTo(min(self.tableView.contentSize.height, maxHeight * 0.8))
+            heightConstraint = make.height.equalTo(min(self.tableView.contentSize.height, maxHeight * 0.8)).constraint
         }
         if style == .bottom && self.modalPresentationStyle == .popover {
             self.preferredContentSize = self.tableView.contentSize

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -21,8 +21,9 @@ extension PhotonActionSheetProtocol {
     typealias URLOpenAction = (URL?, IsPrivateTab) -> Void
     
     func presentSheetWith(title: String? = nil, actions: [[PhotonActionSheetItem]], on viewController: PresentableVC, from view: UIView, suppressPopover: Bool = false) {
-        let sheet = PhotonActionSheet(title: title, actions: actions)
-        sheet.modalPresentationStyle =  (UIDevice.current.userInterfaceIdiom == .pad && !suppressPopover) ? .popover : .overCurrentContext
+        let style: UIModalPresentationStyle = (UIDevice.current.userInterfaceIdiom == .pad && !suppressPopover) ? .popover : .overCurrentContext
+        let sheet = PhotonActionSheet(title: title, actions: actions, style: style)
+        sheet.modalPresentationStyle = style
         sheet.photonTransitionDelegate = PhotonActionSheetAnimator()
         
         if let popoverVC = sheet.popoverPresentationController, sheet.modalPresentationStyle == .popover {


### PR DESCRIPTION
This fix is made up of 2 parts.

1. Use a larger  estimatedSectionHeaderHeight when the menu is used in the long press action (The menu with the site favicon)
2. Remove the old constraint when calling `viewDidLayoutSubviews` again. This doesn't work as well because we only call 'viewDidLayoutSubviews` once. But I still think its the right thing to do. 