### PR TITLE
Bug 1449295 - XCUITest DB fixture load fails due to WAL file locking

### DIFF
--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -30,7 +30,13 @@ class TestAppDelegate: AppDelegate {
                 let profileDir = "\(appRootDir())/profile.testProfile"
                 try? FileManager.default.createDirectory(atPath: profileDir, withIntermediateDirectories: false, attributes: nil)
                 let output = URL(fileURLWithPath: "\(profileDir)/browser.db")
-                try? FileManager.default.removeItem(at: output)
+
+                let enumerator = FileManager.default.enumerator(atPath: profileDir)
+                let filePaths = enumerator?.allObjects as! [String]
+                filePaths.filter{ $0.contains(".db") }.forEach { item in
+                    try! FileManager.default.removeItem(at: URL(fileURLWithPath: "\(profileDir)/\(item)"))
+                }
+
                 try! FileManager.default.copyItem(at: input, to: output)
             }
         }

--- a/XCUITests/DatabaseFixtureTest.swift
+++ b/XCUITests/DatabaseFixtureTest.swift
@@ -24,8 +24,11 @@ class DatabaseFixtureTest: BaseTestCase {
 
     func testHistoryDatabaseFixture() {
         navigator.goto(HomePanel_History)
+        // Small delay to avoid intermittent failures
+        // Ideally, we would wait for the table to become populated, not sure how to do that.
+        sleep(1)
         //History list has two cells that are for recently closed and synced devices that should not count as history items
-        let historyList = app.tables["History List"].cells.count-2
+        let historyList = app.tables["History List"].cells.count - 2
         XCTAssertEqual(historyList, 100, "There should be an entry in the bookmarks list")
     }
 }

--- a/XCUITests/DatabaseFixtureTest.swift
+++ b/XCUITests/DatabaseFixtureTest.swift
@@ -24,11 +24,11 @@ class DatabaseFixtureTest: BaseTestCase {
 
     func testHistoryDatabaseFixture() {
         navigator.goto(HomePanel_History)
-        // Small delay to avoid intermittent failures
-        // Ideally, we would wait for the table to become populated, not sure how to do that.
-        sleep(1)
-        //History list has two cells that are for recently closed and synced devices that should not count as history items
-        let historyList = app.tables["History List"].cells.count - 2
-        XCTAssertEqual(historyList, 100, "There should be an entry in the bookmarks list")
+
+        // History list has two cells that are for recently closed and synced devices that should not count as history items,
+        // the actual max number is 100
+        let loaded = NSPredicate(format: "count == 102")
+        expectation(for: loaded, evaluatedWith: app.tables["History List"].cells, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1449295
Delete all db files in the profile dir before copying in the db fixture.