### PR TITLE
Bug 1479943 -  Dark mode automatic setting label not fitting long L10N label

### DIFF
--- a/Client/Frontend/Settings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettingsController.swift
@@ -126,6 +126,9 @@ class ThemeSettingsController: ThemedTableViewController {
             if indexPath.row == 0 {
                 cell.textLabel?.text = Strings.DisplayThemeAutomaticSwitchTitle
                 cell.detailTextLabel?.text = Strings.DisplayThemeAutomaticSwitchSubtitle
+                cell.detailTextLabel?.numberOfLines = 2
+                cell.detailTextLabel?.minimumScaleFactor = 0.5
+                cell.detailTextLabel?.adjustsFontSizeToFitWidth = true
 
                 let control = UISwitch()
                 control.onTintColor = UIColor.theme.tableView.controlTint


### PR DESCRIPTION
Allow a 2nd line, and if that fills up, enable shrinking the font.