### PR TITLE
Fix #6692 - Moving most of the refactored leanplum A/B test changes from v26.0 to master

### DIFF
--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -147,11 +147,11 @@ class LeanPlumClient {
         assert(Thread.isMainThread)
         return UIApplication.isInPrivateMode
     }
-    
+
     func isLPEnabled() -> Bool {
         return enabled && Leanplum.hasStarted()
     }
-    
+
     func lpSetupType() -> LPSetupType {
         return setupType
     }
@@ -159,15 +159,15 @@ class LeanPlumClient {
     static func shouldEnable(profile: Profile) -> Bool {
         return AppConstants.MOZ_ENABLE_LEANPLUM && (profile.prefs.boolForKey(AppConstants.PrefSendUsageData) ?? true)
     }
-    
+
     func setup(profile: Profile) {
         self.profile = profile
     }
-    
+
     func forceVariableUpdate() {
         Leanplum.forceContentUpdate()
     }
-    
+
     func recordSyncedClients(with profile: Profile?) {
         guard let profile = profile as? BrowserProfile else {
             return

--- a/Client/Application/LeanplumIntegration.swift
+++ b/Client/Application/LeanplumIntegration.swift
@@ -117,6 +117,7 @@ enum LPState: String {
     case startedFirstRun
     case startedSecondRun
 }
+
 class LeanPlumClient {
     static let shared = LeanPlumClient()
 
@@ -126,12 +127,10 @@ class LeanPlumClient {
     private var enabled: Bool = true
     private var setupType: LPSetupType = .none
     // Boolean variable to indicate whether leanplum has finished starting-up
-    var startCallFinished: Bool = false
+//    var startCallFinished: Bool = false
     // Closure delegate for when leanplum has finished starting-up
     var finishedStartingLeanplum: (() -> Void)?
-    // leanplumDeviceId is what comes directly from leanplum and
-    // should be used and kept for showing the device ID in the
-    // debug menu so we can easily find the user in LP dashboard
+    // Comes from LeanPlum, used to show device ID in debug menu and finding user in LP dashboard"
     var leanplumDeviceId: String? {
         return Leanplum.deviceId()
     }
@@ -219,7 +218,8 @@ class LeanPlumClient {
             self.track(event: .openedApp)
 
             assert(Thread.isMainThread)
-            self.startCallFinished = true
+//            self.startCallFinished = true
+            self.lpState = .started
             // https://docs.leanplum.com/reference#callbacks
             // According to the doc all variables should be synced when lp start finishes
             // Relying on this fact and sending the updated AB test variable
@@ -236,7 +236,7 @@ class LeanPlumClient {
                 self.lpState = .startedSecondRun
             }
 
-            self.lpState = .started
+//            self.lpState = .started
             self.checkIfAppWasInstalled(key: PrefsKeys.HasFocusInstalled, isAppInstalled: self.focusInstalled(), lpEvent: .downloadedFocus)
             self.checkIfAppWasInstalled(key: PrefsKeys.HasPocketInstalled, isAppInstalled: self.pocketInstalled(), lpEvent: .downloadedPocket)
             self.recordSyncedClients(with: self.profile)

--- a/Client/Frontend/Intro/IntroScreenWelcomeViewV2.swift
+++ b/Client/Frontend/Intro/IntroScreenWelcomeViewV2.swift
@@ -82,7 +82,7 @@ class IntroScreenWelcomeViewV2: UIView, CardTheme {
         return button
     }()
     // Welcome card items share same type of label hence combining them into a
-    // struct so we can reuse it    
+    // struct so we can reuse it
     private struct WelcomeUICardItem {
         var title: String
         var description: String

--- a/Client/Frontend/Intro/IntroViewModelV2.swift
+++ b/Client/Frontend/Intro/IntroViewModelV2.swift
@@ -37,6 +37,10 @@ class IntroViewModelV2 {
     // Initializer
     init() {
         onboardingResearch = OnboardingUserResearch()
-        screenType = onboardingResearch?.onboardingScreenType
+        // Case: Older user who has updated to a newer version and is not a first time user
+        // When user updates from a version of app which didn't have the
+        // user research onboarding screen type and is trying to Always Show the screen
+        // from Show Tour, we default to our .version1 of the screen
+        screenType = onboardingResearch?.onboardingScreenType ?? .versionV1
     }
 }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -587,16 +587,10 @@ class LeanplumStatus: HiddenSetting {
     }
 }
 
-class ClearOnboardingConstantValues: HiddenSetting {
+class ClearOnboardingABVariables: HiddenSetting {
     override var title: NSAttributedString? {
-        // Onboarding constant values are saved to not show the onboarding screen after user
-        // has already seen it and is dismissed. We however clear it here in this hidden setting
-        // so that when user reopens the app or when browser view controller is re-initialized
-        // we see the onboarding screen again.
-        //
-        // If we are running an A/B test this will also fetch the A/B test variables from
-        // leanplum.
-        return NSAttributedString(string: NSLocalizedString("Debug: Clear onboarding variables", comment: "Debug option"), attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        // If we are running an A/B test this will also fetch the A/B test variables from leanplum. Re-open app to see the effect.
+        return NSAttributedString(string: NSLocalizedString("Debug: Clear onboarding AB variables", comment: "Debug option"), attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -598,7 +598,7 @@ class ClearOnboardingConstantValues: HiddenSetting {
         // leanplum.
         return NSAttributedString(string: NSLocalizedString("Debug: Clear onboarding variables", comment: "Debug option"), attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
-    
+
     override func onClick(_ navigationController: UINavigationController?) {
         settings.profile.prefs.removeObjectForKey(PrefsKeys.IntroSeen)
         OnboardingUserResearch().onboardingScreenType = nil

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -567,19 +567,41 @@ class ToggleOnboarding: HiddenSetting {
 
 class LeanplumStatus: HiddenSetting {
     let lplumSetupType = LeanPlumClient.shared.lpSetupType()
-
     override var title: NSAttributedString? {
-        return NSAttributedString(string: "Leamplum Status: \(lplumSetupType) | Started: \(LeanPlumClient.shared.isRunning())", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: "Leamplum Status: \(lplumSetupType) | Started: \(LeanPlumClient.shared.isRunning())\nLeanplum Devide ID - \(LeanPlumClient.shared.leanplumDeviceId ?? "")", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+    }
+    
+    override func onClick(_ navigationController: UINavigationController?) {
+        copyLeanplumDeviceIDAndPresentAlert(by: navigationController)
+    }
+    
+    func copyLeanplumDeviceIDAndPresentAlert(by navigationController: UINavigationController?) {
+        let alertTitle = Strings.SettingsCopyAppVersionAlertTitle
+        let alert = AlertController(title: alertTitle, message: nil, preferredStyle: .alert)
+        UIPasteboard.general.string = "\(LeanPlumClient.shared.leanplumDeviceId ?? "")"
+        navigationController?.topViewController?.present(alert, animated: true) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                alert.dismiss(animated: true)
+            }
+        }
     }
 }
 
-class SetOnboardingV2: HiddenSetting {
+class ClearOnboardingConstantValues: HiddenSetting {
     override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Debug: Set onboarding type to v2", comment: "Debug option"), attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        // Onboarding constant values are saved to not show the onboarding screen after user
+        // has already seen it and is dismissed. We however clear it here in this hidden setting
+        // so that when user reopens the app or when browser view controller is re-initialized
+        // we see the onboarding screen again.
+        //
+        // If we are running an A/B test this will also fetch the A/B test variables from
+        // leanplum.
+        return NSAttributedString(string: NSLocalizedString("Debug: Clear onboarding variables", comment: "Debug option"), attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
-
+    
     override func onClick(_ navigationController: UINavigationController?) {
-        OnboardingUserResearch().onboardingScreenType = .versionV2
+        settings.profile.prefs.removeObjectForKey(PrefsKeys.IntroSeen)
+        OnboardingUserResearch().onboardingScreenType = nil
     }
 }
 

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -568,7 +568,7 @@ class ToggleOnboarding: HiddenSetting {
 class LeanplumStatus: HiddenSetting {
     let lplumSetupType = LeanPlumClient.shared.lpSetupType()
     override var title: NSAttributedString? {
-        return NSAttributedString(string: "Leamplum Status: \(lplumSetupType) | Started: \(LeanPlumClient.shared.isRunning())\nLeanplum Devide ID - \(LeanPlumClient.shared.leanplumDeviceId ?? "")", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: "LP Setup: \(lplumSetupType) | Started: \(LeanPlumClient.shared.isRunning()) | Device ID: \(LeanPlumClient.shared.leanplumDeviceId ?? "")", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
     
     override func onClick(_ navigationController: UINavigationController?) {

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -139,7 +139,10 @@ class AppSettingsTableViewController: SettingsTableViewController {
                 ChangeToChinaSetting(settings: self),
                 ToggleOnboarding(settings: self),
                 LeanplumStatus(settings: self),
-                ShowEtpCoverSheet(settings: self)
+                ShowEtpCoverSheet(settings: self),
+                ToggleOnboarding(settings: self),
+                LeanplumStatus(settings: self),
+                ClearOnboardingConstantValues(settings: self)
             ])]
 
         return settings

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -142,7 +142,7 @@ class AppSettingsTableViewController: SettingsTableViewController {
                 ShowEtpCoverSheet(settings: self),
                 ToggleOnboarding(settings: self),
                 LeanplumStatus(settings: self),
-                ClearOnboardingConstantValues(settings: self)
+                ClearOnboardingABVariables(settings: self)
             ])]
 
         return settings

--- a/Client/UserResearch/OnboardingUserResearch.swift
+++ b/Client/UserResearch/OnboardingUserResearch.swift
@@ -81,7 +81,7 @@ class OnboardingUserResearch {
             let lpStartStatus = LeanPlumClient.shared.lpState
             var lpVariableValue: OnboardingScreenType = .versionV1
             // Condition: LP has already started but we missed onStartLPVariable callback
-            if lpStartStatus == .started, let boolValue = LPVariables.showOnboardingScreenAB?.boolValue() {
+            if case .started(startedState: _) = lpStartStatus , let boolValue = LPVariables.showOnboardingScreenAB?.boolValue() {
                 lpVariableValue = boolValue ? .versionV1 : .versionV2
                 self.updateTelemetry()
             }

--- a/Client/UserResearch/OnboardingUserResearch.swift
+++ b/Client/UserResearch/OnboardingUserResearch.swift
@@ -7,17 +7,20 @@ import Leanplum
 import Shared
 
 struct LPVariables {
-    static var showOnboardingScreen = LPVar.define("showOnboardingScreen", with: true)
+    // Variable Used for AA test
+    static var showOnboardingScreenAA = LPVar.define("showOnboardingScreen", with: true)
+    // Variable Used for AB test
+    static var showOnboardingScreenAB = LPVar.define("showOnboardingScreen_2", with: true)
 }
 
 enum OnboardingScreenType: String {
-    case versionV1 // Default
-    case versionV2 // New version 2
+    case versionV1 // V1 (Default)
+    case versionV2 // V2
 }
 
 class OnboardingUserResearch {
     // Closure delegate
-    var updatedLPVariables: ((LPVar?) -> Void)?
+    var updatedLPVariable: (() -> Void)?
     // variable
     var lpVariable: LPVar?
     // Constants
@@ -25,7 +28,7 @@ class OnboardingUserResearch {
     // Saving user defaults
     private let defaults = UserDefaults.standard
     // Publicly accessible onboarding screen type
-    var onboardingScreenType:OnboardingScreenType? {
+    var onboardingScreenType: OnboardingScreenType? {
         set(value) {
             if value == nil {
                 defaults.removeObject(forKey: onboardingScreenTypeKey)
@@ -42,23 +45,62 @@ class OnboardingUserResearch {
     }
     
     // MARK: Initializer
-    init(lpVariable: LPVar? = LPVariables.showOnboardingScreen) {
+    init(lpVariable: LPVar? = LPVariables.showOnboardingScreenAB) {
         self.lpVariable = lpVariable
     }
     
     // MARK: public
     func lpVariableObserver() {
-        Leanplum.onVariablesChanged {
-            self.updatedLPVariables?(self.lpVariable)
+        // Condition: Leanplum is disabled
+        // If leanplum is not enabled then we set the value of onboarding research to true
+        // True = .variant 1 which is our default Intro View
+        // False = .variant 2 which is our new Intro View that we are A/B testing against
+        // and get that from the server
+        guard LeanPlumClient.shared.getSettings() != nil else {
+            self.updateValue(onboardingScreenType: .versionV1)
+            self.updatedLPVariable?()
+            return
+        }
+        // Condition: Update from leanplum server
+        // Get the A/B test variant from leanplum server
+        // and update onboarding user reasearch
+        LeanPlumClient.shared.finishedStartingLeanplum = {
+            let showScreenA = LPVariables.showOnboardingScreenAB?.boolValue()
+            LeanPlumClient.shared.finishedStartingLeanplum = nil
+            self.updateTelemetry()
+            let screenType: OnboardingScreenType = (showScreenA ?? true) ? .versionV1 : .versionV2
+            self.updateValue(onboardingScreenType: screenType)
+            self.updatedLPVariable?()
+        }
+        // Conditon: Leanplum server too slow
+        // We don't want our users to be stuck on Onboarding
+        // Wait 2 second and update the onboarding research variable
+        // with true (True = .variant 1)
+        // Ex. Internet connection is unstable due to which
+        // leanplum isn't loading or taking too much time
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            guard LeanPlumClient.shared.finishedStartingLeanplum != nil else {
+                return
+            }
+            let lpStartStatus = LeanPlumClient.shared.startCallFinished
+            var lpVariableValue: OnboardingScreenType = .versionV1
+            // Condition: LP has already started but we missed onStartLPVariable callback
+            if lpStartStatus, let boolValue = LPVariables.showOnboardingScreenAB?.boolValue() {
+                lpVariableValue = boolValue ? .versionV1 : .versionV2
+                self.updateTelemetry()
+            }
+            self.updatedLPVariable = nil
+            self.updateValue(onboardingScreenType: lpVariableValue)
+            self.updatedLPVariable?()
         }
     }
     
-    func updateValue(value: Bool) {
+    func updateValue(onboardingScreenType: OnboardingScreenType) {
         // For LP variable below is the convention
         // we are going to follow
         // True = Current Onboarding Screen
         // False = New Onboarding Screen
-        onboardingScreenType = value ? .versionV1 : .versionV2
+        self.onboardingScreenType = onboardingScreenType
     }
     
     func updateTelemetry() {

--- a/Shared/SentryIntegration.swift
+++ b/Shared/SentryIntegration.swift
@@ -16,6 +16,7 @@ public enum SentryTag: String {
     case general = "General"
     case tabManager = "TabManager"
     case bookmarks = "Bookmarks"
+    case leanplum = "Leanplum"
 }
 
 public class Sentry {


### PR DESCRIPTION
Our v26.0 branch had lot of changes related to troubleshooting A/B test for user research. 

- In this minor refactor I moved chunk of code from BVC to onboarding user research class which is where it belongs
- Removed most sentry events from BVC related to leanplum 