### PR TITLE
Fix #6963 - Part 2: Cleanup and fixes.

### DIFF
--- a/Client/Frontend/Browser/OpenInHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper.swift
@@ -169,7 +169,11 @@ class OpenQLPreviewHelper: NSObject, OpenInHelper, QLPreviewControllerDataSource
     fileprivate let previewController: QLPreviewController
 
     required init?(request: URLRequest?, response: URLResponse, canShowInWebView: Bool, forceDownload: Bool, browserViewController: BrowserViewController) {
-        guard let mimeType = response.mimeType, mimeType == MIMEType.USDZ || mimeType == MIMEType.Reality, let responseURL = response.url as NSURL?, QLPreviewController.canPreview(responseURL), !forceDownload, !canShowInWebView else { return nil }
+        guard let mimeType = response.mimeType,
+                 (mimeType == MIMEType.USDZ || mimeType == MIMEType.Reality),
+                 let responseURL = response.url as NSURL?,
+                 !forceDownload,
+                 !canShowInWebView else { return nil }
         self.url = responseURL
         self.browserViewController = browserViewController
         self.previewController = QLPreviewController()


### PR DESCRIPTION
`QLPreviewController.canPreview(_:)` was erroneously returning false, causing the guard to fail.

![out](https://user-images.githubusercontent.com/650804/88119807-790edb00-cb8f-11ea-9272-72bac076a28d.gif)
