### PR TITLE
Fix #6474: reconfig FxA in the notification service EVERY time a push arrives

### DIFF
--- a/Account/FxAPushMessageHandler.swift
+++ b/Account/FxAPushMessageHandler.swift
@@ -60,55 +60,57 @@ extension FxAPushMessageHandler {
         // return handle(plaintext: string)
         let deferred = PushMessageResult()
         RustFirefoxAccounts.startup(prefs: profile.prefs) { fxa in
-            fxa.accountManager.deviceConstellation()?.processRawIncomingAccountEvent(pushPayload: string) {
-                result in
-                guard case .success(let events) = result else {
-                    if case .failure(let error) = result {
-                        let err = PushMessageError.messageIncomplete(error.localizedDescription)
-                        deferred.fill(Maybe(failure: err))
+            RustFirefoxAccounts.reconfig {
+                fxa.accountManager.deviceConstellation()?.processRawIncomingAccountEvent(pushPayload: string) {
+                    result in
+                    guard case .success(let events) = result else {
+                        if case .failure(let error) = result {
+                            let err = PushMessageError.messageIncomplete(error.localizedDescription)
+                            deferred.fill(Maybe(failure: err))
+                        }
+                        return
                     }
-                    return
-                }
-                events.forEach { event in
-                    switch event {
-                    case .incomingDeviceCommand(let deviceCommand):
-                        switch deviceCommand {
-                            case .tabReceived(_, let tabData):
-                                let title = tabData.last?.title ?? ""
-                                let url = tabData.last?.url ?? ""
-                                let message = PushMessage.commandReceived(tab: ["title": title, "url": url])
+                    events.forEach { event in
+                        switch event {
+                        case .incomingDeviceCommand(let deviceCommand):
+                            switch deviceCommand {
+                                case .tabReceived(_, let tabData):
+                                    let title = tabData.last?.title ?? ""
+                                    let url = tabData.last?.url ?? ""
+                                    let message = PushMessage.commandReceived(tab: ["title": title, "url": url])
+                                    deferred.fill(Maybe(success: message))
+                            }
+                        case .deviceConnected(let deviceName):
+                            let message = PushMessage.deviceConnected(deviceName)
+                            deferred.fill(Maybe(success: message))
+                        case .deviceDisconnected(let deviceInfo):
+                            if deviceInfo.isLocalDevice {
+                                // We can't disconnect the device from the account until we have access to the application, so we'll handle this properly in the AppDelegate (as this code in an extension),
+                                // by calling the FxALoginHelper.applicationDidDisonnect(application).
+                                self.profile.prefs.setBool(true, forKey: PendingAccountDisconnectedKey)
+                                let message = PushMessage.thisDeviceDisconnected
                                 deferred.fill(Maybe(success: message))
-                        }
-                    case .deviceConnected(let deviceName):
-                        let message = PushMessage.deviceConnected(deviceName)
-                        deferred.fill(Maybe(success: message))
-                    case .deviceDisconnected(let deviceInfo):
-                        if deviceInfo.isLocalDevice {
-                            // We can't disconnect the device from the account until we have access to the application, so we'll handle this properly in the AppDelegate (as this code in an extension),
-                            // by calling the FxALoginHelper.applicationDidDisonnect(application).
-                            self.profile.prefs.setBool(true, forKey: PendingAccountDisconnectedKey)
-                            let message = PushMessage.thisDeviceDisconnected
-                            deferred.fill(Maybe(success: message))
-                            return
-                        }
-
-                        guard let profile = self.profile as? BrowserProfile else {
-                            // We can't look up a name in testing, so this is the same as not knowing about it.
-                            let message = PushMessage.deviceDisconnected(nil)
-                            deferred.fill(Maybe(success: message))
-                            return
-                        }
-
-                        profile.remoteClientsAndTabs.getClient(fxaDeviceId: deviceInfo.deviceId).uponQueue(.main) { result in
-                            guard let device = result.successValue else { return }
-                            let message = PushMessage.deviceDisconnected(device?.name)
-                            if let id = device?.guid {
-                                profile.remoteClientsAndTabs.deleteClient(guid: id).uponQueue(.main) { _ in
-                                    print("deleted client")
-                                }
+                                return
                             }
 
-                            deferred.fill(Maybe(success: message))
+                            guard let profile = self.profile as? BrowserProfile else {
+                                // We can't look up a name in testing, so this is the same as not knowing about it.
+                                let message = PushMessage.deviceDisconnected(nil)
+                                deferred.fill(Maybe(success: message))
+                                return
+                            }
+
+                            profile.remoteClientsAndTabs.getClient(fxaDeviceId: deviceInfo.deviceId).uponQueue(.main) { result in
+                                guard let device = result.successValue else { return }
+                                let message = PushMessage.deviceDisconnected(device?.name)
+                                if let id = device?.guid {
+                                    profile.remoteClientsAndTabs.deleteClient(guid: id).uponQueue(.main) { _ in
+                                        print("deleted client")
+                                    }
+                                }
+
+                                deferred.fill(Maybe(success: message))
+                            }
                         }
                     }
                 }

--- a/RustFxA/RustFirefoxAccounts.swift
+++ b/RustFxA/RustFirefoxAccounts.swift
@@ -99,10 +99,10 @@ open class RustFirefoxAccounts {
         return id
     }
 
-    public static func reconfig() {
+    public static func reconfig(_ completion: (() -> Void)? = nil) {
         shared.accountManager = createAccountManager()
         shared.accountManager.initialize() { _ in
-            print("FxA reconfigured")
+            completion?()
         }
     }
 


### PR DESCRIPTION
The notification service is staying alive and retaining the old FxA state after the account has been disconnected and reconnected.