### PR TITLE
Bug 1478598 - XCUITest Select the correct Top Site

### DIFF
--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -158,6 +158,7 @@ class ActivityStreamTest: BaseTestCase {
 
     func testTopSitesOpenInNewTab() {
         navigator.goto(HomePanelsScreen)
+        waitforExistence(TopSiteCellgroup.cells["apple"])
         TopSiteCellgroup.cells["apple"].press(forDuration: 1)
         app.tables["Context Menu"].cells["Open in New Tab"].tap()
         XCTAssert(TopSiteCellgroup.exists)

--- a/XCUITests/PhotonActionSheetTest.swift
+++ b/XCUITests/PhotonActionSheetTest.swift
@@ -15,8 +15,8 @@ class PhotonActionSheetTest: BaseTestCase {
         navigator.goto(NewTabScreen)
 
         // Verify that the site is pinned to top
-        let cell = app.cells["TopSite"].firstMatch
-        XCTAssertEqual(cell.label, "example")
+        let cell = app.cells["example"]
+        waitforExistence(cell)
 
         // Remove pin
         cell.press(forDuration: 2)


### PR DESCRIPTION
PR to fix the issue that is affecting some tests, when defining a top site in the test to tap, the tap is done on a different one