### PR TITLE
Moving Re-arrange tabs in Tabs Tray test to the smoke schema

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_SmokeXCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_SmokeXCUITests.xcscheme
@@ -317,7 +317,16 @@
                   Identifier = "DragAndDropTestIpad">
                </Test>
                <Test
-                  Identifier = "DragAndDropTests">
+                  Identifier = "DragAndDropTests/testDragAndDropHomeTabTabsTray()">
+               </Test>
+               <Test
+                  Identifier = "DragAndDropTests/testRearrangeMoreThan3TabsTabTray()">
+               </Test>
+               <Test
+                  Identifier = "DragAndDropTests/testRearrangeTabsPrivateModeTabTray()">
+               </Test>
+               <Test
+                  Identifier = "DragAndDropTests/testRearrangeTabsTabTrayLandscape()">
                </Test>
                <Test
                   Identifier = "FindInPageTests/testBarDissapearsWhenOpeningTabsTray()">

--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
@@ -236,6 +236,9 @@
                   Identifier = "DragAndDropTestIpad/testTryDragAndDropHistoryToURLBar()">
                </Test>
                <Test
+                  Identifier = "DragAndDropTests/testRearrangeTabsTabTray()">
+               </Test>
+               <Test
                   Identifier = "FindInPageTests/testFindFromMenu()">
                </Test>
                <Test

--- a/XCUITests/DragAndDropTests.swift
+++ b/XCUITests/DragAndDropTests.swift
@@ -21,7 +21,7 @@ class DragAndDropTests: BaseTestCase {
         super.tearDown()
     }
 
-    // Tests disabled because the feature is off for master and 14.x
+    // // Smoketest
     func testRearrangeTabsTabTray() {
         openTwoWebsites()
         navigator.goto(TabTray)


### PR DESCRIPTION
FIxed #4804  - XCUITests(smoketest): Re-arrange tabs in Tabs Tray

