### PR TITLE
Fix #5597 - bg task expiry: don't try to close db

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -349,16 +349,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         var taskId: UIBackgroundTaskIdentifier = UIBackgroundTaskIdentifier(rawValue: 0)
         taskId = application.beginBackgroundTask (expirationHandler: {
             print("Running out of background time, but we have a profile shutdown pending.")
-            self.shutdownProfileWhenNotActive(application)
+            // Do not try to forceClose the db, it will lock the main thread and app will get killed
             application.endBackgroundTask(taskId)
         })
 
         if profile.hasSyncableAccount() {
             profile.syncManager.syncEverything(why: .backgrounded).uponQueue(.main) { _ in
                 self.shutdownProfileWhenNotActive(application)
+                application.endBackgroundTask(taskId)
             }
         } else {
             profile._shutdown()
+            application.endBackgroundTask(taskId)
         }
     }
 


### PR DESCRIPTION
Trying to close  the db when the task expires will lock the main thread
and guarantee the app will get killed.

Instead, iOS will nicely suspend the bg task (because it is off-main), and resume it when the app is foregrounded, which is exactly what we want.

