### PR TITLE
 Fix #6687: QR pairing in China uses different url

### DIFF
--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -883,7 +883,7 @@ class PrivacyPolicySetting: Setting {
 class ChinaSyncServiceSetting: Setting {
     override var accessoryType: UITableViewCell.AccessoryType { return .none }
     var prefs: Prefs { return profile.prefs }
-    let prefKey = "useChinaSyncService"
+    let prefKey = PrefsKeys.KeyEnableChinaSyncService
     let profile: Profile
     let settings: UIViewController
 

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -42,20 +42,17 @@ class FirefoxAccountSignInViewController: UIViewController {
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
 
-        let globalUrl = "firefox.com/pair"
-        let chinaUrl = "firefox.com.cn/pair" // China uses a different pairing screen
+        let placeholder = "firefox.com/pair"
 
-        let msg: String
-        let boldString: String // for specifying the substring that becomes bold
-        if RustFirefoxAccounts.shared.isChinaSyncServiceEnabled {
-            msg = Strings.FxASignin_QRInstructions.replaceFirstOccurrence(of: globalUrl, with: chinaUrl)
-            boldString = chinaUrl
-        } else {
-            msg = Strings.FxASignin_QRInstructions
-            boldString = globalUrl
+        RustFirefoxAccounts.shared.accountManager.uponQueue(.main) { manager in
+            manager.getPairingAuthorityURL { result in
+                guard let url = try? result.get(), let host = url.host else { return }
+                let shortUrl = host + url.path // "firefox.com" + "/pair"
+                let msg = Strings.FxASignin_QRInstructions.replaceFirstOccurrence(of: placeholder, with: shortUrl)
+                label.attributedText = msg.attributedText(boldString: shortUrl, font: DynamicFontHelper().MediumSizeRegularWeightAS)
+            }
         }
 
-        label.attributedText = msg.attributedText(boldString: boldString, font: DynamicFontHelper().MediumSizeRegularWeightAS)
         return label
     }()
     

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -5,6 +5,7 @@
 import Foundation
 import SnapKit
 import Shared
+import Account
 
 /// Reflects parent page that launched FirefoxAccountSignInViewController
 enum FxASignInParentType {
@@ -40,7 +41,21 @@ class FirefoxAccountSignInViewController: UIViewController {
         label.textAlignment = .center
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
-        label.attributedText = Strings.FxASignin_QRInstructions.attributedText(boldString: "firefox.com/pair", font: DynamicFontHelper().MediumSizeRegularWeightAS)
+
+        let globalUrl = "firefox.com/pair"
+        let chinaUrl = "firefox.com.cn/pair" // China uses a different pairing screen
+
+        let msg: String
+        let boldString: String // for specifying the substring that becomes bold
+        if RustFirefoxAccounts.shared.isChinaSyncServiceEnabled {
+            msg = Strings.FxASignin_QRInstructions.replaceFirstOccurrence(of: globalUrl, with: chinaUrl)
+            boldString = chinaUrl
+        } else {
+            msg = Strings.FxASignin_QRInstructions
+            boldString = globalUrl
+        }
+
+        label.attributedText = msg.attributedText(boldString: boldString, font: DynamicFontHelper().MediumSizeRegularWeightAS)
         return label
     }()
     

--- a/RustFxA/RustFirefoxAccounts.swift
+++ b/RustFxA/RustFirefoxAccounts.swift
@@ -9,10 +9,10 @@ import SwiftKeychainWrapper
 let PendingAccountDisconnectedKey = "PendingAccountDisconnect"
 
 // Used to ignore unknown classes when de-archiving
-final class Unknown: NSObject, NSCoding  {
+final class Unknown: NSObject, NSCoding {
     func encode(with coder: NSCoder) {}
     init(coder aDecoder: NSCoder) {
-        super.init();
+        super.init()
     }
 }
 

--- a/RustFxA/RustFirefoxAccounts.swift
+++ b/RustFxA/RustFirefoxAccounts.swift
@@ -104,11 +104,19 @@ open class RustFirefoxAccounts {
         }
     }
 
+    public var isChinaSyncServiceEnabled: Bool {
+        return RustFirefoxAccounts.prefs?.boolForKey(PrefsKeys.KeyEnableChinaSyncService) ?? AppInfo.isChinaEdition
+    }
+
     private func createAccountManager() -> FxAccountManager {
         let prefs = RustFirefoxAccounts.prefs
         assert(prefs != nil)
-        let server = prefs?.intForKey(PrefsKeys.UseStageServer) == 1 ? FxAConfig.Server.stage :
-           (prefs?.boolForKey("useChinaSyncService") ?? AppInfo.isChinaEdition ? FxAConfig.Server.china : FxAConfig.Server.release)
+        let server: FxAConfig.Server
+        if prefs?.intForKey(PrefsKeys.UseStageServer) == 1 {
+            server = FxAConfig.Server.stage
+        } else {
+            server = isChinaSyncServiceEnabled ? FxAConfig.Server.china : FxAConfig.Server.release
+        }
 
         let config: FxAConfig
         let useCustom = prefs?.boolForKey(PrefsKeys.KeyUseCustomFxAContentServer) ?? false || prefs?.boolForKey(PrefsKeys.KeyUseCustomSyncTokenServerOverride) ?? false

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -5,6 +5,9 @@
 import Foundation
 
 public struct PrefsKeys {
+    // When this pref is set (by the user) it overrides default behaviour which is just based on app locale.
+    public static let KeyEnableChinaSyncService = "useChinaSyncService"
+
     public static let KeyLastRemoteTabSyncTime = "lastRemoteTabSyncTime"
     public static let KeyLastSyncFinishTime = "lastSyncFinishTime"
     public static let KeyDefaultHomePageURL = "KeyDefaultHomePageURL"


### PR DESCRIPTION
FIx in two commits, first is a cleanup of how we access the China state.