### PR TITLE
Fix #6948 - Crash after rearranged folder and pressing save button

### DIFF
--- a/Client/Frontend/Library/BookmarkDetailPanel.swift
+++ b/Client/Frontend/Library/BookmarkDetailPanel.swift
@@ -184,13 +184,19 @@ class BookmarkDetailPanel: SiteTableViewController {
             var bookmarkFolders: [(folder: BookmarkFolder, indent: Int)] = []
 
             func addFolder(_ folder: BookmarkFolder, indent: Int = 0) {
-                // Do not append the top "root" folder to this list as
+                // Do not append itself and the top "root" folder to this list as
                 // bookmarks cannot be stored directly within it.
-                if folder.guid != BookmarkRoots.RootGUID {
+                if folder.guid != BookmarkRoots.RootGUID && folder.guid != self.bookmarkNodeGUID {
                     bookmarkFolders.append((folder, indent))
                 }
 
-                for case let childFolder as BookmarkFolder in folder.children ?? [] {
+                var folderChildren: [BookmarkNode]? = nil
+                // Suitable to be appended
+                if folder.guid != self.bookmarkNodeGUID {
+                    folderChildren = folder.children
+                }
+
+                for case let childFolder as BookmarkFolder in folderChildren ?? [] {
                     // Any "root" folders (i.e. "Mobile Bookmarks") should
                     // have an indentation of 0.
                     if childFolder.isRoot {


### PR DESCRIPTION
Fixes #6948 

**Before:**

![bug](https://user-images.githubusercontent.com/19792753/87557647-d521bd00-c6c0-11ea-8177-c345001879f8.gif)

**With this commit:** 

![bug_fix](https://user-images.githubusercontent.com/19792753/87557662-d9e67100-c6c0-11ea-879c-f542b6d86c64.gif)




