### PR TITLE
Bug 1536840 - Deleting FxA account on-device leaves app in state that appears connected

### DIFF
--- a/Client/Frontend/Settings/FxAContentViewController.swift
+++ b/Client/Frontend/Settings/FxAContentViewController.swift
@@ -29,6 +29,7 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
         case changePassword = "change_password"
         case sessionStatus = "session_status"
         case signOut = "sign_out"
+        case deleteAccount = "delete_account"
     }
 
     weak var delegate: FxAContentViewControllerDelegate?
@@ -122,6 +123,13 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
         injectData("message", content: ["status": "error"])
     }
 
+    // The user has deleted their Firefox Account. Disconnect them!
+    fileprivate func onDeleteAccount(_ data: JSON) {
+        FxALoginHelper.sharedInstance.applicationDidDisconnect(UIApplication.shared)
+        LeanPlumClient.shared.set(attributes: [LPAttributeKey.signedInSync: profile.hasAccount()])
+        dismiss(animated: true)
+    }
+
     // The user has signed in to a Firefox Account.  We're done!
     fileprivate func onLogin(_ data: JSON) {
         injectData("message", content: ["status": "login"])
@@ -180,6 +188,8 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
                 onSessionStatus(data)
             case .signOut:
                 onSignOut(data)
+            case .deleteAccount:
+                onDeleteAccount(data)
             }
         }
     }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1536840

I found this bug while trying to test another FxA bug where I needed to be in an "unverified" state and I deleted my account from on the device to re-create it. It is really bad that we didn't support this case before. Basically, this treats account deletion the same as if you disconnected your account.