### PR TITLE
Issue 5491 Send notification After Tab Sent

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1029,6 +1029,8 @@ class BrowserViewController: UIViewController {
         let helper = ShareExtensionHelper(url: url, tab: tab)
 
         let controller = helper.createActivityViewController({ [unowned self] completed, _ in
+            SimpleToast().showAlertWithText(Strings.AppMenuTabSentConfirmMessage, bottomContainer: self.webViewContainer)
+
             // After dismissing, check to see if there were any prompts we queued up
             self.showQueuedAlertIfAvailable()
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1028,8 +1028,35 @@ class BrowserViewController: UIViewController {
     fileprivate func presentActivityViewController(_ url: URL, tab: Tab? = nil, sourceView: UIView?, sourceRect: CGRect, arrowDirection: UIPopoverArrowDirection) {
         let helper = ShareExtensionHelper(url: url, tab: tab)
 
-        let controller = helper.createActivityViewController({ [unowned self] completed, _ in
-            SimpleToast().showAlertWithText(Strings.AppMenuTabSentConfirmMessage, bottomContainer: self.webViewContainer)
+        let controller = helper.createActivityViewController({ [unowned self] completed, activityType in
+
+            // Note: the only share activities I can test on the simulator are the
+            // Reminders app and the Firefox share app
+            print("****ActivityType is: \(activityType)")
+            print("****completed is: \(completed)")
+            if let activityType = activityType,
+                completed {
+                if activityType.rawValue.hasPrefix("org.mozilla.ios") {
+                    // If we're sharing to Firefox, we need to find a way to recognize when we've completed
+                    // a send/share for the different types of Firefox shares
+                    // For example, Cancel, Add To Reading List, and Send to Device all have different numbers of screens
+                    // before a Tab is successfully sent/shared, but they ALL return completed = true for the
+                    // "org.mozilla.ios.Fennec.ShareTo" activityType even if the user cancels out early.
+                    print("*******Definitely Firefox share activity here!")
+
+                    // Presumably, we would uncomment the Toast code below once we solve this probleme of the
+                    // Firefox share activity, somehow
+                    //SimpleToast().showAlertWithText(Strings.AppMenuTabSentConfirmMessage, bottomContainer: self.webViewContainer)
+                } else {
+                    // sending a notification here will work presumably for everything else
+                    // EXCEPT for the Reminders app, which has a bug with the "completed" flag
+                    // (ie it marks the activity as completed even if the user cancels out):
+                    // https://forums.developer.apple.com/thread/77776
+
+                    print("*******It's NOT Firefox sharing")
+                    SimpleToast().showAlertWithText(Strings.AppMenuTabSentConfirmMessage, bottomContainer: self.webViewContainer)
+                }
+            }
 
             // After dismissing, check to see if there were any prompts we queued up
             self.showQueuedAlertIfAvailable()


### PR DESCRIPTION
This pull request addresses issue 5491, which is a new feature request.

https://github.com/mozilla-mobile/firefox-ios/issues/5491

This new feature will enable a notification to be sent after a tab is successfully shared from the Page Actions -> Share Page With .... menu. To get to this menu, the user will tap on the "..." or More menu in the upper right corner, and get a screen that looks like this:
![PageActionMenuFrom3Dots](https://user-images.githubusercontent.com/1022275/67153597-94b81e80-f2a9-11e9-9904-832efcaeb098.png)

Then, the user taps on "Share Page With ..." and get this screen, or something similar, depending on what share apps are available on the user's device:
![ShareMenu](https://user-images.githubusercontent.com/1022275/67153611-c7faad80-f2a9-11e9-8247-702a4a8897ec.png)

For this example, 
I will tap on the Firefox icon, which will get me to this screen. For the purpose of discussion, we will call this the **Firefox-share screen** :
![ShareToFirefoxMenu](https://user-images.githubusercontent.com/1022275/67153639-23c53680-f2aa-11e9-89d0-d734ea82b678.png)

From here, I will tap on the "Send To Device" option and get this screen:
![DevicesScreen](https://user-images.githubusercontent.com/1022275/67153656-6e46b300-f2aa-11e9-9022-0c362b626ad9.png)

Finally, I would select a device and tap on "Send", and hopefully get something like this:
![Simulator Screen Shot - iPhone SE - 2019-10-15 at 20 47 11](https://user-images.githubusercontent.com/1022275/67153665-861e3700-f2aa-11e9-81aa-93a79beb51a1.png)

However, it does not work this way, and there's more work that needs to be done to get there.

 So, here is a list of items for discussion:

- [ ] As shown in the **Firefox-share screen**, there are multiple share activities. And each share activity has a different number of screens that the user must go through before the activity can be flagged as "completed" in the code. At least that's how it should work.

But as the code behaves today, all screens from this point onward will return a flag of "completed" if true, even if the user cancels out early for any of the share activities, or even if the user cancels out of this screen. Because of this, if we place code here to send a notification, a "Tab Sent" notification will be delivered regardless of whether the user completes the share activity or cancels it by this point. The place where this is happening is in **BrowserViewController.swift** , in the **presentActivityViewController()** method.

- [ ] The Reminders app or activity, as shown in the **Firefox-share screen" has a bug. This one returns a "completed" flag of true even if the user cancels out. The bug is explained here:
https://forums.developer.apple.com/thread/77776

- [ ] I can only test the Firefox and Reminders activities / share apps in the simulator (see the **Firefox-share screen**. )The only way I can test other share activities would be to test it on my device. Do we want / need to test other activities? Or should we focus only on the Firefox share activity for this issue?

- [ ] In order to test more activities on my device, my developer id would need to be added to the Team profile for the **firefox-ios** repo. Will this be necessary for me to continue working on this issue? (see item above)

- [ ] I'd like to get some feedback on this PR before adding tests. What do you think?

I know this is a lot to cover / discuss. 

@garvankeeley  Please let me what questions you have for me, or how you'd like to proceed in working on / reviewing this PR. Thanks for your help!




