### PR TITLE
Fixes 108789 in Sentry. Rotating the app with a menu open no longer crashes

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -298,6 +298,7 @@ class BrowserViewController: UIViewController {
 
     @objc func appDidEnterBackgroundNotification() {
         displayedPopoverController?.dismiss(animated: false) {
+            self.updateDisplayedPopoverProperties = nil
             self.displayedPopoverController = nil
         }
     }
@@ -309,6 +310,7 @@ class BrowserViewController: UIViewController {
    @objc  func appWillResignActiveNotification() {
         // Dismiss any popovers that might be visible
         displayedPopoverController?.dismiss(animated: false) {
+            self.updateDisplayedPopoverProperties = nil
             self.displayedPopoverController = nil
         }
 
@@ -2144,16 +2146,20 @@ extension BrowserViewController: ContextMenuHelperDelegate {
             actionSheetController.addAction(copyImageLinkAction, accessibilityIdentifier: "linkContextMenu.copyImageLink")
         }
 
-        // If we're showing an arrow popup, set the anchor to the long press location.
-        if let popoverPresentationController = actionSheetController.popoverPresentationController {
-            popoverPresentationController.sourceView = view
-            popoverPresentationController.sourceRect = CGRect(origin: touchPoint, size: touchSize)
-            popoverPresentationController.permittedArrowDirections = .any
-            popoverPresentationController.delegate = self
+        let setupPopover = { [unowned self] in
+            // If we're showing an arrow popup, set the anchor to the long press location.
+            if let popoverPresentationController = actionSheetController.popoverPresentationController {
+                popoverPresentationController.sourceView = self.view
+                popoverPresentationController.sourceRect = CGRect(origin: touchPoint, size: touchSize)
+                popoverPresentationController.permittedArrowDirections = .any
+                popoverPresentationController.delegate = self
+            }
         }
+        setupPopover()
 
         if actionSheetController.popoverPresentationController != nil {
             displayedPopoverController = actionSheetController
+            updateDisplayedPopoverProperties = setupPopover
         }
 
         if let dialogTitle = dialogTitle {


### PR DESCRIPTION
Here is the crash https://sentry-fm.prod.mozaws.net/mozilla/firefox-ios-17/issues/108789/?query=is%3Aunresolved

To reproduce this crash. Simply open a long press menu on the ipad and rotate the screen. 

The crash happened in `coordinator.animate(alongsideTransition` in BVC:152. Calling `                self.present(popover, animated: true, completion: nil)` would crash even though we had called `dismissVisibleMenus` to dismiss any menus.

For some reason the readermode settings menu would not crash when rotating. Only the long press menu would. Only difference between the two is the readermode menu calls `updateDisplayedPopoverProperties` to reconfigure the menu while the other menu doesnt. 

The fix is to setup a `updateDisplayedPopoverProperties` for the long press menu.
