### PR TITLE
Removed NSPhotoLibraryUsageDescription for iOS14 default browser support

### DIFF
--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -87,8 +87,6 @@
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Websites you visit may request your location.</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>This lets you save and upload photos.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>This lets you take and upload photos.</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/Client/en.lproj/InfoPlist.strings
+++ b/Client/en.lproj/InfoPlist.strings
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 NSLocationWhenInUseUsageDescription = "Websites you visit may request your location.";
-NSPhotoLibraryUsageDescription = "This lets you save and upload photos.";
 NSPhotoLibraryAddUsageDescription = "This lets you save photos.";
 NSCameraUsageDescription = "This lets you take and upload photos.";
 NSMicrophoneUsageDescription = "This lets you take and upload videos.";


### PR DESCRIPTION
**Note:** Couldn't find any place in our app that we use this string. 

We only use the one where we save but not upload pic. 

<img width="853" alt="image" src="https://user-images.githubusercontent.com/8919439/90687258-968c9e80-e23a-11ea-94f0-f10865c88287.png">
