### PR TITLE
Fix #6039 - XCUITests Fix and Update L10Snapshots tests

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/L10nSnapshotTests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/L10nSnapshotTests.xcscheme
@@ -46,12 +46,6 @@
                   Identifier = "L10nSnapshotTests/test04Foo()">
                </Test>
                <Test
-                  Identifier = "L10nSnapshotTests/test07AddSearchProvider()">
-               </Test>
-               <Test
-                  Identifier = "L10nSnapshotTests/test13ReloadButtonContextMenu()">
-               </Test>
-               <Test
                   Identifier = "L10nSnapshotTests/test14SetHompage()">
                </Test>
                <Test

--- a/L10nSnapshotTests/L10nSnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSnapshotTests.swift
@@ -59,6 +59,17 @@ class L10nSnapshotTests: L10nBaseSnapshotTests {
     }
 
     // From here on it is fine to load pages
+    func test07LongPressOnTextOptions() {
+        navigator.openURL(loremIpsumURL)
+
+        // Select some text and long press to find the option
+        app.webViews.element(boundBy: 0).staticTexts.element(boundBy: 0).press(forDuration: 1)
+        snapshot("07LongPressTextOptions-01")
+        waitForExistence(app.menus.children(matching: .menuItem).element(boundBy: 3))
+        app.menus.children(matching: .menuItem).element(boundBy: 3).tap()
+        snapshot("07LongPressTextOptions-02")
+    }
+
     func test08URLBar() {
         navigator.goto(URLBarOpen)
         snapshot("08URLBar-01")

--- a/L10nSnapshotTests/L10nSnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSnapshotTests.swift
@@ -59,20 +59,6 @@ class L10nSnapshotTests: L10nBaseSnapshotTests {
     }
 
     // From here on it is fine to load pages
-
-    func test07AddSearchProvider() {
-        navigator.openURL("www.duckduckgo.com")
-        app.webViews.textFields.element(boundBy: 0).tap()
-        snapshot("07AddSearchProvider-01", waitForLoadingIndicator: false)
-        app.buttons["BrowserViewController.customSearchEngineButton"].tap()
-        snapshot("07AddSearchProvider-02", waitForLoadingIndicator: false)
-
-        let alert = app.alerts.element(boundBy: 0)
-        expectation(for: NSPredicate(format: "exists == 1"), evaluatedWith: alert, handler: nil)
-        waitForExpectations(timeout: 3, handler: nil)
-        alert.buttons.element(boundBy: 0).tap()
-    }
-
     func test08URLBar() {
         navigator.goto(URLBarOpen)
         snapshot("08URLBar-01")
@@ -218,7 +204,7 @@ class L10nSnapshotTests: L10nBaseSnapshotTests {
         snapshot("22TrackingProtectionDisabledPerSite-02")
 
         // Website with blocked elements
-        navigator.openNewURL(urlString: "mozilla.org")
+        navigator.openNewURL(urlString: "twitter.com")
         waitForExistence(app.buttons["TabLocationView.trackingProtectionButton"])
         navigator.goto(TrackingProtectionContextMenuDetails)
         snapshot("22TrackingProtectionBlockedElements-01")

--- a/fastlane/SnapshotHelper.swift
+++ b/fastlane/SnapshotHelper.swift
@@ -168,19 +168,18 @@ open class Snapshot: NSObject {
             app.typeKey(XCUIKeyboardKeySecondaryFn, modifierFlags: [])
         #else
 
-            guard let app = self.app else {
+            guard self.app != nil else {
                 NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
                 return
             }
 
-            let window = app.windows.firstMatch
-            let screenshot = window.screenshot()
+            let screenshot = XCUIScreen.main.screenshot()
             guard var simulator = ProcessInfo().environment["SIMULATOR_DEVICE_NAME"], let screenshotsDir = screenshotsDirectory else { return }
-            
+
             do {
                 // The simulator name contains "Clone X of " inside the screenshot file when running parallelized UI Tests on concurrent devices
-                let regex = try NSRegularExpression(pattern: "Clone [0-1]+ of ")
-                let range = NSMakeRange(0, simulator.count)
+                let regex = try NSRegularExpression(pattern: "Clone [0-9]+ of ")
+                let range = NSRange(location: 0, length: simulator.count)
                 simulator = regex.stringByReplacingMatches(in: simulator, range: range, withTemplate: "")
 
                 let path = screenshotsDir.appendingPathComponent("\(simulator)-\(name).png")
@@ -301,4 +300,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.17]
+// SnapshotHelperVersion [1.21]

--- a/l10n-screenshots.sh
+++ b/l10n-screenshots.sh
@@ -24,6 +24,6 @@ for lang in $LOCALES; do
         --skip_open_summary \
         --derived_data_path l10n-screenshots-dd \
         --erase_simulator --localize_simulator \
-        --devices "iPhone SE" --languages "$lang" \
+        --devices "iPhone 8" --languages "$lang" \
         --output_directory "l10n-screenshots/$lang" > "l10n-screenshots/$lang/snapshot.log" 2>&1
 done


### PR DESCRIPTION
Fixes #6039
-Fix one TP tests by changing the URL, for some reason after iOS13 udpate mozilla.org site is giving a lot of errors while executing the tests
-Re-enables one disabled test
-Removes test adding search engine from the website search field option since that has been disabled. 