### PR TITLE
Fix #5622 - Navigation list is white in Dark Theme

### DIFF
--- a/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -29,8 +29,8 @@ class BackForwardListViewController: UIViewController, UITableViewDataSource, UI
         tableView.delegate = self
         tableView.alwaysBounceVertical = false
         tableView.register(BackForwardTableViewCell.self, forCellReuseIdentifier: self.BackForwardListCellIdentifier)
-        tableView.backgroundColor = BackForwardViewUX.BackgroundColor
-        let blurEffect = UIBlurEffect(style: .extraLight)
+        tableView.backgroundColor = UIColor.theme.tabTray.cellTitleBackground.withAlphaComponent(0.4)
+        let blurEffect = UIBlurEffect(style: UIColor.theme.tabTray.tabTitleBlur)
         let blurEffectView = UIVisualEffectView(effect: blurEffect)
         tableView.backgroundView = blurEffectView
 

--- a/Client/Frontend/Browser/BackForwardTableViewCell.swift
+++ b/Client/Frontend/Browser/BackForwardTableViewCell.swift
@@ -35,7 +35,7 @@ class BackForwardTableViewCell: UITableViewCell {
         let label = UILabel()
         label.text = " "
         label.font = label.font.withSize(BackForwardViewCellUX.fontSize)
-        label.textColor = BackForwardViewCellUX.textColor
+        label.textColor = UIColor.theme.tabTray.tabTitleText
         return label
     }()
 
@@ -45,7 +45,7 @@ class BackForwardTableViewCell: UITableViewCell {
     var isCurrentTab = false {
         didSet {
             if isCurrentTab {
-                label.font = UIFont(name: "HelveticaNeue-Bold", size: BackForwardViewCellUX.fontSize)
+                label.font = UIFont.boldSystemFont(ofSize: BackForwardViewCellUX.fontSize)
             }
         }
     }
@@ -139,6 +139,6 @@ class BackForwardTableViewCell: UITableViewCell {
         connectingForwards = true
         connectingBackwards = true
         isCurrentTab = false
-        label.font = UIFont(name: "HelveticaNeue", size: BackForwardViewCellUX.fontSize)
+        label.font = UIFont.systemFont(ofSize: BackForwardViewCellUX.fontSize)
     }
 }


### PR DESCRIPTION
Also changed the font to use the system font instead of hard-coded 'Helvetica Neue'.

![5622-BackForward-Dark](https://user-images.githubusercontent.com/650804/67175747-5009b180-f395-11e9-95e5-4031bdb3c823.png)
![5622-BackForward-Light](https://user-images.githubusercontent.com/650804/67175748-5009b180-f395-11e9-9865-878bb1b927b2.png)
