### PR TITLE
Bug 1457279 - clear TabContentScripts when a tab is being deallocated.

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -251,6 +251,7 @@ class Tab: NSObject {
             webView.removeObserver(self, forKeyPath: KVOConstants.URL.rawValue)
             tabDelegate?.tab?(self, willDeleteWebView: webView)
         }
+        contentScriptManager.helpers.removeAll()
     }
 
     var loading: Bool {


### PR DESCRIPTION
Simply removing the scripts from the TabContentScriptManager allows them to be deallocated when the tab is deleted. 

I can't get `TabContentScriptManager` to be deallocated though. But because the class doesn't really do anything I dont mind leaking it. Better than how much we were leaking before.