### PR TITLE
Revert "[nobug] dataTask missing a resume"

### DIFF
--- a/Storage/SQL/SQLiteHistoryFavicons.swift
+++ b/Storage/SQL/SQLiteHistoryFavicons.swift
@@ -263,7 +263,7 @@ extension SQLiteHistory: Favicons {
             }
 
             deferred.fill(Maybe(success: faviconURL))
-        }.resume()
+        }
 
         return deferred
     }


### PR DESCRIPTION
Reverts mozilla-mobile/firefox-ios#5059 because of a typo