### PR TITLE
Isabelrios/fix activity stream smoketest issues

### DIFF
--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -191,6 +191,7 @@ class ActivityStreamTest: BaseTestCase {
         app.cells["TopSitesCell"].cells.element(boundBy: 3).press(forDuration:1)
         selectOptionFromContextMenu(option: "Open in New Tab")
         // Check that two tabs are open and one of them is the default top site one
+        navigator.nowAt(HomePanelsScreen)
         navigator.goto(TabTray)
         waitForExistence(app.collectionViews.cells[defaultTopSite["bookmarkLabel"]!])
         let numTabsOpen = app.collectionViews.cells.count
@@ -237,6 +238,7 @@ class ActivityStreamTest: BaseTestCase {
         // Check that two tabs are open and one of them is the default top site one
         // Workaroud needed after xcode 11.3 update Issue 5937
         sleep(1)
+        navigator.nowAt(HomePanelsScreen)
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
         waitForExistence(app.collectionViews.cells[defaultTopSite["bookmarkLabel"]!])

--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -191,6 +191,9 @@ class ActivityStreamTest: BaseTestCase {
         app.cells["TopSitesCell"].cells.element(boundBy: 3).press(forDuration:1)
         selectOptionFromContextMenu(option: "Open in New Tab")
         // Check that two tabs are open and one of them is the default top site one
+        // Needed for BB to work after iOS 13.3 update
+        sleep(1)
+        waitForNoExistence(app.tables["Context Menu"], timeoutValue: 15)
         navigator.nowAt(HomePanelsScreen)
         navigator.goto(TabTray)
         waitForExistence(app.collectionViews.cells[defaultTopSite["bookmarkLabel"]!])
@@ -237,8 +240,9 @@ class ActivityStreamTest: BaseTestCase {
 
         // Check that two tabs are open and one of them is the default top site one
         // Workaroud needed after xcode 11.3 update Issue 5937
-        sleep(1)
+        sleep(2)
         navigator.nowAt(HomePanelsScreen)
+        waitForTabsButton()
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
         waitForExistence(app.collectionViews.cells[defaultTopSite["bookmarkLabel"]!])

--- a/XCUITests/BookmarkingTests.swift
+++ b/XCUITests/BookmarkingTests.swift
@@ -115,7 +115,7 @@ class BookmarkingTests: BaseTestCase {
         
         // Check if it shows in recent bookmarks
         navigator.goto(LibraryPanel_Bookmarks)
-        waitForExistence(app.otherElements["RECENT BOOKMARKS"])
+        waitForExistence(app.otherElements["Recent Bookmarks"])
         waitForExistence(app.staticTexts[urlLabelExample_3])
         XCTAssertEqual(app.tables["Bookmarks List"].cells.count, 5)
         
@@ -126,7 +126,7 @@ class BookmarkingTests: BaseTestCase {
         
         // Check if it shows in recent bookmarks
         navigator.goto(LibraryPanel_Bookmarks)
-        waitForExistence(app.otherElements["RECENT BOOKMARKS"])
+        waitForExistence(app.otherElements["Recent Bookmarks"])
         waitForExistence(app.staticTexts[urlLabelExample_4])
         XCTAssertEqual(app.tables["Bookmarks List"].cells.count, 6)
         


### PR DESCRIPTION
This seems to be the fix to have these tests working. Although not in favor of adding sleeps, at this point after iOS 13.3, is that or disable the tests