### PR TITLE
[nobug, rename] Rename misleading sec token to appIdToken

### DIFF
--- a/Client/Assets/CertError.html
+++ b/Client/Assets/CertError.html
@@ -15,7 +15,7 @@
         if (fresh)
           fresh = false;
         else
-          webkit.messageHandlers.localRequestHelper.postMessage({ securitytoken: SECURITY_TOKEN, type: "reload" });
+          webkit.messageHandlers.localRequestHelper.postMessage({ appIdToken: APP_ID_TOKEN, type: "reload" });
       });
 
     </script>

--- a/Client/Assets/NetError.html
+++ b/Client/Assets/NetError.html
@@ -15,7 +15,7 @@
         if (fresh)
           fresh = false;
         else
-          webkit.messageHandlers.localRequestHelper.postMessage({ securitytoken: SECURITY_TOKEN, type: "reload" });
+          webkit.messageHandlers.localRequestHelper.postMessage({ appIdToken: APP_ID_TOKEN, type: "reload" });
       });
 
     </script>

--- a/Client/Frontend/Browser/DownloadContentScript.swift
+++ b/Client/Frontend/Browser/DownloadContentScript.swift
@@ -28,7 +28,7 @@ class DownloadContentScript: TabContentScript {
     static func requestDownload(url: URL, tab: Tab) {
         let safeUrl = url.absoluteString.replacingOccurrences(of: "'", with: "%27")
         blobUrlForDownload = url.scheme == "blob" ? URL(string: safeUrl) : nil
-        tab.webView?.evaluateJavaScript("window.__firefox__.download('\(safeUrl)', '\(UserScriptManager.securityToken)')")
+        tab.webView?.evaluateJavaScript("window.__firefox__.download('\(safeUrl)', '\(UserScriptManager.appIdToken)')")
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .downloadLinkButton)
     }
 

--- a/Client/Frontend/Browser/LocalRequestHelper.swift
+++ b/Client/Frontend/Browser/LocalRequestHelper.swift
@@ -16,8 +16,8 @@ class LocalRequestHelper: TabContentScript {
 
         let params = message.body as! [String: String]
 
-        guard let token = params["securitytoken"], token == UserScriptManager.securityToken else {
-            print("Missing required security token.")
+        guard let token = params["appIdToken"], token == UserScriptManager.appIdToken else {
+            print("Missing required appid token.")
             return
         }
 

--- a/Client/Frontend/Browser/OpenInHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper.swift
@@ -60,7 +60,7 @@ class DownloadHelper: NSObject, OpenInHelper {
 
     static func requestDownload(url: URL, tab: Tab) {
         let safeUrl = url.absoluteString.replacingOccurrences(of: "'", with: "%27")
-        tab.webView?.evaluateJavaScript("window.__firefox__.download('\(safeUrl)', '\(UserScriptManager.securityToken)')")
+        tab.webView?.evaluateJavaScript("window.__firefox__.download('\(safeUrl)', '\(UserScriptManager.appIdToken)')")
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .downloadLinkButton)
     }
     

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -643,7 +643,7 @@ extension TabManager: WKNavigationDelegate {
         guard let tab = self[webView] else { return }
 
         if let tpHelper = tab.contentBlocker, !tpHelper.isEnabled {
-            webView.evaluateJavaScript("window.__firefox__.TrackingProtectionStats.setEnabled(false, \(UserScriptManager.securityToken))")
+            webView.evaluateJavaScript("window.__firefox__.TrackingProtectionStats.setEnabled(false, \(UserScriptManager.appIdToken))")
         }
     }
 

--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -7,7 +7,7 @@ import WebKit
 class UserScriptManager {
 
     // Scripts can use this to verify the *app* (not JS on the web) is calling into them.
-    public static let securityToken = UUID().uuidString
+    public static let appIdToken = UUID().uuidString
 
     // Singleton instance.
     public static let shared = UserScriptManager()
@@ -30,7 +30,7 @@ class UserScriptManager {
             let name = (mainFrameOnly ? "MainFrame" : "AllFrames") + "AtDocument" + (injectionTime == .atDocumentStart ? "Start" : "End")
             if let path = Bundle.main.path(forResource: name, ofType: "js"),
                 let source = try? NSString(contentsOfFile: path, encoding: String.Encoding.utf8.rawValue) as String {
-                let wrappedSource = "(function() { const SECURITY_TOKEN = '\(UserScriptManager.securityToken)'; \(source) })()"
+                let wrappedSource = "(function() { const APP_ID_TOKEN = '\(UserScriptManager.appIdToken)'; \(source) })()"
                 let userScript = WKUserScript(source: wrappedSource, injectionTime: injectionTime, forMainFrameOnly: mainFrameOnly)
                 compiledUserScripts[name] = userScript
             }

--- a/Client/Frontend/Reader/ReaderViewLoading.html
+++ b/Client/Frontend/Reader/ReaderViewLoading.html
@@ -70,7 +70,7 @@
       request.open("GET", "/reader-mode/page-exists" + document.location.search, true);
       request.onload = function() {
         if (request.status == 200) {
-          webkit.messageHandlers.localRequestHelper.postMessage({ securitytoken: SECURITY_TOKEN, type: "reload" });
+          webkit.messageHandlers.localRequestHelper.postMessage({ appIdToken: APP_ID_TOKEN, type: "reload" });
         } else {
           triggerCheck();
         }

--- a/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentEnd/DownloadHelper.js
+++ b/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentEnd/DownloadHelper.js
@@ -9,8 +9,8 @@ Object.defineProperty(window.__firefox__, "download", {
   enumerable: false,
   configurable: false,
   writable: false,
-  value: function(url, securityToken) {
-    if (securityToken !== SECURITY_TOKEN) {
+  value: function(url, appIdToken) {
+    if (appIdToken !== APP_ID_TOKEN) {
       return;
     }
 

--- a/content-blocker-lib-ios/js/TrackingProtectionStats.js
+++ b/content-blocker-lib-ios/js/TrackingProtectionStats.js
@@ -22,8 +22,8 @@ function install() {
     enumerable: false,
     configurable: false,
     writable: false,
-    value: function(enabled, securityToken) {
-      if (securityToken !== SECURITY_TOKEN || enabled === _enabled) {
+    value: function(enabled, appIdToken) {
+      if (appIdToken !== APP_ID_TOKEN || enabled === _enabled) {
         return;
       }
 


### PR DESCRIPTION
The level of security provided by this is minimal, it mainly prevents casual exploits calling our JS unexpectedly, and it seems to be alarming to external eyes to see this named as it was.