### PR TITLE
Fix #5159 - Bookmark Folders are added at the bottom of the list

### DIFF
--- a/Account/Info.plist
+++ b/Account/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.0</string>
+	<string>19.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AccountTests/Info.plist
+++ b/AccountTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.0</string>
+	<string>19.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Client/Frontend/Library/BookmarkDetailPanel.swift
+++ b/Client/Frontend/Library/BookmarkDetailPanel.swift
@@ -61,6 +61,9 @@ class BookmarkDetailPanel: SiteTableViewController {
     }
 
     var isFolderListExpanded = false
+    
+    // Position at which a new node will be inserted
+    var nodeInsertionIndex: Int?
 
     // Array of tuples containing all of the BookmarkFolders
     // along with their indentation depth.
@@ -70,9 +73,10 @@ class BookmarkDetailPanel: SiteTableViewController {
         return Int(floor((view.frame.width - BookmarkDetailPanelUX.MinIndentedContentWidth) / BookmarkDetailPanelUX.IndentationWidth))
     }
 
-    convenience init(profile: Profile, bookmarkNode: BookmarkNode, parentBookmarkFolder: BookmarkFolder) {
+    convenience init(profile: Profile, bookmarkNode: BookmarkNode, parentBookmarkFolder: BookmarkFolder, nodeInsertionIndex: Int? = nil) {
         self.init(profile: profile, bookmarkNodeGUID: bookmarkNode.guid, bookmarkNodeType: bookmarkNode.type, parentBookmarkFolder: parentBookmarkFolder)
 
+        self.nodeInsertionIndex = nodeInsertionIndex
         self.bookmarkItemPosition = bookmarkNode.position
 
         if let bookmarkItem = bookmarkNode as? BookmarkItem {
@@ -87,9 +91,10 @@ class BookmarkDetailPanel: SiteTableViewController {
         }
     }
 
-    convenience init(profile: Profile, withNewBookmarkNodeType bookmarkNodeType: BookmarkNodeType, parentBookmarkFolder: BookmarkFolder) {
+    convenience init(profile: Profile, withNewBookmarkNodeType bookmarkNodeType: BookmarkNodeType, parentBookmarkFolder: BookmarkFolder, nodeInsertionIndex: Int? = nil) {
         self.init(profile: profile, bookmarkNodeGUID: nil, bookmarkNodeType: bookmarkNodeType, parentBookmarkFolder: parentBookmarkFolder)
 
+        self.nodeInsertionIndex = nodeInsertionIndex
         if bookmarkNodeType == .bookmark {
             self.bookmarkItemOrFolderTitle = ""
             self.bookmarkItemURL = ""
@@ -233,7 +238,12 @@ class BookmarkDetailPanel: SiteTableViewController {
                     return deferMaybe(BookmarkDetailPanelError())
                 }
 
-                return profile.places.createFolder(parentGUID: parentBookmarkFolder.guid, title: bookmarkItemOrFolderTitle).bind({ result in
+                //here 'nil' means the node will be inserted in the end of the list
+                var position: UInt32? = nil
+                if let newNodePosition = nodeInsertionIndex {
+                    position = UInt32(newNodePosition)
+                }
+                return profile.places.createFolder(parentGUID: parentBookmarkFolder.guid, title: bookmarkItemOrFolderTitle, position: position).bind({ result in
                     return result.isFailure ? deferMaybe(BookmarkDetailPanelError()) : succeed()
                 })
             }

--- a/Client/Frontend/Library/BookmarksPanel.swift
+++ b/Client/Frontend/Library/BookmarksPanel.swift
@@ -55,7 +55,6 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
     var bookmarkNodes = [BookmarkNode]()
     var recentBookmarks = [BookmarkNode]()
 
-    fileprivate var flashRowOnNextReload = false
     fileprivate var indexPathToFlashOnReload: IndexPath? = nil
 
     fileprivate lazy var bookmarkFolderIconNormal = UIImage(named: "bookmarkFolder")?.createScaled(BookmarksPanelUX.FolderIconSize).tinted(withColor: UIColor.Photon.Grey90)
@@ -119,7 +118,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
                 }
                 
                 self.indexPathToFlashOnReload = IndexPath(row: NewNodeInsertionIndex.folder.rawValue, section: BookmarksSection.bookmarks.rawValue)
-                let detailController = BookmarkDetailPanel(profile: self.profile, withNewBookmarkNodeType: .folder, parentBookmarkFolder: bookmarkFolder, nodeInsertionIndex: NewNodeInsertionIndex.folder.rawValue)
+                let detailController = BookmarkDetailPanel(profile: self.profile, withNewBookmarkNodeType: .folder, parentBookmarkFolder: bookmarkFolder, nodeInsertionIndex: UInt32(NewNodeInsertionIndex.folder.rawValue))
                 self.navigationController?.pushViewController(detailController, animated: true)
             })
 
@@ -191,13 +190,11 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
                 self.recentBookmarks = []
                 self.tableView.reloadData()
             }
-
-            if self.flashRowOnNextReload {
-                self.flashRowOnNextReload = false
-
+            
+            if let indexPath = self.indexPathToFlashOnReload {
+                self.indexPathToFlashOnReload = nil
                 DispatchQueue.main.asyncAfter(deadline: .now() + BookmarksPanelUX.RowFlashDelay) {
-                    self.flashRow(at: self.indexPathToFlashOnReload ??
-                        IndexPath(row: self.bookmarkNodes.count - 1, section: BookmarksSection.bookmarks.rawValue))
+                    self.flashRow(at: indexPath)
                 }
             }
         }
@@ -278,10 +275,6 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
                 self.tableView.deselectRow(at: indexPath, animated: true)
             }
         }
-    }
-
-    func didAddBookmarkNode() {
-        flashRowOnNextReload = true
     }
 
     @objc fileprivate func didLongPressTableView(_ longPressGestureRecognizer: UILongPressGestureRecognizer) {

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -35,7 +35,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.0</string>
+	<string>19.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/ClientTests/Info.plist
+++ b/ClientTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.0</string>
+	<string>19.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Extensions/NotificationService/Info.plist
+++ b/Extensions/NotificationService/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.0</string>
+	<string>19.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSExtension</key>

--- a/Extensions/ShareTo/Info.plist
+++ b/Extensions/ShareTo/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.0</string>
+	<string>19.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Extensions/Today/Info.plist
+++ b/Extensions/Today/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.0</string>
+	<string>19.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/L10nSnapshotTests/Info.plist
+++ b/L10nSnapshotTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.0</string>
+	<string>19.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/MarketingUITests/Info.plist
+++ b/MarketingUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.0</string>
+	<string>19.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Shared/Supporting Files/Info.plist
+++ b/Shared/Supporting Files/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.0</string>
+	<string>19.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/SharedTests/Info.plist
+++ b/SharedTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.0</string>
+	<string>19.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Storage/Info.plist
+++ b/Storage/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.0</string>
+	<string>19.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/StoragePerfTests/Info.plist
+++ b/StoragePerfTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.0</string>
+	<string>19.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/StorageTests/Info.plist
+++ b/StorageTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.0</string>
+	<string>19.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Sync/Info.plist
+++ b/Sync/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.0</string>
+	<string>19.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/SyncTelemetry/Info.plist
+++ b/SyncTelemetry/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.0</string>
+	<string>19.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/SyncTelemetryTests/Info.plist
+++ b/SyncTelemetryTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.0</string>
+	<string>19.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/SyncTests/Info.plist
+++ b/SyncTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.0</string>
+	<string>19.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/UITests/Info.plist
+++ b/UITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.0</string>
+	<string>19.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/XCUITests/Info.plist
+++ b/XCUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.0</string>
+	<string>19.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Fixes #5159 

Folders are now added at the top while bookmarks and separators are added as usual. The appropriate row is highlighted when tableView is reloaded.

![folder](https://user-images.githubusercontent.com/168651/63732451-0e6cf680-c87d-11e9-92fd-1f4bfd46c19b.gif)
