### PR TITLE
Fix #4826 - Tab title keeps getting reset on thestar.com

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -915,6 +915,7 @@ class BrowserViewController: UIViewController {
             // to navigateInTab(tab:).
             guard let title = tab.title else { break }
             if !title.isEmpty && title != tab.lastTitle {
+                tab.lastTitle = title
                 navigateInTab(tab: tab)
             }
         case .canGoBack:


### PR DESCRIPTION
In debugger, I can see the title change event arriving frequently, and even though the title is not changing, the code is being called for title change.