### PR TITLE
FXIOS-1349 ⁃ Update README to reflect the need for virtualenv in bootstrap.sh.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ Building the code
 -----------------
 
 1. Install the latest [Xcode developer tools](https://developer.apple.com/xcode/downloads/) from Apple.
-1. Install Carthage and Node
+1. Install Carthage, Node, and a Python 3 virtualenv for localization scripts:
     ```shell
     brew update
     brew install carthage
     brew install node
+    pip3 install virtualenv
     ```
 1. Clone the repository:
     ```shell


### PR DESCRIPTION
Without this, the bootstrap script will fail to download localizations (e.g., `ar.lproj`), and the build will fail with messages like

```
error: Build input file cannot be found: '/Users/$USER/repos/firefox-ios/Client/ar.lproj/Today.strings' (in target 'Today' from project 'Client')
```

Tested with `./bootstrap.sh --force`.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1349)
