### PR TITLE
Bug 1514727 - XCUITest Fix Download tests tearDown

### DIFF
--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -97,9 +97,7 @@ class ActivityStreamTest: BaseTestCase {
 
         // Open a new page and wait for the completion
         navigator.nowAt(HomePanelsScreen)
-        navigator.goto(URLBarOpen)
-        app.textFields["address"].typeText(newTopSite["url"]!)
-        app.textFields["address"].typeText("\r")
+        navigator.openURL(newTopSite["url"]!)
         waitUntilPageLoad()
         waitForTabsButton()
         navigator.goto(TabTray)

--- a/XCUITests/DownloadFilesTests.swift
+++ b/XCUITests/DownloadFilesTests.swift
@@ -8,8 +8,6 @@ class DownloadFilesTests: BaseTestCase {
 
     override func tearDown() {
         // The downloaded file has to be removed between tests
-        navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_Downloads)
         waitForExistence(app.tables["DownloadsTable"])
 
         let list = app.tables["DownloadsTable"].cells.count
@@ -47,6 +45,9 @@ class DownloadFilesTests: BaseTestCase {
         XCTAssertTrue(app.tables["Context Menu"].staticTexts[testFileName].exists)
         XCTAssertTrue(app.tables["Context Menu"].cells["download"].exists)
         app.buttons["Cancel"].tap()
+        navigator.goto(BrowserTabMenu)
+        navigator.goto(HomePanel_Downloads)
+        checkTheNumberOfDownloadedItems(items: 0)
     }
 
     func testDownloadFile() {


### PR DESCRIPTION
This PR fixes the Download tests, on of them was failing in the tearDown.
And also an intermittent in the activityStream tests