### PR TITLE
Issue #7699: Update widgets strings

### DIFF
--- a/WidgetKit/OpenTabs/OpenTabsWidget.swift
+++ b/WidgetKit/OpenTabs/OpenTabsWidget.swift
@@ -16,7 +16,7 @@ struct OpenTabsWidget: Widget {
         }
         .supportedFamilies([.systemMedium, .systemLarge])
         .configurationDisplayName(String.QuickViewGalleryTitle)
-        .description(String.QuickViewGalleryDescription)
+        .description(String.QuickViewGalleryDescriptionV2)
     }
 }
 

--- a/WidgetKit/SearchQuickLinksMedium/SearchQuickLinks.swift
+++ b/WidgetKit/SearchQuickLinksMedium/SearchQuickLinks.swift
@@ -55,7 +55,7 @@ struct SearchQuickLinksWidget: Widget {
             SearchQuickLinksEntryView()
         }
         .supportedFamilies([.systemMedium])
-        .configurationDisplayName(String.QuickActionsGalleryTitle)
+        .configurationDisplayName(String.QuickActionsGalleryTitlev2)
         .description(String.FirefoxShortcutGalleryDescription)
     }
 }

--- a/WidgetKit/SearchQuickLinksSmall/SmallQuickLink.swift
+++ b/WidgetKit/SearchQuickLinksSmall/SmallQuickLink.swift
@@ -48,7 +48,7 @@ struct SmallQuickLinkWidget: Widget {
             SmallQuickLinkView(entry: entry)
         }
         .supportedFamilies([.systemSmall])
-        .configurationDisplayName(String.QuickActionsGalleryTitle)
+        .configurationDisplayName(String.QuickActionsGalleryTitlev2)
         .description(String.SearchInFirefoxTitle)
     }
 }


### PR DESCRIPTION
**Note this does not include the update for the small quick actions widget because that functionality has not been implemented yet.**

![Simulator Screen Shot - iPhone 11 - 2021-01-29 at 15 49 36](https://user-images.githubusercontent.com/11432165/106325936-a8428b00-6249-11eb-928d-3a86c3dabc63.png)
![Simulator Screen Shot - iPhone 11 - 2021-01-29 at 15 49 40](https://user-images.githubusercontent.com/11432165/106325945-ab3d7b80-6249-11eb-94bd-54580e764c14.png)
![Simulator Screen Shot - iPhone 11 - 2021-01-29 at 15 49 42](https://user-images.githubusercontent.com/11432165/106325938-a973b800-6249-11eb-99fd-482711f678d7.png)
![Simulator Screen Shot - iPhone 11 - 2021-01-29 at 15 49 45](https://user-images.githubusercontent.com/11432165/106325940-aa0c4e80-6249-11eb-8ebf-ab7ddefbc56c.png)
![Simulator Screen Shot - iPhone 11 - 2021-01-29 at 15 49 48](https://user-images.githubusercontent.com/11432165/106325944-aaa4e500-6249-11eb-9638-5df88492704d.png)

