### PR TITLE
Bug 1534193 - XCUItests update Pocket tests after new UI changes addi…

### DIFF
--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -296,11 +296,18 @@ extension ActivityStreamPanel: UICollectionViewDelegateFlowLayout {
                     view.moreButton.isHidden = false
                     view.moreButton.addTarget(self, action: #selector(showMorePocketStories), for: .touchUpInside)
                     view.titleLabel.textColor = UIColor.Pocket.red
+                    view.titleLabel.accessibilityIdentifier = "pocketTitle"
                     view.moreButton.setTitleColor(UIColor.Pocket.red, for: .normal)
                     view.iconView.tintColor = UIColor.Pocket.red
                     return view
-                case .topSites, .libraryShortcuts:
+                case .topSites:
                     view.title = title
+                    view.titleLabel.accessibilityIdentifier = "topSitesTitle"
+                    view.moreButton.isHidden = true
+                    return view
+                case .libraryShortcuts:
+                    view.title = title
+                    view.titleLabel.accessibilityIdentifier = "libraryTitle"
                     view.moreButton.isHidden = true
                     return view
             }
@@ -835,7 +842,6 @@ extension ASFooterView: Themeable {
 class ASHeaderView: UICollectionReusableView {
     lazy fileprivate var titleLabel: UILabel = {
         let titleLabel = UILabel()
-        titleLabel.accessibilityIdentifier = "pocketTitle"
         titleLabel.text = self.title
         titleLabel.textColor = UIColor.theme.homePanel.activityStreamHeaderText
         titleLabel.font = ASHeaderViewUX.TextFont

--- a/XCUITests/PocketTests.swift
+++ b/XCUITests/PocketTests.swift
@@ -16,10 +16,10 @@ class PocketTest: BaseTestCase {
         if iPad() {
             XCTAssertEqual(numPocketStories, 9)
         } else {
-            XCTAssertEqual(numPocketStories, 4)
+            XCTAssertEqual(numPocketStories, 3)
         }
 
-        // Disable Pocked
+        // Disable Pocket
         navigator.performAction(Action.TogglePocketInNewTab)
         navigator.goto(NewTabScreen)
         waitForNoExistence(app.staticTexts["pocketTitle"])


### PR DESCRIPTION
…ng Library shortcuts

This PR changes some ids. With previous IDs defined and new UI changes, all sections in the UI had the same ID 'pocketTile' and so the test was failing due to multiple matches. With this PR we tried to change the IDs, and the number of Pocket stories to fix the test.