### PR TITLE
FXIOS-839 ⁃ Added A/B Test New Tab Link in Toolbar (Portrait mode)

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -255,6 +255,8 @@
 		435D7CC02461EFCB0043ACB9 /* IntroScreenWelcomeViewV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435D7CBF2461EFCB0043ACB9 /* IntroScreenWelcomeViewV2.swift */; };
 		435D7CC32461EFDD0043ACB9 /* IntroScreenSyncViewV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435D7CC22461EFDD0043ACB9 /* IntroScreenSyncViewV2.swift */; };
 		435D7CC5246209AA0043ACB9 /* IntroViewControllerV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435D7CC4246209AA0043ACB9 /* IntroViewControllerV2.swift */; };
+		4368BC6824FF14650021931D /* NewTabUserResearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4368BC6724FF14650021931D /* NewTabUserResearch.swift */; };
+		4368BC6A24FF14800021931D /* SharedUserResearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4368BC6924FF14800021931D /* SharedUserResearch.swift */; };
 		4390F7F5246CE04300570811 /* IntroViewModelV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4390F7F4246CE04300570811 /* IntroViewModelV2.swift */; };
 		4390F7FF246DAFBE00570811 /* FirefoxColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4390F7FE246DAFBE00570811 /* FirefoxColors.swift */; };
 		43A5643823CD1E1C00B6857D /* UpdateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43A5643523CD1E1B00B6857D /* UpdateViewController.swift */; };
@@ -1460,6 +1462,8 @@
 		435D7CC22461EFDD0043ACB9 /* IntroScreenSyncViewV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroScreenSyncViewV2.swift; sourceTree = "<group>"; };
 		435D7CC4246209AA0043ACB9 /* IntroViewControllerV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewControllerV2.swift; sourceTree = "<group>"; };
 		435FAB17242404B400AE9310 /* FullscreenHelper.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = FullscreenHelper.js; path = Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/FullscreenHelper.js; sourceTree = SOURCE_ROOT; };
+		4368BC6724FF14650021931D /* NewTabUserResearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabUserResearch.swift; sourceTree = "<group>"; };
+		4368BC6924FF14800021931D /* SharedUserResearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedUserResearch.swift; sourceTree = "<group>"; };
 		4390F7F4246CE04300570811 /* IntroViewModelV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewModelV2.swift; sourceTree = "<group>"; };
 		4390F7FE246DAFBE00570811 /* FirefoxColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirefoxColors.swift; sourceTree = "<group>"; };
 		43A5643523CD1E1B00B6857D /* UpdateViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdateViewController.swift; sourceTree = "<group>"; };
@@ -2797,6 +2801,8 @@
 			isa = PBXGroup;
 			children = (
 				434F97F224196B4200812FDF /* OnboardingUserResearch.swift */,
+				4368BC6724FF14650021931D /* NewTabUserResearch.swift */,
+				4368BC6924FF14800021931D /* SharedUserResearch.swift */,
 			);
 			path = UserResearch;
 			sourceTree = "<group>";
@@ -5618,6 +5624,7 @@
 				EBF47E701F7979DF00899189 /* TelemetryWrapper.swift in Sources */,
 				E68F36981EA694000048CF44 /* PanelDataObservers.swift in Sources */,
 				31ADB5DA1E58CEC300E87909 /* ClipboardBarDisplayHandler.swift in Sources */,
+				4368BC6824FF14650021931D /* NewTabUserResearch.swift in Sources */,
 				745DAB3F1CDAB09E00D44181 /* HistoryBackButton.swift in Sources */,
 				EB9A179D20E69A7F00B12184 /* Theme.swift in Sources */,
 				CA03B26A247F1D9E00382B62 /* BreachAlertsClient.swift in Sources */,
@@ -5674,6 +5681,7 @@
 				E6108FF91C84E91C005D25E8 /* BasePasscodeViewController.swift in Sources */,
 				39F4C10A2045DB2E00746155 /* FocusHelper.swift in Sources */,
 				4334145424C63779001541F3 /* IntroScreenSyncViewV1.swift in Sources */,
+				4368BC6A24FF14800021931D /* SharedUserResearch.swift in Sources */,
 				E4CD9F2D1A6DC91200318571 /* TabLocationView.swift in Sources */,
 				0BB5B2881AC0A2B90052877D /* SnackBar.swift in Sources */,
 				EBC4869F2195F58300CDA48D /* SessionRestoreHandler.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -221,6 +221,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
 
         // Leanplum usersearch variable setup for onboarding research
         _ = OnboardingUserResearch()
+        // Leanplum usersearch variable setup for New Tab user research
+        _ = NewTabUserResearch()
         // Leanplum setup
 
         if let profile = self.profile, LeanPlumClient.shouldEnable(profile: profile) {

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -219,9 +219,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
 
         pushNotificationSetup()
 
-        // Leanplum usersearch variable setup for onboarding research
+        // Leanplum user research variable setup for onboarding research
         _ = OnboardingUserResearch()
-        // Leanplum usersearch variable setup for New Tab user research
+        // Leanplum user research variable setup for New tab user research
         _ = NewTabUserResearch()
         // Leanplum setup
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -61,6 +61,7 @@ class BrowserViewController: UIViewController {
     let alertStackView = UIStackView() // All content that appears above the footer should be added to this view. (Find In Page/SnackBars)
     var findInPageBar: FindInPageBar?
     private var onboardingUserResearch: OnboardingUserResearch?
+    private var newTabUserResearch: NewTabUserResearch?
     lazy var mailtoLinkHandler = MailtoLinkHandler()
 
     fileprivate var customSearchBarButton: UIBarButtonItem?
@@ -468,6 +469,9 @@ class BrowserViewController: UIViewController {
         
         // Setup onboarding user research for A/B testing
         onboardingUserResearch = OnboardingUserResearch()
+        // Setup New Tab user research for A/B testing
+        newTabUserResearch = NewTabUserResearch()
+        newTabUserResearch?.lpVariableObserver()
     }
 
     fileprivate func setupConstraints() {
@@ -895,7 +899,7 @@ class BrowserViewController: UIViewController {
     }
     
     func setupMiddleButtonStatus(isLoading: Bool) {
-        let shouldShowNewTabButton = profile.prefs.boolForKey(PrefsKeys.ShowNewTabToolbarButton) ?? false
+        let shouldShowNewTabButton = profile.prefs.boolForKey(PrefsKeys.ShowNewTabToolbarButton) ?? (newTabUserResearch?.newTabState ?? false)
         
         // No tab
         guard let tab = tabManager.selectedTab else {

--- a/Client/UserResearch/NewTabUserResearch.swift
+++ b/Client/UserResearch/NewTabUserResearch.swift
@@ -6,79 +6,75 @@ import Foundation
 import Leanplum
 import Shared
 
-// For LP variable below is the convention we follow
-// True = Current Onboarding Screen
-// False = New Onboarding Screen
-enum OnboardingScreenType: String {
-    case versionV1
-    case versionV2 
-    
-    static func from(boolValue: Bool) -> OnboardingScreenType {
-        return boolValue ? .versionV1 : .versionV2
-    }
-}
-
-class OnboardingUserResearch {
+class NewTabUserResearch {
     // Closure delegate
     var updatedLPVariable: (() -> Void)?
     // variable
     var lpVariable: LPVar?
     // Constants
-    private let onboardingScreenTypeKey = "onboardingScreenTypeKey"
+    private let newTabUserResearchKey = "newTabUserResearchKey"
     // Saving user defaults
     private let defaults = UserDefaults.standard
-    // Publicly accessible onboarding screen type
-    var onboardingScreenType: OnboardingScreenType? {
+    // LP fetched status variable
+    private var fetchedExperimentVariables = false
+    // New tab button state
+    // True: Show new tab button
+    // False: Hide new tab button
+    var newTabState: Bool? {
         set(value) {
             if value == nil {
-                defaults.removeObject(forKey: onboardingScreenTypeKey)
+                defaults.removeObject(forKey: newTabUserResearchKey)
             } else {
-                defaults.set(value?.rawValue, forKey: onboardingScreenTypeKey)
+                defaults.set(value, forKey: newTabUserResearchKey)
             }
         }
         get {
-            guard let value = defaults.value(forKey: onboardingScreenTypeKey) as? String else {
+            guard let value = defaults.value(forKey: newTabUserResearchKey) as? Bool else {
                 return nil
             }
-            return OnboardingScreenType(rawValue: value)
+            return value
         }
     }
     
     // MARK: Initializer
-    init(lpVariable: LPVar? = LPVariables.onboardingABTestV2) {
+    init(lpVariable: LPVar? = LPVariables.newTabButtonABTest) {
         self.lpVariable = lpVariable
     }
     
     // MARK: public
     func lpVariableObserver() {
-        // Condition: Leanplum is disabled; use default intro view
+        print("NewTabUserResearch: lpVariableObserver")
+        // Condition: Leanplum is disabled; Set default New tab state
         guard LeanPlumClient.shared.getSettings() != nil else {
-            self.onboardingScreenType = .versionV1
+            // default state is false
+            self.newTabState = false
             self.updatedLPVariable?()
             return
         }
         // Condition: A/B test variables from leanplum server
         LeanPlumClient.shared.finishedStartingLeanplum = {
-            let showScreenA = LPVariables.onboardingABTestV2?.boolValue()
             LeanPlumClient.shared.finishedStartingLeanplum = nil
-            self.updateTelemetry()
-            let screenType = OnboardingScreenType.from(boolValue: (showScreenA ?? true))
-            self.onboardingScreenType = screenType
-            self.updatedLPVariable?()
-        }
-        // Condition: Leanplum server too slow; Show default onboarding.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            guard LeanPlumClient.shared.finishedStartingLeanplum != nil else {
+            guard self.fetchedExperimentVariables == false else {
                 return
             }
-            let lpStartStatus = LeanPlumClient.shared.lpState
-            var lpVariableValue: OnboardingScreenType = .versionV1
+            self.fetchedExperimentVariables = true
+            self.updateTelemetry()
+            self.newTabState = LPVariables.newTabButtonABTest?.boolValue() ?? false
+            self.updatedLPVariable?()
+        }
+        // Condition: Leanplum server too slow; Set default New tab state
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            guard self.fetchedExperimentVariables == false else {
+                return
+            }
+            // Condition: Leanplum server too slow; Set default New tab state
+            self.newTabState = false
             // Condition: LP has already started but we missed onStartLPVariable callback
-            if case .started(startedState: _) = lpStartStatus , let boolValue = LPVariables.onboardingABTestV2?.boolValue() {
-                lpVariableValue = boolValue ? .versionV1 : .versionV2
+            if case .started(startedState: _) = LeanPlumClient.shared.lpState , let boolValue = LPVariables.newTabButtonABTest?.boolValue() {
+                self.newTabState = boolValue
                 self.updateTelemetry()
             }
-            self.onboardingScreenType = lpVariableValue
+            self.fetchedExperimentVariables = true
             self.updatedLPVariable?()
         }
     }

--- a/Client/UserResearch/NewTabUserResearch.swift
+++ b/Client/UserResearch/NewTabUserResearch.swift
@@ -10,6 +10,7 @@ class NewTabUserResearch {
     // Closure delegate
     var updatedLPVariable: (() -> Void)?
     // variable
+    // Variable
     var lpVariable: LPVar?
     // Constants
     private let newTabUserResearchKey = "newTabUserResearchKey"
@@ -43,7 +44,6 @@ class NewTabUserResearch {
     
     // MARK: public
     func lpVariableObserver() {
-        print("NewTabUserResearch: lpVariableObserver")
         // Condition: Leanplum is disabled; Set default New tab state
         guard LeanPlumClient.shared.getSettings() != nil else {
             // default state is false

--- a/Client/UserResearch/NewTabUserResearch.swift
+++ b/Client/UserResearch/NewTabUserResearch.swift
@@ -7,9 +7,6 @@ import Leanplum
 import Shared
 
 class NewTabUserResearch {
-    // Closure delegate
-    var updatedLPVariable: (() -> Void)?
-    // variable
     // Variable
     var lpVariable: LPVar?
     // Constants
@@ -48,7 +45,6 @@ class NewTabUserResearch {
         guard LeanPlumClient.shared.getSettings() != nil else {
             // default state is false
             self.newTabState = false
-            self.updatedLPVariable?()
             return
         }
         // Condition: A/B test variables from leanplum server
@@ -60,7 +56,6 @@ class NewTabUserResearch {
             self.fetchedExperimentVariables = true
             self.updateTelemetry()
             self.newTabState = LPVariables.newTabButtonABTest?.boolValue() ?? false
-            self.updatedLPVariable?()
         }
         // Condition: Leanplum server too slow; Set default New tab state
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
@@ -72,10 +67,8 @@ class NewTabUserResearch {
             // Condition: LP has already started but we missed onStartLPVariable callback
             if case .started(startedState: _) = LeanPlumClient.shared.lpState , let boolValue = LPVariables.newTabButtonABTest?.boolValue() {
                 self.newTabState = boolValue
-                self.updateTelemetry()
             }
             self.fetchedExperimentVariables = true
-            self.updatedLPVariable?()
         }
     }
     

--- a/Client/UserResearch/SharedUserResearch.swift
+++ b/Client/UserResearch/SharedUserResearch.swift
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Leanplum
+import Shared
+
+struct LPVariables {
+    // Variable Used for AA test
+    static var showOnboardingScreenAA = LPVar.define("showOnboardingScreen", with: true)
+    // Variable Used for AB test
+    static var showOnboardingScreenAB = LPVar.define("showOnboardingScreen_2", with: true)
+    // Variable Used for 2nd Iteration of Onboarding AB Test
+    static var onboardingABTestV2 = LPVar.define("onboardingABTestV2", with: true)
+    // Variable Used for New Tab Button AB Test
+    static var newTabButtonABTest = LPVar.define("newTabButtonABTestProd", with: false)
+}


### PR DESCRIPTION
- [x] Setup and test dev AB test variable on Leanplum 
- [x] Sync up with Data Science and make sure variable name is setup correctly
- [x] Make sure that we are going with default value where `new tab button` is hidden
- [x] Need to setup AB test variable on Leanplum for Production 
- [ ] Test out production setup of Leanplum AB test variable on a device

**BrowserViewController** has instance of _NewTabUserResearch_ to fetch AB test variable from LP
**NewTabUserResearch** fetches AB test variable from LP 
**SharedUserResearch** is just a place to have multiple AB test variable setup

https://jira.mozilla.com/browse/DS-825 - Ticket has been updated with proper comments on where to find the test and its variables

![image](https://user-images.githubusercontent.com/8919439/92019499-b6d15880-ed24-11ea-911a-cceee1699c17.png)

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-839)
