### PR TITLE
Fix #5587 - ipad share sheet drop shadow hack

### DIFF
--- a/Extensions/ShareTo/InitialViewController.swift
+++ b/Extensions/ShareTo/InitialViewController.swift
@@ -93,6 +93,17 @@ class InitialViewController: UIViewController {
         super.viewDidLoad()
         if #available(iOS 13, *) {
             view.backgroundColor = .clear
+
+            // iPad drop shadow removal hack!
+            var view = parent?.view
+            while view != nil, view!.classForCoder.description() != "UITransitionView" {
+                view = view?.superview
+            }
+            if let view = view {
+                // For reasons unknown, if the alpha is < 1.0, the drop shadow is not shown
+                view.alpha = 0.99
+            }
+
         } else {
             view.backgroundColor = UIColor(white: 0.0, alpha: UX.alphaForFullscreenOverlay)
         }


### PR DESCRIPTION
Iterating up the iOS view hierarchy to the UITransitionView, and setting the alpha on that to 0.99 magically makes the drop shadow disappear. 