### PR TITLE
Bug 1631834 - Add missing route used by taskgraph

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -167,6 +167,7 @@ tasks:
                                           then:
                                               - index.mobile.v2.${project}.branch.${short_head_branch}.latest.taskgraph.decision
                                               - index.mobile.v2.${project}.branch.${short_head_branch}.revision.${head_sha}.taskgraph.decision
+                                              - index.mobile.v2.${project}.revision.${head_sha}.taskgraph.decision
                                         - $if: 'tasks_for == "cron"'
                                           then:
                                               # cron context provides ${head_branch} as a short one


### PR DESCRIPTION
Fixes https://firefox-ci-tc.services.mozilla.com/tasks/YTx8Ea--Tr26ZPhLhbM8FA/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FYTx8Ea--Tr26ZPhLhbM8FA%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log#L92

I thought action tasks were working on this repo, but they weren't 😅 