### PR TITLE
Fix #5779 - Panel buttons too close to each other

### DIFF
--- a/Client/Frontend/Library/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController.swift
@@ -238,18 +238,31 @@ class LibraryPanelButton: UIButton {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 5, right: 0)
-        addSubview(nameLabel)
-        nameLabel.snp.makeConstraints { make in
-            make.bottom.equalToSuperview()
-            make.centerX.equalToSuperview()
-            make.width.equalToSuperview()
+
+        // For iPhone 5 screen, don't show the button labels
+        if DeviceInfo.screenSizeOrientationIndependent().width > 320 {
+            if traitCollection.userInterfaceIdiom == .phone {
+                imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 14, right: 0)
+            }
+            addSubview(nameLabel)
+            nameLabel.snp.makeConstraints { make in
+                if traitCollection.userInterfaceIdiom == .phone {
+                    // On phone screen move the label up slightly off the bottom
+                    make.bottom.equalToSuperview().inset(4)
+                } else {
+                    // On the iPad, move the label down slightly
+                    make.bottom.equalToSuperview().offset(4)
+                }
+
+                make.centerX.equalToSuperview()
+                make.width.equalToSuperview()
+            }
+            nameLabel.adjustsFontSizeToFitWidth = true
+            nameLabel.minimumScaleFactor = 0.7
+            nameLabel.numberOfLines = 1
+            nameLabel.font = UIFont.systemFont(ofSize: DynamicFontHelper.defaultHelper.DefaultSmallFontSize - 1)
+            nameLabel.textAlignment = .center
         }
-        nameLabel.adjustsFontSizeToFitWidth = true
-        nameLabel.minimumScaleFactor = 0.7
-        nameLabel.numberOfLines = 1
-        nameLabel.font = DynamicFontHelper.defaultHelper.SmallSizeRegularWeightAS
-        nameLabel.textAlignment = .center
     }
 
     required init(coder: NSCoder) {

--- a/Client/Frontend/Widgets/DrawerViewController.swift
+++ b/Client/Frontend/Widgets/DrawerViewController.swift
@@ -12,7 +12,7 @@ struct DrawerViewControllerUX {
     static let HandleMargin: CGFloat = 20
     static let DrawerCornerRadius: CGFloat = 10
     static let DrawerTopStop: CGFloat = 60
-    static let DrawerPadWidth: CGFloat = 320
+    static let DrawerPadWidth: CGFloat = 380
 }
 
 public class DrawerView: UIView {

--- a/Extensions/ShareTo/InitialViewController.swift
+++ b/Extensions/ShareTo/InitialViewController.swift
@@ -7,19 +7,13 @@ import SnapKit
 import Shared
 import Storage
 
-// Reports portrait screen size regardless of the current orientation.
-func screenSizeOrientationIndependent() -> CGSize {
-    let screenSize = UIScreen.main.bounds.size
-    return CGSize(width: min(screenSize.width, screenSize.height), height: max(screenSize.width, screenSize.height))
-}
-
 // Small iPhone screens in landscape require that the popup have a shorter height.
 func isLandscapeSmallScreen(_ traitCollection: UITraitCollection) -> Bool {
     if !UX.enableResizeRowsForSmallScreens {
         return false
     }
 
-    let hasSmallScreen = screenSizeOrientationIndependent().width <= CGFloat(UX.topViewWidth)
+    let hasSmallScreen = DeviceInfo.screenSizeOrientationIndependent().width <= CGFloat(UX.topViewWidth)
     return hasSmallScreen && traitCollection.verticalSizeClass == .compact
 }
 
@@ -47,7 +41,7 @@ class EmbeddedNavController {
         parent.addChild(navigationController)
         parent.view.addSubview(navigationController.view)
 
-        let width = min(screenSizeOrientationIndependent().width * 0.90, CGFloat(UX.topViewWidth))
+        let width = min(DeviceInfo.screenSizeOrientationIndependent().width * 0.90, CGFloat(UX.topViewWidth))
 
         let initialHeight = isSearchMode ? UX.topViewHeightForSearchMode : UX.topViewHeight
         navigationController.view.snp.makeConstraints { make in

--- a/Shared/DeviceInfo.swift
+++ b/Shared/DeviceInfo.swift
@@ -72,4 +72,10 @@ open class DeviceInfo {
             return false
         }
     }
+
+    // Reports portrait screen size regardless of the current orientation.
+    open class func screenSizeOrientationIndependent() -> CGSize {
+        let screenSize = UIScreen.main.bounds.size
+        return CGSize(width: min(screenSize.width, screenSize.height), height: max(screenSize.width, screenSize.height))
+    }
 }


### PR DESCRIPTION
On iPhone 5, hide the labels,
On other devices make the label 1 pt smaller.
On iPads, increase the width of the slide-out-drawer
Also minor adjustments to vertical spacing of the button labels
