### PR TITLE
Fix #7466⁃ Infinite loop when opening an address link from another app

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -385,16 +385,6 @@ extension BrowserViewController: WKNavigationDelegate {
         //            return
         //        }
 
-        // Second special case are a set of URLs that look like regular http links, but should be handed over to iOS
-        // instead of being loaded in the webview. Note that there is no point in calling canOpenURL() here, because
-        // iOS will always say yes.
-
-        if isAppleMapsURL(url) {
-            UIApplication.shared.open(url, options: [:])
-            decisionHandler(.cancel)
-            return
-        }
-
         if isStoreURL(url) {
             decisionHandler(.cancel)
 


### PR DESCRIPTION
Our special handling was breaking it :\ so I removed it