### PR TITLE
Bug 1523241 - TabsButton animations overlapping and showing wrong count

### DIFF
--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -27,6 +27,10 @@ class TabsButton: UIButton {
     var highlightTextColor: UIColor?
     var highlightBackgroundColor: UIColor?
 
+    // When all animations are completed, this is the most-recently assigned tab count that is shown.
+    // updateTabCount() can be called in rapid succession, this ensures only final tab count is displayed.
+    private var countToBe = "1"
+
     override var isHighlighted: Bool {
         didSet {
             if isHighlighted {
@@ -133,70 +137,73 @@ class TabsButton: UIButton {
         let count = max(count, 1)
         let currentCount = self.countLabel.text
         let infinity = "\u{221E}"
-        let countToBe = (count < 100) ? count.description : infinity
+        countToBe = (count < 100) ? count.description : infinity
 
         // only animate a tab count change if the tab count has actually changed
-        if currentCount != count.description || (clonedTabsButton?.countLabel.text ?? count.description) != count.description {
-            if let _ = self.clonedTabsButton {
-                self.clonedTabsButton?.layer.removeAllAnimations()
-                self.clonedTabsButton?.removeFromSuperview()
-                insideButton.layer.removeAllAnimations()
-            }
-
-            // make a 'clone' of the tabs button
-            let newTabsButton = clone() as! TabsButton
-
-            self.clonedTabsButton = newTabsButton
-            newTabsButton.frame = self.bounds
-            newTabsButton.addTarget(self, action: #selector(cloneDidClickTabs), for: .touchUpInside)
-            newTabsButton.countLabel.text = countToBe
-            newTabsButton.accessibilityValue = countToBe
-            newTabsButton.insideButton.frame = self.insideButton.frame
-            newTabsButton.snp.removeConstraints()
-            self.addSubview(newTabsButton)
-            newTabsButton.snp.makeConstraints { make  in
-                make.center.equalTo(self)
-            }
-
-            // Instead of changing the anchorPoint of the CALayer, lets alter the rotation matrix math to be
-            // a rotation around a non-origin point
-            let frame = self.insideButton.frame
-            let halfTitleHeight = frame.height / 2
-            var newFlipTransform = CATransform3DIdentity
-            newFlipTransform = CATransform3DTranslate(newFlipTransform, 0, halfTitleHeight, 0)
-            newFlipTransform.m34 = -1.0 / 200.0 // add some perspective
-            newFlipTransform = CATransform3DRotate(newFlipTransform, CGFloat(-(Double.pi / 2)), 1.0, 0.0, 0.0)
-            newTabsButton.insideButton.layer.transform = newFlipTransform
-
-            var oldFlipTransform = CATransform3DIdentity
-            oldFlipTransform = CATransform3DTranslate(oldFlipTransform, 0, halfTitleHeight, 0)
-            oldFlipTransform.m34 = -1.0 / 200.0 // add some perspective
-            oldFlipTransform = CATransform3DRotate(oldFlipTransform, CGFloat(-(Double.pi / 2)), 1.0, 0.0, 0.0)
-
-            let animate = {
-                newTabsButton.insideButton.layer.transform = CATransform3DIdentity
-                self.insideButton.layer.transform = oldFlipTransform
-                self.insideButton.layer.opacity = 0
-            }
-
-            let completion: (Bool) -> Void = { completed in
-                let noActiveAnimations = self.insideButton.layer.animationKeys()?.isEmpty ?? true
-                if completed || noActiveAnimations {
-                    newTabsButton.removeFromSuperview()
-                    self.insideButton.layer.opacity = 1
-                    self.insideButton.layer.transform = CATransform3DIdentity
-                }
-                self.accessibilityLabel = NSLocalizedString("Show Tabs", comment: "Accessibility label for the tabs button in the (top) tab toolbar")
-                self.countLabel.text = countToBe
-                self.accessibilityValue = countToBe
-            }
-
-            if animated {
-                UIView.animate(withDuration: 1.5, delay: 0, usingSpringWithDamping: 0.5, initialSpringVelocity: 0.0, options: [], animations: animate, completion: completion)
-            } else {
-                completion(true)
-            }
+        guard currentCount != count.description || (clonedTabsButton?.countLabel.text ?? count.description) != count.description else {
+            return
         }
+
+        if let _ = self.clonedTabsButton {
+            self.clonedTabsButton?.layer.removeAllAnimations()
+            self.clonedTabsButton?.removeFromSuperview()
+            insideButton.layer.removeAllAnimations()
+        }
+
+        // make a 'clone' of the tabs button
+        let newTabsButton = clone() as! TabsButton
+
+        self.clonedTabsButton = newTabsButton
+        newTabsButton.frame = self.bounds
+        newTabsButton.addTarget(self, action: #selector(cloneDidClickTabs), for: .touchUpInside)
+        newTabsButton.countLabel.text = countToBe
+        newTabsButton.accessibilityValue = countToBe
+        newTabsButton.insideButton.frame = self.insideButton.frame
+        newTabsButton.snp.removeConstraints()
+        self.addSubview(newTabsButton)
+        newTabsButton.snp.makeConstraints { make  in
+            make.center.equalTo(self)
+        }
+
+        // Instead of changing the anchorPoint of the CALayer, lets alter the rotation matrix math to be
+        // a rotation around a non-origin point
+        let frame = self.insideButton.frame
+        let halfTitleHeight = frame.height / 2
+        var newFlipTransform = CATransform3DIdentity
+        newFlipTransform = CATransform3DTranslate(newFlipTransform, 0, halfTitleHeight, 0)
+        newFlipTransform.m34 = -1.0 / 200.0 // add some perspective
+        newFlipTransform = CATransform3DRotate(newFlipTransform, CGFloat(-(Double.pi / 2)), 1.0, 0.0, 0.0)
+        newTabsButton.insideButton.layer.transform = newFlipTransform
+
+        var oldFlipTransform = CATransform3DIdentity
+        oldFlipTransform = CATransform3DTranslate(oldFlipTransform, 0, halfTitleHeight, 0)
+        oldFlipTransform.m34 = -1.0 / 200.0 // add some perspective
+        oldFlipTransform = CATransform3DRotate(oldFlipTransform, CGFloat(-(Double.pi / 2)), 1.0, 0.0, 0.0)
+
+        let animate = {
+            newTabsButton.insideButton.layer.transform = CATransform3DIdentity
+            self.insideButton.layer.transform = oldFlipTransform
+            self.insideButton.layer.opacity = 0
+        }
+
+        let completion: (Bool) -> Void = { completed in
+            let noActiveAnimations = self.insideButton.layer.animationKeys()?.isEmpty ?? true
+            if completed || noActiveAnimations {
+                newTabsButton.removeFromSuperview()
+                self.insideButton.layer.opacity = 1
+                self.insideButton.layer.transform = CATransform3DIdentity
+            }
+            self.accessibilityLabel = NSLocalizedString("Show Tabs", comment: "Accessibility label for the tabs button in the (top) tab toolbar")
+            self.countLabel.text = self.countToBe
+            self.accessibilityValue = self.countToBe
+        }
+
+        if animated {
+            UIView.animate(withDuration: 1.5, delay: 0, usingSpringWithDamping: 0.5, initialSpringVelocity: 0.0, options: [], animations: animate, completion: completion)
+        } else {
+            completion(true)
+        }
+
     }
     @objc func cloneDidClickTabs() {
         sendActions(for: .touchUpInside)

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -31,6 +31,9 @@ class TabsButton: UIButton {
     // updateTabCount() can be called in rapid succession, this ensures only final tab count is displayed.
     private var countToBe = "1"
 
+    // Re-entrancy guard to ensure the function is complete before starting another animation.
+    private var isUpdatingTabCount = false
+
     override var isHighlighted: Bool {
         didSet {
             if isHighlighted {
@@ -144,6 +147,16 @@ class TabsButton: UIButton {
             return
         }
 
+        // Re-entrancy guard: if this code is running just update the tab count value without starting another animation.
+        if isUpdatingTabCount {
+            if let clone = self.clonedTabsButton {
+                clone.countLabel.text = countToBe
+                clone.accessibilityValue = countToBe
+            }
+            return
+        }
+        isUpdatingTabCount = true
+
         if let _ = self.clonedTabsButton {
             self.clonedTabsButton?.layer.removeAllAnimations()
             self.clonedTabsButton?.removeFromSuperview()
@@ -196,6 +209,7 @@ class TabsButton: UIButton {
             self.accessibilityLabel = NSLocalizedString("Show Tabs", comment: "Accessibility label for the tabs button in the (top) tab toolbar")
             self.countLabel.text = self.countToBe
             self.accessibilityValue = self.countToBe
+            self.isUpdatingTabCount = false
         }
 
         if animated {


### PR DESCRIPTION
I am only seeing this on 12.1. The updateTabCount(count) is being called repeatedly, and the overlapping animations are behaving unpredictably. One update animation at a time is enough, and just ensure that the most-recently set tab count is the value shown in the final step of the animation.