### PR TITLE
Fixes separator and accessibility items for photon actionsheet

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -83,7 +83,7 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
         view.accessibilityIdentifier = "Action Sheet"
 
         tableView.backgroundColor = .clear
-
+        tableView.addObserver(self, forKeyPath: "contentSize", options: .new, context: nil)
         // In a popover the popover provides the blur background
         // Not using a background color allows the view to style correctly with the popover arrow
         if self.popoverPresentationController == nil {
@@ -164,6 +164,11 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
         }
     }
 
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        tableView.removeObserver(self, forKeyPath: "contentSize")
+    }
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
@@ -200,6 +205,12 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
         }
     }
 
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        if style == .popover {
+            self.preferredContentSize = tableView.contentSize
+        }
+    }
+    
     // Nested tableview rows get additional height
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         if let section = actions[safe: indexPath.section], let action = section[safe: indexPath.row] {
@@ -220,9 +231,6 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
             heightConstraint?.deactivate()
             // The height of the menu should be no more than 85 percent of the screen
             heightConstraint = make.height.equalTo(min(self.tableView.contentSize.height, maxHeight * 0.90)).constraint
-        }
-        if style == .popover {
-            self.preferredContentSize = self.tableView.contentSize
         }
     }
 

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -307,9 +307,7 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
         
         // For menus other than ETP, don't show top and bottom separator lines
         if (title == nil) {
-            if (indexPath != [tableView.numberOfSections - 1, tableView.numberOfRows(inSection: tableView.numberOfSections - 1) - 1]) {
-                cell.addSubBorder()
-            }
+            cell.bottomBorder.isHidden = !(indexPath != [tableView.numberOfSections - 1, tableView.numberOfRows(inSection: tableView.numberOfSections - 1) - 1])
         }
         return cell
     }

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
@@ -23,6 +23,7 @@ private struct PhotonActionSheetCellUX {
 class PhotonActionSheetCell: UITableViewCell {
     static let Padding: CGFloat = 16
     static let HorizontalPadding: CGFloat = 1
+    static let topBottomPadding: CGFloat = 10
     static let VerticalPadding: CGFloat = 2
     static let IconSize = 16
 
@@ -163,7 +164,7 @@ class PhotonActionSheetCell: UITableViewCell {
         }
 
         let padding = PhotonActionSheetCell.Padding
-        let topPadding = PhotonActionSheetCell.HorizontalPadding
+        let topPadding = PhotonActionSheetCell.topBottomPadding
         stackView.snp.makeConstraints { make in
             make.edges.equalTo(contentView).inset(UIEdgeInsets(top: topPadding, left: padding, bottom: topPadding, right: padding))
         }
@@ -273,10 +274,8 @@ class PhotonActionSheetCell: UITableViewCell {
         case .Switch:
             toggleSwitch.setOn(action.isEnabled)
             stackView.addArrangedSubview(toggleSwitch.mainView)
-        case .None:
-            titleLabel.snp.makeConstraints { make in
-                make.top.bottom.equalTo(contentView).inset(10)
-            }
+        default:
+            break // Do nothing. The rest are not supported yet.
         }
         action.customRender?(titleLabel, contentView)
     }

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
@@ -200,7 +200,7 @@ class PhotonActionSheetCell: UITableViewCell {
         subtitleLabel.textColor = UIColor.theme.tableView.rowText
         subtitleLabel.isHidden = action.text == nil
         subtitleLabel.numberOfLines = 0
-        titleLabel.font = action.bold ? DynamicFontHelper.defaultHelper.DeviceFontLargeBold : DynamicFontHelper.defaultHelper.SmallSizeRegularWeightAS
+        titleLabel.font = action.bold ? DynamicFontHelper.defaultHelper.DeviceFontLargeBold : DynamicFontHelper.defaultHelper.SemiMediumRegularWeightAS
         
         accessibilityIdentifier = action.iconString ?? action.accessibilityId
         accessibilityLabel = action.title

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
@@ -201,7 +201,6 @@ class PhotonActionSheetCell: UITableViewCell {
         subtitleLabel.isHidden = action.text == nil
         subtitleLabel.numberOfLines = 0
         titleLabel.font = action.bold ? DynamicFontHelper.defaultHelper.DeviceFontLargeBold : DynamicFontHelper.defaultHelper.SemiMediumRegularWeightAS
-        
         accessibilityIdentifier = action.iconString ?? action.accessibilityId
         accessibilityLabel = action.title
         selectionStyle = action.tapHandler != nil ? .default : .none

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
@@ -175,7 +175,6 @@ class PhotonActionSheetCell: UITableViewCell {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
     func addSubBorder() {
         bottomBorder.backgroundColor = UIColor.theme.tableView.separator
         self.contentView.addSubview(bottomBorder)

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
@@ -123,6 +123,8 @@ class PhotonActionSheetCell: UITableViewCell {
         }
     }
 
+    let bottomBorder = UIView()
+    
     override func prepareForReuse() {
         super.prepareForReuse()
         self.statusIcon.image = nil
@@ -165,17 +167,23 @@ class PhotonActionSheetCell: UITableViewCell {
         stackView.snp.makeConstraints { make in
             make.edges.equalTo(contentView).inset(UIEdgeInsets(top: topPadding, left: padding, bottom: topPadding, right: padding))
         }
+        addSubBorder()
+        // Hiding bottom border by default
+        bottomBorder.isHidden = true
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     func addSubBorder() {
-        let bottomBorder = CALayer()
-        bottomBorder.frame = CGRect(x: 0.0, y: self.contentView.frame.origin.y, width: self.contentView.frame.width, height: 1.0)
-        bottomBorder.backgroundColor = UIColor.theme.tableView.separator.cgColor
-        self.contentView.layer.addSublayer(bottomBorder)
+        bottomBorder.backgroundColor = UIColor.theme.tableView.separator
+        self.contentView.addSubview(bottomBorder)
+        bottomBorder.snp.makeConstraints { make in
+            make.bottom.equalToSuperview()
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(1)
+        }
     }
     
     func configure(with action: PhotonActionSheetItem) {
@@ -191,7 +199,9 @@ class PhotonActionSheetCell: UITableViewCell {
         subtitleLabel.textColor = UIColor.theme.tableView.rowText
         subtitleLabel.isHidden = action.text == nil
         subtitleLabel.numberOfLines = 0
-        titleLabel.font = action.bold ? DynamicFontHelper.defaultHelper.DeviceFontLargeBold : DynamicFontHelper.defaultHelper.LargeSizeRegularWeightAS
+        titleLabel.font = action.bold ? DynamicFontHelper.defaultHelper.DeviceFontLargeBold : DynamicFontHelper.defaultHelper.MediumSizeRegularWeightAS
+        
+        
         accessibilityIdentifier = action.iconString ?? action.accessibilityId
         accessibilityLabel = action.title
         selectionStyle = action.tapHandler != nil ? .default : .none
@@ -263,8 +273,10 @@ class PhotonActionSheetCell: UITableViewCell {
         case .Switch:
             toggleSwitch.setOn(action.isEnabled)
             stackView.addArrangedSubview(toggleSwitch.mainView)
-        default:
-            break // Do nothing. The rest are not supported yet.
+        case .None:
+            titleLabel.snp.makeConstraints { make in
+                make.top.bottom.equalTo(contentView).inset(10)
+            }
         }
         action.customRender?(titleLabel, contentView)
     }

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
@@ -175,6 +175,7 @@ class PhotonActionSheetCell: UITableViewCell {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
     func addSubBorder() {
         bottomBorder.backgroundColor = UIColor.theme.tableView.separator
         self.contentView.addSubview(bottomBorder)

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
@@ -199,7 +199,7 @@ class PhotonActionSheetCell: UITableViewCell {
         subtitleLabel.textColor = UIColor.theme.tableView.rowText
         subtitleLabel.isHidden = action.text == nil
         subtitleLabel.numberOfLines = 0
-        titleLabel.font = action.bold ? DynamicFontHelper.defaultHelper.DeviceFontLargeBold : DynamicFontHelper.defaultHelper.MediumSizeRegularWeightAS
+        titleLabel.font = action.bold ? DynamicFontHelper.defaultHelper.DeviceFontLargeBold : DynamicFontHelper.defaultHelper.SmallSizeRegularWeightAS
         
         
         accessibilityIdentifier = action.iconString ?? action.accessibilityId

--- a/Client/Helpers/DynamicFontHelper.swift
+++ b/Client/Helpers/DynamicFontHelper.swift
@@ -87,6 +87,11 @@ class DynamicFontHelper: NSObject {
      Small = 14, medium = 18, larger = 20
      */
 
+    var SemiMediumRegularWeightAS: UIFont {
+        let size = max(deviceFontSize, 16.5)
+        return UIFont.systemFont(ofSize: size)
+    }
+    
     var MediumSizeRegularWeightAS: UIFont {
         let size = max(deviceFontSize, 18)
         return UIFont.systemFont(ofSize: size)


### PR DESCRIPTION
FXIOS-1845 ⁃ Hamburger menu is broken
FXIOS-1852 ⁃ Page Action menu is broken
FXIOS-1848 ⁃ Separator line is missing in long press on reload button menu
FXIOS-1850 ⁃ Separator line is missing from the long press on tab counter button
MISC - Added a semi medium font size to match design
