### PR TITLE
FXIOS-762 ⁃ Fix #5937: Re-enable more XCUI tests

### DIFF
--- a/XCUITests/BookmarkingTests.swift
+++ b/XCUITests/BookmarkingTests.swift
@@ -136,9 +136,6 @@ class BookmarkingTests: BaseTestCase {
         waitForValueContains(app.textFields["url"], value: url_3)
     }
 
-    // Smoketest
-    // Disabling and modifying this check xcode 11.3 update Issue 5937
-    /*
     func testBookmarksAwesomeBar() {
         navigator.nowAt(BrowserTab)
         navigator.goto(URLBarOpen)
@@ -175,7 +172,7 @@ class BookmarkingTests: BaseTestCase {
         waitForExistence(app.tables["SiteTable"])
         waitForExistence(app.buttons["olx.ro"])
         XCTAssertNotEqual(app.tables["SiteTable"].cells.count, 0)
-    }*/
+    }
 
     func testAddBookmark() {
         addNewBookmark()

--- a/XCUITests/HomePageSettingsUITest.swift
+++ b/XCUITests/HomePageSettingsUITest.swift
@@ -120,9 +120,7 @@ class HomePageSettingsUITests: BaseTestCase {
 
         XCTAssertEqual("Enter a webpage", value as! String)
     }*/
-    
-    // Disabled due to xcode 11.3 udpate Issue 5937
-    /*
+
     func testSetFirefoxHomeAsHome() {
         // Start by setting to History since FF Home is default
         navigator.goto(HomeSettings)
@@ -136,7 +134,7 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.performAction(Action.SelectHomeAsFirefoxHomePage)
         navigator.performAction(Action.GoToHomePage)
         waitForExistence(app.collectionViews.cells["TopSitesCell"])
-    }*/
+    }
 
     func testSetCustomURLAsHome() {
         navigator.goto(HomeSettings)
@@ -150,8 +148,8 @@ class HomePageSettingsUITests: BaseTestCase {
 
         // Workaroud needed after xcode 11.3 update Issue 5937
         // Lets check only that website is open
-        // waitForExistence(app.textFields["url"], timeout: 5)
-        // waitForValueContains(app.textFields["url"], value: "mozilla")
+        waitForExistence(app.textFields["url"], timeout: 5)
+        waitForValueContains(app.textFields["url"], value: "mozilla")
     }
     
     func testTopSitesCustomNumberOfRows() {

--- a/XCUITests/SearchTest.swift
+++ b/XCUITests/SearchTest.swift
@@ -177,13 +177,11 @@ class SearchTests: BaseTestCase {
     func testSearchEngine() {
         // Change to the each search engine and verify the search uses it
         changeSearchEngine(searchEngine: "Bing")
-        // Lets keep only one search engine test, xcode 11.3 update Issue 5937
-        // changeSearchEngine(searchEngine: "DuckDuckGo")
-        // Temporary disabled due to intermittent issue on BB
-        // changeSearchEngine(searchEngine: "Google")
-        // changeSearchEngine(searchEngine: "Twitter")
-        // changeSearchEngine(searchEngine: "Wikipedia")
-        // changeSearchEngine(searchEngine: "Amazon.com")
+        changeSearchEngine(searchEngine: "DuckDuckGo")
+        changeSearchEngine(searchEngine: "Google")
+        changeSearchEngine(searchEngine: "Twitter")
+        changeSearchEngine(searchEngine: "Wikipedia")
+        changeSearchEngine(searchEngine: "Amazon.com")
     }
 
     func testDefaultSearchEngine() {


### PR DESCRIPTION
Using Xcode 11.6, these tests now run and pass locally on simulator (iPhone 11 Pro). They were disabled for failing in Xcode 11.3. The others mentioned in #5937 are already enabled and running.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-762)
