### PR TITLE
Set the `overrideUserInterfaceStyle` on the window and not on a per view basis

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -140,6 +140,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             }
         }
 
+        NotificationCenter.default.addObserver(forName: .DisplayThemeChanged, object: nil, queue: .main) { (notification) -> Void in
+            if !LegacyThemeManager.instance.systemThemeIsOn {
+                self.window?.overrideUserInterfaceStyle = LegacyThemeManager.instance.userInterfaceStyle
+            } else {
+                self.window?.overrideUserInterfaceStyle = .unspecified
+            }
+        }
+
         SystemUtils.onFirstRun()
 
         RustFirefoxAccounts.startup(prefs: profile.prefs).uponQueue(.main) { _ in
@@ -151,6 +159,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
 
     // TODO: Move to scene controller for iOS 13
     private func setupRootViewController() {
+        if !LegacyThemeManager.instance.systemThemeIsOn {
+            self.window?.overrideUserInterfaceStyle = LegacyThemeManager.instance.userInterfaceStyle
+        }
+
         browserViewController = BrowserViewController(profile: self.profile!, tabManager: self.tabManager)
         browserViewController.edgesForExtendedLayout = []
 
@@ -245,13 +257,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
                 InstallType.updateCurrentVersion(version: AppInfo.appVersion)
                 // Profile setup
                 profile.prefs.setString(AppInfo.appVersion, forKey: LatestAppVersionProfileKey)
-                
+
             } else if profile.prefs.boolForKey(PrefsKeys.KeySecondRun) == nil {
                 profile.prefs.setBool(true, forKey: PrefsKeys.KeySecondRun)
             }
         }
 
-        
+
         BGTaskScheduler.shared.register(forTaskWithIdentifier: "org.mozilla.ios.sync.part1", using: DispatchQueue.global()) { task in
             guard self.profile?.hasSyncableAccount() ?? false else {
                 self.shutdownProfileWhenNotActive(application)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -63,10 +63,6 @@ extension BrowserViewController: URLBarDelegate, FeatureFlagsProtocol {
 
         let navigationController = ThemedDefaultNavigationController(rootViewController: tabTrayViewController!)
         navigationController.presentationController?.delegate = tabTrayViewController
-        // If we're not using the system theme, override the view's style to match
-        if !LegacyThemeManager.instance.systemThemeIsOn {
-            navigationController.overrideUserInterfaceStyle = LegacyThemeManager.instance.userInterfaceStyle
-        }
 
         self.present(navigationController, animated: true, completion: nil)
 

--- a/Client/Frontend/Browser/Tabs/ChronologicalTabsViewController.swift
+++ b/Client/Frontend/Browser/Tabs/ChronologicalTabsViewController.swift
@@ -104,8 +104,6 @@ class ChronologicalTabsViewController: UIViewController, NotificationThemeable, 
     }
 
     func applyTheme() {
-        overrideUserInterfaceStyle = LegacyThemeManager.instance.userInterfaceStyle
-        bottomSheetVC?.overrideUserInterfaceStyle = LegacyThemeManager.instance.userInterfaceStyle
         tableView.backgroundColor = UIColor.systemGroupedBackground
         emptyPrivateTabsView.titleLabel.textColor = UIColor.label
         emptyPrivateTabsView.descriptionLabel.textColor = UIColor.secondaryLabel

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -342,7 +342,6 @@ class TabTrayViewController: UIViewController {
 
 extension TabTrayViewController: NotificationThemeable {
      @objc func applyTheme() {
-         overrideUserInterfaceStyle =  LegacyThemeManager.instance.userInterfaceStyle
          view.backgroundColor = UIColor.theme.tabTray.background
          navigationToolbar.barTintColor = UIColor.theme.tabTray.toolbar
          navigationToolbar.tintColor = UIColor.theme.tabTray.toolbarButtonTint

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -481,7 +481,6 @@ extension LibraryViewController: NotificationThemeable {
         viewModel.panelDescriptors.forEach { item in
             (item.viewController as? NotificationThemeable)?.applyTheme()
         }        
-        overrideUserInterfaceStyle = LegacyThemeManager.instance.userInterfaceStyle
 
         // There is an ANNOYING bar in the nav bar above the segment control. These are the
         // UIBarBackgroundShadowViews. We must set them to be clear images in order to

--- a/Client/Frontend/Settings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettingsController.swift
@@ -125,6 +125,8 @@ class ThemeSettingsController: ThemedTableViewController {
     
         let userInterfaceStyle = traitCollection.userInterfaceStyle
         if control.isOn {
+            // Reset the user interface style to the default before choosing our theme
+            UIApplication.shared.delegate?.window??.overrideUserInterfaceStyle = .unspecified
             LegacyThemeManager.instance.current = userInterfaceStyle == .dark ? DarkTheme() : NormalTheme()
         } else if LegacyThemeManager.instance.automaticBrightnessIsOn {
             LegacyThemeManager.instance.updateCurrentThemeBasedOnScreenBrightness()

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyThemeManager.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyThemeManager.swift
@@ -52,11 +52,7 @@ class LegacyThemeManager {
 
     // UIViewControllers / UINavigationControllers need to have `preferredStatusBarStyle` and call this.
     var statusBarStyle: UIStatusBarStyle {
-        if UIScreen.main.traitCollection.userInterfaceStyle == .dark && currentName == .normal {
-            return .darkContent
-        }
-        
-        return currentName == .dark ? .lightContent : .default
+        return .default
     }
 
     var userInterfaceStyle: UIUserInterfaceStyle {


### PR DESCRIPTION
This allows all system UI (share sheets, peek/pop, etc.), and websites that use `prefers-color-scheme` to match the user set theme.

Fixes #9254.