### PR TITLE
Bug 1480563 - Displayed page doesn't match long-press handling

### DIFF
--- a/Client/Frontend/Browser/ContextMenuHelper.swift
+++ b/Client/Frontend/Browser/ContextMenuHelper.swift
@@ -45,11 +45,9 @@ class ContextMenuHelper: NSObject {
             return
         }
 
-        guard sender.state == .began, let elements = self.elements else {
+        guard sender.state == .began else {
             return
         }
-
-        delegate?.contextMenuHelper(self, didLongPressElements: elements, gestureRecognizer: sender)
 
         // To prevent the tapped link from proceeding with navigation, "cancel" the native WKWebView
         // `_highlightLongPressRecognizer`. This preserves the original behavior as seen here:
@@ -60,7 +58,11 @@ class ContextMenuHelper: NSObject {
             nativeHighlightLongPressRecognizer.isEnabled = true
         }
 
-        self.elements = nil
+        if let elements = self.elements {
+            delegate?.contextMenuHelper(self, didLongPressElements: elements, gestureRecognizer: sender)
+
+            self.elements = nil
+        }
     }
 }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1480563

So, I don't have a good STR for this, but I'm able to see what the issue potentially is and this patch fixes it. Essentially, it used to be possible for the native gesture recognizer on the WKWebView to handle the long-press which led to unpredictable results (and the wrong context menu). This patch ensures that the native long-press detector gets cancelled regardless of the state we're in. This should prevent the native context menu from ever appearing.