### PR TITLE
FXIOS-1323 ⁃ Update ImageButtonWithLabel.swift

### DIFF
--- a/WidgetKit/ImageButtonWithLabel.swift
+++ b/WidgetKit/ImageButtonWithLabel.swift
@@ -67,7 +67,7 @@ struct ImageButtonWithLabel: View {
                     HStack(alignment: .top) {
                         VStack(alignment: .leading){
                                 Text(link.label)
-                                    .font(.headline)
+                                    .font(.system(size: 13))
                                     .layoutPriority(1000)
                         }
                         Spacer()


### PR DESCRIPTION
FXIOS-1281
Updated the font size for the homescreen widget's text to 13Px which was previously set as System Headline

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1323)
