### PR TITLE
Bug 1455672 - Telemetry for new share app extension

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -238,6 +238,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
     }
 
     func application(_ application: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+        if let profile = profile, let _ = profile.prefs.boolForKey(PrefsKeys.AppExtensionTelemetryOpenUrl) {
+            profile.prefs.removeObjectForKey(PrefsKeys.AppExtensionTelemetryOpenUrl)
+            UnifiedTelemetry.recordEvent(category: .appExtensionAction, method: .applicationOpenUrl, object: .url)
+        }
+
         guard let routerpath = NavigationPath(url: url) else {
             return false
         }

--- a/Extensions/ShareTo/SendToDevice.swift
+++ b/Extensions/ShareTo/SendToDevice.swift
@@ -36,6 +36,8 @@ class SendToDevice: ClientPickerViewControllerDelegate, InstructionsViewControll
         profile.sendItems([item], toClients: clients).uponQueue(.main) { result in
             profile.shutdown()
             self.finish()
+
+            addAppExtensionTelemetryEvent(forMethod: "send-to-device")
         }
     }
 

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -32,7 +32,9 @@ public struct PrefsKeys {
     public static let KeyCustomSyncAuth = "customSyncAuthServer"
     public static let KeyCustomSyncWeb = "customSyncWebServer"
     public static let UseStageServer = "useStageSyncService"
-    
+
+    public static let AppExtensionTelemetryOpenUrl = "AppExtensionTelemetryOpenUrl"
+    public static let AppExtensionTelemetryEventArray = "AppExtensionTelemetryEvents"
 }
 
 public struct PrefsDefaults {


### PR DESCRIPTION
Stores events in the shared NSUserDefaults, and the host app adds these
to the telemetry events before this data is sent.

https://bugzilla.mozilla.org/show_bug.cgi?id=1455672