### PR TITLE
FXIOS-1170 ⁃ Fixes #7431 - Open tabs widget showed incorrect tabs

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -291,6 +291,8 @@
 		43DDB96A240994370058A068 /* ETPCoverSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DDB969240994360058A068 /* ETPCoverSheetViewController.swift */; };
 		43DDB96C240995A70058A068 /* ETPModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DDB96B240995A70058A068 /* ETPModel.swift */; };
 		43DDB97624099F200058A068 /* ETPViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DDB97524099F200058A068 /* ETPViewModel.swift */; };
+		43E69EC3254D081D00B591C2 /* SimpleTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E69EAF254D064E00B591C2 /* SimpleTab.swift */; };
+		43E69ED7254D081F00B591C2 /* SimpleTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E69EAF254D064E00B591C2 /* SimpleTab.swift */; };
 		43EF756E251D3AD000575E10 /* TopSiteArchiverExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43EF756C251D3AD000575E10 /* TopSiteArchiverExtension.swift */; };
 		43EF75E5251D3C8300575E10 /* TopSiteArchiverExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43EF756C251D3AD000575E10 /* TopSiteArchiverExtension.swift */; };
 		43EF780125228FA500575E10 /* Today.strings in Resources */ = {isa = PBXBuildFile; fileRef = 21374EEAA2C69079F77A0AC3 /* Today.strings */; };
@@ -299,8 +301,8 @@
 		4F514FD41ACD8F2C0022D7EA /* HistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F514FD31ACD8F2C0022D7EA /* HistoryTests.swift */; };
 		4F97573B1AFA6F37006ECC24 /* readerContent.html in Resources */ = {isa = PBXBuildFile; fileRef = 4F9757391AFA6F37006ECC24 /* readerContent.html */; };
 		5002717C41BC7C50F67F1CAD /* StateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50027345B49B967409DDA348 /* StateTests.swift */; };
-		54744E00AB1EB95A92A1DC50 /* Today.strings in Resources */ = {isa = PBXBuildFile; fileRef = 21374EEAA2C69079F77A0AC3 /* Today.strings */; };
 		52262904252505630083DFD5 /* CronTabsPerfTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52262903252505630083DFD5 /* CronTabsPerfTests.swift */; };
+		54744E00AB1EB95A92A1DC50 /* Today.strings in Resources */ = {isa = PBXBuildFile; fileRef = 21374EEAA2C69079F77A0AC3 /* Today.strings */; };
 		554867231DC3935A00183DAA /* HomePageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 554867221DC3935A00183DAA /* HomePageTests.swift */; };
 		580B0C4221748CFE00448DF8 /* DataManagementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580B0C4121748CFE00448DF8 /* DataManagementTests.swift */; };
 		59A681BDFC95A19F05E07223 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A68CCB63E2A565CB03F832 /* SearchViewController.swift */; };
@@ -1923,6 +1925,7 @@
 		43DDB96B240995A70058A068 /* ETPModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ETPModel.swift; sourceTree = "<group>"; };
 		43DDB97524099F200058A068 /* ETPViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ETPViewModel.swift; sourceTree = "<group>"; };
 		43E448868CEE068E52298FEC /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/HistoryPanel.strings"; sourceTree = "<group>"; };
+		43E69EAF254D064E00B591C2 /* SimpleTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleTab.swift; sourceTree = "<group>"; };
 		43EF756C251D3AD000575E10 /* TopSiteArchiverExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSiteArchiverExtension.swift; sourceTree = "<group>"; };
 		44374D28A38301B2A54F591A /* fil */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fil; path = fil.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		443D48F68072CB9805794141 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = "th.lproj/Default Browser.strings"; sourceTree = "<group>"; };
@@ -4207,6 +4210,7 @@
 			children = (
 				1DA3CE5C24EEE73100422BB2 /* OpenTabsWidget.swift */,
 				1D06AE6924FEE8D6000B092B /* TabProvider.swift */,
+				43E69EAF254D064E00B591C2 /* SimpleTab.swift */,
 			);
 			path = OpenTabs;
 			sourceTree = "<group>";
@@ -7091,6 +7095,7 @@
 				43118D07251A9CD100F24376 /* SavedTab.swift in Sources */,
 				4392FB48252EC50400AD3D23 /* InternalSchemeHandler.swift in Sources */,
 				435E34B3254A6A6000406D92 /* TimeConstants.swift in Sources */,
+				43E69ED7254D081F00B591C2 /* SimpleTab.swift in Sources */,
 				1DF42682251BDB3A0086386A /* FaviconFetcher.swift in Sources */,
 				1DDAD13E24F0651C007623C8 /* TopSitesWidget.swift in Sources */,
 				43BA967D2512D15900EB6134 /* Strings.swift in Sources */,
@@ -7638,6 +7643,7 @@
 				396CDB55203C5B870034A3A3 /* TabTrayController+KeyCommands.swift in Sources */,
 				74E36D781B71323500D69DA1 /* SettingsContentViewController.swift in Sources */,
 				EBB8950C21939E4100EB91A0 /* FirefoxTabContentBlocker.swift in Sources */,
+				43E69EC3254D081D00B591C2 /* SimpleTab.swift in Sources */,
 				742A56391D80B54A00BDB803 /* PhotonActionSheet.swift in Sources */,
 				C4EFEECF1CEBB6F2009762A4 /* BackForwardTableViewCell.swift in Sources */,
 				2C49854E206173C800893DAE /* photon-colors.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -275,6 +275,7 @@
 		435D7CC32461EFDD0043ACB9 /* IntroScreenSyncViewV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435D7CC22461EFDD0043ACB9 /* IntroScreenSyncViewV2.swift */; };
 		435D7CC5246209AA0043ACB9 /* IntroViewControllerV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435D7CC4246209AA0043ACB9 /* IntroViewControllerV2.swift */; };
 		435E3391254780B700406D92 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F84B21EF1A0910F600AAB793 /* Images.xcassets */; };
+		435E34B3254A6A6000406D92 /* TimeConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = E650758F1E37F7AB006961AC /* TimeConstants.swift */; };
 		4368BC6824FF14650021931D /* NewTabUserResearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4368BC6724FF14650021931D /* NewTabUserResearch.swift */; };
 		4368BC6A24FF14800021931D /* SharedUserResearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4368BC6924FF14800021931D /* SharedUserResearch.swift */; };
 		4390F7F5246CE04300570811 /* IntroViewModelV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4390F7F4246CE04300570811 /* IntroViewModelV2.swift */; };
@@ -7089,6 +7090,7 @@
 				1D06AE6624FEE4D5000B092B /* TopSitesProvider.swift in Sources */,
 				43118D07251A9CD100F24376 /* SavedTab.swift in Sources */,
 				4392FB48252EC50400AD3D23 /* InternalSchemeHandler.swift in Sources */,
+				435E34B3254A6A6000406D92 /* TimeConstants.swift in Sources */,
 				1DF42682251BDB3A0086386A /* FaviconFetcher.swift in Sources */,
 				1DDAD13E24F0651C007623C8 /* TopSitesWidget.swift in Sources */,
 				43BA967D2512D15900EB6134 /* Strings.swift in Sources */,

--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -70,6 +70,7 @@ extension URLComponents {
 // The root navigation for the Router. Look at the tests to see a complete URL
 enum NavigationPath {
     case url(webURL: URL?, isPrivate: Bool)
+    case widgetUrl(webURL: URL?, lastUsed: Timestamp?)
     case fxa(params: FxALaunchParams)
     case deepLink(DeepLink)
     case text(String)
@@ -108,6 +109,15 @@ enum NavigationPath {
                 TelemetryWrapper.gleanRecordEvent(category: .action, method: .open, object: .asDefaultBrowser)
                 UserDefaults.standard.set(true, forKey: "OpenedAsDefaultBrowser")
             }
+        } else if urlString.starts(with: "\(scheme)://open-url-widget") {
+            
+            // TODO extract timestamp from open-url-widget param
+            var timestamp:Timestamp?
+            
+            // Widget
+            self = .widgetUrl(webURL: url, lastUsed: timestamp)
+    
+            
         } else if urlString.starts(with: "\(scheme)://open-text") {
             let text = components.valueForQuery("text")
             self = .text(text ?? "")

--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -116,7 +116,6 @@ enum NavigationPath {
             }
             let tab = tabs[uuid]
             self = .widgetUrl(webURL: tab?.url, uuid: uuid)
-            
         } else if urlString.starts(with: "\(scheme)://open-text") {
             let text = components.valueForQuery("text")
             self = .text(text ?? "")

--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -121,64 +121,12 @@ enum NavigationPath {
                 UserDefaults.standard.set(true, forKey: "OpenedAsDefaultBrowser")
             }
         } else if urlString.starts(with: "\(scheme)://widget-open-url") {
-            var urlWidget: URL? = nil
-            var timeStamp: Timestamp? = nil
-            
-            guard let stringValue1 = components.valueForQuery("uuid") else {
+            guard let lastTimeUsed = components.valueForQuery("lastUsedTime"), let tabs = SimpleTab.getSimpleTabDict() else {
                 self = .url(webURL: url, isPrivate: false)
                 return
             }
-
-            let userDefaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!
-            let userDefaultsKey = "myTabKey1"
-            if let tbs = userDefaults.object(forKey: userDefaultsKey) as? Data {
-                do {
-                    // Decode data to object
-                    let jsonDecoder = JSONDecoder()
-                    let tabs = try jsonDecoder.decode([String: SimpleTab].self, from: tbs)
-                    tabs.forEach {
-                        print("key - \($0)\nValue - \($1)\n")
-                    }
-                    print("loaded tab\(tabs[stringValue1])")
-                    print("loaded tab url \(tabs[stringValue1]?.url)")
-                    print("loaded tab lastUsedTime \(tabs[stringValue1]?.lastUsedTime)")
-                    self = .widgetUrl(webURL: tabs[stringValue1]?.url, lastUsed: tabs[stringValue1]?.lastUsedTime)
-                    return
-                }
-                catch {
-                }
-            }
-            
-            self = .widgetUrl(webURL: url, lastUsed: timeStamp)
-            // OLD CODE
-            // last time used
-            
-            // TODO extract timestamp from open-url-widget param
-//            guard let stringValue = components.valueForQuery("lastUsedTime") else {
-//                self = .url(webURL: url, isPrivate: false)
-//                return
-//            }
-//
-//            let temp = stringValue.toUInt()
-//            let t2 = Int(stringValue)
-//            if let string = components.valueForQuery("lastUsedTime"), let myInt = Int(string) {
-//                 print("Int : \(myInt)")
-//            }
-//            guard let timestamp = UInt64(stringValue) else {
-//                /* string isn't an Int64, handle error here */
-//                self = .url(webURL: url, isPrivate: false)
-//                return
-//            }
-//
-////            let value:String = components.valueForQuery("lastUsedTime") ?? ""
-////            var timestamp:UInt64 = UInt64("") ?? <#default value#>
-////            if value != nil {
-////                timestamp = UInt64(value!)
-////            }
-//
-//            // Widget
-//            self = .widgetUrl(webURL: url, lastUsed: timestamp)
-//
+            let tab = tabs[lastTimeUsed]
+            self = .widgetUrl(webURL: tab?.url, lastUsed: tab?.lastUsedTime)
             
         } else if urlString.starts(with: "\(scheme)://open-text") {
             let text = components.valueForQuery("text")

--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -112,7 +112,7 @@ enum NavigationPath {
         } else if urlString.starts(with: "\(scheme)://widget-open-url") {
             let tabs = SimpleTab.getSimpleTabs()
             guard let uuid = components.valueForQuery("uuid"), !tabs.isEmpty else {
-                self = .url(webURL: url, isPrivate: false)
+                self = .url(webURL: nil, isPrivate: false)
                 return
             }
             let tab = tabs[uuid]

--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -155,6 +155,8 @@ enum NavigationPath {
         case .text(let text): NavigationPath.handleText(text: text, with: bvc)
         case .glean(let url): NavigationPath.handleGlean(url: url)
         case .closePrivateTabs: NavigationPath.handleClosePrivateTabs(with: bvc, tray: tray)
+        case .widgetUrl(webURL: let webURL, lastUsed: let lastUsed):
+            NavigationPath.handleURL(url: webURL, isPrivate: false, with: bvc)
         }
     }
 
@@ -209,6 +211,15 @@ enum NavigationPath {
             bvc.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate)
         } else {
             bvc.openBlankNewTab(focusLocationField: true, isPrivate: isPrivate)
+        }
+        LeanPlumClient.shared.track(event: .openedNewTab, withParameters: ["Source": "External App or Extension"])
+    }
+    
+    private static func handleWidgetURL(url: URL?, lastUser:Timestamp?, with bvc: BrowserViewController) {
+        if let newURL = url {
+            bvc.switchToTabForWidgetURLOrOpen(newURL, isPrivate: false)
+        } else {
+            bvc.openBlankNewTab(focusLocationField: true, isPrivate: false)
         }
         LeanPlumClient.shared.track(event: .openedNewTab, withParameters: ["Source": "External App or Extension"])
     }

--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -110,7 +110,8 @@ enum NavigationPath {
                 UserDefaults.standard.set(true, forKey: "OpenedAsDefaultBrowser")
             }
         } else if urlString.starts(with: "\(scheme)://widget-open-url") {
-            guard let uuid = components.valueForQuery("uuid"), let tabs = SimpleTab.getSimpleTabDict() else {
+            let tabs = SimpleTab.getSimpleTabs()
+            guard let uuid = components.valueForQuery("uuid"), !tabs.isEmpty else {
                 self = .url(webURL: url, isPrivate: false)
                 return
             }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1062,13 +1062,13 @@ class BrowserViewController: UIViewController {
         }
     }
     
-    func switchToTabForWidgetURLOrOpen(_ url: URL, lastUsed: Timestamp?, isPrivate: Bool = false) {
+    func switchToTabForWidgetURLOrOpen(_ url: URL, uuid: String,  isPrivate: Bool = false) {
         guard !isCrashAlertShowing else {
             urlFromAnotherApp = UrlToOpenModel(url: url, isPrivate: isPrivate)
             return
         }
         popToBVC()
-        if let tab = tabManager.getTabForURL(url, timestamp: lastUsed ?? 0) {
+        if let tab = tabManager.getTabForURL(url, uuid: uuid) {
             tabManager.selectTab(tab)
         } else {
             openURLInNewTab(url, isPrivate: isPrivate)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1068,7 +1068,7 @@ class BrowserViewController: UIViewController {
             return
         }
         popToBVC()
-        if let tab = tabManager.getTabForURL(url, uuid: uuid) {
+        if let tab = tabManager.getTabForUUID(uuid: uuid) {
             tabManager.selectTab(tab)
         } else {
             openURLInNewTab(url, isPrivate: isPrivate)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1062,13 +1062,13 @@ class BrowserViewController: UIViewController {
         }
     }
     
-    func switchToTabForWidgetURLOrOpen(_ url: URL, isPrivate: Bool = false) {
+    func switchToTabForWidgetURLOrOpen(_ url: URL, lastUsed: Timestamp?, isPrivate: Bool = false) {
         guard !isCrashAlertShowing else {
             urlFromAnotherApp = UrlToOpenModel(url: url, isPrivate: isPrivate)
             return
         }
         popToBVC()
-        if let tab = tabManager.getTabForURL(url) {
+        if let tab = tabManager.getTabForURL(url, timestamp: lastUsed ?? 0) {
             tabManager.selectTab(tab)
         } else {
             openURLInNewTab(url, isPrivate: isPrivate)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1061,6 +1061,19 @@ class BrowserViewController: UIViewController {
             openURLInNewTab(url, isPrivate: isPrivate)
         }
     }
+    
+    func switchToTabForWidgetURLOrOpen(_ url: URL, isPrivate: Bool = false) {
+        guard !isCrashAlertShowing else {
+            urlFromAnotherApp = UrlToOpenModel(url: url, isPrivate: isPrivate)
+            return
+        }
+        popToBVC()
+        if let tab = tabManager.getTabForURL(url) {
+            tabManager.selectTab(tab)
+        } else {
+            openURLInNewTab(url, isPrivate: isPrivate)
+        }
+    }
 
     func openURLInNewTab(_ url: URL?, isPrivate: Bool = false) {
         if let selectedTab = tabManager.selectedTab {

--- a/Client/Frontend/Browser/SavedTab+ConfigureExtension.swift
+++ b/Client/Frontend/Browser/SavedTab+ConfigureExtension.swift
@@ -28,7 +28,7 @@ extension SavedTab {
             }
         }
         
-        self.init(screenshotUUID: tab.screenshotUUID, isSelected: isSelected, title: tab.title ?? tab.lastTitle, isPrivate: tab.isPrivate, faviconURL: tab.displayFavicon?.url, url: tab.url, sessionData: sessionData)
+        self.init(screenshotUUID: tab.screenshotUUID, isSelected: isSelected, title: tab.title ?? tab.lastTitle, isPrivate: tab.isPrivate, faviconURL: tab.displayFavicon?.url, url: tab.url, sessionData: sessionData, uuid: tab.tabUUID)
     }
     
     func configureSavedTabUsing(_ tab: Tab, imageStore: DiskImageStore? = nil) -> Tab {
@@ -53,7 +53,7 @@ extension SavedTab {
 
         tab.sessionData = sessionData
         tab.lastTitle = title
-
+        tab.tabUUID = UUID ?? ""
         return tab
     }
 }

--- a/Client/Frontend/Browser/SavedTab.swift
+++ b/Client/Frontend/Browser/SavedTab.swift
@@ -14,6 +14,7 @@ class SavedTab: NSObject, NSCoding {
     var sessionData: SessionData?
     var screenshotUUID: UUID?
     var faviconURL: String?
+    var UUID:String?
     
     var jsonDictionary: [String: AnyObject] {
         let title: String = self.title ?? "null"
@@ -26,7 +27,8 @@ class SavedTab: NSObject, NSCoding {
             "isSelected": String(self.isSelected) as AnyObject,
             "faviconURL": faviconURL as AnyObject,
             "screenshotUUID": uuid as AnyObject,
-            "url": url as AnyObject
+            "url": url as AnyObject,
+            "UUID": self.UUID as AnyObject
         ]
         
         if let sessionDataInfo = self.sessionData?.jsonDictionary {
@@ -36,7 +38,7 @@ class SavedTab: NSObject, NSCoding {
         return json
     }
     
-    init?(screenshotUUID: UUID?, isSelected: Bool, title: String?, isPrivate: Bool, faviconURL: String?, url: URL?, sessionData: SessionData?) {
+    init?(screenshotUUID: UUID?, isSelected: Bool, title: String?, isPrivate: Bool, faviconURL: String?, url: URL?, sessionData: SessionData?, uuid: String) {
 
         self.screenshotUUID = screenshotUUID
         self.isSelected = isSelected
@@ -45,6 +47,7 @@ class SavedTab: NSObject, NSCoding {
         self.faviconURL = faviconURL
         self.url = url
         self.sessionData = sessionData
+        self.UUID = uuid
         
         super.init()
     }
@@ -57,6 +60,7 @@ class SavedTab: NSObject, NSCoding {
         self.isPrivate = coder.decodeBool(forKey: "isPrivate")
         self.faviconURL = coder.decodeObject(forKey: "faviconURL") as? String
         self.url = coder.decodeObject(forKey: "url") as? URL
+        self.UUID = coder.decodeObject(forKey: "UUID") as? String
     }
     
     func encode(with coder: NSCoder) {
@@ -67,5 +71,6 @@ class SavedTab: NSObject, NSCoding {
         coder.encode(isPrivate, forKey: "isPrivate")
         coder.encode(faviconURL, forKey: "faviconURL")
         coder.encode(url, forKey: "url")
+        coder.encode(UUID, forKey: "UUID")
     }
 }

--- a/Client/Frontend/Browser/SiteArchiver.swift
+++ b/Client/Frontend/Browser/SiteArchiver.swift
@@ -7,11 +7,11 @@ import Sentry
 import Shared
 
 struct SiteArchiver {
-    static func tabsToRestore(tabsStateArchivePath: String?) -> [SavedTab] {
+    static func tabsToRestore(tabsStateArchivePath: String?) -> ([SavedTab], [SimpleTab]) {
         guard let tabStateArchivePath = tabsStateArchivePath,
               FileManager.default.fileExists(atPath: tabStateArchivePath),
               let tabData = try? Data(contentsOf: URL(fileURLWithPath: tabStateArchivePath)) else {
-            return [SavedTab]()
+            return ([SavedTab](), [SimpleTab]())
         }
         
         let unarchiver = NSKeyedUnarchiver(forReadingWith: tabData)
@@ -25,9 +25,12 @@ struct SiteArchiver {
                 tag: SentryTag.tabManager,
                 severity: .error,
                 description: "\(unarchiver.error ??? "nil")")
-            return [SavedTab]()
+            SimpleTab.saveSimpleTab(tabs: nil)
+            return ([SavedTab](), [SimpleTab]())
         }
         
-        return tabs
+        let simpleTabs = SimpleTab.convertedTabs(tabs)
+        SimpleTab.saveSimpleTab(tabs: simpleTabs.1)
+        return (tabs, simpleTabs.0)
     }
 }

--- a/Client/Frontend/Browser/SiteArchiver.swift
+++ b/Client/Frontend/Browser/SiteArchiver.swift
@@ -29,7 +29,7 @@ struct SiteArchiver {
             return ([SavedTab](), [SimpleTab]())
         }
         
-        let simpleTabs = SimpleTab.convertedTabs(tabs)
+        let simpleTabs = SimpleTab.convertToSimpleTabs(tabs)
         SimpleTab.saveSimpleTab(tabs: simpleTabs.1)
         return (tabs, simpleTabs.0)
     }

--- a/Client/Frontend/Browser/SiteArchiver.swift
+++ b/Client/Frontend/Browser/SiteArchiver.swift
@@ -6,31 +6,28 @@ import Foundation
 import Sentry
 import Shared
 
+// Struct that retrives saved tabs and simple tabs dictionary for WidgetKit
 struct SiteArchiver {
-    static func tabsToRestore(tabsStateArchivePath: String?) -> ([SavedTab], [SimpleTab]) {
+    static func tabsToRestore(tabsStateArchivePath: String?) -> ([SavedTab], [String: SimpleTab]) {
+        // Get simple tabs for widgetkit
+        let simpleTabsDict = SimpleTab.getSimpleTabs()
+        
         guard let tabStateArchivePath = tabsStateArchivePath,
               FileManager.default.fileExists(atPath: tabStateArchivePath),
               let tabData = try? Data(contentsOf: URL(fileURLWithPath: tabStateArchivePath)) else {
-            return ([SavedTab](), [SimpleTab]())
-        }
-        
-        do {
-            let unarchiver = try NSKeyedUnarchiver(forReadingFrom: tabData)
-            unarchiver.setClass(SavedTab.self, forClassName: "Client.SavedTab")
-            unarchiver.setClass(SessionData.self, forClassName: "Client.SessionData")
-            unarchiver.decodingFailurePolicy = .setErrorAndReturn
-            guard let tabs = unarchiver.decodeObject(forKey: "tabs") as? [SavedTab] else {
-                Sentry.shared.send( message: "Failed to restore tabs", tag: .tabManager, severity: .error, description: "\(unarchiver.error ??? "nil")")
-                SimpleTab.saveSimpleTab(tabs: nil)
-                return ([SavedTab](), [SimpleTab]())
-            }
-            let simpleTabs = SimpleTab.convertToSimpleTabs(tabs)
-            SimpleTab.saveSimpleTab(tabs: simpleTabs.1)
-            return (tabs, simpleTabs.0)
-        } catch {
-            Sentry.shared.send( message: "Failed to restore tabs", tag: .tabManager, severity: .error, description: "Unarchiver failure")
+            return ([SavedTab](), simpleTabsDict)
         }
 
-        return ([SavedTab](), [SimpleTab]())
+        let unarchiver = try NSKeyedUnarchiver(forReadingWith: tabData)
+        unarchiver.setClass(SavedTab.self, forClassName: "Client.SavedTab")
+        unarchiver.setClass(SessionData.self, forClassName: "Client.SessionData")
+        unarchiver.decodingFailurePolicy = .setErrorAndReturn
+        guard let tabs = unarchiver.decodeObject(forKey: "tabs") as? [SavedTab] else {
+            Sentry.shared.send( message: "Failed to restore tabs", tag: .tabManager, severity: .error, description: "\(unarchiver.error ??? "nil")")
+            SimpleTab.saveSimpleTab(tabs: nil)
+            return ([SavedTab](), simpleTabsDict)
+        }
+        
+        return (tabs, simpleTabsDict)
     }
 }

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -74,6 +74,7 @@ class Tab: NSObject {
     
     // Setting defualt page as topsites
     var newTabPageType: NewTabPage = .topSites
+    var tabUUID: String = UUID().uuidString
 
     // To check if current URL is the starting page i.e. either blank page or internal page like topsites
     var isURLStartingPage: Bool {

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -570,20 +570,12 @@ class TabManager: NSObject {
         return tabs.filter({ $0.webView?.url == url }).first
     }
     
-    func getTabForURL(_ url: URL, timestamp: Timestamp) -> Tab? {
+    func getTabForURL(_ url: URL, uuid: String) -> Tab? {
         assert(Thread.isMainThread)
-        let tabs1 = tabs.filter { tab -> Bool in
-            // check main url
-            tab.url == url && tab.lastExecutedTime == timestamp ||
-            tab.url == url && tab.sessionData?.lastUsedTime == timestamp ||
-            tab.sessionData?.urls.last == url && tab.lastExecutedTime == timestamp ||
-            tab.sessionData?.urls.last == url && tab.sessionData?.lastUsedTime == timestamp
-                
-//            tab.sessionData?.urls.last == url &&
-//            tab.sessionData?.lastUsedTime == timestamp
+        let filterdTabs = tabs.filter { tab -> Bool in
+            tab.tabUUID == uuid
         }
-        return tabs1.first
-//        return tabs.filter({ $0.webView?.url == url }).first
+        return filterdTabs.first
     }
 
     @objc func prefsDidChange() {

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -570,7 +570,7 @@ class TabManager: NSObject {
         return tabs.filter({ $0.webView?.url == url }).first
     }
     
-    func getTabForURL(_ url: URL, uuid: String) -> Tab? {
+    func getTabForUUID(uuid: String) -> Tab? {
         assert(Thread.isMainThread)
         let filterdTabs = tabs.filter { tab -> Bool in
             tab.tabUUID == uuid

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -569,6 +569,22 @@ class TabManager: NSObject {
         assert(Thread.isMainThread)
         return tabs.filter({ $0.webView?.url == url }).first
     }
+    
+    func getTabForURL(_ url: URL, timestamp: Timestamp) -> Tab? {
+        assert(Thread.isMainThread)
+        let tabs1 = tabs.filter { tab -> Bool in
+            // check main url
+            tab.url == url && tab.lastExecutedTime == timestamp ||
+            tab.url == url && tab.sessionData?.lastUsedTime == timestamp ||
+            tab.sessionData?.urls.last == url && tab.lastExecutedTime == timestamp ||
+            tab.sessionData?.urls.last == url && tab.sessionData?.lastUsedTime == timestamp
+                
+//            tab.sessionData?.urls.last == url &&
+//            tab.sessionData?.lastUsedTime == timestamp
+        }
+        return tabs1.first
+//        return tabs.filter({ $0.webView?.url == url }).first
+    }
 
     @objc func prefsDidChange() {
         DispatchQueue.main.async {

--- a/Client/Frontend/Browser/TabManagerStore.swift
+++ b/Client/Frontend/Browser/TabManagerStore.swift
@@ -82,11 +82,15 @@ class TabManagerStore {
 
         archiver.encode(savedTabs, forKey: "tabs")
         archiver.finishEncoding()
+        
+        let simpleTabs = SimpleTab.convertToSimpleTabs(savedTabs)
+        
 
         let result = Success()
         writeOperation = DispatchWorkItem {
             let written = tabStateData.write(toFile: path, atomically: true)
             
+            SimpleTab.saveSimpleTab(tabs: simpleTabs)
             // Ignore write failure (could be restoring).
             log.debug("PreserveTabs write ok: \(written), bytes: \(tabStateData.length)")
             result.fill(Maybe(success: ()))

--- a/Client/Frontend/Browser/TabManagerStore.swift
+++ b/Client/Frontend/Browser/TabManagerStore.swift
@@ -30,7 +30,7 @@ class TabManagerStore {
     }
 
     var hasTabsToRestoreAtStartup: Bool {
-        return archivedStartupTabs.count > 0
+        return archivedStartupTabs.0.count > 0
     }
 
     fileprivate func tabsStateArchivePath() -> String? {
@@ -99,7 +99,7 @@ class TabManagerStore {
     }
 
     func restoreStartupTabs(clearPrivateTabs: Bool, tabManager: TabManager) -> Tab? {
-        let selectedTab = restoreTabs(savedTabs: archivedStartupTabs, clearPrivateTabs: clearPrivateTabs, tabManager: tabManager)
+        let selectedTab = restoreTabs(savedTabs: archivedStartupTabs.0, clearPrivateTabs: clearPrivateTabs, tabManager: tabManager)
         return selectedTab
     }
 
@@ -145,6 +145,6 @@ class TabManagerStore {
 extension TabManagerStore {
     func testTabCountOnDisk() -> Int {
         assert(AppConstants.IsRunningTest)
-        return SiteArchiver.tabsToRestore(tabsStateArchivePath: tabsStateArchivePath()).count
+        return SiteArchiver.tabsToRestore(tabsStateArchivePath: tabsStateArchivePath()).0.count
     }
 }

--- a/Client/Frontend/Browser/TabManagerStore.swift
+++ b/Client/Frontend/Browser/TabManagerStore.swift
@@ -47,6 +47,7 @@ class TabManagerStore {
         var savedTabs = [SavedTab]()
         var savedUUIDs = Set<String>()
         for tab in tabs {
+            tab.tabUUID = tab.tabUUID.isEmpty ? UUID().uuidString : tab.tabUUID
             if let savedTab = SavedTab(tab: tab, isSelected: tab == selectedTab) {
                 savedTabs.append(savedTab)
                 if let screenshot = tab.screenshot,
@@ -121,7 +122,6 @@ class TabManagerStore {
             // Provide an empty request to prevent a new tab from loading the home screen
             var tab = tabManager.addTab(flushToDisk: false, zombie: true, isPrivate: savedTab.isPrivate)
             tab = savedTab.configureSavedTabUsing(tab, imageStore: imageStore)
-
             if savedTab.isSelected {
                 tabToSelect = tab
             }

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -7,7 +7,6 @@ import Foundation
 public struct PrefsKeys {
     // When this pref is set (by the user) it overrides default behaviour which is just based on app locale.
     public static let KeyEnableChinaSyncService = "useChinaSyncService"
-
     public static let KeyLastRemoteTabSyncTime = "lastRemoteTabSyncTime"
     public static let KeyLastSyncFinishTime = "lastSyncFinishTime"
     public static let KeyDefaultHomePageURL = "KeyDefaultHomePageURL"
@@ -28,10 +27,9 @@ public struct PrefsKeys {
     public static let KeyInstallSession = "installSessionNumber"
     public static let KeyETPCoverSheetShowType = "etpCoverSheetShowType"
     public static let ShowNewTabToolbarButton = "newTabToolbarButton"
-
     public static let ContextMenuShowLinkPreviews = "showLinkPreviews"
-
     public static let NewTabCustomUrlPrefKey = "HomePageURLPref"
+    
     //Activity Stream
     public static let KeyTopSitesCacheIsValid = "topSitesCacheIsValid"
     public static let KeyTopSitesCacheSize = "topSitesCacheSize"
@@ -40,7 +38,6 @@ public struct PrefsKeys {
     public static let ASRecentHighlightsVisible = "ASRecentHighlightsVisible"
     public static let ASBookmarkHighlightsVisible = "ASBookmarkHighlightsVisible"
     public static let ASLastInvalidation = "ASLastInvalidation"
-
     public static let KeyUseCustomSyncTokenServerOverride = "useCustomSyncTokenServerOverride"
     public static let KeyCustomSyncTokenServerOverride = "customSyncTokenServerOverride"
     public static let KeyUseCustomFxAContentServer = "useCustomFxAContentServer"
@@ -48,11 +45,12 @@ public struct PrefsKeys {
     public static let UseStageServer = "useStageSyncService"
     public static let KeyFxALastCommandIndex = "FxALastCommandIndex"
     public static let KeyFxAHandledCommands = "FxAHandledCommands"
-
     public static let AppExtensionTelemetryOpenUrl = "AppExtensionTelemetryOpenUrl"
     public static let AppExtensionTelemetryEventArray = "AppExtensionTelemetryEvents"
-
     public static let KeyBlockPopups = "blockPopups"
+    
+    // Widgetkit Key
+    public static let WidgetKitSimpleTabKey = "WidgetKitSimpleTabKey"
 }
 
 public struct PrefsDefaults {

--- a/WidgetKit/OpenTabs/OpenTabsWidget.swift
+++ b/WidgetKit/OpenTabs/OpenTabsWidget.swift
@@ -26,11 +26,11 @@ struct OpenTabsView: View {
     @Environment(\.widgetFamily) var widgetFamily
     
     @ViewBuilder
-    func lineItemForTab(_ tab: SimpleTabs) -> some View {
-        let url = tab.url //tab.sessionData!.urls.last!
+    func lineItemForTab(_ tab: SimpleTab) -> some View {
+//        let url = tab.url //tab.sessionData!.urls.last!
 
         VStack(alignment: .leading) {
-            Link(destination: linkToContainingApp("?url=\(url)&lastUsedTime=\(tab.lastUsedTime)", query: "open-url-widget")) {
+            Link(destination: linkToContainingApp("?uuid=\(tab.uuid)", query: "widget-open-url")) {
                 HStack(alignment: .center, spacing: 15) {
                     if (entry.favicons[tab.title!] != nil) {
                         (entry.favicons[tab.title!])!.resizable().frame(width: 16, height: 16)

--- a/WidgetKit/OpenTabs/OpenTabsWidget.swift
+++ b/WidgetKit/OpenTabs/OpenTabsWidget.swift
@@ -26,11 +26,11 @@ struct OpenTabsView: View {
     @Environment(\.widgetFamily) var widgetFamily
     
     @ViewBuilder
-    func lineItemForTab(_ tab: SavedTab) -> some View {
-        let url = tab.sessionData!.urls.last!
+    func lineItemForTab(_ tab: SimpleTabs) -> some View {
+        let url = tab.url //tab.sessionData!.urls.last!
 
         VStack(alignment: .leading) {
-            Link(destination: linkToContainingApp("?url=\(url)", query: "open-url")) {
+            Link(destination: linkToContainingApp("?url=\(url)&lastUsedTime=\(tab.lastUsedTime)", query: "open-url-widget")) {
                 HStack(alignment: .center, spacing: 15) {
                     if (entry.favicons[tab.title!] != nil) {
                         (entry.favicons[tab.title!])!.resizable().frame(width: 16, height: 16)

--- a/WidgetKit/OpenTabs/OpenTabsWidget.swift
+++ b/WidgetKit/OpenTabs/OpenTabsWidget.swift
@@ -29,7 +29,7 @@ struct OpenTabsView: View {
     func lineItemForTab(_ tab: SimpleTab) -> some View {
 
         VStack(alignment: .leading) {
-            Link(destination: linkToContainingApp("?lastUsedTime=\(tab.lastUsedTime ?? 0)", query: "widget-open-url")) {
+            Link(destination: linkToContainingApp("?uuid=\(tab.uuid)", query: "widget-open-url")) {
                 HStack(alignment: .center, spacing: 15) {
                     if (entry.favicons[tab.title!] != nil) {
                         (entry.favicons[tab.title!])!.resizable().frame(width: 16, height: 16)

--- a/WidgetKit/OpenTabs/OpenTabsWidget.swift
+++ b/WidgetKit/OpenTabs/OpenTabsWidget.swift
@@ -27,10 +27,9 @@ struct OpenTabsView: View {
     
     @ViewBuilder
     func lineItemForTab(_ tab: SimpleTab) -> some View {
-//        let url = tab.url //tab.sessionData!.urls.last!
 
         VStack(alignment: .leading) {
-            Link(destination: linkToContainingApp("?uuid=\(tab.uuid)", query: "widget-open-url")) {
+            Link(destination: linkToContainingApp("?lastUsedTime=\(tab.lastUsedTime ?? 0)", query: "widget-open-url")) {
                 HStack(alignment: .center, spacing: 15) {
                     if (entry.favicons[tab.title!] != nil) {
                         (entry.favicons[tab.title!])!.resizable().frame(width: 16, height: 16)

--- a/WidgetKit/OpenTabs/SimpleTab.swift
+++ b/WidgetKit/OpenTabs/SimpleTab.swift
@@ -12,7 +12,6 @@ struct SimpleTab: Hashable, Codable {
     var url: URL?
     let lastUsedTime: Timestamp? // From Session Data
     var faviconURL: String?
-    var uuid: String = ""
     var isPrivate: Bool = false
 }
 
@@ -85,12 +84,10 @@ extension SimpleTab {
             if title.isEmpty {
                 title = url?.shortDisplayString ?? ""
             }
-            
-            // An id for simple tab
-            let tempud = String(tab.sessionData?.lastUsedTime ?? 0)
-            let uuid = UUID().uuidString
-            let value = SimpleTab(title: title, url: url, lastUsedTime: tab.sessionData?.lastUsedTime ?? 0, faviconURL: tab.faviconURL, uuid: tempud, isPrivate: tab.isPrivate)
-            simpleTabs[tempud] = value
+    
+            let lastUsedTime = String(tab.sessionData?.lastUsedTime ?? 0)
+            let value = SimpleTab(title: title, url: url, lastUsedTime: tab.sessionData?.lastUsedTime ?? 0, faviconURL: tab.faviconURL, isPrivate: tab.isPrivate)
+            simpleTabs[lastUsedTime] = value
         }
 
         let arrayFromDic = Array(simpleTabs.values.map{ $0 })

--- a/WidgetKit/OpenTabs/SimpleTab.swift
+++ b/WidgetKit/OpenTabs/SimpleTab.swift
@@ -1,0 +1,52 @@
+//
+//  SimpleTab.swift
+//  Client
+//
+//  Created by Nishant Bhasin on 2020-10-30.
+//  Copyright © 2020 Mozilla. All rights reserved.
+//
+
+import Shared
+
+struct SimpleTab: Hashable, Codable {
+    var title: String?
+    var url: URL?
+    let lastUsedTime: Timestamp? // From Session Data
+    var faviconURL: String?
+    var uuid: String = ""
+}
+
+static func convertedTabs(_ tabs: [SavedTab]) -> ([SimpleTab], [String: SimpleTab]) {
+    var simpleTabs: [String: SimpleTab] = [:]
+    for tab in tabs {
+        var url:URL?
+        // Set URL
+        // Check if we have any url
+        if tab.url != nil {
+            url = tab.url
+        // Check if session data urls have something
+        } else if tab.sessionData?.urls != nil {
+            url = tab.sessionData?.urls.last
+        }
+        
+        // Ignore internal about urls which corresponds to Home
+        if url != nil, url!.absoluteString.starts(with: "internal://local/about/") {
+            continue
+        }
+        
+        // Set Title
+        var title = tab.title ?? ""
+        // There is no title then use the base url
+        if title.isEmpty {
+            title = url?.shortDisplayString ?? ""
+        }
+        
+        // An id for simple tab
+        let uuid = UUID().uuidString
+        let value = SimpleTab(title: title, url: url, lastUsedTime: tab.sessionData?.lastUsedTime ?? 0, faviconURL: tab.faviconURL, uuid: uuid)
+        simpleTabs[uuid] = value
+    }
+
+    let arrayFromDic = Array(simpleTabs.values.map{ $0 })
+    return (arrayFromDic, simpleTabs)
+}

--- a/WidgetKit/OpenTabs/SimpleTab.swift
+++ b/WidgetKit/OpenTabs/SimpleTab.swift
@@ -16,30 +16,11 @@ struct SimpleTab: Hashable, Codable {
 }
 
 extension SimpleTab {
-    static func compareTemp(dict: [String: SimpleTab]?, tab: SavedTab) -> Bool {
-        // case: nothing is saved
-        guard dict != nil else {
-            return false
-        }
-        
-        // case: dict is available lets check if it has a tab
-        for (_,v) in dict! {
-            if tab.sessionData?.lastUsedTime == v.lastUsedTime && tab.url == v.url {
-                return true
-            }
-        }
-        return false
-    }
-    
     static func getSimpleTabDict() -> [String: SimpleTab]? {
         if let tbs = userDefaults.object(forKey: PrefsKeys.WidgetKitSimpleTabKey) as? Data {
             do {
-                // Decode data to object
                 let jsonDecoder = JSONDecoder()
                 let tabs = try jsonDecoder.decode([String: SimpleTab].self, from: tbs)
-                tabs.forEach {
-                    print("key - \($0)\nValue - \($1)\n")
-                }
                 return tabs
             }
             catch {
@@ -60,7 +41,7 @@ extension SimpleTab {
         }
     }
     
-    static func convertedTabs(_ tabs: [SavedTab]) -> ([SimpleTab], [String: SimpleTab]) {
+    static func convertToSimpleTabs(_ tabs: [SavedTab]) -> ([SimpleTab], [String: SimpleTab]) {
         var simpleTabs: [String: SimpleTab] = [:]
         for tab in tabs {
             var url:URL?

--- a/WidgetKit/OpenTabs/SimpleTab.swift
+++ b/WidgetKit/OpenTabs/SimpleTab.swift
@@ -1,12 +1,11 @@
-//
-//  SimpleTab.swift
-//  Client
-//
-//  Created by Nishant Bhasin on 2020-10-30.
-//  Copyright © 2020 Mozilla. All rights reserved.
-//
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Shared
+
+let userDefaultsKey = "myTabKey1"
+let userDefaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!
 
 struct SimpleTab: Hashable, Codable {
     var title: String?
@@ -14,39 +13,89 @@ struct SimpleTab: Hashable, Codable {
     let lastUsedTime: Timestamp? // From Session Data
     var faviconURL: String?
     var uuid: String = ""
+    var isPrivate: Bool = false
 }
 
-static func convertedTabs(_ tabs: [SavedTab]) -> ([SimpleTab], [String: SimpleTab]) {
-    var simpleTabs: [String: SimpleTab] = [:]
-    for tab in tabs {
-        var url:URL?
-        // Set URL
-        // Check if we have any url
-        if tab.url != nil {
-            url = tab.url
-        // Check if session data urls have something
-        } else if tab.sessionData?.urls != nil {
-            url = tab.sessionData?.urls.last
+extension SimpleTab {
+    static func compareTemp(dict: [String: SimpleTab]?, tab: SavedTab) -> Bool {
+        // case: nothing is saved
+        guard dict != nil else {
+            return false
         }
         
-        // Ignore internal about urls which corresponds to Home
-        if url != nil, url!.absoluteString.starts(with: "internal://local/about/") {
-            continue
+        // case: dict is available lets check if it has a tab
+        for (_,v) in dict! {
+            if tab.sessionData?.lastUsedTime == v.lastUsedTime && tab.url == v.url {
+                return true
+            }
         }
-        
-        // Set Title
-        var title = tab.title ?? ""
-        // There is no title then use the base url
-        if title.isEmpty {
-            title = url?.shortDisplayString ?? ""
-        }
-        
-        // An id for simple tab
-        let uuid = UUID().uuidString
-        let value = SimpleTab(title: title, url: url, lastUsedTime: tab.sessionData?.lastUsedTime ?? 0, faviconURL: tab.faviconURL, uuid: uuid)
-        simpleTabs[uuid] = value
+        return false
     }
+    
+    static func getSimpleTabDict() -> [String: SimpleTab]? {
+        if let tbs = userDefaults.object(forKey: userDefaultsKey) as? Data {
+            do {
+                // Decode data to object
+                let jsonDecoder = JSONDecoder()
+                let tabs = try jsonDecoder.decode([String: SimpleTab].self, from: tbs)
+                tabs.forEach {
+                    print("key - \($0)\nValue - \($1)\n")
+                }
+                return tabs
+            }
+            catch {
+                print("Error occured")
+            }
+        }
+        return nil
+    }
+    
+    static func saveSimpleTab(tabs:[String: SimpleTab]?) {
+        guard let tabs = tabs, !tabs.isEmpty else {
+            userDefaults.removeObject(forKey: userDefaultsKey)
+            return
+        }
+        let encoder = JSONEncoder()
+        if let encoded = try? encoder.encode(tabs) {
+            userDefaults.set(encoded, forKey: userDefaultsKey)
+        }
+    }
+    
+    static func convertedTabs(_ tabs: [SavedTab]) -> ([SimpleTab], [String: SimpleTab]) {
+        var simpleTabs: [String: SimpleTab] = [:]
+        for tab in tabs {
+            var url:URL?
+            // Set URL
+            // Check if we have any url
+            if tab.url != nil {
+                url = tab.url
+            // Check if session data urls have something
+            } else if tab.sessionData?.urls != nil {
+                url = tab.sessionData?.urls.last
+            }
+            
+            // Ignore internal about urls which corresponds to Home
+            if url != nil, url!.absoluteString.starts(with: "internal://local/about/") {
+                continue
+            }
+            
+            // Set Title
+            var title = tab.title ?? ""
+            // There is no title then use the base url
+            if title.isEmpty {
+                title = url?.shortDisplayString ?? ""
+            }
+            
+            // An id for simple tab
+            let tempud = String(tab.sessionData?.lastUsedTime ?? 0)
+            let uuid = UUID().uuidString
+            let value = SimpleTab(title: title, url: url, lastUsedTime: tab.sessionData?.lastUsedTime ?? 0, faviconURL: tab.faviconURL, uuid: tempud, isPrivate: tab.isPrivate)
+            simpleTabs[tempud] = value
+        }
 
-    let arrayFromDic = Array(simpleTabs.values.map{ $0 })
-    return (arrayFromDic, simpleTabs)
+        let arrayFromDic = Array(simpleTabs.values.map{ $0 })
+        return (arrayFromDic, simpleTabs)
+    }
 }
+
+

--- a/WidgetKit/OpenTabs/SimpleTab.swift
+++ b/WidgetKit/OpenTabs/SimpleTab.swift
@@ -16,7 +16,7 @@ struct SimpleTab: Hashable, Codable {
 }
 
 extension SimpleTab {
-    static func getSimpleTabDict() -> [String: SimpleTab]? {
+    static func getSimpleTabs() -> [String: SimpleTab] {
         if let tbs = userDefaults.object(forKey: PrefsKeys.WidgetKitSimpleTabKey) as? Data {
             do {
                 let jsonDecoder = JSONDecoder()
@@ -27,7 +27,7 @@ extension SimpleTab {
                 print("Error occured")
             }
         }
-        return nil
+        return [String: SimpleTab]()
     }
     
     static func saveSimpleTab(tabs:[String: SimpleTab]?) {
@@ -41,12 +41,11 @@ extension SimpleTab {
         }
     }
     
-    static func convertToSimpleTabs(_ tabs: [SavedTab]) -> ([SimpleTab], [String: SimpleTab]) {
+    static func convertToSimpleTabs(_ tabs: [SavedTab]) -> [String: SimpleTab] {
         var simpleTabs: [String: SimpleTab] = [:]
         for tab in tabs {
             var url:URL?
             // Set URL
-            // Check if we have any url
             if tab.url != nil {
                 url = tab.url
             // Check if session data urls have something
@@ -54,25 +53,24 @@ extension SimpleTab {
                 url = tab.sessionData?.urls.last
             }
             
-            // Ignore internal about urls which corresponds to Home
+            // Ignore `internal about` urls which corresponds to Home
             if url != nil, url!.absoluteString.starts(with: "internal://local/about/") {
                 continue
             }
             
             // Set Title
             var title = tab.title ?? ""
-            // There is no title then use the base url
+            // There is no title then use the base url Ex https://www.mozilla.org/ will be short displayed as `mozilla`
             if title.isEmpty {
                 title = url?.shortDisplayString ?? ""
             }
-    
+            
+            // Key for simple tabs dictionary is tab UUID which is used to select proper tab when we send UUID to NavigationRouter class handle widget url
             let uuidVal = tab.UUID ?? ""
             let value = SimpleTab(title: title, url: url, lastUsedTime: tab.sessionData?.lastUsedTime ?? 0, faviconURL: tab.faviconURL, isPrivate: tab.isPrivate, uuid: uuidVal)
             simpleTabs[uuidVal] = value
         }
-
-        let arrayFromDic = Array(simpleTabs.values.map{ $0 })
-        return (arrayFromDic, simpleTabs)
+        return simpleTabs
     }
 }
 

--- a/WidgetKit/OpenTabs/SimpleTab.swift
+++ b/WidgetKit/OpenTabs/SimpleTab.swift
@@ -4,7 +4,6 @@
 
 import Shared
 
-let userDefaultsKey = "myTabKey1"
 let userDefaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!
 
 struct SimpleTab: Hashable, Codable {
@@ -13,6 +12,7 @@ struct SimpleTab: Hashable, Codable {
     let lastUsedTime: Timestamp? // From Session Data
     var faviconURL: String?
     var isPrivate: Bool = false
+    var uuid: String = ""
 }
 
 extension SimpleTab {
@@ -32,7 +32,7 @@ extension SimpleTab {
     }
     
     static func getSimpleTabDict() -> [String: SimpleTab]? {
-        if let tbs = userDefaults.object(forKey: userDefaultsKey) as? Data {
+        if let tbs = userDefaults.object(forKey: PrefsKeys.WidgetKitSimpleTabKey) as? Data {
             do {
                 // Decode data to object
                 let jsonDecoder = JSONDecoder()
@@ -51,12 +51,12 @@ extension SimpleTab {
     
     static func saveSimpleTab(tabs:[String: SimpleTab]?) {
         guard let tabs = tabs, !tabs.isEmpty else {
-            userDefaults.removeObject(forKey: userDefaultsKey)
+            userDefaults.removeObject(forKey: PrefsKeys.WidgetKitSimpleTabKey)
             return
         }
         let encoder = JSONEncoder()
         if let encoded = try? encoder.encode(tabs) {
-            userDefaults.set(encoded, forKey: userDefaultsKey)
+            userDefaults.set(encoded, forKey: PrefsKeys.WidgetKitSimpleTabKey)
         }
     }
     
@@ -85,9 +85,9 @@ extension SimpleTab {
                 title = url?.shortDisplayString ?? ""
             }
     
-            let lastUsedTime = String(tab.sessionData?.lastUsedTime ?? 0)
-            let value = SimpleTab(title: title, url: url, lastUsedTime: tab.sessionData?.lastUsedTime ?? 0, faviconURL: tab.faviconURL, isPrivate: tab.isPrivate)
-            simpleTabs[lastUsedTime] = value
+            let uuidVal = tab.UUID ?? ""
+            let value = SimpleTab(title: title, url: url, lastUsedTime: tab.sessionData?.lastUsedTime ?? 0, faviconURL: tab.faviconURL, isPrivate: tab.isPrivate, uuid: uuidVal)
+            simpleTabs[uuidVal] = value
         }
 
         let arrayFromDic = Array(simpleTabs.values.map{ $0 })

--- a/WidgetKit/OpenTabs/TabProvider.swift
+++ b/WidgetKit/OpenTabs/TabProvider.swift
@@ -7,129 +7,30 @@ import WidgetKit
 import UIKit
 import Combine
 
-//struct SimpleTabs: Hashable {
-//    var title: String?
-//    var url: URL?
-//    let lastUsedTime: Timestamp // From Session Data
-//    var faviconURL: String?
-//    var savedTab: SavedTab
-//
-//    static func convertedTabs(_ tabs: [SavedTab]) -> [SimpleTabs] {
-//        var simpleTabs = [SimpleTabs]()
-//        for tab in tabs {
-//            var url:URL?
-//            // Check if we have any url
-//            if tab.url != nil {
-//                url = tab.url
-//              // Check if session data urls have something
-//            } else if tab.sessionData?.urls != nil {
-//                url = tab.sessionData?.urls.last
-//            }
-//
-//            if url != nil, url!.absoluteString.starts(with: "internal://local/about/") {
-//                continue
-//            }
-//
-//            var title = tab.title ?? ""
-//            // There is no title then use the base
-//            if title.isEmpty {
-//                title = url?.shortDisplayString ?? ""
-//            }
-//
-//            let value = SimpleTabs(title: title, url: url, lastUsedTime: tab.sessionData?.lastUsedTime ?? 0, faviconURL: tab.faviconURL, savedTab: tab)
-//            simpleTabs.append(value)
-//        }
-//
-//        return simpleTabs
-//    }
-//}
-
-
-let userDefaultsKey = "myTabKey1"
-let userDefaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!
-var tabsDict: [String: SimpleTab] = [:]
-func saveSimpleTab(tabs:[String: SimpleTab]) {
-//    userDefaults.setValue(tabs, forKey: userDefaultsKey)
-    let encoder = JSONEncoder()
-    if let encoded = try? encoder.encode(tabs) {
-        userDefaults.set(encoded, forKey: userDefaultsKey)
-    }
-//    userDefaults.set(tabs, forKey: userDefaultsKey)
-}
 struct TabProvider: TimelineProvider {
     public typealias Entry = OpenTabsEntry
+    var tabsDict: [String: SimpleTab] = [:]
     
     func placeholder(in context: Context) -> OpenTabsEntry {
         OpenTabsEntry(date: Date(), favicons: [String: Image](), tabs: [])
     }
     
     func getSnapshot(in context: Context, completion: @escaping (OpenTabsEntry) -> Void) {
-        let allOpenTabs = SiteArchiver.tabsToRestore(tabsStateArchivePath: tabsStateArchivePath())
-//        let openTabs = allOpenTabs.filter {
-//            !$0.isPrivate
-////            !$0.isPrivate &&
-////            $0.sessionData != nil &&
-////            $0.url?.absoluteString.starts(with: "internal://") == false &&
-////            $0.title != nil
-//        }
+        let allOpenTabs = SiteArchiver.tabsToRestore(tabsStateArchivePath: tabsStateArchivePath()).1
         
         let openTabs = allOpenTabs.filter {
             !$0.isPrivate
         }
         
-        let tabsList = convertedTabs(openTabs)
+//        let convertedTabs = SimpleTab.convertedTabs(openTabs)
+//        let convertedTabsArray = convertedTabs.0
+//        let convertedTabsDict = convertedTabs.1
+//        SimpleTab.saveSimpleTab(tabs: convertedTabsDict)
         
-        saveSimpleTab(tabs: tabsDict)
-        // Debug ----
-//        let dictionary = ["name": "Adam"]
-//
-//        // Save to User Defaults
-//        userDefaults.set(dictionary, forKey: "ayy")
-//
-//        // Read from User Defaults
-//        let saved = userDefaults.value(forKey: "ayy") as? [String: String]
-//
-//        userDefaults.setValue("Hello", forKey: "Hello")
-//
-//        let ta1 = SimpleTab(title: "temp", url: nil, lastUsedTime: nil, faviconURL: nil, uuid: "0")
-//
-////        UserDefaults.standard.set(try? ta1().encode(value), forKey: key)
-////        userDefaults.set(ta3, forKey: "ayy7")
-//
-//        let encoder = JSONEncoder()
-//        if let encoded = try? encoder.encode(ta1) {
-//            userDefaults.set(encoded, forKey: "ayy8")
-//        }
-//
-//        if let tbs = userDefaults.object(forKey: "ayy8") as? Data {
-//            let decoder = JSONDecoder()
-//            if let tbs = try? decoder.decode(SimpleTab.self, from: tbs) as SimpleTab {
-//                print(tbs.title)
-//            }
-//        }
-//
-////        userDefaults.set(ta3, forKey: "ayy5")
-////        let ta2 = SimpleTab(title: "temp1", url: nil, lastUsedTime: nil, faviconURL: nil, uuid: "1")
-////        let ta3 = SimpleTab(title: "temp2", url: nil, lastUsedTime: nil, faviconURL: nil, uuid: "2")
-////        let ta4 = SimpleTab(title: "temp3", url: nil, lastUsedTime: nil, faviconURL: nil, uuid: "3")
-////
-//        var tabsd: [String: SimpleTab] = [:]
-//        tabsd["1"] = ta1
-////        tabsd["2"] = ta2
-////        tabsd["3"] = ta3
-////        tabsd["4"] = ta4
-//
-//        // Save to User Defaults
-////        userDefaults.set(tabsd, forKey: "ayy1")
-//
-//
-////        let saved2 = userDefaults.value(forKey: "ayy1") as? [String: SimpleTab]
-//
-//        // Debug ^^^^
         let faviconFetchGroup = DispatchGroup()
         
         var tabFaviconDictionary = [String : Image]()
-        for tab in tabsList {
+        for tab in openTabs {
             faviconFetchGroup.enter()
             if let faviconURL = tab.faviconURL {
                 getImageForUrl(URL(string: faviconURL)!, completion: { image in
@@ -145,7 +46,7 @@ struct TabProvider: TimelineProvider {
         }
         
         faviconFetchGroup.notify(queue: .main) {
-            let openTabsEntry = OpenTabsEntry(date: Date(), favicons: tabFaviconDictionary, tabs: tabsList)
+            let openTabsEntry = OpenTabsEntry(date: Date(), favicons: tabFaviconDictionary, tabs: openTabs)
             completion(openTabsEntry)
         }
     }
@@ -162,42 +63,6 @@ struct TabProvider: TimelineProvider {
         profilePath = FileManager.default.containerURL( forSecurityApplicationGroupIdentifier: AppInfo.sharedContainerIdentifier)?.appendingPathComponent("profile.profile").path
         guard let path = profilePath else { return nil }
         return URL(fileURLWithPath: path).appendingPathComponent("tabsState.archive").path
-    }
-
-    func convertedTabs(_ tabs: [SavedTab]) -> [SimpleTab] {
-//        var simpleTabs = [SimpleTab]()
-//        let uuid = UUID().uuidString
-        var simpleTabs: [String: SimpleTab] = [:]
-        for tab in tabs {
-            var url:URL?
-            // Check if we have any url
-            if tab.url != nil {
-                url = tab.url
-              // Check if session data urls have something
-            } else if tab.sessionData?.urls != nil {
-                url = tab.sessionData?.urls.last
-            }
-            
-            if url != nil, url!.absoluteString.starts(with: "internal://local/about/") {
-                continue
-            }
-            
-            var title = tab.title ?? ""
-            // There is no title then use the base
-            if title.isEmpty {
-                title = url?.shortDisplayString ?? ""
-            }
-            let uuid = UUID().uuidString
-            let value = SimpleTab(title: title, url: url, lastUsedTime: tab.sessionData?.lastUsedTime ?? 0, faviconURL: tab.faviconURL, uuid: uuid)
-            simpleTabs[uuid] = value
-
-//            simpleTabs.append(value)
-        }
-        tabsDict = simpleTabs
-//        saveSimpleTab(tabs: simpleTabs)
-        // save tabs
-        let arrayFromDic = Array(simpleTabs.values.map{ $0 })
-        return arrayFromDic
     }
 }
 

--- a/WidgetKit/OpenTabs/TabProvider.swift
+++ b/WidgetKit/OpenTabs/TabProvider.swift
@@ -7,45 +7,58 @@ import WidgetKit
 import UIKit
 import Combine
 
-struct SimpleTabs: Hashable {
-    var title: String?
-    var url: URL?
-    let lastUsedTime: Timestamp? // From Session Data
-    var faviconURL: String?
-    
-    static func convertedTabs(_ tabs: [SavedTab]) -> [SimpleTabs] {
-        var simpleTabs = [SimpleTabs]()
-        for tab in tabs {
-            var url:URL?
-            // Check if we have any url
-            if tab.url != nil {
-                url = tab.url
-              // Check if session data urls have something
-            } else if tab.sessionData?.urls != nil {
-                url = tab.sessionData?.urls.last
-            }
-            
-            if url != nil, url!.absoluteString.starts(with: "internal://local/about/") {
-                continue
-            }
-            
-            var title = tab.title ?? ""
-            // There is no title then use the base
-            if title.isEmpty {
-                title = url?.shortDisplayString ?? ""
-            }
-            
-            let value = SimpleTabs(title: title, url: url, lastUsedTime: tab.sessionData?.lastUsedTime, faviconURL: tab.faviconURL)
-            simpleTabs.append(value)
-        }
-        
-        return simpleTabs
-    }
-}
+//struct SimpleTabs: Hashable {
+//    var title: String?
+//    var url: URL?
+//    let lastUsedTime: Timestamp // From Session Data
+//    var faviconURL: String?
+//    var savedTab: SavedTab
+//
+//    static func convertedTabs(_ tabs: [SavedTab]) -> [SimpleTabs] {
+//        var simpleTabs = [SimpleTabs]()
+//        for tab in tabs {
+//            var url:URL?
+//            // Check if we have any url
+//            if tab.url != nil {
+//                url = tab.url
+//              // Check if session data urls have something
+//            } else if tab.sessionData?.urls != nil {
+//                url = tab.sessionData?.urls.last
+//            }
+//
+//            if url != nil, url!.absoluteString.starts(with: "internal://local/about/") {
+//                continue
+//            }
+//
+//            var title = tab.title ?? ""
+//            // There is no title then use the base
+//            if title.isEmpty {
+//                title = url?.shortDisplayString ?? ""
+//            }
+//
+//            let value = SimpleTabs(title: title, url: url, lastUsedTime: tab.sessionData?.lastUsedTime ?? 0, faviconURL: tab.faviconURL, savedTab: tab)
+//            simpleTabs.append(value)
+//        }
+//
+//        return simpleTabs
+//    }
+//}
 
+
+let userDefaultsKey = "myTabKey1"
+let userDefaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!
+var tabsDict: [String: SimpleTab] = [:]
+func saveSimpleTab(tabs:[String: SimpleTab]) {
+//    userDefaults.setValue(tabs, forKey: userDefaultsKey)
+    let encoder = JSONEncoder()
+    if let encoded = try? encoder.encode(tabs) {
+        userDefaults.set(encoded, forKey: userDefaultsKey)
+    }
+//    userDefaults.set(tabs, forKey: userDefaultsKey)
+}
 struct TabProvider: TimelineProvider {
     public typealias Entry = OpenTabsEntry
-
+    
     func placeholder(in context: Context) -> OpenTabsEntry {
         OpenTabsEntry(date: Date(), favicons: [String: Image](), tabs: [])
     }
@@ -63,8 +76,56 @@ struct TabProvider: TimelineProvider {
         let openTabs = allOpenTabs.filter {
             !$0.isPrivate
         }
-        let tabsList = SimpleTabs.convertedTabs(openTabs)
         
+        let tabsList = convertedTabs(openTabs)
+        
+        saveSimpleTab(tabs: tabsDict)
+        // Debug ----
+//        let dictionary = ["name": "Adam"]
+//
+//        // Save to User Defaults
+//        userDefaults.set(dictionary, forKey: "ayy")
+//
+//        // Read from User Defaults
+//        let saved = userDefaults.value(forKey: "ayy") as? [String: String]
+//
+//        userDefaults.setValue("Hello", forKey: "Hello")
+//
+//        let ta1 = SimpleTab(title: "temp", url: nil, lastUsedTime: nil, faviconURL: nil, uuid: "0")
+//
+////        UserDefaults.standard.set(try? ta1().encode(value), forKey: key)
+////        userDefaults.set(ta3, forKey: "ayy7")
+//
+//        let encoder = JSONEncoder()
+//        if let encoded = try? encoder.encode(ta1) {
+//            userDefaults.set(encoded, forKey: "ayy8")
+//        }
+//
+//        if let tbs = userDefaults.object(forKey: "ayy8") as? Data {
+//            let decoder = JSONDecoder()
+//            if let tbs = try? decoder.decode(SimpleTab.self, from: tbs) as SimpleTab {
+//                print(tbs.title)
+//            }
+//        }
+//
+////        userDefaults.set(ta3, forKey: "ayy5")
+////        let ta2 = SimpleTab(title: "temp1", url: nil, lastUsedTime: nil, faviconURL: nil, uuid: "1")
+////        let ta3 = SimpleTab(title: "temp2", url: nil, lastUsedTime: nil, faviconURL: nil, uuid: "2")
+////        let ta4 = SimpleTab(title: "temp3", url: nil, lastUsedTime: nil, faviconURL: nil, uuid: "3")
+////
+//        var tabsd: [String: SimpleTab] = [:]
+//        tabsd["1"] = ta1
+////        tabsd["2"] = ta2
+////        tabsd["3"] = ta3
+////        tabsd["4"] = ta4
+//
+//        // Save to User Defaults
+////        userDefaults.set(tabsd, forKey: "ayy1")
+//
+//
+////        let saved2 = userDefaults.value(forKey: "ayy1") as? [String: SimpleTab]
+//
+//        // Debug ^^^^
         let faviconFetchGroup = DispatchGroup()
         
         var tabFaviconDictionary = [String : Image]()
@@ -75,7 +136,7 @@ struct TabProvider: TimelineProvider {
                     if image != nil {
                         tabFaviconDictionary[tab.title!] = image
                     }
-                    
+
                     faviconFetchGroup.leave()
                 })
             } else {
@@ -102,10 +163,47 @@ struct TabProvider: TimelineProvider {
         guard let path = profilePath else { return nil }
         return URL(fileURLWithPath: path).appendingPathComponent("tabsState.archive").path
     }
+
+    func convertedTabs(_ tabs: [SavedTab]) -> [SimpleTab] {
+//        var simpleTabs = [SimpleTab]()
+//        let uuid = UUID().uuidString
+        var simpleTabs: [String: SimpleTab] = [:]
+        for tab in tabs {
+            var url:URL?
+            // Check if we have any url
+            if tab.url != nil {
+                url = tab.url
+              // Check if session data urls have something
+            } else if tab.sessionData?.urls != nil {
+                url = tab.sessionData?.urls.last
+            }
+            
+            if url != nil, url!.absoluteString.starts(with: "internal://local/about/") {
+                continue
+            }
+            
+            var title = tab.title ?? ""
+            // There is no title then use the base
+            if title.isEmpty {
+                title = url?.shortDisplayString ?? ""
+            }
+            let uuid = UUID().uuidString
+            let value = SimpleTab(title: title, url: url, lastUsedTime: tab.sessionData?.lastUsedTime ?? 0, faviconURL: tab.faviconURL, uuid: uuid)
+            simpleTabs[uuid] = value
+
+//            simpleTabs.append(value)
+        }
+        tabsDict = simpleTabs
+//        saveSimpleTab(tabs: simpleTabs)
+        // save tabs
+        let arrayFromDic = Array(simpleTabs.values.map{ $0 })
+        return arrayFromDic
+    }
 }
+
 
 struct OpenTabsEntry: TimelineEntry {
     let date: Date
     let favicons: [String : Image]
-    let tabs: [SimpleTabs]
+    let tabs: [SimpleTab]
 }

--- a/WidgetKit/OpenTabs/TabProvider.swift
+++ b/WidgetKit/OpenTabs/TabProvider.swift
@@ -18,7 +18,7 @@ struct TabProvider: TimelineProvider {
     func getSnapshot(in context: Context, completion: @escaping (OpenTabsEntry) -> Void) {
         let allOpenTabs = SiteArchiver.tabsToRestore(tabsStateArchivePath: tabsStateArchivePath()).1
 
-        let openTabs = allOpenTabs.filter {
+        let openTabs = allOpenTabs.values.filter {
             !$0.isPrivate
         }
 

--- a/WidgetKit/OpenTabs/TabProvider.swift
+++ b/WidgetKit/OpenTabs/TabProvider.swift
@@ -17,11 +17,11 @@ struct TabProvider: TimelineProvider {
     
     func getSnapshot(in context: Context, completion: @escaping (OpenTabsEntry) -> Void) {
         let allOpenTabs = SiteArchiver.tabsToRestore(tabsStateArchivePath: tabsStateArchivePath()).1
-        
+
         let openTabs = allOpenTabs.filter {
             !$0.isPrivate
         }
-        
+
         let faviconFetchGroup = DispatchGroup()
         
         var tabFaviconDictionary = [String : Image]()
@@ -32,7 +32,6 @@ struct TabProvider: TimelineProvider {
                     if image != nil {
                         tabFaviconDictionary[tab.title!] = image
                     }
-
                     faviconFetchGroup.leave()
                 })
             } else {
@@ -60,7 +59,6 @@ struct TabProvider: TimelineProvider {
         return URL(fileURLWithPath: path).appendingPathComponent("tabsState.archive").path
     }
 }
-
 
 struct OpenTabsEntry: TimelineEntry {
     let date: Date

--- a/WidgetKit/OpenTabs/TabProvider.swift
+++ b/WidgetKit/OpenTabs/TabProvider.swift
@@ -22,11 +22,6 @@ struct TabProvider: TimelineProvider {
             !$0.isPrivate
         }
         
-//        let convertedTabs = SimpleTab.convertedTabs(openTabs)
-//        let convertedTabsArray = convertedTabs.0
-//        let convertedTabsDict = convertedTabs.1
-//        SimpleTab.saveSimpleTab(tabs: convertedTabsDict)
-        
         let faviconFetchGroup = DispatchGroup()
         
         var tabFaviconDictionary = [String : Image]()


### PR DESCRIPTION
Fixes #7431

Slightly changed mechanism on how we get tab data to and from widgetkit. 

**Before**
Previously we were using `SavedTab` array to loop through and find proper tabs to show in widgetkit. When user tapped on a list item on Open Tabs Widget we would send url via deeplink. This works but not all the time. Reason being the url being sent via deeplink would open new tab and not switch to currently opened tab as either session url / tab url was nil during comparison.

**After**
Solution: Save `SimpleTab` data in shared `UserDefaults` between widgetkit and client app. Also, add a UUID tag to each tab so instead of searching for url we search for exact UUID for that particular tab to open. 

**Flow**
ClientApp -> Saves `SimpleTab` data when `preserveTabs` gets called
Widgetkit -> Gets `SimpleTab` data when timeline needs any update and update Open Tabs Row
Tap Open Tabs Row -> Sends deeplink to client app with only tab UUID to find and select particular tab 

*TabUUID is generated when tab is selected and also gets set during `preserveTabs` state incase some old tabs didn't have TabUUID.  

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1170)

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1170)
