### PR TITLE
fix #6078: [ios 13] revert fix #5716

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -99,21 +99,7 @@ extension BrowserViewController: WKUIDelegate {
 
     @available(iOS 13.0, *)
     func webView(_ webView: WKWebView, contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo, completionHandler: @escaping (UIContextMenuConfiguration?) -> Void) {
-        completionHandler(UIContextMenuConfiguration(identifier: nil, previewProvider: {
-            guard let url = elementInfo.linkURL else { return nil }
-            let previewViewController = UIViewController()
-            previewViewController.view.isUserInteractionEnabled = false
-            let clonedWebView = WKWebView(frame: webView.frame, configuration: webView.configuration)
-
-            previewViewController.view.addSubview(clonedWebView)
-            clonedWebView.snp.makeConstraints { make in
-                make.edges.equalTo(previewViewController.view)
-            }
-
-            clonedWebView.load(URLRequest(url: url))
-
-            return previewViewController
-        }, actionProvider: { (suggested) -> UIMenu? in
+        completionHandler(UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: { (suggested) -> UIMenu? in
             guard let url = elementInfo.linkURL, let currentTab = self.tabManager.selectedTab,
                 let contextHelper = currentTab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper,
                 let elements = contextHelper.elements else { return nil }


### PR DESCRIPTION
This fix just backs out c829026 which introduced previewView in the link context menu on ios 13 clients in order to address #5716 and raise “new tab” closer to the click and bring closer to Safari behavior.  The option to omit link previews was not included. 

This has been shown in #6078 to be a both a privacy and security risk as well as an unrequested use of user’s mobile data. A user is often unable to determine a link target prior to clicking or having the browser click it for them. The preview view also launches into authorization and authentication processes within the context menu, disrupting the browsing session.

With reversion of the #5716 changes the build is successful without additional warnings and all tests passed. No changes in build settings or dependencies were needed.
