### PR TITLE
FXIOS-952 ⁃ Fix #7360: Increase margin around default browser card close button

### DIFF
--- a/Client/Frontend/Home/DefaultBrowserCard.swift
+++ b/Client/Frontend/Home/DefaultBrowserCard.swift
@@ -104,7 +104,7 @@ class DefaultBrowserCard: UIView {
             make.left.equalTo(image.snp.right)
             make.width.lessThanOrEqualTo(223)
             make.bottom.equalTo(settingsButton.snp.top).offset(-16)
-            make.top.equalToSuperview().offset(20)
+            make.top.equalToSuperview().offset(30)
         }
         settingsButton.snp.makeConstraints { make in
             make.top.equalTo(topView.snp.bottom).offset(16)


### PR DESCRIPTION
@brampitoyo @betsymi 

I couldn't get my simulator to translate so I used a substitute string :)

![Simulator Screen Shot - iPhone 11 Pro - 2020-09-23 at 11 56 15](https://user-images.githubusercontent.com/11432165/94038181-24a4f900-fd94-11ea-80ba-bd2cbc07e1fb.png)

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-952)
