### PR TITLE
Bug 1524506 - Incorrect History new tab

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1102,6 +1102,10 @@ class BrowserViewController: UIViewController {
                 webView.evaluateJavaScript("\(ReaderModeNamespace).checkReadability()", completionHandler: nil)
             }
 
+            if urlBar.inOverlayMode, InternalURL.isValid(url: url), url.path.starts(with: "/about/home") {
+                urlBar.leaveOverlayMode()
+            }
+
             TabEvent.post(.didChangeURL(url), for: tab)
         }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1102,7 +1102,7 @@ class BrowserViewController: UIViewController {
                 webView.evaluateJavaScript("\(ReaderModeNamespace).checkReadability()", completionHandler: nil)
             }
 
-            if urlBar.inOverlayMode, InternalURL.isValid(url: url), url.path.starts(with: "/about/home") {
+            if urlBar.inOverlayMode, InternalURL.isValid(url: url), url.path.starts(with: "/\(AboutHomeHandler.path)") {
                 urlBar.leaveOverlayMode()
             }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1524506

To clarify the STR for the original bug:
1. Set "New Tab" to "Blank" in Settings
2. Set "Home" to "History" in Settings
3. Open a new tab, it should be blank with the address bar focused
    - Tapping the back arrow, the page should remain blank
4. Tap "Home" from the app menu, it *should* show the History panel in the current tab but doesn't
    - This is the actual bug
    - The page appears blank with the address bar focused
    - Tapping the back arrow, the History panel will finally be revealed

The solution here is simple: The URL bar should not be in "overlay mode" when showing the History panel.

My one question for you in this review is if there's a better way to check if the URL is the `/about/home` URL. I'm sure there is, but I couldn't figure it out.