### PR TITLE
Making Leanplum Sync more robust

### DIFF
--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -147,6 +147,10 @@ class LeanPlumClient {
     func setup(profile: Profile) {
         self.profile = profile
     }
+    
+    func forceVariableUpdate() {
+        Leanplum.forceContentUpdate()
+    }
 
     func recordSyncedClients(with profile: Profile?) {
         guard let profile = profile as? BrowserProfile else {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2013,6 +2013,12 @@ extension BrowserViewController {
             showProperIntroVC()
             return
         }
+        // forceVariableUpdate - Thie method from Leanplum is used
+        // to re-sync variable and ensures that if any variable
+        // has changed on the Leanplum server side we receive
+        // variable changed callback
+        // Ref: https://docs.leanplum.com/reference#callbacks
+        LeanPlumClient.shared.forceVariableUpdate()
         // Condition: Update from leanplum server
         // Get the A/B test variant from leanplum server
         // and update onboarding user reasearch
@@ -2029,7 +2035,7 @@ extension BrowserViewController {
         // with true (True = .variant 1)
         // Ex. Internet connection is unstable due to which
         // leanplum isn't loading or taking too much time
-        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             guard self.onboardingUserResearch?.updatedLPVariables != nil else {
                 return
             }

--- a/Client/UserResearch/OnboardingUserResearch.swift
+++ b/Client/UserResearch/OnboardingUserResearch.swift
@@ -28,7 +28,7 @@ class OnboardingUserResearch {
     // Saving user defaults
     private let defaults = UserDefaults.standard
     // Publicly accessible onboarding screen type
-    var onboardingScreenType:OnboardingScreenType? {
+    var onboardingScreenType: OnboardingScreenType? {
         set(value) {
             if value == nil {
                 defaults.removeObject(forKey: onboardingScreenTypeKey)


### PR DESCRIPTION
From talking with a LP engineer one way to ensure that we get the latest variable is to re-sync.

We should get a callback when LP starts but for any reason if we do not get a callback just like in case of our showOnboarding variable we can always re-sync values from the server in an active session.

Hence, added support for Leanplum force content update to re-sync variables from server. Also, reduced the time to show default onboarding screen if Leanplum isn't available back 2 sec

Ref: https://docs.leanplum.com/reference#callbacks