### PR TITLE
library branch - fix more xcuitests

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
@@ -224,6 +224,12 @@
                   Identifier = "DomainAutocompleteTest/testDeletingCharsUpdateTheResults()">
                </Test>
                <Test
+                  Identifier = "DragAndDropTestIpad/testTryDragAndDropBookmarkToURLBar()">
+               </Test>
+               <Test
+                  Identifier = "DragAndDropTestIpad/testTryDragAndDropHistoryToURLBar()">
+               </Test>
+               <Test
                   Identifier = "FindInPageTests/testFindFromMenu()">
                </Test>
                <Test

--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -84,7 +84,6 @@ class ActivityStreamTest: BaseTestCase {
 
     func testTopSitesRemoveAllDefaultTopSitesAddNewOne() {
         // Remove all default Top Sites
-        navigator.goto(HomePanel_TopSites)
         waitForExistence(app.cells["facebook"])
         for element in allDefaultTopSites {
             TopSiteCellgroup.cells[element].press(forDuration: 1)
@@ -101,9 +100,11 @@ class ActivityStreamTest: BaseTestCase {
         app.textFields["address"].typeText(newTopSite["url"]!)
         app.textFields["address"].typeText("\r")
         waitUntilPageLoad()
-        navigator.nowAt(BrowserTab)
-        navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_TopSites)
+        waitForTabsButton()
+        navigator.goto(TabTray)
+        // Workaround to have visited website in top sites
+        navigator.performAction(Action.AcceptRemovingAllTabs)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
 
         waitForExistence(TopSiteCellgroup.cells[newTopSite["topSiteLabel"]!])
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 1)
@@ -111,8 +112,12 @@ class ActivityStreamTest: BaseTestCase {
 
     func testTopSitesRemoveAllExceptDefaultClearPrivateData() {
         navigator.goto(BrowserTab)
-        navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_TopSites)
+        waitForTabsButton()
+        navigator.goto(TabTray)
+        // Workaround to have visited website in top sites
+        navigator.performAction(Action.AcceptRemovingAllTabs)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+
         waitForExistence(app.collectionViews.cells["mozilla"])
         XCTAssertTrue(app.collectionViews.cells["mozilla"].exists)
         // A new site has been added to the top sites
@@ -128,8 +133,10 @@ class ActivityStreamTest: BaseTestCase {
     func testTopSitesRemoveAllExceptPinnedClearPrivateData() {
         navigator.goto(BrowserTab)
         navigator.performAction(Action.PinToTopSitesPAM)
-        navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_TopSites)
+        // Workaround to have visited website in top sites
+        navigator.performAction(Action.AcceptRemovingAllTabs)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+
         waitForExistence(app.collectionViews.cells[newTopSite["topSiteLabel"]!])
         XCTAssertTrue(app.collectionViews.cells[newTopSite["topSiteLabel"]!].exists)
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
@@ -251,8 +258,8 @@ class ActivityStreamTest: BaseTestCase {
         XCTAssertTrue(app.tables["Bookmarks List"].staticTexts[defaultTopSite["bookmarkLabel"]!].exists)
 
         // Check that longtapping on the TopSite gives the option to remove it
-        navigator.goto(HomePanel_TopSites)
-        TopSiteCellgroup.cells[defaultTopSite["topSiteLabel"]!]
+        navigator.goto(HomePanelsScreen)
+        app.cells["TopSitesCell"].cells[defaultTopSite["topSiteLabel"]!]
             .press(forDuration: 2)
         XCTAssertTrue(app.tables["Context Menu"].cells["Remove Bookmark"].exists)
 
@@ -274,7 +281,7 @@ class ActivityStreamTest: BaseTestCase {
         XCTAssertTrue(app.tables["Bookmarks List"].staticTexts[newTopSite["bookmarkLabel"]!].exists)
 
         // Check that longtapping on the TopSite gives the option to remove it
-        navigator.goto(HomePanel_TopSites)
+        navigator.goto(HomePanelsScreen)
         TopSiteCellgroup.cells[newTopSite["topSiteLabel"]!].press(forDuration: 1)
 
         // Unbookmark it
@@ -317,20 +324,6 @@ class ActivityStreamTest: BaseTestCase {
         XCTAssertTrue(app.cells["TopSitesCell"].exists)
         let numberOfTopSites = TopSiteCellgroup.cells.matching(identifier: "TopSite").count
         XCTAssertEqual(numberOfTopSites, numberOfExpectedTopSites, "The number of Top Sites is not correct")
-    }
-
-    func testOpenTopSitesFromContextMenu() {
-        // Top Sites is shown by default
-        waitForExistence(app.cells["TopSitesCell"])
-        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
-
-        // Go to a website
-        navigator.openURL("example.com")
-        waitUntilPageLoad()
-
-        // Go back to Top Sites from context menu
-        navigator.browserPerformAction(.openTopSitesOption)
-        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
     }
 
     func testActivityStreamPages() {

--- a/XCUITests/DragAndDropTests.swift
+++ b/XCUITests/DragAndDropTests.swift
@@ -292,6 +292,8 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
         XCTAssertTrue(secondEntryOnList.exists, "second entry after is not correct")
     }
 
+    // Test disabled due to new way bookmark panel is shown, url is not available. Library implementation bug 1506989
+    // Will be removed if this is going the final implementation
     func testTryDragAndDropHistoryToURLBar() {
         if skipPlatform { return }
 
@@ -305,6 +307,8 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
         XCTAssertEqual(urlBarValue, "Search or enter address")
     }
 
+    // Test disabled due to new way bookmark panel is shown, url is not available. Library implementation bug 1506989
+    // Will be removed if this is going the final implementation
     func testTryDragAndDropBookmarkToURLBar() {
         if skipPlatform { return }
 

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -439,7 +439,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     map.addScreenState(HomePanel_Bookmarks) { screenState in
         let bookmarkCell = app.tables["Bookmarks List"].cells.element(boundBy: 0)
         screenState.press(bookmarkCell, to: BookmarksPanelContextMenu)
-        screenState.noop(to: HomePanelsScreen)
+        screenState.tap(app.buttons["Done"], to: HomePanelsScreen)
     }
 
     map.addScreenState(HomePanel_TopSites) { screenState in

--- a/XCUITests/HomePageSettingsUITest.swift
+++ b/XCUITests/HomePageSettingsUITest.swift
@@ -31,7 +31,7 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.goto(BrowserTabMenu)
 
         //Now check open home page should load the previously saved home page
-        let homePageMenuItem = app.tables["Context Menu"].cells["Open Homepage"]
+        let homePageMenuItem = app.cells["menu-Home"]
         waitForExistence(homePageMenuItem)
         homePageMenuItem.tap()
         waitForValueContains(app.textFields["url"], value: websiteUrl1)

--- a/XCUITests/NavigationTest.swift
+++ b/XCUITests/NavigationTest.swift
@@ -96,7 +96,7 @@ class NavigationTest: BaseTestCase {
     }
 
     func testTapSignInShowsFxAFromRemoteTabPanel() {
-        navigator.goto(HomePanel_TopSites)
+        //navigator.goto(HomePanel_TopSites)
         // Open FxAccount from remote tab panel and check the Sign in to Firefox scren
         navigator.goto(HomePanel_History)
         XCTAssertTrue(app.tables["History List"].staticTexts["Synced Devices"].isEnabled)
@@ -358,7 +358,7 @@ class NavigationTest: BaseTestCase {
         XCTAssertTrue(app.tables["Context Menu"].cells["download"].exists)
         app.tables["Context Menu"].cells["download"].tap()
         navigator.goto(BrowserTabMenu)
-        app.tables.cells["menu-panel-Downloads"].tap()
+        navigator.goto(HomePanel_Downloads)
         waitForExistence(app.tables["DownloadsTable"])
         // There should be one item downloaded. It's name and size should be shown
         let downloadedList = app.tables["DownloadsTable"].cells.count

--- a/XCUITests/TopTabsTest.swift
+++ b/XCUITests/TopTabsTest.swift
@@ -94,7 +94,7 @@ class TopTabsTest: BaseTestCase {
 
         // After removing only one tab it automatically goes to HomepanelView
         waitForExistence(app.collectionViews.cells["TopSitesCell"])
-        XCTAssert(app.buttons["HomePanels.TopSites"].exists)
+        XCTAssert(app.cells["TopSitesCell"].cells["TopSite"].exists)
     }
 
     private func openNtabsFromTabTray(numTabs: Int) {


### PR DESCRIPTION
I have gone through a second round of fixing XCUITests. I have also disabled and/or removed some others that don't make sense anymore with the new implementation.

There are still some intermittent failures or some other issues fixed in a different [PR](https://github.com/mozilla-mobile/firefox-ios/pull/4369) (Highlights  and PageControl button removed)