### PR TITLE
Bug 1533718 - XCUITests Followup Fennec name change in Share Sheet

### DIFF
--- a/XCUITests/PhotonActionSheetTest.swift
+++ b/XCUITests/PhotonActionSheetTest.swift
@@ -84,17 +84,19 @@ class PhotonActionSheetTest: BaseTestCase {
         navigator.goto(PageOptionsMenu)
         app.tables["Context Menu"].staticTexts["Share Page With…"].tap()
         waitForExistence(app.buttons["Copy"])
-        let fennecElement = app.collectionViews.cells.collectionViews.containing(.button, identifier:"Reminders").buttons["Fennec (buddybuild)"]
-        if (!fennecElement.exists) {
+        let countButtons = app.collectionViews.cells.collectionViews.buttons.count
+        let fennecElement = app.collectionViews.cells.collectionViews.buttons.element(boundBy: 1)
+        // If Fennec has not been configured there are 5 buttons, 6 if it is there already
+        if (countButtons <= 6) {
             let moreElement = app.collectionViews.cells.collectionViews.containing(.button, identifier:"Reminders").buttons["More"]
             moreElement.tap()
-            waitForExistence(app.switches["Fennec (buddybuild)"])
-            app.switches["Fennec (buddybuild)"].tap()
+            waitForExistence(app.switches["Reminders"])
+            // Tap on Fennec switch
+            app.switches.element(boundBy: 1).tap()
             app.buttons["Done"].tap()
             waitForExistence(app.buttons["Copy"])
         }
         fennecElement.tap()
-
         waitForExistence(app.navigationBars["ShareTo.ShareView"])
     }
 
@@ -106,8 +108,9 @@ class PhotonActionSheetTest: BaseTestCase {
         waitForExistence(app.buttons["Copy"])
         let moreElement = app.collectionViews.cells.collectionViews.containing(.button, identifier:"Reminders").buttons["More"]
         moreElement.tap()
-        waitForExistence(app.switches["Fennec (buddybuild)"])
-        app.switches["Fennec (buddybuild)"].tap()
+        waitForExistence(app.switches["Reminders"])
+        // Tap on Fennec switch
+        app.switches.element(boundBy: 1).tap()
         app.buttons["Done"].tap()
         waitForExistence(app.buttons["Copy"], timeout: 3)
     }


### PR DESCRIPTION
This PR uses the element order for the switch to tap on it while we try to add an id for it. Using the label name is not a solution since it is shown differently in each machine where the tests run