### PR TITLE
For #7868 - XCUITests modify Common workflow for scheduled builds

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1121,6 +1121,7 @@ workflows:
         inputs:
         - scheme: Fennec_Enterprise_UITests
         - simulator_device: iPhone 8
+        is_always_run: true
     - deploy-to-bitrise-io@1.9: {}
     - cache-push@2.2:
         is_always_run: true
@@ -2052,7 +2053,7 @@ workflows:
         - configuration: Release
         - xcodebuild_options: >-
             CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
-            CODE_SIGNING_ALLOWED=NO
+            CODE_SIGNING_ALLOWED=NO -testPlan SmokeXCUITests
         - scheme: Fennec_Enterprise_XCUITests
         - xcodebuild_test_options: '-testPlan SmokeXCUITests'
     - deploy-to-bitrise-io@1.9: {}


### PR DESCRIPTION
Fixes #7868 by allowing the RunUITest workflow to run if any step failed before (as long as it is not directly impacted) and also selecting the -testPlan for the Smoketest workflow otherwise there are several when building the build for testing and an error thrown complaining about that even though the tests can run successfuly

