### PR TITLE
Fix date call in NewXcodeVersions Workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2616,7 +2616,7 @@ workflows:
             # debug log
             set -x
 
-            YESTERDAY=`date -d "yesterday" '+%Y-%m-%d'`
+            YESTERDAY=`date -v -1d '+%Y-%m-%d'`
 
             pip install jq
 


### PR DESCRIPTION
Convert GNU date to macOS

GNU: ```date -d "yesterday" '+%Y-%m-%d' ```

macOS: ```date -v -1d '+%Y-%m-%d'```