### PR TITLE
Bug 1497965 - Make toast views stretch all the way to the bottom of t…

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -388,6 +388,7 @@ class BrowserViewController: UIViewController {
 
         view.addSubview(alertStackView)
         footer = UIView()
+        footer.layer.zPosition = CGFloat.leastNormalMagnitude
         view.addSubview(footer)
         alertStackView.axis = .vertical
         alertStackView.alignment = .center
@@ -1858,8 +1859,7 @@ extension BrowserViewController: TabManagerDelegate {
         }
 
         toast.showToast(viewController: self, delay: delay, duration: duration, makeConstraints: { make in
-            make.left.right.equalTo(self.view)
-            make.bottom.equalTo(self.webViewContainer?.safeArea.bottom ?? 0)
+            make.left.right.bottom.equalTo(self.view)
         })
     }
 

--- a/Client/Frontend/Browser/ButtonToast.swift
+++ b/Client/Frontend/Browser/ButtonToast.swift
@@ -36,12 +36,13 @@ class ButtonToast: Toast {
         self.toastView.backgroundColor = backgroundColor
 
         self.toastView.snp.makeConstraints { make in
-            make.left.right.height.equalTo(self)
-            self.animationConstraint = make.top.equalTo(self).offset(ButtonToastUX.ToastHeight).constraint
+            make.left.right.equalTo(self)
+            make.height.equalTo(ButtonToastUX.ToastHeight)
+            self.animationConstraint = make.top.equalTo(self).offset(ButtonToastUX.ToastHeight + UIConstants.BottomToolbarHeight).constraint
         }
 
         self.snp.makeConstraints { make in
-            make.height.equalTo(ButtonToastUX.ToastHeight)
+            make.height.equalTo(ButtonToastUX.ToastHeight + UIConstants.BottomToolbarHeight)
         }
     }
 

--- a/Client/Frontend/Browser/Toast.swift
+++ b/Client/Frontend/Browser/Toast.swift
@@ -22,6 +22,17 @@ class Toast: UIView {
     lazy var toastView: UIView = {
         let toastView = UIView()
         toastView.backgroundColor = SimpleToastUX.ToastDefaultColor
+
+        let tabToolBarFooterMaskView = UIView()
+        tabToolBarFooterMaskView.backgroundColor = SimpleToastUX.ToastDefaultColor
+        toastView.addSubview(tabToolBarFooterMaskView)
+
+        tabToolBarFooterMaskView.snp.makeConstraints { make in
+          make.left.right.equalTo(toastView)
+          make.height.equalTo(UIConstants.BottomToolbarHeight)
+          make.bottom.equalTo(toastView).offset(UIConstants.BottomToolbarHeight)
+        }
+
         return toastView
     }()
 


### PR DESCRIPTION
This pull request changes extend the toast to stretch all the way to the bottom. #4716

*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [ ] My patch has a standard commit message that looks like `Bug 12345678 - This fixes something something`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots
![Simulator Screen Shot - iPhone XS - 2019-04-15 at 13 04 39](https://user-images.githubusercontent.com/3780511/56115261-97058d00-5f95-11e9-905e-40d71591ece3.png)
![Simulator Screen Shot - iPhone XS - 2019-04-15 at 13 04 42](https://user-images.githubusercontent.com/3780511/56115270-9a991400-5f95-11e9-9106-d2de527db10d.png)

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
