### PR TITLE
PR #5660 followup - Fix broken session restore test

### DIFF
--- a/UITests/SessionRestoreTests.swift
+++ b/UITests/SessionRestoreTests.swift
@@ -9,7 +9,6 @@ import EarlGrey
 import SwiftyJSON
 @testable import Client
 
-/// This test should be disabled since session restore does not seem to work
 class SessionRestoreTests: KIFTestCase {
     fileprivate var webRoot: String!
 

--- a/UITests/SessionRestoreTests.swift
+++ b/UITests/SessionRestoreTests.swift
@@ -7,6 +7,7 @@ import WebKit
 import Shared
 import EarlGrey
 import SwiftyJSON
+@testable import Client
 
 /// This test should be disabled since session restore does not seem to work
 class SessionRestoreTests: KIFTestCase {
@@ -30,7 +31,7 @@ class SessionRestoreTests: KIFTestCase {
         let json = JSON(jsonDict)
         let escapedJSON = json.stringify()?.addingPercentEncoding(withAllowedCharacters: .URLAllowed)
         let webView = tester().waitForView(withAccessibilityLabel: "Web content") as! WKWebView
-        let restoreURL = URL(string: "\(InternalURL.baseUrl)/\(InternalURL.Path.sessionrestore.rawValue)?history=\(escapedJSON!)")
+        let restoreURL = PrivilegedRequest(url: URL(string: "\(InternalURL.baseUrl)/\(InternalURL.Path.sessionrestore.rawValue)?history=\(escapedJSON!)")!).url
 
         // Enter the restore URL and verify the back/forward history.
         // After triggering the restore, the session should look like this:


### PR DESCRIPTION
A `PrivilegedRequest` url has extra UUID url argument appended, and we only allow these for internal URLs.