### PR TITLE
For #8156 - Add workflow to run Smoketest on iPad

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1375,7 +1375,7 @@ workflows:
         inputs:
         - xcodebuild_options: >-
             CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
-            CODE_SIGNING_ALLOWED=NO
+            CODE_SIGNING_ALLOWED=NO -testPlan SmokeXCUITests
         - scheme: Fennec_Enterprise_XCUITests
     - xcode-test@2.4:
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1778,7 +1778,7 @@ trigger_map:
 - push_branch: v32.1
   workflow: xcode12-release-and-beta-nocache
 - pull_request_target_branch: main
-  workflow: RunSmokeXCUITestsiPad
+  workflow: RunUnitTests
 - pull_request_source_branch: '*'
   pull_request_target_branch: chronological-tabs
   workflow: RunUnitTests

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1241,6 +1241,158 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-12.4.x
+  RunSmokeXCUITestsiPad:
+    steps:
+    - activate-ssh-key@4.0:
+        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+    - git-clone@4.0: {}
+    - script@1.1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            echo "PostClone step"
+            carthage checkout
+
+            cd content-blocker-lib-ios/ContentBlockerGen && swift run
+        title: Post clone step for TP updates
+    - cache-pull@2: {}
+    - certificate-and-profile-installer@1.10: {}
+    - script@1:
+        inputs:
+        - content: >-
+            #!/usr/bin/env bash
+
+            # fail if any commands fails
+
+            set -e
+
+            # debug log
+
+            set -x
+
+
+            echo
+            'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64
+            arm64e armv7 armv7s armv6 armv8' > /tmp/tmp.xcconfig
+
+            echo 'EXCLUDED_ARCHS=$(inherited)
+            $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))'
+            >> /tmp/tmp.xcconfig
+
+            echo 'IPHONEOS_DEPLOYMENT_TARGET=11.4' >> /tmp/tmp.xcconfig
+
+            echo 'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig
+
+            echo 'GCC_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig
+
+            export XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig
+
+            envman add --key XCODE_XCCONFIG_FILE --value /tmp/tmp.xcconfig
+        title: 'Workaround carthage lipo bug #3019'
+    - carthage@3.2:
+        inputs:
+        - carthage_options: ' --platform ios'
+    - script@1:
+        title: Remove carthage lipo workaround
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            rm /tmp/tmp.xcconfig
+            envman add --key XCODE_XCCONFIG_FILE --value ''
+    - script@1:
+        title: Copy glean sdk_generator
+        inputs:
+        - content: >-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            # Copy Glean script to source folder from
+            # MozillaAppServices.framework as we need
+            # this script to build iOS App
+
+            cp Carthage/Build/iOS/MozillaAppServices.framework/sdk_generator.sh ./
+    - script@1:
+        inputs:
+        - content: >-
+            #!/usr/bin/env bash
+
+            set -e
+
+            set -x
+
+
+            cd Client.xcodeproj
+
+            sed -i '' 's/"Fennec Development"/"Bitrise Firefox iOS Dev"/'
+            project.pbxproj
+
+            sed -i '' 's/Fennec Today Development/Bitrise Firefox iOS Dev -
+            Fennec Today/' project.pbxproj
+
+            sed -i '' 's/Fennec ShareTo Development/Bitrise Firefox iOS Dev -
+            Share To/' project.pbxproj
+
+            sed -i '' 's/Fennec WidgetKit Development/Bitrise Firefox iOS Dev -
+            WidgetKit/' project.pbxproj
+
+            sed -i '' 's/"XCUITests"/"Bitrise Firefox iOS Dev - XCUI Tests"/'
+            project.pbxproj
+
+            sed -i '' 's/Fennec NotificationService Development/Bitrise Firefox
+            iOS Dev - Notification Service/' project.pbxproj
+
+            sed -i '' 's/CODE_SIGN_IDENTITY = "iPhone
+            Developer"/CODE_SIGN_IDENTITY = "iPhone Distribution"/'
+            project.pbxproj
+
+            cd -
+        title: Set provisioning to Bitrise in xcodeproj
+    - script@1.1:
+        title: NPM install and build
+        inputs:
+        - content: |
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            set -x
+
+            npm install
+            npm run build
+    - 'git::https://github.com/bitrise-steplib/steps-xcode-build-for-test.git@export-fix':
+        inputs:
+        - xcodebuild_options: >-
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+            CODE_SIGNING_ALLOWED=NO
+        - scheme: Fennec_Enterprise_XCUITests
+    - xcode-test@2.4:
+        inputs:
+        - scheme: Fennec_Enterprise_XCUITests
+        - xcodebuild_test_options: '-testPlan SmokeXCUITests'
+        - simulator_os_version: latest
+        - simulator_device: iPad Pro (12.9-inch) (4th generation) 
+    - deploy-to-bitrise-io@1.10: {}
+    - cache-push@2.2: {}
+    - slack@3.1:
+        inputs:
+        - webhook_url: $WEBHOOK_SLACK_TOKEN
+    description: >-
+      This Workflow is to run SmokeTest on iPad simulator device
+    meta:
+      bitrise.io:
+        stack: osx-xcode-12.4.x
   NewXcodeVersions:
     steps:
     - script@1:
@@ -1626,7 +1778,7 @@ trigger_map:
 - push_branch: v32.1
   workflow: xcode12-release-and-beta-nocache
 - pull_request_target_branch: main
-  workflow: RunUnitTests
+  workflow: RunSmokeXCUITestsiPad
 - pull_request_source_branch: '*'
   pull_request_target_branch: chronological-tabs
   workflow: RunUnitTests


### PR DESCRIPTION
Fixes #8156 
Let's add a workflow to run tests on iPad in addition to the scheduled build that runs the whole test suite. This way we could start small fixing the tests and this workflow can be scheduled more often to have a sanity check on iPad devices