### PR TITLE
Bug 1485064 - disable tab reorder again due to crashes

### DIFF
--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -101,7 +101,8 @@ class LeanPlumClient {
     // to prompting with native push permissions.
     private var useFxAPrePush: LPVar = LPVar.define("useFxAPrePush", with: false)
     var enablePocketVideo: LPVar = LPVar.define("pocketVideo", with: false)
-
+    var enableDragDrop: LPVar = LPVar.define("tabTrayDrag", with: false)
+    
     var introScreenVars = LPVar.define("IntroScreen", with: IntroCard.defaultCards().compactMap({ $0.asDictonary() }))
 
     private func isPrivateMode() -> Bool {

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -168,7 +168,7 @@ class TabTrayController: UIViewController {
         collectionView.keyboardDismissMode = .onDrag
 
         // XXX: Bug 1485064 - Temporarily disable drag-and-drop in tabs tray
-         if #available(iOS 11.0, *) {
+        if #available(iOS 11.0, *), LeanPlumClient.shared.enableDragDrop.boolValue() {
              collectionView.dragInteractionEnabled = true
              collectionView.dragDelegate = tabDisplayManager
              collectionView.dropDelegate = tabDisplayManager


### PR DESCRIPTION
Reverting https://github.com/mozilla-mobile/firefox-ios/pull/4245/commits/f120c996393b38c2f0b61c322a6044be55976faa