### PR TITLE
Fix #5215 - Spamming close tab crashes app

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -431,8 +431,7 @@ extension TabDisplayManager: TabManagerDelegate {
         }
 
         updateWith(animationType: .addTab) { [weak self] in
-            if let me = self {
-                let index = me.tabsToDisplay.firstIndex(of: tab) ?? me.dataStore.count
+            if let me = self, let index = me.tabsToDisplay.firstIndex(of: tab) {
                 me.dataStore.insert(tab, at: index)
                 me.collectionView.insertItems(at: [IndexPath(row: index, section: 0)])
             }


### PR DESCRIPTION
Although I landed a fix for this already from a contrib. On further thought, this is more what the code is intended to do. 
The fix is to do nothing (no view updating) in the case where a tab has been added, but that tab is not in the TabManager list after the async code runs (which is totally reasonable because of closing tabs). 

