### PR TITLE
Bug #4993 - VoiceOver focus not correctly set to url bar (on history push)

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1113,7 +1113,7 @@ class BrowserViewController: UIViewController {
             return
         }
 
-        if let url = webView.url {
+        if tab !== tabManager.selectedTab, let url = webView.url {
             if (!InternalURL.isValid(url: url) || url.isReaderModeURL), !url.isFileURL {
                 postLocationChangeNotificationForTab(tab, navigation: navigation)
 
@@ -1130,14 +1130,7 @@ class BrowserViewController: UIViewController {
             TabEvent.post(.didChangeURL(url), for: tab)
         }
 
-        if tab === tabManager.selectedTab {
-            UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: nil)
-            // must be followed by LayoutChanged, as ScreenChanged will make VoiceOver
-            // cursor land on the correct initial element, but if not followed by LayoutChanged,
-            // VoiceOver will sometimes be stuck on the element, not allowing user to move
-            // forward/backward. Strange, but LayoutChanged fixes that.
-            UIAccessibility.post(notification: UIAccessibility.Notification.layoutChanged, argument: nil)
-        } else if let webView = tab.webView {
+        if let webView = tab.webView {
             // To Screenshot a tab that is hidden we must add the webView,
             // then wait enough time for the webview to render.
             view.insertSubview(webView, at: 0)


### PR DESCRIPTION
Not only is the focus moving on history push, all types of page changes
focus the lock icon, NOT the url as it should. This fixes the focus to
go correctly to the URL.
