### PR TITLE
Bug 1483827 - theme display setting, bug with row deselection

### DIFF
--- a/Client/Frontend/Settings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettingsController.swift
@@ -191,4 +191,8 @@ class ThemeSettingsController: ThemedTableViewController {
     override func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
         tableView.cellForRow(at: indexPath)?.accessoryType = .none
     }
+
+    override func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
+        return indexPath.section != Section.automaticOnOff.rawValue
+    }
 }


### PR DESCRIPTION
The row with the automatic on/off should not be part of select/deselect logic, only the light/dark option rows should have that.