### PR TITLE
Fix #4752 - The entries listed in the Library panels are incorrectly …

### DIFF
--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -133,6 +133,8 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        tableView.setEditing(false, animated: false)
         coordinator.animate(alongsideTransition: { context in
             //The AS context menu does not behave correctly. Dismiss it when rotating.
             if let _ = self.presentedViewController as? PhotonActionSheet {


### PR DESCRIPTION
This PR fixes issue #4752 by leaving editing mode when the device is rotated. Additionally, the missing call to super is added to viewWillTransition per [Apple's guidelines](https://developer.apple.com/documentation/uikit/uicontentcontainer/1621466-viewwilltransition).