### PR TITLE
FXIOS-1312 ⁃ Use stable URL for the debug ping viewer

### DIFF
--- a/Docs/glean-testing.md
+++ b/Docs/glean-testing.md
@@ -9,8 +9,8 @@ In order to verify what data is being sent through Glean, you can use the glean 
 * Open safari on either the simulator that has firefox installed with the build you are trying to test, or on a device that has the version of firefox you are trying to test installed
 * Paste the deeplink url into the safari navigation bar and it should prompt you to open firefox, accept this prompt
 * Use firefox to do things that would result in Glean data being sent
-* Navigate to the glean debug dashboard here: https://glean-debug-view-dev-237806.firebaseapp.com/
-    * You can also navigate to the debug dashboard for your specific tag by appending it to that url like this: https://glean-debug-view-dev-237806.firebaseapp.com/pings/Kayla-Glean-Test
+* Navigate to the glean debug dashboard here: https://debug-ping-preview.firebaseapp.com/
+    * You can also navigate to the debug dashboard for your specific tag by appending it to that url like this: https://debug-ping-preview.firebaseapp.com/pings/Kayla-Glean-Test
 * You should see data appear with the date received, ping type, and payload. You can view the json here to see if your data is being sent in the way you expect. 
 
 You can read more about this in [Glean debugging docs](https://mozilla.github.io/glean/book/user/debugging/ios.html) as well.


### PR DESCRIPTION
That URL, while having `preview` in it, is stable.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1312)
