### PR TITLE
Bug 1471569 - Update depedencies for sync integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent any
     triggers {
-        pollSCM('H 0 * * *')
+        cron(env.BRANCH_NAME == 'master' ? 'H 0 * * *' : '')
     }
     options {
         timestamps()

--- a/SyncIntegrationTests/Pipfile.lock
+++ b/SyncIntegrationTests/Pipfile.lock
@@ -39,11 +39,11 @@
         },
         "blessings": {
             "hashes": [
-                "sha256:26dbaf2f89c3e6dee11c10f7c0b85756ed75cf602b1bb7935b4efd8ed67a000f",
-                "sha256:466e43ff45723b272311de0437649df464b33b4daba7a54c69493212958e19c7",
-                "sha256:74919575885552e14bc24a68f8b539690bd1b5629180faa830b1a25b8c7fb6ea"
+                "sha256:98e5854d805f50a5b58ac2333411b0482516a8210f23f43308baeb58d77c157d",
+                "sha256:b1fdd7e7a675295630f9ae71527a8ebc10bfefa236b3d6aa4932ee4462c17ba3",
+                "sha256:caad5211e7ba5afe04367cdd4cfc68fa886e2e08f6f35e76b7387d2109ccea6e"
             ],
-            "version": "==1.6.1"
+            "version": "==1.7"
         },
         "certifi": {
             "hashes": [
@@ -149,10 +149,10 @@
         },
         "idna": {
             "hashes": [
-                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
-                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
             ],
-            "version": "==2.6"
+            "version": "==2.7"
         },
         "ipaddress": {
             "hashes": [
@@ -205,10 +205,11 @@
         },
         "mozinstall": {
             "hashes": [
-                "sha256:e6a650092cf753d0d56374a932bbcfd2b4c7190dafe98101ba5a6f53d00a8b0d"
+                "sha256:034e1e21cf5504324c74cab62944b25cedc7d2650054ec94f537055d6f581d7d",
+                "sha256:8a27c03a98f88f3998d5ba910b61b7f44f7aa43113f60e5b76bf4a860548cb89"
             ],
             "index": "pypi",
-            "version": "==1.15"
+            "version": "==1.16.0"
         },
         "mozlog": {
             "hashes": [
@@ -310,19 +311,19 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:26838b2bc58620e01675485491504c3aa7ee0faf335c37fcd5f8731ca4319591",
-                "sha256:32c49a69566aa7c333188149ad48b58ac11a426d5352ea3d8f6ce843f88199cb"
+                "sha256:8ea01fc4fcc8e1b1e305252b4bc80a1528019ab99fd3b88666c9dc38d754406c",
+                "sha256:90898786b3d0b880b47645bae7b51aa9bbf1e9d1e4510c2cfd15dd65c70ea0cd"
             ],
             "index": "pypi",
-            "version": "==3.6.1"
+            "version": "==3.6.2"
         },
         "pytest-fxa": {
             "hashes": [
-                "sha256:3fb5133f03a9cb0418bbb805189b2fee8bc05750ce6b13dfa5b8e140f54c802b",
-                "sha256:431dc7bbcf14a08b2f6fd2891aa06608925080840f36f36e0214d57b527a7bc3"
+                "sha256:8bbd155ca01871b54b8cca5f780af7dc5961a17196a186dbe33a46e713140d77",
+                "sha256:9a58846b0a4bc76b6318d9f35477a3e5e2a51383a30e02fe7d84142678508995"
             ],
             "index": "pypi",
-            "version": "==1.1.0"
+            "version": "==1.2.0"
         },
         "pytest-html": {
             "hashes": [
@@ -348,11 +349,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b",
-                "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
+                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
+                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
             ],
             "index": "pypi",
-            "version": "==2.18.4"
+            "version": "==2.19.1"
         },
         "requests-hawk": {
             "hashes": [
@@ -384,10 +385,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b",
-                "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "version": "==1.22"
+            "version": "==1.23"
         },
         "webob": {
             "hashes": [

--- a/SyncIntegrationTests/conftest.py
+++ b/SyncIntegrationTests/conftest.py
@@ -44,7 +44,7 @@ def firefox_log(pytestconfig, tmpdir):
 def tps_addon(pytestconfig, tmpdir_factory):
     path = pytestconfig.getoption('tps')
     if path is not None:
-        yield path
+        return path
     task_url = 'https://index.taskcluster.net/v1/task/' \
                'gecko.v2.mozilla-central.latest.firefox.addons.tps'
     task_id = requests.get(task_url).json().get('taskId')
@@ -52,7 +52,7 @@ def tps_addon(pytestconfig, tmpdir_factory):
     addon_url = 'https://queue.taskcluster.net/v1/task/' \
                 '{}/artifacts/public/tps.xpi'.format(task_id)
     scraper = DirectScraper(addon_url, destination=cache_dir)
-    yield scraper.download()
+    return scraper.download()
 
 
 @pytest.fixture


### PR DESCRIPTION
This patch updates the dependencies for the sync integration tests. This is at least needed for the latest version of mozinstall, which fixes an issue where disk images are orphaned, ultimately causing the builds on Jenkins to fail. I've also fixed an issue in the `tps` test fixture, which avoids a teardown failure when a local path to the TPS extension is used.