### PR TITLE
Update L10nBuild and L10nScreenshotsTests Workflows

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -275,29 +275,18 @@ workflows:
             envman add --key XCODE_XCCONFIG_FILE --value ''
         title: Remove carthage lip
     - script@1:
+        title: Copy glean sdk_generator
         inputs:
         - content: >-
             #!/usr/bin/env bash
-
+            # fail if any commands fails
             set -e
-
+            # debug log
             set -x
-
-
-            # Import only the shipping locales (from shipping_locales.txt) on
-            Release
-
-            # builds. Import all locales on Beta and Fennec_Enterprise, except
-            for pull
-
-            # requests.
-
-            git clone https://github.com/boek/ios-l10n-scripts.git -b new_tool || exit 1
-
-            git clone --depth 1 https://github.com/mozilla-l10n/firefoxios-l10n firefoxios-l10n || exit 1
-
-            ./ios-l10n-scripts/ios-l10n-tools --project-path Client.xcodeproj --l10n-project-path ./firefoxios-l10n --import
-        title: Pull in L10n
+            # Copy Glean script to source folder from
+            # MozillaAppServices.framework as we need
+            # this script to build iOS App
+            cp Carthage/Build/iOS/MozillaAppServices.framework/sdk_generator.sh ./
     - script@1.1:
         title: NPM install and build
         inputs:
@@ -346,37 +335,6 @@ workflows:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@4: {}
     - certificate-and-profile-installer@1.10: {}
-    - script@1:
-        inputs:
-        - content: >-
-            #!/usr/bin/env bash
-
-            set -e
-
-            set -x
-
-
-            # Import only the shipping locales (from shipping_locales.txt) on
-            Release
-
-            # builds. Import all locales on Beta and Fennec_Enterprise, except
-            for pull
-
-            # requests.
-
-            git clone https://github.com/mozilla-mobile/ios-l10n-scripts.git ||
-            exit 1
-
-            pip install --user virtualenv
-
-            cd /usr/local/bin
-
-            ln -s /Users/vagrant/Library/Python/3.9/bin/virtualenv .
-
-            cd -
-
-            ./ios-l10n-scripts/import-locales-firefox.sh --release
-        title: Pull in L10n
     - script@1:
         inputs:
         - content: >-


### PR DESCRIPTION
PR to add the copy glean script steps needs for the builds and to remove the pull L10n script step not needed anymore to try to fix the builds when triggering the L10n process to get screenshots for localizers
