### PR TITLE
Bug 1399872 - Select correct tab when closing tab.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1123,8 +1123,6 @@ class BrowserViewController: UIViewController {
 
         if let url = webView.url {
             if !url.isErrorPageURL, !url.isAboutHomeURL {
-                tab.lastExecutedTime = Date.now()
-
                 postLocationChangeNotificationForTab(tab, navigation: navigation)
 
                 // Fire the readability check. This is here and not in the pageShow event handler in ReaderMode.js anymore

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -295,35 +295,36 @@ class TabManagerTests: XCTestCase {
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
 
-        func addTab(_ load: Bool) -> Tab {
+        func addTab(_ visit: Bool) -> Tab {
             let tab = manager.addTab()
-            if load {
+            if visit {
                 tab.lastExecutedTime = Date.now()
             }
             return tab
         }
 
-        let tab0 = addTab(false) // not loaded
+        let tab0 = addTab(false) // not visited
         let tab1 = addTab(true)
         let tab2 = addTab(true)
-        let tab3 = addTab(false) // not loaded
-        let tab4 = addTab(true)
+        let tab3 = addTab(true)
+        let tab4 = addTab(false) // not visited
 
-        // starting at tab2, we should be selecting
-        // [ tab4, tab1, tab3, tab0 ]
+        // starting at tab1, we should be selecting
+        // [ tab3, tab4, tab2, tab0 ]
 
-        manager.selectTab(tab2)
+        manager.selectTab(tab1)
+        tab1.parent = tab3
         manager.removeTab(manager.selectedTab!)
-        // Rule: most recently loaded.
-        XCTAssertEqual(manager.selectedTab, tab4)
-
-        manager.removeTab(manager.selectedTab!)
-        // Rule: most recently loaded.
-        XCTAssertEqual(manager.selectedTab, tab1)
+        // Rule: parent tab if it was the most recently visited
+        XCTAssertEqual(manager.selectedTab, tab3)
 
         manager.removeTab(manager.selectedTab!)
         // Rule: next to the right.
-        XCTAssertEqual(manager.selectedTab, tab3)
+        XCTAssertEqual(manager.selectedTab, tab4)
+
+        manager.removeTab(manager.selectedTab!)
+        // Rule: next to the left, when none to the right
+        XCTAssertEqual(manager.selectedTab, tab2)
 
         manager.removeTab(manager.selectedTab!)
         // Rule: last one left.


### PR DESCRIPTION
This patch checks if the recently closed tab has a parent tab, and if so, selects it.

## Notes for testing this patch
As mentioned in https://bugzilla.mozilla.org/show_bug.cgi?id=1399872:

- Load news.google.com in tab 1
- Load wikipedia.com in tab 2
- Tap on the tab 1 (news.google.com) and tap on an article
        => The article opens in a new tab
- Close the article

news.google.com should become the selected tab

### Questions
The desktop behavior seems to be that if there is ONE child tab, then it will go back and select the parent, if there is more than one child tab, it will select the tab to the right.
In NO case does desktop check what the last active or last executed tab was. Other than the exception just mentioned with child tabs, it seems to always select the next tab to the right.
- Do we want iOS behavior to be exactly like desktop?