### PR TITLE
Issue #5375 Add a Tab Sent notification

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -225,7 +225,7 @@ extension PhotonActionSheetProtocol {
             devicePickerViewController.profileNeedsShutdown = false
             let navigationController = UINavigationController(rootViewController: devicePickerViewController)
             navigationController.modalPresentationStyle = .formSheet
-            bvc.present(navigationController, animated: true, completion: nil)
+            bvc.present(navigationController, animated: true, completion: {success(Strings.AppMenuTabSentConfirmMessage)})
         }
 
         let sharePage = PhotonActionSheetItem(title: Strings.AppMenuSharePageTitleString, iconString: "action_share") { _, _ in


### PR DESCRIPTION

![Simulator Screen Shot - iPhone Xʀ - 2019-09-04 at 21 00 59](https://user-images.githubusercontent.com/409132/64306213-9c20a400-cf57-11e9-9118-46f069005789.png)

I have added a tab sent notification when the user successfully sends a tab to another device.

