### PR TITLE
Fix #5363 -  more space needed when no trackers blocked

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -609,7 +609,7 @@ extension Strings {
 
     // TP Page menu title
     public static let TPPageMenuTitle = NSLocalizedString("Menu.TrackingProtection.TitlePrefix", value: "Protections for %@", comment: "Title on tracking protection menu showing the domain. eg. Protections for mozilla.org")
-    public static let TPPageMenuNoTrackersBlocked = NSLocalizedString("Menu.TrackingProtection.NoTrackersBlocked", value: "No trackers blocked for this site.", comment: "Message in menu when no trackers blocked.")
+    public static let TPPageMenuNoTrackersBlocked = NSLocalizedString("Menu.TrackingProtection.NoTrackersBlocked", value: "No trackers blocked for this site", comment: "Message in menu when no trackers blocked.")
     public static let TPPageMenuBlockedTitle = NSLocalizedString("Menu.TrackingProtection.BlockedTitle", value: "Blocked", comment: "Title on tracking protection menu for blocked items.")
 
     // Category Titles

--- a/XCUITests/TrackingProtectionTests.swift
+++ b/XCUITests/TrackingProtectionTests.swift
@@ -7,7 +7,7 @@ import XCTest
 let blockedElementsString = "Firefox is blocking parts of the page that may track your browsing."
 let tpIsDisabledViaToggleString = "Block online trackers"
 let tpIsDisabledString = "The site includes elements that may track your browsing. You have disabled protection."
-let noTrackingElementsString = "No trackers blocked for this site."
+let noTrackingElementsString = "No trackers blocked for this site"
 
 let websiteWithBlockedElements = "twitter.com"
 let websiteWithoutBlockedElements = "wikipedia.com"


### PR DESCRIPTION
Remove dot (.) after the option text

*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Please make sure you've run the test scheme and all the tests pass. If your changes affect existing tests please make sure to update the tests as well.

