### PR TITLE
Bug 1482883 - Firefox crashes while re-arranging tabs after specific steps

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -175,6 +175,7 @@ extension TabDisplayManager: UICollectionViewDragDelegate {
 
     func collectionView(_ collectionView: UICollectionView, dragSessionDidEnd session: UIDragSession) {
         isDragging = false
+        reloadData()
     }
 
     func collectionView(_ collectionView: UICollectionView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {


### PR DESCRIPTION
- reloadData when collectionView:dragSessionDidEnd

At first I did fix in func updateTabsFrom(_ oldTabs: [Tab]?, to newTabs: [Tab], on completion: (() -> Void)? = nil) but IMO this was just workaround.