### PR TITLE
Remove support for discontinued Inbox by Gmail mail app

### DIFF
--- a/Client/Frontend/Browser/MailProviders.swift
+++ b/Client/Frontend/Browser/MailProviders.swift
@@ -139,18 +139,3 @@ class GoogleGmailIntegration: MailProvider {
         return constructEmailURLString(beginningScheme, metadata: metadata, supportedHeaders: supportedHeaders).asURL
     }
 }
-
-class GoogleInboxIntegration: MailProvider {
-    var beginningScheme = "inbox-gmail://co?"
-    var supportedHeaders = [
-        "to",
-        "cc",
-        "bcc",
-        "subject",
-        "body"
-    ]
-
-    func newEmailURLFromMetadata(_ metadata: MailToMetadata) -> URL? {
-        return constructEmailURLString(beginningScheme, metadata: metadata, supportedHeaders: supportedHeaders).asURL
-    }
-}

--- a/Client/Frontend/Browser/MailtoLinkHandler.swift
+++ b/Client/Frontend/Browser/MailtoLinkHandler.swift
@@ -40,9 +40,6 @@ open class MailtoLinkHandler {
                         providerDict[scheme] = YMailIntegration()
                     } else if scheme == "googlegmail://" {
                         providerDict[scheme] = GoogleGmailIntegration()
-                    } else if scheme == "inbox-gmail://" {
-                        providerDict[scheme] = GoogleInboxIntegration()
-                    }
                 }
             })
         }

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -69,7 +69,6 @@
 		<string>itms-books</string>
 		<string>org-appextension-feature-password-management</string>
 		<string>googlegmail</string>
-		<string>inbox-gmail</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>

--- a/Client/MailSchemes.plist
+++ b/Client/MailSchemes.plist
@@ -50,11 +50,5 @@
 		<key>scheme</key>
 		<string>googlegmail://</string>
 	</dict>
-	<dict>
-		<key>name</key>
-		<string>Inbox by Gmail</string>
-		<key>scheme</key>
-		<string>inbox-gmail://</string>
-	</dict>
 </array>
 </plist>

--- a/XCUITests/MailAppSettingsTests.swift
+++ b/XCUITests/MailAppSettingsTests.swift
@@ -22,7 +22,6 @@ class MailAppSettingsTests: BaseTestCase {
         XCTAssertFalse(app.tables.cells.staticTexts["Spark"].isSelected)
         XCTAssertFalse(app.tables.cells.staticTexts["YMail!"].isSelected)
         XCTAssertFalse(app.tables.cells.staticTexts["Gmail"].isSelected)
-        XCTAssertFalse(app.tables.cells.staticTexts["Inbox by Gmail"].isSelected)
 
         // Check that tapping on an element does nothing
         waitForExistence(app.tables["OpenWithPage.Setting.Options"])


### PR DESCRIPTION
The Inbox by Gmail mail app was [shut down in late March/early April 2019](https://www.blog.google/products/gmail/inbox-signing-find-your-favorite-features-new-gmail/). This PR removes all references to it within Firefox on iOS.

Note: I have not tested how the app handles the removal of the option if the user has already selected Inbox as their mail app.