### PR TITLE
FXIOS-713 ⁃ Fix #5950: Browser rotates upside down in iOS 13

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -136,14 +136,6 @@ class BrowserViewController: UIViewController {
         return false
     }
 
-    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        if UIDevice.current.userInterfaceIdiom == .phone {
-            return .allButUpsideDown
-        } else {
-            return .all
-        }
-    }
-
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -156,7 +156,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>


### PR DESCRIPTION
Fixes #5950 

The default modalPresentationStyle changed from fullscreen to automatic in iOS 13.

Enforce orientations in `info.plist` and remove code managing orientation. This preserves previous behaviour on ipad.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-713)
