### PR TITLE
Bug 1486060 - Disable test and SyncIntegration notifications for PRs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,9 +44,13 @@ pipeline {
                 reportName: 'HTML Report'])
         }
         failure {
-            slackSend(
-                color: 'danger',
-                message: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+            script {
+                if (env.BRANCH_NAME == 'master') {
+                    slackSend(
+                        color: 'danger',
+                        message: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+                }
+            }
         }
         fixed {
             slackSend(

--- a/SyncIntegrationTests/test_integration.py
+++ b/SyncIntegrationTests/test_integration.py
@@ -6,9 +6,9 @@ def test_sync_history_from_device(tps, xcodebuild):
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncHistory')
     tps.run('test_history.js')
 
-def test_sync_tabs_from_device(tps, xcodebuild):
-    xcodebuild.test('XCUITests/IntegrationTests/testFxASyncTabs')
-    tps.run('test_tabs.js')
+#def test_sync_tabs_from_device(tps, xcodebuild):
+#    xcodebuild.test('XCUITests/IntegrationTests/testFxASyncTabs')
+#    tps.run('test_tabs.js')
 
 def test_sync_logins_from_device(tps, xcodebuild):
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncLogins')

--- a/XCUITests/IntegrationTests.swift
+++ b/XCUITests/IntegrationTests.swift
@@ -71,6 +71,7 @@ class IntegrationTests: BaseTestCase {
         waitForInitialSyncComplete()
     }
 
+    /* Disabling test until it is consistently working remotely
     func testFxASyncTabs () {
         navigator.openURL(testingURL)
         waitUntilPageLoad()
@@ -89,7 +90,7 @@ class IntegrationTests: BaseTestCase {
         app.buttons["Settings"].tap()
         app.tables.cells.element(boundBy: 1).tap()
         waitforExistence(app.tables.staticTexts["Sync Now"], timeout: 15)
-    }
+    }*/
 
     func testFxASyncLogins () {
         navigator.openURL("gmail.com")


### PR DESCRIPTION
Disable the test that fails remotely while it is investigated and fixed and the notifications of failures for PRs