### PR TITLE
Fix #5047 - XCUITests goBack button changed to urlBar-cancel

### DIFF
--- a/XCUITests/NavigationTest.swift
+++ b/XCUITests/NavigationTest.swift
@@ -24,7 +24,7 @@ class NavigationTest: BaseTestCase {
         // Check the url placeholder text and that the back and forward buttons are disabled
         XCTAssert(urlPlaceholder == defaultValuePlaceholder)
         if iPad() {
-            app.buttons["goBack"].tap()
+            app.buttons["urlBar-cancel"].tap()
             XCTAssertFalse(app.buttons["URLBarView.backButton"].isEnabled)
             XCTAssertFalse(app.buttons["Forward"].isEnabled)
             app.textFields["url"].tap()

--- a/XCUITests/ScreenGraphTest.swift
+++ b/XCUITests/ScreenGraphTest.swift
@@ -35,7 +35,6 @@ extension ScreenGraphTest {
         // The UserState is mutated in BrowserTab.
         navigator.goto(BrowserTab)
         navigator.nowAt(BrowserTab)
-        wait(forElement: app.webViews.links["Mozilla"], timeout: 5)
         XCTAssertTrue(navigator.userState.url?.starts(with: "www.mozilla.org") ?? false, "Current url recorded by from the url bar is \(navigator.userState.url ?? "nil")")
     }
 

--- a/XCUITests/SearchTest.swift
+++ b/XCUITests/SearchTest.swift
@@ -38,7 +38,7 @@ class SearchTests: BaseTestCase {
         waitForExistence(app.tables["SiteTable"].buttons[SuggestedSite])
 
         // Disable Search suggestion
-        app.buttons["goBack"].tap()
+        app.buttons["urlBar-cancel"].tap()
         navigator.nowAt(HomePanelsScreen)
         suggestionsOnOff()
 
@@ -50,12 +50,12 @@ class SearchTests: BaseTestCase {
         waitForNoExistence(app.tables["SiteTable"].buttons[SuggestedSite])
 
         // Verify that previous choice is remembered
-        app.buttons["goBack"].tap()
+        app.buttons["urlBar-cancel"].tap()
         navigator.nowAt(HomePanelsScreen)
         navigator.goto(URLBarOpen)
         typeOnSearchBar(text: "foobar")
         waitForNoExistence(app.tables["SiteTable"].buttons[SuggestedSite])
-        app.buttons["goBack"].tap()
+        app.buttons["urlBar-cancel"].tap()
         navigator.nowAt(HomePanelsScreen)
 
         // Reset suggestion button, set it to on
@@ -122,8 +122,9 @@ class SearchTests: BaseTestCase {
         app.textFields["address"].press(forDuration: 5)
         app.menuItems["Select All"].tap()
         app.menuItems["Copy"].tap()
-        waitForExistence(app.buttons["goBack"])
-        app.buttons["goBack"].tap()
+        waitForExistence(app.buttons["urlBar-cancel"])
+        app.buttons["urlBar-cancel"].tap()
+
         navigator.nowAt(HomePanelsScreen)
         navigator.goto(URLBarOpen)
         app.textFields["address"].tap()


### PR DESCRIPTION
PR to update goBack button and fix affected tests.
Also fixing an intermittent in the Screengraph test suite