### PR TITLE
Fix #4821 - Tapping on the default engine and going back does not display the toggle switches and the UI

### DIFF
--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -277,6 +277,8 @@ class SearchSettingsTableViewController: ThemedTableViewController {
     }
 
     override func setEditing(_ editing: Bool, animated: Bool) {
+        super.setEditing(editing, animated: animated)
+        tableView.isEditing = true
         showDeletion = editing
         UIView.performWithoutAnimation {
             self.navigationItem.rightBarButtonItem?.title = editing ? Strings.SettingsSearchDoneButton : Strings.SettingsSearchEditButton
@@ -285,7 +287,6 @@ class SearchSettingsTableViewController: ThemedTableViewController {
         navigationItem.rightBarButtonItem?.action = editing ?
             #selector(finishEditing) : #selector(beginEditing)
         tableView.reloadData()
-        super.setEditing(editing, animated: animated)
     }
 }
 

--- a/XCUITests/SearchSettingsUITest.swift
+++ b/XCUITests/SearchSettingsUITest.swift
@@ -88,6 +88,9 @@ class SearchSettingsUITests: BaseTestCase {
         // Check to see we're not in editing state, edit is enable and done does not appear
         XCTAssertTrue(app.buttons["Edit"].isEnabled)
         waitForNoExistence(app.buttons["Done"])
+
+        //Make sure switches are there
+        XCTAssertEqual(app.tables.cells.switches.count, app.tables.cells.count - 2)
     }
 
     func testDeletingLastCustomEngineExitsEditing() {


### PR DESCRIPTION
This bug was introduced when the super call was added in https://github.com/mozilla-mobile/firefox-ios/commit/d5b529cf4d2e18f76f386d519669d55bc66031ec. This PR re-sets the proper editing state for the table after the super call clears it. Additionally, a check for this behavior is added to the UI tests.