### PR TITLE
Fix #8392 - Adds missing iPhone UA string token 

### DIFF
--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -12,7 +12,7 @@ open class UserAgent {
     public static let product = "Mozilla/5.0"
     public static let platform = "AppleWebKit/605.1.15"
     public static let platformDetails = "(KHTML, like Gecko)"
-    
+
     // For iPad, we need to append this to the default UA for google.com to show correct page
     public static let uaBitGoogleIpad = "Version/13.0.3"
 
@@ -47,7 +47,7 @@ open class UserAgent {
     public static func isDesktop(ua: String) -> Bool {
         return ua.lowercased().contains("intel mac")
     }
-    
+
     public static func desktopUserAgent() -> String {
         return "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15"
     }
@@ -55,7 +55,7 @@ open class UserAgent {
     public static func mobileUserAgent() -> String {
         return UserAgentBuilder.defaultMobileUserAgent().userAgent()
     }
-  
+
     public static func oppositeUserAgent(domain: String) -> String {
         let isDefaultUADesktop = UserAgent.isDesktop(ua: UserAgent.getUserAgent(domain: domain))
         if isDefaultUADesktop {
@@ -64,7 +64,7 @@ open class UserAgent {
             return UserAgent.getUserAgent(domain: domain, platform: .Desktop)
         }
     }
-    
+
     public static func getUserAgent(domain: String, platform: UserAgentPlatform) -> String {
         switch platform {
         case .Desktop:
@@ -77,7 +77,7 @@ open class UserAgent {
             }
         }
     }
-    
+
     public static func getUserAgent(domain: String = "") -> String {
         // As of iOS 13 using a hidden webview method does not return the correct UA on
         // iPad (it returns mobile UA). We should consider that method no longer reliable.
@@ -110,7 +110,7 @@ public struct UserAgentBuilder {
     fileprivate var platform = ""
     fileprivate var platformDetails = ""
     fileprivate var extensions = ""
-    
+
     init(product: String, systemInfo: String, platform: String, platformDetails: String, extensions: String) {
         self.product = product
         self.systemInfo = systemInfo
@@ -118,26 +118,26 @@ public struct UserAgentBuilder {
         self.platformDetails = platformDetails
         self.extensions = extensions
     }
-    
+
     public func userAgent() -> String {
         let userAgentItems = [product, systemInfo, platform, platformDetails, extensions]
         return removeEmptyComponentsAndJoin(uaItems: userAgentItems)
     }
-    
+
     public func clone(product: String? = nil, systemInfo: String? = nil, platform: String? = nil, platformDetails: String? = nil, extensions: String? = nil) -> String {
         let userAgentItems = [product ?? self.product, systemInfo ?? self.systemInfo, platform ?? self.platform, platformDetails ?? self.platformDetails, extensions ?? self.extensions]
         return removeEmptyComponentsAndJoin(uaItems: userAgentItems)
     }
-    
+
     /// Helper method to remove the empty components from user agent string that contain only whitespaces or are just empty
     private func removeEmptyComponentsAndJoin(uaItems: [String]) -> String {
         return uaItems.filter{ !$0.isEmptyOrWhitespace() }.joined(separator: " ")
     }
-    
+
     public static func defaultMobileUserAgent() -> UserAgentBuilder {
         return UserAgentBuilder(product: UserAgent.product, systemInfo: "(\(UIDevice.current.model); CPU OS \(UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")) like Mac OS X)", platform: UserAgent.platform, platformDetails: UserAgent.platformDetails, extensions: "FxiOS/\(AppInfo.appVersion)  \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)")
     }
-    
+
     public static func defaultDesktopUserAgent() -> UserAgentBuilder {
         return UserAgentBuilder(product: UserAgent.product, systemInfo: "(Macintosh; Intel Mac OS X 10.15)", platform: UserAgent.platform, platformDetails: UserAgent.platformDetails, extensions: "FxiOS/\(AppInfo.appVersion) \(UserAgent.uaBitSafari)")
     }

--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -135,7 +135,7 @@ public struct UserAgentBuilder {
     }
 
     public static func defaultMobileUserAgent() -> UserAgentBuilder {
-        return UserAgentBuilder(product: UserAgent.product, systemInfo: "(\(UIDevice.current.model); CPU OS \(UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")) like Mac OS X)", platform: UserAgent.platform, platformDetails: UserAgent.platformDetails, extensions: "FxiOS/\(AppInfo.appVersion)  \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)")
+        return UserAgentBuilder(product: UserAgent.product, systemInfo: "(\(UIDevice.current.model); CPU iPhone OS \(UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")) like Mac OS X)", platform: UserAgent.platform, platformDetails: UserAgent.platformDetails, extensions: "FxiOS/\(AppInfo.appVersion)  \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)")
     }
 
     public static func defaultDesktopUserAgent() -> UserAgentBuilder {


### PR DESCRIPTION
Commit bf2545e
probably dropped by mistake the iPhone token from the UA string. This creates at least one Web Compatibility issue for Ebay checkout payment system.

This commit adds it again.


It also removes the extra tabs on the blank lines of the file.