### PR TITLE
Bug 1487165 - TabManagerStore test: disable restoreTabs()

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -595,6 +595,8 @@ extension TabManager {
     }
 
     func restoreTabs() {
+        guard !AppConstants.IsRunningTest else { return }
+
         defer {
             // Always make sure there is a single normal tab.
             if normalTabs.isEmpty {
@@ -604,7 +606,7 @@ extension TabManager {
                 }
             }
         }
-        guard count == 0, !AppConstants.IsRunningTest, !DebugSettingsBundleOptions.skipSessionRestore, store.hasTabsToRestoreAtStartup else {
+        guard count == 0, !DebugSettingsBundleOptions.skipSessionRestore, store.hasTabsToRestoreAtStartup else {
             return
         }
 


### PR DESCRIPTION
This event it happening during the test, and the app has no tabs to restore, so it adds a tab.