### PR TITLE
Fix #5359 - Downloads action sheet: filename cut off

### DIFF
--- a/Client/Frontend/Browser/OpenInHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper.swift
@@ -89,12 +89,20 @@ class DownloadHelper: NSObject, OpenInHelper {
 
         let expectedSize = download.totalBytesExpected != nil ? ByteCountFormatter.string(fromByteCount: download.totalBytesExpected!, countStyle: .file) : nil
 
-        let filenameItem: PhotonActionSheetItem
+        var filenameItem: PhotonActionSheetItem
         if let expectedSize = expectedSize {
             let expectedSizeAndHost = "\(expectedSize) — \(host)"
             filenameItem = PhotonActionSheetItem(title: download.filename, text: expectedSizeAndHost, iconString: "file", iconAlignment: .right, bold: true)
         } else {
             filenameItem = PhotonActionSheetItem(title: download.filename, text: host, iconString: "file", iconAlignment: .right, bold: true)
+        }
+        filenameItem.customHeight = { _ in
+            return 80
+        }
+        filenameItem.customRender = { label, contentView in
+            label.numberOfLines = 2
+            label.font = DynamicFontHelper.defaultHelper.DeviceFontSmallBold
+            label.lineBreakMode = .byCharWrapping
         }
 
         let downloadFileItem = PhotonActionSheetItem(title: Strings.OpenInDownloadHelperAlertDownloadNow, iconString: "download") { _, _ in


### PR DESCRIPTION
Make the filename two lines (after which it will get cut off instead of shrinking),
and increase the height

See screencap: https://github.com/mozilla-mobile/firefox-ios/issues/5359#issuecomment-523905795

