### PR TITLE
Fix #4949 - UITest history entry removal needs to be slower

### DIFF
--- a/UITests/HistoryTests.swift
+++ b/UITests/HistoryTests.swift
@@ -122,7 +122,7 @@ class HistoryTests: KIFTestCase {
         tester().waitForView(withAccessibilityIdentifier: "LibraryPanels.History")
         tester().waitForView(withAccessibilityLabel: "Page 102")
 
-        EarlGrey.selectElement(with: grey_accessibilityLabel("Page 102")).inRoot(grey_kindOfClass(NSClassFromString("UITableView")!)).perform(grey_swipeSlowInDirectionWithStartPoint(.left, 0.4, 0.4))
+        EarlGrey.selectElement(with: grey_accessibilityLabel("Page 102")).inRoot(grey_kindOfClass(NSClassFromString("UITableView")!)).perform(grey_swipeSlowInDirectionWithStartPoint(.left, 0.6, 0.6))
         if !BrowserUtils.iPad() {
             EarlGrey.selectElement(with:grey_accessibilityLabel("Delete"))
                 .inRoot(grey_kindOfClass(NSClassFromString("UISwipeActionStandardButton")!))

--- a/UITests/ReopenLastTabTests.swift
+++ b/UITests/ReopenLastTabTests.swift
@@ -33,16 +33,17 @@ class ReopenLastTabTests: KIFTestCase {
     
     
     func testReopenLastTab() {
-        openReadablePage()
-        tester().waitForWebViewElementWithAccessibilityLabel("Readable Page")
+        if !BrowserUtils.iPad() {
+            openReadablePage()
+            tester().waitForWebViewElementWithAccessibilityLabel("Readable Page")
         
-        openTabsController()
-        closeAllTabs()
-        EarlGrey.shakeDevice()
+            openTabsController()
+            closeAllTabs()
+            EarlGrey.shakeDevice()
         
-        reopenLastPage()
-        tester().waitForWebViewElementWithAccessibilityLabel("Readable Page")
-
+            reopenLastPage()
+            tester().waitForWebViewElementWithAccessibilityLabel("Readable Page")
+        }
     }
     
     func openReadablePage() {


### PR DESCRIPTION
This PR fixes #4949 The transition to remove an entry has to be slower and move the entry until the end otherwise it is not removed and so the test fails.
