### PR TITLE
Fix #4952 - Low contrast menus when reduced transparency/inc. contrast are enabled

### DIFF
--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -24,7 +24,7 @@ fileprivate class DarkTableViewColor: TableViewColor {
 fileprivate class DarkActionMenuColor: ActionMenuColor {
     override var foreground: UIColor { return UIColor.Photon.White100 }
     override var iPhoneBackgroundBlurStyle: UIBlurEffect.Style { return UIBlurEffect.Style.dark }
-    override var iPhoneBackground: UIColor { return defaultBackground }
+    override var iPhoneBackground: UIColor { return defaultBackground.withAlphaComponent(0.9) }
     override var closeButtonBackground: UIColor { return defaultBackground }
 }
 

--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -22,7 +22,7 @@ fileprivate class DarkTableViewColor: TableViewColor {
 }
 
 fileprivate class DarkActionMenuColor: ActionMenuColor {
-    override var foreground: UIColor { return defaultTextAndTint }
+    override var foreground: UIColor { return UIColor.Photon.White100 }
     override var iPhoneBackgroundBlurStyle: UIBlurEffect.Style { return UIBlurEffect.Style.dark }
     override var iPhoneBackground: UIColor { return defaultBackground }
     override var closeButtonBackground: UIColor { return defaultBackground }

--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -23,9 +23,9 @@ fileprivate class DarkTableViewColor: TableViewColor {
 
 fileprivate class DarkActionMenuColor: ActionMenuColor {
     override var foreground: UIColor { return defaultTextAndTint }
-    override var iPhoneBackground: UIColor { return UIColor.Photon.Grey90.withAlphaComponent(0.9) }
+    override var iPhoneBackgroundBlurStyle: UIBlurEffect.Style { return UIBlurEffect.Style.dark }
+    override var iPhoneBackground: UIColor { return defaultBackground }
     override var closeButtonBackground: UIColor { return defaultBackground }
-
 }
 
 fileprivate class DarkURLBarColor: URLBarColor {

--- a/Client/Frontend/Theme/Theme.swift
+++ b/Client/Frontend/Theme/Theme.swift
@@ -48,7 +48,7 @@ class TableViewColor {
 class ActionMenuColor {
     var foreground: UIColor { return defaultTextAndTint }
     var iPhoneBackgroundBlurStyle: UIBlurEffect.Style { return UIBlurEffect.Style.light }
-    var iPhoneBackground: UIColor { return UIColor.theme.browser.background }
+    var iPhoneBackground: UIColor { return defaultBackground.withAlphaComponent(0.9) }
     var closeButtonBackground: UIColor { return defaultBackground }
 }
 

--- a/Client/Frontend/Theme/Theme.swift
+++ b/Client/Frontend/Theme/Theme.swift
@@ -48,7 +48,7 @@ class TableViewColor {
 class ActionMenuColor {
     var foreground: UIColor { return defaultTextAndTint }
     var iPhoneBackgroundBlurStyle: UIBlurEffect.Style { return UIBlurEffect.Style.light }
-    var iPhoneBackground: UIColor { return UIColor.theme.browser.background.withAlphaComponent(0.9) }
+    var iPhoneBackground: UIColor { return UIColor.theme.browser.background }
     var closeButtonBackground: UIColor { return defaultBackground }
 }
 

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -141,10 +141,12 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
 
         // Apply or remove the background blur effect
         if let visualEffectView = tableView.backgroundView as? UIVisualEffectView {
-            if (!UIAccessibility.isReduceTransparencyEnabled) {
-                visualEffectView.effect = UIBlurEffect(style: UIColor.theme.actionMenu.iPhoneBackgroundBlurStyle)
-            } else {
+            if (UIAccessibility.isReduceTransparencyEnabled) {
+                // Remove the visual effect and the background alpha
                 visualEffectView.effect = nil
+                tableView.backgroundView?.backgroundColor = UIColor.theme.actionMenu.iPhoneBackground.withAlphaComponent(1.0)
+            } else {
+                visualEffectView.effect = UIBlurEffect(style: UIColor.theme.actionMenu.iPhoneBackgroundBlurStyle)
             }
         }
 

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -124,6 +124,12 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
 
         NotificationCenter.default.addObserver(self, selector: #selector(stopRotateSyncIcon), name: .ProfileDidFinishSyncing, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(stopRotateSyncIcon), name: .ProfileDidStartSyncing, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(reduceTransparencyChanged), name: UIAccessibility.reduceTransparencyStatusDidChangeNotification, object: nil)
+    }
+
+    @objc func reduceTransparencyChanged() {
+        // If the user toggles transparency settings, re-apply the theme to also toggle the blur effect.
+        applyTheme()
     }
 
     func applyTheme() {
@@ -131,6 +137,15 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
             view.backgroundColor = UIColor.theme.browser.background.withAlphaComponent(0.7)
         } else {
             tableView.backgroundView?.backgroundColor = UIColor.theme.actionMenu.iPhoneBackground
+        }
+
+        // Apply or remove the background blur effect
+        if let visualEffectView = tableView.backgroundView as? UIVisualEffectView {
+            if (!UIAccessibility.isReduceTransparencyEnabled) {
+                visualEffectView.effect = UIBlurEffect(style: UIColor.theme.actionMenu.iPhoneBackgroundBlurStyle)
+            } else {
+                visualEffectView.effect = nil
+            }
         }
 
         tintColor = UIColor.theme.actionMenu.foreground

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
@@ -174,14 +174,14 @@ class PhotonActionSheetCell: UITableViewCell {
 
     func configure(with action: PhotonActionSheetItem, syncManager: SyncManager? = nil) {
         titleLabel.text = action.title
-        titleLabel.textColor = self.tintColor
+        titleLabel.textColor = UIColor.theme.tableView.rowText
         titleLabel.textColor = action.accessory == .Text ? titleLabel.textColor.withAlphaComponent(0.6) : titleLabel.textColor
         titleLabel.numberOfLines = 1
         titleLabel.adjustsFontSizeToFitWidth = true
         titleLabel.minimumScaleFactor = 0.5
 
         subtitleLabel.text = action.text
-        subtitleLabel.textColor = self.tintColor
+        subtitleLabel.textColor = UIColor.theme.tableView.rowText
         subtitleLabel.isHidden = action.text == nil
         titleLabel.font  = action.bold ? DynamicFontHelper.defaultHelper.DeviceFontLargeBold : DynamicFontHelper.defaultHelper.LargeSizeRegularWeightAS
         accessibilityIdentifier = action.iconString


### PR DESCRIPTION
Fixes #4952 

This PR addresses unreadable contrast in popover menus when the "reduced transparency" and/or "increased contrast" accessibility settings are enabled, specifically in night mode.

### Reduced transparency behavior in popup views
The current behavior of popup views in night mode is actually a bug -- there was no defined background blur style for the night theme, it just used the normal theme's color.

Enabling reduced transparency would flatten the opaque blur effect view, and show the original white background. 

This is fixed by defining a dark blur style (that matches the "close" button's color, save for transparency), and removing the 0.9 alpha on the light theme. Additionally, the blur is now _conditionally_ applied when accessibility is turned on/off.

Old light style             |  New dark style
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/2782749/61679168-32f01480-acba-11e9-95d6-c67b69ed4dc8.PNG) | ![](https://user-images.githubusercontent.com/2782749/61679170-35526e80-acba-11e9-8436-0f2726cafb39.PNG)

The potential downside here is decreased contrast with dark-background websites. 

### Increased contrast behavior in popup views

Previously, the popup action sheet cell would use `tintColor` as its text color, which is not inline with other table views which use `rowColor`. Enabling "increased contrast" causes iOS to darken the tint color, which doesn't help in this scenario (dark background!). 

The fix here is changing `tintColor` to `rowColor` for the `PhotonActionSheetCell`, and modifying the `foreground` color in the `DarkTheme` file.

Old (Inc. contr enabled)             |  New (Inc. contr enabled)
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/2782749/61679436-130d2080-acbb-11e9-9d8d-a1f68193800d.PNG) | ![](https://user-images.githubusercontent.com/2782749/61680874-04753800-acc0-11e9-8143-1978dd3bc9e9.PNG)





Sidenote:
Apple has no documentation on how reduced transparency/increased contrast is implemented! Most of my work here has been through the UI debugger.



