### PR TITLE
Added leanplum debug menu option to clear onboarding and also copy LP Device ID

### DIFF
--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -118,6 +118,9 @@ class LeanPlumClient {
     private var prefs: Prefs? { return profile?.prefs }
     private var enabled: Bool = true
     private var setupType: LPSetupType = .none
+    var deviceId: String? {
+        return Leanplum.deviceId()
+    }
     // This defines an external Leanplum varible to enable/disable FxA prepush dialogs.
     // The primary result is having a feature flag controlled by Leanplum, and falling back
     // to prompting with native push permissions.

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -539,9 +539,34 @@ class ToggleOnboarding: HiddenSetting {
 
 class LeanplumStatus: HiddenSetting {
     let lplumSetupType = LeanPlumClient.shared.lpSetupType()
-
     override var title: NSAttributedString? {
-        return NSAttributedString(string: "Leamplum Status: \(lplumSetupType) | Started: \(LeanPlumClient.shared.isRunning())", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: "Leamplum Status: \(lplumSetupType) | Started: \(LeanPlumClient.shared.isRunning())\nLeanplum Devide ID - \(LeanPlumClient.shared.deviceId ?? "")", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+    }
+    
+    override func onClick(_ navigationController: UINavigationController?) {
+        copyLeanplumDeviceIDAndPresentAlert(by: navigationController)
+    }
+    
+    func copyLeanplumDeviceIDAndPresentAlert(by navigationController: UINavigationController?) {
+        let alertTitle = Strings.SettingsCopyAppVersionAlertTitle
+        let alert = AlertController(title: alertTitle, message: nil, preferredStyle: .alert)
+        UIPasteboard.general.string = "\(LeanPlumClient.shared.deviceId ?? "")"
+        navigationController?.topViewController?.present(alert, animated: true) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                alert.dismiss(animated: true)
+            }
+        }
+    }
+}
+
+class ClearOnboardingDefaults: HiddenSetting {
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: NSLocalizedString("Debug: Clear onboarding defaults", comment: "Debug option"), attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+    }
+    
+    override func onClick(_ navigationController: UINavigationController?) {
+        settings.profile.prefs.removeObjectForKey(PrefsKeys.IntroSeen)
+        OnboardingUserResearch().onboardingScreenType = nil
     }
 }
 

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -559,9 +559,16 @@ class LeanplumStatus: HiddenSetting {
     }
 }
 
-class ClearOnboardingDefaults: HiddenSetting {
+class ClearOnboardingConstantValues: HiddenSetting {
     override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Debug: Clear onboarding defaults", comment: "Debug option"), attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        // Onboarding constant values are saved to not show the onboarding screen after user
+        // has already seen it and is dismissed. We however clear it here in this hidden setting
+        // so that when user reopens the app or when browser view controller is re-initialized
+        // we see the onboarding screen again.
+        //
+        // If we are running an A/B test this will also fetch the A/B test variables from
+        // leanplum.
+        return NSAttributedString(string: NSLocalizedString("Debug: Clear onboarding variables", comment: "Debug option"), attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
     
     override func onClick(_ navigationController: UINavigationController?) {

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -138,7 +138,8 @@ class AppSettingsTableViewController: SettingsTableViewController {
                 SentryIDSetting(settings: self),
                 ChangeToChinaSetting(settings: self),
                 ToggleOnboarding(settings: self),
-                LeanplumStatus(settings: self)
+                LeanplumStatus(settings: self),
+                ClearOnboardingDefaults(settings: self)
             ])]
 
         return settings

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -139,7 +139,7 @@ class AppSettingsTableViewController: SettingsTableViewController {
                 ChangeToChinaSetting(settings: self),
                 ToggleOnboarding(settings: self),
                 LeanplumStatus(settings: self),
-                ClearOnboardingDefaults(settings: self)
+                ClearOnboardingConstantValues(settings: self)
             ])]
 
         return settings


### PR DESCRIPTION
- This will help in testing onboarding cards in beta for different version
Ex. we want to change the AB test to show version B then we can go to the Leanplum AB test change the variable and on the app side just clear the onboarding defaults. This will trigger refresh when user comes back to BVC

- Adding the ability to copy device id in debug menu will help in finding the QA device for the user in LP and gather the result values in real time
