### PR TITLE
Bug 1513726 - Set private mode cursor text insertion color

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -709,6 +709,8 @@ extension URLBarView: PrivateModeUI {
         locationActiveBorderColor = UIColor.theme.urlbar.activeBorder(isPrivate)
         progressBar.setGradientColors(startColor: UIColor.theme.loadingBar.start(isPrivate), endColor: UIColor.theme.loadingBar.end(isPrivate))
         ToolbarTextField.applyUIMode(isPrivate: isPrivate)
+
+        applyTheme()
     }
 }
 


### PR DESCRIPTION
A call to applyStyle() when updating the private mode state for the URLBar fixes this.