### PR TITLE
Fix #5678: Sign in to Sync text color should be white

### DIFF
--- a/Client/Frontend/Library/RemoteTabsPanel.swift
+++ b/Client/Frontend/Library/RemoteTabsPanel.swift
@@ -377,7 +377,7 @@ class RemoteTabsNotLoggedInCell: UITableViewCell {
         contentView.addSubview(instructionsLabel)
 
         signInButton.setTitle(Strings.FxASignInToSync, for: [])
-        signInButton.titleLabel?.textColor = .white
+        signInButton.setTitleColor(UIColor.Photon.White100, for: [])
         signInButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .subheadline)
         signInButton.layer.cornerRadius = RemoteTabsPanelUX.EmptyStateSignInButtonCornerRadius
         signInButton.clipsToBounds = true
@@ -421,7 +421,6 @@ class RemoteTabsNotLoggedInCell: UITableViewCell {
         titleLabel.textColor = UIColor.theme.tableView.headerTextDark
         instructionsLabel.textColor = UIColor.theme.tableView.headerTextDark
         signInButton.backgroundColor = RemoteTabsPanelUX.EmptyStateSignInButtonColor
-        signInButton.setTitleColor(UIColor.theme.tableView.headerTextDark, for: [])
         backgroundColor = UIColor.theme.homePanel.panelBackground
     }
 


### PR DESCRIPTION
* apply White color to  the SingIn button instead of applying color depending on Theme