### PR TITLE
FXIOS-716 ⁃ Fix #5174 - Low-res Firefox logo/favicon in Top Sites with IP address…

### DIFF
--- a/Client/Utils/FaviconFetcher.swift
+++ b/Client/Utils/FaviconFetcher.swift
@@ -28,7 +28,7 @@ open class FaviconFetcher: NSObject, XMLParserDelegate {
     static let ExpirationTime = TimeInterval(60*60*24*7) // Only check for icons once a week
     fileprivate static var characterToFaviconCache = [String: UIImage]()
     static var defaultFavicon: UIImage = {
-        return UIImage(named: "defaultFavicon")!
+        return UIImage(named: "splash")!
     }()
 
     static var colors: [String: UIColor] = [:] //An in-Memory data store that stores background colors domains. Stored using url.baseDomain.


### PR DESCRIPTION
Fixes #5174 by using `splash.png` which is big enough.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-716)
