### PR TITLE
Fix #6796 - [XCUITests] TP tests failing after renaming an element ID

### DIFF
--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -380,7 +380,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     map.addScreenState(TrackingProtectionContextMenuDetails) { screenState in
         screenState.gesture(forAction: Action.TrackingProtectionperSiteToggle) { userState in
-            app.tables.cells["tp.add-to-whitelist"].tap()
+            app.tables.cells["tp.add-to-safelist"].tap()
             userState.trackingProtectionPerTabEnabled = !userState.trackingProtectionPerTabEnabled
         }
 


### PR DESCRIPTION
Changing "tp.add-to-whitelist" to "tp.add-to-safelist"