### PR TITLE
FXIOS-1189 ⁃ For #6933 - Adds FxA device id to the deletion ping

### DIFF
--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -157,7 +157,8 @@ class TelemetryWrapper {
 
         // Get the FxA device id and record it in Glean for the deletion-request ping
         profile.getCachedClients().upon { maybeClient in
-            guard let deviceId = maybeClient.successValue?.first?.fxaDeviceId else { return }
+            guard
+                let deviceId = maybeClient.successValue?.first?.fxaDeviceId.flatMap(UUID.init(uuidString:)) else { return }
             GleanMetrics.Deletion.fxaDeviceId.set(deviceId)
         }
 

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -155,6 +155,12 @@ class TelemetryWrapper {
         // Save the profile so we can record settings from it when the notification below fires.
         self.profile = profile
 
+        // Get the FxA device id and record it in Glean for the deletion-request ping
+        profile.getCachedClients().upon { maybeClient in
+            guard let deviceId = maybeClient.successValue?.first?.fxaDeviceId else { return }
+            GleanMetrics.Deletion.fxaDeviceId.set(deviceId)
+        }
+
         // Register an observer to record settings and other metrics that are more appropriate to
         // record on going to background rather than during initialization.
         NotificationCenter.default.addObserver(

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -597,3 +597,19 @@ legacy.ids:
     notification_emails:
       - firefox-ios@mozilla.com
     expires: never
+
+deletion:
+  fxa_device_id:
+    type: string
+    lifetime: user
+    description: |
+      The FxA device id.
+    send_in_pings:
+      - deletion-request
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/6933
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/7629#issuecomment-723312428
+    notification_emails:
+      - firefox-ios@mozilla.com
+    expires: never

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -600,7 +600,7 @@ legacy.ids:
 
 deletion:
   fxa_device_id:
-    type: string
+    type: uuid
     lifetime: user
     description: |
       The FxA device id.

--- a/Docs/metrics.md
+++ b/Docs/metrics.md
@@ -22,6 +22,7 @@ The following metrics are added to the ping:
 
 | Name | Type | Description | Data reviews | Extras | Expiration | [Data Sensitivity](https://wiki.mozilla.org/Firefox/Data_Collection) |
 | --- | --- | --- | --- | --- | --- | --- |
+| deletion.fxa_device_id |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The FxA device id.  |[1](TBD)||never | |
 | legacy.ids.client_id |[uuid](https://mozilla.github.io/glean/book/user/metrics/uuid.html) |The client id from legacy telemetry.  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1635427)||never | |
 
 ## events


### PR DESCRIPTION


┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1189)
