### PR TITLE
FXIOS-1041 ⁃ Fix #7469 - Adds a minimumScaleFactor to the title to prevent truncation

### DIFF
--- a/WidgetKit/ImageButtonWithLabel.swift
+++ b/WidgetKit/ImageButtonWithLabel.swift
@@ -72,6 +72,7 @@ struct ImageButtonWithLabel: View {
                         VStack(alignment: .leading){
                                 Text(link.label)
                                     .font(.headline)
+                                    .minimumScaleFactor(0.75)
                                     .layoutPriority(1000)
                         }
                         Spacer()


### PR DESCRIPTION
On smaller iPads with the font scale set to maximum we get some truncation in the widget. Adding a MinimumScaleFactor will try to scale it down to prevent truncation. After some trial and error I found `0.75` was the largest I could do to prevent truncation.
<img width="1320" alt="image" src="https://user-images.githubusercontent.com/1250545/95523393-5d8fc100-0983-11eb-8a8a-6b9315fdfb32.png">

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1041)
