### PR TITLE
Bug 1480343 - Integration Tests Remove Jenkins ignore

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
             steps {
                 dir('SyncIntegrationTests') {
                     sh 'pipenv install'
-                    sh 'pipenv check -i 36351' // Ignoring vulnerability due to https://github.com/pyupio/safety-db/issues/2272
+                    sh 'pipenv check'
                     sh 'pipenv run pytest ' +
                         '--color=yes ' +
                         '--junit-xml=results/junit.xml ' +


### PR DESCRIPTION
Now that the external issue is fixed we can remove the ignore line added just in case we are missing some vulnerabilities.