### PR TITLE
FXIOS-1012 ⁃ Adds bootstrap checkouts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,8 @@ Client/Assets/MainFrameAtDocumentStart.js
 Client/Assets/MainFrameAtDocumentEnd.js
 Client/Assets/*.js.LICENSE.txt
 *.strings
+
+
+# Checkouts
+firefoxios-l10n
+ios-l10n-scripts


### PR DESCRIPTION
With the updated l10n step added to bootstrap we clone some repos. We could add these to the gitignore to make it easier to work with them

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1012)
