### PR TITLE
Fix #5306 - change top site merging to host and path, Fix #5374 - Removing one top pinned site with different path, but the same host

### DIFF
--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -580,7 +580,7 @@ extension FirefoxHomeViewController: DataObserverDelegate {
 
             // How sites are merged together. We compare against the url's base domain. example m.youtube.com is compared against `youtube.com`
             let unionOnURL = { (site: Site) -> String in
-                return URL(string: site.url)?.normalizedHost ?? ""
+                return URL(string: site.url)?.normalizedHostAndPath ?? ""
             }
 
             // Fetch the default sites

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -398,12 +398,12 @@ extension SQLiteHistory: BrowserHistory {
     }
 
     public func removeFromPinnedTopSites(_ site: Site) -> Success {
-        guard let host = (site.url as String).asURL?.normalizedHost else {
+       guard let guid = site.guid, let host = (site.url as String).asURL?.normalizedHost else {
             return deferMaybe(DatabaseError(description: "Invalid url for site \(site.url)"))
         }
 
         //do a fuzzy delete so dupes can be removed
-        let query: (String, Args?) = ("DELETE FROM pinned_top_sites where domain = ?", [host])
+       let query: (String, Args?) = ("DELETE FROM pinned_top_sites where guid = ?", [guid])
         return db.run([query]) >>== {
             return self.db.run([("UPDATE domains SET showOnTopSites = 1 WHERE domain = ?", [host])])
         }


### PR DESCRIPTION
This bug was reported on https://github.com/mozilla-mobile/firefox-ios/issues/5306 

Issue:
          pinning one top site, overwrites existing top site on the same host 

Solution:
             merging top sites where the host and path are included 

also, Fix #5374 

Issue: 
        when one top pinned site is removed, automatically removes every pinned top site from the     same host

Solution:
           change domain with guid
            


