### PR TITLE
Bug-1622800 - part 4: Use `mobile.v2.firefox-ios` instead of `mobile.…

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -165,14 +165,14 @@ tasks:
                                         - tc-treeherder.v2.${project}.${head_sha}
                                         - $if: 'tasks_for == "github-push"'
                                           then:
-                                              - index.mobile.${project}.v2.branch.${short_head_branch}.latest.taskgraph.decision
-                                              - index.mobile.${project}.v2.branch.${short_head_branch}.revision.${head_sha}.taskgraph.decision
+                                              - index.mobile.v2.${project}.branch.${short_head_branch}.latest.taskgraph.decision
+                                              - index.mobile.v2.${project}.branch.${short_head_branch}.revision.${head_sha}.taskgraph.decision
                                         - $if: 'tasks_for == "cron"'
                                           then:
                                               # cron context provides ${head_branch} as a short one
-                                              - index.mobile.${project}.v2.branch.${head_branch}.latest.taskgraph.decision-${cron.job_name}
-                                              - index.mobile.${project}.v2.branch.${head_branch}.revision.${head_sha}.taskgraph.decision-${cron.job_name}
-                                              - index.mobile.${project}.v2.branch.${head_branch}.revision.${head_sha}.taskgraph.cron.${ownTaskId}
+                                              - index.mobile.v2.${project}.branch.${head_branch}.latest.taskgraph.decision-${cron.job_name}
+                                              - index.mobile.v2.${project}.branch.${head_branch}.revision.${head_sha}.taskgraph.decision-${cron.job_name}
+                                              - index.mobile.v2.${project}.branch.${head_branch}.revision.${head_sha}.taskgraph.cron.${ownTaskId}
                           scopes:
                               $if: 'tasks_for == "github-push"'
                               then:


### PR DESCRIPTION
…firefox-ios.v2`

https://github.com/mozilla-mobile/firefox-ios/commit/36484d4bb5a9b73e391b7c1d876299dc7278cc83#commitcomment-38012360 failed again. I realized `v2` wasn't at the right place in the string 😅 

For the record, authorized scopes are these ones https://firefox-ci-tc.services.mozilla.com/auth/roles/repo%3Agithub.com%2Fmozilla-mobile%2Ffirefox-ios%3Abranch%3A*