### PR TITLE
Bug 1447253 - sites with the same name, but different TLDs are no lon…

### DIFF
--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -558,9 +558,9 @@ extension ActivityStreamPanel: DataObserverDelegate {
                 return succeed()
             }
 
-            // How sites are merged together. We compare against the urls second level domain. example m.youtube.com is compared against `youtube`
+            // How sites are merged together. We compare against the url's base domain. example m.youtube.com is compared against `youtube.com`
             let unionOnURL = { (site: Site) -> String in
-                return URL(string: site.url)?.hostSLD ?? ""
+                return URL(string: site.url)?.baseDomain ?? ""
             }
 
             // Fetch the default sites


### PR DESCRIPTION
…ger considered the same in top sites and pinned top sites.

## Notes for testing this patch
to reproduce the bug:
- open tabs with: https://www.archive.is/ and https://www.archive.org
- pin them both to top sites
- visit the newtab page
- only the most recent one that was pinned will show up.
- if these sites become among the top sites without pinning, the one visited more will show up, the other won't

After this patch, both sites will show on top sites and as pinned top sites.

I spoke with Activity Stream folks, and they do not consider sites of the same name and different TLDs to be duplicates, so both will show on desktop. (They do, however consider "http://..." and "https://..." to be duplicates, but so does this code.)
