### PR TITLE
Fix #5099 - "Add bookmarks" do not work if they are not added with full "https://" or "http://" URL

### DIFF
--- a/Client/Frontend/Library/BookmarkDetailPanel.swift
+++ b/Client/Frontend/Library/BookmarkDetailPanel.swift
@@ -121,6 +121,12 @@ class BookmarkDetailPanel: SiteTableViewController {
                 self.navigationController?.popViewController(animated: true)
             }
         }
+
+        if isNew, bookmarkNodeType == .bookmark {
+            bookmarkItemURL = "https://"
+        }
+
+        updateSaveButton()
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -178,6 +184,15 @@ class BookmarkDetailPanel: SiteTableViewController {
             self.bookmarkFolders = bookmarkFolders
             self.tableView.reloadData()
         }
+    }
+
+    func updateSaveButton() {
+        guard bookmarkNodeType == .bookmark else {
+            return
+        }
+        
+        let url = URL(string: bookmarkItemURL ?? "")
+        navigationItem.rightBarButtonItem?.isEnabled = url?.schemeIsValid == true && url?.host != nil
     }
 
     func save() -> Success {
@@ -344,6 +359,7 @@ extension BookmarkDetailPanel: TextFieldTableViewCellDelegate {
             bookmarkItemOrFolderTitle = text
         case BookmarkDetailFieldsRow.url.rawValue:
             bookmarkItemURL = text
+            updateSaveButton()
         default:
             log.warning("Received didChangeText: for a cell with an IndexPath that should not exist.")
         }


### PR DESCRIPTION
This PR modifies BookmarksDetailPanel to use URIFixup to validate and potentially modify the url the user is entering.

Validation is performed on load and every time the user changes the text in the url field. If it fails, the "Save" button is disabled. If it succeeds, the "Save" button is enabled.

When the user taps "Save", the fixed-up version of the entered URL is used to create/modify the bookmark.

This fixes the issue in #5099 as URIFixup will add the protocol if the user omits it.