### PR TITLE
Fix #5694: Open in 'New Private Tab' doesn't open tab when 'Close Pri…

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -110,8 +110,15 @@ extension BrowserViewController: WKUIDelegate {
                 guard !self.topTabsVisible else {
                     return
                 }
+                var toastLabelText: String
+                
+                if isPrivate {
+                    toastLabelText = Strings.ContextMenuButtonToastNewPrivateTabOpenedLabelText
+                } else {
+                    toastLabelText = Strings.ContextMenuButtonToastNewTabOpenedLabelText
+                }
                 // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
-                let toast = ButtonToast(labelText: Strings.ContextMenuButtonToastNewTabOpenedLabelText, buttonText: Strings.ContextMenuButtonToastNewTabOpenedButtonText, completion: { buttonPressed in
+                let toast = ButtonToast(labelText: toastLabelText, buttonText: Strings.ContextMenuButtonToastNewTabOpenedButtonText, completion: { buttonPressed in
                     if buttonPressed {
                         self.tabManager.selectTab(tab)
                     }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -275,10 +275,10 @@ class TabTrayController: UIViewController {
             fromView = emptyPrivateTabsView
         }
 
+        tabManager.willSwitchTabMode(leavingPBM: tabDisplayManager.isPrivate)
+        
         tabDisplayManager.togglePrivateMode(isOn: !tabDisplayManager.isPrivate, createTabOnEmptyPrivateMode: false)
-
-        tabManager.willSwitchTabMode(leavingPBM: !tabDisplayManager.isPrivate)
-
+        
         if tabDisplayManager.isPrivate, privateTabsAreEmpty() {
             UIView.animate(withDuration: 0.2) {
                 self.searchBarHolder.alpha = 0

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -277,7 +277,7 @@ class TabTrayController: UIViewController {
 
         tabDisplayManager.togglePrivateMode(isOn: !tabDisplayManager.isPrivate, createTabOnEmptyPrivateMode: false)
 
-        tabManager.willSwitchTabMode(leavingPBM: tabDisplayManager.isPrivate)
+        tabManager.willSwitchTabMode(leavingPBM: !tabDisplayManager.isPrivate)
 
         if tabDisplayManager.isPrivate, privateTabsAreEmpty() {
             UIView.animate(withDuration: 0.2) {


### PR DESCRIPTION
* show the proper label when opening private tab from link
* pass proper bool when switching tab mode from the public to private 