### PR TITLE
FXIOS-1118 ⁃ Fix #7554 - Top buttons bar does not respect theme 

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -586,6 +586,7 @@
 		D8EFFA0C1FF5B1FA001D3A09 /* NavigationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EFFA0B1FF5B1FA001D3A09 /* NavigationRouter.swift */; };
 		D8EFFA261FF702A8001D3A09 /* NavigationRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EFFA251FF702A8001D3A09 /* NavigationRouterTests.swift */; };
 		D8FDEB57220CFE970069A582 /* UIImage+ImageEffects.m in Sources */ = {isa = PBXBuildFile; fileRef = D8FDEB55220CFE970069A582 /* UIImage+ImageEffects.m */; };
+		DA3A4FE9254A781A00C4A9C9 /* TabTableViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3A4FE8254A781A00C4A9C9 /* TabTableViewHeader.swift */; };
 		DA9FD88324E213B500168D1E /* QuickLinkSelection.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = DA9FD88124E213B400168D1E /* QuickLinkSelection.intentdefinition */; };
 		DA9FD88424E213B500168D1E /* SmallQuickLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9FD88224E213B400168D1E /* SmallQuickLink.swift */; };
 		DA9FD88624E213CD00168D1E /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9FD88524E213CC00168D1E /* Helpers.swift */; };
@@ -3441,6 +3442,7 @@
 		D9BF406EAD510AF4EC9FD9B2 /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		D9EF4E228315F9C93DBC5BCE /* su */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = su; path = su.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		DA2240A6BF2630FC0A8A0B8F /* es-AR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-AR"; path = "es-AR.lproj/ClearPrivateDataConfirm.strings"; sourceTree = "<group>"; };
+		DA3A4FE8254A781A00C4A9C9 /* TabTableViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTableViewHeader.swift; sourceTree = "<group>"; };
 		DA4446B0870E847782CEFAF4 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		DA654F2582BF9863A719CB00 /* gu-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "gu-IN"; path = "gu-IN.lproj/Shared.strings"; sourceTree = "<group>"; };
 		DA744D888927B768AD70ECF4 /* ml */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ml; path = ml.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
@@ -4235,6 +4237,7 @@
 				23F2C369244E463C00FA4496 /* TabTrayV2ViewModel.swift */,
 				436715882488216A006D1D4E /* TabTableViewCell.swift */,
 				43162A2E2492DB7800F91658 /* EmptyPrivateTabsView.swift */,
+				DA3A4FE8254A781A00C4A9C9 /* TabTableViewHeader.swift */,
 			);
 			path = Tabs;
 			sourceTree = "<group>";
@@ -7647,6 +7650,7 @@
 				74821F8E1DAD8F1400EEEA72 /* FirefoxHomeHighlightCell.swift in Sources */,
 				E69E06BA1C76173D00D0F926 /* RequirePasscodeIntervalViewController.swift in Sources */,
 				D0E89A2920910917001CE5C7 /* DownloadsPanel.swift in Sources */,
+				DA3A4FE9254A781A00C4A9C9 /* TabTableViewHeader.swift in Sources */,
 				D3BA7E0E1B0E934F00153782 /* ContextMenuHelper.swift in Sources */,
 				E660BE061BB0666D009AC090 /* InnerStrokedView.swift in Sources */,
 				0BB5B30B1AC0AD1F0052877D /* LoginsHelper.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1292,8 +1292,18 @@ extension BrowserViewController: URLBarDelegate {
 
         if AppConstants.CHRONOLOGICAL_TABS {
             let tabTrayViewController = TabTrayV2ViewController()
-            let controller = ThemedNavigationController(rootViewController: tabTrayViewController)
-            controller.presentingModalViewControllerDelegate = self
+            let controller: UINavigationController
+            if #available(iOS 13.0, *) {
+                controller = UINavigationController(rootViewController: tabTrayViewController)
+                // If we're not using the system theme, override the view's style to match
+                if !ThemeManager.instance.systemThemeIsOn {
+                    controller.overrideUserInterfaceStyle = ThemeManager.instance.userInterfaceStyle
+                }
+            } else {
+                let themedController = ThemedNavigationController(rootViewController: tabTrayViewController)
+                themedController.presentingModalViewControllerDelegate = self
+                controller = themedController
+            }
             self.present(controller, animated: true, completion: nil)
             self.tabTrayControllerV2 = tabTrayViewController
         } else {

--- a/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import UIKit
+import Shared
 
 class TabTableViewCell: UITableViewCell, Themeable {
     static let identifier = "tabCell"
@@ -29,8 +30,6 @@ class TabTableViewCell: UITableViewCell, Themeable {
         screenshotView.layer.cornerRadius = TabTrayV2ControllerUX.cornerRadius
         screenshotView.layer.borderWidth = 1
         screenshotView.layer.borderColor = UIColor.Photon.Grey30.cgColor
-
-        urlLabel.textColor = UIColor.Photon.Grey40
         
         screenshotView.snp.makeConstraints { make in
             make.height.width.equalTo(100)
@@ -69,7 +68,16 @@ class TabTableViewCell: UITableViewCell, Themeable {
     }
 
     func applyTheme() {
-        backgroundColor = UIColor.theme.tableView.rowBackground
-        textLabel?.textColor = UIColor.theme.tableView.rowText
+        if #available(iOS 13.0, *) {
+            backgroundColor = UIColor.secondarySystemGroupedBackground
+            textLabel?.textColor = UIColor.label
+            detailTextLabel?.textColor = UIColor.secondaryLabel
+            closeButton.tintColor = UIColor.secondaryLabel
+        } else {
+            backgroundColor = UIColor.theme.tableView.rowBackground
+            textLabel?.textColor = UIColor.theme.tableView.rowText
+            detailTextLabel?.textColor = UIColor.theme.tableView.rowDetailText
+            closeButton.tintColor = UIColor.theme.tabTray.cellCloseButton
+        }
     }
 }

--- a/Client/Frontend/Browser/Tabs/TabTableViewHeader.swift
+++ b/Client/Frontend/Browser/Tabs/TabTableViewHeader.swift
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+class TabTableViewHeader: UITableViewHeaderFooterView, Themeable {
+    private struct UX {
+        static let titleHorizontalPadding: CGFloat = 15
+        static let titleVerticalPadding: CGFloat = 6
+        static let titleVerticalLongPadding: CGFloat = 20
+    }
+
+    enum TitleAlignment {
+        case top
+        case bottom
+    }
+
+    var titleAlignment: TitleAlignment = .bottom {
+        didSet {
+            remakeTitleAlignmentConstraints()
+        }
+    }
+
+    lazy var titleLabel: UILabel = {
+        var headerLabel = UILabel()
+        headerLabel.font = UIFont.systemFont(ofSize: 12.0, weight: UIFont.Weight.regular)
+        headerLabel.numberOfLines = 0
+        return headerLabel
+    }()
+
+    fileprivate lazy var bordersHelper = ThemedHeaderFooterViewBordersHelper()
+
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        contentView.addSubview(titleLabel)
+        remakeTitleAlignmentConstraints()
+        applyTheme()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func applyTheme() {
+        if #available(iOS 13.0, *) {
+            contentView.backgroundColor = UIColor.systemGroupedBackground
+            titleLabel.textColor = UIColor.secondaryLabel
+        } else {
+            contentView.backgroundColor = UIColor.theme.tableView.headerBackground
+            titleLabel.textColor = UIColor.theme.tableView.headerTextLight
+        }
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        titleLabel.text = nil
+        titleAlignment = .bottom
+
+        applyTheme()
+    }
+
+    fileprivate func remakeTitleAlignmentConstraints() {
+        switch titleAlignment {
+        case .top:
+            titleLabel.snp.remakeConstraints { make in
+                make.left.right.equalTo(self.contentView).inset(UX.titleHorizontalPadding)
+                make.top.equalTo(self.contentView).offset(UX.titleVerticalPadding)
+                make.bottom.equalTo(self.contentView).offset(-UX.titleVerticalLongPadding)
+            }
+        case .bottom:
+            titleLabel.snp.remakeConstraints { make in
+                make.left.right.equalTo(self.contentView).inset(UX.titleHorizontalPadding)
+                make.bottom.equalTo(self.contentView).offset(-UX.titleVerticalPadding)
+                make.top.equalTo(self.contentView).offset(UX.titleVerticalLongPadding)
+            }
+        }
+    }
+}

--- a/Client/Frontend/Browser/Tabs/TabTrayV2ViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayV2ViewController.swift
@@ -32,8 +32,6 @@ class TabTrayV2ViewController: UIViewController, Themeable {
     }()
     lazy var emptyPrivateTabsView: EmptyPrivateTabsView = {
         let emptyView = EmptyPrivateTabsView()
-        emptyView.titleLabel.textColor = .black
-        emptyView.descriptionLabel.textColor = .black
         emptyView.learnMoreButton.addTarget(self, action: #selector(didTapLearnMore), for: .touchUpInside)
         return emptyView
     }()
@@ -48,14 +46,18 @@ class TabTrayV2ViewController: UIViewController, Themeable {
     lazy var navigationMenu: UISegmentedControl = {
         let navigationMenu = UISegmentedControl(items: [UIImage(named: "nav-tabcounter")!.overlayWith(image: countLabel), UIImage(named: "smallPrivateMask")!, UIImage(named:"panelIconSyncedTabs")!])
         navigationMenu.accessibilityIdentifier = "navBarTabTray"
-        navigationMenu.backgroundColor = UIColor.Photon.Grey10
         navigationMenu.selectedSegmentIndex = viewModel.isInPrivateMode ? 1 : 0
         navigationMenu.addTarget(self, action: #selector(panelChanged), for: .valueChanged)
         return navigationMenu
     }()
+    lazy var navigationToolbar: UIToolbar = {
+        let toolbar = UIToolbar()
+        toolbar.delegate = self
+        toolbar.setItems([UIBarButtonItem(customView: navigationMenu)], animated: false)
+        return toolbar
+    }()
     lazy var deleteAllButton: UIBarButtonItem = {
         let deleteAllButton = UIBarButtonItem(image: UIImage.templateImageNamed("action_delete"), style: .plain, target: self, action: #selector(didTapToolbarDelete))
-        deleteAllButton.tintColor = UIColor.Photon.Grey90A80
         deleteAllButton.accessibilityIdentifier = "closeAllTabsButtonTabTray"
         return deleteAllButton
     }()
@@ -110,10 +112,7 @@ class TabTrayV2ViewController: UIViewController, Themeable {
         setToolbarItems(bottomToolbar, animated: false)
         
         // Add Subviews
-        let navMenuContainer = UIToolbar()
-        navMenuContainer.delegate = self
-        navMenuContainer.setItems([UIBarButtonItem(customView: navigationMenu)], animated: false)
-        view.addSubview(navMenuContainer)
+        view.addSubview(navigationToolbar)
         view.addSubview(tableView)
         view.addSubview(emptyPrivateTabsView)
         viewModel.updateTabs()
@@ -122,9 +121,9 @@ class TabTrayV2ViewController: UIViewController, Themeable {
             make.left.equalTo(view.safeArea.left)
             make.right.equalTo(view.safeArea.right)
             make.bottom.equalTo(view)
-            make.top.equalTo(navMenuContainer.snp.bottom)
+            make.top.equalTo(navigationToolbar.snp.bottom)
         }
-        navMenuContainer.snp.makeConstraints { make in
+        navigationToolbar.snp.makeConstraints { make in
             make.left.right.equalTo(view)
             make.top.equalTo(view.safeArea.top)
         }
@@ -133,7 +132,7 @@ class TabTrayV2ViewController: UIViewController, Themeable {
         }
         emptyPrivateTabsView.snp.makeConstraints { make in
             make.bottom.left.right.equalTo(view)
-            make.top.equalTo(navMenuContainer.snp.bottom)
+            make.top.equalTo(navigationToolbar.snp.bottom)
         }
         
         emptyPrivateTabsView.isHidden = true
@@ -153,12 +152,15 @@ class TabTrayV2ViewController: UIViewController, Themeable {
             emptyPrivateTabsView.descriptionLabel.textColor = UIColor.secondaryLabel
         } else {
             tableView.backgroundColor = UIColor.theme.tableView.headerBackground
+            tableView.separatorColor = UIColor.theme.tableView.separator
             navigationController?.navigationBar.barTintColor = UIColor.theme.tabTray.toolbar
             navigationController?.navigationBar.tintColor = UIColor.theme.tabTray.toolbarButtonTint
             navigationController?.toolbar.barTintColor = UIColor.theme.tabTray.toolbar
             navigationController?.toolbar.tintColor = UIColor.theme.tabTray.toolbarButtonTint
-            navigationMenu.superview?.backgroundColor = UIColor.theme.tabTray.toolbar
-            navigationMenu.tintColor = UIColor.theme.tabTray.toolbarButtonTint
+            navigationToolbar.barTintColor = UIColor.theme.tabTray.toolbar
+            navigationToolbar.tintColor = UIColor.theme.tabTray.toolbarButtonTint
+            emptyPrivateTabsView.titleLabel.textColor = UIColor.theme.tableView.rowText
+            emptyPrivateTabsView.descriptionLabel.textColor = UIColor.theme.tableView.rowDetailText
         }
         setNeedsStatusBarAppearanceUpdate()
     }

--- a/Client/Frontend/Theme/ThemeManager.swift
+++ b/Client/Frontend/Theme/ThemeManager.swift
@@ -61,6 +61,16 @@ class ThemeManager {
         return currentName == .dark ? .lightContent : .default
     }
 
+    @available(iOS 13.0, *)
+    var userInterfaceStyle: UIUserInterfaceStyle {
+        switch currentName {
+        case .dark:
+            return .dark
+        default:
+            return .light
+        }
+    }
+
     func updateCurrentThemeBasedOnScreenBrightness() {
         let prefValue = UserDefaults.standard.float(forKey: ThemeManagerPrefs.automaticSliderValue.rawValue)
 


### PR DESCRIPTION
Fixes #7554, depends on #7556.

<table>
<tr><td>Light Mode</td><td>Dark Mode</td></tr>
<tr>
	<td>
		<img alt ="Simulator Screen Shot - iPhone 11 Pro Max - 2020-10-29 at 18 23 42" src="https://user-images.githubusercontent.com/650804/97639116-5143d480-1a14-11eb-9325-d634825a9f47.png" />
	</td>
	<td>
		<img alt="Simulator Screen Shot - iPhone 11 Pro Max - 2020-10-29 at 18 23 57" src="https://user-images.githubusercontent.com/650804/97639127-5739b580-1a14-11eb-964a-9b60810858da.png" />
	</td>
</tr>
</table>

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1118)
