### PR TITLE
Make badge 10% alpha instead of 15%

### DIFF
--- a/Client/Frontend/Widgets/BadgeIcon.swift
+++ b/Client/Frontend/Widgets/BadgeIcon.swift
@@ -41,7 +41,7 @@ class BadgeWithBackdrop {
     let badge: ToolbarBadge
     let backdrop: UIView
     static let circleSize = CGFloat(40)
-    static let backdropAlpha = CGFloat(0.15)
+    static let backdropAlpha = CGFloat(0.10)
 
     static func makeCircle(color: UIColor?) -> UIView {
         let circle = UIView()


### PR DESCRIPTION
Based on UX feedback, this is a tad dark.
