### PR TITLE
Fix #5301 - Open the new tab depending on the browsing mode on cmd+t

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -43,7 +43,8 @@ extension BrowserViewController {
 
     @objc private func newTabKeyCommand() {
         UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "new-tab"])
-        openBlankNewTab(focusLocationField: true, isPrivate: false)
+        let isPrivate = tabManager.selectedTab?.isPrivate ?? false
+        openBlankNewTab(focusLocationField: true, isPrivate: isPrivate)
     }
 
     @objc private func newPrivateTabKeyCommand() {


### PR DESCRIPTION
This PR changes the behavior of `Cmd+T` on iPad. After that change, this shortcut opens a private tab in private browsing mode and non-private tab in normal mode. This also matches Safari's behavior now.