### PR TITLE
Bug 1622800 - part 15: Add missing treeherder symbol

### DIFF
--- a/.cron.yml
+++ b/.cron.yml
@@ -8,4 +8,5 @@ jobs:
       job:
           type: decision-task
           target-tasks-method: l10n_screenshots
+          treeherder-symbol: l10-screenshots
       when: []  # Manual trigger only


### PR DESCRIPTION
Fixes https://firefox-ci-tc.services.mozilla.com/tasks/C0CzfrS0SHadyei2keQ1dg/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FC0CzfrS0SHadyei2keQ1dg%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log#L87

I couldn't test this on my PR, I needed to be on the production environment.

Firefox iOS currently doesn't use treeherder.mozilla.org. That said, our tooling assumes it does. I looked more closely at the code and I don't think it's a big deal.