### PR TITLE
Feature #6107 - Making cover sheet optional per release

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1927,7 +1927,8 @@ extension BrowserViewController: IntroViewControllerDelegate {
     
     @discardableResult func presentUpdateViewController(_ force: Bool = false, animated: Bool = true) -> Bool {
         let cleanInstall = UpdateViewModel.isCleanInstall(userPrefs: profile.prefs)
-        if force || UpdateViewModel.shouldShow(userPrefs: profile.prefs, isCleanInstall: cleanInstall) {
+        let coverSheetSupportedAppVersion = UpdateViewModel.coverSheetSupportedAppVersion
+        if force || UpdateViewModel.shouldShowUpdateSheet(userPrefs: profile.prefs, isCleanInstall: cleanInstall, supportedAppVersions: coverSheetSupportedAppVersion) {
             let updateViewController = UpdateViewController()
             
             updateViewController.viewModel.shouldStartBrowsing = {

--- a/Client/Frontend/Update/UpdateViewModel.swift
+++ b/Client/Frontend/Update/UpdateViewModel.swift
@@ -13,6 +13,10 @@ class UpdateViewModel {
     // Constants
     let updates: [Update] = [Update(updateImage: #imageLiteral(resourceName: "darkModeUpdate"), updateText: "\(Strings.CoverSheetV22DarkModeTitle)\n\n\(Strings.CoverSheetV22DarkModeDescription)")]
     
+    // We only show coversheet for specific app updates and not all. The list below is for the version(s)
+    // we would like to show the coversheet for.
+    static let coverSheetSupportedAppVersion = ["22.0"]
+    
     init() {
         setupUpdateModel()
     }
@@ -28,29 +32,31 @@ class UpdateViewModel {
         return false
     }
     
-    static func shouldShow(userPrefs: Prefs, currentAppVersion: String = VersionSetting.appVersion, isCleanInstall: Bool) -> Bool {
+    static func shouldShowUpdateSheet(userPrefs: Prefs, currentAppVersion: String = VersionSetting.appVersion, isCleanInstall: Bool, supportedAppVersions:[String] = []) -> Bool {
+        var willShow = false
         if isCleanInstall {
             // We don't show it but save the currentVersion number
             userPrefs.setString(currentAppVersion, forKey: PrefsKeys.KeyLastVersionNumber)
-            return false
+            willShow = false
         } else {
             // Its not a new install so first we check if there is a version number already saved
             if let savedVersion = userPrefs.stringForKey(PrefsKeys.KeyLastVersionNumber) {
                // Version number saved in user prefs is not the same as current version, return true
                if savedVersion != currentAppVersion {
                    userPrefs.setString(currentAppVersion, forKey: PrefsKeys.KeyLastVersionNumber)
-                   return true
+                   willShow = true
                  // Version number saved in user prefs matches the current version, return false
                } else if savedVersion == currentAppVersion {
-                   return false
+                   willShow = false
                }
             } else {
                 // Only way the version is not saved if the user is coming from an app that didn't have this feature
                 // as its not a clean install. Hence we should still show the update screen but save the version
                 userPrefs.setString(currentAppVersion, forKey: PrefsKeys.KeyLastVersionNumber)
-                return true
+                willShow = true
             }
         }
-        return false
+        // Final version check to only show for specific app versions
+        return willShow && supportedAppVersions.contains(currentAppVersion)
     }
 }

--- a/ClientTests/TestBookmarks.swift
+++ b/ClientTests/TestBookmarks.swift
@@ -37,7 +37,7 @@ class TestBookmarks: ProfileTest {
 
             // This'll do.
             _ = profile.places.forceClose()
-            try? profile.files.remove("mock_places.db")
+            try? profile.files.remove("profile-test_places.db")
         }
     }
 }


### PR DESCRIPTION
Added Top level feature flag per version - Enable / Disable the cover sheet. Eg. We made a change and want to show it as part of cover sheet update. We require setting flag per version. We maintain a list of versions in the app on when to show the coversheet