### PR TITLE
Fix #6421: debug setting to change FxA/sync servers

### DIFF
--- a/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
+++ b/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
@@ -8,188 +8,94 @@ import SnapKit
 import FxA
 import Account
 
+fileprivate class CustomFxAContentServerEnableSetting: BoolSetting {
+      init(prefs: Prefs, settingDidChange: ((Bool?) -> Void)? = nil) {
+          super.init(
+              prefs: prefs, prefKey: PrefsKeys.KeyUseCustomFxAContentServer, defaultValue: false,
+              attributedTitleText: NSAttributedString(string: Strings.SettingsAdvancedAccountUseCustomFxAContentServerURITitle),
+              settingDidChange: settingDidChange
+          )
+      }
+  }
+
+  fileprivate class CustomSyncTokenServerEnableSetting: BoolSetting {
+      init(prefs: Prefs, settingDidChange: ((Bool?) -> Void)? = nil) {
+          super.init(
+              prefs: prefs, prefKey: PrefsKeys.KeyUseCustomSyncTokenServerOverride, defaultValue: false,
+              attributedTitleText: NSAttributedString(string: Strings.SettingsAdvancedAccountUseCustomSyncTokenServerTitle),
+              settingDidChange: settingDidChange
+          )
+      }
+  }
+
+  fileprivate class CustomURLSetting: WebPageSetting {
+      override init(prefs: Prefs, prefKey: String, defaultValue: String? = nil, placeholder: String, accessibilityIdentifier: String, isChecked: @escaping () -> Bool = { return false }, settingDidChange: ((String?) -> Void)? = nil) {
+          super.init(prefs: prefs,
+                     prefKey: prefKey,
+                     defaultValue: defaultValue,
+                     placeholder: placeholder,
+                     accessibilityIdentifier: accessibilityIdentifier,
+                     settingDidChange: settingDidChange)
+          textField.clearButtonMode = .always
+      }
+  }
+
+
 class AdvancedAccountSettingViewController: SettingsTableViewController {
     fileprivate let SectionHeaderIdentifier = "SectionHeaderIdentifier"
-
-    fileprivate var customAutoconfigURI: String?
+    fileprivate var customFxAContentURI: String?
     fileprivate var customSyncTokenServerURI: String?
 
     override func viewDidLoad() {
         super.viewDidLoad()
         title = Strings.SettingsAdvancedAccountTitle
-        self.customAutoconfigURI = self.profile.prefs.stringForKey(PrefsKeys.KeyCustomSyncWeb)
+        self.customFxAContentURI = self.profile.prefs.stringForKey(PrefsKeys.KeyCustomFxAContentServer)
         self.customSyncTokenServerURI = self.profile.prefs.stringForKey(PrefsKeys.KeyCustomSyncTokenServerOverride)
     }
 
-    func clearCustomAutoconfigPrefs() {
-        self.profile.prefs.setBool(false, forKey: PrefsKeys.KeyUseCustomAccountAutoconfig)
-        self.profile.prefs.setString("", forKey: PrefsKeys.KeyCustomSyncToken)
-        self.profile.prefs.setString("", forKey: PrefsKeys.KeyCustomSyncProfile)
-        self.profile.prefs.setString("", forKey: PrefsKeys.KeyCustomSyncOauth)
-        self.profile.prefs.setString("", forKey: PrefsKeys.KeyCustomSyncAuth)
-        self.profile.prefs.setString("", forKey: PrefsKeys.KeyCustomSyncWeb)
-
-        // To help prevent the account being in a strange state, we force it to
-        // log out when user clears their custom server preferences.
-        self.profile.removeAccount()
-    }
-
-    func setCustomAutoconfigPrefs() {
-        guard let customAutoconfigURIString = self.customAutoconfigURI, let customAutoconfigURI = URL(string: customAutoconfigURIString), customAutoconfigURI.schemeIsValid, customAutoconfigURI.host != nil  else {
-            // If the user attempts to set a nil url, clear all the custom service perferences
-            // and use default FxA servers.
-            self.displayNoAutoconfigSetAlert()
-            return
-        }
-
-        // FxA stores its server configuation under a well-known path. This attempts to download the configuration
-        // and save it into the users preferences.
-        let syncConfigureString = customAutoconfigURIString + "/.well-known/fxa-client-configuration"
-        guard let syncConfigureURL = URL(string: syncConfigureString) else {
-            return
-        }
-
-        URLSession.shared.dataTask(with: syncConfigureURL, completionHandler: {(data, response, error) in
-            guard error == nil,
-                let data = data,
-                let json = (try? JSONSerialization.jsonObject(with: data, options: .allowFragments)) as? [String: Any],
-                let customSyncToken = json["sync_tokenserver_base_url"] as? String,
-                let customSyncProfile = json["profile_server_base_url"] as? String,
-                let customSyncOauth = json["oauth_server_base_url"] as? String,
-                let customSyncAuth = json["auth_server_base_url"] as? String else {
-
-                // Something went wrong while downloading or parsing the configuration.
-                self.displayAutoconfigErrorAlert()
-                return
-            }
-
-            self.profile.prefs.setBool(true, forKey: PrefsKeys.KeyUseCustomAccountAutoconfig)
-            self.profile.prefs.setString(customSyncToken, forKey: PrefsKeys.KeyCustomSyncToken)
-            self.profile.prefs.setString(customSyncProfile, forKey: PrefsKeys.KeyCustomSyncProfile)
-            self.profile.prefs.setString(customSyncOauth, forKey: PrefsKeys.KeyCustomSyncOauth)
-            self.profile.prefs.setString(customSyncAuth, forKey: PrefsKeys.KeyCustomSyncAuth)
-            self.profile.prefs.setString(customAutoconfigURI.absoluteString, forKey: PrefsKeys.KeyCustomSyncWeb)
-            self.profile.removeAccount()
-            self.displaySuccessAlert()
-        }).resume()
-    }
-
-    func clearCustomSyncTokenServerPrefs() {
-        self.profile.prefs.setBool(false, forKey: PrefsKeys.KeyUseCustomSyncTokenServerOverride)
-        self.profile.prefs.setString("", forKey: PrefsKeys.KeyCustomSyncTokenServerOverride)
-    }
-
-    func setCustomSyncTokenServerPrefs() {
-        guard let customSyncTokenServerURIString = self.customSyncTokenServerURI, let customSyncTokenServerURI = URL(string: customSyncTokenServerURIString), customSyncTokenServerURI.schemeIsValid, customSyncTokenServerURI.host != nil else {
-            // If the user attempts to set a nil url, clear all the custom service perferences
-            // and use default FxA servers.
-            self.displayNoTokenServerSetAlert()
-            return
-        }
-
-        self.profile.prefs.setBool(true, forKey: PrefsKeys.KeyUseCustomSyncTokenServerOverride)
-        self.profile.prefs.setString(customSyncTokenServerURI.absoluteString, forKey: PrefsKeys.KeyCustomSyncTokenServerOverride)
-        self.displaySuccessAlert()
-    }
-
-    func displaySuccessAlert() {
-        let alertController = UIAlertController(title: "", message: Strings.SettingsAdvancedAccountUrlUpdatedAlertMessage, preferredStyle: .alert)
-        let defaultAction = UIAlertAction(title: Strings.OKString, style: .default, handler: nil)
-        alertController.addAction(defaultAction)
-        self.present(alertController, animated: true)
-    }
-
-    func displayAutoconfigErrorAlert() {
-        self.profile.prefs.setBool(false, forKey: PrefsKeys.KeyUseCustomAccountAutoconfig)
-        DispatchQueue.main.async {
-            self.tableView.reloadRows(at: [IndexPath(row: 0, section: 0)], with: .automatic)
-        }
-        let alertController = UIAlertController(title: Strings.SettingsAdvancedAccountUrlErrorAlertTitle, message: Strings.SettingsAdvancedAccountUrlErrorAlertMessage, preferredStyle: .alert)
-        let defaultAction = UIAlertAction(title: Strings.OKString, style: .default, handler: nil)
-        alertController.addAction(defaultAction)
-        self.present(alertController, animated: true)
-    }
-
-    func displayNoAutoconfigSetAlert() {
-        self.profile.prefs.setBool(false, forKey: PrefsKeys.KeyUseCustomAccountAutoconfig)
-        DispatchQueue.main.async {
-            self.tableView.reloadRows(at: [IndexPath(row: 0, section: 0)], with: .automatic)
-        }
-        let alertController = UIAlertController(title: Strings.SettingsAdvancedAccountUrlErrorAlertTitle, message: Strings.SettingsAdvancedAccountEmptyAutoconfigURIErrorAlertMessage, preferredStyle: .alert)
-        let defaultAction = UIAlertAction(title: Strings.OKString, style: .default, handler: nil)
-        alertController.addAction(defaultAction)
-        self.present(alertController, animated: true)
-    }
-
-    func displayNoTokenServerSetAlert() {
-        self.profile.prefs.setBool(false, forKey: PrefsKeys.KeyUseCustomSyncTokenServerOverride)
-        DispatchQueue.main.async {
-            self.tableView.reloadRows(at: [IndexPath(row: 0, section: 2)], with: .automatic)
-        }
-        let alertController = UIAlertController(title: Strings.SettingsAdvancedAccountUrlErrorAlertTitle, message: Strings.SettingsAdvancedAccountEmptyTokenServerURIErrorAlertMessage, preferredStyle: .alert)
-        let defaultAction = UIAlertAction(title: Strings.OKString, style: .default, handler: nil)
-        alertController.addAction(defaultAction)
-        self.present(alertController, animated: true)
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        RustFirefoxAccounts.reconfig()
     }
 
     override func generateSettings() -> [SettingSection] {
         let prefs = profile.prefs
-        let customAutoconfigURISetting = CustomURLSetting(prefs: prefs,
-                                                         prefKey: PrefsKeys.KeyCustomSyncWeb,
-                                                         placeholder: Strings.SettingsAdvancedAccountCustomAutoconfigURIPlaceholder,
-                                                         accessibilityIdentifier: "CustomAutoconfigURISetting",
-                                                         settingDidChange: { fieldText in
-                                                            self.customAutoconfigURI = fieldText
-                                                            if let customAutoconfigURI = self.customAutoconfigURI, customAutoconfigURI.isEmpty {
-                                                                self.clearCustomAutoconfigPrefs()
-                                                                return
-                                                            }
-        })
+
+        let useStage = BoolSetting(prefs: prefs, prefKey: PrefsKeys.UseStageServer, defaultValue: false, attributedTitleText: NSAttributedString(string: NSLocalizedString("Use stage servers", comment: "Debug option"), attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        { isOn in
+            self.settings = self.generateSettings()
+            self.tableView.reloadData()
+        }
+
+        let customFxA = CustomURLSetting(prefs: prefs,
+                                         prefKey: PrefsKeys.KeyCustomFxAContentServer,
+                                         placeholder: Strings.SettingsAdvancedAccountCustomFxAContentServerURI,
+                                         accessibilityIdentifier: "CustomFxAContentServer")
+
         let customSyncTokenServerURISetting = CustomURLSetting(prefs: prefs,
-                                                    prefKey: PrefsKeys.KeyCustomSyncTokenServerOverride,
-                                                    placeholder: Strings.SettingsAdvancedAccountCustomSyncTokenServerURIPlaceholder,
-                                                    accessibilityIdentifier: "CustomSyncTokenServerURISetting",
-                                                    settingDidChange: { fieldText in
-                                                        self.customSyncTokenServerURI = fieldText
-                                                        if let customSyncTokenServerURI = self.customSyncTokenServerURI, customSyncTokenServerURI.isEmpty {
-                                                            self.clearCustomSyncTokenServerPrefs()
-                                                            return
-                                                        }
-        })
+                                        prefKey: PrefsKeys.KeyCustomSyncTokenServerOverride,
+                                        placeholder: Strings.SettingsAdvancedAccountCustomSyncTokenServerURI,
+                                        accessibilityIdentifier: "CustomSyncTokenServerURISetting")
 
         let autoconfigSettings = [
-            CustomAutoconfigEnableSetting(
-                prefs: prefs,
-                settingDidChange: { result in
-                    if result == true {
-                        // Reload the table data to ensure that the updated value is set
-                        self.tableView?.reloadData()
-                        self.setCustomAutoconfigPrefs()
-                    }
-            }),
-            customAutoconfigURISetting
+            CustomFxAContentServerEnableSetting(prefs: prefs) { isOn in
+                self.settings = self.generateSettings()
+                self.tableView.reloadData()
+            },
+            customFxA
         ]
 
         let tokenServerSettings = [
-            CustomSyncTokenServerEnableSetting(
-                prefs: prefs,
-                settingDidChange: { result in
-                    if result == true {
-                        // Reload the table data to ensure that the updated value is set
-                        self.tableView?.reloadData()
-                        self.setCustomSyncTokenServerPrefs()
-                    }
-            }),
+            CustomSyncTokenServerEnableSetting(prefs: prefs),
             customSyncTokenServerURISetting
         ]
 
-        let settings: [SettingSection] = [
-            SettingSection(title: nil, children: autoconfigSettings),
-            SettingSection(title: NSAttributedString(string: Strings.SettingsAdvancedAccountAutoconfigSectionFooter), children: []),
-            SettingSection(title: nil, children: tokenServerSettings),
-            SettingSection(title: NSAttributedString(string: Strings.SettingsAdvancedAccountTokenServerSectionFooter), children: [])
-        ]
+        var settings: [SettingSection] = [SettingSection(title:nil, children: [useStage])]
 
+        if !(prefs.boolForKey(PrefsKeys.UseStageServer) ?? false) {
+            settings.append(SettingSection(title: nil, children: autoconfigSettings))
+            settings.append(SettingSection(title: nil, children: tokenServerSettings))
+        }
         return settings
     }
 
@@ -206,37 +112,5 @@ class AdvancedAccountSettingViewController: SettingsTableViewController {
             return super.tableView(tableView, viewForHeaderInSection: section)
         }
         return headerView
-    }
-}
-
-class CustomAutoconfigEnableSetting: BoolSetting {
-    init(prefs: Prefs, settingDidChange: ((Bool?) -> Void)? = nil) {
-        super.init(
-            prefs: prefs, prefKey: PrefsKeys.KeyUseCustomAccountAutoconfig, defaultValue: false,
-            attributedTitleText: NSAttributedString(string: Strings.SettingsAdvancedAccountUseCustomAccountsServiceTitle),
-            settingDidChange: settingDidChange
-        )
-    }
-}
-
-class CustomSyncTokenServerEnableSetting: BoolSetting {
-    init(prefs: Prefs, settingDidChange: ((Bool?) -> Void)? = nil) {
-        super.init(
-            prefs: prefs, prefKey: PrefsKeys.KeyUseCustomSyncTokenServerOverride, defaultValue: false,
-            attributedTitleText: NSAttributedString(string: Strings.SettingsAdvancedAccountUseCustomSyncTokenServerTitle),
-            settingDidChange: settingDidChange
-        )
-    }
-}
-
-class CustomURLSetting: WebPageSetting {
-    override init(prefs: Prefs, prefKey: String, defaultValue: String? = nil, placeholder: String, accessibilityIdentifier: String, isChecked: @escaping () -> Bool = { return false }, settingDidChange: ((String?) -> Void)? = nil) {
-        super.init(prefs: prefs,
-                   prefKey: prefKey,
-                   defaultValue: defaultValue,
-                   placeholder: placeholder,
-                   accessibilityIdentifier: accessibilityIdentifier,
-                   settingDidChange: settingDidChange)
-        textField.clearButtonMode = .always
     }
 }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -465,10 +465,21 @@ class SlowTheDatabase: HiddenSetting {
     }
 }
 
+class ForgetSyncAuthStateDebugSetting: HiddenSetting {
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: NSLocalizedString("Debug: forget Sync auth state", comment: "Debug option"), attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        settings.profile.rustFxA.syncAuthState.invalidate()
+        settings.tableView.reloadData()
+    }
+}
+
 class SentryIDSetting: HiddenSetting {
     let deviceAppHash = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.string(forKey: "SentryDeviceAppHash") ?? "0000000000000000000000000000000000000000"
     override var title: NSAttributedString? {
-        return NSAttributedString(string: "Debug: \(deviceAppHash)", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText, NSAttributedString.Key.font: UIFont.systemFont(ofSize: 10)])
+        return NSAttributedString(string: "Sentry ID: \(deviceAppHash)", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText, NSAttributedString.Key.font: UIFont.systemFont(ofSize: 10)])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -843,41 +854,6 @@ class ChinaSyncServiceSetting: WithoutAccountSetting {
 
     @objc func switchValueChanged(_ toggle: UISwitch) {
         prefs.setObject(toggle.isOn, forKey: prefKey)
-    }
-}
-
-class StageSyncServiceDebugSetting: WithoutAccountSetting {
-    override var accessoryType: UITableViewCell.AccessoryType { return .none }
-    var prefs: Prefs { return settings.profile.prefs }
-
-    var prefKey: String = "useStageSyncService"
-
-    override var accessibilityIdentifier: String? { return "DebugStageSync" }
-
-    override var hidden: Bool {
-        if !ShowDebugSettings {
-            return true
-        }
-        return false
-    }
-
-    override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Debug: use stage servers", comment: "Debug option"), attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
-    }
-
-    override func onConfigureCell(_ cell: UITableViewCell) {
-        super.onConfigureCell(cell)
-        let control = UISwitchThemed()
-        control.onTintColor = UIColor.theme.tableView.controlTint
-        control.addTarget(self, action: #selector(switchValueChanged), for: .valueChanged)
-        control.isOn = prefs.boolForKey(prefKey) ?? false
-        cell.accessoryView = control
-        cell.selectionStyle = .none
-    }
-
-    @objc func switchValueChanged(_ toggle: UISwitch) {
-        prefs.setObject(toggle.isOn, forKey: prefKey)
-        settings.tableView.reloadData()
     }
 }
 

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -40,11 +40,6 @@ class AppSettingsTableViewController: SettingsTableViewController {
         var settings = [SettingSection]()
 
         let privacyTitle = NSLocalizedString("Privacy", comment: "Privacy section title")
-        let accountDebugSettings = [
-            // Debug settings:
-            //ForgetSyncAuthStateDebugSetting(settings: self),
-            StageSyncServiceDebugSetting(settings: self),
-        ]
 
         let prefs = profile.prefs
         var generalSettings: [Setting] = [
@@ -95,7 +90,7 @@ class AppSettingsTableViewController: SettingsTableViewController {
                 // With a Firefox Account:
                 AccountStatusSetting(settings: self),
                 SyncNowSetting(settings: self)
-            ] + accountChinaSyncSetting + accountDebugSettings)]
+            ] + accountChinaSyncSetting )]
 
         settings += [ SettingSection(title: NSAttributedString(string: Strings.SettingsGeneralSectionTitle), children: generalSettings)]
 
@@ -136,6 +131,7 @@ class AppSettingsTableViewController: SettingsTableViewController {
                 DeleteExportedDataSetting(settings: self),
                 ForceCrashSetting(settings: self),
                 SlowTheDatabase(settings: self),
+                ForgetSyncAuthStateDebugSetting(settings: self),
                 SentryIDSetting(settings: self),
             ])]
 

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -306,56 +306,13 @@ extension Strings {
 
 }
 
-// Custom account settings - These strings did not make it for the v10 l10n deadline so we have turned them into regular strings. These strings will come back localized in a next version.
-
+// For 'Advanced Sync Settings' view, which is a debug setting. English only, there is little value in maintaining L10N strings for these.
 extension Strings {
-    // Settings.AdvancedAccount.AutoconfigSectionFooter
-    // Details for using custom Firefox Account service.
-    public static let SettingsAdvancedAccountAutoconfigSectionFooter = "To use custom Firefox Account/Sync servers via autoconfig, specify the root URL of the custom Firefox Account site. This will download the configuration and setup this device to use the new service. After the new service has been set, you will need to create a new Firefox Account or login with an existing one."
-
-    // Settings.AdvancedAccount.TokenServerSectionFooter
-    // Details for using custom Firefox Account service.
-    public static let SettingsAdvancedAccountTokenServerSectionFooter = "To override a custom Firefox Sync server, specify the URL of the custom Firefox Sync server. After the new server has been set, you will need to log-out and login again for the changes to take effect."
-
-    // Settings.AdvancedAccount.SectionName
-    // Title displayed in header of the setting panel.
     public static let SettingsAdvancedAccountTitle = "Advanced Sync Settings"
-
-    // Settings.AdvancedAccount.CustomAutoconfigURIPlaceholder
-    // Title displayed in header of the setting panel.
-    public static let SettingsAdvancedAccountCustomAutoconfigURIPlaceholder = "Custom Autoconfig URI"
-
-    // Settings.AdvancedAccount.ustomSyncTokenServerURIPlaceholder
-    // Title displayed in header of the setting panel.
-    public static let SettingsAdvancedAccountCustomSyncTokenServerURIPlaceholder = "Custom Sync Token Server URI"
-
-    // Settings.AdvancedAccount.UpdatedAlertMessage
-    // Messaged displayed when sync service has been successfully set.
-    public static let SettingsAdvancedAccountUrlUpdatedAlertMessage = "Firefox Account service updated. To begin using custom server, please log out and re-login."
-
-    // Settings.AdvancedAccount.ErrorAlertTitle
-    // Error alert message title.
-    public static let SettingsAdvancedAccountUrlErrorAlertTitle = "Error"
-
-    // Settings.AdvancedAccount.ErrorAlertMessage
-    // Messaged displayed when sync service has an error setting a custom sync url.
-    public static let SettingsAdvancedAccountUrlErrorAlertMessage = "There was an error while attempting to fetch the autoconfig. Please make sure that it is a valid Firefox Account root URL."
-
-    // Settings.AdvancedAccount.UseCustomAccountsServiceTitle
-    // Toggle switch to use custom FxA server
-    public static let SettingsAdvancedAccountUseCustomAccountsServiceTitle = "Use Custom Autoconfig"
-
-    // Settings.AdvancedAccount.EmptyAutoconfigURIErrorAlertMessage
-    // No custom service set.
-    public static let SettingsAdvancedAccountEmptyAutoconfigURIErrorAlertMessage = "Please enter a custom autoconfig URI before enabling."
-
-    // Settings.AdvancedAccount.UseCustomSyncTokenServerTitle
-    // Toggle switch to use custom FxA server
+    public static let SettingsAdvancedAccountCustomFxAContentServerURI = "Custom Firefox Account Content Server URI"
+    public static let SettingsAdvancedAccountUseCustomFxAContentServerURITitle = "Use Custom FxA Content Server"
+    public static let SettingsAdvancedAccountCustomSyncTokenServerURI = "Custom Sync Token Server URI"
     public static let SettingsAdvancedAccountUseCustomSyncTokenServerTitle = "Use Custom Sync Token Server"
-
-    // Settings.AdvancedAccount.EmptyTokenServerURIErrorAlertMessage
-    // No custom service set.
-    public static let SettingsAdvancedAccountEmptyTokenServerURIErrorAlertMessage = "Please enter a custom token server URI before enabling."
 }
 
 // Open With Settings

--- a/RustFxA/FxAWebView.swift
+++ b/RustFxA/FxAWebView.swift
@@ -125,7 +125,7 @@ class FxAWebView: UIViewController, WKNavigationDelegate {
 
         // Cancel navigation that happens after login to an account, which is when a redirect to `redirectURL` happens.
         // The app handles this event fully in native UI.
-        let redirectUrl = RustFirefoxAccounts.shared.redirectURL
+        let redirectUrl = RustFirefoxAccounts.redirectURL
         if let navigationURL = navigationAction.request.url {
             let expectedRedirectURL = URL(string: redirectUrl)!
             if navigationURL.scheme == expectedRedirectURL.scheme && navigationURL.host == expectedRedirectURL.host && navigationURL.path == expectedRedirectURL.path {

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -37,13 +37,8 @@ public struct PrefsKeys {
 
     public static let KeyUseCustomSyncTokenServerOverride = "useCustomSyncTokenServerOverride"
     public static let KeyCustomSyncTokenServerOverride = "customSyncTokenServerOverride"
-
-    public static let KeyUseCustomAccountAutoconfig = "useCustomSyncService"
-    public static let KeyCustomSyncToken = "customSyncTokenServer"
-    public static let KeyCustomSyncProfile = "customSyncProfileServer"
-    public static let KeyCustomSyncOauth = "customSyncOauthServer"
-    public static let KeyCustomSyncAuth = "customSyncAuthServer"
-    public static let KeyCustomSyncWeb = "customSyncWebServer"
+    public static let KeyUseCustomFxAContentServer = "useCustomFxAContentServer"
+    public static let KeyCustomFxAContentServer = "customFxAContentServer"
     public static let UseStageServer = "useStageSyncService"
     public static let KeyFxALastCommandIndex = "FxALastCommandIndex"
     public static let KeyFxAHandledCommands = "FxAHandledCommands"


### PR DESCRIPTION
This item is shown when tapping 5x on the version number in settings.
Rather than have the `Use stage servers` option at the top-level in settings, it is now in the advances sync settings view, and toggling it on will hide the other options.

The debug fxa/sync settings now looks like this
<img width="291" alt="image" src="https://user-images.githubusercontent.com/5495083/79775893-e5fda500-8302-11ea-9a23-c669a816f3c8.png">

<img width="292" alt="image" src="https://user-images.githubusercontent.com/5495083/79775912-edbd4980-8302-11ea-9665-1beaafccb33f.png">

<img width="296" alt="image" src="https://user-images.githubusercontent.com/5495083/79775932-f57cee00-8302-11ea-8581-84ef8894d65b.png">
