### PR TITLE
 LP - Updated sentry logging and modified leanplum integration

### DIFF
--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -199,6 +199,7 @@ class LeanPlumClient {
             return
         }
         
+        // To be removed after beta testing
         // Adding a self generated user device id because on firefox beta
         // device id always remains the same for iPhone
         if userDeviceId == nil && UIDevice.current.userInterfaceIdiom == .phone {
@@ -217,7 +218,8 @@ class LeanPlumClient {
             setupType = .production
         }
         
-        // Creating a beta user id for Leanplum testing as recommeded by LP Engineers
+        // To be removed after beta testing
+        // Creating a beta user id for Leanplum testing as recommedded by LP Engineers
         let userID = UUID().uuidString + "-Beta"
         Leanplum.setDeviceId(UIDevice.current.identifierForVendor?.uuidString)
         Leanplum.setAppId(LP_AppID, withDevelopmentKey: LP_Key)
@@ -236,6 +238,7 @@ class LeanPlumClient {
 
         self.setupCustomTemplates()
         lpState = .willStart
+        // To be removed after after beta testing - userID value
         Leanplum.start(withUserId: userID, userAttributes: attributes, responseHandler: { _ in
             self.track(event: .openedApp)
             self.onStartResponseStatus = true

--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -222,7 +222,6 @@ class LeanPlumClient {
         // Creating a beta user id for Leanplum testing as recommedded by LP Engineers
         let userID = UUID().uuidString + "-Beta"
         Leanplum.setDeviceId(UIDevice.current.identifierForVendor?.uuidString)
-        Leanplum.setAppId(LP_AppID, withDevelopmentKey: LP_Key)
         setupType = .debug
         
         Leanplum.syncResourcesAsync(true)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2037,9 +2037,18 @@ extension BrowserViewController {
             guard LeanPlumClient.shared.onStartLPVariable != nil else {
                 return
             }
-            Sentry.shared.send(message: "Onboarding Research: onStartLPVariable - LP State - \(LeanPlumClient.shared.lpState.rawValue) | Leanplum server too slow", tag: .leanplum, severity: .debug, description: "Leanplum server too slow")
+            let lpStartStatus = LeanPlumClient.shared.onStartResponseStatus
+            var lpVariableValue = true
+            // Condition: LP has already started but we missed onStartLPVariable callback
+            if lpStartStatus, let boolValue = LPVariables.showOnboardingScreenAB?.boolValue() {
+                lpVariableValue = boolValue
+                self.onboardingUserResearch?.updateTelemetry()
+                Sentry.shared.send(message: "Onboarding Research: onStartLPVariable - LP State - \(LeanPlumClient.shared.lpState.rawValue) | missed onStartLPVariable callback", tag: .leanplum, severity: .debug, description: "missed onStartLPVariable callback")
+            }else {
+                Sentry.shared.send(message: "Onboarding Research: onStartLPVariable - LP State - \(LeanPlumClient.shared.lpState.rawValue) | Leanplum server too slow", tag: .leanplum, severity: .debug, description: "Leanplum server too slow")
+            }
             self.onboardingUserResearch?.updatedLPVariables = nil
-            self.onboardingUserResearch?.updateValue(value: true)
+            self.onboardingUserResearch?.updateValue(value: lpVariableValue)
             self.showProperIntroVC()
         }
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2011,7 +2011,7 @@ extension BrowserViewController {
         // and get that from the server
         guard LeanPlumClient.shared.getSettings() != nil else {
             Sentry.shared.send(message: "Onboarding Research: onStartLPVariable - LP State - \(LeanPlumClient.shared.lpState.rawValue) | Condition: Leanplum is disabled", tag: .leanplum, severity: .debug, description: "Condition: Leanplum is disabled")
-            self.onboardingUserResearch?.updateValue(value: true)
+            self.onboardingUserResearch?.updateValue(onboardingScreenType: true)
             showProperIntroVC()
             return
         }
@@ -2024,7 +2024,7 @@ extension BrowserViewController {
             LeanPlumClient.shared.onStartLPVariable = nil
             print("lp Variable from server \(lpVariableValue)")
             self.onboardingUserResearch?.updateTelemetry()
-            self.onboardingUserResearch?.updateValue(value: lpVariable?.boolValue() ?? true)
+            self.onboardingUserResearch?.updateValue(onboardingScreenType: lpVariable?.boolValue() ?? true)
             self.showProperIntroVC()
         }
         // Conditon: Leanplum server too slow
@@ -2037,18 +2037,19 @@ extension BrowserViewController {
             guard LeanPlumClient.shared.onStartLPVariable != nil else {
                 return
             }
-            let lpStartStatus = LeanPlumClient.shared.onStartResponseStatus
+            // Refactor: lpVariable value to be .varient1 
+            let lpStartStatus = LeanPlumClient.shared.didReceiveLPStartResponse
             var lpVariableValue = true
             // Condition: LP has already started but we missed onStartLPVariable callback
             if lpStartStatus, let boolValue = LPVariables.showOnboardingScreenAB?.boolValue() {
                 lpVariableValue = boolValue
                 self.onboardingUserResearch?.updateTelemetry()
                 Sentry.shared.send(message: "Onboarding Research: onStartLPVariable - LP State - \(LeanPlumClient.shared.lpState.rawValue) | missed onStartLPVariable callback", tag: .leanplum, severity: .debug, description: "missed onStartLPVariable callback")
-            }else {
+            } else {
                 Sentry.shared.send(message: "Onboarding Research: onStartLPVariable - LP State - \(LeanPlumClient.shared.lpState.rawValue) | Leanplum server too slow", tag: .leanplum, severity: .debug, description: "Leanplum server too slow")
             }
             self.onboardingUserResearch?.updatedLPVariables = nil
-            self.onboardingUserResearch?.updateValue(value: lpVariableValue)
+            self.onboardingUserResearch?.updateValue(onboardingScreenType: lpVariableValue)
             self.showProperIntroVC()
         }
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2000,7 +2000,7 @@ extension BrowserViewController {
         // Our boolean variable shouldShow is used to present the onboarding
         // that was presented to the user during first launch
         if alwaysShow {
-            Sentry.shared.send(message: "Onboarding Research: LP State - \(LeanPlumClient.shared.lpState.rawValue)", tag: .leanplum, severity: .debug, description: "Condition: Always Show")
+            Sentry.shared.send(message: "Onboarding Research: LP State - \(LeanPlumClient.shared.lpState.rawValue) | Condition: Always Show", tag: .leanplum, severity: .debug, description: "Condition: Always Show")
             showProperIntroVC()
             return
         }
@@ -2010,7 +2010,7 @@ extension BrowserViewController {
         // False = .variant 2 which is our new Intro View that we are A/B testing against
         // and get that from the server
         guard LeanPlumClient.shared.getSettings() != nil else {
-            Sentry.shared.send(message: "Onboarding Research: LP State - \(LeanPlumClient.shared.lpState.rawValue)", tag: .leanplum, severity: .debug, description: "Condition: Leanplum is disabled")
+            Sentry.shared.send(message: "Onboarding Research: LP State - \(LeanPlumClient.shared.lpState.rawValue) | Condition: Leanplum is disabled", tag: .leanplum, severity: .debug, description: "Condition: Leanplum is disabled")
             self.onboardingUserResearch?.updateValue(value: true)
             showProperIntroVC()
             return
@@ -2020,14 +2020,14 @@ extension BrowserViewController {
         // has changed on the Leanplum server side we receive
         // variable changed callback
         // Ref: https://docs.leanplum.com/reference#callbacks
-        Sentry.shared.send(message: "Onboarding Research: LP State - \(LeanPlumClient.shared.lpState.rawValue)", tag: .leanplum, severity: .debug, description: "Forcing variable update from LP")
+        Sentry.shared.send(message: "Onboarding Research: LP State - \(LeanPlumClient.shared.lpState.rawValue) | Forcing variable update from LP", tag: .leanplum, severity: .debug, description: "Forcing variable update from LP")
         LeanPlumClient.shared.forceVariableUpdate()
         // Condition: Update from leanplum server
         // Get the A/B test variant from leanplum server
         // and update onboarding user reasearch
         onboardingUserResearch?.updatedLPVariables = {(lpVariable) -> () in
             let lpVariableValue = "\(String(describing: lpVariable?.boolValue()))"
-            Sentry.shared.send(message: "Onboarding Research: LP State - \(LeanPlumClient.shared.lpState.rawValue)", tag: .leanplum, severity: .debug, description: "Condition: Received update from LP server with variable value as - \(lpVariableValue)")
+            Sentry.shared.send(message: "Onboarding Research: LP State - \(LeanPlumClient.shared.lpState.rawValue) | Condition: Received update from LP server with variable value as - \(lpVariableValue)", tag: .leanplum, severity: .debug, description: "Condition: Received update from LP server with variable value as - \(lpVariableValue)")
             self.onboardingUserResearch?.updatedLPVariables = nil
             print("lp Variable from server \(lpVariableValue)")
             self.onboardingUserResearch?.updateTelemetry()
@@ -2044,8 +2044,7 @@ extension BrowserViewController {
             guard self.onboardingUserResearch?.updatedLPVariables != nil else {
                 return
             }
-            Sentry.shared.send(message: "Onboarding Research: LP State - \(LeanPlumClient.shared.lpState.rawValue)", tag: .leanplum, severity: .debug, description: "Leanplum server too slow")
-            Sentry.shared.send(message: "Failed to fetch A/B test variables from LP")
+            Sentry.shared.send(message: "Onboarding Research: LP State - \(LeanPlumClient.shared.lpState.rawValue) | Leanplum server too slow", tag: .leanplum, severity: .debug, description: "Leanplum server too slow")
             self.onboardingUserResearch?.updatedLPVariables = nil
             self.onboardingUserResearch?.updateValue(value: true)
             self.showProperIntroVC()

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2011,7 +2011,7 @@ extension BrowserViewController {
         // and get that from the server
         guard LeanPlumClient.shared.getSettings() != nil else {
             Sentry.shared.send(message: "Onboarding Research: onStartLPVariable - LP State - \(LeanPlumClient.shared.lpState.rawValue) | Condition: Leanplum is disabled", tag: .leanplum, severity: .debug, description: "Condition: Leanplum is disabled")
-            self.onboardingUserResearch?.updateValue(onboardingScreenType: true)
+            self.onboardingUserResearch?.updateValue(onboardingScreenType: .versionV1)
             showProperIntroVC()
             return
         }
@@ -2024,7 +2024,8 @@ extension BrowserViewController {
             LeanPlumClient.shared.onStartLPVariable = nil
             print("lp Variable from server \(lpVariableValue)")
             self.onboardingUserResearch?.updateTelemetry()
-            self.onboardingUserResearch?.updateValue(onboardingScreenType: lpVariable?.boolValue() ?? true)
+            let screenType: OnboardingScreenType = !(lpVariable?.boolValue() ?? false) ? .versionV2 : .versionV1
+            self.onboardingUserResearch?.updateValue(onboardingScreenType: screenType)
             self.showProperIntroVC()
         }
         // Conditon: Leanplum server too slow
@@ -2039,10 +2040,10 @@ extension BrowserViewController {
             }
             // Refactor: lpVariable value to be .varient1 
             let lpStartStatus = LeanPlumClient.shared.didReceiveLPStartResponse
-            var lpVariableValue = true
+            var lpVariableValue: OnboardingScreenType = .versionV1
             // Condition: LP has already started but we missed onStartLPVariable callback
             if lpStartStatus, let boolValue = LPVariables.showOnboardingScreenAB?.boolValue() {
-                lpVariableValue = boolValue
+                lpVariableValue = boolValue ? .versionV1 : .versionV2
                 self.onboardingUserResearch?.updateTelemetry()
                 Sentry.shared.send(message: "Onboarding Research: onStartLPVariable - LP State - \(LeanPlumClient.shared.lpState.rawValue) | missed onStartLPVariable callback", tag: .leanplum, severity: .debug, description: "missed onStartLPVariable callback")
             } else {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2000,7 +2000,7 @@ extension BrowserViewController {
         // Our boolean variable shouldShow is used to present the onboarding
         // that was presented to the user during first launch
         if alwaysShow {
-            Sentry.shared.send(message: "Onboarding Research: LP State - \(LeanPlumClient.shared.lpState.rawValue) | Condition: Always Show", tag: .leanplum, severity: .debug, description: "Condition: Always Show")
+            Sentry.shared.send(message: "Onboarding Research: onStartLPVariable - LP State - \(LeanPlumClient.shared.lpState.rawValue) | Condition: Always Show", tag: .leanplum, severity: .debug, description: "Condition: Always Show")
             showProperIntroVC()
             return
         }
@@ -2010,25 +2010,18 @@ extension BrowserViewController {
         // False = .variant 2 which is our new Intro View that we are A/B testing against
         // and get that from the server
         guard LeanPlumClient.shared.getSettings() != nil else {
-            Sentry.shared.send(message: "Onboarding Research: LP State - \(LeanPlumClient.shared.lpState.rawValue) | Condition: Leanplum is disabled", tag: .leanplum, severity: .debug, description: "Condition: Leanplum is disabled")
+            Sentry.shared.send(message: "Onboarding Research: onStartLPVariable - LP State - \(LeanPlumClient.shared.lpState.rawValue) | Condition: Leanplum is disabled", tag: .leanplum, severity: .debug, description: "Condition: Leanplum is disabled")
             self.onboardingUserResearch?.updateValue(value: true)
             showProperIntroVC()
             return
         }
-        // forceVariableUpdate - Thie method from Leanplum is used
-        // to re-sync variable and ensures that if any variable
-        // has changed on the Leanplum server side we receive
-        // variable changed callback
-        // Ref: https://docs.leanplum.com/reference#callbacks
-        Sentry.shared.send(message: "Onboarding Research: LP State - \(LeanPlumClient.shared.lpState.rawValue) | Forcing variable update from LP", tag: .leanplum, severity: .debug, description: "Forcing variable update from LP")
-        LeanPlumClient.shared.forceVariableUpdate()
         // Condition: Update from leanplum server
         // Get the A/B test variant from leanplum server
         // and update onboarding user reasearch
-        onboardingUserResearch?.updatedLPVariables = {(lpVariable) -> () in
+        LeanPlumClient.shared.onStartLPVariable = {(lpVariable) -> () in
             let lpVariableValue = "\(String(describing: lpVariable?.boolValue()))"
-            Sentry.shared.send(message: "Onboarding Research: LP State - \(LeanPlumClient.shared.lpState.rawValue) | Condition: Received update from LP server with variable value as - \(lpVariableValue)", tag: .leanplum, severity: .debug, description: "Condition: Received update from LP server with variable value as - \(lpVariableValue)")
-            self.onboardingUserResearch?.updatedLPVariables = nil
+            Sentry.shared.send(message: "Onboarding Research: onStartLPVariable - LP State - \(LeanPlumClient.shared.lpState.rawValue) | Condition: Received update from LP server with variable value as - \(lpVariableValue)", tag: .leanplum, severity: .debug, description: "Condition: Received update from LP server with variable value as - \(lpVariableValue)")
+            LeanPlumClient.shared.onStartLPVariable = nil
             print("lp Variable from server \(lpVariableValue)")
             self.onboardingUserResearch?.updateTelemetry()
             self.onboardingUserResearch?.updateValue(value: lpVariable?.boolValue() ?? true)
@@ -2041,10 +2034,10 @@ extension BrowserViewController {
         // Ex. Internet connection is unstable due to which
         // leanplum isn't loading or taking too much time
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            guard self.onboardingUserResearch?.updatedLPVariables != nil else {
+            guard LeanPlumClient.shared.onStartLPVariable != nil else {
                 return
             }
-            Sentry.shared.send(message: "Onboarding Research: LP State - \(LeanPlumClient.shared.lpState.rawValue) | Leanplum server too slow", tag: .leanplum, severity: .debug, description: "Leanplum server too slow")
+            Sentry.shared.send(message: "Onboarding Research: onStartLPVariable - LP State - \(LeanPlumClient.shared.lpState.rawValue) | Leanplum server too slow", tag: .leanplum, severity: .debug, description: "Leanplum server too slow")
             self.onboardingUserResearch?.updatedLPVariables = nil
             self.onboardingUserResearch?.updateValue(value: true)
             self.showProperIntroVC()

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -542,7 +542,7 @@ class ToggleOnboarding: HiddenSetting {
 class LeanplumStatus: HiddenSetting {
     let lplumSetupType = LeanPlumClient.shared.lpSetupType()
     override var title: NSAttributedString? {
-        return NSAttributedString(string: "Leamplum Status: \(lplumSetupType) | Started: \(LeanPlumClient.shared.isRunning())\nLeanplum Devide ID - \(LeanPlumClient.shared.deviceId ?? "")", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: "Leamplum Status: \(lplumSetupType) | Started: \(LeanPlumClient.shared.isRunning())\nLeanplum Devide ID - \(LeanPlumClient.shared.leanplumDeviceId ?? "")", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
     
     override func onClick(_ navigationController: UINavigationController?) {
@@ -552,7 +552,7 @@ class LeanplumStatus: HiddenSetting {
     func copyLeanplumDeviceIDAndPresentAlert(by navigationController: UINavigationController?) {
         let alertTitle = Strings.SettingsCopyAppVersionAlertTitle
         let alert = AlertController(title: alertTitle, message: nil, preferredStyle: .alert)
-        UIPasteboard.general.string = "\(LeanPlumClient.shared.deviceId ?? "")"
+        UIPasteboard.general.string = "\(LeanPlumClient.shared.leanplumDeviceId ?? "")"
         navigationController?.topViewController?.present(alert, animated: true) {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 alert.dismiss(animated: true)

--- a/Client/UserResearch/OnboardingUserResearch.swift
+++ b/Client/UserResearch/OnboardingUserResearch.swift
@@ -14,8 +14,8 @@ struct LPVariables {
 }
 
 enum OnboardingScreenType: String {
-    case versionV1 // Default
-    case versionV2 // New version 2
+    case versionV1 // V1 (Default)
+    case versionV2 // V2
 }
 
 class OnboardingUserResearch {
@@ -56,12 +56,12 @@ class OnboardingUserResearch {
         }
     }
     
-    func updateValue(value: Bool) {
+    func updateValue(onboardingScreenType: Bool) {
         // For LP variable below is the convention
         // we are going to follow
         // True = Current Onboarding Screen
         // False = New Onboarding Screen
-        onboardingScreenType = value ? .versionV1 : .versionV2
+        self.onboardingScreenType = onboardingScreenType ? .versionV1 : .versionV2
     }
     
     func updateTelemetry() {

--- a/Client/UserResearch/OnboardingUserResearch.swift
+++ b/Client/UserResearch/OnboardingUserResearch.swift
@@ -56,12 +56,12 @@ class OnboardingUserResearch {
         }
     }
     
-    func updateValue(onboardingScreenType: Bool) {
+    func updateValue(onboardingScreenType: OnboardingScreenType) {
         // For LP variable below is the convention
         // we are going to follow
         // True = Current Onboarding Screen
         // False = New Onboarding Screen
-        self.onboardingScreenType = onboardingScreenType ? .versionV1 : .versionV2
+        self.onboardingScreenType = onboardingScreenType
     }
     
     func updateTelemetry() {


### PR DESCRIPTION
Based on my testing, leanplum.start gets called the last out of all the callbacks. 
Keeping this in mind I am going to try the following approach with sending a callback after it starts.
```
        Leanplum.onStartResponse{ (success:Bool) in
            //3rd
        }
        lpShowOnboarding?.onValueChanged({
            //1st
        })
        Leanplum.onVariablesChanged {
            //2nd
        }
        Leanplum.start {
            //4th
        }
```