### PR TITLE
Revert "Fix #5306 - change top site merging to host and path, Fix #5374 - Removing one top pinned site with different path, but the same host"

### DIFF
--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -580,7 +580,7 @@ extension FirefoxHomeViewController: DataObserverDelegate {
 
             // How sites are merged together. We compare against the url's base domain. example m.youtube.com is compared against `youtube.com`
             let unionOnURL = { (site: Site) -> String in
-                return URL(string: site.url)?.normalizedHostAndPath ?? ""
+                return URL(string: site.url)?.normalizedHost ?? ""
             }
 
             // Fetch the default sites

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -398,12 +398,12 @@ extension SQLiteHistory: BrowserHistory {
     }
 
     public func removeFromPinnedTopSites(_ site: Site) -> Success {
-       guard let guid = site.guid, let host = (site.url as String).asURL?.normalizedHost else {
+        guard let host = (site.url as String).asURL?.normalizedHost else {
             return deferMaybe(DatabaseError(description: "Invalid url for site \(site.url)"))
         }
 
         //do a fuzzy delete so dupes can be removed
-       let query: (String, Args?) = ("DELETE FROM pinned_top_sites where guid = ?", [guid])
+        let query: (String, Args?) = ("DELETE FROM pinned_top_sites where domain = ?", [host])
         return db.run([query]) >>== {
             return self.db.run([("UPDATE domains SET showOnTopSites = 1 WHERE domain = ?", [host])])
         }


### PR DESCRIPTION
Reverts mozilla-mobile/firefox-ios#5373