### PR TITLE
QR code scanner accessibility label

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -133,7 +133,7 @@ class URLBarView: UIView {
         let button = InsetButton()
         button.setImage(UIImage.templateImageNamed("menu-ScanQRCode"), for: .normal)
         button.accessibilityIdentifier = "urlBar-scanQRCode"
-        cancelButton.accessibilityLabel = Strings.ScanQRCodeViewTitle
+        button.accessibilityLabel = Strings.ScanQRCodeViewTitle
         button.clipsToBounds = false
         button.addTarget(self, action: #selector(showQRScanner), for: .touchUpInside)
         button.setContentHuggingPriority(UILayoutPriority(rawValue: 1000), for: .horizontal)


### PR DESCRIPTION
It was probably a mistake introduced by https://github.com/mozilla-mobile/firefox-ios/commit/bcb06cbebfc571bd48ba8b0430f588b4e084ce94

