### PR TITLE
title on FirefoxAccountSignInViewController, show instructions label in dark mode

### DIFF
--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -102,6 +102,7 @@ class FirefoxAccountSignInViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
+        title = Strings.FxASignin_Title
         addSubviews()
         addViewConstraints()
     }
@@ -161,7 +162,7 @@ class FirefoxAccountSignInViewController: UIViewController {
     @objc func emailLoginTapped(_ sender: UIButton) {
         let fxaWebVC = FxAWebViewController(pageType: .emailLoginFlow, profile: profile, dismissalStyle: .popToRootVC)
         UnifiedTelemetry.recordEvent(category: .firefoxAccount, method: .qrPairing, object: telemetryObject, extras: ["flow_type": "email"])
-        presentThemedViewController(navItemLocation: .Left, navItemText: .Close, vcBeingPresented: fxaWebVC, topTabsVisible: true)
+        presentThemedViewController(navItemLocation: .Left, navItemText: .Close, vcBeingPresented: fxaWebVC, topTabsVisible: false)
     }
 }
 

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -105,6 +105,7 @@ class FirefoxAccountSignInViewController: UIViewController {
         title = Strings.FxASignin_Title
         addSubviews()
         addViewConstraints()
+        handleDarkMode()
     }
     
     // MARK: Subview Layout Functions
@@ -145,6 +146,13 @@ class FirefoxAccountSignInViewController: UIViewController {
             make.centerX.equalToSuperview()
             make.width.equalTo(327)
             make.height.equalTo(44)
+        }
+    }
+    
+    func handleDarkMode() {
+        [qrSignInLabel, instructionsLabel].forEach {
+            // UI is not currently themeable, enforce black
+            $0.textColor = .black
         }
     }
     

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -162,7 +162,7 @@ class FirefoxAccountSignInViewController: UIViewController {
     @objc func emailLoginTapped(_ sender: UIButton) {
         let fxaWebVC = FxAWebViewController(pageType: .emailLoginFlow, profile: profile, dismissalStyle: .popToRootVC)
         UnifiedTelemetry.recordEvent(category: .firefoxAccount, method: .qrPairing, object: telemetryObject, extras: ["flow_type": "email"])
-        presentThemedViewController(navItemLocation: .Left, navItemText: .Close, vcBeingPresented: fxaWebVC, topTabsVisible: false)
+        presentThemedViewController(navItemLocation: .Left, navItemText: .Close, vcBeingPresented: fxaWebVC, topTabsVisible: true)
     }
 }
 


### PR DESCRIPTION
Fixes #6654 

"Turn on Sync" string was missing from the navigation bar of the new FirefoxAccountSignInViewController.  This PR adds it to the navigation bar and it is now visible.

