### PR TITLE
#8447 Update left button on library panel to use images

### DIFF
--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -125,7 +125,7 @@ class LibraryViewController: UIViewController {
         topLeftButton.snp.makeConstraints { make in
             make.leading.equalTo(titleContainerView).offset(20)
             make.centerY.equalTo(titleContainerView)
-            make.width.equalTo(80)
+            make.width.equalTo(30)
             make.height.equalTo(30)
         }
         
@@ -308,21 +308,20 @@ class LibraryViewController: UIViewController {
 
     // MARK: - Buttons
     fileprivate func topLeftButtonSetup() {
+        topLeftButton.setTitle("", for: .normal)
         switch panelState.currentState {
         case .bookmarks(state: .inFolder),
              .history(state: .inFolder):
             topLeftButton.isHidden = false
-            topLeftButton.setTitle(Strings.BackTitle, for: .normal)
-            topLeftButton.setImage(nil, for: .normal)
+            let img = UIImage.templateImageNamed("nav-back")
+            topLeftButton.setImage(img, for: .normal)
         case .bookmarks(state: .inFolderEditMode):
             topLeftButton.isHidden = false
-            topLeftButton.setTitle("", for: .normal)
             let img = UIImage.templateImageNamed("nav-add")
             topLeftButton.setImage(img, for: .normal)
         case .bookmarks(state: .itemEditMode):
-            topLeftButton.isHidden = false
-            topLeftButton.setTitle(Strings.CancelString, for: .normal)
-            topLeftButton.setImage(nil, for: .normal)
+            let img = UIImage.templateImageNamed("nav-stop")
+            topLeftButton.setImage(img, for: .normal)
         default:
             topLeftButton.isHidden = true
         }

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -313,7 +313,7 @@ class LibraryViewController: UIViewController {
         case .bookmarks(state: .inFolder),
              .history(state: .inFolder):
             topLeftButton.isHidden = false
-            let img = UIImage.templateImageNamed("nav-back")
+            let img = UIImage.templateImageNamed("goBack")
             topLeftButton.setImage(img, for: .normal)
         case .bookmarks(state: .inFolderEditMode):
             topLeftButton.isHidden = false


### PR DESCRIPTION
Updates buttons on library panel to use images instead of text, thereby fixing the localization issue for now.