### PR TITLE
FXIOS-1150 ⁃ Fix #7558 by reverting ApplicationService to v63.0b cb2ce39

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -12,6 +12,7 @@ github "mozilla-mobile/telemetry-ios"      ~> 1.1
 github "mozilla-mobile/MappaMundi"          "master"
 github "Leanplum/Leanplum-iOS-SDK"          ~> 2.7.2
 github "mozilla-services/shavar-prod-lists" "72.0"
+
 # Use beta version of A~S for XCode12
 github "nbhasin2/application-services" "63.0b"
 # Use release version of application-services

--- a/Cartfile
+++ b/Cartfile
@@ -12,8 +12,11 @@ github "mozilla-mobile/telemetry-ios"      ~> 1.1
 github "mozilla-mobile/MappaMundi"          "master"
 github "Leanplum/Leanplum-iOS-SDK"          ~> 2.7.2
 github "mozilla-services/shavar-prod-lists" "72.0"
+# Use beta version of A~S for XCode12
+github "nbhasin2/application-services" "63.0b"
 # Use release version of application-services
-github "mozilla/application-services"      "v65.0.0"
+# commenting out until we have a fix for https://github.com/mozilla/application-services/issues/3670
+# github "mozilla/application-services"      "v65.0.0"
 
 # Use interim binary version of application-services
 # binary "https://circleci.com/api/v1.1/project/github/mozilla/application-services/2862/artifacts/0/dist/mozilla.app-services.json" ~> 0.0.1-snapshot # mozilla/application-services@fb5c540e99133980911216055425688f22a27be2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -14,7 +14,4 @@ github "mozilla-mobile/MappaMundi" "1d17845e4bd6077d790aca5a2b4a468f19567934"
 github "mozilla-mobile/telemetry-ios" "v1.1.3"
 github "mozilla-services/shavar-prod-lists" "1f282be9bc7bf86cf4d695e2a63dbcdf2eecfb89"
 github "swisspol/GCDWebServer" "3.5.3"
-# Use beta version of A~S for XCode12
 github "nbhasin2/application-services" "63.0b"
-# commenting out until we have a fix for https://github.com/mozilla/application-services/issues/3670
-#github "mozilla/application-services" "v65.0.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -14,4 +14,7 @@ github "mozilla-mobile/MappaMundi" "1d17845e4bd6077d790aca5a2b4a468f19567934"
 github "mozilla-mobile/telemetry-ios" "v1.1.3"
 github "mozilla-services/shavar-prod-lists" "1f282be9bc7bf86cf4d695e2a63dbcdf2eecfb89"
 github "swisspol/GCDWebServer" "3.5.3"
-github "mozilla/application-services" "v65.0.0"
+# Use beta version of A~S for XCode12
+github "nbhasin2/application-services" "63.0b"
+# commenting out until we have a fix for https://github.com/mozilla/application-services/issues/3670
+#github "mozilla/application-services" "v65.0.0"


### PR DESCRIPTION
Fixes mozilla-mobile/firefox-ios#7558

Turns out there is an issue with ApplicationService v65 and there is no good way to get v63 of ApplicationServices framework from CircleCI hence publishing older framework to my own repo until.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1150)
