### PR TITLE
fix #5127 - [iPad] Tab not scrolled into view after changing device orientation in tabs tray and opening a new tab

### DIFF
--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -94,7 +94,8 @@ class TopTabsViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
         tabDisplayManager.refreshStore(evenIfHidden: true)
     }
 


### PR DESCRIPTION
The `TopTabsViewController` view layout has to be triggerd to update the frame to fit the new parent size after rotation. Without this, the `scrollTo` methods of the collection view do not work correctly.

