### PR TITLE
Fix #8058 / FXIOS-1533 - Change WebKit sandbox APIs to only run on iOS 14.4 or higher

### DIFF
--- a/Shared/Extensions/WKWebViewExtensions.swift
+++ b/Shared/Extensions/WKWebViewExtensions.swift
@@ -18,7 +18,7 @@ extension WKWebView {
     ///     - javascript: String representing javascript to be evaluated
     public func evaluateJavascriptInDefaultContentWorld(_ javascript: String) {
         #if compiler(>=5.3)
-            if #available(iOS 14.0, *), USE_NEW_SANDBOX_APIS {
+            if #available(iOS 14.4, *), USE_NEW_SANDBOX_APIS {
                 self.evaluateJavaScript(javascript, in: nil, in: .defaultClient, completionHandler: { _ in })
             } else {
                 self.evaluateJavaScript(javascript)
@@ -34,9 +34,9 @@ extension WKWebView {
     /// - Parameters:
     ///     - javascript: String representing javascript to be evaluated
     ///     - completion: Tuple containing optional data and an optional error
-    public func evaluateJavascriptInDefaultContentWorld(_ javascript: String,_ completion: @escaping ((Any?, Error?) -> Void)) {
+    public func evaluateJavascriptInDefaultContentWorld(_ javascript: String, _ completion: @escaping ((Any?, Error?) -> Void)) {
         #if compiler(>=5.3)
-            if #available(iOS 14.0, *), USE_NEW_SANDBOX_APIS {
+            if #available(iOS 14.4, *), USE_NEW_SANDBOX_APIS {
                 self.evaluateJavaScript(javascript, in: nil, in: .defaultClient) { result in
                     switch result {
                     case .success(let value):
@@ -60,7 +60,7 @@ extension WKWebView {
 
 extension WKUserContentController {
     public func addInDefaultContentWorld(scriptMessageHandler: WKScriptMessageHandler, name: String) {
-        if #available(iOS 14.0, *), USE_NEW_SANDBOX_APIS {
+        if #available(iOS 14.4, *), USE_NEW_SANDBOX_APIS {
             add(scriptMessageHandler, contentWorld: .defaultClient, name: name)
         } else {
             add(scriptMessageHandler, name: name)
@@ -70,7 +70,7 @@ extension WKUserContentController {
 
 extension WKUserScript {
     public class func createInDefaultContentWorld(source: String, injectionTime: WKUserScriptInjectionTime, forMainFrameOnly: Bool) -> WKUserScript {
-        if #available(iOS 14.0, *), USE_NEW_SANDBOX_APIS {
+        if #available(iOS 14.4, *), USE_NEW_SANDBOX_APIS {
             return WKUserScript(source: source, injectionTime: injectionTime, forMainFrameOnly: forMainFrameOnly, in: .defaultClient)
         } else {
             return WKUserScript(source: source, injectionTime: injectionTime, forMainFrameOnly: forMainFrameOnly)


### PR DESCRIPTION
Fixes #8058

Since the APIs seem to be broken on anything less than 14.4, lets just not use them until then.
