### PR TITLE
Bug 1497130 - GCDWebServer backgrounded stop: kills tab restore

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -939,7 +939,9 @@ class BrowserViewController: UIViewController {
     fileprivate func updateURLBarDisplayURL(_ tab: Tab) {
         urlBar.currentURL = tab.url?.displayURL
 
-        let isPage = tab.url?.displayURL?.isWebPage() ?? false
+        // If tab restore fails (the local URL for this didn't finish loading), ensure the reload button is active so the user can reload and restore the tab.
+        let tabRestorationIncomplete = tab.sessionData != nil
+        let isPage = tab.url?.displayURL?.isWebPage() ?? tabRestorationIncomplete
         navigationToolbar.updatePageStatus(isPage)
     }
 
@@ -1094,6 +1096,9 @@ class BrowserViewController: UIViewController {
             print("Cannot navigate in tab without a webView")
             return
         }
+
+        // Tab restore is complete (the local URL for this has loaded).
+        tab.sessionData = nil
 
         if let url = webView.url {
             if !url.isErrorPageURL, !url.isAboutHomeURL, !url.isFileURL {

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -249,7 +249,6 @@ class Tab: NSObject {
             }
 
             let currentPage = sessionData.currentPage
-            self.sessionData = nil
             var jsonDict = [String: AnyObject]()
             jsonDict["history"] = urls as AnyObject?
             jsonDict["currentPage"] = currentPage as AnyObject?
@@ -260,6 +259,8 @@ class Tab: NSObject {
             let restoreURL = URL(string: "\(WebServer.sharedInstance.base)/about/sessionrestore?history=\(escapedJSON)")
             lastRequest = PrivilegedRequest(url: restoreURL!) as URLRequest
             webView.load(lastRequest!)
+
+            // The BVC will set the tab's sessionData = nil when the load request is completed.
         } else if let request = lastRequest {
             webView.load(request)
         } else {
@@ -424,15 +425,15 @@ class Tab: NSObject {
             return
         }
 
-        if let _ = webView?.reloadFromOrigin() {
-            print("reloaded zombified tab from origin")
+        guard let webView = webView else { return }
+
+        if sessionData == nil {
+            webView.reloadFromOrigin()
             return
         }
 
-        if let webView = self.webView {
-            print("restoring webView from scratch")
-            restore(webView)
-        }
+        print("restoring webView from scratch")
+        restore(webView)
     }
 
     func addContentScript(_ helper: TabContentScript, name: String) {


### PR DESCRIPTION
Allow user to reload page to restore the session.

https://bugzilla.mozilla.org/show_bug.cgi?id=1497130