### PR TITLE
 Fix #6721: FxAccountManger crash filling deferred 2x, make re-entrancy-safe

### DIFF
--- a/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
+++ b/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
@@ -55,7 +55,7 @@ class AdvancedAccountSettingViewController: SettingsTableViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        RustFirefoxAccounts.reconfig()
+        RustFirefoxAccounts.reconfig(prefs: profile.prefs)
     }
 
     override func generateSettings() -> [SettingSection] {

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -922,7 +922,7 @@ class ChinaSyncServiceSetting: Setting {
         UnifiedTelemetry.recordEvent(category: .action, method: .tap, object: .chinaServerSwitch)
         guard profile.rustFxA.hasAccount() else {
             prefs.setObject(toggle.isOn, forKey: prefKey)
-            RustFirefoxAccounts.reconfig()
+            RustFirefoxAccounts.reconfig(prefs: profile.prefs)
             return
         }
 
@@ -933,7 +933,7 @@ class ChinaSyncServiceSetting: Setting {
         let ok = UIAlertAction(title: Strings.OKString, style: .default) { _ in
             self.prefs.setObject(toggle.isOn, forKey: self.prefKey)
             self.profile.removeAccount()
-            RustFirefoxAccounts.reconfig()
+            RustFirefoxAccounts.reconfig(prefs: self.profile.prefs)
         }
         let cancel = UIAlertAction(title: Strings.CancelString, style: .default) { _ in
             toggle.setOn(!toggle.isOn, animated: true)

--- a/Shared/Extensions/HashExtensions.swift
+++ b/Shared/Extensions/HashExtensions.swift
@@ -57,18 +57,3 @@ extension Data {
     }
 }
 
-extension Data {
-    public func xoredWith(_ other: Data) -> Data? {
-        if self.count != other.count {
-            return nil
-        }
-        var xoredBytes = [UInt8](repeating: 0, count: self.count)
-        let selfBytes = (self as NSData).bytes.bindMemory(to: UInt8.self, capacity: self.count)
-        let otherBytes = (other as NSData).bytes.bindMemory(to: UInt8.self, capacity: other.count)
-        for i in 0..<self.count {
-            xoredBytes[i] = selfBytes[i] ^ otherBytes[i]
-        }
-        return Data(bytes: UnsafePointer<UInt8>(xoredBytes), count: self.count)
-    }
-
-}


### PR DESCRIPTION
Ignore whitespace when reviewing. Also snuck in a follow up commit that fixes an unrelated Xcode warning about unsafe code.