### PR TITLE
Bug 1470155 - XCUITest Search test remove search engines checks

### DIFF
--- a/XCUITests/SearchTest.swift
+++ b/XCUITests/SearchTest.swift
@@ -166,9 +166,10 @@ class SearchTests: BaseTestCase {
         // Change to the each search engine and verify the search uses it
         changeSearchEngine(searchEngine: "Bing")
         changeSearchEngine(searchEngine: "DuckDuckGo")
-        changeSearchEngine(searchEngine: "Google")
-        changeSearchEngine(searchEngine: "Twitter")
-        changeSearchEngine(searchEngine: "Wikipedia")
+        // Temporary disabled due to intermittent issue on BB
+        // changeSearchEngine(searchEngine: "Google")
+        // changeSearchEngine(searchEngine: "Twitter")
+        // changeSearchEngine(searchEngine: "Wikipedia")
         // changeSearchEngine(searchEngine: "Amazon.com")
     }
 


### PR DESCRIPTION
This PR is to try to fix the intermittent issue that makes the SearchEngine test fails on BB due to timeout because is a very long test