### PR TITLE
Bug 1530622 - [Regression] Remove Bookmark label is not aligned in PageObjectMenu

### DIFF
--- a/Client/Frontend/Menu/Menu.xcassets/menu-Bookmark-Remove.imageset/Contents.json
+++ b/Client/Frontend/Menu/Menu.xcassets/menu-Bookmark-Remove.imageset/Contents.json
@@ -2,18 +2,7 @@
   "images" : [
     {
       "idiom" : "universal",
-      "filename" : "bookmark-remove.png",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "filename" : "bookmark-remove@2x.png",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "filename" : "bookmark-remove@3x.png",
-      "scale" : "3x"
+      "filename" : "bookmark-remove.pdf"
     }
   ],
   "info" : {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1530622