### PR TITLE
Bug 1488937 - profile.storeTabs was off-main, risky and not needed

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -577,8 +577,7 @@ extension TabManager {
 
         // Don't insert into the DB immediately. We tend to contend with more important
         // work like querying for top sites.
-        let queue = DispatchQueue.global(qos: DispatchQoS.background.qosClass)
-        queue.asyncAfter(deadline: .now() + .milliseconds(100)) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
             profile.storeTabs(storedTabs)
         }
     }


### PR DESCRIPTION
This can be on-main. The internal db work is already on a background thread.
Not just a cosmetic fix, I had a startup crash in debug where this was in the stack trace in 2 threads. 
https://bugzilla.mozilla.org/show_bug.cgi?id=1488937
