### PR TITLE
Fix #5862 - Reading list text is not fully displayed in landscapeMode

### DIFF
--- a/Client/Frontend/Library/ReaderPanel.swift
+++ b/Client/Frontend/Library/ReaderPanel.swift
@@ -267,7 +267,7 @@ class ReadingListPanel: UITableViewController, LibraryPanel {
         welcomeLabel.adjustsFontSizeToFitWidth = true
         welcomeLabel.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.top.equalToSuperview().offset(150)
+            make.top.equalToSuperview().offset(UIDevice.current.orientation.isLandscape ? 16 : 150)
             make.width.equalTo(ReadingListPanelUX.WelcomeScreenItemWidth + ReadingListPanelUX.WelcomeScreenCircleSpacer + ReadingListPanelUX.WelcomeScreenCircleWidth)
         }
 


### PR DESCRIPTION
This PR fixes #5862

<img width="555" alt="Screen Shot 2019-12-07 at 15 00 02" src="https://user-images.githubusercontent.com/19792753/70374387-95ad1a00-1902-11ea-98d2-9facdc3a3905.png">
<img width="990" alt="Screen Shot 2019-12-07 at 15 00 07" src="https://user-images.githubusercontent.com/19792753/70374388-95ad1a00-1902-11ea-870e-32aa8e3250fa.png">


