### PR TITLE
Bug 1459013 - Don't add local file viewing to History

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1128,7 +1128,7 @@ class BrowserViewController: UIViewController {
         }
 
         if let url = webView.url {
-            if !url.isErrorPageURL, !url.isAboutHomeURL {
+            if !url.isErrorPageURL, !url.isAboutHomeURL, !url.isFileURL {
                 postLocationChangeNotificationForTab(tab, navigation: navigation)
 
                 // Fire the readability check. This is here and not in the pageShow event handler in ReaderMode.js anymore


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1459013

Another one-liner. There's a lot of reasons why we shouldn't show local files in History. This will save us from a lot of headaches :-)