### PR TITLE
[nobug, cleanup] TelemetryWrapper: clarify and cleanup extra function.

### DIFF
--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -172,7 +172,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
                 TabContentBlocker.prefsChanged()
                 self.tableView.reloadData()
                 LeanPlumClient.shared.track(event: .trackingProtectionSettings, withParameters: ["Strength option": option.rawValue])
-                TelemetryWrapper.recordEvent(category: .action, method: .change, object: .setting, value: ContentBlockingConfig.Prefs.StrengthKey, extras: ["to": option.rawValue])
+                TelemetryWrapper.recordEvent(category: .action, method: .change, object: .setting, extras: ["pref": "ETP-strength", "to": option.rawValue])
                 
                 if option == .strict {
                     let alert = UIAlertController(title: Strings.TrackerProtectionAlertTitle, message: Strings.TrackerProtectionAlertDescription, preferredStyle: .alert)

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -337,7 +337,7 @@ extension SearchSettingsTableViewController: SearchEnginePickerDelegate {
         if let engine = searchEngine {
             model.defaultEngine = engine
             self.tableView.reloadData()
-            TelemetryWrapper.recordEvent(category: .action, method: .change, object: .setting, value: "defaultSearchEngine", extras: ["to": engine.engineID ?? "custom"])
+            TelemetryWrapper.recordEvent(category: .action, method: .change, object: .setting, extras: ["pref": "defaultSearchEngine", "to": engine.engineID ?? "custom"])
         }
         _ = navigationController?.popViewController(animated: true)
     }

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -229,7 +229,7 @@ class BoolSetting: Setting {
     @objc func switchValueChanged(_ control: UISwitch) {
         writeBool(control)
         settingDidChange?(control.isOn)
-        TelemetryWrapper.recordEvent(category: .action, method: .change, object: .setting, value: self.prefKey, extras: ["to": control.isOn])
+        TelemetryWrapper.recordEvent(category: .action, method: .change, object: .setting, extras: ["pref": prefKey as Any, "to": control.isOn])
     }
 
     // These methods allow a subclass to control how the pref is saved

--- a/Client/Frontend/Settings/TranslationSettingsController.swift
+++ b/Client/Frontend/Settings/TranslationSettingsController.swift
@@ -64,8 +64,6 @@ class TranslationSettingsController: ThemedTableViewController {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             UIView.transition(with: self.tableView, duration: 0.2, options: .transitionCrossDissolve, animations: { self.tableView.reloadData()  })
         }
-
-        TelemetryWrapper.recordEvent(category: .action, method: .change, object: .setting, value: "show-translation", extras: ["to": control.isOn ? "on" : "off"])
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {


### PR DESCRIPTION
Our old telemetry was using 'EventValue' to pass the name of the pref, but only in 2 cases in the code, this should have been in the 'extras' array. We also had an extra function in TelemetryWrapper to handle this case. I found this confusing when trying to reason how we are using the code. Also some minor renaming to make things a bit clearer to the reader. 