### PR TITLE
Bug 1487515 - XCUITest: Use internal web server

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_SmokeXCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_SmokeXCUITests.xcscheme
@@ -497,9 +497,6 @@
                   Identifier = "SaveLoginTest/testSaveLogin()">
                </Test>
                <Test
-                  Identifier = "SaveLoginTest/testSavedLoginSelectUnselect()">
-               </Test>
-               <Test
                   Identifier = "SaveLoginTest/testSearchLogin()">
                </Test>
                <Test

--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
@@ -215,6 +215,9 @@
                   Identifier = "BookmarkingTests/testBookmarksAwesomeBar()">
                </Test>
                <Test
+                  Identifier = "BrowsingPDFTests">
+               </Test>
+               <Test
                   Identifier = "ClipBoardTests/testClipboardPasteAndGo()">
                </Test>
                <Test
@@ -293,25 +296,7 @@
                   Identifier = "ReaderViewTest/testLoadReaderContent()">
                </Test>
                <Test
-                  Identifier = "SaveLoginTest/testDeleteLogin()">
-               </Test>
-               <Test
-                  Identifier = "SaveLoginTest/testDoNotSaveLogin()">
-               </Test>
-               <Test
-                  Identifier = "SaveLoginTest/testEditOneLoginEntry()">
-               </Test>
-               <Test
-                  Identifier = "SaveLoginTest/testSaveLogin()">
-               </Test>
-               <Test
-                  Identifier = "SaveLoginTest/testSavedLoginAutofilled()">
-               </Test>
-               <Test
                   Identifier = "SaveLoginTest/testSavedLoginSelectUnselect()">
-               </Test>
-               <Test
-                  Identifier = "SaveLoginTest/testSearchLogin()">
                </Test>
                <Test
                   Identifier = "SearchTests/testDismissPromptPresence()">

--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -109,7 +109,9 @@ class ActivityStreamTest: BaseTestCase {
 
     func testTopSitesRemoveAllExceptDefaultClearPrivateData() {
         navigator.goto(BrowserTab)
+        navigator.goto(BrowserTabMenu)
         navigator.goto(HomePanel_TopSites)
+        waitforExistence(app.collectionViews.cells["mozilla"])
         XCTAssertTrue(app.collectionViews.cells["mozilla"].exists)
         // A new site has been added to the top sites
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
@@ -124,7 +126,8 @@ class ActivityStreamTest: BaseTestCase {
     func testTopSitesRemoveAllExceptPinnedClearPrivateData() {
         navigator.goto(BrowserTab)
         navigator.performAction(Action.PinToTopSitesPAM)
-        navigator.goto(HomePanelsScreen)
+        navigator.goto(BrowserTabMenu)
+        navigator.goto(HomePanel_TopSites)
         waitforExistence(app.collectionViews.cells[newTopSite["topSiteLabel"]!])
         XCTAssertTrue(app.collectionViews.cells[newTopSite["topSiteLabel"]!].exists)
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
@@ -138,7 +141,6 @@ class ActivityStreamTest: BaseTestCase {
     }
 
     func testTopSitesShiftAfterRemovingOne() {
-
         // Check top site in first and second cell
         let topSiteFirstCell = app.collectionViews.cells.collectionViews.cells.element(boundBy: 0).label
         let topSiteSecondCell = app.collectionViews.cells.collectionViews.cells.element(boundBy: 1).label

--- a/XCUITests/BrowsingPDFTests.swift
+++ b/XCUITests/BrowsingPDFTests.swift
@@ -9,11 +9,11 @@ let PDF_website = ["url": "http://www.pdf995.com/samples/pdf.pdf", "pdfValue": "
 class BrowsingPDFTests: BaseTestCase {
     func testOpenPDFViewer() {
         navigator.openURL(PDF_website["url"]!)
+
         waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: PDF_website["pdfValue"]!)
-
         // Swipe Up and Down
-        let element = app/*@START_MENU_TOKEN@*/.webViews/*[[".otherElements[\"Web content\"].webViews",".otherElements[\"contentView\"].webViews",".webViews"],[[[-1,2],[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.children(matching: .other).element
+        let element = app.children(matching: .other).element
         element.swipeUp()
         waitforExistence(app.staticTexts["2 of 5"])
 

--- a/XCUITests/DragAndDropTests.swift
+++ b/XCUITests/DragAndDropTests.swift
@@ -282,11 +282,13 @@ class DragAndDropTests: IpadOnlyTestCase {
 
     func testTryDragAndDropBookmarkToURLBar() {
         if skipPlatform { return }
-
+        navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
+        navigator.performAction(Action.BookmarkThreeDots)
+        navigator.nowAt(BrowserTab)
+        navigator.goto(BrowserTabMenu)
         navigator.goto(HomePanel_Bookmarks)
         waitforExistence(app.tables["Bookmarks List"])
-
-        app.tables["Bookmarks List"].cells.staticTexts[secondWebsite["tabName"]!].press(forDuration: 1, thenDragTo: app.textFields["url"])
+        app.tables["Bookmarks List"].cells.staticTexts["The Book of Mozilla"].press(forDuration: 1, thenDragTo: app.textFields["url"])
 
         // It is not allowed to drop the entry on the url field
         let urlBarValue = app.textFields["url"].value as? String

--- a/XCUITests/DragAndDropTests.swift
+++ b/XCUITests/DragAndDropTests.swift
@@ -282,13 +282,11 @@ class DragAndDropTests: IpadOnlyTestCase {
 
     func testTryDragAndDropBookmarkToURLBar() {
         if skipPlatform { return }
-        navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
-        navigator.performAction(Action.BookmarkThreeDots)
-        navigator.nowAt(BrowserTab)
-        navigator.goto(BrowserTabMenu)
+
         navigator.goto(HomePanel_Bookmarks)
         waitforExistence(app.tables["Bookmarks List"])
-        app.tables["Bookmarks List"].cells.staticTexts["The Book of Mozilla"].press(forDuration: 1, thenDragTo: app.textFields["url"])
+
+        app.tables["Bookmarks List"].cells.staticTexts[secondWebsite["tabName"]!].press(forDuration: 1, thenDragTo: app.textFields["url"])
 
         // It is not allowed to drop the entry on the url field
         let urlBarValue = app.textFields["url"].value as? String

--- a/XCUITests/FindInPageTest.swift
+++ b/XCUITests/FindInPageTest.swift
@@ -13,24 +13,32 @@ class FindInPageTests: BaseTestCase {
 
         waitforExistence(app.buttons["FindInPage.find_next"], timeout: 5)
         waitforExistence(app.buttons["FindInPage.find_previous"], timeout: 5)
-        XCTAssertTrue(app.textFields[""].exists)
+        XCTAssertTrue(app.textFields["FindInPage.searchField"].exists)
     }
 
     func testFindInLargeDoc() {
-        userState.url = "http://localhost:6571/find-in-page-test.html"
-        openFindInPageFromMenu()
+        navigator.openURL("http://localhost:6571/find-in-page-test.html")
+        waitUntilPageLoad()
+        // Workaround until FxSGraph is fixed to allow the previos way with goto
+        navigator.nowAt(BrowserTab)
+
+        waitforExistence(app/*@START_MENU_TOKEN@*/.buttons["TabLocationView.pageOptionsButton"]/*[[".buttons[\"Page Options Menu\"]",".buttons[\"TabLocationView.pageOptionsButton\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/, timeout: 15)
+        app/*@START_MENU_TOKEN@*/.buttons["TabLocationView.pageOptionsButton"]/*[[".buttons[\"Page Options Menu\"]",".buttons[\"TabLocationView.pageOptionsButton\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        waitforExistence(app.tables["Context Menu"].cells["menu-FindInPage"], timeout: 10)
+        app.tables["Context Menu"].cells["menu-FindInPage"].tap()
 
         // Enter some text to start finding
-        app.textFields[""].typeText("Book")
+        app.textFields["FindInPage.searchField"].typeText("Book")
         waitforExistence(app.textFields["Book"], timeout: 15)
         XCTAssertEqual(app.staticTexts["FindInPage.matchCount"].label, "1/500+", "The book word count does match")
     }
 
     func testFindFromMenu() {
+        userState.url = path(forTestPage: "test-mozilla-book.html")
         openFindInPageFromMenu()
 
         // Enter some text to start finding
-        app.textFields[""].typeText("Book")
+        app.textFields["FindInPage.searchField"].typeText("Book")
 
         // Once there are matches, test previous/next buttons
         waitforExistence(app.staticTexts["1/6"])
@@ -61,9 +69,10 @@ class FindInPageTests: BaseTestCase {
     }
 
     func testFindInPageTwoWordsSearch() {
+        userState.url = path(forTestPage: "test-mozilla-book.html")
         openFindInPageFromMenu()
         // Enter some text to start finding
-        app.textFields[""].typeText("The Book of")
+        app.textFields["FindInPage.searchField"].typeText("The Book of")
 
         // Once there are matches, test previous/next buttons
         waitforExistence(app.staticTexts["1/6"])
@@ -71,11 +80,15 @@ class FindInPageTests: BaseTestCase {
     }
 
     func testFindInPageTwoWordsSearchLargeDoc() {
-        userState.url = "http://localhost:6571/find-in-page-test.html"
-        openFindInPageFromMenu()
-
+        navigator.openURL("http://localhost:6571/find-in-page-test.html")
+        waitUntilPageLoad()
+        // Workaround until FxSGraph is fixed to allow the previos way with goto
+        navigator.nowAt(BrowserTab)
+        waitforExistence(app/*@START_MENU_TOKEN@*/.buttons["TabLocationView.pageOptionsButton"]/*[[".buttons[\"Page Options Menu\"]",".buttons[\"TabLocationView.pageOptionsButton\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/, timeout: 15)
+        app/*@START_MENU_TOKEN@*/.buttons["TabLocationView.pageOptionsButton"]/*[[".buttons[\"Page Options Menu\"]",".buttons[\"TabLocationView.pageOptionsButton\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
         // Enter some text to start finding
-        app.textFields[""].typeText("The Book of")
+        app.tables["Context Menu"].cells["menu-FindInPage"].tap()
+        app.textFields["FindInPage.searchField"].typeText("The Book of")
         waitforExistence(app.textFields["The Book of"], timeout: 15)
         XCTAssertEqual(app.staticTexts["FindInPage.matchCount"].label, "1/500+", "The book word count does match")
     }
@@ -84,7 +97,7 @@ class FindInPageTests: BaseTestCase {
         userState.url = "lorem2.com"
         openFindInPageFromMenu()
         // Enter some text to start finding
-        app.textFields[""].typeText("lorem")
+        app.textFields["FindInPage.searchField"].typeText("lorem")
 
         // There should be matches
         waitforExistence(app.staticTexts["1/5"])
@@ -92,6 +105,7 @@ class FindInPageTests: BaseTestCase {
     }
 
     func testQueryWithNoMatches() {
+        userState.url = path(forTestPage: "test-mozilla-book.html")
         openFindInPageFromMenu()
 
         // Try to find text which does not match and check that there are not results
@@ -101,6 +115,7 @@ class FindInPageTests: BaseTestCase {
     }
 
     func testBarDissapearsWhenReloading() {
+        userState.url = path(forTestPage: "test-mozilla-book.html")
         openFindInPageFromMenu()
 
         // Before reloading, it is necessary to hide the keyboard
@@ -113,6 +128,7 @@ class FindInPageTests: BaseTestCase {
     }
 
     func testBarDissapearsWhenOpeningTabsTray() {
+        userState.url = path(forTestPage: "test-mozilla-book.html")
         openFindInPageFromMenu()
 
         // Dismiss keyboard
@@ -130,6 +146,7 @@ class FindInPageTests: BaseTestCase {
     }
 
     func testFindFromSelection() {
+        userState.url = path(forTestPage: "test-mozilla-book.html")
         navigator.goto(BrowserTab)
         let textToFind = "from"
 
@@ -145,7 +162,7 @@ class FindInPageTests: BaseTestCase {
         if (app.menuItems["Find in Page"].exists) {
             app.menuItems["Find in Page"].tap()
         } else {
-            app.menuItems["Show more items"].tap()
+            app.menus.children(matching: .menuItem).element(boundBy: 3).tap()
             waitforExistence(app.menuItems["Find in Page"])
             app.menuItems["Find in Page"].tap()
         }

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -768,6 +768,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     map.addScreenState(BrowserTab) { screenState in
         makeURLBarAvailable(screenState)
         screenState.tap(app.buttons["TabLocationView.pageOptionsButton"], to: PageOptionsMenu)
+        screenState.tap(app.buttons["TabToolbar.menuButton"], to: BrowserTabMenu)
 
         makeToolBarAvailable(screenState)
         let link = app.webViews.element(boundBy: 0).links.element(boundBy: 0)
@@ -821,7 +822,6 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     map.addScreenState(PageOptionsMenu) {screenState in
         screenState.tap(app.tables["Context Menu"].cells["menu-FindInPage"], to: FindInPage)
         screenState.tap(app.tables["Context Menu"].cells["menu-Bookmark"], forAction: Action.BookmarkThreeDots, Action.Bookmark)
-        screenState.tap(app.tables["Context Menu"].cells["action_remove"], forAction: Action.CloseTabFromPageOptions, Action.CloseTab, transitionTo: HomePanelsScreen, if: "tablet != true")
         screenState.tap(app.tables.cells["action_pin"], forAction: Action.PinToTopSitesPAM)
         screenState.tap(app.tables.cells["menu-Copy-Link"], forAction: Action.CopyAddressPAM)
         screenState.backAction = cancelBackAction

--- a/XCUITests/HistoryTests.swift
+++ b/XCUITests/HistoryTests.swift
@@ -50,7 +50,6 @@ class HistoryTests: BaseTestCase {
 
     func testClearHistoryFromSettings() {
         // Browse to have an item in history list
-        //navigator.goto(BrowserTabMenu)
         navigator.goto(HomePanel_History)
         waitforExistence(app.tables.cells["HistoryPanel.recentlyClosedCell"])
         XCTAssertTrue(app.tables.cells.staticTexts[webpage["label"]!].exists)
@@ -69,34 +68,41 @@ class HistoryTests: BaseTestCase {
         waitforNoExistence(app.tables["Recently Closed Tabs List"])
 
         // Go to the default web site  and check whether the option is enabled
+        userState.url = path(forTestPage: "test-mozilla-book.html")
         navigator.goto(BrowserTab)
-        waitUntilPageLoad()
         navigator.goto(BrowserTabMenu)
         navigator.goto(HistoryRecentlyClosed)
         waitforNoExistence(app.tables["Recently Closed Tabs List"])
 
         // Now go back to default website close it and check whether the option is enabled
-        navigator.goto(BrowserTab)
+        navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
+        waitUntilPageLoad()
         navigator.goto(TabTray)
         navigator.performAction(Action.AcceptRemovingAllTabs)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(BrowserTabMenu)
         navigator.goto(HistoryRecentlyClosed)
 
         // The Closed Tabs list should contain the info of the website just closed
-        waitforExistence(app.tables["Recently Closed Tabs List"])
+        waitforExistence(app.tables["Recently Closed Tabs List"], timeout: 3)
         XCTAssertTrue(app.tables.cells.staticTexts[closedWebPageLabel].exists)
 
         // This option should be enabled on private mode too
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+        navigator.nowAt(NewTabScreen)
+        navigator.goto(BrowserTabMenu)
         navigator.goto(HistoryRecentlyClosed)
         waitforExistence(app.tables["Recently Closed Tabs List"])
     }
 
     func testClearRecentlyClosedHistory() {
         // Open the default website
+        userState.url = path(forTestPage: "test-mozilla-book.html")
         navigator.goto(BrowserTab)
         navigator.goto(TabTray)
         navigator.performAction(Action.AcceptRemovingAllTabs)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(BrowserTabMenu)
         navigator.goto(HistoryRecentlyClosed)
         // Once the website is visited and closed it will appear in Recently Closed Tabs list
@@ -113,10 +119,11 @@ class HistoryTests: BaseTestCase {
 
     func testLongTapOptionsRecentlyClosedItem() {
         // Open the default website
+        userState.url = path(forTestPage: "test-mozilla-book.html")
         navigator.goto(BrowserTab)
         navigator.goto(TabTray)
         navigator.performAction(Action.AcceptRemovingAllTabs)
-
+        navigator.nowAt(NewTabScreen)
         navigator.goto(BrowserTabMenu)
         navigator.goto(HistoryRecentlyClosed)
         waitforExistence(app.tables["Recently Closed Tabs List"])
@@ -129,10 +136,11 @@ class HistoryTests: BaseTestCase {
 
     func testOpenInNewTabRecentlyClosedItem() {
         // Open the default website
+        userState.url = path(forTestPage: "test-mozilla-book.html")
         navigator.goto(BrowserTab)
         navigator.goto(TabTray)
         navigator.performAction(Action.AcceptRemovingAllTabs)
-
+        navigator.nowAt(NewTabScreen)
         navigator.goto(HistoryRecentlyClosed)
         waitforExistence(app.tables["Recently Closed Tabs List"])
         XCTAssertTrue(app.tables.cells.staticTexts[closedWebPageLabel].exists)
@@ -148,9 +156,11 @@ class HistoryTests: BaseTestCase {
 
     func testOpenInNewPrivateTabRecentlyClosedItem() {
         // Open the default website
+        userState.url = path(forTestPage: "test-mozilla-book.html")
         navigator.goto(BrowserTab)
         navigator.goto(TabTray)
         navigator.performAction(Action.AcceptRemovingAllTabs)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(HistoryRecentlyClosed)
         waitforExistence(app.tables["Recently Closed Tabs List"])
         XCTAssertTrue(app.tables.cells.staticTexts[closedWebPageLabel].exists)
@@ -168,9 +178,10 @@ class HistoryTests: BaseTestCase {
     func testPrivateClosedSiteDoesNotAppearOnRecentlyClosed() {
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         // Open the default website
+        userState.url = path(forTestPage: "test-mozilla-book.html")
         navigator.goto(BrowserTab)
         // It is necessary to open two sites so that when one is closed private mode is not closed
-        navigator.openNewURL(urlString: "mozilla.org")
+        navigator.openNewURL(urlString: path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
         navigator.goto(TabTray)
         waitforExistence(app.collectionViews.cells[webpage["label"]!])

--- a/XCUITests/HomePageSettingsUITest.swift
+++ b/XCUITests/HomePageSettingsUITest.swift
@@ -44,11 +44,13 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.goto(SettingsScreen)
         // Check that it is not saved
         navigator.goto(HomePageSettings)
+        waitforExistence(app.textFields["HomePageSettingTextField"])
         let valueAfter = app.textFields["HomePageSettingTextField"].value
         XCTAssertEqual("Enter a webpage", valueAfter as! String)
 
         // There is no option to go to Home, instead the website open has the option to be set as HomePageSettings
-        navigator.openURL(websiteUrl1)
+        navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
+        waitUntilPageLoad()
         navigator.goto(BrowserTabMenu)
         let homePageMenuItem = app.tables["Context Menu"].cells["Open Homepage"]
         XCTAssertFalse(homePageMenuItem.exists)
@@ -83,6 +85,7 @@ class HomePageSettingsUITests: BaseTestCase {
         app.textFields["address"].press(forDuration: 5)
         app.menuItems["Select All"].tap()
         app.menuItems["Copy"].tap()
+        waitforExistence(app.buttons["goBack"])
         app.buttons["goBack"].tap()
 
         // Go to HomePage settings and check that it is not possible to copy it into the set webpage field

--- a/XCUITests/NewTabSettings.swift
+++ b/XCUITests/NewTabSettings.swift
@@ -60,9 +60,8 @@ class NewTabSettingsTest: BaseTestCase {
         waitforExistence(app.otherElements.images["emptyBookmarks"])
 
         // Add one bookmark and check the new tab screen
-        navigator.openURL("mozilla.org/en-US/book")
+        navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
         waitUntilPageLoad()
-        navigator.nowAt(BrowserTab)
         navigator.performAction(Action.Bookmark)
         navigator.goto(NewTabScreen)
         waitforExistence(app.tables["Bookmarks List"].cells.staticTexts["The Book of Mozilla"])

--- a/XCUITests/PocketTests.swift
+++ b/XCUITests/PocketTests.swift
@@ -37,8 +37,11 @@ class PocketTest: BaseTestCase {
     func testTapOnMore() {
         // Tap on More should show Pocket website
         navigator.goto(NewTabScreen)
+        waitforExistence(app.buttons["More"], timeout: 5)
         app.buttons["More"].tap()
         waitUntilPageLoad()
+        navigator.nowAt(BrowserTab)
+        waitforExistence(app.buttons["Reader View"], timeout: 10)
         waitForValueContains(app.textFields["url"], value: "getpocket")
     }
 }

--- a/XCUITests/PrivateBrowsingTest.swift
+++ b/XCUITests/PrivateBrowsingTest.swift
@@ -120,6 +120,7 @@ class PrivateBrowsingTest: BaseTestCase {
         // See scenario described in bug 1434545 for more info about this scenario
         enableClosePrivateBrowsingOptionWhenLeaving()
         navigator.openURL(urlExample)
+        waitUntilPageLoad()
         app.webViews.links.staticTexts["More information..."].press(forDuration: 3)
         app.buttons["Open in New Private Tab"].tap()
         waitUntilPageLoad()

--- a/XCUITests/ReaderViewUITest.swift
+++ b/XCUITests/ReaderViewUITest.swift
@@ -6,6 +6,7 @@ import XCTest
 
 class ReaderViewTest: BaseTestCase {
     func testLoadReaderContent() {
+        userState.url = path(forTestPage: "test-mozilla-book.html")
         navigator.goto(BrowserTab)
         app.buttons["Reader View"].tap()
         app.buttons["Reload"].tap()
@@ -15,6 +16,7 @@ class ReaderViewTest: BaseTestCase {
     }
 
     private func addContentToReaderView() {
+        userState.url = path(forTestPage: "test-mozilla-book.html")
         navigator.goto(BrowserTab)
         waitUntilPageLoad()
         app.buttons["Reader View"].tap()
@@ -56,6 +58,8 @@ class ReaderViewTest: BaseTestCase {
     func testAddToReadingListPrivateMode() {
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         // Initially reading list is empty
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+        navigator.goto(BrowserTabMenu)
         navigator.goto(HomePanel_ReadingList)
 
         // Check the button is selected (is disabled and the rest bookmarks and so are enabled)
@@ -154,6 +158,7 @@ class ReaderViewTest: BaseTestCase {
         checkReadingListNumberOfItems(items: 0)
 
         // Add item to Reading List from Page Options Menu
+        userState.url = path(forTestPage: "test-mozilla-book.html")
         navigator.goto(BrowserTab)
         waitUntilPageLoad()
         navigator.browserPerformAction(.addReadingListOption)

--- a/XCUITests/SearchTest.swift
+++ b/XCUITests/SearchTest.swift
@@ -122,6 +122,7 @@ class SearchTests: BaseTestCase {
         app.textFields["address"].press(forDuration: 5)
         app.menuItems["Select All"].tap()
         app.menuItems["Copy"].tap()
+        waitforExistence(app.buttons["goBack"])
         app.buttons["goBack"].tap()
         navigator.nowAt(HomePanelsScreen)
         navigator.goto(URLBarOpen)
@@ -179,13 +180,13 @@ class SearchTests: BaseTestCase {
     }
 
     func testSearchWithFirefoxOption() {
-        navigator.openURL("mozilla.org/en-US/book")
+        navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
         waitUntilPageLoad()
         // Select some text and long press to find the option
         app.webViews.staticTexts["cloud"].press(forDuration: 1)
         if !iPad() {
-            waitforExistence(app.menuItems["Show more items"])
-            app.menuItems["Show more items"].tap()
+            waitforExistence(app.menus.children(matching: .menuItem).element(boundBy: 3))
+            app.menus.children(matching: .menuItem).element(boundBy: 3).tap()
         }
         waitforExistence(app.menuItems["Search with Firefox"])
         app.menuItems["Search with Firefox"].tap()

--- a/XCUITests/ToolbarTest.swift
+++ b/XCUITests/ToolbarTest.swift
@@ -4,8 +4,8 @@
 
 import XCTest
 
-let website1: [String: String] = ["url": "www.mozilla.org", "label": "Internet for people, not profit — Mozilla", "value": "mozilla.org"]
-let website2 = "example.com"
+let website1: [String: String] = ["url": path(forTestPage: "test-mozilla-org.html"), "label": "Internet for people, not profit — Mozilla", "value": "localhost"]
+let website2 = path(forTestPage: "test-example.html")
 
 let PDFWebsite = ["url": "http://www.pdf995.com/samples/pdf.pdf"]
 
@@ -36,7 +36,10 @@ class ToolbarTests: BaseTestCase {
 
         // Navigate to two pages and press back once so that all buttons are enabled in landscape mode.
         navigator.openURL(website1["url"]!)
+        waitUntilPageLoad()
+        waitforExistence(app.webViews.links["Mozilla"], timeout: 5)
         waitForValueContains(app.textFields["url"], value: website1["value"]!)
+
 
         XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
         XCTAssertFalse(app.buttons["Forward"].isEnabled)
@@ -44,7 +47,7 @@ class ToolbarTests: BaseTestCase {
 
         navigator.openURL(website2)
         waitUntilPageLoad()
-        waitForValueContains(app.textFields["url"], value: website2)
+        waitForValueContains(app.textFields["url"], value: "localhost:6571")
         XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
         XCTAssertFalse(app.buttons["Forward"].isEnabled)
 
@@ -79,6 +82,8 @@ class ToolbarTests: BaseTestCase {
 
     func testClearURLTextUsingBackspace() {
         navigator.openURL(website1["url"]!)
+        waitUntilPageLoad()
+        waitforExistence(app.webViews.links["Mozilla"], timeout: 5)
         waitForValueContains(app.textFields["url"], value: website1["value"]!)
 
         // Simulate pressing on backspace key should remove the text

--- a/XCUITests/WebPagesForTesting.swift
+++ b/XCUITests/WebPagesForTesting.swift
@@ -17,7 +17,7 @@ func registerHandlersForTestMethods(server: GCDWebServer) {
         return GCDWebServerDataResponse(html: "<html><body>\(textNodes)</body></html>")
     }
 
-    ["test-password", "test-password-submit"].forEach {
+    ["test-password", "test-password-submit", "test-example", "test-example-link", "test-mozilla-book", "test-mozilla-org"].forEach {
         addHTMLFixture(name: $0, server: server)
     }
 }

--- a/test-fixtures/test-example.html
+++ b/test-fixtures/test-example.html
@@ -1,0 +1,49 @@
+<html>
+<head>
+    <title>Example Domain</title>
+
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style type="text/css">
+    body {
+        background-color: #f0f0f2;
+        margin: 0;
+        padding: 0;
+        font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        
+    }
+    div {
+        width: 600px;
+        margin: 5em auto;
+        padding: 50px;
+        background-color: #fff;
+        border-radius: 1em;
+    }
+    a:link, a:visited {
+        color: #38488f;
+        text-decoration: none;
+    }
+    @media (max-width: 700px) {
+        body {
+            background-color: #fff;
+        }
+        div {
+            width: auto;
+            margin: 0 auto;
+            border-radius: 0;
+            padding: 1em;
+        }
+    }
+    </style>    
+</head>
+
+<body>
+<div>
+    <h1>Example Domain</h1>
+    <p>This domain is established to be used for illustrative examples in documents. You may use this
+    domain in examples without prior coordination or asking for permission.</p>
+    <p><a href="http://www.iana.org/domains/example">More information...</a></p>
+</div>
+</body>
+</html>

--- a/test-fixtures/test-mozilla-book.html
+++ b/test-fixtures/test-mozilla-book.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en-US" dir="ltr">
+<head>
+  <meta http-equiv="Content-type" content="text/html; charset=UTF-8">
+  <title>The Book of Mozilla</title>
+  
+    <link href="/media/css/BUNDLES/book.7ea47490a670.css" rel="stylesheet" type="text/css" />
+  
+</head>
+<body>
+
+
+
+<!-- 10th December 1994: Netscape Navigator 1.0 was released -->
+<!-- This verse announces the birth of the beast (Netscape) and warns bad coders (up to Netscape 3, when you watched the HTML source code with the internal viewer, bad tags blinked). -->
+
+<p class="moztext">
+And the beast shall come forth surrounded by a roiling <em>cloud</em> of
+<em>vengeance</em>. The house of the unbelievers shall be <em>razed</em>
+and they shall be <em>scorched</em> to the earth. Their tags shall <em>blink</em>
+until the end of <em>days.</em>
+</p>
+
+<p class="from">
+from <strong>The Book of Mozilla,</strong> 12:10
+</p>
+
+
+<!-- 31st March 1998: the Netscape Navigator source code was released -->
+<!-- The source code is made available to the legion of thousands of coders of the open source community, that will fight against the followers of Mammon (Microsoft Internet Explorer). -->
+
+<p class="moztext">
+And the beast shall be made <em>legion</em>.
+Its numbers shall be increased a <em>thousand thousand</em> fold.
+The din of a million keyboards like unto a great <em>storm</em>
+shall cover the earth, and the followers of Mammon shall <em>tremble</em>.
+</p>
+
+<p class="from">
+ from <strong>The Book of Mozilla,</strong> 3:31<br/>
+ (Red Letter Edition)
+</p>
+
+
+<!-- 15th July 2003: AOL closed its Netscape division and the Mozilla foundation was created -->
+<!-- The beast died (AOL closed its Netscape division) but immediately rose from its ashes (the creation of the Mozilla foundation and the Firebird browser, although the name was later changed to Firefox). -->
+
+<p class="moztext">
+And so at last the beast <em class="f">fell</em> and the unbelievers rejoiced.
+But all was not lost, for from the ash rose a <em>great bird</em>.
+The bird gazed down upon the unbelievers and cast <em class="f">fire</em>
+and <em>thunder</em> upon them. For the beast had been
+<em>reborn</em> with its strength <em>renewed</em>, and the
+followers of <em>Mammon</em> cowered in horror.
+</p>
+
+<p class="from">
+from <strong>The Book of Mozilla,</strong> 7:15
+</p>
+
+
+<!-- 9th November 2004: Firefox 1.0 is officially released -->
+<!-- The worldwide support of Firefox fans leads to its success, illustrating the power of community-based open source projects. -->
+
+<p class="moztext">
+Mammon slept. And the <em>beast reborn</em> spread over the earth and its numbers
+grew legion. And they proclaimed the times and <em>sacrificed</em> crops unto the
+fire, with the <em>cunning of foxes</em>. And they built a new world in their own
+image as promised by the <em><a href="/about/manifesto.html">
+sacred words</a></em>, and <em><a href="https://wiki.mozilla.org/About:mozilla">spoke
+</a></em> of the beast with their children. Mammon awoke, and lo! it was
+<em>naught</em> but a follower.
+</p>
+
+<p class="from">
+ from <strong>The Book of Mozilla,</strong> 11:9<br/>
+ <small>(10th Edition)</small>
+</p>
+
+
+<!-- 15th January 2013: Firefox OS 1.0 froze -->
+
+<p class="moztext">
+The <em>twins</em> of Mammon quarrelled. Their warring plunged the world into a
+<em>new darkness</em>, and the beast abhorred the darkness. So it began to move
+<em>swiftly</em>, and grew more powerful, and went forth and multiplied.
+And the beasts brought <em class="f">fire</em> and light to the darkness.
+</p>
+
+<p class="from">
+ from <strong>The Book of Mozilla,</strong> 15:1
+</p>
+
+
+<!-- 14th November 2017: Firefox 57 is officially released -->
+<!-- The major release of projects Quantum, Flow, and Photon, bringing Rust-based software,
+     major architectural changes, and a new look to the masses. -->
+
+<p class="moztext">
+The Beast adopted <em>new raiment</em> and studied the ways of <em>Time</em> and
+<em>Space</em> and <em>Light</em> and the <em>Flow</em> of energy through the Universe.
+From its studies, the Beast fashioned new structures from <em>oxidised metal</em> and proclaimed
+their glories. And the Beast’s followers rejoiced, finding renewed purpose in these <em>teachings</em>.
+</p>
+
+<p class="from">
+ from <strong>The Book of Mozilla,</strong> 11:14
+</p>
+
+
+
+</body>
+</html>

--- a/test-fixtures/test-mozilla-org.html
+++ b/test-fixtures/test-mozilla-org.html
@@ -1,0 +1,2774 @@
+
+
+<!doctype html>
+
+<html class="windows x86 no-js" lang="en" dir="ltr" data-latest-firefox="62.0" data-esr-versions="60.2.0" data-gtm-container-id="GTM-MW3R8V" data-gtm-page-id="Homepage" data-stub-attribution-rate="1.0">
+  <head>
+    <meta charset="utf-8">
+
+    <script type="text/javascript" src="/media/js/BUNDLES/site.8391e739b374.js" charset="utf-8"></script>
+
+    <!--[if !lte IE 8]><!-->
+    
+    <!--<![endif]-->
+
+<!--
+             _.-~-.
+           7''  Q..\
+        _7         (_
+      _7  _/    _q.  /
+    _7 . ___  /VVvv-'_                                            .
+   7/ / /~- \_\\      '-._     .-'                      /       //
+  ./ ( /-~-/||'=.__  '::. '-~'' {             ___   /  //     ./{
+ V   V-~-~| ||   __''_   ':::.   ''~-~.___.-'' _/  // / {_   /  {  /
+  VV/-~-~-|/ \ .'__'. '.    '::                     _ _ _        ''.
+  / /~~~~||VVV/ /  \ )  \        _ __ ___   ___ ___(_) | | __ _   .::'
+ / (~-~-~\\.-' /    \'   \::::. | '_ ` _ \ / _ \_  / | | |/ _` | :::'
+/..\    /..\__/      '     '::: | | | | | | (_) / /| | | | (_| | ::'
+vVVv    vVVv                 ': |_| |_| |_|\___/___|_|_|_|\__,_| ''
+
+Hi there, nice to meet you!
+
+Interested in having a direct impact on hundreds of millions of users? Join
+Mozilla, and become part of a global community that’s helping to build a
+brighter future for the Web.
+
+Visit https://careers.mozilla.org to learn about our current job openings.
+Visit https://www.mozilla.org/contribute for more ways to get involved and
+help support Mozilla.
+-->
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    
+<!-- validates bing webmaster tools -->
+<meta name="msvalidate.01" content="B7B177115A634927D608514DA17B2574">
+<!-- YouTube Verification -->
+<meta name="google-site-verification" content="U9a6gH32vLIykvntaDToj-ytYhlZ1AfAgVEKstixQIE">
+
+
+    <title>Internet for people, not profit
+    — Mozilla
+  </title>
+    <meta name="description" content="
+  Mozilla is the not-for-profit behind the lightning fast Firefox browser. We put people over profit to give everyone more power online.
+">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Mozilla">
+    <meta property="og:locale" content="en_US">
+    <meta property="og:url" content="https://www.mozilla.org/en-US/">
+    <meta property="og:image" content="https://www.mozilla.org/media/img/mozorg/mozilla-256.4720741d4108.jpg">
+    <meta property="og:title" content="Internet for people, not profit">
+    <meta property="og:description" content="
+  Mozilla is the not-for-profit behind the lightning fast Firefox browser. We put people over profit to give everyone more power online.
+">
+    <meta property="fb:page_id" content="262134952380">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:site" content="@mozilla">
+    <meta name="twitter:domain" content="mozilla.org">
+    <meta name="twitter:app:name:googleplay" content="Firefox">
+    <meta name="twitter:app:id:googleplay" content="org.mozilla.firefox">
+    <meta name="twitter:app:name:iphone" content="Firefox">
+    <meta name="twitter:app:id:iphone" content="989804926">
+    <meta name="twitter:app:name:ipad" content="Firefox">
+    <meta name="twitter:app:id:ipad" content="989804926">
+    <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="/media/img/favicon/apple-touch-icon-180x180.8772ec154918.png">
+    <link rel="icon" type="image/png" sizes="196x196" href="/media/img/favicon/favicon-196x196.c80e6abe0767.png">
+    <link rel="shortcut icon" href="/media/img/favicon.d4f1f46b91f4.ico">
+        <link rel="canonical" href="https://www.mozilla.org/en-US/">
+    <link rel="alternate" hreflang="x-default" href="https://www.mozilla.org/en-US/">
+    <link rel="alternate" hreflang="an" href="https://www.mozilla.org/an/" title="aragonés">
+        <link rel="alternate" hreflang="ar" href="https://www.mozilla.org/ar/" title="عربي">
+        <link rel="alternate" hreflang="az" href="https://www.mozilla.org/az/" title="Azərbaycanca">
+        <link rel="alternate" hreflang="be" href="https://www.mozilla.org/be/" title="Беларуская">
+        <link rel="alternate" hreflang="bg" href="https://www.mozilla.org/bg/" title="Български">
+        <link rel="alternate" hreflang="bs" href="https://www.mozilla.org/bs/" title="Bosanski">
+        <link rel="alternate" hreflang="ca" href="https://www.mozilla.org/ca/" title="Català">
+        <link rel="alternate" hreflang="cs" href="https://www.mozilla.org/cs/" title="Čeština">
+        <link rel="alternate" hreflang="cy" href="https://www.mozilla.org/cy/" title="Cymraeg">
+        <link rel="alternate" hreflang="da" href="https://www.mozilla.org/da/" title="Dansk">
+        <link rel="alternate" hreflang="de" href="https://www.mozilla.org/de/" title="Deutsch">
+        <link rel="alternate" hreflang="el" href="https://www.mozilla.org/el/" title="Ελληνικά">
+        <link rel="alternate" hreflang="en-CA" href="https://www.mozilla.org/en-CA/" title="English (Canadian)">
+        <link rel="alternate" hreflang="en-GB" href="https://www.mozilla.org/en-GB/" title="English (British)">
+        <link rel="alternate" hreflang="en" href="https://www.mozilla.org/en-US/" title="English">
+        <link rel="alternate" hreflang="en-US" href="https://www.mozilla.org/en-US/" title="English (USA)">
+        <link rel="alternate" hreflang="eo" href="https://www.mozilla.org/eo/" title="Esperanto">
+        <link rel="alternate" hreflang="es-AR" href="https://www.mozilla.org/es-AR/" title="Español (de Argentina)">
+        <link rel="alternate" hreflang="es-CL" href="https://www.mozilla.org/es-CL/" title="Español (de Chile)">
+        <link rel="alternate" hreflang="es" href="https://www.mozilla.org/es-ES/" title="Español">
+        <link rel="alternate" hreflang="es-ES" href="https://www.mozilla.org/es-ES/" title="Español (de España)">
+        <link rel="alternate" hreflang="es-MX" href="https://www.mozilla.org/es-MX/" title="Español (de México)">
+        <link rel="alternate" hreflang="et" href="https://www.mozilla.org/et/" title="Eesti keel">
+        <link rel="alternate" hreflang="eu" href="https://www.mozilla.org/eu/" title="Euskara">
+        <link rel="alternate" hreflang="fa" href="https://www.mozilla.org/fa/" title="فارسی">
+        <link rel="alternate" hreflang="fi" href="https://www.mozilla.org/fi/" title="suomi">
+        <link rel="alternate" hreflang="fr" href="https://www.mozilla.org/fr/" title="Français">
+        <link rel="alternate" hreflang="fy" href="https://www.mozilla.org/fy-NL/" title="Frysk">
+        <link rel="alternate" hreflang="fy-NL" href="https://www.mozilla.org/fy-NL/" title="Frysk">
+        <link rel="alternate" hreflang="gn" href="https://www.mozilla.org/gn/" title="Avañe'ẽ">
+        <link rel="alternate" hreflang="gu" href="https://www.mozilla.org/gu-IN/" title="ગુજરાતી">
+        <link rel="alternate" hreflang="gu-IN" href="https://www.mozilla.org/gu-IN/" title="ગુજરાતી (ભારત)">
+        <link rel="alternate" hreflang="hi" href="https://www.mozilla.org/hi-IN/" title="हिन्दी">
+        <link rel="alternate" hreflang="hi-IN" href="https://www.mozilla.org/hi-IN/" title="हिन्दी (भारत)">
+        <link rel="alternate" hreflang="hu" href="https://www.mozilla.org/hu/" title="magyar">
+        <link rel="alternate" hreflang="hy" href="https://www.mozilla.org/hy-AM/" title="Հայերեն">
+        <link rel="alternate" hreflang="hy-AM" href="https://www.mozilla.org/hy-AM/" title="Հայերեն">
+        <link rel="alternate" hreflang="ia" href="https://www.mozilla.org/ia/" title="Interlingua">
+        <link rel="alternate" hreflang="id" href="https://www.mozilla.org/id/" title="Bahasa Indonesia">
+        <link rel="alternate" hreflang="it" href="https://www.mozilla.org/it/" title="Italiano">
+        <link rel="alternate" hreflang="ja" href="https://www.mozilla.org/ja/" title="日本語">
+        <link rel="alternate" hreflang="ka" href="https://www.mozilla.org/ka/" title="ქართული">
+        <link rel="alternate" hreflang="ko" href="https://www.mozilla.org/ko/" title="한국어">
+        <link rel="alternate" hreflang="lt" href="https://www.mozilla.org/lt/" title="Lietuvių">
+        <link rel="alternate" hreflang="ml" href="https://www.mozilla.org/ml/" title="മലയാളം">
+        <link rel="alternate" hreflang="mr" href="https://www.mozilla.org/mr/" title="मराठी">
+        <link rel="alternate" hreflang="ms" href="https://www.mozilla.org/ms/" title="Melayu">
+        <link rel="alternate" hreflang="nb-NO" href="https://www.mozilla.org/nb-NO/" title="Norsk bokmål">
+        <link rel="alternate" hreflang="nl" href="https://www.mozilla.org/nl/" title="Nederlands">
+        <link rel="alternate" hreflang="nn-NO" href="https://www.mozilla.org/nn-NO/" title="Norsk nynorsk">
+        <link rel="alternate" hreflang="pa" href="https://www.mozilla.org/pa-IN/" title="ਪੰਜਾਬੀ">
+        <link rel="alternate" hreflang="pa-IN" href="https://www.mozilla.org/pa-IN/" title="ਪੰਜਾਬੀ (ਭਾਰਤ)">
+        <link rel="alternate" hreflang="pl" href="https://www.mozilla.org/pl/" title="Polski">
+        <link rel="alternate" hreflang="pt-BR" href="https://www.mozilla.org/pt-BR/" title="Português (do Brasil)">
+        <link rel="alternate" hreflang="pt" href="https://www.mozilla.org/pt-PT/" title="Português">
+        <link rel="alternate" hreflang="pt-PT" href="https://www.mozilla.org/pt-PT/" title="Português (Europeu)">
+        <link rel="alternate" hreflang="rm" href="https://www.mozilla.org/rm/" title="rumantsch">
+        <link rel="alternate" hreflang="ro" href="https://www.mozilla.org/ro/" title="Română">
+        <link rel="alternate" hreflang="ru" href="https://www.mozilla.org/ru/" title="Русский">
+        <link rel="alternate" hreflang="sk" href="https://www.mozilla.org/sk/" title="slovenčina">
+        <link rel="alternate" hreflang="sl" href="https://www.mozilla.org/sl/" title="Slovenščina">
+        <link rel="alternate" hreflang="sq" href="https://www.mozilla.org/sq/" title="Shqip">
+        <link rel="alternate" hreflang="sr" href="https://www.mozilla.org/sr/" title="Српски">
+        <link rel="alternate" hreflang="sv" href="https://www.mozilla.org/sv-SE/" title="Svenska">
+        <link rel="alternate" hreflang="sv-SE" href="https://www.mozilla.org/sv-SE/" title="Svenska">
+        <link rel="alternate" hreflang="ta" href="https://www.mozilla.org/ta/" title="தமிழ்">
+        <link rel="alternate" hreflang="th" href="https://www.mozilla.org/th/" title="ไทย">
+        <link rel="alternate" hreflang="tr" href="https://www.mozilla.org/tr/" title="Türkçe">
+        <link rel="alternate" hreflang="uk" href="https://www.mozilla.org/uk/" title="Українська">
+        <link rel="alternate" hreflang="zh-TW" href="https://www.mozilla.org/zh-TW/" title="正體中文 (繁體)">
+        
+    
+
+    
+
+    <!--[if lte IE 8]>
+      
+      <script src="/media/js/libs/html5shiv.42594ff91377.js"></script>
+
+      
+      
+  <link href="/media/css/BUNDLES/protocol-oldIE.a11e48d1029b.css" rel="stylesheet" type="text/css" />
+
+    <![endif]-->
+
+    <!--[if !lte IE 8]><!-->
+    
+    
+  <link href="/media/css/BUNDLES/protocol-core.6bd70d7573aa.css" rel="stylesheet" type="text/css" />
+
+
+    
+    
+  <link href="/media/css/BUNDLES/home-2018.ec655f8e4f43.css" rel="stylesheet" type="text/css" />
+
+    <!--<![endif]-->
+
+    
+      
+    
+
+    
+    
+      <!--
+Read more about our custom configuration and use of Google Analytics here:
+https://bugzilla.mozilla.org/show_bug.cgi?id=1122305#c8
+-->
+
+<!-- Google Tag Manager -->
+<!-- Customized for Mozilla.org-->
+<!-- Region Container: NONE -->
+<!-- Rollup Container: System Filtered -->
+<!-- Site Container: NONE -->
+
+
+  <script type="text/javascript" src="/media/js/BUNDLES/gtm-snippet.9f9cf2026c5f.js" charset="utf-8"></script>
+
+<!-- End Google Tag Manager -->
+    
+  </head>
+
+  <body id="home" class="html-ltr " >
+    <div id="strings"
+      data-global-close="Close"
+      data-global-next="Next"
+      data-global-previous="Previous"
+      data-global-update-firefox="Update your Firefox"
+      data-global-fx-out-of-date-banner-heading="Your Firefox is out-of-date."
+      data-global-fx-out-of-date-banner-message="Get the most recent version to keep browsing securely."
+      data-global-fx-out-of-date-banner-confirm="Update Firefox"
+      ></div>
+
+  
+  
+    <nav role="navigation" class="moz-global-nav" id="moz-global-nav">
+    <div class="nav-horizontal-menu">
+
+      <button type="button" class="nav-button-menu nav-hidden" id="nav-button-menu" data-link-type="nav" data-link-position="open button" data-link-name="expand" data-link-group="nav element">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 25" width="12" height="25">
+          <title>Menu</title>
+            <rect class="p1" fill="#231f20" x="3" width="5" height="6"></rect>
+            <rect class="p2" fill="#231f20" x="3" y="9.5" width="5" height="6"></rect>
+            <rect class="p3" fill="#231f20" x="3" y="19" width="5" height="6"></rect>
+        </svg>
+      </button>
+
+      <h2 class="nav-logo">
+        <a href="/en-US/">
+          
+          
+            Mozilla
+          
+        </a>
+      </h2>
+
+      <ul class="nav-primary-links">
+        
+        <li class="item-firefox">
+          <a href="/en-US/firefox/" data-link-type="nav" data-link-position="top" data-link-name="Firefox">Firefox</a>
+        </li>
+        <li class="item-pocket">
+          <a href="/en-US/firefox/pocket/" data-link-type="nav" data-link-position="top" data-link-name="Pocket">Pocket</a>
+        </li>
+        <li class="item-internet-health">
+          <a href="/en-US/internet-health/" data-link-type="nav" data-link-position="top" data-link-name="Internet Health">Internet Health</a>
+        </li>
+        <li class="item-technology">
+          <a href="/en-US/technology/" data-link-type="nav" data-link-position="top" data-link-name="Technology">Technology</a>
+        </li>
+        <li class="item-about-us">
+          <a href="/en-US/about/" data-link-type="nav" data-link-position="top" data-link-name="About Us">About Us</a>
+        </li>
+        <li class="item-get-involved">
+          <a href="/en-US/contribute/" data-link-type="nav" data-link-position="top" data-link-name="Get Involved">Get Involved</a>
+        </li>
+      </ul>
+
+      
+
+
+
+
+
+
+
+
+<div id="global-nav-download-firefox" class="download-button">
+  
+  <div class="nojs-download">
+    
+  <div class="download download-dumb">
+    <p role="heading" class="download-heading">
+      
+        Download Firefox
+        — English (US)
+    </p>
+    <ul>
+      <li><a href="https://download.mozilla.org/?product=firefox-stub&amp;os=win64&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="win64"
+               data-download-os="Desktop">Windows 64-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-stub&amp;os=win&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="win"
+               data-download-os="Desktop">Windows 32-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=osx&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="osx"
+               data-download-os="Desktop">macOS</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux64&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="linux64"
+               data-download-os="Desktop">Linux 64-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="linux"
+               data-download-os="Desktop">Linux 32-bit</a>
+        </li><li><a href="https://play.google.com/store/apps/details?id=org.mozilla.firefox&amp;referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="android"
+               data-download-os="Android"
+               >Android</a>
+        </li><li><a href="https://itunes.apple.com/us/app/apple-store/id989804926?pt=373246&amp;mt=8"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="ios"
+               data-download-os="iOS"
+               >iOS</a>
+        </li>
+    </ul>
+  </div>
+
+  </div>
+  
+    
+    <div class="unrecognized-download">
+      <p>Your system may not meet the requirements for Firefox, but you can try one of these versions:</p>
+      
+  <div class="download download-dumb">
+    <p role="heading" class="download-heading">
+      
+        Download Firefox
+        — English (US)
+    </p>
+    <ul>
+      <li><a href="https://download.mozilla.org/?product=firefox-stub&amp;os=win64&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="win64"
+               data-download-os="Desktop">Windows 64-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-stub&amp;os=win&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="win"
+               data-download-os="Desktop">Windows 32-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=osx&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="osx"
+               data-download-os="Desktop">macOS</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux64&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="linux64"
+               data-download-os="Desktop">Linux 64-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="linux"
+               data-download-os="Desktop">Linux 32-bit</a>
+        </li><li><a href="https://play.google.com/store/apps/details?id=org.mozilla.firefox&amp;referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="android"
+               data-download-os="Android"
+               >Android</a>
+        </li><li><a href="https://itunes.apple.com/us/app/apple-store/id989804926?pt=373246&amp;mt=8"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="ios"
+               data-download-os="iOS"
+               >iOS</a>
+        </li>
+    </ul>
+  </div>
+
+    </div>
+    <p class="unsupported-download">
+      Your system doesn't meet the <a href="/en-US/firefox/system-requirements/">requirements</a> to run Firefox.
+    </p>
+    <p class="unsupported-download-osx">
+      Your system doesn't meet the <a href="https://support.mozilla.org/kb/firefox-osx">requirements</a> to run Firefox.
+    </p>
+    <p class="linux-arm-download">
+      Please follow <a href="https://support.mozilla.org/kb/install-firefox-linux">these instructions</a> to install Firefox.
+    </p>
+  
+  <ul class="download-list">
+    
+      <li class="os_win64">
+        <a class="download-link button button-green"
+           href="/firefox/download/thanks/"
+           data-direct-link="https://download.mozilla.org/?product=firefox-stub&amp;os=win64&amp;lang=en-US"
+           data-link-type="download"
+           data-display-name="Windows 64-bit"
+           data-download-version="win64"
+           data-download-os="Desktop"
+           data-download-location="nav">
+          <strong class="download-title">
+            
+              Download Firefox
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_win">
+        <a class="download-link button button-green"
+           href="/firefox/download/thanks/"
+           data-direct-link="https://download.mozilla.org/?product=firefox-stub&amp;os=win&amp;lang=en-US"
+           data-link-type="download"
+           data-display-name="Windows 32-bit"
+           data-download-version="win"
+           data-download-os="Desktop"
+           data-download-location="nav">
+          <strong class="download-title">
+            
+              Download Firefox
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_osx">
+        <a class="download-link button button-green"
+           href="/firefox/download/thanks/"
+           data-direct-link="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=osx&amp;lang=en-US"
+           data-link-type="download"
+           data-display-name="macOS"
+           data-download-version="osx"
+           data-download-os="Desktop"
+           data-download-location="nav">
+          <strong class="download-title">
+            
+              Download Firefox
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_linux64">
+        <a class="download-link button button-green"
+           href="/firefox/download/thanks/"
+           data-direct-link="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux64&amp;lang=en-US"
+           data-link-type="download"
+           data-display-name="Linux 64-bit"
+           data-download-version="linux64"
+           data-download-os="Desktop"
+           data-download-location="nav">
+          <strong class="download-title">
+            
+              Download Firefox
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_linux">
+        <a class="download-link button button-green"
+           href="/firefox/download/thanks/"
+           data-direct-link="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux&amp;lang=en-US"
+           data-link-type="download"
+           data-display-name="Linux 32-bit"
+           data-download-version="linux"
+           data-download-os="Desktop"
+           data-download-location="nav">
+          <strong class="download-title">
+            
+              Download Firefox
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_android">
+        <a class="download-link button button-green"
+           href="https://play.google.com/store/apps/details?id=org.mozilla.firefox&amp;referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org"
+           data-link-type="download"
+           data-display-name="Android"
+           data-download-version="android"
+           data-download-os="Android"
+           
+           data-download-location="nav">
+          <strong class="download-title">
+            
+              Download Firefox
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_ios">
+        <a class="download-link button button-green"
+           href="https://itunes.apple.com/us/app/apple-store/id989804926?pt=373246&amp;mt=8"
+           data-link-type="download"
+           data-display-name="iOS"
+           data-download-version="ios"
+           data-download-os="iOS"
+           
+           data-download-location="nav">
+          <strong class="download-title">
+            
+              Download Firefox
+            
+          </strong>
+        </a>
+      </li>
+    
+  </ul>
+  <small class="fx-privacy-link">
+     
+      
+    
+    <a href="/en-US/privacy/firefox/">Firefox Privacy Notice</a>
+  </small>
+</div>
+  </div>
+</nav>
+
+<nav class="moz-global-nav-drawer" id="moz-global-nav-drawer">
+
+  <button type="button" class="nav-drawer-close-button" id="nav-drawer-close-button" data-link-type="nav" data-link-position="close button" data-link-name="collapse" data-link-group="nav element">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23.3 23.3" width="23" height="23">
+      <title>Close</title>
+      <g fill="#fff">
+        <rect x="8.7" y="8.7" class="rect center" width="6" height="6"></rect>
+        <rect x="8.7" y="8.7" class="rect top-left" width="6" height="6"></rect>
+        <rect x="8.7" y="8.7" class="rect top-right" width="6" height="6"></rect>
+        <rect x="8.7" y="8.7" class="rect bottom-left" width="6" height="6"></rect>
+        <rect x="8.7" y="8.7" class="rect bottom-right" width="6" height="6"></rect>
+      </g>
+    </svg>
+  </button>
+
+  <div class="nav-menu-inner-container">
+    <div class="nav-menu-scroll-pane">
+      <ul class="nav-menu-primary-links">
+        <li class="item-firefox">
+          <h3 class="summary" data-id="firefox">
+            <a href="/en-US/firefox/" data-link-type="nav" data-link-position="side" data-link-name="expand" data-link-group="Firefox">Firefox</a>
+          </h3>
+          <div class="detail">
+            <div class="detail-container">
+              <p class="intro">
+                Get the only browser built for people, not profit.
+              </p>
+              <ul class="nav-menu-secondary-links">
+                <li>
+                  <a href="/en-US/firefox/" data-link-type="nav" data-link-name="Desktop" data-link-group="Firefox">
+                    Desktop
+                  </a>
+                </li>
+                <li>
+                  <a href="/en-US/firefox/mobile/" data-link-type="nav" data-link-name="Mobile" data-link-group="Firefox">
+                    Mobile
+                  </a>
+                </li>
+                <li>
+                  <a href="https://addons.mozilla.org/firefox/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=extensions" data-link-type="nav" data-link-name="Extensions" data-link-group="Firefox">
+                    Extensions
+                  </a>
+                </li>
+                <li>
+                  <a href="https://support.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=support" data-link-type="nav" data-link-name="Support" data-link-group="Firefox">
+                    Support
+                  </a>
+                </li>
+                <li>
+                  <a href="https://blog.mozilla.org/firefox/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=blog" data-link-type="nav" data-link-name="Blog" data-link-group="Firefox">
+                    Blog
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </li>
+        <li class="item-pocket">
+          <h3 class="summary" data-id="pocket">
+            <a href="/en-US/firefox/pocket/" data-link-type="nav" data-link-position="side" data-link-name="expand" data-link-group="Pocket">Pocket</a>
+          </h3>
+          <div class="detail">
+            <div class="detail-container">
+              <p class="intro">
+                When you find something you want to view later, put it in Pocket.
+              </p>
+
+              <ul class="nav-menu-secondary-links">
+                <li>
+                  <a href="/en-US/firefox/pocket/" data-link-type="nav" data-link-name="Get Pocket" data-link-group="Pocket">
+                    Get Pocket
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </li>
+        <li class="item-internet-health">
+          <h3 class="summary" data-id="internet-health">
+            <a href="/en-US/internet-health/" data-link-type="nav" data-link-position="side" data-link-name="expand" data-link-group="Internet Health">Internet Health</a>
+          </h3>
+          <div class="detail">
+            <div class="detail-container">
+              <p class="intro">
+                Internet Health is crucial for the world to thrive. A healthy Internet is one that is private, inclusive, and collaborative.
+              </p>
+
+              <ul class="nav-menu-secondary-links">
+                <li>
+                  <a href="/en-US/internet-health/" data-link-type="nav" data-link-name="About" data-link-group="Internet Health">
+                    About
+                  </a>
+                </li>
+                <li>
+                  <a href="/en-US/internet-health/privacy-security/" data-link-type="nav" data-link-name="Privacy & Security" data-link-group="Internet Health">
+                    Privacy &amp; Security
+                  </a>
+                </li>
+                <li>
+                  <a href="/en-US/internet-health/open-innovation/" data-link-type="nav" data-link-name="Openness" data-link-group="Internet Health">
+                    Openness
+                  </a>
+                </li>
+                <li>
+                  <a href="/en-US/internet-health/decentralization/" data-link-type="nav" data-link-name="Decentralization" data-link-group="Internet Health">
+                    Decentralization
+                  </a>
+                </li>
+                <li>
+                  <a href="/en-US/internet-health/digital-inclusion/" data-link-type="nav" data-link-name="Digital Inclusion" data-link-group="Internet Health">
+                    Digital Inclusion
+                  </a>
+                </li>
+                <li>
+                  <a href="/en-US/internet-health/web-literacy/" data-link-type="nav" data-link-name="Web Literacy" data-link-group="Internet Health">
+                    Web Literacy
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </li>
+        <li class="item-technology">
+          <h3 class="summary" data-id="technology">
+            <a href="/en-US/technology/" data-link-type="nav" data-link-position="side" data-link-name="expand" data-link-group="Technology">Technology</a>
+          </h3>
+          <div class="detail">
+            <div class="detail-container">
+              <p class="intro">
+                Participate and explore our latest innovations — technology built in the open and designed to help keep the Internet healthy.
+              </p>
+
+              <ul class="nav-menu-secondary-links">
+                <li>
+                  <a href="/en-US/technology/" data-link-type="nav" data-link-name="Web Innovations" data-link-group="Technology">
+                    Web Innovations
+                  </a>
+                </li>
+                <li>
+                    <a href="/en-US/developer/" data-link-type="nav" data-link-name="Developer Hub" data-link-group="Technology">Developer Hub</a>
+                </li>
+                <li>
+                  <a href="https://research.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=Research" data-link-type="nav" data-link-name="Research" data-link-group="Technology">Research</a>
+                </li>
+                <li>
+                  <a href="https://vr.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=VR" data-link-type="nav" data-link-name="Virtual Reality" data-link-group="Technology">Virtual Reality</a>
+                </li>
+                <li>
+                  <a href="https://games.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=Games" data-link-type="nav" data-link-name="Games" data-link-group="Technology">Games</a>
+                </li>
+                <li>
+                  <a href="https://developer.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=Documentation" data-link-type="nav" data-link-name="Documentation" data-link-group="Technology">Documentation</a>
+                </li>
+                <li>
+                  <a href="https://hacks.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=HacksBlog" data-link-type="nav" data-link-name="Hacks Blog" data-link-group="Technology">Hacks blog</a>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </li>
+        <li class="item-about-us">
+          <h3 class="summary" data-id="about-us">
+            <a href="/en-US/about/" data-link-type="nav" data-link-position="side" data-link-name="expand" data-link-group="About Us">About Us</a>
+          </h3>
+          <div class="detail">
+            <div class="detail-container">
+              <p class="intro">
+                We’re Mozilla, the proudly non-profit champions of a healthy Internet – keeping it open and accessible to all.
+              </p>
+
+              <ul class="nav-menu-secondary-links">
+                <li>
+                  <a href="/en-US/mission/" data-link-type="nav" data-link-name="Our Mission" data-link-group="About Us">
+                    Our Mission
+                  </a>
+                </li>
+                <li>
+                  <a href="/en-US/about/history/" data-link-type="nav" data-link-name="Our History" data-link-group="About Us">
+                    Our History
+                  </a>
+                </li>
+                <li>
+                  <a href="/en-US/about/leadership/" data-link-type="nav" data-link-name="Our Leadership" data-link-group="About Us">
+                    Leadership
+                  </a>
+                </li>
+                <li>
+                  <a href="/en-US/foundation/" data-link-type="nav" data-link-name="Foundation" data-link-group="About Us">
+                    Foundation
+                  </a>
+                </li>
+                <li>
+                  <a href="https://blog.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=blogs" data-link-type="nav" data-link-name="Blogs" data-link-group="About Us">
+                    Blogs
+                  </a>
+                </li>
+                <li>
+                  <a href="https://careers.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=careers" data-link-type="nav" data-link-name="Careers" data-link-group="About Us">
+                    Careers
+                  </a>
+                </li>
+                <li>
+                  <a href="/en-US/contact/" data-link-type="nav" data-link-name="Contact Us" data-link-group="About Us">
+                    Contact Us
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </li>
+        <li class="item-get-involved">
+          <h3 class="summary" data-id="get-involved">
+            <a href="/en-US/contribute/" data-link-type="nav" data-link-position="side" data-link-name="expand" data-link-group="Get Involved">Get Involved</a>
+          </h3>
+          <div class="detail">
+            <div class="detail-container">
+              <p class="intro">
+                You can help Mozilla keep the Internet healthy – attend an event, volunteer, or make a donation.
+              </p>
+
+              <ul class="nav-menu-secondary-links">
+                <li>
+                  <a href="https://donate.mozilla.org/en-US/?presets=50,30,20,10&amp;amount=30&amp;utm_source=mozilla.org&amp;utm_medium=referral&amp;utm_content=global-nav&amp;currency=usd" data-link-type="nav" data-link-name="Give" data-link-group="Get Involved">
+                    Give
+                  </a>
+                </li>
+                <li>
+                  <a href="/en-US/contribute/" data-link-type="nav" data-link-name="Volunteer" data-link-group="Get Involved">
+                    Volunteer
+                  </a>
+                </li>
+                <li>
+                  <a href="/en-US/contribute/events/" data-link-type="nav" data-link-name="Events" data-link-group="Get Involved">
+                    Events
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div><!-- close .nav-menu-scroll-pane -->
+  </div><!-- close .nav-menu-inner-container -->
+</nav>
+  
+<div id="outer-wrapper">
+    
+<main>
+  <header class="main-page-heading">
+    
+    <h1>Internet for people, not profit</h1>
+  </header>
+  <section id="download-firefox-primary-cta" class="download-firefox-primary-cta">
+    <div class="mzp-l-content">
+      <div class="primary-wrapper">
+          <h2 class="primary-title">The new <strong>Firefox</strong></h2>
+          <h3 class="primary-title-sub">Fast for good.</h3>
+          <p class="primary-desc">2x the speed. Built-in privacy protection. Powered by Mozilla.</p>
+          <p class="primary-desc-sub">There’s a better way to browse.</p>
+          
+
+
+
+
+
+
+
+
+<div id="download-primary" class="download-button">
+  
+  <div class="nojs-download">
+    
+  <div class="download download-dumb">
+    <p role="heading" class="download-heading">
+      
+        Download Firefox
+        — English (US)
+    </p>
+    <ul>
+      <li><a href="https://download.mozilla.org/?product=firefox-stub&amp;os=win64&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="win64"
+               data-download-os="Desktop">Windows 64-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-stub&amp;os=win&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="win"
+               data-download-os="Desktop">Windows 32-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=osx&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="osx"
+               data-download-os="Desktop">macOS</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux64&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="linux64"
+               data-download-os="Desktop">Linux 64-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="linux"
+               data-download-os="Desktop">Linux 32-bit</a>
+        </li><li><a href="https://play.google.com/store/apps/details?id=org.mozilla.firefox&amp;referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="android"
+               data-download-os="Android"
+               >Android</a>
+        </li><li><a href="https://itunes.apple.com/us/app/apple-store/id989804926?pt=373246&amp;mt=8"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="ios"
+               data-download-os="iOS"
+               >iOS</a>
+        </li>
+    </ul>
+  </div>
+
+  </div>
+  
+    
+    <div class="unrecognized-download">
+      <p>Your system may not meet the requirements for Firefox, but you can try one of these versions:</p>
+      
+  <div class="download download-dumb">
+    <p role="heading" class="download-heading">
+      
+        Download Firefox
+        — English (US)
+    </p>
+    <ul>
+      <li><a href="https://download.mozilla.org/?product=firefox-stub&amp;os=win64&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="win64"
+               data-download-os="Desktop">Windows 64-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-stub&amp;os=win&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="win"
+               data-download-os="Desktop">Windows 32-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=osx&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="osx"
+               data-download-os="Desktop">macOS</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux64&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="linux64"
+               data-download-os="Desktop">Linux 64-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="linux"
+               data-download-os="Desktop">Linux 32-bit</a>
+        </li><li><a href="https://play.google.com/store/apps/details?id=org.mozilla.firefox&amp;referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="android"
+               data-download-os="Android"
+               >Android</a>
+        </li><li><a href="https://itunes.apple.com/us/app/apple-store/id989804926?pt=373246&amp;mt=8"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="ios"
+               data-download-os="iOS"
+               >iOS</a>
+        </li>
+    </ul>
+  </div>
+
+    </div>
+    <p class="unsupported-download">
+      Your system doesn't meet the <a href="/en-US/firefox/system-requirements/">requirements</a> to run Firefox.
+    </p>
+    <p class="unsupported-download-osx">
+      Your system doesn't meet the <a href="https://support.mozilla.org/kb/firefox-osx">requirements</a> to run Firefox.
+    </p>
+    <p class="linux-arm-download">
+      Please follow <a href="https://support.mozilla.org/kb/install-firefox-linux">these instructions</a> to install Firefox.
+    </p>
+  
+  <ul class="download-list">
+    
+      <li class="os_win64">
+        <a class="download-link button button-green"
+           href="/firefox/download/thanks/"
+           data-direct-link="https://download.mozilla.org/?product=firefox-stub&amp;os=win64&amp;lang=en-US"
+           data-link-type="download"
+           data-display-name="Windows 64-bit"
+           data-download-version="win64"
+           data-download-os="Desktop"
+           data-download-location="primary cta">
+          <strong class="download-title">
+            
+              
+                
+                  Download Firefox
+                
+              
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_win">
+        <a class="download-link button button-green"
+           href="/firefox/download/thanks/"
+           data-direct-link="https://download.mozilla.org/?product=firefox-stub&amp;os=win&amp;lang=en-US"
+           data-link-type="download"
+           data-display-name="Windows 32-bit"
+           data-download-version="win"
+           data-download-os="Desktop"
+           data-download-location="primary cta">
+          <strong class="download-title">
+            
+              
+                
+                  Download Firefox
+                
+              
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_osx">
+        <a class="download-link button button-green"
+           href="/firefox/download/thanks/"
+           data-direct-link="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=osx&amp;lang=en-US"
+           data-link-type="download"
+           data-display-name="macOS"
+           data-download-version="osx"
+           data-download-os="Desktop"
+           data-download-location="primary cta">
+          <strong class="download-title">
+            
+              
+                
+                  Download Firefox
+                
+              
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_linux64">
+        <a class="download-link button button-green"
+           href="/firefox/download/thanks/"
+           data-direct-link="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux64&amp;lang=en-US"
+           data-link-type="download"
+           data-display-name="Linux 64-bit"
+           data-download-version="linux64"
+           data-download-os="Desktop"
+           data-download-location="primary cta">
+          <strong class="download-title">
+            
+              
+                
+                  Download Firefox
+                
+              
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_linux">
+        <a class="download-link button button-green"
+           href="/firefox/download/thanks/"
+           data-direct-link="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux&amp;lang=en-US"
+           data-link-type="download"
+           data-display-name="Linux 32-bit"
+           data-download-version="linux"
+           data-download-os="Desktop"
+           data-download-location="primary cta">
+          <strong class="download-title">
+            
+              
+                
+                  Download Firefox
+                
+              
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_android">
+        <a class="download-link button button-green"
+           href="https://play.google.com/store/apps/details?id=org.mozilla.firefox&amp;referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org"
+           data-link-type="download"
+           data-display-name="Android"
+           data-download-version="android"
+           data-download-os="Android"
+           
+           data-download-location="primary cta">
+          <strong class="download-title">
+            
+              
+                
+                  <span>Firefox</span> for Android
+                
+              
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_ios">
+        <a class="download-link button button-green"
+           href="https://itunes.apple.com/us/app/apple-store/id989804926?pt=373246&amp;mt=8"
+           data-link-type="download"
+           data-display-name="iOS"
+           data-download-version="ios"
+           data-download-os="iOS"
+           
+           data-download-location="primary cta">
+          <strong class="download-title">
+            
+              
+                <span>Firefox</span> for iOS
+              
+            
+          </strong>
+        </a>
+      </li>
+    
+  </ul>
+  <small class="fx-privacy-link">
+     
+      
+    
+    <a href="/en-US/privacy/firefox/">Firefox Privacy Notice</a>
+  </small>
+</div>
+      </div>
+    </div>
+  </section>
+  <section id="download-firefox-sticky-cta" class="download-firefox-sticky-cta">
+    <div class="mzp-l-content">
+      <div class="primary-wrapper">
+          <h2 class="primary-title">The new <strong>Firefox</strong></h2>
+          <h3 class="primary-title-sub">Fast for good.</h3>
+          <p class="primary-desc-sub">There’s a better way to browse.</p>
+          
+
+
+
+
+
+
+
+
+<div id="download-sticky" class="download-button">
+  
+  <div class="nojs-download">
+    
+  <div class="download download-dumb">
+    <p role="heading" class="download-heading">
+      
+        Download Firefox
+        — English (US)
+    </p>
+    <ul>
+      <li><a href="https://download.mozilla.org/?product=firefox-stub&amp;os=win64&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="win64"
+               data-download-os="Desktop">Windows 64-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-stub&amp;os=win&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="win"
+               data-download-os="Desktop">Windows 32-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=osx&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="osx"
+               data-download-os="Desktop">macOS</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux64&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="linux64"
+               data-download-os="Desktop">Linux 64-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="linux"
+               data-download-os="Desktop">Linux 32-bit</a>
+        </li><li><a href="https://play.google.com/store/apps/details?id=org.mozilla.firefox&amp;referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="android"
+               data-download-os="Android"
+               >Android</a>
+        </li><li><a href="https://itunes.apple.com/us/app/apple-store/id989804926?pt=373246&amp;mt=8"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="ios"
+               data-download-os="iOS"
+               >iOS</a>
+        </li>
+    </ul>
+  </div>
+
+  </div>
+  
+    
+    <div class="unrecognized-download">
+      <p>Your system may not meet the requirements for Firefox, but you can try one of these versions:</p>
+      
+  <div class="download download-dumb">
+    <p role="heading" class="download-heading">
+      
+        Download Firefox
+        — English (US)
+    </p>
+    <ul>
+      <li><a href="https://download.mozilla.org/?product=firefox-stub&amp;os=win64&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="win64"
+               data-download-os="Desktop">Windows 64-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-stub&amp;os=win&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="win"
+               data-download-os="Desktop">Windows 32-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=osx&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="osx"
+               data-download-os="Desktop">macOS</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux64&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="linux64"
+               data-download-os="Desktop">Linux 64-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="linux"
+               data-download-os="Desktop">Linux 32-bit</a>
+        </li><li><a href="https://play.google.com/store/apps/details?id=org.mozilla.firefox&amp;referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="android"
+               data-download-os="Android"
+               >Android</a>
+        </li><li><a href="https://itunes.apple.com/us/app/apple-store/id989804926?pt=373246&amp;mt=8"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="ios"
+               data-download-os="iOS"
+               >iOS</a>
+        </li>
+    </ul>
+  </div>
+
+    </div>
+    <p class="unsupported-download">
+      Your system doesn't meet the <a href="/en-US/firefox/system-requirements/">requirements</a> to run Firefox.
+    </p>
+    <p class="unsupported-download-osx">
+      Your system doesn't meet the <a href="https://support.mozilla.org/kb/firefox-osx">requirements</a> to run Firefox.
+    </p>
+    <p class="linux-arm-download">
+      Please follow <a href="https://support.mozilla.org/kb/install-firefox-linux">these instructions</a> to install Firefox.
+    </p>
+  
+  <ul class="download-list">
+    
+      <li class="os_win64">
+        <a class="download-link button button-green"
+           href="/firefox/download/thanks/"
+           data-direct-link="https://download.mozilla.org/?product=firefox-stub&amp;os=win64&amp;lang=en-US"
+           data-link-type="download"
+           data-display-name="Windows 64-bit"
+           data-download-version="win64"
+           data-download-os="Desktop"
+           data-download-location="sticky cta">
+          <strong class="download-title">
+            
+              
+                
+                  Download Firefox
+                
+              
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_win">
+        <a class="download-link button button-green"
+           href="/firefox/download/thanks/"
+           data-direct-link="https://download.mozilla.org/?product=firefox-stub&amp;os=win&amp;lang=en-US"
+           data-link-type="download"
+           data-display-name="Windows 32-bit"
+           data-download-version="win"
+           data-download-os="Desktop"
+           data-download-location="sticky cta">
+          <strong class="download-title">
+            
+              
+                
+                  Download Firefox
+                
+              
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_osx">
+        <a class="download-link button button-green"
+           href="/firefox/download/thanks/"
+           data-direct-link="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=osx&amp;lang=en-US"
+           data-link-type="download"
+           data-display-name="macOS"
+           data-download-version="osx"
+           data-download-os="Desktop"
+           data-download-location="sticky cta">
+          <strong class="download-title">
+            
+              
+                
+                  Download Firefox
+                
+              
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_linux64">
+        <a class="download-link button button-green"
+           href="/firefox/download/thanks/"
+           data-direct-link="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux64&amp;lang=en-US"
+           data-link-type="download"
+           data-display-name="Linux 64-bit"
+           data-download-version="linux64"
+           data-download-os="Desktop"
+           data-download-location="sticky cta">
+          <strong class="download-title">
+            
+              
+                
+                  Download Firefox
+                
+              
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_linux">
+        <a class="download-link button button-green"
+           href="/firefox/download/thanks/"
+           data-direct-link="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux&amp;lang=en-US"
+           data-link-type="download"
+           data-display-name="Linux 32-bit"
+           data-download-version="linux"
+           data-download-os="Desktop"
+           data-download-location="sticky cta">
+          <strong class="download-title">
+            
+              
+                
+                  Download Firefox
+                
+              
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_android">
+        <a class="download-link button button-green"
+           href="https://play.google.com/store/apps/details?id=org.mozilla.firefox&amp;referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org"
+           data-link-type="download"
+           data-display-name="Android"
+           data-download-version="android"
+           data-download-os="Android"
+           
+           data-download-location="sticky cta">
+          <strong class="download-title">
+            
+              
+                
+                  <span>Firefox</span> for Android
+                
+              
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_ios">
+        <a class="download-link button button-green"
+           href="https://itunes.apple.com/us/app/apple-store/id989804926?pt=373246&amp;mt=8"
+           data-link-type="download"
+           data-display-name="iOS"
+           data-download-version="ios"
+           data-download-os="iOS"
+           
+           data-download-location="sticky cta">
+          <strong class="download-title">
+            
+              
+                <span>Firefox</span> for iOS
+              
+            
+          </strong>
+        </a>
+      </li>
+    
+  </ul>
+  <small class="fx-privacy-link">
+     
+      
+    
+    <a href="/en-US/privacy/firefox/">Firefox Privacy Notice</a>
+  </small>
+</div>
+      </div>
+    </div>
+  </section>
+  <div class="mozilla-content">
+    <div class="mzp-l-content">
+      <div class="mzp-l-card-hero">
+        <section class="mzp-c-card mzp-c-card-large mzp-has-aspect-16-9  ">
+  <a class="mzp-c-card-block-link" href="https://blog.mozilla.org/opendesign/evolving-the-firefox-brand/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=homepage&amp;utm_content=card" data-link-name="Evolving the Firefox brand" data-link-type="link">
+    <div class="mzp-c-card-media-wrapper">
+      <div class="lazy-image-container"><img class="mzp-c-card-image" src="/media/img/placeholder.71a50dbba44c.png" data-src="/media/img/home/2018/cards/design-systems.ba0078794e92.png"  alt="" ><noscript><img class="mzp-c-card-image" src="/media/img/home/2018/cards/design-systems.ba0078794e92.png"  alt="" ></noscript></div>
+    </div>
+    <div class="mzp-c-card-content">
+    
+      <div class="mzp-c-card-tag ">Branding</div>
+    
+      <h2 class="mzp-c-card-title"><span>Evolving the Firefox brand</span></h2>
+    
+      <p class="mzp-c-card-desc">Say “Firefox” and most people think of a web browser on their laptop or phone. There’s more to the story, and our branding needs to evolve.</p>
+    
+    
+    </div>
+  </a>
+  
+</section>
+        <!-- 2 -->
+        <section class="mzp-c-card  mzp-has-aspect-3-2  ">
+  <a class="mzp-c-card-block-link" href="https://www.bloomberg.com/news/articles/2018-08-09/pocket-s-30-million-users-are-great-for-publishers?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=homepage&amp;utm_content=card" data-link-name="Bloomberg: Pocket’s 30M users are great for publishers" data-link-type="link">
+    <div class="mzp-c-card-media-wrapper">
+      <div class="lazy-image-container"><img class="mzp-c-card-image" src="/media/img/placeholder.71a50dbba44c.png" data-src="/media/img/home/2018/cards/pocket-article-illustration.c22a89990304.jpg"  alt="" ><noscript><img class="mzp-c-card-image" src="/media/img/home/2018/cards/pocket-article-illustration.c22a89990304.jpg"  alt="" ></noscript></div>
+    </div>
+    <div class="mzp-c-card-content">
+    
+      <div class="mzp-c-card-tag ">News</div>
+    
+      <h2 class="mzp-c-card-title"><span>Bloomberg: Pocket’s 30M users are great for publishers</span></h2>
+    
+      <p class="mzp-c-card-desc">Mozilla’s focus on leisurely reads is aimed at publishers burned by Facebook. It’s paying off: Traffic is already up 75 percent this year.</p>
+    
+    
+    </div>
+  </a>
+  
+</section>
+        <!-- 3 -->
+        <section class="mzp-c-card  mzp-has-aspect-3-2 mzp-has-video has-video-embed">
+  <a class="mzp-c-card-block-link" href="https://blog.mozilla.org/internetcitizen/2018/08/13/firefox-privacy-philosophy/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=homepage&amp;utm_content=card" data-link-name="The Verge: The future of news feeds" data-link-type="link">
+    <div class="mzp-c-card-media-wrapper">
+      <div class="lazy-image-container"><img class="mzp-c-card-image" src="/media/img/placeholder.71a50dbba44c.png" data-src="/media/img/home/2018/cards/privacy-philosophy.719ad1c4d1e3.png"  alt="" ><noscript><img class="mzp-c-card-image" src="/media/img/home/2018/cards/privacy-philosophy.719ad1c4d1e3.png"  alt="" ></noscript></div>
+    </div>
+    <div class="mzp-c-card-content">
+    
+      <div class="mzp-c-card-tag ">Video</div>
+    
+      <h2 class="mzp-c-card-title"><span>Our privacy philosophy explained</span></h2>
+    
+      <p class="mzp-c-card-desc">These five principles guide how we put people first when we make products, manage data and advocate for policies.</p>
+    
+    
+    </div>
+  </a>
+  
+  <div class="mzp-c-card-video-wrapper hidden">
+    <figure class="mzp-c-card-video-content">
+      <div class="ytcontainer-video">
+        <div class="video-container">
+          <div class="video-play" data-id="fbF9gDSZX6U"></div>
+        </div>
+      </div>
+      <figcaption>
+        <p>These five principles guide how we put people first when we make products, manage data and advocate for policies. <a href="https://blog.mozilla.org/internetcitizen/2018/08/13/firefox-privacy-philosophy/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=homepage&amp;utm_content=card">Read more</a></p>
+      </figcaption>
+    </figure>
+  </div>
+  
+</section>
+        <!-- 4 -->
+        <section class="mzp-c-card  mzp-has-aspect-3-2  ">
+  <a class="mzp-c-card-block-link" href="https://irlpodcast.org/season3/episode3/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=homepage&amp;utm_content=card" data-link-name="IRL: Paid attention" data-link-type="link">
+    <div class="mzp-c-card-media-wrapper">
+      <div class="lazy-image-container"><img class="mzp-c-card-image" src="/media/img/placeholder.71a50dbba44c.png" data-src="/media/img/home/2018/cards/irl-s3-e3.4edece4a77a7.png"  alt="" ><noscript><img class="mzp-c-card-image" src="/media/img/home/2018/cards/irl-s3-e3.4edece4a77a7.png"  alt="" ></noscript></div>
+    </div>
+    <div class="mzp-c-card-content">
+    
+      <div class="mzp-c-card-tag ">Podcast</div>
+    
+      <h2 class="mzp-c-card-title"><span>IRL: Paid attention</span></h2>
+    
+      <p class="mzp-c-card-desc">There’s a new currency in town (and no, we’re not talking about Bitcoin). We’re talking about attention. Tune in to IRL.</p>
+    
+    
+    </div>
+  </a>
+  
+</section>
+        <!-- 5 -->
+        <section class="mzp-c-card  mzp-has-aspect-3-2  ">
+  <a class="mzp-c-card-block-link" href="https://blog.mozilla.org/firefox/make-your-firefox-browser-a-privacy-superpower-with-these-extensions/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=homepage&amp;utm_content=card" data-link-name="Make your browser a privacy superpower" data-link-type="link">
+    <div class="mzp-c-card-media-wrapper">
+      <div class="lazy-image-container"><img class="mzp-c-card-image" src="/media/img/placeholder.71a50dbba44c.png" data-src="/media/img/home/2018/cards/firefox-privacy.a8a19930bb8a.png"  alt="" ><noscript><img class="mzp-c-card-image" src="/media/img/home/2018/cards/firefox-privacy.a8a19930bb8a.png"  alt="" ></noscript></div>
+    </div>
+    <div class="mzp-c-card-content">
+    
+      <div class="mzp-c-card-tag ">Privacy</div>
+    
+      <h2 class="mzp-c-card-title"><span>Make your browser a privacy superpower</span></h2>
+    
+      <p class="mzp-c-card-desc">Customize your Firefox with these privacy extensions so you can browse knowing your personal data is safe.</p>
+    
+    
+    </div>
+  </a>
+  
+</section>
+      </div>
+
+      <div class="mzp-c-billboard mzp-l-billboard-right">
+        <div class="mzp-c-billboard-image-container">
+          <img class="mzp-c-billboard-image" src="/media/img/home/2018/billboard-more-power.f83d248d8724.png" srcset="/media/img/home/2018/billboard-more-power-high-res.5e9e07e1024c.png 1.5x" width="346" alt="" height="346">
+        </div>
+        <div class="mzp-c-billboard-content">
+          <div class="mzp-c-billboard-content-container">
+            <div class="mzp-c-billboard-content-inner">
+              <h2 class="mzp-c-billboard-title">More power to you.</h2>
+              <p class="mzp-c-billboard-desc">We’re the not-for-profit behind products, technologies and programs that make the internet healthier for everyone.</p>
+              <a class="mzp-c-cta-link" href="/en-US/about/">Learn more about us</a>
+            </div>
+          </div>
+        </div>
+      </div>
+<!-- 6 -->
+      <div class="mzp-l-card-half">
+        <section class="mzp-c-card mzp-c-card-medium mzp-has-aspect-16-9  ">
+  <a class="mzp-c-card-block-link" href="https://blog.mozilla.org/blog/2018/08/07/firefox-offers-recommendations-with-latest-test-pilot-experiment-advance/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=homepage&amp;utm_content=card" data-link-name="Advance offers real-time recommendations" data-link-type="link">
+    <div class="mzp-c-card-media-wrapper">
+      <div class="lazy-image-container"><img class="mzp-c-card-image" src="/media/img/placeholder.71a50dbba44c.png" data-src="/media/img/home/2018/cards/recommendations-screenshot.d2eb875dd1f2.jpg"  alt="" ><noscript><img class="mzp-c-card-image" src="/media/img/home/2018/cards/recommendations-screenshot.d2eb875dd1f2.jpg"  alt="" ></noscript></div>
+    </div>
+    <div class="mzp-c-card-content">
+    
+      <div class="mzp-c-card-tag ">Test Pilot</div>
+    
+      <h2 class="mzp-c-card-title"><span>Advance offers real-time recommendations</span></h2>
+    
+      <p class="mzp-c-card-desc">With the latest Firefox experiment, Advance, you can explore more of the web based on your current page and your most recent web history.</p>
+    
+    
+    </div>
+  </a>
+  
+</section>
+<!-- 7 -->
+        <section class="mzp-c-card mzp-c-card-medium mzp-has-aspect-16-9  ">
+  <a class="mzp-c-card-block-link" href="https://blog.mozilla.org/firefox/open-your-own-front-page-using-firefox-new-tab/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=homepage&amp;utm_content=card" data-link-name="Fresh front page, every time" data-link-type="link">
+    <div class="mzp-c-card-media-wrapper">
+      <div class="lazy-image-container"><img class="mzp-c-card-image" src="/media/img/placeholder.71a50dbba44c.png" data-src="/media/img/home/2018/cards/pocket-front-page.230c289eb808.png"  alt="" ><noscript><img class="mzp-c-card-image" src="/media/img/home/2018/cards/pocket-front-page.230c289eb808.png"  alt="" ></noscript></div>
+    </div>
+    <div class="mzp-c-card-content">
+    
+      <div class="mzp-c-card-tag ">Pocket</div>
+    
+      <h2 class="mzp-c-card-title"><span>Fresh front page, every time</span></h2>
+    
+      <p class="mzp-c-card-desc">We’ve made it faster and easier for you to find things that are important to you whenever you open a new tab in Firefox.</p>
+    
+    
+    </div>
+  </a>
+  
+</section>
+      </div>
+    </div>
+
+    
+    <aside class="pocket">
+      <div class="mzp-l-content">
+        <h3 class="section-heading">What we’re reading:</h3>
+        <p class="tagline">Like this feed? <a href="https://getpocket.com/@MozillaHQ">Subscribe</a> via Pocket</p>
+        <div class="mzp-l-card-quarter">
+        
+          <section class="mzp-c-card mzp-c-card-extra-small mzp-has-aspect-16-9  ">
+  <a class="mzp-c-card-block-link" href="https://www.newyorker.com/magazine/2018/09/17/can-mark-zuckerberg-fix-facebook-before-it-breaks-democracy" data-link-name="Pocket Link 1" data-link-type="link">
+    <div class="mzp-c-card-media-wrapper">
+      <div class="lazy-image-container"><img class="mzp-c-card-image" src="/media/img/placeholder.71a50dbba44c.png" data-src="https://img-getpocket.cdn.mozilla.net/direct?url=https%3A%2F%2Fmedia.newyorker.com%2Fphotos%2F5b92bd9501fe0d4c650955f2%2Fmaster%2Fw_727%2Cc_limit%2F180917_r32804.gif&resize=w450"  alt="" ><noscript><img class="mzp-c-card-image" src="https://img-getpocket.cdn.mozilla.net/direct?url=https%3A%2F%2Fmedia.newyorker.com%2Fphotos%2F5b92bd9501fe0d4c650955f2%2Fmaster%2Fw_727%2Cc_limit%2F180917_r32804.gif&resize=w450"  alt="" ></noscript></div>
+    </div>
+    <div class="mzp-c-card-content">
+    
+      <div class="mzp-c-card-tag ">newyorker.com</div>
+    
+      <h2 class="mzp-c-card-title"><span>Can Mark Zuckerberg Fix Facebook Before It Breaks Democracy?</span></h2>
+    
+    
+    </div>
+  </a>
+  
+</section>
+        
+          <section class="mzp-c-card mzp-c-card-extra-small mzp-has-aspect-16-9  ">
+  <a class="mzp-c-card-block-link" href="https://www.nytimes.com/interactive/2018/09/12/technology/kids-apps-data-privacy-google-twitter.html" data-link-name="Pocket Link 2" data-link-type="link">
+    <div class="mzp-c-card-media-wrapper">
+      <div class="lazy-image-container"><img class="mzp-c-card-image" src="/media/img/placeholder.71a50dbba44c.png" data-src="https://img-getpocket.cdn.mozilla.net/direct?url=https%3A%2F%2Fstatic01.nyt.com%2Fimages%2F2018%2F09%2F13%2Freader-center%2F13Kidapps5%2Fmerlin_143608812_3c73e2af-f53b-4a18-82ad-8c3a91d7251d-superJumbo.jpg&resize=w450"  alt="" ><noscript><img class="mzp-c-card-image" src="https://img-getpocket.cdn.mozilla.net/direct?url=https%3A%2F%2Fstatic01.nyt.com%2Fimages%2F2018%2F09%2F13%2Freader-center%2F13Kidapps5%2Fmerlin_143608812_3c73e2af-f53b-4a18-82ad-8c3a91d7251d-superJumbo.jpg&resize=w450"  alt="" ></noscript></div>
+    </div>
+    <div class="mzp-c-card-content">
+    
+      <div class="mzp-c-card-tag ">nytimes.com</div>
+    
+      <h2 class="mzp-c-card-title"><span>How Game Apps That Captivate Kids Have Been Collecting Their Data</span></h2>
+    
+    
+    </div>
+  </a>
+  
+</section>
+        
+          <section class="mzp-c-card mzp-c-card-extra-small mzp-has-aspect-16-9  ">
+  <a class="mzp-c-card-block-link" href="https://blog.mozilla.org/internetcitizen/2018/09/10/social-media-social-lives-common-sense" data-link-name="Pocket Link 3" data-link-type="link">
+    <div class="mzp-c-card-media-wrapper">
+      <div class="lazy-image-container"><img class="mzp-c-card-image" src="/media/img/placeholder.71a50dbba44c.png" data-src="https://img-getpocket.cdn.mozilla.net/direct?url=https%3A%2F%2Fffp4g1ylyit3jdyti1hqcvtb-wpengine.netdna-ssl.com%2Finternetcitizen%2Ffiles%2F2018%2F09%2Fteens-1400x770.png&resize=w450"  alt="" ><noscript><img class="mzp-c-card-image" src="https://img-getpocket.cdn.mozilla.net/direct?url=https%3A%2F%2Fffp4g1ylyit3jdyti1hqcvtb-wpengine.netdna-ssl.com%2Finternetcitizen%2Ffiles%2F2018%2F09%2Fteens-1400x770.png&resize=w450"  alt="" ></noscript></div>
+    </div>
+    <div class="mzp-c-card-content">
+    
+      <div class="mzp-c-card-tag ">blog.mozilla.org</div>
+    
+      <h2 class="mzp-c-card-title"><span>Social Media, Social Lives: Teens Dish on Everything from Cyberbullying to Digital Distraction</span></h2>
+    
+    
+    </div>
+  </a>
+  
+</section>
+        
+          <section class="mzp-c-card mzp-c-card-extra-small mzp-has-aspect-16-9  ">
+  <a class="mzp-c-card-block-link" href="https://irlpodcast.org/season3/episode6/" data-link-name="Pocket Link 4" data-link-type="link">
+    <div class="mzp-c-card-media-wrapper">
+      <div class="lazy-image-container"><img class="mzp-c-card-image" src="/media/img/placeholder.71a50dbba44c.png" data-src="https://img-getpocket.cdn.mozilla.net/direct?url=https%3A%2F%2Firlpodcast.org%2Fimages%2Fepisodes%2FS03E06%2Fshare.png&resize=w450"  alt="" ><noscript><img class="mzp-c-card-image" src="https://img-getpocket.cdn.mozilla.net/direct?url=https%3A%2F%2Firlpodcast.org%2Fimages%2Fepisodes%2FS03E06%2Fshare.png&resize=w450"  alt="" ></noscript></div>
+    </div>
+    <div class="mzp-c-card-content">
+    
+      <div class="mzp-c-card-tag ">irlpodcast.org</div>
+    
+      <h2 class="mzp-c-card-title"><span>Kids These Days</span></h2>
+    
+    
+    </div>
+  </a>
+  
+</section>
+        
+        </div>
+      </div>
+    </aside>
+    
+
+    <div class="mzp-l-content">
+      <div class="mzp-l-card-half">
+<!-- 8 -->
+        <section class="mzp-c-card mzp-c-card-medium mzp-has-aspect-3-2  ">
+  <a class="mzp-c-card-block-link" href="https://blog.mozilla.org/blog/2018/07/11/royalty-free-web-video-codecs/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=homepage&amp;utm_content=card" data-link-name="An invisible tax: Video codecs" data-link-type="link">
+    <div class="mzp-c-card-media-wrapper">
+      <div class="lazy-image-container"><img class="mzp-c-card-image" src="/media/img/placeholder.71a50dbba44c.png" data-src="/media/img/home/2018/cards/video-codecs.20882aa313a0.png"  alt="" ><noscript><img class="mzp-c-card-image" src="/media/img/home/2018/cards/video-codecs.20882aa313a0.png"  alt="" ></noscript></div>
+    </div>
+    <div class="mzp-c-card-content">
+    
+      <div class="mzp-c-card-tag ">Emerging Technologies</div>
+    
+      <h2 class="mzp-c-card-title"><span>An invisible tax: Video codecs</span></h2>
+    
+      <p class="mzp-c-card-desc">Here’s a surprising fact: It costs money to watch video online, even on free sites like YouTube. The open-source AV1 codec could change t...</p>
+    
+    
+    </div>
+  </a>
+  
+</section>
+<!-- 9 -->
+        <section class="mzp-c-card mzp-c-card-medium mzp-has-aspect-3-2  ">
+  <a class="mzp-c-card-block-link" href="https://blog.mozilla.org/internetcitizen/2018/07/27/attention-addiction/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=homepage&amp;utm_content=card" data-link-name="Attention economy to addiction economy" data-link-type="link">
+    <div class="mzp-c-card-media-wrapper">
+      <div class="lazy-image-container"><img class="mzp-c-card-image" src="/media/img/placeholder.71a50dbba44c.png" data-src="/media/img/home/2018/cards/attention-economy.2a102b792382.png"  alt="" ><noscript><img class="mzp-c-card-image" src="/media/img/home/2018/cards/attention-economy.2a102b792382.png"  alt="" ></noscript></div>
+    </div>
+    <div class="mzp-c-card-content">
+    
+      <div class="mzp-c-card-tag ">Internet Health</div>
+    
+      <h2 class="mzp-c-card-title"><span>Attention economy to addiction economy</span></h2>
+    
+      <p class="mzp-c-card-desc">As we depend more on our connected devices, it’s increasingly clear that there’s a dark side to the technology we use every day.</p>
+    
+    
+    </div>
+  </a>
+  
+</section>
+      </div>
+
+      <div class="mzp-c-billboard mzp-l-billboard-left">
+        <div class="mzp-c-billboard-image-container">
+          <img class="mzp-c-billboard-image" src="/media/img/home/2018/billboard-healthy-internet.4c6fc8ad55a2.png" srcset="/media/img/home/2018/billboard-healthy-internet-high-res.56fc2c64c968.png 1.5x" width="346" alt="" height="346">
+        </div>
+        <div class="mzp-c-billboard-content">
+          <div class="mzp-c-billboard-content-container">
+            <div class="mzp-c-billboard-content-inner">
+              <h2 class="mzp-c-billboard-title">Support a healthy internet.</h2>
+              <p class="mzp-c-billboard-desc">Open-source apps. Web literacy curriculum. Guides for fostering gender equality.</p>
+              <a class="mzp-c-cta-link" href="https://foundation.mozilla.org/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=homepage&utm_content=billboard">Visit the Mozilla Foundation</a>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="mzp-l-card-third">
+<!-- 10 -->
+        <section class="mzp-c-card  mzp-has-aspect-16-9  ">
+  <a class="mzp-c-card-block-link" href="https://blog.mozilla.org/internetcitizen/2018/08/07/privacy-apps/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=homepage&amp;utm_content=card" data-link-name="Seven apps that put privacy first" data-link-type="link">
+    <div class="mzp-c-card-media-wrapper">
+      <div class="lazy-image-container"><img class="mzp-c-card-image" src="/media/img/placeholder.71a50dbba44c.png" data-src="/media/img/home/2018/cards/privacy-apps.8f30a35c9f4a.png"  alt="" ><noscript><img class="mzp-c-card-image" src="/media/img/home/2018/cards/privacy-apps.8f30a35c9f4a.png"  alt="" ></noscript></div>
+    </div>
+    <div class="mzp-c-card-content">
+    
+      <div class="mzp-c-card-tag ">Privacy</div>
+    
+      <h2 class="mzp-c-card-title"><span>Seven apps that put privacy first</span></h2>
+    
+      <p class="mzp-c-card-desc">Here are seven apps and services that are committed to your privacy and security, including search engines, email providers and more.</p>
+    
+    
+    </div>
+  </a>
+  
+</section>
+<!-- 11 -->
+        <section class="mzp-c-card  mzp-has-aspect-3-2  ">
+  <a class="mzp-c-card-block-link" href="https://blog.mozilla.org/internetcitizen/2018/08/09/marshall-erwin-trust/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=homepage&amp;utm_content=card" data-link-name="Marshall Erwin talks trust and security" data-link-type="link">
+    <div class="mzp-c-card-media-wrapper">
+      <div class="lazy-image-container"><img class="mzp-c-card-image" src="/media/img/placeholder.71a50dbba44c.png" data-src="/media/img/home/2018/cards/marshall-erwin.c9178d7a9be4.jpg"  alt="" ><noscript><img class="mzp-c-card-image" src="/media/img/home/2018/cards/marshall-erwin.c9178d7a9be4.jpg"  alt="" ></noscript></div>
+    </div>
+    <div class="mzp-c-card-content">
+    
+      <div class="mzp-c-card-tag ">Rapid Fire</div>
+    
+      <h2 class="mzp-c-card-title"><span>Marshall Erwin talks trust and security</span></h2>
+    
+      <p class="mzp-c-card-desc">Get Marshall’s take on why security, privacy and trust matter so much at Mozilla and Firefox.</p>
+    
+    
+    </div>
+  </a>
+  
+</section>
+<!-- 12 -->
+        <section class="mzp-c-card  mzp-has-aspect-16-9  ">
+  <a class="mzp-c-card-block-link" href="https://blog.mozilla.org/internetcitizen/2018/07/31/wetransfer/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=homepage&amp;utm_content=card" data-link-name="WeTransfer keeps community at heart" data-link-type="link">
+    <div class="mzp-c-card-media-wrapper">
+      <div class="lazy-image-container"><img class="mzp-c-card-image" src="/media/img/placeholder.71a50dbba44c.png" data-src="/media/img/home/2018/cards/we-transfer.a483df73225a.png"  alt="" ><noscript><img class="mzp-c-card-image" src="/media/img/home/2018/cards/we-transfer.a483df73225a.png"  alt="" ></noscript></div>
+    </div>
+    <div class="mzp-c-card-content">
+    
+      <div class="mzp-c-card-tag ">Partners</div>
+    
+      <h2 class="mzp-c-card-title"><span>WeTransfer keeps community at heart</span></h2>
+    
+      <p class="mzp-c-card-desc">WeTransfer, the independent file transfer and sharing service, makes file-sharing easy in Firefox while keeping user privacy at heart.</p>
+    
+    
+    </div>
+  </a>
+  
+</section>
+<!-- 13 -->
+        <section class="mzp-c-card  mzp-has-aspect-3-2  ">
+  <a class="mzp-c-card-block-link" href="https://blog.mozilla.org/internetcitizen/2018/07/20/the-ringers-alyssa-bereznak-on-gamification-and-the-attention-economy/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=homepage&amp;utm_content=card" data-link-name="Gamification and the attention economy" data-link-type="link">
+    <div class="mzp-c-card-media-wrapper">
+      <div class="lazy-image-container"><img class="mzp-c-card-image" src="/media/img/placeholder.71a50dbba44c.png" data-src="/media/img/home/2018/cards/instagram-alyssa-bereznak.946794c0232c.png"  alt="" ><noscript><img class="mzp-c-card-image" src="/media/img/home/2018/cards/instagram-alyssa-bereznak.946794c0232c.png"  alt="" ></noscript></div>
+    </div>
+    <div class="mzp-c-card-content">
+    
+      <div class="mzp-c-card-tag ">Guest: Alyssa Bereznak</div>
+    
+      <h2 class="mzp-c-card-title"><span>Gamification and the attention economy</span></h2>
+    
+      <p class="mzp-c-card-desc">The Ringer’s Alyssa Bereznak shares her insights into tech’s race for our attention and how gamification keeps us hooked.</p>
+    
+    
+    </div>
+  </a>
+  
+</section>
+<!-- 14 -->
+        <section class="mzp-c-card  mzp-has-aspect-3-2  ">
+  <a class="mzp-c-card-block-link" href="https://blog.mozilla.org/internetcitizen/2018/07/26/this-is-your-digital-fingerprint/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=homepage&amp;utm_content=card" data-link-name="This is your digital fingerprint" data-link-type="link">
+    <div class="mzp-c-card-media-wrapper">
+      <div class="lazy-image-container"><img class="mzp-c-card-image" src="/media/img/placeholder.71a50dbba44c.png" data-src="/media/img/home/2018/cards/digital-fingerprint.8856280ef4fd.png"  alt="" ><noscript><img class="mzp-c-card-image" src="/media/img/home/2018/cards/digital-fingerprint.8856280ef4fd.png"  alt="" ></noscript></div>
+    </div>
+    <div class="mzp-c-card-content">
+    
+      <div class="mzp-c-card-tag ">Guest: Nick Briz</div>
+    
+      <h2 class="mzp-c-card-title"><span>This is your digital fingerprint</span></h2>
+    
+      <p class="mzp-c-card-desc">Chicago-based teacher and activist Nick Briz explains how people are tracked, surveilled and monetized on the web.</p>
+    
+    
+    </div>
+  </a>
+  
+</section>
+<!-- 15 -->
+        <section class="mzp-c-card  mzp-has-aspect-16-9  ">
+  <a class="mzp-c-card-block-link" href="https://blog.mozilla.org/internetcitizen/2018/08/08/how-the-web-changed-dating-forever/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=homepage&amp;utm_content=card" data-link-name="How the web changed dating forever" data-link-type="link">
+    <div class="mzp-c-card-media-wrapper">
+      <div class="lazy-image-container"><img class="mzp-c-card-image" src="/media/img/placeholder.71a50dbba44c.png" data-src="/media/img/home/2018/cards/online-dating.1cc2e06fd758.png"  alt="" ><noscript><img class="mzp-c-card-image" src="/media/img/home/2018/cards/online-dating.1cc2e06fd758.png"  alt="" ></noscript></div>
+    </div>
+    <div class="mzp-c-card-content">
+    
+      <div class="mzp-c-card-tag ">Guest: Laurie Davis Edwards</div>
+    
+      <h2 class="mzp-c-card-title"><span>How the web changed dating forever</span></h2>
+    
+      <p class="mzp-c-card-desc">There is a rise in the desire for perfection in relationships, except except it takes more than a quick swipe right to get it perfect.</p>
+    
+    
+    </div>
+  </a>
+  
+</section>
+      </div>
+
+      <div class="mzp-c-billboard mzp-l-billboard-right">
+        <div class="mzp-c-billboard-image-container">
+          <img class="mzp-c-billboard-image" src="/media/img/home/2018/billboard-open-minds.11da5ba9e1e9.png" srcset="/media/img/home/2018/billboard-open-minds-high-res.e991a1c381de.png 1.5x" width="346" alt="" height="346">
+        </div>
+        <div class="mzp-c-billboard-content">
+          <div class="mzp-c-billboard-content-container">
+            <div class="mzp-c-billboard-content-inner">
+              <h2 class="mzp-c-billboard-title">Open source. <br>Open minds.</h2>
+              <p class="mzp-c-billboard-desc">Mozilla creates powerful web tech for everyone.</p>
+              <a class="mzp-c-cta-link" href="/en-US/technology/">Explore Mozilla technology</a>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="mzp-l-card-half">
+<!-- 16 -->
+        <section class="mzp-c-card mzp-c-card-medium mzp-has-aspect-3-2  ">
+  <a class="mzp-c-card-block-link" href="https://blog.mozilla.org/firefox/get-your-game-on-in-the-browser/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=homepage&amp;utm_content=card" data-link-name="Get your game on, in the browser" data-link-type="link">
+    <div class="mzp-c-card-media-wrapper">
+      <div class="lazy-image-container"><img class="mzp-c-card-image" src="/media/img/placeholder.71a50dbba44c.png" data-src="/media/img/home/2018/cards/browser-game.7c17671347f9.png"  alt="" ><noscript><img class="mzp-c-card-image" src="/media/img/home/2018/cards/browser-game.7c17671347f9.png"  alt="" ></noscript></div>
+    </div>
+    <div class="mzp-c-card-content">
+    
+      <div class="mzp-c-card-tag ">Privacy</div>
+    
+      <h2 class="mzp-c-card-title"><span>Get your game on, in the browser</span></h2>
+    
+      <p class="mzp-c-card-desc">The web could be the best platform for gaming, and Firefox is the the best browser for gaming. Here’s why. </p>
+    
+    
+    </div>
+  </a>
+  
+</section>
+<!-- 17 -->
+        <section class="mzp-c-card mzp-c-card-medium mzp-has-aspect-3-2  ">
+  <a class="mzp-c-card-block-link" href="https://blog.mozilla.org/blog/2018/07/12/new-features-in-firefox-focus-for-ios-android-now-also-on-the-blackberry-key2/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=homepage&amp;utm_content=card" data-link-name="Firefox Focus rolls out new features" data-link-type="link">
+    <div class="mzp-c-card-media-wrapper">
+      <div class="lazy-image-container"><img class="mzp-c-card-image" src="/media/img/placeholder.71a50dbba44c.png" data-src="/media/img/home/2018/cards/firefox-focus.9332aca26f69.jpg"  alt="" ><noscript><img class="mzp-c-card-image" src="/media/img/home/2018/cards/firefox-focus.9332aca26f69.jpg"  alt="" ></noscript></div>
+    </div>
+    <div class="mzp-c-card-content">
+    
+      <div class="mzp-c-card-tag ">Mobile</div>
+    
+      <h2 class="mzp-c-card-title"><span>Firefox Focus rolls out new features</span></h2>
+    
+      <p class="mzp-c-card-desc">Find in page, desktop view and biometric access make Focus smarter than ever. Available for iOS, Android and now the BlackBerry Key2. </p>
+    
+    
+    </div>
+  </a>
+  
+</section>
+      </div>
+
+      <aside class="mzp-c-newsletter">
+        <div class="mzp-c-newsletter-image">
+          <img class="" src="/media/img/home/2018/newsletter-graphic.3debb24fbacc.png" srcset="/media/img/home/2018/newsletter-graphic-high-res.dfdd8a0a8b68.png 1.5x" alt="">
+        </div>
+
+        <div class="newsletter-content">
+          
+          
+
+
+
+
+
+
+  <form id="newsletter-form" class="mzp-c-newsletter-form" action="/en-US/newsletter/" method="post">
+    <input id="id_newsletters" maxlength="100" name="newsletters" type="hidden" value="mozilla-foundation" />
+    <input type="hidden" name="source_url" value="https://www.mozilla.org/en-US/">
+
+    
+    <header class="mzp-c-newsletter-header">
+      <h3 class="mzp-c-newsletter-title">Love the Web?</h3>
+      
+      <p class="mzp-c-newsletter-tagline">Get the Mozilla newsletter and help us keep it open and free.</p>
+      
+    </header>
+    
+
+    <fieldset class="mzp-c-newsletter-content">
+      
+
+      <p>
+        <label for="id_email">
+        
+          Your email address
+        
+        </label>
+        
+          
+        
+        <input class="mzp-js-email-field" id="id_email" name="email" placeholder="yourname@example.com" required="required" type="email" />
+      </p>
+
+      <div id="newsletter-details" class="mzp-c-newsletter-details">
+        
+          <p><select aria-required="true" id="id_country" name="country" required="required">
+<option value="af">Afghanistan</option>
+<option value="qz">Akrotiri</option>
+<option value="al">Albania</option>
+<option value="dz">Algeria</option>
+<option value="as">American Samoa</option>
+<option value="ad">Andorra</option>
+<option value="ao">Angola</option>
+<option value="ai">Anguilla</option>
+<option value="aq">Antarctica</option>
+<option value="ag">Antigua and Barbuda</option>
+<option value="ar">Argentina</option>
+<option value="am">Armenia</option>
+<option value="aw">Aruba</option>
+<option value="xa">Ashmore and Cartier Islands</option>
+<option value="au">Australia</option>
+<option value="at">Austria</option>
+<option value="az">Azerbaijan</option>
+<option value="bs">Bahamas, The</option>
+<option value="bh">Bahrain</option>
+<option value="xb">Baker Island</option>
+<option value="bd">Bangladesh</option>
+<option value="bb">Barbados</option>
+<option value="qs">Bassas da India</option>
+<option value="by">Belarus</option>
+<option value="be">Belgium</option>
+<option value="bz">Belize</option>
+<option value="bj">Benin</option>
+<option value="bm">Bermuda</option>
+<option value="bt">Bhutan</option>
+<option value="bo">Bolivia</option>
+<option value="bq">Bonaire, Sint Eustatius, and Saba</option>
+<option value="ba">Bosnia and Herzegovina</option>
+<option value="bw">Botswana</option>
+<option value="bv">Bouvet Island</option>
+<option value="br">Brazil</option>
+<option value="io">British Indian Ocean Territory</option>
+<option value="bn">Brunei</option>
+<option value="bg">Bulgaria</option>
+<option value="bf">Burkina Faso</option>
+<option value="mm">Burma</option>
+<option value="bi">Burundi</option>
+<option value="cv">Cabo Verde</option>
+<option value="kh">Cambodia</option>
+<option value="cm">Cameroon</option>
+<option value="ca">Canada</option>
+<option value="ky">Cayman Islands</option>
+<option value="cf">Central African Republic</option>
+<option value="td">Chad</option>
+<option value="cl">Chile</option>
+<option value="cn">China</option>
+<option value="cx">Christmas Island</option>
+<option value="cp">Clipperton Island</option>
+<option value="cc">Cocos (Keeling) Islands</option>
+<option value="co">Colombia</option>
+<option value="km">Comoros</option>
+<option value="cg">Congo (Brazzaville)</option>
+<option value="cd">Congo (Kinshasa)</option>
+<option value="ck">Cook Islands</option>
+<option value="xc">Coral Sea Islands</option>
+<option value="cr">Costa Rica</option>
+<option value="hr">Croatia</option>
+<option value="cu">Cuba</option>
+<option value="cw">Curaçao</option>
+<option value="cy">Cyprus</option>
+<option value="cz">Czech Republic</option>
+<option value="ci">Côte d’Ivoire</option>
+<option value="dk">Denmark</option>
+<option value="xd">Dhekelia</option>
+<option value="dg">Diego Garcia</option>
+<option value="dj">Djibouti</option>
+<option value="dm">Dominica</option>
+<option value="do">Dominican Republic</option>
+<option value="ec">Ecuador</option>
+<option value="eg">Egypt</option>
+<option value="sv">El Salvador</option>
+<option value="gq">Equatorial Guinea</option>
+<option value="er">Eritrea</option>
+<option value="ee">Estonia</option>
+<option value="et">Ethiopia</option>
+<option value="xe">Europa Island</option>
+<option value="fk">Falkland Islands (Islas Malvinas)</option>
+<option value="fo">Faroe Islands</option>
+<option value="fj">Fiji</option>
+<option value="fi">Finland</option>
+<option value="fr">France</option>
+<option value="gf">French Guiana</option>
+<option value="pf">French Polynesia</option>
+<option value="tf">French Southern and Antarctic Lands</option>
+<option value="ga">Gabon</option>
+<option value="gm">Gambia, The</option>
+<option value="xg">Gaza Strip</option>
+<option value="ge">Georgia</option>
+<option value="de">Germany</option>
+<option value="gh">Ghana</option>
+<option value="gi">Gibraltar</option>
+<option value="qx">Glorioso Islands</option>
+<option value="gr">Greece</option>
+<option value="gl">Greenland</option>
+<option value="gd">Grenada</option>
+<option value="gp">Guadeloupe</option>
+<option value="gu">Guam</option>
+<option value="gt">Guatemala</option>
+<option value="gg">Guernsey</option>
+<option value="gn">Guinea</option>
+<option value="gw">Guinea-Bissau</option>
+<option value="gy">Guyana</option>
+<option value="ht">Haiti</option>
+<option value="hm">Heard Island and McDonald Islands</option>
+<option value="hn">Honduras</option>
+<option value="hk">Hong Kong</option>
+<option value="xh">Howland Island</option>
+<option value="hu">Hungary</option>
+<option value="is">Iceland</option>
+<option value="in">India</option>
+<option value="id">Indonesia</option>
+<option value="ir">Iran</option>
+<option value="iq">Iraq</option>
+<option value="ie">Ireland</option>
+<option value="im">Isle of Man</option>
+<option value="il">Israel</option>
+<option value="it">Italy</option>
+<option value="jm">Jamaica</option>
+<option value="xj">Jan Mayen</option>
+<option value="jp">Japan</option>
+<option value="xq">Jarvis Island</option>
+<option value="je">Jersey</option>
+<option value="xu">Johnston Atoll</option>
+<option value="jo">Jordan</option>
+<option value="qu">Juan de Nova Island</option>
+<option value="kz">Kazakhstan</option>
+<option value="ke">Kenya</option>
+<option value="xm">Kingman Reef</option>
+<option value="ki">Kiribati</option>
+<option value="kp">Korea, North</option>
+<option value="kr">Korea, South</option>
+<option value="xk">Kosovo</option>
+<option value="kw">Kuwait</option>
+<option value="kg">Kyrgyzstan</option>
+<option value="la">Laos</option>
+<option value="lv">Latvia</option>
+<option value="lb">Lebanon</option>
+<option value="ls">Lesotho</option>
+<option value="lr">Liberia</option>
+<option value="ly">Libya</option>
+<option value="li">Liechtenstein</option>
+<option value="lt">Lithuania</option>
+<option value="lu">Luxembourg</option>
+<option value="mo">Macau</option>
+<option value="mk">Macedonia</option>
+<option value="mg">Madagascar</option>
+<option value="mw">Malawi</option>
+<option value="my">Malaysia</option>
+<option value="mv">Maldives</option>
+<option value="ml">Mali</option>
+<option value="mt">Malta</option>
+<option value="mh">Marshall Islands</option>
+<option value="mq">Martinique</option>
+<option value="mr">Mauritania</option>
+<option value="mu">Mauritius</option>
+<option value="yt">Mayotte</option>
+<option value="mx">Mexico</option>
+<option value="fm">Micronesia, Federated States of</option>
+<option value="qm">Midway Islands</option>
+<option value="md">Moldova</option>
+<option value="mc">Monaco</option>
+<option value="mn">Mongolia</option>
+<option value="me">Montenegro</option>
+<option value="ms">Montserrat</option>
+<option value="ma">Morocco</option>
+<option value="mz">Mozambique</option>
+<option value="na">Namibia</option>
+<option value="nr">Nauru</option>
+<option value="xv">Navassa Island</option>
+<option value="np">Nepal</option>
+<option value="nl">Netherlands</option>
+<option value="nc">New Caledonia</option>
+<option value="nz">New Zealand</option>
+<option value="ni">Nicaragua</option>
+<option value="ne">Niger</option>
+<option value="ng">Nigeria</option>
+<option value="nu">Niue</option>
+<option value="nf">Norfolk Island</option>
+<option value="mp">Northern Mariana Islands</option>
+<option value="no">Norway</option>
+<option value="om">Oman</option>
+<option value="pk">Pakistan</option>
+<option value="pw">Palau</option>
+<option value="xl">Palmyra Atoll</option>
+<option value="pa">Panama</option>
+<option value="pg">Papua New Guinea</option>
+<option value="xp">Paracel Islands</option>
+<option value="py">Paraguay</option>
+<option value="pe">Peru</option>
+<option value="ph">Philippines</option>
+<option value="pn">Pitcairn Islands</option>
+<option value="pl">Poland</option>
+<option value="pt">Portugal</option>
+<option value="pr">Puerto Rico</option>
+<option value="qa">Qatar</option>
+<option value="re">Reunion</option>
+<option value="ro">Romania</option>
+<option value="ru">Russia</option>
+<option value="rw">Rwanda</option>
+<option value="bl">Saint Barthelemy</option>
+<option value="sh">Saint Helena, Ascension, and Tristan da Cunha</option>
+<option value="kn">Saint Kitts and Nevis</option>
+<option value="lc">Saint Lucia</option>
+<option value="mf">Saint Martin</option>
+<option value="pm">Saint Pierre and Miquelon</option>
+<option value="vc">Saint Vincent and the Grenadines</option>
+<option value="ws">Samoa</option>
+<option value="sm">San Marino</option>
+<option value="st">Sao Tome and Principe</option>
+<option value="sa">Saudi Arabia</option>
+<option value="sn">Senegal</option>
+<option value="rs">Serbia</option>
+<option value="sc">Seychelles</option>
+<option value="sl">Sierra Leone</option>
+<option value="sg">Singapore</option>
+<option value="sx">Sint Maarten</option>
+<option value="sk">Slovakia</option>
+<option value="si">Slovenia</option>
+<option value="sb">Solomon Islands</option>
+<option value="so">Somalia</option>
+<option value="za">South Africa</option>
+<option value="gs">South Georgia and South Sandwich Islands</option>
+<option value="ss">South Sudan</option>
+<option value="es">Spain</option>
+<option value="xs">Spratly Islands</option>
+<option value="lk">Sri Lanka</option>
+<option value="sd">Sudan</option>
+<option value="sr">Suriname</option>
+<option value="xr">Svalbard</option>
+<option value="sz">Swaziland</option>
+<option value="se">Sweden</option>
+<option value="ch">Switzerland</option>
+<option value="sy">Syria</option>
+<option value="tw">Taiwan</option>
+<option value="tj">Tajikistan</option>
+<option value="tz">Tanzania</option>
+<option value="th">Thailand</option>
+<option value="tl">Timor-Leste</option>
+<option value="tg">Togo</option>
+<option value="tk">Tokelau</option>
+<option value="to">Tonga</option>
+<option value="tt">Trinidad and Tobago</option>
+<option value="xt">Tromelin Island</option>
+<option value="tn">Tunisia</option>
+<option value="tr">Turkey</option>
+<option value="tm">Turkmenistan</option>
+<option value="tc">Turks and Caicos Islands</option>
+<option value="tv">Tuvalu</option>
+<option value="ug">Uganda</option>
+<option value="ua">Ukraine</option>
+<option value="ae">United Arab Emirates</option>
+<option value="gb">United Kingdom</option>
+<option value="us" selected="selected">United States</option>
+<option value="uy">Uruguay</option>
+<option value="uz">Uzbekistan</option>
+<option value="vu">Vanuatu</option>
+<option value="va">Vatican City</option>
+<option value="ve">Venezuela</option>
+<option value="vn">Vietnam</option>
+<option value="vg">Virgin Islands, British</option>
+<option value="vi">Virgin Islands, U.S.</option>
+<option value="qw">Wake Island</option>
+<option value="wf">Wallis and Futuna</option>
+<option value="xw">West Bank</option>
+<option value="eh">Western Sahara</option>
+<option value="ye">Yemen</option>
+<option value="zm">Zambia</option>
+<option value="zw">Zimbabwe</option>
+</select></p>
+        
+
+        
+          <p><select aria-required="true" id="id_lang" name="lang" required="required">
+<option value="de">Deutsch</option>
+<option value="en" selected="selected">English</option>
+<option value="es">Español</option>
+<option value="fr">Français</option>
+<option value="pl">Polski</option>
+<option value="pt">Português</option>
+</select></p>
+        
+
+        <fieldset class="mzp-u-inline">
+          <legend>Format</legend>
+          <p>
+            <label for="format-html" class="mzp-u-inline">
+              <input type="radio" id="format-html" name="fmt" value="H" checked> HTML
+            </label>
+            <label for="format-text" class="mzp-u-inline">
+              <input type="radio" id="format-text" name="fmt" value="T"> Text
+            </label>
+          </p>
+        </fieldset>
+
+        <p>
+          <label for="privacy" class="mzp-u-inline">
+            <input type="checkbox" id="privacy" name="privacy" required aria-required="true"> I’m okay with Mozilla handling my info as explained
+            in <a href="/en-US/privacy/websites/">this Privacy Notice</a>
+          </label>
+        </p>
+      </div>
+
+      <p class="mzp-c-form-submit">
+        <button type="submit" id="newsletter-submit" class="mzp-c-button">
+          
+            Sign up now
+          
+        </button>
+
+        
+          <span class="mzp-c-fieldnote">We will only send you Mozilla-related information.</span>
+        
+      </p>
+    </fieldset>
+  </form>
+
+  <div id="newsletter-thanks" class="mzp-c-newsletter-thanks">
+    
+      
+  <h3>Thanks!</h3>
+  <p>
+  If you haven’t previously confirmed a subscription to a Mozilla-related newsletter you may have to do so. Please check your inbox or your spam filter for an email from us.
+  </p>
+
+    
+  </div>
+
+
+        </div>
+      </aside>
+    </div>
+  </div>
+
+  <div class="download-firefox-secondary-cta">
+    <div class="mzp-l-content">
+      <div class="secondary-content">
+        <h2 class="secondary-title">Supporting a healthy internet is easy.</h2>
+        <p class="tagline">Get started by browsing with Firefox powered by Mozilla.</p>
+        
+
+
+
+
+
+
+
+
+<div id="download-secondary" class="download-button">
+  
+  <div class="nojs-download">
+    
+  <div class="download download-dumb">
+    <p role="heading" class="download-heading">
+      
+        Download Firefox
+        — English (US)
+    </p>
+    <ul>
+      <li><a href="https://download.mozilla.org/?product=firefox-stub&amp;os=win64&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="win64"
+               data-download-os="Desktop">Windows 64-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-stub&amp;os=win&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="win"
+               data-download-os="Desktop">Windows 32-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=osx&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="osx"
+               data-download-os="Desktop">macOS</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux64&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="linux64"
+               data-download-os="Desktop">Linux 64-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="linux"
+               data-download-os="Desktop">Linux 32-bit</a>
+        </li><li><a href="https://play.google.com/store/apps/details?id=org.mozilla.firefox&amp;referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="android"
+               data-download-os="Android"
+               >Android</a>
+        </li><li><a href="https://itunes.apple.com/us/app/apple-store/id989804926?pt=373246&amp;mt=8"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="ios"
+               data-download-os="iOS"
+               >iOS</a>
+        </li>
+    </ul>
+  </div>
+
+  </div>
+  
+    
+    <div class="unrecognized-download">
+      <p>Your system may not meet the requirements for Firefox, but you can try one of these versions:</p>
+      
+  <div class="download download-dumb">
+    <p role="heading" class="download-heading">
+      
+        Download Firefox
+        — English (US)
+    </p>
+    <ul>
+      <li><a href="https://download.mozilla.org/?product=firefox-stub&amp;os=win64&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="win64"
+               data-download-os="Desktop">Windows 64-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-stub&amp;os=win&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="win"
+               data-download-os="Desktop">Windows 32-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=osx&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="osx"
+               data-download-os="Desktop">macOS</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux64&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="linux64"
+               data-download-os="Desktop">Linux 64-bit</a>
+        </li><li><a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux&amp;lang=en-US"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="linux"
+               data-download-os="Desktop">Linux 32-bit</a>
+        </li><li><a href="https://play.google.com/store/apps/details?id=org.mozilla.firefox&amp;referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="android"
+               data-download-os="Android"
+               >Android</a>
+        </li><li><a href="https://itunes.apple.com/us/app/apple-store/id989804926?pt=373246&amp;mt=8"
+               class="download-link button button-green"
+               data-link-type="download"
+               data-download-version="ios"
+               data-download-os="iOS"
+               >iOS</a>
+        </li>
+    </ul>
+  </div>
+
+    </div>
+    <p class="unsupported-download">
+      Your system doesn't meet the <a href="/en-US/firefox/system-requirements/">requirements</a> to run Firefox.
+    </p>
+    <p class="unsupported-download-osx">
+      Your system doesn't meet the <a href="https://support.mozilla.org/kb/firefox-osx">requirements</a> to run Firefox.
+    </p>
+    <p class="linux-arm-download">
+      Please follow <a href="https://support.mozilla.org/kb/install-firefox-linux">these instructions</a> to install Firefox.
+    </p>
+  
+  <ul class="download-list">
+    
+      <li class="os_win64">
+        <a class="download-link button button-green"
+           href="/firefox/download/thanks/"
+           data-direct-link="https://download.mozilla.org/?product=firefox-stub&amp;os=win64&amp;lang=en-US"
+           data-link-type="download"
+           data-display-name="Windows 64-bit"
+           data-download-version="win64"
+           data-download-os="Desktop"
+           data-download-location="secondary cta">
+          <strong class="download-title">
+            
+              
+                
+                  Download Firefox
+                
+              
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_win">
+        <a class="download-link button button-green"
+           href="/firefox/download/thanks/"
+           data-direct-link="https://download.mozilla.org/?product=firefox-stub&amp;os=win&amp;lang=en-US"
+           data-link-type="download"
+           data-display-name="Windows 32-bit"
+           data-download-version="win"
+           data-download-os="Desktop"
+           data-download-location="secondary cta">
+          <strong class="download-title">
+            
+              
+                
+                  Download Firefox
+                
+              
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_osx">
+        <a class="download-link button button-green"
+           href="/firefox/download/thanks/"
+           data-direct-link="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=osx&amp;lang=en-US"
+           data-link-type="download"
+           data-display-name="macOS"
+           data-download-version="osx"
+           data-download-os="Desktop"
+           data-download-location="secondary cta">
+          <strong class="download-title">
+            
+              
+                
+                  Download Firefox
+                
+              
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_linux64">
+        <a class="download-link button button-green"
+           href="/firefox/download/thanks/"
+           data-direct-link="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux64&amp;lang=en-US"
+           data-link-type="download"
+           data-display-name="Linux 64-bit"
+           data-download-version="linux64"
+           data-download-os="Desktop"
+           data-download-location="secondary cta">
+          <strong class="download-title">
+            
+              
+                
+                  Download Firefox
+                
+              
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_linux">
+        <a class="download-link button button-green"
+           href="/firefox/download/thanks/"
+           data-direct-link="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux&amp;lang=en-US"
+           data-link-type="download"
+           data-display-name="Linux 32-bit"
+           data-download-version="linux"
+           data-download-os="Desktop"
+           data-download-location="secondary cta">
+          <strong class="download-title">
+            
+              
+                
+                  Download Firefox
+                
+              
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_android">
+        <a class="download-link button button-green"
+           href="https://play.google.com/store/apps/details?id=org.mozilla.firefox&amp;referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org"
+           data-link-type="download"
+           data-display-name="Android"
+           data-download-version="android"
+           data-download-os="Android"
+           
+           data-download-location="secondary cta">
+          <strong class="download-title">
+            
+              
+                
+                  <span>Firefox</span> for Android
+                
+              
+            
+          </strong>
+        </a>
+      </li>
+    
+      <li class="os_ios">
+        <a class="download-link button button-green"
+           href="https://itunes.apple.com/us/app/apple-store/id989804926?pt=373246&amp;mt=8"
+           data-link-type="download"
+           data-display-name="iOS"
+           data-download-version="ios"
+           data-download-os="iOS"
+           
+           data-download-location="secondary cta">
+          <strong class="download-title">
+            
+              
+                <span>Firefox</span> for iOS
+              
+            
+          </strong>
+        </a>
+      </li>
+    
+  </ul>
+  <small class="fx-privacy-link">
+     
+      
+    
+    <a href="/en-US/privacy/firefox/">Firefox Privacy Notice</a>
+  </small>
+</div>
+      </div>
+    </div>
+  </div>
+</main>
+
+
+<script type="application/ld+json">
+	{
+		"@context": "http://schema.org",
+		"@type": "Organization",
+		"name": "Mozilla",
+    "url": "https://www.mozilla.org",
+    "logo": "https://www.mozilla.org/media/img/mozorg/mozilla-256.4720741d4108.jpg",
+		"sameAs": [
+      "https://www.wikidata.org/wiki/Q9661",
+      "https://twitter.com/mozilla",
+      "https://www.facebook.com/mozilla",
+      "https://github.com/mozilla",
+      "https://www.instagram.com/mozilla/",
+      "https://www.youtube.com/user/Mozilla",
+      "https://wikipedia.org/wiki/Mozilla",
+      "https://www.linkedin.com/company/mozilla-corporation"
+		]
+	}
+</script>
+
+
+    
+  <footer class="mzp-c-footer mzp-has-lang-switcher">
+  <div class="mzp-l-content">
+    <nav class="mzp-c-footer-primary">
+      <div class="mzp-c-footer-primary-logo">
+        <a href="/en-US/" data-link-type="footer" data-link-name="Mozilla">Mozilla</a>
+      </div>
+      <section class="mzp-c-footer-section">
+        <h5>
+          <a href="/en-US/" data-link-type="footer" data-link-name="Mozilla">Mozilla</a>
+        </h5>
+        <ul>
+          <li><a href="/en-US/about/" data-link-type="footer" data-link-name="About">About</a></li>
+          <li><a href="https://blog.mozilla.org/" data-link-type="footer" data-link-name="Blog">Blog</a></li>
+          <li><a href="/en-US/contact/" data-link-type="footer" data-link-name="Contact Us">Contact Us</a></li>
+          <li><a href="https://blog.mozilla.org/press/" data-link-type="footer" data-link-name="Press Center">Press Center</a>
+          <li><a href="https://donate.mozilla.org/en-US/?presets=50,30,20,10&amp;amount=30&amp;utm_source=mozilla.org&amp;utm_medium=referral&amp;utm_content=footer&amp;currency=usd" class="donate" data-link-type="footer" data-link-name="Donate">Donate</a></li>
+          <li><a href="https://wiki.mozilla.org/Webdev/GetInvolved/mozilla.org" data-link-type="footer" data-link-name="Contribute to this site">Contribute to this site</a></li>
+          
+          
+            <li><a href="https://github.com/mozilla/bedrock/tree/master/bedrock/mozorg/templates/mozorg/home/home-en.html" data-link-type="footer" data-link-name="Source code for this page">Source code for this page</a></li>
+          
+          <li>
+            <ul class="mzp-c-footer-links-social">
+              <li><a class="twitter" href="https://twitter.com/mozilla" data-link-type="footer" data-link-name="Twitter (@mozilla)">Twitter<span> (@mozilla)</span></a></li>
+              <li><a class="instagram" href="https://www.instagram.com/mozilla/" data-link-type="footer" data-link-name="Instagram (@mozilla)">Instagram<span> (@mozilla)</span></a></li>
+            </ul>
+          </li>
+        </ul>
+      </section>
+      <section class="mzp-c-footer-section">
+        <h5>
+          <a href="/en-US/firefox/" data-link-type="footer" data-link-name="Firefox">Firefox</a>
+        </h5>
+        <ul>
+          <li><a href="/en-US/firefox/new/" data-link-type="footer" data-link-name="Download Firefox">Download Firefox</a></li>
+          <li><a href="/en-US/firefox/" data-link-type="footer" data-link-name="Desktop">Desktop</a></li>
+          <li><a href="/en-US/firefox/mobile/" data-link-type="footer" data-link-name="Mobile">Mobile</a></li>
+          <li><a href="/en-US/firefox/features/" data-link-type="footer" data-link-name="Features">Features</a></li>
+          <li><a href="/en-US/firefox/channel/desktop/" data-link-type="footer" data-link-name="Beta, Nightly, Developer Edition">Beta, Nightly, Developer Edition</a></li>
+          <li>
+            <ul class="mzp-c-footer-links-social">
+              <li><a class="twitter" href="https://twitter.com/firefox" data-link-type="footer" data-link-name="Twitter (@firefox)">Twitter<span> (@firefox)</span></a></li>
+              <li><a class="youtube" href="https://www.youtube.com/firefoxchannel" data-link-type="footer" data-link-name="YouTube (firefoxchannel)">YouTube<span> (firefoxchannel)</span></a></li>
+            </ul>
+          </li>
+        </ul>
+      </section>
+    </nav>
+
+    <nav class="mzp-c-footer-secondary">
+        <div class="mzp-c-footer-legal">
+          <ul>
+            
+            <li><a href="/en-US/privacy/" data-link-type="footer" data-link-name="Privacy">Privacy</a></li>
+            
+            
+              
+            
+            <li><a href="/en-US/privacy/websites/" data-link-type="footer" data-link-name="Privacy">Website Privacy Notice</a></li>
+            <li><a href="/en-US/privacy/websites/#cookies" data-link-type="footer" data-link-name="Cookies">Cookies</a></li>
+            <li><a href="/en-US/about/legal/" data-link-type="footer" data-link-name="Legal">Legal</a></li>
+          </ul>
+          <p class="mzp-c-footer-license">Portions of this content are ©1998–2018 by individual mozilla.org contributors. Content available under a <a rel="license" href="/en-US/foundation/licensing/website-content/">Creative Commons license</a>.</p>
+        </div>
+        
+ <form id="lang_form" class="mzp-c-language-switcher" method="get" action="#">
+   <label for="mzp-c-language-switcher-select">Language</label>
+   <select id="mzp-c-language-switcher-select" class="mzp-c-language-switcher-select" name="lang" dir="ltr">
+     
+       <option lang="an" value="an">aragonés</option>
+     
+       <option lang="ar" value="ar">عربي</option>
+     
+       <option lang="ast" value="ast">Asturianu</option>
+     
+       <option lang="az" value="az">Azərbaycanca</option>
+     
+       <option lang="be" value="be">Беларуская</option>
+     
+       <option lang="bg" value="bg">Български</option>
+     
+       <option lang="bs" value="bs">Bosanski</option>
+     
+       <option lang="ca" value="ca">Català</option>
+     
+       <option lang="cak" value="cak">Maya Kaqchikel</option>
+     
+       <option lang="cs" value="cs">Čeština</option>
+     
+       <option lang="cy" value="cy">Cymraeg</option>
+     
+       <option lang="da" value="da">Dansk</option>
+     
+       <option lang="de" value="de">Deutsch</option>
+     
+       <option lang="dsb" value="dsb">Dolnoserbšćina</option>
+     
+       <option lang="el" value="el">Ελληνικά</option>
+     
+       <option lang="en-CA" value="en-CA">English (Canadian)</option>
+     
+       <option lang="en-GB" value="en-GB">English (British)</option>
+     
+       <option lang="en-US" value="en-US" selected>English</option>
+     
+       <option lang="eo" value="eo">Esperanto</option>
+     
+       <option lang="es-AR" value="es-AR">Español (de Argentina)</option>
+     
+       <option lang="es-CL" value="es-CL">Español (de Chile)</option>
+     
+       <option lang="es-ES" value="es-ES">Español (de España)</option>
+     
+       <option lang="es-MX" value="es-MX">Español (de México)</option>
+     
+       <option lang="et" value="et">Eesti keel</option>
+     
+       <option lang="eu" value="eu">Euskara</option>
+     
+       <option lang="fa" value="fa">فارسی</option>
+     
+       <option lang="fi" value="fi">suomi</option>
+     
+       <option lang="fr" value="fr">Français</option>
+     
+       <option lang="fy-NL" value="fy-NL">Frysk</option>
+     
+       <option lang="gn" value="gn">Avañe'ẽ</option>
+     
+       <option lang="gu-IN" value="gu-IN">ગુજરાતી (ભારત)</option>
+     
+       <option lang="hi-IN" value="hi-IN">हिन्दी (भारत)</option>
+     
+       <option lang="hsb" value="hsb">Hornjoserbsce</option>
+     
+       <option lang="hu" value="hu">magyar</option>
+     
+       <option lang="hy-AM" value="hy-AM">Հայերեն</option>
+     
+       <option lang="ia" value="ia">Interlingua</option>
+     
+       <option lang="id" value="id">Bahasa Indonesia</option>
+     
+       <option lang="it" value="it">Italiano</option>
+     
+       <option lang="ja" value="ja">日本語</option>
+     
+       <option lang="ka" value="ka">ქართული</option>
+     
+       <option lang="kab" value="kab">Taqbaylit</option>
+     
+       <option lang="ko" value="ko">한국어</option>
+     
+       <option lang="lij" value="lij">Ligure</option>
+     
+       <option lang="lt" value="lt">Lietuvių</option>
+     
+       <option lang="ml" value="ml">മലയാളം</option>
+     
+       <option lang="mr" value="mr">मराठी</option>
+     
+       <option lang="ms" value="ms">Melayu</option>
+     
+       <option lang="nb-NO" value="nb-NO">Norsk bokmål</option>
+     
+       <option lang="nl" value="nl">Nederlands</option>
+     
+       <option lang="nn-NO" value="nn-NO">Norsk nynorsk</option>
+     
+       <option lang="pa-IN" value="pa-IN">ਪੰਜਾਬੀ (ਭਾਰਤ)</option>
+     
+       <option lang="pl" value="pl">Polski</option>
+     
+       <option lang="pt-BR" value="pt-BR">Português (do Brasil)</option>
+     
+       <option lang="pt-PT" value="pt-PT">Português (Europeu)</option>
+     
+       <option lang="rm" value="rm">rumantsch</option>
+     
+       <option lang="ro" value="ro">Română</option>
+     
+       <option lang="ru" value="ru">Русский</option>
+     
+       <option lang="sk" value="sk">slovenčina</option>
+     
+       <option lang="sl" value="sl">Slovenščina</option>
+     
+       <option lang="sq" value="sq">Shqip</option>
+     
+       <option lang="sr" value="sr">Српски</option>
+     
+       <option lang="sv-SE" value="sv-SE">Svenska</option>
+     
+       <option lang="ta" value="ta">தமிழ்</option>
+     
+       <option lang="th" value="th">ไทย</option>
+     
+       <option lang="tr" value="tr">Türkçe</option>
+     
+       <option lang="trs" value="trs">Triqui</option>
+     
+       <option lang="uk" value="uk">Українська</option>
+     
+       <option lang="zh-CN" value="zh-CN">中文 (简体)</option>
+     
+       <option lang="zh-TW" value="zh-TW">正體中文 (繁體)</option>
+     
+   </select>
+   <button type="submit">Go</button>
+ </form>
+ 
+    </nav>
+  </div>
+</footer>
+
+  </div>
+
+  <!--[if IE 9]>
+    <script type="text/javascript" src="/media/js/BUNDLES/matchmedia.a6e503dcb8bc.js" charset="utf-8"></script>
+  <![endif]-->
+
+    
+<!--[if !lte IE 8]><!-->
+  <script type="text/javascript" src="/media/js/BUNDLES/common-protocol.03c1384e1b38.js" charset="utf-8"></script>
+<!--<![endif]-->
+
+<!--[if lte IE 8]>
+  <script type="text/javascript" src="/media/js/BUNDLES/common-ie8.1a18bf9598c9.js" charset="utf-8"></script>
+<![endif]-->
+
+
+    
+    
+      
+        <script type="text/javascript" src="/media/js/BUNDLES/stub-attribution.157168bbb235.js" charset="utf-8"></script>
+      
+    
+
+    <!--[if !lte IE 8]><!-->
+    
+  <script type="text/javascript" src="/media/js/BUNDLES/home.4eea5bb095ec.js" charset="utf-8"></script>
+
+
+    
+    
+
+    
+    <!--<![endif]-->
+
+    
+    
+    <img src="https://mozilla.org/set_hsts.gif" class="hidden">
+  </body>
+</html>


### PR DESCRIPTION
As part of the tests improvements work and using the work done in [PR](https://github.com/mozilla-mobile/firefox-ios/pull/4184) , let's try to change testing web sites to "internal" web sites.
There are a few limitations so far preventing us to change all the testing websites, but at least, this is an start.
- Internal web sites visited do not appear on History entry list
- Internal web sites visited do not appear on Top Sites