### PR TITLE
Bug 1413715 - Settings Section titles do not respect safe area insets on the iPhone X when in landscape

### DIFF
--- a/Client/Frontend/Theme/ThemedWidgets.swift
+++ b/Client/Frontend/Theme/ThemedWidgets.swift
@@ -141,13 +141,13 @@ class ThemedTableSectionHeaderFooterView: UITableViewHeaderFooterView, Themeable
         switch titleAlignment {
         case .top:
             titleLabel.snp.remakeConstraints { make in
-                make.left.right.equalTo(self).inset(UX.titleHorizontalPadding)
+                make.left.right.equalTo(self.contentView).inset(UX.titleHorizontalPadding)
                 make.top.equalTo(self).offset(UX.titleVerticalPadding)
                 make.bottom.equalTo(self).offset(-UX.titleVerticalLongPadding)
             }
         case .bottom:
             titleLabel.snp.remakeConstraints { make in
-                make.left.right.equalTo(self).inset(UX.titleHorizontalPadding)
+                make.left.right.equalTo(self.contentView).inset(UX.titleHorizontalPadding)
                 make.bottom.equalTo(self).offset(-UX.titleVerticalPadding)
                 make.top.equalTo(self).offset(UX.titleVerticalLongPadding)
             }


### PR DESCRIPTION
- fixed title alignment constraint

## Screenshots

![bug-1413715-fixed](https://user-images.githubusercontent.com/17826727/42629646-59e96a0e-85d4-11e8-8e03-385b88cf5ad3.jpg)

