### PR TITLE
Bug-1622800 - part 2: Remove "project" prefix

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -252,13 +252,11 @@ tasks:
                                         $if: 'tasks_for == "action"'
                                         then: >
                                             PIP_IGNORE_INSTALLED=0 pip install --user /builds/worker/checkouts/taskgraph &&
-                                            taskcluster/scripts/install-sdk.sh &&
                                             ln -s /builds/worker/artifacts artifacts &&
                                             ~/.local/bin/taskgraph action-callback
                                         else: >
                                             PIP_IGNORE_INSTALLED=0 pip install --user /builds/worker/checkouts/taskgraph &&
                                             PIP_IGNORE_INSTALLED=0 pip install --user arrow taskcluster pyyaml &&
-                                            taskcluster/scripts/install-sdk.sh &&
                                             ln -s /builds/worker/artifacts artifacts &&
                                             ~/.local/bin/taskgraph decision
                                             --pushlog-id='0'

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -165,14 +165,14 @@ tasks:
                                         - tc-treeherder.v2.${project}.${head_sha}
                                         - $if: 'tasks_for == "github-push"'
                                           then:
-                                              - index.project.mobile.${project}.v2.branch.${short_head_branch}.latest.taskgraph.decision
-                                              - index.project.mobile.${project}.v2.branch.${short_head_branch}.revision.${head_sha}.taskgraph.decision
+                                              - index.mobile.${project}.v2.branch.${short_head_branch}.latest.taskgraph.decision
+                                              - index.mobile.${project}.v2.branch.${short_head_branch}.revision.${head_sha}.taskgraph.decision
                                         - $if: 'tasks_for == "cron"'
                                           then:
                                               # cron context provides ${head_branch} as a short one
-                                              - index.project.mobile.${project}.v2.branch.${head_branch}.latest.taskgraph.decision-${cron.job_name}
-                                              - index.project.mobile.${project}.v2.branch.${head_branch}.revision.${head_sha}.taskgraph.decision-${cron.job_name}
-                                              - index.project.mobile.${project}.v2.branch.${head_branch}.revision.${head_sha}.taskgraph.cron.${ownTaskId}
+                                              - index.mobile.${project}.v2.branch.${head_branch}.latest.taskgraph.decision-${cron.job_name}
+                                              - index.mobile.${project}.v2.branch.${head_branch}.revision.${head_sha}.taskgraph.decision-${cron.job_name}
+                                              - index.mobile.${project}.v2.branch.${head_branch}.revision.${head_sha}.taskgraph.cron.${ownTaskId}
                           scopes:
                               $if: 'tasks_for == "github-push"'
                               then:

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -10,7 +10,7 @@ taskgraph:
     repositories:
         mobile:
             name: "Firefox for iOS"
-    cached-task-prefix: project.mobile.firefox-ios
+    cached-task-prefix: mobile.firefox-ios
 
 workers:
     aliases:
@@ -26,4 +26,4 @@ workers:
             worker-type: 'images'
 
 scriptworker:
-    scope-prefix: project:mobile:firefox-ios:releng
+    scope-prefix: mobile:firefox-ios:releng


### PR DESCRIPTION
Follows #6277 up

https://phabricator.services.mozilla.com/D67885 added some of the scopes that https://github.com/mozilla-mobile/firefox-ios/commit/eb01868a5bf90b8f326bb6760e826fe3f390ff3b#commitcomment-37945511 lacks. That said, we're deprecating the `project` prefix. Let's not use it at all before something gets built.