### PR TITLE
Bug 1519864 - Fix max number of topsites on iPad. 

### DIFF
--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -479,7 +479,8 @@ extension ActivityStreamPanel: DataObserverDelegate {
 
     func getTopSites() -> Success {
         let numRows = max(self.profile.prefs.intForKey(PrefsKeys.NumberOfTopSiteRows) ?? TopSitesRowCountSettingsController.defaultNumberOfRows, 1)
-        return self.profile.history.getTopSitesWithLimit(16).both(self.profile.history.getPinnedTopSites()).bindQueue(.main) { (topsites, pinnedSites) in
+        let maxItems = UIDevice.current.userInterfaceIdiom == .pad ? 32 : 16
+        return self.profile.history.getTopSitesWithLimit(maxItems).both(self.profile.history.getPinnedTopSites()).bindQueue(.main) { (topsites, pinnedSites) in
             guard let mySites = topsites.successValue?.asArray(), let pinned = pinnedSites.successValue?.asArray() else {
                 return succeed()
             }

--- a/Client/Frontend/Home/PanelDataObservers.swift
+++ b/Client/Frontend/Home/PanelDataObservers.swift
@@ -6,7 +6,7 @@ import Foundation
 import Deferred
 import Shared
 
-public let ActivityStreamTopSiteCacheSize: Int32 = 16
+public let ActivityStreamTopSiteCacheSize: Int32 = 32
 
 private let log = Logger.browserLogger
 


### PR DESCRIPTION
There are a few different bugs related to the number of TopSites that appear. I think this one is the only one that I can fix that wont introduce weird UI bugs. 

The other bug
[Top Sites are not displaying the correct number of rows when changing device orientation](https://bugzilla.mozilla.org/show_bug.cgi?id=1519874)
- This one can't be fixed without introducing a weird animation that adds/removes every time you rotate the screen. 

