### PR TITLE
FXIOS-1160 ⁃ update tests for chron tabs new ui

### DIFF
--- a/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
@@ -11,7 +11,7 @@ class TabTableViewCell: UITableViewCell, Themeable {
     lazy var closeButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage.templateImageNamed("tab_close"), for: [])
-        button.accessibilityIdentifier = "closeButtonForTabTabTray"
+        button.accessibilityIdentifier = "closeTabButtonTabTray"
         button.tintColor = UIColor.theme.tabTray.cellCloseButton
         button.sizeToFit()
         return button

--- a/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
@@ -11,6 +11,7 @@ class TabTableViewCell: UITableViewCell, Themeable {
     lazy var closeButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage.templateImageNamed("tab_close"), for: [])
+        button.accessibilityIdentifier = "closeButtonForTabTabTray"
         button.tintColor = UIColor.theme.tabTray.cellCloseButton
         button.sizeToFit()
         return button

--- a/Client/Frontend/Browser/Tabs/TabTrayV2ViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayV2ViewController.swift
@@ -55,11 +55,11 @@ class TabTrayV2ViewController: UIViewController, Themeable {
     lazy var bottomToolbar: UIToolbar = {
         let bottomToolbar = UIToolbar()
         let addTabButton = UIBarButtonItem(customView: NewTabButton(target: self, selector: #selector(didTapToolbarAddTab)))
-        addTabButton.accessibilityIdentifier = "newTabTabTray"
+        addTabButton.accessibilityIdentifier = "newTabButtonTabTray"
         let space = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
         let closeAllTabsButton = UIBarButtonItem(image: UIImage(named: "delete"), style: .plain , target: self, action: #selector(didTapToolbarDelete))
         closeAllTabsButton.tintColor = UIColor.Photon.Grey90A80
-        closeAllTabsButton.accessibilityIdentifier = "closeAllTabsTabTray"
+        closeAllTabsButton.accessibilityIdentifier = "closeAllTabsButtonTabTray"
         bottomToolbar.barStyle = .default
         bottomToolbar.backgroundColor = .white
         bottomToolbar.setItems([closeAllTabsButton, space, addTabButton], animated: false)

--- a/Client/Frontend/Browser/Tabs/TabTrayV2ViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayV2ViewController.swift
@@ -46,6 +46,7 @@ class TabTrayV2ViewController: UIViewController, Themeable {
     }()
     lazy var navigationMenu: UISegmentedControl = {
         let navigationMenu = UISegmentedControl(items: [UIImage(named: "nav-tabcounter")!.overlayWith(image: countLabel), UIImage(named: "smallPrivateMask")!, UIImage(named:"panelIconSyncedTabs")!])
+        navigationMenu.accessibilityIdentifier = "navBarTabTray"
         navigationMenu.backgroundColor = UIColor.Photon.Grey10
         navigationMenu.selectedSegmentIndex = viewModel.isInPrivateMode ? 1 : 0
         navigationMenu.addTarget(self, action: #selector(panelChanged), for: .valueChanged)
@@ -54,9 +55,11 @@ class TabTrayV2ViewController: UIViewController, Themeable {
     lazy var bottomToolbar: UIToolbar = {
         let bottomToolbar = UIToolbar()
         let addTabButton = UIBarButtonItem(customView: NewTabButton(target: self, selector: #selector(didTapToolbarAddTab)))
+        addTabButton.accessibilityIdentifier = "newTabTabTray"
         let space = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
         let closeAllTabsButton = UIBarButtonItem(image: UIImage(named: "delete"), style: .plain , target: self, action: #selector(didTapToolbarDelete))
         closeAllTabsButton.tintColor = UIColor.Photon.Grey90A80
+        closeAllTabsButton.accessibilityIdentifier = "closeAllTabsTabTray"
         bottomToolbar.barStyle = .default
         bottomToolbar.backgroundColor = .white
         bottomToolbar.setItems([closeAllTabsButton, space, addTabButton], animated: false)

--- a/UITests/AuthenticationTests.swift
+++ b/UITests/AuthenticationTests.swift
@@ -54,8 +54,8 @@ class AuthenticationTests: KIFTestCase {
         } else {
             tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
         }
-        tester().tapView(withAccessibilityIdentifier: "TabTrayController.maskButton")
-        tester().tapView(withAccessibilityIdentifier: "TabTrayController.addTabButton")
+        tester().tapView(withAccessibilityLabel: "smallPrivateMask")
+        tester().tapView(withAccessibilityIdentifier: "newTabTabTray")
         tester().waitForAnimationsToFinish()
         loadAuthPage()
 

--- a/UITests/AuthenticationTests.swift
+++ b/UITests/AuthenticationTests.swift
@@ -55,7 +55,7 @@ class AuthenticationTests: KIFTestCase {
             tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
         }
         tester().tapView(withAccessibilityLabel: "smallPrivateMask")
-        tester().tapView(withAccessibilityIdentifier: "newTabTabTray")
+        tester().tapView(withAccessibilityIdentifier: "newTabButtonTabTray")
         tester().waitForAnimationsToFinish()
         loadAuthPage()
 

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -225,26 +225,25 @@ class BrowserUtils {
 
     class func resetToAboutHomeKIF(_ tester: KIFUITestActor) {
         if iPad() {
-//            EarlGrey.selectElement(with: grey_accessibilityID("TopTabsViewController.tabsButton")).perform(grey_tap())
             tester.tapView(withAccessibilityIdentifier: "TopTabsViewController.tabsButton")
         } else {
             tester.tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
         }
         
         // if in private mode, close all tabs
-        tester.tapView(withAccessibilityIdentifier: "TabTrayController.maskButton")
+        tester.tapView(withAccessibilityLabel: "smallPrivateMask")
 
-        tester.tapView(withAccessibilityIdentifier: "TabTrayController.removeTabsButton")
+        tester.tapView(withAccessibilityIdentifier: "closeAllTabsTabTray")
         tester.tapView(withAccessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
 
         tester.wait(forTimeInterval: 3)
         /* go to Normal mode */
         if (tester.viewExistsWithLabel("Show Tabs")) {
-            tester.tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
+            tester.tapView(withAccessibilityLabel: "1")
         } else {
-            tester.tapView(withAccessibilityIdentifier: "TabTrayController.maskButton")
+            tester.tapView(withAccessibilityLabel: "smallPrivateMask")
         }
-        tester.tapView(withAccessibilityIdentifier: "TabTrayController.removeTabsButton")
+        tester.tapView(withAccessibilityIdentifier: "closeAllTabsTabTray")
         tester.tapView(withAccessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
     }
 
@@ -307,10 +306,6 @@ class BrowserUtils {
                 tester.setOn(clearables!.contains(clearable), forSwitchWithAccessibilityLabel: clearable.rawValue)
             }
         tester.tapView(withAccessibilityIdentifier: "ClearPrivateData")
-    }
-    
-    class func configEarlGrey() {
-    
     }
 
     class func clearPrivateDataKIF(_ tester: KIFUITestActor) {

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -233,7 +233,7 @@ class BrowserUtils {
         // if in private mode, close all tabs
         tester.tapView(withAccessibilityLabel: "smallPrivateMask")
 
-        tester.tapView(withAccessibilityIdentifier: "closeAllTabsTabTray")
+        tester.tapView(withAccessibilityIdentifier: "closeAllTabsButtonTabTray")
         tester.tapView(withAccessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
 
         tester.wait(forTimeInterval: 3)
@@ -243,7 +243,7 @@ class BrowserUtils {
         } else {
             tester.tapView(withAccessibilityLabel: "smallPrivateMask")
         }
-        tester.tapView(withAccessibilityIdentifier: "closeAllTabsTabTray")
+        tester.tapView(withAccessibilityIdentifier: "closeAllTabsButtonTabTray")
         tester.tapView(withAccessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
     }
 

--- a/UITests/SecurityTests.swift
+++ b/UITests/SecurityTests.swift
@@ -74,6 +74,11 @@ class SecurityTests: KIFTestCase {
 
         // Also make sure the XSS alert doesn't appear.
         XCTAssertFalse(tester().viewExistsWithLabel("Local page loaded"))
+
+        // Workaround number of tabs not updated
+        tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
+        tester().tapView(withAccessibilityIdentifier: "closeAllTabsTabTray")
+        tester().tapView(withAccessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
     }
 
     /// Tap the URL spoof button, which opens a new window to a host with an invalid port.
@@ -89,9 +94,10 @@ class SecurityTests: KIFTestCase {
         // Make sure the URL bar doesn't show the URL since it hasn't loaded.
         XCTAssertFalse(tester().viewExistsWithLabel("http://1.2.3.4:1234/"))
 
-        // Since the newly opened tab doesn't have a URL/title we can't find its accessibility
-        // element to close it in teardown. Workaround: load another page first.
-        BrowserUtils.enterUrlAddressBar(tester(), typeUrl: webRoot!)
+        // Workaround number of tabs not updated
+        tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
+        tester().tapView(withAccessibilityIdentifier: "closeAllTabsTabTray")
+        tester().tapView(withAccessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
     }
 
     // For blob URLs, just show "blob:" to the user (see bug 1446227)

--- a/UITests/SecurityTests.swift
+++ b/UITests/SecurityTests.swift
@@ -77,7 +77,7 @@ class SecurityTests: KIFTestCase {
 
         // Workaround number of tabs not updated
         tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
-        tester().tapView(withAccessibilityIdentifier: "closeAllTabsTabTray")
+        tester().tapView(withAccessibilityIdentifier: "closeAllTabsButtonTabTray")
         tester().tapView(withAccessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
     }
 
@@ -96,7 +96,7 @@ class SecurityTests: KIFTestCase {
 
         // Workaround number of tabs not updated
         tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
-        tester().tapView(withAccessibilityIdentifier: "closeAllTabsTabTray")
+        tester().tapView(withAccessibilityIdentifier: "closeAllTabsButtonTabTray")
         tester().tapView(withAccessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
     }
 

--- a/UITests/TrackingProtectionTests.swift
+++ b/UITests/TrackingProtectionTests.swift
@@ -137,7 +137,7 @@ class TrackingProtectionTests: KIFTestCase, TabEventHandler {
             tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
         }
 
-        tester().tapView(withAccessibilityIdentifier: "TabTrayController.addTabButton")
+        tester().tapView(withAccessibilityIdentifier: "newTabTabTray")
 
         checkStrictTrackingProtection(isBlocking: false, isTPDisabled: true)
         enableStrictMode()

--- a/UITests/TrackingProtectionTests.swift
+++ b/UITests/TrackingProtectionTests.swift
@@ -137,7 +137,7 @@ class TrackingProtectionTests: KIFTestCase, TabEventHandler {
             tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
         }
 
-        tester().tapView(withAccessibilityIdentifier: "newTabTabTray")
+        tester().tapView(withAccessibilityIdentifier: "newTabButtonTabTray")
 
         checkStrictTrackingProtection(isBlocking: false, isTPDisabled: true)
         enableStrictMode()

--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -65,6 +65,7 @@ class ActivityStreamTest: BaseTestCase {
         } else {
             app.buttons["TabToolbar.backButton"].tap()
         }
+        navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         // A new site has been added to the top sites
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)

--- a/XCUITests/BookmarkingTests.swift
+++ b/XCUITests/BookmarkingTests.swift
@@ -75,7 +75,7 @@ class BookmarkingTests: BaseTestCase {
         // Go back, check it's still bookmarked, check it's on bookmarks home panel
         waitForTabsButton()
         navigator.goto(TabTray)
-        app.collectionViews.cells["Example Domain"].tap()
+        app.cells.staticTexts["Example Domain"].tap()
         navigator.nowAt(BrowserTab)
         waitForTabsButton()
         checkBookmarked()
@@ -273,7 +273,6 @@ class BookmarkingTests: BaseTestCase {
 
     private func typeOnSearchBar(text: String) {
         waitForExistence(app.textFields["url"], timeout: 5)
-        sleep(1)
         app.textFields["address"].tap()
         app.textFields["address"].typeText(text)
     }

--- a/XCUITests/FindInPageTest.swift
+++ b/XCUITests/FindInPageTest.swift
@@ -139,8 +139,8 @@ class FindInPageTests: BaseTestCase {
         // Going to tab tray and back to the website hides the search field.
         navigator.goto(TabTray)
 
-        waitForExistence(app.collectionViews.cells["The Book of Mozilla"])
-        app.collectionViews.cells["The Book of Mozilla"].tap()
+        waitForExistence(app.cells.staticTexts["The Book of Mozilla"])
+        app.cells.staticTexts["The Book of Mozilla"].tap()
         XCTAssertFalse(app.textFields[""].exists)
         XCTAssertFalse(app.buttons["FindInPage.find_next"].exists)
         XCTAssertFalse(app.buttons["FindInPage.find_previous"].exists)

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -909,11 +909,11 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     map.addScreenState(TabTray) { screenState in
-        screenState.tap(app.buttons["newTabTabTray"], forAction: Action.OpenNewTabFromTabTray, transitionTo: NewTabScreen)
+        screenState.tap(app.buttons["newTabButtonTabTray"], forAction: Action.OpenNewTabFromTabTray, transitionTo: NewTabScreen)
         screenState.tap(app.buttons["smallPrivateMask"], forAction: Action.TogglePrivateMode) { userState in
             userState.isPrivate = !userState.isPrivate
         }
-        screenState.tap(app.buttons["closeAllTabsTabTray"], to: CloseTabMenu)
+        screenState.tap(app.buttons["closeAllTabsButtonTabTray"], to: CloseTabMenu)
 
         screenState.onEnter { userState in
             userState.numTabs = Int(app.cells.count)
@@ -1117,7 +1117,7 @@ extension MMNavigator where T == FxUserState {
     func createNewTab() {
         let app = XCUIApplication()
         self.goto(TabTray)
-        app.buttons["newTabTabTray"].tap()
+        app.buttons["newTabButtonTabTray"].tap()
         self.nowAt(NewTabScreen)
     }
 

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -909,14 +909,14 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     map.addScreenState(TabTray) { screenState in
-        screenState.tap(app.buttons["TabTrayController.addTabButton"], forAction: Action.OpenNewTabFromTabTray, transitionTo: NewTabScreen)
-        screenState.tap(app.buttons["TabTrayController.maskButton"], forAction: Action.TogglePrivateMode) { userState in
+        screenState.tap(app.buttons["newTabTabTray"], forAction: Action.OpenNewTabFromTabTray, transitionTo: NewTabScreen)
+        screenState.tap(app.buttons["smallPrivateMask"], forAction: Action.TogglePrivateMode) { userState in
             userState.isPrivate = !userState.isPrivate
         }
-        screenState.tap(app.buttons["TabTrayController.removeTabsButton"], to: CloseTabMenu)
+        screenState.tap(app.buttons["closeAllTabsTabTray"], to: CloseTabMenu)
 
         screenState.onEnter { userState in
-            userState.numTabs = Int(app.collectionViews.cells.count)
+            userState.numTabs = Int(app.cells.count)
         }
     }
 
@@ -1001,7 +1001,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             }
         }
 
-        screenState.tap(app.buttons["Private Mode"], forAction: Action.TogglePrivateModeFromTabBarBrowserTab) { userState in
+        screenState.tap(app.buttons["smallPrivateMask"], forAction: Action.TogglePrivateModeFromTabBarBrowserTab) { userState in
             userState.isPrivate = !userState.isPrivate
         }
     }
@@ -1117,7 +1117,7 @@ extension MMNavigator where T == FxUserState {
     func createNewTab() {
         let app = XCUIApplication()
         self.goto(TabTray)
-        app.buttons["TabTrayController.addTabButton"].tap()
+        app.buttons["newTabTabTray"].tap()
         self.nowAt(NewTabScreen)
     }
 

--- a/XCUITests/HistoryTests.swift
+++ b/XCUITests/HistoryTests.swift
@@ -211,9 +211,9 @@ class HistoryTests: BaseTestCase {
         waitUntilPageLoad()
         waitForTabsButton()
         navigator.goto(TabTray)
-        waitForExistence(app.collectionViews.cells[webpage["label"]!])
+        waitForExistence(app.cells.staticTexts[webpage["label"]!])
         // 'x' button to close the tab is not visible, so closing by swiping the tab
-        app.collectionViews.cells[webpage["label"]!].swipeRight()
+        app.cells.staticTexts[webpage["label"]!].swipeRight()
 
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.goto(HomePanelsScreen)

--- a/XCUITests/HomePageSettingsUITest.swift
+++ b/XCUITests/HomePageSettingsUITest.swift
@@ -88,7 +88,6 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.goto(HomeSettings)
         app.textFields["HomeAsCustomURLTextField"].tap()
         app.textFields["HomeAsCustomURLTextField"].press(forDuration: 3)
-        print(app.debugDescription)
         waitForExistence(app.menuItems["Paste"])
         app.menuItems["Paste"].tap()
         waitForValueContains(app.textFields["HomeAsCustomURLTextField"], value: "mozilla")

--- a/XCUITests/PrivateBrowsingTest.swift
+++ b/XCUITests/PrivateBrowsingTest.swift
@@ -49,7 +49,7 @@ class PrivateBrowsingTest: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
 
-        waitForExistence(app.collectionViews.cells[url2Label])
+        waitForExistence(app.cells.staticTexts[url2Label])
         let numTabs = userState.numTabs
         XCTAssertEqual(numTabs, 2, "The number of regular tabs is not correct")
 
@@ -64,15 +64,15 @@ class PrivateBrowsingTest: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
         print(app.debugDescription)
-        waitForExistence(app.collectionViews.cells[url1And3Label])
+        waitForExistence(app.cells.staticTexts[url1And3Label])
         let numPrivTabs = userState.numTabs
         XCTAssertEqual(numPrivTabs, 1, "The number of private tabs is not correct")
 
         // Go back to regular mode and check the total number of tabs
         navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
-        waitForExistence(app.collectionViews.cells[url2Label])
-        waitForNoExistence(app.collectionViews.cells[url1And3Label])
+        waitForExistence(app.cells.staticTexts[url2Label])
+        waitForNoExistence(app.cells.staticTexts[url1And3Label])
         let numRegularTabs = userState.numTabs
         XCTAssertEqual(numRegularTabs, 2, "The number of regular tabs is not correct")
     }
@@ -100,11 +100,11 @@ class PrivateBrowsingTest: BaseTestCase {
 
         // Go back to private browsing and check that the tab has not been closed
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
-        waitForExistence(app.collectionViews.cells[url2Label], timeout: 5)
+        waitForExistence(app.cells.staticTexts[url2Label], timeout: 5)
         checkOpenTabsBeforeClosingPrivateMode()
 
         // Now the enable the Close Private Tabs when closing the Private Browsing Button
-        app.collectionViews.cells[url2Label].tap()
+        app.cells.staticTexts[url2Label].tap()
         waitForTabsButton()
         waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: 10)
         navigator.nowAt(BrowserTab)
@@ -118,7 +118,7 @@ class PrivateBrowsingTest: BaseTestCase {
 
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
-        waitForNoExistence(app.collectionViews.cells[url2Label])
+        waitForNoExistence(app.cells.staticTexts[url2Label])
         checkOpenTabsAfterClosingPrivateMode()
     }
 
@@ -194,7 +194,7 @@ class PrivateBrowsingTest: BaseTestCase {
 
 fileprivate extension BaseTestCase {
     func checkOpenTabsBeforeClosingPrivateMode() {
-        let numPrivTabs = app.collectionViews.cells.count
+        let numPrivTabs = app.tables.cells.count
         XCTAssertEqual(numPrivTabs, 1, "The number of tabs is not correct, the private tab should not have been closed")
     }
 

--- a/XCUITests/TabTraySearchTabsTests.swift
+++ b/XCUITests/TabTraySearchTabsTests.swift
@@ -5,7 +5,7 @@ let secondURL = "mozilla.org/en-US/book"
 let fullFirstURL = "https://www.mozilla.org/en-US/"
 
 class TabTraySearchTabsTests: BaseTestCase {
-
+/* Disble test suite since in theory it does not make sense with Chron tabs implementatio
     func testSearchTabs() {
         // Open two tabs and go to tab tray
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
@@ -72,4 +72,5 @@ class TabTraySearchTabsTests: BaseTestCase {
         let searchValue = app.textFields["Search Tabs"].value
         XCTAssertEqual(searchValue as! String, "Search Tabs")
     }
-}
+     */
+ }

--- a/XCUITests/ToolbarTest.swift
+++ b/XCUITests/ToolbarTest.swift
@@ -60,8 +60,8 @@ class ToolbarTests: BaseTestCase {
         // Open new tab and then go back to previous tab to test navigation buttons.
         waitForTabsButton()
         navigator.goto(TabTray)
-        waitForExistence(app.collectionViews.cells[website1["label"]!])
-        app.collectionViews.cells[website1["label"]!].tap()
+        waitForExistence(app.cells.staticTexts[website1["label"]!])
+        app.cells.staticTexts[website1["label"]!].tap()
         XCTAssertEqual(valueMozilla, urlValueLong)
 
         // Test to see if all the buttons are enabled then close tab.
@@ -73,8 +73,8 @@ class ToolbarTests: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
 
-        waitForExistence(app.collectionViews.cells[website1["label"]!])
-        app.collectionViews.cells[website1["label"]!].swipeRight()
+        waitForExistence(app.cells.staticTexts[website1["label"]!])
+        app.cells.staticTexts[website1["label"]!].swipeRight()
 
         // Go Back to other tab to see if all buttons are disabled.
         navigator.nowAt(BrowserTab)

--- a/XCUITests/TopTabsTest.swift
+++ b/XCUITests/TopTabsTest.swift
@@ -34,7 +34,7 @@ class TopTabsTest: BaseTestCase {
         } else {
             navigator.goto(TabTray)
         }
-        waitForExistence(app.collectionViews.cells[urlLabel], timeout: 5)
+        waitForExistence(app.cells.staticTexts[urlLabel], timeout: 5)
     }
 
     func testAddTabFromContext() {
@@ -51,14 +51,14 @@ class TopTabsTest: BaseTestCase {
 
         // Open tab tray to check that both tabs are there
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
-        waitForExistence(app.collectionViews.cells["Example Domain"])
-        if !app.collectionViews.cells["IANA — IANA-managed Reserved Domains"].exists {
+        waitForExistence(app.cells.staticTexts["Example Domain"])
+        if !app.cells.staticTexts["IANA — IANA-managed Reserved Domains"].exists {
             navigator.goto(TabTray)
-            app.collectionViews.cells["Example Domain"].tap()
+            app.cells.staticTexts["Example Domain"].tap()
             waitUntilPageLoad()
             navigator.nowAt(BrowserTab)
             navigator.goto(TabTray)
-            waitForExistence(app.collectionViews.cells["IANA — IANA-managed Reserved Domains"])
+            waitForExistence(app.cells.staticTexts["IANA — IANA-managed Reserved Domains"])
         }
     }
 
@@ -71,8 +71,8 @@ class TopTabsTest: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
 
-        waitForExistence(app.collectionViews.cells[urlLabel])
-        app.collectionViews.cells[urlLabel].tap()
+        waitForExistence(app.cells.staticTexts[urlLabel])
+        app.cells.staticTexts[urlLabel].tap()
         let valueMozilla = app.textFields["url"].value as! String
         XCTAssertEqual(valueMozilla, urlValueLong)
 
@@ -80,8 +80,8 @@ class TopTabsTest: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
 
-        waitForExistence(app.collectionViews.cells[urlLabelExample])
-        app.collectionViews.cells[urlLabelExample].tap()
+        waitForExistence(app.cells.staticTexts[urlLabelExample])
+        app.cells.staticTexts[urlLabelExample].tap()
         let value = app.textFields["url"].value as! String
         XCTAssertEqual(value, urlValueLongExample)
     }
@@ -92,13 +92,13 @@ class TopTabsTest: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
 
-        waitForExistence(app.collectionViews.cells[urlLabel])
+        waitForExistence(app.cells.staticTexts[urlLabel])
 
         // 'x' button to close the tab is not visible, so closing by swiping the tab
-        app.collectionViews.cells[urlLabel].swipeRight()
+        app.cells.staticTexts[urlLabel].swipeRight()
 
         // After removing only one tab it automatically goes to HomepanelView
-        waitForExistence(app.collectionViews.cells["TopSitesCell"])
+        waitForExistence(app.cells.staticTexts["TopSitesCell"])
         XCTAssert(app.cells["TopSitesCell"].cells["TopSite"].exists)
     }
 
@@ -131,13 +131,14 @@ class TopTabsTest: BaseTestCase {
         // Close all tabs, undo it and check that the number of tabs is correct
         navigator.performAction(Action.AcceptRemovingAllTabs)
         app.buttons["Undo"].tap()
-        waitForExistence(app.collectionViews.cells["TopSitesCell"], timeout: 5)
+        waitForExistence(app.cells.staticTexts["TopSitesCell"], timeout: 5)
         navigator.nowAt(BrowserTab)
         if !iPad() {
             waitForExistence(app.buttons["TabToolbar.tabsButton"], timeout: 5)
         }
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
-        waitForExistence(app.collectionViews.cells[urlLabel])
+        print(app.debugDescription)
+        waitForExistence(app.cells.staticTexts[urlLabel])
     }
 
     func testCloseAllTabsPrivateModeUndo() {
@@ -188,7 +189,7 @@ class TopTabsTest: BaseTestCase {
             waitForExistence(app.buttons["TabToolbar.tabsButton"])
         }
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
-        waitForNoExistence(app.collectionViews.cells[urlLabel])
+        waitForNoExistence(app.cells.staticTexts[urlLabel])
     }
 
     func testCloseAllTabsPrivateMode() {
@@ -222,8 +223,8 @@ class TopTabsTest: BaseTestCase {
             app.cells["quick_action_new_tab"].tap()
             waitForTabsButton()
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
-            waitForExistence(app.collectionViews.cells["Home"])
-            app.collectionViews.cells["Home"].firstMatch.tap()
+            waitForExistence(app.cells.staticTexts["Home"])
+            app.cells.staticTexts["Home"].firstMatch.tap()
 
             // Close tab
             navigator.nowAt(HomePanelsScreen)
@@ -234,8 +235,8 @@ class TopTabsTest: BaseTestCase {
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
 
             // Go to Private Mode
-            waitForExistence(app.collectionViews.cells["Home"])
-            app.collectionViews.cells["Home"].firstMatch.tap()
+            waitForExistence(app.cells.staticTexts["Home"])
+            app.cells.staticTexts["Home"].firstMatch.tap()
             navigator.nowAt(HomePanelsScreen)
             waitForExistence(app.buttons["Show Tabs"])
             app.buttons["Show Tabs"].press(forDuration: 1)
@@ -254,7 +255,7 @@ fileprivate extension BaseTestCase {
     }
 
     func closeTabTrayView(goBackToBrowserTab: String) {
-        app.collectionViews.cells[goBackToBrowserTab].firstMatch.tap()
+        app.cells.staticTexts[goBackToBrowserTab].firstMatch.tap()
         navigator.nowAt(BrowserTab)
     }
 }
@@ -298,8 +299,8 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
         waitForTabsButton()
         navigator.performAction(Action.OpenPrivateTabLongPressTabsButton)
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
-        waitForExistence(app.buttons["TabTrayController.maskButton"])
-        XCTAssertTrue(app.buttons["TabTrayController.maskButton"].isEnabled)
+        waitForExistence(app.buttons["smallPrivateMask"])
+        XCTAssertTrue(app.buttons["smallPrivateMask"].isEnabled)
         XCTAssertTrue(userState.isPrivate)
     }
 
@@ -367,7 +368,7 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
         waitForValueContains(app.textFields["url"], value: "iana")
         XCTAssertTrue(app.links["RFC 2606"].exists)
         navigator.goto(TabTray)
-        XCTAssertTrue(app.buttons["TabTrayController.maskButton"].isEnabled)
+        XCTAssertTrue(app.buttons["smallPrivateMask"].isEnabled)
     }
 }
 


### PR DESCRIPTION
This PR triest to keep tests updated in chronological-tabs branch due to the bigh UI changes that will come and affect the tests.
Changes in this PR:
- Add acc.Ids for elements in the new UI
- Fix UI tests
- Fix most of the XCUITests, there are still things to be done/clarified:
1. Private Browsring first screen, will it be the default home or the welcome page
2. In Tab Tray the number of tabs is not correctly counted by the tests yet
3. Removing a tab from Tab Tray with swipe gesture not implemented, tests not modified yet
4. Drag and Drop tests not disabled yet, depending on the implementation or not of that functionality
5....

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1160)
