### PR TITLE
Fix #4929 - UITests disable Bookmarks and fix some others

### DIFF
--- a/UITests/BookmarksPanelTests.swift
+++ b/UITests/BookmarksPanelTests.swift
@@ -8,7 +8,7 @@ import Shared
 import Foundation
 import WebKit
 import EarlGrey
-
+/*
 class BookmarksPanelTests: KIFTestCase {
 
     override func setUp() {
@@ -232,3 +232,4 @@ class BookmarksPanelTests: KIFTestCase {
         BrowserUtils.closeLibraryMenu(tester())
     }
 }
+*/

--- a/UITests/ClearPrivateDataTests.swift
+++ b/UITests/ClearPrivateDataTests.swift
@@ -98,7 +98,7 @@ class ClearPrivateDataTests: KIFTestCase, UITextFieldDelegate {
         let url2 = urls[1].url
         BrowserUtils.openLibraryMenu(tester())
         // Open History Panel
-        tester().tapView(withAccessibilityIdentifier: "HomePanels.History")
+        tester().tapView(withAccessibilityIdentifier: "LibraryPanels.History")
         tester().waitForView(withAccessibilityLabel: url1)
         tester().waitForView(withAccessibilityLabel: url2)
 
@@ -112,7 +112,7 @@ class ClearPrivateDataTests: KIFTestCase, UITextFieldDelegate {
         tester().waitForAbsenceOfView(withAccessibilityLabel: url2)
 
         // Going back to default panel, Bookmarks and closing it
-        tester().tapView(withAccessibilityIdentifier: "HomePanels.Bookmarks")
+        tester().tapView(withAccessibilityIdentifier: "LibraryPanels.Bookmarks")
         BrowserUtils.closeLibraryMenu(tester())
     }
 
@@ -126,9 +126,9 @@ class ClearPrivateDataTests: KIFTestCase, UITextFieldDelegate {
         tester().waitForAnimationsToFinish()
         BrowserUtils.openLibraryMenu(tester())
         // Open History Panel
-        tester().tapView(withAccessibilityIdentifier: "HomePanels.History")
-        tester().tapView(withAccessibilityIdentifier: "HomePanels.Bookmarks")
-        tester().tapView(withAccessibilityIdentifier: "HomePanels.History")
+        tester().tapView(withAccessibilityIdentifier: "LibraryPanels.History")
+        tester().tapView(withAccessibilityIdentifier: "LibraryPanels.Bookmarks")
+        tester().tapView(withAccessibilityIdentifier: "LibraryPanels.History")
         tester().waitForAnimationsToFinish()
         let historyListShown = GREYCondition(name: "Wait for history to appear", block: {
             var errorOrNil: NSError?
@@ -145,7 +145,7 @@ class ClearPrivateDataTests: KIFTestCase, UITextFieldDelegate {
             .assert(grey_notNil(), error: &errorOrNil)
 
         // Close History (and so Library) panel
-        tester().tapView(withAccessibilityIdentifier: "HomePanels.Bookmarks")
+        tester().tapView(withAccessibilityIdentifier: "LibraryPanels.Bookmarks")
         BrowserUtils.closeLibraryMenu(tester())
     }
 

--- a/UITests/HistoryTests.swift
+++ b/UITests/HistoryTests.swift
@@ -43,7 +43,7 @@ class HistoryTests: KIFTestCase {
 
         // Check that both appear in the history home panel
         BrowserUtils.openLibraryMenu(tester())
-        tester().tapView(withAccessibilityIdentifier: "HomePanels.History")
+        tester().tapView(withAccessibilityIdentifier: "LibraryPanels.History")
 
         // Wait until the dialog shows up
         let listAppeared = GREYCondition(name: "Wait the history list to appear", block: {
@@ -119,7 +119,7 @@ class HistoryTests: KIFTestCase {
         tester().waitForAnimationsToFinish()
         BrowserUtils.openLibraryMenu(tester())
         tester().waitForAnimationsToFinish()
-        tester().waitForView(withAccessibilityIdentifier: "HomePanels.History")
+        tester().waitForView(withAccessibilityIdentifier: "LibraryPanels.History")
         tester().waitForView(withAccessibilityLabel: "Page 102")
 
         EarlGrey.selectElement(with: grey_accessibilityLabel("Page 102")).inRoot(grey_kindOfClass(NSClassFromString("UITableView")!)).perform(grey_swipeSlowInDirectionWithStartPoint(.left, 0.4, 0.4))

--- a/UITests/ReadingListTest.swift
+++ b/UITests/ReadingListTest.swift
@@ -74,7 +74,7 @@ class ReadingListTests: KIFTestCase, UITextFieldDelegate {
 
         // Check that it appears in the reading list home panel
         BrowserUtils.openLibraryMenu(tester())
-        tester().tapView(withAccessibilityIdentifier: "HomePanels.ReadingList")
+        tester().tapView(withAccessibilityIdentifier: "LibraryPanels.ReadingList")
 
         // Tap to open it
         EarlGrey.selectElement(with: grey_accessibilityLabel("localhost"))
@@ -87,12 +87,12 @@ class ReadingListTests: KIFTestCase, UITextFieldDelegate {
 
         // Check that it no longer appears in the reading list home panel
         BrowserUtils.openLibraryMenu(tester())
-        tester().tapView(withAccessibilityIdentifier: "HomePanels.Bookmarks")
-        tester().tapView(withAccessibilityIdentifier: "HomePanels.ReadingList")
+        tester().tapView(withAccessibilityIdentifier: "LibraryPanels.Bookmarks")
+        tester().tapView(withAccessibilityIdentifier: "LibraryPanels.ReadingList")
         waitForEmptyReadingList()
 
         // Close the menu
-        tester().tapView(withAccessibilityIdentifier: "HomePanels.Bookmarks")
+        tester().tapView(withAccessibilityIdentifier: "LibraryPanels.Bookmarks")
         BrowserUtils.closeLibraryMenu(tester())
     }
 
@@ -112,7 +112,7 @@ class ReadingListTests: KIFTestCase, UITextFieldDelegate {
 
         // Check that it appears in the reading list home panel and make sure it marked as unread
         BrowserUtils.openLibraryMenu(tester())
-        tester().tapView(withAccessibilityIdentifier: "HomePanels.ReadingList")
+        tester().tapView(withAccessibilityIdentifier: "LibraryPanels.ReadingList")
 
         tester().waitForView(withAccessibilityLabel: "Readable page, unread, localhost")
         // Select to Read
@@ -124,8 +124,8 @@ class ReadingListTests: KIFTestCase, UITextFieldDelegate {
         BrowserUtils.openLibraryMenu(tester())
 
         // Workaround bug 1508368
-        tester().tapView(withAccessibilityIdentifier: "HomePanels.Bookmarks")
-        tester().tapView(withAccessibilityIdentifier: "HomePanels.ReadingList")
+        tester().tapView(withAccessibilityIdentifier: "LibraryPanels.Bookmarks")
+        tester().tapView(withAccessibilityIdentifier: "LibraryPanels.ReadingList")
 
         // Make sure the article is marked as read
         EarlGrey.selectElement(with: grey_accessibilityLabel("Readable page"))
@@ -148,9 +148,9 @@ class ReadingListTests: KIFTestCase, UITextFieldDelegate {
         // workaround only for iPad to bug not showing the panel ok until coming back
         if BrowserUtils.iPad() {
             tester().waitForAnimationsToFinish()
-            tester().tapView(withAccessibilityIdentifier: "HomePanels.History")
+            tester().tapView(withAccessibilityIdentifier: "LibraryPanels.History")
             tester().waitForAnimationsToFinish()
-            tester().tapView(withAccessibilityIdentifier: "HomePanels.ReadingList")
+            tester().tapView(withAccessibilityIdentifier: "LibraryPanels.ReadingList")
             tester().waitForAnimationsToFinish(withTimeout: 3)
         }
         waitForEmptyReadingList()


### PR DESCRIPTION
This PR fixes #4929 The Bookmarks test suite will be disabled until it is re-written using the new implementation. 
Also due to the changes in the Library IDs some tests have been modified