### PR TITLE
Fix #4839 - Icon not aligned on action sheet menu

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
@@ -157,6 +157,10 @@ class PhotonActionSheetCell: UITableViewCell {
         stackView.addArrangedSubview(textStackView)
         contentView.addSubview(stackView)
 
+        statusIcon.snp.makeConstraints { make in
+            make.size.equalTo(PhotonActionSheetCellUX.StatusIconSize)
+        }
+
         let padding = PhotonActionSheetCell.Padding
         let topPadding = PhotonActionSheetCell.HorizontalPadding
         stackView.snp.makeConstraints { make in


### PR DESCRIPTION
The icon isn't being sized correctly, and there is no layout for it. Setting the size will fix the problem.