### PR TITLE
Bug 1477955 - Settings description text should have smaller font. 

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -21,7 +21,6 @@ extension UILabel {
             textColor = UIColor.theme.tableView.rowText
         } else {
             textColor = nil
-            font = nil
         }
         attributedText = attributed
     }


### PR DESCRIPTION
clearing the font removes styling applied by the cell in setup