### PR TITLE
Fix add back Pull in L10n step needed to take screenshots for each lo…

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -346,6 +346,22 @@ workflows:
     - git-clone@4: {}
     - certificate-and-profile-installer@1.10: {}
     - script@1:
+        title: Pull in L10n
+        inputs:
+        - content: |
+            #!/usr/bin/env bash
+            set -e
+            set -x
+            # Import only the shipping locales (from shipping_locales.txt) on Release
+            # builds. Import all locales on Beta and Fennec_Enterprise, except for pull
+            # requests.
+            git clone https://github.com/mozilla-mobile/ios-l10n-scripts.git ||exit 1
+            pip install --user virtualenv
+            cd /usr/local/bin
+            ln -s /Users/vagrant/Library/Python/3.9/bin/virtualenv .
+            cd -
+            ./ios-l10n-scripts/import-locales-firefox.sh --release
+    - script@1:
         inputs:
         - content: >-
             #!/usr/bin/env bash


### PR DESCRIPTION
…cale

I removed by mistake the Pull in L10n script from this workflow thinking it was the one with the workaround we had until newer implementation for the L10n process. Setting it back should fix, as we have seen by triggering the builds, the issue.
