### PR TITLE
Add telemetry for Your Library on Fx homepage

### DIFF
--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -753,18 +753,38 @@ extension FirefoxHomeViewController: DataObserverDelegate {
 extension FirefoxHomeViewController {
     @objc func openBookmarks() {
         homePanelDelegate?.homePanelDidRequestToOpenLibrary(panel: .bookmarks)
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .tap,
+                                     object: .firefoxHomepage,
+                                     value: .yourLibrarySection,
+                                     extras: [TelemetryWrapper.EventObject.libraryPanel.rawValue: TelemetryWrapper.EventValue.bookmarksPanel.rawValue])
     }
 
     @objc func openHistory() {
         homePanelDelegate?.homePanelDidRequestToOpenLibrary(panel: .history)
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .tap,
+                                     object: .firefoxHomepage,
+                                     value: .yourLibrarySection,
+                                     extras: [TelemetryWrapper.EventObject.libraryPanel.rawValue: TelemetryWrapper.EventValue.historyPanel.rawValue])
     }
 
     @objc func openReadingList() {
         homePanelDelegate?.homePanelDidRequestToOpenLibrary(panel: .readingList)
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .tap,
+                                     object: .firefoxHomepage,
+                                     value: .yourLibrarySection,
+                                     extras: [TelemetryWrapper.EventObject.libraryPanel.rawValue: TelemetryWrapper.EventValue.readingListPanel.rawValue])
     }
 
     @objc func openDownloads() {
         homePanelDelegate?.homePanelDidRequestToOpenLibrary(panel: .downloads)
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .tap,
+                                     object: .firefoxHomepage,
+                                     value: .yourLibrarySection,
+                                     extras: [TelemetryWrapper.EventObject.libraryPanel.rawValue: TelemetryWrapper.EventValue.downloadsPanel.rawValue])
     }
 }
 

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -400,6 +400,7 @@ extension TelemetryWrapper {
         case requestMobileSite = "request-mobile-site"
         case pinToTopSites = "pin-to-top-sites"
         case removePinnedSite = "remove-pinned-site"
+        case firefoxHomepage = "firefox-homepage"
     }
 
     public enum EventValue: String {
@@ -432,6 +433,7 @@ extension TelemetryWrapper {
         case readingPanel = "reading-panel"
         case downloadsPanel = "downloads-panel"
         case syncPanel = "sync-panel"
+        case yourLibrarySection = "your-library-section"
     }
 
     public static func recordEvent(category: EventCategory, method: EventMethod, object: EventObject, value: EventValue? = nil, extras: [String: Any]? = nil) {
@@ -597,6 +599,12 @@ extension TelemetryWrapper {
             GleanMetrics.PageActionMenu.requestDesktopSite.add()
         case (.action, .tap, .requestMobileSite, _, _):
             GleanMetrics.PageActionMenu.requestMobileSite.add()
+
+        // Firefox Homepage
+        case (.action, .tap, .firefoxHomepage, EventValue.yourLibrarySection.rawValue, let extras):
+            if let panel = extras?[EventObject.libraryPanel.rawValue] as? String {
+                GleanMetrics.FirefoxHomePage.yourLibrary[panel].add()
+            }
 
         default:
             let msg = "Uninstrumented metric recorded: \(category), \(method), \(object), \(value), \(String(describing: extras))"

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -335,6 +335,26 @@ experiments:
       - firefox-ios@mozilla.com
     expires: "2021-12-01"
 
+# HomePage
+firefox_home_page:
+  your_library:
+    type: labeled_counter
+    description: |
+      Counts the number of times the user taps the Bookmarks,
+      History, Reading List, or Downloads buttons
+    labels:
+      - bookmarks-panel
+      - history-panel
+      - reading-list-panel
+      - downloads-panel
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/8503
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/8152
+    notification_emails:
+      - firefox-ios@mozilla.com
+    expires: "2021-12-18"
+
 # Library
 library:
   panel_pressed:

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -350,7 +350,7 @@ firefox_home_page:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/8503
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/8152
+      - https://github.com/mozilla-mobile/firefox-ios/pull/8544
     notification_emails:
       - firefox-ios@mozilla.com
     expires: "2021-12-18"


### PR DESCRIPTION
# Request for data collection review form 
1. What questions will you answer with this data?
	* How many users interact with Your Library links from the home page
	* Which library sections are most valuable
	* What is the click-through rate for each (total impressions vs total clicks)

2. Why does Mozilla need to answer these questions? Are there benefits for users? Do we need this information to address product or business requirements? Some example responses:
	* It will provide information essential for understanding importance of the various items, what's important to users, and prioritize future work based on it

3. What alternative methods did you consider to answer these questions? Why were they not sufficient?
	* No other way to collect this data

4. Can current instrumentation answer these questions?
	* No, we didn't have events for these items 

5. List all proposed measurements and indicate the category of data collection for each measurement, using the Firefox data collection categories found on the Mozilla wiki.

Measurement Description | Data Collection Category | Tracking Bug # |
| --- | ----- | ----- |
Counts the number of times a each item in the Your Library section of the Home Page is tapped | 1 | https://github.com/mozilla-mobile/firefox-ios/pull/8544

6. How long will this data be collected? Choose one of the following:
	* I want this data to be collected for 6 months initially (potentially renewable).

7. What populations will you measure?
All countries and channels that have data collection on.

8. If this data collection is default on, what is the opt-out mechanism for users?
	* Toggle switch for 'Send Usage Data' in the app settings.

9. Please provide a general description of how you will analyze this data.
	* By monitoring the count of how often users are performing these actions.

10. Where do you intend to share the results of your analysis?
	* With the mobile team.

11. Is there a third-party tool (i.e. not Telemetry) that you are proposing to use for this data collection? If so:
	* No.
	
Documentation has been updated in this PR and will be reflected in our [metrics.md](https://github.com/mozilla-mobile/firefox-ios/blob/main/Docs/metrics.md) file