### PR TITLE
FXIOS-853 ⁃ Fix Issue #7241/FXIOS-827 - Pairing with Custom Sync Server

### DIFF
--- a/RustFxA/RustFirefoxAccounts.swift
+++ b/RustFxA/RustFirefoxAccounts.swift
@@ -126,19 +126,11 @@ open class RustFirefoxAccounts {
         }
 
         let config: FxAConfig
-        let useCustom = prefs?.boolForKey(PrefsKeys.KeyUseCustomFxAContentServer) ?? false || prefs?.boolForKey(PrefsKeys.KeyUseCustomSyncTokenServerOverride) ?? false
-        if useCustom {
-            let contentUrl: String
-            if prefs?.boolForKey(PrefsKeys.KeyUseCustomFxAContentServer) ?? false, let url = prefs?.stringForKey(PrefsKeys.KeyCustomFxAContentServer) {
-                contentUrl = url
-            } else {
-                contentUrl = "https://stable.dev.lcip.org"
-            }
-
-            let tokenServer = prefs?.boolForKey(PrefsKeys.KeyUseCustomSyncTokenServerOverride) ?? false ? prefs?.stringForKey(PrefsKeys.KeyCustomSyncTokenServerOverride) : nil
+        let tokenServer = prefs?.boolForKey(PrefsKeys.KeyUseCustomSyncTokenServerOverride) ?? false ? prefs?.stringForKey(PrefsKeys.KeyCustomSyncTokenServerOverride) : nil
+        if prefs?.boolForKey(PrefsKeys.KeyUseCustomFxAContentServer) ?? false, let contentUrl = prefs?.stringForKey(PrefsKeys.KeyCustomFxAContentServer)  {
             config = FxAConfig(contentUrl: contentUrl, clientId: RustFirefoxAccounts.clientID, redirectUri: RustFirefoxAccounts.redirectURL, tokenServerUrlOverride: tokenServer)
         } else {
-            config = FxAConfig(server: server, clientId: RustFirefoxAccounts.clientID, redirectUri: RustFirefoxAccounts.redirectURL)
+            config = FxAConfig(server: server, clientId: RustFirefoxAccounts.clientID, redirectUri: RustFirefoxAccounts.redirectURL, tokenServerUrlOverride: tokenServer)
         }
 
         let type = UIDevice.current.userInterfaceIdiom == .pad ? DeviceType.tablet : DeviceType.mobile


### PR DESCRIPTION
This changes the `FxAConfig` init logic to use the release servers when using a custom sync server without a custom content server, instead of hard-coding it to stable.

If the intention is for the stable servers to be used, then the `redirect_uri` needs to be set on the server for the iOS client ID as it is currently an empty string.

Fixes #7241, #6535

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-853)
