### PR TITLE
Fix #5112 - New separator should always be inserted in current scroll position

### DIFF
--- a/Client/Frontend/Library/BookmarkDetailPanel.swift
+++ b/Client/Frontend/Library/BookmarkDetailPanel.swift
@@ -41,6 +41,14 @@ class BookmarkDetailPanel: SiteTableViewController {
     // Editable field(s) that all BookmarkNodes have.
     var parentBookmarkFolder: BookmarkFolder
 
+    // Sort position for the BookmarkItem. If editing, this
+    // value remains the same as it was prior to the edit
+    // unless the parent folder gets changed. In that case,
+    // and in the case of adding a new BookmarkItem, this
+    // value becomes `nil` which causes it to be re-positioned
+    // to the bottom of the parent folder upon saving.
+    var bookmarkItemPosition: UInt32?
+
     // Editable field(s) that only BookmarkItems and
     // BookmarkFolders have.
     var bookmarkItemOrFolderTitle: String?
@@ -64,6 +72,8 @@ class BookmarkDetailPanel: SiteTableViewController {
 
     convenience init(profile: Profile, bookmarkNode: BookmarkNode, parentBookmarkFolder: BookmarkFolder) {
         self.init(profile: profile, bookmarkNodeGUID: bookmarkNode.guid, bookmarkNodeType: bookmarkNode.type, parentBookmarkFolder: parentBookmarkFolder)
+
+        self.bookmarkItemPosition = bookmarkNode.position
 
         if let bookmarkItem = bookmarkNode as? BookmarkItem {
             self.bookmarkItemOrFolderTitle = bookmarkItem.title
@@ -119,6 +129,10 @@ class BookmarkDetailPanel: SiteTableViewController {
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .save) { _ in
             self.save().uponQueue(.main) { _ in
                 self.navigationController?.popViewController(animated: true)
+
+                if self.isNew, let bookmarksPanel = self.navigationController?.visibleViewController as? BookmarksPanel {
+                    bookmarksPanel.didAddBookmarkNode()
+                }
             }
         }
     }
@@ -205,9 +219,9 @@ class BookmarkDetailPanel: SiteTableViewController {
             }
 
             if bookmarkNodeType == .bookmark {
-                return profile.places.updateBookmarkNode(guid: bookmarkNodeGUID, parentGUID: parentBookmarkFolder.guid, title: bookmarkItemOrFolderTitle, url: bookmarkItemURL)
+                return profile.places.updateBookmarkNode(guid: bookmarkNodeGUID, parentGUID: parentBookmarkFolder.guid, position: bookmarkItemPosition, title: bookmarkItemOrFolderTitle, url: bookmarkItemURL)
             } else if bookmarkNodeType == .folder {
-                return profile.places.updateBookmarkNode(guid: bookmarkNodeGUID, parentGUID: parentBookmarkFolder.guid, title: bookmarkItemOrFolderTitle)
+                return profile.places.updateBookmarkNode(guid: bookmarkNodeGUID, parentGUID: parentBookmarkFolder.guid, position: bookmarkItemPosition, title: bookmarkItemOrFolderTitle)
             }
         }
 
@@ -223,8 +237,9 @@ class BookmarkDetailPanel: SiteTableViewController {
             return
         }
 
-        if isFolderListExpanded, let item = bookmarkFolders[safe: indexPath.row] {
+        if isFolderListExpanded, let item = bookmarkFolders[safe: indexPath.row], parentBookmarkFolder.guid != item.folder.guid {
             parentBookmarkFolder = item.folder
+            bookmarkItemPosition = nil
         }
 
         isFolderListExpanded = !isFolderListExpanded
@@ -262,6 +277,19 @@ class BookmarkDetailPanel: SiteTableViewController {
         guard indexPath.section == BookmarkDetailSection.fields.rawValue else {
             guard let cell = tableView.dequeueReusableCell(withIdentifier: BookmarkDetailFolderCellIdentifier, for: indexPath) as? OneLineTableViewCell else {
                 return super.tableView(tableView, cellForRowAt: indexPath)
+            }
+
+            // Disable folder selection when creating a new bookmark or folder.
+            if isNew {
+                cell.textLabel?.alpha = 0.5
+                cell.imageView?.alpha = 0.5
+                cell.selectionStyle = .none
+                cell.isUserInteractionEnabled = false
+            } else {
+                cell.textLabel?.alpha = 1.0
+                cell.imageView?.alpha = 1.0
+                cell.selectionStyle = .default
+                cell.isUserInteractionEnabled = true
             }
 
             cell.imageView?.image = UIImage(named: "bookmarkFolder")?.createScaled(BookmarkDetailPanelUX.FolderIconSize)

--- a/Client/Frontend/Library/BookmarksPanel.swift
+++ b/Client/Frontend/Library/BookmarksPanel.swift
@@ -14,6 +14,7 @@ private let BookmarkSeparatorCellIdentifier = "BookmarkSeparatorCellIdentifier"
 
 private struct BookmarksPanelUX {
     static let FolderIconSize = CGSize(width: 20, height: 20)
+    static let RowFlashDelayInMilliseconds = 400
 }
 
 let LocalizedRootBookmarkFolderStrings = [
@@ -32,6 +33,11 @@ fileprivate class SeparatorTableViewCell: OneLineTableViewCell {
 }
 
 class BookmarksPanel: SiteTableViewController, LibraryPanel {
+    enum BookmarksSection: Int, CaseIterable {
+        case bookmarks
+        case recent
+    }
+
     var libraryPanelDelegate: LibraryPanelDelegate?
 
     lazy var longPressRecognizer: UILongPressGestureRecognizer = {
@@ -47,6 +53,8 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
     var bookmarkFolder: BookmarkFolder?
     var bookmarkNodes = [BookmarkNode]()
     var recentBookmarks = [BookmarkNode]()
+
+    fileprivate var flashLastRowOnNextReload = false
 
     init(profile: Profile, bookmarkFolderGUID: GUID = BookmarkRoots.RootGUID) {
         self.bookmarkFolderGUID = bookmarkFolderGUID
@@ -105,17 +113,21 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
             })
 
             let newSeparator = PhotonActionSheetItem(title: Strings.BookmarksNewSeparator, iconString: "nav-menu", handler: { action in
-                self.profile.places.createSeparator(parentGUID: self.bookmarkFolderGUID) >>== { guid in
+                let centerVisibleRow = self.centerVisibleRow()
+
+                self.profile.places.createSeparator(parentGUID: self.bookmarkFolderGUID, position: UInt32(centerVisibleRow)) >>== { guid in
                     self.profile.places.getBookmark(guid: guid).uponQueue(.main) { result in
                         guard let bookmarkNode = result.successValue, let bookmarkSeparator = bookmarkNode as? BookmarkSeparator else {
                             return
                         }
 
-                        let index = self.bookmarkNodes.count
+                        let indexPath = IndexPath(row: centerVisibleRow, section: BookmarksSection.bookmarks.rawValue)
                         self.tableView.beginUpdates()
-                        self.bookmarkNodes.append(bookmarkSeparator)
-                        self.tableView.insertRows(at: [IndexPath(row: index, section: 0)], with: .automatic)
+                        self.bookmarkNodes.insert(bookmarkSeparator, at: centerVisibleRow)
+                        self.tableView.insertRows(at: [indexPath], with: .automatic)
                         self.tableView.endUpdates()
+
+                        self.flashRow(at: indexPath)
                     }
                 }
             })
@@ -162,7 +174,26 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
                 self.recentBookmarks = []
                 self.tableView.reloadData()
             }
+
+            if self.flashLastRowOnNextReload {
+                self.flashLastRowOnNextReload = false
+
+                let lastIndexPath = IndexPath(row: self.bookmarkNodes.count - 1, section: BookmarksSection.bookmarks.rawValue)
+                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(BookmarksPanelUX.RowFlashDelayInMilliseconds)) {
+                    self.flashRow(at: lastIndexPath)
+                }
+            }
         }
+    }
+
+    fileprivate func centerVisibleRow() -> Int {
+        let visibleCells = tableView.visibleCells
+        if let middleCell = visibleCells[safe: visibleCells.count / 2],
+            let middleIndexPath = tableView.indexPath(for: middleCell) {
+            return middleIndexPath.row
+        }
+
+        return bookmarkNodes.count
     }
 
     fileprivate func deleteBookmarkNodeAtIndexPath(_ indexPath: IndexPath) {
@@ -197,6 +228,18 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
         doDelete()
     }
 
+    func didAddBookmarkNode() {
+        flashLastRowOnNextReload = true
+    }
+
+    func flashRow(at indexPath: IndexPath) {
+        tableView.selectRow(at: indexPath, animated: true, scrollPosition: .middle)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(BookmarksPanelUX.RowFlashDelayInMilliseconds)) {
+            self.tableView.deselectRow(at: indexPath, animated: true)
+        }
+    }
+
     @objc fileprivate func didLongPress(_ longPressGestureRecognizer: UILongPressGestureRecognizer) {
         let touchPoint = longPressGestureRecognizer.location(in: tableView)
         guard longPressGestureRecognizer.state == .began, let indexPath = tableView.indexPathForRow(at: touchPoint) else {
@@ -222,7 +265,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
         tableView.deselectRow(at: indexPath, animated: false)
         let node: BookmarkNode?
 
-        if indexPath.section > 0 {
+        if indexPath.section == BookmarksSection.recent.rawValue {
             node = recentBookmarks[safe: indexPath.row]
         } else {
             node = bookmarkNodes[safe: indexPath.row]
@@ -233,7 +276,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
         }
 
         guard !tableView.isEditing else {
-            if let bookmarkFolder = self.bookmarkFolder {
+            if let bookmarkFolder = self.bookmarkFolder, !(bookmarkNode is BookmarkSeparator) {
                 let detailController = BookmarkDetailPanel(profile: profile, bookmarkNode: bookmarkNode, parentBookmarkFolder: bookmarkFolder)
                 navigationController?.pushViewController(detailController, animated: true)
             }
@@ -260,18 +303,19 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return section == 0 ? bookmarkNodes.count : recentBookmarks.count
+        return section == BookmarksSection.recent.rawValue ? recentBookmarks.count : bookmarkNodes.count
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {
         if let folder = bookmarkFolder, folder.guid == BookmarkRoots.RootGUID {
             return 2
         }
+
         return 1
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let bookmarkNode = indexPath.section == 0 ? bookmarkNodes[safe: indexPath.row] : recentBookmarks[safe: indexPath.row] else {
+        guard let bookmarkNode = indexPath.section == BookmarksSection.recent.rawValue ? recentBookmarks[safe: indexPath.row] : bookmarkNodes[safe: indexPath.row] else {
             return super.tableView(tableView, cellForRowAt: indexPath)
         }
 
@@ -322,18 +366,19 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
     }
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard section > 0, recentBookmarks.count > 0 else {
+        guard section == BookmarksSection.recent.rawValue, !recentBookmarks.isEmpty else {
             return nil
         }
+
         return super.tableView(tableView, viewForHeaderInSection: section)
     }
 
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return section == 0 ? nil : Strings.RecentlyBookmarkedTitle
+        return section == BookmarksSection.recent.rawValue ? Strings.RecentlyBookmarkedTitle : nil
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return section == 0 ? 0 : UITableView.automaticDimension
+        return section == BookmarksSection.recent.rawValue ? UITableView.automaticDimension : 0
     }
 
     func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {

--- a/Client/Frontend/Library/BookmarksPanel.swift
+++ b/Client/Frontend/Library/BookmarksPanel.swift
@@ -233,11 +233,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
             indexPath.row < tableView(tableView, numberOfRowsInSection: indexPath.section)
     }
 
-    func didAddBookmarkNode() {
-        flashLastRowOnNextReload = true
-    }
-
-    func flashRow(at indexPath: IndexPath) {
+    fileprivate func flashRow(at indexPath: IndexPath) {
         guard indexPathIsValid(indexPath) else {
             return
         }
@@ -249,6 +245,10 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
                 self.tableView.deselectRow(at: indexPath, animated: true)
             }
         }
+    }
+
+    func didAddBookmarkNode() {
+        flashLastRowOnNextReload = true
     }
 
     @objc fileprivate func didLongPress(_ longPressGestureRecognizer: UILongPressGestureRecognizer) {

--- a/Client/Frontend/Library/BookmarksPanel.swift
+++ b/Client/Frontend/Library/BookmarksPanel.swift
@@ -14,7 +14,7 @@ private let BookmarkSeparatorCellIdentifier = "BookmarkSeparatorCellIdentifier"
 
 private struct BookmarksPanelUX {
     static let FolderIconSize = CGSize(width: 20, height: 20)
-    static let RowFlashDelayInMilliseconds = 400
+    static let RowFlashDelay: TimeInterval = 0.4
 }
 
 let LocalizedRootBookmarkFolderStrings = [
@@ -179,7 +179,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
                 self.flashLastRowOnNextReload = false
 
                 let lastIndexPath = IndexPath(row: self.bookmarkNodes.count - 1, section: BookmarksSection.bookmarks.rawValue)
-                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(BookmarksPanelUX.RowFlashDelayInMilliseconds)) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + BookmarksPanelUX.RowFlashDelay) {
                     self.flashRow(at: lastIndexPath)
                 }
             }
@@ -228,15 +228,26 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
         doDelete()
     }
 
+    fileprivate func indexPathIsValid(_ indexPath: IndexPath) -> Bool {
+        return indexPath.section < numberOfSections(in: tableView) &&
+            indexPath.row < tableView(tableView, numberOfRowsInSection: indexPath.section)
+    }
+
     func didAddBookmarkNode() {
         flashLastRowOnNextReload = true
     }
 
     func flashRow(at indexPath: IndexPath) {
+        guard indexPathIsValid(indexPath) else {
+            return
+        }
+
         tableView.selectRow(at: indexPath, animated: true, scrollPosition: .middle)
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(BookmarksPanelUX.RowFlashDelayInMilliseconds)) {
-            self.tableView.deselectRow(at: indexPath, animated: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + BookmarksPanelUX.RowFlashDelay) {
+            if self.indexPathIsValid(indexPath) {
+                self.tableView.deselectRow(at: indexPath, animated: true)
+            }
         }
     }
 


### PR DESCRIPTION
This fixes a lot more UX nits than just the separator position. It also auto-scrolls to the newly-created item when making a new folder/bookmark from the "+" in edit mode. Another thing is that we disable the folder selection widget when creating a new folder/bookmark (since you are inherently creating an item in the folder you're currently in anyway). I went over all of these changes with Bryan before putting together this PR.