### PR TITLE
Bug 1458639 - Localize "xxMB/yyMB" download progress string

### DIFF
--- a/Client/Frontend/Browser/DownloadToast.swift
+++ b/Client/Frontend/Browser/DownloadToast.swift
@@ -43,7 +43,7 @@ class DownloadToast: Toast {
     var descriptionText: String {
         let downloadedSize = ByteCountFormatter.string(fromByteCount: combinedBytesDownloaded, countStyle: .file)
         let expectedSize = combinedTotalBytesExpected != nil ? ByteCountFormatter.string(fromByteCount: combinedTotalBytesExpected!, countStyle: .file) : nil
-        let descriptionText = expectedSize != nil ? "\(downloadedSize)/\(expectedSize!)" : downloadedSize
+        let descriptionText = expectedSize != nil ? String(format: Strings.DownloadProgressToastDescriptionText, downloadedSize, expectedSize!) : downloadedSize
 
         guard downloads.count > 1 else {
             return descriptionText
@@ -51,7 +51,7 @@ class DownloadToast: Toast {
 
         let fileCountDescription = String(format: Strings.DownloadMultipleFilesToastDescriptionText, downloads.count)
 
-        return "\(fileCountDescription) \(descriptionText)"
+        return String(format: Strings.DownloadMultipleFilesAndProgressToastDescriptionText, fileCountDescription, descriptionText)
     }
 
     var downloads: [Download] = []

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -352,6 +352,8 @@ extension Strings {
     public static let DownloadFailedToastLabelText = NSLocalizedString("Downloads.Toast.Failed.LabelText", value: "Download Failed", comment: "The label text in the Download Failed toast for showing confirmation that the download has failed.")
     public static let DownloadFailedToastButtonTitled = NSLocalizedString("Downloads.Toast.Failed.RetryButton", value: "Retry", comment: "The button to retry a failed download from the Download Failed toast.")
     public static let DownloadMultipleFilesToastDescriptionText = NSLocalizedString("Downloads.Toast.MultipleFiles.DescriptionText", value: "1 of %d files", comment: "The description text in the Download progress toast for showing the number of files when multiple files are downloading.")
+    public static let DownloadProgressToastDescriptionText = NSLocalizedString("Downloads.Toast.Progress.DescriptionText", value: "%1$@/%2$@", comment: "The description text in the Download progress toast for showing the downloaded file size (1$) out of the total expected file size (2$).")
+    public static let DownloadMultipleFilesAndProgressToastDescriptionText = NSLocalizedString("Downloads.Toast.MultipleFilesAndProgress.DescriptionText", value: "%1$@ %2$@", comment: "The description text in the Download progress toast for showing the number of files (1$) and download progress (2$).")
 }
 
 // Add Custom Search Engine


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1458639

This ensures that the *order* of the strings can be localized.