### PR TITLE
Added debug menu to show type of leanplum settup

### DIFF
--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -537,6 +537,14 @@ class ToggleOnboarding: HiddenSetting {
     }
 }
 
+class LeanplumStatus: HiddenSetting {
+    let lplumSetupType = LeanPlumClient.shared.lpSetupType()
+
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: "Leamplum Status: \(lplumSetupType) | Started: \(LeanPlumClient.shared.isRunning())", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+    }
+}
+
 class SetOnboardingV2: HiddenSetting {
     override var title: NSAttributedString? {
         return NSAttributedString(string: NSLocalizedString("Debug: Set onboarding type to v2", comment: "Debug option"), attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -137,7 +137,8 @@ class AppSettingsTableViewController: SettingsTableViewController {
                 ForgetSyncAuthStateDebugSetting(settings: self),
                 SentryIDSetting(settings: self),
                 ChangeToChinaSetting(settings: self),
-                ToggleOnboarding(settings: self)
+                ToggleOnboarding(settings: self),
+                LeanplumStatus(settings: self)
             ])]
 
         return settings


### PR DESCRIPTION
The debug menu should show status as: 
- debug
- production 
- none (meaning nothing is setup) 

The started option shows if leanplum has started and is running: 

<img width="368" alt="image" src="https://user-images.githubusercontent.com/8919439/82350018-ccff1700-99c8-11ea-9597-27a8a67f7283.png">
