### PR TITLE
Fix for issue #5910 : Long email for fxa is shown with smaller text in Browser Tab Menu 

### DIFF
--- a/Client/Assets/MainFrameAtDocumentEnd.js.LICENSE.txt
+++ b/Client/Assets/MainFrameAtDocumentEnd.js.LICENSE.txt
@@ -1,1 +1,0 @@
-/*! https://mths.be/punycode v1.4.1 by @mathias */

--- a/Client/Assets/MainFrameAtDocumentEnd.js.LICENSE.txt
+++ b/Client/Assets/MainFrameAtDocumentEnd.js.LICENSE.txt
@@ -1,0 +1,1 @@
+/*! https://mths.be/punycode v1.4.1 by @mathias */

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
@@ -176,7 +176,9 @@ class PhotonActionSheetCell: UITableViewCell {
         titleLabel.text = action.title
         titleLabel.textColor = UIColor.theme.tableView.rowText
         titleLabel.textColor = action.accessory == .Text ? titleLabel.textColor.withAlphaComponent(0.6) : titleLabel.textColor
-        titleLabel.adjustsFontSizeToFitWidth = true
+        titleLabel.adjustsFontSizeToFitWidth = false
+        titleLabel.numberOfLines = 1
+        titleLabel.lineBreakMode = .byTruncatingTail
         titleLabel.minimumScaleFactor = 0.5
 
         subtitleLabel.text = action.text


### PR DESCRIPTION
According to the discussions on the opened issue, We needed to keep the size of the text for the email the same as the rest of the menu elements and also add ellipsis.

- I added ellipsis and disabled the resizing of the text so it's consistent with the rest of the menu elements.

<img width="517" alt="Screen Shot 2020-03-28 at 5 51 57 AM" src="https://user-images.githubusercontent.com/11700198/77814389-42312880-70b9-11ea-9dc4-e1904d258818.png">


