### PR TITLE
Bug 1462574 - Download Link option is broken for URLs that redirect

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -115,8 +115,8 @@ class BrowserViewController: UIViewController {
     var pendingRequests = [String : URLRequest]()
 
     // This is set when the user taps "Download Link" from the context menu. We then force a
-    // download of the next request through the `WKNavigationDelegate` that matches this URL.
-    var pendingDownloadURL: URL? = nil
+    // download of the next request through the `WKNavigationDelegate` that matches this web view.
+    var pendingDownloadWebView: WKWebView? = nil
 
     let downloadQueue = DownloadQueue()
 
@@ -2394,7 +2394,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
 
             let downloadTitle = NSLocalizedString("Download Link", comment: "Context menu item for downloading a link URL")
             let downloadAction = UIAlertAction(title: downloadTitle, style: .default) { _ in
-                self.pendingDownloadURL = url
+                self.pendingDownloadWebView = currentTab.webView
                 currentTab.webView?.evaluateJavaScript("window.__firefox__.download('\(url.absoluteString)', '\(UserScriptManager.securityToken)')")
                 UnifiedTelemetry.recordEvent(category: .action, method: .tap, object: .downloadLinkButton)
             }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -116,7 +116,7 @@ class BrowserViewController: UIViewController {
 
     // This is set when the user taps "Download Link" from the context menu. We then force a
     // download of the next request through the `WKNavigationDelegate` that matches this web view.
-    var pendingDownloadWebView: WKWebView? = nil
+    weak var pendingDownloadWebView: WKWebView? = nil
 
     let downloadQueue = DownloadQueue()
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -162,10 +162,10 @@ extension BrowserViewController: WKNavigationDelegate {
             request = pendingRequests.removeValue(forKey: url.absoluteString)
         }
 
-        // We can only show this content in the web view if this URL is not pending
+        // We can only show this content in the web view if this web view is not pending
         // download via the context menu.
-        let canShowInWebView = navigationResponse.canShowMIMEType && (responseURL != pendingDownloadURL)
-        let forceDownload = responseURL == pendingDownloadURL
+        let canShowInWebView = navigationResponse.canShowMIMEType && (webView != pendingDownloadWebView)
+        let forceDownload = webView == pendingDownloadWebView
 
         // Check if this response should be handed off to Passbook.
         if let passbookHelper = OpenPassBookHelper(request: request, response: response, canShowInWebView: canShowInWebView, forceDownload: forceDownload, browserViewController: self) {
@@ -183,9 +183,9 @@ extension BrowserViewController: WKNavigationDelegate {
             // Clear the network activity indicator since our helper is handling the request.
             UIApplication.shared.isNetworkActivityIndicatorVisible = false
 
-            // Clear the pending download URL so that subsequent requests to the same URL
-            // don't invoke another download.
-            pendingDownloadURL = nil
+            // Clear the pending download web view so that subsequent navigations from the same
+            // web view don't invoke another download.
+            pendingDownloadWebView = nil
 
             // Open our helper and cancel this response from the webview.
             downloadHelper.open()


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1462574

This PR makes the web view "navigation interception" a little more forgiving so that we intercept the next navigation that matches the *web view* that the user tapped "Download Link" in instead of matching the URL. It is possible, as reported in this bug, that if the URL redirects, we never match it. This is why this PR changes the behavior to simply see if the web view is the one we're expecting to download from. This should still be a very narrow window and not result in any false-positives.