### PR TITLE
 Bug 1540148 - Awesomebar seems to be prioritizing older results 

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1392,6 +1392,17 @@ extension BrowserViewController: URLBarDelegate {
         return locationActionsForURLBar(urlBar).map { $0.accessibilityCustomAction }
     }
 
+    func urlBar(_ urlBar: URLBarView, didRestoreText text: String) {
+        if text.isEmpty {
+            hideSearchController()
+        } else {
+            showSearchController()
+        }
+
+        searchController?.searchQuery = text
+        searchLoader?.setQueryWithoutAutocomplete(text)
+    }
+
     func urlBar(_ urlBar: URLBarView, didEnterText text: String) {
         if text.isEmpty {
             hideSearchController()

--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -24,14 +24,14 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
     fileprivate let urlBar: URLBarView
     fileprivate let frecentHistory: FrecentHistory
 
-    private var isFirstQuery: Bool
+    private var skipNextAutocomplete: Bool
 
     init(profile: Profile, urlBar: URLBarView) {
         self.profile = profile
         self.urlBar = urlBar
         self.frecentHistory = profile.history.getFrecentHistory()
 
-        self.isFirstQuery = true
+        self.skipNextAutocomplete = false
 
         super.init()
     }
@@ -83,10 +83,10 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
                         return
                     }
 
-                    // If this is the first change of the value, we
-                    // don't need to find an autocomplete suggestion.
-                    guard !self.isFirstQuery else {
-                        self.isFirstQuery = false
+                    // If we should skip the next autocomplete, reset
+                    // the flag and bail out here.
+                    guard !self.skipNextAutocomplete else {
+                        self.skipNextAutocomplete = false
                         return
                     }
 
@@ -108,6 +108,11 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
                 }
             }
         }
+    }
+
+    func setQueryWithoutAutocomplete(_ query: String) {
+        skipNextAutocomplete = true
+        self.query = query
     }
 
     fileprivate func completionForURL(_ url: String) -> String? {

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -39,6 +39,7 @@ protocol URLBarDelegate: AnyObject {
     func urlBarDidTapShield(_ urlBar: URLBarView, from button: UIButton)
     func urlBarLocationAccessibilityActions(_ urlBar: URLBarView) -> [UIAccessibilityCustomAction]?
     func urlBarDidPressScrollToTop(_ urlBar: URLBarView)
+    func urlBar(_ urlBar: URLBarView, didRestoreText text: String)
     func urlBar(_ urlBar: URLBarView, didEnterText text: String)
     func urlBar(_ urlBar: URLBarView, didSubmitText text: String)
     // Returns either (search query, true) or (url, false).
@@ -415,7 +416,7 @@ class URLBarView: UIView {
         if search {
             locationTextField?.text = text
             // Not notifying when empty agrees with AutocompleteTextField.textDidChange.
-            delegate?.urlBar(self, didEnterText: text)
+            delegate?.urlBar(self, didRestoreText: text)
         } else {
             locationTextField?.setTextWithoutSearching(text)
         }

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -73,7 +73,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     fileprivate func commonInit() {
         super.delegate = self
         super.addTarget(self, action: #selector(AutocompleteTextField.textDidChange), for: .editingChanged)
-        notifyTextChanged = debounce(0.15, action: {
+        notifyTextChanged = debounce(0.1, action: {
             if self.isEditing {
                 self.autocompleteDelegate?.autocompleteTextField(self, didEnterText: self.normalizeString(self.text ?? ""))
             }

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -83,20 +83,27 @@ fileprivate func escapeFTSSearchString(_ search: String) -> String {
     // characters. Otherwise, form a different type of search
     // string to attempt to match the start of URLs.
     guard words.count > 1 else {
-        if let word = words.first {
-            if word.count > 2 {
-                return "\"\(word)*\""
-            } else {
-                return "title: \"^\(word)*\" OR " +
-                    "url: \"^http://\(word)*\" OR " +
-                    "url: \"^https://\(word)*\" OR " +
-                    "url: \"^http://www.\(word)*\" OR " +
-                    "url: \"^https://www.\(word)*\" OR " +
-                    "url: \"^http://m.\(word)*\" OR " +
-                    "url: \"^https://m.\(word)*\""
-            }
-        } else {
+        guard let word = words.first else {
             return ""
+        }
+
+        let charThresholdForSearchAll = 2
+        if word.count > charThresholdForSearchAll {
+            return "\"\(word)*\""
+        } else {
+            let titlePrefix = "title: \"^"
+            let httpPrefix = "url: \"^http://"
+            let httpsPrefix = "url: \"^https://"
+
+            return [titlePrefix,
+                    httpPrefix,
+                    httpsPrefix,
+                    httpPrefix + "www.",
+                    httpsPrefix + "www.",
+                    httpPrefix + "m.",
+                    httpsPrefix + "m."]
+                .map({ "\($0)\(word)*\"" })
+                .joined(separator: " OR ")
         }
     }
 

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -91,7 +91,9 @@ fileprivate func escapeFTSSearchString(_ search: String) -> String {
                     "url: \"^http://\(word)*\" OR " +
                     "url: \"^https://\(word)*\" OR " +
                     "url: \"^http://www.\(word)*\" OR " +
-                    "url: \"^https://www.\(word)*\""
+                    "url: \"^https://www.\(word)*\" OR " +
+                    "url: \"^http://m.\(word)*\" OR " +
+                    "url: \"^https://m.\(word)*\""
             }
         } else {
             return ""


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1540148

2 things here:
1. 1 or 2-character queries are now prefaced with `http(s)://(www.)` in order to properly match the start of URLs in history
2. Fix an additional edge case I missed yesterday where the first character typed in the awesomebar on a blank new tab was not autocompleting. Also, this code is *slightly* easier to follow now (i.e. knowing when we're *restoring* versus *entering* text)