### PR TITLE
Fix #6611 - Updated sentry log message to include more details for failing to start Leanplum

### DIFF
--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -165,7 +165,7 @@ class LeanPlumClient {
     fileprivate func start() {
         guard let settings = getSettings(), isLocaleSupported(), !Leanplum.hasStarted() else {
             enabled = false
-            Sentry.shared.send(message: "LeanplumIntegration - Could not be started")
+            Sentry.shared.send(message: "LeanplumIntegration - Could not be started | Settings: \(String(describing: getSettings())) | isLocaleSupported: \(isLocaleSupported()) | Leanplum has not started: \(!Leanplum.hasStarted())")
             log.error("LeanplumIntegration - Could not be started")
             return
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -93,7 +93,7 @@ class BrowserViewController: UIViewController {
     var scrollController = TabScrollingController()
 
     fileprivate var keyboardState: KeyboardState?
-    fileprivate var hasTriedToPresentETPAlready = false
+    var hasTriedToPresentETPAlready = false
     var pendingToast: Toast? // A toast that might be waiting for BVC to appear before displaying
     var downloadToast: DownloadToast? // A toast that is showing the combined download progress
 

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -526,6 +526,27 @@ class SentryIDSetting: HiddenSetting {
     }
 }
 
+class ShowEtpCoverSheet: HiddenSetting {
+    let profile: Profile
+    
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: NSLocalizedString("Debug: Set ETP constants to show Cover Sheet", comment: "Debug option to show ETP Cover Sheet"), attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+    }
+    
+    override init(settings: SettingsTableViewController) {
+        self.profile = settings.profile
+        super.init(settings: settings)
+    }
+    
+    override func onClick(_ navigationController: UINavigationController?) {
+        BrowserViewController.foregroundBVC().hasTriedToPresentETPAlready = false
+        // ETP is shown when user opens app for 3rd time on clean install.
+        // Hence setting session to 2 (0,1,2) for 3rd install as it starts from 0 being 1st session
+        self.profile.prefs.setInt(2, forKey: PrefsKeys.KeyInstallSession)
+        self.profile.prefs.setString(ETPCoverSheetShowType.CleanInstall.rawValue, forKey: PrefsKeys.KeyETPCoverSheetShowType)
+    }
+}
+
 class ToggleOnboarding: HiddenSetting {
     override var title: NSAttributedString? {
         return NSAttributedString(string: NSLocalizedString("Debug: Toggle onboarding type", comment: "Debug option"), attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -530,7 +530,7 @@ class ShowEtpCoverSheet: HiddenSetting {
     let profile: Profile
     
     override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Debug: Set ETP constants to show Cover Sheet", comment: "Debug option to show ETP Cover Sheet"), attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: NSLocalizedString("Debug: ETP Cover Sheet On", comment: "Debug option to show ETP Cover Sheet"), attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
     
     override init(settings: SettingsTableViewController) {

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -138,7 +138,8 @@ class AppSettingsTableViewController: SettingsTableViewController {
                 SentryIDSetting(settings: self),
                 ChangeToChinaSetting(settings: self),
                 ToggleOnboarding(settings: self),
-                LeanplumStatus(settings: self)
+                LeanplumStatus(settings: self),
+                ShowEtpCoverSheet(settings: self)
             ])]
 
         return settings


### PR DESCRIPTION
Also, added option in debug menu to reset ETP Constants and show cover sheet when user goes back to browser view controller


