### PR TITLE
(#8488) Fix TabTray not getting set to nil when not dismissed from a home page

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -822,6 +822,7 @@ class BrowserViewController: UIViewController {
                             if shouldEnterOverlay {
                                 self?.urlBar.enterOverlayMode(nil, pasted: false, search: false)
                             }
+                            self?.tabTrayViewController = nil
                         }
                     }
                 }
@@ -829,6 +830,7 @@ class BrowserViewController: UIViewController {
             } else if !url.absoluteString.hasPrefix("\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)") {
                 hideFirefoxHome()
                 urlBar.locationView.reloadButton.reloadButtonState = .disabled
+                tabTrayViewController = nil
             }
             
         } else if isAboutHomeURL {

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -142,7 +142,9 @@ open class TabToolbarHelper: NSObject {
     }
 
     func didLongPressTabs(_ recognizer: UILongPressGestureRecognizer) {
-        toolbar.tabToolbarDelegate?.tabToolbarDidLongPressTabs(toolbar, button: toolbar.tabsButton)
+        if recognizer.state == .began {
+            toolbar.tabToolbarDelegate?.tabToolbarDidLongPressTabs(toolbar, button: toolbar.tabsButton)
+        }
     }
 
     func didClickForward() {


### PR DESCRIPTION
This fixes the attentive mode issue with long pressing on the tab icon, and with the TabTray not getting set to nil.