### PR TITLE
Set slack notification for NewXcodeVersions workflow and reduce cron …

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,7 +2,7 @@ name: Bitrise Xcode Check and Update
 
 on: 
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 */6 * * *'
 
 jobs:
   build:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2892,6 +2892,8 @@ workflows:
     - slack@3.1:
         run_if: '{{getenv "NEW_XCODE_VERSION" | eq "New_Version_Found"}}'
         inputs:
+        - channel: "#firefox-ios"
+        - text: Build status using latest Xcode detected
         - webhook_url: $WEBHOOK_SLACK_TOKEN
     description: >-
       This Workflow is to run tests (currently SmokeTest) when there is a merge


### PR DESCRIPTION
…checks

PR to add the slack notification the the firefox-ios channel. This will happen only when there is a new xcode version detected. It is not very often so it will not introduce too much noise but we can check with the team once this happens. 

Also, using this PR to reduce the cron job to every 6 hours. It would be enough with that frequency if we see we need more we will increase it.
