### PR TITLE
Bug 1531392 - [Regression] All options for New Tab and Home appear checked at all times

### DIFF
--- a/Client/Frontend/Theme/ThemedWidgets.swift
+++ b/Client/Frontend/Theme/ThemedWidgets.swift
@@ -4,16 +4,7 @@
 import UIKit
 
 class ThemedTableViewCell: UITableViewCell, Themeable {
-
     var detailTextColor: UIColor = UIColor.theme.tableView.disabledRowText
-
-    override func willMove(toWindow newWindow: UIWindow?) {
-        super.willMove(toWindow: newWindow)
-        if newWindow != nil {
-            // UIView appearing
-            applyTheme()
-        }
-    }
 
     func applyTheme() {
         textLabel?.textColor = UIColor.theme.tableView.rowText


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1531392

This removes the overridden implementation of `willMove` that was added in https://github.com/mozilla-mobile/firefox-ios/commit/066fc373d44878c0acd804bfd1317e17b820ed2c