### PR TITLE
Fix #5034: Autocomplete titles overlap urls with Larger Text

### DIFF
--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -112,6 +112,7 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
 
         tableView.accessibilityIdentifier = "SiteTable"
         tableView.cellLayoutMarginsFollowReadableWidth = false
+        tableView.estimatedRowHeight = SiteTableViewControllerUX.RowHeight
 
         // Set an empty footer to prevent empty cells from appearing in the list.
         tableView.tableFooterView = UIView()
@@ -182,7 +183,7 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return SiteTableViewControllerUX.RowHeight
+        return UITableView.automaticDimension
     }
 
     func tableView(_ tableView: UITableView, hasFullWidthSeparatorForRowAtIndexPath indexPath: IndexPath) -> Bool {


### PR DESCRIPTION
Like PR #6265, automatically calculates for each row to accommodate Dynamic Type and  sets `estimatedRowHeight` to the original static value. 
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-03-13 at 08 56 00](https://user-images.githubusercontent.com/13925498/76651191-3e31d200-6521-11ea-9ce8-e78a274570e0.png)
