### PR TITLE
FXIOS-899 ⁃ Fix: siri settings should not be wrapped in iOS14 block

### DIFF
--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -56,9 +56,7 @@ class AppSettingsTableViewController: SettingsTableViewController {
             generalSettings.insert(DefaultBrowserSetting(settings: self), at: 4)
         }
 
-        if #available(iOS 14.0, *) {
-            generalSettings.insert(SiriPageSetting(settings: self), at: 5)
-        }
+        generalSettings.insert(SiriPageSetting(settings: self), at: 5)
 
         let accountChinaSyncSetting: [Setting]
         if !AppInfo.isChinaEdition {

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -56,7 +56,9 @@ class AppSettingsTableViewController: SettingsTableViewController {
             generalSettings.insert(DefaultBrowserSetting(settings: self), at: 4)
         }
 
-        generalSettings.insert(SiriPageSetting(settings: self), at: 5)
+        if #available(iOS 12.0, *) {
+            generalSettings.insert(SiriPageSetting(settings: self), at: 5)
+        }
 
         let accountChinaSyncSetting: [Setting]
         if !AppInfo.isChinaEdition {


### PR DESCRIPTION


┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-899)
