### PR TITLE
SDK-321: Instrument Firefox iOS to show Nimbus can support early startup

### DIFF
--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -506,6 +506,9 @@ extension TelemetryWrapper {
             GleanMetrics.DefaultBrowserOnboarding.dismissPressed.add()
         case (.action, .tap, .goToSettingsDefaultBrowserOnboarding, _, _):
             GleanMetrics.DefaultBrowserOnboarding.goToSettingsPressed.add()
+        // Onboarding
+        case (.action, .press, .dismissedOnboarding, let slideNum, _):
+            GleanMetrics.Onboarding.finish.record(extra: [.slideNum : slideNum])
         // Widget
         case (.action, .open, .mediumTabsOpenUrl, _, _):
             GleanMetrics.Widget.mTabsOpenUrl.add()

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -303,6 +303,29 @@ app:
       - fx-ios-data-stewards@mozilla.com
     expires: "2022-01-01"
 
+# Onboarding metrics
+onboarding:
+  finish:
+    type: event
+    description:
+      The user taps starts browsing and ends the onboarding experience.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/10824
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/11867
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+      - tlong@mozilla.com
+    expires: "2022-08-01"
+    extra_keys:
+      slide_num:
+        description:
+          The current onboarding slide number being viewed when
+          onboarding is dismissed.
+        type: quantity
+
 # Top Site
 top_site:
   tile_pressed:

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -310,15 +310,15 @@ onboarding:
     description:
       The user taps starts browsing and ends the onboarding experience.
     bugs:
-      - https://github.com/mozilla-mobile/fenix/issues/10824
+      - https://mozilla-hub.atlassian.net/browse/SDK-321
     data_reviews:
-      - https://github.com/mozilla-mobile/fenix/pull/11867
+      - https://github.com/mozilla-mobile/firefox-ios/pull/8904
     data_sensitivity:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
       - tlong@mozilla.com
-    expires: "2022-08-01"
+    expires: "2022-01-01"
     extra_keys:
       slide_num:
         description:


### PR DESCRIPTION
In order to run a test on how early we can run experiments via Nimbus, this migrates some of the existing legacy onboarding telemetry to Glean, namely the "dismissed" event which indicates when the "Start Browsing" button was clicked and onboarding was ended.