### PR TITLE
Make space around URL bar dynamic

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -54,6 +54,7 @@ class BrowserViewController: UIViewController {
     var libraryDrawerViewController: DrawerViewController?
     var webViewContainer: UIView!
     var urlBar: URLBarView!
+    var urlBarHeight: Constraint!
     var clipboardBarDisplayHandler: ClipboardBarDisplayHandler?
     var readerModeBar: ReaderModeBarView?
     var readerModeCache: ReaderModeCache
@@ -507,7 +508,7 @@ class BrowserViewController: UIViewController {
 
         urlBar.snp.makeConstraints { make in
             make.leading.trailing.bottom.equalTo(urlBarTopTabsContainer)
-            make.height.equalTo(UIConstants.TopToolbarHeightMax)
+            self.urlBarHeight = make.height.equalTo(UIConstants.TopToolbarHeightMax).constraint
             make.top.equalTo(topTabsContainer.snp.bottom)
         }
 
@@ -526,6 +527,26 @@ class BrowserViewController: UIViewController {
         statusBarOverlay.snp.remakeConstraints { make in
             make.top.left.right.equalTo(self.view)
             make.height.equalTo(self.view.safeAreaInsets.top)
+        }
+
+        adjustURLBarHeightBasedOnLocationViewHeight()
+    }
+
+    fileprivate func adjustURLBarHeightBasedOnLocationViewHeight() {
+        // Make sure that we have a height to actually base our calculations on
+        guard urlBar.locationContainer.bounds.height != 0 else { return }
+        let locationViewHeight = urlBar.locationView.bounds.height
+        let heightWithPadding = locationViewHeight + 10
+
+        // We have to deactivate the original constraint, and remake the constraint
+        // or else funky conflicts happen
+        urlBarHeight.deactivate()
+        urlBar.snp.makeConstraints { make in
+            if heightWithPadding > UIConstants.TopToolbarHeightMax {
+                self.urlBarHeight = make.height.equalTo(UIConstants.TopToolbarHeight).constraint
+            } else {
+                self.urlBarHeight = make.height.equalTo(heightWithPadding).constraint
+            }
         }
     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -54,7 +54,7 @@ class BrowserViewController: UIViewController {
     var libraryDrawerViewController: DrawerViewController?
     var webViewContainer: UIView!
     var urlBar: URLBarView!
-    var urlBarHeight: Constraint!
+    var urlBarHeightConstraint: Constraint!
     var clipboardBarDisplayHandler: ClipboardBarDisplayHandler?
     var readerModeBar: ReaderModeBarView?
     var readerModeCache: ReaderModeCache
@@ -508,7 +508,7 @@ class BrowserViewController: UIViewController {
 
         urlBar.snp.makeConstraints { make in
             make.leading.trailing.bottom.equalTo(urlBarTopTabsContainer)
-            self.urlBarHeight = make.height.equalTo(UIConstants.TopToolbarHeightMax).constraint
+            self.urlBarHeightConstraint = make.height.equalTo(UIConstants.TopToolbarHeightMax).constraint
             make.top.equalTo(topTabsContainer.snp.bottom)
         }
 
@@ -540,13 +540,10 @@ class BrowserViewController: UIViewController {
 
         // We have to deactivate the original constraint, and remake the constraint
         // or else funky conflicts happen
-        urlBarHeight.deactivate()
+        urlBarHeightConstraint.deactivate()
         urlBar.snp.makeConstraints { make in
-            if heightWithPadding > UIConstants.TopToolbarHeightMax {
-                self.urlBarHeight = make.height.equalTo(UIConstants.TopToolbarHeight).constraint
-            } else {
-                self.urlBarHeight = make.height.equalTo(heightWithPadding).constraint
-            }
+            let height =  heightWithPadding > UIConstants.TopToolbarHeightMax ? UIConstants.TopToolbarHeight : heightWithPadding
+            self.urlBarHeightConstraint = make.height.equalTo(height).constraint
         }
     }
 


### PR DESCRIPTION
Calculated the URL bar view's height based on the location bar's size to account for dynamic resizing of text.

![Simulator Screen Shot - iPhone 11 - 2021-03-15 at 09 25 06](https://user-images.githubusercontent.com/11182210/111160502-88082a80-8570-11eb-8f33-e5ec1d79f7e6.png)
![Simulator Screen Shot - iPhone 11 - 2021-03-15 at 09 25 24](https://user-images.githubusercontent.com/11182210/111160504-88a0c100-8570-11eb-8c50-4d19baa46fb3.png)
