### PR TITLE
Changes dispatchWorkItem in DeferredDBOperation to weak to prevent re…

### DIFF
--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -47,7 +47,7 @@ public class DBOperationCancelled : MaybeErrorType {
 }
 
 class DeferredDBOperation<T>: Deferred<T>, Cancellable {
-    fileprivate var dispatchWorkItem: DispatchWorkItem?
+    fileprivate weak var dispatchWorkItem: DispatchWorkItem?
     private var _running = false
 
     fileprivate weak var connection: ConcreteSQLiteDBConnection?


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1523053

`withConnection<T>` creates a `DeferredDBOperation<T>` that is never released according to Instruments. There are a number of ways to break the chain, the cleanest that I could find is committed (setting the `DispatchWorkItem` inside of `DeferredDBOperation<T>` to `weak`).

Other options include changing `doWork()` to `doWork(op: DeferredDBOperation<T>)` or setting `deferred` to be a weak reference inside of the `DispatchWorkItem` block: `DispatchWorkItem { [weak deferred] in ... }`.