### PR TITLE
Fix #6483: downloadqueue callbacks should be main thread only

### DIFF
--- a/Client/Frontend/Browser/DownloadQueue.swift
+++ b/Client/Frontend/Browser/DownloadQueue.swift
@@ -4,8 +4,6 @@
 
 import Foundation
 
-private let downloadOperationQueue = OperationQueue()
-
 protocol DownloadDelegate {
     func download(_ download: Download, didCompleteWithError error: Error?)
     func download(_ download: Download, didDownloadBytes bytesDownloaded: Int64)
@@ -86,7 +84,7 @@ class HTTPDownload: Download {
 
         self.totalBytesExpected = preflightResponse.expectedContentLength > 0 ? preflightResponse.expectedContentLength : nil
 
-        self.session = URLSession(configuration: .default, delegate: self, delegateQueue: downloadOperationQueue)
+        self.session = URLSession(configuration: .default, delegate: self, delegateQueue: .main)
         self.task = session?.downloadTask(with: request)
     }
 


### PR DESCRIPTION
Sorry Nish! One more PR for you, same problem, code being off main again that should be on-main. We don't do any significant work in the callbacks that requires they be off-main. And better that they are slow than crash. I'll get this re-tested.