### PR TITLE
Changed Youtube URL to https

### DIFF
--- a/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -149,7 +149,7 @@ class CustomSearchViewController: SettingsTableViewController {
 
         let settings: [SettingSection] = [
             SettingSection(title: NSAttributedString(string: Strings.SettingsAddCustomEngineTitleLabel), children: [titleField]),
-            SettingSection(title: NSAttributedString(string: Strings.SettingsAddCustomEngineURLLabel), footerTitle: NSAttributedString(string: "http://youtube.com/search?q=%s"), children: [urlField])
+            SettingSection(title: NSAttributedString(string: Strings.SettingsAddCustomEngineURLLabel), footerTitle: NSAttributedString(string: "https://youtube.com/search?q=%s"), children: [urlField])
         ]
 
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .save, target: self, action: #selector(self.addCustomSearchEngine))

--- a/XCUITests/SearchSettingsUITest.swift
+++ b/XCUITests/SearchSettingsUITest.swift
@@ -6,7 +6,7 @@ import XCTest
 
 let defaultSearchEngine1 = "Google"
 let defaultSearchEngine2 = "Amazon.com"
-let customSearchEngine = ["name": "youtube", "url": "http://youtube.com/search?q=%s"]
+let customSearchEngine = ["name": "youtube", "url": "https://youtube.com/search?q=%s"]
 
 class SearchSettingsUITests: BaseTestCase {
     func testDefaultSearchEngine() {


### PR DESCRIPTION
On the custom search engine page, it gives Youtube as an example. The URL begins with http, but it would be better if it began with https, so I changed it. Extremely minor fix.