### PR TITLE
Fix #5043 - HTTP Auth login and page form logins have different fields used

### DIFF
--- a/Client/Frontend/Browser/Authenticator.swift
+++ b/Client/Frontend/Browser/Authenticator.swift
@@ -57,7 +57,10 @@ class Authenticator {
                 return deferMaybe(nil)
             }
 
-            let logins = cursor.asArray()
+            let logins = cursor.compactMap {
+                // HTTP Auth must have nil formSubmitURL and a non-nil httpRealm.
+                return $0?.formSubmitURL == nil && $0?.httpRealm != nil ? $0 : nil
+            }
             var credentials: URLCredential?
 
             // It is possible that we might have duplicate entries since we match against host and scheme://host.

--- a/Client/Frontend/Browser/LoginsHelper.swift
+++ b/Client/Frontend/Browser/LoginsHelper.swift
@@ -254,12 +254,17 @@ class LoginsHelper: TabContentScript {
                 return
             }
 
-            log.debug("Found \(cursor.count) logins.")
+            let logins: [[String: Any]] = cursor.compactMap { login in
+                // `requestLogins` is for webpage forms, not for HTTP Auth, and the latter has httpRealm != nil; filter those out.
+                return login?.httpRealm == nil ? login?.toJSONDict() : nil
+            }
+
+            log.debug("Found \(logins.count) logins.")
 
             let dict: [String: Any] = [
                 "requestId": requestId,
                 "name": "RemoteLogins:loginsFound",
-                "logins": cursor.compactMap({ $0?.toJSONDict() })
+                "logins": logins
             ]
 
             let json = JSON(dict)


### PR DESCRIPTION
We don't want an HTTP Auth login suggested for a webpage on the same domain, and vice-versa.
