### PR TITLE
Bugfix FXIOS-2200 [vXXX] Night mode makes black background white, making dark theme websites light theme

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/NightModeHelper.js
+++ b/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/NightModeHelper.js
@@ -50,6 +50,20 @@ function applyInvertFilterToElement(el) {
   el.style.webkitFilter = NIGHT_MODE_INVERT_FILTER_CSS;
 }
 
+function isWebsiteCSSNightMode(){
+  // Fixes FXIOS177 (enabling night mode makes websites with night mode CSS into day mode)
+  var splitRGB=/rgba?\((\d+), *(\d+), *(\d+)(?:, *(\d+\.?\d*))?\)/g;
+  var bodyBG=window.getComputedStyle(document.body).backgroundColor;
+  var bodyBGSplit=splitRGB.exec(bodyBG);
+  bodyBGSplit.shift();
+  if (bodyBGSplit.length==4){
+  	bodyBGSplit.pop();
+  }
+  // https://css-tricks.com/using-javascript-to-adjust-saturation-and-brightness-of-rgb-colors/#how-to-find-the-lightness-of-an-rgb-color
+  var bodyBGBrightness=(Math.max(...bodyBGSplit)+Math.min(...bodyBGSplit))/2/255;
+  return bodyBGBrightness<=0.5;
+}
+
 function removeInvertFilterFromElement(el) {
   el.style.webkitFilter = el.__firefox__NightMode_originalFilter;
   delete el.__firefox__NightMode_originalFilter;
@@ -75,6 +89,10 @@ Object.defineProperty(window.__firefox__.NightMode, "setEnabled", {
   configurable: false,
   writable: false,
   value: function(enabled) {
+    if (isWebsiteCSSNightMode() && enabled){
+      return;
+    }
+    
     if (enabled === window.__firefox__.NightMode.enabled) {
       return;
     }


### PR DESCRIPTION
Fixes https://github.com/mozilla-mobile/firefox-ios/issues/5772.

I was unable to do a test build because of https://github.com/mozilla-mobile/firefox-ios/issues/7802.

I just copied @Scripter17's code from [this comment](https://github.com/mozilla-mobile/firefox-ios/issues/5772#issuecomment-573380173) on Issue https://github.com/mozilla-mobile/firefox-ios/issues/5772.

The code detects whether the body element has a background color darker than 50% and aborts `NightMode.setEnabled` if this is the case.

Obviously this heuristic is extremely simplistic and could stand to have further iterations. For example, it could check the lightness of the background value of elements other than the HTML body, or it could compare the lightness of the background value to the lightness of the text-color value. I am not in a position to test any variations on this because of, again, https://github.com/mozilla-mobile/firefox-ios/issues/7802.

I am starting this pull request because it seems like a more productive way of getting traction on Issue https://github.com/mozilla-mobile/firefox-ios/issues/5772 than waiting for one of the maintainers to do it instead.