### PR TITLE
TabEvent refactor (no need for TabObservers member, and unregister, etc.)

### DIFF
--- a/Client/DocumentServicesHelper.swift
+++ b/Client/DocumentServicesHelper.swift
@@ -45,8 +45,6 @@ struct DerivedMetadata: Codable {
 }
 
 class DocumentServicesHelper: TabEventHandler {
-    private var tabObservers: TabObservers!
-
     private lazy var singleThreadedQueue: OperationQueue = {
         var queue = OperationQueue()
         queue.name = "Document Services queue"
@@ -56,21 +54,19 @@ class DocumentServicesHelper: TabEventHandler {
     }()
 
     init() {
-        self.tabObservers = registerFor(.didLoadPageMetadata, queue: singleThreadedQueue)
-    }
-
-    deinit {
-        unregister(tabObservers)
+        register(self, forTabEvents: .didLoadPageMetadata)
     }
 
     func tab(_ tab: Tab, didLoadPageMetadata metadata: PageMetadata) {
-        // New analyzers go here. We map through each one and reduce into one dictionary
-        let analyzers = [LanguageDetector()]
-        let dict = analyzers.map({ [$0.name: $0.analyse(metadata: metadata)] }).compactMap({$0}).reduce([:]) { $0.merging($1) { (current, _) in current } }
+        singleThreadedQueue.addOperation {
+            // New analyzers go here. We map through each one and reduce into one dictionary
+            let analyzers = [LanguageDetector()]
+            let dict = analyzers.map({ [$0.name: $0.analyse(metadata: metadata)] }).compactMap({$0}).reduce([:]) { $0.merging($1) { (current, _) in current } }
 
-        guard let derivedMetadata = DerivedMetadata.from(dict: dict) else { return }
-        DispatchQueue.global().async {
-            TabEvent.post(.didDeriveMetadata(derivedMetadata), for: tab)
+            guard let derivedMetadata = DerivedMetadata.from(dict: dict) else { return }
+            DispatchQueue.main.async {
+                TabEvent.post(.didDeriveMetadata(derivedMetadata), for: tab)
+            }
         }
     }
 }

--- a/Client/Frontend/Browser/FaviconHandler.swift
+++ b/Client/Frontend/Browser/FaviconHandler.swift
@@ -10,15 +10,10 @@ import SDWebImage
 class FaviconHandler {
     static let MaximumFaviconSize = 1 * 1024 * 1024 // 1 MiB file size limit
 
-    private var tabObservers: TabObservers!
     private let backgroundQueue = OperationQueue()
 
     init() {
-        self.tabObservers = registerFor(.didLoadPageMetadata, queue: backgroundQueue)
-    }
-
-    deinit {
-        unregister(tabObservers)
+        register(self, forTabEvents: .didLoadPageMetadata)
     }
 
     func loadFaviconURL(_ faviconURL: String, forTab tab: Tab) -> Deferred<Maybe<(Favicon, Data?)>> {
@@ -104,7 +99,8 @@ extension FaviconHandler: TabEventHandler {
             return
         }
 
-        loadFaviconURL(faviconURL, forTab: tab) >>== { (favicon, data) in
+        loadFaviconURL(faviconURL, forTab: tab).uponQueue(.main) { result in
+            guard let (favicon, data) = result.successValue else { return }
             TabEvent.post(.didLoadFavicon(favicon, with: data), for: tab)
         }
     }

--- a/Client/Frontend/Browser/MetadataParserHelper.swift
+++ b/Client/Frontend/Browser/MetadataParserHelper.swift
@@ -12,16 +12,8 @@ import WebKit
 private let log = Logger.browserLogger
 
 class MetadataParserHelper: TabEventHandler {
-    private var tabObservers: TabObservers!
-
     init() {
-        self.tabObservers = registerFor(
-            .didChangeURL,
-            queue: .main)
-    }
-
-    deinit {
-        unregister(tabObservers)
+        register(self, forTabEvents: .didChangeURL)
     }
 
     func tab(_ tab: Tab, didChangeURL url: URL) {
@@ -58,18 +50,11 @@ class MetadataParserHelper: TabEventHandler {
 }
 
 class MediaImageLoader: TabEventHandler {
-    private var tabObservers: TabObservers!
     private let prefs: Prefs
 
     init(_ prefs: Prefs) {
         self.prefs = prefs
-        self.tabObservers = registerFor(
-            .didLoadPageMetadata,
-            queue: .main)
-    }
-
-    deinit {
-        unregister(tabObservers)
+        register(self, forTabEvents: .didLoadPageMetadata)
     }
 
     func tab(_ tab: Tab, didLoadPageMetadata metadata: PageMetadata) {

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -55,7 +55,6 @@ class TabDisplayManager: NSObject {
 
     fileprivate let tabManager: TabManager
     fileprivate let collectionView: UICollectionView
-    private var tabObservers: TabObservers!
     fileprivate weak var tabDisplayer: TabDisplayer?
     private let tabReuseIdentifer: String
 
@@ -110,7 +109,7 @@ class TabDisplayManager: NSObject {
         super.init()
 
         tabManager.addDelegate(self)
-        self.tabObservers = registerFor(.didLoadFavicon, .didChangeURL, queue: .main)
+        register(self, forTabEvents: .didLoadFavicon, .didChangeURL)
 
         tabsToDisplay.forEach {
             self.dataStore.insert($0)
@@ -204,12 +203,6 @@ class TabDisplayManager: NSObject {
             return
         }
         tabManager.removeTabAndUpdateSelectedIndex(tab)
-    }
-
-    // Once we are done with TabManager we need to call removeObservers to avoid a retain cycle with the observers
-    func removeObservers() {
-        unregister(tabObservers)
-        tabObservers = nil
     }
 
     private func recordEventAndBreadcrumb(object: UnifiedTelemetry.EventObject, method: UnifiedTelemetry.EventMethod) {

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -39,7 +39,6 @@ class TabLocationView: UIView {
     var longPressRecognizer: UILongPressGestureRecognizer!
     var tapRecognizer: UITapGestureRecognizer!
     private var contentView: UIStackView!
-    private var tabObservers: TabObservers!
 
     @objc dynamic var baseURLFontColor: UIColor = TabLocationViewUX.BaseURLFontColor {
         didSet { updateTextWithURL() }
@@ -59,10 +58,6 @@ class TabLocationView: UIView {
             }
             setNeedsUpdateConstraints()
         }
-    }
-
-    deinit {
-        unregister(tabObservers)
     }
 
     var readerModeState: ReaderModeState {
@@ -173,7 +168,7 @@ class TabLocationView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        self.tabObservers = registerFor(.didGainFocus, queue: .main)
+        register(self, forTabEvents: .didGainFocus)
 
         NotificationCenter.default.addObserver(self, selector: #selector(onDidChangeContentBlocking), name: .didChangeContentBlocking, object: nil)
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -134,7 +134,6 @@ class TabTrayController: UIViewController {
     deinit {
         tabManager.removeDelegate(self.tabDisplayManager)
         tabManager.removeDelegate(self)
-        tabDisplayManager.removeObservers()
         tabDisplayManager = nil
     }
 

--- a/Client/Frontend/Browser/TranslationToastHandler.swift
+++ b/Client/Frontend/Browser/TranslationToastHandler.swift
@@ -9,18 +9,13 @@ import XCGLogger
 private let log = Logger.browserLogger
 
 class TranslationToastHandler: TabEventHandler {
-    private var tabObservers: TabObservers!
     private let snackBarClassIdentifier = "translationPrompt"
 
     private let setting: TranslationServices
 
     init(_ prefs: Prefs) {
         self.setting = TranslationServices(prefs: prefs)
-        tabObservers = registerFor(.didDeriveMetadata, queue: .main)
-    }
-
-    deinit {
-        unregister(tabObservers)
+        register(self, forTabEvents: .didDeriveMetadata)
     }
 
     func tab(_ tab: Tab, didDeriveMetadata metadata: DerivedMetadata) {

--- a/Client/Helpers/TabEventHandler.swift
+++ b/Client/Helpers/TabEventHandler.swift
@@ -81,6 +81,7 @@ enum TabEventLabel: String {
     case didDeriveMetadata
 }
 
+// Names of events must be unique!
 enum TabEvent {
     case didChangeURL(URL)
     case didLoadPageMetadata(PageMetadata)

--- a/Client/Helpers/UserActivityHandler.swift
+++ b/Client/Helpers/UserActivityHandler.swift
@@ -14,21 +14,8 @@ private let browsingActivityType: String = "org.mozilla.ios.firefox.browsing"
 private let searchableIndex = CSSearchableIndex(name: "firefox")
 
 class UserActivityHandler {
-    private var tabObservers: TabObservers!
-
     init() {
-        self.tabObservers = registerFor(
-                                .didLoseFocus,
-                                .didGainFocus,
-                                .didChangeURL,
-                                .didLoadPageMetadata,
-                                // .didLoadFavicon, // TODO: Bug 1390294
-                                .didClose,
-                                queue: .main)
-    }
-
-    deinit {
-        unregister(tabObservers)
+        register(self, forTabEvents: .didClose, .didLoseFocus, .didGainFocus, .didChangeURL, .didLoadPageMetadata) // .didLoadFavicon, // TODO: Bug 1390294
     }
 
     class func clearSearchIndex(completionHandler: ((Error?) -> Void)? = nil) {

--- a/ClientTests/TabEventHandlerTests.swift
+++ b/ClientTests/TabEventHandlerTests.swift
@@ -22,34 +22,6 @@ class TabEventHandlerTests: XCTestCase {
         TabEvent.post(.didLoseFocus, for: tab)
         XCTAssertFalse(handler.isFocused!)
     }
-
-    func testUnregistration() {
-        let tab = Tab(configuration: WKWebViewConfiguration())
-        let handler = DummyHandler()
-
-        XCTAssertNil(handler.isFocused)
-
-        TabEvent.post(.didGainFocus, for: tab)
-        XCTAssertTrue(handler.isFocused!)
-
-        handler.doUnregister()
-        TabEvent.post(.didLoseFocus, for: tab)
-        // The event didn't reach us, so we should still be focused.
-        XCTAssertTrue(handler.isFocused!)
-    }
-
-//    func testOnlyRegisteredForEvents() {
-//        let tab = Tab(configuration: WKWebViewConfiguration())
-//        let handler = DummyHandler()
-//        handler.doUnregister()
-//        let tabObservers = handler.registerFor(tabEvent: .didGainFocus)
-//        XCTAssertNil(handler.isFocused)
-//        TabEvent.post(.didGainFocus, for: tab)
-//        XCTAssertTrue(handler.isFocused!)
-//        TabEvent.post(.didLoseFocus, for: tab)
-//        XCTAssertTrue(handler.isFocused!)
-//        handler.unregister(tabObservers)
-//    }
 }
 
 

--- a/ClientTests/TabEventHandlerTests.swift
+++ b/ClientTests/TabEventHandlerTests.swift
@@ -38,43 +38,28 @@ class TabEventHandlerTests: XCTestCase {
         XCTAssertTrue(handler.isFocused!)
     }
 
-    func testOnlyRegisteredForEvents() {
-        let tab = Tab(configuration: WKWebViewConfiguration())
-        let handler = DummyHandler()
-        handler.doUnregister()
-
-        let tabObservers = handler.registerFor(.didGainFocus)
-
-        XCTAssertNil(handler.isFocused)
-
-        TabEvent.post(.didGainFocus, for: tab)
-        XCTAssertTrue(handler.isFocused!)
-
-        TabEvent.post(.didLoseFocus, for: tab)
-        XCTAssertTrue(handler.isFocused!)
-
-        handler.unregister(tabObservers)
-    }
+//    func testOnlyRegisteredForEvents() {
+//        let tab = Tab(configuration: WKWebViewConfiguration())
+//        let handler = DummyHandler()
+//        handler.doUnregister()
+//        let tabObservers = handler.registerFor(tabEvent: .didGainFocus)
+//        XCTAssertNil(handler.isFocused)
+//        TabEvent.post(.didGainFocus, for: tab)
+//        XCTAssertTrue(handler.isFocused!)
+//        TabEvent.post(.didLoseFocus, for: tab)
+//        XCTAssertTrue(handler.isFocused!)
+//        handler.unregister(tabObservers)
+//    }
 }
 
 
 class DummyHandler: TabEventHandler {
-    var tabObservers: TabObservers!
-
     // This is not how this should be written in production — the handler shouldn't be keeping track
     // of individual tab state.
     var isFocused: Bool? = nil
 
     init() {
-        tabObservers = registerFor(.didGainFocus, .didLoseFocus)
-    }
-
-    deinit {
-        doUnregister()
-    }
-
-    fileprivate func doUnregister() {
-        unregister(tabObservers)
+         register(self, forTabEvents: .didGainFocus, .didLoseFocus)
     }
 
     func tabDidGainFocus(_ tab: Tab) {

--- a/UITests/TrackingProtectionTests.swift
+++ b/UITests/TrackingProtectionTests.swift
@@ -38,9 +38,7 @@ func checkIfImageLoaded(url: String, shouldBlockImage: Bool) {
 }
 
 class TrackingProtectionTests: KIFTestCase, TabEventHandler {
-
     private var webRoot: String!
-    private var tabObservers: TabObservers!
     var stats = TPPageStats()
     var statsIncrement: XCTestExpectation?
     var statsZero: XCTestExpectation?


### PR DESCRIPTION
Remove the need for clients of the TabEvent API to:
1) have a TabObservers member
2) have to unregister the TabObservers

We can use  objc associated objects to avoid requiring classes to unregister their notification observers. 

Additional cleanup:
- use enum stringification to create the TabEventLabel.
- remove off-main usage of posting notifications, these are main-thread only. If the receiver feels the need to then perform off-main work, they can do so, but this API should be main-thread only. I posit that a cross-thread messaging API is not needed at all, as messages can always be safely passed async on the main thread.


