### PR TITLE
Fix #5956 - Tracking protection shield icon is not updated correctly when different sites are loaded in same tab

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -628,6 +628,9 @@ extension BrowserViewController: WKNavigationDelegate {
         guard let tab = tabManager[webView] else { return }
 
         tab.url = webView.url
+        // When tab url changes after web content starts loading on the page
+        // We notify the contect blocker change so that content blocker status can be correctly shown on beside the URL bar
+        tab.contentBlocker?.notifyContentBlockingChanged()
         self.scrollController.resetZoomState()
 
         if tabManager.selectedTab === tab {


### PR DESCRIPTION
This fixes the issue where the tracker protection icon wasn't updating correctly. By sending content blocker changed notification at the correct time it now shows the correct state for the tracker protection icon when we navigate to different websites. 

Issue: https://github.com/mozilla-mobile/firefox-ios/issues/5956

Steps to reproduce: https://github.com/mozilla-mobile/firefox-ios/issues/5956#issuecomment-572283058