### PR TITLE
FXIOS-910 ⁃ No Issue - Try fix for BR certs problems with tests

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -6364,7 +6364,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = XCUITests/Info.plist;
-				PROVISIONING_PROFILE_SPECIFIER = FirefoxXCUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = XCUITests;
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/XCUITests/XCUITests-Bridging-Header.h";
 				TEST_TARGET_NAME = Client;
 			};
@@ -6374,7 +6375,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = XCUITests/Info.plist;
-				PROVISIONING_PROFILE_SPECIFIER = FirefoxXCUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = XCUITests;
 				TEST_TARGET_NAME = Client;
 			};
 			name = Firefox;
@@ -6383,7 +6385,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = XCUITests/Info.plist;
-				PROVISIONING_PROFILE_SPECIFIER = FirefoxXCUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = XCUITests;
 				TEST_TARGET_NAME = Client;
 			};
 			name = FirefoxBeta;
@@ -6859,7 +6862,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = XCUITests/Info.plist;
-				PROVISIONING_PROFILE_SPECIFIER = FirefoxXCUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = XCUITests;
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/XCUITests/XCUITests-Bridging-Header.h";
 				TEST_TARGET_NAME = Client;
 			};

--- a/XCUITests/Info.plist
+++ b/XCUITests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.mozilla.FirefoxXCUITests</string>
+	<string>org.mozilla.ios.XCUITests</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Trying to apply previous fix as in https://github.com/mozilla-mobile/firefox-ios/pull/5840

Issue maybe related to the way the project has changed to use xcconfigs  https://github.com/mozilla-mobile/firefox-ios/blob/main/Client/Configuration/Common.xcconfig

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-910)
