### PR TITLE
Bug #5011 - Tab Tray inertia scroll w/ hiding find tabs bar

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -764,7 +764,9 @@ fileprivate class TabLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayou
 
             let offset = clamp(abs(scrollView.contentOffset.y), min: 0, max: TabTrayControllerUX.SearchBarHeight)
             searchHeightConstraint?.update(offset: offset)
-            scrollView.contentInset = UIEdgeInsets(top: offset, left: 0, bottom: 0, right: 0)
+            if scrollDirection == .down {
+                scrollView.contentInset = UIEdgeInsets(top: offset, left: 0, bottom: 0, right: 0)
+            }
         } else {
             self.hideSearch()
         }


### PR DESCRIPTION
The hiding of the tabs bar sets scrollView.contentInset, and setting
that breaks the inertial scroll (when finger lifted it stops immediately).
By setting this only on scrollDirection == .down, inertial scroll still
works when going up. It is still broken when scrolling down, the code as written
needs to set the contentInset in this case.
