### PR TITLE
Bug 1459371 - [Regression] PDF viewing is broken in v12.0 (10569) Beta

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1168,8 +1168,8 @@ class BrowserViewController: UIViewController {
     }
     
     // MARK: open in helper utils
-    func addViewForOpenInHelper(_ openInHelper: OpenInHelper) {
-        guard let view = openInHelper.openInView else { return }
+    func addViewForOpenInHelper(_ openInHelper: OpenInHelper?) {
+        guard let openInHelper = openInHelper, let view = openInHelper.openInView else { return }
         webViewContainerToolbar.addSubview(view)
         webViewContainerToolbar.snp.updateConstraints { make in
             make.height.equalTo(OpenInViewUX.ViewHeight)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -165,9 +165,12 @@ extension BrowserViewController: WKNavigationDelegate {
         // We can only show this content in the web view if this URL is not pending
         // download via the context menu.
         let canShowInWebView = navigationResponse.canShowMIMEType && (navigationResponse.response.url != pendingDownloadURL)
+        let forceDownload = navigationResponse.response.url == pendingDownloadURL
 
-        guard var helperForURL = OpenIn.helperForRequest(request, response: navigationResponse.response, canShowInWebView: canShowInWebView, browserViewController: self) else {
+        let openInHelper = OpenIn.helperForRequest(request, response: navigationResponse.response, canShowInWebView: canShowInWebView, forceDownload: forceDownload, browserViewController: self)
+        guard var helperForURL = openInHelper, helperForURL is DownloadHelper else {
             if navigationResponse.canShowMIMEType {
+                addViewForOpenInHelper(openInHelper)
                 decisionHandler(.allow)
                 return
             }

--- a/Client/Frontend/Browser/ErrorPageHelper.swift
+++ b/Client/Frontend/Browser/ErrorPageHelper.swift
@@ -221,7 +221,7 @@ class ErrorPageHelper {
                 // where we are unable to redirect to a `file://` URL during
                 // session restore.
                 if previousURL.isFileURL, FileManager.default.fileExists(atPath: previousURL.path) {
-                    webView.load(PrivilegedRequest(url: previousURL) as URLRequest)
+                    webView.loadFileURL(previousURL, allowingReadAccessTo: previousURL)
                     return
                 }
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -330,6 +330,10 @@ class Tab: NSObject {
     @discardableResult func loadRequest(_ request: URLRequest) -> WKNavigation? {
         if let webView = webView {
             lastRequest = request
+            if let url = request.url, url.isFileURL, request.isPrivileged {
+                return webView.loadFileURL(url, allowingReadAccessTo: url)
+            }
+
             return webView.load(request)
         }
         return nil


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1459371

This wasn't affecting Simulator which is why I didn't notice it sooner. There were too many helpers fighting for the PDF. This also fixes an issue with viewing local `file://` PDFs on-device as well.