### PR TITLE
Bug 1491921 - Remove undoRemoveAllTabs Toast support from TabTray. 

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -366,14 +366,9 @@ extension TabTrayController: TabManagerDelegate {
     func tabManagerDidAddTabs(_ tabManager: TabManager) {}
 
     func tabManagerDidRemoveAllTabs(_ tabManager: TabManager, toast: ButtonToast?) {
-        guard let toast = toast, privateMode else {
-            return
-        }
-        view.addSubview(toast)
-        toast.showToast(delay: SimpleToastUX.ToastPrivateModeDelayBefore, makeConstraints: { make in
-            make.left.right.equalTo(self.view)
-            make.bottom.equalTo(self.toolbar.snp.top)
-        })
+        // No need to handle removeAll toast in TabTray.
+        // When closing all normal tabs we automatically focus a tab and show the BVC. Which will handle the Toast.
+        // We don't show the removeAll toast in PBM
     }
 }
 

--- a/Client/Frontend/Browser/Toast.swift
+++ b/Client/Frontend/Browser/Toast.swift
@@ -35,6 +35,7 @@ class Toast: UIView {
 
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
             viewController?.view.addSubview(self)
+            guard let _ = viewController else { return }
 
             self.snp.makeConstraints(makeConstraints)
             self.layoutIfNeeded()


### PR DESCRIPTION
No need to show the removeAllTabs undo Toast in normal mode so might as well get rid of it. I've also added a check in Toast.swift to make sure the viewcontroller actually exists before trying to setup constraints. 