### PR TITLE
Bug 1406689 - PDFs should just go to ibooks unmodified

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -377,6 +377,7 @@
 		D018F93E1F44A71A0098F8CA /* Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = D018F93D1F44A7190098F8CA /* Schema.swift */; };
 		D02816C21ECA5E2A00240CAA /* HistoryStateHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02816C11ECA5E2A00240CAA /* HistoryStateHelper.swift */; };
 		D02818611EF056C800240CAA /* SentryIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02818601EF056C800240CAA /* SentryIntegration.swift */; };
+		D029A04920A62DB0001DB72F /* TemporaryDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = D029A04820A62DB0001DB72F /* TemporaryDocument.swift */; };
 		D03F8EB22004014E003C2224 /* FaviconHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03F8EB12004014E003C2224 /* FaviconHandler.swift */; };
 		D03F8F23200EAC1F003C2224 /* AllFramesAtDocumentStart.js in Resources */ = {isa = PBXBuildFile; fileRef = D03F8F22200EAC1E003C2224 /* AllFramesAtDocumentStart.js */; };
 		D04D1B862097859B0074B35F /* DownloadToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04D1B852097859B0074B35F /* DownloadToast.swift */; };
@@ -1506,6 +1507,7 @@
 		D018F93D1F44A7190098F8CA /* Schema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Schema.swift; sourceTree = "<group>"; };
 		D02816C11ECA5E2A00240CAA /* HistoryStateHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HistoryStateHelper.swift; sourceTree = "<group>"; };
 		D02818601EF056C800240CAA /* SentryIntegration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SentryIntegration.swift; sourceTree = "<group>"; };
+		D029A04820A62DB0001DB72F /* TemporaryDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemporaryDocument.swift; sourceTree = "<group>"; };
 		D03F8EB12004014E003C2224 /* FaviconHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconHandler.swift; sourceTree = "<group>"; };
 		D03F8F20200EABB0003C2224 /* __firefox__.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = __firefox__.js; sourceTree = "<group>"; };
 		D03F8F22200EAC1E003C2224 /* AllFramesAtDocumentStart.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = AllFramesAtDocumentStart.js; sourceTree = "<group>"; };
@@ -2934,6 +2936,7 @@
 				D314E7F51A37B98700426A76 /* TabToolbar.swift */,
 				D301AAED1A3A55B70078DD1D /* TabTrayController.swift */,
 				396CDB54203C5B870034A3A3 /* TabTrayController+KeyCommands.swift */,
+				D029A04820A62DB0001DB72F /* TemporaryDocument.swift */,
 				3BCE6D3B1CEB9E4D0080928C /* ThirdPartySearchAlerts.swift */,
 				D04D1B91209790B60074B35F /* Toast.swift */,
 				C4E3985F1D22C409004E89BA /* TopTabsLayout.swift */,
@@ -4965,6 +4968,7 @@
 			files = (
 				E68E39BE1C46F42000B85F42 /* AppSettingsTableViewController.swift in Sources */,
 				E640E86A1C73A47C00C5F072 /* PasscodeViews.swift in Sources */,
+				D029A04920A62DB0001DB72F /* TemporaryDocument.swift in Sources */,
 				E692E3371C46E86A009D1240 /* AppSettingsOptions.swift in Sources */,
 				D38F02D11C05127100175932 /* Authenticator.swift in Sources */,
 				E68E7ADC1CAC208200FDCA76 /* SetupPasscodeViewController.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1167,31 +1167,6 @@ class BrowserViewController: UIViewController {
         // Remember whether or not a desktop site was requested
         tab.desktopSite = webView.customUserAgent?.isEmpty == false
     }
-    
-    // MARK: open in helper utils
-    func addViewForOpenInHelper(_ openInHelper: OpenInHelper?) {
-        guard let openInHelper = openInHelper, let view = openInHelper.openInView else { return }
-        webViewContainerToolbar.addSubview(view)
-        webViewContainerToolbar.snp.updateConstraints { make in
-            make.height.equalTo(OpenInViewUX.ViewHeight)
-        }
-        view.snp.makeConstraints { make in
-            make.edges.equalTo(webViewContainerToolbar)
-        }
-        
-        self.openInHelper = openInHelper
-    }
-    
-    func removeOpenInView() {
-        guard let _ = self.openInHelper else { return }
-        webViewContainerToolbar.subviews.forEach { $0.removeFromSuperview() }
-        
-        webViewContainerToolbar.snp.updateConstraints { make in
-            make.height.equalTo(0)
-        }
-        
-        self.openInHelper = nil
-    }
 }
 
 extension BrowserViewController: ClipboardBarDisplayHandlerDelegate {
@@ -1787,7 +1762,6 @@ extension BrowserViewController: TabManagerDelegate {
         // Remove the old accessibilityLabel. Since this webview shouldn't be visible, it doesn't need it
         // and having multiple views with the same label confuses tests.
         if let wv = previous?.webView {
-            removeOpenInView()
             wv.endEditing(true)
             wv.accessibilityLabel = nil
             wv.accessibilityElementsHidden = true

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -44,7 +44,6 @@ class BrowserViewController: UIViewController {
     var clipboardBarDisplayHandler: ClipboardBarDisplayHandler?
     var readerModeBar: ReaderModeBarView?
     var readerModeCache: ReaderModeCache
-    let webViewContainerToolbar = UIView()
     var statusBarOverlay: UIView!
     fileprivate(set) var toolbar: TabToolbar?
     var searchController: SearchViewController?
@@ -336,7 +335,6 @@ class BrowserViewController: UIViewController {
         view.addSubview(webViewContainerBackdrop)
 
         webViewContainer = UIView()
-        webViewContainer.addSubview(webViewContainerToolbar)
         view.addSubview(webViewContainer)
 
         // Temporary work around for covering the non-clipped web view content
@@ -395,7 +393,6 @@ class BrowserViewController: UIViewController {
         scrollController.header = header
         scrollController.footer = footer
         scrollController.snackBars = alertStackView
-        scrollController.webViewContainerToolbar = webViewContainerToolbar
 
         self.updateToolbarStateForTraitCollection(self.traitCollection)
 
@@ -428,11 +425,6 @@ class BrowserViewController: UIViewController {
 
         webViewContainerBackdrop.snp.makeConstraints { make in
             make.edges.equalTo(webViewContainer)
-        }
-
-        webViewContainerToolbar.snp.makeConstraints { make in
-            make.left.right.top.equalTo(webViewContainer)
-            make.height.equalTo(0)
         }
     }
 
@@ -556,7 +548,6 @@ class BrowserViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         presentIntroViewController()
-        self.webViewContainerToolbar.isHidden = false
 
         screenshotHelper.viewIsVisible = true
         screenshotHelper.takePendingScreenshots(tabManager.tabs)
@@ -1233,7 +1224,6 @@ extension BrowserViewController {
 
 extension BrowserViewController: URLBarDelegate {
     func showTabTray() {
-        webViewContainerToolbar.isHidden = true
         updateFindInPageVisibility(visible: false)
         
         let tabTrayController = TabTrayController(tabManager: tabManager, profile: profile, tabTrayDelegate: self)
@@ -1783,8 +1773,7 @@ extension BrowserViewController: TabManagerDelegate {
             scrollController.tab = selected
             webViewContainer.addSubview(webView)
             webView.snp.makeConstraints { make in
-                make.top.equalTo(webViewContainerToolbar.snp.bottom)
-                make.left.right.bottom.equalTo(self.webViewContainer)
+                make.left.right.top.bottom.equalTo(self.webViewContainer)
             }
             webView.accessibilityLabel = NSLocalizedString("Web content", comment: "Accessibility label for the main web content view")
             webView.accessibilityIdentifier = "contentView"

--- a/Client/Frontend/Browser/OpenInHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper.swift
@@ -6,21 +6,7 @@ import Foundation
 import MobileCoreServices
 import PassKit
 import WebKit
-import SnapKit
-
 import Shared
-
-import XCGLogger
-
-private let log = Logger.browserLogger
-
-struct OpenInViewUX {
-    static let ViewHeight: CGFloat = 40.0
-    static let TextFont = UIFont.systemFont(ofSize: 16)
-    static let TextColor = UIColor.Photon.Blue60
-    static let TextOffset = -15
-    static let OpenInString = NSLocalizedString("Open in…", comment: "String indicating that the file can be opened in another application on the device")
-}
 
 struct MIMEType {
     static let Bitmap = "image/bmp"
@@ -53,21 +39,10 @@ struct MIMEType {
 
 protocol OpenInHelper {
     init?(request: URLRequest?, response: URLResponse, canShowInWebView: Bool, forceDownload: Bool, browserViewController: BrowserViewController)
-    var openInView: UIView? { get set }
     func open()
 }
 
-struct OpenIn {
-    static let helpers: [OpenInHelper.Type] = [OpenPdfInHelper.self, OpenPassBookHelper.self, DownloadHelper.self]
-    
-    static func helperForRequest(_ request: URLRequest?, response: URLResponse, canShowInWebView: Bool, forceDownload: Bool, browserViewController: BrowserViewController) -> OpenInHelper? {
-        return helpers.compactMap { $0.init(request: request, response: response, canShowInWebView: canShowInWebView, forceDownload: forceDownload, browserViewController: browserViewController) }.first
-    }
-}
-
 class DownloadHelper: NSObject, OpenInHelper {
-    var openInView: UIView?
-
     fileprivate let request: URLRequest
     fileprivate let preflightResponse: URLResponse
     fileprivate let browserViewController: BrowserViewController
@@ -118,8 +93,6 @@ class DownloadHelper: NSObject, OpenInHelper {
 }
 
 class OpenPassBookHelper: NSObject, OpenInHelper {
-    var openInView: UIView?
-
     fileprivate var url: URL
 
     fileprivate let browserViewController: BrowserViewController
@@ -156,124 +129,5 @@ class OpenPassBookHelper: NSObject, OpenInHelper {
             let addController = PKAddPassesViewController(pass: pass)
             browserViewController.present(addController, animated: true, completion: nil)
         }
-
-    }
-}
-
-class OpenPdfInHelper: NSObject, OpenInHelper, UIDocumentInteractionControllerDelegate {
-    fileprivate var url: URL
-    fileprivate var docController: UIDocumentInteractionController?
-    fileprivate var openInURL: URL?
-
-    lazy var openInView: UIView? = getOpenInView()
-
-    lazy var documentDirectory: URL = {
-        return URL(string: NSTemporaryDirectory())!.appendingPathComponent("pdfs")
-    }()
-
-    fileprivate var filepath: URL?
-
-    required init?(request: URLRequest?, response: URLResponse, canShowInWebView: Bool, forceDownload: Bool, browserViewController: BrowserViewController) {
-        guard let mimeType = response.mimeType, mimeType == MIMEType.PDF, UIApplication.shared.canOpenURL(URL(string: "itms-books:")!),
-            let responseURL = response.url, !forceDownload else { return nil }
-        url = responseURL
-        super.init()
-        setFilePath(response.suggestedFilename ?? url.lastPathComponent )
-    }
-
-    fileprivate func setFilePath(_ suggestedFilename: String) {
-        var filename = suggestedFilename
-        let pathExtension = filename.asURL?.pathExtension
-        if pathExtension == nil {
-            filename.append(".pdf")
-        }
-        filepath = documentDirectory.appendingPathComponent(filename)
-    }
-
-    deinit {
-        guard let url = openInURL else { return }
-        let fileManager = FileManager.default
-        do {
-            try fileManager.removeItem(at: url)
-        } catch {
-            log.error("failed to delete file at \(url): \(error)")
-        }
-    }
-
-    func getOpenInView() -> OpenInView {
-        let overlayView = OpenInView()
-
-        overlayView.openInButton.addTarget(self, action: #selector(open), for: .touchUpInside)
-        return overlayView
-    }
-
-    func createDocumentControllerForURL(url: URL) {
-        docController = UIDocumentInteractionController(url: url)
-        docController?.delegate = self
-        self.openInURL = url
-    }
-
-    func createLocalCopyOfPDF() {
-        guard let filePath = filepath else {
-            log.error("failed to create proper URL")
-            return
-        }
-        if docController == nil {
-            // if we already have a URL but no document controller, just create the document controller
-            if let url = openInURL {
-                createDocumentControllerForURL(url: url)
-                return
-            }
-            let contentsOfFile = try? Data(contentsOf: url)
-            let fileManager = FileManager.default
-            do {
-                try fileManager.createDirectory(atPath: documentDirectory.absoluteString, withIntermediateDirectories: true, attributes: nil)
-                if fileManager.createFile(atPath: filePath.absoluteString, contents: contentsOfFile, attributes: nil) {
-                    let openInURL = URL(fileURLWithPath: filePath.absoluteString)
-                    createDocumentControllerForURL(url: openInURL)
-                } else {
-                    log.error("Unable to create local version of PDF file at \(filePath)")
-                }
-            } catch {
-                log.error("Error on creating directory at \(self.documentDirectory)")
-            }
-        }
-    }
-
-    @objc func open() {
-        createLocalCopyOfPDF()
-        guard let _parentView = self.openInView!.superview, let docController = self.docController else { log.error("view doesn't have a superview so can't open anything"); return }
-        // iBooks should be installed by default on all devices we care about, so regardless of whether or not there are other pdf-capable
-        // apps on this device, if we can open in iBooks we can open this PDF
-        // simulators do not have iBooks so the open in view will not work on the simulator
-        if UIApplication.shared.canOpenURL(URL(string: "itms-books:")!) {
-            log.info("iBooks installed: attempting to open pdf")
-            docController.presentOpenInMenu(from: .zero, in: _parentView, animated: true)
-        } else {
-            log.info("iBooks is not installed")
-        }
-    }
-}
-
-class OpenInView: UIView {
-    let openInButton = UIButton()
-
-    init() {
-        super.init(frame: .zero)
-        openInButton.setTitleColor(OpenInViewUX.TextColor, for: .normal)
-        openInButton.setTitle(OpenInViewUX.OpenInString, for: .normal)
-        openInButton.titleLabel?.font = OpenInViewUX.TextFont
-        openInButton.sizeToFit()
-        self.addSubview(openInButton)
-        openInButton.snp.makeConstraints { make in
-            make.centerY.equalTo(self)
-            make.height.equalTo(self)
-            make.trailing.equalTo(self).offset(OpenInViewUX.TextOffset)
-        }
-        self.backgroundColor = UIColor.Photon.White100
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
     }
 }

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -82,6 +82,10 @@ class Tab: NSObject {
     var mimeType: String?
     var isEditing: Bool = false
 
+    // When viewing a non-HTML content type in the webview (like a PDF document), this URL will
+    // point to a tempfile containing the content so it can be shared to external applications.
+    var temporaryDocument: TemporaryDocument?
+
     fileprivate var _noImageMode = false
 
     /// Returns true if this tab's URL is known, and it's longer than we want to store.

--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -40,7 +40,6 @@ class TabScrollingController: NSObject {
     weak var footer: UIView?
     weak var urlBar: URLBarView?
     weak var snackBars: UIView?
-    weak var webViewContainerToolbar: UIView?
 
     var footerBottomConstraint: Constraint?
     var headerTopConstraint: Constraint?
@@ -202,8 +201,6 @@ private extension TabScrollingController {
             if gesture.state == .ended || gesture.state == .cancelled {
                 lastContentOffset = 0
             }
-            
-            showOrHideWebViewContainerToolbar()
         }
     }
 
@@ -274,14 +271,6 @@ private extension TabScrollingController {
     func checkScrollHeightIsLargeEnoughForScrolling() -> Bool {
         return (UIScreen.main.bounds.size.height + 2 * UIConstants.ToolbarHeight) < scrollView?.contentSize.height ?? 0
     }
-    
-    func showOrHideWebViewContainerToolbar() {
-        if contentOffset.y >= webViewContainerToolbar?.frame.height ?? 0 {
-            webViewContainerToolbar?.isHidden = true
-        } else {
-            webViewContainerToolbar?.isHidden = false
-        }
-    }
 }
 
 extension TabScrollingController: UIGestureRecognizerDelegate {
@@ -329,17 +318,11 @@ extension TabScrollingController: UIScrollViewDelegate {
 
     func scrollViewDidEndZooming(_ scrollView: UIScrollView, with view: UIView?, atScale scale: CGFloat) {
         self.isUserZoom = false
-        showOrHideWebViewContainerToolbar()
-    }
-
-    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        showOrHideWebViewContainerToolbar()
     }
 
     func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {
         if toolbarState == .collapsed {
             showToolbars(animated: true)
-            webViewContainerToolbar?.isHidden = false
             return false
         }
         return true

--- a/Client/Frontend/Browser/TemporaryDocument.swift
+++ b/Client/Frontend/Browser/TemporaryDocument.swift
@@ -84,7 +84,6 @@ extension TemporaryDocument: URLSessionTaskDelegate, URLSessionDownloadDelegate 
             pendingResult?.fill(url)
             pendingResult = nil
         } catch let error {
-            print(error.localizedDescription)
             // If we encounter an error downloading the temp file, just return with the
             // original remote URL so it can still be shared as a web URL.
             if let remoteURL = request.url {

--- a/Client/Frontend/Browser/TemporaryDocument.swift
+++ b/Client/Frontend/Browser/TemporaryDocument.swift
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Deferred
+import Shared
+
+private let temporaryDocumentOperationQueue = OperationQueue()
+
+class TemporaryDocument: NSObject {
+    fileprivate let request: URLRequest
+    fileprivate let filename: String
+
+    fileprivate var session: URLSession?
+
+    fileprivate var downloadTask: URLSessionDownloadTask?
+    fileprivate var localFileURL: URL?
+    fileprivate var pendingResult: Deferred<URL>?
+
+    init(preflightResponse: URLResponse, request: URLRequest) {
+        self.request = request
+        self.filename = preflightResponse.suggestedFilename ?? "unknown"
+
+        super.init()
+
+        self.session = URLSession(configuration: .default, delegate: self, delegateQueue: temporaryDocumentOperationQueue)
+    }
+
+    deinit {
+        // Delete the temp file.
+        if let url = localFileURL {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    func getURL() -> Deferred<URL> {
+        if let url = localFileURL {
+            let result = Deferred<URL>()
+            result.fill(url)
+            return result
+        }
+
+        if let result = pendingResult {
+            return result
+        }
+
+        let result = Deferred<URL>()
+        pendingResult = result
+
+        downloadTask = session?.downloadTask(with: request)
+        downloadTask?.resume()
+
+        UIApplication.shared.isNetworkActivityIndicatorVisible = true
+
+        return result
+    }
+}
+
+extension TemporaryDocument: URLSessionTaskDelegate, URLSessionDownloadDelegate {
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        ensureMainThread {
+            UIApplication.shared.isNetworkActivityIndicatorVisible = false
+        }
+
+        // If we encounter an error downloading the temp file, just return with the
+        // original remote URL so it can still be shared as a web URL.
+        if error != nil, let remoteURL = request.url {
+            pendingResult?.fill(remoteURL)
+            pendingResult = nil
+        }
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+        let tempDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("TempDocs")
+        let url = tempDirectory.appendingPathComponent(filename)
+
+        try? FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true, attributes: nil)
+        try? FileManager.default.removeItem(at: url)
+
+        do {
+            try FileManager.default.moveItem(at: location, to: url)
+            localFileURL = url
+            pendingResult?.fill(url)
+            pendingResult = nil
+        } catch let error {
+            print(error.localizedDescription)
+            // If we encounter an error downloading the temp file, just return with the
+            // original remote URL so it can still be shared as a web URL.
+            if let remoteURL = request.url {
+                pendingResult?.fill(remoteURL)
+                pendingResult = nil
+            }
+        }
+    }
+}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1406689

This ended up being a bit more refactoring than I expected, but overall not too bad. One thing we can do now with this refactoring is easily add a "Download" option to the "Page Actions" menu for when you want to just save the PDF/document you're viewing to the "Downloads" folder. What do you think? We should already have the string we can reuse.