### PR TITLE
Fix #8574 - `StorageTests.testUpdateInTransaction` is failing

### DIFF
--- a/StorageTests/TestSQLiteHistory.swift
+++ b/StorageTests/TestSQLiteHistory.swift
@@ -1635,7 +1635,7 @@ class TestSQLiteHistoryTransactionUpdate: XCTestCase {
         let history = SQLiteHistory(db: db, prefs: prefs)
 
         history.clearHistory().succeeded()
-        let site = Site(url: "http://site/foo", title: "AA")
+        let site = Site(url: "http://site.example/foo", title: "AA")
         site.guid = "abcdefghiabc"
 
         history.insertOrUpdatePlace(site.asPlace(), modified: 1234567890).succeeded()


### PR DESCRIPTION
Fixes #8574.

The `normalizedHost` of the Site being created for this test was returning `nil` due to a change implemented in #8543. Changing the domain to a `proper` one fixes the test.