### PR TITLE
Fix #5635 - XCUITests fix iPad smoketest

### DIFF
--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -192,6 +192,7 @@ class ActivityStreamTest: BaseTestCase {
         app.cells["TopSitesCell"].cells.element(boundBy: 3).press(forDuration:1)
         selectOptionFromContextMenu(option: "Open in New Tab")
         // Check that two tabs are open and one of them is the default top site one
+        sleep(1)
         navigator.goto(TabTray)
         waitForExistence(app.collectionViews.cells[defaultTopSite["bookmarkLabel"]!])
         let numTabsOpen = app.collectionViews.cells.count
@@ -234,6 +235,7 @@ class ActivityStreamTest: BaseTestCase {
         waitForExistence(app.cells["TopSitesCell"].cells.element(boundBy: 3), timeout: 3)
         app.cells["TopSitesCell"].cells.element(boundBy: 3).press(forDuration:1)
         selectOptionFromContextMenu(option: "Open in New Private Tab")
+        sleep(1)
 
         // Check that two tabs are open and one of them is the default top site one
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)


### PR DESCRIPTION
This PR fixes #5635 
I don't like the solution at all, adding sleep but I have not found any other workaround to have tests working. `waitingForExistence`does not work even though I have tried waiting for different elements in the screen...

