### PR TITLE
Bug 1395155 - "Debug: Force Crash" doesn't work on 12.0 (10451)

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -515,7 +515,7 @@ class BrowserViewController: UIViewController {
     }
 
     fileprivate func crashedLastLaunch() -> Bool {
-        return Sentry.crashedLastLaunch
+        return Sentry.crashedLastLaunch || Sentry.forceCrashedLastSession
     }
 
     fileprivate func cleanlyBackgrounded() -> Bool {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1395155

Sentry's "force crash" feature seems to be protected-against in iOS 11. Force-unwrapping an optional, however, is not :-)

This PR also does a simple flag flip in `UserDefaults` to indicate when we force-crashed so that we can also show the session restore prompt as if the crash were a startup crash. This makes it easier for QA to test the session restore prompt.