### PR TITLE
Fixes #5071 - Location text in URL bar not getting selected on focus

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -453,6 +453,9 @@ class URLBarView: UIView {
             self.setLocation(locationText, search: search)
             DispatchQueue.main.async {
                 self.locationTextField?.becomeFirstResponder()
+                // Need to set location again so text could be immediately selected.
+                self.setLocation(locationText, search: search)
+                self.locationTextField?.selectAll(nil)
             }
         }
     }


### PR DESCRIPTION
This PR fixes #5071 where the URL bar not getting properly "text-selected" on focus, which makes standard keyboard shortcuts such as Cmd+C or Cmd+X not usable until the location bar is re-focused. This fix leaves the original `setLocation` as-is, since removing it would make overlay transition becomes jerky.