### PR TITLE
FXIOS-959 ⁃ For #7385 - Moves all user scripts to use defaultContentWorld

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -578,17 +578,6 @@ class Tab: NSObject {
         return sequence(first: parent) { $0?.parent }.contains { $0 == ancestor }
     }
 
-    func injectUserScriptWith(fileName: String, type: String = "js", injectionTime: WKUserScriptInjectionTime = .atDocumentEnd, mainFrameOnly: Bool = true) {
-        guard let webView = self.webView else {
-            return
-        }
-        if let path = Bundle.main.path(forResource: fileName, ofType: type),
-            let source = try? String(contentsOfFile: path) {
-            let userScript = WKUserScript(source: source, injectionTime: injectionTime, forMainFrameOnly: mainFrameOnly)
-            webView.configuration.userContentController.addUserScript(userScript)
-        }
-    }
-
     func observeURLChanges(delegate: URLChangeDelegate) {
         self.urlDidChangeDelegate = delegate
     }
@@ -658,7 +647,7 @@ private class TabContentScriptManager: NSObject, WKScriptMessageHandler {
         // If this helper handles script messages, then get the handler name and register it. The Browser
         // receives all messages and then dispatches them to the right TabHelper.
         if let scriptMessageHandlerName = helper.scriptMessageHandlerName() {
-            tab.webView?.configuration.userContentController.add(self, name: scriptMessageHandlerName)
+            tab.webView?.configuration.userContentController.addInDefaultContentWorld(scriptMessageHandler: self, name: scriptMessageHandlerName)
         }
     }
 

--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -31,7 +31,7 @@ class UserScriptManager {
             if let path = Bundle.main.path(forResource: name, ofType: "js"),
                 let source = try? NSString(contentsOfFile: path, encoding: String.Encoding.utf8.rawValue) as String {
                 let wrappedSource = "(function() { const APP_ID_TOKEN = '\(UserScriptManager.appIdToken)'; \(source) })()"
-                let userScript = WKUserScript(source: wrappedSource, injectionTime: injectionTime, forMainFrameOnly: mainFrameOnly)
+                let userScript = WKUserScript.createInDefaultContentWorld(source: wrappedSource, injectionTime: injectionTime, forMainFrameOnly: mainFrameOnly)
                 compiledUserScripts[name] = userScript
             }
         }

--- a/Shared/Extensions/WKWebViewExtensions.swift
+++ b/Shared/Extensions/WKWebViewExtensions.swift
@@ -5,6 +5,10 @@
 import Foundation
 import WebKit
 
+// Temporary flag to test the new sandboxed javascript environment
+// in iOS 14
+private let USE_NEW_SANDBOX_APIS = false
+
 extension WKWebView {
     
     /// This calls different WebKit evaluateJavaScript functions depending on iOS version
@@ -14,7 +18,7 @@ extension WKWebView {
     ///     - javascript: String representing javascript to be evaluated
     public func evaluateJavascriptInDefaultContentWorld(_ javascript: String) {
         #if compiler(>=5.3)
-            if #available(iOS 14.0, *) {
+            if #available(iOS 14.0, *), USE_NEW_SANDBOX_APIS {
                 self.evaluateJavaScript(javascript, in: nil, in: .defaultClient, completionHandler: { _ in })
             } else {
                 self.evaluateJavaScript(javascript)
@@ -32,7 +36,7 @@ extension WKWebView {
     ///     - completion: Tuple containing optional data and an optional error
     public func evaluateJavascriptInDefaultContentWorld(_ javascript: String,_ completion: @escaping ((Any?, Error?) -> Void)) {
         #if compiler(>=5.3)
-            if #available(iOS 14.0, *) {
+            if #available(iOS 14.0, *), USE_NEW_SANDBOX_APIS {
                 self.evaluateJavaScript(javascript, in: nil, in: .defaultClient) { result in
                     switch result {
                     case .success(let value):
@@ -51,5 +55,25 @@ extension WKWebView {
                 completion(data, error)
             }
         #endif
+    }
+}
+
+extension WKUserContentController {
+    public func addInDefaultContentWorld(scriptMessageHandler: WKScriptMessageHandler, name: String) {
+        if #available(iOS 14.0, *), USE_NEW_SANDBOX_APIS {
+            add(scriptMessageHandler, contentWorld: .defaultClient, name: name)
+        } else {
+            add(scriptMessageHandler, name: name)
+        }
+    }
+}
+
+extension WKUserScript {
+    public class func createInDefaultContentWorld(source: String, injectionTime: WKUserScriptInjectionTime, forMainFrameOnly: Bool) -> WKUserScript {
+        if #available(iOS 14.0, *), USE_NEW_SANDBOX_APIS {
+            return WKUserScript(source: source, injectionTime: injectionTime, forMainFrameOnly: forMainFrameOnly, in: .defaultClient)
+        } else {
+            return WKUserScript(source: source, injectionTime: injectionTime, forMainFrameOnly: forMainFrameOnly)
+        }
     }
 }


### PR DESCRIPTION
- Moves all calls to the user scripts to use convenience methods that call the new sandbox APIs in iOS 14
- Adds additional flag enable/disable using the new sandbox APIs

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-959)
