### PR TITLE
Bug 1493159 - [regression] emag.ro link is incorrectly shared via Firefox extension

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -281,7 +281,10 @@ extension BrowserViewController: WKNavigationDelegate {
 
         // If the content type is not HTML, create a temporary document so it can be downloaded and
         // shared to external applications later. Otherwise, clear the old temporary document.
-        if let tab = tabManager[webView] {
+        // NOTE: This should only happen if the request/response came from the main frame, otherwise
+        // we may end up overriding the "Share Page With..." action to share a temp file that is not
+        // representative of the contents of the web view.
+        if navigationResponse.isForMainFrame, let tab = tabManager[webView] {
             if response.mimeType != MIMEType.HTML, let request = request {
                 tab.temporaryDocument = TemporaryDocument(preflightResponse: response, request: request)
             } else {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1493159