### PR TITLE
Issue #5569: Add more dark mode telemetry

### DIFF
--- a/Client/Frontend/Settings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettingsController.swift
@@ -266,7 +266,6 @@ class ThemeSettingsController: ThemedTableViewController {
             tableView.reloadSections(IndexSet(integer: Section.lightDarkPicker.rawValue), with: .automatic)
             tableView.reloadSections(IndexSet(integer: Section.automaticBrightness.rawValue), with: .none)
             UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .setting, value: indexPath.row == 0 ? .themeModeManually : .themeModeAutomatically)
-        
         } else if indexPath.section == Section.lightDarkPicker.rawValue {
             tableView.cellForRow(at: indexPath)?.accessoryType = .checkmark
             ThemeManager.instance.current = indexPath.row == 0 ? NormalTheme() : DarkTheme()

--- a/Client/Frontend/Settings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettingsController.swift
@@ -133,6 +133,7 @@ class ThemeSettingsController: ThemedTableViewController {
             } else if ThemeManager.instance.automaticBrightnessIsOn {
                 ThemeManager.instance.updateCurrentThemeBasedOnScreenBrightness()
             }
+            UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .setting, value: .systemThemeSwitch, extras: ["to": control.isOn])
         }
         // Switch animation must begin prior to scheduling table view update animation (or the switch will be auto-synchronized to the slower tableview animation and makes the switch behaviour feel slow and non-standard).
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
@@ -264,9 +265,16 @@ class ThemeSettingsController: ThemedTableViewController {
             ThemeManager.instance.automaticBrightnessIsOn = indexPath.row != 0
             tableView.reloadSections(IndexSet(integer: Section.lightDarkPicker.rawValue), with: .automatic)
             tableView.reloadSections(IndexSet(integer: Section.automaticBrightness.rawValue), with: .none)
+            UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .setting, value: indexPath.row == 0 ? .themeModeManually : .themeModeAutomatically)
+        
         } else if indexPath.section == Section.lightDarkPicker.rawValue {
             tableView.cellForRow(at: indexPath)?.accessoryType = .checkmark
             ThemeManager.instance.current = indexPath.row == 0 ? NormalTheme() : DarkTheme()
+<<<<<<< ec33623787a93ca7ff67375613a56836c49964ed
+=======
+            applyTheme()
+            UnifiedTelemetry.recordEvent(category: .action, method: .press, object: .setting, value: indexPath.row == 0 ? .themeLight : .themeDark)
+>>>>>>> Issue #5569: Add click telemetry for theme settings
         }
         applyTheme()
     }

--- a/Client/Telemetry/UnifiedTelemetry.swift
+++ b/Client/Telemetry/UnifiedTelemetry.swift
@@ -210,6 +210,11 @@ extension UnifiedTelemetry {
         case shareMenu = "share-menu"
         case tabTray = "tab-tray"
         case topTabs = "top-tabs"
+        case systemThemeSwitch = "system-theme-switch"
+        case themeModeManually = "theme-manually"
+        case themeModeAutomatically = "theme-automatically"
+        case themeLight = "theme-light"
+        case themeDark = "theme-dark"
     }
 
     public static func recordEvent(category: EventCategory, method: EventMethod, object: EventObject, value: EventValue, extras: [String: Any?]? = nil) {

--- a/Client/Telemetry/UnifiedTelemetry.swift
+++ b/Client/Telemetry/UnifiedTelemetry.swift
@@ -90,6 +90,12 @@ class UnifiedTelemetry {
             self.crashedLastLaunch = false
 
             outputDict["settings"] = settings
+            
+            var userInterfaceStyle = "unknown" // unknown implies that device is on pre-iOS 13
+            if #available(iOS 13.0, *) {
+                userInterfaceStyle = UITraitCollection.current.userInterfaceStyle.rawValue
+            }
+            outputDict["systemTheme"] = userInterfaceStyle
 
             return outputDict
         }


### PR DESCRIPTION
Needed to add telemetry for all the theme settings clicks, as well as the current system theme.