### PR TITLE
Bug 1497130 - GCDWebServer shutdown when backgrounded kills tab restore

### DIFF
--- a/Client/Application/WebServer.swift
+++ b/Client/Application/WebServer.swift
@@ -38,7 +38,7 @@ class WebServer {
             try server.start(options: [
                 GCDWebServerOption_Port: 6571,
                 GCDWebServerOption_BindToLocalhost: true,
-                GCDWebServerOption_AutomaticallySuspendInBackground: true,
+                GCDWebServerOption_AutomaticallySuspendInBackground: false,
                 GCDWebServerOption_AuthenticationMethod: GCDWebServerAuthenticationMethod_Basic,
                 GCDWebServerOption_AuthenticationAccounts: [sessionToken: ""]
             ])


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1497130