### PR TITLE
Bug 1493954 - Firefox will crash when deleting a history item and reconnecting to FxA

### DIFF
--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -204,7 +204,8 @@ class HistoryPanel: SiteTableViewController, HomePanel {
         } else {
             syncDetailText = ""
         }
-        tableView.reloadRows(at: [IndexPath(row: 1, section: Section.syncAndRecentlyClosed.rawValue)], with: .automatic)
+
+        tableView.reloadData()
     }
 
     func updateSyncedDevicesCount() -> Success {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1493954

There's some crazy internal consistency stuff with this table view that goes BOOM if you try reloading just some of the rows or sections after following the STR here. This is kind of a hamfisted approach to fix it, but it is the only thing I've found that works.