### PR TITLE
set ThemedTableViewCell textLabel color to themes rowText color

### DIFF
--- a/Client/Frontend/Theme/ThemedWidgets.swift
+++ b/Client/Frontend/Theme/ThemedWidgets.swift
@@ -16,8 +16,8 @@ class ThemedTableViewCell: UITableViewCell, Themeable {
     }
 
     func applyTheme() {
+        textLabel?.textColor = UIColor.theme.tableView.rowText
         detailTextLabel?.textColor = detailTextColor
-
         backgroundColor = UIColor.theme.tableView.rowBackground
         tintColor = UIColor.theme.general.controlTint
     }


### PR DESCRIPTION
This PR is related to the issue https://github.com/mozilla-mobile/firefox-ios/issues/6352
The textLabels color of ThemedTableViewCell was never set to the a color from the themes color schema.

It's a very small fix, just a one liner!
