### PR TITLE
Bug 1463391 - Share Extension Search: act like paste and go

### DIFF
--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -142,7 +142,8 @@ enum NavigationPath {
     }
 
     private static func handleText(text: String, with bvc: BrowserViewController) {
-        bvc.openBlankNewTab(focusLocationField: true, searchFor: text)
+        bvc.openBlankNewTab(focusLocationField: false)
+        bvc.urlBar(bvc.urlBar, didSubmitText: text)
     }
     
     private static func handleSettings(settings: SettingsPage, with rootNav: UINavigationController, baseSettingsVC: AppSettingsTableViewController, and bvc: BrowserViewController) {


### PR DESCRIPTION
It now acts like using "Paste & Go" in the url bar (uses the same func  as used by the 'paste-and-go action' to perform the search).

https://bugzilla.mozilla.org/show_bug.cgi?id=1463391