### PR TITLE
Fix #8443 - Can’t close Synced Tab view on iPad

### DIFF
--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -72,6 +72,14 @@ class TabTrayViewController: UIViewController {
                                action: nil)
     }()
 
+    lazy var fixedSpace: UIBarButtonItem = {
+        let fixedSpace = UIBarButtonItem(barButtonSystemItem: .fixedSpace,
+                               target: nil,
+                               action: nil)
+        fixedSpace.width = 32
+        return fixedSpace
+    }()
+
     lazy var countLabel: UILabel = {
         let label = UILabel(frame: CGRect(width: 24, height: 24))
         label.font = TabsButtonUX.TitleFont
@@ -192,7 +200,7 @@ class TabTrayViewController: UIViewController {
     fileprivate func iPadViewSetup() {
         navigationItem.leftBarButtonItem = deleteButton
         navigationItem.titleView = navigationMenu
-        navigationItem.rightBarButtonItems = [doneButton, newTabButton]
+        navigationItem.rightBarButtonItems = [doneButton, fixedSpace, newTabButton]
 
         navigationItem.titleView?.snp.makeConstraints { make in
             make.width.equalTo(343)
@@ -280,10 +288,10 @@ class TabTrayViewController: UIViewController {
     fileprivate func updateToolbarItems(forSyncTabs showSyncItems: Bool = false) {
         if UIDevice.current.userInterfaceIdiom == .pad {
             if navigationMenu.selectedSegmentIndex == 2 {
-                navigationItem.rightBarButtonItems = (showSyncItems ? [doneButton, syncTabButton] : [doneButton])
+                navigationItem.rightBarButtonItems = (showSyncItems ? [doneButton, fixedSpace, syncTabButton] : [doneButton])
                 navigationItem.leftBarButtonItem = nil
             } else {
-                navigationItem.rightBarButtonItems = [doneButton, newTabButton]
+                navigationItem.rightBarButtonItems = [doneButton, fixedSpace, newTabButton]
                 navigationItem.leftBarButtonItem = deleteButton
             }
         } else {

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -37,6 +37,12 @@ class TabTrayViewController: UIViewController {
         return button
     }()
 
+    lazy var doneButton: UIBarButtonItem = {
+        let button = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(didTapDone))
+        button.accessibilityIdentifier = "doneButtonTabTray"
+        return button
+    }()
+
     lazy var syncTabButton: UIBarButtonItem = {
         let button = UIBarButtonItem(title: Strings.FxASyncNow,
                                      style: .plain,
@@ -186,7 +192,7 @@ class TabTrayViewController: UIViewController {
     fileprivate func iPadViewSetup() {
         navigationItem.leftBarButtonItem = deleteButton
         navigationItem.titleView = navigationMenu
-        navigationItem.rightBarButtonItem = newTabButton
+        navigationItem.rightBarButtonItems = [doneButton, newTabButton]
 
         navigationItem.titleView?.snp.makeConstraints { make in
             make.width.equalTo(343)
@@ -274,10 +280,10 @@ class TabTrayViewController: UIViewController {
     fileprivate func updateToolbarItems(forSyncTabs showSyncItems: Bool = false) {
         if UIDevice.current.userInterfaceIdiom == .pad {
             if navigationMenu.selectedSegmentIndex == 2 {
-                navigationItem.rightBarButtonItem = (showSyncItems ? syncTabButton : nil)
+                navigationItem.rightBarButtonItems = (showSyncItems ? [doneButton, syncTabButton] : [doneButton])
                 navigationItem.leftBarButtonItem = nil
             } else {
-                navigationItem.rightBarButtonItem = newTabButton
+                navigationItem.rightBarButtonItems = [doneButton, newTabButton]
                 navigationItem.leftBarButtonItem = deleteButton
             }
         } else {
@@ -384,6 +390,10 @@ extension TabTrayViewController {
 
     @objc func didTapSyncTabs(_ sender: UIBarButtonItem) {
         viewModel.didTapSyncTabs(sender)
+    }
+
+    @objc func didTapDone() {
+        self.dismiss(animated: true, completion: nil)
     }
 }
 


### PR DESCRIPTION
Fixes #8443.

![image](https://user-images.githubusercontent.com/650804/119746812-4db7e500-be5f-11eb-8e91-99f64d8ec01b.png)


