### PR TITLE
Bug 1543303 - Don't show clipboard bar for url this is already open in a tab

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -162,7 +162,8 @@ class TabManager: NSObject {
         assert(Thread.isMainThread)
 
         for tab in tabs {
-            if tab.webView?.url == url {
+            if let webViewUrl = tab.webView?.url,
+                url.isEqual(webViewUrl) {
                 return tab
             }
 

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -306,6 +306,14 @@ extension URL {
         }
         return self
     }
+    
+    public func isEqual(_ url: URL) -> Bool {
+        var absoluteString = url.absoluteString
+        if let lastCh = url.absoluteString.last, lastCh == "/" {
+            absoluteString.removeLast()
+        }
+        return (absoluteString == self.absoluteString) ? true : false
+    }
 }
 
 // Extensions to deal with ReaderMode URLs

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -308,11 +308,18 @@ extension URL {
     }
     
     public func isEqual(_ url: URL) -> Bool {
-        var absoluteString = url.absoluteString
-        if let lastCh = url.absoluteString.last, lastCh == "/" {
-            absoluteString.removeLast()
+        if self == url {
+            return true
         }
-        return (absoluteString == self.absoluteString) ? true : false
+
+        // Try an additional equality case by chopping off the trailing slash
+        let urls: [String] = [url.absoluteString, absoluteString].map { item in
+            if let lastCh = item.last, lastCh == "/" {
+                return item.dropLast().lowercased()
+            }
+            return item.lowercased()
+        }
+        return urls[0] == urls[1]
     }
 }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1543303

Copy the page URL, then open the FireFox and show me the "Go to copied link?" view then click "Go" and visit this site.
Kill the app and re-open, then again displays clipboard bar for url this is already open in a tab

Because copied link is "www.google.com" but webView.url is "www.google.com/". That are not same. We handle cases where / exists in some paths