### PR TITLE
FXIOS-1381 ⁃ FXIOS-1166: closes #7605 Confirmation snackbars are missing from address bar context menu action: "Copy Address".

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1534,7 +1534,7 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBarDidLongPressLocation(_ urlBar: URLBarView) {
-        let urlActions = self.getLongPressLocationBarActions(with: urlBar)
+        let urlActions = self.getLongPressLocationBarActions(with: urlBar, webViewContainer: self.webViewContainer)
         let generator = UIImpactFeedbackGenerator(style: .heavy)
         generator.impactOccurred()
         self.presentSheetWith(actions: [urlActions], on: self, from: urlBar)

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -49,7 +49,7 @@ extension PhotonActionSheetProtocol {
         return self.profile.history.isPinnedTopSite(url)
     }
 
-    func getLongPressLocationBarActions(with urlBar: URLBarView) -> [PhotonActionSheetItem] {
+    func getLongPressLocationBarActions(with urlBar: URLBarView, webViewContainer: UIView) -> [PhotonActionSheetItem] {
         let pasteGoAction = PhotonActionSheetItem(title: Strings.PasteAndGoTitle, iconString: "menu-PasteAndGo") { _, _ in
             if let pasteboardContents = UIPasteboard.general.string {
                 urlBar.delegate?.urlBar(urlBar, didSubmitText: pasteboardContents)
@@ -63,9 +63,7 @@ extension PhotonActionSheetProtocol {
         let copyAddressAction = PhotonActionSheetItem(title: Strings.CopyAddressTitle, iconString: "menu-Copy-Link") { _, _ in
             if let url = self.tabManager.selectedTab?.canonicalURL?.displayURL ?? urlBar.currentURL {
                 UIPasteboard.general.url = url
-                if let view = urlBar.window {
-                    SimpleToast().showAlertWithText(Strings.AppMenuCopyURLConfirmMessage, bottomContainer: view)
-                }
+                SimpleToast().showAlertWithText(Strings.AppMenuCopyURLConfirmMessage, bottomContainer: webViewContainer)
             }
         }
         if UIPasteboard.general.string != nil {

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -63,6 +63,9 @@ extension PhotonActionSheetProtocol {
         let copyAddressAction = PhotonActionSheetItem(title: Strings.CopyAddressTitle, iconString: "menu-Copy-Link") { _, _ in
             if let url = self.tabManager.selectedTab?.canonicalURL?.displayURL ?? urlBar.currentURL {
                 UIPasteboard.general.url = url
+                if let view = urlBar.window {
+                    SimpleToast().showAlertWithText(Strings.AppMenuCopyURLConfirmMessage, bottomContainer: view)
+                }
             }
         }
         if UIPasteboard.general.string != nil {


### PR DESCRIPTION
Closes #7605 
Added toast confirmation when copy address as per requirement.


https://user-images.githubusercontent.com/2073238/103979954-e4079a80-514c-11eb-9a7a-0287965dc8ea.mov


Demo Video

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1381)
