### PR TITLE
Updated instances of blue to Photon.Blue40, removed commented overrides

### DIFF
--- a/Client/Frontend/Browser/SimpleToast.swift
+++ b/Client/Frontend/Browser/SimpleToast.swift
@@ -8,7 +8,7 @@ import Shared
 struct SimpleToastUX {
     static let ToastHeight = BottomToolbarHeight
     static let ToastAnimationDuration = 0.5
-    static let ToastDefaultColor = UIColor.Photon.Blue50
+    static let ToastDefaultColor = UIColor.Photon.Blue40
     static let ToastFont = UIFont.systemFont(ofSize: 15)
     static let ToastDismissAfter = DispatchTimeInterval.milliseconds(4500) // 4.5 seconds.
     static let ToastDelayBefore = DispatchTimeInterval.milliseconds(0) // 0 seconds

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -7,7 +7,7 @@ import SnapKit
 
 private struct URLBarViewUX {
     static let TextFieldBorderColor = UIColor.Photon.Grey40
-    static let TextFieldActiveBorderColor = UIColor.Defaults.PaleBlue
+    static let TextFieldActiveBorderColor = UIColor.Photon.Blue40
 
     static let LocationLeftPadding: CGFloat = 8
     static let Padding: CGFloat = 10

--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -18,26 +18,21 @@ fileprivate class DarkTableViewColor: TableViewColor {
     override var headerBackground: UIColor { return UIColor.Photon.Grey80 }
     override var headerTextLight: UIColor { return UIColor.Photon.Grey30 }
     override var headerTextDark: UIColor { return UIColor.Photon.Grey30 }
-//    override var rowActionAccessory: UIColor { return UIColor.Photon.Blue50 }
-//    override var controlTint: UIColor { return rowActionAccessory }
     override var syncText: UIColor { return defaultTextAndTint }
-//    override var errorText: UIColor { return UIColor.Photon.Red50 }
-//    override var warningText: UIColor { return UIColor.Photon.Orange50 }
 }
 
 fileprivate class DarkActionMenuColor: ActionMenuColor {
     override var foreground: UIColor { return defaultTextAndTint }
-    override var iPhoneBackground: UIColor { return UIColor.Photon.Grey90.withAlphaComponent(0.7) }
-    override var iPhoneBackgroundBlurStyle: UIBlurEffectStyle { return UIBlurEffectStyle.light }
+    override var iPhoneBackground: UIColor { return UIColor.Photon.Grey90.withAlphaComponent(0.9) }
     override var closeButtonBackground: UIColor { return defaultBackground }
 
 }
 
 fileprivate class DarkURLBarColor: URLBarColor {
     override var border: UIColor { return UIColor.Photon.Grey50 }
-    override var activeBorder: UIColor { return UIColor.Photon.Blue50A30 }
-    override var tint: UIColor { return UIColor.Photon.Blue50A30 }
-    override var textSelectionHighlight: UIColor { return UIColor.Photon.Blue60 }
+    override var activeBorder: UIColor { return UIColor.Photon.Blue40A30 }
+    override var tint: UIColor { return UIColor.Photon.Blue40A30 }
+    override var textSelectionHighlight: UIColor { return UIColor.Photon.Blue40 }
     override var readerModeButtonSelected: UIColor { return UIColor.Photon.Blue40 }
     override var readerModeButtonUnselected: UIColor { return UIColor.Photon.Grey20 }
     override var pageOptionsSelected: UIColor { return readerModeButtonSelected }
@@ -46,19 +41,12 @@ fileprivate class DarkURLBarColor: URLBarColor {
 
 fileprivate class DarkBrowserColor: BrowserColor {
     override var background: UIColor { return defaultBackground }
-//    override var urlBarDivider: UIColor { return UIColor.Photon.Grey90A10 }
     override var tint: UIColor { return defaultTextAndTint }
 }
 
 // The back/forward/refresh/menu button (bottom toolbar)
 fileprivate class DarkToolbarButtonColor: ToolbarButtonColor {
-//    override var selectedTint: UIColor { return UIColor.Photon.Blue40 }
-//    override var disabledTint: UIColor { return UIColor.Photon.Grey30 }
-}
 
-fileprivate class DarkLoadingBarColor: LoadingBarColor {
-//    override var start: UIColor { return UIColor.Photon.Blue50A30 }
-//    override var end: UIColor { return UIColor.Photon.Blue50 }
 }
 
 fileprivate class DarkTabTrayColor: TabTrayColor {
@@ -69,10 +57,10 @@ fileprivate class DarkTabTrayColor: TabTrayColor {
     override var toolbar: UIColor { return UIColor.Photon.Grey80 }
     override var toolbarButtonTint: UIColor { return defaultTextAndTint }
     override var cellCloseButton: UIColor { return defaultTextAndTint }
-//    override var privateModeLearnMore: UIColor { return UIColor.Photon.Purple60 }
-//    override var privateModePurple: UIColor { return UIColor.Defaults.MobilePrivatePurple }
-//    override var privateModeButtonOffTint: UIColor { return toolbarButtonTint }
-//    override var privateModeButtonOnTint: UIColor { return UIColor.Photon.Grey10 }
+    override var privateModeLearnMore: UIColor { return UIColor.Photon.Purple60 }
+    override var privateModePurple: UIColor { return UIColor.Photon.Purple60 }
+    override var privateModeButtonOffTint: UIColor { return toolbarButtonTint }
+    override var privateModeButtonOnTint: UIColor { return UIColor.Photon.Grey10 }
     override var cellTitleBackground: UIColor { return UIColor.Photon.Grey70 }
     override var searchBackground: UIColor { return UIColor.Photon.Grey60 }
 }
@@ -83,12 +71,6 @@ fileprivate class DarkTopTabsColor: TopTabsColor {
     override var tabBackgroundUnselected: UIColor { return UIColor.Photon.Grey80 }
     override var tabForegroundSelected: UIColor { return UIColor.Photon.Grey10 }
     override var tabForegroundUnselected: UIColor { return UIColor.Photon.Grey40 }
-   
-//    override var selectedLineNormalMode: UIColor { return UIColor.Photon.Blue60 }
-//    override var selectedLinePrivateMode: UIColor { return UIColor.Photon.Purple50 }
-//    override var buttonTint: UIColor { return .red }
-//    override var privateModeButtonOffTint: UIColor { return buttonTint }
-//    override var privateModeButtonOnTint: UIColor { return UIColor.Photon.Grey10 }
     override var closeButtonSelectedTab: UIColor { return tabForegroundSelected }
     override var closeButtonUnselectedTab: UIColor { return tabForegroundUnselected }
     override var separator: UIColor { return UIColor.Photon.Grey50 }
@@ -97,12 +79,12 @@ fileprivate class DarkTopTabsColor: TopTabsColor {
 fileprivate class DarkTextFieldColor: TextFieldColor {
     override var background: UIColor { return UIColor.Photon.Grey60 }
     override var textAndTint: UIColor { return defaultTextAndTint }
-   // override var separator: UIColor { return defaultSeparator }
+
 }
 
 fileprivate class DarkHomePanelColor: HomePanelColor {
     override var toolbarBackground: UIColor { return defaultBackground }
-    override var toolbarHighlight: UIColor { return UIColor.Photon.Blue50 }
+    override var toolbarHighlight: UIColor { return UIColor.Photon.Blue40 }
     override var toolbarTint: UIColor { return UIColor.Photon.Grey30 }
     override var panelBackground: UIColor { return UIColor.Photon.Grey90 }
     override var separator: UIColor { return defaultSeparator }
@@ -117,10 +99,6 @@ fileprivate class DarkHomePanelColor: HomePanelColor {
     override var bookmarkCurrentFolderText: UIColor { return UIColor.Photon.White100 }
     override var bookmarkBackNavCellBackground: UIColor { return UIColor.Photon.Grey70 }
     
-   //  var siteTableHeaderBorder: UIColor { return UIColor.Photon.Grey30.withAlphaComponent(0.8) }
-    // var siteTableHeaderText: UIColor { return UIColor.Photon.Grey80 }
-   // var siteTableHeaderBackground: UIColor { return UIColor.Photon.Grey10 }
-
     override var activityStreamHeaderText: UIColor { return UIColor.Photon.Grey30 }
     override var activityStreamCellTitle: UIColor { return UIColor.Photon.Grey20 }
     override var activityStreamCellDescription: UIColor { return UIColor.Photon.Grey30 }
@@ -134,7 +112,7 @@ fileprivate class DarkHomePanelColor: HomePanelColor {
     override var readingListActive: UIColor { return UIColor.Photon.Grey10 }
     override var readingListDimmed: UIColor { return UIColor.Photon.Grey40 }
 
-    override var searchSuggestionPillBackground: UIColor { return UIColor.Photon.Ink80 }
+    override var searchSuggestionPillBackground: UIColor { return UIColor.Photon.Grey70 }
     override var searchSuggestionPillForeground: UIColor { return defaultTextAndTint }
 }
 
@@ -143,10 +121,6 @@ fileprivate class DarkSnackBarColor: SnackBarColor {
 }
 
 fileprivate class DarkGeneralColor: GeneralColor {
-//    override var passcodeDot: UIColor { return UIColor.Photon.Grey60 }
-//    override var highlightBlue: UIColor { return UIColor.Photon.Blue50 }
-//    override var destructiveRed: UIColor { return UIColor.Photon.Red50 }
-//    override var separator: UIColor { return defaultSeparator }
 
     override var settingsTextPlaceholder: UIColor? { return UIColor.black }
 }
@@ -157,7 +131,6 @@ class DarkTheme: NormalTheme {
     override var urlbar: URLBarColor { return DarkURLBarColor() }
     override var browser: BrowserColor { return DarkBrowserColor() }
     override var toolbarButton: ToolbarButtonColor { return DarkToolbarButtonColor() }
-    override var loadingBar: LoadingBarColor { return DarkLoadingBarColor() }
     override var tabTray: TabTrayColor { return DarkTabTrayColor() }
     override var topTabs: TopTabsColor { return DarkTopTabsColor() }
     override var textField: TextFieldColor { return DarkTextFieldColor() }

--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -57,10 +57,6 @@ fileprivate class DarkTabTrayColor: TabTrayColor {
     override var toolbar: UIColor { return UIColor.Photon.Grey80 }
     override var toolbarButtonTint: UIColor { return defaultTextAndTint }
     override var cellCloseButton: UIColor { return defaultTextAndTint }
-    override var privateModeLearnMore: UIColor { return UIColor.Photon.Purple60 }
-    override var privateModePurple: UIColor { return UIColor.Photon.Purple60 }
-    override var privateModeButtonOffTint: UIColor { return toolbarButtonTint }
-    override var privateModeButtonOnTint: UIColor { return UIColor.Photon.Grey10 }
     override var cellTitleBackground: UIColor { return UIColor.Photon.Grey70 }
     override var searchBackground: UIColor { return UIColor.Photon.Grey60 }
 }

--- a/Client/Frontend/Theme/Theme.swift
+++ b/Client/Frontend/Theme/Theme.swift
@@ -38,7 +38,7 @@ class TableViewColor {
     var headerTextLight: UIColor { return UIColor.Photon.Grey50 }
     // Used for table headers in home panel tables
     var headerTextDark: UIColor { return UIColor.Photon.Grey90 }
-    var rowActionAccessory: UIColor { return UIColor.Photon.Blue50 }
+    var rowActionAccessory: UIColor { return UIColor.Photon.Blue40 }
     var controlTint: UIColor { return rowActionAccessory }
     var syncText: UIColor { return defaultTextAndTint }
     var errorText: UIColor { return UIColor.Photon.Red50 }
@@ -48,15 +48,15 @@ class TableViewColor {
 class ActionMenuColor {
     var foreground: UIColor { return defaultTextAndTint }
     var iPhoneBackgroundBlurStyle: UIBlurEffectStyle { return UIBlurEffectStyle.light }
-    var iPhoneBackground: UIColor { return UIColor.theme.browser.background.withAlphaComponent(0.7) }
+    var iPhoneBackground: UIColor { return UIColor.theme.browser.background.withAlphaComponent(0.9) }
     var closeButtonBackground: UIColor { return defaultBackground }
 }
 
 class URLBarColor {
     var border: UIColor { return UIColor.Photon.Grey50 }
-    var activeBorder: UIColor { return UIColor.Photon.Blue50A30 }
-    var tint: UIColor { return UIColor.Photon.Blue50A30 }
-    var textSelectionHighlight: UIColor { return UIColor.Defaults.iOSTextHighlightBlue }
+    var activeBorder: UIColor { return UIColor.Photon.Blue40A30 }
+    var tint: UIColor { return UIColor.Photon.Blue40A30 }
+    var textSelectionHighlight: UIColor { return UIColor.Photon.Blue40A30 }
     var readerModeButtonSelected: UIColor { return UIColor.Photon.Blue40 }
     var readerModeButtonUnselected: UIColor { return UIColor.Photon.Grey50 }
     var pageOptionsSelected: UIColor { return readerModeButtonSelected }
@@ -76,8 +76,13 @@ class ToolbarButtonColor {
 }
 
 class LoadingBarColor {
-    var start: UIColor { return UIColor.Photon.Blue50A30 }
-    var end: UIColor { return UIColor.Photon.Blue50 }
+    var start: UIColor { return UIColor.Photon.Blue40A30 }
+    var end: UIColor { return UIColor.Photon.Teal60 }
+}
+
+class PrivateLoadingBarColor {
+    var start: UIColor { return UIColor.Photon.Magenta60A30 }
+    var end: UIColor { return UIColor.Photon.Purple60 }
 }
 
 class TabTrayColor {
@@ -88,7 +93,7 @@ class TabTrayColor {
     var toolbar: UIColor { return defaultBackground }
     var toolbarButtonTint: UIColor { return defaultTextAndTint }
     var privateModeLearnMore: UIColor { return UIColor.Photon.Purple60 }
-    var privateModePurple: UIColor { return UIColor.Defaults.MobilePrivatePurple }
+    var privateModePurple: UIColor { return UIColor.Photon.Purple60 }
     var privateModeButtonOffTint: UIColor { return toolbarButtonTint }
     var privateModeButtonOnTint: UIColor { return UIColor.Photon.Grey10 }
     var cellCloseButton: UIColor { return UIColor.Photon.Grey50 }
@@ -103,8 +108,8 @@ class TopTabsColor {
     var tabBackgroundUnselected: UIColor { return UIColor.Photon.Grey80 }
     var tabForegroundSelected: UIColor { return UIColor.Photon.Grey90 }
     var tabForegroundUnselected: UIColor { return UIColor.Photon.Grey40 }
-    var selectedLineNormalMode: UIColor { return UIColor.Photon.Blue60 }
-    var selectedLinePrivateMode: UIColor { return UIColor.Photon.Purple50 }
+    var selectedLineNormalMode: UIColor { return UIColor.Photon.Blue40 }
+    var selectedLinePrivateMode: UIColor { return UIColor.Photon.Purple60 }
     var buttonTint: UIColor { return UIColor.Photon.Grey40 }
     var privateModeButtonOffTint: UIColor { return buttonTint }
     var privateModeButtonOnTint: UIColor { return UIColor.Photon.Grey10 }
@@ -121,7 +126,7 @@ class TextFieldColor {
 
 class HomePanelColor {
     var toolbarBackground: UIColor { return defaultBackground }
-    var toolbarHighlight: UIColor { return UIColor.Photon.Blue50 }
+    var toolbarHighlight: UIColor { return UIColor.Photon.Blue40 }
     var toolbarTint: UIColor { return UIColor.Photon.Grey50 }
 
     var panelBackground: UIColor { return UIColor.Photon.White100 }
@@ -134,7 +139,7 @@ class HomePanelColor {
     var bookmarkIconBorder: UIColor { return UIColor.Photon.Grey30 }
     var bookmarkFolderBackground: UIColor { return UIColor.Photon.Grey10.withAlphaComponent(0.3) } 
     var bookmarkFolderText: UIColor { return UIColor.Photon.Grey80 } 
-    var bookmarkCurrentFolderText: UIColor { return UIColor.theme.general.highlightBlue }
+    var bookmarkCurrentFolderText: UIColor { return UIColor.Photon.Blue40 }
     var bookmarkBackNavCellBackground: UIColor { return UIColor.clear }
     
     var siteTableHeaderBorder: UIColor { return UIColor.Photon.Grey30.withAlphaComponent(0.8) }
@@ -153,19 +158,19 @@ class HomePanelColor {
     var historyHeaderIconsBackground: UIColor { return UIColor.Photon.White100 }
 
     var searchSuggestionPillBackground: UIColor { return UIColor.Photon.White100 }
-    var searchSuggestionPillForeground: UIColor { return UIColor.theme.general.highlightBlue }
+    var searchSuggestionPillForeground: UIColor { return UIColor.Photon.Blue40 }
 }
 
 class SnackBarColor {
     var highlight: UIColor { return UIColor.Defaults.iOSTextHighlightBlue.withAlphaComponent(0.9) }
-    var highlightText: UIColor { return UIColor.Photon.Blue60 }
+    var highlightText: UIColor { return UIColor.Photon.Blue40 }
     var border: UIColor { return UIColor.Photon.Grey30 }
-    var title: UIColor { return UIColor.Photon.Blue50 }
+    var title: UIColor { return UIColor.Photon.Blue40 }
 }
 
 class GeneralColor {
     var passcodeDot: UIColor { return UIColor.Photon.Grey60 }
-    var highlightBlue: UIColor { return UIColor.Photon.Blue50 }
+    var highlightBlue: UIColor { return UIColor.Photon.Blue40A30 }
     var destructiveRed: UIColor { return UIColor.Photon.Red50 }
     var separator: UIColor { return defaultSeparator }
     var settingsTextPlaceholder: UIColor? { return nil }

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -11,7 +11,7 @@ extension UIColor {
         static let MobileGreyF = UIColor(rgb: 0x636369)
         static let iOSTextHighlightBlue = UIColor(rgb: 0xccdded) // This color should exactly match the ios text highlight
         static let Purple60A30 = UIColor(rgba: 0x8000d74c)
-        static let MobilePrivatePurple = UIColor(rgb: 0x8000d74)
+        static let MobilePrivatePurple = UIColor.Photon.Purple60
     // Reader Mode Sepia
         static let LightBeige = UIColor(rgb: 0xf0e6dc)
     }

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -11,8 +11,8 @@ extension UIColor {
         static let MobileGreyF = UIColor(rgb: 0x636369)
         static let iOSTextHighlightBlue = UIColor(rgb: 0xccdded) // This color should exactly match the ios text highlight
         static let Purple60A30 = UIColor(rgba: 0x8000d74c)
-        static let MobilePrivatePurple = UIColor(rgb: 0xcf68ff)
-        static let PaleBlue = UIColor(rgb: 0xB0D5FB)
+        static let MobilePrivatePurple = UIColor(rgb: 0x8000d74)
+    // Reader Mode Sepia
         static let LightBeige = UIColor(rgb: 0xf0e6dc)
     }
 }

--- a/Client/Frontend/photon-colors.swift
+++ b/Client/Frontend/photon-colors.swift
@@ -10,6 +10,7 @@ extension UIColor {
     struct Photon {
         static let Magenta50 = UIColor(rgb: 0xff1ad9)
         static let Magenta60 = UIColor(rgb: 0xed00b5)
+        static let Magenta60A30 = UIColor(rgb: 0x0aed00b5)
         static let Magenta70 = UIColor(rgb: 0xb5007f)
         static let Magenta80 = UIColor(rgb: 0x7d004f)
         static let Magenta90 = UIColor(rgb: 0x440027)
@@ -23,8 +24,8 @@ extension UIColor {
         static let Purple90 = UIColor(rgb: 0x25003e)
 
         static let Blue40 = UIColor(rgb: 0x45a1ff)
-        static let Blue50 = UIColor(rgb: 0x0a84ff)
-        static let Blue50A30 = UIColor(rgba: 0x0a84ff4c)
+        static let Blue40A30 = UIColor(rgb: 0x0a45a1ff)
+        static let Blue50 = UIColor(rgb: 0x0a84ff4)
         static let Blue60 = UIColor(rgb: 0x0060df)
         static let Blue70 = UIColor(rgb: 0x003eaa)
         static let Blue80 = UIColor(rgb: 0x002275)

--- a/Client/Frontend/photon-colors.swift
+++ b/Client/Frontend/photon-colors.swift
@@ -10,7 +10,7 @@ extension UIColor {
     struct Photon {
         static let Magenta50 = UIColor(rgb: 0xff1ad9)
         static let Magenta60 = UIColor(rgb: 0xed00b5)
-        static let Magenta60A30 = UIColor(rgb: 0x0aed00b5)
+        static let Magenta60A30 = UIColor(rgba: 0xed00b54c)
         static let Magenta70 = UIColor(rgb: 0xb5007f)
         static let Magenta80 = UIColor(rgb: 0x7d004f)
         static let Magenta90 = UIColor(rgb: 0x440027)
@@ -24,7 +24,7 @@ extension UIColor {
         static let Purple90 = UIColor(rgb: 0x25003e)
 
         static let Blue40 = UIColor(rgb: 0x45a1ff)
-        static let Blue40A30 = UIColor(rgb: 0x0a45a1ff)
+        static let Blue40A30 = UIColor(rgba: 0x45a1ff4c)
         static let Blue50 = UIColor(rgb: 0x0a84ff4)
         static let Blue60 = UIColor(rgb: 0x0060df)
         static let Blue70 = UIColor(rgb: 0x003eaa)

--- a/Client/Frontend/photon-colors.swift
+++ b/Client/Frontend/photon-colors.swift
@@ -25,7 +25,7 @@ extension UIColor {
 
         static let Blue40 = UIColor(rgb: 0x45a1ff)
         static let Blue40A30 = UIColor(rgba: 0x45a1ff4c)
-        static let Blue50 = UIColor(rgb: 0x0a84ff4)
+        static let Blue50 = UIColor(rgb: 0x0a84ff)
         static let Blue60 = UIColor(rgb: 0x0060df)
         static let Blue70 = UIColor(rgb: 0x003eaa)
         static let Blue80 = UIColor(rgb: 0x002275)


### PR DESCRIPTION
and DarkLoadingBarColor (should be same Light or Dark), bumped Alpha of
App Menu up, added new Alpha colors to photon-colors.

*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [ ] My patch has a standard commit message that looks like `Bug 12345678 - This fixes something something`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
