### PR TITLE
Bug 1523379 - TPStatsBlocklists is not covered by tests

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -505,6 +505,7 @@
 		DD31E0FB1B382B520077078A /* TabPrintPageRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD31E0FA1B382B520077078A /* TabPrintPageRenderer.swift */; };
 		DDA24A431FD84D630098F159 /* DefaultSearchPrefs.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA24A341FD84D620098F159 /* DefaultSearchPrefs.swift */; };
 		DDA24A451FD84D630098F159 /* DefaultSearchPrefs.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA24A341FD84D620098F159 /* DefaultSearchPrefs.swift */; };
+		E1D8BC7A21FF7A0000B100BD /* TPStatsBlocklistsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D8BC7921FF7A0000B100BD /* TPStatsBlocklistsTests.swift */; };
 		E402000A1E6493C800B45AFF /* LaunchArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65075861E37F7AB006961AC /* LaunchArguments.swift */; };
 		E40AFC541DD0E93300DA5651 /* L10nPermissionStringsSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFC531DD0E93300DA5651 /* L10nPermissionStringsSnapshotTests.swift */; };
 		E40AFC651DD0F25500DA5651 /* L10nBaseSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFC641DD0F25500DA5651 /* L10nBaseSnapshotTests.swift */; };
@@ -1674,6 +1675,7 @@
 		D8EFFA251FF702A8001D3A09 /* NavigationRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRouterTests.swift; sourceTree = "<group>"; };
 		DD31E0FA1B382B520077078A /* TabPrintPageRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabPrintPageRenderer.swift; sourceTree = "<group>"; };
 		DDA24A341FD84D620098F159 /* DefaultSearchPrefs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultSearchPrefs.swift; sourceTree = "<group>"; };
+		E1D8BC7921FF7A0000B100BD /* TPStatsBlocklistsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPStatsBlocklistsTests.swift; sourceTree = "<group>"; };
 		E40A18F71EDC73D5006B7F28 /* Fennec.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Fennec.entitlements; sourceTree = "<group>"; };
 		E40A18F81EDC73D5006B7F28 /* FennecEnterprise.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = FennecEnterprise.entitlements; sourceTree = "<group>"; };
 		E40A18F91EDC73D5006B7F28 /* Firefox.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Firefox.entitlements; sourceTree = "<group>"; };
@@ -3497,6 +3499,7 @@
 				39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */,
 				D8EFFA251FF702A8001D3A09 /* NavigationRouterTests.swift */,
 				63306D442110BAF000F25400 /* TabManagerStoreTests.swift */,
+				E1D8BC7921FF7A0000B100BD /* TPStatsBlocklistsTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -5371,6 +5374,7 @@
 				4A59B58AD11B5EE1F80BBDEB /* TestHistory.swift in Sources */,
 				A83E5B1D1C1DA8D80026D912 /* UIPasteboardExtensionsTests.swift in Sources */,
 				28D52E2F1BCDF53900187A1D /* ResetTests.swift in Sources */,
+				E1D8BC7A21FF7A0000B100BD /* TPStatsBlocklistsTests.swift in Sources */,
 				D82ED2641FEB3C420059570B /* DefaultSearchPrefsTests.swift in Sources */,
 				3B61CD591F2A750800D38DE1 /* PocketFeedTests.swift in Sources */,
 				E696FE511C47F86E00EC007C /* AuthenticatorTests.swift in Sources */,

--- a/ClientTests/TPStatsBlocklistsTests.swift
+++ b/ClientTests/TPStatsBlocklistsTests.swift
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@testable import Client
+
+import XCTest
+
+class TPStatsBlocklistsTests: XCTestCase {
+    var blocklists: TPStatsBlocklists!
+    
+    override func setUp() {
+        super.setUp()
+        
+        blocklists = TPStatsBlocklists()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        blocklists = nil
+    }
+    
+    func testLoadPerformance() {
+        self.measureMetrics([.wallClockTime], automaticallyStartMeasuring: true) {
+            blocklists.load()
+            self.stopMeasuring()
+        }
+    }
+    
+    func testURLInListPerformance() {
+        blocklists.load()
+        
+        let whitelistedRegexs = [".google.com"].compactMap { (domain) -> NSRegularExpression? in
+            return wildcardContentBlockerDomainToRegex(domain: domain)
+        }
+        
+        self.measureMetrics([.wallClockTime], automaticallyStartMeasuring: true) {
+            _ = blocklists.urlIsInList(URL(string: "https://www.firefox.com")!, whitelistedDomains: whitelistedRegexs)
+            self.stopMeasuring()
+        }
+    }
+    
+    func testURLInList() {
+        blocklists.load()
+        
+        func urlTest(_ urlString: String, _ whitelistedDomains: [String] = []) -> BlocklistName? {
+            let whitelistedRegexs = whitelistedDomains.compactMap { (domain) -> NSRegularExpression? in
+                return wildcardContentBlockerDomainToRegex(domain: domain)
+            }
+
+            return blocklists.urlIsInList(URL(string: urlString)!, whitelistedDomains: whitelistedRegexs)
+        }
+        
+        XCTAssertEqual(urlTest("https://www.firefox.com"), nil)
+        XCTAssertEqual(urlTest("https://2leep.com/track"), .advertising)
+        XCTAssertEqual(urlTest("https://sub.2leep.com/ad"), .advertising)
+        XCTAssertEqual(urlTest("https://admeld.com"), nil)
+        XCTAssertEqual(urlTest("https://admeld.com/popup"), .advertising)
+        XCTAssertEqual(urlTest("https://sub.admeld.com"), nil)
+        XCTAssertEqual(urlTest("https://subadmeld.com"), nil)
+        
+        XCTAssertEqual(urlTest("https://aolanswers.com"), .content)
+        XCTAssertEqual(urlTest("https://sub.aolanswers.com"), .content)
+        XCTAssertEqual(urlTest("https://aolanswers.com/track"), .content)
+        XCTAssertEqual(urlTest("https://aol.com.aolanswers.com"), .content)
+        XCTAssertEqual(urlTest("https://aol.com.aolanswers.com", [".ers.com"]), nil)
+        XCTAssertEqual(urlTest("https://games.com.aolanswers.com"), .content)
+        XCTAssertEqual(urlTest("https://bluesky.com.aolanswers.com"), .content)
+        
+        XCTAssertEqual(urlTest("https://sub.xiti.com/track"), .analytics)
+        XCTAssertEqual(urlTest("https://backtype.com"), .social)
+        XCTAssertEqual(urlTest("https://backtype.com", [".firefox.com", ".e.com"]), nil)
+    }
+}

--- a/ClientTests/TPStatsBlocklistsTests.swift
+++ b/ClientTests/TPStatsBlocklistsTests.swift
@@ -30,7 +30,7 @@ class TPStatsBlocklistsTests: XCTestCase {
     func testURLInListPerformance() {
         blocklists.load()
         
-        let whitelistedRegexs = [".google.com"].compactMap { (domain) -> NSRegularExpression? in
+        let whitelistedRegexs = ["*google.com"].compactMap { (domain) -> NSRegularExpression? in
             return wildcardContentBlockerDomainToRegex(domain: domain)
         }
         
@@ -71,6 +71,6 @@ class TPStatsBlocklistsTests: XCTestCase {
 
         XCTAssertEqual(blocklist("https://sub.xiti.com/track"), .analytics)
         XCTAssertEqual(blocklist("https://backtype.com"), .social)
-        XCTAssertEqual(blocklist("https://backtype.com", [".firefox.com", "e.com"]), nil)
+        XCTAssertEqual(blocklist("https://backtype.com", ["*firefox.com", "*e.com"]), nil)
     }
 }

--- a/ClientTests/TPStatsBlocklistsTests.swift
+++ b/ClientTests/TPStatsBlocklistsTests.swift
@@ -35,7 +35,9 @@ class TPStatsBlocklistsTests: XCTestCase {
         }
         
         self.measureMetrics([.wallClockTime], automaticallyStartMeasuring: true) {
-            _ = blocklists.urlIsInList(URL(string: "https://www.firefox.com")!, whitelistedDomains: whitelistedRegexs)
+            for _ in 0..<100 {
+                _ = blocklists.urlIsInList(URL(string: "https://www.firefox.com")!, whitelistedDomains: whitelistedRegexs)
+            }
             self.stopMeasuring()
         }
     }
@@ -43,7 +45,7 @@ class TPStatsBlocklistsTests: XCTestCase {
     func testURLInList() {
         blocklists.load()
         
-        func urlTest(_ urlString: String, _ whitelistedDomains: [String] = []) -> BlocklistName? {
+        func blocklist(_ urlString: String, _ whitelistedDomains: [String] = []) -> BlocklistName? {
             let whitelistedRegexs = whitelistedDomains.compactMap { (domain) -> NSRegularExpression? in
                 return wildcardContentBlockerDomainToRegex(domain: domain)
             }
@@ -51,24 +53,24 @@ class TPStatsBlocklistsTests: XCTestCase {
             return blocklists.urlIsInList(URL(string: urlString)!, whitelistedDomains: whitelistedRegexs)
         }
         
-        XCTAssertEqual(urlTest("https://www.firefox.com"), nil)
-        XCTAssertEqual(urlTest("https://2leep.com/track"), .advertising)
-        XCTAssertEqual(urlTest("https://sub.2leep.com/ad"), .advertising)
-        XCTAssertEqual(urlTest("https://admeld.com"), nil)
-        XCTAssertEqual(urlTest("https://admeld.com/popup"), .advertising)
-        XCTAssertEqual(urlTest("https://sub.admeld.com"), nil)
-        XCTAssertEqual(urlTest("https://subadmeld.com"), nil)
-        
-        XCTAssertEqual(urlTest("https://aolanswers.com"), .content)
-        XCTAssertEqual(urlTest("https://sub.aolanswers.com"), .content)
-        XCTAssertEqual(urlTest("https://aolanswers.com/track"), .content)
-        XCTAssertEqual(urlTest("https://aol.com.aolanswers.com"), .content)
-        XCTAssertEqual(urlTest("https://aol.com.aolanswers.com", [".ers.com"]), nil)
-        XCTAssertEqual(urlTest("https://games.com.aolanswers.com"), .content)
-        XCTAssertEqual(urlTest("https://bluesky.com.aolanswers.com"), .content)
-        
-        XCTAssertEqual(urlTest("https://sub.xiti.com/track"), .analytics)
-        XCTAssertEqual(urlTest("https://backtype.com"), .social)
-        XCTAssertEqual(urlTest("https://backtype.com", [".firefox.com", ".e.com"]), nil)
+        XCTAssertEqual(blocklist("https://www.firefox.com"), nil)
+        XCTAssertEqual(blocklist("https://2leep.com/track"), .advertising)
+        XCTAssertEqual(blocklist("https://sub.2leep.com/ad"), .advertising)
+        XCTAssertEqual(blocklist("https://admeld.com"), nil)
+        XCTAssertEqual(blocklist("https://admeld.com/popup"), .advertising)
+        XCTAssertEqual(blocklist("https://sub.admeld.com"), nil)
+        XCTAssertEqual(blocklist("https://subadmeld.com"), nil)
+
+        XCTAssertEqual(blocklist("https://aolanswers.com"), .content)
+        XCTAssertEqual(blocklist("https://sub.aolanswers.com"), .content)
+        XCTAssertEqual(blocklist("https://aolanswers.com/track"), .content)
+        XCTAssertEqual(blocklist("https://aol.com.aolanswers.com"), .content)
+        XCTAssertEqual(blocklist("https://aol.com.aolanswers.com", ["ers.com"]), nil)
+        XCTAssertEqual(blocklist("https://games.com.aolanswers.com"), .content)
+        XCTAssertEqual(blocklist("https://bluesky.com.aolanswers.com"), .content)
+
+        XCTAssertEqual(blocklist("https://sub.xiti.com/track"), .analytics)
+        XCTAssertEqual(blocklist("https://backtype.com"), .social)
+        XCTAssertEqual(blocklist("https://backtype.com", [".firefox.com", "e.com"]), nil)
     }
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1523379

`TPStatsBlocklistsTests.swift` is added to provide benchmarks and a unit test for `TPStatsBlocklists`. Any recommendations or missed edge cases that should be added to the `urlIsInList` test can help a lot.

The motivation for covering `TPStatsBlocklists` with tests, in particular, is a followup performance improvement that benefits from having test coverage to ensure `TPStatsBlocklists` retains desired functionality.
