### PR TITLE
Fix #6668 - Old onboarding card should respect proper theme background

### DIFF
--- a/Client/Frontend/Intro/IntroWelcomeAndSyncViewV1.swift
+++ b/Client/Frontend/Intro/IntroWelcomeAndSyncViewV1.swift
@@ -159,12 +159,9 @@ class IntroWelcomeAndSyncViewV1: UIView, CardTheme {
     
     // MARK: View setup
     private func initialViewSetup() {
-        if #available(iOS 13, *) {
-           backgroundColor = .systemBackground
-        } else {
-           backgroundColor = .white
-        }
-        
+        // Background colour setup
+        backgroundColor = fxBackgroundThemeColour
+        // View setup
         main2panel.axis = .vertical
         main2panel.distribution = .fillEqually
     


### PR DESCRIPTION

<img src="https://user-images.githubusercontent.com/8919439/82832931-93c41c80-9e8a-11ea-9518-5a21e2422c80.png" height="300">

<img src="https://user-images.githubusercontent.com/8919439/82832923-91fa5900-9e8a-11ea-9459-11f3c8b58d95.png" height="300">


[RPReplay_Final1590427170.MP4.zip](https://github.com/mozilla-mobile/firefox-ios/files/4678265/RPReplay_Final1590427170.MP4.zip)
