### PR TITLE
FXIOS-1243 ⁃ No Issue - Update Tests due to failures in some locales

### DIFF
--- a/L10nSnapshotTests/L10nBaseSnapshotTests.swift
+++ b/L10nSnapshotTests/L10nBaseSnapshotTests.swift
@@ -14,9 +14,7 @@ class L10nBaseSnapshotTests: XCTestCase {
     var navigator: MMNavigator<FxUserState>!
     var userState: FxUserState!
 
-    var skipIntro: Bool {
-        return true
-    }
+    var args = [LaunchArguments.ClearProfile, LaunchArguments.SkipWhatsNew, LaunchArguments.SkipETPCoverSheet,LaunchArguments.SkipIntro]
 
     override func setUp() {
         super.setUp()
@@ -24,17 +22,12 @@ class L10nBaseSnapshotTests: XCTestCase {
         app = XCUIApplication()
         setupSnapshot(app)
         app.terminate()
-        var args = [LaunchArguments.ClearProfile, LaunchArguments.SkipWhatsNew, LaunchArguments.SkipETPCoverSheet]
-        if skipIntro {
-            args.append(LaunchArguments.SkipIntro)
-        }
+
         springboardStart(app, args: args)
 
         let map = createScreenGraph(for: self, with: app)
         navigator = map.navigator()
         userState = navigator.userState
-
-        userState.showIntro = !skipIntro
 
         navigator.synchronizeWithUserState()
     }

--- a/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -5,12 +5,23 @@
 import XCTest
 
 class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
-    override var skipIntro: Bool {
-        return false
+
+    var noSkipIntroTest = ["testIntro"]
+
+    override func setUp() {
+        // Test name looks like: "[Class testFunc]", parse out the function name
+        let parts = name.replacingOccurrences(of: "]", with: "").split(separator: " ")
+                let key = String(parts[1])
+        if noSkipIntroTest.contains(key) {
+            args = [LaunchArguments.ClearProfile, LaunchArguments.SkipWhatsNew, LaunchArguments.SkipETPCoverSheet]
+        }
+        super.setUp()
     }
 
     func testIntro() {
         var num = 1
+        waitForExistence(app.buttons["nextOnboardingButton"])
+        navigator.nowAt(Intro_Welcome)
         allIntroPages.forEach { screenName in
             navigator.goto(screenName)
             snapshot("Intro-\(num)-\(screenName)")
@@ -56,6 +67,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
     func test3ReloadButtonContextMenu() {
         navigator.openURL(loremIpsumURL)
+        waitUntilPageLoad()
         waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
         
         navigator.toggleOff(userState.requestDesktopSite, withAction: Action.ToggleRequestDesktopSite)

--- a/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -82,8 +82,10 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
     }
 
     func testFxASignInPage() {
+        navigator.goto(BrowserTabMenu)
+        waitForExistence(app.tables.cells["menu-sync"], timeout: 5)
         navigator.goto(Intro_FxASignin)
-        waitForExistence(app.navigationBars.staticTexts["FxASingin.navBar"])
+        waitForExistence(app.navigationBars.staticTexts["FxASingin.navBar"], timeout: 10)
         snapshot("FxASignInScreen-01")
     }
 }


### PR DESCRIPTION
There were some tests failures mainly in TestSuite1 due to the First Run being shown and so taking longer than expected to show the correct screen to start the test.
In this PR I have modified the set up in that suite so that the First Run is only shown in the test it is tested, but not in the rest.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1243)
