### PR TITLE
[nobug,build] Rome config used Carthage update, not bootstrap

### DIFF
--- a/Romefile
+++ b/Romefile
@@ -10,3 +10,4 @@
   onepassword-app-extension = OnePasswordExtension
   ios_sdk = AdjustSDK
   GCDWebServer = GCDWebServers
+  JSONSchema.swift = JSONSchema

--- a/buddybuild_carthage_command.sh
+++ b/buddybuild_carthage_command.sh
@@ -12,7 +12,7 @@ if [ "$USE_ROME_CARTHAGE" = "YES" ]; then
     rome download --platform iOS
 
     echo "[Rome script] list what is missing and update/build if needed"
-    rome list --missing --platform ios | awk '{print $1}' | xargs carthage update --platform ios
+    rome list --missing --platform ios | awk '{print $1}' | xargs carthage bootstrap --platform ios
 
     echo "[Rome script] upload what is missing"
     rome list --missing --platform ios | awk '{print $1}' | xargs rome upload --platform ios


### PR DESCRIPTION
`carthage update` will change the Cartfile.resolved, change this to `carthage bootstrap`, the latter is the correct command.
Rome is off by default, this is no-risk patch.
