### PR TITLE
Fix #5597: Follow up patch, call self.shutdownProfileWhenNotActive in all bg cases

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -392,7 +392,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         var taskId: UIBackgroundTaskIdentifier = UIBackgroundTaskIdentifier(rawValue: 0)
         taskId = application.beginBackgroundTask (expirationHandler: {
             print("Running out of background time, but we have a profile shutdown pending.")
-            // Do not try to forceClose the db, it will lock the main thread and app will get killed
+            self.shutdownProfileWhenNotActive(application)
             application.endBackgroundTask(taskId)
         })
 
@@ -554,11 +554,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             // If syncing, create a bg task because _shutdown() is blocking and might take a few seconds to complete
             var taskId = UIBackgroundTaskIdentifier(rawValue: 0)
             taskId = application.beginBackgroundTask(expirationHandler: {
+                self.shutdownProfileWhenNotActive(application)
                 application.endBackgroundTask(taskId)
             })
 
             DispatchQueue.main.async {
-                self.profile?._shutdown()
+                self.shutdownProfileWhenNotActive(application)
                 application.endBackgroundTask(taskId)
             }
         } else {


### PR DESCRIPTION
I originally did not call shutdownProfileWhenNotActive in all cases, as it locks up the main thread. However, if this locks up main and the app is killed, the app would have been killed anyway due to files staying locked, and in many cases this actually succeeds in stopping the sync and closes the db. The last point was proven by 20.2 release, whereby shutdownProfileWhenNotActive was removed and the crash rates went up, thus proving it is not shutdownProfileWhenNotActive locking the main thread that is the primary problem (and it in fact succeeds often in shutting down the db/sync)