### PR TITLE
Remove Useless `style.backgroundImage` Assignment

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/NoImageModeHelper.js
+++ b/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/NoImageModeHelper.js
@@ -70,7 +70,6 @@ Object.defineProperty(window.__firefox__.NoImageMode, "setEnabled", {
         }
 
         var backgroundImage = style.backgroundImage;
-        style.backgroundImage = "none";
         style.backgroundImage = backgroundImage;
       });
     });


### PR DESCRIPTION
The assigned value for `style.backgroundImage` was overwritten immediately after it was assigned.
This fixes a [warning from lgtm](https://lgtm.com/projects/g/mozilla-mobile/firefox-ios/snapshot/dff16a1dffb0d243bc35ddb823d289d16c6c639d/files/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/NoImageModeHelper.js?sort=name&dir=ASC&mode=heatmap).

