### PR TITLE
Bug 1493175 - TabDisplayManager crash, tabStore not in-sync with tabsToDisplay

### DIFF
--- a/Client/Frontend/Browser/TabTrayController+KeyCommands.swift
+++ b/Client/Frontend/Browser/TabTrayController+KeyCommands.swift
@@ -74,7 +74,7 @@ extension TabTrayController {
             step = 0
         }
 
-        let tabs = tabDisplayManager.tabStore
+        let tabs = tabDisplayManager.tabsToDisplay
         let currentIndex: Int
         if let selected = tabManager.selectedTab {
             currentIndex = tabs.index(of: selected) ?? 0

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -143,7 +143,7 @@ class TabTrayController: UIViewController {
     }
 
     func focusTab() {
-        guard let currentTab = tabManager.selectedTab, let index = self.tabDisplayManager.tabStore.index(of: currentTab), let rect = self.collectionView.layoutAttributesForItem(at: IndexPath(item: index, section: 0))?.frame else {
+        guard let currentTab = tabManager.selectedTab, let index = tabDisplayManager.tabsToDisplay.index(of: currentTab), let rect = self.collectionView.layoutAttributesForItem(at: IndexPath(item: index, section: 0))?.frame else {
             return
         }
         self.collectionView.scrollRectToVisible(rect, animated: false)
@@ -413,13 +413,11 @@ extension TabTrayController: UITextFieldDelegate {
             }
             return false
         }
-        self.tabDisplayManager.searchActive = true
-        self.tabDisplayManager.searchedTabs = filteredTabs
-        self.tabDisplayManager.performTabUpdates()
+        tabDisplayManager.searchedTabs = filteredTabs
+        tabDisplayManager.performTabUpdates()
     }
 
     func clearSearch() {
-        tabDisplayManager.searchActive = false
         tabDisplayManager.searchedTabs = []
         searchBar.text = ""
         ensureMainThread {
@@ -455,7 +453,7 @@ extension TabTrayController {
     }
 
     func closeTabsForCurrentTray() {
-        tabManager.removeTabsWithUndoToast(tabDisplayManager.tabStore)
+        tabManager.removeTabsWithUndoToast(tabDisplayManager.tabsToDisplay)
         if !tabDisplayManager.isPrivate {
             // when closing all tabs in normal mode we automatically open a new tab and focus it
             self.tabDisplayManager.performTabUpdates {
@@ -507,7 +505,7 @@ extension TabTrayController {
 
 extension TabTrayController: TabSelectionDelegate {
     func didSelectTabAtIndex(_ index: Int) {
-        if let tab = tabDisplayManager.tabStore[safe: index] {
+        if let tab = tabDisplayManager.tabsToDisplay[safe: index] {
             tabManager.selectTab(tab)
             dismissTabTray()
         }
@@ -556,7 +554,7 @@ extension TabTrayController: UIScrollViewAccessibilityDelegate {
 extension TabTrayController: SwipeAnimatorDelegate {
     func swipeAnimator(_ animator: SwipeAnimator, viewWillExitContainerBounds: UIView) {
         guard let tabCell = animator.animatingView as? TabCell, let indexPath = collectionView.indexPath(for: tabCell) else { return }
-        if let tab = tabDisplayManager.tabStore[safe: indexPath.item] {
+        if let tab = tabDisplayManager.tabsToDisplay[safe: indexPath.item] {
             self.removeTab(tab: tab)
             UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, NSLocalizedString("Closing tab", comment: "Accessibility label (used by assistive technology) notifying the user that the tab is being closed."))
         }
@@ -565,7 +563,7 @@ extension TabTrayController: SwipeAnimatorDelegate {
 
 extension TabTrayController: TabCellDelegate {
     func tabCellDidClose(_ cell: TabCell) {
-        if let indexPath = collectionView.indexPath(for: cell), let tab = tabDisplayManager.tabStore[safe: indexPath.item] {
+        if let indexPath = collectionView.indexPath(for: cell), let tab = tabDisplayManager.tabsToDisplay[safe: indexPath.item] {
             self.removeTab(tab: tab)
         }
     }
@@ -582,7 +580,7 @@ extension TabTrayController: TabPeekDelegate {
     }
 
     func tabPeekDidCloseTab(_ tab: Tab) {
-        if let index = tabDisplayManager.tabStore.index(of: tab),
+        if let index = tabDisplayManager.tabsToDisplay.index(of: tab),
             let cell = self.collectionView?.cellForItem(at: IndexPath(item: index, section: 0)) as? TabCell {
             cell.close()
         }
@@ -603,7 +601,7 @@ extension TabTrayController: UIViewControllerPreviewingDelegate {
         guard let indexPath = collectionView.indexPathForItem(at: convertedLocation),
             let cell = collectionView.cellForItem(at: indexPath) else { return nil }
 
-        guard let tab = tabDisplayManager.tabStore[safe: indexPath.row] else {
+        guard let tab = tabDisplayManager.tabsToDisplay[safe: indexPath.row] else {
             return nil
         }
         let tabVC = TabPeekViewController(tab: tab, delegate: self)
@@ -627,7 +625,7 @@ extension TabTrayController {
     func removeTab(tab: Tab) {
         // when removing the last tab (only in normal mode) we will automatically open a new tab.
         // When that happens focus it by dismissing the tab tray
-        let isLastTab = tabDisplayManager.tabStore.count == 1
+        let isLastTab = tabDisplayManager.tabsToDisplay.count == 1
         tabManager.removeTabAndUpdateSelectedIndex(tab)
         guard !tabDisplayManager.searchActive else { return }
         self.emptyPrivateTabsView.isHidden = !self.privateTabsAreEmpty()

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -160,7 +160,7 @@ class TopTabsViewController: UIViewController {
         tabsButton.applyTheme()
         applyUIMode(isPrivate: tabManager.selectedTab?.isPrivate ?? false)
 
-        updateTabCount(tabDisplayManager.tabCount, animated: false)
+        updateTabCount(tabDisplayManager.tabsToDisplay.count, animated: false)
     }
 
     func switchForegroundStatus(isInForeground reveal: Bool) {
@@ -203,7 +203,7 @@ class TopTabsViewController: UIViewController {
     func scrollToCurrentTab(_ animated: Bool = true, centerCell: Bool = false) {
         assertIsMainThread("Only animate on the main thread")
 
-        guard let currentTab = tabManager.selectedTab, let index = tabDisplayManager.tabStore.index(of: currentTab), !collectionView.frame.isEmpty else {
+        guard let currentTab = tabManager.selectedTab, let index = tabDisplayManager.tabsToDisplay.index(of: currentTab), !collectionView.frame.isEmpty else {
             return
         }
         if let frame = collectionView.layoutAttributesForItem(at: IndexPath(row: index, section: 0))?.frame {
@@ -246,7 +246,7 @@ extension TopTabsViewController: TopTabCellDelegate {
         guard let index = collectionView.indexPath(for: cell)?.item else {
             return
         }
-        if let tab = self.tabDisplayManager.tabStore[safe: index] {
+        if let tab = self.tabDisplayManager.tabsToDisplay[safe: index] {
             tabManager.removeTabAndUpdateSelectedIndex(tab)
         }
 


### PR DESCRIPTION
TDM.tabStore gets out of sync with TDB.tabsToDisplay, both are not needed that I can find,
having only one removes the possibility of being out of sync (and stops the crash).
