### PR TITLE
Fixes #5593: Fix cut off Today Widget buttons on iPad

### DIFF
--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -100,9 +100,6 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         stackView.alignment = .fill
         stackView.spacing = 0
         stackView.distribution = UIStackView.Distribution.fillEqually
-        let edge = self.view.frame.size.width * TodayUX.buttonsHorizontalMarginPercentage
-        stackView.layoutMargins = UIEdgeInsets(top: 0, left: edge, bottom: 0, right: edge)
-        stackView.isLayoutMarginsRelativeArrangement = true
         return stackView
     }()
 


### PR DESCRIPTION
The margins were causing the buttons to be cut off. 
Spacing looks like the top image now:
![IMG_0006](https://user-images.githubusercontent.com/11432165/66674143-35feff00-ec30-11e9-868b-413967efea1f.jpg)
