### PR TITLE
Bug 1527859 - Integration tests disable login tests

### DIFF
--- a/SyncIntegrationTests/test_integration.py
+++ b/SyncIntegrationTests/test_integration.py
@@ -9,11 +9,11 @@ def test_sync_history_from_device(tps, xcodebuild):
 def test_sync_tabs_from_device(tps, xcodebuild):
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncTabs')
     tps.run('test_tabs.js')
-
+'''
 def test_sync_logins_from_device(tps, xcodebuild):
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncLogins')
     tps.run('test_password.js')
-
+'''
 def test_sync_bookmark_from_desktop(tps, xcodebuild):
     tps.run('test_bookmark_desktop.js')
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncBookmarkDesktop')
@@ -21,11 +21,11 @@ def test_sync_bookmark_from_desktop(tps, xcodebuild):
 def test_sync_history_from_desktop(tps, xcodebuild):
     tps.run('test_history_desktop.js')
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncHistoryDesktop')
-
+'''
 def test_sync_logins_from_desktop(tps, xcodebuild):
     tps.run('test_password_desktop.js')
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncPasswordDesktop')
-
+'''
 def test_tabs_tabs_from_desktop(tps, xcodebuild):
     tps.run('test_tabs_desktop.js')
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncTabsDesktop')


### PR DESCRIPTION
This a PR to disable temporarily the Sync Integration Logins tests until bug affecting them is solved