### PR TITLE
Fix #5026 - [Regression] Unable to remove a downloaded item, swipe gesture does not work

### DIFF
--- a/Client/Frontend/Widgets/DrawerViewController.swift
+++ b/Client/Frontend/Widgets/DrawerViewController.swift
@@ -269,8 +269,7 @@ public class DrawerViewController: UIViewController {
 extension DrawerViewController: UIGestureRecognizerDelegate {
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         let description = otherGestureRecognizer.description
-        return description.starts(with: "<_UISwipeActionPanGestureRecognizer:") ||
-            !description.starts(with: "<UIScrollViewPanGestureRecognizer:")
+        return !description.starts(with: "<UIScrollViewPanGestureRecognizer:")
     }
 
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {

--- a/Client/Frontend/Widgets/DrawerViewController.swift
+++ b/Client/Frontend/Widgets/DrawerViewController.swift
@@ -111,6 +111,7 @@ public class DrawerViewController: UIViewController {
         view.addSubview(drawerView)
 
         let panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(didRecognizePanGesture))
+        panGestureRecognizer.delegate = self
         drawerView.addGestureRecognizer(panGestureRecognizer)
 
         handleView.backgroundColor = .black
@@ -262,5 +263,19 @@ public class DrawerViewController: UIViewController {
             self.view.removeFromSuperview()
             self.removeFromParent()
         }
+    }
+}
+
+extension DrawerViewController: UIGestureRecognizerDelegate {
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        let description = otherGestureRecognizer.description
+        return description.starts(with: "<_UISwipeActionPanGestureRecognizer:") ||
+            !description.starts(with: "<UIScrollViewPanGestureRecognizer:")
+    }
+
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        let description = otherGestureRecognizer.description
+        return !description.starts(with: "<_UISwipeActionPanGestureRecognizer:") &&
+            !description.starts(with: "<UIScrollViewPanGestureRecognizer:")
     }
 }


### PR DESCRIPTION
This PR fixes the recognition/cancellation of the various pan/swipe gesture recognizers we encounter with table views inside the drawer view.