### PR TITLE
Update data type for `RemoteTabs` `lastUsed` field for `TabsSynchronizer`

### DIFF
--- a/Shared/TimeConstants.swift
+++ b/Shared/TimeConstants.swift
@@ -213,3 +213,8 @@ public func millisecondsToDecimalSeconds(_ input: Timestamp) -> String {
     let val = Double(input) / 1000
     return String(format: "%.2F", val)
 }
+
+public func millisecondsToSeconds(_ input: Timestamp) -> UInt64 {
+    let val = input / 1000
+    return val
+}

--- a/Sync/Synchronizers/TabsSynchronizer.swift
+++ b/Sync/Synchronizers/TabsSynchronizer.swift
@@ -199,7 +199,7 @@ extension RemoteTab {
             "title": title,
             "icon": icon?.absoluteString as Any? ?? NSNull(),
             "urlHistory": tabHistory,
-            "lastUsed": millisecondsToDecimalSeconds(lastUsed)
+            "lastUsed": millisecondsToSeconds(lastUsed)
         ]
     }
 }


### PR DESCRIPTION
This change fixes #8726 by updating the data type of the `RemoteTabs` `lastUsed` property from a stringified float to an integer during sync so that tab records conform with the expected schema in app services.