### PR TITLE
Added showOnboardingScreen_2 variable for AB test

### DIFF
--- a/Client/UserResearch/OnboardingUserResearch.swift
+++ b/Client/UserResearch/OnboardingUserResearch.swift
@@ -7,7 +7,10 @@ import Leanplum
 import Shared
 
 struct LPVariables {
-    static var showOnboardingScreen = LPVar.define("showOnboardingScreen", with: true)
+    // Variable Used for AA test
+    static var showOnboardingScreenAA = LPVar.define("showOnboardingScreen", with: true)
+    // Variable Used for AB test
+    static var showOnboardingScreenAB = LPVar.define("showOnboardingScreen_2", with: true)
 }
 
 enum OnboardingScreenType: String {
@@ -42,7 +45,7 @@ class OnboardingUserResearch {
     }
     
     // MARK: Initializer
-    init(lpVariable: LPVar? = LPVariables.showOnboardingScreen) {
+    init(lpVariable: LPVar? = LPVariables.showOnboardingScreenAB) {
         self.lpVariable = lpVariable
     }
     


### PR DESCRIPTION
Theory is Leanplum requires a new variable setup for AB test and we cannot use the old AA test variable. 

I tested the a debug build pointing to leanplum production via BB ipa and that seems to work properly by setting up a new variable. Now only option left is to see if this works in v26.x beta or I need to setup a new variable for beta.

Have also contacted LP support for some answers on why our old variable isn't working in Firefox beta 

**Test BuddyBuild:** Should only present the new onboarding screen 
- https://dashboard.buddybuild.com/apps/57bf25c0f096bc01001e21e0/build/5ec4ac764b93000001b5efaa  

