### PR TITLE
Fix #6044 - XCUITests Skip Whats New Page

### DIFF
--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -62,7 +62,7 @@ class TestAppDelegate: AppDelegate {
 
         // Don't show the What's New page.
         if launchArguments.contains(LaunchArguments.SkipWhatsNew) {
-            profile.prefs.setInt(1, forKey: LatestAppVersionProfileKey)
+            profile.prefs.setInt(1, forKey: PrefsKeys.KeyLastVersionNumber)
         }
 
         // Skip the intro when requested by for example tests or automation

--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -62,7 +62,7 @@ class TestAppDelegate: AppDelegate {
 
         // Don't show the What's New page.
         if launchArguments.contains(LaunchArguments.SkipWhatsNew) {
-            profile.prefs.setString(AppInfo.appVersion, forKey: LatestAppVersionProfileKey)
+            profile.prefs.setInt(1, forKey: LatestAppVersionProfileKey)
         }
 
         // Skip the intro when requested by for example tests or automation


### PR DESCRIPTION
Fix #6044. 
After the Whats new page was added for new updates the tests started to fail, looks like the solution implemented previously was not working.

