### PR TITLE
Bug 1638073 - Update api to be appropriate for firefoxci

### DIFF
--- a/SyncIntegrationTests/conftest.py
+++ b/SyncIntegrationTests/conftest.py
@@ -45,11 +45,11 @@ def tps_addon(pytestconfig, tmpdir_factory):
     path = pytestconfig.getoption('tps')
     if path is not None:
         return path
-    task_url = 'https://index.taskcluster.net/v1/task/' \
+    task_url = 'https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/' \
                'gecko.v2.mozilla-central.latest.firefox.addons.tps'
     task_id = requests.get(task_url).json().get('taskId')
     cache_dir = str(pytestconfig.cache.makedir('tps-{}'.format(task_id)))
-    addon_url = 'https://queue.taskcluster.net/v1/task/' \
+    addon_url = 'https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/' \
                 '{}/artifacts/public/tps.xpi'.format(task_id)
     scraper = DirectScraper(addon_url, destination=cache_dir)
     return scraper.download()


### PR DESCRIPTION
This should make the tps xpi actually found in current automation