### PR TITLE
Bug 1506517 - iPhone X toolbar hide/show not working

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -672,7 +672,6 @@ class BrowserViewController: UIViewController {
                 make.bottom.equalTo(self.view).offset(-keyboardHeight)
             } else if let toolbar = self.toolbar {
                 make.bottom.equalTo(toolbar.snp.top)
-                make.bottom.lessThanOrEqualTo(self.view.safeArea.bottom)
             } else {
                 make.bottom.equalTo(self.view)
             }


### PR DESCRIPTION
Caused by earlier commit https://github.com/mozilla-mobile/firefox-ios/commit/6fb111410b9afd78e8ed4a0eb9d184e729d21f8a
Reverting the causative line and re-opening that bug.
