### PR TITLE
fix #5040 - Empty history layout does not appear when removing recent history

### DIFF
--- a/Client/Frontend/Library/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel.swift
@@ -593,7 +593,7 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
             }
         } else {
             tableView.alwaysBounceVertical = true
-            emptyStateOverlayView.removeFromSuperview()
+            tableView.tableFooterView = nil
         }
     }
 


### PR DESCRIPTION
The emptyStateOverlayView reference was not removed correctly from the tableFooterView. Because of this it was not possible to add the overlay again as the table footer.