### PR TITLE
Fix #4968 - Google favicon is displayed in tabs tray after visiting google.com and going back to Home

### DIFF
--- a/Client/Frontend/Browser/FaviconHandler.swift
+++ b/Client/Frontend/Browser/FaviconHandler.swift
@@ -104,7 +104,7 @@ extension FaviconHandler: TabEventHandler {
             TabEvent.post(.didLoadFavicon(favicon, with: data), for: tab)
         }
     }
-    func tabMedatadaNotAvailable(_ tab: Tab) {
+    func tabMetadataNotAvailable(_ tab: Tab) {
         tab.favicons.removeAll(keepingCapacity: false)
     }
 }

--- a/Client/Frontend/Browser/FaviconHandler.swift
+++ b/Client/Frontend/Browser/FaviconHandler.swift
@@ -13,7 +13,7 @@ class FaviconHandler {
     private let backgroundQueue = OperationQueue()
 
     init() {
-        register(self, forTabEvents: .didLoadPageMetadata)
+        register(self, forTabEvents: .didLoadPageMetadata, .pageMetadataNotAvailable)
     }
 
     func loadFaviconURL(_ faviconURL: String, forTab tab: Tab) -> Deferred<Maybe<(Favicon, Data?)>> {
@@ -103,6 +103,9 @@ extension FaviconHandler: TabEventHandler {
             guard let (favicon, data) = result.successValue else { return }
             TabEvent.post(.didLoadFavicon(favicon, with: data), for: tab)
         }
+    }
+    func tabMedatadaNotAvailable(_ tab: Tab) {
+        tab.favicons.removeAll(keepingCapacity: false)
     }
 }
 

--- a/Client/Frontend/Browser/MetadataParserHelper.swift
+++ b/Client/Frontend/Browser/MetadataParserHelper.swift
@@ -21,6 +21,7 @@ class MetadataParserHelper: TabEventHandler {
         // as possible.
         guard let webView = tab.webView,
             let url = webView.url, url.isWebPage(includeDataURIs: false), !InternalURL.isValid(url: url) else {
+                TabEvent.post(.pageMetadataNotAvailable, for: tab)
             return
         }
 
@@ -33,6 +34,7 @@ class MetadataParserHelper: TabEventHandler {
                 let pageURL = tab.url?.displayURL,
                 let pageMetadata = PageMetadata.fromDictionary(dict) else {
                     log.debug("Page contains no metadata!")
+                    TabEvent.post(.pageMetadataNotAvailable, for: tab)
                     return
             }
 

--- a/Client/Helpers/TabEventHandler.swift
+++ b/Client/Helpers/TabEventHandler.swift
@@ -52,7 +52,7 @@ import Storage
 protocol TabEventHandler: AnyObject {
     func tab(_ tab: Tab, didChangeURL url: URL)
     func tab(_ tab: Tab, didLoadPageMetadata metadata: PageMetadata)
-    func tabMedatadaNotAvailable(_ tab: Tab)
+    func tabMetadataNotAvailable(_ tab: Tab)
     func tab(_ tab: Tab, didLoadFavicon favicon: Favicon?, with: Data?)
     func tabDidGainFocus(_ tab: Tab)
     func tabDidLoseFocus(_ tab: Tab)
@@ -67,7 +67,7 @@ protocol TabEventHandler: AnyObject {
 extension TabEventHandler {
     func tab(_ tab: Tab, didChangeURL url: URL) {}
     func tab(_ tab: Tab, didLoadPageMetadata metadata: PageMetadata) {}
-    func tabMedatadaNotAvailable(_ tab: Tab) {}
+    func tabMetadataNotAvailable(_ tab: Tab) {}
     func tab(_ tab: Tab, didLoadFavicon favicon: Favicon?, with: Data?) {}
     func tabDidGainFocus(_ tab: Tab) {}
     func tabDidLoseFocus(_ tab: Tab) {}
@@ -118,7 +118,7 @@ enum TabEvent {
         case .didLoadPageMetadata(let metadata):
             handler.tab(tab, didLoadPageMetadata: metadata)
         case .pageMetadataNotAvailable:
-            handler.tabMedatadaNotAvailable(tab)
+            handler.tabMetadataNotAvailable(tab)
         case .didLoadFavicon(let favicon, let data):
             handler.tab(tab, didLoadFavicon: favicon, with: data)
         case .didGainFocus:

--- a/Client/Helpers/TabEventHandler.swift
+++ b/Client/Helpers/TabEventHandler.swift
@@ -52,6 +52,7 @@ import Storage
 protocol TabEventHandler: AnyObject {
     func tab(_ tab: Tab, didChangeURL url: URL)
     func tab(_ tab: Tab, didLoadPageMetadata metadata: PageMetadata)
+    func tabMedatadaNotAvailable(_ tab: Tab)
     func tab(_ tab: Tab, didLoadFavicon favicon: Favicon?, with: Data?)
     func tabDidGainFocus(_ tab: Tab)
     func tabDidLoseFocus(_ tab: Tab)
@@ -66,6 +67,7 @@ protocol TabEventHandler: AnyObject {
 extension TabEventHandler {
     func tab(_ tab: Tab, didChangeURL url: URL) {}
     func tab(_ tab: Tab, didLoadPageMetadata metadata: PageMetadata) {}
+    func tabMedatadaNotAvailable(_ tab: Tab) {}
     func tab(_ tab: Tab, didLoadFavicon favicon: Favicon?, with: Data?) {}
     func tabDidGainFocus(_ tab: Tab) {}
     func tabDidLoseFocus(_ tab: Tab) {}
@@ -78,6 +80,7 @@ extension TabEventHandler {
 enum TabEventLabel: String {
     case didChangeURL
     case didLoadPageMetadata
+    case pageMetadataNotAvailable
     case didLoadFavicon
     case didGainFocus
     case didLoseFocus
@@ -91,6 +94,7 @@ enum TabEventLabel: String {
 enum TabEvent {
     case didChangeURL(URL)
     case didLoadPageMetadata(PageMetadata)
+    case pageMetadataNotAvailable
     case didLoadFavicon(Favicon?, with: Data?)
     case didGainFocus
     case didLoseFocus
@@ -113,6 +117,8 @@ enum TabEvent {
             handler.tab(tab, didChangeURL: url)
         case .didLoadPageMetadata(let metadata):
             handler.tab(tab, didLoadPageMetadata: metadata)
+        case .pageMetadataNotAvailable:
+            handler.tabMedatadaNotAvailable(tab)
         case .didLoadFavicon(let favicon, let data):
             handler.tab(tab, didLoadFavicon: favicon, with: data)
         case .didGainFocus:


### PR DESCRIPTION
Fixes #4968 

**Initial issue:**
Since the Home URL is not a valid URL, loading it would yield no metadata. Because of that, the FaviconHandler would not clear the current favicons

**Summary of change:**
Added a new TabEvent for when there is no metadata available. This notifies the FaviconHandler that there is no metadata and it should clear the favicons