### PR TITLE
Bug 1622800 - part 7 to 10: Split build step from the screenshot generation one 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Xcode
 build/
+!taskcluster/ci/build
 .build/
 *.pbxuser
 !default.pbxuser

--- a/l10n-screenshots.sh
+++ b/l10n-screenshots.sh
@@ -34,4 +34,5 @@ for lang in $LOCALES; do
         --devices "iPhone 8" --languages "$lang" \
         --output_directory "l10n-screenshots/$lang" \
         $EXTRA_FAST_LANE_ARGS
+    echo "Fastlane exited with code: $?"
 done

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -10,17 +10,15 @@ transforms:
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
-kind-dependencies:
-    - build
-
-job-defaults:
-    bitrise-workflow: jlorenzo_L10nScreenshotsTests
-    build-derived-data-path: {artifact-reference: '<build/public/build/target.zip>'}
-    description: Generate localized screenshots by delegating the work to bitrise.io
-    dependencies:
-        build: build-screenshots
-    run-on-tasks-for: []
 
 jobs:
-    fr:
-        locale: fr
+    screenshots:
+        bitrise-workflow: jlorenzo_L10nBuild
+        description: Generate build instrumented for screenshots, including en-US pictures
+        locale: en-US
+        run-on-tasks-for: []
+        worker:
+            artifacts:
+                - type: file
+                  name: public/build/target.zip
+                  path: /builds/worker/checkouts/src/l10n-screenshots-dd.zip

--- a/taskcluster/ci/generate-screenshots/kind.yml
+++ b/taskcluster/ci/generate-screenshots/kind.yml
@@ -5,13 +5,14 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
-    - ffios_taskgraph.transforms.screenshots:transforms
+    - ffios_taskgraph.transforms.bitrise:transforms
     - ffios_taskgraph.transforms.secrets:transforms
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
 
 job-defaults:
+    bitrise-workflow: jlorenzo_L10nScreenshotsTests
     description: Generate localized screenshots by delegating the work to bitrise.io
     run:
         using: run-commands

--- a/taskcluster/ffios_taskgraph/transforms/bitrise.py
+++ b/taskcluster/ffios_taskgraph/transforms/bitrise.py
@@ -14,12 +14,70 @@ transforms = TransformSequence()
 
 
 @transforms.add
+def set_run_config(config, tasks):
+    for task in tasks:
+        run = task.setdefault("run", {})
+        run.setdefault("using", "run-commands")
+        run.setdefault("use-caches", False)
+
+        run["secrets"] = {
+            "by-level": {
+                "3": [{
+                    "name": "project/mobile/firefox-ios/bitrise",
+                    "key": "api_key",
+                    "path": ".bitrise_token",
+                }],
+                "default": [],
+            },
+        }
+
+        run["dummy-secrets"] = {
+            "by-level": {
+                "3": [],
+                "default": [{
+                    "content": "faketoken",
+                    "path": ".bitrise_token",
+                }],
+            },
+        }
+
+        yield task
+
+
+@transforms.add
+def set_worker_config(config, tasks):
+    for task in tasks:
+        locale = task["locale"]
+
+        worker = task.setdefault("worker", {})
+        artifacts = worker.setdefault("artifacts", [])
+
+        artifacts.extend([{
+            "type": "file",
+            "name": "public/logs/bitrise.log",
+            "path": "/builds/worker/checkouts/src/bitrise.log",
+        }, {
+            "type": "file",
+            "name": "public/screenshots/{}.zip".format(locale),
+            "path": "/builds/worker/checkouts/src/{}.zip".format(locale),
+        }])
+
+        worker.setdefault("docker-image", {"in-tree": "screenshots"})
+        worker.setdefault("max-run-time", 3600)
+
+        task.setdefault("worker-type", "b-linux")
+
+        yield task
+
+
+@transforms.add
 def add_command(config, tasks):
     for task in tasks:
         commands = task["run"].setdefault("commands", [])
         locale = task.pop("locale")
         workflow = task.pop("bitrise-workflow")
-        commands.append([
+
+        command = [
             "python3",
             "taskcluster/scripts/bitrise-schedule.py",
             "--token-file", ".bitrise_token",
@@ -27,6 +85,12 @@ def add_command(config, tasks):
             "--commit", config.params["head_rev"],
             "--workflow", workflow,
             "--locale", locale
-        ])
+        ]
+
+        derived_data_path = task.pop("build-derived-data-path", "")
+        if derived_data_path:
+            command.extend(["--derived-data-path", derived_data_path])
+
+        commands.append(command)
 
         yield task

--- a/taskcluster/ffios_taskgraph/transforms/bitrise.py
+++ b/taskcluster/ffios_taskgraph/transforms/bitrise.py
@@ -18,12 +18,14 @@ def add_command(config, tasks):
     for task in tasks:
         commands = task["run"].setdefault("commands", [])
         locale = task.pop("locale")
+        workflow = task.pop("bitrise-workflow")
         commands.append([
             "python3",
-            "taskcluster/scripts/generate-screenshots.py",
+            "taskcluster/scripts/bitrise-schedule.py",
             "--token-file", ".bitrise_token",
             "--branch", config.params["head_ref"],
             "--commit", config.params["head_rev"],
+            "--workflow", workflow,
             "--locale", locale
         ])
 

--- a/taskcluster/scripts/bitrise-schedule.py
+++ b/taskcluster/scripts/bitrise-schedule.py
@@ -166,6 +166,8 @@ async def download_log(client, build_slug):
 
     response = await do_http_request_json(client, url)
     download_url = response["expiring_raw_log_url"]
+    if not download_url:
+        raise TaskException("Bitrise has no log to offer for job {}. Please check https://app.bitrise.io/app/{}".format(build_slug, BITRISE_APP_SLUG_ID))
     await download_file(download_url, "bitrise.log")
 
 


### PR DESCRIPTION
Depends on https://github.com/mozilla-mobile/firefox-ios/pull/6406 to be landed first.

This PR was tested end-to-end at: https://firefox-ci-tc.services.mozilla.com/tasks/groups/aGBEdpWITpem1ytxAPcdqg. From what I've seen: the build (+ en-US screenshots) task takes about 35-40 minutes, while the (fr) screenshot one takes 20-25. Here is a summary of how the screenshot task [spent its time](https://firefox-ci-tc.services.mozilla.com/tasks/HSFcv2lqT1C8cdMnrCoAMw/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FHSFcv2lqT1C8cdMnrCoAMw%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Fbitrise.log#L22209).


From what I understand, generating screenshots could be faster if some of the tests (like [this one](https://firefox-ci-tc.services.mozilla.com/tasks/HSFcv2lqT1C8cdMnrCoAMw/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FHSFcv2lqT1C8cdMnrCoAMw%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Fbitrise.log#L22030)) didn't fail. I think fixing them is outside of the scope of this PR. We have another problem: bitrise reports the job as succesful even though these tests failed. I'd like to fix this in a followup. 

Thus, to me the next steps are:
 1. Let bitrise report these errors.
 2. Enable all locales and see how bitrise behave with such a load.
 3. Fix the tests.