### PR TITLE
Bug 1539189 - Awesomebar not canceling consecutively typed queries

### DIFF
--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -71,13 +71,20 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
 
                 // Failed cursors are excluded in .get().
                 if let cursor = result.successValue {
-                    // First, see if the query matches any URLs from the user's search history.
+
+                    // Load the data in the table view.
                     self.load(cursor)
+
+                    // If the new search string is not longer than the previous,
+                    // we don't need to find an autocomplete suggestion.
+                    guard oldValue.count < self.query.count else {
+                        return
+                    }
+
+                    // First, see if the query matches any URLs from the user's search history.
                     for site in cursor {
                         if let url = site?.url, let completion = self.completionForURL(url) {
-                            if oldValue.count < self.query.count {
-                                self.urlBar.setAutocompleteSuggestion(completion)
-                            }
+                            self.urlBar.setAutocompleteSuggestion(completion)
                             return
                         }
                     }
@@ -85,9 +92,7 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
                     // If there are no search history matches, try matching one of the Alexa top domains.
                     for domain in self.topDomains {
                         if let completion = self.completionForDomain(domain) {
-                            if oldValue.count < self.query.count {
-                                self.urlBar.setAutocompleteSuggestion(completion)
-                            }
+                            self.urlBar.setAutocompleteSuggestion(completion)
                             return
                         }
                     }

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -73,7 +73,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     fileprivate func commonInit() {
         super.delegate = self
         super.addTarget(self, action: #selector(AutocompleteTextField.textDidChange), for: .editingChanged)
-        notifyTextChanged = debounce(0.1, action: {
+        notifyTextChanged = debounce(0.15, action: {
             if self.isEditing {
                 self.autocompleteDelegate?.autocompleteTextField(self, didEnterText: self.normalizeString(self.text ?? ""))
             }

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -87,7 +87,14 @@ class DeferredDBOperation<T>: Deferred<T>, Cancellable {
     }
     
     override func fill(_ value: T) {
-        dispatchWorkItem = nil
+        defer {
+            dispatchWorkItem = nil
+        }
+
+        guard !cancelled else {
+            return
+        }
+
         super.fill(value)
     }
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1539189

This adds that `cancelled` check in `fill()`.

This also makes a decision to bail out on finding an autocomplete result much earlier now and also moves all the regex matching onto a background thread instead of doing *all* the work in the completion handler on main.