### PR TITLE
Add text-search to open tabs and spotlight

### DIFF
--- a/Client/Experiments/ExperimentConstants.swift
+++ b/Client/Experiments/ExperimentConstants.swift
@@ -5,9 +5,11 @@
 import Foundation
 
 /// An application specific enum of app features that we are configuring
-/// with experiments. Despite being named `NimbusFeatureID`, what we are
-/// considering features here, are considered experiments in Nimbus.
-/// This is expected to grow and shrink across releases of the app.
+/// with experiments. These identify parts of the app that can be configured by Nimbus.
+///
+/// Configuration comes from calling `nimbus.getVariables(featureId)`. The available variables for
+/// each feature is documented in `Docs/features.md`.
+///
 enum NimbusFeatureId: String {
     case nimbusValidation = "nimbus-validation"
     case onboardingDefaultBrowser = "onboarding-default-browser"

--- a/Client/Experiments/ExperimentConstants.swift
+++ b/Client/Experiments/ExperimentConstants.swift
@@ -13,6 +13,7 @@ enum NimbusFeatureId: String {
     case onboardingDefaultBrowser = "onboarding-default-browser"
     case inactiveTabs = "inactiveTabs"
     case librarySectionExperiment = "library-section-experiment"
+    case search = "search"
 }
 
 /// A set of common branch ids used in experiments. Branch ids can be application/experiment specific, so

--- a/Client/Experiments/initial_experiments.json
+++ b/Client/Experiments/initial_experiments.json
@@ -73,7 +73,7 @@
             "last_modified": 1621443780172
         },
         {
-            "slug": "feature-icon-variables-validation-ios",
+            "slug": "ios-search-full-text",
             "appId": "org.mozilla.ios.Fennec",
             "appName": "firefox_ios",
             "channel": "nightly",
@@ -83,19 +83,88 @@
                     "feature": {
                         "value": {},
                         "enabled": true,
-                        "featureId": "nimbus-validation"
+                        "featureId": "search"
                     }
                 },
                 {
-                    "slug": "treatment",
+                    "slug": "open-tabs-only",
                     "ratio": 0,
                     "feature": {
                         "value": {
-                            "settings-title": "Settings.General.SectionName",
-                            "settings-icon": "menu-ViewMobile"
+                            "awesome-bar": {
+                                "use-page-content": true
+                            },
+                            "spotlight": {
+                                "enabled": false
+                            }
                         },
                         "enabled": true,
-                        "featureId": "nimbus-validation"
+                        "featureId": "search"
+                    }
+                },
+                {
+                    "slug": "spotlight-only",
+                    "ratio": 0,
+                    "feature": {
+                        "value": {
+                            "spotlight": {
+                                "description": "excerpt",
+                                "use-html-content": true,
+                                "icon": "screenshot",
+                                "keep-for-days": 28
+                            }
+                        },
+                        "enabled": true,
+                        "featureId": "search"
+                    }
+                },
+
+                {
+                    "slug": "spotlight-letter",
+                    "ratio": 0,
+                    "feature": {
+                        "value": {
+                            "spotlight": {
+                                "enabled": true,
+                                "icon": "letter"
+                            }
+                        },
+                        "enabled": true,
+                        "featureId": "search"
+                    }
+                },
+                {
+                    "slug": "spotlight-favicon",
+                    "ratio": 0,
+                    "feature": {
+                        "value": {
+                            "spotlight": {
+                                "enabled": true,
+                                "icon": "favicon"
+                            }
+                        },
+                        "enabled": true,
+                        "featureId": "search"
+                    }
+                },
+                {
+                    "slug": "spotlight-and-open-tabs",
+                    "ratio": 0,
+                    "feature": {
+                        "value": {
+                            "spotlight": {
+                                "enabled": true,
+                                "description": "excerpt",
+                                "icon": "screenshot",
+                                "use-html-content": true,
+                                "keep-for-days": 28
+                            },
+                            "awesome-bar": {
+                                "use-page-content": true
+                            }
+                        },
+                        "enabled": true,
+                        "featureId": "search"
                     }
                 }
             ],
@@ -116,12 +185,12 @@
                 "randomizationUnit": "nimbus_id"
             },
             "schemaVersion": "1.5.0",
-            "userFacingName": "Nimbus Icon Variables Validation",
+            "userFacingName": "Full text searching with Readbility and Spotlight",
             "referenceBranch": "control",
             "proposedDuration": 14,
             "isEnrollmentPaused": false,
             "proposedEnrollment": 7,
-            "userFacingDescription": "Demonstration experiment to make trivial visible changes to icons in Settings",
+            "userFacingDescription": "Does making full-text available to spotlight or open tabs drive CDOU?",
             "last_modified": 1621443780172
         }
     ]

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1274,7 +1274,7 @@ class BrowserViewController: UIViewController {
 
             if (!InternalURL.isValid(url: url) || url.isReaderModeURL), !url.isFileURL {
                 postLocationChangeNotificationForTab(tab, navigation: navigation)
-
+                tab.readabilityResult = nil
                 webView.evaluateJavascriptInDefaultContentWorld("\(ReaderModeNamespace).checkReadability()")
             }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -19,7 +19,6 @@ extension BrowserViewController: ReaderModeDelegate {
     }
 
     func readerMode(_ readerMode: ReaderMode, didParseReadabilityResult readabilityResult: ReadabilityResult, forTab tab: Tab) {
-        tab.readabilityResult = readabilityResult
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -3,8 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Shared
-import CoreSpotlight
-import MobileCoreServices
 
 private let log = Logger.browserLogger
 extension BrowserViewController: ReaderModeDelegate {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -3,7 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Shared
+import CoreSpotlight
+import MobileCoreServices
 
+private let log = Logger.browserLogger
 extension BrowserViewController: ReaderModeDelegate {
     func readerMode(_ readerMode: ReaderMode, didChangeReaderModeState state: ReaderModeState, forTab tab: Tab) {
         // If this reader mode availability state change is for the tab that we currently show, then update
@@ -19,6 +22,7 @@ extension BrowserViewController: ReaderModeDelegate {
     }
 
     func readerMode(_ readerMode: ReaderMode, didParseReadabilityResult readabilityResult: ReadabilityResult, forTab tab: Tab) {
+        TabEvent.post(.didLoadReadability(readabilityResult), for: tab)
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -19,6 +19,7 @@ extension BrowserViewController: ReaderModeDelegate {
     }
 
     func readerMode(_ readerMode: ReaderMode, didParseReadabilityResult readabilityResult: ReadabilityResult, forTab tab: Tab) {
+        tab.readabilityResult = readabilityResult
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -4,7 +4,6 @@
 
 import Shared
 
-private let log = Logger.browserLogger
 extension BrowserViewController: ReaderModeDelegate {
     func readerMode(_ readerMode: ReaderMode, didChangeReaderModeState state: ReaderModeState, forTab tab: Tab) {
         // If this reader mode availability state change is for the tab that we currently show, then update

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -79,12 +79,14 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
 
     var suggestions: [String]? = []
     var savedQuery: String = ""
+    var experimental: Variables?
     static var userAgent: String?
 
     
     init(profile: Profile, isPrivate: Bool, tabManager: TabManager) {
         self.isPrivate = isPrivate
         self.tabManager = tabManager
+        self.experimental = Experiments.shared.getVariables(featureId: .search).getVariables("awesome-bar")
         super.init(profile: profile)
     }
 
@@ -359,7 +361,8 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         }
         // Searching within the content will get annoying, so only start searching
         // in content when there are at least one word with more than 3 letters in.
-        let searchInContent = searchTerms.find { $0.count >= 3 } != nil
+        let searchInContent = (experimental?.getBool("use-page-content") ?? false)
+            && searchTerms.find { $0.count >= 3 } != nil
 
         filteredOpenedTabs = currentTabs.filter { tab in
             guard let url = tab.url ?? tab.sessionData?.urls.last,

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -350,6 +350,11 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
             if title?.lowercased().range(of: searchString.lowercased()) != nil {
                 return true
             }
+            if searchString.count >= 3 {
+                if tab.readabilityResult?.content.lowercased().range(of: searchString.lowercased()) != nil {
+                    return true
+                }
+            }
             let tabUrl = tab.url ?? tab.sessionData?.urls.last
             if let url = tabUrl, InternalURL.isValid(url: url) {
                 return false

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -345,24 +345,37 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     
     func searchTabs(for searchString: String) {
         let currentTabs = self.isPrivate ? self.tabManager.privateTabs : self.tabManager.normalTabs
-        filteredOpenedTabs = currentTabs.filter { tab in
-            let title = tab.title ?? tab.lastTitle
-            if title?.lowercased().range(of: searchString.lowercased()) != nil {
-                return true
-            }
-            if searchString.count >= 3 {
-                if tab.readabilityResult?.content.lowercased().range(of: searchString.lowercased()) != nil {
-                    return true
-                }
-            }
-            let tabUrl = tab.url ?? tab.sessionData?.urls.last
-            if let url = tabUrl, InternalURL.isValid(url: url) {
+
+        // Small helper function to do case insensitive searching.
+        // We split the search query by spaces so we can simulate full text search.
+        let searchTerms = searchString.split(separator: " ")
+        func find(in content: String?) -> Bool {
+            guard let content = content else {
                 return false
             }
-            if tabUrl?.absoluteString.lowercased().range(of: searchString.lowercased()) != nil {
-                return true
+            return searchTerms.reduce(true) {
+                $0 && content.range(of: $1, options: .caseInsensitive) != nil
             }
-            return false
+        }
+        // Searching within the content will get annoying, so only start searching
+        // in content when there are at least one word with more than 3 letters in.
+        let searchInContent = searchTerms.find { $0.count >= 3 } != nil
+
+        filteredOpenedTabs = currentTabs.filter { tab in
+            guard let url = tab.url ?? tab.sessionData?.urls.last,
+                  !InternalURL.isValid(url: url) else {
+                return false
+            }
+            let lines = [
+                    tab.title ?? tab.lastTitle,
+                    searchInContent ? tab.readabilityResult?.textContent : nil,
+                    url.absoluteString
+                ]
+                .filter { $0 != nil }
+                .map { $0! }
+
+            let text = lines.joined(separator: "\n")
+            return find(in: text)
         }
     }
     

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -79,6 +79,8 @@ class Tab: NSObject {
     // rest of the tab.
     var pageMetadata: PageMetadata?
 
+    var readabilityResult: ReadabilityResult?
+
     var consecutiveCrashes: UInt = 0
     
     // Setting defualt page as topsites

--- a/Client/Frontend/Reader/ReadabilityService.swift
+++ b/Client/Frontend/Reader/ReadabilityService.swift
@@ -3,8 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import Shared
 import WebKit
 
+private let log = Logger.browserLogger
 private let ReadabilityServiceSharedInstance = ReadabilityService()
 
 private let ReadabilityTaskDefaultTimeout = 15
@@ -66,6 +68,7 @@ class ReadabilityOperation: Operation {
                 break
             case .success(let readabilityResult):
                 do {
+                    log.info("ReadabilityService: Readability result available!")
                     try readerModeCache.put(url, readabilityResult)
                 } catch let error as NSError {
                     print("Failed to store readability results in the cache: \(error.localizedDescription)")
@@ -103,6 +106,7 @@ extension ReadabilityOperation: ReaderModeDelegate {
     }
 
     func readerMode(_ readerMode: ReaderMode, didParseReadabilityResult readabilityResult: ReadabilityResult, forTab tab: Tab) {
+        log.info("ReadbilityService: Readability result available!")
         guard tab == self.tab else {
             return
         }

--- a/Client/Frontend/Reader/ReaderMode.swift
+++ b/Client/Frontend/Reader/ReaderMode.swift
@@ -200,6 +200,7 @@ struct ReadabilityResult {
     var domain = ""
     var url = ""
     var content = ""
+    var textContent = ""
     var title = ""
     var credits = ""
     var excerpt = ""
@@ -216,6 +217,9 @@ struct ReadabilityResult {
             }
             if let content = dict["content"] as? String {
                 self.content = content
+            }
+            if let textContent = dict["textContent"] as? String {
+                self.textContent = textContent
             }
             if let excerpt = dict["excerpt"] as? String {
                 self.excerpt = excerpt
@@ -237,6 +241,8 @@ struct ReadabilityResult {
         let domain = object["domain"].string
         let url = object["url"].string
         let content = object["content"].string
+        let textContent = object["textContent"].string
+        let excerpt = object["excerpt"].string
         let title = object["title"].string
         let credits = object["credits"].string
 
@@ -249,11 +255,13 @@ struct ReadabilityResult {
         self.content = content!
         self.title = title!
         self.credits = credits!
+        self.textContent = textContent ?? ""
+        self.excerpt = excerpt ?? ""
     }
 
     /// Encode to a dictionary, which can then for example be json encoded
     func encode() -> [String: Any] {
-        return ["domain": domain, "url": url, "content": content, "title": title, "credits": credits]
+        return ["domain": domain, "url": url, "content": content, "title": title, "credits": credits, "textContent": textContent, "excerpt": excerpt]
     }
 
     /// Encode to a JSON encoded string

--- a/Client/Frontend/Reader/ReaderMode.swift
+++ b/Client/Frontend/Reader/ReaderMode.swift
@@ -201,6 +201,7 @@ struct ReadabilityResult {
     var content = ""
     var title = ""
     var credits = ""
+    var excerpt = ""
 
     init?(object: AnyObject?) {
         if let dict = object as? NSDictionary {
@@ -214,6 +215,9 @@ struct ReadabilityResult {
             }
             if let content = dict["content"] as? String {
                 self.content = content
+            }
+            if let excerpt = dict["excerpt"] as? String {
+                self.excerpt = excerpt
             }
             if let title = dict["title"] as? String {
                 self.title = title

--- a/Client/Frontend/Reader/ReaderMode.swift
+++ b/Client/Frontend/Reader/ReaderMode.swift
@@ -7,6 +7,7 @@ import Shared
 import WebKit
 import SwiftyJSON
 
+private let log = Logger.browserLogger
 let ReaderModeProfileKeyStyle = "readermode.style"
 
 enum ReaderModeMessageType: String {
@@ -311,6 +312,8 @@ class ReaderMode: TabContentScript {
         guard let tab = tab else {
             return
         }
+        log.info("ReaderMode: Readability result available!")
+        tab.readabilityResult = readabilityResult
         delegate?.readerMode(self, didParseReadabilityResult: readabilityResult, forTab: tab)
     }
 

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -36,8 +36,13 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
             (SiteDataClearable(tabManager: self.tabManager), true),
             (TrackingProtectionClearable(), true),
             (DownloadedFilesClearable(), false), // Don't clear downloaded files by default
-            (SpotlightClearable(), false), // On device only, so don't clear by default.
         ]
+
+        if let experimental = Experiments.shared.getVariables(featureId: .search).getVariables("spotlight"),
+           experimental.getBool("enabled") == true { // i.e. defaults to false
+            items.append((SpotlightClearable(), false)) // On device only, so don't clear by default.)
+        }
+
         return items
     }()
 

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -35,7 +35,8 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
             (CookiesClearable(tabManager: self.tabManager), true),
             (SiteDataClearable(tabManager: self.tabManager), true),
             (TrackingProtectionClearable(), true),
-            (DownloadedFilesClearable(), false) // Don't clear downloaded files by default
+            (DownloadedFilesClearable(), false), // Don't clear downloaded files by default
+            (SpotlightClearable(), false), // On device only, so don't clear by default.
         ]
         return items
     }()

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -85,6 +85,18 @@ class CacheClearable: Clearable {
     }
 }
 
+class SpotlightClearable: Clearable {
+    var label: String { .ClearableSpotlight }
+
+    func clear() -> Success {
+        let deferred = Success()
+        UserActivityHandler.clearSearchIndex() { _ in
+            deferred.fill(Maybe(success: ()))
+        }
+        return deferred
+    }
+}
+
 private func deleteLibraryFolderContents(_ folder: String) throws {
     let manager = FileManager.default
     let library = manager.urls(for: .libraryDirectory, in: .userDomainMask)[0]

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1302,6 +1302,7 @@ extension String {
     public static let ClearableOfflineData = MZLocalizedString("Offline Website Data", tableName: "ClearPrivateData", comment: "Settings item for clearing website data")
     public static let ClearableCookies = MZLocalizedString("Cookies", tableName: "ClearPrivateData", comment: "Settings item for clearing cookies")
     public static let ClearableDownloads = MZLocalizedString("Downloaded Files", tableName: "ClearPrivateData", comment: "Settings item for deleting downloaded files")
+    public static let ClearableSpotlight = MZLocalizedString("Spotlight Index", tableName: "ClearPrivateData", comment: "Settings item for deleting the iOS search index of browsed webpages")
 }
 
 // MARK: - SearchEngine Picker

--- a/Client/Helpers/TabEventHandler.swift
+++ b/Client/Helpers/TabEventHandler.swift
@@ -53,6 +53,7 @@ protocol TabEventHandler: AnyObject {
     func tab(_ tab: Tab, didChangeURL url: URL)
     func tab(_ tab: Tab, didLoadPageMetadata metadata: PageMetadata)
     func tabMetadataNotAvailable(_ tab: Tab)
+    func tab(_ tab: Tab, didLoadReadability page: ReadabilityResult)
     func tab(_ tab: Tab, didLoadFavicon favicon: Favicon?, with: Data?)
     func tabDidGainFocus(_ tab: Tab)
     func tabDidLoseFocus(_ tab: Tab)
@@ -67,6 +68,7 @@ extension TabEventHandler {
     func tab(_ tab: Tab, didChangeURL url: URL) {}
     func tab(_ tab: Tab, didLoadPageMetadata metadata: PageMetadata) {}
     func tabMetadataNotAvailable(_ tab: Tab) {}
+    func tab(_ tab: Tab, didLoadReadability page: ReadabilityResult) {}
     func tab(_ tab: Tab, didLoadFavicon favicon: Favicon?, with: Data?) {}
     func tabDidGainFocus(_ tab: Tab) {}
     func tabDidLoseFocus(_ tab: Tab) {}
@@ -78,6 +80,7 @@ extension TabEventHandler {
 enum TabEventLabel: String {
     case didChangeURL
     case didLoadPageMetadata
+    case didLoadReadability
     case pageMetadataNotAvailable
     case didLoadFavicon
     case didGainFocus
@@ -92,6 +95,7 @@ enum TabEvent {
     case didChangeURL(URL)
     case didLoadPageMetadata(PageMetadata)
     case pageMetadataNotAvailable
+    case didLoadReadability(ReadabilityResult)
     case didLoadFavicon(Favicon?, with: Data?)
     case didGainFocus
     case didLoseFocus
@@ -115,6 +119,8 @@ enum TabEvent {
             handler.tab(tab, didLoadPageMetadata: metadata)
         case .pageMetadataNotAvailable:
             handler.tabMetadataNotAvailable(tab)
+        case .didLoadReadability(let result):
+            handler.tab(tab, didLoadReadability: result)
         case .didLoadFavicon(let favicon, let data):
             handler.tab(tab, didLoadFavicon: favicon, with: data)
         case .didGainFocus:

--- a/Client/Helpers/UserActivityHandler.swift
+++ b/Client/Helpers/UserActivityHandler.swift
@@ -80,10 +80,10 @@ extension UserActivityHandler {
         guard let url = tab.url, !tab.isPrivate, url.isWebPage(includeDataURIs: false), !InternalURL.isValid(url: url) else {
             return
         }
-        log.info("Spotlight Indexing\n\(page.excerpt)")
         let attributeSet = CSSearchableItemAttributeSet(itemContentType: kUTTypeText as String)
         attributeSet.title = page.title
         attributeSet.contentDescription = page.excerpt
+        attributeSet.htmlContentData = page.content.utf8EncodedData
 
         if let image = tab.screenshot {
             attributeSet.thumbnailData = image.pngData()

--- a/Docs/features.md
+++ b/Docs/features.md
@@ -1,0 +1,23 @@
+## Features
+
+## `search`
+
+### `awesome-bar`: `Variables`
+
+This sub-feature controls the behaviour of the `awesome-bar`.
+
+| Variable 	| Type 	| Default 	| Implemented by 	| Notes 	|
+|---	|---	|---	|---	|---	|
+| `use-page-content` 	| `Bool` 	| `true` 	| `SearchViewController` 	| If true, then use the text contents of the page,  as determined by readability to find open tabs in the AwesomeBar 	|
+
+### `spotlight`: `Variables`
+
+This sub-feature allows indexing of page content (from Readability) by Spotlight.
+
+| Variable           	| Type     	| Default     	| Implemented by                                                 	| Notes                                                                                                                                                                                          	|
+|--------------------	|----------	|-------------	|----------------------------------------------------------------	|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------	|
+| `enabled`          	| `Bool`   	| `false`     	| `UserActivityHandler`,   `ClearPrivateDataTableViewController` 	| If true, then add readable pages to the Spotlight index                                                                                                                                        	|
+| `description`      	| `String` 	| `excerpt`   	| `UserActivityHandler`                                          	| The text added set as the contentDescription of the page. Possible values:   - `excerpt` the first paragraph.  - `content` the whole page content.  - `none` no description.                   	|
+| `use-html-content` 	| `Bool`   	| `true`      	| `UserActivityHandler`                                          	| Give Spotlight the html as given by Readability.                                                                                                                                               	|
+| `icon`             	| `String` 	| `letter`    	| `UserActivityHandler`                                          	| The thumbnail to use in Spotlight results. Possible values:   - `letter` use the first letter as an image  - `screenshot` use the tab screenshot  - `favicon` use the domain favicon  - `none` 	|
+| `keep-for-days`    	| `Int`    	| iOS default 	| `UserActivityHandler`                                          	| The number of days before an item expires. By default, iOS expires after a month.                                                                                                              	|


### PR DESCRIPTION
This PR adds features to grab the text from Readability (already being run on every page load), and uses it in the SearchViewController to find open tabs.

Additionally, it also gives it to CoreSpotlight to be made available to the user via Spotlight search.

It's all off by default, but configured by as a Nimbus Experiment.

A nimbus experiment is added in `initial_experiments.json`, so can be toggled on and off via the Nimbus Experiments screen.

Finally, the feature and its configuration variables are documented in `Docs/features.md`.