### PR TITLE
FXIOS-1315 ⁃ XCUITests updates for default chron tabs

### DIFF
--- a/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabTableViewCell.swift
@@ -16,6 +16,7 @@ class TabTableViewCell: UITableViewCell, Themeable {
     lazy var closeButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage.templateImageNamed("tab_close"), for: [])
+        button.accessibilityIdentifier = "closeTabButtonTabTray"
         button.tintColor = UIColor.theme.tabTray.cellCloseButton
         button.sizeToFit()
         return button

--- a/L10nSnapshotTests/L10nSuite3SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite3SnapshotTests.swift
@@ -65,6 +65,7 @@ class L10nSuite3SnapshotTests: L10nBaseSnapshotTests {
 
     func testPrivateBrowsingTabsEmptyState() {
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        app.tables.cells.element(boundBy: 0).buttons["closeTabButtonTabTray"].tap()
         snapshot("PrivateBrowsingTabsEmptyState-01")
     }
 }

--- a/UITests/AuthenticationTests.swift
+++ b/UITests/AuthenticationTests.swift
@@ -54,8 +54,8 @@ class AuthenticationTests: KIFTestCase {
         } else {
             tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
         }
-        tester().tapView(withAccessibilityIdentifier: "TabTrayController.maskButton")
-        tester().tapView(withAccessibilityIdentifier: "TabTrayController.addTabButton")
+        tester().tapView(withAccessibilityLabel: "smallPrivateMask")
+        tester().tapView(withAccessibilityIdentifier: "newTabButtonTabTray")
         tester().waitForAnimationsToFinish()
         loadAuthPage()
 

--- a/UITests/ClearPrivateDataTests.swift
+++ b/UITests/ClearPrivateDataTests.swift
@@ -117,7 +117,7 @@ class ClearPrivateDataTests: KIFTestCase, UITextFieldDelegate {
 
     func testClearsCookies() {
         let url = "\(webRoot!)/numberedPage.html?page=1"
-        tester().waitForAnimationsToFinish(withTimeout: 3)
+        tester().waitForAnimationsToFinish(withTimeout: 5)
 
         BrowserUtils.enterUrlAddressBar(tester(), typeUrl: url)
         tester().waitForWebViewElementWithAccessibilityLabel("Page 1")
@@ -137,7 +137,7 @@ class ClearPrivateDataTests: KIFTestCase, UITextFieldDelegate {
         BrowserUtils.acceptClearPrivateData(tester())
         BrowserUtils.closeClearPrivateDataDialog(tester())
 
-        tester().waitForAnimationsToFinish(withTimeout: 3)
+        tester().waitForAnimationsToFinish(withTimeout: 5)
         cookies = getCookies(webView)
         XCTAssertEqual(cookies.cookie, "foo=bar")
         XCTAssertEqual(cookies.localStorage, "foo=bar")

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -225,26 +225,25 @@ class BrowserUtils {
 
     class func resetToAboutHomeKIF(_ tester: KIFUITestActor) {
         if iPad() {
-//            EarlGrey.selectElement(with: grey_accessibilityID("TopTabsViewController.tabsButton")).perform(grey_tap())
             tester.tapView(withAccessibilityIdentifier: "TopTabsViewController.tabsButton")
         } else {
             tester.tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
         }
         
         // if in private mode, close all tabs
-        tester.tapView(withAccessibilityIdentifier: "TabTrayController.maskButton")
+        tester.tapView(withAccessibilityLabel: "smallPrivateMask")
 
-        tester.tapView(withAccessibilityIdentifier: "TabTrayController.removeTabsButton")
+        tester.tapView(withAccessibilityIdentifier: "closeAllTabsButtonTabTray")
         tester.tapView(withAccessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
 
         tester.wait(forTimeInterval: 3)
         /* go to Normal mode */
         if (tester.viewExistsWithLabel("Show Tabs")) {
-            tester.tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
+            tester.tapView(withAccessibilityLabel: "1")
         } else {
-            tester.tapView(withAccessibilityIdentifier: "TabTrayController.maskButton")
+            tester.tapView(withAccessibilityLabel: "1")
         }
-        tester.tapView(withAccessibilityIdentifier: "TabTrayController.removeTabsButton")
+        tester.tapView(withAccessibilityIdentifier: "closeAllTabsButtonTabTray")
         tester.tapView(withAccessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
     }
 
@@ -307,10 +306,6 @@ class BrowserUtils {
                 tester.setOn(clearables!.contains(clearable), forSwitchWithAccessibilityLabel: clearable.rawValue)
             }
         tester.tapView(withAccessibilityIdentifier: "ClearPrivateData")
-    }
-    
-    class func configEarlGrey() {
-    
     }
 
     class func clearPrivateDataKIF(_ tester: KIFUITestActor) {

--- a/UITests/LoginManagerTests.swift
+++ b/UITests/LoginManagerTests.swift
@@ -220,6 +220,11 @@ class LoginManagerTests: KIFTestCase {
         tester().wait(forTimeInterval: 2)
         tester().waitForViewWithAccessibilityValue("a0.com/")
         XCTAssertEqual(UIPasteboard.general.string, "http://a0.com")
+
+        // Workaround
+        tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
+        tester().tapView(withAccessibilityIdentifier: "closeAllTabsButtonTabTray")
+        tester().tapView(withAccessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
     }
 
     func testOpenAndFillFromNormalContext() {
@@ -238,6 +243,11 @@ class LoginManagerTests: KIFTestCase {
 
         tester().wait(forTimeInterval: 10)
         tester().waitForViewWithAccessibilityValue("a0.com/")
+
+        // Workaround
+        tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
+        tester().tapView(withAccessibilityIdentifier: "closeAllTabsButtonTabTray")
+        tester().tapView(withAccessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
     }
     // This test is disabled until bug 1486243 is fixed
     /*func testOpenAndFillFromPrivateContext() {

--- a/UITests/SecurityTests.swift
+++ b/UITests/SecurityTests.swift
@@ -74,6 +74,11 @@ class SecurityTests: KIFTestCase {
 
         // Also make sure the XSS alert doesn't appear.
         XCTAssertFalse(tester().viewExistsWithLabel("Local page loaded"))
+
+        // Workaround number of tabs not updated
+        tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
+        tester().tapView(withAccessibilityIdentifier: "closeAllTabsButtonTabTray")
+        tester().tapView(withAccessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
     }
 
     /// Tap the URL spoof button, which opens a new window to a host with an invalid port.
@@ -89,9 +94,10 @@ class SecurityTests: KIFTestCase {
         // Make sure the URL bar doesn't show the URL since it hasn't loaded.
         XCTAssertFalse(tester().viewExistsWithLabel("http://1.2.3.4:1234/"))
 
-        // Since the newly opened tab doesn't have a URL/title we can't find its accessibility
-        // element to close it in teardown. Workaround: load another page first.
-        BrowserUtils.enterUrlAddressBar(tester(), typeUrl: webRoot!)
+        // Workaround number of tabs not updated
+        tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
+        tester().tapView(withAccessibilityIdentifier: "closeAllTabsButtonTabTray")
+        tester().tapView(withAccessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
     }
 
     // For blob URLs, just show "blob:" to the user (see bug 1446227)

--- a/UITests/TrackingProtectionTests.swift
+++ b/UITests/TrackingProtectionTests.swift
@@ -137,7 +137,7 @@ class TrackingProtectionTests: KIFTestCase, TabEventHandler {
             tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
         }
 
-        tester().tapView(withAccessibilityIdentifier: "TabTrayController.addTabButton")
+        tester().tapView(withAccessibilityIdentifier: "newTabButtonTabTray")
 
         checkStrictTrackingProtection(isBlocking: false, isTPDisabled: true)
         enableStrictMode()

--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -66,6 +66,7 @@ class ActivityStreamTest: BaseTestCase {
         } else {
             app.buttons["TabToolbar.backButton"].tap()
         }
+        navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         // A new site has been added to the top sites
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)

--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -58,7 +58,8 @@ class ActivityStreamTest: BaseTestCase {
         }
     }
 
-    func testTopSitesRemove() {
+    // Disabled due to issue #7611
+    /*func testTopSitesRemove() {
         loadWebPage("http://example.com")
         waitForTabsButton()
         if iPad() {
@@ -75,7 +76,7 @@ class ActivityStreamTest: BaseTestCase {
         app.tables["Context Menu"].cells["Remove"].tap()
         // A top site has been removed
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
-    }
+    }*/
 
     func testTopSitesRemoveDefaultTopSite() {
         TopSiteCellgroup.cells[defaultTopSite["topSiteLabel"]!].press(forDuration: 1)
@@ -85,7 +86,8 @@ class ActivityStreamTest: BaseTestCase {
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 4)
     }
 
-    func testTopSitesRemoveAllDefaultTopSitesAddNewOne() {
+    // Disabled due to issue #7611
+    /*func testTopSitesRemoveAllDefaultTopSitesAddNewOne() {
         // Remove all default Top Sites
         waitForExistence(app.cells["facebook"])
         for element in allDefaultTopSites {
@@ -109,9 +111,10 @@ class ActivityStreamTest: BaseTestCase {
 
         waitForExistence(TopSiteCellgroup.staticTexts[newTopSite["topSiteLabel"]!])
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 1)
-    }
+    }*/
 
-    func testTopSitesRemoveAllExceptDefaultClearPrivateData() {
+    // Disabled due to issue #7611
+    /*func testTopSitesRemoveAllExceptDefaultClearPrivateData() {
         navigator.goto(BrowserTab)
         waitForTabsButton()
         navigator.goto(TabTray)
@@ -129,7 +132,7 @@ class ActivityStreamTest: BaseTestCase {
         navigator.goto(HomePanelsScreen)
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
         XCTAssertFalse(app.cells.staticTexts["mozilla"].exists)
-    }
+    }*/
 
     func testTopSitesRemoveAllExceptPinnedClearPrivateData() {
         navigator.goto(BrowserTab)
@@ -184,8 +187,8 @@ class ActivityStreamTest: BaseTestCase {
         waitForExistence(TopSiteCellgroup.cells["apple"])
         navigator.nowAt(HomePanelsScreen)
         navigator.goto(TabTray)
-        waitForExistence(app.cells.staticTexts["Apple"])
-        XCTAssertTrue(app.cells.staticTexts["Apple"].exists, "A new Tab has not been open")
+        waitForExistence(app.cells.staticTexts["apple.com"])
+        XCTAssertTrue(app.cells.staticTexts["apple.com"].exists, "A new Tab has not been open")
     }
 
     // Smoketest

--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -200,8 +200,8 @@ class ActivityStreamTest: BaseTestCase {
         waitForNoExistence(app.tables["Context Menu"], timeoutValue: 15)
         navigator.nowAt(HomePanelsScreen)
         navigator.goto(TabTray)
-        waitForExistence(app.collectionViews.cells[defaultTopSite["bookmarkLabel"]!])
-        let numTabsOpen = app.collectionViews.cells.count
+        waitForExistence(app.cells.staticTexts[defaultTopSite["bookmarkLabel"]!])
+        let numTabsOpen = app.tables.cells.count
         XCTAssertEqual(numTabsOpen, 2, "New tab not open")
     }
 
@@ -218,15 +218,15 @@ class ActivityStreamTest: BaseTestCase {
 
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         navigator.goto(TabTray)
-        waitForExistence(app.collectionViews.cells.element(boundBy: 0))
+        waitForExistence(app.cells.staticTexts.element(boundBy: 0))
         if !app.collectionViews["Apple"].exists {
-            app.collectionViews.cells.element(boundBy: 0).tap()
+            app.cells.staticTexts.element(boundBy: 0).tap()
             waitForValueContains(app.textFields["url"], value: "apple")
             app.buttons["Show Tabs"].tap()
         }
         navigator.nowAt(TabTray)
-        waitForExistence(app.cells["Apple"])
-        app.collectionViews.cells["Apple"].tap()
+        waitForExistence(app.tables.cells.staticTexts["Apple"])
+        app.cells.staticTexts["Apple"].tap()
 
         // The website is open
         XCTAssertFalse(TopSiteCellgroup.exists)
@@ -250,7 +250,7 @@ class ActivityStreamTest: BaseTestCase {
 
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
-        waitForExistence(app.collectionViews.cells[defaultTopSite["bookmarkLabel"]!])
+        waitForExistence(app.cells.staticTexts[defaultTopSite["bookmarkLabel"]!])
         let numTabsOpen = userState.numTabs
         XCTAssertEqual(numTabsOpen, 1, "New tab not open")
     }

--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -9,7 +9,7 @@ let newTopSite = ["url": "www.mozilla.org", "topSiteLabel": "mozilla", "bookmark
 let allDefaultTopSites = ["facebook", "youtube", "amazon", "wikipedia", "twitter"]
 
 class ActivityStreamTest: BaseTestCase {
-    let TopSiteCellgroup = XCUIApplication().collectionViews.cells["TopSitesCell"]
+    let TopSiteCellgroup = XCUIApplication().cells["TopSitesCell"]
 
     let testWithDB = ["testActivityStreamPages","testTopSitesAdd", "testTopSitesOpenInNewTab", "testTopSitesOpenInNewPrivateTab", "testTopSitesBookmarkNewTopSite", "testTopSitesShareNewTopSite", "testContextMenuInLandscape"]
 
@@ -107,7 +107,7 @@ class ActivityStreamTest: BaseTestCase {
         navigator.performAction(Action.AcceptRemovingAllTabs)
         navigator.performAction(Action.OpenNewTabFromTabTray)
 
-        waitForExistence(TopSiteCellgroup.cells[newTopSite["topSiteLabel"]!])
+        waitForExistence(TopSiteCellgroup.staticTexts[newTopSite["topSiteLabel"]!])
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 1)
     }
 
@@ -119,8 +119,8 @@ class ActivityStreamTest: BaseTestCase {
         navigator.performAction(Action.AcceptRemovingAllTabs)
         navigator.performAction(Action.OpenNewTabFromTabTray)
 
-        waitForExistence(app.collectionViews.cells["mozilla"])
-        XCTAssertTrue(app.collectionViews.cells["mozilla"].exists)
+        waitForExistence(app.cells.staticTexts["mozilla"])
+        XCTAssertTrue(app.cells.staticTexts["mozilla"].exists)
         // A new site has been added to the top sites
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
 
@@ -128,7 +128,7 @@ class ActivityStreamTest: BaseTestCase {
         navigator.performAction(Action.AcceptClearPrivateData)
         navigator.goto(HomePanelsScreen)
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
-        XCTAssertFalse(app.collectionViews.cells["mozilla"].exists)
+        XCTAssertFalse(app.cells.staticTexts["mozilla"].exists)
     }
 
     func testTopSitesRemoveAllExceptPinnedClearPrivateData() {
@@ -180,12 +180,12 @@ class ActivityStreamTest: BaseTestCase {
         XCTAssert(TopSiteCellgroup.exists)
 
         navigator.goto(TabTray)
-        app.collectionViews.cells["Home"].tap()
+        app.cells.staticTexts["Home"].tap()
         waitForExistence(TopSiteCellgroup.cells["apple"])
         navigator.nowAt(HomePanelsScreen)
         navigator.goto(TabTray)
-        waitForExistence(app.collectionViews.cells["Apple"])
-        XCTAssertTrue(app.collectionViews.cells["Apple"].exists, "A new Tab has not been open")
+        waitForExistence(app.cells.staticTexts["Apple"])
+        XCTAssertTrue(app.cells.staticTexts["Apple"].exists, "A new Tab has not been open")
     }
 
     // Smoketest

--- a/XCUITests/BookmarkingTests.swift
+++ b/XCUITests/BookmarkingTests.swift
@@ -76,7 +76,7 @@ class BookmarkingTests: BaseTestCase {
         // Go back, check it's still bookmarked, check it's on bookmarks home panel
         waitForTabsButton()
         navigator.goto(TabTray)
-        app.collectionViews.cells["Example Domain"].tap()
+        app.cells.staticTexts["Example Domain"].tap()
         navigator.nowAt(BrowserTab)
         waitForTabsButton()
         checkBookmarked()
@@ -276,7 +276,6 @@ class BookmarkingTests: BaseTestCase {
 
     private func typeOnSearchBar(text: String) {
         waitForExistence(app.textFields["url"], timeout: 5)
-        sleep(1)
         app.textFields["address"].tap()
         app.textFields["address"].typeText(text)
     }

--- a/XCUITests/DesktopModeTests.swift
+++ b/XCUITests/DesktopModeTests.swift
@@ -147,6 +147,7 @@ class DesktopModeTestsIphone: IphoneOnlyTestCase {
 
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         navigator.openURL(path(forTestPage: "test-user-agent.html"))
+        waitUntilPageLoad()
         // Workaround
         app.buttons["Reload"].tap()
         navigator.goto(PageOptionsMenu)
@@ -155,7 +156,7 @@ class DesktopModeTestsIphone: IphoneOnlyTestCase {
         XCTAssert(app.webViews.staticTexts.matching(identifier: "DESKTOP_UA").count > 0)
 
         navigator.nowAt(BrowserTab)
-        navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleRegularMode)
         navigator.openURL(path(forTestPage: "test-user-agent.html"))
         waitUntilPageLoad()
         XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)

--- a/XCUITests/DragAndDropTests.swift
+++ b/XCUITests/DragAndDropTests.swift
@@ -15,7 +15,7 @@ let twitterTitle = "Twitter"
 
 
 class DragAndDropTests: BaseTestCase {
-
+/* Disble test suite since in theory it does not make sense with Chron tabs implementation
     override func tearDown() {
         XCUIDevice.shared.orientation = UIDeviceOrientation.portrait
         super.tearDown()
@@ -95,7 +95,7 @@ class DragAndDropTests: BaseTestCase {
         dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite.tabName], dropOnElement: app.collectionViews.cells[secondWebsite.tabName])
 
         checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName, secondTab: firstWebsite.tabName)
-    }
+    }*/
 }
 
 fileprivate extension BaseTestCase {

--- a/XCUITests/FindInPageTest.swift
+++ b/XCUITests/FindInPageTest.swift
@@ -139,8 +139,8 @@ class FindInPageTests: BaseTestCase {
         // Going to tab tray and back to the website hides the search field.
         navigator.goto(TabTray)
 
-        waitForExistence(app.collectionViews.cells["The Book of Mozilla"])
-        app.collectionViews.cells["The Book of Mozilla"].tap()
+        waitForExistence(app.cells.staticTexts["The Book of Mozilla"])
+        app.cells.staticTexts["The Book of Mozilla"].tap()
         XCTAssertFalse(app.textFields[""].exists)
         XCTAssertFalse(app.buttons["FindInPage.find_next"].exists)
         XCTAssertFalse(app.buttons["FindInPage.find_previous"].exists)

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -127,6 +127,7 @@ class Action {
     static let OpenNewTabFromTabTray = "OpenNewTabFromTabTray"
     static let AcceptRemovingAllTabs = "AcceptRemovingAllTabs"
 
+    static let ToggleRegularMode = "ToggleRegularMode"
     static let TogglePrivateMode = "TogglePrivateBrowing"
     static let TogglePrivateModeFromTabBarHomePanel = "TogglePrivateModeFromTabBarHomePanel"
     static let TogglePrivateModeFromTabBarBrowserTab = "TogglePrivateModeFromTabBarBrowserTab"
@@ -908,6 +909,9 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     map.addScreenState(TabTray) { screenState in
         screenState.tap(app.buttons["newTabButtonTabTray"], forAction: Action.OpenNewTabFromTabTray, transitionTo: NewTabScreen)
         screenState.tap(app.buttons["smallPrivateMask"], forAction: Action.TogglePrivateMode) { userState in
+            userState.isPrivate = !userState.isPrivate
+        }
+        screenState.tap(app.toolbars.segmentedControls.buttons.firstMatch, forAction: Action.ToggleRegularMode) { userState in
             userState.isPrivate = !userState.isPrivate
         }
         screenState.tap(app.buttons["closeAllTabsButtonTabTray"], to: CloseTabMenu)

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -906,14 +906,14 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     map.addScreenState(TabTray) { screenState in
-        screenState.tap(app.buttons["TabTrayController.addTabButton"], forAction: Action.OpenNewTabFromTabTray, transitionTo: NewTabScreen)
-        screenState.tap(app.buttons["TabTrayController.maskButton"], forAction: Action.TogglePrivateMode) { userState in
+        screenState.tap(app.buttons["newTabButtonTabTray"], forAction: Action.OpenNewTabFromTabTray, transitionTo: NewTabScreen)
+        screenState.tap(app.buttons["smallPrivateMask"], forAction: Action.TogglePrivateMode) { userState in
             userState.isPrivate = !userState.isPrivate
         }
-        screenState.tap(app.buttons["TabTrayController.removeTabsButton"], to: CloseTabMenu)
+        screenState.tap(app.buttons["closeAllTabsButtonTabTray"], to: CloseTabMenu)
 
         screenState.onEnter { userState in
-            userState.numTabs = Int(app.collectionViews.cells.count)
+            userState.numTabs = Int(app.tables.cells.count)
         }
     }
 
@@ -998,7 +998,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             }
         }
 
-        screenState.tap(app.buttons["Private Mode"], forAction: Action.TogglePrivateModeFromTabBarBrowserTab) { userState in
+        screenState.tap(app.buttons["smallPrivateMask"], forAction: Action.TogglePrivateModeFromTabBarBrowserTab) { userState in
             userState.isPrivate = !userState.isPrivate
         }
     }
@@ -1114,7 +1114,7 @@ extension MMNavigator where T == FxUserState {
     func createNewTab() {
         let app = XCUIApplication()
         self.goto(TabTray)
-        app.buttons["TabTrayController.addTabButton"].tap()
+        app.buttons["newTabButtonTabTray"].tap()
         self.nowAt(NewTabScreen)
     }
 

--- a/XCUITests/HistoryTests.swift
+++ b/XCUITests/HistoryTests.swift
@@ -211,9 +211,9 @@ class HistoryTests: BaseTestCase {
         waitUntilPageLoad()
         waitForTabsButton()
         navigator.goto(TabTray)
-        waitForExistence(app.collectionViews.cells[webpage["label"]!])
+        waitForExistence(app.cells.staticTexts[webpage["label"]!])
         // 'x' button to close the tab is not visible, so closing by swiping the tab
-        app.collectionViews.cells[webpage["label"]!].swipeRight()
+        app.cells.staticTexts[webpage["label"]!].swipeRight()
 
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.goto(HomePanelsScreen)

--- a/XCUITests/HistoryTests.swift
+++ b/XCUITests/HistoryTests.swift
@@ -212,8 +212,8 @@ class HistoryTests: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
         waitForExistence(app.cells.staticTexts[webpage["label"]!])
-        // 'x' button to close the tab is not visible, so closing by swiping the tab
-        app.cells.staticTexts[webpage["label"]!].swipeRight()
+        // Close tab by tapping on its 'x' button
+        app.tables.cells.element(boundBy: 0).buttons["closeTabButtonTabTray"].tap()
 
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.goto(HomePanelsScreen)

--- a/XCUITests/HomePageSettingsUITest.swift
+++ b/XCUITests/HomePageSettingsUITest.swift
@@ -88,7 +88,6 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.goto(HomeSettings)
         app.textFields["HomeAsCustomURLTextField"].tap()
         app.textFields["HomeAsCustomURLTextField"].press(forDuration: 3)
-        print(app.debugDescription)
         waitForExistence(app.menuItems["Paste"])
         app.menuItems["Paste"].tap()
         waitForValueContains(app.textFields["HomeAsCustomURLTextField"], value: "mozilla")

--- a/XCUITests/PhotonActionSheetTest.swift
+++ b/XCUITests/PhotonActionSheetTest.swift
@@ -51,11 +51,8 @@ class PhotonActionSheetTest: BaseTestCase {
         let pageObjectButtonCenter = pageObjectButton.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0))
         pageObjectButtonCenter.press(forDuration: 1)
 
-        if #available(iOS 14.0, *) {
-            waitForExistence(app.collectionViews.buttons["Copy"], timeout: 10)
-        } else {
-            waitForExistence(app.cells["Copy"], timeout: 10)
-        }
+        // Wait to see the Share options sheet
+        waitForExistence(app.buttons["Copy"], timeout: 10)
     }
 
     func testSendToDeviceFromPageOptionsMenu() {

--- a/XCUITests/PrivateBrowsingTest.swift
+++ b/XCUITests/PrivateBrowsingTest.swift
@@ -49,7 +49,7 @@ class PrivateBrowsingTest: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
 
-        waitForExistence(app.collectionViews.cells[url2Label])
+        waitForExistence(app.cells.staticTexts[url2Label])
         let numTabs = userState.numTabs
         XCTAssertEqual(numTabs, 2, "The number of regular tabs is not correct")
 
@@ -64,15 +64,15 @@ class PrivateBrowsingTest: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
         print(app.debugDescription)
-        waitForExistence(app.collectionViews.cells[url1And3Label])
+        waitForExistence(app.cells.staticTexts[url1And3Label])
         let numPrivTabs = userState.numTabs
         XCTAssertEqual(numPrivTabs, 1, "The number of private tabs is not correct")
 
         // Go back to regular mode and check the total number of tabs
         navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
-        waitForExistence(app.collectionViews.cells[url2Label])
-        waitForNoExistence(app.collectionViews.cells[url1And3Label])
+        waitForExistence(app.cells.staticTexts[url2Label])
+        waitForNoExistence(app.cells.staticTexts[url1And3Label])
         let numRegularTabs = userState.numTabs
         XCTAssertEqual(numRegularTabs, 2, "The number of regular tabs is not correct")
     }
@@ -100,11 +100,11 @@ class PrivateBrowsingTest: BaseTestCase {
 
         // Go back to private browsing and check that the tab has not been closed
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
-        waitForExistence(app.collectionViews.cells[url2Label], timeout: 5)
+        waitForExistence(app.cells.staticTexts[url2Label], timeout: 5)
         checkOpenTabsBeforeClosingPrivateMode()
 
         // Now the enable the Close Private Tabs when closing the Private Browsing Button
-        app.collectionViews.cells[url2Label].tap()
+        app.cells.staticTexts[url2Label].tap()
         waitForTabsButton()
         waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: 10)
         navigator.nowAt(BrowserTab)
@@ -118,7 +118,7 @@ class PrivateBrowsingTest: BaseTestCase {
 
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
-        waitForNoExistence(app.collectionViews.cells[url2Label])
+        waitForNoExistence(app.cells.staticTexts[url2Label])
         checkOpenTabsAfterClosingPrivateMode()
     }
 
@@ -194,7 +194,7 @@ class PrivateBrowsingTest: BaseTestCase {
 
 fileprivate extension BaseTestCase {
     func checkOpenTabsBeforeClosingPrivateMode() {
-        let numPrivTabs = app.collectionViews.cells.count
+        let numPrivTabs = app.tables.cells.count
         XCTAssertEqual(numPrivTabs, 1, "The number of tabs is not correct, the private tab should not have been closed")
     }
 

--- a/XCUITests/PrivateBrowsingTest.swift
+++ b/XCUITests/PrivateBrowsingTest.swift
@@ -66,10 +66,10 @@ class PrivateBrowsingTest: BaseTestCase {
         print(app.debugDescription)
         waitForExistence(app.cells.staticTexts[url1And3Label])
         let numPrivTabs = userState.numTabs
-        XCTAssertEqual(numPrivTabs, 1, "The number of private tabs is not correct")
+        XCTAssertEqual(numPrivTabs, 2, "The number of private tabs is not correct")
 
         // Go back to regular mode and check the total number of tabs
-        navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleRegularMode)
 
         waitForExistence(app.cells.staticTexts[url2Label])
         waitForNoExistence(app.cells.staticTexts[url1And3Label])
@@ -96,7 +96,7 @@ class PrivateBrowsingTest: BaseTestCase {
         waitForTabsButton()
 
         // Go back to regular browser
-        navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleRegularMode)
 
         // Go back to private browsing and check that the tab has not been closed
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
@@ -114,30 +114,11 @@ class PrivateBrowsingTest: BaseTestCase {
         waitForTabsButton()
 
         // Go back to regular browsing and check that the private tab has been closed and that the initial Private Browsing message appears when going back to Private Browsing
-        navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleRegularMode)
 
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
         waitForNoExistence(app.cells.staticTexts[url2Label])
-        checkOpenTabsAfterClosingPrivateMode()
-    }
-
-    func testClosePrivateTabsOptionClosesPrivateTabsDirectlyFromTabTray() {
-        // See scenario described in bug 1434545 for more info about this scenario
-        enableClosePrivateBrowsingOptionWhenLeaving()
-        navigator.openURL(url3)
-        waitUntilPageLoad()
-        app.webViews.links.staticTexts["More information..."].press(forDuration: 3)
-        app.buttons["Open in New Private Tab"].tap()
-        waitUntilPageLoad()
-        waitForTabsButton()
-        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
-
-        // Check there is one tab
-        navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
-        checkOpenTabsBeforeClosingPrivateMode()
-
-        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         checkOpenTabsAfterClosingPrivateMode()
     }
 
@@ -158,7 +139,7 @@ class PrivateBrowsingTest: BaseTestCase {
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         checkIndexedDBIsCreated()
 
-        navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleRegularMode)
         checkIndexedDBIsCreated()
 
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
@@ -169,9 +150,9 @@ class PrivateBrowsingTest: BaseTestCase {
         // If no private tabs are open, there should be a initial screen with label Private Browsing
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
-        XCTAssertTrue(app.staticTexts["Private Browsing"].exists, "Private Browsing screen is not shown")
         let numPrivTabsFirstTime = userState.numTabs
-        XCTAssertEqual(numPrivTabsFirstTime, 0, "The number of tabs is not correct, there should not be any private tab yet")
+        // With the chron tab implementation there is one tab by default
+        XCTAssertEqual(numPrivTabsFirstTime, 1, "The number of tabs is not correct, there should not be any private tab yet")
 
         // If a private tab is open Private Browsing screen is not shown anymore
         navigator.goto(BrowserTab)
@@ -179,7 +160,7 @@ class PrivateBrowsingTest: BaseTestCase {
         //Wait until the page loads and go to regular browser
         waitUntilPageLoad()
         waitForTabsButton()
-        navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleRegularMode)
 
         // Go back to private browsing
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
@@ -188,20 +169,19 @@ class PrivateBrowsingTest: BaseTestCase {
         XCTAssertFalse(app.staticTexts["Private Browsing"].exists, "Private Browsing screen is shown")
         navigator.nowAt(TabTray)
         let numPrivTabsOpen = userState.numTabs
-        XCTAssertEqual(numPrivTabsOpen, 1, "The number of tabs is not correct, there should be one private tab")
+        XCTAssertEqual(numPrivTabsOpen, 2, "The number of tabs is not correct, there should be two private tab")
     }
 }
 
 fileprivate extension BaseTestCase {
     func checkOpenTabsBeforeClosingPrivateMode() {
         let numPrivTabs = app.tables.cells.count
-        XCTAssertEqual(numPrivTabs, 1, "The number of tabs is not correct, the private tab should not have been closed")
+        XCTAssertEqual(numPrivTabs, 2, "The number of tabs is not correct, the private tab should not have been closed")
     }
 
     func checkOpenTabsAfterClosingPrivateMode() {
         let numPrivTabsAfterClosing = userState.numTabs
-        XCTAssertEqual(numPrivTabsAfterClosing, 0, "The number of tabs is not correct, the private tab should have been closed")
-        XCTAssertTrue(app.staticTexts["Private Browsing"].exists, "Private Browsing screen is not shown")
+        XCTAssertEqual(numPrivTabsAfterClosing, 1, "The number of tabs is not correct, the private tab should have been closed")
     }
 
     func enableClosePrivateBrowsingOptionWhenLeaving() {

--- a/XCUITests/TabTraySearchTabsTests.swift
+++ b/XCUITests/TabTraySearchTabsTests.swift
@@ -5,7 +5,7 @@ let secondURL = "mozilla.org/en-US/book"
 let fullFirstURL = "https://www.mozilla.org/en-US/"
 
 class TabTraySearchTabsTests: BaseTestCase {
-
+    /* Disble test suite since in theory it does not make sense with Chron tabs implementation
     func testSearchTabs() {
         // Open two tabs and go to tab tray
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
@@ -71,5 +71,5 @@ class TabTraySearchTabsTests: BaseTestCase {
         navigator.goto(TabTray)
         let searchValue = app.textFields["Search Tabs"].value
         XCTAssertEqual(searchValue as! String, "Search Tabs")
-    }
+    }*/
 }

--- a/XCUITests/ToolbarTest.swift
+++ b/XCUITests/ToolbarTest.swift
@@ -60,8 +60,8 @@ class ToolbarTests: BaseTestCase {
         // Open new tab and then go back to previous tab to test navigation buttons.
         waitForTabsButton()
         navigator.goto(TabTray)
-        waitForExistence(app.collectionViews.cells[website1["label"]!])
-        app.collectionViews.cells[website1["label"]!].tap()
+        waitForExistence(app.cells.staticTexts[website1["label"]!])
+        app.cells.staticTexts[website1["label"]!].tap()
         XCTAssertEqual(valueMozilla, urlValueLong)
 
         // Test to see if all the buttons are enabled then close tab.
@@ -73,8 +73,8 @@ class ToolbarTests: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
 
-        waitForExistence(app.collectionViews.cells[website1["label"]!])
-        app.collectionViews.cells[website1["label"]!].swipeRight()
+        waitForExistence(app.cells.staticTexts[website1["label"]!])
+        app.cells.staticTexts[website1["label"]!].swipeRight()
 
         // Go Back to other tab to see if all buttons are disabled.
         navigator.nowAt(BrowserTab)

--- a/XCUITests/ToolbarTest.swift
+++ b/XCUITests/ToolbarTest.swift
@@ -74,7 +74,7 @@ class ToolbarTests: BaseTestCase {
         navigator.goto(TabTray)
 
         waitForExistence(app.cells.staticTexts[website1["label"]!])
-        app.cells.staticTexts[website1["label"]!].swipeRight()
+        app.tables.cells.element(boundBy: 0).buttons["closeTabButtonTabTray"].tap()
 
         // Go Back to other tab to see if all buttons are disabled.
         navigator.nowAt(BrowserTab)

--- a/XCUITests/TopTabsTest.swift
+++ b/XCUITests/TopTabsTest.swift
@@ -34,7 +34,7 @@ class TopTabsTest: BaseTestCase {
         } else {
             navigator.goto(TabTray)
         }
-        waitForExistence(app.collectionViews.cells[urlLabel], timeout: 5)
+        waitForExistence(app.cells.staticTexts[urlLabel], timeout: 5)
     }
 
     func testAddTabFromContext() {
@@ -51,14 +51,14 @@ class TopTabsTest: BaseTestCase {
 
         // Open tab tray to check that both tabs are there
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
-        waitForExistence(app.collectionViews.cells["Example Domain"])
-        if !app.collectionViews.cells["IANA — IANA-managed Reserved Domains"].exists {
+        waitForExistence(app.cells.staticTexts["Example Domain"])
+        if !app.cells.staticTexts["IANA — IANA-managed Reserved Domains"].exists {
             navigator.goto(TabTray)
-            app.collectionViews.cells["Example Domain"].tap()
+            app.cells.staticTexts["Example Domain"].tap()
             waitUntilPageLoad()
             navigator.nowAt(BrowserTab)
             navigator.goto(TabTray)
-            waitForExistence(app.collectionViews.cells["IANA — IANA-managed Reserved Domains"])
+            waitForExistence(app.cells.staticTexts["IANA — IANA-managed Reserved Domains"])
         }
     }
 
@@ -71,8 +71,8 @@ class TopTabsTest: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
 
-        waitForExistence(app.collectionViews.cells[urlLabel])
-        app.collectionViews.cells[urlLabel].tap()
+        waitForExistence(app.cells.staticTexts[urlLabel])
+        app.cells.staticTexts[urlLabel].tap()
         let valueMozilla = app.textFields["url"].value as! String
         XCTAssertEqual(valueMozilla, urlValueLong)
 
@@ -80,8 +80,8 @@ class TopTabsTest: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
 
-        waitForExistence(app.collectionViews.cells[urlLabelExample])
-        app.collectionViews.cells[urlLabelExample].tap()
+        waitForExistence(app.cells.staticTexts[urlLabelExample])
+        app.cells.staticTexts[urlLabelExample].tap()
         let value = app.textFields["url"].value as! String
         XCTAssertEqual(value, urlValueLongExample)
     }
@@ -92,10 +92,10 @@ class TopTabsTest: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
 
-        waitForExistence(app.collectionViews.cells[urlLabel])
+        waitForExistence(app.cells.staticTexts[urlLabel])
 
-        // 'x' button to close the tab is not visible, so closing by swiping the tab
-        app.collectionViews.cells[urlLabel].swipeRight()
+        // Close the tab using 'x' button
+        app.cells.buttons["closeTabButtonTabTray"].tap()
 
         // After removing only one tab it automatically goes to HomepanelView
         waitForExistence(app.collectionViews.cells["TopSitesCell"])
@@ -131,13 +131,13 @@ class TopTabsTest: BaseTestCase {
         // Close all tabs, undo it and check that the number of tabs is correct
         navigator.performAction(Action.AcceptRemovingAllTabs)
         app.buttons["Undo"].tap()
-        waitForExistence(app.collectionViews.cells["TopSitesCell"], timeout: 5)
+        waitForExistence(app.cells.staticTexts["TopSitesCell"], timeout: 5)
         navigator.nowAt(BrowserTab)
         if !iPad() {
             waitForExistence(app.buttons["TabToolbar.tabsButton"], timeout: 5)
         }
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
-        waitForExistence(app.collectionViews.cells[urlLabel])
+        waitForExistence(app.cells.staticTexts[urlLabel])
     }
 
     func testCloseAllTabsPrivateModeUndo() {
@@ -188,7 +188,7 @@ class TopTabsTest: BaseTestCase {
             waitForExistence(app.buttons["TabToolbar.tabsButton"])
         }
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
-        waitForNoExistence(app.collectionViews.cells[urlLabel])
+        waitForNoExistence(app.cells.staticTexts[urlLabel])
     }
 
     func testCloseAllTabsPrivateMode() {
@@ -201,7 +201,8 @@ class TopTabsTest: BaseTestCase {
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
-        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
+        // By default with new chron tab there is one tab in private mode
+        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 3)
 
         // Close all tabs and check that the number of tabs is correct
         navigator.performAction(Action.AcceptRemovingAllTabs)
@@ -239,8 +240,8 @@ class TopTabsTest: BaseTestCase {
             app.cells["quick_action_new_tab"].tap()
             waitForTabsButton()
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
-            waitForExistence(app.collectionViews.cells["Home"])
-            app.collectionViews.cells["Home"].firstMatch.tap()
+            waitForExistence(app.cells.staticTexts["Home"])
+            app.cells.staticTexts["Home"].firstMatch.tap()
 
             // Close tab
             navigator.nowAt(HomePanelsScreen)
@@ -251,8 +252,8 @@ class TopTabsTest: BaseTestCase {
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
 
             // Go to Private Mode
-            waitForExistence(app.collectionViews.cells["Home"])
-            app.collectionViews.cells["Home"].firstMatch.tap()
+            waitForExistence(app.cells.staticTexts["Home"])
+            app.cells.staticTexts["Home"].firstMatch.tap()
             navigator.nowAt(HomePanelsScreen)
             waitForExistence(app.buttons["Show Tabs"])
             app.buttons["Show Tabs"].press(forDuration: 1)
@@ -271,7 +272,7 @@ fileprivate extension BaseTestCase {
     }
 
     func closeTabTrayView(goBackToBrowserTab: String) {
-        app.collectionViews.cells[goBackToBrowserTab].firstMatch.tap()
+        app.cells.staticTexts[goBackToBrowserTab].firstMatch.tap()
         navigator.nowAt(BrowserTab)
     }
 }
@@ -315,8 +316,8 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
         waitForTabsButton()
         navigator.performAction(Action.OpenPrivateTabLongPressTabsButton)
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
-        waitForExistence(app.buttons["TabTrayController.maskButton"])
-        XCTAssertTrue(app.buttons["TabTrayController.maskButton"].isEnabled)
+        waitForExistence(app.buttons["smallPrivateMask"])
+        XCTAssertTrue(app.buttons["smallPrivateMask"].isEnabled)
         XCTAssertTrue(userState.isPrivate)
     }
 
@@ -383,7 +384,7 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
         waitForExistence(app.textFields["url"], timeout: 5)
         waitForValueContains(app.textFields["url"], value: "iana")
         navigator.goto(TabTray)
-        XCTAssertTrue(app.buttons["TabTrayController.maskButton"].isEnabled)
+        XCTAssertTrue(app.buttons["smallPrivateMask"].isEnabled)
     }
 }
 

--- a/XCUITests/TopTabsTest.swift
+++ b/XCUITests/TopTabsTest.swift
@@ -131,7 +131,7 @@ class TopTabsTest: BaseTestCase {
         // Close all tabs, undo it and check that the number of tabs is correct
         navigator.performAction(Action.AcceptRemovingAllTabs)
         app.buttons["Undo"].tap()
-        waitForExistence(app.cells.staticTexts["TopSitesCell"], timeout: 5)
+        waitForExistence(app.collectionViews.cells["TopSitesCell"], timeout: 5)
         navigator.nowAt(BrowserTab)
         if !iPad() {
             waitForExistence(app.buttons["TabToolbar.tabsButton"], timeout: 5)
@@ -158,7 +158,7 @@ class TopTabsTest: BaseTestCase {
             waitForExistence(app.buttons["TabToolbar.tabsButton"],timeout: 5)
         }
 
-        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
+        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 3)
 
         // Close all tabs, undo it and check that the number of tabs is correct
         navigator.performAction(Action.AcceptRemovingAllTabs)
@@ -362,7 +362,7 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
         XCTAssertTrue(app.links["RFC 2606"].exists)
         waitForExistence(app.buttons["Show Tabs"])
         let numPrivTab = app.buttons["Show Tabs"].value as? String
-        XCTAssertEqual("2", numPrivTab)
+        XCTAssertEqual("3", numPrivTab)
     }
 
     // This test is disabled for iPad because the toast menu is not shown there

--- a/XCUITests/TrackingProtectionTests.swift
+++ b/XCUITests/TrackingProtectionTests.swift
@@ -29,6 +29,7 @@ class TrackingProtectionTests: BaseTestCase {
 
         // Now there should not be any shield icon
         waitForNoExistence(app.buttons["TabLocationView.trackingProtectionButton"])
+        waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: 5)
         navigator.goto(BrowserTab)
 
         // Switch to Private Browsing
@@ -38,6 +39,8 @@ class TrackingProtectionTests: BaseTestCase {
 
         // Make sure TP is off also in PMB
         waitForNoExistence(app.buttons["TabLocationView.trackingProtectionButton"])
+        waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: 10)
+        navigator.goto(SettingsScreen)
         // Enable TP again
         navigator.goto(TrackingProtectionSettings)
         // Turn on ETP


### PR DESCRIPTION
This PR is similar to an old one that updated the tests for the new chron tab implementation with a few more modifications...
The old commit was reverted when chron tabs was not enabled by default but since it is on again on debug builds we would need it.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1315)
