### PR TITLE
Fix #6469: wipe the keychain when disconnecting FxA

### DIFF
--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -543,7 +543,7 @@ open class BrowserProfile: Profile {
 
         // remove Account Metadata
         prefs.removeObjectForKey(PrefsKeys.KeyLastRemoteTabSyncTime)
-        keychain.removeObject(forKey: self.name + ".account")
+        keychain.removeAllKeys()
 
         // Tell any observers that our account has changed.
         NotificationCenter.default.post(name: .FirefoxAccountChanged, object: nil)


### PR DESCRIPTION
Not sure why I didn't do this in the first place.