### PR TITLE
Bug 1450766 – Add the `Version/` field to the spoofed desktop UA string

### DIFF
--- a/ClientTests/ClientTests.swift
+++ b/ClientTests/ClientTests.swift
@@ -51,7 +51,7 @@ class ClientTests: XCTestCase {
 
     func testDesktopUserAgent() {
         let compare: (String) -> Bool = { ua in
-            let range = ua.range(of: "^Mozilla/5\\.0 \\(Macintosh; Intel Mac OS X [0-9_]+\\) Version/[0-9\\.]+ AppleWebKit/[0-9\\.]+ \\(KHTML, like Gecko\\) Safari/[0-9\\.]+$", options: .regularExpression)
+            let range = ua.range(of: "^Mozilla/5\\.0 \\(Macintosh; Intel Mac OS X [0-9_]+\\) AppleWebKit/[0-9\\.]+ \\(KHTML, like Gecko\\) Version/[0-9\\.]+ Safari/[0-9\\.]+$", options: .regularExpression)
             return range != nil
         }
 

--- a/ClientTests/ClientTests.swift
+++ b/ClientTests/ClientTests.swift
@@ -51,7 +51,7 @@ class ClientTests: XCTestCase {
 
     func testDesktopUserAgent() {
         let compare: (String) -> Bool = { ua in
-            let range = ua.range(of: "^Mozilla/5\\.0 \\(Macintosh; Intel Mac OS X [0-9_]+\\) AppleWebKit/[0-9\\.]+ \\(KHTML, like Gecko\\) Safari/[0-9\\.]+$", options: .regularExpression)
+            let range = ua.range(of: "^Mozilla/5\\.0 \\(Macintosh; Intel Mac OS X [0-9_]+\\) Version/[0-9\\.]+ AppleWebKit/[0-9\\.]+ \\(KHTML, like Gecko\\) Safari/[0-9\\.]+$", options: .regularExpression)
             return range != nil
         }
 

--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -127,7 +127,7 @@ open class UserAgent {
 
         // The iOS major version is equal to the Safari major version
         let majoriOSVersion = (UIDevice.current.systemVersion as NSString).components(separatedBy: ".")[0]
-        userAgent.replaceCharacters(in: mobileMatch.range, with: "Version/\(majoriOSVersion).0 ")
+        userAgent.replaceCharacters(in: mobileMatch.range, with: " Version/\(majoriOSVersion).0")
 
         return String(userAgent)
     }

--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -124,7 +124,10 @@ open class UserAgent {
             print("Error: Unable to find Mobile section in UA.")
             return String(userAgent)
         }
-        userAgent.replaceCharacters(in: mobileMatch.range, with: "")
+
+        // The iOS major version is equal to the Safari major version
+        let majoriOSVersion = (UIDevice.current.systemVersion as NSString).components(separatedBy: ".")[0]
+        userAgent.replaceCharacters(in: mobileMatch.range, with: "Version/\(majoriOSVersion).0 ")
 
         return String(userAgent)
     }


### PR DESCRIPTION
Fixes [bug 1450766](https://bugzil.la/1450766)

## Pull Request Checklist

- [x] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Bug 12345678 - This fixes something`
<p></p>

- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [x] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

Irrelevant, as this doesn’t affect UI.

## Notes for testing this patch

*I wrote this patch on Windows with VS Code without a functioning Swift Language Server, as there’s currently none available for Windows, and therefore I have no way to test this myself.*
