### PR TITLE
Fix #4716 - ButtonToast will stretches to the bottom if toolbar is missing

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1848,7 +1848,7 @@ extension BrowserViewController: TabManagerDelegate {
 
         toast.showToast(viewController: self, delay: delay, duration: duration, makeConstraints: { make in
             make.left.right.equalTo(self.view)
-            make.bottom.equalTo(self.webViewContainer?.safeArea.bottom ?? 0)
+            make.bottom.equalTo(self.webViewContainer?.snp.bottom ?? 0)
         })
     }
 

--- a/Client/Frontend/Browser/ButtonToast.swift
+++ b/Client/Frontend/Browser/ButtonToast.swift
@@ -37,11 +37,11 @@ class ButtonToast: Toast {
 
         self.toastView.snp.makeConstraints { make in
             make.left.right.height.equalTo(self)
-            self.animationConstraint = make.top.equalTo(self).offset(ButtonToastUX.ToastHeight).constraint
+            self.animationConstraint = make.top.greaterThanOrEqualTo(self).offset(ButtonToastUX.ToastHeight).constraint
         }
 
         self.snp.makeConstraints { make in
-            make.height.equalTo(ButtonToastUX.ToastHeight)
+            make.height.greaterThanOrEqualTo(ButtonToastUX.ToastHeight)
         }
     }
 
@@ -128,6 +128,9 @@ class ButtonToast: Toast {
             make.centerX.equalTo(toastView)
             make.centerY.equalTo(toastView)
             make.width.equalTo(toastView.snp.width).offset(-2 * ButtonToastUX.ToastPadding)
+            make.bottom.equalTo(toastView.safeArea.bottom)
+            make.top.equalTo(toastView.snp.top)
+            make.height.equalTo(ButtonToastUX.ToastHeight)
         }
 
         return toastView


### PR DESCRIPTION
This pull request makes the ButtonToast extend to the bottom, past the safe are if the toolbar is not visible. [#4716](https://github.com/mozilla-mobile/firefox-ios/issues/4716)

On iPhone X/XS/XR devices, which have a safe area at the bottom, when opening a new tab while the bottom toolbar is hidden, the Toast which notifies the user of the new tab doesn't stretch to the bottom of the screen.
This PR changes the constraints applied to Button Toast, allowing it to stretch to the bottom, if needed.

| Before | After |
| --- | --- |
| ![Simulator Screen Shot - iPhone X - 2019-07-30 at 12 20 34](https://user-images.githubusercontent.com/13573504/62117360-77843d00-b2c4-11e9-8742-42a5c9cf2f23.png) | ![Simulator Screen Shot - iPhone X - 2019-07-30 at 12 20 02](https://user-images.githubusercontent.com/13573504/62117361-77843d00-b2c4-11e9-9d77-94a9f776d7b5.png) 


