### PR TITLE
Fix NewXcodeVersions workflow stack in bitrise.yml

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2971,7 +2971,7 @@ workflows:
       in master
     meta:
       bitrise.io:
-        stack: osx-xcode-10.2.x
+        stack: osx-xcode-10.3.x
     after_run:
     - RunSmokeXCUITests
 app:


### PR DESCRIPTION
> Failed to start Build: stack (osx-xcode-10.2.x) did not match any available stacks

osx-xcode-10.2 does not exist so the workflow was erroring out on trigger 

https://app.bitrise.io/app/6c06d3a40422d10f/all_stack_info

