### PR TITLE
Bug 1467393 - XCUITest Intermittent failure on iPad long press on POM

### DIFF
--- a/XCUITests/PhotonActionSheetTest.swift
+++ b/XCUITests/PhotonActionSheetTest.swift
@@ -37,8 +37,14 @@ class PhotonActionSheetTest: BaseTestCase {
     func testShareOptionIsShownFromShortCut() {
         navigator.goto(BrowserTab)
         waitUntilPageLoad()
+        waitforExistence(app.buttons["TabLocationView.pageOptionsButton"])
         app.buttons["TabLocationView.pageOptionsButton"].press(forDuration: 1)
         // Wait to see the Share options sheet
+        // Workaround since sometimes the button is pressed just on the limit with the url bar text field and the incorrect menu is shown
+        if (app.tables["Context Menu"].cells["menu-PasteAndGo"].exists) {
+            app.otherElements["PopoverDismissRegion"].tap()
+            app.buttons["TabLocationView.pageOptionsButton"].press(forDuration: 1)
+        }
         waitforExistence(app.buttons["Copy"])
     }
 


### PR DESCRIPTION
This PR is to fix an intermittent failure happening on iPad when long pressing the POM. The correct menu is not shown if the button is tapped in the boundary with the button next to it.