### PR TITLE
Bug 1464017 - Fix XCUITest intermittently failing on iPad after Scree…

### DIFF
--- a/XCUITests/DragAndDropTests.swift
+++ b/XCUITests/DragAndDropTests.swift
@@ -218,11 +218,14 @@ class DragAndDropTests: BaseTestCase {
 
     func testDragAndDropBookmarkEntry() {
         navigator.openURL(firstWebsite["url"]!)
+        waitUntilPageLoad()
         navigator.performAction(Action.BookmarkThreeDots)
 
         navigator.openURL(secondWebsite["url"]!)
+        waitUntilPageLoad()
         navigator.performAction(Action.BookmarkThreeDots)
 
+        navigator.goto(BrowserTabMenu)
         navigator.goto(HomePanel_Bookmarks)
         waitforExistence(app.tables["Bookmarks List"])
 

--- a/XCUITests/HistoryTests.swift
+++ b/XCUITests/HistoryTests.swift
@@ -68,6 +68,7 @@ class HistoryTests: BaseTestCase {
         navigator.goto(BrowserTab)
         navigator.goto(TabTray)
         navigator.performAction(Action.AcceptRemovingAllTabs)
+        navigator.goto(BrowserTabMenu)
         navigator.goto(HistoryRecentlyClosed)
 
         // The Closed Tabs list should contain the info of the website just closed
@@ -85,7 +86,7 @@ class HistoryTests: BaseTestCase {
         navigator.goto(BrowserTab)
         navigator.goto(TabTray)
         navigator.performAction(Action.AcceptRemovingAllTabs)
-        navigator.goto(HomePanel_History)
+        navigator.goto(BrowserTabMenu)
         navigator.goto(HistoryRecentlyClosed)
         // Once the website is visited and closed it will appear in Recently Closed Tabs list
         waitforExistence(app.tables["Recently Closed Tabs List"])

--- a/XCUITests/PrivateBrowsingTest.swift
+++ b/XCUITests/PrivateBrowsingTest.swift
@@ -145,6 +145,7 @@ class PrivateBrowsingTest: BaseTestCase {
         navigator.openURL(url1)
         enableClosePrivateBrowsingOptionWhenLeaving()
         // Leave PM by tapping on PM shourt cut
+        navigator.goto(NewTabScreen)
         navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateModeFromTabBarHomePanel)
 
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
@@ -201,6 +202,9 @@ class PrivateBrowsingTest: BaseTestCase {
 
         // Open website and check it does not appear under history once going back to regular mode
         navigator.openURL("http://example.com")
+        waitUntilPageLoad()
+        // This action to enable private mode is defined on HomePanel Screen that is why we need to open a new tab and be sure we are on that screen to use the correct action
+        navigator.goto(NewTabScreen)
         navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateModeFromTabBarHomePanel)
         navigator.goto(HomePanel_History)
         waitforExistence(app.tables["History List"])


### PR DESCRIPTION
…nGraph changes

Tests described in the bug were failing after changing the CloseAllTabs method into an action.
testDragAndDropBookmarkEntry
testRecentlyClosedOptionAvailable
testClearRecentlyClosedHistory
testClosePrivateTabsOptionClosesPrivateTabs
testClosePrivateTabsOptionClosesPrivateTabsShortCutiPad
testiPadDirectAccessPrivateMode

This PR tries to fix those test