### PR TITLE
Fix #5107 - long press on refresh button to load desktop site

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -426,7 +426,11 @@ extension PhotonActionSheetProtocol {
 
         let toggleActionTitle = tab.desktopSite ? Strings.AppMenuViewMobileSiteTitleString : Strings.AppMenuViewDesktopSiteTitleString
         let toggleDesktopSite = PhotonActionSheetItem(title: toggleActionTitle, iconString: "menu-RequestDesktopSite") { action in
-            tab.toggleDesktopSite()
+
+            if let url = tab.url {
+                tab.toggleDesktopSite()
+                Tab.DesktopSites.updateHosts(forUrl: url, isDesktopSite: tab.desktopSite, isPrivate: tab.isPrivate)
+            }
         }
 
         if let helper = tab.contentBlocker {

--- a/XCUITests/DesktopModeTests.swift
+++ b/XCUITests/DesktopModeTests.swift
@@ -4,6 +4,22 @@
 
 import XCTest
 class DesktopModeTests: IphoneOnlyTestCase {
+    func testLongPressReload() {
+        navigator.openURL(path(forTestPage: "test-user-agent.html"))
+        waitUntilPageLoad()
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
+
+        navigator.goto(ReloadLongPressMenu)
+        navigator.performAction(Action.ToggleRequestDesktopSite)
+        waitUntilPageLoad()
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "DESKTOP_UA").count > 0)
+
+        navigator.performAction(Action.CloseTabFromTabTrayLongPressMenu)
+
+        navigator.openURL(path(forTestPage: "test-user-agent.html"))
+        waitUntilPageLoad()
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "DESKTOP_UA").count > 0)
+    }
 
     func testClearPrivateData() {
         if skipPlatform { return }


### PR DESCRIPTION
I forgot to hook this up when landing desktop site changes.