### PR TITLE
Fix 4885 - Update Library buttons IDs

### DIFF
--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -252,7 +252,7 @@ class ActivityStreamTest: BaseTestCase {
         selectOptionFromContextMenu(option: "Bookmark")
 
         // Check that it appears under Bookmarks menu
-        navigator.goto(HomePanel_Bookmarks)
+        navigator.goto(LibraryPanel_Bookmarks)
         waitForExistence(app.tables["Bookmarks List"])
         XCTAssertTrue(app.tables["Bookmarks List"].staticTexts[defaultTopSite["bookmarkLabel"]!].exists)
 
@@ -264,7 +264,7 @@ class ActivityStreamTest: BaseTestCase {
 
         // Unbookmark it
         selectOptionFromContextMenu(option: "Remove Bookmark")
-        navigator.goto(HomePanel_Bookmarks)
+        navigator.goto(LibraryPanel_Bookmarks)
         XCTAssertFalse(app.tables["Bookmarks List"].staticTexts[defaultTopSite["bookmarkLabel"]!].exists)
     }
 
@@ -276,7 +276,7 @@ class ActivityStreamTest: BaseTestCase {
 
         // Check that it appears under Bookmarks menu
         navigator.nowAt(HomePanelsScreen)
-        navigator.goto(HomePanel_Bookmarks)
+        navigator.goto(LibraryPanel_Bookmarks)
         XCTAssertTrue(app.tables["Bookmarks List"].staticTexts[newTopSite["bookmarkLabel"]!].exists)
 
         // Check that longtapping on the TopSite gives the option to remove it
@@ -285,7 +285,7 @@ class ActivityStreamTest: BaseTestCase {
 
         // Unbookmark it
         selectOptionFromContextMenu(option: "Remove Bookmark")
-        navigator.goto(HomePanel_Bookmarks)
+        navigator.goto(LibraryPanel_Bookmarks)
         XCTAssertFalse(app.tables["Bookmarks List"].staticTexts[newTopSite["bookmarkLabel"]!].exists)
     }
 

--- a/XCUITests/BookmarkingTests.swift
+++ b/XCUITests/BookmarkingTests.swift
@@ -94,7 +94,7 @@ class BookmarkingTests: BaseTestCase {
         bookmark()
 
         //There should be a bookmark
-        navigator.goto(HomePanel_Bookmarks)
+        navigator.goto(LibraryPanel_Bookmarks)
         checkItemInBookmarkList()
     }
 

--- a/XCUITests/BrowsingPDFTests.swift
+++ b/XCUITests/BrowsingPDFTests.swift
@@ -82,7 +82,7 @@ class BrowsingPDFTests: BaseTestCase {
         navigator.nowAt(BrowserTab)
 
         // Go to reading list and check that the item is there
-        navigator.goto(HomePanel_ReadingList)
+        navigator.goto(LibraryPanel_ReadingList)
         let savedToReadingList = app.tables["ReadingTable"].cells.staticTexts[PDF_website["longUrlValue"]!]
         waitForExistence(savedToReadingList)
         XCTAssertTrue(savedToReadingList.exists)
@@ -116,7 +116,7 @@ class BrowsingPDFTests: BaseTestCase {
         navigator.openURL(PDF_website["url"]!)
         navigator.performAction(Action.BookmarkThreeDots)
         navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_Bookmarks)
+        navigator.goto(LibraryPanel_Bookmarks)
         waitForExistence(app.tables["Bookmarks List"])
         XCTAssertTrue(app.tables["Bookmarks List"].staticTexts[PDF_website["bookmarkLabel"]!].exists)
     }

--- a/XCUITests/DatabaseFixtureTest.swift
+++ b/XCUITests/DatabaseFixtureTest.swift
@@ -17,7 +17,7 @@ class DatabaseFixtureTest: BaseTestCase {
     }
 
     func testOneBookmark() {
-        navigator.goto(HomePanel_Bookmarks)
+        navigator.goto(LibraryPanel_Bookmarks)
         let list = app.tables["Bookmarks List"].cells.count
         XCTAssertEqual(list, 1, "There should be an entry in the bookmarks list")
     }
@@ -25,7 +25,7 @@ class DatabaseFixtureTest: BaseTestCase {
     func testBookmarksDatabaseFixture() {
         waitForTabsButton()
         navigator.goto(HomePanel_Library)
-        navigator.nowAt(HomePanel_Bookmarks)
+        navigator.nowAt(LibraryPanel_Bookmarks)
         waitForExistence(app.tables["Bookmarks List"], timeout: 15)
 
         let loaded = NSPredicate(format: "count == 1013")
@@ -37,7 +37,7 @@ class DatabaseFixtureTest: BaseTestCase {
     }
 
     func testHistoryDatabaseFixture() {
-        navigator.goto(HomePanel_History)
+        navigator.goto(LibraryPanel_History)
 
         // History list has two cells that are for recently closed and synced devices that should not count as history items,
         // the actual max number is 100

--- a/XCUITests/DownloadFilesTests.swift
+++ b/XCUITests/DownloadFilesTests.swift
@@ -27,7 +27,7 @@ class DownloadFilesTests: BaseTestCase {
     }
 
     func testDownloadFilesAppMenuFirstTime() {
-        navigator.goto(HomePanel_Downloads)
+        navigator.goto(LibraryPanel_Downloads)
         XCTAssertTrue(app.tables["DownloadsTable"].exists)
         // Check that there is not any items and the default text shown is correct
         checkTheNumberOfDownloadedItems(items: 0)
@@ -46,14 +46,14 @@ class DownloadFilesTests: BaseTestCase {
         XCTAssertTrue(app.tables["Context Menu"].cells["download"].exists)
         app.buttons["Cancel"].tap()
         navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_Downloads)
+        navigator.goto(LibraryPanel_Downloads)
         checkTheNumberOfDownloadedItems(items: 0)
     }
 
     func testDownloadFile() {
         downloadFile(fileName: testFileName, numberOfDownlowds: 1)
         navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_Downloads)
+        navigator.goto(LibraryPanel_Downloads)
 
         waitForExistence(app.tables["DownloadsTable"])
         // There should be one item downloaded. It's name and size should be shown
@@ -65,7 +65,7 @@ class DownloadFilesTests: BaseTestCase {
     func testDeleteDownloadedFile() {
         downloadFile(fileName: testFileName, numberOfDownlowds: 1)
         navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_Downloads)
+        navigator.goto(LibraryPanel_Downloads)
         waitForExistence(app.tables["DownloadsTable"])
 
         deleteItem(itemName: testFileName)
@@ -78,7 +78,7 @@ class DownloadFilesTests: BaseTestCase {
     func testShareDownloadedFile() {
         downloadFile(fileName: testFileName, numberOfDownlowds: 1)
         navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_Downloads)
+        navigator.goto(LibraryPanel_Downloads)
         app.tables.cells.staticTexts[testFileName].swipeLeft()
 
         XCTAssertTrue(app.tables.cells.buttons["Share"].exists)
@@ -96,7 +96,7 @@ class DownloadFilesTests: BaseTestCase {
     func testLongPressOnDownloadedFile() {
         downloadFile(fileName: testFileName, numberOfDownlowds: 1)
         navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_Downloads)
+        navigator.goto(LibraryPanel_Downloads)
 
         waitForExistence(app.tables["DownloadsTable"])
         app.tables.cells.staticTexts[testFileName].press(forDuration: 2)
@@ -123,7 +123,7 @@ class DownloadFilesTests: BaseTestCase {
     func testDownloadMoreThanOneFile() {
         downloadFile(fileName: testFileName, numberOfDownlowds: 2)
         navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_Downloads)
+        navigator.goto(LibraryPanel_Downloads)
 
         waitForExistence(app.tables["DownloadsTable"])
         checkTheNumberOfDownloadedItems(items: 2)
@@ -139,7 +139,7 @@ class DownloadFilesTests: BaseTestCase {
 
         // Check there is one item
         navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_Downloads)
+        navigator.goto(LibraryPanel_Downloads)
 
         waitForExistence(app.tables["DownloadsTable"])
         checkTheNumberOfDownloadedItems(items: 1)
@@ -150,7 +150,7 @@ class DownloadFilesTests: BaseTestCase {
         navigator.performAction(Action.AcceptClearPrivateData)
 
         navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_Downloads)
+        navigator.goto(LibraryPanel_Downloads)
         // Check there is still one item
         checkTheNumberOfDownloadedItems(items: 0)
     }

--- a/XCUITests/DragAndDropTests.swift
+++ b/XCUITests/DragAndDropTests.swift
@@ -256,7 +256,7 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
 
         // Drop a bookmark/history entry is only allowed on other apps. This test is to check that nothing happens within the app
         navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_History)
+        navigator.goto(LibraryPanel_History)
 
         let firstEntryOnList = app.tables["History List"].cells.element(boundBy:
             6).staticTexts[exampleDomainTitle]
@@ -276,7 +276,7 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
         if skipPlatform { return }
 
         //navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_Bookmarks)
+        navigator.goto(LibraryPanel_Bookmarks)
         waitForExistence(app.tables["Bookmarks List"])
 
         let firstEntryOnList = app.tables["Bookmarks List"].cells.element(boundBy: 0).staticTexts[exampleDomainTitle]
@@ -297,7 +297,7 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
     func testTryDragAndDropHistoryToURLBar() {
         if skipPlatform { return }
 
-        navigator.goto(HomePanel_History)
+        navigator.goto(LibraryPanel_History)
         waitForExistence(app.tables["History List"].cells.staticTexts[twitterTitle])
 
         app.tables["History List"].cells.staticTexts[twitterTitle].press(forDuration: 1, thenDragTo: app.textFields["url"])
@@ -312,7 +312,7 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
     func testTryDragAndDropBookmarkToURLBar() {
         if skipPlatform { return }
 
-        navigator.goto(HomePanel_Bookmarks)
+        navigator.goto(LibraryPanel_Bookmarks)
         waitForExistence(app.tables["Bookmarks List"])
         app.tables["Bookmarks List"].cells.staticTexts[twitterTitle].press(forDuration: 1, thenDragTo: app.textFields["url"])
 

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -985,10 +985,10 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.dismissOnUse = true
         screenState.backAction = navigationControllerBackAction
 
-        screenState.tap(app.buttons["HomePanels.Bookmarks"], to: HomePanel_Bookmarks)
-        screenState.tap(app.buttons["HomePanels.History"], to: HomePanel_History)
-        screenState.tap(app.buttons["HomePanels.ReadingList"], to: HomePanel_ReadingList)
-        screenState.tap(app.buttons["HomePanels.Downloads"], to: HomePanel_Downloads)
+        screenState.tap(app.buttons["LibraryPanels.Bookmarks"], to: HomePanel_Bookmarks)
+        screenState.tap(app.buttons["LibraryPanels.History"], to: HomePanel_History)
+        screenState.tap(app.buttons["LibraryPanels.ReadingList"], to: HomePanel_ReadingList)
+        screenState.tap(app.buttons["LibraryPanels.Downloads"], to: HomePanel_Downloads)
     }
 
     map.addScreenState(BrowserTabMenu) { screenState in

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -97,18 +97,18 @@ let allIntroPages = [
 let HomePanelsScreen = "HomePanels"
 let PrivateHomePanelsScreen = "PrivateHomePanels"
 let HomePanel_TopSites = "HomePanel.TopSites.0"
-let HomePanel_Bookmarks = "HomePanel.Bookmarks.1"
-let HomePanel_History = "HomePanel.History.2"
-let HomePanel_ReadingList = "HomePanel.ReadingList.3"
-let HomePanel_Downloads = "HomePanel.Downloads.4"
+let LibraryPanel_Bookmarks = "LibraryPanel.Bookmarks.1"
+let LibraryPanel_History = "LibraryPanel.History.2"
+let LibraryPanel_ReadingList = "LibraryPanel.ReadingList.3"
+let LibraryPanel_Downloads = "LibraryPanel.Downloads.4"
 
 let allHomePanels = [
     HomePanelsScreen,
     HomePanel_TopSites,
-    HomePanel_Bookmarks,
-    HomePanel_History,
-    HomePanel_ReadingList,
-    HomePanel_Downloads
+    LibraryPanel_Bookmarks,
+    LibraryPanel_History,
+    LibraryPanel_ReadingList,
+    LibraryPanel_Downloads
 ]
 
 class Action {
@@ -470,7 +470,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         }
     }
 
-    map.addScreenState(HomePanel_Bookmarks) { screenState in
+    map.addScreenState(LibraryPanel_Bookmarks) { screenState in
         let bookmarkCell = app.tables["Bookmarks List"].cells.element(boundBy: 0)
         screenState.press(bookmarkCell, to: BookmarksPanelContextMenu)
         screenState.tap(app.buttons["Done"], to: HomePanelsScreen)
@@ -481,7 +481,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.press(topSites.cells.matching(identifier: "TopSite").element(boundBy: 0), to: TopSitesPanelContextMenu)
     }
 
-    map.addScreenState(HomePanel_History) { screenState in
+    map.addScreenState(LibraryPanel_History) { screenState in
         screenState.press(app.tables["History List"].cells.element(boundBy: 2), to: HistoryPanelContextMenu)
         screenState.tap(app.cells["HistoryPanel.recentlyClosedCell"], to: HistoryRecentlyClosed)
         screenState.tap(app.buttons["Done"], to: HomePanelsScreen)
@@ -491,19 +491,19 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.backAction = navigationControllerBackAction
     }
 
-    map.addScreenState(HomePanel_ReadingList) { screenState in
+    map.addScreenState(LibraryPanel_ReadingList) { screenState in
         screenState.dismissOnUse = true
         screenState.tap(app.buttons["Done"], to: HomePanelsScreen)
     }
 
-    map.addScreenState(HomePanel_Downloads) { screenState in
+    map.addScreenState(LibraryPanel_Downloads) { screenState in
         screenState.dismissOnUse = true
         screenState.tap(app.buttons["Done"], to: HomePanelsScreen)
     }
 
     map.addScreenState(HistoryRecentlyClosed) { screenState in
         screenState.dismissOnUse = true
-        screenState.tap(app.buttons["goBackFromRecentlyClosedHistory"], to: HomePanel_History)
+        screenState.tap(app.buttons["goBackFromRecentlyClosedHistory"], to: LibraryPanel_History)
     }
 
     map.addScreenState(HistoryPanelContextMenu) { screenState in
@@ -985,10 +985,10 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.dismissOnUse = true
         screenState.backAction = navigationControllerBackAction
 
-        screenState.tap(app.buttons["LibraryPanels.Bookmarks"], to: HomePanel_Bookmarks)
-        screenState.tap(app.buttons["LibraryPanels.History"], to: HomePanel_History)
-        screenState.tap(app.buttons["LibraryPanels.ReadingList"], to: HomePanel_ReadingList)
-        screenState.tap(app.buttons["LibraryPanels.Downloads"], to: HomePanel_Downloads)
+        screenState.tap(app.buttons["LibraryPanels.Bookmarks"], to: LibraryPanel_Bookmarks)
+        screenState.tap(app.buttons["LibraryPanels.History"], to: LibraryPanel_History)
+        screenState.tap(app.buttons["LibraryPanels.ReadingList"], to: LibraryPanel_ReadingList)
+        screenState.tap(app.buttons["LibraryPanels.Downloads"], to: LibraryPanel_Downloads)
     }
 
     map.addScreenState(BrowserTabMenu) { screenState in

--- a/XCUITests/HistoryTests.swift
+++ b/XCUITests/HistoryTests.swift
@@ -28,14 +28,14 @@ class HistoryTests: BaseTestCase {
 
     func testEmptyHistoryListFirstTime() {
         // Go to History List from Top Sites and check it is empty
-        navigator.goto(HomePanel_History)
+        navigator.goto(LibraryPanel_History)
         waitForExistence(app.tables.cells["HistoryPanel.recentlyClosedCell"])
         XCTAssertTrue(app.tables.cells["HistoryPanel.recentlyClosedCell"].exists)
         XCTAssertTrue(app.tables.cells["HistoryPanel.syncedDevicesCell"].exists)
     }
 
     func testOpenSyncDevices() {
-        navigator.goto(HomePanel_History)
+        navigator.goto(LibraryPanel_History)
         app.tables.cells["HistoryPanel.syncedDevicesCell"].tap()
         waitForExistence(app.tables.cells.staticTexts["Firefox Sync"])
         XCTAssertTrue(app.tables.buttons["Sign in to Sync"].exists, "Sing in button does not appear")
@@ -43,7 +43,7 @@ class HistoryTests: BaseTestCase {
 
     func testClearHistoryFromSettings() {
         // Browse to have an item in history list
-        navigator.goto(HomePanel_History)
+        navigator.goto(LibraryPanel_History)
         waitForExistence(app.tables.cells["HistoryPanel.recentlyClosedCell"], timeout: 5)
         XCTAssertTrue(app.tables.cells.staticTexts[webpage["label"]!].exists)
 
@@ -51,7 +51,7 @@ class HistoryTests: BaseTestCase {
         navigator.performAction(Action.AcceptClearPrivateData)
 
         // Back on History panel view check that there is not any item
-        navigator.goto(HomePanel_History)
+        navigator.goto(LibraryPanel_History)
         waitForExistence(app.tables.cells["HistoryPanel.recentlyClosedCell"])
         XCTAssertFalse(app.tables.cells.staticTexts[webpage["label"]!].exists)
     }
@@ -77,17 +77,17 @@ class HistoryTests: BaseTestCase {
         waitForNoExistence(app.tables["Recently Closed Tabs List"])
 
         // Go to the default web site  and check whether the option is enabled
-        navigator.nowAt(HomePanel_History)
+        navigator.nowAt(LibraryPanel_History)
         navigator.goto(HomePanelsScreen)
         userState.url = path(forTestPage: "test-mozilla-book.html")
         navigator.goto(BrowserTab)
         navigator.goto(BrowserTabMenu)
         // Workaround to bug 1508368
-        navigator.goto(HomePanel_Bookmarks)
-        navigator.goto(HomePanel_History)
+        navigator.goto(LibraryPanel_Bookmarks)
+        navigator.goto(LibraryPanel_History)
         navigator.goto(HistoryRecentlyClosed)
         waitForNoExistence(app.tables["Recently Closed Tabs List"])
-        navigator.nowAt(HomePanel_History)
+        navigator.nowAt(LibraryPanel_History)
         navigator.goto(HomePanelsScreen)
 
         // Now go back to default website close it and check whether the option is enabled
@@ -217,14 +217,14 @@ class HistoryTests: BaseTestCase {
 
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.goto(HomePanelsScreen)
-        navigator.goto(HomePanel_History)
+        navigator.goto(LibraryPanel_History)
         XCTAssertFalse(app.cells.staticTexts["Recently Closed"].isSelected)
         waitForNoExistence(app.tables["Recently Closed Tabs List"])
 
         // Now verify that on regular mode the recently closed list is empty too
         navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
         navigator.goto(NewTabScreen)
-        navigator.goto(HomePanel_History)
+        navigator.goto(LibraryPanel_History)
         XCTAssertFalse(app.cells.staticTexts["Recently Closed"].isSelected)
         waitForNoExistence(app.tables["Recently Closed Tabs List"])
     }
@@ -244,7 +244,7 @@ class HistoryTests: BaseTestCase {
         }
         // Go to 'goolge.com' to create a recent history entry.
         navigator.openURL("google.com")
-        navigator.goto(HomePanel_History)
+        navigator.goto(LibraryPanel_History)
         XCTAssertTrue(app.tables.cells.staticTexts["Google"].exists)
         navigator.performAction(Action.ClearRecentHistory)
         // Recent data will be removed after calling tapOnClearRecentHistoryOption(optionSelected: "Today").

--- a/XCUITests/IntegrationTests.swift
+++ b/XCUITests/IntegrationTests.swift
@@ -80,7 +80,7 @@ class IntegrationTests: BaseTestCase {
 
         // Wait for initial sync to complete
         waitForInitialSyncComplete()
-        navigator.goto(HomePanel_Bookmarks)
+        navigator.goto(LibraryPanel_Bookmarks)
         waitForExistence(app.tables["Bookmarks List"].cells.element(boundBy: 1).staticTexts["Example Domain"])
     }
 
@@ -137,7 +137,7 @@ class IntegrationTests: BaseTestCase {
         waitForInitialSyncComplete()
 
         // Check synced History
-        navigator.goto(HomePanel_History)
+        navigator.goto(LibraryPanel_History)
         waitForExistence(app.tables.cells.staticTexts[historyItemSavedOnDesktop], timeout: 5)
     }
 
@@ -163,7 +163,7 @@ class IntegrationTests: BaseTestCase {
         waitForInitialSyncComplete()
 
         // Check synced Tabs
-        navigator.goto(HomePanel_History)
+        navigator.goto(LibraryPanel_History)
         waitForExistence(app.cells["HistoryPanel.syncedDevicesCell"], timeout: 5)
         app.cells["HistoryPanel.syncedDevicesCell"].tap()
         // Need to swipe to get the data on the screen on focus

--- a/XCUITests/LibraryTests.swift
+++ b/XCUITests/LibraryTests.swift
@@ -15,7 +15,7 @@ class LibraryTestsIpad: IpadOnlyTestCase {
         navigator.nowAt(HomePanel_Library)
         waitForExistence(app.tables["Bookmarks List"])
         // Go to a different panel, like History
-        navigator.goto(HomePanel_History)
+        navigator.goto(LibraryPanel_History)
         // Verify that next time Library opens in last visited panel
         navigator.goto(HomePanelsScreen)
         waitForExistence(app.buttons["TabToolbar.libraryButton"])
@@ -36,25 +36,25 @@ class LibraryTestsIphone: IphoneOnlyTestCase {
         
         // Check if clicking on Bookmark option shows bookmarks
         app.buttons["menu Bookmark"].tap()
-        navigator.nowAt(HomePanel_Bookmarks)
+        navigator.nowAt(LibraryPanel_Bookmarks)
         waitForExistence(app.tables["Bookmarks List"])
         navigator.goto(HomePanelsScreen)
         
         // Check if clicking on History option shows history
         app.buttons["menu panel History"].tap()
-        navigator.nowAt(HomePanel_History)
+        navigator.nowAt(LibraryPanel_History)
         waitForExistence(app.tables["History List"])
         navigator.goto(HomePanelsScreen)
         
         // Check if clicking on Reading List option shows history
         app.buttons["menu panel ReadingList"].tap()
-        navigator.nowAt(HomePanel_ReadingList)
+        navigator.nowAt(LibraryPanel_ReadingList)
         waitForExistence(app.tables["ReadingTable"])
         navigator.goto(HomePanelsScreen)
         
         // Check if clicking on Downloads option shows history
         app.buttons["menu panel Downloads"].tap()
-        navigator.nowAt(HomePanel_Downloads)
+        navigator.nowAt(LibraryPanel_Downloads)
         waitForExistence(app.tables["DownloadsTable"])
         navigator.goto(HomePanelsScreen)
     }

--- a/XCUITests/NavigationTest.swift
+++ b/XCUITests/NavigationTest.swift
@@ -96,15 +96,14 @@ class NavigationTest: BaseTestCase {
     }
 
     func testTapSignInShowsFxAFromRemoteTabPanel() {
-        //navigator.goto(HomePanel_TopSites)
         // Open FxAccount from remote tab panel and check the Sign in to Firefox scren
-        navigator.goto(HomePanel_History)
+        navigator.goto(LibraryPanel_History)
         XCTAssertTrue(app.tables["History List"].staticTexts["Synced Devices"].isEnabled)
         app.tables["History List"].staticTexts["Synced Devices"].tap()
         app.tables.buttons["Sign in to Sync"].tap()
         checkFirefoxSyncScreenShown()
         app.navigationBars["Client.FxAContentView"].buttons["Done"].tap()
-        navigator.nowAt(HomePanel_History)
+        navigator.nowAt(LibraryPanel_History)
     }
 
     private func checkFirefoxSyncScreenShown() {
@@ -416,7 +415,7 @@ class NavigationTest: BaseTestCase {
         XCTAssertTrue(app.tables["Context Menu"].cells["download"].exists)
         app.tables["Context Menu"].cells["download"].tap()
         navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_Downloads)
+        navigator.goto(LibraryPanel_Downloads)
         waitForExistence(app.tables["DownloadsTable"])
         // There should be one item downloaded. It's name and size should be shown
         let downloadedList = app.tables["DownloadsTable"].cells.count

--- a/XCUITests/PrivateBrowsingTest.swift
+++ b/XCUITests/PrivateBrowsingTest.swift
@@ -16,7 +16,7 @@ class PrivateBrowsingTest: BaseTestCase {
         waitForTabsButton()
         navigator.goto(BrowserTabMenu)
         // Go to History screen
-        navigator.goto(HomePanel_History)
+        navigator.goto(LibraryPanel_History)
         waitForExistence(app.tables["History List"])
 
         XCTAssertTrue(app.tables["History List"].staticTexts[url1Label].exists)
@@ -30,7 +30,7 @@ class PrivateBrowsingTest: BaseTestCase {
 
         navigator.openURL(url2)
         waitForValueContains(app.textFields["url"], value: "facebook")
-        navigator.goto(HomePanel_History)
+        navigator.goto(LibraryPanel_History)
         waitForExistence(app.tables["History List"])
         XCTAssertTrue(app.tables["History List"].staticTexts[url1Label].exists)
         XCTAssertFalse(app.tables["History List"].staticTexts[url2Label].exists)
@@ -218,7 +218,7 @@ class PrivateBrowsingTestIpad: IpadOnlyTestCase {
         // This action to enable private mode is defined on HomePanel Screen that is why we need to open a new tab and be sure we are on that screen to use the correct action
         navigator.goto(NewTabScreen)
         navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateModeFromTabBarHomePanel)
-        navigator.goto(HomePanel_History)
+        navigator.goto(LibraryPanel_History)
         waitForExistence(app.tables["History List"])
         // History without counting Clear Recent History, Recently Closed and Synced devices
         let history = app.tables["History List"].cells.count - 3
@@ -237,7 +237,7 @@ class PrivateBrowsingTestIpad: IpadOnlyTestCase {
         // Open website and check it does not appear under history once going back to regular mode
         navigator.openURL("http://example.com")
         navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateModeFromTabBarBrowserTab)
-        navigator.goto(HomePanel_History)
+        navigator.goto(LibraryPanel_History)
         waitForExistence(app.tables["History List"])
         // History without counting Clear Recent History, Recently Closed and Synced devices
         let history = app.tables["History List"].cells.count - 3

--- a/XCUITests/ReaderViewUITest.swift
+++ b/XCUITests/ReaderViewUITest.swift
@@ -36,19 +36,19 @@ class ReaderViewTest: BaseTestCase {
     // Smoketest
     func testAddToReadingList() {
         // Initially reading list is empty
-        navigator.goto(HomePanel_ReadingList)
+        navigator.goto(LibraryPanel_ReadingList)
 
         // Check the button is selected (is disabled and the rest bookmarks and so are enabled)
-        XCTAssertFalse(app.buttons["HomePanels.ReadingList"].isEnabled)
-        XCTAssertTrue(app.buttons["HomePanels.Bookmarks"].isEnabled)
+        XCTAssertFalse(app.buttons["LibraryPanels.ReadingList"].isEnabled)
+        XCTAssertTrue(app.buttons["LibraryPanels.Bookmarks"].isEnabled)
 
         checkReadingListNumberOfItems(items: 0)
 
         // Add item to reading list and check that it appears
         addContentToReaderView()
         navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_ReadingList)
-        waitForExistence(app.buttons["HomePanels.ReadingList"])
+        navigator.goto(LibraryPanel_ReadingList)
+        waitForExistence(app.buttons["LibraryPanels.ReadingList"])
 
         // Check that there is one item
         let savedToReadingList = app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"]
@@ -62,18 +62,18 @@ class ReaderViewTest: BaseTestCase {
         // Initially reading list is empty
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_ReadingList)
+        navigator.goto(LibraryPanel_ReadingList)
 
         // Check the button is selected (is disabled and the rest bookmarks and so are enabled)
-        XCTAssertFalse(app.buttons["HomePanels.ReadingList"].isEnabled)
-        XCTAssertTrue(app.buttons["HomePanels.Bookmarks"].isEnabled)
+        XCTAssertFalse(app.buttons["LibraryPanels.ReadingList"].isEnabled)
+        XCTAssertTrue(app.buttons["LibraryPanels.Bookmarks"].isEnabled)
         checkReadingListNumberOfItems(items: 0)
 
         // Add item to reading list and check that it appears
         addContentToReaderView()
         navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_ReadingList)
-        waitForExistence(app.buttons["HomePanels.ReadingList"])
+        navigator.goto(LibraryPanel_ReadingList)
+        waitForExistence(app.buttons["LibraryPanels.ReadingList"])
 
         // Check that there is one item
         let savedToReadingList = app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"]
@@ -83,7 +83,7 @@ class ReaderViewTest: BaseTestCase {
 
         // Check that it appears on regular mode
         navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
-        navigator.goto(HomePanel_ReadingList)
+        navigator.goto(LibraryPanel_ReadingList)
         checkReadingListNumberOfItems(items: 1)
     }
 
@@ -110,18 +110,18 @@ class ReaderViewTest: BaseTestCase {
 
         // Go to reader list view to check that there is not any item there
         navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_ReadingList)
-        waitForExistence(app.buttons["HomePanels.ReadingList"])
-        navigator.goto(HomePanel_ReadingList)
+        navigator.goto(LibraryPanel_ReadingList)
+        waitForExistence(app.buttons["LibraryPanels.ReadingList"])
+        navigator.goto(LibraryPanel_ReadingList)
         checkReadingListNumberOfItems(items: 0)
     }
 
     func testMarkAsReadAndUnreadFromReadingList() {
         addContentToReaderView()
         navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_ReadingList)
-        waitForExistence(app.buttons["HomePanels.ReadingList"])
-        navigator.goto(HomePanel_ReadingList)
+        navigator.goto(LibraryPanel_ReadingList)
+        waitForExistence(app.buttons["LibraryPanels.ReadingList"])
+        navigator.goto(LibraryPanel_ReadingList)
 
         // Check that there is one item
         let savedToReadingList = app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"]
@@ -138,9 +138,9 @@ class ReaderViewTest: BaseTestCase {
     func testRemoveFromReadingList() {
         addContentToReaderView()
         navigator.goto(BrowserTabMenu)
-        navigator.goto(HomePanel_ReadingList)
-        waitForExistence(app.buttons["HomePanels.ReadingList"])
-        navigator.goto(HomePanel_ReadingList)
+        navigator.goto(LibraryPanel_ReadingList)
+        waitForExistence(app.buttons["LibraryPanels.ReadingList"])
+        navigator.goto(LibraryPanel_ReadingList)
 
         let savedToReadingList = app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"]
         savedToReadingList.swipeLeft()
@@ -156,7 +156,7 @@ class ReaderViewTest: BaseTestCase {
 
     func testAddToReadingListFromPageOptionsMenu() {
         // First time Reading list is empty
-        navigator.goto(HomePanel_ReadingList)
+        navigator.goto(LibraryPanel_ReadingList)
         checkReadingListNumberOfItems(items: 0)
 
         // Add item to Reading List from Page Options Menu
@@ -167,7 +167,7 @@ class ReaderViewTest: BaseTestCase {
 
         // Now there should be an item on the list
         navigator.nowAt(BrowserTab)
-        navigator.goto(HomePanel_ReadingList)
+        navigator.goto(LibraryPanel_ReadingList)
         checkReadingListNumberOfItems(items: 1)
     }
 
@@ -177,7 +177,7 @@ class ReaderViewTest: BaseTestCase {
 
         // Add item to Reading List
         addContentToReaderView()
-        navigator.goto(HomePanel_ReadingList)
+        navigator.goto(LibraryPanel_ReadingList)
 
         // Long tap on the item just saved
         let savedToReadingList = app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"]
@@ -196,7 +196,7 @@ class ReaderViewTest: BaseTestCase {
     func testRemoveSavedForReadingLongPress() {
         // Add item to Reading List
         addContentToReaderView()
-        navigator.goto(HomePanel_ReadingList)
+        navigator.goto(LibraryPanel_ReadingList)
 
         // Long tap on the item just saved and choose remove
         let savedToReadingList = app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"]


### PR DESCRIPTION
This PR updates the buttons IDs to access the Library panels. Also changing `HomePanel_` to `LibraryPanel_`so that variables names are updated too
