### PR TITLE
Updated menu item order on iPad to match the one on iPhone

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -20,9 +20,6 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
     private var heightConstraint: Constraint?
     var tableView = UITableView(frame: .zero, style: .grouped)
 
-    // Using a popover (ipad), reverse the order of the actions
-    var autoreverseActions = true
-
     lazy var tapRecognizer: UITapGestureRecognizer = {
         let tapRecognizer = UITapGestureRecognizer()
         tapRecognizer.addTarget(self, action: #selector(dismiss))
@@ -108,9 +105,7 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
         }
 
         if style == .popover {
-            if autoreverseActions {
-                self.actions = actions.map({ $0.reversed() }).reversed()
-            }
+            self.actions = actions.map({ $0 })
             tableView.snp.makeConstraints { make in
                 make.edges.equalTo(self.view)
             }

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -22,7 +22,6 @@ extension PhotonActionSheetProtocol {
     func presentSheetWith(title: String? = nil, actions: [[PhotonActionSheetItem]], on viewController: PresentableVC, from view: UIView, closeButtonTitle: String = Strings.CloseButtonTitle, suppressPopover: Bool = false, autoreverseActions: Bool = true) {
         let style: UIModalPresentationStyle = (UIDevice.current.userInterfaceIdiom == .pad && !suppressPopover) ? .popover : .overCurrentContext
         let sheet = PhotonActionSheet(title: title, actions: actions, closeButtonTitle: closeButtonTitle, style: style)
-        sheet.autoreverseActions = autoreverseActions
         sheet.modalPresentationStyle = style
         sheet.photonTransitionDelegate = PhotonActionSheetAnimator()
         if let account = profile.getAccount(), account.actionNeeded == .none {


### PR DESCRIPTION
Fixes #5356
*Initial issue:*
The menu items on iPad were displayed in reversed order compared to iPhone
*Summary of change:*
The iPad menu items are no longer reversed.