### PR TITLE
Update env in build-contributor-pr.yml

### DIFF
--- a/.github/workflows/build-contributor-pr.yml
+++ b/.github/workflows/build-contributor-pr.yml
@@ -4,12 +4,12 @@ on: [pull_request]
 jobs:
   run-ui:
     if: github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: macos-latest
+    runs-on: macos-11
     timeout-minutes: 60
     strategy:
       matrix:
         python-version: [3.9]
-        xcode: [12.4]
+        xcode: [12.5]
         run-config: 
         - { scheme: 'Fennec_Enterprise_XCUITests', destination: 'platform=iOS Simulator,OS=latest,name=iPhone 11', testplan: 'SmokeXCUITests' }
     name: Run UI Smoketests


### PR DESCRIPTION
- Updates worker to macOS 11 and Xcode 12.5

Since Mozilla-mobile is part of [mozilla-corporation enterprise on Github,](https://github.com/enterprises/mozilla-corporation) I think we can run macOS 11 ahead of their public roll-out. I'll try it out here. (@isabelrios this can land, and then I can re-enable the workflow and if it fails I'll re-disable it in the Actions menu).

> The macOS 11 virtual environment is currently in preview and is automatically available to the existing Enterprise plan customers who used macOS hosted runners at least once between May, 1 - June, 1. New Enterprise plan customers, or customers on other plans, should fill the form to request access to macOS 11 virtual environment. Please view our Big Sur guide for more details. 
The macos-latest YAML workflow label still uses the macOS 10.15 virtual environment.

As for public macOS 11 release (which has Xcode 12.5).

> @AaronMT not earlier than it goes out of preview. I'd say approximately transition will take place at the end of summer - mid of the fall, we are working on the plan.