### PR TITLE
FXIOS-1321 ⁃ Fix for FXIOS-1281

### DIFF
--- a/WidgetKit/ImageButtonWithLabel.swift
+++ b/WidgetKit/ImageButtonWithLabel.swift
@@ -71,7 +71,7 @@ struct ImageButtonWithLabel: View {
                     HStack(alignment: .top) {
                         VStack(alignment: .leading){
                                 Text(link.label)
-                                    .font(.headline)
+                                    .font(.system(size: 13))
                                     .minimumScaleFactor(0.75)
                                     .layoutPriority(1000)
                         }


### PR DESCRIPTION
Updated the font size for the homescreen widget's text to 13Px which was previously set as System Headline

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1321)
