### PR TITLE
Fix #4790 - logins.db still locked when app suspended

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -345,14 +345,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             application.endBackgroundTask(taskId)
         })
 
+        func endTask() {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                // Allow time for db closure, as iOS will kill the app immediately if file handles are still open.
+                application.endBackgroundTask(taskId)
+            }
+        }
+
         if profile.hasSyncableAccount() {
             profile.syncManager.syncEverything(why: .backgrounded).uponQueue(.main) { _ in
                 self.shutdownProfileWhenNotActive(application)
-                application.endBackgroundTask(taskId)
+                endTask()
             }
         } else {
             profile._shutdown()
-            application.endBackgroundTask(taskId)
+            endTask()
         }
     }
 


### PR DESCRIPTION
Wait 200 ms before killing the background task to ensure file closure is complete.