### PR TITLE
Make auth failure during device registration drive FxA to "separated".

### DIFF
--- a/Account/FxADeviceRegistration.swift
+++ b/Account/FxADeviceRegistration.swift
@@ -180,7 +180,7 @@ open class FxADeviceRegistrator {
 
     fileprivate static func recoverFromTokenError(_ account: FirefoxAccount, client: FxAClient10) -> Deferred<Maybe<FxADeviceRegistration>> {
         return client.status(forUID: account.uid) >>== { status in
-            _ = account.makeDoghouse()
+            _ = account.makeSeparated()
             if !status.exists {
                 // TODO: Should be in an "I have an iOS account, but the FxA is gone." state.
                 // This will do for now...


### PR DESCRIPTION
Fixes #5755. Sorry, I don't have my build environment set up in order to test this, but I figured I'd at least put up a draft PR to communicate the intent of that issue.

Previously, an auth failure during device registration would drive the
FxA state machine to "doghouse", which is a special terminal state for
when the FxA server tells the client that it needs to upgrade itself
before it can continue using the FxA APIs.

The appropriate state for auth failures is "separated", which prompts
the user to re-enter their password to reconnect to the account.

