### PR TITLE
Alter colors to align with photon design system.

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -66,7 +66,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         self.launchOptions = launchOptions
 
         self.window = UIWindow(frame: UIScreen.main.bounds)
-        self.window!.backgroundColor = UIColor.white
+        self.window!.backgroundColor = UIColor.Photon.White100
 
         // Short circuit the app if we want to email logs from the debug menu
         if DebugSettingsBundleOptions.launchIntoEmailComposer {

--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -280,7 +280,7 @@ class LeanPlumClient {
             LPActionArg(named: LPMessage.ArgAcceptButtonText, with: LPMessage.DefaultOkButtonText),
             LPActionArg(named: LPMessage.ArgCancelAction, withAction: nil),
             LPActionArg(named: LPMessage.ArgCancelButtonText, with: LPMessage.DefaultLaterButtonText),
-            LPActionArg(named: LPMessage.ArgCancelButtonTextColor, with: UIColor.gray)
+            LPActionArg(named: LPMessage.ArgCancelButtonTextColor, with: UIColor.Photon.Grey50)
         ]
         
         let responder: LeanplumActionBlock = { (context) -> Bool in

--- a/Client/Extensions/UIImageViewExtensions.swift
+++ b/Client/Extensions/UIImageViewExtensions.swift
@@ -34,7 +34,7 @@ public extension UIImageView {
     private func color(forImage image: UIImage, andURL url: URL, completed completionBlock: ((UIColor, URL?) -> Void)? = nil) {
         guard let domain = url.baseDomain else {
             self.backgroundColor = .gray
-            completionBlock?(UIColor.gray, url)
+            completionBlock?(UIColor.Photon.Grey50, url)
             return
         }
 
@@ -45,8 +45,8 @@ public extension UIImageView {
             image.getColors(scaleDownSize: CGSize(width: 25, height: 25)) {colors in
                 let isSame = [colors.primary, colors.secondary, colors.detail].every { $0 == colors.primary }
                 if isSame {
-                    completionBlock?(UIColor.white, url)
-                    FaviconFetcher.colors[domain] = UIColor.white
+                    completionBlock?(UIColor.Photon.White100, url)
+                    FaviconFetcher.colors[domain] = UIColor.Photon.White100
                 } else {
                     completionBlock?(colors.background, url)
                     FaviconFetcher.colors[domain] = colors.background

--- a/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -10,7 +10,7 @@ import SnapKit
 
 private struct BackForwardViewUX {
     static let RowHeight: CGFloat = 50
-    static let BackgroundColor = UIColor.Photon.Grey10.withAlphaComponent(0.4)
+    static let BackgroundColor = UIColor.Photon.Grey10A40
 }
 
 class BackForwardListViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, UIGestureRecognizerDelegate {

--- a/Client/Frontend/Browser/BackForwardTableViewCell.swift
+++ b/Client/Frontend/Browser/BackForwardTableViewCell.swift
@@ -8,7 +8,7 @@ import Storage
 class BackForwardTableViewCell: UITableViewCell {
     
     private struct BackForwardViewCellUX {
-        static let bgColor = UIColor.gray
+        static let bgColor = UIColor.Photon.Grey50
         static let faviconWidth = 29
         static let faviconPadding: CGFloat = 20
         static let labelPadding = 20
@@ -21,7 +21,7 @@ class BackForwardTableViewCell: UITableViewCell {
     
     lazy var faviconView: UIImageView = {
         let faviconView = UIImageView(image: FaviconFetcher.defaultFavicon)
-        faviconView.backgroundColor = UIColor.white
+        faviconView.backgroundColor = UIColor.Photon.White100
         faviconView.layer.cornerRadius = 6
         faviconView.layer.borderWidth = 0.5
         faviconView.layer.borderColor = UIColor(white: 0, alpha: 0.1).cgColor
@@ -56,7 +56,7 @@ class BackForwardTableViewCell: UITableViewCell {
                     if s.tileURL.isLocal {
                         self?.faviconView.image = UIImage(named: "faviconFox")
                         self?.faviconView.image = self?.faviconView.image?.createScaled(CGSize(width: BackForwardViewCellUX.IconSize, height: BackForwardViewCellUX.IconSize))
-                        self?.faviconView.backgroundColor = UIColor.white
+                        self?.faviconView.backgroundColor = UIColor.Photon.White100
                         return
                     }
                     

--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -314,7 +314,7 @@ private func createTransitionCellFromTab(_ tab: Tab?, withFrame frame: CGRect) -
         let defaultFavicon = UIImage(named: "defaultFavicon")
         if tab?.isPrivate ?? false {
             cell.favicon.image = defaultFavicon
-            cell.favicon.tintColor = (tab?.isPrivate ?? false) ? UIColor.white : UIColor.darkGray
+            cell.favicon.tintColor = (tab?.isPrivate ?? false) ? UIColor.Photon.White100 : UIColor.Photon.Grey60
         } else {
             cell.favicon.image = defaultFavicon
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -317,7 +317,7 @@ class BrowserViewController: UIViewController {
         KeyboardHelper.defaultHelper.addDelegate(self)
 
         webViewContainerBackdrop = UIView()
-        webViewContainerBackdrop.backgroundColor = UIColor.gray
+        webViewContainerBackdrop.backgroundColor = UIColor.Photon.Grey50
         webViewContainerBackdrop.alpha = 0
         view.addSubview(webViewContainerBackdrop)
 
@@ -2243,7 +2243,7 @@ extension BrowserViewController: ReaderModeBarViewDelegate {
 
                 let setupPopover = { [unowned self] in
                     if let popoverPresentationController = readerModeStyleViewController.popoverPresentationController {
-                        popoverPresentationController.backgroundColor = UIColor.white
+                        popoverPresentationController.backgroundColor = UIColor.Photon.White100
                         popoverPresentationController.delegate = self
                         popoverPresentationController.sourceView = readerModeBar
                         popoverPresentationController.sourceRect = CGRect(x: readerModeBar.frame.width/2, y: UIConstants.ToolbarHeight, width: 1, height: 1)
@@ -2552,7 +2552,7 @@ extension BrowserViewController {
         let domain = webView.url?.domainURL.host
         let matches = self.profile.searchEngines.orderedEngines.filter {$0.shortName == domain}
         if !matches.isEmpty {
-            self.customSearchEngineButton.tintColor = UIColor.gray
+            self.customSearchEngineButton.tintColor = UIColor.Photon.Grey50
             self.customSearchEngineButton.isUserInteractionEnabled = false
         } else {
             self.customSearchEngineButton.tintColor = UIConstants.SystemBlueColor
@@ -2621,7 +2621,7 @@ extension BrowserViewController {
                 return
             }
             self.addSearchEngine(searchQuery, favicon: favicon)
-            self.customSearchEngineButton.tintColor = UIColor.gray
+            self.customSearchEngineButton.tintColor = UIColor.Photon.Grey50
             self.customSearchEngineButton.isUserInteractionEnabled = false
         }
     }
@@ -2637,7 +2637,7 @@ extension BrowserViewController {
         }
 
         let alert = ThirdPartySearchAlerts.addThirdPartySearchEngine { alert in
-            self.customSearchEngineButton.tintColor = UIColor.gray
+            self.customSearchEngineButton.tintColor = UIColor.Photon.Grey50
             self.customSearchEngineButton.isUserInteractionEnabled = false
             SDWebImageManager.shared().loadImage(with: iconURL, options: .continueInBackground, progress: nil) { (image, _, _, _, _, _) in
                 guard let image = image else {

--- a/Client/Frontend/Browser/ButtonToast.swift
+++ b/Client/Frontend/Browser/ButtonToast.swift
@@ -62,7 +62,7 @@ class ButtonToast: UIView {
     
     fileprivate func createView(_ labelText: String, descriptionText: String?, buttonText: String) -> UIView {
         let label = UILabel()
-        label.textColor = UIColor.white
+        label.textColor = UIColor.Photon.White100
         label.font = SimpleToastUX.ToastFont
         label.text = labelText
         label.lineBreakMode = .byWordWrapping
@@ -72,7 +72,7 @@ class ButtonToast: UIView {
         let button = HighlightableButton()
         button.layer.cornerRadius = ButtonToastUX.ToastButtonBorderRadius
         button.layer.borderWidth = ButtonToastUX.ToastButtonBorderWidth
-        button.layer.borderColor = UIColor.white.cgColor
+        button.layer.borderColor = UIColor.Photon.White100.cgColor
         button.setTitle(buttonText, for: [])
         button.setTitleColor(self.toast.backgroundColor, for: .highlighted)
         button.titleLabel?.font = SimpleToastUX.ToastFont
@@ -88,7 +88,7 @@ class ButtonToast: UIView {
         
         if let text = descriptionText {
             let textLabel = UILabel()
-            textLabel.textColor = UIColor.white
+            textLabel.textColor = UIColor.Photon.White100
             textLabel.font = SimpleToastUX.ToastFont
             textLabel.text = text
             textLabel.lineBreakMode = .byTruncatingTail

--- a/Client/Frontend/Browser/FindInPageBar.swift
+++ b/Client/Frontend/Browser/FindInPageBar.swift
@@ -13,11 +13,11 @@ protocol FindInPageBarDelegate: class {
 
 private struct FindInPageUX {
     static let ButtonColor = UIColor.black
-    static let MatchCountColor = UIColor.lightGray
+    static let MatchCountColor = UIColor.Photon.Grey40
     static let MatchCountFont = UIConstants.DefaultChromeFont
-    static let SearchTextColor = UIColor(rgb: 0xe66000)
+    static let SearchTextColor = UIColor.Photon.Orange60
     static let SearchTextFont = UIConstants.DefaultChromeFont
-    static let TopBorderColor = UIColor(rgb: 0xEEEEEE)
+    static let TopBorderColor = UIColor.Photon.Grey20
 }
 
 class FindInPageBar: UIView {

--- a/Client/Frontend/Browser/LoginsHelper.swift
+++ b/Client/Frontend/Browser/LoginsHelper.swift
@@ -87,7 +87,7 @@ class LoginsHelper: TabContentScript {
 
         var attributes = [NSAttributedStringKey: AnyObject]()
         attributes[NSAttributedStringKey.font] = UIFont.systemFont(ofSize: 13, weight: UIFont.Weight.regular)
-        attributes[NSAttributedStringKey.foregroundColor] = UIColor.darkGray
+        attributes[NSAttributedStringKey.foregroundColor] = UIColor.Photon.Grey60
         let attr = NSMutableAttributedString(string: string, attributes: attributes)
         let font: UIFont = UIFont.systemFont(ofSize: 13, weight: UIFont.Weight.medium)
         for range in ranges {

--- a/Client/Frontend/Browser/OpenInHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper.swift
@@ -223,7 +223,7 @@ class OpenInView: UIView {
             make.height.equalTo(self)
             make.trailing.equalTo(self).offset(OpenInViewUX.TextOffset)
         }
-        self.backgroundColor = UIColor.white
+        self.backgroundColor = UIColor.Photon.White100
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Browser/QRCodeViewController.swift
+++ b/Client/Frontend/Browser/QRCodeViewController.swift
@@ -9,8 +9,8 @@ import Shared
 
 private struct QRCodeViewControllerUX {
     static let navigationBarBackgroundColor = UIColor.black
-    static let navigationBarTitleColor = UIColor.white
-    static let maskViewBackgroungColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.5)
+    static let navigationBarTitleColor = UIColor.Photon.White100
+    static let maskViewBackgroundColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.5)
     static let isLightingNavigationItemColor = UIColor(red: 0.45, green: 0.67, blue: 0.84, alpha: 1)
 }
 
@@ -38,7 +38,7 @@ class QRCodeViewController: UIViewController {
     private lazy var instructionsLabel: UILabel = {
         let label = UILabel()
         label.text = Strings.ScanQRCodeInstructionsLabel
-        label.textColor = UIColor.white
+        label.textColor = UIColor.Photon.White100
         label.textAlignment = .center
         label.numberOfLines = 0
         return label
@@ -78,13 +78,13 @@ class QRCodeViewController: UIViewController {
 
         // Setup the NavigationItem
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "qrcode-goBack"), style: .plain, target: self, action: #selector(goBack))
-        self.navigationItem.leftBarButtonItem?.tintColor = UIColor.white
+        self.navigationItem.leftBarButtonItem?.tintColor = UIColor.Photon.White100
 
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(named: "qrcode-light"), style: .plain, target: self, action: #selector(openLight))
         if captureDevice.hasTorch {
-            self.navigationItem.rightBarButtonItem?.tintColor = UIColor.white
+            self.navigationItem.rightBarButtonItem?.tintColor = UIColor.Photon.White100
         } else {
-            self.navigationItem.rightBarButtonItem?.tintColor = UIColor.gray
+            self.navigationItem.rightBarButtonItem?.tintColor = UIColor.Photon.Grey50
             self.navigationItem.rightBarButtonItem?.isEnabled = false
         }
 
@@ -97,7 +97,7 @@ class QRCodeViewController: UIViewController {
             self.present(alert, animated: true, completion: nil)
         }
 
-        maskView.backgroundColor = QRCodeViewControllerUX.maskViewBackgroungColor
+        maskView.backgroundColor = QRCodeViewControllerUX.maskViewBackgroundColor
         self.view.addSubview(maskView)
         self.view.addSubview(scanBorder)
         self.view.addSubview(scanLine)
@@ -185,7 +185,7 @@ class QRCodeViewController: UIViewController {
                 captureDevice.torchMode = AVCaptureDevice.TorchMode.off
                 captureDevice.unlockForConfiguration()
                 navigationItem.rightBarButtonItem?.image = UIImage(named: "qrcode-light")
-                navigationItem.rightBarButtonItem?.tintColor = UIColor.white
+                navigationItem.rightBarButtonItem?.tintColor = UIColor.Photon.White100
             } catch {
                 print(error)
             }

--- a/Client/Frontend/Browser/ReaderModeBarView.swift
+++ b/Client/Frontend/Browser/ReaderModeBarView.swift
@@ -94,7 +94,7 @@ class ReaderModeBarView: UIView {
         guard let context = UIGraphicsGetCurrentContext() else { return }
         context.setLineWidth(0.5)
         context.setStrokeColor(red: 0.1, green: 0.1, blue: 0.1, alpha: 1.0)
-        context.setStrokeColor(UIColor.gray.cgColor)
+        context.setStrokeColor(UIColor.Photon.Grey50.cgColor)
         context.beginPath()
         context.move(to: CGPoint(x: 0, y: frame.height))
         context.addLine(to: CGPoint(x: frame.width, y: frame.height))

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -14,7 +14,7 @@ private enum SearchListSection: Int {
 }
 
 private struct SearchViewControllerUX {
-    static let SearchEngineScrollViewBackgroundColor = UIColor.white.withAlphaComponent(0.8).cgColor
+    static let SearchEngineScrollViewBackgroundColor = UIColor.Photon.White100.withAlphaComponent(0.8).cgColor
     static let SearchEngineScrollViewBorderColor = UIColor.black.withAlphaComponent(0.2).cgColor
 
     // TODO: This should use ToolbarHeight in BVC. Fix this when we create a shared theming file.
@@ -27,7 +27,7 @@ private struct SearchViewControllerUX {
     static let SearchImageHeight: Float = 44
     static let SearchImageWidth: Float = 24
 
-    static let SuggestionBackgroundColor = UIColor(red: 1, green: 1, blue: 1, alpha: 0.8)
+    static let SuggestionBackgroundColor = UIColor.Photon.White100
     static let SuggestionBorderColor = UIConstants.HighlightBlue
     static let SuggestionBorderWidth: CGFloat = 1
     static let SuggestionCornerRadius: CGFloat = 4
@@ -687,7 +687,7 @@ fileprivate class SuggestionButton: InsetButton {
         super.init(frame: frame)
 
         setTitleColor(UIConstants.HighlightBlue, for: [])
-        setTitleColor(UIColor.white, for: .highlighted)
+        setTitleColor(UIColor.Photon.White100, for: .highlighted)
         titleLabel?.font = DynamicFontHelper.defaultHelper.DefaultMediumFont
         backgroundColor = SearchViewControllerUX.SuggestionBackgroundColor
         layer.borderColor = SearchViewControllerUX.SuggestionBorderColor.cgColor

--- a/Client/Frontend/Browser/SimpleToast.swift
+++ b/Client/Frontend/Browser/SimpleToast.swift
@@ -8,7 +8,7 @@ import Shared
 struct SimpleToastUX {
     static let ToastHeight = BottomToolbarHeight
     static let ToastAnimationDuration = 0.5
-    static let ToastDefaultColor = UIColor(red: 10 / 255, green: 132 / 255, blue: 255.0 / 255, alpha: 1)
+    static let ToastDefaultColor = UIColor.Photon.Blue50
     static let ToastFont = UIFont.systemFont(ofSize: 15)
     static let ToastDismissAfter = DispatchTimeInterval.milliseconds(4500) // 4.5 seconds.
     static let ToastDelayBefore = DispatchTimeInterval.milliseconds(0) // 0 seconds
@@ -32,7 +32,7 @@ struct SimpleToast {
 
     fileprivate func createView() -> UILabel {
         let toast = UILabel()
-        toast.textColor = UIColor.white
+        toast.textColor = UIColor.Photon.White100
         toast.backgroundColor = SimpleToastUX.ToastDefaultColor
         toast.font = SimpleToastUX.ToastFont
         toast.textAlignment = .center

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -25,7 +25,7 @@ protocol TabLocationViewDelegate {
 
 private struct TabLocationViewUX {
     static let HostFontColor = UIColor.black
-    static let BaseURLFontColor = UIColor.gray
+    static let BaseURLFontColor = UIColor.Photon.Grey50
     static let Spacing: CGFloat = 8
     static let StatusIconSize: CGFloat = 18
     static let TPIconSize: CGFloat = 24
@@ -92,7 +92,7 @@ class TabLocationView: UIView, TabEventHandler {
 
     lazy var placeholder: NSAttributedString = {
         let placeholderText = NSLocalizedString("Search or enter address", comment: "The text shown in the URL bar on about:home")
-        return NSAttributedString(string: placeholderText, attributes: [NSAttributedStringKey.foregroundColor: UIColor.gray])
+        return NSAttributedString(string: placeholderText, attributes: [NSAttributedStringKey.foregroundColor: UIColor.Photon.Grey40])
     }()
 
     lazy var urlTextField: UITextField = {
@@ -119,7 +119,7 @@ class TabLocationView: UIView, TabEventHandler {
 
     fileprivate lazy var lockImageView: UIImageView = {
         let lockImageView = UIImageView(image: UIImage.templateImageNamed("lock_verified"))
-        lockImageView.tintColor = UIColor.Defaults.LockGreen
+        lockImageView.tintColor = UIColor.Photon.Green50
         lockImageView.isAccessibilityElement = true
         lockImageView.contentMode = .center
         lockImageView.accessibilityLabel = NSLocalizedString("Secure connection", comment: "Accessibility label for the lock icon, which is only present if the connection is secure")

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -153,7 +153,7 @@ class ToolbarButton: UIButton {
         adjustsImageWhenHighlighted = false
         selectedTintColor = tintColor
         unselectedTintColor = tintColor
-        disabledTintColor = UIColor.gray
+        disabledTintColor = UIColor.Photon.Grey50
         imageView?.contentMode = .scaleAspectFit
     }
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -32,7 +32,7 @@ private struct LightTabCellUX {
 }
 
 private struct DarkTabCellUX {
-    static let TabTitleTextColor = UIColor.white
+    static let TabTitleTextColor = UIColor.Photon.White100
 }
 
 protocol TabCellDelegate: class {
@@ -69,7 +69,7 @@ class TabCell: UICollectionViewCell {
     var margin = CGFloat(0)
 
     override init(frame: CGRect) {
-        self.backgroundHolder.backgroundColor = UIColor.white
+        self.backgroundHolder.backgroundColor = UIColor.Photon.White100
         self.backgroundHolder.layer.cornerRadius = TabTrayControllerUX.CornerRadius
         self.backgroundHolder.clipsToBounds = true
         self.backgroundHolder.backgroundColor = TabTrayControllerUX.CellBackgroundColor
@@ -94,7 +94,7 @@ class TabCell: UICollectionViewCell {
         self.closeButton.setImage(UIImage.templateImageNamed("tab_close"), for: [])
         self.closeButton.imageView?.contentMode = .scaleAspectFit
         self.closeButton.contentMode = .center
-        self.closeButton.tintColor = UIColor.lightGray
+        self.closeButton.tintColor = UIColor.Photon.Grey40
         self.closeButton.imageEdgeInsets = UIEdgeInsets(equalInset: TabTrayControllerUX.CloseButtonEdgeInset)
 
         super.init(frame: frame)
@@ -782,7 +782,7 @@ fileprivate class TabManagerDataSource: NSObject, UICollectionViewDataSource {
         let tab = tabs[indexPath.item]
         tabCell.style = tab.isPrivate ? .dark : .light
         tabCell.titleText.text = tab.displayTitle
-        tabCell.closeButton.tintColor = tab.isPrivate ? UIColor.white : UIColor.gray
+        tabCell.closeButton.tintColor = tab.isPrivate ? UIColor.Photon.White100 : UIColor.Photon.Grey50
 
         if !tab.displayTitle.isEmpty {
             tabCell.accessibilityLabel = tab.displayTitle
@@ -798,7 +798,7 @@ fileprivate class TabManagerDataSource: NSObject, UICollectionViewDataSource {
             let defaultFavicon = UIImage(named: "defaultFavicon")
             if tab.isPrivate {
                 tabCell.favicon.image = defaultFavicon
-                tabCell.favicon.tintColor = UIColor.white
+                tabCell.favicon.tintColor = UIColor.Photon.White100
             } else {
                 tabCell.favicon.image = defaultFavicon
             }
@@ -950,9 +950,9 @@ fileprivate class TabLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayou
 }
 
 private struct EmptyPrivateTabsViewUX {
-    static let TitleColor = UIColor.white
+    static let TitleColor = UIColor.Photon.White100
     static let TitleFont = UIFont.systemFont(ofSize: 22, weight: UIFont.Weight.medium)
-    static let DescriptionColor = UIColor.white
+    static let DescriptionColor = UIColor.Photon.White100
     static let DescriptionFont = UIFont.systemFont(ofSize: 17)
     static let LearnMoreFont = UIFont.systemFont(ofSize: 15, weight: UIFont.Weight.medium)
     static let TextMargin: CGFloat = 18

--- a/Client/Frontend/Browser/TopTabsViews.swift
+++ b/Client/Frontend/Browser/TopTabsViews.swift
@@ -221,7 +221,7 @@ class TopTabCell: UICollectionViewCell {
 
 class TopTabFader: UIView {
     lazy var hMaskLayer: CAGradientLayer = {
-        let innerColor: CGColor = UIColor(white: 1, alpha: 1.0).cgColor
+        let innerColor: CGColor = UIColor.Photon.White100.cgColor
         let outerColor: CGColor = UIColor(white: 1, alpha: 0.0).cgColor
         let hMaskLayer = CAGradientLayer()
         hMaskLayer.colors = [outerColor, innerColor, innerColor, outerColor]

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -6,8 +6,8 @@ import Shared
 import SnapKit
 
 private struct URLBarViewUX {
-    static let TextFieldBorderColor = UIColor(rgb: 0xBBBBBB)
-    static let TextFieldActiveBorderColor = UIColor(rgb: 0xB0D5FB)
+    static let TextFieldBorderColor = UIColor.Photon.Grey40
+    static let TextFieldActiveBorderColor = UIColor.Defaults.PaleBlue
 
     static let LocationLeftPadding: CGFloat = 8
     static let Padding: CGFloat = 10

--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -953,7 +953,7 @@ struct ActivityStreamTracker {
 
 // MARK: - Section Header View
 private struct ASHeaderViewUX {
-    static let SeperatorColor =  UIColor(rgb: 0xedecea) //Color not found in Photon
+    static let SeperatorColor =  UIColor.Photon.Grey20
     static let TextFont = DynamicFontHelper.defaultHelper.MediumSizeBoldFontAS
     static let SeperatorHeight = 1
     static let Insets: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? ASPanelUX.SectionInsetsForIpad + ASPanelUX.MinimumInsets : ASPanelUX.MinimumInsets
@@ -986,7 +986,7 @@ class ASHeaderView: UICollectionReusableView {
     lazy fileprivate var titleLabel: UILabel = {
         let titleLabel = UILabel()
         titleLabel.text = self.title
-        titleLabel.textColor = UIColor.gray
+        titleLabel.textColor = UIColor.Photon.Grey50
         titleLabel.font = ASHeaderViewUX.TextFont
         titleLabel.minimumScaleFactor = 0.6
         titleLabel.numberOfLines = 1

--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -195,7 +195,7 @@ private struct ASHorizontalScrollCellUX {
     static let TopSiteEmptyCellIdentifier = "TopSiteItemEmptyCell"
 
     static let TopSiteItemSize = CGSize(width: 75, height: 75)
-    static let BackgroundColor = UIColor.white
+    static let BackgroundColor = UIColor.Photon.White100
     static let PageControlRadius: CGFloat = 3
     static let PageControlSize = CGSize(width: 30, height: 15)
     static let PageControlOffset: CGFloat = 12
@@ -220,7 +220,7 @@ class ASHorizontalScrollCell: UICollectionViewCell {
 
     lazy fileprivate var pageControl: FilledPageControl = {
         let pageControl = FilledPageControl()
-        pageControl.tintColor = UIColor.gray
+        pageControl.tintColor = UIColor.Photon.Grey50
         pageControl.indicatorRadius = ASHorizontalScrollCellUX.PageControlRadius
         pageControl.isUserInteractionEnabled = true
         pageControl.isAccessibilityElement = true

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -25,14 +25,14 @@ private struct BookmarksPanelUX {
     static let BookmarkFolderHeaderViewChevronInset: CGFloat = 10
     static let BookmarkFolderChevronSize: CGFloat = 20
     static let BookmarkFolderChevronLineWidth: CGFloat = 2.0
-    static let BookmarkFolderTextColor = UIColor(red: 92/255, green: 92/255, blue: 92/255, alpha: 1.0)
+    static let BookmarkFolderTextColor = UIColor.Photon.Grey50
     static let BookmarkFolderBGColor = UIColor.Photon.Grey10.withAlphaComponent(0.3)
     static let WelcomeScreenPadding: CGFloat = 15
-    static let WelcomeScreenItemTextColor = UIColor.gray
+    static let WelcomeScreenItemTextColor = UIColor.Photon.Grey50
     static let WelcomeScreenItemWidth = 170
     static let SeparatorRowHeight: CGFloat = 0.5
     static let IconSize: CGFloat = 23
-    static let IconBorderColor = UIColor(white: 0, alpha: 0.1)
+    static let IconBorderColor = UIColor.Photon.Grey30
     static let IconBorderWidth: CGFloat = 0.5
 }
 
@@ -131,7 +131,7 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
 
     fileprivate func createEmptyStateOverlayView() -> UIView {
         let overlayView = UIView()
-        overlayView.backgroundColor = UIColor.white
+        overlayView.backgroundColor = UIColor.Photon.White100
 
         let logoImageView = UIImageView(image: UIImage(named: "emptyBookmarks"))
         overlayView.addSubview(logoImageView)

--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -13,10 +13,10 @@ private typealias CategoryNumber = Int
 private typealias CategorySpec = (section: SectionNumber?, rows: Int, offset: Int)
 
 private struct HistoryPanelUX {
-    static let WelcomeScreenItemTextColor = UIColor.gray
+    static let WelcomeScreenItemTextColor = UIColor.Photon.Grey50
     static let WelcomeScreenItemWidth = 170
     static let IconSize = 23
-    static let IconBorderColor = UIColor(white: 0, alpha: 0.1)
+    static let IconBorderColor = UIColor.Photon.Grey30
     static let IconBorderWidth: CGFloat = 0.5
 }
 
@@ -223,7 +223,7 @@ class HistoryPanel: SiteTableViewController, HomePanel {
 
     private func createEmptyStateOverlayView() -> UIView {
         let overlayView = UIView()
-        overlayView.backgroundColor = UIColor.white
+        overlayView.backgroundColor = UIColor.Photon.White100
 
         let welcomeLabel = UILabel()
         overlayView.addSubview(welcomeLabel)
@@ -331,7 +331,7 @@ class HistoryPanel: SiteTableViewController, HomePanel {
         cell.textLabel!.text = Strings.RecentlyClosedTabsButtonTitle
         cell.detailTextLabel!.text = ""
         cell.imageView!.image = UIImage(named: "recently_closed")
-        cell.imageView?.backgroundColor = UIColor.white
+        cell.imageView?.backgroundColor = UIColor.Photon.White100
         if !hasRecentlyClosed {
             cell.textLabel?.alpha = 0.5
             cell.imageView!.alpha = 0.5

--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -10,10 +10,8 @@ import Storage
 private struct HomePanelViewControllerUX {
     // Height of the top panel switcher button toolbar.
     static let ButtonContainerHeight: CGFloat = 40
-    static let ButtonContainerBorderColor = UIColor.black.withAlphaComponent(0.1)
+    static let ButtonContainerBorderColor = UIColor.Photon.Grey30
     static let BackgroundColorPrivateMode = UIConstants.PrivateModeAssistantToolbarBackgroundColor
-    static let ToolbarButtonDeselectedColorNormalMode = UIColor(white: 0.2, alpha: 0.5)
-    static let ToolbarButtonDeselectedColorPrivateMode = UIColor(white: 0.9, alpha: 1)
     static let ButtonHighlightLineHeight: CGFloat = 2
     static let ButtonSelectionAnimationDuration = 0.2
 }

--- a/Client/Frontend/Home/ReaderPanel.swift
+++ b/Client/Frontend/Home/ReaderPanel.swift
@@ -13,8 +13,8 @@ private let log = Logger.browserLogger
 private struct ReadingListTableViewCellUX {
     static let RowHeight: CGFloat = 86
 
-    static let ActiveTextColor = UIColor(red: 0.2, green: 0.2, blue: 0.2, alpha: 1.0)
-    static let DimmedTextColor = UIColor(red: 0.2, green: 0.2, blue: 0.2, alpha: 0.44)
+    static let ActiveTextColor = UIColor.Photon.Grey70
+    static let DimmedTextColor = UIColor.Photon.Grey40
 
     static let ReadIndicatorWidth: CGFloat =  12  // image width
     static let ReadIndicatorHeight: CGFloat = 12 // image height
@@ -27,12 +27,12 @@ private struct ReadingListTableViewCellUX {
 
     static let HostnameLabelBottomOffset: CGFloat = 11
 
-    static let DeleteButtonBackgroundColor = UIColor(rgb: 0xef4035)
-    static let DeleteButtonTitleColor = UIColor.white
+//    static let DeleteButtonBackgroundColor = UIColor.Photon.Red60
+    static let DeleteButtonTitleColor = UIColor.Photon.White100
     static let DeleteButtonTitleEdgeInsets = UIEdgeInsets(top: 4, left: 4, bottom: 4, right: 4)
 
-    static let MarkAsReadButtonBackgroundColor = UIColor(rgb: 0x2193d1)
-    static let MarkAsReadButtonTitleColor = UIColor.white
+    static let MarkAsReadButtonBackgroundColor = UIColor.Photon.Blue50
+    static let MarkAsReadButtonTitleColor = UIColor.Photon.White100
     static let MarkAsReadButtonTitleEdgeInsets = UIEdgeInsets(top: 4, left: 4, bottom: 4, right: 4)
 
     // Localizable strings
@@ -45,9 +45,9 @@ private struct ReadingListPanelUX {
     // Welcome Screen
     static let WelcomeScreenTopPadding: CGFloat = 16
     static let WelcomeScreenPadding: CGFloat = 15
-    static let WelcomeScreenHeaderTextColor = UIColor.darkGray
+    static let WelcomeScreenHeaderTextColor = UIColor.Photon.Grey60
 
-    static let WelcomeScreenItemTextColor = UIColor.gray
+    static let WelcomeScreenItemTextColor = UIColor.Photon.Grey50
     static let WelcomeScreenItemWidth = 220
     static let WelcomeScreenItemOffset = -20
 
@@ -273,7 +273,7 @@ class ReadingListPanel: UITableViewController, HomePanel {
 
     fileprivate func createEmptyStateOverview() -> UIView {
         let overlayView = UIScrollView(frame: tableView.bounds)
-        overlayView.backgroundColor = UIColor.white
+        overlayView.backgroundColor = UIColor.Photon.White100
         // Unknown why this does not work with autolayout
         overlayView.autoresizingMask = [UIViewAutoresizing.flexibleHeight, UIViewAutoresizing.flexibleWidth]
 
@@ -376,10 +376,10 @@ class ReadingListPanel: UITableViewController, HomePanel {
             return []
         }
 
-        let delete = UITableViewRowAction(style: .normal, title: ReadingListTableViewCellUX.DeleteButtonTitleText) { [weak self] action, index in
+        let delete = UITableViewRowAction(style: .default, title: ReadingListTableViewCellUX.DeleteButtonTitleText) { [weak self] action, index in
             self?.deleteItem(atIndex: index)
         }
-        delete.backgroundColor = ReadingListTableViewCellUX.DeleteButtonBackgroundColor
+//        delete.backgroundColor = ReadingListTableViewCellUX.DeleteButtonBackgroundColor
 
         let toggleText = record.unread ? ReadingListTableViewCellUX.MarkAsReadButtonTitleText : ReadingListTableViewCellUX.MarkAsUnreadButtonTitleText
         let unreadToggle = UITableViewRowAction(style: .normal, title: toggleText.stringSplitWithNewline()) { [weak self] (action, index) in

--- a/Client/Frontend/Home/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Home/RecentlyClosedTabsPanel.swift
@@ -13,7 +13,7 @@ private let log = Logger.browserLogger
 
 private struct RecentlyClosedPanelUX {
     static let IconSize = CGSize(width: 23, height: 23)
-    static let IconBorderColor = UIColor(white: 0, alpha: 0.1)
+    static let IconBorderColor = UIColor.Photon.Grey30
     static let IconBorderWidth: CGFloat = 0.5
 }
 

--- a/Client/Frontend/Home/RemoteTabsPanel.swift
+++ b/Client/Frontend/Home/RemoteTabsPanel.swift
@@ -17,13 +17,13 @@ private struct RemoteTabsPanelUX {
     static let RowHeight = SiteTableViewControllerUX.RowHeight
     static let HeaderBackgroundColor = UIColor.Photon.Grey10
 
-    static let EmptyStateTitleTextColor = UIColor.darkGray
+    static let EmptyStateTitleTextColor = UIColor.Photon.Grey60
 
-    static let EmptyStateInstructionsTextColor = UIColor.gray
+    static let EmptyStateInstructionsTextColor = UIColor.Photon.Grey50
     static let EmptyStateInstructionsWidth = 170
     static let EmptyStateTopPaddingInBetweenItems: CGFloat = 15 // UX TODO I set this to 8 so that it all fits on landscape
-    static let EmptyStateSignInButtonColor = UIColor(red: 0.3, green: 0.62, blue: 1, alpha: 1)
-    static let EmptyStateSignInButtonTitleColor = UIColor.white
+    static let EmptyStateSignInButtonColor = UIColor.Photon.Green60
+    static let EmptyStateSignInButtonTitleColor = UIColor.Photon.White100
     static let EmptyStateSignInButtonCornerRadius: CGFloat = 4
     static let EmptyStateSignInButtonHeight = 44
     static let EmptyStateSignInButtonWidth = 200

--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -88,7 +88,7 @@ class IntroViewController: UIViewController {
         }
 
         assert(cards.count > 1, "Intro is empty. At least 2 cards are required")
-        view.backgroundColor = UIColor.white
+        view.backgroundColor = UIColor.Photon.White100
 
         // Add Views
         view.addSubview(pageControl)
@@ -321,8 +321,8 @@ extension IntroViewController: UIScrollViewDelegate {
 
         var percentageOfScroll = currentHorizontalOffset / maximumHorizontalOffset
         percentageOfScroll = percentageOfScroll > 1.0 ? 1.0 : percentageOfScroll
-        let whiteComponent = UIColor.white.components
-        let grayComponent = UIColor(rgb: 0xF2F2F2).components
+        let whiteComponent = UIColor.Photon.White100.components
+        let grayComponent = UIColor.Photon.Grey20.components
         let newRed   = (1.0 - percentageOfScroll) * whiteComponent.red   + percentageOfScroll * grayComponent.red
         let newGreen = (1.0 - percentageOfScroll) * whiteComponent.green + percentageOfScroll * grayComponent.green
         let newBlue  = (1.0 - percentageOfScroll) * whiteComponent.blue  + percentageOfScroll * grayComponent.blue

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -13,10 +13,10 @@ private struct LoginListUX {
     static let RowHeight: CGFloat = 58
     static let SearchHeight: CGFloat = 58
     static let selectionButtonFont = UIFont.systemFont(ofSize: 16)
-    static let selectionButtonTextColor = UIColor.white
+    static let selectionButtonTextColor = UIColor.Photon.White100
     static let selectionButtonBackground = UIConstants.HighlightBlue
     static let NoResultsFont: UIFont = UIFont.systemFont(ofSize: 16)
-    static let NoResultsTextColor: UIColor = UIColor.lightGray
+    static let NoResultsTextColor: UIColor = UIColor.Photon.Grey40
 }
 
 private extension UITableView {
@@ -90,7 +90,7 @@ class LoginListViewController: SensitiveViewController {
         notificationCenter.addObserver(self, selector: #selector(dismissAlertController), name: .UIApplicationDidEnterBackground, object: nil)
 
         automaticallyAdjustsScrollViewInsets = false
-        self.view.backgroundColor = UIColor.white
+        self.view.backgroundColor = UIColor.Photon.White100
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .edit, target: self, action: #selector(beginEditing))
 
         self.title = NSLocalizedString("Logins", tableName: "LoginManager", comment: "Title for Logins List View screen.")
@@ -157,7 +157,7 @@ class LoginListViewController: SensitiveViewController {
         if loginSelectionController.selectedCount > 0 {
             if navigationItem.rightBarButtonItem == nil {
                 navigationItem.rightBarButtonItem = UIBarButtonItem(title: deleteLoginTitle, style: .plain, target: self, action: #selector(tappedDelete))
-                navigationItem.rightBarButtonItem?.tintColor = UIColor.red
+                navigationItem.rightBarButtonItem?.tintColor = UIColor.Photon.Red50
             }
         } else {
             navigationItem.rightBarButtonItem = nil
@@ -616,7 +616,7 @@ fileprivate class LoadingLoginsView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         addSubview(indicator)
-        backgroundColor = UIColor.white
+        backgroundColor = UIColor.Photon.White100
         indicator.startAnimating()
     }
 

--- a/Client/Frontend/Reader/ReaderModeStyleViewController.swift
+++ b/Client/Frontend/Reader/ReaderModeStyleViewController.swift
@@ -6,31 +6,32 @@ import UIKit
 import Shared
 
 private struct ReaderModeStyleViewControllerUX {
+    // TODO Erica can't find this to visually test
     static let RowHeight = 50
 
     static let Width = 270
     static let Height = 4 * RowHeight
 
-    static let FontTypeRowBackground = UIColor(rgb: 0xfbfbfb)
+    static let FontTypeRowBackground = UIColor.Photon.Grey10
 
-    static let FontTypeTitleSelectedColor = UIColor(rgb: 0x333333)
-    static let FontTypeTitleNormalColor = UIColor.lightGray // TODO THis needs to be 44% of 0x333333
+    static let FontTypeTitleSelectedColor = UIColor.Photon.Grey70
+    static let FontTypeTitleNormalColor = UIColor.Photon.Grey40
 
-    static let FontSizeRowBackground = UIColor(rgb: 0xf4f4f4)
-    static let FontSizeLabelColor = UIColor(rgb: 0x333333)
-    static let FontSizeButtonTextColorEnabled = UIColor(rgb: 0x333333)
-    static let FontSizeButtonTextColorDisabled = UIColor.lightGray // TODO THis needs to be 44% of 0x333333
+    static let FontSizeRowBackground = UIColor.Photon.Grey20
+    static let FontSizeLabelColor = UIColor.Photon.Grey70
+    static let FontSizeButtonTextColorEnabled = UIColor.Photon.Grey70
+    static let FontSizeButtonTextColorDisabled = UIColor.Photon.Grey40
 
-    static let ThemeRowBackgroundColor = UIColor.white
-    static let ThemeTitleColorLight = UIColor(rgb: 0x333333)
-    static let ThemeTitleColorDark = UIColor.white
-    static let ThemeTitleColorSepia = UIColor(rgb: 0x333333)
-    static let ThemeBackgroundColorLight = UIColor.white
-    static let ThemeBackgroundColorDark = UIColor(rgb: 0x333333)
-    static let ThemeBackgroundColorSepia = UIColor(rgb: 0xF0E6DC)
+    static let ThemeRowBackgroundColor = UIColor.Photon.White100
+    static let ThemeTitleColorLight = UIColor.Photon.Grey70
+    static let ThemeTitleColorDark = UIColor.Photon.White100
+    static let ThemeTitleColorSepia = UIColor.Photon.Grey70
+    static let ThemeBackgroundColorLight = UIColor.Photon.White100
+    static let ThemeBackgroundColorDark = UIColor.Photon.Grey70
+    static let ThemeBackgroundColorSepia = UIColor.Defaults.LightBeige
 
-    static let BrightnessRowBackground = UIColor(rgb: 0xf4f4f4)
-    static let BrightnessSliderTintColor = UIColor(rgb: 0xe66000)
+    static let BrightnessRowBackground = UIColor.Photon.Grey20
+    static let BrightnessSliderTintColor = UIColor.Photon.Orange60
     static let BrightnessSliderWidth = 140
     static let BrightnessIconOffset = 10
 }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -81,7 +81,7 @@ class SyncNowSetting: WithAccountSetting {
             return NSAttributedString(
                 string: Strings.FxANoInternetConnection,
                 attributes: [
-                    NSAttributedStringKey.foregroundColor: UIColor.red,
+                    NSAttributedStringKey.foregroundColor: UIColor.Photon.Red60,
                     NSAttributedStringKey.font: DynamicFontHelper.defaultHelper.DefaultMediumFont
                 ]
             )
@@ -90,7 +90,7 @@ class SyncNowSetting: WithAccountSetting {
         return NSAttributedString(
             string: NSLocalizedString("Sync Now", comment: "Sync Firefox Account"),
             attributes: [
-                NSAttributedStringKey.foregroundColor: self.enabled ? SettingsUX.TableViewRowSyncTextColor : UIColor.gray,
+                NSAttributedStringKey.foregroundColor: self.enabled ? SettingsUX.TableViewRowSyncTextColor : UIColor.Photon.Grey50,
                 NSAttributedStringKey.font: DynamicFontHelper.defaultHelper.DefaultStandardFont
             ]
         )
@@ -156,7 +156,7 @@ class SyncNowSetting: WithAccountSetting {
 
         let formattedLabel = timestampFormatter.string(from: Date.fromTimestamp(timestamp))
         let attributedString = NSMutableAttributedString(string: formattedLabel)
-        let attributes = [NSAttributedStringKey.foregroundColor: UIColor.gray, NSAttributedStringKey.font: UIFont.systemFont(ofSize: 12, weight: UIFont.Weight.regular)]
+        let attributes = [NSAttributedStringKey.foregroundColor: UIColor.Photon.Grey50, NSAttributedStringKey.font: UIFont.systemFont(ofSize: 12, weight: UIFont.Weight.regular)]
         let range = NSRange(location: 0, length: attributedString.length)
         attributedString.setAttributes(attributes, range: range)
         return attributedString
@@ -368,7 +368,7 @@ class AccountStatusSetting: WithAccountSetting {
                 break
             }
             
-            let orange = UIColor(red: 255.0 / 255, green: 149.0 / 255, blue: 0.0 / 255, alpha: 1)
+            let orange = UIColor.Photon.Orange50
             let range = NSRange(location: 0, length: string.count)
             let attrs = [NSAttributedStringKey.foregroundColor: orange]
             let res = NSMutableAttributedString(string: string)

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -52,7 +52,7 @@ class ClearPrivateDataTableViewController: UITableViewController {
 
     fileprivate var clearButtonEnabled = true {
         didSet {
-            clearButton?.textLabel?.textColor = clearButtonEnabled ? UIConstants.DestructiveRed : UIColor.lightGray
+            clearButton?.textLabel?.textColor = clearButtonEnabled ? UIConstants.DestructiveRed : UIColor.Photon.Grey40
         }
     }
 

--- a/Client/Frontend/Settings/FxAContentViewController.swift
+++ b/Client/Frontend/Settings/FxAContentViewController.swift
@@ -37,7 +37,7 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
     init(profile: Profile, fxaOptions: FxALaunchParams? = nil) {
         self.profile = profile
         
-        super.init(backgroundColor: UIColor(red: 242 / 255.0, green: 242 / 255.0, blue: 242 / 255.0, alpha: 1.0), title: NSAttributedString(string: "Firefox Accounts"))
+        super.init(backgroundColor: UIColor.Photon.Grey20, title: NSAttributedString(string: "Firefox Accounts"))
         
         if AppConstants.MOZ_FXA_DEEP_LINK_FORM_FILL {
             self.url = self.createFxAURLWith(fxaOptions, profile: profile)

--- a/Client/Frontend/Settings/SettingsContentViewController.swift
+++ b/Client/Frontend/Settings/SettingsContentViewController.swift
@@ -70,7 +70,7 @@ class SettingsContentViewController: UIViewController, WKNavigationDelegate {
         self.interstitialSpinnerView.startAnimating()
     }
 
-    init(backgroundColor: UIColor = UIColor.white, title: NSAttributedString? = nil) {
+    init(backgroundColor: UIColor = UIColor.Photon.White100, title: NSAttributedString? = nil) {
         interstitialBackgroundColor = backgroundColor
         settingsTitle = title
         super.init(nibName: nil, bundle: nil)
@@ -129,7 +129,7 @@ class SettingsContentViewController: UIViewController, WKNavigationDelegate {
         let error = UILabel()
         if let _ = settingsTitle {
             error.text = TODOPageLoadErrorString
-            error.textColor = UIColor.red // Firefox Orange!
+            error.textColor = UIColor.Photon.Red60
             error.textAlignment = .center
         }
         error.isHidden = true

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -10,13 +10,13 @@ struct SettingsUX {
     static let TableViewHeaderBackgroundColor = UIConstants.AppBackgroundColor
     static let TableViewHeaderTextColor = UIColor.Photon.Grey50
     static let TableViewRowTextColor = UIColor.Photon.Grey90
-    static let TableViewDisabledRowTextColor = UIColor.lightGray
-    static let TableViewSeparatorColor = UIColor(rgb: 0xD1D1D4)
+    static let TableViewDisabledRowTextColor = UIColor.Photon.Grey40
+    static let TableViewSeparatorColor = UIColor.Photon.Grey30
     static let TableViewHeaderFooterHeight = CGFloat(44)
-    static let TableViewRowErrorTextColor = UIColor(red: 255/255, green: 0/255, blue: 26/255, alpha: 1.0)
-    static let TableViewRowWarningTextColor = UIColor(red: 245/255, green: 166/255, blue: 35/255, alpha: 1.0)
-    static let TableViewRowActionAccessoryColor = UIColor(red: 0.29, green: 0.56, blue: 0.89, alpha: 1.0)
-    static let TableViewRowSyncTextColor = UIColor(red: 51/255, green: 51/255, blue: 51/255, alpha: 1.0)
+    static let TableViewRowErrorTextColor = UIColor.Photon.Red50
+    static let TableViewRowWarningTextColor = UIColor.Photon.Orange50
+    static let TableViewRowActionAccessoryColor = UIColor.Photon.Blue50
+    static let TableViewRowSyncTextColor = UIColor.Photon.Grey80
 }
 
 // A base setting class that shows a title. You probably want to subclass this, not use it directly.

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -31,58 +31,47 @@ struct BrowserColor {
 extension UIColor {
     // These are defaults from http://design.firefox.com/photon/visuals/color.html
     struct Defaults {
-        // Non-Photon design system colors. These are not in the design doc yet.
-        static let LockGreen = UIColor(rgb: 0x16DA00)
-        static let MobileGreyA = UIColor(rgb: 0xD2D2D4)
-        static let MobileGreyC = UIColor(rgb: 0xE4E4E4)
-        static let MobileGreyD = UIColor(rgb: 0x414146)
-        static let MobileGreyE = UIColor(rgb: 0x2D2D31)
         static let MobileGreyF = UIColor(rgb: 0x636369)
-        static let MobileGreyH = UIColor(rgb: 0xADADb0)
-        static let MobileGreyI = UIColor(rgb: 0x3f3f43)
-        static let MobileGreyJ = UIColor(rgb: 0xE5E5E5)
-        static let MobileBlueA = UIColor(rgb: 0xB0D5FB)
-        static let MobileBlueB = UIColor(rgb: 0x00dcfc)
-        static let MobileBlueC = UIColor(rgb: 0xccdded)
-        static let MobileBlueD = UIColor(rgb: 0x00A2FE)
-        static let MobilePurple = UIColor(rgb: 0x7878a5)
-        static let MobilePurpleB = UIColor(rgb: 0xAC39FF)
+        static let iOSHighlightBlue = UIColor(rgb: 0xccdded) // This color should exactly match the ios text highlight
+        static let Purple60A30 = UIColor(rgba: 0x8000d74c)
         static let MobilePrivatePurple = UIColor(rgb: 0xcf68ff)
+        static let PaleBlue = UIColor(rgb: 0xB0D5FB)
+        static let LightBeige = UIColor(rgb: 0xf0e6dc)
     }
 
     struct Browser {
         static let Background = BrowserColor(normal: Photon.Grey10, pbm: Photon.Grey70)
-        static let Text = BrowserColor(normal: .white, pbm: Defaults.MobileGreyD)
-        static let URLBarDivider = BrowserColor(normal: Defaults.MobileGreyC, pbm: Defaults.MobileGreyD)
+        static let Text = BrowserColor(normal: .white, pbm: Photon.Grey60)
+        static let URLBarDivider = BrowserColor(normal: Photon.Grey90A10, pbm: Photon.Grey60)
         static let LocationBarBackground = Photon.Grey30
-        static let Tint = BrowserColor(normal: Photon.Grey80, pbm: Defaults.MobileGreyA)
+        static let Tint = BrowserColor(normal: Photon.Grey80, pbm: Photon.Grey30)
     }
 
     struct URLBar {
-        static let Border = BrowserColor(normal: Photon.Grey50, pbm: Defaults.MobileGreyE)
-        static let ActiveBorder = BrowserColor(normal: Defaults.MobileBlueA, pbm: Photon.Grey60)
-        static let Tint = BrowserColor(normal: Defaults.MobileBlueB, pbm: Photon.Grey10)
+        static let Border = BrowserColor(normal: Photon.Grey50, pbm: Photon.Grey80)
+        static let ActiveBorder = BrowserColor(normal: Photon.Blue50A30, pbm: Photon.Grey60)
+        static let Tint = BrowserColor(normal: Photon.Blue50A30, pbm: Photon.Grey10)
     }
 
     struct TextField {
         static let Background = BrowserColor(normal: .white, pbm: Defaults.MobileGreyF)
         static let TextAndTint = BrowserColor(normal: Photon.Grey80, pbm: .white)
-        static let Highlight = BrowserColor(normal: Defaults.MobileBlueC, pbm: Defaults.MobilePurple)
-        static let ReaderModeButtonSelected = BrowserColor(normal: Defaults.MobileBlueD, pbm: Defaults.MobilePrivatePurple)
-        static let ReaderModeButtonUnselected = BrowserColor(normal: Photon.Grey50, pbm: Defaults.MobileGreyH)
+        static let Highlight = BrowserColor(normal: Defaults.iOSHighlightBlue, pbm: Defaults.Purple60A30)
+        static let ReaderModeButtonSelected = BrowserColor(normal: Photon.Blue40, pbm: Defaults.MobilePrivatePurple)
+        static let ReaderModeButtonUnselected = BrowserColor(normal: Photon.Grey50, pbm: Photon.Grey40)
         static let PageOptionsSelected = ReaderModeButtonSelected
         static let PageOptionsUnselected = UIColor.Browser.Tint
-        static let Separator = BrowserColor(normal: Defaults.MobileGreyJ, pbm: Defaults.MobileGreyI)
+        static let Separator = BrowserColor(normal: Photon.Grey30, pbm: Photon.Grey70)
     }
 
     // The back/forward/refresh/menu button (bottom toolbar)
     struct ToolbarButton {
-        static let SelectedTint = BrowserColor(normal: Defaults.MobileBlueD, pbm: Defaults.MobilePurpleB)
-        static let DisabledTint = BrowserColor(normal: UIColor.lightGray, pbm: UIColor.gray)
+        static let SelectedTint = BrowserColor(normal: Photon.Blue40, pbm: Photon.Purple50)
+        static let DisabledTint = BrowserColor(normal: Photon.Grey30, pbm: Photon.Grey50)
     }
 
     struct LoadingBar {
-        static let Start = BrowserColor(normal: Defaults.MobileBlueB, pbm: Photon.Purple50)
+        static let Start = BrowserColor(normal: Photon.Blue50A30, pbm: Photon.Purple50)
         static let End = BrowserColor(normal: Photon.Blue50, pbm: Photon.Magenta50)
     }
 
@@ -92,7 +81,7 @@ extension UIColor {
 
     struct TopTabs {
         static let PrivateModeTint = BrowserColor(normal: Photon.Grey10, pbm: Photon.Grey40)
-        static let Background = UIColor.Photon.Grey80
+        static let Background = Photon.Grey80
     }
 
     struct HomePanel {
@@ -125,11 +114,11 @@ public struct UIConstants {
     }
 
     static let AppBackgroundColor = UIColor.Photon.Grey10
-    static let SystemBlueColor = UIColor.Photon.Blue50
+    static let SystemBlueColor = UIColor.Photon.Blue40
     static let ControlTintColor = UIColor.Photon.Blue50
     static let PasscodeDotColor = UIColor.Photon.Grey60
     static let PrivateModeAssistantToolbarBackgroundColor = UIColor.Photon.Grey50
-    static let PrivateModeTextHighlightColor = UIColor.Photon.Purple50
+    static let PrivateModeTextHighlightColor = UIColor.Photon.Purple60
     static let PrivateModePurple = UIColor.Defaults.MobilePrivatePurple
 
     // Static fonts
@@ -144,7 +133,7 @@ public struct UIConstants {
     static let SeparatorColor = UIColor.Photon.Grey30
     static let HighlightBlue = UIColor.Photon.Blue50
     static let DestructiveRed = UIColor.Photon.Red50
-    static let BorderColor = UIColor.darkGray
+    static let BorderColor = UIColor.Photon.Grey60
     static let BackgroundColor = AppBackgroundColor
 
     // Used as backgrounds for favicons

--- a/Client/Frontend/Widgets/ActivityStreamHighlightCell.swift
+++ b/Client/Frontend/Widgets/ActivityStreamHighlightCell.swift
@@ -7,7 +7,7 @@ import Shared
 import Storage
 
 private struct ActivityStreamHighlightCellUX {
-    static let LabelColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.black : UIColor(rgb: 0x353535)
+    static let LabelColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.black : UIColor.Photon.Grey70
     static let BorderWidth: CGFloat = 0.5
     static let CellSideOffset = 20
     static let TitleLabelOffset = 2
@@ -15,10 +15,10 @@ private struct ActivityStreamHighlightCellUX {
     static let SiteImageViewSize = CGSize(width: 99, height: UIDevice.current.userInterfaceIdiom == .pad ? 120 : 90)
     static let StatusIconSize = 12
     static let FaviconSize = CGSize(width: 45, height: 45)
-    static let DescriptionLabelColor = UIColor(rgb: 0x919191) // Not found in Photon colors
+    static let DescriptionLabelColor = UIColor.Photon.Grey50
     static let SelectedOverlayColor = UIColor(white: 0.0, alpha: 0.25)
     static let CornerRadius: CGFloat = 3
-    static let BorderColor = UIColor(white: 0, alpha: 0.1)
+    static let BorderColor = UIColor.Photon.Grey30
 }
 
 class ActivityStreamHighlightCell: UICollectionViewCell {
@@ -205,7 +205,7 @@ class HighlightIntroCell: UICollectionViewCell {
     lazy var descriptionLabel: UILabel = {
         let label = UILabel()
         label.font = DynamicFontHelper.defaultHelper.MediumSizeRegularWeightAS
-        label.textColor = UIColor.darkGray
+        label.textColor = UIColor.Photon.Grey60
         label.numberOfLines = 0
         return label
     }()

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -18,7 +18,7 @@ protocol AutocompleteTextFieldDelegate: class {
 }
 
 private struct AutocompleteTextFieldUX {
-       static let HighlightColor = UIColor(rgb: 0xccdded)
+       static let HighlightColor = UIColor.Defaults.iOSHighlightBlue
 }
 
 class AutocompleteTextField: UITextField, UITextFieldDelegate {

--- a/Client/Frontend/Widgets/ErrorToast.swift
+++ b/Client/Frontend/Widgets/ErrorToast.swift
@@ -7,9 +7,9 @@ import SnapKit
 
 private struct ErrorToastDefaultUX {
     static let cornerRadius: CGFloat = 40
-    static let fillColor = UIColor(red: 186/255, green: 32/255, blue: 36/255, alpha: 1)
+    static let fillColor = UIColor.Photon.Red70
     static let margins = UIEdgeInsets(top: 10, left: 12, bottom: 10, right: 12)
-    static let textColor = UIColor.white
+    static let textColor = UIColor.Photon.White100
 }
 
 class ErrorToast: UIView {

--- a/Client/Frontend/Widgets/GradientProgressBar.swift
+++ b/Client/Frontend/Widgets/GradientProgressBar.swift
@@ -87,7 +87,7 @@ open class GradientProgressBar: UIProgressView {
         alphaMaskLayer.anchorPoint = .zero
         alphaMaskLayer.position = .zero
 
-        alphaMaskLayer.backgroundColor = UIColor.white.cgColor
+        alphaMaskLayer.backgroundColor = UIColor.Photon.White100.cgColor
     }
     
     private func setupGradientLayer() {

--- a/Client/Frontend/Widgets/HistoryBackButton.swift
+++ b/Client/Frontend/Widgets/HistoryBackButton.swift
@@ -37,7 +37,7 @@ class HistoryBackButton: UIButton {
         addSubview(chevron)
         addSubview(title)
 
-        backgroundColor = UIColor.white
+        backgroundColor = UIColor.Photon.White100
 
         chevron.snp.makeConstraints { make in
             make.leading.equalTo(self.safeArea.leading).offset(HistoryBackButtonUX.HistoryHistoryBackButtonHeaderChevronInset)

--- a/Client/Frontend/Widgets/InnerStrokedView.swift
+++ b/Client/Frontend/Widgets/InnerStrokedView.swift
@@ -7,7 +7,7 @@ import UIKit
 /// A transparent view with a rectangular border with rounded corners, stroked
 /// with a semi-transparent white border.
 class InnerStrokedView: UIView {
-    var color = UIColor.white.withAlphaComponent(0.2) {
+    var color = UIColor.Photon.White100.withAlphaComponent(0.2) {
         didSet {
             setNeedsDisplay()
         }

--- a/Client/Frontend/Widgets/LoginTableViewCell.swift
+++ b/Client/Frontend/Widgets/LoginTableViewCell.swift
@@ -74,7 +74,7 @@ class LoginTableViewCell: UITableViewCell {
         let label = UITextField()
         label.font = LoginTableViewCellUX.descriptionLabelFont
         label.textColor = LoginTableViewCellUX.descriptionLabelTextColor
-        label.backgroundColor = UIColor.white
+        label.backgroundColor = UIColor.Photon.White100
         label.isUserInteractionEnabled = false
         label.autocapitalizationType = .none
         label.autocorrectionType = .no
@@ -92,14 +92,14 @@ class LoginTableViewCell: UITableViewCell {
         let label = UILabel()
         label.font = LoginTableViewCellUX.highlightedLabelFont
         label.textColor = LoginTableViewCellUX.highlightedLabelTextColor
-        label.backgroundColor = UIColor.white
+        label.backgroundColor = UIColor.Photon.White100
         label.numberOfLines = 1
         return label
     }()
 
     fileprivate lazy var iconImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.backgroundColor = UIColor.white
+        imageView.backgroundColor = UIColor.Photon.White100
         imageView.contentMode = .scaleAspectFit
         return imageView
     }()
@@ -180,8 +180,8 @@ class LoginTableViewCell: UITableViewCell {
         indentationWidth = 0
         selectionStyle = .none
 
-        contentView.backgroundColor = UIColor.white
-        labelContainer.backgroundColor = UIColor.white
+        contentView.backgroundColor = UIColor.Photon.White100
+        labelContainer.backgroundColor = UIColor.Photon.White100
 
         labelContainer.addSubview(highlightedLabel)
         labelContainer.addSubview(descriptionLabel)

--- a/Client/Frontend/Widgets/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet.swift
@@ -13,7 +13,7 @@ private struct PhotonActionSheetUX {
     static let HeaderFooterHeight: CGFloat = 20
     static let RowHeight: CGFloat = 50
     static let BorderWidth: CGFloat = 0.5
-    static let BorderColor = UIColor(white: 0, alpha: 0.1)
+    static let BorderColor = UIColor.Photon.Grey30
     static let CornerRadius: CGFloat = 10
     static let SiteImageViewSize = 52
     static let IconSize = CGSize(width: 24, height: 24)
@@ -326,13 +326,13 @@ private class PhotonActionSheetTitleHeaderView: UITableViewHeaderFooterView {
         let titleLabel = UILabel()
         titleLabel.font = DynamicFontHelper.defaultHelper.SmallSizeRegularWeightAS
         titleLabel.numberOfLines = 1
-        titleLabel.textColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.black : UIColor.gray
+        titleLabel.textColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.black : UIColor.Photon.Grey50
         return titleLabel
     }()
 
     lazy var separatorView: UIView = {
         let separatorLine = UIView()
-        separatorLine.backgroundColor = UIColor.lightGray
+        separatorLine.backgroundColor = UIColor.Photon.Grey40
         return separatorLine
     }()
 
@@ -468,7 +468,7 @@ private class PhotonActionSheetSeparator: UITableViewHeaderFooterView {
         super.init(reuseIdentifier: reuseIdentifier)
         self.backgroundView = UIView()
         self.backgroundView?.backgroundColor = .clear
-        separatorLineView.backgroundColor = UIColor.lightGray
+        separatorLineView.backgroundColor = UIColor.Photon.Grey40
         self.contentView.addSubview(separatorLineView)
         separatorLineView.snp.makeConstraints { make in
             make.leading.trailing.equalTo(self)

--- a/Client/Frontend/Widgets/SearchInputView.swift
+++ b/Client/Frontend/Widgets/SearchInputView.swift
@@ -9,7 +9,7 @@ private struct SearchInputViewUX {
 
     static let horizontalSpacing: CGFloat = 16
     static let titleFont: UIFont = UIFont.systemFont(ofSize: 16)
-    static let titleColor: UIColor = UIColor.lightGray
+    static let titleColor: UIColor = UIColor.Photon.Grey40
     static let inputColor: UIColor = UIConstants.HighlightBlue
     static let borderColor: UIColor = UIConstants.SeparatorColor
     static let borderLineWidth: CGFloat = 0.5
@@ -78,7 +78,7 @@ class SearchInputView: UIView {
 
     fileprivate lazy var overlay: UIView = {
         let view = UIView()
-        view.backgroundColor = UIColor.white
+        view.backgroundColor = UIColor.Photon.White100
         view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tappedSearch)))
 
         view.isAccessibilityElement = true
@@ -107,7 +107,7 @@ class SearchInputView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        backgroundColor = UIColor.white
+        backgroundColor = UIColor.Photon.White100
         isUserInteractionEnabled = true
 
         addSubview(inputField)

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -8,7 +8,7 @@ import Storage
 struct SiteTableViewControllerUX {
     static let HeaderHeight = CGFloat(32)
     static let RowHeight = CGFloat(44)
-    static let HeaderBorderColor = UIColor(rgb: 0xCFD5D9).withAlphaComponent(0.8)
+    static let HeaderBorderColor = UIColor.Photon.Grey30.withAlphaComponent(0.8)
     static let HeaderTextColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.black : UIColor.Photon.Grey80
     static let HeaderBackgroundColor = UIColor.Photon.Grey10
     static let HeaderFont = UIFont.systemFont(ofSize: 12, weight: UIFont.Weight.medium)

--- a/Client/Frontend/Widgets/SnackBar.swift
+++ b/Client/Frontend/Widgets/SnackBar.swift
@@ -9,8 +9,8 @@ import Shared
 class SnackBarUX {
     static var MaxWidth: CGFloat = 400
     static let BorderWidth: CGFloat = 0.5
-    static let HighlightColor = UIColor(red: 205/255, green: 223/255, blue: 243/255, alpha: 0.9)
-    static let HighlightText = UIColor(red: 42/255, green: 121/255, blue: 213/255, alpha: 1.0)
+    static let HighlightColor = UIColor.Defaults.iOSHighlightBlue.withAlphaComponent(0.9)
+    static let HighlightText = UIColor.Photon.Blue60
 }
 
 /**

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -8,7 +8,7 @@ import Shared
 
 private struct TabsButtonUX {
     static let TitleColor: UIColor = UIColor.Photon.Grey80
-    static let TitleBackgroundColor: UIColor = UIColor.white
+    static let TitleBackgroundColor: UIColor = UIColor.Photon.White100
     static let CornerRadius: CGFloat = 2
     static let TitleFont: UIFont = UIConstants.DefaultChromeSmallFontBold
     static let BorderStrokeWidth: CGFloat = 3
@@ -16,13 +16,13 @@ private struct TabsButtonUX {
 
 class TabsButton: UIButton {
 
-    var textColor = UIColor.white {
+    var textColor = UIColor.Photon.White100 {
         didSet {
             countLabel.textColor = textColor
             borderView.color = textColor
         }
     }
-    var titleBackgroundColor  = UIColor.white {
+    var titleBackgroundColor  = UIColor.Photon.White100 {
         didSet {
             labelBackground.backgroundColor = titleBackgroundColor
         }

--- a/Client/Frontend/Widgets/ToggleButton.swift
+++ b/Client/Frontend/Widgets/ToggleButton.swift
@@ -5,8 +5,7 @@
 import UIKit
 
 private struct UX {
-    static let TopColor = UIColor(red: 179 / 255, green: 83 / 255, blue: 253 / 255, alpha: 1)
-    static let BottomColor = UIColor(red: 146 / 255, green: 16 / 255, blue: 253, alpha: 1)
+    static let BackgroundColor = UIColor.Photon.Purple60
 
     // The amount of pixels the toggle button will expand over the normal size. This results in the larger -> contract animation.
     static let ExpandDelta: CGFloat = 5
@@ -83,7 +82,7 @@ class ToggleButton: UIButton {
     lazy fileprivate var backgroundView: UIView = {
         let view = UIView()
         view.isUserInteractionEnabled = false
-        view.layer.addSublayer(self.gradientLayer)
+        view.layer.addSublayer(self.backgroundLayer)
         return view
     }()
 
@@ -92,11 +91,11 @@ class ToggleButton: UIButton {
         return circle
     }()
 
-    lazy fileprivate var gradientLayer: CAGradientLayer = {
-        let gradientLayer = CAGradientLayer()
-        gradientLayer.colors = [UX.TopColor.cgColor, UX.BottomColor.cgColor]
-        gradientLayer.mask = self.maskShapeLayer
-        return gradientLayer
+    lazy fileprivate var backgroundLayer: CALayer = {
+        let backgroundLayer = CALayer()
+        backgroundLayer.backgroundColor = UX.BackgroundColor.cgColor
+        backgroundLayer.mask = self.maskShapeLayer
+        return backgroundLayer
     }()
 
     override init(frame: CGRect) {
@@ -112,9 +111,9 @@ class ToggleButton: UIButton {
 
         // Make the gradient larger than normal to allow the mask transition to show when it blows up
         // a little larger than the resting size
-        gradientLayer.bounds = backgroundView.frame.insetBy(dx: -UX.ExpandDelta, dy: -UX.ExpandDelta)
+        backgroundLayer.bounds = backgroundView.frame.insetBy(dx: -UX.ExpandDelta, dy: -UX.ExpandDelta)
         maskShapeLayer.bounds = backgroundView.frame
-        gradientLayer.position = CGPoint(x: zeroFrame.midX, y: zeroFrame.midY)
+        backgroundLayer.position = CGPoint(x: zeroFrame.midX, y: zeroFrame.midY)
         maskShapeLayer.position = CGPoint(x: zeroFrame.midX, y: zeroFrame.midY)
 
         updateMaskPathForSelectedState(isSelected)

--- a/Client/Frontend/Widgets/TwoLineCell.swift
+++ b/Client/Frontend/Widgets/TwoLineCell.swift
@@ -12,7 +12,7 @@ struct TwoLineCellUX {
     static let BadgeMargin: CGFloat = 16
     static let BorderFrameSize: CGFloat = 32
     static let TextColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.black : UIColor.Photon.Grey80
-    static let DetailTextColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.darkGray : UIColor.gray
+    static let DetailTextColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.Photon.Grey60 : UIColor.Photon.Grey50
     static let DetailTextTopMargin: CGFloat = 0
 }
 

--- a/Client/Frontend/photon-colors.swift
+++ b/Client/Frontend/photon-colors.swift
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* Photon Colors iOS Variables v3.0.1
+/* Photon Colors iOS Variables v3.1.0
  From https://github.com/FirefoxUX/design-tokens/tree/master/photon-colors#readme */
 import UIKit
 
@@ -59,6 +59,11 @@ extension UIColor {
         static let Orange90 = UIColor(rgb: 0x3e1300)
 
         static let Grey10 = UIColor(rgb: 0xf9f9fa)
+        static let Grey10A10 = UIColor(rgba: 0xf9f9fa19)
+        static let Grey10A20 = UIColor(rgba: 0xf9f9fa33)
+        static let Grey10A40 = UIColor(rgba: 0xf9f9fa66)
+        static let Grey10A60 = UIColor(rgba: 0xf9f9fa99)
+        static let Grey10A80 = UIColor(rgba: 0xf9f9facc)
         static let Grey20 = UIColor(rgb: 0xededf0)
         static let Grey30 = UIColor(rgb: 0xd7d7db)
         static let Grey40 = UIColor(rgb: 0xb1b1b3)

--- a/Client/Utils/FaviconFetcher.swift
+++ b/Client/Utils/FaviconFetcher.swift
@@ -248,7 +248,7 @@ open class FaviconFetcher: NSObject, XMLParserDelegate {
         faviconLabel.text = faviconLetter
         faviconLabel.textAlignment = .center
         faviconLabel.font = UIFont.systemFont(ofSize: 18, weight: UIFont.Weight.medium)
-        faviconLabel.textColor = UIColor.white
+        faviconLabel.textColor = UIColor.Photon.White100
         UIGraphicsBeginImageContextWithOptions(faviconLabel.bounds.size, false, 0.0)
         faviconLabel.layer.render(in: UIGraphicsGetCurrentContext()!)
         faviconImage = UIGraphicsGetImageFromCurrentImageContext()!
@@ -261,7 +261,7 @@ open class FaviconFetcher: NSObject, XMLParserDelegate {
     // Returns a color based on the url's hash
     class func getDefaultColor(_ url: URL) -> UIColor {
         guard let hash = url.baseDomain?.hashValue else {
-            return UIColor.gray
+            return UIColor.Photon.Grey50
         }
         let index = abs(hash) % (UIConstants.DefaultColorStrings.count - 1)
         let colorHex = UIConstants.DefaultColorStrings[index]

--- a/Extensions/ShareTo/ClientPickerViewController.swift
+++ b/Extensions/ShareTo/ClientPickerViewController.swift
@@ -16,10 +16,10 @@ protocol ClientPickerViewControllerDelegate {
 private struct ClientPickerViewControllerUX {
     static let TableHeaderRowHeight = CGFloat(50)
     static let TableHeaderTextFont = UIFont.systemFont(ofSize: 16)
-    static let TableHeaderTextColor = UIColor.gray
+    static let TableHeaderTextColor = UIColor.Photon.Grey50
     static let TableHeaderTextPaddingLeft = CGFloat(20)
 
-    static let DeviceRowTintColor = UIColor(red: 0.427, green: 0.800, blue: 0.102, alpha: 1.0)
+    static let DeviceRowTintColor = UIColor.Photon.Green60
     static let DeviceRowHeight = CGFloat(50)
     static let DeviceRowTextFont = UIFont.systemFont(ofSize: 16)
     static let DeviceRowTextPaddingLeft = CGFloat(72)

--- a/Extensions/ShareTo/InstructionsViewController.swift
+++ b/Extensions/ShareTo/InstructionsViewController.swift
@@ -8,8 +8,8 @@ import SnapKit
 private struct InstructionsViewControllerUX {
     static let TopPadding = CGFloat(20)
     static let TextFont = UIFont.systemFont(ofSize: UIFont.labelFontSize)
-    static let TextColor = UIColor(rgb: 0x555555)
-    static let LinkColor = UIColor.blue
+    static let TextColor = UIColor.Photon.Grey60
+    static let LinkColor = UIColor.Photon.Blue60
 }
 
 protocol InstructionsViewControllerDelegate: class {
@@ -75,7 +75,7 @@ class InstructionsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         edgesForExtendedLayout = []
-        view.backgroundColor = UIColor.white
+        view.backgroundColor = UIColor.Photon.White100
 
         navigationItem.leftBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Close", tableName: "SendTo", comment: "Close button in top navigation bar"), style: .done, target: self, action: #selector(close))
         navigationItem.leftBarButtonItem?.accessibilityIdentifier = "InstructionsViewController.navigationItem.leftBarButtonItem"

--- a/Extensions/ShareTo/UXConstants.swift
+++ b/Extensions/ShareTo/UXConstants.swift
@@ -19,9 +19,9 @@ struct UX {
     static let rowInset: CGFloat = 16
     static let pageInfoRowLeftInset = UX.rowInset + 6
     static let pageInfoLineSpacing: CGFloat = 2
-    static let doneLabelBackgroundColor = UIColor(red: 76 / 255.0, green: 158 / 255.0, blue: 1.0, alpha: 1.0)
+    static let doneLabelBackgroundColor = UIColor.Photon.Blue40
     static let doneLabelFont = UIFont.boldSystemFont(ofSize: 17)
-    static let separatorColor = UIColor(white: CGFloat(205.0/255.0), alpha: 1.0)
+    static let separatorColor = UIColor.Photon.Grey30
     static let baseFont = UIFont.systemFont(ofSize: 15)
     static let actionRowTextAndIconColor = UIColor.Photon.Grey80
 }

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -17,7 +17,7 @@ struct TodayStrings {
 }
 
 private struct TodayUX {
-    static let privateBrowsingColor = UIColor(rgb: 0xCE6EFC)
+    static let privateBrowsingColor = UIColor(rgb: 0xcf68ff)
     static let backgroundHightlightColor = UIColor(white: 216.0/255.0, alpha: 44.0/255.0)
     static let linkTextSize: CGFloat = 10.0
     static let labelTextSize: CGFloat = 14.0


### PR DESCRIPTION
- Change color variables to Photon colors
- Change single-use colors to closest photon color
- Changed UIColor.white to UIColor.White100 - it seems redundant, but done for the sake of consistency and encouraging the use of Photon colors. 
- Removed gradient (and changed the purple tone) from behind the private browsing toggle button.
