### PR TITLE
Fix #5864: Truncate library heading when one word is too long

### DIFF
--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -1044,7 +1044,7 @@ class LibraryShortcutView: UIView {
         }
         title.adjustsFontSizeToFitWidth = true
         title.minimumScaleFactor = 0.7
-        title.numberOfLines = 2
+        title.lineBreakMode = .byTruncatingTail
         title.font = DynamicFontHelper.defaultHelper.SmallSizeRegularWeightAS
         title.textAlignment = .center
         title.snp.makeConstraints { make in
@@ -1099,6 +1099,8 @@ class ASLibraryCell: UICollectionViewCell, Themeable {
             let view = LibraryShortcutView()
             view.button.setImage(item.image, for: .normal)
             view.title.text = item.title
+            let words = view.title.text?.components(separatedBy: NSCharacterSet.whitespacesAndNewlines).count
+            view.title.numberOfLines = words == 1 ? 1 :2
             view.button.backgroundColor = item.color
             view.button.setTitleColor(UIColor.theme.homePanel.topSiteDomain, for: .normal)
             view.accessibilityLabel = item.title


### PR DESCRIPTION
- if the heading is one word, it will truncate if scaling the text still does not fit
- if the heading is more than one word, it gets 2 lines

<img width="308" alt="image" src="https://user-images.githubusercontent.com/11432165/74089868-ac432f00-4a73-11ea-9bfe-018f5c4e4dc0.png">
