### PR TITLE
Bug 1622800 - part 6: Let l10n-screenshotis.sh pass `--test-without-building` to fastlane

### DIFF
--- a/l10n-screenshots.sh
+++ b/l10n-screenshots.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 if [ -d l10n-screenshots ]; then
   echo "The l10n-screenshots directory already exists. You decide."
   exit 1
@@ -10,7 +12,12 @@ if [ ! -d firefoxios-l10n ]; then
     exit 1
 fi
 
-mkdir l10n-screenshots
+mkdir -p l10n-screenshots
+
+if [ "$1" = '--test-without-building' ]; then
+  EXTRA_FAST_LANE_ARGS='--test_without_building'
+  shift
+fi
 
 LOCALES=$*
 if [ $# -eq 0 ]; then
@@ -25,5 +32,6 @@ for lang in $LOCALES; do
         --derived_data_path l10n-screenshots-dd \
         --erase_simulator --localize_simulator \
         --devices "iPhone 8" --languages "$lang" \
-        --output_directory "l10n-screenshots/$lang" > "l10n-screenshots/$lang/snapshot.log" 2>&1
+        --output_directory "l10n-screenshots/$lang" \
+        $EXTRA_FAST_LANE_ARGS
 done


### PR DESCRIPTION
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Please make sure you've run the test scheme and all the tests pass. If your changes affect existing tests please make sure to update the tests as well.

