### PR TITLE
No bug set env var for device on bitrise

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1296,10 +1296,6 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-12.4.x
-    envs:
-    - opts:
-        is_expand: false
-      IOS_DEVICE: iPhone 11
   TEMP:
     steps:
     - activate-ssh-key@4.0:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1284,7 +1284,7 @@ workflows:
         - export_uitest_artifacts: 'true'
         - scheme: Fennec_Enterprise_XCUITests
         - simulator_os_version: latest
-        - simulator_device: iPhone 11
+        - simulator_device: "$IOS_DEVICE"
     - deploy-to-bitrise-io@1.10: {}
     - cache-push@2.2: {}
     - slack@3.1:
@@ -1296,6 +1296,10 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-12.4.x
+    envs:
+    - opts:
+        is_expand: false
+      IOS_DEVICE: iPhone 11
   TEMP:
     steps:
     - activate-ssh-key@4.0:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2242,7 +2242,7 @@ trigger_map:
 - push_branch: v32.1
   workflow: xcode12-release-and-beta-nocache
 - pull_request_target_branch: main
-  workflow: CommonBuild-UItest-XCUISmoketest
+  workflow: RunUnitTests
 - pull_request_source_branch: '*'
   pull_request_target_branch: chronological-tabs
   workflow: RunUnitTests


### PR DESCRIPTION
With this change, if we set the variable when scheduling the build, we could use same workflow for both iPhone and iPad devices
