### PR TITLE
For #6652 - XCUITests fix FxA tests after new ui for QR code

### DIFF
--- a/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -110,4 +110,10 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
            snapshot("MenuOnWebPage-03")
            navigator.back()
        }
+
+    func test11FxASignInPage() {
+        navigator.goto(Intro_FxASignin)
+        waitForExistence(app.navigationBars["Client.FirefoxAccountSignInView"])
+        snapshot("FxASignInScreen-01")
+    }
 }

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -52,6 +52,7 @@ class FirefoxAccountSignInViewController: UIViewController {
         button.setImage(UIImage(named: "qr-code-icon-white"), for: .highlighted)
         let imageWidth = button.imageView?.frame.width ?? 0.0
         button.setTitle(Strings.FxASignin_QRScanSignin, for: .normal)
+        button.accessibilityIdentifier = "QRCodeSignIn.button"
         button.titleLabel?.font = DynamicFontHelper().MediumSizeBoldFontAS
         button.titleEdgeInsets = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 0)
         button.addTarget(self, action: #selector(scanbuttonTapped), for: .touchUpInside)
@@ -66,6 +67,7 @@ class FirefoxAccountSignInViewController: UIViewController {
         button.layer.borderWidth = 1
         button.layer.cornerRadius = 8
         button.setTitle(Strings.FxASignin_EmailSignin, for: .normal)
+        button.accessibilityIdentifier = "EmailSignIn.button"
         button.addTarget(self, action: #selector(emailLoginTapped), for: .touchUpInside)
         button.titleLabel?.font = DynamicFontHelper().MediumSizeBoldFontAS
         return button

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -25,6 +25,7 @@ let SyncSettings = "SyncSettings"
 let FxASigninScreen = "FxASigninScreen"
 let FxCreateAccount = "FxCreateAccount"
 let FxAccountManagementPage = "FxAccountManagementPage"
+let Intro_FxASigninEmail = "Intro_FxASigninEmail"
 let HomeSettings = "HomeSettings"
 let SiriSettings = "SiriSettings"
 let PasscodeSettings = "PasscodeSettings"
@@ -183,6 +184,9 @@ class Action {
 
     static let CloseTab = "CloseTab"
     static let CloseTabFromTabTrayLongPressMenu = "CloseTabFromTabTrayLongPressMenu"
+
+    static let OpenEmailToSignIn = "OpenEmailToSignIn"
+    static let OpenEmailToQR = "OpenEmailToQR"
 
     static let FxATypeEmail = "FxATypeEmail"
     static let FxATypePassword = "FxATypePassword"
@@ -617,7 +621,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         let table = app.tables.element(boundBy: 0)
 
         screenState.tap(table.cells["Sync"], to: SyncSettings, if: "fxaUsername != nil")
-        screenState.tap(table.cells["SignInToSync"], to: FxASigninScreen, if: "fxaUsername == nil")
+        screenState.tap(table.cells["SignInToSync"], to: Intro_FxASignin, if: "fxaUsername == nil")
         screenState.tap(table.cells["Search"], to: SearchSettings)
         screenState.tap(table.cells["NewTab"], to: NewTabSettings)
         screenState.tap(table.cells["Home"], to: HomeSettings)
@@ -697,8 +701,8 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
                 app.webViews.textFields.firstMatch.tap()
                 app.webViews.textFields.firstMatch.typeText(userState.fxaUsername!)
             } else {
-                app.textFields.element(boundBy: 0).tap()
-                app.textFields.element(boundBy: 0).typeText(userState.fxaUsername!)
+                app.textFields["Email"].tap()
+                app.textFields["Email"].typeText(userState.fxaUsername!)
             }
         }
         screenState.gesture(forAction: Action.FxATypePassword) { userState in
@@ -914,7 +918,9 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     map.addScreenState(Intro_FxASignin) { screenState in
-        screenState.tap(app.navigationBars["Client.FxAContentView"].buttons.element(boundBy: 0), to: HomePanelsScreen)
+        screenState.tap(app.navigationBars["Client.FirefoxAccountSignInView"].buttons.element(boundBy: 0), to: HomePanelsScreen)
+        screenState.tap(app.buttons["EmailSignIn.button"], forAction: Action.OpenEmailToSignIn, transitionTo: FxASigninScreen)
+        screenState.tap(app.buttons["QRCodeSignIn.button"], forAction: Action.OpenEmailToQR, transitionTo: Intro_FxASignin)
     }
 
     map.addScreenState(TabTray) { screenState in
@@ -1086,7 +1092,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     map.addScreenState(BrowserTabMenu) { screenState in
         screenState.tap(app.tables.cells["menu-Settings"], to: SettingsScreen)
-        screenState.tap(app.tables.cells["menu-sync"], to: FxASigninScreen, if: "fxaUsername == nil")
+        screenState.tap(app.tables.cells["menu-sync"], to: Intro_FxASignin, if: "fxaUsername == nil")
         screenState.tap(app.tables.cells["key"], to: LoginsSettings)
         screenState.tap(app.tables.cells["menu-library"], to: HomePanel_Library)
         screenState.tap(app.tables.cells["placeholder-avatar"], to: FxAccountManagementPage)

--- a/XCUITests/IntegrationTests.swift
+++ b/XCUITests/IntegrationTests.swift
@@ -38,7 +38,8 @@ class IntegrationTests: BaseTestCase {
     }
 
     private func signInFxAccounts() {
-        navigator.goto(FxASigninScreen)
+        navigator.goto(Intro_FxASignin)
+        navigator.performAction(Action.OpenEmailToSignIn)
         sleep(5)
         waitForExistence(app.navigationBars["Client.FxAWebView"], timeout: 20)
         userState.fxaUsername = ProcessInfo.processInfo.environment["FXA_EMAIL"]!

--- a/XCUITests/NavigationTest.swift
+++ b/XCUITests/NavigationTest.swift
@@ -76,6 +76,7 @@ class NavigationTest: BaseTestCase {
     func testTapSignInShowsFxAFromTour() {
         // Open FxAccount from tour option in settings menu and go throughout all the screens there
         navigator.goto(Intro_FxASignin)
+        navigator.performAction(Action.OpenEmailToSignIn)
         checkFirefoxSyncScreenShown()
 
         // Disabled due to issue 5937, not possible to tap on Close button
@@ -92,14 +93,19 @@ class NavigationTest: BaseTestCase {
         checkFirefoxSyncScreenShownViaSettings()
 
         // After that it is possible to go back to Settings
-        let settingsButton = app.navigationBars["Client.FxAWebView"].buttons["Settings"]
-        settingsButton.tap()
+        let closeButton = app.navigationBars["Client.FxAWebView"].buttons["Close"]
+        closeButton.tap()
+
+        let closeButtonFxView = app.navigationBars["Client.FirefoxAccountSignInView"].buttons["Settings"]
+        closeButtonFxView.tap()
     }
     
     // Beacuse the Settings menu does not stretch tot the top we need a different function to check if the Firefox Sync screen is shown
     private func checkFirefoxSyncScreenShownViaSettings() {
-        waitForExistence(app.navigationBars["Client.FxAWebView"], timeout: 20)
+        waitForExistence(app.navigationBars["Client.FirefoxAccountSignInView"], timeout: 20)
+        app.buttons["EmailSignIn.button"].tap()
         waitForExistence(app.webViews.textFields.element(boundBy: 0), timeout:20)
+
         let email = app.webViews.textFields.element(boundBy: 0)
         // Verify the placeholdervalues here for the textFields
         let mailPlaceholder = "Email"
@@ -112,10 +118,9 @@ class NavigationTest: BaseTestCase {
         navigator.goto(LibraryPanel_SyncedTabs)
 
         app.tables.buttons["Sign in to Sync"].tap()
+        waitForExistence(app.buttons["EmailSignIn.button"], timeout: 10)
+        app.buttons["EmailSignIn.button"].tap()
         checkFirefoxSyncScreenShown()
-        
-        app.navigationBars["Client.FxAWebView"].buttons["Close"].tap()
-        navigator.nowAt(LibraryPanel_SyncedTabs)
     }
 
     private func checkFirefoxSyncScreenShown() {

--- a/XCUITests/SyncFAUITests.swift
+++ b/XCUITests/SyncFAUITests.swift
@@ -24,15 +24,8 @@ class SyncUITests: BaseTestCase {
         // Check menu available from HomeScreenPanel
         navigator.goto(BrowserTabMenu)
         waitForExistence(app.tables["Context Menu"].cells["menu-sync"])
-        navigator.goto(FxASigninScreen)
-        verifyFxASigninScreen()
-
-        // Check menu available from a website
-        navigator.openURL("mozilla.org")
-        waitUntilPageLoad()
-        navigator.goto(BrowserTabMenu)
-        waitForExistence(app.tables["Context Menu"].cells["menu-sync"])
-        navigator.goto(FxASigninScreen)
+        navigator.goto(Intro_FxASignin)
+        navigator.performAction(Action.OpenEmailToSignIn)
         verifyFxASigninScreen()
     }
 
@@ -57,12 +50,7 @@ class SyncUITests: BaseTestCase {
         waitForExistence(app.webViews.staticTexts["Valid email required"])
 
         // Enter only email, wrong and correct and tap sign in
-        userState.fxaUsername = "bademail"
-        navigator.performAction(Action.FxATypeEmail)
-        navigator.performAction(Action.FxATapOnContinueButton)
-        waitForExistence(app.webViews.staticTexts["Valid email required"])
-
-        userState.fxaUsername = "foo1bar2@gmail.com"
+        userState.fxaUsername = "foo1bar2baz3@gmail.com"
         navigator.performAction(Action.FxATypeEmail)
         navigator.performAction(Action.FxATapOnSignInButton)
 
@@ -103,6 +91,15 @@ class SyncUITests: BaseTestCase {
         // Remove the password typed, Show (password) option should not be shown
         app.secureTextFields.element(boundBy: 0).typeText(XCUIKeyboardKey.delete.rawValue)
         waitForNoExistence(app.webViews.staticTexts["Show password"])
+    }
+    
+    func testQRPairing() {
+        navigator.goto(Intro_FxASignin)
+        // QR does not work on sim but checking that the button works, no crash
+        navigator.performAction(Action.OpenEmailToQR)
+        waitForExistence(app.navigationBars["Client.FirefoxAccountSignInView"], timeout: 5)
+        app.navigationBars["Client.FirefoxAccountSignInView"].buttons["Close"].tap()
+        waitForExistence(app.collectionViews.cells["TopSitesCell"])
     }
 
     // Smoketest

--- a/XCUITests/ThirdPartySearchTest.swift
+++ b/XCUITests/ThirdPartySearchTest.swift
@@ -117,8 +117,9 @@ class ThirdPartySearchTest: BaseTestCase {
         
         let tablesQuery = app.tables
         let customengineurlTextView = tablesQuery.textViews["customEngineUrl"]
-        customengineurlTextView.staticTexts["URL (Replace Query with %s)"].tap()
-        customengineurlTextView.press(forDuration: 1.0)
+
+        XCTAssertTrue(tablesQuery.textViews["customEngineUrl"].staticTexts["URL (Replace Query with %s)"].exists)
+        customengineurlTextView.press(forDuration: 2.0)
         app.staticTexts["Paste"].tap()
         sleep(2)
         app.navigationBars.buttons["customEngineSaveButton"].tap()


### PR DESCRIPTION
There is a new  UI between pressing the sync button and seeing the FxA sign in page, tests  have to be updated with that
