### PR TITLE
Bug 1457556 - Mask local file URLs in address bar

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -220,6 +220,16 @@ class Tab: NSObject {
         // we extract the information needed to restore the tabs and create a NSURLRequest with the custom session restore URL
         // to trigger the session restore via custom handlers
         if let sessionData = self.sessionData {
+            // If the last URL in this tab was a `file://` URL, skip session restore and go
+            // directly to loading the URL. This is fine since the only way to get to a file
+            // URL is from the Downloads home panel, so there's no history to restore.
+            if let lastURL = sessionData.urls.last, lastURL.isFileURL {
+                let fileRequest = PrivilegedRequest(url: lastURL) as URLRequest
+                lastRequest = fileRequest
+                webView.load(fileRequest)
+                return
+            }
+
             restoring = true
 
             var urls = [String]()

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -220,16 +220,6 @@ class Tab: NSObject {
         // we extract the information needed to restore the tabs and create a NSURLRequest with the custom session restore URL
         // to trigger the session restore via custom handlers
         if let sessionData = self.sessionData {
-            // If the last URL in this tab was a `file://` URL, skip session restore and go
-            // directly to loading the URL. This is fine since the only way to get to a file
-            // URL is from the Downloads home panel, so there's no history to restore.
-            if let lastURL = sessionData.urls.last, lastURL.isFileURL {
-                let fileRequest = PrivilegedRequest(url: lastURL) as URLRequest
-                lastRequest = fileRequest
-                webView.load(fileRequest)
-                return
-            }
-
             restoring = true
 
             var urls = [String]()

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -186,6 +186,10 @@ extension URL {
     }
 
     public var displayURL: URL? {
+        if self.isFileURL {
+            return URL(string: "file://\(self.lastPathComponent)")
+        }
+
         if self.isReaderModeURL {
             return self.decodeReaderModeURL?.havingRemovedAuthorisationComponents()
         }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1457556

There's two things in this PR:
- Fixes issue where we couldn't restore session on tabs that were showing local files (this was happening even before this PR)
- Changes the `displayURL` for `file://` URLs to just be `file://filename.ext`