### PR TITLE
Bug 1421708 - AVAudioSession keeps playing in background when tab closed

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -111,13 +111,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             setUpWebServer(profile)
         }
 
-        do {
-            // for aural progress bar: play even with silent switch on, and do not stop audio from other apps (like music)
-            try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayback, with: .mixWithOthers)
-        } catch _ {
-            print("Error: Failed to assign AVAudioSession category to allow playing with silent switch on for aural progress bar")
-        }
-
         let imageStore = DiskImageStore(files: profile.files, namespace: "TabManagerScreenshots", quality: UIConstants.ScreenshotQuality)
 
         // Temporary fix for Bug 1390871 - NSInvalidArgumentException: -[WKContentView menuHelperFindInPage]: unrecognized selector


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1421708

Remove this code as we don't need it ATM and it is causing the bug.