### PR TITLE
Fix #6271 - App crash when changing text size

### DIFF
--- a/Client/Frontend/Library/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel.swift
@@ -431,7 +431,6 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
                 emptyStateOverlayView.removeFromSuperview()
             }
             emptyStateOverlayView = createEmptyStateOverlayView()
-            resyncHistory()
             break
         case .DatabaseWasReopened:
             if let dbName = notification.object as? String, dbName == "browser.db" {

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -119,6 +119,9 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
         if let _ = self as? HomePanelContextMenu {
             tableView.dragDelegate = self
         }
+        
+        // notification observer
+        NotificationCenter.default.addObserver(self, selector: #selector(applicationDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
     }
 
     deinit {
@@ -143,6 +146,10 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
                 self.presentedViewController?.dismiss(animated: true, completion: nil)
             }
         }, completion: nil)
+    }
+    
+    @objc func applicationDidBecomeActive(){
+        reloadData()
     }
 
     func reloadData() {


### PR DESCRIPTION
After text size change in IOS settings, we receive a notification "DynamicFontChanged" sent by the system and immediately we try to get bookmarks but it's not possible when the app is in background. To do it later, I added calling reloadData() on didBecomeActive()
