### PR TITLE
Fix #5538 Replacing Brackets in the url with percent encoding

### DIFF
--- a/Client/Frontend/Browser/URIFixup.swift
+++ b/Client/Frontend/Browser/URIFixup.swift
@@ -12,9 +12,10 @@ class URIFixup {
         }
 
         let trimmed = entry.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let escaped = trimmed.addingPercentEncoding(withAllowedCharacters: .URLAllowed) else {
+        guard var escaped = trimmed.addingPercentEncoding(withAllowedCharacters: .URLAllowed) else {
             return nil
         }
+        escaped = replaceBrackets(url: escaped)
 
         // Then check if the URL includes a scheme. This will handle
         // all valid requests starting with "http://", "about:", etc.
@@ -53,5 +54,9 @@ class URIFixup {
             components?.host = host
         }
         return components?.url
+    }
+
+    static func replaceBrackets(url: String) -> String {
+        return url.replacingOccurrences(of: "[", with: "%5B").replacingOccurrences(of: "]", with: "%5D")
     }
 }


### PR DESCRIPTION
Hi, this is my first PR to firefox-ios!

Here I fix the problem when the user submit a bracket (**"["** or **"]"**) in the URL, it causes a  redirect to a google search result, so i replace it with a percent encoding (**"%5B"** and **"%5D"**).

URL Example:

https://stackoverflow.com/search?q=swift+[lint]

