### PR TITLE
No issue: Remove XCResult Parse from build-contributor-pr.yml

### DIFF
--- a/.github/workflows/build-contributor-pr.yml
+++ b/.github/workflows/build-contributor-pr.yml
@@ -1,5 +1,5 @@
 name: Build contributor PR
-on: [workflow_dispatch]
+on: [pull_request]
 jobs:
   run-ui:
     if: github.event.pull_request.head.repo.full_name != github.repository
@@ -31,9 +31,3 @@ jobs:
           with:
            name: xcresult
            path: results.zip
-        - name: Summarize XCResult
-          uses: tbartelmess/analyze-xcoderesults-action@0.1.1
-          if: ${{ always() }}
-          with:
-            results: TestResults.xcresult
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
With the removal of this step I believe we can still run tests on PR without the need for a write access GIthub Token. The result bundle will still be downloadable and viewable, we just won't have any fancy results viewable on Github. Maybe we can revisit it in the future if the project is updated and it's safe.