### PR TITLE
Fix #6844 - Condition for when internet ins't available or leanplum is slow wasn't met

### DIFF
--- a/Client/UserResearch/OnboardingUserResearch.swift
+++ b/Client/UserResearch/OnboardingUserResearch.swift
@@ -100,7 +100,6 @@ class OnboardingUserResearch {
                 lpVariableValue = boolValue ? .versionV1 : .versionV2
                 self.updateTelemetry()
             }
-            self.onboardingScreenType = nil
             self.onboardingScreenType = lpVariableValue
             self.updatedLPVariable?()
         }

--- a/Client/UserResearch/OnboardingUserResearch.swift
+++ b/Client/UserResearch/OnboardingUserResearch.swift
@@ -100,7 +100,7 @@ class OnboardingUserResearch {
                 lpVariableValue = boolValue ? .versionV1 : .versionV2
                 self.updateTelemetry()
             }
-            self.updatedLPVariable = nil
+            self.onboardingScreenType = nil
             self.onboardingScreenType = lpVariableValue
             self.updatedLPVariable?()
         }


### PR DESCRIPTION
Basically for the case when LP is slow or there is no internet available we go to our 2sec timer.
It turns out I accidentally cleared the closure **updartedLPVarilable** which should not have been cleared as thats the closure used in BVC to call show the screen.