### PR TITLE
Bug 1514171 - tab restore followup: about/home was changed

### DIFF
--- a/XCUITests/FindInPageTest.swift
+++ b/XCUITests/FindInPageTest.swift
@@ -17,7 +17,7 @@ class FindInPageTests: BaseTestCase {
     }
 
     func testFindInLargeDoc() {
-        navigator.openURL("http://localhost:6571/find-in-page-test.html")
+        navigator.openURL("http://localhost:6571/test-fixture/find-in-page-test.html")
         // Workaround until FxSGraph is fixed to allow the previos way with goto
         navigator.nowAt(BrowserTab)
 
@@ -80,7 +80,7 @@ class FindInPageTests: BaseTestCase {
     }
 
     func testFindInPageTwoWordsSearchLargeDoc() {
-        navigator.openURL("http://localhost:6571/find-in-page-test.html")
+        navigator.openURL("http://localhost:6571/test-fixture/find-in-page-test.html")
         // Workaround until FxSGraph is fixed to allow the previos way with goto
         navigator.nowAt(BrowserTab)
         waitForExistence(app/*@START_MENU_TOKEN@*/.buttons["TabLocationView.pageOptionsButton"]/*[[".buttons[\"Page Options Menu\"]",".buttons[\"TabLocationView.pageOptionsButton\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/, timeout: 15)

--- a/XCUITests/WebPagesForTesting.swift
+++ b/XCUITests/WebPagesForTesting.swift
@@ -8,7 +8,7 @@ import GCDWebServers
 
 func registerHandlersForTestMethods(server: GCDWebServer) {
     // Add tracking protection check page
-    server.addHandler(forMethod: "GET", path: "/find-in-page-test.html", request: GCDWebServerRequest.self) { (request: GCDWebServerRequest?) in
+    server.addHandler(forMethod: "GET", path: "/test-fixture/find-in-page-test.html", request: GCDWebServerRequest.self) { (request: GCDWebServerRequest?) in
 
         let node = "<span>  And the beast shall come forth surrounded by a roiling cloud of vengeance. The house of the unbelievers shall be razed and they shall be scorched to the earth. Their tags shall blink until the end of days. from The Book of Mozilla, 12:10 And the beast shall be made legion. Its numbers shall be increased a thousand thousand fold. The din of a million keyboards like unto a great storm shall cover the earth, and the followers of Mammon shall tremble. from The Book of Mozilla, 3:31 (Red Letter Edition) </span>"
 


### PR DESCRIPTION
Fixes: 
- about/home was returning the fragment in the path
- The test-fixtures handling wasn't loading the find-in-page test
