### PR TITLE
Fix RunAllXCUITests after bitrise refactor

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -139,9 +139,8 @@ workflows:
     steps:
     - git::https://github.com/bitrise-steplib/steps-xcode-build-for-test.git@export-fix:
         inputs:
-        - xcodebuild_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+        - xcodebuild_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -testPlan Fennec_Enterprise_XCUITests
         - scheme: Fennec_Enterprise_XCUITests
-        - xcodebuild_test_options: "-testPlan Fennec_Enterprise_XCUITests"
     - xcode-test@2:
         inputs:
         - scheme: Fennec_Enterprise_XCUITests

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -802,4 +802,4 @@ trigger_map:
 - push_branch: v35.0
   workflow: xcode12-release-and-beta-nocache
 - pull_request_target_branch: main
-  workflow: RunUnitTests
+  workflow: RunAllXCUITests

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -141,6 +141,7 @@ workflows:
         inputs:
         - xcodebuild_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
         - scheme: Fennec_Enterprise_XCUITests
+        - xcodebuild_test_options: "-testPlan Fennec_Enterprise_XCUITests"
     - xcode-test@2:
         inputs:
         - scheme: Fennec_Enterprise_XCUITests

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -801,4 +801,4 @@ trigger_map:
 - push_branch: v35.0
   workflow: xcode12-release-and-beta-nocache
 - pull_request_target_branch: main
-  workflow: RunAllXCUITests
+  workflow: RunUnitTests


### PR DESCRIPTION
The error with this workflow is: 
`Multiple xctestrun file generated during the build:`
```
/Users/vagrant/Library/Developer/Xcode/DerivedData/Client-gwatsyujoxlvmdbdntpwfkcijybc/Build/Products/Fennec_Enterprise_XCUITests_Fennec_Enterprise_XCUITests_iphoneos14.5-arm64.xctestrun
- /Users/vagrant/Library/Developer/Xcode/DerivedData/Client-gwatsyujoxlvmdbdntpwfkcijybc/Build/Products/Fennec_Enterprise_XCUITests_PerformanceTestPlan_iphoneos14.5-arm64.xctestrun
- /Users/vagrant/Library/Developer/Xcode/DerivedData/Client-gwatsyujoxlvmdbdntpwfkcijybc/Build/Products/Fennec_Enterprise_XCUITests_SmokeXCUITests_iphoneos14.5-arm64.xctestrun
- /Users/vagrant/Library/Developer/Xcode/DerivedData/Client-gwatsyujoxlvmdbdntpwfkcijybc/Build/Products/Fennec_Enterprise_XCUITests_SyncIntegrationTestPlan_iphoneos14.5-arm64.xctestrun
|      
```   

This should be fixed by specifying a test plan