### PR TITLE
Fix #5713 - youtube on ipad showing unsupported browser message

### DIFF
--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -10,7 +10,7 @@ open class UserAgent {
     public static let uaBitMobile = "Mobile/15E148"
 
     // For iPad, we need to append this to the default UA for google.com to show correct page
-    public static let uaBitGoogleIpad = "Version/7.0.3"
+    public static let uaBitGoogleIpad = "Version/13.0.3"
 
     private static var defaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!
 


### PR DESCRIPTION
The version number used matches Safari on iOS 13.2