### PR TITLE
Run taskgraph generation with Python 3

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -257,7 +257,6 @@ tasks:
                                             ~/.local/bin/taskgraph action-callback
                                         else: >
                                             PIP_IGNORE_INSTALLED=0 pip install --user /builds/worker/checkouts/taskgraph &&
-                                            PIP_IGNORE_INSTALLED=0 pip install --user chunkify &&
                                             ln -s /builds/worker/artifacts artifacts &&
                                             ~/.local/bin/taskgraph decision
                                             --pushlog-id='0'

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -252,11 +252,11 @@ tasks:
                                     in:
                                         $if: 'tasks_for == "action"'
                                         then: >
-                                            PIP_IGNORE_INSTALLED=0 pip install --user /builds/worker/checkouts/taskgraph &&
+                                            PIP_IGNORE_INSTALLED=0 pip3 install --user /builds/worker/checkouts/taskgraph &&
                                             ln -s /builds/worker/artifacts artifacts &&
                                             ~/.local/bin/taskgraph action-callback
                                         else: >
-                                            PIP_IGNORE_INSTALLED=0 pip install --user /builds/worker/checkouts/taskgraph &&
+                                            PIP_IGNORE_INSTALLED=0 pip3 install --user /builds/worker/checkouts/taskgraph &&
                                             ln -s /builds/worker/artifacts artifacts &&
                                             ~/.local/bin/taskgraph decision
                                             --pushlog-id='0'

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -7,7 +7,7 @@ tasks:
     - $let:
           taskgraph:
               branch: taskgraph
-              revision: cab4565345d0d0effa66f18fe91335dd6d744031
+              revision: 81f2a1a09e9b0fc1b6c66fd452e065440793c175
           trustDomain: mobile
       in:
           $let:
@@ -235,7 +235,7 @@ tasks:
                               # Note: This task is built server side without the context or tooling that
                               # exist in tree so we must hard code the hash
                               image:
-                                  mozillareleases/taskgraph:decision-mobile-6607973bc60e32323a541861cc5856cd6a0f51ea9fd664ef7d43bca8df53db47@sha256:8c471aacc469ea8e7bb4846c16efe086f7350a5cc1df570cc6c86b22895a2456
+                                  mozillareleases/taskgraph:decision-mobile-44b6b7b4c370220eff56efa8b508aa5157ef9c6e74847c7ecc19d640946ba49e@sha256:4107cbc5e154502529e4d38efa4dc89c05ee54e2cbc6e2e66023e68407502894
 
                               maxRunTime: 1800
 
@@ -280,6 +280,14 @@ tasks:
                                       type: 'directory'
                                       path: '/builds/worker/artifacts'
                                       expires: {$fromNow: '1 year'}
+                                  'public/docker-contexts':
+                                      type: 'directory'
+                                      path: '/builds/worker/checkouts/src/docker-contexts'
+                                      # This needs to be at least the deadline of the
+                                      # decision task + the docker-image task deadlines.
+                                      # It is set to a week to allow for some time for
+                                      # debugging, but they are not useful long-term.
+                                      expires: {$fromNow: '7 day'}
 
                           extra:
                               $merge:

--- a/taskcluster/ffios_taskgraph/__init__.py
+++ b/taskcluster/ffios_taskgraph/__init__.py
@@ -2,15 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
-import os
-import re
-
 from importlib import import_module
-from six import text_type
-from voluptuous import All, Any, Range, Required
-
-from taskgraph.parameters import extend_parameters_schema
 
 
 def register(graph_config):

--- a/taskcluster/ffios_taskgraph/__init__.py
+++ b/taskcluster/ffios_taskgraph/__init__.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 import re
@@ -24,4 +23,4 @@ def register(graph_config):
 
 def _import_modules(modules):
     for module in modules:
-        import_module(".{}".format(module), package=__name__)
+        import_module(f".{module}", package=__name__)

--- a/taskcluster/ffios_taskgraph/job.py
+++ b/taskcluster/ffios_taskgraph/job.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 from taskgraph.transforms.job import run_job_using, configure_taskdesc_for_run
 from taskgraph.util import path
@@ -13,23 +12,23 @@ from six import text_type
 from pipes import quote as shell_quote
 
 secret_schema = {
-    Required("name"): text_type,
-    Required("path"): text_type,
-    Required("key"): text_type,
+    Required("name"): str,
+    Required("path"): str,
+    Required("key"): str,
     Optional("json"): bool,
 }
 
 dummy_secret_schema = {
-    Required("content"): text_type,
-    Required("path"): text_type,
+    Required("content"): str,
+    Required("path"): str,
     Optional("json"): bool,
 }
 
 run_commands_schema = Schema({
     Required("using"): "run-commands",
-    Optional("pre-commands"): [[text_type]],
+    Optional("pre-commands"): [[str]],
     Required("commands"): [[taskref_or_string]],
-    Required("workdir"): text_type,
+    Required("workdir"): str,
     Optional("use-caches"): bool,
     Optional("secrets"): [secret_schema],
     Optional("dummy-secrets"): [dummy_secret_schema],
@@ -98,7 +97,7 @@ def _convert_commands_to_string(commands):
                     part_string = part["task-reference"]
                     should_task_reference = True
                 else:
-                    raise ValueError('Unsupported dict: {}'.format(part))
+                    raise ValueError(f'Unsupported dict: {part}')
             else:
                 part_string = part
 

--- a/taskcluster/ffios_taskgraph/job.py
+++ b/taskcluster/ffios_taskgraph/job.py
@@ -4,10 +4,8 @@
 
 
 from taskgraph.transforms.job import run_job_using, configure_taskdesc_for_run
-from taskgraph.util import path
 from taskgraph.util.schema import Schema, taskref_or_string
 from voluptuous import Required, Optional
-from six import text_type
 
 from pipes import quote as shell_quote
 

--- a/taskcluster/ffios_taskgraph/loader/screenshots_locales.py
+++ b/taskcluster/ffios_taskgraph/loader/screenshots_locales.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-import os
-from copy import deepcopy
 from math import log, ceil
 
 from taskgraph.loader.transform import loader as base_loader

--- a/taskcluster/ffios_taskgraph/loader/screenshots_locales.py
+++ b/taskcluster/ffios_taskgraph/loader/screenshots_locales.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import print_function, unicode_literals
 
 import os
 from copy import deepcopy

--- a/taskcluster/ffios_taskgraph/loader/screenshots_locales.py
+++ b/taskcluster/ffios_taskgraph/loader/screenshots_locales.py
@@ -5,11 +5,11 @@
 from __future__ import print_function, unicode_literals
 
 import os
-
 from copy import deepcopy
-from chunkify import chunkify
 from math import log, ceil
+
 from taskgraph.loader.transform import loader as base_loader
+from ffios_taskgraph.util.chunkify import chunkify
 
 from ..screenshots_locales import get_screenshots_locales
 

--- a/taskcluster/ffios_taskgraph/routes.py
+++ b/taskcluster/ffios_taskgraph/routes.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 import time
 

--- a/taskcluster/ffios_taskgraph/screenshots_locales.py
+++ b/taskcluster/ffios_taskgraph/screenshots_locales.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 import yaml

--- a/taskcluster/ffios_taskgraph/screenshots_locales.py
+++ b/taskcluster/ffios_taskgraph/screenshots_locales.py
@@ -2,11 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
 import os
 import yaml
 
 from taskgraph.util.memoize import memoize
+
 
 @memoize
 def get_screenshots_locales():

--- a/taskcluster/ffios_taskgraph/target_tasks.py
+++ b/taskcluster/ffios_taskgraph/target_tasks.py
@@ -14,4 +14,4 @@ def target_tasks_default(full_task_graph, parameters, graph_config):
     def filter(task, parameters):
         return task.kind == "generate-screenshots"
 
-    return [l for l, t in full_task_graph.tasks.iteritems() if filter(t, parameters)]
+    return [l for l, t in full_task_graph.tasks.items() if filter(t, parameters)]

--- a/taskcluster/ffios_taskgraph/target_tasks.py
+++ b/taskcluster/ffios_taskgraph/target_tasks.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-from taskgraph.target_tasks import _target_task, filter_for_tasks_for
+from taskgraph.target_tasks import _target_task
 
 
 @_target_task('l10n_screenshots')

--- a/taskcluster/ffios_taskgraph/target_tasks.py
+++ b/taskcluster/ffios_taskgraph/target_tasks.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 from taskgraph.target_tasks import _target_task, filter_for_tasks_for
 

--- a/taskcluster/ffios_taskgraph/transforms/bitrise.py
+++ b/taskcluster/ffios_taskgraph/transforms/bitrise.py
@@ -5,7 +5,6 @@
 Resolve secrets and dummy secrets
 """
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 from taskgraph.transforms.base import TransformSequence
 
@@ -56,14 +55,14 @@ def set_worker_config(config, tasks):
         artifacts.append({
             "type": "file",
             "name": "public/logs/bitrise.log",
-            "path": "{}/bitrise.log".format(_ARTIFACTS_DIRECTORY),
+            "path": f"{_ARTIFACTS_DIRECTORY}/bitrise.log",
         })
 
         for locale in task["attributes"]["chunk_locales"]:
             artifacts.append({
                 "type": "file",
-                "name": "public/screenshots/{}.zip".format(locale),
-                "path": "{}/{}.zip".format(_ARTIFACTS_DIRECTORY, locale),
+                "name": f"public/screenshots/{locale}.zip",
+                "path": f"{_ARTIFACTS_DIRECTORY}/{locale}.zip",
             })
 
         worker.setdefault("docker-image", {"in-tree": "screenshots"})

--- a/taskcluster/ffios_taskgraph/transforms/secrets.py
+++ b/taskcluster/ffios_taskgraph/transforms/secrets.py
@@ -5,7 +5,6 @@
 Resolve secrets and dummy secrets
 """
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 from taskgraph.transforms.base import TransformSequence
 from taskgraph.util.schema import resolve_keyed_by

--- a/taskcluster/ffios_taskgraph/util/chunkify.py
+++ b/taskcluster/ffios_taskgraph/util/chunkify.py
@@ -1,0 +1,51 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from itertools import islice
+
+
+class ChunkingError(Exception):
+    pass
+
+
+def split_evenly(n, chunks):
+    """Split an integer into evenly distributed list
+
+    >>> split_evenly(7, 3)
+    [3, 2, 2]
+
+    >>> split_evenly(12, 3)
+    [4, 4, 4]
+
+    >>> split_evenly(35, 10)
+    [4, 4, 4, 4, 4, 3, 3, 3, 3, 3]
+
+    >>> split_evenly(1, 2)
+    Traceback (most recent call last):
+        ...
+    ChunkingError: Number of chunks is greater than number
+
+    """
+    if n < chunks:
+        raise ChunkingError("Number of chunks is greater than number")
+    if n % chunks == 0:
+        # Either we can evenly split or only 1 chunk left
+        return [n / chunks] * chunks
+    # otherwise the current chunk should be a bit larger
+    max_size = n / chunks + 1
+    return [max_size] + split_evenly(n - max_size, chunks - 1)
+
+
+def chunkify(things, this_chunk, chunks):
+    if this_chunk > chunks:
+        raise ChunkingError("this_chunk is greater than total chunks")
+
+    dist = split_evenly(len(things), chunks)
+    start = sum(dist[:this_chunk-1])
+    end = start + dist[this_chunk-1]
+
+    try:
+        return things[start:end]
+    except TypeError:
+        return islice(things, start, end)

--- a/taskcluster/ffios_taskgraph/util/chunkify.py
+++ b/taskcluster/ffios_taskgraph/util/chunkify.py
@@ -31,9 +31,9 @@ def split_evenly(n, chunks):
         raise ChunkingError("Number of chunks is greater than number")
     if n % chunks == 0:
         # Either we can evenly split or only 1 chunk left
-        return [n / chunks] * chunks
+        return [n // chunks] * chunks
     # otherwise the current chunk should be a bit larger
-    max_size = n / chunks + 1
+    max_size = n // chunks + 1
     return [max_size] + split_evenly(n - max_size, chunks - 1)
 
 

--- a/taskcluster/scripts/bitrise-schedule.py
+++ b/taskcluster/scripts/bitrise-schedule.py
@@ -88,11 +88,11 @@ async def async_main(token, branch, commit, workflow, artifacts_directory, local
     headers = {"Authorization": token}
     async with RetryClient(headers=headers) as client:
         build_slug = await schedule_build(client, branch, commit, workflow, locales, derived_data_path)
-        log.info("Created new job. Slug: {}".format(build_slug))
+        log.info(f"Created new job. Slug: {build_slug}")
 
         try:
             await wait_for_job_to_finish(client, build_slug)
-            log.info("Job {} is successful. Retrieving artifacts...".format(build_slug))
+            log.info(f"Job {build_slug} is successful. Retrieving artifacts...")
             await download_artifacts(client, build_slug, artifacts_directory)
         finally:
             log.info("Retrieving bitrise log...")
@@ -126,34 +126,34 @@ async def schedule_build(client, branch, commit, workflow, locales, derived_data
 
     response = await do_http_request_json(client, url, method="post", json=data)
     if response.get("status", "") != "ok":
-        raise Exception("Bitrise status is not ok. Got: {}".format(response))
+        raise Exception(f"Bitrise status is not ok. Got: {response}")
 
     return response["build_slug"]
 
 
 async def wait_for_job_to_finish(client, build_slug):
-    suffix = "builds/{}".format(build_slug)
+    suffix = f"builds/{build_slug}"
     url = BITRISE_URL_TEMPLATE.format(suffix=suffix)
 
     while True:
         response = await do_http_request_json(client, url)
         if response["data"]["finished_at"]:
-            log.info("Job {} is now finished, checking result...".format(build_slug))
+            log.info(f"Job {build_slug} is now finished, checking result...")
             break
         else:
-            log.info("Job {} is still running. Waiting another minute...".format(build_slug))
+            log.info(f"Job {build_slug} is still running. Waiting another minute...")
             await asyncio.sleep(60)
 
     if response["data"]["status_text"] != "success":
         if response["data"]["status_text"] == "error":
-            raise TaskException("Job {} errored! Got: {}".format(build_slug, response), exit_code=1)
+            raise TaskException(f"Job {build_slug} errored! Got: {response}", exit_code=1)
         if response["data"]["status_text"] == "aborted":
-            raise TaskException("Job {} was aborted. Got: {}".format(build_slug, response), exit_code=2)
-        raise TaskException("Job {} is finished but not successful. Got: {}".format(build_slug, response), exit_code=3)
+            raise TaskException(f"Job {build_slug} was aborted. Got: {response}", exit_code=2)
+        raise TaskException(f"Job {build_slug} is finished but not successful. Got: {response}", exit_code=3)
 
 
 async def download_artifacts(client, build_slug, artifacts_directory):
-    suffix = "builds/{}/artifacts".format(build_slug)
+    suffix = f"builds/{build_slug}/artifacts"
     url = BITRISE_URL_TEMPLATE.format(suffix=suffix)
 
     response = await do_http_request_json(client, url)
@@ -164,7 +164,7 @@ async def download_artifacts(client, build_slug, artifacts_directory):
     }
 
     for artifact_slug, title in artifacts_metadata.items():
-        suffix = "builds/{}/artifacts/{}".format(build_slug, artifact_slug)
+        suffix = f"builds/{build_slug}/artifacts/{artifact_slug}"
         url = BITRISE_URL_TEMPLATE.format(suffix=suffix)
 
         response = await do_http_request_json(client, url)
@@ -173,7 +173,7 @@ async def download_artifacts(client, build_slug, artifacts_directory):
 
 
 async def download_log(client, build_slug, artifacts_directory):
-    suffix = "builds/{}/log".format(build_slug)
+    suffix = f"builds/{build_slug}/log"
     url = BITRISE_URL_TEMPLATE.format(suffix=suffix)
 
     response = await do_http_request_json(client, url)
@@ -198,19 +198,19 @@ async def download_file(download_url, file_destination):
                         break
                     fd.write(chunk)
 
-    log.info("'{}' downloaded".format(file_destination))
+    log.info(f"'{file_destination}' downloaded")
 
 
 async def do_http_request_json(client, url, method="get", **kwargs):
-    method_and_url = "{} {}".format(method.upper(), url)
-    log.debug("Making request {}...".format(method_and_url))
+    method_and_url = f"{method.upper()} {url}"
+    log.debug(f"Making request {method_and_url}...")
 
     http_function = getattr(client, method)
     async with http_function(url, **kwargs) as r:
-        log.debug("{} returned HTTP code {}".format(method_and_url, r.status))
+        log.debug(f"{method_and_url} returned HTTP code {r.status}")
         response = await r.json()
 
-    log.debug("{} returned JSON {}".format(method_and_url, response))
+    log.debug(f"{method_and_url} returned JSON {response}")
 
     return response
 

--- a/taskcluster/scripts/bitrise-schedule.py
+++ b/taskcluster/scripts/bitrise-schedule.py
@@ -184,7 +184,6 @@ async def download_log(client, build_slug, artifacts_directory):
         log.error("Bitrise has no log to offer for job {0}. Please check https://app.bitrise.io/build/{0}".format(build_slug))
 
 
-
 CHUNK_SIZE = 128
 
 

--- a/taskcluster/scripts/check-screenshots.py
+++ b/taskcluster/scripts/check-screenshots.py
@@ -60,10 +60,10 @@ _FAILURE_EXIT_CODE = 47
 def _check_files(artifacts_directory, locales, number_of_screenshots_per_locale):
     errors = []
 
-    archives = set(glob.glob("{}/*.zip".format(artifacts_directory)))
+    archives = set(glob.glob(f"{artifacts_directory}/*.zip"))
     archives = _filter_out_derived_data_archive(archives)
     expected_number_of_screenshots_per_archive = {
-        "{}/{}.zip".format(artifacts_directory, locale): number_of_screenshots_per_locale[locale]
+        f"{artifacts_directory}/{locale}.zip": number_of_screenshots_per_locale[locale]
         for locale in locales
     }
 
@@ -75,15 +75,15 @@ def _check_files(artifacts_directory, locales, number_of_screenshots_per_locale)
             )
         )
 
-    log.info("Processing {} archives...".format(len(expected_archives)))
-    log.debug("Archives are expected to have these numbers of screenshots: {}".format(expected_number_of_screenshots_per_archive))
+    log.info(f"Processing {len(expected_archives)} archives...")
+    log.debug(f"Archives are expected to have these numbers of screenshots: {expected_number_of_screenshots_per_archive}")
 
     for archive, expected_number_of_screenshots in expected_number_of_screenshots_per_archive.items():
         errors.extend(_check_single_archive(archive, expected_number_of_screenshots))
 
     if errors:
         error_list = "\n * ".join(errors)
-        log.critical("Got {} error(s) while verifying screenshots: \n * {}".format(len(errors), error_list))
+        log.critical(f"Got {len(errors)} error(s) while verifying screenshots: \n * {error_list}")
         sys.exit(_FAILURE_EXIT_CODE)
 
     log.info("No archive is missing and all of them contain the right number of screenshots!")
@@ -95,7 +95,7 @@ def _filter_out_derived_data_archive(archives):
         with ZipFile(archive) as zip_file:
             # So far, only the derived data archive contains info.plist
             if "info.plist" in zip_file.namelist():
-                log.warn('Archive "{}" seems to be the derived data archive. Ignoring...'.format(archive))
+                log.warn(f'Archive "{archive}" seems to be the derived data archive. Ignoring...')
                 continue
 
             filtered_out_archives.add(archive)
@@ -107,10 +107,10 @@ def _check_single_archive(archive, expected_number_of_screenshots):
 
     with ZipFile(archive) as zip_file:
         all_files = set(zip_file.namelist())
-        png_files = set(file for file in all_files if file.endswith(".png"))
+        png_files = {file for file in all_files if file.endswith(".png")}
         non_png_files = all_files - png_files
         if non_png_files:
-            errors.append('Archive "{}" contains non-png files: {}'.format(archive, non_png_files))
+            errors.append(f'Archive "{archive}" contains non-png files: {non_png_files}')
 
         actual_number_of_screenshots = len(png_files)
         if actual_number_of_screenshots != expected_number_of_screenshots:

--- a/taskcluster/scripts/check-screenshots.py
+++ b/taskcluster/scripts/check-screenshots.py
@@ -7,7 +7,6 @@
 import argparse
 import glob
 import logging
-import os
 import sys
 import yaml
 

--- a/taskcluster/scripts/get-secret.py
+++ b/taskcluster/scripts/get-secret.py
@@ -4,7 +4,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 import argparse
 import base64
@@ -21,7 +20,7 @@ def write_secret_to_file(path, data, key, base64decode=False, json_secret=False,
     except OSError as error:
         if error.errno != errno.EEXIST:
             raise
-    print("Outputting secret to: {}".format(path))
+    print(f"Outputting secret to: {path}")
 
     with open(path, 'a' if append else 'w') as f:
         value = data['secret'][key]

--- a/taskcluster/scripts/write-dummy-secret.py
+++ b/taskcluster/scripts/write-dummy-secret.py
@@ -4,7 +4,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 import argparse
 import errno
@@ -18,7 +17,7 @@ def write_secret_to_file(path, secret):
     except OSError as error:
         if error.errno != errno.EEXIST:
             raise
-    print("Outputting secret to: {}".format(path))
+    print(f"Outputting secret to: {path}")
 
     with open(path, 'w') as f:
         f.write(secret)


### PR DESCRIPTION
Currently we run taskgraph generation with Python 2 which has been unsupported for a year and a half now. This updates firefox-ios to the latest taskgraph revision + decision image, and updates it to run with Python 3.