### PR TITLE
FXIOS-985 ⁃ Issue with Search in Firefox Widget - does not focus the url bar

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1170,10 +1170,6 @@ class BrowserViewController: UIViewController {
                 webView.evaluateJavascriptInDefaultContentWorld("\(ReaderModeNamespace).checkReadability()")
             }
 
-            if urlBar.inOverlayMode, InternalURL.isValid(url: url), url.path.starts(with: "/\(AboutHomeHandler.path)") {
-                urlBar.leaveOverlayMode()
-            }
-
             TabEvent.post(.didChangeURL(url), for: tab)
         }
         


### PR DESCRIPTION
urlbar was becoming unfocused because of `urlBar.leaveOverlayMode()`. Going back in [git history](https://bugzilla.mozilla.org/show_bug.cgi?id=1524506), this was added due to a bug where setting History as a new tab was an option. This option is gone now so it should be safe to remove this check. I verified with blank page as new tab and didn't find any issues.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-985)
