### PR TITLE
FXIOS-1354 ⁃ FXIOS-639 - fixes #6995 If URL schema is valid but empty don't ask to…

### DIFF
--- a/ClientTests/SearchTests.swift
+++ b/ClientTests/SearchTests.swift
@@ -25,7 +25,6 @@ class SearchTests: XCTestCase {
     func testURIFixup() {
         // Check valid URLs. We can load these after some fixup.
         checkValidURL("http://www.mozilla.org", afterFixup: "http://www.mozilla.org")
-        checkValidURL("about:", afterFixup: "about:")
         checkValidURL("about:config", afterFixup: "about:config")
         checkValidURL("about: config", afterFixup: "about:%20config")
         checkValidURL("file:///f/o/o", afterFixup: "file:///f/o/o")
@@ -43,6 +42,10 @@ class SearchTests: XCTestCase {
         checkInvalidURL("创业咖啡")
         checkInvalidURL("创业咖啡 中国")
         checkInvalidURL("创业咖啡. 中国")
+        checkInvalidURL("about:")
+        checkInvalidURL("javascript:")
+        checkInvalidURL("ftp:")
+        
     }
 
     func testURIFixupPunyCode() {

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -286,7 +286,7 @@ extension URL {
      */
     public var schemeIsValid: Bool {
         guard let scheme = scheme else { return false }
-        return permanentURISchemes.contains(scheme.lowercased())
+        return permanentURISchemes.contains(scheme.lowercased()) && self.absoluteURL.absoluteString.lowercased() != scheme + ":"
     }
 
     public func havingRemovedAuthorisationComponents() -> URL {


### PR DESCRIPTION
fixes #6995

Given #6995, added a condition to the URL scheme validation if the scheme is valid (is one of the permanentURISchemes, ex: javascript, telnet, etc.). But is empty (meaning there is nothing more than the scheme, ex: "javascript:", "ftp:") it will be invalid and will do a search instead of trying to open it in another app. The same behavior happens in other browsers in the platform, chrome, safari, opera. and Firefox for android.

https://imgur.com/a/4BrynNl (preview video)

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1354)
