### PR TITLE
Fix #5629: iPad split-screen theme elements

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -175,7 +175,16 @@ class BrowserViewController: UIViewController {
   }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return ThemeManager.instance.statusBarStyle
+        guard urlBar != nil else {
+            return ThemeManager.instance.statusBarStyle
+        }
+        
+        // top-tabs are always dark, so special-case this to light
+        if urlBar.topTabsIsShowing {
+            return .lightContent
+        } else {
+            return ThemeManager.instance.statusBarStyle
+        }
     }
 
     @objc func displayThemeChanged(notification: Notification) {

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -51,6 +51,7 @@ class TopTabsViewController: UIViewController {
         tabsButton.semanticContentAttribute = .forceLeftToRight
         tabsButton.addTarget(self, action: #selector(TopTabsViewController.tabsTrayTapped), for: .touchUpInside)
         tabsButton.accessibilityIdentifier = "TopTabsViewController.tabsButton"
+        tabsButton.inTopTabs = true
         return tabsButton
     }()
 

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -110,6 +110,7 @@ class URLBarView: UIView {
     lazy var tabsButton: TabsButton = {
         let tabsButton = TabsButton.tabTrayButton()
         tabsButton.accessibilityIdentifier = "URLBarView.tabsButton"
+        tabsButton.inTopTabs = false
         return tabsButton
     }()
 

--- a/Client/Frontend/Theme/ThemeManager.swift
+++ b/Client/Frontend/Theme/ThemeManager.swift
@@ -41,8 +41,6 @@ class ThemeManager {
 
     // UIViewControllers / UINavigationControllers need to have `preferredStatusBarStyle` and call this.
     var statusBarStyle: UIStatusBarStyle {
-        // On iPad the dark and normal theme both have a dark tab bar
-        guard UIDevice.current.userInterfaceIdiom == .phone else { return .lightContent }
         return currentName == .dark ? .lightContent : .default
     }
 

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -26,6 +26,7 @@ class TabsButton: UIButton {
     }
     var highlightTextColor: UIColor?
     var highlightBackgroundColor: UIColor?
+    var inTopTabs = false
 
     // When all animations are completed, this is the most-recently assigned tab count that is shown.
     // updateTabCount() can be called in rapid succession, this ensures only final tab count is displayed.
@@ -226,7 +227,7 @@ class TabsButton: UIButton {
 
 extension TabsButton: Themeable {
     func applyTheme() {
-        if UIDevice.current.userInterfaceIdiom == .pad {
+        if inTopTabs {
             textColor = UIColor.theme.topTabs.buttonTint
         } else {
             textColor = UIColor.theme.browser.tint


### PR DESCRIPTION
This fixes Issue #5629 which I submitted regarding incorrect theme applied to UI elements in iPad split-screen. The main issue was that some of the logic simply assumed iPad idiom would always be in a certain layout. I changed that to be a little smarter and to query the actual layout before making those choices.
