### PR TITLE
Bug 1484994 - Disable undo on close all private tabs

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -459,7 +459,7 @@ class TabManager: NSObject {
     }
 
     func removeTabsWithUndoToast(_ tabs: [Tab]) {
-        recentlyClosedForUndo = tabs.compactMap { tab in
+        recentlyClosedForUndo = tabs.filter { !$0.isPrivate }.compactMap { tab in
             return SavedTab(tab: tab, isSelected: false)
         }
 

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -459,7 +459,7 @@ class TabManager: NSObject {
     }
 
     func removeTabsWithUndoToast(_ tabs: [Tab]) {
-        recentlyClosedForUndo = tabs.filter { !$0.isPrivate }.compactMap { tab in
+        recentlyClosedForUndo = normalTabs.compactMap { tab in
             return SavedTab(tab: tab, isSelected: false)
         }
 


### PR DESCRIPTION
This feature seems counter intuitive, that a private tab (thus highly ephemeral) is kept in some form of storage for undo.
I acknowledge that as an advanced user I realize the storage is temporary memory.

Note: this PR is a proposal, I don't have confirmation from UX that removing this feature is desireable.
