### PR TITLE
Bug 1478310 - XCUITest fix SearchWithFirefox test failure due to bug

### DIFF
--- a/XCUITests/BaseTestCase.swift
+++ b/XCUITests/BaseTestCase.swift
@@ -64,7 +64,7 @@ class BaseTestCase: XCTestCase {
         waitFor(element, with: "exists != true", timeout: timeoutValue, file: file, line: line)
     }
 
-    func waitForValueContains(_ element: XCUIElement, value: String, file: String = #file, line: UInt = #line) {
+    func waitForValueContains(_ element: XCUIElement, value: String, timeout: TimeInterval = 5.0, file: String = #file, line: UInt = #line) {
         waitFor(element, with: "value CONTAINS '\(value)'", file: file, line: line)
     }
 

--- a/XCUITests/SearchTest.swift
+++ b/XCUITests/SearchTest.swift
@@ -190,7 +190,7 @@ class SearchTests: BaseTestCase {
         waitforExistence(app.menuItems["Search with Firefox"])
         app.menuItems["Search with Firefox"].tap()
         waitUntilPageLoad()
-        waitForValueContains(app.textFields["url"], value: "google")
+        waitForValueContains(app.textFields["url"], value: "google", timeout: 10)
         // Now there should be two tabs open
         let numTab = app.buttons["Show Tabs"].value as? String
         XCTAssertEqual("2", numTab)


### PR DESCRIPTION
This PR adds a workaround so that the test does not fail due to an existing bug while it is being fixed and will avoid timing issues in the future.

Also adds a way to wait for an element which has certain value for sometime.