### PR TITLE
Bug 1470664 - Firefox iOS is blocking app url scheme navigations (302…

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -140,14 +140,12 @@ extension BrowserViewController: WKNavigationDelegate {
             return
         }
 
-        // Ignore JS navigated links, the intention is to match Safari and native WKWebView behaviour.
-        if navigationAction.navigationType == .linkActivated {
-            UIApplication.shared.open(url, options: [:]) { openedURL in
-                if !openedURL {
-                    let alert = UIAlertController(title: Strings.UnableToOpenURLErrorTitle, message: Strings.UnableToOpenURLError, preferredStyle: .alert)
-                    alert.addAction(UIAlertAction(title: Strings.OKString, style: .default, handler: nil))
-                    self.present(alert, animated: true, completion: nil)
-                }
+        UIApplication.shared.open(url, options: [:]) { openedURL in
+            // Do not show error message for JS navigated links or redirect as it's not the result of a user action.
+            if !openedURL, navigationAction.navigationType == .linkActivated {
+                let alert = UIAlertController(title: Strings.UnableToOpenURLErrorTitle, message: Strings.UnableToOpenURLError, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: Strings.OKString, style: .default, handler: nil))
+                self.present(alert, animated: true, completion: nil)
             }
         }
         decisionHandler(.cancel)


### PR DESCRIPTION
… redirect or JS)

This pull request fixes #3989 (https://bugzilla.mozilla.org/show_bug.cgi?id=1470664). Firefox now allow custom scheme JS navigated links and 302 redirect to be loaded. But if this fails the error alert is not showed to the user.

## Notes for testing this patch

For QA, it can be tested by loading https://julienbodet.github.io/testdeeplinks/index.html.
This html page loads a link opening medium app after the page have loaded and show two links doing the same.

First try it with Medium app installed:
- after the page has loaded, Medium app should open.
- tap on the first link, the app should open too.
- tap on the second link, the app should open too.

Then try it without Medium app installed:
- after the page has loaded, nothing happens and no error popup is displayed.
- tap on the first link, an error popup is displayed.
- tap on the second link, nothing happens and no error popup is displayed. Ideally we want to show an error popup but it's probably a bug of WebKit not considering onclick events as user activated.