### PR TITLE
Bug 1508367 - Tapping account buttons in the history panel should open the login page

### DIFF
--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -212,10 +212,12 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
     }
 
     func homePanelDidRequestToSignIn() {
+        self.dismiss(animated: false, completion: nil)
         delegate?.homePanelDidRequestToSignIn()
     }
 
     func homePanelDidRequestToCreateAccount() {
+        self.dismiss(animated: false, completion: nil)
         delegate?.homePanelDidRequestToCreateAccount()
     }
 


### PR DESCRIPTION
We need to dismiss the new library panel before popping open a new panel.