### PR TITLE
Remove universal links

### DIFF
--- a/Client/Entitlements/FennecApplication.entitlements
+++ b/Client/Entitlements/FennecApplication.entitlements
@@ -4,8 +4,6 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
-	<key>com.apple.developer.associated-domains</key>
-	<array/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.mozilla.ios.Fennec</string>

--- a/Client/Entitlements/FennecApplication.entitlements
+++ b/Client/Entitlements/FennecApplication.entitlements
@@ -5,14 +5,7 @@
 	<key>aps-environment</key>
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:confirm.accounts.firefox.com</string>
-		<string>applinks:confirm.accounts.stage.mozaws.net</string>
-		<string>applinks:latest.dev.lcip.org</string>
-		<string>applinks:nightly.dev.lcip.org</string>
-		<string>applinks:rzte.adj.st</string>
-		<string>applinks:nn8g.adj.st</string>
-	</array>
+	<array/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.mozilla.ios.Fennec</string>

--- a/Client/Entitlements/FirefoxApplication.entitlements
+++ b/Client/Entitlements/FirefoxApplication.entitlements
@@ -4,8 +4,6 @@
 <dict>
 	<key>aps-environment</key>
 	<string>production</string>
-	<key>com.apple.developer.associated-domains</key>
-	<array/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.mozilla.ios.Firefox</string>

--- a/Client/Entitlements/FirefoxApplication.entitlements
+++ b/Client/Entitlements/FirefoxApplication.entitlements
@@ -2,17 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:confirm.accounts.firefox.com</string>
-		<string>applinks:confirm.accounts.stage.mozaws.net</string>
-		<string>applinks:latest.dev.lcip.org</string>
-		<string>applinks:nightly.dev.lcip.org</string>
-		<string>applinks:rzte.adj.st</string>
-		<string>applinks:nn8g.adj.st</string>
-	</array>
 	<key>aps-environment</key>
 	<string>production</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.mozilla.ios.Firefox</string>

--- a/Client/Entitlements/FirefoxBetaApplication.entitlements
+++ b/Client/Entitlements/FirefoxBetaApplication.entitlements
@@ -4,8 +4,6 @@
 <dict>
 	<key>aps-environment</key>
 	<string>production</string>
-	<key>com.apple.developer.associated-domains</key>
-	<array/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.mozilla.ios.FirefoxBeta</string>

--- a/Client/Entitlements/FirefoxBetaApplication.entitlements
+++ b/Client/Entitlements/FirefoxBetaApplication.entitlements
@@ -2,17 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:confirm.accounts.firefox.com</string>
-		<string>applinks:confirm.accounts.stage.mozaws.net</string>
-		<string>applinks:latest.dev.lcip.org</string>
-		<string>applinks:nightly.dev.lcip.org</string>
-		<string>applinks:rzte.adj.st</string>
-		<string>applinks:nn8g.adj.st</string>
-	</array>
 	<key>aps-environment</key>
 	<string>production</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.mozilla.ios.FirefoxBeta</string>


### PR DESCRIPTION
Fixes #7138 

This PR removes all universal links for Apple default browser approval, which are known in the plist as "associated domains"
