### PR TITLE
Fix mergify check-status

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,7 +8,7 @@ pull_request_rules:
   - name: github-actions
     conditions:
       - author=github-actions[bot]
-      - status=Bitrise
+      - check-success=Bitrise
       - files~=(bitrise.yml)
     actions:
       review:


### PR DESCRIPTION
I made a mistake with the status, according to the [documenation](https://docs.mergify.io/conditions.html#about-status-checks) it should be: `check-success` 