### PR TITLE
Fix #6234: Revert "Removing white bar when dark mode is enabled"

### DIFF
--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -67,6 +67,5 @@ class UserScriptManager {
         if noImageMode {
             tab.webView?.configuration.userContentController.addUserScript(noImageModeUserScript)
         }
-        tab.reload()
     }
 }


### PR DESCRIPTION
Reverts mozilla-mobile/firefox-ios#6117 to fix https://github.com/mozilla-mobile/firefox-ios/issues/6234,
Also fixes https://github.com/mozilla-mobile/firefox-ios/issues/6135