### PR TITLE
Fix testTapSignInShowsFxAFromTour (#4816)

### DIFF
--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -371,6 +371,7 @@ class CardView: UIView {
         button.setTitleColor(.white, for: [])
         button.setContentHuggingPriority(UILayoutPriority(rawValue: 1000), for: .vertical)
         button.clipsToBounds = true
+        button.accessibilityIdentifier = "turnOnSync.button"
         return button
     }()
 

--- a/XCUITests/FirstRunTourTests.swift
+++ b/XCUITests/FirstRunTourTests.swift
@@ -21,10 +21,10 @@ class FirstRunTourTests: BaseTestCase {
 
         // Swipe to the second screen
         app.scrollViews["IntroViewController.scrollView"].swipeLeft()
-        waitForExistence(app.staticTexts["Pick up where you left off"])
+        waitForExistence(app.staticTexts["Take Firefox with You"])
         XCTAssertTrue(app.buttons["IntroViewController.startBrowsingButton"].exists)
         XCTAssertTrue(app.images["tour-Sync"].exists)
-        XCTAssertTrue(app.buttons["Sign in to Firefox"].exists)
+        XCTAssertTrue(app.buttons["turnOnSync.button"].exists)
         XCTAssertEqual(app.pageIndicators["IntroViewController.pageControl"].value as? String, "page 2 of 2")
     }
 

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -801,7 +801,8 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             for _ in 1...4 {
                 introScrollView.swipeLeft()
             }
-            app.buttons["Sign in to Firefox"].tap()
+            let turnOnSyncButton = app.buttons["turnOnSync.button"]
+            turnOnSyncButton.tap()
         }
         screenState.backAction = {
             introScrollView.swipeLeft()


### PR DESCRIPTION
There was a change in the strings on the Sync card to match Desktop in commit 2f97d6f6e0f5fd3f4418757326875a098766b9a1. 

Making changes for test to pass. 
