### PR TITLE
Fix #5571: Ensure night mode respects theme choice

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -442,10 +442,12 @@ class BrowserViewController: UIViewController {
         let dropInteraction = UIDropInteraction(delegate: self)
         view.addInteraction(dropInteraction)
 
-        if #available(iOS 13.0, *) {
-            if (ThemeManager.instance.systemThemeIsOn) {
-                let userInterfaceStyle = traitCollection.userInterfaceStyle
-                ThemeManager.instance.current = userInterfaceStyle == .dark ? DarkTheme() : NormalTheme()
+        if !NightModeHelper.isActivated(profile.prefs) {
+            if #available(iOS 13.0, *) {
+                if (ThemeManager.instance.systemThemeIsOn) {
+                    let userInterfaceStyle = traitCollection.userInterfaceStyle
+                    ThemeManager.instance.current = userInterfaceStyle == .dark ? DarkTheme() : NormalTheme()
+                }
             }
         }
     }


### PR DESCRIPTION
Night mode was already behaving correctly. But the check for system theme on startup was not respecting night mode.