### PR TITLE
Bug 1476543 - XCUITest Fix Intermittent failure DatabaseFixture

### DIFF
--- a/XCUITests/DatabaseFixtureTest.swift
+++ b/XCUITests/DatabaseFixtureTest.swift
@@ -27,7 +27,7 @@ class DatabaseFixtureTest: BaseTestCase {
 
         let loaded = NSPredicate(format: "count == 1013")
         expectation(for: loaded, evaluatedWith: app.tables["Bookmarks List"].cells, handler: nil)
-        waitForExpectations(timeout: 10, handler: nil)
+        waitForExpectations(timeout: 30, handler: nil)
 
         let bookmarksList = app.tables["Bookmarks List"].cells.count
         XCTAssertEqual(bookmarksList, 1013, "There should be an entry in the bookmarks list")
@@ -40,6 +40,6 @@ class DatabaseFixtureTest: BaseTestCase {
         // the actual max number is 100
         let loaded = NSPredicate(format: "count == 102")
         expectation(for: loaded, evaluatedWith: app.tables["History List"].cells, handler: nil)
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 30, handler: nil)
     }
 }


### PR DESCRIPTION
PR to increase the timeout in the DatabaseFixture test suite to avoid the intermittent failures on BB due to timeouts