### PR TITLE
 Bug 1488771 - Fix browsertray animation crash. 

### DIFF
--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -261,6 +261,9 @@ private func headerTransform(_ frame: CGRect, toFrame finalFrame: CGRect, contai
 
 //MARK: Private Helper Methods
 private func calculateCollapsedCellFrameUsingCollectionView(_ collectionView: UICollectionView, atIndex index: Int) -> CGRect {
+    guard index < collectionView.numberOfItems(inSection: 0) else {
+        return .zero
+    }
     if let attr = collectionView.collectionViewLayout.layoutAttributesForItem(at: IndexPath(item: index, section: 0)) {
         return collectionView.convert(attr.frame, to: collectionView.superview)
     } else {

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -485,6 +485,9 @@ class TabManager: NSObject {
                 removeTabAndUpdateSelectedIndex(removed)
             } else {
                 removeTabs(tabsCopy)
+                if normalTabs.isEmpty {
+                    selectTab(addTab())
+                }
             }
         }
         for tab in tabs {

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -196,6 +196,27 @@ class TabManagerTests: XCTestCase {
         delegate.verify("Not all delegate methods were called")
     }
 
+    func testDidCreateNormalTabWhenDeletingAll() {
+        let removeAllTabs = MethodSpy(functionName: "tabManagerDidRemoveAllTabs(_:toast:)")
+
+        let profile = TabManagerMockProfile()
+        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let delegate = MockTabManagerDelegate()
+
+        //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
+        let tab = manager.addTab()
+        manager.selectTab(tab)
+        let privateTab = manager.addTab(isPrivate: true)
+        manager.selectTab(privateTab)
+        manager.addDelegate(delegate)
+
+        // This test makes sure that a normal tab is always added even when a normal tab is not selected when calling removeAll
+        delegate.expect([willRemove, didRemove, willAdd, didAdd, removeAllTabs])
+
+        manager.removeTabsWithUndoToast(manager.normalTabs)
+        delegate.verify("Not all delegate methods were called")
+    }
+
     func testDeletePrivateTabsOnExit() {
         //setup
         let profile = TabManagerMockProfile()

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -200,7 +200,7 @@ class TabManagerTests: XCTestCase {
         let removeAllTabs = MethodSpy(functionName: "tabManagerDidRemoveAllTabs(_:toast:)")
 
         let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(profile: profile, imageStore: nil)
         let delegate = MockTabManagerDelegate()
 
         //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about


### PR DESCRIPTION
Ensure that the tab tray can animate even if there are 0 tabs. 

I fixed this by making sure that when we remove all normal tabs we always create a new tab. The `removeTabAndUpdateSelectedIndex` does do this but that isnt called because the selected tab is private when this crash happens. 

I also fixed this on the animation side as well. If a valid cell cant be found simply animate without one. The animation isnt ideal but its better than crashing.