### PR TITLE
Bug 1498249 - XCUITest fix routing issues from BrowserTab

### DIFF
--- a/XCUITests/BaseTestCase.swift
+++ b/XCUITests/BaseTestCase.swift
@@ -120,6 +120,14 @@ class BaseTestCase: XCTestCase {
 
         waitforNoExistence(progressIndicator, timeoutValue: 20.0)
     }
+
+    func waitForTabsButton() {
+        if iPad() {
+        waitforExistence(app.buttons["TopTabsViewController.tabsButton"])
+        } else {
+        waitforExistence(app.buttons["TabToolbar.tabsButton"])
+        }
+    }
 }
 
 class IpadOnlyTestCase: BaseTestCase {

--- a/XCUITests/BookmarkingTests.swift
+++ b/XCUITests/BookmarkingTests.swift
@@ -48,18 +48,21 @@ class BookmarkingTests: BaseTestCase {
         // Go to a webpage, and add to bookmarks, check it's added
         navigator.openURL(path(forTestPage: url_1))
         navigator.nowAt(BrowserTab)
+        waitForTabsButton()
         bookmark()
         checkBookmarked()
 
         // Load a different page on a new tab, check it's not bookmarked
         navigator.openNewURL(urlString: path(forTestPage: url_2["url"]!))
         navigator.nowAt(BrowserTab)
+        waitForTabsButton()
         checkUnbookmarked()
 
         // Go back, check it's still bookmarked, check it's on bookmarks home panel
         navigator.goto(TabTray)
         app.collectionViews.cells["Example Domain"].tap()
         navigator.nowAt(BrowserTab)
+        waitForTabsButton()
         checkBookmarked()
 
         // Open it, then unbookmark it, and check it's no longer on bookmarks home panel

--- a/XCUITests/HistoryTests.swift
+++ b/XCUITests/HistoryTests.swift
@@ -77,6 +77,7 @@ class HistoryTests: BaseTestCase {
         // Now go back to default website close it and check whether the option is enabled
         navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
         waitUntilPageLoad()
+        waitForTabsButton()
         navigator.goto(TabTray)
         navigator.performAction(Action.AcceptRemovingAllTabs)
         navigator.nowAt(NewTabScreen)
@@ -100,6 +101,7 @@ class HistoryTests: BaseTestCase {
         // Open the default website
         userState.url = path(forTestPage: "test-mozilla-book.html")
         navigator.goto(BrowserTab)
+        waitForTabsButton()
         navigator.goto(TabTray)
         navigator.performAction(Action.AcceptRemovingAllTabs)
         navigator.nowAt(NewTabScreen)
@@ -121,6 +123,7 @@ class HistoryTests: BaseTestCase {
         // Open the default website
         userState.url = path(forTestPage: "test-mozilla-book.html")
         navigator.goto(BrowserTab)
+        waitForTabsButton()
         navigator.goto(TabTray)
         navigator.performAction(Action.AcceptRemovingAllTabs)
         navigator.nowAt(NewTabScreen)
@@ -138,6 +141,7 @@ class HistoryTests: BaseTestCase {
         // Open the default website
         userState.url = path(forTestPage: "test-mozilla-book.html")
         navigator.goto(BrowserTab)
+        waitForTabsButton()
         navigator.goto(TabTray)
         navigator.performAction(Action.AcceptRemovingAllTabs)
         navigator.nowAt(NewTabScreen)
@@ -158,6 +162,7 @@ class HistoryTests: BaseTestCase {
         // Open the default website
         userState.url = path(forTestPage: "test-mozilla-book.html")
         navigator.goto(BrowserTab)
+        waitForTabsButton()
         navigator.goto(TabTray)
         navigator.performAction(Action.AcceptRemovingAllTabs)
         navigator.nowAt(NewTabScreen)
@@ -183,6 +188,7 @@ class HistoryTests: BaseTestCase {
         // It is necessary to open two sites so that when one is closed private mode is not closed
         navigator.openNewURL(urlString: path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
+        waitForTabsButton()
         navigator.goto(TabTray)
         waitforExistence(app.collectionViews.cells[webpage["label"]!])
         // 'x' button to close the tab is not visible, so closing by swiping the tab

--- a/XCUITests/HomePageSettingsUITest.swift
+++ b/XCUITests/HomePageSettingsUITest.swift
@@ -51,6 +51,7 @@ class HomePageSettingsUITests: BaseTestCase {
         // There is no option to go to Home, instead the website open has the option to be set as HomePageSettings
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
+        waitForTabsButton()
         navigator.goto(BrowserTabMenu)
         let homePageMenuItem = app.tables["Context Menu"].cells["Open Homepage"]
         XCTAssertFalse(homePageMenuItem.exists)

--- a/XCUITests/PrivateBrowsingTest.swift
+++ b/XCUITests/PrivateBrowsingTest.swift
@@ -90,6 +90,7 @@ class PrivateBrowsingTest: BaseTestCase {
         //  Open a Private tab
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
+        waitForTabsButton()
 
         // Go back to regular browser
         navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
@@ -106,6 +107,7 @@ class PrivateBrowsingTest: BaseTestCase {
         navigator.goto(SettingsScreen)
         closePrivateTabsSwitch.tap()
         navigator.goto(BrowserTab)
+        waitForTabsButton()
 
         // Go back to regular browsing and check that the private tab has been closed and that the initial Private Browsing message appears when going back to Private Browsing
         navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
@@ -124,7 +126,7 @@ class PrivateBrowsingTest: BaseTestCase {
         app.webViews.links.staticTexts["More information..."].press(forDuration: 3)
         app.buttons["Open in New Private Tab"].tap()
         waitUntilPageLoad()
-
+        waitForTabsButton()
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
         // Check there is one tab
@@ -148,6 +150,7 @@ class PrivateBrowsingTest: BaseTestCase {
 
         //Wait until the page loads and go to regular browser
         waitUntilPageLoad()
+        waitForTabsButton()
         navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
         // Go back to private browsing
@@ -188,6 +191,7 @@ class PrivateBrowsingTestIpad: IpadOnlyTestCase {
     // This test is only enabled for iPad. Shortcut does not exists on iPhone
     func testClosePrivateTabsOptionClosesPrivateTabsShortCutiPad() {
         if skipPlatform { return }
+        waitForTabsButton()
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         enableClosePrivateBrowsingOptionWhenLeaving()
@@ -200,6 +204,7 @@ class PrivateBrowsingTestIpad: IpadOnlyTestCase {
 
     func testiPadDirectAccessPrivateMode() {
         if skipPlatform { return }
+        waitForTabsButton()
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateModeFromTabBarHomePanel)
 
         // A Tab opens directly in HomePanels view
@@ -221,6 +226,7 @@ class PrivateBrowsingTestIpad: IpadOnlyTestCase {
     func testiPadDirectAccessPrivateModeBrowserTab() {
         if skipPlatform { return }
         navigator.openURL("www.mozilla.org")
+        waitForTabsButton()
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateModeFromTabBarBrowserTab)
 
         // A Tab opens directly in HomePanels view

--- a/XCUITests/TabTraySearchTabsTests.swift
+++ b/XCUITests/TabTraySearchTabsTests.swift
@@ -11,6 +11,7 @@ class TabTraySearchTabsTests: BaseTestCase {
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
         navigator.openNewURL(urlString: secondURL )
+        waitForTabsButton()
         navigator.goto(TabTray)
 
         // Search no matches
@@ -59,10 +60,12 @@ class TabTraySearchTabsTests: BaseTestCase {
 
     func testSearchFieldClearedAfterVisingWebsite() {
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
+        waitForTabsButton()
         navigator.goto(TabTray)
         searchTabs(tabTitleOrUrl: "mozilla")
         app.collectionViews.cells["Internet for people, not profit — Mozilla"].tap()
         navigator.nowAt(BrowserTab)
+        waitForTabsButton()
         navigator.goto(TabTray)
         let searchValue = app.textFields["Search Tabs"].value
         XCTAssertEqual(searchValue as! String, "Search Tabs")

--- a/XCUITests/ToolbarTest.swift
+++ b/XCUITests/ToolbarTest.swift
@@ -58,6 +58,7 @@ class ToolbarTests: BaseTestCase {
         XCTAssertTrue(app.buttons["Forward"].isEnabled)
 
         // Open new tab and then go back to previous tab to test navigation buttons.
+        waitForTabsButton()
         navigator.goto(TabTray)
         waitforExistence(app.collectionViews.cells[website1["label"]!])
         app.collectionViews.cells[website1["label"]!].tap()

--- a/XCUITests/TopTabsTest.swift
+++ b/XCUITests/TopTabsTest.swift
@@ -16,6 +16,7 @@ let toastUrl = ["url": "twitter.com", "link": "About", "urlLabel": "about"]
 
 class TopTabsTest: BaseTestCase {
     func testAddTabFromTabTray() {
+        waitForTabsButton()
         navigator.goto(TabTray)
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
@@ -57,8 +58,10 @@ class TopTabsTest: BaseTestCase {
     func testSwitchBetweenTabs() {
         // Open two urls from tab tray and switch between them
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
+        waitForTabsButton()
         navigator.goto(TabTray)
         navigator.openURL(urlExample)
+        waitForTabsButton()
         navigator.goto(TabTray)
 
         waitforExistence(app.collectionViews.cells[urlLabel])
@@ -66,6 +69,7 @@ class TopTabsTest: BaseTestCase {
         waitForValueContains(app.textFields["url"], value: "localhost")
 
         navigator.nowAt(BrowserTab)
+        waitForTabsButton()
         navigator.goto(TabTray)
 
         waitforExistence(app.collectionViews.cells[urlLabelExample])
@@ -76,6 +80,7 @@ class TopTabsTest: BaseTestCase {
     func testCloseOneTab() {
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
+        waitForTabsButton()
         navigator.goto(TabTray)
 
         waitforExistence(app.collectionViews.cells[urlLabel])
@@ -99,6 +104,7 @@ class TopTabsTest: BaseTestCase {
         // A different tab than home is open to do the proper checks
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
+        waitForTabsButton()
         navigator.nowAt(BrowserTab)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         if !iPad() {
@@ -123,6 +129,7 @@ class TopTabsTest: BaseTestCase {
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
+        waitForTabsButton()
         openNtabsFromTabTray(numTabs: 1)
         waitforExistence(app.buttons["TabToolbar.tabsButton"], timeout: 3)
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
@@ -138,6 +145,7 @@ class TopTabsTest: BaseTestCase {
         // A different tab than home is open to do the proper checks
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
+        waitForTabsButton()
         // Add several tabs from tab tray menu and check that the  number is correct before closing all
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.nowAt(NewTabScreen)
@@ -161,12 +169,11 @@ class TopTabsTest: BaseTestCase {
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
+        waitForTabsButton()
         // Add several tabs from tab tray menu and check that the  number is correct before closing all
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.nowAt(NewTabScreen)
-        if !iPad() {
-            waitforExistence(app.buttons["TabToolbar.tabsButton"])
-        }
+        waitForTabsButton()
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
 
         // Close all tabs and check that the number of tabs is correct
@@ -204,6 +211,7 @@ class TopTabsTest: BaseTestCase {
 
             // Open New Tab
             app.cells["quick_action_new_tab"].tap()
+            waitForTabsButton()
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
             app.collectionViews.cells["home"].firstMatch.tap()
 
@@ -244,28 +252,23 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
 
     func testCloseTabFromLongPressTabsButton() {
         if skipPlatform { return }
+        waitForTabsButton()
         // This menu is available in HomeScreen or NewTabScreen, so no need to open new websites
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.nowAt(NewTabScreen)
-        if !iPad() {
-            waitforExistence(app.buttons["TabToolbar.tabsButton"])
-        }
+        waitForTabsButton()
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
         closeTabTrayView(goBackToBrowserTab: "home")
 
         navigator.performAction(Action.CloseTabFromTabTrayLongPressMenu)
         navigator.nowAt(NewTabScreen)
-        if !iPad() {
-            waitforExistence(app.buttons["TabToolbar.tabsButton"])
-        }
+        waitForTabsButton()
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
         closeTabTrayView(goBackToBrowserTab: "home")
 
         navigator.performAction(Action.CloseTabFromTabTrayLongPressMenu)
         navigator.nowAt(NewTabScreen)
-        if !iPad() {
-            waitforExistence(app.buttons["TabToolbar.tabsButton"])
-        }
+        waitForTabsButton()
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
         closeTabTrayView(goBackToBrowserTab: "home")
     }
@@ -273,6 +276,7 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
     // This test only runs for iPhone see bug 1409750
     func testAddTabByLongPressTabsButton() {
         if skipPlatform { return }
+        waitForTabsButton()
         navigator.performAction(Action.OpenNewTabLongPressTabsButton)
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
     }
@@ -280,6 +284,7 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
     // This test only runs for iPhone see bug 1409750
     func testAddPrivateTabByLongPressTabsButton() {
         if skipPlatform { return }
+        waitForTabsButton()
         navigator.performAction(Action.OpenPrivateTabLongPressTabsButton)
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
         waitforExistence(app.buttons["TabTrayController.maskButton"])


### PR DESCRIPTION
Since iOS 12 and xcode 10 some transitions are faster than before and so the routing from BrowserTab to TabTray or to BrowserTabMenu fails intermittently when during the test it tries to tap on tabs button. 
This PR adds a method to wait for that button to be available before trying to tap on it.