### PR TITLE
Bug 1365832 - postMessage: event.source is not equal to source window

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -87,7 +87,10 @@ extension BrowserViewController: WKUIDelegate {
 
     func webViewDidClose(_ webView: WKWebView) {
         if let tab = tabManager[webView] {
-            self.tabManager.removeTabAndUpdateSelectedIndex(tab)
+            // Need to wait here in case we're waiting for a pending `window.open()`.
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
+                self.tabManager.removeTabAndUpdateSelectedIndex(tab)
+            }
         }
     }
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1365832

Cleaning out old bugs that have been sitting in my queue today :-)

This bug no longer repros. However, there is an outstanding issue related to the example posted in this bug that can cause a crash in debug builds which is what this PR is fixing. So, for `window.open()` calls, we have a 100ms delay before we update tab manager. The reason for this sucks, but it is related to `window.opener` in JS not being ready until one tick of the run loop. Anyhow, if a page (like this example) calls `window.open()` and then calls `window.close()` on *itself* in the same tick, our tab manager count gets out of whack and we fail an assertion.