### PR TITLE
FXIOS-938 ⁃ #7016 Adds create account label to the FxA pairing screen

### DIFF
--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -109,6 +109,8 @@ class FirefoxAccountSignInViewController: UIViewController {
         
         return label
     }()
+    
+    lazy var scrollView = UIScrollView()
             
     private let profile: Profile
     
@@ -166,17 +168,23 @@ class FirefoxAccountSignInViewController: UIViewController {
     // MARK: Subview Layout Functions
     
     func addSubviews() {
-        view.addSubview(qrSignInLabel)
-        view.addSubview(pairImageView)
-        view.addSubview(instructionsLabel)
-        view.addSubview(scanButton)
-        view.addSubview(emailButton)
-        view.addSubview(createAccountButton)
+        scrollView.addSubview(qrSignInLabel)
+        scrollView.addSubview(pairImageView)
+        scrollView.addSubview(instructionsLabel)
+        scrollView.addSubview(scanButton)
+        scrollView.addSubview(emailButton)
+        scrollView.addSubview(createAccountButton)
+        
+        view.addSubview(scrollView)
     }
     
     func addViewConstraints() {
+        scrollView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+
         qrSignInLabel.snp.makeConstraints { make in
-            make.top.equalTo(view.snp_topMargin).offset(50)
+            make.top.equalTo(scrollView.snp_topMargin).offset(50)
             make.centerX.equalToSuperview()
             make.width.equalToSuperview()
         }
@@ -207,6 +215,7 @@ class FirefoxAccountSignInViewController: UIViewController {
             make.top.equalTo(emailButton.snp.bottomMargin).offset(40)
             make.centerX.equalToSuperview()
             make.width.equalTo(emailButton.snp.width).multipliedBy(0.8)
+            make.bottom.equalTo(scrollView.snp.bottom).offset(-20)
         }
     }
     

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -90,10 +90,13 @@ class FirefoxAccountSignInViewController: UIViewController {
     
     lazy var createAccountButton: UILabel = {
        let label = UILabel()
-        let text = NSMutableAttributedString(string: "No Account? ")
-        let createOne = NSAttributedString(string: "Create one", attributes: [.foregroundColor: UIColor.Photon.Blue50])
-        let rest = NSAttributedString(string: " to sync Firefox between devices.")
+        let space = NSAttributedString(string: " ")
+        let text = NSMutableAttributedString(string: Strings.FxASignin_CreateAccountPt1)
+        let createOne = NSAttributedString(string: Strings.FxASignin_CreateAccountPt2, attributes: [.foregroundColor: UIColor.Photon.Blue50])
+        let rest = NSAttributedString(string: Strings.FxASignin_CreateAccountPt3)
+        text.append(space)
         text.append(createOne)
+        text.append(space)
         text.append(rest)
 
         label.textColor = UIColor.Photon.Grey80

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -98,6 +98,11 @@ class FirefoxAccountSignInViewController: UIViewController {
         text.append(createOne)
         text.append(space)
         text.append(rest)
+        
+        let font = DynamicFontHelper().DefaultSmallFontBold
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 4
+        text.addAttributes([.paragraphStyle: paragraphStyle], range: NSMakeRange(0, text.length))
 
         label.textColor = UIColor.Photon.Grey80
         label.attributedText = text
@@ -105,7 +110,6 @@ class FirefoxAccountSignInViewController: UIViewController {
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
         label.font = DynamicFontHelper().DefaultSmallFontBold
-        
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(createAccountTapped))
         label.addGestureRecognizer(tapGesture)
         label.isUserInteractionEnabled = true

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -87,6 +87,28 @@ class FirefoxAccountSignInViewController: UIViewController {
         button.titleLabel?.font = DynamicFontHelper().MediumSizeBoldFontAS
         return button
     }()
+    
+    lazy var createAccountButton: UILabel = {
+       let label = UILabel()
+        let text = NSMutableAttributedString(string: "No Account? ")
+        let createOne = NSAttributedString(string: "Create one", attributes: [.foregroundColor: UIColor.Photon.Blue50])
+        let rest = NSAttributedString(string: " to sync Firefox between devices.")
+        text.append(createOne)
+        text.append(rest)
+
+        label.textColor = UIColor.Photon.Grey80
+        label.attributedText = text
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
+        label.font = DynamicFontHelper().DefaultSmallFontBold
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(createAccountTapped))
+        label.addGestureRecognizer(tapGesture)
+        label.isUserInteractionEnabled = true
+        
+        return label
+    }()
             
     private let profile: Profile
     
@@ -149,6 +171,7 @@ class FirefoxAccountSignInViewController: UIViewController {
         view.addSubview(instructionsLabel)
         view.addSubview(scanButton)
         view.addSubview(emailButton)
+        view.addSubview(createAccountButton)
     }
     
     func addViewConstraints() {
@@ -180,6 +203,11 @@ class FirefoxAccountSignInViewController: UIViewController {
             make.width.equalTo(327)
             make.height.equalTo(44)
         }
+        createAccountButton.snp.makeConstraints { make in
+            make.top.equalTo(emailButton.snp.bottomMargin).offset(40)
+            make.centerX.equalToSuperview()
+            make.width.equalTo(emailButton.snp.width).multipliedBy(0.8)
+        }
     }
     
     func handleDarkMode() {
@@ -207,6 +235,12 @@ class FirefoxAccountSignInViewController: UIViewController {
             self?.dismissVC()
         }
         TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .qrPairing, object: telemetryObject, extras: ["flow_type": "email"])
+        navigationController?.pushViewController(fxaWebVC, animated: true)
+    }
+    
+    @objc func createAccountTapped(_ sender: UITapGestureRecognizer) {
+        let fxaWebVC = FxAWebViewController(pageType: .emailLoginFlow, profile: profile, dismissalStyle: fxaDismissStyle, deepLinkParams: deepLinkParams)
+        TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .qrPairing, object: telemetryObject, extras: ["flow_type": "create"])
         navigationController?.pushViewController(fxaWebVC, animated: true)
     }
 }


### PR DESCRIPTION
Adds a create account label/button to the sign in page.

<img width="637" alt="image" src="https://user-images.githubusercontent.com/1250545/93829971-bfca9100-fc23-11ea-9d10-603d53da2b6b.png">


I have a couple of questions!

1. I had to wrap this in a UIScrollView for it to work in landscape. Is this preferred or should we compress the items to make them fit.

2. What is this best way to compose a multi part string like this for localization?

3. I'm guessing we wanted to differentiate this tap to the other ones with telemetry.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-938)
