### PR TITLE
FXIOS-719 ⁃ added feature #6192 : Share shortcut to have device in the contact list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ __pycache__
 
 # Node.js
 node_modules
+
+MainFrameAtDocumentEnd.js.LICENSE.txt

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		03CCC9181AF05E7300DBF30D /* RelativeDatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CCC9171AF05E7300DBF30D /* RelativeDatesTests.swift */; };
 		0430A545203B372D00FDF76D /* IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0430A544203B372D00FDF76D /* IntegrationTests.swift */; };
+		0478ACB024394C7600CFC3C5 /* DevicesSharesheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0478ACAF24394C7600CFC3C5 /* DevicesSharesheet.swift */; };
+		0478ACB124394C7600CFC3C5 /* DevicesSharesheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0478ACAF24394C7600CFC3C5 /* DevicesSharesheet.swift */; };
 		0B21E8061E26CCB7000C8779 /* EarlGrey.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0B21E8051E26CCB7000C8779 /* EarlGrey.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		0B305E1B1E3A98A900BE0767 /* BookmarkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B305E1A1E3A98A900BE0767 /* BookmarkingTests.swift */; };
 		0B3D670E1E09B90B00C1EFC7 /* AuthenticationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3D670D1E09B90B00C1EFC7 /* AuthenticationTest.swift */; };
@@ -1167,6 +1169,7 @@
 /* Begin PBXFileReference section */
 		03CCC9171AF05E7300DBF30D /* RelativeDatesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelativeDatesTests.swift; sourceTree = "<group>"; };
 		0430A544203B372D00FDF76D /* IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationTests.swift; sourceTree = "<group>"; };
+		0478ACAF24394C7600CFC3C5 /* DevicesSharesheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevicesSharesheet.swift; sourceTree = "<group>"; };
 		0B21E8051E26CCB7000C8779 /* EarlGrey.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = EarlGrey.framework; path = Carthage/Build/iOS/EarlGrey.framework; sourceTree = "<group>"; };
 		0B305E1A1E3A98A900BE0767 /* BookmarkingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarkingTests.swift; sourceTree = "<group>"; };
 		0B3D670D1E09B90B00C1EFC7 /* AuthenticationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationTest.swift; sourceTree = "<group>"; };
@@ -3652,6 +3655,7 @@
 				E41A7D4A1A1BE04500245963 /* InitialViewController.swift */,
 				EB940747208134AF00702E05 /* UXConstants.swift */,
 				F8708D291A0970990051AB07 /* ShareViewController.swift */,
+				0478ACAF24394C7600CFC3C5 /* DevicesSharesheet.swift */,
 			);
 			path = ShareTo;
 			sourceTree = "<group>";
@@ -5212,6 +5216,7 @@
 				D3FEC38D1AC4B42F00494F45 /* AutocompleteTextField.swift in Sources */,
 				EBE26B57220C959D00D1D99A /* BrowserViewController+TabToolbarDelegate.swift in Sources */,
 				E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */,
+				0478ACB024394C7600CFC3C5 /* DevicesSharesheet.swift in Sources */,
 				3BF56D271CDBBE1F00AC4D75 /* SimpleToast.swift in Sources */,
 				EBB89504219398E500EB91A0 /* TrackingProtectionPageStats.swift in Sources */,
 				D31F95E91AC226CB005C9F3B /* ScreenshotHelper.swift in Sources */,
@@ -5336,6 +5341,7 @@
 				E68F36AD1EA698650048CF44 /* PanelDataObservers.swift in Sources */,
 				E60D03271D511554002FE3F6 /* SyncStatusResolver.swift in Sources */,
 				D04CD74E216CF86F004FF5B0 /* InstructionsViewController.swift in Sources */,
+				0478ACB124394C7600CFC3C5 /* DevicesSharesheet.swift in Sources */,
 				E41A7D4B1A1BE04500245963 /* InitialViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Client/Assets/MainFrameAtDocumentEnd.js.LICENSE.txt
+++ b/Client/Assets/MainFrameAtDocumentEnd.js.LICENSE.txt
@@ -1,1 +1,0 @@
-/*! https://mths.be/punycode v1.4.1 by @mathias */

--- a/Client/Assets/MainFrameAtDocumentEnd.js.LICENSE.txt
+++ b/Client/Assets/MainFrameAtDocumentEnd.js.LICENSE.txt
@@ -1,0 +1,1 @@
+/*! https://mths.be/punycode v1.4.1 by @mathias */

--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -8,20 +8,18 @@ import OnePasswordExtension
 import ShareTo
 import Storage
 
-
 private let log = Logger.browserLogger
 
 class ShareExtensionHelper: NSObject {
-    
     fileprivate weak var selectedTab: Tab?
+    
     fileprivate let url: URL
     fileprivate var onePasswordExtensionItem: NSExtensionItem!
     fileprivate let browserFillIdentifier = "org.appextension.fill-browser-action"
+    
     fileprivate func isFile(url: URL) -> Bool { url.scheme == "file" }
     fileprivate let profile = BrowserProfile(localName: "profile")
     var devicesActions = [DevicesShareSheet]()
-    
-    
     
     // Can be a file:// or http(s):// url
     init(url: URL, tab: Tab?) {
@@ -54,7 +52,6 @@ class ShareExtensionHelper: NSObject {
                 devicesActions.append(deviceShareItem)
             }
         }
-        
         
         let activityViewController = UIActivityViewController(activityItems: activityItems, applicationActivities: devicesActions)
         
@@ -157,7 +154,6 @@ private extension ShareExtensionHelper {
             self.onePasswordExtensionItem = extensionItem
         })
     }
-    
     
     func fillPasswords(_ returnedItems: [AnyObject]) {
         guard let selectedWebView = selectedTab?.webView else {

--- a/Extensions/ShareTo/DevicesSharesheet.swift
+++ b/Extensions/ShareTo/DevicesSharesheet.swift
@@ -1,10 +1,6 @@
-//
-//  ContactsSharesheet.swift
-//  Client
-//
-//  Created by McNoor's  on 4/5/20.
-//  Copyright © 2020 Mozilla. All rights reserved.
-//
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
 import UIKit
@@ -39,7 +35,6 @@ class DevicesShareSheet : UIActivity {
     override class var activityCategory: UIActivity.Category {
         return .share
     }
-    
     
     override func canPerform(withActivityItems activityItems: [Any]) -> Bool {
         return true

--- a/Extensions/ShareTo/DevicesSharesheet.swift
+++ b/Extensions/ShareTo/DevicesSharesheet.swift
@@ -1,0 +1,56 @@
+//
+//  ContactsSharesheet.swift
+//  Client
+//
+//  Created by McNoor's  on 4/5/20.
+//  Copyright © 2020 Mozilla. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import Shared
+
+class DevicesShareSheet : UIActivity {
+    
+    var _activityTitle: String
+    var _activityImage: UIImage?
+    var activityItems = [Any]()
+    var action: ([Any]) -> Void
+    
+    init(title: String, image: UIImage?, performAction: @escaping ([Any]) -> Void) {
+        _activityTitle = title
+        _activityImage = image
+        action = performAction
+        super.init()
+    }
+    
+    override var activityTitle: String? {
+        return _activityTitle
+    }
+
+    override var activityImage: UIImage? {
+        return _activityImage
+    }
+    
+    override var activityType: UIActivity.ActivityType? {
+        return UIActivity.ActivityType(rawValue: "org.Mozilla.firefoxApp.activity")
+    }
+
+    override class var activityCategory: UIActivity.Category {
+        return .share
+    }
+    
+    
+    override func canPerform(withActivityItems activityItems: [Any]) -> Bool {
+        return true
+    }
+    
+    override func prepare(withActivityItems activityItems: [Any]) {
+        self.activityItems = activityItems
+    }
+    
+    override func perform() {
+        action(activityItems)
+        activityDidFinish(true)
+    }
+}


### PR DESCRIPTION
- Added a new UIActivityItem by defining a class DevicesShareSheet to allow user devices to show up in the share sheet.
- Added the action item to the ShareExtensionHelper.swift file that handles the actions of the ShareSheet.

Here it shows all the devices of my account and I can share the tab to eachone of them by clicking it 

P.S. it doesn't show the "Tab sent" feedback message as this is another issue on its own.

<img width="294" alt="Screen Shot 2020-04-06 at 2 41 26 AM" src="https://user-images.githubusercontent.com/11700198/78514219-8f478580-77b0-11ea-99af-0e3559f93347.png">

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-719)
