### PR TITLE
FXIOS-955 ⁃ Fix #7285: Add UI test for switching default browser

### DIFF
--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -108,6 +108,8 @@ let allHomePanels = [
     LibraryPanel_SyncedTabs
 ]
 
+let iOS_Settings = XCUIApplication(bundleIdentifier: "com.apple.Preferences")
+
 class Action {
     static let LoadURL = "LoadURL"
     static let LoadURLByTyping = "LoadURLByTyping"

--- a/XCUITests/SettingsTest.swift
+++ b/XCUITests/SettingsTest.swift
@@ -28,4 +28,33 @@ class SettingsTest: BaseTestCase {
         navigator.performAction(Action.OpenSiriFromSettings)
         waitForExistence(app.buttons["Add to Siri"], timeout: 5)
     }
+
+    func testDefaultBrowser() {
+        // A default browser card should be available on the home screen
+        if #available(iOS 14, *) {
+            waitForExistence(app.staticTexts["Set links from websites, emails, and Messages to open automatically in Firefox."], timeout: 5)
+            waitForExistence(app.buttons["Go to Settings"], timeout: 5)
+            app.buttons["Go to Settings"].tap()
+
+            // Tap on "Default Browser App" and set the browser as a default (Safari is listed first)
+            waitForExistence(iOS_Settings.tables.buttons.element(boundBy: 1), timeout: 5)
+            iOS_Settings.tables.buttons.element(boundBy: 1).tap()
+            iOS_Settings.tables.staticTexts.element(boundBy: 1).tap()
+
+            // Return to the browser
+            app.activate()
+
+            // Tap on "Set as Default Browser" from the in-browser settings
+            navigator.goto(SettingsScreen)
+            let settingsTableView = app.tables["AppSettingsTableViewController.tableView"]
+            let defaultBrowserButton = settingsTableView.cells["Set as Default Browser"]
+            defaultBrowserButton.tap()
+
+            // Verify the browser is selected as a default in iOS settings
+            waitForExistence(iOS_Settings.tables.buttons.element(boundBy: 1), timeout: 5)
+            iOS_Settings.tables.buttons.element(boundBy: 1).tap()
+            waitForExistence(iOS_Settings.tables.cells.buttons["checkmark"])
+            XCTAssertFalse(iOS_Settings.tables.cells.buttons["checkmark"].isEnabled)
+        }
+    }
 }


### PR DESCRIPTION
https://testrail.stage.mozaws.net/index.php?/cases/view/1059934

Fixes #7285 - tests in-app UI flow for setting a default browser, does not test actual iOS default browser through other installed simulator applications

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-955)
