### PR TITLE
Bug 1474585 - Private mask icon not displaying

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1777,7 +1777,7 @@ extension BrowserViewController: TabManagerDelegate {
             if tab.isPrivate != previous?.isPrivate {
                 applyTheme()
 
-                let ui: [PrivateModeUI?] = [toolbar, topTabsViewController]
+                let ui: [PrivateModeUI?] = [toolbar, topTabsViewController, urlBar]
                 ui.forEach { $0?.applyUIMode(isPrivate: tab.isPrivate) }
             }
 

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -7,7 +7,7 @@ import SnapKit
 import Shared
 
 protocol TabToolbarProtocol: AnyObject {
-    weak var tabToolbarDelegate: TabToolbarDelegate? { get set }
+    var tabToolbarDelegate: TabToolbarDelegate? { get set }
     var tabsButton: TabsButton { get }
     var menuButton: ToolbarButton { get }
     var forwardButton: ToolbarButton { get }
@@ -20,6 +20,7 @@ protocol TabToolbarProtocol: AnyObject {
     func updateReloadStatus(_ isLoading: Bool)
     func updatePageStatus(_ isWebPage: Bool)
     func updateTabCount(_ count: Int, animated: Bool)
+    func privateModeBadge(visible: Bool)
 }
 
 protocol TabToolbarDelegate: AnyObject {
@@ -33,6 +34,27 @@ protocol TabToolbarDelegate: AnyObject {
     func tabToolbarDidPressMenu(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressTabs(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidLongPressTabs(_ tabToolbar: TabToolbarProtocol, button: UIButton)
+}
+
+class ToolbarPrivateModeBadge: UIImageView {
+    let privateModeBadgeSize = CGFloat(16)
+    let privateModeBadgeOffset = CGFloat(10)
+
+    init() {
+        super.init(image: UIImage(imageLiteralResourceName: "privateModeBadge"))
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+    func layout(forTabsButton button: UIButton) {
+        snp.remakeConstraints { make in
+            make.size.equalTo(privateModeBadgeSize)
+            make.centerX.equalTo(button).offset(privateModeBadgeOffset)
+            make.centerY.equalTo(button).offset(-privateModeBadgeOffset)
+        }
+    }
 }
 
 @objcMembers
@@ -201,6 +223,12 @@ class TabToolbar: UIView {
     let stopReloadButton = ToolbarButton()
     let actionButtons: [Themeable & UIButton]
 
+    private let privateModeBadge = ToolbarPrivateModeBadge()
+    
+    func privateModeBadge(visible: Bool) {
+        privateModeBadge.isHidden = !visible
+    }
+
     var helper: TabToolbarHelper?
     private let contentView = UIStackView()
 
@@ -212,11 +240,15 @@ class TabToolbar: UIView {
         addSubview(contentView)
         helper = TabToolbarHelper(toolbar: self)
         addButtons(actionButtons)
+        contentView.addSubview(privateModeBadge)
+
         contentView.axis = .horizontal
         contentView.distribution = .fillEqually
     }
 
     override func updateConstraints() {
+        privateModeBadge.layout(forTabsButton: tabsButton)
+
         contentView.snp.makeConstraints { make in
             make.leading.trailing.top.equalTo(self)
             make.bottom.equalTo(self.safeArea.bottom)
@@ -286,6 +318,6 @@ extension TabToolbar: Themeable, PrivateModeUI {
     }
 
     func applyUIMode(isPrivate: Bool) {
-        tabsButton.applyUIMode(isPrivate: isPrivate)
+        privateModeBadge(visible: isPrivate)
     }
 }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -170,6 +170,12 @@ class URLBarView: UIView {
         }
     }
 
+    private let privateModeBadge = ToolbarPrivateModeBadge()
+
+    func privateModeBadge(visible: Bool) {
+            privateModeBadge.isHidden = !visible
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         commonInit()
@@ -183,8 +189,10 @@ class URLBarView: UIView {
     fileprivate func commonInit() {
         locationContainer.addSubview(locationView)
 
-        [scrollToTopButton, line, tabsButton, progressBar, cancelButton, showQRScannerButton].forEach { addSubview($0) }
-        [menuButton, forwardButton, backButton, stopReloadButton, locationContainer].forEach { addSubview($0) }
+        [scrollToTopButton, line, tabsButton, progressBar, cancelButton, showQRScannerButton,
+         menuButton, forwardButton, backButton, stopReloadButton, locationContainer, privateModeBadge].forEach {
+            addSubview($0)
+        }
 
         helper = TabToolbarHelper(toolbar: self)
         setupConstraints()
@@ -256,6 +264,8 @@ class URLBarView: UIView {
             make.centerY.equalTo(self.locationContainer)
             make.size.equalTo(URLBarViewUX.ButtonHeight)
         }
+
+        privateModeBadge.layout(forTabsButton: tabsButton)
     }
 
     override func updateConstraints() {
@@ -481,6 +491,9 @@ class URLBarView: UIView {
         backButton.isHidden = !toolbarIsShowing || inOverlayMode
         tabsButton.isHidden = !toolbarIsShowing || inOverlayMode || topTabsIsShowing
         stopReloadButton.isHidden = !toolbarIsShowing || inOverlayMode
+
+        // badge isHidden is tied to private mode on/off, use alpha to hide in this case
+        privateModeBadge.alpha = (!toolbarIsShowing || inOverlayMode) ? 0 : 1
     }
 
     func animateToOverlayState(overlayMode overlay: Bool, didCancel cancel: Bool = false) {
@@ -680,6 +693,12 @@ extension URLBarView: Themeable {
         backgroundColor = UIColor.theme.browser.background
         line.backgroundColor = UIColor.theme.browser.urlBarDivider
         locationContainer.layer.shadowColor = locationBorderColor.cgColor
+    }
+}
+
+extension URLBarView: PrivateModeUI {
+    func applyUIMode(isPrivate: Bool) {
+        privateModeBadge(visible: isPrivate)
     }
 }
 

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -15,11 +15,6 @@ private struct TabsButtonUX {
 }
 
 class TabsButton: UIButton {
-    var privateModeBadge = UIImageView.init(image: UIImage(imageLiteralResourceName: "privateModeBadge"))
-
-    let privateModeBadgeSize = CGFloat(16)
-    let privateModeBadgeOffset = CGFloat(10)
-
     var textColor = UIColor.clear {
         didSet {
             countLabel.textColor = textColor
@@ -90,8 +85,6 @@ class TabsButton: UIButton {
         insideButton.addSubview(borderView)
         insideButton.addSubview(countLabel)
         addSubview(insideButton)
-        addSubview(privateModeBadge)
-        privateModeBadge.isHidden = true
         isAccessibilityElement = true
         accessibilityTraits |= UIAccessibilityTraitButton
     }
@@ -110,12 +103,6 @@ class TabsButton: UIButton {
         insideButton.snp.remakeConstraints { (make) -> Void in
             make.size.equalTo(24)
             make.center.equalTo(self)
-        }
-
-        privateModeBadge.snp.remakeConstraints { make in
-            make.size.equalTo(privateModeBadgeSize)
-            make.centerX.equalToSuperview().offset(privateModeBadgeOffset)
-            make.centerY.equalToSuperview().offset(-privateModeBadgeOffset)
         }
     }
 
@@ -218,7 +205,7 @@ class TabsButton: UIButton {
     }
 }
 
-extension TabsButton: Themeable, PrivateModeUI {
+extension TabsButton: Themeable {
     func applyTheme() {
         if UIDevice.current.userInterfaceIdiom == .pad {
             titleBackgroundColor = UIColor.theme.topTabs.background
@@ -227,10 +214,6 @@ extension TabsButton: Themeable, PrivateModeUI {
             titleBackgroundColor = UIColor.theme.browser.background
             textColor = UIColor.theme.browser.tint
         }
-    }
-
-    func applyUIMode(isPrivate: Bool) {
-        privateModeBadge.isHidden = !isPrivate
     }
 }
 


### PR DESCRIPTION
This bug is due to TabButton animation complexity. Rather than have the TabButton manage the private mask –as the tab button is fully animated, and the private badge is just a static overlay image- use TabToolbar protocol to to require the top toolbar and urlbar classes to hide/show the private badge. 
 
https://bugzilla.mozilla.org/show_bug.cgi?id=1474585
