### PR TITLE
FXIOS-1050 ⁃ FXIOS-956 fix url detection when url contains more than one #

### DIFF
--- a/Client/Frontend/Browser/URIFixup.swift
+++ b/Client/Frontend/Browser/URIFixup.swift
@@ -48,17 +48,12 @@ class URIFixup {
     }
 
     static func punycodedURL(_ string: String) -> URL? {
-        
         var string = string
         if string.filter({ $0 == "#" }).count > 1 {
-            
-            replaceHashMarks(url: &string)
+            string = replaceHashMarks(url: string)
         }
 
-        guard let url = URL(string: string) else {
-            
-            return nil
-        }
+        guard let url = URL(string: string) else { return nil }
 
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         if AppConstants.MOZ_PUNYCODE {
@@ -72,22 +67,9 @@ class URIFixup {
         return url.replacingOccurrences(of: "[", with: "%5B").replacingOccurrences(of: "]", with: "%5D")
     }
 
-    static func replaceHashMarks(url: inout String) {
-        
-        let firstIndex = url.firstIndex(of: "#")!
-        var start = url.index(firstIndex, offsetBy: 1)
-
-        var ranges: [Range<String.Index>] = []
-        while start <= url.endIndex,
-            let range = url.range(of: "#", range: start..<url.endIndex) {
-                
-            ranges.append(range)
-            start = range.upperBound
-        }
-
-        for range in ranges {
-            
-            url.replaceSubrange(range, with:  "%23")
-        }
+    static func replaceHashMarks(url: String) -> String {
+        guard let firstIndex = url.firstIndex(of: "#") else { return String() }
+        let start = url.index(firstIndex, offsetBy: 1)
+        return url.replacingOccurrences(of: "#", with: "%23", range: start..<url.endIndex)
     }
 }

--- a/Client/Frontend/Browser/URIFixup.swift
+++ b/Client/Frontend/Browser/URIFixup.swift
@@ -48,7 +48,19 @@ class URIFixup {
     }
 
     static func punycodedURL(_ string: String) -> URL? {
-        var components = URLComponents(string: string)
+        
+        var string = string
+        if string.filter({ $0 == "#" }).count > 1 {
+            
+            replaceHashMarks(url: &string)
+        }
+
+        guard let url = URL(string: string) else {
+            
+            return nil
+        }
+
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         if AppConstants.MOZ_PUNYCODE {
             let host = components?.host?.utf8HostToAscii()
             components?.host = host
@@ -58,5 +70,24 @@ class URIFixup {
 
     static func replaceBrackets(url: String) -> String {
         return url.replacingOccurrences(of: "[", with: "%5B").replacingOccurrences(of: "]", with: "%5D")
+    }
+
+    static func replaceHashMarks(url: inout String) {
+        
+        let firstIndex = url.firstIndex(of: "#")!
+        var start = url.index(firstIndex, offsetBy: 1)
+
+        var ranges: [Range<String.Index>] = []
+        while start <= url.endIndex,
+            let range = url.range(of: "#", range: start..<url.endIndex) {
+                
+            ranges.append(range)
+            start = range.upperBound
+        }
+
+        for range in ranges {
+            
+            url.replaceSubrange(range, with:  "%23")
+        }
     }
 }


### PR DESCRIPTION
Issue :-
URLs that contain more than one # are not detected as URLs and when entered in the URL bar open are search request instead.

Reason:-
# are used as markers for subsection in a page.Any URL with more than # needs all # marks to be escaped except for the first.
URL(string:) consider any string with more than one # to be invalid and returns nil.

In URIs, a hash mark # introduces the optional fragment near the end of the URL, More information related can be found on 
https://tools.ietf.org/html/rfc3986

Solution:-
Replace # with %23 except for the first, so that URL(string:) return a valid url.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1050)
