### PR TITLE
[nobug] Cleanup,refactor of favicon code

### DIFF
--- a/Client/Extensions/UIImageViewExtensions.swift
+++ b/Client/Extensions/UIImageViewExtensions.swift
@@ -38,28 +38,12 @@ public extension UIImageView {
             let defaults = fallbackFavicon(forUrl: website)
             backgroundColor = .clear
             self.sd_setImage(with: imageURL, placeholderImage: defaults.image, options: []) {(img, err, _, _) in
-                guard let image = img, let url = website, err == nil else {
+                guard err == nil else {
                     finish(bgColor: defaults.color)
                     return
                 }
-                self.color(forImage: image, andURL: url) { color in
-                    finish(bgColor: color)
-                }
+                finish(bgColor: UIColor.Photon.White100)
             }
-        }
-    }
-
-   /*
-    * Fetch a background color for a specfic favicon UIImage. It uses the URL to store the UIColor in memory for subsequent requests.
-    */
-    private func color(forImage image: UIImage, andURL url: URL, completed completionBlock: ((UIColor) -> Void)? = nil) {
-        let domain = url.domainURL.absoluteString
-        if let color = FaviconFetcher.colors[domain] {
-            self.backgroundColor = color
-            completionBlock?(color)
-        } else {
-            completionBlock?(UIColor.Photon.White100)
-            FaviconFetcher.colors[domain] = UIColor.Photon.White100
         }
     }
 

--- a/Client/Extensions/UIImageViewExtensions.swift
+++ b/Client/Extensions/UIImageViewExtensions.swift
@@ -36,7 +36,7 @@ public extension UIImageView {
         } else {
             let imageURL = URL(string: icon?.url ?? "")
             let defaults = fallbackFavicon(forUrl: website)
-            backgroundColor = defaults.color
+            backgroundColor = .clear
             self.sd_setImage(with: imageURL, placeholderImage: defaults.image, options: []) {(img, err, _, _) in
                 guard let image = img, let url = website, err == nil else {
                     finish(bgColor: defaults.color)

--- a/Client/Extensions/UIImageViewExtensions.swift
+++ b/Client/Extensions/UIImageViewExtensions.swift
@@ -31,8 +31,8 @@ public extension UIImageView {
             completion?(color, url)
         }
 
-        if let url = url, let defaultIcon = FaviconFetcher.getDefaultIconForURL(url: url) {
-            finish(filePath: defaultIcon.url, bgColor: defaultIcon.color)
+        if let url = url, let bundledIcon = FaviconFetcher.getBundledIcon(forUrl: url) {
+            finish(filePath: bundledIcon.filePath, bgColor: bundledIcon.bgcolor)
         } else {
             let imageURL = URL(string: icon?.url ?? "")
             let defaults = defaultFavicon(url)

--- a/Client/Frontend/Browser/BackForwardTableViewCell.swift
+++ b/Client/Frontend/Browser/BackForwardTableViewCell.swift
@@ -53,7 +53,7 @@ class BackForwardTableViewCell: UITableViewCell {
     var site: Site? {
         didSet {
             if let s = site {
-                faviconView.setFavicon(forSite: s, onCompletion: { [weak self] (color, url) in
+                faviconView.setFavicon(forSite: s) { [weak self] in
                     if InternalURL.isValid(url: s.tileURL) {
                         self?.faviconView.image = UIImage(named: "faviconFox")
                         self?.faviconView.image = self?.faviconView.image?.createScaled(CGSize(width: BackForwardViewCellUX.IconSize, height: BackForwardViewCellUX.IconSize))
@@ -62,8 +62,10 @@ class BackForwardTableViewCell: UITableViewCell {
                     }
 
                     self?.faviconView.image = self?.faviconView.image?.createScaled(CGSize(width: BackForwardViewCellUX.IconSize, height: BackForwardViewCellUX.IconSize))
-                    self?.faviconView.backgroundColor = color == .clear ? .white : color
-                })
+                    if self?.faviconView.backgroundColor == .clear {
+                        self?.faviconView.backgroundColor = .white
+                    }
+                }
                 var title = s.title
                 if title.isEmpty {
                     title = s.url

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -390,13 +390,10 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
                     cell.setRightBadge(isBookmark ? self.bookmarkedBadge : nil)
                     cell.imageView?.layer.borderColor = SearchViewControllerUX.IconBorderColor.cgColor
                     cell.imageView?.layer.borderWidth = SearchViewControllerUX.IconBorderWidth
-                    cell.imageView?.setIcon(site.icon, forURL: site.tileURL, completed: { (color, url) in
-                        if site.tileURL == url {
-                            cell.imageView?.image = cell.imageView?.image?.createScaled(CGSize(width: SearchViewControllerUX.IconSize, height: SearchViewControllerUX.IconSize))
-                            cell.imageView?.contentMode = .center
-                            cell.imageView?.backgroundColor = color
-                        }
-                    })
+                    cell.imageView?.contentMode = .center
+                    cell.imageView?.setImageAndBackground(forIcon: site.icon, website: site.tileURL) { [weak cell] in
+                        cell?.imageView?.image = cell?.imageView?.image?.createScaled(CGSize(width: SearchViewControllerUX.IconSize, height: SearchViewControllerUX.IconSize))
+                    }
                 }
             }
             return cell

--- a/Client/Frontend/Browser/TopTabsViews.swift
+++ b/Client/Frontend/Browser/TopTabsViews.swift
@@ -185,13 +185,14 @@ class TopTabCell: UICollectionViewCell, PrivateModeUI {
 
         self.selectedTab = isSelected
         if let siteURL = tab.url?.displayURL {
-            self.favicon.setIcon(tab.displayFavicon, forURL: siteURL, completed: { (color, url) in
-                if siteURL == url {
-                    self.favicon.image = self.favicon.image?.createScaled(CGSize(width: 15, height: 15))
-                    self.favicon.backgroundColor = color == .clear ? .white : color
-                    self.favicon.contentMode = .center
+            self.favicon.contentMode = .center
+            self.favicon.setImageAndBackground(forIcon: tab.displayFavicon, website: siteURL) { [weak self] in
+                guard let self = self else { return }
+                self.favicon.image = self.favicon.image?.createScaled(CGSize(width: 15, height: 15))
+                if self.favicon.backgroundColor == .clear {
+                    self.favicon.backgroundColor = .white
                 }
-            })
+            }
         } else {
             self.favicon.image = UIImage(named: "defaultFavicon")
             self.favicon.contentMode = .scaleAspectFit

--- a/Client/Frontend/Home/FirefoxHomeTopSitesCell.swift
+++ b/Client/Frontend/Home/FirefoxHomeTopSitesCell.swift
@@ -151,14 +151,10 @@ class TopSiteItemCell: UICollectionViewCell, Themeable {
         }
 
         accessibilityLabel = titleLabel.text
-        let tempImageView = UIImageView()
-        tempImageView.setFaviconOrDefaultIcon(forSite: site, onCompletion: { [weak self] (color, url) in
-            if let url = url, url == self?.url {
-                self?.imageView.image = tempImageView.image
-                self?.faviconBG.backgroundColor = color
-                self?.imageView.backgroundColor = color
-            }
-        })
+        faviconBG.backgroundColor = .clear
+        self.imageView.setFaviconOrDefaultIcon(forSite: site) { [weak self] in
+            self?.faviconBG.backgroundColor = self?.imageView.backgroundColor
+        }
 
         applyTheme()
     }

--- a/Client/Frontend/Library/BookmarksPanel.swift
+++ b/Client/Frontend/Library/BookmarksPanel.swift
@@ -383,6 +383,8 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
                 cell.textLabel?.text = bookmarkItem.title
             }
 
+            cell.imageView?.image = nil
+
             let site = Site(url: bookmarkItem.url, title: bookmarkItem.title, bookmarked: true, guid: bookmarkItem.guid)
             profile.favicons.getFaviconImage(forSite: site).uponQueue(.main) { result in
                 // Check that we successfully retrieved an image (should always happen)

--- a/Client/Frontend/Library/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel.swift
@@ -339,13 +339,10 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
 
             cell.imageView?.layer.borderColor = HistoryPanelUX.IconBorderColor.cgColor
             cell.imageView?.layer.borderWidth = HistoryPanelUX.IconBorderWidth
-            cell.imageView?.setIcon(site.icon, forURL: site.tileURL, completed: { (color, url) in
-                if site.tileURL == url {
-                    cell.imageView?.image = cell.imageView?.image?.createScaled(CGSize(width: HistoryPanelUX.IconSize, height: HistoryPanelUX.IconSize))
-                    cell.imageView?.backgroundColor = color
-                    cell.imageView?.contentMode = .center
-                }
-            })
+            cell.imageView?.contentMode = .center
+            cell.imageView?.setImageAndBackground(forIcon: site.icon, website: site.tileURL) { [weak cell] in
+                cell?.imageView?.image = cell?.imageView?.image?.createScaled(CGSize(width: HistoryPanelUX.IconSize, height: HistoryPanelUX.IconSize))
+            }
         }
         return cell
     }

--- a/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -81,10 +81,10 @@ class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {
         let displayURL = tab.url.displayURL ?? tab.url
         twoLineCell.setLines(tab.title, detailText: displayURL.absoluteDisplayString)
         let site: Favicon? = (tab.faviconURL != nil) ? Favicon(url: tab.faviconURL!) : nil
-        cell.imageView!.layer.borderColor = RecentlyClosedPanelUX.IconBorderColor.cgColor
-        cell.imageView!.layer.borderWidth = RecentlyClosedPanelUX.IconBorderWidth
-        cell.imageView!.contentMode = .center
-        cell.imageView!.setImageAndBackground(forIcon: site, website: displayURL) { [weak cell] in
+        cell.imageView?.layer.borderColor = RecentlyClosedPanelUX.IconBorderColor.cgColor
+        cell.imageView?.layer.borderWidth = RecentlyClosedPanelUX.IconBorderWidth
+        cell.imageView?.contentMode = .center
+        cell.imageView?.setImageAndBackground(forIcon: site, website: displayURL) { [weak cell] in
             cell?.imageView?.image = cell?.imageView?.image?.createScaled(RecentlyClosedPanelUX.IconSize)
         }
         return cell

--- a/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -83,13 +83,10 @@ class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {
         let site: Favicon? = (tab.faviconURL != nil) ? Favicon(url: tab.faviconURL!) : nil
         cell.imageView!.layer.borderColor = RecentlyClosedPanelUX.IconBorderColor.cgColor
         cell.imageView!.layer.borderWidth = RecentlyClosedPanelUX.IconBorderWidth
-        cell.imageView?.setIcon(site, forURL: displayURL, completed: { (color, url) in
-            if url == displayURL {
-                cell.imageView?.image = cell.imageView?.image?.createScaled(RecentlyClosedPanelUX.IconSize)
-                cell.imageView?.contentMode = .center
-                cell.imageView?.backgroundColor = color
-            }
-        })
+        cell.imageView!.contentMode = .center
+        cell.imageView!.setImageAndBackground(forIcon: site, website: displayURL) { [weak cell] in
+            cell?.imageView?.image = cell?.imageView?.image?.createScaled(RecentlyClosedPanelUX.IconSize)
+        }
         return cell
     }
 

--- a/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -91,7 +91,7 @@ class CustomSearchViewController: SettingsTableViewController {
         }
 
         FaviconFetcher.fetchFavImageForURL(forURL: url, profile: profile).uponQueue(.main) { result in
-            let image = result.successValue ?? FaviconFetcher.getDefaultFavicon(url)
+            let image = result.successValue ?? FaviconFetcher.letter(forUrl: url)
             let engine = OpenSearchEngine(engineID: nil, shortName: name, image: image, searchTemplate: template, suggestTemplate: nil, isCustomEngine: true)
 
             //Make sure a valid scheme is used

--- a/Client/Frontend/Widgets/FirefoxHomeHighlightCell.swift
+++ b/Client/Frontend/Widgets/FirefoxHomeHighlightCell.swift
@@ -172,13 +172,9 @@ class FirefoxHomeHighlightCell: UICollectionViewCell {
             self.siteImageView.sd_setImage(with: mediaURL)
             self.siteImageView.contentMode = .scaleAspectFill
         } else {
-            let itemURL = site.tileURL
-            self.siteImageView.setFavicon(forSite: site, onCompletion: { [weak self] (color, url)  in
-                if itemURL == url {
-                    self?.siteImageView.image = self?.siteImageView.image?.createScaled(FirefoxHomeHighlightCellUX.FaviconSize)
-                    self?.siteImageView.backgroundColor = color
-                }
-            })
+            self.siteImageView.setFavicon(forSite: site) { [weak self]  in
+                self?.siteImageView.image = self?.siteImageView.image?.createScaled(FirefoxHomeHighlightCellUX.FaviconSize)
+            }
             self.siteImageView.contentMode = .center
         }
 

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetWidgets.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetWidgets.swift
@@ -222,8 +222,7 @@ class PhotonActionSheetSiteHeaderView: UITableViewHeaderFooterView {
 
     func configure(with site: Site) {
         if let _ = site.icon {
-            self.siteImageView.setFavicon(forSite: site) { (color, url) in
-                self.siteImageView.backgroundColor = color
+            self.siteImageView.setFavicon(forSite: site) { 
                 self.siteImageView.image = self.siteImageView.image?.createScaled(PhotonActionSheetUX.IconSize)
             }
         } else if let appDelegate = UIApplication.shared.delegate as? AppDelegate, let profile = appDelegate.profile {

--- a/Client/Utils/FaviconFetcher.swift
+++ b/Client/Utils/FaviconFetcher.swift
@@ -218,8 +218,9 @@ open class FaviconFetcher: NSObject, XMLParserDelegate {
         return deferred
     }
 
-    // Returns the default favicon for a site based on the first letter of the site's domain
-    class func getDefaultFavicon(_ url: URL) -> UIImage {
+    // Create (or return from cache) a fallback image for a site based on the first letter of the site's domain
+    // Letter is white on a clear background
+    class func letter(forUrl url: URL) -> UIImage {
         guard let character = url.baseDomain?.first else {
             return defaultFavicon
         }
@@ -246,7 +247,7 @@ open class FaviconFetcher: NSObject, XMLParserDelegate {
     }
 
     // Returns a color based on the url's hash
-    class func getDefaultColor(_ url: URL) -> UIColor {
+    class func color(forUrl url: URL) -> UIColor {
         // A stable hash (unlike hashValue), from https://useyourloaf.com/blog/swift-hashable/
         func stableHash(_ str: String) -> Int {
             let unicodeScalars = str.unicodeScalars.map { $0.value }

--- a/Client/Utils/FaviconFetcher.swift
+++ b/Client/Utils/FaviconFetcher.swift
@@ -260,7 +260,7 @@ open class FaviconFetcher: NSObject, XMLParserDelegate {
         }
         let index = abs(stableHash(domain)) % (DefaultFaviconBackgroundColors.count - 1)
         let colorHex = DefaultFaviconBackgroundColors[index]
-        print("\(url) \(colorHex)")
+
         return UIColor(colorString: colorHex)
     }
 

--- a/Client/Utils/FaviconFetcher.swift
+++ b/Client/Utils/FaviconFetcher.swift
@@ -31,8 +31,6 @@ open class FaviconFetcher: NSObject, XMLParserDelegate {
         return UIImage(named: "defaultFavicon")!
     }()
 
-    static var colors: [String: UIColor] = [:] //An in-Memory data store that stores background colors domains. Stored using url.baseDomain.
-
     typealias BundledIconType = (bgcolor: UIColor, filePath: String)
     // Sites can be accessed via their baseDomain.
     static let bundledIcons: [String: BundledIconType] = FaviconFetcher.getBundledIcons()

--- a/ClientTests/TestFavicons.swift
+++ b/ClientTests/TestFavicons.swift
@@ -52,7 +52,7 @@ class TestFavicons: ProfileTest {
         // The amazon case tests a special case for multi-reguin domain lookups
         ["http://www.youtube.com", "https://www.taobao.com/", "https://www.amazon.ca"].forEach {
             let url = URL(string: $0)!
-            let icon = FaviconFetcher.getDefaultIconForURL(url: url)
+            let icon = FaviconFetcher.getBundledIcon(forUrl: url)
             XCTAssertNotNil(icon)
         }
     }

--- a/ClientTests/UIImageViewExtensionsTests.swift
+++ b/ClientTests/UIImageViewExtensionsTests.swift
@@ -21,16 +21,16 @@ class UIImageViewExtensionsTests: XCTestCase {
         let url = URL(string: "http://mozilla.com")
         let imageView = UIImageView()
 
-        let goodIcon = FaviconFetcher.getDefaultFavicon(url!)
-        let correctColor = FaviconFetcher.getDefaultColor(url!)
-        imageView.setIcon(nil, forURL: url)
+        let goodIcon = FaviconFetcher.letter(forUrl: url!)
+        let correctColor = FaviconFetcher.color(forUrl: url!)
+        imageView.setImageAndBackground(forIcon: nil, website: url) {}
         XCTAssertEqual(imageView.image!, goodIcon, "The correct default favicon should be applied")
         XCTAssertEqual(imageView.backgroundColor, correctColor, "The correct default color should be applied")
 
-        imageView.setIcon(nil, forURL: URL(string: "http://mozilla.com/blahblah"))
+        imageView.setImageAndBackground(forIcon: nil, website: URL(string: "http://mozilla.com/blahblah")) {}
         XCTAssertEqual(imageView.image!, goodIcon, "The same icon should be applied to all urls with the same domain")
 
-        imageView.setIcon(nil, forURL: URL(string: "b"))
+        imageView.setImageAndBackground(forIcon: nil, website: URL(string: "b")) {}
         XCTAssertEqual(imageView.image, FaviconFetcher.defaultFavicon, "The default favicon should be applied when no information is given about the icon")
     }
 
@@ -42,29 +42,11 @@ class UIImageViewExtensionsTests: XCTestCase {
         }
 
         let favImageView = UIImageView()
-        favImageView.setIcon(Favicon(url: "http://localhost:\(AppInfo.webserverPort)/favicon/icon"), forURL: URL(string: "http://localhost:\(AppInfo.webserverPort)"))
+        favImageView.setImageAndBackground(forIcon: Favicon(url: "http://localhost:\(AppInfo.webserverPort)/favicon/icon"), website: URL(string: "http://localhost:\(AppInfo.webserverPort)")) {}
 
         let expect = expectation(description: "UIImageView async load")
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.0) {
             XCTAssert(originalImage.size.width * originalImage.scale == favImageView.image!.size.width * favImageView.image!.scale, "The correct favicon should be applied to the UIImageView")
-            expect.fulfill()
-        }
-        waitForExpectations(timeout: 5, handler: nil)
-    }
-
-    func testAsyncSetIconFail() {
-        let favImageView = UIImageView()
-
-        let gFavURL = URL(string: "https://www.nofavicon.com/noicon.ico")
-        let gURL = URL(string: "http://nofavicon.com")
-        let correctImage = FaviconFetcher.getDefaultFavicon(gURL!)
-
-        favImageView.setIcon(Favicon(url: gFavURL!.absoluteString), forURL: gURL)
-
-        let expect = expectation(description: "UIImageView async load")
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-           XCTAssert(correctImage.size.width * correctImage.scale == favImageView.image!.size.width * favImageView.image!.scale, "The correct default favicon should be applied to the UIImageView")
             expect.fulfill()
         }
         waitForExpectations(timeout: 5, handler: nil)
@@ -75,15 +57,15 @@ class UIImageViewExtensionsTests: XCTestCase {
 
         let gFavURL = URL(string: "https://www.facebook.com/fav") //This will be fetched from tippy top sites
         let gURL = URL(string: "http://www.facebook.com")!
-        let defaultItem = FaviconFetcher.defaultIcons[gURL.baseDomain!]!
-        let correctImage = UIImage(contentsOfFile: defaultItem.url)!
+        let defaultItem = FaviconFetcher.bundledIcons[gURL.baseDomain!]!
+        let correctImage = UIImage(contentsOfFile: defaultItem.filePath)!
 
-        favImageView.setIcon(Favicon(url: gFavURL!.absoluteString), forURL: gURL)
+        favImageView.setImageAndBackground(forIcon: Favicon(url: gFavURL!.absoluteString), website: gURL) {}
 
         let expect = expectation(description: "UIImageView async load")
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            XCTAssertEqual(favImageView.backgroundColor, defaultItem.color)
+            XCTAssertEqual(favImageView.backgroundColor, defaultItem.bgcolor)
             XCTAssert(correctImage.size.width * correctImage.scale == favImageView.image!.size.width * favImageView.image!.scale, "The correct default favicon should be applied to the UIImageView")
             expect.fulfill()
         }


### PR DESCRIPTION
I am finding favicon fetching code incomprehensible, this is an effort to remedy that.
We now have:

- `bundled` favicons: these are the icons built-in to the binary
- `fallback` favicons: these are when no bundled favicon or no valid URL exists, these are the generated icon with a letter and background color.

 `setIcon` is now `setImageAndBackgroundColor` and no longer returns a tuple in the closure. Note this function takes a `website: URL` argument, this is to clarify this URL is not the favicon URL, rather the URL of the website it is from.

Also, following best practices for SDWebImage image fetching, the only consideration needed for UITableView cell configuration is to ensure `sd_setImage(null)` is called to end any previous operations.