### PR TITLE
Bug 1487165 - Tab store async off-main writes, and scoped lock for reads

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -117,8 +117,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             }
         }
 
-        self.tabManager = TabManager(prefs: profile.prefs, imageStore: imageStore)
-        self.tabManager.stateDelegate = self
+        self.tabManager = TabManager(profile: profile, imageStore: imageStore)
 
         // Add restoration class, the factory that will return the ViewController we
         // will restore with.
@@ -479,20 +478,6 @@ extension AppDelegate: UINavigationControllerDelegate {
             return TrayToBrowserAnimator()
         default:
             return nil
-        }
-    }
-}
-
-extension AppDelegate: TabManagerStateDelegate {
-    func tabManagerWillStoreTabs(_ tabs: [Tab]) {
-        // It is possible that not all tabs have loaded yet, so we filter out tabs with a nil URL.
-        let storedTabs: [RemoteTab] = tabs.compactMap( Tab.toTab )
-
-        // Don't insert into the DB immediately. We tend to contend with more important
-        // work like querying for top sites.
-        let queue = DispatchQueue.global(qos: DispatchQoS.background.qosClass)
-        queue.asyncAfter(deadline: DispatchTime.now() + Double(Int64(ProfileRemoteTabsSyncDelay * Double(NSEC_PER_MSEC))) / Double(NSEC_PER_SEC)) {
-            self.profile?.storeTabs(storedTabs)
         }
     }
 }

--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -10,6 +10,9 @@ import XCGLogger
 private let log = Logger.browserLogger
 
 class TestAppDelegate: AppDelegate {
+
+    lazy var dirForTestProfile = { return "\(self.appRootDir())/profile.testProfile" }()
+
     override func getProfile(_ application: UIApplication) -> Profile {
         if let profile = self.profile {
             return profile
@@ -27,14 +30,13 @@ class TestAppDelegate: AppDelegate {
                 // Grab the name of file in the bundle's test-fixtures dir, and copy it to the runtime app dir.
                 let filename = arg.replacingOccurrences(of: LaunchArguments.LoadDatabasePrefix, with: "")
                 let input = URL(fileURLWithPath: Bundle(for: TestAppDelegate.self).path(forResource: filename, ofType: nil, inDirectory: "test-fixtures")!)
-                let profileDir = "\(appRootDir())/profile.testProfile"
-                try? FileManager.default.createDirectory(atPath: profileDir, withIntermediateDirectories: false, attributes: nil)
-                let output = URL(fileURLWithPath: "\(profileDir)/browser.db")
+                try? FileManager.default.createDirectory(atPath: dirForTestProfile, withIntermediateDirectories: false, attributes: nil)
+                let output = URL(fileURLWithPath: "\(dirForTestProfile)/browser.db")
 
-                let enumerator = FileManager.default.enumerator(atPath: profileDir)
+                let enumerator = FileManager.default.enumerator(atPath: dirForTestProfile)
                 let filePaths = enumerator?.allObjects as! [String]
                 filePaths.filter{ $0.contains(".db") }.forEach { item in
-                    try! FileManager.default.removeItem(at: URL(fileURLWithPath: "\(profileDir)/\(item)"))
+                    try! FileManager.default.removeItem(at: URL(fileURLWithPath: "\(dirForTestProfile)/\(item)"))
                 }
 
                 try! FileManager.default.copyItem(at: input, to: output)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -529,7 +529,7 @@ class BrowserViewController: UIViewController {
     }
 
     fileprivate func showRestoreTabsAlert() {
-        guard canRestoreTabs() else {
+        guard tabManager.hasTabsToRestoreAtStartup() else {
             tabManager.selectTab(tabManager.addTab())
             return
         }
@@ -542,11 +542,6 @@ class BrowserViewController: UIViewController {
             }
         )
         self.present(alert, animated: true, completion: nil)
-    }
-
-    fileprivate func canRestoreTabs() -> Bool {
-        guard let tabsToRestore = tabManager.tabsToRestore() else { return false }
-        return !tabsToRestore.isEmpty
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1740,7 +1740,7 @@ extension BrowserViewController: SearchViewControllerDelegate {
 }
 
 extension BrowserViewController: TabManagerDelegate {
-    func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?) {
+    func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?, isRestoring: Bool) {
         // Remove the old accessibilityLabel. Since this webview shouldn't be visible, it doesn't need it
         // and having multiple views with the same label confuses tests.
         if let wv = previous?.webView {
@@ -1827,9 +1827,9 @@ extension BrowserViewController: TabManagerDelegate {
     func tabManager(_ tabManager: TabManager, willAddTab tab: Tab) {
     }
 
-    func tabManager(_ tabManager: TabManager, didAddTab tab: Tab) {
+    func tabManager(_ tabManager: TabManager, didAddTab tab: Tab, isRestoring: Bool) {
         // If we are restoring tabs then we update the count once at the end
-        if !tabManager.isRestoring {
+        if !isRestoring {
             updateTabCountUsingTabManager(tabManager)
         }
         tab.tabDelegate = self
@@ -1841,7 +1841,7 @@ extension BrowserViewController: TabManagerDelegate {
         }
     }
 
-    func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab) {
+    func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool) {
         updateTabCountUsingTabManager(tabManager)
     }
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -159,7 +159,11 @@ class Tab: NSObject {
         debugTabCount += 1
     }
 
-    class func toTab(_ tab: Tab) -> RemoteTab? {
+    class func toRemoteTab(_ tab: Tab) -> RemoteTab? {
+        if tab.isPrivate {
+            return nil
+        }
+
         if let displayURL = tab.url?.displayURL, RemoteTab.shouldIncludeURL(displayURL) {
             let history = Array(tab.historyList.filter(RemoteTab.shouldIncludeURL).reversed())
             return RemoteTab(clientGUID: nil,

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -58,11 +58,6 @@ class TabDisplayManager: NSObject {
         return self.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
     }
 
-    // This helps make sure animations don't happen before the view is loaded.
-    fileprivate var isRestoring: Bool {
-        return self.tabManager.isRestoring || self.collectionView.frame == CGRect.zero
-    }
-
     init(collectionView: UICollectionView, tabManager: TabManager, tabDisplayer: TabDisplayer, reuseID: String) {
         self.collectionView = collectionView
         self.tabDisplayer = tabDisplayer
@@ -80,6 +75,11 @@ class TabDisplayManager: NSObject {
     func removeObservers() {
         unregister(tabObservers)
         tabObservers = nil
+    }
+
+     // Make sure animations don't happen before the view is loaded.
+    fileprivate func shouldAnimate(isRestoringTabs: Bool) ->Bool {
+        return isRestoringTabs || collectionView.frame == CGRect.zero
     }
 
     private func recordEventAndBreadcrumb(object: UnifiedTelemetry.EventObject, method: UnifiedTelemetry.EventMethod) {
@@ -480,8 +480,8 @@ extension TabDisplayManager: TabManagerDelegate {
         }
     }
 
-    func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?) {
-        if isRestoring {
+    func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?, isRestoring: Bool) {
+        if !shouldAnimate(isRestoringTabs: isRestoring) {
             return
         }
         if !tabsMatchDisplayGroup(selected, b: previous) {
@@ -498,8 +498,8 @@ extension TabDisplayManager: TabManagerDelegate {
         self.oldTabs = self.oldTabs ?? tabStore
     }
 
-    func tabManager(_ tabManager: TabManager, didAddTab tab: Tab) {
-        if isRestoring || (tabManager.selectedTab != nil && !tabsMatchDisplayGroup(tab, b: tabManager.selectedTab)) {
+    func tabManager(_ tabManager: TabManager, didAddTab tab: Tab, isRestoring: Bool) {
+        if !shouldAnimate(isRestoringTabs: isRestoring) || (tabManager.selectedTab != nil && !tabsMatchDisplayGroup(tab, b: tabManager.selectedTab)) {
             return
         }
         performTabUpdates()
@@ -510,9 +510,9 @@ extension TabDisplayManager: TabManagerDelegate {
         self.oldTabs = self.oldTabs ?? tabStore
     }
 
-    func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab) {
+    func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool) {
         recordEventAndBreadcrumb(object: .tab, method: .delete)
-        if isRestoring {
+        if !shouldAnimate(isRestoringTabs: isRestoring) {
             return
         }
         // If we deleted the last private tab. We'll be switching back to normal browsing. Pause updates till then

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -78,7 +78,7 @@ class TabDisplayManager: NSObject {
     }
 
      // Make sure animations don't happen before the view is loaded.
-    fileprivate func shouldAnimate(isRestoringTabs: Bool) ->Bool {
+    fileprivate func shouldAnimate(isRestoringTabs: Bool) -> Bool {
         return isRestoringTabs || collectionView.frame == CGRect.zero
     }
 

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -554,7 +554,7 @@ extension TabManager {
         // Don't insert into the DB immediately. We tend to contend with more important
         // work like querying for top sites.
         let queue = DispatchQueue.global(qos: DispatchQoS.background.qosClass)
-        queue.asyncAfter(deadline: DispatchTime.now() + Double(Int64(ProfileRemoteTabsSyncDelay * Double(NSEC_PER_MSEC))) / Double(NSEC_PER_SEC)) {
+        queue.asyncAfter(deadline: .now() + .milliseconds(100)) {
             profile.storeTabs(storedTabs)
         }
     }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -752,3 +752,22 @@ class TabManagerNavDelegate: NSObject, WKNavigationDelegate {
         decisionHandler(res)
     }
 }
+
+// Helper functions for test cases
+extension TabManager {
+    func testTabCountOnDisk() -> Int {
+        assert(AppConstants.IsRunningTest)
+        return store.testTabCountOnDisk()
+    }
+
+    func testCountRestoredTabs() -> Int {
+        assert(AppConstants.IsRunningTest)
+        _ = store.restoreStartupTabs(clearPrivateTabs: true, tabManager: self)
+        return count
+    }
+
+    func testClearArchive() {
+        assert(AppConstants.IsRunningTest)
+        store.testClearArchive()
+    }
+}

--- a/Client/Frontend/Browser/TabManagerStore.swift
+++ b/Client/Frontend/Browser/TabManagerStore.swift
@@ -32,13 +32,14 @@ class TabManagerStore {
     }
 
     fileprivate func tabsStateArchivePath() -> String? {
-        guard let profilePath = fileManager.containerURL(
-            forSecurityApplicationGroupIdentifier: AppInfo.sharedContainerIdentifier)?
-            .appendingPathComponent("profile.profile").path else {
-                return nil
+        let profilePath: String?
+        if  AppConstants.IsRunningTest {
+            profilePath = (UIApplication.shared.delegate as? TestAppDelegate)?.dirForTestProfile
+        } else {
+            profilePath = fileManager.containerURL( forSecurityApplicationGroupIdentifier: AppInfo.sharedContainerIdentifier)?.appendingPathComponent("profile.profile").path
         }
-
-        return URL(fileURLWithPath: profilePath).appendingPathComponent("tabsState.archive").path
+        guard let path = profilePath else { return nil }
+        return URL(fileURLWithPath: path).appendingPathComponent("tabsState.archive").path
     }
 
     fileprivate func tabsToRestore() -> [SavedTab] {
@@ -138,5 +139,20 @@ class TabManagerStore {
         }
 
         return tabToSelect
+    }
+}
+
+// Functions for testing
+extension TabManagerStore {
+    func testTabCountOnDisk() -> Int {
+        assert(AppConstants.IsRunningTest)
+        return tabsToRestore().count
+    }
+
+    func testClearArchive() {
+        assert(AppConstants.IsRunningTest)
+        if let path = tabsStateArchivePath() {
+            try? FileManager.default.removeItem(atPath: path)
+        }
     }
 }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -353,15 +353,11 @@ class TabTrayController: UIViewController {
 }
 
 extension TabTrayController: TabManagerDelegate {
-    func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?) {}
-
+    func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?, isRestoring: Bool) {}
+    func tabManager(_ tabManager: TabManager, didAddTab tab: Tab, isRestoring: Bool) {}
+    func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool) {}
     func tabManager(_ tabManager: TabManager, willAddTab tab: Tab) {}
-
-    func tabManager(_ tabManager: TabManager, didAddTab tab: Tab) {}
-
     func tabManager(_ tabManager: TabManager, willRemoveTab tab: Tab) {}
-
-    func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab) {}
 
     func tabManagerDidRestoreTabs(_ tabManager: TabManager) {
         self.emptyPrivateTabsView.isHidden = !self.privateTabsAreEmpty()

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -19,13 +19,6 @@ open class TabManagerMockProfile: MockProfile {
     }
 }
 
-open class MockTabManagerStateDelegate: TabManagerStateDelegate {
-    var numberOfTabsStored = 0
-    public func tabManagerWillStoreTabs(_ tabs: [Tab]) {
-        numberOfTabsStored = tabs.count
-    }
-}
-
 struct MethodSpy {
     let functionName: String
     let method: ((_ tabs: [Tab?]) -> Void)?
@@ -41,7 +34,7 @@ struct MethodSpy {
     }
 }
 
-fileprivate let spyDidSelectedTabChange = "tabManager(_:didSelectedTabChange:previous:)"
+fileprivate let spyDidSelectedTabChange = "tabManager(_:didSelectedTabChange:previous:isRestoring:)"
 
 open class MockTabManagerDelegate: TabManagerDelegate {
     //this array represents the order in which delegate methods should be called.
@@ -69,15 +62,15 @@ open class MockTabManagerDelegate: TabManagerDelegate {
         methodCatchers.removeFirst()
     }
 
-    public func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?) {
+    public func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?, isRestoring: Bool) {
         testDelegateMethodWithName(#function, tabs: [selected, previous])
     }
 
-    public func tabManager(_ tabManager: TabManager, didAddTab tab: Tab) {
+    public func tabManager(_ tabManager: TabManager, didAddTab tab: Tab, isRestoring: Bool) {
         testDelegateMethodWithName(#function, tabs: [tab])
     }
 
-    public func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab) {
+    public func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool) {
         testDelegateMethodWithName(#function, tabs: [tab])
     }
 
@@ -105,9 +98,9 @@ open class MockTabManagerDelegate: TabManagerDelegate {
 class TabManagerTests: XCTestCase {
 
     let willRemove = MethodSpy(functionName: "tabManager(_:willRemoveTab:)")
-    let didRemove = MethodSpy(functionName: "tabManager(_:didRemoveTab:)")
+    let didRemove = MethodSpy(functionName: "tabManager(_:didRemoveTab:isRestoring:)")
     let willAdd = MethodSpy(functionName: "tabManager(_:willAddTab:)")
-    let didAdd = MethodSpy(functionName: "tabManager(_:didAddTab:)")
+    let didAdd = MethodSpy(functionName: "tabManager(_:didAddTab:isRestoring:)")
 
     override func setUp() {
         super.setUp()
@@ -117,51 +110,9 @@ class TabManagerTests: XCTestCase {
         super.tearDown()
     }
 
-    func testTabManagerCallsTabManagerStateDelegateOnStoreChangesWithNormalTabs() {
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
-        let stateDelegate = MockTabManagerStateDelegate()
-        manager.stateDelegate = stateDelegate
-        let configuration = WKWebViewConfiguration()
-        configuration.processPool = WKProcessPool()
-
-        // test that non-private tabs are saved to the db
-        // add some non-private tabs to the tab manager
-        for _ in 0..<3 {
-            let tab = Tab(configuration: configuration)
-            tab.url = URL(string: "http://yahoo.com")!
-            manager.configureTab(tab, request: URLRequest(url: tab.url!), flushToDisk: false, zombie: false)
-        }
-
-        manager.storeChanges()
-
-        XCTAssertEqual(stateDelegate.numberOfTabsStored, 3, "Expected state delegate to have been called with 3 tabs, but called with \(stateDelegate.numberOfTabsStored)")
-    }
-
-    func testTabManagerDoesNotCallTabManagerStateDelegateOnStoreChangesWithPrivateTabs() {
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
-        let stateDelegate = MockTabManagerStateDelegate()
-        manager.stateDelegate = stateDelegate
-        let configuration = WKWebViewConfiguration()
-        configuration.processPool = WKProcessPool()
-
-        // test that non-private tabs are saved to the db
-        // add some non-private tabs to the tab manager
-        for _ in 0..<3 {
-            let tab = Tab(configuration: configuration, isPrivate: true)
-            tab.url = URL(string: "http://yahoo.com")!
-            manager.configureTab(tab, request: URLRequest(url: tab.url!), flushToDisk: false, zombie: false)
-        }
-
-        manager.storeChanges()
-
-        XCTAssertEqual(stateDelegate.numberOfTabsStored, 0, "Expected state delegate to have been called with 3 tabs, but called with \(stateDelegate.numberOfTabsStored)")
-    }
-
     func testAddTabShouldAddOneNormalTab() {
         let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(profile: profile, imageStore: nil)
         let delegate = MockTabManagerDelegate()
         manager.addDelegate(delegate)
 
@@ -173,7 +124,7 @@ class TabManagerTests: XCTestCase {
 
     func testAddTabShouldAddOnePrivateTab() {
         let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(profile: profile, imageStore: nil)
         let delegate = MockTabManagerDelegate()
         manager.addDelegate(delegate)
 
@@ -185,14 +136,14 @@ class TabManagerTests: XCTestCase {
 
     func testAddTabAndSelect() {
         let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(profile: profile, imageStore: nil)
         manager.selectTab(manager.addTab())
         XCTAssertEqual(manager.selectedIndex, 0, "There should be selected first tab")
     }
 
     func testMoveTabFromLastToFirstPosition() {
         let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(profile: profile, imageStore: nil)
         // add two tabs, last one will be selected
         manager.selectTab(manager.addTab())
         manager.moveTab(isPrivate: false, fromIndex: 1, toIndex: 0)
@@ -201,7 +152,7 @@ class TabManagerTests: XCTestCase {
 
     func testDidDeleteLastTab() {
         let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(profile: profile, imageStore: nil)
         let delegate = MockTabManagerDelegate()
 
         let didSelect = MethodSpy(functionName: spyDidSelectedTabChange) { tabs in
@@ -221,7 +172,7 @@ class TabManagerTests: XCTestCase {
 
     func testDidDeleteLastPrivateTab() {
         let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(profile: profile, imageStore: nil)
         let delegate = MockTabManagerDelegate()
 
         //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
@@ -248,7 +199,7 @@ class TabManagerTests: XCTestCase {
     func testDeletePrivateTabsOnExit() {
         //setup
         let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(profile: profile, imageStore: nil)
         profile.prefs.setBool(true, forKey: "settings.closePrivateTabs")
 
         // create one private and one normal tab
@@ -284,7 +235,7 @@ class TabManagerTests: XCTestCase {
 
     func testTogglePBMDelete() {
         let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(profile: profile, imageStore: nil)
         profile.prefs.setBool(true, forKey: "settings.closePrivateTabs")
 
         let tab = manager.addTab()
@@ -302,7 +253,7 @@ class TabManagerTests: XCTestCase {
 
     func testRemoveNonSelectedTab() {
         let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(profile: profile, imageStore: nil)
 
         let tab = manager.addTab()
         manager.selectTab(tab)
@@ -316,7 +267,7 @@ class TabManagerTests: XCTestCase {
 
     func testDeleteSelectedTab() {
         let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(profile: profile, imageStore: nil)
         let delegate = MockTabManagerDelegate()
 
         func addTab(_ visit: Bool) -> Tab {
@@ -357,7 +308,7 @@ class TabManagerTests: XCTestCase {
 
     func testDeleteLastTab() {
         let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(profile: profile, imageStore: nil)
         let delegate = MockTabManagerDelegate()
 
         //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
@@ -383,7 +334,7 @@ class TabManagerTests: XCTestCase {
         //setup
         let profile = TabManagerMockProfile()
         let delegate = MockTabManagerDelegate()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(profile: profile, imageStore: nil)
         profile.prefs.setBool(true, forKey: "settings.closePrivateTabs")
 
         // create one private and one normal tab
@@ -423,7 +374,7 @@ class TabManagerTests: XCTestCase {
 
     func testDeleteFirstTab() {
         let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(profile: profile, imageStore: nil)
         let delegate = MockTabManagerDelegate()
 
         //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
@@ -446,7 +397,7 @@ class TabManagerTests: XCTestCase {
 
     func testRemoveTabSelectedTabShouldChangeIndex() {
         let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(profile: profile, imageStore: nil)
 
         let tab1 = manager.addTab()
         manager.addTab()
@@ -463,7 +414,7 @@ class TabManagerTests: XCTestCase {
 
     func testRemoveTabRemovingLastNormalTabShouldNotSwitchToPrivateTab() {
         let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(profile: profile, imageStore: nil)
 
         let tab0 = manager.addTab()
         let tab1 = manager.addTab(isPrivate: true)
@@ -481,7 +432,7 @@ class TabManagerTests: XCTestCase {
 
     func testRemoveAllShouldRemoveAllTabs() {
         let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(profile: profile, imageStore: nil)
 
         let tab0 = manager.addTab()
         let tab1 = manager.addTab()
@@ -495,7 +446,7 @@ class TabManagerTests: XCTestCase {
     // Make sure that when a private tab is added inbetween regular tabs it isnt accidently selected when removing a regular tab
     func testTabsIndex() {
         let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(profile: profile, imageStore: nil)
         let delegate = MockTabManagerDelegate()
 
         // We add 2 tabs. Then a private one before adding another normal tab and selecting it.
@@ -521,7 +472,7 @@ class TabManagerTests: XCTestCase {
 
     func testRemoveTabAndUpdateSelectedIndexIsSelectedParentTabAfterRemoval() {
         let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(profile: profile, imageStore: nil)
 
         func addTab(_ visit: Bool) -> Tab {
             let tab = manager.addTab()
@@ -545,7 +496,7 @@ class TabManagerTests: XCTestCase {
 
     func testTabsIndexClosingFirst() {
         let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(profile: profile, imageStore: nil)
         let delegate = MockTabManagerDelegate()
 
         // We add 2 tabs. Then a private one before adding another normal tab and selecting the first.
@@ -570,7 +521,7 @@ class TabManagerTests: XCTestCase {
 
     func testUndoCloseTabsRemovesAutomaticallyCreatedNonPrivateTab() {
         let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(profile: profile, imageStore: nil)
 
         let tab = manager.addTab()
         let tabToSave = Tab(configuration: WKWebViewConfiguration())


### PR DESCRIPTION
Please follow the split commits comments. 
I hope I split this up to tell the story of the patch with some degree of clarity.

Tests were changed significantly, as the new API is more private than before.