### PR TITLE
Revert "Fix #6154 - Filter logins field has wrong text color in Light theme"

### DIFF
--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -190,19 +190,10 @@ class LoginListViewController: SensitiveViewController {
 
         selectionButton.setTitleColor(UIColor.theme.tableView.rowBackground, for: [])
         selectionButton.backgroundColor = UIColor.theme.general.highlightBlue
-        
-        let isDarkTheme = ThemeManager.instance.currentName == .dark
-        let searchTextField = searchController.searchBar.searchTextField
-        if isDarkTheme {
-            searchTextField.defaultTextAttributes[NSAttributedString.Key.foregroundColor] = UIColor.white
-        } else {
-            searchTextField.defaultTextAttributes[NSAttributedString.Key.foregroundColor] = UIColor.black
-        }
-        
-        if let glassIconView = searchTextField.leftView as? UIImageView {
-            //Magnifying glass
-            glassIconView.image = glassIconView.image?.withRenderingMode(.alwaysTemplate)
-            glassIconView.tintColor = UIColor.theme.tableView.headerTextLight
+
+        let theme = BuiltinThemeName(rawValue: ThemeManager.instance.current.name) ?? .normal
+        if theme == .dark {
+            searchController.searchBar.barStyle = .black
         }
     }
 


### PR DESCRIPTION
Reverts mozilla-mobile/firefox-ios#6251 due to compilation error
```
 'searchTextField' is only available in iOS 13.0 or newer
Client/Frontend/Login Management/LoginListViewController.swift
line 195
```