### PR TITLE
FXIOS-1938: BR and XCode 12.5 optimized builds fix

### DIFF
--- a/Shared/effective_tld_names.swift
+++ b/Shared/effective_tld_names.swift
@@ -2,7 +2,17 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-let ETLD_NAMES_LIST = [
+let ETLD_NAMES_LIST: [String] = {
+    // The Swift compiler (as of Xcode 12.5) will crash during optimised builds if ETLD_NAMES_LIST is a single array.
+    // It is happy to build it this way though.
+    var combined = ETLD_NAMES_LIST_PART_1! + ETLD_NAMES_LIST_PART_2!
+    // Free up the parts now as we never need them again and they are just wasting memory
+    ETLD_NAMES_LIST_PART_1 = nil
+    ETLD_NAMES_LIST_PART_2 = nil
+    return combined
+}()
+
+fileprivate var ETLD_NAMES_LIST_PART_1: [String]? = [
    "ac",
    "com.ac",
    "edu.ac",
@@ -4996,7 +5006,10 @@ let ETLD_NAMES_LIST = [
    "school.nz",
    "om",
    "co.om",
-   "com.om",
+   "com.om"
+]
+
+fileprivate var ETLD_NAMES_LIST_PART_2: [String]? = [
    "edu.om",
    "gov.om",
    "med.om",

--- a/ThirdParty/Deferred/Deferred/ReadWriteLock.swift
+++ b/ThirdParty/Deferred/Deferred/ReadWriteLock.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol ReadWriteLock: class {
+public protocol ReadWriteLock: AnyObject {
     func withReadLock<T>(block: () -> T) -> T
     func withWriteLock<T>(block: () -> T) -> T
 }


### PR DESCRIPTION
As someone pointed out in another ticket XCode 12.5 has made changes due to which one single array crashes during compile time. 

This is the same culprit for BR builds failure. 

I checked this patch in BR and it archived our Firefox iOS app. See log below. Ignore the error for Firefox Beta as that is an upload error and not related to compiling.

https://app.bitrise.io/build/91737fcf18546dbf#?tab=log

cc https://github.com/mozilla-mobile/firefox-ios/issues/8674