### PR TITLE
Fix #5144 - [Bookmarks]Long press on the 'Back' button does not work after entering/exiting Edit mode

### DIFF
--- a/Client/Frontend/Library/BookmarksPanel.swift
+++ b/Client/Frontend/Library/BookmarksPanel.swift
@@ -88,6 +88,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
             self.tableView.setEditing(false, animated: true)
             self.navigationItem.leftBarButtonItem = nil
             self.navigationItem.rightBarButtonItem = self.editBarButtonItem
+            self.setupBackButtonGestureRecognizer()
         }
 
         self.newBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add) { _ in
@@ -143,10 +144,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        if let backButtonView = self.backButtonView() {
-            let backButtonViewLongPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressBackButtonView))
-            backButtonView.addGestureRecognizer(backButtonViewLongPressRecognizer)
-        }
+        setupBackButtonGestureRecognizer()
     }
 
     override func applyTheme() {
@@ -189,6 +187,13 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
                     self.flashRow(at: lastIndexPath)
                 }
             }
+        }
+    }
+
+    fileprivate func setupBackButtonGestureRecognizer() {
+        if let backButtonView = self.backButtonView() {
+            let backButtonViewLongPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressBackButtonView))
+            backButtonView.addGestureRecognizer(backButtonViewLongPressRecognizer)
         }
     }
 


### PR DESCRIPTION
Great find by QA. Basically, when you enter/exit "edit mode", we swap out the default iOS "< Back" button with our "+" (new) button and the built-in iOS button loses its gesture recognizer. All we need to do is re-attach it when we leave edit mode.