### PR TITLE
Fix #6879: reconfig will crash if FxA init is in-progress

### DIFF
--- a/RustFxA/RustFirefoxAccounts.swift
+++ b/RustFxA/RustFirefoxAccounts.swift
@@ -102,6 +102,10 @@ open class RustFirefoxAccounts {
 
     @discardableResult
     public static func reconfig(prefs: Prefs) -> Deferred<FxAccountManager> {
+        if isInitializingAccountManager {
+            // This func is for reconfiguring a completed FxA init, if FxA init is in-progress, let it complete the init as-is
+            return shared.accountManager
+        }
         isInitializingAccountManager = false
         shared.accountManager = Deferred<FxAccountManager>()
         return startup(prefs: prefs)


### PR DESCRIPTION
The crash is from the deferred getting filled twice, which is illegal.

This can't be called twice on the same deferred: https://github.com/mozilla-mobile/firefox-ios/pull/6880/commits/d53b4e04d61fef2b8d063834e2c515a058cccdea#diff-03f1229a7f957587c4de530cd4c447d2R80 (line 80, expand the diff to see the highlight)
