### PR TITLE
FXIOS-759 ⁃ Fix #7123: Empty logins view after switching to a different app

### DIFF
--- a/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
+++ b/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
@@ -22,6 +22,7 @@ class SensitiveViewController: UIViewController {
         notificationCenter.addObserver(self, selector: #selector(checkIfUserRequiresValidation), name: UIApplication.willEnterForegroundNotification, object: nil)
         notificationCenter.addObserver(self, selector: #selector(checkIfUserRequiresValidation), name: UIApplication.didBecomeActiveNotification, object: nil)
         notificationCenter.addObserver(self, selector: #selector(blurContents), name: UIApplication.willResignActiveNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(blurContents), name: UIApplication.didEnterBackgroundNotification, object: nil)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -59,6 +60,7 @@ class SensitiveViewController: UIViewController {
                 AppAuthenticator.presentPasscodeAuthentication(self.navigationController).uponQueue(.main) { isOk in
                     if isOk {
                         self.removeBackgroundedBlur()
+                        self.navigationController?.dismiss(animated: true, completion: nil)
                         self.authState = .notAuthenticating
                     } else {
                         // On cancel, the login list can appear for a split-second, set the view to transparent to avoid this.

--- a/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
+++ b/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
@@ -50,10 +50,10 @@ class SensitiveViewController: UIViewController {
                 self.removeBackgroundedBlur()
             },
             cancel: {
-                self.view.alpha = 0
                 self.promptingForTouchID = false
                 self.authState = .notAuthenticating
-                self.dismiss(animated: false)
+                self.navigationController?.dismiss(animated: true, completion: nil)
+                self.dismiss(animated: true)
             },
             fallback: {
                 self.promptingForTouchID = false
@@ -63,9 +63,8 @@ class SensitiveViewController: UIViewController {
                         self.navigationController?.dismiss(animated: true, completion: nil)
                         self.authState = .notAuthenticating
                     } else {
-                        // On cancel, the login list can appear for a split-second, set the view to transparent to avoid this.
-                        self.view.alpha = 0
-                        self.dismiss(animated: false)
+                        self.navigationController?.dismiss(animated: true, completion: nil)
+                        self.dismiss(animated: true)
                         self.authState = .notAuthenticating
                     }
                 }

--- a/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
+++ b/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
@@ -22,8 +22,6 @@ class SensitiveViewController: UIViewController {
         notificationCenter.addObserver(self, selector: #selector(checkIfUserRequiresValidation), name: UIApplication.willEnterForegroundNotification, object: nil)
         notificationCenter.addObserver(self, selector: #selector(checkIfUserRequiresValidation), name: UIApplication.didBecomeActiveNotification, object: nil)
         notificationCenter.addObserver(self, selector: #selector(blurContents), name: UIApplication.willResignActiveNotification, object: nil)
-        notificationCenter.addObserver(self, selector: #selector(hideLogins), name: UIApplication.didEnterBackgroundNotification, object: nil)
-
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -54,7 +52,6 @@ class SensitiveViewController: UIViewController {
                 self.view.alpha = 0
                 self.promptingForTouchID = false
                 self.authState = .notAuthenticating
-                _ = self.navigationController?.popToRootViewController(animated: false)
                 self.dismiss(animated: false)
             },
             fallback: {
@@ -62,12 +59,10 @@ class SensitiveViewController: UIViewController {
                 AppAuthenticator.presentPasscodeAuthentication(self.navigationController).uponQueue(.main) { isOk in
                     if isOk {
                         self.removeBackgroundedBlur()
-                        self.navigationController?.dismiss(animated: true, completion: nil)
                         self.authState = .notAuthenticating
                     } else {
                         // On cancel, the login list can appear for a split-second, set the view to transparent to avoid this.
                         self.view.alpha = 0
-                        _ = self.navigationController?.popToRootViewController(animated: false)
                         self.dismiss(animated: false)
                         self.authState = .notAuthenticating
                     }
@@ -75,10 +70,6 @@ class SensitiveViewController: UIViewController {
             }
         )
         authState = .presenting
-    }
-
-    @objc func hideLogins() {
-        _ = self.navigationController?.popToRootViewController(animated: true)
     }
 
     @objc func blurContents() {


### PR DESCRIPTION
Fixes #7123. Removes the "go to root view controller" behavior on app deactivation in `SensitiveViewController` which `LoginList` and `LoginDetail` view controllers inherit from. That seemed to have prevented detecting app reactivation from the Login Details view.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-759)
