### PR TITLE
FXIOS-1456 fixes #7933 adds Save to Files to share sheet for PDF

### DIFF
--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -40,13 +40,11 @@ class ShareExtensionHelper: NSObject {
         }
         activityItems.append(self)
 
-        if isFile(url: url)
-        {
-        let activityViewController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
-        }
-        else
-        {
-        let activityViewController = UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+        var activityViewController: UIActivityViewController
+        if isFile(url: url) {
+            activityViewController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        } else {
+            activityViewController = UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
         }
 
         // Hide 'Add to Reading List' which currently uses Safari.

--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -40,7 +40,14 @@ class ShareExtensionHelper: NSObject {
         }
         activityItems.append(self)
 
+        if isFile(url: url)
+        {
+        let activityViewController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        }
+        else
+        {
         let activityViewController = UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+        }
 
         // Hide 'Add to Reading List' which currently uses Safari.
         // We would also hide View Later, if possible, but the exclusion list doesn't currently support


### PR DESCRIPTION
Fixes #7933 by adding Save to Files to share sheet if a PDF is shared. This is done by passing the URL directly in as activityItems in the activityViewController in ShareExtensionHelper.

![IMG_1933](https://user-images.githubusercontent.com/20655124/108633646-eee76780-743a-11eb-9d81-c97d4c859e68.jpg)


