### PR TITLE
FXIOS-765 ⁃ Fix #5554: Re-enable disabled UI tests

### DIFF
--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -308,14 +308,11 @@ class ActivityStreamTest: BaseTestCase {
 
         // Tap on Share option and verify that the menu is shown and it is possible to cancel it
         selectOptionFromContextMenu(option: "Share")
-        // Comenting out until share sheet can be managed with automated tests issue #5477
-        //if !iPad() {
-        //    app.buttons["Cancel"].tap()
-        //}
+        if !iPad() {
+            app.buttons["Close"].tap()
+        }
     }
 
-    // Disable #5554
-    /*
     func testTopSitesShareNewTopSite() {
         navigator.goto(HomePanelsScreen)
         let topSiteCells = TopSiteCellgroup.cells
@@ -324,11 +321,11 @@ class ActivityStreamTest: BaseTestCase {
 
         // Tap on Share option and verify that the menu is shown and it is possible to cancel it....
         selectOptionFromContextMenu(option: "Share")
-        // Comenting out until share sheet can be managed with automated tests issue #5477
-        //if !iPad() {
-        //    app.buttons["Cancel"].tap()
-        //}
-    }*/
+
+        if !iPad() {
+            app.buttons["Close"].tap()
+        }
+    }
 
     private func selectOptionFromContextMenu(option: String) {
         XCTAssertTrue(app.tables["Context Menu"].cells[option].exists)

--- a/XCUITests/DownloadFilesTests.swift
+++ b/XCUITests/DownloadFilesTests.swift
@@ -98,14 +98,13 @@ class DownloadFilesTests: BaseTestCase {
 
         XCTAssertTrue(app.tables.cells.buttons["Share"].exists)
         XCTAssertTrue(app.tables.cells.buttons["Delete"].exists)
-        //Comenting out until share sheet can be managed with automated tests issue #5477
-        //app.tables.cells.buttons["Share"].tap()
-        //waitForExistence(app.otherElements["ActivityListView"])
-        //if iPad() {
-        //    app.otherElements["PopoverDismissRegion"].tap()
-        //} else {
-        //    app.buttons["Cancel"].tap()
-        //}
+        app.tables.cells.buttons["Share"].tap()
+        waitForExistence(app.otherElements["ActivityListView"])
+        if iPad() {
+            app.otherElements["PopoverDismissRegion"].tap()
+        } else {
+            app.buttons["Close"].tap()
+        }
     }
 
     func testLongPressOnDownloadedFile() {
@@ -114,14 +113,13 @@ class DownloadFilesTests: BaseTestCase {
         navigator.goto(LibraryPanel_Downloads)
 
         waitForExistence(app.tables["DownloadsTable"])
-        //Comenting out until share sheet can be managed with automated tests issue #5477
-        //app.tables.cells.staticTexts[testFileName].press(forDuration: 2)
-        //waitForExistence(app.otherElements["ActivityListView"])
-        //if iPad() {
-        //    app.otherElements["PopoverDismissRegion"].tap()
-        //} else {
-        //    app.buttons["Cancel"].tap()
-        //}
+        app.tables.cells.staticTexts[testFileName].press(forDuration: 2)
+        waitForExistence(app.otherElements["ActivityListView"])
+        if iPad() {
+            app.otherElements["PopoverDismissRegion"].tap()
+        } else {
+            app.buttons["Close"].tap()
+        }
      }
 
     private func downloadFile(fileName: String, numberOfDownlowds: Int) {

--- a/XCUITests/PhotonActionSheetTest.swift
+++ b/XCUITests/PhotonActionSheetTest.swift
@@ -29,7 +29,6 @@ class PhotonActionSheetTest: BaseTestCase {
         cell.press(forDuration: 2)
         waitForExistence(app.cells["action_pin"])
     }
-    // Disable issue #5554
 
     func testShareOptionIsShown() {
         navigator.goto(BrowserTab)
@@ -60,29 +59,6 @@ class PhotonActionSheetTest: BaseTestCase {
         waitForExistence(app.navigationBars["Client.InstructionsView"])
         XCTAssertTrue(app.staticTexts["You are not signed in to your Firefox Account."].exists)
     }
-    // Disable issue #5554, More button is not accessible
-    /*
-    // Test disabled due to new implementation Bug 1449708 - new share sheet
-    func testSendToDeviceFromShareOption() {
-        // Open and Wait to see the Share options sheet
-        navigator.browserPerformAction(.shareOption)
-        waitForExistence(app.buttons["More"])
-        waitForNoExistence(app.buttons["Send Tab"])
-        app.collectionViews.cells/*@START_MENU_TOKEN@*/.collectionViews.containing(.button, identifier:"Copy")/*[[".collectionViews.containing(.button, identifier:\"Create PDF\")",".collectionViews.containing(.button, identifier:\"Print\")",".collectionViews.containing(.button, identifier:\"Copy\")"],[[[-1,2],[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.buttons["More"].tap()
-
-        // Enable Send Tab
-        let sendTabButton = app.tables.cells.switches["Send Tab"]
-        sendTabButton.tap()
-        app.navigationBars["Activities"].buttons["Done"].tap()
-
-        // Send Tab option appears on the Share options sheet
-        waitForExistence(app.buttons["Send Tab"])
-        app.buttons["Send Tab"].tap()
-
-        // User not logged in
-        waitForExistence(app.images["emptySync"])
-        XCTAssertTrue(app.staticTexts["You are not signed in to your Firefox Account."].exists)
-    }*/
 
     private func openNewShareSheet() {
         navigator.openURL("example.com")


### PR DESCRIPTION
As per #5554 re-enabled, and swapped ```app.buttons["Cancel"].tap()```  to ```app.buttons["Close"].tap()```. I left ```testSendToDeviceFromShareOption()``` disabled as the More button was not being found and the user-flow is different as Send Tab is not present but the browser (i.e, Fennec (AaronMT)) was visible in the Share Sheet. That particular test will need updating if the More button can be accessed.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-765)
