### PR TITLE
Setup the context menu helper hooks on every URL change event

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -534,6 +534,10 @@ class Tab: NSObject {
             return
         }
 
+        if let helper = contentScriptManager.getContentScript(ContextMenuHelper.name()) as? ContextMenuHelper {
+                helper.replaceWebViewLongPress()
+        }
+
         self.urlDidChangeDelegate?.tab(self, urlDidChangeTo: url)
     }
 


### PR DESCRIPTION
There is a small delay required after the URL change event, as on the initial URL change events WebKit has yet to install the gesture recognizer until the event loop has run (not sure how long to wait here, the 0.2s is arbitrary). This appears very reliable in my testing. 

See https://bugzilla.mozilla.org/show_bug.cgi?id=1520629 for the info on the WebKit bug that is related to this. Apple is fixing the bug, but this patch provides further safety.