### PR TITLE
Bug 1482382 - make sure to update tab count

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1547,6 +1547,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         let closeTab = PhotonActionSheetItem(title: Strings.CloseTabTitle, iconString: "tab_close", iconType: .Image) { action in
             if let tab = self.tabManager.selectedTab {
                 self.tabManager.removeTabAndUpdateSelectedIndex(tab)
+                self.updateTabCountUsingTabManager(self.tabManager)
             }}
         if let tab = self.tabManager.selectedTab {
             return tab.isPrivate ? [newPrivateTab, closeTab] : [newTab, closeTab]


### PR DESCRIPTION
We do call `updateTabCountUsingTabManager` in "didRemoveTab" but because of the refactor of TabManager, there isnt a selected tab when that `didRemoveTab` delegate method is called and the tab count cant be updated. 