### PR TITLE
Revert "Fix #6027 - Wrong version of Google is displayed on iPad"

### DIFF
--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -97,12 +97,10 @@ public struct CustomUserAgentConstant {
     private static let customDesktopUA = UserAgentBuilder.defaultDesktopUserAgent().clone(extensions: "Version/\(AppInfo.appVersion) \(UserAgent.uaBitSafari)")
     public static let mobileUserAgent = [
         "paypal.com": defaultMobileUA,
-        "yahoo.com": defaultMobileUA,
-        "google.com": defaultMobileUA ]
+        "yahoo.com": defaultMobileUA ]
     public static let desktopUserAgent = [
         "paypal.com": customDesktopUA,
-        "yahoo.com": customDesktopUA,
-        "google.com": customDesktopUA ]
+        "yahoo.com": customDesktopUA ]
 }
 
 public struct UserAgentBuilder {


### PR DESCRIPTION
Reverts mozilla-mobile/firefox-ios#6028

This is a bug in Google's UA detection. Adding FxIOS in the UA string causes a different google page to be shown. We need to do some webcompat outreach to get this fixed.