### PR TITLE
Bug 1413705 - Find in Page bar needs to respect safe area insets for iPhone X

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -668,11 +668,12 @@ class BrowserViewController: UIViewController {
 
         alertStackView.snp.remakeConstraints { make in
             make.centerX.equalTo(self.view)
-            make.width.equalTo(self.view.snp.width)
+            make.width.equalTo(self.view.safeArea.width)
             if let keyboardHeight = keyboardState?.intersectionHeightForView(self.view), keyboardHeight > 0 {
                 make.bottom.equalTo(self.view).offset(-keyboardHeight)
             } else if let toolbar = self.toolbar {
                 make.bottom.equalTo(toolbar.snp.top)
+                make.bottom.lessThanOrEqualTo(self.view.safeArea.bottom)
             } else {
                 make.bottom.equalTo(self.view)
             }


### PR DESCRIPTION
Bug 1413705 - Find in Page bar needs to respect safe area insets for iPhone X
https://bugzilla.mozilla.org/show_bug.cgi?id=1413705

![simulator screen shot - iphone x - 2018-10-28 at 22 16 27](https://user-images.githubusercontent.com/17826727/47621974-818fca00-daff-11e8-90fe-fdd754bf4dcc.png)
