### PR TITLE
Bug 1456836 - XCUITests Fix Third Party Intermittents

### DIFF
--- a/XCUITests/ThirdPartySearchTest.swift
+++ b/XCUITests/ThirdPartySearchTest.swift
@@ -107,6 +107,7 @@ class ThirdPartySearchTest: BaseTestCase {
         app.typeText("\r")
 
         // Go to settings and set MDN as the default
+        waitUntilPageLoad()
         navigator.goto(SearchSettings)
 
         app.navigationBars["Search"].buttons["Edit"].tap()
@@ -123,7 +124,6 @@ class ThirdPartySearchTest: BaseTestCase {
         app.typeText("window")
         waitforNoExistence(app.scrollViews.otherElements.buttons["developer.mozilla.org search"])
         XCTAssertFalse(app.scrollViews.otherElements.buttons["developer.mozilla.org search"].exists)
-
     }
 
     func testCustomEngineFromCorrectTemplate() {
@@ -137,6 +137,7 @@ class ThirdPartySearchTest: BaseTestCase {
         app.navigationBars.buttons["customEngineSaveButton"].tap()
 
         // Perform a search using a custom search engine
+        waitforExistence(app.tables.staticTexts["Ask"])
         navigator.goto(HomePanelsScreen)
         app.textFields["url"].tap()
         app.typeText("strange charm")


### PR DESCRIPTION
Tests are intermittently failing becuse the navigation between screen is really fast and when trying to find a button or to go to a menu, it is not accessible.
For these tests, lets add some extra checks so that there is enough time for the actions to take place