### PR TITLE
Bitrise: Fix NewXcodeVersions workflow after bitrise.yml refactor

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -145,7 +145,7 @@ workflows:
         inputs:
         - scheme: Fennec_Enterprise_XCUITests
         - simulator_device: "$IOS_DEVICE"
-  NewXcodeVersion:
+  NewXcodeVersions:
     steps:
     - script@1:
         inputs:
@@ -278,14 +278,7 @@ workflows:
         - channel: "#firefox-ios"
         - text: Build status using latest Xcode detected
         - webhook_url: "$WEBHOOK_SLACK_TOKEN"
-    description: This Workflow is to run tests (currently SmokeTest) when there is
-      a merge in master
-    meta:
-      bitrise.io:
-        stack: osx-xcode-13.0.x
-        machine_type_id: g2.4core
-    description: This Workflow is to run tests (currently SmokeTest) when there is
-      a merge in master
+    description: This Workflow is to build the app using latest xcode available in Bitrise
     meta:
       bitrise.io:
         stack: osx-xcode-13.0.x


### PR DESCRIPTION
I made a mistake when refactoring the bitrise.yml affecting the NewXcodeVersions workflow. 
- A typo in the name, missing latest 's'
- The description and stack fields were duplicated
Locally the update.py script is working fine again
