### PR TITLE
Issue6592 xc UI tests using china server

### DIFF
--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -113,7 +113,7 @@ class TestAppDelegate: AppDelegate {
             profile.prefs.setInt(1, forKey: PrefsKeys.UseStageServer)
         }
 
-        if launchArguments.contains(LaunchArguments.ChinaServer) {
+        if launchArguments.contains(LaunchArguments.FxAChinaServer) {
             profile.prefs.setInt(1, forKey: PrefsKeys.KeyEnableChinaSyncService)
         }
 

--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -113,6 +113,10 @@ class TestAppDelegate: AppDelegate {
             profile.prefs.setInt(1, forKey: PrefsKeys.UseStageServer)
         }
 
+        if launchArguments.contains(LaunchArguments.ChinaServer) {
+            profile.prefs.setInt(1, forKey: PrefsKeys.KeyEnableChinaSyncService)
+        }
+
         self.profile = profile
         return profile
     }

--- a/Shared/LaunchArguments.swift
+++ b/Shared/LaunchArguments.swift
@@ -12,7 +12,7 @@ public struct LaunchArguments {
     public static let SkipETPCoverSheet = "FIREFOX_SKIP_ETP_COVER_SHEET"
     public static let ClearProfile = "FIREFOX_CLEAR_PROFILE"
     public static let StageServer = "FIREFOX_USE_STAGE_SERVER"
-    public static let ChinaServer = "FIREFOX_USE_CHINA_SERVER"
+    public static let FxAChinaServer = "FIREFOX_USE_FXA_CHINA_SERVER"
     public static let DeviceName = "DEVICE_NAME"
     public static let ServerPort = "GCDWEBSERVER_PORT:"
     public static let SkipAddingGoogleTopSite = "SKIP_ADDING_GOOGLE_TOP_SITE"

--- a/Shared/LaunchArguments.swift
+++ b/Shared/LaunchArguments.swift
@@ -12,6 +12,7 @@ public struct LaunchArguments {
     public static let SkipETPCoverSheet = "FIREFOX_SKIP_ETP_COVER_SHEET"
     public static let ClearProfile = "FIREFOX_CLEAR_PROFILE"
     public static let StageServer = "FIREFOX_USE_STAGE_SERVER"
+    public static let ChinaServer = "FIREFOX_USE_CHINA_SERVER"
     public static let DeviceName = "DEVICE_NAME"
     public static let ServerPort = "GCDWEBSERVER_PORT:"
     public static let SkipAddingGoogleTopSite = "SKIP_ADDING_GOOGLE_TOP_SITE"

--- a/SyncIntegrationTests/test_integration.py
+++ b/SyncIntegrationTests/test_integration.py
@@ -35,5 +35,5 @@ def test_sync_disconnect_connect_fxa(tps, xcodebuild):
     tps.run('test_bookmark_login.js')
     xcodebuild.test('XCUITests/IntegrationTests/testFxADisconnectConnect')
  
- def test_sync_china_server(xcodebuild):
-    xcodebuild.test('XCUITests/IntegrationTests/testFxASyncHistoryChina')
+ def test_sync_china_fxa_server(xcodebuild):
+    xcodebuild.test('XCUITests/IntegrationTests/testFxASyncPageUsingChinaFxA')

--- a/SyncIntegrationTests/test_integration.py
+++ b/SyncIntegrationTests/test_integration.py
@@ -35,3 +35,5 @@ def test_sync_disconnect_connect_fxa(tps, xcodebuild):
     tps.run('test_bookmark_login.js')
     xcodebuild.test('XCUITests/IntegrationTests/testFxADisconnectConnect')
  
+ def test_sync_china_server(xcodebuild):
+    xcodebuild.test('XCUITests/IntegrationTests/testFxASyncHistoryChina')

--- a/XCUITests/IntegrationTests.swift
+++ b/XCUITests/IntegrationTests.swift
@@ -14,7 +14,7 @@ private let tabOpenInDesktop = "http://example.com/"
 class IntegrationTests: BaseTestCase {
 
     let testWithDB = ["testFxASyncHistory", "testFxASyncBookmark"]
-    let testChinaServer = ["testFxASyncHistoryChina"]
+    let testFxAChinaServer = ["testFxASyncPageUsingChinaFxA"]
 
     // This DB contains 1 entry example.com
     let historyDB = "exampleURLHistoryBookmark.db"
@@ -26,8 +26,8 @@ class IntegrationTests: BaseTestCase {
      if testWithDB.contains(key) {
      // for the current test name, add the db fixture used
      launchArguments = [LaunchArguments.SkipIntro, LaunchArguments.StageServer, LaunchArguments.SkipWhatsNew, LaunchArguments.SkipETPCoverSheet, LaunchArguments.LoadDatabasePrefix + historyDB]
-     } else if testChinaServer.contains(key) {
-        launchArguments = [LaunchArguments.SkipIntro, LaunchArguments.ChinaServer, LaunchArguments.SkipWhatsNew, LaunchArguments.SkipETPCoverSheet]
+     } else if testFxAChinaServer.contains(key) {
+        launchArguments = [LaunchArguments.SkipIntro, LaunchArguments.FxAChinaServer, LaunchArguments.SkipWhatsNew, LaunchArguments.SkipETPCoverSheet]
      }
      super.setUp()
      }
@@ -72,7 +72,7 @@ class IntegrationTests: BaseTestCase {
         waitForInitialSyncComplete()
     }
 
-    func testFxASyncPageUsingChina () {
+    func testFxASyncPageUsingChinaFxA () {
         // History is generated using the DB so go directly to Sign in
         // Sign into Firefox Accounts
         app.buttons["urlBar-cancel"].tap()
@@ -82,7 +82,7 @@ class IntegrationTests: BaseTestCase {
         waitForExistence(app.navigationBars["Turn on Sync"], timeout: 20)
         waitForExistence(app.webViews.textFields["Email"])
 
-        // Wait for element not present on FxA sign in page China server
+        // Wait for element not present on FxA sign in page China FxA server
         waitForNoExistence(app.webViews.otherElements.staticTexts["Firefox Monitor"])
         XCTAssertFalse(app.webViews.otherElements.staticTexts["Firefox Monitor"].exists)
     }

--- a/XCUITests/IntegrationTests.swift
+++ b/XCUITests/IntegrationTests.swift
@@ -77,10 +77,14 @@ class IntegrationTests: BaseTestCase {
         // Sign into Firefox Accounts
         app.buttons["urlBar-cancel"].tap()
         navigator.goto(BrowserTabMenu)
-        signInFxAccounts()
+        navigator.goto(Intro_FxASignin)
+        navigator.performAction(Action.OpenEmailToSignIn)
+        waitForExistence(app.navigationBars["Turn on Sync"], timeout: 20)
+        waitForExistence(app.webViews.textFields["Email"])
 
-        // Wait for initial sync to complete
-        waitForInitialSyncComplete()
+        // Wait for element not present on FxA sign in page China server
+        waitForNoExistence(app.webViews.otherElements.staticTexts["Firefox Monitor"])
+        XCTAssertFalse(app.webViews.otherElements.staticTexts["Firefox Monitor"].exists)
     }
 
     func testFxASyncBookmark () {

--- a/XCUITests/IntegrationTests.swift
+++ b/XCUITests/IntegrationTests.swift
@@ -72,7 +72,7 @@ class IntegrationTests: BaseTestCase {
         waitForInitialSyncComplete()
     }
 
-    func testFxASyncHistoryChina () {
+    func testFxASyncPageUsingChina () {
         // History is generated using the DB so go directly to Sign in
         // Sign into Firefox Accounts
         app.buttons["urlBar-cancel"].tap()

--- a/XCUITests/IntegrationTests.swift
+++ b/XCUITests/IntegrationTests.swift
@@ -14,6 +14,7 @@ private let tabOpenInDesktop = "http://example.com/"
 class IntegrationTests: BaseTestCase {
 
     let testWithDB = ["testFxASyncHistory", "testFxASyncBookmark"]
+    let testChinaServer = ["testFxASyncHistoryChina"]
 
     // This DB contains 1 entry example.com
     let historyDB = "exampleURLHistoryBookmark.db"
@@ -25,6 +26,8 @@ class IntegrationTests: BaseTestCase {
      if testWithDB.contains(key) {
      // for the current test name, add the db fixture used
      launchArguments = [LaunchArguments.SkipIntro, LaunchArguments.StageServer, LaunchArguments.SkipWhatsNew, LaunchArguments.SkipETPCoverSheet, LaunchArguments.LoadDatabasePrefix + historyDB]
+     } else if testChinaServer.contains(key) {
+        launchArguments = [LaunchArguments.SkipIntro, LaunchArguments.ChinaServer, LaunchArguments.SkipWhatsNew, LaunchArguments.SkipETPCoverSheet]
      }
      super.setUp()
      }
@@ -59,6 +62,17 @@ class IntegrationTests: BaseTestCase {
     }
 
     func testFxASyncHistory () {
+        // History is generated using the DB so go directly to Sign in
+        // Sign into Firefox Accounts
+        app.buttons["urlBar-cancel"].tap()
+        navigator.goto(BrowserTabMenu)
+        signInFxAccounts()
+
+        // Wait for initial sync to complete
+        waitForInitialSyncComplete()
+    }
+
+    func testFxASyncHistoryChina () {
         // History is generated using the DB so go directly to Sign in
         // Sign into Firefox Accounts
         app.buttons["urlBar-cancel"].tap()


### PR DESCRIPTION
It would be nice if we could have sync int tests using china server to realize when/if there are issues there. 

So far I can't find a way to use a testing account with that server, so let's check at least that we use that server and FxA page is loaded for it. 
This test will run as part of the sync int tests, daily on a Jenkins job