### PR TITLE
Add settings UI to opt out of studies

### DIFF
--- a/Client/Experiments/Experiments.swift
+++ b/Client/Experiments/Experiments.swift
@@ -69,7 +69,7 @@ enum Experiments {
     }
 
     /// The `NimbusApi` object. This is the entry point to do anything with the Nimbus SDK on device.
-    public static let shared: NimbusApi = {
+    public static var shared: NimbusApi = {
         guard AppConstants.NIMBUS_ENABLED else {
             return NimbusDisabled.shared
         }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -728,6 +728,7 @@ class SendAnonymousUsageDataSetting: BoolSetting {
                 LeanPlumClient.shared.set(attributes: [LPAttributeKey.telemetryOptIn: $0])
                 LeanPlumClient.shared.set(enabled: $0)
                 Glean.shared.setUploadEnabled($0)
+                Experiments.shared.resetTelemetryIdentifiers()
             }
         )
     }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -733,6 +733,8 @@ class SendAnonymousUsageDataSetting: BoolSetting {
         )
     }
 
+    override var accessibilityIdentifier: String? { return "SendAnonymousUsageData" }
+
     override var url: URL? {
         return SupportUtils.URLForTopic("adjust")
     }
@@ -758,6 +760,8 @@ class StudiesToggleSetting: BoolSetting {
             }
         )
     }
+
+    override var accessibilityIdentifier: String? { return "StudiesToggle" }
 
     override var url: URL? {
         return SupportUtils.URLForTopic("studies")

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -741,6 +741,32 @@ class SendAnonymousUsageDataSetting: BoolSetting {
     }
 }
 
+class StudiesToggleSetting: BoolSetting {
+    init(prefs: Prefs, delegate: SettingsDelegate?) {
+        let statusText = NSMutableAttributedString()
+        statusText.append(NSAttributedString(string: Strings.SettingsStudiesToggleMessage, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.headerTextLight]))
+        statusText.append(NSAttributedString(string: " "))
+        statusText.append(NSAttributedString(string: Strings.SettingsStudiesToggleLink, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.general.highlightBlue]))
+
+        super.init(
+            prefs: prefs, prefKey: AppConstants.PrefStudiesToggle, defaultValue: true,
+            attributedTitleText: NSAttributedString(string: Strings.SettingsStudiesToggleTitle),
+            attributedStatusText: statusText,
+            settingDidChange: { enabled in
+                Experiments.shared.globalUserParticipation = enabled
+            }
+        )
+    }
+
+    override var url: URL? {
+        return SupportUtils.URLForTopic("studies")
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        setUpAndPushSettingsContentViewController(navigationController, self.url)
+    }
+}
+
 // Opens the SUMO page in a new tab
 class OpenSupportPageSetting: Setting {
     init(delegate: SettingsDelegate?) {

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -123,6 +123,7 @@ class AppSettingsTableViewController: SettingsTableViewController {
                 ShowIntroductionSetting(settings: self),
                 SendFeedbackSetting(),
                 SendAnonymousUsageDataSetting(prefs: prefs, delegate: settingsDelegate),
+                StudiesToggleSetting(prefs: prefs, delegate: settingsDelegate),
                 OpenSupportPageSetting(delegate: settingsDelegate),
             ]),
             SettingSection(title: NSAttributedString(string: .AppSettingsAbout), children: [

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -675,9 +675,18 @@ extension Strings {
 
 // Nimbus settings
 extension Strings {
+    public static let SettingsStudiesTitle = MZLocalizedString("Settings.Studies.Title", value: "Studies", comment: "Label used as an item in Settings. Tapping on this item takes you to the Studies panel")
+    public static let SettingsStudiesSectionName = MZLocalizedString("Settings.Studies.SectionName", value: "Studies", comment: "Title displayed in header of the Studies panel")
+    public static let SettingsStudiesActiveSectionTitle = MZLocalizedString("Settings.Studies.Active.SectionName", value: "Active", comment: "Section title for all studies that are currently active")
+    public static let SettingsStudiesCompletedSectionTitle = MZLocalizedString("Settings.Studies.Completed.SectionName", value: "Completed", comment: "Section title for all studies that are completed")
+    public static let SettingsStudiesRemoveButton = MZLocalizedString("Settings.Studies.Remove.Button", value: "Remove", comment: "Button title displayed next to each study allowing the user to opt-out of the study")
+
     public static let SettingsStudiesToggleTitle = MZLocalizedString("Settings.Studies.Toggle.Title", value: "Studies", comment: "Label used as a toggle item in Settings. When this is off, the user is opting out of all studies.")
     public static let SettingsStudiesToggleLink = MZLocalizedString("Settings.Studies.Toggle.Link", value: "Learn More.", comment: "Title for a link that explains what Mozilla means by Studies")
     public static let SettingsStudiesToggleMessage = MZLocalizedString("Settings.Studies.Toggle.Message", value: "Firefox may install and run studies from time to time.", comment: "A short description that explains that Mozilla is running studies")
+
+    public static let SettingsStudiesToggleValueOn = MZLocalizedString("Settings.Studies.Toggle.On", value: "On", comment: "Toggled ON to participate in studies")
+    public static let SettingsStudiesToggleValueOff = MZLocalizedString("Settings.Studies.Toggle.Off", value: "Off", comment: "Toggled OFF to opt-out of studies")
 }
 
 // Do not track

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -673,6 +673,13 @@ extension Strings {
     public static let SettingsSiriOpenURL = MZLocalizedString("Settings.Siri.OpenTabShortcut", value: "Open New Tab", comment: "The description of the open new tab siri shortcut")
 }
 
+// Nimbus settings
+extension Strings {
+    public static let SettingsStudiesToggleTitle = MZLocalizedString("Settings.Studies.Toggle.Title", value: "Studies", comment: "Label used as a toggle item in Settings. When this is off, the user is opting out of all studies.")
+    public static let SettingsStudiesToggleLink = MZLocalizedString("Settings.Studies.Toggle.Link", value: "Learn More.", comment: "Title for a link that explains what Mozilla means by Studies")
+    public static let SettingsStudiesToggleMessage = MZLocalizedString("Settings.Studies.Toggle.Message", value: "Firefox may install and run studies from time to time.", comment: "A short description that explains that Mozilla is running studies")
+}
+
 // Do not track
 extension Strings {
     public static let SettingsDoNotTrackTitle = MZLocalizedString("Settings.DNT.Title", value: "Send websites a Do Not Track signal that you don’t want to be tracked", comment: "DNT Settings title")

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -65,6 +65,7 @@ public struct AppConstants {
     }()
 
     public static let PrefSendUsageData = "settings.sendUsageData"
+    public static let PrefStudiesToggle = "settings.studiesToggle"
 
     /// Enables support for International Domain Names (IDN)
     /// Disabled because of https://bugzilla.mozilla.org/show_bug.cgi?id=1312294


### PR DESCRIPTION
Fixes [SDK-216][1].

This adds a new toggle to the settings screen, adds strings for an up coming about:studies screen, and wires it up to nimbus' global opt out.

It also wires up the existing telemetry opt out to nimbus' `resetTelemetryIdentifiers`, when the user opts in and out of telemetry (for data science reasons).

[1]: https://jira.mozilla.com/browse/SDK-216
<img width=300 src="https://user-images.githubusercontent.com/99338/113173854-b90b7f00-9241-11eb-95ba-8e14a2cfa4a1.png">
