### PR TITLE
Bug 1475608 - Dark theme followup: home panels, status bar

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -772,10 +772,9 @@ class BrowserViewController: UIViewController {
         }
 
         let isPrivate = tabManager.selectedTab?.isPrivate ?? false
-        searchController = SearchViewController(isPrivate: isPrivate)
+        searchController = SearchViewController(profile: profile, isPrivate: isPrivate)
         searchController!.searchEngines = profile.searchEngines
         searchController!.searchDelegate = self
-        searchController!.profile = self.profile
 
         searchLoader = SearchLoader(profile: profile, urlBar: urlBar)
         searchLoader?.addListener(searchController!)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2679,6 +2679,8 @@ extension BrowserViewController: Themeable {
         ui.forEach { $0?.applyTheme() }
         statusBarOverlay.backgroundColor = shouldShowTopTabsForTraitCollection(traitCollection) ? UIColor.Photon.Grey80 : urlBar.backgroundColor
         setNeedsStatusBarAppearanceUpdate()
+
+        homePanelController?.applyTheme()
     }
 }
 

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -70,9 +70,9 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
 
     static var userAgent: String?
 
-    init(isPrivate: Bool) {
+    init(profile: Profile, isPrivate: Bool) {
         self.isPrivate = isPrivate
-        super.init(nibName: nil, bundle: nil)
+        super.init(profile: profile)
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -1040,7 +1040,7 @@ class ASHeaderView: UICollectionReusableView {
     lazy fileprivate var titleLabel: UILabel = {
         let titleLabel = UILabel()
         titleLabel.text = self.title
-        titleLabel.textColor = UIColor.Photon.Grey50
+        titleLabel.textColor = UIColor.theme.homePanel.activityStreamHeaderText
         titleLabel.font = ASHeaderViewUX.TextFont
         titleLabel.minimumScaleFactor = 0.6
         titleLabel.numberOfLines = 1

--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -107,10 +107,11 @@ class ActivityStreamPanel: UICollectionViewController, HomePanel {
         Section.allValues.forEach { self.collectionView?.register(Section($0.rawValue).cellType, forCellWithReuseIdentifier: Section($0.rawValue).cellIdentifier) }
         self.collectionView?.register(ASHeaderView.self, forSupplementaryViewOfKind: UICollectionElementKindSectionHeader, withReuseIdentifier: "Header")
         self.collectionView?.register(ASFooterView.self, forSupplementaryViewOfKind: UICollectionElementKindSectionFooter, withReuseIdentifier: "Footer")
-        collectionView?.backgroundColor = UIColor.theme.browser.background
         collectionView?.keyboardDismissMode = .onDrag
 
         self.profile.panelDataObservers.activityStream.delegate = self
+
+        applyTheme()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -143,6 +144,12 @@ class ActivityStreamPanel: UICollectionViewController, HomePanel {
     }
 
     @objc func reload(notification: Notification) {
+        reloadAll()
+    }
+
+    func applyTheme() {
+        collectionView?.backgroundColor = UIColor.theme.browser.background
+        topSiteCell.collectionView.reloadData()
         reloadAll()
     }
 }

--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -24,7 +24,7 @@ private struct TopSiteCellUX {
 /*
  *  The TopSite cell that appears in the ASHorizontalScrollView.
  */
-class TopSiteItemCell: UICollectionViewCell {
+class TopSiteItemCell: UICollectionViewCell, Themeable {
 
     var url: URL?
 
@@ -37,7 +37,6 @@ class TopSiteItemCell: UICollectionViewCell {
     lazy var pinImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = UIImage.templateImageNamed("pin_small")
-        imageView.tintColor = TopSiteCellUX.PinColor
         return imageView
     }()
 
@@ -46,8 +45,6 @@ class TopSiteItemCell: UICollectionViewCell {
         titleLabel.layer.masksToBounds = true
         titleLabel.textAlignment = .center
         titleLabel.font = TopSiteCellUX.TitleFont
-        titleLabel.textColor = UIColor.theme.homePanel.topSiteDomain
-        titleLabel.backgroundColor = UIColor.clear
         return titleLabel
     }()
 
@@ -56,20 +53,17 @@ class TopSiteItemCell: UICollectionViewCell {
         view.layer.cornerRadius = TopSiteCellUX.CellCornerRadius
         view.layer.masksToBounds = true
         view.layer.borderWidth = TopSiteCellUX.BorderWidth
-        view.layer.borderColor = TopSiteCellUX.BorderColor.cgColor
         return view
     }()
 
     lazy var selectedOverlay: UIView = {
         let selectedOverlay = UIView()
-        selectedOverlay.backgroundColor = TopSiteCellUX.OverlayColor
         selectedOverlay.isHidden = true
         return selectedOverlay
     }()
 
     lazy var titleBorder: CALayer = {
         let border = CALayer()
-        border.backgroundColor = TopSiteCellUX.BorderColor.cgColor
         return border
     }()
 
@@ -170,8 +164,18 @@ class TopSiteItemCell: UICollectionViewCell {
                 self?.imageView.backgroundColor = color
             }
         })
+
+        applyTheme()
     }
 
+    func applyTheme() {
+        imageView.tintColor = TopSiteCellUX.PinColor
+        faviconBG.layer.borderColor = TopSiteCellUX.BorderColor.cgColor
+        selectedOverlay.backgroundColor = TopSiteCellUX.OverlayColor
+        titleBorder.backgroundColor = TopSiteCellUX.BorderColor.cgColor
+        titleLabel.backgroundColor = UIColor.clear
+        titleLabel.textColor = UIColor.theme.homePanel.topSiteDomain
+    }
 }
 
 // An empty cell to show when a row is incomplete

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -435,6 +435,13 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         self.tableView.endUpdates()
         self.updateEmptyPanelState()
     }
+
+    override func applyTheme() {
+        emptyStateOverlayView.removeFromSuperview()
+        emptyStateOverlayView = createEmptyStateOverlayView()
+        updateEmptyPanelState()
+        super.applyTheme()
+    }
 }
 
 extension BookmarksPanel: HomePanelContextMenu {
@@ -507,29 +514,15 @@ class BookmarkFolderTableViewCell: TwoLineTableViewCell {
 fileprivate class BookmarkFolderTableViewHeader: UITableViewHeaderFooterView {
     var delegate: BookmarkFolderTableViewHeaderDelegate?
 
-    lazy var titleLabel: UILabel = {
-        let label = UILabel()
-        label.textColor = UIColor.theme.homePanel.bookmarkCurrentFolderText
-        return label
-    }()
+    let titleLabel = UILabel()
+    let topBorder = UIView()
+    let bottomBorder = UIView()
 
     lazy var chevron: ChevronView = {
         let chevron = ChevronView(direction: .left)
         chevron.tintColor = UIColor.theme.general.highlightBlue
         chevron.lineWidth = BookmarksPanelUX.BookmarkFolderChevronLineWidth
         return chevron
-    }()
-
-    lazy var topBorder: UIView = {
-        let view = UIView()
-        view.backgroundColor = UIColor.theme.homePanel.siteTableHeaderBorder
-        return view
-    }()
-
-    lazy var bottomBorder: UIView = {
-        let view = UIView()
-        view.backgroundColor = UIColor.theme.homePanel.siteTableHeaderBorder
-        return view
     }()
 
     override var textLabel: UILabel? {
@@ -572,6 +565,8 @@ fileprivate class BookmarkFolderTableViewHeader: UITableViewHeaderFooterView {
             make.left.right.bottom.equalTo(self)
             make.height.equalTo(0.5)
         }
+
+        applyTheme()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -581,14 +576,15 @@ fileprivate class BookmarkFolderTableViewHeader: UITableViewHeaderFooterView {
     @objc fileprivate func viewWasTapped(_ gestureRecognizer: UITapGestureRecognizer) {
         delegate?.didSelectHeader()
     }
-}
 
-extension BookmarksPanel: Themeable {
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        applyTheme()
+    }
+
     func applyTheme() {
-        emptyStateOverlayView.removeFromSuperview()
-        emptyStateOverlayView = createEmptyStateOverlayView()
-        updateEmptyPanelState()
-
-        reloadData()
+        titleLabel.textColor = UIColor.theme.homePanel.bookmarkCurrentFolderText
+        topBorder.backgroundColor = UIColor.theme.homePanel.siteTableHeaderBorder
+        bottomBorder.backgroundColor = UIColor.theme.homePanel.siteTableHeaderBorder
     }
 }

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -493,9 +493,6 @@ class BookmarkFolderTableViewCell: TwoLineTableViewCell {
 
     override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        self.backgroundColor = UIColor.theme.homePanel.bookmarkFolderBackground
-        textLabel?.backgroundColor = UIColor.clear
-        textLabel?.textColor = UIColor.theme.homePanel.bookmarkFolderText
 
         imageView?.image = UIImage(named: "bookmarkFolder")
         accessoryType = .disclosureIndicator
@@ -508,6 +505,14 @@ class BookmarkFolderTableViewCell: TwoLineTableViewCell {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func applyTheme() {
+        super.applyTheme()
+        
+        self.backgroundColor = UIColor.theme.homePanel.bookmarkFolderBackground
+        textLabel?.backgroundColor = UIColor.clear
+        textLabel?.textColor = UIColor.theme.homePanel.bookmarkFolderText
     }
 }
 
@@ -586,5 +591,6 @@ fileprivate class BookmarkFolderTableViewHeader: UITableViewHeaderFooterView {
         titleLabel.textColor = UIColor.theme.homePanel.bookmarkCurrentFolderText
         topBorder.backgroundColor = UIColor.theme.homePanel.siteTableHeaderBorder
         bottomBorder.backgroundColor = UIColor.theme.homePanel.siteTableHeaderBorder
+        contentView.backgroundColor = UIColor.theme.homePanel.bookmarkBackNavCellBackground
     }
 }

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -48,8 +48,8 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
     fileprivate let BookmarkSeparatorCellIdentifier = "BookmarkSeparatorIdentifier"
     fileprivate let BookmarkFolderHeaderViewIdentifier = "BookmarkFolderHeaderIdentifier"
 
-    init() {
-        super.init(nibName: nil, bundle: nil)
+    override init(profile: Profile) {
+        super.init(profile: profile)
         NotificationCenter.default.addObserver(self, selector: #selector(notificationReceived), name: .FirefoxAccountChanged, object: nil)
 
         self.tableView.register(SeparatorTableCell.self, forCellReuseIdentifier: BookmarkSeparatorCellIdentifier)
@@ -334,11 +334,10 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
 
         case let folder as BookmarkFolder:
             log.debug("Selected \(folder.guid)")
-            let nextController = BookmarksPanel()
+            let nextController = BookmarksPanel(profile: profile)
             nextController.parentFolders = parentFolders + [source.current]
             nextController.bookmarkFolder = folder
             nextController.homePanelDelegate = self.homePanelDelegate
-            nextController.profile = self.profile
             source.modelFactory.uponQueue(.main) { maybe in
                 guard let factory = maybe.successValue else {
                     // Nothing we can do.

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -127,7 +127,6 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
 
     fileprivate func createEmptyStateOverlayView() -> UIView {
         let overlayView = UIView()
-        overlayView.backgroundColor = UIColor.theme.homePanel.panelBackground
 
         let logoImageView = UIImageView(image: UIImage(named: "emptyBookmarks"))
         overlayView.addSubview(logoImageView)
@@ -146,7 +145,6 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         welcomeLabel.text = emptyBookmarksText
         welcomeLabel.textAlignment = .center
         welcomeLabel.font = DynamicFontHelper.defaultHelper.DeviceFontLight
-        welcomeLabel.textColor = UIColor.theme.homePanel.welcomeScreenText
         welcomeLabel.numberOfLines = 0
         welcomeLabel.adjustsFontSizeToFitWidth = true
 
@@ -155,6 +153,9 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
             make.top.equalTo(logoImageView.snp.bottom).offset(BookmarksPanelUX.WelcomeScreenPadding)
             make.width.equalTo(BookmarksPanelUX.WelcomeScreenItemWidth)
         }
+
+        overlayView.backgroundColor = UIColor.theme.homePanel.panelBackground
+        welcomeLabel.textColor = UIColor.theme.homePanel.welcomeScreenText
 
         return overlayView
     }
@@ -580,5 +581,15 @@ fileprivate class BookmarkFolderTableViewHeader: UITableViewHeaderFooterView {
 
     @objc fileprivate func viewWasTapped(_ gestureRecognizer: UITapGestureRecognizer) {
         delegate?.didSelectHeader()
+    }
+}
+
+extension BookmarksPanel: Themeable {
+    func applyTheme() {
+        emptyStateOverlayView.removeFromSuperview()
+        emptyStateOverlayView = createEmptyStateOverlayView()
+        updateEmptyPanelState()
+
+        reloadData()
     }
 }

--- a/Client/Frontend/Home/DownloadsPanel.swift
+++ b/Client/Frontend/Home/DownloadsPanel.swift
@@ -421,3 +421,13 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
         return [delete, share]
     }
 }
+
+extension DownloadsPanel: Themeable {
+    func applyTheme() {
+        emptyStateOverlayView.removeFromSuperview()
+        emptyStateOverlayView = createEmptyStateOverlayView()
+        updateEmptyPanelState()
+
+        tableView.reloadData()
+    }
+}

--- a/Client/Frontend/Home/DownloadsPanel.swift
+++ b/Client/Frontend/Home/DownloadsPanel.swift
@@ -98,7 +98,7 @@ struct DateGroupedTableData<T : Equatable> {
 
 class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSource, HomePanel {
     weak var homePanelDelegate: HomePanelDelegate?
-    var profile: Profile!
+    let profile: Profile
     var tableView = UITableView()
 
     private let events: [Notification.Name] = [.FileDidDownload, .PrivateDataClearedDownloadedFiles, .DynamicFontChanged]
@@ -109,7 +109,8 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
     private var fileExtensionIcons: [String : UIImage] = [:]
 
     // MARK: - Lifecycle
-    init() {
+    init(profile: Profile) {
+        self.profile = profile
         super.init(nibName: nil, bundle: nil)
         events.forEach { NotificationCenter.default.addObserver(self, selector: #selector(notificationReceived), name: $0, object: nil) }
     }

--- a/Client/Frontend/Home/DownloadsPanel.swift
+++ b/Client/Frontend/Home/DownloadsPanel.swift
@@ -251,7 +251,7 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
         return icon
     }
 
-    private func roundRectImageWithLabel(_ label: String, width: CGFloat, height: CGFloat, radius: CGFloat = 5.0, strokeWidth: CGFloat = 1.0, strokeColor: UIColor = UIColor.Photon.Grey60, fontSize: CGFloat = 9.0) -> UIImage? {
+    private func roundRectImageWithLabel(_ label: String, width: CGFloat, height: CGFloat, radius: CGFloat = 5.0, strokeWidth: CGFloat = 1.0, strokeColor: UIColor = UIColor.theme.homePanel.downloadedFileIcon, fontSize: CGFloat = 9.0) -> UIImage? {
         UIGraphicsBeginImageContextWithOptions(CGSize(width: width, height: height), false, 0.0)
         let context = UIGraphicsGetCurrentContext()
         context?.setStrokeColor(strokeColor.cgColor)

--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -53,8 +53,8 @@ class HistoryPanel: SiteTableViewController, HomePanel {
     }
 
     // MARK: - Lifecycle
-    init() {
-        super.init(nibName: nil, bundle: nil)
+    override init(profile: Profile) {
+        super.init(profile: profile)
         events.forEach { NotificationCenter.default.addObserver(self, selector: #selector(notificationReceived), name: $0, object: nil) }
     }
 
@@ -407,9 +407,8 @@ class HistoryPanel: SiteTableViewController, HomePanel {
         guard hasRecentlyClosed else {
             return
         }
-        let nextController = RecentlyClosedTabsPanel()
+        let nextController = RecentlyClosedTabsPanel(profile: profile)
         nextController.homePanelDelegate = self.homePanelDelegate
-        nextController.profile = self.profile
         self.refreshControl?.endRefreshing()
         self.navigationController?.pushViewController(nextController, animated: true)
     }

--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -571,3 +571,9 @@ extension HistoryPanel: HomePanelContextMenu {
         return actions
     }
 }
+
+extension HistoryPanel: Themeable {
+    func applyTheme() {
+        tableView.reloadData()
+    }
+}

--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -184,7 +184,7 @@ class HistoryPanel: SiteTableViewController, HomePanel {
         self.refreshControl?.endRefreshing()
 
         // Remove the refresh control if the user has logged out in the meantime
-        if !self.profile.hasSyncableAccount() {
+        if self.profile.hasSyncableAccount() {
             self.removeRefreshControl()
         }
     }
@@ -331,7 +331,7 @@ class HistoryPanel: SiteTableViewController, HomePanel {
         cell.textLabel?.text = Strings.RecentlyClosedTabsButtonTitle
         cell.detailTextLabel?.text = ""
         cell.imageView?.image = UIImage(named: "recently_closed")
-        cell.imageView?.backgroundColor = UIColor.Photon.White100
+        cell.imageView?.backgroundColor = UIColor.theme.homePanel.historyHeaderIconsBackground
         if !hasRecentlyClosed {
             cell.textLabel?.alpha = 0.5
             cell.imageView?.alpha = 0.5
@@ -346,7 +346,7 @@ class HistoryPanel: SiteTableViewController, HomePanel {
         cell.textLabel?.text = Strings.SyncedTabsTableViewCellTitle
         cell.detailTextLabel?.text = self.syncDetailText
         cell.imageView?.image = UIImage(named: "synced_devices")
-        cell.imageView?.backgroundColor = .white
+        cell.imageView?.backgroundColor = UIColor.theme.homePanel.historyHeaderIconsBackground
         cell.accessibilityIdentifier = "HistoryPanel.syncedDevicesCell"
         return cell
     }
@@ -543,6 +543,10 @@ class HistoryPanel: SiteTableViewController, HomePanel {
         })
         return [delete]
     }
+
+    override func applyTheme() {
+        super.applyTheme()
+    }
 }
 
 extension HistoryPanel: HomePanelContextMenu {
@@ -568,11 +572,5 @@ extension HistoryPanel: HomePanelContextMenu {
         actions.append(pinTopSite)
         actions.append(removeAction)
         return actions
-    }
-}
-
-extension HistoryPanel: Themeable {
-    func applyTheme() {
-        tableView.reloadData()
     }
 }

--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -22,8 +22,8 @@ protocol HomePanelViewControllerDelegate: AnyObject {
     func homePanelViewControllerDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool)
 }
 
-protocol HomePanel: AnyObject {
-    weak var homePanelDelegate: HomePanelDelegate? { get set }
+protocol HomePanel: AnyObject, Themeable {
+    var homePanelDelegate: HomePanelDelegate? { get set }
 }
 
 struct HomePanelUX {
@@ -291,6 +291,19 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
 // MARK: UIAppearance
 extension HomePanelViewController: Themeable {
     func applyTheme() {
+        func apply(_ vc: UIViewController) -> Bool {
+            guard let vc = vc as? Themeable else { return false }
+            vc.applyTheme()
+            return true
+        }
+
+        childViewControllers.forEach {
+            if !apply($0) {
+                // BookmarksPanel is nested in a UINavigationController, go one layer deeper
+                $0.childViewControllers.forEach { _ = apply($0) }
+            }
+        }
+
         buttonContainerView.backgroundColor = UIColor.theme.homePanel.toolbarBackground
         view.backgroundColor = UIColor.theme.homePanel.toolbarBackground
         buttonTintColor = UIColor.theme.homePanel.toolbarTint

--- a/Client/Frontend/Home/HomePanels.swift
+++ b/Client/Frontend/Home/HomePanels.swift
@@ -27,8 +27,7 @@ class HomePanels {
 
         HomePanelDescriptor(
             makeViewController: { profile in
-                let bookmarks = BookmarksPanel()
-                bookmarks.profile = profile
+                let bookmarks = BookmarksPanel(profile: profile)
                 let controller = UINavigationController(rootViewController: bookmarks)
                 controller.setNavigationBarHidden(true, animated: false)
                 // this re-enables the native swipe to pop gesture on UINavigationController for embedded, navigation bar-less UINavigationControllers
@@ -44,8 +43,7 @@ class HomePanels {
 
         HomePanelDescriptor(
             makeViewController: { profile in
-                let history = HistoryPanel()
-                history.profile = profile
+                let history = HistoryPanel(profile: profile)
                 let controller = UINavigationController(rootViewController: history)
                 controller.setNavigationBarHidden(true, animated: false)
                 controller.interactivePopGestureRecognizer?.delegate = nil
@@ -57,8 +55,7 @@ class HomePanels {
 
         HomePanelDescriptor(
             makeViewController: { profile in
-                let controller = ReadingListPanel()
-                controller.profile = profile
+                let controller = ReadingListPanel(profile: profile)
                 return controller
             },
             imageName: "ReadingList",
@@ -67,8 +64,7 @@ class HomePanels {
 
         HomePanelDescriptor(
             makeViewController: { profile in
-                let controller = DownloadsPanel()
-                controller.profile = profile
+                let controller = DownloadsPanel(profile: profile)
                 return controller
             },
             imageName: "Downloads",

--- a/Client/Frontend/Home/ReaderPanel.swift
+++ b/Client/Frontend/Home/ReaderPanel.swift
@@ -173,7 +173,7 @@ class ReadingListTableViewCell: UITableViewCell {
 
 class ReadingListPanel: UITableViewController, HomePanel {
     weak var homePanelDelegate: HomePanelDelegate?
-    var profile: Profile!
+    let profile: Profile
 
     fileprivate lazy var longPressRecognizer: UILongPressGestureRecognizer = {
         return UILongPressGestureRecognizer(target: self, action: #selector(longPress))
@@ -183,10 +183,13 @@ class ReadingListPanel: UITableViewController, HomePanel {
 
     fileprivate var records: [ReadingListItem]?
 
-    init() {
+    init(profile: Profile) {
+        self.profile = profile
         super.init(nibName: nil, bundle: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(notificationReceived), name: .FirefoxAccountChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(notificationReceived), name: .DynamicFontChanged, object: nil)
+
+        applyTheme()
     }
 
     required init!(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Home/ReaderPanel.swift
+++ b/Client/Frontend/Home/ReaderPanel.swift
@@ -24,7 +24,6 @@ private struct ReadingListTableViewCellUX {
 
     static let HostnameLabelBottomOffset: CGFloat = 11
 
-//    static let DeleteButtonBackgroundColor = UIColor.Photon.Red60
     static let DeleteButtonTitleColor = UIColor.Photon.White100
     static let DeleteButtonTitleEdgeInsets = UIEdgeInsets(top: 4, left: 4, bottom: 4, right: 4)
 
@@ -51,7 +50,7 @@ private struct ReadingListPanelUX {
     static let WelcomeScreenCircleSpacer = 10
 }
 
-class ReadingListTableViewCell: UITableViewCell {
+class ReadingListTableViewCell: UITableViewCell, Themeable {
     var title: String = "Example" {
         didSet {
             titleLabel.text = title
@@ -104,7 +103,6 @@ class ReadingListTableViewCell: UITableViewCell {
         contentView.addSubview(titleLabel)
         contentView.addSubview(hostnameLabel)
 
-        titleLabel.textColor = UIColor.theme.homePanel.readingListActive
         titleLabel.numberOfLines = 2
         titleLabel.snp.makeConstraints { (make) -> Void in
             make.top.equalTo(self.contentView).offset(ReadingListTableViewCellUX.TitleLabelTopOffset)
@@ -113,14 +111,13 @@ class ReadingListTableViewCell: UITableViewCell {
             make.bottom.lessThanOrEqualTo(hostnameLabel.snp.top).priority(1000)
         }
 
-        hostnameLabel.textColor = UIColor.theme.homePanel.readingListActive
         hostnameLabel.numberOfLines = 1
         hostnameLabel.snp.makeConstraints { (make) -> Void in
             make.bottom.equalTo(self.contentView).offset(-ReadingListTableViewCellUX.HostnameLabelBottomOffset)
             make.leading.trailing.equalTo(self.titleLabel)
         }
 
-        setupDynamicFonts()
+        applyTheme()
     }
 
     func setupDynamicFonts() {
@@ -128,8 +125,14 @@ class ReadingListTableViewCell: UITableViewCell {
         hostnameLabel.font = DynamicFontHelper.defaultHelper.DeviceFontSmallLight
     }
 
+    func applyTheme() {
+        titleLabel.textColor = UIColor.theme.homePanel.readingListActive
+        hostnameLabel.textColor = UIColor.theme.homePanel.readingListActive
+    }
+
     override func prepareForReuse() {
         super.prepareForReuse()
+        applyTheme()
         setupDynamicFonts()
     }
 
@@ -206,7 +209,6 @@ class ReadingListPanel: UITableViewController, HomePanel {
         tableView.cellLayoutMarginsFollowReadableWidth = false
         tableView.separatorInset = .zero
         tableView.layoutMargins = .zero
-        tableView.separatorColor = UIColor.theme.tableView.separator
         tableView.register(ReadingListTableViewCell.self, forCellReuseIdentifier: "ReadingListTableViewCell")
 
         // Set an empty footer to prevent empty cells from appearing in the list.
@@ -215,8 +217,6 @@ class ReadingListPanel: UITableViewController, HomePanel {
         if #available(iOS 11.0, *) {
             tableView.dragDelegate = self
         }
-
-        view.backgroundColor = UIColor.theme.tableView.rowBackground
 
         if let newRecords = profile.readingList.getAvailableRecords().value.successValue {
             records = newRecords
@@ -378,7 +378,6 @@ class ReadingListPanel: UITableViewController, HomePanel {
         let delete = UITableViewRowAction(style: .default, title: ReadingListTableViewCellUX.DeleteButtonTitleText) { [weak self] action, index in
             self?.deleteItem(atIndex: index)
         }
-//        delete.backgroundColor = ReadingListTableViewCellUX.DeleteButtonBackgroundColor
 
         let toggleText = record.unread ? ReadingListTableViewCellUX.MarkAsReadButtonTitleText : ReadingListTableViewCellUX.MarkAsUnreadButtonTitleText
         let unreadToggle = UITableViewRowAction(style: .normal, title: toggleText.stringSplitWithNewline()) { [weak self] (action, index) in
@@ -475,6 +474,9 @@ extension ReadingListPanel: UITableViewDragDelegate {
 
 extension ReadingListPanel: Themeable {
     func applyTheme() {
+        tableView.separatorColor = UIColor.theme.tableView.separator
+        view.backgroundColor = UIColor.theme.tableView.rowBackground
+
         emptyStateOverlayView.removeFromSuperview()
         emptyStateOverlayView = createEmptyStateOverview()
 

--- a/Client/Frontend/Home/ReaderPanel.swift
+++ b/Client/Frontend/Home/ReaderPanel.swift
@@ -42,9 +42,7 @@ private struct ReadingListPanelUX {
     // Welcome Screen
     static let WelcomeScreenTopPadding: CGFloat = 16
     static let WelcomeScreenPadding: CGFloat = 15
-    static let WelcomeScreenHeaderTextColor = UIColor.Photon.Grey60
 
-    static let WelcomeScreenItemTextColor = UIColor.Photon.Grey50
     static let WelcomeScreenItemWidth = 220
     static let WelcomeScreenItemOffset = -20
 
@@ -282,7 +280,6 @@ class ReadingListPanel: UITableViewController, HomePanel {
         welcomeLabel.text = NSLocalizedString("Welcome to your Reading List", comment: "See http://mzl.la/1LXbDOL")
         welcomeLabel.textAlignment = .center
         welcomeLabel.font = DynamicFontHelper.defaultHelper.DeviceFontSmallBold
-        welcomeLabel.textColor = ReadingListPanelUX.WelcomeScreenHeaderTextColor
         welcomeLabel.adjustsFontSizeToFitWidth = true
         welcomeLabel.snp.makeConstraints { make in
             make.centerX.equalTo(containerView)
@@ -296,7 +293,6 @@ class ReadingListPanel: UITableViewController, HomePanel {
         containerView.addSubview(readerModeLabel)
         readerModeLabel.text = NSLocalizedString("Open articles in Reader View by tapping the book icon when it appears in the title bar.", comment: "See http://mzl.la/1LXbDOL")
         readerModeLabel.font = DynamicFontHelper.defaultHelper.DeviceFontSmallLight
-        readerModeLabel.textColor = ReadingListPanelUX.WelcomeScreenItemTextColor
         readerModeLabel.numberOfLines = 0
         readerModeLabel.snp.makeConstraints { make in
             make.top.equalTo(welcomeLabel.snp.bottom).offset(ReadingListPanelUX.WelcomeScreenPadding)
@@ -315,7 +311,6 @@ class ReadingListPanel: UITableViewController, HomePanel {
         containerView.addSubview(readingListLabel)
         readingListLabel.text = NSLocalizedString("Save pages to your Reading List by tapping the book plus icon in the Reader View controls.", comment: "See http://mzl.la/1LXbDOL")
         readingListLabel.font = DynamicFontHelper.defaultHelper.DeviceFontSmallLight
-        readingListLabel.textColor = ReadingListPanelUX.WelcomeScreenItemTextColor
         readingListLabel.numberOfLines = 0
         readingListLabel.snp.makeConstraints { make in
             make.top.equalTo(readerModeLabel.snp.bottom).offset(ReadingListPanelUX.WelcomeScreenPadding)
@@ -338,6 +333,10 @@ class ReadingListPanel: UITableViewController, HomePanel {
 
             // And then center it in the overlay view that sits on top of the UITableView
             make.centerX.equalTo(overlayView)
+        }
+
+        [welcomeLabel, readerModeLabel, readingListLabel].forEach {
+            $0.textColor = UIColor.theme.homePanel.welcomeScreenText
         }
 
         return overlayView
@@ -468,5 +467,14 @@ extension ReadingListPanel: UITableViewDragDelegate {
 
     func tableView(_ tableView: UITableView, dragSessionWillBegin session: UIDragSession) {
         presentedViewController?.dismiss(animated: true)
+    }
+}
+
+extension ReadingListPanel: Themeable {
+    func applyTheme() {
+        emptyStateOverlayView.removeFromSuperview()
+        emptyStateOverlayView = createEmptyStateOverview()
+
+        refreshReadingList()
     }
 }

--- a/Client/Frontend/Home/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Home/RecentlyClosedTabsPanel.swift
@@ -24,9 +24,10 @@ class RecentlyClosedTabsPanel: UIViewController, HomePanel {
     fileprivate lazy var recentlyClosedHeader: UILabel = {
         let headerLabel = UILabel()
         headerLabel.text = Strings.RecentlyClosedTabsPanelTitle
+        headerLabel.textColor = UIColor.theme.tableView.headerTextDark
         headerLabel.font = DynamicFontHelper.defaultHelper.DeviceFontHistoryPanel
         headerLabel.textAlignment = .center
-        headerLabel.backgroundColor = .white
+        headerLabel.backgroundColor = UIColor.theme.tableView.headerBackground
         return headerLabel
     }()
 

--- a/Client/Frontend/Home/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Home/RecentlyClosedTabsPanel.swift
@@ -176,3 +176,9 @@ extension RecentlyClosedTabsPanelSiteTableViewController: HomePanelContextMenu {
         return getDefaultContextMenuActions(for: site, homePanelDelegate: homePanelDelegate)
     }
 }
+
+extension RecentlyClosedTabsPanel: Themeable {
+    func applyTheme() {
+        tableViewController.tableView.reloadData()
+    }
+}

--- a/Client/Frontend/Home/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Home/RecentlyClosedTabsPanel.swift
@@ -19,7 +19,7 @@ private struct RecentlyClosedPanelUX {
 
 class RecentlyClosedTabsPanel: UIViewController, HomePanel {
     weak var homePanelDelegate: HomePanelDelegate?
-    var profile: Profile!
+    let profile: Profile
 
     fileprivate lazy var recentlyClosedHeader: UILabel = {
         let headerLabel = UILabel()
@@ -30,7 +30,7 @@ class RecentlyClosedTabsPanel: UIViewController, HomePanel {
         return headerLabel
     }()
 
-    fileprivate var tableViewController = RecentlyClosedTabsPanelSiteTableViewController()
+    fileprivate lazy var tableViewController = RecentlyClosedTabsPanelSiteTableViewController(profile: profile)
 
     fileprivate lazy var historyBackButton: HistoryBackButton = {
         let button = HistoryBackButton()
@@ -38,12 +38,20 @@ class RecentlyClosedTabsPanel: UIViewController, HomePanel {
         return button
     }()
 
+    init(profile: Profile) {
+        self.profile = profile
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = .white
+        view.backgroundColor = UIColor.theme.tableView.headerBackground
 
-        tableViewController.profile = self.profile
         tableViewController.homePanelDelegate = homePanelDelegate
         tableViewController.recentlyClosedTabsPanel = self
 
@@ -87,19 +95,11 @@ class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {
         return UILongPressGestureRecognizer(target: self, action: #selector(RecentlyClosedTabsPanelSiteTableViewController.longPress))
     }()
 
-    init() {
-        super.init(nibName: nil, bundle: nil)
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.addGestureRecognizer(longPressRecognizer)
         tableView.accessibilityIdentifier = "Recently Closed Tabs List"
         self.recentlyClosedTabs = profile.recentlyClosedTabs.tabs
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
     }
 
     @objc fileprivate func longPress(_ longPressGestureRecognizer: UILongPressGestureRecognizer) {

--- a/Client/Frontend/Home/RemoteTabsPanel.swift
+++ b/Client/Frontend/Home/RemoteTabsPanel.swift
@@ -15,15 +15,9 @@ private let log = Logger.browserLogger
 private struct RemoteTabsPanelUX {
     static let HeaderHeight = SiteTableViewControllerUX.RowHeight // Not HeaderHeight!
     static let RowHeight = SiteTableViewControllerUX.RowHeight
-    static let HeaderBackgroundColor = UIColor.Photon.Grey10
-
-    static let EmptyStateTitleTextColor = UIColor.Photon.Grey60
-
-    static let EmptyStateInstructionsTextColor = UIColor.Photon.Grey50
     static let EmptyStateInstructionsWidth = 170
     static let EmptyStateTopPaddingInBetweenItems: CGFloat = 15 // UX TODO I set this to 8 so that it all fits on landscape
     static let EmptyStateSignInButtonColor = UIColor.Photon.Blue40
-    static let EmptyStateSignInButtonTitleColor = UIColor.Photon.White100
     static let EmptyStateSignInButtonCornerRadius: CGFloat = 4
     static let EmptyStateSignInButtonHeight = 44
     static let EmptyStateSignInButtonWidth = 200
@@ -69,8 +63,8 @@ class RemoteTabsPanel: UIViewController, HomePanel {
         tableViewController.profile = profile
         tableViewController.remoteTabsPanel = self
 
-        view.backgroundColor = UIColor.theme.homePanel.panelBackground
-
+        view.backgroundColor = UIColor.theme.tableView.rowBackground
+        tableViewController.tableView.backgroundColor = .clear
         addChildViewController(tableViewController)
         self.view.addSubview(tableViewController.view)
         self.view.addSubview(historyBackButton)
@@ -159,7 +153,7 @@ class RemoteTabsPanelClientAndTabsDataSource: NSObject, RemoteTabsPanelDataSourc
         let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: RemoteClientIdentifier) as! TwoLineHeaderFooterView
         view.frame = CGRect(width: tableView.frame.width, height: RemoteTabsPanelUX.HeaderHeight)
         view.textLabel?.text = client.name
-        view.contentView.backgroundColor = RemoteTabsPanelUX.HeaderBackgroundColor
+        view.contentView.backgroundColor = UIColor.theme.tableView.headerBackground
 
         /*
         * A note on timestamps.
@@ -292,14 +286,14 @@ class RemoteTabsErrorCell: UITableViewCell {
         titleLabel.font = DynamicFontHelper.defaultHelper.DeviceFont
         titleLabel.text = Strings.EmptySyncedTabsPanelStateTitle
         titleLabel.textAlignment = .center
-        titleLabel.textColor = RemoteTabsPanelUX.EmptyStateTitleTextColor
+        titleLabel.textColor = UIColor.theme.tableView.headerTextDark
         containerView.addSubview(titleLabel)
 
         let instructionsLabel = UILabel()
         instructionsLabel.font = DynamicFontHelper.defaultHelper.DeviceFontSmallLight
         instructionsLabel.text = error.localizedString()
         instructionsLabel.textAlignment = .center
-        instructionsLabel.textColor = RemoteTabsPanelUX.EmptyStateInstructionsTextColor
+        instructionsLabel.textColor = UIColor.theme.tableView.headerTextDark
         instructionsLabel.numberOfLines = 0
         containerView.addSubview(instructionsLabel)
 
@@ -366,19 +360,19 @@ class RemoteTabsNotLoggedInCell: UITableViewCell {
         titleLabel.font = DynamicFontHelper.defaultHelper.DeviceFont
         titleLabel.text = Strings.EmptySyncedTabsPanelStateTitle
         titleLabel.textAlignment = .center
-        titleLabel.textColor = RemoteTabsPanelUX.EmptyStateTitleTextColor
+        titleLabel.textColor = UIColor.theme.tableView.headerTextDark
         contentView.addSubview(titleLabel)
 
         instructionsLabel.font = DynamicFontHelper.defaultHelper.DeviceFontSmallLight
         instructionsLabel.text = Strings.EmptySyncedTabsPanelNotSignedInStateDescription
         instructionsLabel.textAlignment = .center
-        instructionsLabel.textColor = RemoteTabsPanelUX.EmptyStateInstructionsTextColor
+        instructionsLabel.textColor = UIColor.theme.tableView.headerTextDark
         instructionsLabel.numberOfLines = 0
         contentView.addSubview(instructionsLabel)
 
         signInButton.backgroundColor = RemoteTabsPanelUX.EmptyStateSignInButtonColor
         signInButton.setTitle(Strings.FxASignInToSync, for: [])
-        signInButton.setTitleColor(RemoteTabsPanelUX.EmptyStateSignInButtonTitleColor, for: [])
+        signInButton.setTitleColor(UIColor.theme.tableView.headerTextDark, for: [])
         signInButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .subheadline)
         signInButton.layer.cornerRadius = RemoteTabsPanelUX.EmptyStateSignInButtonCornerRadius
         signInButton.clipsToBounds = true

--- a/Client/Frontend/Home/RemoteTabsPanel.swift
+++ b/Client/Frontend/Home/RemoteTabsPanel.swift
@@ -609,3 +609,9 @@ extension RemoteTabsTableViewController: HomePanelContextMenu {
         return getDefaultContextMenuActions(for: site, homePanelDelegate: remoteTabsPanel?.homePanelDelegate)
     }
 }
+
+extension RemoteTabsPanel: Themeable {
+    func applyTheme() {
+        tableViewController.tableView.reloadData()
+    }
+}

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -88,7 +88,7 @@ class SyncNowSetting: WithAccountSetting {
         return NSAttributedString(
             string: NSLocalizedString("Sync Now", comment: "Sync Firefox Account"),
             attributes: [
-                NSAttributedStringKey.foregroundColor: self.enabled ? UIColor.theme.tableView.syncText : UIColor.theme.tableView.headerText,
+                NSAttributedStringKey.foregroundColor: self.enabled ? UIColor.theme.tableView.syncText : UIColor.theme.tableView.headerTextLight,
                 NSAttributedStringKey.font: DynamicFontHelper.defaultHelper.DefaultStandardFont
             ]
         )
@@ -150,7 +150,7 @@ class SyncNowSetting: WithAccountSetting {
 
         let formattedLabel = timestampFormatter.string(from: Date.fromTimestamp(timestamp))
         let attributedString = NSMutableAttributedString(string: formattedLabel)
-        let attributes = [NSAttributedStringKey.foregroundColor: UIColor.theme.tableView.headerText, NSAttributedStringKey.font: UIFont.systemFont(ofSize: 12, weight: UIFont.Weight.regular)]
+        let attributes = [NSAttributedStringKey.foregroundColor: UIColor.theme.tableView.headerTextLight, NSAttributedStringKey.font: UIFont.systemFont(ofSize: 12, weight: UIFont.Weight.regular)]
         let range = NSRange(location: 0, length: attributedString.length)
         attributedString.setAttributes(attributes, range: range)
         return attributedString
@@ -668,7 +668,7 @@ class SendFeedbackSetting: Setting {
 class SendAnonymousUsageDataSetting: BoolSetting {
     init(prefs: Prefs, delegate: SettingsDelegate?) {
         let statusText = NSMutableAttributedString()
-        statusText.append(NSAttributedString(string: Strings.SendUsageSettingMessage, attributes: [NSAttributedStringKey.foregroundColor: UIColor.theme.tableView.headerText]))
+        statusText.append(NSAttributedString(string: Strings.SendUsageSettingMessage, attributes: [NSAttributedStringKey.foregroundColor: UIColor.theme.tableView.headerTextLight]))
         statusText.append(NSAttributedString(string: " "))
         statusText.append(NSAttributedString(string: Strings.SendUsageSettingLink, attributes: [NSAttributedStringKey.foregroundColor: UIColor.theme.general.highlightBlue]))
 
@@ -892,7 +892,7 @@ class ChinaSyncServiceSetting: WithoutAccountSetting {
     }
 
     override var status: NSAttributedString? {
-        return NSAttributedString(string: "禁用后使用全球服务同步数据", attributes: [NSAttributedStringKey.foregroundColor: UIColor.theme.tableView.headerText])
+        return NSAttributedString(string: "禁用后使用全球服务同步数据", attributes: [NSAttributedStringKey.foregroundColor: UIColor.theme.tableView.headerTextLight])
     }
 
     override func onConfigureCell(_ cell: UITableViewCell) {
@@ -945,7 +945,7 @@ class StageSyncServiceDebugSetting: WithoutAccountSetting {
             configurationURL = StageFirefoxAccountConfiguration().authEndpointURL
         }
 
-        return NSAttributedString(string: configurationURL.absoluteString, attributes: [NSAttributedStringKey.foregroundColor: UIColor.theme.tableView.headerText])
+        return NSAttributedString(string: configurationURL.absoluteString, attributes: [NSAttributedStringKey.foregroundColor: UIColor.theme.tableView.headerTextLight])
     }
 
     override func onConfigureCell(_ cell: UITableViewCell) {

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -181,7 +181,7 @@ class BoolSetting: Setting {
     convenience init(prefs: Prefs, prefKey: String? = nil, defaultValue: Bool, titleText: String, statusText: String? = nil, settingDidChange: ((Bool) -> Void)? = nil) {
         var statusTextAttributedString: NSAttributedString?
         if let statusTextString = statusText {
-            statusTextAttributedString = NSAttributedString(string: statusTextString, attributes: [NSAttributedStringKey.foregroundColor: UIColor.theme.tableView.headerText])
+            statusTextAttributedString = NSAttributedString(string: statusTextString, attributes: [NSAttributedStringKey.foregroundColor: UIColor.theme.tableView.headerTextLight])
         }
         self.init(prefs: prefs, prefKey: prefKey, defaultValue: defaultValue, attributedTitleText: NSAttributedString(string: titleText, attributes: [NSAttributedStringKey.foregroundColor: UIColor.theme.tableView.rowText]), attributedStatusText: statusTextAttributedString, settingDidChange: settingDidChange)
     }

--- a/Client/Frontend/Settings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettingsController.swift
@@ -72,7 +72,7 @@ class ThemeSettingsController: ThemedTableViewController {
             make.left.right.equalToSuperview().inset(16)
         }
         label.font = UIFont.systemFont(ofSize: UX.footerFontSize)
-        label.textColor = UIColor.theme.tableView.headerText
+        label.textColor = UIColor.theme.tableView.headerTextLight
         return footer
     }
 

--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -12,13 +12,15 @@ fileprivate let defaultTextAndTint = UIColor.Photon.Grey10
 fileprivate class DarkTableViewColor: TableViewColor {
     override var rowBackground: UIColor { return UIColor.Photon.Ink70 }
     override var rowText: UIColor { return defaultTextAndTint }
+    override var rowDetailText: UIColor { return UIColor.Photon.Grey30 }
     override var disabledRowText: UIColor { return UIColor.Photon.Grey40 }
     override var separator: UIColor { return UIColor.Photon.Grey60 }
     override var headerBackground: UIColor { return UIColor.Photon.Ink80 }
-    override var headerText: UIColor { return UIColor.Photon.Grey30 }
+    override var headerTextLight: UIColor { return UIColor.Photon.Grey30 }
+    override var headerTextDark: UIColor { return UIColor.Photon.Grey30 }
 //    override var rowActionAccessory: UIColor { return UIColor.Photon.Blue50 }
 //    override var controlTint: UIColor { return rowActionAccessory }
-//    override var syncText: UIColor { return defaultTextAndTint }
+    override var syncText: UIColor { return defaultTextAndTint }
 //    override var errorText: UIColor { return UIColor.Photon.Red50 }
 //    override var warningText: UIColor { return UIColor.Photon.Orange50 }
 }
@@ -28,6 +30,7 @@ fileprivate class DarkActionMenuColor: ActionMenuColor {
     override var iPhoneBackground: UIColor { return UIColor.Photon.Ink90.withAlphaComponent(0.7) }
     override var iPhoneBackgroundBlurStyle: UIBlurEffectStyle { return UIBlurEffectStyle.light }
     override var closeButtonBackground: UIColor { return defaultBackground }
+
 }
 
 fileprivate class DarkURLBarColor: URLBarColor {
@@ -116,15 +119,19 @@ fileprivate class DarkHomePanelColor: HomePanelColor {
     // var siteTableHeaderText: UIColor { return UIColor.Photon.Grey80 }
    // var siteTableHeaderBackground: UIColor { return UIColor.Photon.Grey10 }
 
-    override var topSiteDomain: UIColor { return defaultTextAndTint }
+    override var activityStreamHeaderText: UIColor { return UIColor.Photon.Grey30 }
+    override var activityStreamCellTitle: UIColor { return UIColor.Photon.Grey20 }
+    override var activityStreamCellDescription: UIColor { return UIColor.Photon.Grey30 }
 
+    override var topSiteDomain: UIColor { return defaultTextAndTint }
+    
+    override var downloadedFileIcon: UIColor { return UIColor.Photon.Grey30 }
+
+    override var historyHeaderIconsBackground: UIColor { return UIColor.clear }
 }
 
 fileprivate class DarkSnackBarColor: SnackBarColor {
-//    override var highlight: UIColor { return UIColor.Defaults.iOSTextHighlightBlue.withAlphaComponent(0.9) }
-//    override var highlightText: UIColor { return UIColor.Photon.Blue60 }
-//    override var border: UIColor { return UIColor.Photon.Grey30 }
-//    override var title: UIColor { return UIColor.Photon.Blue50 }
+// Use defaults
 }
 
 fileprivate class DarkGeneralColor: GeneralColor {

--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -114,6 +114,7 @@ fileprivate class DarkHomePanelColor: HomePanelColor {
     override var bookmarkFolderBackground: UIColor { return UIColor.Photon.Ink80 }
     override var bookmarkFolderText: UIColor { return UIColor.Photon.White100 }
     override var bookmarkCurrentFolderText: UIColor { return UIColor.Photon.White100 }
+    override var bookmarkBackNavCellBackground: UIColor { return UIColor.Photon.Ink70 }
     
    //  var siteTableHeaderBorder: UIColor { return UIColor.Photon.Grey30.withAlphaComponent(0.8) }
     // var siteTableHeaderText: UIColor { return UIColor.Photon.Grey80 }
@@ -128,6 +129,9 @@ fileprivate class DarkHomePanelColor: HomePanelColor {
     override var downloadedFileIcon: UIColor { return UIColor.Photon.Grey30 }
 
     override var historyHeaderIconsBackground: UIColor { return UIColor.clear }
+
+    override var readingListActive: UIColor { return UIColor.Photon.Grey10 }
+    override var readingListDimmed: UIColor { return UIColor.Photon.Grey40 }
 }
 
 fileprivate class DarkSnackBarColor: SnackBarColor {

--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -106,7 +106,7 @@ fileprivate class DarkHomePanelColor: HomePanelColor {
     override var buttonContainerBorder: UIColor { return separator }
     override var backgroundColorPrivateMode: UIColor { return UIColor.Photon.Grey50 }
 
-    override var welcomeScreenText: UIColor { return UIColor.Photon.Grey50 }
+    override var welcomeScreenText: UIColor { return UIColor.Photon.Grey30 }
     override var bookmarkIconBorder: UIColor { return UIColor.Photon.Grey30 }
     override var bookmarkFolderBackground: UIColor { return UIColor.Photon.Ink80 }
     override var bookmarkFolderText: UIColor { return UIColor.Photon.White100 }

--- a/Client/Frontend/Theme/Theme.swift
+++ b/Client/Frontend/Theme/Theme.swift
@@ -134,6 +134,7 @@ class HomePanelColor {
     var bookmarkFolderBackground: UIColor { return UIColor.Photon.Grey10.withAlphaComponent(0.3) } 
     var bookmarkFolderText: UIColor { return UIColor.Photon.Grey80 } 
     var bookmarkCurrentFolderText: UIColor { return UIColor.theme.general.highlightBlue }
+    var bookmarkBackNavCellBackground: UIColor { return UIColor.clear }
     
     var siteTableHeaderBorder: UIColor { return UIColor.Photon.Grey30.withAlphaComponent(0.8) }
 
@@ -143,7 +144,7 @@ class HomePanelColor {
     var activityStreamCellTitle: UIColor { return UIColor.black }
     var activityStreamCellDescription: UIColor { return UIColor.Photon.Grey60 }
 
-    var readingListActive: UIColor { return UIColor.Photon.Grey70 }
+    var readingListActive: UIColor { return defaultTextAndTint }
     var readingListDimmed: UIColor { return UIColor.Photon.Grey40 }
     
     var downloadedFileIcon: UIColor { return UIColor.Photon.Grey60 }

--- a/Client/Frontend/Theme/Theme.swift
+++ b/Client/Frontend/Theme/Theme.swift
@@ -30,10 +30,14 @@ fileprivate let defaultTextAndTint = UIColor.Photon.Grey80
 class TableViewColor {
     var rowBackground: UIColor { return UIColor.Photon.White100 }
     var rowText: UIColor { return UIColor.Photon.Grey90 }
+    var rowDetailText: UIColor { return UIColor.Photon.Grey60 }
     var disabledRowText: UIColor { return UIColor.Photon.Grey40 }
     var separator: UIColor { return defaultSeparator }
     var headerBackground: UIColor { return defaultBackground }
-    var headerText: UIColor { return UIColor.Photon.Grey50 }
+    // Used for table headers in Settings and Photon menus
+    var headerTextLight: UIColor { return UIColor.Photon.Grey50 }
+    // Used for table headers in home panel tables
+    var headerTextDark: UIColor { return UIColor.Photon.Grey90 }
     var rowActionAccessory: UIColor { return UIColor.Photon.Blue50 }
     var controlTint: UIColor { return rowActionAccessory }
     var syncText: UIColor { return defaultTextAndTint }
@@ -128,17 +132,23 @@ class HomePanelColor {
     var welcomeScreenText: UIColor { return UIColor.Photon.Grey50 }
     var bookmarkIconBorder: UIColor { return UIColor.Photon.Grey30 }
     var bookmarkFolderBackground: UIColor { return UIColor.Photon.Grey10.withAlphaComponent(0.3) } 
-    var bookmarkFolderText: UIColor { return UIColor.Photon.Grey50 } 
+    var bookmarkFolderText: UIColor { return UIColor.Photon.Grey80 } 
     var bookmarkCurrentFolderText: UIColor { return UIColor.theme.general.highlightBlue }
     
     var siteTableHeaderBorder: UIColor { return UIColor.Photon.Grey30.withAlphaComponent(0.8) }
-    var siteTableHeaderText: UIColor { return UIColor.Photon.Grey80 }
-    var siteTableHeaderBackground: UIColor { return UIColor.Photon.Grey10 }
 
     var topSiteDomain: UIColor { return UIColor.black }
-    
+
+    var activityStreamHeaderText: UIColor { return UIColor.Photon.Grey50 }
+    var activityStreamCellTitle: UIColor { return UIColor.black }
+    var activityStreamCellDescription: UIColor { return UIColor.Photon.Grey60 }
+
     var readingListActive: UIColor { return UIColor.Photon.Grey70 }
     var readingListDimmed: UIColor { return UIColor.Photon.Grey40 }
+    
+    var downloadedFileIcon: UIColor { return UIColor.Photon.Grey60 }
+    
+    var historyHeaderIconsBackground: UIColor { return UIColor.Photon.White100 }
 }
 
 class SnackBarColor {

--- a/Client/Frontend/Theme/ThemedWidgets.swift
+++ b/Client/Frontend/Theme/ThemedWidgets.swift
@@ -112,7 +112,7 @@ class ThemedTableSectionHeaderFooterView: UITableViewHeaderFooterView, Themeable
         topBorder.backgroundColor = UIColor.theme.tableView.separator
         bottomBorder.backgroundColor = UIColor.theme.tableView.separator
         contentView.backgroundColor = UIColor.theme.tableView.headerBackground
-        titleLabel.textColor = UIColor.theme.tableView.headerText
+        titleLabel.textColor = UIColor.theme.tableView.headerTextLight
     }
 
     func setupInitialConstraints() {
@@ -135,6 +135,8 @@ class ThemedTableSectionHeaderFooterView: UITableViewHeaderFooterView, Themeable
         showBottomBorder = true
         titleLabel.text = nil
         titleAlignment = .bottom
+
+        applyTheme()
     }
 
     fileprivate func remakeTitleAlignmentConstraints() {

--- a/Client/Frontend/Widgets/ActivityStreamHighlightCell.swift
+++ b/Client/Frontend/Widgets/ActivityStreamHighlightCell.swift
@@ -7,7 +7,6 @@ import Shared
 import Storage
 
 private struct ActivityStreamHighlightCellUX {
-    static let LabelColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.black : UIColor.Photon.Grey70
     static let BorderWidth: CGFloat = 0.5
     static let CellSideOffset = 20
     static let TitleLabelOffset = 2
@@ -15,7 +14,6 @@ private struct ActivityStreamHighlightCellUX {
     static let SiteImageViewSize = CGSize(width: 99, height: UIDevice.current.userInterfaceIdiom == .pad ? 120 : 90)
     static let StatusIconSize = 12
     static let FaviconSize = CGSize(width: 45, height: 45)
-    static let DescriptionLabelColor = UIColor.Photon.Grey50
     static let SelectedOverlayColor = UIColor(white: 0.0, alpha: 0.25)
     static let CornerRadius: CGFloat = 3
     static let BorderColor = UIColor.Photon.Grey30
@@ -26,7 +24,7 @@ class ActivityStreamHighlightCell: UICollectionViewCell {
     fileprivate lazy var titleLabel: UILabel = {
         let titleLabel = UILabel()
         titleLabel.font = DynamicFontHelper.defaultHelper.MediumSizeHeavyWeightAS
-        titleLabel.textColor = ActivityStreamHighlightCellUX.LabelColor
+        titleLabel.textColor = UIColor.theme.homePanel.activityStreamCellTitle
         titleLabel.textAlignment = .left
         titleLabel.numberOfLines = 3
         return titleLabel
@@ -35,7 +33,7 @@ class ActivityStreamHighlightCell: UICollectionViewCell {
     fileprivate lazy var descriptionLabel: UILabel = {
         let descriptionLabel = UILabel()
         descriptionLabel.font = DynamicFontHelper.defaultHelper.SmallSizeRegularWeightAS
-        descriptionLabel.textColor = ActivityStreamHighlightCellUX.DescriptionLabelColor
+        descriptionLabel.textColor = UIColor.theme.homePanel.activityStreamCellDescription
         descriptionLabel.textAlignment = .left
         descriptionLabel.numberOfLines = 1
         return descriptionLabel
@@ -44,7 +42,7 @@ class ActivityStreamHighlightCell: UICollectionViewCell {
     fileprivate lazy var domainLabel: UILabel = {
         let descriptionLabel = UILabel()
         descriptionLabel.font = DynamicFontHelper.defaultHelper.SmallSizeRegularWeightAS
-        descriptionLabel.textColor = ActivityStreamHighlightCellUX.DescriptionLabelColor
+        descriptionLabel.textColor = UIColor.theme.homePanel.activityStreamCellDescription
         descriptionLabel.textAlignment = .left
         descriptionLabel.numberOfLines = 1
         descriptionLabel.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 1000), for: .vertical)
@@ -218,7 +216,7 @@ class HighlightIntroCell: UICollectionViewCell {
     lazy var titleLabel: UILabel = {
         let textLabel = UILabel()
         textLabel.font = DynamicFontHelper.defaultHelper.MediumSizeBoldFontAS
-        textLabel.textColor = UIColor.black
+        textLabel.textColor = UIColor.theme.homePanel.activityStreamCellTitle
         textLabel.numberOfLines = 1
         textLabel.adjustsFontSizeToFitWidth = true
         textLabel.minimumScaleFactor = 0.8
@@ -228,7 +226,7 @@ class HighlightIntroCell: UICollectionViewCell {
     lazy var descriptionLabel: UILabel = {
         let label = UILabel()
         label.font = DynamicFontHelper.defaultHelper.MediumSizeRegularWeightAS
-        label.textColor = UIColor.Photon.Grey60
+        label.textColor = UIColor.theme.homePanel.activityStreamCellDescription
         label.numberOfLines = 0
         return label
     }()

--- a/Client/Frontend/Widgets/HistoryBackButton.swift
+++ b/Client/Frontend/Widgets/HistoryBackButton.swift
@@ -37,7 +37,7 @@ class HistoryBackButton: UIButton {
         addSubview(chevron)
         addSubview(title)
 
-        backgroundColor = UIColor.Photon.White100
+        backgroundColor = UIColor.theme.tableView.headerBackground
 
         chevron.snp.makeConstraints { make in
             make.leading.equalTo(self.safeArea.leading).offset(HistoryBackButtonUX.HistoryHistoryBackButtonHeaderChevronInset)

--- a/Client/Frontend/Widgets/LoginTableViewCell.swift
+++ b/Client/Frontend/Widgets/LoginTableViewCell.swift
@@ -15,7 +15,7 @@ protocol LoginTableViewCellDelegate: AnyObject {
 private struct LoginTableViewCellUX {
     static let highlightedLabelFont = UIFont.systemFont(ofSize: 12)
     static let highlightedLabelTextColor = UIConstants.SystemBlueColor
-    static let highlightedLabelEditingTextColor = UIColor.theme.tableView.headerText
+    static let highlightedLabelEditingTextColor = UIColor.theme.tableView.headerTextLight
 
     static let descriptionLabelFont = UIFont.systemFont(ofSize: 16)
     static let descriptionLabelTextColor = UIColor.black

--- a/Client/Frontend/Widgets/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet.swift
@@ -352,7 +352,7 @@ private class PhotonActionSheetTitleHeaderView: UITableViewHeaderFooterView {
         let titleLabel = UILabel()
         titleLabel.font = DynamicFontHelper.defaultHelper.SmallSizeRegularWeightAS
         titleLabel.numberOfLines = 1
-        titleLabel.textColor = UIColor.theme.tableView.headerText
+        titleLabel.textColor = UIColor.theme.tableView.headerTextLight
         return titleLabel
     }()
 

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -70,13 +70,24 @@ class SiteTableViewHeader: UITableViewHeaderFooterView {
 class SiteTableViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
     fileprivate let CellIdentifier = "CellIdentifier"
     fileprivate let HeaderIdentifier = "HeaderIdentifier"
-    var profile: Profile! {
-        didSet {
-            reloadData()
-        }
-    }
+    let profile: Profile!
+
     var data: Cursor<Site> = Cursor<Site>(status: .success, msg: "No data set")
     var tableView = UITableView()
+
+    private override init(nibName: String?, bundle: Bundle?) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    init(profile: Profile) {
+        self.profile = profile
+        super.init(nibName: nil, bundle: nil)
+        applyTheme()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -12,7 +12,7 @@ struct SiteTableViewControllerUX {
     static let HeaderTextMargin = CGFloat(16)
 }
 
-class SiteTableViewHeader: UITableViewHeaderFooterView {
+class SiteTableViewHeader: UITableViewHeaderFooterView, Themeable {
     // I can't get drawRect to play nicely with the glass background. As a fallback
     // we just use views for the top and bottom borders.
     let topBorder = UIView()
@@ -25,13 +25,7 @@ class SiteTableViewHeader: UITableViewHeaderFooterView {
 
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
-
-        topBorder.backgroundColor = UIColor.theme.homePanel.siteTableHeaderBorder
-        bottomBorder.backgroundColor = UIColor.theme.homePanel.siteTableHeaderBorder
-        contentView.backgroundColor = UIColor.theme.homePanel.siteTableHeaderBackground
-
         titleLabel.font = DynamicFontHelper.defaultHelper.DeviceFontMediumBold
-        titleLabel.textColor = UIColor.theme.homePanel.siteTableHeaderText
 
         addSubview(topBorder)
         addSubview(bottomBorder)
@@ -57,10 +51,24 @@ class SiteTableViewHeader: UITableViewHeaderFooterView {
             make.right.lessThanOrEqualTo(contentView) // Fallback for when the right space constraint breaks
             make.centerY.equalTo(contentView)
         }
+
+        applyTheme()
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        applyTheme()
+    }
+
+    func applyTheme() {
+        titleLabel.textColor = UIColor.theme.tableView.headerTextDark
+        topBorder.backgroundColor = UIColor.theme.homePanel.siteTableHeaderBorder
+        bottomBorder.backgroundColor = UIColor.theme.homePanel.siteTableHeaderBorder
+        contentView.backgroundColor = UIColor.theme.tableView.headerBackground
     }
 }
 
@@ -104,8 +112,7 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
         tableView.register(SiteTableViewHeader.self, forHeaderFooterViewReuseIdentifier: HeaderIdentifier)
         tableView.layoutMargins = .zero
         tableView.keyboardDismissMode = .onDrag
-        tableView.backgroundColor = UIColor.theme.tableView.rowBackground
-        tableView.separatorColor = UIColor.theme.tableView.separator
+
         tableView.accessibilityIdentifier = "SiteTable"
         tableView.cellLayoutMarginsFollowReadableWidth = false
 
@@ -160,7 +167,7 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
 
     func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
         if let header = view as? UITableViewHeaderFooterView {
-            header.textLabel?.textColor = UIColor.theme.tableView.headerText
+            header.textLabel?.textColor = UIColor.theme.tableView.headerTextDark
             header.contentView.backgroundColor = UIColor.theme.tableView.headerBackground
         }
     }
@@ -175,6 +182,12 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
 
     func tableView(_ tableView: UITableView, hasFullWidthSeparatorForRowAtIndexPath indexPath: IndexPath) -> Bool {
         return false
+    }
+
+    func applyTheme() {
+        tableView.backgroundColor = UIColor.theme.tableView.rowBackground
+        tableView.separatorColor = UIColor.theme.tableView.separator
+        reloadData()
     }
 }
 

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -78,7 +78,7 @@ class SiteTableViewHeader: UITableViewHeaderFooterView, Themeable {
 class SiteTableViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
     fileprivate let CellIdentifier = "CellIdentifier"
     fileprivate let HeaderIdentifier = "HeaderIdentifier"
-    let profile: Profile!
+    let profile: Profile
 
     var data: Cursor<Site> = Cursor<Site>(status: .success, msg: "No data set")
     var tableView = UITableView()

--- a/Client/Frontend/Widgets/SnackBar.swift
+++ b/Client/Frontend/Widgets/SnackBar.swift
@@ -84,7 +84,7 @@ class SnackBar: UIView {
         label.lineBreakMode = .byWordWrapping
         label.setContentCompressionResistancePriority(.required, for: .horizontal)
         label.numberOfLines = 0
-        label.textColor = UIColor.theme.tableView.rowText
+        label.textColor = UIColor.Photon.Grey90 // If making themeable, change to UIColor.theme.tableView.rowText
         label.backgroundColor = UIColor.clear
         return label
     }()

--- a/Client/Frontend/Widgets/TwoLineCell.swift
+++ b/Client/Frontend/Widgets/TwoLineCell.swift
@@ -14,7 +14,7 @@ struct TwoLineCellUX {
     static let DetailTextTopMargin: CGFloat = 0
 }
 
-class TwoLineTableViewCell: UITableViewCell {
+class TwoLineTableViewCell: UITableViewCell, Themeable {
     fileprivate let twoLineHelper = TwoLineCellHelper()
 
     let _textLabel = UILabel()
@@ -41,6 +41,8 @@ class TwoLineTableViewCell: UITableViewCell {
         layoutMargins = .zero
 
         separatorInset = UIEdgeInsets(top: 0, left: TwoLineCellUX.ImageSize + 2 * TwoLineCellUX.BorderViewMargin, bottom: 0, right: 0)
+
+        applyTheme()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -59,6 +61,11 @@ class TwoLineTableViewCell: UITableViewCell {
         self.selectionStyle = .default
         separatorInset = UIEdgeInsets(top: 0, left: TwoLineCellUX.ImageSize + 2 * TwoLineCellUX.BorderViewMargin, bottom: 0, right: 0)
         twoLineHelper.setupDynamicFonts()
+        applyTheme()
+    }
+
+    func applyTheme() {
+        twoLineHelper.applyTheme()
     }
 
     // Save background color on UITableViewCell "select" because it disappears in the default behavior
@@ -94,24 +101,13 @@ class TwoLineTableViewCell: UITableViewCell {
 }
 
 class SiteTableViewCell: TwoLineTableViewCell {
-    let borderView = UIView()
-
-    override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
-        super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
-        twoLineHelper.setUpViews(self, textLabel: textLabel!, detailTextLabel: detailTextLabel!, imageView: imageView!)
-    }
-
     override func layoutSubviews() {
         super.layoutSubviews()
         twoLineHelper.layoutSubviews(accessoryWidth: self.contentView.frame.origin.x)
     }
-
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
 }
 
-class TwoLineHeaderFooterView: UITableViewHeaderFooterView {
+class TwoLineHeaderFooterView: UITableViewHeaderFooterView, Themeable {
     fileprivate let twoLineHelper = TwoLineCellHelper()
 
     // UITableViewHeaderFooterView includes textLabel and detailTextLabel, so we can't override
@@ -142,10 +138,16 @@ class TwoLineHeaderFooterView: UITableViewHeaderFooterView {
         contentView.addSubview(imageView)
 
         layoutMargins = .zero
+
+        applyTheme()
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    func applyTheme() {
+        twoLineHelper.applyTheme()
     }
 
     override func layoutSubviews() {
@@ -156,6 +158,7 @@ class TwoLineHeaderFooterView: UITableViewHeaderFooterView {
     override func prepareForReuse() {
         super.prepareForReuse()
         twoLineHelper.setUpViews(self, textLabel: _textLabel, detailTextLabel: _detailTextLabel, imageView: imageView)
+        applyTheme()
     }
 
     func mergeAccessibilityLabels(_ views: [AnyObject?]? = nil) {
@@ -177,6 +180,14 @@ private class TwoLineCellHelper {
         self.detailTextLabel = detailTextLabel
         self.imageView = imageView
 
+        setupDynamicFonts()
+
+        imageView.contentMode = .scaleAspectFill
+        imageView.layer.cornerRadius = 6 //hmm
+        imageView.layer.masksToBounds = true
+    }
+
+    func applyTheme() {
         if let headerView = self.container as? UITableViewHeaderFooterView {
             headerView.contentView.backgroundColor = UIColor.clear
         } else {
@@ -185,11 +196,6 @@ private class TwoLineCellHelper {
 
         textLabel.textColor = UIColor.theme.tableView.rowText
         detailTextLabel.textColor = UIColor.theme.tableView.rowDetailText
-        setupDynamicFonts()
-
-        imageView.contentMode = .scaleAspectFill
-        imageView.layer.cornerRadius = 6 //hmm
-        imageView.layer.masksToBounds = true
     }
 
     func setupDynamicFonts() {

--- a/Client/Frontend/Widgets/TwoLineCell.swift
+++ b/Client/Frontend/Widgets/TwoLineCell.swift
@@ -11,8 +11,6 @@ struct TwoLineCellUX {
     static let BadgeSize: CGFloat = 16
     static let BadgeMargin: CGFloat = 16
     static let BorderFrameSize: CGFloat = 32
-    static let TextColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.black : UIColor.Photon.Grey80
-    static let DetailTextColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.Photon.Grey60 : UIColor.Photon.Grey50
     static let DetailTextTopMargin: CGFloat = 0
 }
 
@@ -157,7 +155,7 @@ class TwoLineHeaderFooterView: UITableViewHeaderFooterView {
 
     override func prepareForReuse() {
         super.prepareForReuse()
-        twoLineHelper.setupDynamicFonts()
+        twoLineHelper.setUpViews(self, textLabel: _textLabel, detailTextLabel: _detailTextLabel, imageView: imageView)
     }
 
     func mergeAccessibilityLabels(_ views: [AnyObject?]? = nil) {
@@ -185,8 +183,8 @@ private class TwoLineCellHelper {
             self.container?.backgroundColor = UIColor.clear
         }
 
-        textLabel.textColor = TwoLineCellUX.TextColor
-        detailTextLabel.textColor = TwoLineCellUX.DetailTextColor
+        textLabel.textColor = UIColor.theme.tableView.rowText
+        detailTextLabel.textColor = UIColor.theme.tableView.rowDetailText
         setupDynamicFonts()
 
         imageView.contentMode = .scaleAspectFill


### PR DESCRIPTION
The first commit of Dark Theme left home panels in a partially complete state (I did quick theme support there to land the first patch).
This PR refactors how home panels apply their colors. It is giant because home panels are a *lot* of code.
This also has a minor commit to remove the theme for snack bar, it looks fine IMO in normal colors for now. (Although I could see wanting to change this later).

All the HomePanels and their respective table views, and table view custom headers/footers/cell subclasses, need to have an `applyTheme()` function, where color assignments go.
Steps needed:
- Move color assignment into `applyTheme()`. On-demand color assignment in cellForRowAt /cellForItemAt doesn't need any changes other than ensuring colors are theme colors in the form `UIColor.theme.thecolor`. 
- Ensure applyTheme() is applied to children when called on a parent, or in the case of table views, call reloadData() on table views.
- Ensure table views that reuse header/footer/cells will update their colors when reload data is called.
- classes that were setting up their color scheme in init(), need to call applyTheme() in init(). 

Commit 96ced90 is a cleanup commit to how we init panels, removing the `var profile: Profile!` and making it a `let profile: Profile` which is "better code"®, and easier for me to work with without breaking things.