### PR TITLE
Fix #6390 and #6376: restore bookmark migration code to support tests

### DIFF
--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -331,6 +331,10 @@ open class BrowserProfile: Profile {
         log.debug("Reopening profile.")
         isShutdown = false
 
+        if !places.isOpen && !RustFirefoxAccounts.shared.accountManager.hasAccount() {
+            places.migrateBookmarksIfNeeded(fromBrowserDB: db)
+        }
+
         db.reopenIfClosed()
         _ = logins.reopenIfClosed()
         _ = places.reopenIfClosed()
@@ -427,10 +431,9 @@ open class BrowserProfile: Profile {
         return self.legacyPlaces
     }
 
-    lazy var places: RustPlaces = {
-        let databasePath = URL(fileURLWithPath: (try! files.getAndEnsureDirectory()), isDirectory: true).appendingPathComponent("places.db").path
-        return RustPlaces(databasePath: databasePath)
-    }()
+    lazy var placesDbPath = URL(fileURLWithPath: (try! files.getAndEnsureDirectory()), isDirectory: true).appendingPathComponent("places.db").path
+
+    lazy var places = RustPlaces(databasePath: placesDbPath)
 
     lazy var searchEngines: SearchEngines = {
         return SearchEngines(prefs: self.prefs, files: self.files)


### PR DESCRIPTION
We have tests using browser.db for their bookmarks, which need to be
migrated to places.db for them to run. This means we have a test case
for the migration code, which I didn't realize, and not having a test case
for the migration code was a rationale I used to remove it.
