### PR TITLE
Bug 1474174 - Use AnyObject for class-only protocols

### DIFF
--- a/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
+++ b/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
@@ -8,7 +8,7 @@ import Shared
 import SwiftKeychainWrapper
 
 /// Delegate available for PasscodeEntryViewController consumers to be notified of the validation of a passcode.
-@objc protocol PasscodeEntryDelegate: class {
+@objc protocol PasscodeEntryDelegate: AnyObject {
     func passcodeValidationDidSucceed()
     @objc optional func userDidCancelValidation()
 }

--- a/Client/Frontend/AuthenticationManager/PasscodeViews.swift
+++ b/Client/Frontend/AuthenticationManager/PasscodeViews.swift
@@ -12,7 +12,7 @@ private struct PasscodeUX {
     static let PasscodeFieldSize: CGSize = CGSize(width: 160, height: 32)
 }
 
-@objc protocol PasscodeInputViewDelegate: class {
+@objc protocol PasscodeInputViewDelegate: AnyObject {
     func passcodeInputView(_ inputView: PasscodeInputView, didFinishEnteringCode code: String)
 }
 

--- a/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/Client/Frontend/Browser/BrowserPrompts.swift
@@ -6,7 +6,7 @@ import Foundation
 import WebKit
 import Shared
 
-@objc protocol JSPromptAlertControllerDelegate: class {
+@objc protocol JSPromptAlertControllerDelegate: AnyObject {
     func promptAlertControllerDidDismiss(_ alertController: JSPromptAlertController)
 }
 

--- a/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -9,7 +9,7 @@ public struct ClipboardBarToastUX {
     static let ToastDelay = DispatchTimeInterval.milliseconds(4000)
 }
 
-protocol ClipboardBarDisplayHandlerDelegate: class {
+protocol ClipboardBarDisplayHandlerDelegate: AnyObject {
     func shouldDisplay(clipboardBar bar: ButtonToast)
 }
 

--- a/Client/Frontend/Browser/ContextMenuHelper.swift
+++ b/Client/Frontend/Browser/ContextMenuHelper.swift
@@ -4,7 +4,7 @@
 
 import WebKit
 
-protocol ContextMenuHelperDelegate: class {
+protocol ContextMenuHelperDelegate: AnyObject {
     func contextMenuHelper(_ contextMenuHelper: ContextMenuHelper, didLongPressElements elements: ContextMenuHelper.Elements, gestureRecognizer: UIGestureRecognizer)
     func contextMenuHelper(_ contextMenuHelper: ContextMenuHelper, didCancelGestureRecognizer: UIGestureRecognizer)
 }

--- a/Client/Frontend/Browser/FindInPageBar.swift
+++ b/Client/Frontend/Browser/FindInPageBar.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-protocol FindInPageBarDelegate: class {
+protocol FindInPageBarDelegate: AnyObject {
     func findInPage(_ findInPage: FindInPageBar, didTextChange text: String)
     func findInPage(_ findInPage: FindInPageBar, didFindPreviousWithText text: String)
     func findInPage(_ findInPage: FindInPageBar, didFindNextWithText text: String)

--- a/Client/Frontend/Browser/FindInPageHelper.swift
+++ b/Client/Frontend/Browser/FindInPageHelper.swift
@@ -6,7 +6,7 @@ import Foundation
 import Shared
 import WebKit
 
-protocol FindInPageHelperDelegate: class {
+protocol FindInPageHelperDelegate: AnyObject {
     func findInPageHelper(_ findInPageHelper: FindInPageHelper, didUpdateCurrentResult currentResult: Int)
     func findInPageHelper(_ findInPageHelper: FindInPageHelper, didUpdateTotalResults totalResults: Int)
 }

--- a/Client/Frontend/Browser/HistoryStateHelper.swift
+++ b/Client/Frontend/Browser/HistoryStateHelper.swift
@@ -5,7 +5,7 @@
 import Foundation
 import WebKit
 
-protocol HistoryStateHelperDelegate: class {
+protocol HistoryStateHelperDelegate: AnyObject {
     func historyStateHelper(_ historyStateHelper: HistoryStateHelper, didPushOrReplaceStateInTab tab: Tab)
 }
 

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -42,7 +42,7 @@ private struct SearchViewControllerUX {
     static let IconBorderWidth: CGFloat = 0.5
 }
 
-protocol SearchViewControllerDelegate: class {
+protocol SearchViewControllerDelegate: AnyObject {
     func searchViewController(_ searchViewController: SearchViewController, didSelectURL url: URL)
     func searchViewController(_ searchViewController: SearchViewController, didLongPressSuggestion suggestion: String)
     func presentSearchSettingsController()
@@ -537,7 +537,7 @@ fileprivate class ButtonScrollView: UIScrollView {
     }
 }
 
-fileprivate protocol SuggestionCellDelegate: class {
+fileprivate protocol SuggestionCellDelegate: AnyObject {
     func suggestionCell(_ suggestionCell: SuggestionCell, didSelectSuggestion suggestion: String)
     func suggestionCell(_ suggestionCell: SuggestionCell, didLongPressSuggestion suggestion: String)
 }

--- a/Client/Frontend/Browser/SessionRestoreHelper.swift
+++ b/Client/Frontend/Browser/SessionRestoreHelper.swift
@@ -5,7 +5,7 @@
 import Foundation
 import WebKit
 
-protocol SessionRestoreHelperDelegate: class {
+protocol SessionRestoreHelperDelegate: AnyObject {
     func sessionRestoreHelper(_ helper: SessionRestoreHelper, didRestoreSessionForTab tab: Tab)
 }
 

--- a/Client/Frontend/Browser/SwipeAnimator.swift
+++ b/Client/Frontend/Browser/SwipeAnimator.swift
@@ -22,7 +22,7 @@ private let DefaultParameters =
         minExitVelocity: 800,
         recenterAnimationDuration: 0.15)
 
-protocol SwipeAnimatorDelegate: class {
+protocol SwipeAnimatorDelegate: AnyObject {
     func swipeAnimator(_ animator: SwipeAnimator, viewWillExitContainerBounds: UIView)
 }
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -568,7 +568,7 @@ private class TabContentScriptManager: NSObject, WKScriptMessageHandler {
     }
 }
 
-private protocol TabWebViewDelegate: class {
+private protocol TabWebViewDelegate: AnyObject {
     func tabWebView(_ tabWebView: TabWebView, didSelectFindInPageForSelection selection: String)
 }
 

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -6,16 +6,15 @@ import Foundation
 import Shared
 import Storage
 
-@objc protocol TabSelectionDelegate: class {
+@objc protocol TabSelectionDelegate: AnyObject {
     func didSelectTabAtIndex(_ index: Int)
 }
 
-protocol TopTabCellDelegate: class {
+protocol TopTabCellDelegate: AnyObject {
     func tabCellDidClose(_ cell: UICollectionViewCell)
 }
 
-
-protocol TabDisplayer: class {
+protocol TabDisplayer: AnyObject {
     typealias TabCellIdentifer = String
     var tabCellIdentifer: TabCellIdentifer { get set }
 

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -10,7 +10,7 @@ import XCGLogger
 
 private let log = Logger.browserLogger
 
-protocol TabManagerDelegate: class {
+protocol TabManagerDelegate: AnyObject {
     func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?)
     func tabManager(_ tabManager: TabManager, willAddTab tab: Tab)
     func tabManager(_ tabManager: TabManager, didAddTab tab: Tab)
@@ -22,7 +22,7 @@ protocol TabManagerDelegate: class {
     func tabManagerDidRemoveAllTabs(_ tabManager: TabManager, toast: ButtonToast?)
 }
 
-protocol TabManagerStateDelegate: class {
+protocol TabManagerStateDelegate: AnyObject {
     func tabManagerWillStoreTabs(_ tabs: [Tab])
 }
 

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -7,7 +7,7 @@ import Shared
 import Storage
 import WebKit
 
-protocol TabPeekDelegate: class {
+protocol TabPeekDelegate: AnyObject {
     func tabPeekDidAddBookmark(_ tab: Tab)
     @discardableResult func tabPeekDidAddToReadingList(_ tab: Tab) -> ReadingListItem?
     func tabPeekRequestsPresentationOf(_ viewController: UIViewController)

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -6,7 +6,7 @@ import UIKit
 import SnapKit
 import Shared
 
-protocol TabToolbarProtocol: class {
+protocol TabToolbarProtocol: AnyObject {
     weak var tabToolbarDelegate: TabToolbarDelegate? { get set }
     var tabsButton: TabsButton { get }
     var menuButton: ToolbarButton { get }
@@ -22,7 +22,7 @@ protocol TabToolbarProtocol: class {
     func updateTabCount(_ count: Int, animated: Bool)
 }
 
-protocol TabToolbarDelegate: class {
+protocol TabToolbarDelegate: AnyObject {
     func tabToolbarDidPressBack(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressForward(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidLongPressBack(_ tabToolbar: TabToolbarProtocol, button: UIButton)

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -31,7 +31,7 @@ struct PrivateModeStrings {
     static let toggleAccessibilityValueOff = NSLocalizedString("Off", tableName: "PrivateBrowsing", comment: "Toggled OFF accessibility value")
 }
 
-protocol TabTrayDelegate: class {
+protocol TabTrayDelegate: AnyObject {
     func tabTrayDidDismiss(_ tabTray: TabTrayController)
     func tabTrayDidAddTab(_ tabTray: TabTrayController, tab: Tab)
     func tabTrayDidAddBookmark(_ tab: Tab)
@@ -641,7 +641,7 @@ class TrayToolbar: UIView, Themeable, PrivateModeUI {
     }
 }
 
-protocol TabCellDelegate: class {
+protocol TabCellDelegate: AnyObject {
     func tabCellDidClose(_ cell: TabCell)
 }
 

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -21,7 +21,7 @@ struct TopTabsUX {
     static let SeparatorHeight: CGFloat = 32
 }
 
-protocol TopTabsDelegate: class {
+protocol TopTabsDelegate: AnyObject {
     func topTabsDidPressTabs()
     func topTabsDidPressNewTab(_ isPrivate: Bool)
     func topTabsDidTogglePrivateMode()

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -24,7 +24,7 @@ private struct URLBarViewUX {
     static let ToolbarButtonInsets = UIEdgeInsets(equalInset: Padding)
 }
 
-protocol URLBarDelegate: class {
+protocol URLBarDelegate: AnyObject {
     func urlBarDidPressTabs(_ urlBar: URLBarView)
     func urlBarDidPressReaderMode(_ urlBar: URLBarView)
     /// - returns: whether the long-press was handled by the delegate; i.e. return `false` when the conditions for even starting handling long-press were not satisfied

--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -14,7 +14,7 @@ private struct HomePanelViewControllerUX {
     static let ButtonSelectionAnimationDuration = 0.2
 }
 
-protocol HomePanelViewControllerDelegate: class {
+protocol HomePanelViewControllerDelegate: AnyObject {
     func homePanelViewController(_ homePanelViewController: HomePanelViewController, didSelectURL url: URL, visitType: VisitType)
     func homePanelViewController(_ HomePanelViewController: HomePanelViewController, didSelectPanel panel: Int)
     func homePanelViewControllerDidRequestToSignIn(_ homePanelViewController: HomePanelViewController)
@@ -22,7 +22,7 @@ protocol HomePanelViewControllerDelegate: class {
     func homePanelViewControllerDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool)
 }
 
-protocol HomePanel: class {
+protocol HomePanel: AnyObject {
     weak var homePanelDelegate: HomePanelDelegate? { get set }
 }
 
@@ -30,7 +30,7 @@ struct HomePanelUX {
     static let EmptyTabContentOffset = -180
 }
 
-protocol HomePanelDelegate: class {
+protocol HomePanelDelegate: AnyObject {
     func homePanelDidRequestToSignIn(_ homePanel: HomePanel)
     func homePanelDidRequestToCreateAccount(_ homePanel: HomePanel)
     func homePanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool)

--- a/Client/Frontend/Home/PanelDataObservers.swift
+++ b/Client/Frontend/Home/PanelDataObservers.swift
@@ -17,7 +17,7 @@ protocol DataObserver {
     func refreshIfNeeded(forceHighlights highlights: Bool, forceTopSites topSites: Bool)
 }
 
-protocol DataObserverDelegate: class {
+protocol DataObserverDelegate: AnyObject {
     func didInvalidateDataSources(refresh forced: Bool, highlightsRefreshed: Bool, topSitesRefreshed: Bool)
     func willInvalidateDataSources(forceHighlights highlights: Bool, forceTopSites topSites: Bool)
 }

--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -21,7 +21,7 @@ struct IntroUX {
     static let FadeDuration = 0.25
 }
 
-protocol IntroViewControllerDelegate: class {
+protocol IntroViewControllerDelegate: AnyObject {
     func introViewControllerDidFinish(_ introViewController: IntroViewController, requestToLogin: Bool)
 }
 

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -407,7 +407,7 @@ fileprivate class ListSelectionController: NSObject {
     }
 }
 
-protocol LoginDataSourceObserver: class {
+protocol LoginDataSourceObserver: AnyObject {
     func loginSectionsDidUpdate()
 }
 

--- a/Client/Frontend/Settings/FxAContentViewController.swift
+++ b/Client/Frontend/Settings/FxAContentViewController.swift
@@ -8,7 +8,7 @@ import UIKit
 import WebKit
 import SwiftyJSON
 
-protocol FxAContentViewControllerDelegate: class {
+protocol FxAContentViewControllerDelegate: AnyObject {
     func contentViewControllerDidSignIn(_ viewController: FxAContentViewController, withFlags: FxALoginFlags)
     func contentViewControllerDidCancel(_ viewController: FxAContentViewController)
 }

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -6,7 +6,7 @@ import UIKit
 import SDWebImage
 import Shared
 
-protocol SearchEnginePickerDelegate: class {
+protocol SearchEnginePickerDelegate: AnyObject {
     func searchEnginePicker(_ searchEnginePicker: SearchEnginePicker?, didSelectSearchEngine engine: OpenSearchEngine?)
 }
 

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -474,7 +474,7 @@ class WithoutAccountSetting: AccountSetting {
 }
 
 @objc
-protocol SettingsDelegate: class {
+protocol SettingsDelegate: AnyObject {
     func settingsOpenURLInNewTab(_ url: URL)
 }
 

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -9,7 +9,7 @@ import Shared
 
 /// Delegate for the text field events. Since AutocompleteTextField owns the UITextFieldDelegate,
 /// callers must use this instead.
-protocol AutocompleteTextFieldDelegate: class {
+protocol AutocompleteTextFieldDelegate: AnyObject {
     func autocompleteTextField(_ autocompleteTextField: AutocompleteTextField, didEnterText text: String)
     func autocompleteTextFieldShouldReturn(_ autocompleteTextField: AutocompleteTextField) -> Bool
     func autocompleteTextFieldShouldClear(_ autocompleteTextField: AutocompleteTextField) -> Bool

--- a/Client/Frontend/Widgets/LoginTableViewCell.swift
+++ b/Client/Frontend/Widgets/LoginTableViewCell.swift
@@ -6,7 +6,7 @@ import UIKit
 import SnapKit
 import Storage
 
-protocol LoginTableViewCellDelegate: class {
+protocol LoginTableViewCellDelegate: AnyObject {
     func didSelectOpenAndFillForCell(_ cell: LoginTableViewCell)
     func shouldReturnAfterEditingDescription(_ cell: LoginTableViewCell) -> Bool
     func infoItemForCell(_ cell: LoginTableViewCell) -> InfoItem?

--- a/Client/Frontend/Widgets/SearchInputView.swift
+++ b/Client/Frontend/Widgets/SearchInputView.swift
@@ -13,7 +13,7 @@ private struct SearchInputViewUX {
     static let closeButtonSize: CGFloat = 36
 }
 
-@objc protocol SearchInputViewDelegate: class {
+@objc protocol SearchInputViewDelegate: AnyObject {
 
     func searchInputView(_ searchView: SearchInputView, didChangeTextTo text: String)
 

--- a/Client/Helpers/FxALoginHelper.swift
+++ b/Client/Helpers/FxALoginHelper.swift
@@ -18,7 +18,7 @@ private let log = Logger.browserLogger
 private let verificationPollingInterval = DispatchTimeInterval.seconds(3)
 private let verificationMaxRetries = 100 // Poll every 3 seconds for 5 minutes.
 
-protocol FxAPushLoginDelegate: class {
+protocol FxAPushLoginDelegate: AnyObject {
     func accountLoginDidFail()
 
     func accountLoginDidSucceed(withFlags flags: FxALoginFlags)

--- a/Extensions/ShareTo/InstructionsViewController.swift
+++ b/Extensions/ShareTo/InstructionsViewController.swift
@@ -12,7 +12,7 @@ private struct InstructionsViewControllerUX {
     static let LinkColor = UIColor.Photon.Blue60
 }
 
-protocol InstructionsViewControllerDelegate: class {
+protocol InstructionsViewControllerDelegate: AnyObject {
     func instructionsViewControllerDidClose(_ instructionsViewController: InstructionsViewController)
 }
 

--- a/Extensions/ShareTo/ShareViewController.swift
+++ b/Extensions/ShareTo/ShareViewController.swift
@@ -48,7 +48,7 @@ extension String {
     }
 }
 
-protocol ShareControllerDelegate: class {
+protocol ShareControllerDelegate: AnyObject {
     func finish(afterDelay: TimeInterval)
     func getValidExtensionContext() -> NSExtensionContext?
     func hidePopupWhenShowingAlert()

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -92,7 +92,7 @@ class CommandStoringSyncDelegate: SyncDelegate {
 /**
  * A Profile manages access to the user's data.
  */
-protocol Profile: class {
+protocol Profile: AnyObject {
     var bookmarks: BookmarksModelFactorySource & KeywordSearchSource & ShareToDestination & SyncableBookmarks & LocalItemSource & MirrorItemSource { get }
     // var favicons: Favicons { get }
     var prefs: Prefs { get }

--- a/Shared/Accessibility.swift
+++ b/Shared/Accessibility.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public protocol AccessibilityActionsSource: class {
+public protocol AccessibilityActionsSource: AnyObject {
     func accessibilityCustomActionsForView(_ view: UIView) -> [UIAccessibilityCustomAction]?
 }
 

--- a/Shared/Cancellable.swift
+++ b/Shared/Cancellable.swift
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-public protocol Cancellable: class {
+public protocol Cancellable: AnyObject {
     func cancel()
     var cancelled: Bool { get }
     var running: Bool { get set }

--- a/Shared/KeyboardHelper.swift
+++ b/Shared/KeyboardHelper.swift
@@ -40,7 +40,7 @@ public struct KeyboardState {
     }
 }
 
-public protocol KeyboardHelperDelegate: class {
+public protocol KeyboardHelperDelegate: AnyObject {
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillShowWithState state: KeyboardState)
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState)
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState)

--- a/Shared/Loader.swift
+++ b/Shared/Loader.swift
@@ -7,7 +7,7 @@ import Foundation
 /**
  * Interface for listening to Loader updates.
  */
-public protocol LoaderListener: class {
+public protocol LoaderListener: AnyObject {
     associatedtype T
     func loader(dataLoaded data: T)
 }

--- a/Storage/Bookmarks/Bookmarks.swift
+++ b/Storage/Bookmarks/Bookmarks.swift
@@ -9,11 +9,11 @@ import SwiftyJSON
 
 private let log = Logger.syncLogger
 
-public protocol SearchableBookmarks: class {
+public protocol SearchableBookmarks: AnyObject {
     func bookmarksByURL(_ url: URL) -> Deferred<Maybe<Cursor<BookmarkItem>>>
 }
 
-public protocol SyncableBookmarks: class, ResettableSyncStorage, AccountRemovalDelegate {
+public protocol SyncableBookmarks: AnyObject, ResettableSyncStorage, AccountRemovalDelegate {
     // TODO
     func isUnchanged() -> Deferred<Maybe<Bool>>
     func getLocalBookmarksModifications(limit: Int) -> Deferred<Maybe<(deletions: [GUID], additions: [BookmarkMirrorItem])>>
@@ -24,7 +24,7 @@ public protocol SyncableBookmarks: class, ResettableSyncStorage, AccountRemovalD
     func applyBufferUpdatedCompletionOp(_ op: BufferUpdatedCompletionOp) -> Success
 }
 
-public protocol BookmarkBufferStorage: class {
+public protocol BookmarkBufferStorage: AnyObject {
     func isEmpty() -> Deferred<Maybe<Bool>>
     func applyRecords(_ records: [BookmarkMirrorItem]) -> Success
     func doneApplyingRecordsAfterDownload() -> Success
@@ -38,20 +38,20 @@ public protocol BookmarkBufferStorage: class {
     func getUpstreamRecordCount() -> Deferred<Int?>
 }
 
-public protocol MirrorItemSource: class {
+public protocol MirrorItemSource: AnyObject {
     func getMirrorItemWithGUID(_ guid: GUID) -> Deferred<Maybe<BookmarkMirrorItem>>
     func getMirrorItemsWithGUIDs<T: Collection>(_ guids: T) -> Deferred<Maybe<[GUID: BookmarkMirrorItem]>> where T.Iterator.Element == GUID
     func prefetchMirrorItemsWithGUIDs<T: Collection>(_ guids: T) -> Success where T.Iterator.Element == GUID
 }
 
-public protocol BufferItemSource: class {
+public protocol BufferItemSource: AnyObject {
     func getBufferItemWithGUID(_ guid: GUID) -> Deferred<Maybe<BookmarkMirrorItem>>
     func getBufferItemsWithGUIDs<T: Collection>(_ guids: T) -> Deferred<Maybe<[GUID: BookmarkMirrorItem]>> where T.Iterator.Element == GUID
     func getBufferChildrenGUIDsForParent(_ guid: GUID) -> Deferred<Maybe<[GUID]>>
     func prefetchBufferItemsWithGUIDs<T: Collection>(_ guids: T) -> Success where T.Iterator.Element == GUID
 }
 
-public protocol LocalItemSource: class {
+public protocol LocalItemSource: AnyObject {
     func getLocalItemWithGUID(_ guid: GUID) -> Deferred<Maybe<BookmarkMirrorItem>>
     func getLocalItemsWithGUIDs<T: Collection>(_ guids: T) -> Deferred<Maybe<[GUID: BookmarkMirrorItem]>> where T.Iterator.Element == GUID
     func prefetchLocalItemsWithGUIDs<T: Collection>(_ guids: T) -> Success where T.Iterator.Element == GUID

--- a/Storage/Logins.swift
+++ b/Storage/Logins.swift
@@ -94,7 +94,7 @@ public typealias TimestampedLoginDeltas = (at: Timestamp, changed: LoginDeltas)
 /**
  * LoginData is a wrapper around NSURLCredential and NSURLProtectionSpace to allow us to add extra fields where needed.
  **/
-public protocol LoginData: class {
+public protocol LoginData: AnyObject {
     var guid: String { get set }                 // It'd be nice if this were read-only.
     var credentials: URLCredential { get }
     var protectionSpace: URLProtectionSpace { get }

--- a/Sync/Synchronizers/Bookmarks/BookmarksSynchronizer.swift
+++ b/Sync/Synchronizers/Bookmarks/BookmarksSynchronizer.swift
@@ -376,7 +376,7 @@ class MergeApplier {
  * (e.g., an in-memory monotonic counter) or locking to prevent bookmark operations from
  * racing. Later!
  */
-protocol BookmarksStorageMerger: class {
+protocol BookmarksStorageMerger: AnyObject {
     init(buffer: BookmarkBufferStorage & BufferItemSource, storage: SyncableBookmarks & LocalItemSource & MirrorItemSource)
     func merge() -> Deferred<Maybe<BookmarksMergeResult>>
 }

--- a/Sync/Synchronizers/Bookmarks/Merging.swift
+++ b/Sync/Synchronizers/Bookmarks/Merging.swift
@@ -11,7 +11,7 @@ import XCGLogger
 private let log = Logger.syncLogger
 
 // Because generic protocols in Swift are a pain in the ass.
-public protocol BookmarkStorer: class {
+public protocol BookmarkStorer: AnyObject {
     // TODO: this should probably return a timestamp.
     func applyUpstreamCompletionOp(_ op: UpstreamCompletionOp, itemSources: ItemSources, trackingTimesInto local: LocalOverrideCompletionOp) -> Deferred<Maybe<POSTResult>>
 }


### PR DESCRIPTION
Hi there!

I'm currently working a new SwiftLint [rule](https://github.com/realm/SwiftLint/issues/2283) which suggests using `AnyObject` instead of `class` for class-only protocols as documented by [Apple](https://docs.swift.org/swift-book/LanguageGuide/Protocols.html#ID281).

This PR fixes the [violations raised](https://github.com/realm/SwiftLint/pull/2285#issuecomment-403230327) by the new rule.