### PR TITLE
Bug 1296636 followup - Bookmarklets with quoting not working

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -215,14 +215,13 @@ extension BrowserViewController: WKNavigationDelegate {
 
         if url.scheme == "javascript", navigationAction.request.isPrivileged {
             decisionHandler(.cancel)
-            if let javaScriptString = url.absoluteString.replaceFirstOccurrence(of: "javascript:", with: "").removingPercentEncoding {
+            if var javaScriptString = url.absoluteString.replaceFirstOccurrence(of: "javascript:", with: "").removingPercentEncoding {
                 // iOS keyboards do automatic fancy quoting, replace with regular quotes.
                 // These open/end characters appear the same in the editor, but they are not.
-                var js = javaScriptString.replacingOccurrences(of: "‘", with: "'") // open single quote
-                    .replacingOccurrences(of: "’", with: "'") // end single quote
-                    .replacingOccurrences(of: "“", with: "'") // open quote
-                    .replacingOccurrences(of: "”", with: "'") // end quote
-                webView.evaluateJavaScript(js)
+                [("‘", "'"), ( "’", "'"), ("“", "\""), ("”", "\"")].forEach {
+                    javaScriptString = javaScriptString.replacingOccurrences(of: $0, with: $1)
+                }
+                webView.evaluateJavaScript(javaScriptString)
             }
             return
         }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -216,7 +216,13 @@ extension BrowserViewController: WKNavigationDelegate {
         if url.scheme == "javascript", navigationAction.request.isPrivileged {
             decisionHandler(.cancel)
             if let javaScriptString = url.absoluteString.replaceFirstOccurrence(of: "javascript:", with: "").removingPercentEncoding {
-                webView.evaluateJavaScript(javaScriptString)
+                // iOS keyboards do automatic fancy quoting, replace with regular quotes.
+                // These open/end characters appear the same in the editor, but they are not.
+                var js = javaScriptString.replacingOccurrences(of: "‘", with: "'") // open single quote
+                    .replacingOccurrences(of: "’", with: "'") // end single quote
+                    .replacingOccurrences(of: "“", with: "'") // open quote
+                    .replacingOccurrences(of: "”", with: "'") // end quote
+                webView.evaluateJavaScript(js)
             }
             return
         }


### PR DESCRIPTION
This is a follow-up to https://bugzilla.mozilla.org/show_bug.cgi?id=1296636
If the bookmarklet has a quote, iOS may have replaced it with a fancy quote.

