### PR TITLE
FXIOS-1033 ⁃ Set default browser panel description is cut-off in French

### DIFF
--- a/Client/Frontend/Home/DefaultBrowserCard.swift
+++ b/Client/Frontend/Home/DefaultBrowserCard.swift
@@ -86,12 +86,12 @@ class DefaultBrowserCard: UIView {
         background.snp.makeConstraints { make in
             make.top.left.equalToSuperview().offset(20)
             make.right.bottom.equalToSuperview().offset(-20)
-            make.height.equalTo(210)
+            make.height.greaterThanOrEqualTo(210)
         }
         topView.snp.makeConstraints { make in
             make.top.equalToSuperview()
             make.bottom.equalTo(settingsButton.snp.top)
-            make.height.equalTo(114)
+            make.height.greaterThanOrEqualTo(114)
         }
         image.snp.makeConstraints { make in
             make.left.equalToSuperview().offset(18)


### PR DESCRIPTION
@brampitoyo for UX review:

![Simulator Screen Shot - iPhone 11 - 2020-10-07 at 13 14 07](https://user-images.githubusercontent.com/11432165/95364855-5a230980-089f-11eb-9e43-110c09bf2ea2.png)

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1033)
