### PR TITLE
Bug 1521485 - Random port for running tests 

### DIFF
--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -22,6 +22,15 @@ class TestAppDelegate: AppDelegate {
         let launchArguments = ProcessInfo.processInfo.arguments
 
         launchArguments.forEach { arg in
+            if arg.starts(with: LaunchArguments.ServerPort) {
+                let portString = arg.replacingOccurrences(of: LaunchArguments.ServerPort, with: "")
+                if let port = Int(portString) {
+                    AppInfo.webserverPort = port
+                } else {
+                    fatalError("Failed to set web server port override.")
+                }
+            }
+
             if arg.starts(with: LaunchArguments.LoadDatabasePrefix) {
                 if launchArguments.contains(LaunchArguments.ClearProfile) {
                     fatalError("Clearing profile and loading a test database is not a supported combination.")

--- a/Client/Application/WebServer.swift
+++ b/Client/Application/WebServer.swift
@@ -36,7 +36,7 @@ class WebServer {
     @discardableResult func start() throws -> Bool {
         if !server.isRunning {
             try server.start(options: [
-                GCDWebServerOption_Port: 6571,
+                GCDWebServerOption_Port: AppInfo.webserverPort,
                 GCDWebServerOption_BindToLocalhost: true,
                 GCDWebServerOption_AutomaticallySuspendInBackground: true,
                 GCDWebServerOption_AuthenticationMethod: GCDWebServerAuthenticationMethod_Basic,

--- a/Client/Frontend/Browser/SessionData.swift
+++ b/Client/Frontend/Browser/SessionData.swift
@@ -9,7 +9,8 @@ import Shared
 private func migrate(urls: [URL]) -> [URL] {
     return urls.compactMap { url in
         var url = url
-        [("http://localhost:6571/errors/error.html?url=", "\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)?url=")
+        let port = AppInfo.webserverPort
+        [("http://localhost:\(port)/errors/error.html?url=", "\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)?url=")
             // TODO: handle reader pages ("http://localhost:6571/reader-mode/page?url=", "\(InternalScheme.url)/\(ReaderModeHandler.path)?url=")
             ].forEach {
             oldItem, newItem in

--- a/ClientTests/ClientTests.swift
+++ b/ClientTests/ClientTests.swift
@@ -60,7 +60,7 @@ class ClientTests: XCTestCase {
 
     fileprivate func hostIsValid(_ host: String) -> Bool {
         let expectation = self.expectation(description: "Validate host for \(host)")
-        let request = URLRequest(url: URL(string: "http://\(host):6571/about/license")!)
+        let request = URLRequest(url: URL(string: "http://\(host):\(AppInfo.webserverPort)/about/license")!)
         var response: HTTPURLResponse?
         Alamofire.request(request).authenticate(usingCredential: WebServer.sharedInstance.credentials).response { (res) -> Void in
             response = res.response

--- a/ClientTests/UIImageViewExtensionsTests.swift
+++ b/ClientTests/UIImageViewExtensionsTests.swift
@@ -42,7 +42,7 @@ class UIImageViewExtensionsTests: XCTestCase {
         }
 
         let favImageView = UIImageView()
-        favImageView.setIcon(Favicon(url: "http://localhost:6571/favicon/icon"), forURL: URL(string: "http://localhost:6571"))
+        favImageView.setIcon(Favicon(url: "http://localhost:\(AppInfo.webserverPort)/favicon/icon"), forURL: URL(string: "http://localhost:\(AppInfo.webserverPort)"))
 
         let expect = expectation(description: "UIImageView async load")
         let time = Int64(2 * Double(NSEC_PER_SEC))

--- a/Shared/AppInfo.swift
+++ b/Shared/AppInfo.swift
@@ -83,4 +83,7 @@ open class AppInfo {
     public static var isApplication: Bool {
         return Bundle.main.object(forInfoDictionaryKey: "CFBundlePackageType") as! String == "APPL"
     }
+
+    // The port for the internal webserver, tests can change this
+    public static var webserverPort = 6571
 }

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -366,7 +366,7 @@ public struct InternalURL {
     private let sessionRestoreHistoryItemBaseUrl = "\(InternalURL.baseUrl)/\(InternalURL.Path.sessionrestore.rawValue)?url="
 
     public static func isValid(url: URL) -> Bool {
-        let isWebServerUrl = url.absoluteString.hasPrefix("http://localhost:6571/")
+        let isWebServerUrl = url.absoluteString.hasPrefix("http://localhost:\(AppInfo.webserverPort)/")
         if isWebServerUrl, url.path.hasPrefix("/test-fixture/") {
             // internal test pages need to be treated as external pages
             return false

--- a/Shared/LaunchArguments.swift
+++ b/Shared/LaunchArguments.swift
@@ -11,6 +11,7 @@ public struct LaunchArguments {
     public static let ClearProfile = "FIREFOX_CLEAR_PROFILE"
     public static let StageServer = "FIREFOX_USE_STAGE_SERVER"
     public static let DeviceName = "DEVICE_NAME"
+    public static let ServerPort = "GCDWEBSERVER_PORT:"
 
     // After the colon, put the name of the file to load from test bundle
     public static let LoadDatabasePrefix = "FIREFOX_LOAD_DB_NAMED:"

--- a/SharedTests/NSURLExtensionsTests.swift
+++ b/SharedTests/NSURLExtensionsTests.swift
@@ -198,9 +198,9 @@ class NSURLExtensionsTests: XCTestCase {
             ]
         let badurls = [
             "http://google.com",
-            "http://localhost:6571/sessionrestore.html",
-            "http://localhost:6571/errors/error.html?url=http%3A//mozilla.com",
-            "http://localhost:6571/errors/error.html?url=http%3A//mozilla.com/about/home/%23panel%3D1",
+            "http://localhost:\(AppInfo.webserverPort)/sessionrestore.html",
+            "http://localhost:\(AppInfo.webserverPort)/errors/error.html?url=http%3A//mozilla.com",
+            "http://localhost:\(AppInfo.webserverPort)/errors/error.html?url=http%3A//mozilla.com/about/home/%23panel%3D1",
             ]
 
         checkUrls(goodurls: goodurls, badurls: badurls, checker: { url in
@@ -215,9 +215,9 @@ class NSURLExtensionsTests: XCTestCase {
         ]
         let badurls = [
             "http://google.com",
-            "http://localhost:6571/sessionrestore.html",
-            "http://localhost:6571/errors/error.html?url=http%3A//mozilla.com",
-            "http://localhost:6571/errors/error.html?url=http%3A//mozilla.com/about/home/%23panel%3D1",
+            "http://localhost:\(AppInfo.webserverPort)/sessionrestore.html",
+            "http://localhost:\(AppInfo.webserverPort)/errors/error.html?url=http%3A//mozilla.com",
+            "http://localhost:\(AppInfo.webserverPort)/errors/error.html?url=http%3A//mozilla.com/about/home/%23panel%3D1",
             ]
 
         checkUrls(goodurls: goodurls, badurls: badurls, checker: { url in
@@ -231,7 +231,7 @@ class NSURLExtensionsTests: XCTestCase {
             ]
         let badurls = [
             "http://google.com",
-            "http://localhost:6571/sessionrestore.html",
+            "http://localhost:\(AppInfo.webserverPort)/sessionrestore.html",
             "http://localhost:1234/about/home/#panel=0"
         ]
 
@@ -243,7 +243,7 @@ class NSURLExtensionsTests: XCTestCase {
     func testoriginalURLFromErrorURL() {
         let goodurls = [
             ("\(InternalURL.baseUrl)/\(InternalURL.Path.errorpage)?url=http%3A//mozilla.com", URL(string: "http://mozilla.com")),
-            ("\(InternalURL.baseUrl)/\(InternalURL.Path.errorpage)?url=http%3A//localhost%3A6571/about/home/%23panel%3D1", URL(string: "http://localhost:6571/about/home/#panel=1")),
+            ("\(InternalURL.baseUrl)/\(InternalURL.Path.errorpage)?url=http%3A//localhost%3A\(AppInfo.webserverPort)/about/home/%23panel%3D1", URL(string: "http://localhost:\(AppInfo.webserverPort)/about/home/#panel=1")),
             ]
 
         goodurls.forEach {
@@ -255,12 +255,12 @@ class NSURLExtensionsTests: XCTestCase {
 
     func testisReaderModeURL() {
         let goodurls = [
-            "http://localhost:6571/reader-mode/page",
-            "http://localhost:6571/reader-mode/page?url=https%3A%2F%2Fen%2Em%2Ewikipedia%2Eorg%2Fwiki%2FMain%5FPage",
+            "http://localhost:\(AppInfo.webserverPort)/reader-mode/page",
+            "http://localhost:\(AppInfo.webserverPort)/reader-mode/page?url=https%3A%2F%2Fen%2Em%2Ewikipedia%2Eorg%2Fwiki%2FMain%5FPage",
             ]
         let badurls = [
             "http://google.com",
-            "http://localhost:6571/sessionrestore.html",
+            "http://localhost:\(AppInfo.webserverPort)/sessionrestore.html",
             "http://localhost:1234/about/home/#panel=0"
         ]
 
@@ -277,7 +277,7 @@ class NSURLExtensionsTests: XCTestCase {
         ]
         let badurls = [
             "http://google.com",
-            "http://localhost:6571/sessionrestore.html",
+            "http://localhost:\(AppInfo.webserverPort)/sessionrestore.html",
             "about:reader",
             "http://about:reader?url=http://example.com"
         ]
@@ -288,15 +288,15 @@ class NSURLExtensionsTests: XCTestCase {
 
     func testdecodeReaderModeURL() {
         let goodurls = [
-            ("http://localhost:6571/reader-mode/page?url=https%3A%2F%2Fen%2Em%2Ewikipedia%2Eorg%2Fwiki%2FMain%5FPage&uuidkey=AAAAA", URL(string: "https://en.m.wikipedia.org/wiki/Main_Page")),
+            ("http://localhost:\(AppInfo.webserverPort)/reader-mode/page?url=https%3A%2F%2Fen%2Em%2Ewikipedia%2Eorg%2Fwiki%2FMain%5FPage&uuidkey=AAAAA", URL(string: "https://en.m.wikipedia.org/wiki/Main_Page")),
             ("about:reader?url=https%3A%2F%2Fen%2Em%2Ewikipedia%2Eorg%2Fwiki%2FMain%5FPage&uuidkey=AAAAA", URL(string: "https://en.m.wikipedia.org/wiki/Main_Page")),
             ("about:reader?url=http%3A%2F%2Fexample%2Ecom%3Furl%3Dparam%26key%3Dvalue&uuidkey=AAAAA", URL(string: "http://example.com?url=param&key=value"))
         ]
         let badurls = [
             "http://google.com",
-            "http://localhost:6571/sessionrestore.html",
+            "http://localhost:\(AppInfo.webserverPort)/sessionrestore.html",
             "http://localhost:1234/about/home/#panel=0",
-            "http://localhost:6571/reader-mode/page",
+            "http://localhost:\(AppInfo.webserverPort)/reader-mode/page",
             "about:reader?url="
         ]
 
@@ -304,9 +304,9 @@ class NSURLExtensionsTests: XCTestCase {
         badurls.forEach { XCTAssertNil(URL(string:$0)!.decodeReaderModeURL, $0) }    }
 
     func testencodeReaderModeURL() {
-        let ReaderURL = "http://localhost:6571/reader-mode/page"
+        let ReaderURL = "http://localhost:\(AppInfo.webserverPort)/reader-mode/page"
         let goodurls = [
-            ("https://en.m.wikipedia.org/wiki/Main_Page", URL(string: "http://localhost:6571/reader-mode/page?url=https%3A%2F%2Fen%2Em%2Ewikipedia%2Eorg%2Fwiki%2FMain%5FPage"))
+            ("https://en.m.wikipedia.org/wiki/Main_Page", URL(string: "http://localhost:\(AppInfo.webserverPort)/reader-mode/page?url=https%3A%2F%2Fen%2Em%2Ewikipedia%2Eorg%2Fwiki%2FMain%5FPage"))
             ]
         goodurls.forEach { XCTAssertEqual(URL(string:$0.0)!.encodeReaderModeURL(ReaderURL), $0.1) }
     }
@@ -322,13 +322,13 @@ class NSURLExtensionsTests: XCTestCase {
 
     func testschemeIsValid() {
         let goodurls = [
-            "http://localhost:6571/reader-mode/page",
+            "http://localhost:\(AppInfo.webserverPort)/reader-mode/page",
             "https://google.com",
             "tel:6044044004"
             ]
         let badurls = [
             "blah://google.com",
-            "hax://localhost:6571/sessionrestore.html",
+            "hax://localhost:\(AppInfo.webserverPort)/sessionrestore.html",
             "leet://codes.com"
         ]
 
@@ -338,15 +338,15 @@ class NSURLExtensionsTests: XCTestCase {
 
     func testisWebPage() {
         let goodurls = [
-            "http://localhost:6571/reader-mode/page",
-            "https://127.0.0.1:6571/sessionrestore.html",
-            "data://:6571/sessionrestore.html"
+            "http://localhost:\(AppInfo.webserverPort)/reader-mode/page",
+            "https://127.0.0.1:\(AppInfo.webserverPort)/sessionrestore.html",
+            "data://:\(AppInfo.webserverPort)/sessionrestore.html"
 
         ]
         let badurls = [
             "about://google.com",
             "tel:6044044004",
-            "hax://localhost:6571/about"
+            "hax://localhost:\(AppInfo.webserverPort)/about"
         ]
 
         goodurls.forEach { XCTAssertTrue(URL(string:$0)!.isWebPage(), $0) }
@@ -364,15 +364,15 @@ class NSURLExtensionsTests: XCTestCase {
 
     func testdisplayURL() {
         let goodurls = [
-            ("http://localhost:6571/reader-mode/page?url=https%3A%2F%2Fen%2Em%2Ewikipedia%2Eorg%2Fwiki%2F", "https://en.m.wikipedia.org/wiki/"),
+            ("http://localhost:\(AppInfo.webserverPort)/reader-mode/page?url=https%3A%2F%2Fen%2Em%2Ewikipedia%2Eorg%2Fwiki%2F", "https://en.m.wikipedia.org/wiki/"),
             ("\(InternalURL.baseUrl)/\(InternalURL.Path.errorpage)?url=http%3A//mozilla.com", "http://mozilla.com"),
             ("\(InternalURL.baseUrl)/\(InternalURL.Path.errorpage)?url=http%3A//mozilla.com", "http://mozilla.com"),
-            ("\(InternalURL.baseUrl)/\(InternalURL.Path.errorpage)?url=http%3A%2F%2Flocalhost%3A6571%2Freader-mode%2Fpage%3Furl%3Dhttps%253A%252F%252Fen%252Em%252Ewikipedia%252Eorg%252Fwiki%252F", "https://en.m.wikipedia.org/wiki/"),
+            ("\(InternalURL.baseUrl)/\(InternalURL.Path.errorpage)?url=http%3A%2F%2Flocalhost%3A\(AppInfo.webserverPort)%2Freader-mode%2Fpage%3Furl%3Dhttps%253A%252F%252Fen%252Em%252Ewikipedia%252Eorg%252Fwiki%252F", "https://en.m.wikipedia.org/wiki/"),
             ("https://mail.example.co.uk/index.html", "https://mail.example.co.uk/index.html"),
         ]
         let badurls = [
-            "http://localhost:6571/errors/error.html?url=http%3A//localhost%3A6571/about/home/%23panel%3D1",
-            "http://localhost:6571/errors/error.html",
+            "http://localhost:\(AppInfo.webserverPort)/errors/error.html?url=http%3A//localhost%3A\(AppInfo.webserverPort)/about/home/%23panel%3D1",
+            "http://localhost:\(AppInfo.webserverPort)/errors/error.html",
 
         ]
 
@@ -389,7 +389,7 @@ class NSURLExtensionsTests: XCTestCase {
         ]
         let badurls = [
             "http:///errors/error.html",
-            "http://:6571/about/home",
+            "http://:\(AppInfo.webserverPort)/about/home",
         ]
 
         goodurls.forEach { XCTAssertEqual(URL(string:$0.0)!.normalizedHostAndPath, $0.1) }

--- a/StorageTests/TestLogins.swift
+++ b/StorageTests/TestLogins.swift
@@ -361,9 +361,7 @@ class TestSQLiteLoginsPerf: XCTestCase {
 
         // Measure time to find all matching results
         self.measureMetrics([XCTPerformanceMetric.wallClockTime], automaticallyStartMeasuring: true) {
-            for _ in 0...5 {
-                self.logins.searchLoginsWithQuery("username").succeeded()
-            }
+            self.logins.searchLoginsWithQuery("username").succeeded()
             self.stopMeasuring()
         }
 

--- a/XCUITests/BaseTestCase.swift
+++ b/XCUITests/BaseTestCase.swift
@@ -5,8 +5,10 @@
 import MappaMundi
 import XCTest
 
+let serverPort = Int.random(in: 1025..<65000)
+
 func path(forTestPage page: String) -> String {
-    return "http://localhost:6571/test-fixture/\(page)"
+    return "http://localhost:\(serverPort)/test-fixture/\(page)"
 }
 
 class BaseTestCase: XCTestCase {
@@ -19,7 +21,7 @@ class BaseTestCase: XCTestCase {
 
     // These are used during setUp(). Change them prior to setUp() for the app to launch with different args,
     // or, use restart() to re-launch with custom args.
-    var launchArguments = [LaunchArguments.ClearProfile, LaunchArguments.SkipIntro, LaunchArguments.SkipWhatsNew, LaunchArguments.StageServer, LaunchArguments.DeviceName]
+    var launchArguments = [LaunchArguments.ClearProfile, LaunchArguments.SkipIntro, LaunchArguments.SkipWhatsNew, LaunchArguments.StageServer, LaunchArguments.DeviceName, "\(LaunchArguments.ServerPort)\(serverPort)"]
 
     func setUpScreenGraph() {
         navigator = createScreenGraph(for: self, with: app).navigator()

--- a/XCUITests/FindInPageTest.swift
+++ b/XCUITests/FindInPageTest.swift
@@ -17,7 +17,7 @@ class FindInPageTests: BaseTestCase {
     }
 
     func testFindInLargeDoc() {
-        navigator.openURL("http://localhost:6571/test-fixture/find-in-page-test.html")
+        navigator.openURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
         // Workaround until FxSGraph is fixed to allow the previos way with goto
         navigator.nowAt(BrowserTab)
 
@@ -80,7 +80,7 @@ class FindInPageTests: BaseTestCase {
     }
 
     func testFindInPageTwoWordsSearchLargeDoc() {
-        navigator.openURL("http://localhost:6571/test-fixture/find-in-page-test.html")
+        navigator.openURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
         // Workaround until FxSGraph is fixed to allow the previos way with goto
         navigator.nowAt(BrowserTab)
         waitForExistence(app/*@START_MENU_TOKEN@*/.buttons["TabLocationView.pageOptionsButton"]/*[[".buttons[\"Page Options Menu\"]",".buttons[\"TabLocationView.pageOptionsButton\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/, timeout: 15)

--- a/XCUITests/HistoryTests.swift
+++ b/XCUITests/HistoryTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 let webpage = ["url": "www.mozilla.org", "label": "Internet for people, not profit — Mozilla", "value": "mozilla.org"]
 // This is part of the info the user will see in recent closed tabs once the default visited website (https://www.mozilla.org/en-US/book/) is closed
-let closedWebPageLabel = "localhost:6571/test-fixture/test-mozilla-book.html"
+let closedWebPageLabel = "localhost:\(serverPort)/test-fixture/test-mozilla-book.html"
 
 class HistoryTests: BaseTestCase {
     let testWithDB = ["testOpenHistoryFromBrowserContextMenuOptions", "testClearHistoryFromSettings"]

--- a/XCUITests/SaveLoginsTests.swift
+++ b/XCUITests/SaveLoginsTests.swift
@@ -4,9 +4,9 @@
 
 import XCTest
 
-let domain = "http://localhost:6571"
+let domain = "http://localhost:\(serverPort)"
 let testLoginPage = path(forTestPage: "test-password.html")
-let savedLoginEntry = "test@example.com, http://localhost:6571"
+let savedLoginEntry = "test@example.com, http://localhost:\(serverPort)"
 let urlLogin = "linkedin.com"
 let mailLogin = "iosmztest@mailinator.com"
 

--- a/XCUITests/ToolbarTest.swift
+++ b/XCUITests/ToolbarTest.swift
@@ -4,7 +4,7 @@
 
 import XCTest
 
-let website1: [String: String] = ["url": path(forTestPage: "test-mozilla-org.html"), "label": "Internet for people, not profit — Mozilla", "value": "localhost", "longValue": "localhost:6571/test-fixture/test-mozilla-org.html"]
+let website1: [String: String] = ["url": path(forTestPage: "test-mozilla-org.html"), "label": "Internet for people, not profit — Mozilla", "value": "localhost", "longValue": "localhost:\(serverPort)/test-fixture/test-mozilla-org.html"]
 let website2 = path(forTestPage: "test-example.html")
 
 let PDFWebsite = ["url": "http://www.pdf995.com/samples/pdf.pdf"]
@@ -46,7 +46,7 @@ class ToolbarTests: BaseTestCase {
 
         navigator.openURL(website2)
         waitUntilPageLoad()
-        waitForValueContains(app.textFields["url"], value: "localhost:6571")
+        waitForValueContains(app.textFields["url"], value: "localhost:\(serverPort)")
         XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
         XCTAssertFalse(app.buttons["Forward"].isEnabled)
 

--- a/XCUITests/TopTabsTest.swift
+++ b/XCUITests/TopTabsTest.swift
@@ -7,12 +7,12 @@ import XCTest
 let url = "www.mozilla.org"
 let urlLabel = "Internet for people, not profit — Mozilla"
 let urlValue = "mozilla.org"
-let urlValueLong = "localhost:6571/test-fixture/test-mozilla-org.html"
+let urlValueLong = "localhost:\(serverPort)/test-fixture/test-mozilla-org.html"
 
 let urlExample = path(forTestPage: "test-example.html")
 let urlLabelExample = "Example Domain"
 let urlValueExample = "example"
-let urlValueLongExample = "localhost:6571/test-fixture/test-example.html"
+let urlValueLongExample = "localhost:\(serverPort)/test-fixture/test-example.html"
 
 let toastUrl = ["url": "twitter.com", "link": "About", "urlLabel": "about"]
 

--- a/test-fixtures/test-password.html
+++ b/test-fixtures/test-password.html
@@ -7,7 +7,7 @@
 
 <body aria-label="body">
 
-<form method="GET" action="http://localhost:6571/test-fixture/test-password-submit.html">
+<form method="GET" action="test-fixture/test-password-submit.html">
 <p>Username: <input id="username" type="text" value="test@example.com"></p>
 <p>Password: <input id="password" type="password" value="verysecret"></p>
 <p><input type="submit" value="Login" aria-label="submit"/></p>


### PR DESCRIPTION
Within the client, the `AppInfo.webserverPort` is used.
Within the test code, the global variable is `serverPort`. 