### PR TITLE
FXIOS-829 ⁃ fix for FXIOS-816

### DIFF
--- a/RustFxA/FxAWebViewModel.swift
+++ b/RustFxA/FxAWebViewModel.swift
@@ -160,6 +160,11 @@ extension FxAWebViewModel {
             case .deleteAccount, .signOut:
                 profile.removeAccount()
                 onDismissController?()
+                //if the profile was removed correctly, we need to pop one more view controller
+                //fix for FXIOS-816: https://github.com/mozilla-mobile/firefox-ios/issues/7227#issue-687200349
+                if !profile.hasAccount() {
+                    onDismissController?()
+                }
             case .profileChanged:
                 profile.rustFxA.accountManager.peek()?.refreshProfile(ignoreCache: true)
                 // dismiss keyboard after changing profile in order to see notification view


### PR DESCRIPTION

fixed the bug where the user is redirected to Firefox account tab [FXIOS-816](https://github.com/mozilla-mobile/firefox-ios/issues/7227)

the result: 

![Imgur](https://i.imgur.com/uFXMlXp.gif)

*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Please make sure you've run the test scheme and all the tests pass. If your changes affect existing tests please make sure to update the tests as well.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-829)
