### PR TITLE
Removing white bar when dark mode is enabled 

### DIFF
--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -67,5 +67,6 @@ class UserScriptManager {
         if noImageMode {
             tab.webView?.configuration.userContentController.addUserScript(noImageModeUserScript)
         }
+        tab.reload()
     }
 }


### PR DESCRIPTION
This pull request is addressing the bug found in #5917 

# The issue
Despite dark mode being enabled, and the previous configuration wasn't fully flushed from the webview. That is the reason why the webview had both a header and footer white bars. 
# Solution 
 Reloading the tab would do the trick. 