### PR TITLE
Create new workflow for xcode-test branch

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,39 @@
+name: github actions Demo
+
+on: 
+  schedule:
+    - cron: '1 9 * * *'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+       
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r ./test-fixtures/requirements.txt
+
+    - name: Modify bitrise.yml 
+      run: |
+        python ./test-fixtures/update.py
+
+    - name: Commit and push if bitrise.yml changed
+      run: |-
+        git diff
+        git config --global user.email "bitrise-yml-bot@example.com"
+        git config --global user.name "BITRISE.YML-bot"
+        git diff --quiet || (git add bitrise.yml && git commit -m "Updated bitrise.yml")
+        git push

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2794,6 +2794,171 @@ workflows:
         is_expand: false
       BITRISE_SCHEME: Firefox
     description: ''
+  NewXcodeVersions:
+    steps:
+    - activate-ssh-key@4.0:
+        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+    - git-clone@4.0: {}
+    - script@1.1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            echo "PostClone step"
+            carthage checkout
+
+            cd content-blocker-lib-ios/ContentBlockerGen && swift run
+        title: Post clone step for TP updates
+    - cache-pull@2.4: {}
+    - certificate-and-profile-installer@1.10: {}
+    - script@1:
+        inputs:
+        - content: >-
+            #!/usr/bin/env bash
+
+            set -e
+
+            set -x
+
+
+            echo
+            'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64
+            arm64e armv7 armv7s armv6 armv8' > /tmp/tmp.xcconfig
+
+            echo 'EXCLUDED_ARCHS=$(inherited)
+            $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))'
+            >> /tmp/tmp.xcconfig
+
+            echo 'IPHONEOS_DEPLOYMENT_TARGET=11.4' >> /tmp/tmp.xcconfig
+
+            echo 'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig
+
+            echo 'GCC_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig
+
+            export XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig
+
+            envman add --key XCODE_XCCONFIG_FILE --value /tmp/tmp.xcconfig
+        title: Workaround carthage lipo bug
+    - carthage@3.2:
+        inputs:
+        - carthage_options: '--platform ios'
+    - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+            set -x
+
+            rm /tmp/tmp.xcconfig
+            envman add --key XCODE_XCCONFIG_FILE --value ''
+        title: Remove carthage lipo workaround
+    - script@1:
+        inputs:
+        - content: >-
+
+            #!/usr/bin/env bash
+
+            set -e
+
+            set -x
+
+
+            # Import only the shipping locales (from shipping_locales.txt) on
+            Release
+
+            # builds. Import all locales on Beta and Fennec_Enterprise, except
+            for pull
+
+            # requests.
+
+            git clone https://github.com/mozilla-mobile/ios-l10n-scripts.git ||
+            exit 1
+
+            pip install --user virtualenv
+
+            cd /usr/local/bin
+
+            ln -s /Users/vagrant/Library/Python/3.8/bin/virtualenv .
+
+            cd -
+
+            ./ios-l10n-scripts/import-locales-firefox.sh --release
+        title: Pull in L10N
+    - script@1:
+        inputs:
+        - content: >-
+            #!/usr/bin/env bash
+
+            set -e
+
+            set -x
+
+
+            cd Client.xcodeproj
+
+            sed -i '' 's/"Fennec Development"/"Bitrise Firefox iOS Dev"/'
+            project.pbxproj
+
+            sed -i '' 's/Fennec Today Development/Bitrise Firefox iOS Dev -
+            Fennec Today/' project.pbxproj
+
+            sed -i '' 's/Fennec ShareTo Development/Bitrise Firefox iOS Dev -
+            Share To/' project.pbxproj
+
+            sed -i '' 's/Fennec WidgetKit Development/Bitrise Firefox iOS Dev -
+            WidgetKit/' project.pbxproj
+
+            sed -i '' 's/"XCUITests"/"Bitrise Firefox iOS Dev - XCUI Tests"/'
+            project.pbxproj
+
+            sed -i '' 's/Fennec NotificationService Development/Bitrise Firefox
+            iOS Dev - Notification Service/' project.pbxproj
+
+            sed -i '' 's/CODE_SIGN_IDENTITY = "iPhone
+            Developer"/CODE_SIGN_IDENTITY = "iPhone Distribution"/'
+            project.pbxproj
+
+            cd -
+        title: Set provisioning to Bitrise in xcodeproj
+    - script@1.1:
+        title: NPM install and build
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            npm install
+            npm run build
+    - 'git::https://github.com/bitrise-steplib/steps-xcode-build-for-test.git@export-fix':
+        inputs:
+        - xcodebuild_options: >-
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+            CODE_SIGNING_ALLOWED=NO
+        - scheme: Fennec
+    - xcode-test@2:
+        inputs:
+        - scheme: Fennec
+        - simulator_device: iPhone 8
+    - deploy-to-bitrise-io@1.9: {}
+    - cache-push@2.4: {}
+    - slack@3.1:
+        inputs:
+        - webhook_url: $WEBHOOK_SLACK_TOKEN
+    description: >-
+      This Workflow is to run tests (currently SmokeTest) when there is a merge
+      in master
+    meta:
+      bitrise.io:
+        stack: osx-xcode-12.0.x
+    after_run:
+    - RunSmokeXCUITests
 app:
   envs:
   - opts:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2796,6 +2796,22 @@ workflows:
     description: ''
   NewXcodeVersions:
     steps:
+    - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            YESTERDAY=`date -d "yesterday" '+%Y-%m-%d'`
+
+            pip install jq
+
+            curl -s -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/mozilla-mobile/firefox-ios/commits\?sha\=main\&since\=$YESTERDAY | jq -e -r '.[].commit.author | select(.name | contains("BITRISE.YML-bot"))'
+            test $? -eq 0 || exit 1
+        title: "Check xcode-test branch for recent activity before continuning"
     - activate-ssh-key@4.0:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@4.0: {}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2811,7 +2811,7 @@ workflows:
 
             curl -s -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/mozilla-mobile/firefox-ios/commits\?sha\=main\&since\=$YESTERDAY | jq -e -r '.[].commit.author | select(.name | contains("BITRISE.YML-bot"))'
             test $? -eq 0 || exit 1
-        title: "Check xcode-test branch for recent activity before continuning"
+        title: "Check main branch for recent activity before continuing"
     - activate-ssh-key@4.0:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@4.0: {}
@@ -2972,7 +2972,7 @@ workflows:
       in master
     meta:
       bitrise.io:
-        stack: osx-xcode-12.0.x
+        stack: osx-xcode-10.2.x
     after_run:
     - RunSmokeXCUITests
 app:

--- a/test-fixtures/requirements.txt
+++ b/test-fixtures/requirements.txt
@@ -1,0 +1,3 @@
+semver
+requests
+PyYAML

--- a/test-fixtures/update.py
+++ b/test-fixtures/update.py
@@ -1,0 +1,91 @@
+import os
+import re
+import sys
+import pathlib
+from shutil import copyfile
+import yaml
+
+
+import requests
+import semver
+from requests.exceptions import HTTPError
+
+
+BITRISE_STACK_INFO = 'https://app.bitrise.io/app/6c06d3a40422d10f/all_stack_info'
+'''
+curl ${BITRISE_STACK_INFO} | jq ' . | keys'
+[
+  "available_stacks",
+  "project_types_with_default_stacks",
+  "running_builds_on_private_cloud"
+]
+'''
+pattern = 'osx-xcode-'
+BITRISE_YML = 'bitrise.yml'
+WORKFLOW = 'NewXcodeVersions'
+
+resp = requests.get(BITRISE_STACK_INFO)
+resp.raise_for_status()
+resp_json = resp.json()
+
+
+def parse_semver(raw_str):
+    parsed = raw_str.split(pattern)[1]
+    if parsed[-1] == 'x':
+        p = parsed.split('.x')[0]
+        return '{0}.0'.format(p)
+    else:
+        return False
+
+
+def available_stacks():
+    try:
+        resp = requests.get(BITRISE_STACK_INFO)
+        resp_json = resp.json()
+        return resp_json['available_stacks']
+    except HTTPError as http_error:
+        print('An HTTP error has occurred: {http_error}')
+    except Exception as err:
+        print('An exception has occurred: {err}')
+
+
+def largest_version():
+    stacks = available_stacks()
+    count = 0
+    for item in stacks:
+        if pattern in item:
+            p = parse_semver(item)
+            if p:
+                if count == 0 or semver.compare(largest, p) == -1:
+                    largest = p 
+                count += 1
+    return '{0}.x'.format(largest.split('.0')[0])
+
+
+
+if __name__ == '__main__':
+    '''
+    STEPS
+    1. check bitrise API stack info for latest XCode version
+    2. compare latest with current bitrise.yml stack version in repo 
+    3. if same exit, if not, continue 
+    4. modify bitrise.yml (update stack value)
+    '''
+
+
+    largest_semver = largest_version()
+
+    tmp_file = 'tmp.yml'
+    with open(BITRISE_YML, 'r') as infile:
+        y = yaml.safe_load(infile)
+        current_semver = y['workflows'][WORKFLOW]['meta']['bitrise.io']['stack'] 
+
+        if current_semver == largest_semver:
+            print('XCode version unchanged! aborting.')
+        else:
+            print('New XCode version available: {0} ... updating bitrise.yml!'.format(largest_semver))
+            y['workflows'][WORKFLOW]['meta']['bitrise.io']['stack'] = largest_semver 
+            with open(tmp_file, 'w+') as tmpfile:
+                yaml.dump(y, tmpfile, default_flow_style=False) 
+                copyfile(tmp_file, BITRISE_YML)
+

--- a/test-fixtures/update.py
+++ b/test-fixtures/update.py
@@ -21,7 +21,7 @@ curl ${BITRISE_STACK_INFO} | jq ' . | keys'
 ]
 '''
 pattern = 'osx-xcode-'
-BITRISE_YML = 'bitrise.yml'
+BITRISE_YML = '../bitrise.yml'
 WORKFLOW = 'NewXcodeVersions'
 
 resp = requests.get(BITRISE_STACK_INFO)
@@ -81,9 +81,9 @@ if __name__ == '__main__':
         current_semver = y['workflows'][WORKFLOW]['meta']['bitrise.io']['stack'] 
 
         if current_semver == largest_semver:
-            print('XCode version unchanged! aborting.')
+            print('Xcode version unchanged! aborting.')
         else:
-            print('New XCode version available: {0} ... updating bitrise.yml!'.format(largest_semver))
+            print('New Xcode version available: {0} ... updating bitrise.yml!'.format(largest_semver))
             y['workflows'][WORKFLOW]['meta']['bitrise.io']['stack'] = largest_semver 
             with open(tmp_file, 'w+') as tmpfile:
                 yaml.dump(y, tmpfile, default_flow_style=False) 


### PR DESCRIPTION
This PR would add a new workflow to test and finally enable the xcode-test branch to do its job :) 
This workflow is based in the RunUnitTest workflow which builds the app and runs Unit and SmokeTest. Those checks would be enough to check if the app works well with the newest Xcode versions
