### PR TITLE
Bug 1537709 - ContextMenuHelper retain cycle causing crash

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -858,7 +858,7 @@ class BrowserViewController: UIViewController {
             return
         }
 
-        if tab === tabManager.selectedTab, let helper = tab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper {
+        if let helper = tab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper {
             // This is zero-cost if already installed. It needs to be checked frequently (hence every event here triggers this function), as when a new tab is created it requires multiple attempts to setup the handler correctly.
              helper.replaceGestureHandlerIfNeeded()
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -858,7 +858,7 @@ class BrowserViewController: UIViewController {
             return
         }
 
-        if let helper = tab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper {
+        if tab === tabManager.selectedTab, let helper = tab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper {
             // This is zero-cost if already installed. It needs to be checked frequently (hence every event here triggers this function), as when a new tab is created it requires multiple attempts to setup the handler correctly.
              helper.replaceGestureHandlerIfNeeded()
         }

--- a/Client/Frontend/Browser/ContextMenuHelper.swift
+++ b/Client/Frontend/Browser/ContextMenuHelper.swift
@@ -40,10 +40,10 @@ class ContextMenuHelper: NSObject {
         }
 
         kvoInfo.layer = layer
-        kvoInfo.observation = layer.observe(\.bounds) { (_, _) in
+        kvoInfo.observation = layer.observe(\.bounds) { [weak self] (_, _) in
             // The layer bounds updates when the document context (and gestures) have been setup
-            if self.gestureRecognizerWithDescriptionFragment("ContextMenuHelper") == nil {
-                self.replaceWebViewLongPress()
+            if self?.gestureRecognizerWithDescriptionFragment("ContextMenuHelper") == nil {
+                self?.replaceWebViewLongPress()
             }
         }
     }

--- a/Client/Frontend/Browser/ContextMenuHelper.swift
+++ b/Client/Frontend/Browser/ContextMenuHelper.swift
@@ -30,12 +30,19 @@ class ContextMenuHelper: NSObject {
         self.tab = tab
     }
 
+    func uninstall() {
+        kvoInfo.observation?.invalidate()
+    }
+
     // BVC KVO events for all changes on the webview will call this. It is called a lot during a page load.
     func replaceGestureHandlerIfNeeded() {
         // If the main layer changes, re-install KVO observation.
         // It seems the main layer changes only once after intialization of the webview,
         // so the if condition only runs twice.
-        guard let layer = self.tab?.webView?.scrollView.subviews[0].layer, layer != kvoInfo.layer else {
+
+        guard let scrollview = tab?.webView?.scrollView else { return }
+        let wkContentView = scrollview.subviews.first { String(describing: $0).hasPrefix("<WKContentView") }
+        guard let layer = wkContentView?.layer, layer != kvoInfo.layer else {
             return
         }
 
@@ -52,9 +59,9 @@ class ContextMenuHelper: NSObject {
         // WebKit installs gesture handlers async. If `replaceWebViewLongPress` is called after a wkwebview in most cases a small delay is sufficient
         // See also https://bugs.webkit.org/show_bug.cgi?id=193366
 
-        self.nativeHighlightLongPressRecognizer = self.gestureRecognizerWithDescriptionFragment("action=_highlightLongPressRecognized:")
+        nativeHighlightLongPressRecognizer = gestureRecognizerWithDescriptionFragment("action=_highlightLongPressRecognized:")
 
-        if let nativeLongPressRecognizer = self.gestureRecognizerWithDescriptionFragment("action=_longPressRecognized:") {
+        if let nativeLongPressRecognizer = gestureRecognizerWithDescriptionFragment("action=_longPressRecognized:") {
             nativeLongPressRecognizer.removeTarget(nil, action: nil)
             nativeLongPressRecognizer.addTarget(self, action: #selector(self.longPressGestureDetected))
         }

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -602,6 +602,8 @@ private class TabContentScriptManager: NSObject, WKScriptMessageHandler {
 
     // Without calling this, the TabContentScriptManager will leak.
     func uninstall(tab: Tab) {
+        (helpers[ContextMenuHelper.name()] as? ContextMenuHelper)?.uninstall()
+        
         helpers.forEach { helper in
             if let name = helper.value.scriptMessageHandlerName() {
                 tab.webView?.configuration.userContentController.removeScriptMessageHandler(forName: name)

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -298,13 +298,13 @@ class Tab: NSObject {
     }
 
     func closeAndRemovePrivateBrowsingData() {
+        contentScriptManager.uninstall(tab: self)
+
         webView?.removeObserver(self, forKeyPath: KVOConstants.URL.rawValue)
 
         if let webView = webView {
             tabDelegate?.tab?(self, willDeleteWebView: webView)
         }
-
-        contentScriptManager.helpers.removeAll()
 
         if isPrivate {
             removeAllBrowsingData()
@@ -598,15 +598,22 @@ extension Tab: ContentBlockerTab {
 }
 
 private class TabContentScriptManager: NSObject, WKScriptMessageHandler {
-    fileprivate var helpers = [String: TabContentScript]()
+    private var helpers = [String: TabContentScript]()
+
+    // Without calling this, the TabContentScriptManager will leak.
+    func uninstall(tab: Tab) {
+        helpers.forEach { helper in
+            if let name = helper.value.scriptMessageHandlerName() {
+                tab.webView?.configuration.userContentController.removeScriptMessageHandler(forName: name)
+            }
+        }
+    }
 
     @objc func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         for helper in helpers.values {
-            if let scriptMessageHandlerName = helper.scriptMessageHandlerName() {
-                if scriptMessageHandlerName == message.name {
-                    helper.userContentController(userContentController, didReceiveScriptMessage: message)
-                    return
-                }
+            if let scriptMessageHandlerName = helper.scriptMessageHandlerName(), scriptMessageHandlerName == message.name {
+                helper.userContentController(userContentController, didReceiveScriptMessage: message)
+                return
             }
         }
     }


### PR DESCRIPTION
To be clear, I can't reproduce the crash, but the crash report is reporting
a bad retain of the KVO observer, and there is an obvious bug in that code.
Fingers crossed this fixes it.

The second commit is to fix a long-standing leak in the TabContentScriptManager.

EDIT: I can repro the crash on 12.1 sim, I was using 11.4 sim and it didn't crash.