### PR TITLE
Bug 1484296 - Blank webview after deleting a tab

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -530,7 +530,7 @@ class BrowserViewController: UIViewController {
 
     fileprivate func showRestoreTabsAlert() {
         guard canRestoreTabs() else {
-            self.tabManager.addTabAndSelect()
+            tabManager.selectTab(tabManager.addTab())
             return
         }
         let alert = UIAlertController.restoreTabsAlert(
@@ -538,7 +538,7 @@ class BrowserViewController: UIViewController {
                 self.tabManager.restoreTabs()
             },
             noCallback: { _ in
-                self.tabManager.addTabAndSelect()
+                self.tabManager.selectTab(self.tabManager.addTab())
             }
         )
         self.present(alert, animated: true, completion: nil)
@@ -974,7 +974,7 @@ class BrowserViewController: UIViewController {
         }
 
         switchToPrivacyMode(isPrivate: isPrivate)
-        _ = tabManager.addTabAndSelect(request, isPrivate: isPrivate)
+        tabManager.selectTab(tabManager.addTab(request, isPrivate: isPrivate))
     }
 
     func openBlankNewTab(focusLocationField: Bool, isPrivate: Bool = false, searchFor searchText: String? = nil) {

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -257,12 +257,6 @@ class TabManager: NSObject {
         return self.addTab(request, configuration: configuration, afterTab: afterTab, flushToDisk: true, zombie: false, isPrivate: isPrivate)
     }
 
-    @discardableResult func addTabAndSelect(_ request: URLRequest! = nil, configuration: WKWebViewConfiguration! = nil, afterTab: Tab? = nil, isPrivate: Bool = false) -> Tab {
-        let tab = addTab(request, configuration: configuration, afterTab: afterTab, isPrivate: isPrivate)
-        selectTab(tab)
-        return tab
-    }
-
     func addTabsForURLs(_ urls: [URL], zombie: Bool) {
         assert(Thread.isMainThread)
 

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -379,7 +379,7 @@ class TabManager: NSObject {
         let closedLastPrivateTab = tab.isPrivate && privateTabs.isEmpty
 
         if closedLastNormalTab {
-            addTabAndSelect()
+            selectTab(addTab(), previous: tab)
         } else if closedLastPrivateTab {
             selectTab(tabs.last, previous: tab)
         } else if !isSelectedParentTab(afterRemoving: tab) {

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -342,7 +342,7 @@ class TabTrayController: UIViewController {
         // We dismiss the tab tray once we are done. So no need to re-enable the toolbar
         toolbar.isUserInteractionEnabled = false
 
-        self.tabManager.addTabAndSelect(request, isPrivate: tabDisplayManager.isPrivate)
+        tabManager.selectTab(tabManager.addTab(request, isPrivate: tabDisplayManager.isPrivate))
         self.tabDisplayManager.performTabUpdates {
             self.emptyPrivateTabsView.isHidden = !self.privateTabsAreEmpty()
             self.dismissTabTray()

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -41,8 +41,9 @@ struct MethodSpy {
     }
 }
 
-open class MockTabManagerDelegate: TabManagerDelegate {
+fileprivate let spyDidSelectedTabChange = "tabManager(_:didSelectedTabChange:previous:)"
 
+open class MockTabManagerDelegate: TabManagerDelegate {
     //this array represents the order in which delegate methods should be called.
     //each delegate method will pop the first struct from the array. If the method name doesn't match the struct then the order is incorrect
     //Then it evaluates the method closure which will return true/false depending on if the tabs are correct
@@ -203,12 +204,17 @@ class TabManagerTests: XCTestCase {
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
 
+        let didSelect = MethodSpy(functionName: spyDidSelectedTabChange) { tabs in
+            XCTAssertNotNil(tabs[0])
+            XCTAssertNotNil(tabs[1])
+        }
+
         // create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
         let tab = manager.addTab()
         manager.selectTab(tab)
         manager.addDelegate(delegate)
         // it wont call didSelect because addTabAndSelect did not pass last removed tab
-        delegate.expect([willRemove, didRemove, willAdd, didAdd])
+        delegate.expect([willRemove, didRemove, willAdd, didAdd, didSelect])
         manager.removeTabAndUpdateSelectedIndex(tab)
         delegate.verify("Not all delegate methods were called")
     }
@@ -225,7 +231,7 @@ class TabManagerTests: XCTestCase {
         manager.selectTab(privateTab)
         manager.addDelegate(delegate)
 
-        let didSelect = MethodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
+        let didSelect = MethodSpy(functionName: spyDidSelectedTabChange) { tabs in
             let next = tabs[0]!
             let previous = tabs[1]!
             XCTAssertTrue(previous != next)
@@ -361,7 +367,7 @@ class TabManagerTests: XCTestCase {
         let newSelectedTab = manager.tabs[8]
         manager.addDelegate(delegate)
 
-        let didSelect = MethodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
+        let didSelect = MethodSpy(functionName: spyDidSelectedTabChange) { tabs in
             let next = tabs[0]!
             let previous = tabs[1]!
             XCTAssertEqual(deleteTab, previous)
@@ -399,7 +405,7 @@ class TabManagerTests: XCTestCase {
         XCTAssertEqual(manager.selectedIndex, -1, "The selected index should have been reset")
 
         // didSelect should still be called when switching between a nil tab
-        let didSelect = MethodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
+        let didSelect = MethodSpy(functionName: spyDidSelectedTabChange) { tabs in
             XCTAssertNil(tabs[1], "there should be no previous tab")
             let next = tabs[0]!
             XCTAssertFalse(next.isPrivate)
@@ -427,7 +433,7 @@ class TabManagerTests: XCTestCase {
         let newSelectedTab = manager.tabs[1]
         manager.addDelegate(delegate)
 
-        let didSelect = MethodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
+        let didSelect = MethodSpy(functionName: spyDidSelectedTabChange) { tabs in
             let next = tabs[0]!
             let previous = tabs[1]!
             XCTAssertEqual(deleteTab, previous)
@@ -501,7 +507,7 @@ class TabManagerTests: XCTestCase {
         manager.selectTab(manager.tabs.last)
         manager.addDelegate(delegate)
 
-        let didSelect = MethodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
+        let didSelect = MethodSpy(functionName: spyDidSelectedTabChange) { tabs in
             let next = tabs[0]!
             let previous = tabs[1]!
             XCTAssertEqual(deleted, previous)
@@ -551,7 +557,7 @@ class TabManagerTests: XCTestCase {
         manager.selectTab(manager.tabs.first)
         manager.addDelegate(delegate)
 
-        let didSelect = MethodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
+        let didSelect = MethodSpy(functionName: spyDidSelectedTabChange) { tabs in
             let next = tabs[0]!
             let previous = tabs[1]!
             XCTAssertEqual(deleted, previous)

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -185,8 +185,7 @@ class TabManagerTests: XCTestCase {
     func testAddTabAndSelect() {
         let profile = TabManagerMockProfile()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)
-
-        manager.addTabAndSelect()
+        manager.selectTab(manager.addTab())
         XCTAssertEqual(manager.selectedIndex, 0, "There should be selected first tab")
     }
 
@@ -194,8 +193,7 @@ class TabManagerTests: XCTestCase {
         let profile = TabManagerMockProfile()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         // add two tabs, last one will be selected
-        manager.addTab()
-        manager.addTabAndSelect()
+        manager.selectTab(manager.addTab())
         manager.moveTab(isPrivate: false, fromIndex: 1, toIndex: 0)
         XCTAssertEqual(manager.selectedIndex, 0, "There should be selected second tab")
     }


### PR DESCRIPTION
TabManager select tab starts like this:

```func selectTab(_ tab: Tab?, previous: Tab? = nil) {
        assert(Thread.isMainThread)
        let previous = previous ?? selectedTab

        if previous === tab {
            return
        }```

Without passing in a previousTab, the function exits early. `selectTab` calls the BVC delegate that adds the tab webview to the subviews.