### PR TITLE
Fix #5714 - ETP label is truncated in Settings

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -71,7 +71,7 @@ class Setting: NSObject {
         cell.detailTextLabel?.numberOfLines = 0
         cell.textLabel?.assign(attributed: title)
         cell.textLabel?.textAlignment = textAlignment
-        cell.textLabel?.numberOfLines = 1
+        cell.textLabel?.numberOfLines = 0
         cell.textLabel?.lineBreakMode = .byTruncatingTail
         cell.accessoryType = accessoryType
         cell.accessoryView = accessoryView


### PR DESCRIPTION
- Set the ETP label to support multiple lines of text instead of single line
- Fixed the issue where the ETP label was truncated for longer strings in some languages (Eg. French) 

