### PR TITLE
Fix #5264: Bookmarks overlap when using large and bold text

### DIFF
--- a/Client/Frontend/Library/BookmarksPanel.swift
+++ b/Client/Frontend/Library/BookmarksPanel.swift
@@ -371,6 +371,10 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
         return 1
     }
 
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let bookmarkNode = indexPath.section == BookmarksSection.recent.rawValue ? recentBookmarks[safe: indexPath.row] : bookmarkNodes[safe: indexPath.row] else {
             return super.tableView(tableView, cellForRowAt: indexPath)


### PR DESCRIPTION
Sets the height for each row in BookmarksPanel UITableView to be automatically calculated, so that large dynamic type isn't squashed, unlike original #5264 issue.

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-03-12 at 19 56 38](https://user-images.githubusercontent.com/13925498/76585443-9d4d0380-649b-11ea-8695-fc11b53a9e0d.png)



