### PR TITLE
Bug 1506791 - drag reorder and delete is crashing. let's not.

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -392,9 +392,6 @@ extension TabDisplayManager: TabManagerDelegate {
         }
     }
 
-    func tabManager(_ tabManager: TabManager, willAddTab tab: Tab) {}
-    func tabManager(_ tabManager: TabManager, willRemoveTab tab: Tab) {}
-
     func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool) {
         if isDragging {
             // All we can do (easily) is make the drag a no-op, and reload the data. Not elegant, but this is an edge case.

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -373,12 +373,14 @@ extension TabDisplayManager: TabManagerDelegate {
         // any assumption of previous state of the view. Passing a previous tab (and relying on that to redraw the previous tab as unselected) would be making this assumption about the state of the view.
     }
 
-    func tabManager(_ tabManager: TabManager, willAddTab tab: Tab) {
-        isDragging = false
-    }
-
     func tabManager(_ tabManager: TabManager, didAddTab tab: Tab, isRestoring: Bool) {
         if isRestoring {
+            return
+        }
+
+        if isDragging {
+            isDragging = false
+            refreshStore()
             return
         }
 
@@ -390,11 +392,17 @@ extension TabDisplayManager: TabManagerDelegate {
         }
     }
 
-    func tabManager(_ tabManager: TabManager, willRemoveTab tab: Tab) {
-        isDragging = false
-    }
+    func tabManager(_ tabManager: TabManager, willAddTab tab: Tab) {}
+    func tabManager(_ tabManager: TabManager, willRemoveTab tab: Tab) {}
 
     func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool) {
+        if isDragging {
+            // All we can do (easily) is make the drag a no-op, and reload the data. Not elegant, but this is an edge case.
+            isDragging = false
+            refreshStore()
+            return
+        }
+
         let type = tabManager.normalTabs.isEmpty ? TabAnimationType.removedLastTab : TabAnimationType.removedNonLastTab
 
         updateWith(animationType: type) { [weak self] in

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -12,9 +12,7 @@ private let log = Logger.browserLogger
 
 protocol TabManagerDelegate: AnyObject {
     func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?, isRestoring: Bool)
-    func tabManager(_ tabManager: TabManager, willAddTab tab: Tab)
     func tabManager(_ tabManager: TabManager, didAddTab tab: Tab, isRestoring: Bool)
-    func tabManager(_ tabManager: TabManager, willRemoveTab tab: Tab)
     func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool)
 
     func tabManagerDidRestoreTabs(_ tabManager: TabManager)
@@ -308,8 +306,6 @@ class TabManager: NSObject {
     func configureTab(_ tab: Tab, request: URLRequest?, afterTab parent: Tab? = nil, flushToDisk: Bool, zombie: Bool, isPopup: Bool = false) {
         assert(Thread.isMainThread)
 
-        delegates.forEach { $0.get()?.tabManager(self, willAddTab: tab) }
-
         if parent == nil || parent?.isPrivate != tab.isPrivate {
             tabs.append(tab)
         } else if let parent = parent, var insertIndex = tabs.index(of: parent) {
@@ -415,10 +411,6 @@ class TabManager: NSObject {
         guard let removalIndex = tabs.index(where: { $0 === tab }) else {
             Sentry.shared.sendWithStacktrace(message: "Could not find index of tab to remove", tag: .tabManager, severity: .fatal, description: "Tab count: \(count)")
             return
-        }
-
-        if notify {
-            delegates.forEach { $0.get()?.tabManager(self, willRemoveTab: tab) }
         }
 
         let prevCount = count

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -373,9 +373,7 @@ extension TabTrayController: TabManagerDelegate {
             }
         }
     }
-    func tabManager(_ tabManager: TabManager, willAddTab tab: Tab) {}
-    func tabManager(_ tabManager: TabManager, willRemoveTab tab: Tab) {}
-
+   
     func tabManagerDidRestoreTabs(_ tabManager: TabManager) {
         self.emptyPrivateTabsView.isHidden = !self.privateTabsAreEmpty()
     }

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -78,14 +78,6 @@ open class MockTabManagerDelegate: TabManagerDelegate {
         testDelegateMethodWithName(#function, tabs: [])
     }
 
-    public func tabManager(_ tabManager: TabManager, willRemoveTab tab: Tab) {
-        testDelegateMethodWithName(#function, tabs: [tab])
-    }
-
-    public func tabManager(_ tabManager: TabManager, willAddTab tab: Tab) {
-        testDelegateMethodWithName(#function, tabs: [tab])
-    }
-
     public func tabManagerDidAddTabs(_ tabManager: TabManager) {
         testDelegateMethodWithName(#function, tabs: [])
     }
@@ -97,9 +89,7 @@ open class MockTabManagerDelegate: TabManagerDelegate {
 
 class TabManagerTests: XCTestCase {
 
-    let willRemove = MethodSpy(functionName: "tabManager(_:willRemoveTab:)")
     let didRemove = MethodSpy(functionName: "tabManager(_:didRemoveTab:isRestoring:)")
-    let willAdd = MethodSpy(functionName: "tabManager(_:willAddTab:)")
     let didAdd = MethodSpy(functionName: "tabManager(_:didAddTab:isRestoring:)")
 
     var profile: TabManagerMockProfile!
@@ -123,7 +113,7 @@ class TabManagerTests: XCTestCase {
 
     func testAddTabShouldAddOneNormalTab() {
         manager.addDelegate(delegate)
-        delegate.expect([willAdd, didAdd])
+        delegate.expect([didAdd])
         manager.addTab()
         delegate.verify("Not all delegate methods were called")
         XCTAssertEqual(manager.normalTabs.count, 1, "There should be one normal tab")
@@ -131,7 +121,7 @@ class TabManagerTests: XCTestCase {
 
     func testAddTabShouldAddOnePrivateTab() {
         manager.addDelegate(delegate)
-        delegate.expect([willAdd, didAdd])
+        delegate.expect([didAdd])
         manager.addTab(isPrivate: true)
         delegate.verify("Not all delegate methods were called")
         XCTAssertEqual(manager.privateTabs.count, 1, "There should be one private tab")
@@ -160,7 +150,7 @@ class TabManagerTests: XCTestCase {
         manager.selectTab(tab)
         manager.addDelegate(delegate)
         // it wont call didSelect because addTabAndSelect did not pass last removed tab
-        delegate.expect([willRemove, didRemove, willAdd, didAdd, didSelect])
+        delegate.expect([didRemove, didAdd, didSelect])
         manager.removeTabAndUpdateSelectedIndex(tab)
         delegate.verify("Not all delegate methods were called")
     }
@@ -182,7 +172,7 @@ class TabManagerTests: XCTestCase {
             XCTAssertTrue(previous.isPrivate)
             XCTAssertTrue(self.manager.selectedTab == next)
         }
-        delegate.expect([willRemove, didRemove, didSelect])
+        delegate.expect([didRemove, didSelect])
         manager.removeTabAndUpdateSelectedIndex(privateTab)
         delegate.verify("Not all delegate methods were called")
     }
@@ -203,7 +193,7 @@ class TabManagerTests: XCTestCase {
         }
 
         // This test makes sure that a normal tab is always added even when a normal tab is not selected when calling removeAll
-        delegate.expect([willRemove, didRemove, willAdd, didAdd, didSelect, removeAllTabs])
+        delegate.expect([didRemove, didAdd, didSelect, removeAllTabs])
 
         manager.removeTabsWithUndoToast(manager.normalTabs)
         delegate.verify("Not all delegate methods were called")
@@ -324,7 +314,7 @@ class TabManagerTests: XCTestCase {
             XCTAssertEqual(deleteTab, previous)
             XCTAssertEqual(next, newSelectedTab)
         }
-        delegate.expect([willRemove, didRemove, didSelect])
+        delegate.expect([didRemove, didSelect])
         manager.removeTabAndUpdateSelectedIndex(manager.tabs.last!)
 
         delegate.verify("Not all delegate methods were called")
@@ -384,7 +374,7 @@ class TabManagerTests: XCTestCase {
             XCTAssertEqual(deleteTab, previous)
             XCTAssertEqual(next, newSelectedTab)
         }
-        delegate.expect([willRemove, didRemove, didSelect])
+        delegate.expect([didRemove, didSelect])
         manager.removeTabAndUpdateSelectedIndex(manager.tabs.first!)
         delegate.verify("Not all delegate methods were called")
     }
@@ -445,7 +435,7 @@ class TabManagerTests: XCTestCase {
             XCTAssertEqual(last, previous)
             XCTAssert(next != privateOne && !next.isPrivate)
         }
-        delegate.expect([willRemove, didRemove, didSelect])
+        delegate.expect([didRemove, didSelect])
         manager.removeTabAndUpdateSelectedIndex(last)
 
         delegate.verify("Not all delegate methods were called")
@@ -490,7 +480,7 @@ class TabManagerTests: XCTestCase {
             XCTAssertEqual(deleted, previous)
             XCTAssertEqual(next, newSelected)
         }
-        delegate.expect([willRemove, didRemove, didSelect])
+        delegate.expect([didRemove, didSelect])
         manager.removeTabAndUpdateSelectedIndex(manager.tabs.first!)
         delegate.verify("Not all delegate methods were called")
     }


### PR DESCRIPTION
The fix is to ignore the drag and reload the collection view.
It would be nice-to-have if the drag could be animated back to exit the
drag state, but Apple APIs do not expose that level of control. All we
can do is ignore the drag.

I was trying to do something similar before this patch (by just ignoring the drag), but that was insufficient, the collection view needs to be reloaded fully.