### PR TITLE
Fix Intermittent test failures

### DIFF
--- a/XCUITests/HomePageSettingsUITest.swift
+++ b/XCUITests/HomePageSettingsUITest.swift
@@ -42,6 +42,7 @@ class HomePageSettingsUITests: BaseTestCase {
 
     func testTyping() {
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(HomeSettings)
         // Enter a webpage
@@ -130,6 +131,7 @@ class HomePageSettingsUITests: BaseTestCase {
     func testSetFirefoxHomeAsHome() {
         // Start by setting to History since FF Home is default
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(HomeSettings)
         enterWebPageAsHomepage(text: websiteUrl1)
@@ -146,6 +148,7 @@ class HomePageSettingsUITests: BaseTestCase {
 
     func testSetCustomURLAsHome() {
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(HomeSettings)
         // Enter a webpage
@@ -166,6 +169,7 @@ class HomePageSettingsUITests: BaseTestCase {
     
     func testTopSitesCustomNumberOfRows() {
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         var topSitesPerRow:Int
         //Ensure testing in portrait mode

--- a/XCUITests/MailAppSettingsTests.swift
+++ b/XCUITests/MailAppSettingsTests.swift
@@ -7,6 +7,7 @@ import XCTest
 class MailAppSettingsTests: BaseTestCase {
     func testOpenMailAppSettings() {
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(OpenWithSettings)
 

--- a/XCUITests/NavigationTest.swift
+++ b/XCUITests/NavigationTest.swift
@@ -74,6 +74,7 @@ class NavigationTest: BaseTestCase {
 
     func testTapSignInShowsFxAFromTour() {
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         // Open FxAccount from tour option in settings menu and go throughout all the screens there
         navigator.goto(Intro_FxASignin)
@@ -88,6 +89,7 @@ class NavigationTest: BaseTestCase {
     
     func testTapSigninShowsFxAFromSettings() {
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)
         // Open FxAccount from settings menu and check the Sign in to Firefox scren
@@ -118,6 +120,7 @@ class NavigationTest: BaseTestCase {
 
     func testTapSignInShowsFxAFromRemoteTabPanel() {
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         // Open FxAccount from remote tab panel and check the Sign in to Firefox scren
         navigator.goto(TabTray)
@@ -394,6 +397,7 @@ class NavigationTest: BaseTestCase {
     // In this test, the parent window opens a child and in the child it creates a fake link 'link-created-by-parent'
     func testWriteToChildPopupTab() {
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)
         waitForExistence(app.tables["AppSettingsTableViewController.tableView"])

--- a/XCUITests/NewTabSettings.swift
+++ b/XCUITests/NewTabSettings.swift
@@ -39,6 +39,7 @@ class NewTabSettingsTest: BaseTestCase {
     func testChangeNewTabSettingsShowFirefoxHome() {
         // Set to history page first since FF Home is default
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.performAction(Action.SelectNewTabAsBlankPage)
         navigator.performAction(Action.OpenNewTabFromTabTray)

--- a/XCUITests/SaveLoginsTests.swift
+++ b/XCUITests/SaveLoginsTests.swift
@@ -37,8 +37,8 @@ class SaveLoginTest: BaseTestCase {
     
     func testLoginsListFromBrowserTabMenu() {
         navigator.performAction(Action.CloseURLBarOpen)
-        navigator.nowAt(NewTabScreen)
         waitForTabsButton()
+        navigator.nowAt(NewTabScreen)
         //Make sure you can access empty Login List from Browser Tab Menu
         navigator.goto(LoginsSettings)
         waitForExistence(app.tables["Login List"])
@@ -56,6 +56,7 @@ class SaveLoginTest: BaseTestCase {
     
     func testPasscodeLoginsListFromBrowserTabMenu() {
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.performAction(Action.SetPasscode)
         navigator.nowAt(PasscodeSettings)

--- a/XCUITests/SettingsTest.swift
+++ b/XCUITests/SettingsTest.swift
@@ -28,6 +28,7 @@ class SettingsTest: BaseTestCase {
 
     func testOpenSiriOption() {
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.performAction(Action.OpenSiriFromSettings)
         waitForExistence(app.buttons["Add to Siri"], timeout: 5)

--- a/XCUITests/SyncFAUITests.swift
+++ b/XCUITests/SyncFAUITests.swift
@@ -17,6 +17,7 @@ var code: String!
 class SyncUITests: BaseTestCase {
     func testUIFromSettings () {
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(FxASigninScreen)
         verifyFxASigninScreen()
@@ -25,6 +26,7 @@ class SyncUITests: BaseTestCase {
     func testSyncUIFromBrowserTabMenu() {
         // Check menu available from HomeScreenPanel
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(BrowserTabMenu)
         waitForExistence(app.tables["Context Menu"].cells["menu-sync"])
@@ -47,6 +49,7 @@ class SyncUITests: BaseTestCase {
 
     func testTypeOnGivenFields() {
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(FxASigninScreen)
         waitForExistence(app.navigationBars["Turn on Sync"], timeout: 60)
@@ -87,6 +90,7 @@ class SyncUITests: BaseTestCase {
     func testShowPassword() {
         // The aim of this test is to check if the option to show password is shown when user starts typing and dissapears when no password is typed
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(FxASigninScreen)
         waitForExistence(app.webViews.textFields["Email"], timeout: 20)
@@ -105,6 +109,7 @@ class SyncUITests: BaseTestCase {
     
     func testQRPairing() {
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(Intro_FxASignin)
         // QR does not work on sim but checking that the button works, no crash

--- a/XCUITests/ThirdPartySearchTest.swift
+++ b/XCUITests/ThirdPartySearchTest.swift
@@ -98,6 +98,7 @@ class ThirdPartySearchTest: BaseTestCase {
     
     private func addCustomSearchEngine() {
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.performAction(Action.AddCustomSearchEngine)
         waitForExistence(app.buttons["customEngineSaveButton"], timeout: 3)
@@ -117,6 +118,7 @@ class ThirdPartySearchTest: BaseTestCase {
 
     func testCustomEngineFromIncorrectTemplate() {
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(AddCustomSearchSettings)
         app.textViews["customEngineTitle"].tap()

--- a/XCUITests/ToolbarTest.swift
+++ b/XCUITests/ToolbarTest.swift
@@ -26,6 +26,7 @@ class ToolbarTests: BaseTestCase {
     func testLandscapeNavigationWithTabSwitch() {
         waitForExistence(app.textFields["url"], timeout: 5)
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         let urlPlaceholder = "Search or enter address"
         XCTAssert(app.textFields["url"].exists)
         let defaultValuePlaceholder = app.textFields["url"].placeholderValue!

--- a/XCUITests/TopTabsTest.swift
+++ b/XCUITests/TopTabsTest.swift
@@ -266,9 +266,10 @@ class TopTabsTest: BaseTestCase {
     // Smoketest
     func testLongTapTabCounter() {
         if !iPad() {
-            waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
+            waitForExistence(app.buttons["urlBar-cancel"], timeout: 10)
             // Long tap on Tab Counter should show the correct options
             navigator.performAction(Action.CloseURLBarOpen)
+            waitForTabsButton()
             navigator.nowAt(NewTabScreen)
             waitForExistence(app.buttons["Show Tabs"], timeout: 10)
             app.buttons["Show Tabs"].press(forDuration: 1)
@@ -288,6 +289,7 @@ class TopTabsTest: BaseTestCase {
             // Close tab
             navigator.nowAt(HomePanelsScreen)
             navigator.performAction(Action.CloseURLBarOpen)
+            waitForTabsButton()
             navigator.nowAt(NewTabScreen)
 
             waitForExistence(app.buttons["Show Tabs"])
@@ -295,6 +297,7 @@ class TopTabsTest: BaseTestCase {
             waitForExistence(app.cells["quick_action_new_tab"])
             app.cells["tab_close"].tap()
             navigator.performAction(Action.CloseURLBarOpen)
+            waitForTabsButton()
             navigator.nowAt(NewTabScreen)
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
 
@@ -303,12 +306,14 @@ class TopTabsTest: BaseTestCase {
             app.cells.staticTexts["Home"].firstMatch.tap()
             navigator.nowAt(HomePanelsScreen)
             navigator.performAction(Action.CloseURLBarOpen)
+            waitForTabsButton()
             navigator.nowAt(NewTabScreen)
             waitForExistence(app.buttons["Show Tabs"])
             app.buttons["Show Tabs"].press(forDuration: 1)
             waitForExistence(app.cells["nav-tabcounter"])
             app.cells["nav-tabcounter"].tap()
             navigator.performAction(Action.CloseURLBarOpen)
+            waitForTabsButton()
             navigator.nowAt(NewTabScreen)
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
         }
@@ -336,28 +341,26 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
 
     func testCloseTabFromLongPressTabsButton() {
         if skipPlatform { return }
-        navigator.goto(URLBarOpen)
-        navigator.back()
+        navigator.performAction(Action.CloseURLBarOpen)
         waitForTabsButton()
         // This menu is available in HomeScreen or NewTabScreen, so no need to open new websites
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.performAction(Action.CloseURLBarOpen)
-        navigator.nowAt(NewTabScreen)
         waitForTabsButton()
+        navigator.nowAt(NewTabScreen)
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
         closeTabTrayView(goBackToBrowserTab: "Home")
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.performAction(Action.CloseTabFromTabTrayLongPressMenu)
         navigator.performAction(Action.CloseURLBarOpen)
-        navigator.nowAt(NewTabScreen)
         waitForTabsButton()
+        navigator.nowAt(NewTabScreen)
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
         closeTabTrayView(goBackToBrowserTab: "Home")
         navigator.performAction(Action.CloseURLBarOpen)
-        navigator.nowAt(NewTabScreen)
-        navigator.performAction(Action.CloseTabFromTabTrayLongPressMenu)
-        navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)

--- a/XCUITests/TopTabsTest.swift
+++ b/XCUITests/TopTabsTest.swift
@@ -269,8 +269,8 @@ class TopTabsTest: BaseTestCase {
             waitForExistence(app.buttons["urlBar-cancel"], timeout: 10)
             // Long tap on Tab Counter should show the correct options
             navigator.performAction(Action.CloseURLBarOpen)
-            waitForTabsButton()
             navigator.nowAt(NewTabScreen)
+            waitForNoExistence(app.keyboards.buttons.element(boundBy: 0), timeoutValue: 10)
             waitForExistence(app.buttons["Show Tabs"], timeout: 10)
             app.buttons["Show Tabs"].press(forDuration: 1)
             waitForExistence(app.cells["quick_action_new_tab"])
@@ -282,6 +282,8 @@ class TopTabsTest: BaseTestCase {
             navigator.performAction(Action.CloseURLBarOpen)
 
             waitForTabsButton()
+            navigator.nowAt(NewTabScreen)
+            waitForNoExistence(app.keyboards.buttons.element(boundBy: 0), timeoutValue: 10)
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
             waitForExistence(app.cells.staticTexts["Home"])
             app.cells.staticTexts["Home"].firstMatch.tap()
@@ -290,6 +292,7 @@ class TopTabsTest: BaseTestCase {
             navigator.nowAt(HomePanelsScreen)
             navigator.performAction(Action.CloseURLBarOpen)
             waitForTabsButton()
+            waitForNoExistence(app.keyboards.buttons.element(boundBy: 0), timeoutValue: 10)
             navigator.nowAt(NewTabScreen)
 
             waitForExistence(app.buttons["Show Tabs"])
@@ -298,6 +301,7 @@ class TopTabsTest: BaseTestCase {
             app.cells["tab_close"].tap()
             navigator.performAction(Action.CloseURLBarOpen)
             waitForTabsButton()
+            waitForNoExistence(app.keyboards.buttons.element(boundBy: 0), timeoutValue: 10)
             navigator.nowAt(NewTabScreen)
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
 
@@ -314,6 +318,7 @@ class TopTabsTest: BaseTestCase {
             app.cells["nav-tabcounter"].tap()
             navigator.performAction(Action.CloseURLBarOpen)
             waitForTabsButton()
+            waitForNoExistence(app.keyboards.buttons.element(boundBy: 0), timeoutValue: 10)
             navigator.nowAt(NewTabScreen)
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
         }
@@ -343,10 +348,12 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
         if skipPlatform { return }
         navigator.performAction(Action.CloseURLBarOpen)
         waitForTabsButton()
+        waitForNoExistence(app.keyboards.buttons.element(boundBy: 0), timeoutValue: 10)
         // This menu is available in HomeScreen or NewTabScreen, so no need to open new websites
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.performAction(Action.CloseURLBarOpen)
         waitForTabsButton()
+        waitForNoExistence(app.keyboards.buttons.element(boundBy: 0), timeoutValue: 10)
         navigator.nowAt(NewTabScreen)
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
         closeTabTrayView(goBackToBrowserTab: "Home")
@@ -363,6 +370,7 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
         waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
+        waitForNoExistence(app.keyboards.buttons.element(boundBy: 0), timeoutValue: 10)
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
         closeTabTrayView(goBackToBrowserTab: "Home")
     }


### PR DESCRIPTION
This PR tries to fix the intermittent issue affecting tests in smoke and general suites when trying to tap on the browser tab menu when that option is still not visible, the url bar has not been closed or the keyboard has not been dismissed yet

