### PR TITLE
Fix margins within LoginListTableViewCell

### DIFF
--- a/Client/Frontend/Login Management/BreachAlertsManager.swift
+++ b/Client/Frontend/Login Management/BreachAlertsManager.swift
@@ -52,7 +52,7 @@ final public class BreachAlertsManager {
             self.breaches.append(BreachRecord(
              name: "MockBreach",
              title: "A Mock BreachRecord",
-             domain: "abreachedwithalongstringname.com",
+             domain: "abreachedwithalongstringnameaslkdjflskjfas.com",
              breachDate: "1970-01-02",
              description: "A mock BreachRecord for testing purposes."
             ))

--- a/Client/Frontend/Login Management/LoginDataSource.swift
+++ b/Client/Frontend/Login Management/LoginDataSource.swift
@@ -40,9 +40,10 @@ class LoginDataSource: NSObject, UITableViewDataSource {
     }
 
     @objc func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = LoginListTableViewCell(style: .subtitle, reuseIdentifier: CellReuseIdentifier, inset: tableView.separatorInset)
 
         if indexPath.section == LoginsSettingsSection {
+            let cell = LoginListTableViewSettingsCell(style: .default, reuseIdentifier: CellReuseIdentifier)
+
             let hideSettings = viewModel.searchController?.isActive ?? false || tableView.isEditing
             let setting = indexPath.row == 0 ? boolSettings.0 : boolSettings.1
             setting.onConfigureCell(cell)
@@ -60,7 +61,9 @@ class LoginDataSource: NSObject, UITableViewDataSource {
                     cell.accessoryView?.alpha = 1
                 }
             }
+            return cell
         } else {
+            let cell = LoginListTableViewCell(style: .subtitle, reuseIdentifier: CellReuseIdentifier, inset: tableView.separatorInset)
             guard let login = viewModel.loginAtIndexPath(indexPath) else { return cell }
             cell.textLabel?.text = login.hostname
             cell.detailTextColor = UIColor.theme.tableView.rowDetailText
@@ -68,7 +71,7 @@ class LoginDataSource: NSObject, UITableViewDataSource {
             if let breaches = viewModel.userBreaches, breaches.contains(login) {
                 cell.breachAlertImageView.isHidden = false
             }
-        }
         return cell
+        }
     }
 }

--- a/Client/Frontend/Login Management/LoginDataSource.swift
+++ b/Client/Frontend/Login Management/LoginDataSource.swift
@@ -65,9 +65,9 @@ class LoginDataSource: NSObject, UITableViewDataSource {
         } else {
             let cell = LoginListTableViewCell(style: .subtitle, reuseIdentifier: CellReuseIdentifier, inset: tableView.separatorInset)
             guard let login = viewModel.loginAtIndexPath(indexPath) else { return cell }
-            cell.textLabel?.text = login.hostname
-            cell.detailTextColor = UIColor.theme.tableView.rowDetailText
-            cell.detailTextLabel?.text = login.username
+            cell.hostnameLabel.text = login.hostname
+            cell.usernameLabel.textColor = UIColor.theme.tableView.rowDetailText
+            cell.usernameLabel.text = login.username != "" ? login.username : "(no username)"
             if let breaches = viewModel.userBreaches, breaches.contains(login) {
                 cell.breachAlertImageView.isHidden = false
             }

--- a/Client/Frontend/Login Management/LoginListTableViewCell.swift
+++ b/Client/Frontend/Login Management/LoginListTableViewCell.swift
@@ -22,23 +22,49 @@ class LoginListTableViewCell: ThemedTableViewCell {
         imageView.isHidden = true
         return imageView
     }()
-    lazy var breachMargin: CGFloat = {
-        return -LoginTableViewCellUX.HorizontalMargin*2
+    lazy var breachAlertContainer: UIView = {
+        let view = UIView()
+        view.addSubview(breachAlertImageView)
+        view.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        return view
     }()
+    lazy var breachMargin: CGFloat = {
+        return breachAlertSize+LoginTableViewCellUX.HorizontalMargin*2
+    }()
+
+    let hostnameLabel = UILabel()
+    let usernameLabel = UILabel()
+    private lazy var hostnameContainer: UIView = {
+        let view = UIView()
+        view.addSubview(hostnameLabel)
+        return view
+    }()
+    private lazy var usernameContainer: UIView = {
+        let view = UIView()
+        view.addSubview(usernameLabel)
+        return view
+    }()
+    private lazy var textStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [hostnameContainer, usernameContainer])
+        stack.axis = .vertical
+        return stack
+    }()
+    private lazy var contentStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [textStack, breachAlertContainer])
+        stack.axis = .horizontal
+        return stack
+    }()
+
     var inset: UIEdgeInsets!
 
     init(style: UITableViewCell.CellStyle, reuseIdentifier: String?, inset: UIEdgeInsets) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         self.inset = inset
         accessoryType = .disclosureIndicator
-        contentView.addSubview(breachAlertImageView)
-        breachAlertImageView.snp.remakeConstraints { make in
-            make.centerY.equalTo(contentView)
-            make.trailing.equalTo(contentView.snp.trailing).offset(-LoginTableViewCellUX.HorizontalMargin)
-            make.width.height.equalTo(breachAlertSize)
-        }
+        contentView.addSubview(contentStack)
         // Need to override the default background multi-select color to support theming
         self.multipleSelectionBackgroundView = UIView()
+        self.usernameLabel.textColor = self.detailTextColor
         self.applyTheme()
         setConstraints()
     }
@@ -48,26 +74,24 @@ class LoginListTableViewCell: ThemedTableViewCell {
     }
 
     private func setConstraints() {
-        if (self.detailTextLabel?.text != "") {
-            self.textLabel?.snp.remakeConstraints({ make in
-                guard let textLabel = self.textLabel else { return }
-                make.leading.equalTo(self.snp.leading).offset(inset.left)
-                make.trailing.equalTo(breachAlertImageView).offset(breachMargin)
-                make.bottom.equalTo(self.snp.centerY)//.offset(-textLabel.frame.height/2)
-            })
-            self.detailTextLabel?.snp.remakeConstraints({ make in
-                guard let detailTextLabel = self.detailTextLabel else { return }
-                make.leading.equalToSuperview().offset(inset.left)
-                make.trailing.equalTo(breachAlertImageView).offset(breachMargin)
-                make.top.equalTo(self.snp.centerY)//.offset(detailTextLabel.frame.height/2)
-            })
-        } else {
-            self.textLabel?.snp.remakeConstraints({ make in
-                make.top.equalToSuperview().offset(inset.top)
-                make.trailing.equalTo(breachAlertImageView).offset(breachMargin)
-                make.bottom.equalToSuperview().offset(inset.bottom)
-                make.leading.equalToSuperview().offset(inset.left)
-            })
+        self.contentStack.snp.remakeConstraints { make in
+            make.top.bottom.trailing.equalTo(contentView)
+            make.left.equalTo(contentView).inset(self.inset.left)
+        }
+        self.hostnameLabel.snp.remakeConstraints { make in
+            make.bottom.equalTo(self.contentStack.snp.centerY)
+            make.leading.equalToSuperview()
+            make.trailing.lessThanOrEqualTo(self.textStack.snp.trailing)
+        }
+        self.usernameLabel.snp.remakeConstraints { make in
+            make.top.equalTo(self.contentStack.snp.centerY)
+        }
+        self.breachAlertImageView.snp.remakeConstraints { make in
+            make.width.height.equalTo(breachAlertSize)
+            make.center.equalTo(self.breachAlertContainer.snp.center)
+        }
+        self.breachAlertContainer.snp.remakeConstraints { make in
+            make.width.equalTo(breachMargin)
         }
     }
 

--- a/Client/Frontend/Login Management/LoginListTableViewCell.swift
+++ b/Client/Frontend/Login Management/LoginListTableViewCell.swift
@@ -22,6 +22,9 @@ class LoginListTableViewCell: ThemedTableViewCell {
         imageView.isHidden = true
         return imageView
     }()
+    lazy var breachMargin: CGFloat = {
+        return -LoginTableViewCellUX.HorizontalMargin*2
+    }()
     var inset: UIEdgeInsets!
 
     init(style: UITableViewCell.CellStyle, reuseIdentifier: String?, inset: UIEdgeInsets) {
@@ -47,19 +50,21 @@ class LoginListTableViewCell: ThemedTableViewCell {
     private func setConstraints() {
         if (self.detailTextLabel?.text != "") {
             self.textLabel?.snp.remakeConstraints({ make in
-                make.leading.equalToSuperview().offset(inset.left)
-                make.trailing.equalTo(breachAlertImageView).offset(-LoginTableViewCellUX.HorizontalMargin*2)
-                make.bottom.equalTo(self.contentView.snp.centerY)
+                guard let textLabel = self.textLabel else { return }
+                make.leading.equalTo(self.snp.leading).offset(inset.left)
+                make.trailing.equalTo(breachAlertImageView).offset(breachMargin)
+                make.bottom.equalTo(self.snp.centerY)//.offset(-textLabel.frame.height/2)
             })
             self.detailTextLabel?.snp.remakeConstraints({ make in
-                make.top.equalTo(self.contentView.snp.centerY)
+                guard let detailTextLabel = self.detailTextLabel else { return }
                 make.leading.equalToSuperview().offset(inset.left)
-                make.trailing.equalTo(breachAlertImageView).offset(LoginTableViewCellUX.HorizontalMargin)
+                make.trailing.equalTo(breachAlertImageView).offset(breachMargin)
+                make.top.equalTo(self.snp.centerY)//.offset(detailTextLabel.frame.height/2)
             })
         } else {
             self.textLabel?.snp.remakeConstraints({ make in
                 make.top.equalToSuperview().offset(inset.top)
-                make.trailing.equalTo(breachAlertImageView).offset(-LoginTableViewCellUX.HorizontalMargin*2)
+                make.trailing.equalTo(breachAlertImageView).offset(breachMargin)
                 make.bottom.equalToSuperview().offset(inset.bottom)
                 make.leading.equalToSuperview().offset(inset.left)
             })

--- a/Client/Frontend/Login Management/LoginListTableViewCell.swift
+++ b/Client/Frontend/Login Management/LoginListTableViewCell.swift
@@ -4,43 +4,70 @@
 
 import UIKit
 
+class LoginListTableViewSettingsCell: ThemedTableViewCell {
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 class LoginListTableViewCell: ThemedTableViewCell {
+    private let breachAlertSize: CGFloat = 24
     lazy var breachAlertImageView: UIImageView = {
         let image = UIImage(named: "Breached Website")
         let imageView = UIImageView(image: image)
         imageView.isHidden = true
         return imageView
     }()
-    let breachAlertSize: CGFloat = 24
+    var inset: UIEdgeInsets!
 
     init(style: UITableViewCell.CellStyle, reuseIdentifier: String?, inset: UIEdgeInsets) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        self.inset = inset
         accessoryType = .disclosureIndicator
         contentView.addSubview(breachAlertImageView)
         breachAlertImageView.snp.remakeConstraints { make in
             make.centerY.equalTo(contentView)
             make.trailing.equalTo(contentView.snp.trailing).offset(-LoginTableViewCellUX.HorizontalMargin)
-            make.width.equalTo(breachAlertSize)
-            make.height.equalTo(breachAlertSize)
+            make.width.height.equalTo(breachAlertSize)
         }
-
-        textLabel?.snp.remakeConstraints({ make in
-            make.leading.equalTo(contentView).offset(inset.left)
-            make.trailing.equalTo(breachAlertImageView.snp.leading).offset(-LoginTableViewCellUX.HorizontalMargin/2)
-            make.top.equalTo(inset.top)
-            make.centerY.equalTo(contentView)
-            if let detailTextLabel = self.detailTextLabel {
-                make.bottom.equalTo(detailTextLabel.snp.top)
-                make.top.equalTo(contentView.snp.top).offset(LoginTableViewCellUX.HorizontalMargin)
-            }
-        })
-
         // Need to override the default background multi-select color to support theming
         self.multipleSelectionBackgroundView = UIView()
         self.applyTheme()
+        setConstraints()
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setConstraints() {
+        if (self.detailTextLabel?.text != "") {
+            self.textLabel?.snp.remakeConstraints({ make in
+                make.leading.equalToSuperview().offset(inset.left)
+                make.trailing.equalTo(breachAlertImageView).offset(-LoginTableViewCellUX.HorizontalMargin*2)
+                make.bottom.equalTo(self.contentView.snp.centerY)
+            })
+            self.detailTextLabel?.snp.remakeConstraints({ make in
+                make.top.equalTo(self.contentView.snp.centerY)
+                make.leading.equalToSuperview().offset(inset.left)
+                make.trailing.equalTo(breachAlertImageView).offset(LoginTableViewCellUX.HorizontalMargin)
+            })
+        } else {
+            self.textLabel?.snp.remakeConstraints({ make in
+                make.top.equalToSuperview().offset(inset.top)
+                make.trailing.equalTo(breachAlertImageView).offset(-LoginTableViewCellUX.HorizontalMargin*2)
+                make.bottom.equalToSuperview().offset(inset.bottom)
+                make.leading.equalToSuperview().offset(inset.left)
+            })
+        }
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        setConstraints()
     }
 }

--- a/Client/Frontend/Login Management/LoginListViewModel.swift
+++ b/Client/Frontend/Login Management/LoginListViewModel.swift
@@ -62,7 +62,7 @@ final class LoginListViewModel {
         let deferred = Deferred<Maybe<[LoginRecord]>>()
         profile.logins.searchLoginsWithQuery(query) >>== { logins in
             var log = logins.asArray()
-            log.append(LoginRecord(fromJSONDict: ["hostname" : "abreachedwithalongstringname.com", "timePasswordChanged": 46800000]))
+            log.append(LoginRecord(fromJSONDict: ["hostname" : "abreachedwithalongstringnameaslkdjflskjfas.com", "timePasswordChanged": 46800000]))
             log.append(LoginRecord(fromJSONDict: ["hostname" : "abreach.com", "timePasswordChanged": 46800000, "username": "username"]))
             deferred.fillIfUnfilled(Maybe(success: log))
             succeed()

--- a/ClientTests/BreachAlertsTests.swift
+++ b/ClientTests/BreachAlertsTests.swift
@@ -25,7 +25,7 @@ let amockRecord = BreachRecord(
 let longMock = BreachRecord(
  name: "MockBreach",
  title: "A Mock BreachRecord",
- domain: "abreachedwithalongstringname.com",
+ domain: "abreachedwithalongstringnameaslkdjflskjfas.com",
  breachDate: "1970-01-02",
  description: "A mock BreachRecord for testing purposes."
 )


### PR DESCRIPTION
The text in the `LoginListTableViewCell`s are currently misaligned due to the addition of the `breachAlertImageView`. This is an attempt to fix them using stack views and custom labels rather than depending on the default `textLabel` and `descriptionTextLabel`.