### PR TITLE
 Bug 1480428 - Dont allow toggling of PBM when a drag is active. 

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -26,7 +26,7 @@ class TabDisplayManager: NSObject {
 
     fileprivate let tabManager: TabManager
     var isPrivate = false
-    fileprivate var isDragging = false
+    var isDragging = false
     fileprivate let collectionView: UICollectionView
     typealias CompletionBlock = () -> Void
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -254,6 +254,10 @@ class TabTrayController: UIViewController {
     }
 
     @objc func didTogglePrivateMode() {
+        if tabDisplayManager.isDragging {
+            return
+        }
+
         let scaleDownTransform = CGAffineTransform(scaleX: 0.9, y: 0.9)
 
         let newOffset = CGPoint(x: 0.0, y: collectionView.contentOffset.y)
@@ -328,6 +332,10 @@ class TabTrayController: UIViewController {
     }
 
     func openNewTab(_ request: URLRequest? = nil) {
+        if tabDisplayManager.isDragging {
+            return
+        }
+
         self.tabManager.addTabAndSelect(request, isPrivate: tabDisplayManager.isPrivate)
         self.tabDisplayManager.performTabUpdates {
             self.emptyPrivateTabsView.isHidden = !self.privateTabsAreEmpty()


### PR DESCRIPTION
Steps to reproduce 
1. have a few tabs open in each browsing mode. 
2. In normal mode drag a tab around, while holding the tab switch to PBM
3. end the drag 
4. Try dragging a tab in PBM 
5. crash

Im not 100% if this is the only thing causing the crash. But the crash does seem to indicate a reordering so this is most likely it.