### PR TITLE
Bug 1514800 - Scanning a QR code does not open an URL in the same tab

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1147,14 +1147,12 @@ extension BrowserViewController: ClipboardBarDisplayHandlerDelegate {
 extension BrowserViewController: QRCodeViewControllerDelegate {
     func didScanQRCodeWithURL(_ url: URL) {
         guard let tab = tabManager.selectedTab else { return }
-        openBlankNewTab(focusLocationField: false)
         finishEditingAndSubmit(url, visitType: VisitType.typed, forTab: tab)
         UnifiedTelemetry.recordEvent(category: .action, method: .scan, object: .qrCodeURL)
     }
 
     func didScanQRCodeWithText(_ text: String) {
         guard let tab = tabManager.selectedTab else { return }
-        openBlankNewTab(focusLocationField: false)
         submitSearchText(text, forTab: tab)
         UnifiedTelemetry.recordEvent(category: .action, method: .scan, object: .qrCodeText)
     }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1514800

I don't know how this ever worked. I think the previous behavior was exploiting some weird timing in new tab creation. Regardless, the QR code scanner should open the URL in the current tab simply because of the flow of the UI. So, there's no reason to create a new tab when we scan.