### PR TITLE
Update L10n tests to run successfully on Bitrise

### DIFF
--- a/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -79,6 +79,9 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     }
 
     func testTopSitesMenu() {
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
+        app.buttons["urlBar-cancel"].tap()
+        waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: 5)
         navigator.goto(HomePanel_TopSites)
         navigator.goto(TopSitesPanelContextMenu)
         snapshot("TopSitesMenu-01")
@@ -117,8 +120,10 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     }*/
 
     func testETPperSite() {
-        // Enable Strict ETP
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
         app.buttons["urlBar-cancel"].tap()
+        waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: 5)
+        // Enable Strict ETP
         navigator.goto(TrackingProtectionSettings)
         // Check the warning alert
          app.cells["Settings.TrackingProtectionOption.BlockListStrict"].tap()
@@ -139,7 +144,9 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     }
 
     func testSettingsETP() {
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
         app.buttons["urlBar-cancel"].tap()
+        waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: 5)
         navigator.goto(TrackingProtectionSettings)
 
         waitForExistence(app.cells["Settings.TrackingProtectionOption.BlockListBasic"])

--- a/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -88,6 +88,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
         app.buttons["urlBar-cancel"].tap()
         navigator.nowAt(NewTabScreen)
+        waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: 5)
         navigator.goto(BrowserTabMenu)
         waitForExistence(app.tables.cells["menu-sync"], timeout: 5)
         navigator.goto(Intro_FxASignin)

--- a/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -13,7 +13,9 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
                 "LibraryPanels.Downloads",
                 "LibraryPanels.SyncedTabs"
             ]
+            waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
             app.buttons["urlBar-cancel"].tap()
+            waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: 5)
             navigator.goto(LibraryPanel_Bookmarks)
             snapshot("PanelsEmptyState-LibraryPanels.Bookmarks")
             libraryPanels.forEach { panel in

--- a/L10nSnapshotTests/L10nSuite3SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite3SnapshotTests.swift
@@ -13,7 +13,9 @@ class L10nSuite3SnapshotTests: L10nBaseSnapshotTests {
     }
 
     func testPasscodeSettings() {
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
         app.buttons["urlBar-cancel"].tap()
+        waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: 5)
         navigator.goto(PasscodeSettings)
         app.tables.cells["TurnOnPasscode"].tap()
         snapshot("SetPasscodeScreen-1-nopasscode")

--- a/L10nSnapshotTests/L10nSuite3SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite3SnapshotTests.swift
@@ -39,22 +39,27 @@ class L10nSuite3SnapshotTests: L10nBaseSnapshotTests {
     }
 
     func testDefaultTopSites() {
-        waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: 5)
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
         app.buttons["urlBar-cancel"].tap()
+        waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: 5)
         navigator.goto(HomePanelsScreen)
         snapshot("DefaultTopSites-01")
     }
 
     func testMenuOnTopSites() {
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
         app.buttons["urlBar-cancel"].tap()
-        navigator.goto(NewTabScreen)
+        waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: 5)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(BrowserTabMenu)
         snapshot("MenuOnTopSites-01")
     }
 
     func testSettings() {
         let table = app.tables.element(boundBy: 0)
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
         app.buttons["urlBar-cancel"].tap()
+        waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: 5)
         navigator.goto(SettingsScreen)
         table.forEachScreen { i in
             snapshot("Settings-main-\(i)")
@@ -69,7 +74,9 @@ class L10nSuite3SnapshotTests: L10nBaseSnapshotTests {
     }
 
     func testPrivateBrowsingTabsEmptyState() {
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
         app.buttons["urlBar-cancel"].tap()
+        waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: 5)
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         app.tables.cells.element(boundBy: 0).buttons["closeTabButtonTabTray"].tap()
         snapshot("PrivateBrowsingTabsEmptyState-01")

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1778,7 +1778,7 @@ trigger_map:
 - push_branch: v32.1
   workflow: xcode12-release-and-beta-nocache
 - pull_request_target_branch: main
-  workflow: RunUnitTests
+  workflow: L10nBuild
 - pull_request_source_branch: '*'
   pull_request_target_branch: chronological-tabs
   workflow: RunUnitTests

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1778,7 +1778,7 @@ trigger_map:
 - push_branch: v32.1
   workflow: xcode12-release-and-beta-nocache
 - pull_request_target_branch: main
-  workflow: L10nBuild
+  workflow: RunUnitTests
 - pull_request_source_branch: '*'
   pull_request_target_branch: chronological-tabs
   workflow: RunUnitTests


### PR DESCRIPTION
We just tried to trigger the L10n process to get a new set of screenshots but most of the locales failed due to timing issues with the cancel url bar open. Trying to fix that with this PR

