### PR TITLE
Fix #6348: Correctly process engine enablements on first sync.

### DIFF
--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -509,7 +509,7 @@ open class ServerConfigurationRequiredError: RecoverableSyncState {
         if let oldEngineConfiguration = s.engineConfiguration {
             metaGlobal = createMetaGlobalWithEngineConfiguration(oldEngineConfiguration, enginesEnablements: enginesEnablements)
         } else {
-            metaGlobal = createMetaGlobal(enginesEnablements: s.enginesEnablements)
+            metaGlobal = createMetaGlobal(enginesEnablements: enginesEnablements)
         }
         return client.uploadMetaGlobal(metaGlobal, ifUnmodifiedSince: nil)
             // ... and a new crypto/keys.


### PR DESCRIPTION
This appears to fix https://github.com/mozilla-mobile/firefox-ios/issues/6348 for me, but I don't understand this code well enough to know for sure, or to add any tests. @eoger it looks like you're familiar with from from https://github.com/mozilla-mobile/firefox-ios/pull/3355, could you please see if this makes sense?