### PR TITLE
Fix #6212: CWTS options in webview need to be reflected in native settings

### DIFF
--- a/RustFxA/FxAWebView.swift
+++ b/RustFxA/FxAWebView.swift
@@ -178,6 +178,11 @@ extension FxAWebView: WKScriptMessageHandler {
         if let declinedSyncEngines = data["declinedSyncEngines"] as? [String] {
             // Stash the declined engines so on first sync we can disable them!
             UserDefaults.standard.set(declinedSyncEngines, forKey: "fxa.cwts.declinedSyncEngines")
+            
+            for engineName in declinedSyncEngines {
+                let prefName = "sync.engine.\(engineName).enabled"
+                profile.prefs.setBool(false, forKey: prefName)
+            }
         }
 
         if let engines = data["offeredSyncEngines"] as? [String], engines.count > 0 {


### PR DESCRIPTION
The setting for this is shown here https://github.com/mozilla-mobile/firefox-ios/blob/1c4b280931e3b2aedca79fb5e02ff43144700d2e/Client/Frontend/Settings/SyncContentSettingsViewController.swift#L154