### PR TITLE
FXIOS-855 ⁃ Fixed "Contributor OK" link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For bug fixes and features for a specific release use the version branch.
 Getting involved
 ----------------
 
-Want to contribute but don't know where to start? Here is a list of [issues that are contributor friendly](https://github.com/mozilla-mobile/firefox-ios/issues?q=is%3Aissue+is%3Aopen+label%3A%22Contributor+OK+%F0%9F%A4%9D%22)
+Want to contribute but don't know where to start? Here is a list of [issues that are contributor friendly](https://github.com/mozilla-mobile/firefox-ios/labels/Contributor%20OK)
 
 Building the code
 -----------------


### PR DESCRIPTION
Looks like there was previously an emoji handshake in the label that has since been removed, causing the viewer to go to an empty list of GitHub Issues. Removed the emoji from the link so that it takes folks to the correct label within GitHub Issues

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-855)
