### PR TITLE
 Bug 1499058 - TabDisplayManager use chained/imperative operation queue

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -708,6 +708,7 @@
 		EB9A179C20E69A7F00B12184 /* DarkTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9A179920E69A7E00B12184 /* DarkTheme.swift */; };
 		EB9A179D20E69A7F00B12184 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9A179A20E69A7E00B12184 /* Theme.swift */; };
 		EB9A179F20E6C1A200B12184 /* ThemedWidgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9A179E20E6C1A200B12184 /* ThemedWidgets.swift */; };
+		EB9CB1A5217F782300127F55 /* TabDisplayManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9CB1A4217F782300127F55 /* TabDisplayManagerTests.swift */; };
 		EBA1CC1E214AB8FD009E6B06 /* StorageTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289A4C121C4EB90600A460E3 /* StorageTestUtils.swift */; };
 		EBA31D791F7999030055463D /* SyncPingCentre.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBA31D781F7999030055463D /* SyncPingCentre.swift */; };
 		EBA31D7B1F79990C0055463D /* SyncTelemetryEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBA31D7A1F79990C0055463D /* SyncTelemetryEvents.swift */; };
@@ -1871,6 +1872,7 @@
 		EB9A179920E69A7E00B12184 /* DarkTheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DarkTheme.swift; sourceTree = "<group>"; };
 		EB9A179A20E69A7E00B12184 /* Theme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		EB9A179E20E6C1A200B12184 /* ThemedWidgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemedWidgets.swift; sourceTree = "<group>"; };
+		EB9CB1A4217F782300127F55 /* TabDisplayManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDisplayManagerTests.swift; sourceTree = "<group>"; };
 		EBA31D781F7999030055463D /* SyncPingCentre.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncPingCentre.swift; sourceTree = "<group>"; };
 		EBA31D7A1F79990C0055463D /* SyncTelemetryEvents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncTelemetryEvents.swift; sourceTree = "<group>"; };
 		EBA31D7C1F79996E0055463D /* SyncTelemetryUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncTelemetryUtils.swift; sourceTree = "<group>"; };
@@ -3450,6 +3452,7 @@
 				39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */,
 				D8EFFA251FF702A8001D3A09 /* NavigationRouterTests.swift */,
 				63306D442110BAF000F25400 /* TabManagerStoreTests.swift */,
+				EB9CB1A4217F782300127F55 /* TabDisplayManagerTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -5306,6 +5309,7 @@
 				7BBFEE741BB405D900A305AA /* TabManagerTests.swift in Sources */,
 				39236E721FCC600200A38F1B /* TabEventHandlerTests.swift in Sources */,
 				0BA8964C1A250E6500C1010C /* TestBookmarks.swift in Sources */,
+				EB9CB1A5217F782300127F55 /* TabDisplayManagerTests.swift in Sources */,
 				D8BA1790206D47830023AC00 /* DeferredTestUtils.swift in Sources */,
 				2F13E79B1AC0C02700D75081 /* StringExtensionsTests.swift in Sources */,
 				2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */,

--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -101,7 +101,7 @@ class LeanPlumClient {
     // to prompting with native push permissions.
     private var useFxAPrePush: LPVar = LPVar.define("useFxAPrePush", with: false)
     var enablePocketVideo: LPVar = LPVar.define("pocketVideo", with: false)
-    var enableDragDrop: LPVar = LPVar.define("tabTrayDrag", with: false)
+    var enableDragDrop: LPVar = LPVar.define("tabTrayDrag", with: true)
     var enableTabBarReorder: LPVar = LPVar.define("tabBarDragReorder", with: true)
 
     var introScreenVars = LPVar.define("IntroScreen", with: IntroCard.defaultCards().compactMap({ $0.asDictonary() }))

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -945,7 +945,7 @@ class BrowserViewController: UIViewController {
 
     // MARK: Opening New Tabs
     func switchToPrivacyMode(isPrivate: Bool) {
-         if let tabTrayController = self.tabTrayController, tabTrayController.privateMode != isPrivate {
+         if let tabTrayController = self.tabTrayController, tabTrayController.tabDisplayManager.isPrivate != isPrivate {
             tabTrayController.changePrivacyMode(isPrivate)
         }
         topTabsViewController?.applyUIMode(isPrivate: isPrivate)
@@ -1397,7 +1397,6 @@ extension BrowserViewController: URLBarDelegate {
 
         let possibleKeyword = String(trimmedText[..<possibleKeywordQuerySeparatorSpace])
         let possibleQuery = String(trimmedText[trimmedText.index(after: possibleKeywordQuerySeparatorSpace)...])
-
 
         profile.bookmarks.getURLForKeywordSearch(possibleKeyword).uponQueue(.main) { result in
             if var urlString = result.successValue,
@@ -1906,7 +1905,7 @@ extension BrowserViewController: TabManagerDelegate {
     }
 
     func tabManagerDidRemoveAllTabs(_ tabManager: TabManager, toast: ButtonToast?) {
-        guard let toast = toast, !(tabTrayController?.privateMode  ?? false) else {
+        guard let toast = toast, !(tabTrayController?.tabDisplayManager.isPrivate  ?? false) else {
             return
         }
         show(toast: toast, afterWaiting: ButtonToastUX.ToastDelay)
@@ -1921,7 +1920,6 @@ extension BrowserViewController: TabManagerDelegate {
         }
     }
 }
-
 
 // MARK: - UIPopoverPresentationControllerDelegate
 

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -453,3 +453,15 @@ extension TabDisplayManager: TabManagerDelegate {
     }
 }
 
+// Functions for testing
+extension TabDisplayManager {
+    func test_toggleIsDragging() {
+        assert(AppConstants.IsRunningTest)
+        isDragging = !isDragging
+    }
+
+    func test_getIsDragging() -> Bool {
+        assert(AppConstants.IsRunningTest)
+        return isDragging
+    }
+}

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -310,9 +310,9 @@ extension TabDisplayManager: UICollectionViewDropDelegate {
 
 extension TabDisplayManager: TabEventHandler {
     private func updateCellFor(tab: Tab) {
-        guard let index = dataStore.index(of: tab) else { return }
 
         updateWith(animationType: .updateTab) { [weak self] in
+            guard let index = self?.dataStore.index(of: tab) else { return }
             self?.collectionView.reloadItems(at: [IndexPath(row: index, section: 0)])
         }
     }

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -393,6 +393,16 @@ extension TabDisplayManager: TabManagerDelegate {
         }
     }
 
+    /* Function to take operations off the queue recursively, and perform them (i.e. performBatchUpdates) in sequence.
+     If this func is called while it (or performBatchUpdates) is running, it returns immediately.
+
+     The `refreshStore()` function will clear the queue and reload data, and the view will instantly match the tab manager.
+     Therefore, don't put operations on the queue that depend on previous operations on the queue. In these cases, just check
+     the current state on-demand in the operation (for example, don't assume that a previous tab is selected because that was the previous operation in queue).
+     
+     For app events where each operation should be animated for the user to see, performedChainedOperations() is the one to use,
+     and for bulk updates where it is ok to just redraw the entire view with the latest state, use `refreshStore()`.
+     */
     private func performChainedOperations() {
         guard !performingChainedOperations, let (type, operation) = operations.popLast() else {
             return

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -394,22 +394,19 @@ extension TabDisplayManager: TabManagerDelegate {
     }
 
     private func performChainedOperations() {
-        if performingChainedOperations {
+        guard !performingChainedOperations, let (type, operation) = operations.popLast() else {
             return
         }
-
-        if let (type, operation) = operations.popLast() {
-            performingChainedOperations = true
-            collectionView.performBatchUpdates({ [weak self] in
-                // Baseline animation speed is 1.0, which is too slow, this (odd) code sets it to 3x
-                self?.collectionView.forFirstBaselineLayout.layer.speed = 3.0
-                operation()
-                }, completion: { [weak self] (done) in
-                    self?.performingChainedOperations = false
-                    self?.tabDisplayCompletionDelegate?.completedAnimation(for: type)
-                    self?.performChainedOperations()
-            })
-        }
+        performingChainedOperations = true
+        collectionView.performBatchUpdates({ [weak self] in
+            // Baseline animation speed is 1.0, which is too slow, this (odd) code sets it to 3x
+            self?.collectionView.forFirstBaselineLayout.layer.speed = 3.0
+            operation()
+            }, completion: { [weak self] (done) in
+                self?.performingChainedOperations = false
+                self?.tabDisplayCompletionDelegate?.completedAnimation(for: type)
+                self?.performChainedOperations()
+        })
     }
 
     private func updateWith(animationType: TabAnimationType, operation: (() -> Void)?) {

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -6,6 +6,21 @@ import Foundation
 import Shared
 import Storage
 
+// MARK: Delegate for animation completion notifications.
+enum TabAnimationType {
+    case addTab
+    case removedNonLastTab
+    case removedLastTab
+    case updateTab
+    case moveTab
+}
+
+protocol TabDisplayCompletionDelegate: AnyObject {
+    func completedAnimation(for: TabAnimationType)
+}
+
+// MARK: -
+
 @objc protocol TabSelectionDelegate: AnyObject {
     func didSelectTabAtIndex(_ index: Int)
 }
@@ -23,40 +38,37 @@ protocol TabDisplayer: AnyObject {
 }
 
 class TabDisplayManager: NSObject {
+    var performingChainedOperations = false
+
+    var dataStore = WeakList<Tab>()
+    var operations = [(TabAnimationType, (() -> Void))]()
+    weak var tabDisplayCompletionDelegate: TabDisplayCompletionDelegate?
 
     fileprivate let tabManager: TabManager
-    var isPrivate = false
+
+    // Instead of using UICollectionView.hasActiveDrag, manage the 'drag is active' flag ourselves in order to cancel the drag. UICollectionView has no drag cancellation support.
+    // ANY tab manager operation that arrives should set this to false, effectively cancelling the drag.
     var isDragging = false
     fileprivate let collectionView: UICollectionView
-    typealias CompletionBlock = () -> Void
 
     private var tabObservers: TabObservers!
     fileprivate weak var tabDisplayer: TabDisplayer?
-    let tabReuseIdentifer: String
+    private let tabReuseIdentifer: String
 
-    var searchedTabs: [Tab] = []
-    var searchActive: Bool = false
-
-    var tabStore: [Tab] = [] //the actual datastore
-    fileprivate var pendingUpdatesToTabs: [Tab] = [] //the datastore we are transitioning to
-    fileprivate var needReloads: [Tab?] = [] // Tabs that need to be reloaded
-    fileprivate var completionBlocks: [CompletionBlock] = [] //blocks are performed once animations finish
-    fileprivate var isUpdating = false
-    var pendingReloadData = false
-    fileprivate var oldTabs: [Tab]? // The last state of the tabs before an animation
-    fileprivate weak var oldSelectedTab: Tab? // Used to select the right tab when transitioning between private/normal tabs
-
-    var tabCount: Int {
-        return self.tabStore.count
+    var searchedTabs: [Tab]?
+    var searchActive: Bool {
+        return searchedTabs != nil
     }
 
     private var tabsToDisplay: [Tab] {
-        if searchActive {
+        if let searchedTabs = searchedTabs {
             // tabs can be deleted while a search is active. Make sure the tab still exists in the tabmanager before displaying
             return searchedTabs.filter({ tabManager.tabs.contains($0) })
         }
         return self.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
     }
+
+    private(set) var isPrivate = false
 
     init(collectionView: UICollectionView, tabManager: TabManager, tabDisplayer: TabDisplayer, reuseID: String) {
         self.collectionView = collectionView
@@ -68,7 +80,76 @@ class TabDisplayManager: NSObject {
 
         tabManager.addDelegate(self)
         self.tabObservers = registerFor(.didLoadFavicon, .didChangeURL, queue: .main)
-        self.tabStore = self.tabsToDisplay
+
+        tabsToDisplay.forEach {
+            self.dataStore.insert($0)
+        }
+        collectionView.reloadData()
+    }
+
+    func togglePrivateMode(isOn: Bool, createTabOnEmptyPrivateMode: Bool) {
+        isPrivate = isOn
+
+        searchedTabs = nil
+        refreshStore()
+
+        if createTabOnEmptyPrivateMode {
+            //if private tabs is empty and we are transitioning to it add a tab
+            if tabManager.privateTabs.isEmpty && isPrivate {
+                tabManager.addTab(isPrivate: true)
+            }
+        }
+        
+        let tab = mostRecentTab(inTabs: tabsToDisplay) ?? tabsToDisplay.last
+        if let tab = tab {
+            tabManager.selectTab(tab)
+        }
+    }
+    
+    func searchTabsAnimated() {
+        let isUnchanged = tabsToDisplay.zip(dataStore).reduce(true) { $0 && $1.0 === $1.1 }
+        if !tabsToDisplay.isEmpty && isUnchanged {
+            return
+        }
+
+        operations.removeAll()
+        dataStore.removeAll()
+        tabsToDisplay.forEach {
+            self.dataStore.insert($0)
+        }
+
+        // animates the changes
+        collectionView.reloadSections(IndexSet(integer: 0))
+    }
+
+    func refreshStore(evenIfHidden: Bool = false) {
+        operations.removeAll()
+        dataStore.removeAll()
+        tabsToDisplay.forEach {
+            self.dataStore.insert($0)
+        }
+        collectionView.reloadData()
+
+        if evenIfHidden {
+            // reloadData() will reset the data for the collection view,
+            // but if called when offscreen it will not render properly,
+            // unless reloadItems is explicitly called on each item.
+            // Avoid calling with evenIfHidden=true, as it can cause a blink effect as the cell is updated.
+            // The cause of the blinking effect is unknown (and unusual).
+            var indexPaths = [IndexPath]()
+            for i in 0..<collectionView.numberOfItems(inSection: 0) {
+                indexPaths.append(IndexPath(item: i, section: 0))
+            }
+            collectionView.reloadItems(at: indexPaths)
+        }
+
+    }
+
+    func close(cell: UICollectionViewCell) {
+        guard let index = collectionView.indexPath(for: cell)?.item, let tab = dataStore.at(index) else {
+            return
+        }
+        tabManager.removeTabAndUpdateSelectedIndex(tab)
     }
 
     // Once we are done with TabManager we need to call removeObservers to avoid a retain cycle with the observers
@@ -77,51 +158,22 @@ class TabDisplayManager: NSObject {
         tabObservers = nil
     }
 
-     // Make sure animations don't happen before the view is loaded.
-    fileprivate func shouldAnimate(isRestoringTabs: Bool) -> Bool {
-        return !isRestoringTabs && collectionView.frame != CGRect.zero
-    }
-
     private func recordEventAndBreadcrumb(object: UnifiedTelemetry.EventObject, method: UnifiedTelemetry.EventMethod) {
         let isTabTray = tabDisplayer as? TabTrayController != nil
         let eventValue = isTabTray ? UnifiedTelemetry.EventValue.tabTray : UnifiedTelemetry.EventValue.topTabs
         UnifiedTelemetry.recordEvent(category: .action, method: method, object: object, value: eventValue)
-        Sentry.shared.breadcrumb(category: "Tab Action", message: "object: \(object), action: \(method.rawValue), \(eventValue.rawValue), tab count: \(tabStore.count) ")
-    }
-
-    func togglePBM() {
-        if isUpdating || pendingReloadData {
-            return
-        }
-        let isPrivate = self.isPrivate
-        self.pendingReloadData = true // Stops animations from happening
-        let oldSelectedTab = self.oldSelectedTab
-        self.oldSelectedTab = tabManager.selectedTab
-
-        //if private tabs is empty and we are transitioning to it add a tab
-        if tabManager.privateTabs.isEmpty  && !isPrivate {
-            tabManager.addTab(isPrivate: true)
-        }
-
-        //get the tabs from which we will select which one to nominate for tribute (selection)
-        //the isPrivate boolean still hasnt been flipped. (It'll be flipped in the BVC didSelectedTabChange method)
-        let tabs = !isPrivate ? tabManager.privateTabs : tabManager.normalTabs
-        if let tab = oldSelectedTab, tabs.index(of: tab) != nil {
-            tabManager.selectTab(tab)
-        } else {
-            tabManager.selectTab(tabs.last)
-        }
     }
 }
 
 extension TabDisplayManager: UICollectionViewDataSource {
     @objc func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return tabStore.count
+        return dataStore.count
     }
 
     @objc func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let tab = tabStore[indexPath.row]
+        let tab = dataStore.at(indexPath.row)!
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: self.tabReuseIdentifer, for: indexPath)
+        assert(tabDisplayer != nil)
         if let tabCell = tabDisplayer?.cellFactory(for: cell, using: tab) {
             return tabCell
         } else {
@@ -130,7 +182,7 @@ extension TabDisplayManager: UICollectionViewDataSource {
     }
 
     @objc func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-        let view = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: "HeaderFooter", for: indexPath) as! TopTabsHeaderFooter
+        guard let view = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: "HeaderFooter", for: indexPath) as? TopTabsHeaderFooter else { return UICollectionReusableView() }
         view.arrangeLine(kind)
         return view
     }
@@ -138,7 +190,7 @@ extension TabDisplayManager: UICollectionViewDataSource {
 
 extension TabDisplayManager: TabSelectionDelegate {
     func didSelectTabAtIndex(_ index: Int) {
-        let tab = tabStore[index]
+        guard let tab = dataStore.at(index) else { return }
         if tabsToDisplay.index(of: tab) != nil {
             tabManager.selectTab(tab)
         }
@@ -181,14 +233,11 @@ extension TabDisplayManager: UICollectionViewDragDelegate {
 
     func collectionView(_ collectionView: UICollectionView, dragSessionDidEnd session: UIDragSession) {
         isDragging = false
-        reloadData()
     }
 
     func collectionView(_ collectionView: UICollectionView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
-        // We need to store the earliest oldTabs. So if one already exists use that.
-        self.oldTabs = self.oldTabs ?? tabStore
 
-        let tab = tabStore[indexPath.item]
+        guard let tab = dataStore.at(indexPath.item) else { return [] }
 
         // Get the tab's current URL. If it is `nil`, check the `sessionData` since
         // it may be a tab that has not been restored yet.
@@ -222,17 +271,25 @@ extension TabDisplayManager: UICollectionViewDragDelegate {
 @available(iOS 11.0, *)
 extension TabDisplayManager: UICollectionViewDropDelegate {
     func collectionView(_ collectionView: UICollectionView, performDropWith coordinator: UICollectionViewDropCoordinator) {
-        guard let destinationIndexPath = coordinator.destinationIndexPath, let dragItem = coordinator.items.first?.dragItem, let tab = dragItem.localObject as? Tab, let sourceIndex = tabStore.index(of: tab) else {
+        guard isDragging, let destinationIndexPath = coordinator.destinationIndexPath, let dragItem = coordinator.items.first?.dragItem, let tab = dragItem.localObject as? Tab, let sourceIndex = dataStore.index(of: tab) else {
             return
         }
+        isDragging = false
 
         recordEventAndBreadcrumb(object: .tab, method: .drop)
 
         coordinator.drop(dragItem, toItemAt: destinationIndexPath)
-        isDragging = false
 
         self.tabManager.moveTab(isPrivate: self.isPrivate, fromIndex: sourceIndex, toIndex: destinationIndexPath.item)
-        self.performTabUpdates()
+
+        _ = dataStore.remove(tab)
+        dataStore.insert(tab, at: destinationIndexPath.item)
+
+        let start = IndexPath(row: sourceIndex, section: 0)
+        let end = IndexPath(row: destinationIndexPath.item, section: 0)
+        updateWith(animationType: .moveTab) { [weak self] in
+            self?.collectionView.moveItem(at: start, to: end)
+        }
     }
 
     func collectionView(_ collectionView: UICollectionView, dropSessionDidUpdate session: UIDropSession, withDestinationIndexPath destinationIndexPath: IndexPath?) -> UICollectionViewDropProposal {
@@ -243,7 +300,7 @@ extension TabDisplayManager: UICollectionViewDropDelegate {
         // If the `isDragging` is not `true` by the time we get here, we've had other
         // add/remove operations happen while the drag was going on. We must return a
         // `.cancel` operation continuously until `isDragging` can be reset.
-        guard tabStore.index(of: tab) != nil, isDragging else {
+        guard dataStore.index(of: tab) != nil, isDragging else {
             return UICollectionViewDropProposal(operation: .cancel)
         }
 
@@ -252,297 +309,105 @@ extension TabDisplayManager: UICollectionViewDropDelegate {
 }
 
 extension TabDisplayManager: TabEventHandler {
-    func tab(_ tab: Tab, didLoadFavicon favicon: Favicon?, with: Data?) {
-        assertIsMainThread("UICollectionView changes can only be performed from the main thread")
+    private func updateCellFor(tab: Tab) {
+        guard let index = dataStore.index(of: tab) else { return }
 
-        if tabStore.index(of: tab) != nil {
-            needReloads.append(tab)
-            performTabUpdates()
+        updateWith(animationType: .updateTab) { [weak self] in
+            self?.collectionView.reloadItems(at: [IndexPath(row: index, section: 0)])
         }
+    }
+
+    func tab(_ tab: Tab, didLoadFavicon favicon: Favicon?, with: Data?) {
+        updateCellFor(tab: tab)
     }
 
     func tab(_ tab: Tab, didChangeURL url: URL) {
-        assertIsMainThread("UICollectionView changes can only be performed from the main thread")
-
-        if tabStore.index(of: tab) != nil {
-            needReloads.append(tab)
-            performTabUpdates()
-        }
-    }
-}
-
-// Collection Diff (animations)
-extension TabDisplayManager {
-    struct TopTabMoveChange: Hashable {
-        let from: IndexPath
-        let to: IndexPath
-
-        var hashValue: Int {
-            return from.hashValue + to.hashValue
-        }
-
-        // Consider equality when from/to are equal as well as swapped. This is because
-        // moving a tab from index 2 to index 1 will result in TWO changes: 2 -> 1 and 1 -> 2
-        // We only need to keep *one* of those two changes when dealing with a move.
-        static func ==(lhs: TabDisplayManager.TopTabMoveChange, rhs: TabDisplayManager.TopTabMoveChange) -> Bool {
-            return (lhs.from == rhs.from && lhs.to == rhs.to) || (lhs.from == rhs.to && lhs.to == rhs.from)
-        }
-    }
-
-    struct TopTabChangeSet {
-        let reloads: Set<IndexPath>
-        let inserts: Set<IndexPath>
-        let deletes: Set<IndexPath>
-        let moves: Set<TopTabMoveChange>
-
-        init(reloadArr: [IndexPath], insertArr: [IndexPath], deleteArr: [IndexPath], moveArr: [TopTabMoveChange]) {
-            reloads = Set(reloadArr)
-            inserts = Set(insertArr)
-            deletes = Set(deleteArr)
-            moves = Set(moveArr)
-        }
-
-        var isEmpty: Bool {
-            return reloads.isEmpty && inserts.isEmpty && deletes.isEmpty && moves.isEmpty
-        }
-    }
-
-    // create a TopTabChangeSet which is a snapshot of updates to perfrom on a collectionView
-    func calculateDiffWith(_ oldTabs: [Tab], to newTabs: [Tab], and reloadTabs: [Tab?]) -> TopTabChangeSet {
-        let inserts: [IndexPath] = newTabs.enumerated().compactMap { index, tab in
-            if oldTabs.index(of: tab) == nil {
-                return IndexPath(row: index, section: 0)
-            }
-            return nil
-        }
-
-        let deletes: [IndexPath] = oldTabs.enumerated().compactMap { index, tab in
-            if newTabs.index(of: tab) == nil {
-                return IndexPath(row: index, section: 0)
-            }
-            return nil
-        }
-
-        let moves: [TopTabMoveChange] = newTabs.enumerated().compactMap { newIndex, tab in
-            if let oldIndex = oldTabs.index(of: tab), oldIndex != newIndex {
-                return TopTabMoveChange(from: IndexPath(row: oldIndex, section: 0), to: IndexPath(row: newIndex, section: 0))
-            }
-            return nil
-        }
-
-        // Create based on what is visibile but filter out tabs we are about to insert/delete.
-        let reloads: [IndexPath] = reloadTabs.compactMap { tab in
-            guard let tab = tab, newTabs.index(of: tab) != nil else {
-                return nil
-            }
-            return IndexPath(row: newTabs.index(of: tab)!, section: 0)
-            }.filter { return inserts.index(of: $0) == nil && deletes.index(of: $0) == nil }
-
-        Sentry.shared.breadcrumb(category: "Tab Diff", message: "reloads: \(reloads.count), inserts: \(inserts.count), deletes: \(deletes.count), moves: \(moves.count)")
-
-        return TopTabChangeSet(reloadArr: reloads, insertArr: inserts, deleteArr: deletes, moveArr: moves)
-    }
-
-    func updateTabsFrom(_ oldTabs: [Tab]?, to newTabs: [Tab]) {
-        assertIsMainThread("Updates can only be performed from the main thread")
-        guard let oldTabs = oldTabs, !self.isUpdating, !self.pendingReloadData, !self.isDragging else {
-            return
-        }
-
-        func performPendingCompletions() {
-            for block in self.completionBlocks {
-                block()
-            }
-            self.completionBlocks.removeAll()
-        }
-
-        // Lets create our change set
-        let update = self.calculateDiffWith(oldTabs, to: newTabs, and: needReloads)
-        flushPendingChanges()
-
-        // If there are no changes. We have nothing to do
-        if update.isEmpty {
-            performPendingCompletions()
-            return
-        }
-
-        // The actual update block. We update the dataStore right before we do the UI updates.
-        let updateBlock = {
-            self.tabStore = newTabs
-
-            // Only consider moves if no other operations are pending.
-            if update.deletes.count == 0, update.inserts.count == 0 {
-                for move in update.moves {
-                    self.collectionView.moveItem(at: move.from, to: move.to)
-                }
-            } else {
-                self.collectionView.deleteItems(at: Array(update.deletes))
-                self.collectionView.insertItems(at: Array(update.inserts))
-            }
-            self.collectionView.reloadItems(at: Array(update.reloads))
-        }
-
-        //Lets lock any other updates from happening.
-        self.isUpdating = true
-        self.isDragging = false
-        self.pendingUpdatesToTabs = newTabs // This var helps other mutations that might happen while updating.
-
-        let onComplete: () -> Void = {
-            performPendingCompletions()
-            self.isUpdating = false
-            self.pendingUpdatesToTabs = []
-            // run completion blocks
-            // Sometimes there might be a pending reload. Lets do that.
-            if self.pendingReloadData {
-                return self.reloadData()
-            }
-
-            // There can be pending animations. Run update again to clear them.
-            let tabs = self.oldTabs ?? self.tabStore
-
-            self.completionBlocks.append {
-                if !update.inserts.isEmpty || !update.reloads.isEmpty {
-                    self.tabDisplayer?.focusSelectedTab()
-                }
-            }
-            self.updateTabsFrom(tabs, to: self.tabsToDisplay)
-        }
-
-        // The actual update. Only animate the changes if no tabs have moved
-        // as a result of drag-and-drop.
-        if update.moves.count == 0, tabDisplayer is TopTabsViewController {
-            UIView.animate(withDuration: TopTabsUX.AnimationSpeed, animations: {
-                self.collectionView.performBatchUpdates(updateBlock)
-            }) { (_) in
-                onComplete()
-            }
-        } else {
-            self.collectionView.performBatchUpdates(updateBlock) { _ in
-                onComplete()
-            }
-        }
-    }
-
-    fileprivate func flushPendingChanges() {
-        oldTabs = nil
-        needReloads.removeAll()
-    }
-
-    func reloadData(_ completionBlock: CompletionBlock? = nil) {
-        assertIsMainThread("reloadData must only be called from main thread")
-        if let block = completionBlock {
-            completionBlocks.append(block)
-        }
-
-        if self.isUpdating || self.collectionView.superview == nil {
-            self.pendingReloadData = true
-            return
-        }
-
-        isUpdating = true
-        isDragging = false
-        self.tabStore = self.tabsToDisplay
-        self.flushPendingChanges()
-        UIView.animate(withDuration: TopTabsUX.AnimationSpeed, animations: {
-            self.collectionView.reloadData()
-            self.collectionView.collectionViewLayout.invalidateLayout()
-            self.collectionView.layoutIfNeeded()
-            self.tabDisplayer?.focusSelectedTab()
-        }, completion: { (_) in
-            self.isUpdating = false
-            self.pendingReloadData = false
-            self.performTabUpdates()
-        })
+        updateCellFor(tab: tab)
     }
 }
 
 extension TabDisplayManager: TabManagerDelegate {
-
-    // Because we don't know when we are about to transition to private mode
-    // check to make sure that the tab we are trying to add is being added to the right tab group
-    fileprivate func tabsMatchDisplayGroup(_ a: Tab?, b: Tab?) -> Bool {
-        if let a = a, let b = b, a.isPrivate == b.isPrivate {
-            return true
-        }
-        return false
-    }
-
-    func performTabUpdates(_ completionBlock: CompletionBlock? = nil) {
-        if let block = completionBlock {
-            completionBlocks.append(block)
-        }
-        guard !isUpdating else {
-            return
-        }
-
-        let fromTabs = !self.pendingUpdatesToTabs.isEmpty ? self.pendingUpdatesToTabs : self.oldTabs
-        self.oldTabs = fromTabs ?? self.tabStore
-        if self.pendingReloadData && !isUpdating {
-            self.reloadData()
-        } else {
-            self.updateTabsFrom(self.oldTabs, to: self.tabsToDisplay)
-        }
-    }
-
     func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?, isRestoring: Bool) {
-        if !shouldAnimate(isRestoringTabs: isRestoring) {
-            return
+        isDragging = false
+
+        if let selected = selected {
+            updateCellFor(tab: selected)
         }
-        if !tabsMatchDisplayGroup(selected, b: previous) {
-            self.reloadData()
-        } else {
-            self.needReloads.append(selected)
-            self.needReloads.append(previous)
-            performTabUpdates()
+        if let previous = previous {
+            updateCellFor(tab: previous)
         }
     }
 
     func tabManager(_ tabManager: TabManager, willAddTab tab: Tab) {
-        // We need to store the earliest oldTabs. So if one already exists use that.
-        self.oldTabs = self.oldTabs ?? tabStore
+        isDragging = false
     }
 
     func tabManager(_ tabManager: TabManager, didAddTab tab: Tab, isRestoring: Bool) {
-        if !shouldAnimate(isRestoringTabs: isRestoring) || (tabManager.selectedTab != nil && !tabsMatchDisplayGroup(tab, b: tabManager.selectedTab)) {
+        if isRestoring {
             return
         }
-        performTabUpdates()
+
+        updateWith(animationType: .addTab) { [weak self] in
+            if let me = self {
+                me.dataStore.insert(tab)
+                me.collectionView.insertItems(at: [IndexPath(row: me.dataStore.count - 1, section: 0)])
+            }
+        }
     }
 
     func tabManager(_ tabManager: TabManager, willRemoveTab tab: Tab) {
-        // We need to store the earliest oldTabs. So if one already exists use that.
-        self.oldTabs = self.oldTabs ?? tabStore
+        isDragging = false
     }
 
     func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool) {
-        recordEventAndBreadcrumb(object: .tab, method: .delete)
-        if !shouldAnimate(isRestoringTabs: isRestoring) {
-            return
+        let type = tabManager.normalTabs.isEmpty ? TabAnimationType.removedLastTab : TabAnimationType.removedNonLastTab
+
+        updateWith(animationType: type) { [weak self] in
+            guard let removed = self?.dataStore.remove(tab) else { return }
+            self?.collectionView.deleteItems(at: [IndexPath(row: removed, section: 0)])
         }
-        // If we deleted the last private tab. We'll be switching back to normal browsing. Pause updates till then
-        if self.tabsToDisplay.isEmpty {
-            self.pendingReloadData = true
+    }
+
+    private func performChainedOperations() {
+        if performingChainedOperations {
             return
         }
 
-        // dont want to hold a ref to a deleted tab
-        if tab === oldSelectedTab {
-            oldSelectedTab = nil
+        if let (type, operation) = operations.popLast() {
+            performingChainedOperations = true
+            collectionView.performBatchUpdates({ [weak self] in
+                // Baseline animation speed is 1.0, which is too slow, this (odd) code sets it to 3x
+                self?.collectionView.forFirstBaselineLayout.layer.speed = 3.0
+                operation()
+                }, completion: { [weak self] (done) in
+                    self?.performingChainedOperations = false
+                    self?.tabDisplayCompletionDelegate?.completedAnimation(for: type)
+                    self?.performChainedOperations()
+            })
+        }
+    }
+
+    private func updateWith(animationType: TabAnimationType, operation: (() -> Void)?) {
+        if let op = operation {
+            operations.insert((animationType, op), at: 0)
         }
 
-        performTabUpdates()
+        performChainedOperations()
     }
 
     func tabManagerDidRestoreTabs(_ tabManager: TabManager) {
-        self.reloadData()
+        isDragging = false
+        refreshStore()
     }
 
     func tabManagerDidAddTabs(_ tabManager: TabManager) {
-        recordEventAndBreadcrumb(object: .tab, method: .add)
+        isDragging = false
+        refreshStore()
     }
 
     func tabManagerDidRemoveAllTabs(_ tabManager: TabManager, toast: ButtonToast?) {
-        recordEventAndBreadcrumb(object: .tab, method: .deleteAll)
-        self.reloadData()
+        isDragging = false
+        refreshStore()
     }
 }
+

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -175,13 +175,11 @@ class TabManager: NSObject {
         return nil
     }
 
+    // This function updates the _selectedIndex.
+    // Note: it is safe to call this with `tab` and `previous` as the same tab, for use in the case where the index of the tab has changed (such as after deletion).
     func selectTab(_ tab: Tab?, previous: Tab? = nil) {
         assert(Thread.isMainThread)
         let previous = previous ?? selectedTab
-
-        if previous === tab {
-            return
-        }
 
         // Make sure to wipe the private tabs if the user has the pref turned on
         if shouldClearPrivateTabs(), !(tab?.isPrivate ?? false) {
@@ -404,7 +402,8 @@ class TabManager: NSObject {
                 }
             }
         } else if deletedIndex < _selectedIndex {
-            selectTab(tabs[safe: _selectedIndex - 1], previous: tab)
+            let selected = tabs[safe: _selectedIndex - 1]
+            selectTab(selected, previous: selected)
         }
     }
 

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -463,18 +463,9 @@ class TabManager: NSObject {
     func removeTabsWithUndoToast(_ tabs: [Tab]) {
         recentlyClosedForUndo = normalTabs.compactMap { SavedTab(tab: $0, isSelected: false) }
 
-        var tabsCopy = tabs
-
-        // Remove the current tab last to prevent switching tabs while removing tabs
-        if let selectedTab = selectedTab, let selectedIndex = tabsCopy.index(of: selectedTab) {
-            let removed = tabsCopy.remove(at: selectedIndex)
-            removeTabs(tabsCopy)
-            removeTabAndUpdateSelectedIndex(removed)
-        } else {
-            removeTabs(tabsCopy)
-            if normalTabs.isEmpty {
-                selectTab(addTab())
-            }
+        removeTabs(tabs)
+        if normalTabs.isEmpty {
+            selectTab(addTab())
         }
 
         tabs.forEach({ $0.hideContent() })

--- a/Client/Frontend/Browser/TabTrayController+KeyCommands.swift
+++ b/Client/Frontend/Browser/TabTrayController+KeyCommands.swift
@@ -7,7 +7,7 @@ import UIKit
 
 extension TabTrayController {
     override var keyCommands: [UIKeyCommand]? {
-        let toggleText = privateMode ? Strings.SwitchToNonPBMKeyCodeTitle: Strings.SwitchToPBMKeyCodeTitle
+        let toggleText = tabDisplayManager.isPrivate ? Strings.SwitchToNonPBMKeyCodeTitle: Strings.SwitchToPBMKeyCodeTitle
         var commands = [
             UIKeyCommand(input: "`", modifierFlags: .command, action: #selector(didTogglePrivateModeKeyCommand), discoverabilityTitle: toggleText),
             UIKeyCommand(input: "w", modifierFlags: .command, action: #selector(didCloseTabKeyCommand)),
@@ -74,7 +74,7 @@ extension TabTrayController {
             step = 0
         }
 
-        let tabs = tabDisplayManager.tabStore
+        let tabs = tabDisplayManager.dataStore
         let currentIndex: Int
         if let selected = tabManager.selectedTab {
             currentIndex = tabs.index(of: selected) ?? 0
@@ -83,7 +83,7 @@ extension TabTrayController {
         }
 
         let nextIndex = max(0, min(currentIndex + step, tabs.count - 1))
-        if let nextTab = tabs[safe: nextIndex] {
+        if let nextTab = tabs.at(nextIndex) {
             tabManager.selectTab(nextTab)
         }
     }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -484,6 +484,9 @@ extension TabTrayController {
                     self.emptyPrivateTabsView.alpha = 1
                 }, completion: nil)
             }
+        } else if tabManager.normalTabs.count == 1, let tab = tabManager.normalTabs.first {
+            tabManager.selectTab(tab)
+            dismissTabTray()
         }
     }
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -89,13 +89,6 @@ class TabTrayController: UIViewController {
         return cancelButton
     }()
 
-    fileprivate(set) internal var privateMode: Bool = false {
-        didSet {
-            toolbar.applyUIMode(isPrivate: privateMode)
-            searchBar.applyUIMode(isPrivate: privateMode)
-        }
-    }
-
     fileprivate lazy var emptyPrivateTabsView: EmptyPrivateTabsView = {
         let emptyView = EmptyPrivateTabsView()
         emptyView.learnMoreButton.addTarget(self, action: #selector(didTapLearnMore), for: .touchUpInside)
@@ -129,6 +122,8 @@ class TabTrayController: UIViewController {
         // these will be animated during view show/hide transition
         statusBarBG.alpha = 0
         searchBarHolder.alpha = 0
+
+        tabDisplayManager.tabDisplayCompletionDelegate = self
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -144,7 +139,7 @@ class TabTrayController: UIViewController {
     }
 
     func focusTab() {
-        guard let currentTab = tabManager.selectedTab, let index = self.tabDisplayManager.tabStore.index(of: currentTab), let rect = self.collectionView.layoutAttributesForItem(at: IndexPath(item: index, section: 0))?.frame else {
+        guard let currentTab = tabManager.selectedTab, let index = self.tabDisplayManager.dataStore.index(of: currentTab), let rect = self.collectionView.layoutAttributesForItem(at: IndexPath(item: index, section: 0))?.frame else {
             return
         }
         self.collectionView.scrollRectToVisible(rect, animated: false)
@@ -196,7 +191,9 @@ class TabTrayController: UIViewController {
         }
 
         if let tab = tabManager.selectedTab, tab.isPrivate {
-            privateMode = true
+            tabDisplayManager.togglePrivateMode(isOn: true, createTabOnEmptyPrivateMode: false)
+            toolbar.applyUIMode(isPrivate: true)
+            searchBar.applyUIMode(isPrivate: true)
         }
 
         if traitCollection.forceTouchCapability == .available {
@@ -278,11 +275,11 @@ class TabTrayController: UIViewController {
             fromView = emptyPrivateTabsView
         }
 
-        tabDisplayManager.isPrivate = !tabDisplayManager.isPrivate
-        tabManager.willSwitchTabMode(leavingPBM: privateMode)
-        privateMode = !privateMode
+        tabDisplayManager.togglePrivateMode(isOn: !tabDisplayManager.isPrivate, createTabOnEmptyPrivateMode: false)
 
-        if privateMode, privateTabsAreEmpty() {
+        tabManager.willSwitchTabMode(leavingPBM: tabDisplayManager.isPrivate)
+
+        if tabDisplayManager.isPrivate, privateTabsAreEmpty() {
             UIView.animate(withDuration: 0.2) {
                 self.searchBarHolder.alpha = 0
             }
@@ -295,15 +292,14 @@ class TabTrayController: UIViewController {
         if tabDisplayManager.searchActive {
             self.didPressCancel()
         } else {
-            self.tabDisplayManager.reloadData()
+            self.tabDisplayManager.refreshStore()
         }
 
-        tabDisplayManager.isPrivate = privateMode
         // If we are exiting private mode and we have the close private tabs option selected, make sure
         // we clear out all of the private tabs
-        let exitingPrivateMode = !privateMode && tabManager.shouldClearPrivateTabs()
+        let exitingPrivateMode = !tabDisplayManager.isPrivate && tabManager.shouldClearPrivateTabs()
 
-        toolbar.maskButton.setSelected(privateMode, animated: true)
+        toolbar.maskButton.setSelected(tabDisplayManager.isPrivate, animated: true)
         collectionView.layoutSubviews()
 
         let toView: UIView
@@ -335,11 +331,21 @@ class TabTrayController: UIViewController {
             }
             self.collectionView.alpha = 1
             self.toolbar.isUserInteractionEnabled = true
+
+            // A final reload to ensure no animations happen while completing the transition.
+            self.tabDisplayManager.refreshStore()
+        }
+
+        toolbar.applyUIMode(isPrivate: tabDisplayManager.isPrivate)
+        searchBar.applyUIMode(isPrivate: tabDisplayManager.isPrivate)
+
+        if let search = searchBar.text, !search.isEmpty {
+            searchTabs(for: search)
         }
     }
 
     fileprivate func privateTabsAreEmpty() -> Bool {
-        return privateMode && tabManager.privateTabs.count == 0
+        return tabDisplayManager.isPrivate && tabManager.privateTabs.isEmpty
     }
 
     @objc func openTab() {
@@ -354,20 +360,14 @@ class TabTrayController: UIViewController {
         toolbar.isUserInteractionEnabled = false
 
         tabManager.selectTab(tabManager.addTab(request, isPrivate: tabDisplayManager.isPrivate))
-        self.tabDisplayManager.performTabUpdates {
-            self.emptyPrivateTabsView.isHidden = !self.privateTabsAreEmpty()
-            self.dismissTabTray()
-        }
-        LeanPlumClient.shared.track(event: .openedNewTab, withParameters: ["Source": "Tab Tray"])
     }
-
 }
 
 extension TabTrayController: TabManagerDelegate {
     func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?, isRestoring: Bool) {}
     func tabManager(_ tabManager: TabManager, didAddTab tab: Tab, isRestoring: Bool) {}
     func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool) {
-        if privateMode, privateTabsAreEmpty() {
+        if tabDisplayManager.isPrivate, privateTabsAreEmpty() {
             UIView.animate(withDuration: 0.2) {
                 self.searchBarHolder.alpha = 0
             }
@@ -381,7 +381,7 @@ extension TabTrayController: TabManagerDelegate {
     }
 
     func tabManagerDidAddTabs(_ tabManager: TabManager) {
-        if privateMode {
+        if tabDisplayManager.isPrivate {
             UIView.animate(withDuration: 0.2) {
                 self.searchBarHolder.alpha = 1
             }
@@ -410,9 +410,8 @@ extension TabTrayController: UITextFieldDelegate {
             clearSearch()
             return
         }
-        ensureMainThread {
-            self.searchTabs(for: text)
-        }
+
+        searchTabs(for: text)
     }
 
     func textFieldDidBeginEditing(_ textField: UITextField) {
@@ -436,18 +435,15 @@ extension TabTrayController: UITextFieldDelegate {
             }
             return false
         }
-        self.tabDisplayManager.searchActive = true
-        self.tabDisplayManager.searchedTabs = filteredTabs
-        self.tabDisplayManager.performTabUpdates()
+        tabDisplayManager.searchedTabs = filteredTabs
+
+        tabDisplayManager.searchTabsAnimated()
     }
 
     func clearSearch() {
-        tabDisplayManager.searchActive = false
-        tabDisplayManager.searchedTabs = []
+        tabDisplayManager.searchedTabs = nil
         searchBar.text = ""
-        ensureMainThread {
-            self.tabDisplayManager.performTabUpdates()
-        }
+        tabDisplayManager.refreshStore()
     }
 }
 
@@ -478,13 +474,8 @@ extension TabTrayController {
     }
 
     func closeTabsForCurrentTray() {
-        tabManager.removeTabsWithUndoToast(tabDisplayManager.tabStore)
-        if !tabDisplayManager.isPrivate {
-            // when closing all tabs in normal mode we automatically open a new tab and focus it
-            self.tabDisplayManager.performTabUpdates {
-                self.dismissTabTray()
-            }
-        } else {
+        tabManager.removeTabsWithUndoToast(tabDisplayManager.dataStore.compactMap { $0 })
+        if tabDisplayManager.isPrivate {
             emptyPrivateTabsView.isHidden = !self.privateTabsAreEmpty()
             if !emptyPrivateTabsView.isHidden {
                 // Fade in the empty private tabs message. This slow fade allows time for the closing tab animations to complete.
@@ -503,6 +494,8 @@ extension TabTrayController {
     }
 
     func dismissTabTray() {
+        collectionView.layer.removeAllAnimations()
+        collectionView.cellForItem(at: IndexPath(row: 0, section: 0))?.layer.removeAllAnimations()
         _ = self.navigationController?.popViewController(animated: true)
     }
 
@@ -511,7 +504,7 @@ extension TabTrayController {
 // MARK: - App Notifications
 extension TabTrayController {
     @objc func appWillResignActiveNotification() {
-        if privateMode {
+        if tabDisplayManager.isPrivate {
             collectionView.alpha = 0
             searchBarHolder.alpha = 0
         }
@@ -523,7 +516,7 @@ extension TabTrayController {
         UIView.animate(withDuration: 0.2) {
             self.collectionView.alpha = 1
 
-            if self.privateMode, !self.privateTabsAreEmpty() {
+            if self.tabDisplayManager.isPrivate, !self.privateTabsAreEmpty() {
                 self.searchBarHolder.alpha = 1
             }
         }
@@ -532,7 +525,7 @@ extension TabTrayController {
 
 extension TabTrayController: TabSelectionDelegate {
     func didSelectTabAtIndex(_ index: Int) {
-        if let tab = tabDisplayManager.tabStore[safe: index] {
+        if let tab = tabDisplayManager.dataStore.at(index) {
             tabManager.selectTab(tab)
             dismissTabTray()
         }
@@ -581,7 +574,7 @@ extension TabTrayController: UIScrollViewAccessibilityDelegate {
 extension TabTrayController: SwipeAnimatorDelegate {
     func swipeAnimator(_ animator: SwipeAnimator, viewWillExitContainerBounds: UIView) {
         guard let tabCell = animator.animatingView as? TabCell, let indexPath = collectionView.indexPath(for: tabCell) else { return }
-        if let tab = tabDisplayManager.tabStore[safe: indexPath.item] {
+        if let tab = tabDisplayManager.dataStore.at(indexPath.item) {
             self.removeTab(tab: tab)
             UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, NSLocalizedString("Closing tab", comment: "Accessibility label (used by assistive technology) notifying the user that the tab is being closed."))
         }
@@ -590,8 +583,8 @@ extension TabTrayController: SwipeAnimatorDelegate {
 
 extension TabTrayController: TabCellDelegate {
     func tabCellDidClose(_ cell: TabCell) {
-        if let indexPath = collectionView.indexPath(for: cell), let tab = tabDisplayManager.tabStore[safe: indexPath.item] {
-            self.removeTab(tab: tab)
+        if let indexPath = collectionView.indexPath(for: cell), let tab = tabDisplayManager.dataStore.at(indexPath.item) {
+            removeTab(tab: tab)
         }
     }
 }
@@ -607,7 +600,7 @@ extension TabTrayController: TabPeekDelegate {
     }
 
     func tabPeekDidCloseTab(_ tab: Tab) {
-        if let index = tabDisplayManager.tabStore.index(of: tab),
+        if let index = tabDisplayManager.dataStore.index(of: tab),
             let cell = self.collectionView?.cellForItem(at: IndexPath(item: index, section: 0)) as? TabCell {
             cell.close()
         }
@@ -628,7 +621,7 @@ extension TabTrayController: UIViewControllerPreviewingDelegate {
         guard let indexPath = collectionView.indexPathForItem(at: convertedLocation),
             let cell = collectionView.cellForItem(at: indexPath) else { return nil }
 
-        guard let tab = tabDisplayManager.tabStore[safe: indexPath.row] else {
+        guard let tab = tabDisplayManager.dataStore.at(indexPath.row) else {
             return nil
         }
         let tabVC = TabPeekViewController(tab: tab, delegate: self)
@@ -648,19 +641,30 @@ extension TabTrayController: UIViewControllerPreviewingDelegate {
     }
 }
 
-extension TabTrayController {
-    func removeTab(tab: Tab) {
-        // when removing the last tab (only in normal mode) we will automatically open a new tab.
-        // When that happens focus it by dismissing the tab tray
-        let isLastTab = tabDisplayManager.tabStore.count == 1
-        tabManager.removeTabAndUpdateSelectedIndex(tab)
-        guard !tabDisplayManager.searchActive else { return }
-        self.emptyPrivateTabsView.isHidden = !self.privateTabsAreEmpty()
-        self.tabDisplayManager.performTabUpdates {
-            if isLastTab, !self.tabDisplayManager.isPrivate {
+extension TabTrayController: TabDisplayCompletionDelegate {
+    func completedAnimation(for type: TabAnimationType) {
+        emptyPrivateTabsView.isHidden = !privateTabsAreEmpty()
+
+        switch type {
+        case .addTab:
+            dismissTabTray()
+            LeanPlumClient.shared.track(event: .openedNewTab, withParameters: ["Source": "Tab Tray"])
+        case .removedLastTab:
+            // when removing the last tab (only in normal mode) we will automatically open a new tab.
+            // When that happens focus it by dismissing the tab tray
+            if !tabDisplayManager.isPrivate {
                 self.dismissTabTray()
             }
+        case .removedNonLastTab, .updateTab, .moveTab:
+            break
         }
+    }
+}
+
+extension TabTrayController {
+    func removeTab(tab: Tab) {
+        tabDisplayManager.tabDisplayCompletionDelegate = self
+        tabManager.removeTabAndUpdateSelectedIndex(tab)
     }
 }
 

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -94,16 +94,10 @@ class TopTabsViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        tabDisplayManager.performTabUpdates()
+
+        tabDisplayManager.refreshStore(evenIfHidden: true)
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        // Will only be done once, on first appearance, due to the check
-        if isBeingPresented || isMovingToParentViewController {
-            tabDisplayManager.performTabUpdates()
-        }
-    }
 
     deinit {
         tabManager.removeDelegate(self.tabDisplayManager)
@@ -160,7 +154,7 @@ class TopTabsViewController: UIViewController {
         tabsButton.applyTheme()
         applyUIMode(isPrivate: tabManager.selectedTab?.isPrivate ?? false)
 
-        updateTabCount(tabDisplayManager.tabCount, animated: false)
+        updateTabCount(tabDisplayManager.dataStore.count, animated: false)
     }
 
     func switchForegroundStatus(isInForeground reveal: Bool) {
@@ -183,27 +177,20 @@ class TopTabsViewController: UIViewController {
     }
 
     @objc func newTabTapped() {
-        if tabDisplayManager.pendingReloadData {
-            return
-        }
         self.delegate?.topTabsDidPressNewTab(self.tabDisplayManager.isPrivate)
         LeanPlumClient.shared.track(event: .openedNewTab, withParameters: ["Source": "Add tab button in the URL Bar on iPad"])
     }
 
     @objc func togglePrivateModeTapped() {
-        let currentMode = tabDisplayManager.isPrivate
-
-        tabDisplayManager.togglePBM()
-        if currentMode != tabDisplayManager.isPrivate {
-            delegate?.topTabsDidTogglePrivateMode()
-        }
+        tabDisplayManager.togglePrivateMode(isOn: !tabDisplayManager.isPrivate, createTabOnEmptyPrivateMode: true)
+        delegate?.topTabsDidTogglePrivateMode()
         self.privateModeButton.setSelected(tabDisplayManager.isPrivate, animated: true)
     }
 
     func scrollToCurrentTab(_ animated: Bool = true, centerCell: Bool = false) {
         assertIsMainThread("Only animate on the main thread")
 
-        guard let currentTab = tabManager.selectedTab, let index = tabDisplayManager.tabStore.index(of: currentTab), !collectionView.frame.isEmpty else {
+        guard let currentTab = tabManager.selectedTab, let index = tabDisplayManager.dataStore.index(of: currentTab), !collectionView.frame.isEmpty else {
             return
         }
         if let frame = collectionView.layoutAttributesForItem(at: IndexPath(row: index, section: 0))?.frame {
@@ -242,20 +229,13 @@ extension TopTabsViewController: TabDisplayer {
 
 extension TopTabsViewController: TopTabCellDelegate {
     func tabCellDidClose(_ cell: UICollectionViewCell) {
-        // Trying to remove tabs while animating can lead to crashes as indexes change. If updates are happening don't allow tabs to be removed.
-        guard let index = collectionView.indexPath(for: cell)?.item else {
-            return
-        }
-        if let tab = self.tabDisplayManager.tabStore[safe: index] {
-            tabManager.removeTabAndUpdateSelectedIndex(tab)
-        }
-
+        tabDisplayManager.close(cell: cell)
     }
 }
 
 extension TopTabsViewController: Themeable, PrivateModeUI {
     func applyUIMode(isPrivate: Bool) {
-        tabDisplayManager.isPrivate = isPrivate
+        tabDisplayManager.togglePrivateMode(isOn: isPrivate, createTabOnEmptyPrivateMode: true)
 
         privateModeButton.onTint = UIColor.theme.topTabs.privateModeButtonOnTint
         privateModeButton.offTint = UIColor.theme.topTabs.privateModeButtonOffTint
@@ -267,6 +247,6 @@ extension TopTabsViewController: Themeable, PrivateModeUI {
         newTab.tintColor = UIColor.theme.topTabs.buttonTint
         view.backgroundColor = UIColor.theme.topTabs.background
         collectionView.backgroundColor = view.backgroundColor
-        tabDisplayManager.reloadData()
+        tabDisplayManager.refreshStore()
     }
 }

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -250,3 +250,12 @@ extension TopTabsViewController: Themeable, PrivateModeUI {
         tabDisplayManager.refreshStore()
     }
 }
+
+// Functions for testing
+extension TopTabsViewController {
+    func test_getDisplayManager() -> TabDisplayManager {
+        assert(AppConstants.IsRunningTest)
+        return tabDisplayManager
+    }
+}
+

--- a/ClientTests/TabDisplayManagerTests.swift
+++ b/ClientTests/TabDisplayManagerTests.swift
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@testable import Client
+import UIKit
+import WebKit
+import XCTest
+
+class TabDisplayManagerTests: XCTestCase {
+    let configuration = WKWebViewConfiguration()
+
+    var bvc: BrowserViewController {
+        return (UIApplication.shared.delegate as! AppDelegate).browserViewController
+    }
+
+    var displayManager: TabDisplayManager {
+        return bvc.topTabsViewController!.test_getDisplayManager()
+    }
+
+    var tabManager: TabManager {
+        return bvc.tabManager
+    }
+
+    // Without session data, a Tab can't become a SavedTab and get archived
+    func addTab(isPrivate: Bool = false) -> Tab {
+        let tab = Tab(configuration: configuration, isPrivate: isPrivate)
+        tabManager.configureTab(tab, request: nil, flushToDisk: false, zombie: false)
+        return tab
+    }
+
+    func testIsDraggingBecomesFalse() {
+        if !bvc.urlBar.topTabsIsShowing {
+            // this test is for iPad-only as it requires the tab display manager to be showing
+            return
+        }
+
+        displayManager.test_toggleIsDragging()
+        let tab = addTab()
+        XCTAssertFalse(displayManager.test_getIsDragging())
+
+        displayManager.test_toggleIsDragging()
+        tabManager.selectTab(tab)
+        XCTAssertFalse(displayManager.test_getIsDragging())
+
+        displayManager.test_toggleIsDragging()
+        tabManager.removeTabs([tab])
+        XCTAssertFalse(displayManager.test_getIsDragging())
+    }
+}

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -197,8 +197,13 @@ class TabManagerTests: XCTestCase {
         manager.selectTab(privateTab)
         manager.addDelegate(delegate)
 
+
+        let didSelect = MethodSpy(functionName: spyDidSelectedTabChange) { _ in
+            // test fails if this not called
+        }
+
         // This test makes sure that a normal tab is always added even when a normal tab is not selected when calling removeAll
-        delegate.expect([willRemove, didRemove, willAdd, didAdd, removeAllTabs])
+        delegate.expect([willRemove, didRemove, willAdd, didAdd, didSelect, removeAllTabs])
 
         manager.removeTabsWithUndoToast(manager.normalTabs)
         delegate.verify("Not all delegate methods were called")

--- a/Shared/Extensions/UIImageExtensions.swift
+++ b/Shared/Extensions/UIImageExtensions.swift
@@ -34,15 +34,6 @@ extension UIImage {
         return image
     }
 
-    /// Generates a UIImage from GIF data by calling out to SDWebImage. The latter in turn uses UIImage(data: NSData)
-    /// in certain cases so we have to synchronize calls (see bug 1223132).
-    public static func imageFromGIFDataThreadSafe(_ data: Data) -> UIImage? {
-        imageLock.lock()
-        let image = UIImage.sd_animatedGIF(with: data)
-        imageLock.unlock()
-        return image
-    }
-
     public static func createWithColor(_ size: CGSize, color: UIColor) -> UIImage {
         UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
         let context = UIGraphicsGetCurrentContext()

--- a/Shared/WeakList.swift
+++ b/Shared/WeakList.swift
@@ -24,14 +24,40 @@ open class WeakList<T: AnyObject>: Sequence {
      * been deallocated) to reuse them, so this class may not be appropriate in situations where
      * insertion is frequent.
      */
-    open func insert(_ item: T) {
+    open func insert(_ item: T, at: Int? = nil) {
         // Reuse any existing slots that have been deallocated.
         for wrapper in items where wrapper.value == nil {
             wrapper.value = item
             return
         }
 
-        items.append(WeakRef(item))
+        if let at = at, 0...items.endIndex ~= at {
+            items.insert(WeakRef(item), at: at)
+        } else {
+            items.append(WeakRef(item))
+        }
+    }
+
+    open var count: Int {
+        return items.count
+    }
+
+    open func removeAll() {
+        items.removeAll()
+    }
+
+    open func remove(_ item: T) -> Int? {
+        guard let index = self.index(of: item) else { return nil }
+        items.remove(at: index)
+        return index
+    }
+
+    open func at(_ index: Int) -> T? {
+        return items[safe: index]?.value
+    }
+
+    open func index(of item: T) -> Int? {
+        return items.index { $0.value === item }
     }
 
     open func makeIterator() -> AnyIterator<T> {

--- a/XCUITests/DragAndDropTests.swift
+++ b/XCUITests/DragAndDropTests.swift
@@ -4,11 +4,15 @@
 
 import XCTest
 
-let firstWebsite = ["url": "www.wikipedia.org", "tabName": "Wikipedia"]
-let secondWebsite = ["url": "www.twitter.com", "tabName": "Twitter"]
-let exampleWebsite = ["url": "www.example.com", "tabName": "Example Domain"]
-let homeTab = ["tabName": "home"]
-let websiteWithSearchField = ["url": "https://developer.mozilla.org/en-US/search", "urlSearchField": "Search the docs"]
+let firstWebsite = (url: path(forTestPage: "test-mozilla-org.html"), tabName: "Internet for people, not profit — Mozilla")
+let secondWebsite = (url: path(forTestPage: "test-mozilla-book.html"), tabName: "The Book of Mozilla")
+let exampleWebsite = (url: path(forTestPage: "test-example.html"), tabName: "Example Domain")
+let homeTabName = "home"
+let websiteWithSearchField = (url: "https://developer.mozilla.org/en-US/search", urlSearchField: "Search the docs")
+
+let exampleDomainTitle = "Example Domain"
+let twitterTitle = "Twitter"
+
 
 class DragAndDropTests: IpadOnlyTestCase {
 
@@ -35,9 +39,9 @@ class DragAndDropTests: IpadOnlyTestCase {
 
     private func openTwoWebsites() {
         // Open two tabs
-        navigator.openURL(firstWebsite["url"]!)
+        navigator.openURL(firstWebsite.url)
         navigator.goto(TabTray)
-        navigator.openURL(secondWebsite["url"]!)
+        navigator.openURL(secondWebsite.url)
         waitUntilPageLoad()
     }
 
@@ -63,12 +67,12 @@ class DragAndDropTests: IpadOnlyTestCase {
         if skipPlatform { return }
 
         openTwoWebsites()
-        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite["tabName"]!, secondTab: secondWebsite["tabName"]!)
+        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite.tabName, secondTab: secondWebsite.tabName)
         // Drag first tab on the second one
-        dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite["tabName"]!], dropOnElement: app.collectionViews.cells[secondWebsite["tabName"]!])
-        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite["tabName"]!, secondTab: firstWebsite["tabName"]!)
+        dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite.tabName], dropOnElement: app.collectionViews.cells[secondWebsite.tabName])
+        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName, secondTab: firstWebsite.tabName)
         // Check that focus is kept on last website open
-        XCTAssertEqual(app.textFields["url"].value! as? String, "mobile.twitter.com/", "The tab has not been dropped correctly")
+        XCTAssert(secondWebsite.url.contains(app.textFields["url"].value! as! String), "The tab has not been dropped correctly")
     }
 
     func testRearrangeTabsLandscape() {
@@ -77,44 +81,44 @@ class DragAndDropTests: IpadOnlyTestCase {
         // Set the device in landscape mode
         XCUIDevice.shared.orientation = UIDeviceOrientation.landscapeLeft
         openTwoWebsites()
-        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite["tabName"]!, secondTab: secondWebsite["tabName"]!)
+        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite.tabName, secondTab: secondWebsite.tabName)
 
         // Rearrange the tabs via drag home tab and drop it on twitter tab
-        dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite["tabName"]!], dropOnElement: app.collectionViews.cells[secondWebsite["tabName"]!])
+        dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite.tabName], dropOnElement: app.collectionViews.cells[secondWebsite.tabName])
 
-         checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite["tabName"]!, secondTab: firstWebsite["tabName"]!)
+         checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName, secondTab: firstWebsite.tabName)
         // Check that focus is kept on last website open
-        XCTAssertEqual(app.textFields["url"].value! as? String, "mobile.twitter.com/", "The tab has not been dropped correctly")
+        XCTAssert(secondWebsite.url.contains(app.textFields["url"].value! as! String), "The tab has not been dropped correctly")
     }
     // Tests disabled because the feature is off for master and 14.x
     func testRearrangeTabsTabTray() {
         openTwoWebsites()
         navigator.goto(TabTray)
-        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite["tabName"]!, secondTab: secondWebsite["tabName"]!)
-        dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite["tabName"]!], dropOnElement: app.collectionViews.cells[secondWebsite["tabName"]!])
-        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite["tabName"]!, secondTab: firstWebsite["tabName"]!)
+        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite.tabName, secondTab: secondWebsite.tabName)
+        dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite.tabName], dropOnElement: app.collectionViews.cells[secondWebsite.tabName])
+        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName, secondTab: firstWebsite.tabName)
     }
 
      func testRearrangeMoreThan3TabsTabTray() {
         // Arranging more than 3 to check that it works moving tabs between lines
-        let thirdWebsite = ["url": "example.com", "tabName": "Example Domain"]
+        let thirdWebsite = (url: "example.com", tabName: "Example Domain")
 
         // Open three websites and home tab
         openTwoWebsites()
         navigator.performAction(Action.OpenNewTabFromTabTray)
-        navigator.openNewURL(urlString: thirdWebsite["url"]!)
+        navigator.openNewURL(urlString: thirdWebsite.url)
         waitUntilPageLoad()
         navigator.goto(TabTray)
 
         let fourthWebsitePosition = app.collectionViews.cells.element(boundBy: 3).label
-        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite["tabName"]!, secondTab: secondWebsite["tabName"]!)
-        XCTAssertEqual(fourthWebsitePosition, thirdWebsite["tabName"]!, "last tab before is not correct")
+        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite.tabName, secondTab: secondWebsite.tabName)
+        XCTAssertEqual(fourthWebsitePosition, thirdWebsite.tabName, "last tab before is not correct")
 
-        dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite["tabName"]!], dropOnElement: app.collectionViews.cells[thirdWebsite["tabName"]!])
+        dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite.tabName], dropOnElement: app.collectionViews.cells[thirdWebsite.tabName])
 
         let thirdWebsitePosition = app.collectionViews.cells.element(boundBy: 2).label
-        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite["tabName"]! , secondTab: homeTab["tabName"]!)
-        XCTAssertEqual(thirdWebsitePosition, thirdWebsite["tabName"]!, "last tab after is not correct")
+        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName , secondTab: homeTabName)
+        XCTAssertEqual(thirdWebsitePosition, thirdWebsite.tabName, "last tab after is not correct")
     }
 
     func testRearrangeTabsTabTrayLandscape() {
@@ -122,55 +126,55 @@ class DragAndDropTests: IpadOnlyTestCase {
         XCUIDevice.shared.orientation = UIDeviceOrientation.landscapeLeft
         openTwoWebsites()
         navigator.goto(TabTray)
-        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite["tabName"]!, secondTab: secondWebsite["tabName"]!)
+        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite.tabName, secondTab: secondWebsite.tabName)
 
         // Rearrange the tabs via drag home tab and drop it on twitter tab
-        dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite["tabName"]!], dropOnElement: app.collectionViews.cells[secondWebsite["tabName"]!])
+        dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite.tabName], dropOnElement: app.collectionViews.cells[secondWebsite.tabName])
 
-        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite["tabName"]!, secondTab: firstWebsite["tabName"]!)
+        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName, secondTab: firstWebsite.tabName)
     }
 
     func testDragDropToInvalidArea() {
         if skipPlatform { return }
 
         openTwoWebsites()
-        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite["tabName"]!, secondTab: secondWebsite["tabName"]!)
+        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite.tabName, secondTab: secondWebsite.tabName)
         // Rearrange the tabs via drag home tab and drop it to the tabs button
-        dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite["tabName"]!], dropOnElement: app.buttons["TopTabsViewController.tabsButton"])
+        dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite.tabName], dropOnElement: app.buttons["TopTabsViewController.tabsButton"])
 
         // Check that the order of the tabs have not changed
-        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite["tabName"]!, secondTab: secondWebsite["tabName"]!)
+        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite.tabName, secondTab: secondWebsite.tabName)
         // Check that focus on the website does not change either
-        XCTAssertEqual(app.textFields["url"].value! as? String, "mobile.twitter.com/", "The tab has not been dropped correctly")
+        XCTAssert(secondWebsite.url.contains(app.textFields["url"].value! as! String), "The tab has not been dropped correctly")
     }
 
     func testDragAndDropHomeTab() {
         if skipPlatform { return }
 
         // Home tab is open and then a new website
-        navigator.openNewURL(urlString: secondWebsite["url"]!)
+        navigator.openNewURL(urlString: secondWebsite.url)
         waitUntilPageLoad()
         waitforExistence(app.collectionViews.cells.element(boundBy: 1))
-        checkTabsOrder(dragAndDropTab: false, firstTab: homeTab["tabName"]!, secondTab: secondWebsite["tabName"]!)
+        checkTabsOrder(dragAndDropTab: false, firstTab: homeTabName, secondTab: secondWebsite.tabName)
 
         // Drag and drop home tab from the second position to the first one
-        dragAndDrop(dragElement: app.collectionViews.cells["home"], dropOnElement: app.collectionViews.cells[secondWebsite["tabName"]!])
+        dragAndDrop(dragElement: app.collectionViews.cells["home"], dropOnElement: app.collectionViews.cells[secondWebsite.tabName])
 
-        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite["tabName"]! , secondTab: homeTab["tabName"]!)
+        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName , secondTab: homeTabName)
         // Check that focus is kept on last website open
-        XCTAssertEqual(app.textFields["url"].value! as? String, "mobile.twitter.com/", "The tab has not been dropped correctly")
+        XCTAssert(secondWebsite.url.contains(app.textFields["url"].value! as! String), "The tab has not been dropped correctly")
     }
 
     func testDragAndDropHomeTabTabsTray() {
-        navigator.openNewURL(urlString: secondWebsite["url"]!)
+        navigator.openNewURL(urlString: secondWebsite.url)
         waitUntilPageLoad()
         navigator.goto(TabTray)
-        checkTabsOrder(dragAndDropTab: false, firstTab: homeTab["tabName"]!, secondTab: secondWebsite["tabName"]!)
+        checkTabsOrder(dragAndDropTab: false, firstTab: homeTabName, secondTab: secondWebsite.tabName)
 
         // Drag and drop home tab from the first position to the second
-        dragAndDrop(dragElement: app.collectionViews.cells["home"], dropOnElement: app.collectionViews.cells[secondWebsite["tabName"]!])
+        dragAndDrop(dragElement: app.collectionViews.cells["home"], dropOnElement: app.collectionViews.cells[secondWebsite.tabName])
 
-        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite["tabName"]! , secondTab: homeTab["tabName"]!)
+        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName , secondTab: homeTabName)
     }
 
     func testRearrangeTabsPrivateMode() {
@@ -178,24 +182,24 @@ class DragAndDropTests: IpadOnlyTestCase {
 
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         openTwoWebsites()
-        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite["tabName"]!, secondTab: secondWebsite["tabName"]!)
+        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite.tabName, secondTab: secondWebsite.tabName)
         // Drag first tab on the second one
-        dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite["tabName"]!], dropOnElement: app.collectionViews.cells[secondWebsite["tabName"]!])
+        dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite.tabName], dropOnElement: app.collectionViews.cells[secondWebsite.tabName])
 
-        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite["tabName"]!, secondTab: firstWebsite["tabName"]!)
+        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName, secondTab: firstWebsite.tabName)
         // Check that focus is kept on last website open
-        XCTAssertEqual(app.textFields["url"].value! as? String, "mobile.twitter.com/", "The tab has not been dropped correctly")
+        XCTAssert(secondWebsite.url.contains(app.textFields["url"].value! as! String), "The tab has not been dropped correctly")
     }
 
     func testRearrangeTabsPrivateModeTabTray() {
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         openTwoWebsites()
         navigator.goto(TabTray)
-        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite["tabName"]!, secondTab: secondWebsite["tabName"]!)
+        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite.tabName, secondTab: secondWebsite.tabName)
         // Drag first tab on the second one
-        dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite["tabName"]!], dropOnElement: app.collectionViews.cells[secondWebsite["tabName"]!])
+        dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite.tabName], dropOnElement: app.collectionViews.cells[secondWebsite.tabName])
 
-        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite["tabName"]!, secondTab: firstWebsite["tabName"]!)
+        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName, secondTab: firstWebsite.tabName)
     }
 
     // This test drags the address bar and since it is not possible to drop it on another app, lets do it in a search box
@@ -205,26 +209,26 @@ class DragAndDropTests: IpadOnlyTestCase {
         navigator.openURL("developer.mozilla.org/en-US/search")
         waitUntilPageLoad()
         // Check the text in the search field before dragging and dropping the url text field
-        XCTAssertEqual(app.webViews.searchFields[websiteWithSearchField["urlSearchField"]!].placeholderValue, "Search the docs")
+        XCTAssertEqual(app.webViews.searchFields[websiteWithSearchField.urlSearchField].placeholderValue, "Search the docs")
         // DragAndDrop the url for only one second so that the TP menu is not shown and the search box is not covered
-        app.textFields["url"].press(forDuration: 1, thenDragTo: app.webViews.searchFields[websiteWithSearchField["urlSearchField"]!])
+        app.textFields["url"].press(forDuration: 1, thenDragTo: app.webViews.searchFields[websiteWithSearchField.urlSearchField])
         // Verify that the text in the search field is the same as the text in the url text field
-        XCTAssertEqual(app.webViews.searchFields[websiteWithSearchField["urlSearchField"]!].value as? String, websiteWithSearchField["url"]!)
+        XCTAssertEqual(app.webViews.searchFields[websiteWithSearchField.urlSearchField].value as? String, websiteWithSearchField.url)
     }
 
     //Test disabled due to a known crash Bug 1493175
     func testRearrangeTabsTabTrayIsKeptinTopTabs() {
         openTwoWebsites()
-        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite["tabName"]!, secondTab: secondWebsite["tabName"]!)
+        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite.tabName, secondTab: secondWebsite.tabName)
         navigator.goto(TabTray)
 
         // Drag first tab on the second one
-        dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite["tabName"]!], dropOnElement: app.collectionViews.cells[secondWebsite["tabName"]!])
-        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite["tabName"]!, secondTab: firstWebsite["tabName"]!)
+        dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite.tabName], dropOnElement: app.collectionViews.cells[secondWebsite.tabName])
+        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName, secondTab: firstWebsite.tabName)
 
         // Leave Tab Tray and check order in Top Tabs
-        app.collectionViews.cells[firstWebsite["tabName"]!].tap()
-        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite["tabName"]!, secondTab: firstWebsite["tabName"]!)
+        app.collectionViews.cells[firstWebsite.tabName].tap()
+        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName, secondTab: firstWebsite.tabName)
     }
  
     func testDragAndDropHistoryEntry() {
@@ -235,14 +239,14 @@ class DragAndDropTests: IpadOnlyTestCase {
         navigator.goto(HomePanel_History)
 
         let firstEntryOnList = app.tables["History List"].cells.element(boundBy:
-            5).staticTexts[exampleWebsite["tabName"]!]
-        let secondEntryOnList = app.tables["History List"].cells.element(boundBy: 2).staticTexts[secondWebsite["tabName"]!]
+            5).staticTexts[exampleDomainTitle]
+        let secondEntryOnList = app.tables["History List"].cells.element(boundBy: 2).staticTexts[twitterTitle]
 
         XCTAssertTrue(firstEntryOnList.exists, "first entry before is not correct")
         XCTAssertTrue(secondEntryOnList.exists, "second entry before is not correct")
 
         // Drag and Drop the element and check that the position of the two elements does not change
-        app.tables["History List"].cells.staticTexts[secondWebsite["tabName"]!].press(forDuration: 1, thenDragTo: app.tables["History List"].cells.staticTexts[exampleWebsite["tabName"]!])
+        app.tables["History List"].cells.staticTexts[twitterTitle].press(forDuration: 1, thenDragTo: app.tables["History List"].cells.staticTexts[exampleDomainTitle])
 
         XCTAssertTrue(firstEntryOnList.exists, "first entry after is not correct")
         XCTAssertTrue(secondEntryOnList.exists, "second entry after is not correct")
@@ -255,14 +259,14 @@ class DragAndDropTests: IpadOnlyTestCase {
         navigator.goto(HomePanel_Bookmarks)
         waitforExistence(app.tables["Bookmarks List"])
 
-        let firstEntryOnList = app.tables["Bookmarks List"].cells.element(boundBy: 0).staticTexts[exampleWebsite["tabName"]!]
-        let secondEntryOnList = app.tables["Bookmarks List"].cells.element(boundBy: 3).staticTexts[secondWebsite["tabName"]!]
+        let firstEntryOnList = app.tables["Bookmarks List"].cells.element(boundBy: 0).staticTexts[exampleDomainTitle]
+        let secondEntryOnList = app.tables["Bookmarks List"].cells.element(boundBy: 3).staticTexts[twitterTitle]
 
         XCTAssertTrue(firstEntryOnList.exists, "first entry after is not correct")
         XCTAssertTrue(secondEntryOnList.exists, "second entry after is not correct")
 
         // Drag and Drop the element and check that the position of the two elements does not change
-        app.tables["Bookmarks List"].cells.staticTexts[exampleWebsite["tabName"]!].press(forDuration: 1, thenDragTo: app.tables["Bookmarks List"].cells.staticTexts[secondWebsite["tabName"]!])
+        app.tables["Bookmarks List"].cells.staticTexts[exampleDomainTitle].press(forDuration: 1, thenDragTo: app.tables["Bookmarks List"].cells.staticTexts[twitterTitle])
 
         XCTAssertTrue(firstEntryOnList.exists, "first entry after is not correct")
         XCTAssertTrue(secondEntryOnList.exists, "second entry after is not correct")
@@ -272,9 +276,9 @@ class DragAndDropTests: IpadOnlyTestCase {
         if skipPlatform { return }
 
         navigator.goto(HomePanel_History)
-        waitforExistence(app.tables["History List"].cells.staticTexts[secondWebsite["tabName"]!])
+        waitforExistence(app.tables["History List"].cells.staticTexts[twitterTitle])
 
-        app.tables["History List"].cells.staticTexts[secondWebsite["tabName"]!].press(forDuration: 1, thenDragTo: app.textFields["url"])
+        app.tables["History List"].cells.staticTexts[twitterTitle].press(forDuration: 1, thenDragTo: app.textFields["url"])
 
         // It is not allowed to drop the entry on the url field
         let urlBarValue = app.textFields["url"].value as? String
@@ -286,7 +290,7 @@ class DragAndDropTests: IpadOnlyTestCase {
 
         navigator.goto(HomePanel_Bookmarks)
         waitforExistence(app.tables["Bookmarks List"])
-        app.tables["Bookmarks List"].cells.staticTexts[secondWebsite["tabName"]!].press(forDuration: 1, thenDragTo: app.textFields["url"])
+        app.tables["Bookmarks List"].cells.staticTexts[twitterTitle].press(forDuration: 1, thenDragTo: app.textFields["url"])
 
         // It is not allowed to drop the entry on the url field
         let urlBarValue = app.textFields["url"].value as? String

--- a/XCUITests/DragAndDropTests.swift
+++ b/XCUITests/DragAndDropTests.swift
@@ -87,7 +87,7 @@ class DragAndDropTests: IpadOnlyTestCase {
         XCTAssertEqual(app.textFields["url"].value! as? String, "mobile.twitter.com/", "The tab has not been dropped correctly")
     }
     // Tests disabled because the feature is off for master and 14.x
-    /*func testRearrangeTabsTabTray() {
+    func testRearrangeTabsTabTray() {
         openTwoWebsites()
         navigator.goto(TabTray)
         checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite["tabName"]!, secondTab: secondWebsite["tabName"]!)
@@ -128,7 +128,7 @@ class DragAndDropTests: IpadOnlyTestCase {
         dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite["tabName"]!], dropOnElement: app.collectionViews.cells[secondWebsite["tabName"]!])
 
         checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite["tabName"]!, secondTab: firstWebsite["tabName"]!)
-    }*/
+    }
 
     func testDragDropToInvalidArea() {
         if skipPlatform { return }
@@ -161,7 +161,7 @@ class DragAndDropTests: IpadOnlyTestCase {
         XCTAssertEqual(app.textFields["url"].value! as? String, "mobile.twitter.com/", "The tab has not been dropped correctly")
     }
 
-    /*func testDragAndDropHomeTabTabsTray() {
+    func testDragAndDropHomeTabTabsTray() {
         navigator.openNewURL(urlString: secondWebsite["url"]!)
         waitUntilPageLoad()
         navigator.goto(TabTray)
@@ -171,7 +171,7 @@ class DragAndDropTests: IpadOnlyTestCase {
         dragAndDrop(dragElement: app.collectionViews.cells["home"], dropOnElement: app.collectionViews.cells[secondWebsite["tabName"]!])
 
         checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite["tabName"]! , secondTab: homeTab["tabName"]!)
-    }*/
+    }
 
     func testRearrangeTabsPrivateMode() {
         if skipPlatform { return }
@@ -187,7 +187,7 @@ class DragAndDropTests: IpadOnlyTestCase {
         XCTAssertEqual(app.textFields["url"].value! as? String, "mobile.twitter.com/", "The tab has not been dropped correctly")
     }
 
-    /*func testRearrangeTabsPrivateModeTabTray() {
+    func testRearrangeTabsPrivateModeTabTray() {
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         openTwoWebsites()
         navigator.goto(TabTray)
@@ -196,7 +196,7 @@ class DragAndDropTests: IpadOnlyTestCase {
         dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite["tabName"]!], dropOnElement: app.collectionViews.cells[secondWebsite["tabName"]!])
 
         checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite["tabName"]!, secondTab: firstWebsite["tabName"]!)
-    }*/
+    }
 
     // This test drags the address bar and since it is not possible to drop it on another app, lets do it in a search box
     func testDragAddressBarIntoSearchBox() {
@@ -212,7 +212,7 @@ class DragAndDropTests: IpadOnlyTestCase {
         XCTAssertEqual(app.webViews.searchFields[websiteWithSearchField["urlSearchField"]!].value as? String, websiteWithSearchField["url"]!)
     }
 
-    /* Test disabled due to a known crash Bug 1493175
+    //Test disabled due to a known crash Bug 1493175
     func testRearrangeTabsTabTrayIsKeptinTopTabs() {
         openTwoWebsites()
         checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite["tabName"]!, secondTab: secondWebsite["tabName"]!)
@@ -225,7 +225,7 @@ class DragAndDropTests: IpadOnlyTestCase {
         // Leave Tab Tray and check order in Top Tabs
         app.collectionViews.cells[firstWebsite["tabName"]!].tap()
         checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite["tabName"]!, secondTab: firstWebsite["tabName"]!)
-    }*/
+    }
  
     func testDragAndDropHistoryEntry() {
         if skipPlatform { return }


### PR DESCRIPTION
- remove all state management in TDM
- weakify all self in closures
- private mode toggling logic consolidated into TDM
- drag-to-reorder operations are cancelled on *any* TabManager tab event (add, remove, select); deciding to impose this restriction was critical to the design of this code; without this restriction, the code will be more complicated and risky.

Uncertainties:
- with text in the search field and toggling private mode, I kept the search text and the search will be performed in the current mode, alternatively, the mode change could clear the search text
- if I can get a list of edge cases that the original code was designed to handle I'll write the tests to ensure this code also handles that.

All tests are enabled and passing locally. 