### PR TITLE
Bug 1494269 - XCUITest Disable testDeletingCharUpdateTheResult due to…

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
@@ -221,6 +221,9 @@
                   Identifier = "ClipBoardTests/testClipboardPasteAndGo()">
                </Test>
                <Test
+                  Identifier = "DomainAutocompleteTest/testDeletingCharsUpdateTheResults()">
+               </Test>
+               <Test
                   Identifier = "FindInPageTests/testFindFromMenu()">
                </Test>
                <Test

--- a/XCUITests/DomainAutocompleteTest.swift
+++ b/XCUITests/DomainAutocompleteTest.swift
@@ -170,6 +170,7 @@ class DomainAutocompleteTest: BaseTestCase {
         XCTAssertEqual(value3 as? String, "    moz ", "Wrong autocompletion")
     }
 
+    // This test is disabled for general schema due to bug 1494269
     func testDeletingCharsUpdateTheResults() {
         let url1 = ["url" : "git.es", "label" : "git.es - Dominio premium en venta"]
         let url2 = ["url" : "github.com", "label" : "The world's leading software development platform · GitHub"]


### PR DESCRIPTION
… preloaded DB issue

Looks like the pre-loaded DB approach does not work for this test in the latest environment iOS 12, xCode 10. If it continues failing, we will implement the test without pre-loaded DB so that it keeps running