### PR TITLE
Bug 1496710 - TopSites orientation change layout breakage

### DIFF
--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -135,8 +135,12 @@ class ActivityStreamPanel: UICollectionViewController, HomePanel {
             }
             self.collectionViewLayout.invalidateLayout()
             self.collectionView?.reloadData()
-        }, completion: nil)
+        }, completion: { _ in
+            // Workaround: label positions are not correct without additional reload
+            self.collectionView?.reloadData()
+        })
     }
+
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)


### PR DESCRIPTION
Adding a reload restores this layout. I spent time looking into the layout details to see if there might be some actual bug in the code, but I couldn't find anything. Hence, this workaround instead.