### PR TITLE
Fix #6550: make RustFirefoxAccounts accountManager a Deferred

### DIFF
--- a/Account/FxAPushMessageHandler.swift
+++ b/Account/FxAPushMessageHandler.swift
@@ -6,6 +6,7 @@ import Shared
 import SwiftyJSON
 import Account
 import SwiftKeychainWrapper
+import os.log
 
 private let log = Logger.syncLogger
 
@@ -61,58 +62,63 @@ extension FxAPushMessageHandler {
 
         // return handle(plaintext: string)
         let deferred = PushMessageResult()
-        RustFirefoxAccounts.startup(prefs: profile.prefs) { fxa in
-            RustFirefoxAccounts.reconfig {
-                fxa.accountManager.deviceConstellation()?.processRawIncomingAccountEvent(pushPayload: string) {
+        RustFirefoxAccounts.startup(prefs: profile.prefs).uponQueue(.main) { _ in
+            RustFirefoxAccounts.reconfig { accountManager in
+                accountManager.deviceConstellation()?.processRawIncomingAccountEvent(pushPayload: string) {
                     result in
-                    guard case .success(let events) = result else {
+                    guard case .success(let events) = result, let firstEvent = events.first else {
+                        let err: PushMessageError
                         if case .failure(let error) = result {
-                            let err = PushMessageError.messageIncomplete(error.localizedDescription)
-                            deferred.fill(Maybe(failure: err))
+                            err = PushMessageError.messageIncomplete(error.localizedDescription)
+                        } else {
+                            err = PushMessageError.messageIncomplete("empty message")
                         }
+                        deferred.fill(Maybe(failure: err))
                         return
                     }
-                    events.forEach { event in
-                        switch event {
-                        case .incomingDeviceCommand(let deviceCommand):
-                            switch deviceCommand {
-                                case .tabReceived(_, let tabData):
-                                    let title = tabData.last?.title ?? ""
-                                    let url = tabData.last?.url ?? ""
-                                    let message = PushMessage.commandReceived(tab: ["title": title, "url": url])
-                                    deferred.fill(Maybe(success: message))
-                            }
-                        case .deviceConnected(let deviceName):
-                            let message = PushMessage.deviceConnected(deviceName)
+                    if events.count > 1 {
+                        // Log to the console for debugging release builds
+                        os_log("%{public}@", log: OSLog(subsystem: "org.mozilla.firefox", category: "firefoxnotificationservice"), type: OSLogType.debug, "Multiple events arrived, only handling the first event.")
+                    }
+                    switch firstEvent {
+                    case .incomingDeviceCommand(let deviceCommand):
+                        switch deviceCommand {
+                        case .tabReceived(_, let tabData):
+                            let title = tabData.last?.title ?? ""
+                            let url = tabData.last?.url ?? ""
+                            let message = PushMessage.commandReceived(tab: ["title": title, "url": url])
                             deferred.fill(Maybe(success: message))
-                        case .deviceDisconnected(let deviceInfo):
-                            if deviceInfo.isLocalDevice {
-                                // We can't disconnect the device from the account until we have access to the application, so we'll handle this properly in the AppDelegate (as this code in an extension),
-                                // by calling the FxALoginHelper.applicationDidDisonnect(application).
-                                self.profile.prefs.setBool(true, forKey: PendingAccountDisconnectedKey)
-                                let message = PushMessage.thisDeviceDisconnected
-                                deferred.fill(Maybe(success: message))
-                                return
-                            }
-
-                            guard let profile = self.profile as? BrowserProfile else {
-                                // We can't look up a name in testing, so this is the same as not knowing about it.
-                                let message = PushMessage.deviceDisconnected(nil)
-                                deferred.fill(Maybe(success: message))
-                                return
-                            }
-
-                            profile.remoteClientsAndTabs.getClient(fxaDeviceId: deviceInfo.deviceId).uponQueue(.main) { result in
-                                guard let device = result.successValue else { return }
-                                let message = PushMessage.deviceDisconnected(device?.name)
-                                if let id = device?.guid {
-                                    profile.remoteClientsAndTabs.deleteClient(guid: id).uponQueue(.main) { _ in
-                                        print("deleted client")
-                                    }
+                        }
+                    case .deviceConnected(let deviceName):
+                        let message = PushMessage.deviceConnected(deviceName)
+                        deferred.fill(Maybe(success: message))
+                    case .deviceDisconnected(let deviceInfo):
+                        if deviceInfo.isLocalDevice {
+                            // We can't disconnect the device from the account until we have access to the application, so we'll handle this properly in the AppDelegate (as this code in an extension),
+                            // by calling the FxALoginHelper.applicationDidDisonnect(application).
+                            self.profile.prefs.setBool(true, forKey: PendingAccountDisconnectedKey)
+                            let message = PushMessage.thisDeviceDisconnected
+                            deferred.fill(Maybe(success: message))
+                            return
+                        }
+                        
+                        guard let profile = self.profile as? BrowserProfile else {
+                            // We can't look up a name in testing, so this is the same as not knowing about it.
+                            let message = PushMessage.deviceDisconnected(nil)
+                            deferred.fill(Maybe(success: message))
+                            return
+                        }
+                        
+                        profile.remoteClientsAndTabs.getClient(fxaDeviceId: deviceInfo.deviceId).uponQueue(.main) { result in
+                            guard let device = result.successValue else { return }
+                            let message = PushMessage.deviceDisconnected(device?.name)
+                            if let id = device?.guid {
+                                profile.remoteClientsAndTabs.deleteClient(guid: id).uponQueue(.main) { _ in
+                                    print("deleted client")
                                 }
-
-                                deferred.fill(Maybe(success: message))
                             }
+                            
+                            deferred.fill(Maybe(success: message))
                         }
                     }
                 }

--- a/Account/SyncAuthState.swift
+++ b/Account/SyncAuthState.swift
@@ -141,29 +141,31 @@ open class FirefoxAccountSyncAuthState: SyncAuthState {
 
         let deferred = Deferred<Maybe<(token: TokenServerToken, forKey: Data)>>()
 
-        RustFirefoxAccounts.shared.accountManager.getTokenServerEndpointURL() { result in
-            guard case .success(let tokenServerEndpointURL) = result else {
-                deferred.fill(Maybe(failure: FxAClientError.local(NSError())))
-                return
-            }
+        RustFirefoxAccounts.shared.accountManager.uponQueue(.main) { accountManager in
+            accountManager.getTokenServerEndpointURL() { result in
+                guard case .success(let tokenServerEndpointURL) = result else {
+                    deferred.fill(Maybe(failure: FxAClientError.local(NSError())))
+                    return
+                }
 
-            let client = TokenServerClient(url: tokenServerEndpointURL)
-            RustFirefoxAccounts.shared.accountManager.getAccessToken(scope: OAuthScope.oldSync) { res in
-                switch res {
-                    case .failure(let err):
-                        deferred.fill(Maybe(failure: err as MaybeErrorType))
-                    case .success(let accessToken):
-                        log.debug("Fetching token server token.")
-                        client.token(token: accessToken.token, kid: accessToken.key!.kid).upon { result in
-                        guard let token = result.successValue else {
-                            deferred.fill(Maybe(failure: result.failureValue!))
-                            return
+                let client = TokenServerClient(url: tokenServerEndpointURL)
+                accountManager.getAccessToken(scope: OAuthScope.oldSync) { res in
+                    switch res {
+                        case .failure(let err):
+                            deferred.fill(Maybe(failure: err as MaybeErrorType))
+                        case .success(let accessToken):
+                            log.debug("Fetching token server token.")
+                            client.token(token: accessToken.token, kid: accessToken.key!.kid).upon { result in
+                            guard let token = result.successValue else {
+                                deferred.fill(Maybe(failure: result.failureValue!))
+                                return
+                            }
+                            let kSync = accessToken.key!.k.base64urlSafeDecodedData!
+                            let newCache = SyncAuthStateCache(token: token, forKey: kSync,expiresAt: now + 1000 * token.durationInSeconds)
+                            log.debug("Fetched token server token!  Token expires at \(newCache.expiresAt).")
+                            self.cache.value = newCache
+                            deferred.fill(Maybe(success: (token: token, forKey: kSync)))
                         }
-                        let kSync = accessToken.key!.k.base64urlSafeDecodedData!
-                        let newCache = SyncAuthStateCache(token: token, forKey: kSync,expiresAt: now + 1000 * token.durationInSeconds)
-                        log.debug("Fetched token server token!  Token expires at \(newCache.expiresAt).")
-                        self.cache.value = newCache
-                        deferred.fill(Maybe(success: (token: token, forKey: kSync)))
                     }
                 }
             }

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -144,6 +144,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         self.updateAuthenticationInfo()
         SystemUtils.onFirstRun()
 
+        RustFirefoxAccounts.startup(prefs: profile.prefs).uponQueue(.main) { _ in
+            print("RustFirefoxAccounts started")
+        }
         log.info("startApplication end")
         return true
     }
@@ -225,10 +228,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         AutocompleteTextField.appearance().semanticContentAttribute = .forceLeftToRight
 
         pushNotificationSetup()
-
-        if let profile = profile as? BrowserProfile {
-            RustFirefoxAccounts.startup(prefs: profile.prefs) { _ in }
-        }
 
         // Leanplum usersearch variable setup for onboarding research
         _ = OnboardingUserResearch()

--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -197,7 +197,7 @@ class LeanPlumClient {
         })
 
         NotificationCenter.default.addObserver(forName: .FirefoxAccountChanged, object: nil, queue: .main) { _ in
-            if !RustFirefoxAccounts.shared.accountManager.hasAccount() {
+            if !RustFirefoxAccounts.shared.hasAccount() {
                 LeanPlumClient.shared.set(attributes: [LPAttributeKey.signedInSync: false])
             }
         }

--- a/Client/Frontend/Extensions/DevicePickerViewController.swift
+++ b/Client/Frontend/Extensions/DevicePickerViewController.swift
@@ -71,8 +71,8 @@ class DevicePickerViewController: UITableViewController {
         }
 
         let profile = ensureOpenProfile()
-        RustFirefoxAccounts.startup(prefs: profile.prefs) { shared in
-            shared.accountManager.deviceConstellation()?.refreshState()
+        RustFirefoxAccounts.startup(prefs: profile.prefs).uponQueue(.main) { accountManager in
+            accountManager.deviceConstellation()?.refreshState()
         }
 
         loadList()
@@ -86,8 +86,8 @@ class DevicePickerViewController: UITableViewController {
 
     private func loadList() {
         let profile = ensureOpenProfile()
-        RustFirefoxAccounts.startup(prefs: profile.prefs) { [weak self] shared in
-            guard let state = shared.accountManager.deviceConstellation()?.state() else {
+        RustFirefoxAccounts.startup(prefs: profile.prefs).uponQueue(.main) { [weak self] accountManager in
+            guard let state = accountManager.deviceConstellation()?.state() else {
                 self?.loadingState = .loaded
                 return
             }
@@ -221,7 +221,7 @@ class DevicePickerViewController: UITableViewController {
     }
 
     @objc func refresh() {
-        RustFirefoxAccounts.shared.accountManager.deviceConstellation()?.refreshState()
+        RustFirefoxAccounts.shared.accountManager.peek()?.deviceConstellation()?.refreshState()
         if let refreshControl = self.refreshControl {
             refreshControl.beginRefreshing()
             let height = -(refreshControl.bounds.size.height + (self.navigationController?.navigationBar.bounds.size.height ?? 0))

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -335,8 +335,7 @@ class AccountStatusSetting: WithAccountSetting {
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        let account = profile.rustFxA.accountManager
-        guard !account.accountNeedsReauth() else {
+        guard !profile.rustFxA.accountNeedsReauth() else {
             let view = FxAWebView(pageType: .emailLoginFlow, profile: profile, dismissalStyle: .popToRootVC)
             navigationController?.pushViewController(view, animated: true)
             return

--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -72,7 +72,7 @@ class DisconnectSetting: Setting {
 
 class DeviceNamePersister: SettingValuePersister {
     func readPersistedValue() -> String? {
-        guard let val = RustFirefoxAccounts.shared.accountManager.deviceConstellation()?
+        guard let val = RustFirefoxAccounts.shared.accountManager.peek()?.deviceConstellation()?
             .state()?.localDevice?.displayName else {
                 return UserDefaults.standard.string(forKey: RustFirefoxAccounts.prefKeyLastDeviceName)
         }
@@ -82,7 +82,7 @@ class DeviceNamePersister: SettingValuePersister {
 
     func writePersistedValue(value: String?) {
         guard let newName = value,
-              let deviceConstellation = RustFirefoxAccounts.shared.accountManager.deviceConstellation() else {
+            let deviceConstellation = RustFirefoxAccounts.shared.accountManager.peek()?.deviceConstellation() else {
             return
         }
         UserDefaults.standard.set(newName, forKey: RustFirefoxAccounts.prefKeyLastDeviceName)
@@ -127,7 +127,7 @@ class SyncContentSettingsViewController: SettingsTableViewController {
 
         self.title = Strings.FxASettingsTitle
 
-        RustFirefoxAccounts.shared.accountManager.deviceConstellation()?.refreshState()
+        RustFirefoxAccounts.shared.accountManager.peek()?.deviceConstellation()?.refreshState()
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Widgets/PhotonActionSheet/AppMenu.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/AppMenu.swift
@@ -88,13 +88,13 @@ extension PhotonActionSheetProtocol {
         }
 
         let rustAccount = RustFirefoxAccounts.shared
-        let needsReauth = rustAccount.accountManager.accountNeedsReauth()
+        let needsReauth = rustAccount.accountNeedsReauth()
 
         guard let userProfile = rustAccount.userProfile else {
             return PhotonActionSheetItem(title: Strings.FxASignInToSync, iconString: "menu-sync", handler: action)
         }
         let title: String = {
-            if rustAccount.accountManager.accountNeedsReauth() {
+            if rustAccount.accountNeedsReauth() {
                 return Strings.FxAAccountVerifyPassword
             }
             return userProfile.displayName ?? userProfile.email

--- a/Extensions/NotificationService/NotificationService.swift
+++ b/Extensions/NotificationService/NotificationService.swift
@@ -141,6 +141,7 @@ extension SyncDataDisplay {
     }
 
     func displayAccountVerifiedNotification() {
+        Sentry.shared.send(message: "SentTab error: account not verified")
         #if MOZ_CHANNEL_BETA || DEBUG
             presentNotification(title: Strings.SentTab_NoTabArrivingNotification_title, body: "DEBUG: Account Verified")
             return
@@ -149,9 +150,9 @@ extension SyncDataDisplay {
     }
 
     func displayUnknownMessageNotification(debugInfo: String) {
+        Sentry.shared.send(message: "SentTab error: \(debugInfo)")
         #if MOZ_CHANNEL_BETA || DEBUG
             presentNotification(title: Strings.SentTab_NoTabArrivingNotification_title, body: "DEBUG: " + debugInfo)
-            Sentry.shared.send(message: "SentTab error: \(debugInfo)")
             return
         #endif
 
@@ -189,10 +190,10 @@ extension SyncDataDisplay {
             title = Strings.SentTab_NoTabArrivingNotification_title
             #if MOZ_CHANNEL_BETA || DEBUG
                 body = "DEBUG: Sent Tabs with no tab"
-                Sentry.shared.send(message: "SentTab error: no tab")
             #else
                 body = Strings.SentTab_NoTabArrivingNotification_body
             #endif
+            Sentry.shared.send(message: "SentTab error: no tab")
         } else {
             let deviceNames = Set(tabs.compactMap { $0["deviceName"] as? String })
             if let deviceName = deviceNames.first, deviceNames.count == 1 {

--- a/Extensions/ShareTo/ShareViewController.swift
+++ b/Extensions/ShareTo/ShareViewController.swift
@@ -107,7 +107,7 @@ class ShareViewController: UIViewController {
         }
 
         let profile = BrowserProfile(localName: "profile")
-        RustFirefoxAccounts.startup(prefs: profile.prefs) { _ in }
+        RustFirefoxAccounts.startup(prefs: profile.prefs).uponQueue(.main) { _ in }
     }
 
     private func setupRows() {

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -143,57 +143,67 @@ open class SyncStateMachine {
     }
 
     open func toReady(_ authState: SyncAuthState) -> ReadyDeferred {
-        let token = authState.token(Date.now(), canBeExpired: false)
-        return chainDeferred(token, f: { (token, kSync) in
-            log.debug("Got token from auth state.")
-            if Logger.logPII {
-                log.debug("Server is \(token.api_endpoint).")
+        let readyDeferred = ReadyDeferred()
+        RustFirefoxAccounts.shared.accountManager.uponQueue(.main) { accountManager in
+            authState.token(Date.now(), canBeExpired: false).uponQueue(.main) { success in
+                guard let (token, kSync) = success.successValue else {
+                    assert(false)
+                    return
+                }
+                log.debug("Got token from auth state.")
+                if Logger.logPII {
+                   log.debug("Server is \(token.api_endpoint).")
+                }
+                let prior = Scratchpad.restoreFromPrefs(self.scratchpadPrefs, syncKeyBundle: KeyBundle.fromKSync(kSync))
+                if prior == nil {
+                   log.info("No persisted Sync state. Starting over.")
+                }
+                var scratchpad = prior ?? Scratchpad(b: KeyBundle.fromKSync(kSync), persistingTo: self.scratchpadPrefs)
+
+                // Take the scratchpad and add the fxaDeviceId from the state, and hashedUID from the token
+                let b = Scratchpad.Builder(p: scratchpad)
+
+                if let deviceID = accountManager.deviceConstellation()?.state()?.localDevice?.id {
+                   b.fxaDeviceId = deviceID
+                } else {
+                   // Either deviceRegistration hasn't occurred yet (our bug) or
+                   // FxA has given us an UnknownDevice error.
+                   log.warning("Device registration has not taken place before sync.")
+                }
+                b.hashedUID = token.hashedFxAUID
+
+                if let enginesEnablements = authState.enginesEnablements,
+                  !enginesEnablements.isEmpty {
+                   b.enginesEnablements = enginesEnablements
+                }
+
+                if let clientName = authState.clientName {
+                   b.clientName = clientName
+                }
+
+                // Detect if we've changed anything in our client record from the last time we synced…
+                let ourClientUnchanged = (b.fxaDeviceId == scratchpad.fxaDeviceId)
+
+                // …and if so, trigger a reset of clients.
+                if !ourClientUnchanged {
+                   b.localCommands.insert(LocalCommand.resetEngine(engine: "clients"))
+                }
+
+                scratchpad = b.build()
+
+                log.info("Advancing to InitialWithLiveToken.")
+                let state = InitialWithLiveToken(scratchpad: scratchpad, token: token)
+
+                // Start with fresh visibility data.
+                self.stateLabelsSeen = [:]
+                self.stateLabelSequence = []
+
+                self.advanceFromState(state).uponQueue(.main) { success in
+                    readyDeferred.fill(success)
+                }
             }
-            let prior = Scratchpad.restoreFromPrefs(self.scratchpadPrefs, syncKeyBundle: KeyBundle.fromKSync(kSync))
-            if prior == nil {
-                log.info("No persisted Sync state. Starting over.")
-            }
-            var scratchpad = prior ?? Scratchpad(b: KeyBundle.fromKSync(kSync), persistingTo: self.scratchpadPrefs)
-
-            // Take the scratchpad and add the fxaDeviceId from the state, and hashedUID from the token
-            let b = Scratchpad.Builder(p: scratchpad)
-            if let deviceID = RustFirefoxAccounts.shared.accountManager.deviceConstellation()?.state()?.localDevice?.id {
-                b.fxaDeviceId = deviceID
-            } else {
-                // Either deviceRegistration hasn't occurred yet (our bug) or
-                // FxA has given us an UnknownDevice error.
-                log.warning("Device registration has not taken place before sync.")
-            }
-            b.hashedUID = token.hashedFxAUID
-
-            if let enginesEnablements = authState.enginesEnablements,
-               !enginesEnablements.isEmpty {
-                b.enginesEnablements = enginesEnablements
-            }
-
-            if let clientName = authState.clientName {
-                b.clientName = clientName
-            }
-
-            // Detect if we've changed anything in our client record from the last time we synced…
-            let ourClientUnchanged = (b.fxaDeviceId == scratchpad.fxaDeviceId)
-
-            // …and if so, trigger a reset of clients.
-            if !ourClientUnchanged {
-                b.localCommands.insert(LocalCommand.resetEngine(engine: "clients"))
-            }
-
-            scratchpad = b.build()
-
-            log.info("Advancing to InitialWithLiveToken.")
-            let state = InitialWithLiveToken(scratchpad: scratchpad, token: token)
-
-            // Start with fresh visibility data.
-            self.stateLabelsSeen = [:]
-            self.stateLabelSequence = []
-
-            return self.advanceFromState(state)
-        })
+        }
+        return readyDeferred
     }
 }
 


### PR DESCRIPTION
This ensures that there is no race condition of code accessing the accountManager before it
has been initialized (which takes a few ticks to complete).

I can't guarantee this fixes the bug, but it is the only possibility I can think of, and is an area of risk in the code that needs to be eliminated anyway as a possibility.