### PR TITLE
Bug 1508008 - Dark theme: bg should be dark when opening new blank tab

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2385,6 +2385,10 @@ extension BrowserViewController: Themeable {
         setNeedsStatusBarAppearanceUpdate()
 
         (presentedViewController as? Themeable)?.applyTheme()
+
+        // Update the `background-color` of any blank webviews.
+        let webViews = tabManager.tabs.compactMap({ $0.webView as? TabWebView })
+        webViews.forEach({ $0.applyTheme() })
     }
 }
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -631,8 +631,17 @@ private protocol TabWebViewDelegate: AnyObject {
     func tabWebViewSearchWithFirefox(_ tabWebViewSearchWithFirefox: TabWebView, didSelectSearchWithFirefoxForSelection selection: String)
 }
 
-private class TabWebView: WKWebView, MenuHelperInterface {
+class TabWebView: WKWebView, MenuHelperInterface {
     fileprivate weak var delegate: TabWebViewDelegate?
+
+    // Updates the `background-color` of the webview to match
+    // the theme if the webview is showing "about:blank" (nil).
+    func applyTheme() {
+        if url == nil {
+            let backgroundColor = ThemeManager.instance.current.browser.background.hexString
+            evaluateJavaScript("document.documentElement.style.backgroundColor = '\(backgroundColor)';")
+        }
+    }
 
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
         return super.canPerformAction(action, withSender: sender) || action == MenuHelper.SelectorFindInPage
@@ -652,7 +661,7 @@ private class TabWebView: WKWebView, MenuHelperInterface {
         }
     }
 
-    fileprivate override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+    internal override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         // The find-in-page selection menu only appears if the webview is the first responder.
         becomeFirstResponder()
 

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -337,7 +337,11 @@ class TabManager: NSObject {
                 let url = NewTabHomePageAccessors.getHomePage(profile.prefs)!
                 tab.loadRequest(URLRequest(url: url))
             case .blankPage:
-                // Do nothing: we're already seeing a blank page.
+                // If we're showing "about:blank" in a webview, set
+                // the <html> `background-color` to match the theme.
+                if let webView = tab.webView as? TabWebView {
+                    webView.applyTheme()
+                }
                 break
             default:
                 // The common case, where the NewTabPage enum defines


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1508008

Had to relax the scope of the `TabWebView` class a bit to keep this DRY. The `applyTheme()` function I added to it only has effect if the webview's `url` is `nil` (meaning the initial "about:blank" state).