### PR TITLE
Support Pass for iOS password manager

### DIFF
--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -110,6 +110,7 @@ private extension ShareExtensionHelper {
             || (activityType == "com.lastpass.ilastpass.LastPassExt")
             || (activityType == "in.sinew.Walletx.WalletxExt")
             || (activityType == "com.8bit.bitwarden.find-login-action-extension")
+            || (activityType == "me.mssun.passforios.find-login-action-extension")
 
     }
 


### PR DESCRIPTION
Detect password manager extension for Pass for iOS (https://github.com/mssun/passforios)

Edit from Garvan, added bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1458648

