### PR TITLE
Fix #4773 - XCUITest disable saved login autofilled

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_SmokeXCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_SmokeXCUITests.xcscheme
@@ -407,6 +407,12 @@
                   Identifier = "LibraryTest">
                </Test>
                <Test
+                  Identifier = "LibraryTestsIpad">
+               </Test>
+               <Test
+                  Identifier = "LibraryTestsIphone">
+               </Test>
+               <Test
                   Identifier = "MailAppSettingsTests">
                </Test>
                <Test

--- a/XCUITests/SaveLoginsTests.swift
+++ b/XCUITests/SaveLoginsTests.swift
@@ -181,6 +181,7 @@ class SaveLoginTest: BaseTestCase {
     }
 
     // Smoketest
+    /* Disabling this test until a local website can be used to prevent from false failures
     func testSavedLoginAutofilled() {
         navigator.openURL(urlLogin)
         waitUntilPageLoad()
@@ -206,5 +207,5 @@ class SaveLoginTest: BaseTestCase {
         XCTAssertEqual(emailValue as! String, mailLogin)
         let passwordValue = app.webViews.secureTextFields["Password"].value!
         XCTAssertEqual(passwordValue as! String, "••••••••")
-    }
+    }*/
 }


### PR DESCRIPTION
This PR is to disable an unstable test to prevent us from having false failures. 
Also using this PR to disable tests that are not part of the smoketest suite