### PR TITLE
Fix #6668 - Onboarding card should get built in theme on relaunch

### DIFF
--- a/Client/Frontend/Intro/IntroScreenSyncViewV2.swift
+++ b/Client/Frontend/Intro/IntroScreenSyncViewV2.swift
@@ -38,14 +38,14 @@ to make it center in the top container view.
 
 */
 
-class IntroScreenSyncViewV2: UIView {
+class IntroScreenSyncViewV2: UIView, CardTheme {
     // Private vars
     private var fxTextThemeColour: UIColor {
         // For dark theme we want to show light colours and for light we want to show dark colours
-        return UpdateViewController.theme == .dark ? .white : .black
+        return theme == .dark ? .white : .black
     }
     private var fxBackgroundThemeColour: UIColor {
-        return UpdateViewController.theme == .dark ? UIColor.Firefox.DarkGrey10 : .white
+        return theme == .dark ? UIColor.Firefox.DarkGrey10 : .white
     }
     private lazy var titleImageView: UIImageView = {
         let imgView = UIImageView(image: #imageLiteral(resourceName: "tour-sync-v2"))

--- a/Client/Frontend/Intro/IntroScreenWelcomeViewV2.swift
+++ b/Client/Frontend/Intro/IntroScreenWelcomeViewV2.swift
@@ -40,14 +40,14 @@ in the middle of the screen.
 
 */
 
-class IntroScreenWelcomeViewV2: UIView {
+class IntroScreenWelcomeViewV2: UIView, CardTheme {
     // Private vars
     private var fxTextThemeColour: UIColor {
         // For dark theme we want to show light colours and for light we want to show dark colours
-        return UpdateViewController.theme == .dark ? .white : .black
+        return theme == .dark ? .white : .black
     }
     private var fxBackgroundThemeColour: UIColor {
-        return UpdateViewController.theme == .dark ? UIColor.Firefox.DarkGrey10 : .white
+        return theme == .dark ? UIColor.Firefox.DarkGrey10 : .white
     }
     private lazy var titleImageView: UIImageView = {
         let imgView = UIImageView(image: #imageLiteral(resourceName: "splash"))

--- a/Client/Frontend/Intro/IntroViewModelV2.swift
+++ b/Client/Frontend/Intro/IntroViewModelV2.swift
@@ -11,6 +11,16 @@ struct ViewControllerConsts {
     }
 }
 
+protocol CardTheme {
+    var theme: BuiltinThemeName { get }
+}
+
+extension CardTheme {
+    var theme: BuiltinThemeName {
+        return BuiltinThemeName(rawValue: ThemeManager.instance.current.name) ?? .normal
+    }
+}
+
 // MARK: Requires Work (Currently part of A/B test)
 // Intro View Model V2 - This is suppose to be the main view model for the
 // IntroView V2 however since we are running an onboarding A/B test

--- a/Client/Frontend/Intro/IntroWelcomeAndSyncViewV1.swift
+++ b/Client/Frontend/Intro/IntroWelcomeAndSyncViewV1.swift
@@ -25,14 +25,14 @@ import Shared
 
  */
 
-class IntroWelcomeAndSyncViewV1: UIView {
+class IntroWelcomeAndSyncViewV1: UIView, CardTheme {
     // Private vars
     private var fxTextThemeColour: UIColor {
         // For dark theme we want to show light colours and for light we want to show dark colours
-        return UpdateViewController.theme == .dark ? .white : .black
+        return theme == .dark ? .white : .black
     }
     private var fxBackgroundThemeColour: UIColor {
-        return UpdateViewController.theme == .dark ? .black : .white
+        return theme == .dark ? .black : .white
     }
     // Screen constants
     private let screenHeight = UIScreen.main.bounds.size.height


### PR DESCRIPTION
Previously using a static variable was not giving the proper theme values. 
- Creating a protocol and adding variable to its extension is a better solution as it now allows the protocol to be consumed by multiple views. 
- It also allows the views to override values if needed 

<img src="https://user-images.githubusercontent.com/8919439/82686137-56aa2100-9c23-11ea-9452-cc3feccb958d.png" height="300">

<img src="https://user-images.githubusercontent.com/8919439/82686145-5873e480-9c23-11ea-8c23-4afe6033a21c.png" height="300">