### PR TITLE
Remove deprecated spinlock API in Deferred

### DIFF
--- a/ThirdParty/Deferred/Deferred/ReadWriteLock.swift
+++ b/ThirdParty/Deferred/Deferred/ReadWriteLock.swift
@@ -37,7 +37,7 @@ public final class GCDReadWriteLock: ReadWriteLock {
 
 public class AtomicInt {
     private var mutex = pthread_mutex_t()
-    var value: Int32 = 0
+    private(set) var value: Int32 = 0
 
     init() {
         pthread_mutex_init(&mutex, nil)
@@ -70,8 +70,6 @@ public final class CASSpinLock: ReadWriteLock {
     }
 
     private let _state = AtomicInt()
-
-    public init() {}
 
     public func withWriteLock<T>(block: () -> T) -> T {
         // spin until we acquire write lock

--- a/ThirdParty/Deferred/Deferred/ReadWriteLock.swift
+++ b/ThirdParty/Deferred/Deferred/ReadWriteLock.swift
@@ -35,30 +35,28 @@ public final class GCDReadWriteLock: ReadWriteLock {
     }
 }
 
-public final class SpinLock: ReadWriteLock {
-    private var lock: UnsafeMutablePointer<Int32>
+public class AtomicInt {
+    private var mutex = pthread_mutex_t()
+    var value: Int32 = 0
 
-    public init() {
-        lock = UnsafeMutablePointer.allocate(capacity: 1)
-        lock.pointee = OS_SPINLOCK_INIT
+    init() {
+        pthread_mutex_init(&mutex, nil)
     }
 
     deinit {
-        lock.deallocate()
+        pthread_mutex_destroy(&mutex)
     }
 
-    public func withReadLock<T>(block: () -> T) -> T {
-        OSSpinLockLock(lock)
-        let result = block()
-        OSSpinLockUnlock(lock)
-        return result
-    }
-
-    public func withWriteLock<T>(block: () -> T) -> T {
-        OSSpinLockLock(lock)
-        let result = block()
-        OSSpinLockUnlock(lock)
-        return result
+    func compareAndSwap(oldValue: Int32, newValue: Int32) -> Bool {
+        pthread_mutex_lock(&mutex)
+        defer {
+            pthread_mutex_unlock(&mutex)
+        }
+        if oldValue != value {
+            return false
+        }
+        value = newValue
+        return true
     }
 }
 
@@ -71,25 +69,18 @@ public final class CASSpinLock: ReadWriteLock {
         static let MASK_READER_BITS          = ~MASK_WRITER_BITS
     }
 
-    private var _state: UnsafeMutablePointer<Int32>
+    private let _state = AtomicInt()
 
-    public init() {
-        _state = UnsafeMutablePointer.allocate(capacity: 1)
-        _state.pointee = 0
-    }
-
-    deinit {
-        _state.deallocate()
-    }
+    public init() {}
 
     public func withWriteLock<T>(block: () -> T) -> T {
         // spin until we acquire write lock
         repeat {
-            let state = _state.pointee
+            let state = _state.value
 
             // if there are no readers and no one holds the write lock, try to grab the write lock immediately
             if (state == 0 || state == Masks.WRITER_WAITING_BIT) &&
-                OSAtomicCompareAndSwap32Barrier(state, Masks.WRITER_BIT, _state) {
+                _state.compareAndSwap(oldValue: state, newValue: Masks.WRITER_BIT) {
                     break
             }
 
@@ -97,7 +88,7 @@ public final class CASSpinLock: ReadWriteLock {
             // it isn't already to block any new readers, then wait a bit before
             // trying again. Ignore CAS failure - we'll just try again next iteration
             if state & Masks.WRITER_WAITING_BIT == 0 {
-                OSAtomicCompareAndSwap32Barrier(state, state | Masks.WRITER_WAITING_BIT, _state)
+                _ = _state.compareAndSwap(oldValue: state, newValue: state | Masks.WRITER_WAITING_BIT)
             }
         } while true
 
@@ -106,11 +97,11 @@ public final class CASSpinLock: ReadWriteLock {
 
         // unlock
         repeat {
-            let state = _state.pointee
+            let state = _state.value
 
             // clear everything except (possibly) WRITER_WAITING_BIT, which will only be set
             // if another writer is already here and waiting (which will keep out readers)
-            if OSAtomicCompareAndSwap32Barrier(state, state & Masks.WRITER_WAITING_BIT, _state) {
+            if _state.compareAndSwap(oldValue: state, newValue: state & Masks.WRITER_WAITING_BIT) {
                 break
             }
         } while true
@@ -121,11 +112,11 @@ public final class CASSpinLock: ReadWriteLock {
     public func withReadLock<T>(block: () -> T) -> T {
         // spin until we acquire read lock
         repeat {
-            let state = _state.pointee
+            let state = _state.value
 
             // if there is no writer and no writer waiting, try to increment reader count
             if (state & Masks.MASK_WRITER_BITS) == 0 &&
-                OSAtomicCompareAndSwap32Barrier(state, state + 1, _state) {
+                _state.compareAndSwap(oldValue: state, newValue: state + 1) {
                     break
             }
         } while true
@@ -135,7 +126,7 @@ public final class CASSpinLock: ReadWriteLock {
 
         // decrement reader count
         repeat {
-            let state = _state.pointee
+            let state = _state.value
 
             // sanity check that we have a positive reader count before decrementing it
             assert((state & Masks.MASK_READER_BITS) > 0, "unlocking read lock - invalid reader count")
@@ -144,7 +135,7 @@ public final class CASSpinLock: ReadWriteLock {
             let newState = ((state & Masks.MASK_READER_BITS) - 1) |
                 (state & Masks.WRITER_WAITING_BIT)
 
-            if OSAtomicCompareAndSwap32Barrier(state, newState, _state) {
+            if _state.compareAndSwap(oldValue: state, newValue: newState) {
                 break
             }
         } while true


### PR DESCRIPTION
In an effort to keep changes minimal (or 1:1 in this case), I duplicated the test-and-set API usage. (Obviously this *could* be rewritten to not use test-and-set style API.)

