### PR TITLE
Bug 1622800 - part 5: Schedule a single screenshot job to Bitrise

### DIFF
--- a/taskcluster/ci/docker-image/kind.yml
+++ b/taskcluster/ci/docker-image/kind.yml
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - taskgraph.transforms.docker_image:transforms
+    - taskgraph.transforms.cached_tasks:transforms
+    - taskgraph.transforms.task:transforms
+
+jobs:
+    screenshots: {}

--- a/taskcluster/ci/generate-screenshots/kind.yml
+++ b/taskcluster/ci/generate-screenshots/kind.yml
@@ -1,0 +1,50 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - ffios_taskgraph.transforms.screenshots:transforms
+    - ffios_taskgraph.transforms.secrets:transforms
+    - taskgraph.transforms.job:transforms
+    - taskgraph.transforms.task:transforms
+
+
+job-defaults:
+    description: Generate localized screenshots by delegating the work to bitrise.io
+    run:
+        using: run-commands
+        use-caches: false
+        secrets:
+            by-level:
+                '3':
+                    - name: project/mobile/firefox-ios/bitrise
+                      key: api_key
+                      path: .bitrise_token
+                default: []
+        dummy-secrets:
+            by-level:
+                '3': []
+                default:
+                      - content: "faketoken"
+                        path: .bitrise_token
+    run-on-tasks-for: []
+    worker:
+        artifacts:
+            - type: file
+              name: public/logs/bitrise.log
+              path: /builds/worker/checkouts/src/bitrise.log
+        docker-image: {in-tree: screenshots}
+        max-run-time: 3600
+    worker-type: b-linux
+
+jobs:
+    fr:
+        locale: fr
+        worker:
+            # TODO: Move artifacts in transforms once we start supporting all locales
+            artifacts:
+                - type: file
+                  name: public/screenshots/fr.zip
+                  path: /builds/worker/checkouts/src/fr.zip

--- a/taskcluster/docker/screenshots/Dockerfile
+++ b/taskcluster/docker/screenshots/Dockerfile
@@ -1,0 +1,54 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+FROM ubuntu:18.04
+
+MAINTAINER Johan Lorenzo "jlorenzo+docker@mozilla.com"
+
+# Add worker user
+RUN mkdir /builds && \
+    useradd -d /builds/worker -s /bin/bash -m worker && \
+    chown worker:worker /builds/worker && \
+    mkdir /builds/worker/artifacts && \
+    chown worker:worker /builds/worker/artifacts
+
+WORKDIR /builds/worker/
+
+
+ENV CURL='curl --location --retry 5' \
+    LANG='en_US.UTF-8' \
+    TERM='dumb'
+
+
+RUN apt-get update -qq \
+    # We need to install tzdata before all of the other packages. Otherwise it will show an interactive dialog that
+    # we cannot navigate while building the Docker image.
+    && apt-get install -y tzdata \
+    && apt-get install -y curl \
+                          git \
+                          locales \
+                          mercurial \
+                          python3 \
+                          python3-pip \
+    && apt-get clean
+
+RUN pip3 install --upgrade pip
+COPY requirements.txt ./
+RUN pip3 install -r requirements.txt
+
+RUN locale-gen "$LANG"
+
+# %include-run-task
+
+ENV SHELL=/bin/bash \
+    HOME=/builds/worker \
+    PATH="/builds/worker/.local/bin:$PATH"
+
+
+VOLUME /builds/worker/checkouts
+VOLUME /builds/worker/.cache
+
+
+# run-task expects to run as root
+USER root

--- a/taskcluster/docker/screenshots/requirements.txt
+++ b/taskcluster/docker/screenshots/requirements.txt
@@ -1,0 +1,2 @@
+aiohttp-retry
+taskcluster

--- a/taskcluster/ffios_taskgraph/job.py
+++ b/taskcluster/ffios_taskgraph/job.py
@@ -57,6 +57,7 @@ def configure_run_commands_schema(config, job, taskdesc):
 
 def _generate_secret_command(secret):
     secret_command = [
+        "python3",  # XXX Other mobile projects run this script under python2
         "taskcluster/scripts/get-secret.py",
         "-s", secret["name"],
         "-k", secret["key"],
@@ -70,6 +71,7 @@ def _generate_secret_command(secret):
 
 def _generate_dummy_secret_command(secret):
     secret_command = [
+        "python3",  # XXX Other mobile projects run this script under python2
         "taskcluster/scripts/write-dummy-secret.py",
         "-f", secret["path"],
         "-c", secret["content"],

--- a/taskcluster/ffios_taskgraph/transforms/screenshots.py
+++ b/taskcluster/ffios_taskgraph/transforms/screenshots.py
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+Resolve secrets and dummy secrets
+"""
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from taskgraph.transforms.base import TransformSequence
+
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def add_command(config, tasks):
+    for task in tasks:
+        commands = task["run"].setdefault("commands", [])
+        locale = task.pop("locale")
+        commands.append([
+            "python3",
+            "taskcluster/scripts/generate-screenshots.py",
+            "--token-file", ".bitrise_token",
+            "--branch", config.params["head_ref"],
+            "--commit", config.params["head_rev"],
+            "--locale", locale
+        ])
+
+        yield task

--- a/taskcluster/ffios_taskgraph/transforms/secrets.py
+++ b/taskcluster/ffios_taskgraph/transforms/secrets.py
@@ -1,0 +1,27 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+Resolve secrets and dummy secrets
+"""
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import resolve_keyed_by
+
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def resolve_keys(config, tasks):
+    for task in tasks:
+        for key in ("run.secrets", "run.dummy-secrets"):
+            resolve_keyed_by(
+                task,
+                key,
+                item_name=task["name"],
+                level=config.params["level"]
+            )
+        yield task

--- a/taskcluster/scripts/generate-screenshots.py
+++ b/taskcluster/scripts/generate-screenshots.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import argparse
+import asyncio
+import logging
+import sys
+
+from aiohttp_retry import RetryClient
+
+
+log = logging.getLogger(__name__)
+
+BITRISE_APP_SLUG_ID = "6c06d3a40422d10f"
+BITRISE_URL_TEMPLATE = "https://api.bitrise.io/v0.1/apps/" + BITRISE_APP_SLUG_ID + "/{suffix}"
+
+
+class TaskException(Exception):
+    def __init__(self, *args, exit_code=1):
+        """Initialize ScriptWorkerTaskException.
+        Args:
+            *args: These are passed on via super().
+            exit_code (int, optional): The exit_code we should exit with when
+                this exception is raised.  Defaults to 1 (failure).
+        """
+        self.exit_code = exit_code
+        super(Exception, self).__init__(*args)
+
+
+def sync_main(
+    loop_function=asyncio.get_event_loop,
+):
+    """
+    This function sets up the basic needs for a script to run. More specifically:
+        * it initializes the logging
+        * it creates the asyncio event loop so that `async_main` can run
+    Args:
+        loop_function (function, optional): the function to call to get the
+            event loop; here for testing purposes. Defaults to
+            ``asyncio.get_event_loop``.
+    """
+    _init_logging()
+
+    parser = argparse.ArgumentParser(description="Generate a screenshot by delegating the work to bitrise.io")
+
+    parser.add_argument("--token-file", required=True, type=argparse.FileType("r"), help="file that contains the bitrise.io token")
+    parser.add_argument("--branch", required=True, help="the git branch to generate screenshots from")
+    parser.add_argument("--commit", required=True, help="the git commit hash to generate screenshots from")
+    parser.add_argument("--locale", required=True, help="locale to generate the screenshots for")
+
+    result = parser.parse_args()
+
+    token = result.token_file.read().strip()
+    if token.rstrip() == "faketoken":
+        log.warn('"faketoken" detected. Not uploading anything to the service.')
+        sys.exit(0)
+
+    loop = loop_function()
+    loop.run_until_complete(_handle_asyncio_loop(
+        async_main, token, result.branch, result.commit, result.locale
+    ))
+
+
+def _init_logging():
+    logging.basicConfig(
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        level=logging.DEBUG,
+    )
+
+
+async def _handle_asyncio_loop(async_main, token, branch, commit, locale):
+    try:
+        await async_main(token, branch, commit, locale)
+    except TaskException as exc:
+        log.exception("Failed to run task")
+        sys.exit(exc.exit_code)
+
+
+async def async_main(token, branch, commit, locale):
+    headers = {"Authorization": token}
+    async with RetryClient(headers=headers) as client:
+        build_slug = await schedule_build(client, branch, commit, locale)
+        log.info("Created new job. Slug: {}".format(build_slug))
+
+        try:
+            await wait_for_job_to_finish(client, build_slug)
+            log.info("Job {} is successful. Retrieving artifacts...".format(build_slug))
+            await download_artifacts(client, build_slug)
+        finally:
+            log.info("Retrieving bitrise log...")
+            await download_log(client, build_slug)
+
+
+async def schedule_build(client, branch, commit, locale):
+    url = BITRISE_URL_TEMPLATE.format(suffix="builds")
+    data = {
+        "hook_info": {
+            "type": "bitrise",
+        },
+        "build_params": {
+            "branch": branch,
+            "commit_hash": commit,
+            "environments": [{
+                "mapped_to": "MOZ_LOCALE",
+                "value": locale,
+            }],
+            "workflow_id": "jlorenzo_L10nScreenshotsTests",
+        },
+    }
+
+    response = await do_http_request_json(client, url, method="post", json=data)
+    if response.get("status", "") != "ok":
+        raise Exception("Bitrise status is not ok. Got: {}".format(response))
+
+    return response["build_slug"]
+
+
+async def wait_for_job_to_finish(client, build_slug):
+    suffix = "builds/{}".format(build_slug)
+    url = BITRISE_URL_TEMPLATE.format(suffix=suffix)
+
+    while True:
+        response = await do_http_request_json(client, url)
+        if response["data"]["finished_at"]:
+            log.info("Job {} is now finished, checking result...".format(build_slug))
+            break
+        else:
+            log.info("Job {} is still running. Waiting another minute...".format(build_slug))
+            await asyncio.sleep(60)
+
+    if response["data"]["status_text"] != "success":
+        if response["data"]["status_text"] == "error":
+            raise TaskException("Job {} errored! Got: {}".format(build_slug, response), exit_code=1)
+        if response["data"]["status_text"] == "aborted":
+            raise TaskException("Job {} was aborted. Got: {}".format(build_slug, response), exit_code=2)
+        raise TaskException("Job {} is finished but not successful. Got: {}".format(build_slug, response), exit_code=3)
+
+
+async def download_artifacts(client, build_slug):
+    suffix = "builds/{}/artifacts".format(build_slug)
+    url = BITRISE_URL_TEMPLATE.format(suffix=suffix)
+
+    response = await do_http_request_json(client, url)
+
+    artifacts_metadata = {
+        metadata["slug"]: metadata["title"]
+        for metadata in response["data"]
+    }
+
+    for artifact_slug, title in artifacts_metadata.items():
+        suffix = "builds/{}/artifacts/{}".format(build_slug, artifact_slug)
+        url = BITRISE_URL_TEMPLATE.format(suffix=suffix)
+
+        response = await do_http_request_json(client, url)
+        download_url = response["data"]["expiring_download_url"]
+        await download_file(download_url, title)
+
+
+async def download_log(client, build_slug):
+    suffix = "builds/{}/log".format(build_slug)
+    url = BITRISE_URL_TEMPLATE.format(suffix=suffix)
+
+    response = await do_http_request_json(client, url)
+    download_url = response["expiring_raw_log_url"]
+    await download_file(download_url, "bitrise.log")
+
+
+CHUNK_SIZE = 128
+
+
+async def download_file(download_url, file_destination):
+    async with RetryClient() as s3_client:
+        async with s3_client.get(download_url) as resp:
+            with open(file_destination, "wb") as fd:
+                while True:
+                    chunk = await resp.content.read(CHUNK_SIZE)
+                    if not chunk:
+                        break
+                    fd.write(chunk)
+
+    log.info("'{}' downloaded".format(file_destination))
+
+
+async def do_http_request_json(client, url, method="get", **kwargs):
+    method_and_url = "{} {}".format(method.upper(), url)
+    log.debug("Making request {}...".format(method_and_url))
+
+    http_function = getattr(client, method)
+    async with http_function(url, **kwargs) as r:
+        log.debug("{} returned HTTP code {}".format(method_and_url, r.status))
+        response = await r.json()
+
+    log.debug("{} returned JSON {}".format(method_and_url, response))
+
+    return response
+
+
+__name__ == "__main__" and sync_main()


### PR DESCRIPTION
This PR is not the last one but is a stepping stone to get the final goal achieved. Here's what it basically does:

0. Just like in https://github.com/mozilla-mobile/firefox-ios/pull/6277, the decision task still runs taskgraph, there's no change here.
1. Taskgraph used to schedule no task. Now, it schedules 2.
2. The first task creates a docker image which contains everything to run `generate-screenshots.py`.
3. The second task runs `generate-screenshots.py` on the docker image. This script delegates both the build and the screenshot generation to bitrise and fetches the artifacts. You can see the results there \o/ https://firefox-ci-tc.services.mozilla.com/tasks/dFVHYucpRjOJEcdQp_OVNQ/runs/0#artifacts

At the moment, the second task just generates screenshots for a single locale. I plan to change this in a followup PR. My next followup, though, will be about splitting the second task into 2: one that lets bitrise generate the final build, and the second one that takes care of just generating the screenshots. This way, adding new locales will just add the screenshot steps and not a full build. 

If you have any questions about "taskgraph", "the decision task", or "docker images", feel free to have a look at https://johanlorenzo.github.io/blog/2019/10/24/taskgraph-is-now-deployed-to-the-biggest-mozilla-mobile-projects.html