### PR TITLE
Fix #4971 - Firefox will crash when trying to re-arrange an unloaded tab

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -379,7 +379,16 @@ extension TabDisplayManager: TabEventHandler {
                 }
             }
 
-            self?.collectionView.reloadItems(at: items)
+            for item in items {
+                if let cell = self?.collectionView.cellForItem(at: item), let tab = self?.dataStore.at(item.row) {
+                    let isSelected = (item.row == index && tab == self?.tabManager.selectedTab)
+                    if let tabCell = cell as? TabCell {
+                        tabCell.configureWith(tab: tab, is: isSelected)
+                    } else if let tabCell = cell as? TopTabCell {
+                        tabCell.configureWith(tab: tab, isSelected: isSelected)
+                    }
+                }
+            }
         }
     }
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -1160,6 +1160,10 @@ class TabCell: UICollectionViewCell {
         }
         if selected {
             setTabSelected(tab.isPrivate)
+        } else {
+            layer.shadowOffset = .zero
+            layer.shadowPath = nil
+            layer.shadowOpacity = 0
         }
         screenshotView.image = tab.screenshot
     }

--- a/Client/Frontend/Browser/TopTabsViews.swift
+++ b/Client/Frontend/Browser/TopTabsViews.swift
@@ -75,6 +75,8 @@ class TopTabCell: UICollectionViewCell, PrivateModeUI {
             closeButton.layer.shadowColor = backgroundColor?.cgColor
             if selectedTab {
                 drawShadow()
+            } else {
+                self.layer.shadowOpacity = 0
             }
         }
     }


### PR DESCRIPTION
This PR fixes #4971. When data is received a reload is called on the relevant cell, which replaces it with an updated one. When this happens while a drag is in progress, it can cause a crash.

This fixes the issue by updating the existing cell rather than reloading it.