### PR TITLE
Fix #5589 - Top Sites section is not displayed on the tab after opening a new tab from outside the app

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -237,6 +237,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             }
             UnifiedTelemetry.recordEvent(category: .appExtensionAction, method: .applicationOpenUrl, object: object)
         }
+        
+        if let profile = self.profile {
+            profile._reopen()
+
+            if profile.prefs.boolForKey(PendingAccountDisconnectedKey) ?? false {
+                FxALoginHelper.sharedInstance.applicationDidDisconnect(application)
+            }
+
+            profile.syncManager.applicationDidBecomeActive()
+
+            setUpWebServer(profile)
+        }
 
         DispatchQueue.main.async {
             NavigationPath.handle(nav: routerpath, with: BrowserViewController.foregroundBVC())
@@ -258,18 +270,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         let defaults = UserDefaults()
         defaults.set(false, forKey: "ApplicationCleanlyBackgrounded")
 
-        if let profile = self.profile {
-            profile._reopen()
-
-            if profile.prefs.boolForKey(PendingAccountDisconnectedKey) ?? false {
-                FxALoginHelper.sharedInstance.applicationDidDisconnect(application)
-            }
-
-            profile.syncManager.applicationDidBecomeActive()
-
-            setUpWebServer(profile)
-        }
-        
         // Resume file downloads.
         // TODO: iOS 13 needs to iterate all the BVCs.
         BrowserViewController.foregroundBVC().downloadQueue.resumeAll()

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -237,18 +237,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             }
             UnifiedTelemetry.recordEvent(category: .appExtensionAction, method: .applicationOpenUrl, object: object)
         }
-        
-        if let profile = self.profile {
-            profile._reopen()
-
-            if profile.prefs.boolForKey(PendingAccountDisconnectedKey) ?? false {
-                FxALoginHelper.sharedInstance.applicationDidDisconnect(application)
-            }
-
-            profile.syncManager.applicationDidBecomeActive()
-
-            setUpWebServer(profile)
-        }
 
         DispatchQueue.main.async {
             NavigationPath.handle(nav: routerpath, with: BrowserViewController.foregroundBVC())
@@ -270,6 +258,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         let defaults = UserDefaults()
         defaults.set(false, forKey: "ApplicationCleanlyBackgrounded")
 
+        if let profile = self.profile {
+            profile._reopen()
+
+            if profile.prefs.boolForKey(PendingAccountDisconnectedKey) ?? false {
+                FxALoginHelper.sharedInstance.applicationDidDisconnect(application)
+            }
+
+            profile.syncManager.applicationDidBecomeActive()
+
+            setUpWebServer(profile)
+        }
+        
+        BrowserViewController.foregroundBVC().firefoxHomeViewController?.reloadAll()
+        
         // Resume file downloads.
         // TODO: iOS 13 needs to iterate all the BVCs.
         BrowserViewController.foregroundBVC().downloadQueue.resumeAll()


### PR DESCRIPTION
I have put the profile reopening before the invocation of SQLite query for top sites with using application open, instead of applicationDidBecomeActive, which misses 3-4 queries (one of it is "Top sites") if the application invoked outside such as Today and Siri.