### PR TITLE
Fix #5999 -Tabs tray button is not consistent with other buttons when tapped

### DIFF
--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -13,13 +13,13 @@ private struct TabsButtonUX {
 }
 
 class TabsButton: UIButton {
-    var textColor = UIColor.clear {
+    var textColor = UIColor.Photon.Blue40 {
         didSet {
             countLabel.textColor = textColor
             borderView.color = textColor
         }
     }
-    var titleBackgroundColor = UIColor.clear {
+    var titleBackgroundColor = UIColor.Photon.Blue40 {
         didSet {
             labelBackground.backgroundColor = titleBackgroundColor
         }


### PR DESCRIPTION
'View Tabs' button behaved differently from the other buttons. After pressing on the toolbar - button frame disappeared, instead of turning blue (like the other buttons):

https://monosnap.com/file/rqyCVEvJSXll87dDQvZBPXKaqFkTjm

The back/forward/refresh/menu button were in the Theme file, and Tabs Button was in the different file. After changing previous 'clear' colour to 'blue40' 'View Tabs' button in the toolbar behaved like the rest of the buttons.

https://monosnap.com/file/C6mBbuPiYmCx6zYK1xJbMGkIAND9aX
(same behaviour in the regular tab)

P.S. the link for the old PR https://github.com/mozilla-mobile/firefox-ios/pull/6007
I was figuring out how to clean commit history mess and ended up removing the necessary branch.

