### PR TITLE
For #6390 - XCUITests Disable failing tests due to issues with preloa…

### DIFF
--- a/XCUITests/DatabaseFixtureTest.swift
+++ b/XCUITests/DatabaseFixtureTest.swift
@@ -16,11 +16,13 @@ class DatabaseFixtureTest: BaseTestCase {
         super.setUp()
     }
 
+    /*Disabled due to issue 6390
     func testOneBookmark() {
         navigator.goto(MobileBookmarks)
         let list = app.tables["Bookmarks List"].cells.count
         XCTAssertEqual(list, 1, "There should be an entry in the bookmarks list")
-    }
+    }*/
+
     /*Disabled due to 5733 iOS 13
     func testBookmarksDatabaseFixture() {
         waitForTabsButton()

--- a/XCUITests/DomainAutocompleteTest.swift
+++ b/XCUITests/DomainAutocompleteTest.swift
@@ -27,6 +27,7 @@ class DomainAutocompleteTest: BaseTestCase {
         super.setUp()
     }
 
+    /*Disabled due to issue 6390
     func testAutocomplete() {
         // Basic autocompletion cases
         navigator.goto(URLBarOpen)
@@ -42,8 +43,10 @@ class DomainAutocompleteTest: BaseTestCase {
         waitForValueContains(app.textFields["address"], value: website["value"]!)
         let value2 = app.textFields["address"].value
         XCTAssertEqual(value2 as? String, website["value"]!, "Wrong autocompletion")
-    }
+    }*/
+
     // Test that deleting characters works correctly with autocomplete
+    /*Disabled due to issue 6390
     func testAutocompleteDeletingChars() {
         navigator.goto(URLBarOpen)
         app.textFields["address"].typeText("www.moz")
@@ -59,7 +62,8 @@ class DomainAutocompleteTest: BaseTestCase {
 
         let value = app.textFields["address"].value
         XCTAssertEqual(value as? String, website["value"]!, "Wrong autocompletion")
-    }
+    }*/
+
     // Delete the entire string and verify that the home panels are shown again.
     func testDeleteEntireString() {
         navigator.goto(URLBarOpen)


### PR DESCRIPTION
…ded DDBB

This PR is a temporary solution due to issue #6390 Those are the only XCUITests failing at the moment, and while that issues is investigated let's disable the failing tests. Manually none of the issues is reproducible, the problem is due to the use of the pre-loaded DDBB created to be used for the tests