### PR TITLE
Fixed dSYM archive line in buddybuild_postbuild.sh

### DIFF
--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -10,7 +10,7 @@ test_runner="XCUITests-Runner"
 
 if [ "$BUDDYBUILD_SCHEME" = "Fennec" ]; then
   cd  $BUDDYBUILD_PRODUCT_DIR
-  find . -name "*.dSYM" -print | zip /tmp/dsyms.zip 
+  find . -name "*.dSYM" -print | zip /tmp/dsyms.zip -@
   curl -F ipa=@$BUDDYBUILD_IPA_PATH  -u $NIMBLEDROID_API_KEY: https://nimbledroid.com/api/v2/ipas \
        -F "dsym=@/tmp/dsyms.zip" \
        -F test_identifiers='ActivityStreamTest/testDefaultSites,DomainAutocompleteTest/testAutocomplete,DatabaseFixtureTest/testHistoryDatabaseFixture,BrowsingPDFTests/testBookmarkPDF,ActivityStreamTest/testTopSitesBookmarkNewTopSite,FindInPageTests/testFindInLargeDoc,FirstRunTourTests/testFirstRunTour'


### PR DESCRIPTION
As per https://dashboard.buddybuild.com/apps/57bf25c0f096bc01001e21e0/build/5b476069c289ad000159cfc4#logs at the bottom ''_zip error: Nothing to do! (/tmp/dsyms.zip)_'' – I forgot the **-@** line to create the archive