### PR TITLE
Fix# 5430 - Twitter breaks with strict ETP on

### DIFF
--- a/content-blocker-lib-ios/build-disconnect.py
+++ b/content-blocker-lib-ios/build-disconnect.py
@@ -35,8 +35,6 @@ def create_blocklist_entry(resource, related_domains):
                         "load-type": ["third-party"]},
             "action": {"type": action }}
 
-    # remove this property from the list of related domains
-    related_domains = filter(lambda a: a not in resource, related_domains)
     if len(related_domains) > 0:
         result["trigger"]["unless-domain"] = unless_domain(related_domains)
     return result

--- a/content-blocker-lib-ios/src/ContentBlocker.swift
+++ b/content-blocker-lib-ios/src/ContentBlocker.swift
@@ -220,7 +220,13 @@ extension ContentBlocker {
     // remove all the content blockers and reload them.
     func removeOldListsByDateFromStore(completion: @escaping () -> Void) {
 
-        guard let fileDate = dateOfMostRecentBlockerFile(), let prefsNewestDate = UserDefaults.standard.object(forKey: "blocker-file-date") as? Date else {
+            guard let fileDate = dateOfMostRecentBlockerFile() else {
+            completion()
+            return
+        }
+
+        guard let prefsNewestDate = UserDefaults.standard.object(forKey: "blocker-file-date") as? Date else {
+            UserDefaults.standard.set(fileDate, forKey: "blocker-file-date")
             completion()
             return
         }
@@ -231,6 +237,7 @@ extension ContentBlocker {
         }
 
         UserDefaults.standard.set(fileDate, forKey: "blocker-file-date")
+
         removeAllRulesInStore() {
             completion()
         }


### PR DESCRIPTION
It looks like the domain being blocked must also be in the `unless domains` section for it to be excluded when it is a first party domain. 