### PR TITLE
8455 FXIOS-1794 ⁃ Separator line is displayed in download file prompt

### DIFF
--- a/Client/Frontend/Browser/OpenInHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper.swift
@@ -118,7 +118,7 @@ class DownloadHelper: NSObject {
 
         let actions = [[filenameItem], [downloadFileItem]]
 
-        browserViewController.presentSheetWith(actions: actions, on: browserViewController, from: browserViewController.urlBar, closeButtonTitle: Strings.CancelString, suppressPopover: true)
+        browserViewController.presentSheetWith(title: download.filename, actions: actions, on: browserViewController, from: browserViewController.urlBar, closeButtonTitle: Strings.CancelString, suppressPopover: true)
     }
 }
 


### PR DESCRIPTION
I added the title of the file at the top so that the divider lines would be in the right place. It's a quick fix but I think we will be redesigning this dialog soon so it should it be fine for now.
![Simulator Screen Shot - iPhone 11 - 2021-05-11 at 11 28 58](https://user-images.githubusercontent.com/11432165/117842605-1a187080-b24c-11eb-910e-c545df4147cd.png)
