### PR TITLE
Bug 1497441 - The Switch to tab toast does not respect safe area insets on iPhone X

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1899,7 +1899,7 @@ extension BrowserViewController: TabManagerDelegate {
 
         toast.showToast(viewController: self, delay: delay, duration: duration, makeConstraints: { make in
             make.left.right.equalTo(self.view)
-            make.bottom.equalTo(self.webViewContainer)
+            make.bottom.equalTo(self.webViewContainer?.safeArea.bottom ?? 0)
         })
     }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1497441