### PR TITLE
Fix telemetry events for qr feature

### DIFF
--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -200,7 +200,7 @@ enum NavigationPath {
             viewController.tabManager = tabManager
             controller.pushViewController(viewController, animated: true)
         case .fxa:
-            let viewController = bvc.getSignInOrFxASettingsVC(flowType: .emailLoginFlow)
+            let viewController = bvc.getSignInOrFxASettingsVC(flowType: .emailLoginFlow, referringPage: .settings)
             controller.pushViewController(viewController, animated: true)
         case .theme:
             controller.pushViewController(ThemeSettingsController(), animated: true)

--- a/Client/Frontend/Widgets/PhotonActionSheet/AppMenu.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/AppMenu.swift
@@ -79,12 +79,12 @@ extension PhotonActionSheetProtocol {
         return items
     }
 
-    func syncMenuButton(showFxA: @escaping (_ params: FxALaunchParams?, _ flowType: FxAPageType) -> Void) -> PhotonActionSheetItem? {
+    func syncMenuButton(showFxA: @escaping (_ params: FxALaunchParams?, _ flowType: FxAPageType,_ referringPage: ReferringPage) -> Void) -> PhotonActionSheetItem? {
         //profile.getAccount()?.updateProfile()
 
         let action: ((PhotonActionSheetItem, UITableViewCell) -> Void) = { action,_ in
             let fxaParams = FxALaunchParams(query: ["entrypoint": "browsermenu"])
-            showFxA(fxaParams, .emailLoginFlow)
+            showFxA(fxaParams, .emailLoginFlow, .appMenu)
         }
 
         let rustAccount = RustFirefoxAccounts.shared

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -159,17 +159,17 @@ class FirefoxAccountSignInViewController: UIViewController {
     
     /// Use email login button tapped
     @objc func emailLoginTapped(_ sender: UIButton) {
-        let fxaWebVC = FxAWebViewController(pageType: .emailLoginFlow, profile: profile, dismissalStyle: .popToRootVC)
+        let fxaWebVC = FxAWebViewController(pageType: .emailLoginFlow, profile: profile, dismissalStyle: .dismiss)
         UnifiedTelemetry.recordEvent(category: .firefoxAccount, method: .qrPairing, object: telemetryObject, extras: ["flow_type": "email"])
-        presentThemedViewController(navItemLocation: .Left, navItemText: .Close, vcBeingPresented: fxaWebVC, topTabsVisible: true)
+        navigationController?.pushViewController(fxaWebVC, animated: true)
     }
 }
 
 // MARK: QRCodeViewControllerDelegate Functions
 extension FirefoxAccountSignInViewController: QRCodeViewControllerDelegate {
     func didScanQRCodeWithURL(_ url: URL) {
-        let vc = FxAWebViewController(pageType: .qrCode(url: url.absoluteString), profile: profile, dismissalStyle: .popToRootVC)
-        presentThemedViewController(navItemLocation: .Left, navItemText: .Close, vcBeingPresented: vc, topTabsVisible: true)
+        let vc = FxAWebViewController(pageType: .qrCode(url: url.absoluteString), profile: profile, dismissalStyle: .dismiss)
+        navigationController?.pushViewController(vc, animated: true)
     }
 
     func didScanQRCodeWithText(_ text: String) {

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -77,6 +77,10 @@ class FirefoxAccountSignInViewController: UIViewController {
     /// telemetryObject deduced from parentType initializer is sent with telemetry events on button click
     private let telemetryObject: UnifiedTelemetry.EventObject
     
+    /// Dismissal style for FxAWebViewController
+    /// Changes based on whether or not this VC is launched from the app menu or settings
+    private let fxaDismissStyle: DismissType
+    
     // MARK: Init() and viewDidLoad()
     
     /// - Parameters:
@@ -87,10 +91,13 @@ class FirefoxAccountSignInViewController: UIViewController {
         switch parentType {
         case .appMenu:
             self.telemetryObject = .appMenu
+            self.fxaDismissStyle = .dismiss
         case .onboarding:
             self.telemetryObject = .onboarding
+            self.fxaDismissStyle = .dismiss
         case .settings:
             self.telemetryObject = .settings
+            self.fxaDismissStyle = .popToRootVC
         }
         super.init(nibName: nil, bundle: nil)
     }
@@ -159,7 +166,7 @@ class FirefoxAccountSignInViewController: UIViewController {
     
     /// Use email login button tapped
     @objc func emailLoginTapped(_ sender: UIButton) {
-        let fxaWebVC = FxAWebViewController(pageType: .emailLoginFlow, profile: profile, dismissalStyle: .dismiss)
+        let fxaWebVC = FxAWebViewController(pageType: .emailLoginFlow, profile: profile, dismissalStyle: fxaDismissStyle)
         UnifiedTelemetry.recordEvent(category: .firefoxAccount, method: .qrPairing, object: telemetryObject, extras: ["flow_type": "email"])
         navigationController?.pushViewController(fxaWebVC, animated: true)
     }
@@ -168,7 +175,7 @@ class FirefoxAccountSignInViewController: UIViewController {
 // MARK: QRCodeViewControllerDelegate Functions
 extension FirefoxAccountSignInViewController: QRCodeViewControllerDelegate {
     func didScanQRCodeWithURL(_ url: URL) {
-        let vc = FxAWebViewController(pageType: .qrCode(url: url.absoluteString), profile: profile, dismissalStyle: .dismiss)
+        let vc = FxAWebViewController(pageType: .qrCode(url: url.absoluteString), profile: profile, dismissalStyle: fxaDismissStyle)
         navigationController?.pushViewController(vc, animated: true)
     }
 


### PR DESCRIPTION
Previously, we were always setting `.appMenu` as the `parentPage` and `object` for Telemetry when you launched the sign in/sign up flow from the `BrowserViewController`.  This was incorrect as you can also come from the onboarding flow and enter the `BrowserViewController` `getSignInOrFxASettingsVC` function. This PR fixes that, so Telemetry event information is sent correctly according to requirements in #6436 

