### PR TITLE
FXIOS-1220 ⁃ Fixes #6933: Added a follow-up commit to send hashed device id to glean deletion ping

### DIFF
--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -5,6 +5,8 @@
 import MozillaAppServices
 import Shared
 import Telemetry
+import Account
+import Sync
 
 class TelemetryWrapper {
     let legacyTelemetry = Telemetry.default
@@ -155,13 +157,8 @@ class TelemetryWrapper {
         // Save the profile so we can record settings from it when the notification below fires.
         self.profile = profile
 
-        // Get the FxA device id and record it in Glean for the deletion-request ping
-        profile.getCachedClients().upon { maybeClient in
-            guard
-                let deviceId = maybeClient.successValue?.first?.fxaDeviceId.flatMap(UUID.init(uuidString:)) else { return }
-            GleanMetrics.Deletion.fxaDeviceId.set(deviceId)
-        }
-
+        sendFxADeletionPing()
+        
         // Register an observer to record settings and other metrics that are more appropriate to
         // record on going to background rather than during initialization.
         NotificationCenter.default.addObserver(
@@ -170,6 +167,18 @@ class TelemetryWrapper {
             name: UIApplication.didEnterBackgroundNotification,
             object: nil
         )
+    }
+    
+    func sendFxADeletionPing() {
+        guard let prefs = profile?.prefs else { return }
+        // Grab our token so we can use the hashed_fxa_uid and clientGUID from our scratchpad for deletion-request ping
+        RustFirefoxAccounts.shared.syncAuthState.token(Date.now(), canBeExpired: false) >>== { (token, kSync) in
+            let scratchpadPrefs = prefs.branch("sync.scratchpad")
+            guard let scratchpad = Scratchpad.restoreFromPrefs(scratchpadPrefs, syncKeyBundle: KeyBundle.fromKSync(kSync)) else { return }
+
+            let deviceId = (scratchpad.clientGUID + token.hashedFxAUID).sha256.hexEncodedString
+            GleanMetrics.Deletion.fxaDeviceId.set(deviceId)
+        }
     }
 
     // Function for recording metrics that are better recorded when going to background due

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -599,7 +599,7 @@ legacy.ids:
     expires: never
 
 deletion:
-  fxa_device_id:
+  sync_device_id:
     type: string
     lifetime: user
     description: |

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -600,7 +600,7 @@ legacy.ids:
 
 deletion:
   fxa_device_id:
-    type: uuid
+    type: string
     lifetime: user
     description: |
       The FxA device id.

--- a/Docs/metrics.md
+++ b/Docs/metrics.md
@@ -22,7 +22,7 @@ The following metrics are added to the ping:
 
 | Name | Type | Description | Data reviews | Extras | Expiration | [Data Sensitivity](https://wiki.mozilla.org/Firefox/Data_Collection) |
 | --- | --- | --- | --- | --- | --- | --- |
-| deletion.fxa_device_id |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The FxA device id.  |[1](TBD)||never | |
+| deletion.sync_device_id |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The FxA device id.  |[1](https://github.com/mozilla-mobile/firefox-ios/pull/7629#issuecomment-723312428)||never | |
 | legacy.ids.client_id |[uuid](https://mozilla.github.io/glean/book/user/metrics/uuid.html) |The client id from legacy telemetry.  |[1](https://bugzilla.mozilla.org/show_bug.cgi?id=1635427)||never | |
 
 ## events

--- a/Sync/State.swift
+++ b/Sync/State.swift
@@ -368,9 +368,9 @@ open class Scratchpad {
 
     // What's our client name?
     let clientName: String
-    let clientGUID: String
     let fxaDeviceId: String
     let hashedUID: String?
+    public let clientGUID: String
 
     var hashedDeviceID: String? {
         guard let hashedUID = hashedUID else {


### PR DESCRIPTION
- updated metrics yaml type to string in order to support hashed device id instead of uuid
- changed client guid protection level to public so that we can use it for deletion ping

Addresses: 
https://github.com/mozilla-mobile/firefox-ios/issues/6933#issuecomment-727660561

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1220)
