### PR TITLE
Fix #6722: no reload() datasource when app backgrounded (db closed)

### DIFF
--- a/Client/Frontend/Library/BookmarkDetailPanel.swift
+++ b/Client/Frontend/Library/BookmarkDetailPanel.swift
@@ -171,6 +171,8 @@ class BookmarkDetailPanel: SiteTableViewController {
     }
 
     override func reloadData() {
+        // Can be called while app backgrounded and the db closed, don't try to reload the data source in this case
+        if profile.isShutdown { return }
         profile.places.getBookmarksTree(rootGUID: BookmarkRoots.RootGUID, recursive: true).uponQueue(.main) { result in
             guard let rootFolder = result.successValue as? BookmarkFolder else {
                 // TODO: Handle error case?

--- a/Client/Frontend/Library/BookmarksPanel.swift
+++ b/Client/Frontend/Library/BookmarksPanel.swift
@@ -163,6 +163,8 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
     }
 
     override func reloadData() {
+        // Can be called while app backgrounded and the db closed, don't try to reload the data source in this case
+        if profile.isShutdown { return }
         profile.places.getBookmarksTree(rootGUID: bookmarkFolderGUID, recursive: false).uponQueue(.main) { result in
 
             guard let folder = result.successValue as? BookmarkFolder else {

--- a/Client/Frontend/Library/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel.swift
@@ -155,6 +155,8 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
     // MARK: - Loading data
 
     override func reloadData() {
+        // Can be called while app backgrounded and the db closed, don't try to reload the data source in this case
+        if profile.isShutdown { return }
         guard !isFetchInProgress else { return }
         groupedSites = DateGroupedTableData<Site>()
 


### PR DESCRIPTION
```
@objc fileprivate func notificationReceived(_ notification: Notification) {
        switch notification.name {
        case .FirefoxAccountChanged, .DynamicFontChanged:
            reloadData()
```
Can be called when the app is backgrounded (that code is in our library table views). Another problem is traitcollectiondidchange is called while the app is going to background (because iOS is bizarre and does this), and we risk having closed the DB before reloadData is called.