### PR TITLE
Issue #4704 - Audit Settings table view cell border thicknesses

### DIFF
--- a/Client/Frontend/AuthenticationManager/RequirePasscodeIntervalViewController.swift
+++ b/Client/Frontend/AuthenticationManager/RequirePasscodeIntervalViewController.swift
@@ -39,12 +39,10 @@ class RequirePasscodeIntervalViewController: UITableViewController {
 
         let headerFooterFrame = CGRect(width: self.view.frame.width, height: SettingsUX.TableViewHeaderFooterHeight)
         let headerView = ThemedTableSectionHeaderFooterView(frame: headerFooterFrame)
-        headerView.showTopBorder = false
         headerView.showBottomBorder = true
 
         let footerView = ThemedTableSectionHeaderFooterView(frame: headerFooterFrame)
         footerView.showTopBorder = true
-        footerView.showBottomBorder = false
 
         tableView.tableHeaderView = headerView
         tableView.tableFooterView = footerView

--- a/Client/Frontend/Browser/OpenWithSettingsViewController.swift
+++ b/Client/Frontend/Browser/OpenWithSettingsViewController.swift
@@ -30,12 +30,7 @@ class OpenWithSettingsViewController: ThemedTableViewController {
         let headerFooterFrame = CGRect(width: self.view.frame.width, height: SettingsUX.TableViewHeaderFooterHeight)
         let headerView = ThemedTableSectionHeaderFooterView(frame: headerFooterFrame)
         headerView.titleLabel.text = Strings.SettingsOpenWithPageTitle.uppercased()
-        headerView.showTopBorder = false
-        headerView.showBottomBorder = true
-
         let footerView = ThemedTableSectionHeaderFooterView(frame: headerFooterFrame)
-        footerView.showTopBorder = false
-        footerView.showBottomBorder = false
 
         tableView.tableHeaderView = headerView
         tableView.tableFooterView = footerView

--- a/Client/Frontend/Library/BookmarksPanel.swift
+++ b/Client/Frontend/Library/BookmarksPanel.swift
@@ -414,6 +414,8 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
         }
 
         headerView.titleLabel.text = Strings.RecentlyBookmarkedTitle.uppercased()
+        headerView.showTopBorder = true
+        headerView.showBottomBorder = true
 
         return headerView
     }

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -380,7 +380,9 @@ extension LoginListViewController: UITableViewDelegate {
             return nil
         }
         headerView.titleLabel.text = Strings.LoginsListTitle
-        headerView.showTopBorder = false
+        // not using a grouped table: show header borders
+        headerView.showTopBorder = true
+        headerView.showBottomBorder = true
         headerView.applyTheme()
         return headerView
     }
@@ -555,12 +557,10 @@ class LoginDataSource: NSObject, UITableViewDataSource {
     @objc func numberOfSections(in tableView: UITableView) -> Int {
         if  loginRecordSections.isEmpty {
             tableView.backgroundView = emptyStateView
-            tableView.separatorStyle = .none
             return 1
         }
 
         tableView.backgroundView = nil
-        tableView.separatorStyle = .singleLine
         // Add one section for the settings section.
         return loginRecordSections.count + 1
     }

--- a/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
+++ b/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
@@ -199,11 +199,9 @@ class AdvancedAccountSettingViewController: SettingsTableViewController {
         headerView.titleLabel.text = sectionSetting.title?.string
 
         switch section {
-        // Hide the bottom border for the FxA custom server notes.
         case 1, 3:
             headerView.titleAlignment = .top
             headerView.titleLabel.numberOfLines = 0
-            headerView.showBottomBorder = false
         default:
             return super.tableView(tableView, viewForHeaderInSection: section)
         }

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -146,15 +146,6 @@ class AppSettingsTableViewController: SettingsTableViewController {
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let headerView = super.tableView(tableView, viewForHeaderInSection: section) as! ThemedTableSectionHeaderFooterView
-        // Prevent the top border from showing for the General section.
-        if !profile.hasAccount() {
-            switch section {
-                case 1:
-                    headerView.showTopBorder = false
-            default:
-                break
-            }
-        }
         return headerView
     }
 }

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -64,8 +64,6 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
         tableView.register(ThemedTableSectionHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: SectionHeaderFooterIdentifier)
 
         let footer = ThemedTableSectionHeaderFooterView(frame: CGRect(width: tableView.bounds.width, height: SettingsUX.TableViewHeaderFooterHeight))
-        footer.showBottomBorder = false
-        footer.showTopBorder = false
         tableView.tableFooterView = footer
     }
 
@@ -180,7 +178,6 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: SectionHeaderFooterIdentifier) as? ThemedTableSectionHeaderFooterView
-        headerView?.showTopBorder = false
         var sectionTitle: String?
         if section == SectionToggles {
             sectionTitle = Strings.SettingsClearPrivateDataTitle

--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -78,7 +78,7 @@ class TPAccessoryInfo: ThemedTableViewController {
 
         sep.backgroundColor = UIColor.theme.tableView.separator
         sep.snp.makeConstraints { make in
-            make.height.equalTo(1)
+            make.height.equalTo(0.5)
             make.width.equalToSuperview()
         }
         return topStack
@@ -155,7 +155,6 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
         super.init(style: .grouped)
 
         self.title = Strings.SettingsTrackingProtectionSectionName
-        hasSectionSeparatorLine = false
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Settings/HomePageSettingViewController.swift
+++ b/Client/Frontend/Settings/HomePageSettingViewController.swift
@@ -16,7 +16,6 @@ class HomePageSettingViewController: SettingsTableViewController {
         super.init(style: .grouped)
 
         self.title = Strings.AppMenuOpenHomePageTitleString
-        hasSectionSeparatorLine = false
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -100,7 +99,6 @@ class TopSitesRowCountSettingsController: SettingsTableViewController {
         numberOfRows = self.prefs.intForKey(PrefsKeys.NumberOfTopSiteRows) ?? TopSitesRowCountSettingsController.defaultNumberOfRows
         super.init(style: .grouped)
         self.title = Strings.AppMenuTopSitesTitleString
-        hasSectionSeparatorLine = false
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -94,11 +94,6 @@ class LoginDetailViewController: SensitiveViewController {
         // Add empty footer view to prevent seperators from being drawn past the last item.
         tableView.tableFooterView = UIView()
 
-        // Add a line on top of the table view so when the user pulls down it looks 'correct'.
-        let topLine = UIView(frame: CGRect(width: tableView.frame.width, height: 0.5))
-        topLine.backgroundColor = UIColor.theme.tableView.separator
-        tableView.tableHeaderView = topLine
-
         // Normally UITableViewControllers handle responding to content inset changes from keyboard events when editing
         // but since we don't use the tableView's editing flag for editing we handle this ourselves.
         KeyboardHelper.defaultHelper.addDelegate(self)

--- a/Client/Frontend/Settings/NewTabContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/NewTabContentSettingsViewController.swift
@@ -16,7 +16,6 @@ class NewTabContentSettingsViewController: SettingsTableViewController {
         super.init(style: .grouped)
 
         self.title = Strings.SettingsNewTabTitle
-        hasSectionSeparatorLine = false
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -218,7 +218,6 @@ class SearchSettingsTableViewController: ThemedTableViewController {
             return nil
         }
 
-        footerView.showBottomBorder = false
         footerView.applyTheme()
         return footerView
     }

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -587,8 +587,6 @@ class SettingsTableViewController: ThemedTableViewController {
     var profile: Profile!
     var tabManager: TabManager!
 
-    var hasSectionSeparatorLine = true
-
     /// Used to calculate cell heights.
     fileprivate lazy var dummyToggleCell: UITableViewCell = {
         let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "dummyCell")
@@ -707,12 +705,6 @@ class SettingsTableViewController: ThemedTableViewController {
         if let sectionTitle = sectionSetting.title?.string {
             headerView.titleLabel.text = sectionTitle.uppercased()
         }
-        // Hide the top border for the top section to avoid having a double line at the top
-        if section == 0 || !hasSectionSeparatorLine {
-            headerView.showTopBorder = false
-        } else {
-            headerView.showTopBorder = true
-        }
 
         headerView.applyTheme()
         return headerView
@@ -726,7 +718,6 @@ class SettingsTableViewController: ThemedTableViewController {
         let footerView = ThemedTableSectionHeaderFooterView()
         footerView.titleLabel.text = sectionFooter
         footerView.titleAlignment = .top
-        footerView.showBottomBorder = false
         footerView.applyTheme()
         return footerView
     }

--- a/Client/Frontend/Settings/SiriSettingsViewController.swift
+++ b/Client/Frontend/Settings/SiriSettingsViewController.swift
@@ -16,7 +16,6 @@ class SiriSettingsViewController: SettingsTableViewController {
         super.init(style: .grouped)
 
         self.title = Strings.SettingsSiriSectionName
-        hasSectionSeparatorLine = false
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -119,7 +119,6 @@ class SyncContentSettingsViewController: SettingsTableViewController {
         super.init(style: .grouped)
 
         self.title = Strings.FxASettingsTitle
-        hasSectionSeparatorLine = false
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Settings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettingsController.swift
@@ -45,8 +45,6 @@ class ThemeSettingsController: ThemedTableViewController {
 
         let headerFooterFrame = CGRect(width: self.view.frame.width, height: SettingsUX.TableViewHeaderFooterHeight)
         let headerView = ThemedTableSectionHeaderFooterView(frame: headerFooterFrame)
-        headerView.showTopBorder = false
-        headerView.showBottomBorder = true
         tableView.tableHeaderView = headerView
         headerView.titleLabel.text = Strings.DisplayThemeSectionHeader
 

--- a/Client/Frontend/Settings/TranslationSettingsController.swift
+++ b/Client/Frontend/Settings/TranslationSettingsController.swift
@@ -37,8 +37,6 @@ class TranslationSettingsController: ThemedTableViewController {
 
         let headerFooterFrame = CGRect(width: self.view.frame.width, height: SettingsUX.TableViewHeaderFooterHeight)
         let headerView = ThemedTableSectionHeaderFooterView(frame: headerFooterFrame)
-        headerView.showTopBorder = false
-        headerView.showBottomBorder = true
         tableView.tableHeaderView = headerView
         headerView.titleLabel.text = Strings.SettingTranslateSnackBarSectionHeader
     }

--- a/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
@@ -43,7 +43,7 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
         tableView.register(ThemedTableSectionHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: SectionHeaderFooterIdentifier)
 
         let footer = ThemedTableSectionHeaderFooterView(frame: CGRect(width: tableView.bounds.width, height: SettingsUX.TableViewHeaderFooterHeight))
-        footer.showBottomBorder = false
+        footer.showTopBorder = true
         tableView.tableFooterView = footer
 
         view.addSubview(tableView)
@@ -177,7 +177,21 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: SectionHeaderFooterIdentifier) as? ThemedTableSectionHeaderFooterView
         headerView?.titleLabel.text = section == Section.sites.rawValue ? Strings.SettingsWebsiteDataTitle : nil
-        headerView?.showBottomBorder = false
+
+        headerView?.showTopBorder = true
+        headerView?.showBottomBorder = true
+
+        // top section: no top border (this is a plain table)
+        guard let section = Section(rawValue: section) else { return headerView }
+        if section == .sites {
+            headerView?.showTopBorder = false
+
+            // no records: no bottom border (would make 2 with the one from the clear button)
+            let emptyRecords = siteRecords?.isEmpty ?? true
+            if emptyRecords {
+                headerView?.showBottomBorder = false
+            }
+        }
         return headerView
     }
 
@@ -195,7 +209,8 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
 
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         let footerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: SectionHeaderFooterIdentifier) as? ThemedTableSectionHeaderFooterView
-        footerView?.showBottomBorder = false
+        footerView?.showTopBorder = true
+        footerView?.showBottomBorder = true
         return footerView
     }
 

--- a/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
@@ -29,7 +29,7 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
         view.addSubview(tableView)
 
         let footer = ThemedTableSectionHeaderFooterView(frame: CGRect(width: tableView.bounds.width, height: SettingsUX.TableViewHeaderFooterHeight))
-        footer.showBottomBorder = false
+        footer.showTopBorder = true
         tableView.tableFooterView = footer
 
         tableView.snp.makeConstraints { make in
@@ -64,6 +64,8 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: SectionHeaderFooterIdentifier) as? ThemedTableSectionHeaderFooterView
         headerView?.titleLabel.text = Strings.SettingsWebsiteDataTitle
+        headerView?.showTopBorder = section != 0
+        headerView?.showBottomBorder = true
         return headerView
     }
 

--- a/Client/Frontend/Theme/ThemedWidgets.swift
+++ b/Client/Frontend/Theme/ThemedWidgets.swift
@@ -70,13 +70,13 @@ class ThemedTableSectionHeaderFooterView: UITableViewHeaderFooterView, Themeable
         }
     }
 
-    var showTopBorder: Bool = true {
+    var showTopBorder: Bool = false {
         didSet {
             topBorder.isHidden = !showTopBorder
         }
     }
 
-    var showBottomBorder: Bool = true {
+    var showBottomBorder: Bool = false {
         didSet {
             bottomBorder.isHidden = !showBottomBorder
         }
@@ -91,7 +91,7 @@ class ThemedTableSectionHeaderFooterView: UITableViewHeaderFooterView, Themeable
 
     fileprivate lazy var topBorder: UIView = {
         let topBorder = UIView()
-       return topBorder
+        return topBorder
     }()
 
     fileprivate lazy var bottomBorder: UIView = {
@@ -104,6 +104,7 @@ class ThemedTableSectionHeaderFooterView: UITableViewHeaderFooterView, Themeable
         addSubview(titleLabel)
         addSubview(topBorder)
         addSubview(bottomBorder)
+        setDefaultBordersValues()
         setupInitialConstraints()
         applyTheme()
     }
@@ -127,16 +128,20 @@ class ThemedTableSectionHeaderFooterView: UITableViewHeaderFooterView, Themeable
 
         topBorder.snp.makeConstraints { make in
             make.top.left.right.equalTo(self)
-            make.height.equalTo(0.5)
+            make.height.equalTo(0.25)
         }
 
         remakeTitleAlignmentConstraints()
     }
 
+    func setDefaultBordersValues() {
+        showTopBorder = false
+        showBottomBorder = false
+    }
+
     override func prepareForReuse() {
         super.prepareForReuse()
-        showTopBorder = true
-        showBottomBorder = true
+        setDefaultBordersValues()
         titleLabel.text = nil
         titleAlignment = .bottom
 


### PR DESCRIPTION
Before / after screenshots will follow in the next post.

Went through all tables, corrected the border thicknesses, occasionally added missing borders.

As most settings screens use a grouped table, which does not need borders in the headers, switched showTop/BottomBorder to false by default in ThemedTableSectionHeaderFooterView.

A few things that were noted along the way, that might be considered as a basis to new issues:
- Login & passwords and Login details borders width do not go all the way to the left for the first and last cell. The Data management screen does it correctly.
- Both reading list and download panels have issues with switching themes. To reproduce, in day mode, open reading list and / or download panel, then switch to night mode and reopen the panels: they are part day / part night themed.

Also, got carried away at some point and worked on the Library tables (bookmarks, history, etc) as well, until realizing issue concerned tables from Settings only. Library tables are *not* included in this commit as to respect the issue scope. Should you want those corrections though, as part of of a new issue for instance, the changes and before / after screenshots can be made available.