### PR TITLE
Bug 1497428 - The (X) icon is incorrect color right after starting the app

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -771,7 +771,7 @@ class ToolbarTextField: AutocompleteTextField {
         // http://stackoverflow.com/questions/27944781/how-to-change-the-tint-color-of-the-clear-button-on-a-uitextfield
         for view in subviews as [UIView] {
             if let button = view as? UIButton {
-                if let image = button.image(for: []) {
+                if let image = UIImage.templateImageNamed("topTabs-closeTabs") {
                     if tintedClearImage == nil {
                         tintedClearImage = tintImage(image, color: clearButtonTintColor)
                     }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -769,16 +769,14 @@ class ToolbarTextField: AutocompleteTextField {
         // Since we're unable to change the tint color of the clear image, we need to iterate through the
         // subviews, find the clear button, and tint it ourselves. Thanks to Mikael Hellman for the tip:
         // http://stackoverflow.com/questions/27944781/how-to-change-the-tint-color-of-the-clear-button-on-a-uitextfield
-        for view in subviews as [UIView] {
-            if let button = view as? UIButton {
-                if let image = UIImage.templateImageNamed("topTabs-closeTabs") {
-                    if tintedClearImage == nil {
-                        tintedClearImage = tintImage(image, color: clearButtonTintColor)
-                    }
+       for case let button as UIButton in subviews {
+            if let image = UIImage.templateImageNamed("topTabs-closeTabs") {
+                if tintedClearImage == nil {
+                    tintedClearImage = tintImage(image, color: clearButtonTintColor)
+                }
 
-                    if button.imageView?.image != tintedClearImage {
-                        button.setImage(tintedClearImage, for: [])
-                    }
+                if button.imageView?.image != tintedClearImage {
+                    button.setImage(tintedClearImage, for: [])
                 }
             }
         }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1497428

There's two different code paths we go through depending on if we're coming from a blank tab or a tab with a page loaded. In the case where we're coming from a blank tab, we never actually set the clear button image with our own image and it was resorting to using the iOS default image. This is why it wasn't tinting correctly in this case.