### PR TITLE
Fix #4840 - Close all pb mode animates one-by-one

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -218,24 +218,27 @@ class TabDisplayManager: NSObject {
     }
 
     // When using 'Close All', hide all the tabs so they don't animate their deletion individually
-    func hideDisplayedTabs() -> Success {
-        let deferred = Success()
+    func hideDisplayedTabs( completion: @escaping () -> Void) {
+
+        var cells = [UICollectionViewCell]()
         for i in 0..<collectionView.numberOfItems(inSection: 0) {
             guard let cell = collectionView.cellForItem(at: IndexPath(row: i, section: 0)) else { continue }
-            UIView.animate(withDuration: 0.2,
-                           animations: {
-                                cell.contentView.alpha = 0
-                                cell.alpha = 0 },
-                           completion: { _ in
-                                cell.contentView.alpha = 1
-                                cell.alpha = 1
-                                cell.isHidden = true
-                                if !deferred.isFilled {
-                                    deferred.fill(Maybe(success: ()))
-                                }
-            })
+            cells.append(cell)
         }
-        return deferred
+
+        UIView.animate(withDuration: 0.2,
+                       animations: {
+                            cells.forEach {
+                                $0.alpha = 0
+
+                            }
+                        }, completion: { _ in
+                            cells.forEach {
+                                $0.alpha = 1
+                                $0.isHidden = true
+                            }
+                            completion()
+                        })
     }
 }
 

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -219,18 +219,12 @@ class TabDisplayManager: NSObject {
 
     // When using 'Close All', hide all the tabs so they don't animate their deletion individually
     func hideDisplayedTabs( completion: @escaping () -> Void) {
-
-        var cells = [UICollectionViewCell]()
-        for i in 0..<collectionView.numberOfItems(inSection: 0) {
-            guard let cell = collectionView.cellForItem(at: IndexPath(row: i, section: 0)) else { continue }
-            cells.append(cell)
-        }
+        let cells = collectionView.visibleCells
 
         UIView.animate(withDuration: 0.2,
                        animations: {
                             cells.forEach {
                                 $0.alpha = 0
-
                             }
                         }, completion: { _ in
                             cells.forEach {

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -216,6 +216,27 @@ class TabDisplayManager: NSObject {
         let eventValue = isTabTray ? UnifiedTelemetry.EventValue.tabTray : UnifiedTelemetry.EventValue.topTabs
         UnifiedTelemetry.recordEvent(category: .action, method: method, object: object, value: eventValue)
     }
+
+    // When using 'Close All', hide all the tabs so they don't animate their deletion individually
+    func hideDisplayedTabs() -> Success {
+        let deferred = Success()
+        for i in 0..<collectionView.numberOfItems(inSection: 0) {
+            guard let cell = collectionView.cellForItem(at: IndexPath(row: i, section: 0)) else { continue }
+            UIView.animate(withDuration: 0.2,
+                           animations: {
+                                cell.contentView.alpha = 0
+                                cell.alpha = 0 },
+                           completion: { _ in
+                                cell.contentView.alpha = 1
+                                cell.alpha = 1
+                                cell.isHidden = true
+                                if !deferred.isFilled {
+                                    deferred.fill(Maybe(success: ()))
+                                }
+            })
+        }
+        return deferred
+    }
 }
 
 extension TabDisplayManager: UICollectionViewDataSource {

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -476,7 +476,7 @@ extension TabTrayController {
     }
 
     func closeTabsForCurrentTray() {
-        tabDisplayManager.hideDisplayedTabs().uponQueue(.main) { _ in
+        tabDisplayManager.hideDisplayedTabs() {
             self.tabManager.removeTabsWithUndoToast(self.tabDisplayManager.dataStore.compactMap { $0 })
             if self.tabDisplayManager.isPrivate {
                 self.emptyPrivateTabsView.isHidden = !self.privateTabsAreEmpty()


### PR DESCRIPTION
This PR hides the tabs first (before the deletion) so the animation isn't happening one-by-one.