### PR TITLE
Fix #5877 - [iPad][iOS 12.x] Library panel buttons are cut off

### DIFF
--- a/Client/Frontend/Library/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController.swift
@@ -253,6 +253,8 @@ class LibraryPanelButton: UIButton {
             let currentDeviceType = UIDevice.current.userInterfaceIdiom
             if currentDeviceType == .phone {
                 imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 14, right: 0)
+            } else {
+                imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 12, right: 0)
             }
             addSubview(nameLabel)
             nameLabel.snp.makeConstraints { make in
@@ -261,7 +263,7 @@ class LibraryPanelButton: UIButton {
                     make.bottom.equalToSuperview().inset(4)
                 } else {
                     // On the iPad, move the label down slightly
-                    make.bottom.equalToSuperview().offset(4)
+                    make.bottom.equalToSuperview().inset(2)
                 }
 
                 make.centerX.equalToSuperview()


### PR DESCRIPTION
Fixed the bottom right padding issues on iPad for Bookmark View.


<img width="1412" alt="image" src="https://user-images.githubusercontent.com/8919439/70477146-34be4700-1aa6-11ea-9791-c88d49c2ef7a.png">
