### PR TITLE
Bug 1455046 - Add a title to the Page Action menu

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1289,7 +1289,7 @@ extension BrowserViewController: URLBarDelegate {
             let pageActions = self.getTabActions(tab: tab, buttonView: button, presentShareMenu: actionMenuPresenter,
                                                  findInPage: findInPageAction, presentableVC: self, isBookmarked: isBookmarked,
                                                  success: successCallback)
-            self.presentSheetWith(actions: pageActions, on: self, from: button)
+            self.presentSheetWith(title: Strings.PageActionMenuTitle, actions: pageActions, on: self, from: button)
         }
     }
     

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -439,6 +439,7 @@ extension Strings {
     public static let AppMenuRemoveBookmarkConfirmMessage = NSLocalizedString("Menu.RemoveBookmark.Confirm", value: "Bookmark Removed", comment: "Toast displayed to the user after a bookmark has been removed.")
     public static let AppMenuAddToReadingListConfirmMessage = NSLocalizedString("Menu.AddToReadingList.Confirm", value: "Added To Reading List", comment: "Toast displayed to the user after adding the item to their reading list.")
     public static let SendToDeviceTitle = NSLocalizedString("Send to Device", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to send the current tab to another device")
+    public static let PageActionMenuTitle = NSLocalizedString("Menu.PageActions.Title", value: "Page Actions", comment: "Label for title in page action menu.")
 }
 
 // Snackbar shown when tapping app store link


### PR DESCRIPTION
~String-only land before the freeze.~ (*EDIT*: changed this PR to actually have the title in the menu as suggested)
https://bugzilla.mozilla.org/show_bug.cgi?id=1455046
