### PR TITLE
[needsuplift] Bug 1298516 - Clearing all private data does not clear Reader Mode caches

### DIFF
--- a/Client/Frontend/Reader/ReaderModeCache.swift
+++ b/Client/Frontend/Reader/ReaderModeCache.swift
@@ -30,6 +30,8 @@ protocol ReaderModeCache {
     func delete(_ url: URL, error: NSErrorPointer)
 
     func contains(_ url: URL) -> Bool
+
+    func clear()
 }
 
 /// A non-persistent cache for readerized content for times when you don't want to write reader data to disk.
@@ -62,6 +64,10 @@ class MemoryReaderModeCache: ReaderModeCache {
 
     func contains(_ url: URL) -> Bool {
         return cache.object(forKey: url as AnyObject) != nil
+    }
+
+    func clear() {
+        cache.removeAllObjects()
     }
 }
 
@@ -118,10 +124,14 @@ class DiskReaderModeCache: ReaderModeCache {
         return false
     }
 
+    private static var readerViewCacheURL: URL? {
+        let cachesDirectoryURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+        return cachesDirectoryURL?.appendingPathComponent("ReaderView", isDirectory: true)
+    }
+
     fileprivate func cachePathsForURL(_ url: URL) -> (cacheDirectoryPath: String, contentFilePath: String)? {
-        let paths = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true)
-        if !paths.isEmpty, let hashedPath = hashedPathForURL(url) {
-            let cacheDirectoryURL = URL(fileURLWithPath: NSString.path(withComponents: [paths[0], "ReaderView", hashedPath]))
+        if let mainURL = DiskReaderModeCache.readerViewCacheURL, let hashedPath = hashedPathForURL(url) {
+            let cacheDirectoryURL = mainURL.appendingPathComponent(hashedPath)
             return (cacheDirectoryURL.path, cacheDirectoryURL.appendingPathComponent("content.json").path)
         }
 
@@ -138,5 +148,12 @@ class DiskReaderModeCache: ReaderModeCache {
         guard let data = url.absoluteString.data(using: .utf8) else { return nil }
 
         return data.sha1.hexEncodedString as NSString?
+    }
+
+    func clear() {
+        guard let mainURL = DiskReaderModeCache.readerViewCacheURL else { return }
+        do {
+            try FileManager.default.removeItem(at: mainURL)
+        } catch {}
     }
 }

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -81,6 +81,9 @@ class CacheClearable: Clearable {
         let dataTypes = Set([WKWebsiteDataTypeDiskCache, WKWebsiteDataTypeMemoryCache])
         WKWebsiteDataStore.default().removeData(ofTypes: dataTypes, modifiedSince: .distantPast, completionHandler: {})
 
+        MemoryReaderModeCache.sharedInstance.clear()
+        DiskReaderModeCache.sharedInstance.clear()
+
         log.debug("CacheClearable succeeded.")
         return succeed()
     }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1298516

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Bug 12345678 - This fixes something something`

- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [x] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have marked the bug with `[needsuplift]`
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Notes for testing this patch

This change clears both the memory and disk reader mode caches when the user selects Data Management > Cache and Clear Private Data.