### PR TITLE
Fix #6670: allow empty title for sendtab url

### DIFF
--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -489,8 +489,8 @@ open class BrowserProfile: Profile {
                 return
             }
             devices.forEach {
-                if let id = $0.id, let title = item.title {
-                    constellation.sendEventToDevice(targetDeviceId: id, e: .sendTab(title: title, url: item.url))
+                if let id = $0.id {
+                    constellation.sendEventToDevice(targetDeviceId: id, e: .sendTab(title: item.title ?? "", url: item.url))
                 }
             }
             deferred.fill(Maybe(success: ()))


### PR DESCRIPTION
Various apps don't fill in a title on shared URLs, this bug is a regression on our part