### PR TITLE
Fixes #7893 crash after closing tabs over 100

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -500,7 +500,7 @@ class TabManager: NSObject {
         privateConfiguration = TabManager.makeWebViewConfig(isPrivate: true, prefs: profile.prefs)
     }
 
-    func removeTabsNoToast(_ tabs: [Tab]) {
+    func removeTabsAndAddNormalTab(_ tabs: [Tab]) {
         for tab in tabs {
             self.removeTab(tab, flushToDisk: false, notify: true)
         }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -500,6 +500,18 @@ class TabManager: NSObject {
         privateConfiguration = TabManager.makeWebViewConfig(isPrivate: true, prefs: profile.prefs)
     }
 
+    func removeTabsWithNoUndoToast(_ tabs: [Tab]) {
+        for tab in tabs {
+            self.removeTab(tab, flushToDisk: false, notify: true)
+        }
+        
+        if normalTabs.isEmpty {
+            selectTab(addTab())
+        }
+        
+        storeChanges()
+    }
+    
     func removeTabsWithUndoToast(_ tabs: [Tab]) {
         recentlyClosedForUndo = normalTabs.compactMap {
             SavedTab(tab: $0, isSelected: selectedTab === $0)

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -500,7 +500,7 @@ class TabManager: NSObject {
         privateConfiguration = TabManager.makeWebViewConfig(isPrivate: true, prefs: profile.prefs)
     }
 
-    func removeTabsWithNoUndoToast(_ tabs: [Tab]) {
+    func removeTabsNoToast(_ tabs: [Tab]) {
         for tab in tabs {
             self.removeTab(tab, flushToDisk: false, notify: true)
         }
@@ -512,7 +512,7 @@ class TabManager: NSObject {
         storeChanges()
     }
     
-    func removeTabsWithUndoToast(_ tabs: [Tab]) {
+    func removeTabsWithToast(_ tabs: [Tab]) {
         recentlyClosedForUndo = normalTabs.compactMap {
             SavedTab(tab: $0, isSelected: selectedTab === $0)
         }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -504,11 +504,9 @@ class TabManager: NSObject {
         for tab in tabs {
             self.removeTab(tab, flushToDisk: false, notify: true)
         }
-        
         if normalTabs.isEmpty {
             selectTab(addTab())
         }
-        
         storeChanges()
     }
     

--- a/Client/Frontend/Browser/TabTrayControllerV1.swift
+++ b/Client/Frontend/Browser/TabTrayControllerV1.swift
@@ -486,7 +486,20 @@ extension TabTrayControllerV1 {
     }
 
     func closeTabsForCurrentTray() {
-        self.tabManager.removeTabsWithNoUndoToast(self.tabDisplayManager.dataStore.compactMap { $0 })
+        let tabs = self.tabDisplayManager.dataStore.compactMap { $0 }
+        self.tabManager.removeTabsWithUndoToast(tabs)
+        guard tabs.count >= 100 else {
+            self.tabManager.removeTabsWithNoUndoToast(tabs)
+            closeTabsTrayHelper()
+            return
+        }
+        tabDisplayManager.hideDisplayedTabs() {
+            self.tabManager.removeTabsWithUndoToast(tabs)
+            self.closeTabsTrayHelper()
+        }
+    }
+    
+    func closeTabsTrayHelper() {
         if self.tabDisplayManager.isPrivate {
             self.emptyPrivateTabsView.isHidden = !self.privateTabsAreEmpty()
             if !self.emptyPrivateTabsView.isHidden {
@@ -501,7 +514,7 @@ extension TabTrayControllerV1 {
             self.dismissTabTray()
         }
     }
-
+    
     func changePrivacyMode(_ isPrivate: Bool) {
         if isPrivate != tabDisplayManager.isPrivate {
             didTogglePrivateMode()

--- a/Client/Frontend/Browser/TabTrayControllerV1.swift
+++ b/Client/Frontend/Browser/TabTrayControllerV1.swift
@@ -486,21 +486,19 @@ extension TabTrayControllerV1 {
     }
 
     func closeTabsForCurrentTray() {
-        tabDisplayManager.hideDisplayedTabs() {
-            self.tabManager.removeTabsWithUndoToast(self.tabDisplayManager.dataStore.compactMap { $0 })
-            if self.tabDisplayManager.isPrivate {
-                self.emptyPrivateTabsView.isHidden = !self.privateTabsAreEmpty()
-                if !self.emptyPrivateTabsView.isHidden {
-                    // Fade in the empty private tabs message. This slow fade allows time for the closing tab animations to complete.
-                    self.emptyPrivateTabsView.alpha = 0
-                    UIView.animate(withDuration: 0.5, animations: {
-                        self.emptyPrivateTabsView.alpha = 1
-                    }, completion: nil)
-                }
-            } else if self.tabManager.normalTabs.count == 1, let tab = self.tabManager.normalTabs.first {
-                self.tabManager.selectTab(tab)
-                self.dismissTabTray()
+        self.tabManager.removeTabsWithNoUndoToast(self.tabDisplayManager.dataStore.compactMap { $0 })
+        if self.tabDisplayManager.isPrivate {
+            self.emptyPrivateTabsView.isHidden = !self.privateTabsAreEmpty()
+            if !self.emptyPrivateTabsView.isHidden {
+                // Fade in the empty private tabs message. This slow fade allows time for the closing tab animations to complete.
+                self.emptyPrivateTabsView.alpha = 0
+                UIView.animate(withDuration: 0.5, animations: {
+                    self.emptyPrivateTabsView.alpha = 1
+                }, completion: nil)
             }
+        } else if self.tabManager.normalTabs.count == 1, let tab = self.tabManager.normalTabs.first {
+            self.tabManager.selectTab(tab)
+            self.dismissTabTray()
         }
     }
 

--- a/Client/Frontend/Browser/TabTrayControllerV1.swift
+++ b/Client/Frontend/Browser/TabTrayControllerV1.swift
@@ -489,7 +489,7 @@ extension TabTrayControllerV1 {
         let tabs = self.tabDisplayManager.dataStore.compactMap { $0 }
         let maxTabs = 100
         if tabs.count >= maxTabs {
-            self.tabManager.removeTabsNoToast(tabs)
+            self.tabManager.removeTabsAndAddNormalTab(tabs)
         } else {
             self.tabManager.removeTabsWithToast(tabs)
         }

--- a/Client/Frontend/Browser/TabTrayControllerV1.swift
+++ b/Client/Frontend/Browser/TabTrayControllerV1.swift
@@ -488,7 +488,8 @@ extension TabTrayControllerV1 {
     func closeTabsForCurrentTray() {
         let tabs = self.tabDisplayManager.dataStore.compactMap { $0 }
         self.tabManager.removeTabsWithUndoToast(tabs)
-        guard tabs.count >= 100 else {
+        let maxTabs = 10
+        guard tabs.count >= maxTabs else {
             self.tabManager.removeTabsWithNoUndoToast(tabs)
             closeTabsTrayHelper()
             return
@@ -514,7 +515,7 @@ extension TabTrayControllerV1 {
             self.dismissTabTray()
         }
     }
-    
+
     func changePrivacyMode(_ isPrivate: Bool) {
         if isPrivate != tabDisplayManager.isPrivate {
             didTogglePrivateMode()

--- a/Client/Frontend/Browser/TabTrayControllerV1.swift
+++ b/Client/Frontend/Browser/TabTrayControllerV1.swift
@@ -487,17 +487,13 @@ extension TabTrayControllerV1 {
 
     func closeTabsForCurrentTray() {
         let tabs = self.tabDisplayManager.dataStore.compactMap { $0 }
-        self.tabManager.removeTabsWithUndoToast(tabs)
-        let maxTabs = 10
-        guard tabs.count >= maxTabs else {
-            self.tabManager.removeTabsWithNoUndoToast(tabs)
-            closeTabsTrayHelper()
-            return
+        let maxTabs = 100
+        if tabs.count >= maxTabs {
+            self.tabManager.removeTabsNoToast(tabs)
+        } else {
+            self.tabManager.removeTabsWithToast(tabs)
         }
-        tabDisplayManager.hideDisplayedTabs() {
-            self.tabManager.removeTabsWithUndoToast(tabs)
-            self.closeTabsTrayHelper()
-        }
+        closeTabsTrayHelper()
     }
     
     func closeTabsTrayHelper() {

--- a/Client/Frontend/Browser/Tabs/TabTrayV2ViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayV2ViewModel.swift
@@ -169,10 +169,17 @@ class TabTrayV2ViewModel: NSObject {
 
     func closeTabsForCurrentTray() {
         viewController.hideDisplayedTabs() {
-            self.tabManager.removeTabsWithUndoToast(self.dataStore.compactMap { $0.1 }.flatMap { $0 })
-                if self.getTabs().count == 1, let tab = self.getTabs().first {
-                self.tabManager.selectTab(tab)
-                    self.viewController.dismissTabTray()
+            let maxTabs = 100
+            let tabs = self.dataStore.compactMap { $0.1 }.flatMap { $0 }
+            if tabs.count >= maxTabs {
+                self.tabManager.removeTabsNoToast(tabs)
+            } else {
+                self.tabManager.removeTabsWithToast(tabs)
+            }
+            
+            if self.getTabs().count == 1, let tab = self.getTabs().first {
+            self.tabManager.selectTab(tab)
+                self.viewController.dismissTabTray()
             }
         }
     }

--- a/Client/Frontend/Browser/Tabs/TabTrayV2ViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayV2ViewModel.swift
@@ -172,7 +172,7 @@ class TabTrayV2ViewModel: NSObject {
             let maxTabs = 100
             let tabs = self.dataStore.compactMap { $0.1 }.flatMap { $0 }
             if tabs.count >= maxTabs {
-                self.tabManager.removeTabsNoToast(tabs)
+                self.tabManager.removeTabsAndAddNormalTab(tabs)
             } else {
                 self.tabManager.removeTabsWithToast(tabs)
             }

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -195,7 +195,7 @@ class TabManagerTests: XCTestCase {
         // This test makes sure that a normal tab is always added even when a normal tab is not selected when calling removeAll
         delegate.expect([didRemove, didAdd, didSelect, removeAllTabs])
 
-        manager.removeTabsWithUndoToast(manager.normalTabs)
+        manager.removeTabsWithToast(manager.normalTabs)
         delegate.verify("Not all delegate methods were called")
     }
 


### PR DESCRIPTION
Tabs are closed without undo for when there are more than 100 tabs

Change is for both TabTray v1 and v2 (chon tabs)