### PR TITLE
For #8077 - L10nTests Add new test for Set Default Browser card

### DIFF
--- a/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -139,6 +139,7 @@ class DefaultBrowserOnboardingViewController: UIViewController {
         button.layer.cornerRadius = UpdateViewControllerUX.StartBrowsingButton.cornerRadius
         button.setTitleColor(.white, for: .normal)
         button.backgroundColor = UpdateViewControllerUX.StartBrowsingButton.colour
+        button.accessibilityIdentifier = "DefaultBrowserCard.goToSettingsButton"
         return button
     }()
     

--- a/Client/Frontend/Home/DefaultBrowserCard.swift
+++ b/Client/Frontend/Home/DefaultBrowserCard.swift
@@ -34,6 +34,7 @@ class DefaultBrowserCard: UIView {
         button.titleLabel?.textAlignment = .center
         button.layer.cornerRadius = 8
         button.layer.masksToBounds = true
+        button.accessibilityIdentifier = "Home.learnMoreDefaultBrowserbutton"
         return button
     }()
     lazy var image: UIImageView = {

--- a/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -153,4 +153,13 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         app.tables.cells.staticTexts.firstMatch.swipeUp()
         snapshot("TrackingProtectionStrictMoreInfo-02")
     }
+
+    func testSetDefaultBrowser() {
+        if #available(iOS 14, *) {
+            waitForExistence(app.buttons["Home.learnMoreDefaultBrowserbutton"], timeout: 5)
+            app.buttons["Home.learnMoreDefaultBrowserbutton"].tap()
+            waitForExistence(app.buttons["DefaultBrowserCard.goToSettingsButton"], timeout: 5)
+            snapshot("HomeDefaultBrowserLearnMore")
+        }
+    }
 }


### PR DESCRIPTION
Fixes #8077 by adding a new test to get a screenshot for the Learn More option in the Set Defualt Browser card.
In order to get that working in all locales it is necessary also to add accessibilityIdentifiers to several buttons
