### PR TITLE
Fixes #8518 - [accessibility] - Instant Search text breaks off for larger fonts

### DIFF
--- a/Client/Frontend/Widgets/OneLineCellAndFooter.swift
+++ b/Client/Frontend/Widgets/OneLineCellAndFooter.swift
@@ -85,7 +85,7 @@ class OneLineTableViewCell: UITableViewCell, Themeable {
         }
         
         titleLabel.snp.makeConstraints { make in
-            make.height.equalTo(20)
+            make.height.equalTo(40)
             make.centerY.equalTo(midView.snp.centerY)
             make.leading.equalTo(midView.snp.leading)
             make.trailing.equalTo(midView.snp.trailing)


### PR DESCRIPTION

https://user-images.githubusercontent.com/8919439/118538233-e9d54400-b71b-11eb-98d5-ef7435b09f38.mov

