### PR TITLE
Bug 1372404 - Allow opening about:reader URLs in ReaderMode

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -333,6 +333,12 @@ class Tab: NSObject {
 
     @discardableResult func loadRequest(_ request: URLRequest) -> WKNavigation? {
         if let webView = webView {
+            // Convert about:reader?url=http://example.com URLs to local ReaderMode URLs
+            if let url = request.url, let syncedReaderModeURL = url.decodeReaderModeURL, let localReaderModeURL = syncedReaderModeURL.encodeReaderModeURL(WebServer.sharedInstance.baseReaderModeURL()) {
+                let readerModeRequest = PrivilegedRequest(url: localReaderModeURL) as URLRequest
+                lastRequest = readerModeRequest
+                return webView.load(readerModeRequest)
+            }
             lastRequest = request
             if let url = request.url, url.isFileURL, request.isPrivileged {
                 return webView.loadFileURL(url, allowingReadAccessTo: url)

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -329,8 +329,12 @@ extension URL {
         return scheme == "http" && host == "localhost" && path == "/reader-mode/page"
     }
 
+    public var isSyncedReaderModeURL: Bool {
+        return self.absoluteString.hasPrefix("about:reader?url=")
+    }
+
     public var decodeReaderModeURL: URL? {
-        if self.isReaderModeURL {
+        if self.isReaderModeURL || self.isSyncedReaderModeURL {
             if let components = URLComponents(url: self, resolvingAgainstBaseURL: false), let queryItems = components.queryItems, queryItems.count == 1 {
                 if let queryItem = queryItems.first, let value = queryItem.value {
                     return URL(string: value)

--- a/SharedTests/NSURLExtensionsTests.swift
+++ b/SharedTests/NSURLExtensionsTests.swift
@@ -257,15 +257,35 @@ class NSURLExtensionsTests: XCTestCase {
         badurls.forEach { XCTAssertFalse(URL(string:$0)!.isReaderModeURL, $0) }
     }
 
+    func testisSyncedReaderModeURL() {
+        let goodurls = [
+            "about:reader?url=",
+            "about:reader?url=http://example.com",
+            "about:reader?url=https%3A%2F%2Fen%2Em%2Ewikipedia%2Eorg%2Fwiki%2FMain%5FPage"
+        ]
+        let badurls = [
+            "http://google.com",
+            "http://localhost:6571/sessionrestore.html",
+            "about:reader",
+            "http://about:reader?url=http://example.com"
+        ]
+
+        goodurls.forEach { XCTAssertTrue(URL(string:$0)!.isSyncedReaderModeURL, $0) }
+        badurls.forEach { XCTAssertFalse(URL(string:$0)!.isSyncedReaderModeURL, $0) }
+    }
+
     func testdecodeReaderModeURL() {
         let goodurls = [
-            ("http://localhost:6571/reader-mode/page?url=https%3A%2F%2Fen%2Em%2Ewikipedia%2Eorg%2Fwiki%2FMain%5FPage", URL(string: "https://en.m.wikipedia.org/wiki/Main_Page"))
+            ("http://localhost:6571/reader-mode/page?url=https%3A%2F%2Fen%2Em%2Ewikipedia%2Eorg%2Fwiki%2FMain%5FPage", URL(string: "https://en.m.wikipedia.org/wiki/Main_Page")),
+            ("about:reader?url=https%3A%2F%2Fen%2Em%2Ewikipedia%2Eorg%2Fwiki%2FMain%5FPage", URL(string: "https://en.m.wikipedia.org/wiki/Main_Page")),
+            ("about:reader?url=http%3A%2F%2Fexample%2Ecom%3Furl%3Dparam%26key%3Dvalue", URL(string: "http://example.com?url=param&key=value"))
         ]
         let badurls = [
             "http://google.com",
             "http://localhost:6571/sessionrestore.html",
             "http://localhost:1234/about/home/#panel=0",
-            "http://localhost:6571/reader-mode/page"
+            "http://localhost:6571/reader-mode/page",
+            "about:reader?url="
         ]
 
         goodurls.forEach { XCTAssertEqual(URL(string:$0.0)!.decodeReaderModeURL, $0.1) }


### PR DESCRIPTION
about:reader URLs synced from Android or Desktop versions of Firefox can't be opened on iOS, and blocks sending reader mode links in general. 

Related bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1359861

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Bug 12345678 - This fixes something something`

- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] ~I have updated the *UI Tests* to cover new or changed functionality~ N/A
- [ ] I have marked the bug with `[needsuplift]`
- [ ] ~I have made sure that localizable strings use `NSLocalizableString()`~ N/A

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

0. Open about:config and change the `services.sync.engine.tabs.filteredUrls` pref to allow sending about:reader URL tabs:
    ```
    ^(about:((?!reader).)*|resource:.*|chrome:.*|wyciwyg:.*|file:.*|blob:.*|moz-extension:.*)$
    ```
1. Open a page with reader mode enabled on Firefox or Android ([example](https://www.popularmechanics.com/science/environment/a20966184/carbon-dioxide-nanotubes-lithium-carbonate/))
2. Right-click the tab, send it to an iOS device
3. Make sure the tab loads the content in reader mode
