### PR TITLE
Update library panel states (#8453)

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -419,6 +419,8 @@
 		C8399D9122DE5E5200EFA5CA /* disconnect-block-advertising.json in Resources */ = {isa = PBXBuildFile; fileRef = C8399D8F22DE5E5200EFA5CA /* disconnect-block-advertising.json */; };
 		C8399D9322DE5E5B00EFA5CA /* disconnect-block-analytics.json in Resources */ = {isa = PBXBuildFile; fileRef = C8399D9222DE5E5B00EFA5CA /* disconnect-block-analytics.json */; };
 		C8399D9522DE5E6200EFA5CA /* disconnect-block-social.json in Resources */ = {isa = PBXBuildFile; fileRef = C8399D9422DE5E6200EFA5CA /* disconnect-block-social.json */; };
+		C8445A14264428DC00B83F53 /* LibraryPanelViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8445A13264428DC00B83F53 /* LibraryPanelViewState.swift */; };
+		C8445AD126443C7F00B83F53 /* LibraryPanelViewStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8445AD026443C7F00B83F53 /* LibraryPanelViewStateTests.swift */; };
 		C8611C8E1F71904C00C3DE7D /* DiskImageStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BF8CBC1B7472FA0007AFE6 /* DiskImageStoreTests.swift */; };
 		C8611CB01F71AEBA00C3DE7D /* NoImageModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8611CA11F71AEB900C3DE7D /* NoImageModeTests.swift */; };
 		C86E4F712493BA8E0087BFD9 /* Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86E4F702493BA8E0087BFD9 /* Metrics.swift */; };
@@ -2977,6 +2979,8 @@
 		C8399D8F22DE5E5200EFA5CA /* disconnect-block-advertising.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "disconnect-block-advertising.json"; sourceTree = "<group>"; };
 		C8399D9222DE5E5B00EFA5CA /* disconnect-block-analytics.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "disconnect-block-analytics.json"; sourceTree = "<group>"; };
 		C8399D9422DE5E6200EFA5CA /* disconnect-block-social.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "disconnect-block-social.json"; sourceTree = "<group>"; };
+		C8445A13264428DC00B83F53 /* LibraryPanelViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryPanelViewState.swift; sourceTree = "<group>"; };
+		C8445AD026443C7F00B83F53 /* LibraryPanelViewStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryPanelViewStateTests.swift; sourceTree = "<group>"; };
 		C8464093BC0470D518B16C72 /* af */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		C8611CA11F71AEB900C3DE7D /* NoImageModeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoImageModeTests.swift; sourceTree = "<group>"; };
 		C86E4F702493BA8E0087BFD9 /* Metrics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Metrics.swift; sourceTree = "<group>"; };
@@ -4294,6 +4298,7 @@
 			children = (
 				F84B22221A09122500AAB793 /* LibraryViewController.swift */,
 				274A36CD239EB9EC00A21587 /* LibraryViewController+LibraryPanelDelegate.swift */,
+				C8445A13264428DC00B83F53 /* LibraryPanelViewState.swift */,
 			);
 			path = LibraryViewController;
 			sourceTree = "<group>";
@@ -5935,6 +5940,7 @@
 				DACDE995225E537900C8F37F /* VersionSettingTests.swift */,
 				D815A3A724A53F3200AAB221 /* TabToolbarHelperTests.swift */,
 				D525DFB225FBE5E000B18763 /* TabTests.swift */,
+				C8445AD026443C7F00B83F53 /* LibraryPanelViewStateTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -7881,6 +7887,7 @@
 				E65075571E37F714006961AC /* FaviconFetcher.swift in Sources */,
 				048B4C8024A53EEB001B56E8 /* ImageButtonWithLabel.swift in Sources */,
 				D863C8F21F68BFC20058D95F /* GradientProgressBar.swift in Sources */,
+				C8445A14264428DC00B83F53 /* LibraryPanelViewState.swift in Sources */,
 				D59431ED25E9912900F0BA82 /* WidgetIntents.intentdefinition in Sources */,
 				CAC458F1249429C20042561A /* LoginListSelectionHelper.swift in Sources */,
 				EB9A178E20E525DF00B12184 /* ThemeSettingsController.swift in Sources */,
@@ -7955,6 +7962,7 @@
 				E60D032A1D5118DB002FE3F6 /* SyncStatusResolverTests.swift in Sources */,
 				E683F0A61E92E0820035D990 /* MockableHistory.swift in Sources */,
 				D815A3A824A53F3200AAB221 /* TabToolbarHelperTests.swift in Sources */,
+				C8445AD126443C7F00B83F53 /* LibraryPanelViewStateTests.swift in Sources */,
 				A83E5B1E1C1DAAAA0026D912 /* UIPasteboardExtensions.swift in Sources */,
 				0BF42D4F1A7CD09600889E28 /* TestFavicons.swift in Sources */,
 				7BBFEE741BB405D900A305AA /* TabManagerTests.swift in Sources */,

--- a/Client/Frontend/Library/LibraryViewController/LibraryPanelViewState.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryPanelViewState.swift
@@ -36,17 +36,6 @@ enum LibraryPanelMainState: Equatable {
     }
 }
 
-/// This enum describes the different states the Bookmarks panel,
-/// in the Library Panel, can have. All other Library Panels do
-/// not have states associated with them, allowing this one
-/// state to be persisted.
-enum BookmarksPanelState {
-    case home
-    case inFolder
-    case inFolderEditMode
-    case bookmarkEditMode
-}
-
 enum LibraryPanelSubState {
     case mainView
     case inFolder

--- a/Client/Frontend/Library/LibraryViewController/LibraryPanelViewState.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryPanelViewState.swift
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/// Describes the main views of the Library Panel using an enum with
+/// an associated value as each main state may have different substates.
 enum LibraryPanelMainState: Equatable {
     case bookmarks(state: LibraryPanelSubState)
     case history(state: LibraryPanelSubState)
@@ -36,6 +38,8 @@ enum LibraryPanelMainState: Equatable {
     }
 }
 
+/// Describes the available substates for LibaryPanel states. These are universal
+/// and thus can be used on each particular panel to describe it's current state.
 enum LibraryPanelSubState {
     case mainView
     case inFolder
@@ -71,6 +75,10 @@ enum LibraryPanelSubState {
     }
 }
 
+/// The `LibraryPanelViewState` class is a state machine that will keep track of the
+/// current state of each panel of the Library Panel. The current state is accessed/updated
+/// through the `currentState` variable, which will ensure that specific substates for each
+/// are preserved.
 class LibraryPanelViewState {
     private var state: LibraryPanelMainState = .bookmarks(state: .mainView)
     var currentState: LibraryPanelMainState {

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -296,11 +296,11 @@ class LibraryViewController: UIViewController {
         case .bookmarks:
             panelState.currentState = .bookmarks(state: .mainView)
         case .downloads:
-            panelState.currentState = .downloads(state: .mainView)
+            panelState.currentState = .downloads
         case .history:
             panelState.currentState = .history(state: .mainView)
         case .readingList:
-            panelState.currentState = .readingList(state: .mainView)
+            panelState.currentState = .readingList
         default:
             return
         }

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -25,7 +25,7 @@ class LibraryViewController: UIViewController {
     // Delegate
     weak var delegate: LibraryPanelDelegate?
     // Variables
-    fileprivate var bookmarkPanelState: BookmarksPanelState = .home
+    fileprivate var panelState = LibraryPanelViewState()
     // Views
     fileprivate var controllerContainerView = UIView()
     fileprivate var titleContainerView = UIView()
@@ -75,25 +75,6 @@ class LibraryViewController: UIViewController {
         return button
     }()
 
-    @objc func panelChanged() {
-        switch librarySegmentControl.selectedSegmentIndex {
-        case 0:
-            selectedPanel = .bookmarks
-            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .libraryPanel, value: .bookmarksPanel)
-        case 1:
-            selectedPanel = .history
-            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .libraryPanel, value: .historyPanel)
-        case 2:
-            selectedPanel = .downloads
-            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .libraryPanel, value: .downloadsPanel)
-        case 3:
-            selectedPanel = .readingList
-            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .libraryPanel, value: .readingListPanel)
-        default:
-            return
-        }
-    }
-    
     init(profile: Profile) {
         self.profile = profile
 
@@ -106,6 +87,7 @@ class LibraryViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: - View setup & lifecycle
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         updateViewWithState()
@@ -114,7 +96,6 @@ class LibraryViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor =  UIColor.theme.homePanel.panelBackground
-        bookmarkPanelState = .home
         self.edgesForExtendedLayout = []
         view.addSubview(controllerContainerView)
         view.addSubview(librarySegmentControl)
@@ -185,6 +166,17 @@ class LibraryViewController: UIViewController {
         applyTheme()
     }
 
+    override var preferredStatusBarStyle: UIStatusBarStyle { return ThemeManager.instance.currentName == .dark ? .lightContent : .default
+    }
+
+    func updateViewWithState() {
+        updatePanelState()
+        topLeftButtonSetup()
+        topRightButtonSetup()
+    }
+
+
+    // MARK: - Panel
     var selectedPanel: LibraryPanelType? = nil {
         didSet {
             if oldValue == selectedPanel {
@@ -209,7 +201,8 @@ class LibraryViewController: UIViewController {
 
                 if index < panelDescriptors.count {
                     panelDescriptors[index].setup()
-                    if let panel = self.panelDescriptors[index].viewController, let navigationController = self.panelDescriptors[index].navigationController {
+                    if let panel = self.panelDescriptors[index].viewController,
+                       let navigationController = self.panelDescriptors[index].navigationController {
                         let accessibilityLabel = self.panelDescriptors[index].accessibilityLabel
                         setupLibraryPanel(panel, accessibilityLabel: accessibilityLabel)
                         self.showPanel(navigationController)
@@ -221,110 +214,6 @@ class LibraryViewController: UIViewController {
         }
     }
 
-    func updateViewWithState() {
-        updateBookmarkPanelState()
-        topLeftButtonSetup()
-        topRightButtonSetup()
-    }
-
-    func updateBookmarkPanelState() {
-        if librarySegmentControl.selectedSegmentIndex == 0 {
-            if let panel = children.first as? UINavigationController,
-               panel.viewControllers.count > 1 {
-                if bookmarkPanelState == .home {
-                    bookmarkPanelState = .inFolder
-                } else if bookmarkPanelState == .inFolderEditMode,
-                     let _ = panel.viewControllers.last as? BookmarkDetailPanel {
-                    bookmarkPanelState = .bookmarkEditMode
-                }
-            } else {
-                bookmarkPanelState = .home
-            }
-        }
-        children.first?.navigationController?.toolbar.backgroundColor = .red
-    }
-
-    func topLeftButtonSetup() {
-        switch bookmarkPanelState {
-        case .home:
-            topLeftButton.isHidden = true
-        case .inFolder:
-            topLeftButton.isHidden = false
-            topLeftButton.setTitle(Strings.BackTitle, for: .normal)
-            topLeftButton.setImage(nil, for: .normal)
-        case .inFolderEditMode:
-            topLeftButton.isHidden = false
-            topLeftButton.setTitle("", for: .normal)
-            let img = UIImage.templateImageNamed("nav-add")
-            topLeftButton.setImage(img, for: .normal)
-        case .bookmarkEditMode:
-            topLeftButton.isHidden = false
-            topLeftButton.setTitle(Strings.CancelString, for: .normal)
-            topLeftButton.setImage(nil, for: .normal)
-        }
-    }
-
-    func topRightButtonSetup() {
-        switch bookmarkPanelState {
-        case .home:
-            topRightButton.setTitle(String.AppSettingsDone, for: .normal)
-        case .inFolder:
-            topRightButton.setTitle(Strings.BookmarksEdit, for: .normal)
-        case .inFolderEditMode:
-            topRightButton.setTitle(String.AppSettingsDone, for: .normal)
-        case .bookmarkEditMode:
-            topRightButton.setTitle(Strings.SettingsAddCustomEngineSaveButtonText, for: .normal)
-        }
-    }
-
-    @objc func topLeftButtonAction() {
-        guard let panel = children.first as? UINavigationController else { return }
-        switch bookmarkPanelState {
-        case .home:
-            return
-        case .inFolder:
-            if panel.viewControllers.count > 1 {
-                bookmarkPanelState = .home
-                panel.popViewController(animated: true)
-            }
-        case .inFolderEditMode:
-            guard let bookmarksPanel = panel.viewControllers.last as? BookmarksPanel else { return }
-            bookmarksPanel.addNewBookmarkItemAction()
-        case .bookmarkEditMode:
-            bookmarkPanelState = .inFolderEditMode
-            panel.popViewController(animated: true)
-        }
-        updateViewWithState()
-    }
-
-    @objc func topRightButtonAction() {
-        guard let panel = children.first as? UINavigationController else { return }
-
-        switch bookmarkPanelState {
-        case .home:
-            self.dismiss(animated: true, completion: nil)
-        case .inFolder:
-            guard let bookmarksPanel = panel.viewControllers.last as? BookmarksPanel else { return }
-            bookmarkPanelState = .inFolderEditMode
-            bookmarksPanel.enableEditMode()
-        case .inFolderEditMode:
-            guard let bookmarksPanel = panel.viewControllers.last as? BookmarksPanel else { return }
-            bookmarkPanelState = .inFolder
-            bookmarksPanel.disableEditMode()
-        case .bookmarkEditMode:
-            guard let bookmarkEditView = panel.viewControllers.last as? BookmarkDetailPanel else { return }
-            bookmarkEditView.save().uponQueue(.main) { _ in
-                self.bookmarkPanelState = .inFolderEditMode
-                panel.popViewController(animated: true)
-                if bookmarkEditView.isNew,
-                   let bookmarksPanel = panel.navigationController?.visibleViewController as? BookmarksPanel {
-                    bookmarksPanel.didAddBookmarkNode()
-                }
-            }
-        }
-        updateViewWithState()
-    }
-    
     func setupLibraryPanel(_ panel: UIViewController, accessibilityLabel: String) {
         (panel as? LibraryPanel)?.libraryPanelDelegate = self
         panel.view.accessibilityNavigationStyle = .combined
@@ -334,8 +223,23 @@ class LibraryViewController: UIViewController {
         panel.navigationController?.isNavigationBarHidden = true
     }
 
-    override var preferredStatusBarStyle: UIStatusBarStyle {
-        return ThemeManager.instance.currentName == .dark ? .lightContent : .default
+    @objc func panelChanged() {
+        switch librarySegmentControl.selectedSegmentIndex {
+        case 0:
+            selectedPanel = .bookmarks
+            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .libraryPanel, value: .bookmarksPanel)
+        case 1:
+            selectedPanel = .history
+            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .libraryPanel, value: .historyPanel)
+        case 2:
+            selectedPanel = .downloads
+            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .libraryPanel, value: .downloadsPanel)
+        case 3:
+            selectedPanel = .readingList
+            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .libraryPanel, value: .readingListPanel)
+        default:
+            return
+        }
     }
 
     fileprivate func hideCurrentPanel() {
@@ -349,6 +253,7 @@ class LibraryViewController: UIViewController {
     }
 
     fileprivate func showPanel(_ libraryPanel: UIViewController) {
+        updateStateOnShowPanel(to: selectedPanel)
         addChild(libraryPanel)
         libraryPanel.beginAppearanceTransition(true, animated: false)
         controllerContainerView.addSubview(libraryPanel.view)
@@ -357,6 +262,160 @@ class LibraryViewController: UIViewController {
             make.edges.equalToSuperview()
         }
         libraryPanel.didMove(toParent: self)
+    }
+
+    fileprivate func updatePanelState() {
+        guard let panel = children.first as? UINavigationController else { return }
+
+        if selectedPanel == .bookmarks {
+            if panel.viewControllers.count > 1 {
+                if panelState.currentState == .bookmarks(state: .mainView) {
+                    panelState.currentState = .bookmarks(state: .inFolder)
+                } else if panelState.currentState == .bookmarks(state: .inFolderEditMode),
+                     let _ = panel.viewControllers.last as? BookmarkDetailPanel {
+                    panelState.currentState = .bookmarks(state: .itemEditMode)
+                }
+            } else {
+                panelState.currentState = .bookmarks(state: .mainView)
+            }
+
+        } else if selectedPanel == .history {
+            if panel.viewControllers.count > 1 {
+                if panelState.currentState == .history(state: .mainView) {
+                    panelState.currentState = .history(state: .inFolder)
+                }
+            } else {
+                panelState.currentState = .history(state: .mainView)
+            }
+        }
+        children.first?.navigationController?.toolbar.backgroundColor = .red
+    }
+
+    fileprivate func updateStateOnShowPanel(to panelType: LibraryPanelType?) {
+        switch panelType {
+        case .bookmarks:
+            panelState.currentState = .bookmarks(state: .mainView)
+        case .downloads:
+            panelState.currentState = .downloads(state: .mainView)
+        case .history:
+            panelState.currentState = .history(state: .mainView)
+        case .readingList:
+            panelState.currentState = .readingList(state: .mainView)
+        default:
+            return
+        }
+    }
+
+    // MARK: - Buttons
+    fileprivate func topLeftButtonSetup() {
+        switch panelState.currentState {
+        case .bookmarks(state: .inFolder),
+             .history(state: .inFolder):
+            topLeftButton.isHidden = false
+            topLeftButton.setTitle(Strings.BackTitle, for: .normal)
+            topLeftButton.setImage(nil, for: .normal)
+        case .bookmarks(state: .inFolderEditMode):
+            topLeftButton.isHidden = false
+            topLeftButton.setTitle("", for: .normal)
+            let img = UIImage.templateImageNamed("nav-add")
+            topLeftButton.setImage(img, for: .normal)
+        case .bookmarks(state: .itemEditMode):
+            topLeftButton.isHidden = false
+            topLeftButton.setTitle(Strings.CancelString, for: .normal)
+            topLeftButton.setImage(nil, for: .normal)
+        default:
+            topLeftButton.isHidden = true
+        }
+    }
+
+    fileprivate func topRightButtonSetup() {
+        switch panelState.currentState {
+        case .bookmarks(state: .inFolder):
+            topRightButton.setTitle(Strings.BookmarksEdit, for: .normal)
+        case .bookmarks(state: .inFolderEditMode):
+            topRightButton.setTitle(String.AppSettingsDone, for: .normal)
+        case .bookmarks(state: .itemEditMode):
+            topRightButton.setTitle(Strings.SettingsAddCustomEngineSaveButtonText, for: .normal)
+        default:
+            topRightButton.setTitle(String.AppSettingsDone, for: .normal)
+        }
+    }
+
+    // MARK: - Left Button Actions
+    @objc func topLeftButtonAction() {
+        guard let panel = children.first as? UINavigationController else { return }
+
+        switch panelState.currentState {
+        case .bookmarks(state: let state):
+            leftButtonBookmarkActions(for: state, onPanel: panel)
+        case .history(state: .inFolder):
+            panel.popViewController(animated: true)
+        default:
+            return
+        }
+        updateViewWithState()
+    }
+
+    fileprivate func leftButtonBookmarkActions(for state: LibraryPanelSubState, onPanel panel: UINavigationController) {
+
+        switch state {
+        case .mainView:
+            return
+
+        case .inFolder:
+            if panel.viewControllers.count > 1 {
+                panelState.currentState = .bookmarks(state: .mainView)
+                panel.popViewController(animated: true)
+            }
+
+        case .inFolderEditMode:
+            guard let bookmarksPanel = panel.viewControllers.last as? BookmarksPanel else { return }
+            bookmarksPanel.addNewBookmarkItemAction()
+
+        case .itemEditMode:
+            panelState.currentState = .bookmarks(state: .inFolderEditMode)
+            panel.popViewController(animated: true)
+        }
+    }
+
+    // MARK: - Right Button Actions
+    @objc func topRightButtonAction() {
+        switch panelState.currentState {
+        case .bookmarks(state: let state):
+            rightButtonBookmarkActions(for: state)
+        default:
+            self.dismiss(animated: true, completion: nil)
+        }
+        updateViewWithState()
+    }
+
+    fileprivate func rightButtonBookmarkActions(for state: LibraryPanelSubState) {
+        guard let panel = children.first as? UINavigationController else { return }
+        switch state {
+        case .mainView:
+            self.dismiss(animated: true, completion: nil)
+
+        case .inFolder:
+            guard let bookmarksPanel = panel.viewControllers.last as? BookmarksPanel else { return }
+            panelState.currentState = .bookmarks(state: .inFolderEditMode)
+            bookmarksPanel.enableEditMode()
+
+        case .inFolderEditMode:
+            guard let bookmarksPanel = panel.viewControllers.last as? BookmarksPanel else { return }
+            panelState.currentState = .bookmarks(state: .inFolder)
+            bookmarksPanel.disableEditMode()
+
+        case .itemEditMode:
+            guard let bookmarkEditView = panel.viewControllers.last as? BookmarkDetailPanel else { return }
+            bookmarkEditView.save().uponQueue(.main) { _ in
+                self.panelState.currentState = .bookmarks(state: .inFolderEditMode)
+                panel.popViewController(animated: true)
+                if bookmarkEditView.isNew,
+                   let bookmarksPanel = panel.navigationController?.visibleViewController as? BookmarksPanel {
+                    bookmarksPanel.didAddBookmarkNode()
+                }
+            }
+        }
     }
 }
 

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -18,17 +18,6 @@ extension LibraryViewController: UIToolbarDelegate {
     }
 }
 
-/// This enum describes the different states the Bookmarks panel,
-/// in the Library Panel, can have. All other Library Panels do
-/// not have states associated with them, allowing this one
-/// state to be persisted.
-enum BookmarksPanelState {
-    case home
-    case inFolder
-    case inFolderEditMode
-    case bookmarkEditMode
-}
-
 class LibraryViewController: UIViewController {
 
     let profile: Profile
@@ -72,6 +61,7 @@ class LibraryViewController: UIViewController {
         button.setTitle(Strings.BackTitle, for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: .regular)
         button.setTitleColor(UIColor.systemBlue, for: .normal)
+        button.titleLabel?.textAlignment = .left
         button.addTarget(self, action: #selector(topLeftButtonAction), for: .touchUpInside)
         return button
     }()
@@ -154,7 +144,7 @@ class LibraryViewController: UIViewController {
         topLeftButton.snp.makeConstraints { make in
             make.leading.equalTo(titleContainerView).offset(20)
             make.centerY.equalTo(titleContainerView)
-            make.width.equalTo(60)
+            make.width.equalTo(80)
             make.height.equalTo(30)
         }
         

--- a/ClientTests/LibraryPanelViewStateTests.swift
+++ b/ClientTests/LibraryPanelViewStateTests.swift
@@ -1,0 +1,165 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import XCTest
+@testable import Client
+
+class LibraryPanelViewStateTests: XCTestCase {
+    var panelState: LibraryPanelViewState?
+
+    override func setUp() {
+        panelState = LibraryPanelViewState()
+    }
+
+    override func tearDown() {
+        panelState = nil
+    }
+
+    //MARK: - Single panel interaction tests
+    func testStateMachineInitializesWithProperState() {
+        let actualState = panelState?.currentState
+        let expectedState: LibraryPanelMainState = .bookmarks(state: .mainView)
+
+        XCTAssertEqual(actualState, expectedState, "The library panel view is not initializing correctly.")
+    }
+
+    func testStateChangingToSameState() {
+        panelState?.currentState = .bookmarks(state: .mainView)
+
+        let actualState = panelState?.currentState
+        let expectedState: LibraryPanelMainState = .bookmarks(state: .mainView)
+
+        XCTAssertEqual(actualState, expectedState, "The library panel view changing from one state to the same state is not working!")
+    }
+
+    func testStateOnBookmarkPanelGoesIntoFolderState() {
+        panelState?.currentState = .bookmarks(state: .inFolder)
+
+        let actualState = panelState?.currentState
+        let expectedState: LibraryPanelMainState = .bookmarks(state: .inFolder)
+
+        XCTAssertEqual(actualState, expectedState, "The library panel view did not correctly enter the .inFolder state for bookmarks")
+    }
+
+    func testStateOnBookmarkPanelGoesIntoEditFolderState() {
+        panelState?.currentState = .bookmarks(state: .inFolder)
+        panelState?.currentState = .bookmarks(state: .inFolderEditMode)
+
+        let actualState = panelState?.currentState
+        let expectedState: LibraryPanelMainState = .bookmarks(state: .inFolderEditMode)
+
+        XCTAssertEqual(actualState, expectedState, "The library panel view did not correctly enter the .inFolderEditMode state for bookmarks")
+    }
+
+    func testStateOnBookmarkPanelGoesIntoItemEditState() {
+        panelState?.currentState = .bookmarks(state: .inFolder)
+        panelState?.currentState = .bookmarks(state: .inFolderEditMode)
+        panelState?.currentState = .bookmarks(state: .itemEditMode)
+
+        let actualState = panelState?.currentState
+        let expectedState: LibraryPanelMainState = .bookmarks(state: .itemEditMode)
+
+        XCTAssertEqual(actualState, expectedState, "The library panel view did not correctly enter the .inFolderEditMode state for bookmarks")
+    }
+
+    func testStateOnBookmarkPanelGoesBackToFolderEditModeFromItemEditState() {
+        panelState?.currentState = .bookmarks(state: .inFolder)
+        panelState?.currentState = .bookmarks(state: .inFolderEditMode)
+        panelState?.currentState = .bookmarks(state: .itemEditMode)
+        panelState?.currentState = .bookmarks(state: .inFolderEditMode)
+
+        let actualState = panelState?.currentState
+        let expectedState: LibraryPanelMainState = .bookmarks(state: .inFolderEditMode)
+
+        XCTAssertEqual(actualState, expectedState, "The library panel view did not correctly enter the .inFolderEditMode state for bookmarks from the .itemEditMode state")
+    }
+
+    func testStateOnBookmarkPanelFollowStateProgressionMovingIntoStates() {
+        panelState?.currentState = .bookmarks(state: .inFolderEditMode)
+        var actualState = panelState?.currentState
+        var wrongState: LibraryPanelMainState = .bookmarks(state: .inFolderEditMode)
+        let expectedState: LibraryPanelMainState = .bookmarks(state: .mainView)
+        XCTAssertEqual(actualState, expectedState, "The library panel view did not correctly enter the .inFolderEditMode state for bookmarks")
+        XCTAssertNotEqual(actualState, wrongState, "Attempting to move to the wrong state did not fail!")
+
+        panelState?.currentState = .bookmarks(state: .itemEditMode)
+        actualState = panelState?.currentState
+        wrongState = .bookmarks(state: .itemEditMode)
+        XCTAssertEqual(actualState, expectedState, "The library panel view did not correctly enter the .inFolderEditMode state for bookmarks")
+        XCTAssertNotEqual(actualState, wrongState, "Attempting to move to the wrong state did not fail!")
+    }
+
+    func testStateOnBookmarkPanelFollowsStateProgressionMovingOutOfStates() {
+        // Go to last state
+        panelState?.currentState = .bookmarks(state: .inFolder)
+        panelState?.currentState = .bookmarks(state: .inFolderEditMode)
+        panelState?.currentState = .bookmarks(state: .itemEditMode)
+
+        // attempt to climb backwards
+        panelState?.currentState = .bookmarks(state: .inFolder)
+        var actualState = panelState?.currentState
+        var wrongState: LibraryPanelMainState = .bookmarks(state: .inFolder)
+        let expectedState: LibraryPanelMainState = .bookmarks(state: .itemEditMode)
+
+        XCTAssertEqual(actualState, expectedState, "The library panel view did not correctly enter the .inFolderEditMode state for bookmarks")
+        XCTAssertNotEqual(actualState, wrongState, "Attempting to move to the wrong state did not fail!")
+
+        panelState?.currentState = .bookmarks(state: .mainView)
+        actualState = panelState?.currentState
+        wrongState = .bookmarks(state: .mainView)
+        XCTAssertEqual(actualState, expectedState, "The library panel view did not correctly enter the .inFolderEditMode state for bookmarks")
+        XCTAssertNotEqual(actualState, wrongState, "Attempting to move to the wrong state did not fail!")
+    }
+
+    // MARK: - Multi-panel tests
+    func testStateForBookmarkMainViewToOtherPanelMainView() {
+        panelState?.currentState = .history(state: .mainView)
+
+        let actualState = panelState?.currentState
+        let expectedState: LibraryPanelMainState = .history(state: .mainView)
+
+        XCTAssertEqual(actualState, expectedState, "The library panel view did not correctly enter the .history(.mainView) state for the History Panel")
+    }
+
+    func testStateForBookmarkMainViewToOtherPanelMainViewAndBack() {
+        panelState?.currentState = .history(state: .mainView)
+        panelState?.currentState = .bookmarks(state: .mainView)
+
+        let actualState = panelState?.currentState
+        let expectedState: LibraryPanelMainState = .bookmarks(state: .mainView)
+
+        XCTAssertEqual(actualState, expectedState, "The library panel view did not correctly return to the .bookmarks(.mainView) state")
+    }
+
+    func testBookmarkViewInFolderModeSwitchingToOtherPanelAndReturningToCorrectBookmarksState() {
+        panelState?.currentState = .bookmarks(state: .inFolder)
+        panelState?.currentState = .history(state: .mainView)
+        panelState?.currentState = .bookmarks(state: .mainView)
+
+        let actualState = panelState?.currentState
+        let expectedState: LibraryPanelMainState = .bookmarks(state: .inFolder)
+
+        XCTAssertEqual(actualState, expectedState, "The library panel view did not correctly return to the .bookmarks(.inFolder) state")
+    }
+
+    func testChangingDifferentPanelsAndSavingStates() {
+        panelState?.currentState = .bookmarks(state: .inFolder)
+        panelState?.currentState = .bookmarks(state: .inFolderEditMode)
+        panelState?.currentState = .history(state: .mainView)
+        panelState?.currentState = .history(state: .inFolder)
+        panelState?.currentState = .downloads(state: .mainView)
+        panelState?.currentState = .bookmarks(state: .mainView)
+
+        var actualState = panelState?.currentState
+        var expectedState: LibraryPanelMainState = .bookmarks(state: .inFolderEditMode)
+
+        XCTAssertEqual(actualState, expectedState, "The library panel view did not correctly return to the .bookmarks(.inFolderEditMode) state")
+
+        panelState?.currentState = .history(state: .mainView)
+        actualState = panelState?.currentState
+        expectedState = .history(state: .inFolder)
+
+        XCTAssertEqual(actualState, expectedState, "The library panel view did not correctly return to the .history(.inFolder) state")
+    }
+}

--- a/ClientTests/LibraryPanelViewStateTests.swift
+++ b/ClientTests/LibraryPanelViewStateTests.swift
@@ -148,7 +148,7 @@ class LibraryPanelViewStateTests: XCTestCase {
         panelState?.currentState = .bookmarks(state: .inFolderEditMode)
         panelState?.currentState = .history(state: .mainView)
         panelState?.currentState = .history(state: .inFolder)
-        panelState?.currentState = .downloads(state: .mainView)
+        panelState?.currentState = .downloads
         panelState?.currentState = .bookmarks(state: .mainView)
 
         var actualState = panelState?.currentState


### PR DESCRIPTION
This PR addresses the state where library panel states were overwriting each other. Here, I've updated the state machine to be more sophisticated (with requisite tests to make sure it behaves how we expect). Then, I've updated the `LibraryViewController` to use this new implementation. I've also refactored it slightly, for better organization.

This PR will not be addressing #8447 as we'd anticipated, as design's answer for that is more complex that what we had intended.