### PR TITLE
Fix #5909 - Remove border on built-in icons

### DIFF
--- a/Client/Extensions/UIImageViewExtensions.swift
+++ b/Client/Extensions/UIImageViewExtensions.swift
@@ -20,15 +20,18 @@ extension UIColor {
 
 public extension UIImageView {
 
-    func setIcon(_ icon: Favicon?, forURL url: URL?, completed completion: ((UIColor, URL?) -> Void)? = nil ) {
-        func finish(filePath: String?, bgColor: UIColor) {
+    func setIcon(_ icon: Favicon?, forURL url: URL?, completed completion: ((UIColor?, URL?) -> Void)? = nil ) {
+        func finish(filePath: String?, bgColor: UIColor?) {
             if let filePath = filePath {
                 self.image = UIImage(contentsOfFile: filePath)
             }
+            
             // If the background color is clear, we may decide to set our own background based on the theme.
-            let color = bgColor.components.alpha < 0.01 ? UIColor.theme.general.faviconBackground : bgColor
-            self.backgroundColor = color
-            completion?(color, url)
+            if let color = bgColor, color.components.alpha < 0.01 {
+                completion?(UIColor.theme.general.faviconBackground, url)
+            } else {
+                completion?(bgColor, url)
+            }
         }
 
         if let url = url, let defaultIcon = FaviconFetcher.getDefaultIconForURL(url: url) {
@@ -51,18 +54,17 @@ public extension UIImageView {
    /*
     * Fetch a background color for a specfic favicon UIImage. It uses the URL to store the UIColor in memory for subsequent requests.
     */
-    private func color(forImage image: UIImage, andURL url: URL, completed completionBlock: ((UIColor) -> Void)? = nil) {
+    private func color(forImage image: UIImage, andURL url: URL, completed completionBlock: ((UIColor?) -> Void)? = nil) {
         let domain = url.domainURL.absoluteString
         if let color = FaviconFetcher.colors[domain] {
             self.backgroundColor = color
             completionBlock?(color)
         } else {
-            completionBlock?(UIColor.Photon.White100)
-            FaviconFetcher.colors[domain] = UIColor.Photon.White100
+            completionBlock?(nil)
         }
     }
 
-    func setFavicon(forSite site: Site, onCompletion completionBlock: ((UIColor, URL?) -> Void)? = nil ) {
+    func setFavicon(forSite site: Site, onCompletion completionBlock: ((UIColor?, URL?) -> Void)? = nil ) {
         self.setIcon(site.icon, forURL: site.tileURL, completed: completionBlock)
     }
 

--- a/Client/Frontend/Home/FirefoxHomeTopSitesCell.swift
+++ b/Client/Frontend/Home/FirefoxHomeTopSitesCell.swift
@@ -161,11 +161,10 @@ class TopSiteItemCell: UICollectionViewCell, Themeable {
                     guard let faviconBG = self?.faviconBG , let frame = self?.frame else { return }
                     if color == nil {
                         make.size.equalTo(frame.width)
-                        make.center.equalTo(faviconBG)
                     } else {
                         make.size.equalTo(floor(frame.width * TopSiteCellUX.IconSizePercent))
-                        make.center.equalTo(faviconBG)
                     }
+                     make.center.equalTo(faviconBG)
                 }
             }
         })

--- a/Client/Frontend/Home/FirefoxHomeTopSitesCell.swift
+++ b/Client/Frontend/Home/FirefoxHomeTopSitesCell.swift
@@ -52,7 +52,6 @@ class TopSiteItemCell: UICollectionViewCell, Themeable {
         let view = UIView()
         view.layer.cornerRadius = TopSiteCellUX.CellCornerRadius
         view.layer.masksToBounds = true
-        view.layer.borderWidth = TopSiteCellUX.BorderWidth
         return view
     }()
 
@@ -157,15 +156,25 @@ class TopSiteItemCell: UICollectionViewCell, Themeable {
                 self?.imageView.image = tempImageView.image
                 self?.faviconBG.backgroundColor = color
                 self?.imageView.backgroundColor = color
+                
+                self?.imageView.snp.remakeConstraints { make in
+                    guard let faviconBG = self?.faviconBG , let frame = self?.frame else { return }
+                    if color == nil {
+                        make.size.equalTo(frame.width)
+                        make.center.equalTo(faviconBG)
+                    } else {
+                        make.size.equalTo(floor(frame.width * TopSiteCellUX.IconSizePercent))
+                        make.center.equalTo(faviconBG)
+                    }
+                }
             }
         })
-
+        
         applyTheme()
     }
 
     func applyTheme() {
         imageView.tintColor = TopSiteCellUX.PinColor
-        faviconBG.layer.borderColor = TopSiteCellUX.BorderColor.cgColor
         selectedOverlay.backgroundColor = TopSiteCellUX.OverlayColor
         titleBorder.backgroundColor = TopSiteCellUX.BorderColor.cgColor
         titleLabel.backgroundColor = UIColor.clear


### PR DESCRIPTION
* remake constraints for imageView in TopSiteCell, it depends on color of the website,  if we have this color we set imageView width to 80% of cell.frame.width ( make.size.equalTo(floor(frame.width * TopSiteCellUX.IconSizePercent)) ) otherwise we set full size of cell.frame.width for imageView 
* if we dont have color we set it to nil and pass to completion handler  

