### PR TITLE
Issue #5176 - Use sendWithStacktrace for rust log

### DIFF
--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -264,7 +264,7 @@ open class BrowserProfile: Profile {
             case .warn:
                 log.warning(logString)
             case .error:
-                Sentry.shared.send(message: message, tag: .rustLog, severity: .error, extra: ["rust-tag": tag ?? "no-tag"])
+                Sentry.shared.sendWithStacktrace(message: logString, tag: .rustLog, severity: .error)
                 log.error(logString)
             }
 


### PR DESCRIPTION
Rather than just a `send`.

This doesn't fix #5176, it just improves the logging.