### PR TITLE
Bug 1507464 - Using copy address will remove the URL fragment when copied

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -379,8 +379,8 @@ class BrowserViewController: UIViewController {
             return false
         })
         copyAddressAction = AccessibleAction(name: Strings.CopyAddressTitle, handler: { () -> Bool in
-            if let url = self.urlBar.currentURL {
-                UIPasteboard.general.url = url as URL
+            if let url = self.tabManager.selectedTab?.canonicalURL?.displayURL ?? self.urlBar.currentURL {
+                UIPasteboard.general.url = url
             }
             return true
         })

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -74,6 +74,16 @@ class Tab: NSObject {
     var canonicalURL: URL? {
         if let string = pageMetadata?.siteURL,
             let siteURL = URL(string: string) {
+
+            // If the canonical URL from the page metadata doesn't contain the
+            // "#" fragment, check if the tab's URL has a fragment and if so,
+            // append it to the canonical URL.
+            if siteURL.fragment == nil,
+                let fragment = self.url?.fragment,
+                let siteURLWithFragment = URL(string: "\(string)#\(fragment)") {
+                return siteURLWithFragment
+            }
+
             return siteURL
         }
         return self.url

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -312,8 +312,8 @@ extension PhotonActionSheetProtocol {
             }
         }
         let copyAddressAction = PhotonActionSheetItem(title: Strings.CopyAddressTitle, iconString: "menu-Copy-Link") { action in
-            if let url = urlBar.currentURL {
-                UIPasteboard.general.url = url as URL
+            if let url = self.tabManager.selectedTab?.canonicalURL?.displayURL ?? urlBar.currentURL {
+                UIPasteboard.general.url = url
             }
         }
         if UIPasteboard.general.string != nil {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1507464

In addition to fixing the issue where the fragment is missing from the canonical URL, this patch also makes the various methods of copying the current URL consistent. For some reason, we were only copying the canonical URL through the page actions menu, but just taking the ordinary URL for the long-press menu. ¯\_(ツ)_/¯