### PR TITLE
Bug 1497456 - XCUITests Unsuccessfully intermittent error

### DIFF
--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -307,7 +307,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     map.addScreenState(URLBarLongPressMenu) { screenState in
         let menu = app.tables["Context Menu"].firstMatch
-        screenState.onEnterWaitFor(element: menu)
+        //screenState.onEnterWaitFor(element: menu)
 
         screenState.gesture(forAction: Action.LoadURLByPasting, Action.LoadURL) { userState in
             UIPasteboard.general.string = userState.url ?? defaultURL
@@ -393,11 +393,11 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.dismissOnUse = true
         // Would like to use app.otherElements.deviceStatusBars.networkLoadingIndicators.element
         // but this means exposing some of SnapshotHelper to another target.
-        if !(app.progressIndicators.element(boundBy: 0).exists) {
+        /*if !(app.progressIndicators.element(boundBy: 0).exists) {
             screenState.onEnterWaitFor("exists != true", element: app.progressIndicators.element(boundBy: 0), if: "waitForLoading == true")
         } else {
             screenState.onEnterWaitFor(element: app.progressIndicators.element(boundBy: 0), if: "waitForLoading == false")
-        }
+        }*/
 
         screenState.noop(to: BrowserTab, if: "waitForLoading == true")
         screenState.noop(to: BasicAuthDialog, if: "waitForLoading == false")

--- a/XCUITests/ScreenGraphTest.swift
+++ b/XCUITests/ScreenGraphTest.swift
@@ -176,8 +176,8 @@ fileprivate func createTestGraph(for test: XCTestCase, with app: XCUIApplication
         screenState.dismissOnUse = true
         // Would like to use app.otherElements.deviceStatusBars.networkLoadingIndicators.element
         // but this means exposing some of SnapshotHelper to another target.
-        screenState.onEnterWaitFor("exists != true",
-                                   element: app.progressIndicators.element(boundBy: 0))
+        // screenState.onEnterWaitFor("exists != true",
+                                   // element: app.progressIndicators.element(boundBy: 0))
         screenState.noop(to: BrowserTab)
     }
 


### PR DESCRIPTION
With latest environment we are seeing this error more frequently. It happens more on iPad tests. 
Let's try to modify the ScreenGraph so that tests do not fail due to this. It is a timing issue that fails when the progress bar is not shown accordingly while the webpage is loading, or it is not shown at all or if it disappears very quickly.