### PR TITLE
Bug 1526353 - Long press 'Open in new tab' should open adjacent to the current tab

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -411,8 +411,9 @@ extension TabDisplayManager: TabManagerDelegate {
 
         updateWith(animationType: .addTab) { [weak self] in
             if let me = self {
-                me.dataStore.insert(tab)
-                me.collectionView.insertItems(at: [IndexPath(row: me.dataStore.count - 1, section: 0)])
+                let index = me.tabsToDisplay.firstIndex(of: tab) ?? me.tabsToDisplay.count
+                me.dataStore.insert(tab, at: index)
+                me.collectionView.insertItems(at: [IndexPath(row: index, section: 0)])
             }
         }
     }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1526353

`TabDisplayManager` was always inserting the new tab at the end of its list. In this bug, if you long-pressed something on the Home panel and selected "Open in New Tab", it would appear to open at the end of the tab list. However, if you simply toggled the tabs tray or went in/out of PBM, the top tabs would refresh and the tab would appear in its correct location.