### PR TITLE
Fix #5716: Show previews for the context menu on iOS 13

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -99,7 +99,21 @@ extension BrowserViewController: WKUIDelegate {
 
     @available(iOS 13.0, *)
     func webView(_ webView: WKWebView, contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo, completionHandler: @escaping (UIContextMenuConfiguration?) -> Void) {
-        completionHandler(UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: { (suggested) -> UIMenu? in
+        completionHandler(UIContextMenuConfiguration(identifier: nil, previewProvider: {
+            guard let url = elementInfo.linkURL else { return nil }
+            let previewViewController = UIViewController()
+            previewViewController.view.isUserInteractionEnabled = false
+            let clonedWebView = WKWebView(frame: webView.frame, configuration: webView.configuration)
+
+            previewViewController.view.addSubview(clonedWebView)
+            clonedWebView.snp.makeConstraints { make in
+                make.edges.equalTo(previewViewController.view)
+            }
+
+            clonedWebView.load(URLRequest(url: url))
+
+            return previewViewController
+        }, actionProvider: { (suggested) -> UIMenu? in
             guard let url = elementInfo.linkURL, let currentTab = self.tabManager.selectedTab,
                 let contextHelper = currentTab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper,
                 let elements = contextHelper.elements else { return nil }


### PR DESCRIPTION
Showing a preview brings the context menu closer to the bottom of the screen for easier use, and brings us closer to parity with Safari.

![Screenshot 2019-11-08 at 12 43 45 AM](https://user-images.githubusercontent.com/650804/68452587-fab90700-01c0-11ea-8085-3f605960143c.png)
