### PR TITLE
Update appservices local build docs after switch to dynamic library.

### DIFF
--- a/Docs/BUILDING.md
+++ b/Docs/BUILDING.md
@@ -56,7 +56,7 @@ Firefox for iOS depends internally on some of the [shared Rust components](https
 
   ```
   rm -rf Carthage/Build/iOS/MozillaAppServices.framework
-  ln -s ~/REPLACE_WITH_PATH_TO_YOUR_LOCAL_CHECKOUT/application-services/Carthage/Build/iOS/Static/MozillaAppServices.framework Carthage/Build/iOS
+  ln -s ~/REPLACE_WITH_PATH_TO_YOUR_LOCAL_CHECKOUT/application-services/Carthage/Build/iOS/MozillaAppServices.framework Carthage/Build/iOS
   ```
 
 4. Build firefox-ios.

--- a/appservices_local_dev.sh
+++ b/appservices_local_dev.sh
@@ -35,7 +35,7 @@ if [[ "${ACTION}" == "enable" ]]; then
   if [ ! -h "${FRAMEWORK_LOCATION}" ]; then
     msg "Replacing Carthage package by symbolic link..."
     rm -rf "${FRAMEWORK_LOCATION}"
-    ln -s "${APP_SERVICES_DIR}/Carthage/Build/iOS/Static/MozillaAppServices.framework" "${PWD}/Carthage/Build/iOS"
+    ln -s "${APP_SERVICES_DIR}/Carthage/Build/iOS/MozillaAppServices.framework" "${PWD}/Carthage/Build/iOS"
   fi
   msg "Building Application Services."
   pushd "${APP_SERVICES_DIR}"


### PR DESCRIPTION
The appservices local build now produces a dynamic library, so you
need to symlink it from `Carthage/Builds/iOS/` without the `Static`
suffix.

*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Please make sure you've run the test scheme and all the tests pass. If your changes affect existing tests please make sure to update the tests as well.

