### PR TITLE
Bug 1479843 - Optimize top sites query

### DIFF
--- a/Client/Frontend/Home/PanelDataObservers.swift
+++ b/Client/Frontend/Home/PanelDataObservers.swift
@@ -72,17 +72,21 @@ class ActivityStreamDataObserver: DataObserver {
             return
         }
 
+        // Flip the `KeyTopSitesCacheIsValid` flag now to prevent subsequent calls to refresh
+        // from re-invalidating the cache.
+        if shouldInvalidateTopSites {
+            self.profile.prefs.setBool(true, forKey: PrefsKeys.KeyTopSitesCacheIsValid)
+        }
+
+        // Set the `ASLastInvalidation` timestamp now to prevent subsequent calls to refresh
+        // from re-invalidating the cache.
+        if shouldInvalidateHighlights {
+            let newInvalidationTime = shouldInvalidateHighlights ? Date.now() : lastInvalidationTime
+            self.profile.prefs.setLong(newInvalidationTime, forKey: PrefsKeys.ASLastInvalidation)
+        }
+
         self.delegate?.willInvalidateDataSources(forceHighlights: highlights, forceTopSites: topSites)
         self.profile.recommendations.repopulate(invalidateTopSites: shouldInvalidateTopSites, invalidateHighlights: shouldInvalidateHighlights).uponQueue(.main) { _ in
-            if shouldInvalidateTopSites {
-                self.profile.prefs.setBool(true, forKey: PrefsKeys.KeyTopSitesCacheIsValid)
-            }
-
-            if shouldInvalidateHighlights {
-                let newInvalidationTime = shouldInvalidateHighlights ? Date.now() : lastInvalidationTime
-                self.profile.prefs.setLong(newInvalidationTime, forKey: PrefsKeys.ASLastInvalidation)
-            }
-
             self.delegate?.didInvalidateDataSources(refresh: highlights || topSites, highlightsRefreshed: shouldInvalidateHighlights, topSitesRefreshed: shouldInvalidateTopSites)
         }
     }

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -574,11 +574,21 @@ fileprivate struct SQLiteFrecentHistory: FrecentHistory {
                 coalesce(sum(CASE visits.is_local WHEN 1 THEN 0 ELSE 1 END), 0) AS remoteVisitCount
             FROM history
                 INNER JOIN (
-                    SELECT COUNT(rowid) AS visitCount, siteID
-                    FROM visits
-                    GROUP BY siteID
-                    ORDER BY visitCount DESC
-                    LIMIT 5000
+                    SELECT siteID FROM (
+                        SELECT COUNT(rowid) AS visitCount, siteID
+                        FROM visits
+                        GROUP BY siteID
+                        ORDER BY visitCount DESC
+                        LIMIT 5000
+                    )
+                    UNION ALL
+                    SELECT siteID FROM (
+                        SELECT siteID
+                        FROM visits
+                        GROUP BY siteID
+                        ORDER BY max(date) DESC
+                        LIMIT 1000
+                    )
                 ) AS groupedVisits ON
                     groupedVisits.siteID = history.id
                 INNER JOIN domains ON

--- a/Sync/SyncConstants.swift
+++ b/Sync/SyncConstants.swift
@@ -8,5 +8,5 @@ public struct SyncConstants {
     // Suitable for use in dispatch_time().
     public static let SyncDelayTriggered: Int = 3000
     public static let SyncOnForegroundMinimumDelayMillis: UInt64 = 5 * 60 * 1000
-    public static let SyncOnForegroundAfterMillis: Int64 = 5000
+    public static let SyncOnForegroundAfterMillis: Int64 = 10000
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1479843

This query effectively only considers the top 5,000 most-visited sites in the `history` table before running the frecency query.

We update the cached top sites by running this query shortly after startup which causes any Awesomebar searches to have to wait in the DB queue. With large data sets, the old version of this query could take several seconds. This patch should resolve in a considerable improvement in startup time as well as time for first search to complete.

Here's the timings for the old vs. new queries on my laptop:

Old:
`Run Time: real 1.474 user 1.209664 sys 0.181942`

New:
`Run Time: real 0.136 user 0.130527 sys 0.004912`

CC: @rnewman for input on whether or not this approach makes sense