### PR TITLE
Bug 1532976 - Only try reopen the DB on app lifecycle events

### DIFF
--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -417,9 +417,6 @@ extension ActivityStreamPanel: DataObserverDelegate {
         // If the pocket stories are not availible for the Locale the PocketAPI will return nil
         // So it is okay if the default here is true
 
-        //Reopen the db if its closed. If it is already open this will do nothing.
-        self.profile.reopen()
-
         self.getTopSites().uponQueue(.main) { _ in
             // If there is no pending cache update and highlights are empty. Show the onboarding screen
             self.collectionView?.reloadData()


### PR DESCRIPTION
There is a perf bug in ActivityStreamPanel trying to reopen the DB, which is a
main-thread locking DB operation.
Revert the patch for Bug 1519805 and re-open it
reopened: https://bugzilla.mozilla.org/show_bug.cgi?id=1519805
