### PR TITLE
Bug 1499887 - Remove TabManager mimetype detection because we dont need to detect PDFs anymore.

### DIFF
--- a/Client/Frontend/Browser/TabManagerStore.swift
+++ b/Client/Frontend/Browser/TabManagerStore.swift
@@ -120,7 +120,7 @@ class TabManagerStore {
         return selectedTab
     }
 
-    func restoreTabs(savedTabs: [SavedTab], clearPrivateTabs: Bool, tabManager: TabManager) -> Tab? {
+    @discardableResult func restoreTabs(savedTabs: [SavedTab], clearPrivateTabs: Bool, tabManager: TabManager) -> Tab? {
         assertIsMainThread("Restoration is a main-only operation")
         guard !lockedForReading, savedTabs.count > 0 else { return nil }
         lockedForReading = true

--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -31,11 +31,6 @@ class TabScrollingController: NSObject {
         }
     }
 
-    // Constraint-based animation is causing PDF docs to flicker. This is used to bypass this animation.
-    var isTabShowingPDF: Bool {
-        return (tab?.mimeType ?? "") == MIMEType.PDF
-    }
-
     weak var header: UIView?
     weak var footer: UIView?
     weak var urlBar: URLBarView?
@@ -190,7 +185,7 @@ private extension TabScrollingController {
             if checkRubberbandingForDelta(delta) && checkScrollHeightIsLargeEnoughForScrolling() {
                 let bottomIsNotRubberbanding = contentOffset.y + scrollViewHeight < contentSize.height
                 let topIsRubberbanding = contentOffset.y <= 0
-                if isTabShowingPDF || ((toolbarState != .collapsed || topIsRubberbanding) && bottomIsNotRubberbanding) {
+                if (toolbarState != .collapsed || topIsRubberbanding) && bottomIsNotRubberbanding {
                     scrollWithDelta(delta)
                 }
 
@@ -295,9 +290,9 @@ extension TabScrollingController: UIScrollViewDelegate {
 
         if (decelerate || (toolbarState == .animating && !decelerate)) && checkScrollHeightIsLargeEnoughForScrolling() {
             if scrollDirection == .up {
-                showToolbars(animated: !isTabShowingPDF)
+                showToolbars(animated: true)
             } else if scrollDirection == .down {
-                hideToolbars(animated: !isTabShowingPDF)
+                hideToolbars(animated: true)
             }
         }
     }


### PR DESCRIPTION
We used to have a openIn toolbar that would appear when viewing a PDF. With the addition of the download manager and better file handling we no longer show this dedicated toolbar. 

Without the toolbar the show/hide animation of the toolbars no longer causes flickers. Remove our workaround from https://bugzilla.mozilla.org/show_bug.cgi?id=1385845

I've also cleaned up a few other lines. Fixing indentation and simplifying some loops.