### PR TITLE
Bug 1527857 - Include `passwords` in the default Sync `m/g` record

### DIFF
--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -30,11 +30,15 @@ private let DefaultEngines: [String: Int] = [
     "clients": ClientsStorageVersion,
     "history": HistoryStorageVersion,
     "tabs": TabsStorageVersion,
-    // We opt-in to syncing collections we don't know about, since no client offers to sync non-enabled,
-    // non-declined engines yet.  See Bug 969669.
+    // We include collections we don't know about, or don't implement in Swift,
+    // because they'll be disabled on other clients if we omit them (bug
+    // 1479929).
+    "passwords": 1,
     "forms": 1,
     "addons": 1,
     "prefs": 2,
+    "addresses": 1,
+    "creditcards": 1,
 ]
 
 // Names of collections which will appear as declined in a default

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -98,7 +98,7 @@ class MetaGlobalTests: XCTestCase {
         guard let engineConfiguration = ready.scratchpad.engineConfiguration else {
             return
         }
-        XCTAssertEqual(engineConfiguration.enabled.sorted(), ["addons", "bookmarks", "clients", "forms", "history", "prefs", "tabs"])
+        XCTAssertEqual(engineConfiguration.enabled.sorted(), ["addons", "addresses", "bookmarks", "clients", "creditcards", "forms", "history", "passwords", "prefs", "tabs"])
         XCTAssertEqual(engineConfiguration.declined, [])
 
         // Basic verifications.


### PR DESCRIPTION
We need to include all collections that we expect to sync, even ones
we don't support (addresses and credit cards) or implement in Swift
(logins), because they'll be disabled by default on other clients if
we omit them from the record.

CC @justindarc for context.
@isabelrios, could you please check if this fixes the TPS failures you were seeing with #4519?