### PR TITLE
Fix #5237 - 'Recent Bookmarks' header should match other table view headers

### DIFF
--- a/Client/Frontend/Library/BookmarksPanel.swift
+++ b/Client/Frontend/Library/BookmarksPanel.swift
@@ -68,7 +68,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
 
         self.tableView.register(OneLineTableViewCell.self, forCellReuseIdentifier: BookmarkNodeCellIdentifier)
         self.tableView.register(SeparatorTableViewCell.self, forCellReuseIdentifier: BookmarkSeparatorCellIdentifier)
-        self.tableView.register(ThemedTableSectionHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: BookmarkSectionHeaderIdentifier)
+        self.tableView.register(SiteTableViewHeader.self, forHeaderFooterViewReuseIdentifier: BookmarkSectionHeaderIdentifier)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -409,11 +409,11 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard section == BookmarksSection.recent.rawValue, !recentBookmarks.isEmpty,
-            let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: BookmarkSectionHeaderIdentifier) as? ThemedTableSectionHeaderFooterView else {
+            let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: BookmarkSectionHeaderIdentifier) as? SiteTableViewHeader else {
             return nil
         }
 
-        headerView.titleLabel.text = Strings.RecentlyBookmarkedTitle.uppercased()
+        headerView.titleLabel.text = Strings.RecentlyBookmarkedTitle
         headerView.showBorder(for: .top, true)
         headerView.showBorder(for: .bottom, true)
 


### PR DESCRIPTION
Fixes #5237 

Not sure if this is what we really need, but now "Recent Bookmarks" matches "Today" header. Let me know if any other changes are needed


![Simulator Screen Shot - iPhone 11 Pro Max - 2019-12-29 at 21 11 21](https://user-images.githubusercontent.com/168651/71561768-80e82000-2a83-11ea-8ce6-c460f65c08e7.png)


![Simulator Screen Shot - iPhone 11 Pro Max - 2019-12-29 at 21 11 19](https://user-images.githubusercontent.com/168651/71561770-8a718800-2a83-11ea-92f4-849fa2e484e6.png)

