### PR TITLE
Bug 1493182 - SMS: and MAILTO: not showing prompt before opening

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -562,6 +562,7 @@ extension Strings {
 // Snackbar shown when tapping app store link
 extension Strings {
     public static let ExternalLinkAppStoreConfirmationTitle = NSLocalizedString("ExternalLink.AppStore.ConfirmationTitle", value: "Open this link in the App Store?", comment: "Question shown to user when tapping a link that opens the App Store app")
+    public static let ExternalLinkGenericConfirmation = NSLocalizedString("ExternalLink.AppStore.GenericConfirmationTitle", value: "Open this link in external app?", comment: "Question shown to user when tapping an SMS or MailTo link that opens the external app for those.")
 }
 
 // ContentBlocker/TrackingProtection strings


### PR DESCRIPTION
[sms://234-234-2345](sms://234-234-2345) and [mailto:happy@happyfeet.com](mailto:happy@happyfeet.com) don't ask the user to confirm before opening the external app and creating a draft message.

You can try the 'Send a SMS' link on http://thenewcode.com/856/Send-a-SMS-Text-From-A-Link since github won't linkify the sms://.