### PR TITLE
4745 Set scrollview constraint to UIPageControl - PageControl bullets work…

### DIFF
--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -111,7 +111,7 @@ class IntroViewController: UIViewController {
         }
         scrollView.snp.makeConstraints { make in
             make.left.right.top.equalTo(self.view)
-            make.bottom.equalTo(startBrowsingButton.snp.top)
+            make.bottom.equalTo(pageControl.snp.top)
         }
 
         pageControl.snp.makeConstraints { make in


### PR DESCRIPTION
Grabbed this bug 4745 and found out it is a low hanging fruit to start contributing to Firefox-ios.

On the Onboardingscreen: Changed the bottom constraints of the scrollview to be equal to the top of the pageControl view instead of the startBrowsing button - this change makes the bullets tappable again.  