### PR TITLE
Fix #6027 - Wrong version of Google is displayed on iPad

### DIFF
--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -98,11 +98,13 @@ public struct CustomUserAgentConstant {
     public static let mobileUserAgent = [
         "whatsapp.com": defaultMobileUA,
         "paypal.com": defaultMobileUA,
-        "yahoo.com": defaultMobileUA ]
+        "yahoo.com": defaultMobileUA,
+        "google.com": defaultMobileUA ]
     public static let desktopUserAgent = [
         "whatsapp.com": customDesktopUA,
         "paypal.com": customDesktopUA,
-        "yahoo.com": customDesktopUA ]
+        "yahoo.com": customDesktopUA,
+        "google.com": customDesktopUA ]
 }
 
 public struct UserAgentBuilder {


### PR DESCRIPTION
We currently have a issue on iPad that the wrong version of Google is displayed. See https://github.com/mozilla-mobile/firefox-ios/issues/6027. This PR is to fix that issue.