### PR TITLE
FXIOS-1399 ⁃ FXIOS-1168: closes #7608 when the keyboard is minimized on scroll, th…

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -732,6 +732,11 @@ extension URLBarView: TabLocationViewDelegate {
 }
 
 extension URLBarView: AutocompleteTextFieldDelegate {
+    func autocompleteTextFieldShouldEndEditing(_ autocompleteTextField: AutocompleteTextField) -> Bool {
+        leaveOverlayMode()
+        return true
+    }
+
     func autocompleteTextFieldShouldReturn(_ autocompleteTextField: AutocompleteTextField) -> Bool {
         guard let text = locationTextField?.text else { return true }
         if !text.trimmingCharacters(in: .whitespaces).isEmpty {

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -11,6 +11,7 @@ import Shared
 /// callers must use this instead.
 protocol AutocompleteTextFieldDelegate: AnyObject {
     func autocompleteTextField(_ autocompleteTextField: AutocompleteTextField, didEnterText text: String)
+    func autocompleteTextFieldShouldEndEditing(_ autocompleteTextField: AutocompleteTextField) -> Bool
     func autocompleteTextFieldShouldReturn(_ autocompleteTextField: AutocompleteTextField) -> Bool
     func autocompleteTextFieldShouldClear(_ autocompleteTextField: AutocompleteTextField) -> Bool
     func autocompleteTextFieldDidCancel(_ autocompleteTextField: AutocompleteTextField)
@@ -246,7 +247,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
 
     func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
         applyCompletion()
-        return true
+        return autocompleteDelegate?.autocompleteTextFieldShouldEndEditing(self) ?? true
     }
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {


### PR DESCRIPTION
…e address bar should be unfocused/unselected.

Added autocompleteTextFieldShouldEndEditing to delegate so that we can listen to unfocus of url text field, listen to it and leave overlay mode.

┆Issue is synchronized with this [Jira Task](https://jira.mozilla.com/browse/FXIOS-1399)
