### PR TITLE
FXIOS-1031 ⁃ Fix #7470: Add a UI test for Undo Bookmark

### DIFF
--- a/XCUITests/BookmarkingTests.swift
+++ b/XCUITests/BookmarkingTests.swift
@@ -37,6 +37,15 @@ class BookmarkingTests: BaseTestCase {
         }
     }
 
+    private func undoBookmarkRemoval() {
+        navigator.goto(PageOptionsMenu)
+        waitForExistence(app.tables.cells["Remove Bookmark"])
+        app.cells["Remove Bookmark"].tap()
+        navigator.nowAt(BrowserTab)
+        waitForExistence(app.buttons["Undo"], timeout: 3)
+        app.buttons["Undo"].tap()
+    }
+
     private func checkUnbookmarked() {
         navigator.goto(PageOptionsMenu)
         waitForExistence(app.tables.cells["Bookmark This Page"])
@@ -230,6 +239,16 @@ class BookmarkingTests: BaseTestCase {
         waitForExistence(app.tables["Context Menu"])
         app.tables["Context Menu"].cells["action_bookmark_remove"].tap()
         checkItemsInBookmarksList(items: 0)
+    }
+
+    func testUndoDeleteBookmark() {
+        navigator.openURL(path(forTestPage: url_1))
+        navigator.nowAt(BrowserTab)
+        waitForTabsButton()
+        bookmark()
+        checkBookmarked()
+        undoBookmarkRemoval()
+        checkBookmarked()
     }
 
     private func addNewBookmark() {


### PR DESCRIPTION
For: https://testrail.stage.mozaws.net/index.php?/cases/view/845971&group_by=cases:created_on&group_order=desc&group_id=-1

Add's a simple UI test for Undo Bookmark.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1031)
