### PR TITLE
Bug 1496712 - TDM not selecting new tab, ensure completion blocks are…

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -343,10 +343,17 @@ extension TabDisplayManager {
         return TopTabChangeSet(reloadArr: reloads, insertArr: inserts, deleteArr: deletes, moveArr: moves)
     }
 
-    func updateTabsFrom(_ oldTabs: [Tab]?, to newTabs: [Tab], on completion: (() -> Void)? = nil) {
+    func updateTabsFrom(_ oldTabs: [Tab]?, to newTabs: [Tab]) {
         assertIsMainThread("Updates can only be performed from the main thread")
         guard let oldTabs = oldTabs, !self.isUpdating, !self.pendingReloadData, !self.isDragging else {
             return
+        }
+
+        func performPendingCompletions() {
+            for block in self.completionBlocks {
+                block()
+            }
+            self.completionBlocks.removeAll()
         }
 
         // Lets create our change set
@@ -355,7 +362,7 @@ extension TabDisplayManager {
 
         // If there are no changes. We have nothing to do
         if update.isEmpty {
-            completion?()
+            performPendingCompletions()
             return
         }
 
@@ -381,7 +388,7 @@ extension TabDisplayManager {
         self.pendingUpdatesToTabs = newTabs // This var helps other mutations that might happen while updating.
 
         let onComplete: () -> Void = {
-            completion?()
+            performPendingCompletions()
             self.isUpdating = false
             self.pendingUpdatesToTabs = []
             // run completion blocks
@@ -392,11 +399,13 @@ extension TabDisplayManager {
 
             // There can be pending animations. Run update again to clear them.
             let tabs = self.oldTabs ?? self.tabStore
-            self.updateTabsFrom(tabs, to: self.tabsToDisplay, on: {
+
+            self.completionBlocks.append {
                 if !update.inserts.isEmpty || !update.reloads.isEmpty {
                     self.tabDisplayer?.focusSelectedTab()
                 }
-            })
+            }
+            self.updateTabsFrom(tabs, to: self.tabsToDisplay)
         }
 
         // The actual update. Only animate the changes if no tabs have moved
@@ -471,12 +480,7 @@ extension TabDisplayManager: TabManagerDelegate {
         if self.pendingReloadData && !isUpdating {
             self.reloadData()
         } else {
-            self.updateTabsFrom(self.oldTabs, to: self.tabsToDisplay) {
-                for block in self.completionBlocks {
-                    block()
-                }
-                self.completionBlocks.removeAll()
-            }
+            self.updateTabsFrom(self.oldTabs, to: self.tabsToDisplay)
         }
     }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1496712

The code works such that blocks are queued to be run when batchupdates is completed,
The code was setup so the completion blocks getting called is optional, and this bug is that the completion block for the new tab is not called, thus the the tab tray is not dismissed.
The fix is to ensure the pending completion blocks are always called.
There are too many state flags in this code for me to follow to see why a particular path is deciding not to call the completion blocks, but I am confident this step is required for the intended design pattern of the code.