### PR TITLE
Bug 1480336 - Fix UI LoginManagerTests

### DIFF
--- a/UITests/LoginManagerTests.swift
+++ b/UITests/LoginManagerTests.swift
@@ -686,6 +686,7 @@ class LoginManagerTests: KIFTestCase {
         var passwordField = passwordCell.descriptionLabel
 
         tester().tapView(withAccessibilityLabel: "Next")
+        tester().waitForAnimationsToFinish()
         tester().clearTextFromAndThenEnterText(intoCurrentFirstResponder: "")
         tester().tapView(withAccessibilityLabel: "Done")
 

--- a/UITests/LoginManagerTests.swift
+++ b/UITests/LoginManagerTests.swift
@@ -36,17 +36,10 @@ class LoginManagerTests: KIFTestCase {
             return success
         })
 
-        if BrowserUtils.iPad() {
-            EarlGrey.selectElement(with: grey_accessibilityLabel("Menu")).perform(grey_tap())
-            let settings_button = grey_allOf([grey_accessibilityLabel("Settings"),
-                                              grey_accessibilityID("menu-Settings")])
-            EarlGrey.selectElement(with: settings_button).perform(grey_tap())
-        } else {
-            let menu_button = grey_allOf([grey_accessibilityLabel("Menu"),
+        let menu_button = grey_allOf([grey_accessibilityLabel("Menu"),
                                           grey_accessibilityID("TabToolbar.menuButton")])
-            EarlGrey.selectElement(with: menu_button).perform(grey_tap())
-            EarlGrey.selectElement(with: grey_text("Settings")).perform(grey_tap())
-        }
+        EarlGrey.selectElement(with: menu_button).perform(grey_tap())
+        EarlGrey.selectElement(with: grey_text("Settings")).perform(grey_tap())
 
         let success = menuAppeared.wait(withTimeout: 20)
         GREYAssertTrue(success, reason: "Failed to display settings dialog")
@@ -57,7 +50,12 @@ class LoginManagerTests: KIFTestCase {
                 .assert(grey_notNil())
         }
 
-        EarlGrey.selectElement(with: grey_accessibilityLabel("Logins")).perform(grey_tap())
+        EarlGrey.selectElement(with:grey_accessibilityLabel("Tracking Protection"))
+            .using(searchAction: grey_scrollInDirection(GREYDirection.down, 400),
+                   onElementWithMatcher: grey_kindOfClass(UITableView.self))
+            .assert(grey_notNil())
+
+        EarlGrey.selectElement(with: grey_accessibilityID("Logins")).perform(grey_tap())
     }
 
     fileprivate func closeLoginManager() {

--- a/UITests/LoginManagerTests.swift
+++ b/UITests/LoginManagerTests.swift
@@ -287,12 +287,12 @@ class LoginManagerTests: KIFTestCase {
         }
 
         if BrowserUtils.iPad() {
-            EarlGrey.selectElement(with: grey_accessibilityLabel("Logins"))
+            EarlGrey.selectElement(with: grey_accessibilityLabel("Tracking Protection"))
                 .using(searchAction: grey_scrollInDirection(.down, 200),
                        onElementWithMatcher: grey_accessibilityID("AppSettingsTableViewController.tableView"))
                 .assert(grey_notNil())
         }
-        EarlGrey.selectElement(with: grey_accessibilityLabel("Logins")).perform(grey_tap())
+        EarlGrey.selectElement(with: grey_accessibilityID("Logins")).perform(grey_tap())
 
         tester().waitForView(withAccessibilityLabel: "a0@email.com, http://a0.com")
         tester().tapView(withAccessibilityLabel: "a0@email.com, http://a0.com")


### PR DESCRIPTION
This PR fixes the Login Manager tests that were failing on ipad due to the need to scroll to get to the Logins menu now that there is a new item in the menu settings list