### PR TITLE
For #5958 enable sync ui tests - iOS 13.4 update

### DIFF
--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -172,8 +172,8 @@ class ActivityStreamTest: BaseTestCase {
         waitForExistence(TopSiteCellgroup.cells["apple"])
         TopSiteCellgroup.cells["apple"].press(forDuration: 1)
         app.tables["Context Menu"].cells["Open in New Tab"].tap()
+        // The new tab is open but curren screen is still Homescreen
         XCTAssert(TopSiteCellgroup.exists)
-        XCTAssertFalse(app.staticTexts["apple"].exists)
 
         navigator.goto(TabTray)
         app.collectionViews.cells["Home"].tap()

--- a/XCUITests/ClipBoardTests.swift
+++ b/XCUITests/ClipBoardTests.swift
@@ -17,7 +17,7 @@ class ClipBoardTests: BaseTestCase {
     func copyUrl() {
         navigator.goto(URLBarOpen)
         waitForExistence(app.textFields["address"])
-        app.textFields["address"].press(forDuration: 3)
+        app.textFields["address"].tap()
         waitForExistence(app.menuItems["Copy"])
         app.menuItems["Copy"].tap()
         app.typeText("\r")

--- a/XCUITests/FindInPageTest.swift
+++ b/XCUITests/FindInPageTest.swift
@@ -156,13 +156,13 @@ class FindInPageTests: BaseTestCase {
         let stringToFind = app.webViews.staticTexts.matching(identifier: textToFind)
         let firstStringToFind = stringToFind.element(boundBy: 0)
         firstStringToFind.press(forDuration: 3)
-        waitForExistence(app.menuItems["Copy"])
+        waitForExistence(app.menuItems["Copy"], timeout: 5)
         // Find in page is correctly launched, bar with text pre-filled and
         // the buttons to find next and previous
         if (app.menuItems["Find in Page"].exists) {
             app.menuItems["Find in Page"].tap()
         } else {
-            app.menus.children(matching: .menuItem).element(boundBy: 3).tap()
+            app.menuItems["show.next.items.menu.button"].tap()
             waitForExistence(app.menuItems["Find in Page"])
             app.menuItems["Find in Page"].tap()
         }

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -694,8 +694,8 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
         screenState.gesture(forAction: Action.FxATypeEmail) { userState in
             if isTablet {
-                app.webViews.textFields.element(boundBy: 0).tap()
-                app.webViews.textFields.element(boundBy: 0).typeText(userState.fxaUsername!)
+                app.webViews.textFields.firstMatch.tap()
+                app.webViews.textFields.firstMatch.typeText(userState.fxaUsername!)
             } else {
                 app.textFields.element(boundBy: 0).tap()
                 app.textFields.element(boundBy: 0).typeText(userState.fxaUsername!)

--- a/XCUITests/HomePageSettingsUITest.swift
+++ b/XCUITests/HomePageSettingsUITest.swift
@@ -196,8 +196,7 @@ class HomePageSettingsUITests: BaseTestCase {
         enterWebPageAsHomepage(text: websiteUrl1)
         waitForValueContains(app.textFields["HomeAsCustomURLTextField"], value: "mozilla")
         navigator.goto(SettingsScreen)
-        //Assert that the label showing up in Settings is equal to the URL entere (NOT CURRENTLY WORKING, SHOWING HOMEPAGE INSTEAD OF URL)
-        XCTAssertEqual(app.tables.cells["Home"].label, "Home, Homepage")
+        XCTAssertEqual(app.tables.cells["Home"].label, "Home, Firefox Home")
         //Switch to FXHome and check label
         navigator.performAction(Action.SelectHomeAsFirefoxHomePage)
         navigator.nowAt(HomeSettings)

--- a/XCUITests/NavigationTest.swift
+++ b/XCUITests/NavigationTest.swift
@@ -91,23 +91,20 @@ class NavigationTest: BaseTestCase {
         signInToFirefoxStaticText.tap()
         checkFirefoxSyncScreenShownViaSettings()
 
-        // Disable check, page load issues on iOS13.3 sims, issue #5937
         // After that it is possible to go back to Settings
-        // let settingsButton = app.navigationBars["Client.FxAContentView"].buttons["Settings"]
-        // settingsButton.tap()
+        let settingsButton = app.navigationBars["Client.FxAWebView"].buttons["Settings"]
+        settingsButton.tap()
     }
     
     // Beacuse the Settings menu does not stretch tot the top we need a different function to check if the Firefox Sync screen is shown
     private func checkFirefoxSyncScreenShownViaSettings() {
-        // Disable check, page load issues on iOS13.3 sims, issue #5937
-        waitForExistence(app.webViews.firstMatch, timeout: 20)
-//        waitForExistence(app.navigationBars["Client.FxAContentView"], timeout: 50)
-//        waitForExistence(app.webViews.textFields.element(boundBy: 0), timeout:50)
-//        let email = app.webViews.textFields.element(boundBy: 0)
-//        // Verify the placeholdervalues here for the textFields
-//        let mailPlaceholder = "Email"
-//        let defaultMailPlaceholder = email.placeholderValue!
-//        XCTAssertEqual(mailPlaceholder, defaultMailPlaceholder, "The mail placeholder does not show the correct value")
+        waitForExistence(app.navigationBars["Client.FxAWebView"], timeout: 20)
+        waitForExistence(app.webViews.textFields.element(boundBy: 0), timeout:20)
+        let email = app.webViews.textFields.element(boundBy: 0)
+        // Verify the placeholdervalues here for the textFields
+        let mailPlaceholder = "Email"
+        let defaultMailPlaceholder = email.placeholderValue!
+        XCTAssertEqual(mailPlaceholder, defaultMailPlaceholder, "The mail placeholder does not show the correct value")
     }
 
     func testTapSignInShowsFxAFromRemoteTabPanel() {
@@ -117,8 +114,8 @@ class NavigationTest: BaseTestCase {
         app.tables.buttons["Sign in to Sync"].tap()
         checkFirefoxSyncScreenShown()
         
-        // Disable check, page load issues on iOS13.3 sims, issue #5937 app.navigationBars["Client.FxAContentView"].buttons["Close"].tap()
-        // navigator.nowAt(LibraryPanel_SyncedTabs)
+        app.navigationBars["Client.FxAWebView"].buttons["Close"].tap()
+        navigator.nowAt(LibraryPanel_SyncedTabs)
     }
 
     private func checkFirefoxSyncScreenShown() {

--- a/XCUITests/NewTabSettings.swift
+++ b/XCUITests/NewTabSettings.swift
@@ -76,7 +76,7 @@ class NewTabSettingsTest: BaseTestCase {
         waitForValueContains(app.textFields["NewTabAsCustomURLTextField"], value: "mozilla")
         navigator.goto(SettingsScreen)
         //Assert that the label showing up in Settings is equal to the URL entere (NOT CURRENTLY WORKING, SHOWING HOMEPAGE INSTEAD)
-        XCTAssertEqual(app.tables.cells["NewTab"].label, "New Tab, Homepage")
+        XCTAssertEqual(app.tables.cells["NewTab"].label, "New Tab, Firefox Home")
         //Switch to Blank page and check label
         navigator.performAction(Action.SelectNewTabAsBlankPage)
         navigator.nowAt(NewTabSettings)

--- a/XCUITests/PhotonActionSheetTest.swift
+++ b/XCUITests/PhotonActionSheetTest.swift
@@ -32,6 +32,7 @@ class PhotonActionSheetTest: BaseTestCase {
     // Disable issue #5554
 
     func testShareOptionIsShown() {
+        navigator.goto(BrowserTab)
         navigator.browserPerformAction(.shareOption)
 
         // Wait to see the Share options sheet
@@ -86,7 +87,7 @@ class PhotonActionSheetTest: BaseTestCase {
         navigator.goto(PageOptionsMenu)
         app.tables["Context Menu"].staticTexts["Share Page With…"].tap()
         waitForExistence(app.cells["Copy"], timeout: 5)
-        let fennecElement = app.collectionViews.scrollViews.cells.element(boundBy: 1)
+        let fennecElement = app.collectionViews.scrollViews.cells.element(boundBy: 2)
 
         fennecElement.tap()
         waitForExistence(app.navigationBars["ShareTo.ShareView"], timeout: 5)

--- a/XCUITests/PhotonActionSheetTest.swift
+++ b/XCUITests/PhotonActionSheetTest.swift
@@ -87,7 +87,9 @@ class PhotonActionSheetTest: BaseTestCase {
         navigator.goto(PageOptionsMenu)
         app.tables["Context Menu"].staticTexts["Share Page With…"].tap()
         waitForExistence(app.cells["Copy"], timeout: 5)
-        let fennecElement = app.collectionViews.scrollViews.cells.element(boundBy: 2)
+        // This is not ideal but only way to get the element on iPhone 8
+        // for iPhone 11, that would be boundBy: 2
+        let fennecElement = app.collectionViews.scrollViews.cells.element(boundBy: 1)
 
         fennecElement.tap()
         waitForExistence(app.navigationBars["ShareTo.ShareView"], timeout: 5)

--- a/XCUITests/SearchTest.swift
+++ b/XCUITests/SearchTest.swift
@@ -192,8 +192,8 @@ class SearchTests: BaseTestCase {
         // Select some text and long press to find the option
         app.webViews.staticTexts["cloud"].press(forDuration: 1)
         if !iPad() {
-            waitForExistence(app.menus.children(matching: .menuItem).element(boundBy: 3))
-            app.menus.children(matching: .menuItem).element(boundBy: 3).tap()
+            waitForExistence(app.menuItems["show.next.items.menu.button"], timeout: 5)
+            app.menuItems["show.next.items.menu.button"].tap()
         }
         waitForExistence(app.menuItems["Search with Firefox"])
         app.menuItems["Search with Firefox"].tap()

--- a/XCUITests/SyncFAUITests.swift
+++ b/XCUITests/SyncFAUITests.swift
@@ -27,37 +27,30 @@ class SyncUITests: BaseTestCase {
         navigator.goto(FxASigninScreen)
         verifyFxASigninScreen()
 
-        // Disabling, xcode 11.3 update Issue 5937
-        /*
         // Check menu available from a website
         navigator.openURL("mozilla.org")
         waitUntilPageLoad()
         navigator.goto(BrowserTabMenu)
         waitForExistence(app.tables["Context Menu"].cells["menu-sync"])
         navigator.goto(FxASigninScreen)
-        verifyFxASigninScreen()*/
+        verifyFxASigninScreen()
     }
 
     private func verifyFxASigninScreen() {
-        // Disable check, page load issues on iOS13.3 sims, issue #5937
-        waitForExistence(app.webViews.firstMatch, timeout: 20)
-        // Workaround BB iOS13
-//        waitForExistence(app.navigationBars["Client.FxAContentView"], timeout: 60)
-//        waitForExistence(app.webViews.textFields["Email"], timeout: 60)
-//        XCTAssertTrue(app.navigationBars["Client.FxAContentView"].exists)
-//        XCTAssertTrue(app.webViews.textFields["Email"].exists)
-//
-//        // Verify the placeholdervalues here for the textFields
-//        let mailPlaceholder = "Email"
-//        let defaultMailPlaceholder = app.webViews.textFields["Email"].placeholderValue!
-//        XCTAssertEqual(mailPlaceholder, defaultMailPlaceholder, "The mail placeholder does not show the correct value")
-//        XCTAssertTrue(app.webViews.buttons["Continue"].exists)
+        waitForExistence(app.navigationBars["Client.FxAWebView"], timeout: 30)
+        waitForExistence(app.webViews.textFields["Email"], timeout: 10)
+        XCTAssertTrue(app.webViews.textFields["Email"].exists)
+
+        // Verify the placeholdervalues here for the textFields
+        let mailPlaceholder = "Email"
+        let defaultMailPlaceholder = app.webViews.textFields["Email"].placeholderValue!
+        XCTAssertEqual(mailPlaceholder, defaultMailPlaceholder, "The mail placeholder does not show the correct value")
+        XCTAssertTrue(app.webViews.buttons["Continue"].exists)
     }
-    // Disabling, xcode 11.3 update Issue 5937
-    /*
+
     func testTypeOnGivenFields() {
         navigator.goto(FxASigninScreen)
-        waitForExistence(app.navigationBars["Client.FxAContentView"], timeout: 60)
+        waitForExistence(app.navigationBars["Client.FxAWebView"], timeout: 60)
 
         // Tap Sign in without any value in email Password focus on Email
         navigator.performAction(Action.FxATapOnContinueButton)
@@ -69,7 +62,7 @@ class SyncUITests: BaseTestCase {
         navigator.performAction(Action.FxATapOnContinueButton)
         waitForExistence(app.webViews.staticTexts["Valid email required"])
 
-        userState.fxaUsername = "valid@gmail.com"
+        userState.fxaUsername = "foo1bar2@gmail.com"
         navigator.performAction(Action.FxATypeEmail)
         navigator.performAction(Action.FxATapOnSignInButton)
 
@@ -83,27 +76,22 @@ class SyncUITests: BaseTestCase {
         userState.fxaPassword = "atleasteight"
         navigator.performAction(Action.FxATypePassword)
         waitForExistence(app.secureTextFields["Repeat password"], timeout: 10)
-    }*/
+    }
 
     func testCreateAnAccountLink() {
         navigator.goto(FxASigninScreen)
-        // Disable check, page load issues on iOS13.3 sims, issue #5937
         waitForExistence(app.webViews.firstMatch, timeout: 20)
-//      waitForExistence(app.navigationBars["Client.FxAContentView"], timeout: 60)
-//        waitForExistence(app.webViews.textFields["Email"], timeout: 40)
-//        userState.fxaUsername = "valid@gmail.com"
-//        navigator.performAction(Action.FxATypeEmail)
-//        navigator.performAction(Action.FxATapOnContinueButton)
-//        waitForExistence(app.webViews.buttons["Create account"])
+        waitForExistence(app.webViews.textFields["Email"], timeout: 40)
+        userState.fxaUsername = "foo1bar2@gmail.com"
+        navigator.performAction(Action.FxATypeEmail)
+        navigator.performAction(Action.FxATapOnContinueButton)
+        waitForExistence(app.webViews.buttons["Create account"])
     }
-    // Disabling, xcode 11.3 update Issue 5937
-    /*
+
     func testShowPassword() {
         // The aim of this test is to check if the option to show password is shown when user starts typing and dissapears when no password is typed
         navigator.goto(FxASigninScreen)
-        // Workaround BB iOS13
-        waitForExistence(app.navigationBars["Client.FxAContentView"], timeout: 60)
-        waitForExistence(app.webViews.textFields["Email"], timeout: 50)
+        waitForExistence(app.webViews.textFields["Email"], timeout: 20)
         // Typing on Email should not show Show (password) option
         userState.fxaUsername = "iosmztest@gmail.com"
         navigator.performAction(Action.FxATypeEmail)
@@ -111,11 +99,11 @@ class SyncUITests: BaseTestCase {
         // Typing on Password should show Show (password) option
         userState.fxaPassword = "f"
         navigator.performAction(Action.FxATypePassword)
-        waitForExistence(app.webViews.staticTexts["Show password"])
+        waitForExistence(app.webViews.otherElements["Show password"], timeout: 3)
         // Remove the password typed, Show (password) option should not be shown
         app.secureTextFields.element(boundBy: 0).typeText(XCUIKeyboardKey.delete.rawValue)
         waitForNoExistence(app.webViews.staticTexts["Show password"])
-    }*/
+    }
 
     // Smoketest
     /*Disabled due to the new 6 digits authen code to verify account

--- a/XCUITests/TopTabsTest.swift
+++ b/XCUITests/TopTabsTest.swift
@@ -308,10 +308,10 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
     func testSwitchBetweenTabsToastButton() {
         if skipPlatform { return }
 
-        navigator.openURL(toastUrl["url"]!)
+        navigator.openURL(urlExample)
         waitUntilPageLoad()
 
-        app.webViews.links.staticTexts[toastUrl["link"]!].press(forDuration: 1)
+        app.webViews.links.firstMatch.press(forDuration: 1)
         waitForExistence(app.buttons["Open in New Tab"])
         app.buttons["Open in New Tab"].press(forDuration: 1)
         waitForExistence(app.buttons["Switch"])
@@ -319,8 +319,8 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
 
         // Check that the tab has changed
         waitUntilPageLoad()
-        waitForValueContains(app.textFields["url"], value: toastUrl["urlLabel"]!)
-        XCTAssertTrue(app.staticTexts[toastUrl["link"]!].exists)
+        waitForValueContains(app.textFields["url"], value: "iana")
+        XCTAssertTrue(app.links["RFC 2606"].exists)
         waitForExistence(app.buttons["Show Tabs"])
         let numTab = app.buttons["Show Tabs"].value as? String
         XCTAssertEqual("2", numTab)
@@ -328,10 +328,10 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
 
         // Go to Private mode and do the same
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
-        navigator.openURL(toastUrl["url"]!)
+        navigator.openURL(urlExample)
         waitUntilPageLoad()
-        waitForExistence(app.webViews.links[toastUrl["link"]!])
-        app.webViews.links[toastUrl["link"]!].press(forDuration: 1)
+        waitForExistence(app.webViews.links.firstMatch)
+        app.webViews.links.firstMatch.press(forDuration: 1)
         waitForExistence(app.buttons["Open in New Private Tab"])
         app.buttons["Open in New Private Tab"].press(forDuration: 1)
         waitForExistence(app.buttons["Switch"])
@@ -340,8 +340,8 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
         // Check that the tab has changed
         waitUntilPageLoad()
         waitForExistence(app.textFields["url"], timeout: 5)
-        waitForValueContains(app.textFields["url"], value: toastUrl["urlLabel"]!)
-        XCTAssertTrue(app.staticTexts[toastUrl["link"]!].exists)
+        waitForValueContains(app.textFields["url"], value: "iana")
+        XCTAssertTrue(app.links["RFC 2606"].exists)
         waitForExistence(app.buttons["Show Tabs"])
         let numPrivTab = app.buttons["Show Tabs"].value as? String
         XCTAssertEqual("2", numPrivTab)
@@ -352,10 +352,10 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
     func testSwitchBetweenTabsNoPrivatePrivateToastButton() {
         if skipPlatform { return }
 
-        navigator.openURL(toastUrl["url"]!)
+        navigator.openURL(urlExample)
         waitUntilPageLoad()
 
-        app.webViews.links[toastUrl["link"]!].press(forDuration: 1)
+        app.webViews.links.firstMatch.press(forDuration: 1)
         waitForExistence(app.buttons["Open in New Tab"], timeout: 3)
         app.buttons["Open in New Private Tab"].press(forDuration: 1)
         waitForExistence(app.buttons["Switch"], timeout: 5)
@@ -364,8 +364,8 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
         // Check that the tab has changed to the new open one and that the user is in private mode
         waitUntilPageLoad()
         waitForExistence(app.textFields["url"], timeout: 5)
-        waitForValueContains(app.textFields["url"], value: toastUrl["urlLabel"]!)
-        XCTAssertTrue(app.staticTexts[toastUrl["link"]!].exists)
+        waitForValueContains(app.textFields["url"], value: "iana")
+        XCTAssertTrue(app.links["RFC 2606"].exists)
         navigator.goto(TabTray)
         XCTAssertTrue(app.buttons["TabTrayController.maskButton"].isEnabled)
     }

--- a/XCUITests/TranslationSnackBarTest.swift
+++ b/XCUITests/TranslationSnackBarTest.swift
@@ -5,7 +5,7 @@
 import XCTest
 
 class TranslationSnackBarTest: BaseTestCase {
-    /*
+
     // This test checks to the correct functionalty of the Translation prompt and Translation is done corrrectly using Google
     func testSnackBarDisplayed() {
         userState.localeIsExpectedDifferent = true
@@ -19,7 +19,7 @@ class TranslationSnackBarTest: BaseTestCase {
         navigator.performAction(Action.SelectTranslateThisPage)
         waitForValueContains(app.textFields["url"], value: "translate.google")
     }
-    
+
     // This test checks to see if Translation is enabled by default from the Settings menu and can be correctly disabled
     func testTranslationDisabled() {
         navigator.goto(TranslationSettings)
@@ -40,5 +40,5 @@ class TranslationSnackBarTest: BaseTestCase {
         waitUntilPageLoad()
         navigator.performAction(Action.SelectTranslateThisPage)
         waitForValueContains(app.textFields["url"], value: "translatetheweb")
-    }*/
+    }
 }


### PR DESCRIPTION
Fixes #5958 
The new iOS version iOS13.4 fixes several things that were broken with iOS 13.3
-SyncUI tests can be enabled, the webview shows the elements again and it is possible to interact with them
-The translation menu is working again and so the tests enabled
-The share sheet tests are working again

Those are the main changes in this PR. 