### PR TITLE
WIP: Test for MacOS11 runner on Github Actions

### DIFF
--- a/.github/workflows/macOS-11-test.yml
+++ b/.github/workflows/macOS-11-test.yml
@@ -1,0 +1,12 @@
+name: CI
+on:
+  pull_request:
+    branches: [ main ]
+jobs:
+  build:
+    runs-on: macos-11
+    steps:
+      - uses: actions/checkout@v2
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!


### PR DESCRIPTION
The MacOS11 runners are in private pool but it should be available to the mozilla org with sign-up (which I submitted). This tests if the MacOS11 runner is available.