### PR TITLE
Sync Int tests fix indentation error

### DIFF
--- a/SyncIntegrationTests/test_integration.py
+++ b/SyncIntegrationTests/test_integration.py
@@ -34,6 +34,6 @@ def test_sync_tabs_from_desktop(tps, xcodebuild):
 def test_sync_disconnect_connect_fxa(tps, xcodebuild):
     tps.run('test_bookmark_login.js')
     xcodebuild.test('XCUITests/IntegrationTests/testFxADisconnectConnect')
- 
- def test_sync_china_fxa_server(xcodebuild):
+
+def test_sync_china_fxa_server(xcodebuild):
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncPageUsingChinaFxA')


### PR DESCRIPTION
I made an indentation mistake when finally enabling this test
