### PR TITLE
Bug 1474822 - XCUITest Adapt New Tab Settings tests to the new implem…

### DIFF
--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -39,7 +39,6 @@ let WebImageContextMenu = "WebImageContextMenu"
 let WebLinkContextMenu = "WebLinkContextMenu"
 let CloseTabMenu = "CloseTabMenu"
 let AddCustomSearchSettings = "AddCustomSearchSettings"
-let NewTabChoiceSettings = "NewTabChoiceSettings"
 let DisablePasscodeSettings = "DisablePasscodeSettings"
 let ChangePasscodeSettings = "ChangePasscodeSettings"
 let LockedLoginsSettings = "LockedLoginsSettings"
@@ -55,7 +54,6 @@ let allSettingsScreens = [
     SearchSettings,
     AddCustomSearchSettings,
     NewTabSettings,
-    NewTabChoiceSettings,
     HomePageSettings,
     OpenWithSettings,
 
@@ -546,7 +544,17 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     map.addScreenState(NewTabSettings) { screenState in
         let table = app.tables.element(boundBy: 0)
-        screenState.tap(table.cells["NewTabOption"], to: NewTabChoiceSettings)
+
+        screenState.gesture(forAction: Action.SelectNewTabAsBlankPage) { UserState in
+            table.cells["Blank Page"].tap()
+        }
+        screenState.gesture(forAction: Action.SelectNewTabAsBookmarksPage) { UserState in
+            table.cells["Bookmarks"].tap()
+        }
+        screenState.gesture(forAction: Action.SelectNewTabAsHistoryPage) { UserState in
+            table.cells["History"].tap()
+        }
+
         screenState.gesture(forAction: Action.TogglePocketInNewTab) { userState in
             userState.pocketInNewTab = !userState.pocketInNewTab
             table.switches["ASPocketStoriesVisible"].tap()
@@ -560,20 +568,6 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             table.switches["ASRecentHighlightsVisible"].tap()
         }
         screenState.backAction = navigationControllerBackAction
-    }
-
-    map.addScreenState(NewTabChoiceSettings) { screenState in
-        let table = app.tables["NewTabPage.Setting.Options"]
-        screenState.backAction = navigationControllerBackAction
-        screenState.gesture(forAction: Action.SelectNewTabAsBlankPage) { UserState in
-            table.cells["Blank"].tap()
-        }
-        screenState.gesture(forAction: Action.SelectNewTabAsBookmarksPage) { UserState in
-            table.cells["Bookmarks"].tap()
-        }
-        screenState.gesture(forAction: Action.SelectNewTabAsHistoryPage) { UserState in
-            table.cells["History"].tap()
-        }
     }
 
     map.addScreenState(HomePageSettings) { screenState in

--- a/XCUITests/NewTabSettings.swift
+++ b/XCUITests/NewTabSettings.swift
@@ -7,8 +7,12 @@ import XCTest
 class NewTabSettingsTest: BaseTestCase {
     func testCheckNewTabSettingsByDefault() {
         navigator.goto(NewTabSettings)
-        waitforExistence(app.navigationBars["New Tab Settings"])
-        waitforExistence(app.tables.cells.staticTexts["Show your Top Sites"])
+        print(app.debugDescription)
+        waitforExistence(app.navigationBars["New Tab"])
+        XCTAssertTrue(app.tables.cells["Top Sites"].exists)
+        XCTAssertTrue(app.tables.cells["Blank Page"].exists)
+        XCTAssertTrue(app.tables.cells["Bookmarks"].exists)
+        XCTAssertTrue(app.tables.cells["History"].exists)
         XCTAssertTrue(app.tables.switches["ASPocketStoriesVisible"].isEnabled)
         XCTAssertTrue(app.tables.switches["ASBookmarkHighlightsVisible"].isEnabled)
         XCTAssertTrue(app.tables.switches["ASRecentHighlightsVisible"].isEnabled)
@@ -36,8 +40,8 @@ class NewTabSettingsTest: BaseTestCase {
     }
 
     func testChangeNewTabSettingsShowBlankPage() {
-        navigator.goto(NewTabChoiceSettings)
-        waitforExistence(app.tables["NewTabPage.Setting.Options"])
+        navigator.goto(NewTabSettings)
+        waitforExistence(app.navigationBars["New Tab"])
 
         navigator.performAction(Action.SelectNewTabAsBlankPage)
         navigator.performAction(Action.OpenNewTabFromTabTray)
@@ -48,22 +52,25 @@ class NewTabSettingsTest: BaseTestCase {
     }
 
     func testChangeNewTabSettingsShowYourBookmarks() {
-        navigator.goto(NewTabChoiceSettings)
-        waitforExistence(app.tables["NewTabPage.Setting.Options"])
+        navigator.goto(NewTabSettings)
+        waitforExistence(app.navigationBars["New Tab"])
         // Show Bookmarks panel without bookmarks
         navigator.performAction(Action.SelectNewTabAsBookmarksPage)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         waitforExistence(app.otherElements.images["emptyBookmarks"])
 
         // Add one bookmark and check the new tab screen
-        navigator.performAction(Action.BookmarkThreeDots)
+        navigator.openURL("mozilla.org/en-US/book")
+        waitUntilPageLoad()
+        navigator.nowAt(BrowserTab)
+        navigator.performAction(Action.Bookmark)
         navigator.goto(NewTabScreen)
         waitforExistence(app.tables["Bookmarks List"].cells.staticTexts["The Book of Mozilla"])
         waitforNoExistence(app.staticTexts["Highlights"])
     }
     func testChangeNewTabSettingsShowYourHistory() {
-        navigator.goto(NewTabChoiceSettings)
-        waitforExistence(app.tables["NewTabPage.Setting.Options"])
+        navigator.goto(NewTabSettings)
+        waitforExistence(app.navigationBars["New Tab"])
         // Show History Panel without history
         navigator.performAction(Action.SelectNewTabAsHistoryPage)
         navigator.performAction(Action.OpenNewTabFromTabTray)


### PR DESCRIPTION
…entation

Due to latest changes for the New Tab Settings tests are failing, they need to be modified so that they behave as the new implementation is defined. This PR is for doing the changes needed.