### PR TITLE
Fix #6206: Placeholder text does not follow dynamic font sizing

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -364,6 +364,8 @@ class StringSetting: Setting, UITextFieldDelegate {
         cell.accessibilityTraits = UIAccessibilityTraits.none
         cell.contentView.addSubview(textField)
 
+        textField.font = DynamicFontHelper.defaultHelper.DefaultStandardFont
+
         textField.snp.makeConstraints { make in
             make.height.equalTo(44)
             make.trailing.equalTo(cell.contentView).offset(-Padding)


### PR DESCRIPTION
Sets textField font to be dynamic rather than static and modifies constraint calculations to resize correctly.

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-03-16 at 15 28 31](https://user-images.githubusercontent.com/13925498/76805202-6c224b00-679b-11ea-9417-b13098ccab5e.png)
