### PR TITLE
Bug 1442857 - Reader View toolbar hides while scrolling.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -390,6 +390,7 @@ class BrowserViewController: UIViewController {
         clipboardBarDisplayHandler?.delegate = self
         
         scrollController.urlBar = urlBar
+        scrollController.readerModeBar = readerModeBar
         scrollController.header = header
         scrollController.footer = footer
         scrollController.snackBars = alertStackView
@@ -2096,6 +2097,7 @@ extension BrowserViewController {
             readerModeBar.delegate = self
             view.insertSubview(readerModeBar, belowSubview: header)
             self.readerModeBar = readerModeBar
+            scrollController.readerModeBar = self.readerModeBar
         }
 
         updateReaderModeBar()
@@ -2108,6 +2110,7 @@ extension BrowserViewController {
             readerModeBar.removeFromSuperview()
             self.readerModeBar = nil
             self.updateViewConstraints()
+            scrollController.readerModeBar = self.readerModeBar
         }
     }
 

--- a/Client/Frontend/Browser/ReaderModeBarView.swift
+++ b/Client/Frontend/Browser/ReaderModeBarView.swift
@@ -109,6 +109,10 @@ class ReaderModeBarView: UIView {
         return button
     }
 
+    func updateAlphaForSubviews(_ alpha: CGFloat) {
+        self.alpha = alpha
+    }
+
     @objc func tappedReadStatusButton(_ sender: UIButton!) {
         UnifiedTelemetry.recordEvent(category: .action, method: .tap, object: .readingListItem, value: unread ? .markAsRead : .markAsUnread, extras: [ "from": "reader-mode-toolbar" ])
         delegate?.readerModeBar(self, didSelectButton: unread ? .markAsRead : .markAsUnread)

--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -39,6 +39,7 @@ class TabScrollingController: NSObject {
     weak var header: UIView?
     weak var footer: UIView?
     weak var urlBar: URLBarView?
+    weak var readerModeBar: ReaderModeBarView?
     weak var snackBars: UIView?
 
     var footerBottomConstraint: Constraint?
@@ -74,7 +75,11 @@ class TabScrollingController: NSObject {
     fileprivate var contentOffset: CGPoint { return scrollView?.contentOffset ?? .zero }
     fileprivate var contentSize: CGSize { return scrollView?.contentSize ?? .zero }
     fileprivate var scrollViewHeight: CGFloat { return scrollView?.frame.height ?? 0 }
-    fileprivate var topScrollHeight: CGFloat { return header?.frame.height ?? 0 }
+    fileprivate var topScrollHeight: CGFloat {
+        guard let headerHeight = header?.frame.height else { return 0 }
+        guard let readerModeHeight = readerModeBar?.frame.height else { return headerHeight }
+        return headerHeight + readerModeHeight
+    }
     fileprivate var bottomScrollHeight: CGFloat { return footer?.frame.height ?? 0 }
     fileprivate var snackBarsFrame: CGRect { return snackBars?.frame ?? .zero }
 
@@ -226,6 +231,7 @@ private extension TabScrollingController {
 
         let alpha = 1 - abs(headerTopOffset / topScrollHeight)
         urlBar?.updateAlphaForSubviews(alpha)
+        readerModeBar?.updateAlphaForSubviews(alpha)
     }
 
     func isHeaderDisplayedForGivenOffset(_ offset: CGFloat) -> Bool {
@@ -257,6 +263,7 @@ private extension TabScrollingController {
             self.headerTopOffset = headerOffset
             self.footerBottomOffset = footerOffset
             self.urlBar?.updateAlphaForSubviews(alpha)
+            self.readerModeBar?.updateAlphaForSubviews(alpha)
             self.header?.superview?.layoutIfNeeded()
         }
 


### PR DESCRIPTION
ReaderModeBar now behaves as if it is the same as the header on scrolling up and down. It scrolls away and fades.

topScrollHeight takes into account the reader mode menu if it is open. If it finds a header, it is the header height, if it finds both a header and a readerModeBar then it is the two heights added together.