### PR TITLE
Fix #4939 - XCUITests rename new tab title as Home

### DIFF
--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -177,7 +177,7 @@ class ActivityStreamTest: BaseTestCase {
         XCTAssertFalse(app.staticTexts["apple"].exists)
 
         navigator.goto(TabTray)
-        app.collectionViews.cells["home"].tap()
+        app.collectionViews.cells["Home"].tap()
         waitForExistence(TopSiteCellgroup.cells["apple"])
         navigator.nowAt(HomePanelsScreen)
         navigator.goto(TabTray)

--- a/XCUITests/DragAndDropTests.swift
+++ b/XCUITests/DragAndDropTests.swift
@@ -7,7 +7,7 @@ import XCTest
 let firstWebsite = (url: path(forTestPage: "test-mozilla-org.html"), tabName: "Internet for people, not profit — Mozilla")
 let secondWebsite = (url: path(forTestPage: "test-mozilla-book.html"), tabName: "The Book of Mozilla")
 let exampleWebsite = (url: path(forTestPage: "test-example.html"), tabName: "Example Domain")
-let homeTabName = "home"
+let homeTabName = "Home"
 let websiteWithSearchField = (url: "https://developer.mozilla.org/en-US/search", urlSearchField: "Search the docs")
 
 let exampleDomainTitle = "Example Domain"
@@ -80,7 +80,7 @@ class DragAndDropTests: BaseTestCase {
         checkTabsOrder(dragAndDropTab: false, firstTab: homeTabName, secondTab: secondWebsite.tabName)
 
         // Drag and drop home tab from the first position to the second
-        dragAndDrop(dragElement: app.collectionViews.cells["home"], dropOnElement: app.collectionViews.cells[secondWebsite.tabName])
+        dragAndDrop(dragElement: app.collectionViews.cells["Home"], dropOnElement: app.collectionViews.cells[secondWebsite.tabName])
 
         checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName , secondTab: homeTabName)
     }
@@ -201,7 +201,7 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
         waitForExistence(app.collectionViews.cells.element(boundBy: 1))
 
         // Drag and drop home tab from the second position to the first one
-        dragAndDrop(dragElement: app.collectionViews.cells["home"], dropOnElement: app.collectionViews.cells[secondWebsite.tabName])
+        dragAndDrop(dragElement: app.collectionViews.cells["Home"], dropOnElement: app.collectionViews.cells[secondWebsite.tabName])
 
         checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName , secondTab: homeTabName)
         // Check that focus is kept on last website open

--- a/XCUITests/TopTabsTest.swift
+++ b/XCUITests/TopTabsTest.swift
@@ -199,7 +199,7 @@ class TopTabsTest: BaseTestCase {
             app.cells["quick_action_new_tab"].tap()
             waitForTabsButton()
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
-            app.collectionViews.cells["home"].firstMatch.tap()
+            app.collectionViews.cells["Home"].firstMatch.tap()
 
             // Close tab
             navigator.nowAt(HomePanelsScreen)
@@ -210,7 +210,7 @@ class TopTabsTest: BaseTestCase {
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
 
             // Go to Private Mode
-            app.collectionViews.cells["home"].firstMatch.tap()
+            app.collectionViews.cells["Home"].firstMatch.tap()
             navigator.nowAt(HomePanelsScreen)
             waitForExistence(app.buttons["Show Tabs"])
             app.buttons["Show Tabs"].press(forDuration: 1)
@@ -244,19 +244,19 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
-        closeTabTrayView(goBackToBrowserTab: "home")
+        closeTabTrayView(goBackToBrowserTab: "Home")
 
         navigator.performAction(Action.CloseTabFromTabTrayLongPressMenu)
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
-        closeTabTrayView(goBackToBrowserTab: "home")
+        closeTabTrayView(goBackToBrowserTab: "Home")
 
         navigator.performAction(Action.CloseTabFromTabTrayLongPressMenu)
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
-        closeTabTrayView(goBackToBrowserTab: "home")
+        closeTabTrayView(goBackToBrowserTab: "Home")
     }
 
     // This test only runs for iPhone see bug 1409750
@@ -351,7 +351,7 @@ class TopTabsTestIpad: IpadOnlyTestCase {
         let numTab = app.buttons["Show Tabs"].value as? String
         XCTAssertEqual("3", numTab)
         // Remove one tab by tapping on 'x' button
-        app.collectionViews["Top Tabs View"].children(matching: .cell).matching(identifier: "home").element(boundBy: 1).buttons["Remove page — Open New Tab"].tap()
+        app.collectionViews["Top Tabs View"].children(matching: .cell).matching(identifier: "Home").element(boundBy: 1).buttons["Remove page — Open New Tab"].tap()
         waitForExistence(app.buttons["Show Tabs"])
         let numTabAfterRemovingThirdTab = app.buttons["Show Tabs"].value as? String
         XCTAssertEqual("2", numTabAfterRemovingThirdTab)
@@ -392,7 +392,7 @@ class TopTabsTestIpad: IpadOnlyTestCase {
         app.collectionViews["Top Tabs View"].cells.element(boundBy: lastCell).swipeRight()
         app.collectionViews["Top Tabs View"].cells[urlLabel].buttons.element(boundBy: 0).tap()
         // Confirm the view did not scroll to the selected cell
-        XCTAssertEqual(app.collectionViews["Top Tabs View"].cells.element(boundBy: lastCell).label, "home")
+        XCTAssertEqual(app.collectionViews["Top Tabs View"].cells.element(boundBy: lastCell).label, "Home")
         // Confirm the url bar still has selected cell value
         waitForValueContains(app.textFields["url"], value: urlValueLongExample)
     }


### PR DESCRIPTION
This PR fixes #4939 When opening a new tab in the tab tray the title will be Home instead of Open New Tab or home