### PR TITLE
FXIOS-1022 ⁃ Restrict usage of UIKey to iOS 13.4+

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2351,13 +2351,21 @@ extension BrowserViewController: ContextMenuHelperDelegate {
     
     //Support for CMD+ Click on link to open in a new tab
      override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
-         guard let key = presses.first?.key, (key.keyCode == .keyboardLeftGUI || key.keyCode == .keyboardRightGUI) else { return } //GUI buttons = CMD buttons on ipad/mac
-         self.isCmdClickForNewTab = true
+         if #available(iOS 13.4, *) {
+             guard let key = presses.first?.key, (key.keyCode == .keyboardLeftGUI || key.keyCode == .keyboardRightGUI) else { return } //GUI buttons = CMD buttons on ipad/mac
+             self.isCmdClickForNewTab = true
+         } else {
+             super.pressesBegan(presses, with: event)
+         }
     }
     
     override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
-        guard let key = presses.first?.key, (key.keyCode == .keyboardLeftGUI || key.keyCode == .keyboardRightGUI) else { return }
-        self.isCmdClickForNewTab = false
+        if #available(iOS 13.4, *) {
+            guard let key = presses.first?.key, (key.keyCode == .keyboardLeftGUI || key.keyCode == .keyboardRightGUI) else { return }
+            self.isCmdClickForNewTab = false
+        } else {
+            super.pressesEnded(presses, with: event)
+        }
     }
 }
 


### PR DESCRIPTION
UIKey was introduced on iOS 13.4

This relates to the issue: Fixes #7461 

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1022)
