### PR TITLE
Bug 1516477 - Don't compare langauge code strings directly.

### DIFF
--- a/Client/Frontend/Browser/TranslationToastHandler.swift
+++ b/Client/Frontend/Browser/TranslationToastHandler.swift
@@ -40,7 +40,7 @@ class TranslationToastHandler: TabEventHandler {
             return
         }
 
-        if myLanguage != pageLanguage {
+        if Locale(identifier: pageLanguage).languageCode != Locale(identifier: myLanguage).languageCode {
             self.promptTranslation(tab, from: pageLanguage, to: myLanguage)
         }
     }


### PR DESCRIPTION
Sometimes page-metadata-parser incorrectly parses language codes. When later compared in swift we do a direct string comparison which can fail. Instead use Foundation's Locale to parse the language code properly before comparing.