### PR TITLE
Bug 1485341 - Top Sites, Bookmarks and History are not displayed after sending a tab via 3DT from Tabs Tray

### DIFF
--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -166,6 +166,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
             let clientPickerController = ClientPickerViewController()
             clientPickerController.clientPickerDelegate = clientPickerDelegate
             clientPickerController.profile = browserProfile
+            clientPickerController.profileNeedsShutdown = false
             if let url = tab.url?.absoluteString {
                 clientPickerController.shareItem = ShareItem(url: url, title: tab.title, favicon: nil)
             }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1485341

We clear this flag when accessing from the Page Actions menu. We must've forgot to clear it here too.