### PR TITLE
Added .command file to automate building the code

### DIFF
--- a/AutomateFirefoxBuild.command
+++ b/AutomateFirefoxBuild.command
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo -en '\033[1mWhich directory do you want to download to? -> \033[0m' 
+read -r DESIRED_DIRECTORY
+sudo xcode-select --install
+sudo xcode-select -switch /Library/DeveloperCommandLineTools
+brew update
+brew install carthage node virtualenv
+cd $DESIRED_DIRECTORY
+git clone https://github.com/mozilla-mobile/firefox-ios
+cd firefox-ios
+sh ./bootstrap.sh
+open -a Xcode Client.xcodeproj


### PR DESCRIPTION
**Summary of the Change**

I added a .command script to automate building the code. The motivation for this was while building the code on an array of machines I was looking for something to automate the build process. This is an issue that I have noticed many of my peers face too. The dependency for the script is bash which is preinstalled on macOS until atleast Big Sur (version 11). The script allows the user to click on the file and input directory to which they want to clone the repository. None of my changes affect existing tests. Bitrise seems to fail though

