### PR TITLE
Bug 1497432 - Nonfunctional "Delete" button available for the synced desktop bookmarks

### DIFF
--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -376,6 +376,13 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         return .none
     }
 
+    func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        guard let source = source else {
+            return false
+        }
+        return source.current.itemIsEditableAtIndex(indexPath.row)
+    }
+
     func tableView(_ tableView: UITableView, editingStyleForRowAtIndexPath indexPath: IndexPath) -> UITableViewCellEditingStyle {
         return editingStyleforRow(atIndexPath: indexPath)
     }


### PR DESCRIPTION
Bug 1497432
Nonfunctional "Delete" button available for the synced desktop bookmarks
https://bugzilla.mozilla.org/show_bug.cgi?id=1497432