### PR TITLE
FXIOS-1357 ⁃ FXIOS-1348 — Correct deferMaybe implementation, allowing history sync to complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ Building the code
 -----------------
 
 1. Install the latest [Xcode developer tools](https://developer.apple.com/xcode/downloads/) from Apple.
-1. Install Carthage and Node
+1. Install Carthage, Node, and a Python 3 virtualenv for localization scripts:
     ```shell
     brew update
     brew install carthage
     brew install node
+    pip3 install virtualenv
     ```
 1. Clone the repository:
     ```shell

--- a/Shared/DeferredUtils.swift
+++ b/Shared/DeferredUtils.swift
@@ -60,6 +60,12 @@ public func deferMaybe<T>(_ s: T) -> Deferred<Maybe<T>> {
     return Deferred(value: Maybe(success: s))
 }
 
+// This specific overload prevents Strings, which conform to MaybeErrorType, from
+// always matching the failure case. See <https://github.com/mozilla-mobile/firefox-ios/issues/7791>.
+public func deferMaybe(_ s: String) -> Deferred<Maybe<String>> {
+    return Deferred(value: Maybe(success: s))
+}
+
 public func deferMaybe<T>(_ e: MaybeErrorType) -> Deferred<Maybe<T>> {
     return Deferred(value: Maybe(failure: e))
 }

--- a/SharedTests/DeferredTests.swift
+++ b/SharedTests/DeferredTests.swift
@@ -123,4 +123,7 @@ class DeferredTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
+    func testDeferMaybe() {
+        XCTAssertTrue(deferMaybe("foo").value.isSuccess)
+    }
 }

--- a/StorageTests/TestSQLiteHistory.swift
+++ b/StorageTests/TestSQLiteHistory.swift
@@ -1074,7 +1074,7 @@ class TestSQLiteHistory: XCTestCase {
         // Insert something with an invalid domain ID. We have to manually do this since domains are usually hidden.
         let insertDeferred = db.withConnection { connection -> Void in
             try connection.executeChange("PRAGMA foreign_keys = OFF")
-                         let insert = "INSERT INTO history (guid, url, title, local_modified, is_deleted, should_upload, domain_id) VALUES (?, ?, ?, ?, ?, ?, ?)"
+            let insert = "INSERT OR REPLACE INTO history (guid, url, title, local_modified, is_deleted, should_upload, domain_id) VALUES (?, ?, ?, ?, ?, ?, ?)"
             let args: Args = [Bytes.generateGUID(), site.url, site.title, Date.now(), 0, 0, -1]
             try connection.executeChange(insert, withArgs: args)
         }
@@ -1643,5 +1643,8 @@ class TestSQLiteHistoryTransactionUpdate: XCTestCase {
         let ts: MicrosecondTimestamp = baseInstantInMicros
         let local = SiteVisit(site: site, date: ts, type: VisitType.link)
         XCTAssertTrue(history.addLocalVisit(local).value.isSuccess)
+
+        // Doing it again is a no-op and will not fail.
+        history.insertOrUpdatePlace(site.asPlace(), modified: 1234567890).succeeded()
     }
 }


### PR DESCRIPTION
See the discussion in #7791.

This change ensures that

```swift
deferMaybe("some string")
```

means *success*, not *error*. Just because a string can be printed doesn't mean it's an error!

This pull request is built on top of #7793 in order to simplify rebases and landing.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1357)
