### PR TITLE
Add Archive pre-action call to scheme-postbuild script

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
@@ -328,5 +328,23 @@
    <ArchiveAction
       buildConfiguration = "Fennec"
       revealArchiveInOrganizer = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "sh &quot;${SRCROOT}/test-fixtures/scheme-postbuild.sh&quot; || exit 1">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+                     BuildableName = "Client.app"
+                     BlueprintName = "Client"
+                     ReferencedContainer = "container:Client.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
    </ArchiveAction>
 </Scheme>


### PR DESCRIPTION
Our test runner is trying to access a database for each test class that is stored in the `test-fixtures` directory of the  project. Our scheme defines a pre-action step for the Test action that copies the databases to the app bundle but it’s missing that step for the Archive action.

@npark-mozilla can you verify if these two automatically inserted lines are expected?

`                   BuildableIdentifier = "primary"
                     BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
`