### PR TITLE
Bug 1512168 - Fix testChangeNewTabSettingsShowYourHistory broken on sim

### DIFF
--- a/XCUITests/NewTabSettings.swift
+++ b/XCUITests/NewTabSettings.swift
@@ -60,7 +60,8 @@ class NewTabSettingsTest: BaseTestCase {
 
         // Add one history item and check the new tab screen
         navigator.openURL("example.com")
-        navigator.nowAt(BrowserTab)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+        waitForTabsButton()
         navigator.performAction(Action.OpenNewTabFromTabTray)
         waitForExistence(app.tables["History List"].cells.staticTexts["Example Domain"])
     }


### PR DESCRIPTION
This test is failing on sim, adding an extra step fixes it.