### PR TITLE
Bug 1507097 - XCUITests(smoketest): Clear Website data

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_SmokeXCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_SmokeXCUITests.xcscheme
@@ -299,7 +299,7 @@
                   Identifier = "CopiedLinksTests">
                </Test>
                <Test
-                  Identifier = "DataManagementTests">
+                  Identifier = "DataManagementTests/testWebSiteDataOptions()">
                </Test>
                <Test
                   Identifier = "DatabaseFixtureTest">

--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
@@ -221,6 +221,9 @@
                   Identifier = "ClipBoardTests/testClipboardPasteAndGo()">
                </Test>
                <Test
+                  Identifier = "DataManagementTests/testWebSiteDataEnterFirstTime()">
+               </Test>
+               <Test
                   Identifier = "DomainAutocompleteTest/testDeletingCharsUpdateTheResults()">
                </Test>
                <Test


### PR DESCRIPTION
Moving testWebSiteDataEnterFirstTime to the Smoke schema. 