### PR TITLE
Fix #8434 Hamburger menu position is incorrect after locking and unlocking the device

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -332,6 +332,9 @@ class BrowserViewController: UIViewController {
             self.updateDisplayedPopoverProperties = nil
             self.displayedPopoverController = nil
         }
+        if let _ = self.presentedViewController as? PhotonActionSheet {
+            self.presentedViewController?.dismiss(animated: true, completion: nil)
+        }
     }
 
     @objc func tappedTopArea() {


### PR DESCRIPTION
I decided to hide all popover menus when the app is backgrounded to solve this