### PR TITLE
Bug 1421082 - Reports of Sync Not Working After Successful Login

### DIFF
--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -114,6 +114,11 @@ class HistoryPanel: SiteTableViewController, HomePanel {
     }
 
     func updateSyncedDevicesCount() -> Success {
+        guard self.profile.hasSyncableAccount() else {
+            self.currentSyncedDevicesCount = 0
+            return succeed()
+        }
+
         return chainDeferred(self.profile.getCachedClientsAndTabs()) { tabsAndClients in
             self.currentSyncedDevicesCount = tabsAndClients.count
             return succeed()


### PR DESCRIPTION
I solved it!

The issue was that we were unable to open `logins.db` after migrating to a new device because the Keychain keys were missing. Because of that, the entire Sync process was stopping almost immediately after beginning because the DB was closed. This PR also fixes one other cosmetic issue which is that the table view cell showing remote tabs should indicate that we're not logged in while we're in this state (logged out due to no keys).