### PR TITLE
Bug 1504973 - XCUITests fix testRearrangeTabsTabTrayLandscape iPhone

### DIFF
--- a/XCUITests/BaseTestCase.swift
+++ b/XCUITests/BaseTestCase.swift
@@ -125,7 +125,12 @@ class BaseTestCase: XCTestCase {
         if iPad() {
         waitForExistence(app.buttons["TopTabsViewController.tabsButton"], timeout: 10)
         } else {
-        waitForExistence(app.buttons["TabToolbar.tabsButton"], timeout: 10)
+            // iPhone sim tabs button is called differently when in portrait or landscape
+            if (XCUIDevice.shared.orientation == UIDeviceOrientation.landscapeLeft) {
+                waitForExistence(app.buttons["URLBarView.tabsButton"], timeout: 10)
+            } else {
+                waitForExistence(app.buttons["TabToolbar.tabsButton"], timeout: 10)
+            }
         }
     }
 }


### PR DESCRIPTION
The tabs button is different in portrait and landscape, need to update that for this test.