### PR TITLE
Fix #5869: Increased tap area of Switch button by adding additional clear button for ease of use

### DIFF
--- a/Client/Frontend/Browser/ButtonToast.swift
+++ b/Client/Frontend/Browser/ButtonToast.swift
@@ -14,6 +14,12 @@ struct ButtonToastUX {
     static let ToastButtonBorderWidth: CGFloat = 1
     static let ToastLabelFont = UIFont.systemFont(ofSize: 15, weight: .semibold)
     static let ToastDescriptionFont = UIFont.systemFont(ofSize: 13)
+    
+    struct ToastButtonPaddedView {
+        static let WidthOffset: CGFloat = 20.0
+        static let TopOffset: CGFloat = 5.0
+        static let BottomOffset: CGFloat = 20.0
+    }
 }
 
 class ButtonToast: Toast {
@@ -31,7 +37,8 @@ class ButtonToast: Toast {
         self.completionHandler = completion
 
         self.clipsToBounds = true
-        self.addSubview(createView(labelText, descriptionText: descriptionText, imageName: imageName, buttonText: buttonText, textAlignment: textAlignment))
+        let createdToastView = createView(labelText, descriptionText: descriptionText, imageName: imageName, buttonText: buttonText, textAlignment: textAlignment)
+        self.addSubview(createdToastView)
 
         self.toastView.backgroundColor = backgroundColor
 
@@ -60,7 +67,7 @@ class ButtonToast: Toast {
             icon.tintColor = UIColor.Photon.White100
             horizontalStackView.addArrangedSubview(icon)
         }
-
+        
         let labelStackView = UIStackView()
         labelStackView.axis = .vertical
         labelStackView.alignment = .leading
@@ -90,29 +97,7 @@ class ButtonToast: Toast {
         }
 
         horizontalStackView.addArrangedSubview(labelStackView)
-
-        if let buttonText = buttonText {
-            let button = HighlightableButton()
-            button.layer.cornerRadius = ButtonToastUX.ToastButtonBorderRadius
-            button.layer.borderWidth = ButtonToastUX.ToastButtonBorderWidth
-            button.layer.borderColor = UIColor.Photon.White100.cgColor
-            button.setTitle(buttonText, for: [])
-            button.setTitleColor(toastView.backgroundColor, for: .highlighted)
-            button.titleLabel?.font = SimpleToastUX.ToastFont
-            button.titleLabel?.numberOfLines = 1
-            button.titleLabel?.lineBreakMode = .byClipping
-            button.titleLabel?.adjustsFontSizeToFitWidth = true
-            button.titleLabel?.minimumScaleFactor = 0.1
-            button.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(buttonPressed)))
-
-            button.snp.makeConstraints { (make) in
-                make.width.equalTo(button.titleLabel!.intrinsicContentSize.width + 4 * ButtonToastUX.ToastButtonPadding)
-                make.height.equalTo(button.titleLabel!.intrinsicContentSize.height + 2 * ButtonToastUX.ToastButtonPadding )
-            }
-
-            horizontalStackView.addArrangedSubview(button)
-        }
-
+        setupPaddedButton(stackView: horizontalStackView, buttonText: buttonText)
         toastView.addSubview(horizontalStackView)
 
         if textAlignment == .center {
@@ -125,24 +110,66 @@ class ButtonToast: Toast {
             }
         }
 
+        labelStackView.snp.makeConstraints { make in
+            make.centerY.equalTo(horizontalStackView.snp.centerY)
+        }
+        
         horizontalStackView.snp.makeConstraints { make in
-            make.centerX.equalTo(toastView)
-            make.centerY.equalTo(toastView)
-            make.width.equalTo(toastView.snp.width).offset(-2 * ButtonToastUX.ToastPadding)
+            make.left.equalTo(toastView.snp.left).offset(ButtonToastUX.ToastPadding)
+            make.right.equalTo(toastView.snp.right)
             make.bottom.equalTo(toastView.safeArea.bottom)
             make.top.equalTo(toastView.snp.top)
             make.height.equalTo(ButtonToastUX.ToastHeight)
         }
-
         return toastView
     }
-
-    @objc func buttonPressed(_ gestureRecognizer: UIGestureRecognizer) {
-        completionHandler?(true)
-        dismiss(true)
+    
+    func setupPaddedButton(stackView: UIStackView, buttonText: String?) {
+        guard let buttonText = buttonText else { return }
+            
+        let paddedView = UIView()
+        paddedView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.addArrangedSubview(paddedView)
+        paddedView.snp.makeConstraints { make in
+            make.top.equalTo(stackView.snp.top).offset(ButtonToastUX.ToastButtonPaddedView.TopOffset)
+            make.bottom.equalTo(stackView.snp.bottom).offset(ButtonToastUX.ToastButtonPaddedView.BottomOffset)
+        }
+        
+        let roundedButton = HighlightableButton()
+        roundedButton.translatesAutoresizingMaskIntoConstraints = false
+        roundedButton.layer.cornerRadius = ButtonToastUX.ToastButtonBorderRadius
+        roundedButton.layer.borderWidth = ButtonToastUX.ToastButtonBorderWidth
+        roundedButton.layer.borderColor = UIColor.Photon.White100.cgColor
+        roundedButton.setTitle(buttonText, for: [])
+        roundedButton.setTitleColor(toastView.backgroundColor, for: .highlighted)
+        roundedButton.titleLabel?.font = SimpleToastUX.ToastFont
+        roundedButton.titleLabel?.numberOfLines = 1
+        roundedButton.titleLabel?.lineBreakMode = .byClipping
+        roundedButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        roundedButton.titleLabel?.minimumScaleFactor = 0.1
+        paddedView.addSubview(roundedButton)
+        roundedButton.snp.makeConstraints { make in
+            make.height.equalTo(roundedButton.titleLabel!.intrinsicContentSize.height + 2 * ButtonToastUX.ToastButtonPadding)
+            make.width.equalTo(roundedButton.titleLabel!.intrinsicContentSize.width + 2 * ButtonToastUX.ToastButtonPadding)
+            make.centerY.centerX.equalToSuperview()
+        }
+        roundedButton.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(buttonPressed)))
+        
+        paddedView.snp.makeConstraints { make in
+            make.top.equalTo(stackView.snp.top)
+            make.bottom.equalTo(stackView.snp.bottom)
+            make.width.equalTo(roundedButton.snp.width).offset(ButtonToastUX.ToastButtonPaddedView.WidthOffset)
+        }
+        paddedView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(buttonPressed)))
     }
 
     override func showToast(viewController: UIViewController? = nil, delay: DispatchTimeInterval = SimpleToastUX.ToastDelayBefore, duration: DispatchTimeInterval? = SimpleToastUX.ToastDismissAfter, makeConstraints: @escaping (SnapKit.ConstraintMaker) -> Swift.Void) {
         super.showToast(viewController: viewController, delay: delay, duration: duration, makeConstraints: makeConstraints)
+    }
+    
+    // MARK: - Button action
+    @objc func buttonPressed() {
+        completionHandler?(true)
+        dismiss(true)
     }
 }


### PR DESCRIPTION
The idea here is to add more area for user to be able to tap on the "Switch" button when they open a new tab. 