### PR TITLE
Fix #4843 -  Copying version to clipboard makes debug menu hard to access

### DIFF
--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -602,7 +602,6 @@ class VersionSetting: Setting {
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        copyAppVersionAndPresentAlert(by: navigationController)
         DebugSettingsClickCount += 1
         if DebugSettingsClickCount >= 5 {
             DebugSettingsClickCount = 0
@@ -610,7 +609,11 @@ class VersionSetting: Setting {
             settings.tableView.reloadData()
         }
     }
-    
+
+    override func onLongPress(_ navigationController: UINavigationController?) {
+        copyAppVersionAndPresentAlert(by: navigationController)
+    }
+
     func copyAppVersionAndPresentAlert(by navigationController: UINavigationController?) {
         let alertTitle = Strings.SettingsCopyAppVersionAlertTitle
         let alert = AlertController(title: alertTitle, message: nil, preferredStyle: .alert)

--- a/ClientTests/VersionSettingTests.swift
+++ b/ClientTests/VersionSettingTests.swift
@@ -14,7 +14,7 @@ class VersionSettingTests: XCTestCase {
         let versionSetting = VersionSetting(settings: settingsTable)
         
         // MARK: - when
-        versionSetting.onClick(navigationController)
+        versionSetting.onLongPress(navigationController)
         
         // MARK: - then
         let appVersionString = UIPasteboard.general.string


### PR DESCRIPTION
This is an alternate PR that simply adds a long-press gesture recognizer to the table view and copies the version to the clipboard using that gesture instead. I'd rather do this than to change the debug menu behavior since it is something that a lot of users are already aware of and use.