### PR TITLE
Remove the lines which call 'synchronize' on the shared UserDefaults …

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -60,7 +60,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             self.applicationCleanlyBackgrounded = defaults.bool(forKey: "ApplicationCleanlyBackgrounded")
         }
         defaults.set(false, forKey: "ApplicationCleanlyBackgrounded")
-        defaults.synchronize()
 
         // Hold references to willFinishLaunching parameters for delayed app launch
         self.application = application
@@ -255,7 +254,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
 
         let defaults = UserDefaults()
         defaults.set(false, forKey: "ApplicationCleanlyBackgrounded")
-        defaults.synchronize()
 
         if let profile = self.profile {
             profile._reopen()
@@ -314,7 +312,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
 
         let defaults = UserDefaults()
         defaults.set(true, forKey: "ApplicationCleanlyBackgrounded")
-        defaults.synchronize()
 
         // Pause file downloads.
         browserViewController.downloadQueue.pauseAll()

--- a/Shared/SentryIntegration.swift
+++ b/Shared/SentryIntegration.swift
@@ -64,7 +64,6 @@ public class Sentry {
             // be used for both the main application and the app extensions.
             if let defaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier), defaults.string(forKey: SentryDeviceAppHashKey) == nil {
                 defaults.set(Bytes.generateRandomBytes(DeviceAppHashLength).hexEncodedString, forKey: SentryDeviceAppHashKey)
-                defaults.synchronize()
             }
 
             // For all outgoing reports, override the default device identifier with our own random


### PR DESCRIPTION
…instance

* Removed four lines of code which called the 'synchronize' method on the shared UserDefaults instance
* The docs specify that the synchronize method is unnecessary and should not be used
* All tests pass