### PR TITLE
No issue: Add auth in contributor workflow (bootstrap step)

### DIFF
--- a/.github/workflows/build-contributor-pr.yml
+++ b/.github/workflows/build-contributor-pr.yml
@@ -21,6 +21,8 @@ jobs:
             python-version: ${{ matrix.python-version }}
         - name: Run Boostrap
           run: sh ./bootstrap.sh
+          env:
+            GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         - name: Build and Test
           run: xcodebuild clean test -scheme '${{ matrix.run-config['scheme'] }}' -destination '${{ matrix.run-config['destination'] }}' -testPlan '${{ matrix.run-config['testplan'] }}' -resultBundlePath TestResults -derivedDataPath results
         - name: Archive Results


### PR DESCRIPTION
Not sure if this will work without the need for tampering the bootstrap scripts or writing a custom one or pulling out the irrelevant steps like l10n out. Worth trying it for a few days until we see the issue again.

@isabelrios - saw this from a few other examples here https://github.com/search?q=carthage+bootstrap+GITHUB_TOKEN+path%3A.github%2Fworkflows&type=Code (e.g, [here](https://github.com/AckeeCZ/TezosSwift/blob/57646c754feb0ffe9c7cee07db851fcaa4bbea2c/.github/workflows/tests.yml#L22))

(no need to add a secret as it's automatically created)

> GitHub automatically creates a GITHUB_TOKEN secret to use in your workflow. You can use the GITHUB_TOKEN to authenticate in a workflow run.

https://docs.github.com/en/actions/reference/authentication-in-a-workflow