### PR TITLE
Follow up issue8214 xc UI tests update test suites2

### DIFF
--- a/XCUITests/HistoryTests.swift
+++ b/XCUITests/HistoryTests.swift
@@ -272,6 +272,7 @@ class HistoryTests: BaseTestCase {
     
     private func navigateToGoogle(){
         navigator.openURL("example.com")
+        waitUntilPageLoad()
         navigator.goto(LibraryPanel_History)
         XCTAssertTrue(app.tables.cells.staticTexts["Example Domain"].exists)
     }

--- a/XCUITests/NavigationTest.swift
+++ b/XCUITests/NavigationTest.swift
@@ -408,6 +408,7 @@ class NavigationTest: BaseTestCase {
 
     // Smoketest
     func testVerifyBrowserTabMenu() {
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
         navigator.performAction(Action.CloseURLBarOpen)
         waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: 5)
         navigator.nowAt(NewTabScreen)

--- a/XCUITests/NewTabSettings.swift
+++ b/XCUITests/NewTabSettings.swift
@@ -8,6 +8,7 @@ let websiteUrl = "www.mozilla.org"
 class NewTabSettingsTest: BaseTestCase {
     // Smoketest
     func testCheckNewTabSettingsByDefault() {
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
         navigator.performAction(Action.CloseURLBarOpen)
         waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: 5)
         navigator.nowAt(NewTabScreen)
@@ -20,6 +21,7 @@ class NewTabSettingsTest: BaseTestCase {
 
     // Smoketest
     func testChangeNewTabSettingsShowBlankPage() {
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
         navigator.performAction(Action.CloseURLBarOpen)
         waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: 5)
         navigator.nowAt(NewTabScreen)
@@ -53,8 +55,9 @@ class NewTabSettingsTest: BaseTestCase {
     }
 
     func testChangeNewTabSettingsShowCustomURL() {
-        navigator.goto(URLBarOpen)
-        navigator.back()
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(NewTabSettings)
         waitForExistence(app.navigationBars["New Tab"])
         // Check the placeholder value

--- a/XCUITests/PrivateBrowsingTest.swift
+++ b/XCUITests/PrivateBrowsingTest.swift
@@ -109,7 +109,7 @@ class PrivateBrowsingTest: BaseTestCase {
 
         // Now the enable the Close Private Tabs when closing the Private Browsing Button
         app.cells.staticTexts[url2Label].tap()
-        // Workaround to issue ... to be filed
+        // Workaround to issue 8295 while it is fixed
         app.buttons["urlBar-cancel"].tap()
         waitForTabsButton()
         waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: 10)

--- a/XCUITests/PrivateBrowsingTest.swift
+++ b/XCUITests/PrivateBrowsingTest.swift
@@ -44,6 +44,8 @@ class PrivateBrowsingTest: BaseTestCase {
 
     func testTabCountShowsOnlyNormalOrPrivateTabCount() {
         // Open two tabs in normal browsing and check the number of tabs open
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.openNewURL(urlString: url2)
         waitUntilPageLoad()
         waitForTabsButton()
@@ -79,6 +81,8 @@ class PrivateBrowsingTest: BaseTestCase {
 
     func testClosePrivateTabsOptionClosesPrivateTabs() {
         // Check that Close Private Tabs when closing the Private Browsing Button is off by default
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: 5)
         navigator.goto(SettingsScreen)
         let settingsTableView = app.tables["AppSettingsTableViewController.tableView"]
@@ -105,6 +109,8 @@ class PrivateBrowsingTest: BaseTestCase {
 
         // Now the enable the Close Private Tabs when closing the Private Browsing Button
         app.cells.staticTexts[url2Label].tap()
+        // Workaround to issue ... to be filed
+        app.buttons["urlBar-cancel"].tap()
         waitForTabsButton()
         waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: 10)
         navigator.nowAt(BrowserTab)
@@ -127,6 +133,8 @@ class PrivateBrowsingTest: BaseTestCase {
      https://bugzilla.mozilla.org/show_bug.cgi?id=1646756
      */
     func testClearIndexedDB() {
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         enableClosePrivateBrowsingOptionWhenLeaving()
 
         func checkIndexedDBIsCreated() {
@@ -147,6 +155,8 @@ class PrivateBrowsingTest: BaseTestCase {
     }
 
     func testPrivateBrowserPanelView() {
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         // If no private tabs are open, there should be a initial screen with label Private Browsing
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 

--- a/XCUITests/ReaderViewUITest.swift
+++ b/XCUITests/ReaderViewUITest.swift
@@ -66,8 +66,12 @@ class ReaderViewTest: BaseTestCase {
     }
 
     func testAddToReadingListPrivateMode() {
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         navigator.performAction(Action.OpenNewTabFromTabTray)
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_ReadingList)
         
@@ -91,7 +95,10 @@ class ReaderViewTest: BaseTestCase {
         checkReadingListNumberOfItems(items: 1)
 
         // Check that it appears on regular mode
-        navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleRegularMode)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(LibraryPanel_ReadingList)
         checkReadingListNumberOfItems(items: 1)
     }
@@ -164,6 +171,8 @@ class ReaderViewTest: BaseTestCase {
     }
 
     func testAddToReadingListFromPageOptionsMenu() {
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         // First time Reading list is empty
         navigator.goto(LibraryPanel_ReadingList)
         checkReadingListNumberOfItems(items: 0)

--- a/XCUITests/SaveLoginsTests.swift
+++ b/XCUITests/SaveLoginsTests.swift
@@ -36,6 +36,8 @@ class SaveLoginTest: BaseTestCase {
     }
     
     func testLoginsListFromBrowserTabMenu() {
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         waitForTabsButton()
         //Make sure you can access empty Login List from Browser Tab Menu
         navigator.goto(LoginsSettings)
@@ -53,6 +55,8 @@ class SaveLoginTest: BaseTestCase {
     }
     
     func testPasscodeLoginsListFromBrowserTabMenu() {
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.performAction(Action.SetPasscode)
         navigator.nowAt(PasscodeSettings)
         navigator.goto(SettingsScreen)

--- a/XCUITests/ScreenGraphTest.swift
+++ b/XCUITests/ScreenGraphTest.swift
@@ -40,6 +40,9 @@ extension ScreenGraphTest {
     }
 
     func testBackStack() {
+        wait(forElement: app.buttons["urlBar-cancel"], timeout: 5)
+        app.buttons["urlBar-cancel"].tap()
+        navigator.nowAt(BrowserTab)
         // We'll go through the browser tab, through the menu.
         navigator.goto(SettingsScreen)
         // Going back, there is no explicit way back to the browser tab,
@@ -50,6 +53,9 @@ extension ScreenGraphTest {
     }
 
     func testSimpleToggleAction() {
+        wait(forElement: app.buttons["urlBar-cancel"], timeout: 5)
+        app.buttons["urlBar-cancel"].tap()
+        navigator.nowAt(BrowserTab)
         // Switch night mode on, by toggling.
         navigator.performAction(TestActions.ToggleNightMode)
         XCTAssertTrue(navigator.userState.nightMode)
@@ -92,6 +98,9 @@ extension ScreenGraphTest {
     }
 
     func testConditionalEdgesSimple() {
+        wait(forElement: app.buttons["urlBar-cancel"], timeout: 5)
+        app.buttons["urlBar-cancel"].tap()
+        navigator.nowAt(BrowserTab)
         XCTAssertTrue(navigator.can(goto: PasscodeSettingsOff))
         XCTAssertFalse(navigator.can(goto: PasscodeSettingsOn))
         navigator.goto(PasscodeSettingsOff)
@@ -99,6 +108,8 @@ extension ScreenGraphTest {
     }
 
     func testConditionalEdgesRerouting() {
+        app.buttons["urlBar-cancel"].tap()
+        navigator.nowAt(BrowserTab)
         // The navigator should dynamically reroute to the target screen
         // if the userState changes.
         // This test adds to the graph a passcode setting screen. In that screen,

--- a/XCUITests/SearchSettingsUITest.swift
+++ b/XCUITests/SearchSettingsUITest.swift
@@ -10,6 +10,8 @@ let customSearchEngine = ["name": "youtube", "url": "https://youtube.com/search?
 
 class SearchSettingsUITests: BaseTestCase {
     func testDefaultSearchEngine() {
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(SearchSettings)
         // Check the default browser
         let defaultSearchEngine = app.tables.cells.element(boundBy: 0)
@@ -23,6 +25,8 @@ class SearchSettingsUITests: BaseTestCase {
     }
 
     func testCustomSearchEngineIsEditable() {
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(SearchSettings)
         // Add a custom search engine
         addCustomSearchEngine()
@@ -52,6 +56,8 @@ class SearchSettingsUITests: BaseTestCase {
     }
 
     func testCustomSearchEngineAsDefaultIsNotEditable() {
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(SearchSettings)
         // Edit is disabled
         XCTAssertFalse(app.buttons["Edit"].isEnabled)
@@ -70,6 +76,8 @@ class SearchSettingsUITests: BaseTestCase {
     }
 
     func testNavigateToSearchPickerTurnsOffEditing() {
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(SearchSettings)
         // Edit is disabled
         XCTAssertFalse(app.buttons["Edit"].isEnabled)
@@ -94,6 +102,8 @@ class SearchSettingsUITests: BaseTestCase {
     }
 
     func testDeletingLastCustomEngineExitsEditing() {
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(SearchSettings)
         // Edit is disabled
         XCTAssertFalse(app.buttons["Edit"].isEnabled)

--- a/XCUITests/SearchTest.swift
+++ b/XCUITests/SearchTest.swift
@@ -169,6 +169,7 @@ class SearchTests: BaseTestCase {
 
     // Smoketest
     func testSearchEngine() {
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         // Change to the each search engine and verify the search uses it

--- a/XCUITests/SearchTest.swift
+++ b/XCUITests/SearchTest.swift
@@ -7,7 +7,7 @@ import XCTest
 private let LabelPrompt: String = "Turn on search suggestions?"
 private let SuggestedSite: String = "foobar meaning"
 private let SuggestedSite2: String = "foobar google"
-private let SuggestedSite3: String = "foobar2000 mac"
+private let SuggestedSite3: String = "foobar2000"
 
 private let SuggestedSite4: String = "foo bar baz"
 private let SuggestedSite5: String = "foo bar baz qux"
@@ -182,6 +182,8 @@ class SearchTests: BaseTestCase {
     }
 
     func testDefaultSearchEngine() {
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(SearchSettings)
         XCTAssert(app.tables.staticTexts["Google"].exists)
     }
@@ -211,8 +213,10 @@ class SearchTests: BaseTestCase {
     }
     
     func testSearchIconOnAboutHome() {
+        navigator.performAction(Action.CloseURLBarOpen)
         waitForTabsButton()
         navigator.performAction(Action.OpenNewTabFromTabTray)
+        navigator.performAction(Action.CloseURLBarOpen)
         waitForTabsButton()
         
         // Search icon is displayed.

--- a/XCUITests/SettingsTest.swift
+++ b/XCUITests/SettingsTest.swift
@@ -6,6 +6,8 @@ import XCTest
 
 class SettingsTest: BaseTestCase {
     func testHelpOpensSUMOInTab() {
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)
         let settingsTableView = app.tables["AppSettingsTableViewController.tableView"]
 
@@ -25,6 +27,8 @@ class SettingsTest: BaseTestCase {
     }
 
     func testOpenSiriOption() {
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.performAction(Action.OpenSiriFromSettings)
         waitForExistence(app.buttons["Add to Siri"], timeout: 5)
     }
@@ -47,6 +51,9 @@ class SettingsTest: BaseTestCase {
             app.activate()
 
             // Tap on "Set as Default Browser" from the in-browser settings
+            waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
+            navigator.performAction(Action.CloseURLBarOpen)
+            navigator.nowAt(NewTabScreen)
             navigator.goto(SettingsScreen)
             let settingsTableView = app.tables["AppSettingsTableViewController.tableView"]
             let defaultBrowserButton = settingsTableView.cells["Set as Default Browser"]

--- a/XCUITests/SyncFAUITests.swift
+++ b/XCUITests/SyncFAUITests.swift
@@ -16,12 +16,16 @@ var code: String!
 
 class SyncUITests: BaseTestCase {
     func testUIFromSettings () {
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(FxASigninScreen)
         verifyFxASigninScreen()
     }
 
     func testSyncUIFromBrowserTabMenu() {
         // Check menu available from HomeScreenPanel
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(BrowserTabMenu)
         waitForExistence(app.tables["Context Menu"].cells["menu-sync"])
         navigator.goto(Intro_FxASignin)
@@ -42,6 +46,8 @@ class SyncUITests: BaseTestCase {
     }
 
     func testTypeOnGivenFields() {
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(FxASigninScreen)
         waitForExistence(app.navigationBars["Turn on Sync"], timeout: 60)
 
@@ -67,6 +73,8 @@ class SyncUITests: BaseTestCase {
     }
 
     func testCreateAnAccountLink() {
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(FxASigninScreen)
         waitForExistence(app.webViews.firstMatch, timeout: 20)
         waitForExistence(app.webViews.textFields["Email"], timeout: 40)
@@ -78,6 +86,8 @@ class SyncUITests: BaseTestCase {
 
     func testShowPassword() {
         // The aim of this test is to check if the option to show password is shown when user starts typing and dissapears when no password is typed
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(FxASigninScreen)
         waitForExistence(app.webViews.textFields["Email"], timeout: 20)
         // Typing on Email should not show Show (password) option
@@ -94,6 +104,8 @@ class SyncUITests: BaseTestCase {
     }
     
     func testQRPairing() {
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(Intro_FxASignin)
         // QR does not work on sim but checking that the button works, no crash
         navigator.performAction(Action.OpenEmailToQR)

--- a/XCUITests/ThirdPartySearchTest.swift
+++ b/XCUITests/ThirdPartySearchTest.swift
@@ -97,6 +97,8 @@ class ThirdPartySearchTest: BaseTestCase {
     }
     
     private func addCustomSearchEngine() {
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.performAction(Action.AddCustomSearchEngine)
         waitForExistence(app.buttons["customEngineSaveButton"], timeout: 3)
         app.buttons["customEngineSaveButton"].tap()
@@ -114,6 +116,8 @@ class ThirdPartySearchTest: BaseTestCase {
     }
 
     func testCustomEngineFromIncorrectTemplate() {
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(AddCustomSearchSettings)
         app.textViews["customEngineTitle"].tap()
         app.typeText("Feeling Lucky")

--- a/XCUITests/TopTabsTest.swift
+++ b/XCUITests/TopTabsTest.swift
@@ -278,8 +278,7 @@ class TopTabsTest: BaseTestCase {
 
             // Open New Tab
             app.cells["quick_action_new_tab"].tap()
-            navigator.goto(URLBarOpen)
-            navigator.back()
+            navigator.performAction(Action.CloseURLBarOpen)
 
             waitForTabsButton()
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)


### PR DESCRIPTION
This PR is based on the work needed for Issue #8214 so that the full test plan runs green again.
In this PR the test suites updated are:
-ThirdPartySearch
-SyncUI
-Settings
-Search
-SearchSettingsUI
-ScreenGraphTest
-SaveLogin
-ReaderView
-PrivateBrowsing