### PR TITLE
Bug 1481452 - Fix focusTab behaviour

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -141,10 +141,10 @@ class TabTrayController: UIViewController {
     }
 
     func focusTab() {
-        guard let currentTab = tabManager.selectedTab, let index = self.tabDisplayManager.tabStore.index(of: currentTab) else {
+        guard let currentTab = tabManager.selectedTab, let index = self.tabDisplayManager.tabStore.index(of: currentTab), let rect = self.collectionView.layoutAttributesForItem(at: IndexPath(item: index, section: 0))?.frame else {
             return
         }
-        self.collectionView.scrollToItem(at: IndexPath(item: index, section: 0), at: .bottom, animated: false)
+        self.collectionView.scrollRectToVisible(rect, animated: false)
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
- Fix focusTab behaviour

After long investigation I realised that for an unknown reason collectionView.scrollToItem does not work for iPhone8, it simply does not trigger scrollViewDidScroll. 
I have checked all constraints and everything that came to my mind and I did not found solution... but!
I have found in documentation different method (scrollRectToVisible) which do almost the same job and works perfectly. 
