### PR TITLE
Properly show the device ID when viewing FxA Settings

### DIFF
--- a/RustFxA/FxAWebView.swift
+++ b/RustFxA/FxAWebView.swift
@@ -189,12 +189,14 @@ extension FxAWebView: WKScriptMessageHandler {
         let data: String
         if pageType == .settingsPage {
             let fxa = RustFirefoxAccounts.shared.accountManager
-            let email = fxa.accountProfile()?.email ?? ""
+            let uid = fxa.accountProfile()?.uid ?? ""
             let token = (try? fxa.getSessionToken().get()) ?? ""
             data = """
-            {   signedInUser: {
+            {
+                capabilities: {},
+                signedInUser: {
                     sessionToken: "\(token)",
-                    email: "\(email)",
+                    uid: "\(uid)",
                     verified: true,
                 }
             }


### PR DESCRIPTION
Related to issue https://github.com/mozilla-mobile/firefox-ios/issues/6407

@garvankeeley r?