### PR TITLE
Xcuitests disable intermittents

### DIFF
--- a/XCUITests/AuthenticationTest.swift
+++ b/XCUITests/AuthenticationTest.swift
@@ -57,9 +57,10 @@ class AuthenticationTest: BaseTestCase {
         waitForExistence(springboard.icons["XCUITests-Runner"], timeout: 10)
         app.activate()
 
+        // Disable this part do to Issue 8333
         // Need to be sure the app is ready
-        navigator.nowAt(LockedLoginsSettings)
-        waitForExistence(app.navigationBars["Enter Passcode"], timeout: 10)
+        // navigator.nowAt(LockedLoginsSettings)
+        // waitForExistence(app.navigationBars["Enter Passcode"], timeout: 10)
     }
 
     func testPromptPassCodeUponReentryWithDelay() {

--- a/XCUITests/DownloadFilesTests.swift
+++ b/XCUITests/DownloadFilesTests.swift
@@ -45,9 +45,10 @@ class DownloadFilesTests: BaseTestCase {
         waitUntilPageLoad()
         // Verify that the context menu prior to download a file is correct
         app.webViews.staticTexts[testFileName].firstMatch.tap()
+        waitForExistence(app.webViews.buttons["Download"], timeout: 3)
         app.webViews.buttons["Download"].tap()
 
-        waitForExistence(app.tables["Context Menu"])
+        waitForExistence(app.tables["Context Menu"], timeout: 5)
         XCTAssertTrue(app.tables["Context Menu"].staticTexts[testFileName].exists)
         XCTAssertTrue(app.tables["Context Menu"].cells["download"].exists)
         app.buttons["Cancel"].tap()

--- a/XCUITests/PhotonActionSheetTest.swift
+++ b/XCUITests/PhotonActionSheetTest.swift
@@ -53,7 +53,7 @@ class PhotonActionSheetTest: BaseTestCase {
         pageObjectButtonCenter.press(forDuration: 1)
 
         // Wait to see the Share options sheet
-        waitForExistence(app.buttons["Copy"], timeout: 15)
+        // waitForExistence(app.buttons["Copy"], timeout: 15)
     }
 
     func testSendToDeviceFromPageOptionsMenu() {

--- a/XCUITests/ScreenGraphTest.swift
+++ b/XCUITests/ScreenGraphTest.swift
@@ -77,7 +77,8 @@ extension ScreenGraphTest {
         XCTAssertEqual(navigator.screenState, BrowserTabMenu)
     }
 
-    func testChainedActionPerf1() {
+    func testChainedActionPerf1() throws {
+        throw XCTSkip("Skipping this test due intermittent failures")
         let navigator = self.navigator!
         measure {
             navigator.userState.url = defaultURL
@@ -216,7 +217,6 @@ fileprivate func createTestGraph(for test: XCTestCase, with app: XCUIApplication
         screenState.gesture(forAction: TestActions.LoadURLByPasting, TestActions.LoadURL) { userState in
             UIPasteboard.general.string = userState.url ?? defaultURL
             app.textFields["url"].press(forDuration: 1.0)
-            print(app.debugDescription)
             app.tables["Context Menu"].cells["menu-PasteAndGo"].tap()
         }
     }

--- a/XCUITests/SmokeXCUITests.xctestplan
+++ b/XCUITests/SmokeXCUITests.xctestplan
@@ -73,6 +73,7 @@
         "FirstRunTourTests\/testShowTourFromSettings()",
         "FirstRunTourTests\/testStartBrowsingFromSecondScreen()",
         "FxScreenGraphTests",
+        "HistoryTests\/testAllOptionsArePresent()",
         "HistoryTests\/testClearHistoryFromSettings()",
         "HistoryTests\/testClearRecentHistory()",
         "HistoryTests\/testClearRecentlyClosedHistory()",


### PR DESCRIPTION
- Fixes #8333 by commenting the last part of the test. It fails when checking the app once it is backgrounded and foregrounded again
- Disable one test from the Smoketest plan as it is running as part as the Full Test Plan
- Add extra check for download test that has [failed](https://app.bitrise.io/build/82b2d0cccd166093#?tab=log) a few times as part as the Full Test Plan