### PR TITLE
[needsuplift] Bug 1479630 - The separator lines in the homepanels are too bright in the dark theme

### DIFF
--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -1009,32 +1009,41 @@ struct ActivityStreamTracker {
 
 // MARK: - Section Header View
 private struct ASHeaderViewUX {
-    static let SeperatorColor =  UIColor.Photon.Grey20
+    static var SeparatorColor: UIColor { return UIColor.theme.homePanel.separator }
     static let TextFont = DynamicFontHelper.defaultHelper.MediumSizeBoldFontAS
-    static let SeperatorHeight = 1
+    static let SeparatorHeight = 1
     static let Insets: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? ASPanelUX.SectionInsetsForIpad + ASPanelUX.MinimumInsets : ASPanelUX.MinimumInsets
     static let TitleTopInset: CGFloat = 5
 }
 
 class ASFooterView: UICollectionReusableView {
 
+    private var separatorLineView: UIView?
+
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        let seperatorLine = UIView()
-        seperatorLine.backgroundColor = ASHeaderViewUX.SeperatorColor
+        let separatorLine = UIView()
         self.backgroundColor = UIColor.clear
-        addSubview(seperatorLine)
-        seperatorLine.snp.makeConstraints { make in
-            make.height.equalTo(ASHeaderViewUX.SeperatorHeight)
+        addSubview(separatorLine)
+        separatorLine.snp.makeConstraints { make in
+            make.height.equalTo(ASHeaderViewUX.SeparatorHeight)
             make.leading.equalTo(self.snp.leading)
             make.trailing.equalTo(self.snp.trailing)
             make.top.equalTo(self.snp.top)
         }
+        separatorLineView = separatorLine
+        applyTheme()
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension ASFooterView: Themeable {
+    func applyTheme() {
+        separatorLineView?.backgroundColor = ASHeaderViewUX.SeparatorColor
     }
 }
 

--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -309,6 +309,7 @@ extension HomePanelViewController: Themeable {
         buttonTintColor = UIColor.theme.homePanel.toolbarTint
         buttonSelectedTintColor = UIColor.theme.homePanel.toolbarHighlight
         highlightLine.backgroundColor = UIColor.theme.homePanel.toolbarHighlight
+        buttonContainerBottomBorderView.backgroundColor = UIColor.theme.homePanel.buttonContainerBorder
         updateButtonTints()
     }
 }

--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -6,7 +6,7 @@ import Foundation
 
 // Convenience reference to these normal mode colors which are used in a few color classes.
 fileprivate let defaultBackground = UIColor.Photon.Grey80
-fileprivate let defaultSeparator = UIColor.Photon.Grey30
+fileprivate let defaultSeparator = UIColor.Photon.Grey60
 fileprivate let defaultTextAndTint = UIColor.Photon.Grey10
 
 fileprivate class DarkTableViewColor: TableViewColor {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1479630

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Bug 12345678 - This fixes something something`

- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [x] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have marked the bug with `[needsuplift]`
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

After this change:
![](https://user-images.githubusercontent.com/43912814/46574564-d01bcf80-c96a-11e8-8298-fbc8d2be5c3e.png)

## Notes for testing this patch
This change makes the home panel separator lines darker when the theme is set to dark. To test this, select Settings > Display > Dark.