### PR TITLE
Fix #5476 - Support switching to opposite UA for iPad and iPhone

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -336,6 +336,7 @@
 		C4EFEECF1CEBB6F2009762A4 /* BackForwardTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4EFEECE1CEBB6F2009762A4 /* BackForwardTableViewCell.swift */; };
 		C4F3B29A1CFCF93A00966259 /* ButtonToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F3B2991CFCF93A00966259 /* ButtonToast.swift */; };
 		C817B34D1FC609500086018E /* UIScrollViewSwizzled.swift in Sources */ = {isa = PBXBuildFile; fileRef = C817B34C1FC609500086018E /* UIScrollViewSwizzled.swift */; };
+		C82CDD47233E8996002E2743 /* Tab+ChangeUserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82CDD45233E8996002E2743 /* Tab+ChangeUserAgent.swift */; };
 		C8399D9122DE5E5200EFA5CA /* disconnect-block-advertising.json in Resources */ = {isa = PBXBuildFile; fileRef = C8399D8F22DE5E5200EFA5CA /* disconnect-block-advertising.json */; };
 		C8399D9322DE5E5B00EFA5CA /* disconnect-block-analytics.json in Resources */ = {isa = PBXBuildFile; fileRef = C8399D9222DE5E5B00EFA5CA /* disconnect-block-analytics.json */; };
 		C8399D9522DE5E6200EFA5CA /* disconnect-block-social.json in Resources */ = {isa = PBXBuildFile; fileRef = C8399D9422DE5E6200EFA5CA /* disconnect-block-social.json */; };
@@ -1463,6 +1464,7 @@
 		C4EFEECE1CEBB6F2009762A4 /* BackForwardTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackForwardTableViewCell.swift; sourceTree = "<group>"; };
 		C4F3B2991CFCF93A00966259 /* ButtonToast.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonToast.swift; sourceTree = "<group>"; };
 		C817B34C1FC609500086018E /* UIScrollViewSwizzled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScrollViewSwizzled.swift; sourceTree = "<group>"; };
+		C82CDD45233E8996002E2743 /* Tab+ChangeUserAgent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Tab+ChangeUserAgent.swift"; sourceTree = "<group>"; };
 		C8399D8F22DE5E5200EFA5CA /* disconnect-block-advertising.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "disconnect-block-advertising.json"; sourceTree = "<group>"; };
 		C8399D9222DE5E5B00EFA5CA /* disconnect-block-analytics.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "disconnect-block-analytics.json"; sourceTree = "<group>"; };
 		C8399D9422DE5E6200EFA5CA /* disconnect-block-social.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "disconnect-block-social.json"; sourceTree = "<group>"; };
@@ -2889,6 +2891,7 @@
 				C8F457A61F1FD75A000CB895 /* BrowserViewController */,
 				D3A994951A3686BD008AD1AC /* BrowserViewController.swift */,
 				C4F3B2991CFCF93A00966259 /* ButtonToast.swift */,
+				C82CDD45233E8996002E2743 /* Tab+ChangeUserAgent.swift */,
 				31ADB5D91E58CEC300E87909 /* ClipboardBarDisplayHandler.swift */,
 				D3BA7E0D1B0E934F00153782 /* ContextMenuHelper.swift */,
 				3BE7275C1CCFE8B60099189F /* CustomSearchHandler.swift */,
@@ -5116,6 +5119,7 @@
 				D34DC8531A16C40C00D49B7B /* Profile.swift in Sources */,
 				E4B3348C1BC01D8F004E2BFF /* AdjustIntegration.swift in Sources */,
 				E65075541E37F6FC006961AC /* DynamicFontHelper.swift in Sources */,
+				C82CDD47233E8996002E2743 /* Tab+ChangeUserAgent.swift in Sources */,
 				C4E3984C1D21F2FD004E89BA /* TabTrayButtonExtensions.swift in Sources */,
 				D3FEC38D1AC4B42F00494F45 /* AutocompleteTextField.swift in Sources */,
 				EBE26B57220C959D00D1D99A /* BrowserViewController+TabToolbarDelegate.swift in Sources */,

--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -85,7 +85,7 @@ class TestAppDelegate: AppDelegate {
             resetApplication()
         }
 
-        Tab.DesktopSites.clear()
+        Tab.ChangeUserAgent.clear()
 
         return super.application(application, willFinishLaunchingWithOptions: launchOptions)
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -271,26 +271,8 @@ extension BrowserViewController: WKNavigationDelegate {
         // always allow this. Additionally, data URIs are also handled just like normal web pages.
 
         if ["http", "https", "data", "blob", "file"].contains(url.scheme) {
-
             if navigationAction.targetFrame?.isMainFrame ?? false {
-                tab.desktopSite = Tab.DesktopSites.contains(url: url, isPrivate: false)
-                if !tab.desktopSite, tab.isPrivate {
-                    // Private mode has an additional memory-only list to check.
-                    tab.desktopSite = Tab.DesktopSites.contains(url: url, isPrivate: true)
-                }
-
-                let requestUA = navigationAction.request.value(forHTTPHeaderField: "User-Agent") ?? ""
-                if UserAgent.isDesktop(ua: requestUA) != tab.desktopSite {
-                    let _url: URL
-                    // if the url has 'm.' or 'mobile.' in it, remove it.
-                    if url.normalizedHost != url.host, let scheme = url.scheme, let fullpath = url.normalizedHostAndPath {
-                        let desktopUrl = scheme + "://" + fullpath
-                        _url = URL(string: desktopUrl) ??  url
-                    } else {
-                        _url = url
-                    }
-                    webView.load(URLRequest(url: _url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 60) as URLRequest)
-                }
+                tab.changedUserAgent = Tab.ChangeUserAgent.contains(url: url)
             }
 
             pendingRequests[url.absoluteString] = navigationAction.request

--- a/Client/Frontend/Browser/Tab+ChangeUserAgent.swift
+++ b/Client/Frontend/Browser/Tab+ChangeUserAgent.swift
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extension Tab {
+    class ChangeUserAgent {
+        // Track these in-memory only
+        static var privateModeHostList = Set<String>()
+
+        private static let file: URL = {
+            let root = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            return root.appendingPathComponent("changed-ua-set-of-hosts.xcarchive")
+        } ()
+
+        private static var baseDomainList: Set<String> = {
+            if let hosts = NSKeyedUnarchiver.unarchiveObject(withFile: ChangeUserAgent.file.path) as? Set<String> {
+                return hosts
+            }
+            return Set<String>()
+        } ()
+
+        static func clear() {
+            try? FileManager.default.removeItem(at: Tab.ChangeUserAgent.file)
+            baseDomainList.removeAll()
+        }
+
+        static func contains(url: URL) -> Bool {
+            guard let baseDomain = url.baseDomain else { return false }
+            return privateModeHostList.contains(baseDomain) || baseDomainList.contains(baseDomain)
+        }
+
+        static func updateDomainList(forUrl url: URL, isChangedUA: Bool, isPrivate: Bool) {
+            guard let baseDomain = url.baseDomain, !baseDomain.isEmpty else { return }
+
+            if isPrivate {
+                if isChangedUA {
+                    ChangeUserAgent.privateModeHostList.insert(baseDomain)
+                    return
+                } else {
+                    ChangeUserAgent.privateModeHostList.remove(baseDomain)
+                    // Continue to next section and try remove it from `hostList` also.
+                }
+            }
+
+            if isChangedUA, !baseDomainList.contains(baseDomain) {
+                baseDomainList.insert(baseDomain)
+            } else if !isChangedUA, baseDomainList.contains(baseDomain) {
+                baseDomainList.remove(baseDomain)
+            } else {
+                // Don't save to disk, return early
+                return
+            }
+
+            // At this point, saving to disk takes place.
+            do {
+                let data = try NSKeyedArchiver.archivedData(withRootObject: baseDomainList, requiringSecureCoding: false)
+                try data.write(to: ChangeUserAgent.file)
+            } catch {
+                print("Couldn't write file: \(error)")
+            }
+        }
+
+    }
+}

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -44,7 +44,6 @@ protocol URLChangeDelegate {
 
 struct TabState {
     var isPrivate: Bool = false
-    var desktopSite: Bool = false
     var url: URL?
     var title: String?
     var favicon: Favicon?
@@ -64,7 +63,7 @@ class Tab: NSObject {
     }
 
     var tabState: TabState {
-        return TabState(isPrivate: _isPrivate, desktopSite: desktopSite, url: url, title: displayTitle, favicon: displayFavicon)
+        return TabState(isPrivate: _isPrivate, url: url, title: displayTitle, favicon: displayFavicon)
     }
 
     // PageMetadata is derived from the page content itself, and as such lags behind the

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -159,11 +159,10 @@ class Tab: NSObject {
     var lastTitle: String?
 
     /// Whether or not the desktop site was requested with the last request, reload or navigation.
-    var desktopSite: Bool = false {
+    var changedUserAgent: Bool = false {
         didSet {
-            webView?.customUserAgent = desktopSite ? UserAgent.desktopUserAgent() : nil
-
-            if desktopSite != oldValue {
+            webView?.customUserAgent = changedUserAgent ? UserAgent.oppositeUserAgent() : nil
+            if changedUserAgent != oldValue {
                 TabEvent.post(.didToggleDesktopMode, for: self)
             }
         }
@@ -538,8 +537,8 @@ class Tab: NSObject {
         }
     }
 
-    func toggleDesktopSite() {
-        desktopSite = !desktopSite
+    func toggleChangeUserAgent() {
+        changedUserAgent = !changedUserAgent
         reload()
         TabEvent.post(.didToggleDesktopMode, for: self)
     }

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -706,68 +706,6 @@ class TabWebView: WKWebView, MenuHelperInterface {
     }
 }
 
-// Desktop site host list management.
-extension Tab {
-    // Store the list of hosts as an xcarchive for simplicity.
-    struct DesktopSites {
-        // Track these in-memory only
-        static var privateModeHostList = Set<String>()
-
-        private static let file: URL = {
-            let root = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-            return root.appendingPathComponent("desktop-sites-set-of-strings.xcarchive")
-        } ()
-
-        private static var baseDomainList: Set<String> = {
-            if let hosts = NSKeyedUnarchiver.unarchiveObject(withFile: DesktopSites.file.path) as? Set<String> {
-                return hosts
-            }
-            return Set<String>()
-        } ()
-
-        static func clear() {
-            try? FileManager.default.removeItem(at: Tab.DesktopSites.file)
-            baseDomainList.removeAll()
-        }
-
-        static func contains(url: URL, isPrivate: Bool) -> Bool {
-            guard let baseDomain = url.baseDomain else { return false }
-            return isPrivate ? privateModeHostList.contains(baseDomain) : baseDomainList.contains(baseDomain)
-        }
-
-        // Will extract the host from the URL and enable or disable it as a desktop site, and write the file if needed.
-        static func updateDomainList(forUrl url: URL, isDesktopSite: Bool, isPrivate: Bool) {
-            guard let baseDomain = url.baseDomain, !baseDomain.isEmpty else { return }
-
-            if isPrivate {
-                if isDesktopSite {
-                    DesktopSites.privateModeHostList.insert(baseDomain)
-                    return
-                } else {
-                    DesktopSites.privateModeHostList.remove(baseDomain)
-                    // Continue to next section and try remove it from `hostList` also.
-                }
-            }
-
-            if isDesktopSite, !baseDomainList.contains(baseDomain) {
-                baseDomainList.insert(baseDomain)
-            } else if !isDesktopSite, baseDomainList.contains(baseDomain) {
-                baseDomainList.remove(baseDomain)
-            } else {
-                // Don't save to disk, return early
-                return
-            }
-
-            // At this point, saving to disk takes place.
-            do {
-                let data = try NSKeyedArchiver.archivedData(withRootObject: baseDomainList, requiringSecureCoding: false)
-                try data.write(to: DesktopSites.file)
-            } catch {
-                print("Couldn't write file: \(error)")
-            }
-        }
-    }
-}
 ///
 // Temporary fix for Bug 1390871 - NSInvalidArgumentException: -[WKContentView menuHelperFindInPage]: unrecognized selector
 //

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -454,15 +454,6 @@ class Tab: NSObject {
     }
 
     func reload() {
-        let userAgent: String? = desktopSite ? UserAgent.desktopUserAgent() : nil
-        if (userAgent ?? "") != webView?.customUserAgent, let currentItem = webView?.backForwardList.currentItem {
-            webView?.customUserAgent = userAgent
-
-            // Reload the initial URL to avoid UA specific redirection
-            loadRequest(PrivilegedRequest(url: currentItem.initialURL, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 60) as URLRequest)
-            return
-        }
-
         if let _ = webView?.reloadFromOrigin() {
             print("reloaded zombified tab from origin")
             return

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -407,11 +407,11 @@ extension TabLocationView: TabEventHandler {
 
     func tabDidGainFocus(_ tab: Tab) {
         updateBlockerStatus(forTab: tab)
-        menuBadge.show(tab.desktopSite)
+        menuBadge.show(tab.changedUserAgent)
     }
 
     func tabDidToggleDesktopMode(_ tab: Tab) {
-        menuBadge.show(tab.desktopSite)
+        menuBadge.show(tab.changedUserAgent)
     }
 }
 

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -225,7 +225,7 @@ class TabManager: NSObject {
         recentlyClosedForUndo.removeAll()
 
         // Clear every time entering/exiting this mode.
-        Tab.DesktopSites.privateModeHostList = Set<String>()
+        Tab.ChangeUserAgent.privateModeHostList = Set<String>()
 
         if shouldClearPrivateTabs() && leavingPBM {
             removeAllPrivateTabs()

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -42,7 +42,7 @@ class HistoryClearable: Clearable {
     func clear() -> Success {
 
         // Treat desktop sites as part of browsing history.
-        Tab.DesktopSites.clear()
+        Tab.ChangeUserAgent.clear()
 
         return profile.history.clearHistory().bindQueue(.main) { success in
             SDImageCache.shared.clearDisk()

--- a/Client/Frontend/Widgets/PhotonActionSheet/PageActionMenu.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PageActionMenu.swift
@@ -39,11 +39,17 @@ extension PhotonActionSheetProtocol {
             return [[shareFile]]
         }
 
-        let toggleActionTitle = tab.desktopSite ? Strings.AppMenuViewMobileSiteTitleString : Strings.AppMenuViewDesktopSiteTitleString
-        let toggleDesktopSite = PhotonActionSheetItem(title: toggleActionTitle, iconString: "menu-RequestDesktopSite", isEnabled: tab.desktopSite, badgeIconNamed: "menuBadge") { _, _ in
+        let defaultUAisDesktop = UserAgent.isDesktop(ua: UserAgent.defaultUserAgent())
+        let toggleActionTitle: String
+        if defaultUAisDesktop {
+            toggleActionTitle = tab.changedUserAgent ? Strings.AppMenuViewDesktopSiteTitleString : Strings.AppMenuViewMobileSiteTitleString
+        } else {
+            toggleActionTitle = tab.changedUserAgent ? Strings.AppMenuViewMobileSiteTitleString : Strings.AppMenuViewDesktopSiteTitleString
+        }
+        let toggleDesktopSite = PhotonActionSheetItem(title: toggleActionTitle, iconString: "menu-RequestDesktopSite", isEnabled: tab.changedUserAgent, badgeIconNamed: "menuBadge") { _, _ in
             if let url = tab.url {
-                tab.toggleDesktopSite()
-                Tab.DesktopSites.updateDomainList(forUrl: url, isDesktopSite: tab.desktopSite, isPrivate: tab.isPrivate)
+                tab.toggleChangeUserAgent()
+                Tab.ChangeUserAgent.updateDomainList(forUrl: url, isChangedUA: tab.changedUserAgent, isPrivate: tab.isPrivate)
             }
         }
 

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -76,12 +76,18 @@ extension PhotonActionSheetProtocol {
             return []
         }
 
-        let toggleActionTitle = tab.desktopSite ? Strings.AppMenuViewMobileSiteTitleString : Strings.AppMenuViewDesktopSiteTitleString
+        let defaultUAisDesktop = UserAgent.isDesktop(ua: UserAgent.defaultUserAgent())
+        let toggleActionTitle: String
+        if defaultUAisDesktop {
+            toggleActionTitle = tab.changedUserAgent ? Strings.AppMenuViewDesktopSiteTitleString : Strings.AppMenuViewMobileSiteTitleString
+        } else {
+            toggleActionTitle = tab.changedUserAgent ? Strings.AppMenuViewMobileSiteTitleString : Strings.AppMenuViewDesktopSiteTitleString
+        }
         let toggleDesktopSite = PhotonActionSheetItem(title: toggleActionTitle, iconString: "menu-RequestDesktopSite") { _, _ in
 
             if let url = tab.url {
-                tab.toggleDesktopSite()
-                Tab.DesktopSites.updateDomainList(forUrl: url, isDesktopSite: tab.desktopSite, isPrivate: tab.isPrivate)
+                tab.toggleChangeUserAgent()
+                Tab.ChangeUserAgent.updateDomainList(forUrl: url, isChangedUA: tab.changedUserAgent, isPrivate: tab.isPrivate)
             }
         }
 

--- a/ClientTests/ClientTests.swift
+++ b/ClientTests/ClientTests.swift
@@ -31,7 +31,7 @@ class ClientTests: XCTestCase {
         }
 
         XCTAssertTrue(compare(UserAgent.defaultUserAgent()), "User agent computes correctly.")
-        XCTAssertTrue(compare(UserAgent.cachedUserAgent(checkiOSVersion: true)!), "User agent is cached correctly.")
+        //XCTAssertTrue(compare(UserAgent.cachedUserAgent(checkiOSVersion: true)!), "User agent is cached correctly.")
 
         let expectation = self.expectation(description: "Found Firefox user agent")
 

--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -5,27 +5,6 @@
 import WebKit
 import UIKit
 
-private extension WKWebView {
-    func evaluate(script: String, completion: @escaping (Any?, Error?) -> Void) {
-        var finished = false
-
-        evaluateJavaScript(script) { (result, error) in
-            if error == nil {
-                if result != nil {
-                    completion(result, nil)
-                }
-            } else {
-                completion(nil, error)
-            }
-            finished = true
-        }
-
-        while !finished {
-            RunLoop.current.run(mode: RunLoop.Mode.default, before: Date.distantFuture)
-        }
-    }
-}
-
 open class UserAgent {
     private static var defaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!
 
@@ -49,91 +28,14 @@ open class UserAgent {
         return clientUserAgent(prefix: "Firefox-iOS")
     }
 
-    /**
-     * Use this if you know that a value must have been computed before your
-     * code runs, or you don't mind failure.
-     */
-    public static func cachedUserAgent(checkiOSVersion: Bool = true,
-                                     checkFirefoxVersion: Bool = true,
-                                     checkFirefoxBuildNumber: Bool = true) -> String? {
-        let currentiOSVersion = UIDevice.current.systemVersion
-        let lastiOSVersion = defaults.string(forKey: "LastDeviceSystemVersionNumber")
-
-        let currentFirefoxBuildNumber = AppInfo.buildNumber
-        let currentFirefoxVersion = AppInfo.appVersion
-        let lastFirefoxVersion = defaults.string(forKey: "LastFirefoxVersionNumber")
-        let lastFirefoxBuildNumber = defaults.string(forKey: "LastFirefoxBuildNumber")
-
-        if let firefoxUA = defaults.string(forKey: "UserAgent") {
-            if (!checkiOSVersion || (lastiOSVersion == currentiOSVersion))
-                && (!checkFirefoxVersion || (lastFirefoxVersion == currentFirefoxVersion)
-                && (!checkFirefoxBuildNumber || (lastFirefoxBuildNumber == currentFirefoxBuildNumber))) {
-                return firefoxUA
-            }
-        }
-
-        return nil
-    }
-
-    /**
-     * This will typically return quickly, but can require creation of a UIWebView.
-     * As a result, it must be called on the UI thread.
-     */
     public static func defaultUserAgent() -> String {
-        assert(Thread.current.isMainThread, "This method must be called on the main thread.")
-
-        if let firefoxUA = UserAgent.cachedUserAgent(checkiOSVersion: true) {
-            return firefoxUA
+        // As of iOS 13 using a hidden webview method does not return the correct UA on
+        // iPad (it returns mobile UA). We should consider that method no longer reliable.
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            return desktopUserAgent()
+        } else {
+            return mobileUserAgent()
         }
-
-        let webView = WKWebView()
-        webView.loadHTMLString("<html></html>", baseURL: nil)
-
-        let appVersion = AppInfo.appVersion
-        let buildNumber = AppInfo.buildNumber
-        let currentiOSVersion = UIDevice.current.systemVersion
-        defaults.set(currentiOSVersion, forKey: "LastDeviceSystemVersionNumber")
-        defaults.set(appVersion, forKey: "LastFirefoxVersionNumber")
-        defaults.set(buildNumber, forKey: "LastFirefoxBuildNumber")
-
-        var userAgent = ""
-        // Synchronously get the UA, note this is called only once after install and then cached
-        webView.evaluate(script: "navigator.userAgent") { (object, error) in
-            if let ua = object as? String {
-                userAgent = ua
-            } else {
-                print("Failed to get user agent.")
-            }
-        }
-
-        // Extract the WebKit version and use it as the Safari version.
-        let webKitVersionRegex = try! NSRegularExpression(pattern: "AppleWebKit/([^ ]+) ", options: [])
-
-        let match = webKitVersionRegex.firstMatch(in: userAgent, options: [],
-            range: NSRange(location: 0, length: userAgent.count))
-
-        if match == nil {
-            print("Error: Unable to determine WebKit version in UA.")
-            return userAgent     // Fall back to Safari's.
-        }
-
-        let webKitVersion = (userAgent as NSString).substring(with: match!.range(at: 1))
-
-        // Insert "FxiOS/<version>" before the Mobile/ section.
-        let mobileRange = (userAgent as NSString).range(of: "Mobile/")
-        if mobileRange.location == NSNotFound {
-            print("Error: Unable to find Mobile section in UA.")
-            return userAgent     // Fall back to Safari's.
-        }
-
-        let mutableUA = NSMutableString(string: userAgent)
-        mutableUA.insert("FxiOS/\(appVersion)b\(AppInfo.buildNumber) ", at: mobileRange.location)
-
-        let firefoxUA = "\(mutableUA) Safari/\(webKitVersion)"
-
-        defaults.set(firefoxUA, forKey: "UserAgent")
-
-        return firefoxUA
     }
 
     public static func isDesktop(ua: String) -> Bool {
@@ -141,28 +43,19 @@ open class UserAgent {
     }
 
     public static func desktopUserAgent() -> String {
-        let userAgent = NSMutableString(string: defaultUserAgent())
+        return "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15) AppleWebKit/605.1.15 (KHTML, like Gecko)"
+    }
 
-        // Spoof platform section
-        let platformRegex = try! NSRegularExpression(pattern: "\\([^\\)]+\\)", options: [])
-        guard let platformMatch = platformRegex.firstMatch(in: userAgent as String, options: [], range: NSRange(location: 0, length: userAgent.length)) else {
-            print("Error: Unable to determine platform in UA.")
-            return String(userAgent)
+    public static func mobileUserAgent() -> String {
+        return "Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16C101"
+    }
+
+    public static func oppositeUserAgent() -> String {
+        let isDefaultUADesktop = UserAgent.isDesktop(ua: UserAgent.defaultUserAgent())
+        if isDefaultUADesktop {
+            return mobileUserAgent()
+        } else {
+            return desktopUserAgent()
         }
-        userAgent.replaceCharacters(in: platformMatch.range, with: "(Macintosh; Intel Mac OS X 10_11_1)")
-
-        // Strip mobile section
-        let mobileRegex = try! NSRegularExpression(pattern: " FxiOS/[^ ]+ Mobile/[^ ]+", options: [])
-
-        guard let mobileMatch = mobileRegex.firstMatch(in: userAgent as String, options: [], range: NSRange(location: 0, length: userAgent.length)) else {
-            print("Error: Unable to find Mobile section in UA.")
-            return String(userAgent)
-        }
-
-        // The iOS major version is equal to the Safari major version
-        let majoriOSVersion = (UIDevice.current.systemVersion as NSString).components(separatedBy: ".")[0]
-        userAgent.replaceCharacters(in: mobileMatch.range, with: " Version/\(majoriOSVersion).0")
-
-        return String(userAgent)
     }
 }


### PR DESCRIPTION
iPad UA is now desktop by default, thus need to switch to the opposite UA on each platform.
Fixes #5476, this PR is for Xcode11 only