### PR TITLE
Fix 5637 - Send tab is reopening the db in background

### DIFF
--- a/Client/Frontend/Extensions/DevicePickerViewController.swift
+++ b/Client/Frontend/Extensions/DevicePickerViewController.swift
@@ -202,7 +202,7 @@ class DevicePickerViewController: UITableViewController {
         if let profile = self.profile {
             // Re-open the profile if it was shutdown. This happens when we run from an app extension, where we must
             // make sure that the profile is only open for brief moments of time.
-            if profile.isShutdown {
+            if profile.isShutdown && Bundle.main.bundleURL.pathExtension == "appex" {
                 profile._reopen()
             }
             return profile


### PR DESCRIPTION
We should only be reopening the db if this is an app extension. Otherwise we are opening a file in background, and iOS kills the app for having a file lock in background.
