### PR TITLE
Fix #5462 - XCUITest updated TP test with no blocked elements

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheet/TrackingProtectionMenu.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/TrackingProtectionMenu.swift
@@ -229,6 +229,7 @@ extension PhotonActionSheetProtocol {
                 l.textAlignment = .center
                 l.textColor = UIColor.theme.tableView.headerTextLight
                 l.text = Strings.TPPageMenuNoTrackersBlocked
+                l.accessibilityIdentifier = "tp.no-trackers-blocked"
                 contentView.addSubview(l)
                 l.snp.makeConstraints { make in
                     make.center.equalToSuperview()

--- a/XCUITests/TrackingProtectionTests.swift
+++ b/XCUITests/TrackingProtectionTests.swift
@@ -7,7 +7,7 @@ import XCTest
 let blockedElementsString = "Firefox is blocking parts of the page that may track your browsing."
 let tpIsDisabledViaToggleString = "Block online trackers"
 let tpIsDisabledString = "The site includes elements that may track your browsing. You have disabled protection."
-let noTrackingElementsString = "No trackers blocked for this site."
+let noTrackingElementsString = "tp.no-trackers-blocked"
 
 let websiteWithBlockedElements = "twitter.com"
 let websiteWithoutBlockedElements = "wikipedia.com"


### PR DESCRIPTION
PR to fix #5462 by adding an Acc.ID for the string changed and modifying the test to use it.
