### PR TITLE
Bug 5288 - Page metadata not set to nil when not available

### DIFF
--- a/Client/Frontend/Browser/MetadataParserHelper.swift
+++ b/Client/Frontend/Browser/MetadataParserHelper.swift
@@ -22,11 +22,14 @@ class MetadataParserHelper: TabEventHandler {
         guard let webView = tab.webView,
             let url = webView.url, url.isWebPage(includeDataURIs: false), !InternalURL.isValid(url: url) else {
                 TabEvent.post(.pageMetadataNotAvailable, for: tab)
-            return
+                tab.pageMetadata = nil
+                return
         }
 
         webView.evaluateJavaScript("__firefox__.metadata && __firefox__.metadata.getMetadata()") { (result, error) in
             guard error == nil else {
+                TabEvent.post(.pageMetadataNotAvailable, for: tab)
+                tab.pageMetadata = nil
                 return
             }
 
@@ -35,6 +38,7 @@ class MetadataParserHelper: TabEventHandler {
                 let pageMetadata = PageMetadata.fromDictionary(dict) else {
                     log.debug("Page contains no metadata!")
                     TabEvent.post(.pageMetadataNotAvailable, for: tab)
+                    tab.pageMetadata = nil
                     return
             }
 


### PR DESCRIPTION
The tab metadata (i.e. META tag on the page) is used to find the shareable URL (Google Amp pages is one use case, not sure of the other use cases), but if no metadata is available (say for a PDF page) then the original URL should be used.