### PR TITLE
Bug 1532976 - Remove DB lock to check if db isclosed

### DIFF
--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -254,8 +254,9 @@ open class SwiftData {
     /// Reopens a database that had previously been force-closed.
     /// Does nothing if this database is already open.
     func reopenIfClosed() {
+        // Non guarded read to avoid locking the queue (which can be slow). Simultaneous read-writes are a non-issue with a bool in this case.
+        guard self.closed else { return }
         primaryConnectionQueue.sync {
-            guard self.closed else { return }
             self.closed = false
             let baseFilename = URL(fileURLWithPath: self.filename).lastPathComponent
             NotificationCenter.default.post(name: .DatabaseWasReopened, object: baseFilename)


### PR DESCRIPTION
When introducing sleep statements into the DB ops, this call be seen locking the main thread repeatedly when the ActivityStream panel shows. 
One might argue that this boolean could be wrapped in a dedicated serial queue (with `test` and `testAndSet` type ops), but I don't see the need just yet.