### PR TITLE
Bug 1247022 - 'Find in Page' highlight clears when changing tabs.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1053,7 +1053,7 @@ class BrowserViewController: UIViewController {
         LeanPlumClient.shared.track(event: .userSharedWebpage)
     }
 
-    func updateFindInPageVisibility(visible: Bool) {
+    func updateFindInPageVisibility(visible: Bool, tab: Tab? = nil) {
         if visible {
             if findInPageBar == nil {
                 let findInPageBar = FindInPageBar()
@@ -1079,7 +1079,8 @@ class BrowserViewController: UIViewController {
             self.findInPageBar?.becomeFirstResponder()
         } else if let findInPageBar = self.findInPageBar {
             findInPageBar.endEditing(true)
-            guard let webView = tabManager.selectedTab?.webView else { return }
+            let tab = tab ?? tabManager.selectedTab
+            guard let webView = tab?.webView else { return }
             webView.evaluateJavaScript("__firefox__.findDone()", completionHandler: nil)
             findInPageBar.removeFromSuperview()
             self.findInPageBar = nil
@@ -1825,7 +1826,7 @@ extension BrowserViewController: TabManagerDelegate {
             }
         }
 
-        updateFindInPageVisibility(visible: false)
+        updateFindInPageVisibility(visible: false, tab: previous)
 
         navigationToolbar.updateReloadStatus(selected?.loading ?? false)
         navigationToolbar.updateBackStatus(selected?.canGoBack ?? false)


### PR DESCRIPTION
Previously, `updateFindInPageVisibility` was being called after the tabManager.selectedTab had already changed to the new tab, so the find results were being cleared from the new tab, and not the tab we left behind.

I created a new method `willSelectedTabChange`, that will be called before the change - from here we can call `updateFindInPageVisibility` before the navigation.

## Notes for testing this patch

- on ipad
- open a few tabs
- go to a site like cnn.com
- use find in page and type something to create a highlight
- change to one of the other tabs
- change back to the tab that you were using find in page

- the find bar should be gone from the bottom, and the highlight should be gone. 

## Questions
I'm just learning swift, so I might have done something funny. I was copying the way that `didSelectedTabChange` was done, in looping through all the delegates and calling it in `TabManager.swift`. However, then I needed to create empty methods on two delegates - this is what I'm most uncertain about. For the sake of the API being balanced, or for use in the future, perhaps I leave them in? I thought about selecting only the delegates that are used instead of using `forEach`, but perhaps that is unnecessary work?

edit - I've now added a default method instead.


