### PR TITLE
Bug 1511313 - tab display manager addTab: check privacy state matches before showing the tab

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -384,6 +384,10 @@ extension TabDisplayManager: TabManagerDelegate {
             return
         }
 
+        if tab.isPrivate != self.isPrivate {
+            return
+        }
+
         updateWith(animationType: .addTab) { [weak self] in
             if let me = self {
                 me.dataStore.insert(tab)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1511313