### PR TITLE
FXIOS-857 ⁃ Fix Carthage issue on BB

### DIFF
--- a/buddybuild_carthage_command.sh
+++ b/buddybuild_carthage_command.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
-#carthage bootstrap $CARTHAGE_VERBOSE --platform ios --color auto --cache-builds
+carthage bootstrap $CARTHAGE_VERBOSE --platform ios --color auto --cache-builds
 
 # Workaround to Carthage issue with latest version 0.35.0
 # https://github.com/Carthage/Carthage/issues/3003
-brew uninstall --force carthage
-brew install https://github.com/Homebrew/homebrew-core/raw/09ceff6c1de7ebbfedb42c0941a48bfdca932c0f/Formula/carthage.rb
+# Issue still open but error on BB carthage formula file from an arbitrary URL is disabled!
+# brew uninstall --force carthage
+# brew install https://github.com/Homebrew/homebrew-core/raw/09ceff6c1de7ebbfedb42c0941a48bfdca932c0f/Formula/carthage.rb
 
 carthage version
 

--- a/buddybuild_carthage_command.sh
+++ b/buddybuild_carthage_command.sh
@@ -1,12 +1,3 @@
 #!/bin/bash
-carthage bootstrap $CARTHAGE_VERBOSE --platform ios --color auto --cache-builds
-
-# Workaround to Carthage issue with latest version 0.35.0
-# https://github.com/Carthage/Carthage/issues/3003
-# Issue still open but error on BB carthage formula file from an arbitrary URL is disabled!
-# brew uninstall --force carthage
-# brew install https://github.com/Homebrew/homebrew-core/raw/09ceff6c1de7ebbfedb42c0941a48bfdca932c0f/Formula/carthage.rb
-
 carthage version
-
 ./carthage_command.sh


### PR DESCRIPTION
PR to fix the issue affecting main on BB: 
`Error: Calling Non-checksummed download of carthage formula file from an arbitrary URL is disabled! Use ‘brew extract’ or ‘brew create’ and ‘brew tap-new’ to create a formula file in a tap on GitHub instead.right this error`

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-857)
