### PR TITLE
Fix #5864 Bookmarks wraps on iPhone SE

### DIFF
--- a/Client/Frontend/Home/FirefoxHomeTopSitesCell.swift
+++ b/Client/Frontend/Home/FirefoxHomeTopSitesCell.swift
@@ -42,7 +42,10 @@ class TopSiteItemCell: UICollectionViewCell, Themeable {
 
     lazy fileprivate var titleLabel: UILabel = {
         let titleLabel = UILabel()
-        titleLabel.layer.masksToBounds = true
+        titleLabel.adjustsFontSizeToFitWidth = true
+        titleLabel.minimumScaleFactor = 0.7
+        titleLabel.lineBreakMode = .byWordWrapping
+        titleLabel.numberOfLines = 2
         titleLabel.textAlignment = .center
         titleLabel.font = TopSiteCellUX.TitleFont
         return titleLabel

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -1035,6 +1035,7 @@ class LibraryShortcutView: UIView {
         }
         title.adjustsFontSizeToFitWidth = true
         title.minimumScaleFactor = 0.7
+        title.lineBreakMode = .byWordWrapping
         title.numberOfLines = 2
         title.font = DynamicFontHelper.defaultHelper.SmallSizeRegularWeightAS
         title.textAlignment = .center

--- a/Client/Helpers/DynamicFontHelper.swift
+++ b/Client/Helpers/DynamicFontHelper.swift
@@ -21,7 +21,7 @@ class DynamicFontHelper: NSObject {
         defaultStandardFontSize = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body).pointSize // 14pt -> 17pt -> 23pt
         deviceFontSize = defaultStandardFontSize * (UIDevice.current.userInterfaceIdiom == .pad ? iPadFactor : iPhoneFactor)
         defaultMediumFontSize = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .footnote).pointSize // 12pt -> 13pt -> 19pt
-        defaultSmallFontSize = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .caption1).pointSize // 11pt -> 12pt -> 17pt
+        defaultSmallFontSize = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .caption2).pointSize // 11pt -> 12pt -> 17pt
 
         super.init()
     }


### PR DESCRIPTION
* Set defaultSmallFontSize to caption2 - the font used for alternate captions.
* Shrinking text to fit label size in FirefoxHomeView
