### PR TITLE
Bug 1487928 - Favicons do not appear in awesomebar search results

### DIFF
--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -189,7 +189,7 @@ fileprivate struct SQLiteFrecentHistory: FrecentHistory {
     }
 
     func getSites(whereURLContains filter: String?, historyLimit limit: Int, bookmarksLimit: Int) -> Deferred<Maybe<Cursor<Site>>> {
-        let factory = SQLiteHistory.basicHistoryColumnFactory
+        let factory = SQLiteHistory.iconHistoryColumnFactory
 
         let params = FrecencyQueryParams.urlCompletion(bookmarksLimit: bookmarksLimit, whereURLContains: filter ?? "", groupClause: "GROUP BY historyID ")
         let (query, args) = getFrecencyQuery(historyLimit: limit, params: params)
@@ -398,7 +398,17 @@ fileprivate struct SQLiteFrecentHistory: FrecentHistory {
             return (historySQL, args)
         }
 
-        let allSQL = "SELECT * FROM (SELECT * FROM (\(historySQL)) UNION SELECT * FROM (\(bookmarksSQL))) ORDER BY is_bookmarked DESC, frecencies DESC"
+        let allSQL = """
+            SELECT *
+            FROM (
+                SELECT * FROM (\(historySQL))
+                UNION
+                SELECT * FROM (\(bookmarksSQL))
+            ) AS hb
+            LEFT OUTER JOIN view_favicons_widest ON view_favicons_widest.siteID = hb.historyID
+            ORDER BY is_bookmarked DESC, frecencies DESC
+            """
+
         return (allSQL, args)
     }
 
@@ -542,7 +552,16 @@ fileprivate struct SQLiteFrecentHistory: FrecentHistory {
             return (historySQL, args)
         }
 
-        let allSQL = "SELECT * FROM (SELECT * FROM (\(historySQL)) UNION SELECT * FROM (\(bookmarksSQL))) ORDER BY is_bookmarked DESC, frecencies DESC"
+        let allSQL = """
+            SELECT *
+            FROM (
+                SELECT * FROM (\(historySQL))
+                UNION
+                SELECT * FROM (\(bookmarksSQL))
+            ) AS hb
+            LEFT OUTER JOIN view_favicons_widest ON view_favicons_widest.siteID = hb.historyID
+            ORDER BY is_bookmarked DESC, frecencies DESC
+            """
         return (allSQL, args)
     }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1487928

I don't think this has ever worked (or at least not for quite a while). I haven't directly benchmarked this yet, but I haven't seen any noticeable perf issues with my ~200k history DB. At the stage where we `LEFT OUTER JOIN` to favicons, the bulk of the query is done and the number of results has been limited. So, the cost of doing this join *should* be minimized.