### PR TITLE
FXIOS-639 ⁃ Fixes: #6995 - If URL schema is valid but empty don't ask to open in external app

### DIFF
--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -286,7 +286,7 @@ extension URL {
      */
     public var schemeIsValid: Bool {
         guard let scheme = scheme else { return false }
-        return permanentURISchemes.contains(scheme.lowercased())
+        return permanentURISchemes.contains(scheme.lowercased()) && self.absoluteURL.absoluteString.lowercased() != scheme + ":"
     }
 
     public func havingRemovedAuthorisationComponents() -> URL {


### PR DESCRIPTION
fixes #6995

Given #6995, added a condition to the URL scheme validation if the scheme is valid (is one of the permanentURISchemes, ex: javascript, telnet, etc.). But is empty (meaning there is nothing more than the scheme, ex: "javascript:", "ftp:") it will be invalid and will do a search instead of trying to open it in another app. The same behavior happens in other browsers in the platform, chrome, safari, opera.

https://imgur.com/a/4BrynNl (preview video)

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1351)
