### PR TITLE
Fix #4852 - Clean up remaining bits of old bookmarks implementation in Storage

### DIFF
--- a/Client/Frontend/Library/BookmarksPanel.swift
+++ b/Client/Frontend/Library/BookmarksPanel.swift
@@ -57,7 +57,10 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
     var libraryPanelDelegate: LibraryPanelDelegate?
 
     let refreshControl = UIRefreshControl()
-    let longPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(didLongPress))
+
+    lazy var longPressRecognizer: UILongPressGestureRecognizer = {
+        return UILongPressGestureRecognizer(target: self, action: #selector(didLongPress))
+    }()
 
     let bookmarkFolderGUID: GUID
 
@@ -331,10 +334,7 @@ extension BookmarksPanel: LibraryPanelContextMenu {
             return nil
         }
 
-        let site = Site(url: bookmarkItem.url, title: bookmarkItem.title, bookmarked: true, guid: bookmarkItem.guid)
-        // TODO: Determine how to pull in a favicon
-        // site.icon = bookmarkItem.favicon
-        return site
+        return Site(url: bookmarkItem.url, title: bookmarkItem.title, bookmarked: true, guid: bookmarkItem.guid)
     }
 
     func getContextMenuActions(for site: Site, with indexPath: IndexPath) -> [PhotonActionSheetItem]? {

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetWidgets.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetWidgets.swift
@@ -208,9 +208,20 @@ class PhotonActionSheetSiteHeaderView: UITableViewHeaderFooterView {
     }
 
     func configure(with site: Site) {
-        self.siteImageView.setFavicon(forSite: site) { (color, url) in
-            self.siteImageView.backgroundColor = color
-            self.siteImageView.image = self.siteImageView.image?.createScaled(PhotonActionSheetUX.IconSize)
+        if let _ = site.icon {
+            self.siteImageView.setFavicon(forSite: site) { (color, url) in
+                self.siteImageView.backgroundColor = color
+                self.siteImageView.image = self.siteImageView.image?.createScaled(PhotonActionSheetUX.IconSize)
+            }
+        } else if let appDelegate = UIApplication.shared.delegate as? AppDelegate, let profile = appDelegate.profile {
+            profile.favicons.getFaviconImage(forSite: site).uponQueue(.main) { result in
+                guard let image = result.successValue else {
+                    return
+                }
+
+                self.siteImageView.backgroundColor = .clear
+                self.siteImageView.image = image.createScaled(PhotonActionSheetUX.IconSize)
+            }
         }
         self.titleLabel.text = site.title.isEmpty ? site.url : site.title
         self.descriptionLabel.text = site.tileURL.baseDomain

--- a/Storage/Rust/RustPlaces.swift
+++ b/Storage/Rust/RustPlaces.swift
@@ -241,7 +241,7 @@ public class RustPlaces {
         return error
     }
 
-    public func sync(unlockInfo: SyncUnlockInfo) -> Success {
+    public func syncBookmarks(unlockInfo: SyncUnlockInfo) -> Success {
         let deferred = Success()
 
         writerQueue.async {

--- a/Storage/SQL/SQLiteHistoryFavicons.swift
+++ b/Storage/SQL/SQLiteHistoryFavicons.swift
@@ -124,21 +124,13 @@ extension SQLiteHistory: Favicons {
                 // Now set up the mapping.
                 try conn.executeChange(query, withArgs: args)
 
-                // Try to update the favicon ID column in each bookmarks table. There can be
-                // multiple bookmarks with a particular URI, and a mirror bookmark can be
-                // locally changed, so either or both of these statements can update multiple rows.
-                if let id = id {
-                    icon.id = id
-
-                    try? conn.executeChange("UPDATE bookmarksLocal SET faviconID = ? WHERE bmkUri = ?", withArgs: [id, site.url])
-                    try? conn.executeChange("UPDATE bookmarksMirror SET faviconID = ? WHERE bmkUri = ?", withArgs: [id, site.url])
-
-                    return id
+                guard let faviconID = id else {
+                    let err = DatabaseError(description: "Error adding favicon. ID = 0")
+                    log.error("addFavicon(_:, forSite:) encountered an error: \(err.localizedDescription)")
+                    throw err
                 }
 
-                let err = DatabaseError(description: "Error adding favicon. ID = 0")
-                log.error("addFavicon(_:, forSite:) encountered an error: \(err.localizedDescription)")
-                throw err
+                return faviconID
             }
         }
 

--- a/StorageTests/TestSQLiteHistory.swift
+++ b/StorageTests/TestSQLiteHistory.swift
@@ -93,10 +93,10 @@ class BrowserSchemaV6: BaseHistoricalBrowserSchema {
         let type = 2 // "folder"
         let root = 0
 
-        let titleMobile = NSLocalizedString("Mobile Bookmarks", tableName: "Storage", comment: "The title of the folder that contains mobile bookmarks. This should match bookmarks.folder.mobile.label on Android.")
-        let titleMenu = NSLocalizedString("Bookmarks Menu", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the menu. This should match bookmarks.folder.menu.label on Android.")
-        let titleToolbar = NSLocalizedString("Bookmarks Toolbar", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the toolbar. This should match bookmarks.folder.toolbar.label on Android.")
-        let titleUnsorted = NSLocalizedString("Unsorted Bookmarks", tableName: "Storage", comment: "The name of the folder that contains unsorted desktop bookmarks. This should match bookmarks.folder.unfiled.label on Android.")
+        let titleMobile = Strings.BookmarksFolderTitleMobile
+        let titleMenu = Strings.BookmarksFolderTitleMenu
+        let titleToolbar = Strings.BookmarksFolderTitleToolbar
+        let titleUnsorted = Strings.BookmarksFolderTitleUnsorted
 
         let args: Args = [
             root, BookmarkRoots.RootGUID, type, "Root", root,
@@ -272,10 +272,10 @@ class BrowserSchemaV7: BaseHistoricalBrowserSchema {
         let type = 2 // "folder"
         let root = 0
 
-        let titleMobile = NSLocalizedString("Mobile Bookmarks", tableName: "Storage", comment: "The title of the folder that contains mobile bookmarks. This should match bookmarks.folder.mobile.label on Android.")
-        let titleMenu = NSLocalizedString("Bookmarks Menu", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the menu. This should match bookmarks.folder.menu.label on Android.")
-        let titleToolbar = NSLocalizedString("Bookmarks Toolbar", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the toolbar. This should match bookmarks.folder.toolbar.label on Android.")
-        let titleUnsorted = NSLocalizedString("Unsorted Bookmarks", tableName: "Storage", comment: "The name of the folder that contains unsorted desktop bookmarks. This should match bookmarks.folder.unfiled.label on Android.")
+        let titleMobile = Strings.BookmarksFolderTitleMobile
+        let titleMenu = Strings.BookmarksFolderTitleMenu
+        let titleToolbar = Strings.BookmarksFolderTitleToolbar
+        let titleUnsorted = Strings.BookmarksFolderTitleUnsorted
 
         let args: Args = [
             root, BookmarkRoots.RootGUID, type, "Root", root,
@@ -456,10 +456,10 @@ class BrowserSchemaV8: BaseHistoricalBrowserSchema {
         let type = 2 // "folder"
         let root = 0
 
-        let titleMobile = NSLocalizedString("Mobile Bookmarks", tableName: "Storage", comment: "The title of the folder that contains mobile bookmarks. This should match bookmarks.folder.mobile.label on Android.")
-        let titleMenu = NSLocalizedString("Bookmarks Menu", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the menu. This should match bookmarks.folder.menu.label on Android.")
-        let titleToolbar = NSLocalizedString("Bookmarks Toolbar", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the toolbar. This should match bookmarks.folder.toolbar.label on Android.")
-        let titleUnsorted = NSLocalizedString("Unsorted Bookmarks", tableName: "Storage", comment: "The name of the folder that contains unsorted desktop bookmarks. This should match bookmarks.folder.unfiled.label on Android.")
+        let titleMobile = Strings.BookmarksFolderTitleMobile
+        let titleMenu = Strings.BookmarksFolderTitleMenu
+        let titleToolbar = Strings.BookmarksFolderTitleToolbar
+        let titleUnsorted = Strings.BookmarksFolderTitleUnsorted
 
         let args: Args = [
             root, BookmarkRoots.RootGUID, type, "Root", root,
@@ -655,10 +655,10 @@ class BrowserSchemaV10: BaseHistoricalBrowserSchema {
         let type = 2 // "folder"
         let root = 0
 
-        let titleMobile = NSLocalizedString("Mobile Bookmarks", tableName: "Storage", comment: "The title of the folder that contains mobile bookmarks. This should match bookmarks.folder.mobile.label on Android.")
-        let titleMenu = NSLocalizedString("Bookmarks Menu", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the menu. This should match bookmarks.folder.menu.label on Android.")
-        let titleToolbar = NSLocalizedString("Bookmarks Toolbar", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the toolbar. This should match bookmarks.folder.toolbar.label on Android.")
-        let titleUnsorted = NSLocalizedString("Unsorted Bookmarks", tableName: "Storage", comment: "The name of the folder that contains unsorted desktop bookmarks. This should match bookmarks.folder.unfiled.label on Android.")
+        let titleMobile = Strings.BookmarksFolderTitleMobile
+        let titleMenu = Strings.BookmarksFolderTitleMenu
+        let titleToolbar = Strings.BookmarksFolderTitleToolbar
+        let titleUnsorted = Strings.BookmarksFolderTitleUnsorted
 
         let args: Args = [
             root, BookmarkRoots.RootGUID, type, "Root", root,


### PR DESCRIPTION
This is just a bunch of cleanup and odd & ends. It fixes the long-press context menu for Bookmarks including proper favicons fetching. Removes a bunch of unused code from the StorageTests and some duplicate strings. It also syncs Logins when backgrounding again since we feel better about that now.