### PR TITLE
Bug 1500857 - XCUITest TopSites selection

### DIFF
--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -92,6 +92,7 @@ class ActivityStreamTest: BaseTestCase {
         }
 
         let numberOfTopSites = TopSiteCellgroup.cells.matching(identifier: "TopSite").count
+        waitforNoExistence(TopSiteCellgroup.cells["TopSite"])
         XCTAssertEqual(numberOfTopSites, 0, "All top sites should have been removed")
 
         // Open a new page and wait for the completion
@@ -149,12 +150,13 @@ class ActivityStreamTest: BaseTestCase {
         XCTAssertTrue(topSiteFirstCell == allDefaultTopSites[0])
         XCTAssertTrue(topSiteSecondCell == allDefaultTopSites[1])
 
-        // Remove it
-        waitforExistence(app.cells["facebook"])
-        app.cells["facebook"].press(forDuration: 1)
+        // Remove facebook top sites, first cell
+        waitforExistence(app.cells["TopSitesCell"].cells.element(boundBy: 0), timeout: 3)
+        app.cells["TopSitesCell"].cells.element(boundBy: 0).press(forDuration:1)
         selectOptionFromContextMenu(option: "Remove")
 
         // Check top site in first cell now
+        waitforExistence(app.collectionViews.cells.collectionViews.cells.element(boundBy: 0))
         let topSiteCells = TopSiteCellgroup.cells
         let topSiteFirstCellAfter = app.collectionViews.cells.collectionViews.cells.element(boundBy: 0).label
         XCTAssertTrue(topSiteFirstCellAfter == topSiteCells["youtube"].label, "First top site does not match")
@@ -180,7 +182,8 @@ class ActivityStreamTest: BaseTestCase {
     // Smoketest
     func testTopSitesOpenInNewTabDefaultTopSite() {
         // Open one of the sites from Topsites and wait until page is loaded
-        app.cells[defaultTopSite["topSiteLabel"]!].press(forDuration: 1)
+        waitforExistence(app.cells["TopSitesCell"].cells.element(boundBy: 3), timeout: 3)
+        app.cells["TopSitesCell"].cells.element(boundBy: 3).press(forDuration:1)
         selectOptionFromContextMenu(option: "Open in New Tab")
         waitUntilPageLoad()
 
@@ -194,8 +197,9 @@ class ActivityStreamTest: BaseTestCase {
     // Smoketest
     func testTopSitesOpenInNewPrivateTab() {
         navigator.goto(HomePanelsScreen)
-        waitforExistence(app.cells["apple"])
-        app.collectionViews.cells["TopSitesCell"].cells["apple"].press(forDuration: 1)
+        // Long tap on apple top site, second cell
+        waitforExistence(app.cells["TopSitesCell"].cells.element(boundBy: 2), timeout: 3)
+        app.cells["TopSitesCell"].cells.element(boundBy: 2).press(forDuration:1)
         app.tables["Context Menu"].cells["Open in New Private Tab"].tap()
 
         XCTAssert(TopSiteCellgroup.exists)
@@ -222,8 +226,9 @@ class ActivityStreamTest: BaseTestCase {
     // Smoketest
     func testTopSitesOpenInNewPrivateTabDefaultTopSite() {
         // Open one of the sites from Topsites and wait until page is loaded
-        TopSiteCellgroup.cells[defaultTopSite["topSiteLabel"]!]
-            .press(forDuration: 1)
+        // Long tap on apple top site, second cell
+        waitforExistence(app.cells["TopSitesCell"].cells.element(boundBy: 3), timeout: 3)
+        app.cells["TopSitesCell"].cells.element(boundBy: 3).press(forDuration:1)
         selectOptionFromContextMenu(option: "Open in New Private Tab")
 
         // Check that two tabs are open and one of them is the default top site one
@@ -235,8 +240,9 @@ class ActivityStreamTest: BaseTestCase {
     }
 
     func testTopSitesBookmarkDefaultTopSite() {
-        // Bookmark a default TopSite
-        app.cells[defaultTopSite["topSiteLabel"]!].press(forDuration: 1)
+        // Bookmark a default TopSite, Wikipedia, third top site
+        waitforExistence(app.cells["TopSitesCell"].cells.element(boundBy: 3), timeout: 3)
+        app.cells["TopSitesCell"].cells.element(boundBy: 3).press(forDuration:1)
         selectOptionFromContextMenu(option: "Bookmark")
 
         // Check that it appears under Bookmarks menu
@@ -314,17 +320,17 @@ class ActivityStreamTest: BaseTestCase {
     }
 
     func testOpenTopSitesFromContextMenu () {
-         // Top Sites is shown by default
-         waitforExistence(app.cells["TopSitesCell"])
-         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
+        // Top Sites is shown by default
+        waitforExistence(app.cells["TopSitesCell"])
+        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
 
-         // Go to a website
-         navigator.openURL("example.com")
-         waitUntilPageLoad()
+        // Go to a website
+        navigator.openURL("example.com")
+        waitUntilPageLoad()
 
-         // Go back to Top Sites from context menu
-         navigator.browserPerformAction(.openTopSitesOption)
-         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
+        // Go back to Top Sites from context menu
+        navigator.browserPerformAction(.openTopSitesOption)
+        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
     }
 
     func testActivityStreamPages() {


### PR DESCRIPTION
To avoid issues when selecting a top site that sometimes happens randomly although the name is specified, lets try to use the cell number instead