### PR TITLE
Bug 1516585 - Fix regression where about:blank iframes were not loading.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -184,6 +184,11 @@ extension BrowserViewController: WKNavigationDelegate {
             return
         }
 
+        if url.scheme == "about" {
+            decisionHandler(.allow)
+            return
+        }
+
         // Second special case are a set of URLs that look like regular http links, but should be handed over to iOS
         // instead of being loaded in the webview. Note that there is no point in calling canOpenURL() here, because
         // iOS will always say yes. TODO Is this the same as isWhitelisted?


### PR DESCRIPTION
This is simply added back in from here 
https://github.com/mozilla-mobile/firefox-ios/commit/8b1450fbeb87f1f559a2f8e42971c715dc96bcaf#diff-102ff0213da1e7f1099172d5e6b137a1L164