### PR TITLE
Modify Screengraph for iPad and update/fix tests

### DIFF
--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -212,8 +212,13 @@ class ActivityStreamTest: BaseTestCase {
         waitForNoExistence(app.tables["Context Menu"], timeoutValue: 15)
         navigator.nowAt(HomePanelsScreen)
         navigator.goto(TabTray)
-        waitForExistence(app.cells.staticTexts["wikipedia.org"], timeout: 5)
-        let numTabsOpen = app.tables.cells.count
+        var numTabsOpen = app.tables.cells.count
+        if iPad() {
+            waitForExistence(app.cells.staticTexts["Wikipedia"], timeout: 5)
+            numTabsOpen = app.collectionViews.cells.count
+        } else {
+            waitForExistence(app.cells.staticTexts["wikipedia.org"], timeout: 5)
+        }
         XCTAssertEqual(numTabsOpen, 2, "New tab not open")
     }
 
@@ -239,7 +244,11 @@ class ActivityStreamTest: BaseTestCase {
             app.buttons["Show Tabs"].tap()
         }
         navigator.nowAt(TabTray)
-        waitForExistence(app.tables.cells.staticTexts["Apple"])
+        if iPad() {
+            waitForExistence(app.collectionViews.cells.staticTexts["Apple"], timeout: 5)
+        } else {
+            waitForExistence(app.tables.cells.staticTexts["Apple"], timeout: 5)
+        }
         app.cells.staticTexts["Apple"].tap()
 
         // The website is open
@@ -267,7 +276,11 @@ class ActivityStreamTest: BaseTestCase {
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
         waitForExistence(app.cells.staticTexts[defaultTopSite["bookmarkLabel"]!])
-        let numTabsOpen = userState.numTabs
+        var numTabsOpen = userState.numTabs
+        if iPad() {
+            navigator.goto(TabTray)
+            numTabsOpen = app.collectionViews.cells.count
+        }
         XCTAssertEqual(numTabsOpen, 1, "New tab not open")
     }
     /* Disable due to https://github.com/mozilla-mobile/firefox-ios/issues/7521

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -911,14 +911,24 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     map.addScreenState(TabTray) { screenState in
-        screenState.tap(app.buttons["newTabButtonTabTray"], forAction: Action.OpenNewTabFromTabTray, transitionTo: NewTabScreen)
-        screenState.tap(app.buttons["smallPrivateMask"], forAction: Action.TogglePrivateMode) { userState in
+
+        if isTablet {
+            screenState.tap(app.buttons["TabTrayController.addTabButton"], forAction: Action.OpenNewTabFromTabTray, transitionTo: NewTabScreen)
+            screenState.tap(app.buttons["TabTrayController.maskButton"], forAction: Action.TogglePrivateMode) { userState in
             userState.isPrivate = !userState.isPrivate
-        }
-        screenState.tap(app.toolbars.segmentedControls.buttons.firstMatch, forAction: Action.ToggleRegularMode) { userState in
+            }
+
+            screenState.tap(app.buttons["TabTrayController.removeTabsButton"], to: CloseTabMenu)
+        } else {
+            screenState.tap(app.buttons["newTabButtonTabTray"], forAction: Action.OpenNewTabFromTabTray, transitionTo: NewTabScreen)
+            screenState.tap(app.buttons["smallPrivateMask"], forAction: Action.TogglePrivateMode) { userState in
             userState.isPrivate = !userState.isPrivate
+            }
+            screenState.tap(app.toolbars.segmentedControls.buttons.firstMatch, forAction: Action.ToggleRegularMode) { userState in
+            userState.isPrivate = !userState.isPrivate
+            }
+            screenState.tap(app.buttons["closeAllTabsButtonTabTray"], to: CloseTabMenu)
         }
-        screenState.tap(app.buttons["closeAllTabsButtonTabTray"], to: CloseTabMenu)
 
         screenState.onEnter { userState in
             userState.numTabs = Int(app.tables.cells.count)
@@ -1122,7 +1132,11 @@ extension MMNavigator where T == FxUserState {
     func createNewTab() {
         let app = XCUIApplication()
         self.goto(TabTray)
-        app.buttons["newTabButtonTabTray"].tap()
+        if isTablet {
+            app.buttons["TabTrayController.addTabButton"].tap()
+        } else {
+            app.buttons["newTabButtonTabTray"].tap()
+        }
         self.nowAt(NewTabScreen)
     }
 

--- a/XCUITests/NavigationTest.swift
+++ b/XCUITests/NavigationTest.swift
@@ -407,7 +407,9 @@ class NavigationTest: BaseTestCase {
         XCTAssertTrue(app.tables.cells["menu-NightMode"].exists)
         XCTAssertTrue(app.tables.cells["whatsnew"].exists)
         XCTAssertTrue(app.tables.cells["menu-Settings"].exists)
-        XCTAssertTrue(app.buttons["PhotonMenu.close"].exists)
+        if !iPad() {
+            XCTAssertTrue(app.buttons["PhotonMenu.close"].exists)
+        }
     }
 
     // Smoketest

--- a/XCUITests/PhotonActionSheetTest.swift
+++ b/XCUITests/PhotonActionSheetTest.swift
@@ -94,14 +94,14 @@ class PhotonActionSheetTest: BaseTestCase {
         navigator.goto(PageOptionsMenu)
         waitForExistence(app.tables["Context Menu"].cells["action_share"], timeout: 5)
         app.tables["Context Menu"].staticTexts["Share Page With…"].tap()
-        if #available(iOS 14.0, *) {
-            waitForExistence(app.collectionViews.buttons["Copy"], timeout: 10)
-        } else {
-            waitForExistence(app.cells["Copy"], timeout: 10)
-        }
+
         // This is not ideal but only way to get the element on iPhone 8
         // for iPhone 11, that would be boundBy: 2
-        let fennecElement = app.collectionViews.scrollViews.cells.element(boundBy: 2)
+        var  fennecElement = app.collectionViews.scrollViews.cells.element(boundBy: 2)
+        if iPad() {
+            waitForExistence(app.collectionViews.buttons["Copy"], timeout: 10)
+            fennecElement = app.collectionViews.scrollViews.cells.element(boundBy: 1)
+        }
 
         fennecElement.tap()
         waitForExistence(app.navigationBars["ShareTo.ShareView"], timeout: 10)

--- a/XCUITests/PrivateBrowsingTest.swift
+++ b/XCUITests/PrivateBrowsingTest.swift
@@ -225,7 +225,9 @@ class PrivateBrowsingTestIpad: IpadOnlyTestCase {
         waitUntilPageLoad()
         // This action to enable private mode is defined on HomePanel Screen that is why we need to open a new tab and be sure we are on that screen to use the correct action
         navigator.goto(NewTabScreen)
+
         navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateModeFromTabBarHomePanel)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(LibraryPanel_History)
         waitForExistence(app.tables["History List"])
         // History without counting Clear Recent History, Recently Closed

--- a/XCUITests/TopTabsTest.swift
+++ b/XCUITests/TopTabsTest.swift
@@ -132,11 +132,18 @@ class TopTabsTest: BaseTestCase {
 
         navigator.goto(URLBarOpen)
         navigator.back()
+        if iPad() {
+            navigator.goto(TabTray)
+            print(app.collectionViews.cells.count)
+        }
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
 
         // Close all tabs, undo it and check that the number of tabs is correct
         navigator.performAction(Action.AcceptRemovingAllTabs)
-        app.buttons["Undo"].tap()
+
+        waitForExistence(app.otherElements.buttons.staticTexts["Undo"])
+        app.otherElements.buttons.staticTexts["Undo"].tap()
+        print(app.debugDescription)
         waitForExistence(app.collectionViews.cells["TopSitesCell"], timeout: 5)
         navigator.nowAt(BrowserTab)
         if !iPad() {
@@ -145,6 +152,10 @@ class TopTabsTest: BaseTestCase {
 
         navigator.goto(URLBarOpen)
         navigator.back()
+
+        if iPad() {
+            navigator.goto(TabTray)
+        }
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
 
         waitForExistence(app.cells.staticTexts[urlLabel])
@@ -172,8 +183,11 @@ class TopTabsTest: BaseTestCase {
 
         navigator.goto(URLBarOpen)
         navigator.back()
-        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 3)
-
+        if iPad() {
+            checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
+        } else {
+            checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 3)
+        }
         // Close all tabs, undo it and check that the number of tabs is correct
         navigator.performAction(Action.AcceptRemovingAllTabs)
         waitForExistence(app.staticTexts["Private Browsing"], timeout: 10)
@@ -239,7 +253,9 @@ class TopTabsTest: BaseTestCase {
         // Go back to portrait mode
         XCUIDevice.shared.orientation = .portrait
         // Verify that the '+' is not displayed
-        waitForNoExistence(app.buttons["TabToolbar.addNewTabButton"])
+        if !iPad() {
+            waitForNoExistence(app.buttons["TabToolbar.addNewTabButton"])
+        }
     }
 
     // Smoketest
@@ -293,7 +309,11 @@ class TopTabsTest: BaseTestCase {
 fileprivate extension BaseTestCase {
     func checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: Int) {
         navigator.goto(TabTray)
-        let numTabsOpen = userState.numTabs
+        var numTabsOpen = userState.numTabs
+        if iPad() {
+            numTabsOpen = app.collectionViews.cells.count
+        }
+
         XCTAssertEqual(numTabsOpen, expectedNumberOfTabsOpen, "The number of tabs open is not correct")
     }
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -721,7 +721,7 @@ workflows:
         inputs:
         - scheme: Fennec_Enterprise_XCUITests
         - xcodebuild_test_options: '-testPlan SmokeXCUITests'
-        - simulator_device: iPhone 11
+        - simulator_device: iPad Air (3rd generation)
         is_always_run: true
     - deploy-to-bitrise-io@1.9: {}
     - cache-push@2.2: {}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -681,7 +681,7 @@ workflows:
     - xcode-test@2:
         inputs:
         - scheme: Fennec
-        - simulator_device: iPhone 8
+        - simulator_device: iPad Air (3rd generation)
     - deploy-to-bitrise-io@1.9: {}
     - cache-push@2.4: {}
     - slack@3.1:
@@ -721,7 +721,7 @@ workflows:
         inputs:
         - scheme: Fennec_Enterprise_XCUITests
         - xcodebuild_test_options: '-testPlan SmokeXCUITests'
-        - simulator_device: iPad Air (3rd generation)
+        - simulator_device: iPad Pro (12.9-inch) (4th generation)
         is_always_run: true
     - deploy-to-bitrise-io@1.9: {}
     - cache-push@2.2: {}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -681,7 +681,7 @@ workflows:
     - xcode-test@2:
         inputs:
         - scheme: Fennec
-        - simulator_device: iPad Air (3rd generation)
+        - simulator_device: iPhone 8
     - deploy-to-bitrise-io@1.9: {}
     - cache-push@2.4: {}
     - slack@3.1:
@@ -721,7 +721,7 @@ workflows:
         inputs:
         - scheme: Fennec_Enterprise_XCUITests
         - xcodebuild_test_options: '-testPlan SmokeXCUITests'
-        - simulator_device: iPad Pro (12.9-inch) (4th generation)
+        - simulator_device: iPhone 11
         is_always_run: true
     - deploy-to-bitrise-io@1.9: {}
     - cache-push@2.2: {}


### PR DESCRIPTION
PR to try to fix the tests on iPad simulator. 
Starting by updating the FxScreengrhap to manage the old tab tray implementation, current on iPad and fixing tests for the Smoke test plan
