### PR TITLE
Fix #4730 - Settings for New Tab and Home: deselecting Custom URL should not clear it

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -358,8 +358,10 @@ class StringSetting: Setting, UITextFieldDelegate {
             make.trailing.equalTo(cell.contentView).offset(-Padding)
             make.leading.equalTo(cell.contentView).offset(Padding)
         }
-        textField.text = self.persister.readPersistedValue() ?? defaultValue
-        textFieldDidChange(textField)
+        if let value = self.persister.readPersistedValue() {
+            textField.text = value
+            textFieldDidChange(textField)
+        }
     }
 
     override func onClick(_ navigationController: UINavigationController?) {


### PR DESCRIPTION
Fixes #4730

It's not clear if we should save url when user unchecks the url and then leaves the screen, but this is the formal fix for the STR: url is unchecked, but it remains in place. Only if user unchecks the url and then taps "Back", the url is removed.


![ezgif-1-1b4bf96c09ae](https://user-images.githubusercontent.com/168651/64481026-7ce67880-d1dc-11e9-92ed-fc18114328b0.gif)
