### PR TITLE
Fix 4884 - XCUITests Update Bookmarks tests

### DIFF
--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -252,12 +252,13 @@ class ActivityStreamTest: BaseTestCase {
         selectOptionFromContextMenu(option: "Bookmark")
 
         // Check that it appears under Bookmarks menu
-        navigator.goto(LibraryPanel_Bookmarks)
+        navigator.goto(MobileBookmarks)
         waitForExistence(app.tables["Bookmarks List"])
         XCTAssertTrue(app.tables["Bookmarks List"].staticTexts[defaultTopSite["bookmarkLabel"]!].exists)
 
         // Check that longtapping on the TopSite gives the option to remove it
-        navigator.goto(HomePanelsScreen)
+        navigator.performAction(Action.ExitMobileBookmarksFolder)
+        navigator.nowAt(HomePanelsScreen)
         app.cells["TopSitesCell"].cells[defaultTopSite["topSiteLabel"]!]
             .press(forDuration: 2)
         XCTAssertTrue(app.tables["Context Menu"].cells["Remove Bookmark"].exists)
@@ -276,11 +277,12 @@ class ActivityStreamTest: BaseTestCase {
 
         // Check that it appears under Bookmarks menu
         navigator.nowAt(HomePanelsScreen)
-        navigator.goto(LibraryPanel_Bookmarks)
+        navigator.goto(MobileBookmarks)
         XCTAssertTrue(app.tables["Bookmarks List"].staticTexts[newTopSite["bookmarkLabel"]!].exists)
 
         // Check that longtapping on the TopSite gives the option to remove it
-        navigator.goto(HomePanelsScreen)
+        navigator.performAction(Action.ExitMobileBookmarksFolder)
+        navigator.nowAt(HomePanelsScreen)
         TopSiteCellgroup.cells[newTopSite["topSiteLabel"]!].press(forDuration: 1)
 
         // Unbookmark it

--- a/XCUITests/BookmarkingTests.swift
+++ b/XCUITests/BookmarkingTests.swift
@@ -94,7 +94,7 @@ class BookmarkingTests: BaseTestCase {
         bookmark()
 
         //There should be a bookmark
-        navigator.goto(LibraryPanel_Bookmarks)
+        navigator.goto(MobileBookmarks)
         checkItemInBookmarkList()
     }
 

--- a/XCUITests/DatabaseFixtureTest.swift
+++ b/XCUITests/DatabaseFixtureTest.swift
@@ -17,15 +17,14 @@ class DatabaseFixtureTest: BaseTestCase {
     }
 
     func testOneBookmark() {
-        navigator.goto(LibraryPanel_Bookmarks)
+        navigator.goto(MobileBookmarks)
         let list = app.tables["Bookmarks List"].cells.count
         XCTAssertEqual(list, 1, "There should be an entry in the bookmarks list")
     }
 
     func testBookmarksDatabaseFixture() {
         waitForTabsButton()
-        navigator.goto(HomePanel_Library)
-        navigator.nowAt(LibraryPanel_Bookmarks)
+        navigator.goto(MobileBookmarks)
         waitForExistence(app.tables["Bookmarks List"], timeout: 15)
 
         let loaded = NSPredicate(format: "count == 1013")

--- a/XCUITests/DragAndDropTests.swift
+++ b/XCUITests/DragAndDropTests.swift
@@ -275,8 +275,7 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
     func testDragAndDropBookmarkEntry() {
         if skipPlatform { return }
 
-        //navigator.goto(BrowserTabMenu)
-        navigator.goto(LibraryPanel_Bookmarks)
+        navigator.goto(MobileBookmarks)
         waitForExistence(app.tables["Bookmarks List"])
 
         let firstEntryOnList = app.tables["Bookmarks List"].cells.element(boundBy: 0).staticTexts[exampleDomainTitle]
@@ -312,7 +311,7 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
     func testTryDragAndDropBookmarkToURLBar() {
         if skipPlatform { return }
 
-        navigator.goto(LibraryPanel_Bookmarks)
+        navigator.goto(MobileBookmarks)
         waitForExistence(app.tables["Bookmarks List"])
         app.tables["Bookmarks List"].cells.staticTexts[twitterTitle].press(forDuration: 1, thenDragTo: app.textFields["url"])
 

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -54,6 +54,7 @@ let TranslationSettings = "TranslationSettings"
 let HomePanel_Library = "HomePanel_Library"
 let TranslatePageMenu = "TranslatePageMenu"
 let DontTranslatePageMenu = "DontTranslatePageMenu"
+let MobileBookmarks = "MobileBookmarks"
 
 // These are in the exact order they appear in the settings
 // screen. XCUIApplication loses them on small screens.
@@ -206,6 +207,8 @@ class Action {
     static let DisableTranslation = "DisableTranlation"
     static let SelectGoogle = "SelectGoogle"
     static let SelectBing = "SelectBing"
+
+    static let ExitMobileBookmarksFolder = "ExitMobileBookmarksFolder"
 }
 
 @objcMembers
@@ -473,7 +476,16 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     map.addScreenState(LibraryPanel_Bookmarks) { screenState in
         let bookmarkCell = app.tables["Bookmarks List"].cells.element(boundBy: 0)
         screenState.press(bookmarkCell, to: BookmarksPanelContextMenu)
+        screenState.tap(app.cells.staticTexts["Mobile Bookmarks"], to: MobileBookmarks)
         screenState.tap(app.buttons["Done"], to: HomePanelsScreen)
+    }
+
+    map.addScreenState(MobileBookmarks) { screenState in
+        let bookmarkCell = app.tables["Bookmarks List"].cells.element(boundBy: 0)
+        screenState.press(bookmarkCell, to: BookmarksPanelContextMenu)
+        screenState.gesture(forAction: Action.ExitMobileBookmarksFolder) { userState in
+            app.buttons["Done"].tap()
+        }
     }
 
     map.addScreenState(HomePanel_TopSites) { screenState in


### PR DESCRIPTION
This PR updates the Bookmarks tests. Now the bookmarks saved appear in Mobile Bookmarks folder not in the Bookmarks panel root directory