### PR TITLE
Bug 1453626 - [Regression] Crash when trying to launch the app from T…

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -244,7 +244,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         return shouldPerformAdditionalDelegateHandling
     }
 
-    func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
+    func application(_ application: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
         guard let routerpath = NavigationPath(url: url) else {
             return false
         }


### PR DESCRIPTION
…oday Widget

Crash is due to [SR-7240](https://bugs.swift.org/browse/SR-7240). Changed method from `application(_:open:sourceApplication:annotation:)` to `application(_:open:options:)` as a fix.