### PR TITLE
Bug 1486269 - XCUITest Disable Drag&Drop due to a bug

### DIFF
--- a/XCUITests/DragAndDropTests.swift
+++ b/XCUITests/DragAndDropTests.swift
@@ -82,7 +82,7 @@ class DragAndDropTests: BaseTestCase {
         // Check that focus is kept on last website open
         XCTAssertEqual(app.textFields["url"].value! as? String, "mobile.twitter.com/", "The tab has not been dropped correctly")
     }
-
+    // Tests disabled because the feature is off due to a non repro crash bug 1486269
     /*func testRearrangeTabsTabTray() {
         openTwoWebsites()
         navigator.goto(TabTray)

--- a/XCUITests/DragAndDropTests.swift
+++ b/XCUITests/DragAndDropTests.swift
@@ -83,7 +83,7 @@ class DragAndDropTests: BaseTestCase {
         XCTAssertEqual(app.textFields["url"].value! as? String, "mobile.twitter.com/", "The tab has not been dropped correctly")
     }
 
-    func testRearrangeTabsTabTray() {
+    /*func testRearrangeTabsTabTray() {
         openTwoWebsites()
         navigator.goto(TabTray)
         checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite["tabName"]!, secondTab: secondWebsite["tabName"]!)
@@ -124,7 +124,7 @@ class DragAndDropTests: BaseTestCase {
         dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite["tabName"]!], dropOnElement: app.collectionViews.cells[secondWebsite["tabName"]!])
 
         checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite["tabName"]!, secondTab: firstWebsite["tabName"]!)
-    }
+    }*/
 
     func testDragDropToInvalidArea() {
         openTwoWebsites()
@@ -153,7 +153,7 @@ class DragAndDropTests: BaseTestCase {
         XCTAssertEqual(app.textFields["url"].value! as? String, "mobile.twitter.com/", "The tab has not been dropped correctly")
     }
 
-    func testDragAndDropHomeTabTabsTray() {
+    /*func testDragAndDropHomeTabTabsTray() {
         navigator.openNewURL(urlString: secondWebsite["url"]!)
         waitUntilPageLoad()
         navigator.goto(TabTray)
@@ -163,7 +163,7 @@ class DragAndDropTests: BaseTestCase {
         dragAndDrop(dragElement: app.collectionViews.cells["home"], dropOnElement: app.collectionViews.cells[secondWebsite["tabName"]!])
 
         checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite["tabName"]! , secondTab: homeTab["tabName"]!)
-    }
+    }*/
 
     func testRearrangeTabsPrivateMode() {
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
@@ -177,7 +177,7 @@ class DragAndDropTests: BaseTestCase {
         XCTAssertEqual(app.textFields["url"].value! as? String, "mobile.twitter.com/", "The tab has not been dropped correctly")
     }
 
-    func testRearrangeTabsPrivateModeTabTray() {
+    /*func testRearrangeTabsPrivateModeTabTray() {
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         openTwoWebsites()
         navigator.goto(TabTray)
@@ -186,7 +186,7 @@ class DragAndDropTests: BaseTestCase {
         dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite["tabName"]!], dropOnElement: app.collectionViews.cells[secondWebsite["tabName"]!])
 
         checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite["tabName"]!, secondTab: firstWebsite["tabName"]!)
-    }
+    }*/
 
     // This test drags the address bar and since it is not possible to drop it on another app, lets do it in a search box
     func testDragAddressBarIntoSearchBox() {
@@ -200,7 +200,7 @@ class DragAndDropTests: BaseTestCase {
         XCTAssertEqual(app.webViews.searchFields[websiteWithSearchField["urlSearchField"]!].value as? String, websiteWithSearchField["url"]!)
     }
 
-    func testRearrangeTabsTabTrayIsKeptinTopTabs() {
+    /*func testRearrangeTabsTabTrayIsKeptinTopTabs() {
         openTwoWebsites()
         checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite["tabName"]!, secondTab: secondWebsite["tabName"]!)
         navigator.goto(TabTray)
@@ -212,7 +212,7 @@ class DragAndDropTests: BaseTestCase {
         // Leave Tab Tray and check order in Top Tabs
         app.collectionViews.cells[firstWebsite["tabName"]!].tap()
         checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite["tabName"]!, secondTab: firstWebsite["tabName"]!)
-    }
+    }*/
 
     func testDragAndDropHistoryEntry() {
         // Drop a bookmark/history entry is only allowed on other apps. This test is to check that nothing happens within the app

--- a/XCUITests/TabTraySearchTabsTests.swift
+++ b/XCUITests/TabTraySearchTabsTests.swift
@@ -47,7 +47,7 @@ class TabTraySearchTabsTests: BaseTestCase {
         XCTAssertEqual(app.collectionViews.cells.count, 1)
     }
 
-    func testDragAndDropTabToSearchTabField() {
+    /*func testDragAndDropTabToSearchTabField() {
         navigator.openURL(firstURL)
         navigator.goto(TabTray)
         waitforExistence(app.textFields["Search Tabs"])
@@ -55,7 +55,7 @@ class TabTraySearchTabsTests: BaseTestCase {
         waitForValueContains(app.textFields["Search Tabs"], value: "mozilla.org")
         let searchValue = app.textFields["Search Tabs"].value
         XCTAssertEqual(searchValue as! String, fullFirstURL)
-    }
+    }*/
 
     func testSearchFieldClearedAfterVisingWebsite() {
         navigator.openURL(firstURL)

--- a/XCUITests/TabTraySearchTabsTests.swift
+++ b/XCUITests/TabTraySearchTabsTests.swift
@@ -46,7 +46,7 @@ class TabTraySearchTabsTests: BaseTestCase {
         searchTabs(tabTitleOrUrl: "internet")
         XCTAssertEqual(app.collectionViews.cells.count, 1)
     }
-
+    // Test disabled because the DragAndDrop is off due to a non repro crash bug 1486269
     /*func testDragAndDropTabToSearchTabField() {
         navigator.openURL(firstURL)
         navigator.goto(TabTray)


### PR DESCRIPTION
Due to a crash Drag & Drop in the tab tray has been disabled. This PR disable the tests until it is working again