### PR TITLE
Bug 1479455 - New Topsites from websites with very low frecency

### DIFF
--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -595,7 +595,7 @@ fileprivate struct SQLiteFrecentHistory: FrecentHistory {
                     domains.id = history.domain_id
                 INNER JOIN visits ON
                     visits.siteID = history.id
-            WHERE (history.is_deleted = 0) AND ((domains.showOnTopSites IS 1) AND (domains.domain NOT LIKE 'r.%') AND (domains.domain NOT LIKE 'google.%') )
+            WHERE (history.is_deleted = 0) AND ((domains.showOnTopSites IS 1) AND (domains.domain NOT LIKE 'r.%') AND (domains.domain NOT LIKE 'google.%')) AND (history.url LIKE 'http%')
             GROUP BY historyID
             """
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1479455

This removes history items from appearing in the results that do not start with `http`. The problem this aims to solve is to prevent non-web URLs (desktop extensions, etc.) from showing up in Top Sites.

NOTE: This only fixes the query for the *new* version of this query. Since this issue was reported in Beta and we'll likely ship the updated query in v14, I don't think it is necessary to fix it in the old query.