### PR TITLE
FXIOS-712 ⁃ Fix #6986 - Search icons should be displayed on Blank Tab as New Tab

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -74,6 +74,7 @@ class URLBarView: UIView {
                 // Cancel any pending/in-progress animations related to the progress bar
                 self.progressBar.setProgress(1, animated: false)
                 self.progressBar.alpha = 0.0
+                self.progressBar.isHidden = true
             }
         }
     }
@@ -413,6 +414,10 @@ class URLBarView: UIView {
         progressBar.isHidden = true
         progressBar.setProgress(0, animated: false)
     }
+    
+    func isProgressBarShowing() -> Bool {
+        return !progressBar.isHidden
+    }
 
     func updateReaderModeState(_ state: ReaderModeState) {
         locationView.readerModeState = state
@@ -497,6 +502,7 @@ class URLBarView: UIView {
         cancelButton.alpha = inOverlayMode ? 1 : 0
         showQRScannerButton.alpha = inOverlayMode ? 1 : 0
         progressBar.alpha = inOverlayMode || didCancel ? 0 : 1
+        progressBar.isHidden = inOverlayMode || didCancel ? true : false
         tabsButton.alpha = inOverlayMode ? 0 : 1
         appMenuButton.alpha = inOverlayMode ? 0 : 1
         libraryButton.alpha = inOverlayMode ? 0 : 1


### PR DESCRIPTION
There were multiple gotchas and below is a basic approach of showing the correct tab middle icon. 
It mainly relies and tries to match the progress bar state i.e. 

**Blank Tab:** 
-- Show search icon

**Home Tab:**
-- Show search icon 

**Loading any tab & Progress Bar is showing:** 
-- Show X icon 

**Going to tab tray while a website is already loaded & selecting a tab while Progress Bar isn't showing:** 
-- Show the reload icon 


There might be other places but these are the places I can think of where to show proper state for middle button.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-712)
