### PR TITLE
Bug 1515064 - Security tests failing due to url changes

### DIFF
--- a/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
+++ b/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
@@ -250,7 +250,6 @@ class ErrorPageHelper {
 
     func loadPage(_ error: NSError, forUrl url: URL, inWebView webView: WKWebView) {
         guard var components = URLComponents(string: "\(InternalURL.baseUrl)/\(ErrorPageHandler.path)"), let webViewUrl = webView.url else {
-            assertionFailure()
             return
         }
 

--- a/UITests/SecurityTests.swift
+++ b/UITests/SecurityTests.swift
@@ -58,8 +58,9 @@ class SecurityTests: KIFTestCase {
             tabcount = tester().waitForView(withAccessibilityIdentifier: "TabToolbar.tabsButton")?.accessibilityValue
         }
 
-        // After running the exploit, make sure a new tab wasn't opened.
+        // make sure a new tab wasn't opened.
         tester().tapWebViewElementWithAccessibilityLabel("Error exploit")
+        tester().wait(forTimeInterval: 1.0)
         let newTabcount:String?
         if BrowserUtils.iPad() {
             newTabcount = tester().waitForView(withAccessibilityIdentifier: "TopTabsViewController.tabsButton")?.accessibilityValue
@@ -74,11 +75,11 @@ class SecurityTests: KIFTestCase {
     /// but we shouldn't be able to load session restore.
     func testWindowExploit() {
         tester().tapWebViewElementWithAccessibilityLabel("New tab exploit")
-        tester().wait(forTimeInterval: 30)
+        tester().wait(forTimeInterval: 5)
         let webView = tester().waitForView(withAccessibilityLabel: "Web content") as! WKWebView
 
         // Make sure the URL doesn't change.
-        XCTAssertEqual(webView.url!.path, "/errors/error.html")
+        XCTAssert(webView.url == nil)
 
         // Also make sure the XSS alert doesn't appear.
         XCTAssertFalse(tester().viewExistsWithLabel("Local page loaded"))

--- a/UITests/localhostLoad.html
+++ b/UITests/localhostLoad.html
@@ -3,8 +3,8 @@
 <head>
 <script>
   var json = '{"history":["javascript:alert(\'Local page loaded\')"],"currentPage":-1}';
-  var sessionURL = 'http://localhost:6571/about/sessionrestore?history=' + escape(json);
-  var errorURL = 'http://localhost:6571/errors/error.html?url=nttps://mozilla.com/';
+  var sessionURL = 'internal://local/sessionrestore?history=' + escape(json);
+  var errorURL = 'internal://local/errorpage?url=https://mozilla.com/';
 
   function newTabExploit() {
     var win = window.open("http://1.2.3.4.5");


### PR DESCRIPTION
This is due to updates to tab restoration URLs
