### PR TITLE
[Fix] FXIOS-1946: Firefox home overlay mode wasn't being presented 

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -916,7 +916,7 @@ class BrowserViewController: UIViewController {
 
     func finishEditingAndSubmit(_ url: URL, visitType: VisitType, forTab tab: Tab) {
         urlBar.currentURL = url
-        urlBar.leaveOverlayMode(didCancel: true)
+        urlBar.leaveOverlayMode()
 
         if let nav = tab.loadRequest(URLRequest(url: url)) {
             self.recordNavigationInTab(tab, navigation: nav, visitType: visitType)
@@ -1548,11 +1548,6 @@ extension BrowserViewController: LibraryPanelDelegate {
 }
 
 extension BrowserViewController: HomePanelDelegate {
-    func homePanelDidScroll() {
-        guard urlBar.inOverlayMode else { return }
-        urlBar.leaveOverlayMode()
-    }
-    
     func homePanelDidRequestToOpenLibrary(panel: LibraryPanelType) {
         showLibrary(panel: panel)
         view.endEditing(true)
@@ -2314,6 +2309,7 @@ extension BrowserViewController: DevicePickerViewControllerDelegate, Instruction
 // MARK: - reopen last closed tab
 
 extension BrowserViewController {
+
     override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
         if AppConstants.MOZ_SHAKE_TO_RESTORE {
                 homePanelDidRequestToRestoreClosedTab(motion)

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -58,7 +58,6 @@ protocol HomePanelDelegate: AnyObject {
     func homePanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool)
     func homePanel(didSelectURL url: URL, visitType: VisitType, isGoogleTopSite: Bool)
     func homePanelDidRequestToOpenLibrary(panel: LibraryPanelType)
-    func homePanelDidScroll()
 }
 
 protocol HomePanel: Themeable {
@@ -380,9 +379,6 @@ extension FirefoxHomeViewController {
 
 // MARK: -  Tableview Delegate
 extension FirefoxHomeViewController: UICollectionViewDelegateFlowLayout {
-    override func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        homePanelDelegate?.homePanelDidScroll()
-    }
 
     override func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         switch kind {


### PR DESCRIPTION
Revert "Fix #7608 - Leaves overlay mode when homepanel is scrolled (#8618)

Had to revert above commit as `scrollViewDidScroll` gets called first time when HomeViewController is loaded and causes BVC to be in a weird state. 