### PR TITLE
Revert "FXIOS-1382 ⁃ FXIOS-1168: closes #7608 when the keyboard is minimized on scroll, the address bar should be unfocused/unselected."

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -732,11 +732,6 @@ extension URLBarView: TabLocationViewDelegate {
 }
 
 extension URLBarView: AutocompleteTextFieldDelegate {
-    func autocompleteTextFieldShouldEndEditing(_ autocompleteTextField: AutocompleteTextField) -> Bool {
-        leaveOverlayMode()
-        return true
-    }
-
     func autocompleteTextFieldShouldReturn(_ autocompleteTextField: AutocompleteTextField) -> Bool {
         guard let text = locationTextField?.text else { return true }
         if !text.trimmingCharacters(in: .whitespaces).isEmpty {

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -11,7 +11,6 @@ import Shared
 /// callers must use this instead.
 protocol AutocompleteTextFieldDelegate: AnyObject {
     func autocompleteTextField(_ autocompleteTextField: AutocompleteTextField, didEnterText text: String)
-    func autocompleteTextFieldShouldEndEditing(_ autocompleteTextField: AutocompleteTextField) -> Bool
     func autocompleteTextFieldShouldReturn(_ autocompleteTextField: AutocompleteTextField) -> Bool
     func autocompleteTextFieldShouldClear(_ autocompleteTextField: AutocompleteTextField) -> Bool
     func autocompleteTextFieldDidCancel(_ autocompleteTextField: AutocompleteTextField)
@@ -247,7 +246,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
 
     func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
         applyCompletion()
-        return autocompleteDelegate?.autocompleteTextFieldShouldEndEditing(self) ?? true
+        return true
     }
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {


### PR DESCRIPTION
Reverts mozilla-mobile/firefox-ios#7825