### PR TITLE
Fix #4775 - Use Library navigation controller for Bookmarks and History panels

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -382,6 +382,7 @@
 		D05434D9225BAA6200FDE4EF /* RustPlaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05434D8225BAA6200FDE4EF /* RustPlaces.swift */; };
 		D05434E3225BBC4100FDE4EF /* RustShared.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05434E2225BBC4100FDE4EF /* RustShared.swift */; };
 		D05435192261171200FDE4EF /* Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FCAE21A1ABB51F800877008 /* Storage.framework */; };
+		D054352A226687A400FDE4EF /* UIBarButtonItemExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0543529226687A400FDE4EF /* UIBarButtonItemExtensions.swift */; };
 		D057B2AB220103BC000614E0 /* RustLogins.swift in Sources */ = {isa = PBXBuildFile; fileRef = D057B2AA220103BC000614E0 /* RustLogins.swift */; };
 		D0625C98208E87F10081F3B2 /* DownloadQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0625C97208E87F10081F3B2 /* DownloadQueue.swift */; };
 		D0625CA8208FC47A0081F3B2 /* BrowserViewController+DownloadQueueDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0625CA7208FC47A0081F3B2 /* BrowserViewController+DownloadQueueDelegate.swift */; };
@@ -1476,6 +1477,7 @@
 		D05434BF2257DE9900FDE4EF /* Leanplum.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Leanplum.framework; path = Carthage/Build/iOS/Leanplum.framework; sourceTree = "<group>"; };
 		D05434D8225BAA6200FDE4EF /* RustPlaces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustPlaces.swift; sourceTree = "<group>"; };
 		D05434E2225BBC4100FDE4EF /* RustShared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustShared.swift; sourceTree = "<group>"; };
+		D0543529226687A400FDE4EF /* UIBarButtonItemExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIBarButtonItemExtensions.swift; sourceTree = "<group>"; };
 		D057B2AA220103BC000614E0 /* RustLogins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustLogins.swift; sourceTree = "<group>"; };
 		D0625C97208E87F10081F3B2 /* DownloadQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadQueue.swift; sourceTree = "<group>"; };
 		D0625CA7208FC47A0081F3B2 /* BrowserViewController+DownloadQueueDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BrowserViewController+DownloadQueueDelegate.swift"; sourceTree = "<group>"; };
@@ -3035,6 +3037,7 @@
 				7B9BF91B1E43472E00CB24F4 /* JSONExtensions.swift */,
 				7B3D9E641E4CBFDB007A50DA /* NSCoderExtensions.swift */,
 				E693F0D81E9D64BD0086DC17 /* OptionalExtensions.swift */,
+				D0543529226687A400FDE4EF /* UIBarButtonItemExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -4566,6 +4569,7 @@
 				E650759B1E37F7AB006961AC /* CrashSimulator.m in Sources */,
 				288A2DB51AB8B38D0023ABC3 /* Error.swift in Sources */,
 				E65075A91E37F7AB006961AC /* URLExtensions.swift in Sources */,
+				D054352A226687A400FDE4EF /* UIBarButtonItemExtensions.swift in Sources */,
 				7479B4EF1C5306A200DF000B /* Reachability.swift in Sources */,
 				E65075B31E37F7AB006961AC /* KeyboardHelper.swift in Sources */,
 				E65075AA1E37F7AB006961AC /* URLProtectionSpaceExtensions.swift in Sources */,

--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -161,7 +161,7 @@ enum NavigationPath {
         }
 
         let controller = ThemedNavigationController(rootViewController: baseSettingsVC)
-        controller.popoverDelegate = bvc
+        controller.presentingModalViewControllerDelegate = bvc
         controller.modalPresentationStyle = UIModalPresentationStyle.formSheet
         rootNav.present(controller, animated: true, completion: nil)
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -745,9 +745,6 @@ class BrowserViewController: UIViewController {
             libraryViewController.selectedPanel = panel
         }
 
-//        let controller = ThemedNavigationController(rootViewController: libraryViewController)
-//        controller.presentingModalViewControllerDelegate = self
-
         // Wait to present VC in an async dispatch queue to prevent a case where dismissal
         // of this popover on iPad seems to block the presentation of the modal VC.
         DispatchQueue.main.async {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -732,27 +732,26 @@ class BrowserViewController: UIViewController {
     }
 
     func showLibrary(panel: LibraryPanelType? = nil) {
-        if let presentedVC = self.presentedViewController {
-            presentedVC.dismiss(animated: true, completion: nil)
+        if let presentedViewController = self.presentedViewController {
+            presentedViewController.dismiss(animated: true, completion: nil)
         }
 
-        let libraryViewController = self.libraryViewController ?? LibraryViewController()
-        libraryViewController.profile = self.profile
+        let libraryViewController = self.libraryViewController ?? LibraryViewController(profile: profile)
         libraryViewController.delegate = self
+
         self.libraryViewController = libraryViewController
 
         if panel != nil {
             libraryViewController.selectedPanel = panel
         }
 
-        let controller = ThemedNavigationController(rootViewController: libraryViewController)
-        controller.popoverDelegate = self
-        controller.modalPresentationStyle = .formSheet
+//        let controller = ThemedNavigationController(rootViewController: libraryViewController)
+//        controller.presentingModalViewControllerDelegate = self
 
         // Wait to present VC in an async dispatch queue to prevent a case where dismissal
         // of this popover on iPad seems to block the presentation of the modal VC.
         DispatchQueue.main.async {
-            self.present(controller, animated: true, completion: nil)
+            self.present(libraryViewController, animated: true, completion: nil)
         }
     }
 
@@ -1078,8 +1077,7 @@ class BrowserViewController: UIViewController {
         settingsTableViewController.settingsDelegate = self
 
         let controller = ThemedNavigationController(rootViewController: settingsTableViewController)
-        controller.popoverDelegate = self
-        controller.modalPresentationStyle = .formSheet
+        controller.presentingModalViewControllerDelegate = self
         self.present(controller, animated: true, completion: nil)
     }
 
@@ -1978,7 +1976,6 @@ extension BrowserViewController: IntroViewControllerDelegate {
         let vcToPresent = getSignInViewController(fxaOptions)
         vcToPresent.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissSignInViewController))
         let themedNavigationController = ThemedNavigationController(rootViewController: vcToPresent)
-		themedNavigationController.modalPresentationStyle = .formSheet
         themedNavigationController.navigationBar.isTranslucent = false
         self.present(themedNavigationController, animated: true, completion: nil)
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -65,7 +65,6 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
                 guard let loginsVC = loginsVC else { return }
                 loginsVC.shownFromAppMenu = true
                 let navController = ThemedNavigationController(rootViewController: loginsVC)
-                navController.modalPresentationStyle = .formSheet
                 self.present(navController, animated: true)
             }
         }

--- a/Client/Frontend/Library/BookmarksPanel.swift
+++ b/Client/Frontend/Library/BookmarksPanel.swift
@@ -11,7 +11,6 @@ private let log = Logger.browserLogger
 
 private let BookmarkFolderCellIdentifier = "BookmarkFolderCellIdentifier"
 private let BookmarkSeparatorCellIdentifier = "BookmarkSeparatorCellIdentifier"
-private let BookmarkFolderHeaderViewIdentifier = "BookmarkFolderHeaderViewIdentifier"
 
 private struct BookmarksPanelUX {
     static let BookmarkFolderHeaderViewChevronInset: CGFloat = 10
@@ -23,6 +22,13 @@ private struct BookmarksPanelUX {
     static let IconSize: CGFloat = 23
     static let IconBorderWidth: CGFloat = 0.5
 }
+
+private let LocalizedRootFolderStrings = [
+    BookmarkRoots.MenuFolderGUID: Strings.BookmarksFolderTitleMenu,
+    BookmarkRoots.ToolbarFolderGUID: Strings.BookmarksFolderTitleToolbar,
+    BookmarkRoots.UnfiledFolderGUID: Strings.BookmarksFolderTitleUnsorted,
+    BookmarkRoots.MobileFolderGUID: Strings.BookmarksFolderTitleMobile
+]
 
 fileprivate class BookmarkFolderTableViewCell: TwoLineTableViewCell {
     override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
@@ -47,88 +53,6 @@ fileprivate class BookmarkFolderTableViewCell: TwoLineTableViewCell {
     }
 }
 
-fileprivate class BookmarkFolderTableViewHeader: UITableViewHeaderFooterView {
-    var delegate: BookmarkFolderTableViewHeaderDelegate?
-
-    let titleLabel = UILabel()
-    let topBorder = UIView()
-    let bottomBorder = UIView()
-
-    lazy var chevron: ChevronView = {
-        let chevron = ChevronView(direction: .left)
-        chevron.tintColor = UIColor.theme.general.highlightBlue
-        chevron.lineWidth = BookmarksPanelUX.BookmarkFolderChevronLineWidth
-        return chevron
-    }()
-
-    override var textLabel: UILabel? { return titleLabel }
-
-    override init(reuseIdentifier: String?) {
-        super.init(reuseIdentifier: reuseIdentifier)
-
-        isUserInteractionEnabled = true
-
-        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(viewWasTapped))
-        addGestureRecognizer(tapGestureRecognizer)
-
-        addSubview(topBorder)
-        addSubview(bottomBorder)
-        contentView.addSubview(chevron)
-        contentView.addSubview(titleLabel)
-
-        chevron.snp.makeConstraints { make in
-            make.leading.equalTo(contentView).offset(BookmarksPanelUX.BookmarkFolderHeaderViewChevronInset)
-            make.centerY.equalTo(contentView)
-            make.size.equalTo(BookmarksPanelUX.BookmarkFolderChevronSize)
-        }
-
-        titleLabel.snp.makeConstraints { make in
-            make.leading.equalTo(chevron.snp.trailing).offset(BookmarksPanelUX.BookmarkFolderHeaderViewChevronInset)
-            make.trailing.greaterThanOrEqualTo(contentView).offset(-BookmarksPanelUX.BookmarkFolderHeaderViewChevronInset)
-            make.centerY.equalTo(contentView)
-        }
-
-        topBorder.snp.makeConstraints { make in
-            make.left.right.equalTo(self)
-            make.top.equalTo(self).offset(-0.5)
-            make.height.equalTo(0.5)
-        }
-
-        bottomBorder.snp.makeConstraints { make in
-            make.left.right.bottom.equalTo(self)
-            make.height.equalTo(0.5)
-        }
-
-        applyTheme()
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    @objc fileprivate func viewWasTapped(_ gestureRecognizer: UITapGestureRecognizer) {
-        delegate?.didSelectHeader()
-    }
-
-    override func prepareForReuse() {
-        super.prepareForReuse()
-
-        applyTheme()
-    }
-
-    func applyTheme() {
-        textLabel?.font = DynamicFontHelper.defaultHelper.DeviceFontHistoryPanel
-        titleLabel.textColor = UIColor.theme.homePanel.bookmarkCurrentFolderText
-        topBorder.backgroundColor = UIColor.theme.homePanel.siteTableHeaderBorder
-        bottomBorder.backgroundColor = UIColor.theme.homePanel.siteTableHeaderBorder
-        contentView.backgroundColor = UIColor.theme.homePanel.bookmarkBackNavCellBackground
-    }
-}
-
-fileprivate protocol BookmarkFolderTableViewHeaderDelegate {
-    func didSelectHeader()
-}
-
 class BookmarksPanel: SiteTableViewController, LibraryPanel {
     var libraryPanelDelegate: LibraryPanelDelegate?
 
@@ -139,8 +63,6 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
 
     var bookmarkFolder: BookmarkFolder?
     var bookmarkNodes = [BookmarkNode]()
-
-    lazy var emptyStateOverlayView = createEmptyStateOverlayView()
 
     init(profile: Profile, bookmarkFolderGUID: GUID = BookmarkRoots.RootGUID) {
         self.bookmarkFolderGUID = bookmarkFolderGUID
@@ -154,7 +76,6 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
 
         self.tableView.register(SeparatorTableCell.self, forCellReuseIdentifier: BookmarkSeparatorCellIdentifier)
         self.tableView.register(BookmarkFolderTableViewCell.self, forCellReuseIdentifier: BookmarkFolderCellIdentifier)
-        self.tableView.register(BookmarkFolderTableViewHeader.self, forHeaderFooterViewReuseIdentifier: BookmarkFolderHeaderViewIdentifier)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -167,6 +88,10 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
         tableView.addGestureRecognizer(longPressRecognizer)
         tableView.accessibilityIdentifier = "Bookmarks List"
         tableView.addSubview(refreshControl)
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done) { _ in
+            self.dismiss(animated: true, completion: nil)
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -184,65 +109,10 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
 
     override func applyTheme() {
         super.applyTheme()
-
-        emptyStateOverlayView.removeFromSuperview()
-        emptyStateOverlayView = createEmptyStateOverlayView()
-        updateEmptyPanelState()
     }
 
     override func reloadData() {
         loadData()
-    }
-
-    fileprivate func createEmptyStateOverlayView() -> UIView {
-        let logoImageView = UIImageView(image: UIImage.templateImageNamed("emptyBookmarks"))
-        logoImageView.tintColor = UIColor.Photon.Grey60
-
-        let welcomeLabel = UILabel()
-        welcomeLabel.text = Strings.BookmarksPanelEmptyStateTitle
-        welcomeLabel.textAlignment = .center
-        welcomeLabel.textColor = UIColor.theme.homePanel.welcomeScreenText
-        welcomeLabel.font = DynamicFontHelper.defaultHelper.DeviceFontLight
-        welcomeLabel.numberOfLines = 0
-        welcomeLabel.adjustsFontSizeToFitWidth = true
-
-        let overlayView = UIView()
-        overlayView.backgroundColor = UIColor.theme.homePanel.panelBackground
-        overlayView.addSubview(logoImageView)
-        overlayView.addSubview(welcomeLabel)
-
-        logoImageView.snp.makeConstraints { make in
-            make.centerX.equalTo(overlayView)
-            make.size.equalTo(60)
-            // Sets proper top constraint for iPhone 6 in portait and for iPad.
-            make.centerY.equalTo(overlayView).offset(LibraryPanelUX.EmptyTabContentOffset).priority(100)
-
-            // Sets proper top constraint for iPhone 4, 5 in portrait.
-            make.top.greaterThanOrEqualTo(overlayView).offset(50)
-        }
-
-        welcomeLabel.snp.makeConstraints { make in
-            make.centerX.equalTo(overlayView)
-            make.top.equalTo(logoImageView.snp.bottom).offset(BookmarksPanelUX.WelcomeScreenPadding)
-            make.width.equalTo(BookmarksPanelUX.WelcomeScreenItemWidth)
-        }
-
-        return overlayView
-    }
-
-    fileprivate func updateEmptyPanelState() {
-        if bookmarkFolder?.guid == BookmarkRoots.RootGUID,
-            bookmarkNodes.isEmpty {
-            if emptyStateOverlayView.superview == nil {
-                view.addSubview(emptyStateOverlayView)
-                view.bringSubview(toFront: emptyStateOverlayView)
-                emptyStateOverlayView.snp.makeConstraints { make -> Void in
-                    make.edges.equalTo(tableView)
-                }
-            }
-        } else {
-            emptyStateOverlayView.removeFromSuperview()
-        }
     }
 
     fileprivate func loadData() {
@@ -254,14 +124,12 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
                 self.bookmarkFolder = nil
                 self.bookmarkNodes = []
                 self.tableView.reloadData()
-                self.updateEmptyPanelState()
                 return
             }
 
             self.bookmarkFolder = folder
             self.bookmarkNodes = folder.children ?? []
             self.tableView.reloadData()
-            self.updateEmptyPanelState()
         }
     }
 
@@ -285,8 +153,6 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
         bookmarkNodes.remove(at: indexPath.row)
         tableView.deleteRows(at: [indexPath], with: .left)
         tableView.endUpdates()
-
-        updateEmptyPanelState()
     }
 
     @objc fileprivate func didLongPress(_ longPressGestureRecognizer: UILongPressGestureRecognizer) {
@@ -323,6 +189,11 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
         switch bookmarkNode {
         case let bookmarkFolder as BookmarkFolder:
             let nextController = BookmarksPanel(profile: profile, bookmarkFolderGUID: bookmarkFolder.guid)
+            if bookmarkFolder.isRoot, let localizedString = LocalizedRootFolderStrings[bookmarkFolder.guid] {
+                nextController.title = localizedString
+            } else {
+                nextController.title = bookmarkFolder.title
+            }
             nextController.libraryPanelDelegate = libraryPanelDelegate
             navigationController?.pushViewController(nextController, animated: true)
         case let bookmarkItem as BookmarkItem:
@@ -346,7 +217,11 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
         switch bookmarkNode {
         case let bookmarkFolder as BookmarkFolder:
             let cell = tableView.dequeueReusableCell(withIdentifier: BookmarkFolderCellIdentifier, for: indexPath)
-            cell.textLabel?.text = bookmarkFolder.title
+            if bookmarkFolder.isRoot, let localizedString = LocalizedRootFolderStrings[bookmarkFolder.guid] {
+                cell.textLabel?.text = localizedString
+            } else {
+                cell.textLabel?.text = bookmarkFolder.title
+            }
             return cell
         case let bookmarkItem as BookmarkItem:
             let cell = super.tableView(tableView, cellForRowAt: indexPath)
@@ -372,6 +247,14 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
         return super.tableView(tableView, heightForRowAt: indexPath)
     }
 
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        return nil
+    }
+
+    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return 0
+    }
+
     override func tableView(_ tableView: UITableView, hasFullWidthSeparatorForRowAtIndexPath indexPath: IndexPath) -> Bool {
         // Show a full-width border for cells above separators, so they don't have a weird step.
         // Separators themselves already have a full-width border, but let's force the issue
@@ -383,31 +266,6 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
         }
 
         return super.tableView(tableView, hasFullWidthSeparatorForRowAtIndexPath: indexPath)
-    }
-
-    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        // Don't show a header for the root.
-        guard let bookmarkFolder = self.bookmarkFolder, bookmarkFolder.guid != BookmarkRoots.RootGUID else {
-            return nil
-        }
-
-        guard let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: BookmarkFolderHeaderViewIdentifier) as? BookmarkFolderTableViewHeader else {
-            return nil
-        }
-
-        header.delegate = self
-        header.textLabel?.text = bookmarkFolder.title
-
-        return header
-    }
-
-    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        // Don't show a header for the root.
-        guard let bookmarkFolder = self.bookmarkFolder, bookmarkFolder.guid != BookmarkRoots.RootGUID else {
-            return 0
-        }
-
-        return SiteTableViewControllerUX.RowHeight
     }
 
     func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
@@ -484,13 +342,5 @@ extension BookmarksPanel: LibraryPanelContextMenu {
         actions.append(removeAction)
 
         return actions
-    }
-}
-
-// MARK: BookmarkFolderTableViewHeaderDelegate
-
-extension BookmarksPanel: BookmarkFolderTableViewHeaderDelegate {
-    fileprivate func didSelectHeader() {
-        _ = self.navigationController?.popViewController(animated: true)
     }
 }

--- a/Client/Frontend/Library/DownloadsPanel.swift
+++ b/Client/Frontend/Library/DownloadsPanel.swift
@@ -90,6 +90,10 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
 
         // Set an empty footer to prevent empty cells from appearing in the list.
         tableView.tableFooterView = UIView()
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done) { _ in
+            self.dismiss(animated: true, completion: nil)
+        }
     }
 
     deinit {

--- a/Client/Frontend/Library/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel.swift
@@ -122,6 +122,10 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
         updateSyncedDevicesCount().uponQueue(.main) { result in
             self.updateNumberOfSyncedDevices(self.currentSyncedDevicesCount)
         }
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done) { _ in
+            self.dismiss(animated: true, completion: nil)
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -277,6 +281,7 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
 
     func navigateToSyncedTabs() {
         let nextController = RemoteTabsPanel(profile: profile)
+        nextController.title = Strings.SyncedTabsTableViewCellTitle
         nextController.libraryPanelDelegate = libraryPanelDelegate
         refreshControl?.endRefreshing()
         navigationController?.pushViewController(nextController, animated: true)
@@ -288,6 +293,7 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
         }
 
         let nextController = RecentlyClosedTabsPanel(profile: profile)
+        nextController.title = Strings.RecentlyClosedTabsButtonTitle
         nextController.libraryPanelDelegate = libraryPanelDelegate
         refreshControl?.endRefreshing()
         navigationController?.pushViewController(nextController, animated: true)

--- a/Client/Frontend/Library/LibraryPanels.swift
+++ b/Client/Frontend/Library/LibraryPanels.swift
@@ -4,53 +4,97 @@
 
 import UIKit
 import Shared
+import Storage
+
+protocol LibraryPanel: AnyObject, Themeable {
+    var libraryPanelDelegate: LibraryPanelDelegate? { get set }
+}
+
+struct LibraryPanelUX {
+    static let EmptyTabContentOffset = -180
+}
+
+protocol LibraryPanelDelegate: AnyObject {
+    func libraryPanelDidRequestToSignIn()
+    func libraryPanelDidRequestToCreateAccount()
+    func libraryPanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool)
+    func libraryPanel(didSelectURL url: URL, visitType: VisitType)
+    func libraryPanel(didSelectURLString url: String, visitType: VisitType)
+}
+
+enum LibraryPanelType: Int {
+    case bookmarks = 0
+    case history = 1
+    case readingList = 2
+    case downloads = 3
+}
 
 /**
  * Data for identifying and constructing a LibraryPanel.
  */
-struct LibraryPanelDescriptor {
-    let makeViewController: (_ profile: Profile) -> UIViewController
+class LibraryPanelDescriptor {
+    lazy var viewController: UIViewController = self.makeViewController(self.profile)
+    lazy var navigationController: UINavigationController = ThemedNavigationController(rootViewController: self.viewController)
+
+    fileprivate let makeViewController: (_ profile: Profile) -> UIViewController
+    fileprivate let profile: Profile
+
     let imageName: String
     let accessibilityLabel: String
     let accessibilityIdentifier: String
+
+    init(makeViewController: @escaping ((_ profile: Profile) -> UIViewController), profile: Profile, imageName: String, accessibilityLabel: String, accessibilityIdentifier: String) {
+        self.makeViewController = makeViewController
+        self.profile = profile
+
+        self.imageName = imageName
+        self.accessibilityLabel = accessibilityLabel
+        self.accessibilityIdentifier = accessibilityIdentifier
+    }
 }
 
 class LibraryPanels {
-    let enabledPanels = [
+    fileprivate let profile: Profile
+
+    init(profile: Profile) {
+        self.profile = profile
+    }
+
+    lazy var enabledPanels = [
         LibraryPanelDescriptor(
             makeViewController: { profile in
-                let controller = BookmarksPanel(profile: profile)
-                return controller
+                return BookmarksPanel(profile: profile)
             },
+            profile: profile,
             imageName: "Bookmarks",
             accessibilityLabel: NSLocalizedString("Bookmarks", comment: "Panel accessibility label"),
             accessibilityIdentifier: "LibraryPanels.Bookmarks"),
 
         LibraryPanelDescriptor(
             makeViewController: { profile in
-                let controller = HistoryPanel(profile: profile)
-                return controller
+                return HistoryPanel(profile: profile)
             },
+            profile: profile,
             imageName: "History",
             accessibilityLabel: NSLocalizedString("History", comment: "Panel accessibility label"),
             accessibilityIdentifier: "LibraryPanels.History"),
 
         LibraryPanelDescriptor(
             makeViewController: { profile in
-                let controller = ReadingListPanel(profile: profile)
-                return controller
+                return ReadingListPanel(profile: profile)
             },
+            profile: profile,
             imageName: "ReadingList",
             accessibilityLabel: NSLocalizedString("Reading list", comment: "Panel accessibility label"),
             accessibilityIdentifier: "LibraryPanels.ReadingList"),
 
         LibraryPanelDescriptor(
             makeViewController: { profile in
-                let controller = DownloadsPanel(profile: profile)
-                return controller
+                return DownloadsPanel(profile: profile)
             },
+            profile: profile,
             imageName: "Downloads",
             accessibilityLabel: NSLocalizedString("Downloads", comment: "Panel accessibility label"),
             accessibilityIdentifier: "LibraryPanels.Downloads"),
-        ]
+    ]
 }

--- a/Client/Frontend/Library/ReaderPanel.swift
+++ b/Client/Frontend/Library/ReaderPanel.swift
@@ -221,6 +221,10 @@ class ReadingListPanel: UITableViewController, LibraryPanel {
         // Set an empty footer to prevent empty cells from appearing in the list.
         tableView.tableFooterView = UIView()
         tableView.dragDelegate = self
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done) { _ in
+            self.dismiss(animated: true, completion: nil)
+        }
     }
 
     @objc func notificationReceived(_ notification: Notification) {
@@ -268,7 +272,7 @@ class ReadingListPanel: UITableViewController, LibraryPanel {
         welcomeLabel.adjustsFontSizeToFitWidth = true
         welcomeLabel.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.top.equalToSuperview().offset(50)
+            make.top.equalToSuperview().offset(150)
             make.width.equalTo(ReadingListPanelUX.WelcomeScreenItemWidth + ReadingListPanelUX.WelcomeScreenCircleSpacer + ReadingListPanelUX.WelcomeScreenCircleWidth)
         }
 

--- a/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -80,6 +80,10 @@ class RecentlyClosedTabsPanel: UIViewController, LibraryPanel {
         }
 
         tableViewController.didMove(toParentViewController: self)
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done) { _ in
+            self.dismiss(animated: true, completion: nil)
+        }
     }
 
     @objc fileprivate func historyBackButtonWasTapped(_ gestureRecognizer: UITapGestureRecognizer) {
@@ -102,6 +106,10 @@ class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {
         tableView.addGestureRecognizer(longPressRecognizer)
         tableView.accessibilityIdentifier = "Recently Closed Tabs List"
         self.recentlyClosedTabs = profile.recentlyClosedTabs.tabs
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done) { _ in
+            self.dismiss(animated: true, completion: nil)
+        }
     }
 
     @objc fileprivate func longPress(_ longPressGestureRecognizer: UILongPressGestureRecognizer) {

--- a/Client/Frontend/Library/RemoteTabsPanel.swift
+++ b/Client/Frontend/Library/RemoteTabsPanel.swift
@@ -83,6 +83,10 @@ class RemoteTabsPanel: UIViewController, LibraryPanel {
         }
 
         tableViewController.didMove(toParentViewController: self)
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done) { _ in
+            self.dismiss(animated: true, completion: nil)
+        }
     }
 
     @objc func notificationReceived(_ notification: Notification) {
@@ -500,6 +504,10 @@ fileprivate class RemoteTabsTableViewController: UITableViewController {
         tableView.tableFooterView = UIView() // prevent extra empty rows at end
         tableView.delegate = nil
         tableView.dataSource = nil
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done) { _ in
+            self.dismiss(animated: true, completion: nil)
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/Client/Frontend/Settings/SettingsNavigationController.swift
+++ b/Client/Frontend/Settings/SettingsNavigationController.swift
@@ -5,10 +5,10 @@
 import UIKit
 
 class ThemedNavigationController: UINavigationController {
-    var popoverDelegate: PresentingModalViewControllerDelegate?
+    var presentingModalViewControllerDelegate: PresentingModalViewControllerDelegate?
 
     @objc func done() {
-        if let delegate = popoverDelegate {
+        if let delegate = presentingModalViewControllerDelegate {
             delegate.dismissPresentedModalViewController(self, animated: true)
         } else {
             self.dismiss(animated: true, completion: nil)
@@ -21,6 +21,7 @@ class ThemedNavigationController: UINavigationController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        modalPresentationStyle = .formSheet
         applyTheme()
     }
 }
@@ -37,7 +38,7 @@ extension ThemedNavigationController: Themeable {
     }
 }
 
-protocol PresentingModalViewControllerDelegate {
+protocol PresentingModalViewControllerDelegate: AnyObject {
     func dismissPresentedModalViewController(_ modalViewController: UIViewController, animated: Bool)
 }
 

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -368,6 +368,14 @@ extension Strings {
     public static let CustomEngineDuplicateErrorMessage = NSLocalizedString("Search.ThirdPartyEngines.DuplicateErrorMessage", value: "A search engine with this title or URL has already been added.", comment: "A message explaining fault in custom search engine form.")
 }
 
+// Root Bookmarks folders
+extension Strings {
+    public static let BookmarksFolderTitleMobile = NSLocalizedString("Mobile Bookmarks", tableName: "Storage", comment: "The title of the folder that contains mobile bookmarks. This should match bookmarks.folder.mobile.label on Android.")
+    public static let BookmarksFolderTitleMenu = NSLocalizedString("Bookmarks Menu", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the menu. This should match bookmarks.folder.menu.label on Android.")
+    public static let BookmarksFolderTitleToolbar = NSLocalizedString("Bookmarks Toolbar", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the toolbar. This should match bookmarks.folder.toolbar.label on Android.")
+    public static let BookmarksFolderTitleUnsorted = NSLocalizedString("Unsorted Bookmarks", tableName: "Storage", comment: "The name of the folder that contains unsorted desktop bookmarks. This should match bookmarks.folder.unfiled.label on Android.")
+}
+
 // Bookmark Management
 extension Strings {
     public static let BookmarksTitle = NSLocalizedString("Bookmarks.Title.Label", value: "Title", comment: "The label for the title of a bookmark")

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -106,8 +106,7 @@ extension PhotonActionSheetProtocol {
             settingsTableViewController.settingsDelegate = vcDelegate
 
             let controller = ThemedNavigationController(rootViewController: settingsTableViewController)
-            controller.popoverDelegate = vcDelegate
-            controller.modalPresentationStyle = .formSheet
+            controller.presentingModalViewControllerDelegate = vcDelegate
 
             // Wait to present VC in an async dispatch queue to prevent a case where dismissal
             // of this popover on iPad seems to block the presentation of the modal VC.

--- a/Shared/Extensions/UIBarButtonItemExtensions.swift
+++ b/Shared/Extensions/UIBarButtonItemExtensions.swift
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+
+// https://medium.com/@BeauNouvelle/adding-a-closure-to-uibarbuttonitem-24dfc217fe72
+extension UIBarButtonItem {
+    private class UIBarButtonItemClosureWrapper: NSObject {
+        let closure: (UIBarButtonItem) -> ()
+        init(_ closure: @escaping (UIBarButtonItem) -> ()) {
+            self.closure = closure
+        }
+    }
+
+    private struct AssociatedKeys {
+        static var targetClosure = "targetClosure"
+    }
+
+    private var targetClosure: ((UIBarButtonItem) -> ())? {
+        get {
+            guard let closureWrapper = objc_getAssociatedObject(self, &AssociatedKeys.targetClosure) as? UIBarButtonItemClosureWrapper else { return nil }
+            return closureWrapper.closure
+        }
+        set(newValue) {
+            guard let newValue = newValue else { return }
+            objc_setAssociatedObject(self, &AssociatedKeys.targetClosure, UIBarButtonItemClosureWrapper(newValue), objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+
+    public convenience init(title: String?, style: UIBarButtonItem.Style, closure: @escaping (UIBarButtonItem) -> ()) {
+        self.init(title: title, style: style, target: nil, action: nil)
+        targetClosure = closure
+        action = #selector(UIBarButtonItem.closureAction)
+    }
+
+    public convenience init(barButtonSystemItem systemItem: UIBarButtonItem.SystemItem, closure: @escaping (UIBarButtonItem) -> ()) {
+        self.init(barButtonSystemItem: systemItem, target: nil, action: nil)
+        targetClosure = closure
+        action = #selector(UIBarButtonItem.closureAction)
+    }
+
+    @objc func closureAction() {
+        targetClosure?(self)
+    }
+}

--- a/Storage/SQL/BrowserSchema.swift
+++ b/Storage/SQL/BrowserSchema.swift
@@ -6,11 +6,6 @@ import Foundation
 import Shared
 import XCGLogger
 
-let BookmarksFolderTitleMobile: String = NSLocalizedString("Mobile Bookmarks", tableName: "Storage", comment: "The title of the folder that contains mobile bookmarks. This should match bookmarks.folder.mobile.label on Android.")
-let BookmarksFolderTitleMenu: String = NSLocalizedString("Bookmarks Menu", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the menu. This should match bookmarks.folder.menu.label on Android.")
-let BookmarksFolderTitleToolbar: String = NSLocalizedString("Bookmarks Toolbar", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the toolbar. This should match bookmarks.folder.toolbar.label on Android.")
-let BookmarksFolderTitleUnsorted: String = NSLocalizedString("Unsorted Bookmarks", tableName: "Storage", comment: "The name of the folder that contains unsorted desktop bookmarks. This should match bookmarks.folder.unfiled.label on Android.")
-
 let _TableBookmarks = "bookmarks"                                      // Removed in v12. Kept for migration.
 let TableBookmarksMirror = "bookmarksMirror"                           // Added in v9.
 let TableBookmarksMirrorStructure = "bookmarksMirrorStructure"         // Added in v10.


### PR DESCRIPTION
Some of the changes around `LibraryPanels` and `makeViewController` are so that we only ever create each of those root view controllers for the library panels once and cache it. This way, the user can navigate `n`-levels deep in any of the library panels and not lose their place if they switch between panels.