### PR TITLE
Fix #5215 - iPad: Firefox crashed when closing tab too fast using external keyboard

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -432,7 +432,7 @@ extension TabDisplayManager: TabManagerDelegate {
 
         updateWith(animationType: .addTab) { [weak self] in
             if let me = self {
-                let index = me.tabsToDisplay.firstIndex(of: tab) ?? me.tabsToDisplay.count
+                let index = me.tabsToDisplay.firstIndex(of: tab) ?? me.dataStore.count
                 me.dataStore.insert(tab, at: index)
                 me.collectionView.insertItems(at: [IndexPath(row: index, section: 0)])
             }


### PR DESCRIPTION
This PR fixes a crash which can occur when a tab is closed before the previous tab closing has been completely handled.

Also fixes #5233, which is the same bug.