### PR TITLE
FXIOS-1042 ⁃ Follow up 7471 - XCUITest still a few tests needed changes

### DIFF
--- a/XCUITests/AuthenticationTest.swift
+++ b/XCUITests/AuthenticationTest.swift
@@ -134,6 +134,7 @@ class AuthenticationTest: BaseTestCase {
         navigator.performAction(Action.UnlockLoginsSettings)
         waitForExistence(app.tables["Login List"])
         navigator.goto(SettingsScreen)
+        navigator.goto(NewTabScreen)
         // Trying again should display passcode screen since we've set the interval to be immediately.
         navigator.goto(LockedLoginsSettings)
         waitForExistence(app.navigationBars["Enter Passcode"], timeout: 3)

--- a/XCUITests/LibraryTests.swift
+++ b/XCUITests/LibraryTests.swift
@@ -28,9 +28,7 @@ class LibraryTestsIphone: IphoneOnlyTestCase {
     
     func testLibraryShortcutHomePage () {
         if skipPlatform {return}
-        if #available(iOS 14.0, *) {
-            app.buttons["libraryMoreButton"].swipeUp()
-        }
+
         waitForExistence(app.staticTexts["libraryTitle"], timeout: 3)
         waitForExistence(app.buttons["menu Bookmark"])
         waitForExistence(app.buttons["menu panel ReadingList"])

--- a/XCUITests/PocketTests.swift
+++ b/XCUITests/PocketTests.swift
@@ -36,12 +36,8 @@ class PocketTest: BaseTestCase {
     }
 
     func testTapOnMore() {
-        // Tap on More should show Pocket website
-        navigator.goto(NewTabScreen)
-        print(app.debugDescription)
         waitForExistence(app.buttons["More"], timeout: 5)
-        // Workaround to app.buttons["More"].tap() for BB flaky failures tapping on See All button
-        app.buttons.element(boundBy: 3).tap()
+        app.buttons["More"].tap()
         waitUntilPageLoad()
         navigator.nowAt(BrowserTab)
         waitForExistence(app.textFields["url"], timeout: 15)

--- a/XCUITests/SearchTest.swift
+++ b/XCUITests/SearchTest.swift
@@ -42,8 +42,10 @@ class SearchTests: BaseTestCase {
 
         // Disable Search suggestion
         app.buttons["urlBar-cancel"].tap()
-        navigator.nowAt(HomePanelsScreen)
+
         waitForTabsButton()
+        app.buttons["TabToolbar.menuButton"].tap()
+        navigator.nowAt(BrowserTabMenu)
         suggestionsOnOff()
 
         // Suggestions should not be shown
@@ -64,7 +66,9 @@ class SearchTests: BaseTestCase {
         XCTAssertFalse(app.tables["SiteTable"].buttons.firstMatch.exists)
 
         app.buttons["urlBar-cancel"].tap()
-        navigator.nowAt(HomePanelsScreen)
+        waitForTabsButton()
+        app.buttons["TabToolbar.menuButton"].tap()
+        navigator.nowAt(BrowserTabMenu)
 
         // Reset suggestion button, set it to on
         suggestionsOnOff()


### PR DESCRIPTION
To complete the work on issue #7471 there are some changes needed since there are still 5 tests failing when running the general scheme on Bitrise:

https://addons-testing.bitrise.io/builds/33bd16d8c8ef4f4e/testreport/348e42fc-d3b0-44cf-b3b5-41f234762052/testsuite/0/testcases?status=failed

AuthenticationTest.testEnteringLoginsUsingPasscode()
LibraryTestsIphone.testLibraryShortcutHomePage()
PocketTest.testPocketEnabledByDefault()
PocketTest.testTapOnMore()
SearchTests.testPromptPresence()

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1042)
