### PR TITLE
Bug 1453291 - Address bar menu pin option changes to unpin option whe…

### DIFF
--- a/ClientTests/MockableHistory.swift
+++ b/ClientTests/MockableHistory.swift
@@ -22,6 +22,7 @@ class MockableHistory: BrowserHistory, SyncableHistory, ResettableSyncStorage {
     func removeHostFromTopSites(_ host: String) -> Success { fatalError() }
     func clearTopSitesCache() -> Success { fatalError() }
     func removeFromPinnedTopSites(_ site: Site) -> Success { fatalError() }
+    func isPinnedTopSite(_ url: String) -> Deferred<Maybe<Bool>> { fatalError()}
     func addPinnedTopSite(_ site: Site) -> Success { fatalError() }
     func getPinnedTopSites() -> Deferred<Maybe<Cursor<Site>>> { fatalError() }
     func getSitesByLastVisit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>> { fatalError() }

--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -35,6 +35,7 @@ public protocol BrowserHistory {
     func removeFromPinnedTopSites(_ site: Site) -> Success
     func addPinnedTopSite(_ site: Site) -> Success
     func getPinnedTopSites() -> Deferred<Maybe<Cursor<Site>>>
+    func isPinnedTopSite(_ url: String) -> Deferred<Maybe<Bool>>
 }
 
 /**

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -395,6 +395,16 @@ extension SQLiteHistory: BrowserHistory {
         }
     }
 
+    public func isPinnedTopSite(_ url: String) -> Deferred<Maybe<Bool>> {
+        let sql = """
+        SELECT * FROM pinned_top_sites
+        WHERE url = ?
+        LIMIT 1
+        """
+        let args: Args = [url]
+        return self.db.queryReturnsResults(sql, args: args)
+    }
+
     public func getPinnedTopSites() -> Deferred<Maybe<Cursor<Site>>> {
         let sql = """
             SELECT * FROM pinned_top_sites LEFT OUTER JOIN view_history_id_favicon ON


### PR DESCRIPTION
…n site is pinned.

Bugzilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1453291

This changes the menu drop down option from "Pin to Top Sites" to "Remove Pinned Site" when the site has been pinned.
<img width="284" alt="screen shot 2018-05-01 at 5 35 47 pm" src="https://user-images.githubusercontent.com/10803178/39494911-2aff5ccc-4d66-11e8-9656-535668c7b572.png">

The new option removes the pinned site.

We now have to check for both the pinned status and the bookmarked status before we are able to open the menu dropdown.

