### PR TITLE
Fix #6376: migration of pre-rust bookmarks breaking tests

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -224,13 +224,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         pushNotificationSetup()
 
         if let profile = profile as? BrowserProfile {
-            RustFirefoxAccounts.startup(prefs: profile.prefs) { shared in
-                if !shared.accountManager.hasAccount() {
-                    // Migrate bookmarks from old browser.db to new Rust places.db only
-                    // if this user is NOT signed into Sync (only migrates once if needed).
-                    profile.places.migrateBookmarksIfNeeded(fromBrowserDB: profile.db)
-                }
-            }
+            RustFirefoxAccounts.startup(prefs: profile.prefs) { _ in }
         }
 
         // Leanplum usersearch variable setup for onboarding research

--- a/Storage/Rust/RustPlaces.swift
+++ b/Storage/Rust/RustPlaces.swift
@@ -120,35 +120,6 @@ public class RustPlaces {
         return deferred
     }
 
-    public func migrateBookmarksIfNeeded(fromBrowserDB browserDB: BrowserDB) {
-        // Since we use the existence of places.db as an indication that we've
-        // already migrated bookmarks, assert that places.db is not open here.
-        assert(!isOpen, "Shouldn't attempt to migrate bookmarks after opening Rust places.db")
-
-        // We only need to migrate bookmarks here if the old browser.db file
-        // already exists AND the new Rust places.db file does NOT exist yet.
-        // This is to ensure that we only ever run this migration ONCE. In
-        // addition, it is the caller's (Profile.swift) responsibility to NOT
-        // use this migration API for users signed into a Firefox Account.
-        // Those users will automatically get all their bookmarks on next Sync.
-        guard FileManager.default.fileExists(atPath: browserDB.databasePath),
-            !FileManager.default.fileExists(atPath: databasePath) else {
-            return
-        }
-
-        // Ensure that the old BrowserDB schema is up-to-date before migrating.
-        _ = browserDB.touch().value
-
-        // Open the Rust places.db now for the first time.
-        _ = reopenIfClosed()
-
-        do {
-            try api?.migrateBookmarksFromBrowserDb(path: browserDB.databasePath)
-        } catch let err as NSError {
-            Sentry.shared.sendWithStacktrace(message: "Error encountered while migrating bookmarks from BrowserDB", tag: SentryTag.rustPlaces, severity: .error, description: err.localizedDescription)
-        }
-    }
-
     public func getBookmarksTree(rootGUID: GUID, recursive: Bool) -> Deferred<Maybe<BookmarkNode?>> {
         return withReader { connection in
             return try connection.getBookmarksTree(rootGUID: rootGUID, recursive: recursive)


### PR DESCRIPTION
For migration of users to Rust bookmarks backend, if users are signed in to sync, then next sync will download their bookmarks.
For users not using sync, they will lose their bookmarks, this code (`migrateBookmarksIfNeeded`) extracts their bookmarks from browser.db into places.db.
This code is old at this point, we have no test case for it, and it has to run at a very specifc point in app init, which is hard to ensure given the async startup nature of the new firefox account system.
I think the risk of keeping this outweighs the risk of removing it.
