### PR TITLE
Fix #4730 - Settings for New Tab and Home: deselecting Custom URL should not clear it

### DIFF
--- a/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
+++ b/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
@@ -230,7 +230,7 @@ class CustomSyncTokenServerEnableSetting: BoolSetting {
 }
 
 class CustomURLSetting: WebPageSetting {
-    override init(prefs: Prefs, prefKey: String, defaultValue: String? = nil, placeholder: String, accessibilityIdentifier: String, settingDidChange: ((String?) -> Void)? = nil) {
+    override init(prefs: Prefs, prefKey: String, defaultValue: String? = nil, placeholder: String, accessibilityIdentifier: String, isChecked: @escaping () -> Bool = { return false }, settingDidChange: ((String?) -> Void)? = nil) {
         super.init(prefs: prefs,
                    prefKey: prefKey,
                    defaultValue: defaultValue,

--- a/Client/Frontend/Settings/HomePageSettingViewController.swift
+++ b/Client/Frontend/Settings/HomePageSettingViewController.swift
@@ -28,7 +28,6 @@ class HomePageSettingViewController: SettingsTableViewController {
         self.hasHomePage = HomeButtonHomePageAccessors.getHomePage(self.prefs) != nil
 
         let onFinished = {
-            self.prefs.removeObjectForKey(PrefsKeys.HomeButtonHomePageURL)
             self.prefs.setString(self.currentChoice.rawValue, forKey: NewTabAccessors.HomePrefKey)
             self.tableView.reloadData()
         }
@@ -37,7 +36,7 @@ class HomePageSettingViewController: SettingsTableViewController {
             self.currentChoice = NewTabPage.topSites
             onFinished()
         })
-        let showWebPage = WebPageSetting(prefs: prefs, prefKey: PrefsKeys.HomeButtonHomePageURL, defaultValue: nil, placeholder: Strings.CustomNewPageURL, accessibilityIdentifier: "HomeAsCustomURL", settingDidChange: { (string) in
+        let showWebPage = WebPageSetting(prefs: prefs, prefKey: PrefsKeys.HomeButtonHomePageURL, defaultValue: nil, placeholder: Strings.CustomNewPageURL, accessibilityIdentifier: "HomeAsCustomURL", isChecked: {return !showTopSites.isChecked()}, settingDidChange: { (string) in
             self.currentChoice = NewTabPage.homePage
             self.prefs.setString(self.currentChoice.rawValue, forKey: NewTabAccessors.HomePrefKey)
             self.tableView.reloadData()

--- a/Client/Frontend/Settings/NewTabContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/NewTabContentSettingsViewController.swift
@@ -28,7 +28,6 @@ class NewTabContentSettingsViewController: SettingsTableViewController {
 
         let onFinished = {
             self.prefs.setString(self.currentChoice.rawValue, forKey: NewTabAccessors.NewTabPrefKey)
-            self.prefs.removeObjectForKey(HomePageConstants.NewTabCustomUrlPrefKey)
             self.tableView.reloadData()
         }
 
@@ -40,7 +39,7 @@ class NewTabContentSettingsViewController: SettingsTableViewController {
             self.currentChoice = NewTabPage.blankPage
             onFinished()
         })
-        let showWebPage = WebPageSetting(prefs: prefs, prefKey: HomePageConstants.NewTabCustomUrlPrefKey, defaultValue: nil, placeholder: Strings.CustomNewPageURL, accessibilityIdentifier: "NewTabAsCustomURL", settingDidChange: { (string) in
+        let showWebPage = WebPageSetting(prefs: prefs, prefKey: HomePageConstants.NewTabCustomUrlPrefKey, defaultValue: nil, placeholder: Strings.CustomNewPageURL, accessibilityIdentifier: "NewTabAsCustomURL", isChecked: {return !showTopSites.isChecked() && !showBlankPage.isChecked()}, settingDidChange: { (string) in
             self.currentChoice = NewTabPage.homePage
             self.prefs.setString(self.currentChoice.rawValue, forKey: NewTabAccessors.NewTabPrefKey)
             self.tableView.reloadData()

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -269,7 +269,10 @@ class StringPrefSetting: StringSetting {
 }
 
 class WebPageSetting: StringPrefSetting {
-    init(prefs: Prefs, prefKey: String, defaultValue: String? = nil, placeholder: String, accessibilityIdentifier: String, settingDidChange: ((String?) -> Void)? = nil) {
+    let isChecked: () -> Bool
+
+    init(prefs: Prefs, prefKey: String, defaultValue: String? = nil, placeholder: String, accessibilityIdentifier: String, isChecked: @escaping () -> Bool = { return false }, settingDidChange: ((String?) -> Void)? = nil) {
+        self.isChecked = isChecked
         super.init(prefs: prefs,
                    prefKey: prefKey,
                    defaultValue: defaultValue,
@@ -291,7 +294,7 @@ class WebPageSetting: StringPrefSetting {
 
     override func onConfigureCell(_ cell: UITableViewCell) {
         super.onConfigureCell(cell)
-        cell.accessoryType = .checkmark
+        cell.accessoryType = isChecked() ? .checkmark : .none
         textField.textAlignment = .left
     }
 


### PR DESCRIPTION
Fixes #4730. Now URL is always preserved until removed on purpose