### PR TITLE
Issue #6092 - XCUITests update tests to match manual tests on test rail

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_SmokeXCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_SmokeXCUITests.xcscheme
@@ -170,9 +170,9 @@
       buildConfiguration = "Fennec"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       language = "en"
-      region = "US"
-      shouldUseLaunchSchemeArgsEnv = "NO">
+      region = "US">
       <PreActions>
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
@@ -182,10 +182,28 @@
             </ActionContent>
          </ExecutionAction>
       </PreActions>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+            BuildableName = "Client.app"
+            BlueprintName = "Client"
+            ReferencedContainer = "container:Client.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "FIREFOX_CLEAR_PROFILE"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "FIREFOX_TEST"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <Testables>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "NO">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "3BFE4B061D342FB800DDF53F"
@@ -336,7 +354,28 @@
                   Identifier = "DomainAutocompleteTest">
                </Test>
                <Test
-                  Identifier = "DownloadFilesTests">
+                  Identifier = "DownloadFilesTests/testDeleteDownloadedFile()">
+               </Test>
+               <Test
+                  Identifier = "DownloadFilesTests/testDownloadFile()">
+               </Test>
+               <Test
+                  Identifier = "DownloadFilesTests/testDownloadFileContextMenu()">
+               </Test>
+               <Test
+                  Identifier = "DownloadFilesTests/testDownloadFilesAppMenuFirstTime()">
+               </Test>
+               <Test
+                  Identifier = "DownloadFilesTests/testDownloadMoreThanOneFile()">
+               </Test>
+               <Test
+                  Identifier = "DownloadFilesTests/testLongPressOnDownloadedFile()">
+               </Test>
+               <Test
+                  Identifier = "DownloadFilesTests/testRemoveUserDataRemovesDownloadedFiles()">
+               </Test>
+               <Test
+                  Identifier = "DownloadFilesTests/testShareDownloadedFile()">
                </Test>
                <Test
                   Identifier = "DragAndDropTestIpad">
@@ -552,7 +591,10 @@
                   Identifier = "PrivateBrowsingTest/testiPadDirectAccessPrivateModeBrowserTab()">
                </Test>
                <Test
-                  Identifier = "PrivateBrowsingTestIpad">
+                  Identifier = "PrivateBrowsingTestIpad/testClosePrivateTabsOptionClosesPrivateTabsShortCutiPad()">
+               </Test>
+               <Test
+                  Identifier = "PrivateBrowsingTestIpad/testiPadDirectAccessPrivateModeBrowserTab()">
                </Test>
                <Test
                   Identifier = "ReaderViewTest/testAddToReadingListFromPageOptionsMenu()">
@@ -585,16 +627,13 @@
                   Identifier = "SaveLoginTest/testDoNotSaveLogin()">
                </Test>
                <Test
-                  Identifier = "SaveLoginTest/testEditOneLoginEntry()">
-               </Test>
-               <Test
                   Identifier = "SaveLoginTest/testLoginsListFromBrowserTabMenu()">
                </Test>
                <Test
                   Identifier = "SaveLoginTest/testPasscodeLoginsListFromBrowserTabMenu()">
                </Test>
                <Test
-                  Identifier = "SaveLoginTest/testSaveLogin()">
+                  Identifier = "SaveLoginTest/testSavedLoginSelectUnselect()">
                </Test>
                <Test
                   Identifier = "SaveLoginTest/testSearchLogin()">
@@ -705,13 +744,7 @@
                   Identifier = "TopTabsTestIpad/testUpdateTabCounter()">
                </Test>
                <Test
-                  Identifier = "TopTabsTestIphone/testAddPrivateTabByLongPressTabsButton()">
-               </Test>
-               <Test
-                  Identifier = "TopTabsTestIphone/testAddTabByLongPressTabsButton()">
-               </Test>
-               <Test
-                  Identifier = "TopTabsTestIphone/testCloseTabFromLongPressTabsButton()">
+                  Identifier = "TrackingProtectionTests/testBasicMoreInfo()">
                </Test>
                <Test
                   Identifier = "TrackingProtectionTests/testDisableForSiteDoesNotDisableForOthersDifferentTab()">
@@ -726,16 +759,13 @@
                   Identifier = "TrackingProtectionTests/testDisablingTPforOneSiteDoesNotChangeGeneralTPOption()">
                </Test>
                <Test
-                  Identifier = "TrackingProtectionTests/testOpenSettingsFromTPcontextMenu()">
-               </Test>
-               <Test
-                  Identifier = "TrackingProtectionTests/testBasicMoreInfo()">
-               </Test>
-               <Test
                   Identifier = "TrackingProtectionTests/testMenuWhenThereAreBlockedElements()">
                </Test>
                <Test
                   Identifier = "TrackingProtectionTests/testMenuWhenThereAreNotBlockedElements()">
+               </Test>
+               <Test
+                  Identifier = "TrackingProtectionTests/testOpenSettingsFromTPcontextMenu()">
                </Test>
                <Test
                   Identifier = "TrackingProtectionTests/testTPMenuHomePanel()">
@@ -752,27 +782,6 @@
             </SkippedTests>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
-            BuildableName = "Client.app"
-            BlueprintName = "Client"
-            ReferencedContainer = "container:Client.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <CommandLineArguments>
-         <CommandLineArgument
-            argument = "FIREFOX_CLEAR_PROFILE"
-            isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "FIREFOX_TEST"
-            isEnabled = "YES">
-         </CommandLineArgument>
-      </CommandLineArguments>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Fennec"
@@ -801,8 +810,6 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Fennec"

--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
@@ -170,9 +170,28 @@
       buildConfiguration = "Fennec"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       language = "en"
-      region = "US"
-      shouldUseLaunchSchemeArgsEnv = "NO">
+      region = "US">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+            BuildableName = "Client.app"
+            BlueprintName = "Client"
+            ReferencedContainer = "container:Client.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "FIREFOX_CLEAR_PROFILE"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "FIREFOX_TEST"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -221,6 +240,9 @@
                   Identifier = "DomainAutocompleteTest/testDeletingCharsUpdateTheResults()">
                </Test>
                <Test
+                  Identifier = "DownloadFilesTests/testToastButtonToGoToDownloads()">
+               </Test>
+               <Test
                   Identifier = "DragAndDropTestIpad/testTryDragAndDropBookmarkToURLBar()">
                </Test>
                <Test
@@ -234,6 +256,9 @@
                </Test>
                <Test
                   Identifier = "HistoryTests/testClearPrivateDataButtonDisabled()">
+               </Test>
+               <Test
+                  Identifier = "HistoryTests/testDeleteHistoryEntryBySwiping()">
                </Test>
                <Test
                   Identifier = "HomePageSettingsTest">
@@ -272,6 +297,9 @@
                   Identifier = "NewTabSettingsTest/testChangeNewTabSettingsShowBlankPage()">
                </Test>
                <Test
+                  Identifier = "NewTabSettingsTest/testChangeNewTabSettingsShowCustomURL()">
+               </Test>
+               <Test
                   Identifier = "NewTabSettingsTest/testChangeNewTabSettingsShowYourBookmarks()">
                </Test>
                <Test
@@ -282,9 +310,6 @@
                </Test>
                <Test
                   Identifier = "NewTabSettingsTest/testToggleOffOnAdditionalContentBookmarks()">
-               </Test>
-	       <Test
-                  Identifier = "NewTabSettingsTest/testChangeNewTabSettingsShowCustomURL()">
                </Test>
                <Test
                   Identifier = "NoImageTests">
@@ -311,16 +336,25 @@
                   Identifier = "PrivateBrowsingTest/testiPadDirectAccessPrivateModeBrowserTab()">
                </Test>
                <Test
+                  Identifier = "PrivateBrowsingTestIpad/testiPadDirectAccessPrivateMode()">
+               </Test>
+               <Test
+                  Identifier = "ReaderViewTest/testAddToReaderListOptions()">
+               </Test>
+               <Test
                   Identifier = "ReaderViewTest/testAddToReadingList()">
                </Test>
                <Test
                   Identifier = "ReaderViewTest/testLoadReaderContent()">
                </Test>
                <Test
-                  Identifier = "SaveLoginTest/testSavedLoginAutofilled()">
+                  Identifier = "SaveLoginTest/testEditOneLoginEntry()">
                </Test>
                <Test
-                  Identifier = "SaveLoginTest/testSavedLoginSelectUnselect()">
+                  Identifier = "SaveLoginTest/testSaveLogin()">
+               </Test>
+               <Test
+                  Identifier = "SaveLoginTest/testSavedLoginAutofilled()">
                </Test>
                <Test
                   Identifier = "ScreenGraphTest/testUserStateChanges()">
@@ -374,6 +408,15 @@
                   Identifier = "TopTabsTest/testSwitchBetweenTabsToastButton()">
                </Test>
                <Test
+                  Identifier = "TopTabsTestIphone/testAddPrivateTabByLongPressTabsButton()">
+               </Test>
+               <Test
+                  Identifier = "TopTabsTestIphone/testAddTabByLongPressTabsButton()">
+               </Test>
+               <Test
+                  Identifier = "TopTabsTestIphone/testCloseTabFromLongPressTabsButton()">
+               </Test>
+               <Test
                   Identifier = "TopTabsTestIphone/testSwitchBetweenTabsNoPrivatePrivateToastButton()">
                </Test>
                <Test
@@ -388,27 +431,6 @@
             </SkippedTests>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
-            BuildableName = "Client.app"
-            BlueprintName = "Client"
-            ReferencedContainer = "container:Client.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <CommandLineArguments>
-         <CommandLineArgument
-            argument = "FIREFOX_CLEAR_PROFILE"
-            isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "FIREFOX_TEST"
-            isEnabled = "YES">
-         </CommandLineArgument>
-      </CommandLineArguments>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Fennec"
@@ -437,8 +459,6 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Fennec"

--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
@@ -225,6 +225,9 @@
                   Identifier = "BaseTestCase">
                </Test>
                <Test
+                  Identifier = "BookmarkingTests/testBookmarkLibraryAddDeleteBookmark()">
+               </Test>
+               <Test
                   Identifier = "BookmarkingTests/testBookmarksAwesomeBar()">
                </Test>
                <Test

--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests_Integration.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests_Integration.xcscheme
@@ -170,9 +170,9 @@
       buildConfiguration = "Fennec"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       language = "en"
-      region = "US"
-      shouldUseLaunchSchemeArgsEnv = "NO">
+      region = "US">
       <PreActions>
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
@@ -182,6 +182,37 @@
             </ActionContent>
          </ExecutionAction>
       </PreActions>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+            BuildableName = "Client.app"
+            BlueprintName = "Client"
+            ReferencedContainer = "container:Client.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "FIREFOX_CLEAR_PROFILE"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "FIREFOX_TEST"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "FXA_EMAIL"
+            value = "$(FXA_EMAIL)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "FXA_PASSWORD"
+            value = "$(FXA_PASSWORD)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -221,6 +252,12 @@
                   Identifier = "DatabaseFixtureTest">
                </Test>
                <Test
+                  Identifier = "DesktopModeTestsIpad">
+               </Test>
+               <Test
+                  Identifier = "DesktopModeTestsIphone">
+               </Test>
+               <Test
                   Identifier = "DisplaySettingTests">
                </Test>
                <Test
@@ -255,6 +292,12 @@
                </Test>
                <Test
                   Identifier = "HomePageUITest">
+               </Test>
+               <Test
+                  Identifier = "LibraryTestsIpad">
+               </Test>
+               <Test
+                  Identifier = "LibraryTestsIphone">
                </Test>
                <Test
                   Identifier = "MailAppSettingsTests">
@@ -367,42 +410,15 @@
                <Test
                   Identifier = "TrackingProtectionTests">
                </Test>
+               <Test
+                  Identifier = "TranslationSnackBarTest">
+               </Test>
+               <Test
+                  Identifier = "WhatsNewTest">
+               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
-            BuildableName = "Client.app"
-            BlueprintName = "Client"
-            ReferencedContainer = "container:Client.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <CommandLineArguments>
-         <CommandLineArgument
-            argument = "FIREFOX_CLEAR_PROFILE"
-            isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "FIREFOX_TEST"
-            isEnabled = "YES">
-         </CommandLineArgument>
-      </CommandLineArguments>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "FXA_EMAIL"
-            value = "$(FXA_EMAIL)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "FXA_PASSWORD"
-            value = "$(FXA_PASSWORD)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Fennec"
@@ -431,8 +447,6 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Fennec"

--- a/XCUITests/BookmarkingTests.swift
+++ b/XCUITests/BookmarkingTests.swift
@@ -261,4 +261,27 @@ class BookmarkingTests: BaseTestCase {
         app.textFields["address"].tap()
         app.textFields["address"].typeText(text)
     }
+
+    // Smoketest
+    func testBookmarkLibraryAddDeleteBookmark() {
+        // Verify that there are only 4 cells without recent bookmarks
+        navigator.goto(LibraryPanel_Bookmarks)
+        waitForNoExistence(app.otherElements["Recent Bookmarks"])
+        // There are 4 rows for the default folders
+        XCTAssertEqual(app.tables["Bookmarks List"].cells.count, 4)
+
+        //Add a bookmark
+        navigator.openURL(url_3)
+        waitForTabsButton()
+        bookmark()
+
+        // Check that it appers in Bookmarks panel
+        navigator.goto(LibraryPanel_Bookmarks)
+        //waitForExistence(app.staticTexts["Example Domain"], timeout: 10)
+        app.tables["Bookmarks List"].cells.staticTexts["Example Domain"].swipeLeft()
+        // Delete the Bookmark added, check it is removed
+        app.buttons["Delete"].tap()
+        waitForNoExistence(app.tables["Bookmarks List"].cells.staticTexts["Example Domain"], timeoutValue: 10)
+        XCTAssertFalse(app.tables["Bookmarks List"].cells.staticTexts["Example Domain"].exists, "Bookmark not removed successfully")
+    }
 }

--- a/XCUITests/HistoryTests.swift
+++ b/XCUITests/HistoryTests.swift
@@ -292,4 +292,16 @@ class HistoryTests: BaseTestCase {
             XCTAssertTrue(app.sheets.buttons[option].exists)
         }
     }
+
+    // Smoketest
+    func testDeleteHistoryEntryBySwiping() {
+        navigateToGoogle()
+        navigator.goto(LibraryPanel_History)
+        print(app.debugDescription)
+        waitForExistence(app.cells.staticTexts["http://example.com/"], timeout: 10)
+        app.cells.staticTexts["http://example.com/"].firstMatch.swipeLeft()
+        waitForExistence(app.buttons["Delete"], timeout: 10)
+        app.buttons["Delete"].tap()
+        waitForNoExistence(app.staticTexts["http://example.com"])
+    }
 }

--- a/XCUITests/NavigationTest.swift
+++ b/XCUITests/NavigationTest.swift
@@ -172,12 +172,16 @@ class NavigationTest: BaseTestCase {
     // Smoketest
     func testLongPressLinkOptions() {
         navigator.openURL(path(forTestPage: "test-example.html"))
+        waitForExistence(app.webViews.links[website_2["link"]!], timeout: 30)
         app.webViews.links[website_2["link"]!].press(forDuration: 2)
         waitForExistence(app.scrollViews.staticTexts[website_2["moreLinkLongPressUrl"]!])
+        print(app.debugDescription)
         XCTAssertTrue(app.buttons["Open in New Tab"].exists, "The option is not shown")
         XCTAssertTrue(app.buttons["Open in New Private Tab"].exists, "The option is not shown")
         XCTAssertTrue(app.buttons["Copy Link"].exists, "The option is not shown")
         XCTAssertTrue(app.buttons["Download Link"].exists, "The option is not shown")
+        XCTAssertTrue(app.buttons["Share Link"].exists, "The option is not shown")
+        XCTAssertTrue(app.buttons["Bookmark Link"].exists, "The option is not shown")
     }
 
     func testLongPressLinkOptionsPrivateMode() {

--- a/XCUITests/NavigationTest.swift
+++ b/XCUITests/NavigationTest.swift
@@ -175,7 +175,7 @@ class NavigationTest: BaseTestCase {
         waitForExistence(app.webViews.links[website_2["link"]!], timeout: 30)
         app.webViews.links[website_2["link"]!].press(forDuration: 2)
         waitForExistence(app.scrollViews.staticTexts[website_2["moreLinkLongPressUrl"]!])
-        print(app.debugDescription)
+
         XCTAssertTrue(app.buttons["Open in New Tab"].exists, "The option is not shown")
         XCTAssertTrue(app.buttons["Open in New Private Tab"].exists, "The option is not shown")
         XCTAssertTrue(app.buttons["Copy Link"].exists, "The option is not shown")

--- a/XCUITests/ReaderViewUITest.swift
+++ b/XCUITests/ReaderViewUITest.swift
@@ -211,4 +211,13 @@ class ReaderViewTest: BaseTestCase {
         waitForNoExistence(app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"])
         XCTAssertFalse(app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"].exists)
     }
+
+    // Smoketest
+    func testAddToReaderListOptions() {
+        addContentToReaderView()
+        // Check that Settings layouts options are shown
+        waitForExistence(app.buttons["ReaderModeBarView.settingsButton"], timeout: 10)
+        app.buttons["ReaderModeBarView.settingsButton"].tap()
+        XCTAssertTrue(app.buttons["Light"].exists)
+    }
 }


### PR DESCRIPTION
Fixes part of issue 6092 by updating some tests, modify some others and enable/disable in the Smoketest schema according to the manual tests defined there
