### PR TITLE
FXIOS-710 ⁃ Create breach details view

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -384,6 +384,7 @@
 		CA24B52224ABD7D40093848C /* LoginsListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA24B52024ABD7D40093848C /* LoginsListViewModelTests.swift */; };
 		CA24B53924ABFE250093848C /* LoginsListSelectionHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA24B53824ABFE250093848C /* LoginsListSelectionHelperTests.swift */; };
 		CA24B53B24ABFE5D0093848C /* LoginsListDataSourceHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA24B53A24ABFE5D0093848C /* LoginsListDataSourceHelperTests.swift */; };
+		CA4ACE4924C8C91600F55894 /* BreachAlertsDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4ACE4824C8C91500F55894 /* BreachAlertsDetailView.swift */; };
 		CA520E7A24913C1B00CCAB48 /* LoginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA520E7924913C1B00CCAB48 /* LoginListViewModel.swift */; };
 		CA77ABFD24773C92005079F9 /* BreachAlertsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA77ABF424772D98005079F9 /* BreachAlertsManager.swift */; };
 		CA7BD568248189E800A0A61B /* BreachAlertsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7BD564248185B500A0A61B /* BreachAlertsTests.swift */; };
@@ -1542,6 +1543,7 @@
 		CA24B52024ABD7D40093848C /* LoginsListViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginsListViewModelTests.swift; sourceTree = "<group>"; };
 		CA24B53824ABFE250093848C /* LoginsListSelectionHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginsListSelectionHelperTests.swift; sourceTree = "<group>"; };
 		CA24B53A24ABFE5D0093848C /* LoginsListDataSourceHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginsListDataSourceHelperTests.swift; sourceTree = "<group>"; };
+		CA4ACE4824C8C91500F55894 /* BreachAlertsDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreachAlertsDetailView.swift; sourceTree = "<group>"; };
 		CA520E7924913C1B00CCAB48 /* LoginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginListViewModel.swift; sourceTree = "<group>"; };
 		CA77ABF424772D98005079F9 /* BreachAlertsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreachAlertsManager.swift; sourceTree = "<group>"; };
 		CA7BD564248185B500A0A61B /* BreachAlertsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreachAlertsTests.swift; sourceTree = "<group>"; };
@@ -3189,8 +3191,8 @@
 			children = (
 				E63ED8E01BFD25580097D08E /* LoginListViewController.swift */,
 				CA8226F224C11DB7008A6F38 /* LoginListTableViewCell.swift */,
-				E63ED7D71BFCD9990097D08E /* LoginDetailTableViewCell.swift */,
 				E633E2D91C21EAF8001FFF6C /* LoginDetailViewController.swift */,
+				E63ED7D71BFCD9990097D08E /* LoginDetailTableViewCell.swift */,
 				CAA3B7E52497DCB60094E3C1 /* LoginDataSource.swift */,
 				CA520E7924913C1B00CCAB48 /* LoginListViewModel.swift */,
 				CA7FC7D224A6A9B70012F347 /* LoginListDataSourceHelper.swift */,
@@ -3198,6 +3200,7 @@
 				CAC458F0249429C20042561A /* LoginListSelectionHelper.swift */,
 				CA77ABF424772D98005079F9 /* BreachAlertsManager.swift */,
 				CA03B269247F1D9E00382B62 /* BreachAlertsClient.swift */,
+				CA4ACE4824C8C91500F55894 /* BreachAlertsDetailView.swift */,
 			);
 			path = "Login Management";
 			sourceTree = "<group>";
@@ -5282,6 +5285,7 @@
 				EBA3B2D02268F40C00728BDB /* SyncMenuButton.swift in Sources */,
 				D31A0FC71A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */,
 				435D7CC5246209AA0043ACB9 /* IntroViewControllerV2.swift in Sources */,
+				CA4ACE4924C8C91600F55894 /* BreachAlertsDetailView.swift in Sources */,
 				A83E5AB71C1D993D0026D912 /* UIPasteboardExtensions.swift in Sources */,
 				D8EFFA0C1FF5B1FA001D3A09 /* NavigationRouter.swift in Sources */,
 				D0E55C4F1FB4FD23006DC274 /* FormPostHelper.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1014,6 +1014,7 @@ class BrowserViewController: UIViewController {
             request = nil
         }
 
+        print(request)
         switchToPrivacyMode(isPrivate: isPrivate)
         tabManager.selectTab(tabManager.addTab(request, isPrivate: isPrivate))
     }
@@ -1215,6 +1216,7 @@ extension BrowserViewController: QRCodeViewControllerDelegate {
 
 extension BrowserViewController: SettingsDelegate {
     func settingsOpenURLInNewTab(_ url: URL) {
+        print(url)
         let isPrivate = tabManager.selectedTab?.isPrivate ?? false
         self.openURLInNewTab(url, isPrivate: isPrivate)
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1014,7 +1014,6 @@ class BrowserViewController: UIViewController {
             request = nil
         }
 
-        print(request)
         switchToPrivacyMode(isPrivate: isPrivate)
         tabManager.selectTab(tabManager.addTab(request, isPrivate: isPrivate))
     }
@@ -1216,7 +1215,6 @@ extension BrowserViewController: QRCodeViewControllerDelegate {
 
 extension BrowserViewController: SettingsDelegate {
     func settingsOpenURLInNewTab(_ url: URL) {
-        print(url)
         let isPrivate = tabManager.selectedTab?.isPrivate ?? false
         self.openURLInNewTab(url, isPrivate: isPrivate)
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -87,11 +87,11 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         let viewLogins: PhotonActionSheetItem? = !isLoginsButtonShowing ? nil :
             PhotonActionSheetItem(title: Strings.LoginsAndPasswordsTitle, iconString: "key", iconType: .Image, iconAlignment: .left, isEnabled: true) { _, _ in
             guard let navController = self.navigationController else { return }
-                let navigationHandler: ((_ url: URL?) -> Void) = { url in
-                    UIApplication.shared.keyWindow?.rootViewController?.dismiss(animated: true, completion: nil)
-                    self.openURLInNewTab(url)
-                }
-                LoginListViewController.create(authenticateInNavigationController: navController, profile: self.profile, settingsDelegate: self, webpageNavigationHandler: navigationHandler).uponQueue(.main) { loginsVC in
+            let navigationHandler: ((_ url: URL?) -> Void) = { url in
+                UIApplication.shared.keyWindow?.rootViewController?.dismiss(animated: true, completion: nil)
+                self.openURLInNewTab(url)
+            }
+            LoginListViewController.create(authenticateInNavigationController: navController, profile: self.profile, settingsDelegate: self, webpageNavigationHandler: navigationHandler).uponQueue(.main) { loginsVC in
                 guard let loginsVC = loginsVC else { return }
                 loginsVC.shownFromAppMenu = true
                 let navController = ThemedNavigationController(rootViewController: loginsVC)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -87,7 +87,11 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         let viewLogins: PhotonActionSheetItem? = !isLoginsButtonShowing ? nil :
             PhotonActionSheetItem(title: Strings.LoginsAndPasswordsTitle, iconString: "key", iconType: .Image, iconAlignment: .left, isEnabled: true) { _, _ in
             guard let navController = self.navigationController else { return }
-            LoginListViewController.create(authenticateInNavigationController: navController, profile: self.profile, settingsDelegate: self).uponQueue(.main) { loginsVC in
+                let navigationHandler: ((_ url: URL?) -> ()) = { url in
+                    UIApplication.shared.keyWindow?.rootViewController?.dismiss(animated: true, completion: nil)
+                    self.openURLInNewTab(url)
+                }
+                LoginListViewController.create(authenticateInNavigationController: navController, profile: self.profile, settingsDelegate: self, webpageNavigationHandler: navigationHandler).uponQueue(.main) { loginsVC in
                 guard let loginsVC = loginsVC else { return }
                 loginsVC.shownFromAppMenu = true
                 let navController = ThemedNavigationController(rootViewController: loginsVC)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -62,7 +62,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     }
 
     func tabToolbarDidPressMenu(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
-        var whatsNewAction: PhotonActionSheetItem? = nil
+        var whatsNewAction: PhotonActionSheetItem?
         let showBadgeForWhatsNew = shouldShowWhatsNew()
         if showBadgeForWhatsNew {
             // Set the version number of the app, so the What's new will stop showing
@@ -87,7 +87,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         let viewLogins: PhotonActionSheetItem? = !isLoginsButtonShowing ? nil :
             PhotonActionSheetItem(title: Strings.LoginsAndPasswordsTitle, iconString: "key", iconType: .Image, iconAlignment: .left, isEnabled: true) { _, _ in
             guard let navController = self.navigationController else { return }
-                let navigationHandler: ((_ url: URL?) -> ()) = { url in
+                let navigationHandler: ((_ url: URL?) -> Void) = { url in
                     UIApplication.shared.keyWindow?.rootViewController?.dismiss(animated: true, completion: nil)
                     self.openURLInNewTab(url)
                 }

--- a/Client/Frontend/Login Management/BreachAlertsClient.swift
+++ b/Client/Frontend/Login Management/BreachAlertsClient.swift
@@ -23,7 +23,6 @@ public class BreachAlertsClient: BreachAlertsClientProtocol {
 
     /// Makes a network request to an endpoint and hands off the result to a completion handler.
     public func fetchData(endpoint: Endpoint, completion: @escaping (_ result: Maybe<Data>) -> Void) {
-        // endpoint.rawValue is the url
         guard let url = URL(string: endpoint.rawValue) else {
             completion(Maybe(failure: BreachAlertsError(description: "bad endpoint URL")))
             return

--- a/Client/Frontend/Login Management/BreachAlertsDetailView.swift
+++ b/Client/Frontend/Login Management/BreachAlertsDetailView.swift
@@ -29,7 +29,7 @@ class BreachAlertsDetailView: UIView {
         return button
     }()
 
-    lazy var titleContainer: UIStackView = {
+    lazy var titleStack: UIStackView = {
         let container = UIStackView(arrangedSubviews: [titleIcon, titleLabel, titleLearnMore])
         container.axis = .horizontal
         return container
@@ -56,8 +56,8 @@ class BreachAlertsDetailView: UIView {
         return button
     }()
 
-    lazy var contentStack: UIStackView = {
-        let stack = UIStackView(arrangedSubviews: [titleContainer, breachDateLabel, descriptionLabel, goToButton])
+    private lazy var contentStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [titleStack, breachDateLabel, descriptionLabel, goToButton])
         stack.axis = .vertical
         return stack
     }()
@@ -68,9 +68,6 @@ class BreachAlertsDetailView: UIView {
         self.backgroundColor = UIColor.red
         self.layer.cornerRadius = 5
         self.layer.masksToBounds = true
-        self.snp.makeConstraints { make in
-            make.height.greaterThanOrEqualTo(200)
-        }
 
         self.addSubview(contentStack)
     }
@@ -79,11 +76,12 @@ class BreachAlertsDetailView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    internal override func updateConstraints() {
-        super.updateConstraints()
-
-//        contentStack.snp.remakeConstraints { make in
-//            make.edges.equalToSuperview()
-//        }
+    override func layoutSubviews() {
+        titleStack.snp.remakeConstraints { make in
+            make.leading.trailing.equalToSuperview()
+        }
+        contentStack.snp.remakeConstraints { make in
+            make.top.bottom.equalToSuperview()
+        }
     }
 }

--- a/Client/Frontend/Login Management/BreachAlertsDetailView.swift
+++ b/Client/Frontend/Login Management/BreachAlertsDetailView.swift
@@ -82,7 +82,6 @@ class BreachAlertsDetailView: UIView {
         button.isUserInteractionEnabled = true
         button.text = Strings.BreachAlertsLink
         button.accessibilityLabel = Strings.BreachAlertsLink.description
-//        button.titleLabel?.te
         return button
     }()
 

--- a/Client/Frontend/Login Management/BreachAlertsDetailView.swift
+++ b/Client/Frontend/Login Management/BreachAlertsDetailView.swift
@@ -10,7 +10,7 @@ class BreachAlertsDetailView: UIView {
     private let textColor = UIColor.white
     private let titleIconSize: CGFloat = 24
     private lazy var titleIconContainerSize: CGFloat = {
-        return titleIconSize+LoginTableViewCellUX.HorizontalMargin*2
+        return titleIconSize + LoginTableViewCellUX.HorizontalMargin * 2
     }()
 
     lazy var titleIcon: UIImageView = {

--- a/Client/Frontend/Login Management/BreachAlertsDetailView.swift
+++ b/Client/Frontend/Login Management/BreachAlertsDetailView.swift
@@ -30,7 +30,9 @@ class BreachAlertsDetailView: UIView {
     }()
 
     lazy var titleContainer: UIStackView = {
-        return UIStackView(arrangedSubviews: [titleIcon, titleLabel, titleLearnMore])
+        let container = UIStackView(arrangedSubviews: [titleIcon, titleLabel, titleLearnMore])
+        container.axis = .horizontal
+        return container
     }()
 
     lazy var breachDateLabel: UILabel = {
@@ -54,21 +56,34 @@ class BreachAlertsDetailView: UIView {
         return button
     }()
 
+    lazy var contentStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [titleContainer, breachDateLabel, descriptionLabel, goToButton])
+        stack.axis = .vertical
+        return stack
+    }()
+
     override init(frame: CGRect) {
         super.init(frame: frame)
 
         self.backgroundColor = UIColor.red
         self.layer.cornerRadius = 5
         self.layer.masksToBounds = true
+        self.snp.makeConstraints { make in
+            make.height.greaterThanOrEqualTo(200)
+        }
 
-        self.addSubview(titleContainer)
-        self.addSubview(breachDateLabel)
-        self.addSubview(descriptionLabel)
-        self.addSubview(goToButton)
+        self.addSubview(contentStack)
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
+    internal override func updateConstraints() {
+        super.updateConstraints()
+
+//        contentStack.snp.remakeConstraints { make in
+//            make.edges.equalToSuperview()
+//        }
+    }
 }

--- a/Client/Frontend/Login Management/BreachAlertsDetailView.swift
+++ b/Client/Frontend/Login Management/BreachAlertsDetailView.swift
@@ -124,6 +124,7 @@ class BreachAlertsDetailView: UIView {
         self.accessibilityElements = [titleLabel, learnMoreButton, breachDateLabel, descriptionLabel, goToButton]
 
         self.addSubview(contentStack)
+        self.configureView(for: self.traitCollection)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -145,6 +146,7 @@ class BreachAlertsDetailView: UIView {
         self.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
     }
 
+    // Populate the view with information from a BreachRecord.
     public func setup(_ breach: BreachRecord) {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
@@ -163,5 +165,38 @@ class BreachAlertsDetailView: UIView {
 
         self.goToButton.accessibilityValue = breach.domain
         self.breachDateLabel.accessibilityValue = "\(dateFormatter.string(from: date))."
+    }
+
+    // MARK: - Dynamic Type Support
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if previousTraitCollection?.preferredContentSizeCategory != self.traitCollection.preferredContentSizeCategory {
+            configureView(for: self.traitCollection)
+        }
+    }
+
+    // If large fonts are enabled, set the title stack vertically.
+    // Else, set the title stack horizontally.
+    private func configureView(for traitCollection: UITraitCollection) {
+        let contentSize = traitCollection.preferredContentSizeCategory
+        if contentSize.isAccessibilityCategory {
+            self.titleStack.axis = .vertical
+            self.titleStack.alignment = .leading
+            self.titleLabel.snp.makeConstraints { make in
+                make.leading.equalToSuperview().offset(self.titleIconSize)
+            }
+            self.learnMoreButton.snp.makeConstraints { make in
+                make.leading.equalToSuperview().offset(self.titleIconSize)
+            }
+        } else {
+            self.titleStack.axis = .horizontal
+            self.titleStack.alignment = .leading
+            self.titleLabel.snp.makeConstraints { make in
+                make.centerY.equalToSuperview()
+            }
+            self.learnMoreButton.snp.makeConstraints { make in
+                make.centerY.equalToSuperview()
+            }
+        }
     }
 }

--- a/Client/Frontend/Login Management/BreachAlertsDetailView.swift
+++ b/Client/Frontend/Login Management/BreachAlertsDetailView.swift
@@ -144,4 +144,24 @@ class BreachAlertsDetailView: UIView {
         }
         self.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
     }
+
+    public func setup(_ breach: BreachRecord) {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        guard let date = dateFormatter.date(from: breach.breachDate) else { return }
+        dateFormatter.dateStyle = .medium
+        self.breachDateLabel.text! += " \(dateFormatter.string(from: date))."
+        let goToText = Strings.BreachAlertsLink + " \(breach.domain)"
+        let attributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: UIColor.white,
+            .underlineStyle: NSUnderlineStyle.single.rawValue
+        ]
+        let attributedText = NSMutableAttributedString(string: goToText, attributes: attributes)
+        self.goToButton.attributedText = attributedText
+        self.goToButton.sizeToFit()
+        self.layoutIfNeeded()
+
+        self.goToButton.accessibilityValue = breach.domain
+        self.breachDateLabel.accessibilityValue = "\(dateFormatter.string(from: date))."
+    }
 }

--- a/Client/Frontend/Login Management/BreachAlertsDetailView.swift
+++ b/Client/Frontend/Login Management/BreachAlertsDetailView.swift
@@ -16,6 +16,8 @@ class BreachAlertsDetailView: UIView {
     lazy var titleIcon: UIImageView = {
         let imageView = UIImageView(image: BreachAlertsManager.icon)
         imageView.tintColor = textColor
+        imageView.accessibilityTraits = .image
+        imageView.accessibilityLabel = "Breach Alert Icon"
         return imageView
     }()
 
@@ -38,20 +40,26 @@ class BreachAlertsDetailView: UIView {
         label.textColor = textColor
         label.text = Strings.BreachAlertsTitle
         label.sizeToFit()
+        label.isAccessibilityElement = true
+        label.accessibilityTraits = .staticText
+        label.accessibilityLabel = Strings.BreachAlertsTitle
         return label
     }()
 
-    lazy var titleLearnMore: UIButton = {
+    lazy var learnMoreButton: UIButton = {
         let button = UIButton()
         button.titleLabel?.font = DynamicFontHelper.defaultHelper.DeviceFontLight
         button.setTitle(Strings.BreachAlertsLearnMore, for: .normal)
         button.setTitleColor(textColor, for: .normal)
         button.tintColor = .white
+        button.isAccessibilityElement = true
+        button.accessibilityTraits = .button
+        button.accessibilityLabel = Strings.BreachAlertsLearnMore
         return button
     }()
 
     lazy var titleStack: UIStackView = {
-        let container = UIStackView(arrangedSubviews: [titleIconContainer, titleLabel, titleLearnMore])
+        let container = UIStackView(arrangedSubviews: [titleIconContainer, titleLabel, learnMoreButton])
         container.axis = .horizontal
         return container
     }()
@@ -62,6 +70,9 @@ class BreachAlertsDetailView: UIView {
         label.textColor = textColor
         label.numberOfLines = 0
         label.font = DynamicFontHelper.defaultHelper.DeviceFontSmallBold
+        label.isAccessibilityElement = true
+        label.accessibilityTraits = .staticText
+        label.accessibilityLabel = Strings.BreachAlertsBreachDate
         return label
     }()
 
@@ -71,6 +82,8 @@ class BreachAlertsDetailView: UIView {
         label.numberOfLines = 0
         label.textColor = textColor
         label.font = DynamicFontHelper.defaultHelper.DeviceFontSmall
+        label.isAccessibilityElement = true
+        label.accessibilityTraits = .staticText
         return label
     }()
 
@@ -81,7 +94,9 @@ class BreachAlertsDetailView: UIView {
         button.numberOfLines = 0
         button.isUserInteractionEnabled = true
         button.text = Strings.BreachAlertsLink
-        button.accessibilityLabel = Strings.BreachAlertsLink.description
+        button.isAccessibilityElement = true
+        button.accessibilityTraits = .button
+        button.accessibilityLabel = Strings.BreachAlertsLink
         return button
     }()
 
@@ -104,6 +119,9 @@ class BreachAlertsDetailView: UIView {
         self.backgroundColor = BreachAlertsManager.detailColor
         self.layer.cornerRadius = 5
         self.layer.masksToBounds = true
+
+        self.isAccessibilityElement = false
+        self.accessibilityElements = [titleLabel, learnMoreButton, breachDateLabel, descriptionLabel, goToButton]
 
         self.addSubview(contentStack)
     }

--- a/Client/Frontend/Login Management/BreachAlertsDetailView.swift
+++ b/Client/Frontend/Login Management/BreachAlertsDetailView.swift
@@ -14,8 +14,8 @@ class BreachAlertsDetailView: UIView {
     }()
 
     lazy var titleIcon: UIImageView = {
-        let image = UIImage(named: "Breached Website")?.tinted(withColor: .white)
-        let imageView = UIImageView(image: image)
+        let imageView = UIImageView(image: BreachAlertsManager.icon)
+        imageView.tintColor = textColor
         return imageView
     }()
 
@@ -42,9 +42,10 @@ class BreachAlertsDetailView: UIView {
     }()
 
     lazy var titleLearnMore: UIButton = {
-        let button = UIButton() //? or detail disclosure?
+        let button = UIButton()
         button.setTitle(Strings.BreachAlertsLearnMore, for: .normal)
         button.setTitleColor(textColor, for: .normal)
+        button.tintColor = .white
         return button
     }()
 
@@ -68,7 +69,7 @@ class BreachAlertsDetailView: UIView {
         label.text = Strings.BreachAlertsDescription
         label.numberOfLines = 0
         label.textColor = textColor
-        label.font = DynamicFontHelper.defaultHelper.DeviceFont
+        label.font = DynamicFontHelper.defaultHelper.DeviceFontSmall
         return label
     }()
 
@@ -80,8 +81,14 @@ class BreachAlertsDetailView: UIView {
         return button
     }()
 
+    private lazy var infoStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [breachDateLabel, descriptionLabel, goToButton])
+        stack.axis = .vertical
+        return stack
+    }()
+
     private lazy var contentStack: UIStackView = {
-        let stack = UIStackView(arrangedSubviews: [titleStack, breachDateLabel, descriptionLabel, goToButton])
+        let stack = UIStackView(arrangedSubviews: [titleStack, infoStack])
         stack.axis = .vertical
         return stack
     }()
@@ -89,7 +96,7 @@ class BreachAlertsDetailView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        self.backgroundColor = UIColor.red
+        self.backgroundColor = BreachAlertsManager.detailColor
         self.layer.cornerRadius = 5
         self.layer.masksToBounds = true
 
@@ -104,8 +111,12 @@ class BreachAlertsDetailView: UIView {
         titleStack.snp.remakeConstraints { make in
             make.leading.trailing.equalToSuperview()
         }
+        infoStack.snp.remakeConstraints { make in
+            make.leading.equalToSuperview().inset(titleIconContainerSize)
+        }
         contentStack.snp.remakeConstraints { make in
             make.edges.equalToSuperview().inset(LoginTableViewCellUX.HorizontalMargin)
         }
+        self.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
     }
 }

--- a/Client/Frontend/Login Management/BreachAlertsDetailView.swift
+++ b/Client/Frontend/Login Management/BreachAlertsDetailView.swift
@@ -10,7 +10,7 @@ class BreachAlertsDetailView: UIView {
     private let textColor = UIColor.white
     private let titleIconSize: CGFloat = 24
     private lazy var titleIconContainerSize: CGFloat = {
-        return titleIconSize+LoginTableViewCellUX.HorizontalMargin
+        return titleIconSize+LoginTableViewCellUX.HorizontalMargin*2
     }()
 
     lazy var titleIcon: UIImageView = {
@@ -27,7 +27,7 @@ class BreachAlertsDetailView: UIView {
             make.center.equalToSuperview()
         }
         container.snp.makeConstraints { make in
-            make.width.equalTo(titleIconContainerSize)
+            make.width.height.equalTo(titleIconContainerSize)
         }
         return container
     }()
@@ -43,6 +43,7 @@ class BreachAlertsDetailView: UIView {
 
     lazy var titleLearnMore: UIButton = {
         let button = UIButton()
+        button.titleLabel?.font = DynamicFontHelper.defaultHelper.DeviceFontLight
         button.setTitle(Strings.BreachAlertsLearnMore, for: .normal)
         button.setTitleColor(textColor, for: .normal)
         button.tintColor = .white
@@ -73,16 +74,21 @@ class BreachAlertsDetailView: UIView {
         return label
     }()
 
-    lazy var goToButton: UIButton = {
-        let button = UIButton()
-        button.setTitleColor(textColor, for: .normal)
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.DeviceFontSmallBold
-        button.contentHorizontalAlignment = .left
+    lazy var goToButton: UILabel = {
+        let button = UILabel()
+        button.font = DynamicFontHelper.defaultHelper.DeviceFontSmallBold
+        button.textColor = textColor
+        button.numberOfLines = 0
+        button.isUserInteractionEnabled = true
+        button.text = Strings.BreachAlertsLink
+        button.accessibilityLabel = Strings.BreachAlertsLink.description
+//        button.titleLabel?.te
         return button
     }()
 
     private lazy var infoStack: UIStackView = {
         let stack = UIStackView(arrangedSubviews: [breachDateLabel, descriptionLabel, goToButton])
+        stack.distribution = .fillProportionally
         stack.axis = .vertical
         return stack
     }()
@@ -113,9 +119,11 @@ class BreachAlertsDetailView: UIView {
         }
         infoStack.snp.remakeConstraints { make in
             make.leading.equalToSuperview().inset(titleIconContainerSize)
+            make.trailing.equalToSuperview()
         }
         contentStack.snp.remakeConstraints { make in
-            make.edges.equalToSuperview().inset(LoginTableViewCellUX.HorizontalMargin)
+            make.bottom.trailing.equalToSuperview().inset(LoginTableViewCellUX.HorizontalMargin)
+            make.leading.top.equalToSuperview()
         }
         self.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
     }

--- a/Client/Frontend/Login Management/BreachAlertsDetailView.swift
+++ b/Client/Frontend/Login Management/BreachAlertsDetailView.swift
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+import Shared
+
+class BreachAlertsDetailView: UIView {
+
+    private let textColor = UIColor.white
+
+    lazy var titleIcon: UIImageView = {
+        let image = UIImage(named: "Breached Website@3x")
+        return UIImageView(image: image)
+    }()
+
+    lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = DynamicFontHelper.defaultHelper.DeviceFontLarge
+        label.textColor = textColor
+        label.text = Strings.BreachAlertsTitle
+        return label
+    }()
+
+    lazy var titleLearnMore: UIButton = {
+        let button = UIButton(type: .detailDisclosure)
+        button.titleLabel?.text = Strings.BreachAlertsLearnMore
+        button.titleLabel?.textColor = textColor
+        return button
+    }()
+
+    lazy var titleContainer: UIStackView = {
+        return UIStackView(arrangedSubviews: [titleIcon, titleLabel, titleLearnMore])
+    }()
+
+    lazy var breachDateLabel: UILabel = {
+        let label = UILabel()
+        label.text = Strings.BreachAlertsBreachDate
+        label.textColor = textColor
+        return label
+    }()
+
+    lazy var descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.text = Strings.BreachAlertsDescription
+        label.textColor = textColor
+        return label
+    }()
+
+    lazy var goToButton: UIButton = {
+        let button = UIButton()
+        button.titleLabel?.text = Strings.BreachAlertsLink
+        button.titleLabel?.textColor = textColor
+        return button
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        self.backgroundColor = UIColor.red
+        self.layer.cornerRadius = 5
+        self.layer.masksToBounds = true
+
+        self.addSubview(titleContainer)
+        self.addSubview(breachDateLabel)
+        self.addSubview(descriptionLabel)
+        self.addSubview(goToButton)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}

--- a/Client/Frontend/Login Management/BreachAlertsDetailView.swift
+++ b/Client/Frontend/Login Management/BreachAlertsDetailView.swift
@@ -8,29 +8,48 @@ import Shared
 class BreachAlertsDetailView: UIView {
 
     private let textColor = UIColor.white
+    private let titleIconSize: CGFloat = 24
+    private lazy var titleIconContainerSize: CGFloat = {
+        return titleIconSize+LoginTableViewCellUX.HorizontalMargin
+    }()
 
     lazy var titleIcon: UIImageView = {
-        let image = UIImage(named: "Breached Website@3x")
-        return UIImageView(image: image)
+        let image = UIImage(named: "Breached Website")?.tinted(withColor: .white)
+        let imageView = UIImageView(image: image)
+        return imageView
+    }()
+
+    lazy var titleIconContainer: UIView = {
+        let container = UIView()
+        container.addSubview(titleIcon)
+        titleIcon.snp.makeConstraints { make in
+            make.width.height.equalTo(titleIconSize)
+            make.center.equalToSuperview()
+        }
+        container.snp.makeConstraints { make in
+            make.width.equalTo(titleIconContainerSize)
+        }
+        return container
     }()
 
     lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.font = DynamicFontHelper.defaultHelper.DeviceFontLarge
+        label.font = DynamicFontHelper.defaultHelper.DeviceFontLargeBold
         label.textColor = textColor
         label.text = Strings.BreachAlertsTitle
+        label.sizeToFit()
         return label
     }()
 
     lazy var titleLearnMore: UIButton = {
-        let button = UIButton(type: .detailDisclosure)
-        button.titleLabel?.text = Strings.BreachAlertsLearnMore
-        button.titleLabel?.textColor = textColor
+        let button = UIButton() //? or detail disclosure?
+        button.setTitle(Strings.BreachAlertsLearnMore, for: .normal)
+        button.setTitleColor(textColor, for: .normal)
         return button
     }()
 
     lazy var titleStack: UIStackView = {
-        let container = UIStackView(arrangedSubviews: [titleIcon, titleLabel, titleLearnMore])
+        let container = UIStackView(arrangedSubviews: [titleIconContainer, titleLabel, titleLearnMore])
         container.axis = .horizontal
         return container
     }()
@@ -39,20 +58,25 @@ class BreachAlertsDetailView: UIView {
         let label = UILabel()
         label.text = Strings.BreachAlertsBreachDate
         label.textColor = textColor
+        label.numberOfLines = 0
+        label.font = DynamicFontHelper.defaultHelper.DeviceFontSmallBold
         return label
     }()
 
     lazy var descriptionLabel: UILabel = {
         let label = UILabel()
         label.text = Strings.BreachAlertsDescription
+        label.numberOfLines = 0
         label.textColor = textColor
+        label.font = DynamicFontHelper.defaultHelper.DeviceFont
         return label
     }()
 
     lazy var goToButton: UIButton = {
         let button = UIButton()
-        button.titleLabel?.text = Strings.BreachAlertsLink
-        button.titleLabel?.textColor = textColor
+        button.setTitleColor(textColor, for: .normal)
+        button.titleLabel?.font = DynamicFontHelper.defaultHelper.DeviceFontSmallBold
+        button.contentHorizontalAlignment = .left
         return button
     }()
 
@@ -81,7 +105,7 @@ class BreachAlertsDetailView: UIView {
             make.leading.trailing.equalToSuperview()
         }
         contentStack.snp.remakeConstraints { make in
-            make.top.bottom.equalToSuperview()
+            make.edges.equalToSuperview().inset(LoginTableViewCellUX.HorizontalMargin)
         }
     }
 }

--- a/Client/Frontend/Login Management/BreachAlertsManager.swift
+++ b/Client/Frontend/Login Management/BreachAlertsManager.swift
@@ -40,8 +40,6 @@ final public class BreachAlertsManager {
     ///    - Parameters:
     ///         - completion: a completion handler for the processed breaches
     func loadBreaches(completion: @escaping (Maybe<Set<BreachRecord>>) -> Void) {
-        print("loadBreaches(): called")
-
         self.breachAlertsClient.fetchData(endpoint: .breachedAccounts) { maybeData in
             guard let data = maybeData.successValue else {
                 completion(Maybe(failure: BreachAlertsError(description: "failed to load breaches data")))
@@ -56,14 +54,21 @@ final public class BreachAlertsManager {
             // remove for release
             self.breaches.insert(BreachRecord(
              name: "MockBreach",
-             title: "A Mock BreachRecord",
-             domain: "twitter.com",
+             title: "A Mock Blockbuster Record",
+             domain: "blockbuster.com",
              breachDate: "1970-01-02",
              description: "A mock BreachRecord for testing purposes."
             ))
             self.breaches.insert(BreachRecord(
              name: "MockBreach",
-             title: "A Mock BreachRecord",
+             title: "A Mock Lorem Ipsum Record",
+             domain: "lipsum.com",
+             breachDate: "1970-01-02",
+             description: "A mock BreachRecord for testing purposes."
+            ))
+            self.breaches.insert(BreachRecord(
+             name: "MockBreach",
+             title: "A Long Mock Breach Record",
              domain: "duisatconsecteturloremdonecmassasapienfaucibusetmolestieacfeugiatsedlectusvestibulummattisullamcorpervelitsedullamcorp.com",
              breachDate: "1970-01-02",
              description: "A mock BreachRecord for testing purposes."

--- a/Client/Frontend/Login Management/BreachAlertsManager.swift
+++ b/Client/Frontend/Login Management/BreachAlertsManager.swift
@@ -28,6 +28,7 @@ final public class BreachAlertsManager {
     static let icon = UIImage(named: "Breached Website")?.withRenderingMode(.alwaysTemplate)
     static let listColor = UIColor(red: 0.78, green: 0.16, blue: 0.18, alpha: 1.00)
     static let detailColor = UIColor(red: 0.59, green: 0.11, blue: 0.11, alpha: 1.00)
+    static let monitorAboutUrl = URL(string: "https://monitor.firefox.com/about")
     var breaches = Set<BreachRecord>()
     var breachAlertsClient: BreachAlertsClientProtocol
 

--- a/Client/Frontend/Login Management/BreachAlertsManager.swift
+++ b/Client/Frontend/Login Management/BreachAlertsManager.swift
@@ -68,8 +68,8 @@ final public class BreachAlertsManager {
             ))
             self.breaches.insert(BreachRecord(
              name: "MockBreach",
-             title: "A Long Mock Breach Record",
-             domain: "duisatconsecteturloremdonecmassasapienfaucibusetmolestieacfeugiatsedlectusvestibulummattisullamcorpervelitsedullamcorp.com",
+             title: "A Mock Swift Breach Record",
+             domain: "swift.org",
              breachDate: "1970-01-02",
              description: "A mock BreachRecord for testing purposes."
             ))

--- a/Client/Frontend/Login Management/BreachAlertsManager.swift
+++ b/Client/Frontend/Login Management/BreachAlertsManager.swift
@@ -64,7 +64,7 @@ final public class BreachAlertsManager {
             self.breaches.insert(BreachRecord(
              name: "MockBreach",
              title: "A Mock BreachRecord",
-             domain: "abreach.com",
+             domain: "duisatconsecteturloremdonecmassasapienfaucibusetmolestieacfeugiatsedlectusvestibulummattisullamcorpervelitsedullamcorp.com",
              breachDate: "1970-01-02",
              description: "A mock BreachRecord for testing purposes."
             ))

--- a/Client/Frontend/Login Management/BreachAlertsManager.swift
+++ b/Client/Frontend/Login Management/BreachAlertsManager.swift
@@ -57,7 +57,7 @@ final public class BreachAlertsManager {
             self.breaches.insert(BreachRecord(
              name: "MockBreach",
              title: "A Mock BreachRecord",
-             domain: "abreachedwithalongstringnameaslkdjflskjfas.com",
+             domain: "twitter.com",
              breachDate: "1970-01-02",
              description: "A mock BreachRecord for testing purposes."
             ))

--- a/Client/Frontend/Login Management/BreachAlertsManager.swift
+++ b/Client/Frontend/Login Management/BreachAlertsManager.swift
@@ -25,6 +25,9 @@ struct BreachRecord: Codable, Equatable, Hashable {
 
 /// A manager for the user's breached login information, if any.
 final public class BreachAlertsManager {
+    static let icon = UIImage(named: "Breached Website")?.withRenderingMode(.alwaysTemplate)
+    static let listColor = UIColor(red: 0.78, green: 0.16, blue: 0.18, alpha: 1.00)
+    static let detailColor = UIColor(red: 0.59, green: 0.11, blue: 0.11, alpha: 1.00)
     var breaches = Set<BreachRecord>()
     var breachAlertsClient: BreachAlertsClientProtocol
 

--- a/Client/Frontend/Login Management/LoginListTableViewCell.swift
+++ b/Client/Frontend/Login Management/LoginListTableViewCell.swift
@@ -6,8 +6,8 @@ import UIKit
 
 class LoginListTableViewCell: ThemedTableViewCell {
     lazy var breachAlertImageView: UIImageView = {
-        let image = UIImage(named: "Breached Website")
-        let imageView = UIImageView(image: image)
+        let imageView = UIImageView(image: BreachAlertsManager.icon)
+        imageView.tintColor = BreachAlertsManager.listColor
         imageView.isHidden = true
         return imageView
     }()

--- a/Client/Frontend/Login Management/LoginListTableViewCell.swift
+++ b/Client/Frontend/Login Management/LoginListTableViewCell.swift
@@ -64,6 +64,7 @@ class LoginListTableViewCell: ThemedTableViewCell {
         contentView.addSubview(contentStack)
         // Need to override the default background multi-select color to support theming
         self.multipleSelectionBackgroundView = UIView()
+        self.hostnameLabel.textColor = UIColor.theme.tableView.rowText
         self.usernameLabel.textColor = self.detailTextColor
         self.applyTheme()
         setConstraints()

--- a/Client/Frontend/Login Management/LoginListTableViewCell.swift
+++ b/Client/Frontend/Login Management/LoginListTableViewCell.swift
@@ -30,7 +30,7 @@ class LoginListTableViewCell: ThemedTableViewCell {
             make.top.equalTo(inset.top)
             make.centerY.equalTo(contentView)
             if let detailTextLabel = self.detailTextLabel {
-                make.bottom.equalTo(detailTextLabel.snp.top)
+                make.bottom.equalTo(detailTextLabel.snp.top).offset(inset.top)
                 make.top.equalTo(contentView.snp.top).offset(LoginTableViewCellUX.HorizontalMargin)
             }
         })

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -445,6 +445,7 @@ extension LoginListViewController: LoginViewModelDelegate {
             self.viewModel.breachIndexPath.forEach {
                 guard let cell = self.tableView.cellForRow(at: $0) as? LoginListTableViewCell else { return }
                 cell.breachAlertImageView.isHidden = false
+                cell.accessibilityValue = "Breached Login Alert"
             }
         }
     }

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -377,7 +377,12 @@ extension LoginListViewController: UITableViewDelegate {
             toggleDeleteBarButton()
         } else if let login = viewModel.loginAtIndexPath(indexPath) {
             tableView.deselectRow(at: indexPath, animated: true)
-            let detailViewController = LoginDetailViewController(profile: viewModel.profile, login: login, isBreached: viewModel.breachIndexPath.contains(indexPath))
+            let detailViewController = LoginDetailViewController(profile: viewModel.profile, login: login)
+            if viewModel.breachIndexPath.contains(indexPath) {
+                guard let login = viewModel.loginAtIndexPath(indexPath) else { return }
+                let breach = viewModel.breachAlertsManager.breachRecordForLogin(login)
+                detailViewController.setBreachRecord(breach: breach)
+            }
             detailViewController.settingsDelegate = settingsDelegate
             navigationController?.pushViewController(detailViewController, animated: true)
         }

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -377,7 +377,7 @@ extension LoginListViewController: UITableViewDelegate {
             toggleDeleteBarButton()
         } else if let login = viewModel.loginAtIndexPath(indexPath) {
             tableView.deselectRow(at: indexPath, animated: true)
-            let detailViewController = LoginDetailViewController(profile: viewModel.profile, login: login)
+            let detailViewController = LoginDetailViewController(profile: viewModel.profile, login: login, isBreached: viewModel.breachIndexPath.contains(indexPath))
             detailViewController.settingsDelegate = settingsDelegate
             navigationController?.pushViewController(detailViewController, animated: true)
         }

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -40,7 +40,7 @@ class LoginListViewController: SensitiveViewController {
 
     weak var settingsDelegate: SettingsDelegate?
     var shownFromAppMenu: Bool = false
-    var webpageNavigationHandler: ((_ url: URL?) -> ())?
+    var webpageNavigationHandler: ((_ url: URL?) -> Void)?
 
     // Titles for selection/deselect/delete buttons
     fileprivate let deselectAllTitle = NSLocalizedString("Deselect All", tableName: "LoginManager", comment: "Label for the button used to deselect all logins.")
@@ -59,7 +59,7 @@ class LoginListViewController: SensitiveViewController {
         return prefs.boolForKey(PrefsKeys.LoginsShowShortcutMenuItem) ?? true
     }
 
-    static func create(authenticateInNavigationController navigationController: UINavigationController, profile: Profile, settingsDelegate: SettingsDelegate, webpageNavigationHandler: ((_ url: URL?) -> ())?) -> Deferred<LoginListViewController?> {
+    static func create(authenticateInNavigationController navigationController: UINavigationController, profile: Profile, settingsDelegate: SettingsDelegate, webpageNavigationHandler: ((_ url: URL?) -> Void)?) -> Deferred<LoginListViewController?> {
         let deferred = Deferred<LoginListViewController?>()
 
         func fillDeferred(ok: Bool) {
@@ -96,7 +96,7 @@ class LoginListViewController: SensitiveViewController {
         return deferred
     }
 
-    private init(profile: Profile, webpageNavigationHandler: ((_ url: URL?) -> ())?) {
+    private init(profile: Profile, webpageNavigationHandler: ((_ url: URL?) -> Void)?) {
         self.viewModel = LoginListViewModel(profile: profile, searchController: searchController)
         self.loginDataSource = LoginDataSource(viewModel: self.viewModel)
         self.webpageNavigationHandler = webpageNavigationHandler

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -40,6 +40,7 @@ class LoginListViewController: SensitiveViewController {
 
     weak var settingsDelegate: SettingsDelegate?
     var shownFromAppMenu: Bool = false
+    var webpageNavigationHandler: ((_ url: URL?) -> ())?
 
     // Titles for selection/deselect/delete buttons
     fileprivate let deselectAllTitle = NSLocalizedString("Deselect All", tableName: "LoginManager", comment: "Label for the button used to deselect all logins.")
@@ -58,13 +59,13 @@ class LoginListViewController: SensitiveViewController {
         return prefs.boolForKey(PrefsKeys.LoginsShowShortcutMenuItem) ?? true
     }
 
-    static func create(authenticateInNavigationController navigationController: UINavigationController, profile: Profile, settingsDelegate: SettingsDelegate) -> Deferred<LoginListViewController?> {
+    static func create(authenticateInNavigationController navigationController: UINavigationController, profile: Profile, settingsDelegate: SettingsDelegate, webpageNavigationHandler: ((_ url: URL?) -> ())?) -> Deferred<LoginListViewController?> {
         let deferred = Deferred<LoginListViewController?>()
 
         func fillDeferred(ok: Bool) {
             if ok {
                 LeanPlumClient.shared.track(event: .openedLogins)
-                let viewController = LoginListViewController(profile: profile)
+                let viewController = LoginListViewController(profile: profile, webpageNavigationHandler: webpageNavigationHandler)
                 viewController.settingsDelegate = settingsDelegate
                 deferred.fill(viewController)
             } else {
@@ -95,9 +96,10 @@ class LoginListViewController: SensitiveViewController {
         return deferred
     }
 
-    private init(profile: Profile) {
+    private init(profile: Profile, webpageNavigationHandler: ((_ url: URL?) -> ())?) {
         self.viewModel = LoginListViewModel(profile: profile, searchController: searchController)
         self.loginDataSource = LoginDataSource(viewModel: self.viewModel)
+        self.webpageNavigationHandler = webpageNavigationHandler
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -377,7 +379,7 @@ extension LoginListViewController: UITableViewDelegate {
             toggleDeleteBarButton()
         } else if let login = viewModel.loginAtIndexPath(indexPath) {
             tableView.deselectRow(at: indexPath, animated: true)
-            let detailViewController = LoginDetailViewController(profile: viewModel.profile, login: login)
+            let detailViewController = LoginDetailViewController(profile: viewModel.profile, login: login, webpageNavigationHandler: webpageNavigationHandler)
             if viewModel.breachIndexPath.contains(indexPath) {
                 guard let login = viewModel.loginAtIndexPath(indexPath) else { return }
                 let breach = viewModel.breachAlertsManager.breachRecordForLogin(login)

--- a/Client/Frontend/Login Management/LoginListViewModel.swift
+++ b/Client/Frontend/Login Management/LoginListViewModel.swift
@@ -62,8 +62,9 @@ final class LoginListViewModel {
         let deferred = Deferred<Maybe<[LoginRecord]>>()
         profile.logins.searchLoginsWithQuery(query) >>== { logins in
             var log = logins.asArray()
-            log.append(LoginRecord(fromJSONDict: ["hostname" : "twitter.com", "timePasswordChanged": 46800000]))
-            log.append(LoginRecord(fromJSONDict: ["hostname" : "duisatconsecteturloremdonecmassasapienfaucibusetmolestieacfeugiatsedlectusvestibulummattisullamcorpervelitsedullamcorp.com", "timePasswordChanged": 46800000, "username": "username"]))
+            log.append(LoginRecord(fromJSONDict: ["hostname" : "https://blockbuster.com", "timePasswordChanged": 46800000]))
+            log.append(LoginRecord(fromJSONDict: ["hostname" : "https://lipsum.com", "timePasswordChanged": 46800000, "username": "lorem", "password": "ipsum"]))
+            log.append(LoginRecord(fromJSONDict: ["hostname" : "https://www.duisatconsecteturloremdonecmassasapienfaucibusetmolestieacfeugiatsedlectusvestibulummattisullamcorpervelitsedullamcorp.com", "timePasswordChanged": 46800000, "username": "username"]))
             deferred.fillIfUnfilled(Maybe(success: log))
             succeed()
         }

--- a/Client/Frontend/Login Management/LoginListViewModel.swift
+++ b/Client/Frontend/Login Management/LoginListViewModel.swift
@@ -63,7 +63,7 @@ final class LoginListViewModel {
         profile.logins.searchLoginsWithQuery(query) >>== { logins in
             var log = logins.asArray()
             log.append(LoginRecord(fromJSONDict: ["hostname" : "twitter.com", "timePasswordChanged": 46800000]))
-            log.append(LoginRecord(fromJSONDict: ["hostname" : "abreach.com", "timePasswordChanged": 46800000, "username": "username"]))
+            log.append(LoginRecord(fromJSONDict: ["hostname" : "duisatconsecteturloremdonecmassasapienfaucibusetmolestieacfeugiatsedlectusvestibulummattisullamcorpervelitsedullamcorp.com", "timePasswordChanged": 46800000, "username": "username"]))
             deferred.fillIfUnfilled(Maybe(success: log))
             succeed()
         }

--- a/Client/Frontend/Login Management/LoginListViewModel.swift
+++ b/Client/Frontend/Login Management/LoginListViewModel.swift
@@ -62,7 +62,7 @@ final class LoginListViewModel {
         let deferred = Deferred<Maybe<[LoginRecord]>>()
         profile.logins.searchLoginsWithQuery(query) >>== { logins in
             var log = logins.asArray()
-            log.append(LoginRecord(fromJSONDict: ["hostname" : "abreachedwithalongstringnameaslkdjflskjfas.com", "timePasswordChanged": 46800000]))
+            log.append(LoginRecord(fromJSONDict: ["hostname" : "twitter.com", "timePasswordChanged": 46800000]))
             log.append(LoginRecord(fromJSONDict: ["hostname" : "abreach.com", "timePasswordChanged": 46800000, "username": "username"]))
             deferred.fillIfUnfilled(Maybe(success: log))
             succeed()

--- a/Client/Frontend/Login Management/LoginListViewModel.swift
+++ b/Client/Frontend/Login Management/LoginListViewModel.swift
@@ -62,9 +62,9 @@ final class LoginListViewModel {
         let deferred = Deferred<Maybe<[LoginRecord]>>()
         profile.logins.searchLoginsWithQuery(query) >>== { logins in
             var log = logins.asArray()
-            log.append(LoginRecord(fromJSONDict: ["hostname" : "https://blockbuster.com", "timePasswordChanged": 46800000]))
+            log.append(LoginRecord(fromJSONDict: ["hostname" : "https://blockbuster.com", "timePasswordChanged": 46800000, "password": "ipsum"]))
             log.append(LoginRecord(fromJSONDict: ["hostname" : "https://lipsum.com", "timePasswordChanged": 46800000, "username": "lorem", "password": "ipsum"]))
-            log.append(LoginRecord(fromJSONDict: ["hostname" : "https://www.duisatconsecteturloremdonecmassasapienfaucibusetmolestieacfeugiatsedlectusvestibulummattisullamcorpervelitsedullamcorp.com", "timePasswordChanged": 46800000, "username": "username"]))
+            log.append(LoginRecord(fromJSONDict: ["hostname" : "https://swift.org", "timePasswordChanged": 46800000, "username": "username", "password": "ipsum"]))
             deferred.fillIfUnfilled(Maybe(success: log))
             succeed()
         }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -821,6 +821,7 @@ class LoginsSetting: Setting {
         guard let navController = navigationController else { return }
         let navigationHandler: ((_ url: URL?) -> Void) = { url in
             guard let url = url else { return }
+            UIApplication.shared.keyWindow?.rootViewController?.dismiss(animated: true, completion: nil)
             self.delegate?.settingsOpenURLInNewTab(url)
         }
         LoginListViewController.create(authenticateInNavigationController: navController, profile: profile, settingsDelegate: BrowserViewController.foregroundBVC(), webpageNavigationHandler: navigationHandler).uponQueue(.main) { loginsVC in

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -666,7 +666,7 @@ class LicenseAndAcknowledgementsSetting: Setting {
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        setUpAndPushSettingsContentViewController(navigationController)
+        setUpAndPushSettingsContentViewController(navigationController, self.url)
     }
 }
 
@@ -682,7 +682,7 @@ class YourRightsSetting: Setting {
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        setUpAndPushSettingsContentViewController(navigationController)
+        setUpAndPushSettingsContentViewController(navigationController, self.url)
     }
 }
 
@@ -715,7 +715,7 @@ class SendFeedbackSetting: Setting {
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        setUpAndPushSettingsContentViewController(navigationController)
+        setUpAndPushSettingsContentViewController(navigationController, self.url)
     }
 }
 
@@ -744,7 +744,7 @@ class SendAnonymousUsageDataSetting: BoolSetting {
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        setUpAndPushSettingsContentViewController(navigationController)
+        setUpAndPushSettingsContentViewController(navigationController, self.url)
     }
 }
 
@@ -820,7 +820,8 @@ class LoginsSetting: Setting {
         
         guard let navController = navigationController else { return }
         let navigationHandler: ((_ url: URL?) -> Void) = { url in
-//            self.openURLInNewTab(url)
+            guard let url = url else { return }
+            self.delegate?.settingsOpenURLInNewTab(url)
         }
         LoginListViewController.create(authenticateInNavigationController: navController, profile: profile, settingsDelegate: BrowserViewController.foregroundBVC(), webpageNavigationHandler: navigationHandler).uponQueue(.main) { loginsVC in
             guard let loginsVC = loginsVC else { return }
@@ -918,7 +919,7 @@ class PrivacyPolicySetting: Setting {
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        setUpAndPushSettingsContentViewController(navigationController)
+        setUpAndPushSettingsContentViewController(navigationController, self.url)
     }
 }
 

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -819,7 +819,10 @@ class LoginsSetting: Setting {
         deselectRow()
         
         guard let navController = navigationController else { return }
-        LoginListViewController.create(authenticateInNavigationController: navController, profile: profile, settingsDelegate: BrowserViewController.foregroundBVC()).uponQueue(.main) { loginsVC in
+        let navigationHandler: ((_ url: URL?) -> ()) = { url in
+//            self.openURLInNewTab(url)
+        }
+        LoginListViewController.create(authenticateInNavigationController: navController, profile: profile, settingsDelegate: BrowserViewController.foregroundBVC(), webpageNavigationHandler: navigationHandler).uponQueue(.main) { loginsVC in
             guard let loginsVC = loginsVC else { return }
             LeanPlumClient.shared.track(event: .openedLogins)
             navController.pushViewController(loginsVC, animated: true)

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -607,7 +607,7 @@ class VersionSetting: Setting {
     }
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: String(format: NSLocalizedString("Version %@ (%@)", comment: "Version number of Firefox shown in settings"),  VersionSetting.appVersion, VersionSetting.appBuildNumber), attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: String(format: NSLocalizedString("Version %@ (%@)", comment: "Version number of Firefox shown in settings"),  VersionSetting.appVersion,  VersionSetting.appBuildNumber), attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
     
     public static var appVersion: String {
@@ -819,7 +819,7 @@ class LoginsSetting: Setting {
         deselectRow()
         
         guard let navController = navigationController else { return }
-        let navigationHandler: ((_ url: URL?) -> ()) = { url in
+        let navigationHandler: ((_ url: URL?) -> Void) = { url in
 //            self.openURLInNewTab(url)
         }
         LoginListViewController.create(authenticateInNavigationController: navController, profile: profile, settingsDelegate: BrowserViewController.foregroundBVC(), webpageNavigationHandler: navigationHandler).uponQueue(.main) { loginsVC in

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -607,7 +607,7 @@ class VersionSetting: Setting {
     }
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: String(format: NSLocalizedString("Version %@ (%@)", comment: "Version number of Firefox shown in settings"),  VersionSetting.appVersion,  VersionSetting.appBuildNumber), attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: String(format: NSLocalizedString("Version %@ (%@)", comment: "Version number of Firefox shown in settings"), VersionSetting.appVersion,  VersionSetting.appBuildNumber), attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
     
     public static var appVersion: String {

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -87,6 +87,7 @@ class LoginDetailViewController: SensitiveViewController {
         tableView.snp.makeConstraints { make in
             make.edges.equalTo(self.view)
         }
+        tableView.estimatedRowHeight = 44.0
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -138,9 +139,13 @@ extension LoginDetailViewController: UITableViewDataSource {
         switch InfoItem(rawValue: indexPath.row)! {
         case .breachItem:
             let breachCell = cell(forIndexPath: indexPath)
+            guard let breach = self.breach else { return breachCell }
+            breachCell.isHidden = false
             let breachDetailView = BreachAlertsDetailView()
             breachCell.contentView.addSubview(breachDetailView)
-            guard let breach = self.breach else { return breachCell }
+            breachDetailView.snp.makeConstraints { make in
+                make.edges.equalTo(breachCell.contentView).inset(LoginTableViewCellUX.HorizontalMargin)
+            }
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = "yyyy-MM-dd"
             guard let date = dateFormatter.date(from: breach.breachDate) else { return breachCell }
@@ -153,14 +158,12 @@ extension LoginDetailViewController: UITableViewDataSource {
                 .underlineStyle: NSUnderlineStyle.single.rawValue
             ]
             let attributedText = NSMutableAttributedString(string: text, attributes: attributes)
-            breachDetailView.goToButton.setAttributedTitle(attributedText, for: .normal)
+            breachDetailView.goToButton.attributedText = attributedText
+            breachDetailView.goToButton.sizeToFit()
             breachDetailView.titleLearnMore.addTarget(self, action: #selector(didTapBreachLearnMore), for: .touchUpInside)
-            
-            breachDetailView.snp.makeConstraints { make in
-                make.leading.top.equalToSuperview().offset(LoginTableViewCellUX.HorizontalMargin)
-                make.trailing.bottom.equalToSuperview().inset(LoginTableViewCellUX.HorizontalMargin)
-            }
+            breachDetailView.layoutIfNeeded()
             return breachCell
+
         case .usernameItem:
             let loginCell = cell(forIndexPath: indexPath)
             loginCell.highlightedLabelTitle = NSLocalizedString("Username", tableName: "LoginManager", comment: "Label displayed above the username row in Login Detail View.")
@@ -271,7 +274,8 @@ extension LoginDetailViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         switch InfoItem(rawValue: indexPath.row)! {
         case .breachItem:
-            return self.breach != nil ? 240 : 0
+            guard let _ = self.breach else { return 0 }
+            return UITableView.automaticDimension
         case .usernameItem, .passwordItem, .websiteItem:
             return LoginDetailUX.InfoRowHeight
         case .lastModifiedSeparator:

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -44,6 +44,8 @@ class LoginDetailViewController: SensitiveViewController {
     fileprivate var menuControllerCell: LoginDetailTableViewCell?
     fileprivate var deleteAlert: UIAlertController?
     weak var settingsDelegate: SettingsDelegate?
+    fileprivate let breachDetailsView = BreachAlertsDetailView()
+    fileprivate var isBreached = false
 
     fileprivate var login: LoginRecord {
         didSet {
@@ -59,12 +61,19 @@ class LoginDetailViewController: SensitiveViewController {
         }
     }
 
-    init(profile: Profile, login: LoginRecord) {
+    init(profile: Profile, login: LoginRecord, isBreached: Bool) {
         self.login = login
         self.profile = profile
+        self.isBreached = isBreached
         super.init(nibName: nil, bundle: nil)
 
         NotificationCenter.default.addObserver(self, selector: #selector(dismissAlertController), name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+//            self.breachDetailsView.snp.makeConstraints { make in
+//                make.top.leading.trailing.equalTo(self.view)
+//                make.bottom.equalTo(tableView)
+//            }
+
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -77,6 +86,10 @@ class LoginDetailViewController: SensitiveViewController {
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .edit, target: self, action: #selector(edit))
 
         view.addSubview(tableView)
+
+        if self.isBreached {
+            tableView.tableHeaderView = breachDetailsView
+        }
         tableView.snp.makeConstraints { make in
             make.edges.equalTo(self.view)
         }

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -151,7 +151,6 @@ extension LoginDetailViewController: UITableViewDataSource {
             guard let date = dateFormatter.date(from: breach.breachDate) else { return breachCell }
             dateFormatter.dateStyle = .medium
             breachDetailView.breachDateLabel.text! += " \(dateFormatter.string(from: date))."
-
             let text = Strings.BreachAlertsLink + " \(breach.domain)"
             let attributes: [NSAttributedString.Key: Any] = [
                 .foregroundColor: UIColor.white,

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -139,13 +139,26 @@ extension LoginDetailViewController: UITableViewDataSource {
             let breachCell = cell(forIndexPath: indexPath)
             let breachDetailView = BreachAlertsDetailView()
             breachCell.contentView.addSubview(breachDetailView)
+            guard let breach = self.breach else { return breachCell }
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy-MM-dd"
+            guard let date = dateFormatter.date(from: breach.breachDate) else { return breachCell }
+            dateFormatter.dateStyle = .medium
+            breachDetailView.breachDateLabel.text! += " \(dateFormatter.string(from: date))."
 
-            breachDetailView.breachDateLabel.text! += " \(String(describing: breach?.breachDate))."
-            breachDetailView.goToButton.titleLabel?.text! += " \(String(describing: breach?.domain))."
-
-            breachDetailView.snp.remakeConstraints({ make in
-                make.edges.equalTo(breachCell.contentView)
-            })
+            let text = Strings.BreachAlertsLink + " \(breach.domain)"
+            let attributes: [NSAttributedString.Key: Any] = [
+                .foregroundColor: UIColor.white,
+                .underlineStyle: NSUnderlineStyle.single.rawValue
+            ]
+            let attributedText = NSMutableAttributedString(string: text, attributes: attributes)
+            breachDetailView.goToButton.setAttributedTitle(attributedText, for: .normal)
+            breachDetailView.titleLearnMore.addTarget(self, action: #selector(didTapBreachLearnMore), for: .touchUpInside)
+            
+            breachDetailView.snp.makeConstraints { make in
+                make.leading.top.equalToSuperview().offset(LoginTableViewCellUX.HorizontalMargin)
+                make.trailing.bottom.equalToSuperview().inset(LoginTableViewCellUX.HorizontalMargin)
+            }
             return breachCell
         case .usernameItem:
             let loginCell = cell(forIndexPath: indexPath)
@@ -257,7 +270,7 @@ extension LoginDetailViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         switch InfoItem(rawValue: indexPath.row)! {
         case .breachItem:
-            return self.breach != nil ? UITableView.automaticDimension : 0
+            return self.breach != nil ? 250 : 0
         case .usernameItem, .passwordItem, .websiteItem:
             return LoginDetailUX.InfoRowHeight
         case .lastModifiedSeparator:
@@ -289,6 +302,23 @@ extension LoginDetailViewController {
 
     @objc func dismissAlertController() {
         self.deleteAlert?.dismiss(animated: false, completion: nil)
+    }
+
+    @objc func didTapBreachLearnMore() {
+        //? https://monitor.firefox.com/about
+
+//        if let selectedTab = tabManager.selectedTab {
+//            screenshotHelper.takeScreenshot(selectedTab)
+//        }
+//        let request: URLRequest?
+//        if let url = url {
+//            request = URLRequest(url: url)
+//        } else {
+//            request = nil
+//        }
+//
+//        switchToPrivacyMode(isPrivate: isPrivate)
+//        tabManager.selectTab(tabManager.addTab(request, isPrivate: isPrivate))
     }
 
     func deleteLogin() {

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -68,12 +68,6 @@ class LoginDetailViewController: SensitiveViewController {
         super.init(nibName: nil, bundle: nil)
 
         NotificationCenter.default.addObserver(self, selector: #selector(dismissAlertController), name: UIApplication.didEnterBackgroundNotification, object: nil)
-
-//            self.breachDetailsView.snp.makeConstraints { make in
-//                make.top.leading.trailing.equalTo(self.view)
-//                make.bottom.equalTo(tableView)
-//            }
-
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -87,9 +81,6 @@ class LoginDetailViewController: SensitiveViewController {
 
         view.addSubview(tableView)
 
-        if self.isBreached {
-            tableView.tableHeaderView = breachDetailsView
-        }
         tableView.snp.makeConstraints { make in
             make.edges.equalTo(self.view)
         }
@@ -133,6 +124,10 @@ class LoginDetailViewController: SensitiveViewController {
             cell?.separatorInset = .zero
             cell?.layoutMargins = .zero
             cell?.preservesSuperviewLayoutMargins = false
+        }
+
+        if self.isBreached {
+            tableView.tableHeaderView = breachDetailsView
         }
     }
 }

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -323,10 +323,16 @@ extension LoginDetailViewController {
     }
 
     @objc func didTapBreachLink(_ sender: UITapGestureRecognizer? = nil) {
-        guard var domain = self.breach?.domain else { return }
-        var urlComponents = URLComponents(string: domain)
-        urlComponents?.scheme = "https"
-        webpageNavigationHandler?(urlComponents?.url)
+        guard let domain = self.breach?.domain else { return }
+        var urlComponents = URLComponents()
+        urlComponents.host = domain
+        urlComponents.scheme = "https"
+        urlComponents.path = ""
+//        webpageNavigationHandler?(urlComponents.url)
+        guard let url = urlComponents.url else { return }
+        print(url)
+        print(url.absoluteString)
+        self.settingsDelegate?.settingsOpenURLInNewTab(url)
     }
 
     func deleteLogin() {

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -147,29 +147,14 @@ extension LoginDetailViewController: UITableViewDataSource {
             breachDetailView.snp.makeConstraints { make in
                 make.edges.equalTo(breachCell.contentView).inset(LoginTableViewCellUX.HorizontalMargin)
             }
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "yyyy-MM-dd"
-            guard let date = dateFormatter.date(from: breach.breachDate) else { return breachCell }
-            dateFormatter.dateStyle = .medium
-            breachDetailView.breachDateLabel.text! += " \(dateFormatter.string(from: date))."
-            let goToText = Strings.BreachAlertsLink + " \(breach.domain)"
-            let attributes: [NSAttributedString.Key: Any] = [
-                .foregroundColor: UIColor.white,
-                .underlineStyle: NSUnderlineStyle.single.rawValue
-            ]
-            let attributedText = NSMutableAttributedString(string: goToText, attributes: attributes)
-            breachDetailView.goToButton.attributedText = attributedText
-            breachDetailView.goToButton.sizeToFit()
+            breachDetailView.setup(breach)
+
             breachDetailView.learnMoreButton.addTarget(self, action: #selector(didTapBreachLearnMore), for: .touchUpInside)
             let breachLinkGesture = UITapGestureRecognizer(target: self, action: #selector(didTapBreachLink(_:)))
             breachDetailView.goToButton.addGestureRecognizer(breachLinkGesture)
-            breachDetailView.layoutIfNeeded()
-
             breachCell.isAccessibilityElement = false
             breachCell.contentView.accessibilityElementsHidden = true
             breachCell.accessibilityElements = [breachDetailView]
-            breachDetailView.goToButton.accessibilityValue = breach.domain
-            breachDetailView.breachDateLabel.accessibilityValue = "\(dateFormatter.string(from: date))."
 
             return breachCell
 

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -45,13 +45,13 @@ class LoginDetailViewController: SensitiveViewController {
     fileprivate var menuControllerCell: LoginDetailTableViewCell?
     fileprivate var deleteAlert: UIAlertController?
     weak var settingsDelegate: SettingsDelegate?
-    let breachDetailView = BreachAlertsDetailView()
     fileprivate var breach: BreachRecord?
     fileprivate var login: LoginRecord {
         didSet {
             tableView.reloadData()
         }
     }
+    var webpageNavigationHandler: ((_ url: URL?) -> ())?
 
     fileprivate var isEditingFieldData: Bool = false {
         didSet {
@@ -61,9 +61,10 @@ class LoginDetailViewController: SensitiveViewController {
         }
     }
 
-    init(profile: Profile, login: LoginRecord) {
+    init(profile: Profile, login: LoginRecord, webpageNavigationHandler: ((_ url: URL?) -> ())?) {
         self.login = login
         self.profile = profile
+        self.webpageNavigationHandler = webpageNavigationHandler
         super.init(nibName: nil, bundle: nil)
 
         NotificationCenter.default.addObserver(self, selector: #selector(dismissAlertController), name: UIApplication.didEnterBackgroundNotification, object: nil)
@@ -160,6 +161,8 @@ extension LoginDetailViewController: UITableViewDataSource {
             breachDetailView.goToButton.attributedText = attributedText
             breachDetailView.goToButton.sizeToFit()
             breachDetailView.titleLearnMore.addTarget(self, action: #selector(didTapBreachLearnMore), for: .touchUpInside)
+            let breachLinkGesture = UITapGestureRecognizer(target: self, action: #selector(didTapBreachLink(_:)))
+            breachDetailView.goToButton.addGestureRecognizer(breachLinkGesture)
             breachDetailView.layoutIfNeeded()
             return breachCell
 
@@ -309,20 +312,12 @@ extension LoginDetailViewController {
     }
 
     @objc func didTapBreachLearnMore() {
-        //? https://monitor.firefox.com/about
+        webpageNavigationHandler?(BreachAlertsManager.monitorAboutUrl)
+    }
 
-//        if let selectedTab = tabManager.selectedTab {
-//            screenshotHelper.takeScreenshot(selectedTab)
-//        }
-//        let request: URLRequest?
-//        if let url = url {
-//            request = URLRequest(url: url)
-//        } else {
-//            request = nil
-//        }
-//
-//        switchToPrivacyMode(isPrivate: isPrivate)
-//        tabManager.selectTab(tabManager.addTab(request, isPrivate: isPrivate))
+    @objc func didTapBreachLink(_ sender: UITapGestureRecognizer? = nil) {
+        guard let domain = self.breach?.domain else { return }
+        webpageNavigationHandler?(URL(string: domain))
     }
 
     func deleteLogin() {

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -324,10 +324,9 @@ extension LoginDetailViewController {
 
     @objc func didTapBreachLink(_ sender: UITapGestureRecognizer? = nil) {
         guard var domain = self.breach?.domain else { return }
-        if !(domain.starts(with: "https://") || domain.starts(with: "http://") || domain.starts(with: "www.")) {
-            domain = "https://\(domain)"
-        }
-        webpageNavigationHandler?(URL(string: domain))
+        var urlComponents = URLComponents(string: domain)
+        urlComponents?.scheme = "https"
+        webpageNavigationHandler?(urlComponents?.url)
     }
 
     func deleteLogin() {

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -152,18 +152,25 @@ extension LoginDetailViewController: UITableViewDataSource {
             guard let date = dateFormatter.date(from: breach.breachDate) else { return breachCell }
             dateFormatter.dateStyle = .medium
             breachDetailView.breachDateLabel.text! += " \(dateFormatter.string(from: date))."
-            let text = Strings.BreachAlertsLink + " \(breach.domain)"
+            let goToText = Strings.BreachAlertsLink + " \(breach.domain)"
             let attributes: [NSAttributedString.Key: Any] = [
                 .foregroundColor: UIColor.white,
                 .underlineStyle: NSUnderlineStyle.single.rawValue
             ]
-            let attributedText = NSMutableAttributedString(string: text, attributes: attributes)
+            let attributedText = NSMutableAttributedString(string: goToText, attributes: attributes)
             breachDetailView.goToButton.attributedText = attributedText
             breachDetailView.goToButton.sizeToFit()
-            breachDetailView.titleLearnMore.addTarget(self, action: #selector(didTapBreachLearnMore), for: .touchUpInside)
+            breachDetailView.learnMoreButton.addTarget(self, action: #selector(didTapBreachLearnMore), for: .touchUpInside)
             let breachLinkGesture = UITapGestureRecognizer(target: self, action: #selector(didTapBreachLink(_:)))
             breachDetailView.goToButton.addGestureRecognizer(breachLinkGesture)
             breachDetailView.layoutIfNeeded()
+
+            breachCell.isAccessibilityElement = false
+            breachCell.contentView.accessibilityElementsHidden = true
+            breachCell.accessibilityElements = [breachDetailView]
+            breachDetailView.goToButton.accessibilityLabel = goToText
+            breachDetailView.breachDateLabel.accessibilityValue = "\(dateFormatter.string(from: date))."
+
             return breachCell
 
         case .usernameItem:

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -51,7 +51,7 @@ class LoginDetailViewController: SensitiveViewController {
             tableView.reloadData()
         }
     }
-    var webpageNavigationHandler: ((_ url: URL?) -> ())?
+    var webpageNavigationHandler: ((_ url: URL?) -> Void)?
 
     fileprivate var isEditingFieldData: Bool = false {
         didSet {
@@ -61,7 +61,7 @@ class LoginDetailViewController: SensitiveViewController {
         }
     }
 
-    init(profile: Profile, login: LoginRecord, webpageNavigationHandler: ((_ url: URL?) -> ())?) {
+    init(profile: Profile, login: LoginRecord, webpageNavigationHandler: ((_ url: URL?) -> Void)?) {
         self.login = login
         self.profile = profile
         self.webpageNavigationHandler = webpageNavigationHandler

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -327,12 +327,7 @@ extension LoginDetailViewController {
         var urlComponents = URLComponents()
         urlComponents.host = domain
         urlComponents.scheme = "https"
-        urlComponents.path = ""
-//        webpageNavigationHandler?(urlComponents.url)
-        guard let url = urlComponents.url else { return }
-        print(url)
-        print(url.absoluteString)
-        self.settingsDelegate?.settingsOpenURLInNewTab(url)
+        webpageNavigationHandler?(urlComponents.url)
     }
 
     func deleteLogin() {

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -168,7 +168,7 @@ extension LoginDetailViewController: UITableViewDataSource {
             breachCell.isAccessibilityElement = false
             breachCell.contentView.accessibilityElementsHidden = true
             breachCell.accessibilityElements = [breachDetailView]
-            breachDetailView.goToButton.accessibilityLabel = goToText
+            breachDetailView.goToButton.accessibilityValue = breach.domain
             breachDetailView.breachDateLabel.accessibilityValue = "\(dateFormatter.string(from: date))."
 
             return breachCell

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -45,6 +45,7 @@ class LoginDetailViewController: SensitiveViewController {
     fileprivate var menuControllerCell: LoginDetailTableViewCell?
     fileprivate var deleteAlert: UIAlertController?
     weak var settingsDelegate: SettingsDelegate?
+    let breachDetailView = BreachAlertsDetailView()
     fileprivate var breach: BreachRecord?
     fileprivate var login: LoginRecord {
         didSet {
@@ -270,7 +271,7 @@ extension LoginDetailViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         switch InfoItem(rawValue: indexPath.row)! {
         case .breachItem:
-            return self.breach != nil ? 250 : 0
+            return self.breach != nil ? 240 : 0
         case .usernameItem, .passwordItem, .websiteItem:
             return LoginDetailUX.InfoRowHeight
         case .lastModifiedSeparator:

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -316,7 +316,10 @@ extension LoginDetailViewController {
     }
 
     @objc func didTapBreachLink(_ sender: UITapGestureRecognizer? = nil) {
-        guard let domain = self.breach?.domain else { return }
+        guard var domain = self.breach?.domain else { return }
+        if !(domain.starts(with: "https://") || domain.starts(with: "http://") || domain.starts(with: "www.")) {
+            domain = "https://\(domain)"
+        }
         webpageNavigationHandler?(URL(string: domain))
     }
 

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -110,7 +110,7 @@ class Setting: NSObject {
     func onLongPress(_ navigationController: UINavigationController?) { return }
 
     // Helper method to set up and push a SettingsContentViewController
-    func setUpAndPushSettingsContentViewController(_ navigationController: UINavigationController?) {
+    func setUpAndPushSettingsContentViewController(_ navigationController: UINavigationController?, _ url: URL? = nil) {
         if let url = self.url {
             let viewController = SettingsContentViewController()
             viewController.settingsTitle = self.title

--- a/ClientTests/BreachAlertsTests.swift
+++ b/ClientTests/BreachAlertsTests.swift
@@ -7,33 +7,33 @@ import Storage
 import Shared
 import XCTest
 
-let mockRecord = BreachRecord(
+let blockbusterBreach = BreachRecord(
  name: "MockBreach",
- title: "A Mock BreachRecord",
- domain: "breached.com",
+ title: "A Mock Blockbuster Record",
+ domain: "blockbuster.com",
  breachDate: "1970-01-02",
  description: "A mock BreachRecord for testing purposes."
 )
 // remove for official release
-let amockRecord = BreachRecord(
+let lipsumBreach = BreachRecord(
  name: "MockBreach",
- title: "A Mock BreachRecord",
+ title: "A Mock Lorem Ipsum Record",
+ domain: "lipsum.com",
+ breachDate: "1970-01-02",
+ description: "A mock BreachRecord for testing purposes."
+)
+let longBreach = BreachRecord(
+ name: "MockBreach",
+ title: "A Long Mock Breach Record",
  domain: "duisatconsecteturloremdonecmassasapienfaucibusetmolestieacfeugiatsedlectusvestibulummattisullamcorpervelitsedullamcorp.com",
  breachDate: "1970-01-02",
  description: "A mock BreachRecord for testing purposes."
 )
-let longMock = BreachRecord(
- name: "MockBreach",
- title: "A Mock BreachRecord",
- domain: "twitter.com",
- breachDate: "1970-01-02",
- description: "A mock BreachRecord for testing purposes."
-)
 let unbreachedLogin = LoginRecord(fromJSONDict: ["hostname" : "http://unbreached.com", "timePasswordChanged": 1594411049000])
-let breachedLogin = LoginRecord(fromJSONDict: ["hostname" : "http://breached.com", "timePasswordChanged": 46800000])
+let breachedLogin = LoginRecord(fromJSONDict: ["hostname" : "http://blockbuster.com", "timePasswordChanged": 46800000])
 class MockBreachAlertsClient: BreachAlertsClientProtocol {
     func fetchData(endpoint: BreachAlertsClient.Endpoint, completion: @escaping (Maybe<Data>) -> Void) {
-        guard let mockData = try? JSONEncoder().encode([mockRecord].self) else {
+        guard let mockData = try? JSONEncoder().encode([blockbusterBreach].self) else {
             completion(Maybe(failure: BreachAlertsError(description: "failed to encode mockRecord")))
             return
         }
@@ -55,7 +55,7 @@ class BreachAlertsTests: XCTestCase {
             XCTAssertTrue(maybeBreaches.isSuccess)
             XCTAssertNotNil(maybeBreaches.successValue)
             if let breaches = maybeBreaches.successValue {
-                XCTAssertEqual([mockRecord, longMock, amockRecord], breaches)
+                XCTAssertEqual([blockbusterBreach, longBreach, lipsumBreach], breaches)
             }
         }
     }
@@ -94,8 +94,13 @@ class BreachAlertsTests: XCTestCase {
         let unbreached = ["unbreached.com": [unbreachedLogin]]
         var result = breachAlertsManager.loginsByHostname([unbreachedLogin])
         XCTAssertEqual(result, unbreached)
-        let breached = ["breached.com": [breachedLogin]]
+        let blockbuster = ["blockbuster.com": [breachedLogin]]
         result = breachAlertsManager.loginsByHostname([breachedLogin])
-        XCTAssertEqual(result, breached)
+        XCTAssertEqual(result, blockbuster)
+    }
+
+    func testBreachRecordForLogin() {
+        breachAlertsManager.loadBreaches { _ in }
+        XCTAssertEqual(blockbusterBreach, breachAlertsManager.breachRecordForLogin(breachedLogin))
     }
 }

--- a/ClientTests/BreachAlertsTests.swift
+++ b/ClientTests/BreachAlertsTests.swift
@@ -25,7 +25,7 @@ let amockRecord = BreachRecord(
 let longMock = BreachRecord(
  name: "MockBreach",
  title: "A Mock BreachRecord",
- domain: "abreachedwithalongstringnameaslkdjflskjfas.com",
+ domain: "twitter.com",
  breachDate: "1970-01-02",
  description: "A mock BreachRecord for testing purposes."
 )

--- a/ClientTests/BreachAlertsTests.swift
+++ b/ClientTests/BreachAlertsTests.swift
@@ -18,7 +18,7 @@ let mockRecord = BreachRecord(
 let amockRecord = BreachRecord(
  name: "MockBreach",
  title: "A Mock BreachRecord",
- domain: "abreach.com",
+ domain: "duisatconsecteturloremdonecmassasapienfaucibusetmolestieacfeugiatsedlectusvestibulummattisullamcorpervelitsedullamcorp.com",
  breachDate: "1970-01-02",
  description: "A mock BreachRecord for testing purposes."
 )

--- a/ClientTests/BreachAlertsTests.swift
+++ b/ClientTests/BreachAlertsTests.swift
@@ -24,8 +24,8 @@ let lipsumBreach = BreachRecord(
 )
 let longBreach = BreachRecord(
  name: "MockBreach",
- title: "A Long Mock Breach Record",
- domain: "duisatconsecteturloremdonecmassasapienfaucibusetmolestieacfeugiatsedlectusvestibulummattisullamcorpervelitsedullamcorp.com",
+ title: "A Mock Swift Breach Record",
+ domain: "swift.org",
  breachDate: "1970-01-02",
  description: "A mock BreachRecord for testing purposes."
 )

--- a/ClientTests/LoginsListViewModelTests.swift
+++ b/ClientTests/LoginsListViewModelTests.swift
@@ -45,19 +45,19 @@ class LoginsListViewModelTests: XCTestCase {
     func testQueryLogins() {
         let emptyQueryResult = self.viewModel.queryLogins("")
         XCTAssertTrue(emptyQueryResult.value.isSuccess)
-        XCTAssertEqual(emptyQueryResult.value.successValue?.count, 12)
+        XCTAssertEqual(emptyQueryResult.value.successValue?.count, 13)
 
         let exampleQueryResult = self.viewModel.queryLogins("example")
         XCTAssertTrue(exampleQueryResult.value.isSuccess)
-        XCTAssertEqual(exampleQueryResult.value.successValue?.count, 12)
+        XCTAssertEqual(exampleQueryResult.value.successValue?.count, 13)
 
         let threeQueryResult = self.viewModel.queryLogins("3")
         XCTAssertTrue(threeQueryResult.value.isSuccess)
-        XCTAssertEqual(threeQueryResult.value.successValue?.count, 3)
+        XCTAssertEqual(threeQueryResult.value.successValue?.count, 4)
 
         let zQueryResult = self.viewModel.queryLogins("yxz")
         XCTAssertTrue(zQueryResult.value.isSuccess)
-        XCTAssertEqual(zQueryResult.value.successValue?.count, 2)
+        XCTAssertEqual(zQueryResult.value.successValue?.count, 3)
     }
 
     func testIsDuringSearchControllerDismiss() {


### PR DESCRIPTION
Closes #6959. Adds a switch case for a breach view in `LoginDetailViewController`'s `cellForRowAt`. Also:

- changes `BreachAlertsManager`'s stored breaches from an array to a set for faster computation.
- adds a `breachRecordForLogin` to find a breach associated with a login.
- opens links to monitor.firefox.com/about and to breached website on button tap.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-710)
