### PR TITLE
Bug 1478791 - Upgrade Sentry to 4.0.1

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-github "getsentry/sentry-cocoa"             "3.12.4"
+github "getsentry/sentry-cocoa"             "4.0.1"
 github "Alamofire/Alamofire"                ~> 4.0
 github "sleroux/Deferred"                   "Swift3.0"
 github "SnapKit/SnapKit"                    "3.1.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "getsentry/sentry-cocoa" "3.12.4"
+github "getsentry/sentry-cocoa" "4.0.1"
 github "Alamofire/Alamofire" "4.3.0"
 github "sleroux/Deferred" "35b8927c1b94ce074e10793c57e1f80d0e2227fa"
 github "cezheng/Fuzi" "2.0.2"


### PR DESCRIPTION
This patch upgraded Sentry to 4.0.1.