### PR TITLE
Fix #4984: Tab Tray should respect 'Reduce Motion' accessibility setting

### DIFF
--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -67,22 +67,31 @@ private extension TrayToBrowserAnimator {
         // Re-calculate the starting transforms for header/footer views in case we switch orientation
         resetTransformsForViews([bvc.header, bvc.readerModeBar, bvc.footer])
         transformHeaderFooterForBVC(bvc, toFrame: startingFrame, container: container)
+        
+        let frameResizeClosure = {
+            // Scale up the cell and reset the transforms for the header/footers
+            cell.frame = finalFrame
+            container.layoutIfNeeded()
+            cell.title.transform = CGAffineTransform(translationX: 0, y: -cell.title.frame.height)
+            bvc.tabTrayDidDismiss(tabTray)
+            tabTray.toolbar.transform = CGAffineTransform(translationX: 0, y: UIConstants.BottomToolbarHeight)
+            tabCollectionViewSnapshot.transform = CGAffineTransform(scaleX: 0.9, y: 0.9) 
+        }
+
+        if UIAccessibility.isReduceMotionEnabled {
+            frameResizeClosure()
+        }
 
         UIView.animate(withDuration: self.transitionDuration(using: transitionContext),
             delay: 0, usingSpringWithDamping: 1,
             initialSpringVelocity: 0,
             options: [],
             animations: {
-            // Scale up the cell and reset the transforms for the header/footers
-            cell.frame = finalFrame
-            container.layoutIfNeeded()
-            cell.title.transform = CGAffineTransform(translationX: 0, y: -cell.title.frame.height)
-
-            bvc.tabTrayDidDismiss(tabTray)
+            if !UIAccessibility.isReduceMotionEnabled {
+                frameResizeClosure()
+            }
             UIApplication.shared.windows.first?.backgroundColor = UIColor.theme.browser.background
             tabTray.navigationController?.setNeedsStatusBarAppearanceUpdate()
-            tabTray.toolbar.transform = CGAffineTransform(translationX: 0, y: UIConstants.BottomToolbarHeight)
-            tabCollectionViewSnapshot.transform = CGAffineTransform(scaleX: 0.9, y: 0.9)
             tabCollectionViewSnapshot.alpha = 0
             tabTray.statusBarBG.alpha = 0
             tabTray.searchBarHolder.alpha = 0
@@ -180,20 +189,27 @@ private extension BrowserToTrayAnimator {
             let finalFrame = calculateCollapsedCellFrameUsingCollectionView(tabTray.collectionView,
                 atIndex: scrollToIndex)
             tabTray.toolbar.transform = CGAffineTransform(translationX: 0, y: UIConstants.BottomToolbarHeight)
+            
+            let frameResizeClosure = {
+                cell.frame = finalFrame
+                cell.layoutIfNeeded()
+                transformHeaderFooterForBVC(bvc, toFrame: finalFrame, container: container)
+                resetTransformsForViews([tabCollectionViewSnapshot])
+            }
+            
+            if UIAccessibility.isReduceMotionEnabled {
+                frameResizeClosure()
+            }
 
             UIView.animate(withDuration: self.transitionDuration(using: transitionContext),
                 delay: 0, usingSpringWithDamping: 1,
                 initialSpringVelocity: 0,
                 options: [],
                 animations: {
-                cell.frame = finalFrame
                 cell.title.transform = .identity
-                cell.layoutIfNeeded()
 
                 UIApplication.shared.windows.first?.backgroundColor = UIColor.theme.tabTray.background
                 tabTray.navigationController?.setNeedsStatusBarAppearanceUpdate()
-
-                transformHeaderFooterForBVC(bvc, toFrame: finalFrame, container: container)
 
                 bvc.urlBar.updateAlphaForSubviews(0)
                 bvc.footer.alpha = 0
@@ -202,7 +218,11 @@ private extension BrowserToTrayAnimator {
                 tabTray.statusBarBG.alpha = 1
                 tabTray.searchBarHolder.alpha = 1
                 tabTray.toolbar.transform = .identity
-                resetTransformsForViews([tabCollectionViewSnapshot])
+                
+                if !UIAccessibility.isReduceMotionEnabled {
+                    frameResizeClosure()
+                }
+                    
             }, completion: { finished in
                 // Remove any of the views we used for the animation
                 cell.removeFromSuperview()


### PR DESCRIPTION
Frames resizing has been moved to closures that get called either in animation closures (if Reduce Motion is disabled) or outside animation closures (if Reduce Motion is enabled)

Reduce Motion is ON:

https://www.dropbox.com/s/og9mh9smnkntv9o/static.mov?dl=0


Reduce Motion is OFF:

https://www.dropbox.com/s/g8xl1q2amivbzyw/moving.mov?dl=0