### PR TITLE
Revert "Bug 1493175 - TabDisplayManager crash, tabStore not in-sync with tabsToDisplay"

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -35,8 +35,9 @@ class TabDisplayManager: NSObject {
     let tabReuseIdentifer: String
 
     var searchedTabs: [Tab] = []
-    var searchActive: Bool { return !searchedTabs.isEmpty }
+    var searchActive: Bool = false
 
+    var tabStore: [Tab] = [] //the actual datastore
     fileprivate var pendingUpdatesToTabs: [Tab] = [] //the datastore we are transitioning to
     fileprivate var needReloads: [Tab?] = [] // Tabs that need to be reloaded
     fileprivate var completionBlocks: [CompletionBlock] = [] //blocks are performed once animations finish
@@ -45,7 +46,11 @@ class TabDisplayManager: NSObject {
     fileprivate var oldTabs: [Tab]? // The last state of the tabs before an animation
     fileprivate weak var oldSelectedTab: Tab? // Used to select the right tab when transitioning between private/normal tabs
 
-    var tabsToDisplay: [Tab] {
+    var tabCount: Int {
+        return self.tabStore.count
+    }
+
+    private var tabsToDisplay: [Tab] {
         if searchActive {
             // tabs can be deleted while a search is active. Make sure the tab still exists in the tabmanager before displaying
             return searchedTabs.filter({ tabManager.tabs.contains($0) })
@@ -63,6 +68,7 @@ class TabDisplayManager: NSObject {
 
         tabManager.addDelegate(self)
         self.tabObservers = registerFor(.didLoadFavicon, .didChangeURL, queue: .main)
+        self.tabStore = self.tabsToDisplay
     }
 
     // Once we are done with TabManager we need to call removeObservers to avoid a retain cycle with the observers
@@ -80,7 +86,7 @@ class TabDisplayManager: NSObject {
         let isTabTray = tabDisplayer as? TabTrayController != nil
         let eventValue = isTabTray ? UnifiedTelemetry.EventValue.tabTray : UnifiedTelemetry.EventValue.topTabs
         UnifiedTelemetry.recordEvent(category: .action, method: method, object: object, value: eventValue)
-        Sentry.shared.breadcrumb(category: "Tab Action", message: "object: \(object), action: \(method.rawValue), \(eventValue.rawValue), tab count: \(tabsToDisplay.count) ")
+        Sentry.shared.breadcrumb(category: "Tab Action", message: "object: \(object), action: \(method.rawValue), \(eventValue.rawValue), tab count: \(tabStore.count) ")
     }
 
     func togglePBM() {
@@ -110,11 +116,11 @@ class TabDisplayManager: NSObject {
 
 extension TabDisplayManager: UICollectionViewDataSource {
     @objc func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return tabsToDisplay.count
+        return tabStore.count
     }
 
     @objc func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let tab = tabsToDisplay[indexPath.row]
+        let tab = tabStore[indexPath.row]
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: self.tabReuseIdentifer, for: indexPath)
         if let tabCell = tabDisplayer?.cellFactory(for: cell, using: tab) {
             return tabCell
@@ -132,7 +138,7 @@ extension TabDisplayManager: UICollectionViewDataSource {
 
 extension TabDisplayManager: TabSelectionDelegate {
     func didSelectTabAtIndex(_ index: Int) {
-        let tab = tabsToDisplay[index]
+        let tab = tabStore[index]
         if tabsToDisplay.index(of: tab) != nil {
             tabManager.selectTab(tab)
         }
@@ -180,9 +186,9 @@ extension TabDisplayManager: UICollectionViewDragDelegate {
 
     func collectionView(_ collectionView: UICollectionView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
         // We need to store the earliest oldTabs. So if one already exists use that.
-        self.oldTabs = self.oldTabs ?? tabsToDisplay
+        self.oldTabs = self.oldTabs ?? tabStore
 
-        let tab = tabsToDisplay[indexPath.item]
+        let tab = tabStore[indexPath.item]
 
         // Get the tab's current URL. If it is `nil`, check the `sessionData` since
         // it may be a tab that has not been restored yet.
@@ -216,7 +222,7 @@ extension TabDisplayManager: UICollectionViewDragDelegate {
 @available(iOS 11.0, *)
 extension TabDisplayManager: UICollectionViewDropDelegate {
     func collectionView(_ collectionView: UICollectionView, performDropWith coordinator: UICollectionViewDropCoordinator) {
-        guard let destinationIndexPath = coordinator.destinationIndexPath, let dragItem = coordinator.items.first?.dragItem, let tab = dragItem.localObject as? Tab, let sourceIndex = tabsToDisplay.index(of: tab) else {
+        guard let destinationIndexPath = coordinator.destinationIndexPath, let dragItem = coordinator.items.first?.dragItem, let tab = dragItem.localObject as? Tab, let sourceIndex = tabStore.index(of: tab) else {
             return
         }
 
@@ -237,7 +243,7 @@ extension TabDisplayManager: UICollectionViewDropDelegate {
         // If the `isDragging` is not `true` by the time we get here, we've had other
         // add/remove operations happen while the drag was going on. We must return a
         // `.cancel` operation continuously until `isDragging` can be reset.
-        guard tabsToDisplay.index(of: tab) != nil, isDragging else {
+        guard tabStore.index(of: tab) != nil, isDragging else {
             return UICollectionViewDropProposal(operation: .cancel)
         }
 
@@ -249,7 +255,7 @@ extension TabDisplayManager: TabEventHandler {
     func tab(_ tab: Tab, didLoadFavicon favicon: Favicon?, with: Data?) {
         assertIsMainThread("UICollectionView changes can only be performed from the main thread")
 
-        if tabsToDisplay.index(of: tab) != nil {
+        if tabStore.index(of: tab) != nil {
             needReloads.append(tab)
             performTabUpdates()
         }
@@ -258,7 +264,7 @@ extension TabDisplayManager: TabEventHandler {
     func tab(_ tab: Tab, didChangeURL url: URL) {
         assertIsMainThread("UICollectionView changes can only be performed from the main thread")
 
-        if tabsToDisplay.index(of: tab) != nil {
+        if tabStore.index(of: tab) != nil {
             needReloads.append(tab)
             performTabUpdates()
         }
@@ -355,6 +361,8 @@ extension TabDisplayManager {
 
         // The actual update block. We update the dataStore right before we do the UI updates.
         let updateBlock = {
+            self.tabStore = newTabs
+
             // Only consider moves if no other operations are pending.
             if update.deletes.count == 0, update.inserts.count == 0 {
                 for move in update.moves {
@@ -383,7 +391,7 @@ extension TabDisplayManager {
             }
 
             // There can be pending animations. Run update again to clear them.
-            let tabs = self.oldTabs ?? self.tabsToDisplay
+            let tabs = self.oldTabs ?? self.tabStore
             self.updateTabsFrom(tabs, to: self.tabsToDisplay, on: {
                 if !update.inserts.isEmpty || !update.reloads.isEmpty {
                     self.tabDisplayer?.focusSelectedTab()
@@ -424,7 +432,7 @@ extension TabDisplayManager {
 
         isUpdating = true
         isDragging = false
-
+        self.tabStore = self.tabsToDisplay
         self.flushPendingChanges()
         UIView.animate(withDuration: TopTabsUX.AnimationSpeed, animations: {
             self.collectionView.reloadData()
@@ -459,7 +467,7 @@ extension TabDisplayManager: TabManagerDelegate {
         }
 
         let fromTabs = !self.pendingUpdatesToTabs.isEmpty ? self.pendingUpdatesToTabs : self.oldTabs
-        oldTabs = fromTabs ?? tabsToDisplay
+        self.oldTabs = fromTabs ?? self.tabStore
         if self.pendingReloadData && !isUpdating {
             self.reloadData()
         } else {
@@ -487,7 +495,7 @@ extension TabDisplayManager: TabManagerDelegate {
 
     func tabManager(_ tabManager: TabManager, willAddTab tab: Tab) {
         // We need to store the earliest oldTabs. So if one already exists use that.
-        oldTabs = oldTabs ?? tabsToDisplay
+        self.oldTabs = self.oldTabs ?? tabStore
     }
 
     func tabManager(_ tabManager: TabManager, didAddTab tab: Tab, isRestoring: Bool) {
@@ -499,7 +507,7 @@ extension TabDisplayManager: TabManagerDelegate {
 
     func tabManager(_ tabManager: TabManager, willRemoveTab tab: Tab) {
         // We need to store the earliest oldTabs. So if one already exists use that.
-        self.oldTabs = self.oldTabs ?? tabsToDisplay
+        self.oldTabs = self.oldTabs ?? tabStore
     }
 
     func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool) {

--- a/Client/Frontend/Browser/TabTrayController+KeyCommands.swift
+++ b/Client/Frontend/Browser/TabTrayController+KeyCommands.swift
@@ -74,7 +74,7 @@ extension TabTrayController {
             step = 0
         }
 
-        let tabs = tabDisplayManager.tabsToDisplay
+        let tabs = tabDisplayManager.tabStore
         let currentIndex: Int
         if let selected = tabManager.selectedTab {
             currentIndex = tabs.index(of: selected) ?? 0

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -160,7 +160,7 @@ class TopTabsViewController: UIViewController {
         tabsButton.applyTheme()
         applyUIMode(isPrivate: tabManager.selectedTab?.isPrivate ?? false)
 
-        updateTabCount(tabDisplayManager.tabsToDisplay.count, animated: false)
+        updateTabCount(tabDisplayManager.tabCount, animated: false)
     }
 
     func switchForegroundStatus(isInForeground reveal: Bool) {
@@ -203,7 +203,7 @@ class TopTabsViewController: UIViewController {
     func scrollToCurrentTab(_ animated: Bool = true, centerCell: Bool = false) {
         assertIsMainThread("Only animate on the main thread")
 
-        guard let currentTab = tabManager.selectedTab, let index = tabDisplayManager.tabsToDisplay.index(of: currentTab), !collectionView.frame.isEmpty else {
+        guard let currentTab = tabManager.selectedTab, let index = tabDisplayManager.tabStore.index(of: currentTab), !collectionView.frame.isEmpty else {
             return
         }
         if let frame = collectionView.layoutAttributesForItem(at: IndexPath(row: index, section: 0))?.frame {
@@ -246,7 +246,7 @@ extension TopTabsViewController: TopTabCellDelegate {
         guard let index = collectionView.indexPath(for: cell)?.item else {
             return
         }
-        if let tab = self.tabDisplayManager.tabsToDisplay[safe: index] {
+        if let tab = self.tabDisplayManager.tabStore[safe: index] {
             tabManager.removeTabAndUpdateSelectedIndex(tab)
         }
 


### PR DESCRIPTION
Reverts mozilla-mobile/firefox-ios#4257

Crashes switching private browsing on iPad using tab bar PBM button.