### PR TITLE
No issue: Set read all on contributor workflow

### DIFF
--- a/.github/workflows/build-contributor-pr.yml
+++ b/.github/workflows/build-contributor-pr.yml
@@ -1,4 +1,5 @@
 name: Build contributor PR
+permissions: read-all
 on: [pull_request]
 jobs:
   run-ui:


### PR DESCRIPTION
As per conversation on Slack. We don't want any writes to `bootstrap.sh`