### PR TITLE
Fix #5424 - Hide Images toggle is not visible

### DIFF
--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -123,6 +123,7 @@ fileprivate class DarkGeneralColor: GeneralColor {
     override var settingsTextPlaceholder: UIColor? { return UIColor.Photon.Grey50 }
     override var faviconBackground: UIColor { return UIColor.Photon.White100 }
     override var passcodeDot: UIColor { return UIColor.Photon.Grey40 }
+    override var switchToggle: UIColor { return UIColor.Photon.Grey40 }
 }
 
 class DarkTheme: NormalTheme {

--- a/Client/Frontend/Theme/Theme.swift
+++ b/Client/Frontend/Theme/Theme.swift
@@ -200,6 +200,7 @@ class GeneralColor {
     var separator: UIColor { return defaultSeparator }
     var settingsTextPlaceholder: UIColor? { return nil }
     var controlTint: UIColor { return UIColor.Photon.Blue40 }
+    var switchToggle: UIColor { return UIColor.Photon.Grey90A40 }
 }
 
 protocol Theme {
@@ -216,6 +217,7 @@ protocol Theme {
     var snackbar: SnackBarColor { get }
     var general: GeneralColor { get }
     var actionMenu: ActionMenuColor { get }
+    var switchToggleTheme: GeneralColor { get }
 }
 
 class NormalTheme: Theme {
@@ -232,4 +234,5 @@ class NormalTheme: Theme {
     var snackbar: SnackBarColor { return SnackBarColor() }
     var general: GeneralColor { return GeneralColor() }
     var actionMenu: ActionMenuColor { return ActionMenuColor() }
+    var switchToggleTheme: GeneralColor { return GeneralColor() }
 }

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
@@ -91,8 +91,7 @@ class PhotonActionSheetCell: UITableViewCell {
         func setOn(_ on: Bool) {
             foreground.image = on ? UIImage(named: "menu-customswitch-on") : UIImage(named: "menu-customswitch-off")
             mainView.accessibilityIdentifier = on ? "enabled" : "disabled"
-            mainView.tintColor = on ? UIColor.theme.general.controlTint : UIColor.Photon.Grey90A40
-        }
+            mainView.tintColor = on ? UIColor.theme.general.controlTint : UIColor.Photon.theme.general.switchToggle }
     }
 
     let toggleSwitch = ToggleSwitch()

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
@@ -91,7 +91,7 @@ class PhotonActionSheetCell: UITableViewCell {
         func setOn(_ on: Bool) {
             foreground.image = on ? UIImage(named: "menu-customswitch-on") : UIImage(named: "menu-customswitch-off")
             mainView.accessibilityIdentifier = on ? "enabled" : "disabled"
-            mainView.tintColor = on ? UIColor.theme.general.controlTint : UIColor.Photon.theme.general.switchToggle }
+            mainView.tintColor = on ? UIColor.theme.general.controlTint : UIColor.theme.general.switchToggle }
     }
 
     let toggleSwitch = ToggleSwitch()


### PR DESCRIPTION
Menu switch was almost invisible in dark mode: https://monosnap.com/file/qudIm3mUEVTdkGR0IbOIGhtrYnQHn6

I have put a slightly different colour without alpha value: https://monosnap.com/file/KyndF0gCQOEziuF6BWuHIkHodDjyff

I have tested in incognito mode and with different accessibility settings, as mentioned in a related bug.

P.S. link for the old PR https://github.com/mozilla-mobile/firefox-ios/pull/5930
I was figuring out how to clean commit history mess and ended up removing the necessary branch. 