### PR TITLE
Bug 1496787 - Deleting tab.index < selectedIndex breaks selection state

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -405,7 +405,7 @@ class TabManager: NSObject {
                 }
             }
         } else if deletedIndex < _selectedIndex {
-            selectTab(viableTabs[safe: _selectedIndex - 1], previous: tab)
+            selectTab(tabs[safe: _selectedIndex - 1], previous: tab)
         }
     }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1496787
