### PR TITLE
Fix #5558 - Share downloaded file hangs app

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheet/PageActionMenu.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PageActionMenu.swift
@@ -6,9 +6,8 @@ import Shared
 import Storage
 
 extension PhotonActionSheetProtocol {
-
-    fileprivate func shareFileURL(url: URL, file: URL?, buttonView: UIView, presentableVC: PresentableVC) {
-        let helper = ShareExtensionHelper(url: url, file: file, tab: tabManager.selectedTab)
+    fileprivate func share(fileURL: URL, buttonView: UIView, presentableVC: PresentableVC) {
+        let helper = ShareExtensionHelper(url: fileURL, tab: tabManager.selectedTab)
         let controller = helper.createActivityViewController { completed, activityType in
             print("Shared downloaded file: \(completed)")
         }
@@ -33,7 +32,7 @@ extension PhotonActionSheetProtocol {
             let shareFile = PhotonActionSheetItem(title: Strings.AppMenuSharePageTitleString, iconString: "action_share") { _, _ in
                 guard let url = tab.url else { return }
 
-                self.shareFileURL(url: url, file: nil, buttonView: buttonView, presentableVC: presentableVC)
+                self.share(fileURL: url, buttonView: buttonView, presentableVC: presentableVC)
             }
 
             return [[shareFile]]
@@ -135,7 +134,7 @@ extension PhotonActionSheetProtocol {
                     // If we successfully got a temp file URL, share it like a downloaded file,
                     // otherwise present the ordinary share menu for the web URL.
                     if tempDocURL.isFileURL {
-                        self.shareFileURL(url: url, file: tempDocURL, buttonView: buttonView, presentableVC: presentableVC)
+                        self.share(fileURL: tempDocURL, buttonView: buttonView, presentableVC: presentableVC)
                     } else {
                         presentShareMenu(url, tab, buttonView, .up)
                     }


### PR DESCRIPTION
The root cause of the hang was due to returning the wrong type of URL in `activityViewControllerPlaceholderItem`, I found if I return a file path that isn't resolvable, the iOS share sheet can caused the app to hang.

Overall the ShareExtension needed some refactoring to handle URLs that are file or http seamlessly.