### PR TITLE
[nobug, build] buddybuild_postclone remove unneeded rust arch

### DIFF
--- a/buddybuild_postclone.sh
+++ b/buddybuild_postclone.sh
@@ -21,7 +21,7 @@ npm run build
 
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 source $HOME/.cargo/env
-rustup target add aarch64-apple-ios armv7-apple-ios armv7s-apple-ios x86_64-apple-ios i386-apple-ios
+rustup target add aarch64-apple-ios x86_64-apple-ios
 cargo install cargo-lipo
 
 #


### PR DESCRIPTION
Minor optimization to the buddybuild script, only 64-bit sim and iOS 11+ architectures are needed.