### PR TITLE
Fix #5006: Add ability to set custom identity.sync.tokenserver.uri fo…

### DIFF
--- a/Account/TokenServerClient.swift
+++ b/Account/TokenServerClient.swift
@@ -162,7 +162,7 @@ open class TokenServerClient {
             }
 
             let json = JSON(data)
-            let remoteTimestampHeader = response.allHeaderFields["X-Timestamp"] as? String
+            let remoteTimestampHeader = (response.allHeaderFields as NSDictionary)["x-timestamp"] as? String
             if let remoteError = TokenServerClient.remoteError(fromJSON: json, statusCode: response.statusCode, remoteTimestampHeader: remoteTimestampHeader) {
                 deferred.fill(Maybe(failure: remoteError))
                 return


### PR DESCRIPTION
PR fixes #5006 

Communication with a self-hosted sync server silently fails for some users because the HTTP "X-Timestamp" header field name is accessed in a case-sensitive manner. The root cause seems to be a known [bug in Swift itself](https://bugs.swift.org/browse/SR-2429). To solve this issue, the workaround as suggested in that bug report (casting to NSDictionary) was applied and seems to fix things. Usage of [value()](https://developer.apple.com/documentation/foundation/httpurlresponse/3240613-value) would be the preferred solution, but depends on iOS 13+.
