### PR TITLE
Bug 1530399 - New Tab/Home labels for 'Firefox Home' incorrectly appear as 'TopSites'

### DIFF
--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -966,7 +966,7 @@ class NewTabPageSetting: Setting {
     override var accessibilityIdentifier: String? { return "NewTab" }
 
     override var status: NSAttributedString {
-        return NSAttributedString(string: NewTabAccessors.getNewTabPage(self.profile.prefs).rawValue)
+        return NSAttributedString(string: NewTabAccessors.getNewTabPage(self.profile.prefs).settingTitle)
     }
 
     override var style: UITableViewCellStyle { return .value1 }
@@ -991,7 +991,7 @@ class HomeSetting: Setting {
     override var accessibilityIdentifier: String? { return "Home" }
 
     override var status: NSAttributedString {
-        return NSAttributedString(string: NewTabAccessors.getHomePage(self.profile.prefs).rawValue)
+        return NSAttributedString(string: NewTabAccessors.getHomePage(self.profile.prefs).settingTitle)
     }
 
     override var style: UITableViewCellStyle { return .value1 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1530399