### PR TITLE
Fix 6987 / FXIOS-635: Landscape New Tab URL Focus Fix

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -58,7 +58,6 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     func tabToolbarDidPressAddNewTab(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
         let isPrivate = tabManager.selectedTab?.isPrivate ?? false
         tabManager.selectTab(tabManager.addTab(nil, isPrivate: isPrivate))
-        focusLocationTextField(forTab: tabManager.selectedTab)
     }
 
     func tabToolbarDidPressMenu(_ tabToolbar: TabToolbarProtocol, button: UIButton) {


### PR DESCRIPTION
Issue Fixed: https://github.com/mozilla-mobile/firefox-ios/issues/6987

Summary:

removed `focusLocationTextField` call in`tabToolbarDidPressAddNewTab` when a new tab is tapped so the url text field doesnt get automatically focused.
