### PR TITLE
Fix #4927 - [XCUITests] History tests after ID removal

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_SmokeXCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_SmokeXCUITests.xcscheme
@@ -365,6 +365,9 @@
                   Identifier = "HistoryTests/testClearHistoryFromSettings()">
                </Test>
                <Test
+                  Identifier = "HistoryTests/testClearRecentHistory()">
+               </Test>
+               <Test
                   Identifier = "HistoryTests/testClearRecentlyClosedHistory()">
                </Test>
                <Test

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -499,7 +499,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     map.addScreenState(HistoryRecentlyClosed) { screenState in
         screenState.dismissOnUse = true
-        screenState.tap(app.buttons["goBackFromRecentlyClosedHistory"], to: LibraryPanel_History)
+        screenState.tap(app.buttons["History"].firstMatch, to: LibraryPanel_History)
     }
 
     map.addScreenState(HistoryPanelContextMenu) { screenState in


### PR DESCRIPTION
This PR is to fix the History tests due to the latest modifications around History and related panels.
Also using this PR to disable one test from the smoketest since it runs as part of the regular test suite
