### PR TITLE
 Bug 1491483 - Dont reset the cursor if we arent removing an autofill completion

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -162,18 +162,22 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
 
         // Clear the current completion, then set the text without the attributed style.
         let text = (self.text ?? "") + (self.autocompleteTextLabel?.text ?? "")
-        removeCompletion()
+        let didRemoveCompletion = removeCompletion()
         self.text = text
         hideCursor = false
         // Move the cursor to the end of the completion.
-        selectedTextRange = textRange(from: endOfDocument, to: endOfDocument)
+        if didRemoveCompletion {
+            selectedTextRange = textRange(from: endOfDocument, to: endOfDocument)
+        }
     }
 
-    /// Removes the autocomplete-highlighted
-    @objc fileprivate func removeCompletion() {
+    /// Removes the autocomplete-highlighted. Returns true if a completion was actually removed
+    @objc @discardableResult fileprivate func removeCompletion() -> Bool {
+        let hasActiveCompletion = isSelectionActive
         autocompleteTextLabel?.removeFromSuperview()
         clearButton?.removeFromSuperview()
         autocompleteTextLabel = nil
+        return hasActiveCompletion
     }
 
     // `shouldChangeCharactersInRange` is called before the text changes, and textDidChange is called after.


### PR DESCRIPTION
We intercept touches in `touchesBegan` to allow an autocompletion that we might be showing to be filled in the urlbar. We also reset the cursor to the end of the textfield. Problem is we do this even if there isnt any autocomplete text