### PR TITLE
FXIOS-1828, FXIOS-1811 - Added top site probes and tracking to measure Pocket impressions and key metrics

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -754,6 +754,10 @@ class BrowserViewController: UIViewController {
     func showFirefoxHome(inline: Bool) {
         homePanelIsInline = inline
         if self.firefoxHomeViewController == nil {
+            // Firefox home page tracking i.e. being shown from awesomebar vs bottom right hamburger menu
+            let trackingValue: TelemetryWrapper.EventValue = homePanelIsInline ? .openHomeFromPhotonMenuButton : .openHomeFromAwesomebar
+            TelemetryWrapper.recordEvent(category: .action, method: .open, object: .firefoxHomepage, value: trackingValue, extras: nil)
+            
             let firefoxHomeViewController = FirefoxHomeViewController(profile: profile)
             firefoxHomeViewController.homePanelDelegate = self
             self.firefoxHomeViewController = firefoxHomeViewController

--- a/Client/Frontend/Home/FirefoxHomeTopSitesCell.swift
+++ b/Client/Frontend/Home/FirefoxHomeTopSitesCell.swift
@@ -404,7 +404,7 @@ class ASHorizontalScrollCellManager: NSObject, UICollectionViewDelegate, UIColle
 
     var content: [Site] = []
 
-    var urlPressedHandler: ((URL, IndexPath) -> Void)?
+    var urlPressedHandler: ((Site, IndexPath) -> Void)?
     // The current traits that define the parent ViewController. Used to determine how many rows/columns should be created.
     var currentTraits: UITraitCollection?
 
@@ -446,9 +446,6 @@ class ASHorizontalScrollCellManager: NSObject, UICollectionViewDelegate, UIColle
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let contentItem = content[indexPath.row]
-        guard let url = contentItem.url.asURL else {
-            return
-        }
-        urlPressedHandler?(url, indexPath)
+        urlPressedHandler?(contentItem, indexPath)
     }
 }

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -122,6 +122,7 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel {
     fileprivate let profile: Profile
     fileprivate let pocketAPI = Pocket()
     fileprivate let flowLayout = UICollectionViewFlowLayout()
+    fileprivate var hasSentPocketSectionEvent = false
 
     fileprivate lazy var topSitesManager: ASHorizontalScrollCellManager = {
         let manager = ASHorizontalScrollCellManager()
@@ -163,6 +164,10 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -382,6 +387,11 @@ extension FirefoxHomeViewController: UICollectionViewDelegateFlowLayout {
             let title = Section(indexPath.section).title
             switch Section(indexPath.section) {
             case .pocket:
+                // tracking pocket section shown
+                if !hasSentPocketSectionEvent {
+                    TelemetryWrapper.recordEvent(category: .action, method: .view, object: .pocketSectionImpression, value: nil, extras: nil)
+                    hasSentPocketSectionEvent = true
+                }
                 view.title = title
                 view.moreButton.isHidden = false
                 view.moreButton.setTitle(Strings.PocketMoreStoriesText, for: .normal)
@@ -703,7 +713,8 @@ extension FirefoxHomeViewController: DataObserverDelegate {
         switch section {
         case .pocket:
             site = Site(url: pocketStories[index].url.absoluteString, title: pocketStories[index].title)
-            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .pocketStory)
+            let key = TelemetryWrapper.EventExtraKey.pocketTilePosition.rawValue
+            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .pocketStory, value: nil, extras: [key : "\(index)"])
         case .topSites:
             return
         case .libraryShortcuts:

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -546,7 +546,7 @@ extension FirefoxHomeViewController: DataObserverDelegate {
             let maxItems = Int(numRows) * self.topSitesManager.numberOfHorizontalItems()
             
             var sites = Array(result.prefix(maxItems))
-            
+
             // Check if all result items are pinned site
             var pinnedSites = 0
             result.forEach {
@@ -569,9 +569,11 @@ extension FirefoxHomeViewController: DataObserverDelegate {
                 }
             }
             self.topSitesManager.content = sites
-            self.topSitesManager.urlPressedHandler = { [unowned self] url, indexPath in
+            self.topSitesManager.urlPressedHandler = { [unowned self] site, indexPath in
                 self.longPressRecognizer.isEnabled = false
+                guard let url = site.url.asURL else { return }
                 let isGoogleTopSiteUrl = url.absoluteString == GoogleTopSiteConstants.usUrl || url.absoluteString == GoogleTopSiteConstants.rowUrl
+                topSiteTracking(site: site, position: indexPath.item)
                 self.showSiteWithURLHandler(url as URL, isGoogleTopSite: isGoogleTopSiteUrl)
             }
 
@@ -583,6 +585,16 @@ extension FirefoxHomeViewController: DataObserverDelegate {
             // Refresh the AS data in the background so we'll have fresh data next time we show.
             self.profile.panelDataObservers.activityStream.refreshIfNeeded(forceTopSites: false)
         }
+    }
+    
+    func topSiteTracking(site: Site, position: Int) {
+        let topSitePositionKey = TelemetryWrapper.EventExtraKey.topSitePosition.rawValue
+        let topSiteTileTypeKey = TelemetryWrapper.EventExtraKey.topSiteTileType.rawValue
+        let isPinnedAndGoogle = site is PinnedSite && site.guid == GoogleTopSiteConstants.googleGUID
+        let isPinnedOnly = site is PinnedSite
+        let isSuggestedSite = site is SuggestedSite
+        let type = isPinnedAndGoogle ? "google" : isPinnedOnly ? "user-added" : isSuggestedSite ? "suggested" : "history-based"
+        TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .topSiteTile, value: nil, extras: [topSitePositionKey : "\(position)", topSiteTileTypeKey: type])
     }
 
     func getPocketSites() -> Success {
@@ -678,7 +690,7 @@ extension FirefoxHomeViewController: DataObserverDelegate {
         }
     }
 
-    fileprivate func fetchBookmarkStatus(for site: Site, with indexPath: IndexPath, forSection section: Section, completionHandler: @escaping () -> Void) {
+    fileprivate func fetchBookmarkStatus(for site: Site, completionHandler: @escaping () -> Void) {
         profile.places.isBookmarked(url: site.url).uponQueue(.main) { result in
             let isBookmarked = result.successValue ?? false
             site.setBookmarked(isBookmarked)
@@ -744,7 +756,7 @@ extension FirefoxHomeViewController {
 extension FirefoxHomeViewController: HomePanelContextMenu {
     func presentContextMenu(for site: Site, with indexPath: IndexPath, completionHandler: @escaping () -> PhotonActionSheet?) {
 
-        fetchBookmarkStatus(for: site, with: indexPath, forSection: Section(indexPath.section)) {
+        fetchBookmarkStatus(for: site) {
             guard let contextMenu = completionHandler() else { return }
             self.present(contextMenu, animated: true, completion: nil)
         }

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -379,6 +379,7 @@ extension TelemetryWrapper {
         case mediumTopSitesWidget = "medium-top-sites-widget"
         case topSiteTile = "top-site-tile"
         case pocketStory = "pocket-story"
+        case pocketSectionImpression = "pocket-section-impression"
         case library = "library"
         case home = "home-page"
         case blockImagesEnabled = "block-images-enabled"
@@ -435,11 +436,14 @@ extension TelemetryWrapper {
         case downloadsPanel = "downloads-panel"
         case syncPanel = "sync-panel"
         case yourLibrarySection = "your-library-section"
+        case openHomeFromAwesomebar = "open-home-from-awesomebar"
+        case openHomeFromPhotonMenuButton = "open-home-from-photon-menu-button"
     }
     
     public enum EventExtraKey: String {
         case topSitePosition = "tilePosition"
         case topSiteTileType = "tileType"
+        case pocketTilePosition = "pocketTilePosition"
     }
 
     public static func recordEvent(category: EventCategory, method: EventMethod, object: EventObject, value: EventValue? = nil, extras: [String: Any]? = nil) {
@@ -547,8 +551,18 @@ extension TelemetryWrapper {
             GleanMetrics.Widget.mQuickActionClosePrivate.add()
         case (.action, .open, .mediumTopSitesWidget, _, _):
             GleanMetrics.Widget.mTopSitesWidget.add()
-        case (.action, .tap, .pocketStory, _, _):
-            GleanMetrics.Pocket.openStory.add()
+
+        // Pocket
+        case (.action, .tap, .pocketStory, _, let extras):
+            if let position = extras?[EventExtraKey.pocketTilePosition.rawValue] as? String {
+                GleanMetrics.Pocket.openStoryPosition[position].add()
+            } else {
+                let msg = "Uninstrumented pref metric: \(category), \(method), \(object), \(value), \(String(describing: extras))"
+                Sentry.shared.send(message: msg, severity: .debug)
+            }
+        case (.action, .view, .pocketSectionImpression, _, _):
+            GleanMetrics.Pocket.sectionImpressions.add()
+
         // Library
         case (.action, .tap, .libraryPanel, let type, _):
             GleanMetrics.Library.panelPressed[type].add()
@@ -613,13 +627,17 @@ extension TelemetryWrapper {
             GleanMetrics.PageActionMenu.requestDesktopSite.add()
         case (.action, .tap, .requestMobileSite, _, _):
             GleanMetrics.PageActionMenu.requestMobileSite.add()
-
+            
         // Firefox Homepage
         case (.action, .tap, .firefoxHomepage, EventValue.yourLibrarySection.rawValue, let extras):
             if let panel = extras?[EventObject.libraryPanel.rawValue] as? String {
                 GleanMetrics.FirefoxHomePage.yourLibrary[panel].add()
             }
-
+        case (.action, .open, .firefoxHomepage, EventValue.openHomeFromAwesomebar.rawValue, _):
+            GleanMetrics.FirefoxHomePage.openFromAwesomebar.add()
+        case (.action, .open, .firefoxHomepage, EventValue.openHomeFromPhotonMenuButton.rawValue, _):
+            GleanMetrics.FirefoxHomePage.openFromMenuHomeButton.add()
+            
         default:
             let msg = "Uninstrumented metric recorded: \(category), \(method), \(object), \(value), \(String(describing: extras))"
             Sentry.shared.send(message: msg, severity: .debug)

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -313,7 +313,7 @@ app:
 # Top Site
 top_site:
   tile_pressed:
-    type: event
+    type: counter
     description: |
       Records an event when user taps on top site tile.
     extra_keys:

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -327,10 +327,10 @@ top_site:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/8501
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/8636/
+      - https://github.com/mozilla-mobile/firefox-ios/pull/8662
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2021-12-02"
+    expires: "2021-12-07"
 
 # Experiments
 experiments:
@@ -379,24 +379,24 @@ firefox_home_page:
   open_from_menu_home_button:
     type: counter
     description: |
-        Records when user gets to home screen
-        from hamburger menu.
+        Counts when user opens Firefox Home from
+        bottom right hamburger menu Home button.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/8481
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/8481
+      - https://github.com/mozilla-mobile/firefox-ios/pull/8662
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2021-12-07"
   open_from_awesomebar:
     type: counter
     description: |
-        Records when user gets to home screen
+        Counts when a user opens Firefox Home
         from awesomebar.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/8481
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/8481
+      - https://github.com/mozilla-mobile/firefox-ios/pull/8662
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2021-12-07"
@@ -587,23 +587,25 @@ pocket:
   open_story_position:
     type: labeled_counter
     description: |
-        Counts the number of times a user opens
-        Pocket article from Firefox home Pocket feed
+        Counts when a user opens Pocket article from
+        Firefox Home Pocket feed.
+        The label is position of tile i.e. 0,1,2...
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/8481
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/8481
+      - https://github.com/mozilla-mobile/firefox-ios/pull/8662
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2021-12-07"
   section_impressions:
     type: counter
     description: |
-        Counts the number of times a user gets to pocket section
+        Counts when a user gets to pocket section
+        on Firefox Home
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/8481
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/8481
+      - https://github.com/mozilla-mobile/firefox-ios/pull/8662
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2021-12-07"

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -310,6 +310,28 @@ app:
       - fx-ios-data-stewards@mozilla.com
     expires: "2021-09-01"
 
+# Top Site
+top_site:
+  tile_pressed:
+    type: event
+    description: |
+      Records an event when user taps on top site tile.
+    extra_keys:
+      tile_type:
+        description: |
+          Type of tile pressed (Ex: google,
+          suggested, user-added or history-based)
+      position:
+        description: |
+          Position of top site.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/8501
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/8636/
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2021-12-02"
+
 # Experiments
 experiments:
   experiment_enrollment:

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -313,7 +313,7 @@ app:
 # Top Site
 top_site:
   tile_pressed:
-    type: counter
+    type: event
     description: |
       Records an event when user taps on top site tile.
     extra_keys:

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -376,6 +376,30 @@ firefox_home_page:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2021-12-18"
+  open_from_menu_home_button:
+    type: counter
+    description: |
+        Records when user gets to home screen
+        from hamburger menu.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/8481
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/8481
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2021-12-07"
+  open_from_awesomebar:
+    type: counter
+    description: |
+        Records when user gets to home screen
+        from awesomebar.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/8481
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/8481
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2021-12-07"
 
 # Library
 library:
@@ -560,18 +584,29 @@ page_action_menu:
 
 # Pocket
 pocket:
-  open_story:
-    type: counter
+  open_story_position:
+    type: labeled_counter
     description: |
         Counts the number of times a user opens
         Pocket article from Firefox home Pocket feed
     bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/6195
+      - https://github.com/mozilla-mobile/firefox-ios/issues/8481
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/8009
+      - https://github.com/mozilla-mobile/firefox-ios/issues/8481
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2021-08-19"
+    expires: "2021-12-07"
+  section_impressions:
+    type: counter
+    description: |
+        Counts the number of times a user gets to pocket section
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/8481
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/8481
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2021-12-07"
 
 # Preference metrics
 preferences:


### PR DESCRIPTION
Tracking to help understand how users use top site, pocket tiles and Firefox home page