### PR TITLE
Fix #4824 - TP whitelisting: fix bad file parsing breaking strict mode

### DIFF
--- a/content-blocker-lib-ios/src/ContentBlocker.swift
+++ b/content-blocker-lib-ios/src/ContentBlocker.swift
@@ -252,7 +252,8 @@ extension ContentBlocker {
                 }
                 self.loadJsonFromBundle(forResource: filename) { jsonString in
                     var str = jsonString
-                    str.insert(contentsOf: self.whitelistAsJSON(), at: str.index(str.endIndex, offsetBy: -1))
+                    guard let range = str.range(of: "]", options: String.CompareOptions.backwards) else { return }
+                    str = str.replacingCharacters(in: range, with: self.whitelistAsJSON() + "]")
                     self.ruleStore.compileContentRuleList(forIdentifier: filename, encodedContentRuleList: str) { rule, error in
                         if let error = error {
                             print("Content blocker error: \(error)")


### PR DESCRIPTION
The file was expected to end in '}]', a simple newline or space would
break this.

This would only crash in debug builds, due to an assert() to catch this.