### PR TITLE
Bug 1190602 - Formatting of 'Licenses' could use some clean up.

### DIFF
--- a/Client/Assets/About/Licenses.html
+++ b/Client/Assets/About/Licenses.html
@@ -13,11 +13,51 @@ body,p,h1,h2,h3 {
 h2 {
     padding: 0;
     margin: 0;
-    text-transform: uppercase;
 }
 .link {
   margin: 0;
   text-size: 55%;
+}
+
+/* accordion behavior */
+
+/* hide checkboxes */
+.ac-container input { 
+	display: none;
+}
+/* default to 'closed' */
+.ac-container article {
+	margin-top: -1px;
+	overflow: hidden;
+	height: 0px;
+	position: relative;
+	z-index: 10;
+}
+/* 'open' when checked */
+.ac-container input:checked ~ article {
+	height: auto;
+}
+/* '+/-' indicator styles/spacing */
+.ac-container label {
+	display: block;
+	padding-right: 21px
+}
+.ac-container h4,
+.ac-container h2 {
+	display: inline-block;
+	padding-right: 17px;
+}
+.ac-container label h4:after,
+.ac-container label h2:after {
+	content: '\02795';
+	font-size: 1rem;
+	display: inline-block;
+	position: absolute;
+	right: 17px;	
+}
+.ac-container input:checked + label h4:after,
+.ac-container input:checked + label h2:after {
+	content: "\2796";	
 }
 </style>
 </head>
@@ -30,9 +70,12 @@ h2 {
 
 
 
-
 <h3 id="mozilla-public-license-version-2.0">Mozilla Public License<br>Version 2.0</h3>
-<h4 id="definitions">1. Definitions</h4>
+<div class="ac-container">
+<div>
+<input id="ac-1" name="accordion-1" type="checkbox" />
+<label for="ac-1"><h4 id="definitions">1. Definitions</h4></label>
+<article>
 <dl>
 <dt>1.1. “Contributor”</dt>
 <dd><p>means each individual or legal entity that creates, contributes to the creation of, or owns Covered Software.</p>
@@ -85,7 +128,12 @@ h2 {
 <dd><p>means an individual or a legal entity exercising rights under this License. For legal entities, “You” includes any entity that controls, is controlled by, or is under common control with You. For purposes of this definition, “control” means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of more than fifty percent (50%) of the outstanding shares or beneficial ownership of such entity.</p>
 </dd>
 </dl>
-<h4 id="license-grants-and-conditions">2. License Grants and Conditions</h4>
+</article>
+</div>
+<div>
+<input id="ac-2" name="accordion-1" type="checkbox" />
+<label for="ac-2"><h4 id="license-grants-and-conditions">2. License Grants and Conditions</h4></label>
+<article>
 <h3 id="grants">2.1. Grants</h3>
 <p>Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license:</p>
 <ol type="a">
@@ -110,7 +158,12 @@ h2 {
 <p>This License is not intended to limit any rights You have under applicable copyright doctrines of fair use, fair dealing, or other equivalents.</p>
 <h3 id="conditions">2.7. Conditions</h3>
 <p>Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in Section&nbsp;2.1.</p>
-<h4 id="responsibilities">3. Responsibilities</h4>
+</article>
+</div>
+<div>
+<input id="ac-3" name="accordion-1" type="checkbox" />
+<label for="ac-3"><h4 id="responsibilities">3. Responsibilities</h4></label>
+<article>
 <h3 id="distribution-of-source-form">3.1. Distribution of Source Form</h3>
 <p>All distribution of Covered Software in Source Code Form, including any Modifications that You create or to which You contribute, must be under the terms of this License. You must inform recipients that the Source Code Form of the Covered Software is governed by the terms of this License, and how they can obtain a copy of this License. You may not attempt to alter or restrict the recipients’ rights in the Source Code Form.</p>
 <h3 id="distribution-of-executable-form">3.2. Distribution of Executable Form</h3>
@@ -125,21 +178,56 @@ h2 {
 <p>You may not remove or alter the substance of any license notices (including copyright notices, patent notices, disclaimers of warranty, or limitations of liability) contained within the Source Code Form of the Covered Software, except that You may alter any license notices to the extent required to remedy known factual inaccuracies.</p>
 <h3 id="application-of-additional-terms">3.5. Application of Additional Terms</h3>
 <p>You may choose to offer, and to charge a fee for, warranty, support, indemnity or liability obligations to one or more recipients of Covered Software. However, You may do so only on Your own behalf, and not on behalf of any Contributor. You must make it absolutely clear that any such warranty, support, indemnity, or liability obligation is offered by You alone, and You hereby agree to indemnify every Contributor for any liability incurred by such Contributor as a result of warranty, support, indemnity or liability terms You offer. You may include additional disclaimers of warranty and limitations of liability specific to any jurisdiction.</p>
-<h4 id="inability-to-comply-due-to-statute-or-regulation">4. Inability to Comply Due to Statute or Regulation</h4>
+</article>
+<div>
+<div>
+<input id="ac-4" name="accordion-1" type="checkbox" />
+<label for="ac-4"><h4 id="inability-to-comply-due-to-statute-or-regulation">4. Inability to Comply Due to Statute or Regulation</h4></label>
+<article>
 <p>If it is impossible for You to comply with any of the terms of this License with respect to some or all of the Covered Software due to statute, judicial order, or regulation then You must: (a) comply with the terms of this License to the maximum extent possible; and (b) describe the limitations and the code they affect. Such description must be placed in a text file included with all distributions of the Covered Software under this License. Except to the extent prohibited by statute or regulation, such description must be sufficiently detailed for a recipient of ordinary skill to be able to understand it.</p>
-<h4 id="termination">5. Termination</h4>
+</article>
+</div>
+<div>
+<input id="ac-5" name="accordion-1" type="checkbox" />
+<label for="ac-5"><h4 id="termination">5. Termination</h4></label>
+<article>
 <p>5.1. The rights granted under this License will terminate automatically if You fail to comply with any of its terms. However, if You become compliant, then the rights granted under this License from a particular Contributor are reinstated (a) provisionally, unless and until such Contributor explicitly and finally terminates Your grants, and (b) on an ongoing basis, if such Contributor fails to notify You of the non-compliance by some reasonable means prior to 60 days after You have come back into compliance. Moreover, Your grants from a particular Contributor are reinstated on an ongoing basis if such Contributor notifies You of the non-compliance by some reasonable means, this is the first time You have received notice of non-compliance with this License from such Contributor, and You become compliant prior to 30 days after Your receipt of the notice.</p>
 <p>5.2. If You initiate litigation against any entity by asserting a patent infringement claim (excluding declaratory judgment actions, counter-claims, and cross-claims) alleging that a Contributor Version directly or indirectly infringes any patent, then the rights granted to You by any and all Contributors for the Covered Software under Section&nbsp;2.1 of this License shall terminate.</p>
 <p>5.3. In the event of termination under Sections&nbsp;5.1 or 5.2 above, all end user license agreements (excluding distributors and resellers) which have been validly granted by You or Your distributors under this License prior to termination shall survive termination.</p>
-<h4 id="disclaimer-of-warranty">6. Disclaimer of Warranty</h4>
+</article>
+</div>
+<div>
+<input id="ac-6" name="accordion-1" type="checkbox" />
+<label for="ac-6"><h4 id="disclaimer-of-warranty">6. Disclaimer of Warranty</h4></label>
+<article>
 <p><em>Covered Software is provided under this License on an “as is” basis, without warranty of any kind, either expressed, implied, or statutory, including, without limitation, warranties that the Covered Software is free of defects, merchantable, fit for a particular purpose or non-infringing. The entire risk as to the quality and performance of the Covered Software is with You. Should any Covered Software prove defective in any respect, You (not any Contributor) assume the cost of any necessary servicing, repair, or correction. This disclaimer of warranty constitutes an essential part of this License. No use of any Covered Software is authorized under this License except under this disclaimer.</em></p>
-<h4 id="limitation-of-liability">7. Limitation of Liability</h4>
+<article>
+</div>
+<div>
+<input id="ac-7" name="accordion-1" type="checkbox" />
+<label for="ac-7"><h4 id="limitation-of-liability">7. Limitation of Liability</h4></label>
+<article>
 <p><em>Under no circumstances and under no legal theory, whether tort (including negligence), contract, or otherwise, shall any Contributor, or anyone who distributes Covered Software as permitted above, be liable to You for any direct, indirect, special, incidental, or consequential damages of any character including, without limitation, damages for lost profits, loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses, even if such party shall have been informed of the possibility of such damages. This limitation of liability shall not apply to liability for death or personal injury resulting from such party’s negligence to the extent applicable law prohibits such limitation. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so this exclusion and limitation may not apply to You.</em></p>
-<h4 id="litigation">8. Litigation</h4>
+</article>
+</div>
+<div>
+<input id="ac-8" name="accordion-1" type="checkbox" />
+<label for="ac-8"><h4 id="litigation">8. Litigation</h4></label>
+<article>
 <p>Any litigation relating to this License may be brought only in the courts of a jurisdiction where the defendant maintains its principal place of business and such litigation shall be governed by laws of that jurisdiction, without reference to its conflict-of-law provisions. Nothing in this Section shall prevent a party’s ability to bring cross-claims or counter-claims.</p>
-<h4 id="miscellaneous">9. Miscellaneous</h4>
+</article>
+</div>
+<div>
+<input id="ac-9" name="accordion-1" type="checkbox" />
+<label for="ac-9"><h4 id="miscellaneous">9. Miscellaneous</h4></label>
+<article>
 <p>This License represents the complete agreement concerning the subject matter hereof. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable. Any law or regulation which provides that the language of a contract shall be construed against the drafter shall not be used to construe this License against a Contributor.</p>
-<h4 id="versions-of-the-license">10. Versions of the License</h4>
+</article>
+</div>
+<div>
+<input id="ac-10" name="accordion-1" type="checkbox" />
+<label for="ac-10"><h4 id="versions-of-the-license">10. Versions of the License</h4></label>
+<article>
 <h3 id="new-versions">10.1. New Versions</h3>
 <p>Mozilla Foundation is the license steward. Except as provided in Section&nbsp;10.3, no one other than the license steward has the right to modify or publish new versions of this License. Each version will be given a distinguishing version number.</p>
 <h3 id="effect-of-new-versions">10.2. Effect of New Versions</h3>
@@ -158,9 +246,8 @@ h2 {
 <blockquote>
 <p>This Source Code Form is “Incompatible With Secondary Licenses”, as defined by the Mozilla Public License, v. 2.0.</p>
 </blockquote>
-
-
-
+</article>
+</div>
 
 
 
@@ -170,8 +257,10 @@ h2 {
 <center><p>-</p></center>
 
 <!-- -->
-
-<h2>Alamofire</h2>
+<div>
+<input id="ac-11" name="accordion-1" type="checkbox" />
+<label for="ac-11"><h2>Alamofire</h2></label>
+<article>
 <p class="link"><a href="http://alamofire.org">alamofire.org</a></p>
 <div class="text">
 <p>Copyright (c) 2014 Alamofire (http://alamofire.org/)</p>
@@ -194,11 +283,16 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.</p>
 </div>
+</article>
+</div>
 <center><p>-</p></center>
 
 <!-- -->
 
-<h2>Base32</h2>
+<div>
+<input id="ac-12" name="accordion-1" type="checkbox" />
+<label for="ac-12"><h2>Base32</h2></label>
+<article>
 <p class="link"><a href="https://github.com/norio-nomura/Base32">github.com/norio-nomura/Base32</a></p>
 <div class="text">
 <p>The MIT License (MIT)</p>
@@ -223,9 +317,14 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.</p>
 </div>
+</article>
+</div>
 <center><p>-</p></center>
 
-<h2>Box</h2>
+<div>
+<input id="ac-13" name="accordion-1" type="checkbox" />
+<label for="ac-13"><h2>Box</h2></label>
+<article>
 <p class="link"><a href="https://github.com/robrix/Box">github.com/robrix/Box</a></p>
 <div class="text">
 <p>The MIT License (MIT)</p>
@@ -249,12 +348,17 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE</p>
 </div>
+</article>
+</div>
 <center><p>-</p></center>
 
-<h2>Deferred</h2>
+<div>
+<input id="ac-14" name="accordion-1" type="checkbox" />
+<label for="ac-14"><h2>Deferred</h2></label>
+<article>
 <p class="link"><a href="https://github.com/bignerdranch/Deferred">github.com/bignerdranch/Deferred</a></p>
 <div class="text">
-<p>Copyright (c) 2014 John Gallagher &lt;jgallagher@bignerdranch.com&gt;
+<p>Copyright (c) 2014 John Gallagher &lt;jgallagher@bignerdranch.com&gt;</p>
 
 <p>Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -274,8 +378,14 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.</p>
 </div>
+</article>
+</div>
+<center><p>-</p></center>
 
-<h2>FilledPageControl</h2>
+<div>
+<input id="ac-15" name="accordion-1" type="checkbox" />
+<label for="ac-15"><h2>FilledPageControl</h2></label>
+<article>
 <p>Copyright (c) 2016 Kyle Zaragoza <popwarsweet@gmail.com></p>
 
 <p>Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -295,9 +405,14 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.</p>
+</article>
+</div>
+<center><p>-</p></center>
 
-
-<h2>GCDWebServer</h2>
+<div>
+<input id="ac-16" name="accordion-1" type="checkbox" />
+<label for="ac-16"><h2>GCDWebServer</h2></label>
+<article>
 <p class="link"><a href="https://github.com/swisspol/GCDWebServer">github.com/swisspol/GCDWebServer</a></p>
 <div class="text">
 <p>Copyright (c) 2012-2014, Pierre-Olivier Latour</p>
@@ -328,10 +443,15 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
 </div>
+</article>
+</div>
 <center><p>-</p></center>
 
 
-<h2>KIF</h2>
+<div>
+<input id="ac-17" name="accordion-1" type="checkbox" />
+<label for="ac-17"><h2>KIF</h2></label>
+<article>
 <p class="link"><a href="https://github.com/kif-framework/KIF">https://github.com/kif-framework/KIF</a></p>
 <div class="text">
 <p>Copyright 2011 Square, Inc.</p>
@@ -349,8 +469,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.</p>
 </div>
+</article>
+</div>
+<center><p>-</p></center>
 
-<h2>Result</h2>
+<div>
+<input id="ac-18" name="accordion-1" type="checkbox" />
+<label for="ac-18"><h2>Result</h2></label>
+<article>
 <p class="link"><a href="https://github.com/bignerdranch/Result">github.com/bignerdranch/Result</a></p>
 <div class="text">
 <p>Copyright (c) 2014 John Gallagher &lt;jgallagher@bignerdranch.com&gt;</p>
@@ -373,8 +499,14 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.</p>
 </div>
+</article>
+</div>
+<center><p>-</p></center>
 
-<h2>SDWebImage</h2>
+<div>
+<input id="ac-19" name="accordion-1" type="checkbox" />
+<label for="ac-19"><h2>SDWebImage</h2></label>
+<article>
 <p class="link"><a href="https://github.com/rs/SDWebImage">github.com/rs/SDWebImage</a></p>
 <div class="text">
 <p>Copyright (c) 2009 Olivier Poitrey &lt;rs@dailymotion.com&gt;</p>
@@ -397,10 +529,15 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.</p>
 </div>
+</article>
+</div>
 <center><p>-</p></center>
 
 
-<h2>SQLite.swift</h2>
+<div>
+<input id="ac-20" name="accordion-1" type="checkbox" />
+<label for="ac-20"><h2>SQLite.swift</h2></label>
+<article>
 <p class="link"><a href="https://github.com/stephencelis/SQLite.swift">github.com/stephencelis/SQLite.swift</a></p>
 <div class="text">
 <p>(The MIT License)</p>
@@ -425,10 +562,15 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.</p>
 </div>
+</article>
+</div>
 <center><p>-</p></center>
 
 
-<h2>Fuzi</h2>
+<div>
+<input id="ac-21" name="accordion-1" type="checkbox" />
+<label for="ac-21"><h2>Fuzi</h2></label>
+<article>
 <p class="link"><a href="https://github.com/cezheng/Fuzi">github.com/cezheng/Fuzi</a></p>
 <div class="text">
 <p>Copyright (c) 2015 Ce Zheng</p>
@@ -451,10 +593,15 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.</p>
 </div>
+</article>
+</div>
 <center><p>-</p></center>
 
 
-<h2>Snap</h2>
+<div>
+<input id="ac-22" name="accordion-1" type="checkbox" />
+<label for="ac-22"><h2>Snap</h2></label>
+<article>
 <p class="link"><a href="https://github.com/SnapKit">github.com/SnapKit</a></p>
 <div class="text">
 <p>Copyright (c) 2011-Present SnapKit Team - https://github.com/SnapKit</p>
@@ -477,10 +624,15 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.</p>
 </div>
+</article>
+</div>
 <center><p>-</p></center>
 
 
-<h2>XCGLogger</h2>
+<div>
+<input id="ac-23" name="accordion-1" type="checkbox" />
+<label for="ac-23"><h2>XCGLogger</h2></label>
+<article>
 <p class="link"><a href="https://github.com/DaveWoodCom/XCGLogger">github.com/DaveWoodCom/XCGLogger</a></p>
 <div class="text">
 <p>The MIT License (MIT)</p>
@@ -505,10 +657,15 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.</p>
 </div>
+</article>
+</div>
 <center><p>-</p></center>
 
 
-<h2>Readability</h2>
+<div>
+<input id="ac-24" name="accordion-1" type="checkbox" />
+<label for="ac-24"><h2>Readability</h2></label>
+<article>
 <p class="link"><a href="https://github.com/mozilla/readability">github.com/mozilla/readability</a></p>
 <div class="text">
 <p>Copyright (c) 2010 Arc90 Inc</p>
@@ -525,10 +682,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.</p>
 </div>
+</article>
+</div>
 <center><p>-</p></center>
 
 
-<h2>sqlchipher</h2>
+<div>
+<input id="ac-25" name="accordion-1" type="checkbox" />
+<label for="ac-25"><h2>sqlchipher</h2></label>
+<article>
 <p class="link"><a href="https://github.com/sqlcipher/sqlcipher">github.com/sqlcipher/sqlcipher</a></p>
 <div class="text">
 <p>Copyright (c) 2008, ZETETIC LLC</p>
@@ -559,10 +721,15 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
 </div>
+</article>
+</div>
 <center><p>-</p></center>
 
 
-<h2>SwiftKeychainWrapper</h2>
+<div>
+<input id="ac-26" name="accordion-1" type="checkbox" />
+<label for="ac-26"><h2>SwiftKeychainWrapper</h2></label>
+<article>
 <p class="link"><a href="https://github.com/jrendel/SwiftKeychainWrapper">github.com/jrendel/SwiftKeychainWrapper</a></p>
 <div class="text">
 <p>The MIT License (MIT)</p>
@@ -587,10 +754,15 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.</p>
 </div>
+</article>
+</div>
 <center><p>-</p></center>
 
 
-<h2>Swift-JSON</h2>
+<div>
+<input id="ac-27" name="accordion-1" type="checkbox" />
+<label for="ac-27"><h2>Swift-JSON</h2></label>
+<article>
 <p class="link"><a href="https://github.com/dankogai/swift-json">https://github.com/dankogai/swift-json</a></p>
 <div class="text">
 <p>The MIT License (MIT)</p>
@@ -615,9 +787,14 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.</p>
 </div>
+</article>
+</div>
+<center><p>-</p></center>
 
 <div>
-<h2>UIImageColors</h2>
+<input id="ac-28" name="accordion-1" type="checkbox" />
+<label for="ac-28"><h2>UIImageColors</h2></label>
+<article>
 <p class="link"><a href="https://github.com/jathu/UIImageColors">github.com/jathu/UIImageColors</a></p>
 
 <p>Created by Jathu Satkunarajah (@jathu) on 2015-06-11 - Toronto</p>
@@ -644,9 +821,14 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.</p>
+</article>
 </div>
+<center><p>-</p></center>
 
-<h2>UIImageViewAligned</h2>
+<div>
+<input id="ac-29" name="accordion-1" type="checkbox" />
+<label for="ac-29"><h2>UIImageViewAligned</h2></label>
+<article>
 <p class="link"><a href="https://github.com/reydanro/UIImageViewAligned">github.com/reydanro/UIImageViewAligned</a></p>
 <div class="text">
 <p>The MIT License (MIT)</p>
@@ -670,5 +852,7 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
 </div>
-
+</article>
+</div>
+<section class="ac-container">
 </html>


### PR DESCRIPTION
This PR contains a copy-pasted *Licenses.html* version from [another PR made by @JoelTheWriter](https://github.com/mozilla-mobile/firefox-ios/pull/2211). The original PR is closed, so I'm re-submiting the changes here. The behavior requested in [Bug 1190602](https://bugzilla.mozilla.org/show_bug.cgi?id=1190602) is implemented there, so why not to push it upstream?

## Screenshots

**BEFORE**

<img src="https://user-images.githubusercontent.com/5212518/38176295-3084d96a-35a1-11e8-89ed-10c468555387.png" width="300"> <img src="https://user-images.githubusercontent.com/5212518/38176294-306c6efc-35a1-11e8-8068-046e87c01f83.png" width="300"> 

**AFTER**

<img src="https://user-images.githubusercontent.com/5212518/38176352-1c5ee4de-35a2-11e8-9d66-7fc1dc5e38d4.png" width="300"> <img src="https://user-images.githubusercontent.com/5212518/38176351-1c43e256-35a2-11e8-99f5-1fab43888741.png" width="300"> 

*Note:* I'd suggest to review the formatting (e.g. font sizes and separators) and consider to adjust them to look more consistent. However, I believe this is  a subject of separate task.