### PR TITLE
Fix #5105 - XCUITests fail after URL Bar changes

### DIFF
--- a/UITests/DomainAutocompleteTests.swift
+++ b/UITests/DomainAutocompleteTests.swift
@@ -67,7 +67,7 @@ class DomainAutocompleteTests: KIFTestCase {
         tester().waitForAnimationsToFinish()
         let textField2 = tester().waitForView(withAccessibilityLabel: "Address and Search") as! UITextField
         // Facebook word appears highlighted and so it is shown as facebook\u{7F} when extracting the value to compare
-        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField2 , prefix: "", completion: "facebook\u{7F}")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField2 , prefix: "facebook\u{7F}", completion: "")
     }
 
     // Bug https://bugzilla.mozilla.org/show_bug.cgi?id=1541832 scenario 1

--- a/XCUITests/ClipBoardTests.swift
+++ b/XCUITests/ClipBoardTests.swift
@@ -17,8 +17,6 @@ class ClipBoardTests: BaseTestCase {
     func copyUrl() {
         navigator.goto(URLBarOpen)
         app.textFields["address"].press(forDuration: 3)
-        waitForExistence(app.menuItems["Select All"])
-        app.menuItems["Select All"].tap()
         waitForExistence(app.menuItems["Copy"])
         app.menuItems["Copy"].tap()
         app.typeText("\r")

--- a/XCUITests/NavigationTest.swift
+++ b/XCUITests/NavigationTest.swift
@@ -352,6 +352,10 @@ class NavigationTest: BaseTestCase {
         app.textFields["url"].press(forDuration:3)
         app.tables.cells["menu-Copy-Link"].tap()
         app.textFields["url"].tap()
+        // Since the textField value appears all selected first time is clicked
+        // this workaround is necessary
+        app.textFields["address"].tap()
+        app.textFields["address"].tap()
         app.textFields["address"].press(forDuration: 2)
 
         //Ensure that long press on address bar brings up a menu with Select All, Select, Paste, and Paste & Go


### PR DESCRIPTION
This PR fixes #5105 and so the tests specified there that now are failing due to changes in the URL Bar, no first time accessing it from website, it is focused.
