### PR TITLE
Fix #5025 - XCUITests tests have to work with new Library panel

### DIFF
--- a/UITests/ClearPrivateDataTests.swift
+++ b/UITests/ClearPrivateDataTests.swift
@@ -87,7 +87,6 @@ class ClearPrivateDataTests: KIFTestCase, UITextFieldDelegate {
             XCTAssertNotNil(tester()
                 .waitForView(withAccessibilityLabel: clearable.rawValue, value: switchValue, traits: UIAccessibilityTraits.none))
         }
-
         BrowserUtils.closeClearPrivateDataDialog()
     }
 
@@ -103,16 +102,12 @@ class ClearPrivateDataTests: KIFTestCase, UITextFieldDelegate {
         tester().waitForView(withAccessibilityLabel: url2)
 
         BrowserUtils.closeLibraryMenu(tester())
-
         BrowserUtils.clearPrivateData([BrowserUtils.Clearable.History], swipe: false)
-
         BrowserUtils.openLibraryMenu(tester())
         // Open History Panel
         tester().waitForAbsenceOfView(withAccessibilityLabel: url1)
         tester().waitForAbsenceOfView(withAccessibilityLabel: url2)
 
-        // Going back to default panel, Bookmarks and closing it
-        tester().tapView(withAccessibilityIdentifier: "LibraryPanels.Bookmarks")
         BrowserUtils.closeLibraryMenu(tester())
     }
 
@@ -145,7 +140,6 @@ class ClearPrivateDataTests: KIFTestCase, UITextFieldDelegate {
             .assert(grey_notNil(), error: &errorOrNil)
 
         // Close History (and so Library) panel
-        tester().tapView(withAccessibilityIdentifier: "LibraryPanels.Bookmarks")
         BrowserUtils.closeLibraryMenu(tester())
     }
 

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -423,7 +423,13 @@ class BrowserUtils {
     }
 
     class func closeLibraryMenu(_ tester: KIFUITestActor) {
-        tester.tapView(withAccessibilityLabel: "Done")
+        if iPad() {
+            EarlGrey.selectElement(with: grey_accessibilityID("TabToolbar.libraryButton"))
+                .perform(grey_tap())
+        } else {
+            EarlGrey.selectElement(with: grey_accessibilityID("History"))
+                .perform(grey_swipeFastInDirection(GREYDirection.down))
+        }
         tester.waitForAnimationsToFinish()
     }
 }

--- a/UITests/ReadingListTest.swift
+++ b/UITests/ReadingListTest.swift
@@ -92,7 +92,7 @@ class ReadingListTests: KIFTestCase, UITextFieldDelegate {
         waitForEmptyReadingList()
 
         // Close the menu
-        tester().tapView(withAccessibilityIdentifier: "LibraryPanels.Bookmarks")
+        tester().tapView(withAccessibilityIdentifier: "LibraryPanels.History")
         BrowserUtils.closeLibraryMenu(tester())
     }
 
@@ -145,17 +145,10 @@ class ReadingListTests: KIFTestCase, UITextFieldDelegate {
             .perform(grey_tap())
 
         // check the entry no longer exist
-        // workaround only for iPad to bug not showing the panel ok until coming back
-        if BrowserUtils.iPad() {
-            tester().waitForAnimationsToFinish()
-            tester().tapView(withAccessibilityIdentifier: "LibraryPanels.History")
-            tester().waitForAnimationsToFinish()
-            tester().tapView(withAccessibilityIdentifier: "LibraryPanels.ReadingList")
-            tester().waitForAnimationsToFinish(withTimeout: 3)
-        }
         waitForEmptyReadingList()
 
         // Close Reading (and so Library) panel
+        tester().tapView(withAccessibilityIdentifier: "LibraryPanels.History")
         BrowserUtils.closeLibraryMenu(tester())
     }
 

--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -258,7 +258,9 @@ class ActivityStreamTest: BaseTestCase {
 
         // Check that longtapping on the TopSite gives the option to remove it
         navigator.performAction(Action.ExitMobileBookmarksFolder)
-        navigator.nowAt(HomePanelsScreen)
+        navigator.nowAt(LibraryPanel_Bookmarks)
+        navigator.performAction(Action.CloseBookmarkPanel)
+
         app.cells["TopSitesCell"].cells[defaultTopSite["topSiteLabel"]!]
             .press(forDuration: 2)
         XCTAssertTrue(app.tables["Context Menu"].cells["Remove Bookmark"].exists)
@@ -282,7 +284,8 @@ class ActivityStreamTest: BaseTestCase {
 
         // Check that longtapping on the TopSite gives the option to remove it
         navigator.performAction(Action.ExitMobileBookmarksFolder)
-        navigator.nowAt(HomePanelsScreen)
+        navigator.goto(HomePanelsScreen)
+        waitForExistence(TopSiteCellgroup.cells[newTopSite["topSiteLabel"]!])
         TopSiteCellgroup.cells[newTopSite["topSiteLabel"]!].press(forDuration: 1)
 
         // Unbookmark it

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -210,6 +210,7 @@ class Action {
     static let CloseBookmarkPanel = "CloseBookmarkPanel"
     static let CloseReadingListPanel = "CloseReadingListPanel"
     static let CloseHistoryListPanel = "CloseHistoryListPanel"
+    static let CloseDownloadsPanel = "CloseDownloadsPanel"
 }
 
 @objcMembers
@@ -530,7 +531,14 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     map.addScreenState(LibraryPanel_Downloads) { screenState in
         screenState.dismissOnUse = true
-        screenState.tap(app.buttons["Done"], to: HomePanelsScreen)
+        let downloadsElement = app.navigationBars["Downloads"]
+        screenState.gesture(forAction: Action.CloseDownloadsPanel, transitionTo: HomePanelsScreen) { userState in
+            if isTablet {
+                app.buttons["TabToolbar.libraryButton"].tap()
+            } else {
+                downloadsElement.press(forDuration: 2, thenDragTo: app.buttons["LibraryPanels.Downloads"])
+            }
+        }
     }
 
     map.addScreenState(HistoryRecentlyClosed) { screenState in

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -207,6 +207,9 @@ class Action {
     static let SelectBing = "SelectBing"
 
     static let ExitMobileBookmarksFolder = "ExitMobileBookmarksFolder"
+    static let CloseBookmarkPanel = "CloseBookmarkPanel"
+    static let CloseReadingListPanel = "CloseReadingListPanel"
+    static let CloseHistoryListPanel = "CloseHistoryListPanel"
 }
 
 @objcMembers
@@ -473,16 +476,22 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     map.addScreenState(LibraryPanel_Bookmarks) { screenState in
         let bookmarkCell = app.tables["Bookmarks List"].cells.element(boundBy: 0)
-        screenState.press(bookmarkCell, to: BookmarksPanelContextMenu)
+        let bookmarksElement = app.navigationBars["Bookmarks"].otherElements["Bookmarks"]
         screenState.tap(app.cells.staticTexts["Mobile Bookmarks"], to: MobileBookmarks)
-        screenState.tap(app.buttons["Done"], to: HomePanelsScreen)
+        screenState.gesture(forAction: Action.CloseBookmarkPanel, transitionTo: HomePanelsScreen) { userState in
+            if isTablet {
+                app.buttons["TabToolbar.libraryButton"].tap()
+            } else {
+                bookmarksElement.press(forDuration: 2, thenDragTo: app.buttons["LibraryPanels.Bookmarks"])
+            }
+        }
     }
 
     map.addScreenState(MobileBookmarks) { screenState in
-        let bookmarkCell = app.tables["Bookmarks List"].cells.element(boundBy: 0)
-        screenState.press(bookmarkCell, to: BookmarksPanelContextMenu)
-        screenState.gesture(forAction: Action.ExitMobileBookmarksFolder) { userState in
-            app.buttons["Done"].tap()
+        let bookmarksMenuNavigationBar = app.navigationBars["Mobile Bookmarks"]
+        let bookmarksButton = bookmarksMenuNavigationBar.buttons["Bookmarks"]
+        screenState.gesture(forAction: Action.ExitMobileBookmarksFolder, transitionTo: LibraryPanel_Bookmarks) { userState in
+                bookmarksButton.tap()
         }
     }
 
@@ -494,16 +503,29 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     map.addScreenState(LibraryPanel_History) { screenState in
         screenState.press(app.tables["History List"].cells.element(boundBy: 2), to: HistoryPanelContextMenu)
         screenState.tap(app.cells["HistoryPanel.recentlyClosedCell"], to: HistoryRecentlyClosed)
-        screenState.tap(app.buttons["Done"], to: HomePanelsScreen)
         screenState.gesture(forAction: Action.ClearRecentHistory) { userState in
             app.tables["History List"].cells.matching(identifier: "HistoryPanel.clearHistory").element(boundBy: 0).tap()
         }
-        screenState.backAction = navigationControllerBackAction
+        let historyListElement = app.navigationBars["History"]
+        screenState.gesture(forAction: Action.CloseHistoryListPanel, transitionTo: HomePanelsScreen) { userState in
+            if isTablet {
+                app.buttons["TabToolbar.libraryButton"].tap()
+            } else {
+                historyListElement.press(forDuration: 2, thenDragTo: app.buttons["LibraryPanels.History"])
+            }
+        }
     }
 
     map.addScreenState(LibraryPanel_ReadingList) { screenState in
         screenState.dismissOnUse = true
-        screenState.tap(app.buttons["Done"], to: HomePanelsScreen)
+        let readingListElement = app.navigationBars["Reading list"]
+        screenState.gesture(forAction: Action.CloseReadingListPanel, transitionTo: HomePanelsScreen) { userState in
+            if isTablet {
+                app.buttons["TabToolbar.libraryButton"].tap()
+            } else {
+                readingListElement.press(forDuration: 2, thenDragTo: app.buttons["LibraryPanels.ReadingList"])
+            }
+        }
     }
 
     map.addScreenState(LibraryPanel_Downloads) { screenState in
@@ -518,15 +540,9 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     map.addScreenState(HistoryPanelContextMenu) { screenState in
         screenState.dismissOnUse = true
-        screenState.tap(app.buttons["Done"], to: HomePanelsScreen)
     }
 
     map.addScreenState(TopSitesPanelContextMenu) { screenState in
-        screenState.dismissOnUse = true
-        screenState.backAction = dismissContextMenuAction
-    }
-
-    map.addScreenState(BookmarksPanelContextMenu) { screenState in
         screenState.dismissOnUse = true
         screenState.backAction = dismissContextMenuAction
     }

--- a/XCUITests/ReaderViewUITest.swift
+++ b/XCUITests/ReaderViewUITest.swift
@@ -45,8 +45,6 @@ class ReaderViewTest: BaseTestCase {
 
         // Check to make sure the reading list is empty
         checkReadingListNumberOfItems(items: 0)
-        app.buttons["Done"].tap()
-        navigator.nowAt(HomePanelsScreen)
         
         // Add item to reading list and check that it appears
         addContentToReaderView()


### PR DESCRIPTION
This PR fixes #5025. 
There is a new way to go back from each Library panel to HomeScreen. Tests have been modified. 

There are still some tests failing due to bugs affecting this new panel (#5026, #5027) but once they are solved, all tests should work again
