### PR TITLE
Hide Tab Tray when the last tab is removed

### DIFF
--- a/Client/Frontend/Browser/Tabs/TabTrayV2ViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayV2ViewModel.swift
@@ -154,8 +154,13 @@ class TabTrayV2ViewModel: NSObject {
         guard let section = TabSection(rawValue: index.section), let tab = dataStore[section]?[index.row] else {
             return
         }
-        
+
+        let tabCount = self.getTabs().count
         tabManager.removeTabAndUpdateSelectedIndex(tab)
+        if tabCount == 1 && self.getTabs().count == 1 {
+            // The last tab was removed. Dismiss the tab tray
+            self.viewController.dismissTabTray()
+        }
     }
 
     // When using 'Close All', hide all the tabs so they don't animate their deletion individually

--- a/Client/Frontend/Browser/Tabs/TabTrayV2ViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayV2ViewModel.swift
@@ -169,7 +169,7 @@ class TabTrayV2ViewModel: NSObject {
     }
     func closeTabsForCurrentTray() {
         viewController.hideDisplayedTabs() {
-            self.tabManager.removeTabsWithUndoToast(self.dataStore.compactMap{ $0.1 }.flatMap{ $0 })
+            self.tabManager.removeTabsWithUndoToast(self.dataStore.compactMap { $0.1 }.flatMap { $0 })
                 if self.getTabs().count == 1, let tab = self.getTabs().first {
                 self.tabManager.selectTab(tab)
                     self.viewController.dismissTabTray()


### PR DESCRIPTION
Fixes #6820 by closing the tab tray when the last tab is removed from the tray UI.