### PR TITLE
Issue #5471 - Library panels: table view cells/headers borders thickness and color are inconsistent

### DIFF
--- a/Client/Frontend/AuthenticationManager/RequirePasscodeIntervalViewController.swift
+++ b/Client/Frontend/AuthenticationManager/RequirePasscodeIntervalViewController.swift
@@ -39,10 +39,10 @@ class RequirePasscodeIntervalViewController: UITableViewController {
 
         let headerFooterFrame = CGRect(width: self.view.frame.width, height: SettingsUX.TableViewHeaderFooterHeight)
         let headerView = ThemedTableSectionHeaderFooterView(frame: headerFooterFrame)
-        headerView.showBottomBorder = true
+        headerView.showBorder(for: .bottom, true)
 
         let footerView = ThemedTableSectionHeaderFooterView(frame: headerFooterFrame)
-        footerView.showTopBorder = true
+        footerView.showBorder(for: .top, true)
 
         tableView.tableHeaderView = headerView
         tableView.tableFooterView = footerView

--- a/Client/Frontend/Library/BookmarkDetailPanel.swift
+++ b/Client/Frontend/Library/BookmarkDetailPanel.swift
@@ -383,6 +383,11 @@ class BookmarkDetailPanel: SiteTableViewController {
 
         return BookmarkDetailPanelUX.FieldRowHeight
     }
+
+    override func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        let header = view as? SiteTableViewHeader
+        header?.showBorder(for: .top, section != 0)
+    }
 }
 
 extension BookmarkDetailPanel: TextFieldTableViewCellDelegate {

--- a/Client/Frontend/Library/BookmarksPanel.swift
+++ b/Client/Frontend/Library/BookmarksPanel.swift
@@ -414,8 +414,8 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
         }
 
         headerView.titleLabel.text = Strings.RecentlyBookmarkedTitle.uppercased()
-        headerView.showTopBorder = true
-        headerView.showBottomBorder = true
+        headerView.showBorder(for: .top, true)
+        headerView.showBorder(for: .bottom, true)
 
         return headerView
     }

--- a/Client/Frontend/Library/DownloadsPanel.swift
+++ b/Client/Frontend/Library/DownloadsPanel.swift
@@ -9,6 +9,7 @@ import Storage
 private struct DownloadsPanelUX {
     static let WelcomeScreenPadding: CGFloat = 15
     static let WelcomeScreenItemWidth = 170
+    static let HeaderHeight: CGFloat = 28
 }
 
 struct DownloadedFile: Equatable {
@@ -81,6 +82,7 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
         tableView.delegate = self
         tableView.dataSource = self
         tableView.register(TwoLineTableViewCell.self, forCellReuseIdentifier: "TwoLineTableViewCell")
+        tableView.register(SiteTableViewHeader.self, forHeaderFooterViewReuseIdentifier: "SiteTableViewHeader")
         tableView.layoutMargins = .zero
         tableView.keyboardDismissMode = .onDrag
         tableView.accessibilityIdentifier = "DownloadsTable"
@@ -290,23 +292,42 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
         }
     }
 
-    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        guard groupedDownloadedFiles.numberOfItemsForSection(section) > 0 else { return 0 }
+
+        return DownloadsPanelUX.HeaderHeight
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard groupedDownloadedFiles.numberOfItemsForSection(section) > 0 else { return nil }
+
+        let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: "SiteTableViewHeader") as? SiteTableViewHeader
 
         switch section {
         case 0:
-            return Strings.TableDateSectionTitleToday
+            header?.textLabel?.text = Strings.TableDateSectionTitleToday
         case 1:
-            return Strings.TableDateSectionTitleYesterday
+            header?.textLabel?.text = Strings.TableDateSectionTitleYesterday
         case 2:
-            return Strings.TableDateSectionTitleLastWeek
+            header?.textLabel?.text = Strings.TableDateSectionTitleLastWeek
         case 3:
-            return Strings.TableDateSectionTitleLastMonth
+            header?.textLabel?.text = Strings.TableDateSectionTitleLastMonth
         default:
             assertionFailure("Invalid Downloads section \(section)")
         }
 
-        return nil
+        header?.showBorder(for: .top, !isFirstSection(section))
+
+        return header
+    }
+
+    func isFirstSection(_ section: Int) -> Bool {
+        for i in 0..<section {
+            if groupedDownloadedFiles.numberOfItemsForSection(i) > 0 {
+                return false
+            }
+        }
+        return true
     }
 
     func configureDownloadedFile(_ cell: UITableViewCell, for indexPath: IndexPath) -> UITableViewCell {

--- a/Client/Frontend/Library/RemoteTabsPanel.swift
+++ b/Client/Frontend/Library/RemoteTabsPanel.swift
@@ -156,6 +156,8 @@ class RemoteTabsPanelClientAndTabsDataSource: NSObject, RemoteTabsPanelDataSourc
         view.textLabel?.text = client.name
         view.contentView.backgroundColor = UIColor.theme.tableView.headerBackground
 
+        view.showBorder(for: .top, section != 0)
+
         /*
         * A note on timestamps.
         * We have access to two timestamps here: the timestamp of the remote client record,
@@ -503,6 +505,8 @@ fileprivate class RemoteTabsTableViewController: UITableViewController {
         tableView.tableFooterView = UIView() // prevent extra empty rows at end
         tableView.delegate = nil
         tableView.dataSource = nil
+
+        tableView.separatorColor = UIColor.theme.tableView.separator
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -628,6 +632,7 @@ extension RemoteTabsTableViewController: LibraryPanelContextMenu {
 extension RemoteTabsPanel: Themeable {
     func applyTheme() {
         historyBackButton.applyTheme()
+        tableViewController.tableView.separatorColor = UIColor.theme.tableView.separator
         tableViewController.tableView.reloadData()
         tableViewController.refreshTabs()
     }

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -381,8 +381,8 @@ extension LoginListViewController: UITableViewDelegate {
         }
         headerView.titleLabel.text = Strings.LoginsListTitle
         // not using a grouped table: show header borders
-        headerView.showTopBorder = true
-        headerView.showBottomBorder = true
+        headerView.showBorder(for: .top, true)
+        headerView.showBorder(for: .bottom, true)
         headerView.applyTheme()
         return headerView
     }

--- a/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
@@ -43,7 +43,7 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
         tableView.register(ThemedTableSectionHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: SectionHeaderFooterIdentifier)
 
         let footer = ThemedTableSectionHeaderFooterView(frame: CGRect(width: tableView.bounds.width, height: SettingsUX.TableViewHeaderFooterHeight))
-        footer.showTopBorder = true
+        footer.showBorder(for: .top, true)
         tableView.tableFooterView = footer
 
         view.addSubview(tableView)
@@ -178,18 +178,18 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
         let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: SectionHeaderFooterIdentifier) as? ThemedTableSectionHeaderFooterView
         headerView?.titleLabel.text = section == Section.sites.rawValue ? Strings.SettingsWebsiteDataTitle : nil
 
-        headerView?.showTopBorder = true
-        headerView?.showBottomBorder = true
+        headerView?.showBorder(for: .top, true)
+        headerView?.showBorder(for: .bottom, true)
 
         // top section: no top border (this is a plain table)
         guard let section = Section(rawValue: section) else { return headerView }
         if section == .sites {
-            headerView?.showTopBorder = false
+            headerView?.showBorder(for: .top, false)
 
             // no records: no bottom border (would make 2 with the one from the clear button)
             let emptyRecords = siteRecords?.isEmpty ?? true
             if emptyRecords {
-                headerView?.showBottomBorder = false
+                headerView?.showBorder(for: .bottom, false)
             }
         }
         return headerView
@@ -209,8 +209,8 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
 
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         let footerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: SectionHeaderFooterIdentifier) as? ThemedTableSectionHeaderFooterView
-        footerView?.showTopBorder = true
-        footerView?.showBottomBorder = true
+        footerView?.showBorder(for: .top, true)
+        footerView?.showBorder(for: .bottom, true)
         return footerView
     }
 

--- a/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
@@ -29,7 +29,7 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
         view.addSubview(tableView)
 
         let footer = ThemedTableSectionHeaderFooterView(frame: CGRect(width: tableView.bounds.width, height: SettingsUX.TableViewHeaderFooterHeight))
-        footer.showTopBorder = true
+        footer.showBorder(for: .top, true)
         tableView.tableFooterView = footer
 
         tableView.snp.makeConstraints { make in
@@ -64,8 +64,8 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: SectionHeaderFooterIdentifier) as? ThemedTableSectionHeaderFooterView
         headerView?.titleLabel.text = Strings.SettingsWebsiteDataTitle
-        headerView?.showTopBorder = section != 0
-        headerView?.showBottomBorder = true
+        headerView?.showBorder(for: .top, section != 0)
+        headerView?.showBorder(for: .bottom, true)
         return headerView
     }
 

--- a/Client/Frontend/Theme/ThemedWidgets.swift
+++ b/Client/Frontend/Theme/ThemedWidgets.swift
@@ -70,18 +70,6 @@ class ThemedTableSectionHeaderFooterView: UITableViewHeaderFooterView, Themeable
         }
     }
 
-    var showTopBorder: Bool = false {
-        didSet {
-            topBorder.isHidden = !showTopBorder
-        }
-    }
-
-    var showBottomBorder: Bool = false {
-        didSet {
-            bottomBorder.isHidden = !showBottomBorder
-        }
-    }
-
     lazy var titleLabel: UILabel = {
         var headerLabel = UILabel()
         headerLabel.font = UIFont.systemFont(ofSize: 12.0, weight: UIFont.Weight.regular)
@@ -89,21 +77,12 @@ class ThemedTableSectionHeaderFooterView: UITableViewHeaderFooterView, Themeable
         return headerLabel
     }()
 
-    fileprivate lazy var topBorder: UIView = {
-        let topBorder = UIView()
-        return topBorder
-    }()
-
-    fileprivate lazy var bottomBorder: UIView = {
-        let bottomBorder = UIView()
-        return bottomBorder
-    }()
+    fileprivate lazy var bordersHelper = ThemedHeaderFooterViewBordersHelper()
 
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
-        addSubview(titleLabel)
-        addSubview(topBorder)
-        addSubview(bottomBorder)
+        contentView.addSubview(titleLabel)
+        bordersHelper.initBorders(view: self)
         setDefaultBordersValues()
         setupInitialConstraints()
         applyTheme()
@@ -114,29 +93,22 @@ class ThemedTableSectionHeaderFooterView: UITableViewHeaderFooterView, Themeable
     }
 
     func applyTheme() {
-        topBorder.backgroundColor = UIColor.theme.tableView.separator
-        bottomBorder.backgroundColor = UIColor.theme.tableView.separator
+        bordersHelper.applyTheme()
         contentView.backgroundColor = UIColor.theme.tableView.headerBackground
         titleLabel.textColor = UIColor.theme.tableView.headerTextLight
     }
 
     func setupInitialConstraints() {
-        bottomBorder.snp.makeConstraints { make in
-            make.bottom.left.right.equalTo(self)
-            make.height.equalTo(0.5)
-        }
-
-        topBorder.snp.makeConstraints { make in
-            make.top.left.right.equalTo(self)
-            make.height.equalTo(0.25)
-        }
-
         remakeTitleAlignmentConstraints()
     }
 
+    func showBorder(for location: ThemedHeaderFooterViewBordersHelper.BorderLocation, _ show: Bool) {
+        bordersHelper.showBorder(for: location, show)
+    }
+
     func setDefaultBordersValues() {
-        showTopBorder = false
-        showBottomBorder = false
+        bordersHelper.showBorder(for: .top, false)
+        bordersHelper.showBorder(for: .bottom, false)
     }
 
     override func prepareForReuse() {
@@ -153,16 +125,62 @@ class ThemedTableSectionHeaderFooterView: UITableViewHeaderFooterView, Themeable
         case .top:
             titleLabel.snp.remakeConstraints { make in
                 make.left.right.equalTo(self.contentView).inset(UX.titleHorizontalPadding)
-                make.top.equalTo(self).offset(UX.titleVerticalPadding)
-                make.bottom.equalTo(self).offset(-UX.titleVerticalLongPadding)
+                make.top.equalTo(self.contentView).offset(UX.titleVerticalPadding)
+                make.bottom.equalTo(self.contentView).offset(-UX.titleVerticalLongPadding)
             }
         case .bottom:
             titleLabel.snp.remakeConstraints { make in
                 make.left.right.equalTo(self.contentView).inset(UX.titleHorizontalPadding)
-                make.bottom.equalTo(self).offset(-UX.titleVerticalPadding)
-                make.top.equalTo(self).offset(UX.titleVerticalLongPadding)
+                make.bottom.equalTo(self.contentView).offset(-UX.titleVerticalPadding)
+                make.top.equalTo(self.contentView).offset(UX.titleVerticalLongPadding)
             }
         }
+    }
+}
+
+class ThemedHeaderFooterViewBordersHelper: Themeable {
+    enum BorderLocation {
+        case top
+        case bottom
+    }
+
+    fileprivate lazy var topBorder: UIView = {
+        let topBorder = UIView()
+        return topBorder
+    }()
+
+    fileprivate lazy var bottomBorder: UIView = {
+        let bottomBorder = UIView()
+        return bottomBorder
+    }()
+
+    func showBorder(for location: BorderLocation, _ show: Bool) {
+        switch location {
+        case .top:
+            topBorder.isHidden = !show
+        case .bottom:
+            bottomBorder.isHidden = !show
+        }
+    }
+
+    func initBorders(view: UITableViewHeaderFooterView) {
+        view.contentView.addSubview(topBorder)
+        view.contentView.addSubview(bottomBorder)
+
+        topBorder.snp.makeConstraints { make in
+            make.left.right.top.equalTo(view.contentView)
+            make.height.equalTo(0.25)
+        }
+
+        bottomBorder.snp.makeConstraints { make in
+            make.left.right.bottom.equalTo(view.contentView)
+            make.height.equalTo(0.5)
+        }
+    }
+
+    func applyTheme() {
+        topBorder.backgroundColor = UIColor.theme.tableView.separator
+        bottomBorder.backgroundColor = UIColor.theme.tableView.separator
     }
 }
 

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -13,11 +13,8 @@ struct SiteTableViewControllerUX {
 }
 
 class SiteTableViewHeader: UITableViewHeaderFooterView, Themeable {
-    // I can't get drawRect to play nicely with the glass background. As a fallback
-    // we just use views for the top and bottom borders.
-    let topBorder = UIView()
-    let bottomBorder = UIView()
     let titleLabel = UILabel()
+    fileprivate let bordersHelper = ThemedHeaderFooterViewBordersHelper()
 
     override var textLabel: UILabel? {
         return titleLabel
@@ -27,20 +24,10 @@ class SiteTableViewHeader: UITableViewHeaderFooterView, Themeable {
         super.init(reuseIdentifier: reuseIdentifier)
         titleLabel.font = DynamicFontHelper.defaultHelper.DeviceFontMediumBold
 
-        addSubview(topBorder)
-        addSubview(bottomBorder)
         contentView.addSubview(titleLabel)
 
-        topBorder.snp.makeConstraints { make in
-            make.left.right.equalTo(self)
-            make.top.equalTo(self).offset(-0.5)
-            make.height.equalTo(0.5)
-        }
-
-        bottomBorder.snp.makeConstraints { make in
-            make.left.right.bottom.equalTo(self)
-            make.height.equalTo(0.5)
-        }
+        bordersHelper.initBorders(view: self)
+        setDefaultBordersValues()
 
         // A table view will initialize the header with CGSizeZero before applying the actual size. Hence, the label's constraints
         // must not impose a minimum width on the content view.
@@ -61,14 +48,23 @@ class SiteTableViewHeader: UITableViewHeaderFooterView, Themeable {
 
     override func prepareForReuse() {
         super.prepareForReuse()
+        setDefaultBordersValues()
         applyTheme()
     }
 
     func applyTheme() {
         titleLabel.textColor = UIColor.theme.tableView.headerTextDark
-        topBorder.backgroundColor = UIColor.theme.homePanel.siteTableHeaderBorder
-        bottomBorder.backgroundColor = UIColor.theme.homePanel.siteTableHeaderBorder
         contentView.backgroundColor = UIColor.theme.tableView.headerBackground
+        bordersHelper.applyTheme()
+    }
+
+    func showBorder(for location: ThemedHeaderFooterViewBordersHelper.BorderLocation, _ show: Bool) {
+        bordersHelper.showBorder(for: location, show)
+    }
+
+    func setDefaultBordersValues() {
+        bordersHelper.showBorder(for: .top, true)
+        bordersHelper.showBorder(for: .bottom, true)
     }
 }
 

--- a/Client/Frontend/Widgets/TwoLineCell.swift
+++ b/Client/Frontend/Widgets/TwoLineCell.swift
@@ -109,6 +109,7 @@ class SiteTableViewCell: TwoLineTableViewCell {
 
 class TwoLineHeaderFooterView: UITableViewHeaderFooterView, Themeable {
     fileprivate let twoLineHelper = TwoLineCellHelper()
+    fileprivate let bordersHelper = ThemedHeaderFooterViewBordersHelper()
 
     // UITableViewHeaderFooterView includes textLabel and detailTextLabel, so we can't override
     // them.  Unfortunately, they're also used in ways that interfere with us just using them: I get
@@ -132,6 +133,8 @@ class TwoLineHeaderFooterView: UITableViewHeaderFooterView, Themeable {
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
         twoLineHelper.setUpViews(self, textLabel: _textLabel, detailTextLabel: _detailTextLabel, imageView: imageView)
+        bordersHelper.initBorders(view: self)
+        setDefaultBordersValues()
 
         contentView.addSubview(_textLabel)
         contentView.addSubview(_detailTextLabel)
@@ -148,6 +151,16 @@ class TwoLineHeaderFooterView: UITableViewHeaderFooterView, Themeable {
 
     func applyTheme() {
         twoLineHelper.applyTheme()
+        bordersHelper.applyTheme()
+    }
+
+    func showBorder(for location: ThemedHeaderFooterViewBordersHelper.BorderLocation, _ show: Bool) {
+        bordersHelper.showBorder(for: location, show)
+    }
+
+    func setDefaultBordersValues() {
+        bordersHelper.showBorder(for: .top, true)
+        bordersHelper.showBorder(for: .bottom, true)
     }
 
     override func layoutSubviews() {
@@ -158,6 +171,7 @@ class TwoLineHeaderFooterView: UITableViewHeaderFooterView, Themeable {
     override func prepareForReuse() {
         super.prepareForReuse()
         twoLineHelper.setUpViews(self, textLabel: _textLabel, detailTextLabel: _detailTextLabel, imageView: imageView)
+        setDefaultBordersValues()
         applyTheme()
     }
 


### PR DESCRIPTION
Before / after screenshots will follow in the next post.

Went through all tables, corrected the border thicknesses, missing borders, and borders colors in dark mode.

Header borders management has been extracted from ThemedTableSectionHeaderFooterView into ThemedHeaderFooterViewBordersHelper, to avoid code duplication. This allowed reuse in SiteTableViewHeader and TwoLineHeaderFooterView.