### PR TITLE
[needsuplift] No Bug - Remove broken link in Read Me

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ We encourage you to participate in this open source project. We love Pull Reques
 Want to contribute but don't know where to start? Here is a list of [Good First Bugs.](http://www.joshmatthews.net/bugsahoy/?mobileios=1&simple=1)
 
 Likewise, the design and UX is still in flux. Don't get attached to them. They will change tomorrow!
-https://mozilla.invisionapp.com/share/HA254M642#/screens/63057282?maintainScrollPosition=false
 
 *GitHub issues are enabled* on this repository, but we encourage you to file a bug (see above). We'll accept issues to track work items that don't yet have a pull request, and also as an early funnel for bug reports, but Bugzilla is the source of truth for lots of good reasons — issues will be shifted into Bugzilla, and pull requests need a bug number.
 


### PR DESCRIPTION
## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Bug 12345678 - This fixes something something`

- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [x] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have marked the bug with `[needsuplift]`
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Notes for testing this patch
Remove the broken link from the Read Me. The link shows the following:
![](https://user-images.githubusercontent.com/43912814/46574166-1ec66b00-c965-11e8-8edd-8acfa6a061a2.png)
