### PR TITLE
Bug 1530969 - Send tab causes two focused tabs

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -473,10 +473,6 @@ class BrowserViewController: UIViewController {
             if !receivedURLs.isEmpty {
                 DispatchQueue.main.async {
                     self.tabManager.addTabsForURLs(receivedURLs, zombie: false)
-
-                    if let lastURL = receivedURLs.last, let tab = self.tabManager.getTabForURL(lastURL) {
-                        self.tabManager.selectTab(tab)
-                    }
                 }
             }
         }

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -476,11 +476,9 @@ extension TabDisplayManager: TabManagerDelegate {
 
     func tabManagerDidAddTabs(_ tabManager: TabManager) {
         cancelDragAndGestures()
-        refreshStore()
     }
 
     func tabManagerDidRemoveAllTabs(_ tabManager: TabManager, toast: ButtonToast?) {
         cancelDragAndGestures()
-        refreshStore()
     }
 }


### PR DESCRIPTION
TabDisplayManager's refreshStore() will cancel any pending animations, which in
this case is a selected tab change animation. Need to be more careful about
using this call in the TabDisplayManager.
