### PR TITLE
Fixes #8106 - Added a check for iOS14 before presenting default browser onboarding view

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1804,6 +1804,7 @@ extension BrowserViewController {
     
     // Default browser onboarding
     func presentDBOnboardingViewController(_ force: Bool = false) {
+        guard #available(iOS 14.0, *) else { return }
         let shouldShow = DefaultBrowserOnboardingViewModel.shouldShowDefaultBrowserOnboarding(userPrefs: profile.prefs)
         guard force || shouldShow else {
             return


### PR DESCRIPTION
Default browser is only available on iOS14 hence its onboarding view should only come up for users with iOS 14 and above.