### PR TITLE
Bug 1496728 - Share tab selected tab wrong

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -535,9 +535,6 @@ extension TabDisplayManager: TabManagerDelegate {
 
     func tabManagerDidAddTabs(_ tabManager: TabManager) {
         recordEventAndBreadcrumb(object: .tab, method: .add)
-        DispatchQueue.main.async {
-            self.reloadData()
-        }
     }
 
     func tabManagerDidRemoveAllTabs(_ tabManager: TabManager, toast: ButtonToast?) {

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -535,7 +535,9 @@ extension TabDisplayManager: TabManagerDelegate {
 
     func tabManagerDidAddTabs(_ tabManager: TabManager) {
         recordEventAndBreadcrumb(object: .tab, method: .add)
-        self.reloadData()
+        DispatchQueue.main.async {
+            self.reloadData()
+        }
     }
 
     func tabManagerDidRemoveAllTabs(_ tabManager: TabManager, toast: ButtonToast?) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1496728

This is a workaround. ~~`reloadData` is not needed, because the tab manager correctly notifies the TDM of events as it is adding the tab (i.e. add new tab event, select tab event). For some reason `reloadData` breaks the display in this case.~~

This isn't a particularly complicated case, it is just adding a single tab, yet two are drawn selected.
~~A reloadData() at any time *should* reload the collection view from the current state of the tab manager, but it doesn't display the selected tab state correctly in the existing code, I am not sure why.~~ UICollectionViews that aren't tied to being visible on-screen can have rendering problems if reloadData called before appearing, as it tries to only render visible cells. 

I verified the tab manager state is correct throughout the events that happen when a tab is shared, so the bug is in the collection view display code somewhere.