### PR TITLE
Fix for issue #6180: [iPad] Long press on refresh menu string cut off

### DIFF
--- a/Client/Assets/MainFrameAtDocumentEnd.js.LICENSE.txt
+++ b/Client/Assets/MainFrameAtDocumentEnd.js.LICENSE.txt
@@ -1,1 +1,0 @@
-/*! https://mths.be/punycode v1.4.1 by @mathias */

--- a/Client/Assets/MainFrameAtDocumentEnd.js.LICENSE.txt
+++ b/Client/Assets/MainFrameAtDocumentEnd.js.LICENSE.txt
@@ -1,0 +1,1 @@
+/*! https://mths.be/punycode v1.4.1 by @mathias */

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -107,7 +107,7 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
         if style == .popover {
             tableView.snp.makeConstraints { make in
                 make.top.bottom.equalTo(self.view)
-                make.width.equalTo(350)
+                make.width.equalTo(400)
             }
         } else {
             tableView.snp.makeConstraints { make in

--- a/Client/Frontend/Widgets/PhotonActionSheet/TrackingProtectionMenu.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/TrackingProtectionMenu.swift
@@ -181,7 +181,7 @@ extension PhotonActionSheetProtocol {
         }
         addToWhitelist.accessibilityId = "tp.add-to-whitelist"
         addToWhitelist.customHeight = { _ in
-            return PhotonActionSheetUX.RowHeight + 20
+            return PhotonActionSheetUX.RowHeight
         }
 
         let settings = PhotonActionSheetItem(title: Strings.TPProtectionSettings, iconString: "settings") { _, _ in


### PR DESCRIPTION
Changed width of the popver menu to fit the text instead of reflowing to the next line and increasing the height of the row.

<img width="466" alt="Screen Shot 2020-04-04 at 12 52 03 AM" src="https://user-images.githubusercontent.com/11700198/78417545-6bab0080-7633-11ea-912b-ca1a52fed0b2.png">


