### PR TITLE
[nobug, logging] Glean: beta-only sentry logging for uninstrumented metric

### DIFF
--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -439,7 +439,8 @@ extension TelemetryWrapper {
         case (.action, .tap, .startSearchButton, _, _):
             GleanMetrics.Search.startSearchPressed.add()
         default:
-            print("Uninstrumented metric recorded: \(category), \(method), \(object), \(value), \(String(describing: extras))")
+            let msg = "Uninstrumented metric recorded: \(category), \(method), \(object), \(value), \(String(describing: extras))"
+            Sentry.shared.send(message: msg, severity: .debug)
         }
     }
 }


### PR DESCRIPTION
Logging these only to the console isn't likely to catch all the cases, using Sentry will help here.