### PR TITLE
Update release_checklist_template.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist_template.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist_template.md
@@ -15,7 +15,7 @@ Branch setup, steps typically done when creating new version branch
 - [ ] Ensure L10N box has been run (if needed) to do string export
 - [ ] Check for [security advisories](https://github.com/mozilla-mobile/firefox-ios/wiki/Release-Build-Checklist/#security-advisories) 
 - [ ] Tag release in GitHub (Eng task)
-    - [ ] Copy commits with author names into notes section of release
+    - [ ] Link to commit diff between versions
 - [ ] File P.I. request
 - [ ] Release Notes updated
 - [ ] Submit build to Apple (Select YES to IDFA, 'Attribute this app installation to a previously served advertisement')

--- a/.github/ISSUE_TEMPLATE/release_checklist_template.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist_template.md
@@ -15,6 +15,7 @@ Branch setup, steps typically done when creating new version branch
 - [ ] Ensure L10N box has been run (if needed) to do string export
 - [ ] Check for [security advisories](https://github.com/mozilla-mobile/firefox-ios/wiki/Release-Build-Checklist/#security-advisories) 
 - [ ] Tag release in GitHub (Eng task)
+    - [ ] Copy commits with author names into notes section of release
 - [ ] File P.I. request
 - [ ] Release Notes updated
 - [ ] Submit build to Apple (Select YES to IDFA, 'Attribute this app installation to a previously served advertisement')


### PR DESCRIPTION
Pasting the full commit list can get kind of messy so I started just pasting the link to the GitHub diff list (which is also a lot quicker and easier to do). @garvankeeley do you have an opinion on which one we should do?