### PR TITLE
Fix #5351 - Action sheet height calculated wrong

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -193,6 +193,12 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
         tableView.sectionFooterHeight = 1
 
         applyTheme()
+
+        DispatchQueue.main.async {
+            // Pick up the correct/final tableview.contentsize in order to set the height.
+            // Without async dispatch, the contentsize is wrong.
+            self.view.setNeedsLayout()
+        }
     }
 
     // Nested tableview rows get additional height
@@ -304,7 +310,12 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         if section == 0 {
-            return (site != nil || title != nil) ? PhotonActionSheetUX.TitleHeaderSectionHeight : 6
+            if site != nil {
+                return PhotonActionSheetUX.TitleHeaderSectionHeightWithSite
+            } else if title != nil {
+                return PhotonActionSheetUX.TitleHeaderSectionHeight
+            }
+            return 6
         }
 
         return PhotonActionSheetUX.SeparatorRowHeight

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetWidgets.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetWidgets.swift
@@ -26,6 +26,7 @@ struct PhotonActionSheetUX {
     static let TablePadding: CGFloat = 6
     static let SeparatorRowHeight: CGFloat = 13
     static let TitleHeaderSectionHeight: CGFloat = 40
+    static let TitleHeaderSectionHeightWithSite: CGFloat = 70
 }
 
 public enum PresentationStyle {


### PR DESCRIPTION
The tableView.contentSize is incorrect in certain cases, but is correct when calling re-layout after viewWillAppear().
