### PR TITLE
Bug 1510953 - UITests remove workaround since bugs are fixed

### DIFF
--- a/UITests/ClearPrivateDataTests.swift
+++ b/UITests/ClearPrivateDataTests.swift
@@ -123,10 +123,13 @@ class ClearPrivateDataTests: KIFTestCase, UITextFieldDelegate {
         let url1 = urls[0].url
         let url2 = urls[1].url
         BrowserUtils.clearPrivateData(BrowserUtils.AllClearables.subtracting([BrowserUtils.Clearable.History]), swipe: false)
+        tester().waitForAnimationsToFinish()
         BrowserUtils.openLibraryMenu(tester())
         // Open History Panel
         tester().tapView(withAccessibilityIdentifier: "HomePanels.History")
-
+        tester().tapView(withAccessibilityIdentifier: "HomePanels.Bookmarks")
+        tester().tapView(withAccessibilityIdentifier: "HomePanels.History")
+        tester().waitForAnimationsToFinish()
         let historyListShown = GREYCondition(name: "Wait for history to appear", block: {
             var errorOrNil: NSError?
             EarlGrey.selectElement(with: grey_accessibilityLabel(url1))

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -416,7 +416,6 @@ class BrowserUtils {
         tester.tapView(withAccessibilityIdentifier: "TabToolbar.menuButton")
         tester.waitForAnimationsToFinish()
         tester.tapView(withAccessibilityIdentifier: "menu-library")
-        tester.waitForView(withAccessibilityIdentifier: "HomePanels.History")
     }
 
     class func closeLibraryMenu(_ tester: KIFUITestActor) {

--- a/UITests/HistoryTests.swift
+++ b/UITests/HistoryTests.swift
@@ -80,10 +80,8 @@ class HistoryTests: KIFTestCase {
 
         // Check that both appear in the history home panel
         BrowserUtils.openLibraryMenu(tester())
+        tester().waitForAnimationsToFinish()
 
-        // Workaround bug 1508368, go to bookmarks, then to library for updating data
-        tester().tapView(withAccessibilityIdentifier: "HomePanels.Bookmarks")
-        tester().tapView(withAccessibilityIdentifier: "HomePanels.History")
         EarlGrey.selectElement(with: grey_accessibilityLabel(urls[0]))
             .perform(grey_longPress())
         EarlGrey.selectElement(with: grey_accessibilityLabel("Delete from History"))
@@ -115,14 +113,14 @@ class HistoryTests: KIFTestCase {
         for pageNo in 1...102 {
             BrowserUtils.addHistoryEntry("Page \(pageNo)", url: URL(string: "\(webRoot!)/numberedPage.html?page=\(pageNo)")!)
         }
+        tester().wait(forTimeInterval: 2)
         let urlToDelete = "\(webRoot!)/numberedPage.html?page=\(102)"
         let oldestUrl = "\(webRoot!)/numberedPage.html?page=\(101)"
-
+        tester().waitForAnimationsToFinish()
         BrowserUtils.openLibraryMenu(tester())
-
-        // Workaround bug 1508368, go to bookmarks, then to library for updating data
-        tester().tapView(withAccessibilityIdentifier: "HomePanels.Bookmarks")
-        tester().tapView(withAccessibilityIdentifier: "HomePanels.History")
+        tester().waitForAnimationsToFinish()
+        tester().waitForView(withAccessibilityIdentifier: "HomePanels.History")
+        tester().waitForView(withAccessibilityLabel: "Page 102")
 
         EarlGrey.selectElement(with: grey_accessibilityLabel("Page 102")).inRoot(grey_kindOfClass(NSClassFromString("UITableView")!)).perform(grey_swipeSlowInDirectionWithStartPoint(.left, 0.4, 0.4))
         if !BrowserUtils.iPad() {


### PR DESCRIPTION
This PR is to remove the workaround for UITests affected by bug: 1508368
Once it is fixed workaround does not work and has to be removed.