### PR TITLE
Fixes #7893 - Firefox crashes after tapping close all tabs 

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -10530,6 +10530,7 @@
 				INFOPLIST_FILE = UITests/Info.plist;
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/UITests/UITests-Bridging-Header.h";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Fennec;
 		};
@@ -10538,6 +10539,7 @@
 			buildSettings = {
 				INFOPLIST_FILE = UITests/Info.plist;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Release;
 		};
@@ -10593,6 +10595,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "";
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Firefox;
 		};
@@ -10922,6 +10925,7 @@
 				INFOPLIST_FILE = UITests/Info.plist;
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/UITests/UITests-Bridging-Header.h";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Fennec_Enterprise;
 		};
@@ -11076,6 +11080,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "";
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = FirefoxBeta;
 		};

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -499,6 +499,18 @@ class TabManager: NSObject {
         privateConfiguration = TabManager.makeWebViewConfig(isPrivate: true, prefs: profile.prefs)
     }
 
+    func removeTabsWithNoUndoToast(_ tabs: [Tab]) {
+        for tab in tabs {
+            self.removeTab(tab, flushToDisk: false, notify: true)
+        }
+        
+        if normalTabs.isEmpty {
+            selectTab(addTab())
+        }
+        
+        storeChanges()
+    }
+    
     func removeTabsWithUndoToast(_ tabs: [Tab]) {
         recentlyClosedForUndo = normalTabs.compactMap {
             SavedTab(tab: $0, isSelected: selectedTab === $0)

--- a/Client/Frontend/Browser/TabTrayControllerV1.swift
+++ b/Client/Frontend/Browser/TabTrayControllerV1.swift
@@ -493,21 +493,19 @@ extension TabTrayControllerV1 {
     }
 
     func closeTabsForCurrentTray() {
-        tabDisplayManager.hideDisplayedTabs() {
-            self.tabManager.removeTabsWithUndoToast(self.tabDisplayManager.dataStore.compactMap { $0 })
-            if self.tabDisplayManager.isPrivate {
-                self.emptyPrivateTabsView.isHidden = !self.privateTabsAreEmpty()
-                if !self.emptyPrivateTabsView.isHidden {
-                    // Fade in the empty private tabs message. This slow fade allows time for the closing tab animations to complete.
-                    self.emptyPrivateTabsView.alpha = 0
-                    UIView.animate(withDuration: 0.5, animations: {
-                        self.emptyPrivateTabsView.alpha = 1
-                    }, completion: nil)
-                }
-            } else if self.tabManager.normalTabs.count == 1, let tab = self.tabManager.normalTabs.first {
-                self.tabManager.selectTab(tab)
-                self.dismissTabTray()
+        self.tabManager.removeTabsWithNoUndoToast(self.tabDisplayManager.dataStore.compactMap { $0 })
+        if self.tabDisplayManager.isPrivate {
+            self.emptyPrivateTabsView.isHidden = !self.privateTabsAreEmpty()
+            if !self.emptyPrivateTabsView.isHidden {
+                // Fade in the empty private tabs message. This slow fade allows time for the closing tab animations to complete.
+                self.emptyPrivateTabsView.alpha = 0
+                UIView.animate(withDuration: 0.5, animations: {
+                    self.emptyPrivateTabsView.alpha = 1
+                }, completion: nil)
             }
+        } else if self.tabManager.normalTabs.count == 1, let tab = self.tabManager.normalTabs.first {
+            self.tabManager.selectTab(tab)
+            self.dismissTabTray()
         }
     }
 

--- a/WidgetKit/OpenTabs/OpenTabsWidget.swift
+++ b/WidgetKit/OpenTabs/OpenTabsWidget.swift
@@ -16,7 +16,7 @@ struct OpenTabsWidget: Widget {
         }
         .supportedFamilies([.systemMedium, .systemLarge])
         .configurationDisplayName(String.QuickViewGalleryTitle)
-        .description(String.QuickViewGalleryDescription)
+        .description(String.QuickViewGalleryDescriptionV2)
     }
 }
 

--- a/WidgetKit/SearchQuickLinksMedium/SearchQuickLinks.swift
+++ b/WidgetKit/SearchQuickLinksMedium/SearchQuickLinks.swift
@@ -55,7 +55,7 @@ struct SearchQuickLinksWidget: Widget {
             SearchQuickLinksEntryView()
         }
         .supportedFamilies([.systemMedium])
-        .configurationDisplayName(String.QuickActionsGalleryTitle)
+        .configurationDisplayName(String.QuickActionsGalleryTitlev2)
         .description(String.FirefoxShortcutGalleryDescription)
     }
 }

--- a/WidgetKit/SearchQuickLinksSmall/SmallQuickLink.swift
+++ b/WidgetKit/SearchQuickLinksSmall/SmallQuickLink.swift
@@ -48,7 +48,7 @@ struct SmallQuickLinkWidget: Widget {
             SmallQuickLinkView(entry: entry)
         }
         .supportedFamilies([.systemSmall])
-        .configurationDisplayName(String.QuickActionsGalleryTitle)
+        .configurationDisplayName(String.QuickActionsGalleryTitlev2)
         .description(String.SearchInFirefoxTitle)
     }
 }

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -741,6 +741,160 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-11.7.x
+  RunUnitTestsNewL10N:
+    steps:
+    - activate-ssh-key@4.0:
+        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+    - git-clone@4.0: {}
+    - script@1.1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            echo "PostClone step"
+            carthage checkout
+
+            cd content-blocker-lib-ios/ContentBlockerGen && swift run
+        title: Post clone step for TP updates
+    - cache-pull@2.4: {}
+    - certificate-and-profile-installer@1.10: {}
+    - script@1:
+        inputs:
+        - content: >-
+            #!/usr/bin/env bash
+
+            set -e
+
+            set -x
+
+
+            echo
+            'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64
+            arm64e armv7 armv7s armv6 armv8' > /tmp/tmp.xcconfig
+
+            echo 'EXCLUDED_ARCHS=$(inherited)
+            $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))'
+            >> /tmp/tmp.xcconfig
+
+            echo 'IPHONEOS_DEPLOYMENT_TARGET=11.4' >> /tmp/tmp.xcconfig
+
+            echo 'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig
+
+            echo 'GCC_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig
+
+            export XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig
+
+            envman add --key XCODE_XCCONFIG_FILE --value /tmp/tmp.xcconfig
+        title: Workaround carthage lipo bug
+    - carthage@3.2:
+        inputs:
+        - carthage_options: '--platform ios'
+    - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+            set -x
+
+            rm /tmp/tmp.xcconfig
+            envman add --key XCODE_XCCONFIG_FILE --value ''
+        title: Remove carthage lipo workaround
+    - script@1:
+        inputs:
+        - content: >-
+
+            #!/usr/bin/env bash
+
+            set -e
+
+            set -x
+
+            # Import only the shipping locales (from shipping_locales.txt) on
+            Release
+
+            # builds. Import all locales on Beta and Fennec_Enterprise, except
+            for pull
+
+            # requests.
+            git clone https://github.com/boek/ios-l10n-scripts.git -b new_tool || exit 1
+            echo "Creating firefoxios-l10n Git repo" rm -rf firefoxios-l10n git clone --depth 1 https://github.com/mozilla-l10n/firefoxios-l10n firefoxios-l10n || exit 1
+            ./ios-l10n-scripts/ios-l10n-tools --project-path Client.xcodeproj --l10n-project-path ./firefoxios-l10n --import
+        title: Pull in L10N
+    - script@1:
+        inputs:
+        - content: >-
+            #!/usr/bin/env bash
+
+            set -e
+
+            set -x
+
+
+            cd Client.xcodeproj
+
+            sed -i '' 's/"Fennec Development"/"Bitrise Firefox iOS Dev"/'
+            project.pbxproj
+
+            sed -i '' 's/Fennec Today Development/Bitrise Firefox iOS Dev -
+            Fennec Today/' project.pbxproj
+
+            sed -i '' 's/Fennec ShareTo Development/Bitrise Firefox iOS Dev -
+            Share To/' project.pbxproj
+
+            sed -i '' 's/Fennec WidgetKit Development/Bitrise Firefox iOS Dev -
+            WidgetKit/' project.pbxproj
+
+            sed -i '' 's/"XCUITests"/"Bitrise Firefox iOS Dev - XCUI Tests"/'
+            project.pbxproj
+
+            sed -i '' 's/Fennec NotificationService Development/Bitrise Firefox
+            iOS Dev - Notification Service/' project.pbxproj
+
+            sed -i '' 's/CODE_SIGN_IDENTITY = "iPhone
+            Developer"/CODE_SIGN_IDENTITY = "iPhone Distribution"/'
+            project.pbxproj
+
+            cd -
+        title: Set provisioning to Bitrise in xcodeproj
+    - script@1.1:
+        title: NPM install and build
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            npm install
+            npm run build
+    - 'git::https://github.com/bitrise-steplib/steps-xcode-build-for-test.git@export-fix':
+        inputs:
+        - xcodebuild_options: >-
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+            CODE_SIGNING_ALLOWED=NO
+        - scheme: Fennec
+    - xcode-test@2:
+        inputs:
+        - scheme: Fennec
+        - simulator_device: iPhone 8
+    - deploy-to-bitrise-io@1.9: {}
+    - cache-push@2.4: {}
+    - slack@3.1:
+        inputs:
+        - webhook_url: $WEBHOOK_SLACK_TOKEN
+    description: >-
+      This Workflow is to run tests (currently SmokeTest) when there is a merge
+      in master
+    meta:
+      bitrise.io:
+        stack: osx-xcode-12.3.x
+    after_run:
+    - RunSmokeXCUITests
   RunUnitTests:
     steps:
     - activate-ssh-key@4.0:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1128,6 +1128,9 @@ workflows:
         inputs:
         - webhook_url: $WEBHOOK_SLACK_TOKEN
     description: This Workflow is to run tests UI TESTS
+    meta:
+      bitrise.io:
+        stack: osx-xcode-12.3.x
   RunSmokeXCUITests:
     steps:
     - cache-pull@2.1:
@@ -1144,6 +1147,9 @@ workflows:
         inputs:
         - webhook_url: $WEBHOOK_SLACK_TOKEN
     description: This Workflow is to run tests UI TESTS
+    meta:
+      bitrise.io:
+        stack: osx-xcode-12.3.x
     before_run: []
   xcode12-3-build-only:
     steps:
@@ -1686,6 +1692,9 @@ workflows:
     description: >-
       This Workflow is to run tests (currently SmokeTest) when there is a merge
       in master
+    meta:
+      bitrise.io:
+        stack: osx-xcode-12.3.x
   TEMP:
     steps:
     - activate-ssh-key@4.0:
@@ -2062,6 +2071,9 @@ workflows:
     description: >-
       This Workflow is to run tests (currently SmokeTest) when there is a merge
       in master
+    meta:
+      bitrise.io:
+        stack: osx-xcode-12.3.x
     after_run:
     - RunUITests
     - RunSmokeXCUITests
@@ -2391,206 +2403,6 @@ workflows:
         - scheme: L10nSnapshotTests
         - simulator_os_version: '14.0'
         - simulator_device: iPhone 11
-    - deploy-to-bitrise-io@1.10: {}
-    - cache-push@2.2: {}
-    - slack@3.1:
-        inputs:
-        - webhook_url: $WEBHOOK_SLACK_TOKEN
-    description: >-
-      This Workflow is to run tests (currently SmokeTest) when there is a merge
-      in master
-  aaronmt_chrontab_perftests:
-    steps:
-    - activate-ssh-key@4.0:
-        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-    - git-clone@4.0: {}
-    - script@1.1:
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            # fail if any commands fails
-            set -e
-            # debug log
-            set -x
-
-            echo "PostClone step"
-            carthage checkout
-
-            cd content-blocker-lib-ios/ContentBlockerGen && swift run
-        title: Post clone step for TP updates
-    - cache-pull@2: {}
-    - certificate-and-profile-installer@1.10: {}
-    - script@1:
-        inputs:
-        - content: >-
-            #!/usr/bin/env bash
-
-            # fail if any commands fails
-
-            set -e
-
-            # debug log
-
-            set -x
-
-
-            echo
-            'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64
-            arm64e armv7 armv7s armv6 armv8' > /tmp/tmp.xcconfig
-
-            echo 'EXCLUDED_ARCHS=$(inherited)
-            $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))'
-            >> /tmp/tmp.xcconfig
-
-            echo 'IPHONEOS_DEPLOYMENT_TARGET=11.4' >> /tmp/tmp.xcconfig
-
-            echo 'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig
-
-            echo 'GCC_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig
-
-            export XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig
-
-            envman add --key XCODE_XCCONFIG_FILE --value /tmp/tmp.xcconfig
-        title: 'Workaround carthage lipo bug #3019'
-    - carthage@3.2:
-        inputs:
-        - carthage_options: ' --platform ios'
-    - script@1:
-        title: Remove carthage lipo workaround
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            # fail if any commands fails
-            set -e
-            # debug log
-            set -x
-
-            rm /tmp/tmp.xcconfig
-            envman add --key XCODE_XCCONFIG_FILE --value ''
-    - script@1:
-        inputs:
-        - content: >-
-            #!/usr/bin/env bash
-
-            set -e
-
-            set -x
-
-
-            # Import only the shipping locales (from shipping_locales.txt) on
-            Release
-
-            # builds. Import all locales on Beta and Fennec_Enterprise, except
-            for pull
-
-            # requests.
-
-            git clone https://github.com/mozilla-mobile/ios-l10n-scripts.git ||
-            exit 1
-
-            pip install --user virtualenv
-
-            cd /usr/local/bin
-
-            ln -s /Users/vagrant/Library/Python/3.9/bin/virtualenv .
-
-            cd -
-
-            ./ios-l10n-scripts/import-locales-firefox.sh --release
-        title: Pull in L10n
-    - script@1:
-        inputs:
-        - content: >-
-            #!/usr/bin/env bash
-
-            set -e
-
-            set -x
-
-
-            cd Client.xcodeproj
-
-            sed -i '' 's/"Fennec Development"/"Bitrise Firefox iOS Dev"/'
-            project.pbxproj
-
-            sed -i '' 's/Fennec Today Development/Bitrise Firefox iOS Dev -
-            Fennec Today/' project.pbxproj
-
-            sed -i '' 's/Fennec ShareTo Development/Bitrise Firefox iOS Dev -
-            Share To/' project.pbxproj
-
-            sed -i '' 's/Fennec WidgetKit Development/Bitrise Firefox iOS Dev -
-            WidgetKit/' project.pbxproj
-
-            sed -i '' 's/"XCUITests"/"Bitrise Firefox iOS Dev - XCUI Tests"/'
-            project.pbxproj
-
-            sed -i '' 's/Fennec NotificationService Development/Bitrise Firefox
-            iOS Dev - Notification Service/' project.pbxproj
-
-            sed -i '' 's/CODE_SIGN_IDENTITY = "iPhone
-            Developer"/CODE_SIGN_IDENTITY = "iPhone Distribution"/'
-            project.pbxproj
-
-            cd -
-        title: Set provisioning to Bitrise in xcodeproj
-    - script@1.1:
-        title: NPM install and build
-        inputs:
-        - content: |
-            #!/usr/bin/env bash
-            # fail if any commands fails
-            set -e
-            set -x
-
-            npm install
-            npm run build
-    - 'git::https://github.com/bitrise-steplib/steps-xcode-build-for-test.git@export-fix':
-        inputs:
-        - xcodebuild_options: >-
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
-            CODE_SIGNING_ALLOWED=NO -testPlan PerformanceTestPlan
-        - scheme: Fennec_Enterprise_XCUITests
-    - xcode-test@2:
-        inputs:
-        - simulator_device: iPhone 11
-        - xcodebuild_test_options: '-testPlan PerformanceTestPlan'
-        - scheme: Fennec_Enterprise_XCUITests
-    - script@1:
-        inputs:
-        - content: >
-            #!/usr/bin/env bash
-
-            # fail if any commands fails
-
-            set -e
-
-            # debug log
-
-            set -x
-
-
-
-            # download xcresult-extract and run it
-
-            git clone https://github.com/AaronMT/xcresult_extract.git || exit 1
-
-            #pip3 install virtualenv
-
-            #virtualenv .
-
-            #source ./bin/activate
-
-            cd xcresult_extract
-
-            python3 xcresult_extract.py -project $BITRISE_PROJECT_PATH -scheme
-            "Fennec_Enterprise_XCUITests" -resultBundlePath
-            $BITRISE_XCRESULT_PATH
-        title: Download and run XCResult Extract
-    - virtual-device-testing-for-ios@0:
-        inputs:
-        - download_test_results: 'true'
-        - test_devices: 'iphone11,13.6,en,portrait'
     - deploy-to-bitrise-io@1.10: {}
     - cache-push@2.2: {}
     - slack@3.1:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2616,7 +2616,7 @@ workflows:
             # debug log
             set -x
 
-            YESTERDAY=`date -d "yesterday" '+%Y-%m-%d'`
+            YESTERDAY=`date -v -1d '+%Y-%m-%d'`
 
             pip install jq
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2772,9 +2772,9 @@ workflows:
 
             YESTERDAY=`date -v -1d '+%Y-%m-%d'`
 
-            pip install jq
+            brew install jq
 
-            curl -s -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/mozilla-mobile/firefox-ios/commits\?sha\=main\&since\=$YESTERDAY | jq -e -r '.[].commit.author | select(.name | contains("BITRISE.YML-bot"))'
+            curl -X GET -s -H 'Accept: application/vnd.github.v3+json' -H "authorization: Bearer ${GITHUB_ACCESS_TOKEN}" https://api.github.com/repos/mozilla-mobile/firefox-ios/commits\?sha\=main\&since\=$YESTERDAY | jq -e -r '.[].commit.author | select(.name | contains("BITRISE.YML-bot"))' > /dev/null/
             test $? -eq 0 || exit 1
         title: "Check main branch for recent activity before continuing"
     - activate-ssh-key@4.0:

--- a/test-fixtures/update.py
+++ b/test-fixtures/update.py
@@ -21,8 +21,10 @@ curl ${BITRISE_STACK_INFO} | jq ' . | keys'
 ]
 '''
 pattern = 'osx-xcode-'
-BITRISE_YML = '../bitrise.yml'
+BITRISE_YML = 'bitrise.yml'
 WORKFLOW = 'NewXcodeVersions'
+
+print(os.getcwd())
 
 resp = requests.get(BITRISE_STACK_INFO)
 resp.raise_for_status()
@@ -76,6 +78,8 @@ if __name__ == '__main__':
     largest_semver = largest_version()
 
     tmp_file = 'tmp.yml'
+    print(os.getcwd())
+
     with open(BITRISE_YML, 'r') as infile:
         y = yaml.safe_load(infile)
         current_semver = y['workflows'][WORKFLOW]['meta']['bitrise.io']['stack'] 


### PR DESCRIPTION
Refactored `closeTabsForCurrentTray` method so that it that no longer saves tabs when performing close all. This way we avoid showing `toast to undo 100+ tabs close` and avoid heavy write operation that causes app to crash and app to slow down.

Making it a draft for now so that I can test it on a real device. 