### PR TITLE
FXIOS-1716: fix sync now button for unauthenticated state

### DIFF
--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -160,7 +160,7 @@ class TabTrayViewController: UIViewController {
             navigationController?.isToolbarHidden = true
         } else {
             navigationController?.isToolbarHidden = false
-            updateToolbarItems()
+            updateToolbarItems(forSyncTabs: viewModel.profile.hasSyncableAccount())
         }
     }
 
@@ -229,7 +229,7 @@ class TabTrayViewController: UIViewController {
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .libraryPanel, value: .syncPanel, extras: nil)
             if children.first == viewModel.tabTrayView {
                 hideCurrentPanel()
-                updateToolbarItems(forSyncTabs: true)
+                updateToolbarItems(forSyncTabs: viewModel.profile.hasSyncableAccount())
                 showPanel(viewModel.syncedTabsController)
             }
         default:
@@ -242,7 +242,7 @@ class TabTrayViewController: UIViewController {
             hideCurrentPanel()
             showPanel(viewModel.tabTrayView)
         }
-        updateToolbarItems()
+        updateToolbarItems(forSyncTabs: viewModel.profile.hasSyncableAccount())
         viewModel.tabTrayView.didTogglePrivateMode(privateMode)
     }
 
@@ -273,16 +273,18 @@ class TabTrayViewController: UIViewController {
 
     fileprivate func updateToolbarItems(forSyncTabs showSyncItems: Bool = false) {
         if UIDevice.current.userInterfaceIdiom == .pad {
-            if showSyncItems || navigationMenu.selectedSegmentIndex == 2 {
-                navigationItem.rightBarButtonItem = nil
+            if navigationMenu.selectedSegmentIndex == 2 {
+                navigationItem.rightBarButtonItem = (showSyncItems ? syncTabButton : nil)
                 navigationItem.leftBarButtonItem = nil
             } else {
                 navigationItem.rightBarButtonItem = newTabButton
                 navigationItem.leftBarButtonItem = deleteButton
             }
-
         } else {
-            let newToolbarItems = showSyncItems ? bottomToolbarItemsForSync : bottomToolbarItems
+            var newToolbarItems: [UIBarButtonItem]? = bottomToolbarItems
+            if navigationMenu.selectedSegmentIndex == 2 {
+                newToolbarItems = showSyncItems ? bottomToolbarItemsForSync : nil
+            }
             setToolbarItems(newToolbarItems, animated: true)
         }
     }


### PR DESCRIPTION
# Overview

This ticket is for [JIRA ticket](https://jira.mozilla.com/browse/FXIOS-1716) and issue #8341. A PR related to this work is https://github.com/mozilla-mobile/firefox-ios/pull/8582. 

Please see the [design spec](https://www.figma.com/file/WboC4Dn9iu9wie2GodfSAg/Post-MR1?node-id=51%3A7703) to verify. 