### PR TITLE
Bug 1462422 - Pocket stories should check the count returned before displaying

### DIFF
--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -414,9 +414,10 @@ extension ActivityStreamPanel {
         case .highlights:
             return self.highlights.count
         case .pocket:
-            return pocketStories.isEmpty ? 0 : Int(numItems)
+            // There should always be a full row of pocket stories (numItems) otherwise don't show them
+            return pocketStories.isEmpty || (pocketStories.count < Int(numItems)) ? 0 : Int(numItems)
         case .pocketVideo:
-            return pocketVideoStories.isEmpty ? 0 : Int(numItems)
+            return pocketVideoStories.isEmpty || (pocketVideoStories.count < Int(numItems)) ? 0 : Int(numItems)
         case .highlightIntro:
             return self.highlights.isEmpty && showHighlightIntro && isHighlightsEnabled() ? 1 : 0
         }


### PR DESCRIPTION
For the pocket stories in Activity Stream the goal is to always have enough to show exactly 1 row of pocket stories. On the iPhone that would be 2. On the iPad thats 4. So when fetching stories from the Pocket API. We always fetch 4. 


If any of those fail to parse and we end up with fewer stories, when displaying stories on the iPad the app will crash. 

We assume that either we will get 4 stories or 0. But don't handle the case where we fail to parse 1. In this case we still assume we have 4 and try to display 4 stories crashing on the last one.