### PR TITLE
Bug 1493136 - In normal browsing mode, use iOS default cursor color.

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -810,11 +810,11 @@ extension ToolbarTextField: Themeable {
         backgroundColor = UIColor.theme.textField.background
         textColor = UIColor.theme.textField.textAndTint
         clearButtonTintColor = textColor
-        tintColor = AutocompleteTextField.textSelectionColor
+        tintColor = AutocompleteTextField.textSelectionColor.textFieldMode
     }
 
     // ToolbarTextField is created on-demand, so the textSelectionColor is a static prop for use when created
     static func applyUIMode(isPrivate: Bool) {
-       textSelectionColor = UIColor.theme.urlbar.activeBorder(isPrivate)
+       textSelectionColor = UIColor.theme.urlbar.textSelectionHighlight(isPrivate)
     }
 }

--- a/Client/Frontend/Theme/Theme.swift
+++ b/Client/Frontend/Theme/Theme.swift
@@ -61,14 +61,18 @@ class URLBarColor {
 
     // This text selection color is used in two ways:
     // 1) <UILabel>.background = textSelectionHighlight.withAlphaComponent(textSelectionHighlightAlpha)
-    // To simulate text highlighting when the URL bar is tapped once, this is a background color to create a simulated selected text effect. The color will have an alpha of 0.27 applied when assigning it to the background.
+    // To simulate text highlighting when the URL bar is tapped once, this is a background color to create a simulated selected text effect. The color will have an alpha applied when assigning it to the background.
     // 2) <UITextField>.tintColor = textSelectionHighlight.
     // When the text is in edit mode (tapping URL bar second time), this is assigned to the to set the selection (and cursor) color. The color is assigned directly to the tintColor.
-    // The built-in tintColor property changes the alpha of the assigned color to ~0.27, so textSelectionHighlight.withAlphaComponent(textSelectionHighlightAlpha) should produce a very similar color.
-    func textSelectionHighlight(_ isPrivate: Bool) -> UIColor {
-        return !isPrivate ? UIColor(rgb: 0x3d89cc) : UIColor.Defaults.MobilePrivatePurple
+    typealias TextSelectionHighlight = (labelMode: UIColor, textFieldMode: UIColor?)
+    func textSelectionHighlight(_ isPrivate: Bool) -> TextSelectionHighlight {
+        if isPrivate {
+            let color = UIColor.Defaults.MobilePrivatePurple
+            return (labelMode: color.withAlphaComponent(0.25), textFieldMode: color)
+        } else {
+            return (labelMode: UIColor.Defaults.iOSTextHighlightBlue, textFieldMode: nil)
+        }
     }
-    var textSelectionHighlightAlpha = CGFloat(0.27)
 
     var readerModeButtonSelected: UIColor { return UIColor.Photon.Blue40 }
     var readerModeButtonUnselected: UIColor { return UIColor.Photon.Grey50 }

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -42,7 +42,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     fileprivate var notifyTextChanged: (() -> Void)?
     private var lastReplacement: String?
 
-    static var textSelectionColor = UIColor()
+    static var textSelectionColor = URLBarColor.TextSelectionHighlight(labelMode: UIColor(), textFieldMode: nil)
 
     override var text: String? {
         didSet {
@@ -204,7 +204,10 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
 
         let suggestionText = String(suggestion[suggestion.index(suggestion.startIndex, offsetBy: normalized.count)...])
         let autocompleteText = NSMutableAttributedString(string: suggestionText)
-        autocompleteText.addAttribute(NSAttributedStringKey.backgroundColor, value: AutocompleteTextField.textSelectionColor.withAlphaComponent(UIColor.theme.urlbar.textSelectionHighlightAlpha), range: NSRange(location: 0, length: suggestionText.count))
+
+        let color = AutocompleteTextField.textSelectionColor.labelMode
+        autocompleteText.addAttribute(NSAttributedStringKey.backgroundColor, value: color, range: NSRange(location: 0, length: suggestionText.count))
+
         autocompleteTextLabel?.removeFromSuperview() // should be nil. But just in case
         autocompleteTextLabel = createAutocompleteLabelWith(autocompleteText)
         if let l = autocompleteTextLabel {


### PR DESCRIPTION
We tried making it Blue40, but the insertion point cursor becomes hard to see.

I made it explicit in the code when the highlight color is for the UILabel mode, vs UITextField mode.

https://bugzilla.mozilla.org/show_bug.cgi?id=1493136