### PR TITLE
FXIOS-1064 ⁃ FXIOS 977 - Issue 7414 - Link sharing via whatsapp is not working

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -15,13 +15,12 @@ private let schemesAllowedToBeOpenedAsPopups = ["http", "https", "javascript", "
 extension BrowserViewController: WKUIDelegate {
     func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
         guard let parentTab = tabManager[webView] else { return nil }
-        
         guard !navigationAction.isInternalUnprivileged, shouldRequestBeOpenedAsPopup(navigationAction.request) else {
             print("Denying popup from request: \(navigationAction.request)")
             
             guard let url = navigationAction.request.url else { return nil }
             
-            if url.scheme == "whatsapp" && UIApplication.shared.canOpenURL(url){
+            if url.scheme == "whatsapp" && UIApplication.shared.canOpenURL(url) {
                 UIApplication.shared.open(url, options: [:])
             }
             

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -15,9 +15,16 @@ private let schemesAllowedToBeOpenedAsPopups = ["http", "https", "javascript", "
 extension BrowserViewController: WKUIDelegate {
     func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
         guard let parentTab = tabManager[webView] else { return nil }
-
+        
         guard !navigationAction.isInternalUnprivileged, shouldRequestBeOpenedAsPopup(navigationAction.request) else {
             print("Denying popup from request: \(navigationAction.request)")
+            
+            guard let url = navigationAction.request.url else { return nil }
+            
+            if url.scheme == "whatsapp" && UIApplication.shared.canOpenURL(url){
+                UIApplication.shared.open(url, options: [:])
+            }
+            
             return nil
         }
 

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -65,6 +65,7 @@
 		<string>org-appextension-feature-password-management</string>
 		<string>googlegmail</string>
 		<string>fastmail</string>
+		<string>whatsapp</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>


### PR DESCRIPTION
Issue Fixed :-
https://github.com/mozilla-mobile/firefox-ios/issues/7414

Why Issue was happening:-

The reason links were not getting shared via whatsapp was 
**webView(_:createWebViewWith:for:windowFeatures:)** was returning nil.

How is it fixed:-
1.url scheme is checked for whatsapp before returning nil
2.url is checked with canOpenUrl to see if app is installed on phone or not.
3.whatsapp scheme is added to LSApplicationQueriesSchemes

Tested on:-
Iphone 7
iOS 13.6.1

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1064)
