### PR TITLE
Bug 1518472 - XCUITests Fix warning compiling tests

### DIFF
--- a/XCUITests/HomePageSettingsUITest.swift
+++ b/XCUITests/HomePageSettingsUITest.swift
@@ -24,7 +24,7 @@ class HomePageSettingsUITests: BaseTestCase {
         XCTAssertTrue(app.tables.cells["History"].exists)
         XCTAssertTrue(app.tables.cells["HomePageSetting"].exists)
         waitForExistence(app.tables.cells["TopSitesRows"])
-        XCTAssertEqual(app.tables.cells["TopSitesRows"].label as! String, "Top Sites, Rows: 2")
+        XCTAssertEqual(app.tables.cells["TopSitesRows"].label as String, "Top Sites, Rows: 2")
         XCTAssertTrue(app.tables.switches["ASPocketStoriesVisible"].isEnabled)
     }
 


### PR DESCRIPTION
Small change in this PR to fix a warning that appears in logs in regards to the test implementation in HomePageSettingsUITest suite