### PR TITLE
Bug 1478952 - Incorrect animation when closing all tabs in private mode

### DIFF
--- a/Client/Frontend/Browser/SimpleToast.swift
+++ b/Client/Frontend/Browser/SimpleToast.swift
@@ -12,6 +12,7 @@ struct SimpleToastUX {
     static let ToastFont = UIFont.systemFont(ofSize: 15)
     static let ToastDismissAfter = DispatchTimeInterval.milliseconds(4500) // 4.5 seconds.
     static let ToastDelayBefore = DispatchTimeInterval.milliseconds(0) // 0 seconds
+    static let ToastPrivateModeDelayBefore = DispatchTimeInterval.milliseconds(750)
     static let BottomToolbarHeight = CGFloat(45)
 }
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -360,7 +360,7 @@ extension TabTrayController: TabManagerDelegate {
             return
         }
         view.addSubview(toast)
-        toast.showToast(makeConstraints: { make in
+        toast.showToast(delay: SimpleToastUX.ToastPrivateModeDelayBefore, makeConstraints: { make in
             make.left.right.equalTo(self.view)
             make.bottom.equalTo(self.toolbar.snp.top)
         })


### PR DESCRIPTION
- add delay for Toast in PrivateMode

The reason why animation is incorrect is the fact that in NormalMode animation wait until we will see newly created Tab, but in PrivateMode we will not create new Tab. 
Thats why we see Undo Toast immediately so I decided to add a delay to showToast.