### PR TITLE
Bug 1484098 - Dark theme for favicon background

### DIFF
--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -457,7 +457,7 @@ func == (lhs: IntroCard, rhs: IntroCard) -> Bool {
 }
 
 extension UIColor {
-    var components:(red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
+    var components: (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
         var r: CGFloat = 0
         var g: CGFloat = 0
         var b: CGFloat = 0

--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -109,8 +109,8 @@ fileprivate class DarkSnackBarColor: SnackBarColor {
 }
 
 fileprivate class DarkGeneralColor: GeneralColor {
-
     override var settingsTextPlaceholder: UIColor? { return UIColor.black }
+    override var faviconBackground: UIColor { return UIColor.Photon.White100 }
 }
 
 class DarkTheme: NormalTheme {

--- a/Client/Frontend/Theme/Theme.swift
+++ b/Client/Frontend/Theme/Theme.swift
@@ -187,6 +187,7 @@ class SnackBarColor {
 }
 
 class GeneralColor {
+    var faviconBackground: UIColor { return UIColor.clear }
     var passcodeDot: UIColor { return UIColor.Photon.Grey60 }
     var highlightBlue: UIColor { return UIColor.Photon.Blue40 }
     var destructiveRed: UIColor { return UIColor.Photon.Red50 }


### PR DESCRIPTION
Clear favicon backgrounds will need to be white, as some favicons are a dark image on a clear background and won't be visible on a dark background.
https://bugzilla.mozilla.org/show_bug.cgi?id=1484098