### PR TITLE
FXIOS-874 ⁃ Downloads secure fixes

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2197,8 +2197,13 @@ extension BrowserViewController: ContextMenuHelperDelegate {
             actionSheetController.addAction(bookmarkAction, accessibilityIdentifier: "linkContextMenu.bookmarkLink")
 
             let downloadAction = UIAlertAction(title: Strings.ContextMenuDownloadLink, style: .default) { _ in
-                self.pendingDownloadWebView = currentTab.webView
-                DownloadContentScript.requestDownload(url: url, tab: currentTab)
+                // This checks if download is a blob, if yes, begin blob download process
+                if !DownloadContentScript.requestBlobDownload(url: url, tab: currentTab) {
+                    //if not a blob, set pendingDownloadWebView and load the request in the webview, which will trigger the WKWebView navigationResponse delegate function and eventually downloadHelper.open()
+                    self.pendingDownloadWebView = currentTab.webView
+                    let request = URLRequest(url: url)
+                    currentTab.webView?.load(request)
+                }
             }
             actionSheetController.addAction(downloadAction, accessibilityIdentifier: "linkContextMenu.download")
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -171,8 +171,13 @@ extension BrowserViewController: WKUIDelegate {
             })
 
             actions.append(UIAction(title: Strings.ContextMenuDownloadLink, image: UIImage.templateImageNamed("menu-panel-Downloads"), identifier: UIAction.Identifier("linkContextMenu.download")) {_ in
-                self.pendingDownloadWebView = currentTab.webView
-                DownloadContentScript.requestDownload(url: url, tab: currentTab)
+                // This checks if download is a blob, if yes, begin blob download process
+                if !DownloadContentScript.requestBlobDownload(url: url, tab: currentTab) {
+                    //if not a blob, set pendingDownloadWebView and load the request in the webview, which will trigger the WKWebView navigationResponse delegate function and eventually downloadHelper.open()
+                    self.pendingDownloadWebView = currentTab.webView
+                    let request = URLRequest(url: url)
+                    currentTab.webView?.load(request)
+                }
             })
 
             actions.append(UIAction(title: Strings.ContextMenuCopyLink, image: UIImage.templateImageNamed("menu-Copy-Link"), identifier: UIAction.Identifier("linkContextMenu.copyLink")) { _ in

--- a/Client/Frontend/Browser/DownloadContentScript.swift
+++ b/Client/Frontend/Browser/DownloadContentScript.swift
@@ -25,11 +25,21 @@ class DownloadContentScript: TabContentScript {
         return "downloadManager"
     }
 
-    static func requestDownload(url: URL, tab: Tab) {
+    /// This function handles blob downloads
+    ///  - Checks if the url has a blob url scheme, returns false early if not.
+    ///  - If it is a blob, this function calls javascript (DownloadHelper.js) to start handling the download of the blob.
+    /// - Parameters:
+    ///     - url: URL of item to be downloaded
+    ///     - tab: Tab item is being downloaded from
+    static func requestBlobDownload(url: URL, tab: Tab) -> Bool {
         let safeUrl = url.absoluteString.replacingOccurrences(of: "'", with: "%27")
-        blobUrlForDownload = url.scheme == "blob" ? URL(string: safeUrl) : nil
+        guard url.scheme == "blob" else {
+            return false
+        }
+        blobUrlForDownload = URL(string: safeUrl)
         tab.webView?.evaluateJavaScript("window.__firefox__.download('\(safeUrl)', '\(UserScriptManager.appIdToken)')")
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .downloadLinkButton)
+        return true
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {

--- a/Client/Frontend/Browser/DownloadQueue.swift
+++ b/Client/Frontend/Browser/DownloadQueue.swift
@@ -74,9 +74,14 @@ class HTTPDownload: Download {
         return string.components(separatedBy: allowed.inverted).joined()
      }
 
-    init(preflightResponse: URLResponse, request: URLRequest) {
+    init?(preflightResponse: URLResponse, request: URLRequest) {
         self.preflightResponse = preflightResponse
         self.request = request
+        
+        // Verify scheme is a secure http or https scheme before moving forward with HTTPDownload initialization
+        guard let scheme = request.url?.scheme, (scheme == "http" || scheme == "https") else {
+            return nil
+        }
 
         super.init()
 

--- a/Client/Frontend/Browser/OpenInHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper.swift
@@ -92,7 +92,9 @@ class DownloadHelper: NSObject, OpenInHelper {
             return
         }
 
-        let download = HTTPDownload(preflightResponse: preflightResponse, request: request)
+        guard let download = HTTPDownload(preflightResponse: preflightResponse, request: request) else {
+            return
+        }
 
         let expectedSize = download.totalBytesExpected != nil ? ByteCountFormatter.string(fromByteCount: download.totalBytesExpected!, countStyle: .file) : nil
 


### PR DESCRIPTION
Fixes #7059 

- Be more explicit about when `evaluateJavascript` is used for downloads and change `requestDownload` function to `requestBlobDownload`. 
- Adds more protection to only download items with `http` or `https` schemes if download url is not a blob scheme.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-874)
