### PR TITLE
FXIOS-1380 ⁃ FXIOS-1281: closes #7722 widgets font size too large on medium search widget

### DIFF
--- a/WidgetKit/ImageButtonWithLabel.swift
+++ b/WidgetKit/ImageButtonWithLabel.swift
@@ -71,7 +71,7 @@ struct ImageButtonWithLabel: View {
                     HStack(alignment: .top) {
                         VStack(alignment: .leading){
                                 Text(link.label)
-                                    .font(.headline)
+                                    .font(.system(size: 13, weight: .semibold, design: .default))
                                     .minimumScaleFactor(0.75)
                                     .layoutPriority(1000)
                         }

--- a/WidgetKit/ImageButtonWithLabel.swift
+++ b/WidgetKit/ImageButtonWithLabel.swift
@@ -71,7 +71,7 @@ struct ImageButtonWithLabel: View {
                     HStack(alignment: .top) {
                         VStack(alignment: .leading){
                                 Text(link.label)
-                                    .font(.system(size: 13, weight: .semibold, design: .default))
+                                    .font(.footnote)
                                     .minimumScaleFactor(0.75)
                                     .layoutPriority(1000)
                         }


### PR DESCRIPTION
closes #7722 Changed font size from .headline (17), to 13 as instructed.

Before | After
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 - 2021-01-08 at 00 16 38](https://user-images.githubusercontent.com/2073238/103978139-ccc6ae00-5148-11eb-8094-242fa81cab44.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-08 at 00 19 08](https://user-images.githubusercontent.com/2073238/103978145-d2bc8f00-5148-11eb-8256-6e60524381b5.png)

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1380)
