### PR TITLE
Bug 1535007 - Improve unverified state of setting screen

### DIFF
--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -157,6 +157,8 @@ class SyncNowSetting: WithAccountSetting {
         return attributedString
     }
 
+    override var hidden: Bool { return !enabled }
+
     override var enabled: Bool {
         if !DeviceInfo.hasConnectivity() {
             return false


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1535007

Pretty simple fix: don't show the "Sync Now" row if it isn't enabled.