### PR TITLE
Bug 1459058 - Remove inapplicable items from Page Actions Menu for local files

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -131,7 +131,27 @@ extension PhotonActionSheetProtocol {
                        isBookmarked: Bool,
                        isPinned: Bool,
                        success: @escaping (String) -> Void) -> Array<[PhotonActionSheetItem]> {
-        
+        if tab.url?.isFileURL ?? false {
+            let shareFile = PhotonActionSheetItem(title: Strings.AppMenuSharePageTitleString, iconString: "action_share") { action in
+                guard let url = tab.url else { return }
+
+                let helper = ShareExtensionHelper(url: url, tab: nil)
+                let controller = helper.createActivityViewController { completed, activityType in
+                    print("Shared downloaded file: \(completed)")
+                }
+
+                if let popoverPresentationController = controller.popoverPresentationController {
+                    popoverPresentationController.sourceView = buttonView
+                    popoverPresentationController.sourceRect = buttonView.bounds
+                    popoverPresentationController.permittedArrowDirections = .any
+                }
+
+                presentableVC.present(controller, animated: true, completion: nil)
+            }
+
+            return [[shareFile]]
+        }
+
         let toggleActionTitle = tab.desktopSite ? Strings.AppMenuViewMobileSiteTitleString : Strings.AppMenuViewDesktopSiteTitleString
         let toggleDesktopSite = PhotonActionSheetItem(title: toggleActionTitle, iconString: "menu-RequestDesktopSite") { action in
             tab.toggleDesktopSite()
@@ -224,7 +244,7 @@ extension PhotonActionSheetProtocol {
             bvc.present(navigationController, animated: true, completion: nil)
         }
         
-        let share = PhotonActionSheetItem(title: Strings.AppMenuSharePageTitleString, iconString: "action_share") { action in
+        let sharePage = PhotonActionSheetItem(title: Strings.AppMenuSharePageTitleString, iconString: "action_share") { action in
             guard let url = tab.canonicalURL?.displayURL else { return }
             presentShareMenu(url, tab, buttonView, .up)
         }
@@ -234,7 +254,7 @@ extension PhotonActionSheetProtocol {
             success(Strings.AppMenuCopyURLConfirmMessage)
         }
 
-        var mainActions = [share]
+        var mainActions = [sharePage]
 
         // Disable bookmarking and reading list if the URL is too long.
         if !tab.urlIsTooLong {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1459058

This PR removes everything from the Page Actions menu except for the "Share" option which invokes the actual file share sheet instead of the URL one. This allows a downloaded file like a PDF to be shared from the Page Actions menu the same way it can be shared from the Downloads home panel.

<img width="260" alt="screen shot 2018-05-09 at 5 31 49 pm" src="https://user-images.githubusercontent.com/207595/39840869-e730d2f6-53ae-11e8-9caa-7020566caedc.png">

<img width="260" alt="screen shot 2018-05-09 at 5 31 54 pm" src="https://user-images.githubusercontent.com/207595/39840873-e9fd75de-53ae-11e8-980c-7c2eb58ab499.png">
