### PR TITLE
Bug 1487354 - UITests: change tearDown to new Data Management name fo…

### DIFF
--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -328,11 +328,11 @@ class BrowserUtils {
                 .perform(grey_swipeFastInDirection(GREYDirection.left))
         }
         EarlGrey.selectElement(with: settings_button).perform(grey_tap())
-        EarlGrey.selectElement(with: grey_accessibilityLabel("Clear Private Data"))
+        EarlGrey.selectElement(with: grey_accessibilityID("ClearPrivateData"))
             .using(searchAction: grey_scrollInDirection(.down, 200),
                    onElementWithMatcher: grey_accessibilityID("AppSettingsTableViewController.tableView"))
             .assert(grey_notNil())
-        EarlGrey.selectElement(with: grey_accessibilityLabel("Clear Private Data")).perform(grey_tap())
+        EarlGrey.selectElement(with: grey_accessibilityID("ClearPrivateData")).perform(grey_tap())
     }
 
     class func closeClearPrivateDataDialog() {


### PR DESCRIPTION
…r Clear Data option

This PR fixes the UI tests which are broken due to the change in the name for the Clear Private Menu option. See [commit](https://github.com/mozilla-mobile/firefox-ios/commit/d76068581ac040a34a93b7824c12f1b367e68a41) Now IDs have been used to avoid this problem in the future.