### PR TITLE
Bug 1541832 - UITests: New test to cover regression autocompletion

### DIFF
--- a/UITests/DomainAutocompleteTests.swift
+++ b/UITests/DomainAutocompleteTests.swift
@@ -45,6 +45,67 @@ class DomainAutocompleteTests: KIFTestCase {
         BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "bar.baz", completion: ".org")
     }
 
+    func testAutocompleteAfterDeleteWithBackSpace() {
+        tester().waitForAnimationsToFinish()
+        tester().tapView(withAccessibilityIdentifier: "url")
+        let textField = tester().waitForView(withAccessibilityLabel: "Address and Search") as! UITextField
+        tester().enterText(intoCurrentFirstResponder: "facebook")
+        tester().waitForAnimationsToFinish()
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "facebook", completion: ".com")
+
+        // Remove the completion part .com
+        tester().enterText(intoCurrentFirstResponder: XCUIKeyboardKey.delete.rawValue)
+        tester().waitForAnimationsToFinish()
+
+        // Tap on Go to perform a search
+        EarlGrey.selectElement(with: grey_accessibilityLabel("Go")).perform(grey_tap())
+        tester().waitForAnimationsToFinish()
+        tester().wait(forTimeInterval: 1)
+
+        // Tap on the url to go back to the awesomebar results
+        tester().tapView(withAccessibilityIdentifier: "url")
+        tester().waitForAnimationsToFinish()
+        let textField2 = tester().waitForView(withAccessibilityLabel: "Address and Search") as! UITextField
+        // Facebook word appears highlighted and so it is shown as facebook\u{7F} when extracting the value to compare
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField2 , prefix: "", completion: "facebook\u{7F}")
+    }
+
+    // Bug https://bugzilla.mozilla.org/show_bug.cgi?id=1541832 scenario 1
+    func testAutocompleteOnechar() {
+        tester().waitForAnimationsToFinish()
+        tester().tapView(withAccessibilityIdentifier: "url")
+        let textField = tester().waitForView(withAccessibilityLabel: "Address and Search") as! UITextField
+        tester().enterText(intoCurrentFirstResponder: "f")
+        tester().waitForAnimationsToFinish()
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "f", completion: "acebook.com")
+    }
+
+    // Bug https://bugzilla.mozilla.org/show_bug.cgi?id=1541832 scenario 2
+    func testAutocompleteOneCharAfterRemovingPreviousTerm() {
+        tester().tapView(withAccessibilityIdentifier: "url")
+        let textField = tester().waitForView(withAccessibilityLabel: "Address and Search") as! UITextField
+        tester().enterText(intoCurrentFirstResponder: "foo")
+
+        // Remove the completion part and the the foo chars one by one
+        for _ in 1...4 {
+            EarlGrey.selectElement(with: grey_accessibilityID("address")).perform(grey_typeText("\u{0008}"))
+        }
+        tester().waitForAnimationsToFinish()
+        tester().enterText(intoCurrentFirstResponder: "f")
+        tester().waitForAnimationsToFinish()
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "f", completion: "acebook.com")
+    }
+
+    // Bug https://bugzilla.mozilla.org/show_bug.cgi?id=1541832 scenario 3
+    func testAutocompleteOneCharAfterRemovingWithClearButton() {
+        tester().tapView(withAccessibilityIdentifier: "url")
+        let textField = tester().waitForView(withAccessibilityLabel: "Address and Search") as! UITextField
+        tester().enterText(intoCurrentFirstResponder: "foo")
+        tester().tapView(withAccessibilityLabel: "Clear text")
+        tester().enterText(intoCurrentFirstResponder: "f")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "f", completion: "acebook.com")
+    }
+
     override func tearDown() {
         super.tearDown()
         EarlGrey.selectElement(with: grey_accessibilityID("goBack")).perform(grey_tap())

--- a/XCUITests/SearchTest.swift
+++ b/XCUITests/SearchTest.swift
@@ -198,4 +198,11 @@ class SearchTests: BaseTestCase {
         let numTab = app.buttons["Show Tabs"].value as? String
         XCTAssertEqual("2", numTab)
     }
+    // Bug https://bugzilla.mozilla.org/show_bug.cgi?id=1541832 scenario 4
+    func testSearchStartAfterTypingTwoWords() {
+        navigator.goto(URLBarOpen)
+        app.typeText("foo bar")
+        app.typeText(XCUIKeyboardKey.return.rawValue)
+        waitForValueContains(app.textFields["url"], value: "google")
+    }
 }


### PR DESCRIPTION
This PR adds a new UITest to cover one more scenario in the Domain Autocompletion test suite