### PR TITLE
Bug 1494972 - removing a tab not updating the count

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1816,9 +1816,7 @@ extension BrowserViewController: TabManagerDelegate {
             }
         }
 
-        if let selected = selected, let previous = previous, selected.isPrivate != previous.isPrivate {
-            updateTabCountUsingTabManager(tabManager)
-        }
+        updateTabCountUsingTabManager(tabManager)
 
         removeAllBars()
         if let bars = selected?.bars {


### PR DESCRIPTION
BVC selected tab change has an unecessary optimization to avoid calling this
unecessarily. However the tab manager state is too complex for API clients to
be doing these types of micro-optimizations, so simply updating the count if the
selected tab changed is a reasonable fix.

The underlying bug is that the tab manager has no selected tab when calling the didDeleteTab
delegate func on the BVC, and the BVC will only update the tab count when a tab is selected.
