### PR TITLE
Bug 1449652 - Add sync button to browser menu.

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet.swift
@@ -660,7 +660,6 @@ private class PhotonActionSheetCell: UITableViewCell {
                 if action.iconAlignment == .right {
                     stackView.addArrangedSubview(statusIcon)
                 } else {
-
                     stackView.insertArrangedSubview(statusIcon, at: 0)
                 }
             } else {
@@ -699,7 +698,6 @@ private class PhotonActionSheetCell: UITableViewCell {
                     syncButton?.contentHorizontalAlignment = .right
                     syncButton?.snp.makeConstraints { make in
                         make.size.equalTo(40)
-                        make.height.equalTo(40)
                     }
                 }
                 syncButton?.updateAnimations()
@@ -708,7 +706,6 @@ private class PhotonActionSheetCell: UITableViewCell {
                     make.edges.equalTo(contentView).inset(UIEdgeInsets(top: 0, left: padding, bottom: 0, right: padding))
                 }
             }
-
         default:
             break // Do nothing. The rest are not supported yet.
         }

--- a/Client/Frontend/Widgets/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet.swift
@@ -64,6 +64,8 @@ private enum PresentationStyle {
 
 class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataSource, UIGestureRecognizerDelegate {
     fileprivate(set) var actions: [[PhotonActionSheetItem]]
+
+    var syncManager: SyncManager? // used to display the sync button
     
     private var site: Site?
     private let style: PresentationStyle
@@ -169,6 +171,15 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
                 }
                 make.width.equalTo(width)
             }
+        }
+
+        NotificationCenter.default.addObserver(self, selector: #selector(stopRotateSyncIcon), name: .ProfileDidFinishSyncing, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(stopRotateSyncIcon), name: .ProfileDidStartSyncing, object: nil)
+    }
+
+    @objc func stopRotateSyncIcon() {
+        ensureMainThread {
+            self.tableView.reloadData()
         }
     }
 
@@ -288,7 +299,8 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
         let cell = tableView.dequeueReusableCell(withIdentifier: PhotonActionSheetUX.CellName, for: indexPath) as! PhotonActionSheetCell
         let action = actions[indexPath.section][indexPath.row]
         cell.tintColor = self.tintColor
-        cell.configure(with: action)
+        let syncManager = action.accessory == .Sync ? self.syncManager : nil
+        cell.configure(with: action, syncManager: syncManager)
         return cell
     }
     
@@ -495,6 +507,7 @@ public enum PhotonActionSheetCellAccessoryType {
     case Disclosure
     case Switch
     case Text
+    case Sync // Sync is a special case.
     case None
 }
 
@@ -503,6 +516,8 @@ private class PhotonActionSheetCell: UITableViewCell {
     static let HorizontalPadding: CGFloat = 10
     static let VerticalPadding: CGFloat = 2
     static let IconSize = 16
+
+    var syncButton: SyncMenuButton?
 
     lazy var titleLabel: UILabel = {
         let titleLabel = UILabel()
@@ -615,7 +630,7 @@ private class PhotonActionSheetCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(with action: PhotonActionSheetItem) {
+    func configure(with action: PhotonActionSheetItem, syncManager: SyncManager? = nil) {
         titleLabel.text = action.title
         titleLabel.textColor = self.tintColor
         titleLabel.textColor = action.accessory == .Text ? titleLabel.textColor.withAlphaComponent(0.6) : titleLabel.textColor
@@ -630,7 +645,7 @@ private class PhotonActionSheetCell: UITableViewCell {
         if let iconName = action.iconString, let image = UIImage(named: iconName)?.withRenderingMode(.alwaysTemplate) {
             statusIcon.sd_setImage(with: action.iconURL, placeholderImage: image, options: []) { (img, err, _, _) in
                 if let img = img {
-                    self.statusIcon.image = img.createScaled(CGSize(width: 30, height: 30))
+                    self.statusIcon.image = img.createScaled(PhotonActionSheetUX.IconSize)
                 }
             }
             // When the iconURL is not nil we are most likely showing a profile picture.
@@ -639,12 +654,13 @@ private class PhotonActionSheetCell: UITableViewCell {
             if action.iconURL == nil {
                 statusIcon.tintColor = self.tintColor
             } else {
-                self.statusIcon.image = self.statusIcon.image?.createScaled(CGSize(width: 30, height: 30))
+                self.statusIcon.image = self.statusIcon.image?.createScaled(PhotonActionSheetUX.IconSize)
             }
             if statusIcon.superview == nil {
                 if action.iconAlignment == .right {
                     stackView.addArrangedSubview(statusIcon)
                 } else {
+
                     stackView.insertArrangedSubview(statusIcon, at: 0)
                 }
             } else {
@@ -655,6 +671,9 @@ private class PhotonActionSheetCell: UITableViewCell {
             }
         } else {
             statusIcon.removeFromSuperview()
+        }
+        if action.accessory != .Sync {
+            syncButton?.removeFromSuperview()
         }
 
         switch action.accessory {
@@ -671,8 +690,89 @@ private class PhotonActionSheetCell: UITableViewCell {
             toggleSwitch.accessibilityIdentifier = action.isEnabled ? "enabled" : "disabled"
             toggleSwitch.image = image
             stackView.addArrangedSubview(toggleSwitch)
+        case .Sync:
+            if let manager = syncManager {
+                if syncButton == nil {
+                    let button = SyncMenuButton(with: manager)
+                    stackView.addArrangedSubview(button)
+                    syncButton = button
+                    syncButton?.contentHorizontalAlignment = .right
+                    syncButton?.snp.makeConstraints { make in
+                        make.size.equalTo(40)
+                        make.height.equalTo(40)
+                    }
+                }
+                syncButton?.updateAnimations()
+                let padding = PhotonActionSheetCell.Padding
+                stackView.snp.remakeConstraints { make in
+                    make.edges.equalTo(contentView).inset(UIEdgeInsets(top: 0, left: padding, bottom: 0, right: padding))
+                }
+            }
+
         default:
             break // Do nothing. The rest are not supported yet.
         }
     }
 }
+
+private class SyncMenuButton: UIButton {
+
+    let syncManager: SyncManager
+    let iconSize = CGSize(width: 24, height: 24)
+
+    init(with syncManager: SyncManager) {
+        self.syncManager = syncManager
+        super.init(frame: .zero)
+
+        self.addTarget(self, action: #selector(startSync), for: .touchUpInside)
+
+        let line = UIView()
+        line.backgroundColor = UIColor.Photon.Grey40
+        self.addSubview(line)
+        line.snp.makeConstraints { make in
+            make.width.equalTo(1)
+            make.leading.equalToSuperview()
+            make.top.bottom.equalToSuperview()
+        }
+
+        guard let syncStatus = syncManager.syncDisplayState else {
+            self.setImage(UIImage(named: "FxA-Sync")?.createScaled(iconSize), for: .normal)
+            return
+        }
+
+        let imageName = (syncStatus == .inProgress) ? "FxA-Sync-Blue" : "FxA-Sync"
+        setImage(UIImage(named: imageName)?.createScaled(iconSize), for: .normal)
+
+        if syncStatus == .inProgress {
+            animate()
+        }
+    }
+
+    private func animate() {
+        let continuousRotateAnimation = CABasicAnimation(keyPath: "transform.rotation")
+        continuousRotateAnimation.fromValue = 0.0
+        continuousRotateAnimation.toValue = CGFloat(Double.pi)
+        continuousRotateAnimation.isRemovedOnCompletion = true
+        continuousRotateAnimation.duration = 0.5
+        continuousRotateAnimation.repeatCount = .infinity
+        self.imageView?.layer.add(continuousRotateAnimation, forKey: "rotateKey")
+    }
+
+    func updateAnimations() {
+        self.imageView?.layer.removeAllAnimations()
+        setImage(UIImage(named: "FxA-Sync")?.createScaled(iconSize), for: .normal)
+        if let syncStatus = syncManager.syncDisplayState, syncStatus == .inProgress {
+            setImage(UIImage(named: "FxA-Sync-Blue")?.createScaled(iconSize), for: .normal)
+            animate()
+        }
+    }
+
+    @objc func startSync() {
+        self.syncManager.syncEverything(why: .syncNow)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -25,7 +25,11 @@ extension PhotonActionSheetProtocol {
         let sheet = PhotonActionSheet(title: title, actions: actions, closeButtonTitle: closeButtonTitle, style: style)
         sheet.modalPresentationStyle = style
         sheet.photonTransitionDelegate = PhotonActionSheetAnimator()
-        
+        if let account = profile.getAccount(), account.actionNeeded == .none {
+            // the sync manager is only needed when we have a logged in user with sync in a good state
+            sheet.syncManager = profile.syncManager // the syncmanager is used to display the sync button in the browser menu
+        }
+
         if let popoverVC = sheet.popoverPresentationController, sheet.modalPresentationStyle == .popover {
             popoverVC.delegate = viewController
             popoverVC.sourceView = view
@@ -456,7 +460,7 @@ extension PhotonActionSheetProtocol {
         if let actionNeeded = account?.actionNeeded {
             iconURL = (actionNeeded == .none) ? account?.fxaProfile?.avatar.url : nil
         }
-        let syncOption = PhotonActionSheetItem(title: title, iconString: iconString, iconURL: iconURL, handler: action)
+        let syncOption = PhotonActionSheetItem(title: title, iconString: iconString, iconURL: iconURL, accessory: .Sync, handler: action)
         return [syncOption]
     }
 }


### PR DESCRIPTION
This took a lot longer than I would have liked. 

The saddest thing about this patch is that I had to break the ActionSheet abstraction in order to achieve this. Before, the PhotonActionSheet was separated from the inner workings of sync and firefox. In order to add this button I had no choice but to pull in parts of sync to properly build this 😢. I'm more upset about this than I should be. 
![simulator screen shot - iphone se - 2018-05-08 at 15 12 48](https://user-images.githubusercontent.com/522281/39785803-5b1e958c-52d2-11e8-9910-7c35c30787df.png)

