### PR TITLE
Fix #6722 - BookmarksPanel crashes when changing Font Weight

### DIFF
--- a/Client/Frontend/Library/BookmarksPanel.swift
+++ b/Client/Frontend/Library/BookmarksPanel.swift
@@ -308,8 +308,10 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
 
     @objc fileprivate func notificationReceived(_ notification: Notification) {
         switch notification.name {
-        case .FirefoxAccountChanged, .DynamicFontChanged:
+        case .FirefoxAccountChanged:
             reloadData()
+        case .DynamicFontChanged:
+            tableView.reloadData()
         default:
             log.warning("Received unexpected notification \(notification.name)")
             break


### PR DESCRIPTION
There is no need to call the method `reloadData` directly. 


```
override func reloadData() {
    profile.places.getBookmarksTree(rootGUID: bookmarkFolderGUID, recursive: false).uponQueue(.main) { result in

        guard let folder = result.successValue as? BookmarkFolder else {
            // TODO: Handle error case?
            self.bookmarkFolder = nil
            self.bookmarkNodes = [] // <-  this line cause bookmark nodes became empty.
            self.recentBookmarks = []
            return
        }
        
        // ....
    }
}
```

```
func applyTheme() {
        // ...
        if let rows = tableView.indexPathsForVisibleRows {
            tableView.reloadRows(at: rows, with: .none) // <- visible rows are not empty, but the data source (bookmarkNodes) has become empty. So a crash happened here.
            tableView.reloadSections(IndexSet(rows.map { $0.section }), with: .none)
        }
    }
}
```
