### PR TITLE
Bug 1497512 - undo close all, get extra tab

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -506,7 +506,8 @@ class TabManager: NSObject {
     }
 
     func undoCloseTabs() {
-        guard recentlyClosedForUndo.count > 0 else {
+        guard let isPrivate = recentlyClosedForUndo.first?.isPrivate else {
+            // No valid tabs
             return
         }
 
@@ -514,6 +515,7 @@ class TabManager: NSObject {
 
         recentlyClosedForUndo.removeAll()
 
+        let tabs = isPrivate ? privateTabs : normalTabs
         tabs.forEach { tab in
             tab.showContent(true)
         }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1497512

Using 'tabManager.tabs.first' was wrong, as this might not be the first normal tab.