### PR TITLE
Moved glean script out of ApplicationServices framework v69.0.0 to source directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ Client/Assets/*.js.LICENSE.txt
 # L10n
 /firefoxios-l10n
 /ios-l10n-scripts
+
+# Glean 
+sdk_generator.sh

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -274,7 +274,6 @@
 		435222C125882E3800FCA5B6 /* WidgetKitTopSiteModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435222C025882E3800FCA5B6 /* WidgetKitTopSiteModel.swift */; };
 		435222C225882E3800FCA5B6 /* WidgetKitTopSiteModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435222C025882E3800FCA5B6 /* WidgetKitTopSiteModel.swift */; };
 		4357697525B733CC0017B210 /* MozillaAppServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EBCF403C221CBC9A00B38F28 /* MozillaAppServices.framework */; };
-		4357697625B733CC0017B210 /* MozillaAppServices.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = EBCF403C221CBC9A00B38F28 /* MozillaAppServices.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		435D660323D793DF0046EFA2 /* UpdateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435D660223D793DF0046EFA2 /* UpdateModel.swift */; };
 		435D660523D794B90046EFA2 /* UpdateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435D660423D794B90046EFA2 /* UpdateViewModel.swift */; };
 		435D660723D7962C0046EFA2 /* UpdateCoverSheetTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435D660623D7962C0046EFA2 /* UpdateCoverSheetTableViewCell.swift */; };
@@ -1107,7 +1106,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				4357697625B733CC0017B210 /* MozillaAppServices.framework in Copy Frameworks */,
 				C82043C32523DD6A00740B71 /* Sync.framework in Copy Frameworks */,
 				C87703D225223EA5006E38EB /* Shared.framework in Copy Frameworks */,
 			);
@@ -6949,6 +6947,7 @@
 				"$(SRCROOT)/Carthage/Build/iOS/Telemetry.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/SwiftProtobuf.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/Leanplum.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/MozillaAppServices.framework",
 			);
 			name = "Copy Carthage Dependencies";
 			outputPaths = (
@@ -6975,7 +6974,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "rm -rf .venv; bash $PWD/Carthage/Build/iOS/MozillaAppServices.framework/sdk_generator.sh -m $SRCROOT/docs -g MozillaAppServices\n";
+			shellScript = "rm -rf .venv; bash $SRCROOT/sdk_generator.sh -m $SRCROOT/docs -g MozillaAppServices\n";
 		};
 		E4A69F612048AFEA00D9017B /* Copy Carthage Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1073,10 +1073,25 @@ workflows:
             # debug log
             set -x
 
-
             rm /tmp/tmp.xcconfig
             envman add --key XCODE_XCCONFIG_FILE --value ''
         title: remove carthage lipo workaround
+    - script@1:
+        title: Move sdk_generator
+        inputs:
+        - content: >-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            # Move Glean script to source folder from
+            # MozillaAppServices.framework as we don't
+            # want to ship our app with Glean shell
+            # script inside A~S framework
+
+            mv Carthage/Build/iOS/MozillaAppServices.framework/sdk_generator.sh ./
     - script@1:
         inputs:
         - content: >-

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1077,7 +1077,7 @@ workflows:
             envman add --key XCODE_XCCONFIG_FILE --value ''
         title: remove carthage lipo workaround
     - script@1:
-        title: Move sdk_generator
+        title: Move glean sdk_generator
         inputs:
         - content: >-
             #!/usr/bin/env bash
@@ -1493,6 +1493,22 @@ workflows:
     - carthage@3.2:
         inputs:
         - carthage_options: ' --platform ios --cache-builds'
+    - script@1:
+        title: Move glean sdk_generator
+        inputs:
+        - content: >-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            # Move Glean script to source folder from
+            # MozillaAppServices.framework as we don't
+            # want to ship our app with Glean shell
+            # script inside A~S framework
+
+            mv Carthage/Build/iOS/MozillaAppServices.framework/sdk_generator.sh ./
     - script@1:
         inputs:
         - content: |-

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1494,6 +1494,19 @@ workflows:
         inputs:
         - carthage_options: ' --platform ios --cache-builds'
     - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+
+            rm /tmp/tmp.xcconfig
+            envman add --key XCODE_XCCONFIG_FILE --value ''
+        title: remove carthage lipo workaround
+    - script@1:
         title: Move glean sdk_generator
         inputs:
         - content: >-
@@ -1509,19 +1522,6 @@ workflows:
             # script inside A~S framework
 
             mv Carthage/Build/iOS/MozillaAppServices.framework/sdk_generator.sh ./
-    - script@1:
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            # fail if any commands fails
-            set -e
-            # debug log
-            set -x
-
-
-            rm /tmp/tmp.xcconfig
-            envman add --key XCODE_XCCONFIG_FILE --value ''
-        title: remove carthage lipo workaround
     - script@1:
         inputs:
         - content: >-

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -46,8 +46,11 @@ fi
 # Run carthage
 ./carthage_command.sh
 
-# Install Node.js dependencies and build user scripts
+# Move Glean script to source folder from MozillaAppServices.framework
+# as we don't want to ship our app with this Glean script inside framework
+mv Carthage/Build/iOS/MozillaAppServices.framework/sdk_generator.sh ./
 
+# Install Node.js dependencies and build user scripts
 npm install
 npm run build
 


### PR DESCRIPTION
- Updated bitrise.yml and bootstrap to fix Application Services v69.0.0 changes
- Moved glean script out of ApplicationServices framework v69.0.0 to Firefox source directory. We don't want this script to be signed
- MozillaAppServices copy framework will now be handled by Carthage

With this change we will have to run ./bootstrap again but it is necessary for our Firefox iOS app to build properly.
And this also helps to code sign proper contents of Application Services when we submit to AppStore

