### PR TITLE
Bug 1460376 - Get client guid and send to device when sending tabs.

### DIFF
--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -444,7 +444,8 @@ open class BrowserProfile: Profile {
     }
 
     public func sendItems(_ items: [ShareItem], toClients clients: [RemoteClient]) -> Deferred<Maybe<SyncStatus>> {
-        let id = DeviceInfo.clientIdentifier(self.prefs)
+        let scratchpadPrefs = self.prefs.branch("sync.scratchpad")
+        let id = scratchpadPrefs.stringForKey("clientGUID") ?? ""
         let commands = items.map { item in
             SyncCommand.displayURIFromShareItem(item, asClient: id)
         }


### PR DESCRIPTION
DeviceInfo.clientIdentifier(self.prefs) returns an id that the fxa account is unfamiliar with, this was the id we would send when we sent a tab to a different device. What we want is the guid connected to fxa. 

When we send a tab to a device we we previously saw "tab received" as the title, now we see:
<img width="378" alt="screen shot 2018-05-09 at 11 01 32 am" src="https://user-images.githubusercontent.com/10803178/39822362-5c29a380-5378-11e8-92e2-0febf7d99ecc.png">

I had a lot of trouble figuring out how to get access to the scratchpad/scratchpad prefs from the profile. Let me know if there's a better way. This was what was done in `SyncTelemetryUtils.swift`. 

I also can't seem to find an open bug for this, I saw it from rfeeley.
