### PR TITLE
Fix #6085 - Unknown fxa login errors should not transition to separated, stay at same

### DIFF
--- a/Account/FxALoginStateMachine.swift
+++ b/Account/FxALoginStateMachine.swift
@@ -106,7 +106,7 @@ class FxALoginStateMachine {
                                 log.error("Unsuccessful HTTP request: \(error.description)!  Assuming error is transient and not transitioning.")
                                 return same
                             } else {
-                                log.error("Unknown error: \(error.description).  Transitioning to same.")
+                                log.error("Unknown error: \(error.description).  Assuming error is transient and not transitioning.")
                                 return same
                             }
                         case let .local(localError) where localError.domain == NSURLErrorDomain:
@@ -116,7 +116,7 @@ class FxALoginStateMachine {
                             break
                         }
                     }
-                    log.error("Unknown error: \(result.failureValue!).  Transitioning to same.")
+                    log.error("Unknown error: \(result.failureValue!).  Assuming error is transient and not transitioning.")
                     return same
                 }
             }
@@ -156,7 +156,7 @@ class FxALoginStateMachine {
                                 log.error("Unsuccessful HTTP request: \(error.description)!  Assuming error is transient and not transitioning.")
                                 return same
                             } else {
-                                log.error("Unknown error: \(error.description).  Transitioning to Same.")
+                                log.error("Unknown error: \(error.description).  Assuming error is transient and not transitioning.")
                                 return same
                             }
                         case let .local(localError) where localError.domain == NSURLErrorDomain:
@@ -166,7 +166,7 @@ class FxALoginStateMachine {
                             break
                         }
                     }
-                    log.error("Unknown error: \(result.failureValue!).  Transitioning to Same.")
+                    log.error("Unknown error: \(result.failureValue!).  Assuming error is transient and not transitioning.")
                     return same
                 }
             }

--- a/Account/FxALoginStateMachine.swift
+++ b/Account/FxALoginStateMachine.swift
@@ -106,8 +106,8 @@ class FxALoginStateMachine {
                                 log.error("Unsuccessful HTTP request: \(error.description)!  Assuming error is transient and not transitioning.")
                                 return same
                             } else {
-                                log.error("Unknown error: \(error.description).  Transitioning to Separated.")
-                                return separated
+                                log.error("Unknown error: \(error.description).  Transitioning to same.")
+                                return same
                             }
                         case let .local(localError) where localError.domain == NSURLErrorDomain:
                             log.warning("Local networking error: \(result.failureValue!).  Assuming transient and not transitioning.")
@@ -116,8 +116,8 @@ class FxALoginStateMachine {
                             break
                         }
                     }
-                    log.error("Unknown error: \(result.failureValue!).  Transitioning to Separated.")
-                    return separated
+                    log.error("Unknown error: \(result.failureValue!).  Transitioning to same.")
+                    return same
                 }
             }
 
@@ -156,8 +156,8 @@ class FxALoginStateMachine {
                                 log.error("Unsuccessful HTTP request: \(error.description)!  Assuming error is transient and not transitioning.")
                                 return same
                             } else {
-                                log.error("Unknown error: \(error.description).  Transitioning to Separated.")
-                                return separated
+                                log.error("Unknown error: \(error.description).  Transitioning to Same.")
+                                return same
                             }
                         case let .local(localError) where localError.domain == NSURLErrorDomain:
                             log.warning("Local networking error: \(result.failureValue!).  Assuming transient and not transitioning.")
@@ -166,8 +166,8 @@ class FxALoginStateMachine {
                             break
                         }
                     }
-                    log.error("Unknown error: \(result.failureValue!).  Transitioning to Separated.")
-                    return separated
+                    log.error("Unknown error: \(result.failureValue!).  Transitioning to Same.")
+                    return same
                 }
             }
 


### PR DESCRIPTION
These  changes were made based on @eoger direction on this