### PR TITLE
Bug 1534563 - New tab scroll position is incorrect if opened after scolling down pocket stories

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1659,6 +1659,14 @@ extension BrowserViewController: SearchViewControllerDelegate {
 
 extension BrowserViewController: TabManagerDelegate {
     func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?, isRestoring: Bool) {
+        // Reset the scroll position for the ActivityStreamPanel so that it
+        // is always presented scrolled to the top when switching tabs.
+        if !isRestoring, selected != previous,
+            let homePanelVC = homePanelController as? TabbedHomePanelController,
+            let activityStreamPanel = homePanelVC.currentPanel as? ActivityStreamPanel {
+            activityStreamPanel.scrollToTop()
+        }
+
         // Remove the old accessibilityLabel. Since this webview shouldn't be visible, it doesn't need it
         // and having multiple views with the same label confuses tests.
         if let wv = previous?.webView {
@@ -1769,9 +1777,6 @@ extension BrowserViewController: TabManagerDelegate {
                 urlBar.leaveOverlayMode()
             }
         }
-    }
-
-    func tabManager(_ tabManager: TabManager, willAddTab tab: Tab) {
     }
 
     func tabManager(_ tabManager: TabManager, didAddTab tab: Tab, isRestoring: Bool) {

--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -149,6 +149,10 @@ class ActivityStreamPanel: UICollectionViewController, HomePanel {
             collectionView.reloadData()
         }
     }
+
+    func scrollToTop(animated: Bool = false) {
+        collectionView?.setContentOffset(.zero, animated: animated)
+    }
 }
 
 // MARK: -  Section management


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1534563

This resets the scroll position of the `ActivityStreamPanel` any time the selected tab changes so that it is always presented from the top when the user changes or opens a new tab.