### PR TITLE
Bug 1478010 - search with firefox comes up directly after button press

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1002,6 +1002,18 @@ class BrowserViewController: UIViewController {
         }
     }
 
+    func openSearchNewTab(isPrivate: Bool = false, _ text: String) {
+        popToBVC()
+        let engine = profile.searchEngines.defaultEngine
+        if let searchURL = engine.searchURLForQuery(text) {
+            openURLInNewTab(searchURL, isPrivate: isPrivate, isPrivileged: true)
+        } else {
+            // We still don't have a valid URL, so something is broken. Give up.
+            print("Error handling URL entry: \"\(text)\".")
+            assertionFailure("Couldn't generate search URL: \(text)")
+        }
+    }
+
     fileprivate func popToBVC() {
         guard let currentViewController = navigationController?.topViewController else {
                 return
@@ -1696,11 +1708,7 @@ extension BrowserViewController: TabDelegate {
     }
 
     func tab(_ tab: Tab, didSelectSearchWithFirefoxForSelection selection: String) {
-        let currentChoice = NewTabAccessors.getNewTabPage(self.profile.prefs)
-        self.profile.prefs.setString(NewTabPage.blankPage.rawValue, forKey: NewTabAccessors.PrefKey)
-        openBlankNewTab(focusLocationField: false, isPrivate: tab.isPrivate)
-        submitSearchText(selection)
-        self.profile.prefs.setString(currentChoice.rawValue, forKey: NewTabAccessors.PrefKey)
+        openSearchNewTab(isPrivate: tab.isPrivate, selection)
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1696,8 +1696,11 @@ extension BrowserViewController: TabDelegate {
     }
 
     func tab(_ tab: Tab, didSelectSearchWithFirefoxForSelection selection: String) {
+        let currentChoice = NewTabAccessors.getNewTabPage(self.profile.prefs)
+        self.profile.prefs.setString(NewTabPage.blankPage.rawValue, forKey: NewTabAccessors.PrefKey)
         openBlankNewTab(focusLocationField: false, isPrivate: tab.isPrivate)
         submitSearchText(selection)
+        self.profile.prefs.setString(currentChoice.rawValue, forKey: NewTabAccessors.PrefKey)
     }
 }
 


### PR DESCRIPTION
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Homepage, or whatever the user set as default does not show anymore when clicking search with firefox.

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [ ] My patch has a standard commit message that looks like `Bug 12345678 - This fixes something something`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
