### PR TITLE
Fix #6232 - Crashes when trying to add account picture

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheet/AppMenu.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/AppMenu.swift
@@ -62,6 +62,10 @@ extension PhotonActionSheetProtocol {
             settingsTableViewController.settingsDelegate = vcDelegate
 
             let controller = ThemedNavigationController(rootViewController: settingsTableViewController)
+            // On iPhone iOS13 the WKWebview crashes while presenting file picker if its not full screen. Ref #6232
+            if UIDevice.current.userInterfaceIdiom == .phone {
+                controller.modalPresentationStyle = .fullScreen
+            }
             controller.presentingModalViewControllerDelegate = vcDelegate
 
             // Wait to present VC in an async dispatch queue to prevent a case where dismissal


### PR DESCRIPTION
An issue with iOS 13 results in WKWebView to crash on the image picker when its not fullscreen.
Hence, made the webview to be fullscreen. 

