### PR TITLE
Bug 1484613 - Harden TabDisplayManager for TabTray. 

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -113,13 +113,14 @@ extension TabDisplayManager: UICollectionViewDataSource {
     @objc func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let tab = tabStore[indexPath.row]
         guard let identifer = tabDisplayer?.tabCellIdentifer else {
+            assertionFailure("tabCellIdentifer is required")
             return UICollectionViewCell()
         }
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: identifer, for: indexPath)
         if let tabCell = tabDisplayer?.cellFactory(for: cell, using: tab) {
             return tabCell
         } else {
-            return UICollectionViewCell()
+            return cell
         }
     }
 
@@ -356,7 +357,7 @@ extension TabDisplayManager {
             self.tabStore = newTabs
 
             // Only consider moves if no other operations are pending.
-            if update.deletes.count == 0, update.inserts.count == 0, update.reloads.count == 0 {
+            if update.deletes.count == 0, update.inserts.count == 0 {
                 for move in update.moves {
                     self.collectionView.moveItem(at: move.from, to: move.to)
                 }
@@ -393,7 +394,7 @@ extension TabDisplayManager {
 
         // The actual update. Only animate the changes if no tabs have moved
         // as a result of drag-and-drop.
-        if update.moves.count == 0 {
+        if update.moves.count == 0, tabDisplayer is TopTabsViewController {
             UIView.animate(withDuration: TopTabsUX.AnimationSpeed, animations: {
                 self.collectionView.performBatchUpdates(updateBlock)
             }) { (_) in

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -32,6 +32,7 @@ class TabDisplayManager: NSObject {
 
     private var tabObservers: TabObservers!
     fileprivate weak var tabDisplayer: TabDisplayer?
+    let tabReuseIdentifer: String
 
     var searchedTabs: [Tab] = []
     var searchActive: Bool = false
@@ -62,11 +63,12 @@ class TabDisplayManager: NSObject {
         return self.tabManager.isRestoring || self.collectionView.frame == CGRect.zero
     }
 
-    init(collectionView: UICollectionView, tabManager: TabManager, tabDisplayer: TabDisplayer) {
+    init(collectionView: UICollectionView, tabManager: TabManager, tabDisplayer: TabDisplayer, reuseID: String) {
         self.collectionView = collectionView
         self.tabDisplayer = tabDisplayer
         self.tabManager = tabManager
         self.isPrivate = tabManager.selectedTab?.isPrivate ?? false
+        self.tabReuseIdentifer = reuseID
         super.init()
 
         tabManager.addDelegate(self)
@@ -112,11 +114,7 @@ extension TabDisplayManager: UICollectionViewDataSource {
 
     @objc func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let tab = tabStore[indexPath.row]
-        guard let identifer = tabDisplayer?.tabCellIdentifer else {
-            assertionFailure("tabCellIdentifer is required")
-            return UICollectionViewCell()
-        }
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: identifer, for: indexPath)
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: self.tabReuseIdentifer, for: indexPath)
         if let tabCell = tabDisplayer?.cellFactory(for: cell, using: tab) {
             return tabCell
         } else {

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -119,8 +119,8 @@ class TabTrayController: UIViewController {
         super.init(nibName: nil, bundle: nil)
 
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
-        tabDisplayManager = TabDisplayManager(collectionView: self.collectionView, tabManager: self.tabManager, tabDisplayer: self)
         collectionView.register(TabCell.self, forCellWithReuseIdentifier: TabCell.Identifier)
+        tabDisplayManager = TabDisplayManager(collectionView: self.collectionView, tabManager: self.tabManager, tabDisplayer: self)
         collectionView.dataSource = tabDisplayManager
         collectionView.delegate = tabLayoutDelegate
         collectionView.contentInset = UIEdgeInsets(top: TabTrayControllerUX.SearchBarHeight, left: 0, bottom: 0, right: 0)
@@ -444,7 +444,7 @@ extension TabTrayController: TabDisplayer {
     }
 
     func cellFactory(for cell: UICollectionViewCell, using tab: Tab) -> UICollectionViewCell {
-        guard let tabCell = cell as? TabCell else { return UICollectionViewCell() }
+        guard let tabCell = cell as? TabCell else { return cell }
         tabCell.animator.delegate = self
         tabCell.delegate = self
         let selected = tab == tabManager.selectedTab

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -120,7 +120,7 @@ class TabTrayController: UIViewController {
 
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
         collectionView.register(TabCell.self, forCellWithReuseIdentifier: TabCell.Identifier)
-        tabDisplayManager = TabDisplayManager(collectionView: self.collectionView, tabManager: self.tabManager, tabDisplayer: self)
+        tabDisplayManager = TabDisplayManager(collectionView: self.collectionView, tabManager: self.tabManager, tabDisplayer: self, reuseID: TabCell.Identifier)
         collectionView.dataSource = tabDisplayManager
         collectionView.delegate = tabLayoutDelegate
         collectionView.contentInset = UIEdgeInsets(top: TabTrayControllerUX.SearchBarHeight, left: 0, bottom: 0, right: 0)

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -80,7 +80,7 @@ class TopTabsViewController: UIViewController {
         self.tabManager = tabManager
         super.init(nibName: nil, bundle: nil)
 
-        tabDisplayManager = TabDisplayManager(collectionView: self.collectionView, tabManager: self.tabManager, tabDisplayer: self)
+        tabDisplayManager = TabDisplayManager(collectionView: self.collectionView, tabManager: self.tabManager, tabDisplayer: self, reuseID: TopTabCell.Identifier)
         collectionView.dataSource = tabDisplayManager
         collectionView.delegate = tabLayoutDelegate
         [UICollectionElementKindSectionHeader, UICollectionElementKindSectionFooter].forEach {


### PR DESCRIPTION
My second attempt to find this tricky crash

- Make sure to always return a TabCell never a generic UICollectionViewCell
- If the ReuseIdentifier is nil, assert
- A reload should not stop a move from animating 
- only use the UIView.animate when in TopTabs, we do this to make the animations more snappy. Dont need that for TabTray
- Register the tabCell before creating TabDisplayManger in case when dequeing it crashes