### PR TITLE
Removed LP Setup in hidden menu that got added twice

### DIFF
--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -138,7 +138,6 @@ class AppSettingsTableViewController: SettingsTableViewController {
                 SentryIDSetting(settings: self),
                 ChangeToChinaSetting(settings: self),
                 ToggleOnboarding(settings: self),
-                LeanplumStatus(settings: self),
                 ShowEtpCoverSheet(settings: self),
                 ToggleOnboarding(settings: self),
                 LeanplumStatus(settings: self),


### PR DESCRIPTION
Turns out the LP setup in Hidden menu got added twice and we don't need to show it multiple times. 
Hence, removing one of them from Hidden menu. 