### PR TITLE
Fix - Update Pocket more URL

### DIFF
--- a/Providers/PocketFeed.swift
+++ b/Providers/PocketFeed.swift
@@ -47,7 +47,7 @@ private class PocketError: MaybeErrorType {
 
 class Pocket {
     private let pocketGlobalFeed: String
-    static let MoreStoriesURL = URL(string: "https://getpocket.com/explore/trending?src=ff_ios&cdn=0")!
+    static let MoreStoriesURL = URL(string: "https://getpocket.com/explore?src=ff_ios&cdn=0")!
 
     // Allow endPoint to be overriden for testing
     init(endPoint: String = PocketGlobalFeed) {


### PR DESCRIPTION
Fixes #6235 

This fix swaps out an old URL for the new Pocket "More" URL.
