### PR TITLE
Bug 1419634 - Highlights behind the notch on the iPhone X when in landscape

### DIFF
--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -1080,11 +1080,11 @@ class ASHeaderView: UICollectionReusableView {
         moreButton.snp.makeConstraints { make in
             make.top.equalTo(self).inset(ASHeaderViewUX.TitleTopInset)
             make.bottom.equalTo(self)
-            self.rightConstraint = make.trailing.equalTo(self).inset(-titleInsets).constraint
+            self.rightConstraint = make.trailing.equalTo(self.safeArea.trailing).inset(-titleInsets).constraint
         }
         moreButton.setContentCompressionResistancePriority(.required, for: .horizontal)
         titleLabel.snp.makeConstraints { make in
-            self.leftConstraint = make.leading.equalTo(self).inset(titleInsets).constraint
+            self.leftConstraint = make.leading.equalTo(self.safeArea.leading).inset(titleInsets).constraint
             make.trailing.equalTo(moreButton.snp.leading).inset(-ASHeaderViewUX.TitleTopInset)
             make.top.equalTo(self).inset(ASHeaderViewUX.TitleTopInset)
             make.bottom.equalTo(self)

--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -257,7 +257,7 @@ class ASHorizontalScrollCell: UICollectionViewCell {
         pageControl.addGestureRecognizer(self.pageControlPress)
 
         collectionView.snp.makeConstraints { make in
-            make.edges.equalTo(contentView)
+            make.edges.equalTo(contentView.safeArea.edges)
         }
 
         pageControl.snp.makeConstraints { make in

--- a/Client/Frontend/Widgets/ActivityStreamHighlightCell.swift
+++ b/Client/Frontend/Widgets/ActivityStreamHighlightCell.swift
@@ -114,24 +114,25 @@ class ActivityStreamHighlightCell: UICollectionViewCell {
 
         siteImageView.snp.makeConstraints { make in
             make.top.equalTo(contentView)
-            make.leading.trailing.equalTo(contentView)
+            make.leading.equalTo(contentView.safeArea.leading)
+            make.trailing.equalTo(contentView.safeArea.trailing)
             make.centerX.equalTo(contentView)
             make.height.equalTo(ActivityStreamHighlightCellUX.SiteImageViewSize)
         }
 
         selectedOverlay.snp.makeConstraints { make in
-            make.edges.equalTo(contentView)
+            make.edges.equalTo(contentView.safeArea.edges)
         }
 
         domainLabel.snp.makeConstraints { make in
             make.leading.equalTo(siteImageView)
-            make.trailing.equalTo(contentView)
+            make.trailing.equalTo(contentView.safeArea.trailing)
             make.top.equalTo(siteImageView.snp.bottom).offset(5)
         }
 
         titleLabel.snp.makeConstraints { make in
             make.leading.equalTo(siteImageView)
-            make.trailing.equalTo(contentView)
+            make.trailing.equalTo(contentView.safeArea.trailing)
             make.top.equalTo(domainLabel.snp.bottom).offset(5)
         }
 


### PR DESCRIPTION
- Fixed activity stream constraints to work properly in iPhone X

## Screenshots

![image](https://user-images.githubusercontent.com/17826727/42641446-d6e1318e-85f4-11e8-99a4-3e1e2d4431c2.png)
