### PR TITLE
Fix #7053: Add prompt visible UI test for HTTP Basic Auth

### DIFF
--- a/XCUITests/AuthenticationTest.swift
+++ b/XCUITests/AuthenticationTest.swift
@@ -4,6 +4,8 @@
 
 import XCTest
 
+let testBasicHTTPAuthURL = "https://jigsaw.w3.org/HTTP/Basic/"
+
 class AuthenticationTest: BaseTestCase {
 
     fileprivate func setInterval(_ interval: String = "Immediately") {
@@ -262,5 +264,27 @@ class AuthenticationTest: BaseTestCase {
         navigator.goto(LockedLoginsSettings)
         waitForExistence(app.navigationBars["Enter Passcode"])
         navigator.performAction(Action.UnlockLoginsSettings)
+    }
+
+    func testBasicHTTPAuthenticationPromptVisible() {
+        navigator.openURL(testBasicHTTPAuthURL)
+
+        waitForExistence(app.staticTexts["Authentication required"], timeout: 5)
+        waitForExistence(app.staticTexts["A username and password are being requested by jigsaw.w3.org. The site says: test"])
+
+        let placeholderValueUsername = app.alerts.textFields.element(boundBy: 0).value as! String
+        let placeholderValuePassword = app.alerts.secureTextFields.element(boundBy: 0).value as! String
+
+        XCTAssertEqual(placeholderValueUsername, "Username")
+        XCTAssertEqual(placeholderValuePassword, "Password")
+
+        waitForExistence(app.alerts.buttons["Cancel"])
+        waitForExistence(app.alerts.buttons["Log in"])
+
+        // Skip login due to HTTP Basic Authentication crash in #5757
+
+        // Dismiss authentication prompt
+        app.alerts.buttons["Cancel"].tap()
+        waitForNoExistence(app.alerts.buttons["Cancel"], timeoutValue:5)
     }
 }


### PR DESCRIPTION
Closes #7053 – add a prompt visible UI test for HTTP Basic Auth