### PR TITLE
Fix #5248 - Make sure numberOfRowsInSection and cellForRowAt use same data source.

### DIFF
--- a/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -113,7 +113,7 @@ class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return profile.recentlyClosedTabs.tabs.count
+        return self.recentlyClosedTabs.count
     }
 
 }


### PR DESCRIPTION
If `profile.recentlyClosedTabs.tabs` changes after `viewdidload` then the count of `self.recentlyClosedTabs` will be different from `profile.recentlyClosedTabs.tabs` causing a crash