### PR TITLE
Fix #6014: Allow etp title to span multiple lines

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
@@ -22,7 +22,7 @@ private struct PhotonActionSheetCellUX {
 
 class PhotonActionSheetCell: UITableViewCell {
     static let Padding: CGFloat = 16
-    static let HorizontalPadding: CGFloat = 10
+    static let HorizontalPadding: CGFloat = 1
     static let VerticalPadding: CGFloat = 2
     static let IconSize = 16
 
@@ -176,7 +176,7 @@ class PhotonActionSheetCell: UITableViewCell {
         titleLabel.text = action.title
         titleLabel.textColor = UIColor.theme.tableView.rowText
         titleLabel.textColor = action.accessory == .Text ? titleLabel.textColor.withAlphaComponent(0.6) : titleLabel.textColor
-        titleLabel.numberOfLines = 1
+        titleLabel.lineBreakMode = .byWordWrapping
         titleLabel.adjustsFontSizeToFitWidth = true
         titleLabel.minimumScaleFactor = 0.5
 

--- a/Client/Frontend/Widgets/PhotonActionSheet/TrackingProtectionMenu.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/TrackingProtectionMenu.swift
@@ -163,7 +163,7 @@ extension PhotonActionSheetProtocol {
             self.showDomainTable(title: action.title, description: desc, blocker: blocker, categories: [BlocklistCategory.cryptomining])
         }
 
-        var addToWhitelist = PhotonActionSheetItem(title: Strings.TPBlockingSiteEnabled, isEnabled: !isWhitelisted, accessory: .Switch) { _, cell in
+        var addToWhitelist = PhotonActionSheetItem(title: Strings.ETPOn, isEnabled: !isWhitelisted, accessory: .Switch) { _, cell in
             LeanPlumClient.shared.track(event: .trackingProtectionWhiteList)
             UnifiedTelemetry.recordEvent(category: .action, method: .add, object: .trackingProtectionWhitelist)
             ContentBlocker.shared.whitelist(enable: tab.contentBlocker?.status != .Whitelisted, url: currentURL) {
@@ -174,9 +174,9 @@ extension PhotonActionSheetProtocol {
         }
         addToWhitelist.customRender = { title, _ in
             if tab.contentBlocker?.status == .Whitelisted {
-                title.text = Strings.TPBlockingSiteDisabled
+                title.text = Strings.ETPOff
             } else {
-                title.text = Strings.TPBlockingSiteEnabled
+                title.text = Strings.ETPOn
             }
         }
         addToWhitelist.accessibilityId = "tp.add-to-whitelist"


### PR DESCRIPTION
**This should be merged after this release is out because it is waiting on string localization**

*Note that spacing changed  a bit due to the padding change but it is not that noticeable (see screenshots) and doesn't seem to cause any problems*
Before:
![Simulator Screen Shot - iPhone 11 - 2020-02-12 at 16 21 39](https://user-images.githubusercontent.com/11432165/74378935-d61e8d80-4db4-11ea-858c-d871c928bddd.png)

After:
![Simulator Screen Shot - iPhone 11 - 2020-02-12 at 15 00 46](https://user-images.githubusercontent.com/11432165/74378961-e0408c00-4db4-11ea-940d-45f1cee9b476.png)

![Simulator Screen Shot - iPhone 11 - 2020-02-12 at 15 00 52](https://user-images.githubusercontent.com/11432165/74378939-d880e780-4db4-11ea-8b7a-4b116007abe0.png)

