### PR TITLE
increase PhotonActionSheetTitleHeaderView padding

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetWidgets.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetWidgets.swift
@@ -98,7 +98,7 @@ public struct PhotonActionSheetItem {
 }
 
 class PhotonActionSheetTitleHeaderView: UITableViewHeaderFooterView {
-    static let Padding: CGFloat = 12
+    static let Padding: CGFloat = 16
 
     lazy var titleLabel: UILabel = {
         let titleLabel = UILabel()


### PR DESCRIPTION
Fixes issue #5390 

The title of the photon action sheet now lines up with the content.