### PR TITLE
Bug 1480428 - Followup, Harden tab tray to prevent too many animations

### DIFF
--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -27,6 +27,9 @@ private extension TrayToBrowserAnimator {
         let displayedTabs = selectedTab.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
         guard let expandFromIndex = displayedTabs.index(of: selectedTab) else { return }
 
+        //Disable toolbar until animation completes
+        tabTray.toolbar.isUserInteractionEnabled = false
+
         bvc.view.frame = transitionContext.finalFrame(for: bvc)
 
         // Hide browser components
@@ -83,6 +86,7 @@ private extension TrayToBrowserAnimator {
             tabCollectionViewSnapshot.alpha = 0
             tabTray.statusBarBG.alpha = 0
             tabTray.searchBarHolder.alpha = 0
+            tabTray.toolbar.isUserInteractionEnabled = true
         }, completion: { finished in
             // Remove any of the views we used for the animation
             cell.removeFromSuperview()
@@ -120,6 +124,9 @@ private extension BrowserToTrayAnimator {
         let tabManager = bvc.tabManager
         let displayedTabs = selectedTab.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
         guard let scrollToIndex = displayedTabs.index(of: selectedTab) else { return }
+
+        //Disable toolbar until animation completes
+        tabTray.toolbar.isUserInteractionEnabled = false
 
         tabTray.view.frame = transitionContext.finalFrame(for: tabTray)
 
@@ -208,6 +215,7 @@ private extension BrowserToTrayAnimator {
 
                 resetTransformsForViews([bvc.header, bvc.readerModeBar, bvc.footer])
                 bvc.urlBar.isTransitioning = false
+                tabTray.toolbar.isUserInteractionEnabled = true
                 transitionContext.completeTransition(true)
             })
         }

--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -86,7 +86,6 @@ private extension TrayToBrowserAnimator {
             tabCollectionViewSnapshot.alpha = 0
             tabTray.statusBarBG.alpha = 0
             tabTray.searchBarHolder.alpha = 0
-            tabTray.toolbar.isUserInteractionEnabled = true
         }, completion: { finished in
             // Remove any of the views we used for the animation
             cell.removeFromSuperview()
@@ -97,6 +96,7 @@ private extension TrayToBrowserAnimator {
             bvc.webViewContainerBackdrop.isHidden = false
             bvc.homePanelController?.view.isHidden = false
             bvc.urlBar.isTransitioning = false
+            tabTray.toolbar.isUserInteractionEnabled = true
             transitionContext.completeTransition(true)
         })
     }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -322,7 +322,6 @@ class TabTrayController: UIViewController {
             }
             self.collectionView.alpha = 1
             self.toolbar.isUserInteractionEnabled = true
-
         }
     }
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -257,6 +257,7 @@ class TabTrayController: UIViewController {
         if tabDisplayManager.isDragging {
             return
         }
+        toolbar.isUserInteractionEnabled = false
 
         let scaleDownTransform = CGAffineTransform(scaleX: 0.9, y: 0.9)
 
@@ -320,6 +321,8 @@ class TabTrayController: UIViewController {
                 toView.removeFromSuperview()
             }
             self.collectionView.alpha = 1
+            self.toolbar.isUserInteractionEnabled = true
+
         }
     }
 
@@ -335,6 +338,8 @@ class TabTrayController: UIViewController {
         if tabDisplayManager.isDragging {
             return
         }
+        // We dismiss the tab tray once we are done. So no need to re-enable the toolbar
+        toolbar.isUserInteractionEnabled = false
 
         self.tabManager.addTabAndSelect(request, isPrivate: tabDisplayManager.isPrivate)
         self.tabDisplayManager.performTabUpdates {


### PR DESCRIPTION
This should help prevent the NSInternalInconsistencyException from triggering