### PR TITLE
Bug 1135920 - Support being the default browser

### DIFF
--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -56,7 +56,7 @@
 			<string>org.mozilla.Client</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>http</string>
+				<string>http, https</string>
 			</array>
 		</dict>
 	</array>

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -49,6 +49,16 @@
 				<string>$(MOZ_INTERNAL_URL_SCHEME)</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>org.mozilla.Client</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>http</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>


### PR DESCRIPTION
This PR add default browser support to Firefox. When Safari is disabled in the Restriction settings then iOS will look for apps that register support for the http scheme. This add the http scheme to the app's supported URL types. iCab Mobile already supports this feature so I don't see why Firefox can't support it as well.

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Bug 12345678 - This fixes something something`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Notes for testing this patch

1. Disable Safari by opening Settings.app > General > Restrictions > Safari > Off
2. Open a link in any app
3. See that the link opens in Firefox. If this is the first time this action is preformed then iOS will show a pop up asking if the user wants to open the link in Firefox. Also make sure that iCab Mobile isn't installed as it also wants to be the default browser when Safari is disabled.