### PR TITLE
Bug 1457945 - Handle invalid Content-Length headers for downloads

### DIFF
--- a/Client/Frontend/Browser/DownloadQueue.swift
+++ b/Client/Frontend/Browser/DownloadQueue.swift
@@ -38,7 +38,7 @@ class Download: NSObject {
         self.mimeType = preflightResponse.mimeType ?? "application/octet-stream"
         self.filename = preflightResponse.suggestedFilename ?? "unknown"
 
-        self.totalBytesExpected = preflightResponse.expectedContentLength
+        self.totalBytesExpected = preflightResponse.expectedContentLength > 0 ? preflightResponse.expectedContentLength : nil
         self.bytesDownloaded = 0
 
         super.init()


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1457945