### PR TITLE
No Bug - Renable DragDrop in the TabTray.

### DIFF
--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -101,7 +101,6 @@ class LeanPlumClient {
     // to prompting with native push permissions.
     private var useFxAPrePush: LPVar = LPVar.define("useFxAPrePush", with: false)
     var enablePocketVideo: LPVar = LPVar.define("pocketVideo", with: false)
-    var enableDragDrop: LPVar = LPVar.define("tabTrayDrag", with: false)
 
     var introScreenVars = LPVar.define("IntroScreen", with: IntroCard.defaultCards().compactMap({ $0.asDictonary() }))
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -168,7 +168,7 @@ class TabTrayController: UIViewController {
         collectionView.keyboardDismissMode = .onDrag
 
         // XXX: Bug 1485064 - Temporarily disable drag-and-drop in tabs tray
-         if #available(iOS 11.0, *), LeanPlumClient.shared.enableDragDrop.boolValue() {
+         if #available(iOS 11.0, *) {
              collectionView.dragInteractionEnabled = true
              collectionView.dragDelegate = tabDisplayManager
              collectionView.dropDelegate = tabDisplayManager


### PR DESCRIPTION
We've had this enabled via LP for a week now and havent seen an increase in crashes. Safe to turn it on for everyone again.