### PR TITLE
FXIOS-1244 ⁃ Fix #7662: Turn off chron tabs for iPad

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1131,7 +1131,7 @@ class BrowserViewController: UIViewController {
 
     fileprivate func popToBVC() {
         guard let currentViewController = navigationController?.topViewController else {
-                return
+            return
         }
         currentViewController.dismiss(animated: true, completion: nil)
         if currentViewController != self {
@@ -1335,7 +1335,7 @@ extension BrowserViewController: URLBarDelegate {
 
         updateFindInPageVisibility(visible: false)
         
-        let shouldShowChronTabs = profile.prefs.boolForKey(PrefsKeys.ChronTabsPrefKey) ?? (chronTabsUserResearch?.chronTabsState ?? false)
+        let shouldShowChronTabs = UIDevice.current.userInterfaceIdiom != .pad && profile.prefs.boolForKey(PrefsKeys.ChronTabsPrefKey) ?? (chronTabsUserResearch?.chronTabsState ?? false)
         if shouldShowChronTabs {
             let tabTrayViewController = TabTrayV2ViewController(tabTrayDelegate: self, profile: profile)
             let controller: UINavigationController


### PR DESCRIPTION


┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1244)
