### PR TITLE
Bug 1537709 - Follow up patch, some code wasn't removed.

### DIFF
--- a/Client/Frontend/Browser/ContextMenuHelper.swift
+++ b/Client/Frontend/Browser/ContextMenuHelper.swift
@@ -55,7 +55,7 @@ class ContextMenuHelper: NSObject {
         }
     }
 
-    func replaceWebViewLongPress() {
+    private func replaceWebViewLongPress() {
         // WebKit installs gesture handlers async. If `replaceWebViewLongPress` is called after a wkwebview in most cases a small delay is sufficient
         // See also https://bugs.webkit.org/show_bug.cgi?id=193366
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -534,10 +534,6 @@ class Tab: NSObject {
             return
         }
 
-        if let helper = contentScriptManager.getContentScript(ContextMenuHelper.name()) as? ContextMenuHelper {
-                helper.replaceWebViewLongPress()
-        }
-
         self.urlDidChangeDelegate?.tab(self, urlDidChangeTo: url)
     }
 


### PR DESCRIPTION
There was an extra gesture handler installation from a prev iteration of the
patch that was not removed.
