### PR TITLE
fix #8063 - Adds firefox-ios param to webcompat reporting url

### DIFF
--- a/Shared/SupportUtils.swift
+++ b/Shared/SupportUtils.swift
@@ -24,6 +24,6 @@ public struct SupportUtils {
         else {
             return nil
         }
-        return URL(string: "https://webcompat.com/issues/new?src=mobile-reporter&url=\(escapedUrl)")
+        return URL(string: "https://webcompat.com/issues/new?src=mobile-reporter&label=browser-firefox-ios&url=\(escapedUrl)")
     }
 }


### PR DESCRIPTION
The reporting URL for a better labeling by the webcompat.com server will need an extra parameter. 
