### PR TITLE
Added License info in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,8 @@ Contributing
 -----------------
 
 Want to contribute to this repository? Check out [Contributing Guidelines](https://github.com/mozilla-mobile/firefox-ios/blob/main/CONTRIBUTING.md)
+
+License
+-----------------
+
+Firefox for iOS is published under [MPL-2.0 License](https://github.com/mozilla-mobile/firefox-ios/blob/main/LICENSE). Do read the license before Contributing.

--- a/README.md
+++ b/README.md
@@ -79,4 +79,6 @@ Want to contribute to this repository? Check out [Contributing Guidelines](https
 License
 -----------------
 
-Firefox for iOS is published under [MPL-2.0 License](https://github.com/mozilla-mobile/firefox-ios/blob/main/LICENSE). Do read the license before Contributing.
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/


### PR DESCRIPTION
#8096 
## Readme Updation
* So this is a small contribution which is really important in such repositories. Because before contributing to any repository the contributor must know the License policy. 
* Without the proper knowledge policy there are chances that the user exploit the project.
* So to stop such activities we must add the ```License```  info in the Readme.md file such that the user remembers to have a look on it.
* This enhancement is quite small but really important when we see future aspects of such amazing application.