### PR TITLE
Bug 1492060 - tests need restoreTabs() called so a tab is created

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -595,8 +595,6 @@ extension TabManager {
     }
 
     func restoreTabs() {
-        guard !AppConstants.IsRunningTest else { return }
-
         defer {
             // Always make sure there is a single normal tab.
             if normalTabs.isEmpty {
@@ -606,7 +604,7 @@ extension TabManager {
                 }
             }
         }
-        guard count == 0, !DebugSettingsBundleOptions.skipSessionRestore, store.hasTabsToRestoreAtStartup else {
+        guard count == 0, !AppConstants.IsRunningTest, !DebugSettingsBundleOptions.skipSessionRestore, store.hasTabsToRestoreAtStartup else {
             return
         }
 

--- a/ClientTests/TabManagerStoreTests.swift
+++ b/ClientTests/TabManagerStoreTests.swift
@@ -22,8 +22,15 @@ class TabManagerStoreTests: XCTestCase {
         manager = TabManager(profile: profile, imageStore: nil)
         configuration.processPool = WKProcessPool()
 
-        manager.testClearArchive()
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            // BVC.viewWillAppear() calls restoreTabs() which interferes with these tests. (On iPhone, ClientTests never dismiss the intro screen, on iPad the intro is a popover on the BVC).
+            // Wait for this to happen (UIView.window only gets assigned after viewWillAppear()), then begin testing.
+            let bvc = (UIApplication.shared.delegate as! AppDelegate).browserViewController
+            let predicate = XCTNSPredicateExpectation(predicate: NSPredicate(format: "view.window != nil"), object: bvc)
+            wait(for: [predicate], timeout: 20)
+        }
 
+        manager.testClearArchive()
     }
 
     override func tearDown() {


### PR DESCRIPTION
`restoreTabs()` conflicts with the tab storage tests, so I made these tests wait until `restoreTabs()` is called at startup, then run the test.