### PR TITLE
For #8617 - Use constraints to size the headers of the activity stream

### DIFF
--- a/Client/Frontend/Home/ASHeaderView.swift
+++ b/Client/Frontend/Home/ASHeaderView.swift
@@ -67,6 +67,7 @@ class ASHeaderView: UICollectionReusableView {
         }
         moreButton.setContentCompressionResistancePriority(.required, for: .horizontal)
         titleLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(10)
             make.leading.equalTo(self.safeArea.leading).inset(titleInsets)
             make.trailing.equalTo(moreButton.snp.leading).inset(-FirefoxHomeHeaderViewUX.TitleTopInset)
             

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -441,14 +441,28 @@ extension FirefoxHomeViewController: UICollectionViewDelegateFlowLayout {
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+        
+        let indexPath = IndexPath(row: 0, section: section)
+        let headerView = self.collectionView(
+            collectionView,
+            viewForSupplementaryElementOfKind: UICollectionView.elementKindSectionHeader,
+            at: indexPath
+        )
+
+        let recommendedSize: CGSize
         switch Section(section) {
         case .pocket:
-            return pocketStories.isEmpty ? .zero : Section(section).headerHeight
+            guard !pocketStories.isEmpty else { return .zero }
+            recommendedSize = Section(section).headerHeight
         case .topSites:
-            return Section(section).headerHeight
+            recommendedSize = Section(section).headerHeight
         case .libraryShortcuts:
-            return UIDevice.current.userInterfaceIdiom == .pad ? CGSize.zero : Section(section).headerHeight
+            guard UIDevice.current.userInterfaceIdiom != .pad else { return .zero }
+            recommendedSize =  Section(section).headerHeight
         }
+        
+        // Take constraints into account when sizing the header
+        return headerView.systemLayoutSizeFitting(recommendedSize)
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {


### PR DESCRIPTION
<img width="741" alt="image" src="https://user-images.githubusercontent.com/1250545/121628372-ee94cb80-ca2d-11eb-92ae-7c0cd370db6f.png">

<img width="741" alt="image" src="https://user-images.githubusercontent.com/1250545/121628418-079d7c80-ca2e-11eb-8f05-a7dbc6b8a39a.png">


before:

<img width="785" alt="image" src="https://user-images.githubusercontent.com/1250545/121627733-c062bc00-ca2c-11eb-883e-ebed8b22205e.png">
