### PR TITLE
Bug 1492099 - Make sure tab animations can happen even if the frame zero

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -425,7 +425,7 @@ extension TabDisplayManager {
             completionBlocks.append(block)
         }
 
-        if self.isUpdating || self.collectionView.frame == CGRect.zero {
+        if self.isUpdating || self.collectionView.superview == nil {
             self.pendingReloadData = true
             return
         }


### PR DESCRIPTION
I think checking to see if the superview is nil should be good enough. 