### PR TITLE
Bug 1480033 - Fix UI Tracking Protection Tests

### DIFF
--- a/UITests/TrackingProtectionTests.swift
+++ b/UITests/TrackingProtectionTests.swift
@@ -123,7 +123,7 @@ class TrackingProtectionTests: KIFTestCase, TabEventHandler {
 
         // Scroll to Tracking Protection Menu
         EarlGrey.selectElement(with:grey_accessibilityLabel("Tracking Protection"))
-            .using(searchAction: grey_scrollInDirection(GREYDirection.down, 200),
+            .using(searchAction: grey_scrollInDirection(GREYDirection.down, 400),
                    onElementWithMatcher: grey_kindOfClass(UITableView.self))
             .assert(grey_notNil())
             .perform(grey_tap())


### PR DESCRIPTION
PR to fix the UI Tracking Protection Tests, the menu in settings screen was not available when scrolling down.