### PR TITLE
Bug 1519089 - The translate prompt is displayed on the main page when opening a link in a background tab

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1690,6 +1690,13 @@ extension BrowserViewController: TabDelegate {
     }
 
     func tab(_ tab: Tab, didAddSnackbar bar: SnackBar) {
+        // If the Tab that had a SnackBar added to it is not currently
+        // the selected Tab, do nothing right now. If/when the Tab gets
+        // selected later, we will show the SnackBar at that time.
+        guard tab == tabManager.selectedTab else {
+            return
+        }
+
         showBar(bar, animated: true)
     }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1519089

Thankfully, this turned out to be a pretty simple fix :-)