### PR TITLE
FXIOS-867 ⁃ Use new WKContentWorld parameter on evaluateJavaScript

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -496,6 +496,7 @@
 		CA90753824929B22005B794D /* NoLoginsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA90753724929B22005B794D /* NoLoginsView.swift */; };
 		CAA3B7E62497DCB60094E3C1 /* LoginDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA3B7E52497DCB60094E3C1 /* LoginDataSource.swift */; };
 		CAC458F1249429C20042561A /* LoginListSelectionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC458F0249429C20042561A /* LoginListSelectionHelper.swift */; };
+		CD1CE85F24EDE66A00006DFB /* WKWebViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1CE85E24EDE66A00006DFB /* WKWebViewExtensions.swift */; };
 		CDB3BE8724746787009320EE /* FirefoxAccountSignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB3BE8624746787009320EE /* FirefoxAccountSignInViewController.swift */; };
 		CE7F11941F3CEEC800ABFC0B /* RemoteDevices.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F115E1F3CCEF900ABFC0B /* RemoteDevices.swift */; };
 		CEFA977E1FAA6B490016F365 /* SyncContentSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFA977D1FAA6B490016F365 /* SyncContentSettingsViewController.swift */; };
@@ -1702,6 +1703,7 @@
 		CA90753724929B22005B794D /* NoLoginsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoLoginsView.swift; sourceTree = "<group>"; };
 		CAA3B7E52497DCB60094E3C1 /* LoginDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginDataSource.swift; sourceTree = "<group>"; };
 		CAC458F0249429C20042561A /* LoginListSelectionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginListSelectionHelper.swift; sourceTree = "<group>"; };
+		CD1CE85E24EDE66A00006DFB /* WKWebViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKWebViewExtensions.swift; sourceTree = "<group>"; };
 		CDB3BE8624746787009320EE /* FirefoxAccountSignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirefoxAccountSignInViewController.swift; sourceTree = "<group>"; };
 		CE7F115E1F3CCEF900ABFC0B /* RemoteDevices.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteDevices.swift; sourceTree = "<group>"; };
 		CEFA977D1FAA6B490016F365 /* SyncContentSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncContentSettingsViewController.swift; sourceTree = "<group>"; };
@@ -3555,6 +3557,7 @@
 				7B3D9E641E4CBFDB007A50DA /* NSCoderExtensions.swift */,
 				E693F0D81E9D64BD0086DC17 /* OptionalExtensions.swift */,
 				D0543529226687A400FDE4EF /* UIBarButtonItemExtensions.swift */,
+				CD1CE85E24EDE66A00006DFB /* WKWebViewExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -5255,6 +5258,7 @@
 				E65075A01E37F7AB006961AC /* ArrayExtensions.swift in Sources */,
 				E65075A31E37F7AB006961AC /* KeychainWrapperExtensions.swift in Sources */,
 				E65075921E37F7AB006961AC /* Accessibility.swift in Sources */,
+				CD1CE85F24EDE66A00006DFB /* WKWebViewExtensions.swift in Sources */,
 				E65075B51E37F7AB006961AC /* LaunchArguments.swift in Sources */,
 				E65075BB1E37F7AB006961AC /* RollingFileLogger.swift in Sources */,
 				E650759D1E37F7AB006961AC /* DeviceInfo.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1155,7 +1155,7 @@ class BrowserViewController: UIViewController {
             if (!InternalURL.isValid(url: url) || url.isReaderModeURL), !url.isFileURL {
                 postLocationChangeNotificationForTab(tab, navigation: navigation)
 
-                webView.evaluateJavaScript("\(ReaderModeNamespace).checkReadability()", completionHandler: nil)
+                webView.evaluateJavascriptInDefaultContentWorld("\(ReaderModeNamespace).checkReadability()")
             }
 
             if urlBar.inOverlayMode, InternalURL.isValid(url: url), url.path.starts(with: "/\(AboutHomeHandler.path)") {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+FindInPage.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+FindInPage.swift
@@ -33,7 +33,7 @@ extension BrowserViewController {
             findInPageBar.endEditing(true)
             let tab = tab ?? tabManager.selectedTab
             guard let webView = tab?.webView else { return }
-            webView.evaluateJavaScript("__firefox__.findDone()", completionHandler: nil)
+            webView.evaluateJavascriptInDefaultContentWorld("__firefox__.findDone()")
             findInPageBar.removeFromSuperview()
             self.findInPageBar = nil
             updateViewConstraints()
@@ -63,7 +63,7 @@ extension BrowserViewController: FindInPageBarDelegate, FindInPageHelperDelegate
     fileprivate func find(_ text: String, function: String) {
         guard let webView = tabManager.selectedTab?.webView else { return }
         let escaped = text.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
-        webView.evaluateJavaScript("__firefox__.\(function)(\"\(escaped)\")", completionHandler: nil)
+        webView.evaluateJavascriptInDefaultContentWorld("__firefox__.\(function)(\"\(escaped)\")")
     }
 
     func findInPageHelper(_ findInPageHelper: FindInPageHelper, didUpdateCurrentResult currentResult: Int) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -106,18 +106,14 @@ extension BrowserViewController {
             webView.go(to: forwardList.first!)
         } else {
             // Store the readability result in the cache and load it. This will later move to the ReadabilityHelper.
-            webView.evaluateJavaScript("\(ReaderModeNamespace).readerize()", completionHandler: { (object, error) -> Void in
+            webView.evaluateJavascriptInDefaultContentWorld("\(ReaderModeNamespace).readerize()") { object, error in
                 if let readabilityResult = ReadabilityResult(object: object as AnyObject?) {
-                    do {
-                        try self.readerModeCache.put(currentURL, readabilityResult)
-                    } catch _ {
-                    }
-                    
+                    try? self.readerModeCache.put(currentURL, readabilityResult)
                     if let nav = webView.load(PrivilegedRequest(url: readerModeURL) as URLRequest) {
                         self.ignoreNavigationInTab(tab, navigation: nav)
                     }
                 }
-            })
+            }
         }
     }
 

--- a/Client/Frontend/Browser/DownloadContentScript.swift
+++ b/Client/Frontend/Browser/DownloadContentScript.swift
@@ -28,7 +28,7 @@ class DownloadContentScript: TabContentScript {
     static func requestDownload(url: URL, tab: Tab) {
         let safeUrl = url.absoluteString.replacingOccurrences(of: "'", with: "%27")
         blobUrlForDownload = url.scheme == "blob" ? URL(string: safeUrl) : nil
-        tab.webView?.evaluateJavaScript("window.__firefox__.download('\(safeUrl)', '\(UserScriptManager.appIdToken)')")
+        tab.webView?.evaluateJavascriptInDefaultContentWorld("window.__firefox__.download('\(safeUrl)', '\(UserScriptManager.appIdToken)')")
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .downloadLinkButton)
     }
 

--- a/Client/Frontend/Browser/LoginsHelper.swift
+++ b/Client/Frontend/Browser/LoginsHelper.swift
@@ -271,7 +271,7 @@ class LoginsHelper: TabContentScript {
 
             let json = JSON(dict)
             let injectJavaScript = "window.__firefox__.logins.inject(\(json.stringify()!))"
-            self.tab?.webView?.evaluateJavaScript(injectJavaScript)
+            self.tab?.webView?.evaluateJavascriptInDefaultContentWorld(injectJavaScript)
         }
     }
 }

--- a/Client/Frontend/Browser/MetadataParserHelper.swift
+++ b/Client/Frontend/Browser/MetadataParserHelper.swift
@@ -25,8 +25,7 @@ class MetadataParserHelper: TabEventHandler {
                 tab.pageMetadata = nil
                 return
         }
-
-        webView.evaluateJavaScript("__firefox__.metadata && __firefox__.metadata.getMetadata()") { (result, error) in
+        webView.evaluateJavascriptInDefaultContentWorld("__firefox__.metadata && __firefox__.metadata.getMetadata()") { result, error in
             guard error == nil else {
                 TabEvent.post(.pageMetadataNotAvailable, for: tab)
                 tab.pageMetadata = nil

--- a/Client/Frontend/Browser/OpenInHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper.swift
@@ -60,7 +60,7 @@ class DownloadHelper: NSObject, OpenInHelper {
 
     static func requestDownload(url: URL, tab: Tab) {
         let safeUrl = url.absoluteString.replacingOccurrences(of: "'", with: "%27")
-        tab.webView?.evaluateJavaScript("window.__firefox__.download('\(safeUrl)', '\(UserScriptManager.appIdToken)')")
+        tab.webView?.evaluateJavascriptInDefaultContentWorld("window.__firefox__.download('\(safeUrl)', '\(UserScriptManager.appIdToken)')")
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .downloadLinkButton)
     }
     

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -709,6 +709,14 @@ class TabWebView: WKWebView, MenuHelperInterface {
 
         return super.hitTest(point, with: event)
     }
+    
+    /// Override evaluateJavascript - should not be called directly on TabWebViews any longer
+    // We should only be calling evaluateJavascriptInDefaultContentWorld in the future
+    @available(*, unavailable, message:"Do not call evaluateJavaScript directly on TabWebViews, should only be called on super class")
+    override func evaluateJavaScript(_ javaScriptString: String, completionHandler: ((Any?, Error?) -> Void)? = nil) {
+        super.evaluateJavaScript(javaScriptString, completionHandler: completionHandler)
+    }
+    
 }
 
 ///

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -157,7 +157,7 @@ class Tab: NSObject {
                 return
             }
 
-            webView?.evaluateJavaScript("window.__firefox__.NightMode.setEnabled(\(nightMode))")
+            webView?.evaluateJavascriptInDefaultContentWorld("window.__firefox__.NightMode.setEnabled(\(nightMode))")
             // For WKWebView background color to take effect, isOpaque must be false,
             // which is counter-intuitive. Default is true. The color is previously
             // set to black in the WKWebView init.
@@ -680,7 +680,7 @@ class TabWebView: WKWebView, MenuHelperInterface {
     func applyTheme() {
         if url == nil {
             let backgroundColor = ThemeManager.instance.current.browser.background.hexString
-            evaluateJavaScript("document.documentElement.style.backgroundColor = '\(backgroundColor)';")
+            evaluateJavascriptInDefaultContentWorld("document.documentElement.style.backgroundColor = '\(backgroundColor)';")
         }
         window?.backgroundColor = UIColor.theme.browser.background
     }
@@ -690,14 +690,14 @@ class TabWebView: WKWebView, MenuHelperInterface {
     }
 
     @objc func menuHelperFindInPage() {
-        evaluateJavaScript("getSelection().toString()") { result, _ in
+        evaluateJavascriptInDefaultContentWorld("getSelection().toString()") { result, _ in
             let selection = result as? String ?? ""
             self.delegate?.tabWebView(self, didSelectFindInPageForSelection: selection)
         }
     }
 
     @objc func menuHelperSearchWithFirefox() {
-        evaluateJavaScript("getSelection().toString()") { result, _ in
+        evaluateJavascriptInDefaultContentWorld("getSelection().toString()") { result, _ in
             let selection = result as? String ?? ""
             self.delegate?.tabWebViewSearchWithFirefox(self, didSelectSearchWithFirefoxForSelection: selection)
         }
@@ -723,7 +723,7 @@ class TabWebView: WKWebView, MenuHelperInterface {
 class TabWebViewMenuHelper: UIView {
     @objc func swizzledMenuHelperFindInPage() {
         if let tabWebView = superview?.superview as? TabWebView {
-            tabWebView.evaluateJavaScript("getSelection().toString()") { result, _ in
+            tabWebView.evaluateJavascriptInDefaultContentWorld("getSelection().toString()") { result, _ in
                 let selection = result as? String ?? ""
                 tabWebView.delegate?.tabWebView(tabWebView, didSelectFindInPageForSelection: selection)
             }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -643,7 +643,7 @@ extension TabManager: WKNavigationDelegate {
         guard let tab = self[webView] else { return }
 
         if let tpHelper = tab.contentBlocker, !tpHelper.isEnabled {
-            webView.evaluateJavaScript("window.__firefox__.TrackingProtectionStats.setEnabled(false, \(UserScriptManager.appIdToken))")
+            webView.evaluateJavascriptInDefaultContentWorld("window.__firefox__.TrackingProtectionStats.setEnabled(false, \(UserScriptManager.appIdToken))")
         }
     }
 

--- a/Client/Frontend/InternalSchemeHandler/SessionRestoreHandler.swift
+++ b/Client/Frontend/InternalSchemeHandler/SessionRestoreHandler.swift
@@ -13,7 +13,7 @@ extension WKWebView {
     // Use JS to redirect the page without adding a history entry
     func replaceLocation(with url: URL) {
         let safeUrl = url.absoluteString.replacingOccurrences(of: "'", with: apostropheEncoded)
-        evaluateJavaScript("location.replace('\(safeUrl)')")
+        evaluateJavascriptInDefaultContentWorld("location.replace('\(safeUrl)')")
     }
 }
 

--- a/Client/Frontend/Reader/ReadabilityService.swift
+++ b/Client/Frontend/Reader/ReadabilityService.swift
@@ -91,7 +91,7 @@ extension ReadabilityOperation: WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        webView.evaluateJavaScript("\(ReaderModeNamespace).checkReadability()")
+        webView.evaluateJavascriptInDefaultContentWorld("\(ReaderModeNamespace).checkReadability()")
     }
 }
 

--- a/Client/Frontend/Reader/ReaderMode.swift
+++ b/Client/Frontend/Reader/ReaderMode.swift
@@ -332,9 +332,9 @@ class ReaderMode: TabContentScript {
     var style: ReaderModeStyle = DefaultReaderModeStyle {
         didSet {
             if state == ReaderModeState.active {
-                tab?.webView?.evaluateJavaScript("\(ReaderModeNamespace).setStyle(\(style.encode()))", completionHandler: { (object, error) -> Void in
+                tab?.webView?.evaluateJavascriptInDefaultContentWorld("\(ReaderModeNamespace).setStyle(\(style.encode()))") { object, error in
                     return
-                })
+                }
             }
         }
     }

--- a/RustFxA/FxAWebViewController.swift
+++ b/RustFxA/FxAWebViewController.swift
@@ -105,7 +105,7 @@ extension FxAWebViewController: WKScriptMessageHandler {
 extension FxAWebViewController {
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         let hideLongpress = "document.body.style.webkitTouchCallout='none';"
-        webView.evaluateJavaScript(hideLongpress)
+        webView.evaluateJavascriptInDefaultContentWorld(hideLongpress)
 
         //The helpBrowser shows the current URL in the navbar, the main fxa webview does not.
         guard webView !== helpBrowser else {

--- a/RustFxA/FxAWebViewModel.swift
+++ b/RustFxA/FxAWebViewModel.swift
@@ -182,7 +182,7 @@ extension FxAWebViewModel {
             window.dispatchEvent(new CustomEvent('WebChannelMessageToContent', { detail: JSON.stringify(msg) }));
         """
 
-        webView.evaluateJavaScript(msg)
+        webView.evaluateJavascriptInDefaultContentWorld(msg)
     }
 
     /// Respond to the webpage session status notification by either passing signed in user info (for settings), or by passing CWTS setup info (in case the user is signing up for an account). This latter case is also used for the sign-in state.

--- a/Shared/Extensions/WKWebViewExtensions.swift
+++ b/Shared/Extensions/WKWebViewExtensions.swift
@@ -7,6 +7,11 @@ import WebKit
 
 extension WKWebView {
     
+    /// This calls different WebKit evaluateJavaScript functions depending on iOS version
+    ///  - If iOS14 or higher, evaluates Javascript in a .defaultClient sandboxed content world
+    ///  - If below iOS14, evaluates Javascript without sandboxed environment
+    /// - Parameters:
+    ///     - javascript: String representing javascript to be evaluated
     public func evaluateJavascriptInDefaultContentWorld(_ javascript: String) {
         if #available(iOS 14.0, *) {
             self.evaluateJavaScript(javascript, in: nil, in: .defaultClient, completionHandler: { _ in })
@@ -15,7 +20,13 @@ extension WKWebView {
         }
     }
     
-    public func evaluateJavascriptInDefaultContentWorld(_ javascript: String, completion: @escaping ((Any?, Error?) -> Void)) {
+    /// This calls different WebKit evaluateJavaScript functions depending on iOS version with a completion that passes a tuple with optional data or an optional error
+    ///  - If iOS14 or higher, evaluates Javascript in a .defaultClient sandboxed content world
+    ///  - If below iOS14, evaluates Javascript without sandboxed environment
+    /// - Parameters:
+    ///     - javascript: String representing javascript to be evaluated
+    ///     - completion: Tuple containing optional data and an optional error
+    public func evaluateJavascriptInDefaultContentWorld(_ javascript: String,_ completion: @escaping ((Any?, Error?) -> Void)) {
         if #available(iOS 14.0, *) {
             self.evaluateJavaScript(javascript, in: nil, in: .defaultClient) { result in
                 switch result {

--- a/Shared/Extensions/WKWebViewExtensions.swift
+++ b/Shared/Extensions/WKWebViewExtensions.swift
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import WebKit
+
+extension WKWebView {
+    
+    public func evaluateJavascriptInDefaultContentWorld(_ javascript: String) {
+        if #available(iOS 14.0, *) {
+            self.evaluateJavaScript(javascript, in: nil, in: .defaultClient, completionHandler: { _ in })
+        } else {
+            self.evaluateJavaScript(javascript)
+        }
+    }
+    
+    public func evaluateJavascriptInDefaultContentWorld(_ javascript: String, completion: @escaping ((Any?, Error?) -> Void)) {
+        if #available(iOS 14.0, *) {
+            self.evaluateJavaScript(javascript, in: nil, in: .defaultClient) { result in
+                switch result {
+                case .success(let value):
+                    completion(value, nil)
+                case .failure(let error):
+                    completion(nil, error)
+                }
+            }
+        } else {
+            self.evaluateJavaScript(javascript) { data, error  in
+                completion(data, error)
+            }
+        }
+    }
+}

--- a/UITests/ClearPrivateDataTests.swift
+++ b/UITests/ClearPrivateDataTests.swift
@@ -193,7 +193,7 @@ class ClearPrivateDataTests: KIFTestCase, UITextFieldDelegate {
 
     fileprivate func setCookies(_ webView: WKWebView, cookie: String) {
         let expectation = self.expectation(description: "Set cookie")
-        webView.evaluateJavaScript("document.cookie = \"\(cookie)\"; localStorage.cookie = \"\(cookie)\"; sessionStorage.cookie = \"\(cookie)\";") { result, _ in
+        webView.evaluateJavascriptInDefaultContentWorld("document.cookie = \"\(cookie)\"; localStorage.cookie = \"\(cookie)\"; sessionStorage.cookie = \"\(cookie)\";") { result, _ in
             expectation.fulfill()
         }
         waitForExpectations(timeout: 10, handler: nil)
@@ -204,7 +204,7 @@ class ClearPrivateDataTests: KIFTestCase, UITextFieldDelegate {
         var value: String!
         let expectation = self.expectation(description: "Got cookie")
 
-        webView.evaluateJavaScript("JSON.stringify([document.cookie, localStorage.cookie, sessionStorage.cookie])") { result, _ in
+        webView.evaluateJavascriptInDefaultContentWorld("JSON.stringify([document.cookie, localStorage.cookie, sessionStorage.cookie])") { result, _ in
             value = result as! String
             expectation.fulfill()
         }

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -132,8 +132,8 @@ extension KIFUITestActor {
         var stepResult = KIFTestStepResult.wait
 
         let escaped = text.replacingOccurrences(of: "\"", with: "\\\"")
-        webView.evaluateJavaScript("KIFHelper.enterTextIntoInputWithName(\"\(escaped)\", \"\(inputName)\");") { success, _ in
-            stepResult = (success as! Bool) ? KIFTestStepResult.success : KIFTestStepResult.failure
+        webView.evaluateJavascriptInDefaultContentWorld("KIFHelper.enterTextIntoInputWithName(\"\(escaped)\", \"\(inputName)\");") { success, _ in
+            stepResult = (success as? Bool) ? KIFTestStepResult.success : KIFTestStepResult.failure
         }
 
         run { error in
@@ -152,8 +152,8 @@ extension KIFUITestActor {
         var stepResult = KIFTestStepResult.wait
 
         let escaped = text.replacingOccurrences(of: "\"", with: "\\\"")
-        webView.evaluateJavaScript("KIFHelper.tapElementWithAccessibilityLabel(\"\(escaped)\")") { success, _ in
-            stepResult = (success as! Bool) ? KIFTestStepResult.success : KIFTestStepResult.failure
+        webView.evaluateJavascriptInDefaultContentWorld("KIFHelper.tapElementWithAccessibilityLabel(\"\(escaped)\")") { success, _ in
+            stepResult = (success as? Bool) ? KIFTestStepResult.success : KIFTestStepResult.failure
         }
 
         run { error in
@@ -173,7 +173,7 @@ extension KIFUITestActor {
         var found = false
 
         let escaped = text.replacingOccurrences(of: "\"", with: "\\\"")
-        webView.evaluateJavaScript("KIFHelper.hasElementWithAccessibilityLabel(\"\(escaped)\")") { success, _ in
+        webView.evaluateJavascriptInDefaultContentWorld("KIFHelper.hasElementWithAccessibilityLabel(\"\(escaped)\")") { success, _ in
             found = success as? Bool ?? false
             stepResult = KIFTestStepResult.success
         }
@@ -193,14 +193,19 @@ extension KIFUITestActor {
 
         var stepResult = KIFTestStepResult.wait
 
-        webView.evaluateJavaScript("typeof KIFHelper") { result, _ in
-            if result as! String == "undefined" {
+        webView.evaluateJavascriptInDefaultContentWorld("typeof KIFHelper") { result, _ in
+            if let result = result as? String, result == "undefined" {
                 let bundle = Bundle(for: BrowserTests.self)
                 let path = bundle.path(forResource: "KIFHelper", ofType: "js")!
-                let source = try! String(contentsOfFile: path, encoding: .utf8)
-                webView.evaluateJavaScript(source, completionHandler: nil)
+                if let source = try? String(contentsOfFile: path, encoding: .utf8) {
+                    webView.evaluateJavascriptInDefaultContentWorld(source)
+                    stepResult = KIFTestStepResult.success
+                } else {
+                    stepResult = KIFTestStepResult.failure
+                }
+            } else {
+                stepResult = KIFTestStepResult.failure
             }
-            stepResult = KIFTestStepResult.success
         }
 
         run { _ in return stepResult }

--- a/content-blocker-lib-ios/src/ContentBlocker.swift
+++ b/content-blocker-lib-ios/src/ContentBlocker.swift
@@ -149,7 +149,7 @@ class ContentBlocker {
 
         // Async required here to ensure remove() call is processed.
         DispatchQueue.main.async() { [weak tab] in
-            tab?.currentWebView()?.evaluateJavaScript("window.__firefox__.NoImageMode.setEnabled(\(enabled))")
+            tab?.currentWebView()?.evaluateJavascriptInDefaultContentWorld("window.__firefox__.NoImageMode.setEnabled(\(enabled))")
         }
     }
 }


### PR DESCRIPTION
This is a copy of a previous [Pull Request](https://github.com/mozilla-mobile/firefox-ios/pull/7194), with the relevant commits cherry picked. This was created due to branching issues with the previous PR. 

Fixes #7118

This PR adds WKWebView extension functions called evaluateJavascriptInDefaultContentWorld which check the iOS version, and if it is 14 or higher, they use the new evaluateJavascript WebKit functions that allow you to evaluate javascript in a sandboxed environment (.defaultClient).

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-867)
