### PR TITLE
Tint the default favicon white when in dark mode

### DIFF
--- a/Client/Frontend/Browser/TabTrayControllerV1.swift
+++ b/Client/Frontend/Browser/TabTrayControllerV1.swift
@@ -1176,12 +1176,11 @@ class TabCell: UICollectionViewCell {
         if let favIcon = tab.displayFavicon, let url = URL(string: favIcon.url) {
             favicon.sd_setImage(with: url, placeholderImage: UIImage(named: "defaultFavicon"), options: [], completed: nil)
         } else {
-            let defaultFavicon = UIImage(named: "defaultFavicon")
-            if tab.isPrivate {
-                favicon.image = defaultFavicon
+            if ThemeManager.instance.currentName == .dark {
+                favicon.image = UIImage(named: "defaultFavicon")?.withRenderingMode(.alwaysTemplate)
                 favicon.tintColor = UIColor.theme.tabTray.faviconTint
             } else {
-                favicon.image = defaultFavicon
+                favicon.image = UIImage(named: "defaultFavicon")
             }
         }
         if selected {


### PR DESCRIPTION
Fixes #6304 

![Simulator Screen Shot - iPhone 8 - 2020-06-27 at 14 17 45](https://user-images.githubusercontent.com/490833/85932467-479d3b00-b881-11ea-9d2a-3f89767732b2.png)
![Simulator Screen Shot - iPhone 8 - 2020-06-27 at 14 18 04](https://user-images.githubusercontent.com/490833/85932471-4966fe80-b881-11ea-906e-32cd8e4f4f99.png)
![Simulator Screen Shot - iPhone 8 - 2020-06-27 at 14 20 18](https://user-images.githubusercontent.com/490833/85932479-55eb5700-b881-11ea-854c-45bc28508957.png)
![Simulator Screen Shot - iPhone 8 - 2020-06-27 at 14 20 43](https://user-images.githubusercontent.com/490833/85932486-6996bd80-b881-11ea-9b3f-e1361a2223fd.png)
