### PR TITLE
Bug 1453847 - Prevent TopTabs from animating when it is not visible.

### DIFF
--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -118,7 +118,7 @@ class TopTabsViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         if self.tabsToDisplay != self.tabStore {
-            self.reloadData()
+            performTabUpdates()
         }
     }
 
@@ -655,7 +655,7 @@ extension TopTabsViewController: TabManagerDelegate {
     }
 
     func performTabUpdates() {
-        guard !isUpdating else {
+        guard !isUpdating, view.window != nil else {
             return
         }
 


### PR DESCRIPTION
This helps prevent a TopTabs crash that happens when a tab is removed from the Tabs Tray.