### PR TITLE
FXIOS-1784: Changed background color of tab tray to Light Gray 30 and Dark theme screenshot to Dark Gray 40

### DIFF
--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -648,7 +648,7 @@ class TabCell: UICollectionViewCell {
         let view = UIView()
         view.layer.cornerRadius = GridTabTrayControllerUX.CornerRadius
         view.clipsToBounds = true
-        view.backgroundColor =  .blue// UIColor.theme.tabTray.cellBackground
+        view.backgroundColor = UIColor.theme.tabTray.cellBackground
         return view
     }()
 
@@ -659,7 +659,7 @@ class TabCell: UICollectionViewCell {
         view.isUserInteractionEnabled = false
         view.alignLeft = true
         view.alignTop = true
-        view.backgroundColor = UIColor.theme.browser.background
+        view.backgroundColor = UIColor.theme.tabTray.screenshotBackground
         return view
     }()
 

--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -56,7 +56,7 @@ fileprivate class DarkTabTrayColor: TabTrayColor {
     override var tabTitleText: UIColor { return defaultTextAndTint }
     override var tabTitleBlur: UIBlurEffect.Style { return UIBlurEffect.Style.dark }
     override var background: UIColor { return UIColor.Photon.Grey80 }
-    override var screenshotBackground: UIColor { return UIColor.Photon.LightGrey80 }
+    override var screenshotBackground: UIColor { return UIColor.Photon.DarkGrey40 }
     override var cellBackground: UIColor { return defaultBackground }
     override var toolbar: UIColor { return UIColor.Photon.Grey80 }
     override var toolbarButtonTint: UIColor { return defaultTextAndTint }

--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -56,6 +56,7 @@ fileprivate class DarkTabTrayColor: TabTrayColor {
     override var tabTitleText: UIColor { return defaultTextAndTint }
     override var tabTitleBlur: UIBlurEffect.Style { return UIBlurEffect.Style.dark }
     override var background: UIColor { return UIColor.Photon.Grey80 }
+    override var screenshotBackground: UIColor { return UIColor.Photon.LightGrey80 }
     override var cellBackground: UIColor { return defaultBackground }
     override var toolbar: UIColor { return UIColor.Photon.Grey80 }
     override var toolbarButtonTint: UIColor { return defaultTextAndTint }

--- a/Client/Frontend/Theme/Theme.swift
+++ b/Client/Frontend/Theme/Theme.swift
@@ -108,6 +108,7 @@ class TabTrayColor {
     var tabTitleText: UIColor { return UIColor.black }
     var tabTitleBlur: UIBlurEffect.Style { return UIBlurEffect.Style.extraLight }
     var background: UIColor { return UIColor.Photon.LightGrey30 }
+    var screenshotBackground: UIColor { return UIColor.Photon.Grey10 }
     var cellBackground: UIColor { return defaultBackground }
     var toolbar: UIColor { return defaultBackground }
     var toolbarButtonTint: UIColor { return defaultTextAndTint }

--- a/Client/Frontend/Theme/Theme.swift
+++ b/Client/Frontend/Theme/Theme.swift
@@ -107,7 +107,7 @@ class LoadingBarColor {
 class TabTrayColor {
     var tabTitleText: UIColor { return UIColor.black }
     var tabTitleBlur: UIBlurEffect.Style { return UIBlurEffect.Style.extraLight }
-    var background: UIColor { return UIColor.Photon.LightGrey10 }
+    var background: UIColor { return UIColor.Photon.LightGrey30 }
     var cellBackground: UIColor { return defaultBackground }
     var toolbar: UIColor { return defaultBackground }
     var toolbarButtonTint: UIColor { return defaultTextAndTint }


### PR DESCRIPTION
Changed background of Tab Tray to a LightGray30 previously it was LightGray10
Changed background of Dark Tab Tray screenshot to DarkGrey40


<table>
  <tr>
    <td> <img src="https://user-images.githubusercontent.com/8919439/117377786-0fec2000-aea2-11eb-9b92-32c5fe38ccce.png"  alt="1" width = 360px height = 640px ></td>
    <td> <img src="https://user-images.githubusercontent.com/8919439/117477329-e11a8c00-af2b-11eb-9b04-98a70e58b643.png" alt="2" width = 360px height = 640px></td>
  </tr>
</table>