### PR TITLE
Fix #4698 - Wrong favicon background color

### DIFF
--- a/Client/Extensions/UIImageViewExtensions.swift
+++ b/Client/Extensions/UIImageViewExtensions.swift
@@ -41,12 +41,7 @@ public extension UIImageView {
     * Fetch a background color for a specfic favicon UIImage. It uses the URL to store the UIColor in memory for subsequent requests.
     */
     private func color(forImage image: UIImage, andURL url: URL, completed completionBlock: ((UIColor) -> Void)? = nil) {
-        guard let domain = url.baseDomain else {
-            self.backgroundColor = UIColor.Photon.Grey50
-            completionBlock?(UIColor.Photon.Grey50)
-            return
-        }
-
+        let domain = url.domainURL.absoluteString
         if let color = FaviconFetcher.colors[domain] {
             self.backgroundColor = color
             completionBlock?(color)


### PR DESCRIPTION
Background color should not be stored by base domain (www.mozilla.org -> becomes mozilla.org), as favicons exist for subdomains (www.mozilla.org, bugzilla.mozilla.org, etc). In this case whichever subdomain was visited first, that would become the background color for the domain.