### PR TITLE
Bug 1453654 - RemoteTab should use compactMap instead of flatMap to filter out nil urls.

### DIFF
--- a/Sync/Synchronizers/TabsSynchronizer.swift
+++ b/Sync/Synchronizers/TabsSynchronizer.swift
@@ -192,7 +192,7 @@ open class TabsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchroniz
 
 extension RemoteTab {
     public func toDictionary() -> Dictionary<String, Any>? {
-        let tabHistory = history.flatMap { $0.absoluteString }
+        let tabHistory = history.compactMap { $0.absoluteString }
         if tabHistory.isEmpty {
             return nil
         }


### PR DESCRIPTION
Usually the compiler is pretty good at catching these. But for some reason it did not warn that this should have been changed to compactMap 🤷‍♂️ 

