### PR TITLE
XCUI Sync Int Tests: Bug 1610758 - TPS update its preferences

### DIFF
--- a/SyncIntegrationTests/conftest.py
+++ b/SyncIntegrationTests/conftest.py
@@ -86,7 +86,7 @@ def tps_profile(pytestconfig, tps_addon, tps_config, tps_log, fxa_urls):
         # 'devtools.debugger.remote-enabled': True,
         'engine.bookmarks.repair.enabled': False,
         'extensions.autoDisableScopes': 10,
-        'extensions.legacy.enabled': True,
+        'extensions.experiments.enabled': True,
         'extensions.update.enabled': False,
         'extensions.update.notifyUser': False,
         'identity.fxaccounts.autoconfig.uri': fxa_urls['content'],

--- a/SyncIntegrationTests/test_integration.py
+++ b/SyncIntegrationTests/test_integration.py
@@ -10,11 +10,11 @@ def test_sync_bookmark_from_desktop(tps, xcodebuild):
 def test_sync_history_from_device(tps, xcodebuild):
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncHistory')
     tps.run('test_history.js')
-'''
+
 def test_sync_tabs_from_device(tps, xcodebuild):
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncTabs')
     tps.run('test_tabs.js')
-'''
+
 def test_sync_history_from_desktop(tps, xcodebuild):
     tps.run('test_history_desktop.js')
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncHistoryDesktop')
@@ -22,7 +22,7 @@ def test_sync_history_from_desktop(tps, xcodebuild):
 def test_sync_logins_from_device(tps, xcodebuild):
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncLogins')
     tps.run('test_password.js')
-
+'''
 def test_sync_logins_from_desktop(tps, xcodebuild):
     tps.run('test_password_desktop.js')
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncPasswordDesktop')
@@ -30,5 +30,4 @@ def test_sync_logins_from_desktop(tps, xcodebuild):
 def test_sync_tabs_from_desktop(tps, xcodebuild):
     tps.run('test_tabs_desktop.js')
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncTabsDesktop')
-'''
-   
+ 

--- a/SyncIntegrationTests/xcodebuild.py
+++ b/SyncIntegrationTests/xcodebuild.py
@@ -10,7 +10,7 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 class XCodeBuild(object):
     binary = 'xcodebuild'
-    destination = 'platform=iOS Simulator,name=iPhone X'
+    destination = 'platform=iOS Simulator,name=iPhone 11,OS=13.2.2'
     logger = logging.getLogger()
     scheme = 'Fennec_Enterprise_XCUITests_Integration'
     xcrun = XCRun()

--- a/XCUITests/IntegrationTests.swift
+++ b/XCUITests/IntegrationTests.swift
@@ -165,9 +165,8 @@ class IntegrationTests: BaseTestCase {
         waitForInitialSyncComplete()
 
         // Check synced Tabs
-        navigator.goto(LibraryPanel_History)
-        waitForExistence(app.cells["HistoryPanel.syncedDevicesCell"], timeout: 5)
-        app.cells["HistoryPanel.syncedDevicesCell"].tap()
+        navigator.goto(LibraryPanel_SyncedTabs)
+
         // Need to swipe to get the data on the screen on focus
         app.swipeDown()
         waitForExistence(app.tables.otherElements["profile1"], timeout: 10)


### PR DESCRIPTION
This PR fixes the TPS issue by updating its preferences used when Nightly is launched.

Also, some tests have been enabled again and some updates added, like the new way to see the sync tabs.
