### PR TITLE
Fix Issue 6153 : New Tab "Custom URL" placeholder text is barely visible

### DIFF
--- a/Client/Frontend/Theme/Theme.swift
+++ b/Client/Frontend/Theme/Theme.swift
@@ -198,7 +198,7 @@ class GeneralColor {
     var highlightBlue: UIColor { return UIColor.Photon.Blue40 }
     var destructiveRed: UIColor { return UIColor.Photon.Red50 }
     var separator: UIColor { return defaultSeparator }
-    var settingsTextPlaceholder: UIColor? { return nil }
+    var settingsTextPlaceholder: UIColor? { return UIColor.Photon.Grey40 }
     var controlTint: UIColor { return UIColor.Photon.Blue40 }
     var switchToggle: UIColor { return UIColor.Photon.Grey90A40 }
 }


### PR DESCRIPTION
Set Color Photon.Grey40 for the Settings Placeholder text property

<img width="288" alt="Screen Shot 2020-04-02 at 10 44 48 PM" src="https://user-images.githubusercontent.com/11700198/78299966-01ad3100-7537-11ea-88d7-b27319457468.png">
