### PR TITLE
Bug 1501398 - Restore sync integration tests now that TPS is a web extension

### DIFF
--- a/SyncIntegrationTests/conftest.py
+++ b/SyncIntegrationTests/conftest.py
@@ -100,9 +100,9 @@ def tps_profile(pytestconfig, tps_addon, tps_config, tps_log, fxa_urls):
         'services.sync.log.logger': 'Trace',
         'services.sync.log.logger.engine': 'Trace',
         'services.sync.testing.tps': True,
+        'testing.tps.logFile': tps_log,
         'toolkit.startup.max_resumed_crashes': -1,
         'tps.config': json.dumps(tps_config),
-        'tps.logfile': tps_log,
         'tps.seconds_since_epoch': int(time.time()),
         'xpinstall.signatures.required': False
     }

--- a/SyncIntegrationTests/tps.py
+++ b/SyncIntegrationTests/tps.py
@@ -21,13 +21,12 @@ class TPS(object):
         self.firefox_log.write(line + '\n')
 
     def run(self, test, phase='phase1', ignore_unused_engines=True):
-        args = [
-            '-tps={}'.format(os.path.abspath(test)),
-            '-tpsphase={}'.format(phase),
-            '-marionette']
-        if ignore_unused_engines:
-            args.append('--ignore-unused-engines')
-
+        self.profile.set_preferences({
+            'testing.tps.testFile': os.path.abspath(test),
+            'testing.tps.testPhase': phase,
+            'testing.tps.ignoreUnusedEngines': ignore_unused_engines,
+        })
+        args = ['-marionette']
         process_args = {'processOutputLine': [self._log]}
         self.logger.info('Running: {} {}'.format(self.firefox, ' '.join(args)))
         self.logger.info('Using profile at: {}'.format(self.profile.profile))

--- a/XCUITests/IntegrationTests.swift
+++ b/XCUITests/IntegrationTests.swift
@@ -43,6 +43,7 @@ class IntegrationTests: BaseTestCase {
         navigator.performAction(Action.FxATypeEmail)
         navigator.performAction(Action.FxATypePassword)
         navigator.performAction(Action.FxATapOnSignInButton)
+        sleep(3)
         allowNotifications()
     }
 


### PR DESCRIPTION
Now that TPS is a web extension, some of the configuration that was previously provided by command line arguments are now handled using preferences. This patch updates the sync integration tests to work against the latest version of TPS.

## Pull Request Checklist

- [x] My patch has gone through review and I have addressed review comments
- [X] My patch has a standard commit message that looks like `Bug 12345678 - This fixes something something`

- [X] ~~I have updated the *Unit Tests* to cover new or changed functionality~~
- [X] ~~I have updated the *UI Tests* to cover new or changed functionality~~
- [ ] I have marked the bug with `[needsuplift]`
- [X] ~~I have made sure that localizable strings use `NSLocalizableString()`~~

## Notes for testing this patch

You can run the sync integration tests by following the instructions in SyncIntegration/README.md. Note that the tests are failing for me, which may be a bug in the test or the sync code. @isabelrios is attempting to replicate the issue manually, and can also use this pull request to see if she can replicate the automated test failures.

Also note that the sleep in this patch is not ideal, and may be able to be replaced with a suitable wait, I understand from @isabelrios that this is related to another known issue.
