### PR TITLE
[needsuplift] Bug 1480066 - Prompt to enter passcode top navigation bar not theming

### DIFF
--- a/Client/Frontend/AuthenticationManager/BasePasscodeViewController.swift
+++ b/Client/Frontend/AuthenticationManager/BasePasscodeViewController.swift
@@ -25,7 +25,7 @@ class BasePasscodeViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = UIColor.theme.tableView.headerBackground
+        applyTheme()
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(self.dismissAnimated))
         automaticallyAdjustsScrollViewInsets = false
     }
@@ -88,5 +88,17 @@ extension BasePasscodeViewController {
 
         // Store mutations on authentication info object
         KeychainWrapper.sharedAppContainerKeychain.setAuthenticationInfo(authenticationInfo)
+    }
+}
+
+extension BasePasscodeViewController: Themeable {
+    func applyTheme() {
+        view.backgroundColor = UIColor.theme.tableView.headerBackground
+        let navigationBar = navigationController?.navigationBar
+        navigationBar?.barTintColor = UIColor.theme.tableView.headerBackground
+        navigationBar?.barStyle = ThemeManager.instance.currentName == .dark ? .black : .default
+        navigationBar?.tintColor = UIColor.theme.general.controlTint
+        navigationBar?.titleTextAttributes = [.foregroundColor: UIColor.theme.tableView.headerTextDark]
+        setNeedsStatusBarAppearanceUpdate()
     }
 }

--- a/Client/Frontend/AuthenticationManager/PasscodeViews.swift
+++ b/Client/Frontend/AuthenticationManager/PasscodeViews.swift
@@ -39,6 +39,7 @@ class PasscodeInputView: UIView, UIKeyInput {
     }
 
     @objc var keyboardType: UIKeyboardType = .numberPad
+    @objc var keyboardAppearance: UIKeyboardAppearance = ThemeManager.instance.currentName == .dark ? .dark : .default
 
     init(frame: CGRect, passcodeSize: Int) {
         self.passcodeSize = passcodeSize
@@ -123,6 +124,7 @@ class PasscodePane: UIView {
         let label = UILabel()
         label.font = UIConstants.DefaultChromeFont
         label.isAccessibilityElement = true
+        label.textColor = UIColor.theme.tableView.rowText
         return label
     }()
 

--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -111,6 +111,7 @@ fileprivate class DarkSnackBarColor: SnackBarColor {
 fileprivate class DarkGeneralColor: GeneralColor {
     override var settingsTextPlaceholder: UIColor? { return UIColor.black }
     override var faviconBackground: UIColor { return UIColor.Photon.White100 }
+    override var passcodeDot: UIColor { return UIColor.Photon.Grey40 }
 }
 
 class DarkTheme: NormalTheme {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1480066

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Bug 12345678 - This fixes something something`

- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [x] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have marked the bug with `[needsuplift]`
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots
After this change (compare with old screenshot: https://bugzilla.mozilla.org/attachment.cgi?id=8996671):
![](https://user-images.githubusercontent.com/43912814/46574652-36edb880-c96c-11e8-92c0-cfcf3d0eee46.png)

## Notes for testing this patch
This change fixes the enter passcode screen appearance in dark theme mode. To test, select Settings > Display > Dark. Then go to Settings > Passcode For Logins > Turn Passcode On/Change Passcode