### PR TITLE
Bug 1481431 - Fix top tabs animation when selecting tab. 

### DIFF
--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -216,7 +216,7 @@ class TopTabsViewController: UIViewController {
 extension TopTabsViewController: TabDisplayer {
 
     func focusSelectedTab() {
-        self.scrollToCurrentTab(true, centerCell: true)
+        self.scrollToCurrentTab(true)
     }
 
     func cellFactory(for cell: UICollectionViewCell, using tab: Tab) -> UICollectionViewCell {


### PR DESCRIPTION
Centering the tab in the viewport was causing issues where the animations would look off when selecting a tab.