### PR TITLE
Keep `configurable` and `enumerable` true when overriding `Image.prototype.src`

### DIFF
--- a/content-blocker-lib-ios/js/TrackingProtectionStats.js
+++ b/content-blocker-lib-ios/js/TrackingProtectionStats.js
@@ -154,7 +154,9 @@ function install() {
       set: function(value) {
         sendMessage(this.src);
         originalImageSrc.set.call(this, value);
-      }
+      },
+      enumerable: true,
+      configurable: true,
     });
 
     // -------------------------------------------------


### PR DESCRIPTION
Here's what the property descriptor looks like in Safari iOS 14.6:
```
> Object.getOwnPropertyDescriptor(Image.prototype, 'src')
< {get: function, set: function, enumerable: true, configurable: true}
```

