### PR TITLE
Bug 1483175 - Close all private tabs bypasses normal tab close, tab not cleaned up

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -274,7 +274,7 @@ class Tab: NSObject {
         #endif
     }
 
-    func close() {
+    func closeAndRemovePrivateBrowsingData() {
         webView?.removeObserver(self, forKeyPath: KVOConstants.URL.rawValue)
 
         if let webView = webView {
@@ -285,10 +285,7 @@ class Tab: NSObject {
         webView?.navigationDelegate = nil
         webView?.removeFromSuperview()
         webView = nil
-    }
 
-    func closeAndRemovePrivateBrowsingData() {
-        close()
         if isPrivate {
             removeAllBrowsingData()
         }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -445,17 +445,14 @@ class TabManager: NSObject {
         return false
     }
 
-    /// Removes all private tabs from the manager without notifying delegates.
     private func removeAllPrivateTabs() {
         // reset the selectedTabIndex if we are on a private tab because we will be removing it.
         if selectedTab?.isPrivate ?? false {
             _selectedIndex = -1
         }
-        tabs.forEach { tab in
-            if tab.isPrivate {
-                tab.webView?.removeFromSuperview()
-                tab.removeAllBrowsingData()
-            }
+
+        tabs.filter { $0.isPrivate }.forEach { tab in
+                tab.closeAndRemovePrivateBrowsingData()
         }
 
         tabs = tabs.filter { !$0.isPrivate }


### PR DESCRIPTION
Close all private tabs was not calling the Tab close function which calls the delegates to unhook themselves from the tab (and also ensure the Tab is dereferenced and the webview set to nil).