### PR TITLE
Fix sync int tests for fxa china server

### DIFF
--- a/XCUITests/IntegrationTests.swift
+++ b/XCUITests/IntegrationTests.swift
@@ -80,7 +80,7 @@ class IntegrationTests: BaseTestCase {
         navigator.goto(Intro_FxASignin)
         navigator.performAction(Action.OpenEmailToSignIn)
         waitForExistence(app.navigationBars["Turn on Sync"], timeout: 20)
-        waitForExistence(app.webViews.textFields["Email"])
+        waitForExistence(app.webViews.textFields["Email"], timeout: 20)
 
         // Wait for element not present on FxA sign in page China FxA server
         waitForNoExistence(app.webViews.otherElements.staticTexts["Firefox Monitor"])


### PR DESCRIPTION
Adding a timeout to be sure the FxA sign in page is loaded