### PR TITLE
Bug 1507485 - Don't display "Paste & Go" when the clipboard is empty

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -332,6 +332,14 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
 }
 
 extension AutocompleteTextField: MenuHelperInterface {
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if action == MenuHelper.SelectorPasteAndGo {
+            return UIPasteboard.general.hasStrings
+        }
+
+        return super.canPerformAction(action, withSender: sender)
+    }
+
     @objc func menuHelperPasteAndGo() {
         autocompleteDelegate?.autocompletePasteAndGo(self)
     }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1507485