### PR TITLE
Bug 1478701 - Dark theme breaks Settings > Require Passcode

### DIFF
--- a/Client/Frontend/AuthenticationManager/RequirePasscodeIntervalViewController.swift
+++ b/Client/Frontend/AuthenticationManager/RequirePasscodeIntervalViewController.swift
@@ -62,6 +62,7 @@ class RequirePasscodeIntervalViewController: UITableViewController {
         let intervalTitle = NSAttributedString.tableRowTitle(option.settingTitle, enabled: true)
         cell.textLabel?.attributedText = intervalTitle
         cell.accessoryType = authenticationInfo?.requiredPasscodeInterval == option ? .checkmark : .none
+        cell.backgroundColor = UIColor.theme.tableView.rowBackground
         return cell
     }
 


### PR DESCRIPTION
Fixed:
<img width="369" alt="image" src="https://user-images.githubusercontent.com/5495083/43477725-eec8fa28-94c9-11e8-9c34-32547578b0ce.png">
