### PR TITLE
FXIOS-1266 ⁃ Fixes chron tabs title overflow #7703 and empty screenshot issue #7673

### DIFF
--- a/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
@@ -50,7 +50,7 @@ class TabTableViewCell: UITableViewCell, Themeable {
         }
         
         websiteTitle.snp.makeConstraints { make in
-             make.leading.equalTo(screenshotView.snp.trailing).offset(TabTrayV2ControllerUX.screenshotMarginLeftRight)
+            make.leading.equalTo(screenshotView.snp.trailing).offset(TabTrayV2ControllerUX.screenshotMarginLeftRight)
             make.top.equalToSuperview().offset(TabTrayV2ControllerUX.textMarginTopBottom)
             make.bottom.equalTo(urlLabel.snp.top)
             make.trailing.equalToSuperview().offset(-16)

--- a/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
@@ -49,7 +49,12 @@ class TabTableViewCell: UITableViewCell, Themeable {
             make.bottom.equalToSuperview().offset(-TabTrayV2ControllerUX.screenshotMarginTopBottom)
         }
         
-        loadTitleConstraint()
+        websiteTitle.snp.makeConstraints { make in
+             make.leading.equalTo(screenshotView.snp.trailing).offset(TabTrayV2ControllerUX.screenshotMarginLeftRight)
+            make.top.equalToSuperview().offset(TabTrayV2ControllerUX.textMarginTopBottom)
+            make.bottom.equalTo(urlLabel.snp.top)
+            make.trailing.equalToSuperview().offset(-16)
+        }
 
         urlLabel.snp.makeConstraints { make in
             make.leading.equalTo(screenshotView.snp.trailing).offset(TabTrayV2ControllerUX.screenshotMarginLeftRight)
@@ -60,11 +65,11 @@ class TabTableViewCell: UITableViewCell, Themeable {
     }
     
     // Helper method to load website title constraint
-    func loadTitleConstraint() {
+    func remakeTitleConstraint() {
         guard let websiteTitle = websiteTitle, let screenshotView = screenshotView, let urlLabel = urlLabel else { return }
         
         websiteTitle.numberOfLines = 2
-        websiteTitle.snp.makeConstraints { make in
+        websiteTitle.snp.remakeConstraints { make in
              make.leading.equalTo(screenshotView.snp.trailing).offset(TabTrayV2ControllerUX.screenshotMarginLeftRight)
             make.top.equalToSuperview().offset(TabTrayV2ControllerUX.textMarginTopBottom)
             make.bottom.equalTo(urlLabel.snp.top)

--- a/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
@@ -5,9 +5,13 @@
 import Foundation
 import UIKit
 import Shared
+import SnapKit
 
 class TabTableViewCell: UITableViewCell, Themeable {
     static let identifier = "tabCell"
+    var screenshotView: UIImageView?
+    var websiteTitle: UILabel?
+    var urlLabel: UILabel?
     
     lazy var closeButton: UIButton = {
         let button = UIButton()
@@ -19,10 +23,18 @@ class TabTableViewCell: UITableViewCell, Themeable {
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
-        guard let screenshotView = imageView,
-            let websiteTitle = textLabel,
-            let urlLabel = detailTextLabel
-            else { return }
+        guard let imageView = imageView, let title = textLabel, let label = detailTextLabel else { return }
+        
+        self.screenshotView = imageView
+        self.websiteTitle = title
+        self.urlLabel = label
+        
+        viewSetup()
+        applyTheme()
+    }
+    
+    private func viewSetup() {
+        guard let websiteTitle = websiteTitle, let screenshotView = screenshotView, let urlLabel = urlLabel else { return }
         
         screenshotView.contentMode = .scaleAspectFill
         screenshotView.clipsToBounds = true
@@ -37,23 +49,27 @@ class TabTableViewCell: UITableViewCell, Themeable {
             make.bottom.equalToSuperview().offset(-TabTrayV2ControllerUX.screenshotMarginTopBottom)
         }
         
-        websiteTitle.numberOfLines = 2
-        
-        websiteTitle.snp.makeConstraints { make in
-            make.leading.equalTo(screenshotView.snp.trailing).offset(TabTrayV2ControllerUX.screenshotMarginLeftRight)
-            make.top.equalToSuperview().offset(TabTrayV2ControllerUX.textMarginTopBottom)
-            make.bottom.equalTo(urlLabel.snp.top)
-            make.trailing.equalToSuperview().offset(-16)
-        }
-        
+        loadTitleConstraint()
+
         urlLabel.snp.makeConstraints { make in
             make.leading.equalTo(screenshotView.snp.trailing).offset(TabTrayV2ControllerUX.screenshotMarginLeftRight)
             make.trailing.equalToSuperview()
             make.top.equalTo(websiteTitle.snp.bottom).offset(3)
             make.bottom.equalToSuperview().offset(-TabTrayV2ControllerUX.textMarginTopBottom * CGFloat(websiteTitle.numberOfLines))
         }
-
-        applyTheme()
+    }
+    
+    // Helper method to load website title constraint. When
+    func loadTitleConstraint() {
+        guard let websiteTitle = websiteTitle, let screenshotView = screenshotView, let urlLabel = urlLabel else { return }
+        
+        websiteTitle.numberOfLines = 2
+        websiteTitle.snp.makeConstraints { make in
+             make.leading.equalTo(screenshotView.snp.trailing).offset(TabTrayV2ControllerUX.screenshotMarginLeftRight).constraint
+            make.top.equalToSuperview().offset(TabTrayV2ControllerUX.textMarginTopBottom)
+            make.bottom.equalTo(urlLabel.snp.top)
+            make.trailing.equalToSuperview().offset(-16)
+        }
     }
     
     required init?(coder: NSCoder) {
@@ -62,8 +78,7 @@ class TabTableViewCell: UITableViewCell, Themeable {
 
     override func prepareForReuse() {
         super.prepareForReuse()
-
-        self.applyTheme()
+        applyTheme()
     }
 
     func applyTheme() {

--- a/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
@@ -64,7 +64,7 @@ class TabTableViewCell: UITableViewCell, Themeable {
         }
     }
     
-    // Helper method to load website title constraint
+    // Helper method to remake title constraint
     func remakeTitleConstraint() {
         guard let websiteTitle = websiteTitle, let screenshotView = screenshotView, let urlLabel = urlLabel else { return }
         

--- a/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
@@ -71,7 +71,7 @@ class TabTableViewCell: UITableViewCell, Themeable {
         
         websiteTitle.numberOfLines = 2
         websiteTitle.snp.remakeConstraints { make in
-             make.leading.equalTo(screenshotView.snp.trailing).offset(TabTrayV2ControllerUX.screenshotMarginLeftRight)
+            make.leading.equalTo(screenshotView.snp.trailing).offset(TabTrayV2ControllerUX.screenshotMarginLeftRight)
             make.top.equalToSuperview().offset(TabTrayV2ControllerUX.textMarginTopBottom)
             make.bottom.equalTo(urlLabel.snp.top)
             make.trailing.equalToSuperview().offset(-16)

--- a/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
@@ -59,13 +59,13 @@ class TabTableViewCell: UITableViewCell, Themeable {
         }
     }
     
-    // Helper method to load website title constraint. When
+    // Helper method to load website title constraint
     func loadTitleConstraint() {
         guard let websiteTitle = websiteTitle, let screenshotView = screenshotView, let urlLabel = urlLabel else { return }
         
         websiteTitle.numberOfLines = 2
         websiteTitle.snp.makeConstraints { make in
-             make.leading.equalTo(screenshotView.snp.trailing).offset(TabTrayV2ControllerUX.screenshotMarginLeftRight).constraint
+             make.leading.equalTo(screenshotView.snp.trailing).offset(TabTrayV2ControllerUX.screenshotMarginLeftRight)
             make.top.equalToSuperview().offset(TabTrayV2ControllerUX.textMarginTopBottom)
             make.bottom.equalTo(urlLabel.snp.top)
             make.trailing.equalToSuperview().offset(-16)

--- a/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
@@ -49,6 +49,7 @@ class TabTableViewCell: UITableViewCell, Themeable {
             make.bottom.equalToSuperview().offset(-TabTrayV2ControllerUX.screenshotMarginTopBottom)
         }
         
+        websiteTitle.numberOfLines = 2
         websiteTitle.snp.makeConstraints { make in
             make.leading.equalTo(screenshotView.snp.trailing).offset(TabTrayV2ControllerUX.screenshotMarginLeftRight)
             make.top.equalToSuperview().offset(TabTrayV2ControllerUX.textMarginTopBottom)

--- a/Client/Frontend/Browser/Tabs/TabTrayV2ViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayV2ViewController.swift
@@ -229,7 +229,7 @@ extension TabTrayV2ViewController: UITableViewDataSource {
         tabCell.separatorInset = UIEdgeInsets.zero
         
         viewModel.configure(cell: tabCell, for: indexPath)
-        
+        tabCell.loadTitleConstraint()
         return tabCell
     }
     

--- a/Client/Frontend/Browser/Tabs/TabTrayV2ViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayV2ViewController.swift
@@ -229,7 +229,7 @@ extension TabTrayV2ViewController: UITableViewDataSource {
         tabCell.separatorInset = UIEdgeInsets.zero
         
         viewModel.configure(cell: tabCell, for: indexPath)
-        tabCell.loadTitleConstraint()
+        tabCell.remakeTitleConstraint()
         return tabCell
     }
     

--- a/Client/Frontend/Browser/Tabs/TabTrayV2ViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayV2ViewModel.swift
@@ -215,19 +215,11 @@ class TabTrayV2ViewModel: NSObject {
         let baseDomain = tab.sessionData?.urls.last?.baseDomain ?? tab.url?.baseDomain
         let urlLabel = baseDomain != nil ? baseDomain!.contains("local") ? " " : baseDomain : " "
 
-//        var image = UIImage()
         cell.screenshotView?.image = tab.screenshot
+        // Set Favicon from domain url when screenshot is empty for tab
         if tab.screenshot == nil, let domainUrl = getTabDomainUrl(tab: tab) {
-//            image = FaviconFetcher.letter(forUrl: domainUrl)
             cell.screenshotView?.setImageAndBackground(forIcon: tab.displayFavicon, website: domainUrl) {}
-            
-//            cell.screenshotView?.setImageAndBackground(forIcon: tab.displayFavicon, website: domainUrl) { [weak cell] in
-//
-//            }
         }
-        
-//        tab.displayFavicon
-//
         cell.websiteTitle?.text = tab.displayTitle
         cell.urlLabel?.text = urlLabel
         cell.accessoryView = cell.closeButton

--- a/Client/Frontend/Browser/Tabs/TabTrayV2ViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayV2ViewModel.swift
@@ -46,6 +46,13 @@ class TabTrayV2ViewModel: NSObject {
         return self.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
     }
     
+    func getTabDomainUrl(tab: Tab) -> URL? {
+        guard tab.url != nil else {
+            return tab.sessionData?.urls.last?.domainURL
+        }
+        return tab.url?.domainURL
+    }
+    
     func countOfNormalTabs() -> Int {
         return tabManager.normalTabs.count
     }
@@ -203,15 +210,26 @@ class TabTrayV2ViewModel: NSObject {
     
     func configure(cell: TabTableViewCell, for index: IndexPath) {
         guard let section = TabSection(rawValue: index.section),
-            let data = dataStore[section]?[index.row],
-            let textLabel = cell.textLabel,
-            let detailTextLabel = cell.detailTextLabel,
-            let imageView = cell.imageView
-            else { return }
-        let baseDomain = data.sessionData?.urls.last?.baseDomain ?? data.url?.baseDomain        
-        detailTextLabel.text = baseDomain != nil ? baseDomain!.contains("local") ? " " : baseDomain : " "
-        textLabel.text = data.displayTitle
-        imageView.image = data.screenshot ?? UIImage()
+              let tab = dataStore[section]?[index.row] else { return }
+
+        let baseDomain = tab.sessionData?.urls.last?.baseDomain ?? tab.url?.baseDomain
+        let urlLabel = baseDomain != nil ? baseDomain!.contains("local") ? " " : baseDomain : " "
+
+//        var image = UIImage()
+        cell.screenshotView?.image = tab.screenshot
+        if tab.screenshot == nil, let domainUrl = getTabDomainUrl(tab: tab) {
+//            image = FaviconFetcher.letter(forUrl: domainUrl)
+            cell.screenshotView?.setImageAndBackground(forIcon: tab.displayFavicon, website: domainUrl) {}
+            
+//            cell.screenshotView?.setImageAndBackground(forIcon: tab.displayFavicon, website: domainUrl) { [weak cell] in
+//
+//            }
+        }
+        
+//        tab.displayFavicon
+//
+        cell.websiteTitle?.text = tab.displayTitle
+        cell.urlLabel?.text = urlLabel
         cell.accessoryView = cell.closeButton
     }
 }


### PR DESCRIPTION
Fixes #7673 ⁃ [Chron tabs] Empty screenshot shows up in chron tabs for last week
Fixes #7703 ⁃ [Chron tabs] Title overflow when quickly switching between private and regular tabs

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1266)
