### PR TITLE
Fix #4865 - Crash when removing several history entries quickly

### DIFF
--- a/Client/Frontend/Library/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel.swift
@@ -263,6 +263,10 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
         }
 
         profile.history.removeHistoryForURL(site.url).uponQueue(.main) { result in
+            guard site == self.siteForIndexPath(indexPath) else {
+                self.reloadData()
+                return
+            }
             self.tableView.beginUpdates()
             self.groupedSites.remove(site)
             self.tableView.deleteRows(at: [indexPath], with: .right)


### PR DESCRIPTION
If a history entry is deleted and then a second entry is deleted before the client has finished removing the first one, this can, depending on the entires removed, lead to a crash or other incorrect behavior.

To fix this issue, this PR adds a check between the entry being removed from storage and being removed from the UI. If the indexPath is no longer valid at this point, the fallback behavior is a reload of the view.