### PR TITLE
FXIOS-703 ⁃ Fix #6814: English string truncates for ETP

### DIFF
--- a/Client/Frontend/Browser/OpenInHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper.swift
@@ -106,7 +106,7 @@ class DownloadHelper: NSObject, OpenInHelper {
         filenameItem.customHeight = { _ in
             return 80
         }
-        filenameItem.customRender = { label, contentView in
+        filenameItem.customRender = { label, _, contentView in
             label.numberOfLines = 2
             label.font = DynamicFontHelper.defaultHelper.DeviceFontSmallBold
             label.lineBreakMode = .byCharWrapping

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
@@ -281,6 +281,6 @@ class PhotonActionSheetCell: UITableViewCell {
             break // Do nothing. The rest are not supported yet.
         }
 
-        action.customRender?(titleLabel, contentView)
+        action.customRender?(titleLabel, subtitleLabel, contentView)
     }
 }

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetWidgets.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetWidgets.swift
@@ -73,7 +73,7 @@ public struct PhotonActionSheetItem {
     public fileprivate(set) var badgeIconName: String?
 
     // Enable title customization beyond what the interface provides,
-    public var customRender: ((_ title: UILabel, _ contentView: UIView) -> Void)?
+    public var customRender: ((_ title: UILabel, _ subtitle: UILabel, _ contentView: UIView) -> Void)?
 
     // Enable height customization
     public var customHeight: ((PhotonActionSheetItem) -> CGFloat)?

--- a/Client/Frontend/Widgets/PhotonActionSheet/TrackingProtectionMenu.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/TrackingProtectionMenu.swift
@@ -63,7 +63,7 @@ extension PhotonActionSheetProtocol {
 
     @available(iOS 11.0, *)
     private func menuActionsForTrackingProtectionDisabled(for tab: Tab) -> [[PhotonActionSheetItem]] {
-        let enableTP = PhotonActionSheetItem(title: Strings.EnableTPBlockingGlobally, iconString: "menu-TrackingProtection") { _, _ in
+        let enableTP = PhotonActionSheetItem(title: Strings.TrackingProtectionEnableTitle, text: Strings.EnableTPBlockingGlobally, iconString: "menu-TrackingProtection") { _, _ in
             FirefoxTabContentBlocker.toggleTrackingProtectionEnabled(prefs: self.profile.prefs)
             tab.reload()
         }
@@ -92,7 +92,7 @@ extension PhotonActionSheetProtocol {
         nestedTableViewDomainList = NestedTableViewDelegate(dataSource: NestedTableDataSource(data: data))
 
         var list = PhotonActionSheetItem(title: "")
-        list.customRender = { _, contentView in
+        list.customRender = { _, _, contentView in
             if nestedTableView != nil {
                 nestedTableView?.removeFromSuperview()
             }
@@ -120,7 +120,7 @@ extension PhotonActionSheetProtocol {
         }
 
         var info = PhotonActionSheetItem(title: description, accessory: .None)
-        info.customRender = { (label, contentView) in
+        info.customRender = { (label, _, contentView) in
             label.numberOfLines = 0
         }
         info.customHeight = { _ in
@@ -139,11 +139,11 @@ extension PhotonActionSheetProtocol {
         }
 
         var blockedtitle = PhotonActionSheetItem(title: Strings.TPPageMenuBlockedTitle, accessory: .Text, bold: true)
-        blockedtitle.customRender = { label, _ in
+        blockedtitle.customRender = { label, _, _ in
             label.font = DynamicFontHelper.defaultHelper.DeviceFontSmallBold
         }
         blockedtitle.customHeight = { _ in
-            return PhotonActionSheetUX.RowHeight - 10
+            return UITableView.automaticDimension
         }
 
         let xsitecookies = PhotonActionSheetItem(title: Strings.TPCrossSiteCookiesBlocked, iconString: "tp-cookie", accessory: .Disclosure) { action, _ in
@@ -163,7 +163,7 @@ extension PhotonActionSheetProtocol {
             self.showDomainTable(title: action.title, description: desc, blocker: blocker, categories: [BlocklistCategory.cryptomining])
         }
 
-        var addToSafelist = PhotonActionSheetItem(title: Strings.ETPOn, isEnabled: !isSafelisted, accessory: .Switch) { _, cell in
+        var addToSafelist = PhotonActionSheetItem(title: Strings.TrackingProtectionEnableTitle, text: Strings.ETPOn, isEnabled: !isSafelisted, accessory: .Switch) { _, cell in
             LeanPlumClient.shared.track(event: .trackingProtectionSafeList)
             TelemetryWrapper.recordEvent(category: .action, method: .add, object: .trackingProtectionSafelist)
             ContentBlocker.shared.safelist(enable: tab.contentBlocker?.status != .safelisted, url: currentURL) {
@@ -172,11 +172,11 @@ extension PhotonActionSheetProtocol {
                 cell.backgroundView?.setNeedsDisplay()
             }
         }
-        addToSafelist.customRender = { title, _ in
+        addToSafelist.customRender = { title, subtitle, _ in
             if tab.contentBlocker?.status == .safelisted {
-                title.text = Strings.ETPOff
+                subtitle.text = Strings.ETPOff
             } else {
-                title.text = Strings.ETPOn
+                subtitle.text = Strings.ETPOn
             }
         }
         addToSafelist.accessibilityId = "tp.add-to-safelist"
@@ -227,7 +227,7 @@ extension PhotonActionSheetProtocol {
         if items[0].count == 1 {
             // no items were blocked
             var noblockeditems = PhotonActionSheetItem(title: "", accessory: .Text)
-            noblockeditems.customRender = { title, contentView in
+            noblockeditems.customRender = { title, subtitle, contentView in
                 let l = UILabel()
                 l.numberOfLines = 0
                 l.textAlignment = .center


### PR DESCRIPTION
Fixes #6814. Adds a field in `PhotonActionSheet.customRender` to modify the `subtitleLabel`/`text` of a `PhotonActionCell` and implements captions as suggested in #6814   

Configuration 1 Enabled | Configuration 1 Disabled
-|-
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-08-04 at 17 11 46](https://user-images.githubusercontent.com/13925498/89358263-ba1aeb00-d677-11ea-87e4-0a94748b7b1a.png)| ![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-08-04 at 17 11 49](https://user-images.githubusercontent.com/13925498/89358265-bc7d4500-d677-11ea-9f94-a3edf7151bca.png)

Configuration 2 Enabled | Configuration 2 Disabled
-|-
 ![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-08-04 at 17 11 59](https://user-images.githubusercontent.com/13925498/89358268-bd15db80-d677-11ea-8e00-3e17e25b0a7f.png) | ![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-08-04 at 17 12 01](https://user-images.githubusercontent.com/13925498/89358269-bdae7200-d677-11ea-8929-aaf2b0b108bd.png)

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-703)
