### PR TITLE
Fix Bug 1584757 - Update mozilla/application-services version in Cartfile

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -16,7 +16,7 @@ github "Leanplum/Leanplum-iOS-SDK"          ~> 2.6.0
 github "mozilla-services/shavar-prod-lists" "master"
 
 # Use release version of application-services
-github "mozilla/application-services"      "v0.32.3"
+github "mozilla/application-services"      "v0.40.0"
 
 # Use interim binary version of application-services
 # binary "https://circleci.com/api/v1.1/project/github/mozilla/application-services/2862/artifacts/0/dist/mozilla.app-services.json" ~> 0.0.1-snapshot # mozilla/application-services@fb5c540e99133980911216055425688f22a27be2


### PR DESCRIPTION
Fixes [Bug 1584757](https://bugzilla.mozilla.org/show_bug.cgi?id=1584757)
This patch upgrades the version of `mozilla/application-services` dependency in Cartfile, so it supports the machines with Swift 5.1.