### PR TITLE
Bug 1500997 - XCUITests fix testTypeOnGivenFields

### DIFF
--- a/XCUITests/SyncFAUITests.swift
+++ b/XCUITests/SyncFAUITests.swift
@@ -81,7 +81,7 @@ class SyncUITests: BaseTestCase {
         userState.fxaPassword = "atleasteight"
         navigator.performAction(Action.FxATypePassword)
         navigator.performAction(Action.FxATapOnSignInButton)
-        waitforExistence(app.webViews.staticTexts["Unknown account."])
+        waitforExistence(app.webViews.staticTexts["Unknown account."], timeout: 10)
         XCTAssertTrue(app.webViews.links["Sign up"].exists)
     }
 


### PR DESCRIPTION
If the log in lasts too long the test fails, lets see if adding a timeout for the waitingforExistence fixes the issue