### PR TITLE
Fix #4900 Rename new tabs to Home instead of Open new tab.

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -364,12 +364,12 @@ class Tab: NSObject {
         // When picking a display title. Tabs with sessionData are pending a restore so show their old title.
         // To prevent flickering of the display title. If a tab is restoring make sure to use its lastTitle.
         if let url = self.url, InternalURL(url)?.isAboutHomeURL ?? false, sessionData == nil, !restoring {
-            return Strings.OpenNewTabFromTabTrayKeyCodeTitle
+            return Strings.AppMenuOpenHomePageTitleString
         }
 
         //lets double check the sessionData in case this is a non-restored new tab
-        if let firstURL = sessionData?.urls.first, InternalURL(firstURL)?.isAboutHomeURL ?? false {
-            return Strings.OpenNewTabFromTabTrayKeyCodeTitle
+        if let firstURL = sessionData?.urls.first, sessionData?.urls.count == 1,  InternalURL(firstURL)?.isAboutHomeURL ?? false {
+            return Strings.AppMenuOpenHomePageTitleString
         }
 
         guard let lastTitle = lastTitle, !lastTitle.isEmpty else {


### PR DESCRIPTION
Also changed how we show the `Home` title. I noticed on pages not yet restored it was showing `New Tab` because the first URL in the session data stack was a home URL. I added a check to make sure to only show `Home` if the stack only contains 1 url (the internal home page URL)