### PR TITLE
FXIOS-741 ⁃ Bug 1608838: Include data sensitivity category

### DIFF
--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -29,6 +29,8 @@ search:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -43,6 +45,8 @@ search:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -55,6 +59,8 @@ search:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -78,6 +84,8 @@ preferences:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -93,6 +101,8 @@ preferences:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -108,6 +118,8 @@ preferences:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -119,6 +131,8 @@ preferences:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -130,6 +144,8 @@ preferences:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -141,6 +157,8 @@ preferences:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -152,6 +170,8 @@ preferences:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -166,6 +186,8 @@ application_services:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -178,6 +200,8 @@ application_services:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -190,6 +214,8 @@ application_services:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -205,6 +231,8 @@ tracking_protection:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -219,6 +247,8 @@ tracking_protection:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -234,6 +264,8 @@ theme:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -246,6 +278,8 @@ theme:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -258,6 +292,8 @@ theme:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -271,6 +307,8 @@ theme:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -290,6 +328,8 @@ tabs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -306,6 +346,8 @@ tabs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -322,6 +364,8 @@ tabs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -334,6 +378,8 @@ tabs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/6886
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/issues/6886
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-21"
@@ -352,6 +398,8 @@ bookmarks:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -371,6 +419,8 @@ bookmarks:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -390,6 +440,8 @@ bookmarks:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -407,6 +459,8 @@ bookmarks:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -421,6 +475,8 @@ reader_mode:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -432,6 +488,8 @@ reader_mode:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -454,6 +512,8 @@ reading_list:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -466,6 +526,8 @@ reading_list:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -483,6 +545,8 @@ reading_list:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -495,6 +559,8 @@ reading_list:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -507,6 +573,8 @@ reading_list:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -521,6 +589,8 @@ qr_code:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_sensitivity:
+      - interaction
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-07-01"
@@ -538,6 +608,8 @@ legacy.ids:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1635427
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1635427
+    data_sensitivity:
+      - technical
     notification_emails:
       - firefox-ios@mozilla.com
     expires: never


### PR DESCRIPTION
Glean recently added a metadata field to include the data sensitivity category with each metric.  This information is already included in every data review -- I just ran a scraper to collect it from the data review and include it here.

This has no actual impact on the client behavior -- it will simply be used downstream in various Glean related tools.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-741)
