### PR TITLE
Fix #5781 - [iPad] Tabs tray layout is not correct when entering split screen

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -48,7 +48,6 @@ class TabTrayController: UIViewController {
     var collectionView: UICollectionView!
 
     let statusBarBG = UIView()
-
     lazy var toolbar: TrayToolbar = {
         let toolbar = TrayToolbar()
         toolbar.addTabButton.addTarget(self, action: #selector(didTapToolbarAddTab), for: .touchUpInside)
@@ -131,12 +130,17 @@ class TabTrayController: UIViewController {
         self.view.layoutIfNeeded()
     }
 
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        // When the app enters split screen mode we refresh the collection view layout to show the proper grid
+        collectionView.collectionViewLayout.invalidateLayout()
+    }
+    
     deinit {
         tabManager.removeDelegate(self.tabDisplayManager)
         tabManager.removeDelegate(self)
         tabDisplayManager = nil
     }
-
+    
     func focusTab() {
         guard let currentTab = tabManager.selectedTab, let index = self.tabDisplayManager.dataStore.index(of: currentTab), let rect = self.collectionView.layoutAttributesForItem(at: IndexPath(item: index, section: 0))?.frame else {
             return


### PR DESCRIPTION
Tabs collection view layout wasn't being refreshed when the the app entered split screen mode. Now when the user changes the width while in split screen mode the code changes accommodates for refreshing the collection view layout. 

- Run Firefox on iPad 
- Open many tabs (Eg. 10)
- Go to the tabs collection (Tray) 
- Now add another app Eg. Messages as a split screen app 
- It should show the proper layout

<img width="796" alt="image" src="https://user-images.githubusercontent.com/8919439/71034785-2bf1f480-20e8-11ea-9745-dfa99dd058e2.png">
