### PR TITLE
Bug 1477382 - minor dark theme fixes

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -175,7 +175,6 @@ class BrowserViewController: UIViewController {
 
     @objc func displayThemeChanged(notification: Notification) {
         applyTheme()
-        setNeedsStatusBarAppearanceUpdate()
     }
 
     func shouldShowFooterForTraitCollection(_ previousTraitCollection: UITraitCollection) -> Bool {

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -27,8 +27,8 @@ private struct SearchViewControllerUX {
     static let SearchImageHeight: Float = 44
     static let SearchImageWidth: Float = 24
 
-    static let SuggestionBackgroundColor = UIColor.Photon.White100
-    static let SuggestionBorderColor = UIColor.theme.general.highlightBlue
+    static let SuggestionBackgroundColor = UIColor.theme.homePanel.searchSuggestionPilBackground
+    static let SuggestionBorderColor = UIColor.theme.homePanel.searchSuggestionPillForeground
     static let SuggestionBorderWidth: CGFloat = 1
     static let SuggestionCornerRadius: CGFloat = 4
     static let SuggestionInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
@@ -394,8 +394,8 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
                     let isBookmark = site.bookmarked ?? false
                     cell.setLines(site.title, detailText: site.url)
                     cell.setRightBadge(isBookmark ? self.bookmarkedBadge : nil)
-                    cell.imageView!.layer.borderColor = SearchViewControllerUX.IconBorderColor.cgColor
-                    cell.imageView!.layer.borderWidth = SearchViewControllerUX.IconBorderWidth
+                    cell.imageView?.layer.borderColor = SearchViewControllerUX.IconBorderColor.cgColor
+                    cell.imageView?.layer.borderWidth = SearchViewControllerUX.IconBorderWidth
                     cell.imageView?.setIcon(site.icon, forURL: site.tileURL, completed: { (color, url) in
                         if site.tileURL == url {
                             cell.imageView?.image = cell.imageView?.image?.createScaled(CGSize(width: SearchViewControllerUX.IconSize, height: SearchViewControllerUX.IconSize))
@@ -680,7 +680,7 @@ fileprivate class SuggestionButton: InsetButton {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        setTitleColor(UIColor.theme.general.highlightBlue, for: [])
+        setTitleColor(UIColor.theme.homePanel.searchSuggestionPillForeground, for: [])
         setTitleColor(UIColor.Photon.White100, for: .highlighted)
         titleLabel?.font = DynamicFontHelper.defaultHelper.DefaultMediumFont
         backgroundColor = SearchViewControllerUX.SuggestionBackgroundColor

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -255,5 +255,6 @@ extension TopTabsViewController: Themeable, PrivateModeUI {
         newTab.tintColor = UIColor.theme.topTabs.buttonTint
         view.backgroundColor = UIColor.theme.topTabs.background
         collectionView.backgroundColor = view.backgroundColor
+        collectionView.reloadData()
     }
 }

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -255,6 +255,6 @@ extension TopTabsViewController: Themeable, PrivateModeUI {
         newTab.tintColor = UIColor.theme.topTabs.buttonTint
         view.backgroundColor = UIColor.theme.topTabs.background
         collectionView.backgroundColor = view.backgroundColor
-        collectionView.reloadData()
+        tabDisplayManager.reloadData()
     }
 }

--- a/Client/Frontend/Home/DownloadsPanel.swift
+++ b/Client/Frontend/Home/DownloadsPanel.swift
@@ -343,6 +343,13 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
         return configureDownloadedFile(cell, for: indexPath)
     }
 
+    func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        if let header = view as? UITableViewHeaderFooterView {
+            header.textLabel?.textColor = UIColor.theme.tableView.headerTextDark
+            header.contentView.backgroundColor = UIColor.theme.tableView.headerBackground
+        }
+    }
+
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         guard groupedDownloadedFiles.itemsForSection(section).count > 0 else { return nil }
 

--- a/Client/Frontend/Home/RemoteTabsPanel.swift
+++ b/Client/Frontend/Home/RemoteTabsPanel.swift
@@ -176,12 +176,13 @@ class RemoteTabsPanelClientAndTabsDataSource: NSObject, RemoteTabsPanelDataSourc
 
         let image: UIImage?
         if client.type == "desktop" {
-            image = UIImage(named: "deviceTypeDesktop")
+            image = UIImage.templateImageNamed("deviceTypeDesktop")
             image?.accessibilityLabel = NSLocalizedString("computer", comment: "Accessibility label for Desktop Computer (PC) image in remote tabs list")
         } else {
-            image = UIImage(named: "deviceTypeMobile")
+            image = UIImage.templateImageNamed("deviceTypeMobile")
             image?.accessibilityLabel = NSLocalizedString("mobile device", comment: "Accessibility label for Mobile Device image in remote tabs list")
         }
+        view.imageView.tintColor = UIColor.theme.tableView.rowText
         view.imageView.image = image
         view.imageView.contentMode = .center
 

--- a/Client/Frontend/Settings/SettingsNavigationController.swift
+++ b/Client/Frontend/Settings/SettingsNavigationController.swift
@@ -16,7 +16,20 @@ class SettingsNavigationController: UINavigationController {
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return .default
+        return ThemeManager.instance.statusBarStyle
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        applyTheme()
+    }
+}
+
+extension SettingsNavigationController: Themeable {
+    func applyTheme() {
+        navigationBar.barTintColor = UIColor.theme.tableView.headerBackground
+        navigationBar.titleTextAttributes = [NSAttributedStringKey.foregroundColor: UIColor.theme.tableView.headerTextDark]
+        setNeedsStatusBarAppearanceUpdate()
     }
 }
 

--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -133,6 +133,9 @@ fileprivate class DarkHomePanelColor: HomePanelColor {
 
     override var readingListActive: UIColor { return UIColor.Photon.Grey10 }
     override var readingListDimmed: UIColor { return UIColor.Photon.Grey40 }
+
+    override var searchSuggestionPilBackground: UIColor { return UIColor.Photon.Ink80 }
+    override var searchSuggestionPillForeground: UIColor { return defaultTextAndTint }
 }
 
 fileprivate class DarkSnackBarColor: SnackBarColor {

--- a/Client/Frontend/Theme/Theme.swift
+++ b/Client/Frontend/Theme/Theme.swift
@@ -151,6 +151,9 @@ class HomePanelColor {
     var downloadedFileIcon: UIColor { return UIColor.Photon.Grey60 }
     
     var historyHeaderIconsBackground: UIColor { return UIColor.Photon.White100 }
+
+    var searchSuggestionPilBackground: UIColor { return UIColor.Photon.White100 }
+    var searchSuggestionPillForeground: UIColor { return UIColor.theme.general.highlightBlue }
 }
 
 class SnackBarColor {

--- a/Client/Frontend/Theme/ThemedWidgets.swift
+++ b/Client/Frontend/Theme/ThemedWidgets.swift
@@ -45,6 +45,9 @@ class ThemedTableViewController: UITableViewController, Themeable {
         tableView.reloadData()
 
         (tableView.tableHeaderView as? Themeable)?.applyTheme()
+
+        // Update the settings navigation bar
+        (navigationController as? Themeable)?.applyTheme()
     }
 }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1477382

- Top navigation bar settings not theming
- invert pills on search suggestion
- remote tabs panel device icon tint (currently black and icons are invisible) 
- downloads panel header text
- top tabs update when changing theme
