### PR TITLE
Fixes #5525: Move a non-optional variable definition out of the guard statement

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -102,7 +102,8 @@ extension BrowserViewController: WKUIDelegate {
         completionHandler(UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: { (suggested) -> UIMenu? in
             guard let url = elementInfo.linkURL, let currentTab = self.tabManager.selectedTab,
                 let contextHelper = currentTab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper,
-                let elements = contextHelper.elements, let isPrivate = currentTab.isPrivate else { return nil }
+                let elements = contextHelper.elements else { return nil }
+            let isPrivate = currentTab.isPrivate
 
             let addTab = { (rURL: URL, isPrivate: Bool) in
                 let tab = self.tabManager.addTab(URLRequest(url: rURL as URL), afterTab: currentTab, isPrivate: isPrivate)


### PR DESCRIPTION
As I mentioned in #5525, there is a syntax error currently in the **master branch**, which is caused by a non-optional variable inside the guard statement. I've fixed this error by moving this variable of type Bool outside of the guard statement. This lets project be compiled successfully.