### PR TITLE
Bugfix #8234 Open Last Bookmark shortcut value

### DIFF
--- a/Client/Frontend/Library/BookmarksPanel.swift
+++ b/Client/Frontend/Library/BookmarksPanel.swift
@@ -239,6 +239,21 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
             return
         }
 
+        func removeShortcut() {
+            // Get most recent bookmark
+            profile.places.getRecentBookmarks(limit: 1).uponQueue(.main) { result in
+                guard let bookmarkItems = result.successValue else { return }
+                if bookmarkItems.count == 0 {
+                    // Remove the openLastBookmark shortcut
+                    QuickActions.sharedInstance.removeDynamicApplicationShortcutItemOfType(.openLastBookmark, fromApplication: .shared)
+                } else {
+                    // Update the last bookmark shortcut
+                    let userData = [QuickActions.TabURLKey: bookmarkItems[0].url, QuickActions.TabTitleKey: bookmarkItems[0].title]
+                    QuickActions.sharedInstance.addDynamicApplicationShortcutItemOfType(.openLastBookmark, withUserData: userData, toApplication: .shared)
+                }
+            }
+        }
+
         func doDelete() {
             // Perform the delete asynchronously even though we update the
             // table view data source immediately for responsiveness.
@@ -252,6 +267,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
             }
             tableView.deleteRows(at: [indexPath], with: .left)
             tableView.endUpdates()
+            removeShortcut()
         }
 
         // If this node is a folder and it is not empty, we need

--- a/Client/Frontend/Widgets/PhotonActionSheet/PageActionMenu.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PageActionMenu.swift
@@ -88,6 +88,18 @@ extension PhotonActionSheetProtocol {
             self.profile.places.deleteBookmarksWithURL(url: url.absoluteString).uponQueue(.main) { result in
                 if result.isSuccess {
                     success(Strings.AppMenuRemoveBookmarkConfirmMessage, .removeBookmark)
+                    // Get most recent bookmark
+                    self.profile.places.getRecentBookmarks(limit: 1).uponQueue(.main) { result in
+                        guard let bookmarkItems = result.successValue else { return }
+                        if bookmarkItems.count == 0 {
+                            // Remove the openLastBookmark shortcut
+                            QuickActions.sharedInstance.removeDynamicApplicationShortcutItemOfType(.openLastBookmark, fromApplication: .shared)
+                        } else {
+                            // Update the last bookmark shortcut
+                            let userData = [QuickActions.TabURLKey: bookmarkItems[0].url, QuickActions.TabTitleKey: bookmarkItems[0].title]
+                            QuickActions.sharedInstance.addDynamicApplicationShortcutItemOfType(.openLastBookmark, withUserData: userData, toApplication: .shared)
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
Issue #8234

This PR fixes the way the value of the "Open Last Bookmark" shortcut is defined.

When we delete a bookmark, if it was the last one, we remove the shortcut otherwise we update the value of the last bookmark shortcut with the value of the most `N - 1` recent one.

Here is the new  workflow:
<p align="center">
<img width="200" src="https://user-images.githubusercontent.com/32459935/114639334-d9b9e700-9ccd-11eb-822d-261010106095.gif">
</p>

NOTE: I would like to refactor my code to put the "update-remove shortcut bookmark" logic in one place and import it into `BookmarksPanel` and `PageActionMenu` but I don't know exactly where I can put it.