### PR TITLE
Bug 1476938 - Theme for sync device welcome screen

### DIFF
--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -396,9 +396,8 @@ class HistoryPanel: SiteTableViewController, HomePanel {
     }
 
     func showSyncedTabs() {
-        let nextController = RemoteTabsPanel()
+        let nextController = RemoteTabsPanel(profile: profile)
         nextController.homePanelDelegate = self.homePanelDelegate
-        nextController.profile = self.profile
         self.refreshControl?.endRefreshing()
         self.navigationController?.pushViewController(nextController, animated: true)
     }
@@ -545,6 +544,10 @@ class HistoryPanel: SiteTableViewController, HomePanel {
     }
 
     override func applyTheme() {
+        emptyStateOverlayView.removeFromSuperview()
+        emptyStateOverlayView = createEmptyStateOverlayView()
+        updateEmptyPanelState()
+
         super.applyTheme()
     }
 }

--- a/Client/Frontend/Home/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Home/RecentlyClosedTabsPanel.swift
@@ -180,6 +180,7 @@ extension RecentlyClosedTabsPanelSiteTableViewController: HomePanelContextMenu {
 
 extension RecentlyClosedTabsPanel: Themeable {
     func applyTheme() {
+        historyBackButton.applyTheme()
         tableViewController.tableView.reloadData()
     }
 }

--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -103,7 +103,7 @@ fileprivate class DarkHomePanelColor: HomePanelColor {
     override var toolbarBackground: UIColor { return defaultBackground }
     override var toolbarHighlight: UIColor { return UIColor.Photon.Blue50 }
     override var toolbarTint: UIColor { return UIColor.Photon.Grey30 }
-    override var panelBackground: UIColor { return UIColor.black }
+    override var panelBackground: UIColor { return UIColor.Photon.Ink90 }
     override var separator: UIColor { return defaultSeparator }
     override var border: UIColor { return UIColor.Photon.Grey60 }
     override var buttonContainerBorder: UIColor { return separator }

--- a/Client/Frontend/Widgets/HistoryBackButton.swift
+++ b/Client/Frontend/Widgets/HistoryBackButton.swift
@@ -11,23 +11,21 @@ private struct HistoryBackButtonUX {
     static let HistoryHistoryBackButtonHeaderChevronLineWidth: CGFloat = 3.0
 }
 
-class HistoryBackButton: UIButton {
+class HistoryBackButton: UIButton, Themeable {
     lazy var title: UILabel = {
         let label = UILabel()
-        label.textColor = UIColor.theme.general.highlightBlue
         label.text = Strings.HistoryBackButtonTitle
         return label
     }()
 
     lazy var chevron: ChevronView = {
         let chevron = ChevronView(direction: .left)
-        chevron.tintColor = UIColor.theme.general.highlightBlue
         chevron.lineWidth = HistoryBackButtonUX.HistoryHistoryBackButtonHeaderChevronLineWidth
         return chevron
     }()
 
-    lazy var topBorder: UIView = self.createBorderView()
-    lazy var bottomBorder: UIView = self.createBorderView()
+    let topBorder = UIView()
+    let bottomBorder = UIView()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -36,8 +34,6 @@ class HistoryBackButton: UIButton {
         addSubview(topBorder)
         addSubview(chevron)
         addSubview(title)
-
-        backgroundColor = UIColor.theme.tableView.headerBackground
 
         chevron.snp.makeConstraints { make in
             make.leading.equalTo(self.safeArea.leading).offset(HistoryBackButtonUX.HistoryHistoryBackButtonHeaderChevronInset)
@@ -56,15 +52,18 @@ class HistoryBackButton: UIButton {
             make.top.equalTo(self).offset(-0.5)
             make.height.equalTo(0.5)
         }
-    }
 
-    fileprivate func createBorderView() -> UIView {
-        let view = UIView()
-        view.backgroundColor = UIColor.theme.homePanel.siteTableHeaderBorder
-        return view
+        applyTheme()
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    func applyTheme() {
+        title.textColor = UIColor.theme.general.highlightBlue
+        chevron.tintColor = UIColor.theme.general.highlightBlue
+        backgroundColor = UIColor.theme.tableView.headerBackground
+        [topBorder, bottomBorder].forEach { $0.backgroundColor = UIColor.theme.homePanel.siteTableHeaderBorder }
     }
 }


### PR DESCRIPTION
When digging here, I found a few more theme nits (not just the Sync Device panel welcome screen):
- remote tabs panel didn't live update, nor did the history back button
- remove profile implicitly unwrapped property