### PR TITLE
Bug 1478952 - animation bug closing all tabs in private mode: fix empty tray message (part 2/2)

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -465,7 +465,14 @@ extension TabTrayController {
                 self.dismissTabTray()
             }
         } else {
-            self.emptyPrivateTabsView.isHidden = !self.privateTabsAreEmpty()
+            emptyPrivateTabsView.isHidden = !self.privateTabsAreEmpty()
+            if !emptyPrivateTabsView.isHidden {
+                // Fade in the empty private tabs message. This slow fade allows time for the closing tab animations to complete.
+                emptyPrivateTabsView.alpha = 0
+                UIView.animate(withDuration: 0.5, animations: {
+                    self.emptyPrivateTabsView.alpha = 1
+                })
+            }
         }
     }
 


### PR DESCRIPTION
The empty tray message shows immediately, which is ugly, as the closing tabs animation is still in progress and this message collides visually. 
Fading in the empty tray UIView (rather than immediately showing) avoids the problem.