### PR TITLE
Fix6300: Needless `Array` initialization in `Sync.Ready`

### DIFF
--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -979,7 +979,7 @@ extension Ready: EngineStateChanges {
                 break
             }
         }
-        return Array(needReset).sorted()
+        return needReset.sorted()
     }
 
     public func enginesEnabled() -> [String] {
@@ -992,7 +992,7 @@ extension Ready: EngineStateChanges {
                 break
             }
         }
-        return Array(engines).sorted()
+        return engines.sorted()
     }
 
     public func enginesDisabled() -> [String] {
@@ -1005,7 +1005,7 @@ extension Ready: EngineStateChanges {
                 break
             }
         }
-        return Array(engines).sorted()
+        return engines.sorted()
     }
 
     public func clearLocalCommands() {


### PR DESCRIPTION
Hello.
Thank you for firefox-ios.
In this pull removed I removed some Needless `Array` initialization in `Sync.Ready`. Hope it will improve performance/code readability a little bit.
Fixed #6300.

