### PR TITLE
Bug 1537948 - 0xdead10cc crashes

### DIFF
--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -245,7 +245,7 @@ open class SwiftData {
     /// The shutdown is *sync*, meaning the queue will complete the current db operations before closing.
     /// If an operation is queued with an open connection, it will execute before this runs.
     func forceClose() {
-        primaryConnectionQueue.async {
+        primaryConnectionQueue.sync {
             guard !self.closed else { return }
             self.closed = true
             self.primaryConnection = nil
@@ -258,7 +258,7 @@ open class SwiftData {
     /// Reopens a database that had previously been force-closed.
     /// Does nothing if this database is already open.
     func reopenIfClosed() {
-        primaryConnectionQueue.async {
+        primaryConnectionQueue.sync {
             guard self.closed else { return }
             self.closed = false
             let baseFilename = URL(fileURLWithPath: self.filename).lastPathComponent


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1537948

Upon reconsideration, I don't feel comfortable about this recent change we made where we went from `sync` to `async` on `forceClose()` and `reopenIfClosed()`. Since we removed the extraneous calls to `reopenIfClosed()`, this should be fine.