### PR TITLE
Bug 1514769 - XCUITests Remove workaround for DataManagementTests

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_SmokeXCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_SmokeXCUITests.xcscheme
@@ -649,6 +649,9 @@
                <Test
                   Identifier = "TrackingProtectionTests/testTrackingProtectionToggle()">
                </Test>
+               <Test
+                  Identifier = "TranslationSnackBarTest">
+               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>

--- a/XCUITests/DataManagementTests.swift
+++ b/XCUITests/DataManagementTests.swift
@@ -6,15 +6,11 @@ import XCTest
 
 class DataManagementTests: BaseTestCase {
 
-    //Testing the entries are correctly added and deleted. This a termporary behaviour. This test will be changed after releasing Firefox 15.x and Bug 1499074 will be fixed.
     func testWebSiteDataEnterFirstTime() {
-        navigator.goto(WebsiteDataSettings)
-        let expectedWebsiteDataEntries = app.tables.cells.count
-        XCTAssertEqual(expectedWebsiteDataEntries, 2)
         navigator.performAction(Action.AcceptClearAllWebsiteData)
         let expectedWebsiteDataEntries2 = app.tables.cells.count
         XCTAssertEqual(expectedWebsiteDataEntries2, 1)
-        navigator.createNewTab()
+        navigator.openURL("example.com")
         navigator.goto(WebsiteDataSettings)
         let expectedWebsiteDataEntries3 = app.tables.cells.count
         XCTAssertEqual(expectedWebsiteDataEntries3, 2)


### PR DESCRIPTION
This PR removes a workaround due to an existing bug already closed and fixes an issue with the test