### PR TITLE
Fix 4881 - Sync Integration disable tests temporally

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,30 +42,30 @@ pipeline {
                 dir('SyncIntegrationTests') {
                     sh 'pipenv install'
                     sh 'pipenv check'
-                    sh 'pipenv run pytest ' +
-                        '--color=yes ' +
-                        '--junit-xml=results/junit.xml ' +
-                        '--html=results/index.html'
+                    // sh 'pipenv run pytest ' +
+                    //    '--color=yes ' +
+                    //    '--junit-xml=results/junit.xml ' +
+                    //    '--html=results/index.html'
                 }
             }
         }
     }
     post {
-        always {
-            script {
-                if (env.BRANCH_NAME == 'master') {
-                archiveArtifacts 'SyncIntegrationTests/results/*'
-                junit 'SyncIntegrationTests/results/*.xml'
-                publishHTML(target: [
-                    allowMissing: false,
-                    alwaysLinkToLastBuild: true,
-                    keepAll: true,
-                    reportDir: 'SyncIntegrationTests/results',
-                    reportFiles: 'index.html',
-                    reportName: 'HTML Report'])
-                }
-            }
-        }
+        // always {
+            // script {
+                // if (env.BRANCH_NAME == 'master') {
+                // archiveArtifacts 'SyncIntegrationTests/results/*'
+                // junit 'SyncIntegrationTests/results/*.xml'
+                // publishHTML(target: [
+                    // allowMissing: false,
+                    // alwaysLinkToLastBuild: true,
+                    // keepAll: true,
+                    // reportDir: 'SyncIntegrationTests/results',
+                    // reportFiles: 'index.html',
+                    // reportName: 'HTML Report'])
+                // }
+            // }
+        // }
 
         failure {
             script {


### PR DESCRIPTION
Tests are failing, until we get them working again let's disable them so that build is not always red. 
