### PR TITLE
 Fix 4892 - Library button text: 28px more width 

### DIFF
--- a/Client/Frontend/Library/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController.swift
@@ -23,7 +23,7 @@ class LibraryViewController: UIViewController {
         stackView.axis = .horizontal
         stackView.alignment = .fill
         stackView.distribution = .fillEqually
-        stackView.spacing = 14
+        stackView.spacing = 0
         stackView.clipsToBounds = true
         stackView.accessibilityNavigationStyle = .combined
         stackView.accessibilityLabel = NSLocalizedString("Panel Chooser", comment: "Accessibility label for the Library panel's bottom toolbar containing a list of the home panels (top sites, bookmarks, history, remote tabs, reading list).")
@@ -232,7 +232,7 @@ class LibraryPanelButton: UIButton {
         }
         nameLabel.adjustsFontSizeToFitWidth = true
         nameLabel.minimumScaleFactor = 0.7
-        nameLabel.numberOfLines = 2
+        nameLabel.numberOfLines = 1
         nameLabel.font = DynamicFontHelper.defaultHelper.SmallSizeRegularWeightAS
         nameLabel.textAlignment = .center
     }


### PR DESCRIPTION
Also, the text now can shrink slightly because it is set to a 1-line label.