### PR TITLE
FXIOS-1194 ⁃ Fix landscape simulator issue on BR

### DIFF
--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -33,6 +33,7 @@ class ActivityStreamTest: BaseTestCase {
     }
 
     override func tearDown() {
+        XCUIDevice.shared.orientation = .portrait
         super.tearDown()
     }
 
@@ -350,6 +351,7 @@ class ActivityStreamTest: BaseTestCase {
     func testContextMenuInLandscape() {
         XCUIDevice.shared.orientation = .landscapeLeft
 
+        waitForExistence(TopSiteCellgroup.cells["apple"], timeout: 5)
         TopSiteCellgroup.cells["apple"].press(forDuration: 1)
 
         let contextMenuHeight = app.tables["Context Menu"].frame.size.height


### PR DESCRIPTION
Some tests are failing on BR because looks like they are running on landscape and they should not...one test that runs on landscape fails and it does not return the sims to portrait. Trying to fix that with this PR

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1194)
