### PR TITLE
 Bug #4710 - Desktop mode persists per-domain 

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -672,6 +672,7 @@
 		E6FF6ACA1D873CFF0070C294 /* PageMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FF6AC91D873CFF0070C294 /* PageMetadata.swift */; };
 		EB1C84BF212EFFBF001489DF /* BrowserViewController+ReaderMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1C84B6212EFFBF001489DF /* BrowserViewController+ReaderMode.swift */; };
 		EB3A38A02032673E004C6E67 /* DatabaseFixtureTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB3A38912032673D004C6E67 /* DatabaseFixtureTest.swift */; };
+		EB63CA51228F0539005FD0EF /* DesktopModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB63CA4F228F0538005FD0EF /* DesktopModeTests.swift */; };
 		EB6E0C60207E6C3100FBFF7E /* SendToDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB6E0C5F207E6C3000FBFF7E /* SendToDevice.swift */; };
 		EB7FFFC820A9D38D003E1E34 /* AlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB7FFFBF20A9D38C003E1E34 /* AlertController.swift */; };
 		EB8A0A77206ABCE000A9859A /* WebPagesForTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB7A651020699BD200B52A5F /* WebPagesForTesting.swift */; };
@@ -1783,6 +1784,7 @@
 		E6FF6AC91D873CFF0070C294 /* PageMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PageMetadata.swift; sourceTree = "<group>"; };
 		EB1C84B6212EFFBF001489DF /* BrowserViewController+ReaderMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BrowserViewController+ReaderMode.swift"; sourceTree = "<group>"; };
 		EB3A38912032673D004C6E67 /* DatabaseFixtureTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseFixtureTest.swift; sourceTree = "<group>"; };
+		EB63CA4F228F0538005FD0EF /* DesktopModeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DesktopModeTests.swift; sourceTree = "<group>"; };
 		EB6E0C5F207E6C3000FBFF7E /* SendToDevice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendToDevice.swift; sourceTree = "<group>"; };
 		EB7A651020699BD200B52A5F /* WebPagesForTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPagesForTesting.swift; sourceTree = "<group>"; };
 		EB7FFFBF20A9D38C003E1E34 /* AlertController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertController.swift; sourceTree = "<group>"; };
@@ -2508,6 +2510,7 @@
 				2CC1B3EF1E9B861400814EEC /* DomainAutocompleteTest.swift */,
 				2C473BCF209778900008C853 /* DownloadFilesTests.swift */,
 				2C4A07DB20246EAD0083E320 /* DragAndDropTests.swift */,
+				EB63CA4F228F0538005FD0EF /* DesktopModeTests.swift */,
 				2C8C07761E7800EA00DC1237 /* FindInPageTest.swift */,
 				2C4B6BF220349EB800A009C2 /* FirstRunTourTests.swift */,
 				39C261CB2018DE20009D97BD /* FxScreenGraphTests.swift */,
@@ -4801,6 +4804,7 @@
 				39CE74F621A823DD007AE4F2 /* TranslationSnackBarTest.swift in Sources */,
 				3BFE4B501D34673D00DDF53F /* ThirdPartySearchTest.swift in Sources */,
 				EB3A38A02032673E004C6E67 /* DatabaseFixtureTest.swift in Sources */,
+				EB63CA51228F0539005FD0EF /* DesktopModeTests.swift in Sources */,
 				2CF9D9AA20067FA10083DF2A /* BrowsingPDFTests.swift in Sources */,
 				0BC9C9C41F26F54D000E8AB5 /* SiteLoadTest.swift in Sources */,
 				2C4B6BF320349EB800A009C2 /* FirstRunTourTests.swift in Sources */,

--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
@@ -173,15 +173,6 @@
       language = "en"
       region = "US"
       shouldUseLaunchSchemeArgsEnv = "NO">
-      <PreActions>
-         <ExecutionAction
-            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
-            <ActionContent
-               title = "Run Script"
-               scriptText = "/usr/local/bin/carthage checkout">
-            </ActionContent>
-         </ExecutionAction>
-      </PreActions>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -85,6 +85,8 @@ class TestAppDelegate: AppDelegate {
             resetApplication()
         }
 
+        try? FileManager.default.removeItem(at: Tab.DesktopSites.file)
+
         return super.application(application, willFinishLaunchingWithOptions: launchOptions)
     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1139,9 +1139,6 @@ class BrowserViewController: UIViewController {
                 }
             }
         }
-
-        // Remember whether or not a desktop site was requested
-        tab.desktopSite = webView.customUserAgent?.isEmpty == false
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -270,8 +270,12 @@ extension BrowserViewController: WKNavigationDelegate {
 
         if ["http", "https", "data", "blob", "file"].contains(url.scheme) {
 
-            if navigationAction.targetFrame?.isMainFrame ?? navigationAction.sourceFrame.isMainFrame {
-                tab.desktopSite = Tab.DesktopSites.hostList.contains(url.host ?? "")
+            if let host = url.host, navigationAction.targetFrame?.isMainFrame ?? false {
+                tab.desktopSite = Tab.DesktopSites.hostList.contains(host)
+                if !tab.desktopSite, tab.isPrivate {
+                    // Private mode has an additional memory-only list to check.
+                    tab.desktopSite = Tab.DesktopSites.privateModeHostList.contains(host)
+                }
             }
 
             if navigationAction.navigationType == .linkActivated {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -269,6 +269,11 @@ extension BrowserViewController: WKNavigationDelegate {
         // always allow this. Additionally, data URIs are also handled just like normal web pages.
 
         if ["http", "https", "data", "blob", "file"].contains(url.scheme) {
+
+            if navigationAction.targetFrame?.isMainFrame ?? navigationAction.sourceFrame.isMainFrame {
+                tab.desktopSite = Tab.DesktopSites.hostList.contains(url.host ?? "")
+            }
+
             if navigationAction.navigationType == .linkActivated {
                 resetSpoofedUserAgentIfRequired(webView, newURL: url)
             } else if navigationAction.navigationType == .backForward {

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -148,6 +148,10 @@ class Tab: NSObject {
     var desktopSite: Bool = false {
         didSet {
             webView?.customUserAgent = desktopSite ? UserAgent.desktopUserAgent() : nil
+
+            if desktopSite != oldValue {
+                TabEvent.post(.didToggleDesktopMode, for: self)
+            }
         }
     }
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -714,14 +714,14 @@ extension Tab {
         static func updateHosts(forUrl url: URL, isDesktopSite: Bool, isPrivate: Bool) {
             guard let host = url.host, !host.isEmpty else { return }
 
-            guard !isPrivate else {
-                if isDesktopSite, !hostList.contains(host), !DesktopSites.privateModeHostList.contains(host) {
+            if isPrivate {
+                if isDesktopSite {
                     DesktopSites.privateModeHostList.insert(host)
-                } else if !isDesktopSite, (hostList.contains(host) || DesktopSites.privateModeHostList.contains(host)) {
+                    return
+                } else {
                     DesktopSites.privateModeHostList.remove(host)
-                    hostList.remove(host)
+                    // Continue to next section and try remove it from `hostList` also.
                 }
-                return
             }
 
             if isDesktopSite, !hostList.contains(host) {
@@ -729,9 +729,11 @@ extension Tab {
             } else if !isDesktopSite, hostList.contains(host) {
                 hostList.remove(host)
             } else {
+                // Don't save to disk, return early
                 return
             }
 
+            // At this point, saving to disk takes place.
             do {
                 let data = try NSKeyedArchiver.archivedData(withRootObject: hostList, requiringSecureCoding: false)
                 try data.write(to: DesktopSites.file)

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -224,6 +224,9 @@ class TabManager: NSObject {
     func willSwitchTabMode(leavingPBM: Bool) {
         recentlyClosedForUndo.removeAll()
 
+        // Clear every time entering/exiting this mode.
+        Tab.DesktopSites.privateModeHostList = Set<String>()
+
         if shouldClearPrivateTabs() && leavingPBM {
             removeAllPrivateTabs()
         }

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -40,6 +40,11 @@ class HistoryClearable: Clearable {
     }
 
     func clear() -> Success {
+
+        // Treat desktop sites as part of browsing history.
+        try? FileManager.default.removeItem(at: Tab.DesktopSites.file)
+        Tab.DesktopSites.hostList.removeAll()
+
         return profile.history.clearHistory().bindQueue(.main) { success in
             SDImageCache.shared().clearDisk()
             SDImageCache.shared().clearMemory()

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -152,7 +152,10 @@ extension PhotonActionSheetProtocol {
 
         let toggleActionTitle = tab.desktopSite ? Strings.AppMenuViewMobileSiteTitleString : Strings.AppMenuViewDesktopSiteTitleString
         let toggleDesktopSite = PhotonActionSheetItem(title: toggleActionTitle, iconString: "menu-RequestDesktopSite", isEnabled: tab.desktopSite, badgeIconNamed: "menuBadge") { action in
-            tab.toggleDesktopSite()
+            if let url = tab.url {
+                tab.toggleDesktopSite()
+                Tab.DesktopSites.updateHosts(forUrl: url, isDesktopSite: tab.desktopSite)
+            }
         }
 
         let addReadingList = PhotonActionSheetItem(title: Strings.AppMenuAddToReadingListTitleString, iconString: "addToReadingList") { action in

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -154,7 +154,7 @@ extension PhotonActionSheetProtocol {
         let toggleDesktopSite = PhotonActionSheetItem(title: toggleActionTitle, iconString: "menu-RequestDesktopSite", isEnabled: tab.desktopSite, badgeIconNamed: "menuBadge") { action in
             if let url = tab.url {
                 tab.toggleDesktopSite()
-                Tab.DesktopSites.updateHosts(forUrl: url, isDesktopSite: tab.desktopSite)
+                Tab.DesktopSites.updateHosts(forUrl: url, isDesktopSite: tab.desktopSite, isPrivate: tab.isPrivate)
             }
         }
 

--- a/XCUITests/DesktopModeTests.swift
+++ b/XCUITests/DesktopModeTests.swift
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import XCTest
+class DesktopModeTests: BaseTestCase {
+    func testSameHostInMultipleTabs() {
+        navigator.openURL(path(forTestPage: "test-user-agent.html"))
+        waitUntilPageLoad()
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
+        navigator.goto(PageOptionsMenu)
+        navigator.goto(RequestDesktopSite)
+        waitUntilPageLoad()
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "DESKTOP_UA").count > 0)
+
+        // Tab #2
+        navigator.nowAt(BrowserTab)
+        navigator.performAction(Action.OpenNewTabLongPressTabsButton)
+        navigator.openURL(path(forTestPage: "test-user-agent.html"))
+        waitUntilPageLoad()
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "DESKTOP_UA").count > 0)
+        navigator.goto(PageOptionsMenu)
+        navigator.goto(RequestDesktopSite)
+        waitUntilPageLoad()
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
+
+        // Tab #3
+        navigator.nowAt(BrowserTab)
+        navigator.performAction(Action.OpenNewTabLongPressTabsButton)
+        navigator.openURL(path(forTestPage: "test-user-agent.html"))
+        waitUntilPageLoad()
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
+    }
+
+    func testPrivateMode() {
+        navigator.openURL(path(forTestPage: "test-user-agent.html"))
+        waitUntilPageLoad()
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
+
+        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        navigator.openURL(path(forTestPage: "test-user-agent.html"))
+        navigator.goto(PageOptionsMenu)
+        navigator.goto(RequestDesktopSite)
+        waitUntilPageLoad()
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "DESKTOP_UA").count > 0)
+
+        navigator.nowAt(BrowserTab)
+        navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        navigator.openURL(path(forTestPage: "test-user-agent.html"))
+        waitUntilPageLoad()
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
+    }
+}

--- a/XCUITests/DesktopModeTests.swift
+++ b/XCUITests/DesktopModeTests.swift
@@ -4,6 +4,29 @@
 
 import XCTest
 class DesktopModeTests: BaseTestCase {
+
+    func testClearPrivateData() {
+        navigator.openURL(path(forTestPage: "test-user-agent.html"))
+        waitUntilPageLoad()
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
+        navigator.goto(PageOptionsMenu)
+        navigator.goto(RequestDesktopSite)
+        waitUntilPageLoad()
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "DESKTOP_UA").count > 0)
+
+        // Go to Clear Data
+        navigator.nowAt(BrowserTab)
+        navigator.performAction(Action.AcceptClearPrivateData)
+        navigator.goto(BrowserTab)
+        
+        // Tab #2
+        navigator.nowAt(BrowserTab)
+        navigator.performAction(Action.OpenNewTabLongPressTabsButton)
+        navigator.openURL(path(forTestPage: "test-user-agent.html"))
+        waitUntilPageLoad()
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
+    }
+
     func testSameHostInMultipleTabs() {
         navigator.openURL(path(forTestPage: "test-user-agent.html"))
         waitUntilPageLoad()
@@ -32,7 +55,35 @@ class DesktopModeTests: BaseTestCase {
         XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
     }
 
-    func testPrivateMode() {
+    func testPrivateModeOffAlsoRemovesFromNormalMode() {
+        navigator.openURL(path(forTestPage: "test-user-agent.html"))
+        waitUntilPageLoad()
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
+        navigator.goto(PageOptionsMenu)
+        navigator.goto(RequestDesktopSite) // toggle on
+        waitUntilPageLoad()
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "DESKTOP_UA").count > 0)
+
+        // is now on in normal mode
+
+        navigator.nowAt(BrowserTab)
+        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        navigator.openURL(path(forTestPage: "test-user-agent.html"))
+        navigator.goto(PageOptionsMenu)
+        navigator.goto(RequestDesktopSite) // toggle off
+        waitUntilPageLoad()
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
+
+        // is now off in private, mode, confirm it is off in normal mode
+
+        navigator.nowAt(BrowserTab)
+        navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        navigator.openURL(path(forTestPage: "test-user-agent.html"))
+        waitUntilPageLoad()
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
+    }
+
+    func testPrivateModeOnHasNoAffectOnNormalMode() {
         navigator.openURL(path(forTestPage: "test-user-agent.html"))
         waitUntilPageLoad()
         XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -55,6 +55,8 @@ let HomePanel_Library = "HomePanel_Library"
 let TranslatePageMenu = "TranslatePageMenu"
 let DontTranslatePageMenu = "DontTranslatePageMenu"
 let MobileBookmarks = "MobileBookmarks"
+let RequestDesktopSite = "RequestDesktopSite"
+let RequestMobileSite = "RequestMobileSite"
 
 // These are in the exact order they appear in the settings
 // screen. XCUIApplication loses them on small screens.
@@ -959,6 +961,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     // make sure after the menu action, navigator.nowAt() is used to set the current state
     map.addScreenState(PageOptionsMenu) {screenState in
+        screenState.tap(app.tables["Context Menu"].cells["menu-RequestDesktopSite"], to: RequestDesktopSite)
         screenState.tap(app.tables["Context Menu"].cells["menu-FindInPage"], to: FindInPage)
         screenState.tap(app.tables["Context Menu"].cells["menu-Bookmark"], forAction: Action.BookmarkThreeDots, Action.Bookmark)
         screenState.tap(app.tables.cells["action_pin"], forAction: Action.PinToTopSitesPAM)
@@ -974,6 +977,8 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     map.addScreenState(FindInPage) { screenState in
         screenState.tap(app.buttons["FindInPage.close"], to: BrowserTab)
     }
+
+    map.addScreenState(RequestDesktopSite) { _ in }
 
     map.addScreenState(HomePanel_Library) { screenState in
         screenState.dismissOnUse = true

--- a/XCUITests/WebPagesForTesting.swift
+++ b/XCUITests/WebPagesForTesting.swift
@@ -18,7 +18,7 @@ func registerHandlersForTestMethods(server: GCDWebServer) {
     }
 
     ["test-window-opener", "test-password", "test-password-submit", "test-password-2", "test-password-submit-2", "empty-login-form", "empty-login-form-submit", "test-example", "test-example-link", "test-mozilla-book", "test-mozilla-org",
-        "manifesto-en", "manifesto-es", "manifesto-zh-CN", "manifesto-ar"].forEach {
+        "manifesto-en", "manifesto-es", "manifesto-zh-CN", "manifesto-ar", "test-user-agent"].forEach {
         addHTMLFixture(name: $0, server: server)
     }
 }

--- a/test-fixtures/test-user-agent.html
+++ b/test-fixtures/test-user-agent.html
@@ -1,0 +1,21 @@
+<html>
+<head>
+<meta name="viewport" content="width=device-width">
+
+<script>
+    window.onload = () => {
+        let found = navigator.userAgent.indexOf("iPhone") > -1
+        if (found) {
+            document.body.innerHTML = "MOBILE_UA"
+        } else {
+            document.body.innerHTML = "DESKTOP_UA"
+        }
+    }
+</script>
+
+</head>
+<body aria-label="body">
+TEST PAGE
+</body>
+</html>
+


### PR DESCRIPTION
Todo: Tests for
- set desktop site, switch tab, ensure not set, switch back, ensure set
- navigate to another site, ensure it is off, then nav back, ensure it is on, nav again, ensure it is off
- enable private tab, set a site to desktop mode, exit private mode, verify site is not in desktop mode
- set a site to desktop mode, enable private tab, set that site to non-desktop mode, exit private mode and verify site is loaded as non-desktop

*** Note the last case reflects the way the code is currently, alternatively, that change could persist only for private browsing mode (I just thought that was a bit overkill in terms of app logic when the other way is simpler).