### PR TITLE
Missing screenshots

### DIFF
--- a/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -18,13 +18,14 @@ class ScreenshotHelper {
         self.controller = controller
     }
     
+    /// Takes a screenshot of the WebView to be displayed on the tab view page
+    /**
+     If taking a screenshot of the home page, uses our custom screenshot `UIView` extension function
+     If taking a screenshot of a website, uses apple's `takeSnapshot` function
+     */
     func takeScreenshot(_ tab: Tab) {
-        guard let webView = tab.webView else {
-            //handle error here
-            return
-        }
-        guard let url = tab.url else {
-            //handle this error as well
+        guard let webView = tab.webView, let url = tab.url else {
+            print("Screenshot Error: We do not have the data we need to take a screenshot")
             return
         }
         //Handle home page snapshots, can not use Apple API snapshot function for this

--- a/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -25,7 +25,7 @@ class ScreenshotHelper {
      */
     func takeScreenshot(_ tab: Tab) {
         guard let webView = tab.webView, let url = tab.url else {
-            print("Screenshot Error: We do not have the data we need to take a screenshot")
+            Sentry.shared.send(message: "Tab Snapshot Error", tag: .tabManager, severity: .debug, description: "Tab webView or url is nil")
             return
         }
         //Handle home page snapshots, can not use Apple API snapshot function for this
@@ -45,7 +45,9 @@ class ScreenshotHelper {
                 if let image = image {
                     tab.setScreenshot(image)
                 } else if let error = error {
-                    print("Snapshot error: \(error)")
+                    Sentry.shared.send(message: "Tab snapshot error", tag: .tabManager, severity: .debug, description: error.localizedDescription)
+                } else {
+                    Sentry.shared.send(message: "Tab snapshot error", tag: .tabManager, severity: .debug, description: "No error description")
                 }
             }
         }


### PR DESCRIPTION
Fixes #6916 

Fixes issue where users see tabs with no image on their tab view page.  This issue was caused by the tab `WKWebview` sending notification center messages that the title or url for the page had changed.  This resulted in us taking a new screenshot, but the `WKWebview` was not rendering in time, so we were capturing blank screenshot images.

This switches to using Apple's `takeSnapshot` function, which handles taking snapshots in the background.  

