### PR TITLE
Bug 1622800 - part 16: Stop using jlorenzo's workflows

### DIFF
--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -15,7 +15,7 @@ jobs:
     screenshots:
         attributes:
             chunk_locales: ["en-US"]
-        bitrise-workflow: jlorenzo_L10nBuild
+        bitrise-workflow: L10nBuild
         description: Generate build instrumented for screenshots, including en-US pictures
         run-on-tasks-for: []
         worker:

--- a/taskcluster/ci/generate-screenshots/kind.yml
+++ b/taskcluster/ci/generate-screenshots/kind.yml
@@ -19,7 +19,7 @@ not-for-locales:
 locales-per-chunk: 6
 
 job-defaults:
-    bitrise-workflow: jlorenzo_L10nScreenshotsTests
+    bitrise-workflow: L10nScreenshotsTests
     build-derived-data-path: {artifact-reference: '<build/public/build/target.zip>'}
     description: Generate localized screenshots by delegating the work to bitrise.io
     dependencies:


### PR DESCRIPTION
⚠️ `L10nScreenshotsTests` already exists. @isabelrios, do you mind if I replace it with the one I created as `jlorenzo_L10nScreenshotsTests`? 