### PR TITLE
Debugging load WebView link addresses

### DIFF
--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
 	<key>AppIdentifierPrefix</key>
 	<string>$(APP_IDENTIFIER_PREFIX)</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>


### PR DESCRIPTION
Debugging load WebView link addresses when throws the following exception: Error Domain=NSURLErrorDomain Code=-1022
Given URL can not be loaded because the application transport security policy requires a secure connection. That changed after iOS9 http protocol https security protocol.