### PR TITLE
Fix #5764 - Xcuitests new Sync tabs option update tests

### DIFF
--- a/XCUITests/DatabaseFixtureTest.swift
+++ b/XCUITests/DatabaseFixtureTest.swift
@@ -40,7 +40,7 @@ class DatabaseFixtureTest: BaseTestCase {
 
         // History list has two cells that are for recently closed and synced devices that should not count as history items,
         // the actual max number is 100
-        let loaded = NSPredicate(format: "count == 103")
+        let loaded = NSPredicate(format: "count == 102")
         expectation(for: loaded, evaluatedWith: app.tables["History List"].cells, handler: nil)
         waitForExpectations(timeout: 30, handler: nil)
     }

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -1058,7 +1058,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.backAction = navigationControllerBackAction
 
         screenState.tap(app.buttons["LibraryPanels.Bookmarks"], to: LibraryPanel_Bookmarks)
-//        screenState.tap(app.buttons["LibraryPanels.History"], to: LibraryPanel_History)
+        screenState.tap(app.buttons["LibraryPanels.History"], to: LibraryPanel_History)
         screenState.tap(app.buttons["LibraryPanels.ReadingList"], to: LibraryPanel_ReadingList)
         screenState.tap(app.buttons["LibraryPanels.Downloads"], to: LibraryPanel_Downloads)
         screenState.tap(app.buttons["LibraryPanels.SyncedTabs"], to: LibraryPanel_SyncedTabs)

--- a/XCUITests/HistoryTests.swift
+++ b/XCUITests/HistoryTests.swift
@@ -31,12 +31,10 @@ class HistoryTests: BaseTestCase {
         navigator.goto(LibraryPanel_History)
         waitForExistence(app.tables.cells["HistoryPanel.recentlyClosedCell"])
         XCTAssertTrue(app.tables.cells["HistoryPanel.recentlyClosedCell"].exists)
-        XCTAssertTrue(app.tables.cells["HistoryPanel.syncedDevicesCell"].exists)
     }
 
     func testOpenSyncDevices() {
-        navigator.goto(LibraryPanel_History)
-        app.tables.cells["HistoryPanel.syncedDevicesCell"].tap()
+        navigator.goto(LibraryPanel_SyncedTabs)
         waitForExistence(app.tables.cells.staticTexts["Firefox Sync"])
         XCTAssertTrue(app.tables.buttons["Sign in to Sync"].exists, "Sing in button does not appear")
     }

--- a/XCUITests/NavigationTest.swift
+++ b/XCUITests/NavigationTest.swift
@@ -98,13 +98,12 @@ class NavigationTest: BaseTestCase {
 
     func testTapSignInShowsFxAFromRemoteTabPanel() {
         // Open FxAccount from remote tab panel and check the Sign in to Firefox scren
-        navigator.goto(LibraryPanel_History)
-        XCTAssertTrue(app.tables["History List"].staticTexts["Synced Devices"].isEnabled)
-        app.tables["History List"].staticTexts["Synced Devices"].tap()
+        navigator.goto(LibraryPanel_SyncedTabs)
+
         app.tables.buttons["Sign in to Sync"].tap()
         checkFirefoxSyncScreenShown()
         app.navigationBars["Client.FxAContentView"].buttons["Done"].tap()
-        navigator.nowAt(LibraryPanel_History)
+        navigator.nowAt(LibraryPanel_SyncedTabs)
     }
 
     private func checkFirefoxSyncScreenShown() {

--- a/XCUITests/PrivateBrowsingTest.swift
+++ b/XCUITests/PrivateBrowsingTest.swift
@@ -20,8 +20,8 @@ class PrivateBrowsingTest: BaseTestCase {
         waitForExistence(app.tables["History List"])
 
         XCTAssertTrue(app.tables["History List"].staticTexts[url1Label].exists)
-        // History without counting Clear Recent History, Recently Closed and Synced devices
-        let history = app.tables["History List"].cells.count - 3
+        // History without counting Clear Recent History and Recently Closed
+        let history = app.tables["History List"].cells.count - 2
 
         XCTAssertEqual(history, 1, "History entries in regular browsing do not match")
 
@@ -36,7 +36,7 @@ class PrivateBrowsingTest: BaseTestCase {
         XCTAssertFalse(app.tables["History List"].staticTexts[url2Label].exists)
 
         // Open one tab in private browsing and check the total number of tabs
-        let privateHistory = app.tables["History List"].cells.count - 3
+        let privateHistory = app.tables["History List"].cells.count - 2
         XCTAssertEqual(privateHistory, 1, "History entries in private browsing do not match")
     }
 


### PR DESCRIPTION
Fix #5764 after the new Sync tabs option added in homescreen instead of History. Tests updated accordingly to access History as it is defined now