### PR TITLE
Fix grammar snack bar

### DIFF
--- a/Client/Frontend/Widgets/SnackBar.swift
+++ b/Client/Frontend/Widgets/SnackBar.swift
@@ -141,7 +141,7 @@ class SnackBar: UIView {
 
         titleView.snp.makeConstraints { make in
             make.top.equalTo(self).offset(UIConstants.DefaultPadding)
-            make.height.equalTo(UIConstants.SnackbarButtonHeight - 2 * UIConstants.DefaultPadding)
+            make.height.greaterThanOrEqualTo(UIConstants.SnackbarButtonHeight - 2 * UIConstants.DefaultPadding)
             make.centerX.equalTo(self).priority(500)
             make.width.lessThanOrEqualTo(self).inset(UIConstants.DefaultPadding * 2).priority(1000)
         }

--- a/Client/Frontend/Widgets/SnackBar.swift
+++ b/Client/Frontend/Widgets/SnackBar.swift
@@ -37,6 +37,7 @@ class SnackButton: UIButton {
         } else {
             titleLabel?.font = DynamicFontHelper.defaultHelper.DefaultStandardFont
         }
+        titleLabel?.adjustsFontForContentSizeCategory = false
         setTitle(title, for: .normal)
         setTitleColor(UIColor.theme.snackbar.highlightText, for: .highlighted)
         setTitleColor(UIColor.theme.snackbar.title, for: .normal)


### PR DESCRIPTION
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

The constraints were correct, but because the labels were made with dynamicfonthelper, the sizes changed when I set a text size in iphone settings. I removed the automatic adjustment and it works now.

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [ ] My patch has a standard commit message that looks like `Bug 12345678 - This fixes something something`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
