### PR TITLE
Fix #4720, When restoring new tabs make sure to show the new tab title.

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -364,7 +364,12 @@ class Tab: NSObject {
         // When picking a display title. Tabs with sessionData are pending a restore so show their old title.
         // To prevent flickering of the display title. If a tab is restoring make sure to use its lastTitle.
         if let url = self.url, InternalURL(url)?.isAboutHomeURL ?? false, sessionData == nil, !restoring {
-            return ""
+            return Strings.OpenNewTabFromTabTrayKeyCodeTitle
+        }
+
+        //lets double check the sessionData in case this is a non-restored new tab
+        if let firstURL = sessionData?.urls.first, InternalURL(firstURL)?.isAboutHomeURL ?? false {
+            return Strings.OpenNewTabFromTabTrayKeyCodeTitle
         }
 
         guard let lastTitle = lastTitle, !lastTitle.isEmpty else {


### PR DESCRIPTION
This wasn't as bad as I thought. Tabs with webpages loaded restore titles correctly. Its only new tabs currently showing topsites that have issues. I've fixed that in this patch. 