### PR TITLE
Fix searchbar hide issue

### DIFF
--- a/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
@@ -82,13 +82,6 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
         definesPresentationContext = true
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        // Allows the search bar to be scrolled away even though we initially show it.
-        navigationItem.hidesSearchBarWhenScrolling = true
-    }
-
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = ThemedTableViewCell(style: .default, reuseIdentifier: nil)
         let section = Section(rawValue: indexPath.section)!

--- a/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
@@ -76,10 +76,14 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
             searchController.searchBar.barStyle = .black
         }
         navigationItem.searchController = searchController
-        navigationItem.hidesSearchBarWhenScrolling = false
         self.searchController = searchController
 
         definesPresentationContext = true
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        unfoldSearchbar()
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -239,5 +243,10 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
         siteRecords = []
         showMoreButtonEnabled = false
         tableView.reloadData()
+    }
+    
+    private func unfoldSearchbar() {
+        guard let searchBarHeight = navigationItem.searchController?.searchBar.intrinsicContentSize.height else { return }
+        tableView.setContentOffset(CGPoint(x: 0, y: -searchBarHeight + tableView.contentOffset.y), animated: true)
     }
 }


### PR DESCRIPTION
This fixes issue https://github.com/mozilla-mobile/firefox-ios/issues/6684

For safeArea devices like iPhone X, iPhone 11 the current approach to initially set `hidesSearchBarWhenScrolling = false` and enable it in viewDidAppear does not work this way. The hiding of the searchBar does not work and the background of all top elements are broken.

Steps to fix this:

1.  We need to remove the lines mentioned above to have the default ios behaviour for searchbarController. This is a initially hidden searchbar which unfolds on drag. 
2. As we want to show the searchBar initially we have to drag programmatically. to do this we need to calculate the intrinsicContentSize of the searchBar and the tableView.contentOffset to move the contentOffset, this ends up in a nice animated unfolding of the searchbar, without backgroundColor issues and the ability to "hide" the searchBar on upscroll!

![Bildschirmvideo aufnehmen 2020-05-28 um 10 02 15](https://user-images.githubusercontent.com/15312205/83115462-ab89e380-a0ca-11ea-861e-7948c277dd97.gif)

