### PR TITLE
Bug 1459169 - Fix XCUITest FindInPage assertion

### DIFF
--- a/XCUITests/FindInPageTest.swift
+++ b/XCUITests/FindInPageTest.swift
@@ -22,6 +22,10 @@ class FindInPageTests: BaseTestCase {
 
         // Enter some text to start finding
         app.textFields[""].typeText("Book")
+        var i = 0
+        repeat {
+            i = i+1
+        } while (app.textFields["Book"].exists == false && i < 5)
         XCTAssertEqual(app.staticTexts["FindInPage.matchCount"].label, "1/500+", "The book word count does match")
     }
 
@@ -75,6 +79,11 @@ class FindInPageTests: BaseTestCase {
 
         // Enter some text to start finding
         app.textFields[""].typeText("The Book of")
+        var i = 0
+        repeat {
+            i = i+1
+        } while (app.textFields["The Book of"].exists == false && i < 5)
+
         XCTAssertEqual(app.staticTexts["FindInPage.matchCount"].label, "1/500+", "The book word count does match")
     }
 


### PR DESCRIPTION
The assertion to check the words found fails because it is done before the number is available. We have to wait for that. 