### PR TITLE
Issue #5297 - Text label placeholders in Settings difficult to read in Night Mode

### DIFF
--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -118,7 +118,7 @@ fileprivate class DarkSnackBarColor: SnackBarColor {
 }
 
 fileprivate class DarkGeneralColor: GeneralColor {
-    override var settingsTextPlaceholder: UIColor? { return UIColor.black }
+    override var settingsTextPlaceholder: UIColor? { return UIColor.Photon.Grey50 }
     override var faviconBackground: UIColor { return UIColor.Photon.White100 }
     override var passcodeDot: UIColor { return UIColor.Photon.Grey40 }
 }


### PR DESCRIPTION
Fix for issue [#5297](https://github.com/mozilla-mobile/firefox-ios/issues/5297)

This simply changes the Dark Mode theme color for settings placeholder text from `UIColor.black` to `UIColor.Photon.Grey50`. This makes it easier to see the placeholder text of settings text fields when using Dark Mode.

Grey50 seemed like a good choice between readability and theme consistency.

Please see screenshots below.

![Simulator Screen Shot - iPhone 8 - 2019-08-07 at 18 19 25](https://user-images.githubusercontent.com/7377358/62662185-2bc73880-b941-11e9-9384-abd500049e8b.png)
![Simulator Screen Shot - iPhone 8 - 2019-08-07 at 18 19 35](https://user-images.githubusercontent.com/7377358/62662186-2bc73880-b941-11e9-9a4b-7e153a9c1f89.png)