### PR TITLE
Bug 1520635 - Webview and Chrome out of sync

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1884,8 +1884,12 @@ extension BrowserViewController: TabManagerDelegate {
         }
 
         updateInContentHomePanel(selected?.url as URL?)
-        if let tab = selected, tab.url == nil, !tab.restoring, NewTabAccessors.getNewTabPage(self.profile.prefs) == .blankPage {
-            self.urlBar.tabLocationViewDidTapLocation(self.urlBar.locationView)
+        if let tab = selected, NewTabAccessors.getNewTabPage(self.profile.prefs) == .blankPage {
+            if tab.url == nil, !tab.restoring {
+                urlBar.tabLocationViewDidTapLocation(urlBar.locationView)
+            } else {
+                urlBar.leaveOverlayMode()
+            }
         }
     }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1520635

This repros 100% with the following STR:

1. Set New Tab to "Blank Page"
2. Open "twitter.com" in the first tab
3. Open "reddit.com" in a second tab
4. Tap the address bar in the tab with "reddit.com" to focus it
5. Open the tabs tray
6. Close the tab with "reddit.com"
7. Select the tab with "twitter.com"

You will then see the tab with "twitter.com" show a focused address bar with "reddit.com" in it.