### PR TITLE
Bug 1480551 - Improve HistoryPanel query

### DIFF
--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -149,7 +149,7 @@ class HistoryPanel: SiteTableViewController, HomePanel {
     }
 
     private func fetchData() -> Deferred<Maybe<Cursor<Site>>> {
-        return profile.history.getSitesByLastVisit(QueryLimit)
+        return profile.history.getSitesByLastVisit(limit: QueryLimit, offset: 0)
     }
 
     private func setData(_ data: Cursor<Site>) {

--- a/ClientTests/MockableHistory.swift
+++ b/ClientTests/MockableHistory.swift
@@ -25,7 +25,7 @@ class MockableHistory: BrowserHistory, SyncableHistory, ResettableSyncStorage {
     func isPinnedTopSite(_ url: String) -> Deferred<Maybe<Bool>> { fatalError()}
     func addPinnedTopSite(_ site: Site) -> Success { fatalError() }
     func getPinnedTopSites() -> Deferred<Maybe<Cursor<Site>>> { fatalError() }
-    func getSitesByLastVisit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>> { fatalError() }
+    func getSitesByLastVisit(limit: Int, offset: Int) -> Deferred<Maybe<Cursor<Site>>> { fatalError() }
     func setTopSitesNeedsInvalidation() { fatalError() }
     func updateTopSitesCacheIfInvalidated() -> Deferred<Maybe<Bool>> { fatalError() }
     func setTopSitesCacheSize(_ size: Int32) { fatalError() }

--- a/ClientTests/TestHistory.swift
+++ b/ClientTests/TestHistory.swift
@@ -17,7 +17,7 @@ class TestHistory: ProfileTest {
 
     fileprivate func innerCheckSites(_ history: BrowserHistory, callback: @escaping (_ cursor: Cursor<Site>) -> Void) {
         // Retrieve the entry
-        history.getSitesByLastVisit(100).upon {
+        history.getSitesByLastVisit(limit: 100, offset: 0).upon {
             XCTAssertTrue($0.isSuccess)
             callback($0.successValue!)
         }
@@ -25,7 +25,7 @@ class TestHistory: ProfileTest {
 
     fileprivate func checkSites(_ history: BrowserHistory, urls: [String: String], s: Bool = true) {
         // Retrieve the entry.
-        if let cursor = history.getSitesByLastVisit(100).value.successValue {
+        if let cursor = history.getSitesByLastVisit(limit: 100, offset: 0).value.successValue {
             XCTAssertEqual(cursor.status, CursorStatus.success, "Returned success \(cursor.statusMessage).")
             XCTAssertEqual(cursor.count, urls.count, "Cursor has \(urls.count) entries.")
 
@@ -47,7 +47,7 @@ class TestHistory: ProfileTest {
 
     fileprivate func checkVisits(_ history: BrowserHistory, url: String) {
         let expectation = self.expectation(description: "Wait for history")
-        history.getSitesByLastVisit(100).upon { result in
+        history.getSitesByLastVisit(limit: 100, offset: 0).upon { result in
             XCTAssertTrue(result.isSuccess)
             history.getFrecentHistory().getSites(whereURLContains: url, historyLimit: 100, bookmarksLimit: 0).upon { result in
                 XCTAssertTrue(result.isSuccess)

--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -25,7 +25,7 @@ public protocol BrowserHistory {
     func removeSiteFromTopSites(_ site: Site) -> Success
     func removeHostFromTopSites(_ host: String) -> Success
     func getFrecentHistory() -> FrecentHistory
-    func getSitesByLastVisit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>>
+    func getSitesByLastVisit(limit: Int, offset: Int) -> Deferred<Maybe<Cursor<Site>>>
     func getTopSitesWithLimit(_ limit: Int) -> Deferred<Maybe<Cursor<Site>>>
     func setTopSitesNeedsInvalidation()
     func setTopSitesCacheSize(_ size: Int32)

--- a/StorageTests/TestSQLiteHistory.swift
+++ b/StorageTests/TestSQLiteHistory.swift
@@ -1078,7 +1078,7 @@ class TestSQLiteHistory: XCTestCase {
 
         let prefs = MockProfilePrefs()
         let history = SQLiteHistory(db: db, prefs: prefs)
-        let results = history.getSitesByLastVisit(10).value.successValue
+        let results = history.getSitesByLastVisit(limit: 10, offset: 0).value.successValue
         XCTAssertNotNil(results)
         XCTAssertEqual(results![0]?.url, "http://www.example.com")
 
@@ -1217,7 +1217,7 @@ class TestSQLiteHistory: XCTestCase {
 
         func checkSitesByDate(_ f: @escaping (Cursor<Site>) -> Success) -> () -> Success {
             return {
-                history.getSitesByLastVisit(10)
+                history.getSitesByLastVisit(limit: 10, offset: 0)
                 >>== f
             }
         }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1480551

In my measurements, this new query is about 20-25% faster than the old one. It also allows us to fetch an offset so we can now do pagination (infinite scrolling) in the HistoryPanel. Hence, this PR alters our API in Storage to accept an `offset` argument.