### PR TITLE
Fix #5732: Dark mode: placeholder text color in 'Homepage settings' and 'Add search engine' is incorrect

### DIFF
--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -120,7 +120,7 @@ fileprivate class DarkSnackBarColor: SnackBarColor {
 }
 
 fileprivate class DarkGeneralColor: GeneralColor {
-    override var settingsTextPlaceholder: UIColor? { return UIColor.black }
+    override var settingsTextPlaceholder: UIColor? { return UIColor.Photon.Grey50 }
     override var faviconBackground: UIColor { return UIColor.Photon.White100 }
     override var passcodeDot: UIColor { return UIColor.Photon.Grey40 }
 }


### PR DESCRIPTION
Fixes #5732 

![68546986-29172c00-03e5-11ea-9aac-0c1d814b2468](https://user-images.githubusercontent.com/168651/68708356-362a4b80-059c-11ea-962a-4a0cffcdec0a.png)