### PR TITLE
Bug 1482169 - live theme change: search pills not updating

### DIFF
--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -27,8 +27,8 @@ private struct SearchViewControllerUX {
     static let SearchImageHeight: Float = 44
     static let SearchImageWidth: Float = 24
 
-    static let SuggestionBackgroundColor = UIColor.theme.homePanel.searchSuggestionPilBackground
-    static let SuggestionBorderColor = UIColor.theme.homePanel.searchSuggestionPillForeground
+    static var SuggestionBackgroundColor: UIColor { return UIColor.theme.homePanel.searchSuggestionPillBackground }
+    static var SuggestionBorderColor: UIColor { return UIColor.theme.homePanel.searchSuggestionPillForeground }
     static let SuggestionBorderWidth: CGFloat = 1
     static let SuggestionCornerRadius: CGFloat = 4
     static let SuggestionInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)

--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -134,7 +134,7 @@ fileprivate class DarkHomePanelColor: HomePanelColor {
     override var readingListActive: UIColor { return UIColor.Photon.Grey10 }
     override var readingListDimmed: UIColor { return UIColor.Photon.Grey40 }
 
-    override var searchSuggestionPilBackground: UIColor { return UIColor.Photon.Ink80 }
+    override var searchSuggestionPillBackground: UIColor { return UIColor.Photon.Ink80 }
     override var searchSuggestionPillForeground: UIColor { return defaultTextAndTint }
 }
 

--- a/Client/Frontend/Theme/Theme.swift
+++ b/Client/Frontend/Theme/Theme.swift
@@ -152,7 +152,7 @@ class HomePanelColor {
     
     var historyHeaderIconsBackground: UIColor { return UIColor.Photon.White100 }
 
-    var searchSuggestionPilBackground: UIColor { return UIColor.Photon.White100 }
+    var searchSuggestionPillBackground: UIColor { return UIColor.Photon.White100 }
     var searchSuggestionPillForeground: UIColor { return UIColor.theme.general.highlightBlue }
 }
 


### PR DESCRIPTION
This fixes the most critical bug for 13.1, which was the app having to be restarted to change the pill color.

The remaining minor bug is that while the search suggestion pills are showing and the brightness changes they don't change their theme until the search panel is shown a second time. I'll fix this for 13.2.

