### PR TITLE
Fix for issue #5795

### DIFF
--- a/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
+++ b/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
@@ -273,6 +273,12 @@ class ErrorPageHelper {
                    location.replace(url.toString());
                 })();
             """)
+
+            components.queryItems = queryItems
+            if let urlWithQuery = components.url {
+                webView.load(PrivilegedRequest(url: urlWithQuery) as URLRequest)
+            }
+            
             return
         }
 

--- a/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
+++ b/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
@@ -255,6 +255,15 @@ class ErrorPageHelper {
             return
         }
 
+        var queryItems = [
+            URLQueryItem(name: InternalURL.Param.url.rawValue, value: url.absoluteString),
+            URLQueryItem(name: "code", value: String(error.code)),
+            URLQueryItem(name: "domain", value: error.domain),
+            URLQueryItem(name: "description", value: error.localizedDescription),
+            // 'timestamp' is used for the js reload logic
+            URLQueryItem(name: "timestamp", value: "\(Int(Date().timeIntervalSince1970 * 1000))")
+        ]
+
         // When an error page is reloaded, the js on the page checks if >2s have passed since the error page was initially loaded, and if so, it reloads the original url for the page. If that original page immediately errors out again, we don't want to push another error page on history stack. This will detect this case, and clear the timestamp to ensure the error page doesn't try to reload.
         if let internalUrl = InternalURL(webViewUrl), internalUrl.originalURLFromErrorPage == url {
             webView.evaluateJavaScript("""
@@ -266,15 +275,6 @@ class ErrorPageHelper {
             """)
             return
         }
-
-        var queryItems = [
-            URLQueryItem(name: InternalURL.Param.url.rawValue, value: url.absoluteString),
-            URLQueryItem(name: "code", value: String(error.code)),
-            URLQueryItem(name: "domain", value: error.domain),
-            URLQueryItem(name: "description", value: error.localizedDescription),
-            // 'timestamp' is used for the js reload logic
-            URLQueryItem(name: "timestamp", value: "\(Int(Date().timeIntervalSince1970 * 1000))")
-        ]
 
         // If this is an invalid certificate, show a certificate error allowing the
         // user to go back or continue. The certificate itself is encoded and added as


### PR DESCRIPTION
Avoids getting a white screen whenever the user reloads or uses the "Try again" button when inside a "Connection error" view in less than 2 seconds. Before returning from the js function, a web view with the appropriate error is displayed by WebKit.