### PR TITLE
Bug 1636842 - part 3: Error out if errors are found while looking at …

### DIFF
--- a/taskcluster/scripts/check-screenshots.py
+++ b/taskcluster/scripts/check-screenshots.py
@@ -84,8 +84,7 @@ def _check_files(artifacts_directory, locales, number_of_screenshots_per_locale)
     if errors:
         error_list = "\n * ".join(errors)
         log.critical("Got {} error(s) while verifying screenshots: \n * {}".format(len(errors), error_list))
-        # TODO Uncomment the next line once screenshot tests are fixed on all locales.
-        # sys.exit(_FAILURE_EXIT_CODE)
+        sys.exit(_FAILURE_EXIT_CODE)
 
     log.info("No archive is missing and all of them contain the right number of screenshots!")
 


### PR DESCRIPTION
…screenshots

The [last run](https://firefox-ci-tc.services.mozilla.com/tasks/groups/XqK0nFXkRoq7c4Nytp5LfA) was error-free (I looked at all logs)! We're now ready to bail out if something looks wrong.
