### PR TITLE
FXIOS-797 ⁃ FIX767 — Command ⌘ + link to open in new tab

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -119,6 +119,8 @@ class BrowserViewController: UIViewController {
     weak var pendingDownloadWebView: WKWebView?
 
     let downloadQueue = DownloadQueue()
+    var shouldOpenInNewTab = false
+
 
     init(profile: Profile, tabManager: TabManager) {
         self.profile = profile
@@ -2348,6 +2350,17 @@ extension BrowserViewController: ContextMenuHelperDelegate {
             self.displayedPopoverController = nil
         }
     }
+    
+    //Support for CMD+ Click on link to open in a new tab
+     override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+         guard let key = presses.first?.key, (key.keyCode == .keyboardLeftGUI || key.keyCode == .keyboardRightGUI) else { return } //GUI buttons = CMD buttons on ipad/mac
+             self.shouldOpenInNewTab = true
+     
+        }
+        override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+            guard let key = presses.first?.key, (key.keyCode == .keyboardLeftGUI || key.keyCode == .keyboardRightGUI) else { return }
+             self.shouldOpenInNewTab = false
+         }
 }
 
 extension BrowserViewController {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -119,7 +119,7 @@ class BrowserViewController: UIViewController {
     weak var pendingDownloadWebView: WKWebView?
 
     let downloadQueue = DownloadQueue()
-    var shouldOpenInNewTab = false
+    var isCmdClickForNewTab = false
 
 
     init(profile: Profile, tabManager: TabManager) {
@@ -2354,13 +2354,13 @@ extension BrowserViewController: ContextMenuHelperDelegate {
     //Support for CMD+ Click on link to open in a new tab
      override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
          guard let key = presses.first?.key, (key.keyCode == .keyboardLeftGUI || key.keyCode == .keyboardRightGUI) else { return } //GUI buttons = CMD buttons on ipad/mac
-             self.shouldOpenInNewTab = true
-     
-        }
-        override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
-            guard let key = presses.first?.key, (key.keyCode == .keyboardLeftGUI || key.keyCode == .keyboardRightGUI) else { return }
-             self.shouldOpenInNewTab = false
-         }
+         self.isCmdClickForNewTab = true
+    }
+    
+    override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        guard let key = presses.first?.key, (key.keyCode == .keyboardLeftGUI || key.keyCode == .keyboardRightGUI) else { return }
+        self.isCmdClickForNewTab = false
+    }
 }
 
 extension BrowserViewController {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -580,10 +580,10 @@ extension BrowserViewController: WKNavigationDelegate {
             tab.mimeType = response.mimeType
         }
         
-        if shouldOpenInNewTab {
+        if isCmdClickForNewTab {
             guard let url = webView.url, let isPrivate = self.tabManager.selectedTab?.isPrivate else { return }
             homePanelDidRequestToOpenInNewTab(url, isPrivate: isPrivate)
-            self.shouldOpenInNewTab = false // the new tab will ask for the policy, if shouldOpenInNewTab = true, it will try to open itself in a new tab, so for now, we can make it false
+            self.isCmdClickForNewTab = false
             decisionHandler(.cancel)
         }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -579,6 +579,13 @@ extension BrowserViewController: WKNavigationDelegate {
 
             tab.mimeType = response.mimeType
         }
+        
+        if shouldOpenInNewTab {
+            guard let url = webView.url, let isPrivate = self.tabManager.selectedTab?.isPrivate else { return }
+            homePanelDidRequestToOpenInNewTab(url, isPrivate: isPrivate)
+            self.shouldOpenInNewTab = false // the new tab will ask for the policy, if shouldOpenInNewTab = true, it will try to open itself in a new tab, so for now, we can make it false
+            decisionHandler(.cancel)
+        }
 
         // If none of our helpers are responsible for handling this response,
         // just let the webview handle it as normal.


### PR DESCRIPTION
[FXIOS-767](https://github.com/mozilla-mobile/firefox-ios/issues/7147)- users can open links in new tab by pressing command and tapping the link

tested on simulator for iPads and iPhones, 

<img src="https://i.imgur.com/AhEmlIS.gif" width="600" height="900" />

all tests passed.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-797)
