### PR TITLE
Fix #5844 - Library panel buttons are cutoff on iOS 12

### DIFF
--- a/Client/Frontend/Library/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController.swift
@@ -238,15 +238,25 @@ class LibraryPanelButton: UIButton {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+        
+        setupLibraryPanel()
+    }
 
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    fileprivate func setupLibraryPanel() {
+        
         // For iPhone 5 screen, don't show the button labels
         if DeviceInfo.screenSizeOrientationIndependent().width > 320 {
-            if traitCollection.userInterfaceIdiom == .phone {
+            let currentDeviceType = UIDevice.current.userInterfaceIdiom
+            if currentDeviceType == .phone {
                 imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 14, right: 0)
             }
             addSubview(nameLabel)
             nameLabel.snp.makeConstraints { make in
-                if traitCollection.userInterfaceIdiom == .phone {
+                if currentDeviceType == .phone {
                     // On phone screen move the label up slightly off the bottom
                     make.bottom.equalToSuperview().inset(4)
                 } else {
@@ -263,10 +273,6 @@ class LibraryPanelButton: UIButton {
             nameLabel.font = UIFont.systemFont(ofSize: DynamicFontHelper.defaultHelper.DefaultSmallFontSize - 1)
             nameLabel.textAlignment = .center
         }
-    }
-
-    required init(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
     }
 }
 


### PR DESCRIPTION
Fixed issue where the UserInterfaceIdiom wasn't getting the correct type of device on iOS 12. 
Due to this even though the constraints etc. are fine the phone didn't display correct height for labels. 

Using the UserInterfaceIdiom from the current uidevice gives the correct type of device. Also, did little bit of refactoring. 

Tested on iPhone 8 (iOS 12) and (iOS 13) 