### PR TITLE
FXIOS-1006 ⁃ Fix 5033: Firefox addressbar doesn't respect Larger Text accessibility setting

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -796,6 +796,7 @@
 		EF5742E3AE9ACDD5BBE7AF95 /* Intro.strings in Resources */ = {isa = PBXBuildFile; fileRef = 99C54F4F8354A39A0F06511F /* Intro.strings */; };
 		F35B8D2B1D6380EA008E3D61 /* SessionRestore.html in Resources */ = {isa = PBXBuildFile; fileRef = F35B8D2A1D6380EA008E3D61 /* SessionRestore.html */; };
 		F35B8D2D1D6383E9008E3D61 /* SessionRestoreHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F35B8D2C1D6383E9008E3D61 /* SessionRestoreHelper.swift */; };
+		F61D45742539016300F19A33 /* AdjustableFontSizeProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A7936B252D2CD900349C0B /* AdjustableFontSizeProtocol.swift */; };
 		F6F942FEAEECEDA197C48DCE /* HistoryPanel.strings in Resources */ = {isa = PBXBuildFile; fileRef = 67AF4B8392ADBAA41F1B3AD0 /* HistoryPanel.strings */; };
 		F84B21DA1A090F8100AAB793 /* ClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84B21D91A090F8100AAB793 /* ClientTests.swift */; };
 		F84B22041A0910F600AAB793 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84B21E51A0910F600AAB793 /* AppDelegate.swift */; };
@@ -3870,6 +3871,7 @@
 		F5E84699B672AEC4CE4D5871 /* af */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/FindInPage.strings; sourceTree = "<group>"; };
 		F5F94E989BFE5C0AAD2FFCFD /* bo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bo; path = bo.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		F63D438AB501007BE110524A /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
+		F6A7936B252D2CD900349C0B /* AdjustableFontSizeProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustableFontSizeProtocol.swift; sourceTree = "<group>"; };
 		F6AA4920A08DE9E2F0BC44C2 /* br */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = br; path = br.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		F6B547FFB6722A9411C5F91F /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		F6EA434FA5D8305063BC630B /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -5334,6 +5336,7 @@
 		E4E0BB141AFBC9E4008D6260 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				F6A7936B252D2CD900349C0B /* AdjustableFontSizeProtocol.swift */,
 				43B137F123A181A200CB7FA0 /* NSUserDefaultsPrefs.swift */,
 				C8CFF4E322F9FDB5002CC6BD /* effective_tld_names.swift */,
 				D35210E01CB2F16600FC5DCB /* Strings.swift */,
@@ -7154,6 +7157,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F61D45742539016300F19A33 /* AdjustableFontSizeProtocol.swift in Sources */,
 				E65075991E37F7AB006961AC /* Cancellable.swift in Sources */,
 				E65075BE1E37F7AB006961AC /* TimeConstants.swift in Sources */,
 				E65075B21E37F7AB006961AC /* Functions.swift in Sources */,

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -274,6 +274,8 @@ class TabLocationView: UIView {
         menuBadge.add(toParent: contentView)
         menuBadge.layout(onButton: pageOptionsButton)
         menuBadge.show(false)
+        
+        adjustFonts()
     }
 
     required init(coder: NSCoder) {
@@ -281,8 +283,10 @@ class TabLocationView: UIView {
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        
         if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            urlTextField.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.body)
+            adjustFonts()
         }
     }
 
@@ -452,6 +456,12 @@ extension TabLocationView: TabEventHandler {
 
     func tabDidToggleDesktopMode(_ tab: Tab) {
         menuBadge.show(tab.changedUserAgent)
+    }
+}
+
+extension TabLocationView: AdjustableFontSizeProtocol {
+    func resize(size: CGFloat) {
+        urlTextField.font = urlTextField.font?.withSize(size)
     }
 }
 

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -105,7 +105,6 @@ class TabLocationView: UIView {
         urlTextField.attributedPlaceholder = self.placeholder
         urlTextField.accessibilityIdentifier = "url"
         urlTextField.accessibilityActionsSource = self
-        urlTextField.font = UIConstants.DefaultChromeFont
         urlTextField.backgroundColor = .clear
         urlTextField.accessibilityLabel = "Address Bar"
 
@@ -279,6 +278,12 @@ class TabLocationView: UIView {
 
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
+            urlTextField.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.body)
+        }
     }
 
     private lazy var _accessibilityElements = [urlTextField, readerModeButton, reloadButton, pageOptionsButton, trackingProtectionButton]

--- a/Client/Frontend/Browser/TabTrayControllerV1.swift
+++ b/Client/Frontend/Browser/TabTrayControllerV1.swift
@@ -108,7 +108,7 @@ class TabTrayControllerV1: UIViewController {
     private var placeholder: NSAttributedString {
         return NSAttributedString(string: Strings.TabSearchPlaceholderText, attributes:
                                     [NSAttributedString.Key.foregroundColor: UIColor.theme.tabTray.tabTitleText.withAlphaComponent(0.7),
-             NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: UIFont.TextStyle.body)])
+                                     NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: UIFont.TextStyle.body)])
     }
 
     init(tabManager: TabManager, profile: Profile, tabTrayDelegate: TabTrayDelegate? = nil) {

--- a/Client/Frontend/Browser/TabTrayControllerV1.swift
+++ b/Client/Frontend/Browser/TabTrayControllerV1.swift
@@ -64,7 +64,6 @@ class TabTrayControllerV1: UIViewController {
         searchBar.leftView = UIImageView(image: UIImage(named: "quickSearch"))
         searchBar.leftViewMode = .unlessEditing
         searchBar.textColor = UIColor.theme.tabTray.tabTitleText
-        searchBar.attributedPlaceholder = NSAttributedString(string: Strings.TabSearchPlaceholderText, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tabTray.tabTitleText.withAlphaComponent(0.7)])
         searchBar.clearButtonMode = .never
         searchBar.delegate = self
         searchBar.addTarget(self, action: #selector(textDidChange), for: .editingChanged)
@@ -104,6 +103,12 @@ class TabTrayControllerV1: UIViewController {
 
     var numberOfColumns: Int {
         return tabLayoutDelegate.numberOfColumns
+    }
+    
+    private var placeholder: NSAttributedString {
+        return NSAttributedString(string: Strings.TabSearchPlaceholderText, attributes:
+                                    [NSAttributedString.Key.foregroundColor: UIColor.theme.tabTray.tabTitleText.withAlphaComponent(0.7),
+             NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: UIFont.TextStyle.body)])
     }
 
     init(tabManager: TabManager, profile: Profile, tabTrayDelegate: TabTrayDelegate? = nil) {
@@ -202,6 +207,8 @@ class TabTrayControllerV1: UIViewController {
             searchBar.applyUIMode(isPrivate: true)
         }
 
+        setupFonts()
+        
         if traitCollection.forceTouchCapability == .available {
             registerForPreviewing(with: self, sourceView: view)
         }
@@ -217,6 +224,7 @@ class TabTrayControllerV1: UIViewController {
         super.traitCollectionDidChange(previousTraitCollection)
         // Update the trait collection we reference in our layout delegate
         tabLayoutDelegate.traitCollection = traitCollection
+        setupFonts()
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -266,6 +274,11 @@ class TabTrayControllerV1: UIViewController {
         searchBar.snp.makeConstraints { make in
             make.edges.equalTo(roundedSearchBarHolder).inset(UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10))
         }
+    }
+    
+    private func setupFonts() {
+        searchBar.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.body)
+        searchBar.attributedPlaceholder = self.placeholder
     }
 
     @objc func didTogglePrivateMode() {

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -362,7 +362,6 @@ class URLBarView: UIView {
         locationTextField.returnKeyType = .go
         locationTextField.clearButtonMode = .whileEditing
         locationTextField.textAlignment = .left
-        locationTextField.font = UIConstants.DefaultChromeFont
         locationTextField.accessibilityIdentifier = "address"
         locationTextField.accessibilityLabel = NSLocalizedString("Address and Search", comment: "Accessibility label for address and search field, both words (Address, Search) are therefore nouns.")
         locationTextField.attributedPlaceholder = self.locationView.placeholder
@@ -379,6 +378,10 @@ class URLBarView: UIView {
         locationTextField.backgroundColor = UIColor.theme.textField.backgroundInOverlay
     }
 
+    private func setupFonts() {
+        locationTextField?.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.body)
+    }
+    
     override func becomeFirstResponder() -> Bool {
         return self.locationTextField?.becomeFirstResponder() ?? false
     }
@@ -512,6 +515,8 @@ class URLBarView: UIView {
     }
 
     func transitionToOverlay(_ didCancel: Bool = false) {
+        setupFonts()
+        
         locationView.contentView.alpha = inOverlayMode ? 0 : 1
         cancelButton.alpha = inOverlayMode ? 1 : 0
         showQRScannerButton.alpha = inOverlayMode ? 1 : 0
@@ -593,6 +598,12 @@ class URLBarView: UIView {
 
     @objc func tappedScrollToTopArea() {
         delegate?.urlBarDidPressScrollToTop(self)
+    }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
+            setupFonts()
+        }
     }
 }
 

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -377,10 +377,6 @@ class URLBarView: UIView {
         locationTextField.applyTheme()
         locationTextField.backgroundColor = UIColor.theme.textField.backgroundInOverlay
     }
-
-    private func setupFonts() {
-        locationTextField?.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.body)
-    }
     
     override func becomeFirstResponder() -> Bool {
         return self.locationTextField?.becomeFirstResponder() ?? false
@@ -515,7 +511,7 @@ class URLBarView: UIView {
     }
 
     func transitionToOverlay(_ didCancel: Bool = false) {
-        setupFonts()
+        adjustFonts()
         
         locationView.contentView.alpha = inOverlayMode ? 0 : 1
         cancelButton.alpha = inOverlayMode ? 1 : 0
@@ -601,8 +597,10 @@ class URLBarView: UIView {
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        
         if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            setupFonts()
+            adjustFonts()
         }
     }
 }
@@ -821,6 +819,12 @@ extension URLBarView: PrivateModeUI {
         ToolbarTextField.applyUIMode(isPrivate: isPrivate)
 
         applyTheme()
+    }
+}
+
+extension URLBarView: AdjustableFontSizeProtocol {
+    func resize(size: CGFloat) {
+        locationTextField?.font = locationTextField?.font?.withSize(size)
     }
 }
 

--- a/Extensions/Today/ImageButtonWithLabel.swift
+++ b/Extensions/Today/ImageButtonWithLabel.swift
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import UIKit
+import Shared
 
 class ImageButtonWithLabel: UIView {
     lazy var button = UIButton()
@@ -37,9 +38,25 @@ class ImageButtonWithLabel: UIView {
         label.numberOfLines = 0
         label.textAlignment = .center
         label.lineBreakMode = .byWordWrapping
+        
+        adjustFonts()
     }
 
     func addTarget(_ target: AnyObject?, action: Selector, forControlEvents events: UIControl.Event) {
         button.addTarget(target, action: action, for: events)
+    }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        
+        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
+            adjustFonts()
+        }
+    }
+}
+
+extension ImageButtonWithLabel: AdjustableFontSizeProtocol {
+    func resize(size: CGFloat) {
+        label.font = label.font.withSize(size)
     }
 }

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -26,7 +26,6 @@ class TodayViewController: UIViewController, NCWidgetProviding, TodayWidgetAppea
         let label = imageButton.label
         label.textColor = TodayUX.labelColor
         label.tintColor = TodayUX.labelColor
-        label.font = UIFont.preferredFont(forTextStyle: .body)
         label.adjustsFontForContentSizeCategory = true
         return imageButton
     }
@@ -71,7 +70,6 @@ class TodayViewController: UIViewController, NCWidgetProviding, TodayWidgetAppea
         let widgetView: UIView!
         self.extensionContext?.widgetLargestAvailableDisplayMode = .compact
         viewModel.setViewDelegate(todayViewDelegate: self)
-        NotificationCenter.default.addObserver(self, selector: #selector(preferredContentSizeChanged(_:)), name: UIContentSizeCategory.didChangeNotification, object: nil)
         let effectView: UIVisualEffectView
 
         if #available(iOS 13, *) {
@@ -102,41 +100,11 @@ class TodayViewController: UIViewController, NCWidgetProviding, TodayWidgetAppea
         } else {
             buttonStackView.removeArrangedSubview(openCopiedLinkButton)
         }
-        adjustFonts()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         let edge = size.width * TodayUX.buttonsHorizontalMarginPercentage
         buttonStackView.layoutMargins = UIEdgeInsets(top: 0, left: edge, bottom: 0, right: edge)
-    }
-
-    @objc func preferredContentSizeChanged(_ notification: Notification) {
-        adjustFonts()
-    }
-
-    func adjustFonts() {
-        let size = traitCollection.preferredContentSizeCategory
-        switch size {
-        case let size where size >= .accessibilityMedium:
-            resize(size: 25)
-        case let size where size <= .extraExtraExtraLarge && size > .extraLarge:
-            resize(size: 15)
-        case let size where size >= .large && size <= .extraLarge:
-            resize(size: 14)
-        case let size where size == .medium:
-            resize(size: 12)
-        case let size where size >= .extraSmall && size <= .small:
-            resize(size: 8)
-        default:
-            resize(size: UIFont.systemFontSize)
-        }
-    }
-
-    func resize(size: CGFloat) {
-        newTabButton.label.font = newTabButton.label.font.withSize(size)
-        newPrivateTabButton.label.font = newPrivateTabButton.label.font.withSize(size)
-        openCopiedLinkButton.label.font = openCopiedLinkButton.label.font.withSize(size)
-        closePrivateTabsButton.label.font = closePrivateTabsButton.label.font.withSize(size)
     }
 
     func widgetMarginInsets(forProposedMarginInsets defaultMarginInsets: UIEdgeInsets) -> UIEdgeInsets {

--- a/Shared/AdjustableFontSizeProtocol.swift
+++ b/Shared/AdjustableFontSizeProtocol.swift
@@ -1,0 +1,34 @@
+//
+//  AdjustableFontSizeProtocol.swift
+//  Client
+//
+//  Created by Mykola Aleshchenko on 07.10.2020.
+//  Copyright © 2020 Mozilla. All rights reserved.
+//
+
+import UIKit
+
+public protocol AdjustableFontSizeProtocol: UIView {
+    func adjustFonts()
+    func resize(size: CGFloat)
+}
+
+public extension AdjustableFontSizeProtocol {
+    func adjustFonts() {
+        let size = traitCollection.preferredContentSizeCategory
+        switch size {
+        case let size where size >= .accessibilityMedium:
+            resize(size: 25)
+        case let size where size <= .extraExtraExtraLarge && size > .extraLarge:
+            resize(size: 15)
+        case let size where size >= .large && size <= .extraLarge:
+            resize(size: 14)
+        case let size where size == .medium:
+            resize(size: 12)
+        case let size where size >= .extraSmall && size <= .small:
+            resize(size: 8)
+        default:
+            resize(size: UIFont.systemFontSize)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5033 

Search bars: https://www.dropbox.com/s/dtbca4ong42ddaa/search_bars.mov?dl=0
Widget: https://www.dropbox.com/s/g640dqs1ohsj5ui/widget.mov?dl=0

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1006)
