### PR TITLE
FxiOS2908 - Library Section A/B test setup

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -392,6 +392,7 @@
 		C4E398601D22C409004E89BA /* TopTabsLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E3985F1D22C409004E89BA /* TopTabsLayout.swift */; };
 		C4EFEECF1CEBB6F2009762A4 /* BackForwardTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4EFEECE1CEBB6F2009762A4 /* BackForwardTableViewCell.swift */; };
 		C4F3B29A1CFCF93A00966259 /* ButtonToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F3B2991CFCF93A00966259 /* ButtonToast.swift */; };
+		C80685D126A0C93900DCD895 /* UserResearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80685D026A0C93900DCD895 /* UserResearch.swift */; };
 		C8163851268A0899004C7160 /* AddCredentialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8163850268A0899004C7160 /* AddCredentialViewController.swift */; };
 		C817B34D1FC609500086018E /* UIScrollViewSwizzled.swift in Sources */ = {isa = PBXBuildFile; fileRef = C817B34C1FC609500086018E /* UIScrollViewSwizzled.swift */; };
 		C81AC6B626160091007800C5 /* TabTrayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81AC6B526160091007800C5 /* TabTrayViewModel.swift */; };
@@ -2877,6 +2878,7 @@
 		C7C54345A164D550CF2BC575 /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		C7D341F8BA6A9E44518C11C8 /* oc */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = oc; path = oc.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		C7DB49358A6A84AA7391EEE6 /* ta */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ta; path = ta.lproj/Intro.strings; sourceTree = "<group>"; };
+		C80685D026A0C93900DCD895 /* UserResearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserResearch.swift; sourceTree = "<group>"; };
 		C8154C5887169941126C530A /* lt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lt; path = lt.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		C8163850268A0899004C7160 /* AddCredentialViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCredentialViewController.swift; sourceTree = "<group>"; };
 		C817B34C1FC609500086018E /* UIScrollViewSwizzled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScrollViewSwizzled.swift; sourceTree = "<group>"; };
@@ -4715,6 +4717,7 @@
 				39EF434D260A73950011E22E /* Experiments.swift */,
 				39EF4362260CEE5E0011E22E /* ExperimentConstants.swift */,
 				3964F5FB2656D2B500065278 /* initial_experiments.json */,
+				C80685D026A0C93900DCD895 /* UserResearch.swift */,
 			);
 			path = Experiments;
 			sourceTree = "<group>";
@@ -7874,6 +7877,7 @@
 				D88FDAAF1F4E2BA000FD9709 /* PhotonActionSheetAnimator.swift in Sources */,
 				E698FFDA1B4AADF40001F623 /* TabScrollController.swift in Sources */,
 				D34510881ACF415700EC27F0 /* SearchLoader.swift in Sources */,
+				C80685D126A0C93900DCD895 /* UserResearch.swift in Sources */,
 				DA9FD88924E213E500168D1E /* QuickLinkSelection.intentdefinition in Sources */,
 				CA7FC7D324A6A9B70012F347 /* LoginListDataSourceHelper.swift in Sources */,
 				43AB6FA425DC53D30016B015 /* ASHeaderView.swift in Sources */,

--- a/Client/Experiments/ExperimentConstants.swift
+++ b/Client/Experiments/ExperimentConstants.swift
@@ -12,6 +12,7 @@ enum NimbusFeatureId: String {
     case nimbusValidation = "nimbus-validation"
     case onboardingDefaultBrowser = "onboarding-default-browser"
     case inactiveTabs = "inactiveTabs"
+    case librarySectionExperiment = "library-section-experiment"
 }
 
 /// A set of common branch ids used in experiments. Branch ids can be application/experiment specific, so
@@ -26,5 +27,10 @@ enum NimbusExperimentBranch {
     enum InactiveTab {
         static let control = "inactiveTabControl"
         static let treatment = "inactiveTabTreatment"
+    }
+
+    enum LibrarySectionABTest {
+        static let control = "librarySectionABTestShowLibrary"
+        static let variation = "librarySectionABTestShowRecentlySaved"
     }
 }

--- a/Client/Experiments/UserResearch.swift
+++ b/Client/Experiments/UserResearch.swift
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import MozillaAppServices
+
+protocol UserResearch {
+    func setupExperiment()
+}
+
+extension UserResearch {
+    var experiments: NimbusApi {
+        return Experiments.shared
+    }
+}

--- a/Client/Experiments/UserResearch.swift
+++ b/Client/Experiments/UserResearch.swift
@@ -4,6 +4,8 @@
 
 import MozillaAppServices
 
+/// This procol will give access to the `Experiments` singleton and require
+/// the conforming class to set up an experiment.
 protocol UserResearch {
     func setupExperiment()
 }

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -124,7 +124,7 @@ extension HomePanelContextMenu {
 
 // MARK: - HomeVC
 
-class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureFlagsProtocol {
+class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureFlagsProtocol, UserResearch {
     weak var homePanelDelegate: HomePanelDelegate?
     weak var libraryPanelDelegate: LibraryPanelDelegate?
     fileprivate let profile: Profile
@@ -156,6 +156,16 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
     }()
 
     var pocketStories: [PocketStory] = []
+
+    // Temporary variables to track the nimbus setting.
+    var nimbusExperimentShowLibrarySetting: Bool = true
+
+    var isYourLibrarySectionEnabled: Bool {
+        get {
+            // Library shortcuts should be disabled on the iPad
+            return UIDevice.current.userInterfaceIdiom != .pad && nimbusExperimentShowLibrarySetting
+        }
+    }
     
     var hasRecentBookmarks = false
     var hasReadingListitems = false
@@ -163,13 +173,13 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
         get {
             guard featureFlags.isFeatureActive(.recentlySaved) else { return false }
             
-            return (hasRecentBookmarks || hasReadingListitems)
-                && profile.prefs.boolForKey(PrefsKeys.recentlySavedSectionEnabled) ?? false
+            return (hasRecentBookmarks || hasReadingListitems) && !nimbusExperimentShowLibrarySetting
         }
     }
 
-    init(profile: Profile) {
+    init(profile: Profile, experiments: NimbusApi = Experiments.shared) {
         self.profile = profile
+        self.experiments = experiments
         super.init(collectionViewLayout: flowLayout)
         self.collectionView?.delegate = self
         self.collectionView?.dataSource = self
@@ -186,6 +196,8 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
     
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        setupExperiment()
 
         Section.allCases.forEach { collectionView.register($0.cellType, forCellWithReuseIdentifier: $0.cellIdentifier) }
         self.collectionView?.register(ASHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: "Header")
@@ -243,6 +255,16 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
     }
     
     // MARK: - Helpers
+
+    func setupExperiment() {
+        nimbusExperimentShowLibrarySetting = experiments.withExperiment(featureId: .librarySectionExperiment) { branch -> Bool in
+                switch branch {
+                case .some(NimbusExperimentBranch.LibrarySectionABTest.control): return true
+                case .some(NimbusExperimentBranch.LibrarySectionABTest.variation): return false
+                default: return true
+            }
+        }
+    }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
@@ -524,9 +546,9 @@ extension FirefoxHomeViewController: UICollectionViewDelegateFlowLayout {
         case .topSites:
             return Section(section).headerHeight
         case .libraryShortcuts:
-            return UIDevice.current.userInterfaceIdiom == .pad ? CGSize.zero : Section(section).headerHeight
+            return isYourLibrarySectionEnabled ? Section(section).headerHeight : .zero
         case .recentlySaved:
-            let size = ((isRecentlySavedSectionEnabled ? Section(section).headerHeight : .zero))
+            let size = isRecentlySavedSectionEnabled ? Section(section).headerHeight : .zero
             return size
         }
     }
@@ -577,8 +599,7 @@ extension FirefoxHomeViewController {
             let numberOfItems = (isRecentlySavedSectionEnabled ? 1 : 0)
             return numberOfItems
         case .libraryShortcuts:
-            // disable the libary shortcuts on the ipad
-            return UIDevice.current.userInterfaceIdiom == .pad ? 0 : 1
+            return isYourLibrarySectionEnabled ? 1 : 0
         }
     }
 

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -179,7 +179,6 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
 
     init(profile: Profile, experiments: NimbusApi = Experiments.shared) {
         self.profile = profile
-        self.experiments = experiments
         super.init(collectionViewLayout: flowLayout)
         self.collectionView?.delegate = self
         self.collectionView?.dataSource = self


### PR DESCRIPTION
This PR sets up the following experiment:

- Control: Current experience which displays **Your Library** on Firefox home and no **Recently Saved**
- Variant: **Your Library** section is removed and **Recently Saved** section is displayed instead

It also adds a `UserResearch` protocol to give access to the `Experiments` singleton, as well as requiring an experiment to be set up on the adopting class.

Tested using this [gist](https://gist.githubusercontent.com/electricRGB/aed28bece64ad18027c2550c29ee1c37/raw/56ff6210b6da887271222763c3a7bcdbe84fa86a/prod_payload.json).

[Wiki page for Nimbus Experiments for Firefox iOS (wip)](https://github.com/mozilla-mobile/firefox-ios/wiki/Nimbus-Experiments)