### PR TITLE
FXIOS-722 ⁃ 6504 - Updated Sign In Actions on Synced Tabs and Send Tabs pages.

### DIFF
--- a/Client/Assets/MainFrameAtDocumentEnd.js.LICENSE.txt
+++ b/Client/Assets/MainFrameAtDocumentEnd.js.LICENSE.txt
@@ -1,0 +1,1 @@
+/*! https://mths.be/punycode v1.4.1 by @mathias */

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2412,6 +2412,12 @@ extension BrowserViewController: TopTabsDelegate {
 }
 
 extension BrowserViewController: DevicePickerViewControllerDelegate, InstructionsViewControllerDelegate {
+    func instructionsViewDidRequestToSignIn() {
+        self.dismissSignInViewController()
+        let fxaParams = FxALaunchParams(query: ["entrypoint": "homepanel"])
+        presentSignInViewController(fxaParams)
+    }
+    
     func instructionsViewControllerDidClose(_ instructionsViewController: InstructionsViewController) {
         self.popToBVC()
     }

--- a/Client/Frontend/Extensions/DevicePickerViewController.swift
+++ b/Client/Frontend/Extensions/DevicePickerViewController.swift
@@ -359,7 +359,10 @@ class DevicePickerNoClientsTableViewCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupHelpView(contentView,
             introText: Strings.SendToNoDevicesFound,
-            showMeText: "") // TODO We used to have a 'show me how to ...' text here. But, we cannot open web pages from the extension. So this is clear for now until we decide otherwise.
+            showMeText: "",
+            target: nil,
+            action: nil
+        ) // TODO We used to have a 'show me how to ...' text here. But, we cannot open web pages from the extension. So this is clear for now until we decide otherwise.
         // Move the separator off screen
         separatorInset = UIEdgeInsets(top: 0, left: 1000, bottom: 0, right: 0)
     }

--- a/Client/Frontend/Extensions/InstructionsViewController.swift
+++ b/Client/Frontend/Extensions/InstructionsViewController.swift
@@ -11,6 +11,11 @@ private struct InstructionsViewControllerUX {
     static let TextFont = UIFont.systemFont(ofSize: UIFont.labelFontSize)
     static let TextColor = UIColor.Photon.Grey60
     static let LinkColor = UIColor.Photon.Blue60
+    static let EmptyStateSignInButtonColor = UIColor.Photon.Blue40
+    static let EmptyStateSignInButtonHeight = 44
+    static let EmptyStateSignInButtonWidth = 200
+    static let EmptyStateTopPaddingInBetweenItems: CGFloat = 15
+    static let EmptyStateSignInButtonCornerRadius: CGFloat = 8
 }
 
 protocol InstructionsViewControllerDelegate: AnyObject {
@@ -32,7 +37,7 @@ private func highlightLink(_ s: NSString, withColor color: UIColor) -> NSAttribu
     return a
 }
 
-func setupHelpView(_ view: UIView, introText: String, showMeText: String) {
+func setupHelpView(_ view: UIView, introText: String, showMeText: String, target: Any?, action: Selector?) {
     let imageView = UIImageView()
     imageView.image = UIImage(named: "emptySync")
     view.addSubview(imageView)
@@ -68,6 +73,26 @@ func setupHelpView(_ view: UIView, introText: String, showMeText: String) {
         make.top.equalTo(label1.snp.bottom).offset(InstructionsViewControllerUX.TopPadding)
         make.centerX.equalTo(view)
     }
+    
+    if let target = target, let action = action {
+        let signInButton = UIButton()
+        signInButton.setTitle(Strings.FxASignInToFirefox, for: [])
+        signInButton.setTitleColor(UIColor.Photon.White100, for: [])
+        signInButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .headline)
+        signInButton.layer.cornerRadius = InstructionsViewControllerUX.EmptyStateSignInButtonCornerRadius
+        signInButton.clipsToBounds = true
+        signInButton.addTarget(target, action: action, for: .touchUpInside)
+        view.addSubview(signInButton)
+        
+        signInButton.snp.makeConstraints { (make) -> Void in
+            make.width.equalTo(InstructionsViewControllerUX.EmptyStateSignInButtonWidth)
+            make.height.equalTo(InstructionsViewControllerUX.EmptyStateSignInButtonHeight)
+            make.top.equalTo(label2.snp.bottom).offset(InstructionsViewControllerUX.TopPadding)
+            make.centerX.equalTo(view)
+        }
+        
+        signInButton.backgroundColor = InstructionsViewControllerUX.EmptyStateSignInButtonColor
+    }
 }
 
 class InstructionsViewController: UIViewController {
@@ -78,12 +103,13 @@ class InstructionsViewController: UIViewController {
         edgesForExtendedLayout = []
         view.backgroundColor = UIColor.Photon.White100
 
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: Strings.SendToCloseButton, style: .done, target: self, action: #selector(close))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: Strings.SendToCancelButton, style: .done, target: self, action: #selector(close))
         navigationItem.leftBarButtonItem?.accessibilityIdentifier = "InstructionsViewController.navigationItem.leftBarButtonItem"
 
         setupHelpView(view,
             introText: Strings.SendToNotSignedInText,
-                showMeText: Strings.SendToNotSignedInMessage)
+                showMeText: Strings.SendToNotSignedInMessage,
+                target: self, action: #selector(signIn))
     }
 
     @objc func close() {
@@ -92,5 +118,9 @@ class InstructionsViewController: UIViewController {
 
     func showMeHow() {
         print("Show me how") // TODO Not sure what to do or if to keep this. Waiting for UX feedback.
+    }
+    
+    @objc fileprivate func signIn() {
+       
     }
 }

--- a/Client/Frontend/Extensions/InstructionsViewController.swift
+++ b/Client/Frontend/Extensions/InstructionsViewController.swift
@@ -20,6 +20,7 @@ private struct InstructionsViewControllerUX {
 
 protocol InstructionsViewControllerDelegate: AnyObject {
     func instructionsViewControllerDidClose(_ instructionsViewController: InstructionsViewController)
+    func instructionsViewDidRequestToSignIn()
 }
 
 private func highlightLink(_ s: NSString, withColor color: UIColor) -> NSAttributedString {
@@ -121,6 +122,6 @@ class InstructionsViewController: UIViewController {
     }
     
     @objc fileprivate func signIn() {
-       
+       delegate?.instructionsViewDidRequestToSignIn()
     }
 }

--- a/Client/Frontend/Library/RemoteTabsPanel.swift
+++ b/Client/Frontend/Library/RemoteTabsPanel.swift
@@ -18,7 +18,7 @@ private struct RemoteTabsPanelUX {
     static let EmptyStateInstructionsWidth = 170
     static let EmptyStateTopPaddingInBetweenItems: CGFloat = 15 // UX TODO I set this to 8 so that it all fits on landscape
     static let EmptyStateSignInButtonColor = UIColor.Photon.Blue40
-    static let EmptyStateSignInButtonCornerRadius: CGFloat = 4
+    static let EmptyStateSignInButtonCornerRadius: CGFloat = 8
     static let EmptyStateSignInButtonHeight = 44
     static let EmptyStateSignInButtonWidth = 200
 
@@ -366,7 +366,7 @@ class RemoteTabsNotLoggedInCell: UITableViewCell {
 
         signInButton.setTitle(Strings.FxASignInToSync, for: [])
         signInButton.setTitleColor(UIColor.Photon.White100, for: [])
-        signInButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .subheadline)
+        signInButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .headline)
         signInButton.layer.cornerRadius = RemoteTabsPanelUX.EmptyStateSignInButtonCornerRadius
         signInButton.clipsToBounds = true
         signInButton.addTarget(self, action: #selector(signIn), for: .touchUpInside)

--- a/Client/Frontend/Library/RemoteTabsPanel.swift
+++ b/Client/Frontend/Library/RemoteTabsPanel.swift
@@ -349,7 +349,6 @@ class RemoteTabsNotLoggedInCell: UITableViewCell {
         selectionStyle = .none
 
         self.libraryPanel = libraryPanel
-        let createAnAccountButton = UIButton(type: .system)
 
         emptyStateImageView.image = UIImage.templateImageNamed(emptySyncImageName)
         contentView.addSubview(emptyStateImageView)
@@ -373,11 +372,6 @@ class RemoteTabsNotLoggedInCell: UITableViewCell {
         signInButton.addTarget(self, action: #selector(signIn), for: .touchUpInside)
         contentView.addSubview(signInButton)
 
-        createAnAccountButton.setTitle(NSLocalizedString("Create an account", comment: "See http://mzl.la/1Qtkf0j"), for: [])
-        createAnAccountButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .caption1)
-        createAnAccountButton.addTarget(self, action: #selector(createAnAccount), for: .touchUpInside)
-        contentView.addSubview(createAnAccountButton)
-
         emptyStateImageView.snp.makeConstraints { (make) -> Void in
             make.centerX.equalTo(instructionsLabel)
 
@@ -391,11 +385,6 @@ class RemoteTabsNotLoggedInCell: UITableViewCell {
         titleLabel.snp.makeConstraints { make in
             make.top.equalTo(emptyStateImageView.snp.bottom).offset(RemoteTabsPanelUX.EmptyStateTopPaddingInBetweenItems)
             make.centerX.equalTo(emptyStateImageView)
-        }
-
-        createAnAccountButton.snp.makeConstraints { (make) -> Void in
-            make.centerX.equalTo(signInButton)
-            make.top.equalTo(signInButton.snp.bottom).offset(RemoteTabsPanelUX.EmptyStateTopPaddingInBetweenItems)
         }
 
         applyTheme()

--- a/Client/Frontend/Library/RemoteTabsPanel.swift
+++ b/Client/Frontend/Library/RemoteTabsPanel.swift
@@ -408,12 +408,6 @@ class RemoteTabsNotLoggedInCell: UITableViewCell {
         }
     }
 
-    @objc fileprivate func createAnAccount() {
-        if let libraryPanel = self.libraryPanel {
-            libraryPanel.libraryPanelDelegate?.libraryPanelDidRequestToCreateAccount()
-        }
-    }
-
     override func updateConstraints() {
         if UIApplication.shared.statusBarOrientation.isLandscape && !(DeviceInfo.deviceModel().range(of: "iPad") != nil) {
             instructionsLabel.snp.remakeConstraints { make in

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -239,6 +239,7 @@ extension Strings {
     // Settings strings
     public static let FxAFirefoxAccount = NSLocalizedString("FxA.FirefoxAccount", value: "Firefox Account", comment: "Settings section title for Firefox Account")
     public static let FxASignInToSync = NSLocalizedString("FxA.SignIntoSync", value: "Sign In to Sync", comment: "Button label to sign into Sync")
+    public static let FxASignInToFirefox = NSLocalizedString("FxA.SignIntoFirefox", value: "Sign In to Firefox", comment: "Button label to sign into Firefox")
     public static let FxATakeYourWebWithYou = NSLocalizedString("FxA.TakeYourWebWithYou", value: "Take Your Web With You", comment: "Call to action for sign into sync button")
     public static let FxASyncUsageDetails = NSLocalizedString("FxA.SyncExplain", value: "Get your tabs, bookmarks, and passwords from your other devices.", comment: "Label explaining what sync does")
     public static let FxAAccountVerificationRequired = NSLocalizedString("FxA.AccountVerificationRequired", value: "Account Verification Required", comment: "Label stating your account is not verified")

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -238,7 +238,7 @@ extension Strings {
 extension Strings {
     // Settings strings
     public static let FxAFirefoxAccount = NSLocalizedString("FxA.FirefoxAccount", value: "Firefox Account", comment: "Settings section title for Firefox Account")
-    public static let FxASignInToSync = NSLocalizedString("FxA.SignIntoSync", value: "Sign in to Sync", comment: "Button label to sign into Sync")
+    public static let FxASignInToSync = NSLocalizedString("FxA.SignIntoSync", value: "Sign In to Sync", comment: "Button label to sign into Sync")
     public static let FxATakeYourWebWithYou = NSLocalizedString("FxA.TakeYourWebWithYou", value: "Take Your Web With You", comment: "Call to action for sign into sync button")
     public static let FxASyncUsageDetails = NSLocalizedString("FxA.SyncExplain", value: "Get your tabs, bookmarks, and passwords from your other devices.", comment: "Label explaining what sync does")
     public static let FxAAccountVerificationRequired = NSLocalizedString("FxA.AccountVerificationRequired", value: "Account Verification Required", comment: "Label stating your account is not verified")

--- a/Extensions/ShareTo/SendToDevice.swift
+++ b/Extensions/ShareTo/SendToDevice.swift
@@ -21,6 +21,10 @@ class SendToDevice: DevicePickerViewControllerDelegate, InstructionsViewControll
         devicePickerViewController.profile = nil // This means the picker will open and close the default profile
         return devicePickerViewController
     }
+    
+    func instructionsViewDidRequestToSignIn() {
+        
+    }
 
     func finish() {
         delegate?.finish(afterDelay: 0)


### PR DESCRIPTION
1. Created account link on synced tabs page has been removed, as shown in the new spec.
2. Sign in button on send to device page has been added matching the new spec.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-722)
