### PR TITLE
Bug 1527035 - iOS 12.2 breaks context menu

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -853,7 +853,7 @@ class BrowserViewController: UIViewController {
     }
 
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
-        guard let webView = object as? WKWebView else {
+        guard let webView = object as? WKWebView, let tab = tabManager[webView] else {
             assert(false)
             return
         }
@@ -862,14 +862,14 @@ class BrowserViewController: UIViewController {
             return
         }
 
-        if webView == tabManager.selectedTab?.webView, let tab = tabManager.selectedTab, let helper = tab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper {
+        if let helper = tab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper {
             // This is zero-cost if already installed. It needs to be checked frequently (hence every event here triggers this function), as when a new tab is created it requires multiple attempts to setup the handler correctly.
-	    helper.replaceGestureHandlerIfNeeded()
+             helper.replaceGestureHandlerIfNeeded()
         }
 
         switch path {
         case .estimatedProgress:
-            guard webView == tabManager.selectedTab?.webView else { break }
+            guard tab === tabManager.selectedTab else { break }
             if let url = webView.url, !InternalURL.isValid(url: url) {
                 urlBar.updateProgressBar(Float(webView.estimatedProgress))
             } else {
@@ -878,7 +878,7 @@ class BrowserViewController: UIViewController {
         case .loading:
             guard let loading = change?[.newKey] as? Bool else { break }
 
-            if webView == tabManager.selectedTab?.webView {
+            if tab === tabManager.selectedTab {
                 navigationToolbar.updateReloadStatus(loading)
             }
 
@@ -886,8 +886,6 @@ class BrowserViewController: UIViewController {
                 runScriptsOnWebView(webView)
             }
         case .URL:
-            guard let tab = tabManager[webView] else { break }
-
             // To prevent spoofing, only change the URL immediately if the new URL is on
             // the same origin as the current URL. Otherwise, do nothing and wait for
             // didCommitNavigation to confirm the page load.
@@ -899,8 +897,6 @@ class BrowserViewController: UIViewController {
                 }
             }
         case .title:
-            guard let tab = tabManager[webView] else { break }
-
             // Ensure that the tab title *actually* changed to prevent repeated calls
             // to navigateInTab(tab:).
             guard let title = tab.title else { break }
@@ -908,14 +904,14 @@ class BrowserViewController: UIViewController {
                 navigateInTab(tab: tab)
             }
         case .canGoBack:
-            guard webView == tabManager.selectedTab?.webView,
-                let canGoBack = change?[.newKey] as? Bool else { break }
-
+            guard tab === tabManager.selectedTab, let canGoBack = change?[.newKey] as? Bool else {
+                break
+            }
             navigationToolbar.updateBackStatus(canGoBack)
         case .canGoForward:
-            guard webView == tabManager.selectedTab?.webView,
-                let canGoForward = change?[.newKey] as? Bool else { break }
-
+            guard tab === tabManager.selectedTab, let canGoForward = change?[.newKey] as? Bool else {
+                break
+            }
             navigationToolbar.updateForwardStatus(canGoForward)
         default:
             assertionFailure("Unhandled KVO key: \(keyPath ?? "nil")")

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -862,6 +862,10 @@ class BrowserViewController: UIViewController {
             return
         }
 
+        if webView == tabManager.selectedTab?.webView, let tab = tabManager.selectedTab, let helper = tab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper {
+             helper.replaceGestureHandlerIfNeeded()
+        }
+
         switch path {
         case .estimatedProgress:
             guard webView == tabManager.selectedTab?.webView else { break }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -863,7 +863,8 @@ class BrowserViewController: UIViewController {
         }
 
         if webView == tabManager.selectedTab?.webView, let tab = tabManager.selectedTab, let helper = tab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper {
-             helper.replaceGestureHandlerIfNeeded()
+            // This is zero-cost if already installed. It needs to be checked frequently (hence every event here triggers this function), as when a new tab is created it requires multiple attempts to setup the handler correctly.
+	    helper.replaceGestureHandlerIfNeeded()
         }
 
         switch path {

--- a/Client/Frontend/Browser/ContextMenuHelper.swift
+++ b/Client/Frontend/Browser/ContextMenuHelper.swift
@@ -42,7 +42,7 @@ class ContextMenuHelper: NSObject {
         kvoInfo.layer = layer
         kvoInfo.observation = layer.observe(\.bounds) { (_, _) in
             // The layer bounds updates when the document context (and gestures) have been setup
-            if self.gestureRecognizerWithDescriptionFragment("ContextMenuHelper") == nil  {
+            if self.gestureRecognizerWithDescriptionFragment("ContextMenuHelper") == nil {
                 self.replaceWebViewLongPress()
             }
         }


### PR DESCRIPTION
The WKContentView's main CALayer gets 'bounds' notifications when the content view setup is complete.
Installing the gesture handler override at this time seems to work well.
