### PR TITLE
Bug 1472709 - XCUITest SyncIntegration test starting on Desktop

### DIFF
--- a/SyncIntegrationTests/test_bookmark_desktop.js
+++ b/SyncIntegrationTests/test_bookmark_desktop.js
@@ -1,0 +1,26 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+/*
+ * The list of phases mapped to their corresponding profiles.  The object
+ * here must be in strict JSON format, as it will get parsed by the Python
+ * testrunner (no single quotes, extra comma's, etc).
+ */
+EnableEngines(["bookmarks"]);
+
+var phases = { "phase1": "profile1" };
+
+
+// expected bookmark state
+var bookmarksCreated = {
+"mobile": [{
+  uri: "http://www.example.com/",
+  title: "Example Domain"}]
+};
+
+// sync and verify bookmarks
+Phase("phase1", [
+  [Sync],
+  [Bookmarks.add, bookmarksCreated],
+  [Sync]
+]);

--- a/SyncIntegrationTests/test_integration.py
+++ b/SyncIntegrationTests/test_integration.py
@@ -13,3 +13,7 @@ def test_sync_tabs_from_device(tps, xcodebuild):
 def test_sync_logins_from_device(tps, xcodebuild):
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncLogins')
     tps.run('test_password.js')
+
+def test_sync_bookmark_from_desktop(tps, xcodebuild):
+    tps.run('test_bookmark_desktop.js')
+    xcodebuild.test('XCUITests/IntegrationTests/testFxASyncBookmarkDesktop')

--- a/XCUITests/IntegrationTests.swift
+++ b/XCUITests/IntegrationTests.swift
@@ -71,6 +71,20 @@ class IntegrationTests: BaseTestCase {
         waitForInitialSyncComplete()
     }
 
+    func testFxASyncBookmarkDesktop () {
+        // Bookmark is added by the DB
+        // Sign into Firefox Accounts
+        signInFxAccounts()
+
+        // Wait for initial sync to complete
+        waitForInitialSyncComplete()
+        navigator.goto(HomePanelsScreen)
+        waitForTabsButton()
+        navigator.goto(BrowserTabMenu)
+        navigator.goto(HomePanel_Bookmarks)
+        waitForExistence(app.tables["Bookmarks List"].cells.element(boundBy: 1).staticTexts["Example Domain"])
+    }
+
     func testFxASyncTabs () {
         navigator.openURL(testingURL)
         waitUntilPageLoad()


### PR DESCRIPTION
This PR is to continue with the work regarding the sync integration tests. In this case the idea is start the login in desktop having one bookmark there and check that it appears on iOS.