### PR TITLE
Bug 1486583 - Use permanent table for storing awesomebar bookmarks as a 'materialized view'

### DIFF
--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -307,7 +307,7 @@ fileprivate struct SQLiteFrecentHistory: FrecentHistory {
             }
         } else {
             whereClause = " WHERE (history.is_deleted = 0)\(whereFragment)"
-            bookmarksWhereClause = " WHERE (1 = 1)\(whereFragment)"
+            bookmarksWhereClause = (whereData == nil) ? "" : " WHERE (\(whereData!))"
             args = []
         }
 
@@ -449,7 +449,7 @@ fileprivate struct SQLiteFrecentHistory: FrecentHistory {
             }
         } else {
             ftsWhereClause = " WHERE (history.is_deleted = 0)\(whereFragment)"
-            bookmarksWhereClause = " WHERE (1 = 1)\(whereFragment)"
+            bookmarksWhereClause = (whereData == nil) ? "" : " WHERE (\(whereData!))"
             args = []
         }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1486583

This doesn't effectively change any behavior, but makes this cached data accessible across multiple DB connections (temp tables are only accessible on the connection that created them).

This PR also fixes an issue with a code path that we don't ever hit where we reuse a `WHERE` clause on this table.