### PR TITLE
Bug 1538604 - Install context menu crash, no more layer.bounds KVO

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -534,10 +534,6 @@ class Tab: NSObject {
             return
         }
 
-        if let helper = contentScriptManager.getContentScript(ContextMenuHelper.name()) as? ContextMenuHelper {
-                helper.replaceWebViewLongPress()
-        }
-
         self.urlDidChangeDelegate?.tab(self, urlDidChangeTo: url)
     }
 
@@ -602,8 +598,6 @@ private class TabContentScriptManager: NSObject, WKScriptMessageHandler {
 
     // Without calling this, the TabContentScriptManager will leak.
     func uninstall(tab: Tab) {
-        (helpers[ContextMenuHelper.name()] as? ContextMenuHelper)?.uninstall()
-        
         helpers.forEach { helper in
             if let name = helper.value.scriptMessageHandlerName() {
                 tab.webView?.configuration.userContentController.removeScriptMessageHandler(forName: name)


### PR DESCRIPTION
Simplfy the approach, and just try install the gesture handler on
all webview events. This method seems highly reliable as once the webview
is loading a URL, the WKContentView appears to have been fully initialized and
the gestures can be overridden.

There are ample progress and URL change events that happen before the document is interactive for the user.