### PR TITLE
 Bug 1488841 - XCUITests: Data Management

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -285,6 +285,7 @@
 		5002717C41BC7C50F67F1CAD /* StateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50027345B49B967409DDA348 /* StateTests.swift */; };
 		554867231DC3935A00183DAA /* HomePageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 554867221DC3935A00183DAA /* HomePageTests.swift */; };
 		55A747171DC46FC400CE1B57 /* HomePageUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A747161DC46FC400CE1B57 /* HomePageUITest.swift */; };
+		580B0C4221748CFE00448DF8 /* DataManagementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580B0C4121748CFE00448DF8 /* DataManagementTests.swift */; };
 		59A681BDFC95A19F05E07223 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A68CCB63E2A565CB03F832 /* SearchViewController.swift */; };
 		59A68B280D62462B85CF57A4 /* HistoryPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A6825233896FC846499289 /* HistoryPanel.swift */; };
 		59A68D66379CFA85C4EAF00B /* TwoLineCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A68B1F857A8638598A63A0 /* TwoLineCell.swift */; };
@@ -1453,6 +1454,7 @@
 		50027345B49B967409DDA348 /* StateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StateTests.swift; path = SyncTests/StateTests.swift; sourceTree = "<group>"; };
 		554867221DC3935A00183DAA /* HomePageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomePageTests.swift; sourceTree = "<group>"; };
 		55A747161DC46FC400CE1B57 /* HomePageUITest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomePageUITest.swift; sourceTree = "<group>"; };
+		580B0C4121748CFE00448DF8 /* DataManagementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManagementTests.swift; sourceTree = "<group>"; };
 		59A6825233896FC846499289 /* HistoryPanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = HistoryPanel.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		59A6839879D615FC1C0D71CE /* BookmarksPanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksPanel.swift; sourceTree = "<group>"; };
 		59A685F4EAD19EDEC854BCA4 /* ReaderPanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderPanel.swift; sourceTree = "<group>"; };
@@ -2658,6 +2660,7 @@
 				3BF4B8DA1D38493300493393 /* Utils */,
 				EB7A651020699BD200B52A5F /* WebPagesForTesting.swift */,
 				0B9D40781E8D5AC80059E664 /* XCUITests-Bridging-Header.h */,
+				580B0C4121748CFE00448DF8 /* DataManagementTests.swift */,
 			);
 			path = XCUITests;
 			sourceTree = "<group>";
@@ -4954,6 +4957,7 @@
 				2CF449A51E7BFE2C00FD7595 /* NavigationTest.swift in Sources */,
 				2C32EA442100C4BF00A25912 /* TabTraySearchTabsTests.swift in Sources */,
 				2C2A91291FA2410D002E36BD /* HistoryTests.swift in Sources */,
+				580B0C4221748CFE00448DF8 /* DataManagementTests.swift in Sources */,
 				3BF4B8E91D38497A00493393 /* BaseTestCase.swift in Sources */,
 				3D9CAA1C1EFCD655002434DD /* ClipBoardTests.swift in Sources */,
 				2CB1A65A1FDEA8B60084E96D /* NewTabSettings.swift in Sources */,

--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_SmokeXCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_SmokeXCUITests.xcscheme
@@ -299,6 +299,9 @@
                   Identifier = "CopiedLinksTests">
                </Test>
                <Test
+                  Identifier = "DataManagementTests">
+               </Test>
+               <Test
                   Identifier = "DatabaseFixtureTest">
                </Test>
                <Test

--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests_Integration.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests_Integration.xcscheme
@@ -215,6 +215,9 @@
                   Identifier = "CopiedLinksTests">
                </Test>
                <Test
+                  Identifier = "DataManagementTests">
+               </Test>
+               <Test
                   Identifier = "DatabaseFixtureTest">
                </Test>
                <Test

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -77,6 +77,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
         if indexPath.section == SectionArrow {
             cell.accessoryType = .disclosureIndicator
             cell.textLabel?.text = Strings.SettingsWebsiteDataTitle
+            cell.accessibilityIdentifier = "WebsiteData"
             clearButton = cell
         } else if indexPath.section == SectionToggles {
             cell.textLabel?.text = clearables[indexPath.item].clearable.label

--- a/XCUITests/DataManagementTests.swift
+++ b/XCUITests/DataManagementTests.swift
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import XCTest
+
+class DataManagementTests: BaseTestCase {
+
+    //Testing the entries are correctly added and deleted. This a termporary behaviour. This test will be changed after releasing Firefox 15.x and Bug 1499074 will be fixed.
+    func testWebSiteDataEnterFirstTime() {
+        navigator.goto(WebsiteDataSettings)
+        let expectedWebsiteDataEntries = app.tables.cells.count
+        XCTAssertEqual(expectedWebsiteDataEntries, 2)
+        navigator.performAction(Action.AcceptClearAllWebsiteData)
+        let expectedWebsiteDataEntries2 = app.tables.cells.count
+        XCTAssertEqual(expectedWebsiteDataEntries2, 1)
+        navigator.createNewTab()
+        navigator.goto(WebsiteDataSettings)
+        let expectedWebsiteDataEntries3 = app.tables.cells.count
+        XCTAssertEqual(expectedWebsiteDataEntries3, 2)
+    }
+    
+    // Testing the search bar, search results and 'Show More' option.
+    func testWebSiteDataOptions() {
+        // Visiting some websites to create Website Data needed to reveal the "Show More" button
+        let websitesList = ["www.facebook.com", "www.youtube.com", "www.twitter.com", "www.google.com", "www.facebook.com", "www.mozilla.org"]
+        for website in websitesList {
+            navigator.openURL(website)
+        }
+        navigator.goto(WebsiteDataSettings)
+        navigator.performAction(Action.TapOnFilterWebsites)
+        app.typeText("youtube")
+        waitforExistence(app.tables["Search results"])
+        let expectedSearchResults = app.tables["Search results"].cells.count
+        XCTAssertEqual(expectedSearchResults, 1)
+        navigator.performAction(Action.TapOnFilterWebsites)
+        app.typeText("foo")
+        let expectedNoSearchResults = app.tables["Search results"].cells.count
+        XCTAssertEqual(expectedNoSearchResults, 0)
+        app.buttons["Cancel"].tap()
+        navigator.performAction(Action.ShowMoreWebsiteDataEntries)
+        let expectedShowMoreWebsites = app.tables.cells.count
+        XCTAssertNotEqual(expectedShowMoreWebsites, 9)
+        navigator.performAction(Action.AcceptClearAllWebsiteData)
+        waitforExistence(app.tables.cells["ClearAllWebsiteData"])
+        let expectedWebsitesCleared = app.tables.cells.count
+        XCTAssertEqual(expectedWebsitesCleared, 1)
+    }
+}

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -30,6 +30,8 @@ let PasscodeIntervalSettings = "PasscodeIntervalSettings"
 let SearchSettings = "SearchSettings"
 let NewTabSettings = "NewTabSettings"
 let ClearPrivateDataSettings = "ClearPrivateDataSettings"
+let WebsiteDataSettings = "WebsiteDataSettings"
+let WebsiteSearchDataSettings = "WebsiteSearchDataSettings"
 let LoginsSettings = "LoginsSettings"
 let OpenWithSettings = "OpenWithSettings"
 let ShowTourInSettings = "ShowTourInSettings"
@@ -152,6 +154,9 @@ class Action {
     static let SelectNewTabAsHistoryPage = "SelectNewTabAsHistoryPage"
 
     static let AcceptClearPrivateData = "AcceptClearPrivateData"
+    static let AcceptClearAllWebsiteData = "AcceptClearAllWebsiteData"
+    static let TapOnFilterWebsites = "TapOnFilterWebsites"
+    static let ShowMoreWebsiteDataEntries = "ShowMoreWebsiteDataEntries"
 
     static let ToggleTrackingProtectionPerTabEnabled = "ToggleTrackingProtectionPerTabEnabled"
     static let ToggleTrackingProtectionSettingOnNormalMode = "ToggleTrackingProtectionSettingAlwaysOn"
@@ -542,6 +547,22 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.backAction = navigationControllerBackAction
     }
 
+    map.addScreenState(WebsiteDataSettings) { screenState in
+        screenState.gesture(forAction: Action.AcceptClearAllWebsiteData) { userState in
+            app.tables.cells["ClearAllWebsiteData"].tap()
+            app.alerts.buttons["OK"].tap()
+        }
+        // The swipeDown() is a workaround for an intermitent issue that the search filed is not always in view.
+        screenState.gesture(forAction: Action.TapOnFilterWebsites) { userState in
+            app.swipeDown()
+            app.searchFields["Filter Sites"].tap()
+        }
+        screenState.gesture(forAction: Action.ShowMoreWebsiteDataEntries) { userState in
+            app.tables.cells["ShowMoreWebsiteData"].tap()
+        }
+        screenState.backAction = navigationControllerBackAction
+    }
+    
     map.addScreenState(NewTabSettings) { screenState in
         let table = app.tables.element(boundBy: 0)
 
@@ -666,6 +687,8 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     map.addScreenState(ClearPrivateDataSettings) { screenState in
+        let table = app.tables.element(boundBy: 0)
+        screenState.tap(app.cells["WebsiteData"], to: WebsiteDataSettings)
         screenState.gesture(forAction: Action.AcceptClearPrivateData) { userState in
             app.tables.cells["ClearPrivateData"].tap()
             app.alerts.buttons["OK"].tap()


### PR DESCRIPTION
Tests to Data Management:

1- testWebSiteDataEnterFirstTime()
- Enter in the Website Data menu, check that there are is one entry
- Tap on Clear all website data
- Check if there are no etries
- Open a new tab
- Go back to the menu and check that there is one entry


2- testWebSiteDataOptions()
- Browse to four sites to have some Website Data 
- Open Website Data menu and type on the search bar
    - check entries match
- Tap on Show more
    - check to see if more than 8 entries are displayed

Forgot about : 
- Tap on Clear all website data
    - check that no entries are shown