### PR TITLE
For #7586 - Removes mobile prefixes when toggling desktop mode

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -561,6 +561,7 @@
 		D47A50F7254840210019A838 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		D4C4BDCE2253725E00986F04 /* LibraryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C4BDCD2253725E00986F04 /* LibraryTests.swift */; };
 		D4F3D789232F960600FBB9AA /* WhatsNewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F3D788232F960600FBB9AA /* WhatsNewTest.swift */; };
+		D525DFB325FBE5E000B18763 /* TabTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D525DFB225FBE5E000B18763 /* TabTests.swift */; };
 		D58A202925C9D96400105D25 /* BookmarkPanel.strings in Resources */ = {isa = PBXBuildFile; fileRef = D58A202725C9D96400105D25 /* BookmarkPanel.strings */; };
 		D58A202C25C9D96400105D25 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D58A202A25C9D96400105D25 /* Localizable.strings */; };
 		D58A202F25C9D96400105D25 /* BookmarkPanelDeleteConfirm.strings in Resources */ = {isa = PBXBuildFile; fileRef = D58A202D25C9D96400105D25 /* BookmarkPanelDeleteConfirm.strings */; };
@@ -3205,6 +3206,7 @@
 		D5220E9525D1AE360090C53C /* es-AR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-AR"; path = "es-AR.lproj/BookmarkPanel.strings"; sourceTree = "<group>"; };
 		D5220E9625D1AE360090C53C /* es-AR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-AR"; path = "es-AR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		D5220E9725D1AE360090C53C /* es-AR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-AR"; path = "es-AR.lproj/BookmarkPanelDeleteConfirm.strings"; sourceTree = "<group>"; };
+		D525DFB225FBE5E000B18763 /* TabTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTests.swift; sourceTree = "<group>"; };
 		D52AA82125D1AF4B0017EB67 /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/Localizable.strings; sourceTree = "<group>"; };
 		D52AA82225D1AF4B0017EB67 /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/BookmarkPanel.strings; sourceTree = "<group>"; };
 		D52AA82325D1AF4B0017EB67 /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/BookmarkPanelDeleteConfirm.strings; sourceTree = "<group>"; };
@@ -5772,6 +5774,7 @@
 				E1D8BC7921FF7A0000B100BD /* TPStatsBlocklistsTests.swift */,
 				DACDE995225E537900C8F37F /* VersionSettingTests.swift */,
 				D815A3A724A53F3200AAB221 /* TabToolbarHelperTests.swift */,
+				D525DFB225FBE5E000B18763 /* TabTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -7796,6 +7799,7 @@
 				CA24B52224ABD7D40093848C /* LoginsListViewModelTests.swift in Sources */,
 				CA24B53924ABFE250093848C /* LoginsListSelectionHelperTests.swift in Sources */,
 				2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */,
+				D525DFB325FBE5E000B18763 /* TabTests.swift in Sources */,
 				D8EFFA261FF702A8001D3A09 /* NavigationRouterTests.swift in Sources */,
 				63306D452110BAF000F25400 /* TabManagerStoreTests.swift in Sources */,
 				CA7BD568248189E800A0A61B /* BreachAlertsTests.swift in Sources */,

--- a/ClientTests/TabTests.swift
+++ b/ClientTests/TabTests.swift
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import XCTest
+@testable import Client
+
+class TabTests: XCTestCase {
+
+    func testWithoutMobilePrefixRemovesMobilePrefixes() {
+        let url = URL(string: "https://m.wikipedia.org/wiki/Firefox")!
+        let newUrl = url.withoutMobilePrefix()
+        XCTAssertEqual(newUrl.host, "wikipedia.org")
+    }
+
+    func testWithoutMobilePrefixRemovesMobile() {
+        let url = URL(string: "https://en.mobile.wikipedia.org/wiki/Firefox")!
+        let newUrl = url.withoutMobilePrefix()
+        XCTAssertEqual(newUrl.host, "en.wikipedia.org")
+    }
+}


### PR DESCRIPTION
Tries to remove `m.` and `mobile.` from the host to re-request the desktop site with a changed user agent