### PR TITLE
Bug 1486243 - App freezes after following certain steps

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -478,16 +478,14 @@ class TabManager: NSObject {
         var tabsCopy = tabs
 
         // Remove the current tab last to prevent switching tabs while removing tabs
-        if let selectedTab = selectedTab {
-            if let selectedIndex = tabsCopy.index(of: selectedTab) {
-                let removed = tabsCopy.remove(at: selectedIndex)
-                removeTabs(tabsCopy)
-                removeTabAndUpdateSelectedIndex(removed)
-            } else {
-                removeTabs(tabsCopy)
-                if normalTabs.isEmpty {
-                    selectTab(addTab())
-                }
+        if let selectedTab = selectedTab, let selectedIndex = tabsCopy.index(of: selectedTab) {
+            let removed = tabsCopy.remove(at: selectedIndex)
+            removeTabs(tabsCopy)
+            removeTabAndUpdateSelectedIndex(removed)
+        } else {
+            removeTabs(tabsCopy)
+            if normalTabs.isEmpty {
+                selectTab(addTab())
             }
         }
         for tab in tabs {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1486243

What's happening here is (for some reason) when following the STR in the bug and switching back to normal browsing mode after closing all private tabs, there's no selected tab. Since there's no selected tab, the `removeTabsWithUndoToast()` call does not actually remove any tabs which gets us stuck in a bad state.