### PR TITLE
Bug 1497184 - Homepage settings buttons are not centered

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -269,7 +269,6 @@ protocol SettingValuePersister {
 /// This takes an optional settingIsValid and settingDidChange callback
 /// If settingIsValid returns false, the Setting will not change and the text remains red.
 class StringSetting: Setting, UITextFieldDelegate {
-
     var Padding: CGFloat = 8
 
     fileprivate let defaultValue: String?
@@ -393,6 +392,8 @@ class CheckmarkSetting: Setting {
 /// isEnabled is called on each tableview.reloadData. If it returns
 /// false then the 'button' appears disabled.
 class ButtonSetting: Setting {
+    var Padding: CGFloat = 8
+
     let onButtonClick: (UINavigationController?) -> Void
     let destructive: Bool
     let isEnabled: (() -> Bool)?
@@ -413,6 +414,11 @@ class ButtonSetting: Setting {
         } else {
             cell.textLabel?.textColor = UIColor.theme.tableView.disabledRowText
         }
+        cell.textLabel?.snp.makeConstraints({ make in
+            make.height.equalTo(44)
+            make.trailing.equalTo(cell.contentView).offset(-Padding)
+            make.leading.equalTo(cell.contentView).offset(Padding)
+        })
         cell.textLabel?.textAlignment = .center
         cell.accessibilityTraits = UIAccessibilityTraitButton
         cell.selectionStyle = .none


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1497184

I'm not sure if/how this ever worked. The text label in `ButtonSetting` cells was not taking up the full size of the cell, therefore the `.center` alignment was doing nothing. Also, I checked and the Homepage screen is the only screen in the app that uses `ButtonSetting`, so there's no surface area for any other regressions with this patch.