### PR TITLE
Bug 1456064 - XCUITest Update PhotonActionSheet tests

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
@@ -215,6 +215,9 @@
                   Identifier = "NavigationTest/testToggleBetweenMobileAndDesktopSiteFromSite()">
                </Test>
                <Test
+                  Identifier = "PhotonActionSheetTest/testSendToDeviceFromShareOption()">
+               </Test>
+               <Test
                   Identifier = "PrivateBrowsingTest/testClosePrivateTabsOptionClosesPrivateTabsShortCutiPad()">
                </Test>
                <Test
@@ -273,7 +276,6 @@
       buildConfiguration = "Fennec_Enterprise"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "1"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests_iPad.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests_iPad.xcscheme
@@ -209,6 +209,9 @@
                   Identifier = "NavigationTest/testToggleBetweenMobileAndDesktopSiteFromSite()">
                </Test>
                <Test
+                  Identifier = "PhotonActionSheetTest/testSendToDeviceFromShareOption()">
+               </Test>
+               <Test
                   Identifier = "ReaderViewTest">
                </Test>
                <Test
@@ -273,7 +276,6 @@
       buildConfiguration = "Fennec_Enterprise"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "1"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/XCUITests/PhotonActionSheetTest.swift
+++ b/XCUITests/PhotonActionSheetTest.swift
@@ -49,6 +49,7 @@ class PhotonActionSheetTest: BaseTestCase {
         XCTAssertTrue(app.staticTexts["You are not signed in to your Firefox Account."].exists)
     }
 
+    // Test disabled due to new implementation Bug 1449708 - new share sheet
     func testSendToDeviceFromShareOption() {
         // Open and Wait to see the Share options sheet
         navigator.browserPerformAction(.shareOption)


### PR DESCRIPTION
With the new Share sheet implementation (See [PR](https://github.com/mozilla-mobile/firefox-ios/pull/3826)) there is one test under PhotonActionSheet test suite that does make sense now. This PR is to disable it.