### PR TITLE
[nobug] Nit: badge icon should be set to not handle taps

### DIFF
--- a/Client/Frontend/Widgets/BadgeIcon.swift
+++ b/Client/Frontend/Widgets/BadgeIcon.swift
@@ -17,6 +17,8 @@ class ToolbarBadge: UIView {
 
         addSubview(background)
         addSubview(badge)
+
+        [background, badge].forEach { $0.isUserInteractionEnabled = false }
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -60,6 +62,7 @@ class BadgeWithBackdrop {
         backdrop = BadgeWithBackdrop.makeCircle(color: color)
         badge.isHidden = true
         backdrop.isHidden = true
+        backdrop.isUserInteractionEnabled = false
     }
 
     func add(toParent parent: UIView) {


### PR DESCRIPTION
In simulator I can click right on the badge and the button won't
activate. On an actual device I can't repro it. For correctness,
the badge should not accept taps.
Update to Xcode 10.2.1, Swift 4.2 (from 4.0).
