### PR TITLE
Bug 1535008 - Unverified icon looks pointy

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -487,7 +487,8 @@ extension PhotonActionSheetProtocol {
         }
 
         let iconURL = (actionNeeded == .none) ? account?.fxaProfile?.avatar.url : nil
-        let syncOption = PhotonActionSheetItem(title: title, iconString: iconString, iconURL: iconURL, iconType: .URL, accessory: .Sync, handler: action)
+        let iconType: PhotonActionSheetIconType = (actionNeeded == .none) ? .URL : .Image
+        let syncOption = PhotonActionSheetItem(title: title, iconString: iconString, iconURL: iconURL, iconType: iconType, accessory: .Sync, handler: action)
         return syncOption
     }
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1535008

Another simple fix. The `iconType` dictates whether or not we set a `cornerRadius` on the image layer. The only time the `.URL` type is used is for loading the avatar icon which *should* have a `cornerRadius`. All other regular icons are of type `.Image` and do not have a `cornerRadius`.