### PR TITLE
iPad, iPhone, and Elective Surgery

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -384,6 +384,7 @@
 		C4EFEECF1CEBB6F2009762A4 /* BackForwardTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4EFEECE1CEBB6F2009762A4 /* BackForwardTableViewCell.swift */; };
 		C4F3B29A1CFCF93A00966259 /* ButtonToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F3B2991CFCF93A00966259 /* ButtonToast.swift */; };
 		C817B34D1FC609500086018E /* UIScrollViewSwizzled.swift in Sources */ = {isa = PBXBuildFile; fileRef = C817B34C1FC609500086018E /* UIScrollViewSwizzled.swift */; };
+		C81AC6B626160091007800C5 /* TabTrayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81AC6B526160091007800C5 /* TabTrayViewModel.swift */; };
 		C82043852523DBF600740B71 /* Sync.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2827315E1ABC9BE600AA1954 /* Sync.framework */; };
 		C820439A2523DC4500740B71 /* libStorage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FCAE21A1ABB51F800877008 /* libStorage.a */; };
 		C82043AE2523DC8B00740B71 /* Sync.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2827315E1ABC9BE600AA1954 /* Sync.framework */; };
@@ -2848,6 +2849,7 @@
 		C7DB49358A6A84AA7391EEE6 /* ta */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ta; path = ta.lproj/Intro.strings; sourceTree = "<group>"; };
 		C8154C5887169941126C530A /* lt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lt; path = lt.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		C817B34C1FC609500086018E /* UIScrollViewSwizzled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScrollViewSwizzled.swift; sourceTree = "<group>"; };
+		C81AC6B526160091007800C5 /* TabTrayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayViewModel.swift; sourceTree = "<group>"; };
 		C82CDD45233E8996002E2743 /* Tab+ChangeUserAgent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Tab+ChangeUserAgent.swift"; sourceTree = "<group>"; };
 		C8340B7324EC69EE00FE91A6 /* CHNumber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHNumber.h; sourceTree = "<group>"; };
 		C8340B7424EC69EE00FE91A6 /* ASNUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASNUtils.m; sourceTree = "<group>"; };
@@ -4143,6 +4145,7 @@
 				DA3A4FE8254A781A00C4A9C9 /* TabTableViewHeader.swift */,
 				43E9BDFA255E0904005BCB91 /* TabMoreMenuHeader.swift */,
 				DA52E1D925F5961F0092204C /* TabTrayViewController.swift */,
+				C81AC6B526160091007800C5 /* TabTrayViewModel.swift */,
 				2FDE87FD1ABB3817005317B1 /* RemoteTabsPanel.swift */,
 			);
 			path = Tabs;
@@ -7708,6 +7711,7 @@
 				EBE26B57220C959D00D1D99A /* BrowserViewController+TabToolbarDelegate.swift in Sources */,
 				E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */,
 				3BF56D271CDBBE1F00AC4D75 /* SimpleToast.swift in Sources */,
+				C81AC6B626160091007800C5 /* TabTrayViewModel.swift in Sources */,
 				EBB89504219398E500EB91A0 /* TrackingProtectionPageStats.swift in Sources */,
 				D31F95E91AC226CB005C9F3B /* ScreenshotHelper.swift in Sources */,
 				28EADE5D1AFC3A78007FB2FB /* UIImageViewExtensions.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -55,6 +55,7 @@ extension BrowserViewController: URLBarDelegate {
                     // Respect LP value
                     shouldShowChronTabs = chronLPValue
                 }
+                profile.prefs.setBool(shouldShowChronTabs, forKey: PrefsKeys.ChronTabsPrefKey)
             }
         }
 

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -507,7 +507,7 @@ extension GridTabViewController {
 
 // MARK: - Toolbar Actions
 extension GridTabViewController {
-    func performToolbarAction(_ action: TabTrayViewAction, sender: UIButton) {
+    func performToolbarAction(_ action: TabTrayViewAction, sender: UIBarButtonItem) {
         switch action {
         case .addTab:
             didTapToolbarAddTab()
@@ -523,7 +523,7 @@ extension GridTabViewController {
         openNewTab()
     }
 
-    func didTapToolbarDelete(_ sender: UIButton) {
+    func didTapToolbarDelete(_ sender: UIBarButtonItem) {
         if tabDisplayManager.isDragging {
             return
         }
@@ -531,8 +531,7 @@ extension GridTabViewController {
         let controller = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         controller.addAction(UIAlertAction(title: Strings.AppMenuCloseAllTabsTitleString, style: .default, handler: { _ in self.closeTabsForCurrentTray() }), accessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
         controller.addAction(UIAlertAction(title: .TabTrayCloseAllTabsPromptCancel, style: .cancel, handler: nil), accessibilityIdentifier: "TabTrayController.deleteButton.cancel")
-        controller.popoverPresentationController?.sourceView = sender
-        controller.popoverPresentationController?.sourceRect = sender.bounds
+        controller.popoverPresentationController?.barButtonItem = sender
         present(controller, animated: true, completion: nil)
     }
 }

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -78,7 +78,9 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
         super.viewWillAppear(animated)
         self.view.layoutIfNeeded()
 
-        parent?.navigationItem.title = Strings.TabTrayV2Title
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            parent?.navigationItem.title = Strings.TabTrayV2Title
+        }
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -77,10 +77,6 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.view.layoutIfNeeded()
-
-        if UIDevice.current.userInterfaceIdiom == .phone {
-            parent?.navigationItem.title = Strings.TabTrayV2Title
-        }
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -42,15 +42,6 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
     var webViewContainerBackdrop: UIView!
     var collectionView: UICollectionView!
 
-    lazy var normalToolbarItems: [UIBarButtonItem] = {
-        let bottomToolbar = [
-            UIBarButtonItem(image: UIImage.templateImageNamed("action_delete"), style: .plain, target: self, action: #selector(didTapToolbarDelete)),
-            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
-            UIBarButtonItem(customView: NewTabButton(target: self, selector: #selector(didTapToolbarAddTab)))
-        ]
-        return bottomToolbar
-    }()
-
     fileprivate lazy var emptyPrivateTabsView: EmptyPrivateTabsView = {
         let emptyView = EmptyPrivateTabsView()
         emptyView.learnMoreButton.addTarget(self, action: #selector(didTapLearnMore), for: .touchUpInside)
@@ -88,10 +79,6 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
         self.view.layoutIfNeeded()
 
         parent?.navigationItem.title = Strings.TabTrayV2Title
-
-        // Bottom toolbar
-        parent?.navigationController?.isToolbarHidden = false
-        parent?.setToolbarItems(normalToolbarItems, animated: animated)
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -250,13 +237,6 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
 
     fileprivate func privateTabsAreEmpty() -> Bool {
         return tabDisplayManager.isPrivate && tabManager.privateTabs.isEmpty
-    }
-
-    @objc func didTapToolbarAddTab() {
-        if tabDisplayManager.isDragging {
-            return
-        }
-        openNewTab()
     }
 
     func openNewTab(_ request: URLRequest? = nil) {
@@ -527,8 +507,25 @@ extension GridTabViewController {
     }
 }
 
+// MARK: - Toolbar Actions
 extension GridTabViewController {
-    @objc func didTapToolbarDelete(_ sender: UIButton) {
+    func performToolbarAction(_ action: TabTrayViewAction, sender: UIButton) {
+        switch action {
+        case .addTab:
+            didTapToolbarAddTab()
+        case .deleteTab:
+            didTapToolbarDelete(sender)
+        }
+    }
+
+    func didTapToolbarAddTab() {
+        if tabDisplayManager.isDragging {
+            return
+        }
+        openNewTab()
+    }
+
+    func didTapToolbarDelete(_ sender: UIButton) {
         if tabDisplayManager.isDragging {
             return
         }

--- a/Client/Frontend/Browser/Tabs/ChronologicalTabsViewController.swift
+++ b/Client/Frontend/Browser/Tabs/ChronologicalTabsViewController.swift
@@ -153,7 +153,7 @@ class ChronologicalTabsViewController: UIViewController, Themeable, TabTrayViewD
 
 // MARK: - Toolbar Actions
 extension ChronologicalTabsViewController {
-    func performToolbarAction(_ action: TabTrayViewAction, sender: UIButton) {
+    func performToolbarAction(_ action: TabTrayViewAction, sender: UIBarButtonItem) {
         switch action {
         case .addTab:
             didTapToolbarAddTab()
@@ -168,12 +168,12 @@ extension ChronologicalTabsViewController {
         TelemetryWrapper.recordEvent(category: .action, method: .add, object: .tab, value: viewModel.isInPrivateMode ? .privateTab : .normalTab)
     }
 
-    func didTapToolbarDelete(_ sender: UIButton) {
+    func didTapToolbarDelete(_ sender: UIBarButtonItem) {
         let controller = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         controller.addAction(UIAlertAction(title: Strings.AppMenuCloseAllTabsTitleString, style: .default, handler: { _ in self.viewModel.closeTabsForCurrentTray() }), accessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
         controller.addAction(UIAlertAction(title: Strings.CancelString, style: .cancel, handler: nil), accessibilityIdentifier: "TabTrayController.deleteButton.cancel")
-        controller.popoverPresentationController?.sourceView = sender
-        controller.popoverPresentationController?.sourceRect = sender.bounds
+        controller.view.tintColor = UIColor.white
+        controller.popoverPresentationController?.barButtonItem = sender
         present(controller, animated: true, completion: nil)
         TelemetryWrapper.recordEvent(category: .action, method: .deleteAll, object: .tab, value: viewModel.isInPrivateMode ? .privateTab : .normalTab)
     }

--- a/Client/Frontend/Browser/Tabs/ChronologicalTabsViewController.swift
+++ b/Client/Frontend/Browser/Tabs/ChronologicalTabsViewController.swift
@@ -74,13 +74,6 @@ class ChronologicalTabsViewController: UIViewController, Themeable, TabTrayViewD
         applyTheme()
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        if UIDevice.current.userInterfaceIdiom == .phone {
-            parent?.navigationItem.title = Strings.TabTrayV2Title
-        }
-    }
-
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         viewModel.addPrivateTab()

--- a/Client/Frontend/Browser/Tabs/ChronologicalTabsViewController.swift
+++ b/Client/Frontend/Browser/Tabs/ChronologicalTabsViewController.swift
@@ -76,7 +76,9 @@ class ChronologicalTabsViewController: UIViewController, Themeable, TabTrayViewD
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        parent?.navigationItem.title = Strings.TabTrayV2Title
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            parent?.navigationItem.title = Strings.TabTrayV2Title
+        }
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/Client/Frontend/Browser/Tabs/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabsPanel.swift
@@ -61,15 +61,11 @@ class RemoteTabsPanel: SiteTableViewController, LibraryPanel {
 
         tableViewController.didMove(toParent: self)
 
-        parent?.navigationItem.title = Strings.AppMenuSyncedTabsTitleString
-        parent?.navigationController?.isToolbarHidden = true
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            parent?.navigationItem.title = Strings.AppMenuSyncedTabsTitleString
+        }
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        parent?.navigationItem.setRightBarButton(nil, animated: animated)
-        parent?.navigationController?.setToolbarHidden(true, animated: animated)
-    }
-    
     override func applyTheme() {
         super.applyTheme()
         tableViewController.tableView.backgroundColor = UIColor.theme.tableView.rowBackground

--- a/Client/Frontend/Browser/Tabs/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabsPanel.swift
@@ -60,10 +60,6 @@ class RemoteTabsPanel: SiteTableViewController, LibraryPanel {
         }
 
         tableViewController.didMove(toParent: self)
-
-        if UIDevice.current.userInterfaceIdiom == .phone {
-            parent?.navigationItem.title = Strings.AppMenuSyncedTabsTitleString
-        }
     }
 
     override func applyTheme() {

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -7,8 +7,14 @@ import Shared
 import SnapKit
 import UIKit
 
+enum TabTrayViewAction {
+    case addTab
+    case deleteTab
+}
+
 protocol TabTrayViewDelegate: UIViewController {
     func didTogglePrivateMode(_ togglePrivateModeOn: Bool)
+    func performToolbarAction(_ action: TabTrayViewAction, sender: UIButton)
 }
 
 class TabTrayViewController: UIViewController {
@@ -42,6 +48,24 @@ class TabTrayViewController: UIViewController {
         return toolbar
     }()
 
+    lazy var bottomToolbarItems: [UIBarButtonItem] = {
+        let bottomToolbar = [
+            UIBarButtonItem(image: UIImage.templateImageNamed("action_delete"), style: .plain, target: self, action: #selector(didTapDeleteTab(_:))),
+            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+            UIBarButtonItem(customView: NewTabButton(target: self, selector: #selector(didTapAddTab)))
+        ]
+        return bottomToolbar
+    }()
+
+    @objc func didTapDeleteTab(_ sender: UIButton) {
+        tabTrayView.performToolbarAction(.deleteTab, sender: sender)
+    }
+
+    @objc func didTapAddTab(_ sender: UIButton) {
+        tabTrayView.performToolbarAction(.addTab, sender: sender)
+    }
+
+
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return .lightContent
     }
@@ -68,6 +92,13 @@ class TabTrayViewController: UIViewController {
         viewSetup()
         applyTheme()
         setupNotifications()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        navigationController?.isToolbarHidden = false
+        setToolbarItems(bottomToolbarItems, animated: animated)
     }
 
     private func viewSetup() {
@@ -187,6 +218,7 @@ extension TabTrayViewController: UIAdaptivePresentationControllerDelegate, UIPop
     // Returning None here makes sure that the Popover is actually presented as a Popover and
     // not as a full-screen modal, which is the default on compact device classes.
     func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
+
         return .none
     }
 

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -32,6 +32,10 @@ class TabTrayViewController: UIViewController {
         return UIBarButtonItem(customView: NewTabButton(target: self, selector: #selector(didTapAddTab)))
     }()
 
+    lazy var syncTabButton: UIBarButtonItem = {
+        return UIBarButtonItem(title: Strings.FxASyncNow, style: .plain, target: self, action: #selector(didTapSyncTabs))
+    }()
+
     lazy var flexibleSpace: UIBarButtonItem = {
         return UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
     }()
@@ -48,7 +52,9 @@ class TabTrayViewController: UIViewController {
     lazy var navigationMenu: UISegmentedControl = {
         var navigationMenu: UISegmentedControl
         if UIDevice.current.userInterfaceIdiom == .pad {
-            navigationMenu = UISegmentedControl(items: ["Tabs", "Private", "Synced"])
+            navigationMenu = UISegmentedControl(items: [Strings.TabTraySegmentedControlTitlesTabs,
+                                                        Strings.TabTraySegmentedControlTitlesPrivateTabs,
+                                                        Strings.TabTraySegmentedControlTitlesSyncedTabs])
         } else {
             navigationMenu = UISegmentedControl(items: [UIImage(named: "nav-tabcounter")!.overlayWith(image: countLabel),
                                                         UIImage(named: "smallPrivateMask")!,
@@ -81,8 +87,11 @@ class TabTrayViewController: UIViewController {
     }()
 
     lazy var bottomToolbarItems: [UIBarButtonItem] = {
-        let bottomToolbar = [deleteButton, flexibleSpace, newTabButton]
-        return bottomToolbar
+        return [deleteButton, flexibleSpace, newTabButton]
+    }()
+
+    lazy var bottomToolbarItemsForSync: [UIBarButtonItem] = {
+        return [flexibleSpace, syncTabButton]
     }()
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -167,6 +176,7 @@ class TabTrayViewController: UIViewController {
             if children.first == tabTrayView {
                 hideCurrentPanel()
                 let syncedTabsController = RemoteTabsPanel(profile: self.profile)
+                setToolbarItems(bottomToolbarItemsForSync, animated: true)
                 showPanel(syncedTabsController)
             }
         default:
@@ -179,6 +189,7 @@ class TabTrayViewController: UIViewController {
             hideCurrentPanel()
             showPanel(tabTrayView)
         }
+        setToolbarItems(bottomToolbarItems, animated: true)
         tabTrayView.didTogglePrivateMode(privateMode)
     }
 
@@ -214,6 +225,11 @@ extension TabTrayViewController {
 
     @objc func didTapAddTab(_ sender: UIButton) {
         tabTrayView.performToolbarAction(.addTab, sender: sender)
+    }
+
+    @objc func didTapSyncTabs(_ sender: UIButton) {
+        // TODO: Sync tabs implementation
+        print("I'm a gonna sync dem tabs!")
     }
 }
 

--- a/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
@@ -1,10 +1,6 @@
-//
-//  TabTrayViewModel.swift
-//  Client
-//
-//  Created by Roux Buciu on 2021-04-01.
-//  Copyright © 2021 Mozilla. All rights reserved.
-//
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Shared
 
@@ -49,15 +45,15 @@ class TabTrayViewModel {
 
 // MARK: - Actions
 extension TabTrayViewModel {
-    @objc func didTapDeleteTab(_ sender: UIButton) {
+    @objc func didTapDeleteTab(_ sender: UIBarButtonItem) {
         tabTrayView.performToolbarAction(.deleteTab, sender: sender)
     }
 
-    @objc func didTapAddTab(_ sender: UIButton) {
+    @objc func didTapAddTab(_ sender: UIBarButtonItem) {
         tabTrayView.performToolbarAction(.addTab, sender: sender)
     }
 
-    @objc func didTapSyncTabs(_ sender: UIButton) {
+    @objc func didTapSyncTabs(_ sender: UIBarButtonItem) {
         // TODO: Sync tabs implementation
         print("I'm a gonna sync dem tabs!")
     }

--- a/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
@@ -17,51 +17,6 @@ class TabTrayViewModel {
     let tabTrayView: TabTrayViewDelegate
     let syncedTabsController: RemoteTabsPanel
 
-    // Buttons & Menus
-    lazy var deleteButton: UIBarButtonItem = {
-        return UIBarButtonItem(image: UIImage.templateImageNamed("action_delete"), style: .plain, target: self, action: #selector(didTapDeleteTab(_:)))
-    }()
-
-    lazy var newTabButton: UIBarButtonItem = {
-        return UIBarButtonItem(customView: NewTabButton(target: self, selector: #selector(didTapAddTab)))
-    }()
-
-    lazy var syncTabButton: UIBarButtonItem = {
-        return UIBarButtonItem(title: Strings.FxASyncNow, style: .plain, target: self, action: #selector(didTapSyncTabs))
-    }()
-
-    lazy var flexibleSpace: UIBarButtonItem = {
-        return UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-    }()
-
-    lazy var countLabel: UILabel = {
-        let label = UILabel(frame: CGRect(width: 24, height: 24))
-        label.font = TabsButtonUX.TitleFont
-        label.layer.cornerRadius = TabsButtonUX.CornerRadius
-        label.textAlignment = .center
-        label.text = String(tabManager.normalTabs.count)
-        return label
-    }()
-
-    lazy var iPadNavigationMenu: UISegmentedControl = {
-        return UISegmentedControl(items: [Strings.TabTraySegmentedControlTitlesTabs,
-                                          Strings.TabTraySegmentedControlTitlesPrivateTabs,
-                                          Strings.TabTraySegmentedControlTitlesSyncedTabs])
-    }()
-
-    lazy var iPhoneNavigationMenu: UISegmentedControl = {
-        return UISegmentedControl(items: [UIImage(named: "nav-tabcounter")!.overlayWith(image: countLabel),
-                                          UIImage(named: "smallPrivateMask")!,
-                                          UIImage(named: "synced_devices")!])
-    }()
-
-    lazy var bottomToolbarItems: [UIBarButtonItem] = {
-        return [deleteButton, flexibleSpace, newTabButton]
-    }()
-
-    lazy var bottomToolbarItemsForSync: [UIBarButtonItem] = {
-        return [flexibleSpace, syncTabButton]
-    }()
 
 
     init(tabTrayDelegate: TabTrayDelegate? = nil, profile: Profile, showChronTabs: Bool = false) {
@@ -75,6 +30,20 @@ class TabTrayViewModel {
         }
         self.syncedTabsController = RemoteTabsPanel(profile: self.profile)
 
+    }
+
+    func navTitle(for segmentIndex: Int) -> String? {
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            switch segmentIndex {
+            case 0, 1:
+                return Strings.TabTrayV2Title
+            case 2:
+                return Strings.AppMenuSyncedTabsTitleString
+            default:
+                return nil
+            }
+        }
+        return nil
     }
 }
 

--- a/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
@@ -13,8 +13,6 @@ class TabTrayViewModel {
     let tabTrayView: TabTrayViewDelegate
     let syncedTabsController: RemoteTabsPanel
 
-
-
     init(tabTrayDelegate: TabTrayDelegate? = nil, profile: Profile, showChronTabs: Bool = false) {
         self.profile = profile
         self.tabManager = BrowserViewController.foregroundBVC().tabManager
@@ -25,7 +23,6 @@ class TabTrayViewModel {
             self.tabTrayView = GridTabViewController(tabManager: self.tabManager, profile: profile, tabTrayDelegate: tabTrayDelegate)
         }
         self.syncedTabsController = RemoteTabsPanel(profile: self.profile)
-
     }
 
     func navTitle(for segmentIndex: Int) -> String? {

--- a/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
@@ -1,0 +1,95 @@
+//
+//  TabTrayViewModel.swift
+//  Client
+//
+//  Created by Roux Buciu on 2021-04-01.
+//  Copyright © 2021 Mozilla. All rights reserved.
+//
+
+import Shared
+
+class TabTrayViewModel {
+
+    fileprivate let profile: Profile
+    let tabManager: TabManager
+
+    // Tab Tray Views
+    let tabTrayView: TabTrayViewDelegate
+    let syncedTabsController: RemoteTabsPanel
+
+    // Buttons & Menus
+    lazy var deleteButton: UIBarButtonItem = {
+        return UIBarButtonItem(image: UIImage.templateImageNamed("action_delete"), style: .plain, target: self, action: #selector(didTapDeleteTab(_:)))
+    }()
+
+    lazy var newTabButton: UIBarButtonItem = {
+        return UIBarButtonItem(customView: NewTabButton(target: self, selector: #selector(didTapAddTab)))
+    }()
+
+    lazy var syncTabButton: UIBarButtonItem = {
+        return UIBarButtonItem(title: Strings.FxASyncNow, style: .plain, target: self, action: #selector(didTapSyncTabs))
+    }()
+
+    lazy var flexibleSpace: UIBarButtonItem = {
+        return UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+    }()
+
+    lazy var countLabel: UILabel = {
+        let label = UILabel(frame: CGRect(width: 24, height: 24))
+        label.font = TabsButtonUX.TitleFont
+        label.layer.cornerRadius = TabsButtonUX.CornerRadius
+        label.textAlignment = .center
+        label.text = String(tabManager.normalTabs.count)
+        return label
+    }()
+
+    lazy var iPadNavigationMenu: UISegmentedControl = {
+        return UISegmentedControl(items: [Strings.TabTraySegmentedControlTitlesTabs,
+                                          Strings.TabTraySegmentedControlTitlesPrivateTabs,
+                                          Strings.TabTraySegmentedControlTitlesSyncedTabs])
+    }()
+
+    lazy var iPhoneNavigationMenu: UISegmentedControl = {
+        return UISegmentedControl(items: [UIImage(named: "nav-tabcounter")!.overlayWith(image: countLabel),
+                                          UIImage(named: "smallPrivateMask")!,
+                                          UIImage(named: "synced_devices")!])
+    }()
+
+    lazy var bottomToolbarItems: [UIBarButtonItem] = {
+        return [deleteButton, flexibleSpace, newTabButton]
+    }()
+
+    lazy var bottomToolbarItemsForSync: [UIBarButtonItem] = {
+        return [flexibleSpace, syncTabButton]
+    }()
+
+
+    init(tabTrayDelegate: TabTrayDelegate? = nil, profile: Profile, showChronTabs: Bool = false) {
+        self.profile = profile
+        self.tabManager = BrowserViewController.foregroundBVC().tabManager
+
+        if showChronTabs {
+            self.tabTrayView = ChronologicalTabsViewController(tabTrayDelegate: tabTrayDelegate, profile: self.profile)
+        } else {
+            self.tabTrayView = GridTabViewController(tabManager: self.tabManager, profile: profile, tabTrayDelegate: tabTrayDelegate)
+        }
+        self.syncedTabsController = RemoteTabsPanel(profile: self.profile)
+
+    }
+}
+
+// MARK: - Actions
+extension TabTrayViewModel {
+    @objc func didTapDeleteTab(_ sender: UIButton) {
+        tabTrayView.performToolbarAction(.deleteTab, sender: sender)
+    }
+
+    @objc func didTapAddTab(_ sender: UIButton) {
+        tabTrayView.performToolbarAction(.addTab, sender: sender)
+    }
+
+    @objc func didTapSyncTabs(_ sender: UIButton) {
+        // TODO: Sync tabs implementation
+        print("I'm a gonna sync dem tabs!")
+    }
+}

--- a/Client/Frontend/Settings/SettingsNavigationController.swift
+++ b/Client/Frontend/Settings/SettingsNavigationController.swift
@@ -21,7 +21,7 @@ class ThemedNavigationController: UINavigationController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        modalPresentationStyle = .formSheet
+        modalPresentationStyle = .overFullScreen
         modalPresentationCapturesStatusBarAppearance = true
         applyTheme()
     }

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -394,6 +394,11 @@ extension Strings {
     public static let TabTrayV2OlderHeader = MZLocalizedString("TabTray.Older.Header", value: "Older", comment: "The section header for tabs opened before last week")
     public static let TabTraySwipeMenuMore = MZLocalizedString("TabTray.SwipeMenu.More", value: "More", comment: "The button title to see more options to perform on the tab.")
     public static let TabTrayMoreMenuCopy = MZLocalizedString("TabTray.MoreMenu.Copy", value: "Copy", comment: "The title on the button to copy the tab address.")
+
+    // Segmented Control tites for iPad
+    public static let TabTraySegmentedControlTitlesTabs = MZLocalizedString("TabTray.SegmentedControlTitles.Tabs", value: "Tabs", comment: "The title on the button to look at regular tabs.")
+    public static let TabTraySegmentedControlTitlesPrivateTabs = MZLocalizedString("TabTray.SegmentedControlTitles.PrivateTabs", value: "Private", comment: "The title on the button to look at private tabs.")
+    public static let TabTraySegmentedControlTitlesSyncedTabs = MZLocalizedString("TabTray.SegmentedControlTitles.SyncedTabs", value: "Synced", comment: "The title on the button to look at synced tabs.")
 }
 
 //Clipboard Toast


### PR DESCRIPTION
This PR does the following

- Implements a TabTrayViewModel for the business logic of TabTrayViewController
- Moves the responsibility of the toolbar (whether bottom or top) from GridTabsVC, RemoteTabsVC, and ChronTabs VC to the TabsTrayVC/VM (this was fun surgery!)
- Adds the Sync Now button on the toolbar for Sync Tabs view. (just a placeholder for now; it doesn't do anything except print some silly text)
- Separates the design for iPhone & iPad
- Fixes behaviour of the "Delete all tabs" button for both iPad & iPhone given the new implementation
- Removes needless import statements
- General cleanup

TODO: Ask @brampitoyo / @athomasmoz questions re: the Delete all button popup - what should it look like: the standard iOS style (which is what we currently have in prod), or should we have the label be white/dark based on the mode? This may require a sync-up with @dnarcese because she's doing some work on something similar, I think?