### PR TITLE
Fix #4700: Reader view should switch to a darker theme when using Night mode

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2314,9 +2314,17 @@ extension BrowserViewController: Themeable {
         let tabs = tabManager.tabs
         tabs.forEach { $0.applyTheme() }
 
-        if let readerMode = self.tabManager.selectedTab?.getContentScript(name: ReaderMode.name()) as? ReaderMode {
-            let theme = ReaderModeTheme(rawValue: ThemeManager.instance.currentName.rawValue) ?? .light
-            readerMode.style = ReaderModeStyle(theme: theme.preferredTheme, fontType: readerMode.style.fontType, fontSize: readerMode.style.fontSize)
+        guard let readerMode = self.tabManager.selectedTab?.getContentScript(name: ReaderMode.name()) as? ReaderMode else { return }            
+        readerMode.style = ReaderModeStyle(theme: theme,
+                                           fontType: readerMode.style.fontType,
+                                           fontSize: readerMode.style.fontSize)
+    }
+    
+    private var theme: ReaderModeTheme {
+        get {
+            guard let dict = profile.prefs.dictionaryForKey(ReaderModeProfileKeyStyle),
+                  let style = ReaderModeStyle(dict: dict) else { return ReaderModeTheme() }
+            return ReaderModeTheme().preferredTheme(for: style.theme)
         }
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2313,19 +2313,9 @@ extension BrowserViewController: Themeable {
 
         let tabs = tabManager.tabs
         tabs.forEach { $0.applyTheme() }
-
-        guard let readerMode = self.tabManager.selectedTab?.getContentScript(name: ReaderMode.name()) as? ReaderMode else { return }            
-        readerMode.style = ReaderModeStyle(theme: theme,
-                                           fontType: readerMode.style.fontType,
-                                           fontSize: readerMode.style.fontSize)
-    }
-    
-    private var theme: ReaderModeTheme {
-        get {
-            guard let dict = profile.prefs.dictionaryForKey(ReaderModeProfileKeyStyle),
-                  let style = ReaderModeStyle(dict: dict) else { return ReaderModeTheme() }
-            return ReaderModeTheme().preferredTheme(for: style.theme)
-        }
+        
+        guard let contentScript = self.tabManager.selectedTab?.getContentScript(name: ReaderMode.name()) else { return }
+        appyThemeForPreferences(profile.prefs, contentScript: contentScript)
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2313,6 +2313,11 @@ extension BrowserViewController: Themeable {
 
         let tabs = tabManager.tabs
         tabs.forEach { $0.applyTheme() }
+
+        if let readerMode = self.tabManager.selectedTab?.getContentScript(name: ReaderMode.name()) as? ReaderMode {
+            let theme = ReaderModeTheme(rawValue: ThemeManager.instance.currentName.rawValue) ?? .light
+            readerMode.style = ReaderModeStyle(theme: theme.preferredTheme, fontType: readerMode.style.fontType, fontSize: readerMode.style.fontSize)
+        }
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -23,7 +23,14 @@ extension BrowserViewController: ReaderModeDelegate {
 }
 
 extension BrowserViewController: ReaderModeStyleViewControllerDelegate {
-    func readerModeStyleViewController(_ readerModeStyleViewController: ReaderModeStyleViewController, didConfigureStyle style: ReaderModeStyle) {
+    func readerModeStyleViewController(_ readerModeStyleViewController: ReaderModeStyleViewController, 
+                                       didConfigureStyle style: ReaderModeStyle,
+                                       isUsingUserDefinedColor: Bool) {
+        var newStyle = style
+        if !isUsingUserDefinedColor {
+            newStyle.ensurePreferredColorThemeIfNeeded()
+        }
+        
         // Persist the new style to the profile
         let encodedStyle: [String: Any] = style.encodeAsDictionary()
         profile.prefs.setObject(encodedStyle, forKey: ReaderModeProfileKeyStyle)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -153,6 +153,10 @@ extension BrowserViewController {
         readerModeStyle.fontSize = ReaderModeFontSize.defaultSize
         self.readerModeStyleViewController(ReaderModeStyleViewController(), didConfigureStyle: readerModeStyle)
     }
+    
+    func appyThemeForPreferences(_ preferences: Prefs, contentScript: TabContentScript) {
+        ReaderModeStyleViewController().applyTheme(preferences, contentScript: contentScript)
+    }
 }
 
 extension BrowserViewController: ReaderModeBarViewDelegate {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -39,9 +39,9 @@ extension BrowserViewController: ReaderModeStyleViewControllerDelegate {
             if let tab = tabManager[tabIndex] {
                 if let readerMode = tab.getContentScript(name: "ReaderMode") as? ReaderMode {
                     if readerMode.state == ReaderModeState.active {
-                        readerMode.style = ReaderModeStyle(theme: style.theme,
-                                                           fontType: ReaderModeFontType(type: style.fontType.rawValue),
-                                                           fontSize: style.fontSize)
+                        readerMode.style = ReaderModeStyle(theme: newStyle.theme,
+                                                           fontType: ReaderModeFontType(type: newStyle.fontType.rawValue),
+                                                           fontSize: newStyle.fontSize)
                     }
                 }
             }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -158,7 +158,9 @@ extension BrowserViewController {
             }
         }
         readerModeStyle.fontSize = ReaderModeFontSize.defaultSize
-        self.readerModeStyleViewController(ReaderModeStyleViewController(), didConfigureStyle: readerModeStyle)
+        self.readerModeStyleViewController(ReaderModeStyleViewController(), 
+                                           didConfigureStyle: readerModeStyle, 
+                                           isUsingUserDefinedColor: false)
     }
     
     func appyThemeForPreferences(_ preferences: Prefs, contentScript: TabContentScript) {

--- a/Client/Frontend/Reader/ReaderMode.swift
+++ b/Client/Frontend/Reader/ReaderMode.swift
@@ -160,10 +160,6 @@ struct ReaderModeStyle {
         return ["theme": theme.rawValue, "fontType": fontType.rawValue, "fontSize": fontSize.rawValue]
     }
 
-    init() {
-        self.init(theme: ReaderModeTheme.preferredTheme(), fontType: .sansSerif, fontSize: ReaderModeFontSize.defaultSize)
-    }
-
     init(theme: ReaderModeTheme, fontType: ReaderModeFontType, fontSize: ReaderModeFontSize) {
         self.theme = theme
         self.fontType = fontType

--- a/Client/Frontend/Reader/ReaderMode.swift
+++ b/Client/Frontend/Reader/ReaderMode.swift
@@ -29,6 +29,10 @@ enum ReaderModeTheme: String {
     case light = "light"
     case dark = "dark"
     case sepia = "sepia"
+
+    init() {
+        self = ReaderModeTheme(rawValue: ThemeManager.instance.currentName.rawValue)?.preferredTheme() ?? .light
+    }
 }
 
 private struct FontFamily {
@@ -138,6 +142,10 @@ struct ReaderModeStyle {
     /// Encode the style to a dictionary that can be stored in the profile
     func encodeAsDictionary() -> [String: Any] {
         return ["theme": theme.rawValue, "fontType": fontType.rawValue, "fontSize": fontSize.rawValue]
+    }
+
+    init() {
+        self.init(theme: ReaderModeTheme(), fontType: .sansSerif, fontSize: ReaderModeFontSize.defaultSize)
     }
 
     init(theme: ReaderModeTheme, fontType: ReaderModeFontType, fontSize: ReaderModeFontSize) {

--- a/Client/Frontend/Reader/ReaderMode.swift
+++ b/Client/Frontend/Reader/ReaderMode.swift
@@ -174,6 +174,10 @@ struct ReaderModeStyle {
         self.fontType = fontType
         self.fontSize = fontSize!
     }
+    
+    mutating func ensurePreferredColorThemeIfNeeded() {
+        self.theme = ReaderModeTheme().preferredTheme(for: self.theme)
+    }
 }
 
 let DefaultReaderModeStyle = ReaderModeStyle(theme: .light, fontType: .sansSerif, fontSize: ReaderModeFontSize.defaultSize)

--- a/Client/Frontend/Reader/ReaderMode.swift
+++ b/Client/Frontend/Reader/ReaderMode.swift
@@ -30,15 +30,25 @@ enum ReaderModeTheme: String {
     case dark = "dark"
     case sepia = "sepia"
 
-    init() {
-        self = ReaderModeTheme(rawValue: ThemeManager.instance.currentName.rawValue)?.preferredTheme() ?? .light
+    static func preferredTheme(for theme: ReaderModeTheme? = nil) -> ReaderModeTheme {
+        // If there is no reader theme provided than we default to light theme
+        let readerTheme = theme ?? .light
+        // Get current Firefox theme (Dark vs Normal)
+        // Normal means light theme. This is the overall theme used
+        // by Firefox iOS app
+        let appWideTheme = ThemeManager.instance.currentName
+        // We check for 3 basic themes we have Light / Dark / Sepia
+        // Theme: Dark - app-wide dark overrides all
+        if appWideTheme == .dark {
+            return .dark
+        // Theme: Sepia - special case for when the theme is sepia.
+        // For this we only check the them supplied and not the app wide theme
+        } else if readerTheme == .sepia {
+            return .sepia
+        }
+        // Theme: Light - Default case for when there is no theme supplied i.e. nil and we revert to light
+        return readerTheme
     }
-}
-
-private struct FontFamily {
-    static let serifFamily = [ReaderModeFontType.serif, ReaderModeFontType.serifBold]
-    static let sansFamily = [ReaderModeFontType.sansSerif, ReaderModeFontType.sansSerifBold]
-    static let families = [serifFamily, sansFamily]
 }
 
 private struct FontFamily {
@@ -151,7 +161,7 @@ struct ReaderModeStyle {
     }
 
     init() {
-        self.init(theme: ReaderModeTheme(), fontType: .sansSerif, fontSize: ReaderModeFontSize.defaultSize)
+        self.init(theme: ReaderModeTheme.preferredTheme(), fontType: .sansSerif, fontSize: ReaderModeFontSize.defaultSize)
     }
 
     init(theme: ReaderModeTheme, fontType: ReaderModeFontType, fontSize: ReaderModeFontSize) {
@@ -182,7 +192,7 @@ struct ReaderModeStyle {
     }
     
     mutating func ensurePreferredColorThemeIfNeeded() {
-        self.theme = ReaderModeTheme().preferredTheme(for: self.theme)
+        self.theme = ReaderModeTheme.preferredTheme(for: self.theme)
     }
 }
 

--- a/Client/Frontend/Reader/ReaderMode.swift
+++ b/Client/Frontend/Reader/ReaderMode.swift
@@ -41,6 +41,12 @@ private struct FontFamily {
     static let families = [serifFamily, sansFamily]
 }
 
+private struct FontFamily {
+    static let serifFamily = [ReaderModeFontType.serif, ReaderModeFontType.serifBold]
+    static let sansFamily = [ReaderModeFontType.sansSerif, ReaderModeFontType.sansSerifBold]
+    static let families = [serifFamily, sansFamily]
+}
+
 enum ReaderModeFontType: String {
     case serif = "serif"
     case serifBold = "serif-bold"

--- a/Client/Frontend/Reader/ReaderMode.swift
+++ b/Client/Frontend/Reader/ReaderMode.swift
@@ -162,7 +162,7 @@ struct ReaderModeStyle {
             return nil
         }
 
-        self.theme = theme!
+        self.theme = theme ?? ReaderModeTheme.preferredTheme()
         self.fontType = fontType
         self.fontSize = fontSize!
     }

--- a/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -42,7 +42,7 @@ struct ReaderModeHandlers {
                                 style.ensurePreferredColorThemeIfNeeded()
                                 readerModeStyle = style
                         } else {
-                            readerModeStyle.theme = ReaderModeTheme()
+                            readerModeStyle.theme = ReaderModeTheme.preferredTheme()
                         }
                         if let html = ReaderModeUtils.generateReaderContent(readabilityResult, initialStyle: readerModeStyle),
                             let response = GCDWebServerDataResponse(html: html) {

--- a/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -39,7 +39,7 @@ struct ReaderModeHandlers {
                         var readerModeStyle = DefaultReaderModeStyle
                         if let dict = profile.prefs.dictionaryForKey(ReaderModeProfileKeyStyle),
                            var style = ReaderModeStyle(dict: dict) {
-                                style.theme = ReaderModeTheme().preferredTheme(for: style.theme)
+                                style.ensurePreferredColorThemeIfNeeded()
                                 readerModeStyle = style
                         } else {
                             readerModeStyle.theme = ReaderModeTheme()

--- a/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -37,10 +37,12 @@ struct ReaderModeHandlers {
                         // We have this page in our cache, so we can display it. Just grab the correct style from the
                         // profile and then generate HTML from the Readability results.
                         var readerModeStyle = DefaultReaderModeStyle
-                        if let dict = profile.prefs.dictionaryForKey(ReaderModeProfileKeyStyle) {
-                            if let style = ReaderModeStyle(dict: dict) {
+                        if let dict = profile.prefs.dictionaryForKey(ReaderModeProfileKeyStyle),
+                           var style = ReaderModeStyle(dict: dict) {
+                                style.theme = ReaderModeTheme().preferredTheme(for: style.theme)
                                 readerModeStyle = style
-                            }
+                        } else {
+                            readerModeStyle.theme = ReaderModeTheme()
                         }
                         if let html = ReaderModeUtils.generateReaderContent(readabilityResult, initialStyle: readerModeStyle),
                             let response = GCDWebServerDataResponse(html: html) {

--- a/Client/Frontend/Reader/ReaderModeStyleViewController.swift
+++ b/Client/Frontend/Reader/ReaderModeStyleViewController.swift
@@ -47,24 +47,6 @@ class ReaderModeStyleViewController: UIViewController, Themeable {
     fileprivate var fontTypeRow: UIView!
     fileprivate var fontSizeRow: UIView!
     fileprivate var brightnessRow: UIView!
-
-    func applyTheme() {
-        fontTypeRow.backgroundColor = UIColor.theme.tableView.rowBackground
-        fontSizeRow.backgroundColor = UIColor.theme.tableView.rowBackground
-        brightnessRow.backgroundColor = UIColor.theme.tableView.rowBackground
-        fontSizeLabel.textColor = UIColor.theme.tableView.rowText
-        fontTypeButtons.forEach { button in
-            button.setTitleColor(UIColor.theme.tableView.rowText, for: .selected)
-            button.setTitleColor(UIColor.Photon.Grey40, for: [])
-        }
-        fontSizeButtons.forEach { button in
-            button.setTitleColor(UIColor.theme.tableView.rowText, for: .normal)
-            button.setTitleColor(UIColor.theme.tableView.disabledRowText, for: .disabled)
-        }
-        separatorLines.forEach { line in
-            line.backgroundColor = UIColor.theme.tableView.separator
-        }
-    }
     
     override func viewDidLoad() {
         // Our preferred content size has a fixed width and height based on the rows + padding
@@ -189,6 +171,37 @@ class ReaderModeStyleViewController: UIViewController, Themeable {
         slider.value = Float(UIScreen.main.brightness)
         
         applyTheme()
+    }
+    
+    
+    // MARK: - Theme
+    func applyTheme() {
+        fontTypeRow.backgroundColor = UIColor.theme.tableView.rowBackground
+        fontSizeRow.backgroundColor = UIColor.theme.tableView.rowBackground
+        brightnessRow.backgroundColor = UIColor.theme.tableView.rowBackground
+        fontSizeLabel.textColor = UIColor.theme.tableView.rowText
+        fontTypeButtons.forEach { button in
+            button.setTitleColor(UIColor.theme.tableView.rowText, for: .selected)
+            button.setTitleColor(UIColor.Photon.Grey40, for: [])
+        }
+        fontSizeButtons.forEach { button in
+            button.setTitleColor(UIColor.theme.tableView.rowText, for: .normal)
+            button.setTitleColor(UIColor.theme.tableView.disabledRowText, for: .disabled)
+        }
+        separatorLines.forEach { line in
+            line.backgroundColor = UIColor.theme.tableView.separator
+        }
+    }
+    
+    func applyTheme(_ preferences: Prefs, contentScript: TabContentScript) {        
+        guard let readerPreferences = preferences.dictionaryForKey(ReaderModeProfileKeyStyle),
+              let readerMode = contentScript as? ReaderMode,
+              let style = ReaderModeStyle(dict: readerPreferences) else { return }
+        
+        let theme = ReaderModeTheme().preferredTheme(for: style.theme)
+        readerMode.style = ReaderModeStyle(theme: theme,
+                                           fontType: readerModeStyle.fontType,
+                                           fontSize: readerModeStyle.fontSize)
     }
 
     fileprivate func makeSeparatorView(fromView: UIView, topConstraint: UIView) {

--- a/Client/Frontend/Reader/ReaderModeStyleViewController.swift
+++ b/Client/Frontend/Reader/ReaderModeStyleViewController.swift
@@ -28,21 +28,11 @@ private struct ReaderModeStyleViewControllerUX {
 
 // MARK: -
 
-protocol ReaderModeStyleViewControllerDelegate {
-    func readerModeStyleViewController(_ readerModeStyleViewController: ReaderModeStyleViewController, 
-                                       didConfigureStyle style: ReaderModeStyle)
-    
+protocol ReaderModeStyleViewControllerDelegate {    
+    // isUsingUserDefinedColor should be false by default unless we need to override the default color 
     func readerModeStyleViewController(_ readerModeStyleViewController: ReaderModeStyleViewController, 
                                        didConfigureStyle style: ReaderModeStyle,
                                        isUsingUserDefinedColor: Bool)
-}
-
-extension ReaderModeStyleViewControllerDelegate {
-    // Can't use default values in protocols, using chained method calls instead
-    func readerModeStyleViewController(_ readerModeStyleViewController: ReaderModeStyleViewController, 
-                                       didConfigureStyle style: ReaderModeStyle) {
-        self.readerModeStyleViewController(readerModeStyleViewController, didConfigureStyle: style, isUsingUserDefinedColor: false)
-    }
 }
 
 // MARK: -


### PR DESCRIPTION
Fixes #4700

This is the 2nd attempt to fix the issue. The latest commit makes sure we switch back to sepia when switching off dark mode in case sepia was used before. Description from the previous PR:

"In this PR, any reader theme is overridden by the app-wide theme. When Reader mode is opened or app theme is changed, reader's theme will be matched to app's theme.

It's still possible to use any reader theme by setting the desired one, but it will be overridden next time we open Reader mode or change app-wide theme".



![Untitled1](https://user-images.githubusercontent.com/168651/71537541-46b53c00-2926-11ea-982a-b1db14a38050.gif)
