### PR TITLE
Bug 1483841 - The Loading bar is briefly displayed only after the page is loaded

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -856,10 +856,9 @@ class BrowserViewController: UIViewController {
 
         switch path {
         case .estimatedProgress:
-            guard webView == tabManager.selectedTab?.webView,
-                let progress = change?[.newKey] as? Float else { break }
+            guard webView == tabManager.selectedTab?.webView else { break }
             if !(webView.url?.isLocalUtility ?? false) {
-                urlBar.updateProgressBar(progress)
+                urlBar.updateProgressBar(Float(webView.estimatedProgress))
             } else {
                 urlBar.hideProgressBar()
             }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1483841

This `guard` statement was falling through because there was no value in `change`. We can simply get `estimatedProgress` directly from a property on the webview though.