### PR TITLE
Fix #5072 - Startup icon in splash screen gets cropped

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -132,6 +132,10 @@ class BrowserViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override var prefersStatusBarHidden: Bool {
+        return false
+    }
+
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         if UIDevice.current.userInterfaceIdiom == .phone {
             return .allButUpsideDown

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -185,5 +185,7 @@
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
 	<true/>
+	<key>UIStatusBarHidden</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
This PR fixes #5072, solving an issue of the startup icon in splash screen getting cropped because of the in status bar.