### PR TITLE
Bug 1501292 - Popup blocker setting should default to the pref value.

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -208,8 +208,6 @@ class Tab: NSObject {
     func createWebview() {
         if webView == nil {
             configuration.userContentController = WKUserContentController()
-            configuration.preferences = WKPreferences()
-            configuration.preferences.javaScriptCanOpenWindowsAutomatically = false
             configuration.allowsInlineMediaPlayback = true
             let webView = TabWebView(frame: .zero, configuration: configuration)
             webView.delegate = self


### PR DESCRIPTION
... rather than a hard-coded boolean.

I had difficulty reproducing this problem manually, and our current popup blocking test passes. However when experimenting with popup blocking toggling as part of an experiment I found the setting change wasn't taking effect unless I applied this patch.

The Tab gets a passed-in WKConfiguration when it is created, and that configuration (see `TabManager.configuration`) has `javaScriptCanOpenWindowsAutomatically` set to the current pref value. We also have a listener for prefs changed that updates the configuration (and iterates all the tabs to update them), that func is `TabManager.prefsDidChange()`.

https://bugzilla.mozilla.org/show_bug.cgi?id=1501292