### PR TITLE
[nobug, build] Change sentry DSN env var to remove specific version

### DIFF
--- a/buddybuild_prebuild.sh
+++ b/buddybuild_prebuild.sh
@@ -41,11 +41,11 @@ fi
 #
 
 if [ "$BUDDYBUILD_SCHEME" == FirefoxBeta ]; then
-  echo "Setting SentryDSN to $SENTRY_DSN_BETA_180"
-  /usr/libexec/PlistBuddy -c "Set SentryDSN $SENTRY_DSN_BETA_180" "Client/Info.plist"
+  echo "Setting SentryDSN to $SENTRY_DSN_BETA"
+  /usr/libexec/PlistBuddy -c "Set SentryDSN $SENTRY_DSN_BETA" "Client/Info.plist"
 elif [ "$BUDDYBUILD_SCHEME" == Firefox ]; then
-  echo "Setting SentryDSN to $SENTRY_DSN_RELEASE_180"
-  /usr/libexec/PlistBuddy -c "Set SentryDSN $SENTRY_DSN_RELEASE_180" "Client/Info.plist"
+  echo "Setting SentryDSN to $SENTRY_DSN_RELEASE"
+  /usr/libexec/PlistBuddy -c "Set SentryDSN $SENTRY_DSN_RELEASE" "Client/Info.plist"
 fi
 
 #


### PR DESCRIPTION
Now in buddybuild we can set `SENTRY_DSN_BETA` and `SENTRY_DSN_RELEASE` for each release branch. I am not sure why there was a version number in the first place.