### PR TITLE
For #8612 - toggle onboarding image using Nimbus

### DIFF
--- a/Client/Experiments/ExperimentConstants.swift
+++ b/Client/Experiments/ExperimentConstants.swift
@@ -8,6 +8,7 @@ import Foundation
 /// This is expected to grow and shrink across releases of the app.
 enum FeatureId: String {
     case nimbusValidation = "nimbus-validation"
+    case onboardingDefaultBrowser = "onboarding-default-browser"
 }
 
 /// A set of common branch ids used in experiments. Branch ids can be application/experiment specific, so
@@ -17,4 +18,5 @@ enum ExperimentBranch {
     static let a2 = "a2"
     static let control = "control"
     static let treatment = "treatment"
+    static let defaultBrowserTreatment = "defaultBrowserTreatment"
 }

--- a/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -181,8 +181,10 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
         updateTheme()
         
         // Initialize
-        self.view.addSubview(topImageView)
-        self.view.addSubview(imageText)
+        if viewModel.displayTitleImage {
+            self.view.addSubview(topImageView)
+            self.view.addSubview(imageText)
+        }
         self.view.addSubview(closeButton)
         textView.addSubview(containerView)
         containerView.addSubview(titleLabel)
@@ -214,25 +216,29 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
             make.right.equalToSuperview().inset(UpdateViewControllerUX.DoneButton.paddingRight)
             make.height.equalTo(44)
         }
-        // The top imageview constraints setup
-        topImageView.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.top.equalTo(closeButton.snp.bottom).offset(10)
-            make.height.equalTo(200)
-            make.width.equalTo(340)
-        }
-        let layoutDirection = UIApplication.shared.userInterfaceLayoutDirection
-        imageText.snp.makeConstraints { make in
-            make.top.equalTo(topImageView.snp.top).offset(121)
-            if layoutDirection == .leftToRight {
-                make.left.equalTo(topImageView.snp.left).inset(20)
-            } else {
-                make.right.equalTo(topImageView.snp.right).inset(20)
+        
+        if viewModel.displayTitleImage {
+            // The top imageview constraints setup
+            topImageView.snp.makeConstraints { make in
+                make.centerX.equalToSuperview()
+                make.top.equalTo(closeButton.snp.bottom).offset(10)
+                make.height.equalTo(200)
+                make.width.equalTo(340)
+            }
+            let layoutDirection = UIApplication.shared.userInterfaceLayoutDirection
+            imageText.snp.makeConstraints { make in
+                make.top.equalTo(topImageView.snp.top).offset(121)
+                if layoutDirection == .leftToRight {
+                    make.left.equalTo(topImageView.snp.left).inset(20)
+                } else {
+                    make.right.equalTo(topImageView.snp.right).inset(20)
+                }
             }
         }
         let textOffset = screenSize.height > 668 ? DBOnboardingUX.textOffset : DBOnboardingUX.textOffsetSmall
         textView.snp.makeConstraints { make in
-            make.top.equalTo(topImageView.snp.bottom).offset(textOffset)
+            let offset = viewModel.displayTitleImage ? textOffset : 10
+            make.top.equalTo(viewModel.displayTitleImage ? topImageView.snp.bottom : closeButton.snp.bottom).offset(offset)
             make.left.right.equalToSuperview().inset(36)
             make.bottom.equalTo(goToSettingsButton.snp.top)
         }
@@ -242,7 +248,12 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
                                   screenSize.height > 640 ? DBOnboardingUX.containerViewHeightSmall : DBOnboardingUX.containerViewHeightXSmall
         let containerViewWidth = screenSize.height > 668 ? 350 : 300
         containerView.snp.makeConstraints { make in
-            make.centerY.centerX.equalToSuperview()
+            if containerViewHeight <= DBOnboardingUX.containerViewHeightSmall {
+                make.centerY.equalToSuperview()
+            } else {
+                make.top.equalToSuperview()
+            }
+            make.centerX.equalToSuperview()
             make.height.equalTo(containerViewHeight)
             make.width.equalTo(containerViewWidth)
         }

--- a/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewModel.swift
+++ b/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewModel.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Shared
+import MozillaAppServices
 
 enum InstallType: String, Codable {
     case fresh
@@ -46,8 +47,12 @@ class DefaultBrowserOnboardingViewModel {
     //  Internal vars
     var model: DefaultBrowserOnboardingModel?
     var goToSettings: (() -> Void)?
+    private let experiments: NimbusApi
     
-    init() {
+    private(set) lazy var displayTitleImage = !(experiments.withVariables(featureId: .onboardingDefaultBrowser).getBool("should-hide-title-image") ?? false)
+    
+    init(experiments: NimbusApi = Experiments.shared) {
+        self.experiments = experiments
         setupUpdateModel()
     }
 


### PR DESCRIPTION
iOS:
<img width="550" alt="image" src="https://user-images.githubusercontent.com/1250545/121407405-1e4fb080-c914-11eb-9960-c54fd9ee4fee.png">
<img width="550" alt="image" src="https://user-images.githubusercontent.com/1250545/121407476-36273480-c914-11eb-8397-096ecd685582.png">


iPadOS:
<img width="790" alt="image" src="https://user-images.githubusercontent.com/1250545/121408138-ea28bf80-c914-11eb-91bf-4c450c66f02b.png">
<img width="790" alt="image" src="https://user-images.githubusercontent.com/1250545/121409038-e3e71300-c915-11eb-808c-f70c251db3cd.png">


