### PR TITLE
Bug 1498495 - bvc-to-tabtray animation missing layoutIfNeeded 

### DIFF
--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -134,7 +134,7 @@ private extension BrowserToTrayAnimator {
         container.insertSubview(tabTray.view, belowSubview: bvc.view)
 
         // Force subview layout on the collection view so we can calculate the correct end frame for the animation
-        tabTray.view.layoutSubviews()
+        tabTray.view.layoutIfNeeded()
         tabTray.focusTab()
 
         // Build a tab cell that we will use to animate the scaling of the browser to the tab

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -239,17 +239,21 @@ class TabTrayController: UIViewController {
         }
 
         searchBarHolder.snp.makeConstraints { make in
-            make.leading.equalTo(view.safeArea.leading)
-            make.trailing.equalTo(view.safeArea.trailing)
+            make.leading.equalTo(view.snp.leading)
+            make.trailing.equalTo(view.snp.trailing)
             make.height.equalTo(TabTrayControllerUX.SearchBarHeight)
-            self.tabLayoutDelegate.searchHeightConstraint = make.bottom.equalTo(self.topLayoutGuide.snp.bottom).constraint
-        }
-        searchBar.snp.makeConstraints { make in
-            make.edges.equalTo(searchBarHolder).inset(UIEdgeInsetsMake(15, 20, 10, 40))
+            self.tabLayoutDelegate.searchHeightConstraint = make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.top).constraint
         }
 
         roundedSearchBarHolder.snp.makeConstraints { make in
-            make.edges.equalTo(searchBarHolder).inset(UIEdgeInsetsMake(15, 10, 10, 10))
+            make.top.equalTo(searchBarHolder).offset(15)
+            make.leading.equalTo(view.safeArea.leading).offset(10) // we can just make the nested view conform to the safe area
+            make.trailing.equalTo(view.safeArea.trailing).offset(-10)
+            make.bottom.equalTo(searchBarHolder).offset(-10)
+        }
+
+        searchBar.snp.makeConstraints { make in
+            make.edges.equalTo(roundedSearchBarHolder).inset(UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10))
         }
     }
 


### PR DESCRIPTION
also updated the layout of notch devices in layout, see the screenshot