### PR TITLE
String refactor (Part 1)

### DIFF
--- a/Client/Application/AppDelegate+PushNotifications.swift
+++ b/Client/Application/AppDelegate+PushNotifications.swift
@@ -25,7 +25,7 @@ enum SentTabAction: String {
     static let TabSendCategory = "TabSendCategory"
 
     static func registerActions() {
-        let viewAction = UNNotificationAction(identifier: SentTabAction.view.rawValue, title: Strings.SentTabViewActionTitle, options: .foreground)
+        let viewAction = UNNotificationAction(identifier: SentTabAction.view.rawValue, title: .SentTabViewActionTitle, options: .foreground)
 
         // Register ourselves to handle the notification category set by NotificationService for APNS notifications
         let sentTabCategory = UNNotificationCategory(identifier: "org.mozilla.ios.SentTab.placeholder", actions: [viewAction], intentIdentifiers: [], options: UNNotificationCategoryOptions(rawValue: 0))

--- a/Client/Application/AppDelegate+PushNotifications.swift
+++ b/Client/Application/AppDelegate+PushNotifications.swift
@@ -25,7 +25,7 @@ enum SentTabAction: String {
     static let TabSendCategory = "TabSendCategory"
 
     static func registerActions() {
-        let viewAction = UNNotificationAction(identifier: SentTabAction.view.rawValue, title: .SentTabViewActionTitle, options: .foreground)
+        let viewAction = UNNotificationAction(identifier: SentTabAction.view.rawValue, title: .Notifications.SentTab.ViewActionTitle, options: .foreground)
 
         // Register ourselves to handle the notification category set by NotificationService for APNS notifications
         let sentTabCategory = UNNotificationCategory(identifier: "org.mozilla.ios.SentTab.placeholder", actions: [viewAction], intentIdentifiers: [], options: UNNotificationCategoryOptions(rawValue: 0))

--- a/Client/Application/AppDelegate+SyncSentTabs.swift
+++ b/Client/Application/AppDelegate+SyncSentTabs.swift
@@ -50,9 +50,9 @@ class AppSyncDelegate: SyncDelegate {
                 let notificationContent = UNMutableNotificationContent()
                 let title: String
                 if let deviceName = deviceName {
-                    title = String(format: Strings.SentTab_TabArrivingNotification_WithDevice_title, deviceName)
+                    title = String(format: .SentTab_TabArrivingNotification_WithDevice_title, deviceName)
                 } else {
-                    title = Strings.SentTab_TabArrivingNotification_NoDevice_title
+                    title = .SentTab_TabArrivingNotification_NoDevice_title
                 }
                 notificationContent.title = title
                 notificationContent.body = url.absoluteDisplayExternalString

--- a/Client/Application/AppDelegate+SyncSentTabs.swift
+++ b/Client/Application/AppDelegate+SyncSentTabs.swift
@@ -50,9 +50,9 @@ class AppSyncDelegate: SyncDelegate {
                 let notificationContent = UNMutableNotificationContent()
                 let title: String
                 if let deviceName = deviceName {
-                    title = String(format: .SentTab_TabArrivingNotification_WithDevice_title, deviceName)
+                    title = String(format: .Notifications.SentTab.TabArrivingWithDeviceTitle, deviceName)
                 } else {
-                    title = .SentTab_TabArrivingNotification_NoDevice_title
+                    title = .Notifications.SentTab.TabArrivingNoDeviceTitle
                 }
                 notificationContent.title = title
                 notificationContent.body = url.absoluteDisplayExternalString

--- a/Client/Extensions/UIAlertControllerExtensions.swift
+++ b/Client/Extensions/UIAlertControllerExtensions.swift
@@ -26,25 +26,25 @@ extension UIAlertController {
         dontSendCallback: @escaping UIAlertActionCallback) -> UIAlertController {
 
         let alert = UIAlertController(
-            title: .CrashOptInAlertTitle,
-            message: .CrashOptInAlertMessage,
+            title: .Alerts.CrashOptIn.Title,
+            message: .Alerts.CrashOptIn.Message,
             preferredStyle: .alert
         )
 
         let sendReport = UIAlertAction(
-            title: .CrashOptInAlertSend,
+            title: .Alerts.CrashOptIn.Send,
             style: .default,
             handler: sendReportCallback
         )
 
         let alwaysSend = UIAlertAction(
-            title: .CrashOptInAlertAlwaysSend,
+            title: .Alerts.CrashOptIn.AlwaysSend,
             style: .default,
             handler: alwaysSendCallback
         )
 
         let dontSend = UIAlertAction(
-            title: .CrashOptInAlertDontSend,
+            title: .Alerts.CrashOptIn.DontSend,
             style: .default,
             handler: dontSendCallback
         )
@@ -66,19 +66,19 @@ extension UIAlertController {
     */
     class func restoreTabsAlert(okayCallback: @escaping UIAlertActionCallback, noCallback: @escaping UIAlertActionCallback) -> UIAlertController {
         let alert = UIAlertController(
-            title: .RestoreTabsAlertTitle,
-            message: .RestoreTabsAlertMessage,
+            title: .Alerts.RestoreTabs.Title,
+            message: .Alerts.RestoreTabs.Message,
             preferredStyle: .alert
         )
 
         let noOption = UIAlertAction(
-            title: .RestoreTabsAlertNo,
+            title: .Alerts.RestoreTabs.No,
             style: .cancel,
             handler: noCallback
         )
 
         let okayOption = UIAlertAction(
-            title: .RestoreTabsAlertOkay,
+            title: .Alerts.RestoreTabs.Okay,
             style: .default,
             handler: okayCallback
         )
@@ -91,18 +91,18 @@ extension UIAlertController {
     class func clearPrivateDataAlert(okayCallback: @escaping (UIAlertAction) -> Void) -> UIAlertController {
         let alert = UIAlertController(
             title: "",
-            message: .ClearPrivateDataAlertMessage,
+            message: .Alerts.ClearPrivateData.Message,
             preferredStyle: .alert
         )
 
         let noOption = UIAlertAction(
-            title: .ClearPrivateDataAlertCancel,
+            title: .Alerts.ClearPrivateData.Cancel,
             style: .cancel,
             handler: nil
         )
 
         let okayOption = UIAlertAction(
-            title: .ClearPrivateDataAlertOk,
+            title: .Alerts.ClearPrivateData.Ok,
             style: .destructive,
             handler: okayCallback
         )
@@ -115,18 +115,18 @@ extension UIAlertController {
     class func clearSelectedWebsiteDataAlert(okayCallback: @escaping (UIAlertAction) -> Void) -> UIAlertController {
         let alert = UIAlertController(
             title: "",
-            message: .ClearSelectedWebsiteDataAlertMessage,
+            message: .Alerts.ClearWebsiteData.SelectedWebsiteDataMessage,
             preferredStyle: .alert
         )
 
         let noOption = UIAlertAction(
-            title: .ClearWebsiteDataAlertCancel,
+            title: .Alerts.ClearWebsiteData.Cancel,
             style: .cancel,
             handler: nil
         )
 
         let okayOption = UIAlertAction(
-            title: .ClearWebsiteDataAlertOk,
+            title: .Alerts.ClearWebsiteData.Ok,
             style: .destructive,
             handler: okayCallback
         )
@@ -139,18 +139,18 @@ extension UIAlertController {
     class func clearAllWebsiteDataAlert(okayCallback: @escaping (UIAlertAction) -> Void) -> UIAlertController {
         let alert = UIAlertController(
             title: "",
-            message: .ClearAllWebsiteDataAlertMessage,
+            message: .Alerts.ClearWebsiteData.AllWebsiteDataMessage,
             preferredStyle: .alert
         )
 
         let noOption = UIAlertAction(
-            title: .ClearWebsiteDataAlertCancel,
+            title: .Alerts.ClearWebsiteData.Cancel,
             style: .cancel,
             handler: nil
         )
 
         let okayOption = UIAlertAction(
-            title: .ClearWebsiteDataAlertOk,
+            title: .Alerts.ClearWebsiteData.Ok,
             style: .destructive,
             handler: okayCallback
         )
@@ -171,18 +171,18 @@ extension UIAlertController {
     class func clearSyncedHistoryAlert(okayCallback: @escaping (UIAlertAction) -> Void) -> UIAlertController {
         let alert = UIAlertController(
             title: "",
-            message: .ClearSyncedHistoryAlertMessage,
+            message: .Alerts.ClearSyncedHistoryData.Message,
             preferredStyle: .alert
         )
 
         let noOption = UIAlertAction(
-            title: .ClearSyncedHistoryAlertCancel,
+            title: .Alerts.ClearSyncedHistoryData.Cancel,
             style: .cancel,
             handler: nil
         )
 
         let okayOption = UIAlertAction(
-            title: .ClearSyncedHistoryAlertOk,
+            title: .Alerts.ClearSyncedHistoryData.Ok,
             style: .destructive,
             handler: okayCallback
         )
@@ -207,13 +207,13 @@ extension UIAlertController {
 
         let deleteAlert: UIAlertController
         if hasSyncedLogins {
-            deleteAlert = UIAlertController(title: .DeleteLoginAlertTitle, message: .DeleteLoginAlertSyncedMessage, preferredStyle: .alert)
+            deleteAlert = UIAlertController(title: .Alerts.DeleteLogin.Title, message: .Alerts.DeleteLogin.SyncedMessage, preferredStyle: .alert)
         } else {
-            deleteAlert = UIAlertController(title: .DeleteLoginAlertTitle, message: .DeleteLoginAlertLocalMessage, preferredStyle: .alert)
+            deleteAlert = UIAlertController(title: .Alerts.DeleteLogin.Title, message: .Alerts.DeleteLogin.LocalMessage, preferredStyle: .alert)
         }
 
-        let cancelAction = UIAlertAction(title: .DeleteLoginAlertCancel, style: .cancel, handler: nil)
-        let deleteAction = UIAlertAction(title: .DeleteLoginAlertDelete, style: .destructive, handler: deleteCallback)
+        let cancelAction = UIAlertAction(title: .Alerts.DeleteLogin.Cancel, style: .cancel, handler: nil)
+        let deleteAction = UIAlertAction(title: .Alerts.DeleteLogin.Delete, style: .destructive, handler: deleteCallback)
 
         deleteAlert.addAction(cancelAction)
         deleteAlert.addAction(deleteAction)

--- a/Client/Extensions/UIViewControllerExtension.swift
+++ b/Client/Extensions/UIViewControllerExtension.swift
@@ -16,9 +16,9 @@ enum NavigationItemText {
     func localizedString() -> String {
         switch self {
         case .Done:
-            return Strings.SettingsSearchDoneButton
+            return .SettingsSearchDoneButton
         case .Close:
-            return Strings.CloseButtonTitle
+            return .CloseButtonTitle
         }
     }
 }

--- a/Client/Extensions/UIViewControllerExtension.swift
+++ b/Client/Extensions/UIViewControllerExtension.swift
@@ -16,7 +16,7 @@ enum NavigationItemText {
     func localizedString() -> String {
         switch self {
         case .Done:
-            return .SettingsSearchDoneButton
+            return .Settings.SearchDoneButton
         case .Close:
             return .CloseButtonTitle
         }

--- a/Client/Frontend/Accessors/NewTabAccessors.swift
+++ b/Client/Frontend/Accessors/NewTabAccessors.swift
@@ -49,11 +49,11 @@ enum NewTabPage: String {
     var settingTitle: String {
         switch self {
         case .blankPage:
-            return Strings.SettingsNewTabBlankPage
+            return .SettingsNewTabBlankPage
         case .homePage:
-            return Strings.SettingsNewTabHomePage
+            return .SettingsNewTabHomePage
         case .topSites:
-            return Strings.SettingsNewTabTopSites
+            return .SettingsNewTabTopSites
         }
     }
 

--- a/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
+++ b/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
@@ -11,7 +11,7 @@ class AppAuthenticator {
     static func presentAuthenticationUsingInfo(_ authenticationInfo: AuthenticationKeychainInfo, touchIDReason: String, success: (() -> Void)?, cancel: (() -> Void)?, fallback: (() -> Void)?) {
         if authenticationInfo.useTouchID {
             let localAuthContext = LAContext()
-            localAuthContext.localizedFallbackTitle = .AuthenticationEnterPasscode
+            localAuthContext.localizedFallbackTitle = .AuthenticationManager.EnterPasscode
             localAuthContext.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: touchIDReason) { didSucceed, error in
                 if didSucceed {
                     // Update our authentication info's last validation timestamp so we don't ask again based

--- a/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
+++ b/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
@@ -270,9 +270,9 @@ class AuthenticationSettingsViewController: SettingsTableViewController {
         if localAuthContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) {
             let title: String
             if localAuthContext.biometryType == .faceID {
-                title = Strings.UseFaceID
+                title = .UseFaceID
             } else {
-                title = Strings.UseTouchID
+                title = .UseTouchID
             }
             requirePasscodeSectionChildren.append(
                 TouchIDSetting(

--- a/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
+++ b/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
@@ -27,7 +27,7 @@ class TurnPasscodeOnSetting: Setting {
 
     init(settings: SettingsTableViewController, delegate: SettingsDelegate? = nil) {
         self.settings = settings as? AuthenticationSettingsViewController
-        super.init(title: NSAttributedString.tableRowTitle(.AuthenticationTurnOnPasscode, enabled: true),
+        super.init(title: NSAttributedString.tableRowTitle(.AuthenticationManager.TurnOnPasscode, enabled: true),
                    delegate: delegate)
     }
 
@@ -47,7 +47,7 @@ class TurnPasscodeOffSetting: Setting {
 
     init(settings: SettingsTableViewController, delegate: SettingsDelegate? = nil) {
         self.settings = settings as? AuthenticationSettingsViewController
-        super.init(title: NSAttributedString.tableRowTitle(.AuthenticationTurnOffPasscode, enabled: true),
+        super.init(title: NSAttributedString.tableRowTitle(.AuthenticationManager.TurnOffPasscode, enabled: true),
                    delegate: delegate)
     }
 
@@ -68,7 +68,7 @@ class ChangePasscodeSetting: Setting {
     init(settings: SettingsTableViewController, delegate: SettingsDelegate? = nil, enabled: Bool) {
         self.settings = settings as? AuthenticationSettingsViewController
 
-        let attributedTitle = NSAttributedString.tableRowTitle(.AuthenticationChangePasscode, enabled: enabled)
+        let attributedTitle = NSAttributedString.tableRowTitle(.AuthenticationManager.ChangePasscode, enabled: enabled)
 
         super.init(title: attributedTitle,
                    delegate: delegate,
@@ -108,7 +108,7 @@ class RequirePasscodeSetting: Setting {
         self.navigationController = settings.navigationController
         self.settings = settings as? AuthenticationSettingsViewController
 
-        let title: String = .AuthenticationRequirePasscode
+        let title: String = .AuthenticationManager.RequirePasscode
         let attributedTitle = NSAttributedString.tableRowTitle(title, enabled: enabled ?? true)
         super.init(title: attributedTitle,
                    delegate: delegate,
@@ -129,7 +129,7 @@ class RequirePasscodeSetting: Setting {
         }
 
         if authInfo.requiresValidation() {
-            AppAuthenticator.presentAuthenticationUsingInfo(authInfo, touchIDReason: .AuthenticationRequirePasscodeTouchReason, success: {
+            AppAuthenticator.presentAuthenticationUsingInfo(authInfo, touchIDReason: .AuthenticationManager.RequirePasscodeTouchReason, success: {
                 self.navigateToRequireInterval()
             }, cancel: nil, fallback: {
                 AppAuthenticator.presentPasscodeAuthentication(self.navigationController).uponQueue(.main) { isOk in
@@ -203,7 +203,7 @@ class TouchIDSetting: Setting {
         if authInfo.useTouchID {
             AppAuthenticator.presentAuthenticationUsingInfo(
                 authInfo,
-                touchIDReason: .AuthenticationDisableTouchReason,
+                touchIDReason: .AuthenticationManager.DisableTouchReason,
                 success: self.touchIDSuccess,
                 cancel: nil,
                 fallback: self.touchIDFallback
@@ -246,20 +246,20 @@ class AuthenticationSettingsViewController: SettingsTableViewController {
         if localAuthContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) {
             let title: String
             if localAuthContext.biometryType == .faceID {
-                title = .AuthenticationFaceIDPasscodeSetting
+                title = .AuthenticationManager.FaceIDPasscodeSetting
             } else {
-                title = .AuthenticationTouchIDPasscodeSetting
+                title = .AuthenticationManager.TouchIDPasscodeSetting
             }
             navigationItem.title = title
         } else {
-            navigationItem.title = .AuthenticationPasscode
+            navigationItem.title = .AuthenticationManager.Passcode
         }
     }
 
     fileprivate func passcodeEnabledSettings() -> [SettingSection] {
         var settings = [SettingSection]()
 
-        let passcodeSectionTitle = NSAttributedString(string: .AuthenticationPasscode)
+        let passcodeSectionTitle = NSAttributedString(string: .AuthenticationManager.Passcode)
         let passcodeSection = SettingSection(title: passcodeSectionTitle, children: [
             TurnPasscodeOffSetting(settings: self),
             ChangePasscodeSetting(settings: self, delegate: nil, enabled: true)
@@ -270,9 +270,9 @@ class AuthenticationSettingsViewController: SettingsTableViewController {
         if localAuthContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) {
             let title: String
             if localAuthContext.biometryType == .faceID {
-                title = .UseFaceID
+                title = .Settings.UseFaceID
             } else {
-                title = .UseTouchID
+                title = .Settings.UseTouchID
             }
             requirePasscodeSectionChildren.append(
                 TouchIDSetting(
@@ -302,7 +302,7 @@ class AuthenticationSettingsViewController: SettingsTableViewController {
     fileprivate func passcodeDisabledSettings() -> [SettingSection] {
         var settings = [SettingSection]()
 
-        let passcodeSectionTitle = NSAttributedString(string: .AuthenticationPasscode)
+        let passcodeSectionTitle = NSAttributedString(string: .AuthenticationManager.Passcode)
         let passcodeSection = SettingSection(title: passcodeSectionTitle, children: [
             TurnPasscodeOnSetting(settings: self),
             ChangePasscodeSetting(settings: self, delegate: nil, enabled: false)

--- a/Client/Frontend/AuthenticationManager/BasePasscodeViewController.swift
+++ b/Client/Frontend/AuthenticationManager/BasePasscodeViewController.swift
@@ -52,15 +52,15 @@ extension BasePasscodeViewController {
     }
 
     func displayLockoutError() {
-        displayError(.AuthenticationMaximumAttemptsReachedNoTime)
+        displayError(.AuthenticationManager.MaximumAttemptsReachedNoTime)
     }
 
     func failMismatchPasscode() {
-        displayError(.AuthenticationMismatchPasscodeError)
+        displayError(.AuthenticationManager.MismatchPasscodeError)
     }
 
     func failMustBeDifferent() {
-        displayError(.AuthenticationUseNewPasscodeError)
+        displayError(.AuthenticationManager.UseNewPasscodeError)
     }
 
     func failIncorrectPasscode(_ inputView: PasscodeInputView) {
@@ -68,11 +68,11 @@ extension BasePasscodeViewController {
         let numberOfAttempts = authenticationInfo?.failedAttempts ?? 0
         if numberOfAttempts == AllowedPasscodeFailedAttempts {
             authenticationInfo?.lockOutUser()
-            displayError(.AuthenticationMaximumAttemptsReachedNoTime)
+            displayError(.AuthenticationManager.MaximumAttemptsReachedNoTime)
             inputView.isUserInteractionEnabled = false
             resignFirstResponder()
         } else {
-            displayError(String(format: .AuthenticationIncorrectAttemptsRemaining, (AllowedPasscodeFailedAttempts - numberOfAttempts)))
+            displayError(String(format: .AuthenticationManager.IncorrectAttemptsRemaining, (AllowedPasscodeFailedAttempts - numberOfAttempts)))
         }
 
         inputView.resetCode()

--- a/Client/Frontend/AuthenticationManager/ChangePasscodeViewController.swift
+++ b/Client/Frontend/AuthenticationManager/ChangePasscodeViewController.swift
@@ -13,11 +13,11 @@ class ChangePasscodeViewController: PagingPasscodeViewController, PasscodeInputV
 
     override init() {
         super.init()
-        self.title = .AuthenticationChangePasscode
+        self.title = .AuthenticationManager.ChangePasscode
         self.panes = [
-            PasscodePane(title: .AuthenticationEnterPasscode, passcodeSize: authenticationInfo?.passcode?.count ?? 6),
-            PasscodePane(title: .AuthenticationEnterNewPasscode, passcodeSize: 6),
-            PasscodePane(title: .AuthenticationReenterPasscode, passcodeSize: 6),
+            PasscodePane(title: .AuthenticationManager.EnterPasscode, passcodeSize: authenticationInfo?.passcode?.count ?? 6),
+            PasscodePane(title: .AuthenticationManager.EnterNewPasscode, passcodeSize: 6),
+            PasscodePane(title: .AuthenticationManager.ReenterPasscode, passcodeSize: 6),
         ]
     }
 

--- a/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
+++ b/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
@@ -26,7 +26,7 @@ class PasscodeEntryViewController: BasePasscodeViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = .AuthenticationEnterPasscodeTitle
+        title = .AuthenticationManager.EnterPasscodeTitle
         view.addSubview(passcodePane)
         passcodePane.snp.makeConstraints { make in
             make.bottom.left.right.equalTo(self.view)

--- a/Client/Frontend/AuthenticationManager/RemovePasscodeViewController.swift
+++ b/Client/Frontend/AuthenticationManager/RemovePasscodeViewController.swift
@@ -10,9 +10,9 @@ import Shared
 class RemovePasscodeViewController: PagingPasscodeViewController, PasscodeInputViewDelegate {
     override init() {
         super.init()
-        self.title = .AuthenticationTurnOffPasscode
+        self.title = .AuthenticationManager.TurnOffPasscode
         self.panes = [
-            PasscodePane(title: .AuthenticationEnterPasscode, passcodeSize: authenticationInfo?.passcode?.count ?? 6),
+            PasscodePane(title: .AuthenticationManager.EnterPasscode, passcodeSize: authenticationInfo?.passcode?.count ?? 6),
         ]
     }
 

--- a/Client/Frontend/AuthenticationManager/RequirePasscodeIntervalViewController.swift
+++ b/Client/Frontend/AuthenticationManager/RequirePasscodeIntervalViewController.swift
@@ -30,7 +30,7 @@ class RequirePasscodeIntervalViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = .AuthenticationRequirePasscode
+        title = .AuthenticationManager.RequirePasscode
 
         tableView.accessibilityIdentifier = "AuthenticationManager.passcodeIntervalTableView"
 

--- a/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
+++ b/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
@@ -43,7 +43,7 @@ class SensitiveViewController: UIViewController {
 
         promptingForTouchID = true
         AppAuthenticator.presentAuthenticationUsingInfo(authInfo,
-            touchIDReason: .AuthenticationLoginsTouchReason,
+                                                        touchIDReason: .AuthenticationManager.LoginsTouchReason,
             success: {
                 self.promptingForTouchID = false
                 self.authState = .notAuthenticating

--- a/Client/Frontend/AuthenticationManager/SetupPasscodeViewController.swift
+++ b/Client/Frontend/AuthenticationManager/SetupPasscodeViewController.swift
@@ -12,10 +12,10 @@ class SetupPasscodeViewController: PagingPasscodeViewController, PasscodeInputVi
 
     override init() {
         super.init()
-        self.title = .AuthenticationSetPasscode
+        self.title = .AuthenticationManager.SetPasscode
         self.panes = [
-            PasscodePane(title: .AuthenticationEnterAPasscode, passcodeSize: 6),
-            PasscodePane(title: .AuthenticationReenterPasscode, passcodeSize: 6),
+            PasscodePane(title: .AuthenticationManager.EnterAPasscode, passcodeSize: 6),
+            PasscodePane(title: .AuthenticationManager.ReenterPasscode, passcodeSize: 6),
         ]
     }
 

--- a/Client/Frontend/Browser/Authenticator.swift
+++ b/Client/Frontend/Browser/Authenticator.swift
@@ -106,19 +106,19 @@ class Authenticator {
 
         let deferred = Deferred<Maybe<LoginRecord>>()
         let alert: AlertController
-        let title: String = .AuthenticatorPromptTitle
+        let title: String = .Authenticator.PromptTitle
         if !(protectionSpace.realm?.isEmpty ?? true) {
-            let msg: String = .AuthenticatorPromptRealmMessage
+            let msg: String = .Authenticator.PromptRealmMessage
             let formatted = NSString(format: msg as NSString, protectionSpace.host, protectionSpace.realm ?? "") as String
             alert = AlertController(title: title, message: formatted, preferredStyle: .alert)
         } else {
-            let msg: String = .AuthenticatorPromptEmptyRealmMessage
+            let msg: String = .Authenticator.PromptEmptyRealmMessage
             let formatted = NSString(format: msg as NSString, protectionSpace.host) as String
             alert = AlertController(title: title, message: formatted, preferredStyle: .alert)
         }
 
         // Add a button to log in.
-        let action = UIAlertAction(title: .AuthenticatorLogin,
+        let action = UIAlertAction(title: .Authenticator.Login,
             style: .default) { (action) -> Void in
                 guard let user = alert.textFields?[0].text, let pass = alert.textFields?[1].text else { deferred.fill(Maybe(failure: LoginRecordError(description: "Username and Password required"))); return }
 
@@ -129,20 +129,20 @@ class Authenticator {
         alert.addAction(action, accessibilityIdentifier: "authenticationAlert.loginRequired")
 
         // Add a cancel button.
-        let cancel = UIAlertAction(title: .AuthenticatorCancel, style: .cancel) { (action) -> Void in
+        let cancel = UIAlertAction(title: .Authenticator.Cancel, style: .cancel) { (action) -> Void in
             deferred.fill(Maybe(failure: LoginRecordError(description: "Save password cancelled")))
         }
         alert.addAction(cancel, accessibilityIdentifier: "authenticationAlert.cancel")
 
         // Add a username textfield.
         alert.addTextField { (textfield) -> Void in
-            textfield.placeholder = .AuthenticatorUsernamePlaceholder
+            textfield.placeholder = .Authenticator.UsernamePlaceholder
             textfield.text = credentials?.user
         }
 
         // Add a password textfield.
         alert.addTextField { (textfield) -> Void in
-            textfield.placeholder = .AuthenticatorPasswordPlaceholder
+            textfield.placeholder = .Authenticator.PasswordPlaceholder
             textfield.isSecureTextEntry = true
             textfield.text = credentials?.password
         }

--- a/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -249,7 +249,7 @@ class BackForwardListViewController: UIViewController, UITableViewDataSource, UI
 
         let isAboutHomeURL = InternalURL(item.url)?.isAboutHomeURL ?? false
         guard !isAboutHomeURL else {
-            cell.site = Site(url: item.url.absoluteString, title: Strings.FirefoxHomePage)
+            cell.site = Site(url: item.url.absoluteString, title: .FirefoxHomePage)
             return cell
         }
 

--- a/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/Client/Frontend/Browser/BrowserPrompts.swift
@@ -46,7 +46,7 @@ struct MessageAlert: JSAlertInfo {
         let alertController = JSPromptAlertController(title: titleForJavaScriptPanelInitiatedByFrame(frame),
             message: message,
             preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: Strings.OKString, style: .default) { _ in
+        alertController.addAction(UIAlertAction(title: .OKString, style: .default) { _ in
             self.completionHandler()
         })
         alertController.alertInfo = self
@@ -72,10 +72,10 @@ struct ConfirmPanelAlert: JSAlertInfo {
     func alertController() -> JSPromptAlertController {
         // Show JavaScript confirm dialogs.
         let alertController = JSPromptAlertController(title: titleForJavaScriptPanelInitiatedByFrame(frame), message: message, preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: Strings.OKString, style: .default) { _ in
+        alertController.addAction(UIAlertAction(title: .OKString, style: .default) { _ in
             self.completionHandler(true)
         })
-        alertController.addAction(UIAlertAction(title: Strings.CancelString, style: .cancel) { _ in
+        alertController.addAction(UIAlertAction(title: .CancelString, style: .cancel) { _ in
             self.cancel()
         })
         alertController.alertInfo = self
@@ -109,10 +109,10 @@ struct TextInputAlert: JSAlertInfo {
             input = textField
             input.text = self.defaultText
         })
-        alertController.addAction(UIAlertAction(title: Strings.OKString, style: .default) { _ in
+        alertController.addAction(UIAlertAction(title: .OKString, style: .default) { _ in
             self.completionHandler(input.text)
         })
-        alertController.addAction(UIAlertAction(title: Strings.CancelString, style: .cancel) { _ in
+        alertController.addAction(UIAlertAction(title: .CancelString, style: .cancel) { _ in
             self.cancel()
         })
         alertController.alertInfo = self

--- a/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/Client/Frontend/Browser/BrowserPrompts.swift
@@ -46,7 +46,7 @@ struct MessageAlert: JSAlertInfo {
         let alertController = JSPromptAlertController(title: titleForJavaScriptPanelInitiatedByFrame(frame),
             message: message,
             preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: .OKString, style: .default) { _ in
+        alertController.addAction(UIAlertAction(title: .General.OKString, style: .default) { _ in
             self.completionHandler()
         })
         alertController.alertInfo = self
@@ -72,10 +72,10 @@ struct ConfirmPanelAlert: JSAlertInfo {
     func alertController() -> JSPromptAlertController {
         // Show JavaScript confirm dialogs.
         let alertController = JSPromptAlertController(title: titleForJavaScriptPanelInitiatedByFrame(frame), message: message, preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: .OKString, style: .default) { _ in
+        alertController.addAction(UIAlertAction(title: .General.OKString, style: .default) { _ in
             self.completionHandler(true)
         })
-        alertController.addAction(UIAlertAction(title: .CancelString, style: .cancel) { _ in
+        alertController.addAction(UIAlertAction(title: .General.CancelString, style: .cancel) { _ in
             self.cancel()
         })
         alertController.alertInfo = self
@@ -109,10 +109,10 @@ struct TextInputAlert: JSAlertInfo {
             input = textField
             input.text = self.defaultText
         })
-        alertController.addAction(UIAlertAction(title: .OKString, style: .default) { _ in
+        alertController.addAction(UIAlertAction(title: .General.OKString, style: .default) { _ in
             self.completionHandler(input.text)
         })
-        alertController.addAction(UIAlertAction(title: .CancelString, style: .cancel) { _ in
+        alertController.addAction(UIAlertAction(title: .General.CancelString, style: .cancel) { _ in
             self.cancel()
         })
         alertController.alertInfo = self

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -419,14 +419,14 @@ class BrowserViewController: UIViewController {
         view.addSubview(header)
 
         // UIAccessibilityCustomAction subclass holding an AccessibleAction instance does not work, thus unable to generate AccessibleActions and UIAccessibilityCustomActions "on-demand" and need to make them "persistent" e.g. by being stored in BVC
-        pasteGoAction = AccessibleAction(name: Strings.PasteAndGoTitle, handler: { () -> Bool in
+        pasteGoAction = AccessibleAction(name: .PasteAndGoTitle, handler: { () -> Bool in
             if let pasteboardContents = UIPasteboard.general.string {
                 self.urlBar(self.urlBar, didSubmitText: pasteboardContents)
                 return true
             }
             return false
         })
-        pasteAction = AccessibleAction(name: Strings.PasteTitle, handler: { () -> Bool in
+        pasteAction = AccessibleAction(name: .PasteTitle, handler: { () -> Bool in
             if let pasteboardContents = UIPasteboard.general.string {
                 // Enter overlay mode and make the search controller appear.
                 self.urlBar.enterOverlayMode(pasteboardContents, pasted: true, search: true)
@@ -435,7 +435,7 @@ class BrowserViewController: UIViewController {
             }
             return false
         })
-        copyAddressAction = AccessibleAction(name: Strings.CopyAddressTitle, handler: { () -> Bool in
+        copyAddressAction = AccessibleAction(name: .CopyAddressTitle, handler: { () -> Bool in
             if let url = self.tabManager.selectedTab?.canonicalURL?.displayURL ?? self.urlBar.currentURL {
                 UIPasteboard.general.url = url
             }
@@ -950,8 +950,8 @@ class BrowserViewController: UIViewController {
     }
 
     private func showBookmarksToast() {
-        let toast = ButtonToast(labelText: Strings.AppMenuAddBookmarkConfirmMessage,
-                                buttonText: Strings.BookmarksEdit,
+        let toast = ButtonToast(labelText: .AppMenuAddBookmarkConfirmMessage,
+                                buttonText: .BookmarksEdit,
                                 textAlignment: .left) { isButtonTapped in
             isButtonTapped ? self.openBookmarkEditPanel() : nil
         }
@@ -1548,7 +1548,7 @@ extension BrowserViewController: LibraryPanelDelegate {
             return
         }
         // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
-        let toast = ButtonToast(labelText: Strings.ContextMenuButtonToastNewTabOpenedLabelText, buttonText: Strings.ContextMenuButtonToastNewTabOpenedButtonText, completion: { buttonPressed in
+        let toast = ButtonToast(labelText: .ContextMenuButtonToastNewTabOpenedLabelText, buttonText: .ContextMenuButtonToastNewTabOpenedButtonText, completion: { buttonPressed in
             if buttonPressed {
                 self.tabManager.selectTab(tab)
             }
@@ -1580,7 +1580,7 @@ extension BrowserViewController: HomePanelDelegate {
             return
         }
         // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
-        let toast = ButtonToast(labelText: Strings.ContextMenuButtonToastNewTabOpenedLabelText, buttonText: Strings.ContextMenuButtonToastNewTabOpenedButtonText, completion: { buttonPressed in
+        let toast = ButtonToast(labelText: .ContextMenuButtonToastNewTabOpenedLabelText, buttonText: .ContextMenuButtonToastNewTabOpenedButtonText, completion: { buttonPressed in
             if buttonPressed {
                 self.tabManager.selectTab(tab)
             }
@@ -2006,7 +2006,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                         return
                     }
                     // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
-                    let toast = ButtonToast(labelText: Strings.ContextMenuButtonToastNewTabOpenedLabelText, buttonText: Strings.ContextMenuButtonToastNewTabOpenedButtonText, completion: { buttonPressed in
+                    let toast = ButtonToast(labelText: .ContextMenuButtonToastNewTabOpenedLabelText, buttonText: .ContextMenuButtonToastNewTabOpenedButtonText, completion: { buttonPressed in
                         if buttonPressed {
                             self.tabManager.selectTab(tab)
                         }
@@ -2015,24 +2015,24 @@ extension BrowserViewController: ContextMenuHelperDelegate {
             }
 
             if !isPrivate {
-                let openNewTabAction = UIAlertAction(title: Strings.ContextMenuOpenInNewTab, style: .default) { _ in
+                let openNewTabAction = UIAlertAction(title: .ContextMenuOpenInNewTab, style: .default) { _ in
                     addTab(url, false)
                 }
                 actionSheetController.addAction(openNewTabAction, accessibilityIdentifier: "linkContextMenu.openInNewTab")
             }
 
-            let openNewPrivateTabAction = UIAlertAction(title: Strings.ContextMenuOpenInNewPrivateTab, style: .default) { _ in
+            let openNewPrivateTabAction = UIAlertAction(title: .ContextMenuOpenInNewPrivateTab, style: .default) { _ in
                 addTab(url, true)
             }
             actionSheetController.addAction(openNewPrivateTabAction, accessibilityIdentifier: "linkContextMenu.openInNewPrivateTab")
 
-            let bookmarkAction = UIAlertAction(title: Strings.ContextMenuBookmarkLink, style: .default) { _ in
+            let bookmarkAction = UIAlertAction(title: .ContextMenuBookmarkLink, style: .default) { _ in
                 self.addBookmark(url: url.absoluteString, title: elements.title)
                 TelemetryWrapper.recordEvent(category: .action, method: .add, object: .bookmark, value: .contextMenu)
             }
             actionSheetController.addAction(bookmarkAction, accessibilityIdentifier: "linkContextMenu.bookmarkLink")
 
-            let downloadAction = UIAlertAction(title: Strings.ContextMenuDownloadLink, style: .default) { _ in
+            let downloadAction = UIAlertAction(title: .ContextMenuDownloadLink, style: .default) { _ in
                 // This checks if download is a blob, if yes, begin blob download process
                 if !DownloadContentScript.requestBlobDownload(url: url, tab: currentTab) {
                     //if not a blob, set pendingDownloadWebView and load the request in the webview, which will trigger the WKWebView navigationResponse delegate function and eventually downloadHelper.open()
@@ -2043,12 +2043,12 @@ extension BrowserViewController: ContextMenuHelperDelegate {
             }
             actionSheetController.addAction(downloadAction, accessibilityIdentifier: "linkContextMenu.download")
 
-            let copyAction = UIAlertAction(title: Strings.ContextMenuCopyLink, style: .default) { _ in
+            let copyAction = UIAlertAction(title: .ContextMenuCopyLink, style: .default) { _ in
                 UIPasteboard.general.url = url as URL
             }
             actionSheetController.addAction(copyAction, accessibilityIdentifier: "linkContextMenu.copyLink")
 
-            let shareAction = UIAlertAction(title: Strings.ContextMenuShareLink, style: .default) { _ in
+            let shareAction = UIAlertAction(title: .ContextMenuShareLink, style: .default) { _ in
                 self.presentActivityViewController(url as URL, sourceView: self.view, sourceRect: CGRect(origin: touchPoint, size: touchSize), arrowDirection: .any)
             }
             actionSheetController.addAction(shareAction, accessibilityIdentifier: "linkContextMenu.share")
@@ -2059,7 +2059,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                 dialogTitle = elements.title ?? url.absoluteString
             }
 
-            let saveImageAction = UIAlertAction(title: Strings.ContextMenuSaveImage, style: .default) { _ in
+            let saveImageAction = UIAlertAction(title: .ContextMenuSaveImage, style: .default) { _ in
                 self.getImageData(url) { data in
                     guard let image = UIImage(data: data) else { return }
                     self.writeToPhotoAlbum(image: image)
@@ -2067,7 +2067,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
             }
             actionSheetController.addAction(saveImageAction, accessibilityIdentifier: "linkContextMenu.saveImage")
 
-            let copyAction = UIAlertAction(title: Strings.ContextMenuCopyImage, style: .default) { _ in
+            let copyAction = UIAlertAction(title: .ContextMenuCopyImage, style: .default) { _ in
                 // put the actual image on the clipboard
                 // do this asynchronously just in case we're in a low bandwidth situation
                 let pasteboard = UIPasteboard.general
@@ -2098,7 +2098,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
             }
             actionSheetController.addAction(copyAction, accessibilityIdentifier: "linkContextMenu.copyImage")
 
-            let copyImageLinkAction = UIAlertAction(title: Strings.ContextMenuCopyImageLink, style: .default) { _ in
+            let copyImageLinkAction = UIAlertAction(title: .ContextMenuCopyImageLink, style: .default) { _ in
                 UIPasteboard.general.url = url as URL
             }
             actionSheetController.addAction(copyImageLinkAction, accessibilityIdentifier: "linkContextMenu.copyImageLink")
@@ -2128,7 +2128,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
             }
         }
 
-        let cancelAction = UIAlertAction(title: Strings.CancelString, style: UIAlertAction.Style.cancel, handler: nil)
+        let cancelAction = UIAlertAction(title: .CancelString, style: UIAlertAction.Style.cancel, handler: nil)
         actionSheetController.addAction(cancelAction)
         self.present(actionSheetController, animated: true, completion: nil)
     }
@@ -2311,15 +2311,15 @@ extension BrowserViewController: DevicePickerViewControllerDelegate, Instruction
         guard let tab = tabManager.selectedTab, let url = tab.canonicalURL?.displayURL?.absoluteString else { return }
         let shareItem = ShareItem(url: url, title: tab.title, favicon: tab.displayFavicon)
         guard shareItem.isShareable else {
-            let alert = UIAlertController(title: Strings.SendToErrorTitle, message: Strings.SendToErrorMessage, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: Strings.SendToErrorOKButton, style: .default) { _ in self.popToBVC()})
+            let alert = UIAlertController(title: .SendToErrorTitle, message: .SendToErrorMessage, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: .SendToErrorOKButton, style: .default) { _ in self.popToBVC()})
             present(alert, animated: true, completion: nil)
             return
         }
         profile.sendItem(shareItem, toDevices: devices).uponQueue(.main) { _ in
             self.popToBVC()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                SimpleToast().showAlertWithText(Strings.AppMenuTabSentConfirmMessage, bottomContainer: self.webViewContainer)
+                SimpleToast().showAlertWithText(.AppMenuTabSentConfirmMessage, bottomContainer: self.webViewContainer)
             }
         }
     }
@@ -2340,9 +2340,9 @@ extension BrowserViewController {
             let lastClosedURL = profile.recentlyClosedTabs.tabs.first?.url,
             let selectedTab = tabManager.selectedTab else { return }
 
-        let alertTitleText = Strings.ReopenLastTabAlertTitle
-        let reopenButtonText = Strings.ReopenLastTabButtonText
-        let cancelButtonText = Strings.ReopenLastTabCancelText
+        let alertTitleText = String.ReopenLastTabAlertTitle
+        let reopenButtonText = String.ReopenLastTabButtonText
+        let cancelButtonText = String.ReopenLastTabCancelText
 
         func reopenLastTab(_ action: UIAlertAction) {
             let request = URLRequest(url: lastClosedURL)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -950,8 +950,8 @@ class BrowserViewController: UIViewController {
     }
 
     private func showBookmarksToast() {
-        let toast = ButtonToast(labelText: .AppMenuAddBookmarkConfirmMessage,
-                                buttonText: .BookmarksEdit,
+        let toast = ButtonToast(labelText: .AppMenu.AddBookmarkConfirmMessage,
+                                buttonText: .Bookmarks.Management.Edit,
                                 textAlignment: .left) { isButtonTapped in
             isButtonTapped ? self.openBookmarkEditPanel() : nil
         }
@@ -1699,7 +1699,7 @@ extension BrowserViewController: TabManagerDelegate {
                 }
             }
 
-            webView.accessibilityLabel = .WebViewAccessibilityLabel
+            webView.accessibilityLabel = .BrowserViewController.WebViewAccessibilityLabel
             webView.accessibilityIdentifier = "contentView"
             webView.accessibilityElementsHidden = false
 
@@ -2128,7 +2128,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
             }
         }
 
-        let cancelAction = UIAlertAction(title: .CancelString, style: UIAlertAction.Style.cancel, handler: nil)
+        let cancelAction = UIAlertAction(title: .General.CancelString, style: UIAlertAction.Style.cancel, handler: nil)
         actionSheetController.addAction(cancelAction)
         self.present(actionSheetController, animated: true, completion: nil)
     }
@@ -2311,15 +2311,15 @@ extension BrowserViewController: DevicePickerViewControllerDelegate, Instruction
         guard let tab = tabManager.selectedTab, let url = tab.canonicalURL?.displayURL?.absoluteString else { return }
         let shareItem = ShareItem(url: url, title: tab.title, favicon: tab.displayFavicon)
         guard shareItem.isShareable else {
-            let alert = UIAlertController(title: .SendToErrorTitle, message: .SendToErrorMessage, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: .SendToErrorOKButton, style: .default) { _ in self.popToBVC()})
+            let alert = UIAlertController(title: .ShareExtension.SendTo.ErrorTitle, message: .ShareExtension.SendTo.ErrorMessage, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: .ShareExtension.SendTo.ErrorOKButton, style: .default) { _ in self.popToBVC()})
             present(alert, animated: true, completion: nil)
             return
         }
         profile.sendItem(shareItem, toDevices: devices).uponQueue(.main) { _ in
             self.popToBVC()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                SimpleToast().showAlertWithText(.AppMenuTabSentConfirmMessage, bottomContainer: self.webViewContainer)
+                SimpleToast().showAlertWithText(.AppMenu.TabSentConfirmMessage, bottomContainer: self.webViewContainer)
             }
         }
     }
@@ -2340,9 +2340,9 @@ extension BrowserViewController {
             let lastClosedURL = profile.recentlyClosedTabs.tabs.first?.url,
             let selectedTab = tabManager.selectedTab else { return }
 
-        let alertTitleText = String.ReopenLastTabAlertTitle
-        let reopenButtonText = String.ReopenLastTabButtonText
-        let cancelButtonText = String.ReopenLastTabCancelText
+        let alertTitleText = String.Alerts.ShakeToRestore.AlertTitle
+        let reopenButtonText = String.Alerts.ShakeToRestore.ButtonText
+        let cancelButtonText = String.Alerts.ShakeToRestore.CancelText
 
         func reopenLastTab(_ action: UIAlertAction) {
             let request = URLRequest(url: lastClosedURL)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+DownloadQueueDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+DownloadQueueDelegate.swift
@@ -18,7 +18,7 @@ extension BrowserViewController: DownloadQueueDelegate {
                 if buttonPressed, !downloadQueue.isEmpty {
                     downloadQueue.cancelAll()
 
-                    let downloadCancelledToast = ButtonToast(labelText: Strings.DownloadCancelledToastLabelText, backgroundColor: UIColor.Photon.Grey60, textAlignment: .center)
+                    let downloadCancelledToast = ButtonToast(labelText: .DownloadCancelledToastLabelText, backgroundColor: UIColor.Photon.Grey60, textAlignment: .center)
 
                     self.show(toast: downloadCancelledToast)
                 }
@@ -49,7 +49,7 @@ extension BrowserViewController: DownloadQueueDelegate {
             downloadToast.dismiss(false)
 
             if error == nil {
-                let downloadCompleteToast = ButtonToast(labelText: download.filename, imageName: "check", buttonText: Strings.DownloadsButtonTitle, completion: { buttonPressed in
+                let downloadCompleteToast = ButtonToast(labelText: download.filename, imageName: "check", buttonText: .DownloadsButtonTitle, completion: { buttonPressed in
                     guard buttonPressed else { return }
 
                     self.showLibrary(panel: .downloads)
@@ -58,7 +58,7 @@ extension BrowserViewController: DownloadQueueDelegate {
 
                 self.show(toast: downloadCompleteToast, duration: DispatchTimeInterval.seconds(8))
             } else {
-                let downloadFailedToast = ButtonToast(labelText: Strings.DownloadFailedToastLabelText, backgroundColor: UIColor.Photon.Grey60, textAlignment: .center)
+                let downloadFailedToast = ButtonToast(labelText:.DownloadFailedToastLabelText, backgroundColor: UIColor.Photon.Grey60, textAlignment: .center)
 
                 self.show(toast: downloadFailedToast, duration: nil)
             }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -115,24 +115,24 @@ extension BrowserViewController {
             UIKeyCommand(input: UIKeyCommand.inputRightArrow, modifierFlags: .command, action: #selector(goForwardKeyCommand)),
         ]
         let tabNavigation = [
-            UIKeyCommand(input: "r", modifierFlags: .command, action: #selector(reloadTabKeyCommand), discoverabilityTitle: Strings.ReloadPageTitle),
-            UIKeyCommand(input: "[", modifierFlags: .command, action: #selector(goBackKeyCommand), discoverabilityTitle: Strings.BackTitle),
-            UIKeyCommand(input: "]", modifierFlags: .command, action: #selector(goForwardKeyCommand), discoverabilityTitle: Strings.ForwardTitle),
+            UIKeyCommand(input: "r", modifierFlags: .command, action: #selector(reloadTabKeyCommand), discoverabilityTitle: .ReloadPageTitle),
+            UIKeyCommand(input: "[", modifierFlags: .command, action: #selector(goBackKeyCommand), discoverabilityTitle: .BackTitle),
+            UIKeyCommand(input: "]", modifierFlags: .command, action: #selector(goForwardKeyCommand), discoverabilityTitle: .ForwardTitle),
 
-            UIKeyCommand(input: "f", modifierFlags: .command, action: #selector(findInPageKeyCommand), discoverabilityTitle: Strings.FindTitle),
-            UIKeyCommand(input: "l", modifierFlags: .command, action: #selector(selectLocationBarKeyCommand), discoverabilityTitle: Strings.SelectLocationBarTitle),
-            UIKeyCommand(input: "t", modifierFlags: .command, action: #selector(newTabKeyCommand), discoverabilityTitle: Strings.NewTabTitle),
-            UIKeyCommand(input: "p", modifierFlags: [.command, .shift], action: #selector(newPrivateTabKeyCommand), discoverabilityTitle: Strings.NewPrivateTabTitle),
-            UIKeyCommand(input: "w", modifierFlags: .command, action: #selector(closeTabKeyCommand), discoverabilityTitle: Strings.CloseTabTitle),
-            UIKeyCommand(input: "\t", modifierFlags: .control, action: #selector(nextTabKeyCommand), discoverabilityTitle: Strings.ShowNextTabTitle),
-            UIKeyCommand(input: "\t", modifierFlags: [.control, .shift], action: #selector(previousTabKeyCommand), discoverabilityTitle: Strings.ShowPreviousTabTitle),
+            UIKeyCommand(input: "f", modifierFlags: .command, action: #selector(findInPageKeyCommand), discoverabilityTitle: .FindTitle),
+            UIKeyCommand(input: "l", modifierFlags: .command, action: #selector(selectLocationBarKeyCommand), discoverabilityTitle: .SelectLocationBarTitle),
+            UIKeyCommand(input: "t", modifierFlags: .command, action: #selector(newTabKeyCommand), discoverabilityTitle: .NewTabTitle),
+            UIKeyCommand(input: "p", modifierFlags: [.command, .shift], action: #selector(newPrivateTabKeyCommand), discoverabilityTitle: .NewPrivateTabTitle),
+            UIKeyCommand(input: "w", modifierFlags: .command, action: #selector(closeTabKeyCommand), discoverabilityTitle: .CloseTabTitle),
+            UIKeyCommand(input: "\t", modifierFlags: .control, action: #selector(nextTabKeyCommand), discoverabilityTitle: .ShowNextTabTitle),
+            UIKeyCommand(input: "\t", modifierFlags: [.control, .shift], action: #selector(previousTabKeyCommand), discoverabilityTitle: .ShowPreviousTabTitle),
 
             // Switch tab to match Safari on iOS.
             UIKeyCommand(input: "]", modifierFlags: [.command, .shift], action: #selector(nextTabKeyCommand)),
             UIKeyCommand(input: "[", modifierFlags: [.command, .shift], action: #selector(previousTabKeyCommand)),
 
             UIKeyCommand(input: "\\", modifierFlags: [.command, .shift], action: #selector(showTabTrayKeyCommand)), // Safari on macOS
-            UIKeyCommand(input: "\t", modifierFlags: [.command, .alternate], action: #selector(showTabTrayKeyCommand), discoverabilityTitle: Strings.ShowTabTrayFromTabKeyCodeTitle)
+            UIKeyCommand(input: "\t", modifierFlags: [.command, .alternate], action: #selector(showTabTrayKeyCommand), discoverabilityTitle: .ShowTabTrayFromTabKeyCodeTitle)
         ]
 
         let isEditingText = tabManager.selectedTab?.isEditing ?? false

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -73,7 +73,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
             // Redraw the toolbar so the badge hides from the appMenu button.
             updateToolbarStateForTraitCollection(view.traitCollection)
         }
-        whatsNewAction = PhotonActionSheetItem(title: Strings.WhatsNewString, iconString: "whatsnew", isEnabled: showBadgeForWhatsNew) { _, _ in
+        whatsNewAction = PhotonActionSheetItem(title: .WhatsNewString, iconString: "whatsnew", isEnabled: showBadgeForWhatsNew) { _, _ in
             if let whatsNewTopic = AppInfo.whatsNewTopic, let whatsNewURL = SupportUtils.URLForTopic(whatsNewTopic) {
                 TelemetryWrapper.recordEvent(category: .action, method: .open, object: .whatsNew)
                 self.openURLInNewTab(whatsNewURL)
@@ -88,7 +88,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         let syncAction = syncMenuButton(showFxA: presentSignInViewController)
         let isLoginsButtonShowing = LoginListViewController.shouldShowAppMenuShortcut(forPrefs: profile.prefs)
         let viewLogins: PhotonActionSheetItem? = !isLoginsButtonShowing ? nil :
-            PhotonActionSheetItem(title: Strings.AppMenuPasswords, iconString: "key", iconType: .Image, iconAlignment: .left, isEnabled: true) { _, _ in
+            PhotonActionSheetItem(title: .AppMenuPasswords, iconString: "key", iconType: .Image, iconAlignment: .left, isEnabled: true) { _, _ in
             guard let navController = self.navigationController else { return }
             let navigationHandler: ((_ url: URL?) -> Void) = { url in
                 UIApplication.shared.keyWindow?.rootViewController?.dismiss(animated: true, completion: nil)
@@ -140,10 +140,10 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
             }
         }
 
-        let privateBrowsingMode = PhotonActionSheetItem(title: Strings.privateBrowsingModeTitle, iconString: "nav-tabcounter", iconType: .TabsButton, tabCount: tabCount) { _, _ in
+        let privateBrowsingMode = PhotonActionSheetItem(title: .privateBrowsingModeTitle, iconString: "nav-tabcounter", iconType: .TabsButton, tabCount: tabCount) { _, _ in
             action()
         }
-        let normalBrowsingMode = PhotonActionSheetItem(title: Strings.normalBrowsingModeTitle, iconString: "nav-tabcounter", iconType: .TabsButton, tabCount: tabCount) { _, _ in
+        let normalBrowsingMode = PhotonActionSheetItem(title: .normalBrowsingModeTitle, iconString: "nav-tabcounter", iconType: .TabsButton, tabCount: tabCount) { _, _ in
             action()
         }
 
@@ -154,14 +154,14 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     }
 
     func getMoreTabToolbarLongPressActions() -> [PhotonActionSheetItem] {
-        let newTab = PhotonActionSheetItem(title: Strings.NewTabTitle, iconString: "quick_action_new_tab", iconType: .Image) { _, _ in
+        let newTab = PhotonActionSheetItem(title: .NewTabTitle, iconString: "quick_action_new_tab", iconType: .Image) { _, _ in
             let shouldFocusLocationField = NewTabAccessors.getNewTabPage(self.profile.prefs) == .blankPage
             self.openBlankNewTab(focusLocationField: shouldFocusLocationField, isPrivate: false)
         }
-        let newPrivateTab = PhotonActionSheetItem(title: Strings.NewPrivateTabTitle, iconString: "quick_action_new_tab", iconType: .Image) { _, _ in
+        let newPrivateTab = PhotonActionSheetItem(title: .NewPrivateTabTitle, iconString: "quick_action_new_tab", iconType: .Image) { _, _ in
             let shouldFocusLocationField = NewTabAccessors.getNewTabPage(self.profile.prefs) == .blankPage
             self.openBlankNewTab(focusLocationField: shouldFocusLocationField, isPrivate: true)}
-        let closeTab = PhotonActionSheetItem(title: Strings.CloseTabTitle, iconString: "tab_close", iconType: .Image) { _, _ in
+        let closeTab = PhotonActionSheetItem(title: .CloseTabTitle, iconString: "tab_close", iconType: .Image) { _, _ in
             if let tab = self.tabManager.selectedTab {
                 self.tabManager.removeTabAndUpdateSelectedIndex(tab)
                 self.updateTabCountUsingTabManager(self.tabManager)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -73,7 +73,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
             // Redraw the toolbar so the badge hides from the appMenu button.
             updateToolbarStateForTraitCollection(view.traitCollection)
         }
-        whatsNewAction = PhotonActionSheetItem(title: .WhatsNewString, iconString: "whatsnew", isEnabled: showBadgeForWhatsNew) { _, _ in
+        whatsNewAction = PhotonActionSheetItem(title: .AppMenu.WhatsNewString, iconString: "whatsnew", isEnabled: showBadgeForWhatsNew) { _, _ in
             if let whatsNewTopic = AppInfo.whatsNewTopic, let whatsNewURL = SupportUtils.URLForTopic(whatsNewTopic) {
                 TelemetryWrapper.recordEvent(category: .action, method: .open, object: .whatsNew)
                 self.openURLInNewTab(whatsNewURL)
@@ -88,7 +88,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         let syncAction = syncMenuButton(showFxA: presentSignInViewController)
         let isLoginsButtonShowing = LoginListViewController.shouldShowAppMenuShortcut(forPrefs: profile.prefs)
         let viewLogins: PhotonActionSheetItem? = !isLoginsButtonShowing ? nil :
-            PhotonActionSheetItem(title: .AppMenuPasswords, iconString: "key", iconType: .Image, iconAlignment: .left, isEnabled: true) { _, _ in
+            PhotonActionSheetItem(title: .AppMenu.Passwords, iconString: "key", iconType: .Image, iconAlignment: .left, isEnabled: true) { _, _ in
             guard let navController = self.navigationController else { return }
             let navigationHandler: ((_ url: URL?) -> Void) = { url in
                 UIApplication.shared.keyWindow?.rootViewController?.dismiss(animated: true, completion: nil)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -137,7 +137,7 @@ extension BrowserViewController: URLBarDelegate, FeatureFlagsProtocol {
         let successCallback: (String, ButtonToastAction) -> Void = { (successMessage, toastAction) in
             switch toastAction {
             case .removeBookmark:
-                let toast = ButtonToast(labelText: successMessage, buttonText: .UndoString, textAlignment: .left) { isButtonTapped in
+                let toast = ButtonToast(labelText: successMessage, buttonText: .General.UndoString, textAlignment: .left) { isButtonTapped in
                     isButtonTapped ? self.addBookmark(url: urlString) : nil
                 }
                 self.show(toast: toast)
@@ -175,7 +175,7 @@ extension BrowserViewController: URLBarDelegate, FeatureFlagsProtocol {
     func urlBarDidTapShield(_ urlBar: URLBarView) {
         if let tab = self.tabManager.selectedTab {
             let trackingProtectionMenu = self.getTrackingSubMenu(for: tab)
-            let title = String.localizedStringWithFormat(.TPPageMenuTitle, tab.url?.host ?? "")
+            let title = String.localizedStringWithFormat(.TrackingProtection.PageMenuTitles.Title, tab.url?.host ?? "")
             TelemetryWrapper.recordEvent(category: .action, method: .press, object: .trackingProtectionMenu)
             let shouldSuppress = UIDevice.current.userInterfaceIdiom != .pad
             self.presentSheetWith(title: title, actions: trackingProtectionMenu, on: self, from: urlBar, suppressPopover: shouldSuppress)
@@ -212,7 +212,7 @@ extension BrowserViewController: URLBarDelegate, FeatureFlagsProtocol {
         guard let tab = tabManager.selectedTab,
                let url = tab.url?.displayURL
             else {
-            UIAccessibility.post(notification: UIAccessibility.Notification.announcement, argument: String.ReaderModeAddPageGeneralErrorAccessibilityLabel)
+            UIAccessibility.post(notification: UIAccessibility.Notification.announcement, argument: String.BrowserViewController.ReaderMode.AddPageGeneralErrorAccessibilityLabel)
                 return false
         }
 
@@ -220,10 +220,10 @@ extension BrowserViewController: URLBarDelegate, FeatureFlagsProtocol {
 
         switch result.value {
         case .success:
-            UIAccessibility.post(notification: UIAccessibility.Notification.announcement, argument: String.ReaderModeAddPageSuccessAcessibilityLabel)
-            SimpleToast().showAlertWithText(.ShareAddToReadingListDone, bottomContainer: self.webViewContainer)
+            UIAccessibility.post(notification: UIAccessibility.Notification.announcement, argument: String.BrowserViewController.ReaderMode.AddPageSuccessAcessibilityLabel)
+            SimpleToast().showAlertWithText(.ShareExtension.AddToReadingListDone, bottomContainer: self.webViewContainer)
         case .failure(let error):
-            UIAccessibility.post(notification: UIAccessibility.Notification.announcement, argument: String.ReaderModeAddPageMaybeExistsErrorAccessibilityLabel)
+            UIAccessibility.post(notification: UIAccessibility.Notification.announcement, argument: String.BrowserViewController.ReaderMode.AddPageMaybeExistsErrorAccessibilityLabel)
             print("readingList.createRecordWithURL(url: \"\(url.absoluteString)\", ...) failed with error: \(error)")
         }
         return true

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -45,7 +45,7 @@ extension BrowserViewController: URLBarDelegate, FeatureFlagsProtocol {
                 return
             }
             // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
-            let toast = ButtonToast(labelText: Strings.ContextMenuButtonToastNewTabOpenedLabelText, buttonText: Strings.ContextMenuButtonToastNewTabOpenedButtonText, completion: { buttonPressed in
+            let toast = ButtonToast(labelText: .ContextMenuButtonToastNewTabOpenedLabelText, buttonText: .ContextMenuButtonToastNewTabOpenedButtonText, completion: { buttonPressed in
                 if buttonPressed {
                     self.tabManager.selectTab(tab)
                 }
@@ -137,7 +137,7 @@ extension BrowserViewController: URLBarDelegate, FeatureFlagsProtocol {
         let successCallback: (String, ButtonToastAction) -> Void = { (successMessage, toastAction) in
             switch toastAction {
             case .removeBookmark:
-                let toast = ButtonToast(labelText: successMessage, buttonText: Strings.UndoString, textAlignment: .left) { isButtonTapped in
+                let toast = ButtonToast(labelText: successMessage, buttonText: .UndoString, textAlignment: .left) { isButtonTapped in
                     isButtonTapped ? self.addBookmark(url: urlString) : nil
                 }
                 self.show(toast: toast)
@@ -175,7 +175,7 @@ extension BrowserViewController: URLBarDelegate, FeatureFlagsProtocol {
     func urlBarDidTapShield(_ urlBar: URLBarView) {
         if let tab = self.tabManager.selectedTab {
             let trackingProtectionMenu = self.getTrackingSubMenu(for: tab)
-            let title = String.localizedStringWithFormat(Strings.TPPageMenuTitle, tab.url?.host ?? "")
+            let title = String.localizedStringWithFormat(.TPPageMenuTitle, tab.url?.host ?? "")
             TelemetryWrapper.recordEvent(category: .action, method: .press, object: .trackingProtectionMenu)
             let shouldSuppress = UIDevice.current.userInterfaceIdiom != .pad
             self.presentSheetWith(title: title, actions: trackingProtectionMenu, on: self, from: urlBar, suppressPopover: shouldSuppress)
@@ -221,7 +221,7 @@ extension BrowserViewController: URLBarDelegate, FeatureFlagsProtocol {
         switch result.value {
         case .success:
             UIAccessibility.post(notification: UIAccessibility.Notification.announcement, argument: String.ReaderModeAddPageSuccessAcessibilityLabel)
-            SimpleToast().showAlertWithText(Strings.ShareAddToReadingListDone, bottomContainer: self.webViewContainer)
+            SimpleToast().showAlertWithText(.ShareAddToReadingListDone, bottomContainer: self.webViewContainer)
         case .failure(let error):
             UIAccessibility.post(notification: UIAccessibility.Notification.announcement, argument: String.ReaderModeAddPageMaybeExistsErrorAccessibilityLabel)
             print("readingList.createRecordWithURL(url: \"\(url.absoluteString)\", ...) failed with error: \(error)")

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -248,9 +248,9 @@ extension BrowserViewController: WKUIDelegate {
         guard error != nil else { return }
         DispatchQueue.main.async {
             let accessDenied = UIAlertController(title: .PhotoLibraryFirefoxWouldLikeAccessTitle, message: .PhotoLibraryFirefoxWouldLikeAccessMessage, preferredStyle: .alert)
-            let dismissAction = UIAlertAction(title: .CancelString, style: .default, handler: nil)
+            let dismissAction = UIAlertAction(title: .General.CancelString, style: .default, handler: nil)
             accessDenied.addAction(dismissAction)
-            let settingsAction = UIAlertAction(title: .OpenSettingsString, style: .default ) { _ in
+            let settingsAction = UIAlertAction(title: .General.OpenSettingsString, style: .default ) { _ in
                 UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!, options: [:])
             }
             accessDenied.addAction(settingsAction)
@@ -319,12 +319,12 @@ extension BrowserViewController: WKNavigationDelegate {
 
     // Use for sms and mailto links, which do not show a confirmation before opening.
     fileprivate func showSnackbar(forExternalUrl url: URL, tab: Tab, completion: @escaping (Bool) -> ()) {
-        let snackBar = TimerSnackBar(text: .ExternalLinkGenericConfirmation + "\n\(url.absoluteString)", img: nil)
-        let ok = SnackButton(title: .OKString, accessibilityIdentifier: "AppOpenExternal.button.ok") { bar in
+        let snackBar = TimerSnackBar(text: .Snackbar.ExternalLinks.GenericConfirmation + "\n\(url.absoluteString)", img: nil)
+        let ok = SnackButton(title: .General.OKString, accessibilityIdentifier: "AppOpenExternal.button.ok") { bar in
             tab.removeSnackbar(bar)
             completion(true)
         }
-        let cancel = SnackButton(title: .CancelString, accessibilityIdentifier: "AppOpenExternal.button.cancel") { bar in
+        let cancel = SnackButton(title: .General.CancelString, accessibilityIdentifier: "AppOpenExternal.button.cancel") { bar in
             tab.removeSnackbar(bar)
             completion(false)
         }
@@ -472,7 +472,7 @@ extension BrowserViewController: WKNavigationDelegate {
                     // Do not show error message for JS navigated links or redirect as it's not the result of a user action.
                     if !openedURL, navigationAction.navigationType == .linkActivated {
                         let alert = UIAlertController(title: .UnableToOpenURLErrorTitle, message: .UnableToOpenURLError, preferredStyle: .alert)
-                        alert.addAction(UIAlertAction(title: .OKString, style: .default, handler: nil))
+                        alert.addAction(UIAlertAction(title: .General.OKString, style: .default, handler: nil))
                         self.present(alert, animated: true, completion: nil)
                     }
                 }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -135,12 +135,12 @@ extension BrowserViewController: WKUIDelegate {
                 var toastLabelText: String
                 
                 if isPrivate {
-                    toastLabelText = Strings.ContextMenuButtonToastNewPrivateTabOpenedLabelText
+                    toastLabelText = .ContextMenuButtonToastNewPrivateTabOpenedLabelText
                 } else {
-                    toastLabelText = Strings.ContextMenuButtonToastNewTabOpenedLabelText
+                    toastLabelText = .ContextMenuButtonToastNewTabOpenedLabelText
                 }
                 // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
-                let toast = ButtonToast(labelText: toastLabelText, buttonText: Strings.ContextMenuButtonToastNewTabOpenedButtonText, completion: { buttonPressed in
+                let toast = ButtonToast(labelText: toastLabelText, buttonText: .ContextMenuButtonToastNewTabOpenedButtonText, completion: { buttonPressed in
                     if buttonPressed {
                         self.tabManager.selectTab(tab)
                     }
@@ -159,21 +159,21 @@ extension BrowserViewController: WKUIDelegate {
             var actions = [UIAction]()
 
             if !isPrivate {
-                actions.append(UIAction(title: Strings.ContextMenuOpenInNewTab, image: UIImage.templateImageNamed("menu-NewTab"), identifier: UIAction.Identifier(rawValue: "linkContextMenu.openInNewTab")) {_ in
+                actions.append(UIAction(title: .ContextMenuOpenInNewTab, image: UIImage.templateImageNamed("menu-NewTab"), identifier: UIAction.Identifier(rawValue: "linkContextMenu.openInNewTab")) {_ in
                     addTab(url, false)
                 })
             }
 
-            actions.append(UIAction(title: Strings.ContextMenuOpenInNewPrivateTab, image: UIImage.templateImageNamed("menu-NewPrivateTab"), identifier: UIAction.Identifier("linkContextMenu.openInNewPrivateTab")) { _ in
+            actions.append(UIAction(title: .ContextMenuOpenInNewPrivateTab, image: UIImage.templateImageNamed("menu-NewPrivateTab"), identifier: UIAction.Identifier("linkContextMenu.openInNewPrivateTab")) { _ in
                 addTab(url, true)
             })
 
-            actions.append(UIAction(title: Strings.ContextMenuBookmarkLink, image: UIImage.templateImageNamed("menu-Bookmark"), identifier: UIAction.Identifier("linkContextMenu.bookmarkLink")) { _ in
+            actions.append(UIAction(title: .ContextMenuBookmarkLink, image: UIImage.templateImageNamed("menu-Bookmark"), identifier: UIAction.Identifier("linkContextMenu.bookmarkLink")) { _ in
                 self.addBookmark(url: url.absoluteString, title: elements.title)
                 TelemetryWrapper.recordEvent(category: .action, method: .add, object: .bookmark, value: .contextMenu)
             })
 
-            actions.append(UIAction(title: Strings.ContextMenuDownloadLink, image: UIImage.templateImageNamed("menu-panel-Downloads"), identifier: UIAction.Identifier("linkContextMenu.download")) {_ in
+            actions.append(UIAction(title: .ContextMenuDownloadLink, image: UIImage.templateImageNamed("menu-panel-Downloads"), identifier: UIAction.Identifier("linkContextMenu.download")) {_ in
                 // This checks if download is a blob, if yes, begin blob download process
                 if !DownloadContentScript.requestBlobDownload(url: url, tab: currentTab) {
                     //if not a blob, set pendingDownloadWebView and load the request in the webview, which will trigger the WKWebView navigationResponse delegate function and eventually downloadHelper.open()
@@ -183,11 +183,11 @@ extension BrowserViewController: WKUIDelegate {
                 }
             })
 
-            actions.append(UIAction(title: Strings.ContextMenuCopyLink, image: UIImage.templateImageNamed("menu-Copy-Link"), identifier: UIAction.Identifier("linkContextMenu.copyLink")) { _ in
+            actions.append(UIAction(title: .ContextMenuCopyLink, image: UIImage.templateImageNamed("menu-Copy-Link"), identifier: UIAction.Identifier("linkContextMenu.copyLink")) { _ in
                 UIPasteboard.general.url = url
             })
 
-            actions.append(UIAction(title: Strings.ContextMenuShareLink, image: UIImage.templateImageNamed("action_share"), identifier: UIAction.Identifier("linkContextMenu.share")) { _ in
+            actions.append(UIAction(title: .ContextMenuShareLink, image: UIImage.templateImageNamed("action_share"), identifier: UIAction.Identifier("linkContextMenu.share")) { _ in
                 guard let tab = self.tabManager[webView], let helper = tab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper else { return }
                 // This is only used on ipad for positioning the popover. On iPhone it is an action sheet.
                 let p = webView.convert(helper.touchPoint, to: self.view)
@@ -195,14 +195,14 @@ extension BrowserViewController: WKUIDelegate {
             })
 
             if let url = elements.image {
-                actions.append(UIAction(title: Strings.ContextMenuSaveImage, identifier: UIAction.Identifier("linkContextMenu.saveImage")) { _ in
+                actions.append(UIAction(title: .ContextMenuSaveImage, identifier: UIAction.Identifier("linkContextMenu.saveImage")) { _ in
                     getImageData(url) { data in
                         guard let image = UIImage(data: data) else { return }
                         self.writeToPhotoAlbum(image: image)
                     }
                 })
 
-                actions.append(UIAction(title: Strings.ContextMenuCopyImage, identifier: UIAction.Identifier("linkContextMenu.copyImage")) { _ in
+                actions.append(UIAction(title: .ContextMenuCopyImage, identifier: UIAction.Identifier("linkContextMenu.copyImage")) { _ in
                     // put the actual image on the clipboard
                     // do this asynchronously just in case we're in a low bandwidth situation
                     let pasteboard = UIPasteboard.general
@@ -231,7 +231,7 @@ extension BrowserViewController: WKUIDelegate {
                     }.resume()
                 })
 
-                actions.append(UIAction(title: Strings.ContextMenuCopyImageLink, identifier: UIAction.Identifier("linkContextMenu.copyImageLink")) { _ in
+                actions.append(UIAction(title: .ContextMenuCopyImageLink, identifier: UIAction.Identifier("linkContextMenu.copyImageLink")) { _ in
                     UIPasteboard.general.url = url as URL
                 })
             }
@@ -247,10 +247,10 @@ extension BrowserViewController: WKUIDelegate {
     @objc func saveError(_ image: UIImage, didFinishSavingWithError error: Error?, contextInfo: UnsafeRawPointer) {
         guard error != nil else { return }
         DispatchQueue.main.async {
-            let accessDenied = UIAlertController(title: Strings.PhotoLibraryFirefoxWouldLikeAccessTitle, message: Strings.PhotoLibraryFirefoxWouldLikeAccessMessage, preferredStyle: .alert)
-            let dismissAction = UIAlertAction(title: Strings.CancelString, style: .default, handler: nil)
+            let accessDenied = UIAlertController(title: .PhotoLibraryFirefoxWouldLikeAccessTitle, message: .PhotoLibraryFirefoxWouldLikeAccessMessage, preferredStyle: .alert)
+            let dismissAction = UIAlertAction(title: .CancelString, style: .default, handler: nil)
             accessDenied.addAction(dismissAction)
-            let settingsAction = UIAlertAction(title: Strings.OpenSettingsString, style: .default ) { _ in
+            let settingsAction = UIAlertAction(title: .OpenSettingsString, style: .default ) { _ in
                 UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!, options: [:])
             }
             accessDenied.addAction(settingsAction)
@@ -319,12 +319,12 @@ extension BrowserViewController: WKNavigationDelegate {
 
     // Use for sms and mailto links, which do not show a confirmation before opening.
     fileprivate func showSnackbar(forExternalUrl url: URL, tab: Tab, completion: @escaping (Bool) -> ()) {
-        let snackBar = TimerSnackBar(text: Strings.ExternalLinkGenericConfirmation + "\n\(url.absoluteString)", img: nil)
-        let ok = SnackButton(title: Strings.OKString, accessibilityIdentifier: "AppOpenExternal.button.ok") { bar in
+        let snackBar = TimerSnackBar(text: .ExternalLinkGenericConfirmation + "\n\(url.absoluteString)", img: nil)
+        let ok = SnackButton(title: .OKString, accessibilityIdentifier: "AppOpenExternal.button.ok") { bar in
             tab.removeSnackbar(bar)
             completion(true)
         }
-        let cancel = SnackButton(title: Strings.CancelString, accessibilityIdentifier: "AppOpenExternal.button.cancel") { bar in
+        let cancel = SnackButton(title: .CancelString, accessibilityIdentifier: "AppOpenExternal.button.cancel") { bar in
             tab.removeSnackbar(bar)
             completion(false)
         }
@@ -471,8 +471,8 @@ extension BrowserViewController: WKNavigationDelegate {
                 UIApplication.shared.open(url, options: [:]) { openedURL in
                     // Do not show error message for JS navigated links or redirect as it's not the result of a user action.
                     if !openedURL, navigationAction.navigationType == .linkActivated {
-                        let alert = UIAlertController(title: Strings.UnableToOpenURLErrorTitle, message: Strings.UnableToOpenURLError, preferredStyle: .alert)
-                        alert.addAction(UIAlertAction(title: Strings.OKString, style: .default, handler: nil))
+                        let alert = UIAlertController(title: .UnableToOpenURLErrorTitle, message: .UnableToOpenURLError, preferredStyle: .alert)
+                        alert.addAction(UIAlertAction(title: .OKString, style: .default, handler: nil))
                         self.present(alert, animated: true, completion: nil)
                     }
                 }

--- a/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -141,9 +141,9 @@ class ClipboardBarDisplayHandler: NSObject, URLChangeDelegate {
 
             self.clipboardToast =
                 ButtonToast(
-                    labelText: Strings.GoToCopiedLink,
+                    labelText: .GoToCopiedLink,
                     descriptionText: url.absoluteDisplayString,
-                    buttonText: Strings.GoButtonTittle,
+                    buttonText: .GoButtonTittle,
                     completion: { buttonPressed in
                         if buttonPressed {
                             self.delegate?.settingsOpenURLInNewTab(url)

--- a/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -141,9 +141,9 @@ class ClipboardBarDisplayHandler: NSObject, URLChangeDelegate {
 
             self.clipboardToast =
                 ButtonToast(
-                    labelText: .GoToCopiedLink,
+                    labelText: .Clipboard.Toast.GoToCopiedLink,
                     descriptionText: url.absoluteDisplayString,
-                    buttonText: .GoButtonTittle,
+                    buttonText: .Clipboard.Toast.GoButtonTittle,
                     completion: { buttonPressed in
                         if buttonPressed {
                             self.delegate?.settingsOpenURLInNewTab(url)

--- a/Client/Frontend/Browser/DownloadToast.swift
+++ b/Client/Frontend/Browser/DownloadToast.swift
@@ -43,15 +43,15 @@ class DownloadToast: Toast {
     var descriptionText: String {
         let downloadedSize = ByteCountFormatter.string(fromByteCount: combinedBytesDownloaded, countStyle: .file)
         let expectedSize = combinedTotalBytesExpected != nil ? ByteCountFormatter.string(fromByteCount: combinedTotalBytesExpected!, countStyle: .file) : nil
-        let descriptionText = expectedSize != nil ? String(format: Strings.DownloadProgressToastDescriptionText, downloadedSize, expectedSize!) : downloadedSize
+        let descriptionText = expectedSize != nil ? String(format: .DownloadProgressToastDescriptionText, downloadedSize, expectedSize!) : downloadedSize
 
         guard downloads.count > 1 else {
             return descriptionText
         }
 
-        let fileCountDescription = String(format: Strings.DownloadMultipleFilesToastDescriptionText, downloads.count)
+        let fileCountDescription = String(format: .DownloadMultipleFilesToastDescriptionText, downloads.count)
 
-        return String(format: Strings.DownloadMultipleFilesAndProgressToastDescriptionText, fileCountDescription, descriptionText)
+        return String(format: .DownloadMultipleFilesAndProgressToastDescriptionText, fileCountDescription, descriptionText)
     }
 
     var downloads: [Download] = []
@@ -167,9 +167,9 @@ class DownloadToast: Toast {
     }
 
     @objc func buttonPressed(_ gestureRecognizer: UIGestureRecognizer) {
-        let alert = AlertController(title: Strings.CancelDownloadDialogTitle, message: Strings.CancelDownloadDialogMessage, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: Strings.CancelDownloadDialogResume, style: .cancel, handler: nil), accessibilityIdentifier: "cancelDownloadAlert.resume")
-        alert.addAction(UIAlertAction(title: Strings.CancelDownloadDialogCancel, style: .default, handler: { action in
+        let alert = AlertController(title: .CancelDownloadDialogTitle, message: .CancelDownloadDialogMessage, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: .CancelDownloadDialogResume, style: .cancel, handler: nil), accessibilityIdentifier: "cancelDownloadAlert.resume")
+        alert.addAction(UIAlertAction(title: .CancelDownloadDialogCancel, style: .default, handler: { action in
             self.completionHandler?(true)
             self.dismiss(true)
             TelemetryWrapper.recordEvent(category: .action, method: .cancel, object: .download)

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -509,7 +509,7 @@ extension GridTabViewController: TabDisplayCompletionDelegate, RecentlyClosedPan
     // TabDisplayCompletionDelegate
     func displayRecentlyClosedTabs() {
         recentlyClosedTabsPanel = RecentlyClosedTabsPanel(profile: profile)
-        recentlyClosedTabsPanel!.title = Strings.RecentlyClosedTabsButtonTitle
+        recentlyClosedTabsPanel!.title = .RecentlyClosedTabsButtonTitle
         recentlyClosedTabsPanel!.recentlyClosedTabsDelegate = self
         navigationController?.pushViewController(recentlyClosedTabsPanel!, animated: true)
     }
@@ -563,7 +563,7 @@ extension GridTabViewController {
         }
 
         let controller = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        controller.addAction(UIAlertAction(title: Strings.AppMenuCloseAllTabsTitleString, style: .default, handler: { _ in self.closeTabsForCurrentTray() }), accessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
+        controller.addAction(UIAlertAction(title: .AppMenuCloseAllTabsTitleString, style: .default, handler: { _ in self.closeTabsForCurrentTray() }), accessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
         controller.addAction(UIAlertAction(title: .TabTrayCloseAllTabsPromptCancel, style: .cancel, handler: nil), accessibilityIdentifier: "TabTrayController.deleteButton.cancel")
         controller.popoverPresentationController?.barButtonItem = sender
         present(controller, animated: true, completion: nil)

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -563,7 +563,7 @@ extension GridTabViewController {
         }
 
         let controller = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        controller.addAction(UIAlertAction(title: .AppMenuCloseAllTabsTitleString, style: .default, handler: { _ in self.closeTabsForCurrentTray() }), accessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
+        controller.addAction(UIAlertAction(title: .AppMenu.CloseAllTabsTitleString, style: .default, handler: { _ in self.closeTabsForCurrentTray() }), accessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
         controller.addAction(UIAlertAction(title: .TabTrayCloseAllTabsPromptCancel, style: .cancel, handler: nil), accessibilityIdentifier: "TabTrayController.deleteButton.cancel")
         controller.popoverPresentationController?.barButtonItem = sender
         present(controller, animated: true, completion: nil)

--- a/Client/Frontend/Browser/LoginsHelper.swift
+++ b/Client/Frontend/Browser/LoginsHelper.swift
@@ -175,9 +175,9 @@ class LoginsHelper: TabContentScript {
         let url = login.hostname.replacingOccurrences(of: https, with: "", options: .regularExpression, range: nil)
         let userName = login.username
         if !userName.isEmpty {
-            promptMessage = String(format: Strings.SaveLoginUsernamePrompt, userName, url)
+            promptMessage = String(format: .SaveLoginUsernamePrompt, userName, url)
         } else {
-            promptMessage = String(format: Strings.SaveLoginPrompt, url)
+            promptMessage = String(format: .SaveLoginPrompt, url)
         }
 
         if let existingPrompt = self.snackBar {
@@ -185,12 +185,12 @@ class LoginsHelper: TabContentScript {
         }
 
         snackBar = TimerSnackBar(text: promptMessage, img: UIImage(named: "key"))
-        let dontSave = SnackButton(title: Strings.LoginsHelperDontSaveButtonTitle, accessibilityIdentifier: "SaveLoginPrompt.dontSaveButton", bold: false) { bar in
+        let dontSave = SnackButton(title: .LoginsHelperDontSaveButtonTitle, accessibilityIdentifier: "SaveLoginPrompt.dontSaveButton", bold: false) { bar in
             self.tab?.removeSnackbar(bar)
             self.snackBar = nil
             return
         }
-        let save = SnackButton(title: Strings.LoginsHelperSaveLoginButtonTitle, accessibilityIdentifier: "SaveLoginPrompt.saveLoginButton", bold: true) { bar in
+        let save = SnackButton(title: .LoginsHelperSaveLoginButtonTitle, accessibilityIdentifier: "SaveLoginPrompt.saveLoginButton", bold: true) { bar in
             self.tab?.removeSnackbar(bar)
             self.snackBar = nil
             _ = self.profile.logins.add(login: login)
@@ -210,9 +210,9 @@ class LoginsHelper: TabContentScript {
         let formatted: String
         let userName = new.username
         if !userName.isEmpty {
-            formatted = String(format: Strings.UpdateLoginUsernamePrompt, userName, new.hostname)
+            formatted = String(format: .UpdateLoginUsernamePrompt, userName, new.hostname)
         } else {
-            formatted = String(format: Strings.UpdateLoginPrompt, new.hostname)
+            formatted = String(format: .UpdateLoginPrompt, new.hostname)
         }
 
         if let existingPrompt = self.snackBar {
@@ -220,11 +220,11 @@ class LoginsHelper: TabContentScript {
         }
 
         snackBar = TimerSnackBar(text: formatted, img: UIImage(named: "key"))
-        let dontSave = SnackButton(title: Strings.LoginsHelperDontUpdateButtonTitle, accessibilityIdentifier: "UpdateLoginPrompt.donttUpdateButton", bold: false) { bar in
+        let dontSave = SnackButton(title: .LoginsHelperDontUpdateButtonTitle, accessibilityIdentifier: "UpdateLoginPrompt.donttUpdateButton", bold: false) { bar in
             self.tab?.removeSnackbar(bar)
             self.snackBar = nil
         }
-        let update = SnackButton(title: Strings.LoginsHelperUpdateButtonTitle, accessibilityIdentifier: "UpdateLoginPrompt.updateButton", bold: true) { bar in
+        let update = SnackButton(title: .LoginsHelperUpdateButtonTitle, accessibilityIdentifier: "UpdateLoginPrompt.updateButton", bold: true) { bar in
             self.tab?.removeSnackbar(bar)
             self.snackBar = nil
             _ = self.profile.logins.update(login: new)

--- a/Client/Frontend/Browser/OpenInHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper.swift
@@ -111,14 +111,14 @@ class DownloadHelper: NSObject {
             label.lineBreakMode = .byCharWrapping
         }
 
-        let downloadFileItem = PhotonActionSheetItem(title: Strings.OpenInDownloadHelperAlertDownloadNow, iconString: "download") { _, _ in
+        let downloadFileItem = PhotonActionSheetItem(title: .OpenInDownloadHelperAlertDownloadNow, iconString: "download") { _, _ in
             self.browserViewController.downloadQueue.enqueue(download)
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .downloadNowButton)
         }
 
         let actions = [[filenameItem], [downloadFileItem]]
 
-        browserViewController.presentSheetWith(title: download.filename, actions: actions, on: browserViewController, from: browserViewController.urlBar, closeButtonTitle: Strings.CancelString, suppressPopover: true)
+        browserViewController.presentSheetWith(title: download.filename, actions: actions, on: browserViewController, from: browserViewController.urlBar, closeButtonTitle: .CancelString, suppressPopover: true)
     }
 }
 
@@ -150,8 +150,8 @@ class OpenPassBookHelper: NSObject {
                 }
             }
         } catch {
-            let alertController = UIAlertController(title: Strings.UnableToAddPassErrorTitle, message: Strings.UnableToAddPassErrorMessage, preferredStyle: .alert)
-            alertController.addAction(UIAlertAction(title: Strings.UnableToAddPassErrorDismiss, style: .cancel) { (action) in
+            let alertController = UIAlertController(title: .UnableToAddPassErrorTitle, message: .UnableToAddPassErrorMessage, preferredStyle: .alert)
+            alertController.addAction(UIAlertAction(title: .UnableToAddPassErrorDismiss, style: .cancel) { (action) in
                     // Do nothing.
             })
             browserViewController.present(alertController, animated: true, completion: nil)

--- a/Client/Frontend/Browser/OpenInHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper.swift
@@ -118,7 +118,7 @@ class DownloadHelper: NSObject {
 
         let actions = [[filenameItem], [downloadFileItem]]
 
-        browserViewController.presentSheetWith(title: download.filename, actions: actions, on: browserViewController, from: browserViewController.urlBar, closeButtonTitle: .CancelString, suppressPopover: true)
+        browserViewController.presentSheetWith(title: download.filename, actions: actions, on: browserViewController, from: browserViewController.urlBar, closeButtonTitle: .General.CancelString, suppressPopover: true)
     }
 }
 

--- a/Client/Frontend/Browser/OpenWithSettingsViewController.swift
+++ b/Client/Frontend/Browser/OpenWithSettingsViewController.swift
@@ -23,13 +23,13 @@ class OpenWithSettingsViewController: ThemedTableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = Strings.SettingsOpenWithSectionName
+        title = .SettingsOpenWithSectionName
 
         tableView.accessibilityIdentifier = "OpenWithPage.Setting.Options"
 
         let headerFooterFrame = CGRect(width: self.view.frame.width, height: SettingsUX.TableViewHeaderFooterHeight)
         let headerView = ThemedTableSectionHeaderFooterView(frame: headerFooterFrame)
-        headerView.titleLabel.text = Strings.SettingsOpenWithPageTitle.uppercased()
+        headerView.titleLabel.text = .SettingsOpenWithPageTitle.uppercased()
         let footerView = ThemedTableSectionHeaderFooterView(frame: headerFooterFrame)
 
         tableView.tableHeaderView = headerView

--- a/Client/Frontend/Browser/QRCodeViewController.swift
+++ b/Client/Frontend/Browser/QRCodeViewController.swift
@@ -38,7 +38,7 @@ class QRCodeViewController: UIViewController {
     private let scanBorder = UIImageView(image: UIImage(named: "qrcode-scanBorder"))
     private lazy var instructionsLabel: UILabel = {
         let label = UILabel()
-        label.text = Strings.ScanQRCodeInstructionsLabel
+        label.text = .ScanQRCodeInstructionsLabel
         label.textColor = UIColor.Photon.White100
         label.textAlignment = .center
         label.numberOfLines = 0
@@ -57,7 +57,7 @@ class QRCodeViewController: UIViewController {
             return
         }
 
-        self.navigationItem.title = Strings.ScanQRCodeViewTitle
+        self.navigationItem.title = .ScanQRCodeViewTitle
 
         // Setup the NavigationBar
         self.navigationController?.navigationBar.barTintColor = QRCodeViewControllerUX.navigationBarBackgroundColor
@@ -82,8 +82,8 @@ class QRCodeViewController: UIViewController {
             view.backgroundColor = QRCodeViewControllerUX.viewBackgroundDeniedColor
             self.navigationItem.rightBarButtonItem?.isEnabled = false
 
-            let alert = UIAlertController(title: "", message: Strings.ScanQRCodePermissionErrorMessage, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: Strings.ScanQRCodeErrorOKButton, style: .default, handler: { (action) -> Void in
+            let alert = UIAlertController(title: "", message: .ScanQRCodePermissionErrorMessage, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: .ScanQRCodeErrorOKButton, style: .default, handler: { (action) -> Void in
                 self.dismiss(animated: true)
             }))
             self.present(alert, animated: true, completion: nil)
@@ -275,8 +275,8 @@ extension QRCodeViewController: AVCaptureMetadataOutputObjectsDelegate {
     func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
         if metadataObjects.isEmpty {
             self.captureSession.stopRunning()
-            let alert = AlertController(title: "", message: Strings.ScanQRCodeInvalidDataErrorMessage, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: Strings.ScanQRCodeErrorOKButton, style: .default, handler: { (UIAlertAction) in
+            let alert = AlertController(title: "", message: .ScanQRCodeInvalidDataErrorMessage, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: .ScanQRCodeErrorOKButton, style: .default, handler: { (UIAlertAction) in
                 self.captureSession.startRunning()
             }), accessibilityIdentifier: "qrCodeAlert.okButton")
             self.present(alert, animated: true, completion: nil)

--- a/Client/Frontend/Browser/ReaderModeBarView.swift
+++ b/Client/Frontend/Browser/ReaderModeBarView.swift
@@ -14,11 +14,11 @@ enum ReaderModeBarButtonType {
 
     fileprivate var localizedDescription: String {
         switch self {
-        case .markAsRead: return .ReaderModeBarMarkAsRead
-        case .markAsUnread: return .ReaderModeBarMarkAsUnread
-        case .settings: return .ReaderModeBarSettings
-        case .addToReadingList: return .ReaderModeBarAddToReadingList
-        case .removeFromReadingList: return .ReaderModeBarRemoveFromReadingList
+        case .markAsRead: return .ReaderMode.Bar.MarkAsRead
+        case .markAsUnread: return .ReaderMode.Bar.MarkAsUnread
+        case .settings: return .ReaderMode.Bar.Settings
+        case .addToReadingList: return .ReaderMode.Bar.AddToReadingList
+        case .removeFromReadingList: return .ReaderMode.Bar.RemoveFromReadingList
         }
     }
 

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -230,7 +230,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         searchButton.imageView?.contentMode = .center
         searchButton.layer.backgroundColor = SearchViewControllerUX.EngineButtonBackgroundColor
         searchButton.addTarget(self, action: #selector(didClickSearchButton), for: .touchUpInside)
-        searchButton.accessibilityLabel = String(format: .SearchSettingsAccessibilityLabel)
+        searchButton.accessibilityLabel = String(format: .SearchView.SettingsAccessibilityLabel)
 
         searchEngineScrollViewContent.addSubview(searchButton)
         searchButton.snp.makeConstraints { make in
@@ -250,7 +250,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
             engineButton.imageView?.layer.cornerRadius = 4
             engineButton.layer.backgroundColor = SearchViewControllerUX.EngineButtonBackgroundColor
             engineButton.addTarget(self, action: #selector(didSelectEngine), for: .touchUpInside)
-            engineButton.accessibilityLabel = String(format: .SearchSearchEngineAccessibilityLabel, engine.shortName)
+            engineButton.accessibilityLabel = String(format: .SearchView.SearchEngineAccessibilityLabel, engine.shortName)
 
             engineButton.imageView?.snp.makeConstraints { make in
                 make.width.height.equalTo(SearchViewControllerUX.FaviconSize)
@@ -574,7 +574,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
                 let openedTab = self.filteredOpenedTabs[indexPath.row]
                 twoLineCell.descriptionLabel.isHidden = false
                 twoLineCell.titleLabel.text = openedTab.title ?? openedTab.lastTitle
-                twoLineCell.descriptionLabel.text = String.SearchSuggestionCellSwitchToTabLabel
+                twoLineCell.descriptionLabel.text = .SearchView.SuggestionCellSwitchToTabLabel
                 twoLineCell.leftOverlayImageView.image = openAndSyncTabBadge
                 twoLineCell.leftImageView.layer.borderColor = SearchViewControllerUX.IconBorderColor.cgColor
                 twoLineCell.leftImageView.layer.borderWidth = SearchViewControllerUX.IconBorderWidth

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -425,12 +425,12 @@ class Tab: NSObject {
         // When picking a display title. Tabs with sessionData are pending a restore so show their old title.
         // To prevent flickering of the display title. If a tab is restoring make sure to use its lastTitle.
         if let url = self.url, InternalURL(url)?.isAboutHomeURL ?? false, sessionData == nil, !restoring {
-            return Strings.AppMenuOpenHomePageTitleString
+            return .AppMenuOpenHomePageTitleString
         }
 
         //lets double check the sessionData in case this is a non-restored new tab
         if let firstURL = sessionData?.urls.first, sessionData?.urls.count == 1, InternalURL(firstURL)?.isAboutHomeURL ?? false {
-            return Strings.AppMenuOpenHomePageTitleString
+            return .AppMenuOpenHomePageTitleString
         }
 
         if let url = self.url, !InternalURL.isValid(url: url), let shownUrl = url.displayURL?.absoluteString {

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -293,7 +293,7 @@ class Tab: NSObject {
             let webView = TabWebView(frame: .zero, configuration: configuration)
             webView.delegate = self
 
-            webView.accessibilityLabel = .WebViewAccessibilityLabel
+            webView.accessibilityLabel = .BrowserViewController.WebViewAccessibilityLabel
             webView.allowsBackForwardNavigationGestures = true
 
             if #available(iOS 13, *) {
@@ -425,12 +425,12 @@ class Tab: NSObject {
         // When picking a display title. Tabs with sessionData are pending a restore so show their old title.
         // To prevent flickering of the display title. If a tab is restoring make sure to use its lastTitle.
         if let url = self.url, InternalURL(url)?.isAboutHomeURL ?? false, sessionData == nil, !restoring {
-            return .AppMenuOpenHomePageTitleString
+            return .AppMenu.OpenHomePageTitleString
         }
 
         //lets double check the sessionData in case this is a non-restored new tab
         if let firstURL = sessionData?.urls.first, sessionData?.urls.count == 1, InternalURL(firstURL)?.isAboutHomeURL ?? false {
-            return .AppMenuOpenHomePageTitleString
+            return .AppMenu.OpenHomePageTitleString
         }
 
         if let url = self.url, !InternalURL.isValid(url: url), let shownUrl = url.displayURL?.absoluteString {

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -53,8 +53,8 @@ enum TabDisplaySection: Int, CaseIterable {
 
     var title: String? {
         switch self {
-        case .regularTabs: return .ASPocketTitle2
-        case .inactiveTabs: return .RecentlySavedSectionTitle
+        case .regularTabs: return .ActivityStream.PocketTitle2
+        case .inactiveTabs: return .ActivityStream.RecentlySavedSectionTitle
         }
     }
     

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -53,8 +53,8 @@ enum TabDisplaySection: Int, CaseIterable {
 
     var title: String? {
         switch self {
-        case .regularTabs: return Strings.ASPocketTitle2
-        case .inactiveTabs: return Strings.RecentlySavedSectionTitle
+        case .regularTabs: return .ASPocketTitle2
+        case .inactiveTabs: return .RecentlySavedSectionTitle
         }
     }
     

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -81,7 +81,7 @@ class TabLocationView: UIView {
                     if !readerModeButton.isHidden {
                         // Delay the Reader Mode accessibility announcement briefly to prevent interruptions.
                         DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(2)) {
-                            UIAccessibility.post(notification: UIAccessibility.Notification.announcement, argument: String.ReaderModeAvailableVoiceOverAnnouncement)
+                            UIAccessibility.post(notification: UIAccessibility.Notification.announcement, argument: String.ReaderMode.AvailableVoiceOverAnnouncement)
                         }
                     }
                 }

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -81,7 +81,7 @@ class TabLocationView: UIView {
                     if !readerModeButton.isHidden {
                         // Delay the Reader Mode accessibility announcement briefly to prevent interruptions.
                         DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(2)) {
-                            UIAccessibility.post(notification: UIAccessibility.Notification.announcement, argument: Strings.ReaderModeAvailableVoiceOverAnnouncement)
+                            UIAccessibility.post(notification: UIAccessibility.Notification.announcement, argument: String.ReaderModeAvailableVoiceOverAnnouncement)
                         }
                     }
                 }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -560,7 +560,7 @@ class TabManager: NSObject, FeatureFlagsProtocol {
         var toast: ButtonToast?
         let numberOfTabs = recentlyClosedForUndo.count
         if numberOfTabs > 0 {
-            toast = ButtonToast(labelText: String.localizedStringWithFormat(Strings.TabsDeleteAllUndoTitle, numberOfTabs), buttonText: Strings.TabsDeleteAllUndoAction, completion: { buttonPressed in
+            toast = ButtonToast(labelText: String.localizedStringWithFormat(.TabsDeleteAllUndoTitle, numberOfTabs), buttonText: .TabsDeleteAllUndoAction, completion: { buttonPressed in
                 if buttonPressed {
                     self.undoCloseTabs()
                     self.storeChanges()

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -47,7 +47,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
                     })
             }
             if self.hasRemoteClients {
-                actions.append(UIPreviewAction(title: Strings.SendToDeviceTitle, style: .default) { [weak self] previewAction, viewController in
+                actions.append(UIPreviewAction(title: .SendToDeviceTitle, style: .default) { [weak self] previewAction, viewController in
                     guard let wself = self, let clientPicker = wself.fxaDevicePicker else { return }
                     wself.delegate?.tabPeekRequestsPresentationOf(clientPicker)
                     })
@@ -58,7 +58,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
                 actions.append(UIPreviewAction(title: .TabPeekCopyUrl, style: .default) {[weak self] previewAction, viewController in
                     guard let wself = self, let url = wself.tab?.canonicalURL else { return }
                     UIPasteboard.general.url = url
-                    SimpleToast().showAlertWithText(Strings.AppMenuCopyURLConfirmMessage, bottomContainer: wself.view)
+                    SimpleToast().showAlertWithText(.AppMenuCopyURLConfirmMessage, bottomContainer: wself.view)
                 })
             }
         }
@@ -83,7 +83,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
                     })
             }
             if self.hasRemoteClients {
-                actions.append(UIAction(title: Strings.SendToDeviceTitle, image: UIImage.templateImageNamed("menu-Send"), identifier: nil) { [weak self] _ in
+                actions.append(UIAction(title: .SendToDeviceTitle, image: UIImage.templateImageNamed("menu-Send"), identifier: nil) { [weak self] _ in
                     guard let wself = self, let clientPicker = wself.fxaDevicePicker else { return }
                     wself.delegate?.tabPeekRequestsPresentationOf(clientPicker)
                     })
@@ -91,7 +91,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
             actions.append(UIAction(title: .TabPeekCopyUrl, image: UIImage.templateImageNamed("menu-Copy-Link"), identifier: nil) {[weak self] _ in
                 guard let wself = self, let url = wself.tab?.canonicalURL else { return }
                 UIPasteboard.general.url = url
-                SimpleToast().showAlertWithText(Strings.AppMenuCopyURLConfirmMessage, bottomContainer: wself.view)
+                SimpleToast().showAlertWithText(.AppMenuCopyURLConfirmMessage, bottomContainer: wself.view)
             })
         }
         actions.append(UIAction(title: .TabPeekCloseTab, image: UIImage.templateImageNamed("menu-CloseTabs"), identifier: nil) { [weak self] _ in

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -47,7 +47,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
                     })
             }
             if self.hasRemoteClients {
-                actions.append(UIPreviewAction(title: .SendToDeviceTitle, style: .default) { [weak self] previewAction, viewController in
+                actions.append(UIPreviewAction(title: .AppMenu.SendToDeviceTitle, style: .default) { [weak self] previewAction, viewController in
                     guard let wself = self, let clientPicker = wself.fxaDevicePicker else { return }
                     wself.delegate?.tabPeekRequestsPresentationOf(clientPicker)
                     })
@@ -58,7 +58,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
                 actions.append(UIPreviewAction(title: .TabPeekCopyUrl, style: .default) {[weak self] previewAction, viewController in
                     guard let wself = self, let url = wself.tab?.canonicalURL else { return }
                     UIPasteboard.general.url = url
-                    SimpleToast().showAlertWithText(.AppMenuCopyURLConfirmMessage, bottomContainer: wself.view)
+                    SimpleToast().showAlertWithText(.AppMenu.CopyURLConfirmMessage, bottomContainer: wself.view)
                 })
             }
         }
@@ -83,7 +83,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
                     })
             }
             if self.hasRemoteClients {
-                actions.append(UIAction(title: .SendToDeviceTitle, image: UIImage.templateImageNamed("menu-Send"), identifier: nil) { [weak self] _ in
+                actions.append(UIAction(title: .AppMenu.SendToDeviceTitle, image: UIImage.templateImageNamed("menu-Send"), identifier: nil) { [weak self] _ in
                     guard let wself = self, let clientPicker = wself.fxaDevicePicker else { return }
                     wself.delegate?.tabPeekRequestsPresentationOf(clientPicker)
                     })
@@ -91,7 +91,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
             actions.append(UIAction(title: .TabPeekCopyUrl, image: UIImage.templateImageNamed("menu-Copy-Link"), identifier: nil) {[weak self] _ in
                 guard let wself = self, let url = wself.tab?.canonicalURL else { return }
                 UIPasteboard.general.url = url
-                SimpleToast().showAlertWithText(.AppMenuCopyURLConfirmMessage, bottomContainer: wself.view)
+                SimpleToast().showAlertWithText(.AppMenu.CopyURLConfirmMessage, bottomContainer: wself.view)
             })
         }
         actions.append(UIAction(title: .TabPeekCloseTab, image: UIImage.templateImageNamed("menu-CloseTabs"), identifier: nil) { [weak self] _ in

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -115,13 +115,13 @@ open class TabToolbarHelper: NSObject {
         
         toolbar.appMenuButton.contentMode = .center
         toolbar.appMenuButton.setImage(UIImage.templateImageNamed("nav-menu"), for: .normal)
-        toolbar.appMenuButton.accessibilityLabel = .AppMenuButtonAccessibilityLabel
+        toolbar.appMenuButton.accessibilityLabel = .AppMenu.ButtonAccessibilityLabel
         toolbar.appMenuButton.addTarget(self, action: #selector(didClickMenu), for: .touchUpInside)
         toolbar.appMenuButton.accessibilityIdentifier = "TabToolbar.menuButton"
 
         toolbar.bookmarksButton.contentMode = .center
         toolbar.bookmarksButton.setImage(UIImage.templateImageNamed("menu-panel-Bookmarks"), for: .normal)
-        toolbar.bookmarksButton.accessibilityLabel = .AppMenuButtonAccessibilityLabel
+        toolbar.bookmarksButton.accessibilityLabel = .AppMenu.ButtonAccessibilityLabel
         toolbar.bookmarksButton.addTarget(self, action: #selector(didClickLibrary), for: .touchUpInside)
         toolbar.bookmarksButton.accessibilityIdentifier = "TabToolbar.libraryButton"
         setTheme(forButtons: toolbar.actionButtons)

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -109,19 +109,19 @@ open class TabToolbarHelper: NSObject {
         toolbar.tabsButton.addGestureRecognizer(longPressGestureTabsButton)
 
         toolbar.addNewTabButton.setImage(UIImage.templateImageNamed("menu-NewTab"), for: .normal)
-        toolbar.addNewTabButton.accessibilityLabel = Strings.AddTabAccessibilityLabel
+        toolbar.addNewTabButton.accessibilityLabel = .AddTabAccessibilityLabel
         toolbar.addNewTabButton.addTarget(self, action: #selector(didClickAddNewTab), for: .touchUpInside)
         toolbar.addNewTabButton.accessibilityIdentifier = "TabToolbar.addNewTabButton"
         
         toolbar.appMenuButton.contentMode = .center
         toolbar.appMenuButton.setImage(UIImage.templateImageNamed("nav-menu"), for: .normal)
-        toolbar.appMenuButton.accessibilityLabel = Strings.AppMenuButtonAccessibilityLabel
+        toolbar.appMenuButton.accessibilityLabel = .AppMenuButtonAccessibilityLabel
         toolbar.appMenuButton.addTarget(self, action: #selector(didClickMenu), for: .touchUpInside)
         toolbar.appMenuButton.accessibilityIdentifier = "TabToolbar.menuButton"
 
         toolbar.bookmarksButton.contentMode = .center
         toolbar.bookmarksButton.setImage(UIImage.templateImageNamed("menu-panel-Bookmarks"), for: .normal)
-        toolbar.bookmarksButton.accessibilityLabel = Strings.AppMenuButtonAccessibilityLabel
+        toolbar.bookmarksButton.accessibilityLabel = .AppMenuButtonAccessibilityLabel
         toolbar.bookmarksButton.addTarget(self, action: #selector(didClickLibrary), for: .touchUpInside)
         toolbar.bookmarksButton.accessibilityIdentifier = "TabToolbar.libraryButton"
         setTheme(forButtons: toolbar.actionButtons)

--- a/Client/Frontend/Browser/TabTrayController+KeyCommands.swift
+++ b/Client/Frontend/Browser/TabTrayController+KeyCommands.swift
@@ -7,14 +7,14 @@ import UIKit
 
 extension GridTabViewController {
     override var keyCommands: [UIKeyCommand]? {
-        let toggleText = tabDisplayManager.isPrivate ? Strings.SwitchToNonPBMKeyCodeTitle: Strings.SwitchToPBMKeyCodeTitle
+        let toggleText = tabDisplayManager.isPrivate ? String.SwitchToNonPBMKeyCodeTitle: String.SwitchToPBMKeyCodeTitle
         let commands = [
             UIKeyCommand(input: "`", modifierFlags: .command, action: #selector(didTogglePrivateModeKeyCommand), discoverabilityTitle: toggleText),
             UIKeyCommand(input: "w", modifierFlags: .command, action: #selector(didCloseTabKeyCommand)),
-            UIKeyCommand(input: "w", modifierFlags: [.command, .shift], action: #selector(didCloseAllTabsKeyCommand), discoverabilityTitle: Strings.CloseAllTabsFromTabTrayKeyCodeTitle),
+            UIKeyCommand(input: "w", modifierFlags: [.command, .shift], action: #selector(didCloseAllTabsKeyCommand), discoverabilityTitle: .CloseAllTabsFromTabTrayKeyCodeTitle),
             UIKeyCommand(input: "\\", modifierFlags: [.command, .shift], action: #selector(didEnterTabKeyCommand)),
             UIKeyCommand(input: "\t", modifierFlags: [.command, .alternate], action: #selector(didEnterTabKeyCommand)),
-            UIKeyCommand(input: "t", modifierFlags: .command, action: #selector(didOpenNewTabKeyCommand), discoverabilityTitle: Strings.OpenNewTabFromTabTrayKeyCodeTitle),
+            UIKeyCommand(input: "t", modifierFlags: .command, action: #selector(didOpenNewTabKeyCommand), discoverabilityTitle: .OpenNewTabFromTabTrayKeyCodeTitle),
             UIKeyCommand(input: UIKeyCommand.inputDownArrow, modifierFlags: [], action: #selector(didChangeSelectedTabKeyCommand(sender:))),
             UIKeyCommand(input: UIKeyCommand.inputUpArrow, modifierFlags: [], action: #selector(didChangeSelectedTabKeyCommand(sender:))),
         ]

--- a/Client/Frontend/Browser/Tabs/ChronologicalTabsViewController.swift
+++ b/Client/Frontend/Browser/Tabs/ChronologicalTabsViewController.swift
@@ -76,7 +76,7 @@ class ChronologicalTabsViewController: UIViewController, Themeable, TabTrayViewD
 
     private func viewSetup() {
         if #available(iOS 13.0, *) { } else {
-            parent?.navigationItem.leftBarButtonItem = UIBarButtonItem(title: Strings.CloseButtonTitle, style: .done, target: self, action: #selector(dismissTabTray))
+            parent?.navigationItem.leftBarButtonItem = UIBarButtonItem(title: .CloseButtonTitle, style: .done, target: self, action: #selector(dismissTabTray))
             TelemetryWrapper.recordEvent(category: .action, method: .close, object: .tabTray)
         }
 
@@ -163,8 +163,8 @@ extension ChronologicalTabsViewController {
 
     func didTapToolbarDelete(_ sender: UIBarButtonItem) {
         let controller = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        controller.addAction(UIAlertAction(title: Strings.AppMenuCloseAllTabsTitleString, style: .default, handler: { _ in self.viewModel.closeTabsForCurrentTray() }), accessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
-        controller.addAction(UIAlertAction(title: Strings.CancelString, style: .cancel, handler: nil), accessibilityIdentifier: "TabTrayController.deleteButton.cancel")
+        controller.addAction(UIAlertAction(title: .AppMenuCloseAllTabsTitleString, style: .default, handler: { _ in self.viewModel.closeTabsForCurrentTray() }), accessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
+        controller.addAction(UIAlertAction(title: .CancelString, style: .cancel, handler: nil), accessibilityIdentifier: "TabTrayController.deleteButton.cancel")
         controller.view.tintColor = UIColor.white
         controller.popoverPresentationController?.barButtonItem = sender
         present(controller, animated: true, completion: nil)
@@ -261,11 +261,11 @@ extension ChronologicalTabsViewController: UITableViewDelegate {
         return section == TabSection(rawValue: section)?.rawValue && viewModel.numberOfRowsInSection(section: section) != 0 ? UITableView.automaticDimension : 0
     }
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        let share = UIContextualAction(style: .normal, title: Strings.ShareContextMenuTitle, handler: { (action, view, completionHandler) in
+        let share = UIContextualAction(style: .normal, title: .ShareContextMenuTitle, handler: { (action, view, completionHandler) in
             guard let tab = self.viewModel.getTab(forIndex: indexPath), let url = tab.url else { return }
             self.presentActivityViewController(url, tab: tab)
         })
-        let more = UIContextualAction(style: .normal, title: Strings.PocketMoreStoriesText, handler: { (action, view, completionHandler) in
+        let more = UIContextualAction(style: .normal, title: .PocketMoreStoriesText, handler: { (action, view, completionHandler) in
             // Bottom toolbar
             self.navigationController?.isToolbarHidden = true
 
@@ -276,7 +276,7 @@ extension ChronologicalTabsViewController: UITableViewDelegate {
             self.bottomSheetVC?.showView()
 
         })
-        let delete = UIContextualAction(style: .destructive, title: Strings.CloseButtonTitle, handler: { (action, view, completionHandler) in
+        let delete = UIContextualAction(style: .destructive, title: .CloseButtonTitle, handler: { (action, view, completionHandler) in
             self.viewModel.removeTab(forIndex: indexPath)
         })
 

--- a/Client/Frontend/Browser/Tabs/ChronologicalTabsViewController.swift
+++ b/Client/Frontend/Browser/Tabs/ChronologicalTabsViewController.swift
@@ -163,8 +163,8 @@ extension ChronologicalTabsViewController {
 
     func didTapToolbarDelete(_ sender: UIBarButtonItem) {
         let controller = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        controller.addAction(UIAlertAction(title: .AppMenuCloseAllTabsTitleString, style: .default, handler: { _ in self.viewModel.closeTabsForCurrentTray() }), accessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
-        controller.addAction(UIAlertAction(title: .CancelString, style: .cancel, handler: nil), accessibilityIdentifier: "TabTrayController.deleteButton.cancel")
+        controller.addAction(UIAlertAction(title: .AppMenu.CloseAllTabsTitleString, style: .default, handler: { _ in self.viewModel.closeTabsForCurrentTray() }), accessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
+        controller.addAction(UIAlertAction(title: .General.CancelString, style: .cancel, handler: nil), accessibilityIdentifier: "TabTrayController.deleteButton.cancel")
         controller.view.tintColor = UIColor.white
         controller.popoverPresentationController?.barButtonItem = sender
         present(controller, animated: true, completion: nil)
@@ -265,7 +265,7 @@ extension ChronologicalTabsViewController: UITableViewDelegate {
             guard let tab = self.viewModel.getTab(forIndex: indexPath), let url = tab.url else { return }
             self.presentActivityViewController(url, tab: tab)
         })
-        let more = UIContextualAction(style: .normal, title: .PocketMoreStoriesText, handler: { (action, view, completionHandler) in
+        let more = UIContextualAction(style: .normal, title: .ActivityStream.PocketMoreStoriesText, handler: { (action, view, completionHandler) in
             // Bottom toolbar
             self.navigationController?.isToolbarHidden = true
 

--- a/Client/Frontend/Browser/Tabs/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabsPanel.swift
@@ -105,7 +105,7 @@ enum RemoteTabsError {
         switch self {
         // This does not have a localized string because we have a whole specific screen for it.
         case .notLoggedIn: return ""
-        case .noClients: return Strings.EmptySyncedTabsPanelNullStateDescription
+        case .noClients: return .EmptySyncedTabsPanelNullStateDescription
         case .noTabs: return .RemoteTabErrorNoTabs
         case .failedToSync: return .RemoteTabErrorFailedToSync
         }
@@ -274,7 +274,7 @@ class RemoteTabsErrorCell: UITableViewCell {
         }
 
         titleLabel.font = DynamicFontHelper.defaultHelper.DeviceFont
-        titleLabel.text = Strings.EmptySyncedTabsPanelStateTitle
+        titleLabel.text = .EmptySyncedTabsPanelStateTitle
         titleLabel.textAlignment = .center
         containerView.addSubview(titleLabel)
 
@@ -348,17 +348,17 @@ class RemoteTabsNotLoggedInCell: UITableViewCell {
         contentView.addSubview(emptyStateImageView)
 
         titleLabel.font = DynamicFontHelper.defaultHelper.DeviceFont
-        titleLabel.text = Strings.EmptySyncedTabsPanelStateTitle
+        titleLabel.text = .EmptySyncedTabsPanelStateTitle
         titleLabel.textAlignment = .center
         contentView.addSubview(titleLabel)
 
         instructionsLabel.font = DynamicFontHelper.defaultHelper.DeviceFontSmallLight
-        instructionsLabel.text = Strings.EmptySyncedTabsPanelNotSignedInStateDescription
+        instructionsLabel.text = .EmptySyncedTabsPanelNotSignedInStateDescription
         instructionsLabel.textAlignment = .center
         instructionsLabel.numberOfLines = 0
         contentView.addSubview(instructionsLabel)
 
-        signInButton.setTitle(Strings.FxASignInToSync, for: [])
+        signInButton.setTitle(.FxASignInToSync, for: [])
         signInButton.setTitleColor(UIColor.Photon.White100, for: [])
         signInButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .subheadline)
         signInButton.layer.cornerRadius = RemoteTabsPanelUX.EmptyStateSignInButtonCornerRadius

--- a/Client/Frontend/Browser/Tabs/TabMoreMenuViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabMoreMenuViewController.swift
@@ -16,13 +16,13 @@ class TabMoreMenuViewController: UIViewController, Themeable {
     let profile: Profile
     let tabIndex: IndexPath
 
-    let titles: [Int: [String]] = [ 1: [Strings.ShareAddToReadingList,
-                                        Strings.BookmarkContextMenuTitle,
-                                        Strings.AddToShortcutsActionTitle],
-                                    2: [Strings.CloseTabTitle],
-                                    0: [Strings.CopyAddressTitle,
-                                        Strings.ShareContextMenuTitle,
-                                        Strings.SendToDeviceTitle]
+    let titles: [Int: [String]] = [ 1: [.ShareAddToReadingList,
+                                        .BookmarkContextMenuTitle,
+                                        .AddToShortcutsActionTitle],
+                                    2: [.CloseTabTitle],
+                                    0: [.CopyAddressTitle,
+                                        .ShareContextMenuTitle,
+                                        .SendToDeviceTitle]
     ]
     let imageViews: [Int: [UIImageView]] = [ 1: [UIImageView(image: UIImage.templateImageNamed("library-readinglist")),
                                                  UIImageView(image: UIImage.templateImageNamed("bookmark")),
@@ -204,7 +204,7 @@ extension TabMoreMenuViewController: UITableViewDelegate {
             switch indexPath.row {
             case 0:
                 UIPasteboard.general.url = url
-                SimpleToast().showAlertWithText(Strings.AppMenuCopyURLConfirmMessage, bottomContainer: self.view)
+                SimpleToast().showAlertWithText(.AppMenuCopyURLConfirmMessage, bottomContainer: self.view)
                 dismissMenu()
             case 1:
                 dismissMenu()

--- a/Client/Frontend/Browser/Tabs/TabMoreMenuViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabMoreMenuViewController.swift
@@ -16,13 +16,13 @@ class TabMoreMenuViewController: UIViewController, Themeable {
     let profile: Profile
     let tabIndex: IndexPath
 
-    let titles: [Int: [String]] = [ 1: [.ShareAddToReadingList,
+    let titles: [Int: [String]] = [ 1: [.ShareExtension.AddToReadingList,
                                         .BookmarkContextMenuTitle,
                                         .AddToShortcutsActionTitle],
                                     2: [.CloseTabTitle],
                                     0: [.CopyAddressTitle,
                                         .ShareContextMenuTitle,
-                                        .SendToDeviceTitle]
+                                        .AppMenu.SendToDeviceTitle]
     ]
     let imageViews: [Int: [UIImageView]] = [ 1: [UIImageView(image: UIImage.templateImageNamed("library-readinglist")),
                                                  UIImageView(image: UIImage.templateImageNamed("bookmark")),
@@ -204,7 +204,7 @@ extension TabMoreMenuViewController: UITableViewDelegate {
             switch indexPath.row {
             case 0:
                 UIPasteboard.general.url = url
-                SimpleToast().showAlertWithText(.AppMenuCopyURLConfirmMessage, bottomContainer: self.view)
+                SimpleToast().showAlertWithText(.AppMenu.CopyURLConfirmMessage, bottomContainer: self.view)
                 dismissMenu()
             case 1:
                 dismissMenu()

--- a/Client/Frontend/Browser/Tabs/TabTrayV2ViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayV2ViewModel.swift
@@ -134,16 +134,16 @@ class TabTrayV2ViewModel: NSObject {
         
         switch section {
         case .today:
-            sectionHeader = Strings.TabTrayV2TodayHeader
+            sectionHeader = .TabTrayV2TodayHeader
             date = dateFormatter.string(from: Date())
         case .yesterday:
-            sectionHeader = Strings.TabTrayV2YesterdayHeader
+            sectionHeader = .TabTrayV2YesterdayHeader
             date = dateFormatter.string(from: Date.yesterday)
         case .lastWeek:
-            sectionHeader = Strings.TabTrayV2LastWeekHeader
+            sectionHeader = .TabTrayV2LastWeekHeader
             date = dateIntervalFormatter.string(from: Date().lastWeek, to: Date(timeInterval: 6.0 * 24.0 * 3600.0, since: Date().lastWeek))
         case .older:
-            sectionHeader = Strings.TabTrayV2OlderHeader
+            sectionHeader = .TabTrayV2OlderHeader
             date = ""
         default:
             sectionHeader = ""

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -44,7 +44,7 @@ class TabTrayViewController: UIViewController {
     }()
 
     lazy var syncTabButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(title: Strings.FxASyncNow,
+        let button = UIBarButtonItem(title: .FxASyncNow,
                                      style: .plain,
                                      target: self,
                                      action: #selector(didTapSyncTabs))
@@ -55,7 +55,7 @@ class TabTrayViewController: UIViewController {
     
     lazy var syncLoadingView: UIStackView = {
         let syncingLabel = UILabel()
-        syncingLabel.text = Strings.SyncingMessageWithEllipsis
+        syncingLabel.text = .SyncingMessageWithEllipsis
         
         let activityIndicator = UIActivityIndicatorView(style: .gray)
         activityIndicator.color = .systemGray
@@ -112,9 +112,9 @@ class TabTrayViewController: UIViewController {
     }()
 
     lazy var iPadNavigationMenuIdentifiers: UISegmentedControl = {
-        return UISegmentedControl(items: [Strings.TabTraySegmentedControlTitlesTabs,
-                                          Strings.TabTraySegmentedControlTitlesPrivateTabs,
-                                          Strings.TabTraySegmentedControlTitlesSyncedTabs])
+        return UISegmentedControl(items: [String.TabTraySegmentedControlTitlesTabs,
+                                          String.TabTraySegmentedControlTitlesPrivateTabs,
+                                          String.TabTraySegmentedControlTitlesSyncedTabs])
     }()
 
     lazy var iPhoneNavigationMenuIdentifiers: UISegmentedControl = {
@@ -331,7 +331,7 @@ class TabTrayViewController: UIViewController {
                 guard let self = self else { return }
                 
                 self.syncTabButton.customView = nil
-                self.syncTabButton.title = Strings.FxASyncNow
+                self.syncTabButton.title = .FxASyncNow
                 self.syncTabButton.isEnabled = true
             }
         default:

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -55,7 +55,7 @@ class TabTrayViewController: UIViewController {
     
     lazy var syncLoadingView: UIStackView = {
         let syncingLabel = UILabel()
-        syncingLabel.text = .SyncingMessageWithEllipsis
+        syncingLabel.text = .Syncing.SyncingMessageWithEllipsis
         
         let activityIndicator = UIActivityIndicatorView(style: .gray)
         activityIndicator.color = .systemGray

--- a/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
@@ -32,7 +32,7 @@ class TabTrayViewModel {
             case 0, 1:
                 return .TabTrayV2Title
             case 2:
-                return .AppMenuSyncedTabsTitleString
+                return .AppMenu.SyncedTabsTitleString
             default:
                 return nil
             }

--- a/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
@@ -30,9 +30,9 @@ class TabTrayViewModel {
         if foriPhone {
             switch segmentIndex {
             case 0, 1:
-                return Strings.TabTrayV2Title
+                return .TabTrayV2Title
             case 2:
-                return Strings.AppMenuSyncedTabsTitleString
+                return .AppMenuSyncedTabsTitleString
             default:
                 return nil
             }

--- a/Client/Frontend/Browser/ThirdPartySearchAlerts.swift
+++ b/Client/Frontend/Browser/ThirdPartySearchAlerts.swift
@@ -24,19 +24,19 @@ class ThirdPartySearchAlerts: UIAlertController {
 
     static func addThirdPartySearchEngine(_ okayCallback: @escaping (UIAlertAction) -> Void) -> UIAlertController {
         let alert = ThirdPartySearchAlerts(
-            title: Strings.ThirdPartySearchAddTitle,
-            message: Strings.ThirdPartySearchAddMessage,
+            title: .ThirdPartySearchAddTitle,
+            message: .ThirdPartySearchAddMessage,
             preferredStyle: .alert
         )
 
         let noOption = UIAlertAction(
-            title: Strings.ThirdPartySearchCancelButton,
+            title: .ThirdPartySearchCancelButton,
             style: .cancel,
             handler: nil
         )
 
         let okayOption = UIAlertAction(
-            title: Strings.ThirdPartySearchOkayButton,
+            title: .ThirdPartySearchOkayButton,
             style: .default,
             handler: okayCallback
         )
@@ -54,18 +54,18 @@ class ThirdPartySearchAlerts: UIAlertController {
      **/
 
     static func failedToAddThirdPartySearch() -> UIAlertController {
-        return searchAlertWithOK(title: Strings.ThirdPartySearchFailedTitle,
-                                 message: Strings.ThirdPartySearchFailedMessage)
+        return searchAlertWithOK(title: .ThirdPartySearchFailedTitle,
+                                 message: .ThirdPartySearchFailedMessage)
     }
 
     static func incorrectCustomEngineForm() -> UIAlertController {
-        return searchAlertWithOK(title: Strings.CustomEngineFormErrorTitle,
-                                      message: Strings.CustomEngineFormErrorMessage)
+        return searchAlertWithOK(title: .CustomEngineFormErrorTitle,
+                                      message: .CustomEngineFormErrorMessage)
     }
 
     static func duplicateCustomEngine() -> UIAlertController {
-        return searchAlertWithOK(title: Strings.CustomEngineDuplicateErrorTitle,
-                                 message: Strings.CustomEngineDuplicateErrorMessage)
+        return searchAlertWithOK(title: .CustomEngineDuplicateErrorTitle,
+                                 message: .CustomEngineDuplicateErrorMessage)
     }
 
     private static func searchAlertWithOK(title: String, message: String) -> UIAlertController {
@@ -76,7 +76,7 @@ class ThirdPartySearchAlerts: UIAlertController {
         )
 
         let okayOption = UIAlertAction(
-            title: Strings.ThirdPartySearchOkayButton,
+            title: .ThirdPartySearchOkayButton,
             style: .default,
             handler: nil
         )

--- a/Client/Frontend/Browser/ThirdPartySearchAlerts.swift
+++ b/Client/Frontend/Browser/ThirdPartySearchAlerts.swift
@@ -24,19 +24,19 @@ class ThirdPartySearchAlerts: UIAlertController {
 
     static func addThirdPartySearchEngine(_ okayCallback: @escaping (UIAlertAction) -> Void) -> UIAlertController {
         let alert = ThirdPartySearchAlerts(
-            title: .ThirdPartySearchAddTitle,
-            message: .ThirdPartySearchAddMessage,
+            title: .Settings.Search.ThirdPartyEngine.AddTitle,
+            message: .Settings.Search.ThirdPartyEngine.AddMessage,
             preferredStyle: .alert
         )
 
         let noOption = UIAlertAction(
-            title: .ThirdPartySearchCancelButton,
+            title: .Settings.Search.ThirdPartyEngine.CancelButton,
             style: .cancel,
             handler: nil
         )
 
         let okayOption = UIAlertAction(
-            title: .ThirdPartySearchOkayButton,
+            title: .Settings.Search.ThirdPartyEngine.OkayButton,
             style: .default,
             handler: okayCallback
         )
@@ -54,18 +54,18 @@ class ThirdPartySearchAlerts: UIAlertController {
      **/
 
     static func failedToAddThirdPartySearch() -> UIAlertController {
-        return searchAlertWithOK(title: .ThirdPartySearchFailedTitle,
-                                 message: .ThirdPartySearchFailedMessage)
+        return searchAlertWithOK(title: .Settings.Search.ThirdPartyEngine.FailedTitle,
+                                 message: .Settings.Search.ThirdPartyEngine.FailedMessage)
     }
 
     static func incorrectCustomEngineForm() -> UIAlertController {
-        return searchAlertWithOK(title: .CustomEngineFormErrorTitle,
-                                      message: .CustomEngineFormErrorMessage)
+        return searchAlertWithOK(title: .Settings.Search.ThirdPartyEngine.FormErrorTitle,
+                                 message: .Settings.Search.ThirdPartyEngine.FormErrorMessage)
     }
 
     static func duplicateCustomEngine() -> UIAlertController {
-        return searchAlertWithOK(title: .CustomEngineDuplicateErrorTitle,
-                                 message: .CustomEngineDuplicateErrorMessage)
+        return searchAlertWithOK(title: .Settings.Search.ThirdPartyEngine.DuplicateErrorTitle,
+                                 message: .Settings.Search.ThirdPartyEngine.DuplicateErrorMessage)
     }
 
     private static func searchAlertWithOK(title: String, message: String) -> UIAlertController {
@@ -76,7 +76,7 @@ class ThirdPartySearchAlerts: UIAlertController {
         )
 
         let okayOption = UIAlertAction(
-            title: .ThirdPartySearchOkayButton,
+            title: .Settings.Search.ThirdPartyEngine.OkayButton,
             style: .default,
             handler: nil
         )

--- a/Client/Frontend/Browser/TopTabsViews.swift
+++ b/Client/Frontend/Browser/TopTabsViews.swift
@@ -106,16 +106,16 @@ class TopTabCell: UICollectionViewCell, Themeable {
 
         if tab.displayTitle.isEmpty {
             if let url = tab.webView?.url, let internalScheme = InternalURL(url) {
-                self.titleText.text = Strings.AppMenuNewTabTitleString
+                self.titleText.text = .AppMenuNewTabTitleString
                 self.accessibilityLabel = internalScheme.aboutComponent
             } else {
                 self.titleText.text = tab.webView?.url?.absoluteDisplayString
             }
             
-            self.closeButton.accessibilityLabel = String(format: Strings.TopSitesRemoveButtonAccessibilityLabel, self.titleText.text ?? "")
+            self.closeButton.accessibilityLabel = String(format: .TopSitesRemoveButtonAccessibilityLabel, self.titleText.text ?? "")
         } else {
             self.accessibilityLabel = tab.displayTitle
-            self.closeButton.accessibilityLabel = String(format: Strings.TopSitesRemoveButtonAccessibilityLabel, tab.displayTitle)
+            self.closeButton.accessibilityLabel = String(format: .TopSitesRemoveButtonAccessibilityLabel, tab.displayTitle)
         }
 
         self.selectedTab = isSelected

--- a/Client/Frontend/Browser/TopTabsViews.swift
+++ b/Client/Frontend/Browser/TopTabsViews.swift
@@ -106,16 +106,16 @@ class TopTabCell: UICollectionViewCell, Themeable {
 
         if tab.displayTitle.isEmpty {
             if let url = tab.webView?.url, let internalScheme = InternalURL(url) {
-                self.titleText.text = .AppMenuNewTabTitleString
+                self.titleText.text = .AppMenu.NewTabTitleString
                 self.accessibilityLabel = internalScheme.aboutComponent
             } else {
                 self.titleText.text = tab.webView?.url?.absoluteDisplayString
             }
             
-            self.closeButton.accessibilityLabel = String(format: .TopSitesRemoveButtonAccessibilityLabel, self.titleText.text ?? "")
+            self.closeButton.accessibilityLabel = String(format: .TopSites.RemoveButtonAccessibilityLabel, self.titleText.text ?? "")
         } else {
             self.accessibilityLabel = tab.displayTitle
-            self.closeButton.accessibilityLabel = String(format: .TopSitesRemoveButtonAccessibilityLabel, tab.displayTitle)
+            self.closeButton.accessibilityLabel = String(format: .TopSites.RemoveButtonAccessibilityLabel, tab.displayTitle)
         }
 
         self.selectedTab = isSelected

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -125,7 +125,7 @@ class URLBarView: UIView {
         let cancelButton = InsetButton()
         cancelButton.setImage(UIImage.templateImageNamed("goBack"), for: .normal)
         cancelButton.accessibilityIdentifier = "urlBar-cancel"
-        cancelButton.accessibilityLabel = Strings.BackTitle
+        cancelButton.accessibilityLabel = .BackTitle
         cancelButton.addTarget(self, action: #selector(didClickCancel), for: .touchUpInside)
         cancelButton.alpha = 0
         return cancelButton
@@ -135,7 +135,7 @@ class URLBarView: UIView {
         let button = InsetButton()
         button.setImage(UIImage.templateImageNamed("menu-ScanQRCode"), for: .normal)
         button.accessibilityIdentifier = "urlBar-scanQRCode"
-        button.accessibilityLabel = Strings.ScanQRCodeViewTitle
+        button.accessibilityLabel = .ScanQRCodeViewTitle
         button.clipsToBounds = false
         button.addTarget(self, action: #selector(showQRScanner), for: .touchUpInside)
         button.setContentHuggingPriority(UILayoutPriority(rawValue: 1000), for: .horizontal)

--- a/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -134,7 +134,7 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
     }()
     private lazy var goToSettingsButton: UIButton = {
         let button = UIButton()
-        button.setTitle(Strings.CoverSheetETPSettingsButton, for: .normal)
+        button.setTitle(.CoverSheetETPSettingsButton, for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: descriptionFontSize)
         button.layer.cornerRadius = UpdateViewControllerUX.StartBrowsingButton.cornerRadius
         button.setTitleColor(.white, for: .normal)

--- a/Client/Frontend/EnhancedTrackingProtection/ETPCoverSheetViewController.swift
+++ b/Client/Frontend/EnhancedTrackingProtection/ETPCoverSheetViewController.swift
@@ -42,7 +42,7 @@ class ETPCoverSheetViewController: UIViewController {
     }
     private var doneButton: UIButton = {
         let button = UIButton()
-        button.setTitle(Strings.SettingsSearchDoneButton, for: .normal)
+        button.setTitle(.SettingsSearchDoneButton, for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .regular)
         button.setTitleColor(UIColor.systemBlue, for: .normal)
         return button
@@ -73,7 +73,7 @@ class ETPCoverSheetViewController: UIViewController {
     }()
     private lazy var goToSettingsButton: UIButton = {
         let button = UIButton()
-        button.setTitle(Strings.CoverSheetETPSettingsButton, for: .normal)
+        button.setTitle(.CoverSheetETPSettingsButton, for: .normal)
         button.titleLabel?.font = UpdateViewControllerUX.StartBrowsingButton.font
         button.layer.cornerRadius = UpdateViewControllerUX.StartBrowsingButton.cornerRadius
         button.setTitleColor(.white, for: .normal)
@@ -82,7 +82,7 @@ class ETPCoverSheetViewController: UIViewController {
     }()
     private lazy var startBrowsingButton: UIButton = {
         let button = UIButton()
-        button.setTitle(Strings.StartBrowsingButtonTitle, for: .normal)
+        button.setTitle(.StartBrowsingButtonTitle, for: .normal)
         button.titleLabel?.font = UpdateViewControllerUX.StartBrowsingButton.font
         button.setTitleColor(UIColor.Photon.Blue50, for: .normal)
         button.backgroundColor = .clear

--- a/Client/Frontend/EnhancedTrackingProtection/ETPCoverSheetViewController.swift
+++ b/Client/Frontend/EnhancedTrackingProtection/ETPCoverSheetViewController.swift
@@ -42,7 +42,7 @@ class ETPCoverSheetViewController: UIViewController {
     }
     private var doneButton: UIButton = {
         let button = UIButton()
-        button.setTitle(.SettingsSearchDoneButton, for: .normal)
+        button.setTitle(.Settings.SearchDoneButton, for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .regular)
         button.setTitleColor(UIColor.systemBlue, for: .normal)
         return button

--- a/Client/Frontend/EnhancedTrackingProtection/ETPViewModel.swift
+++ b/Client/Frontend/EnhancedTrackingProtection/ETPViewModel.swift
@@ -20,7 +20,7 @@ class ETPViewModel {
     }
 
     private func setupUpdateModel() {
-        etpCoverSheetmodel = ETPCoverSheetModel(titleImage: #imageLiteral(resourceName: "shield"), titleText: Strings.CoverSheetETPTitle, descriptionText: Strings.CoverSheetETPDescription)
+        etpCoverSheetmodel = ETPCoverSheetModel(titleImage: #imageLiteral(resourceName: "shield"), titleText: .CoverSheetETPTitle, descriptionText: .CoverSheetETPDescription)
     }
     
     static func shouldShowETPCoverSheet(userPrefs: Prefs, currentAppVersion: String = VersionSetting.appVersion, isCleanInstall: Bool, supportedAppVersions: [String] = etpCoverSheetSupportedAppVersion) -> Bool {

--- a/Client/Frontend/Extensions/DevicePickerViewController.swift
+++ b/Client/Frontend/Extensions/DevicePickerViewController.swift
@@ -47,11 +47,11 @@ class DevicePickerViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = Strings.SendToTitle
+        title = .SendToTitle
         refreshControl = UIRefreshControl()
         refreshControl?.addTarget(self, action: #selector(refresh), for: .valueChanged)
         navigationItem.leftBarButtonItem = UIBarButtonItem(
-            title: Strings.SendToCancelButton,
+            title: .SendToCancelButton,
             style: .plain,
             target: self,
             action: #selector(cancel)
@@ -108,7 +108,7 @@ class DevicePickerViewController: UITableViewController {
             if self.devices.isEmpty {
                 self.navigationItem.rightBarButtonItem = nil
             } else {
-                self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: Strings.SendToSendButtonTitle, style: .done, target: self, action: #selector(self.send))
+                self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: .SendToSendButtonTitle, style: .done, target: self, action: #selector(self.send))
                 self.navigationItem.rightBarButtonItem?.isEnabled = false
             }
 
@@ -262,7 +262,7 @@ class DevicePickerTableViewHeaderCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         addSubview(nameLabel)
         nameLabel.font = DevicePickerViewControllerUX.TableHeaderTextFont
-        nameLabel.text = Strings.SendToDevicesListTitle
+        nameLabel.text = .SendToDevicesListTitle
         nameLabel.textColor = DevicePickerViewControllerUX.TableHeaderTextColor
 
         nameLabel.snp.makeConstraints { (make) -> Void in
@@ -359,7 +359,7 @@ class DevicePickerNoClientsTableViewCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupHelpView(contentView,
-            introText: Strings.SendToNoDevicesFound,
+            introText: .SendToNoDevicesFound,
             showMeText: "") // TODO We used to have a 'show me how to ...' text here. But, we cannot open web pages from the extension. So this is clear for now until we decide otherwise.
         // Move the separator off screen
         separatorInset = UIEdgeInsets(top: 0, left: 1000, bottom: 0, right: 0)

--- a/Client/Frontend/Extensions/DevicePickerViewController.swift
+++ b/Client/Frontend/Extensions/DevicePickerViewController.swift
@@ -47,11 +47,11 @@ class DevicePickerViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = .SendToTitle
+        title = .ShareExtension.SendTo.Title
         refreshControl = UIRefreshControl()
         refreshControl?.addTarget(self, action: #selector(refresh), for: .valueChanged)
         navigationItem.leftBarButtonItem = UIBarButtonItem(
-            title: .SendToCancelButton,
+            title: .ShareExtension.SendTo.CancelButton,
             style: .plain,
             target: self,
             action: #selector(cancel)
@@ -108,7 +108,7 @@ class DevicePickerViewController: UITableViewController {
             if self.devices.isEmpty {
                 self.navigationItem.rightBarButtonItem = nil
             } else {
-                self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: .SendToSendButtonTitle, style: .done, target: self, action: #selector(self.send))
+                self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: .ShareExtension.SendTo.SendButtonTitle, style: .done, target: self, action: #selector(self.send))
                 self.navigationItem.rightBarButtonItem?.isEnabled = false
             }
 
@@ -262,7 +262,7 @@ class DevicePickerTableViewHeaderCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         addSubview(nameLabel)
         nameLabel.font = DevicePickerViewControllerUX.TableHeaderTextFont
-        nameLabel.text = .SendToDevicesListTitle
+        nameLabel.text = .ShareExtension.SendTo.DevicesListTitle
         nameLabel.textColor = DevicePickerViewControllerUX.TableHeaderTextColor
 
         nameLabel.snp.makeConstraints { (make) -> Void in
@@ -359,7 +359,7 @@ class DevicePickerNoClientsTableViewCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupHelpView(contentView,
-            introText: .SendToNoDevicesFound,
+                      introText: .ShareExtension.SendTo.NoDevicesFound,
             showMeText: "") // TODO We used to have a 'show me how to ...' text here. But, we cannot open web pages from the extension. So this is clear for now until we decide otherwise.
         // Move the separator off screen
         separatorInset = UIEdgeInsets(top: 0, left: 1000, bottom: 0, right: 0)

--- a/Client/Frontend/Extensions/InstructionsViewController.swift
+++ b/Client/Frontend/Extensions/InstructionsViewController.swift
@@ -78,12 +78,12 @@ class InstructionsViewController: UIViewController {
         edgesForExtendedLayout = []
         view.backgroundColor = UIColor.Photon.White100
 
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: Strings.SendToCloseButton, style: .done, target: self, action: #selector(close))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: .SendToCloseButton, style: .done, target: self, action: #selector(close))
         navigationItem.leftBarButtonItem?.accessibilityIdentifier = "InstructionsViewController.navigationItem.leftBarButtonItem"
 
         setupHelpView(view,
-            introText: Strings.SendToNotSignedInText,
-                showMeText: Strings.SendToNotSignedInMessage)
+            introText: .SendToNotSignedInText,
+                showMeText: .SendToNotSignedInMessage)
     }
 
     @objc func close() {

--- a/Client/Frontend/Extensions/InstructionsViewController.swift
+++ b/Client/Frontend/Extensions/InstructionsViewController.swift
@@ -78,12 +78,12 @@ class InstructionsViewController: UIViewController {
         edgesForExtendedLayout = []
         view.backgroundColor = UIColor.Photon.White100
 
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: .SendToCloseButton, style: .done, target: self, action: #selector(close))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: .ShareExtension.SendTo.CloseButton, style: .done, target: self, action: #selector(close))
         navigationItem.leftBarButtonItem?.accessibilityIdentifier = "InstructionsViewController.navigationItem.leftBarButtonItem"
 
         setupHelpView(view,
-            introText: .SendToNotSignedInText,
-                showMeText: .SendToNotSignedInMessage)
+                      introText: .ShareExtension.SendTo.NotSignedInText,
+                      showMeText: .ShareExtension.SendTo.NotSignedInMessage)
     }
 
     @objc func close() {

--- a/Client/Frontend/Extensions/SiriShortcuts.swift
+++ b/Client/Frontend/Extensions/SiriShortcuts.swift
@@ -22,9 +22,9 @@ class SiriShortcuts {
 
     private var openUrlActivity: NSUserActivity? = {
         let activity = NSUserActivity(activityType: activityType.openURL.rawValue)
-        activity.title = Strings.SettingsSiriOpenURL
+        activity.title = .SettingsSiriOpenURL
         activity.isEligibleForPrediction = true
-        activity.suggestedInvocationPhrase = Strings.SettingsSiriOpenURL
+        activity.suggestedInvocationPhrase = .SettingsSiriOpenURL
         activity.persistentIdentifier = NSUserActivityPersistentIdentifier(activityType.openURL.rawValue)
         return activity
     }()

--- a/Client/Frontend/Extensions/SiriShortcuts.swift
+++ b/Client/Frontend/Extensions/SiriShortcuts.swift
@@ -22,9 +22,9 @@ class SiriShortcuts {
 
     private var openUrlActivity: NSUserActivity? = {
         let activity = NSUserActivity(activityType: activityType.openURL.rawValue)
-        activity.title = .SettingsSiriOpenURL
+        activity.title = .Settings.SiriShortcuts.SiriOpenURL
         activity.isEligibleForPrediction = true
-        activity.suggestedInvocationPhrase = .SettingsSiriOpenURL
+        activity.suggestedInvocationPhrase = .Settings.SiriShortcuts.SiriOpenURL
         activity.persistentIdentifier = NSUserActivityPersistentIdentifier(activityType.openURL.rawValue)
         return activity
     }()

--- a/Client/Frontend/Home/ASLibraryCell.swift
+++ b/Client/Frontend/Home/ASLibraryCell.swift
@@ -17,10 +17,10 @@ class ASLibraryCell: UICollectionViewCell, Themeable {
 
     var libraryButtons: [LibraryShortcutView] = []
 
-    let bookmarks = LibraryPanel(title: .AppMenuBookmarksTitleString, image: UIImage.templateImageNamed("menu-Bookmark"), color: UIColor.Photon.Blue40)
-    let history = LibraryPanel(title: .AppMenuHistoryTitleString, image: UIImage.templateImageNamed("menu-panel-History"), color: UIColor.Photon.Violet50)
-    let readingList = LibraryPanel(title: .AppMenuReadingListTitleString, image: UIImage.templateImageNamed("menu-panel-ReadingList"), color: UIColor.Photon.Pink40)
-    let downloads = LibraryPanel(title: .AppMenuDownloadsTitleString, image: UIImage.templateImageNamed("menu-panel-Downloads"), color: UIColor.Photon.Green60)
+    let bookmarks = LibraryPanel(title: .AppMenu.BookmarksTitleString, image: UIImage.templateImageNamed("menu-Bookmark"), color: UIColor.Photon.Blue40)
+    let history = LibraryPanel(title: .AppMenu.HistoryTitleString, image: UIImage.templateImageNamed("menu-panel-History"), color: UIColor.Photon.Violet50)
+    let readingList = LibraryPanel(title: .AppMenu.ReadingListTitleString, image: UIImage.templateImageNamed("menu-panel-ReadingList"), color: UIColor.Photon.Pink40)
+    let downloads = LibraryPanel(title: .AppMenu.DownloadsTitleString, image: UIImage.templateImageNamed("menu-panel-Downloads"), color: UIColor.Photon.Green60)
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Client/Frontend/Home/ASLibraryCell.swift
+++ b/Client/Frontend/Home/ASLibraryCell.swift
@@ -17,10 +17,10 @@ class ASLibraryCell: UICollectionViewCell, Themeable {
 
     var libraryButtons: [LibraryShortcutView] = []
 
-    let bookmarks = LibraryPanel(title: Strings.AppMenuBookmarksTitleString, image: UIImage.templateImageNamed("menu-Bookmark"), color: UIColor.Photon.Blue40)
-    let history = LibraryPanel(title: Strings.AppMenuHistoryTitleString, image: UIImage.templateImageNamed("menu-panel-History"), color: UIColor.Photon.Violet50)
-    let readingList = LibraryPanel(title: Strings.AppMenuReadingListTitleString, image: UIImage.templateImageNamed("menu-panel-ReadingList"), color: UIColor.Photon.Pink40)
-    let downloads = LibraryPanel(title: Strings.AppMenuDownloadsTitleString, image: UIImage.templateImageNamed("menu-panel-Downloads"), color: UIColor.Photon.Green60)
+    let bookmarks = LibraryPanel(title: .AppMenuBookmarksTitleString, image: UIImage.templateImageNamed("menu-Bookmark"), color: UIColor.Photon.Blue40)
+    let history = LibraryPanel(title: .AppMenuHistoryTitleString, image: UIImage.templateImageNamed("menu-panel-History"), color: UIColor.Photon.Violet50)
+    let readingList = LibraryPanel(title: .AppMenuReadingListTitleString, image: UIImage.templateImageNamed("menu-panel-ReadingList"), color: UIColor.Photon.Pink40)
+    let downloads = LibraryPanel(title: .AppMenuDownloadsTitleString, image: UIImage.templateImageNamed("menu-panel-Downloads"), color: UIColor.Photon.Green60)
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -379,11 +379,11 @@ extension FirefoxHomeViewController {
 
         var title: String? {
             switch self {
-            case .pocket: return .ASPocketTitle2
+            case .pocket: return .ActivityStream.PocketTitle2
             case .jumpBackIn: return .FirefoxHomeJumpBackInSectionTitle
-            case .recentlySaved: return .RecentlySavedSectionTitle
-            case .topSites: return .ASShortcutsTitle
-            case .libraryShortcuts: return .AppMenuLibraryTitleString
+            case .recentlySaved: return .ActivityStream.RecentlySavedSectionTitle
+            case .topSites: return .ActivityStream.ShortcutsTitle
+            case .libraryShortcuts: return .AppMenu.LibraryTitleString
             }
         }
 
@@ -519,7 +519,7 @@ extension FirefoxHomeViewController: UICollectionViewDelegateFlowLayout {
                     hasSentPocketSectionEvent = true
                 }
                 view.moreButton.isHidden = false
-                view.moreButton.setTitle(.PocketMoreStoriesText, for: .normal)
+                view.moreButton.setTitle(.ActivityStream.PocketMoreStoriesText, for: .normal)
                 view.moreButton.addTarget(self, action: #selector(showMorePocketStories), for: .touchUpInside)
                 view.titleLabel.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.SectionTitles.pocket
                 return view
@@ -536,7 +536,7 @@ extension FirefoxHomeViewController: UICollectionViewDelegateFlowLayout {
                 return view
             case .recentlySaved:
                 view.moreButton.isHidden = false
-                view.moreButton.setTitle(.RecentlySavedShowAllText, for: .normal)
+                view.moreButton.setTitle(.ActivityStream.RecentlySavedShowAllText, for: .normal)
                 view.moreButton.addTarget(self, action: #selector(openBookmarks), for: .touchUpInside)
                 view.moreButton.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.MoreButtons.recentlySaved
                 view.titleLabel.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.SectionTitles.recentlySaved

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -129,11 +129,11 @@ extension HomePanelContextMenu {
     func getDefaultContextMenuActions(for site: Site, homePanelDelegate: HomePanelDelegate?) -> [PhotonActionSheetItem]? {
         guard let siteURL = URL(string: site.url) else { return nil }
 
-        let openInNewTabAction = PhotonActionSheetItem(title: Strings.OpenInNewTabContextMenuTitle, iconString: "quick_action_new_tab") { _, _ in
+        let openInNewTabAction = PhotonActionSheetItem(title: .OpenInNewTabContextMenuTitle, iconString: "quick_action_new_tab") { _, _ in
             homePanelDelegate?.homePanelDidRequestToOpenInNewTab(siteURL, isPrivate: false)
         }
 
-        let openInNewPrivateTabAction = PhotonActionSheetItem(title: Strings.OpenInNewPrivateTabContextMenuTitle, iconString: "quick_action_new_private_tab") { _, _ in
+        let openInNewPrivateTabAction = PhotonActionSheetItem(title: .OpenInNewPrivateTabContextMenuTitle, iconString: "quick_action_new_private_tab") { _, _ in
             homePanelDelegate?.homePanelDidRequestToOpenInNewTab(siteURL, isPrivate: true)
         }
 
@@ -379,11 +379,11 @@ extension FirefoxHomeViewController {
 
         var title: String? {
             switch self {
-            case .pocket: return Strings.ASPocketTitle2
-            case .jumpBackIn: return String.FirefoxHomeJumpBackInSectionTitle
-            case .recentlySaved: return Strings.RecentlySavedSectionTitle
-            case .topSites: return Strings.ASShortcutsTitle
-            case .libraryShortcuts: return Strings.AppMenuLibraryTitleString
+            case .pocket: return .ASPocketTitle2
+            case .jumpBackIn: return .FirefoxHomeJumpBackInSectionTitle
+            case .recentlySaved: return .RecentlySavedSectionTitle
+            case .topSites: return .ASShortcutsTitle
+            case .libraryShortcuts: return .AppMenuLibraryTitleString
             }
         }
 
@@ -519,7 +519,7 @@ extension FirefoxHomeViewController: UICollectionViewDelegateFlowLayout {
                     hasSentPocketSectionEvent = true
                 }
                 view.moreButton.isHidden = false
-                view.moreButton.setTitle(Strings.PocketMoreStoriesText, for: .normal)
+                view.moreButton.setTitle(.PocketMoreStoriesText, for: .normal)
                 view.moreButton.addTarget(self, action: #selector(showMorePocketStories), for: .touchUpInside)
                 view.titleLabel.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.SectionTitles.pocket
                 return view
@@ -536,7 +536,7 @@ extension FirefoxHomeViewController: UICollectionViewDelegateFlowLayout {
                 return view
             case .recentlySaved:
                 view.moreButton.isHidden = false
-                view.moreButton.setTitle(Strings.RecentlySavedShowAllText, for: .normal)
+                view.moreButton.setTitle(.RecentlySavedShowAllText, for: .normal)
                 view.moreButton.addTarget(self, action: #selector(openBookmarks), for: .touchUpInside)
                 view.moreButton.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.MoreButtons.recentlySaved
                 view.titleLabel.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.SectionTitles.recentlySaved
@@ -1018,20 +1018,20 @@ extension FirefoxHomeViewController: HomePanelContextMenu {
             return nil
         }
 
-        let openInNewTabAction = PhotonActionSheetItem(title: Strings.OpenInNewTabContextMenuTitle, iconString: "quick_action_new_tab") { _, _ in
+        let openInNewTabAction = PhotonActionSheetItem(title: .OpenInNewTabContextMenuTitle, iconString: "quick_action_new_tab") { _, _ in
             self.homePanelDelegate?.homePanelDidRequestToOpenInNewTab(siteURL, isPrivate: false)
             if Section(indexPath.section) == .pocket {
                 TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .pocketStory)
             }
         }
 
-        let openInNewPrivateTabAction = PhotonActionSheetItem(title: Strings.OpenInNewPrivateTabContextMenuTitle, iconString: "quick_action_new_private_tab") { _, _ in
+        let openInNewPrivateTabAction = PhotonActionSheetItem(title: .OpenInNewPrivateTabContextMenuTitle, iconString: "quick_action_new_private_tab") { _, _ in
             self.homePanelDelegate?.homePanelDidRequestToOpenInNewTab(siteURL, isPrivate: true)
         }
 
         let bookmarkAction: PhotonActionSheetItem
         if site.bookmarked ?? false {
-            bookmarkAction = PhotonActionSheetItem(title: Strings.RemoveBookmarkContextMenuTitle, iconString: "action_bookmark_remove", handler: { _, _ in
+            bookmarkAction = PhotonActionSheetItem(title: .RemoveBookmarkContextMenuTitle, iconString: "action_bookmark_remove", handler: { _, _ in
                 self.profile.places.deleteBookmarksWithURL(url: site.url) >>== {
                     self.profile.panelDataObservers.activityStream.refreshIfNeeded(forceTopSites: false)
                     site.setBookmarked(false)
@@ -1040,7 +1040,7 @@ extension FirefoxHomeViewController: HomePanelContextMenu {
                 TelemetryWrapper.recordEvent(category: .action, method: .delete, object: .bookmark, value: .activityStream)
             })
         } else {
-            bookmarkAction = PhotonActionSheetItem(title: Strings.BookmarkContextMenuTitle, iconString: "action_bookmark", handler: { _, _ in
+            bookmarkAction = PhotonActionSheetItem(title: .BookmarkContextMenuTitle, iconString: "action_bookmark", handler: { _, _ in
                 let shareItem = ShareItem(url: site.url, title: site.title, favicon: site.icon)
                 _ = self.profile.places.createBookmark(parentGUID: BookmarkRoots.MobileFolderGUID, url: shareItem.url, title: shareItem.title)
 
@@ -1057,7 +1057,7 @@ extension FirefoxHomeViewController: HomePanelContextMenu {
             })
         }
 
-        let shareAction = PhotonActionSheetItem(title: Strings.ShareContextMenuTitle, iconString: "action_share", handler: { _, _ in
+        let shareAction = PhotonActionSheetItem(title: .ShareContextMenuTitle, iconString: "action_share", handler: { _, _ in
             let helper = ShareExtensionHelper(url: siteURL, tab: nil)
             let controller = helper.createActivityViewController { (_, _) in }
             if UIDevice.current.userInterfaceIdiom == .pad, let popoverController = controller.popoverPresentationController {
@@ -1072,15 +1072,15 @@ extension FirefoxHomeViewController: HomePanelContextMenu {
             self.present(controller, animated: true, completion: nil)
         })
 
-        let removeTopSiteAction = PhotonActionSheetItem(title: Strings.RemoveContextMenuTitle, iconString: "action_remove", handler: { _, _ in
+        let removeTopSiteAction = PhotonActionSheetItem(title: .RemoveContextMenuTitle, iconString: "action_remove", handler: { _, _ in
             self.hideURLFromTopSites(site)
         })
 
-        let pinTopSite = PhotonActionSheetItem(title: Strings.AddToShortcutsActionTitle, iconString: "action_pin", handler: { _, _ in
+        let pinTopSite = PhotonActionSheetItem(title: .AddToShortcutsActionTitle, iconString: "action_pin", handler: { _, _ in
             self.pinTopSite(site)
         })
 
-        let removePinTopSite = PhotonActionSheetItem(title: Strings.RemoveFromShortcutsActionTitle, iconString: "action_unpin", handler: { _, _ in
+        let removePinTopSite = PhotonActionSheetItem(title: .RemoveFromShortcutsActionTitle, iconString: "action_unpin", handler: { _, _ in
             self.removePinTopSite(site)
         })
 

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -529,7 +529,7 @@ extension FirefoxHomeViewController: UICollectionViewDelegateFlowLayout {
                     hasSentJumpBackInSectionEvent = true
                 }
                 view.moreButton.isHidden = false
-                view.moreButton.setTitle(Strings.RecentlySavedShowAllText, for: .normal)
+                view.moreButton.setTitle(.ActivityStream.RecentlySavedShowAllText, for: .normal)
                 view.moreButton.addTarget(self, action: #selector(openTabTray), for: .touchUpInside)
                 view.moreButton.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.MoreButtons.jumpBackIn
                 view.titleLabel.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.SectionTitles.jumpBackIn

--- a/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
+++ b/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
@@ -192,16 +192,16 @@ class ErrorPageHandler: InternalSchemeResponse {
             }
 
             asset = Bundle.main.path(forResource: "CertError", ofType: "html")
-            actions = "<button onclick='history.back()'>\(Strings.ErrorPagesGoBackButton)</button>"
-            variables["error_title"] = Strings.ErrorPagesCertWarningTitle
+            actions = "<button onclick='history.back()'>\(String.ErrorPagesGoBackButton)</button>"
+            variables["error_title"] = .ErrorPagesCertWarningTitle
             variables["cert_error"] = certError
-            variables["long_description"] = String(format: Strings.ErrorPagesCertWarningDescription, "<b>\(errURLDomain)</b>")
-            variables["advanced_button"] = Strings.ErrorPagesAdvancedButton
-            variables["warning_description"] = Strings.ErrorPagesCertWarningDescription
-            variables["warning_advanced1"] = Strings.ErrorPagesAdvancedWarning1
-            variables["warning_advanced2"] = Strings.ErrorPagesAdvancedWarning2
+            variables["long_description"] = String(format: .ErrorPagesCertWarningDescription, "<b>\(errURLDomain)</b>")
+            variables["advanced_button"] = .ErrorPagesAdvancedButton
+            variables["warning_description"] = .ErrorPagesCertWarningDescription
+            variables["warning_advanced1"] = .ErrorPagesAdvancedWarning1
+            variables["warning_advanced2"] = .ErrorPagesAdvancedWarning2
             variables["warning_actions"] =
-                "<p><a id='\(UserScriptManager.appIdToken)__firefox__visitOnce' href='#'>\(Strings.ErrorPagesVisitOnceButton)</button></p>"
+                "<p><a id='\(UserScriptManager.appIdToken)__firefox__visitOnce' href='#'>\(String.ErrorPagesVisitOnceButton)</button></p>"
         }
 
         variables["actions"] = actions

--- a/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
+++ b/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
@@ -169,7 +169,7 @@ class ErrorPageHandler: InternalSchemeResponse {
             "short_description": errDomain,
             ]
 
-        let tryAgain: String = .ErrorPageTryAgain
+        let tryAgain: String = .ErrorPages.TryAgain
         var actions = "<script>function reloader() { location.replace((new URL(location.href)).searchParams.get(\"url\")); }" +
                     "</script><button onclick='reloader()'>\(tryAgain)</button>"
 
@@ -179,7 +179,7 @@ class ErrorPageHandler: InternalSchemeResponse {
             }
         } else if errDomain == MozDomain {
             if errCode == MozErrorDownloadsNotEnabled {
-                let downloadInSafari: String = .ErrorPageOpenInSafari
+                let downloadInSafari: String = .ErrorPages.OpenInSafari
 
                 // Overwrite the normal try-again action.
                 actions = "<button onclick='webkit.messageHandlers.errorPageHelperMessageManager.postMessage({type: \"\(MessageOpenInSafari)\"})'>\(downloadInSafari)</button>"
@@ -192,16 +192,16 @@ class ErrorPageHandler: InternalSchemeResponse {
             }
 
             asset = Bundle.main.path(forResource: "CertError", ofType: "html")
-            actions = "<button onclick='history.back()'>\(String.ErrorPagesGoBackButton)</button>"
-            variables["error_title"] = .ErrorPagesCertWarningTitle
+            actions = "<button onclick='history.back()'>\(String.ErrorPages.GoBackButton)</button>"
+            variables["error_title"] = .ErrorPages.CertWarningTitle
             variables["cert_error"] = certError
-            variables["long_description"] = String(format: .ErrorPagesCertWarningDescription, "<b>\(errURLDomain)</b>")
-            variables["advanced_button"] = .ErrorPagesAdvancedButton
-            variables["warning_description"] = .ErrorPagesCertWarningDescription
-            variables["warning_advanced1"] = .ErrorPagesAdvancedWarning1
-            variables["warning_advanced2"] = .ErrorPagesAdvancedWarning2
+            variables["long_description"] = String(format: .ErrorPages.CertWarningDescription, "<b>\(errURLDomain)</b>")
+            variables["advanced_button"] = .ErrorPages.AdvancedButton
+            variables["warning_description"] = .ErrorPages.CertWarningDescription
+            variables["warning_advanced1"] = .ErrorPages.AdvancedWarning1
+            variables["warning_advanced2"] = .ErrorPages.AdvancedWarning2
             variables["warning_actions"] =
-                "<p><a id='\(UserScriptManager.appIdToken)__firefox__visitOnce' href='#'>\(String.ErrorPagesVisitOnceButton)</button></p>"
+                "<p><a id='\(UserScriptManager.appIdToken)__firefox__visitOnce' href='#'>\(String.ErrorPages.VisitOnceButton)</button></p>"
         }
 
         variables["actions"] = actions

--- a/Client/Frontend/Intro/IntroScreenSyncView.swift
+++ b/Client/Frontend/Intro/IntroScreenSyncView.swift
@@ -54,7 +54,7 @@ class IntroScreenSyncView: UIView, CardTheme {
     }()
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.text = Strings.CardTitleFxASyncDevices
+        label.text = .CardTitleFxASyncDevices
         label.textColor = fxTextThemeColour
         label.font = UIFont.systemFont(ofSize: 22, weight: .semibold)
         label.textAlignment = .center
@@ -63,7 +63,7 @@ class IntroScreenSyncView: UIView, CardTheme {
     }()
     private lazy var descriptionLabel: UILabel = {
         let label = UILabel()
-        label.text = Strings.CardDescriptionFxASyncDevices
+        label.text = .CardDescriptionFxASyncDevices
         label.textColor = fxTextThemeColour
         label.font = UIFont.systemFont(ofSize: 22, weight: .regular)
         label.textAlignment = .center
@@ -75,7 +75,7 @@ class IntroScreenSyncView: UIView, CardTheme {
         button.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
         button.layer.cornerRadius = 10
         button.backgroundColor = UIColor.Photon.Blue50
-        button.setTitle(Strings.IntroSignUpButtonTitle, for: .normal)
+        button.setTitle(.IntroSignUpButtonTitle, for: .normal)
         button.accessibilityIdentifier = "signUpButtonSyncView"
         return button
     }()
@@ -84,7 +84,7 @@ class IntroScreenSyncView: UIView, CardTheme {
         button.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
         button.backgroundColor = .clear
         button.setTitleColor(UIColor.Photon.Blue50, for: .normal)
-        button.setTitle(Strings.StartBrowsingButtonTitle, for: .normal)
+        button.setTitle(.StartBrowsingButtonTitle, for: .normal)
         button.titleLabel?.textAlignment = .center
         button.accessibilityIdentifier = "startBrowsingButtonSyncView"
         return button

--- a/Client/Frontend/Intro/IntroScreenWelcomeView.swift
+++ b/Client/Frontend/Intro/IntroScreenWelcomeView.swift
@@ -27,7 +27,7 @@ class IntroScreenWelcomeView: UIView, CardTheme {
     }()
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.text = Strings.CardTitleWelcome
+        label.text = .CardTitleWelcome
         label.textColor = fxTextThemeColour
         label.font = UIFont.systemFont(ofSize: 32, weight: .bold)
         label.textAlignment = .center
@@ -37,7 +37,7 @@ class IntroScreenWelcomeView: UIView, CardTheme {
     private lazy var subTitleLabelPage1: UILabel = {
         let fontSize: CGFloat = screenSize.width <= 320 ? 16 : 20
         let label = UILabel()
-        label.text = Strings.CardTextWelcome
+        label.text = .CardTextWelcome
         label.textColor = fxTextThemeColour
         label.font = UIFont.systemFont(ofSize: fontSize)
         label.textAlignment = .center
@@ -61,7 +61,7 @@ class IntroScreenWelcomeView: UIView, CardTheme {
         button.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .bold)
         button.layer.cornerRadius = 10
         button.backgroundColor = UIColor.Photon.Blue50
-        button.setTitle(Strings.IntroSignUpButtonTitle, for: .normal)
+        button.setTitle(.IntroSignUpButtonTitle, for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
         button.setTitleColor(.white, for: .normal)
         button.titleLabel?.textAlignment = .center
@@ -75,7 +75,7 @@ class IntroScreenWelcomeView: UIView, CardTheme {
         button.layer.borderWidth = 1
         button.layer.borderColor = UIColor.gray.cgColor
         button.backgroundColor = .clear
-        button.setTitle(Strings.IntroSignInButtonTitle, for: .normal)
+        button.setTitle(.IntroSignInButtonTitle, for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
         button.setTitleColor(UIColor.Photon.Blue50, for: .normal)
         button.titleLabel?.textAlignment = .center
@@ -83,7 +83,7 @@ class IntroScreenWelcomeView: UIView, CardTheme {
     }()
     private lazy var nextButton: UIButton = {
         let button = UIButton()
-        button.setTitle(Strings.IntroNextButtonTitle, for: .normal)
+        button.setTitle(.IntroNextButtonTitle, for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
         button.setTitleColor(UIColor.Photon.Blue50, for: .normal)
         button.titleLabel?.textAlignment = .center

--- a/Client/Frontend/Library/BookmarkDetailPanel.swift
+++ b/Client/Frontend/Library/BookmarkDetailPanel.swift
@@ -74,7 +74,7 @@ class BookmarkDetailPanel: SiteTableViewController {
     var isPresentedFromToast = false
 
     fileprivate lazy var topRightButton: UIBarButtonItem =  {
-        let button = UIBarButtonItem(title: Strings.SettingsAddCustomEngineSaveButtonText, style: .done, target: self, action: #selector(topRightButtonAction))
+        let button = UIBarButtonItem(title: .SettingsAddCustomEngineSaveButtonText, style: .done, target: self, action: #selector(topRightButtonAction))
         return button
     }()
 
@@ -94,11 +94,11 @@ class BookmarkDetailPanel: SiteTableViewController {
             self.bookmarkItemOrFolderTitle = bookmarkItem.title
             self.bookmarkItemURL = bookmarkItem.url
 
-            self.title = Strings.BookmarksEditBookmark
+            self.title = .BookmarksEditBookmark
         } else if let bookmarkFolder = bookmarkNode as? BookmarkFolder {
             self.bookmarkItemOrFolderTitle = bookmarkFolder.title
 
-            self.title = Strings.BookmarksEditFolder
+            self.title = .BookmarksEditFolder
         }
     }
 
@@ -109,11 +109,11 @@ class BookmarkDetailPanel: SiteTableViewController {
             self.bookmarkItemOrFolderTitle = ""
             self.bookmarkItemURL = ""
 
-            self.title = Strings.BookmarksNewBookmark
+            self.title = .BookmarksNewBookmark
         } else if bookmarkNodeType == .folder {
             self.bookmarkItemOrFolderTitle = ""
 
-            self.title = Strings.BookmarksNewFolder
+            self.title = .BookmarksNewFolder
         }
     }
 
@@ -386,13 +386,13 @@ class BookmarkDetailPanel: SiteTableViewController {
 
         switch indexPath.row {
         case BookmarkDetailFieldsRow.title.rawValue:
-            cell.titleLabel.text = Strings.BookmarkDetailFieldTitle
+            cell.titleLabel.text = .BookmarkDetailFieldTitle
             cell.textField.text = bookmarkItemOrFolderTitle
             cell.textField.autocapitalizationType = .sentences
             cell.textField.keyboardType = .default
             return cell
         case BookmarkDetailFieldsRow.url.rawValue:
-            cell.titleLabel.text = Strings.BookmarkDetailFieldURL
+            cell.titleLabel.text = .BookmarkDetailFieldURL
             cell.textField.text = bookmarkItemURL
             cell.textField.autocapitalizationType = .none
             cell.textField.keyboardType = .URL

--- a/Client/Frontend/Library/BookmarkDetailPanel.swift
+++ b/Client/Frontend/Library/BookmarkDetailPanel.swift
@@ -74,7 +74,7 @@ class BookmarkDetailPanel: SiteTableViewController {
     var isPresentedFromToast = false
 
     fileprivate lazy var topRightButton: UIBarButtonItem =  {
-        let button = UIBarButtonItem(title: .SettingsAddCustomEngineSaveButtonText, style: .done, target: self, action: #selector(topRightButtonAction))
+        let button = UIBarButtonItem(title: .Settings.Search.AddCustomEngine.SaveButtonText, style: .done, target: self, action: #selector(topRightButtonAction))
         return button
     }()
 
@@ -94,11 +94,11 @@ class BookmarkDetailPanel: SiteTableViewController {
             self.bookmarkItemOrFolderTitle = bookmarkItem.title
             self.bookmarkItemURL = bookmarkItem.url
 
-            self.title = .BookmarksEditBookmark
+            self.title = .Bookmarks.Management.EditBookmark
         } else if let bookmarkFolder = bookmarkNode as? BookmarkFolder {
             self.bookmarkItemOrFolderTitle = bookmarkFolder.title
 
-            self.title = .BookmarksEditFolder
+            self.title = .Bookmarks.Management.EditFolder
         }
     }
 
@@ -109,11 +109,11 @@ class BookmarkDetailPanel: SiteTableViewController {
             self.bookmarkItemOrFolderTitle = ""
             self.bookmarkItemURL = ""
 
-            self.title = .BookmarksNewBookmark
+            self.title = .Bookmarks.Management.NewBookmark
         } else if bookmarkNodeType == .folder {
             self.bookmarkItemOrFolderTitle = ""
 
-            self.title = .BookmarksNewFolder
+            self.title = .Bookmarks.Management.NewFolder
         }
     }
 
@@ -386,13 +386,13 @@ class BookmarkDetailPanel: SiteTableViewController {
 
         switch indexPath.row {
         case BookmarkDetailFieldsRow.title.rawValue:
-            cell.titleLabel.text = .BookmarkDetailFieldTitle
+            cell.titleLabel.text = .Bookmarks.Management.DetailFieldTitle
             cell.textField.text = bookmarkItemOrFolderTitle
             cell.textField.autocapitalizationType = .sentences
             cell.textField.keyboardType = .default
             return cell
         case BookmarkDetailFieldsRow.url.rawValue:
-            cell.titleLabel.text = .BookmarkDetailFieldURL
+            cell.titleLabel.text = .Bookmarks.Management.DetailFieldURL
             cell.textField.text = bookmarkItemURL
             cell.textField.autocapitalizationType = .none
             cell.textField.keyboardType = .URL

--- a/Client/Frontend/Library/BookmarksPanel.swift
+++ b/Client/Frontend/Library/BookmarksPanel.swift
@@ -19,10 +19,10 @@ private struct BookmarksPanelUX {
 }
 
 let LocalizedRootBookmarkFolderStrings = [
-    BookmarkRoots.MenuFolderGUID: String.BookmarksFolderTitleMenu,
-    BookmarkRoots.ToolbarFolderGUID: String.BookmarksFolderTitleToolbar,
-    BookmarkRoots.UnfiledFolderGUID: String.BookmarksFolderTitleUnsorted,
-    BookmarkRoots.MobileFolderGUID: String.BookmarksFolderTitleMobile
+    BookmarkRoots.MenuFolderGUID: String.Bookmarks.FolderTitle.Menu,
+    BookmarkRoots.ToolbarFolderGUID: String.Bookmarks.FolderTitle.Toolbar,
+    BookmarkRoots.UnfiledFolderGUID: String.Bookmarks.FolderTitle.Unsorted,
+    BookmarkRoots.MobileFolderGUID: String.Bookmarks.FolderTitle.Mobile
 ]
 
 fileprivate class SeparatorTableViewCell: OneLineTableViewCell {
@@ -82,7 +82,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
     }
     
     func addNewBookmarkItemAction() {
-        let newBookmark = PhotonActionSheetItem(title: .BookmarksNewBookmark, iconString: "action_bookmark", handler: { _, _ in
+        let newBookmark = PhotonActionSheetItem(title: .Bookmarks.Management.NewBookmark, iconString: "action_bookmark", handler: { _, _ in
             guard let bookmarkFolder = self.bookmarkFolder else {
                 return
             }
@@ -91,7 +91,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
             self.navigationController?.pushViewController(detailController, animated: true)
         })
 
-        let newFolder = PhotonActionSheetItem(title: .BookmarksNewFolder, iconString: "bookmarkFolder", handler: { _, _ in
+        let newFolder = PhotonActionSheetItem(title: .Bookmarks.Management.NewFolder, iconString: "bookmarkFolder", handler: { _, _ in
             guard let bookmarkFolder = self.bookmarkFolder else {
                 return
             }
@@ -100,7 +100,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
             self.navigationController?.pushViewController(detailController, animated: true)
         })
 
-        let newSeparator = PhotonActionSheetItem(title: .BookmarksNewSeparator, iconString: "nav-menu", handler: { _, _ in
+        let newSeparator = PhotonActionSheetItem(title: .Bookmarks.Management.NewSeparator, iconString: "nav-menu", handler: { _, _ in
             let centerVisibleRow = self.centerVisibleRow()
 
             self.profile.places.createSeparator(parentGUID: self.bookmarkFolderGUID, position: UInt32(centerVisibleRow)) >>== { guid in
@@ -229,9 +229,9 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
         // to prompt the user before deleting.
         if let bookmarkFolder = bookmarkNode as? BookmarkFolder,
             !bookmarkFolder.childGUIDs.isEmpty {
-            let alertController = UIAlertController(title: .BookmarksDeleteFolderWarningTitle, message: .BookmarksDeleteFolderWarningDescription, preferredStyle: .alert)
-            alertController.addAction(UIAlertAction(title: .BookmarksDeleteFolderCancelButtonLabel, style: .cancel))
-            alertController.addAction(UIAlertAction(title: .BookmarksDeleteFolderDeleteButtonLabel, style: .destructive) { (action) in
+            let alertController = UIAlertController(title: .Bookmarks.Management.DeleteFolderWarningTitle, message: .Bookmarks.Management.DeleteFolderWarningDescription, preferredStyle: .alert)
+            alertController.addAction(UIAlertAction(title: .Bookmarks.Management.DeleteFolderCancelButtonLabel, style: .cancel))
+            alertController.addAction(UIAlertAction(title: .Bookmarks.Management.DeleteFolderDeleteButtonLabel, style: .destructive) { (action) in
                 doDelete()
             })
             present(alertController, animated: true, completion: nil)
@@ -404,7 +404,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
             return nil
         }
 
-        headerView.titleLabel.text = .RecentlyBookmarkedTitle
+        headerView.titleLabel.text = .ActivityStream.RecentlyBookmarkedTitle
         headerView.showBorder(for: .top, true)
         headerView.showBorder(for: .bottom, true)
 
@@ -462,7 +462,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
     }
 
     func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
-        let delete = UITableViewRowAction(style: .default, title: .BookmarksPanelDeleteTableAction, handler: { (action, indexPath) in
+        let delete = UITableViewRowAction(style: .default, title: .Bookmarks.Management.PanelDeleteTableAction, handler: { (action, indexPath) in
             self.deleteBookmarkNodeAtIndexPath(indexPath)
             TelemetryWrapper.recordEvent(category: .action, method: .delete, object: .bookmark, value: .bookmarksPanel, extras: ["gesture": "swipe"])
         })
@@ -499,7 +499,7 @@ extension BookmarksPanel: LibraryPanelContextMenu {
         let pinTopSite = PhotonActionSheetItem(title: Strings.AddToShortcutsActionTitle, iconString: "action_pin", handler: { _, _ in
             self.profile.history.addPinnedTopSite(site).uponQueue(.main) { result in
                 if result.isSuccess {
-                    SimpleToast().showAlertWithText(.AppMenuAddPinToShortcutsConfirmMessage, bottomContainer: self.view)
+                    SimpleToast().showAlertWithText(.AppMenu.AddPinToShortcutsConfirmMessage, bottomContainer: self.view)
                 }
             }
         })

--- a/Client/Frontend/Library/BookmarksPanel.swift
+++ b/Client/Frontend/Library/BookmarksPanel.swift
@@ -19,10 +19,10 @@ private struct BookmarksPanelUX {
 }
 
 let LocalizedRootBookmarkFolderStrings = [
-    BookmarkRoots.MenuFolderGUID: Strings.BookmarksFolderTitleMenu,
-    BookmarkRoots.ToolbarFolderGUID: Strings.BookmarksFolderTitleToolbar,
-    BookmarkRoots.UnfiledFolderGUID: Strings.BookmarksFolderTitleUnsorted,
-    BookmarkRoots.MobileFolderGUID: Strings.BookmarksFolderTitleMobile
+    BookmarkRoots.MenuFolderGUID: String.BookmarksFolderTitleMenu,
+    BookmarkRoots.ToolbarFolderGUID: String.BookmarksFolderTitleToolbar,
+    BookmarkRoots.UnfiledFolderGUID: String.BookmarksFolderTitleUnsorted,
+    BookmarkRoots.MobileFolderGUID: String.BookmarksFolderTitleMobile
 ]
 
 fileprivate class SeparatorTableViewCell: OneLineTableViewCell {
@@ -82,7 +82,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
     }
     
     func addNewBookmarkItemAction() {
-        let newBookmark = PhotonActionSheetItem(title: Strings.BookmarksNewBookmark, iconString: "action_bookmark", handler: { _, _ in
+        let newBookmark = PhotonActionSheetItem(title: .BookmarksNewBookmark, iconString: "action_bookmark", handler: { _, _ in
             guard let bookmarkFolder = self.bookmarkFolder else {
                 return
             }
@@ -91,7 +91,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
             self.navigationController?.pushViewController(detailController, animated: true)
         })
 
-        let newFolder = PhotonActionSheetItem(title: Strings.BookmarksNewFolder, iconString: "bookmarkFolder", handler: { _, _ in
+        let newFolder = PhotonActionSheetItem(title: .BookmarksNewFolder, iconString: "bookmarkFolder", handler: { _, _ in
             guard let bookmarkFolder = self.bookmarkFolder else {
                 return
             }
@@ -100,7 +100,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
             self.navigationController?.pushViewController(detailController, animated: true)
         })
 
-        let newSeparator = PhotonActionSheetItem(title: Strings.BookmarksNewSeparator, iconString: "nav-menu", handler: { _, _ in
+        let newSeparator = PhotonActionSheetItem(title: .BookmarksNewSeparator, iconString: "nav-menu", handler: { _, _ in
             let centerVisibleRow = self.centerVisibleRow()
 
             self.profile.places.createSeparator(parentGUID: self.bookmarkFolderGUID, position: UInt32(centerVisibleRow)) >>== { guid in
@@ -229,9 +229,9 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
         // to prompt the user before deleting.
         if let bookmarkFolder = bookmarkNode as? BookmarkFolder,
             !bookmarkFolder.childGUIDs.isEmpty {
-            let alertController = UIAlertController(title: Strings.BookmarksDeleteFolderWarningTitle, message: Strings.BookmarksDeleteFolderWarningDescription, preferredStyle: .alert)
-            alertController.addAction(UIAlertAction(title: Strings.BookmarksDeleteFolderCancelButtonLabel, style: .cancel))
-            alertController.addAction(UIAlertAction(title: Strings.BookmarksDeleteFolderDeleteButtonLabel, style: .destructive) { (action) in
+            let alertController = UIAlertController(title: .BookmarksDeleteFolderWarningTitle, message: .BookmarksDeleteFolderWarningDescription, preferredStyle: .alert)
+            alertController.addAction(UIAlertAction(title: .BookmarksDeleteFolderCancelButtonLabel, style: .cancel))
+            alertController.addAction(UIAlertAction(title: .BookmarksDeleteFolderDeleteButtonLabel, style: .destructive) { (action) in
                 doDelete()
             })
             present(alertController, animated: true, completion: nil)
@@ -404,7 +404,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
             return nil
         }
 
-        headerView.titleLabel.text = Strings.RecentlyBookmarkedTitle
+        headerView.titleLabel.text = .RecentlyBookmarkedTitle
         headerView.showBorder(for: .top, true)
         headerView.showBorder(for: .bottom, true)
 
@@ -462,7 +462,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
     }
 
     func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
-        let delete = UITableViewRowAction(style: .default, title: Strings.BookmarksPanelDeleteTableAction, handler: { (action, indexPath) in
+        let delete = UITableViewRowAction(style: .default, title: .BookmarksPanelDeleteTableAction, handler: { (action, indexPath) in
             self.deleteBookmarkNodeAtIndexPath(indexPath)
             TelemetryWrapper.recordEvent(category: .action, method: .delete, object: .bookmark, value: .bookmarksPanel, extras: ["gesture": "swipe"])
         })
@@ -499,13 +499,13 @@ extension BookmarksPanel: LibraryPanelContextMenu {
         let pinTopSite = PhotonActionSheetItem(title: Strings.AddToShortcutsActionTitle, iconString: "action_pin", handler: { _, _ in
             self.profile.history.addPinnedTopSite(site).uponQueue(.main) { result in
                 if result.isSuccess {
-                    SimpleToast().showAlertWithText(Strings.AppMenuAddPinToShortcutsConfirmMessage, bottomContainer: self.view)
+                    SimpleToast().showAlertWithText(.AppMenuAddPinToShortcutsConfirmMessage, bottomContainer: self.view)
                 }
             }
         })
         actions.append(pinTopSite)
 
-        let removeAction = PhotonActionSheetItem(title: Strings.RemoveBookmarkContextMenuTitle, iconString: "action_bookmark_remove", handler: { _, _ in
+        let removeAction = PhotonActionSheetItem(title: .RemoveBookmarkContextMenuTitle, iconString: "action_bookmark_remove", handler: { _, _ in
             self.deleteBookmarkNodeAtIndexPath(indexPath)
             TelemetryWrapper.recordEvent(category: .action, method: .delete, object: .bookmark, value: .bookmarksPanel, extras: ["gesture": "long-press"])
         })

--- a/Client/Frontend/Library/BookmarksPanel.swift
+++ b/Client/Frontend/Library/BookmarksPanel.swift
@@ -496,7 +496,7 @@ extension BookmarksPanel: LibraryPanelContextMenu {
             return nil
         }
 
-        let pinTopSite = PhotonActionSheetItem(title: Strings.AddToShortcutsActionTitle, iconString: "action_pin", handler: { _, _ in
+        let pinTopSite = PhotonActionSheetItem(title: .AddToShortcutsActionTitle, iconString: "action_pin", handler: { _, _ in
             self.profile.history.addPinnedTopSite(site).uponQueue(.main) { result in
                 if result.isSuccess {
                     SimpleToast().showAlertWithText(.AppMenu.AddPinToShortcutsConfirmMessage, bottomContainer: self.view)

--- a/Client/Frontend/Library/DownloadsPanel.swift
+++ b/Client/Frontend/Library/DownloadsPanel.swift
@@ -307,13 +307,13 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
 
         switch section {
         case 0:
-            header?.textLabel?.text = .TableDateSectionTitleToday
+            header?.textLabel?.text = .TableDateSectionTitles.Today
         case 1:
-            header?.textLabel?.text = .TableDateSectionTitleYesterday
+            header?.textLabel?.text = .TableDateSectionTitles.Yesterday
         case 2:
-            header?.textLabel?.text = .TableDateSectionTitleLastWeek
+            header?.textLabel?.text = .TableDateSectionTitles.LastWeek
         case 3:
-            header?.textLabel?.text = .TableDateSectionTitleLastMonth
+            header?.textLabel?.text = .TableDateSectionTitles.LastMonth
         default:
             assertionFailure("Invalid Downloads section \(section)")
         }

--- a/Client/Frontend/Library/DownloadsPanel.swift
+++ b/Client/Frontend/Library/DownloadsPanel.swift
@@ -260,7 +260,7 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
 
         let welcomeLabel = UILabel()
         overlayView.addSubview(welcomeLabel)
-        welcomeLabel.text = Strings.DownloadsPanelEmptyStateTitle
+        welcomeLabel.text = .DownloadsPanelEmptyStateTitle
         welcomeLabel.textAlignment = .center
         welcomeLabel.font = DynamicFontHelper.defaultHelper.DeviceFontLight
         welcomeLabel.textColor = UIColor.theme.homePanel.welcomeScreenText
@@ -307,13 +307,13 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
 
         switch section {
         case 0:
-            header?.textLabel?.text = Strings.TableDateSectionTitleToday
+            header?.textLabel?.text = .TableDateSectionTitleToday
         case 1:
-            header?.textLabel?.text = Strings.TableDateSectionTitleYesterday
+            header?.textLabel?.text = .TableDateSectionTitleYesterday
         case 2:
-            header?.textLabel?.text = Strings.TableDateSectionTitleLastWeek
+            header?.textLabel?.text = .TableDateSectionTitleLastWeek
         case 3:
-            header?.textLabel?.text = Strings.TableDateSectionTitleLastMonth
+            header?.textLabel?.text = .TableDateSectionTitleLastMonth
         default:
             assertionFailure("Invalid Downloads section \(section)")
         }
@@ -375,8 +375,8 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
     }
 
     func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
-        let deleteTitle = Strings.DownloadsPanelDeleteTitle
-        let shareTitle = Strings.DownloadsPanelShareTitle
+        let deleteTitle = String.DownloadsPanelDeleteTitle
+        let shareTitle = String.DownloadsPanelShareTitle
         let delete = UITableViewRowAction(style: .destructive, title: deleteTitle, handler: { (action, indexPath) in
             if let downloadedFile = self.downloadedFileForIndexPath(indexPath) {
                 if self.deleteDownloadedFile(downloadedFile) {

--- a/Client/Frontend/Library/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel.swift
@@ -37,13 +37,13 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
         var title: String? {
             switch self {
             case .today:
-                return .TableDateSectionTitleToday
+                return .TableDateSectionTitles.Today
             case .yesterday:
-                return .TableDateSectionTitleYesterday
+                return .TableDateSectionTitles.Yesterday
             case .lastWeek:
-                return .TableDateSectionTitleLastWeek
+                return .TableDateSectionTitles.LastWeek
             case .lastMonth:
-                return .TableDateSectionTitleLastMonth
+                return .TableDateSectionTitles.LastMonth
             default:
                 return nil
             }
@@ -237,7 +237,7 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
     func pinToTopSites(_ site: Site) {
         profile.history.addPinnedTopSite(site).uponQueue(.main) { result in
             if result.isSuccess {
-                SimpleToast().showAlertWithText(.AppMenuAddPinToShortcutsConfirmMessage, bottomContainer: self.view)
+                SimpleToast().showAlertWithText(.AppMenu.AddPinToShortcutsConfirmMessage, bottomContainer: self.view)
             }
         }
     }
@@ -266,7 +266,7 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
             }
         }
 
-        let alert = UIAlertController(title: .ClearHistoryMenuTitle, message: nil, preferredStyle: .actionSheet)
+        let alert = UIAlertController(title: .ClearHistoryMenu.Title, message: nil, preferredStyle: .actionSheet)
 
         // This will run on the iPad-only, and sets the alert to be centered with no arrow.
         if let popoverController = alert.popoverPresentationController {
@@ -275,16 +275,16 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
             popoverController.permittedArrowDirections = []
         }
 
-        [(String.ClearHistoryMenuOptionTheLastHour, 1),
-         (String.ClearHistoryMenuOptionToday, 24),
-         (String.ClearHistoryMenuOptionTodayAndYesterday, 48)].forEach {
+        [(String.ClearHistoryMenu.OptionTheLastHour, 1),
+         (String.ClearHistoryMenu.OptionToday, 24),
+         (String.ClearHistoryMenu.OptionTodayAndYesterday, 48)].forEach {
             (name, time) in
             let action = UIAlertAction(title: name, style: .destructive) { _ in
                 remove(hoursAgo: time)
             }
             alert.addAction(action)
         }
-        alert.addAction(UIAlertAction(title: .ClearHistoryMenuOptionEverything, style: .destructive, handler: { _ in
+        alert.addAction(UIAlertAction(title: .ClearHistoryMenu.OptionEverything, style: .destructive, handler: { _ in
             let types = WKWebsiteDataStore.allWebsiteDataTypes()
             WKWebsiteDataStore.default().removeData(ofTypes: types, modifiedSince: .distantPast, completionHandler: {})
             self.profile.history.clearHistory().uponQueue(.main) { _ in
@@ -292,7 +292,7 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
             }
             self.profile.recentlyClosedTabs.clearTabs()
         }))
-        let cancelAction = UIAlertAction(title: .CancelString, style: .cancel)
+        let cancelAction = UIAlertAction(title: .General.CancelString, style: .cancel)
         alert.addAction(cancelAction)
         present(alert, animated: true)
     }

--- a/Client/Frontend/Library/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel.swift
@@ -37,13 +37,13 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
         var title: String? {
             switch self {
             case .today:
-                return Strings.TableDateSectionTitleToday
+                return .TableDateSectionTitleToday
             case .yesterday:
-                return Strings.TableDateSectionTitleYesterday
+                return .TableDateSectionTitleYesterday
             case .lastWeek:
-                return Strings.TableDateSectionTitleLastWeek
+                return .TableDateSectionTitleLastWeek
             case .lastMonth:
-                return Strings.TableDateSectionTitleLastMonth
+                return .TableDateSectionTitleLastMonth
             default:
                 return nil
             }
@@ -237,7 +237,7 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
     func pinToTopSites(_ site: Site) {
         profile.history.addPinnedTopSite(site).uponQueue(.main) { result in
             if result.isSuccess {
-                SimpleToast().showAlertWithText(Strings.AppMenuAddPinToShortcutsConfirmMessage, bottomContainer: self.view)
+                SimpleToast().showAlertWithText(.AppMenuAddPinToShortcutsConfirmMessage, bottomContainer: self.view)
             }
         }
     }
@@ -248,7 +248,7 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
         }
 
         let nextController = RecentlyClosedTabsPanel(profile: profile)
-        nextController.title = Strings.RecentlyClosedTabsButtonTitle
+        nextController.title = .RecentlyClosedTabsButtonTitle
         nextController.libraryPanelDelegate = libraryPanelDelegate
         refreshControl?.endRefreshing()
         navigationController?.pushViewController(nextController, animated: true)
@@ -266,7 +266,7 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
             }
         }
 
-        let alert = UIAlertController(title: Strings.ClearHistoryMenuTitle, message: nil, preferredStyle: .actionSheet)
+        let alert = UIAlertController(title: .ClearHistoryMenuTitle, message: nil, preferredStyle: .actionSheet)
 
         // This will run on the iPad-only, and sets the alert to be centered with no arrow.
         if let popoverController = alert.popoverPresentationController {
@@ -275,16 +275,16 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
             popoverController.permittedArrowDirections = []
         }
 
-        [(Strings.ClearHistoryMenuOptionTheLastHour, 1),
-         (Strings.ClearHistoryMenuOptionToday, 24),
-         (Strings.ClearHistoryMenuOptionTodayAndYesterday, 48)].forEach {
+        [(String.ClearHistoryMenuOptionTheLastHour, 1),
+         (String.ClearHistoryMenuOptionToday, 24),
+         (String.ClearHistoryMenuOptionTodayAndYesterday, 48)].forEach {
             (name, time) in
             let action = UIAlertAction(title: name, style: .destructive) { _ in
                 remove(hoursAgo: time)
             }
             alert.addAction(action)
         }
-        alert.addAction(UIAlertAction(title: Strings.ClearHistoryMenuOptionEverything, style: .destructive, handler: { _ in
+        alert.addAction(UIAlertAction(title: .ClearHistoryMenuOptionEverything, style: .destructive, handler: { _ in
             let types = WKWebsiteDataStore.allWebsiteDataTypes()
             WKWebsiteDataStore.default().removeData(ofTypes: types, modifiedSince: .distantPast, completionHandler: {})
             self.profile.history.clearHistory().uponQueue(.main) { _ in
@@ -292,7 +292,7 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
             }
             self.profile.recentlyClosedTabs.clearTabs()
         }))
-        let cancelAction = UIAlertAction(title: Strings.CancelString, style: .cancel)
+        let cancelAction = UIAlertAction(title: .CancelString, style: .cancel)
         alert.addAction(cancelAction)
         present(alert, animated: true)
     }
@@ -311,7 +311,7 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
 
     func configureClearHistory(_ cell: OneLineTableViewCell, for indexPath: IndexPath) -> OneLineTableViewCell {
         clearHistoryCell = cell
-        cell.titleLabel.text = Strings.HistoryPanelClearHistoryButtonTitle
+        cell.titleLabel.text = .HistoryPanelClearHistoryButtonTitle
         cell.leftImageView.image = UIImage.templateImageNamed("forget")
         cell.leftImageView.tintColor = UIColor.theme.browser.tint
         cell.leftImageView.backgroundColor = UIColor.theme.homePanel.historyHeaderIconsBackground
@@ -330,7 +330,7 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
 
     func configureRecentlyClosed(_ cell: OneLineTableViewCell, for indexPath: IndexPath) -> OneLineTableViewCell {
         cell.accessoryType = .disclosureIndicator
-        cell.titleLabel.text = Strings.RecentlyClosedTabsButtonTitle
+        cell.titleLabel.text = .RecentlyClosedTabsButtonTitle
         cell.leftImageView.image = UIImage.templateImageNamed("recently_closed")
         cell.leftImageView.tintColor = UIColor.theme.browser.tint
         cell.leftImageView.backgroundColor = UIColor.theme.homePanel.historyHeaderIconsBackground
@@ -521,7 +521,7 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
         if indexPath.section == Section.additionalHistoryActions.rawValue {
             return []
         }
-        let title: String = Strings.HistoryPanelDelete
+        let title: String = .HistoryPanelDelete
 
         let delete = UITableViewRowAction(style: .default, title: title, handler: { (action, indexPath) in
             self.removeHistoryForURLAtIndexPath(indexPath: indexPath)
@@ -557,7 +557,7 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
 
         let welcomeLabel = UILabel()
         overlayView.addSubview(welcomeLabel)
-        welcomeLabel.text = Strings.HistoryPanelEmptyStateTitle
+        welcomeLabel.text = .HistoryPanelEmptyStateTitle
         welcomeLabel.textAlignment = .center
         welcomeLabel.font = DynamicFontHelper.defaultHelper.DeviceFontLight
         welcomeLabel.textColor = UIColor.theme.homePanel.welcomeScreenText
@@ -628,11 +628,11 @@ extension HistoryPanel: LibraryPanelContextMenu {
     func getContextMenuActions(for site: Site, with indexPath: IndexPath) -> [PhotonActionSheetItem]? {
         guard var actions = getDefaultContextMenuActions(for: site, libraryPanelDelegate: libraryPanelDelegate) else { return nil }
 
-        let removeAction = PhotonActionSheetItem(title: Strings.DeleteFromHistoryContextMenuTitle, iconString: "action_delete", handler: { _, _ in
+        let removeAction = PhotonActionSheetItem(title: .DeleteFromHistoryContextMenuTitle, iconString: "action_delete", handler: { _, _ in
             self.removeHistoryForURLAtIndexPath(indexPath: indexPath)
         })
 
-        let pinTopSite = PhotonActionSheetItem(title: Strings.AddToShortcutsActionTitle, iconString: "action_pin", handler: { _, _ in
+        let pinTopSite = PhotonActionSheetItem(title: .AddToShortcutsActionTitle, iconString: "action_pin", handler: { _, _ in
             self.pinToTopSites(site)
         })
         actions.append(pinTopSite)

--- a/Client/Frontend/Library/LibraryPanelContextMenu.swift
+++ b/Client/Frontend/Library/LibraryPanelContextMenu.swift
@@ -37,11 +37,11 @@ extension LibraryPanelContextMenu {
     func getRecentlyClosedTabContexMenuActions(for site: Site, recentlyClosedPanelDelegate: RecentlyClosedPanelDelegate?) ->  [PhotonActionSheetItem]? {
         guard let siteURL = URL(string: site.url) else { return nil }
 
-        let openInNewTabAction = PhotonActionSheetItem(title: Strings.OpenInNewTabContextMenuTitle, iconString: "quick_action_new_tab") { _, _ in
+        let openInNewTabAction = PhotonActionSheetItem(title: .OpenInNewTabContextMenuTitle, iconString: "quick_action_new_tab") { _, _ in
             recentlyClosedPanelDelegate?.openRecentlyClosedSiteInNewTab(siteURL, isPrivate: false)
         }
 
-        let openInNewPrivateTabAction = PhotonActionSheetItem(title: Strings.OpenInNewPrivateTabContextMenuTitle, iconString: "quick_action_new_private_tab") { _, _ in
+        let openInNewPrivateTabAction = PhotonActionSheetItem(title: .OpenInNewPrivateTabContextMenuTitle, iconString: "quick_action_new_private_tab") { _, _ in
             recentlyClosedPanelDelegate?.openRecentlyClosedSiteInNewTab(siteURL, isPrivate: true)
         }
 
@@ -51,11 +51,11 @@ extension LibraryPanelContextMenu {
     func getRemoteTabContexMenuActions(for site: Site, remotePanelDelegate: RemotePanelDelegate?) ->  [PhotonActionSheetItem]? {
         guard let siteURL = URL(string: site.url) else { return nil }
 
-        let openInNewTabAction = PhotonActionSheetItem(title: Strings.OpenInNewTabContextMenuTitle, iconString: "quick_action_new_tab") { _, _ in
+        let openInNewTabAction = PhotonActionSheetItem(title: .OpenInNewTabContextMenuTitle, iconString: "quick_action_new_tab") { _, _ in
             remotePanelDelegate?.remotePanelDidRequestToOpenInNewTab(siteURL, isPrivate: false)
         }
 
-        let openInNewPrivateTabAction = PhotonActionSheetItem(title: Strings.OpenInNewPrivateTabContextMenuTitle, iconString: "quick_action_new_private_tab") { _, _ in
+        let openInNewPrivateTabAction = PhotonActionSheetItem(title: .OpenInNewPrivateTabContextMenuTitle, iconString: "quick_action_new_private_tab") { _, _ in
             remotePanelDelegate?.remotePanelDidRequestToOpenInNewTab(siteURL, isPrivate: true)
         }
 
@@ -65,11 +65,11 @@ extension LibraryPanelContextMenu {
     func getDefaultContextMenuActions(for site: Site, libraryPanelDelegate: LibraryPanelDelegate?) -> [PhotonActionSheetItem]? {
         guard let siteURL = URL(string: site.url) else { return nil }
 
-        let openInNewTabAction = PhotonActionSheetItem(title: Strings.OpenInNewTabContextMenuTitle, iconString: "quick_action_new_tab") { _, _ in
+        let openInNewTabAction = PhotonActionSheetItem(title: .OpenInNewTabContextMenuTitle, iconString: "quick_action_new_tab") { _, _ in
             libraryPanelDelegate?.libraryPanelDidRequestToOpenInNewTab(siteURL, isPrivate: false)
         }
 
-        let openInNewPrivateTabAction = PhotonActionSheetItem(title: Strings.OpenInNewPrivateTabContextMenuTitle, iconString: "quick_action_new_private_tab") { _, _ in
+        let openInNewPrivateTabAction = PhotonActionSheetItem(title: .OpenInNewPrivateTabContextMenuTitle, iconString: "quick_action_new_private_tab") { _, _ in
             libraryPanelDelegate?.libraryPanelDidRequestToOpenInNewTab(siteURL, isPrivate: true)
         }
 

--- a/Client/Frontend/Library/LibraryPanels.swift
+++ b/Client/Frontend/Library/LibraryPanels.swift
@@ -31,13 +31,13 @@ enum LibraryPanelType: Int, CaseIterable {
     var title: String {
         switch self {
         case .bookmarks:
-            return Strings.AppMenuBookmarksTitleString
+            return .AppMenuBookmarksTitleString
         case .history:
-            return Strings.AppMenuHistoryTitleString
+            return .AppMenuHistoryTitleString
         case .downloads:
-            return Strings.AppMenuDownloadsTitleString
+            return .AppMenuDownloadsTitleString
         case .readingList:
-            return Strings.AppMenuReadingListTitleString
+            return .AppMenuReadingListTitleString
         }
     }
 }

--- a/Client/Frontend/Library/LibraryPanels.swift
+++ b/Client/Frontend/Library/LibraryPanels.swift
@@ -31,13 +31,13 @@ enum LibraryPanelType: Int, CaseIterable {
     var title: String {
         switch self {
         case .bookmarks:
-            return .AppMenuBookmarksTitleString
+            return .AppMenu.BookmarksTitleString
         case .history:
-            return .AppMenuHistoryTitleString
+            return .AppMenu.HistoryTitleString
         case .downloads:
-            return .AppMenuDownloadsTitleString
+            return .AppMenu.DownloadsTitleString
         case .readingList:
-            return .AppMenuReadingListTitleString
+            return .AppMenu.ReadingListTitleString
         }
     }
 }
@@ -88,7 +88,7 @@ class LibraryPanels {
             },
             profile: profile,
             imageName: "Bookmarks",
-            accessibilityLabel: .LibraryPanelBookmarksAccessibilityLabel,
+            accessibilityLabel: .LibraryPanel.AccessibilityLabels.Bookmarks,
             accessibilityIdentifier: "LibraryPanels.Bookmarks"),
 
         LibraryPanelDescriptor(
@@ -97,7 +97,7 @@ class LibraryPanels {
             },
             profile: profile,
             imageName: "History",
-            accessibilityLabel: .LibraryPanelHistoryAccessibilityLabel,
+            accessibilityLabel: .LibraryPanel.AccessibilityLabels.History,
             accessibilityIdentifier: "LibraryPanels.History"),
 
         LibraryPanelDescriptor(
@@ -106,7 +106,7 @@ class LibraryPanels {
             },
             profile: profile,
             imageName: "Downloads",
-            accessibilityLabel: .LibraryPanelDownloadsAccessibilityLabel,
+            accessibilityLabel: .LibraryPanel.AccessibilityLabels.Downloads,
             accessibilityIdentifier: "LibraryPanels.Downloads"),
 
         LibraryPanelDescriptor(
@@ -115,7 +115,7 @@ class LibraryPanels {
             },
             profile: profile,
             imageName: "ReadingList",
-            accessibilityLabel: .LibraryPanelReadingListAccessibilityLabel,
+            accessibilityLabel: .LibraryPanel.AccessibilityLabels.ReadingList,
             accessibilityIdentifier: "LibraryPanels.ReadingList")
     ]
 }

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -70,7 +70,7 @@ class LibraryViewController: UIViewController {
     }()
 
     fileprivate lazy var bottomRightButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(title: Strings.BookmarksEdit, style: .plain, target: self, action: #selector(bottomRightButtonAction))
+        let button = UIBarButtonItem(title: .BookmarksEdit, style: .plain, target: self, action: #selector(bottomRightButtonAction))
         button.accessibilityIdentifier = "bookmarksPanelBottomRightButton"
         return button
     }()
@@ -350,7 +350,7 @@ class LibraryViewController: UIViewController {
         case .bookmarks(state: .inFolderEditMode):
             navigationItem.rightBarButtonItem = nil
         case .bookmarks(state: .itemEditMode):
-            topRightButton.title = Strings.SettingsAddCustomEngineSaveButtonText
+            topRightButton.title = .SettingsAddCustomEngineSaveButtonText
             navigationItem.rightBarButtonItem = topRightButton
         default:
             topRightButton.title = String.AppSettingsDone
@@ -371,7 +371,7 @@ class LibraryViewController: UIViewController {
         switch viewModel.currentPanelState {
         case .bookmarks(state: let subState):
             if subState == .inFolder {
-                bottomRightButton.title = Strings.BookmarksEdit
+                bottomRightButton.title = .BookmarksEdit
             } else if subState == .inFolderEditMode {
                 bottomRightButton.title = String.AppSettingsDone
             }

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -58,7 +58,7 @@ class LibraryViewController: UIViewController {
     }()
 
     fileprivate lazy var topRightButton: UIBarButtonItem =  {
-        let button = UIBarButtonItem(title: String.AppSettingsDone, style: .done, target: self, action: #selector(topRightButtonAction))
+        let button = UIBarButtonItem(title: .Settings.Done, style: .done, target: self, action: #selector(topRightButtonAction))
         button.accessibilityIdentifier = "libraryPanelTopRightButton"
         return button
     }()
@@ -70,7 +70,7 @@ class LibraryViewController: UIViewController {
     }()
 
     fileprivate lazy var bottomRightButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(title: .BookmarksEdit, style: .plain, target: self, action: #selector(bottomRightButtonAction))
+        let button = UIBarButtonItem(title: .Bookmarks.Management.Edit, style: .plain, target: self, action: #selector(bottomRightButtonAction))
         button.accessibilityIdentifier = "bookmarksPanelBottomRightButton"
         return button
     }()
@@ -350,10 +350,10 @@ class LibraryViewController: UIViewController {
         case .bookmarks(state: .inFolderEditMode):
             navigationItem.rightBarButtonItem = nil
         case .bookmarks(state: .itemEditMode):
-            topRightButton.title = .SettingsAddCustomEngineSaveButtonText
+            topRightButton.title = .Settings.Search.AddCustomEngine.SaveButtonText
             navigationItem.rightBarButtonItem = topRightButton
         default:
-            topRightButton.title = String.AppSettingsDone
+            topRightButton.title = .Settings.Done
             navigationItem.rightBarButtonItem = topRightButton
         }
     }
@@ -371,9 +371,9 @@ class LibraryViewController: UIViewController {
         switch viewModel.currentPanelState {
         case .bookmarks(state: let subState):
             if subState == .inFolder {
-                bottomRightButton.title = .BookmarksEdit
+                bottomRightButton.title = .Bookmarks.Management.Edit
             } else if subState == .inFolderEditMode {
-                bottomRightButton.title = String.AppSettingsDone
+                bottomRightButton.title = .Settings.Done
             }
         default:
             return

--- a/Client/Frontend/Library/ReaderPanel.swift
+++ b/Client/Frontend/Library/ReaderPanel.swift
@@ -150,7 +150,7 @@ class ReadingListTableViewCell: UITableViewCell, Themeable {
     fileprivate func updateAccessibilityLabel() {
         if let hostname = hostnameLabel.text,
                   let title = titleLabel.text {
-            let unreadStatus: String = unread ? .ReaderPanelUnreadAccessibilityLabel : .ReaderPanelReadAccessibilityLabel
+            let unreadStatus: String = unread ? .ReaderPanel.UnreadAccessibilityLabel : .ReaderPanel.ReadAccessibilityLabel
             let string = "\(title), \(unreadStatus), \(hostname)"
             var label: AnyObject
             if !unread {
@@ -256,7 +256,7 @@ class ReadingListPanel: UITableViewController, LibraryPanel {
 
         let welcomeLabel = UILabel()
         overlayView.addSubview(welcomeLabel)
-        welcomeLabel.text = .ReaderPanelWelcome
+        welcomeLabel.text = .ReaderPanel.Welcome
         welcomeLabel.textAlignment = .center
         welcomeLabel.font = DynamicFontHelper.defaultHelper.DeviceFontSmallBold
         welcomeLabel.adjustsFontSizeToFitWidth = true
@@ -268,7 +268,7 @@ class ReadingListPanel: UITableViewController, LibraryPanel {
 
         let readerModeLabel = UILabel()
         overlayView.addSubview(readerModeLabel)
-        readerModeLabel.text = .ReaderPanelReadingModeDescription
+        readerModeLabel.text = .ReaderPanel.ReadingModeDescription
         readerModeLabel.font = DynamicFontHelper.defaultHelper.DeviceFontSmallLight
         readerModeLabel.numberOfLines = 0
         readerModeLabel.snp.makeConstraints { make in
@@ -286,7 +286,7 @@ class ReadingListPanel: UITableViewController, LibraryPanel {
 
         let readingListLabel = UILabel()
         overlayView.addSubview(readingListLabel)
-        readingListLabel.text = .ReaderPanelReadingListDescription
+        readingListLabel.text = .ReaderPanel.ReadingListDescription
         readingListLabel.font = DynamicFontHelper.defaultHelper.DeviceFontSmallLight
         readingListLabel.numberOfLines = 0
         readingListLabel.snp.makeConstraints { make in
@@ -340,11 +340,11 @@ class ReadingListPanel: UITableViewController, LibraryPanel {
             return []
         }
 
-        let delete = UITableViewRowAction(style: .default, title: .ReaderPanelRemove) { [weak self] action, index in
+        let delete = UITableViewRowAction(style: .default, title: .ReaderPanel.Remove) { [weak self] action, index in
             self?.deleteItem(atIndex: index)
         }
 
-        let toggleText: String = record.unread ? .ReaderPanelMarkAsRead : .ReaderModeBarMarkAsUnread
+        let toggleText: String = record.unread ? .ReaderPanel.MarkAsRead : .ReaderMode.Bar.MarkAsUnread
         let unreadToggle = UITableViewRowAction(style: .normal, title: toggleText.stringSplitWithNewline()) { [weak self] (action, index) in
             self?.toggleItem(atIndex: index)
         }

--- a/Client/Frontend/Library/ReaderPanel.swift
+++ b/Client/Frontend/Library/ReaderPanel.swift
@@ -409,7 +409,7 @@ extension ReadingListPanel: LibraryPanelContextMenu {
     func getContextMenuActions(for site: Site, with indexPath: IndexPath) -> [PhotonActionSheetItem]? {
         guard var actions = getDefaultContextMenuActions(for: site, libraryPanelDelegate: libraryPanelDelegate) else { return nil }
 
-        let removeAction = PhotonActionSheetItem(title: Strings.RemoveContextMenuTitle, iconString: "action_remove", handler: { _, _ in
+        let removeAction = PhotonActionSheetItem(title: .RemoveContextMenuTitle, iconString: "action_remove", handler: { _, _ in
             self.deleteItem(atIndex: indexPath)
         })
 

--- a/Client/Frontend/Login Management/AddCredentialViewController.swift
+++ b/Client/Frontend/Login Management/AddCredentialViewController.swift
@@ -39,7 +39,7 @@ class AddCredentialViewController: UIViewController {
     
     fileprivate lazy var cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancel))
     fileprivate lazy var saveButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(title: Strings.SettingsAddCustomEngineSaveButtonText, style: .done, target: self, action: #selector(addCredential))
+        let button = UIBarButtonItem(title: .SettingsAddCustomEngineSaveButtonText, style: .done, target: self, action: #selector(addCredential))
         button.isEnabled = false
         return button
     }()

--- a/Client/Frontend/Login Management/AddCredentialViewController.swift
+++ b/Client/Frontend/Login Management/AddCredentialViewController.swift
@@ -39,7 +39,7 @@ class AddCredentialViewController: UIViewController {
     
     fileprivate lazy var cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancel))
     fileprivate lazy var saveButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(title: .SettingsAddCustomEngineSaveButtonText, style: .done, target: self, action: #selector(addCredential))
+        let button = UIBarButtonItem(title: .Settings.Search.AddCustomEngine.SaveButtonText, style: .done, target: self, action: #selector(addCredential))
         button.isEnabled = false
         return button
     }()
@@ -123,7 +123,7 @@ extension AddCredentialViewController: UITableViewDataSource {
 
         case .usernameItem:
             let loginCell = cell(forIndexPath: indexPath)
-            loginCell.highlightedLabelTitle = .LoginDetailUsername
+            loginCell.highlightedLabelTitle = .Login.Detail.Username
             loginCell.descriptionLabel.keyboardType = .emailAddress
             loginCell.descriptionLabel.returnKeyType = .next
             loginCell.isEditingFieldData = true
@@ -133,7 +133,7 @@ extension AddCredentialViewController: UITableViewDataSource {
 
         case .passwordItem:
             let loginCell = cell(forIndexPath: indexPath)
-            loginCell.highlightedLabelTitle = .LoginDetailPassword
+            loginCell.highlightedLabelTitle = .Login.Detail.Password
             loginCell.descriptionLabel.returnKeyType = .default
             loginCell.displayDescriptionAsPassword = true
             loginCell.isEditingFieldData = true
@@ -143,7 +143,7 @@ extension AddCredentialViewController: UITableViewDataSource {
 
         case .websiteItem:
             let loginCell = cell(forIndexPath: indexPath)
-            loginCell.highlightedLabelTitle = .LoginDetailWebsite
+            loginCell.highlightedLabelTitle = .Login.Detail.Website
             websiteField = loginCell.descriptionLabel
             loginCell.placeholder = "https://www.example.com"
             websiteField?.accessibilityIdentifier = "websiteField"

--- a/Client/Frontend/Login Management/BreachAlertsDetailView.swift
+++ b/Client/Frontend/Login Management/BreachAlertsDetailView.swift
@@ -38,11 +38,11 @@ class BreachAlertsDetailView: UIView {
         let label = UILabel()
         label.font = DynamicFontHelper.defaultHelper.DeviceFontLargeBold
         label.textColor = textColor
-        label.text = Strings.BreachAlertsTitle
+        label.text = .BreachAlertsTitle
         label.sizeToFit()
         label.isAccessibilityElement = true
         label.accessibilityTraits = .staticText
-        label.accessibilityLabel = Strings.BreachAlertsTitle
+        label.accessibilityLabel = .BreachAlertsTitle
         return label
     }()
 
@@ -52,14 +52,14 @@ class BreachAlertsDetailView: UIView {
             .foregroundColor: UIColor.white,
             .underlineStyle: NSUnderlineStyle.single.rawValue
         ]
-        let attributedText = NSMutableAttributedString(string: Strings.BreachAlertsLearnMore, attributes: attributes)
+        let attributedText = NSMutableAttributedString(string: .BreachAlertsLearnMore, attributes: attributes)
         button.titleLabel?.font = DynamicFontHelper.defaultHelper.DeviceFontSmallBold
         button.setAttributedTitle(attributedText, for: .normal)
         button.setTitleColor(textColor, for: .normal)
         button.tintColor = .white
         button.isAccessibilityElement = true
         button.accessibilityTraits = .button
-        button.accessibilityLabel = Strings.BreachAlertsLearnMore
+        button.accessibilityLabel = .BreachAlertsLearnMore
         return button
     }()
 
@@ -71,19 +71,19 @@ class BreachAlertsDetailView: UIView {
 
     lazy var breachDateLabel: UILabel = {
         let label = UILabel()
-        label.text = Strings.BreachAlertsBreachDate
+        label.text = .BreachAlertsBreachDate
         label.textColor = textColor
         label.numberOfLines = 0
         label.font = DynamicFontHelper.defaultHelper.DeviceFontSmallBold
         label.isAccessibilityElement = true
         label.accessibilityTraits = .staticText
-        label.accessibilityLabel = Strings.BreachAlertsBreachDate
+        label.accessibilityLabel = .BreachAlertsBreachDate
         return label
     }()
 
     lazy var descriptionLabel: UILabel = {
         let label = UILabel()
-        label.text = Strings.BreachAlertsDescription
+        label.text = .BreachAlertsDescription
         label.numberOfLines = 0
         label.textColor = textColor
         label.font = DynamicFontHelper.defaultHelper.DeviceFontSmall
@@ -98,10 +98,10 @@ class BreachAlertsDetailView: UIView {
         button.textColor = textColor
         button.numberOfLines = 0
         button.isUserInteractionEnabled = true
-        button.text = Strings.BreachAlertsLink
+        button.text = .BreachAlertsLink
         button.isAccessibilityElement = true
         button.accessibilityTraits = .button
-        button.accessibilityLabel = Strings.BreachAlertsLink
+        button.accessibilityLabel = .BreachAlertsLink
         return button
     }()
 
@@ -159,7 +159,7 @@ class BreachAlertsDetailView: UIView {
         guard let date = dateFormatter.date(from: breach.breachDate) else { return }
         dateFormatter.dateStyle = .medium
         self.breachDateLabel.text! += " \(dateFormatter.string(from: date))."
-        let goToText = Strings.BreachAlertsLink + " \(breach.domain)"
+        let goToText = .BreachAlertsLink + " \(breach.domain)"
         let attributes: [NSAttributedString.Key: Any] = [
             .foregroundColor: UIColor.white,
             .underlineStyle: NSUnderlineStyle.single.rawValue

--- a/Client/Frontend/Login Management/BreachAlertsDetailView.swift
+++ b/Client/Frontend/Login Management/BreachAlertsDetailView.swift
@@ -38,11 +38,11 @@ class BreachAlertsDetailView: UIView {
         let label = UILabel()
         label.font = DynamicFontHelper.defaultHelper.DeviceFontLargeBold
         label.textColor = textColor
-        label.text = .BreachAlertsTitle
+        label.text = .Alerts.Breach.Title
         label.sizeToFit()
         label.isAccessibilityElement = true
         label.accessibilityTraits = .staticText
-        label.accessibilityLabel = .BreachAlertsTitle
+        label.accessibilityLabel = .Alerts.Breach.Title
         return label
     }()
 
@@ -52,14 +52,14 @@ class BreachAlertsDetailView: UIView {
             .foregroundColor: UIColor.white,
             .underlineStyle: NSUnderlineStyle.single.rawValue
         ]
-        let attributedText = NSMutableAttributedString(string: .BreachAlertsLearnMore, attributes: attributes)
+        let attributedText = NSMutableAttributedString(string: .Alerts.Breach.LearnMore, attributes: attributes)
         button.titleLabel?.font = DynamicFontHelper.defaultHelper.DeviceFontSmallBold
         button.setAttributedTitle(attributedText, for: .normal)
         button.setTitleColor(textColor, for: .normal)
         button.tintColor = .white
         button.isAccessibilityElement = true
         button.accessibilityTraits = .button
-        button.accessibilityLabel = .BreachAlertsLearnMore
+        button.accessibilityLabel = .Alerts.Breach.LearnMore
         return button
     }()
 
@@ -71,19 +71,19 @@ class BreachAlertsDetailView: UIView {
 
     lazy var breachDateLabel: UILabel = {
         let label = UILabel()
-        label.text = .BreachAlertsBreachDate
+        label.text = .Alerts.Breach.BreachDate
         label.textColor = textColor
         label.numberOfLines = 0
         label.font = DynamicFontHelper.defaultHelper.DeviceFontSmallBold
         label.isAccessibilityElement = true
         label.accessibilityTraits = .staticText
-        label.accessibilityLabel = .BreachAlertsBreachDate
+        label.accessibilityLabel = .Alerts.Breach.BreachDate
         return label
     }()
 
     lazy var descriptionLabel: UILabel = {
         let label = UILabel()
-        label.text = .BreachAlertsDescription
+        label.text = .Alerts.Breach.Description
         label.numberOfLines = 0
         label.textColor = textColor
         label.font = DynamicFontHelper.defaultHelper.DeviceFontSmall
@@ -98,10 +98,10 @@ class BreachAlertsDetailView: UIView {
         button.textColor = textColor
         button.numberOfLines = 0
         button.isUserInteractionEnabled = true
-        button.text = .BreachAlertsLink
+        button.text = .Alerts.Breach.Link
         button.isAccessibilityElement = true
         button.accessibilityTraits = .button
-        button.accessibilityLabel = .BreachAlertsLink
+        button.accessibilityLabel = .Alerts.Breach.Link
         return button
     }()
 
@@ -159,7 +159,7 @@ class BreachAlertsDetailView: UIView {
         guard let date = dateFormatter.date(from: breach.breachDate) else { return }
         dateFormatter.dateStyle = .medium
         self.breachDateLabel.text! += " \(dateFormatter.string(from: date))."
-        let goToText = .BreachAlertsLink + " \(breach.domain)"
+        let goToText = .Alerts.Breach.Link + " \(breach.domain)"
         let attributes: [NSAttributedString.Key: Any] = [
             .foregroundColor: UIColor.white,
             .underlineStyle: NSUnderlineStyle.single.rawValue

--- a/Client/Frontend/Login Management/LoginDataSource.swift
+++ b/Client/Frontend/Login Management/LoginDataSource.swift
@@ -16,8 +16,8 @@ class LoginDataSource: NSObject, UITableViewDataSource {
     init(viewModel: LoginListViewModel) {
         self.viewModel = viewModel
         boolSettings = (
-            BoolSetting(prefs: viewModel.profile.prefs, prefKey: PrefsKeys.LoginsSaveEnabled, defaultValue: true, attributedTitleText: NSAttributedString(string: Strings.SettingToSaveLogins)),
-            BoolSetting(prefs: viewModel.profile.prefs, prefKey: PrefsKeys.LoginsShowShortcutMenuItem, defaultValue: true, attributedTitleText: NSAttributedString(string: Strings.SettingToShowLoginsInAppMenu)))
+            BoolSetting(prefs: viewModel.profile.prefs, prefKey: PrefsKeys.LoginsSaveEnabled, defaultValue: true, attributedTitleText: NSAttributedString(string: .SettingToSaveLogins)),
+            BoolSetting(prefs: viewModel.profile.prefs, prefKey: PrefsKeys.LoginsShowShortcutMenuItem, defaultValue: true, attributedTitleText: NSAttributedString(string: .SettingToShowLoginsInAppMenu)))
         super.init()
     }
 

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -103,7 +103,7 @@ class LoginListViewController: SensitiveViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.title = Strings.LoginsAndPasswordsTitle
+        self.title = .LoginsAndPasswordsTitle
         tableView.register(ThemedTableViewCell.self, forCellReuseIdentifier: CellReuseIdentifier)
         tableView.register(ThemedTableSectionHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: SectionHeaderId)
 
@@ -117,7 +117,7 @@ class LoginListViewController: SensitiveViewController {
         searchController.searchBar.autocapitalizationType = .none
         searchController.searchResultsUpdater = self
         searchController.obscuresBackgroundDuringPresentation = false
-        searchController.searchBar.placeholder = Strings.LoginsListSearchPlaceholder
+        searchController.searchBar.placeholder = .LoginsListSearchPlaceholder
         searchController.delegate = self
         navigationItem.hidesSearchBarWhenScrolling = false
         navigationItem.searchController = searchController
@@ -373,7 +373,7 @@ extension LoginListViewController: UITableViewDelegate {
         guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: SectionHeaderId) as? ThemedTableSectionHeaderFooterView else {
             return nil
         }
-        headerView.titleLabel.text = Strings.LoginsListTitle
+        headerView.titleLabel.text = .LoginsListTitle
         headerView.titleLabel.font = DynamicFontHelper.defaultHelper.DeviceFontSmall
         // not using a grouped table: show header borders
         headerView.showBorder(for: .top, true)

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -72,7 +72,7 @@ class LoginListViewController: SensitiveViewController {
             return deferred
         }
 
-        AppAuthenticator.presentAuthenticationUsingInfo(authInfo, touchIDReason: .AuthenticationLoginsTouchReason, success: {
+        AppAuthenticator.presentAuthenticationUsingInfo(authInfo, touchIDReason: .AuthenticationManager.LoginsTouchReason, success: {
             fillDeferred(ok: true)
         }, cancel: {
             fillDeferred(ok: false)
@@ -203,7 +203,7 @@ class LoginListViewController: SensitiveViewController {
     lazy var editButton = UIBarButtonItem(barButtonSystemItem: .edit, target: self, action: #selector(beginEditing))
     lazy var addCredentialButton = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(presentAddCredential))
     lazy var deleteButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(title: .LoginListDelete, style: .plain, target: self, action: #selector(tappedDelete))
+        let button = UIBarButtonItem(title: .Login.List.Delete, style: .plain, target: self, action: #selector(tappedDelete))
         button.tintColor = UIColor.Photon.Red50
         return button
     }()
@@ -232,7 +232,7 @@ class LoginListViewController: SensitiveViewController {
 
     fileprivate func toggleSelectionTitle() {
         let areAllSelected = loginSelectionController.selectedCount == viewModel.count
-        selectionButton.setTitle(areAllSelected ? .LoginListDeselctAll : .LoginListSelctAll, for: [])
+        selectionButton.setTitle(areAllSelected ? .Login.List.DeselctAll : .Login.List.SelctAll, for: [])
     }
 }
 
@@ -275,7 +275,7 @@ private extension LoginListViewController {
         navigationItem.rightBarButtonItems = nil
         navigationItem.leftBarButtonItems = [cancelSelectionButton]
         selectionButtonHeightConstraint?.update(offset: UIConstants.ToolbarHeight)
-        selectionButton.setTitle(.LoginListSelctAll, for: [])
+        selectionButton.setTitle(.Login.List.SelctAll, for: [])
         self.view.layoutIfNeeded()
         tableView.setEditing(true, animated: true)
         tableView.reloadData()

--- a/Client/Frontend/Login Management/NoLoginsView.swift
+++ b/Client/Frontend/Login Management/NoLoginsView.swift
@@ -19,7 +19,7 @@ class NoLoginsView: UIView {
         let label = UILabel()
         label.font = LoginListViewModel.LoginListUX.NoResultsFont
         label.textColor = LoginListViewModel.LoginListUX.NoResultsTextColor
-        label.text = .NoLoginsFound
+        label.text = .Login.NoLoginsFound
         return label
     }()
 

--- a/Client/Frontend/Reader/ReaderModeStyleViewController.swift
+++ b/Client/Frontend/Reader/ReaderModeStyleViewController.swift
@@ -348,7 +348,7 @@ class FontSizeButton: UIButton {
             setTitle(.ReaderModeStyleLargerLabel, for: [])
             accessibilityLabel = .ReaderModeStyleLargerAccessibilityLabel
         case .reset:
-            accessibilityLabel = Strings.ReaderModeResetFontSizeAccessibilityLabel
+            accessibilityLabel = .ReaderModeResetFontSizeAccessibilityLabel
         }
 
         // TODO Does this need to change with the selected font type? Not sure if makes sense for just +/-

--- a/Client/Frontend/Reader/ReaderModeStyleViewController.swift
+++ b/Client/Frontend/Reader/ReaderModeStyleViewController.swift
@@ -348,7 +348,7 @@ class FontSizeButton: UIButton {
             setTitle(.ReaderModeStyleLargerLabel, for: [])
             accessibilityLabel = .ReaderModeStyleLargerAccessibilityLabel
         case .reset:
-            accessibilityLabel = .ReaderModeResetFontSizeAccessibilityLabel
+            accessibilityLabel = .ReaderMode.ResetFontSizeAccessibilityLabel
         }
 
         // TODO Does this need to change with the selected font type? Not sure if makes sense for just +/-

--- a/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
+++ b/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
@@ -12,7 +12,7 @@ fileprivate class CustomFxAContentServerEnableSetting: BoolSetting {
       init(prefs: Prefs, settingDidChange: ((Bool?) -> Void)? = nil) {
           super.init(
               prefs: prefs, prefKey: PrefsKeys.KeyUseCustomFxAContentServer, defaultValue: false,
-              attributedTitleText: NSAttributedString(string: Strings.SettingsAdvancedAccountUseCustomFxAContentServerURITitle),
+              attributedTitleText: NSAttributedString(string: .SettingsAdvancedAccountUseCustomFxAContentServerURITitle),
               settingDidChange: settingDidChange
           )
       }
@@ -22,7 +22,7 @@ fileprivate class CustomFxAContentServerEnableSetting: BoolSetting {
       init(prefs: Prefs, settingDidChange: ((Bool?) -> Void)? = nil) {
           super.init(
               prefs: prefs, prefKey: PrefsKeys.KeyUseCustomSyncTokenServerOverride, defaultValue: false,
-              attributedTitleText: NSAttributedString(string: Strings.SettingsAdvancedAccountUseCustomSyncTokenServerTitle),
+              attributedTitleText: NSAttributedString(string: .SettingsAdvancedAccountUseCustomSyncTokenServerTitle),
               settingDidChange: settingDidChange
           )
       }
@@ -48,7 +48,7 @@ class AdvancedAccountSettingViewController: SettingsTableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = Strings.SettingsAdvancedAccountTitle
+        title = .SettingsAdvancedAccountTitle
         self.customFxAContentURI = self.profile.prefs.stringForKey(PrefsKeys.KeyCustomFxAContentServer)
         self.customSyncTokenServerURI = self.profile.prefs.stringForKey(PrefsKeys.KeyCustomSyncTokenServerOverride)
     }
@@ -69,12 +69,12 @@ class AdvancedAccountSettingViewController: SettingsTableViewController {
 
         let customFxA = CustomURLSetting(prefs: prefs,
                                          prefKey: PrefsKeys.KeyCustomFxAContentServer,
-                                         placeholder: Strings.SettingsAdvancedAccountCustomFxAContentServerURI,
+                                         placeholder: .SettingsAdvancedAccountCustomFxAContentServerURI,
                                          accessibilityIdentifier: "CustomFxAContentServer")
 
         let customSyncTokenServerURISetting = CustomURLSetting(prefs: prefs,
                                         prefKey: PrefsKeys.KeyCustomSyncTokenServerOverride,
-                                        placeholder: Strings.SettingsAdvancedAccountCustomSyncTokenServerURI,
+                                        placeholder: .SettingsAdvancedAccountCustomSyncTokenServerURI,
                                         accessibilityIdentifier: "CustomSyncTokenServerURISetting")
 
         let autoconfigSettings = [

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -41,7 +41,7 @@ class ConnectSetting: WithoutAccountSetting {
     override var accessoryView: UIImageView? { return disclosureIndicator }
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: Strings.FxASignInToSync, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: .FxASignInToSync, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override var accessibilityIdentifier: String? { return "SignInToSync" }
@@ -87,7 +87,7 @@ class SyncNowSetting: WithAccountSetting {
     fileprivate var syncNowTitle: NSAttributedString {
         if !DeviceInfo.hasConnectivity() {
             return NSAttributedString(
-                string: Strings.FxANoInternetConnection,
+                string: .FxANoInternetConnection,
                 attributes: [
                     NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.errorText,
                     NSAttributedString.Key.font: DynamicFontHelper.defaultHelper.DefaultMediumFont
@@ -96,7 +96,7 @@ class SyncNowSetting: WithAccountSetting {
         }
 
         return NSAttributedString(
-            string: Strings.FxASyncNow,
+            string: .FxASyncNow,
             attributes: [
                 NSAttributedString.Key.foregroundColor: self.enabled ? UIColor.theme.tableView.syncText : UIColor.theme.tableView.headerTextLight,
                 NSAttributedString.Key.font: DynamicFontHelper.defaultHelper.DefaultStandardFont
@@ -104,7 +104,7 @@ class SyncNowSetting: WithAccountSetting {
         )
     }
 
-    fileprivate let syncingTitle = NSAttributedString(string: Strings.SyncingMessageWithEllipsis, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.syncText, NSAttributedString.Key.font: UIFont.systemFont(ofSize: DynamicFontHelper.defaultHelper.DefaultStandardFontSize, weight: UIFont.Weight.regular)])
+    fileprivate let syncingTitle = NSAttributedString(string: .SyncingMessageWithEllipsis, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.syncText, NSAttributedString.Key.font: UIFont.systemFont(ofSize: DynamicFontHelper.defaultHelper.DefaultStandardFontSize, weight: UIFont.Weight.regular)])
 
     func startRotateSyncIcon() {
         DispatchQueue.main.async {
@@ -180,7 +180,7 @@ class SyncNowSetting: WithAccountSetting {
 
     fileprivate lazy var troubleshootButton: UIButton = {
         let troubleshootButton = UIButton(type: .roundedRect)
-        troubleshootButton.setTitle(Strings.FirefoxSyncTroubleshootTitle, for: .normal)
+        troubleshootButton.setTitle(.FirefoxSyncTroubleshootTitle, for: .normal)
         troubleshootButton.addTarget(self, action: #selector(self.troubleshoot), for: .touchUpInside)
         troubleshootButton.tintColor = UIColor.theme.tableView.rowActionAccessory
         troubleshootButton.titleLabel?.font = DynamicFontHelper.defaultHelper.DefaultSmallFont
@@ -325,7 +325,7 @@ class AccountStatusSetting: WithAccountSetting {
 
     override var status: NSAttributedString? {
         if RustFirefoxAccounts.shared.isActionNeeded {
-            let string = Strings.FxAAccountVerifyPassword
+            let string = String.FxAAccountVerifyPassword
             let orange = UIColor.theme.tableView.warningText
             let range = NSRange(location: 0, length: string.count)
             let attrs = [NSAttributedString.Key.foregroundColor: orange]
@@ -503,7 +503,7 @@ class SentryIDSetting: HiddenSetting {
     }
 
     func copyAppDeviceIDAndPresentAlert(by navigationController: UINavigationController?) {
-        let alertTitle = Strings.SettingsCopyAppVersionAlertTitle
+        let alertTitle = String.SettingsCopyAppVersionAlertTitle
         let alert = AlertController(title: alertTitle, message: nil, preferredStyle: .alert)
         getSelectedCell(by: navigationController)?.setSelected(false, animated: true)
         UIPasteboard.general.string = deviceAppHash
@@ -683,7 +683,7 @@ class VersionSetting: Setting {
     }
 
     func copyAppVersionAndPresentAlert(by navigationController: UINavigationController?) {
-        let alertTitle = Strings.SettingsCopyAppVersionAlertTitle
+        let alertTitle = String.SettingsCopyAppVersionAlertTitle
         let alert = AlertController(title: alertTitle, message: nil, preferredStyle: .alert)
         getSelectedCell(by: navigationController)?.setSelected(false, animated: true)
         UIPasteboard.general.string = self.title?.string
@@ -768,13 +768,13 @@ class SendFeedbackSetting: Setting {
 class SendAnonymousUsageDataSetting: BoolSetting {
     init(prefs: Prefs, delegate: SettingsDelegate?) {
         let statusText = NSMutableAttributedString()
-        statusText.append(NSAttributedString(string: Strings.SendUsageSettingMessage, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.headerTextLight]))
+        statusText.append(NSAttributedString(string: .SendUsageSettingMessage, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.headerTextLight]))
         statusText.append(NSAttributedString(string: " "))
-        statusText.append(NSAttributedString(string: Strings.SendUsageSettingLink, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.general.highlightBlue]))
+        statusText.append(NSAttributedString(string: .SendUsageSettingLink, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.general.highlightBlue]))
 
         super.init(
             prefs: prefs, prefKey: AppConstants.PrefSendUsageData, defaultValue: true,
-            attributedTitleText: NSAttributedString(string: Strings.SendUsageSettingTitle),
+            attributedTitleText: NSAttributedString(string: .SendUsageSettingTitle),
             attributedStatusText: statusText,
             settingDidChange: {
                 Glean.shared.setUploadEnabled($0)
@@ -797,16 +797,16 @@ class SendAnonymousUsageDataSetting: BoolSetting {
 class StudiesToggleSetting: BoolSetting {
     init(prefs: Prefs, delegate: SettingsDelegate?) {
         let statusText = NSMutableAttributedString()
-        statusText.append(NSAttributedString(string: Strings.SettingsStudiesToggleMessage, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.headerTextLight]))
+        statusText.append(NSAttributedString(string: .SettingsStudiesToggleMessage, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.headerTextLight]))
         // Temporarily removing this until we get a SUMO article up for this setting.
         // https://github.com/mozilla-mobile/firefox-ios/issues/8241
         //
         // statusText.append(NSAttributedString(string: " "))
-        // statusText.append(NSAttributedString(string: Strings.SettingsStudiesToggleLink, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.general.highlightBlue]))
+        // statusText.append(NSAttributedString(string: .SettingsStudiesToggleLink, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.general.highlightBlue]))
 
         super.init(
             prefs: prefs, prefKey: AppConstants.PrefStudiesToggle, defaultValue: true,
-            attributedTitleText: NSAttributedString(string: Strings.SettingsStudiesToggleTitle),
+            attributedTitleText: NSAttributedString(string: .SettingsStudiesToggleTitle),
             attributedStatusText: statusText,
             settingDidChange: { enabled in
                 Experiments.shared.globalUserParticipation = enabled
@@ -885,7 +885,7 @@ class LoginsSetting: Setting {
         self.navigationController = settings.navigationController
         self.settings = settings as? AppSettingsTableViewController
         
-        super.init(title: NSAttributedString(string: Strings.LoginsAndPasswordsTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]),
+        super.init(title: NSAttributedString(string: .LoginsAndPasswordsTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]),
                    delegate: delegate)
     }
 
@@ -954,7 +954,7 @@ class ContentBlockerSetting: Setting {
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
         self.tabManager = settings.tabManager
-        super.init(title: NSAttributedString(string: Strings.SettingsTrackingProtectionSectionName, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .SettingsTrackingProtectionSectionName, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -977,7 +977,7 @@ class ClearPrivateDataSetting: Setting {
         self.profile = settings.profile
         self.tabManager = settings.tabManager
 
-        let clearTitle = Strings.SettingsDataManagementSectionName
+        let clearTitle = String.SettingsDataManagementSectionName
         super.init(title: NSAttributedString(string: clearTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
@@ -1047,12 +1047,12 @@ class ChinaSyncServiceSetting: Setting {
 
         let msg = "更改此设置后，再次登录您的帐户" // "Sign-in again to your account after changing this setting"
         let alert = UIAlertController(title: "", message: msg, preferredStyle: .alert)
-        let ok = UIAlertAction(title: Strings.OKString, style: .default) { _ in
+        let ok = UIAlertAction(title: .OKString, style: .default) { _ in
             self.prefs.setObject(toggle.isOn, forKey: self.prefKey)
             self.profile.removeAccount()
             RustFirefoxAccounts.reconfig(prefs: self.profile.prefs)
         }
-        let cancel = UIAlertAction(title: Strings.CancelString, style: .default) { _ in
+        let cancel = UIAlertAction(title: .CancelString, style: .default) { _ in
             toggle.setOn(!toggle.isOn, animated: true)
         }
         alert.addAction(ok)
@@ -1076,7 +1076,7 @@ class NewTabPageSetting: Setting {
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
-        super.init(title: NSAttributedString(string: Strings.SettingsNewTabSectionName, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .SettingsNewTabSectionName, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -1112,7 +1112,7 @@ class HomeSetting: Setting {
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
 
-        super.init(title: NSAttributedString(string: Strings.AppMenuOpenHomePageTitleString, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .AppMenuOpenHomePageTitleString, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -1133,7 +1133,7 @@ class SiriPageSetting: Setting {
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
 
-        super.init(title: NSAttributedString(string: Strings.SettingsSiriSectionName, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .SettingsSiriSectionName, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -1182,7 +1182,7 @@ class OpenWithSetting: Setting {
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
 
-        super.init(title: NSAttributedString(string: Strings.SettingsOpenWithSectionName, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .SettingsOpenWithSectionName, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -1199,7 +1199,7 @@ class AdvancedAccountSetting: HiddenSetting {
     override var accessibilityIdentifier: String? { return "AdvancedAccount.Setting" }
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: Strings.SettingsAdvancedAccountTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: .SettingsAdvancedAccountTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override init(settings: SettingsTableViewController) {
@@ -1226,18 +1226,18 @@ class ThemeSetting: Setting {
 
     override var status: NSAttributedString {
         if ThemeManager.instance.systemThemeIsOn {
-            return NSAttributedString(string: Strings.SystemThemeSectionHeader)
+            return NSAttributedString(string: .SystemThemeSectionHeader)
         } else if !ThemeManager.instance.automaticBrightnessIsOn {
-            return NSAttributedString(string: Strings.DisplayThemeManualStatusLabel)
+            return NSAttributedString(string: .DisplayThemeManualStatusLabel)
         } else if ThemeManager.instance.automaticBrightnessIsOn {
-            return NSAttributedString(string: Strings.DisplayThemeAutomaticStatusLabel)
+            return NSAttributedString(string: .DisplayThemeAutomaticStatusLabel)
         }
         return NSAttributedString(string: "")
     }
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
-        super.init(title: NSAttributedString(string: Strings.SettingsDisplayThemeTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .SettingsDisplayThemeTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -104,7 +104,7 @@ class SyncNowSetting: WithAccountSetting {
         )
     }
 
-    fileprivate let syncingTitle = NSAttributedString(string: .SyncingMessageWithEllipsis, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.syncText, NSAttributedString.Key.font: UIFont.systemFont(ofSize: DynamicFontHelper.defaultHelper.DefaultStandardFontSize, weight: UIFont.Weight.regular)])
+    fileprivate let syncingTitle = NSAttributedString(string: .Syncing.SyncingMessageWithEllipsis, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.syncText, NSAttributedString.Key.font: UIFont.systemFont(ofSize: DynamicFontHelper.defaultHelper.DefaultStandardFontSize, weight: UIFont.Weight.regular)])
 
     func startRotateSyncIcon() {
         DispatchQueue.main.async {
@@ -180,7 +180,7 @@ class SyncNowSetting: WithAccountSetting {
 
     fileprivate lazy var troubleshootButton: UIButton = {
         let troubleshootButton = UIButton(type: .roundedRect)
-        troubleshootButton.setTitle(.FirefoxSyncTroubleshootTitle, for: .normal)
+        troubleshootButton.setTitle(.Syncing.FirefoxSync.TroubleshootTitle, for: .normal)
         troubleshootButton.addTarget(self, action: #selector(self.troubleshoot), for: .touchUpInside)
         troubleshootButton.tintColor = UIColor.theme.tableView.rowActionAccessory
         troubleshootButton.titleLabel?.font = DynamicFontHelper.defaultHelper.DefaultSmallFont
@@ -503,7 +503,7 @@ class SentryIDSetting: HiddenSetting {
     }
 
     func copyAppDeviceIDAndPresentAlert(by navigationController: UINavigationController?) {
-        let alertTitle = String.SettingsCopyAppVersionAlertTitle
+        let alertTitle = String.Settings.CopyAppVersionAlertTitle
         let alert = AlertController(title: alertTitle, message: nil, preferredStyle: .alert)
         getSelectedCell(by: navigationController)?.setSelected(false, animated: true)
         UIPasteboard.general.string = deviceAppHash
@@ -683,7 +683,7 @@ class VersionSetting: Setting {
     }
 
     func copyAppVersionAndPresentAlert(by navigationController: UINavigationController?) {
-        let alertTitle = String.SettingsCopyAppVersionAlertTitle
+        let alertTitle = String.Settings.CopyAppVersionAlertTitle
         let alert = AlertController(title: alertTitle, message: nil, preferredStyle: .alert)
         getSelectedCell(by: navigationController)?.setSelected(false, animated: true)
         UIPasteboard.general.string = self.title?.string
@@ -705,7 +705,7 @@ class VersionSetting: Setting {
 // Opens the license page in a new tab
 class LicenseAndAcknowledgementsSetting: Setting {
     override var title: NSAttributedString? {
-        return NSAttributedString(string: .AppSettingsLicenses, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: .Settings.AboutSection.Licenses, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override var url: URL? {
@@ -720,7 +720,7 @@ class LicenseAndAcknowledgementsSetting: Setting {
 // Opens about:rights page in the content view controller
 class YourRightsSetting: Setting {
     override var title: NSAttributedString? {
-        return NSAttributedString(string: .AppSettingsYourRights, attributes:
+        return NSAttributedString(string: .Settings.AboutSection.YourRights, attributes:
             [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
@@ -741,7 +741,7 @@ class ShowIntroductionSetting: Setting {
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
-        super.init(title: NSAttributedString(string: .AppSettingsShowTour, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .Settings.SupportSection.ShowTour, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -753,7 +753,7 @@ class ShowIntroductionSetting: Setting {
 
 class SendFeedbackSetting: Setting {
     override var title: NSAttributedString? {
-        return NSAttributedString(string: .AppSettingsSendFeedback, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: .Settings.SupportSection.SendFeedback, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override var url: URL? {
@@ -768,13 +768,13 @@ class SendFeedbackSetting: Setting {
 class SendAnonymousUsageDataSetting: BoolSetting {
     init(prefs: Prefs, delegate: SettingsDelegate?) {
         let statusText = NSMutableAttributedString()
-        statusText.append(NSAttributedString(string: .SendUsageSettingMessage, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.headerTextLight]))
+        statusText.append(NSAttributedString(string: .Settings.SupportSection.SendUsageMessage, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.headerTextLight]))
         statusText.append(NSAttributedString(string: " "))
-        statusText.append(NSAttributedString(string: .SendUsageSettingLink, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.general.highlightBlue]))
+        statusText.append(NSAttributedString(string: .Settings.SupportSection.SendUsageLink, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.general.highlightBlue]))
 
         super.init(
             prefs: prefs, prefKey: AppConstants.PrefSendUsageData, defaultValue: true,
-            attributedTitleText: NSAttributedString(string: .SendUsageSettingTitle),
+            attributedTitleText: NSAttributedString(string: .Settings.SupportSection.SendUsageTitle),
             attributedStatusText: statusText,
             settingDidChange: {
                 Glean.shared.setUploadEnabled($0)
@@ -797,7 +797,7 @@ class SendAnonymousUsageDataSetting: BoolSetting {
 class StudiesToggleSetting: BoolSetting {
     init(prefs: Prefs, delegate: SettingsDelegate?) {
         let statusText = NSMutableAttributedString()
-        statusText.append(NSAttributedString(string: .SettingsStudiesToggleMessage, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.headerTextLight]))
+        statusText.append(NSAttributedString(string: .Settings.SupportSection.StudiesToggleMessage, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.headerTextLight]))
         // Temporarily removing this until we get a SUMO article up for this setting.
         // https://github.com/mozilla-mobile/firefox-ios/issues/8241
         //
@@ -831,7 +831,7 @@ class StudiesToggleSetting: BoolSetting {
 // Opens the SUMO page in a new tab
 class OpenSupportPageSetting: Setting {
     init(delegate: SettingsDelegate?) {
-        super.init(title: NSAttributedString(string: .AppSettingsHelp, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]),
+        super.init(title: NSAttributedString(string: .Settings.SupportSection.Help, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]),
             delegate: delegate)
     }
 
@@ -858,7 +858,7 @@ class SearchSetting: Setting {
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
-        super.init(title: NSAttributedString(string: .AppSettingsSearch, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .Settings.GeneralSection.Search, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -927,12 +927,12 @@ class TouchIDPasscodeSetting: Setting {
         let title: String
         if localAuthContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) {
             if localAuthContext.biometryType == .faceID {
-                title = .AuthenticationFaceIDPasscodeSetting
+                title = .AuthenticationManager.FaceIDPasscodeSetting
             } else {
-                title = .AuthenticationTouchIDPasscodeSetting
+                title = .AuthenticationManager.TouchIDPasscodeSetting
             }
         } else {
-            title = .AuthenticationPasscode
+            title = .AuthenticationManager.Passcode
         }
         super.init(title: NSAttributedString(string: title, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]),
                    delegate: delegate)
@@ -977,7 +977,7 @@ class ClearPrivateDataSetting: Setting {
         self.profile = settings.profile
         self.tabManager = settings.tabManager
 
-        let clearTitle = String.SettingsDataManagementSectionName
+        let clearTitle = String.Settings.PrivacySection.DataManagementSectionName
         super.init(title: NSAttributedString(string: clearTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
@@ -991,7 +991,7 @@ class ClearPrivateDataSetting: Setting {
 
 class PrivacyPolicySetting: Setting {
     override var title: NSAttributedString? {
-        return NSAttributedString(string: .AppSettingsPrivacyPolicy, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: .Settings.PrivacySection.PrivacyPolicy, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override var url: URL? {
@@ -1047,12 +1047,12 @@ class ChinaSyncServiceSetting: Setting {
 
         let msg = "更改此设置后，再次登录您的帐户" // "Sign-in again to your account after changing this setting"
         let alert = UIAlertController(title: "", message: msg, preferredStyle: .alert)
-        let ok = UIAlertAction(title: .OKString, style: .default) { _ in
+        let ok = UIAlertAction(title: .General.OKString, style: .default) { _ in
             self.prefs.setObject(toggle.isOn, forKey: self.prefKey)
             self.profile.removeAccount()
             RustFirefoxAccounts.reconfig(prefs: self.profile.prefs)
         }
-        let cancel = UIAlertAction(title: .CancelString, style: .default) { _ in
+        let cancel = UIAlertAction(title: .General.CancelString, style: .default) { _ in
             toggle.setOn(!toggle.isOn, animated: true)
         }
         alert.addAction(ok)
@@ -1112,7 +1112,7 @@ class HomeSetting: Setting {
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
 
-        super.init(title: NSAttributedString(string: .AppMenuOpenHomePageTitleString, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .AppMenu.OpenHomePageTitleString, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -1133,7 +1133,7 @@ class SiriPageSetting: Setting {
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
 
-        super.init(title: NSAttributedString(string: .SettingsSiriSectionName, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .Settings.GeneralSection.SiriSectionName, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -72,11 +72,11 @@ class AppSettingsTableViewController: SettingsTableViewController {
 
         generalSettings += [
             BoolSetting(prefs: prefs, prefKey: "showClipboardBar", defaultValue: false,
-                        titleText: Strings.SettingsOfferClipboardBarTitle,
-                        statusText: Strings.SettingsOfferClipboardBarStatus),
+                        titleText: .SettingsOfferClipboardBarTitle,
+                        statusText: .SettingsOfferClipboardBarStatus),
             BoolSetting(prefs: prefs, prefKey: PrefsKeys.ContextMenuShowLinkPreviews, defaultValue: true,
-                        titleText: Strings.SettingsShowLinkPreviewsTitle,
-                        statusText: Strings.SettingsShowLinkPreviewsStatus)
+                        titleText: .SettingsShowLinkPreviewsTitle,
+                        statusText: .SettingsShowLinkPreviewsStatus)
         ]
         
         if #available(iOS 14.0, *) {
@@ -85,9 +85,9 @@ class AppSettingsTableViewController: SettingsTableViewController {
             ]
         }
         
-        let accountSectionTitle = NSAttributedString(string: Strings.FxAFirefoxAccount)
+        let accountSectionTitle = NSAttributedString(string: .FxAFirefoxAccount)
 
-        let footerText = !profile.hasAccount() ? NSAttributedString(string: Strings.FxASyncUsageDetails) : nil
+        let footerText = !profile.hasAccount() ? NSAttributedString(string: .FxASyncUsageDetails) : nil
         settings += [
             SettingSection(title: accountSectionTitle, footerTitle: footerText, children: [
                 // Without a Firefox Account:
@@ -98,7 +98,7 @@ class AppSettingsTableViewController: SettingsTableViewController {
                 SyncNowSetting(settings: self)
             ] + accountChinaSyncSetting )]
 
-        settings += [ SettingSection(title: NSAttributedString(string: Strings.SettingsGeneralSectionTitle), children: generalSettings)]
+        settings += [ SettingSection(title: NSAttributedString(string: .SettingsGeneralSectionTitle), children: generalSettings)]
 
         var privacySettings = [Setting]()
         privacySettings.append(LoginsSetting(settings: self, delegate: settingsDelegate))

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -13,12 +13,12 @@ class AppSettingsTableViewController: SettingsTableViewController {
         super.viewDidLoad()
 
         let variables = Experiments.shared.getVariables(featureId: .nimbusValidation)
-        let title = variables.getText("settings-title") ?? .AppSettingsTitle
+        let title = variables.getText("settings-title") ?? .Settings.Title
         let suffix = variables.getString("settings-title-punctuation") ?? ""
 
         navigationItem.title = "\(title)\(suffix)"
         navigationItem.rightBarButtonItem = UIBarButtonItem(
-            title: .AppSettingsDone,
+            title: .Settings.Done,
             style: .done,
             target: navigationController, action: #selector((navigationController as! ThemedNavigationController).done))
         navigationItem.rightBarButtonItem?.accessibilityIdentifier = "AppSettingsTableViewController.navigationItem.leftBarButtonItem"
@@ -50,7 +50,7 @@ class AppSettingsTableViewController: SettingsTableViewController {
             OpenWithSetting(settings: self),
             ThemeSetting(settings: self),
             BoolSetting(prefs: prefs, prefKey: PrefsKeys.KeyBlockPopups, defaultValue: true,
-                        titleText: .AppSettingsBlockPopups),
+                        titleText: .Settings.GeneralSection.BlockPopups),
            ]
 
         if #available(iOS 12.0, *) {
@@ -72,11 +72,11 @@ class AppSettingsTableViewController: SettingsTableViewController {
 
         generalSettings += [
             BoolSetting(prefs: prefs, prefKey: "showClipboardBar", defaultValue: false,
-                        titleText: .SettingsOfferClipboardBarTitle,
-                        statusText: .SettingsOfferClipboardBarStatus),
+                        titleText: .Settings.GeneralSection.OfferClipboardBarTitle,
+                        statusText: .Settings.GeneralSection.OfferClipboardBarStatus),
             BoolSetting(prefs: prefs, prefKey: PrefsKeys.ContextMenuShowLinkPreviews, defaultValue: true,
-                        titleText: .SettingsShowLinkPreviewsTitle,
-                        statusText: .SettingsShowLinkPreviewsStatus)
+                        titleText: .Settings.GeneralSection.ShowLinkPreviewsTitle,
+                        statusText: .Settings.GeneralSection.ShowLinkPreviewsStatus)
         ]
         
         if #available(iOS 14.0, *) {
@@ -98,7 +98,7 @@ class AppSettingsTableViewController: SettingsTableViewController {
                 SyncNowSetting(settings: self)
             ] + accountChinaSyncSetting )]
 
-        settings += [ SettingSection(title: NSAttributedString(string: .SettingsGeneralSectionTitle), children: generalSettings)]
+        settings += [ SettingSection(title: NSAttributedString(string: .Settings.SectionTitle.General), children: generalSettings)]
 
         var privacySettings = [Setting]()
         privacySettings.append(LoginsSetting(settings: self, delegate: settingsDelegate))
@@ -110,8 +110,8 @@ class AppSettingsTableViewController: SettingsTableViewController {
             BoolSetting(prefs: prefs,
                 prefKey: "settings.closePrivateTabs",
                 defaultValue: false,
-                titleText: .AppSettingsClosePrivateTabsTitle,
-                statusText: .AppSettingsClosePrivateTabsDescription)
+                titleText: .Settings.PrivacySection.ClosePrivateTabsTitle,
+                statusText: .Settings.PrivacySection.ClosePrivateTabsDescription)
         ]
 
         privacySettings.append(ContentBlockerSetting(settings: self))
@@ -121,15 +121,15 @@ class AppSettingsTableViewController: SettingsTableViewController {
         ]
 
         settings += [
-            SettingSection(title: NSAttributedString(string: .AppSettingsPrivacyTitle), children: privacySettings),
-            SettingSection(title: NSAttributedString(string: .AppSettingsSupport), children: [
+            SettingSection(title: NSAttributedString(string: .Settings.SectionTitle.Privacy), children: privacySettings),
+            SettingSection(title: NSAttributedString(string: .Settings.SectionTitle.Support), children: [
                 ShowIntroductionSetting(settings: self),
                 SendFeedbackSetting(),
                 SendAnonymousUsageDataSetting(prefs: prefs, delegate: settingsDelegate),
                 StudiesToggleSetting(prefs: prefs, delegate: settingsDelegate),
                 OpenSupportPageSetting(delegate: settingsDelegate),
             ]),
-            SettingSection(title: NSAttributedString(string: .AppSettingsAbout), children: [
+            SettingSection(title: NSAttributedString(string: .Settings.SectionTitle.About), children: [
                 VersionSetting(settings: self),
                 LicenseAndAcknowledgementsSetting(),
                 YourRightsSetting(),

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -65,7 +65,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        title = Strings.SettingsDataManagementTitle
+        title = .SettingsDataManagementTitle
 
         tableView.register(ThemedTableSectionHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: SectionHeaderFooterIdentifier)
 
@@ -78,7 +78,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
 
         if indexPath.section == SectionArrow {
             cell.accessoryType = .disclosureIndicator
-            cell.textLabel?.text = Strings.SettingsWebsiteDataTitle
+            cell.textLabel?.text = .SettingsWebsiteDataTitle
             cell.accessibilityIdentifier = "WebsiteData"
             clearButton = cell
         } else if indexPath.section == SectionToggles {
@@ -92,7 +92,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
             control.tag = indexPath.item
         } else {
             assert(indexPath.section == SectionButton)
-            cell.textLabel?.text = Strings.SettingsClearPrivateDataClearButton
+            cell.textLabel?.text = .SettingsClearPrivateDataClearButton
             cell.textLabel?.textAlignment = .center
             cell.textLabel?.textColor = UIColor.theme.general.destructiveRed
             cell.accessibilityTraits = UIAccessibilityTraits.button
@@ -183,7 +183,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
         let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: SectionHeaderFooterIdentifier) as? ThemedTableSectionHeaderFooterView
         var sectionTitle: String?
         if section == SectionToggles {
-            sectionTitle = Strings.SettingsClearPrivateDataTitle
+            sectionTitle = .SettingsClearPrivateDataTitle
         } else {
             sectionTitle = nil
         }

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -65,7 +65,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        title = .SettingsDataManagementTitle
+        title = .Settings.DataManagementTitle
 
         tableView.register(ThemedTableSectionHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: SectionHeaderFooterIdentifier)
 
@@ -78,7 +78,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
 
         if indexPath.section == SectionArrow {
             cell.accessoryType = .disclosureIndicator
-            cell.textLabel?.text = .SettingsWebsiteDataTitle
+            cell.textLabel?.text = .Settings.WebsiteDataTitle
             cell.accessibilityIdentifier = "WebsiteData"
             clearButton = cell
         } else if indexPath.section == SectionToggles {
@@ -92,7 +92,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
             control.tag = indexPath.item
         } else {
             assert(indexPath.section == SectionButton)
-            cell.textLabel?.text = .SettingsClearPrivateDataClearButton
+            cell.textLabel?.text = .Settings.ClearPrivateDataClearButton
             cell.textLabel?.textAlignment = .center
             cell.textLabel?.textColor = UIColor.theme.general.destructiveRed
             cell.accessibilityTraits = UIAccessibilityTraits.button
@@ -183,7 +183,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
         let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: SectionHeaderFooterIdentifier) as? ThemedTableSectionHeaderFooterView
         var sectionTitle: String?
         if section == SectionToggles {
-            sectionTitle = .SettingsClearPrivateDataTitle
+            sectionTitle = .Settings.ClearPrivateDataTitle
         } else {
             sectionTitle = nil
         }

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -158,7 +158,7 @@ class CookiesClearable: Clearable {
 class TrackingProtectionClearable: Clearable {
     //@TODO: re-using string because we are too late in cycle to change strings
     var label: String {
-        return Strings.SettingsTrackingProtectionSectionName
+        return .SettingsTrackingProtectionSectionName
     }
 
     func clear() -> Success {

--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -9,18 +9,18 @@ extension BlockingStrength {
     var settingTitle: String {
         switch self {
         case .basic:
-            return Strings.TrackingProtectionOptionBlockListLevelStandard
+            return .TrackingProtectionOptionBlockListLevelStandard
         case .strict:
-            return Strings.TrackingProtectionOptionBlockListLevelStrict
+            return .TrackingProtectionOptionBlockListLevelStrict
         }
     }
 
     var settingSubtitle: String {
         switch self {
         case .basic:
-            return Strings.TrackingProtectionStandardLevelDescription
+            return .TrackingProtectionStandardLevelDescription
         case .strict:
-            return Strings.TrackingProtectionStrictLevelDescription
+            return .TrackingProtectionStrictLevelDescription
         }
     }
 
@@ -56,7 +56,7 @@ class TPAccessoryInfo: ThemedTableViewController {
         stack.axis = .vertical
 
         let header = UILabel()
-        header.text = Strings.TPAccessoryInfoBlocksTitle
+        header.text = .TPAccessoryInfoBlocksTitle
         header.font = DynamicFontHelper.defaultHelper.DefaultMediumBoldFont
         header.textColor = UIColor.theme.tableView.headerTextLight
 
@@ -96,33 +96,33 @@ class TPAccessoryInfo: ThemedTableViewController {
         let cell = ThemedTableViewCell(style: .subtitle, reuseIdentifier: nil)
         if indexPath.section == 0 {
             if indexPath.row == 0 {
-                cell.textLabel?.text = Strings.TPSocialBlocked
+                cell.textLabel?.text = .TPSocialBlocked
             } else {
-                cell.textLabel?.text = Strings.TPCategoryDescriptionSocial
+                cell.textLabel?.text = .TPCategoryDescriptionSocial
             }
         } else if indexPath.section == 1 {
             if indexPath.row == 0 {
-                cell.textLabel?.text = Strings.TPCrossSiteBlocked
+                cell.textLabel?.text = .TPCrossSiteBlocked
             } else {
-                cell.textLabel?.text = Strings.TPCategoryDescriptionCrossSite
+                cell.textLabel?.text = .TPCategoryDescriptionCrossSite
             }
         } else if indexPath.section == 2 {
             if indexPath.row == 0 {
-                cell.textLabel?.text = Strings.TPCryptominersBlocked
+                cell.textLabel?.text = .TPCryptominersBlocked
             } else {
-                cell.textLabel?.text = Strings.TPCategoryDescriptionCryptominers
+                cell.textLabel?.text = .TPCategoryDescriptionCryptominers
             }
         } else if indexPath.section == 3 {
             if indexPath.row == 0 {
-                cell.textLabel?.text = Strings.TPFingerprintersBlocked
+                cell.textLabel?.text = .TPFingerprintersBlocked
             } else {
-                cell.textLabel?.text = Strings.TPCategoryDescriptionFingerprinters
+                cell.textLabel?.text = .TPCategoryDescriptionFingerprinters
             }
         } else if indexPath.section == 4 {
             if indexPath.row == 0 {
-                cell.textLabel?.text = Strings.TPContentBlocked
+                cell.textLabel?.text = .TPContentBlocked
             } else {
-                cell.textLabel?.text = Strings.TPCategoryDescriptionContentTrackers
+                cell.textLabel?.text = .TPCategoryDescriptionContentTrackers
             }
         }
         cell.imageView?.tintColor = UIColor.theme.tableView.rowText
@@ -149,7 +149,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
 
         super.init(style: .grouped)
 
-        self.title = Strings.SettingsTrackingProtectionSectionName
+        self.title = .SettingsTrackingProtectionSectionName
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -170,8 +170,8 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
                 TelemetryWrapper.recordEvent(category: .action, method: .change, object: .setting, extras: ["pref": "ETP-strength", "to": option.rawValue])
                 
                 if option == .strict {
-                    let alert = UIAlertController(title: Strings.TrackerProtectionAlertTitle, message: Strings.TrackerProtectionAlertDescription, preferredStyle: .alert)
-                    alert.addAction(UIAlertAction(title: Strings.TrackerProtectionAlertButton, style: .default, handler: nil))
+                    let alert = UIAlertController(title: .TrackerProtectionAlertTitle, message: .TrackerProtectionAlertDescription, preferredStyle: .alert)
+                    alert.addAction(UIAlertAction(title: .TrackerProtectionAlertButton, style: .default, handler: nil))
                     self.present(alert, animated: true)
                 }
             })
@@ -185,7 +185,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
             return setting
         }
 
-        let enabledSetting = BoolSetting(prefs: profile.prefs, prefKey: ContentBlockingConfig.Prefs.EnabledKey, defaultValue: ContentBlockingConfig.Defaults.NormalBrowsing, attributedTitleText: NSAttributedString(string: Strings.TrackingProtectionEnableTitle)) { [weak self] enabled in
+        let enabledSetting = BoolSetting(prefs: profile.prefs, prefKey: ContentBlockingConfig.Prefs.EnabledKey, defaultValue: ContentBlockingConfig.Defaults.NormalBrowsing, attributedTitleText: NSAttributedString(string: .TrackingProtectionEnableTitle)) { [weak self] enabled in
             TabContentBlocker.prefsChanged()
             strengthSetting.forEach { item in
                 item.enabled = enabled
@@ -193,13 +193,13 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
             self?.tableView.reloadData()
         }
 
-        let firstSection = SettingSection(title: nil, footerTitle: NSAttributedString(string: Strings.TrackingProtectionCellFooter), children: [enabledSetting])
+        let firstSection = SettingSection(title: nil, footerTitle: NSAttributedString(string: .TrackingProtectionCellFooter), children: [enabledSetting])
 
-        let optionalFooterTitle = NSAttributedString(string: Strings.TrackingProtectionLevelFooter)
+        let optionalFooterTitle = NSAttributedString(string: .TrackingProtectionLevelFooter)
 
         // The bottom of the block lists section has a More Info button, implemented as a custom footer view,
         // SettingSection needs footerTitle set to create a footer, which we then override the view for.
-        let blockListsTitle = Strings.TrackingProtectionOptionProtectionLevelTitle
+        let blockListsTitle = String.TrackingProtectionOptionProtectionLevelTitle
         let secondSection = SettingSection(title: NSAttributedString(string: blockListsTitle), footerTitle: optionalFooterTitle, children: strengthSetting)
         return [firstSection, secondSection]
     }
@@ -216,7 +216,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
         }
 
         // TODO: Get a dedicated string for this.
-        let title = Strings.TrackerProtectionLearnMore
+        let title = String.TrackerProtectionLearnMore
 
         var attributes = [NSAttributedString.Key: AnyObject]()
         attributes[NSAttributedString.Key.font] = UIFont.systemFont(ofSize: 12, weight: UIFont.Weight.regular)

--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -56,7 +56,7 @@ class TPAccessoryInfo: ThemedTableViewController {
         stack.axis = .vertical
 
         let header = UILabel()
-        header.text = .TPAccessoryInfoBlocksTitle
+        header.text = .TrackingProtection.AccessoryInfoBlocksTitle
         header.font = DynamicFontHelper.defaultHelper.DefaultMediumBoldFont
         header.textColor = UIColor.theme.tableView.headerTextLight
 
@@ -96,33 +96,33 @@ class TPAccessoryInfo: ThemedTableViewController {
         let cell = ThemedTableViewCell(style: .subtitle, reuseIdentifier: nil)
         if indexPath.section == 0 {
             if indexPath.row == 0 {
-                cell.textLabel?.text = .TPSocialBlocked
+                cell.textLabel?.text = .TrackingProtection.Category.Titles.SocialBlocked
             } else {
-                cell.textLabel?.text = .TPCategoryDescriptionSocial
+                cell.textLabel?.text = .TrackingProtection.Category.Descriptions.Social
             }
         } else if indexPath.section == 1 {
             if indexPath.row == 0 {
-                cell.textLabel?.text = .TPCrossSiteBlocked
+                cell.textLabel?.text = .TrackingProtection.Category.Titles.CrossSiteBlocked
             } else {
-                cell.textLabel?.text = .TPCategoryDescriptionCrossSite
+                cell.textLabel?.text = .TrackingProtection.Category.Descriptions.CrossSite
             }
         } else if indexPath.section == 2 {
             if indexPath.row == 0 {
-                cell.textLabel?.text = .TPCryptominersBlocked
+                cell.textLabel?.text = .TrackingProtection.Category.Titles.CryptominersBlocked
             } else {
-                cell.textLabel?.text = .TPCategoryDescriptionCryptominers
+                cell.textLabel?.text = .TrackingProtection.Category.Descriptions.Cryptominers
             }
         } else if indexPath.section == 3 {
             if indexPath.row == 0 {
-                cell.textLabel?.text = .TPFingerprintersBlocked
+                cell.textLabel?.text = .TrackingProtection.Category.Titles.FingerprintersBlocked
             } else {
-                cell.textLabel?.text = .TPCategoryDescriptionFingerprinters
+                cell.textLabel?.text = .TrackingProtection.Category.Descriptions.Fingerprinters
             }
         } else if indexPath.section == 4 {
             if indexPath.row == 0 {
-                cell.textLabel?.text = .TPContentBlocked
+                cell.textLabel?.text = .TrackingProtection.Category.Titles.ContentBlocked
             } else {
-                cell.textLabel?.text = .TPCategoryDescriptionContentTrackers
+                cell.textLabel?.text = .TrackingProtection.Category.Descriptions.ContentTrackers
             }
         }
         cell.imageView?.tintColor = UIColor.theme.tableView.rowText

--- a/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -39,7 +39,7 @@ class CustomSearchViewController: SettingsTableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = Strings.SettingsAddCustomEngineTitle
+        title = .SettingsAddCustomEngineTitle
         view.addSubview(spinnerView)
         spinnerView.snp.makeConstraints { make in
             make.center.equalTo(self.view.snp.center)
@@ -127,7 +127,7 @@ class CustomSearchViewController: SettingsTableViewController {
             return URL(string: string)
         }
 
-        let titleField = CustomSearchEngineTextView(placeholder: Strings.SettingsAddCustomEngineTitlePlaceholder, settingIsValid: { text in
+        let titleField = CustomSearchEngineTextView(placeholder: .SettingsAddCustomEngineTitlePlaceholder, settingIsValid: { text in
             return text != nil && text != ""
         }, settingDidChange: {fieldText in
             guard let title = fieldText else {
@@ -138,7 +138,7 @@ class CustomSearchViewController: SettingsTableViewController {
         titleField.textField.text = engineTitle
         titleField.textField.accessibilityIdentifier = "customEngineTitle"
 
-        let urlField = CustomSearchEngineTextView(placeholder: Strings.SettingsAddCustomEngineURLPlaceholder, height: 133,
+        let urlField = CustomSearchEngineTextView(placeholder: .SettingsAddCustomEngineURLPlaceholder, height: 133,
             keyboardType: .URL, settingIsValid: { text in
             //Can check url text text validity here.
             return true
@@ -151,8 +151,8 @@ class CustomSearchViewController: SettingsTableViewController {
         urlField.textField.accessibilityIdentifier = "customEngineUrl"
 
         let settings: [SettingSection] = [
-            SettingSection(title: NSAttributedString(string: Strings.SettingsAddCustomEngineTitleLabel), children: [titleField]),
-            SettingSection(title: NSAttributedString(string: Strings.SettingsAddCustomEngineURLLabel), footerTitle: NSAttributedString(string: "https://youtube.com/search?q=%s"), children: [urlField])
+            SettingSection(title: NSAttributedString(string: .SettingsAddCustomEngineTitleLabel), children: [titleField]),
+            SettingSection(title: NSAttributedString(string: .SettingsAddCustomEngineURLLabel), footerTitle: NSAttributedString(string: "https://youtube.com/search?q=%s"), children: [urlField])
         ]
 
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .save, target: self, action: #selector(self.addCustomSearchEngine))

--- a/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -39,7 +39,7 @@ class CustomSearchViewController: SettingsTableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = .SettingsAddCustomEngineTitle
+        title = .Settings.Search.AddCustomEngine.Title
         view.addSubview(spinnerView)
         spinnerView.snp.makeConstraints { make in
             make.center.equalTo(self.view.snp.center)
@@ -127,7 +127,7 @@ class CustomSearchViewController: SettingsTableViewController {
             return URL(string: string)
         }
 
-        let titleField = CustomSearchEngineTextView(placeholder: .SettingsAddCustomEngineTitlePlaceholder, settingIsValid: { text in
+        let titleField = CustomSearchEngineTextView(placeholder: .Settings.Search.AddCustomEngine.TitlePlaceholder, settingIsValid: { text in
             return text != nil && text != ""
         }, settingDidChange: {fieldText in
             guard let title = fieldText else {
@@ -138,7 +138,7 @@ class CustomSearchViewController: SettingsTableViewController {
         titleField.textField.text = engineTitle
         titleField.textField.accessibilityIdentifier = "customEngineTitle"
 
-        let urlField = CustomSearchEngineTextView(placeholder: .SettingsAddCustomEngineURLPlaceholder, height: 133,
+        let urlField = CustomSearchEngineTextView(placeholder: .Settings.Search.AddCustomEngine.URLPlaceholder, height: 133,
             keyboardType: .URL, settingIsValid: { text in
             //Can check url text text validity here.
             return true
@@ -151,8 +151,8 @@ class CustomSearchViewController: SettingsTableViewController {
         urlField.textField.accessibilityIdentifier = "customEngineUrl"
 
         let settings: [SettingSection] = [
-            SettingSection(title: NSAttributedString(string: .SettingsAddCustomEngineTitleLabel), children: [titleField]),
-            SettingSection(title: NSAttributedString(string: .SettingsAddCustomEngineURLLabel), footerTitle: NSAttributedString(string: "https://youtube.com/search?q=%s"), children: [urlField])
+            SettingSection(title: NSAttributedString(string: .Settings.Search.AddCustomEngine.TitleLabel), children: [titleField]),
+            SettingSection(title: NSAttributedString(string: .Settings.Search.AddCustomEngine.URLLabel), footerTitle: NSAttributedString(string: "https://youtube.com/search?q=%s"), children: [urlField])
         ]
 
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .save, target: self, action: #selector(self.addCustomSearchEngine))

--- a/Client/Frontend/Settings/HomePageSettingViewController.swift
+++ b/Client/Frontend/Settings/HomePageSettingViewController.swift
@@ -15,7 +15,7 @@ class HomePageSettingViewController: SettingsTableViewController {
         self.prefs = prefs
         super.init(style: .grouped)
 
-        self.title = Strings.AppMenuOpenHomePageTitleString
+        self.title = .AppMenuOpenHomePageTitleString
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -32,24 +32,24 @@ class HomePageSettingViewController: SettingsTableViewController {
             self.tableView.reloadData()
         }
 
-        let showTopSites = CheckmarkSetting(title: NSAttributedString(string: Strings.SettingsNewTabTopSites), subtitle: nil, accessibilityIdentifier: "HomeAsFirefoxHome", isChecked: {return self.currentChoice == NewTabPage.topSites}, onChecked: {
+        let showTopSites = CheckmarkSetting(title: NSAttributedString(string: .SettingsNewTabTopSites), subtitle: nil, accessibilityIdentifier: "HomeAsFirefoxHome", isChecked: {return self.currentChoice == NewTabPage.topSites}, onChecked: {
             self.currentChoice = NewTabPage.topSites
             onFinished()
         })
-        let showWebPage = WebPageSetting(prefs: prefs, prefKey: PrefsKeys.HomeButtonHomePageURL, defaultValue: nil, placeholder: Strings.CustomNewPageURL, accessibilityIdentifier: "HomeAsCustomURL", isChecked: {return !showTopSites.isChecked()}, settingDidChange: { (string) in
+        let showWebPage = WebPageSetting(prefs: prefs, prefKey: PrefsKeys.HomeButtonHomePageURL, defaultValue: nil, placeholder: .CustomNewPageURL, accessibilityIdentifier: "HomeAsCustomURL", isChecked: {return !showTopSites.isChecked()}, settingDidChange: { (string) in
             self.currentChoice = NewTabPage.homePage
             self.prefs.setString(self.currentChoice.rawValue, forKey: NewTabAccessors.HomePrefKey)
             self.tableView.reloadData()
         })
         showWebPage.textField.textAlignment = .natural
 
-        let section = SettingSection(title: NSAttributedString(string: Strings.NewTabSectionName), footerTitle: NSAttributedString(string: Strings.NewTabSectionNameFooter), children: [showTopSites, showWebPage])
+        let section = SettingSection(title: NSAttributedString(string: .NewTabSectionName), footerTitle: NSAttributedString(string: .NewTabSectionNameFooter), children: [showTopSites, showWebPage])
 
-        let topsitesSection = SettingSection(title: NSAttributedString(string: Strings.SettingsTopSitesCustomizeTitle), footerTitle: NSAttributedString(string: Strings.SettingsTopSitesCustomizeFooter), children: [TopSitesSettings(settings: self)])
+        let topsitesSection = SettingSection(title: NSAttributedString(string: .SettingsTopSitesCustomizeTitle), footerTitle: NSAttributedString(string: .SettingsTopSitesCustomizeFooter), children: [TopSitesSettings(settings: self)])
 
         let isPocketEnabledDefault = Pocket.IslocaleSupported(Locale.current.identifier)
-        let pocketSetting = BoolSetting(prefs: profile.prefs, prefKey: PrefsKeys.ASPocketStoriesVisible, defaultValue: isPocketEnabledDefault, attributedTitleText: NSAttributedString(string: Strings.SettingsNewTabPocket))
-        let pocketSection = SettingSection(title: NSAttributedString(string: Strings.SettingsNewTabASTitle), footerTitle: NSAttributedString(string: Strings.SettingsNewTabPocketFooter), children: [pocketSetting])
+        let pocketSetting = BoolSetting(prefs: profile.prefs, prefKey: PrefsKeys.ASPocketStoriesVisible, defaultValue: isPocketEnabledDefault, attributedTitleText: NSAttributedString(string: .SettingsNewTabPocket))
+        let pocketSection = SettingSection(title: NSAttributedString(string: .SettingsNewTabASTitle), footerTitle: NSAttributedString(string: .SettingsNewTabPocketFooter), children: [pocketSetting])
         return [section, topsitesSection, pocketSection]
     }
 
@@ -69,7 +69,7 @@ class HomePageSettingViewController: SettingsTableViewController {
         override var accessoryType: UITableViewCell.AccessoryType { return .disclosureIndicator }
         override var status: NSAttributedString {
             let num = self.profile.prefs.intForKey(PrefsKeys.NumberOfTopSiteRows) ?? TopSitesRowCountSettingsController.defaultNumberOfRows
-            return NSAttributedString(string: String(format: Strings.TopSitesRowCount, num))
+            return NSAttributedString(string: String(format: .TopSitesRowCount, num))
         }
 
         override var accessibilityIdentifier: String? { return "TopSitesRows" }
@@ -77,7 +77,7 @@ class HomePageSettingViewController: SettingsTableViewController {
 
         init(settings: SettingsTableViewController) {
             self.profile = settings.profile
-            super.init(title: NSAttributedString(string: Strings.ASTopSitesTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+            super.init(title: NSAttributedString(string: .ASTopSitesTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
         }
 
         override func onClick(_ navigationController: UINavigationController?) {
@@ -97,7 +97,7 @@ class TopSitesRowCountSettingsController: SettingsTableViewController {
         self.prefs = prefs
         numberOfRows = self.prefs.intForKey(PrefsKeys.NumberOfTopSiteRows) ?? TopSitesRowCountSettingsController.defaultNumberOfRows
         super.init(style: .grouped)
-        self.title = Strings.AppMenuTopSitesTitleString
+        self.title = .AppMenuTopSitesTitleString
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -115,7 +115,7 @@ class TopSitesRowCountSettingsController: SettingsTableViewController {
         }
 
         let rows = [1, 2, 3, 4].map(createSetting)
-        let section = SettingSection(title: NSAttributedString(string: Strings.TopSitesRowSettingFooter), footerTitle: nil, children: rows)
+        let section = SettingSection(title: NSAttributedString(string: .TopSitesRowSettingFooter), footerTitle: nil, children: rows)
         return [section]
     }
 }

--- a/Client/Frontend/Settings/HomePageSettingViewController.swift
+++ b/Client/Frontend/Settings/HomePageSettingViewController.swift
@@ -15,7 +15,7 @@ class HomePageSettingViewController: SettingsTableViewController {
         self.prefs = prefs
         super.init(style: .grouped)
 
-        self.title = .AppMenuOpenHomePageTitleString
+        self.title = .AppMenu.OpenHomePageTitleString
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -69,7 +69,7 @@ class HomePageSettingViewController: SettingsTableViewController {
         override var accessoryType: UITableViewCell.AccessoryType { return .disclosureIndicator }
         override var status: NSAttributedString {
             let num = self.profile.prefs.intForKey(PrefsKeys.NumberOfTopSiteRows) ?? TopSitesRowCountSettingsController.defaultNumberOfRows
-            return NSAttributedString(string: String(format: .TopSitesRowCount, num))
+            return NSAttributedString(string: String(format: .ActivityStream.TopSitesRowCount, num))
         }
 
         override var accessibilityIdentifier: String? { return "TopSitesRows" }
@@ -77,7 +77,7 @@ class HomePageSettingViewController: SettingsTableViewController {
 
         init(settings: SettingsTableViewController) {
             self.profile = settings.profile
-            super.init(title: NSAttributedString(string: .ASTopSitesTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+            super.init(title: NSAttributedString(string: .ActivityStream.TopSitesTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
         }
 
         override func onClick(_ navigationController: UINavigationController?) {
@@ -97,7 +97,7 @@ class TopSitesRowCountSettingsController: SettingsTableViewController {
         self.prefs = prefs
         numberOfRows = self.prefs.intForKey(PrefsKeys.NumberOfTopSiteRows) ?? TopSitesRowCountSettingsController.defaultNumberOfRows
         super.init(style: .grouped)
-        self.title = .AppMenuTopSitesTitleString
+        self.title = .AppMenu.TopSitesTitleString
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -115,7 +115,7 @@ class TopSitesRowCountSettingsController: SettingsTableViewController {
         }
 
         let rows = [1, 2, 3, 4].map(createSetting)
-        let section = SettingSection(title: NSAttributedString(string: .TopSitesRowSettingFooter), footerTitle: nil, children: rows)
+        let section = SettingSection(title: NSAttributedString(string: .ActivityStream.TopSitesRowSettingFooter), footerTitle: nil, children: rows)
         return [section]
     }
 }

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -161,7 +161,7 @@ extension LoginDetailViewController: UITableViewDataSource {
 
         case .usernameItem:
             let loginCell = cell(forIndexPath: indexPath)
-            loginCell.highlightedLabelTitle = .LoginDetailUsername
+            loginCell.highlightedLabelTitle = .Login.Detail.Username
             loginCell.descriptionLabel.text = login.username
             loginCell.descriptionLabel.keyboardType = .emailAddress
             loginCell.descriptionLabel.returnKeyType = .next
@@ -172,7 +172,7 @@ extension LoginDetailViewController: UITableViewDataSource {
 
         case .passwordItem:
             let loginCell = cell(forIndexPath: indexPath)
-            loginCell.highlightedLabelTitle = .LoginDetailPassword
+            loginCell.highlightedLabelTitle = .Login.Detail.Password
             loginCell.descriptionLabel.text = login.password
             loginCell.descriptionLabel.returnKeyType = .default
             loginCell.displayDescriptionAsPassword = true
@@ -183,7 +183,7 @@ extension LoginDetailViewController: UITableViewDataSource {
 
         case .websiteItem:
             let loginCell = cell(forIndexPath: indexPath)
-            loginCell.highlightedLabelTitle = .LoginDetailWebsite
+            loginCell.highlightedLabelTitle = .Login.Detail.Website
             loginCell.descriptionLabel.text = login.hostname
             websiteField = loginCell.descriptionLabel
             websiteField?.accessibilityIdentifier = "websiteField"
@@ -195,8 +195,8 @@ extension LoginDetailViewController: UITableViewDataSource {
 
         case .lastModifiedSeparator:
             let cell = CenteredDetailCell(style: .subtitle, reuseIdentifier: nil)
-            let created: String = .LoginDetailCreatedAt
-            let lastModified: String = .LoginDetailModifiedAt
+            let created: String = .Login.Detail.CreatedAt
+            let lastModified: String = .Login.Detail.ModifiedAt
 
             let lastModifiedFormatted = String(format: lastModified, Date.fromTimestamp(UInt64(login.timePasswordChanged)).toRelativeTimeString(dateStyle: .medium))
             let createdFormatted = String(format: created, Date.fromTimestamp(UInt64(login.timeCreated)).toRelativeTimeString(dateStyle: .medium, timeStyle: .none))
@@ -209,7 +209,7 @@ extension LoginDetailViewController: UITableViewDataSource {
 
         case .deleteItem:
             let deleteCell = cell(forIndexPath: indexPath)
-            deleteCell.textLabel?.text = .LoginDetailDelete
+            deleteCell.textLabel?.text = .Login.Detail.Delete
             deleteCell.textLabel?.textAlignment = .center
             deleteCell.textLabel?.textColor = UIColor.theme.general.destructiveRed
             deleteCell.accessibilityTraits = UIAccessibilityTraits.button

--- a/Client/Frontend/Settings/NewTabContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/NewTabContentSettingsViewController.swift
@@ -15,7 +15,7 @@ class NewTabContentSettingsViewController: SettingsTableViewController {
         self.prefs = prefs
         super.init(style: .grouped)
 
-        self.title = Strings.SettingsNewTabTitle
+        self.title = .SettingsNewTabTitle
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -31,22 +31,22 @@ class NewTabContentSettingsViewController: SettingsTableViewController {
             self.tableView.reloadData()
         }
 
-        let showTopSites = CheckmarkSetting(title: NSAttributedString(string: Strings.SettingsNewTabTopSites), subtitle: nil, accessibilityIdentifier: "NewTabAsFirefoxHome", isChecked: {return self.currentChoice == NewTabPage.topSites}, onChecked: {
+        let showTopSites = CheckmarkSetting(title: NSAttributedString(string: .SettingsNewTabTopSites), subtitle: nil, accessibilityIdentifier: "NewTabAsFirefoxHome", isChecked: {return self.currentChoice == NewTabPage.topSites}, onChecked: {
             self.currentChoice = NewTabPage.topSites
             onFinished()
         })
-        let showBlankPage = CheckmarkSetting(title: NSAttributedString(string: Strings.SettingsNewTabBlankPage), subtitle: nil, accessibilityIdentifier: "NewTabAsBlankPage", isChecked: {return self.currentChoice == NewTabPage.blankPage}, onChecked: {
+        let showBlankPage = CheckmarkSetting(title: NSAttributedString(string: .SettingsNewTabBlankPage), subtitle: nil, accessibilityIdentifier: "NewTabAsBlankPage", isChecked: {return self.currentChoice == NewTabPage.blankPage}, onChecked: {
             self.currentChoice = NewTabPage.blankPage
             onFinished()
         })
-        let showWebPage = WebPageSetting(prefs: prefs, prefKey: HomePageConstants.NewTabCustomUrlPrefKey, defaultValue: nil, placeholder: Strings.CustomNewPageURL, accessibilityIdentifier: "NewTabAsCustomURL", isChecked: {return !showTopSites.isChecked() && !showBlankPage.isChecked()}, settingDidChange: { (string) in
+        let showWebPage = WebPageSetting(prefs: prefs, prefKey: HomePageConstants.NewTabCustomUrlPrefKey, defaultValue: nil, placeholder: .CustomNewPageURL, accessibilityIdentifier: "NewTabAsCustomURL", isChecked: {return !showTopSites.isChecked() && !showBlankPage.isChecked()}, settingDidChange: { (string) in
             self.currentChoice = NewTabPage.homePage
             self.prefs.setString(self.currentChoice.rawValue, forKey: NewTabAccessors.NewTabPrefKey)
             self.tableView.reloadData()
         })
         showWebPage.textField.textAlignment = .natural
 
-        let section = SettingSection(title: NSAttributedString(string: Strings.NewTabSectionName), footerTitle: NSAttributedString(string: Strings.NewTabSectionNameFooter), children: [showTopSites, showBlankPage, showWebPage])
+        let section = SettingSection(title: NSAttributedString(string: .NewTabSectionName), footerTitle: NSAttributedString(string: .NewTabSectionNameFooter), children: [showTopSites, showBlankPage, showWebPage])
 
         return [section]
     }

--- a/Client/Frontend/Settings/SearchEnginePicker.swift
+++ b/Client/Frontend/Settings/SearchEnginePicker.swift
@@ -12,8 +12,8 @@ class SearchEnginePicker: ThemedTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        navigationItem.title = .SearchEnginePickerTitle
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: .SearchEnginePickerCancel, style: .plain, target: self, action: #selector(cancel))
+        navigationItem.title = .Settings.Search.EnginePicker.Title
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: .Settings.Search.EnginePicker.Cancel, style: .plain, target: self, action: #selector(cancel))
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -50,10 +50,10 @@ class SearchSettingsTableViewController: ThemedTableViewController {
 
         // Insert Done button if being presented outside of the Settings Nav stack
         if !(self.navigationController is ThemedNavigationController) {
-            self.navigationItem.leftBarButtonItem = UIBarButtonItem(title: Strings.SettingsSearchDoneButton, style: .done, target: self, action: #selector(self.dismissAnimated))
+            self.navigationItem.leftBarButtonItem = UIBarButtonItem(title: .SettingsSearchDoneButton, style: .done, target: self, action: #selector(self.dismissAnimated))
         }
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: Strings.SettingsSearchEditButton, style: .plain, target: self,
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: .SettingsSearchEditButton, style: .plain, target: self,
                                                                  action: #selector(beginEditing))
     }
 
@@ -121,9 +121,9 @@ class SearchSettingsTableViewController: ThemedTableViewController {
                 cell.selectionStyle = .none
             } else {
                 cell.editingAccessoryType = .disclosureIndicator
-                cell.accessibilityLabel = Strings.SettingsAddCustomEngineTitle
+                cell.accessibilityLabel = .SettingsAddCustomEngineTitle
                 cell.accessibilityIdentifier = "customEngineViewButton"
-                cell.textLabel?.text = Strings.SettingsAddCustomEngine
+                cell.textLabel?.text = .SettingsAddCustomEngine
             }
         }
 
@@ -161,7 +161,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
             customSearchEngineForm.profile = self.profile
             customSearchEngineForm.successCallback = {
                 guard let window = self.view.window else { return }
-                SimpleToast().showAlertWithText(Strings.ThirdPartySearchEngineAdded, bottomContainer: window)
+                SimpleToast().showAlertWithText(.ThirdPartySearchEngineAdded, bottomContainer: window)
             }
             navigationController?.pushViewController(customSearchEngineForm, animated: true)
         }
@@ -291,7 +291,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
         tableView.isEditing = true
         showDeletion = editing
         UIView.performWithoutAnimation {
-            self.navigationItem.rightBarButtonItem?.title = editing ? Strings.SettingsSearchDoneButton : Strings.SettingsSearchEditButton
+            self.navigationItem.rightBarButtonItem?.title = editing ? .SettingsSearchDoneButton : .SettingsSearchEditButton
         }
         navigationItem.rightBarButtonItem?.isEnabled = isEditable
         navigationItem.rightBarButtonItem?.action = editing ?

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -39,7 +39,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        navigationItem.title = .SearchSettingsTitle
+        navigationItem.title = .Settings.Search.Title
 
         // To allow re-ordering the list of search engines at all times.
         tableView.isEditing = true
@@ -50,10 +50,10 @@ class SearchSettingsTableViewController: ThemedTableViewController {
 
         // Insert Done button if being presented outside of the Settings Nav stack
         if !(self.navigationController is ThemedNavigationController) {
-            self.navigationItem.leftBarButtonItem = UIBarButtonItem(title: .SettingsSearchDoneButton, style: .done, target: self, action: #selector(self.dismissAnimated))
+            self.navigationItem.leftBarButtonItem = UIBarButtonItem(title: .Settings.SearchDoneButton, style: .done, target: self, action: #selector(self.dismissAnimated))
         }
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: .SettingsSearchEditButton, style: .plain, target: self,
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: .Settings.SearchEditButton, style: .plain, target: self,
                                                                  action: #selector(beginEditing))
     }
 
@@ -79,14 +79,14 @@ class SearchSettingsTableViewController: ThemedTableViewController {
             case ItemDefaultEngine:
                 engine = model.defaultEngine
                 cell.editingAccessoryType = .disclosureIndicator
-                cell.accessibilityLabel = .SearchSettingsDefaultSearchEngineAccessibilityLabel
+                cell.accessibilityLabel = .Settings.Search.DefaultSearchEngineAccessibilityLabel
                 cell.accessibilityValue = engine.shortName
                 cell.textLabel?.text = engine.shortName
                 cell.imageView?.image = engine.image.createScaled(IconSize)
                 cell.imageView?.layer.cornerRadius = 4
                 cell.imageView?.layer.masksToBounds = true
             case ItemDefaultSuggestions:
-                cell.textLabel?.text = .SearchSettingsShowSearchSuggestions
+                cell.textLabel?.text = .Settings.Search.ShowSearchSuggestions
                 let toggle = UISwitchThemed()
                 toggle.onTintColor = UIColor.theme.tableView.controlTint
                 toggle.addTarget(self, action: #selector(didToggleSearchSuggestions), for: .valueChanged)
@@ -121,9 +121,9 @@ class SearchSettingsTableViewController: ThemedTableViewController {
                 cell.selectionStyle = .none
             } else {
                 cell.editingAccessoryType = .disclosureIndicator
-                cell.accessibilityLabel = .SettingsAddCustomEngineTitle
+                cell.accessibilityLabel = .Settings.Search.AddCustomEngine.Title
                 cell.accessibilityIdentifier = "customEngineViewButton"
-                cell.textLabel?.text = .SettingsAddCustomEngine
+                cell.textLabel?.text = .Settings.Search.AddCustomEngine.AddCustomEngine
             }
         }
 
@@ -161,7 +161,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
             customSearchEngineForm.profile = self.profile
             customSearchEngineForm.successCallback = {
                 guard let window = self.view.window else { return }
-                SimpleToast().showAlertWithText(.ThirdPartySearchEngineAdded, bottomContainer: window)
+                SimpleToast().showAlertWithText(.Settings.Search.ThirdPartyEngine.EngineAdded, bottomContainer: window)
             }
             navigationController?.pushViewController(customSearchEngineForm, animated: true)
         }
@@ -215,9 +215,9 @@ class SearchSettingsTableViewController: ThemedTableViewController {
         let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: SectionHeaderIdentifier) as! ThemedTableSectionHeaderFooterView
         var sectionTitle: String
         if section == SectionDefault {
-            sectionTitle = .SearchSettingsDefaultSearchEngineTitle
+            sectionTitle = .Settings.Search.DefaultSearchEngineTitle
         } else {
-            sectionTitle = .SearchSettingsQuickSearchEnginesTitle
+            sectionTitle = .Settings.Search.QuickSearchEnginesTitle
         }
         headerView.titleLabel.text = sectionTitle
 
@@ -291,7 +291,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
         tableView.isEditing = true
         showDeletion = editing
         UIView.performWithoutAnimation {
-            self.navigationItem.rightBarButtonItem?.title = editing ? .SettingsSearchDoneButton : .SettingsSearchEditButton
+            self.navigationItem.rightBarButtonItem?.title = editing ? .Settings.SearchDoneButton : .Settings.SearchEditButton
         }
         navigationItem.rightBarButtonItem?.isEnabled = isEditable
         navigationItem.rightBarButtonItem?.action = editing ?

--- a/Client/Frontend/Settings/SiriSettingsViewController.swift
+++ b/Client/Frontend/Settings/SiriSettingsViewController.swift
@@ -15,7 +15,7 @@ class SiriSettingsViewController: SettingsTableViewController {
         self.prefs = prefs
         super.init(style: .grouped)
 
-        self.title = Strings.SettingsSiriSectionName
+        self.title = .SettingsSiriSectionName
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -24,7 +24,7 @@ class SiriSettingsViewController: SettingsTableViewController {
 
     override func generateSettings() -> [SettingSection] {
         let setting = SiriOpenURLSetting(settings: self)
-        let firstSection = SettingSection(title: nil, footerTitle: NSAttributedString(string: Strings.SettingsSiriSectionDescription), children: [setting])
+        let firstSection = SettingSection(title: nil, footerTitle: NSAttributedString(string: .SettingsSiriSectionDescription), children: [setting])
         return [firstSection]
     }
 }
@@ -36,7 +36,7 @@ class SiriOpenURLSetting: Setting {
     override var accessibilityIdentifier: String? { return "SiriSettings" }
 
     init(settings: SettingsTableViewController) {
-        super.init(title: NSAttributedString(string: Strings.SettingsSiriOpenURL, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .SettingsSiriOpenURL, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {

--- a/Client/Frontend/Settings/SiriSettingsViewController.swift
+++ b/Client/Frontend/Settings/SiriSettingsViewController.swift
@@ -15,7 +15,7 @@ class SiriSettingsViewController: SettingsTableViewController {
         self.prefs = prefs
         super.init(style: .grouped)
 
-        self.title = .SettingsSiriSectionName
+        self.title = .Settings.GeneralSection.SiriSectionName
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -24,7 +24,7 @@ class SiriSettingsViewController: SettingsTableViewController {
 
     override func generateSettings() -> [SettingSection] {
         let setting = SiriOpenURLSetting(settings: self)
-        let firstSection = SettingSection(title: nil, footerTitle: NSAttributedString(string: .SettingsSiriSectionDescription), children: [setting])
+        let firstSection = SettingSection(title: nil, footerTitle: NSAttributedString(string: .Settings.SiriShortcuts.SiriSectionDescription), children: [setting])
         return [firstSection]
     }
 }
@@ -36,7 +36,7 @@ class SiriOpenURLSetting: Setting {
     override var accessibilityIdentifier: String? { return "SiriSettings" }
 
     init(settings: SettingsTableViewController) {
-        super.init(title: NSAttributedString(string: .SettingsSiriOpenURL, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .Settings.SiriShortcuts.SiriOpenURL, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {

--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -18,7 +18,7 @@ class ManageFxAccountSetting: Setting {
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
 
-        super.init(title: NSAttributedString(string: Strings.FxAManageAccount, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .FxAManageAccount, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -34,7 +34,7 @@ class DisconnectSetting: Setting {
     override var textAlignment: NSTextAlignment { return .center }
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: Strings.SettingsDisconnectSyncButton, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.general.destructiveRed])
+        return NSAttributedString(string: .SettingsDisconnectSyncButton, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.general.destructiveRed])
     }
     
     init(settings: SettingsTableViewController) {
@@ -46,15 +46,15 @@ class DisconnectSetting: Setting {
 
     override func onClick(_ navigationController: UINavigationController?) {
         let alertController = UIAlertController(
-            title: Strings.SettingsDisconnectSyncAlertTitle,
-            message: Strings.SettingsDisconnectSyncAlertBody,
+            title: .SettingsDisconnectSyncAlertTitle,
+            message: .SettingsDisconnectSyncAlertBody,
             preferredStyle: UIAlertController.Style.alert)
         alertController.addAction(
-            UIAlertAction(title: Strings.SettingsDisconnectCancelAction, style: .cancel) { (action) in
+            UIAlertAction(title: .SettingsDisconnectCancelAction, style: .cancel) { (action) in
                 // Do nothing.
         })
         alertController.addAction(
-            UIAlertAction(title: Strings.SettingsDisconnectDestructiveAction, style: .destructive) { (action) in
+            UIAlertAction(title: .SettingsDisconnectDestructiveAction, style: .destructive) { (action) in
                 self.profile.removeAccount()
                 TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .settings, object: .accountDisconnected)
 
@@ -125,7 +125,7 @@ class SyncContentSettingsViewController: SettingsTableViewController {
     init() {
         super.init(style: .grouped)
 
-        self.title = Strings.FxASettingsTitle
+        self.title = .FxASettingsTitle
 
         RustFirefoxAccounts.shared.accountManager.peek()?.deviceConstellation()?.refreshState()
     }
@@ -159,15 +159,15 @@ class SyncContentSettingsViewController: SettingsTableViewController {
         let manage = ManageFxAccountSetting(settings: self)
         let manageSection = SettingSection(title: nil, footerTitle: nil, children: [manage])
 
-        let bookmarks = BoolSetting(prefs: profile.prefs, prefKey: "sync.engine.bookmarks.enabled", defaultValue: true, attributedTitleText: NSAttributedString(string: Strings.FirefoxSyncBookmarksEngine), attributedStatusText: nil, settingDidChange: engineSettingChanged("bookmarks"))
-        let history = BoolSetting(prefs: profile.prefs, prefKey: "sync.engine.history.enabled", defaultValue: true, attributedTitleText: NSAttributedString(string: Strings.FirefoxSyncHistoryEngine), attributedStatusText: nil, settingDidChange: engineSettingChanged("history"))
-        let tabs = BoolSetting(prefs: profile.prefs, prefKey: "sync.engine.tabs.enabled", defaultValue: true, attributedTitleText: NSAttributedString(string: Strings.FirefoxSyncTabsEngine), attributedStatusText: nil, settingDidChange: engineSettingChanged("tabs"))
-        let passwords = BoolSetting(prefs: profile.prefs, prefKey: "sync.engine.passwords.enabled", defaultValue: true, attributedTitleText: NSAttributedString(string: Strings.FirefoxSyncLoginsEngine), attributedStatusText: nil, settingDidChange: engineSettingChanged("passwords"))
+        let bookmarks = BoolSetting(prefs: profile.prefs, prefKey: "sync.engine.bookmarks.enabled", defaultValue: true, attributedTitleText: NSAttributedString(string: .FirefoxSyncBookmarksEngine), attributedStatusText: nil, settingDidChange: engineSettingChanged("bookmarks"))
+        let history = BoolSetting(prefs: profile.prefs, prefKey: "sync.engine.history.enabled", defaultValue: true, attributedTitleText: NSAttributedString(string: .FirefoxSyncHistoryEngine), attributedStatusText: nil, settingDidChange: engineSettingChanged("history"))
+        let tabs = BoolSetting(prefs: profile.prefs, prefKey: "sync.engine.tabs.enabled", defaultValue: true, attributedTitleText: NSAttributedString(string: .FirefoxSyncTabsEngine), attributedStatusText: nil, settingDidChange: engineSettingChanged("tabs"))
+        let passwords = BoolSetting(prefs: profile.prefs, prefKey: "sync.engine.passwords.enabled", defaultValue: true, attributedTitleText: NSAttributedString(string: .FirefoxSyncLoginsEngine), attributedStatusText: nil, settingDidChange: engineSettingChanged("passwords"))
 
-        let enginesSection = SettingSection(title: NSAttributedString(string: Strings.FxASettingsSyncSettings), footerTitle: nil, children: [bookmarks, history, tabs, passwords])
+        let enginesSection = SettingSection(title: NSAttributedString(string: .FxASettingsSyncSettings), footerTitle: nil, children: [bookmarks, history, tabs, passwords])
 
         let deviceName = DeviceNameSetting(settings: self)
-        let deviceNameSection = SettingSection(title: NSAttributedString(string: Strings.FxASettingsDeviceName), footerTitle: nil, children: [deviceName])
+        let deviceNameSection = SettingSection(title: NSAttributedString(string: .FxASettingsDeviceName), footerTitle: nil, children: [deviceName])
 
         let disconnect = DisconnectSetting(settings: self)
         let disconnectSection = SettingSection(title: nil, footerTitle: nil, children: [disconnect])

--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -34,7 +34,7 @@ class DisconnectSetting: Setting {
     override var textAlignment: NSTextAlignment { return .center }
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: .SettingsDisconnectSyncButton, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.general.destructiveRed])
+        return NSAttributedString(string: .Settings.DisconnectSyncButton, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.general.destructiveRed])
     }
     
     init(settings: SettingsTableViewController) {
@@ -46,15 +46,15 @@ class DisconnectSetting: Setting {
 
     override func onClick(_ navigationController: UINavigationController?) {
         let alertController = UIAlertController(
-            title: .SettingsDisconnectSyncAlertTitle,
-            message: .SettingsDisconnectSyncAlertBody,
+            title: .Settings.DisconnectSyncAlertTitle,
+            message: .Settings.DisconnectSyncAlertBody,
             preferredStyle: UIAlertController.Style.alert)
         alertController.addAction(
-            UIAlertAction(title: .SettingsDisconnectCancelAction, style: .cancel) { (action) in
+            UIAlertAction(title: .Settings.DisconnectCancelAction, style: .cancel) { (action) in
                 // Do nothing.
         })
         alertController.addAction(
-            UIAlertAction(title: .SettingsDisconnectDestructiveAction, style: .destructive) { (action) in
+            UIAlertAction(title: .Settings.DisconnectDestructiveAction, style: .destructive) { (action) in
                 self.profile.removeAccount()
                 TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .settings, object: .accountDisconnected)
 
@@ -159,10 +159,10 @@ class SyncContentSettingsViewController: SettingsTableViewController {
         let manage = ManageFxAccountSetting(settings: self)
         let manageSection = SettingSection(title: nil, footerTitle: nil, children: [manage])
 
-        let bookmarks = BoolSetting(prefs: profile.prefs, prefKey: "sync.engine.bookmarks.enabled", defaultValue: true, attributedTitleText: NSAttributedString(string: .FirefoxSyncBookmarksEngine), attributedStatusText: nil, settingDidChange: engineSettingChanged("bookmarks"))
-        let history = BoolSetting(prefs: profile.prefs, prefKey: "sync.engine.history.enabled", defaultValue: true, attributedTitleText: NSAttributedString(string: .FirefoxSyncHistoryEngine), attributedStatusText: nil, settingDidChange: engineSettingChanged("history"))
-        let tabs = BoolSetting(prefs: profile.prefs, prefKey: "sync.engine.tabs.enabled", defaultValue: true, attributedTitleText: NSAttributedString(string: .FirefoxSyncTabsEngine), attributedStatusText: nil, settingDidChange: engineSettingChanged("tabs"))
-        let passwords = BoolSetting(prefs: profile.prefs, prefKey: "sync.engine.passwords.enabled", defaultValue: true, attributedTitleText: NSAttributedString(string: .FirefoxSyncLoginsEngine), attributedStatusText: nil, settingDidChange: engineSettingChanged("passwords"))
+        let bookmarks = BoolSetting(prefs: profile.prefs, prefKey: "sync.engine.bookmarks.enabled", defaultValue: true, attributedTitleText: NSAttributedString(string: .Syncing.FirefoxSync.BookmarksEngine), attributedStatusText: nil, settingDidChange: engineSettingChanged("bookmarks"))
+        let history = BoolSetting(prefs: profile.prefs, prefKey: "sync.engine.history.enabled", defaultValue: true, attributedTitleText: NSAttributedString(string: .Syncing.FirefoxSync.HistoryEngine), attributedStatusText: nil, settingDidChange: engineSettingChanged("history"))
+        let tabs = BoolSetting(prefs: profile.prefs, prefKey: "sync.engine.tabs.enabled", defaultValue: true, attributedTitleText: NSAttributedString(string: .Syncing.FirefoxSync.TabsEngine), attributedStatusText: nil, settingDidChange: engineSettingChanged("tabs"))
+        let passwords = BoolSetting(prefs: profile.prefs, prefKey: "sync.engine.passwords.enabled", defaultValue: true, attributedTitleText: NSAttributedString(string: .Syncing.FirefoxSync.LoginsEngine), attributedStatusText: nil, settingDidChange: engineSettingChanged("passwords"))
 
         let enginesSection = SettingSection(title: NSAttributedString(string: .FxASettingsSyncSettings), footerTitle: nil, children: [bookmarks, history, tabs, passwords])
 

--- a/Client/Frontend/Settings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettingsController.swift
@@ -54,7 +54,7 @@ class ThemeSettingsController: ThemedTableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = Strings.SettingsDisplayThemeTitle
+        title = .SettingsDisplayThemeTitle
         tableView.accessibilityIdentifier = "DisplayTheme.Setting.Options"
         tableView.backgroundColor = UIColor.theme.tableView.headerBackground
 
@@ -75,11 +75,11 @@ class ThemeSettingsController: ThemedTableViewController {
         headerView.titleLabel.text = {
             switch section {
             case .systemTheme:
-                return Strings.SystemThemeSectionHeader
+                return .SystemThemeSectionHeader
             case .automaticBrightness:
-                return Strings.ThemeSwitchModeSectionHeader
+                return .ThemeSwitchModeSectionHeader
             case .lightDarkPicker:
-                return isAutoBrightnessOn ? Strings.DisplayThemeBrightnessThresholdSectionHeader : Strings.ThemePickerSectionHeader
+                return isAutoBrightnessOn ? .DisplayThemeBrightnessThresholdSectionHeader : .ThemePickerSectionHeader
             }
         }()
         headerView.titleLabel.text = headerView.titleLabel.text?.uppercased()
@@ -93,7 +93,7 @@ class ThemeSettingsController: ThemedTableViewController {
         let footer = UIView()
         let label = UILabel()
         footer.addSubview(label)
-        label.text = Strings.DisplayThemeSectionFooter
+        label.text = .DisplayThemeSectionFooter
         label.numberOfLines = 0
         label.snp.makeConstraints { make in
             make.top.equalToSuperview().inset(4)
@@ -173,7 +173,7 @@ class ThemeSettingsController: ThemedTableViewController {
         let section = Section(rawValue: indexPath.section) ?? .automaticBrightness
         switch section {
         case .systemTheme:
-            cell.textLabel?.text = Strings.SystemThemeSectionSwitchTitle
+            cell.textLabel?.text = .SystemThemeSectionSwitchTitle
             cell.textLabel?.numberOfLines = 0
             cell.textLabel?.lineBreakMode = .byWordWrapping
 
@@ -186,11 +186,11 @@ class ThemeSettingsController: ThemedTableViewController {
             cell.accessoryView = control
         case .automaticBrightness:
             if indexPath.row == 0 {
-                cell.textLabel?.text = Strings.DisplayThemeManualSwitchTitle
-                cell.detailTextLabel?.text = Strings.DisplayThemeManualSwitchSubtitle
+                cell.textLabel?.text = .DisplayThemeManualSwitchTitle
+                cell.detailTextLabel?.text = .DisplayThemeManualSwitchSubtitle
             } else {
-                cell.textLabel?.text = Strings.DisplayThemeAutomaticSwitchTitle
-                cell.detailTextLabel?.text = Strings.DisplayThemeAutomaticSwitchSubtitle
+                cell.textLabel?.text = .DisplayThemeAutomaticSwitchTitle
+                cell.detailTextLabel?.text = .DisplayThemeAutomaticSwitchSubtitle
             }
             cell.detailTextLabel?.numberOfLines = 2
             cell.detailTextLabel?.minimumScaleFactor = 0.5
@@ -217,9 +217,9 @@ class ThemeSettingsController: ThemedTableViewController {
                 self.slider = (slider, deviceBrightnessIndicator)
             } else {
                 if indexPath.row == 0 {
-                    cell.textLabel?.text = Strings.DisplayThemeOptionLight
+                    cell.textLabel?.text = .DisplayThemeOptionLight
                 } else {
-                    cell.textLabel?.text = Strings.DisplayThemeOptionDark
+                    cell.textLabel?.text = .DisplayThemeOptionDark
                 }
 
                 let theme = BuiltinThemeName(rawValue: ThemeManager.instance.current.name) ?? .normal

--- a/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
@@ -20,8 +20,8 @@ class WebsiteDataManagementViewModel {
     
     var clearButtonTitle: String {
         switch selectedRecords.count {
-        case 0: return Strings.SettingsClearAllWebsiteDataButton
-        default: return String(format: Strings.SettingsClearSelectedWebsiteDataButton, "\(selectedRecords.count)")
+        case 0: return .SettingsClearAllWebsiteDataButton
+        default: return String(format: .SettingsClearSelectedWebsiteDataButton, "\(selectedRecords.count)")
         }
     }
     
@@ -111,7 +111,7 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = Strings.SettingsWebsiteDataTitle
+        title = .SettingsWebsiteDataTitle
         navigationController?.setToolbarHidden(true, animated: false)
 
         tableView = UITableView()
@@ -161,7 +161,7 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
 
         searchController.searchResultsUpdater = searchResultsViewController
         searchController.obscuresBackgroundDuringPresentation = false
-        searchController.searchBar.placeholder = Strings.SettingsFilterSitesSearchLabel
+        searchController.searchBar.placeholder = .SettingsFilterSitesSearchLabel
         searchController.searchBar.delegate = self
 
         if theme == .dark {
@@ -192,7 +192,7 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
                 }
             }
         case .showMore:
-            cell.textLabel?.text = Strings.SettingsWebsiteDataShowMoreButton
+            cell.textLabel?.text = .SettingsWebsiteDataShowMoreButton
             cell.textLabel?.textColor = showMoreButtonEnabled ? UIColor.theme.general.highlightBlue : UIColor.gray
             cell.accessibilityTraits = UIAccessibilityTraits.button
             cell.accessibilityIdentifier = "ShowMoreWebsiteData"
@@ -269,7 +269,7 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: SectionHeaderFooterIdentifier) as? ThemedTableSectionHeaderFooterView
-        headerView?.titleLabel.text = section == Section.sites.rawValue ? Strings.SettingsWebsiteDataTitle : nil
+        headerView?.titleLabel.text = section == Section.sites.rawValue ? .SettingsWebsiteDataTitle : nil
 
         headerView?.showBorder(for: .top, true)
         headerView?.showBorder(for: .bottom, true)

--- a/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
@@ -20,8 +20,8 @@ class WebsiteDataManagementViewModel {
     
     var clearButtonTitle: String {
         switch selectedRecords.count {
-        case 0: return .SettingsClearAllWebsiteDataButton
-        default: return String(format: .SettingsClearSelectedWebsiteDataButton, "\(selectedRecords.count)")
+        case 0: return .Settings.ClearAllWebsiteDataButton
+        default: return String(format: .Settings.ClearSelectedWebsiteDataButton, "\(selectedRecords.count)")
         }
     }
     
@@ -111,7 +111,7 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = .SettingsWebsiteDataTitle
+        title = .Settings.WebsiteDataTitle
         navigationController?.setToolbarHidden(true, animated: false)
 
         tableView = UITableView()
@@ -161,7 +161,7 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
 
         searchController.searchResultsUpdater = searchResultsViewController
         searchController.obscuresBackgroundDuringPresentation = false
-        searchController.searchBar.placeholder = .SettingsFilterSitesSearchLabel
+        searchController.searchBar.placeholder = .Settings.FilterSitesSearchLabel
         searchController.searchBar.delegate = self
 
         if theme == .dark {
@@ -192,7 +192,7 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
                 }
             }
         case .showMore:
-            cell.textLabel?.text = .SettingsWebsiteDataShowMoreButton
+            cell.textLabel?.text = .Settings.WebsiteDataShowMoreButton
             cell.textLabel?.textColor = showMoreButtonEnabled ? UIColor.theme.general.highlightBlue : UIColor.gray
             cell.accessibilityTraits = UIAccessibilityTraits.button
             cell.accessibilityIdentifier = "ShowMoreWebsiteData"
@@ -269,7 +269,7 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: SectionHeaderFooterIdentifier) as? ThemedTableSectionHeaderFooterView
-        headerView?.titleLabel.text = section == Section.sites.rawValue ? .SettingsWebsiteDataTitle : nil
+        headerView?.titleLabel.text = section == Section.sites.rawValue ? .Settings.WebsiteDataTitle : nil
 
         headerView?.showBorder(for: .top, true)
         headerView?.showBorder(for: .bottom, true)

--- a/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
@@ -131,7 +131,7 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: SectionHeaderFooterIdentifier) as? ThemedTableSectionHeaderFooterView
-        headerView?.titleLabel.text = section == Section.sites.rawValue ? Strings.SettingsWebsiteDataTitle : nil
+        headerView?.titleLabel.text = section == Section.sites.rawValue ? .SettingsWebsiteDataTitle : nil
 
         headerView?.showBorder(for: .top, true)
         headerView?.showBorder(for: .bottom, true)

--- a/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
@@ -131,7 +131,7 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: SectionHeaderFooterIdentifier) as? ThemedTableSectionHeaderFooterView
-        headerView?.titleLabel.text = section == Section.sites.rawValue ? .SettingsWebsiteDataTitle : nil
+        headerView?.titleLabel.text = section == Section.sites.rawValue ? .Settings.WebsiteDataTitle : nil
 
         headerView?.showBorder(for: .top, true)
         headerView?.showBorder(for: .bottom, true)

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -4,25 +4,39 @@
 
 import Foundation
 
+/// Strings Discussion
+///
+/// Strings constants in the FireFox iOS app are defined in this file. To make it easy for
+/// localization, all strings are defined as `MZLocalizedString`. Strings should be separated
+/// according to the feature/view they are a part of. For example, all strings relating to
+/// time constants can be found under the `public struct TimeConstants` section.
+///
+/// For ease of identifying when a string was last updated, `MZLocalizedString` has a
+/// `lastEditedIn` parameter that is of type `AppVersionTag`. When adding a new string, or
+/// updating a string, an appropriate tag sholud be created in the `AppVersionTag` enum,
+/// and that string should then be tagged accordingly. This allows easy identification of
+/// new/updated strings during localization import/export. In the case that a string was
+/// added/edited before the `AppVersionTag` was introduced, it is marked as `.unknown`.
+
 public struct Strings {
     public static let bundle = Bundle(for: BundleClass.self)
 }
 
 class BundleClass {}
 
-enum StringsAppVersionTag {
+enum AppVersionTag {
     case v350
     case v360
 
     case unknown
 }
 
-func MZLocalizedString(_ key: String, tableName: String? = nil, value: String = "", comment: String, lastEditedIn: StringsAppVersionTag) -> String {
+func MZLocalizedString(_ key: String, tableName: String? = nil, value: String = "", comment: String, lastEditedIn: AppVersionTag) -> String {
     return NSLocalizedString(key, tableName: tableName, bundle: Strings.bundle, value: value, comment: comment)
 }
 
 // MARK: - General
-extension Strings {
+extension String {
     public static let OKString = MZLocalizedString("OK", comment: "OK button", lastEditedIn: .unknown)
     public static let CancelString = MZLocalizedString("Cancel", comment: "Label for Cancel button", lastEditedIn: .unknown)
     public static let NotNowString = MZLocalizedString("Toasts.NotNow", value: "Not Now", comment: "label for Not Now button", lastEditedIn: .unknown)
@@ -32,7 +46,7 @@ extension Strings {
 }
 
 // MARK: - Table date section titles
-extension Strings {
+extension String {
     public static let TableDateSectionTitleToday = MZLocalizedString("Today", comment: "History tableview section header", lastEditedIn: .unknown)
     public static let TableDateSectionTitleYesterday = MZLocalizedString("Yesterday", comment: "History tableview section header", lastEditedIn: .unknown)
     public static let TableDateSectionTitleLastWeek = MZLocalizedString("Last week", comment: "History tableview section header", lastEditedIn: .unknown)
@@ -40,14 +54,14 @@ extension Strings {
 }
 
 // MARK: - Top Sites
-extension Strings {
+extension String {
     public static let TopSitesEmptyStateDescription = MZLocalizedString("TopSites.EmptyState.Description", value: "Your most visited sites will show up here.", comment: "Description label for the empty Top Sites state.", lastEditedIn: .unknown)
     public static let TopSitesEmptyStateTitle = MZLocalizedString("TopSites.EmptyState.Title", value: "Welcome to Top Sites", comment: "The title for the empty Top Sites state", lastEditedIn: .unknown)
     public static let TopSitesRemoveButtonAccessibilityLabel = MZLocalizedString("TopSites.RemovePage.Button", value: "Remove page — %@", comment: "Button shown in editing mode to remove this site from the top sites panel.", lastEditedIn: .unknown)
 }
 
 // MARK: - Activity Stream
-extension Strings {
+extension String {
     public static let ASPocketTitle = MZLocalizedString("ActivityStream.Pocket.SectionTitle", value: "Trending on Pocket", comment: "Section title label for Recommended by Pocket section", lastEditedIn: .unknown)
     public static let ASPocketTitle2 = MZLocalizedString("ActivityStream.Pocket.SectionTitle2", value: "Recommended by Pocket", comment: "Section title label for Recommended by Pocket section", lastEditedIn: .unknown)
     public static let ASTopSitesTitle =  MZLocalizedString("ActivityStream.TopSites.SectionTitle", value: "Top Sites", comment: "Section title label for Top Sites", lastEditedIn: .unknown)
@@ -65,7 +79,7 @@ extension Strings {
 }
 
 // MARK: - Home Panel Context Menu
-extension Strings {
+extension String {
     public static let OpenInNewTabContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.OpenInNewTab", value: "Open in New Tab", comment: "The title for the Open in New Tab context menu action for sites in Home Panels", lastEditedIn: .unknown)
     public static let OpenInNewPrivateTabContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.OpenInNewPrivateTab", value: "Open in New Private Tab", comment: "The title for the Open in New Private Tab context menu action for sites in Home Panels", lastEditedIn: .unknown)
     public static let BookmarkContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.Bookmark", value: "Bookmark", comment: "The title for the Bookmark context menu action for sites in Home Panels", lastEditedIn: .unknown)
@@ -82,12 +96,12 @@ extension Strings {
 }
 
 //  MARK: - PhotonActionSheet String
-extension Strings {
+extension String {
     public static let CloseButtonTitle = MZLocalizedString("PhotonMenu.close", value: "Close", comment: "Button for closing the menu action sheet", lastEditedIn: .unknown)
 }
 
 // MARK: - Home page
-extension Strings {
+extension String {
     public static let SettingsHomePageSectionName = MZLocalizedString("Settings.HomePage.SectionName", value: "Homepage", comment: "Label used as an item in Settings. When touched it will open a dialog to configure the home page and its uses.", lastEditedIn: .unknown)
     public static let SettingsHomePageTitle = MZLocalizedString("Settings.HomePage.Title", value: "Homepage Settings", comment: "Title displayed in header of the setting panel.", lastEditedIn: .unknown)
     public static let SettingsHomePageURLSectionTitle = MZLocalizedString("Settings.HomePage.URL.Title", value: "Current Homepage", comment: "Title of the setting section containing the URL of the current home page.", lastEditedIn: .unknown)
@@ -106,7 +120,7 @@ extension Strings {
 }
 
 // MARK: - Settings
-extension Strings {
+extension String {
     public static let SettingsGeneralSectionTitle = MZLocalizedString("Settings.General.SectionName", value: "General", comment: "General settings section title", lastEditedIn: .unknown)
     public static let SettingsClearPrivateDataClearButton = MZLocalizedString("Settings.ClearPrivateData.Clear.Button", value: "Clear Private Data", comment: "Button in settings that clears private data for the selected items.", lastEditedIn: .unknown)
     public static let SettingsClearAllWebsiteDataButton = MZLocalizedString("Settings.ClearAllWebsiteData.Clear.Button", value: "Clear All Website Data", comment: "Button in Data Management that clears all items.", lastEditedIn: .unknown)
@@ -134,7 +148,7 @@ extension Strings {
 }
 
 // MARK: - Error pages
-extension Strings {
+extension String {
     public static let ErrorPagesAdvancedButton = MZLocalizedString("ErrorPages.Advanced.Button", value: "Advanced", comment: "Label for button to perform advanced actions on the error page", lastEditedIn: .unknown)
     public static let ErrorPagesAdvancedWarning1 = MZLocalizedString("ErrorPages.AdvancedWarning1.Text", value: "Warning: we can’t confirm your connection to this website is secure.", comment: "Warning text when clicking the Advanced button on error pages", lastEditedIn: .unknown)
     public static let ErrorPagesAdvancedWarning2 = MZLocalizedString("ErrorPages.AdvancedWarning2.Text", value: "It may be a misconfiguration or tampering by an attacker. Proceed if you accept the potential risk.", comment: "Additional warning text when clicking the Advanced button on error pages", lastEditedIn: .unknown)
@@ -145,7 +159,7 @@ extension Strings {
 }
 
 // MARK: - Logins Helper
-extension Strings {
+extension String {
     public static let LoginsHelperSaveLoginButtonTitle = MZLocalizedString("LoginsHelper.SaveLogin.Button", value: "Save Login", comment: "Button to save the user's password", lastEditedIn: .unknown)
     public static let LoginsHelperDontSaveButtonTitle = MZLocalizedString("LoginsHelper.DontSave.Button", value: "Don’t Save", comment: "Button to not save the user's password", lastEditedIn: .unknown)
     public static let LoginsHelperUpdateButtonTitle = MZLocalizedString("LoginsHelper.Update.Button", value: "Update", comment: "Button to update the user's password", lastEditedIn: .unknown)
@@ -153,14 +167,14 @@ extension Strings {
 }
 
 // MARK: - Downloads Panel
-extension Strings {
+extension String {
     public static let DownloadsPanelEmptyStateTitle = MZLocalizedString("DownloadsPanel.EmptyState.Title", value: "Downloaded files will show up here.", comment: "Title for the Downloads Panel empty state.", lastEditedIn: .unknown)
     public static let DownloadsPanelDeleteTitle = MZLocalizedString("DownloadsPanel.Delete.Title", value: "Delete", comment: "Action button for deleting downloaded files in the Downloads panel.", lastEditedIn: .unknown)
     public static let DownloadsPanelShareTitle = MZLocalizedString("DownloadsPanel.Share.Title", value: "Share", comment: "Action button for sharing downloaded files in the Downloads panel.", lastEditedIn: .unknown)
 }
 
 // MARK: - History Panel
-extension Strings {
+extension String {
     public static let SyncedTabsTableViewCellTitle = MZLocalizedString("HistoryPanel.SyncedTabsCell.Title", value: "Synced Devices", comment: "Title for the Synced Tabs Cell in the History Panel", lastEditedIn: .unknown)
     public static let HistoryBackButtonTitle = MZLocalizedString("HistoryPanel.HistoryBackButton.Title", value: "History", comment: "Title for the Back to History button in the History Panel", lastEditedIn: .unknown)
     public static let EmptySyncedTabsPanelStateTitle = MZLocalizedString("HistoryPanel.EmptySyncedTabsState.Title", value: "Firefox Sync", comment: "Title for the empty synced tabs state in the History Panel", lastEditedIn: .unknown)
@@ -179,7 +193,7 @@ extension Strings {
 }
 
 // MARK: - Clear recent history action menu
-extension Strings {
+extension String {
     public static let ClearHistoryMenuTitle = MZLocalizedString("HistoryPanel.ClearHistoryMenuTitle", value: "Clearing Recent History will remove history, cookies, and other browser data.", comment: "Title for popup action menu to clear recent history.", lastEditedIn: .unknown)
     public static let ClearHistoryMenuOptionTheLastHour = MZLocalizedString("HistoryPanel.ClearHistoryMenuOptionTheLastHour", value: "The Last Hour", comment: "Button to perform action to clear history for the last hour", lastEditedIn: .unknown)
     public static let ClearHistoryMenuOptionToday = MZLocalizedString("HistoryPanel.ClearHistoryMenuOptionToday", value: "Today", comment: "Button to perform action to clear history for today only", lastEditedIn: .unknown)
@@ -188,7 +202,7 @@ extension Strings {
 }
 
 // MARK: - Syncing
-extension Strings {
+extension String {
     public static let SyncingMessageWithEllipsis = MZLocalizedString("Sync.SyncingEllipsis.Label", value: "Syncing…", comment: "Message displayed when the user's account is syncing with ellipsis at the end", lastEditedIn: .unknown)
     public static let SyncingMessageWithoutEllipsis = MZLocalizedString("Sync.Syncing.Label", value: "Syncing", comment: "Message displayed when the user's account is syncing with no ellipsis", lastEditedIn: .unknown)
 
@@ -224,7 +238,7 @@ extension Strings {
 }
 
 // MARK: - Firefox Logins
-extension Strings {
+extension String {
     public static let LoginsAndPasswordsTitle = MZLocalizedString("Settings.LoginsAndPasswordsTitle", value: "Logins & Passwords", comment: "Title for the logins and passwords screen. Translation could just use 'Logins' if the title is too long", lastEditedIn: .unknown)
 
     // Prompts
@@ -257,7 +271,7 @@ extension Strings {
 }
 
 // MARK: - Firefox Account
-extension Strings {
+extension String {
     // Settings strings
     public static let FxAFirefoxAccount = MZLocalizedString("FxA.FirefoxAccount", value: "Firefox Account", comment: "Settings section title for Firefox Account", lastEditedIn: .unknown)
     public static let FxASignInToSync = MZLocalizedString("FxA.SignIntoSync", value: "Sign in to Sync", comment: "Button label to sign into Sync", lastEditedIn: .unknown)
@@ -286,7 +300,7 @@ extension Strings {
 }
 
 // MARK: - Hotkey Titles
-extension Strings {
+extension String {
     public static let ReloadPageTitle = MZLocalizedString("Hotkeys.Reload.DiscoveryTitle", value: "Reload Page", comment: "Label to display in the Discoverability overlay for keyboard shortcuts", lastEditedIn: .unknown)
     public static let BackTitle = MZLocalizedString("Hotkeys.Back.DiscoveryTitle", value: "Back", comment: "Label to display in the Discoverability overlay for keyboard shortcuts", lastEditedIn: .unknown)
     public static let ForwardTitle = MZLocalizedString("Hotkeys.Forward.DiscoveryTitle", value: "Forward", comment: "Label to display in the Discoverability overlay for keyboard shortcuts", lastEditedIn: .unknown)
@@ -303,7 +317,7 @@ extension Strings {
 }
 
 // MARK: - New tab choice settings
-extension Strings {
+extension String {
     public static let CustomNewPageURL = MZLocalizedString("Settings.NewTab.CustomURL", value: "Custom URL", comment: "Label used to set a custom url as the new tab option (homepage).", lastEditedIn: .unknown)
     public static let SettingsNewTabSectionName = MZLocalizedString("Settings.NewTab.SectionName", value: "New Tab", comment: "Label used as an item in Settings. When touched it will open a dialog to configure the new tab behavior.", lastEditedIn: .unknown)
     public static let NewTabSectionName =
@@ -333,7 +347,7 @@ extension Strings {
 
 // MARK: - Advanced Sync Settings (Debug)
 // For 'Advanced Sync Settings' view, which is a debug setting. English only, there is little value in maintaining L10N strings for these.
-extension Strings {
+extension String {
     public static let SettingsAdvancedAccountTitle = "Advanced Sync Settings"
     public static let SettingsAdvancedAccountCustomFxAContentServerURI = "Custom Firefox Account Content Server URI"
     public static let SettingsAdvancedAccountUseCustomFxAContentServerURITitle = "Use Custom FxA Content Server"
@@ -342,13 +356,13 @@ extension Strings {
 }
 
 // MARK: - Open With Settings
-extension Strings {
+extension String {
     public static let SettingsOpenWithSectionName = MZLocalizedString("Settings.OpenWith.SectionName", value: "Mail App", comment: "Label used as an item in Settings. When touched it will open a dialog to configure the open with (mail links) behavior.", lastEditedIn: .unknown)
     public static let SettingsOpenWithPageTitle = MZLocalizedString("Settings.OpenWith.PageTitle", value: "Open mail links with", comment: "Title for Open With Settings", lastEditedIn: .unknown)
 }
 
 // MARK: - Third Party Search Engines
-extension Strings {
+extension String {
     public static let ThirdPartySearchEngineAdded = MZLocalizedString("Search.ThirdPartyEngines.AddSuccess", value: "Added Search engine!", comment: "The success message that appears after a user sucessfully adds a new search engine", lastEditedIn: .unknown)
     public static let ThirdPartySearchAddTitle = MZLocalizedString("Search.ThirdPartyEngines.AddTitle", value: "Add Search Provider?", comment: "The title that asks the user to Add the search provider", lastEditedIn: .unknown)
     public static let ThirdPartySearchAddMessage = MZLocalizedString("Search.ThirdPartyEngines.AddMessage", value: "The new search engine will appear in the quick search bar.", comment: "The message that asks the user to Add the search provider explaining where the search engine will appear", lastEditedIn: .unknown)
@@ -363,7 +377,7 @@ extension Strings {
 }
 
 // MARK: - Root Bookmarks folders
-extension Strings {
+extension String {
     public static let BookmarksFolderTitleMobile = MZLocalizedString("Mobile Bookmarks", tableName: "Storage", comment: "The title of the folder that contains mobile bookmarks. This should match bookmarks.folder.mobile.label on Android.", lastEditedIn: .unknown)
     public static let BookmarksFolderTitleMenu = MZLocalizedString("Bookmarks Menu", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the menu. This should match bookmarks.folder.menu.label on Android.", lastEditedIn: .unknown)
     public static let BookmarksFolderTitleToolbar = MZLocalizedString("Bookmarks Toolbar", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the toolbar. This should match bookmarks.folder.toolbar.label on Android.", lastEditedIn: .unknown)
@@ -371,7 +385,7 @@ extension Strings {
 }
 
 // MARK: - Bookmark Management
-extension Strings {
+extension String {
     public static let BookmarksTitle = MZLocalizedString("Bookmarks.Title.Label", value: "Title", comment: "The label for the title of a bookmark", lastEditedIn: .unknown)
     public static let BookmarksURL = MZLocalizedString("Bookmarks.URL.Label", value: "URL", comment: "The label for the URL of a bookmark", lastEditedIn: .unknown)
     public static let BookmarksFolder = MZLocalizedString("Bookmarks.Folder.Label", value: "Folder", comment: "The label to show the location of the folder where the bookmark is located", lastEditedIn: .unknown)
@@ -396,14 +410,14 @@ extension Strings {
 }
 
 // MARK: - Tabs Delete All Undo Toast
-extension Strings {
+extension String {
     public static let TabsDeleteAllUndoTitle = MZLocalizedString("Tabs.DeleteAllUndo.Title", value: "%d tab(s) closed", comment: "The label indicating that all the tabs were closed", lastEditedIn: .unknown)
     public static let TabsDeleteAllUndoAction = MZLocalizedString("Tabs.DeleteAllUndo.Button", value: "Undo", comment: "The button to undo the delete all tabs", lastEditedIn: .unknown)
     public static let TabSearchPlaceholderText = MZLocalizedString("Tabs.Search.PlaceholderText", value: "Search Tabs", comment: "The placeholder text for the tab search bar", lastEditedIn: .unknown)
 }
 
 // MARK: - Tab tray (chronological tabs)
-extension Strings {
+extension String {
     public static let TabTrayV2Title = MZLocalizedString("TabTray.Title", value: "Open Tabs", comment: "The title for the tab tray", lastEditedIn: .unknown)
     public static let TabTrayV2TodayHeader = MZLocalizedString("TabTray.Today.Header", value: "Today", comment: "The section header for tabs opened today", lastEditedIn: .unknown)
     public static let TabTrayV2YesterdayHeader = MZLocalizedString("TabTray.Yesterday.Header", value: "Yesterday", comment: "The section header for tabs opened yesterday", lastEditedIn: .unknown)
@@ -420,7 +434,7 @@ extension Strings {
 }
 
 // MARK: - Clipboard Toast
-extension Strings {
+extension String {
     public static let GoToCopiedLink = MZLocalizedString("ClipboardToast.GoToCopiedLink.Title", value: "Go to copied link?", comment: "Message displayed when the user has a copied link on the clipboard", lastEditedIn: .unknown)
     public static let GoButtonTittle = MZLocalizedString("ClipboardToast.GoToCopiedLink.Button", value: "Go", comment: "The button to open a new tab with the copied link", lastEditedIn: .unknown)
 
@@ -429,13 +443,13 @@ extension Strings {
 }
 
 // MARK: - Link Previews
-extension Strings {
+extension String {
     public static let SettingsShowLinkPreviewsTitle = MZLocalizedString("Settings.ShowLinkPreviews.Title", value: "Show Link Previews", comment: "Title of setting to enable link previews when long-pressing links.", lastEditedIn: .unknown)
     public static let SettingsShowLinkPreviewsStatus = MZLocalizedString("Settings.ShowLinkPreviews.Status", value: "When Long-pressing Links", comment: "Description displayed under the ”Show Link Previews” option", lastEditedIn: .unknown)
 }
 
 // MARK: - Errors
-extension Strings {
+extension String {
     public static let UnableToDownloadError = MZLocalizedString("Downloads.Error.Message", value: "Downloads aren’t supported in Firefox yet.", comment: "The message displayed to a user when they try and perform the download of an asset that Firefox cannot currently handle.", lastEditedIn: .unknown)
     public static let UnableToAddPassErrorTitle = MZLocalizedString("AddPass.Error.Title", value: "Failed to Add Pass", comment: "Title of the 'Add Pass Failed' alert. See https://support.apple.com/HT204003 for context on Wallet.", lastEditedIn: .unknown)
     public static let UnableToAddPassErrorMessage = MZLocalizedString("AddPass.Error.Message", value: "An error occured while adding the pass to Wallet. Please try again later.", comment: "Text of the 'Add Pass Failed' alert.  See https://support.apple.com/HT204003 for context on Wallet.", lastEditedIn: .unknown)
@@ -445,7 +459,7 @@ extension Strings {
 }
 
 // MARK: - Download Helper
-extension Strings {
+extension String {
     public static let OpenInDownloadHelperAlertDownloadNow = MZLocalizedString("Downloads.Alert.DownloadNow", value: "Download Now", comment: "The label of the button the user will press to start downloading a file", lastEditedIn: .unknown)
     public static let DownloadsButtonTitle = MZLocalizedString("Downloads.Toast.GoToDownloads.Button", value: "Downloads", comment: "The button to open a new tab with the Downloads home panel", lastEditedIn: .unknown)
     public static let CancelDownloadDialogTitle = MZLocalizedString("Downloads.CancelDialog.Title", value: "Cancel Download", comment: "Alert dialog title when the user taps the cancel download icon.", lastEditedIn: .unknown)
@@ -461,7 +475,7 @@ extension Strings {
 }
 
 // MARK: - Add Custom Search Engine
-extension Strings {
+extension String {
     public static let SettingsAddCustomEngine = MZLocalizedString("Settings.AddCustomEngine", value: "Add Search Engine", comment: "The button text in Search Settings that opens the Custom Search Engine view.", lastEditedIn: .unknown)
     public static let SettingsAddCustomEngineTitle = MZLocalizedString("Settings.AddCustomEngine.Title", value: "Add Search Engine", comment: "The title of the  Custom Search Engine view.", lastEditedIn: .unknown)
     public static let SettingsAddCustomEngineTitleLabel = MZLocalizedString("Settings.AddCustomEngine.TitleLabel", value: "Title", comment: "The title for the field which sets the title for a custom search engine.", lastEditedIn: .unknown)
@@ -472,7 +486,7 @@ extension Strings {
 }
 
 // MARK: - Context menu ButtonToast instances.
-extension Strings {
+extension String {
     public static let ContextMenuButtonToastNewTabOpenedLabelText = MZLocalizedString("ContextMenu.ButtonToast.NewTabOpened.LabelText", value: "New Tab opened", comment: "The label text in the Button Toast for switching to a fresh New Tab.", lastEditedIn: .unknown)
     public static let ContextMenuButtonToastNewTabOpenedButtonText = MZLocalizedString("ContextMenu.ButtonToast.NewTabOpened.ButtonText", value: "Switch", comment: "The button text in the Button Toast for switching to a fresh New Tab.", lastEditedIn: .unknown)
     public static let ContextMenuButtonToastNewPrivateTabOpenedLabelText = MZLocalizedString("ContextMenu.ButtonToast.NewPrivateTabOpened.LabelText", value: "New Private Tab opened", comment: "The label text in the Button Toast for switching to a fresh New Private Tab.", lastEditedIn: .unknown)
@@ -480,7 +494,7 @@ extension Strings {
 }
 
 // MARK: - Page context menu items (i.e. links and images).
-extension Strings {
+extension String {
     public static let ContextMenuOpenInNewTab = MZLocalizedString("ContextMenu.OpenInNewTabButtonTitle", value: "Open in New Tab", comment: "Context menu item for opening a link in a new tab", lastEditedIn: .unknown)
     public static let ContextMenuOpenInNewPrivateTab = MZLocalizedString("ContextMenu.OpenInNewPrivateTabButtonTitle", tableName: "PrivateBrowsing", value: "Open in New Private Tab", comment: "Context menu option for opening a link in a new private tab", lastEditedIn: .unknown)
 
@@ -497,14 +511,14 @@ extension Strings {
 }
 
 // MARK: - Photo Library access
-extension Strings {
+extension String {
     public static let PhotoLibraryFirefoxWouldLikeAccessTitle = MZLocalizedString("PhotoLibrary.FirefoxWouldLikeAccessTitle", value: "Firefox would like to access your Photos", comment: "See http://mzl.la/1G7uHo7", lastEditedIn: .unknown)
     public static let PhotoLibraryFirefoxWouldLikeAccessMessage = MZLocalizedString("PhotoLibrary.FirefoxWouldLikeAccessMessage", value: "This allows you to save the image to your Camera Roll.", comment: "See http://mzl.la/1G7uHo7", lastEditedIn: .unknown)
 }
 
 // MARK: - Sent tabs notifications
 // These are displayed when the app is backgrounded or the device is locked.
-extension Strings {
+extension String {
     // zero tabs
     public static let SentTab_NoTabArrivingNotification_title = MZLocalizedString("SentTab.NoTabArrivingNotification.title", value: "Firefox Sync", comment: "Title of notification received after a spurious message from FxA has been received.", lastEditedIn: .unknown)
     public static let SentTab_NoTabArrivingNotification_body =
@@ -523,7 +537,7 @@ extension Strings {
 }
 
 // MARK: - Additional messages sent via Push from FxA
-extension Strings {
+extension String {
     public static let FxAPush_DeviceDisconnected_ThisDevice_title = MZLocalizedString("FxAPush_DeviceDisconnected_ThisDevice_title", value: "Sync Disconnected", comment: "Title of a notification displayed when this device has been disconnected by another device.", lastEditedIn: .unknown)
     public static let FxAPush_DeviceDisconnected_ThisDevice_body = MZLocalizedString("FxAPush_DeviceDisconnected_ThisDevice_body", value: "This device has been successfully disconnected from Firefox Sync.", comment: "Body of a notification displayed when this device has been disconnected from FxA by another device.", lastEditedIn: .unknown)
     public static let FxAPush_DeviceDisconnected_title = MZLocalizedString("FxAPush_DeviceDisconnected_title", value: "Sync Disconnected", comment: "Title of a notification displayed when named device has been disconnected from FxA.", lastEditedIn: .unknown)
@@ -536,13 +550,13 @@ extension Strings {
 }
 
 // MARK: - Reader Mode
-extension Strings {
+extension String {
     public static let ReaderModeAvailableVoiceOverAnnouncement = MZLocalizedString("ReaderMode.Available.VoiceOverAnnouncement", value: "Reader Mode available", comment: "Accessibility message e.g. spoken by VoiceOver when Reader Mode becomes available.", lastEditedIn: .unknown)
     public static let ReaderModeResetFontSizeAccessibilityLabel = MZLocalizedString("Reset text size", comment: "Accessibility label for button resetting font size in display settings of reader mode", lastEditedIn: .unknown)
 }
 
 // MARK: - QR Code scanner
-extension Strings {
+extension String {
     public static let ScanQRCodeViewTitle = MZLocalizedString("ScanQRCode.View.Title", value: "Scan QR Code", comment: "Title for the QR code scanner view.", lastEditedIn: .unknown)
     public static let ScanQRCodeInstructionsLabel = MZLocalizedString("ScanQRCode.Instructions.Label", value: "Align QR code within frame to scan", comment: "Text for the instructions label, displayed in the QR scanner view", lastEditedIn: .unknown)
     public static let ScanQRCodeInvalidDataErrorMessage = MZLocalizedString("ScanQRCode.InvalidDataError.Message", value: "The data is invalid", comment: "Text of the prompt that is shown to the user when the data is invalid", lastEditedIn: .unknown)
@@ -551,7 +565,7 @@ extension Strings {
 }
 
 // MARK: - App menu
-extension Strings {
+extension String {
     public static let AppMenuReportSiteIssueTitleString = MZLocalizedString("Menu.ReportSiteIssueAction.Title", tableName: "Menu", value: "Report Site Issue", comment: "Label for the button, displayed in the menu, used to report a compatibility issue with the current page.", lastEditedIn: .unknown)
     public static let AppMenuLibraryReloadString = MZLocalizedString("Menu.Library.Reload", tableName: "Menu", value: "Reload", comment: "Label for the button, displayed in the menu, used to Reload the webpage", lastEditedIn: .unknown)
     public static let StopReloadPageTitle = MZLocalizedString("Menu.Library.StopReload", value: "Stop", comment: "Label for the button displayed in the menu used to stop the reload of the webpage", lastEditedIn: .unknown)
@@ -614,13 +628,13 @@ extension Strings {
 }
 
 // MARK: - Snackbar shown when tapping app store link
-extension Strings {
+extension String {
     public static let ExternalLinkAppStoreConfirmationTitle = MZLocalizedString("ExternalLink.AppStore.ConfirmationTitle", value: "Open this link in the App Store?", comment: "Question shown to user when tapping a link that opens the App Store app", lastEditedIn: .unknown)
     public static let ExternalLinkGenericConfirmation = MZLocalizedString("ExternalLink.AppStore.GenericConfirmationTitle", value: "Open this link in external app?", comment: "Question shown to user when tapping an SMS or MailTo link that opens the external app for those.", lastEditedIn: .unknown)
 }
 
 // MARK: - ContentBlocker/TrackingProtection string
-extension Strings {
+extension String {
     public static let SettingsTrackingProtectionSectionName = MZLocalizedString("Settings.TrackingProtection.SectionName", value: "Tracking Protection", comment: "Row in top-level of settings that gets tapped to show the tracking protection settings detail view.", lastEditedIn: .unknown)
 
     public static let TrackingProtectionEnableTitle = MZLocalizedString("Settings.TrackingProtectionOption.NormalBrowsingLabelOn", value: "Enhanced Tracking Protection", comment: "Settings option to specify that Tracking Protection is on", lastEditedIn: .unknown)
@@ -645,7 +659,7 @@ extension Strings {
 }
 
 // MARK: - Tracking Protection menu
-extension Strings {
+extension String {
     public static let TPBlockingDescription = MZLocalizedString("Menu.TrackingProtectionBlocking.Description", value: "Firefox is blocking parts of the page that may track your browsing.", comment: "Description of the Tracking protection menu when TP is blocking parts of the page", lastEditedIn: .unknown)
     public static let TPNoBlockingDescription = MZLocalizedString("Menu.TrackingProtectionNoBlocking.Description", value: "No tracking elements detected on this page.", comment: "The description of the Tracking Protection menu item when no scripts are blocked but tracking protection is enabled.", lastEditedIn: .unknown)
     public static let TPBlockingDisabledDescription = MZLocalizedString("Menu.TrackingProtectionBlockingDisabled.Description", value: "Block online trackers", comment: "The description of the Tracking Protection menu item when tracking is enabled", lastEditedIn: .unknown)
@@ -702,14 +716,14 @@ extension Strings {
 }
 
 // MARK: - Location bar long press menu
-extension Strings {
+extension String {
     public static let PasteAndGoTitle = MZLocalizedString("Menu.PasteAndGo.Title", value: "Paste & Go", comment: "The title for the button that lets you paste and go to a URL", lastEditedIn: .unknown)
     public static let PasteTitle = MZLocalizedString("Menu.Paste.Title", value: "Paste", comment: "The title for the button that lets you paste into the location bar", lastEditedIn: .unknown)
     public static let CopyAddressTitle = MZLocalizedString("Menu.Copy.Title", value: "Copy Address", comment: "The title for the button that lets you copy the url from the location bar.", lastEditedIn: .unknown)
 }
 
 // MARK: - Settings Home
-extension Strings {
+extension String {
     public static let SendUsageSettingTitle = MZLocalizedString("Settings.SendUsage.Title", value: "Send Usage Data", comment: "The title for the setting to send usage data.", lastEditedIn: .unknown)
     public static let SendUsageSettingLink = MZLocalizedString("Settings.SendUsage.Link", value: "Learn More.", comment: "title for a link that explains how mozilla collects telemetry", lastEditedIn: .unknown)
     public static let SendUsageSettingMessage = MZLocalizedString("Settings.SendUsage.Message", value: "Mozilla strives to only collect what we need to provide and improve Firefox for everyone.", comment: "A short description that explains why mozilla collects usage data.", lastEditedIn: .unknown)
@@ -719,7 +733,7 @@ extension Strings {
 }
 
 // MARK: - Nimbus settings
-extension Strings {
+extension String {
     public static let SettingsStudiesTitle = MZLocalizedString("Settings.Studies.Title", value: "Studies", comment: "Label used as an item in Settings. Tapping on this item takes you to the Studies panel", lastEditedIn: .unknown)
     public static let SettingsStudiesSectionName = MZLocalizedString("Settings.Studies.SectionName", value: "Studies", comment: "Title displayed in header of the Studies panel", lastEditedIn: .unknown)
     public static let SettingsStudiesActiveSectionTitle = MZLocalizedString("Settings.Studies.Active.SectionName", value: "Active", comment: "Section title for all studies that are currently active", lastEditedIn: .unknown)
@@ -735,14 +749,14 @@ extension Strings {
 }
 
 // MARK: - Do not track
-extension Strings {
+extension String {
     public static let SettingsDoNotTrackTitle = MZLocalizedString("Settings.DNT.Title", value: "Send websites a Do Not Track signal that you don’t want to be tracked", comment: "DNT Settings title", lastEditedIn: .unknown)
     public static let SettingsDoNotTrackOptionOnWithTP = MZLocalizedString("Settings.DNT.OptionOnWithTP", value: "Only when using Tracking Protection", comment: "DNT Settings option for only turning on when Tracking Protection is also on", lastEditedIn: .unknown)
     public static let SettingsDoNotTrackOptionAlwaysOn = MZLocalizedString("Settings.DNT.OptionAlwaysOn", value: "Always", comment: "DNT Settings option for always on", lastEditedIn: .unknown)
 }
 
 // MARK: - Intro Onboarding slides
-extension Strings {
+extension String {
     // First Card
     public static let CardTitleWelcome = MZLocalizedString("Intro.Slides.Welcome.Title.v2", tableName: "Intro", value: "Welcome to Firefox", comment: "Title for the first panel 'Welcome' in the First Run tour.", lastEditedIn: .unknown)
     public static let CardTitleAutomaticPrivacy = MZLocalizedString("Intro.Slides.Automatic.Privacy.Title", tableName: "Intro", value: "Automatic Privacy", comment: "Title for the first item in the table related to automatic privacy", lastEditedIn: .unknown)
@@ -775,7 +789,7 @@ extension Strings {
 }
 
 // MARK: - Keyboard short cuts
-extension Strings {
+extension String {
     public static let ShowTabTrayFromTabKeyCodeTitle = MZLocalizedString("Tab.ShowTabTray.KeyCodeTitle", value: "Show All Tabs", comment: "Hardware shortcut to open the tab tray from a tab. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
     public static let CloseTabFromTabTrayKeyCodeTitle = MZLocalizedString("TabTray.CloseTab.KeyCodeTitle", value: "Close Selected Tab", comment: "Hardware shortcut to close the selected tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
     public static let CloseAllTabsFromTabTrayKeyCodeTitle = MZLocalizedString("TabTray.CloseAllTabs.KeyCodeTitle", value: "Close All Tabs", comment: "Hardware shortcut to close all tabs from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
@@ -787,7 +801,7 @@ extension Strings {
 }
 
 // MARK: - Share extension
-extension Strings {
+extension String {
     public static let SendToCancelButton = MZLocalizedString("SendTo.Cancel.Button", value: "Cancel", comment: "Button title for cancelling share screen", lastEditedIn: .unknown)
     public static let SendToErrorOKButton = MZLocalizedString("SendTo.Error.OK.Button", value: "OK", comment: "OK button to dismiss the error prompt.", lastEditedIn: .unknown)
     public static let SendToErrorTitle = MZLocalizedString("SendTo.Error.Title", value: "The link you are trying to share cannot be shared.", comment: "Title of error prompt displayed when an invalid URL is shared.", lastEditedIn: .unknown)
@@ -800,7 +814,7 @@ extension Strings {
     public static let SendToTitle = MZLocalizedString("SendTo.NavBar.Title", value: "Send Tab", comment: "Title of the dialog that allows you to send a tab to a different device", lastEditedIn: .unknown)
     public static let SendToSendButtonTitle = MZLocalizedString("SendTo.SendAction.Text", value: "Send", comment: "Navigation bar button to Send the current page to a device", lastEditedIn: .unknown)
     public static let SendToDevicesListTitle = MZLocalizedString("SendTo.DeviceList.Text", value: "Available devices:", comment: "Header for the list of devices table", lastEditedIn: .unknown)
-    public static let ShareSendToDevice = Strings.SendToDeviceTitle
+    public static let ShareSendToDevice = SendToDeviceTitle
 
     // The above items are re-used strings from the old extension. New strings below.
 
@@ -819,14 +833,14 @@ extension Strings {
 }
 
 // MARK: - PasswordAutofill extension
-extension Strings {
+extension String {
     public static let PasswordAutofillTitle = MZLocalizedString("PasswordAutoFill.SectionTitle", value: "Firefox Credentials", comment: "Title of the extension that shows firefox passwords", lastEditedIn: .unknown)
     public static let CredentialProviderNoCredentialError = MZLocalizedString("PasswordAutoFill.NoPasswordsFoundTitle", value: "You don’t have any credentials synced from your Firefox Account", comment: "Error message shown in the remote tabs panel", lastEditedIn: .unknown)
     public static let AvailableCredentialsHeader = MZLocalizedString("PasswordAutoFill.PasswordsListTitle", value: "Available Credentials:", comment: "Header for the list of credentials table", lastEditedIn: .unknown)
 }
 
 // MARK: - Translation bar
-extension Strings {
+extension String {
     public static let TranslateSnackBarPrompt = MZLocalizedString("TranslationToastHandler.PromptTranslate.Title", value: "This page appears to be in %1$@. Translate to %2$@ with %3$@?", comment: "Prompt for translation. The first parameter is the language the page is in. The second parameter is the name of our local language. The third is the name of the service.", lastEditedIn: .unknown)
     public static let TranslateSnackBarYes = MZLocalizedString("TranslationToastHandler.PromptTranslate.OK", value: "Yes", comment: "Button to allow the page to be translated to the user locale language", lastEditedIn: .unknown)
     public static let TranslateSnackBarNo = MZLocalizedString("TranslationToastHandler.PromptTranslate.Cancel", value: "No", comment: "Button to disallow the page to be translated to the user locale language", lastEditedIn: .unknown)
@@ -839,7 +853,7 @@ extension Strings {
 }
 
 // MARK: - Display Theme
-extension Strings {
+extension String {
     public static let SettingsDisplayThemeTitle = MZLocalizedString("Settings.DisplayTheme.Title.v2", value: "Theme", comment: "Title in main app settings for Theme settings", lastEditedIn: .unknown)
     public static let DisplayThemeBrightnessThresholdSectionHeader = MZLocalizedString("Settings.DisplayTheme.BrightnessThreshold.SectionHeader", value: "Threshold", comment: "Section header for brightness slider.", lastEditedIn: .unknown)
     public static let DisplayThemeSectionFooter = MZLocalizedString("Settings.DisplayTheme.SectionFooter", value: "The theme will automatically change based on your display brightness. You can set the threshold where the theme changes. The circle indicates your display's current brightness.", comment: "Display (theme) settings footer describing how the brightness slider works.", lastEditedIn: .unknown)
@@ -857,12 +871,12 @@ extension Strings {
     public static let DisplayThemeOptionDark = MZLocalizedString("Settings.DisplayTheme.OptionDark", value: "Dark", comment: "Option choice in display theme settings for dark theme", lastEditedIn: .unknown)
 }
 
-extension Strings {
+extension String {
     public static let AddTabAccessibilityLabel = MZLocalizedString("TabTray.AddTab.Button", value: "Add Tab", comment: "Accessibility label for the Add Tab button in the Tab Tray.", lastEditedIn: .unknown)
 }
 
 // MARK: - Cover Sheet
-extension Strings {
+extension String {
     // Dark Mode Cover Sheet
     public static let CoverSheetV22DarkModeTitle = MZLocalizedString("CoverSheet.v22.DarkMode.Title", value: "Dark theme now includes a dark keyboard and dark splash screen.", comment: "Title for the new dark mode change in the version 22 app release.", lastEditedIn: .unknown)
     public static let CoverSheetV22DarkModeDescription = MZLocalizedString("CoverSheet.v22.DarkMode.Description", value: "For iOS 13 users, Firefox now automatically switches to a dark theme when your phone is set to Dark Mode. To change this behavior, go to Settings > Theme.", comment: "Description for the new dark mode change in the version 22 app release. It describes the new automatic dark theme and how to change the theme settings.", lastEditedIn: .unknown)
@@ -874,7 +888,7 @@ extension Strings {
 }
 
 // MARK: - FxA Signin screen
-extension Strings {
+extension String {
     public static let FxASignin_Title = MZLocalizedString("fxa.signin.turn-on-sync", value: "Turn on Sync", comment: "FxA sign in view title", lastEditedIn: .unknown)
     public static let FxASignin_Subtitle = MZLocalizedString("fxa.signin.camera-signin", value: "Sign In with Your Camera", comment: "FxA sign in view subtitle", lastEditedIn: .unknown)
     public static let FxASignin_QRInstructions = MZLocalizedString("fxa.signin.qr-link-instruction", value: "On your computer open Firefox and go to firefox.com/pair", comment: "FxA sign in view qr code instructions", lastEditedIn: .unknown)
@@ -1393,13 +1407,15 @@ extension String {
 
 // MARK: - Credential Provider
 extension String {
-    public static let LoginsWelcomeViewTitle = MZLocalizedString("Logins.WelcomeView.Title", value: "Take your passwords everywhere", comment: "Label displaying welcome view title", lastEditedIn: .unknown)
-    public static let LoginsListSearchCancel = MZLocalizedString("LoginsList.Search.Cancel", value: "Cancel", comment: "Cancel button title", lastEditedIn: .unknown)
-    public static let LoginsListSearchPlaceholder = MZLocalizedString("LoginsList.Search.Placeholder", value: "Search logins", comment: "Placeholder text for search field", lastEditedIn: .unknown)
-    public static let LoginsListSelectPasswordTitle = MZLocalizedString("LoginsList.SelectPassword.Title", value: "Select a password to fill", comment: "Label displaying select a password to fill instruction", lastEditedIn: .unknown)
-    public static let LoginsListNoMatchingResultTitle = MZLocalizedString("LoginsList.NoMatchingResult.Title", value: "No matching logins", comment: "Label displayed when a user searches and no matches can be found against the search query", lastEditedIn: .unknown)
-    public static let LoginsListNoMatchingResultSubtitle = MZLocalizedString("LoginsList.NoMatchingResult.Subtitle", value: "There are no results matching your search.", comment: "Label that appears after the search if there are no logins matching the search", lastEditedIn: .unknown)
-    public static let LoginsListNoLoginsFoundDescription = MZLocalizedString("LoginsList.NoLoginsFound.Description", value: "Saved logins will show up here. If you saved your logins to Firefox on a different device, sign in to your Firefox Account.", comment: "Label shown when there are no logins to list", lastEditedIn: .unknown)
+    struct CredetntialProvider {
+        public static let LoginsWelcomeViewTitle = MZLocalizedString("Logins.WelcomeView.Title", value: "Take your passwords everywhere", comment: "Label displaying welcome view title", lastEditedIn: .unknown)
+        public static let LoginsListSearchCancel = MZLocalizedString("LoginsList.Search.Cancel", value: "Cancel", comment: "Cancel button title", lastEditedIn: .unknown)
+        public static let LoginsListSearchPlaceholder = MZLocalizedString("LoginsList.Search.Placeholder", value: "Search logins", comment: "Placeholder text for search field", lastEditedIn: .unknown)
+        public static let LoginsListSelectPasswordTitle = MZLocalizedString("LoginsList.SelectPassword.Title", value: "Select a password to fill", comment: "Label displaying select a password to fill instruction", lastEditedIn: .unknown)
+        public static let LoginsListNoMatchingResultTitle = MZLocalizedString("LoginsList.NoMatchingResult.Title", value: "No matching logins", comment: "Label displayed when a user searches and no matches can be found against the search query", lastEditedIn: .unknown)
+        public static let LoginsListNoMatchingResultSubtitle = MZLocalizedString("LoginsList.NoMatchingResult.Subtitle", value: "There are no results matching your search.", comment: "Label that appears after the search if there are no logins matching the search", lastEditedIn: .unknown)
+        public static let LoginsListNoLoginsFoundDescription = MZLocalizedString("LoginsList.NoLoginsFound.Description", value: "Saved logins will show up here. If you saved your logins to Firefox on a different device, sign in to your Firefox Account.", comment: "Label shown when there are no logins to list", lastEditedIn: .unknown)
+    }
 }
 
 // MARK: - v35 Strings

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -327,6 +327,7 @@ extension String {
     public static let ClearableOfflineData = MZLocalizedString("Offline Website Data", tableName: "ClearPrivateData", comment: "Settings item for clearing website data", lastEditedIn: .unknown)
     public static let ClearableCookies = MZLocalizedString("Cookies", tableName: "ClearPrivateData", comment: "Settings item for clearing cookies", lastEditedIn: .unknown)
     public static let ClearableDownloads = MZLocalizedString("Downloaded Files", tableName: "ClearPrivateData", comment: "Settings item for deleting downloaded files", lastEditedIn: .unknown)
+    public static let ClearableSpotlight = MZLocalizedString("Spotlight Index", tableName: "ClearPrivateData", comment: "Settings item for deleting the iOS search index of browsed webpages", lastEditedIn: .unknown)
 }
 
 // MARK: - D

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -17,6 +17,10 @@ import Foundation
 /// and that string should then be tagged accordingly. This allows easy identification of
 /// new/updated strings during localization import/export. In the case that a string was
 /// added/edited before the `AppVersionTag` was introduced, it is marked as `.unknown`.
+/// This tag is ONLY used for identification purposes, and nothing else.
+///
+/// Finally, strings are aphabetized according to the first letter of the feature
+/// name/category/view they're organized under.
 
 public struct Strings {
     public static let bundle = Bundle(for: BundleClass.self)
@@ -31,139 +35,306 @@ enum AppVersionTag {
     case unknown
 }
 
-func MZLocalizedString(_ key: String, tableName: String? = nil, value: String = "", comment: String, lastEditedIn: AppVersionTag) -> String {
+fileprivate func MZLocalizedString(_ key: String, tableName: String? = nil, value: String = "", comment: String, lastEditedIn: AppVersionTag) -> String {
     return NSLocalizedString(key, tableName: tableName, bundle: Strings.bundle, value: value, comment: comment)
 }
 
-// MARK: - General
-extension String {
-    public static let OKString = MZLocalizedString("OK", comment: "OK button", lastEditedIn: .unknown)
-    public static let CancelString = MZLocalizedString("Cancel", comment: "Label for Cancel button", lastEditedIn: .unknown)
-    public static let NotNowString = MZLocalizedString("Toasts.NotNow", value: "Not Now", comment: "label for Not Now button", lastEditedIn: .unknown)
-    public static let AppStoreString = MZLocalizedString("Toasts.OpenAppStore", value: "Open App Store", comment: "Open App Store button", lastEditedIn: .unknown)
-    public static let UndoString = MZLocalizedString("Toasts.Undo", value: "Undo", comment: "Label for button to undo the action just performed", lastEditedIn: .unknown)
-    public static let OpenSettingsString = MZLocalizedString("Open Settings", comment: "See http://mzl.la/1G7uHo7", lastEditedIn: .unknown)
-}
-
-// MARK: - Table date section titles
-extension String {
-    public static let TableDateSectionTitleToday = MZLocalizedString("Today", comment: "History tableview section header", lastEditedIn: .unknown)
-    public static let TableDateSectionTitleYesterday = MZLocalizedString("Yesterday", comment: "History tableview section header", lastEditedIn: .unknown)
-    public static let TableDateSectionTitleLastWeek = MZLocalizedString("Last week", comment: "History tableview section header", lastEditedIn: .unknown)
-    public static let TableDateSectionTitleLastMonth = MZLocalizedString("Last month", comment: "History tableview section header", lastEditedIn: .unknown)
-}
-
-// MARK: - Top Sites
-extension String {
-    public static let TopSitesEmptyStateDescription = MZLocalizedString("TopSites.EmptyState.Description", value: "Your most visited sites will show up here.", comment: "Description label for the empty Top Sites state.", lastEditedIn: .unknown)
-    public static let TopSitesEmptyStateTitle = MZLocalizedString("TopSites.EmptyState.Title", value: "Welcome to Top Sites", comment: "The title for the empty Top Sites state", lastEditedIn: .unknown)
-    public static let TopSitesRemoveButtonAccessibilityLabel = MZLocalizedString("TopSites.RemovePage.Button", value: "Remove page — %@", comment: "Button shown in editing mode to remove this site from the top sites panel.", lastEditedIn: .unknown)
-}
+// MARK: - A
 
 // MARK: - Activity Stream
 extension String {
-    public static let ASPocketTitle = MZLocalizedString("ActivityStream.Pocket.SectionTitle", value: "Trending on Pocket", comment: "Section title label for Recommended by Pocket section", lastEditedIn: .unknown)
-    public static let ASPocketTitle2 = MZLocalizedString("ActivityStream.Pocket.SectionTitle2", value: "Recommended by Pocket", comment: "Section title label for Recommended by Pocket section", lastEditedIn: .unknown)
-    public static let ASTopSitesTitle =  MZLocalizedString("ActivityStream.TopSites.SectionTitle", value: "Top Sites", comment: "Section title label for Top Sites", lastEditedIn: .unknown)
-    public static let ASShortcutsTitle =  MZLocalizedString("ActivityStream.Shortcuts.SectionTitle", value: "Shortcuts", comment: "Section title label for Shortcuts", lastEditedIn: .unknown)
-    public static let HighlightVistedText = MZLocalizedString("ActivityStream.Highlights.Visited", value: "Visited", comment: "The description of a highlight if it is a site the user has visited", lastEditedIn: .unknown)
-    public static let HighlightBookmarkText = MZLocalizedString("ActivityStream.Highlights.Bookmark", value: "Bookmarked", comment: "The description of a highlight if it is a site the user has bookmarked", lastEditedIn: .unknown)
-    public static let PocketTrendingText = MZLocalizedString("ActivityStream.Pocket.Trending", value: "Trending", comment: "The description of a Pocket Story", lastEditedIn: .unknown)
-    public static let PocketMoreStoriesText = MZLocalizedString("ActivityStream.Pocket.MoreLink", value: "More", comment: "The link that shows more Pocket trending stories", lastEditedIn: .unknown)
-    public static let TopSitesRowSettingFooter = MZLocalizedString("ActivityStream.TopSites.RowSettingFooter", value: "Set Rows", comment: "The title for the setting page which lets you select the number of top site rows", lastEditedIn: .unknown)
-    public static let TopSitesRowCount = MZLocalizedString("ActivityStream.TopSites.RowCount", value: "Rows: %d", comment: "label showing how many rows of topsites are shown. %d represents a number", lastEditedIn: .unknown)
-    public static let RecentlyBookmarkedTitle = MZLocalizedString("ActivityStream.NewRecentBookmarks.Title", value: "Recent Bookmarks", comment: "Section title label for recently bookmarked websites", lastEditedIn: .unknown)
-    public static let RecentlyVisitedTitle = MZLocalizedString("ActivityStream.RecentHistory.Title", value: "Recently Visited", comment: "Section title label for recently visited websites", lastEditedIn: .unknown)
-    public static let RecentlySavedSectionTitle = MZLocalizedString("ActivityStream.Library.Title", value: "Recently Saved", comment: "A string used to signify the start of the Recently Saved section in Home Screen.", lastEditedIn: .unknown)
-    public static let RecentlySavedShowAllText = MZLocalizedString("RecentlySaved.Actions.More", value: "Show All", comment: "More button text for Recently Saved items at the home page.", lastEditedIn: .unknown)
+    public struct ActivityStream {
+        public static let PocketTitle2 = MZLocalizedString("ActivityStream.Pocket.SectionTitle2", value: "Recommended by Pocket", comment: "Section title label for Recommended by Pocket section", lastEditedIn: .unknown)
+        public static let TopSitesTitle =  MZLocalizedString("ActivityStream.TopSites.SectionTitle", value: "Top Sites", comment: "Section title label for Top Sites", lastEditedIn: .unknown)
+        public static let ShortcutsTitle =  MZLocalizedString("ActivityStream.Shortcuts.SectionTitle", value: "Shortcuts", comment: "Section title label for Shortcuts", lastEditedIn: .unknown)
+        public static let PocketMoreStoriesText = MZLocalizedString("ActivityStream.Pocket.MoreLink", value: "More", comment: "The link that shows more Pocket trending stories", lastEditedIn: .unknown)
+        public static let TopSitesRowSettingFooter = MZLocalizedString("ActivityStream.TopSites.RowSettingFooter", value: "Set Rows", comment: "The title for the setting page which lets you select the number of top site rows", lastEditedIn: .unknown)
+        public static let TopSitesRowCount = MZLocalizedString("ActivityStream.TopSites.RowCount", value: "Rows: %d", comment: "label showing how many rows of topsites are shown. %d represents a number", lastEditedIn: .unknown)
+        public static let RecentlyBookmarkedTitle = MZLocalizedString("ActivityStream.NewRecentBookmarks.Title", value: "Recent Bookmarks", comment: "Section title label for recently bookmarked websites", lastEditedIn: .unknown)
+        public static let RecentlyVisitedTitle = MZLocalizedString("ActivityStream.RecentHistory.Title", value: "Recently Visited", comment: "Section title label for recently visited websites", lastEditedIn: .unknown)
+        public static let RecentlySavedSectionTitle = MZLocalizedString("ActivityStream.Library.Title", value: "Recently Saved", comment: "A string used to signify the start of the Recently Saved section in Home Screen.", lastEditedIn: .unknown)
+        public static let RecentlySavedShowAllText = MZLocalizedString("RecentlySaved.Actions.More", value: "Show All", comment: "More button text for Recently Saved items at the home page.", lastEditedIn: .unknown)
+    }
 }
 
-// MARK: - Home Panel Context Menu
+
+// MARK: - Alerts
 extension String {
-    public static let OpenInNewTabContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.OpenInNewTab", value: "Open in New Tab", comment: "The title for the Open in New Tab context menu action for sites in Home Panels", lastEditedIn: .unknown)
-    public static let OpenInNewPrivateTabContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.OpenInNewPrivateTab", value: "Open in New Private Tab", comment: "The title for the Open in New Private Tab context menu action for sites in Home Panels", lastEditedIn: .unknown)
-    public static let BookmarkContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.Bookmark", value: "Bookmark", comment: "The title for the Bookmark context menu action for sites in Home Panels", lastEditedIn: .unknown)
-    public static let RemoveBookmarkContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.RemoveBookmark", value: "Remove Bookmark", comment: "The title for the Remove Bookmark context menu action for sites in Home Panels", lastEditedIn: .unknown)
-    public static let DeleteFromHistoryContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.DeleteFromHistory", value: "Delete from History", comment: "The title for the Delete from History context menu action for sites in Home Panels", lastEditedIn: .unknown)
-    public static let ShareContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.Share", value: "Share", comment: "The title for the Share context menu action for sites in Home Panels", lastEditedIn: .unknown)
-    public static let RemoveContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.Remove", value: "Remove", comment: "The title for the Remove context menu action for sites in Home Panels", lastEditedIn: .unknown)
-    public static let PinTopsiteActionTitle = MZLocalizedString("ActivityStream.ContextMenu.PinTopsite", value: "Pin to Top Sites", comment: "The title for the pinning a topsite action", lastEditedIn: .unknown)
-    public static let PinTopsiteActionTitle2 = MZLocalizedString("ActivityStream.ContextMenu.PinTopsite2", value: "Pin", comment: "The title for the pinning a topsite action", lastEditedIn: .unknown)
-    public static let UnpinTopsiteActionTitle2 = MZLocalizedString("ActivityStream.ContextMenu.UnpinTopsite", value: "Unpin", comment: "The title for the unpinning a topsite action", lastEditedIn: .unknown)
-    public static let AddToShortcutsActionTitle = MZLocalizedString("ActivityStream.ContextMenu.AddToShortcuts", value: "Add to Shortcuts", comment: "The title for the pinning a shortcut action", lastEditedIn: .unknown)
-    public static let RemoveFromShortcutsActionTitle = MZLocalizedString("ActivityStream.ContextMenu.RemoveFromShortcuts", value: "Remove from Shortcuts", comment: "The title for removing a shortcut action", lastEditedIn: .unknown)
-    public static let RemovePinTopsiteActionTitle = MZLocalizedString("ActivityStream.ContextMenu.RemovePinTopsite", value: "Remove Pinned Site", comment: "The title for removing a pinned topsite action", lastEditedIn: .unknown)
+    public struct Alerts {
+        public struct Breach {
+            // Breach Alerts
+            public static let Title = MZLocalizedString("BreachAlerts.Title", value: "Website Breach", comment: "Title for the Breached Login Detail View.", lastEditedIn: .unknown)
+            public static let LearnMore = MZLocalizedString("BreachAlerts.LearnMoreButton", value: "Learn more", comment: "Link to monitor.firefox.com to learn more about breached passwords", lastEditedIn: .unknown)
+            public static let BreachDate = MZLocalizedString("BreachAlerts.BreachDate", value: "This breach occurred on", comment: "Describes the date on which the breach occurred", lastEditedIn: .unknown)
+            public static let Description = MZLocalizedString("BreachAlerts.Description", value: "Passwords were leaked or stolen since you last changed your password. To protect this account, log in to the site and change your password.", comment: "Description of what a breach is", lastEditedIn: .unknown)
+            public static let Link = MZLocalizedString("BreachAlerts.Link", value: "Go to", comment: "Leads to a link to the breached website", lastEditedIn: .unknown)
+        }
+
+        public struct ClearPrivateData {
+            public static let Message = MZLocalizedString("This action will clear all of your private data. It cannot be undone.", tableName: "ClearPrivateDataConfirm", comment: "Description of the confirmation dialog shown when a user tries to clear their private data.", lastEditedIn: .unknown)
+            public static let Cancel = MZLocalizedString("Cancel", tableName: "ClearPrivateDataConfirm", comment: "The cancel button when confirming clear private data.", lastEditedIn: .unknown)
+            public static let Ok = MZLocalizedString("OK", tableName: "ClearPrivateDataConfirm", comment: "The button that clears private data.", lastEditedIn: .unknown)
+        }
+
+        public struct ClearSyncedHistoryData {
+            public static let Message = MZLocalizedString("This action will clear all of your private data, including history from your synced devices.", tableName: "ClearHistoryConfirm", comment: "Description of the confirmation dialog shown when a user tries to clear history that's synced to another device.", lastEditedIn: .unknown)
+            // TODO: these look like the same as in ClearPrivateDataAlert, I think we can remove them
+            public static let Cancel = MZLocalizedString("Cancel", tableName: "ClearHistoryConfirm", comment: "The cancel button when confirming clear history.", lastEditedIn: .unknown)
+            public static let Ok = MZLocalizedString("OK", tableName: "ClearHistoryConfirm", comment: "The confirmation button that clears history even when Sync is connected.", lastEditedIn: .unknown)
+        }
+
+        public struct ClearWebsiteData {
+            public static let AllWebsiteDataMessage = MZLocalizedString("Settings.WebsiteData.ConfirmPrompt", value: "This action will clear all of your website data. It cannot be undone.", comment: "Description of the confirmation dialog shown when a user tries to clear their private data.", lastEditedIn: .unknown)
+            public static let SelectedWebsiteDataMessage = MZLocalizedString("Settings.WebsiteData.SelectedConfirmPrompt", value: "This action will clear the selected items. It cannot be undone.", comment: "Description of the confirmation dialog shown when a user tries to clear some of their private data.", lastEditedIn: .unknown)
+            // TODO: these look like the same as in ClearPrivateDataAlert, I think we can remove them
+            public static let Cancel = MZLocalizedString("Cancel", tableName: "ClearPrivateDataConfirm", comment: "The cancel button when confirming clear private data.", lastEditedIn: .unknown)
+            public static let Ok = MZLocalizedString("OK", tableName: "ClearPrivateDataConfirm", comment: "The button that clears private data.", lastEditedIn: .unknown)
+        }
+
+        public struct CrashOptIn {
+            public static let Title = MZLocalizedString("Oops! Firefox crashed", comment: "Title for prompt displayed to user after the app crashes", lastEditedIn: .unknown)
+            public static let Message = MZLocalizedString("Send a crash report so Mozilla can fix the problem?", comment: "Message displayed in the crash dialog above the buttons used to select when sending reports", lastEditedIn: .unknown)
+            public static let Send = MZLocalizedString("Send Report", comment: "Used as a button label for crash dialog prompt", lastEditedIn: .unknown)
+            public static let AlwaysSend = MZLocalizedString("Always Send", comment: "Used as a button label for crash dialog prompt", lastEditedIn: .unknown)
+            public static let DontSend = MZLocalizedString("Don’t Send", comment: "Used as a button label for crash dialog prompt", lastEditedIn: .unknown)
+        }
+
+        public struct DeleteLogin {
+            public static let Title = MZLocalizedString("Are you sure?", tableName: "LoginManager", comment: "Prompt title when deleting logins", lastEditedIn: .unknown)
+            public static let SyncedMessage = MZLocalizedString("Logins will be removed from all connected devices.", tableName: "LoginManager", comment: "Prompt message warning the user that deleted logins will remove logins from all connected devices", lastEditedIn: .unknown)
+            public static let LocalMessage = MZLocalizedString("Logins will be permanently removed.", tableName: "LoginManager", comment: "Prompt message warning the user that deleting non-synced logins will permanently remove them", lastEditedIn: .unknown)
+            public static let Cancel = MZLocalizedString("Cancel", tableName: "LoginManager", comment: "Prompt option for cancelling out of deletion", lastEditedIn: .unknown)
+            public static let Delete = MZLocalizedString("Delete", tableName: "LoginManager", comment: "Label for the button used to delete the current login.", lastEditedIn: .unknown)
+        }
+
+        public struct RestoreTabs {
+            public static let Title = MZLocalizedString("Well, this is embarrassing.", comment: "Restore Tabs Prompt Title", lastEditedIn: .unknown)
+            public static let Message = MZLocalizedString("Looks like Firefox crashed previously. Would you like to restore your tabs?", comment: "Restore Tabs Prompt Description", lastEditedIn: .unknown)
+            public static let No = MZLocalizedString("No", comment: "Restore Tabs Negative Action", lastEditedIn: .unknown)
+            public static let Okay = MZLocalizedString("Okay", comment: "Restore Tabs Affirmative Action", lastEditedIn: .unknown)
+        }
+        
+        public struct ShakeToRestore {
+            public static let AlertTitle = MZLocalizedString("ReopenAlert.Title", value: "Reopen Last Closed Tab", comment: "Reopen alert title shown at home page.", lastEditedIn: .unknown)
+            public static let ButtonText = MZLocalizedString("ReopenAlert.Actions.Reopen", value: "Reopen", comment: "Reopen button text shown in reopen-alert at home page.", lastEditedIn: .unknown)
+            public static let CancelText = MZLocalizedString("ReopenAlert.Actions.Cancel", value: "Cancel", comment: "Cancel button text shown in reopen-alert at home page.", lastEditedIn: .unknown)
+        }
+    }
 }
 
-//  MARK: - PhotonActionSheet String
+// MARK: - App menu
 extension String {
-    public static let CloseButtonTitle = MZLocalizedString("PhotonMenu.close", value: "Close", comment: "Button for closing the menu action sheet", lastEditedIn: .unknown)
+    public struct AppMenu {
+        public static let ReportSiteIssueTitleString = MZLocalizedString("Menu.ReportSiteIssueAction.Title", tableName: "Menu", value: "Report Site Issue", comment: "Label for the button, displayed in the menu, used to report a compatibility issue with the current page.", lastEditedIn: .unknown)
+        public static let StopReloadPageTitle = MZLocalizedString("Menu.Library.StopReload", value: "Stop", comment: "Label for the button displayed in the menu used to stop the reload of the webpage", lastEditedIn: .unknown)
+        public static let LibraryTitleString = MZLocalizedString("Menu.Library.Title", tableName: "Menu", value: "Your Library", comment: "Label for the button, displayed in the menu, used to open the Library", lastEditedIn: .unknown)
+        public static let AddToReadingListTitleString = MZLocalizedString("Menu.AddToReadingList.Title", tableName: "Menu", value: "Add to Reading List", comment: "Label for the button, displayed in the menu, used to add a page to the reading list.", lastEditedIn: .unknown)
+
+        public static let SharePageTitleString = MZLocalizedString("Menu.SharePageAction.Title", tableName: "Menu", value: "Share Page With…", comment: "Label for the button, displayed in the menu, used to open the share dialog.", lastEditedIn: .unknown)
+        public static let CopyLinkTitleString = MZLocalizedString("Menu.CopyLink.Title", tableName: "Menu", value: "Copy Link", comment: "Label for the button, displayed in the menu, used to copy the current page link to the clipboard.", lastEditedIn: .unknown)
+        public static let NewTabTitleString = MZLocalizedString("Menu.NewTabAction.Title", tableName: "Menu", value: "Open New Tab", comment: "Label for the button, displayed in the menu, used to open a new tab", lastEditedIn: .unknown)
+        public static let AddBookmarkTitleString2 = MZLocalizedString("Menu.AddBookmarkAction2.Title", tableName: "Menu", value: "Add Bookmark", comment: "Label for the button, displayed in the menu, used to create a bookmark for the current website.", lastEditedIn: .unknown)
+        public static let RemoveBookmarkTitleString = MZLocalizedString("Menu.RemoveBookmarkAction.Title", tableName: "Menu", value: "Remove Bookmark", comment: "Label for the button, displayed in the menu, used to delete an existing bookmark for the current website.", lastEditedIn: .unknown)
+        public static let FindInPageTitleString = MZLocalizedString("Menu.FindInPageAction.Title", tableName: "Menu", value: "Find in Page", comment: "Label for the button, displayed in the menu, used to open the toolbar to search for text within the current page.", lastEditedIn: .unknown)
+        public static let ViewDesktopSiteTitleString = MZLocalizedString("Menu.ViewDekstopSiteAction.Title", tableName: "Menu", value: "Request Desktop Site", comment: "Label for the button, displayed in the menu, used to request the desktop version of the current website.", lastEditedIn: .unknown)
+        public static let ViewMobileSiteTitleString = MZLocalizedString("Menu.ViewMobileSiteAction.Title", tableName: "Menu", value: "Request Mobile Site", comment: "Label for the button, displayed in the menu, used to request the mobile version of the current website.", lastEditedIn: .unknown)
+        public static let SettingsTitleString = MZLocalizedString("Menu.OpenSettingsAction.Title", tableName: "Menu", value: "Settings", comment: "Label for the button, displayed in the menu, used to open the Settings menu.", lastEditedIn: .unknown)
+        public static let CloseAllTabsTitleString = MZLocalizedString("Menu.CloseAllTabsAction.Title", tableName: "Menu", value: "Close All Tabs", comment: "Label for the button, displayed in the menu, used to close all tabs currently open.", lastEditedIn: .unknown)
+        public static let OpenHomePageTitleString = MZLocalizedString("Menu.OpenHomePageAction.Title", tableName: "Menu", value: "Home", comment: "Label for the button, displayed in the menu, used to navigate to the home page.", lastEditedIn: .unknown)
+        public static let TopSitesTitleString = MZLocalizedString("Menu.OpenTopSitesAction.AccessibilityLabel", tableName: "Menu", value: "Top Sites", comment: "Accessibility label for the button, displayed in the menu, used to open the Top Sites home panel.", lastEditedIn: .unknown)
+        public static let BookmarksTitleString = MZLocalizedString("Menu.OpenBookmarksAction.AccessibilityLabel.v2", tableName: "Menu", value: "Bookmarks", comment: "Accessibility label for the button, displayed in the menu, used to open the Bookmarks home panel. Please keep as short as possible, <15 chars of space available.", lastEditedIn: .unknown)
+        public static let ReadingListTitleString = MZLocalizedString("Menu.OpenReadingListAction.AccessibilityLabel.v2", tableName: "Menu", value: "Reading List", comment: "Accessibility label for the button, displayed in the menu, used to open the Reading list home panel. Please keep as short as possible, <15 chars of space available.", lastEditedIn: .unknown)
+        public static let HistoryTitleString = MZLocalizedString("Menu.OpenHistoryAction.AccessibilityLabel.v2", tableName: "Menu", value: "History", comment: "Accessibility label for the button, displayed in the menu, used to open the History home panel. Please keep as short as possible, <15 chars of space available.", lastEditedIn: .unknown)
+        public static let DownloadsTitleString = MZLocalizedString("Menu.OpenDownloadsAction.AccessibilityLabel.v2", tableName: "Menu", value: "Downloads", comment: "Accessibility label for the button, displayed in the menu, used to open the Downloads home panel. Please keep as short as possible, <15 chars of space available.", lastEditedIn: .unknown)
+        public static let SyncedTabsTitleString = MZLocalizedString("Menu.OpenSyncedTabsAction.AccessibilityLabel.v2", tableName: "Menu", value: "Synced Tabs", comment: "Accessibility label for the button, displayed in the menu, used to open the Synced Tabs home panel. Please keep as short as possible, <15 chars of space available.", lastEditedIn: .unknown)
+        public static let ButtonAccessibilityLabel = MZLocalizedString("Toolbar.Menu.AccessibilityLabel", value: "Menu", comment: "Accessibility label for the Menu button.", lastEditedIn: .unknown)
+        public static let TurnOnNightMode = MZLocalizedString("Menu.NightModeTurnOn.Label2", value: "Turn on Night Mode", comment: "Label for the button, displayed in the menu, turns on night mode.", lastEditedIn: .unknown)
+        public static let TurnOffNightMode = MZLocalizedString("Menu.NightModeTurnOff.Label2", value: "Turn off Night Mode", comment: "Label for the button, displayed in the menu, turns off night mode.", lastEditedIn: .unknown)
+        public static let NoImageMode = MZLocalizedString("Menu.NoImageModeBlockImages.Label", value: "Block Images", comment: "Label for the button, displayed in the menu, hides images on the webpage when pressed.", lastEditedIn: .unknown)
+        public static let ShowImageMode = MZLocalizedString("Menu.NoImageModeShowImages.Label", value: "Show Images", comment: "Label for the button, displayed in the menu, shows images on the webpage when pressed.", lastEditedIn: .unknown)
+        public static let Bookmarks = MZLocalizedString("Menu.Bookmarks.Label", value: "Bookmarks", comment: "Label for the button, displayed in the menu, takes you to to bookmarks screen when pressed.", lastEditedIn: .unknown)
+        public static let History = MZLocalizedString("Menu.History.Label", value: "History", comment: "Label for the button, displayed in the menu, takes you to to History screen when pressed.", lastEditedIn: .unknown)
+        public static let Downloads = MZLocalizedString("Menu.Downloads.Label", value: "Downloads", comment: "Label for the button, displayed in the menu, takes you to to Downloads screen when pressed.", lastEditedIn: .unknown)
+        public static let ReadingList = MZLocalizedString("Menu.ReadingList.Label", value: "Reading List", comment: "Label for the button, displayed in the menu, takes you to to Reading List screen when pressed.", lastEditedIn: .unknown)
+        public static let Passwords = MZLocalizedString("Menu.Passwords.Label", value: "Passwords", comment: "Label for the button, displayed in the menu, takes you to to passwords screen when pressed.", lastEditedIn: .unknown)
+        public static let BackUpAndSyncData = MZLocalizedString("Menu.BackUpAndSync.Label", value: "Back up and Sync Data", comment: "Label for the button, displayed in the menu, takes you to sync sign in when pressed.", lastEditedIn: .unknown)
+        public static let CopyURLConfirmMessage = MZLocalizedString("Menu.CopyURL.Confirm", value: "URL Copied To Clipboard", comment: "Toast displayed to user after copy url pressed.", lastEditedIn: .unknown)
+
+        public static let AddBookmarkConfirmMessage = MZLocalizedString("Menu.AddBookmark.Confirm", value: "Bookmark Added", comment: "Toast displayed to the user after a bookmark has been added.", lastEditedIn: .unknown)
+        public static let TabSentConfirmMessage = MZLocalizedString("Menu.TabSent.Confirm", value: "Tab Sent", comment: "Toast displayed to the user after a tab has been sent successfully.", lastEditedIn: .unknown)
+        public static let RemoveBookmarkConfirmMessage = MZLocalizedString("Menu.RemoveBookmark.Confirm", value: "Bookmark Removed", comment: "Toast displayed to the user after a bookmark has been removed.", lastEditedIn: .unknown)
+        public static let AddPinToShortcutsConfirmMessage = MZLocalizedString("Menu.AddPin.Confirm2", value: "Added to Shortcuts", comment: "Toast displayed to the user after adding the item to the Shortcuts.", lastEditedIn: .unknown)
+        public static let RemovePinFromShortcutsConfirmMessage = MZLocalizedString("Menu.RemovePin.Confirm2", value: "Removed from Shortcuts", comment: "Toast displayed to the user after removing the item to the Shortcuts.", lastEditedIn: .unknown)
+        public static let AddToReadingListConfirmMessage = MZLocalizedString("Menu.AddToReadingList.Confirm", value: "Added To Reading List", comment: "Toast displayed to the user after adding the item to their reading list.", lastEditedIn: .unknown)
+        public static let SendToDeviceTitle = MZLocalizedString("Send to Device", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to send the current tab to another device", lastEditedIn: .unknown)
+        public static let SendLinkToDeviceTitle = MZLocalizedString("Menu.SendLinkToDevice", tableName: "3DTouchActions", value: "Send Link to Device", comment: "Label for preview action on Tab Tray Tab to send the current link to another device", lastEditedIn: .unknown)
+        public static let WhatsNewString = MZLocalizedString("Menu.WhatsNew.Title", value: "What's New", comment: "The title for the option to view the What's new page.", lastEditedIn: .unknown)
+    }
 }
 
-// MARK: - Home page
+// MARK: - Authenticator strings
 extension String {
-    public static let SettingsHomePageSectionName = MZLocalizedString("Settings.HomePage.SectionName", value: "Homepage", comment: "Label used as an item in Settings. When touched it will open a dialog to configure the home page and its uses.", lastEditedIn: .unknown)
-    public static let SettingsHomePageTitle = MZLocalizedString("Settings.HomePage.Title", value: "Homepage Settings", comment: "Title displayed in header of the setting panel.", lastEditedIn: .unknown)
-    public static let SettingsHomePageURLSectionTitle = MZLocalizedString("Settings.HomePage.URL.Title", value: "Current Homepage", comment: "Title of the setting section containing the URL of the current home page.", lastEditedIn: .unknown)
-    public static let SettingsHomePageUseCurrentPage = MZLocalizedString("Settings.HomePage.UseCurrent.Button", value: "Use Current Page", comment: "Button in settings to use the current page as home page.", lastEditedIn: .unknown)
-    public static let SettingsHomePagePlaceholder = MZLocalizedString("Settings.HomePage.URL.Placeholder", value: "Enter a webpage", comment: "Placeholder text in the homepage setting when no homepage has been set.", lastEditedIn: .unknown)
-    public static let SettingsHomePageUseCopiedLink = MZLocalizedString("Settings.HomePage.UseCopiedLink.Button", value: "Use Copied Link", comment: "Button in settings to use the current link on the clipboard as home page.", lastEditedIn: .unknown)
-    public static let SettingsHomePageUseDefault = MZLocalizedString("Settings.HomePage.UseDefault.Button", value: "Use Default", comment: "Button in settings to use the default home page. If no default is set, then this button isn't shown.", lastEditedIn: .unknown)
-    public static let SettingsHomePageClear = MZLocalizedString("Settings.HomePage.Clear.Button", value: "Clear", comment: "Button in settings to clear the home page.", lastEditedIn: .unknown)
-    public static let SetHomePageDialogTitle = MZLocalizedString("HomePage.Set.Dialog.Title", value: "Do you want to use this web page as your home page?", comment: "Alert dialog title when the user opens the home page for the first time.", lastEditedIn: .unknown)
-    public static let SetHomePageDialogMessage = MZLocalizedString("HomePage.Set.Dialog.Message", value: "You can change this at any time in Settings", comment: "Alert dialog body when the user opens the home page for the first time.", lastEditedIn: .unknown)
-    public static let SetHomePageDialogYes = MZLocalizedString("HomePage.Set.Dialog.OK", value: "Set Homepage", comment: "Button accepting changes setting the home page for the first time.", lastEditedIn: .unknown)
-    public static let SetHomePageDialogNo = MZLocalizedString("HomePage.Set.Dialog.Cancel", value: "Cancel", comment: "Button cancelling changes setting the home page for the first time.", lastEditedIn: .unknown)
-    public static let ReopenLastTabAlertTitle = MZLocalizedString("ReopenAlert.Title", value: "Reopen Last Closed Tab", comment: "Reopen alert title shown at home page.", lastEditedIn: .unknown)
-    public static let ReopenLastTabButtonText = MZLocalizedString("ReopenAlert.Actions.Reopen", value: "Reopen", comment: "Reopen button text shown in reopen-alert at home page.", lastEditedIn: .unknown)
-    public static let ReopenLastTabCancelText = MZLocalizedString("ReopenAlert.Actions.Cancel", value: "Cancel", comment: "Cancel button text shown in reopen-alert at home page.", lastEditedIn: .unknown)
+    public struct Authenticator {
+        public static let Cancel = MZLocalizedString("Cancel", comment: "Label for Cancel button", lastEditedIn: .unknown)
+        public static let Login = MZLocalizedString("Log in", comment: "Authentication prompt log in button", lastEditedIn: .unknown)
+        public static let PromptTitle = MZLocalizedString("Authentication required", comment: "Authentication prompt title", lastEditedIn: .unknown)
+        public static let PromptRealmMessage = MZLocalizedString("A username and password are being requested by %@. The site says: %@", comment: "Authentication prompt message with a realm. First parameter is the hostname. Second is the realm string", lastEditedIn: .unknown)
+        public static let PromptEmptyRealmMessage = MZLocalizedString("A username and password are being requested by %@.", comment: "Authentication prompt message with no realm. Parameter is the hostname of the site", lastEditedIn: .unknown)
+        public static let UsernamePlaceholder = MZLocalizedString("Username", comment: "Username textbox in Authentication prompt", lastEditedIn: .unknown)
+        public static let PasswordPlaceholder = MZLocalizedString("Password", comment: "Password textbox in Authentication prompt", lastEditedIn: .unknown)
+    }
+
+    public struct AuthenticationManager {
+        public static let Passcode = MZLocalizedString("Passcode For Logins", tableName: "AuthenticationManager", comment: "Label for the Passcode item in Settings", lastEditedIn: .unknown)
+        public static let TouchIDPasscodeSetting = MZLocalizedString("Touch ID & Passcode", tableName: "AuthenticationManager", comment: "Label for the Touch ID/Passcode item in Settings", lastEditedIn: .unknown)
+        public static let FaceIDPasscodeSetting = MZLocalizedString("Face ID & Passcode", tableName: "AuthenticationManager", comment: "Label for the Face ID/Passcode item in Settings", lastEditedIn: .unknown)
+        public static let RequirePasscode = MZLocalizedString("Require Passcode", tableName: "AuthenticationManager", comment: "Text displayed in the 'Interval' section, followed by the current interval setting, e.g. 'Immediately'", lastEditedIn: .unknown)
+        public static let EnterAPasscode = MZLocalizedString("Enter a passcode", tableName: "AuthenticationManager", comment: "Text displayed above the input field when entering a new passcode", lastEditedIn: .unknown)
+        public static let EnterPasscodeTitle = MZLocalizedString("Enter Passcode", tableName: "AuthenticationManager", comment: "Title of the dialog used to request the passcode", lastEditedIn: .unknown)
+        public static let EnterPasscode = MZLocalizedString("Enter passcode", tableName: "AuthenticationManager", comment: "Text displayed above the input field when changing the existing passcode", lastEditedIn: .unknown)
+        public static let ReenterPasscode = MZLocalizedString("Re-enter passcode", tableName: "AuthenticationManager", comment: "Text displayed above the input field when confirming a passcode", lastEditedIn: .unknown)
+        public static let SetPasscode = MZLocalizedString("Set Passcode", tableName: "AuthenticationManager", comment: "Title of the dialog used to set a passcode", lastEditedIn: .unknown)
+        public static let TurnOffPasscode = MZLocalizedString("Turn Passcode Off", tableName: "AuthenticationManager", comment: "Label used as a setting item to turn off passcode", lastEditedIn: .unknown)
+        public static let TurnOnPasscode = MZLocalizedString("Turn Passcode On", tableName: "AuthenticationManager", comment: "Label used as a setting item to turn on passcode", lastEditedIn: .unknown)
+        public static let ChangePasscode = MZLocalizedString("Change Passcode", tableName: "AuthenticationManager", comment: "Label used as a setting item and title of the following screen to change the current passcode", lastEditedIn: .unknown)
+        public static let EnterNewPasscode = MZLocalizedString("Enter a new passcode", tableName: "AuthenticationManager", comment: "Text displayed above the input field when changing the existing passcode", lastEditedIn: .unknown)
+        public static let Immediately = MZLocalizedString("Immediately", tableName: "AuthenticationManager", comment: "'Immediately' interval item for selecting when to require passcode", lastEditedIn: .unknown)
+        public static let OneMinute = MZLocalizedString("After 1 minute", tableName: "AuthenticationManager", comment: "'After 1 minute' interval item for selecting when to require passcode", lastEditedIn: .unknown)
+        public static let FiveMinutes = MZLocalizedString("After 5 minutes", tableName: "AuthenticationManager", comment: "'After 5 minutes' interval item for selecting when to require passcode", lastEditedIn: .unknown)
+        public static let TenMinutes = MZLocalizedString("After 10 minutes", tableName: "AuthenticationManager", comment: "'After 10 minutes' interval item for selecting when to require passcode", lastEditedIn: .unknown)
+        public static let FifteenMinutes = MZLocalizedString("After 15 minutes", tableName: "AuthenticationManager", comment: "'After 15 minutes' interval item for selecting when to require passcode", lastEditedIn: .unknown)
+        public static let OneHour = MZLocalizedString("After 1 hour", tableName: "AuthenticationManager", comment: "'After 1 hour' interval item for selecting when to require passcode", lastEditedIn: .unknown)
+        public static let LoginsTouchReason = MZLocalizedString("Use your fingerprint to access Logins now.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when accessing logins", lastEditedIn: .unknown)
+        public static let RequirePasscodeTouchReason = MZLocalizedString("touchid.require.passcode.reason.label", tableName: "AuthenticationManager", value: "Use your fingerprint to access configuring your required passcode interval.", comment: "Touch ID prompt subtitle when accessing the require passcode setting", lastEditedIn: .unknown)
+        public static let DisableTouchReason = MZLocalizedString("touchid.disable.reason.label", tableName: "AuthenticationManager", value: "Use your fingerprint to disable Touch ID.", comment: "Touch ID prompt subtitle when disabling Touch ID", lastEditedIn: .unknown)
+        public static let IncorrectAttemptsRemaining = MZLocalizedString("Incorrect passcode. Try again (Attempts remaining: %d).", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode when trying to enter a protected section of the app with attempts remaining", lastEditedIn: .unknown)
+        public static let MaximumAttemptsReachedNoTime = MZLocalizedString("Maximum attempts reached. Please try again later.", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode and has reached the maximum number of attempts.", lastEditedIn: .unknown)
+        public static let MismatchPasscodeError = MZLocalizedString("Passcodes didn’t match. Try again.", tableName: "AuthenticationManager", comment: "Error message displayed to user when their confirming passcode doesn't match the first code.", lastEditedIn: .unknown)
+        public static let UseNewPasscodeError = MZLocalizedString("New passcode must be different than existing code.", tableName: "AuthenticationManager", comment: "Error message displayed when user tries to enter the same passcode as their existing code when changing it.", lastEditedIn: .unknown)
+    }
+
 }
 
-// MARK: - Settings
+
+// MARK: - B
+
+// MARK: - Root Bookmarks folders
 extension String {
-    public static let SettingsGeneralSectionTitle = MZLocalizedString("Settings.General.SectionName", value: "General", comment: "General settings section title", lastEditedIn: .unknown)
-    public static let SettingsClearPrivateDataClearButton = MZLocalizedString("Settings.ClearPrivateData.Clear.Button", value: "Clear Private Data", comment: "Button in settings that clears private data for the selected items.", lastEditedIn: .unknown)
-    public static let SettingsClearAllWebsiteDataButton = MZLocalizedString("Settings.ClearAllWebsiteData.Clear.Button", value: "Clear All Website Data", comment: "Button in Data Management that clears all items.", lastEditedIn: .unknown)
-    public static let SettingsClearSelectedWebsiteDataButton = MZLocalizedString("Settings.ClearSelectedWebsiteData.ClearSelected.Button", value: "Clear Items: %1$@", comment: "Button in Data Management that clears private data for the selected items. Parameter is the number of items to be cleared", lastEditedIn: .unknown)
-    public static let SettingsClearPrivateDataSectionName = MZLocalizedString("Settings.ClearPrivateData.SectionName", value: "Clear Private Data", comment: "Label used as an item in Settings. When touched it will open a dialog prompting the user to make sure they want to clear all of their private data.", lastEditedIn: .unknown)
-    public static let SettingsDataManagementSectionName = MZLocalizedString("Settings.DataManagement.SectionName", value: "Data Management", comment: "Label used as an item in Settings. When touched it will open a dialog prompting the user to make sure they want to clear all of their private data.", lastEditedIn: .unknown)
-    public static let SettingsFilterSitesSearchLabel = MZLocalizedString("Settings.DataManagement.SearchLabel", value: "Filter Sites", comment: "Default text in search bar for Data Management", lastEditedIn: .unknown)
-    public static let SettingsClearPrivateDataTitle = MZLocalizedString("Settings.ClearPrivateData.Title", value: "Clear Private Data", comment: "Title displayed in header of the setting panel.", lastEditedIn: .unknown)
-    public static let SettingsDataManagementTitle = MZLocalizedString("Settings.DataManagement.Title", value: "Data Management", comment: "Title displayed in header of the setting panel.", lastEditedIn: .unknown)
-    public static let SettingsWebsiteDataTitle = MZLocalizedString("Settings.WebsiteData.Title", value: "Website Data", comment: "Title displayed in header of the Data Management panel.", lastEditedIn: .unknown)
-    public static let SettingsWebsiteDataShowMoreButton = MZLocalizedString("Settings.WebsiteData.ButtonShowMore", value: "Show More", comment: "Button shows all websites on website data tableview", lastEditedIn: .unknown)
-    public static let SettingsEditWebsiteSearchButton = MZLocalizedString("Settings.WebsiteData.ButtonEdit", value: "Edit", comment: "Button to edit website search results", lastEditedIn: .unknown)
-    public static let SettingsDeleteWebsiteSearchButton = MZLocalizedString("Settings.WebsiteData.ButtonDelete", value: "Delete", comment: "Button to delete website in search results", lastEditedIn: .unknown)
-    public static let SettingsDoneWebsiteSearchButton = MZLocalizedString("Settings.WebsiteData.ButtonDone", value: "Done", comment: "Button to exit edit website search results", lastEditedIn: .unknown)
-    public static let SettingsDisconnectSyncAlertTitle = MZLocalizedString("Settings.Disconnect.Title", value: "Disconnect Sync?", comment: "Title of the alert when prompting the user asking to disconnect.", lastEditedIn: .unknown)
-    public static let SettingsDisconnectSyncAlertBody = MZLocalizedString("Settings.Disconnect.Body", value: "Firefox will stop syncing with your account, but won’t delete any of your browsing data on this device.", comment: "Body of the alert when prompting the user asking to disconnect.", lastEditedIn: .unknown)
-    public static let SettingsDisconnectSyncButton = MZLocalizedString("Settings.Disconnect.Button", value: "Disconnect Sync", comment: "Button displayed at the bottom of settings page allowing users to Disconnect from FxA", lastEditedIn: .unknown)
-    public static let SettingsDisconnectCancelAction = MZLocalizedString("Settings.Disconnect.CancelButton", value: "Cancel", comment: "Cancel action button in alert when user is prompted for disconnect", lastEditedIn: .unknown)
-    public static let SettingsDisconnectDestructiveAction = MZLocalizedString("Settings.Disconnect.DestructiveButton", value: "Disconnect", comment: "Destructive action button in alert when user is prompted for disconnect", lastEditedIn: .unknown)
-    public static let SettingsSearchDoneButton = MZLocalizedString("Settings.Search.Done.Button", value: "Done", comment: "Button displayed at the top of the search settings.", lastEditedIn: .unknown)
-    public static let SettingsSearchEditButton = MZLocalizedString("Settings.Search.Edit.Button", value: "Edit", comment: "Button displayed at the top of the search settings.", lastEditedIn: .unknown)
-    public static let UseTouchID = MZLocalizedString("Use Touch ID", tableName: "AuthenticationManager", comment: "List section title for when to use Touch ID", lastEditedIn: .unknown)
-    public static let UseFaceID = MZLocalizedString("Use Face ID", tableName: "AuthenticationManager", comment: "List section title for when to use Face ID", lastEditedIn: .unknown)
-    public static let SettingsCopyAppVersionAlertTitle = MZLocalizedString("Settings.CopyAppVersion.Title", value: "Copied to clipboard", comment: "Copy app version alert shown in settings.", lastEditedIn: .unknown)
+    public struct Bookmarks {
+        public struct FolderTitle {
+            public static let Mobile = MZLocalizedString("Mobile Bookmarks", tableName: "Storage", comment: "The title of the folder that contains mobile bookmarks. This should match bookmarks.folder.mobile.label on Android.", lastEditedIn: .unknown)
+            public static let Menu = MZLocalizedString("Bookmarks Menu", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the menu. This should match bookmarks.folder.menu.label on Android.", lastEditedIn: .unknown)
+            public static let Toolbar = MZLocalizedString("Bookmarks Toolbar", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the toolbar. This should match bookmarks.folder.toolbar.label on Android.", lastEditedIn: .unknown)
+            public static let Unsorted = MZLocalizedString("Unsorted Bookmarks", tableName: "Storage", comment: "The name of the folder that contains unsorted desktop bookmarks. This should match bookmarks.folder.unfiled.label on Android.", lastEditedIn: .unknown)
+        }
+
+        public struct Management {
+            public static let NewBookmark = MZLocalizedString("Bookmarks.NewBookmark.Label", value: "New Bookmark", comment: "The button to create a new bookmark", lastEditedIn: .unknown)
+            public static let NewFolder = MZLocalizedString("Bookmarks.NewFolder.Label", value: "New Folder", comment: "The button to create a new folder", lastEditedIn: .unknown)
+            public static let NewSeparator = MZLocalizedString("Bookmarks.NewSeparator.Label", value: "New Separator", comment: "The button to create a new separator", lastEditedIn: .unknown)
+            public static let EditBookmark = MZLocalizedString("Bookmarks.EditBookmark.Label", value: "Edit Bookmark", comment: "The button to edit a bookmark", lastEditedIn: .unknown)
+            public static let Edit = MZLocalizedString("Bookmarks.Edit.Button", value: "Edit", comment: "The button on the snackbar to edit a bookmark after adding it.", lastEditedIn: .unknown)
+            public static let EditFolder = MZLocalizedString("Bookmarks.EditFolder.Label", value: "Edit Folder", comment: "The button to edit a folder", lastEditedIn: .unknown)
+            public static let DeleteFolderWarningTitle = MZLocalizedString("Bookmarks.DeleteFolderWarning.Title", tableName: "BookmarkPanelDeleteConfirm", value: "This folder isn’t empty.", comment: "Title of the confirmation alert when the user tries to delete a folder that still contains bookmarks and/or folders.", lastEditedIn: .unknown)
+            public static let DeleteFolderWarningDescription = MZLocalizedString("Bookmarks.DeleteFolderWarning.Description", tableName: "BookmarkPanelDeleteConfirm", value: "Are you sure you want to delete it and its contents?", comment: "Main body of the confirmation alert when the user tries to delete a folder that still contains bookmarks and/or folders.", lastEditedIn: .unknown)
+            public static let DeleteFolderCancelButtonLabel = MZLocalizedString("Bookmarks.DeleteFolderWarning.CancelButton.Label", tableName: "BookmarkPanelDeleteConfirm", value: "Cancel", comment: "Button label to cancel deletion when the user tried to delete a non-empty folder.", lastEditedIn: .unknown)
+            public static let DeleteFolderDeleteButtonLabel = MZLocalizedString("Bookmarks.DeleteFolderWarning.DeleteButton.Label", tableName: "BookmarkPanelDeleteConfirm", value: "Delete", comment: "Button label for the button that deletes a folder and all of its children.", lastEditedIn: .unknown)
+            public static let PanelDeleteTableAction = MZLocalizedString("Delete", tableName: "BookmarkPanel", comment: "Action button for deleting bookmarks in the bookmarks panel.", lastEditedIn: .unknown)
+            public static let DetailFieldTitle = MZLocalizedString("Bookmark.DetailFieldTitle.Label", value: "Title", comment: "The label for the Title field when editing a bookmark", lastEditedIn: .unknown)
+            public static let DetailFieldURL = MZLocalizedString("Bookmark.DetailFieldURL.Label", value: "URL", comment: "The label for the URL field when editing a bookmark", lastEditedIn: .unknown)
+        }
+    }
+
 }
 
-// MARK: - Error pages
+// MARK: - BrowserViewController
 extension String {
-    public static let ErrorPagesAdvancedButton = MZLocalizedString("ErrorPages.Advanced.Button", value: "Advanced", comment: "Label for button to perform advanced actions on the error page", lastEditedIn: .unknown)
-    public static let ErrorPagesAdvancedWarning1 = MZLocalizedString("ErrorPages.AdvancedWarning1.Text", value: "Warning: we can’t confirm your connection to this website is secure.", comment: "Warning text when clicking the Advanced button on error pages", lastEditedIn: .unknown)
-    public static let ErrorPagesAdvancedWarning2 = MZLocalizedString("ErrorPages.AdvancedWarning2.Text", value: "It may be a misconfiguration or tampering by an attacker. Proceed if you accept the potential risk.", comment: "Additional warning text when clicking the Advanced button on error pages", lastEditedIn: .unknown)
-    public static let ErrorPagesCertWarningDescription = MZLocalizedString("ErrorPages.CertWarning.Description", value: "The owner of %@ has configured their website improperly. To protect your information from being stolen, Firefox has not connected to this website.", comment: "Warning text on the certificate error page", lastEditedIn: .unknown)
-    public static let ErrorPagesCertWarningTitle = MZLocalizedString("ErrorPages.CertWarning.Title", value: "This Connection is Untrusted", comment: "Title on the certificate error page", lastEditedIn: .unknown)
-    public static let ErrorPagesGoBackButton = MZLocalizedString("ErrorPages.GoBack.Button", value: "Go Back", comment: "Label for button to go back from the error page", lastEditedIn: .unknown)
-    public static let ErrorPagesVisitOnceButton = MZLocalizedString("ErrorPages.VisitOnce.Button", value: "Visit site anyway", comment: "Button label to temporarily continue to the site from the certificate error page", lastEditedIn: .unknown)
+    public struct BrowserViewController {
+        public struct ReaderMode {
+            public static let AddPageGeneralErrorAccessibilityLabel = MZLocalizedString("Could not add page to Reading list", comment: "Accessibility message e.g. spoken by VoiceOver after adding current webpage to the Reading List failed.", lastEditedIn: .unknown)
+            public static let AddPageSuccessAcessibilityLabel = MZLocalizedString("Added page to Reading List", comment: "Accessibility message e.g. spoken by VoiceOver after the current page gets added to the Reading List using the Reader View button, e.g. by long-pressing it or by its accessibility custom action.", lastEditedIn: .unknown)
+            public static let AddPageMaybeExistsErrorAccessibilityLabel = MZLocalizedString("Could not add page to Reading List. Maybe it’s already there?", comment: "Accessibility message e.g. spoken by VoiceOver after the user wanted to add current page to the Reading List and this was not done, likely because it already was in the Reading List, but perhaps also because of real failures.", lastEditedIn: .unknown)
+        }
+
+        public static let WebViewAccessibilityLabel = MZLocalizedString("Web content", comment: "Accessibility label for the main web content view", lastEditedIn: .unknown)
+    }
 }
 
-// MARK: - Logins Helper
+// MARK: - C
+// MARK: - Clear recent history action menu
 extension String {
-    public static let LoginsHelperSaveLoginButtonTitle = MZLocalizedString("LoginsHelper.SaveLogin.Button", value: "Save Login", comment: "Button to save the user's password", lastEditedIn: .unknown)
-    public static let LoginsHelperDontSaveButtonTitle = MZLocalizedString("LoginsHelper.DontSave.Button", value: "Don’t Save", comment: "Button to not save the user's password", lastEditedIn: .unknown)
-    public static let LoginsHelperUpdateButtonTitle = MZLocalizedString("LoginsHelper.Update.Button", value: "Update", comment: "Button to update the user's password", lastEditedIn: .unknown)
-    public static let LoginsHelperDontUpdateButtonTitle = MZLocalizedString("LoginsHelper.DontUpdate.Button", value: "Don’t Update", comment: "Button to not update the user's password", lastEditedIn: .unknown)
+    public struct ClearHistoryMenu {
+        public static let Title = MZLocalizedString("HistoryPanel.ClearHistoryMenuTitle", value: "Clearing Recent History will remove history, cookies, and other browser data.", comment: "Title for popup action menu to clear recent history.", lastEditedIn: .unknown)
+        public static let OptionTheLastHour = MZLocalizedString("HistoryPanel.ClearHistoryMenuOptionTheLastHour", value: "The Last Hour", comment: "Button to perform action to clear history for the last hour", lastEditedIn: .unknown)
+        public static let OptionToday = MZLocalizedString("HistoryPanel.ClearHistoryMenuOptionToday", value: "Today", comment: "Button to perform action to clear history for today only", lastEditedIn: .unknown)
+        public static let OptionTodayAndYesterday = MZLocalizedString("HistoryPanel.ClearHistoryMenuOptionTodayAndYesterday", value: "Today and Yesterday", comment: "Button to perform action to clear history for yesterday and today", lastEditedIn: .unknown)
+        public static let OptionEverything = MZLocalizedString("HistoryPanel.ClearHistoryMenuOptionEverything", value: "Everything", comment: "Option title to clear all browsing history.", lastEditedIn: .unknown)
+    }
+}
+
+// MARK: - Clipboard Toast
+extension String {
+    public struct Clipboard {
+        public struct Toast {
+            public static let GoToCopiedLink = MZLocalizedString("ClipboardToast.GoToCopiedLink.Title", value: "Go to copied link?", comment: "Message displayed when the user has a copied link on the clipboard", lastEditedIn: .unknown)
+            public static let GoButtonTittle = MZLocalizedString("ClipboardToast.GoToCopiedLink.Button", value: "Go", comment: "The button to open a new tab with the copied link", lastEditedIn: .unknown)
+        }
+
+    }
+
+}
+
+// MARK: - Credential Provider
+extension String {
+    struct CredetntialProvider {
+        public static let LoginsWelcomeViewTitle = MZLocalizedString("Logins.WelcomeView.Title", value: "Take your passwords everywhere", comment: "Label displaying welcome view title", lastEditedIn: .unknown)
+        public static let LoginsListSearchCancel = MZLocalizedString("LoginsList.Search.Cancel", value: "Cancel", comment: "Cancel button title", lastEditedIn: .unknown)
+        public static let LoginsListSearchPlaceholder = MZLocalizedString("LoginsList.Search.Placeholder", value: "Search logins", comment: "Placeholder text for search field", lastEditedIn: .unknown)
+        public static let LoginsListSelectPasswordTitle = MZLocalizedString("LoginsList.SelectPassword.Title", value: "Select a password to fill", comment: "Label displaying select a password to fill instruction", lastEditedIn: .unknown)
+        public static let LoginsListNoMatchingResultTitle = MZLocalizedString("LoginsList.NoMatchingResult.Title", value: "No matching logins", comment: "Label displayed when a user searches and no matches can be found against the search query", lastEditedIn: .unknown)
+        public static let LoginsListNoMatchingResultSubtitle = MZLocalizedString("LoginsList.NoMatchingResult.Subtitle", value: "There are no results matching your search.", comment: "Label that appears after the search if there are no logins matching the search", lastEditedIn: .unknown)
+        public static let LoginsListNoLoginsFoundDescription = MZLocalizedString("LoginsList.NoLoginsFound.Description", value: "Saved logins will show up here. If you saved your logins to Firefox on a different device, sign in to your Firefox Account.", comment: "Label shown when there are no logins to list", lastEditedIn: .unknown)
+    }
+}
+
+// MARK: - Context menu ButtonToast instances.
+extension String {
+    public static let ContextMenuButtonToastNewTabOpenedLabelText = MZLocalizedString("ContextMenu.ButtonToast.NewTabOpened.LabelText", value: "New Tab opened", comment: "The label text in the Button Toast for switching to a fresh New Tab.", lastEditedIn: .unknown)
+    public static let ContextMenuButtonToastNewTabOpenedButtonText = MZLocalizedString("ContextMenu.ButtonToast.NewTabOpened.ButtonText", value: "Switch", comment: "The button text in the Button Toast for switching to a fresh New Tab.", lastEditedIn: .unknown)
+    public static let ContextMenuButtonToastNewPrivateTabOpenedLabelText = MZLocalizedString("ContextMenu.ButtonToast.NewPrivateTabOpened.LabelText", value: "New Private Tab opened", comment: "The label text in the Button Toast for switching to a fresh New Private Tab.", lastEditedIn: .unknown)
+    public static let ContextMenuButtonToastNewPrivateTabOpenedButtonText = MZLocalizedString("ContextMenu.ButtonToast.NewPrivateTabOpened.ButtonText", value: "Switch", comment: "The button text in the Button Toast for switching to a fresh New Private Tab.", lastEditedIn: .unknown)
+}
+
+// MARK: - Cover Sheet
+extension String {
+    // Dark Mode Cover Sheet
+    public static let CoverSheetV22DarkModeTitle = MZLocalizedString("CoverSheet.v22.DarkMode.Title", value: "Dark theme now includes a dark keyboard and dark splash screen.", comment: "Title for the new dark mode change in the version 22 app release.", lastEditedIn: .unknown)
+    public static let CoverSheetV22DarkModeDescription = MZLocalizedString("CoverSheet.v22.DarkMode.Description", value: "For iOS 13 users, Firefox now automatically switches to a dark theme when your phone is set to Dark Mode. To change this behavior, go to Settings > Theme.", comment: "Description for the new dark mode change in the version 22 app release. It describes the new automatic dark theme and how to change the theme settings.", lastEditedIn: .unknown)
+
+    // ETP Cover Sheet
+    public static let CoverSheetETPTitle = MZLocalizedString("CoverSheet.v24.ETP.Title", value: "Protection Against Ad Tracking", comment: "Title for the new ETP mode i.e. standard vs strict", lastEditedIn: .unknown)
+    public static let CoverSheetETPDescription = MZLocalizedString("CoverSheet.v24.ETP.Description", value: "Built-in Enhanced Tracking Protection helps stop ads from following you around. Turn on Strict to block even more trackers, ads, and popups. ", comment: "Description for the new ETP mode i.e. standard vs strict", lastEditedIn: .unknown)
+    public static let CoverSheetETPSettingsButton = MZLocalizedString("CoverSheet.v24.ETP.Settings.Button", value: "Go to Settings", comment: "Text for the new ETP settings button", lastEditedIn: .unknown)
+}
+
+// MARK: - Clearables
+extension String {
+    // Removed Clearables as part of Bug 1226654, but keeping the string around.
+    private static let removedSavedLoginsLabel = MZLocalizedString("Saved Logins", tableName: "ClearPrivateData", comment: "Settings item for clearing passwords and login data", lastEditedIn: .unknown)
+
+    public static let ClearableHistory = MZLocalizedString("Browsing History", tableName: "ClearPrivateData", comment: "Settings item for clearing browsing history", lastEditedIn: .unknown)
+    public static let ClearableCache = MZLocalizedString("Cache", tableName: "ClearPrivateData", comment: "Settings item for clearing the cache", lastEditedIn: .unknown)
+    public static let ClearableOfflineData = MZLocalizedString("Offline Website Data", tableName: "ClearPrivateData", comment: "Settings item for clearing website data", lastEditedIn: .unknown)
+    public static let ClearableCookies = MZLocalizedString("Cookies", tableName: "ClearPrivateData", comment: "Settings item for clearing cookies", lastEditedIn: .unknown)
+    public static let ClearableDownloads = MZLocalizedString("Downloaded Files", tableName: "ClearPrivateData", comment: "Settings item for deleting downloaded files", lastEditedIn: .unknown)
+}
+
+// MARK: - D
+// MARK: - DeviceInfo
+extension String {
+    public struct DeviceInfo {
+        public static let ClientNameDescription = MZLocalizedString("%@ on %@", tableName: "Shared", comment: "A brief descriptive name for this app on this device, used for Send Tab and Synced Tabs. The first argument is the app name. The second argument is the device name.", lastEditedIn: .unknown)
+    }
 }
 
 // MARK: - Downloads Panel
@@ -173,70 +344,107 @@ extension String {
     public static let DownloadsPanelShareTitle = MZLocalizedString("DownloadsPanel.Share.Title", value: "Share", comment: "Action button for sharing downloaded files in the Downloads panel.", lastEditedIn: .unknown)
 }
 
-// MARK: - History Panel
+// MARK: - Download Helper
 extension String {
-    public static let SyncedTabsTableViewCellTitle = MZLocalizedString("HistoryPanel.SyncedTabsCell.Title", value: "Synced Devices", comment: "Title for the Synced Tabs Cell in the History Panel", lastEditedIn: .unknown)
-    public static let HistoryBackButtonTitle = MZLocalizedString("HistoryPanel.HistoryBackButton.Title", value: "History", comment: "Title for the Back to History button in the History Panel", lastEditedIn: .unknown)
-    public static let EmptySyncedTabsPanelStateTitle = MZLocalizedString("HistoryPanel.EmptySyncedTabsState.Title", value: "Firefox Sync", comment: "Title for the empty synced tabs state in the History Panel", lastEditedIn: .unknown)
-    public static let EmptySyncedTabsPanelNotSignedInStateDescription = MZLocalizedString("HistoryPanel.EmptySyncedTabsPanelNotSignedInState.Description", value: "Sign in to view a list of tabs from your other devices.", comment: "Description for the empty synced tabs 'not signed in' state in the History Panel", lastEditedIn: .unknown)
-    public static let EmptySyncedTabsPanelNotYetVerifiedStateDescription = MZLocalizedString("HistoryPanel.EmptySyncedTabsPanelNotYetVerifiedState.Description", value: "Your account needs to be verified.", comment: "Description for the empty synced tabs 'not yet verified' state in the History Panel", lastEditedIn: .unknown)
-    public static let EmptySyncedTabsPanelSingleDeviceSyncStateDescription = MZLocalizedString("HistoryPanel.EmptySyncedTabsPanelSingleDeviceSyncState.Description", value: "Want to see your tabs from other devices here?", comment: "Description for the empty synced tabs 'single device Sync' state in the History Panel", lastEditedIn: .unknown)
-    public static let EmptySyncedTabsPanelTabSyncDisabledStateDescription = MZLocalizedString("HistoryPanel.EmptySyncedTabsPanelTabSyncDisabledState.Description", value: "Turn on tab syncing to view a list of tabs from your other devices.", comment: "Description for the empty synced tabs 'tab sync disabled' state in the History Panel", lastEditedIn: .unknown)
-    public static let EmptySyncedTabsPanelNullStateDescription = MZLocalizedString("HistoryPanel.EmptySyncedTabsNullState.Description", value: "Your tabs from other devices show up here.", comment: "Description for the empty synced tabs null state in the History Panel", lastEditedIn: .unknown)
-    public static let SyncedTabsTableViewCellDescription = MZLocalizedString("HistoryPanel.SyncedTabsCell.Description.Pluralized", value: "%d device(s) connected", comment: "Description that corresponds with a number of devices connected for the Synced Tabs Cell in the History Panel", lastEditedIn: .unknown)
-    public static let HistoryPanelEmptyStateTitle = MZLocalizedString("HistoryPanel.EmptyState.Title", value: "Websites you’ve visited recently will show up here.", comment: "Title for the History Panel empty state.", lastEditedIn: .unknown)
-    public static let RecentlyClosedTabsButtonTitle = MZLocalizedString("HistoryPanel.RecentlyClosedTabsButton.Title", value: "Recently Closed", comment: "Title for the Recently Closed button in the History Panel", lastEditedIn: .unknown)
-    public static let RecentlyClosedTabsPanelTitle = MZLocalizedString("RecentlyClosedTabsPanel.Title", value: "Recently Closed", comment: "Title for the Recently Closed Tabs Panel", lastEditedIn: .unknown)
-    public static let HistoryPanelClearHistoryButtonTitle = MZLocalizedString("HistoryPanel.ClearHistoryButtonTitle", value: "Clear Recent History…", comment: "Title for button in the history panel to clear recent history", lastEditedIn: .unknown)
-    public static let FirefoxHomePage = MZLocalizedString("Firefox.HomePage.Title", value: "Firefox Home Page", comment: "Title for firefox about:home page in tab history list", lastEditedIn: .unknown)
-    public static let HistoryPanelDelete = MZLocalizedString("Delete", tableName: "HistoryPanel", comment: "Action button for deleting history entries in the history panel.", lastEditedIn: .unknown)
+    public static let OpenInDownloadHelperAlertDownloadNow = MZLocalizedString("Downloads.Alert.DownloadNow", value: "Download Now", comment: "The label of the button the user will press to start downloading a file", lastEditedIn: .unknown)
+    public static let DownloadsButtonTitle = MZLocalizedString("Downloads.Toast.GoToDownloads.Button", value: "Downloads", comment: "The button to open a new tab with the Downloads home panel", lastEditedIn: .unknown)
+    public static let CancelDownloadDialogTitle = MZLocalizedString("Downloads.CancelDialog.Title", value: "Cancel Download", comment: "Alert dialog title when the user taps the cancel download icon.", lastEditedIn: .unknown)
+    public static let CancelDownloadDialogMessage = MZLocalizedString("Downloads.CancelDialog.Message", value: "Are you sure you want to cancel this download?", comment: "Alert dialog body when the user taps the cancel download icon.", lastEditedIn: .unknown)
+    public static let CancelDownloadDialogResume = MZLocalizedString("Downloads.CancelDialog.Resume", value: "Resume", comment: "Button declining the cancellation of the download.", lastEditedIn: .unknown)
+    public static let CancelDownloadDialogCancel = MZLocalizedString("Downloads.CancelDialog.Cancel", value: "Cancel", comment: "Button confirming the cancellation of the download.", lastEditedIn: .unknown)
+    public static let DownloadCancelledToastLabelText = MZLocalizedString("Downloads.Toast.Cancelled.LabelText", value: "Download Cancelled", comment: "The label text in the Download Cancelled toast for showing confirmation that the download was cancelled.", lastEditedIn: .unknown)
+    public static let DownloadFailedToastLabelText = MZLocalizedString("Downloads.Toast.Failed.LabelText", value: "Download Failed", comment: "The label text in the Download Failed toast for showing confirmation that the download has failed.", lastEditedIn: .unknown)
+    public static let DownloadFailedToastButtonTitled = MZLocalizedString("Downloads.Toast.Failed.RetryButton", value: "Retry", comment: "The button to retry a failed download from the Download Failed toast.", lastEditedIn: .unknown)
+    public static let DownloadMultipleFilesToastDescriptionText = MZLocalizedString("Downloads.Toast.MultipleFiles.DescriptionText", value: "1 of %d files", comment: "The description text in the Download progress toast for showing the number of files when multiple files are downloading.", lastEditedIn: .unknown)
+    public static let DownloadProgressToastDescriptionText = MZLocalizedString("Downloads.Toast.Progress.DescriptionText", value: "%1$@/%2$@", comment: "The description text in the Download progress toast for showing the downloaded file size (1$) out of the total expected file size (2$).", lastEditedIn: .unknown)
+    public static let DownloadMultipleFilesAndProgressToastDescriptionText = MZLocalizedString("Downloads.Toast.MultipleFilesAndProgress.DescriptionText", value: "%1$@ %2$@", comment: "The description text in the Download progress toast for showing the number of files (1$) and download progress (2$). This string only consists of two placeholders for purposes of displaying two other strings side-by-side where 1$ is Downloads.Toast.MultipleFiles.DescriptionText and 2$ is Downloads.Toast.Progress.DescriptionText. This string should only consist of the two placeholders side-by-side separated by a single space and 1$ should come before 2$ everywhere except for right-to-left locales.", lastEditedIn: .unknown)
 }
 
-// MARK: - Clear recent history action menu
+// MARK: - Do not track
 extension String {
-    public static let ClearHistoryMenuTitle = MZLocalizedString("HistoryPanel.ClearHistoryMenuTitle", value: "Clearing Recent History will remove history, cookies, and other browser data.", comment: "Title for popup action menu to clear recent history.", lastEditedIn: .unknown)
-    public static let ClearHistoryMenuOptionTheLastHour = MZLocalizedString("HistoryPanel.ClearHistoryMenuOptionTheLastHour", value: "The Last Hour", comment: "Button to perform action to clear history for the last hour", lastEditedIn: .unknown)
-    public static let ClearHistoryMenuOptionToday = MZLocalizedString("HistoryPanel.ClearHistoryMenuOptionToday", value: "Today", comment: "Button to perform action to clear history for today only", lastEditedIn: .unknown)
-    public static let ClearHistoryMenuOptionTodayAndYesterday = MZLocalizedString("HistoryPanel.ClearHistoryMenuOptionTodayAndYesterday", value: "Today and Yesterday", comment: "Button to perform action to clear history for yesterday and today", lastEditedIn: .unknown)
-    public static let ClearHistoryMenuOptionEverything = MZLocalizedString("HistoryPanel.ClearHistoryMenuOptionEverything", value: "Everything", comment: "Option title to clear all browsing history.", lastEditedIn: .unknown)
+    public static let SettingsDoNotTrackTitle = MZLocalizedString("Settings.DNT.Title", value: "Send websites a Do Not Track signal that you don’t want to be tracked", comment: "DNT Settings title", lastEditedIn: .unknown)
+    public static let SettingsDoNotTrackOptionOnWithTP = MZLocalizedString("Settings.DNT.OptionOnWithTP", value: "Only when using Tracking Protection", comment: "DNT Settings option for only turning on when Tracking Protection is also on", lastEditedIn: .unknown)
+    public static let SettingsDoNotTrackOptionAlwaysOn = MZLocalizedString("Settings.DNT.OptionAlwaysOn", value: "Always", comment: "DNT Settings option for always on", lastEditedIn: .unknown)
 }
 
-// MARK: - Syncing
+// MARK: - Display Theme
 extension String {
-    public static let SyncingMessageWithEllipsis = MZLocalizedString("Sync.SyncingEllipsis.Label", value: "Syncing…", comment: "Message displayed when the user's account is syncing with ellipsis at the end", lastEditedIn: .unknown)
-    public static let SyncingMessageWithoutEllipsis = MZLocalizedString("Sync.Syncing.Label", value: "Syncing", comment: "Message displayed when the user's account is syncing with no ellipsis", lastEditedIn: .unknown)
+    public static let SettingsDisplayThemeTitle = MZLocalizedString("Settings.DisplayTheme.Title.v2", value: "Theme", comment: "Title in main app settings for Theme settings", lastEditedIn: .unknown)
+    public static let DisplayThemeBrightnessThresholdSectionHeader = MZLocalizedString("Settings.DisplayTheme.BrightnessThreshold.SectionHeader", value: "Threshold", comment: "Section header for brightness slider.", lastEditedIn: .unknown)
+    public static let DisplayThemeSectionFooter = MZLocalizedString("Settings.DisplayTheme.SectionFooter", value: "The theme will automatically change based on your display brightness. You can set the threshold where the theme changes. The circle indicates your display's current brightness.", comment: "Display (theme) settings footer describing how the brightness slider works.", lastEditedIn: .unknown)
+    public static let SystemThemeSectionHeader = MZLocalizedString("Settings.DisplayTheme.SystemTheme.SectionHeader", value: "System Theme", comment: "System theme settings section title", lastEditedIn: .unknown)
+    public static let SystemThemeSectionSwitchTitle = MZLocalizedString("Settings.DisplayTheme.SystemTheme.SwitchTitle", value: "Use System Light/Dark Mode", comment: "System theme settings switch to choose whether to use the same theme as the system", lastEditedIn: .unknown)
+    public static let ThemeSwitchModeSectionHeader = MZLocalizedString("Settings.DisplayTheme.SwitchMode.SectionHeader", value: "Switch Mode", comment: "Switch mode settings section title", lastEditedIn: .unknown)
+    public static let ThemePickerSectionHeader = MZLocalizedString("Settings.DisplayTheme.ThemePicker.SectionHeader", value: "Theme Picker", comment: "Theme picker settings section title", lastEditedIn: .unknown)
+    public static let DisplayThemeAutomaticSwitchTitle = MZLocalizedString("Settings.DisplayTheme.SwitchTitle", value: "Automatically", comment: "Display (theme) settings switch to choose whether to set the dark mode manually, or automatically based on the brightness slider.", lastEditedIn: .unknown)
+    public static let DisplayThemeAutomaticStatusLabel = MZLocalizedString("Settings.DisplayTheme.SwitchTitle", value: "Automatic", comment: "Display (theme) settings label to show if automatically switch theme is enabled.", lastEditedIn: .unknown)
+    public static let DisplayThemeAutomaticSwitchSubtitle = MZLocalizedString("Settings.DisplayTheme.SwitchSubtitle", value: "Switch automatically based on screen brightness", comment: "Display (theme) settings switch subtitle, explaining the title 'Automatically'.", lastEditedIn: .unknown)
+    public static let DisplayThemeManualSwitchTitle = MZLocalizedString("Settings.DisplayTheme.Manual.SwitchTitle", value: "Manually", comment: "Display (theme) setting to choose the theme manually.", lastEditedIn: .unknown)
+    public static let DisplayThemeManualSwitchSubtitle = MZLocalizedString("Settings.DisplayTheme.Manual.SwitchSubtitle", value: "Pick which theme you want", comment: "Display (theme) settings switch subtitle, explaining the title 'Manually'.", lastEditedIn: .unknown)
+    public static let DisplayThemeManualStatusLabel = MZLocalizedString("Settings.DisplayTheme.Manual.StatusLabel", value: "Manual", comment: "Display (theme) settings label to show if manually switch theme is enabled.", lastEditedIn: .unknown)
+    public static let DisplayThemeOptionLight = MZLocalizedString("Settings.DisplayTheme.OptionLight", value: "Light", comment: "Option choice in display theme settings for light theme", lastEditedIn: .unknown)
+    public static let DisplayThemeOptionDark = MZLocalizedString("Settings.DisplayTheme.OptionDark", value: "Dark", comment: "Option choice in display theme settings for dark theme", lastEditedIn: .unknown)
+}
 
-    public static let FirstTimeSyncLongTime = MZLocalizedString("Sync.FirstTimeMessage.Label", value: "Your first sync may take a while", comment: "Message displayed when the user syncs for the first time", lastEditedIn: .unknown)
+// MARK: - Default Browser
+extension String {
+    public static let DefaultBrowserCardTitle = MZLocalizedString("DefaultBrowserCard.Title", tableName: "Default Browser", value: "Switch Your Default Browser", comment: "Title for small card shown that allows user to switch their default browser to Firefox.", lastEditedIn: .unknown)
+    public static let DefaultBrowserCardDescription = MZLocalizedString("DefaultBrowserCard.Description", tableName: "Default Browser", value: "Set links from websites, emails, and Messages to open automatically in Firefox.", comment: "Description for small card shown that allows user to switch their default browser to Firefox.", lastEditedIn: .unknown)
+    public static let DefaultBrowserCardButton = MZLocalizedString("DefaultBrowserCard.Button.v2", tableName: "Default Browser", value: "Learn How", comment: "Button string to learn how to set your default browser.", lastEditedIn: .unknown)
+    public static let DefaultBrowserMenuItem = MZLocalizedString("Settings.DefaultBrowserMenuItem", tableName: "Default Browser", value: "Set as Default Browser", comment: "Menu option for setting Firefox as default browser.", lastEditedIn: .unknown)
+    public static let DefaultBrowserOnboardingScreenshot = MZLocalizedString("DefaultBrowserOnboarding.Screenshot", tableName: "Default Browser", value: "Default Browser App", comment: "Text for the screenshot of the iOS system settings page for Firefox.", lastEditedIn: .unknown)
+    public static let DefaultBrowserOnboardingDescriptionStep1 = MZLocalizedString("DefaultBrowserOnboarding.Description1", tableName: "Default Browser", value: "1. Go to Settings", comment: "Description for default browser onboarding card.", lastEditedIn: .unknown)
+    public static let DefaultBrowserOnboardingDescriptionStep2 = MZLocalizedString("DefaultBrowserOnboarding.Description2", tableName: "Default Browser", value: "2. Tap Default Browser App", comment: "Description for default browser onboarding card.", lastEditedIn: .unknown)
+    public static let DefaultBrowserOnboardingDescriptionStep3 = MZLocalizedString("DefaultBrowserOnboarding.Description3", tableName: "Default Browser", value: "3. Select Firefox", comment: "Description for default browser onboarding card.", lastEditedIn: .unknown)
+    public static let DefaultBrowserOnboardingButton = MZLocalizedString("DefaultBrowserOnboarding.Button", tableName: "Default Browser", value: "Go to Settings", comment: "Button string to open settings that allows user to switch their default browser to Firefox.", lastEditedIn: .unknown)
+}
 
-    public static let FirefoxSyncOfflineTitle = MZLocalizedString("SyncState.Offline.Title", value: "Sync is offline", comment: "Title for Sync status message when Sync failed due to being offline", lastEditedIn: .unknown)
-    public static let FirefoxSyncNotStartedTitle = MZLocalizedString("SyncState.NotStarted.Title", value: "Sync is unavailable", comment: "Title for Sync status message when Sync failed to start.", lastEditedIn: .unknown)
-    public static let FirefoxSyncPartialTitle = MZLocalizedString("SyncState.Partial.Title", value: "Sync is experiencing issues syncing %@", comment: "Title for Sync status message when a component of Sync failed to complete, where %@ represents the name of the component, i.e. Sync is experiencing issues syncing Bookmarks", lastEditedIn: .unknown)
-    public static let FirefoxSyncFailedTitle = MZLocalizedString("SyncState.Failed.Title", value: "Syncing has failed", comment: "Title for Sync status message when synchronization failed to complete", lastEditedIn: .unknown)
-    public static let FirefoxSyncTroubleshootTitle = MZLocalizedString("Settings.TroubleShootSync.Title", value: "Troubleshoot", comment: "Title of link to help page to find out how to solve Sync issues", lastEditedIn: .unknown)
-    public static let FirefoxSyncCreateAccount = MZLocalizedString("Sync.NoAccount.Description", value: "No account? Create one to sync Firefox between devices.", comment: "String displayed on Sign In to Sync page that allows the user to create a new account.", lastEditedIn: .unknown)
-
-    public static let FirefoxSyncBookmarksEngine = MZLocalizedString("Bookmarks", comment: "Toggle bookmarks syncing setting", lastEditedIn: .unknown)
-    public static let FirefoxSyncHistoryEngine = MZLocalizedString("History", comment: "Toggle history syncing setting", lastEditedIn: .unknown)
-    public static let FirefoxSyncTabsEngine = MZLocalizedString("Open Tabs", comment: "Toggle tabs syncing setting", lastEditedIn: .unknown)
-    public static let FirefoxSyncLoginsEngine = MZLocalizedString("Logins", comment: "Toggle logins syncing setting", lastEditedIn: .unknown)
-
-    public static func localizedStringForSyncComponent(_ componentName: String) -> String? {
-        switch componentName {
-        case "bookmarks":
-            return MZLocalizedString("SyncState.Bookmark.Title", value: "Bookmarks", comment: "The Bookmark sync component, used in SyncState.Partial.Title", lastEditedIn: .unknown)
-        case "clients":
-            return MZLocalizedString("SyncState.Clients.Title", value: "Remote Clients", comment: "The Remote Clients sync component, used in SyncState.Partial.Title", lastEditedIn: .unknown)
-        case "tabs":
-            return MZLocalizedString("SyncState.Tabs.Title", value: "Tabs", comment: "The Tabs sync component, used in SyncState.Partial.Title", lastEditedIn: .unknown)
-        case "logins":
-            return MZLocalizedString("SyncState.Logins.Title", value: "Logins", comment: "The Logins sync component, used in SyncState.Partial.Title", lastEditedIn: .unknown)
-        case "history":
-            return MZLocalizedString("SyncState.History.Title", value: "History", comment: "The History sync component, used in SyncState.Partial.Title", lastEditedIn: .unknown)
-        default: return nil
-        }
+// MARK: - Default Suggested Site
+extension String {
+    public struct DefaultSuggestedSites {
+        public static let Facebook = MZLocalizedString("Facebook", comment: "Tile title for Facebook", lastEditedIn: .unknown)
+        public static let YouTube = MZLocalizedString("YouTube", comment: "Tile title for YouTube", lastEditedIn: .unknown)
+        public static let Amazon = MZLocalizedString("Amazon", comment: "Tile title for Amazon", lastEditedIn: .unknown)
+        public static let Wikipedia = MZLocalizedString("Wikipedia", comment: "Tile title for Wikipedia", lastEditedIn: .unknown)
+        public static let Twitter = MZLocalizedString("Twitter", comment: "Tile title for Twitter", lastEditedIn: .unknown)
     }
 }
 
+// MARK: - E
+// MARK: - Error pages
+extension String {
+    public struct ErrorPages {
+        public static let AdvancedButton = MZLocalizedString("ErrorPages.Advanced.Button", value: "Advanced", comment: "Label for button to perform advanced actions on the error page", lastEditedIn: .unknown)
+        public static let AdvancedWarning1 = MZLocalizedString("ErrorPages.AdvancedWarning1.Text", value: "Warning: we can’t confirm your connection to this website is secure.", comment: "Warning text when clicking the Advanced button on error pages", lastEditedIn: .unknown)
+        public static let AdvancedWarning2 = MZLocalizedString("ErrorPages.AdvancedWarning2.Text", value: "It may be a misconfiguration or tampering by an attacker. Proceed if you accept the potential risk.", comment: "Additional warning text when clicking the Advanced button on error pages", lastEditedIn: .unknown)
+        public static let CertWarningDescription = MZLocalizedString("ErrorPages.CertWarning.Description", value: "The owner of %@ has configured their website improperly. To protect your information from being stolen, Firefox has not connected to this website.", comment: "Warning text on the certificate error page", lastEditedIn: .unknown)
+        public static let CertWarningTitle = MZLocalizedString("ErrorPages.CertWarning.Title", value: "This Connection is Untrusted", comment: "Title on the certificate error page", lastEditedIn: .unknown)
+        public static let GoBackButton = MZLocalizedString("ErrorPages.GoBack.Button", value: "Go Back", comment: "Label for button to go back from the error page", lastEditedIn: .unknown)
+        public static let VisitOnceButton = MZLocalizedString("ErrorPages.VisitOnce.Button", value: "Visit site anyway", comment: "Button label to temporarily continue to the site from the certificate error page", lastEditedIn: .unknown)
+        public static let TryAgain = MZLocalizedString("Try again", tableName: "ErrorPages", comment: "Shown in error pages on a button that will try to load the page again", lastEditedIn: .unknown)
+        public static let OpenInSafari = MZLocalizedString("Open in Safari", tableName: "ErrorPages", comment: "Shown in error pages for files that can't be shown and need to be downloaded.", lastEditedIn: .unknown)
+    }
+}
+
+// MARK: - Errors
+extension String {
+    public static let UnableToDownloadError = MZLocalizedString("Downloads.Error.Message", value: "Downloads aren’t supported in Firefox yet.", comment: "The message displayed to a user when they try and perform the download of an asset that Firefox cannot currently handle.", lastEditedIn: .unknown)
+    public static let UnableToAddPassErrorTitle = MZLocalizedString("AddPass.Error.Title", value: "Failed to Add Pass", comment: "Title of the 'Add Pass Failed' alert. See https://support.apple.com/HT204003 for context on Wallet.", lastEditedIn: .unknown)
+    public static let UnableToAddPassErrorMessage = MZLocalizedString("AddPass.Error.Message", value: "An error occured while adding the pass to Wallet. Please try again later.", comment: "Text of the 'Add Pass Failed' alert.  See https://support.apple.com/HT204003 for context on Wallet.", lastEditedIn: .unknown)
+    public static let UnableToAddPassErrorDismiss = MZLocalizedString("AddPass.Error.Dismiss", value: "OK", comment: "Button to dismiss the 'Add Pass Failed' alert.  See https://support.apple.com/HT204003 for context on Wallet.", lastEditedIn: .unknown)
+    public static let UnableToOpenURLError = MZLocalizedString("OpenURL.Error.Message", value: "Firefox cannot open the page because it has an invalid address.", comment: "The message displayed to a user when they try to open a URL that cannot be handled by Firefox, or any external app.", lastEditedIn: .unknown)
+    public static let UnableToOpenURLErrorTitle = MZLocalizedString("OpenURL.Error.Title", value: "Cannot Open Page", comment: "Title of the message shown when the user attempts to navigate to an invalid link.", lastEditedIn: .unknown)
+}
+
+// MARK: - Empty Private tab view
+extension String {
+    public static let PrivateBrowsingLearnMore = MZLocalizedString("Learn More", tableName: "PrivateBrowsing", comment: "Text button displayed when there are no tabs open while in private mode", lastEditedIn: .unknown)
+    public static let PrivateBrowsingTitle = MZLocalizedString("Private Browsing", tableName: "PrivateBrowsing", comment: "Title displayed for when there are no open tabs while in private mode", lastEditedIn: .unknown)
+    public static let PrivateBrowsingDescription = MZLocalizedString("Firefox won’t remember any of your history or cookies, but new bookmarks will be saved.", tableName: "PrivateBrowsing", comment: "Description text displayed when there are no open tabs while in private mode", lastEditedIn: .unknown)
+}
+
+
+// MARK: - F
 // MARK: - Firefox Logins
 extension String {
     public static let LoginsAndPasswordsTitle = MZLocalizedString("Settings.LoginsAndPasswordsTitle", value: "Logins & Passwords", comment: "Title for the logins and passwords screen. Translation could just use 'Logins' if the title is too long", lastEditedIn: .unknown)
@@ -262,12 +470,6 @@ extension String {
     public static let LoginsDetailViewLoginTitle = MZLocalizedString("LoginsDetailView.LoginTitle", value: "Login", comment: "Title for the login detail view", lastEditedIn: .unknown)
     public static let LoginsDetailViewLoginModified = MZLocalizedString("LoginsDetailView.LoginModified", value: "Modified", comment: "Login detail view field name for the last modified date", lastEditedIn: .unknown)
 
-    // Breach Alerts
-    public static let BreachAlertsTitle = MZLocalizedString("BreachAlerts.Title", value: "Website Breach", comment: "Title for the Breached Login Detail View.", lastEditedIn: .unknown)
-    public static let BreachAlertsLearnMore = MZLocalizedString("BreachAlerts.LearnMoreButton", value: "Learn more", comment: "Link to monitor.firefox.com to learn more about breached passwords", lastEditedIn: .unknown)
-    public static let BreachAlertsBreachDate = MZLocalizedString("BreachAlerts.BreachDate", value: "This breach occurred on", comment: "Describes the date on which the breach occurred", lastEditedIn: .unknown)
-    public static let BreachAlertsDescription = MZLocalizedString("BreachAlerts.Description", value: "Passwords were leaked or stolen since you last changed your password. To protect this account, log in to the site and change your password.", comment: "Description of what a breach is", lastEditedIn: .unknown)
-    public static let BreachAlertsLink = MZLocalizedString("BreachAlerts.Link", value: "Go to", comment: "Leads to a link to the breached website", lastEditedIn: .unknown)
 }
 
 // MARK: - Firefox Account
@@ -299,6 +501,87 @@ extension String {
     public static let FxAAccountUpgradeFirefox = MZLocalizedString("Upgrade Firefox to connect", comment: "Text message in the settings table view", lastEditedIn: .unknown)
 }
 
+// MARK: - FxA Signin screen
+extension String {
+    public struct FirefoxAccount {
+        public struct Push {
+            public struct DeviceDisconnected {
+                public static let ThisDeviceTitle = MZLocalizedString("FxAPush_DeviceDisconnected_ThisDevice_title", value: "Sync Disconnected", comment: "Title of a notification displayed when this device has been disconnected by another device.", lastEditedIn: .unknown)
+                public static let ThisDeviceBody = MZLocalizedString("FxAPush_DeviceDisconnected_ThisDevice_body", value: "This device has been successfully disconnected from Firefox Sync.", comment: "Body of a notification displayed when this device has been disconnected from FxA by another device.", lastEditedIn: .unknown)
+                public static let NamedDeviceTitle = MZLocalizedString("FxAPush_DeviceDisconnected_title", value: "Sync Disconnected", comment: "Title of a notification displayed when named device has been disconnected from FxA.", lastEditedIn: .unknown)
+                public static let NamedDeviceBody = MZLocalizedString("FxAPush_DeviceDisconnected_body", value: "%@ has been successfully disconnected.", comment: "Body of a notification displayed when named device has been disconnected from FxA. %@ refers to the name of the disconnected device.", lastEditedIn: .unknown)
+
+                public static let UnknownDeviceBody = MZLocalizedString("FxAPush_DeviceDisconnected_UnknownDevice_body", value: "A device has disconnected from Firefox Sync", comment: "Body of a notification displayed when unnamed device has been disconnected from FxA.", lastEditedIn: .unknown)
+            }
+
+            public struct DeviceConnected {
+                public static let Title = MZLocalizedString("FxAPush_DeviceConnected_title", value: "Sync Connected", comment: "Title of a notification displayed when another device has connected to FxA.", lastEditedIn: .unknown)
+                public static let Body = MZLocalizedString("FxAPush_DeviceConnected_body", value: "Firefox Sync has connected to %@", comment: "Title of a notification displayed when another device has connected to FxA. %@ refers to the name of the newly connected device.", lastEditedIn: .unknown)
+            }
+        }
+    }
+
+    public struct SignIn {
+
+    }
+
+    public static let FxASignin_Title = MZLocalizedString("fxa.signin.turn-on-sync", value: "Turn on Sync", comment: "FxA sign in view title", lastEditedIn: .unknown)
+    public static let FxASignin_Subtitle = MZLocalizedString("fxa.signin.camera-signin", value: "Sign In with Your Camera", comment: "FxA sign in view subtitle", lastEditedIn: .unknown)
+    public static let FxASignin_QRInstructions = MZLocalizedString("fxa.signin.qr-link-instruction", value: "On your computer open Firefox and go to firefox.com/pair", comment: "FxA sign in view qr code instructions", lastEditedIn: .unknown)
+    public static let FxASignin_QRScanSignin = MZLocalizedString("fxa.signin.ready-to-scan", value: "Ready to Scan", comment: "FxA sign in view qr code scan button", lastEditedIn: .unknown)
+    public static let FxASignin_EmailSignin = MZLocalizedString("fxa.signin.use-email-instead", value: "Use Email Instead", comment: "FxA sign in view email login button", lastEditedIn: .unknown)
+}
+
+// MARK: - FxA QR code scanning screen
+extension String {
+    public static let FxAQRCode_Instructions = MZLocalizedString("fxa.qr-scanning-view.instructions", value: "Scan the QR code shown at firefox.com/pair", comment: "Instructions shown on qr code scanning view", lastEditedIn: .unknown)
+}
+
+// MARK: - FxAWebViewController
+extension String {
+    public static let FxAWebContentAccessibilityLabel = MZLocalizedString("Web content", comment: "Accessibility label for the main web content view", lastEditedIn: .unknown)
+}
+
+// MARK: - Find in page
+extension String {
+    public static let FindInPagePreviousAccessibilityLabel = MZLocalizedString("Previous in-page result", tableName: "FindInPage", comment: "Accessibility label for previous result button in Find in Page Toolbar.", lastEditedIn: .unknown)
+    public static let FindInPageNextAccessibilityLabel = MZLocalizedString("Next in-page result", tableName: "FindInPage", comment: "Accessibility label for next result button in Find in Page Toolbar.", lastEditedIn: .unknown)
+    public static let FindInPageDoneAccessibilityLabel = MZLocalizedString("Done", tableName: "FindInPage", comment: "Done button in Find in Page Toolbar.", lastEditedIn: .unknown)
+}
+
+// MARK: - G
+// MARK: - General
+extension String {
+    public struct General {
+        public static let OKString = MZLocalizedString("OK", comment: "OK button", lastEditedIn: .unknown)
+        public static let CancelString = MZLocalizedString("Cancel", comment: "Label for Cancel button", lastEditedIn: .unknown)
+        public static let NotNowString = MZLocalizedString("Toasts.NotNow", value: "Not Now", comment: "label for Not Now button", lastEditedIn: .unknown)
+        public static let AppStoreString = MZLocalizedString("Toasts.OpenAppStore", value: "Open App Store", comment: "Open App Store button", lastEditedIn: .unknown)
+        public static let UndoString = MZLocalizedString("Toasts.Undo", value: "Undo", comment: "Label for button to undo the action just performed", lastEditedIn: .unknown)
+        public static let OpenSettingsString = MZLocalizedString("Open Settings", comment: "See http://mzl.la/1G7uHo7", lastEditedIn: .unknown)
+    }
+}
+
+// MARK: - H
+// MARK: - History Panel
+extension String {
+    public static let SyncedTabsTableViewCellTitle = MZLocalizedString("HistoryPanel.SyncedTabsCell.Title", value: "Synced Devices", comment: "Title for the Synced Tabs Cell in the History Panel", lastEditedIn: .unknown)
+    public static let HistoryBackButtonTitle = MZLocalizedString("HistoryPanel.HistoryBackButton.Title", value: "History", comment: "Title for the Back to History button in the History Panel", lastEditedIn: .unknown)
+    public static let EmptySyncedTabsPanelStateTitle = MZLocalizedString("HistoryPanel.EmptySyncedTabsState.Title", value: "Firefox Sync", comment: "Title for the empty synced tabs state in the History Panel", lastEditedIn: .unknown)
+    public static let EmptySyncedTabsPanelNotSignedInStateDescription = MZLocalizedString("HistoryPanel.EmptySyncedTabsPanelNotSignedInState.Description", value: "Sign in to view a list of tabs from your other devices.", comment: "Description for the empty synced tabs 'not signed in' state in the History Panel", lastEditedIn: .unknown)
+    public static let EmptySyncedTabsPanelNotYetVerifiedStateDescription = MZLocalizedString("HistoryPanel.EmptySyncedTabsPanelNotYetVerifiedState.Description", value: "Your account needs to be verified.", comment: "Description for the empty synced tabs 'not yet verified' state in the History Panel", lastEditedIn: .unknown)
+    public static let EmptySyncedTabsPanelSingleDeviceSyncStateDescription = MZLocalizedString("HistoryPanel.EmptySyncedTabsPanelSingleDeviceSyncState.Description", value: "Want to see your tabs from other devices here?", comment: "Description for the empty synced tabs 'single device Sync' state in the History Panel", lastEditedIn: .unknown)
+    public static let EmptySyncedTabsPanelTabSyncDisabledStateDescription = MZLocalizedString("HistoryPanel.EmptySyncedTabsPanelTabSyncDisabledState.Description", value: "Turn on tab syncing to view a list of tabs from your other devices.", comment: "Description for the empty synced tabs 'tab sync disabled' state in the History Panel", lastEditedIn: .unknown)
+    public static let EmptySyncedTabsPanelNullStateDescription = MZLocalizedString("HistoryPanel.EmptySyncedTabsNullState.Description", value: "Your tabs from other devices show up here.", comment: "Description for the empty synced tabs null state in the History Panel", lastEditedIn: .unknown)
+    public static let SyncedTabsTableViewCellDescription = MZLocalizedString("HistoryPanel.SyncedTabsCell.Description.Pluralized", value: "%d device(s) connected", comment: "Description that corresponds with a number of devices connected for the Synced Tabs Cell in the History Panel", lastEditedIn: .unknown)
+    public static let HistoryPanelEmptyStateTitle = MZLocalizedString("HistoryPanel.EmptyState.Title", value: "Websites you’ve visited recently will show up here.", comment: "Title for the History Panel empty state.", lastEditedIn: .unknown)
+    public static let RecentlyClosedTabsButtonTitle = MZLocalizedString("HistoryPanel.RecentlyClosedTabsButton.Title", value: "Recently Closed", comment: "Title for the Recently Closed button in the History Panel", lastEditedIn: .unknown)
+    public static let RecentlyClosedTabsPanelTitle = MZLocalizedString("RecentlyClosedTabsPanel.Title", value: "Recently Closed", comment: "Title for the Recently Closed Tabs Panel", lastEditedIn: .unknown)
+    public static let HistoryPanelClearHistoryButtonTitle = MZLocalizedString("HistoryPanel.ClearHistoryButtonTitle", value: "Clear Recent History…", comment: "Title for button in the history panel to clear recent history", lastEditedIn: .unknown)
+    public static let FirefoxHomePage = MZLocalizedString("Firefox.HomePage.Title", value: "Firefox Home Page", comment: "Title for firefox about:home page in tab history list", lastEditedIn: .unknown)
+    public static let HistoryPanelDelete = MZLocalizedString("Delete", tableName: "HistoryPanel", comment: "Action button for deleting history entries in the history panel.", lastEditedIn: .unknown)
+}
+
 // MARK: - Hotkey Titles
 extension String {
     public static let ReloadPageTitle = MZLocalizedString("Hotkeys.Reload.DiscoveryTitle", value: "Reload Page", comment: "Label to display in the Discoverability overlay for keyboard shortcuts", lastEditedIn: .unknown)
@@ -316,6 +599,153 @@ extension String {
     public static let ShowPreviousTabTitle = MZLocalizedString("Hotkeys.ShowPreviousTab.DiscoveryTitle", value: "Show Previous Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts", lastEditedIn: .unknown)
 }
 
+
+// MARK: - Home Panel Context Menu
+extension String {
+    public static let OpenInNewTabContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.OpenInNewTab", value: "Open in New Tab", comment: "The title for the Open in New Tab context menu action for sites in Home Panels", lastEditedIn: .unknown)
+    public static let OpenInNewPrivateTabContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.OpenInNewPrivateTab", value: "Open in New Private Tab", comment: "The title for the Open in New Private Tab context menu action for sites in Home Panels", lastEditedIn: .unknown)
+    public static let BookmarkContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.Bookmark", value: "Bookmark", comment: "The title for the Bookmark context menu action for sites in Home Panels", lastEditedIn: .unknown)
+    public static let RemoveBookmarkContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.RemoveBookmark", value: "Remove Bookmark", comment: "The title for the Remove Bookmark context menu action for sites in Home Panels", lastEditedIn: .unknown)
+    public static let DeleteFromHistoryContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.DeleteFromHistory", value: "Delete from History", comment: "The title for the Delete from History context menu action for sites in Home Panels", lastEditedIn: .unknown)
+    public static let ShareContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.Share", value: "Share", comment: "The title for the Share context menu action for sites in Home Panels", lastEditedIn: .unknown)
+    public static let RemoveContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.Remove", value: "Remove", comment: "The title for the Remove context menu action for sites in Home Panels", lastEditedIn: .unknown)
+    public static let PinTopsiteActionTitle = MZLocalizedString("ActivityStream.ContextMenu.PinTopsite", value: "Pin to Top Sites", comment: "The title for the pinning a topsite action", lastEditedIn: .unknown)
+    public static let PinTopsiteActionTitle2 = MZLocalizedString("ActivityStream.ContextMenu.PinTopsite2", value: "Pin", comment: "The title for the pinning a topsite action", lastEditedIn: .unknown)
+    public static let UnpinTopsiteActionTitle2 = MZLocalizedString("ActivityStream.ContextMenu.UnpinTopsite", value: "Unpin", comment: "The title for the unpinning a topsite action", lastEditedIn: .unknown)
+    public static let AddToShortcutsActionTitle = MZLocalizedString("ActivityStream.ContextMenu.AddToShortcuts", value: "Add to Shortcuts", comment: "The title for the pinning a shortcut action", lastEditedIn: .unknown)
+    public static let RemoveFromShortcutsActionTitle = MZLocalizedString("ActivityStream.ContextMenu.RemoveFromShortcuts", value: "Remove from Shortcuts", comment: "The title for removing a shortcut action", lastEditedIn: .unknown)
+    public static let RemovePinTopsiteActionTitle = MZLocalizedString("ActivityStream.ContextMenu.RemovePinTopsite", value: "Remove Pinned Site", comment: "The title for removing a pinned topsite action", lastEditedIn: .unknown)
+}
+
+
+// MARK: - I
+// MARK: - Intro Onboarding slides
+extension String {
+    // First Card
+    public static let CardTitleWelcome = MZLocalizedString("Intro.Slides.Welcome.Title.v2", tableName: "Intro", value: "Welcome to Firefox", comment: "Title for the first panel 'Welcome' in the First Run tour.", lastEditedIn: .unknown)
+    public static let CardTitleAutomaticPrivacy = MZLocalizedString("Intro.Slides.Automatic.Privacy.Title", tableName: "Intro", value: "Automatic Privacy", comment: "Title for the first item in the table related to automatic privacy", lastEditedIn: .unknown)
+    public static let CardDescriptionAutomaticPrivacy = MZLocalizedString("Intro.Slides.Automatic.Privacy.Description", tableName: "Intro", value: "Enhanced Tracking Protection blocks malware and stops trackers.", comment: "Description for the first item in the table related to automatic privacy", lastEditedIn: .unknown)
+    public static let CardTitleFastSearch = MZLocalizedString("Intro.Slides.Fast.Search.Title", tableName: "Intro", value: "Fast Search", comment: "Title for the second item in the table related to fast searching via address bar", lastEditedIn: .unknown)
+    public static let CardDescriptionFastSearch = MZLocalizedString("Intro.Slides.Fast.Search.Description", tableName: "Intro", value: "Search suggestions get you to websites faster.", comment: "Description for the second item in the table related to fast searching via address bar", lastEditedIn: .unknown)
+    public static let CardTitleSafeSync = MZLocalizedString("Intro.Slides.Safe.Sync.Title", tableName: "Intro", value: "Safe Sync", comment: "Title for the third item in the table related to safe syncing with a firefox account", lastEditedIn: .unknown)
+    public static let CardDescriptionSafeSync = MZLocalizedString("Intro.Slides.Safe.Sync.Description", tableName: "Intro", value: "Protect your logins and data everywhere you use Firefox.", comment: "Description for the third item in the table related to safe syncing with a firefox account", lastEditedIn: .unknown)
+
+    // Second Card
+    public static let CardTitleFxASyncDevices = MZLocalizedString("Intro.Slides.Firefox.Account.Sync.Title", tableName: "Intro", value: "Sync Firefox Between Devices", comment: "Title for the first item in the table related to syncing data (bookmarks, history) via firefox account between devices", lastEditedIn: .unknown)
+    public static let CardDescriptionFxASyncDevices = MZLocalizedString("Intro.Slides.Firefox.Account.Sync.Description", tableName: "Intro", value: "Bring bookmarks, history, and passwords to Firefox on this device.", comment: "Description for the first item in the table related to syncing data (bookmarks, history) via firefox account between devices", lastEditedIn: .unknown)
+
+    //----Other----//
+    public static let CardTitleSearch = MZLocalizedString("Intro.Slides.Search.Title", tableName: "Intro", value: "Your search, your way", comment: "Title for the second  panel 'Search' in the First Run tour.", lastEditedIn: .unknown)
+    public static let CardTitlePrivate = MZLocalizedString("Intro.Slides.Private.Title", tableName: "Intro", value: "Browse like no one’s watching", comment: "Title for the third panel 'Private Browsing' in the First Run tour.", lastEditedIn: .unknown)
+    public static let CardTitleMail = MZLocalizedString("Intro.Slides.Mail.Title", tableName: "Intro", value: "You’ve got mail… options", comment: "Title for the fourth panel 'Mail' in the First Run tour.", lastEditedIn: .unknown)
+    public static let CardTitleSync = MZLocalizedString("Intro.Slides.TrailheadSync.Title.v2", tableName: "Intro", value: "Sync your bookmarks, history, and passwords to your phone.", comment: "Title for the second panel 'Sync' in the First Run tour.", lastEditedIn: .unknown)
+
+    public static let CardTextWelcome = MZLocalizedString("Intro.Slides.Welcome.Description.v2", tableName: "Intro", value: "Fast, private, and on your side.", comment: "Description for the 'Welcome' panel in the First Run tour.", lastEditedIn: .unknown)
+    public static let CardTextSearch = MZLocalizedString("Intro.Slides.Search.Description", tableName: "Intro", value: "Searching for something different? Choose another default search engine (or add your own) in Settings.", comment: "Description for the 'Favorite Search Engine' panel in the First Run tour.", lastEditedIn: .unknown)
+    public static let CardTextPrivate = MZLocalizedString("Intro.Slides.Private.Description", tableName: "Intro", value: "Tap the mask icon to slip into Private Browsing mode.", comment: "Description for the 'Private Browsing' panel in the First Run tour.", lastEditedIn: .unknown)
+    public static let CardTextMail = MZLocalizedString("Intro.Slides.Mail.Description", tableName: "Intro", value: "Use any email app — not just Mail — with Firefox.", comment: "Description for the 'Mail' panel in the First Run tour.", lastEditedIn: .unknown)
+    public static let CardTextSync = MZLocalizedString("Intro.Slides.TrailheadSync.Description", tableName: "Intro", value: "Sign in to your account to sync and access more features.", comment: "Description for the 'Sync' panel in the First Run tour.", lastEditedIn: .unknown)
+    public static let SignInButtonTitle = MZLocalizedString("Turn on Sync…", tableName: "Intro", comment: "The button that opens the sign in page for sync. See http://mzl.la/1T8gxwo", lastEditedIn: .unknown)
+    public static let StartBrowsingButtonTitle = MZLocalizedString("Start Browsing", tableName: "Intro", comment: "See http://mzl.la/1T8gxwo", lastEditedIn: .unknown)
+    public static let IntroNextButtonTitle = MZLocalizedString("Intro.Slides.Button.Next", tableName: "Intro", value: "Next", comment: "Next button on the first intro screen.", lastEditedIn: .unknown)
+    public static let IntroSignInButtonTitle = MZLocalizedString("Intro.Slides.Button.SignIn", tableName: "Intro", value: "Sign In", comment: "Sign in to Firefox account button on second intro screen.", lastEditedIn: .unknown)
+    public static let IntroSignUpButtonTitle = MZLocalizedString("Intro.Slides.Button.SignUp", tableName: "Intro", value: "Sign Up", comment: "Sign up to Firefox account button on second intro screen.", lastEditedIn: .unknown)
+}
+
+// MARK: - J
+
+// MARK: - K
+// MARK: - Keyboard short cuts
+extension String {
+    public static let ShowTabTrayFromTabKeyCodeTitle = MZLocalizedString("Tab.ShowTabTray.KeyCodeTitle", value: "Show All Tabs", comment: "Hardware shortcut to open the tab tray from a tab. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
+    public static let CloseTabFromTabTrayKeyCodeTitle = MZLocalizedString("TabTray.CloseTab.KeyCodeTitle", value: "Close Selected Tab", comment: "Hardware shortcut to close the selected tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
+    public static let CloseAllTabsFromTabTrayKeyCodeTitle = MZLocalizedString("TabTray.CloseAllTabs.KeyCodeTitle", value: "Close All Tabs", comment: "Hardware shortcut to close all tabs from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
+    public static let OpenSelectedTabFromTabTrayKeyCodeTitle = MZLocalizedString("TabTray.OpenSelectedTab.KeyCodeTitle", value: "Open Selected Tab", comment: "Hardware shortcut open the selected tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
+    public static let OpenNewTabFromTabTrayKeyCodeTitle = MZLocalizedString("TabTray.OpenNewTab.KeyCodeTitle", value: "Open New Tab", comment: "Hardware shortcut to open a new tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
+    public static let ReopenClosedTabKeyCodeTitle = MZLocalizedString("ReopenClosedTab.KeyCodeTitle", value: "Reopen Closed Tab", comment: "Hardware shortcut to reopen the last closed tab, from the tab or the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
+    public static let SwitchToPBMKeyCodeTitle = MZLocalizedString("SwitchToPBM.KeyCodeTitle", value: "Private Browsing Mode", comment: "Hardware shortcut switch to the private browsing tab or tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
+    public static let SwitchToNonPBMKeyCodeTitle = MZLocalizedString("SwitchToNonPBM.KeyCodeTitle", value: "Normal Browsing Mode", comment: "Hardware shortcut for non-private tab or tab. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
+}
+
+
+// MARK: - L
+// MARK: - Logins Helper
+extension String {
+    public static let LoginsHelperSaveLoginButtonTitle = MZLocalizedString("LoginsHelper.SaveLogin.Button", value: "Save Login", comment: "Button to save the user's password", lastEditedIn: .unknown)
+    public static let LoginsHelperDontSaveButtonTitle = MZLocalizedString("LoginsHelper.DontSave.Button", value: "Don’t Save", comment: "Button to not save the user's password", lastEditedIn: .unknown)
+    public static let LoginsHelperUpdateButtonTitle = MZLocalizedString("LoginsHelper.Update.Button", value: "Update", comment: "Button to update the user's password", lastEditedIn: .unknown)
+    public static let LoginsHelperDontUpdateButtonTitle = MZLocalizedString("LoginsHelper.DontUpdate.Button", value: "Don’t Update", comment: "Button to not update the user's password", lastEditedIn: .unknown)
+}
+
+// MARK: - Location bar long press menu
+extension String {
+    public static let PasteAndGoTitle = MZLocalizedString("Menu.PasteAndGo.Title", value: "Paste & Go", comment: "The title for the button that lets you paste and go to a URL", lastEditedIn: .unknown)
+    public static let PasteTitle = MZLocalizedString("Menu.Paste.Title", value: "Paste", comment: "The title for the button that lets you paste into the location bar", lastEditedIn: .unknown)
+    public static let CopyAddressTitle = MZLocalizedString("Menu.Copy.Title", value: "Copy Address", comment: "The title for the button that lets you copy the url from the location bar.", lastEditedIn: .unknown)
+}
+
+// MARK: - LibraryPanel
+extension String {
+    public struct LibraryPanel {
+        public struct AccessibilityLabels {
+            public static let Bookmarks = MZLocalizedString("Bookmarks", comment: "Panel accessibility label", lastEditedIn: .unknown)
+            public static let History = MZLocalizedString("History", comment: "Panel accessibility label", lastEditedIn: .unknown)
+            public static let ReadingList = MZLocalizedString("Reading list", comment: "Panel accessibility label", lastEditedIn: .unknown)
+            public static let Downloads = MZLocalizedString("Downloads", comment: "Panel accessibility label", lastEditedIn: .unknown)
+            public static let SyncedTabs = MZLocalizedString("Synced Tabs", comment: "Panel accessibility label", lastEditedIn: .unknown)
+        }
+    }
+}
+
+// MARK: - LibraryViewController
+extension String {
+    public static let LibraryPanelChooserAccessibilityLabel = MZLocalizedString("Panel Chooser", comment: "Accessibility label for the Library panel's bottom toolbar containing a list of the home panels (top sites, bookmarks, history, remote tabs, reading list).", lastEditedIn: .unknown)
+}
+
+// MARK: - Login
+extension String {
+    public struct Login {
+        public static let NoLoginsFound = MZLocalizedString("No logins found", tableName: "LoginManager", comment: "Label displayed when no logins are found after searching.", lastEditedIn: .unknown)
+
+        public struct List {
+            public static let DeselctAll = MZLocalizedString("Deselect All", tableName: "LoginManager", comment: "Label for the button used to deselect all logins.", lastEditedIn: .unknown)
+            public static let SelctAll = MZLocalizedString("Select All", tableName: "LoginManager", comment: "Label for the button used to select all logins.", lastEditedIn: .unknown)
+            public static let Delete = MZLocalizedString("Delete", tableName: "LoginManager", comment: "Label for the button used to delete the current login.", lastEditedIn: .unknown)
+        }
+
+        public struct Detail {
+            public static let Username = MZLocalizedString("Username", tableName: "LoginManager", comment: "Label displayed above the username row in Login Detail View.", lastEditedIn: .unknown)
+            public static let Password = MZLocalizedString("Password", tableName: "LoginManager", comment: "Label displayed above the password row in Login Detail View.", lastEditedIn: .unknown)
+            public static let Website = MZLocalizedString("Website", tableName: "LoginManager", comment: "Label displayed above the website row in Login Detail View.", lastEditedIn: .unknown)
+            public static let CreatedAt =  MZLocalizedString("Created %@", tableName: "LoginManager", comment: "Label describing when the current login was created with the timestamp as the parameter.", lastEditedIn: .unknown)
+            public static let ModifiedAt = MZLocalizedString("Modified %@", tableName: "LoginManager", comment: "Label describing when the current login was last modified with the timestamp as the parameter.", lastEditedIn: .unknown)
+            public static let Delete = MZLocalizedString("Delete", tableName: "LoginManager", comment: "Label for the button used to delete the current login.", lastEditedIn: .unknown)
+        }
+    }
+}
+
+// MARK: - M
+// MARK: - MenuHelper
+extension String {
+    public struct MenuHelper {
+        public static let PasteAndGo = MZLocalizedString("UIMenuItem.PasteGo", value: "Paste & Go", comment: "The menu item that pastes the current contents of the clipboard into the URL bar and navigates to the page", lastEditedIn: .unknown)
+        public static let Reveal = MZLocalizedString("Reveal", tableName: "LoginManager", comment: "Reveal password text selection menu item", lastEditedIn: .unknown)
+        public static let Hide =  MZLocalizedString("Hide", tableName: "LoginManager", comment: "Hide password text selection menu item", lastEditedIn: .unknown)
+        public static let Copy = MZLocalizedString("Copy", tableName: "LoginManager", comment: "Copy password text selection menu item", lastEditedIn: .unknown)
+        public static let OpenAndFill = MZLocalizedString("Open & Fill", tableName: "LoginManager", comment: "Open and Fill website text selection menu item", lastEditedIn: .unknown)
+        public static let FindInPage = MZLocalizedString("Find in Page", tableName: "FindInPage", comment: "Text selection menu item", lastEditedIn: .unknown)
+        public static let SearchWithFirefox = MZLocalizedString("UIMenuItem.SearchWithFirefox", value: "Search with Firefox", comment: "Search in New Tab Text selection menu item", lastEditedIn: .unknown)
+    }
+}
+
+// MARK: - MR1 Strings
+extension String {
+    public static let AwesomeBarSearchWithEngineButtonTitle = MZLocalizedString("Awesomebar.SearchWithEngine.Title", value: "Search with %@", comment: "Title for button to suggest searching with a search engine. First argument is the name of the search engine to select", lastEditedIn: .unknown)
+    public static let AwesomeBarSearchWithEngineButtonDescription = MZLocalizedString("Awesomebar.SearchWithEngine.Description", value: "Search %@ directly from the address bar", comment: "Description for button to suggest searching with a search engine. First argument is the name of the search engine to select", lastEditedIn: .unknown)
+}
+
+
+// MARK: - N
 // MARK: - New tab choice settings
 extension String {
     public static let CustomNewPageURL = MZLocalizedString("Settings.NewTab.CustomURL", value: "Custom URL", comment: "Label used to set a custom url as the new tab option (homepage).", lastEditedIn: .unknown)
@@ -345,152 +775,55 @@ extension String {
     public static let SettingsTopSitesCustomizeFooter2 = MZLocalizedString("Settings.NewTab.Option.CustomizeFooter2", value: "Sites you save or visit", comment: "The footer for the section to customize top sites in the new tab settings page.", lastEditedIn: .unknown)
 }
 
-// MARK: - Advanced Sync Settings (Debug)
-// For 'Advanced Sync Settings' view, which is a debug setting. English only, there is little value in maintaining L10N strings for these.
+// MARK: - Nimbus settings
 extension String {
-    public static let SettingsAdvancedAccountTitle = "Advanced Sync Settings"
-    public static let SettingsAdvancedAccountCustomFxAContentServerURI = "Custom Firefox Account Content Server URI"
-    public static let SettingsAdvancedAccountUseCustomFxAContentServerURITitle = "Use Custom FxA Content Server"
-    public static let SettingsAdvancedAccountCustomSyncTokenServerURI = "Custom Sync Token Server URI"
-    public static let SettingsAdvancedAccountUseCustomSyncTokenServerTitle = "Use Custom Sync Token Server"
+    public static let SettingsStudiesSectionName = MZLocalizedString("Settings.Studies.SectionName", value: "Studies", comment: "Title displayed in header of the Studies panel", lastEditedIn: .unknown)
+    public static let SettingsStudiesActiveSectionTitle = MZLocalizedString("Settings.Studies.Active.SectionName", value: "Active", comment: "Section title for all studies that are currently active", lastEditedIn: .unknown)
+    public static let SettingsStudiesCompletedSectionTitle = MZLocalizedString("Settings.Studies.Completed.SectionName", value: "Completed", comment: "Section title for all studies that are completed", lastEditedIn: .unknown)
+    public static let SettingsStudiesRemoveButton = MZLocalizedString("Settings.Studies.Remove.Button", value: "Remove", comment: "Button title displayed next to each study allowing the user to opt-out of the study", lastEditedIn: .unknown)
+
+    public static let SettingsStudiesToggleTitle = MZLocalizedString("Settings.Studies.Toggle.Title", value: "Studies", comment: "Label used as a toggle item in Settings. When this is off, the user is opting out of all studies.", lastEditedIn: .unknown)
+    public static let SettingsStudiesToggleLink = MZLocalizedString("Settings.Studies.Toggle.Link", value: "Learn More.", comment: "Title for a link that explains what Mozilla means by Studies", lastEditedIn: .unknown)
+
+    public static let SettingsStudiesToggleValueOn = MZLocalizedString("Settings.Studies.Toggle.On", value: "On", comment: "Toggled ON to participate in studies", lastEditedIn: .unknown)
+    public static let SettingsStudiesToggleValueOff = MZLocalizedString("Settings.Studies.Toggle.Off", value: "Off", comment: "Toggled OFF to opt-out of studies", lastEditedIn: .unknown)
 }
 
+// MARK: - Notifications
+// These are displayed when the app is backgrounded or the device is locked.
+extension String {
+    public struct Notifications {
+        public struct SentTab {
+            // zero tabs
+            public static let NoTabArrivingTitle = MZLocalizedString("SentTab.NoTabArrivingNotification.title", value: "Firefox Sync", comment: "Title of notification received after a spurious message from FxA has been received.", lastEditedIn: .unknown)
+            public static let NoTabArrivingBody =
+                MZLocalizedString("SentTab.NoTabArrivingNotification.body", value: "Tap to begin", comment: "Body of notification received after a spurious message from FxA has been received.", lastEditedIn: .unknown)
+
+            // one or more tabs
+            public static let TabArrivingNoDeviceTitle = MZLocalizedString("SentTab_TabArrivingNotification_NoDevice_title", value: "Tab received", comment: "Title of notification shown when the device is sent one or more tabs from an unnamed device.", lastEditedIn: .unknown)
+            public static let TabArrivingNoDeviceBody = MZLocalizedString("SentTab_TabArrivingNotification_NoDevice_body", value: "New tab arrived from another device.", comment: "Body of notification shown when the device is sent one or more tabs from an unnamed device.", lastEditedIn: .unknown)
+            public static let TabArrivingWithDeviceTitle = MZLocalizedString("SentTab_TabArrivingNotification_WithDevice_title", value: "Tab received from %@", comment: "Title of notification shown when the device is sent one or more tabs from the named device. %@ is the placeholder for the device name. This device name will be localized by that device.", lastEditedIn: .unknown)
+            public static let TabArrivingWithDeviceBody = MZLocalizedString("SentTab_TabArrivingNotification_WithDevice_body", value: "New tab arrived in %@", comment: "Body of notification shown when the device is sent one or more tabs from the named device. %@ is the placeholder for the app name.", lastEditedIn: .unknown)
+
+            // Notification Actions
+            public static let ViewActionTitle = MZLocalizedString("SentTab.ViewAction.title", value: "View", comment: "Label for an action used to view one or more tabs from a notification.", lastEditedIn: .unknown)
+        }
+    }
+}
+
+
+// MARK: - O
 // MARK: - Open With Settings
 extension String {
     public static let SettingsOpenWithSectionName = MZLocalizedString("Settings.OpenWith.SectionName", value: "Mail App", comment: "Label used as an item in Settings. When touched it will open a dialog to configure the open with (mail links) behavior.", lastEditedIn: .unknown)
     public static let SettingsOpenWithPageTitle = MZLocalizedString("Settings.OpenWith.PageTitle", value: "Open mail links with", comment: "Title for Open With Settings", lastEditedIn: .unknown)
 }
 
-// MARK: - Third Party Search Engines
+
+// MARK: - P
+// MARK: - PhotonActionSheet String
 extension String {
-    public static let ThirdPartySearchEngineAdded = MZLocalizedString("Search.ThirdPartyEngines.AddSuccess", value: "Added Search engine!", comment: "The success message that appears after a user sucessfully adds a new search engine", lastEditedIn: .unknown)
-    public static let ThirdPartySearchAddTitle = MZLocalizedString("Search.ThirdPartyEngines.AddTitle", value: "Add Search Provider?", comment: "The title that asks the user to Add the search provider", lastEditedIn: .unknown)
-    public static let ThirdPartySearchAddMessage = MZLocalizedString("Search.ThirdPartyEngines.AddMessage", value: "The new search engine will appear in the quick search bar.", comment: "The message that asks the user to Add the search provider explaining where the search engine will appear", lastEditedIn: .unknown)
-    public static let ThirdPartySearchCancelButton = MZLocalizedString("Search.ThirdPartyEngines.Cancel", value: "Cancel", comment: "The cancel button if you do not want to add a search engine.", lastEditedIn: .unknown)
-    public static let ThirdPartySearchOkayButton = MZLocalizedString("Search.ThirdPartyEngines.OK", value: "OK", comment: "The confirmation button", lastEditedIn: .unknown)
-    public static let ThirdPartySearchFailedTitle = MZLocalizedString("Search.ThirdPartyEngines.FailedTitle", value: "Failed", comment: "A title explaining that we failed to add a search engine", lastEditedIn: .unknown)
-    public static let ThirdPartySearchFailedMessage = MZLocalizedString("Search.ThirdPartyEngines.FailedMessage", value: "The search provider could not be added.", comment: "A title explaining that we failed to add a search engine", lastEditedIn: .unknown)
-    public static let CustomEngineFormErrorTitle = MZLocalizedString("Search.ThirdPartyEngines.FormErrorTitle", value: "Failed", comment: "A title stating that we failed to add custom search engine.", lastEditedIn: .unknown)
-    public static let CustomEngineFormErrorMessage = MZLocalizedString("Search.ThirdPartyEngines.FormErrorMessage", value: "Please fill all fields correctly.", comment: "A message explaining fault in custom search engine form.", lastEditedIn: .unknown)
-    public static let CustomEngineDuplicateErrorTitle = MZLocalizedString("Search.ThirdPartyEngines.DuplicateErrorTitle", value: "Failed", comment: "A title stating that we failed to add custom search engine.", lastEditedIn: .unknown)
-    public static let CustomEngineDuplicateErrorMessage = MZLocalizedString("Search.ThirdPartyEngines.DuplicateErrorMessage", value: "A search engine with this title or URL has already been added.", comment: "A message explaining fault in custom search engine form.", lastEditedIn: .unknown)
-}
-
-// MARK: - Root Bookmarks folders
-extension String {
-    public static let BookmarksFolderTitleMobile = MZLocalizedString("Mobile Bookmarks", tableName: "Storage", comment: "The title of the folder that contains mobile bookmarks. This should match bookmarks.folder.mobile.label on Android.", lastEditedIn: .unknown)
-    public static let BookmarksFolderTitleMenu = MZLocalizedString("Bookmarks Menu", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the menu. This should match bookmarks.folder.menu.label on Android.", lastEditedIn: .unknown)
-    public static let BookmarksFolderTitleToolbar = MZLocalizedString("Bookmarks Toolbar", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the toolbar. This should match bookmarks.folder.toolbar.label on Android.", lastEditedIn: .unknown)
-    public static let BookmarksFolderTitleUnsorted = MZLocalizedString("Unsorted Bookmarks", tableName: "Storage", comment: "The name of the folder that contains unsorted desktop bookmarks. This should match bookmarks.folder.unfiled.label on Android.", lastEditedIn: .unknown)
-}
-
-// MARK: - Bookmark Management
-extension String {
-    public static let BookmarksTitle = MZLocalizedString("Bookmarks.Title.Label", value: "Title", comment: "The label for the title of a bookmark", lastEditedIn: .unknown)
-    public static let BookmarksURL = MZLocalizedString("Bookmarks.URL.Label", value: "URL", comment: "The label for the URL of a bookmark", lastEditedIn: .unknown)
-    public static let BookmarksFolder = MZLocalizedString("Bookmarks.Folder.Label", value: "Folder", comment: "The label to show the location of the folder where the bookmark is located", lastEditedIn: .unknown)
-    public static let BookmarksNewBookmark = MZLocalizedString("Bookmarks.NewBookmark.Label", value: "New Bookmark", comment: "The button to create a new bookmark", lastEditedIn: .unknown)
-    public static let BookmarksNewFolder = MZLocalizedString("Bookmarks.NewFolder.Label", value: "New Folder", comment: "The button to create a new folder", lastEditedIn: .unknown)
-    public static let BookmarksNewSeparator = MZLocalizedString("Bookmarks.NewSeparator.Label", value: "New Separator", comment: "The button to create a new separator", lastEditedIn: .unknown)
-    public static let BookmarksEditBookmark = MZLocalizedString("Bookmarks.EditBookmark.Label", value: "Edit Bookmark", comment: "The button to edit a bookmark", lastEditedIn: .unknown)
-    public static let BookmarksEdit = MZLocalizedString("Bookmarks.Edit.Button", value: "Edit", comment: "The button on the snackbar to edit a bookmark after adding it.", lastEditedIn: .unknown)
-    public static let BookmarksEditFolder = MZLocalizedString("Bookmarks.EditFolder.Label", value: "Edit Folder", comment: "The button to edit a folder", lastEditedIn: .unknown)
-    public static let BookmarksFolderName = MZLocalizedString("Bookmarks.FolderName.Label", value: "Folder Name", comment: "The label for the title of the new folder", lastEditedIn: .unknown)
-    public static let BookmarksFolderLocation = MZLocalizedString("Bookmarks.FolderLocation.Label", value: "Location", comment: "The label for the location of the new folder", lastEditedIn: .unknown)
-    public static let BookmarksDeleteFolderWarningTitle = MZLocalizedString("Bookmarks.DeleteFolderWarning.Title", tableName: "BookmarkPanelDeleteConfirm", value: "This folder isn’t empty.", comment: "Title of the confirmation alert when the user tries to delete a folder that still contains bookmarks and/or folders.", lastEditedIn: .unknown)
-    public static let BookmarksDeleteFolderWarningDescription = MZLocalizedString("Bookmarks.DeleteFolderWarning.Description", tableName: "BookmarkPanelDeleteConfirm", value: "Are you sure you want to delete it and its contents?", comment: "Main body of the confirmation alert when the user tries to delete a folder that still contains bookmarks and/or folders.", lastEditedIn: .unknown)
-    public static let BookmarksDeleteFolderCancelButtonLabel = MZLocalizedString("Bookmarks.DeleteFolderWarning.CancelButton.Label", tableName: "BookmarkPanelDeleteConfirm", value: "Cancel", comment: "Button label to cancel deletion when the user tried to delete a non-empty folder.", lastEditedIn: .unknown)
-    public static let BookmarksDeleteFolderDeleteButtonLabel = MZLocalizedString("Bookmarks.DeleteFolderWarning.DeleteButton.Label", tableName: "BookmarkPanelDeleteConfirm", value: "Delete", comment: "Button label for the button that deletes a folder and all of its children.", lastEditedIn: .unknown)
-    public static let BookmarksPanelEmptyStateTitle = MZLocalizedString("BookmarksPanel.EmptyState.Title", value: "Bookmarks you save will show up here.", comment: "Status label for the empty Bookmarks state.", lastEditedIn: .unknown)
-    public static let BookmarksPanelDeleteTableAction = MZLocalizedString("Delete", tableName: "BookmarkPanel", comment: "Action button for deleting bookmarks in the bookmarks panel.", lastEditedIn: .unknown)
-    public static let BookmarkDetailFieldTitle = MZLocalizedString("Bookmark.DetailFieldTitle.Label", value: "Title", comment: "The label for the Title field when editing a bookmark", lastEditedIn: .unknown)
-    public static let BookmarkDetailFieldURL = MZLocalizedString("Bookmark.DetailFieldURL.Label", value: "URL", comment: "The label for the URL field when editing a bookmark", lastEditedIn: .unknown)
-    public static let BookmarkDetailFieldsHeaderBookmarkTitle = MZLocalizedString("Bookmark.BookmarkDetail.FieldsHeader.Bookmark.Title", value: "Bookmark", comment: "The header title for the fields when editing a Bookmark", lastEditedIn: .unknown)
-    public static let BookmarkDetailFieldsHeaderFolderTitle = MZLocalizedString("Bookmark.BookmarkDetail.FieldsHeader.Folder.Title", value: "Folder", comment: "The header title for the fields when editing a Folder", lastEditedIn: .unknown)
-}
-
-// MARK: - Tabs Delete All Undo Toast
-extension String {
-    public static let TabsDeleteAllUndoTitle = MZLocalizedString("Tabs.DeleteAllUndo.Title", value: "%d tab(s) closed", comment: "The label indicating that all the tabs were closed", lastEditedIn: .unknown)
-    public static let TabsDeleteAllUndoAction = MZLocalizedString("Tabs.DeleteAllUndo.Button", value: "Undo", comment: "The button to undo the delete all tabs", lastEditedIn: .unknown)
-    public static let TabSearchPlaceholderText = MZLocalizedString("Tabs.Search.PlaceholderText", value: "Search Tabs", comment: "The placeholder text for the tab search bar", lastEditedIn: .unknown)
-}
-
-// MARK: - Tab tray (chronological tabs)
-extension String {
-    public static let TabTrayV2Title = MZLocalizedString("TabTray.Title", value: "Open Tabs", comment: "The title for the tab tray", lastEditedIn: .unknown)
-    public static let TabTrayV2TodayHeader = MZLocalizedString("TabTray.Today.Header", value: "Today", comment: "The section header for tabs opened today", lastEditedIn: .unknown)
-    public static let TabTrayV2YesterdayHeader = MZLocalizedString("TabTray.Yesterday.Header", value: "Yesterday", comment: "The section header for tabs opened yesterday", lastEditedIn: .unknown)
-    public static let TabTrayV2LastWeekHeader = MZLocalizedString("TabTray.LastWeek.Header", value: "Last Week", comment: "The section header for tabs opened last week", lastEditedIn: .unknown)
-    public static let TabTrayV2OlderHeader = MZLocalizedString("TabTray.Older.Header", value: "Older", comment: "The section header for tabs opened before last week", lastEditedIn: .unknown)
-    public static let TabTraySwipeMenuMore = MZLocalizedString("TabTray.SwipeMenu.More", value: "More", comment: "The button title to see more options to perform on the tab.", lastEditedIn: .unknown)
-    public static let TabTrayMoreMenuCopy = MZLocalizedString("TabTray.MoreMenu.Copy", value: "Copy", comment: "The title on the button to copy the tab address.", lastEditedIn: .unknown)
-    public static let TabTrayV2PrivateTitle = MZLocalizedString("TabTray.PrivateTitle", value: "Private Tabs", comment: "The title for the tab tray in private mode", lastEditedIn: .unknown)
-
-    // Segmented Control tites for iPad
-    public static let TabTraySegmentedControlTitlesTabs = MZLocalizedString("TabTray.SegmentedControlTitles.Tabs", value: "Tabs", comment: "The title on the button to look at regular tabs.", lastEditedIn: .unknown)
-    public static let TabTraySegmentedControlTitlesPrivateTabs = MZLocalizedString("TabTray.SegmentedControlTitles.PrivateTabs", value: "Private", comment: "The title on the button to look at private tabs.", lastEditedIn: .unknown)
-    public static let TabTraySegmentedControlTitlesSyncedTabs = MZLocalizedString("TabTray.SegmentedControlTitles.SyncedTabs", value: "Synced", comment: "The title on the button to look at synced tabs.", lastEditedIn: .unknown)
-}
-
-// MARK: - Clipboard Toast
-extension String {
-    public static let GoToCopiedLink = MZLocalizedString("ClipboardToast.GoToCopiedLink.Title", value: "Go to copied link?", comment: "Message displayed when the user has a copied link on the clipboard", lastEditedIn: .unknown)
-    public static let GoButtonTittle = MZLocalizedString("ClipboardToast.GoToCopiedLink.Button", value: "Go", comment: "The button to open a new tab with the copied link", lastEditedIn: .unknown)
-
-    public static let SettingsOfferClipboardBarTitle = MZLocalizedString("Settings.OfferClipboardBar.Title", value: "Offer to Open Copied Links", comment: "Title of setting to enable the Go to Copied URL feature. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349", lastEditedIn: .unknown)
-    public static let SettingsOfferClipboardBarStatus = MZLocalizedString("Settings.OfferClipboardBar.Status", value: "When Opening Firefox", comment: "Description displayed under the ”Offer to Open Copied Link” option. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349", lastEditedIn: .unknown)
-}
-
-// MARK: - Link Previews
-extension String {
-    public static let SettingsShowLinkPreviewsTitle = MZLocalizedString("Settings.ShowLinkPreviews.Title", value: "Show Link Previews", comment: "Title of setting to enable link previews when long-pressing links.", lastEditedIn: .unknown)
-    public static let SettingsShowLinkPreviewsStatus = MZLocalizedString("Settings.ShowLinkPreviews.Status", value: "When Long-pressing Links", comment: "Description displayed under the ”Show Link Previews” option", lastEditedIn: .unknown)
-}
-
-// MARK: - Errors
-extension String {
-    public static let UnableToDownloadError = MZLocalizedString("Downloads.Error.Message", value: "Downloads aren’t supported in Firefox yet.", comment: "The message displayed to a user when they try and perform the download of an asset that Firefox cannot currently handle.", lastEditedIn: .unknown)
-    public static let UnableToAddPassErrorTitle = MZLocalizedString("AddPass.Error.Title", value: "Failed to Add Pass", comment: "Title of the 'Add Pass Failed' alert. See https://support.apple.com/HT204003 for context on Wallet.", lastEditedIn: .unknown)
-    public static let UnableToAddPassErrorMessage = MZLocalizedString("AddPass.Error.Message", value: "An error occured while adding the pass to Wallet. Please try again later.", comment: "Text of the 'Add Pass Failed' alert.  See https://support.apple.com/HT204003 for context on Wallet.", lastEditedIn: .unknown)
-    public static let UnableToAddPassErrorDismiss = MZLocalizedString("AddPass.Error.Dismiss", value: "OK", comment: "Button to dismiss the 'Add Pass Failed' alert.  See https://support.apple.com/HT204003 for context on Wallet.", lastEditedIn: .unknown)
-    public static let UnableToOpenURLError = MZLocalizedString("OpenURL.Error.Message", value: "Firefox cannot open the page because it has an invalid address.", comment: "The message displayed to a user when they try to open a URL that cannot be handled by Firefox, or any external app.", lastEditedIn: .unknown)
-    public static let UnableToOpenURLErrorTitle = MZLocalizedString("OpenURL.Error.Title", value: "Cannot Open Page", comment: "Title of the message shown when the user attempts to navigate to an invalid link.", lastEditedIn: .unknown)
-}
-
-// MARK: - Download Helper
-extension String {
-    public static let OpenInDownloadHelperAlertDownloadNow = MZLocalizedString("Downloads.Alert.DownloadNow", value: "Download Now", comment: "The label of the button the user will press to start downloading a file", lastEditedIn: .unknown)
-    public static let DownloadsButtonTitle = MZLocalizedString("Downloads.Toast.GoToDownloads.Button", value: "Downloads", comment: "The button to open a new tab with the Downloads home panel", lastEditedIn: .unknown)
-    public static let CancelDownloadDialogTitle = MZLocalizedString("Downloads.CancelDialog.Title", value: "Cancel Download", comment: "Alert dialog title when the user taps the cancel download icon.", lastEditedIn: .unknown)
-    public static let CancelDownloadDialogMessage = MZLocalizedString("Downloads.CancelDialog.Message", value: "Are you sure you want to cancel this download?", comment: "Alert dialog body when the user taps the cancel download icon.", lastEditedIn: .unknown)
-    public static let CancelDownloadDialogResume = MZLocalizedString("Downloads.CancelDialog.Resume", value: "Resume", comment: "Button declining the cancellation of the download.", lastEditedIn: .unknown)
-    public static let CancelDownloadDialogCancel = MZLocalizedString("Downloads.CancelDialog.Cancel", value: "Cancel", comment: "Button confirming the cancellation of the download.", lastEditedIn: .unknown)
-    public static let DownloadCancelledToastLabelText = MZLocalizedString("Downloads.Toast.Cancelled.LabelText", value: "Download Cancelled", comment: "The label text in the Download Cancelled toast for showing confirmation that the download was cancelled.", lastEditedIn: .unknown)
-    public static let DownloadFailedToastLabelText = MZLocalizedString("Downloads.Toast.Failed.LabelText", value: "Download Failed", comment: "The label text in the Download Failed toast for showing confirmation that the download has failed.", lastEditedIn: .unknown)
-    public static let DownloadFailedToastButtonTitled = MZLocalizedString("Downloads.Toast.Failed.RetryButton", value: "Retry", comment: "The button to retry a failed download from the Download Failed toast.", lastEditedIn: .unknown)
-    public static let DownloadMultipleFilesToastDescriptionText = MZLocalizedString("Downloads.Toast.MultipleFiles.DescriptionText", value: "1 of %d files", comment: "The description text in the Download progress toast for showing the number of files when multiple files are downloading.", lastEditedIn: .unknown)
-    public static let DownloadProgressToastDescriptionText = MZLocalizedString("Downloads.Toast.Progress.DescriptionText", value: "%1$@/%2$@", comment: "The description text in the Download progress toast for showing the downloaded file size (1$) out of the total expected file size (2$).", lastEditedIn: .unknown)
-    public static let DownloadMultipleFilesAndProgressToastDescriptionText = MZLocalizedString("Downloads.Toast.MultipleFilesAndProgress.DescriptionText", value: "%1$@ %2$@", comment: "The description text in the Download progress toast for showing the number of files (1$) and download progress (2$). This string only consists of two placeholders for purposes of displaying two other strings side-by-side where 1$ is Downloads.Toast.MultipleFiles.DescriptionText and 2$ is Downloads.Toast.Progress.DescriptionText. This string should only consist of the two placeholders side-by-side separated by a single space and 1$ should come before 2$ everywhere except for right-to-left locales.", lastEditedIn: .unknown)
-}
-
-// MARK: - Add Custom Search Engine
-extension String {
-    public static let SettingsAddCustomEngine = MZLocalizedString("Settings.AddCustomEngine", value: "Add Search Engine", comment: "The button text in Search Settings that opens the Custom Search Engine view.", lastEditedIn: .unknown)
-    public static let SettingsAddCustomEngineTitle = MZLocalizedString("Settings.AddCustomEngine.Title", value: "Add Search Engine", comment: "The title of the  Custom Search Engine view.", lastEditedIn: .unknown)
-    public static let SettingsAddCustomEngineTitleLabel = MZLocalizedString("Settings.AddCustomEngine.TitleLabel", value: "Title", comment: "The title for the field which sets the title for a custom search engine.", lastEditedIn: .unknown)
-    public static let SettingsAddCustomEngineURLLabel = MZLocalizedString("Settings.AddCustomEngine.URLLabel", value: "URL", comment: "The title for URL Field", lastEditedIn: .unknown)
-    public static let SettingsAddCustomEngineTitlePlaceholder = MZLocalizedString("Settings.AddCustomEngine.TitlePlaceholder", value: "Search Engine", comment: "The placeholder for Title Field when saving a custom search engine.", lastEditedIn: .unknown)
-    public static let SettingsAddCustomEngineURLPlaceholder = MZLocalizedString("Settings.AddCustomEngine.URLPlaceholder", value: "URL (Replace Query with %s)", comment: "The placeholder for URL Field when saving a custom search engine", lastEditedIn: .unknown)
-    public static let SettingsAddCustomEngineSaveButtonText = MZLocalizedString("Settings.AddCustomEngine.SaveButtonText", value: "Save", comment: "The text on the Save button when saving a custom search engine", lastEditedIn: .unknown)
-}
-
-// MARK: - Context menu ButtonToast instances.
-extension String {
-    public static let ContextMenuButtonToastNewTabOpenedLabelText = MZLocalizedString("ContextMenu.ButtonToast.NewTabOpened.LabelText", value: "New Tab opened", comment: "The label text in the Button Toast for switching to a fresh New Tab.", lastEditedIn: .unknown)
-    public static let ContextMenuButtonToastNewTabOpenedButtonText = MZLocalizedString("ContextMenu.ButtonToast.NewTabOpened.ButtonText", value: "Switch", comment: "The button text in the Button Toast for switching to a fresh New Tab.", lastEditedIn: .unknown)
-    public static let ContextMenuButtonToastNewPrivateTabOpenedLabelText = MZLocalizedString("ContextMenu.ButtonToast.NewPrivateTabOpened.LabelText", value: "New Private Tab opened", comment: "The label text in the Button Toast for switching to a fresh New Private Tab.", lastEditedIn: .unknown)
-    public static let ContextMenuButtonToastNewPrivateTabOpenedButtonText = MZLocalizedString("ContextMenu.ButtonToast.NewPrivateTabOpened.ButtonText", value: "Switch", comment: "The button text in the Button Toast for switching to a fresh New Private Tab.", lastEditedIn: .unknown)
+    public static let CloseButtonTitle = MZLocalizedString("PhotonMenu.close", value: "Close", comment: "Button for closing the menu action sheet", lastEditedIn: .unknown)
 }
 
 // MARK: - Page context menu items (i.e. links and images).
@@ -516,45 +849,15 @@ extension String {
     public static let PhotoLibraryFirefoxWouldLikeAccessMessage = MZLocalizedString("PhotoLibrary.FirefoxWouldLikeAccessMessage", value: "This allows you to save the image to your Camera Roll.", comment: "See http://mzl.la/1G7uHo7", lastEditedIn: .unknown)
 }
 
-// MARK: - Sent tabs notifications
-// These are displayed when the app is backgrounded or the device is locked.
+// MARK: - PasswordAutofill extension
 extension String {
-    // zero tabs
-    public static let SentTab_NoTabArrivingNotification_title = MZLocalizedString("SentTab.NoTabArrivingNotification.title", value: "Firefox Sync", comment: "Title of notification received after a spurious message from FxA has been received.", lastEditedIn: .unknown)
-    public static let SentTab_NoTabArrivingNotification_body =
-        MZLocalizedString("SentTab.NoTabArrivingNotification.body", value: "Tap to begin", comment: "Body of notification received after a spurious message from FxA has been received.", lastEditedIn: .unknown)
-
-    // one or more tabs
-    public static let SentTab_TabArrivingNotification_NoDevice_title = MZLocalizedString("SentTab_TabArrivingNotification_NoDevice_title", value: "Tab received", comment: "Title of notification shown when the device is sent one or more tabs from an unnamed device.", lastEditedIn: .unknown)
-    public static let SentTab_TabArrivingNotification_NoDevice_body = MZLocalizedString("SentTab_TabArrivingNotification_NoDevice_body", value: "New tab arrived from another device.", comment: "Body of notification shown when the device is sent one or more tabs from an unnamed device.", lastEditedIn: .unknown)
-    public static let SentTab_TabArrivingNotification_WithDevice_title = MZLocalizedString("SentTab_TabArrivingNotification_WithDevice_title", value: "Tab received from %@", comment: "Title of notification shown when the device is sent one or more tabs from the named device. %@ is the placeholder for the device name. This device name will be localized by that device.", lastEditedIn: .unknown)
-    public static let SentTab_TabArrivingNotification_WithDevice_body = MZLocalizedString("SentTab_TabArrivingNotification_WithDevice_body", value: "New tab arrived in %@", comment: "Body of notification shown when the device is sent one or more tabs from the named device. %@ is the placeholder for the app name.", lastEditedIn: .unknown)
-
-    // Notification Actions
-    public static let SentTabViewActionTitle = MZLocalizedString("SentTab.ViewAction.title", value: "View", comment: "Label for an action used to view one or more tabs from a notification.", lastEditedIn: .unknown)
-    public static let SentTabBookmarkActionTitle = MZLocalizedString("SentTab.BookmarkAction.title", value: "Bookmark", comment: "Label for an action used to bookmark one or more tabs from a notification.", lastEditedIn: .unknown)
-    public static let SentTabAddToReadingListActionTitle = MZLocalizedString("SentTab.AddToReadingListAction.Title", value: "Add to Reading List", comment: "Label for an action used to add one or more tabs recieved from a notification to the reading list.", lastEditedIn: .unknown)
+    public static let PasswordAutofillTitle = MZLocalizedString("PasswordAutoFill.SectionTitle", value: "Firefox Credentials", comment: "Title of the extension that shows firefox passwords", lastEditedIn: .unknown)
+    public static let CredentialProviderNoCredentialError = MZLocalizedString("PasswordAutoFill.NoPasswordsFoundTitle", value: "You don’t have any credentials synced from your Firefox Account", comment: "Error message shown in the remote tabs panel", lastEditedIn: .unknown)
+    public static let AvailableCredentialsHeader = MZLocalizedString("PasswordAutoFill.PasswordsListTitle", value: "Available Credentials:", comment: "Header for the list of credentials table", lastEditedIn: .unknown)
 }
 
-// MARK: - Additional messages sent via Push from FxA
-extension String {
-    public static let FxAPush_DeviceDisconnected_ThisDevice_title = MZLocalizedString("FxAPush_DeviceDisconnected_ThisDevice_title", value: "Sync Disconnected", comment: "Title of a notification displayed when this device has been disconnected by another device.", lastEditedIn: .unknown)
-    public static let FxAPush_DeviceDisconnected_ThisDevice_body = MZLocalizedString("FxAPush_DeviceDisconnected_ThisDevice_body", value: "This device has been successfully disconnected from Firefox Sync.", comment: "Body of a notification displayed when this device has been disconnected from FxA by another device.", lastEditedIn: .unknown)
-    public static let FxAPush_DeviceDisconnected_title = MZLocalizedString("FxAPush_DeviceDisconnected_title", value: "Sync Disconnected", comment: "Title of a notification displayed when named device has been disconnected from FxA.", lastEditedIn: .unknown)
-    public static let FxAPush_DeviceDisconnected_body = MZLocalizedString("FxAPush_DeviceDisconnected_body", value: "%@ has been successfully disconnected.", comment: "Body of a notification displayed when named device has been disconnected from FxA. %@ refers to the name of the disconnected device.", lastEditedIn: .unknown)
 
-    public static let FxAPush_DeviceDisconnected_UnknownDevice_body = MZLocalizedString("FxAPush_DeviceDisconnected_UnknownDevice_body", value: "A device has disconnected from Firefox Sync", comment: "Body of a notification displayed when unnamed device has been disconnected from FxA.", lastEditedIn: .unknown)
-
-    public static let FxAPush_DeviceConnected_title = MZLocalizedString("FxAPush_DeviceConnected_title", value: "Sync Connected", comment: "Title of a notification displayed when another device has connected to FxA.", lastEditedIn: .unknown)
-    public static let FxAPush_DeviceConnected_body = MZLocalizedString("FxAPush_DeviceConnected_body", value: "Firefox Sync has connected to %@", comment: "Title of a notification displayed when another device has connected to FxA. %@ refers to the name of the newly connected device.", lastEditedIn: .unknown)
-}
-
-// MARK: - Reader Mode
-extension String {
-    public static let ReaderModeAvailableVoiceOverAnnouncement = MZLocalizedString("ReaderMode.Available.VoiceOverAnnouncement", value: "Reader Mode available", comment: "Accessibility message e.g. spoken by VoiceOver when Reader Mode becomes available.", lastEditedIn: .unknown)
-    public static let ReaderModeResetFontSizeAccessibilityLabel = MZLocalizedString("Reset text size", comment: "Accessibility label for button resetting font size in display settings of reader mode", lastEditedIn: .unknown)
-}
-
+// MARK: - Q
 // MARK: - QR Code scanner
 extension String {
     public static let ScanQRCodeViewTitle = MZLocalizedString("ScanQRCode.View.Title", value: "Scan QR Code", comment: "Title for the QR code scanner view.", lastEditedIn: .unknown)
@@ -564,73 +867,315 @@ extension String {
     public static let ScanQRCodeErrorOKButton = MZLocalizedString("ScanQRCode.Error.OK.Button", value: "OK", comment: "OK button to dismiss the error prompt.", lastEditedIn: .unknown)
 }
 
-// MARK: - App menu
+// MARK: - QuickActions
 extension String {
-    public static let AppMenuReportSiteIssueTitleString = MZLocalizedString("Menu.ReportSiteIssueAction.Title", tableName: "Menu", value: "Report Site Issue", comment: "Label for the button, displayed in the menu, used to report a compatibility issue with the current page.", lastEditedIn: .unknown)
-    public static let AppMenuLibraryReloadString = MZLocalizedString("Menu.Library.Reload", tableName: "Menu", value: "Reload", comment: "Label for the button, displayed in the menu, used to Reload the webpage", lastEditedIn: .unknown)
-    public static let StopReloadPageTitle = MZLocalizedString("Menu.Library.StopReload", value: "Stop", comment: "Label for the button displayed in the menu used to stop the reload of the webpage", lastEditedIn: .unknown)
-    public static let AppMenuLibraryTitleString = MZLocalizedString("Menu.Library.Title", tableName: "Menu", value: "Your Library", comment: "Label for the button, displayed in the menu, used to open the Library", lastEditedIn: .unknown)
-    public static let AppMenuRecentlySavedTitle = MZLocalizedString("Menu.RecentlySaved.Title", tableName: "Menu", value: "Recently Saved", comment: "A string used to signify the start of the Recently Saved section in Home Screen.", lastEditedIn: .unknown)
-    public static let AppMenuAddToReadingListTitleString = MZLocalizedString("Menu.AddToReadingList.Title", tableName: "Menu", value: "Add to Reading List", comment: "Label for the button, displayed in the menu, used to add a page to the reading list.", lastEditedIn: .unknown)
-    public static let AppMenuShowTabsTitleString = MZLocalizedString("Menu.ShowTabs.Title", tableName: "Menu", value: "Show Tabs", comment: "Label for the button, displayed in the menu, used to open the tabs tray", lastEditedIn: .unknown)
-    public static let AppMenuSharePageTitleString = MZLocalizedString("Menu.SharePageAction.Title", tableName: "Menu", value: "Share Page With…", comment: "Label for the button, displayed in the menu, used to open the share dialog.", lastEditedIn: .unknown)
-    public static let AppMenuCopyURLTitleString = MZLocalizedString("Menu.CopyAddress.Title", tableName: "Menu", value: "Copy Address", comment: "Label for the button, displayed in the menu, used to copy the page url to the clipboard.", lastEditedIn: .unknown)
-    public static let AppMenuCopyLinkTitleString = MZLocalizedString("Menu.CopyLink.Title", tableName: "Menu", value: "Copy Link", comment: "Label for the button, displayed in the menu, used to copy the current page link to the clipboard.", lastEditedIn: .unknown)
-    public static let AppMenuNewTabTitleString = MZLocalizedString("Menu.NewTabAction.Title", tableName: "Menu", value: "Open New Tab", comment: "Label for the button, displayed in the menu, used to open a new tab", lastEditedIn: .unknown)
-    public static let AppMenuNewPrivateTabTitleString = MZLocalizedString("Menu.NewPrivateTabAction.Title", tableName: "Menu", value: "Open New Private Tab", comment: "Label for the button, displayed in the menu, used to open a new private tab.", lastEditedIn: .unknown)
-    public static let AppMenuAddBookmarkTitleString = MZLocalizedString("Menu.AddBookmarkAction.Title", tableName: "Menu", value: "Bookmark This Page", comment: "Label for the button, displayed in the menu, used to create a bookmark for the current website.", lastEditedIn: .unknown)
-    public static let AppMenuAddBookmarkTitleString2 = MZLocalizedString("Menu.AddBookmarkAction2.Title", tableName: "Menu", value: "Add Bookmark", comment: "Label for the button, displayed in the menu, used to create a bookmark for the current website.", lastEditedIn: .unknown)
-    public static let AppMenuRemoveBookmarkTitleString = MZLocalizedString("Menu.RemoveBookmarkAction.Title", tableName: "Menu", value: "Remove Bookmark", comment: "Label for the button, displayed in the menu, used to delete an existing bookmark for the current website.", lastEditedIn: .unknown)
-    public static let AppMenuFindInPageTitleString = MZLocalizedString("Menu.FindInPageAction.Title", tableName: "Menu", value: "Find in Page", comment: "Label for the button, displayed in the menu, used to open the toolbar to search for text within the current page.", lastEditedIn: .unknown)
-    public static let AppMenuViewDesktopSiteTitleString = MZLocalizedString("Menu.ViewDekstopSiteAction.Title", tableName: "Menu", value: "Request Desktop Site", comment: "Label for the button, displayed in the menu, used to request the desktop version of the current website.", lastEditedIn: .unknown)
-    public static let AppMenuViewMobileSiteTitleString = MZLocalizedString("Menu.ViewMobileSiteAction.Title", tableName: "Menu", value: "Request Mobile Site", comment: "Label for the button, displayed in the menu, used to request the mobile version of the current website.", lastEditedIn: .unknown)
-    public static let AppMenuTranslatePageTitleString = MZLocalizedString("Menu.TranslatePageAction.Title", tableName: "Menu", value: "Translate Page", comment: "Label for the button, displayed in the menu, used to translate the current page.", lastEditedIn: .unknown)
-    public static let AppMenuScanQRCodeTitleString = MZLocalizedString("Menu.ScanQRCodeAction.Title", tableName: "Menu", value: "Scan QR Code", comment: "Label for the button, displayed in the menu, used to open the QR code scanner.", lastEditedIn: .unknown)
-    public static let AppMenuSettingsTitleString = MZLocalizedString("Menu.OpenSettingsAction.Title", tableName: "Menu", value: "Settings", comment: "Label for the button, displayed in the menu, used to open the Settings menu.", lastEditedIn: .unknown)
-    public static let AppMenuCloseAllTabsTitleString = MZLocalizedString("Menu.CloseAllTabsAction.Title", tableName: "Menu", value: "Close All Tabs", comment: "Label for the button, displayed in the menu, used to close all tabs currently open.", lastEditedIn: .unknown)
-    public static let AppMenuOpenHomePageTitleString = MZLocalizedString("Menu.OpenHomePageAction.Title", tableName: "Menu", value: "Home", comment: "Label for the button, displayed in the menu, used to navigate to the home page.", lastEditedIn: .unknown)
-    public static let AppMenuTopSitesTitleString = MZLocalizedString("Menu.OpenTopSitesAction.AccessibilityLabel", tableName: "Menu", value: "Top Sites", comment: "Accessibility label for the button, displayed in the menu, used to open the Top Sites home panel.", lastEditedIn: .unknown)
-    public static let AppMenuBookmarksTitleString = MZLocalizedString("Menu.OpenBookmarksAction.AccessibilityLabel.v2", tableName: "Menu", value: "Bookmarks", comment: "Accessibility label for the button, displayed in the menu, used to open the Bookmarks home panel. Please keep as short as possible, <15 chars of space available.", lastEditedIn: .unknown)
-    public static let AppMenuReadingListTitleString = MZLocalizedString("Menu.OpenReadingListAction.AccessibilityLabel.v2", tableName: "Menu", value: "Reading List", comment: "Accessibility label for the button, displayed in the menu, used to open the Reading list home panel. Please keep as short as possible, <15 chars of space available.", lastEditedIn: .unknown)
-    public static let AppMenuHistoryTitleString = MZLocalizedString("Menu.OpenHistoryAction.AccessibilityLabel.v2", tableName: "Menu", value: "History", comment: "Accessibility label for the button, displayed in the menu, used to open the History home panel. Please keep as short as possible, <15 chars of space available.", lastEditedIn: .unknown)
-    public static let AppMenuDownloadsTitleString = MZLocalizedString("Menu.OpenDownloadsAction.AccessibilityLabel.v2", tableName: "Menu", value: "Downloads", comment: "Accessibility label for the button, displayed in the menu, used to open the Downloads home panel. Please keep as short as possible, <15 chars of space available.", lastEditedIn: .unknown)
-    public static let AppMenuSyncedTabsTitleString = MZLocalizedString("Menu.OpenSyncedTabsAction.AccessibilityLabel.v2", tableName: "Menu", value: "Synced Tabs", comment: "Accessibility label for the button, displayed in the menu, used to open the Synced Tabs home panel. Please keep as short as possible, <15 chars of space available.", lastEditedIn: .unknown)
-    public static let AppMenuLibrarySeeAllTitleString = MZLocalizedString("Menu.SeeAllAction.Title", tableName: "Menu", value: "See All", comment: "Label for the button, displayed in Firefox Home, used to see all Library panels.", lastEditedIn: .unknown)
-    public static let AppMenuButtonAccessibilityLabel = MZLocalizedString("Toolbar.Menu.AccessibilityLabel", value: "Menu", comment: "Accessibility label for the Menu button.", lastEditedIn: .unknown)
-    public static let TabTrayDeleteMenuButtonAccessibilityLabel = MZLocalizedString("Toolbar.Menu.CloseAllTabs", value: "Close All Tabs", comment: "Accessibility label for the Close All Tabs menu button.", lastEditedIn: .unknown)
-    public static let AppMenuNightMode = MZLocalizedString("Menu.NightModeTurnOn.Label", value: "Enable Night Mode", comment: "Label for the button, displayed in the menu, turns on night mode.", lastEditedIn: .unknown)
-    public static let AppMenuTurnOnNightMode = MZLocalizedString("Menu.NightModeTurnOn.Label2", value: "Turn on Night Mode", comment: "Label for the button, displayed in the menu, turns on night mode.", lastEditedIn: .unknown)
-    public static let AppMenuTurnOffNightMode = MZLocalizedString("Menu.NightModeTurnOff.Label2", value: "Turn off Night Mode", comment: "Label for the button, displayed in the menu, turns off night mode.", lastEditedIn: .unknown)
-    public static let AppMenuNoImageMode = MZLocalizedString("Menu.NoImageModeBlockImages.Label", value: "Block Images", comment: "Label for the button, displayed in the menu, hides images on the webpage when pressed.", lastEditedIn: .unknown)
-    public static let AppMenuShowImageMode = MZLocalizedString("Menu.NoImageModeShowImages.Label", value: "Show Images", comment: "Label for the button, displayed in the menu, shows images on the webpage when pressed.", lastEditedIn: .unknown)
-    public static let AppMenuBookmarks = MZLocalizedString("Menu.Bookmarks.Label", value: "Bookmarks", comment: "Label for the button, displayed in the menu, takes you to to bookmarks screen when pressed.", lastEditedIn: .unknown)
-    public static let AppMenuHistory = MZLocalizedString("Menu.History.Label", value: "History", comment: "Label for the button, displayed in the menu, takes you to to History screen when pressed.", lastEditedIn: .unknown)
-    public static let AppMenuDownloads = MZLocalizedString("Menu.Downloads.Label", value: "Downloads", comment: "Label for the button, displayed in the menu, takes you to to Downloads screen when pressed.", lastEditedIn: .unknown)
-    public static let AppMenuReadingList = MZLocalizedString("Menu.ReadingList.Label", value: "Reading List", comment: "Label for the button, displayed in the menu, takes you to to Reading List screen when pressed.", lastEditedIn: .unknown)
-    public static let AppMenuPasswords = MZLocalizedString("Menu.Passwords.Label", value: "Passwords", comment: "Label for the button, displayed in the menu, takes you to to passwords screen when pressed.", lastEditedIn: .unknown)
-    public static let AppMenuBackUpAndSyncData = MZLocalizedString("Menu.BackUpAndSync.Label", value: "Back up and Sync Data", comment: "Label for the button, displayed in the menu, takes you to sync sign in when pressed.", lastEditedIn: .unknown)
-    public static let AppMenuManageAccount = MZLocalizedString("Menu.ManageAccount.Label", value: "Manage Account %@", comment: "Label for the button, displayed in the menu, takes you to screen to manage account when pressed. First argument is the display name for the current account", lastEditedIn: .unknown)
-    public static let AppMenuCopyURLConfirmMessage = MZLocalizedString("Menu.CopyURL.Confirm", value: "URL Copied To Clipboard", comment: "Toast displayed to user after copy url pressed.", lastEditedIn: .unknown)
-    
-    public static let AppMenuAddBookmarkConfirmMessage = MZLocalizedString("Menu.AddBookmark.Confirm", value: "Bookmark Added", comment: "Toast displayed to the user after a bookmark has been added.", lastEditedIn: .unknown)
-    public static let AppMenuTabSentConfirmMessage = MZLocalizedString("Menu.TabSent.Confirm", value: "Tab Sent", comment: "Toast displayed to the user after a tab has been sent successfully.", lastEditedIn: .unknown)
-    public static let AppMenuRemoveBookmarkConfirmMessage = MZLocalizedString("Menu.RemoveBookmark.Confirm", value: "Bookmark Removed", comment: "Toast displayed to the user after a bookmark has been removed.", lastEditedIn: .unknown)
-    public static let AppMenuAddPinToTopSitesConfirmMessage = MZLocalizedString("Menu.AddPin.Confirm", value: "Pinned To Top Sites", comment: "Toast displayed to the user after adding the item to the Top Sites.", lastEditedIn: .unknown)
-    public static let AppMenuAddPinToShortcutsConfirmMessage = MZLocalizedString("Menu.AddPin.Confirm2", value: "Added to Shortcuts", comment: "Toast displayed to the user after adding the item to the Shortcuts.", lastEditedIn: .unknown)
-    public static let AppMenuRemovePinFromShortcutsConfirmMessage = MZLocalizedString("Menu.RemovePin.Confirm2", value: "Removed from Shortcuts", comment: "Toast displayed to the user after removing the item to the Shortcuts.", lastEditedIn: .unknown)
-    public static let AppMenuRemovePinFromTopSitesConfirmMessage = MZLocalizedString("Menu.RemovePin.Confirm", value: "Removed From Top Sites", comment: "Toast displayed to the user after removing the item from the Top Sites.", lastEditedIn: .unknown)
-    public static let AppMenuAddToReadingListConfirmMessage = MZLocalizedString("Menu.AddToReadingList.Confirm", value: "Added To Reading List", comment: "Toast displayed to the user after adding the item to their reading list.", lastEditedIn: .unknown)
-    public static let SendToDeviceTitle = MZLocalizedString("Send to Device", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to send the current tab to another device", lastEditedIn: .unknown)
-    public static let SendLinkToDeviceTitle = MZLocalizedString("Menu.SendLinkToDevice", tableName: "3DTouchActions", value: "Send Link to Device", comment: "Label for preview action on Tab Tray Tab to send the current link to another device", lastEditedIn: .unknown)
-    public static let PageActionMenuTitle = MZLocalizedString("Menu.PageActions.Title", value: "Page Actions", comment: "Label for title in page action menu.", lastEditedIn: .unknown)
-    public static let WhatsNewString = MZLocalizedString("Menu.WhatsNew.Title", value: "What's New", comment: "The title for the option to view the What's new page.", lastEditedIn: .unknown)
-    public static let AppMenuShowPageSourceString = MZLocalizedString("Menu.PageSourceAction.Title", tableName: "Menu", value: "View Page Source", comment: "Label for the button, displayed in the menu, used to show the html page source", lastEditedIn: .unknown)
+    public static let QuickActionsLastBookmarkTitle = MZLocalizedString("Open Last Bookmark", tableName: "3DTouchActions", comment: "String describing the action of opening the last added bookmark from the home screen Quick Actions via 3D Touch", lastEditedIn: .unknown)
+}
+
+// MARK: - R
+// MARK: - Reader Mode
+extension String {
+    public struct ReaderMode {
+        public static let AvailableVoiceOverAnnouncement = MZLocalizedString("ReaderMode.Available.VoiceOverAnnouncement", value: "Reader Mode available", comment: "Accessibility message e.g. spoken by VoiceOver when Reader Mode becomes available.", lastEditedIn: .unknown)
+        public static let ResetFontSizeAccessibilityLabel = MZLocalizedString("Reset text size", comment: "Accessibility label for button resetting font size in display settings of reader mode", lastEditedIn: .unknown)
+
+        public struct Bar {
+            public static let MarkAsRead = MZLocalizedString("Mark as Read", comment: "Name for Mark as read button in reader mode", lastEditedIn: .unknown)
+            public static let MarkAsUnread = MZLocalizedString("Mark as Unread", comment: "Name for Mark as unread button in reader mode", lastEditedIn: .unknown)
+            public static let Settings = MZLocalizedString("Display Settings", comment: "Name for display settings button in reader mode. Display in the meaning of presentation, not monitor.", lastEditedIn: .unknown)
+            public static let AddToReadingList = MZLocalizedString("Add to Reading List", comment: "Name for button adding current article to reading list in reader mode", lastEditedIn: .unknown)
+            public static let RemoveFromReadingList = MZLocalizedString("Remove from Reading List", comment: "Name for button removing current article from reading list in reader mode", lastEditedIn: .unknown)
+        }
+    }
+}
+
+// MARK: - ReaderPanel
+extension String {
+    public struct ReaderPanel {
+        public static let Remove = MZLocalizedString("Remove", comment: "Title for the button that removes a reading list item", lastEditedIn: .unknown)
+        public static let MarkAsRead = MZLocalizedString("Mark as Read", comment: "Title for the button that marks a reading list item as read", lastEditedIn: .unknown)
+        public static let MarkAsUnread =  MZLocalizedString("Mark as Unread", comment: "Title for the button that marks a reading list item as unread", lastEditedIn: .unknown)
+        public static let UnreadAccessibilityLabel = MZLocalizedString("unread", comment: "Accessibility label for unread article in reading list. It's a past participle - functions as an adjective.", lastEditedIn: .unknown)
+        public static let ReadAccessibilityLabel = MZLocalizedString("read", comment: "Accessibility label for read article in reading list. It's a past participle - functions as an adjective.", lastEditedIn: .unknown)
+        public static let Welcome = MZLocalizedString("Welcome to your Reading List", comment: "See http://mzl.la/1LXbDOL", lastEditedIn: .unknown)
+        public static let ReadingModeDescription = MZLocalizedString("Open articles in Reader View by tapping the book icon when it appears in the title bar.", comment: "See http://mzl.la/1LXbDOL", lastEditedIn: .unknown)
+        public static let ReadingListDescription = MZLocalizedString("Save pages to your Reading List by tapping the book plus icon in the Reader View controls.", comment: "See http://mzl.la/1LXbDOL", lastEditedIn: .unknown)
+    }
+}
+
+// MARK: - Remote Tabs Panel
+extension String {
+    // Backup and active strings added in Bug 1205294.
+    public static let RemoteTabEmptyStateInstructionsSyncTabsPasswordsBookmarksString = MZLocalizedString("Sync your tabs, bookmarks, passwords and more.", comment: "Text displayed when the Sync home panel is empty, describing the features provided by Sync to invite the user to log in.", lastEditedIn: .unknown)
+    public static let RemoteTabEmptyStateInstructionsSyncTabsPasswordsString = MZLocalizedString("Sync your tabs, passwords and more.", comment: "Text displayed when the Sync home panel is empty, describing the features provided by Sync to invite the user to log in.", lastEditedIn: .unknown)
+    public static let RemoteTabEmptyStateInstructionsGetTabsBookmarksPasswordsString = MZLocalizedString("Get your open tabs, bookmarks, and passwords from your other devices.", comment: "A re-worded offer about Sync, displayed when the Sync home panel is empty, that emphasizes one-way data transfer, not syncing.", lastEditedIn: .unknown)
+
+    public static let RemoteTabErrorNoTabs = MZLocalizedString("You don’t have any tabs open in Firefox on your other devices.", comment: "Error message in the remote tabs panel", lastEditedIn: .unknown)
+    public static let RemoteTabErrorFailedToSync = MZLocalizedString("There was a problem accessing tabs from your other devices. Try again in a few moments.", comment: "Error message in the remote tabs panel", lastEditedIn: .unknown)
+    public static let RemoteTabLastSync = MZLocalizedString("Last synced: %@", comment: "Remote tabs last synced time. Argument is the relative date string.", lastEditedIn: .unknown)
+    public static let RemoteTabComputerAccessibilityLabel = MZLocalizedString("computer", comment: "Accessibility label for Desktop Computer (PC) image in remote tabs list", lastEditedIn: .unknown)
+    public static let RemoteTabMobileAccessibilityLabel =  MZLocalizedString("mobile device", comment: "Accessibility label for Mobile Device image in remote tabs list", lastEditedIn: .unknown)
+    public static let RemoteTabCreateAccount = MZLocalizedString("Create an account", comment: "See http://mzl.la/1Qtkf0j", lastEditedIn: .unknown)
+}
+
+
+// MARK: - Reader Mode Handler
+extension String {
+    public static let ReaderModeHandlerLoadingContent = MZLocalizedString("Loading content…", comment: "Message displayed when the reader mode page is loading. This message will appear only when sharing to Firefox reader mode from another app.", lastEditedIn: .unknown)
+    public static let ReaderModeHandlerPageCantDisplay = MZLocalizedString("The page could not be displayed in Reader View.", comment: "Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Firefox reader mode from another app.", lastEditedIn: .unknown)
+    public static let ReaderModeHandlerLoadOriginalPage = MZLocalizedString("Load original page", comment: "Link for going to the non-reader page when the reader view could not be loaded. This message will appear only when sharing to Firefox reader mode from another app.", lastEditedIn: .unknown)
+    public static let ReaderModeHandlerError = MZLocalizedString("There was an error converting the page", comment: "Error displayed when reader mode cannot be enabled", lastEditedIn: .unknown)
+}
+
+// MARK: - ReaderModeStyle
+extension String {
+    public static let ReaderModeStyleBrightnessAccessibilityLabel = MZLocalizedString("Brightness", comment: "Accessibility label for brightness adjustment slider in Reader Mode display settings", lastEditedIn: .unknown)
+    public static let ReaderModeStyleFontTypeAccessibilityLabel = MZLocalizedString("Changes font type.", comment: "Accessibility hint for the font type buttons in reader mode display settings", lastEditedIn: .unknown)
+    public static let ReaderModeStyleSansSerifFontType = MZLocalizedString("Sans-serif", comment: "Font type setting in the reading view settings", lastEditedIn: .unknown)
+    public static let ReaderModeStyleSerifFontType = MZLocalizedString("Serif", comment: "Font type setting in the reading view settings", lastEditedIn: .unknown)
+    public static let ReaderModeStyleSmallerLabel = MZLocalizedString("-", comment: "Button for smaller reader font size. Keep this extremely short! This is shown in the reader mode toolbar.", lastEditedIn: .unknown)
+    public static let ReaderModeStyleSmallerAccessibilityLabel = MZLocalizedString("Decrease text size", comment: "Accessibility label for button decreasing font size in display settings of reader mode", lastEditedIn: .unknown)
+    public static let ReaderModeStyleLargerLabel = MZLocalizedString("+", comment: "Button for larger reader font size. Keep this extremely short! This is shown in the reader mode toolbar.", lastEditedIn: .unknown)
+    public static let ReaderModeStyleLargerAccessibilityLabel = MZLocalizedString("Increase text size", comment: "Accessibility label for button increasing font size in display settings of reader mode", lastEditedIn: .unknown)
+    public static let ReaderModeStyleFontSize = MZLocalizedString("Aa", comment: "Button for reader mode font size. Keep this extremely short! This is shown in the reader mode toolbar.", lastEditedIn: .unknown)
+    public static let ReaderModeStyleChangeColorSchemeAccessibilityHint = MZLocalizedString("Changes color theme.", comment: "Accessibility hint for the color theme setting buttons in reader mode display settings", lastEditedIn: .unknown)
+    public static let ReaderModeStyleLightLabel = MZLocalizedString("Light", comment: "Light theme setting in Reading View settings", lastEditedIn: .unknown)
+    public static let ReaderModeStyleDarkLabel = MZLocalizedString("Dark", comment: "Dark theme setting in Reading View settings", lastEditedIn: .unknown)
+    public static let ReaderModeStyleSepiaLabel = MZLocalizedString("Sepia", comment: "Sepia theme setting in Reading View settings", lastEditedIn: .unknown)
+}
+
+
+// MARK: - S
+
+extension String {
+    // MARK: - Settings
+    public struct Settings {
+
+        public struct SectionTitle {
+            public static let Privacy = MZLocalizedString("Privacy", comment: "Privacy section title", lastEditedIn: .unknown)
+            public static let Support = MZLocalizedString("Support", comment: "Support section title", lastEditedIn: .unknown)
+            public static let About = MZLocalizedString("About", comment: "About settings section title", lastEditedIn: .unknown)
+            public static let General = MZLocalizedString("Settings.General.SectionName", value: "General", comment: "General settings section title", lastEditedIn: .unknown)
+        }
+
+        public static let Title = MZLocalizedString("Settings", comment: "Title in the settings view controller title bar", lastEditedIn: .unknown)
+        public static let Done = MZLocalizedString("Done", comment: "Done button on left side of the Settings view controller title bar", lastEditedIn: .unknown)
+
+        public struct GeneralSection {
+            public static let Search = MZLocalizedString("Search", comment: "Open search section of settings", lastEditedIn: .unknown)
+            public static let SiriSectionName = MZLocalizedString("Settings.Siri.SectionName", value: "Siri Shortcuts", comment: "The option that takes you to the siri shortcuts settings page", lastEditedIn: .unknown)
+            public static let BlockPopups = MZLocalizedString("Block Pop-up Windows", comment: "Block pop-up windows setting", lastEditedIn: .unknown)
+            public static let OfferClipboardBarTitle = MZLocalizedString("Settings.OfferClipboardBar.Title", value: "Offer to Open Copied Links", comment: "Title of setting to enable the Go to Copied URL feature. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349", lastEditedIn: .unknown)
+            public static let OfferClipboardBarStatus = MZLocalizedString("Settings.OfferClipboardBar.Status", value: "When Opening Firefox", comment: "Description displayed under the ”Offer to Open Copied Link” option. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349", lastEditedIn: .unknown)
+            public static let ShowLinkPreviewsTitle = MZLocalizedString("Settings.ShowLinkPreviews.Title", value: "Show Link Previews", comment: "Title of setting to enable link previews when long-pressing links.", lastEditedIn: .unknown)
+            public static let ShowLinkPreviewsStatus = MZLocalizedString("Settings.ShowLinkPreviews.Status", value: "When Long-pressing Links", comment: "Description displayed under the ”Show Link Previews” option", lastEditedIn: .unknown)
+        }
+
+        public struct PrivacySection {
+            public static let PrivacyPolicy = MZLocalizedString("Privacy Policy", comment: "Show Firefox Browser Privacy Policy page from the Privacy section in the settings. See https://www.mozilla.org/privacy/firefox/", lastEditedIn: .unknown)
+            public static let ClosePrivateTabsTitle = MZLocalizedString("Close Private Tabs", tableName: "PrivateBrowsing", comment: "Setting for closing private tabs", lastEditedIn: .unknown)
+            public static let ClosePrivateTabsDescription = MZLocalizedString("When Leaving Private Browsing", tableName: "PrivateBrowsing", comment: "Will be displayed in Settings under 'Close Private Tabs'", lastEditedIn: .unknown)
+            public static let DataManagementSectionName = MZLocalizedString("Settings.DataManagement.SectionName", value: "Data Management", comment: "Label used as an item in Settings. When touched it will open a dialog prompting the user to make sure they want to clear all of their private data.", lastEditedIn: .unknown)
+        }
+
+        public struct SupportSection {
+            public static let SendUsageTitle = MZLocalizedString("Settings.SendUsage.Title", value: "Send Usage Data", comment: "The title for the setting to send usage data.", lastEditedIn: .unknown)
+            public static let SendUsageMessage = MZLocalizedString("Settings.SendUsage.Message", value: "Mozilla strives to only collect what we need to provide and improve Firefox for everyone.", comment: "A short description that explains why mozilla collects usage data.", lastEditedIn: .unknown)
+            public static let SendUsageLink = MZLocalizedString("Settings.SendUsage.Link", value: "Learn More.", comment: "title for a link that explains how mozilla collects telemetry", lastEditedIn: .unknown)
+            public static let ShowTour = MZLocalizedString("Show Tour", comment: "Show the on-boarding screen again from the settings", lastEditedIn: .unknown)
+            public static let StudiesTitle = MZLocalizedString("Settings.Studies.Title", value: "Studies", comment: "Label used as an item in Settings. Tapping on this item takes you to the Studies panel", lastEditedIn: .unknown)
+            public static let StudiesToggleMessage = MZLocalizedString("Settings.Studies.Toggle.Message", value: "Firefox may install and run studies from time to time.", comment: "A short description that explains that Mozilla is running studies", lastEditedIn: .unknown)
+            public static let SendFeedback = MZLocalizedString("Send Feedback", comment: "Menu item in settings used to open input.mozilla.org where people can submit feedback", lastEditedIn: .unknown)
+            public static let Help = MZLocalizedString("Help", comment: "Show the SUMO support page from the Support section in the settings. see http://mzl.la/1dmM8tZ", lastEditedIn: .unknown)
+        }
+
+        public struct AboutSection {
+            public static let Licenses = MZLocalizedString("Licenses", comment: "Settings item that opens a tab containing the licenses. See http://mzl.la/1NSAWCG", lastEditedIn: .unknown)
+            public static let YourRights = MZLocalizedString("Your Rights", comment: "Your Rights settings section title", lastEditedIn: .unknown)
+        }
+
+        public struct SiriShortcuts {
+            public static let SiriSectionDescription = MZLocalizedString("Settings.Siri.SectionDescription", value: "Use Siri shortcuts to quickly open Firefox via Siri", comment: "The description that describes what siri shortcuts are", lastEditedIn: .unknown)
+            public static let SiriOpenURL = MZLocalizedString("Settings.Siri.OpenTabShortcut", value: "Open New Tab", comment: "The description of the open new tab siri shortcut", lastEditedIn: .unknown)
+        }
+
+        // MARK: - Search
+        public struct Search {
+            public static let Title = MZLocalizedString("Search", comment: "Navigation title for search settings.", lastEditedIn: .unknown)
+            public static let DefaultSearchEngineAccessibilityLabel = MZLocalizedString("Default Search Engine", comment: "Accessibility label for default search engine setting.", lastEditedIn: .unknown)
+            public static let ShowSearchSuggestions = MZLocalizedString("Show Search Suggestions", comment: "Label for show search suggestions setting.", lastEditedIn: .unknown)
+            public static let DefaultSearchEngineTitle = MZLocalizedString("Default Search Engine", comment: "Title for default search engine settings section.", lastEditedIn: .unknown)
+            public static let QuickSearchEnginesTitle = MZLocalizedString("Quick-Search Engines", comment: "Title for quick-search engines settings section.", lastEditedIn: .unknown)
+
+            // MARK: - SearchEngine Picker
+            public struct EnginePicker {
+                public static let Title = MZLocalizedString("Default Search Engine", comment: "Title for default search engine picker.", lastEditedIn: .unknown)
+                public static let Cancel = MZLocalizedString("Cancel", comment: "Label for Cancel button", lastEditedIn: .unknown)
+            }
+
+            // MARK: - Add Custom Engine
+            public struct AddCustomEngine {
+                public static let AddCustomEngine = MZLocalizedString("Settings.AddCustomEngine", value: "Add Search Engine", comment: "The button text in Search Settings that opens the Custom Search Engine view.", lastEditedIn: .unknown)
+                public static let Title = MZLocalizedString("Settings.AddCustomEngine.Title", value: "Add Search Engine", comment: "The title of the  Custom Search Engine view.", lastEditedIn: .unknown)
+                public static let TitleLabel = MZLocalizedString("Settings.AddCustomEngine.TitleLabel", value: "Title", comment: "The title for the field which sets the title for a custom search engine.", lastEditedIn: .unknown)
+                public static let URLLabel = MZLocalizedString("Settings.AddCustomEngine.URLLabel", value: "URL", comment: "The title for URL Field", lastEditedIn: .unknown)
+                public static let TitlePlaceholder = MZLocalizedString("Settings.AddCustomEngine.TitlePlaceholder", value: "Search Engine", comment: "The placeholder for Title Field when saving a custom search engine.", lastEditedIn: .unknown)
+                public static let URLPlaceholder = MZLocalizedString("Settings.AddCustomEngine.URLPlaceholder", value: "URL (Replace Query with %s)", comment: "The placeholder for URL Field when saving a custom search engine", lastEditedIn: .unknown)
+                public static let SaveButtonText = MZLocalizedString("Settings.AddCustomEngine.SaveButtonText", value: "Save", comment: "The text on the Save button when saving a custom search engine", lastEditedIn: .unknown)
+            }
+
+            public struct ThirdPartyEngine {
+                public static let EngineAdded = MZLocalizedString("Search.ThirdPartyEngines.AddSuccess", value: "Added Search engine!", comment: "The success message that appears after a user sucessfully adds a new search engine", lastEditedIn: .unknown)
+                public static let AddTitle = MZLocalizedString("Search.ThirdPartyEngines.AddTitle", value: "Add Search Provider?", comment: "The title that asks the user to Add the search provider", lastEditedIn: .unknown)
+                public static let AddMessage = MZLocalizedString("Search.ThirdPartyEngines.AddMessage", value: "The new search engine will appear in the quick search bar.", comment: "The message that asks the user to Add the search provider explaining where the search engine will appear", lastEditedIn: .unknown)
+                public static let CancelButton = MZLocalizedString("Search.ThirdPartyEngines.Cancel", value: "Cancel", comment: "The cancel button if you do not want to add a search engine.", lastEditedIn: .unknown)
+                public static let OkayButton = MZLocalizedString("Search.ThirdPartyEngines.OK", value: "OK", comment: "The confirmation button", lastEditedIn: .unknown)
+                public static let FailedTitle = MZLocalizedString("Search.ThirdPartyEngines.FailedTitle", value: "Failed", comment: "A title explaining that we failed to add a search engine", lastEditedIn: .unknown)
+                public static let FailedMessage = MZLocalizedString("Search.ThirdPartyEngines.FailedMessage", value: "The search provider could not be added.", comment: "A title explaining that we failed to add a search engine", lastEditedIn: .unknown)
+
+                public static let FormErrorTitle = MZLocalizedString("Search.ThirdPartyEngines.FormErrorTitle", value: "Failed", comment: "A title stating that we failed to add custom search engine.", lastEditedIn: .unknown)
+                public static let FormErrorMessage = MZLocalizedString("Search.ThirdPartyEngines.FormErrorMessage", value: "Please fill all fields correctly.", comment: "A message explaining fault in custom search engine form.", lastEditedIn: .unknown)
+                public static let DuplicateErrorTitle = MZLocalizedString("Search.ThirdPartyEngines.DuplicateErrorTitle", value: "Failed", comment: "A title stating that we failed to add custom search engine.", lastEditedIn: .unknown)
+                public static let DuplicateErrorMessage = MZLocalizedString("Search.ThirdPartyEngines.DuplicateErrorMessage", value: "A search engine with this title or URL has already been added.", comment: "A message explaining fault in custom search engine form.", lastEditedIn: .unknown)
+            }
+        }
+
+
+        public static let ClearPrivateDataClearButton = MZLocalizedString("Settings.ClearPrivateData.Clear.Button", value: "Clear Private Data", comment: "Button in settings that clears private data for the selected items.", lastEditedIn: .unknown)
+        public static let ClearAllWebsiteDataButton = MZLocalizedString("Settings.ClearAllWebsiteData.Clear.Button", value: "Clear All Website Data", comment: "Button in Data Management that clears all items.", lastEditedIn: .unknown)
+        public static let ClearSelectedWebsiteDataButton = MZLocalizedString("Settings.ClearSelectedWebsiteData.ClearSelected.Button", value: "Clear Items: %1$@", comment: "Button in Data Management that clears private data for the selected items. Parameter is the number of items to be cleared", lastEditedIn: .unknown)
+
+        public static let FilterSitesSearchLabel = MZLocalizedString("Settings.DataManagement.SearchLabel", value: "Filter Sites", comment: "Default text in search bar for Data Management", lastEditedIn: .unknown)
+        public static let ClearPrivateDataTitle = MZLocalizedString("Settings.ClearPrivateData.Title", value: "Clear Private Data", comment: "Title displayed in header of the setting panel.", lastEditedIn: .unknown)
+        public static let DataManagementTitle = MZLocalizedString("Settings.DataManagement.Title", value: "Data Management", comment: "Title displayed in header of the setting panel.", lastEditedIn: .unknown)
+        public static let WebsiteDataTitle = MZLocalizedString("Settings.WebsiteData.Title", value: "Website Data", comment: "Title displayed in header of the Data Management panel.", lastEditedIn: .unknown)
+        public static let WebsiteDataShowMoreButton = MZLocalizedString("Settings.WebsiteData.ButtonShowMore", value: "Show More", comment: "Button shows all websites on website data tableview", lastEditedIn: .unknown)
+        public static let DisconnectSyncAlertTitle = MZLocalizedString("Settings.Disconnect.Title", value: "Disconnect Sync?", comment: "Title of the alert when prompting the user asking to disconnect.", lastEditedIn: .unknown)
+        public static let DisconnectSyncAlertBody = MZLocalizedString("Settings.Disconnect.Body", value: "Firefox will stop syncing with your account, but won’t delete any of your browsing data on this device.", comment: "Body of the alert when prompting the user asking to disconnect.", lastEditedIn: .unknown)
+        public static let DisconnectSyncButton = MZLocalizedString("Settings.Disconnect.Button", value: "Disconnect Sync", comment: "Button displayed at the bottom of settings page allowing users to Disconnect from FxA", lastEditedIn: .unknown)
+        public static let DisconnectCancelAction = MZLocalizedString("Settings.Disconnect.CancelButton", value: "Cancel", comment: "Cancel action button in alert when user is prompted for disconnect", lastEditedIn: .unknown)
+        public static let DisconnectDestructiveAction = MZLocalizedString("Settings.Disconnect.DestructiveButton", value: "Disconnect", comment: "Destructive action button in alert when user is prompted for disconnect", lastEditedIn: .unknown)
+        public static let SearchDoneButton = MZLocalizedString("Settings.Search.Done.Button", value: "Done", comment: "Button displayed at the top of the search settings.", lastEditedIn: .unknown)
+        public static let SearchEditButton = MZLocalizedString("Settings.Search.Edit.Button", value: "Edit", comment: "Button displayed at the top of the search settings.", lastEditedIn: .unknown)
+        public static let UseTouchID = MZLocalizedString("Use Touch ID", tableName: "AuthenticationManager", comment: "List section title for when to use Touch ID", lastEditedIn: .unknown)
+        public static let UseFaceID = MZLocalizedString("Use Face ID", tableName: "AuthenticationManager", comment: "List section title for when to use Face ID", lastEditedIn: .unknown)
+        public static let CopyAppVersionAlertTitle = MZLocalizedString("Settings.CopyAppVersion.Title", value: "Copied to clipboard", comment: "Copy app version alert shown in settings.", lastEditedIn: .unknown)
+    }
+
+// MARK: - Advanced Sync Settings (Debug)
+// For 'Advanced Sync Settings' view, which is a debug setting. English only, there is little value in maintaining L10N strings for these.
+    public static let SettingsAdvancedAccountTitle = "Advanced Sync Settings"
+    public static let SettingsAdvancedAccountCustomFxAContentServerURI = "Custom Firefox Account Content Server URI"
+    public static let SettingsAdvancedAccountUseCustomFxAContentServerURITitle = "Use Custom FxA Content Server"
+    public static let SettingsAdvancedAccountCustomSyncTokenServerURI = "Custom Sync Token Server URI"
+    public static let SettingsAdvancedAccountUseCustomSyncTokenServerTitle = "Use Custom Sync Token Server"
+
+    public static let AdvancedAccountUseStageServer = MZLocalizedString("Use stage servers", comment: "Debug option", lastEditedIn: .unknown)
+}
+
+
+// MARK: - Syncing
+extension String {
+    public struct Syncing {
+        public static let SyncingMessageWithEllipsis = MZLocalizedString("Sync.SyncingEllipsis.Label", value: "Syncing…", comment: "Message displayed when the user's account is syncing with ellipsis at the end", lastEditedIn: .unknown)
+
+        public struct FirefoxSync {
+            public static let OfflineTitle = MZLocalizedString("SyncState.Offline.Title", value: "Sync is offline", comment: "Title for Sync status message when Sync failed due to being offline", lastEditedIn: .unknown)
+            public static let TroubleshootTitle = MZLocalizedString("Settings.TroubleShootSync.Title", value: "Troubleshoot", comment: "Title of link to help page to find out how to solve Sync issues", lastEditedIn: .unknown)
+            public static let BookmarksEngine = MZLocalizedString("Bookmarks", comment: "Toggle bookmarks syncing setting", lastEditedIn: .unknown)
+            public static let HistoryEngine = MZLocalizedString("History", comment: "Toggle history syncing setting", lastEditedIn: .unknown)
+            public static let TabsEngine = MZLocalizedString("Open Tabs", comment: "Toggle tabs syncing setting", lastEditedIn: .unknown)
+            public static let LoginsEngine = MZLocalizedString("Logins", comment: "Toggle logins syncing setting", lastEditedIn: .unknown)
+        }
+    }
 }
 
 // MARK: - Snackbar shown when tapping app store link
 extension String {
-    public static let ExternalLinkAppStoreConfirmationTitle = MZLocalizedString("ExternalLink.AppStore.ConfirmationTitle", value: "Open this link in the App Store?", comment: "Question shown to user when tapping a link that opens the App Store app", lastEditedIn: .unknown)
-    public static let ExternalLinkGenericConfirmation = MZLocalizedString("ExternalLink.AppStore.GenericConfirmationTitle", value: "Open this link in external app?", comment: "Question shown to user when tapping an SMS or MailTo link that opens the external app for those.", lastEditedIn: .unknown)
+    public struct Snackbar {
+        public struct ExternalLinks {
+            public static let AppStoreConfirmationTitle = MZLocalizedString("ExternalLink.AppStore.ConfirmationTitle", value: "Open this link in the App Store?", comment: "Question shown to user when tapping a link that opens the App Store app", lastEditedIn: .unknown)
+            public static let GenericConfirmation = MZLocalizedString("ExternalLink.AppStore.GenericConfirmationTitle", value: "Open this link in external app?", comment: "Question shown to user when tapping an SMS or MailTo link that opens the external app for those.", lastEditedIn: .unknown)
+        }
+    }
+}
+
+// MARK: - Share extension
+extension String {
+    public struct ShareExtension {
+        public struct SendTo {
+            public static let CancelButton = MZLocalizedString("SendTo.Cancel.Button", value: "Cancel", comment: "Button title for cancelling share screen", lastEditedIn: .unknown)
+            public static let ErrorOKButton = MZLocalizedString("SendTo.Error.OK.Button", value: "OK", comment: "OK button to dismiss the error prompt.", lastEditedIn: .unknown)
+            public static let ErrorTitle = MZLocalizedString("SendTo.Error.Title", value: "The link you are trying to share cannot be shared.", comment: "Title of error prompt displayed when an invalid URL is shared.", lastEditedIn: .unknown)
+            public static let ErrorMessage = MZLocalizedString("SendTo.Error.Message", value: "Only HTTP and HTTPS links can be shared.", comment: "Message in error prompt explaining why the URL is invalid.", lastEditedIn: .unknown)
+            public static let CloseButton = MZLocalizedString("SendTo.Cancel.Button", value: "Close", comment: "Close button in top navigation bar", lastEditedIn: .unknown)
+            public static let NotSignedInText = MZLocalizedString("SendTo.NotSignedIn.Title", value: "You are not signed in to your Firefox Account.", comment: "See http://mzl.la/1ISlXnU", lastEditedIn: .unknown)
+            public static let NotSignedInMessage = MZLocalizedString("SendTo.NotSignedIn.Message", value: "Please open Firefox, go to Settings and sign in to continue.", comment: "See http://mzl.la/1ISlXnU", lastEditedIn: .unknown)
+            public static let NoDevicesFound = MZLocalizedString("SendTo.NoDevicesFound.Message", value: "You don’t have any other devices connected to this Firefox Account available to sync.", comment: "Error message shown in the remote tabs panel", lastEditedIn: .unknown)
+            public static let Title = MZLocalizedString("SendTo.NavBar.Title", value: "Send Tab", comment: "Title of the dialog that allows you to send a tab to a different device", lastEditedIn: .unknown)
+            public static let SendButtonTitle = MZLocalizedString("SendTo.SendAction.Text", value: "Send", comment: "Navigation bar button to Send the current page to a device", lastEditedIn: .unknown)
+            public static let DevicesListTitle = MZLocalizedString("SendTo.DeviceList.Text", value: "Available devices:", comment: "Header for the list of devices table", lastEditedIn: .unknown)
+            public static let Device = String.AppMenu.SendToDeviceTitle
+        }
+
+        // The above items are re-used strings from the old extension. New strings below.
+        public static let AddToReadingList = MZLocalizedString("ShareExtension.AddToReadingListAction.Title", value: "Add to Reading List", comment: "Action label on share extension to add page to the Firefox reading list.", lastEditedIn: .unknown)
+        public static let AddToReadingListDone = MZLocalizedString("ShareExtension.AddToReadingListActionDone.Title", value: "Added to Reading List", comment: "Share extension label shown after user has performed 'Add to Reading List' action.", lastEditedIn: .unknown)
+        public static let BookmarkThisPage = MZLocalizedString("ShareExtension.BookmarkThisPageAction.Title", value: "Bookmark This Page", comment: "Action label on share extension to bookmark the page in Firefox.", lastEditedIn: .unknown)
+        public static let BookmarkThisPageDone = MZLocalizedString("ShareExtension.BookmarkThisPageActionDone.Title", value: "Bookmarked", comment: "Share extension label shown after user has performed 'Bookmark this Page' action.", lastEditedIn: .unknown)
+
+        public static let OpenInFirefox = MZLocalizedString("ShareExtension.OpenInFirefoxAction.Title", value: "Open in Firefox", comment: "Action label on share extension to immediately open page in Firefox.", lastEditedIn: .unknown)
+        public static let SearchInFirefox = MZLocalizedString("ShareExtension.SeachInFirefoxAction.Title", value: "Search in Firefox", comment: "Action label on share extension to search for the selected text in Firefox.", lastEditedIn: .unknown)
+
+        public static let LoadInBackground = MZLocalizedString("ShareExtension.LoadInBackgroundAction.Title", value: "Load in Background", comment: "Action label on share extension to load the page in Firefox when user switches apps to bring it to foreground.", lastEditedIn: .unknown)
+        public static let LoadInBackgroundDone = MZLocalizedString("ShareExtension.LoadInBackgroundActionDone.Title", value: "Loading in Firefox", comment: "Share extension label shown after user has performed 'Load in Background' action.", lastEditedIn: .unknown)
+    }
+}
+
+// MARK: - SearchViewController
+extension String {
+    public struct SearchView {
+        public static let SettingsAccessibilityLabel = MZLocalizedString("Search Settings", tableName: "Search", comment: "Label for search settings button.", lastEditedIn: .unknown)
+        public static let SearchEngineAccessibilityLabel = MZLocalizedString("%@ search", tableName: "Search", comment: "Label for search engine buttons. The argument corresponds to the name of the search engine.", lastEditedIn: .unknown)
+        public static let SuggestionCellSwitchToTabLabel = MZLocalizedString("Search.Awesomebar.SwitchToTab", value: "Switch to tab", comment: "Search suggestion cell label that allows user to switch to tab which they searched for in url bar", lastEditedIn: .unknown)
+    }
+}
+
+
+
+// MARK: - SettingsContent
+extension String {
+    public static let SettingsContentPageLoadError = MZLocalizedString("Could not load page.", comment: "Error message that is shown in settings when there was a problem loading", lastEditedIn: .unknown)
+}
+
+// MARK: - SearchInput
+extension String {
+    public static let SearchInputAccessibilityLabel = MZLocalizedString("Search Input Field", tableName: "LoginManager", comment: "Accessibility label for the search input field in the Logins list", lastEditedIn: .unknown)
+    public static let SearchInputTitle = MZLocalizedString("Search", tableName: "LoginManager", comment: "Title for the search field at the top of the Logins list screen", lastEditedIn: .unknown)
+    public static let SearchInputClearAccessibilityLabel = MZLocalizedString("Clear Search", tableName: "LoginManager", comment: "Accessibility message e.g. spoken by VoiceOver after the user taps the close button in the search field to clear the search and exit search mode", lastEditedIn: .unknown)
+    public static let SearchInputEnterSearchMode = MZLocalizedString("Enter Search Mode", tableName: "LoginManager", comment: "Accessibility label for entering search mode for logins", lastEditedIn: .unknown)
+}
+
+// MARK: - T
+// MARK: - Table date section titles
+extension String {
+    public struct TableDateSectionTitles {
+        public static let Today = MZLocalizedString("Today", comment: "History tableview section header", lastEditedIn: .unknown)
+        public static let Yesterday = MZLocalizedString("Yesterday", comment: "History tableview section header", lastEditedIn: .unknown)
+        public static let LastWeek = MZLocalizedString("Last week", comment: "History tableview section header", lastEditedIn: .unknown)
+        public static let LastMonth = MZLocalizedString("Last month", comment: "History tableview section header", lastEditedIn: .unknown)
+    }
+}
+
+// MARK: - Top Sites
+extension String {
+    public struct TopSites {
+        public static let RemoveButtonAccessibilityLabel = MZLocalizedString("TopSites.RemovePage.Button", value: "Remove page — %@", comment: "Button shown in editing mode to remove this site from the top sites panel.", lastEditedIn: .unknown)
+
+        // Unused
+        public static let EmptyStateDescription = MZLocalizedString("TopSites.EmptyState.Description", value: "Your most visited sites will show up here.", comment: "Description label for the empty Top Sites state.", lastEditedIn: .unknown)
+        public static let EmptyStateTitle = MZLocalizedString("TopSites.EmptyState.Title", value: "Welcome to Top Sites", comment: "The title for the empty Top Sites state", lastEditedIn: .unknown)
+    }
 }
 
 // MARK: - ContentBlocker/TrackingProtection string
@@ -660,183 +1205,75 @@ extension String {
 
 // MARK: - Tracking Protection menu
 extension String {
-    public static let TPBlockingDescription = MZLocalizedString("Menu.TrackingProtectionBlocking.Description", value: "Firefox is blocking parts of the page that may track your browsing.", comment: "Description of the Tracking protection menu when TP is blocking parts of the page", lastEditedIn: .unknown)
-    public static let TPNoBlockingDescription = MZLocalizedString("Menu.TrackingProtectionNoBlocking.Description", value: "No tracking elements detected on this page.", comment: "The description of the Tracking Protection menu item when no scripts are blocked but tracking protection is enabled.", lastEditedIn: .unknown)
-    public static let TPBlockingDisabledDescription = MZLocalizedString("Menu.TrackingProtectionBlockingDisabled.Description", value: "Block online trackers", comment: "The description of the Tracking Protection menu item when tracking is enabled", lastEditedIn: .unknown)
-    public static let TPBlockingMoreInfo = MZLocalizedString("Menu.TrackingProtectionMoreInfo.Description", value: "Learn more about how Tracking Protection blocks online trackers that collect your browsing data across multiple websites.", comment: "more info about what tracking protection is about", lastEditedIn: .unknown)
-    public static let EnableTPBlockingGlobally = MZLocalizedString("Menu.TrackingProtectionEnable.Title", value: "Enable Tracking Protection", comment: "A button to enable tracking protection inside the menu.", lastEditedIn: .unknown)
-    public static let TPBlockingSiteEnabled = MZLocalizedString("Menu.TrackingProtectionEnable1.Title", value: "Enabled for this site", comment: "A button to enable tracking protection inside the menu.", lastEditedIn: .unknown)
-    public static let TPEnabledConfirmed = MZLocalizedString("Menu.TrackingProtectionEnabled.Title", value: "Tracking Protection is now on for this site.", comment: "The confirmation toast once tracking protection has been enabled", lastEditedIn: .unknown)
-    public static let TPDisabledConfirmed = MZLocalizedString("Menu.TrackingProtectionDisabled.Title", value: "Tracking Protection is now off for this site.", comment: "The confirmation toast once tracking protection has been disabled", lastEditedIn: .unknown)
-    public static let TPBlockingSiteDisabled = MZLocalizedString("Menu.TrackingProtectionDisable1.Title", value: "Disabled for this site", comment: "The button that disabled TP for a site.", lastEditedIn: .unknown)
-    public static let ETPOn = MZLocalizedString("Menu.EnhancedTrackingProtectionOn.Title", value: "Enhanced Tracking Protection is ON for this site.", comment: "A switch to enable enhanced tracking protection inside the menu.", lastEditedIn: .unknown)
-    public static let ETPOff = MZLocalizedString("Menu.EnhancedTrackingProtectionOff.Title", value: "Enhanced Tracking Protection is OFF for this site.", comment: "A switch to disable enhanced tracking protection inside the menu.", lastEditedIn: .unknown)
-    public static let StrictETPWithITP = MZLocalizedString("Menu.EnhancedTrackingProtectionStrictWithITP.Title", value: "Firefox blocks cross-site trackers, social trackers, cryptominers, fingerprinters, and tracking content.", comment: "Description for having strict ETP protection with ITP offered in iOS14+", lastEditedIn: .unknown)
-    public static let StandardETPWithITP = MZLocalizedString("Menu.EnhancedTrackingProtectionStandardWithITP.Title", value: "Firefox blocks cross-site trackers, social trackers, cryptominers, and fingerprinters.", comment: "Description for having standard ETP protection with ITP offered in iOS14+", lastEditedIn: .unknown)
+    public struct TrackingProtection {
+        public static let NoBlockingDescription = MZLocalizedString("Menu.TrackingProtectionNoBlocking.Description", value: "No tracking elements detected on this page.", comment: "The description of the Tracking Protection menu item when no scripts are blocked but tracking protection is enabled.", lastEditedIn: .unknown)
+        public static let BlockingMoreInfo = MZLocalizedString("Menu.TrackingProtectionMoreInfo.Description", value: "Learn more about how Tracking Protection blocks online trackers that collect your browsing data across multiple websites.", comment: "more info about what tracking protection is about", lastEditedIn: .unknown)
+        public static let EnableTPBlockingGlobally = MZLocalizedString("Menu.TrackingProtectionEnable.Title", value: "Enable Tracking Protection", comment: "A button to enable tracking protection inside the menu.", lastEditedIn: .unknown)
+        public static let ETPOn = MZLocalizedString("Menu.EnhancedTrackingProtectionOn.Title", value: "Enhanced Tracking Protection is ON for this site.", comment: "A switch to enable enhanced tracking protection inside the menu.", lastEditedIn: .unknown)
+        public static let ETPOff = MZLocalizedString("Menu.EnhancedTrackingProtectionOff.Title", value: "Enhanced Tracking Protection is OFF for this site.", comment: "A switch to disable enhanced tracking protection inside the menu.", lastEditedIn: .unknown)
+        public static let StrictETPWithITP = MZLocalizedString("Menu.EnhancedTrackingProtectionStrictWithITP.Title", value: "Firefox blocks cross-site trackers, social trackers, cryptominers, fingerprinters, and tracking content.", comment: "Description for having strict ETP protection with ITP offered in iOS14+", lastEditedIn: .unknown)
+        public static let StandardETPWithITP = MZLocalizedString("Menu.EnhancedTrackingProtectionStandardWithITP.Title", value: "Firefox blocks cross-site trackers, social trackers, cryptominers, and fingerprinters.", comment: "Description for having standard ETP protection with ITP offered in iOS14+", lastEditedIn: .unknown)
 
-    // TP Page menu title
-    public static let TPPageMenuTitle = MZLocalizedString("Menu.TrackingProtection.TitlePrefix", value: "Protections for %@", comment: "Title on tracking protection menu showing the domain. eg. Protections for mozilla.org", lastEditedIn: .unknown)
-    public static let TPPageMenuNoTrackersBlocked = MZLocalizedString("Menu.TrackingProtection.NoTrackersBlockedTitle", value: "No trackers known to Firefox were detected on this page.", comment: "Message in menu when no trackers blocked.", lastEditedIn: .unknown)
-    public static let TPPageMenuBlockedTitle = MZLocalizedString("Menu.TrackingProtection.BlockedTitle", value: "Blocked", comment: "Title on tracking protection menu for blocked items.", lastEditedIn: .unknown)
+        public struct PageMenuTitles {
+            public static let Title = MZLocalizedString("Menu.TrackingProtection.TitlePrefix", value: "Protections for %@", comment: "Title on tracking protection menu showing the domain. eg. Protections for mozilla.org", lastEditedIn: .unknown)
+            public static let NoTrackersBlocked = MZLocalizedString("Menu.TrackingProtection.NoTrackersBlockedTitle", value: "No trackers known to Firefox were detected on this page.", comment: "Message in menu when no trackers blocked.", lastEditedIn: .unknown)
+            public static let BlockedTitle = MZLocalizedString("Menu.TrackingProtection.BlockedTitle", value: "Blocked", comment: "Title on tracking protection menu for blocked items.", lastEditedIn: .unknown)
+        }
 
-    // Category Titles
-    public static let TPCryptominersBlocked = MZLocalizedString("Menu.TrackingProtectionCryptominersBlocked.Title", value: "Cryptominers", comment: "The title that shows the number of cryptomining scripts blocked", lastEditedIn: .unknown)
-    public static let TPFingerprintersBlocked = MZLocalizedString("Menu.TrackingProtectionFingerprintersBlocked.Title", value: "Fingerprinters", comment: "The title that shows the number of fingerprinting scripts blocked", lastEditedIn: .unknown)
-    public static let TPCrossSiteCookiesBlocked = MZLocalizedString("Menu.TrackingProtectionCrossSiteCookies.Title", value: "Cross-Site Tracking Cookies", comment: "The title that shows the number of cross-site cookies blocked", lastEditedIn: .unknown)
-    public static let TPCrossSiteBlocked = MZLocalizedString("Menu.TrackingProtectionCrossSiteTrackers.Title", value: "Cross-Site Trackers", comment: "The title that shows the number of cross-site URLs blocked", lastEditedIn: .unknown)
-    public static let TPSocialBlocked = MZLocalizedString("Menu.TrackingProtectionBlockedSocial.Title", value: "Social Trackers", comment: "The title that shows the number of social URLs blocked", lastEditedIn: .unknown)
-    public static let TPContentBlocked = MZLocalizedString("Menu.TrackingProtectionBlockedContent.Title", value: "Tracking content", comment: "The title that shows the number of content cookies blocked", lastEditedIn: .unknown)
 
-    // Shortcut on bottom of TP page menu to get to settings.
-    public static let TPProtectionSettings = MZLocalizedString("Menu.TrackingProtection.ProtectionSettings.Title", value: "Protection Settings", comment: "The title for tracking protection settings", lastEditedIn: .unknown)
+        // Shortcut on bottom of TP page menu to get to settings.
+        public static let ProtectionSettings = MZLocalizedString("Menu.TrackingProtection.ProtectionSettings.Title", value: "Protection Settings", comment: "The title for tracking protection settings", lastEditedIn: .unknown)
+        public static let SafeListRemove = MZLocalizedString("Menu.TrackingProtectionWhitelistRemove.Title", value: "Enable for this site", comment: "label for the menu item that lets you remove a website from the tracking protection whitelist", lastEditedIn: .unknown)
 
-    // Remove if unused -->
-    public static let TPListTitle_CrossSiteCookies = MZLocalizedString("Menu.TrackingProtectionListTitle.CrossSiteCookies", value: "Blocked Cross-Site Tracking Cookies", comment: "Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners`", lastEditedIn: .unknown)
-    public static let TPListTitle_Social = MZLocalizedString("Menu.TrackingProtectionListTitle.Social", value: "Blocked Social Trackers", comment: "Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners`", lastEditedIn: .unknown)
-    public static let TPListTitle_Fingerprinters = MZLocalizedString("Menu.TrackingProtectionListTitle.Fingerprinters", value: "Blocked Fingerprinters", comment: "Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners`", lastEditedIn: .unknown)
-    public static let TPListTitle_Cryptominer = MZLocalizedString("Menu.TrackingProtectionListTitle.Cryptominers", value: "Blocked Cryptominers", comment: "Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners`", lastEditedIn: .unknown)
-    /// <--
+        // Settings info
+        public static let AccessoryInfoBlocksTitle = MZLocalizedString("Settings.TrackingProtection.Info.BlocksTitle", value: "BLOCKS", comment: "The Title on info view which shows a list of all blocked websites", lastEditedIn: .unknown)
 
-    public static let TPSafeListOn = MZLocalizedString("Menu.TrackingProtectionOption.WhiteListOnDescription", value: "The site includes elements that may track your browsing. You have disabled protection.", comment: "label for the menu item to show when the website is whitelisted from blocking trackers.", lastEditedIn: .unknown)
-    public static let TPSafeListRemove = MZLocalizedString("Menu.TrackingProtectionWhitelistRemove.Title", value: "Enable for this site", comment: "label for the menu item that lets you remove a website from the tracking protection whitelist", lastEditedIn: .unknown)
+        public struct Category {
+            public struct Titles {
+                public static let CryptominersBlocked = MZLocalizedString("Menu.TrackingProtectionCryptominersBlocked.Title", value: "Cryptominers", comment: "The title that shows the number of cryptomining scripts blocked", lastEditedIn: .unknown)
+                public static let FingerprintersBlocked = MZLocalizedString("Menu.TrackingProtectionFingerprintersBlocked.Title", value: "Fingerprinters", comment: "The title that shows the number of fingerprinting scripts blocked", lastEditedIn: .unknown)
+                public static let CrossSiteBlocked = MZLocalizedString("Menu.TrackingProtectionCrossSiteTrackers.Title", value: "Cross-Site Trackers", comment: "The title that shows the number of cross-site URLs blocked", lastEditedIn: .unknown)
+                public static let SocialBlocked = MZLocalizedString("Menu.TrackingProtectionBlockedSocial.Title", value: "Social Trackers", comment: "The title that shows the number of social URLs blocked", lastEditedIn: .unknown)
+                public static let ContentBlocked = MZLocalizedString("Menu.TrackingProtectionBlockedContent.Title", value: "Tracking content", comment: "The title that shows the number of content cookies blocked", lastEditedIn: .unknown)
+            }
 
-    // Settings info
-    public static let TPAccessoryInfoTitleStrict = MZLocalizedString("Settings.TrackingProtection.Info.StrictTitle", value: "Offers stronger protection, but may cause some sites to break.", comment: "Explanation of strict mode.", lastEditedIn: .unknown)
-    public static let TPAccessoryInfoTitleBasic = MZLocalizedString("Settings.TrackingProtection.Info.BasicTitle", value: "Balanced for protection and performance.", comment: "Explanation of basic mode.", lastEditedIn: .unknown)
-    public static let TPAccessoryInfoBlocksTitle = MZLocalizedString("Settings.TrackingProtection.Info.BlocksTitle", value: "BLOCKS", comment: "The Title on info view which shows a list of all blocked websites", lastEditedIn: .unknown)
-
-    // Category descriptions
-    public static let TPCategoryDescriptionSocial = MZLocalizedString("Menu.TrackingProtectionDescription.SocialNetworksNew", value: "Social networks place trackers on other websites to build a more complete and targeted profile of you. Blocking these trackers reduces how much social media companies can see what do you online.", comment: "Description of social network trackers.", lastEditedIn: .unknown)
-    public static let TPCategoryDescriptionCrossSite = MZLocalizedString("Menu.TrackingProtectionDescription.CrossSiteNew", value: "These cookies follow you from site to site to gather data about what you do online. They are set by third parties such as advertisers and analytics companies.", comment: "Description of cross-site trackers.", lastEditedIn: .unknown)
-    public static let TPCategoryDescriptionCryptominers = MZLocalizedString("Menu.TrackingProtectionDescription.CryptominersNew", value: "Cryptominers secretly use your system’s computing power to mine digital money. Cryptomining scripts drain your battery, slow down your computer, and can increase your energy bill.", comment: "Description of cryptominers.", lastEditedIn: .unknown)
-    public static let TPCategoryDescriptionFingerprinters = MZLocalizedString("Menu.TrackingProtectionDescription.Fingerprinters", value: "The settings on your browser and computer are unique. Fingerprinters collect a variety of these unique settings to create a profile of you, which can be used to track you as you browse.", comment: "Description of fingerprinters.", lastEditedIn: .unknown)
-    public static let TPCategoryDescriptionContentTrackers = MZLocalizedString("Menu.TrackingProtectionDescription.ContentTrackers", value: "Websites may load outside ads, videos, and other content that contains hidden trackers. Blocking this can make websites load faster, but some buttons, forms, and login fields, might not work.", comment: "Description of content trackers.", lastEditedIn: .unknown)
-
-    public static let TPMoreInfo = MZLocalizedString("Settings.TrackingProtection.MoreInfo", value: "More Info…", comment: "'More Info' link on the Tracking Protection settings screen.", lastEditedIn: .unknown)
+            public struct Descriptions {
+                public static let Social = MZLocalizedString("Menu.TrackingProtectionDescription.SocialNetworksNew", value: "Social networks place trackers on other websites to build a more complete and targeted profile of you. Blocking these trackers reduces how much social media companies can see what do you online.", comment: "Description of social network trackers.", lastEditedIn: .unknown)
+                public static let CrossSite = MZLocalizedString("Menu.TrackingProtectionDescription.CrossSiteNew", value: "These cookies follow you from site to site to gather data about what you do online. They are set by third parties such as advertisers and analytics companies.", comment: "Description of cross-site trackers.", lastEditedIn: .unknown)
+                public static let Cryptominers = MZLocalizedString("Menu.TrackingProtectionDescription.CryptominersNew", value: "Cryptominers secretly use your system’s computing power to mine digital money. Cryptomining scripts drain your battery, slow down your computer, and can increase your energy bill.", comment: "Description of cryptominers.", lastEditedIn: .unknown)
+                public static let Fingerprinters = MZLocalizedString("Menu.TrackingProtectionDescription.Fingerprinters", value: "The settings on your browser and computer are unique. Fingerprinters collect a variety of these unique settings to create a profile of you, which can be used to track you as you browse.", comment: "Description of fingerprinters.", lastEditedIn: .unknown)
+                public static let ContentTrackers = MZLocalizedString("Menu.TrackingProtectionDescription.ContentTrackers", value: "Websites may load outside ads, videos, and other content that contains hidden trackers. Blocking this can make websites load faster, but some buttons, forms, and login fields, might not work.", comment: "Description of content trackers.", lastEditedIn: .unknown)
+            }
+        }
+    }
 }
 
-// MARK: - Location bar long press menu
+// MARK: - Third Party Search Engines
 extension String {
-    public static let PasteAndGoTitle = MZLocalizedString("Menu.PasteAndGo.Title", value: "Paste & Go", comment: "The title for the button that lets you paste and go to a URL", lastEditedIn: .unknown)
-    public static let PasteTitle = MZLocalizedString("Menu.Paste.Title", value: "Paste", comment: "The title for the button that lets you paste into the location bar", lastEditedIn: .unknown)
-    public static let CopyAddressTitle = MZLocalizedString("Menu.Copy.Title", value: "Copy Address", comment: "The title for the button that lets you copy the url from the location bar.", lastEditedIn: .unknown)
 }
 
-// MARK: - Settings Home
+// MARK: - Tabs Delete All Undo Toast
 extension String {
-    public static let SendUsageSettingTitle = MZLocalizedString("Settings.SendUsage.Title", value: "Send Usage Data", comment: "The title for the setting to send usage data.", lastEditedIn: .unknown)
-    public static let SendUsageSettingLink = MZLocalizedString("Settings.SendUsage.Link", value: "Learn More.", comment: "title for a link that explains how mozilla collects telemetry", lastEditedIn: .unknown)
-    public static let SendUsageSettingMessage = MZLocalizedString("Settings.SendUsage.Message", value: "Mozilla strives to only collect what we need to provide and improve Firefox for everyone.", comment: "A short description that explains why mozilla collects usage data.", lastEditedIn: .unknown)
-    public static let SettingsSiriSectionName = MZLocalizedString("Settings.Siri.SectionName", value: "Siri Shortcuts", comment: "The option that takes you to the siri shortcuts settings page", lastEditedIn: .unknown)
-    public static let SettingsSiriSectionDescription = MZLocalizedString("Settings.Siri.SectionDescription", value: "Use Siri shortcuts to quickly open Firefox via Siri", comment: "The description that describes what siri shortcuts are", lastEditedIn: .unknown)
-    public static let SettingsSiriOpenURL = MZLocalizedString("Settings.Siri.OpenTabShortcut", value: "Open New Tab", comment: "The description of the open new tab siri shortcut", lastEditedIn: .unknown)
+    public static let TabsDeleteAllUndoTitle = MZLocalizedString("Tabs.DeleteAllUndo.Title", value: "%d tab(s) closed", comment: "The label indicating that all the tabs were closed", lastEditedIn: .unknown)
+    public static let TabsDeleteAllUndoAction = MZLocalizedString("Tabs.DeleteAllUndo.Button", value: "Undo", comment: "The button to undo the delete all tabs", lastEditedIn: .unknown)
+    public static let TabSearchPlaceholderText = MZLocalizedString("Tabs.Search.PlaceholderText", value: "Search Tabs", comment: "The placeholder text for the tab search bar", lastEditedIn: .unknown)
 }
 
-// MARK: - Nimbus settings
+// MARK: - Tab tray (chronological tabs)
 extension String {
-    public static let SettingsStudiesTitle = MZLocalizedString("Settings.Studies.Title", value: "Studies", comment: "Label used as an item in Settings. Tapping on this item takes you to the Studies panel", lastEditedIn: .unknown)
-    public static let SettingsStudiesSectionName = MZLocalizedString("Settings.Studies.SectionName", value: "Studies", comment: "Title displayed in header of the Studies panel", lastEditedIn: .unknown)
-    public static let SettingsStudiesActiveSectionTitle = MZLocalizedString("Settings.Studies.Active.SectionName", value: "Active", comment: "Section title for all studies that are currently active", lastEditedIn: .unknown)
-    public static let SettingsStudiesCompletedSectionTitle = MZLocalizedString("Settings.Studies.Completed.SectionName", value: "Completed", comment: "Section title for all studies that are completed", lastEditedIn: .unknown)
-    public static let SettingsStudiesRemoveButton = MZLocalizedString("Settings.Studies.Remove.Button", value: "Remove", comment: "Button title displayed next to each study allowing the user to opt-out of the study", lastEditedIn: .unknown)
+    public static let TabTrayV2Title = MZLocalizedString("TabTray.Title", value: "Open Tabs", comment: "The title for the tab tray", lastEditedIn: .unknown)
+    public static let TabTrayV2TodayHeader = MZLocalizedString("TabTray.Today.Header", value: "Today", comment: "The section header for tabs opened today", lastEditedIn: .unknown)
+    public static let TabTrayV2YesterdayHeader = MZLocalizedString("TabTray.Yesterday.Header", value: "Yesterday", comment: "The section header for tabs opened yesterday", lastEditedIn: .unknown)
+    public static let TabTrayV2LastWeekHeader = MZLocalizedString("TabTray.LastWeek.Header", value: "Last Week", comment: "The section header for tabs opened last week", lastEditedIn: .unknown)
+    public static let TabTrayV2OlderHeader = MZLocalizedString("TabTray.Older.Header", value: "Older", comment: "The section header for tabs opened before last week", lastEditedIn: .unknown)
+    public static let TabTraySwipeMenuMore = MZLocalizedString("TabTray.SwipeMenu.More", value: "More", comment: "The button title to see more options to perform on the tab.", lastEditedIn: .unknown)
+    public static let TabTrayMoreMenuCopy = MZLocalizedString("TabTray.MoreMenu.Copy", value: "Copy", comment: "The title on the button to copy the tab address.", lastEditedIn: .unknown)
+    public static let TabTrayV2PrivateTitle = MZLocalizedString("TabTray.PrivateTitle", value: "Private Tabs", comment: "The title for the tab tray in private mode", lastEditedIn: .unknown)
 
-    public static let SettingsStudiesToggleTitle = MZLocalizedString("Settings.Studies.Toggle.Title", value: "Studies", comment: "Label used as a toggle item in Settings. When this is off, the user is opting out of all studies.", lastEditedIn: .unknown)
-    public static let SettingsStudiesToggleLink = MZLocalizedString("Settings.Studies.Toggle.Link", value: "Learn More.", comment: "Title for a link that explains what Mozilla means by Studies", lastEditedIn: .unknown)
-    public static let SettingsStudiesToggleMessage = MZLocalizedString("Settings.Studies.Toggle.Message", value: "Firefox may install and run studies from time to time.", comment: "A short description that explains that Mozilla is running studies", lastEditedIn: .unknown)
-
-    public static let SettingsStudiesToggleValueOn = MZLocalizedString("Settings.Studies.Toggle.On", value: "On", comment: "Toggled ON to participate in studies", lastEditedIn: .unknown)
-    public static let SettingsStudiesToggleValueOff = MZLocalizedString("Settings.Studies.Toggle.Off", value: "Off", comment: "Toggled OFF to opt-out of studies", lastEditedIn: .unknown)
-}
-
-// MARK: - Do not track
-extension String {
-    public static let SettingsDoNotTrackTitle = MZLocalizedString("Settings.DNT.Title", value: "Send websites a Do Not Track signal that you don’t want to be tracked", comment: "DNT Settings title", lastEditedIn: .unknown)
-    public static let SettingsDoNotTrackOptionOnWithTP = MZLocalizedString("Settings.DNT.OptionOnWithTP", value: "Only when using Tracking Protection", comment: "DNT Settings option for only turning on when Tracking Protection is also on", lastEditedIn: .unknown)
-    public static let SettingsDoNotTrackOptionAlwaysOn = MZLocalizedString("Settings.DNT.OptionAlwaysOn", value: "Always", comment: "DNT Settings option for always on", lastEditedIn: .unknown)
-}
-
-// MARK: - Intro Onboarding slides
-extension String {
-    // First Card
-    public static let CardTitleWelcome = MZLocalizedString("Intro.Slides.Welcome.Title.v2", tableName: "Intro", value: "Welcome to Firefox", comment: "Title for the first panel 'Welcome' in the First Run tour.", lastEditedIn: .unknown)
-    public static let CardTitleAutomaticPrivacy = MZLocalizedString("Intro.Slides.Automatic.Privacy.Title", tableName: "Intro", value: "Automatic Privacy", comment: "Title for the first item in the table related to automatic privacy", lastEditedIn: .unknown)
-    public static let CardDescriptionAutomaticPrivacy = MZLocalizedString("Intro.Slides.Automatic.Privacy.Description", tableName: "Intro", value: "Enhanced Tracking Protection blocks malware and stops trackers.", comment: "Description for the first item in the table related to automatic privacy", lastEditedIn: .unknown)
-    public static let CardTitleFastSearch = MZLocalizedString("Intro.Slides.Fast.Search.Title", tableName: "Intro", value: "Fast Search", comment: "Title for the second item in the table related to fast searching via address bar", lastEditedIn: .unknown)
-    public static let CardDescriptionFastSearch = MZLocalizedString("Intro.Slides.Fast.Search.Description", tableName: "Intro", value: "Search suggestions get you to websites faster.", comment: "Description for the second item in the table related to fast searching via address bar", lastEditedIn: .unknown)
-    public static let CardTitleSafeSync = MZLocalizedString("Intro.Slides.Safe.Sync.Title", tableName: "Intro", value: "Safe Sync", comment: "Title for the third item in the table related to safe syncing with a firefox account", lastEditedIn: .unknown)
-    public static let CardDescriptionSafeSync = MZLocalizedString("Intro.Slides.Safe.Sync.Description", tableName: "Intro", value: "Protect your logins and data everywhere you use Firefox.", comment: "Description for the third item in the table related to safe syncing with a firefox account", lastEditedIn: .unknown)
-    
-    // Second Card
-    public static let CardTitleFxASyncDevices = MZLocalizedString("Intro.Slides.Firefox.Account.Sync.Title", tableName: "Intro", value: "Sync Firefox Between Devices", comment: "Title for the first item in the table related to syncing data (bookmarks, history) via firefox account between devices", lastEditedIn: .unknown)
-    public static let CardDescriptionFxASyncDevices = MZLocalizedString("Intro.Slides.Firefox.Account.Sync.Description", tableName: "Intro", value: "Bring bookmarks, history, and passwords to Firefox on this device.", comment: "Description for the first item in the table related to syncing data (bookmarks, history) via firefox account between devices", lastEditedIn: .unknown)
-    
-    //----Other----//
-    public static let CardTitleSearch = MZLocalizedString("Intro.Slides.Search.Title", tableName: "Intro", value: "Your search, your way", comment: "Title for the second  panel 'Search' in the First Run tour.", lastEditedIn: .unknown)
-    public static let CardTitlePrivate = MZLocalizedString("Intro.Slides.Private.Title", tableName: "Intro", value: "Browse like no one’s watching", comment: "Title for the third panel 'Private Browsing' in the First Run tour.", lastEditedIn: .unknown)
-    public static let CardTitleMail = MZLocalizedString("Intro.Slides.Mail.Title", tableName: "Intro", value: "You’ve got mail… options", comment: "Title for the fourth panel 'Mail' in the First Run tour.", lastEditedIn: .unknown)
-    public static let CardTitleSync = MZLocalizedString("Intro.Slides.TrailheadSync.Title.v2", tableName: "Intro", value: "Sync your bookmarks, history, and passwords to your phone.", comment: "Title for the second panel 'Sync' in the First Run tour.", lastEditedIn: .unknown)
-
-    public static let CardTextWelcome = MZLocalizedString("Intro.Slides.Welcome.Description.v2", tableName: "Intro", value: "Fast, private, and on your side.", comment: "Description for the 'Welcome' panel in the First Run tour.", lastEditedIn: .unknown)
-    public static let CardTextSearch = MZLocalizedString("Intro.Slides.Search.Description", tableName: "Intro", value: "Searching for something different? Choose another default search engine (or add your own) in Settings.", comment: "Description for the 'Favorite Search Engine' panel in the First Run tour.", lastEditedIn: .unknown)
-    public static let CardTextPrivate = MZLocalizedString("Intro.Slides.Private.Description", tableName: "Intro", value: "Tap the mask icon to slip into Private Browsing mode.", comment: "Description for the 'Private Browsing' panel in the First Run tour.", lastEditedIn: .unknown)
-    public static let CardTextMail = MZLocalizedString("Intro.Slides.Mail.Description", tableName: "Intro", value: "Use any email app — not just Mail — with Firefox.", comment: "Description for the 'Mail' panel in the First Run tour.", lastEditedIn: .unknown)
-    public static let CardTextSync = MZLocalizedString("Intro.Slides.TrailheadSync.Description", tableName: "Intro", value: "Sign in to your account to sync and access more features.", comment: "Description for the 'Sync' panel in the First Run tour.", lastEditedIn: .unknown)
-    public static let SignInButtonTitle = MZLocalizedString("Turn on Sync…", tableName: "Intro", comment: "The button that opens the sign in page for sync. See http://mzl.la/1T8gxwo", lastEditedIn: .unknown)
-    public static let StartBrowsingButtonTitle = MZLocalizedString("Start Browsing", tableName: "Intro", comment: "See http://mzl.la/1T8gxwo", lastEditedIn: .unknown)
-    public static let IntroNextButtonTitle = MZLocalizedString("Intro.Slides.Button.Next", tableName: "Intro", value: "Next", comment: "Next button on the first intro screen.", lastEditedIn: .unknown)
-    public static let IntroSignInButtonTitle = MZLocalizedString("Intro.Slides.Button.SignIn", tableName: "Intro", value: "Sign In", comment: "Sign in to Firefox account button on second intro screen.", lastEditedIn: .unknown)
-    public static let IntroSignUpButtonTitle = MZLocalizedString("Intro.Slides.Button.SignUp", tableName: "Intro", value: "Sign Up", comment: "Sign up to Firefox account button on second intro screen.", lastEditedIn: .unknown)
-}
-
-// MARK: - Keyboard short cuts
-extension String {
-    public static let ShowTabTrayFromTabKeyCodeTitle = MZLocalizedString("Tab.ShowTabTray.KeyCodeTitle", value: "Show All Tabs", comment: "Hardware shortcut to open the tab tray from a tab. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
-    public static let CloseTabFromTabTrayKeyCodeTitle = MZLocalizedString("TabTray.CloseTab.KeyCodeTitle", value: "Close Selected Tab", comment: "Hardware shortcut to close the selected tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
-    public static let CloseAllTabsFromTabTrayKeyCodeTitle = MZLocalizedString("TabTray.CloseAllTabs.KeyCodeTitle", value: "Close All Tabs", comment: "Hardware shortcut to close all tabs from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
-    public static let OpenSelectedTabFromTabTrayKeyCodeTitle = MZLocalizedString("TabTray.OpenSelectedTab.KeyCodeTitle", value: "Open Selected Tab", comment: "Hardware shortcut open the selected tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
-    public static let OpenNewTabFromTabTrayKeyCodeTitle = MZLocalizedString("TabTray.OpenNewTab.KeyCodeTitle", value: "Open New Tab", comment: "Hardware shortcut to open a new tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
-    public static let ReopenClosedTabKeyCodeTitle = MZLocalizedString("ReopenClosedTab.KeyCodeTitle", value: "Reopen Closed Tab", comment: "Hardware shortcut to reopen the last closed tab, from the tab or the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
-    public static let SwitchToPBMKeyCodeTitle = MZLocalizedString("SwitchToPBM.KeyCodeTitle", value: "Private Browsing Mode", comment: "Hardware shortcut switch to the private browsing tab or tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
-    public static let SwitchToNonPBMKeyCodeTitle = MZLocalizedString("SwitchToNonPBM.KeyCodeTitle", value: "Normal Browsing Mode", comment: "Hardware shortcut for non-private tab or tab. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
-}
-
-// MARK: - Share extension
-extension String {
-    public static let SendToCancelButton = MZLocalizedString("SendTo.Cancel.Button", value: "Cancel", comment: "Button title for cancelling share screen", lastEditedIn: .unknown)
-    public static let SendToErrorOKButton = MZLocalizedString("SendTo.Error.OK.Button", value: "OK", comment: "OK button to dismiss the error prompt.", lastEditedIn: .unknown)
-    public static let SendToErrorTitle = MZLocalizedString("SendTo.Error.Title", value: "The link you are trying to share cannot be shared.", comment: "Title of error prompt displayed when an invalid URL is shared.", lastEditedIn: .unknown)
-    public static let SendToErrorMessage = MZLocalizedString("SendTo.Error.Message", value: "Only HTTP and HTTPS links can be shared.", comment: "Message in error prompt explaining why the URL is invalid.", lastEditedIn: .unknown)
-    public static let SendToCloseButton = MZLocalizedString("SendTo.Cancel.Button", value: "Close", comment: "Close button in top navigation bar", lastEditedIn: .unknown)
-    public static let SendToNotSignedInText = MZLocalizedString("SendTo.NotSignedIn.Title", value: "You are not signed in to your Firefox Account.", comment: "See http://mzl.la/1ISlXnU", lastEditedIn: .unknown)
-    public static let SendToNotSignedInMessage = MZLocalizedString("SendTo.NotSignedIn.Message", value: "Please open Firefox, go to Settings and sign in to continue.", comment: "See http://mzl.la/1ISlXnU", lastEditedIn: .unknown)
-    public static let SendToSignInButton = MZLocalizedString("SendTo.SignIn.Button", value: "Sign In to Firefox", comment: "The text for the button on the Send to Device page if you are not signed in to Firefox Accounts.", lastEditedIn: .unknown)
-    public static let SendToNoDevicesFound = MZLocalizedString("SendTo.NoDevicesFound.Message", value: "You don’t have any other devices connected to this Firefox Account available to sync.", comment: "Error message shown in the remote tabs panel", lastEditedIn: .unknown)
-    public static let SendToTitle = MZLocalizedString("SendTo.NavBar.Title", value: "Send Tab", comment: "Title of the dialog that allows you to send a tab to a different device", lastEditedIn: .unknown)
-    public static let SendToSendButtonTitle = MZLocalizedString("SendTo.SendAction.Text", value: "Send", comment: "Navigation bar button to Send the current page to a device", lastEditedIn: .unknown)
-    public static let SendToDevicesListTitle = MZLocalizedString("SendTo.DeviceList.Text", value: "Available devices:", comment: "Header for the list of devices table", lastEditedIn: .unknown)
-    public static let ShareSendToDevice = SendToDeviceTitle
-
-    // The above items are re-used strings from the old extension. New strings below.
-
-    public static let ShareAddToReadingList = MZLocalizedString("ShareExtension.AddToReadingListAction.Title", value: "Add to Reading List", comment: "Action label on share extension to add page to the Firefox reading list.", lastEditedIn: .unknown)
-    public static let ShareAddToReadingListDone = MZLocalizedString("ShareExtension.AddToReadingListActionDone.Title", value: "Added to Reading List", comment: "Share extension label shown after user has performed 'Add to Reading List' action.", lastEditedIn: .unknown)
-    public static let ShareBookmarkThisPage = MZLocalizedString("ShareExtension.BookmarkThisPageAction.Title", value: "Bookmark This Page", comment: "Action label on share extension to bookmark the page in Firefox.", lastEditedIn: .unknown)
-    public static let ShareBookmarkThisPageDone = MZLocalizedString("ShareExtension.BookmarkThisPageActionDone.Title", value: "Bookmarked", comment: "Share extension label shown after user has performed 'Bookmark this Page' action.", lastEditedIn: .unknown)
-
-    public static let ShareOpenInFirefox = MZLocalizedString("ShareExtension.OpenInFirefoxAction.Title", value: "Open in Firefox", comment: "Action label on share extension to immediately open page in Firefox.", lastEditedIn: .unknown)
-    public static let ShareSearchInFirefox = MZLocalizedString("ShareExtension.SeachInFirefoxAction.Title", value: "Search in Firefox", comment: "Action label on share extension to search for the selected text in Firefox.", lastEditedIn: .unknown)
-    public static let ShareOpenInPrivateModeNow = MZLocalizedString("ShareExtension.OpenInPrivateModeAction.Title", value: "Open in Private Mode", comment: "Action label on share extension to immediately open page in Firefox in private mode.", lastEditedIn: .unknown)
-
-    public static let ShareLoadInBackground = MZLocalizedString("ShareExtension.LoadInBackgroundAction.Title", value: "Load in Background", comment: "Action label on share extension to load the page in Firefox when user switches apps to bring it to foreground.", lastEditedIn: .unknown)
-    public static let ShareLoadInBackgroundDone = MZLocalizedString("ShareExtension.LoadInBackgroundActionDone.Title", value: "Loading in Firefox", comment: "Share extension label shown after user has performed 'Load in Background' action.", lastEditedIn: .unknown)
-
-}
-
-// MARK: - PasswordAutofill extension
-extension String {
-    public static let PasswordAutofillTitle = MZLocalizedString("PasswordAutoFill.SectionTitle", value: "Firefox Credentials", comment: "Title of the extension that shows firefox passwords", lastEditedIn: .unknown)
-    public static let CredentialProviderNoCredentialError = MZLocalizedString("PasswordAutoFill.NoPasswordsFoundTitle", value: "You don’t have any credentials synced from your Firefox Account", comment: "Error message shown in the remote tabs panel", lastEditedIn: .unknown)
-    public static let AvailableCredentialsHeader = MZLocalizedString("PasswordAutoFill.PasswordsListTitle", value: "Available Credentials:", comment: "Header for the list of credentials table", lastEditedIn: .unknown)
+    // Segmented Control tites for iPad
+    public static let TabTraySegmentedControlTitlesTabs = MZLocalizedString("TabTray.SegmentedControlTitles.Tabs", value: "Tabs", comment: "The title on the button to look at regular tabs.", lastEditedIn: .unknown)
+    public static let TabTraySegmentedControlTitlesPrivateTabs = MZLocalizedString("TabTray.SegmentedControlTitles.PrivateTabs", value: "Private", comment: "The title on the button to look at private tabs.", lastEditedIn: .unknown)
+    public static let TabTraySegmentedControlTitlesSyncedTabs = MZLocalizedString("TabTray.SegmentedControlTitles.SyncedTabs", value: "Synced", comment: "The title on the button to look at synced tabs.", lastEditedIn: .unknown)
 }
 
 // MARK: - Translation bar
@@ -852,71 +1289,20 @@ extension String {
     public static let SettingTranslateSnackBarSwitchSubtitle = MZLocalizedString("Settings.TranslateSnackBar.SwitchSubtitle", value: "Offer to translate any site written in a language that is different from your default language.", comment: "Switch to choose if the language of a page is detected and offer to translate.", lastEditedIn: .unknown)
 }
 
-// MARK: - Display Theme
-extension String {
-    public static let SettingsDisplayThemeTitle = MZLocalizedString("Settings.DisplayTheme.Title.v2", value: "Theme", comment: "Title in main app settings for Theme settings", lastEditedIn: .unknown)
-    public static let DisplayThemeBrightnessThresholdSectionHeader = MZLocalizedString("Settings.DisplayTheme.BrightnessThreshold.SectionHeader", value: "Threshold", comment: "Section header for brightness slider.", lastEditedIn: .unknown)
-    public static let DisplayThemeSectionFooter = MZLocalizedString("Settings.DisplayTheme.SectionFooter", value: "The theme will automatically change based on your display brightness. You can set the threshold where the theme changes. The circle indicates your display's current brightness.", comment: "Display (theme) settings footer describing how the brightness slider works.", lastEditedIn: .unknown)
-    public static let SystemThemeSectionHeader = MZLocalizedString("Settings.DisplayTheme.SystemTheme.SectionHeader", value: "System Theme", comment: "System theme settings section title", lastEditedIn: .unknown)
-    public static let SystemThemeSectionSwitchTitle = MZLocalizedString("Settings.DisplayTheme.SystemTheme.SwitchTitle", value: "Use System Light/Dark Mode", comment: "System theme settings switch to choose whether to use the same theme as the system", lastEditedIn: .unknown)
-    public static let ThemeSwitchModeSectionHeader = MZLocalizedString("Settings.DisplayTheme.SwitchMode.SectionHeader", value: "Switch Mode", comment: "Switch mode settings section title", lastEditedIn: .unknown)
-    public static let ThemePickerSectionHeader = MZLocalizedString("Settings.DisplayTheme.ThemePicker.SectionHeader", value: "Theme Picker", comment: "Theme picker settings section title", lastEditedIn: .unknown)
-    public static let DisplayThemeAutomaticSwitchTitle = MZLocalizedString("Settings.DisplayTheme.SwitchTitle", value: "Automatically", comment: "Display (theme) settings switch to choose whether to set the dark mode manually, or automatically based on the brightness slider.", lastEditedIn: .unknown)
-    public static let DisplayThemeAutomaticStatusLabel = MZLocalizedString("Settings.DisplayTheme.SwitchTitle", value: "Automatic", comment: "Display (theme) settings label to show if automatically switch theme is enabled.", lastEditedIn: .unknown)
-    public static let DisplayThemeAutomaticSwitchSubtitle = MZLocalizedString("Settings.DisplayTheme.SwitchSubtitle", value: "Switch automatically based on screen brightness", comment: "Display (theme) settings switch subtitle, explaining the title 'Automatically'.", lastEditedIn: .unknown)
-    public static let DisplayThemeManualSwitchTitle = MZLocalizedString("Settings.DisplayTheme.Manual.SwitchTitle", value: "Manually", comment: "Display (theme) setting to choose the theme manually.", lastEditedIn: .unknown)
-    public static let DisplayThemeManualSwitchSubtitle = MZLocalizedString("Settings.DisplayTheme.Manual.SwitchSubtitle", value: "Pick which theme you want", comment: "Display (theme) settings switch subtitle, explaining the title 'Manually'.", lastEditedIn: .unknown)
-    public static let DisplayThemeManualStatusLabel = MZLocalizedString("Settings.DisplayTheme.Manual.StatusLabel", value: "Manual", comment: "Display (theme) settings label to show if manually switch theme is enabled.", lastEditedIn: .unknown)
-    public static let DisplayThemeOptionLight = MZLocalizedString("Settings.DisplayTheme.OptionLight", value: "Light", comment: "Option choice in display theme settings for light theme", lastEditedIn: .unknown)
-    public static let DisplayThemeOptionDark = MZLocalizedString("Settings.DisplayTheme.OptionDark", value: "Dark", comment: "Option choice in display theme settings for dark theme", lastEditedIn: .unknown)
-}
-
-extension String {
-    public static let AddTabAccessibilityLabel = MZLocalizedString("TabTray.AddTab.Button", value: "Add Tab", comment: "Accessibility label for the Add Tab button in the Tab Tray.", lastEditedIn: .unknown)
-}
-
-// MARK: - Cover Sheet
-extension String {
-    // Dark Mode Cover Sheet
-    public static let CoverSheetV22DarkModeTitle = MZLocalizedString("CoverSheet.v22.DarkMode.Title", value: "Dark theme now includes a dark keyboard and dark splash screen.", comment: "Title for the new dark mode change in the version 22 app release.", lastEditedIn: .unknown)
-    public static let CoverSheetV22DarkModeDescription = MZLocalizedString("CoverSheet.v22.DarkMode.Description", value: "For iOS 13 users, Firefox now automatically switches to a dark theme when your phone is set to Dark Mode. To change this behavior, go to Settings > Theme.", comment: "Description for the new dark mode change in the version 22 app release. It describes the new automatic dark theme and how to change the theme settings.", lastEditedIn: .unknown)
-    
-    // ETP Cover Sheet
-    public static let CoverSheetETPTitle = MZLocalizedString("CoverSheet.v24.ETP.Title", value: "Protection Against Ad Tracking", comment: "Title for the new ETP mode i.e. standard vs strict", lastEditedIn: .unknown)
-    public static let CoverSheetETPDescription = MZLocalizedString("CoverSheet.v24.ETP.Description", value: "Built-in Enhanced Tracking Protection helps stop ads from following you around. Turn on Strict to block even more trackers, ads, and popups. ", comment: "Description for the new ETP mode i.e. standard vs strict", lastEditedIn: .unknown)
-    public static let CoverSheetETPSettingsButton = MZLocalizedString("CoverSheet.v24.ETP.Settings.Button", value: "Go to Settings", comment: "Text for the new ETP settings button", lastEditedIn: .unknown)
-}
-
-// MARK: - FxA Signin screen
-extension String {
-    public static let FxASignin_Title = MZLocalizedString("fxa.signin.turn-on-sync", value: "Turn on Sync", comment: "FxA sign in view title", lastEditedIn: .unknown)
-    public static let FxASignin_Subtitle = MZLocalizedString("fxa.signin.camera-signin", value: "Sign In with Your Camera", comment: "FxA sign in view subtitle", lastEditedIn: .unknown)
-    public static let FxASignin_QRInstructions = MZLocalizedString("fxa.signin.qr-link-instruction", value: "On your computer open Firefox and go to firefox.com/pair", comment: "FxA sign in view qr code instructions", lastEditedIn: .unknown)
-    public static let FxASignin_QRScanSignin = MZLocalizedString("fxa.signin.ready-to-scan", value: "Ready to Scan", comment: "FxA sign in view qr code scan button", lastEditedIn: .unknown)
-    public static let FxASignin_EmailSignin = MZLocalizedString("fxa.signin.use-email-instead", value: "Use Email Instead", comment: "FxA sign in view email login button", lastEditedIn: .unknown)
-    public static let FxASignin_CreateAccountPt1 = MZLocalizedString("fxa.signin.create-account-pt-1", value: "Sync Firefox between devices with an account.", comment: "FxA sign in create account label.", lastEditedIn: .unknown)
-    public static let FxASignin_CreateAccountPt2 = MZLocalizedString("fxa.signin.create-account-pt-2", value: "Create Firefox account.", comment: "FxA sign in create account label. This will be linked to the site to create an account.", lastEditedIn: .unknown)
-}
-
-// MARK: - FxA QR code scanning screen
-extension String {
-    public static let FxAQRCode_Instructions = MZLocalizedString("fxa.qr-scanning-view.instructions", value: "Scan the QR code shown at firefox.com/pair", comment: "Instructions shown on qr code scanning view", lastEditedIn: .unknown)
-}
-
 // MARK: - Today Widget Strings - [New Search - Private Search]
 extension String {
     public static let NewTabButtonLabel = MZLocalizedString("TodayWidget.NewTabButtonLabelV1", tableName: "Today", value: "New Search", comment: "Open New Tab button label", lastEditedIn: .unknown)
     public static let CopiedLinkLabelFromPasteBoard = MZLocalizedString("TodayWidget.CopiedLinkLabelFromPasteBoardV1", tableName: "Today", value: "Copied Link from clipboard", comment: "Copied Link from clipboard displayed", lastEditedIn: .unknown)
     public static let NewPrivateTabButtonLabel = MZLocalizedString("TodayWidget.PrivateTabButtonLabelV1", tableName: "Today", value: "Private Search", comment: "Open New Private Tab button label", lastEditedIn: .unknown)
-    
+
     // Widget - Shared
 
     public static let QuickActionsGalleryTitle = MZLocalizedString("TodayWidget.QuickActionsGalleryTitle", tableName: "Today", value: "Quick Actions", comment: "Quick Actions title when widget enters edit mode", lastEditedIn: .unknown)
     public static let QuickActionsGalleryTitlev2 = MZLocalizedString("TodayWidget.QuickActionsGalleryTitleV2", tableName: "Today", value: "Firefox Shortcuts", comment: "Firefox shortcuts title when widget enters edit mode. Do not translate the word Firefox.", lastEditedIn: .unknown)
-    
+
     // Quick View - Gallery View
     public static let QuickViewGalleryTile = MZLocalizedString("TodayWidget.QuickViewGalleryTitle", tableName: "Today", value: "Quick View", comment: "Quick View title user is picking a widget to add.", lastEditedIn: .unknown)
-    
+
     // Quick Action - Medium Size Quick Action
     public static let QuickActionsSubLabel = MZLocalizedString("TodayWidget.QuickActionsSubLabel", tableName: "Today", value: "Firefox - Quick Actions", comment: "Sub label for medium size quick action widget", lastEditedIn: .unknown)
     public static let NewSearchButtonLabel = MZLocalizedString("TodayWidget.NewSearchButtonLabelV1", tableName: "Today", value: "Search in Firefox", comment: "Open New Tab button label", lastEditedIn: .unknown)
@@ -925,10 +1311,10 @@ extension String {
     public static let GoToCopiedLinkLabelV2 = MZLocalizedString("TodayWidget.GoToCopiedLinkLabelV2", tableName: "Today", value: "Go to\nCopied Link", comment: "Go to copied link", lastEditedIn: .unknown)
     public static let GoToCopiedLinkLabelV3 = MZLocalizedString("TodayWidget.GoToCopiedLinkLabelV3", tableName: "Today", value: "Go to Copied Link", comment: "Go To Copied Link text pasted on the clipboard but this string doesn't have new line character", lastEditedIn: .unknown)
     public static let ClosePrivateTab = MZLocalizedString("TodayWidget.ClosePrivateTabsButton", tableName: "Today", value: "Close Private Tabs", comment: "Close Private Tabs button label", lastEditedIn: .unknown)
-    
+
     // Quick Action - Medium Size - Gallery View
     public static let FirefoxShortcutGalleryDescription = MZLocalizedString("TodayWidget.FirefoxShortcutGalleryDescription", tableName: "Today", value: "Add Firefox shortcuts to your Home screen.", comment: "Description for medium size widget to add Firefox Shortcut to home screen", lastEditedIn: .unknown)
-    
+
     // Quick Action - Small Size Widget
     public static let SearchInFirefoxTitle = MZLocalizedString("TodayWidget.SearchInFirefoxTitle", tableName: "Today", value: "Search in Firefox", comment: "Title for small size widget which allows users to search in Firefox. Do not translate the word Firefox.", lastEditedIn: .unknown)
     public static let SearchInPrivateTabLabelV2 = MZLocalizedString("TodayWidget.SearchInPrivateTabLabelV2", tableName: "Today", value: "Search in\nPrivate Tab", comment: "Search in private tab", lastEditedIn: .unknown)
@@ -936,7 +1322,7 @@ extension String {
     public static let ClosePrivateTabsLabelV2 = MZLocalizedString("TodayWidget.ClosePrivateTabsLabelV2", tableName: "Today", value: "Close\nPrivate Tabs", comment: "Close Private Tabs", lastEditedIn: .unknown)
     public static let ClosePrivateTabsLabelV3 = MZLocalizedString("TodayWidget.ClosePrivateTabsLabelV3", tableName: "Today", value: "Close\nPrivate\nTabs", comment: "Close Private Tabs", lastEditedIn: .unknown)
     public static let GoToCopiedLinkLabelV4 = MZLocalizedString("TodayWidget.GoToCopiedLinkLabelV4", tableName: "Today", value: "Go to\nCopied\nLink", comment: "Go to copied link", lastEditedIn: .unknown)
-    
+
     // Quick Action - Small Size Widget - Edit Mode
     public static let QuickActionDescription = MZLocalizedString("TodayWidget.QuickActionDescription", tableName: "Today", value: "Select a Firefox shortcut to add to your Home screen.", comment: "Quick action description when widget enters edit mode", lastEditedIn: .unknown)
     public static let QuickActionDropDownMenu = MZLocalizedString("TodayWidget.QuickActionDropDownMenu", tableName: "Today", value: "Quick action", comment: "Quick Actions left label text for dropdown menu when widget enters edit mode", lastEditedIn: .unknown)
@@ -944,14 +1330,14 @@ extension String {
     public static let DropDownMenuItemNewPrivateSearch = MZLocalizedString("TodayWidget.DropDownMenuItemNewPrivateSearch", tableName: "Today", value: "New Private Search", comment: "Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands", lastEditedIn: .unknown)
     public static let DropDownMenuItemGoToCopiedLink = MZLocalizedString("TodayWidget.DropDownMenuItemGoToCopiedLink", tableName: "Today", value: "Go to Copied Link", comment: "Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands", lastEditedIn: .unknown)
     public static let DropDownMenuItemClearPrivateTabs = MZLocalizedString("TodayWidget.DropDownMenuItemClearPrivateTabs", tableName: "Today", value: "Clear Private Tabs", comment: "Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands", lastEditedIn: .unknown)
-    
+
     // Quick Action - Small Size - Gallery View
     public static let QuickActionGalleryDescription = MZLocalizedString("TodayWidget.QuickActionGalleryDescription", tableName: "Today", value: "Add a Firefox shortcut to your Home screen. After adding the widget, touch and hold to edit it and select a different shortcut.", comment: "Description for small size widget to add it to home screen", lastEditedIn: .unknown)
-    
+
     // Top Sites - Medium Size Widget
     public static let TopSitesSubLabel = MZLocalizedString("TodayWidget.TopSitesSubLabel", tableName: "Today", value: "Firefox - Top Sites", comment: "Sub label for Top Sites widget", lastEditedIn: .unknown)
     public static let TopSitesSubLabel2 = MZLocalizedString("TodayWidget.TopSitesSubLabel2", tableName: "Today", value: "Firefox - Website Shortcuts", comment: "Sub label for Shortcuts widget", lastEditedIn: .unknown)
-    
+
     // Top Sites - Medium Size - Gallery View
     public static let TopSitesGalleryTitle = MZLocalizedString("TodayWidget.TopSitesGalleryTitle", tableName: "Today", value: "Top Sites", comment: "Title for top sites widget to add Firefox top sites shotcuts to home screen", lastEditedIn: .unknown)
     public static let TopSitesGalleryTitleV2 = MZLocalizedString("TodayWidget.TopSitesGalleryTitleV2", tableName: "Today", value: "Website Shortcuts", comment: "Title for top sites widget to add Firefox top sites shotcuts to home screen", lastEditedIn: .unknown)
@@ -963,14 +1349,14 @@ extension String {
     public static let OpenFirefoxLabel = MZLocalizedString("TodayWidget.OpenFirefoxLabel", tableName: "Today", value: "Open Firefox", comment: "Open Firefox when there are no tabs opened in tab tray i.e. Empty State", lastEditedIn: .unknown)
     public static let NoOpenTabsLabel = MZLocalizedString("TodayWidget.NoOpenTabsLabel", tableName: "Today", value: "No open tabs.", comment: "Label that is shown when there are no tabs opened in tab tray i.e. Empty State", lastEditedIn: .unknown)
     public static let NoOpenTabsLabelV2 = MZLocalizedString("TodayWidget.NoOpenTabsLabelV2", tableName: "Today", value: "No Open Tabs", comment: "Label that is shown when there are no tabs opened in tab tray i.e. Empty State", lastEditedIn: .unknown)
-    
-    
+
+
     // Quick View Open Tabs - Medium Size - Gallery View
     public static let QuickViewGalleryTitle = MZLocalizedString("TodayWidget.QuickViewGalleryTitle", tableName: "Today", value: "Quick View", comment: "Title for Quick View widget in Gallery View where user can add it to home screen", lastEditedIn: .unknown)
     public static let QuickViewGalleryDescription = MZLocalizedString("TodayWidget.QuickViewGalleryDescription", tableName: "Today", value: "Access your open tabs directly on your homescreen.", comment: "Description for Quick View widget in Gallery View where user can add it to home screen", lastEditedIn: .unknown)
     public static let QuickViewGalleryDescriptionV2 = MZLocalizedString("TodayWidget.QuickViewGalleryDescriptionV2", tableName: "Today", value: "Add shortcuts to your open tabs.", comment: "Description for Quick View widget in Gallery View where user can add it to home screen", lastEditedIn: .unknown)
     public static let ViewMore = MZLocalizedString("TodayWidget.ViewMore", tableName: "Today", value: "View More", comment: "View More for Quick View widget in Gallery View where we don't know how many tabs might be opened", lastEditedIn: .unknown)
-    
+
     // Quick View Open Tabs - Large Size - Gallery View
     public static let QuickViewLargeGalleryDescription = MZLocalizedString("TodayWidget.QuickViewLargeGalleryDescription", tableName: "Today", value: "Add shortcuts to your open tabs.", comment: "Description for Quick View widget in Gallery View where user can add it to home screen", lastEditedIn: .unknown)
 
@@ -981,155 +1367,6 @@ extension String {
     // Pocket - Large - Medium Size - Gallery View
     public static let PocketWidgetGalleryTitle = MZLocalizedString("TodayWidget.PocketWidgetTitle", tableName: "Today", value: "Recommended by Pocket", comment: "Title for Firefox Pocket stories widget in Gallery View where user can add it to home screen. Pocket is the name of another app.", lastEditedIn: .unknown)
     public static let PocketWidgetGalleryDescription = MZLocalizedString("TodayWidget.PocketWidgetGalleryDescription", tableName: "Today", value: "Discover fascinating and thought-provoking stories from across the web, curated by Pocket.", comment: "Description for Firefox Pocket stories widget in Gallery View where user can add it to home screen. Pocket is the name of another app.", lastEditedIn: .unknown)
-}
-
-// MARK: - Default Browser
-extension String {
-    public static let DefaultBrowserCardTitle = MZLocalizedString("DefaultBrowserCard.Title", tableName: "Default Browser", value: "Switch Your Default Browser", comment: "Title for small card shown that allows user to switch their default browser to Firefox.", lastEditedIn: .unknown)
-    public static let DefaultBrowserCardDescription = MZLocalizedString("DefaultBrowserCard.Description", tableName: "Default Browser", value: "Set links from websites, emails, and Messages to open automatically in Firefox.", comment: "Description for small card shown that allows user to switch their default browser to Firefox.", lastEditedIn: .unknown)
-    public static let DefaultBrowserCardButton = MZLocalizedString("DefaultBrowserCard.Button.v2", tableName: "Default Browser", value: "Learn How", comment: "Button string to learn how to set your default browser.", lastEditedIn: .unknown)
-    public static let DefaultBrowserMenuItem = MZLocalizedString("Settings.DefaultBrowserMenuItem", tableName: "Default Browser", value: "Set as Default Browser", comment: "Menu option for setting Firefox as default browser.", lastEditedIn: .unknown)
-    public static let DefaultBrowserOnboardingScreenshot = MZLocalizedString("DefaultBrowserOnboarding.Screenshot", tableName: "Default Browser", value: "Default Browser App", comment: "Text for the screenshot of the iOS system settings page for Firefox.", lastEditedIn: .unknown)
-    public static let DefaultBrowserOnboardingDescriptionStep1 = MZLocalizedString("DefaultBrowserOnboarding.Description1", tableName: "Default Browser", value: "1. Go to Settings", comment: "Description for default browser onboarding card.", lastEditedIn: .unknown)
-    public static let DefaultBrowserOnboardingDescriptionStep2 = MZLocalizedString("DefaultBrowserOnboarding.Description2", tableName: "Default Browser", value: "2. Tap Default Browser App", comment: "Description for default browser onboarding card.", lastEditedIn: .unknown)
-    public static let DefaultBrowserOnboardingDescriptionStep3 = MZLocalizedString("DefaultBrowserOnboarding.Description3", tableName: "Default Browser", value: "3. Select Firefox", comment: "Description for default browser onboarding card.", lastEditedIn: .unknown)
-    public static let DefaultBrowserOnboardingButton = MZLocalizedString("DefaultBrowserOnboarding.Button", tableName: "Default Browser", value: "Go to Settings", comment: "Button string to open settings that allows user to switch their default browser to Firefox.", lastEditedIn: .unknown)
-}
-
-// MARK: - FxAWebViewController
-extension String {
-    public static let FxAWebContentAccessibilityLabel = MZLocalizedString("Web content", comment: "Accessibility label for the main web content view", lastEditedIn: .unknown)
-}
-
-// MARK: - QuickActions
-extension String {
-    public static let QuickActionsLastBookmarkTitle = MZLocalizedString("Open Last Bookmark", tableName: "3DTouchActions", comment: "String describing the action of opening the last added bookmark from the home screen Quick Actions via 3D Touch", lastEditedIn: .unknown)
-}
-
-// MARK: - CrashOptInAlert
-extension String {
-    public static let CrashOptInAlertTitle = MZLocalizedString("Oops! Firefox crashed", comment: "Title for prompt displayed to user after the app crashes", lastEditedIn: .unknown)
-    public static let CrashOptInAlertMessage = MZLocalizedString("Send a crash report so Mozilla can fix the problem?", comment: "Message displayed in the crash dialog above the buttons used to select when sending reports", lastEditedIn: .unknown)
-    public static let CrashOptInAlertSend = MZLocalizedString("Send Report", comment: "Used as a button label for crash dialog prompt", lastEditedIn: .unknown)
-    public static let CrashOptInAlertAlwaysSend = MZLocalizedString("Always Send", comment: "Used as a button label for crash dialog prompt", lastEditedIn: .unknown)
-    public static let CrashOptInAlertDontSend = MZLocalizedString("Don’t Send", comment: "Used as a button label for crash dialog prompt", lastEditedIn: .unknown)
-}
-
-// MARK: - RestoreTabsAlert
-extension String {
-    public static let RestoreTabsAlertTitle = MZLocalizedString("Well, this is embarrassing.", comment: "Restore Tabs Prompt Title", lastEditedIn: .unknown)
-    public static let RestoreTabsAlertMessage = MZLocalizedString("Looks like Firefox crashed previously. Would you like to restore your tabs?", comment: "Restore Tabs Prompt Description", lastEditedIn: .unknown)
-    public static let RestoreTabsAlertNo = MZLocalizedString("No", comment: "Restore Tabs Negative Action", lastEditedIn: .unknown)
-    public static let RestoreTabsAlertOkay = MZLocalizedString("Okay", comment: "Restore Tabs Affirmative Action", lastEditedIn: .unknown)
-}
-
-// MARK: - ClearPrivateDataAlert
-extension String {
-    public static let ClearPrivateDataAlertMessage = MZLocalizedString("This action will clear all of your private data. It cannot be undone.", tableName: "ClearPrivateDataConfirm", comment: "Description of the confirmation dialog shown when a user tries to clear their private data.", lastEditedIn: .unknown)
-    public static let ClearPrivateDataAlertCancel = MZLocalizedString("Cancel", tableName: "ClearPrivateDataConfirm", comment: "The cancel button when confirming clear private data.", lastEditedIn: .unknown)
-    public static let ClearPrivateDataAlertOk = MZLocalizedString("OK", tableName: "ClearPrivateDataConfirm", comment: "The button that clears private data.", lastEditedIn: .unknown)
-}
-
-// MARK: - ClearWebsiteDataAlert
-extension String {
-    public static let ClearAllWebsiteDataAlertMessage = MZLocalizedString("Settings.WebsiteData.ConfirmPrompt", value: "This action will clear all of your website data. It cannot be undone.", comment: "Description of the confirmation dialog shown when a user tries to clear their private data.", lastEditedIn: .unknown)
-    public static let ClearSelectedWebsiteDataAlertMessage = MZLocalizedString("Settings.WebsiteData.SelectedConfirmPrompt", value: "This action will clear the selected items. It cannot be undone.", comment: "Description of the confirmation dialog shown when a user tries to clear some of their private data.", lastEditedIn: .unknown)
-    // TODO: these look like the same as in ClearPrivateDataAlert, I think we can remove them
-    public static let ClearWebsiteDataAlertCancel = MZLocalizedString("Cancel", tableName: "ClearPrivateDataConfirm", comment: "The cancel button when confirming clear private data.", lastEditedIn: .unknown)
-    public static let ClearWebsiteDataAlertOk = MZLocalizedString("OK", tableName: "ClearPrivateDataConfirm", comment: "The button that clears private data.", lastEditedIn: .unknown)
-}
-
-// MARK: - ClearSyncedHistoryAlert
-extension String {
-    public static let ClearSyncedHistoryAlertMessage = MZLocalizedString("This action will clear all of your private data, including history from your synced devices.", tableName: "ClearHistoryConfirm", comment: "Description of the confirmation dialog shown when a user tries to clear history that's synced to another device.", lastEditedIn: .unknown)
-    // TODO: these look like the same as in ClearPrivateDataAlert, I think we can remove them
-    public static let ClearSyncedHistoryAlertCancel = MZLocalizedString("Cancel", tableName: "ClearHistoryConfirm", comment: "The cancel button when confirming clear history.", lastEditedIn: .unknown)
-    public static let ClearSyncedHistoryAlertOk = MZLocalizedString("OK", tableName: "ClearHistoryConfirm", comment: "The confirmation button that clears history even when Sync is connected.", lastEditedIn: .unknown)
-}
-
-// MARK: - DeleteLoginAlert
-extension String {
-    public static let DeleteLoginAlertTitle = MZLocalizedString("Are you sure?", tableName: "LoginManager", comment: "Prompt title when deleting logins", lastEditedIn: .unknown)
-    public static let DeleteLoginAlertSyncedMessage = MZLocalizedString("Logins will be removed from all connected devices.", tableName: "LoginManager", comment: "Prompt message warning the user that deleted logins will remove logins from all connected devices", lastEditedIn: .unknown)
-    public static let DeleteLoginAlertLocalMessage = MZLocalizedString("Logins will be permanently removed.", tableName: "LoginManager", comment: "Prompt message warning the user that deleting non-synced logins will permanently remove them", lastEditedIn: .unknown)
-    public static let DeleteLoginAlertCancel = MZLocalizedString("Cancel", tableName: "LoginManager", comment: "Prompt option for cancelling out of deletion", lastEditedIn: .unknown)
-    public static let DeleteLoginAlertDelete = MZLocalizedString("Delete", tableName: "LoginManager", comment: "Label for the button used to delete the current login.", lastEditedIn: .unknown)
-}
-
-// MARK: - Strings used in multiple areas within the Authentication Manager
-extension String {
-    public static let AuthenticationPasscode = MZLocalizedString("Passcode For Logins", tableName: "AuthenticationManager", comment: "Label for the Passcode item in Settings", lastEditedIn: .unknown)
-    public static let AuthenticationTouchIDPasscodeSetting = MZLocalizedString("Touch ID & Passcode", tableName: "AuthenticationManager", comment: "Label for the Touch ID/Passcode item in Settings", lastEditedIn: .unknown)
-    public static let AuthenticationFaceIDPasscodeSetting = MZLocalizedString("Face ID & Passcode", tableName: "AuthenticationManager", comment: "Label for the Face ID/Passcode item in Settings", lastEditedIn: .unknown)
-    public static let AuthenticationRequirePasscode = MZLocalizedString("Require Passcode", tableName: "AuthenticationManager", comment: "Text displayed in the 'Interval' section, followed by the current interval setting, e.g. 'Immediately'", lastEditedIn: .unknown)
-    public static let AuthenticationEnterAPasscode = MZLocalizedString("Enter a passcode", tableName: "AuthenticationManager", comment: "Text displayed above the input field when entering a new passcode", lastEditedIn: .unknown)
-    public static let AuthenticationEnterPasscodeTitle = MZLocalizedString("Enter Passcode", tableName: "AuthenticationManager", comment: "Title of the dialog used to request the passcode", lastEditedIn: .unknown)
-    public static let AuthenticationEnterPasscode = MZLocalizedString("Enter passcode", tableName: "AuthenticationManager", comment: "Text displayed above the input field when changing the existing passcode", lastEditedIn: .unknown)
-    public static let AuthenticationReenterPasscode = MZLocalizedString("Re-enter passcode", tableName: "AuthenticationManager", comment: "Text displayed above the input field when confirming a passcode", lastEditedIn: .unknown)
-    public static let AuthenticationSetPasscode = MZLocalizedString("Set Passcode", tableName: "AuthenticationManager", comment: "Title of the dialog used to set a passcode", lastEditedIn: .unknown)
-    public static let AuthenticationTurnOffPasscode = MZLocalizedString("Turn Passcode Off", tableName: "AuthenticationManager", comment: "Label used as a setting item to turn off passcode", lastEditedIn: .unknown)
-    public static let AuthenticationTurnOnPasscode = MZLocalizedString("Turn Passcode On", tableName: "AuthenticationManager", comment: "Label used as a setting item to turn on passcode", lastEditedIn: .unknown)
-    public static let AuthenticationChangePasscode = MZLocalizedString("Change Passcode", tableName: "AuthenticationManager", comment: "Label used as a setting item and title of the following screen to change the current passcode", lastEditedIn: .unknown)
-    public static let AuthenticationEnterNewPasscode = MZLocalizedString("Enter a new passcode", tableName: "AuthenticationManager", comment: "Text displayed above the input field when changing the existing passcode", lastEditedIn: .unknown)
-    public static let AuthenticationImmediately = MZLocalizedString("Immediately", tableName: "AuthenticationManager", comment: "'Immediately' interval item for selecting when to require passcode", lastEditedIn: .unknown)
-    public static let AuthenticationOneMinute = MZLocalizedString("After 1 minute", tableName: "AuthenticationManager", comment: "'After 1 minute' interval item for selecting when to require passcode", lastEditedIn: .unknown)
-    public static let AuthenticationFiveMinutes = MZLocalizedString("After 5 minutes", tableName: "AuthenticationManager", comment: "'After 5 minutes' interval item for selecting when to require passcode", lastEditedIn: .unknown)
-    public static let AuthenticationTenMinutes = MZLocalizedString("After 10 minutes", tableName: "AuthenticationManager", comment: "'After 10 minutes' interval item for selecting when to require passcode", lastEditedIn: .unknown)
-    public static let AuthenticationFifteenMinutes = MZLocalizedString("After 15 minutes", tableName: "AuthenticationManager", comment: "'After 15 minutes' interval item for selecting when to require passcode", lastEditedIn: .unknown)
-    public static let AuthenticationOneHour = MZLocalizedString("After 1 hour", tableName: "AuthenticationManager", comment: "'After 1 hour' interval item for selecting when to require passcode", lastEditedIn: .unknown)
-    public static let AuthenticationLoginsTouchReason = MZLocalizedString("Use your fingerprint to access Logins now.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when accessing logins", lastEditedIn: .unknown)
-    public static let AuthenticationRequirePasscodeTouchReason = MZLocalizedString("touchid.require.passcode.reason.label", tableName: "AuthenticationManager", value: "Use your fingerprint to access configuring your required passcode interval.", comment: "Touch ID prompt subtitle when accessing the require passcode setting", lastEditedIn: .unknown)
-    public static let AuthenticationDisableTouchReason = MZLocalizedString("touchid.disable.reason.label", tableName: "AuthenticationManager", value: "Use your fingerprint to disable Touch ID.", comment: "Touch ID prompt subtitle when disabling Touch ID", lastEditedIn: .unknown)
-    public static let AuthenticationWrongPasscodeError = MZLocalizedString("Incorrect passcode. Try again.", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode when trying to enter a protected section of the app", lastEditedIn: .unknown)
-    public static let AuthenticationIncorrectAttemptsRemaining = MZLocalizedString("Incorrect passcode. Try again (Attempts remaining: %d).", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode when trying to enter a protected section of the app with attempts remaining", lastEditedIn: .unknown)
-    public static let AuthenticationMaximumAttemptsReached = MZLocalizedString("Maximum attempts reached. Please try again in an hour.", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode and has reached the maximum number of attempts.", lastEditedIn: .unknown)
-    public static let AuthenticationMaximumAttemptsReachedNoTime = MZLocalizedString("Maximum attempts reached. Please try again later.", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode and has reached the maximum number of attempts.", lastEditedIn: .unknown)
-    public static let AuthenticationMismatchPasscodeError = MZLocalizedString("Passcodes didn’t match. Try again.", tableName: "AuthenticationManager", comment: "Error message displayed to user when their confirming passcode doesn't match the first code.", lastEditedIn: .unknown)
-    public static let AuthenticationUseNewPasscodeError = MZLocalizedString("New passcode must be different than existing code.", tableName: "AuthenticationManager", comment: "Error message displayed when user tries to enter the same passcode as their existing code when changing it.", lastEditedIn: .unknown)
-}
-
-// MARK: - Authenticator strings
-extension String {
-    public static let AuthenticatorCancel = MZLocalizedString("Cancel", comment: "Label for Cancel button", lastEditedIn: .unknown)
-    public static let AuthenticatorLogin = MZLocalizedString("Log in", comment: "Authentication prompt log in button", lastEditedIn: .unknown)
-    public static let AuthenticatorPromptTitle = MZLocalizedString("Authentication required", comment: "Authentication prompt title", lastEditedIn: .unknown)
-    public static let AuthenticatorPromptRealmMessage = MZLocalizedString("A username and password are being requested by %@. The site says: %@", comment: "Authentication prompt message with a realm. First parameter is the hostname. Second is the realm string", lastEditedIn: .unknown)
-    public static let AuthenticatorPromptEmptyRealmMessage = MZLocalizedString("A username and password are being requested by %@.", comment: "Authentication prompt message with no realm. Parameter is the hostname of the site", lastEditedIn: .unknown)
-    public static let AuthenticatorUsernamePlaceholder = MZLocalizedString("Username", comment: "Username textbox in Authentication prompt", lastEditedIn: .unknown)
-    public static let AuthenticatorPasswordPlaceholder = MZLocalizedString("Password", comment: "Password textbox in Authentication prompt", lastEditedIn: .unknown)
-}
-
-// MARK: - BrowserViewController
-extension String {
-    public static let ReaderModeAddPageGeneralErrorAccessibilityLabel = MZLocalizedString("Could not add page to Reading list", comment: "Accessibility message e.g. spoken by VoiceOver after adding current webpage to the Reading List failed.", lastEditedIn: .unknown)
-    public static let ReaderModeAddPageSuccessAcessibilityLabel = MZLocalizedString("Added page to Reading List", comment: "Accessibility message e.g. spoken by VoiceOver after the current page gets added to the Reading List using the Reader View button, e.g. by long-pressing it or by its accessibility custom action.", lastEditedIn: .unknown)
-    public static let ReaderModeAddPageMaybeExistsErrorAccessibilityLabel = MZLocalizedString("Could not add page to Reading List. Maybe it’s already there?", comment: "Accessibility message e.g. spoken by VoiceOver after the user wanted to add current page to the Reading List and this was not done, likely because it already was in the Reading List, but perhaps also because of real failures.", lastEditedIn: .unknown)
-    public static let WebViewAccessibilityLabel = MZLocalizedString("Web content", comment: "Accessibility label for the main web content view", lastEditedIn: .unknown)
-}
-
-// MARK: - Find in page
-extension String {
-    public static let FindInPagePreviousAccessibilityLabel = MZLocalizedString("Previous in-page result", tableName: "FindInPage", comment: "Accessibility label for previous result button in Find in Page Toolbar.", lastEditedIn: .unknown)
-    public static let FindInPageNextAccessibilityLabel = MZLocalizedString("Next in-page result", tableName: "FindInPage", comment: "Accessibility label for next result button in Find in Page Toolbar.", lastEditedIn: .unknown)
-    public static let FindInPageDoneAccessibilityLabel = MZLocalizedString("Done", tableName: "FindInPage", comment: "Done button in Find in Page Toolbar.", lastEditedIn: .unknown)
-}
-
-// MARK: - Reader Mode Bar
-extension String {
-    public static let ReaderModeBarMarkAsRead = MZLocalizedString("Mark as Read", comment: "Name for Mark as read button in reader mode", lastEditedIn: .unknown)
-    public static let ReaderModeBarMarkAsUnread = MZLocalizedString("Mark as Unread", comment: "Name for Mark as unread button in reader mode", lastEditedIn: .unknown)
-    public static let ReaderModeBarSettings = MZLocalizedString("Display Settings", comment: "Name for display settings button in reader mode. Display in the meaning of presentation, not monitor.", lastEditedIn: .unknown)
-    public static let ReaderModeBarAddToReadingList = MZLocalizedString("Add to Reading List", comment: "Name for button adding current article to reading list in reader mode", lastEditedIn: .unknown)
-    public static let ReaderModeBarRemoveFromReadingList = MZLocalizedString("Remove from Reading List", comment: "Name for button removing current article from reading list in reader mode", lastEditedIn: .unknown)
-}
-
-// MARK: - SearchViewController
-extension String {
-    public static let SearchSettingsAccessibilityLabel = MZLocalizedString("Search Settings", tableName: "Search", comment: "Label for search settings button.", lastEditedIn: .unknown)
-    public static let SearchSearchEngineAccessibilityLabel = MZLocalizedString("%@ search", tableName: "Search", comment: "Label for search engine buttons. The argument corresponds to the name of the search engine.", lastEditedIn: .unknown)
-    public static let SearchSearchEngineSuggestionAccessibilityLabel = MZLocalizedString("Search suggestions from %@", tableName: "Search", comment: "Accessibility label for image of default search engine displayed left to the actual search suggestions from the engine. The parameter substituted for \"%@\" is the name of the search engine. E.g.: Search suggestions from Google", lastEditedIn: .unknown)
-    public static let SearchSearchSuggestionTapAccessibilityHint = MZLocalizedString("Searches for the suggestion", comment: "Accessibility hint describing the action performed when a search suggestion is clicked", lastEditedIn: .unknown)
-    public static let SearchSuggestionCellSwitchToTabLabel = MZLocalizedString("Search.Awesomebar.SwitchToTab", value: "Switch to tab", comment: "Search suggestion cell label that allows user to switch to tab which they searched for in url bar", lastEditedIn: .unknown)
 }
 
 // MARK: - Tab Location View
@@ -1159,6 +1396,7 @@ extension String {
     public static let TabToolbarBackAccessibilityLabel = MZLocalizedString("Back", comment: "Accessibility label for the Back button in the tab toolbar.", lastEditedIn: .unknown)
     public static let TabToolbarForwardAccessibilityLabel = MZLocalizedString("Forward", comment: "Accessibility Label for the tab toolbar Forward button", lastEditedIn: .unknown)
     public static let TabToolbarNavigationToolbarAccessibilityLabel = MZLocalizedString("Navigation Toolbar", comment: "Accessibility label for the navigation toolbar displayed at the bottom of the screen.", lastEditedIn: .unknown)
+    public static let AddTabAccessibilityLabel = MZLocalizedString("TabTray.AddTab.Button", value: "Add Tab", comment: "Accessibility label for the Add Tab button in the Tab Tray.", lastEditedIn: .unknown)
 }
 
 // MARK: - Tab Tray v1
@@ -1182,177 +1420,6 @@ extension String {
     public static let TabTrayCurrentlySelectedTabAccessibilityLabel = MZLocalizedString("TabTray.CurrentSelectedTab.A11Y", value: "Currently selected tab.", comment: "Accessibility label for the currently selected tab.", lastEditedIn: .unknown)
 }
 
-// MARK: - URL Bar
-extension String {
-    public static let URLBarLocationAccessibilityLabel = MZLocalizedString("Address and Search", comment: "Accessibility label for address and search field, both words (Address, Search) are therefore nouns.", lastEditedIn: .unknown)
-}
-
-// MARK: - Error Pages
-extension String {
-    public static let ErrorPageTryAgain = MZLocalizedString("Try again", tableName: "ErrorPages", comment: "Shown in error pages on a button that will try to load the page again", lastEditedIn: .unknown)
-    public static let ErrorPageOpenInSafari = MZLocalizedString("Open in Safari", tableName: "ErrorPages", comment: "Shown in error pages for files that can't be shown and need to be downloaded.", lastEditedIn: .unknown)
-}
-
-// MARK: - LibraryPanel
-extension String {
-    public static let LibraryPanelBookmarksAccessibilityLabel = MZLocalizedString("Bookmarks", comment: "Panel accessibility label", lastEditedIn: .unknown)
-    public static let LibraryPanelHistoryAccessibilityLabel = MZLocalizedString("History", comment: "Panel accessibility label", lastEditedIn: .unknown)
-    public static let LibraryPanelReadingListAccessibilityLabel = MZLocalizedString("Reading list", comment: "Panel accessibility label", lastEditedIn: .unknown)
-    public static let LibraryPanelDownloadsAccessibilityLabel = MZLocalizedString("Downloads", comment: "Panel accessibility label", lastEditedIn: .unknown)
-    public static let LibraryPanelSyncedTabsAccessibilityLabel = MZLocalizedString("Synced Tabs", comment: "Panel accessibility label", lastEditedIn: .unknown)
-}
-
-// MARK: - LibraryViewController
-extension String {
-    public static let LibraryPanelChooserAccessibilityLabel = MZLocalizedString("Panel Chooser", comment: "Accessibility label for the Library panel's bottom toolbar containing a list of the home panels (top sites, bookmarks, history, remote tabs, reading list).", lastEditedIn: .unknown)
-}
-
-// MARK: - ReaderPanel
-extension String {
-    public static let ReaderPanelRemove = MZLocalizedString("Remove", comment: "Title for the button that removes a reading list item", lastEditedIn: .unknown)
-    public static let ReaderPanelMarkAsRead = MZLocalizedString("Mark as Read", comment: "Title for the button that marks a reading list item as read", lastEditedIn: .unknown)
-    public static let ReaderPanelMarkAsUnread =  MZLocalizedString("Mark as Unread", comment: "Title for the button that marks a reading list item as unread", lastEditedIn: .unknown)
-    public static let ReaderPanelUnreadAccessibilityLabel = MZLocalizedString("unread", comment: "Accessibility label for unread article in reading list. It's a past participle - functions as an adjective.", lastEditedIn: .unknown)
-    public static let ReaderPanelReadAccessibilityLabel = MZLocalizedString("read", comment: "Accessibility label for read article in reading list. It's a past participle - functions as an adjective.", lastEditedIn: .unknown)
-    public static let ReaderPanelWelcome = MZLocalizedString("Welcome to your Reading List", comment: "See http://mzl.la/1LXbDOL", lastEditedIn: .unknown)
-    public static let ReaderPanelReadingModeDescription = MZLocalizedString("Open articles in Reader View by tapping the book icon when it appears in the title bar.", comment: "See http://mzl.la/1LXbDOL", lastEditedIn: .unknown)
-    public static let ReaderPanelReadingListDescription = MZLocalizedString("Save pages to your Reading List by tapping the book plus icon in the Reader View controls.", comment: "See http://mzl.la/1LXbDOL", lastEditedIn: .unknown)
-}
-
-// MARK: - Remote Tabs Panel
-extension String {
-    // Backup and active strings added in Bug 1205294.
-    public static let RemoteTabEmptyStateInstructionsSyncTabsPasswordsBookmarksString = MZLocalizedString("Sync your tabs, bookmarks, passwords and more.", comment: "Text displayed when the Sync home panel is empty, describing the features provided by Sync to invite the user to log in.", lastEditedIn: .unknown)
-    public static let RemoteTabEmptyStateInstructionsSyncTabsPasswordsString = MZLocalizedString("Sync your tabs, passwords and more.", comment: "Text displayed when the Sync home panel is empty, describing the features provided by Sync to invite the user to log in.", lastEditedIn: .unknown)
-    public static let RemoteTabEmptyStateInstructionsGetTabsBookmarksPasswordsString = MZLocalizedString("Get your open tabs, bookmarks, and passwords from your other devices.", comment: "A re-worded offer about Sync, displayed when the Sync home panel is empty, that emphasizes one-way data transfer, not syncing.", lastEditedIn: .unknown)
-
-    public static let RemoteTabErrorNoTabs = MZLocalizedString("You don’t have any tabs open in Firefox on your other devices.", comment: "Error message in the remote tabs panel", lastEditedIn: .unknown)
-    public static let RemoteTabErrorFailedToSync = MZLocalizedString("There was a problem accessing tabs from your other devices. Try again in a few moments.", comment: "Error message in the remote tabs panel", lastEditedIn: .unknown)
-    public static let RemoteTabLastSync = MZLocalizedString("Last synced: %@", comment: "Remote tabs last synced time. Argument is the relative date string.", lastEditedIn: .unknown)
-    public static let RemoteTabComputerAccessibilityLabel = MZLocalizedString("computer", comment: "Accessibility label for Desktop Computer (PC) image in remote tabs list", lastEditedIn: .unknown)
-    public static let RemoteTabMobileAccessibilityLabel =  MZLocalizedString("mobile device", comment: "Accessibility label for Mobile Device image in remote tabs list", lastEditedIn: .unknown)
-    public static let RemoteTabCreateAccount = MZLocalizedString("Create an account", comment: "See http://mzl.la/1Qtkf0j", lastEditedIn: .unknown)
-}
-
-// MARK: - Login list
-extension String {
-    public static let LoginListDeselctAll = MZLocalizedString("Deselect All", tableName: "LoginManager", comment: "Label for the button used to deselect all logins.", lastEditedIn: .unknown)
-    public static let LoginListSelctAll = MZLocalizedString("Select All", tableName: "LoginManager", comment: "Label for the button used to select all logins.", lastEditedIn: .unknown)
-    public static let LoginListDelete = MZLocalizedString("Delete", tableName: "LoginManager", comment: "Label for the button used to delete the current login.", lastEditedIn: .unknown)
-}
-
-// MARK: - Login Detail
-extension String {
-    public static let LoginDetailUsername = MZLocalizedString("Username", tableName: "LoginManager", comment: "Label displayed above the username row in Login Detail View.", lastEditedIn: .unknown)
-    public static let LoginDetailPassword = MZLocalizedString("Password", tableName: "LoginManager", comment: "Label displayed above the password row in Login Detail View.", lastEditedIn: .unknown)
-    public static let LoginDetailWebsite = MZLocalizedString("Website", tableName: "LoginManager", comment: "Label displayed above the website row in Login Detail View.", lastEditedIn: .unknown)
-    public static let LoginDetailCreatedAt =  MZLocalizedString("Created %@", tableName: "LoginManager", comment: "Label describing when the current login was created with the timestamp as the parameter.", lastEditedIn: .unknown)
-    public static let LoginDetailModifiedAt = MZLocalizedString("Modified %@", tableName: "LoginManager", comment: "Label describing when the current login was last modified with the timestamp as the parameter.", lastEditedIn: .unknown)
-    public static let LoginDetailDelete = MZLocalizedString("Delete", tableName: "LoginManager", comment: "Label for the button used to delete the current login.", lastEditedIn: .unknown)
-}
-
-// MARK: - No Logins View
-extension String {
-    public static let NoLoginsFound = MZLocalizedString("No logins found", tableName: "LoginManager", comment: "Label displayed when no logins are found after searching.", lastEditedIn: .unknown)
-}
-
-// MARK: - Reader Mode Handler
-extension String {
-    public static let ReaderModeHandlerLoadingContent = MZLocalizedString("Loading content…", comment: "Message displayed when the reader mode page is loading. This message will appear only when sharing to Firefox reader mode from another app.", lastEditedIn: .unknown)
-    public static let ReaderModeHandlerPageCantDisplay = MZLocalizedString("The page could not be displayed in Reader View.", comment: "Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Firefox reader mode from another app.", lastEditedIn: .unknown)
-    public static let ReaderModeHandlerLoadOriginalPage = MZLocalizedString("Load original page", comment: "Link for going to the non-reader page when the reader view could not be loaded. This message will appear only when sharing to Firefox reader mode from another app.", lastEditedIn: .unknown)
-    public static let ReaderModeHandlerError = MZLocalizedString("There was an error converting the page", comment: "Error displayed when reader mode cannot be enabled", lastEditedIn: .unknown)
-}
-
-// MARK: - ReaderModeStyle
-extension String {
-    public static let ReaderModeStyleBrightnessAccessibilityLabel = MZLocalizedString("Brightness", comment: "Accessibility label for brightness adjustment slider in Reader Mode display settings", lastEditedIn: .unknown)
-    public static let ReaderModeStyleFontTypeAccessibilityLabel = MZLocalizedString("Changes font type.", comment: "Accessibility hint for the font type buttons in reader mode display settings", lastEditedIn: .unknown)
-    public static let ReaderModeStyleSansSerifFontType = MZLocalizedString("Sans-serif", comment: "Font type setting in the reading view settings", lastEditedIn: .unknown)
-    public static let ReaderModeStyleSerifFontType = MZLocalizedString("Serif", comment: "Font type setting in the reading view settings", lastEditedIn: .unknown)
-    public static let ReaderModeStyleSmallerLabel = MZLocalizedString("-", comment: "Button for smaller reader font size. Keep this extremely short! This is shown in the reader mode toolbar.", lastEditedIn: .unknown)
-    public static let ReaderModeStyleSmallerAccessibilityLabel = MZLocalizedString("Decrease text size", comment: "Accessibility label for button decreasing font size in display settings of reader mode", lastEditedIn: .unknown)
-    public static let ReaderModeStyleLargerLabel = MZLocalizedString("+", comment: "Button for larger reader font size. Keep this extremely short! This is shown in the reader mode toolbar.", lastEditedIn: .unknown)
-    public static let ReaderModeStyleLargerAccessibilityLabel = MZLocalizedString("Increase text size", comment: "Accessibility label for button increasing font size in display settings of reader mode", lastEditedIn: .unknown)
-    public static let ReaderModeStyleFontSize = MZLocalizedString("Aa", comment: "Button for reader mode font size. Keep this extremely short! This is shown in the reader mode toolbar.", lastEditedIn: .unknown)
-    public static let ReaderModeStyleChangeColorSchemeAccessibilityHint = MZLocalizedString("Changes color theme.", comment: "Accessibility hint for the color theme setting buttons in reader mode display settings", lastEditedIn: .unknown)
-    public static let ReaderModeStyleLightLabel = MZLocalizedString("Light", comment: "Light theme setting in Reading View settings", lastEditedIn: .unknown)
-    public static let ReaderModeStyleDarkLabel = MZLocalizedString("Dark", comment: "Dark theme setting in Reading View settings", lastEditedIn: .unknown)
-    public static let ReaderModeStyleSepiaLabel = MZLocalizedString("Sepia", comment: "Sepia theme setting in Reading View settings", lastEditedIn: .unknown)
-}
-
-// MARK: - Empty Private tab view
-extension String {
-    public static let PrivateBrowsingLearnMore = MZLocalizedString("Learn More", tableName: "PrivateBrowsing", comment: "Text button displayed when there are no tabs open while in private mode", lastEditedIn: .unknown)
-    public static let PrivateBrowsingTitle = MZLocalizedString("Private Browsing", tableName: "PrivateBrowsing", comment: "Title displayed for when there are no open tabs while in private mode", lastEditedIn: .unknown)
-    public static let PrivateBrowsingDescription = MZLocalizedString("Firefox won’t remember any of your history or cookies, but new bookmarks will be saved.", tableName: "PrivateBrowsing", comment: "Description text displayed when there are no open tabs while in private mode", lastEditedIn: .unknown)
-}
-
-// MARK: - Advanced Account Setting
-extension String {
-    public static let AdvancedAccountUseStageServer = MZLocalizedString("Use stage servers", comment: "Debug option", lastEditedIn: .unknown)
-}
-
-// MARK: - App Settings
-extension String {
-    public static let AppSettingsLicenses = MZLocalizedString("Licenses", comment: "Settings item that opens a tab containing the licenses. See http://mzl.la/1NSAWCG", lastEditedIn: .unknown)
-    public static let AppSettingsYourRights = MZLocalizedString("Your Rights", comment: "Your Rights settings section title", lastEditedIn: .unknown)
-    public static let AppSettingsShowTour = MZLocalizedString("Show Tour", comment: "Show the on-boarding screen again from the settings", lastEditedIn: .unknown)
-    public static let AppSettingsSendFeedback = MZLocalizedString("Send Feedback", comment: "Menu item in settings used to open input.mozilla.org where people can submit feedback", lastEditedIn: .unknown)
-    public static let AppSettingsHelp = MZLocalizedString("Help", comment: "Show the SUMO support page from the Support section in the settings. see http://mzl.la/1dmM8tZ", lastEditedIn: .unknown)
-    public static let AppSettingsSearch = MZLocalizedString("Search", comment: "Open search section of settings", lastEditedIn: .unknown)
-    public static let AppSettingsPrivacyPolicy = MZLocalizedString("Privacy Policy", comment: "Show Firefox Browser Privacy Policy page from the Privacy section in the settings. See https://www.mozilla.org/privacy/firefox/", lastEditedIn: .unknown)
-    
-    public static let AppSettingsTitle = MZLocalizedString("Settings", comment: "Title in the settings view controller title bar", lastEditedIn: .unknown)
-    public static let AppSettingsDone = MZLocalizedString("Done", comment: "Done button on left side of the Settings view controller title bar", lastEditedIn: .unknown)
-    public static let AppSettingsPrivacyTitle = MZLocalizedString("Privacy", comment: "Privacy section title", lastEditedIn: .unknown)
-    public static let AppSettingsBlockPopups = MZLocalizedString("Block Pop-up Windows", comment: "Block pop-up windows setting", lastEditedIn: .unknown)
-    public static let AppSettingsClosePrivateTabsTitle = MZLocalizedString("Close Private Tabs", tableName: "PrivateBrowsing", comment: "Setting for closing private tabs", lastEditedIn: .unknown)
-    public static let AppSettingsClosePrivateTabsDescription = MZLocalizedString("When Leaving Private Browsing", tableName: "PrivateBrowsing", comment: "Will be displayed in Settings under 'Close Private Tabs'", lastEditedIn: .unknown)
-    public static let AppSettingsSupport = MZLocalizedString("Support", comment: "Support section title", lastEditedIn: .unknown)
-    public static let AppSettingsAbout = MZLocalizedString("About", comment: "About settings section title", lastEditedIn: .unknown)
-}
-
-// MARK: - Clearables
-extension String {
-    // Removed Clearables as part of Bug 1226654, but keeping the string around.
-    private static let removedSavedLoginsLabel = MZLocalizedString("Saved Logins", tableName: "ClearPrivateData", comment: "Settings item for clearing passwords and login data", lastEditedIn: .unknown)
-    
-    public static let ClearableHistory = MZLocalizedString("Browsing History", tableName: "ClearPrivateData", comment: "Settings item for clearing browsing history", lastEditedIn: .unknown)
-    public static let ClearableCache = MZLocalizedString("Cache", tableName: "ClearPrivateData", comment: "Settings item for clearing the cache", lastEditedIn: .unknown)
-    public static let ClearableOfflineData = MZLocalizedString("Offline Website Data", tableName: "ClearPrivateData", comment: "Settings item for clearing website data", lastEditedIn: .unknown)
-    public static let ClearableCookies = MZLocalizedString("Cookies", tableName: "ClearPrivateData", comment: "Settings item for clearing cookies", lastEditedIn: .unknown)
-    public static let ClearableDownloads = MZLocalizedString("Downloaded Files", tableName: "ClearPrivateData", comment: "Settings item for deleting downloaded files", lastEditedIn: .unknown)
-}
-
-// MARK: - SearchEngine Picker
-extension String {
-    public static let SearchEnginePickerTitle = MZLocalizedString("Default Search Engine", comment: "Title for default search engine picker.", lastEditedIn: .unknown)
-    public static let SearchEnginePickerCancel = MZLocalizedString("Cancel", comment: "Label for Cancel button", lastEditedIn: .unknown)
-}
-
-// MARK: - SearchSettings
-extension String {
-    public static let SearchSettingsTitle = MZLocalizedString("Search", comment: "Navigation title for search settings.", lastEditedIn: .unknown)
-    public static let SearchSettingsDefaultSearchEngineAccessibilityLabel = MZLocalizedString("Default Search Engine", comment: "Accessibility label for default search engine setting.", lastEditedIn: .unknown)
-    public static let SearchSettingsShowSearchSuggestions = MZLocalizedString("Show Search Suggestions", comment: "Label for show search suggestions setting.", lastEditedIn: .unknown)
-    public static let SearchSettingsDefaultSearchEngineTitle = MZLocalizedString("Default Search Engine", comment: "Title for default search engine settings section.", lastEditedIn: .unknown)
-    public static let SearchSettingsQuickSearchEnginesTitle = MZLocalizedString("Quick-Search Engines", comment: "Title for quick-search engines settings section.", lastEditedIn: .unknown)
-}
-
-// MARK: - SettingsContent
-extension String {
-    public static let SettingsContentPageLoadError = MZLocalizedString("Could not load page.", comment: "Error message that is shown in settings when there was a problem loading", lastEditedIn: .unknown)
-}
-
-// MARK: - SearchInput
-extension String {
-    public static let SearchInputAccessibilityLabel = MZLocalizedString("Search Input Field", tableName: "LoginManager", comment: "Accessibility label for the search input field in the Logins list", lastEditedIn: .unknown)
-    public static let SearchInputTitle = MZLocalizedString("Search", tableName: "LoginManager", comment: "Title for the search field at the top of the Logins list screen", lastEditedIn: .unknown)
-    public static let SearchInputClearAccessibilityLabel = MZLocalizedString("Clear Search", tableName: "LoginManager", comment: "Accessibility message e.g. spoken by VoiceOver after the user taps the close button in the search field to clear the search and exit search mode", lastEditedIn: .unknown)
-    public static let SearchInputEnterSearchMode = MZLocalizedString("Enter Search Mode", tableName: "LoginManager", comment: "Accessibility label for entering search mode for logins", lastEditedIn: .unknown)
-}
-
 // MARK: - TabsButton
 extension String {
     public static let TabsButtonShowTabsAccessibilityLabel = MZLocalizedString("Show Tabs", comment: "Accessibility label for the tabs button in the (top) tab toolbar", lastEditedIn: .unknown)
@@ -1364,59 +1431,35 @@ extension String {
     public static let TabTrayButtonShowTabsAccessibilityLabel = MZLocalizedString("Show Tabs", comment: "Accessibility Label for the tabs button in the tab toolbar", lastEditedIn: .unknown)
 }
 
-// MARK: - MenuHelper
-extension String {
-    public static let MenuHelperPasteAndGo = MZLocalizedString("UIMenuItem.PasteGo", value: "Paste & Go", comment: "The menu item that pastes the current contents of the clipboard into the URL bar and navigates to the page", lastEditedIn: .unknown)
-    public static let MenuHelperReveal = MZLocalizedString("Reveal", tableName: "LoginManager", comment: "Reveal password text selection menu item", lastEditedIn: .unknown)
-    public static let MenuHelperHide =  MZLocalizedString("Hide", tableName: "LoginManager", comment: "Hide password text selection menu item", lastEditedIn: .unknown)
-    public static let MenuHelperCopy = MZLocalizedString("Copy", tableName: "LoginManager", comment: "Copy password text selection menu item", lastEditedIn: .unknown)
-    public static let MenuHelperOpenAndFill = MZLocalizedString("Open & Fill", tableName: "LoginManager", comment: "Open and Fill website text selection menu item", lastEditedIn: .unknown)
-    public static let MenuHelperFindInPage = MZLocalizedString("Find in Page", tableName: "FindInPage", comment: "Text selection menu item", lastEditedIn: .unknown)
-    public static let MenuHelperSearchWithFirefox = MZLocalizedString("UIMenuItem.SearchWithFirefox", value: "Search with Firefox", comment: "Search in New Tab Text selection menu item", lastEditedIn: .unknown)
-}
-
-// MARK: - DeviceInfo
-extension String {
-    public static let DeviceInfoClientNameDescription = MZLocalizedString("%@ on %@", tableName: "Shared", comment: "A brief descriptive name for this app on this device, used for Send Tab and Synced Tabs. The first argument is the app name. The second argument is the device name.", lastEditedIn: .unknown)
-}
-
 // MARK: - TimeConstants
 extension String {
-    public static let TimeConstantMoreThanAMonth = MZLocalizedString("more than a month ago", comment: "Relative date for dates older than a month and less than two months.", lastEditedIn: .unknown)
-    public static let TimeConstantMoreThanAWeek = MZLocalizedString("more than a week ago", comment: "Description for a date more than a week ago, but less than a month ago.", lastEditedIn: .unknown)
-    public static let TimeConstantYesterday = MZLocalizedString("yesterday", comment: "Relative date for yesterday.", lastEditedIn: .unknown)
-    public static let TimeConstantThisWeek = MZLocalizedString("this week", comment: "Relative date for date in past week.", lastEditedIn: .unknown)
-    public static let TimeConstantRelativeToday = MZLocalizedString("today at %@", comment: "Relative date for date older than a minute.", lastEditedIn: .unknown)
-    public static let TimeConstantJustNow = MZLocalizedString("just now", comment: "Relative time for a tab that was visited within the last few moments.", lastEditedIn: .unknown)
-}
-
-// MARK: - Default Suggested Site
-extension String {
-    public static let DefaultSuggestedFacebook = MZLocalizedString("Facebook", comment: "Tile title for Facebook", lastEditedIn: .unknown)
-    public static let DefaultSuggestedYouTube = MZLocalizedString("YouTube", comment: "Tile title for YouTube", lastEditedIn: .unknown)
-    public static let DefaultSuggestedAmazon = MZLocalizedString("Amazon", comment: "Tile title for Amazon", lastEditedIn: .unknown)
-    public static let DefaultSuggestedWikipedia = MZLocalizedString("Wikipedia", comment: "Tile title for Wikipedia", lastEditedIn: .unknown)
-    public static let DefaultSuggestedTwitter = MZLocalizedString("Twitter", comment: "Tile title for Twitter", lastEditedIn: .unknown)
-}
-
-// MARK: - MR1 Strings
-extension String {
-    public static let AwesomeBarSearchWithEngineButtonTitle = MZLocalizedString("Awesomebar.SearchWithEngine.Title", value: "Search with %@", comment: "Title for button to suggest searching with a search engine. First argument is the name of the search engine to select", lastEditedIn: .unknown)
-    public static let AwesomeBarSearchWithEngineButtonDescription = MZLocalizedString("Awesomebar.SearchWithEngine.Description", value: "Search %@ directly from the address bar", comment: "Description for button to suggest searching with a search engine. First argument is the name of the search engine to select", lastEditedIn: .unknown)
-}
-
-// MARK: - Credential Provider
-extension String {
-    struct CredetntialProvider {
-        public static let LoginsWelcomeViewTitle = MZLocalizedString("Logins.WelcomeView.Title", value: "Take your passwords everywhere", comment: "Label displaying welcome view title", lastEditedIn: .unknown)
-        public static let LoginsListSearchCancel = MZLocalizedString("LoginsList.Search.Cancel", value: "Cancel", comment: "Cancel button title", lastEditedIn: .unknown)
-        public static let LoginsListSearchPlaceholder = MZLocalizedString("LoginsList.Search.Placeholder", value: "Search logins", comment: "Placeholder text for search field", lastEditedIn: .unknown)
-        public static let LoginsListSelectPasswordTitle = MZLocalizedString("LoginsList.SelectPassword.Title", value: "Select a password to fill", comment: "Label displaying select a password to fill instruction", lastEditedIn: .unknown)
-        public static let LoginsListNoMatchingResultTitle = MZLocalizedString("LoginsList.NoMatchingResult.Title", value: "No matching logins", comment: "Label displayed when a user searches and no matches can be found against the search query", lastEditedIn: .unknown)
-        public static let LoginsListNoMatchingResultSubtitle = MZLocalizedString("LoginsList.NoMatchingResult.Subtitle", value: "There are no results matching your search.", comment: "Label that appears after the search if there are no logins matching the search", lastEditedIn: .unknown)
-        public static let LoginsListNoLoginsFoundDescription = MZLocalizedString("LoginsList.NoLoginsFound.Description", value: "Saved logins will show up here. If you saved your logins to Firefox on a different device, sign in to your Firefox Account.", comment: "Label shown when there are no logins to list", lastEditedIn: .unknown)
+    public struct TimeConstants {
+        public static let MoreThanAMonth = MZLocalizedString("more than a month ago", comment: "Relative date for dates older than a month and less than two months.", lastEditedIn: .unknown)
+        public static let MoreThanAWeek = MZLocalizedString("more than a week ago", comment: "Description for a date more than a week ago, but less than a month ago.", lastEditedIn: .unknown)
+        public static let Yesterday = MZLocalizedString("yesterday", comment: "Relative date for yesterday.", lastEditedIn: .unknown)
+        public static let ThisWeek = MZLocalizedString("this week", comment: "Relative date for date in past week.", lastEditedIn: .unknown)
+        public static let RelativeToday = MZLocalizedString("today at %@", comment: "Relative date for date older than a minute.", lastEditedIn: .unknown)
+        public static let JustNow = MZLocalizedString("just now", comment: "Relative time for a tab that was visited within the last few moments.", lastEditedIn: .unknown)
     }
 }
+
+// MARK: - U
+// MARK: - URL Bar
+extension String {
+    public static let URLBarLocationAccessibilityLabel = MZLocalizedString("Address and Search", comment: "Accessibility label for address and search field, both words (Address, Search) are therefore nouns.", lastEditedIn: .unknown)
+}
+
+// MARK: - V
+// MARK: - W
+// MARK: - X
+// MARK: - Y
+// MARK: - Z
+
+
+
+
+
+
 
 // MARK: - v35 Strings
 extension String {
@@ -1432,4 +1475,123 @@ extension String {
 extension String {
     public static let ProtectionStatusSheetConnectionSecure = MZLocalizedString("ProtectionStatusSheet.SecureConnection", value: "Secure Connection", comment: "value for label to indicate user is on a secure ssl connection", lastEditedIn: .v360)
     public static let ProtectionStatusSheetConnectionInsecure = MZLocalizedString("ProtectionStatusSheet.InsecureConnection", value: "Insecure Connection", comment: "value for label to indicate user is on an unencrypted website", lastEditedIn: .v360)
+}
+
+// MARK: - Deprecated Strings
+// These strings are no longer used but are being kept around for localization.
+extension String {
+    public struct Deprecated {
+
+        public static let ASPocketTitle = MZLocalizedString("ActivityStream.Pocket.SectionTitle", value: "Trending on Pocket", comment: "Section title label for Recommended by Pocket section", lastEditedIn: .unknown)
+        public static let HighlightVistedText = MZLocalizedString("ActivityStream.Highlights.Visited", value: "Visited", comment: "The description of a highlight if it is a site the user has visited", lastEditedIn: .unknown)
+        public static let HighlightBookmarkText = MZLocalizedString("ActivityStream.Highlights.Bookmark", value: "Bookmarked", comment: "The description of a highlight if it is a site the user has bookmarked", lastEditedIn: .unknown)
+        public static let PocketTrendingText = MZLocalizedString("ActivityStream.Pocket.Trending", value: "Trending", comment: "The description of a Pocket Story", lastEditedIn: .unknown)
+
+        public static let SettingsHomePageSectionName = MZLocalizedString("Settings.HomePage.SectionName", value: "Homepage", comment: "Label used as an item in Settings. When touched it will open a dialog to configure the home page and its uses.", lastEditedIn: .unknown)
+        public static let SettingsHomePageTitle = MZLocalizedString("Settings.HomePage.Title", value: "Homepage Settings", comment: "Title displayed in header of the setting panel.", lastEditedIn: .unknown)
+        public static let SettingsHomePageURLSectionTitle = MZLocalizedString("Settings.HomePage.URL.Title", value: "Current Homepage", comment: "Title of the setting section containing the URL of the current home page.", lastEditedIn: .unknown)
+        public static let SettingsHomePageUseCurrentPage = MZLocalizedString("Settings.HomePage.UseCurrent.Button", value: "Use Current Page", comment: "Button in settings to use the current page as home page.", lastEditedIn: .unknown)
+        public static let SettingsHomePageTextPlaceholder = MZLocalizedString("Settings.HomePage.URL.Placeholder", value: "Enter a webpage", comment: "Placeholder text in the homepage setting when no homepage has been set.", lastEditedIn: .unknown)
+        public static let SettingsHomePageUseCopiedLink = MZLocalizedString("Settings.HomePage.UseCopiedLink.Button", value: "Use Copied Link", comment: "Button in settings to use the current link on the clipboard as home page.", lastEditedIn: .unknown)
+        public static let SettingsHomePageUseDefault = MZLocalizedString("Settings.HomePage.UseDefault.Button", value: "Use Default", comment: "Button in settings to use the default home page. If no default is set, then this button isn't shown.", lastEditedIn: .unknown)
+        public static let SettingsHomePageClear = MZLocalizedString("Settings.HomePage.Clear.Button", value: "Clear", comment: "Button in settings to clear the home page.", lastEditedIn: .unknown)
+
+        public static let SetHomePageDialogTitle = MZLocalizedString("HomePage.Set.Dialog.Title", value: "Do you want to use this web page as your home page?", comment: "Alert dialog title when the user opens the home page for the first time.", lastEditedIn: .unknown)
+        public static let SetHomePageDialogMessage = MZLocalizedString("HomePage.Set.Dialog.Message", value: "You can change this at any time in Settings", comment: "Alert dialog body when the user opens the home page for the first time.", lastEditedIn: .unknown)
+        public static let SetHomePageDialogYes = MZLocalizedString("HomePage.Set.Dialog.OK", value: "Set Homepage", comment: "Button accepting changes setting the home page for the first time.", lastEditedIn: .unknown)
+        public static let SetHomePageDialogNo = MZLocalizedString("HomePage.Set.Dialog.Cancel", value: "Cancel", comment: "Button cancelling changes setting the home page for the first time.", lastEditedIn: .unknown)
+
+        public static let FxASignin_CreateAccountPt1 = MZLocalizedString("fxa.signin.create-account-pt-1", value: "Sync Firefox between devices with an account.", comment: "FxA sign in create account label.", lastEditedIn: .unknown)
+        public static let FxASignin_CreateAccountPt2 = MZLocalizedString("fxa.signin.create-account-pt-2", value: "Create Firefox account.", comment: "FxA sign in create account label. This will be linked to the site to create an account.", lastEditedIn: .unknown)
+
+        public static let AppMenuLibraryReloadString = MZLocalizedString("Menu.Library.Reload", tableName: "Menu", value: "Reload", comment: "Label for the button, displayed in the menu, used to Reload the webpage", lastEditedIn: .unknown)
+        public static let AppMenuRecentlySavedTitle = MZLocalizedString("Menu.RecentlySaved.Title", tableName: "Menu", value: "Recently Saved", comment: "A string used to signify the start of the Recently Saved section in Home Screen.", lastEditedIn: .unknown)
+        public static let AppMenuShowTabsTitleString = MZLocalizedString("Menu.ShowTabs.Title", tableName: "Menu", value: "Show Tabs", comment: "Label for the button, displayed in the menu, used to open the tabs tray", lastEditedIn: .unknown)
+        public static let AppMenuCopyURLTitleString = MZLocalizedString("Menu.CopyAddress.Title", tableName: "Menu", value: "Copy Address", comment: "Label for the button, displayed in the menu, used to copy the page url to the clipboard.", lastEditedIn: .unknown)
+        public static let AppMenuNewPrivateTabTitleString = MZLocalizedString("Menu.NewPrivateTabAction.Title", tableName: "Menu", value: "Open New Private Tab", comment: "Label for the button, displayed in the menu, used to open a new private tab.", lastEditedIn: .unknown)
+        public static let AppMenuAddBookmarkTitleString = MZLocalizedString("Menu.AddBookmarkAction.Title", tableName: "Menu", value: "Bookmark This Page", comment: "Label for the button, displayed in the menu, used to create a bookmark for the current website.", lastEditedIn: .unknown)
+        public static let AppMenuTranslatePageTitleString = MZLocalizedString("Menu.TranslatePageAction.Title", tableName: "Menu", value: "Translate Page", comment: "Label for the button, displayed in the menu, used to translate the current page.", lastEditedIn: .unknown)
+        public static let AppMenuScanQRCodeTitleString = MZLocalizedString("Menu.ScanQRCodeAction.Title", tableName: "Menu", value: "Scan QR Code", comment: "Label for the button, displayed in the menu, used to open the QR code scanner.", lastEditedIn: .unknown)
+        public static let AppMenuLibrarySeeAllTitleString = MZLocalizedString("Menu.SeeAllAction.Title", tableName: "Menu", value: "See All", comment: "Label for the button, displayed in Firefox Home, used to see all Library panels.", lastEditedIn: .unknown)
+        public static let TabTrayDeleteMenuButtonAccessibilityLabel = MZLocalizedString("Toolbar.Menu.CloseAllTabs", value: "Close All Tabs", comment: "Accessibility label for the Close All Tabs menu button.", lastEditedIn: .unknown)
+        public static let AppMenuNightMode = MZLocalizedString("Menu.NightModeTurnOn.Label", value: "Enable Night Mode", comment: "Label for the button, displayed in the menu, turns on night mode.", lastEditedIn: .unknown)
+        public static let AppMenuManageAccount = MZLocalizedString("Menu.ManageAccount.Label", value: "Manage Account %@", comment: "Label for the button, displayed in the menu, takes you to screen to manage account when pressed. First argument is the display name for the current account", lastEditedIn: .unknown)
+        public static let AppMenuAddPinToTopSitesConfirmMessage = MZLocalizedString("Menu.AddPin.Confirm", value: "Pinned To Top Sites", comment: "Toast displayed to the user after adding the item to the Top Sites.", lastEditedIn: .unknown)
+        public static let AppMenuRemovePinFromTopSitesConfirmMessage = MZLocalizedString("Menu.RemovePin.Confirm", value: "Removed From Top Sites", comment: "Toast displayed to the user after removing the item from the Top Sites.", lastEditedIn: .unknown)
+        public static let PageActionMenuTitle = MZLocalizedString("Menu.PageActions.Title", value: "Page Actions", comment: "Label for title in page action menu.", lastEditedIn: .unknown)
+        public static let AppMenuShowPageSourceString = MZLocalizedString("Menu.PageSourceAction.Title", tableName: "Menu", value: "View Page Source", comment: "Label for the button, displayed in the menu, used to show the html page source", lastEditedIn: .unknown)
+
+
+        public static let BookmarksTitle = MZLocalizedString("Bookmarks.Title.Label", value: "Title", comment: "The label for the title of a bookmark", lastEditedIn: .unknown)
+        public static let BookmarksURL = MZLocalizedString("Bookmarks.URL.Label", value: "URL", comment: "The label for the URL of a bookmark", lastEditedIn: .unknown)
+        public static let BookmarksFolder = MZLocalizedString("Bookmarks.Folder.Label", value: "Folder", comment: "The label to show the location of the folder where the bookmark is located", lastEditedIn: .unknown)
+        public static let BookmarksFolderName = MZLocalizedString("Bookmarks.FolderName.Label", value: "Folder Name", comment: "The label for the title of the new folder", lastEditedIn: .unknown)
+        public static let BookmarksFolderLocation = MZLocalizedString("Bookmarks.FolderLocation.Label", value: "Location", comment: "The label for the location of the new folder", lastEditedIn: .unknown)
+        public static let BookmarksPanelEmptyStateTitle = MZLocalizedString("BookmarksPanel.EmptyState.Title", value: "Bookmarks you save will show up here.", comment: "Status label for the empty Bookmarks state.", lastEditedIn: .unknown)
+        public static let BookmarkDetailFieldsHeaderBookmarkTitle = MZLocalizedString("Bookmark.BookmarkDetail.FieldsHeader.Bookmark.Title", value: "Bookmark", comment: "The header title for the fields when editing a Bookmark", lastEditedIn: .unknown)
+        public static let BookmarkDetailFieldsHeaderFolderTitle = MZLocalizedString("Bookmark.BookmarkDetail.FieldsHeader.Folder.Title", value: "Folder", comment: "The header title for the fields when editing a Folder", lastEditedIn: .unknown)
+
+
+        public static let SettingsClearPrivateDataSectionName = MZLocalizedString("Settings.ClearPrivateData.SectionName", value: "Clear Private Data", comment: "Label used as an item in Settings. When touched it will open a dialog prompting the user to make sure they want to clear all of their private data.", lastEditedIn: .unknown)
+        public static let SettingsEditWebsiteSearchButton = MZLocalizedString("Settings.WebsiteData.ButtonEdit", value: "Edit", comment: "Button to edit website search results", lastEditedIn: .unknown)
+        public static let SettingsDeleteWebsiteSearchButton = MZLocalizedString("Settings.WebsiteData.ButtonDelete", value: "Delete", comment: "Button to delete website in search results", lastEditedIn: .unknown)
+        public static let SettingsDoneWebsiteSearchButton = MZLocalizedString("Settings.WebsiteData.ButtonDone", value: "Done", comment: "Button to exit edit website search results", lastEditedIn: .unknown)
+
+
+        public static let SyncingMessageWithoutEllipsis = MZLocalizedString("Sync.Syncing.Label", value: "Syncing", comment: "Message displayed when the user's account is syncing with no ellipsis", lastEditedIn: .unknown)
+        public static let FirstTimeSyncLongTime = MZLocalizedString("Sync.FirstTimeMessage.Label", value: "Your first sync may take a while", comment: "Message displayed when the user syncs for the first time", lastEditedIn: .unknown)
+        public static let FirefoxSyncNotStartedTitle = MZLocalizedString("SyncState.NotStarted.Title", value: "Sync is unavailable", comment: "Title for Sync status message when Sync failed to start.", lastEditedIn: .unknown)
+        public static let FirefoxSyncPartialTitle = MZLocalizedString("SyncState.Partial.Title", value: "Sync is experiencing issues syncing %@", comment: "Title for Sync status message when a component of Sync failed to complete, where %@ represents the name of the component, i.e. Sync is experiencing issues syncing Bookmarks", lastEditedIn: .unknown)
+        public static let FirefoxSyncFailedTitle = MZLocalizedString("SyncState.Failed.Title", value: "Syncing has failed", comment: "Title for Sync status message when synchronization failed to complete", lastEditedIn: .unknown)
+        public static let FirefoxSyncCreateAccount = MZLocalizedString("Sync.NoAccount.Description", value: "No account? Create one to sync Firefox between devices.", comment: "String displayed on Sign In to Sync page that allows the user to create a new account.", lastEditedIn: .unknown)
+
+        public static func localizedStringForSyncComponent(_ componentName: String) -> String? {
+            switch componentName {
+            case "bookmarks":
+                return MZLocalizedString("SyncState.Bookmark.Title", value: "Bookmarks", comment: "The Bookmark sync component, used in SyncState.Partial.Title", lastEditedIn: .unknown)
+            case "clients":
+                return MZLocalizedString("SyncState.Clients.Title", value: "Remote Clients", comment: "The Remote Clients sync component, used in SyncState.Partial.Title", lastEditedIn: .unknown)
+            case "tabs":
+                return MZLocalizedString("SyncState.Tabs.Title", value: "Tabs", comment: "The Tabs sync component, used in SyncState.Partial.Title", lastEditedIn: .unknown)
+            case "logins":
+                return MZLocalizedString("SyncState.Logins.Title", value: "Logins", comment: "The Logins sync component, used in SyncState.Partial.Title", lastEditedIn: .unknown)
+            case "history":
+                return MZLocalizedString("SyncState.History.Title", value: "History", comment: "The History sync component, used in SyncState.Partial.Title", lastEditedIn: .unknown)
+            default: return nil
+            }
+        }
+
+
+        public static let SentTabBookmarkActionTitle = MZLocalizedString("SentTab.BookmarkAction.title", value: "Bookmark", comment: "Label for an action used to bookmark one or more tabs from a notification.", lastEditedIn: .unknown)
+        public static let SentTabAddToReadingListActionTitle = MZLocalizedString("SentTab.AddToReadingListAction.Title", value: "Add to Reading List", comment: "Label for an action used to add one or more tabs recieved from a notification to the reading list.", lastEditedIn: .unknown)
+
+
+        public static let SendToSignInButton = MZLocalizedString("SendTo.SignIn.Button", value: "Sign In to Firefox", comment: "The text for the button on the Send to Device page if you are not signed in to Firefox Accounts.", lastEditedIn: .unknown)
+        public static let ShareOpenInPrivateModeNow = MZLocalizedString("ShareExtension.OpenInPrivateModeAction.Title", value: "Open in Private Mode", comment: "Action label on share extension to immediately open page in Firefox in private mode.", lastEditedIn: .unknown)
+
+
+        public static let AuthenticationWrongPasscodeError = MZLocalizedString("Incorrect passcode. Try again.", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode when trying to enter a protected section of the app", lastEditedIn: .unknown)
+        public static let AuthenticationMaximumAttemptsReached = MZLocalizedString("Maximum attempts reached. Please try again in an hour.", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode and has reached the maximum number of attempts.", lastEditedIn: .unknown)
+
+
+        public static let SearchSearchEngineSuggestionAccessibilityLabel = MZLocalizedString("Search suggestions from %@", tableName: "Search", comment: "Accessibility label for image of default search engine displayed left to the actual search suggestions from the engine. The parameter substituted for \"%@\" is the name of the search engine. E.g.: Search suggestions from Google", lastEditedIn: .unknown)
+        public static let SearchSearchSuggestionTapAccessibilityHint = MZLocalizedString("Searches for the suggestion", comment: "Accessibility hint describing the action performed when a search suggestion is clicked", lastEditedIn: .unknown)
+
+
+        public static let TPBlockingDescription = MZLocalizedString("Menu.TrackingProtectionBlocking.Description", value: "Firefox is blocking parts of the page that may track your browsing.", comment: "Description of the Tracking protection menu when TP is blocking parts of the page", lastEditedIn: .unknown)
+        public static let TPBlockingDisabledDescription = MZLocalizedString("Menu.TrackingProtectionBlockingDisabled.Description", value: "Block online trackers", comment: "The description of the Tracking Protection menu item when tracking is enabled", lastEditedIn: .unknown)
+        public static let TPBlockingSiteEnabled = MZLocalizedString("Menu.TrackingProtectionEnable1.Title", value: "Enabled for this site", comment: "A button to enable tracking protection inside the menu.", lastEditedIn: .unknown)
+        public static let TPEnabledConfirmed = MZLocalizedString("Menu.TrackingProtectionEnabled.Title", value: "Tracking Protection is now on for this site.", comment: "The confirmation toast once tracking protection has been enabled", lastEditedIn: .unknown)
+        public static let TPDisabledConfirmed = MZLocalizedString("Menu.TrackingProtectionDisabled.Title", value: "Tracking Protection is now off for this site.", comment: "The confirmation toast once tracking protection has been disabled", lastEditedIn: .unknown)
+        public static let TPBlockingSiteDisabled = MZLocalizedString("Menu.TrackingProtectionDisable1.Title", value: "Disabled for this site", comment: "The button that disabled TP for a site.", lastEditedIn: .unknown)
+        public static let TPCrossSiteCookiesBlocked = MZLocalizedString("Menu.TrackingProtectionCrossSiteCookies.Title", value: "Cross-Site Tracking Cookies", comment: "The title that shows the number of cross-site cookies blocked", lastEditedIn: .unknown)
+        public static let TPListTitle_CrossSiteCookies = MZLocalizedString("Menu.TrackingProtectionListTitle.CrossSiteCookies", value: "Blocked Cross-Site Tracking Cookies", comment: "Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners`", lastEditedIn: .unknown)
+        public static let TPListTitle_Social = MZLocalizedString("Menu.TrackingProtectionListTitle.Social", value: "Blocked Social Trackers", comment: "Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners`", lastEditedIn: .unknown)
+        public static let TPListTitle_Fingerprinters = MZLocalizedString("Menu.TrackingProtectionListTitle.Fingerprinters", value: "Blocked Fingerprinters", comment: "Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners`", lastEditedIn: .unknown)
+        public static let TPListTitle_Cryptominer = MZLocalizedString("Menu.TrackingProtectionListTitle.Cryptominers", value: "Blocked Cryptominers", comment: "Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners`", lastEditedIn: .unknown)
+        public static let TPSafeListOn = MZLocalizedString("Menu.TrackingProtectionOption.WhiteListOnDescription", value: "The site includes elements that may track your browsing. You have disabled protection.", comment: "label for the menu item to show when the website is whitelisted from blocking trackers.", lastEditedIn: .unknown)
+        public static let TPAccessoryInfoTitleStrict = MZLocalizedString("Settings.TrackingProtection.Info.StrictTitle", value: "Offers stronger protection, but may cause some sites to break.", comment: "Explanation of strict mode.", lastEditedIn: .unknown)
+        public static let TPAccessoryInfoTitleBasic = MZLocalizedString("Settings.TrackingProtection.Info.BasicTitle", value: "Balanced for protection and performance.", comment: "Explanation of basic mode.", lastEditedIn: .unknown)
+        public static let TPMoreInfo = MZLocalizedString("Settings.TrackingProtection.MoreInfo", value: "More Info…", comment: "'More Info' link on the Tracking Protection settings screen.", lastEditedIn: .unknown)
+    }
 }

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -10,207 +10,214 @@ public struct Strings {
 
 class BundleClass {}
 
-func MZLocalizedString(_ key: String, tableName: String? = nil, value: String = "", comment: String) -> String {
+enum StringsAppVersionTag {
+    case v350
+    case v360
+
+    case unknown
+}
+
+func MZLocalizedString(_ key: String, tableName: String? = nil, value: String = "", comment: String, lastEditedIn: StringsAppVersionTag) -> String {
     return NSLocalizedString(key, tableName: tableName, bundle: Strings.bundle, value: value, comment: comment)
 }
 
 // MARK: - General
 extension Strings {
-    public static let OKString = MZLocalizedString("OK", comment: "OK button")
-    public static let CancelString = MZLocalizedString("Cancel", comment: "Label for Cancel button")
-    public static let NotNowString = MZLocalizedString("Toasts.NotNow", value: "Not Now", comment: "label for Not Now button")
-    public static let AppStoreString = MZLocalizedString("Toasts.OpenAppStore", value: "Open App Store", comment: "Open App Store button")
-    public static let UndoString = MZLocalizedString("Toasts.Undo", value: "Undo", comment: "Label for button to undo the action just performed")
-    public static let OpenSettingsString = MZLocalizedString("Open Settings", comment: "See http://mzl.la/1G7uHo7")
+    public static let OKString = MZLocalizedString("OK", comment: "OK button", lastEditedIn: .unknown)
+    public static let CancelString = MZLocalizedString("Cancel", comment: "Label for Cancel button", lastEditedIn: .unknown)
+    public static let NotNowString = MZLocalizedString("Toasts.NotNow", value: "Not Now", comment: "label for Not Now button", lastEditedIn: .unknown)
+    public static let AppStoreString = MZLocalizedString("Toasts.OpenAppStore", value: "Open App Store", comment: "Open App Store button", lastEditedIn: .unknown)
+    public static let UndoString = MZLocalizedString("Toasts.Undo", value: "Undo", comment: "Label for button to undo the action just performed", lastEditedIn: .unknown)
+    public static let OpenSettingsString = MZLocalizedString("Open Settings", comment: "See http://mzl.la/1G7uHo7", lastEditedIn: .unknown)
 }
 
 // MARK: - Table date section titles
 extension Strings {
-    public static let TableDateSectionTitleToday = MZLocalizedString("Today", comment: "History tableview section header")
-    public static let TableDateSectionTitleYesterday = MZLocalizedString("Yesterday", comment: "History tableview section header")
-    public static let TableDateSectionTitleLastWeek = MZLocalizedString("Last week", comment: "History tableview section header")
-    public static let TableDateSectionTitleLastMonth = MZLocalizedString("Last month", comment: "History tableview section header")
+    public static let TableDateSectionTitleToday = MZLocalizedString("Today", comment: "History tableview section header", lastEditedIn: .unknown)
+    public static let TableDateSectionTitleYesterday = MZLocalizedString("Yesterday", comment: "History tableview section header", lastEditedIn: .unknown)
+    public static let TableDateSectionTitleLastWeek = MZLocalizedString("Last week", comment: "History tableview section header", lastEditedIn: .unknown)
+    public static let TableDateSectionTitleLastMonth = MZLocalizedString("Last month", comment: "History tableview section header", lastEditedIn: .unknown)
 }
 
 // MARK: - Top Sites
 extension Strings {
-    public static let TopSitesEmptyStateDescription = MZLocalizedString("TopSites.EmptyState.Description", value: "Your most visited sites will show up here.", comment: "Description label for the empty Top Sites state.")
-    public static let TopSitesEmptyStateTitle = MZLocalizedString("TopSites.EmptyState.Title", value: "Welcome to Top Sites", comment: "The title for the empty Top Sites state")
-    public static let TopSitesRemoveButtonAccessibilityLabel = MZLocalizedString("TopSites.RemovePage.Button", value: "Remove page — %@", comment: "Button shown in editing mode to remove this site from the top sites panel.")
+    public static let TopSitesEmptyStateDescription = MZLocalizedString("TopSites.EmptyState.Description", value: "Your most visited sites will show up here.", comment: "Description label for the empty Top Sites state.", lastEditedIn: .unknown)
+    public static let TopSitesEmptyStateTitle = MZLocalizedString("TopSites.EmptyState.Title", value: "Welcome to Top Sites", comment: "The title for the empty Top Sites state", lastEditedIn: .unknown)
+    public static let TopSitesRemoveButtonAccessibilityLabel = MZLocalizedString("TopSites.RemovePage.Button", value: "Remove page — %@", comment: "Button shown in editing mode to remove this site from the top sites panel.", lastEditedIn: .unknown)
 }
 
 // MARK: - Activity Stream
 extension Strings {
-    public static let ASPocketTitle = MZLocalizedString("ActivityStream.Pocket.SectionTitle", value: "Trending on Pocket", comment: "Section title label for Recommended by Pocket section")
-    public static let ASPocketTitle2 = MZLocalizedString("ActivityStream.Pocket.SectionTitle2", value: "Recommended by Pocket", comment: "Section title label for Recommended by Pocket section")
-    public static let ASTopSitesTitle =  MZLocalizedString("ActivityStream.TopSites.SectionTitle", value: "Top Sites", comment: "Section title label for Top Sites")
-    public static let ASShortcutsTitle =  MZLocalizedString("ActivityStream.Shortcuts.SectionTitle", value: "Shortcuts", comment: "Section title label for Shortcuts")
-    public static let HighlightVistedText = MZLocalizedString("ActivityStream.Highlights.Visited", value: "Visited", comment: "The description of a highlight if it is a site the user has visited")
-    public static let HighlightBookmarkText = MZLocalizedString("ActivityStream.Highlights.Bookmark", value: "Bookmarked", comment: "The description of a highlight if it is a site the user has bookmarked")
-    public static let PocketTrendingText = MZLocalizedString("ActivityStream.Pocket.Trending", value: "Trending", comment: "The description of a Pocket Story")
-    public static let PocketMoreStoriesText = MZLocalizedString("ActivityStream.Pocket.MoreLink", value: "More", comment: "The link that shows more Pocket trending stories")
-    public static let TopSitesRowSettingFooter = MZLocalizedString("ActivityStream.TopSites.RowSettingFooter", value: "Set Rows", comment: "The title for the setting page which lets you select the number of top site rows")
-    public static let TopSitesRowCount = MZLocalizedString("ActivityStream.TopSites.RowCount", value: "Rows: %d", comment: "label showing how many rows of topsites are shown. %d represents a number")
-    public static let RecentlyBookmarkedTitle = MZLocalizedString("ActivityStream.NewRecentBookmarks.Title", value: "Recent Bookmarks", comment: "Section title label for recently bookmarked websites")
-    public static let RecentlyVisitedTitle = MZLocalizedString("ActivityStream.RecentHistory.Title", value: "Recently Visited", comment: "Section title label for recently visited websites")
-    public static let RecentlySavedSectionTitle = MZLocalizedString("ActivityStream.Library.Title", value: "Recently Saved", comment: "A string used to signify the start of the Recently Saved section in Home Screen.")
-    public static let RecentlySavedShowAllText = MZLocalizedString("RecentlySaved.Actions.More", value: "Show All", comment: "More button text for Recently Saved items at the home page.")
+    public static let ASPocketTitle = MZLocalizedString("ActivityStream.Pocket.SectionTitle", value: "Trending on Pocket", comment: "Section title label for Recommended by Pocket section", lastEditedIn: .unknown)
+    public static let ASPocketTitle2 = MZLocalizedString("ActivityStream.Pocket.SectionTitle2", value: "Recommended by Pocket", comment: "Section title label for Recommended by Pocket section", lastEditedIn: .unknown)
+    public static let ASTopSitesTitle =  MZLocalizedString("ActivityStream.TopSites.SectionTitle", value: "Top Sites", comment: "Section title label for Top Sites", lastEditedIn: .unknown)
+    public static let ASShortcutsTitle =  MZLocalizedString("ActivityStream.Shortcuts.SectionTitle", value: "Shortcuts", comment: "Section title label for Shortcuts", lastEditedIn: .unknown)
+    public static let HighlightVistedText = MZLocalizedString("ActivityStream.Highlights.Visited", value: "Visited", comment: "The description of a highlight if it is a site the user has visited", lastEditedIn: .unknown)
+    public static let HighlightBookmarkText = MZLocalizedString("ActivityStream.Highlights.Bookmark", value: "Bookmarked", comment: "The description of a highlight if it is a site the user has bookmarked", lastEditedIn: .unknown)
+    public static let PocketTrendingText = MZLocalizedString("ActivityStream.Pocket.Trending", value: "Trending", comment: "The description of a Pocket Story", lastEditedIn: .unknown)
+    public static let PocketMoreStoriesText = MZLocalizedString("ActivityStream.Pocket.MoreLink", value: "More", comment: "The link that shows more Pocket trending stories", lastEditedIn: .unknown)
+    public static let TopSitesRowSettingFooter = MZLocalizedString("ActivityStream.TopSites.RowSettingFooter", value: "Set Rows", comment: "The title for the setting page which lets you select the number of top site rows", lastEditedIn: .unknown)
+    public static let TopSitesRowCount = MZLocalizedString("ActivityStream.TopSites.RowCount", value: "Rows: %d", comment: "label showing how many rows of topsites are shown. %d represents a number", lastEditedIn: .unknown)
+    public static let RecentlyBookmarkedTitle = MZLocalizedString("ActivityStream.NewRecentBookmarks.Title", value: "Recent Bookmarks", comment: "Section title label for recently bookmarked websites", lastEditedIn: .unknown)
+    public static let RecentlyVisitedTitle = MZLocalizedString("ActivityStream.RecentHistory.Title", value: "Recently Visited", comment: "Section title label for recently visited websites", lastEditedIn: .unknown)
+    public static let RecentlySavedSectionTitle = MZLocalizedString("ActivityStream.Library.Title", value: "Recently Saved", comment: "A string used to signify the start of the Recently Saved section in Home Screen.", lastEditedIn: .unknown)
+    public static let RecentlySavedShowAllText = MZLocalizedString("RecentlySaved.Actions.More", value: "Show All", comment: "More button text for Recently Saved items at the home page.", lastEditedIn: .unknown)
 }
 
 // MARK: - Home Panel Context Menu
 extension Strings {
-    public static let OpenInNewTabContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.OpenInNewTab", value: "Open in New Tab", comment: "The title for the Open in New Tab context menu action for sites in Home Panels")
-    public static let OpenInNewPrivateTabContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.OpenInNewPrivateTab", value: "Open in New Private Tab", comment: "The title for the Open in New Private Tab context menu action for sites in Home Panels")
-    public static let BookmarkContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.Bookmark", value: "Bookmark", comment: "The title for the Bookmark context menu action for sites in Home Panels")
-    public static let RemoveBookmarkContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.RemoveBookmark", value: "Remove Bookmark", comment: "The title for the Remove Bookmark context menu action for sites in Home Panels")
-    public static let DeleteFromHistoryContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.DeleteFromHistory", value: "Delete from History", comment: "The title for the Delete from History context menu action for sites in Home Panels")
-    public static let ShareContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.Share", value: "Share", comment: "The title for the Share context menu action for sites in Home Panels")
-    public static let RemoveContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.Remove", value: "Remove", comment: "The title for the Remove context menu action for sites in Home Panels")
-    public static let PinTopsiteActionTitle = MZLocalizedString("ActivityStream.ContextMenu.PinTopsite", value: "Pin to Top Sites", comment: "The title for the pinning a topsite action")
-    public static let PinTopsiteActionTitle2 = MZLocalizedString("ActivityStream.ContextMenu.PinTopsite2", value: "Pin", comment: "The title for the pinning a topsite action")
-    public static let UnpinTopsiteActionTitle2 = MZLocalizedString("ActivityStream.ContextMenu.UnpinTopsite", value: "Unpin", comment: "The title for the unpinning a topsite action")
-    public static let AddToShortcutsActionTitle = MZLocalizedString("ActivityStream.ContextMenu.AddToShortcuts", value: "Add to Shortcuts", comment: "The title for the pinning a shortcut action")
-    public static let RemoveFromShortcutsActionTitle = MZLocalizedString("ActivityStream.ContextMenu.RemoveFromShortcuts", value: "Remove from Shortcuts", comment: "The title for removing a shortcut action")
-    public static let RemovePinTopsiteActionTitle = MZLocalizedString("ActivityStream.ContextMenu.RemovePinTopsite", value: "Remove Pinned Site", comment: "The title for removing a pinned topsite action")
+    public static let OpenInNewTabContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.OpenInNewTab", value: "Open in New Tab", comment: "The title for the Open in New Tab context menu action for sites in Home Panels", lastEditedIn: .unknown)
+    public static let OpenInNewPrivateTabContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.OpenInNewPrivateTab", value: "Open in New Private Tab", comment: "The title for the Open in New Private Tab context menu action for sites in Home Panels", lastEditedIn: .unknown)
+    public static let BookmarkContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.Bookmark", value: "Bookmark", comment: "The title for the Bookmark context menu action for sites in Home Panels", lastEditedIn: .unknown)
+    public static let RemoveBookmarkContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.RemoveBookmark", value: "Remove Bookmark", comment: "The title for the Remove Bookmark context menu action for sites in Home Panels", lastEditedIn: .unknown)
+    public static let DeleteFromHistoryContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.DeleteFromHistory", value: "Delete from History", comment: "The title for the Delete from History context menu action for sites in Home Panels", lastEditedIn: .unknown)
+    public static let ShareContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.Share", value: "Share", comment: "The title for the Share context menu action for sites in Home Panels", lastEditedIn: .unknown)
+    public static let RemoveContextMenuTitle = MZLocalizedString("HomePanel.ContextMenu.Remove", value: "Remove", comment: "The title for the Remove context menu action for sites in Home Panels", lastEditedIn: .unknown)
+    public static let PinTopsiteActionTitle = MZLocalizedString("ActivityStream.ContextMenu.PinTopsite", value: "Pin to Top Sites", comment: "The title for the pinning a topsite action", lastEditedIn: .unknown)
+    public static let PinTopsiteActionTitle2 = MZLocalizedString("ActivityStream.ContextMenu.PinTopsite2", value: "Pin", comment: "The title for the pinning a topsite action", lastEditedIn: .unknown)
+    public static let UnpinTopsiteActionTitle2 = MZLocalizedString("ActivityStream.ContextMenu.UnpinTopsite", value: "Unpin", comment: "The title for the unpinning a topsite action", lastEditedIn: .unknown)
+    public static let AddToShortcutsActionTitle = MZLocalizedString("ActivityStream.ContextMenu.AddToShortcuts", value: "Add to Shortcuts", comment: "The title for the pinning a shortcut action", lastEditedIn: .unknown)
+    public static let RemoveFromShortcutsActionTitle = MZLocalizedString("ActivityStream.ContextMenu.RemoveFromShortcuts", value: "Remove from Shortcuts", comment: "The title for removing a shortcut action", lastEditedIn: .unknown)
+    public static let RemovePinTopsiteActionTitle = MZLocalizedString("ActivityStream.ContextMenu.RemovePinTopsite", value: "Remove Pinned Site", comment: "The title for removing a pinned topsite action", lastEditedIn: .unknown)
 }
 
 //  MARK: - PhotonActionSheet String
 extension Strings {
-    public static let CloseButtonTitle = MZLocalizedString("PhotonMenu.close", value: "Close", comment: "Button for closing the menu action sheet")
+    public static let CloseButtonTitle = MZLocalizedString("PhotonMenu.close", value: "Close", comment: "Button for closing the menu action sheet", lastEditedIn: .unknown)
 }
 
 // MARK: - Home page
 extension Strings {
-    public static let SettingsHomePageSectionName = MZLocalizedString("Settings.HomePage.SectionName", value: "Homepage", comment: "Label used as an item in Settings. When touched it will open a dialog to configure the home page and its uses.")
-    public static let SettingsHomePageTitle = MZLocalizedString("Settings.HomePage.Title", value: "Homepage Settings", comment: "Title displayed in header of the setting panel.")
-    public static let SettingsHomePageURLSectionTitle = MZLocalizedString("Settings.HomePage.URL.Title", value: "Current Homepage", comment: "Title of the setting section containing the URL of the current home page.")
-    public static let SettingsHomePageUseCurrentPage = MZLocalizedString("Settings.HomePage.UseCurrent.Button", value: "Use Current Page", comment: "Button in settings to use the current page as home page.")
-    public static let SettingsHomePagePlaceholder = MZLocalizedString("Settings.HomePage.URL.Placeholder", value: "Enter a webpage", comment: "Placeholder text in the homepage setting when no homepage has been set.")
-    public static let SettingsHomePageUseCopiedLink = MZLocalizedString("Settings.HomePage.UseCopiedLink.Button", value: "Use Copied Link", comment: "Button in settings to use the current link on the clipboard as home page.")
-    public static let SettingsHomePageUseDefault = MZLocalizedString("Settings.HomePage.UseDefault.Button", value: "Use Default", comment: "Button in settings to use the default home page. If no default is set, then this button isn't shown.")
-    public static let SettingsHomePageClear = MZLocalizedString("Settings.HomePage.Clear.Button", value: "Clear", comment: "Button in settings to clear the home page.")
-    public static let SetHomePageDialogTitle = MZLocalizedString("HomePage.Set.Dialog.Title", value: "Do you want to use this web page as your home page?", comment: "Alert dialog title when the user opens the home page for the first time.")
-    public static let SetHomePageDialogMessage = MZLocalizedString("HomePage.Set.Dialog.Message", value: "You can change this at any time in Settings", comment: "Alert dialog body when the user opens the home page for the first time.")
-    public static let SetHomePageDialogYes = MZLocalizedString("HomePage.Set.Dialog.OK", value: "Set Homepage", comment: "Button accepting changes setting the home page for the first time.")
-    public static let SetHomePageDialogNo = MZLocalizedString("HomePage.Set.Dialog.Cancel", value: "Cancel", comment: "Button cancelling changes setting the home page for the first time.")
-    public static let ReopenLastTabAlertTitle = MZLocalizedString("ReopenAlert.Title", value: "Reopen Last Closed Tab", comment: "Reopen alert title shown at home page.")
-    public static let ReopenLastTabButtonText = MZLocalizedString("ReopenAlert.Actions.Reopen", value: "Reopen", comment: "Reopen button text shown in reopen-alert at home page.")
-    public static let ReopenLastTabCancelText = MZLocalizedString("ReopenAlert.Actions.Cancel", value: "Cancel", comment: "Cancel button text shown in reopen-alert at home page.")
+    public static let SettingsHomePageSectionName = MZLocalizedString("Settings.HomePage.SectionName", value: "Homepage", comment: "Label used as an item in Settings. When touched it will open a dialog to configure the home page and its uses.", lastEditedIn: .unknown)
+    public static let SettingsHomePageTitle = MZLocalizedString("Settings.HomePage.Title", value: "Homepage Settings", comment: "Title displayed in header of the setting panel.", lastEditedIn: .unknown)
+    public static let SettingsHomePageURLSectionTitle = MZLocalizedString("Settings.HomePage.URL.Title", value: "Current Homepage", comment: "Title of the setting section containing the URL of the current home page.", lastEditedIn: .unknown)
+    public static let SettingsHomePageUseCurrentPage = MZLocalizedString("Settings.HomePage.UseCurrent.Button", value: "Use Current Page", comment: "Button in settings to use the current page as home page.", lastEditedIn: .unknown)
+    public static let SettingsHomePagePlaceholder = MZLocalizedString("Settings.HomePage.URL.Placeholder", value: "Enter a webpage", comment: "Placeholder text in the homepage setting when no homepage has been set.", lastEditedIn: .unknown)
+    public static let SettingsHomePageUseCopiedLink = MZLocalizedString("Settings.HomePage.UseCopiedLink.Button", value: "Use Copied Link", comment: "Button in settings to use the current link on the clipboard as home page.", lastEditedIn: .unknown)
+    public static let SettingsHomePageUseDefault = MZLocalizedString("Settings.HomePage.UseDefault.Button", value: "Use Default", comment: "Button in settings to use the default home page. If no default is set, then this button isn't shown.", lastEditedIn: .unknown)
+    public static let SettingsHomePageClear = MZLocalizedString("Settings.HomePage.Clear.Button", value: "Clear", comment: "Button in settings to clear the home page.", lastEditedIn: .unknown)
+    public static let SetHomePageDialogTitle = MZLocalizedString("HomePage.Set.Dialog.Title", value: "Do you want to use this web page as your home page?", comment: "Alert dialog title when the user opens the home page for the first time.", lastEditedIn: .unknown)
+    public static let SetHomePageDialogMessage = MZLocalizedString("HomePage.Set.Dialog.Message", value: "You can change this at any time in Settings", comment: "Alert dialog body when the user opens the home page for the first time.", lastEditedIn: .unknown)
+    public static let SetHomePageDialogYes = MZLocalizedString("HomePage.Set.Dialog.OK", value: "Set Homepage", comment: "Button accepting changes setting the home page for the first time.", lastEditedIn: .unknown)
+    public static let SetHomePageDialogNo = MZLocalizedString("HomePage.Set.Dialog.Cancel", value: "Cancel", comment: "Button cancelling changes setting the home page for the first time.", lastEditedIn: .unknown)
+    public static let ReopenLastTabAlertTitle = MZLocalizedString("ReopenAlert.Title", value: "Reopen Last Closed Tab", comment: "Reopen alert title shown at home page.", lastEditedIn: .unknown)
+    public static let ReopenLastTabButtonText = MZLocalizedString("ReopenAlert.Actions.Reopen", value: "Reopen", comment: "Reopen button text shown in reopen-alert at home page.", lastEditedIn: .unknown)
+    public static let ReopenLastTabCancelText = MZLocalizedString("ReopenAlert.Actions.Cancel", value: "Cancel", comment: "Cancel button text shown in reopen-alert at home page.", lastEditedIn: .unknown)
 }
 
 // MARK: - Settings
 extension Strings {
-    public static let SettingsGeneralSectionTitle = MZLocalizedString("Settings.General.SectionName", value: "General", comment: "General settings section title")
-    public static let SettingsClearPrivateDataClearButton = MZLocalizedString("Settings.ClearPrivateData.Clear.Button", value: "Clear Private Data", comment: "Button in settings that clears private data for the selected items.")
-    public static let SettingsClearAllWebsiteDataButton = MZLocalizedString("Settings.ClearAllWebsiteData.Clear.Button", value: "Clear All Website Data", comment: "Button in Data Management that clears all items.")
-    public static let SettingsClearSelectedWebsiteDataButton = MZLocalizedString("Settings.ClearSelectedWebsiteData.ClearSelected.Button", value: "Clear Items: %1$@", comment: "Button in Data Management that clears private data for the selected items. Parameter is the number of items to be cleared")
-    public static let SettingsClearPrivateDataSectionName = MZLocalizedString("Settings.ClearPrivateData.SectionName", value: "Clear Private Data", comment: "Label used as an item in Settings. When touched it will open a dialog prompting the user to make sure they want to clear all of their private data.")
-    public static let SettingsDataManagementSectionName = MZLocalizedString("Settings.DataManagement.SectionName", value: "Data Management", comment: "Label used as an item in Settings. When touched it will open a dialog prompting the user to make sure they want to clear all of their private data.")
-    public static let SettingsFilterSitesSearchLabel = MZLocalizedString("Settings.DataManagement.SearchLabel", value: "Filter Sites", comment: "Default text in search bar for Data Management")
-    public static let SettingsClearPrivateDataTitle = MZLocalizedString("Settings.ClearPrivateData.Title", value: "Clear Private Data", comment: "Title displayed in header of the setting panel.")
-    public static let SettingsDataManagementTitle = MZLocalizedString("Settings.DataManagement.Title", value: "Data Management", comment: "Title displayed in header of the setting panel.")
-    public static let SettingsWebsiteDataTitle = MZLocalizedString("Settings.WebsiteData.Title", value: "Website Data", comment: "Title displayed in header of the Data Management panel.")
-    public static let SettingsWebsiteDataShowMoreButton = MZLocalizedString("Settings.WebsiteData.ButtonShowMore", value: "Show More", comment: "Button shows all websites on website data tableview")
-    public static let SettingsEditWebsiteSearchButton = MZLocalizedString("Settings.WebsiteData.ButtonEdit", value: "Edit", comment: "Button to edit website search results")
-    public static let SettingsDeleteWebsiteSearchButton = MZLocalizedString("Settings.WebsiteData.ButtonDelete", value: "Delete", comment: "Button to delete website in search results")
-    public static let SettingsDoneWebsiteSearchButton = MZLocalizedString("Settings.WebsiteData.ButtonDone", value: "Done", comment: "Button to exit edit website search results")
-    public static let SettingsDisconnectSyncAlertTitle = MZLocalizedString("Settings.Disconnect.Title", value: "Disconnect Sync?", comment: "Title of the alert when prompting the user asking to disconnect.")
-    public static let SettingsDisconnectSyncAlertBody = MZLocalizedString("Settings.Disconnect.Body", value: "Firefox will stop syncing with your account, but won’t delete any of your browsing data on this device.", comment: "Body of the alert when prompting the user asking to disconnect.")
-    public static let SettingsDisconnectSyncButton = MZLocalizedString("Settings.Disconnect.Button", value: "Disconnect Sync", comment: "Button displayed at the bottom of settings page allowing users to Disconnect from FxA")
-    public static let SettingsDisconnectCancelAction = MZLocalizedString("Settings.Disconnect.CancelButton", value: "Cancel", comment: "Cancel action button in alert when user is prompted for disconnect")
-    public static let SettingsDisconnectDestructiveAction = MZLocalizedString("Settings.Disconnect.DestructiveButton", value: "Disconnect", comment: "Destructive action button in alert when user is prompted for disconnect")
-    public static let SettingsSearchDoneButton = MZLocalizedString("Settings.Search.Done.Button", value: "Done", comment: "Button displayed at the top of the search settings.")
-    public static let SettingsSearchEditButton = MZLocalizedString("Settings.Search.Edit.Button", value: "Edit", comment: "Button displayed at the top of the search settings.")
-    public static let UseTouchID = MZLocalizedString("Use Touch ID", tableName: "AuthenticationManager", comment: "List section title for when to use Touch ID")
-    public static let UseFaceID = MZLocalizedString("Use Face ID", tableName: "AuthenticationManager", comment: "List section title for when to use Face ID")
-    public static let SettingsCopyAppVersionAlertTitle = MZLocalizedString("Settings.CopyAppVersion.Title", value: "Copied to clipboard", comment: "Copy app version alert shown in settings.")
+    public static let SettingsGeneralSectionTitle = MZLocalizedString("Settings.General.SectionName", value: "General", comment: "General settings section title", lastEditedIn: .unknown)
+    public static let SettingsClearPrivateDataClearButton = MZLocalizedString("Settings.ClearPrivateData.Clear.Button", value: "Clear Private Data", comment: "Button in settings that clears private data for the selected items.", lastEditedIn: .unknown)
+    public static let SettingsClearAllWebsiteDataButton = MZLocalizedString("Settings.ClearAllWebsiteData.Clear.Button", value: "Clear All Website Data", comment: "Button in Data Management that clears all items.", lastEditedIn: .unknown)
+    public static let SettingsClearSelectedWebsiteDataButton = MZLocalizedString("Settings.ClearSelectedWebsiteData.ClearSelected.Button", value: "Clear Items: %1$@", comment: "Button in Data Management that clears private data for the selected items. Parameter is the number of items to be cleared", lastEditedIn: .unknown)
+    public static let SettingsClearPrivateDataSectionName = MZLocalizedString("Settings.ClearPrivateData.SectionName", value: "Clear Private Data", comment: "Label used as an item in Settings. When touched it will open a dialog prompting the user to make sure they want to clear all of their private data.", lastEditedIn: .unknown)
+    public static let SettingsDataManagementSectionName = MZLocalizedString("Settings.DataManagement.SectionName", value: "Data Management", comment: "Label used as an item in Settings. When touched it will open a dialog prompting the user to make sure they want to clear all of their private data.", lastEditedIn: .unknown)
+    public static let SettingsFilterSitesSearchLabel = MZLocalizedString("Settings.DataManagement.SearchLabel", value: "Filter Sites", comment: "Default text in search bar for Data Management", lastEditedIn: .unknown)
+    public static let SettingsClearPrivateDataTitle = MZLocalizedString("Settings.ClearPrivateData.Title", value: "Clear Private Data", comment: "Title displayed in header of the setting panel.", lastEditedIn: .unknown)
+    public static let SettingsDataManagementTitle = MZLocalizedString("Settings.DataManagement.Title", value: "Data Management", comment: "Title displayed in header of the setting panel.", lastEditedIn: .unknown)
+    public static let SettingsWebsiteDataTitle = MZLocalizedString("Settings.WebsiteData.Title", value: "Website Data", comment: "Title displayed in header of the Data Management panel.", lastEditedIn: .unknown)
+    public static let SettingsWebsiteDataShowMoreButton = MZLocalizedString("Settings.WebsiteData.ButtonShowMore", value: "Show More", comment: "Button shows all websites on website data tableview", lastEditedIn: .unknown)
+    public static let SettingsEditWebsiteSearchButton = MZLocalizedString("Settings.WebsiteData.ButtonEdit", value: "Edit", comment: "Button to edit website search results", lastEditedIn: .unknown)
+    public static let SettingsDeleteWebsiteSearchButton = MZLocalizedString("Settings.WebsiteData.ButtonDelete", value: "Delete", comment: "Button to delete website in search results", lastEditedIn: .unknown)
+    public static let SettingsDoneWebsiteSearchButton = MZLocalizedString("Settings.WebsiteData.ButtonDone", value: "Done", comment: "Button to exit edit website search results", lastEditedIn: .unknown)
+    public static let SettingsDisconnectSyncAlertTitle = MZLocalizedString("Settings.Disconnect.Title", value: "Disconnect Sync?", comment: "Title of the alert when prompting the user asking to disconnect.", lastEditedIn: .unknown)
+    public static let SettingsDisconnectSyncAlertBody = MZLocalizedString("Settings.Disconnect.Body", value: "Firefox will stop syncing with your account, but won’t delete any of your browsing data on this device.", comment: "Body of the alert when prompting the user asking to disconnect.", lastEditedIn: .unknown)
+    public static let SettingsDisconnectSyncButton = MZLocalizedString("Settings.Disconnect.Button", value: "Disconnect Sync", comment: "Button displayed at the bottom of settings page allowing users to Disconnect from FxA", lastEditedIn: .unknown)
+    public static let SettingsDisconnectCancelAction = MZLocalizedString("Settings.Disconnect.CancelButton", value: "Cancel", comment: "Cancel action button in alert when user is prompted for disconnect", lastEditedIn: .unknown)
+    public static let SettingsDisconnectDestructiveAction = MZLocalizedString("Settings.Disconnect.DestructiveButton", value: "Disconnect", comment: "Destructive action button in alert when user is prompted for disconnect", lastEditedIn: .unknown)
+    public static let SettingsSearchDoneButton = MZLocalizedString("Settings.Search.Done.Button", value: "Done", comment: "Button displayed at the top of the search settings.", lastEditedIn: .unknown)
+    public static let SettingsSearchEditButton = MZLocalizedString("Settings.Search.Edit.Button", value: "Edit", comment: "Button displayed at the top of the search settings.", lastEditedIn: .unknown)
+    public static let UseTouchID = MZLocalizedString("Use Touch ID", tableName: "AuthenticationManager", comment: "List section title for when to use Touch ID", lastEditedIn: .unknown)
+    public static let UseFaceID = MZLocalizedString("Use Face ID", tableName: "AuthenticationManager", comment: "List section title for when to use Face ID", lastEditedIn: .unknown)
+    public static let SettingsCopyAppVersionAlertTitle = MZLocalizedString("Settings.CopyAppVersion.Title", value: "Copied to clipboard", comment: "Copy app version alert shown in settings.", lastEditedIn: .unknown)
 }
 
 // MARK: - Error pages
 extension Strings {
-    public static let ErrorPagesAdvancedButton = MZLocalizedString("ErrorPages.Advanced.Button", value: "Advanced", comment: "Label for button to perform advanced actions on the error page")
-    public static let ErrorPagesAdvancedWarning1 = MZLocalizedString("ErrorPages.AdvancedWarning1.Text", value: "Warning: we can’t confirm your connection to this website is secure.", comment: "Warning text when clicking the Advanced button on error pages")
-    public static let ErrorPagesAdvancedWarning2 = MZLocalizedString("ErrorPages.AdvancedWarning2.Text", value: "It may be a misconfiguration or tampering by an attacker. Proceed if you accept the potential risk.", comment: "Additional warning text when clicking the Advanced button on error pages")
-    public static let ErrorPagesCertWarningDescription = MZLocalizedString("ErrorPages.CertWarning.Description", value: "The owner of %@ has configured their website improperly. To protect your information from being stolen, Firefox has not connected to this website.", comment: "Warning text on the certificate error page")
-    public static let ErrorPagesCertWarningTitle = MZLocalizedString("ErrorPages.CertWarning.Title", value: "This Connection is Untrusted", comment: "Title on the certificate error page")
-    public static let ErrorPagesGoBackButton = MZLocalizedString("ErrorPages.GoBack.Button", value: "Go Back", comment: "Label for button to go back from the error page")
-    public static let ErrorPagesVisitOnceButton = MZLocalizedString("ErrorPages.VisitOnce.Button", value: "Visit site anyway", comment: "Button label to temporarily continue to the site from the certificate error page")
+    public static let ErrorPagesAdvancedButton = MZLocalizedString("ErrorPages.Advanced.Button", value: "Advanced", comment: "Label for button to perform advanced actions on the error page", lastEditedIn: .unknown)
+    public static let ErrorPagesAdvancedWarning1 = MZLocalizedString("ErrorPages.AdvancedWarning1.Text", value: "Warning: we can’t confirm your connection to this website is secure.", comment: "Warning text when clicking the Advanced button on error pages", lastEditedIn: .unknown)
+    public static let ErrorPagesAdvancedWarning2 = MZLocalizedString("ErrorPages.AdvancedWarning2.Text", value: "It may be a misconfiguration or tampering by an attacker. Proceed if you accept the potential risk.", comment: "Additional warning text when clicking the Advanced button on error pages", lastEditedIn: .unknown)
+    public static let ErrorPagesCertWarningDescription = MZLocalizedString("ErrorPages.CertWarning.Description", value: "The owner of %@ has configured their website improperly. To protect your information from being stolen, Firefox has not connected to this website.", comment: "Warning text on the certificate error page", lastEditedIn: .unknown)
+    public static let ErrorPagesCertWarningTitle = MZLocalizedString("ErrorPages.CertWarning.Title", value: "This Connection is Untrusted", comment: "Title on the certificate error page", lastEditedIn: .unknown)
+    public static let ErrorPagesGoBackButton = MZLocalizedString("ErrorPages.GoBack.Button", value: "Go Back", comment: "Label for button to go back from the error page", lastEditedIn: .unknown)
+    public static let ErrorPagesVisitOnceButton = MZLocalizedString("ErrorPages.VisitOnce.Button", value: "Visit site anyway", comment: "Button label to temporarily continue to the site from the certificate error page", lastEditedIn: .unknown)
 }
 
 // MARK: - Logins Helper
 extension Strings {
-    public static let LoginsHelperSaveLoginButtonTitle = MZLocalizedString("LoginsHelper.SaveLogin.Button", value: "Save Login", comment: "Button to save the user's password")
-    public static let LoginsHelperDontSaveButtonTitle = MZLocalizedString("LoginsHelper.DontSave.Button", value: "Don’t Save", comment: "Button to not save the user's password")
-    public static let LoginsHelperUpdateButtonTitle = MZLocalizedString("LoginsHelper.Update.Button", value: "Update", comment: "Button to update the user's password")
-    public static let LoginsHelperDontUpdateButtonTitle = MZLocalizedString("LoginsHelper.DontUpdate.Button", value: "Don’t Update", comment: "Button to not update the user's password")
+    public static let LoginsHelperSaveLoginButtonTitle = MZLocalizedString("LoginsHelper.SaveLogin.Button", value: "Save Login", comment: "Button to save the user's password", lastEditedIn: .unknown)
+    public static let LoginsHelperDontSaveButtonTitle = MZLocalizedString("LoginsHelper.DontSave.Button", value: "Don’t Save", comment: "Button to not save the user's password", lastEditedIn: .unknown)
+    public static let LoginsHelperUpdateButtonTitle = MZLocalizedString("LoginsHelper.Update.Button", value: "Update", comment: "Button to update the user's password", lastEditedIn: .unknown)
+    public static let LoginsHelperDontUpdateButtonTitle = MZLocalizedString("LoginsHelper.DontUpdate.Button", value: "Don’t Update", comment: "Button to not update the user's password", lastEditedIn: .unknown)
 }
 
 // MARK: - Downloads Panel
 extension Strings {
-    public static let DownloadsPanelEmptyStateTitle = MZLocalizedString("DownloadsPanel.EmptyState.Title", value: "Downloaded files will show up here.", comment: "Title for the Downloads Panel empty state.")
-    public static let DownloadsPanelDeleteTitle = MZLocalizedString("DownloadsPanel.Delete.Title", value: "Delete", comment: "Action button for deleting downloaded files in the Downloads panel.")
-    public static let DownloadsPanelShareTitle = MZLocalizedString("DownloadsPanel.Share.Title", value: "Share", comment: "Action button for sharing downloaded files in the Downloads panel.")
+    public static let DownloadsPanelEmptyStateTitle = MZLocalizedString("DownloadsPanel.EmptyState.Title", value: "Downloaded files will show up here.", comment: "Title for the Downloads Panel empty state.", lastEditedIn: .unknown)
+    public static let DownloadsPanelDeleteTitle = MZLocalizedString("DownloadsPanel.Delete.Title", value: "Delete", comment: "Action button for deleting downloaded files in the Downloads panel.", lastEditedIn: .unknown)
+    public static let DownloadsPanelShareTitle = MZLocalizedString("DownloadsPanel.Share.Title", value: "Share", comment: "Action button for sharing downloaded files in the Downloads panel.", lastEditedIn: .unknown)
 }
 
 // MARK: - History Panel
 extension Strings {
-    public static let SyncedTabsTableViewCellTitle = MZLocalizedString("HistoryPanel.SyncedTabsCell.Title", value: "Synced Devices", comment: "Title for the Synced Tabs Cell in the History Panel")
-    public static let HistoryBackButtonTitle = MZLocalizedString("HistoryPanel.HistoryBackButton.Title", value: "History", comment: "Title for the Back to History button in the History Panel")
-    public static let EmptySyncedTabsPanelStateTitle = MZLocalizedString("HistoryPanel.EmptySyncedTabsState.Title", value: "Firefox Sync", comment: "Title for the empty synced tabs state in the History Panel")
-    public static let EmptySyncedTabsPanelNotSignedInStateDescription = MZLocalizedString("HistoryPanel.EmptySyncedTabsPanelNotSignedInState.Description", value: "Sign in to view a list of tabs from your other devices.", comment: "Description for the empty synced tabs 'not signed in' state in the History Panel")
-    public static let EmptySyncedTabsPanelNotYetVerifiedStateDescription = MZLocalizedString("HistoryPanel.EmptySyncedTabsPanelNotYetVerifiedState.Description", value: "Your account needs to be verified.", comment: "Description for the empty synced tabs 'not yet verified' state in the History Panel")
-    public static let EmptySyncedTabsPanelSingleDeviceSyncStateDescription = MZLocalizedString("HistoryPanel.EmptySyncedTabsPanelSingleDeviceSyncState.Description", value: "Want to see your tabs from other devices here?", comment: "Description for the empty synced tabs 'single device Sync' state in the History Panel")
-    public static let EmptySyncedTabsPanelTabSyncDisabledStateDescription = MZLocalizedString("HistoryPanel.EmptySyncedTabsPanelTabSyncDisabledState.Description", value: "Turn on tab syncing to view a list of tabs from your other devices.", comment: "Description for the empty synced tabs 'tab sync disabled' state in the History Panel")
-    public static let EmptySyncedTabsPanelNullStateDescription = MZLocalizedString("HistoryPanel.EmptySyncedTabsNullState.Description", value: "Your tabs from other devices show up here.", comment: "Description for the empty synced tabs null state in the History Panel")
-    public static let SyncedTabsTableViewCellDescription = MZLocalizedString("HistoryPanel.SyncedTabsCell.Description.Pluralized", value: "%d device(s) connected", comment: "Description that corresponds with a number of devices connected for the Synced Tabs Cell in the History Panel")
-    public static let HistoryPanelEmptyStateTitle = MZLocalizedString("HistoryPanel.EmptyState.Title", value: "Websites you’ve visited recently will show up here.", comment: "Title for the History Panel empty state.")
-    public static let RecentlyClosedTabsButtonTitle = MZLocalizedString("HistoryPanel.RecentlyClosedTabsButton.Title", value: "Recently Closed", comment: "Title for the Recently Closed button in the History Panel")
-    public static let RecentlyClosedTabsPanelTitle = MZLocalizedString("RecentlyClosedTabsPanel.Title", value: "Recently Closed", comment: "Title for the Recently Closed Tabs Panel")
-    public static let HistoryPanelClearHistoryButtonTitle = MZLocalizedString("HistoryPanel.ClearHistoryButtonTitle", value: "Clear Recent History…", comment: "Title for button in the history panel to clear recent history")
-    public static let FirefoxHomePage = MZLocalizedString("Firefox.HomePage.Title", value: "Firefox Home Page", comment: "Title for firefox about:home page in tab history list")
-    public static let HistoryPanelDelete = MZLocalizedString("Delete", tableName: "HistoryPanel", comment: "Action button for deleting history entries in the history panel.")
+    public static let SyncedTabsTableViewCellTitle = MZLocalizedString("HistoryPanel.SyncedTabsCell.Title", value: "Synced Devices", comment: "Title for the Synced Tabs Cell in the History Panel", lastEditedIn: .unknown)
+    public static let HistoryBackButtonTitle = MZLocalizedString("HistoryPanel.HistoryBackButton.Title", value: "History", comment: "Title for the Back to History button in the History Panel", lastEditedIn: .unknown)
+    public static let EmptySyncedTabsPanelStateTitle = MZLocalizedString("HistoryPanel.EmptySyncedTabsState.Title", value: "Firefox Sync", comment: "Title for the empty synced tabs state in the History Panel", lastEditedIn: .unknown)
+    public static let EmptySyncedTabsPanelNotSignedInStateDescription = MZLocalizedString("HistoryPanel.EmptySyncedTabsPanelNotSignedInState.Description", value: "Sign in to view a list of tabs from your other devices.", comment: "Description for the empty synced tabs 'not signed in' state in the History Panel", lastEditedIn: .unknown)
+    public static let EmptySyncedTabsPanelNotYetVerifiedStateDescription = MZLocalizedString("HistoryPanel.EmptySyncedTabsPanelNotYetVerifiedState.Description", value: "Your account needs to be verified.", comment: "Description for the empty synced tabs 'not yet verified' state in the History Panel", lastEditedIn: .unknown)
+    public static let EmptySyncedTabsPanelSingleDeviceSyncStateDescription = MZLocalizedString("HistoryPanel.EmptySyncedTabsPanelSingleDeviceSyncState.Description", value: "Want to see your tabs from other devices here?", comment: "Description for the empty synced tabs 'single device Sync' state in the History Panel", lastEditedIn: .unknown)
+    public static let EmptySyncedTabsPanelTabSyncDisabledStateDescription = MZLocalizedString("HistoryPanel.EmptySyncedTabsPanelTabSyncDisabledState.Description", value: "Turn on tab syncing to view a list of tabs from your other devices.", comment: "Description for the empty synced tabs 'tab sync disabled' state in the History Panel", lastEditedIn: .unknown)
+    public static let EmptySyncedTabsPanelNullStateDescription = MZLocalizedString("HistoryPanel.EmptySyncedTabsNullState.Description", value: "Your tabs from other devices show up here.", comment: "Description for the empty synced tabs null state in the History Panel", lastEditedIn: .unknown)
+    public static let SyncedTabsTableViewCellDescription = MZLocalizedString("HistoryPanel.SyncedTabsCell.Description.Pluralized", value: "%d device(s) connected", comment: "Description that corresponds with a number of devices connected for the Synced Tabs Cell in the History Panel", lastEditedIn: .unknown)
+    public static let HistoryPanelEmptyStateTitle = MZLocalizedString("HistoryPanel.EmptyState.Title", value: "Websites you’ve visited recently will show up here.", comment: "Title for the History Panel empty state.", lastEditedIn: .unknown)
+    public static let RecentlyClosedTabsButtonTitle = MZLocalizedString("HistoryPanel.RecentlyClosedTabsButton.Title", value: "Recently Closed", comment: "Title for the Recently Closed button in the History Panel", lastEditedIn: .unknown)
+    public static let RecentlyClosedTabsPanelTitle = MZLocalizedString("RecentlyClosedTabsPanel.Title", value: "Recently Closed", comment: "Title for the Recently Closed Tabs Panel", lastEditedIn: .unknown)
+    public static let HistoryPanelClearHistoryButtonTitle = MZLocalizedString("HistoryPanel.ClearHistoryButtonTitle", value: "Clear Recent History…", comment: "Title for button in the history panel to clear recent history", lastEditedIn: .unknown)
+    public static let FirefoxHomePage = MZLocalizedString("Firefox.HomePage.Title", value: "Firefox Home Page", comment: "Title for firefox about:home page in tab history list", lastEditedIn: .unknown)
+    public static let HistoryPanelDelete = MZLocalizedString("Delete", tableName: "HistoryPanel", comment: "Action button for deleting history entries in the history panel.", lastEditedIn: .unknown)
 }
 
 // MARK: - Clear recent history action menu
 extension Strings {
-    public static let ClearHistoryMenuTitle = MZLocalizedString("HistoryPanel.ClearHistoryMenuTitle", value: "Clearing Recent History will remove history, cookies, and other browser data.", comment: "Title for popup action menu to clear recent history.")
-    public static let ClearHistoryMenuOptionTheLastHour = MZLocalizedString("HistoryPanel.ClearHistoryMenuOptionTheLastHour", value: "The Last Hour", comment: "Button to perform action to clear history for the last hour")
-    public static let ClearHistoryMenuOptionToday = MZLocalizedString("HistoryPanel.ClearHistoryMenuOptionToday", value: "Today", comment: "Button to perform action to clear history for today only")
-    public static let ClearHistoryMenuOptionTodayAndYesterday = MZLocalizedString("HistoryPanel.ClearHistoryMenuOptionTodayAndYesterday", value: "Today and Yesterday", comment: "Button to perform action to clear history for yesterday and today")
-    public static let ClearHistoryMenuOptionEverything = MZLocalizedString("HistoryPanel.ClearHistoryMenuOptionEverything", value: "Everything", comment: "Option title to clear all browsing history.")
+    public static let ClearHistoryMenuTitle = MZLocalizedString("HistoryPanel.ClearHistoryMenuTitle", value: "Clearing Recent History will remove history, cookies, and other browser data.", comment: "Title for popup action menu to clear recent history.", lastEditedIn: .unknown)
+    public static let ClearHistoryMenuOptionTheLastHour = MZLocalizedString("HistoryPanel.ClearHistoryMenuOptionTheLastHour", value: "The Last Hour", comment: "Button to perform action to clear history for the last hour", lastEditedIn: .unknown)
+    public static let ClearHistoryMenuOptionToday = MZLocalizedString("HistoryPanel.ClearHistoryMenuOptionToday", value: "Today", comment: "Button to perform action to clear history for today only", lastEditedIn: .unknown)
+    public static let ClearHistoryMenuOptionTodayAndYesterday = MZLocalizedString("HistoryPanel.ClearHistoryMenuOptionTodayAndYesterday", value: "Today and Yesterday", comment: "Button to perform action to clear history for yesterday and today", lastEditedIn: .unknown)
+    public static let ClearHistoryMenuOptionEverything = MZLocalizedString("HistoryPanel.ClearHistoryMenuOptionEverything", value: "Everything", comment: "Option title to clear all browsing history.", lastEditedIn: .unknown)
 }
 
 // MARK: - Syncing
 extension Strings {
-    public static let SyncingMessageWithEllipsis = MZLocalizedString("Sync.SyncingEllipsis.Label", value: "Syncing…", comment: "Message displayed when the user's account is syncing with ellipsis at the end")
-    public static let SyncingMessageWithoutEllipsis = MZLocalizedString("Sync.Syncing.Label", value: "Syncing", comment: "Message displayed when the user's account is syncing with no ellipsis")
+    public static let SyncingMessageWithEllipsis = MZLocalizedString("Sync.SyncingEllipsis.Label", value: "Syncing…", comment: "Message displayed when the user's account is syncing with ellipsis at the end", lastEditedIn: .unknown)
+    public static let SyncingMessageWithoutEllipsis = MZLocalizedString("Sync.Syncing.Label", value: "Syncing", comment: "Message displayed when the user's account is syncing with no ellipsis", lastEditedIn: .unknown)
 
-    public static let FirstTimeSyncLongTime = MZLocalizedString("Sync.FirstTimeMessage.Label", value: "Your first sync may take a while", comment: "Message displayed when the user syncs for the first time")
+    public static let FirstTimeSyncLongTime = MZLocalizedString("Sync.FirstTimeMessage.Label", value: "Your first sync may take a while", comment: "Message displayed when the user syncs for the first time", lastEditedIn: .unknown)
 
-    public static let FirefoxSyncOfflineTitle = MZLocalizedString("SyncState.Offline.Title", value: "Sync is offline", comment: "Title for Sync status message when Sync failed due to being offline")
-    public static let FirefoxSyncNotStartedTitle = MZLocalizedString("SyncState.NotStarted.Title", value: "Sync is unavailable", comment: "Title for Sync status message when Sync failed to start.")
-    public static let FirefoxSyncPartialTitle = MZLocalizedString("SyncState.Partial.Title", value: "Sync is experiencing issues syncing %@", comment: "Title for Sync status message when a component of Sync failed to complete, where %@ represents the name of the component, i.e. Sync is experiencing issues syncing Bookmarks")
-    public static let FirefoxSyncFailedTitle = MZLocalizedString("SyncState.Failed.Title", value: "Syncing has failed", comment: "Title for Sync status message when synchronization failed to complete")
-    public static let FirefoxSyncTroubleshootTitle = MZLocalizedString("Settings.TroubleShootSync.Title", value: "Troubleshoot", comment: "Title of link to help page to find out how to solve Sync issues")
-    public static let FirefoxSyncCreateAccount = MZLocalizedString("Sync.NoAccount.Description", value: "No account? Create one to sync Firefox between devices.", comment: "String displayed on Sign In to Sync page that allows the user to create a new account.")
+    public static let FirefoxSyncOfflineTitle = MZLocalizedString("SyncState.Offline.Title", value: "Sync is offline", comment: "Title for Sync status message when Sync failed due to being offline", lastEditedIn: .unknown)
+    public static let FirefoxSyncNotStartedTitle = MZLocalizedString("SyncState.NotStarted.Title", value: "Sync is unavailable", comment: "Title for Sync status message when Sync failed to start.", lastEditedIn: .unknown)
+    public static let FirefoxSyncPartialTitle = MZLocalizedString("SyncState.Partial.Title", value: "Sync is experiencing issues syncing %@", comment: "Title for Sync status message when a component of Sync failed to complete, where %@ represents the name of the component, i.e. Sync is experiencing issues syncing Bookmarks", lastEditedIn: .unknown)
+    public static let FirefoxSyncFailedTitle = MZLocalizedString("SyncState.Failed.Title", value: "Syncing has failed", comment: "Title for Sync status message when synchronization failed to complete", lastEditedIn: .unknown)
+    public static let FirefoxSyncTroubleshootTitle = MZLocalizedString("Settings.TroubleShootSync.Title", value: "Troubleshoot", comment: "Title of link to help page to find out how to solve Sync issues", lastEditedIn: .unknown)
+    public static let FirefoxSyncCreateAccount = MZLocalizedString("Sync.NoAccount.Description", value: "No account? Create one to sync Firefox between devices.", comment: "String displayed on Sign In to Sync page that allows the user to create a new account.", lastEditedIn: .unknown)
 
-    public static let FirefoxSyncBookmarksEngine = MZLocalizedString("Bookmarks", comment: "Toggle bookmarks syncing setting")
-    public static let FirefoxSyncHistoryEngine = MZLocalizedString("History", comment: "Toggle history syncing setting")
-    public static let FirefoxSyncTabsEngine = MZLocalizedString("Open Tabs", comment: "Toggle tabs syncing setting")
-    public static let FirefoxSyncLoginsEngine = MZLocalizedString("Logins", comment: "Toggle logins syncing setting")
+    public static let FirefoxSyncBookmarksEngine = MZLocalizedString("Bookmarks", comment: "Toggle bookmarks syncing setting", lastEditedIn: .unknown)
+    public static let FirefoxSyncHistoryEngine = MZLocalizedString("History", comment: "Toggle history syncing setting", lastEditedIn: .unknown)
+    public static let FirefoxSyncTabsEngine = MZLocalizedString("Open Tabs", comment: "Toggle tabs syncing setting", lastEditedIn: .unknown)
+    public static let FirefoxSyncLoginsEngine = MZLocalizedString("Logins", comment: "Toggle logins syncing setting", lastEditedIn: .unknown)
 
     public static func localizedStringForSyncComponent(_ componentName: String) -> String? {
         switch componentName {
         case "bookmarks":
-            return MZLocalizedString("SyncState.Bookmark.Title", value: "Bookmarks", comment: "The Bookmark sync component, used in SyncState.Partial.Title")
+            return MZLocalizedString("SyncState.Bookmark.Title", value: "Bookmarks", comment: "The Bookmark sync component, used in SyncState.Partial.Title", lastEditedIn: .unknown)
         case "clients":
-            return MZLocalizedString("SyncState.Clients.Title", value: "Remote Clients", comment: "The Remote Clients sync component, used in SyncState.Partial.Title")
+            return MZLocalizedString("SyncState.Clients.Title", value: "Remote Clients", comment: "The Remote Clients sync component, used in SyncState.Partial.Title", lastEditedIn: .unknown)
         case "tabs":
-            return MZLocalizedString("SyncState.Tabs.Title", value: "Tabs", comment: "The Tabs sync component, used in SyncState.Partial.Title")
+            return MZLocalizedString("SyncState.Tabs.Title", value: "Tabs", comment: "The Tabs sync component, used in SyncState.Partial.Title", lastEditedIn: .unknown)
         case "logins":
-            return MZLocalizedString("SyncState.Logins.Title", value: "Logins", comment: "The Logins sync component, used in SyncState.Partial.Title")
+            return MZLocalizedString("SyncState.Logins.Title", value: "Logins", comment: "The Logins sync component, used in SyncState.Partial.Title", lastEditedIn: .unknown)
         case "history":
-            return MZLocalizedString("SyncState.History.Title", value: "History", comment: "The History sync component, used in SyncState.Partial.Title")
+            return MZLocalizedString("SyncState.History.Title", value: "History", comment: "The History sync component, used in SyncState.Partial.Title", lastEditedIn: .unknown)
         default: return nil
         }
     }
@@ -218,110 +225,110 @@ extension Strings {
 
 // MARK: - Firefox Logins
 extension Strings {
-    public static let LoginsAndPasswordsTitle = MZLocalizedString("Settings.LoginsAndPasswordsTitle", value: "Logins & Passwords", comment: "Title for the logins and passwords screen. Translation could just use 'Logins' if the title is too long")
+    public static let LoginsAndPasswordsTitle = MZLocalizedString("Settings.LoginsAndPasswordsTitle", value: "Logins & Passwords", comment: "Title for the logins and passwords screen. Translation could just use 'Logins' if the title is too long", lastEditedIn: .unknown)
 
     // Prompts
-    public static let SaveLoginUsernamePrompt = MZLocalizedString("LoginsHelper.PromptSaveLogin.Title", value: "Save login %@ for %@?", comment: "Prompt for saving a login. The first parameter is the username being saved. The second parameter is the hostname of the site.")
-    public static let SaveLoginPrompt = MZLocalizedString("LoginsHelper.PromptSavePassword.Title", value: "Save password for %@?", comment: "Prompt for saving a password with no username. The parameter is the hostname of the site.")
-    public static let UpdateLoginUsernamePrompt = MZLocalizedString("LoginsHelper.PromptUpdateLogin.Title.TwoArg", value: "Update login %@ for %@?", comment: "Prompt for updating a login. The first parameter is the username for which the password will be updated for. The second parameter is the hostname of the site.")
-    public static let UpdateLoginPrompt = MZLocalizedString("LoginsHelper.PromptUpdateLogin.Title.OneArg", value: "Update login for %@?", comment: "Prompt for updating a login. The first parameter is the hostname for which the password will be updated for.")
+    public static let SaveLoginUsernamePrompt = MZLocalizedString("LoginsHelper.PromptSaveLogin.Title", value: "Save login %@ for %@?", comment: "Prompt for saving a login. The first parameter is the username being saved. The second parameter is the hostname of the site.", lastEditedIn: .unknown)
+    public static let SaveLoginPrompt = MZLocalizedString("LoginsHelper.PromptSavePassword.Title", value: "Save password for %@?", comment: "Prompt for saving a password with no username. The parameter is the hostname of the site.", lastEditedIn: .unknown)
+    public static let UpdateLoginUsernamePrompt = MZLocalizedString("LoginsHelper.PromptUpdateLogin.Title.TwoArg", value: "Update login %@ for %@?", comment: "Prompt for updating a login. The first parameter is the username for which the password will be updated for. The second parameter is the hostname of the site.", lastEditedIn: .unknown)
+    public static let UpdateLoginPrompt = MZLocalizedString("LoginsHelper.PromptUpdateLogin.Title.OneArg", value: "Update login for %@?", comment: "Prompt for updating a login. The first parameter is the hostname for which the password will be updated for.", lastEditedIn: .unknown)
 
     // Setting
-    public static let SettingToSaveLogins = MZLocalizedString("Settings.SaveLogins.Title", value: "Save Logins", comment: "Setting to enable the built-in password manager")
-    public static let SettingToShowLoginsInAppMenu = MZLocalizedString("Settings.ShowLoginsInAppMenu.Title", value: "Show in Application Menu", comment: "Setting to show Logins & Passwords quick access in the application menu")
+    public static let SettingToSaveLogins = MZLocalizedString("Settings.SaveLogins.Title", value: "Save Logins", comment: "Setting to enable the built-in password manager", lastEditedIn: .unknown)
+    public static let SettingToShowLoginsInAppMenu = MZLocalizedString("Settings.ShowLoginsInAppMenu.Title", value: "Show in Application Menu", comment: "Setting to show Logins & Passwords quick access in the application menu", lastEditedIn: .unknown)
 
     // List view
-    public static let LoginsListTitle = MZLocalizedString("LoginsList.Title", value: "SAVED LOGINS", comment: "Title for the list of logins")
-    public static let LoginsListSearchPlaceholder = MZLocalizedString("LoginsList.LoginsListSearchPlaceholder", value: "Filter", comment: "Placeholder test for search box in logins list view.")
-    public static let LoginsFilterWebsite = MZLocalizedString("LoginsList.LoginsListFilterWebsite", value: "Website", comment: "For filtering the login list, search only the website names")
-    public static let LoginsFilterLogin = MZLocalizedString("LoginsList.LoginsListFilterLogin", value: "Login", comment: "For filtering the login list, search only the login names")
-    public static let LoginsFilterAll = MZLocalizedString("LoginsList.LoginsListFilterSearchAll", value: "All", comment: "For filtering the login list, search both website and login names.")
+    public static let LoginsListTitle = MZLocalizedString("LoginsList.Title", value: "SAVED LOGINS", comment: "Title for the list of logins", lastEditedIn: .unknown)
+    public static let LoginsListSearchPlaceholder = MZLocalizedString("LoginsList.LoginsListSearchPlaceholder", value: "Filter", comment: "Placeholder test for search box in logins list view.", lastEditedIn: .unknown)
+    public static let LoginsFilterWebsite = MZLocalizedString("LoginsList.LoginsListFilterWebsite", value: "Website", comment: "For filtering the login list, search only the website names", lastEditedIn: .unknown)
+    public static let LoginsFilterLogin = MZLocalizedString("LoginsList.LoginsListFilterLogin", value: "Login", comment: "For filtering the login list, search only the login names", lastEditedIn: .unknown)
+    public static let LoginsFilterAll = MZLocalizedString("LoginsList.LoginsListFilterSearchAll", value: "All", comment: "For filtering the login list, search both website and login names.", lastEditedIn: .unknown)
 
     // Detail view
-    public static let LoginsDetailViewLoginTitle = MZLocalizedString("LoginsDetailView.LoginTitle", value: "Login", comment: "Title for the login detail view")
-    public static let LoginsDetailViewLoginModified = MZLocalizedString("LoginsDetailView.LoginModified", value: "Modified", comment: "Login detail view field name for the last modified date")
+    public static let LoginsDetailViewLoginTitle = MZLocalizedString("LoginsDetailView.LoginTitle", value: "Login", comment: "Title for the login detail view", lastEditedIn: .unknown)
+    public static let LoginsDetailViewLoginModified = MZLocalizedString("LoginsDetailView.LoginModified", value: "Modified", comment: "Login detail view field name for the last modified date", lastEditedIn: .unknown)
 
     // Breach Alerts
-    public static let BreachAlertsTitle = MZLocalizedString("BreachAlerts.Title", value: "Website Breach", comment: "Title for the Breached Login Detail View.")
-    public static let BreachAlertsLearnMore = MZLocalizedString("BreachAlerts.LearnMoreButton", value: "Learn more", comment: "Link to monitor.firefox.com to learn more about breached passwords")
-    public static let BreachAlertsBreachDate = MZLocalizedString("BreachAlerts.BreachDate", value: "This breach occurred on", comment: "Describes the date on which the breach occurred")
-    public static let BreachAlertsDescription = MZLocalizedString("BreachAlerts.Description", value: "Passwords were leaked or stolen since you last changed your password. To protect this account, log in to the site and change your password.", comment: "Description of what a breach is")
-    public static let BreachAlertsLink = MZLocalizedString("BreachAlerts.Link", value: "Go to", comment: "Leads to a link to the breached website")
+    public static let BreachAlertsTitle = MZLocalizedString("BreachAlerts.Title", value: "Website Breach", comment: "Title for the Breached Login Detail View.", lastEditedIn: .unknown)
+    public static let BreachAlertsLearnMore = MZLocalizedString("BreachAlerts.LearnMoreButton", value: "Learn more", comment: "Link to monitor.firefox.com to learn more about breached passwords", lastEditedIn: .unknown)
+    public static let BreachAlertsBreachDate = MZLocalizedString("BreachAlerts.BreachDate", value: "This breach occurred on", comment: "Describes the date on which the breach occurred", lastEditedIn: .unknown)
+    public static let BreachAlertsDescription = MZLocalizedString("BreachAlerts.Description", value: "Passwords were leaked or stolen since you last changed your password. To protect this account, log in to the site and change your password.", comment: "Description of what a breach is", lastEditedIn: .unknown)
+    public static let BreachAlertsLink = MZLocalizedString("BreachAlerts.Link", value: "Go to", comment: "Leads to a link to the breached website", lastEditedIn: .unknown)
 }
 
 // MARK: - Firefox Account
 extension Strings {
     // Settings strings
-    public static let FxAFirefoxAccount = MZLocalizedString("FxA.FirefoxAccount", value: "Firefox Account", comment: "Settings section title for Firefox Account")
-    public static let FxASignInToSync = MZLocalizedString("FxA.SignIntoSync", value: "Sign in to Sync", comment: "Button label to sign into Sync")
-    public static let FxATakeYourWebWithYou = MZLocalizedString("FxA.TakeYourWebWithYou", value: "Take Your Web With You", comment: "Call to action for sign into sync button")
-    public static let FxASyncUsageDetails = MZLocalizedString("FxA.SyncExplain", value: "Get your tabs, bookmarks, and passwords from your other devices.", comment: "Label explaining what sync does")
-    public static let FxAAccountVerificationRequired = MZLocalizedString("FxA.AccountVerificationRequired", value: "Account Verification Required", comment: "Label stating your account is not verified")
-    public static let FxAAccountVerificationDetails = MZLocalizedString("FxA.AccountVerificationDetails", value: "Wrong email? Disconnect below to start over.", comment: "Label stating how to disconnect account")
-    public static let FxAManageAccount = MZLocalizedString("FxA.ManageAccount", value: "Manage Account & Devices", comment: "Button label to go to Firefox Account settings")
-    public static let FxASyncNow = MZLocalizedString("FxA.SyncNow", value: "Sync Now", comment: "Button label to Sync your Firefox Account")
-    public static let FxANoInternetConnection = MZLocalizedString("FxA.NoInternetConnection", value: "No Internet Connection", comment: "Label when no internet is present")
-    public static let FxASettingsTitle = MZLocalizedString("Settings.FxA.Title", value: "Firefox Account", comment: "Title displayed in header of the FxA settings panel.")
-    public static let FxASettingsSyncSettings = MZLocalizedString("Settings.FxA.Sync.SectionName", value: "Sync Settings", comment: "Label used as a section title in the Firefox Accounts Settings screen.")
-    public static let FxASettingsDeviceName = MZLocalizedString("Settings.FxA.DeviceName", value: "Device Name", comment: "Label used for the device name settings section.")
-    public static let FxAOpenSyncPreferences = MZLocalizedString("FxA.OpenSyncPreferences", value: "Open Sync Preferences", comment: "Button label to open Sync preferences")
-    public static let FxAConnectAnotherDevice = MZLocalizedString("FxA.ConnectAnotherDevice", value: "Connect Another Device", comment: "Button label to connect another device to Sync")
-    public static let FxARemoveAccountButton = MZLocalizedString("FxA.RemoveAccount", value: "Remove", comment: "Remove button is displayed on firefox account page under certain scenarios where user would like to remove their account.")
-    public static let FxARemoveAccountAlertTitle = MZLocalizedString("FxA.RemoveAccountAlertTitle", value: "Remove Account", comment: "Remove account alert is the final confirmation before user removes their firefox account")
-    public static let FxARemoveAccountAlertMessage = MZLocalizedString("FxA.RemoveAccountAlertMessage", value: "Remove the Firefox Account associated with this device to sign in as a different user.", comment: "Description string for alert view that gets presented when user tries to remove an account.")
+    public static let FxAFirefoxAccount = MZLocalizedString("FxA.FirefoxAccount", value: "Firefox Account", comment: "Settings section title for Firefox Account", lastEditedIn: .unknown)
+    public static let FxASignInToSync = MZLocalizedString("FxA.SignIntoSync", value: "Sign in to Sync", comment: "Button label to sign into Sync", lastEditedIn: .unknown)
+    public static let FxATakeYourWebWithYou = MZLocalizedString("FxA.TakeYourWebWithYou", value: "Take Your Web With You", comment: "Call to action for sign into sync button", lastEditedIn: .unknown)
+    public static let FxASyncUsageDetails = MZLocalizedString("FxA.SyncExplain", value: "Get your tabs, bookmarks, and passwords from your other devices.", comment: "Label explaining what sync does", lastEditedIn: .unknown)
+    public static let FxAAccountVerificationRequired = MZLocalizedString("FxA.AccountVerificationRequired", value: "Account Verification Required", comment: "Label stating your account is not verified", lastEditedIn: .unknown)
+    public static let FxAAccountVerificationDetails = MZLocalizedString("FxA.AccountVerificationDetails", value: "Wrong email? Disconnect below to start over.", comment: "Label stating how to disconnect account", lastEditedIn: .unknown)
+    public static let FxAManageAccount = MZLocalizedString("FxA.ManageAccount", value: "Manage Account & Devices", comment: "Button label to go to Firefox Account settings", lastEditedIn: .unknown)
+    public static let FxASyncNow = MZLocalizedString("FxA.SyncNow", value: "Sync Now", comment: "Button label to Sync your Firefox Account", lastEditedIn: .unknown)
+    public static let FxANoInternetConnection = MZLocalizedString("FxA.NoInternetConnection", value: "No Internet Connection", comment: "Label when no internet is present", lastEditedIn: .unknown)
+    public static let FxASettingsTitle = MZLocalizedString("Settings.FxA.Title", value: "Firefox Account", comment: "Title displayed in header of the FxA settings panel.", lastEditedIn: .unknown)
+    public static let FxASettingsSyncSettings = MZLocalizedString("Settings.FxA.Sync.SectionName", value: "Sync Settings", comment: "Label used as a section title in the Firefox Accounts Settings screen.", lastEditedIn: .unknown)
+    public static let FxASettingsDeviceName = MZLocalizedString("Settings.FxA.DeviceName", value: "Device Name", comment: "Label used for the device name settings section.", lastEditedIn: .unknown)
+    public static let FxAOpenSyncPreferences = MZLocalizedString("FxA.OpenSyncPreferences", value: "Open Sync Preferences", comment: "Button label to open Sync preferences", lastEditedIn: .unknown)
+    public static let FxAConnectAnotherDevice = MZLocalizedString("FxA.ConnectAnotherDevice", value: "Connect Another Device", comment: "Button label to connect another device to Sync", lastEditedIn: .unknown)
+    public static let FxARemoveAccountButton = MZLocalizedString("FxA.RemoveAccount", value: "Remove", comment: "Remove button is displayed on firefox account page under certain scenarios where user would like to remove their account.", lastEditedIn: .unknown)
+    public static let FxARemoveAccountAlertTitle = MZLocalizedString("FxA.RemoveAccountAlertTitle", value: "Remove Account", comment: "Remove account alert is the final confirmation before user removes their firefox account", lastEditedIn: .unknown)
+    public static let FxARemoveAccountAlertMessage = MZLocalizedString("FxA.RemoveAccountAlertMessage", value: "Remove the Firefox Account associated with this device to sign in as a different user.", comment: "Description string for alert view that gets presented when user tries to remove an account.", lastEditedIn: .unknown)
 
     // Surface error strings
-    public static let FxAAccountVerificationRequiredSurface = MZLocalizedString("FxA.AccountVerificationRequiredSurface", value: "You need to verify %@. Check your email for the verification link from Firefox.", comment: "Message explaining that user needs to check email for Firefox Account verfication link.")
-    public static let FxAResendEmail = MZLocalizedString("FxA.ResendEmail", value: "Resend Email", comment: "Button label to resend email")
-    public static let FxAAccountVerifyEmail = MZLocalizedString("Verify your email address", comment: "Text message in the settings table view")
-    public static let FxAAccountVerifyPassword = MZLocalizedString("Enter your password to connect", comment: "Text message in the settings table view")
-    public static let FxAAccountUpgradeFirefox = MZLocalizedString("Upgrade Firefox to connect", comment: "Text message in the settings table view")
+    public static let FxAAccountVerificationRequiredSurface = MZLocalizedString("FxA.AccountVerificationRequiredSurface", value: "You need to verify %@. Check your email for the verification link from Firefox.", comment: "Message explaining that user needs to check email for Firefox Account verfication link.", lastEditedIn: .unknown)
+    public static let FxAResendEmail = MZLocalizedString("FxA.ResendEmail", value: "Resend Email", comment: "Button label to resend email", lastEditedIn: .unknown)
+    public static let FxAAccountVerifyEmail = MZLocalizedString("Verify your email address", comment: "Text message in the settings table view", lastEditedIn: .unknown)
+    public static let FxAAccountVerifyPassword = MZLocalizedString("Enter your password to connect", comment: "Text message in the settings table view", lastEditedIn: .unknown)
+    public static let FxAAccountUpgradeFirefox = MZLocalizedString("Upgrade Firefox to connect", comment: "Text message in the settings table view", lastEditedIn: .unknown)
 }
 
 // MARK: - Hotkey Titles
 extension Strings {
-    public static let ReloadPageTitle = MZLocalizedString("Hotkeys.Reload.DiscoveryTitle", value: "Reload Page", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-    public static let BackTitle = MZLocalizedString("Hotkeys.Back.DiscoveryTitle", value: "Back", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-    public static let ForwardTitle = MZLocalizedString("Hotkeys.Forward.DiscoveryTitle", value: "Forward", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let ReloadPageTitle = MZLocalizedString("Hotkeys.Reload.DiscoveryTitle", value: "Reload Page", comment: "Label to display in the Discoverability overlay for keyboard shortcuts", lastEditedIn: .unknown)
+    public static let BackTitle = MZLocalizedString("Hotkeys.Back.DiscoveryTitle", value: "Back", comment: "Label to display in the Discoverability overlay for keyboard shortcuts", lastEditedIn: .unknown)
+    public static let ForwardTitle = MZLocalizedString("Hotkeys.Forward.DiscoveryTitle", value: "Forward", comment: "Label to display in the Discoverability overlay for keyboard shortcuts", lastEditedIn: .unknown)
 
-    public static let FindTitle = MZLocalizedString("Hotkeys.Find.DiscoveryTitle", value: "Find", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-    public static let SelectLocationBarTitle = MZLocalizedString("Hotkeys.SelectLocationBar.DiscoveryTitle", value: "Select Location Bar", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-    public static let privateBrowsingModeTitle = MZLocalizedString("Hotkeys.PrivateMode.DiscoveryTitle", value: "Private Browsing Mode", comment: "Label to switch to private browsing mode")
-    public static let normalBrowsingModeTitle = MZLocalizedString("Hotkeys.NormalMode.DiscoveryTitle", value: "Normal Browsing Mode", comment: "Label to switch to normal browsing mode")
-    public static let NewTabTitle = MZLocalizedString("Hotkeys.NewTab.DiscoveryTitle", value: "New Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-    public static let NewPrivateTabTitle = MZLocalizedString("Hotkeys.NewPrivateTab.DiscoveryTitle", value: "New Private Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-    public static let CloseTabTitle = MZLocalizedString("Hotkeys.CloseTab.DiscoveryTitle", value: "Close Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-    public static let ShowNextTabTitle = MZLocalizedString("Hotkeys.ShowNextTab.DiscoveryTitle", value: "Show Next Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-    public static let ShowPreviousTabTitle = MZLocalizedString("Hotkeys.ShowPreviousTab.DiscoveryTitle", value: "Show Previous Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let FindTitle = MZLocalizedString("Hotkeys.Find.DiscoveryTitle", value: "Find", comment: "Label to display in the Discoverability overlay for keyboard shortcuts", lastEditedIn: .unknown)
+    public static let SelectLocationBarTitle = MZLocalizedString("Hotkeys.SelectLocationBar.DiscoveryTitle", value: "Select Location Bar", comment: "Label to display in the Discoverability overlay for keyboard shortcuts", lastEditedIn: .unknown)
+    public static let privateBrowsingModeTitle = MZLocalizedString("Hotkeys.PrivateMode.DiscoveryTitle", value: "Private Browsing Mode", comment: "Label to switch to private browsing mode", lastEditedIn: .unknown)
+    public static let normalBrowsingModeTitle = MZLocalizedString("Hotkeys.NormalMode.DiscoveryTitle", value: "Normal Browsing Mode", comment: "Label to switch to normal browsing mode", lastEditedIn: .unknown)
+    public static let NewTabTitle = MZLocalizedString("Hotkeys.NewTab.DiscoveryTitle", value: "New Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts", lastEditedIn: .unknown)
+    public static let NewPrivateTabTitle = MZLocalizedString("Hotkeys.NewPrivateTab.DiscoveryTitle", value: "New Private Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts", lastEditedIn: .unknown)
+    public static let CloseTabTitle = MZLocalizedString("Hotkeys.CloseTab.DiscoveryTitle", value: "Close Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts", lastEditedIn: .unknown)
+    public static let ShowNextTabTitle = MZLocalizedString("Hotkeys.ShowNextTab.DiscoveryTitle", value: "Show Next Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts", lastEditedIn: .unknown)
+    public static let ShowPreviousTabTitle = MZLocalizedString("Hotkeys.ShowPreviousTab.DiscoveryTitle", value: "Show Previous Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts", lastEditedIn: .unknown)
 }
 
 // MARK: - New tab choice settings
 extension Strings {
-    public static let CustomNewPageURL = MZLocalizedString("Settings.NewTab.CustomURL", value: "Custom URL", comment: "Label used to set a custom url as the new tab option (homepage).")
-    public static let SettingsNewTabSectionName = MZLocalizedString("Settings.NewTab.SectionName", value: "New Tab", comment: "Label used as an item in Settings. When touched it will open a dialog to configure the new tab behavior.")
+    public static let CustomNewPageURL = MZLocalizedString("Settings.NewTab.CustomURL", value: "Custom URL", comment: "Label used to set a custom url as the new tab option (homepage).", lastEditedIn: .unknown)
+    public static let SettingsNewTabSectionName = MZLocalizedString("Settings.NewTab.SectionName", value: "New Tab", comment: "Label used as an item in Settings. When touched it will open a dialog to configure the new tab behavior.", lastEditedIn: .unknown)
     public static let NewTabSectionName =
-        MZLocalizedString("Settings.NewTab.TopSectionName", value: "Show", comment: "Label at the top of the New Tab screen after entering New Tab in settings")
-    public static let SettingsNewTabTitle = MZLocalizedString("Settings.NewTab.Title", value: "New Tab", comment: "Title displayed in header of the setting panel.")
+        MZLocalizedString("Settings.NewTab.TopSectionName", value: "Show", comment: "Label at the top of the New Tab screen after entering New Tab in settings", lastEditedIn: .unknown)
+    public static let SettingsNewTabTitle = MZLocalizedString("Settings.NewTab.Title", value: "New Tab", comment: "Title displayed in header of the setting panel.", lastEditedIn: .unknown)
     public static let NewTabSectionNameFooter =
-        MZLocalizedString("Settings.NewTab.TopSectionNameFooter", value: "Choose what to load when opening a new tab", comment: "Footer at the bottom of the New Tab screen after entering New Tab in settings")
-    public static let SettingsNewTabTopSites = MZLocalizedString("Settings.NewTab.Option.FirefoxHome", value: "Firefox Home", comment: "Option in settings to show Firefox Home when you open a new tab")
-    public static let SettingsNewTabBookmarks = MZLocalizedString("Settings.NewTab.Option.Bookmarks", value: "Bookmarks", comment: "Option in settings to show bookmarks when you open a new tab")
-    public static let SettingsNewTabHistory = MZLocalizedString("Settings.NewTab.Option.History", value: "History", comment: "Option in settings to show history when you open a new tab")
-    public static let SettingsNewTabReadingList = MZLocalizedString("Settings.NewTab.Option.ReadingList", value: "Show your Reading List", comment: "Option in settings to show reading list when you open a new tab")
-    public static let SettingsNewTabBlankPage = MZLocalizedString("Settings.NewTab.Option.BlankPage", value: "Blank Page", comment: "Option in settings to show a blank page when you open a new tab")
-    public static let SettingsNewTabHomePage = MZLocalizedString("Settings.NewTab.Option.HomePage", value: "Homepage", comment: "Option in settings to show your homepage when you open a new tab")
-    public static let SettingsNewTabDescription = MZLocalizedString("Settings.NewTab.Description", value: "When you open a New Tab:", comment: "A description in settings of what the new tab choice means")
+        MZLocalizedString("Settings.NewTab.TopSectionNameFooter", value: "Choose what to load when opening a new tab", comment: "Footer at the bottom of the New Tab screen after entering New Tab in settings", lastEditedIn: .unknown)
+    public static let SettingsNewTabTopSites = MZLocalizedString("Settings.NewTab.Option.FirefoxHome", value: "Firefox Home", comment: "Option in settings to show Firefox Home when you open a new tab", lastEditedIn: .unknown)
+    public static let SettingsNewTabBookmarks = MZLocalizedString("Settings.NewTab.Option.Bookmarks", value: "Bookmarks", comment: "Option in settings to show bookmarks when you open a new tab", lastEditedIn: .unknown)
+    public static let SettingsNewTabHistory = MZLocalizedString("Settings.NewTab.Option.History", value: "History", comment: "Option in settings to show history when you open a new tab", lastEditedIn: .unknown)
+    public static let SettingsNewTabReadingList = MZLocalizedString("Settings.NewTab.Option.ReadingList", value: "Show your Reading List", comment: "Option in settings to show reading list when you open a new tab", lastEditedIn: .unknown)
+    public static let SettingsNewTabBlankPage = MZLocalizedString("Settings.NewTab.Option.BlankPage", value: "Blank Page", comment: "Option in settings to show a blank page when you open a new tab", lastEditedIn: .unknown)
+    public static let SettingsNewTabHomePage = MZLocalizedString("Settings.NewTab.Option.HomePage", value: "Homepage", comment: "Option in settings to show your homepage when you open a new tab", lastEditedIn: .unknown)
+    public static let SettingsNewTabDescription = MZLocalizedString("Settings.NewTab.Description", value: "When you open a New Tab:", comment: "A description in settings of what the new tab choice means", lastEditedIn: .unknown)
     // AS Panel settings
-    public static let SettingsNewTabASTitle = MZLocalizedString("Settings.NewTab.Option.ASTitle", value: "Customize Top Sites", comment: "The title of the section in newtab that lets you modify the topsites panel")
-    public static let SettingsNewTabPocket = MZLocalizedString("Settings.NewTab.Option.Pocket", value: "Trending on Pocket", comment: "Option in settings to turn on off pocket recommendations")
-    public static let SettingsNewTabRecommendedByPocket = MZLocalizedString("Settings.NewTab.Option.RecommendedByPocket", value: "Recommended by %@", comment: "Option in settings to turn on off pocket recommendations First argument is the pocket brand name")
-    public static let SettingsNewTabRecommendedByPocketDescription = MZLocalizedString("Settings.NewTab.Option.RecommendedByPocketDescription", value: "Exceptional content curated by %@, part of the %@ family", comment: "Descriptoin for the option in settings to turn on off pocket recommendations. First argument is the pocket brand name, second argument is the pocket product name.")
-    public static let SettingsNewTabPocketFooter = MZLocalizedString("Settings.NewTab.Option.PocketFooter", value: "Great content from around the web.", comment: "Footer caption for pocket settings")
-    public static let SettingsNewTabHiglightsHistory = MZLocalizedString("Settings.NewTab.Option.HighlightsHistory", value: "Visited", comment: "Option in settings to turn off history in the highlights section")
-    public static let SettingsNewTabHighlightsBookmarks = MZLocalizedString("Settings.NewTab.Option.HighlightsBookmarks", value: "Recent Bookmarks", comment: "Option in the settings to turn off recent bookmarks in the Highlights section")
-    public static let SettingsTopSitesCustomizeTitle = MZLocalizedString("Settings.NewTab.Option.CustomizeTitle", value: "Customize Firefox Home", comment: "The title for the section to customize top sites in the new tab settings page.")
-    public static let SettingsTopSitesCustomizeFooter = MZLocalizedString("Settings.NewTab.Option.CustomizeFooter", value: "The sites you visit most", comment: "The footer for the section to customize top sites in the new tab settings page.")
-    public static let SettingsTopSitesCustomizeFooter2 = MZLocalizedString("Settings.NewTab.Option.CustomizeFooter2", value: "Sites you save or visit", comment: "The footer for the section to customize top sites in the new tab settings page.")
+    public static let SettingsNewTabASTitle = MZLocalizedString("Settings.NewTab.Option.ASTitle", value: "Customize Top Sites", comment: "The title of the section in newtab that lets you modify the topsites panel", lastEditedIn: .unknown)
+    public static let SettingsNewTabPocket = MZLocalizedString("Settings.NewTab.Option.Pocket", value: "Trending on Pocket", comment: "Option in settings to turn on off pocket recommendations", lastEditedIn: .unknown)
+    public static let SettingsNewTabRecommendedByPocket = MZLocalizedString("Settings.NewTab.Option.RecommendedByPocket", value: "Recommended by %@", comment: "Option in settings to turn on off pocket recommendations First argument is the pocket brand name", lastEditedIn: .unknown)
+    public static let SettingsNewTabRecommendedByPocketDescription = MZLocalizedString("Settings.NewTab.Option.RecommendedByPocketDescription", value: "Exceptional content curated by %@, part of the %@ family", comment: "Descriptoin for the option in settings to turn on off pocket recommendations. First argument is the pocket brand name, second argument is the pocket product name.", lastEditedIn: .unknown)
+    public static let SettingsNewTabPocketFooter = MZLocalizedString("Settings.NewTab.Option.PocketFooter", value: "Great content from around the web.", comment: "Footer caption for pocket settings", lastEditedIn: .unknown)
+    public static let SettingsNewTabHiglightsHistory = MZLocalizedString("Settings.NewTab.Option.HighlightsHistory", value: "Visited", comment: "Option in settings to turn off history in the highlights section", lastEditedIn: .unknown)
+    public static let SettingsNewTabHighlightsBookmarks = MZLocalizedString("Settings.NewTab.Option.HighlightsBookmarks", value: "Recent Bookmarks", comment: "Option in the settings to turn off recent bookmarks in the Highlights section", lastEditedIn: .unknown)
+    public static let SettingsTopSitesCustomizeTitle = MZLocalizedString("Settings.NewTab.Option.CustomizeTitle", value: "Customize Firefox Home", comment: "The title for the section to customize top sites in the new tab settings page.", lastEditedIn: .unknown)
+    public static let SettingsTopSitesCustomizeFooter = MZLocalizedString("Settings.NewTab.Option.CustomizeFooter", value: "The sites you visit most", comment: "The footer for the section to customize top sites in the new tab settings page.", lastEditedIn: .unknown)
+    public static let SettingsTopSitesCustomizeFooter2 = MZLocalizedString("Settings.NewTab.Option.CustomizeFooter2", value: "Sites you save or visit", comment: "The footer for the section to customize top sites in the new tab settings page.", lastEditedIn: .unknown)
 }
 
 // MARK: - Advanced Sync Settings (Debug)
@@ -336,1078 +343,1077 @@ extension Strings {
 
 // MARK: - Open With Settings
 extension Strings {
-    public static let SettingsOpenWithSectionName = MZLocalizedString("Settings.OpenWith.SectionName", value: "Mail App", comment: "Label used as an item in Settings. When touched it will open a dialog to configure the open with (mail links) behavior.")
-    public static let SettingsOpenWithPageTitle = MZLocalizedString("Settings.OpenWith.PageTitle", value: "Open mail links with", comment: "Title for Open With Settings")
+    public static let SettingsOpenWithSectionName = MZLocalizedString("Settings.OpenWith.SectionName", value: "Mail App", comment: "Label used as an item in Settings. When touched it will open a dialog to configure the open with (mail links) behavior.", lastEditedIn: .unknown)
+    public static let SettingsOpenWithPageTitle = MZLocalizedString("Settings.OpenWith.PageTitle", value: "Open mail links with", comment: "Title for Open With Settings", lastEditedIn: .unknown)
 }
 
 // MARK: - Third Party Search Engines
 extension Strings {
-    public static let ThirdPartySearchEngineAdded = MZLocalizedString("Search.ThirdPartyEngines.AddSuccess", value: "Added Search engine!", comment: "The success message that appears after a user sucessfully adds a new search engine")
-    public static let ThirdPartySearchAddTitle = MZLocalizedString("Search.ThirdPartyEngines.AddTitle", value: "Add Search Provider?", comment: "The title that asks the user to Add the search provider")
-    public static let ThirdPartySearchAddMessage = MZLocalizedString("Search.ThirdPartyEngines.AddMessage", value: "The new search engine will appear in the quick search bar.", comment: "The message that asks the user to Add the search provider explaining where the search engine will appear")
-    public static let ThirdPartySearchCancelButton = MZLocalizedString("Search.ThirdPartyEngines.Cancel", value: "Cancel", comment: "The cancel button if you do not want to add a search engine.")
-    public static let ThirdPartySearchOkayButton = MZLocalizedString("Search.ThirdPartyEngines.OK", value: "OK", comment: "The confirmation button")
-    public static let ThirdPartySearchFailedTitle = MZLocalizedString("Search.ThirdPartyEngines.FailedTitle", value: "Failed", comment: "A title explaining that we failed to add a search engine")
-    public static let ThirdPartySearchFailedMessage = MZLocalizedString("Search.ThirdPartyEngines.FailedMessage", value: "The search provider could not be added.", comment: "A title explaining that we failed to add a search engine")
-    public static let CustomEngineFormErrorTitle = MZLocalizedString("Search.ThirdPartyEngines.FormErrorTitle", value: "Failed", comment: "A title stating that we failed to add custom search engine.")
-    public static let CustomEngineFormErrorMessage = MZLocalizedString("Search.ThirdPartyEngines.FormErrorMessage", value: "Please fill all fields correctly.", comment: "A message explaining fault in custom search engine form.")
-    public static let CustomEngineDuplicateErrorTitle = MZLocalizedString("Search.ThirdPartyEngines.DuplicateErrorTitle", value: "Failed", comment: "A title stating that we failed to add custom search engine.")
-    public static let CustomEngineDuplicateErrorMessage = MZLocalizedString("Search.ThirdPartyEngines.DuplicateErrorMessage", value: "A search engine with this title or URL has already been added.", comment: "A message explaining fault in custom search engine form.")
+    public static let ThirdPartySearchEngineAdded = MZLocalizedString("Search.ThirdPartyEngines.AddSuccess", value: "Added Search engine!", comment: "The success message that appears after a user sucessfully adds a new search engine", lastEditedIn: .unknown)
+    public static let ThirdPartySearchAddTitle = MZLocalizedString("Search.ThirdPartyEngines.AddTitle", value: "Add Search Provider?", comment: "The title that asks the user to Add the search provider", lastEditedIn: .unknown)
+    public static let ThirdPartySearchAddMessage = MZLocalizedString("Search.ThirdPartyEngines.AddMessage", value: "The new search engine will appear in the quick search bar.", comment: "The message that asks the user to Add the search provider explaining where the search engine will appear", lastEditedIn: .unknown)
+    public static let ThirdPartySearchCancelButton = MZLocalizedString("Search.ThirdPartyEngines.Cancel", value: "Cancel", comment: "The cancel button if you do not want to add a search engine.", lastEditedIn: .unknown)
+    public static let ThirdPartySearchOkayButton = MZLocalizedString("Search.ThirdPartyEngines.OK", value: "OK", comment: "The confirmation button", lastEditedIn: .unknown)
+    public static let ThirdPartySearchFailedTitle = MZLocalizedString("Search.ThirdPartyEngines.FailedTitle", value: "Failed", comment: "A title explaining that we failed to add a search engine", lastEditedIn: .unknown)
+    public static let ThirdPartySearchFailedMessage = MZLocalizedString("Search.ThirdPartyEngines.FailedMessage", value: "The search provider could not be added.", comment: "A title explaining that we failed to add a search engine", lastEditedIn: .unknown)
+    public static let CustomEngineFormErrorTitle = MZLocalizedString("Search.ThirdPartyEngines.FormErrorTitle", value: "Failed", comment: "A title stating that we failed to add custom search engine.", lastEditedIn: .unknown)
+    public static let CustomEngineFormErrorMessage = MZLocalizedString("Search.ThirdPartyEngines.FormErrorMessage", value: "Please fill all fields correctly.", comment: "A message explaining fault in custom search engine form.", lastEditedIn: .unknown)
+    public static let CustomEngineDuplicateErrorTitle = MZLocalizedString("Search.ThirdPartyEngines.DuplicateErrorTitle", value: "Failed", comment: "A title stating that we failed to add custom search engine.", lastEditedIn: .unknown)
+    public static let CustomEngineDuplicateErrorMessage = MZLocalizedString("Search.ThirdPartyEngines.DuplicateErrorMessage", value: "A search engine with this title or URL has already been added.", comment: "A message explaining fault in custom search engine form.", lastEditedIn: .unknown)
 }
 
 // MARK: - Root Bookmarks folders
 extension Strings {
-    public static let BookmarksFolderTitleMobile = MZLocalizedString("Mobile Bookmarks", tableName: "Storage", comment: "The title of the folder that contains mobile bookmarks. This should match bookmarks.folder.mobile.label on Android.")
-    public static let BookmarksFolderTitleMenu = MZLocalizedString("Bookmarks Menu", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the menu. This should match bookmarks.folder.menu.label on Android.")
-    public static let BookmarksFolderTitleToolbar = MZLocalizedString("Bookmarks Toolbar", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the toolbar. This should match bookmarks.folder.toolbar.label on Android.")
-    public static let BookmarksFolderTitleUnsorted = MZLocalizedString("Unsorted Bookmarks", tableName: "Storage", comment: "The name of the folder that contains unsorted desktop bookmarks. This should match bookmarks.folder.unfiled.label on Android.")
+    public static let BookmarksFolderTitleMobile = MZLocalizedString("Mobile Bookmarks", tableName: "Storage", comment: "The title of the folder that contains mobile bookmarks. This should match bookmarks.folder.mobile.label on Android.", lastEditedIn: .unknown)
+    public static let BookmarksFolderTitleMenu = MZLocalizedString("Bookmarks Menu", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the menu. This should match bookmarks.folder.menu.label on Android.", lastEditedIn: .unknown)
+    public static let BookmarksFolderTitleToolbar = MZLocalizedString("Bookmarks Toolbar", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the toolbar. This should match bookmarks.folder.toolbar.label on Android.", lastEditedIn: .unknown)
+    public static let BookmarksFolderTitleUnsorted = MZLocalizedString("Unsorted Bookmarks", tableName: "Storage", comment: "The name of the folder that contains unsorted desktop bookmarks. This should match bookmarks.folder.unfiled.label on Android.", lastEditedIn: .unknown)
 }
 
 // MARK: - Bookmark Management
 extension Strings {
-    public static let BookmarksTitle = MZLocalizedString("Bookmarks.Title.Label", value: "Title", comment: "The label for the title of a bookmark")
-    public static let BookmarksURL = MZLocalizedString("Bookmarks.URL.Label", value: "URL", comment: "The label for the URL of a bookmark")
-    public static let BookmarksFolder = MZLocalizedString("Bookmarks.Folder.Label", value: "Folder", comment: "The label to show the location of the folder where the bookmark is located")
-    public static let BookmarksNewBookmark = MZLocalizedString("Bookmarks.NewBookmark.Label", value: "New Bookmark", comment: "The button to create a new bookmark")
-    public static let BookmarksNewFolder = MZLocalizedString("Bookmarks.NewFolder.Label", value: "New Folder", comment: "The button to create a new folder")
-    public static let BookmarksNewSeparator = MZLocalizedString("Bookmarks.NewSeparator.Label", value: "New Separator", comment: "The button to create a new separator")
-    public static let BookmarksEditBookmark = MZLocalizedString("Bookmarks.EditBookmark.Label", value: "Edit Bookmark", comment: "The button to edit a bookmark")
-    public static let BookmarksEdit = MZLocalizedString("Bookmarks.Edit.Button", value: "Edit", comment: "The button on the snackbar to edit a bookmark after adding it.")
-    public static let BookmarksEditFolder = MZLocalizedString("Bookmarks.EditFolder.Label", value: "Edit Folder", comment: "The button to edit a folder")
-    public static let BookmarksFolderName = MZLocalizedString("Bookmarks.FolderName.Label", value: "Folder Name", comment: "The label for the title of the new folder")
-    public static let BookmarksFolderLocation = MZLocalizedString("Bookmarks.FolderLocation.Label", value: "Location", comment: "The label for the location of the new folder")
-    public static let BookmarksDeleteFolderWarningTitle = MZLocalizedString("Bookmarks.DeleteFolderWarning.Title", tableName: "BookmarkPanelDeleteConfirm", value: "This folder isn’t empty.", comment: "Title of the confirmation alert when the user tries to delete a folder that still contains bookmarks and/or folders.")
-    public static let BookmarksDeleteFolderWarningDescription = MZLocalizedString("Bookmarks.DeleteFolderWarning.Description", tableName: "BookmarkPanelDeleteConfirm", value: "Are you sure you want to delete it and its contents?", comment: "Main body of the confirmation alert when the user tries to delete a folder that still contains bookmarks and/or folders.")
-    public static let BookmarksDeleteFolderCancelButtonLabel = MZLocalizedString("Bookmarks.DeleteFolderWarning.CancelButton.Label", tableName: "BookmarkPanelDeleteConfirm", value: "Cancel", comment: "Button label to cancel deletion when the user tried to delete a non-empty folder.")
-    public static let BookmarksDeleteFolderDeleteButtonLabel = MZLocalizedString("Bookmarks.DeleteFolderWarning.DeleteButton.Label", tableName: "BookmarkPanelDeleteConfirm", value: "Delete", comment: "Button label for the button that deletes a folder and all of its children.")
-    public static let BookmarksPanelEmptyStateTitle = MZLocalizedString("BookmarksPanel.EmptyState.Title", value: "Bookmarks you save will show up here.", comment: "Status label for the empty Bookmarks state.")
-    public static let BookmarksPanelDeleteTableAction = MZLocalizedString("Delete", tableName: "BookmarkPanel", comment: "Action button for deleting bookmarks in the bookmarks panel.")
-    public static let BookmarkDetailFieldTitle = MZLocalizedString("Bookmark.DetailFieldTitle.Label", value: "Title", comment: "The label for the Title field when editing a bookmark")
-    public static let BookmarkDetailFieldURL = MZLocalizedString("Bookmark.DetailFieldURL.Label", value: "URL", comment: "The label for the URL field when editing a bookmark")
-    public static let BookmarkDetailFieldsHeaderBookmarkTitle = MZLocalizedString("Bookmark.BookmarkDetail.FieldsHeader.Bookmark.Title", value: "Bookmark", comment: "The header title for the fields when editing a Bookmark")
-    public static let BookmarkDetailFieldsHeaderFolderTitle = MZLocalizedString("Bookmark.BookmarkDetail.FieldsHeader.Folder.Title", value: "Folder", comment: "The header title for the fields when editing a Folder")
+    public static let BookmarksTitle = MZLocalizedString("Bookmarks.Title.Label", value: "Title", comment: "The label for the title of a bookmark", lastEditedIn: .unknown)
+    public static let BookmarksURL = MZLocalizedString("Bookmarks.URL.Label", value: "URL", comment: "The label for the URL of a bookmark", lastEditedIn: .unknown)
+    public static let BookmarksFolder = MZLocalizedString("Bookmarks.Folder.Label", value: "Folder", comment: "The label to show the location of the folder where the bookmark is located", lastEditedIn: .unknown)
+    public static let BookmarksNewBookmark = MZLocalizedString("Bookmarks.NewBookmark.Label", value: "New Bookmark", comment: "The button to create a new bookmark", lastEditedIn: .unknown)
+    public static let BookmarksNewFolder = MZLocalizedString("Bookmarks.NewFolder.Label", value: "New Folder", comment: "The button to create a new folder", lastEditedIn: .unknown)
+    public static let BookmarksNewSeparator = MZLocalizedString("Bookmarks.NewSeparator.Label", value: "New Separator", comment: "The button to create a new separator", lastEditedIn: .unknown)
+    public static let BookmarksEditBookmark = MZLocalizedString("Bookmarks.EditBookmark.Label", value: "Edit Bookmark", comment: "The button to edit a bookmark", lastEditedIn: .unknown)
+    public static let BookmarksEdit = MZLocalizedString("Bookmarks.Edit.Button", value: "Edit", comment: "The button on the snackbar to edit a bookmark after adding it.", lastEditedIn: .unknown)
+    public static let BookmarksEditFolder = MZLocalizedString("Bookmarks.EditFolder.Label", value: "Edit Folder", comment: "The button to edit a folder", lastEditedIn: .unknown)
+    public static let BookmarksFolderName = MZLocalizedString("Bookmarks.FolderName.Label", value: "Folder Name", comment: "The label for the title of the new folder", lastEditedIn: .unknown)
+    public static let BookmarksFolderLocation = MZLocalizedString("Bookmarks.FolderLocation.Label", value: "Location", comment: "The label for the location of the new folder", lastEditedIn: .unknown)
+    public static let BookmarksDeleteFolderWarningTitle = MZLocalizedString("Bookmarks.DeleteFolderWarning.Title", tableName: "BookmarkPanelDeleteConfirm", value: "This folder isn’t empty.", comment: "Title of the confirmation alert when the user tries to delete a folder that still contains bookmarks and/or folders.", lastEditedIn: .unknown)
+    public static let BookmarksDeleteFolderWarningDescription = MZLocalizedString("Bookmarks.DeleteFolderWarning.Description", tableName: "BookmarkPanelDeleteConfirm", value: "Are you sure you want to delete it and its contents?", comment: "Main body of the confirmation alert when the user tries to delete a folder that still contains bookmarks and/or folders.", lastEditedIn: .unknown)
+    public static let BookmarksDeleteFolderCancelButtonLabel = MZLocalizedString("Bookmarks.DeleteFolderWarning.CancelButton.Label", tableName: "BookmarkPanelDeleteConfirm", value: "Cancel", comment: "Button label to cancel deletion when the user tried to delete a non-empty folder.", lastEditedIn: .unknown)
+    public static let BookmarksDeleteFolderDeleteButtonLabel = MZLocalizedString("Bookmarks.DeleteFolderWarning.DeleteButton.Label", tableName: "BookmarkPanelDeleteConfirm", value: "Delete", comment: "Button label for the button that deletes a folder and all of its children.", lastEditedIn: .unknown)
+    public static let BookmarksPanelEmptyStateTitle = MZLocalizedString("BookmarksPanel.EmptyState.Title", value: "Bookmarks you save will show up here.", comment: "Status label for the empty Bookmarks state.", lastEditedIn: .unknown)
+    public static let BookmarksPanelDeleteTableAction = MZLocalizedString("Delete", tableName: "BookmarkPanel", comment: "Action button for deleting bookmarks in the bookmarks panel.", lastEditedIn: .unknown)
+    public static let BookmarkDetailFieldTitle = MZLocalizedString("Bookmark.DetailFieldTitle.Label", value: "Title", comment: "The label for the Title field when editing a bookmark", lastEditedIn: .unknown)
+    public static let BookmarkDetailFieldURL = MZLocalizedString("Bookmark.DetailFieldURL.Label", value: "URL", comment: "The label for the URL field when editing a bookmark", lastEditedIn: .unknown)
+    public static let BookmarkDetailFieldsHeaderBookmarkTitle = MZLocalizedString("Bookmark.BookmarkDetail.FieldsHeader.Bookmark.Title", value: "Bookmark", comment: "The header title for the fields when editing a Bookmark", lastEditedIn: .unknown)
+    public static let BookmarkDetailFieldsHeaderFolderTitle = MZLocalizedString("Bookmark.BookmarkDetail.FieldsHeader.Folder.Title", value: "Folder", comment: "The header title for the fields when editing a Folder", lastEditedIn: .unknown)
 }
 
 // MARK: - Tabs Delete All Undo Toast
 extension Strings {
-    public static let TabsDeleteAllUndoTitle = MZLocalizedString("Tabs.DeleteAllUndo.Title", value: "%d tab(s) closed", comment: "The label indicating that all the tabs were closed")
-    public static let TabsDeleteAllUndoAction = MZLocalizedString("Tabs.DeleteAllUndo.Button", value: "Undo", comment: "The button to undo the delete all tabs")
-    public static let TabSearchPlaceholderText = MZLocalizedString("Tabs.Search.PlaceholderText", value: "Search Tabs", comment: "The placeholder text for the tab search bar")
+    public static let TabsDeleteAllUndoTitle = MZLocalizedString("Tabs.DeleteAllUndo.Title", value: "%d tab(s) closed", comment: "The label indicating that all the tabs were closed", lastEditedIn: .unknown)
+    public static let TabsDeleteAllUndoAction = MZLocalizedString("Tabs.DeleteAllUndo.Button", value: "Undo", comment: "The button to undo the delete all tabs", lastEditedIn: .unknown)
+    public static let TabSearchPlaceholderText = MZLocalizedString("Tabs.Search.PlaceholderText", value: "Search Tabs", comment: "The placeholder text for the tab search bar", lastEditedIn: .unknown)
 }
 
 // MARK: - Tab tray (chronological tabs)
 extension Strings {
-    public static let TabTrayV2Title = MZLocalizedString("TabTray.Title", value: "Open Tabs", comment: "The title for the tab tray")
-    public static let TabTrayV2TodayHeader = MZLocalizedString("TabTray.Today.Header", value: "Today", comment: "The section header for tabs opened today")
-    public static let TabTrayV2YesterdayHeader = MZLocalizedString("TabTray.Yesterday.Header", value: "Yesterday", comment: "The section header for tabs opened yesterday")
-    public static let TabTrayV2LastWeekHeader = MZLocalizedString("TabTray.LastWeek.Header", value: "Last Week", comment: "The section header for tabs opened last week")
-    public static let TabTrayV2OlderHeader = MZLocalizedString("TabTray.Older.Header", value: "Older", comment: "The section header for tabs opened before last week")
-    public static let TabTraySwipeMenuMore = MZLocalizedString("TabTray.SwipeMenu.More", value: "More", comment: "The button title to see more options to perform on the tab.")
-    public static let TabTrayMoreMenuCopy = MZLocalizedString("TabTray.MoreMenu.Copy", value: "Copy", comment: "The title on the button to copy the tab address.")
-    public static let TabTrayV2PrivateTitle = MZLocalizedString("TabTray.PrivateTitle", value: "Private Tabs", comment: "The title for the tab tray in private mode")
+    public static let TabTrayV2Title = MZLocalizedString("TabTray.Title", value: "Open Tabs", comment: "The title for the tab tray", lastEditedIn: .unknown)
+    public static let TabTrayV2TodayHeader = MZLocalizedString("TabTray.Today.Header", value: "Today", comment: "The section header for tabs opened today", lastEditedIn: .unknown)
+    public static let TabTrayV2YesterdayHeader = MZLocalizedString("TabTray.Yesterday.Header", value: "Yesterday", comment: "The section header for tabs opened yesterday", lastEditedIn: .unknown)
+    public static let TabTrayV2LastWeekHeader = MZLocalizedString("TabTray.LastWeek.Header", value: "Last Week", comment: "The section header for tabs opened last week", lastEditedIn: .unknown)
+    public static let TabTrayV2OlderHeader = MZLocalizedString("TabTray.Older.Header", value: "Older", comment: "The section header for tabs opened before last week", lastEditedIn: .unknown)
+    public static let TabTraySwipeMenuMore = MZLocalizedString("TabTray.SwipeMenu.More", value: "More", comment: "The button title to see more options to perform on the tab.", lastEditedIn: .unknown)
+    public static let TabTrayMoreMenuCopy = MZLocalizedString("TabTray.MoreMenu.Copy", value: "Copy", comment: "The title on the button to copy the tab address.", lastEditedIn: .unknown)
+    public static let TabTrayV2PrivateTitle = MZLocalizedString("TabTray.PrivateTitle", value: "Private Tabs", comment: "The title for the tab tray in private mode", lastEditedIn: .unknown)
 
     // Segmented Control tites for iPad
-    public static let TabTraySegmentedControlTitlesTabs = MZLocalizedString("TabTray.SegmentedControlTitles.Tabs", value: "Tabs", comment: "The title on the button to look at regular tabs.")
-    public static let TabTraySegmentedControlTitlesPrivateTabs = MZLocalizedString("TabTray.SegmentedControlTitles.PrivateTabs", value: "Private", comment: "The title on the button to look at private tabs.")
-    public static let TabTraySegmentedControlTitlesSyncedTabs = MZLocalizedString("TabTray.SegmentedControlTitles.SyncedTabs", value: "Synced", comment: "The title on the button to look at synced tabs.")
+    public static let TabTraySegmentedControlTitlesTabs = MZLocalizedString("TabTray.SegmentedControlTitles.Tabs", value: "Tabs", comment: "The title on the button to look at regular tabs.", lastEditedIn: .unknown)
+    public static let TabTraySegmentedControlTitlesPrivateTabs = MZLocalizedString("TabTray.SegmentedControlTitles.PrivateTabs", value: "Private", comment: "The title on the button to look at private tabs.", lastEditedIn: .unknown)
+    public static let TabTraySegmentedControlTitlesSyncedTabs = MZLocalizedString("TabTray.SegmentedControlTitles.SyncedTabs", value: "Synced", comment: "The title on the button to look at synced tabs.", lastEditedIn: .unknown)
 }
 
 // MARK: - Clipboard Toast
 extension Strings {
-    public static let GoToCopiedLink = MZLocalizedString("ClipboardToast.GoToCopiedLink.Title", value: "Go to copied link?", comment: "Message displayed when the user has a copied link on the clipboard")
-    public static let GoButtonTittle = MZLocalizedString("ClipboardToast.GoToCopiedLink.Button", value: "Go", comment: "The button to open a new tab with the copied link")
+    public static let GoToCopiedLink = MZLocalizedString("ClipboardToast.GoToCopiedLink.Title", value: "Go to copied link?", comment: "Message displayed when the user has a copied link on the clipboard", lastEditedIn: .unknown)
+    public static let GoButtonTittle = MZLocalizedString("ClipboardToast.GoToCopiedLink.Button", value: "Go", comment: "The button to open a new tab with the copied link", lastEditedIn: .unknown)
 
-    public static let SettingsOfferClipboardBarTitle = MZLocalizedString("Settings.OfferClipboardBar.Title", value: "Offer to Open Copied Links", comment: "Title of setting to enable the Go to Copied URL feature. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349")
-    public static let SettingsOfferClipboardBarStatus = MZLocalizedString("Settings.OfferClipboardBar.Status", value: "When Opening Firefox", comment: "Description displayed under the ”Offer to Open Copied Link” option. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349")
+    public static let SettingsOfferClipboardBarTitle = MZLocalizedString("Settings.OfferClipboardBar.Title", value: "Offer to Open Copied Links", comment: "Title of setting to enable the Go to Copied URL feature. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349", lastEditedIn: .unknown)
+    public static let SettingsOfferClipboardBarStatus = MZLocalizedString("Settings.OfferClipboardBar.Status", value: "When Opening Firefox", comment: "Description displayed under the ”Offer to Open Copied Link” option. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349", lastEditedIn: .unknown)
 }
 
 // MARK: - Link Previews
 extension Strings {
-    public static let SettingsShowLinkPreviewsTitle = MZLocalizedString("Settings.ShowLinkPreviews.Title", value: "Show Link Previews", comment: "Title of setting to enable link previews when long-pressing links.")
-    public static let SettingsShowLinkPreviewsStatus = MZLocalizedString("Settings.ShowLinkPreviews.Status", value: "When Long-pressing Links", comment: "Description displayed under the ”Show Link Previews” option")
+    public static let SettingsShowLinkPreviewsTitle = MZLocalizedString("Settings.ShowLinkPreviews.Title", value: "Show Link Previews", comment: "Title of setting to enable link previews when long-pressing links.", lastEditedIn: .unknown)
+    public static let SettingsShowLinkPreviewsStatus = MZLocalizedString("Settings.ShowLinkPreviews.Status", value: "When Long-pressing Links", comment: "Description displayed under the ”Show Link Previews” option", lastEditedIn: .unknown)
 }
 
 // MARK: - Errors
 extension Strings {
-    public static let UnableToDownloadError = MZLocalizedString("Downloads.Error.Message", value: "Downloads aren’t supported in Firefox yet.", comment: "The message displayed to a user when they try and perform the download of an asset that Firefox cannot currently handle.")
-    public static let UnableToAddPassErrorTitle = MZLocalizedString("AddPass.Error.Title", value: "Failed to Add Pass", comment: "Title of the 'Add Pass Failed' alert. See https://support.apple.com/HT204003 for context on Wallet.")
-    public static let UnableToAddPassErrorMessage = MZLocalizedString("AddPass.Error.Message", value: "An error occured while adding the pass to Wallet. Please try again later.", comment: "Text of the 'Add Pass Failed' alert.  See https://support.apple.com/HT204003 for context on Wallet.")
-    public static let UnableToAddPassErrorDismiss = MZLocalizedString("AddPass.Error.Dismiss", value: "OK", comment: "Button to dismiss the 'Add Pass Failed' alert.  See https://support.apple.com/HT204003 for context on Wallet.")
-    public static let UnableToOpenURLError = MZLocalizedString("OpenURL.Error.Message", value: "Firefox cannot open the page because it has an invalid address.", comment: "The message displayed to a user when they try to open a URL that cannot be handled by Firefox, or any external app.")
-    public static let UnableToOpenURLErrorTitle = MZLocalizedString("OpenURL.Error.Title", value: "Cannot Open Page", comment: "Title of the message shown when the user attempts to navigate to an invalid link.")
+    public static let UnableToDownloadError = MZLocalizedString("Downloads.Error.Message", value: "Downloads aren’t supported in Firefox yet.", comment: "The message displayed to a user when they try and perform the download of an asset that Firefox cannot currently handle.", lastEditedIn: .unknown)
+    public static let UnableToAddPassErrorTitle = MZLocalizedString("AddPass.Error.Title", value: "Failed to Add Pass", comment: "Title of the 'Add Pass Failed' alert. See https://support.apple.com/HT204003 for context on Wallet.", lastEditedIn: .unknown)
+    public static let UnableToAddPassErrorMessage = MZLocalizedString("AddPass.Error.Message", value: "An error occured while adding the pass to Wallet. Please try again later.", comment: "Text of the 'Add Pass Failed' alert.  See https://support.apple.com/HT204003 for context on Wallet.", lastEditedIn: .unknown)
+    public static let UnableToAddPassErrorDismiss = MZLocalizedString("AddPass.Error.Dismiss", value: "OK", comment: "Button to dismiss the 'Add Pass Failed' alert.  See https://support.apple.com/HT204003 for context on Wallet.", lastEditedIn: .unknown)
+    public static let UnableToOpenURLError = MZLocalizedString("OpenURL.Error.Message", value: "Firefox cannot open the page because it has an invalid address.", comment: "The message displayed to a user when they try to open a URL that cannot be handled by Firefox, or any external app.", lastEditedIn: .unknown)
+    public static let UnableToOpenURLErrorTitle = MZLocalizedString("OpenURL.Error.Title", value: "Cannot Open Page", comment: "Title of the message shown when the user attempts to navigate to an invalid link.", lastEditedIn: .unknown)
 }
 
 // MARK: - Download Helper
 extension Strings {
-    public static let OpenInDownloadHelperAlertDownloadNow = MZLocalizedString("Downloads.Alert.DownloadNow", value: "Download Now", comment: "The label of the button the user will press to start downloading a file")
-    public static let DownloadsButtonTitle = MZLocalizedString("Downloads.Toast.GoToDownloads.Button", value: "Downloads", comment: "The button to open a new tab with the Downloads home panel")
-    public static let CancelDownloadDialogTitle = MZLocalizedString("Downloads.CancelDialog.Title", value: "Cancel Download", comment: "Alert dialog title when the user taps the cancel download icon.")
-    public static let CancelDownloadDialogMessage = MZLocalizedString("Downloads.CancelDialog.Message", value: "Are you sure you want to cancel this download?", comment: "Alert dialog body when the user taps the cancel download icon.")
-    public static let CancelDownloadDialogResume = MZLocalizedString("Downloads.CancelDialog.Resume", value: "Resume", comment: "Button declining the cancellation of the download.")
-    public static let CancelDownloadDialogCancel = MZLocalizedString("Downloads.CancelDialog.Cancel", value: "Cancel", comment: "Button confirming the cancellation of the download.")
-    public static let DownloadCancelledToastLabelText = MZLocalizedString("Downloads.Toast.Cancelled.LabelText", value: "Download Cancelled", comment: "The label text in the Download Cancelled toast for showing confirmation that the download was cancelled.")
-    public static let DownloadFailedToastLabelText = MZLocalizedString("Downloads.Toast.Failed.LabelText", value: "Download Failed", comment: "The label text in the Download Failed toast for showing confirmation that the download has failed.")
-    public static let DownloadFailedToastButtonTitled = MZLocalizedString("Downloads.Toast.Failed.RetryButton", value: "Retry", comment: "The button to retry a failed download from the Download Failed toast.")
-    public static let DownloadMultipleFilesToastDescriptionText = MZLocalizedString("Downloads.Toast.MultipleFiles.DescriptionText", value: "1 of %d files", comment: "The description text in the Download progress toast for showing the number of files when multiple files are downloading.")
-    public static let DownloadProgressToastDescriptionText = MZLocalizedString("Downloads.Toast.Progress.DescriptionText", value: "%1$@/%2$@", comment: "The description text in the Download progress toast for showing the downloaded file size (1$) out of the total expected file size (2$).")
-    public static let DownloadMultipleFilesAndProgressToastDescriptionText = MZLocalizedString("Downloads.Toast.MultipleFilesAndProgress.DescriptionText", value: "%1$@ %2$@", comment: "The description text in the Download progress toast for showing the number of files (1$) and download progress (2$). This string only consists of two placeholders for purposes of displaying two other strings side-by-side where 1$ is Downloads.Toast.MultipleFiles.DescriptionText and 2$ is Downloads.Toast.Progress.DescriptionText. This string should only consist of the two placeholders side-by-side separated by a single space and 1$ should come before 2$ everywhere except for right-to-left locales.")
+    public static let OpenInDownloadHelperAlertDownloadNow = MZLocalizedString("Downloads.Alert.DownloadNow", value: "Download Now", comment: "The label of the button the user will press to start downloading a file", lastEditedIn: .unknown)
+    public static let DownloadsButtonTitle = MZLocalizedString("Downloads.Toast.GoToDownloads.Button", value: "Downloads", comment: "The button to open a new tab with the Downloads home panel", lastEditedIn: .unknown)
+    public static let CancelDownloadDialogTitle = MZLocalizedString("Downloads.CancelDialog.Title", value: "Cancel Download", comment: "Alert dialog title when the user taps the cancel download icon.", lastEditedIn: .unknown)
+    public static let CancelDownloadDialogMessage = MZLocalizedString("Downloads.CancelDialog.Message", value: "Are you sure you want to cancel this download?", comment: "Alert dialog body when the user taps the cancel download icon.", lastEditedIn: .unknown)
+    public static let CancelDownloadDialogResume = MZLocalizedString("Downloads.CancelDialog.Resume", value: "Resume", comment: "Button declining the cancellation of the download.", lastEditedIn: .unknown)
+    public static let CancelDownloadDialogCancel = MZLocalizedString("Downloads.CancelDialog.Cancel", value: "Cancel", comment: "Button confirming the cancellation of the download.", lastEditedIn: .unknown)
+    public static let DownloadCancelledToastLabelText = MZLocalizedString("Downloads.Toast.Cancelled.LabelText", value: "Download Cancelled", comment: "The label text in the Download Cancelled toast for showing confirmation that the download was cancelled.", lastEditedIn: .unknown)
+    public static let DownloadFailedToastLabelText = MZLocalizedString("Downloads.Toast.Failed.LabelText", value: "Download Failed", comment: "The label text in the Download Failed toast for showing confirmation that the download has failed.", lastEditedIn: .unknown)
+    public static let DownloadFailedToastButtonTitled = MZLocalizedString("Downloads.Toast.Failed.RetryButton", value: "Retry", comment: "The button to retry a failed download from the Download Failed toast.", lastEditedIn: .unknown)
+    public static let DownloadMultipleFilesToastDescriptionText = MZLocalizedString("Downloads.Toast.MultipleFiles.DescriptionText", value: "1 of %d files", comment: "The description text in the Download progress toast for showing the number of files when multiple files are downloading.", lastEditedIn: .unknown)
+    public static let DownloadProgressToastDescriptionText = MZLocalizedString("Downloads.Toast.Progress.DescriptionText", value: "%1$@/%2$@", comment: "The description text in the Download progress toast for showing the downloaded file size (1$) out of the total expected file size (2$).", lastEditedIn: .unknown)
+    public static let DownloadMultipleFilesAndProgressToastDescriptionText = MZLocalizedString("Downloads.Toast.MultipleFilesAndProgress.DescriptionText", value: "%1$@ %2$@", comment: "The description text in the Download progress toast for showing the number of files (1$) and download progress (2$). This string only consists of two placeholders for purposes of displaying two other strings side-by-side where 1$ is Downloads.Toast.MultipleFiles.DescriptionText and 2$ is Downloads.Toast.Progress.DescriptionText. This string should only consist of the two placeholders side-by-side separated by a single space and 1$ should come before 2$ everywhere except for right-to-left locales.", lastEditedIn: .unknown)
 }
 
 // MARK: - Add Custom Search Engine
 extension Strings {
-    public static let SettingsAddCustomEngine = MZLocalizedString("Settings.AddCustomEngine", value: "Add Search Engine", comment: "The button text in Search Settings that opens the Custom Search Engine view.")
-    public static let SettingsAddCustomEngineTitle = MZLocalizedString("Settings.AddCustomEngine.Title", value: "Add Search Engine", comment: "The title of the  Custom Search Engine view.")
-    public static let SettingsAddCustomEngineTitleLabel = MZLocalizedString("Settings.AddCustomEngine.TitleLabel", value: "Title", comment: "The title for the field which sets the title for a custom search engine.")
-    public static let SettingsAddCustomEngineURLLabel = MZLocalizedString("Settings.AddCustomEngine.URLLabel", value: "URL", comment: "The title for URL Field")
-    public static let SettingsAddCustomEngineTitlePlaceholder = MZLocalizedString("Settings.AddCustomEngine.TitlePlaceholder", value: "Search Engine", comment: "The placeholder for Title Field when saving a custom search engine.")
-    public static let SettingsAddCustomEngineURLPlaceholder = MZLocalizedString("Settings.AddCustomEngine.URLPlaceholder", value: "URL (Replace Query with %s)", comment: "The placeholder for URL Field when saving a custom search engine")
-    public static let SettingsAddCustomEngineSaveButtonText = MZLocalizedString("Settings.AddCustomEngine.SaveButtonText", value: "Save", comment: "The text on the Save button when saving a custom search engine")
+    public static let SettingsAddCustomEngine = MZLocalizedString("Settings.AddCustomEngine", value: "Add Search Engine", comment: "The button text in Search Settings that opens the Custom Search Engine view.", lastEditedIn: .unknown)
+    public static let SettingsAddCustomEngineTitle = MZLocalizedString("Settings.AddCustomEngine.Title", value: "Add Search Engine", comment: "The title of the  Custom Search Engine view.", lastEditedIn: .unknown)
+    public static let SettingsAddCustomEngineTitleLabel = MZLocalizedString("Settings.AddCustomEngine.TitleLabel", value: "Title", comment: "The title for the field which sets the title for a custom search engine.", lastEditedIn: .unknown)
+    public static let SettingsAddCustomEngineURLLabel = MZLocalizedString("Settings.AddCustomEngine.URLLabel", value: "URL", comment: "The title for URL Field", lastEditedIn: .unknown)
+    public static let SettingsAddCustomEngineTitlePlaceholder = MZLocalizedString("Settings.AddCustomEngine.TitlePlaceholder", value: "Search Engine", comment: "The placeholder for Title Field when saving a custom search engine.", lastEditedIn: .unknown)
+    public static let SettingsAddCustomEngineURLPlaceholder = MZLocalizedString("Settings.AddCustomEngine.URLPlaceholder", value: "URL (Replace Query with %s)", comment: "The placeholder for URL Field when saving a custom search engine", lastEditedIn: .unknown)
+    public static let SettingsAddCustomEngineSaveButtonText = MZLocalizedString("Settings.AddCustomEngine.SaveButtonText", value: "Save", comment: "The text on the Save button when saving a custom search engine", lastEditedIn: .unknown)
 }
 
 // MARK: - Context menu ButtonToast instances.
 extension Strings {
-    public static let ContextMenuButtonToastNewTabOpenedLabelText = MZLocalizedString("ContextMenu.ButtonToast.NewTabOpened.LabelText", value: "New Tab opened", comment: "The label text in the Button Toast for switching to a fresh New Tab.")
-    public static let ContextMenuButtonToastNewTabOpenedButtonText = MZLocalizedString("ContextMenu.ButtonToast.NewTabOpened.ButtonText", value: "Switch", comment: "The button text in the Button Toast for switching to a fresh New Tab.")
-    public static let ContextMenuButtonToastNewPrivateTabOpenedLabelText = MZLocalizedString("ContextMenu.ButtonToast.NewPrivateTabOpened.LabelText", value: "New Private Tab opened", comment: "The label text in the Button Toast for switching to a fresh New Private Tab.")
-    public static let ContextMenuButtonToastNewPrivateTabOpenedButtonText = MZLocalizedString("ContextMenu.ButtonToast.NewPrivateTabOpened.ButtonText", value: "Switch", comment: "The button text in the Button Toast for switching to a fresh New Private Tab.")
+    public static let ContextMenuButtonToastNewTabOpenedLabelText = MZLocalizedString("ContextMenu.ButtonToast.NewTabOpened.LabelText", value: "New Tab opened", comment: "The label text in the Button Toast for switching to a fresh New Tab.", lastEditedIn: .unknown)
+    public static let ContextMenuButtonToastNewTabOpenedButtonText = MZLocalizedString("ContextMenu.ButtonToast.NewTabOpened.ButtonText", value: "Switch", comment: "The button text in the Button Toast for switching to a fresh New Tab.", lastEditedIn: .unknown)
+    public static let ContextMenuButtonToastNewPrivateTabOpenedLabelText = MZLocalizedString("ContextMenu.ButtonToast.NewPrivateTabOpened.LabelText", value: "New Private Tab opened", comment: "The label text in the Button Toast for switching to a fresh New Private Tab.", lastEditedIn: .unknown)
+    public static let ContextMenuButtonToastNewPrivateTabOpenedButtonText = MZLocalizedString("ContextMenu.ButtonToast.NewPrivateTabOpened.ButtonText", value: "Switch", comment: "The button text in the Button Toast for switching to a fresh New Private Tab.", lastEditedIn: .unknown)
 }
 
 // MARK: - Page context menu items (i.e. links and images).
 extension Strings {
-    public static let ContextMenuOpenInNewTab = MZLocalizedString("ContextMenu.OpenInNewTabButtonTitle", value: "Open in New Tab", comment: "Context menu item for opening a link in a new tab")
-    public static let ContextMenuOpenInNewPrivateTab = MZLocalizedString("ContextMenu.OpenInNewPrivateTabButtonTitle", tableName: "PrivateBrowsing", value: "Open in New Private Tab", comment: "Context menu option for opening a link in a new private tab")
+    public static let ContextMenuOpenInNewTab = MZLocalizedString("ContextMenu.OpenInNewTabButtonTitle", value: "Open in New Tab", comment: "Context menu item for opening a link in a new tab", lastEditedIn: .unknown)
+    public static let ContextMenuOpenInNewPrivateTab = MZLocalizedString("ContextMenu.OpenInNewPrivateTabButtonTitle", tableName: "PrivateBrowsing", value: "Open in New Private Tab", comment: "Context menu option for opening a link in a new private tab", lastEditedIn: .unknown)
 
-    public static let ContextMenuOpenLinkInNewTab = MZLocalizedString("ContextMenu.OpenLinkInNewTabButtonTitle", value: "Open Link in New Tab", comment: "Context menu item for opening a link in a new tab")
-    public static let ContextMenuOpenLinkInNewPrivateTab = MZLocalizedString("ContextMenu.OpenLinkInNewPrivateTabButtonTitle", value: "Open Link in New Private Tab", comment: "Context menu item for opening a link in a new private tab")
+    public static let ContextMenuOpenLinkInNewTab = MZLocalizedString("ContextMenu.OpenLinkInNewTabButtonTitle", value: "Open Link in New Tab", comment: "Context menu item for opening a link in a new tab", lastEditedIn: .unknown)
+    public static let ContextMenuOpenLinkInNewPrivateTab = MZLocalizedString("ContextMenu.OpenLinkInNewPrivateTabButtonTitle", value: "Open Link in New Private Tab", comment: "Context menu item for opening a link in a new private tab", lastEditedIn: .unknown)
 
-    public static let ContextMenuBookmarkLink = MZLocalizedString("ContextMenu.BookmarkLinkButtonTitle", value: "Bookmark Link", comment: "Context menu item for bookmarking a link URL")
-    public static let ContextMenuDownloadLink = MZLocalizedString("ContextMenu.DownloadLinkButtonTitle", value: "Download Link", comment: "Context menu item for downloading a link URL")
-    public static let ContextMenuCopyLink = MZLocalizedString("ContextMenu.CopyLinkButtonTitle", value: "Copy Link", comment: "Context menu item for copying a link URL to the clipboard")
-    public static let ContextMenuShareLink = MZLocalizedString("ContextMenu.ShareLinkButtonTitle", value: "Share Link", comment: "Context menu item for sharing a link URL")
-    public static let ContextMenuSaveImage = MZLocalizedString("ContextMenu.SaveImageButtonTitle", value: "Save Image", comment: "Context menu item for saving an image")
-    public static let ContextMenuCopyImage = MZLocalizedString("ContextMenu.CopyImageButtonTitle", value: "Copy Image", comment: "Context menu item for copying an image to the clipboard")
-    public static let ContextMenuCopyImageLink = MZLocalizedString("ContextMenu.CopyImageLinkButtonTitle", value: "Copy Image Link", comment: "Context menu item for copying an image URL to the clipboard")
+    public static let ContextMenuBookmarkLink = MZLocalizedString("ContextMenu.BookmarkLinkButtonTitle", value: "Bookmark Link", comment: "Context menu item for bookmarking a link URL", lastEditedIn: .unknown)
+    public static let ContextMenuDownloadLink = MZLocalizedString("ContextMenu.DownloadLinkButtonTitle", value: "Download Link", comment: "Context menu item for downloading a link URL", lastEditedIn: .unknown)
+    public static let ContextMenuCopyLink = MZLocalizedString("ContextMenu.CopyLinkButtonTitle", value: "Copy Link", comment: "Context menu item for copying a link URL to the clipboard", lastEditedIn: .unknown)
+    public static let ContextMenuShareLink = MZLocalizedString("ContextMenu.ShareLinkButtonTitle", value: "Share Link", comment: "Context menu item for sharing a link URL", lastEditedIn: .unknown)
+    public static let ContextMenuSaveImage = MZLocalizedString("ContextMenu.SaveImageButtonTitle", value: "Save Image", comment: "Context menu item for saving an image", lastEditedIn: .unknown)
+    public static let ContextMenuCopyImage = MZLocalizedString("ContextMenu.CopyImageButtonTitle", value: "Copy Image", comment: "Context menu item for copying an image to the clipboard", lastEditedIn: .unknown)
+    public static let ContextMenuCopyImageLink = MZLocalizedString("ContextMenu.CopyImageLinkButtonTitle", value: "Copy Image Link", comment: "Context menu item for copying an image URL to the clipboard", lastEditedIn: .unknown)
 }
 
 // MARK: - Photo Library access
 extension Strings {
-    public static let PhotoLibraryFirefoxWouldLikeAccessTitle = MZLocalizedString("PhotoLibrary.FirefoxWouldLikeAccessTitle", value: "Firefox would like to access your Photos", comment: "See http://mzl.la/1G7uHo7")
-    public static let PhotoLibraryFirefoxWouldLikeAccessMessage = MZLocalizedString("PhotoLibrary.FirefoxWouldLikeAccessMessage", value: "This allows you to save the image to your Camera Roll.", comment: "See http://mzl.la/1G7uHo7")
+    public static let PhotoLibraryFirefoxWouldLikeAccessTitle = MZLocalizedString("PhotoLibrary.FirefoxWouldLikeAccessTitle", value: "Firefox would like to access your Photos", comment: "See http://mzl.la/1G7uHo7", lastEditedIn: .unknown)
+    public static let PhotoLibraryFirefoxWouldLikeAccessMessage = MZLocalizedString("PhotoLibrary.FirefoxWouldLikeAccessMessage", value: "This allows you to save the image to your Camera Roll.", comment: "See http://mzl.la/1G7uHo7", lastEditedIn: .unknown)
 }
 
 // MARK: - Sent tabs notifications
 // These are displayed when the app is backgrounded or the device is locked.
 extension Strings {
     // zero tabs
-    public static let SentTab_NoTabArrivingNotification_title = MZLocalizedString("SentTab.NoTabArrivingNotification.title", value: "Firefox Sync", comment: "Title of notification received after a spurious message from FxA has been received.")
+    public static let SentTab_NoTabArrivingNotification_title = MZLocalizedString("SentTab.NoTabArrivingNotification.title", value: "Firefox Sync", comment: "Title of notification received after a spurious message from FxA has been received.", lastEditedIn: .unknown)
     public static let SentTab_NoTabArrivingNotification_body =
-        MZLocalizedString("SentTab.NoTabArrivingNotification.body", value: "Tap to begin", comment: "Body of notification received after a spurious message from FxA has been received.")
+        MZLocalizedString("SentTab.NoTabArrivingNotification.body", value: "Tap to begin", comment: "Body of notification received after a spurious message from FxA has been received.", lastEditedIn: .unknown)
 
     // one or more tabs
-    public static let SentTab_TabArrivingNotification_NoDevice_title = MZLocalizedString("SentTab_TabArrivingNotification_NoDevice_title", value: "Tab received", comment: "Title of notification shown when the device is sent one or more tabs from an unnamed device.")
-    public static let SentTab_TabArrivingNotification_NoDevice_body = MZLocalizedString("SentTab_TabArrivingNotification_NoDevice_body", value: "New tab arrived from another device.", comment: "Body of notification shown when the device is sent one or more tabs from an unnamed device.")
-    public static let SentTab_TabArrivingNotification_WithDevice_title = MZLocalizedString("SentTab_TabArrivingNotification_WithDevice_title", value: "Tab received from %@", comment: "Title of notification shown when the device is sent one or more tabs from the named device. %@ is the placeholder for the device name. This device name will be localized by that device.")
-    public static let SentTab_TabArrivingNotification_WithDevice_body = MZLocalizedString("SentTab_TabArrivingNotification_WithDevice_body", value: "New tab arrived in %@", comment: "Body of notification shown when the device is sent one or more tabs from the named device. %@ is the placeholder for the app name.")
+    public static let SentTab_TabArrivingNotification_NoDevice_title = MZLocalizedString("SentTab_TabArrivingNotification_NoDevice_title", value: "Tab received", comment: "Title of notification shown when the device is sent one or more tabs from an unnamed device.", lastEditedIn: .unknown)
+    public static let SentTab_TabArrivingNotification_NoDevice_body = MZLocalizedString("SentTab_TabArrivingNotification_NoDevice_body", value: "New tab arrived from another device.", comment: "Body of notification shown when the device is sent one or more tabs from an unnamed device.", lastEditedIn: .unknown)
+    public static let SentTab_TabArrivingNotification_WithDevice_title = MZLocalizedString("SentTab_TabArrivingNotification_WithDevice_title", value: "Tab received from %@", comment: "Title of notification shown when the device is sent one or more tabs from the named device. %@ is the placeholder for the device name. This device name will be localized by that device.", lastEditedIn: .unknown)
+    public static let SentTab_TabArrivingNotification_WithDevice_body = MZLocalizedString("SentTab_TabArrivingNotification_WithDevice_body", value: "New tab arrived in %@", comment: "Body of notification shown when the device is sent one or more tabs from the named device. %@ is the placeholder for the app name.", lastEditedIn: .unknown)
 
     // Notification Actions
-    public static let SentTabViewActionTitle = MZLocalizedString("SentTab.ViewAction.title", value: "View", comment: "Label for an action used to view one or more tabs from a notification.")
-    public static let SentTabBookmarkActionTitle = MZLocalizedString("SentTab.BookmarkAction.title", value: "Bookmark", comment: "Label for an action used to bookmark one or more tabs from a notification.")
-    public static let SentTabAddToReadingListActionTitle = MZLocalizedString("SentTab.AddToReadingListAction.Title", value: "Add to Reading List", comment: "Label for an action used to add one or more tabs recieved from a notification to the reading list.")
+    public static let SentTabViewActionTitle = MZLocalizedString("SentTab.ViewAction.title", value: "View", comment: "Label for an action used to view one or more tabs from a notification.", lastEditedIn: .unknown)
+    public static let SentTabBookmarkActionTitle = MZLocalizedString("SentTab.BookmarkAction.title", value: "Bookmark", comment: "Label for an action used to bookmark one or more tabs from a notification.", lastEditedIn: .unknown)
+    public static let SentTabAddToReadingListActionTitle = MZLocalizedString("SentTab.AddToReadingListAction.Title", value: "Add to Reading List", comment: "Label for an action used to add one or more tabs recieved from a notification to the reading list.", lastEditedIn: .unknown)
 }
 
 // MARK: - Additional messages sent via Push from FxA
 extension Strings {
-    public static let FxAPush_DeviceDisconnected_ThisDevice_title = MZLocalizedString("FxAPush_DeviceDisconnected_ThisDevice_title", value: "Sync Disconnected", comment: "Title of a notification displayed when this device has been disconnected by another device.")
-    public static let FxAPush_DeviceDisconnected_ThisDevice_body = MZLocalizedString("FxAPush_DeviceDisconnected_ThisDevice_body", value: "This device has been successfully disconnected from Firefox Sync.", comment: "Body of a notification displayed when this device has been disconnected from FxA by another device.")
-    public static let FxAPush_DeviceDisconnected_title = MZLocalizedString("FxAPush_DeviceDisconnected_title", value: "Sync Disconnected", comment: "Title of a notification displayed when named device has been disconnected from FxA.")
-    public static let FxAPush_DeviceDisconnected_body = MZLocalizedString("FxAPush_DeviceDisconnected_body", value: "%@ has been successfully disconnected.", comment: "Body of a notification displayed when named device has been disconnected from FxA. %@ refers to the name of the disconnected device.")
+    public static let FxAPush_DeviceDisconnected_ThisDevice_title = MZLocalizedString("FxAPush_DeviceDisconnected_ThisDevice_title", value: "Sync Disconnected", comment: "Title of a notification displayed when this device has been disconnected by another device.", lastEditedIn: .unknown)
+    public static let FxAPush_DeviceDisconnected_ThisDevice_body = MZLocalizedString("FxAPush_DeviceDisconnected_ThisDevice_body", value: "This device has been successfully disconnected from Firefox Sync.", comment: "Body of a notification displayed when this device has been disconnected from FxA by another device.", lastEditedIn: .unknown)
+    public static let FxAPush_DeviceDisconnected_title = MZLocalizedString("FxAPush_DeviceDisconnected_title", value: "Sync Disconnected", comment: "Title of a notification displayed when named device has been disconnected from FxA.", lastEditedIn: .unknown)
+    public static let FxAPush_DeviceDisconnected_body = MZLocalizedString("FxAPush_DeviceDisconnected_body", value: "%@ has been successfully disconnected.", comment: "Body of a notification displayed when named device has been disconnected from FxA. %@ refers to the name of the disconnected device.", lastEditedIn: .unknown)
 
-    public static let FxAPush_DeviceDisconnected_UnknownDevice_body = MZLocalizedString("FxAPush_DeviceDisconnected_UnknownDevice_body", value: "A device has disconnected from Firefox Sync", comment: "Body of a notification displayed when unnamed device has been disconnected from FxA.")
+    public static let FxAPush_DeviceDisconnected_UnknownDevice_body = MZLocalizedString("FxAPush_DeviceDisconnected_UnknownDevice_body", value: "A device has disconnected from Firefox Sync", comment: "Body of a notification displayed when unnamed device has been disconnected from FxA.", lastEditedIn: .unknown)
 
-    public static let FxAPush_DeviceConnected_title = MZLocalizedString("FxAPush_DeviceConnected_title", value: "Sync Connected", comment: "Title of a notification displayed when another device has connected to FxA.")
-    public static let FxAPush_DeviceConnected_body = MZLocalizedString("FxAPush_DeviceConnected_body", value: "Firefox Sync has connected to %@", comment: "Title of a notification displayed when another device has connected to FxA. %@ refers to the name of the newly connected device.")
+    public static let FxAPush_DeviceConnected_title = MZLocalizedString("FxAPush_DeviceConnected_title", value: "Sync Connected", comment: "Title of a notification displayed when another device has connected to FxA.", lastEditedIn: .unknown)
+    public static let FxAPush_DeviceConnected_body = MZLocalizedString("FxAPush_DeviceConnected_body", value: "Firefox Sync has connected to %@", comment: "Title of a notification displayed when another device has connected to FxA. %@ refers to the name of the newly connected device.", lastEditedIn: .unknown)
 }
 
 // MARK: - Reader Mode
 extension Strings {
-    public static let ReaderModeAvailableVoiceOverAnnouncement = MZLocalizedString("ReaderMode.Available.VoiceOverAnnouncement", value: "Reader Mode available", comment: "Accessibility message e.g. spoken by VoiceOver when Reader Mode becomes available.")
-    public static let ReaderModeResetFontSizeAccessibilityLabel = MZLocalizedString("Reset text size", comment: "Accessibility label for button resetting font size in display settings of reader mode")
+    public static let ReaderModeAvailableVoiceOverAnnouncement = MZLocalizedString("ReaderMode.Available.VoiceOverAnnouncement", value: "Reader Mode available", comment: "Accessibility message e.g. spoken by VoiceOver when Reader Mode becomes available.", lastEditedIn: .unknown)
+    public static let ReaderModeResetFontSizeAccessibilityLabel = MZLocalizedString("Reset text size", comment: "Accessibility label for button resetting font size in display settings of reader mode", lastEditedIn: .unknown)
 }
 
 // MARK: - QR Code scanner
 extension Strings {
-    public static let ScanQRCodeViewTitle = MZLocalizedString("ScanQRCode.View.Title", value: "Scan QR Code", comment: "Title for the QR code scanner view.")
-    public static let ScanQRCodeInstructionsLabel = MZLocalizedString("ScanQRCode.Instructions.Label", value: "Align QR code within frame to scan", comment: "Text for the instructions label, displayed in the QR scanner view")
-    public static let ScanQRCodeInvalidDataErrorMessage = MZLocalizedString("ScanQRCode.InvalidDataError.Message", value: "The data is invalid", comment: "Text of the prompt that is shown to the user when the data is invalid")
-    public static let ScanQRCodePermissionErrorMessage = MZLocalizedString("ScanQRCode.PermissionError.Message", value: "Please allow Firefox to access your device’s camera in ‘Settings’ -> ‘Privacy’ -> ‘Camera’.", comment: "Text of the prompt user to setup the camera authorization.")
-    public static let ScanQRCodeErrorOKButton = MZLocalizedString("ScanQRCode.Error.OK.Button", value: "OK", comment: "OK button to dismiss the error prompt.")
+    public static let ScanQRCodeViewTitle = MZLocalizedString("ScanQRCode.View.Title", value: "Scan QR Code", comment: "Title for the QR code scanner view.", lastEditedIn: .unknown)
+    public static let ScanQRCodeInstructionsLabel = MZLocalizedString("ScanQRCode.Instructions.Label", value: "Align QR code within frame to scan", comment: "Text for the instructions label, displayed in the QR scanner view", lastEditedIn: .unknown)
+    public static let ScanQRCodeInvalidDataErrorMessage = MZLocalizedString("ScanQRCode.InvalidDataError.Message", value: "The data is invalid", comment: "Text of the prompt that is shown to the user when the data is invalid", lastEditedIn: .unknown)
+    public static let ScanQRCodePermissionErrorMessage = MZLocalizedString("ScanQRCode.PermissionError.Message", value: "Please allow Firefox to access your device’s camera in ‘Settings’ -> ‘Privacy’ -> ‘Camera’.", comment: "Text of the prompt user to setup the camera authorization.", lastEditedIn: .unknown)
+    public static let ScanQRCodeErrorOKButton = MZLocalizedString("ScanQRCode.Error.OK.Button", value: "OK", comment: "OK button to dismiss the error prompt.", lastEditedIn: .unknown)
 }
 
 // MARK: - App menu
 extension Strings {
-    public static let AppMenuReportSiteIssueTitleString = MZLocalizedString("Menu.ReportSiteIssueAction.Title", tableName: "Menu", value: "Report Site Issue", comment: "Label for the button, displayed in the menu, used to report a compatibility issue with the current page.")
-    public static let AppMenuLibraryReloadString = MZLocalizedString("Menu.Library.Reload", tableName: "Menu", value: "Reload", comment: "Label for the button, displayed in the menu, used to Reload the webpage")
-    public static let StopReloadPageTitle = MZLocalizedString("Menu.Library.StopReload", value: "Stop", comment: "Label for the button displayed in the menu used to stop the reload of the webpage")
-    public static let AppMenuLibraryTitleString = MZLocalizedString("Menu.Library.Title", tableName: "Menu", value: "Your Library", comment: "Label for the button, displayed in the menu, used to open the Library")
-    public static let AppMenuRecentlySavedTitle = MZLocalizedString("Menu.RecentlySaved.Title", tableName: "Menu", value: "Recently Saved", comment: "A string used to signify the start of the Recently Saved section in Home Screen.")
-    public static let AppMenuAddToReadingListTitleString = MZLocalizedString("Menu.AddToReadingList.Title", tableName: "Menu", value: "Add to Reading List", comment: "Label for the button, displayed in the menu, used to add a page to the reading list.")
-    public static let AppMenuShowTabsTitleString = MZLocalizedString("Menu.ShowTabs.Title", tableName: "Menu", value: "Show Tabs", comment: "Label for the button, displayed in the menu, used to open the tabs tray")
-    public static let AppMenuSharePageTitleString = MZLocalizedString("Menu.SharePageAction.Title", tableName: "Menu", value: "Share Page With…", comment: "Label for the button, displayed in the menu, used to open the share dialog.")
-    public static let AppMenuCopyURLTitleString = MZLocalizedString("Menu.CopyAddress.Title", tableName: "Menu", value: "Copy Address", comment: "Label for the button, displayed in the menu, used to copy the page url to the clipboard.")
-    public static let AppMenuCopyLinkTitleString = MZLocalizedString("Menu.CopyLink.Title", tableName: "Menu", value: "Copy Link", comment: "Label for the button, displayed in the menu, used to copy the current page link to the clipboard.")
-    public static let AppMenuNewTabTitleString = MZLocalizedString("Menu.NewTabAction.Title", tableName: "Menu", value: "Open New Tab", comment: "Label for the button, displayed in the menu, used to open a new tab")
-    public static let AppMenuNewPrivateTabTitleString = MZLocalizedString("Menu.NewPrivateTabAction.Title", tableName: "Menu", value: "Open New Private Tab", comment: "Label for the button, displayed in the menu, used to open a new private tab.")
-    public static let AppMenuAddBookmarkTitleString = MZLocalizedString("Menu.AddBookmarkAction.Title", tableName: "Menu", value: "Bookmark This Page", comment: "Label for the button, displayed in the menu, used to create a bookmark for the current website.")
-    public static let AppMenuAddBookmarkTitleString2 = MZLocalizedString("Menu.AddBookmarkAction2.Title", tableName: "Menu", value: "Add Bookmark", comment: "Label for the button, displayed in the menu, used to create a bookmark for the current website.")
-    public static let AppMenuRemoveBookmarkTitleString = MZLocalizedString("Menu.RemoveBookmarkAction.Title", tableName: "Menu", value: "Remove Bookmark", comment: "Label for the button, displayed in the menu, used to delete an existing bookmark for the current website.")
-    public static let AppMenuFindInPageTitleString = MZLocalizedString("Menu.FindInPageAction.Title", tableName: "Menu", value: "Find in Page", comment: "Label for the button, displayed in the menu, used to open the toolbar to search for text within the current page.")
-    public static let AppMenuViewDesktopSiteTitleString = MZLocalizedString("Menu.ViewDekstopSiteAction.Title", tableName: "Menu", value: "Request Desktop Site", comment: "Label for the button, displayed in the menu, used to request the desktop version of the current website.")
-    public static let AppMenuViewMobileSiteTitleString = MZLocalizedString("Menu.ViewMobileSiteAction.Title", tableName: "Menu", value: "Request Mobile Site", comment: "Label for the button, displayed in the menu, used to request the mobile version of the current website.")
-    public static let AppMenuTranslatePageTitleString = MZLocalizedString("Menu.TranslatePageAction.Title", tableName: "Menu", value: "Translate Page", comment: "Label for the button, displayed in the menu, used to translate the current page.")
-    public static let AppMenuScanQRCodeTitleString = MZLocalizedString("Menu.ScanQRCodeAction.Title", tableName: "Menu", value: "Scan QR Code", comment: "Label for the button, displayed in the menu, used to open the QR code scanner.")
-    public static let AppMenuSettingsTitleString = MZLocalizedString("Menu.OpenSettingsAction.Title", tableName: "Menu", value: "Settings", comment: "Label for the button, displayed in the menu, used to open the Settings menu.")
-    public static let AppMenuCloseAllTabsTitleString = MZLocalizedString("Menu.CloseAllTabsAction.Title", tableName: "Menu", value: "Close All Tabs", comment: "Label for the button, displayed in the menu, used to close all tabs currently open.")
-    public static let AppMenuOpenHomePageTitleString = MZLocalizedString("Menu.OpenHomePageAction.Title", tableName: "Menu", value: "Home", comment: "Label for the button, displayed in the menu, used to navigate to the home page.")
-    public static let AppMenuTopSitesTitleString = MZLocalizedString("Menu.OpenTopSitesAction.AccessibilityLabel", tableName: "Menu", value: "Top Sites", comment: "Accessibility label for the button, displayed in the menu, used to open the Top Sites home panel.")
-    public static let AppMenuBookmarksTitleString = MZLocalizedString("Menu.OpenBookmarksAction.AccessibilityLabel.v2", tableName: "Menu", value: "Bookmarks", comment: "Accessibility label for the button, displayed in the menu, used to open the Bookmarks home panel. Please keep as short as possible, <15 chars of space available.")
-    public static let AppMenuReadingListTitleString = MZLocalizedString("Menu.OpenReadingListAction.AccessibilityLabel.v2", tableName: "Menu", value: "Reading List", comment: "Accessibility label for the button, displayed in the menu, used to open the Reading list home panel. Please keep as short as possible, <15 chars of space available.")
-    public static let AppMenuHistoryTitleString = MZLocalizedString("Menu.OpenHistoryAction.AccessibilityLabel.v2", tableName: "Menu", value: "History", comment: "Accessibility label for the button, displayed in the menu, used to open the History home panel. Please keep as short as possible, <15 chars of space available.")
-    public static let AppMenuDownloadsTitleString = MZLocalizedString("Menu.OpenDownloadsAction.AccessibilityLabel.v2", tableName: "Menu", value: "Downloads", comment: "Accessibility label for the button, displayed in the menu, used to open the Downloads home panel. Please keep as short as possible, <15 chars of space available.")
-    public static let AppMenuSyncedTabsTitleString = MZLocalizedString("Menu.OpenSyncedTabsAction.AccessibilityLabel.v2", tableName: "Menu", value: "Synced Tabs", comment: "Accessibility label for the button, displayed in the menu, used to open the Synced Tabs home panel. Please keep as short as possible, <15 chars of space available.")
-    public static let AppMenuLibrarySeeAllTitleString = MZLocalizedString("Menu.SeeAllAction.Title", tableName: "Menu", value: "See All", comment: "Label for the button, displayed in Firefox Home, used to see all Library panels.")
-    public static let AppMenuButtonAccessibilityLabel = MZLocalizedString("Toolbar.Menu.AccessibilityLabel", value: "Menu", comment: "Accessibility label for the Menu button.")
-    public static let TabTrayDeleteMenuButtonAccessibilityLabel = MZLocalizedString("Toolbar.Menu.CloseAllTabs", value: "Close All Tabs", comment: "Accessibility label for the Close All Tabs menu button.")
-    public static let AppMenuNightMode = MZLocalizedString("Menu.NightModeTurnOn.Label", value: "Enable Night Mode", comment: "Label for the button, displayed in the menu, turns on night mode.")
-    public static let AppMenuTurnOnNightMode = MZLocalizedString("Menu.NightModeTurnOn.Label2", value: "Turn on Night Mode", comment: "Label for the button, displayed in the menu, turns on night mode.")
-    public static let AppMenuTurnOffNightMode = MZLocalizedString("Menu.NightModeTurnOff.Label2", value: "Turn off Night Mode", comment: "Label for the button, displayed in the menu, turns off night mode.")
-    public static let AppMenuNoImageMode = MZLocalizedString("Menu.NoImageModeBlockImages.Label", value: "Block Images", comment: "Label for the button, displayed in the menu, hides images on the webpage when pressed.")
-    public static let AppMenuShowImageMode = MZLocalizedString("Menu.NoImageModeShowImages.Label", value: "Show Images", comment: "Label for the button, displayed in the menu, shows images on the webpage when pressed.")
-    public static let AppMenuBookmarks = MZLocalizedString("Menu.Bookmarks.Label", value: "Bookmarks", comment: "Label for the button, displayed in the menu, takes you to to bookmarks screen when pressed.")
-    public static let AppMenuHistory = MZLocalizedString("Menu.History.Label", value: "History", comment: "Label for the button, displayed in the menu, takes you to to History screen when pressed.")
-    public static let AppMenuDownloads = MZLocalizedString("Menu.Downloads.Label", value: "Downloads", comment: "Label for the button, displayed in the menu, takes you to to Downloads screen when pressed.")
-    public static let AppMenuReadingList = MZLocalizedString("Menu.ReadingList.Label", value: "Reading List", comment: "Label for the button, displayed in the menu, takes you to to Reading List screen when pressed.")
-    public static let AppMenuPasswords = MZLocalizedString("Menu.Passwords.Label", value: "Passwords", comment: "Label for the button, displayed in the menu, takes you to to passwords screen when pressed.")
-    public static let AppMenuBackUpAndSyncData = MZLocalizedString("Menu.BackUpAndSync.Label", value: "Back up and Sync Data", comment: "Label for the button, displayed in the menu, takes you to sync sign in when pressed.")
-    public static let AppMenuManageAccount = MZLocalizedString("Menu.ManageAccount.Label", value: "Manage Account %@", comment: "Label for the button, displayed in the menu, takes you to screen to manage account when pressed. First argument is the display name for the current account")
-    public static let AppMenuCopyURLConfirmMessage = MZLocalizedString("Menu.CopyURL.Confirm", value: "URL Copied To Clipboard", comment: "Toast displayed to user after copy url pressed.")
+    public static let AppMenuReportSiteIssueTitleString = MZLocalizedString("Menu.ReportSiteIssueAction.Title", tableName: "Menu", value: "Report Site Issue", comment: "Label for the button, displayed in the menu, used to report a compatibility issue with the current page.", lastEditedIn: .unknown)
+    public static let AppMenuLibraryReloadString = MZLocalizedString("Menu.Library.Reload", tableName: "Menu", value: "Reload", comment: "Label for the button, displayed in the menu, used to Reload the webpage", lastEditedIn: .unknown)
+    public static let StopReloadPageTitle = MZLocalizedString("Menu.Library.StopReload", value: "Stop", comment: "Label for the button displayed in the menu used to stop the reload of the webpage", lastEditedIn: .unknown)
+    public static let AppMenuLibraryTitleString = MZLocalizedString("Menu.Library.Title", tableName: "Menu", value: "Your Library", comment: "Label for the button, displayed in the menu, used to open the Library", lastEditedIn: .unknown)
+    public static let AppMenuRecentlySavedTitle = MZLocalizedString("Menu.RecentlySaved.Title", tableName: "Menu", value: "Recently Saved", comment: "A string used to signify the start of the Recently Saved section in Home Screen.", lastEditedIn: .unknown)
+    public static let AppMenuAddToReadingListTitleString = MZLocalizedString("Menu.AddToReadingList.Title", tableName: "Menu", value: "Add to Reading List", comment: "Label for the button, displayed in the menu, used to add a page to the reading list.", lastEditedIn: .unknown)
+    public static let AppMenuShowTabsTitleString = MZLocalizedString("Menu.ShowTabs.Title", tableName: "Menu", value: "Show Tabs", comment: "Label for the button, displayed in the menu, used to open the tabs tray", lastEditedIn: .unknown)
+    public static let AppMenuSharePageTitleString = MZLocalizedString("Menu.SharePageAction.Title", tableName: "Menu", value: "Share Page With…", comment: "Label for the button, displayed in the menu, used to open the share dialog.", lastEditedIn: .unknown)
+    public static let AppMenuCopyURLTitleString = MZLocalizedString("Menu.CopyAddress.Title", tableName: "Menu", value: "Copy Address", comment: "Label for the button, displayed in the menu, used to copy the page url to the clipboard.", lastEditedIn: .unknown)
+    public static let AppMenuCopyLinkTitleString = MZLocalizedString("Menu.CopyLink.Title", tableName: "Menu", value: "Copy Link", comment: "Label for the button, displayed in the menu, used to copy the current page link to the clipboard.", lastEditedIn: .unknown)
+    public static let AppMenuNewTabTitleString = MZLocalizedString("Menu.NewTabAction.Title", tableName: "Menu", value: "Open New Tab", comment: "Label for the button, displayed in the menu, used to open a new tab", lastEditedIn: .unknown)
+    public static let AppMenuNewPrivateTabTitleString = MZLocalizedString("Menu.NewPrivateTabAction.Title", tableName: "Menu", value: "Open New Private Tab", comment: "Label for the button, displayed in the menu, used to open a new private tab.", lastEditedIn: .unknown)
+    public static let AppMenuAddBookmarkTitleString = MZLocalizedString("Menu.AddBookmarkAction.Title", tableName: "Menu", value: "Bookmark This Page", comment: "Label for the button, displayed in the menu, used to create a bookmark for the current website.", lastEditedIn: .unknown)
+    public static let AppMenuAddBookmarkTitleString2 = MZLocalizedString("Menu.AddBookmarkAction2.Title", tableName: "Menu", value: "Add Bookmark", comment: "Label for the button, displayed in the menu, used to create a bookmark for the current website.", lastEditedIn: .unknown)
+    public static let AppMenuRemoveBookmarkTitleString = MZLocalizedString("Menu.RemoveBookmarkAction.Title", tableName: "Menu", value: "Remove Bookmark", comment: "Label for the button, displayed in the menu, used to delete an existing bookmark for the current website.", lastEditedIn: .unknown)
+    public static let AppMenuFindInPageTitleString = MZLocalizedString("Menu.FindInPageAction.Title", tableName: "Menu", value: "Find in Page", comment: "Label for the button, displayed in the menu, used to open the toolbar to search for text within the current page.", lastEditedIn: .unknown)
+    public static let AppMenuViewDesktopSiteTitleString = MZLocalizedString("Menu.ViewDekstopSiteAction.Title", tableName: "Menu", value: "Request Desktop Site", comment: "Label for the button, displayed in the menu, used to request the desktop version of the current website.", lastEditedIn: .unknown)
+    public static let AppMenuViewMobileSiteTitleString = MZLocalizedString("Menu.ViewMobileSiteAction.Title", tableName: "Menu", value: "Request Mobile Site", comment: "Label for the button, displayed in the menu, used to request the mobile version of the current website.", lastEditedIn: .unknown)
+    public static let AppMenuTranslatePageTitleString = MZLocalizedString("Menu.TranslatePageAction.Title", tableName: "Menu", value: "Translate Page", comment: "Label for the button, displayed in the menu, used to translate the current page.", lastEditedIn: .unknown)
+    public static let AppMenuScanQRCodeTitleString = MZLocalizedString("Menu.ScanQRCodeAction.Title", tableName: "Menu", value: "Scan QR Code", comment: "Label for the button, displayed in the menu, used to open the QR code scanner.", lastEditedIn: .unknown)
+    public static let AppMenuSettingsTitleString = MZLocalizedString("Menu.OpenSettingsAction.Title", tableName: "Menu", value: "Settings", comment: "Label for the button, displayed in the menu, used to open the Settings menu.", lastEditedIn: .unknown)
+    public static let AppMenuCloseAllTabsTitleString = MZLocalizedString("Menu.CloseAllTabsAction.Title", tableName: "Menu", value: "Close All Tabs", comment: "Label for the button, displayed in the menu, used to close all tabs currently open.", lastEditedIn: .unknown)
+    public static let AppMenuOpenHomePageTitleString = MZLocalizedString("Menu.OpenHomePageAction.Title", tableName: "Menu", value: "Home", comment: "Label for the button, displayed in the menu, used to navigate to the home page.", lastEditedIn: .unknown)
+    public static let AppMenuTopSitesTitleString = MZLocalizedString("Menu.OpenTopSitesAction.AccessibilityLabel", tableName: "Menu", value: "Top Sites", comment: "Accessibility label for the button, displayed in the menu, used to open the Top Sites home panel.", lastEditedIn: .unknown)
+    public static let AppMenuBookmarksTitleString = MZLocalizedString("Menu.OpenBookmarksAction.AccessibilityLabel.v2", tableName: "Menu", value: "Bookmarks", comment: "Accessibility label for the button, displayed in the menu, used to open the Bookmarks home panel. Please keep as short as possible, <15 chars of space available.", lastEditedIn: .unknown)
+    public static let AppMenuReadingListTitleString = MZLocalizedString("Menu.OpenReadingListAction.AccessibilityLabel.v2", tableName: "Menu", value: "Reading List", comment: "Accessibility label for the button, displayed in the menu, used to open the Reading list home panel. Please keep as short as possible, <15 chars of space available.", lastEditedIn: .unknown)
+    public static let AppMenuHistoryTitleString = MZLocalizedString("Menu.OpenHistoryAction.AccessibilityLabel.v2", tableName: "Menu", value: "History", comment: "Accessibility label for the button, displayed in the menu, used to open the History home panel. Please keep as short as possible, <15 chars of space available.", lastEditedIn: .unknown)
+    public static let AppMenuDownloadsTitleString = MZLocalizedString("Menu.OpenDownloadsAction.AccessibilityLabel.v2", tableName: "Menu", value: "Downloads", comment: "Accessibility label for the button, displayed in the menu, used to open the Downloads home panel. Please keep as short as possible, <15 chars of space available.", lastEditedIn: .unknown)
+    public static let AppMenuSyncedTabsTitleString = MZLocalizedString("Menu.OpenSyncedTabsAction.AccessibilityLabel.v2", tableName: "Menu", value: "Synced Tabs", comment: "Accessibility label for the button, displayed in the menu, used to open the Synced Tabs home panel. Please keep as short as possible, <15 chars of space available.", lastEditedIn: .unknown)
+    public static let AppMenuLibrarySeeAllTitleString = MZLocalizedString("Menu.SeeAllAction.Title", tableName: "Menu", value: "See All", comment: "Label for the button, displayed in Firefox Home, used to see all Library panels.", lastEditedIn: .unknown)
+    public static let AppMenuButtonAccessibilityLabel = MZLocalizedString("Toolbar.Menu.AccessibilityLabel", value: "Menu", comment: "Accessibility label for the Menu button.", lastEditedIn: .unknown)
+    public static let TabTrayDeleteMenuButtonAccessibilityLabel = MZLocalizedString("Toolbar.Menu.CloseAllTabs", value: "Close All Tabs", comment: "Accessibility label for the Close All Tabs menu button.", lastEditedIn: .unknown)
+    public static let AppMenuNightMode = MZLocalizedString("Menu.NightModeTurnOn.Label", value: "Enable Night Mode", comment: "Label for the button, displayed in the menu, turns on night mode.", lastEditedIn: .unknown)
+    public static let AppMenuTurnOnNightMode = MZLocalizedString("Menu.NightModeTurnOn.Label2", value: "Turn on Night Mode", comment: "Label for the button, displayed in the menu, turns on night mode.", lastEditedIn: .unknown)
+    public static let AppMenuTurnOffNightMode = MZLocalizedString("Menu.NightModeTurnOff.Label2", value: "Turn off Night Mode", comment: "Label for the button, displayed in the menu, turns off night mode.", lastEditedIn: .unknown)
+    public static let AppMenuNoImageMode = MZLocalizedString("Menu.NoImageModeBlockImages.Label", value: "Block Images", comment: "Label for the button, displayed in the menu, hides images on the webpage when pressed.", lastEditedIn: .unknown)
+    public static let AppMenuShowImageMode = MZLocalizedString("Menu.NoImageModeShowImages.Label", value: "Show Images", comment: "Label for the button, displayed in the menu, shows images on the webpage when pressed.", lastEditedIn: .unknown)
+    public static let AppMenuBookmarks = MZLocalizedString("Menu.Bookmarks.Label", value: "Bookmarks", comment: "Label for the button, displayed in the menu, takes you to to bookmarks screen when pressed.", lastEditedIn: .unknown)
+    public static let AppMenuHistory = MZLocalizedString("Menu.History.Label", value: "History", comment: "Label for the button, displayed in the menu, takes you to to History screen when pressed.", lastEditedIn: .unknown)
+    public static let AppMenuDownloads = MZLocalizedString("Menu.Downloads.Label", value: "Downloads", comment: "Label for the button, displayed in the menu, takes you to to Downloads screen when pressed.", lastEditedIn: .unknown)
+    public static let AppMenuReadingList = MZLocalizedString("Menu.ReadingList.Label", value: "Reading List", comment: "Label for the button, displayed in the menu, takes you to to Reading List screen when pressed.", lastEditedIn: .unknown)
+    public static let AppMenuPasswords = MZLocalizedString("Menu.Passwords.Label", value: "Passwords", comment: "Label for the button, displayed in the menu, takes you to to passwords screen when pressed.", lastEditedIn: .unknown)
+    public static let AppMenuBackUpAndSyncData = MZLocalizedString("Menu.BackUpAndSync.Label", value: "Back up and Sync Data", comment: "Label for the button, displayed in the menu, takes you to sync sign in when pressed.", lastEditedIn: .unknown)
+    public static let AppMenuManageAccount = MZLocalizedString("Menu.ManageAccount.Label", value: "Manage Account %@", comment: "Label for the button, displayed in the menu, takes you to screen to manage account when pressed. First argument is the display name for the current account", lastEditedIn: .unknown)
+    public static let AppMenuCopyURLConfirmMessage = MZLocalizedString("Menu.CopyURL.Confirm", value: "URL Copied To Clipboard", comment: "Toast displayed to user after copy url pressed.", lastEditedIn: .unknown)
     
-    public static let AppMenuAddBookmarkConfirmMessage = MZLocalizedString("Menu.AddBookmark.Confirm", value: "Bookmark Added", comment: "Toast displayed to the user after a bookmark has been added.")
-    public static let AppMenuTabSentConfirmMessage = MZLocalizedString("Menu.TabSent.Confirm", value: "Tab Sent", comment: "Toast displayed to the user after a tab has been sent successfully.")
-    public static let AppMenuRemoveBookmarkConfirmMessage = MZLocalizedString("Menu.RemoveBookmark.Confirm", value: "Bookmark Removed", comment: "Toast displayed to the user after a bookmark has been removed.")
-    public static let AppMenuAddPinToTopSitesConfirmMessage = MZLocalizedString("Menu.AddPin.Confirm", value: "Pinned To Top Sites", comment: "Toast displayed to the user after adding the item to the Top Sites.")
-    public static let AppMenuAddPinToShortcutsConfirmMessage = MZLocalizedString("Menu.AddPin.Confirm2", value: "Added to Shortcuts", comment: "Toast displayed to the user after adding the item to the Shortcuts.")
-    public static let AppMenuRemovePinFromShortcutsConfirmMessage = MZLocalizedString("Menu.RemovePin.Confirm2", value: "Removed from Shortcuts", comment: "Toast displayed to the user after removing the item to the Shortcuts.")
-    public static let AppMenuRemovePinFromTopSitesConfirmMessage = MZLocalizedString("Menu.RemovePin.Confirm", value: "Removed From Top Sites", comment: "Toast displayed to the user after removing the item from the Top Sites.")
-    public static let AppMenuAddToReadingListConfirmMessage = MZLocalizedString("Menu.AddToReadingList.Confirm", value: "Added To Reading List", comment: "Toast displayed to the user after adding the item to their reading list.")
-    public static let SendToDeviceTitle = MZLocalizedString("Send to Device", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to send the current tab to another device")
-    public static let SendLinkToDeviceTitle = MZLocalizedString("Menu.SendLinkToDevice", tableName: "3DTouchActions", value: "Send Link to Device", comment: "Label for preview action on Tab Tray Tab to send the current link to another device")
-    public static let PageActionMenuTitle = MZLocalizedString("Menu.PageActions.Title", value: "Page Actions", comment: "Label for title in page action menu.")
-    public static let WhatsNewString = MZLocalizedString("Menu.WhatsNew.Title", value: "What's New", comment: "The title for the option to view the What's new page.")
-    public static let AppMenuShowPageSourceString = MZLocalizedString("Menu.PageSourceAction.Title", tableName: "Menu", value: "View Page Source", comment: "Label for the button, displayed in the menu, used to show the html page source")
+    public static let AppMenuAddBookmarkConfirmMessage = MZLocalizedString("Menu.AddBookmark.Confirm", value: "Bookmark Added", comment: "Toast displayed to the user after a bookmark has been added.", lastEditedIn: .unknown)
+    public static let AppMenuTabSentConfirmMessage = MZLocalizedString("Menu.TabSent.Confirm", value: "Tab Sent", comment: "Toast displayed to the user after a tab has been sent successfully.", lastEditedIn: .unknown)
+    public static let AppMenuRemoveBookmarkConfirmMessage = MZLocalizedString("Menu.RemoveBookmark.Confirm", value: "Bookmark Removed", comment: "Toast displayed to the user after a bookmark has been removed.", lastEditedIn: .unknown)
+    public static let AppMenuAddPinToTopSitesConfirmMessage = MZLocalizedString("Menu.AddPin.Confirm", value: "Pinned To Top Sites", comment: "Toast displayed to the user after adding the item to the Top Sites.", lastEditedIn: .unknown)
+    public static let AppMenuAddPinToShortcutsConfirmMessage = MZLocalizedString("Menu.AddPin.Confirm2", value: "Added to Shortcuts", comment: "Toast displayed to the user after adding the item to the Shortcuts.", lastEditedIn: .unknown)
+    public static let AppMenuRemovePinFromShortcutsConfirmMessage = MZLocalizedString("Menu.RemovePin.Confirm2", value: "Removed from Shortcuts", comment: "Toast displayed to the user after removing the item to the Shortcuts.", lastEditedIn: .unknown)
+    public static let AppMenuRemovePinFromTopSitesConfirmMessage = MZLocalizedString("Menu.RemovePin.Confirm", value: "Removed From Top Sites", comment: "Toast displayed to the user after removing the item from the Top Sites.", lastEditedIn: .unknown)
+    public static let AppMenuAddToReadingListConfirmMessage = MZLocalizedString("Menu.AddToReadingList.Confirm", value: "Added To Reading List", comment: "Toast displayed to the user after adding the item to their reading list.", lastEditedIn: .unknown)
+    public static let SendToDeviceTitle = MZLocalizedString("Send to Device", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to send the current tab to another device", lastEditedIn: .unknown)
+    public static let SendLinkToDeviceTitle = MZLocalizedString("Menu.SendLinkToDevice", tableName: "3DTouchActions", value: "Send Link to Device", comment: "Label for preview action on Tab Tray Tab to send the current link to another device", lastEditedIn: .unknown)
+    public static let PageActionMenuTitle = MZLocalizedString("Menu.PageActions.Title", value: "Page Actions", comment: "Label for title in page action menu.", lastEditedIn: .unknown)
+    public static let WhatsNewString = MZLocalizedString("Menu.WhatsNew.Title", value: "What's New", comment: "The title for the option to view the What's new page.", lastEditedIn: .unknown)
+    public static let AppMenuShowPageSourceString = MZLocalizedString("Menu.PageSourceAction.Title", tableName: "Menu", value: "View Page Source", comment: "Label for the button, displayed in the menu, used to show the html page source", lastEditedIn: .unknown)
 }
 
 // MARK: - Snackbar shown when tapping app store link
 extension Strings {
-    public static let ExternalLinkAppStoreConfirmationTitle = MZLocalizedString("ExternalLink.AppStore.ConfirmationTitle", value: "Open this link in the App Store?", comment: "Question shown to user when tapping a link that opens the App Store app")
-    public static let ExternalLinkGenericConfirmation = MZLocalizedString("ExternalLink.AppStore.GenericConfirmationTitle", value: "Open this link in external app?", comment: "Question shown to user when tapping an SMS or MailTo link that opens the external app for those.")
+    public static let ExternalLinkAppStoreConfirmationTitle = MZLocalizedString("ExternalLink.AppStore.ConfirmationTitle", value: "Open this link in the App Store?", comment: "Question shown to user when tapping a link that opens the App Store app", lastEditedIn: .unknown)
+    public static let ExternalLinkGenericConfirmation = MZLocalizedString("ExternalLink.AppStore.GenericConfirmationTitle", value: "Open this link in external app?", comment: "Question shown to user when tapping an SMS or MailTo link that opens the external app for those.", lastEditedIn: .unknown)
 }
 
 // MARK: - ContentBlocker/TrackingProtection string
 extension Strings {
-    public static let SettingsTrackingProtectionSectionName = MZLocalizedString("Settings.TrackingProtection.SectionName", value: "Tracking Protection", comment: "Row in top-level of settings that gets tapped to show the tracking protection settings detail view.")
+    public static let SettingsTrackingProtectionSectionName = MZLocalizedString("Settings.TrackingProtection.SectionName", value: "Tracking Protection", comment: "Row in top-level of settings that gets tapped to show the tracking protection settings detail view.", lastEditedIn: .unknown)
 
-    public static let TrackingProtectionEnableTitle = MZLocalizedString("Settings.TrackingProtectionOption.NormalBrowsingLabelOn", value: "Enhanced Tracking Protection", comment: "Settings option to specify that Tracking Protection is on")
+    public static let TrackingProtectionEnableTitle = MZLocalizedString("Settings.TrackingProtectionOption.NormalBrowsingLabelOn", value: "Enhanced Tracking Protection", comment: "Settings option to specify that Tracking Protection is on", lastEditedIn: .unknown)
 
-    public static let TrackingProtectionOptionOnOffFooter = MZLocalizedString("Settings.TrackingProtectionOption.EnabledStateFooterLabel", value: "Tracking is the collection of your browsing data across multiple websites.", comment: "Description label shown on tracking protection options screen.")
-    public static let TrackingProtectionOptionProtectionLevelTitle = MZLocalizedString("Settings.TrackingProtection.ProtectionLevelTitle", value: "Protection Level", comment: "Title for tracking protection options section where level can be selected.")
-    public static let TrackingProtectionOptionBlockListsHeader = MZLocalizedString("Settings.TrackingProtection.BlockListsHeader", value: "You can choose which list Firefox will use to block Web elements that may track your browsing activity.", comment: "Header description for tracking protection options section where Basic/Strict block list can be selected")
-    public static let TrackingProtectionOptionBlockListLevelStandard = MZLocalizedString("Settings.TrackingProtectionOption.BasicBlockList", value: "Standard (default)", comment: "Tracking protection settings option for using the basic blocklist.")
-    public static let TrackingProtectionOptionBlockListLevelStrict = MZLocalizedString("Settings.TrackingProtectionOption.BlockListStrict", value: "Strict", comment: "Tracking protection settings option for using the strict blocklist.")
-    public static let TrackingProtectionReloadWithout = MZLocalizedString("Menu.ReloadWithoutTrackingProtection.Title", value: "Reload Without Tracking Protection", comment: "Label for the button, displayed in the menu, used to reload the current website without Tracking Protection")
-    public static let TrackingProtectionReloadWith = MZLocalizedString("Menu.ReloadWithTrackingProtection.Title", value: "Reload With Tracking Protection", comment: "Label for the button, displayed in the menu, used to reload the current website with Tracking Protection enabled")
+    public static let TrackingProtectionOptionOnOffFooter = MZLocalizedString("Settings.TrackingProtectionOption.EnabledStateFooterLabel", value: "Tracking is the collection of your browsing data across multiple websites.", comment: "Description label shown on tracking protection options screen.", lastEditedIn: .unknown)
+    public static let TrackingProtectionOptionProtectionLevelTitle = MZLocalizedString("Settings.TrackingProtection.ProtectionLevelTitle", value: "Protection Level", comment: "Title for tracking protection options section where level can be selected.", lastEditedIn: .unknown)
+    public static let TrackingProtectionOptionBlockListsHeader = MZLocalizedString("Settings.TrackingProtection.BlockListsHeader", value: "You can choose which list Firefox will use to block Web elements that may track your browsing activity.", comment: "Header description for tracking protection options section where Basic/Strict block list can be selected", lastEditedIn: .unknown)
+    public static let TrackingProtectionOptionBlockListLevelStandard = MZLocalizedString("Settings.TrackingProtectionOption.BasicBlockList", value: "Standard (default)", comment: "Tracking protection settings option for using the basic blocklist.", lastEditedIn: .unknown)
+    public static let TrackingProtectionOptionBlockListLevelStrict = MZLocalizedString("Settings.TrackingProtectionOption.BlockListStrict", value: "Strict", comment: "Tracking protection settings option for using the strict blocklist.", lastEditedIn: .unknown)
+    public static let TrackingProtectionReloadWithout = MZLocalizedString("Menu.ReloadWithoutTrackingProtection.Title", value: "Reload Without Tracking Protection", comment: "Label for the button, displayed in the menu, used to reload the current website without Tracking Protection", lastEditedIn: .unknown)
+    public static let TrackingProtectionReloadWith = MZLocalizedString("Menu.ReloadWithTrackingProtection.Title", value: "Reload With Tracking Protection", comment: "Label for the button, displayed in the menu, used to reload the current website with Tracking Protection enabled", lastEditedIn: .unknown)
 
-    public static let TrackingProtectionProtectionStrictInfoFooter = MZLocalizedString("Settings.TrackingProtection.StrictLevelInfoFooter", value: "Blocking trackers could impact the functionality of some websites.", comment: "Additional information about the strict level setting")
-    public static let TrackingProtectionCellFooter = MZLocalizedString("Settings.TrackingProtection.ProtectionCellFooter", value: "Reduces targeted ads and helps stop advertisers from tracking your browsing.", comment: "Additional information about your Enhanced Tracking Protection")
-    public static let TrackingProtectionStandardLevelDescription = MZLocalizedString("Settings.TrackingProtection.ProtectionLevelStandard.Description", value: "Allows some ad tracking so websites function properly.", comment: "Description for standard level tracker protection")
-    public static let TrackingProtectionStrictLevelDescription = MZLocalizedString("Settings.TrackingProtection.ProtectionLevelStrict.Description", value: "Blocks more trackers, ads, and popups. Pages load faster, but some functionality may not work.", comment: "Description for strict level tracker protection")
-    public static let TrackingProtectionLevelFooter = MZLocalizedString("Settings.TrackingProtection.ProtectionLevel.Footer", value: "If a site doesn’t work as expected, tap the shield in the address bar and turn off Enhanced Tracking Protection for that page.", comment: "Footer information for tracker protection level.")
-    public static let TrackerProtectionLearnMore = MZLocalizedString("Settings.TrackingProtection.LearnMore", value: "Learn more", comment: "'Learn more' info link on the Tracking Protection settings screen.")
-    public static let TrackerProtectionAlertTitle =  MZLocalizedString("Settings.TrackingProtection.Alert.Title", value: "Heads up!", comment: "Title for the tracker protection alert.")
-    public static let TrackerProtectionAlertDescription =  MZLocalizedString("Settings.TrackingProtection.Alert.Description", value: "If a site doesn’t work as expected, tap the shield in the address bar and turn off Enhanced Tracking Protection for that page.", comment: "Decription for the tracker protection alert.")
-    public static let TrackerProtectionAlertButton =  MZLocalizedString("Settings.TrackingProtection.Alert.Button", value: "OK, Got It", comment: "Dismiss button for the tracker protection alert.")
+    public static let TrackingProtectionProtectionStrictInfoFooter = MZLocalizedString("Settings.TrackingProtection.StrictLevelInfoFooter", value: "Blocking trackers could impact the functionality of some websites.", comment: "Additional information about the strict level setting", lastEditedIn: .unknown)
+    public static let TrackingProtectionCellFooter = MZLocalizedString("Settings.TrackingProtection.ProtectionCellFooter", value: "Reduces targeted ads and helps stop advertisers from tracking your browsing.", comment: "Additional information about your Enhanced Tracking Protection", lastEditedIn: .unknown)
+    public static let TrackingProtectionStandardLevelDescription = MZLocalizedString("Settings.TrackingProtection.ProtectionLevelStandard.Description", value: "Allows some ad tracking so websites function properly.", comment: "Description for standard level tracker protection", lastEditedIn: .unknown)
+    public static let TrackingProtectionStrictLevelDescription = MZLocalizedString("Settings.TrackingProtection.ProtectionLevelStrict.Description", value: "Blocks more trackers, ads, and popups. Pages load faster, but some functionality may not work.", comment: "Description for strict level tracker protection", lastEditedIn: .unknown)
+    public static let TrackingProtectionLevelFooter = MZLocalizedString("Settings.TrackingProtection.ProtectionLevel.Footer", value: "If a site doesn’t work as expected, tap the shield in the address bar and turn off Enhanced Tracking Protection for that page.", comment: "Footer information for tracker protection level.", lastEditedIn: .unknown)
+    public static let TrackerProtectionLearnMore = MZLocalizedString("Settings.TrackingProtection.LearnMore", value: "Learn more", comment: "'Learn more' info link on the Tracking Protection settings screen.", lastEditedIn: .unknown)
+    public static let TrackerProtectionAlertTitle =  MZLocalizedString("Settings.TrackingProtection.Alert.Title", value: "Heads up!", comment: "Title for the tracker protection alert.", lastEditedIn: .unknown)
+    public static let TrackerProtectionAlertDescription =  MZLocalizedString("Settings.TrackingProtection.Alert.Description", value: "If a site doesn’t work as expected, tap the shield in the address bar and turn off Enhanced Tracking Protection for that page.", comment: "Decription for the tracker protection alert.", lastEditedIn: .unknown)
+    public static let TrackerProtectionAlertButton =  MZLocalizedString("Settings.TrackingProtection.Alert.Button", value: "OK, Got It", comment: "Dismiss button for the tracker protection alert.", lastEditedIn: .unknown)
 }
 
 // MARK: - Tracking Protection menu
 extension Strings {
-    public static let TPBlockingDescription = MZLocalizedString("Menu.TrackingProtectionBlocking.Description", value: "Firefox is blocking parts of the page that may track your browsing.", comment: "Description of the Tracking protection menu when TP is blocking parts of the page")
-    public static let TPNoBlockingDescription = MZLocalizedString("Menu.TrackingProtectionNoBlocking.Description", value: "No tracking elements detected on this page.", comment: "The description of the Tracking Protection menu item when no scripts are blocked but tracking protection is enabled.")
-    public static let TPBlockingDisabledDescription = MZLocalizedString("Menu.TrackingProtectionBlockingDisabled.Description", value: "Block online trackers", comment: "The description of the Tracking Protection menu item when tracking is enabled")
-    public static let TPBlockingMoreInfo = MZLocalizedString("Menu.TrackingProtectionMoreInfo.Description", value: "Learn more about how Tracking Protection blocks online trackers that collect your browsing data across multiple websites.", comment: "more info about what tracking protection is about")
-    public static let EnableTPBlockingGlobally = MZLocalizedString("Menu.TrackingProtectionEnable.Title", value: "Enable Tracking Protection", comment: "A button to enable tracking protection inside the menu.")
-    public static let TPBlockingSiteEnabled = MZLocalizedString("Menu.TrackingProtectionEnable1.Title", value: "Enabled for this site", comment: "A button to enable tracking protection inside the menu.")
-    public static let TPEnabledConfirmed = MZLocalizedString("Menu.TrackingProtectionEnabled.Title", value: "Tracking Protection is now on for this site.", comment: "The confirmation toast once tracking protection has been enabled")
-    public static let TPDisabledConfirmed = MZLocalizedString("Menu.TrackingProtectionDisabled.Title", value: "Tracking Protection is now off for this site.", comment: "The confirmation toast once tracking protection has been disabled")
-    public static let TPBlockingSiteDisabled = MZLocalizedString("Menu.TrackingProtectionDisable1.Title", value: "Disabled for this site", comment: "The button that disabled TP for a site.")
-    public static let ETPOn = MZLocalizedString("Menu.EnhancedTrackingProtectionOn.Title", value: "Enhanced Tracking Protection is ON for this site.", comment: "A switch to enable enhanced tracking protection inside the menu.")
-    public static let ETPOff = MZLocalizedString("Menu.EnhancedTrackingProtectionOff.Title", value: "Enhanced Tracking Protection is OFF for this site.", comment: "A switch to disable enhanced tracking protection inside the menu.")
-    public static let StrictETPWithITP = MZLocalizedString("Menu.EnhancedTrackingProtectionStrictWithITP.Title", value: "Firefox blocks cross-site trackers, social trackers, cryptominers, fingerprinters, and tracking content.", comment: "Description for having strict ETP protection with ITP offered in iOS14+")
-    public static let StandardETPWithITP = MZLocalizedString("Menu.EnhancedTrackingProtectionStandardWithITP.Title", value: "Firefox blocks cross-site trackers, social trackers, cryptominers, and fingerprinters.", comment: "Description for having standard ETP protection with ITP offered in iOS14+")
+    public static let TPBlockingDescription = MZLocalizedString("Menu.TrackingProtectionBlocking.Description", value: "Firefox is blocking parts of the page that may track your browsing.", comment: "Description of the Tracking protection menu when TP is blocking parts of the page", lastEditedIn: .unknown)
+    public static let TPNoBlockingDescription = MZLocalizedString("Menu.TrackingProtectionNoBlocking.Description", value: "No tracking elements detected on this page.", comment: "The description of the Tracking Protection menu item when no scripts are blocked but tracking protection is enabled.", lastEditedIn: .unknown)
+    public static let TPBlockingDisabledDescription = MZLocalizedString("Menu.TrackingProtectionBlockingDisabled.Description", value: "Block online trackers", comment: "The description of the Tracking Protection menu item when tracking is enabled", lastEditedIn: .unknown)
+    public static let TPBlockingMoreInfo = MZLocalizedString("Menu.TrackingProtectionMoreInfo.Description", value: "Learn more about how Tracking Protection blocks online trackers that collect your browsing data across multiple websites.", comment: "more info about what tracking protection is about", lastEditedIn: .unknown)
+    public static let EnableTPBlockingGlobally = MZLocalizedString("Menu.TrackingProtectionEnable.Title", value: "Enable Tracking Protection", comment: "A button to enable tracking protection inside the menu.", lastEditedIn: .unknown)
+    public static let TPBlockingSiteEnabled = MZLocalizedString("Menu.TrackingProtectionEnable1.Title", value: "Enabled for this site", comment: "A button to enable tracking protection inside the menu.", lastEditedIn: .unknown)
+    public static let TPEnabledConfirmed = MZLocalizedString("Menu.TrackingProtectionEnabled.Title", value: "Tracking Protection is now on for this site.", comment: "The confirmation toast once tracking protection has been enabled", lastEditedIn: .unknown)
+    public static let TPDisabledConfirmed = MZLocalizedString("Menu.TrackingProtectionDisabled.Title", value: "Tracking Protection is now off for this site.", comment: "The confirmation toast once tracking protection has been disabled", lastEditedIn: .unknown)
+    public static let TPBlockingSiteDisabled = MZLocalizedString("Menu.TrackingProtectionDisable1.Title", value: "Disabled for this site", comment: "The button that disabled TP for a site.", lastEditedIn: .unknown)
+    public static let ETPOn = MZLocalizedString("Menu.EnhancedTrackingProtectionOn.Title", value: "Enhanced Tracking Protection is ON for this site.", comment: "A switch to enable enhanced tracking protection inside the menu.", lastEditedIn: .unknown)
+    public static let ETPOff = MZLocalizedString("Menu.EnhancedTrackingProtectionOff.Title", value: "Enhanced Tracking Protection is OFF for this site.", comment: "A switch to disable enhanced tracking protection inside the menu.", lastEditedIn: .unknown)
+    public static let StrictETPWithITP = MZLocalizedString("Menu.EnhancedTrackingProtectionStrictWithITP.Title", value: "Firefox blocks cross-site trackers, social trackers, cryptominers, fingerprinters, and tracking content.", comment: "Description for having strict ETP protection with ITP offered in iOS14+", lastEditedIn: .unknown)
+    public static let StandardETPWithITP = MZLocalizedString("Menu.EnhancedTrackingProtectionStandardWithITP.Title", value: "Firefox blocks cross-site trackers, social trackers, cryptominers, and fingerprinters.", comment: "Description for having standard ETP protection with ITP offered in iOS14+", lastEditedIn: .unknown)
 
     // TP Page menu title
-    public static let TPPageMenuTitle = MZLocalizedString("Menu.TrackingProtection.TitlePrefix", value: "Protections for %@", comment: "Title on tracking protection menu showing the domain. eg. Protections for mozilla.org")
-    public static let TPPageMenuNoTrackersBlocked = MZLocalizedString("Menu.TrackingProtection.NoTrackersBlockedTitle", value: "No trackers known to Firefox were detected on this page.", comment: "Message in menu when no trackers blocked.")
-    public static let TPPageMenuBlockedTitle = MZLocalizedString("Menu.TrackingProtection.BlockedTitle", value: "Blocked", comment: "Title on tracking protection menu for blocked items.")
+    public static let TPPageMenuTitle = MZLocalizedString("Menu.TrackingProtection.TitlePrefix", value: "Protections for %@", comment: "Title on tracking protection menu showing the domain. eg. Protections for mozilla.org", lastEditedIn: .unknown)
+    public static let TPPageMenuNoTrackersBlocked = MZLocalizedString("Menu.TrackingProtection.NoTrackersBlockedTitle", value: "No trackers known to Firefox were detected on this page.", comment: "Message in menu when no trackers blocked.", lastEditedIn: .unknown)
+    public static let TPPageMenuBlockedTitle = MZLocalizedString("Menu.TrackingProtection.BlockedTitle", value: "Blocked", comment: "Title on tracking protection menu for blocked items.", lastEditedIn: .unknown)
 
     // Category Titles
-    public static let TPCryptominersBlocked = MZLocalizedString("Menu.TrackingProtectionCryptominersBlocked.Title", value: "Cryptominers", comment: "The title that shows the number of cryptomining scripts blocked")
-    public static let TPFingerprintersBlocked = MZLocalizedString("Menu.TrackingProtectionFingerprintersBlocked.Title", value: "Fingerprinters", comment: "The title that shows the number of fingerprinting scripts blocked")
-    public static let TPCrossSiteCookiesBlocked = MZLocalizedString("Menu.TrackingProtectionCrossSiteCookies.Title", value: "Cross-Site Tracking Cookies", comment: "The title that shows the number of cross-site cookies blocked")
-    public static let TPCrossSiteBlocked = MZLocalizedString("Menu.TrackingProtectionCrossSiteTrackers.Title", value: "Cross-Site Trackers", comment: "The title that shows the number of cross-site URLs blocked")
-    public static let TPSocialBlocked = MZLocalizedString("Menu.TrackingProtectionBlockedSocial.Title", value: "Social Trackers", comment: "The title that shows the number of social URLs blocked")
-    public static let TPContentBlocked = MZLocalizedString("Menu.TrackingProtectionBlockedContent.Title", value: "Tracking content", comment: "The title that shows the number of content cookies blocked")
+    public static let TPCryptominersBlocked = MZLocalizedString("Menu.TrackingProtectionCryptominersBlocked.Title", value: "Cryptominers", comment: "The title that shows the number of cryptomining scripts blocked", lastEditedIn: .unknown)
+    public static let TPFingerprintersBlocked = MZLocalizedString("Menu.TrackingProtectionFingerprintersBlocked.Title", value: "Fingerprinters", comment: "The title that shows the number of fingerprinting scripts blocked", lastEditedIn: .unknown)
+    public static let TPCrossSiteCookiesBlocked = MZLocalizedString("Menu.TrackingProtectionCrossSiteCookies.Title", value: "Cross-Site Tracking Cookies", comment: "The title that shows the number of cross-site cookies blocked", lastEditedIn: .unknown)
+    public static let TPCrossSiteBlocked = MZLocalizedString("Menu.TrackingProtectionCrossSiteTrackers.Title", value: "Cross-Site Trackers", comment: "The title that shows the number of cross-site URLs blocked", lastEditedIn: .unknown)
+    public static let TPSocialBlocked = MZLocalizedString("Menu.TrackingProtectionBlockedSocial.Title", value: "Social Trackers", comment: "The title that shows the number of social URLs blocked", lastEditedIn: .unknown)
+    public static let TPContentBlocked = MZLocalizedString("Menu.TrackingProtectionBlockedContent.Title", value: "Tracking content", comment: "The title that shows the number of content cookies blocked", lastEditedIn: .unknown)
 
     // Shortcut on bottom of TP page menu to get to settings.
-    public static let TPProtectionSettings = MZLocalizedString("Menu.TrackingProtection.ProtectionSettings.Title", value: "Protection Settings", comment: "The title for tracking protection settings")
+    public static let TPProtectionSettings = MZLocalizedString("Menu.TrackingProtection.ProtectionSettings.Title", value: "Protection Settings", comment: "The title for tracking protection settings", lastEditedIn: .unknown)
 
     // Remove if unused -->
-    public static let TPListTitle_CrossSiteCookies = MZLocalizedString("Menu.TrackingProtectionListTitle.CrossSiteCookies", value: "Blocked Cross-Site Tracking Cookies", comment: "Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners`")
-    public static let TPListTitle_Social = MZLocalizedString("Menu.TrackingProtectionListTitle.Social", value: "Blocked Social Trackers", comment: "Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners`")
-    public static let TPListTitle_Fingerprinters = MZLocalizedString("Menu.TrackingProtectionListTitle.Fingerprinters", value: "Blocked Fingerprinters", comment: "Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners`")
-    public static let TPListTitle_Cryptominer = MZLocalizedString("Menu.TrackingProtectionListTitle.Cryptominers", value: "Blocked Cryptominers", comment: "Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners`")
+    public static let TPListTitle_CrossSiteCookies = MZLocalizedString("Menu.TrackingProtectionListTitle.CrossSiteCookies", value: "Blocked Cross-Site Tracking Cookies", comment: "Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners`", lastEditedIn: .unknown)
+    public static let TPListTitle_Social = MZLocalizedString("Menu.TrackingProtectionListTitle.Social", value: "Blocked Social Trackers", comment: "Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners`", lastEditedIn: .unknown)
+    public static let TPListTitle_Fingerprinters = MZLocalizedString("Menu.TrackingProtectionListTitle.Fingerprinters", value: "Blocked Fingerprinters", comment: "Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners`", lastEditedIn: .unknown)
+    public static let TPListTitle_Cryptominer = MZLocalizedString("Menu.TrackingProtectionListTitle.Cryptominers", value: "Blocked Cryptominers", comment: "Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners`", lastEditedIn: .unknown)
     /// <--
 
-    public static let TPSafeListOn = MZLocalizedString("Menu.TrackingProtectionOption.WhiteListOnDescription", value: "The site includes elements that may track your browsing. You have disabled protection.", comment: "label for the menu item to show when the website is whitelisted from blocking trackers.")
-    public static let TPSafeListRemove = MZLocalizedString("Menu.TrackingProtectionWhitelistRemove.Title", value: "Enable for this site", comment: "label for the menu item that lets you remove a website from the tracking protection whitelist")
+    public static let TPSafeListOn = MZLocalizedString("Menu.TrackingProtectionOption.WhiteListOnDescription", value: "The site includes elements that may track your browsing. You have disabled protection.", comment: "label for the menu item to show when the website is whitelisted from blocking trackers.", lastEditedIn: .unknown)
+    public static let TPSafeListRemove = MZLocalizedString("Menu.TrackingProtectionWhitelistRemove.Title", value: "Enable for this site", comment: "label for the menu item that lets you remove a website from the tracking protection whitelist", lastEditedIn: .unknown)
 
     // Settings info
-    public static let TPAccessoryInfoTitleStrict = MZLocalizedString("Settings.TrackingProtection.Info.StrictTitle", value: "Offers stronger protection, but may cause some sites to break.", comment: "Explanation of strict mode.")
-    public static let TPAccessoryInfoTitleBasic = MZLocalizedString("Settings.TrackingProtection.Info.BasicTitle", value: "Balanced for protection and performance.", comment: "Explanation of basic mode.")
-    public static let TPAccessoryInfoBlocksTitle = MZLocalizedString("Settings.TrackingProtection.Info.BlocksTitle", value: "BLOCKS", comment: "The Title on info view which shows a list of all blocked websites")
+    public static let TPAccessoryInfoTitleStrict = MZLocalizedString("Settings.TrackingProtection.Info.StrictTitle", value: "Offers stronger protection, but may cause some sites to break.", comment: "Explanation of strict mode.", lastEditedIn: .unknown)
+    public static let TPAccessoryInfoTitleBasic = MZLocalizedString("Settings.TrackingProtection.Info.BasicTitle", value: "Balanced for protection and performance.", comment: "Explanation of basic mode.", lastEditedIn: .unknown)
+    public static let TPAccessoryInfoBlocksTitle = MZLocalizedString("Settings.TrackingProtection.Info.BlocksTitle", value: "BLOCKS", comment: "The Title on info view which shows a list of all blocked websites", lastEditedIn: .unknown)
 
     // Category descriptions
-    public static let TPCategoryDescriptionSocial = MZLocalizedString("Menu.TrackingProtectionDescription.SocialNetworksNew", value: "Social networks place trackers on other websites to build a more complete and targeted profile of you. Blocking these trackers reduces how much social media companies can see what do you online.", comment: "Description of social network trackers.")
-    public static let TPCategoryDescriptionCrossSite = MZLocalizedString("Menu.TrackingProtectionDescription.CrossSiteNew", value: "These cookies follow you from site to site to gather data about what you do online. They are set by third parties such as advertisers and analytics companies.", comment: "Description of cross-site trackers.")
-    public static let TPCategoryDescriptionCryptominers = MZLocalizedString("Menu.TrackingProtectionDescription.CryptominersNew", value: "Cryptominers secretly use your system’s computing power to mine digital money. Cryptomining scripts drain your battery, slow down your computer, and can increase your energy bill.", comment: "Description of cryptominers.")
-    public static let TPCategoryDescriptionFingerprinters = MZLocalizedString("Menu.TrackingProtectionDescription.Fingerprinters", value: "The settings on your browser and computer are unique. Fingerprinters collect a variety of these unique settings to create a profile of you, which can be used to track you as you browse.", comment: "Description of fingerprinters.")
-    public static let TPCategoryDescriptionContentTrackers = MZLocalizedString("Menu.TrackingProtectionDescription.ContentTrackers", value: "Websites may load outside ads, videos, and other content that contains hidden trackers. Blocking this can make websites load faster, but some buttons, forms, and login fields, might not work.", comment: "Description of content trackers.")
+    public static let TPCategoryDescriptionSocial = MZLocalizedString("Menu.TrackingProtectionDescription.SocialNetworksNew", value: "Social networks place trackers on other websites to build a more complete and targeted profile of you. Blocking these trackers reduces how much social media companies can see what do you online.", comment: "Description of social network trackers.", lastEditedIn: .unknown)
+    public static let TPCategoryDescriptionCrossSite = MZLocalizedString("Menu.TrackingProtectionDescription.CrossSiteNew", value: "These cookies follow you from site to site to gather data about what you do online. They are set by third parties such as advertisers and analytics companies.", comment: "Description of cross-site trackers.", lastEditedIn: .unknown)
+    public static let TPCategoryDescriptionCryptominers = MZLocalizedString("Menu.TrackingProtectionDescription.CryptominersNew", value: "Cryptominers secretly use your system’s computing power to mine digital money. Cryptomining scripts drain your battery, slow down your computer, and can increase your energy bill.", comment: "Description of cryptominers.", lastEditedIn: .unknown)
+    public static let TPCategoryDescriptionFingerprinters = MZLocalizedString("Menu.TrackingProtectionDescription.Fingerprinters", value: "The settings on your browser and computer are unique. Fingerprinters collect a variety of these unique settings to create a profile of you, which can be used to track you as you browse.", comment: "Description of fingerprinters.", lastEditedIn: .unknown)
+    public static let TPCategoryDescriptionContentTrackers = MZLocalizedString("Menu.TrackingProtectionDescription.ContentTrackers", value: "Websites may load outside ads, videos, and other content that contains hidden trackers. Blocking this can make websites load faster, but some buttons, forms, and login fields, might not work.", comment: "Description of content trackers.", lastEditedIn: .unknown)
 
-    public static let TPMoreInfo = MZLocalizedString("Settings.TrackingProtection.MoreInfo", value: "More Info…", comment: "'More Info' link on the Tracking Protection settings screen.")
+    public static let TPMoreInfo = MZLocalizedString("Settings.TrackingProtection.MoreInfo", value: "More Info…", comment: "'More Info' link on the Tracking Protection settings screen.", lastEditedIn: .unknown)
 }
 
 // MARK: - Location bar long press menu
 extension Strings {
-    public static let PasteAndGoTitle = MZLocalizedString("Menu.PasteAndGo.Title", value: "Paste & Go", comment: "The title for the button that lets you paste and go to a URL")
-    public static let PasteTitle = MZLocalizedString("Menu.Paste.Title", value: "Paste", comment: "The title for the button that lets you paste into the location bar")
-    public static let CopyAddressTitle = MZLocalizedString("Menu.Copy.Title", value: "Copy Address", comment: "The title for the button that lets you copy the url from the location bar.")
+    public static let PasteAndGoTitle = MZLocalizedString("Menu.PasteAndGo.Title", value: "Paste & Go", comment: "The title for the button that lets you paste and go to a URL", lastEditedIn: .unknown)
+    public static let PasteTitle = MZLocalizedString("Menu.Paste.Title", value: "Paste", comment: "The title for the button that lets you paste into the location bar", lastEditedIn: .unknown)
+    public static let CopyAddressTitle = MZLocalizedString("Menu.Copy.Title", value: "Copy Address", comment: "The title for the button that lets you copy the url from the location bar.", lastEditedIn: .unknown)
 }
 
 // MARK: - Settings Home
 extension Strings {
-    public static let SendUsageSettingTitle = MZLocalizedString("Settings.SendUsage.Title", value: "Send Usage Data", comment: "The title for the setting to send usage data.")
-    public static let SendUsageSettingLink = MZLocalizedString("Settings.SendUsage.Link", value: "Learn More.", comment: "title for a link that explains how mozilla collects telemetry")
-    public static let SendUsageSettingMessage = MZLocalizedString("Settings.SendUsage.Message", value: "Mozilla strives to only collect what we need to provide and improve Firefox for everyone.", comment: "A short description that explains why mozilla collects usage data.")
-    public static let SettingsSiriSectionName = MZLocalizedString("Settings.Siri.SectionName", value: "Siri Shortcuts", comment: "The option that takes you to the siri shortcuts settings page")
-    public static let SettingsSiriSectionDescription = MZLocalizedString("Settings.Siri.SectionDescription", value: "Use Siri shortcuts to quickly open Firefox via Siri", comment: "The description that describes what siri shortcuts are")
-    public static let SettingsSiriOpenURL = MZLocalizedString("Settings.Siri.OpenTabShortcut", value: "Open New Tab", comment: "The description of the open new tab siri shortcut")
+    public static let SendUsageSettingTitle = MZLocalizedString("Settings.SendUsage.Title", value: "Send Usage Data", comment: "The title for the setting to send usage data.", lastEditedIn: .unknown)
+    public static let SendUsageSettingLink = MZLocalizedString("Settings.SendUsage.Link", value: "Learn More.", comment: "title for a link that explains how mozilla collects telemetry", lastEditedIn: .unknown)
+    public static let SendUsageSettingMessage = MZLocalizedString("Settings.SendUsage.Message", value: "Mozilla strives to only collect what we need to provide and improve Firefox for everyone.", comment: "A short description that explains why mozilla collects usage data.", lastEditedIn: .unknown)
+    public static let SettingsSiriSectionName = MZLocalizedString("Settings.Siri.SectionName", value: "Siri Shortcuts", comment: "The option that takes you to the siri shortcuts settings page", lastEditedIn: .unknown)
+    public static let SettingsSiriSectionDescription = MZLocalizedString("Settings.Siri.SectionDescription", value: "Use Siri shortcuts to quickly open Firefox via Siri", comment: "The description that describes what siri shortcuts are", lastEditedIn: .unknown)
+    public static let SettingsSiriOpenURL = MZLocalizedString("Settings.Siri.OpenTabShortcut", value: "Open New Tab", comment: "The description of the open new tab siri shortcut", lastEditedIn: .unknown)
 }
 
 // MARK: - Nimbus settings
 extension Strings {
-    public static let SettingsStudiesTitle = MZLocalizedString("Settings.Studies.Title", value: "Studies", comment: "Label used as an item in Settings. Tapping on this item takes you to the Studies panel")
-    public static let SettingsStudiesSectionName = MZLocalizedString("Settings.Studies.SectionName", value: "Studies", comment: "Title displayed in header of the Studies panel")
-    public static let SettingsStudiesActiveSectionTitle = MZLocalizedString("Settings.Studies.Active.SectionName", value: "Active", comment: "Section title for all studies that are currently active")
-    public static let SettingsStudiesCompletedSectionTitle = MZLocalizedString("Settings.Studies.Completed.SectionName", value: "Completed", comment: "Section title for all studies that are completed")
-    public static let SettingsStudiesRemoveButton = MZLocalizedString("Settings.Studies.Remove.Button", value: "Remove", comment: "Button title displayed next to each study allowing the user to opt-out of the study")
+    public static let SettingsStudiesTitle = MZLocalizedString("Settings.Studies.Title", value: "Studies", comment: "Label used as an item in Settings. Tapping on this item takes you to the Studies panel", lastEditedIn: .unknown)
+    public static let SettingsStudiesSectionName = MZLocalizedString("Settings.Studies.SectionName", value: "Studies", comment: "Title displayed in header of the Studies panel", lastEditedIn: .unknown)
+    public static let SettingsStudiesActiveSectionTitle = MZLocalizedString("Settings.Studies.Active.SectionName", value: "Active", comment: "Section title for all studies that are currently active", lastEditedIn: .unknown)
+    public static let SettingsStudiesCompletedSectionTitle = MZLocalizedString("Settings.Studies.Completed.SectionName", value: "Completed", comment: "Section title for all studies that are completed", lastEditedIn: .unknown)
+    public static let SettingsStudiesRemoveButton = MZLocalizedString("Settings.Studies.Remove.Button", value: "Remove", comment: "Button title displayed next to each study allowing the user to opt-out of the study", lastEditedIn: .unknown)
 
-    public static let SettingsStudiesToggleTitle = MZLocalizedString("Settings.Studies.Toggle.Title", value: "Studies", comment: "Label used as a toggle item in Settings. When this is off, the user is opting out of all studies.")
-    public static let SettingsStudiesToggleLink = MZLocalizedString("Settings.Studies.Toggle.Link", value: "Learn More.", comment: "Title for a link that explains what Mozilla means by Studies")
-    public static let SettingsStudiesToggleMessage = MZLocalizedString("Settings.Studies.Toggle.Message", value: "Firefox may install and run studies from time to time.", comment: "A short description that explains that Mozilla is running studies")
+    public static let SettingsStudiesToggleTitle = MZLocalizedString("Settings.Studies.Toggle.Title", value: "Studies", comment: "Label used as a toggle item in Settings. When this is off, the user is opting out of all studies.", lastEditedIn: .unknown)
+    public static let SettingsStudiesToggleLink = MZLocalizedString("Settings.Studies.Toggle.Link", value: "Learn More.", comment: "Title for a link that explains what Mozilla means by Studies", lastEditedIn: .unknown)
+    public static let SettingsStudiesToggleMessage = MZLocalizedString("Settings.Studies.Toggle.Message", value: "Firefox may install and run studies from time to time.", comment: "A short description that explains that Mozilla is running studies", lastEditedIn: .unknown)
 
-    public static let SettingsStudiesToggleValueOn = MZLocalizedString("Settings.Studies.Toggle.On", value: "On", comment: "Toggled ON to participate in studies")
-    public static let SettingsStudiesToggleValueOff = MZLocalizedString("Settings.Studies.Toggle.Off", value: "Off", comment: "Toggled OFF to opt-out of studies")
+    public static let SettingsStudiesToggleValueOn = MZLocalizedString("Settings.Studies.Toggle.On", value: "On", comment: "Toggled ON to participate in studies", lastEditedIn: .unknown)
+    public static let SettingsStudiesToggleValueOff = MZLocalizedString("Settings.Studies.Toggle.Off", value: "Off", comment: "Toggled OFF to opt-out of studies", lastEditedIn: .unknown)
 }
 
 // MARK: - Do not track
 extension Strings {
-    public static let SettingsDoNotTrackTitle = MZLocalizedString("Settings.DNT.Title", value: "Send websites a Do Not Track signal that you don’t want to be tracked", comment: "DNT Settings title")
-    public static let SettingsDoNotTrackOptionOnWithTP = MZLocalizedString("Settings.DNT.OptionOnWithTP", value: "Only when using Tracking Protection", comment: "DNT Settings option for only turning on when Tracking Protection is also on")
-    public static let SettingsDoNotTrackOptionAlwaysOn = MZLocalizedString("Settings.DNT.OptionAlwaysOn", value: "Always", comment: "DNT Settings option for always on")
+    public static let SettingsDoNotTrackTitle = MZLocalizedString("Settings.DNT.Title", value: "Send websites a Do Not Track signal that you don’t want to be tracked", comment: "DNT Settings title", lastEditedIn: .unknown)
+    public static let SettingsDoNotTrackOptionOnWithTP = MZLocalizedString("Settings.DNT.OptionOnWithTP", value: "Only when using Tracking Protection", comment: "DNT Settings option for only turning on when Tracking Protection is also on", lastEditedIn: .unknown)
+    public static let SettingsDoNotTrackOptionAlwaysOn = MZLocalizedString("Settings.DNT.OptionAlwaysOn", value: "Always", comment: "DNT Settings option for always on", lastEditedIn: .unknown)
 }
 
 // MARK: - Intro Onboarding slides
 extension Strings {
     // First Card
-    public static let CardTitleWelcome = MZLocalizedString("Intro.Slides.Welcome.Title.v2", tableName: "Intro", value: "Welcome to Firefox", comment: "Title for the first panel 'Welcome' in the First Run tour.")
-    public static let CardTitleAutomaticPrivacy = MZLocalizedString("Intro.Slides.Automatic.Privacy.Title", tableName: "Intro", value: "Automatic Privacy", comment: "Title for the first item in the table related to automatic privacy")
-    public static let CardDescriptionAutomaticPrivacy = MZLocalizedString("Intro.Slides.Automatic.Privacy.Description", tableName: "Intro", value: "Enhanced Tracking Protection blocks malware and stops trackers.", comment: "Description for the first item in the table related to automatic privacy")
-    public static let CardTitleFastSearch = MZLocalizedString("Intro.Slides.Fast.Search.Title", tableName: "Intro", value: "Fast Search", comment: "Title for the second item in the table related to fast searching via address bar")
-    public static let CardDescriptionFastSearch = MZLocalizedString("Intro.Slides.Fast.Search.Description", tableName: "Intro", value: "Search suggestions get you to websites faster.", comment: "Description for the second item in the table related to fast searching via address bar")
-    public static let CardTitleSafeSync = MZLocalizedString("Intro.Slides.Safe.Sync.Title", tableName: "Intro", value: "Safe Sync", comment: "Title for the third item in the table related to safe syncing with a firefox account")
-    public static let CardDescriptionSafeSync = MZLocalizedString("Intro.Slides.Safe.Sync.Description", tableName: "Intro", value: "Protect your logins and data everywhere you use Firefox.", comment: "Description for the third item in the table related to safe syncing with a firefox account")
+    public static let CardTitleWelcome = MZLocalizedString("Intro.Slides.Welcome.Title.v2", tableName: "Intro", value: "Welcome to Firefox", comment: "Title for the first panel 'Welcome' in the First Run tour.", lastEditedIn: .unknown)
+    public static let CardTitleAutomaticPrivacy = MZLocalizedString("Intro.Slides.Automatic.Privacy.Title", tableName: "Intro", value: "Automatic Privacy", comment: "Title for the first item in the table related to automatic privacy", lastEditedIn: .unknown)
+    public static let CardDescriptionAutomaticPrivacy = MZLocalizedString("Intro.Slides.Automatic.Privacy.Description", tableName: "Intro", value: "Enhanced Tracking Protection blocks malware and stops trackers.", comment: "Description for the first item in the table related to automatic privacy", lastEditedIn: .unknown)
+    public static let CardTitleFastSearch = MZLocalizedString("Intro.Slides.Fast.Search.Title", tableName: "Intro", value: "Fast Search", comment: "Title for the second item in the table related to fast searching via address bar", lastEditedIn: .unknown)
+    public static let CardDescriptionFastSearch = MZLocalizedString("Intro.Slides.Fast.Search.Description", tableName: "Intro", value: "Search suggestions get you to websites faster.", comment: "Description for the second item in the table related to fast searching via address bar", lastEditedIn: .unknown)
+    public static let CardTitleSafeSync = MZLocalizedString("Intro.Slides.Safe.Sync.Title", tableName: "Intro", value: "Safe Sync", comment: "Title for the third item in the table related to safe syncing with a firefox account", lastEditedIn: .unknown)
+    public static let CardDescriptionSafeSync = MZLocalizedString("Intro.Slides.Safe.Sync.Description", tableName: "Intro", value: "Protect your logins and data everywhere you use Firefox.", comment: "Description for the third item in the table related to safe syncing with a firefox account", lastEditedIn: .unknown)
     
     // Second Card
-    public static let CardTitleFxASyncDevices = MZLocalizedString("Intro.Slides.Firefox.Account.Sync.Title", tableName: "Intro", value: "Sync Firefox Between Devices", comment: "Title for the first item in the table related to syncing data (bookmarks, history) via firefox account between devices")
-    public static let CardDescriptionFxASyncDevices = MZLocalizedString("Intro.Slides.Firefox.Account.Sync.Description", tableName: "Intro", value: "Bring bookmarks, history, and passwords to Firefox on this device.", comment: "Description for the first item in the table related to syncing data (bookmarks, history) via firefox account between devices")
+    public static let CardTitleFxASyncDevices = MZLocalizedString("Intro.Slides.Firefox.Account.Sync.Title", tableName: "Intro", value: "Sync Firefox Between Devices", comment: "Title for the first item in the table related to syncing data (bookmarks, history) via firefox account between devices", lastEditedIn: .unknown)
+    public static let CardDescriptionFxASyncDevices = MZLocalizedString("Intro.Slides.Firefox.Account.Sync.Description", tableName: "Intro", value: "Bring bookmarks, history, and passwords to Firefox on this device.", comment: "Description for the first item in the table related to syncing data (bookmarks, history) via firefox account between devices", lastEditedIn: .unknown)
     
     //----Other----//
-    public static let CardTitleSearch = MZLocalizedString("Intro.Slides.Search.Title", tableName: "Intro", value: "Your search, your way", comment: "Title for the second  panel 'Search' in the First Run tour.")
-    public static let CardTitlePrivate = MZLocalizedString("Intro.Slides.Private.Title", tableName: "Intro", value: "Browse like no one’s watching", comment: "Title for the third panel 'Private Browsing' in the First Run tour.")
-    public static let CardTitleMail = MZLocalizedString("Intro.Slides.Mail.Title", tableName: "Intro", value: "You’ve got mail… options", comment: "Title for the fourth panel 'Mail' in the First Run tour.")
-    public static let CardTitleSync = MZLocalizedString("Intro.Slides.TrailheadSync.Title.v2", tableName: "Intro", value: "Sync your bookmarks, history, and passwords to your phone.", comment: "Title for the second panel 'Sync' in the First Run tour.")
+    public static let CardTitleSearch = MZLocalizedString("Intro.Slides.Search.Title", tableName: "Intro", value: "Your search, your way", comment: "Title for the second  panel 'Search' in the First Run tour.", lastEditedIn: .unknown)
+    public static let CardTitlePrivate = MZLocalizedString("Intro.Slides.Private.Title", tableName: "Intro", value: "Browse like no one’s watching", comment: "Title for the third panel 'Private Browsing' in the First Run tour.", lastEditedIn: .unknown)
+    public static let CardTitleMail = MZLocalizedString("Intro.Slides.Mail.Title", tableName: "Intro", value: "You’ve got mail… options", comment: "Title for the fourth panel 'Mail' in the First Run tour.", lastEditedIn: .unknown)
+    public static let CardTitleSync = MZLocalizedString("Intro.Slides.TrailheadSync.Title.v2", tableName: "Intro", value: "Sync your bookmarks, history, and passwords to your phone.", comment: "Title for the second panel 'Sync' in the First Run tour.", lastEditedIn: .unknown)
 
-    public static let CardTextWelcome = MZLocalizedString("Intro.Slides.Welcome.Description.v2", tableName: "Intro", value: "Fast, private, and on your side.", comment: "Description for the 'Welcome' panel in the First Run tour.")
-    public static let CardTextSearch = MZLocalizedString("Intro.Slides.Search.Description", tableName: "Intro", value: "Searching for something different? Choose another default search engine (or add your own) in Settings.", comment: "Description for the 'Favorite Search Engine' panel in the First Run tour.")
-    public static let CardTextPrivate = MZLocalizedString("Intro.Slides.Private.Description", tableName: "Intro", value: "Tap the mask icon to slip into Private Browsing mode.", comment: "Description for the 'Private Browsing' panel in the First Run tour.")
-    public static let CardTextMail = MZLocalizedString("Intro.Slides.Mail.Description", tableName: "Intro", value: "Use any email app — not just Mail — with Firefox.", comment: "Description for the 'Mail' panel in the First Run tour.")
-    public static let CardTextSync = MZLocalizedString("Intro.Slides.TrailheadSync.Description", tableName: "Intro", value: "Sign in to your account to sync and access more features.", comment: "Description for the 'Sync' panel in the First Run tour.")
-    public static let SignInButtonTitle = MZLocalizedString("Turn on Sync…", tableName: "Intro", comment: "The button that opens the sign in page for sync. See http://mzl.la/1T8gxwo")
-    public static let StartBrowsingButtonTitle = MZLocalizedString("Start Browsing", tableName: "Intro", comment: "See http://mzl.la/1T8gxwo")
-    public static let IntroNextButtonTitle = MZLocalizedString("Intro.Slides.Button.Next", tableName: "Intro", value: "Next", comment: "Next button on the first intro screen.")
-    public static let IntroSignInButtonTitle = MZLocalizedString("Intro.Slides.Button.SignIn", tableName: "Intro", value: "Sign In", comment: "Sign in to Firefox account button on second intro screen.")
-    public static let IntroSignUpButtonTitle = MZLocalizedString("Intro.Slides.Button.SignUp", tableName: "Intro", value: "Sign Up", comment: "Sign up to Firefox account button on second intro screen.")
+    public static let CardTextWelcome = MZLocalizedString("Intro.Slides.Welcome.Description.v2", tableName: "Intro", value: "Fast, private, and on your side.", comment: "Description for the 'Welcome' panel in the First Run tour.", lastEditedIn: .unknown)
+    public static let CardTextSearch = MZLocalizedString("Intro.Slides.Search.Description", tableName: "Intro", value: "Searching for something different? Choose another default search engine (or add your own) in Settings.", comment: "Description for the 'Favorite Search Engine' panel in the First Run tour.", lastEditedIn: .unknown)
+    public static let CardTextPrivate = MZLocalizedString("Intro.Slides.Private.Description", tableName: "Intro", value: "Tap the mask icon to slip into Private Browsing mode.", comment: "Description for the 'Private Browsing' panel in the First Run tour.", lastEditedIn: .unknown)
+    public static let CardTextMail = MZLocalizedString("Intro.Slides.Mail.Description", tableName: "Intro", value: "Use any email app — not just Mail — with Firefox.", comment: "Description for the 'Mail' panel in the First Run tour.", lastEditedIn: .unknown)
+    public static let CardTextSync = MZLocalizedString("Intro.Slides.TrailheadSync.Description", tableName: "Intro", value: "Sign in to your account to sync and access more features.", comment: "Description for the 'Sync' panel in the First Run tour.", lastEditedIn: .unknown)
+    public static let SignInButtonTitle = MZLocalizedString("Turn on Sync…", tableName: "Intro", comment: "The button that opens the sign in page for sync. See http://mzl.la/1T8gxwo", lastEditedIn: .unknown)
+    public static let StartBrowsingButtonTitle = MZLocalizedString("Start Browsing", tableName: "Intro", comment: "See http://mzl.la/1T8gxwo", lastEditedIn: .unknown)
+    public static let IntroNextButtonTitle = MZLocalizedString("Intro.Slides.Button.Next", tableName: "Intro", value: "Next", comment: "Next button on the first intro screen.", lastEditedIn: .unknown)
+    public static let IntroSignInButtonTitle = MZLocalizedString("Intro.Slides.Button.SignIn", tableName: "Intro", value: "Sign In", comment: "Sign in to Firefox account button on second intro screen.", lastEditedIn: .unknown)
+    public static let IntroSignUpButtonTitle = MZLocalizedString("Intro.Slides.Button.SignUp", tableName: "Intro", value: "Sign Up", comment: "Sign up to Firefox account button on second intro screen.", lastEditedIn: .unknown)
 }
 
 // MARK: - Keyboard short cuts
 extension Strings {
-    public static let ShowTabTrayFromTabKeyCodeTitle = MZLocalizedString("Tab.ShowTabTray.KeyCodeTitle", value: "Show All Tabs", comment: "Hardware shortcut to open the tab tray from a tab. Shown in the Discoverability overlay when the hardware Command Key is held down.")
-    public static let CloseTabFromTabTrayKeyCodeTitle = MZLocalizedString("TabTray.CloseTab.KeyCodeTitle", value: "Close Selected Tab", comment: "Hardware shortcut to close the selected tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.")
-    public static let CloseAllTabsFromTabTrayKeyCodeTitle = MZLocalizedString("TabTray.CloseAllTabs.KeyCodeTitle", value: "Close All Tabs", comment: "Hardware shortcut to close all tabs from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.")
-    public static let OpenSelectedTabFromTabTrayKeyCodeTitle = MZLocalizedString("TabTray.OpenSelectedTab.KeyCodeTitle", value: "Open Selected Tab", comment: "Hardware shortcut open the selected tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.")
-    public static let OpenNewTabFromTabTrayKeyCodeTitle = MZLocalizedString("TabTray.OpenNewTab.KeyCodeTitle", value: "Open New Tab", comment: "Hardware shortcut to open a new tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.")
-    public static let ReopenClosedTabKeyCodeTitle = MZLocalizedString("ReopenClosedTab.KeyCodeTitle", value: "Reopen Closed Tab", comment: "Hardware shortcut to reopen the last closed tab, from the tab or the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.")
-    public static let SwitchToPBMKeyCodeTitle = MZLocalizedString("SwitchToPBM.KeyCodeTitle", value: "Private Browsing Mode", comment: "Hardware shortcut switch to the private browsing tab or tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.")
-    public static let SwitchToNonPBMKeyCodeTitle = MZLocalizedString("SwitchToNonPBM.KeyCodeTitle", value: "Normal Browsing Mode", comment: "Hardware shortcut for non-private tab or tab. Shown in the Discoverability overlay when the hardware Command Key is held down.")
+    public static let ShowTabTrayFromTabKeyCodeTitle = MZLocalizedString("Tab.ShowTabTray.KeyCodeTitle", value: "Show All Tabs", comment: "Hardware shortcut to open the tab tray from a tab. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
+    public static let CloseTabFromTabTrayKeyCodeTitle = MZLocalizedString("TabTray.CloseTab.KeyCodeTitle", value: "Close Selected Tab", comment: "Hardware shortcut to close the selected tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
+    public static let CloseAllTabsFromTabTrayKeyCodeTitle = MZLocalizedString("TabTray.CloseAllTabs.KeyCodeTitle", value: "Close All Tabs", comment: "Hardware shortcut to close all tabs from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
+    public static let OpenSelectedTabFromTabTrayKeyCodeTitle = MZLocalizedString("TabTray.OpenSelectedTab.KeyCodeTitle", value: "Open Selected Tab", comment: "Hardware shortcut open the selected tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
+    public static let OpenNewTabFromTabTrayKeyCodeTitle = MZLocalizedString("TabTray.OpenNewTab.KeyCodeTitle", value: "Open New Tab", comment: "Hardware shortcut to open a new tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
+    public static let ReopenClosedTabKeyCodeTitle = MZLocalizedString("ReopenClosedTab.KeyCodeTitle", value: "Reopen Closed Tab", comment: "Hardware shortcut to reopen the last closed tab, from the tab or the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
+    public static let SwitchToPBMKeyCodeTitle = MZLocalizedString("SwitchToPBM.KeyCodeTitle", value: "Private Browsing Mode", comment: "Hardware shortcut switch to the private browsing tab or tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
+    public static let SwitchToNonPBMKeyCodeTitle = MZLocalizedString("SwitchToNonPBM.KeyCodeTitle", value: "Normal Browsing Mode", comment: "Hardware shortcut for non-private tab or tab. Shown in the Discoverability overlay when the hardware Command Key is held down.", lastEditedIn: .unknown)
 }
 
 // MARK: - Share extension
 extension Strings {
-    public static let SendToCancelButton = MZLocalizedString("SendTo.Cancel.Button", value: "Cancel", comment: "Button title for cancelling share screen")
-    public static let SendToErrorOKButton = MZLocalizedString("SendTo.Error.OK.Button", value: "OK", comment: "OK button to dismiss the error prompt.")
-    public static let SendToErrorTitle = MZLocalizedString("SendTo.Error.Title", value: "The link you are trying to share cannot be shared.", comment: "Title of error prompt displayed when an invalid URL is shared.")
-    public static let SendToErrorMessage = MZLocalizedString("SendTo.Error.Message", value: "Only HTTP and HTTPS links can be shared.", comment: "Message in error prompt explaining why the URL is invalid.")
-    public static let SendToCloseButton = MZLocalizedString("SendTo.Cancel.Button", value: "Close", comment: "Close button in top navigation bar")
-    public static let SendToNotSignedInText = MZLocalizedString("SendTo.NotSignedIn.Title", value: "You are not signed in to your Firefox Account.", comment: "See http://mzl.la/1ISlXnU")
-    public static let SendToNotSignedInMessage = MZLocalizedString("SendTo.NotSignedIn.Message", value: "Please open Firefox, go to Settings and sign in to continue.", comment: "See http://mzl.la/1ISlXnU")
-    public static let SendToSignInButton = MZLocalizedString("SendTo.SignIn.Button", value: "Sign In to Firefox", comment: "The text for the button on the Send to Device page if you are not signed in to Firefox Accounts.")
-    public static let SendToNoDevicesFound = MZLocalizedString("SendTo.NoDevicesFound.Message", value: "You don’t have any other devices connected to this Firefox Account available to sync.", comment: "Error message shown in the remote tabs panel")
-    public static let SendToTitle = MZLocalizedString("SendTo.NavBar.Title", value: "Send Tab", comment: "Title of the dialog that allows you to send a tab to a different device")
-    public static let SendToSendButtonTitle = MZLocalizedString("SendTo.SendAction.Text", value: "Send", comment: "Navigation bar button to Send the current page to a device")
-    public static let SendToDevicesListTitle = MZLocalizedString("SendTo.DeviceList.Text", value: "Available devices:", comment: "Header for the list of devices table")
+    public static let SendToCancelButton = MZLocalizedString("SendTo.Cancel.Button", value: "Cancel", comment: "Button title for cancelling share screen", lastEditedIn: .unknown)
+    public static let SendToErrorOKButton = MZLocalizedString("SendTo.Error.OK.Button", value: "OK", comment: "OK button to dismiss the error prompt.", lastEditedIn: .unknown)
+    public static let SendToErrorTitle = MZLocalizedString("SendTo.Error.Title", value: "The link you are trying to share cannot be shared.", comment: "Title of error prompt displayed when an invalid URL is shared.", lastEditedIn: .unknown)
+    public static let SendToErrorMessage = MZLocalizedString("SendTo.Error.Message", value: "Only HTTP and HTTPS links can be shared.", comment: "Message in error prompt explaining why the URL is invalid.", lastEditedIn: .unknown)
+    public static let SendToCloseButton = MZLocalizedString("SendTo.Cancel.Button", value: "Close", comment: "Close button in top navigation bar", lastEditedIn: .unknown)
+    public static let SendToNotSignedInText = MZLocalizedString("SendTo.NotSignedIn.Title", value: "You are not signed in to your Firefox Account.", comment: "See http://mzl.la/1ISlXnU", lastEditedIn: .unknown)
+    public static let SendToNotSignedInMessage = MZLocalizedString("SendTo.NotSignedIn.Message", value: "Please open Firefox, go to Settings and sign in to continue.", comment: "See http://mzl.la/1ISlXnU", lastEditedIn: .unknown)
+    public static let SendToSignInButton = MZLocalizedString("SendTo.SignIn.Button", value: "Sign In to Firefox", comment: "The text for the button on the Send to Device page if you are not signed in to Firefox Accounts.", lastEditedIn: .unknown)
+    public static let SendToNoDevicesFound = MZLocalizedString("SendTo.NoDevicesFound.Message", value: "You don’t have any other devices connected to this Firefox Account available to sync.", comment: "Error message shown in the remote tabs panel", lastEditedIn: .unknown)
+    public static let SendToTitle = MZLocalizedString("SendTo.NavBar.Title", value: "Send Tab", comment: "Title of the dialog that allows you to send a tab to a different device", lastEditedIn: .unknown)
+    public static let SendToSendButtonTitle = MZLocalizedString("SendTo.SendAction.Text", value: "Send", comment: "Navigation bar button to Send the current page to a device", lastEditedIn: .unknown)
+    public static let SendToDevicesListTitle = MZLocalizedString("SendTo.DeviceList.Text", value: "Available devices:", comment: "Header for the list of devices table", lastEditedIn: .unknown)
     public static let ShareSendToDevice = Strings.SendToDeviceTitle
 
     // The above items are re-used strings from the old extension. New strings below.
 
-    public static let ShareAddToReadingList = MZLocalizedString("ShareExtension.AddToReadingListAction.Title", value: "Add to Reading List", comment: "Action label on share extension to add page to the Firefox reading list.")
-    public static let ShareAddToReadingListDone = MZLocalizedString("ShareExtension.AddToReadingListActionDone.Title", value: "Added to Reading List", comment: "Share extension label shown after user has performed 'Add to Reading List' action.")
-    public static let ShareBookmarkThisPage = MZLocalizedString("ShareExtension.BookmarkThisPageAction.Title", value: "Bookmark This Page", comment: "Action label on share extension to bookmark the page in Firefox.")
-    public static let ShareBookmarkThisPageDone = MZLocalizedString("ShareExtension.BookmarkThisPageActionDone.Title", value: "Bookmarked", comment: "Share extension label shown after user has performed 'Bookmark this Page' action.")
+    public static let ShareAddToReadingList = MZLocalizedString("ShareExtension.AddToReadingListAction.Title", value: "Add to Reading List", comment: "Action label on share extension to add page to the Firefox reading list.", lastEditedIn: .unknown)
+    public static let ShareAddToReadingListDone = MZLocalizedString("ShareExtension.AddToReadingListActionDone.Title", value: "Added to Reading List", comment: "Share extension label shown after user has performed 'Add to Reading List' action.", lastEditedIn: .unknown)
+    public static let ShareBookmarkThisPage = MZLocalizedString("ShareExtension.BookmarkThisPageAction.Title", value: "Bookmark This Page", comment: "Action label on share extension to bookmark the page in Firefox.", lastEditedIn: .unknown)
+    public static let ShareBookmarkThisPageDone = MZLocalizedString("ShareExtension.BookmarkThisPageActionDone.Title", value: "Bookmarked", comment: "Share extension label shown after user has performed 'Bookmark this Page' action.", lastEditedIn: .unknown)
 
-    public static let ShareOpenInFirefox = MZLocalizedString("ShareExtension.OpenInFirefoxAction.Title", value: "Open in Firefox", comment: "Action label on share extension to immediately open page in Firefox.")
-    public static let ShareSearchInFirefox = MZLocalizedString("ShareExtension.SeachInFirefoxAction.Title", value: "Search in Firefox", comment: "Action label on share extension to search for the selected text in Firefox.")
-    public static let ShareOpenInPrivateModeNow = MZLocalizedString("ShareExtension.OpenInPrivateModeAction.Title", value: "Open in Private Mode", comment: "Action label on share extension to immediately open page in Firefox in private mode.")
+    public static let ShareOpenInFirefox = MZLocalizedString("ShareExtension.OpenInFirefoxAction.Title", value: "Open in Firefox", comment: "Action label on share extension to immediately open page in Firefox.", lastEditedIn: .unknown)
+    public static let ShareSearchInFirefox = MZLocalizedString("ShareExtension.SeachInFirefoxAction.Title", value: "Search in Firefox", comment: "Action label on share extension to search for the selected text in Firefox.", lastEditedIn: .unknown)
+    public static let ShareOpenInPrivateModeNow = MZLocalizedString("ShareExtension.OpenInPrivateModeAction.Title", value: "Open in Private Mode", comment: "Action label on share extension to immediately open page in Firefox in private mode.", lastEditedIn: .unknown)
 
-    public static let ShareLoadInBackground = MZLocalizedString("ShareExtension.LoadInBackgroundAction.Title", value: "Load in Background", comment: "Action label on share extension to load the page in Firefox when user switches apps to bring it to foreground.")
-    public static let ShareLoadInBackgroundDone = MZLocalizedString("ShareExtension.LoadInBackgroundActionDone.Title", value: "Loading in Firefox", comment: "Share extension label shown after user has performed 'Load in Background' action.")
+    public static let ShareLoadInBackground = MZLocalizedString("ShareExtension.LoadInBackgroundAction.Title", value: "Load in Background", comment: "Action label on share extension to load the page in Firefox when user switches apps to bring it to foreground.", lastEditedIn: .unknown)
+    public static let ShareLoadInBackgroundDone = MZLocalizedString("ShareExtension.LoadInBackgroundActionDone.Title", value: "Loading in Firefox", comment: "Share extension label shown after user has performed 'Load in Background' action.", lastEditedIn: .unknown)
 
 }
 
 // MARK: - PasswordAutofill extension
 extension Strings {
-    public static let PasswordAutofillTitle = MZLocalizedString("PasswordAutoFill.SectionTitle", value: "Firefox Credentials", comment: "Title of the extension that shows firefox passwords")
-    public static let CredentialProviderNoCredentialError = MZLocalizedString("PasswordAutoFill.NoPasswordsFoundTitle", value: "You don’t have any credentials synced from your Firefox Account", comment: "Error message shown in the remote tabs panel")
-    public static let AvailableCredentialsHeader = MZLocalizedString("PasswordAutoFill.PasswordsListTitle", value: "Available Credentials:", comment: "Header for the list of credentials table")
+    public static let PasswordAutofillTitle = MZLocalizedString("PasswordAutoFill.SectionTitle", value: "Firefox Credentials", comment: "Title of the extension that shows firefox passwords", lastEditedIn: .unknown)
+    public static let CredentialProviderNoCredentialError = MZLocalizedString("PasswordAutoFill.NoPasswordsFoundTitle", value: "You don’t have any credentials synced from your Firefox Account", comment: "Error message shown in the remote tabs panel", lastEditedIn: .unknown)
+    public static let AvailableCredentialsHeader = MZLocalizedString("PasswordAutoFill.PasswordsListTitle", value: "Available Credentials:", comment: "Header for the list of credentials table", lastEditedIn: .unknown)
 }
 
 // MARK: - Translation bar
 extension Strings {
-    public static let TranslateSnackBarPrompt = MZLocalizedString("TranslationToastHandler.PromptTranslate.Title", value: "This page appears to be in %1$@. Translate to %2$@ with %3$@?", comment: "Prompt for translation. The first parameter is the language the page is in. The second parameter is the name of our local language. The third is the name of the service.")
-    public static let TranslateSnackBarYes = MZLocalizedString("TranslationToastHandler.PromptTranslate.OK", value: "Yes", comment: "Button to allow the page to be translated to the user locale language")
-    public static let TranslateSnackBarNo = MZLocalizedString("TranslationToastHandler.PromptTranslate.Cancel", value: "No", comment: "Button to disallow the page to be translated to the user locale language")
+    public static let TranslateSnackBarPrompt = MZLocalizedString("TranslationToastHandler.PromptTranslate.Title", value: "This page appears to be in %1$@. Translate to %2$@ with %3$@?", comment: "Prompt for translation. The first parameter is the language the page is in. The second parameter is the name of our local language. The third is the name of the service.", lastEditedIn: .unknown)
+    public static let TranslateSnackBarYes = MZLocalizedString("TranslationToastHandler.PromptTranslate.OK", value: "Yes", comment: "Button to allow the page to be translated to the user locale language", lastEditedIn: .unknown)
+    public static let TranslateSnackBarNo = MZLocalizedString("TranslationToastHandler.PromptTranslate.Cancel", value: "No", comment: "Button to disallow the page to be translated to the user locale language", lastEditedIn: .unknown)
 
-    public static let SettingTranslateSnackBarSectionHeader = MZLocalizedString("Settings.TranslateSnackBar.SectionHeader", value: "Services", comment: "Translation settings section title")
-    public static let SettingTranslateSnackBarSectionFooter = MZLocalizedString("Settings.TranslateSnackBar.SectionFooter", value: "The web page language is detected on the device, and a translation from a remote service is offered.", comment: "Translation settings footer describing how language detection and translation happens.")
-    public static let SettingTranslateSnackBarTitle = MZLocalizedString("Settings.TranslateSnackBar.Title", value: "Translation", comment: "Title in main app settings for Translation toast settings")
-    public static let SettingTranslateSnackBarSwitchTitle = MZLocalizedString("Settings.TranslateSnackBar.SwitchTitle", value: "Offer Translation", comment: "Switch to choose if the language of a page is detected and offer to translate.")
-    public static let SettingTranslateSnackBarSwitchSubtitle = MZLocalizedString("Settings.TranslateSnackBar.SwitchSubtitle", value: "Offer to translate any site written in a language that is different from your default language.", comment: "Switch to choose if the language of a page is detected and offer to translate.")
+    public static let SettingTranslateSnackBarSectionHeader = MZLocalizedString("Settings.TranslateSnackBar.SectionHeader", value: "Services", comment: "Translation settings section title", lastEditedIn: .unknown)
+    public static let SettingTranslateSnackBarSectionFooter = MZLocalizedString("Settings.TranslateSnackBar.SectionFooter", value: "The web page language is detected on the device, and a translation from a remote service is offered.", comment: "Translation settings footer describing how language detection and translation happens.", lastEditedIn: .unknown)
+    public static let SettingTranslateSnackBarTitle = MZLocalizedString("Settings.TranslateSnackBar.Title", value: "Translation", comment: "Title in main app settings for Translation toast settings", lastEditedIn: .unknown)
+    public static let SettingTranslateSnackBarSwitchTitle = MZLocalizedString("Settings.TranslateSnackBar.SwitchTitle", value: "Offer Translation", comment: "Switch to choose if the language of a page is detected and offer to translate.", lastEditedIn: .unknown)
+    public static let SettingTranslateSnackBarSwitchSubtitle = MZLocalizedString("Settings.TranslateSnackBar.SwitchSubtitle", value: "Offer to translate any site written in a language that is different from your default language.", comment: "Switch to choose if the language of a page is detected and offer to translate.", lastEditedIn: .unknown)
 }
 
 // MARK: - Display Theme
 extension Strings {
-    public static let SettingsDisplayThemeTitle = MZLocalizedString("Settings.DisplayTheme.Title.v2", value: "Theme", comment: "Title in main app settings for Theme settings")
-    public static let DisplayThemeBrightnessThresholdSectionHeader = MZLocalizedString("Settings.DisplayTheme.BrightnessThreshold.SectionHeader", value: "Threshold", comment: "Section header for brightness slider.")
-    public static let DisplayThemeSectionFooter = MZLocalizedString("Settings.DisplayTheme.SectionFooter", value: "The theme will automatically change based on your display brightness. You can set the threshold where the theme changes. The circle indicates your display's current brightness.", comment: "Display (theme) settings footer describing how the brightness slider works.")
-    public static let SystemThemeSectionHeader = MZLocalizedString("Settings.DisplayTheme.SystemTheme.SectionHeader", value: "System Theme", comment: "System theme settings section title")
-    public static let SystemThemeSectionSwitchTitle = MZLocalizedString("Settings.DisplayTheme.SystemTheme.SwitchTitle", value: "Use System Light/Dark Mode", comment: "System theme settings switch to choose whether to use the same theme as the system")
-    public static let ThemeSwitchModeSectionHeader = MZLocalizedString("Settings.DisplayTheme.SwitchMode.SectionHeader", value: "Switch Mode", comment: "Switch mode settings section title")
-    public static let ThemePickerSectionHeader = MZLocalizedString("Settings.DisplayTheme.ThemePicker.SectionHeader", value: "Theme Picker", comment: "Theme picker settings section title")
-    public static let DisplayThemeAutomaticSwitchTitle = MZLocalizedString("Settings.DisplayTheme.SwitchTitle", value: "Automatically", comment: "Display (theme) settings switch to choose whether to set the dark mode manually, or automatically based on the brightness slider.")
-    public static let DisplayThemeAutomaticStatusLabel = MZLocalizedString("Settings.DisplayTheme.SwitchTitle", value: "Automatic", comment: "Display (theme) settings label to show if automatically switch theme is enabled.")
-    public static let DisplayThemeAutomaticSwitchSubtitle = MZLocalizedString("Settings.DisplayTheme.SwitchSubtitle", value: "Switch automatically based on screen brightness", comment: "Display (theme) settings switch subtitle, explaining the title 'Automatically'.")
-    public static let DisplayThemeManualSwitchTitle = MZLocalizedString("Settings.DisplayTheme.Manual.SwitchTitle", value: "Manually", comment: "Display (theme) setting to choose the theme manually.")
-    public static let DisplayThemeManualSwitchSubtitle = MZLocalizedString("Settings.DisplayTheme.Manual.SwitchSubtitle", value: "Pick which theme you want", comment: "Display (theme) settings switch subtitle, explaining the title 'Manually'.")
-    public static let DisplayThemeManualStatusLabel = MZLocalizedString("Settings.DisplayTheme.Manual.StatusLabel", value: "Manual", comment: "Display (theme) settings label to show if manually switch theme is enabled.")
-    public static let DisplayThemeOptionLight = MZLocalizedString("Settings.DisplayTheme.OptionLight", value: "Light", comment: "Option choice in display theme settings for light theme")
-    public static let DisplayThemeOptionDark = MZLocalizedString("Settings.DisplayTheme.OptionDark", value: "Dark", comment: "Option choice in display theme settings for dark theme")
+    public static let SettingsDisplayThemeTitle = MZLocalizedString("Settings.DisplayTheme.Title.v2", value: "Theme", comment: "Title in main app settings for Theme settings", lastEditedIn: .unknown)
+    public static let DisplayThemeBrightnessThresholdSectionHeader = MZLocalizedString("Settings.DisplayTheme.BrightnessThreshold.SectionHeader", value: "Threshold", comment: "Section header for brightness slider.", lastEditedIn: .unknown)
+    public static let DisplayThemeSectionFooter = MZLocalizedString("Settings.DisplayTheme.SectionFooter", value: "The theme will automatically change based on your display brightness. You can set the threshold where the theme changes. The circle indicates your display's current brightness.", comment: "Display (theme) settings footer describing how the brightness slider works.", lastEditedIn: .unknown)
+    public static let SystemThemeSectionHeader = MZLocalizedString("Settings.DisplayTheme.SystemTheme.SectionHeader", value: "System Theme", comment: "System theme settings section title", lastEditedIn: .unknown)
+    public static let SystemThemeSectionSwitchTitle = MZLocalizedString("Settings.DisplayTheme.SystemTheme.SwitchTitle", value: "Use System Light/Dark Mode", comment: "System theme settings switch to choose whether to use the same theme as the system", lastEditedIn: .unknown)
+    public static let ThemeSwitchModeSectionHeader = MZLocalizedString("Settings.DisplayTheme.SwitchMode.SectionHeader", value: "Switch Mode", comment: "Switch mode settings section title", lastEditedIn: .unknown)
+    public static let ThemePickerSectionHeader = MZLocalizedString("Settings.DisplayTheme.ThemePicker.SectionHeader", value: "Theme Picker", comment: "Theme picker settings section title", lastEditedIn: .unknown)
+    public static let DisplayThemeAutomaticSwitchTitle = MZLocalizedString("Settings.DisplayTheme.SwitchTitle", value: "Automatically", comment: "Display (theme) settings switch to choose whether to set the dark mode manually, or automatically based on the brightness slider.", lastEditedIn: .unknown)
+    public static let DisplayThemeAutomaticStatusLabel = MZLocalizedString("Settings.DisplayTheme.SwitchTitle", value: "Automatic", comment: "Display (theme) settings label to show if automatically switch theme is enabled.", lastEditedIn: .unknown)
+    public static let DisplayThemeAutomaticSwitchSubtitle = MZLocalizedString("Settings.DisplayTheme.SwitchSubtitle", value: "Switch automatically based on screen brightness", comment: "Display (theme) settings switch subtitle, explaining the title 'Automatically'.", lastEditedIn: .unknown)
+    public static let DisplayThemeManualSwitchTitle = MZLocalizedString("Settings.DisplayTheme.Manual.SwitchTitle", value: "Manually", comment: "Display (theme) setting to choose the theme manually.", lastEditedIn: .unknown)
+    public static let DisplayThemeManualSwitchSubtitle = MZLocalizedString("Settings.DisplayTheme.Manual.SwitchSubtitle", value: "Pick which theme you want", comment: "Display (theme) settings switch subtitle, explaining the title 'Manually'.", lastEditedIn: .unknown)
+    public static let DisplayThemeManualStatusLabel = MZLocalizedString("Settings.DisplayTheme.Manual.StatusLabel", value: "Manual", comment: "Display (theme) settings label to show if manually switch theme is enabled.", lastEditedIn: .unknown)
+    public static let DisplayThemeOptionLight = MZLocalizedString("Settings.DisplayTheme.OptionLight", value: "Light", comment: "Option choice in display theme settings for light theme", lastEditedIn: .unknown)
+    public static let DisplayThemeOptionDark = MZLocalizedString("Settings.DisplayTheme.OptionDark", value: "Dark", comment: "Option choice in display theme settings for dark theme", lastEditedIn: .unknown)
 }
 
 extension Strings {
-    public static let AddTabAccessibilityLabel = MZLocalizedString("TabTray.AddTab.Button", value: "Add Tab", comment: "Accessibility label for the Add Tab button in the Tab Tray.")
+    public static let AddTabAccessibilityLabel = MZLocalizedString("TabTray.AddTab.Button", value: "Add Tab", comment: "Accessibility label for the Add Tab button in the Tab Tray.", lastEditedIn: .unknown)
 }
 
 // MARK: - Cover Sheet
 extension Strings {
     // Dark Mode Cover Sheet
-    public static let CoverSheetV22DarkModeTitle = MZLocalizedString("CoverSheet.v22.DarkMode.Title", value: "Dark theme now includes a dark keyboard and dark splash screen.", comment: "Title for the new dark mode change in the version 22 app release.")
-    public static let CoverSheetV22DarkModeDescription = MZLocalizedString("CoverSheet.v22.DarkMode.Description", value: "For iOS 13 users, Firefox now automatically switches to a dark theme when your phone is set to Dark Mode. To change this behavior, go to Settings > Theme.", comment: "Description for the new dark mode change in the version 22 app release. It describes the new automatic dark theme and how to change the theme settings.")
+    public static let CoverSheetV22DarkModeTitle = MZLocalizedString("CoverSheet.v22.DarkMode.Title", value: "Dark theme now includes a dark keyboard and dark splash screen.", comment: "Title for the new dark mode change in the version 22 app release.", lastEditedIn: .unknown)
+    public static let CoverSheetV22DarkModeDescription = MZLocalizedString("CoverSheet.v22.DarkMode.Description", value: "For iOS 13 users, Firefox now automatically switches to a dark theme when your phone is set to Dark Mode. To change this behavior, go to Settings > Theme.", comment: "Description for the new dark mode change in the version 22 app release. It describes the new automatic dark theme and how to change the theme settings.", lastEditedIn: .unknown)
     
     // ETP Cover Sheet
-    public static let CoverSheetETPTitle = MZLocalizedString("CoverSheet.v24.ETP.Title", value: "Protection Against Ad Tracking", comment: "Title for the new ETP mode i.e. standard vs strict")
-    public static let CoverSheetETPDescription = MZLocalizedString("CoverSheet.v24.ETP.Description", value: "Built-in Enhanced Tracking Protection helps stop ads from following you around. Turn on Strict to block even more trackers, ads, and popups. ", comment: "Description for the new ETP mode i.e. standard vs strict")
-    public static let CoverSheetETPSettingsButton = MZLocalizedString("CoverSheet.v24.ETP.Settings.Button", value: "Go to Settings", comment: "Text for the new ETP settings button")
+    public static let CoverSheetETPTitle = MZLocalizedString("CoverSheet.v24.ETP.Title", value: "Protection Against Ad Tracking", comment: "Title for the new ETP mode i.e. standard vs strict", lastEditedIn: .unknown)
+    public static let CoverSheetETPDescription = MZLocalizedString("CoverSheet.v24.ETP.Description", value: "Built-in Enhanced Tracking Protection helps stop ads from following you around. Turn on Strict to block even more trackers, ads, and popups. ", comment: "Description for the new ETP mode i.e. standard vs strict", lastEditedIn: .unknown)
+    public static let CoverSheetETPSettingsButton = MZLocalizedString("CoverSheet.v24.ETP.Settings.Button", value: "Go to Settings", comment: "Text for the new ETP settings button", lastEditedIn: .unknown)
 }
 
 // MARK: - FxA Signin screen
 extension Strings {
-    public static let FxASignin_Title = MZLocalizedString("fxa.signin.turn-on-sync", value: "Turn on Sync", comment: "FxA sign in view title")
-    public static let FxASignin_Subtitle = MZLocalizedString("fxa.signin.camera-signin", value: "Sign In with Your Camera", comment: "FxA sign in view subtitle")
-    public static let FxASignin_QRInstructions = MZLocalizedString("fxa.signin.qr-link-instruction", value: "On your computer open Firefox and go to firefox.com/pair", comment: "FxA sign in view qr code instructions")
-    public static let FxASignin_QRScanSignin = MZLocalizedString("fxa.signin.ready-to-scan", value: "Ready to Scan", comment: "FxA sign in view qr code scan button")
-    public static let FxASignin_EmailSignin = MZLocalizedString("fxa.signin.use-email-instead", value: "Use Email Instead", comment: "FxA sign in view email login button")
-    public static let FxASignin_CreateAccountPt1 = MZLocalizedString("fxa.signin.create-account-pt-1", value: "Sync Firefox between devices with an account.", comment: "FxA sign in create account label.")
-    public static let FxASignin_CreateAccountPt2 = MZLocalizedString("fxa.signin.create-account-pt-2", value: "Create Firefox account.", comment: "FxA sign in create account label. This will be linked to the site to create an account.")
+    public static let FxASignin_Title = MZLocalizedString("fxa.signin.turn-on-sync", value: "Turn on Sync", comment: "FxA sign in view title", lastEditedIn: .unknown)
+    public static let FxASignin_Subtitle = MZLocalizedString("fxa.signin.camera-signin", value: "Sign In with Your Camera", comment: "FxA sign in view subtitle", lastEditedIn: .unknown)
+    public static let FxASignin_QRInstructions = MZLocalizedString("fxa.signin.qr-link-instruction", value: "On your computer open Firefox and go to firefox.com/pair", comment: "FxA sign in view qr code instructions", lastEditedIn: .unknown)
+    public static let FxASignin_QRScanSignin = MZLocalizedString("fxa.signin.ready-to-scan", value: "Ready to Scan", comment: "FxA sign in view qr code scan button", lastEditedIn: .unknown)
+    public static let FxASignin_EmailSignin = MZLocalizedString("fxa.signin.use-email-instead", value: "Use Email Instead", comment: "FxA sign in view email login button", lastEditedIn: .unknown)
+    public static let FxASignin_CreateAccountPt1 = MZLocalizedString("fxa.signin.create-account-pt-1", value: "Sync Firefox between devices with an account.", comment: "FxA sign in create account label.", lastEditedIn: .unknown)
+    public static let FxASignin_CreateAccountPt2 = MZLocalizedString("fxa.signin.create-account-pt-2", value: "Create Firefox account.", comment: "FxA sign in create account label. This will be linked to the site to create an account.", lastEditedIn: .unknown)
 }
 
 // MARK: - FxA QR code scanning screen
 extension String {
-    public static let FxAQRCode_Instructions = MZLocalizedString("fxa.qr-scanning-view.instructions", value: "Scan the QR code shown at firefox.com/pair", comment: "Instructions shown on qr code scanning view")
+    public static let FxAQRCode_Instructions = MZLocalizedString("fxa.qr-scanning-view.instructions", value: "Scan the QR code shown at firefox.com/pair", comment: "Instructions shown on qr code scanning view", lastEditedIn: .unknown)
 }
 
 // MARK: - Today Widget Strings - [New Search - Private Search]
 extension String {
-    public static let NewTabButtonLabel = MZLocalizedString("TodayWidget.NewTabButtonLabelV1", tableName: "Today", value: "New Search", comment: "Open New Tab button label")
-    public static let CopiedLinkLabelFromPasteBoard = MZLocalizedString("TodayWidget.CopiedLinkLabelFromPasteBoardV1", tableName: "Today", value: "Copied Link from clipboard", comment: "Copied Link from clipboard displayed")
-    public static let NewPrivateTabButtonLabel = MZLocalizedString("TodayWidget.PrivateTabButtonLabelV1", tableName: "Today", value: "Private Search", comment: "Open New Private Tab button label")
+    public static let NewTabButtonLabel = MZLocalizedString("TodayWidget.NewTabButtonLabelV1", tableName: "Today", value: "New Search", comment: "Open New Tab button label", lastEditedIn: .unknown)
+    public static let CopiedLinkLabelFromPasteBoard = MZLocalizedString("TodayWidget.CopiedLinkLabelFromPasteBoardV1", tableName: "Today", value: "Copied Link from clipboard", comment: "Copied Link from clipboard displayed", lastEditedIn: .unknown)
+    public static let NewPrivateTabButtonLabel = MZLocalizedString("TodayWidget.PrivateTabButtonLabelV1", tableName: "Today", value: "Private Search", comment: "Open New Private Tab button label", lastEditedIn: .unknown)
     
     // Widget - Shared
 
-    public static let QuickActionsGalleryTitle = MZLocalizedString("TodayWidget.QuickActionsGalleryTitle", tableName: "Today", value: "Quick Actions", comment: "Quick Actions title when widget enters edit mode")
-    public static let QuickActionsGalleryTitlev2 = MZLocalizedString("TodayWidget.QuickActionsGalleryTitleV2", tableName: "Today", value: "Firefox Shortcuts", comment: "Firefox shortcuts title when widget enters edit mode. Do not translate the word Firefox.")
+    public static let QuickActionsGalleryTitle = MZLocalizedString("TodayWidget.QuickActionsGalleryTitle", tableName: "Today", value: "Quick Actions", comment: "Quick Actions title when widget enters edit mode", lastEditedIn: .unknown)
+    public static let QuickActionsGalleryTitlev2 = MZLocalizedString("TodayWidget.QuickActionsGalleryTitleV2", tableName: "Today", value: "Firefox Shortcuts", comment: "Firefox shortcuts title when widget enters edit mode. Do not translate the word Firefox.", lastEditedIn: .unknown)
     
     // Quick View - Gallery View
-    public static let QuickViewGalleryTile = MZLocalizedString("TodayWidget.QuickViewGalleryTitle", tableName: "Today", value: "Quick View", comment: "Quick View title user is picking a widget to add.")
+    public static let QuickViewGalleryTile = MZLocalizedString("TodayWidget.QuickViewGalleryTitle", tableName: "Today", value: "Quick View", comment: "Quick View title user is picking a widget to add.", lastEditedIn: .unknown)
     
     // Quick Action - Medium Size Quick Action
-    public static let QuickActionsSubLabel = MZLocalizedString("TodayWidget.QuickActionsSubLabel", tableName: "Today", value: "Firefox - Quick Actions", comment: "Sub label for medium size quick action widget")
-    public static let NewSearchButtonLabel = MZLocalizedString("TodayWidget.NewSearchButtonLabelV1", tableName: "Today", value: "Search in Firefox", comment: "Open New Tab button label")
-    public static let NewPrivateTabButtonLabelV2 = MZLocalizedString("TodayWidget.NewPrivateTabButtonLabelV2", tableName: "Today", value: "Search in Private Tab", comment: "Open New Private Tab button label for medium size action")
-    public static let GoToCopiedLinkLabel = MZLocalizedString("TodayWidget.GoToCopiedLinkLabelV1", tableName: "Today", value: "Go to copied link", comment: "Go to link pasted on the clipboard")
-    public static let GoToCopiedLinkLabelV2 = MZLocalizedString("TodayWidget.GoToCopiedLinkLabelV2", tableName: "Today", value: "Go to\nCopied Link", comment: "Go to copied link")
-    public static let GoToCopiedLinkLabelV3 = MZLocalizedString("TodayWidget.GoToCopiedLinkLabelV3", tableName: "Today", value: "Go to Copied Link", comment: "Go To Copied Link text pasted on the clipboard but this string doesn't have new line character")
-    public static let ClosePrivateTab = MZLocalizedString("TodayWidget.ClosePrivateTabsButton", tableName: "Today", value: "Close Private Tabs", comment: "Close Private Tabs button label")
+    public static let QuickActionsSubLabel = MZLocalizedString("TodayWidget.QuickActionsSubLabel", tableName: "Today", value: "Firefox - Quick Actions", comment: "Sub label for medium size quick action widget", lastEditedIn: .unknown)
+    public static let NewSearchButtonLabel = MZLocalizedString("TodayWidget.NewSearchButtonLabelV1", tableName: "Today", value: "Search in Firefox", comment: "Open New Tab button label", lastEditedIn: .unknown)
+    public static let NewPrivateTabButtonLabelV2 = MZLocalizedString("TodayWidget.NewPrivateTabButtonLabelV2", tableName: "Today", value: "Search in Private Tab", comment: "Open New Private Tab button label for medium size action", lastEditedIn: .unknown)
+    public static let GoToCopiedLinkLabel = MZLocalizedString("TodayWidget.GoToCopiedLinkLabelV1", tableName: "Today", value: "Go to copied link", comment: "Go to link pasted on the clipboard", lastEditedIn: .unknown)
+    public static let GoToCopiedLinkLabelV2 = MZLocalizedString("TodayWidget.GoToCopiedLinkLabelV2", tableName: "Today", value: "Go to\nCopied Link", comment: "Go to copied link", lastEditedIn: .unknown)
+    public static let GoToCopiedLinkLabelV3 = MZLocalizedString("TodayWidget.GoToCopiedLinkLabelV3", tableName: "Today", value: "Go to Copied Link", comment: "Go To Copied Link text pasted on the clipboard but this string doesn't have new line character", lastEditedIn: .unknown)
+    public static let ClosePrivateTab = MZLocalizedString("TodayWidget.ClosePrivateTabsButton", tableName: "Today", value: "Close Private Tabs", comment: "Close Private Tabs button label", lastEditedIn: .unknown)
     
     // Quick Action - Medium Size - Gallery View
-    public static let FirefoxShortcutGalleryDescription = MZLocalizedString("TodayWidget.FirefoxShortcutGalleryDescription", tableName: "Today", value: "Add Firefox shortcuts to your Home screen.", comment: "Description for medium size widget to add Firefox Shortcut to home screen")
+    public static let FirefoxShortcutGalleryDescription = MZLocalizedString("TodayWidget.FirefoxShortcutGalleryDescription", tableName: "Today", value: "Add Firefox shortcuts to your Home screen.", comment: "Description for medium size widget to add Firefox Shortcut to home screen", lastEditedIn: .unknown)
     
     // Quick Action - Small Size Widget
-    public static let SearchInFirefoxTitle = MZLocalizedString("TodayWidget.SearchInFirefoxTitle", tableName: "Today", value: "Search in Firefox", comment: "Title for small size widget which allows users to search in Firefox. Do not translate the word Firefox.")
-    public static let SearchInPrivateTabLabelV2 = MZLocalizedString("TodayWidget.SearchInPrivateTabLabelV2", tableName: "Today", value: "Search in\nPrivate Tab", comment: "Search in private tab")
-    public static let SearchInFirefoxV2 = MZLocalizedString("TodayWidget.SearchInFirefoxV2", tableName: "Today", value: "Search in\nFirefox", comment: "Search in Firefox. Do not translate the word Firefox")
-    public static let ClosePrivateTabsLabelV2 = MZLocalizedString("TodayWidget.ClosePrivateTabsLabelV2", tableName: "Today", value: "Close\nPrivate Tabs", comment: "Close Private Tabs")
-    public static let ClosePrivateTabsLabelV3 = MZLocalizedString("TodayWidget.ClosePrivateTabsLabelV3", tableName: "Today", value: "Close\nPrivate\nTabs", comment: "Close Private Tabs")
-    public static let GoToCopiedLinkLabelV4 = MZLocalizedString("TodayWidget.GoToCopiedLinkLabelV4", tableName: "Today", value: "Go to\nCopied\nLink", comment: "Go to copied link")
+    public static let SearchInFirefoxTitle = MZLocalizedString("TodayWidget.SearchInFirefoxTitle", tableName: "Today", value: "Search in Firefox", comment: "Title for small size widget which allows users to search in Firefox. Do not translate the word Firefox.", lastEditedIn: .unknown)
+    public static let SearchInPrivateTabLabelV2 = MZLocalizedString("TodayWidget.SearchInPrivateTabLabelV2", tableName: "Today", value: "Search in\nPrivate Tab", comment: "Search in private tab", lastEditedIn: .unknown)
+    public static let SearchInFirefoxV2 = MZLocalizedString("TodayWidget.SearchInFirefoxV2", tableName: "Today", value: "Search in\nFirefox", comment: "Search in Firefox. Do not translate the word Firefox", lastEditedIn: .unknown)
+    public static let ClosePrivateTabsLabelV2 = MZLocalizedString("TodayWidget.ClosePrivateTabsLabelV2", tableName: "Today", value: "Close\nPrivate Tabs", comment: "Close Private Tabs", lastEditedIn: .unknown)
+    public static let ClosePrivateTabsLabelV3 = MZLocalizedString("TodayWidget.ClosePrivateTabsLabelV3", tableName: "Today", value: "Close\nPrivate\nTabs", comment: "Close Private Tabs", lastEditedIn: .unknown)
+    public static let GoToCopiedLinkLabelV4 = MZLocalizedString("TodayWidget.GoToCopiedLinkLabelV4", tableName: "Today", value: "Go to\nCopied\nLink", comment: "Go to copied link", lastEditedIn: .unknown)
     
     // Quick Action - Small Size Widget - Edit Mode
-    public static let QuickActionDescription = MZLocalizedString("TodayWidget.QuickActionDescription", tableName: "Today", value: "Select a Firefox shortcut to add to your Home screen.", comment: "Quick action description when widget enters edit mode")
-    public static let QuickActionDropDownMenu = MZLocalizedString("TodayWidget.QuickActionDropDownMenu", tableName: "Today", value: "Quick action", comment: "Quick Actions left label text for dropdown menu when widget enters edit mode")
-    public static let DropDownMenuItemNewSearch = MZLocalizedString("TodayWidget.DropDownMenuItemNewSearch", tableName: "Today", value: "New Search", comment: "Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands")
-    public static let DropDownMenuItemNewPrivateSearch = MZLocalizedString("TodayWidget.DropDownMenuItemNewPrivateSearch", tableName: "Today", value: "New Private Search", comment: "Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands")
-    public static let DropDownMenuItemGoToCopiedLink = MZLocalizedString("TodayWidget.DropDownMenuItemGoToCopiedLink", tableName: "Today", value: "Go to Copied Link", comment: "Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands")
-    public static let DropDownMenuItemClearPrivateTabs = MZLocalizedString("TodayWidget.DropDownMenuItemClearPrivateTabs", tableName: "Today", value: "Clear Private Tabs", comment: "Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands")
+    public static let QuickActionDescription = MZLocalizedString("TodayWidget.QuickActionDescription", tableName: "Today", value: "Select a Firefox shortcut to add to your Home screen.", comment: "Quick action description when widget enters edit mode", lastEditedIn: .unknown)
+    public static let QuickActionDropDownMenu = MZLocalizedString("TodayWidget.QuickActionDropDownMenu", tableName: "Today", value: "Quick action", comment: "Quick Actions left label text for dropdown menu when widget enters edit mode", lastEditedIn: .unknown)
+    public static let DropDownMenuItemNewSearch = MZLocalizedString("TodayWidget.DropDownMenuItemNewSearch", tableName: "Today", value: "New Search", comment: "Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands", lastEditedIn: .unknown)
+    public static let DropDownMenuItemNewPrivateSearch = MZLocalizedString("TodayWidget.DropDownMenuItemNewPrivateSearch", tableName: "Today", value: "New Private Search", comment: "Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands", lastEditedIn: .unknown)
+    public static let DropDownMenuItemGoToCopiedLink = MZLocalizedString("TodayWidget.DropDownMenuItemGoToCopiedLink", tableName: "Today", value: "Go to Copied Link", comment: "Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands", lastEditedIn: .unknown)
+    public static let DropDownMenuItemClearPrivateTabs = MZLocalizedString("TodayWidget.DropDownMenuItemClearPrivateTabs", tableName: "Today", value: "Clear Private Tabs", comment: "Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands", lastEditedIn: .unknown)
     
     // Quick Action - Small Size - Gallery View
-    public static let QuickActionGalleryDescription = MZLocalizedString("TodayWidget.QuickActionGalleryDescription", tableName: "Today", value: "Add a Firefox shortcut to your Home screen. After adding the widget, touch and hold to edit it and select a different shortcut.", comment: "Description for small size widget to add it to home screen")
+    public static let QuickActionGalleryDescription = MZLocalizedString("TodayWidget.QuickActionGalleryDescription", tableName: "Today", value: "Add a Firefox shortcut to your Home screen. After adding the widget, touch and hold to edit it and select a different shortcut.", comment: "Description for small size widget to add it to home screen", lastEditedIn: .unknown)
     
     // Top Sites - Medium Size Widget
-    public static let TopSitesSubLabel = MZLocalizedString("TodayWidget.TopSitesSubLabel", tableName: "Today", value: "Firefox - Top Sites", comment: "Sub label for Top Sites widget")
-    public static let TopSitesSubLabel2 = MZLocalizedString("TodayWidget.TopSitesSubLabel2", tableName: "Today", value: "Firefox - Website Shortcuts", comment: "Sub label for Shortcuts widget")
+    public static let TopSitesSubLabel = MZLocalizedString("TodayWidget.TopSitesSubLabel", tableName: "Today", value: "Firefox - Top Sites", comment: "Sub label for Top Sites widget", lastEditedIn: .unknown)
+    public static let TopSitesSubLabel2 = MZLocalizedString("TodayWidget.TopSitesSubLabel2", tableName: "Today", value: "Firefox - Website Shortcuts", comment: "Sub label for Shortcuts widget", lastEditedIn: .unknown)
     
     // Top Sites - Medium Size - Gallery View
-    public static let TopSitesGalleryTitle = MZLocalizedString("TodayWidget.TopSitesGalleryTitle", tableName: "Today", value: "Top Sites", comment: "Title for top sites widget to add Firefox top sites shotcuts to home screen")
-    public static let TopSitesGalleryTitleV2 = MZLocalizedString("TodayWidget.TopSitesGalleryTitleV2", tableName: "Today", value: "Website Shortcuts", comment: "Title for top sites widget to add Firefox top sites shotcuts to home screen")
-    public static let TopSitesGalleryDescription = MZLocalizedString("TodayWidget.TopSitesGalleryDescription", tableName: "Today", value: "Add shortcuts to frequently and recently visited sites.", comment: "Description for top sites widget to add Firefox top sites shotcuts to home screen")
+    public static let TopSitesGalleryTitle = MZLocalizedString("TodayWidget.TopSitesGalleryTitle", tableName: "Today", value: "Top Sites", comment: "Title for top sites widget to add Firefox top sites shotcuts to home screen", lastEditedIn: .unknown)
+    public static let TopSitesGalleryTitleV2 = MZLocalizedString("TodayWidget.TopSitesGalleryTitleV2", tableName: "Today", value: "Website Shortcuts", comment: "Title for top sites widget to add Firefox top sites shotcuts to home screen", lastEditedIn: .unknown)
+    public static let TopSitesGalleryDescription = MZLocalizedString("TodayWidget.TopSitesGalleryDescription", tableName: "Today", value: "Add shortcuts to frequently and recently visited sites.", comment: "Description for top sites widget to add Firefox top sites shotcuts to home screen", lastEditedIn: .unknown)
 
     // Quick View Open Tabs - Medium Size Widget
-    public static let QuickViewOpenTabsSubLabel = MZLocalizedString("TodayWidget.QuickViewOpenTabsSubLabel", tableName: "Today", value: "Firefox - Open Tabs", comment: "Sub label for Top Sites widget")
-    public static let MoreTabsLabel = MZLocalizedString("TodayWidget.MoreTabsLabel", tableName: "Today", value: "+%d More…", comment: "%d represents number and it becomes something like +5 more where 5 is the number of open tabs in tab tray beyond what is displayed in the widget")
-    public static let OpenFirefoxLabel = MZLocalizedString("TodayWidget.OpenFirefoxLabel", tableName: "Today", value: "Open Firefox", comment: "Open Firefox when there are no tabs opened in tab tray i.e. Empty State")
-    public static let NoOpenTabsLabel = MZLocalizedString("TodayWidget.NoOpenTabsLabel", tableName: "Today", value: "No open tabs.", comment: "Label that is shown when there are no tabs opened in tab tray i.e. Empty State")
-    public static let NoOpenTabsLabelV2 = MZLocalizedString("TodayWidget.NoOpenTabsLabelV2", tableName: "Today", value: "No Open Tabs", comment: "Label that is shown when there are no tabs opened in tab tray i.e. Empty State")
+    public static let QuickViewOpenTabsSubLabel = MZLocalizedString("TodayWidget.QuickViewOpenTabsSubLabel", tableName: "Today", value: "Firefox - Open Tabs", comment: "Sub label for Top Sites widget", lastEditedIn: .unknown)
+    public static let MoreTabsLabel = MZLocalizedString("TodayWidget.MoreTabsLabel", tableName: "Today", value: "+%d More…", comment: "%d represents number and it becomes something like +5 more where 5 is the number of open tabs in tab tray beyond what is displayed in the widget", lastEditedIn: .unknown)
+    public static let OpenFirefoxLabel = MZLocalizedString("TodayWidget.OpenFirefoxLabel", tableName: "Today", value: "Open Firefox", comment: "Open Firefox when there are no tabs opened in tab tray i.e. Empty State", lastEditedIn: .unknown)
+    public static let NoOpenTabsLabel = MZLocalizedString("TodayWidget.NoOpenTabsLabel", tableName: "Today", value: "No open tabs.", comment: "Label that is shown when there are no tabs opened in tab tray i.e. Empty State", lastEditedIn: .unknown)
+    public static let NoOpenTabsLabelV2 = MZLocalizedString("TodayWidget.NoOpenTabsLabelV2", tableName: "Today", value: "No Open Tabs", comment: "Label that is shown when there are no tabs opened in tab tray i.e. Empty State", lastEditedIn: .unknown)
     
     
     // Quick View Open Tabs - Medium Size - Gallery View
-    public static let QuickViewGalleryTitle = MZLocalizedString("TodayWidget.QuickViewGalleryTitle", tableName: "Today", value: "Quick View", comment: "Title for Quick View widget in Gallery View where user can add it to home screen")
-    public static let QuickViewGalleryDescription = MZLocalizedString("TodayWidget.QuickViewGalleryDescription", tableName: "Today", value: "Access your open tabs directly on your homescreen.", comment: "Description for Quick View widget in Gallery View where user can add it to home screen")
-    public static let QuickViewGalleryDescriptionV2 = MZLocalizedString("TodayWidget.QuickViewGalleryDescriptionV2", tableName: "Today", value: "Add shortcuts to your open tabs.", comment: "Description for Quick View widget in Gallery View where user can add it to home screen")
-    public static let ViewMore = MZLocalizedString("TodayWidget.ViewMore", tableName: "Today", value: "View More", comment: "View More for Quick View widget in Gallery View where we don't know how many tabs might be opened")
+    public static let QuickViewGalleryTitle = MZLocalizedString("TodayWidget.QuickViewGalleryTitle", tableName: "Today", value: "Quick View", comment: "Title for Quick View widget in Gallery View where user can add it to home screen", lastEditedIn: .unknown)
+    public static let QuickViewGalleryDescription = MZLocalizedString("TodayWidget.QuickViewGalleryDescription", tableName: "Today", value: "Access your open tabs directly on your homescreen.", comment: "Description for Quick View widget in Gallery View where user can add it to home screen", lastEditedIn: .unknown)
+    public static let QuickViewGalleryDescriptionV2 = MZLocalizedString("TodayWidget.QuickViewGalleryDescriptionV2", tableName: "Today", value: "Add shortcuts to your open tabs.", comment: "Description for Quick View widget in Gallery View where user can add it to home screen", lastEditedIn: .unknown)
+    public static let ViewMore = MZLocalizedString("TodayWidget.ViewMore", tableName: "Today", value: "View More", comment: "View More for Quick View widget in Gallery View where we don't know how many tabs might be opened", lastEditedIn: .unknown)
     
     // Quick View Open Tabs - Large Size - Gallery View
-    public static let QuickViewLargeGalleryDescription = MZLocalizedString("TodayWidget.QuickViewLargeGalleryDescription", tableName: "Today", value: "Add shortcuts to your open tabs.", comment: "Description for Quick View widget in Gallery View where user can add it to home screen")
+    public static let QuickViewLargeGalleryDescription = MZLocalizedString("TodayWidget.QuickViewLargeGalleryDescription", tableName: "Today", value: "Add shortcuts to your open tabs.", comment: "Description for Quick View widget in Gallery View where user can add it to home screen", lastEditedIn: .unknown)
 
     // Pocket - Large - Medium Size Widget
-    public static let PocketWidgetSubLabel = MZLocalizedString("TodayWidget.PocketWidgetSubLabel", tableName: "Today", value: "Firefox - Recommended by Pocket", comment: "Sub label for medium size Firefox Pocket stories widge widget. Pocket is the name of another app.")
-    public static let ViewMoreDots = MZLocalizedString("TodayWidget.ViewMoreDots", tableName: "Today", value: "View More…", comment: "View More… for Firefox Pocket stories widget where we don't know how many articles are available.")
+    public static let PocketWidgetSubLabel = MZLocalizedString("TodayWidget.PocketWidgetSubLabel", tableName: "Today", value: "Firefox - Recommended by Pocket", comment: "Sub label for medium size Firefox Pocket stories widge widget. Pocket is the name of another app.", lastEditedIn: .unknown)
+    public static let ViewMoreDots = MZLocalizedString("TodayWidget.ViewMoreDots", tableName: "Today", value: "View More…", comment: "View More… for Firefox Pocket stories widget where we don't know how many articles are available.", lastEditedIn: .unknown)
 
     // Pocket - Large - Medium Size - Gallery View
-    public static let PocketWidgetGalleryTitle = MZLocalizedString("TodayWidget.PocketWidgetTitle", tableName: "Today", value: "Recommended by Pocket", comment: "Title for Firefox Pocket stories widget in Gallery View where user can add it to home screen. Pocket is the name of another app.")
-    public static let PocketWidgetGalleryDescription = MZLocalizedString("TodayWidget.PocketWidgetGalleryDescription", tableName: "Today", value: "Discover fascinating and thought-provoking stories from across the web, curated by Pocket.", comment: "Description for Firefox Pocket stories widget in Gallery View where user can add it to home screen. Pocket is the name of another app.")
+    public static let PocketWidgetGalleryTitle = MZLocalizedString("TodayWidget.PocketWidgetTitle", tableName: "Today", value: "Recommended by Pocket", comment: "Title for Firefox Pocket stories widget in Gallery View where user can add it to home screen. Pocket is the name of another app.", lastEditedIn: .unknown)
+    public static let PocketWidgetGalleryDescription = MZLocalizedString("TodayWidget.PocketWidgetGalleryDescription", tableName: "Today", value: "Discover fascinating and thought-provoking stories from across the web, curated by Pocket.", comment: "Description for Firefox Pocket stories widget in Gallery View where user can add it to home screen. Pocket is the name of another app.", lastEditedIn: .unknown)
 }
 
 // MARK: - Default Browser
 extension String {
-    public static let DefaultBrowserCardTitle = MZLocalizedString("DefaultBrowserCard.Title", tableName: "Default Browser", value: "Switch Your Default Browser", comment: "Title for small card shown that allows user to switch their default browser to Firefox.")
-    public static let DefaultBrowserCardDescription = MZLocalizedString("DefaultBrowserCard.Description", tableName: "Default Browser", value: "Set links from websites, emails, and Messages to open automatically in Firefox.", comment: "Description for small card shown that allows user to switch their default browser to Firefox.")
-    public static let DefaultBrowserCardButton = MZLocalizedString("DefaultBrowserCard.Button.v2", tableName: "Default Browser", value: "Learn How", comment: "Button string to learn how to set your default browser.")
-    public static let DefaultBrowserMenuItem = MZLocalizedString("Settings.DefaultBrowserMenuItem", tableName: "Default Browser", value: "Set as Default Browser", comment: "Menu option for setting Firefox as default browser.")
-    public static let DefaultBrowserOnboardingScreenshot = MZLocalizedString("DefaultBrowserOnboarding.Screenshot", tableName: "Default Browser", value: "Default Browser App", comment: "Text for the screenshot of the iOS system settings page for Firefox.")
-    public static let DefaultBrowserOnboardingDescriptionStep1 = MZLocalizedString("DefaultBrowserOnboarding.Description1", tableName: "Default Browser", value: "1. Go to Settings", comment: "Description for default browser onboarding card.")
-    public static let DefaultBrowserOnboardingDescriptionStep2 = MZLocalizedString("DefaultBrowserOnboarding.Description2", tableName: "Default Browser", value: "2. Tap Default Browser App", comment: "Description for default browser onboarding card.")
-    public static let DefaultBrowserOnboardingDescriptionStep3 = MZLocalizedString("DefaultBrowserOnboarding.Description3", tableName: "Default Browser", value: "3. Select Firefox", comment: "Description for default browser onboarding card.")
-    public static let DefaultBrowserOnboardingButton = MZLocalizedString("DefaultBrowserOnboarding.Button", tableName: "Default Browser", value: "Go to Settings", comment: "Button string to open settings that allows user to switch their default browser to Firefox.")
+    public static let DefaultBrowserCardTitle = MZLocalizedString("DefaultBrowserCard.Title", tableName: "Default Browser", value: "Switch Your Default Browser", comment: "Title for small card shown that allows user to switch their default browser to Firefox.", lastEditedIn: .unknown)
+    public static let DefaultBrowserCardDescription = MZLocalizedString("DefaultBrowserCard.Description", tableName: "Default Browser", value: "Set links from websites, emails, and Messages to open automatically in Firefox.", comment: "Description for small card shown that allows user to switch their default browser to Firefox.", lastEditedIn: .unknown)
+    public static let DefaultBrowserCardButton = MZLocalizedString("DefaultBrowserCard.Button.v2", tableName: "Default Browser", value: "Learn How", comment: "Button string to learn how to set your default browser.", lastEditedIn: .unknown)
+    public static let DefaultBrowserMenuItem = MZLocalizedString("Settings.DefaultBrowserMenuItem", tableName: "Default Browser", value: "Set as Default Browser", comment: "Menu option for setting Firefox as default browser.", lastEditedIn: .unknown)
+    public static let DefaultBrowserOnboardingScreenshot = MZLocalizedString("DefaultBrowserOnboarding.Screenshot", tableName: "Default Browser", value: "Default Browser App", comment: "Text for the screenshot of the iOS system settings page for Firefox.", lastEditedIn: .unknown)
+    public static let DefaultBrowserOnboardingDescriptionStep1 = MZLocalizedString("DefaultBrowserOnboarding.Description1", tableName: "Default Browser", value: "1. Go to Settings", comment: "Description for default browser onboarding card.", lastEditedIn: .unknown)
+    public static let DefaultBrowserOnboardingDescriptionStep2 = MZLocalizedString("DefaultBrowserOnboarding.Description2", tableName: "Default Browser", value: "2. Tap Default Browser App", comment: "Description for default browser onboarding card.", lastEditedIn: .unknown)
+    public static let DefaultBrowserOnboardingDescriptionStep3 = MZLocalizedString("DefaultBrowserOnboarding.Description3", tableName: "Default Browser", value: "3. Select Firefox", comment: "Description for default browser onboarding card.", lastEditedIn: .unknown)
+    public static let DefaultBrowserOnboardingButton = MZLocalizedString("DefaultBrowserOnboarding.Button", tableName: "Default Browser", value: "Go to Settings", comment: "Button string to open settings that allows user to switch their default browser to Firefox.", lastEditedIn: .unknown)
 }
 
 // MARK: - FxAWebViewController
 extension String {
-    public static let FxAWebContentAccessibilityLabel = MZLocalizedString("Web content", comment: "Accessibility label for the main web content view")
+    public static let FxAWebContentAccessibilityLabel = MZLocalizedString("Web content", comment: "Accessibility label for the main web content view", lastEditedIn: .unknown)
 }
 
 // MARK: - QuickActions
 extension String {
-    public static let QuickActionsLastBookmarkTitle = MZLocalizedString("Open Last Bookmark", tableName: "3DTouchActions", comment: "String describing the action of opening the last added bookmark from the home screen Quick Actions via 3D Touch")
+    public static let QuickActionsLastBookmarkTitle = MZLocalizedString("Open Last Bookmark", tableName: "3DTouchActions", comment: "String describing the action of opening the last added bookmark from the home screen Quick Actions via 3D Touch", lastEditedIn: .unknown)
 }
 
 // MARK: - CrashOptInAlert
 extension String {
-    public static let CrashOptInAlertTitle = MZLocalizedString("Oops! Firefox crashed", comment: "Title for prompt displayed to user after the app crashes")
-    public static let CrashOptInAlertMessage = MZLocalizedString("Send a crash report so Mozilla can fix the problem?", comment: "Message displayed in the crash dialog above the buttons used to select when sending reports")
-    public static let CrashOptInAlertSend = MZLocalizedString("Send Report", comment: "Used as a button label for crash dialog prompt")
-    public static let CrashOptInAlertAlwaysSend = MZLocalizedString("Always Send", comment: "Used as a button label for crash dialog prompt")
-    public static let CrashOptInAlertDontSend = MZLocalizedString("Don’t Send", comment: "Used as a button label for crash dialog prompt")
+    public static let CrashOptInAlertTitle = MZLocalizedString("Oops! Firefox crashed", comment: "Title for prompt displayed to user after the app crashes", lastEditedIn: .unknown)
+    public static let CrashOptInAlertMessage = MZLocalizedString("Send a crash report so Mozilla can fix the problem?", comment: "Message displayed in the crash dialog above the buttons used to select when sending reports", lastEditedIn: .unknown)
+    public static let CrashOptInAlertSend = MZLocalizedString("Send Report", comment: "Used as a button label for crash dialog prompt", lastEditedIn: .unknown)
+    public static let CrashOptInAlertAlwaysSend = MZLocalizedString("Always Send", comment: "Used as a button label for crash dialog prompt", lastEditedIn: .unknown)
+    public static let CrashOptInAlertDontSend = MZLocalizedString("Don’t Send", comment: "Used as a button label for crash dialog prompt", lastEditedIn: .unknown)
 }
 
 // MARK: - RestoreTabsAlert
 extension String {
-    public static let RestoreTabsAlertTitle = MZLocalizedString("Well, this is embarrassing.", comment: "Restore Tabs Prompt Title")
-    public static let RestoreTabsAlertMessage = MZLocalizedString("Looks like Firefox crashed previously. Would you like to restore your tabs?", comment: "Restore Tabs Prompt Description")
-    public static let RestoreTabsAlertNo = MZLocalizedString("No", comment: "Restore Tabs Negative Action")
-    public static let RestoreTabsAlertOkay = MZLocalizedString("Okay", comment: "Restore Tabs Affirmative Action")
+    public static let RestoreTabsAlertTitle = MZLocalizedString("Well, this is embarrassing.", comment: "Restore Tabs Prompt Title", lastEditedIn: .unknown)
+    public static let RestoreTabsAlertMessage = MZLocalizedString("Looks like Firefox crashed previously. Would you like to restore your tabs?", comment: "Restore Tabs Prompt Description", lastEditedIn: .unknown)
+    public static let RestoreTabsAlertNo = MZLocalizedString("No", comment: "Restore Tabs Negative Action", lastEditedIn: .unknown)
+    public static let RestoreTabsAlertOkay = MZLocalizedString("Okay", comment: "Restore Tabs Affirmative Action", lastEditedIn: .unknown)
 }
 
 // MARK: - ClearPrivateDataAlert
 extension String {
-    public static let ClearPrivateDataAlertMessage = MZLocalizedString("This action will clear all of your private data. It cannot be undone.", tableName: "ClearPrivateDataConfirm", comment: "Description of the confirmation dialog shown when a user tries to clear their private data.")
-    public static let ClearPrivateDataAlertCancel = MZLocalizedString("Cancel", tableName: "ClearPrivateDataConfirm", comment: "The cancel button when confirming clear private data.")
-    public static let ClearPrivateDataAlertOk = MZLocalizedString("OK", tableName: "ClearPrivateDataConfirm", comment: "The button that clears private data.")
+    public static let ClearPrivateDataAlertMessage = MZLocalizedString("This action will clear all of your private data. It cannot be undone.", tableName: "ClearPrivateDataConfirm", comment: "Description of the confirmation dialog shown when a user tries to clear their private data.", lastEditedIn: .unknown)
+    public static let ClearPrivateDataAlertCancel = MZLocalizedString("Cancel", tableName: "ClearPrivateDataConfirm", comment: "The cancel button when confirming clear private data.", lastEditedIn: .unknown)
+    public static let ClearPrivateDataAlertOk = MZLocalizedString("OK", tableName: "ClearPrivateDataConfirm", comment: "The button that clears private data.", lastEditedIn: .unknown)
 }
 
 // MARK: - ClearWebsiteDataAlert
 extension String {
-    public static let ClearAllWebsiteDataAlertMessage = MZLocalizedString("Settings.WebsiteData.ConfirmPrompt", value: "This action will clear all of your website data. It cannot be undone.", comment: "Description of the confirmation dialog shown when a user tries to clear their private data.")
-    public static let ClearSelectedWebsiteDataAlertMessage = MZLocalizedString("Settings.WebsiteData.SelectedConfirmPrompt", value: "This action will clear the selected items. It cannot be undone.", comment: "Description of the confirmation dialog shown when a user tries to clear some of their private data.")
+    public static let ClearAllWebsiteDataAlertMessage = MZLocalizedString("Settings.WebsiteData.ConfirmPrompt", value: "This action will clear all of your website data. It cannot be undone.", comment: "Description of the confirmation dialog shown when a user tries to clear their private data.", lastEditedIn: .unknown)
+    public static let ClearSelectedWebsiteDataAlertMessage = MZLocalizedString("Settings.WebsiteData.SelectedConfirmPrompt", value: "This action will clear the selected items. It cannot be undone.", comment: "Description of the confirmation dialog shown when a user tries to clear some of their private data.", lastEditedIn: .unknown)
     // TODO: these look like the same as in ClearPrivateDataAlert, I think we can remove them
-    public static let ClearWebsiteDataAlertCancel = MZLocalizedString("Cancel", tableName: "ClearPrivateDataConfirm", comment: "The cancel button when confirming clear private data.")
-    public static let ClearWebsiteDataAlertOk = MZLocalizedString("OK", tableName: "ClearPrivateDataConfirm", comment: "The button that clears private data.")
+    public static let ClearWebsiteDataAlertCancel = MZLocalizedString("Cancel", tableName: "ClearPrivateDataConfirm", comment: "The cancel button when confirming clear private data.", lastEditedIn: .unknown)
+    public static let ClearWebsiteDataAlertOk = MZLocalizedString("OK", tableName: "ClearPrivateDataConfirm", comment: "The button that clears private data.", lastEditedIn: .unknown)
 }
 
 // MARK: - ClearSyncedHistoryAlert
 extension String {
-    public static let ClearSyncedHistoryAlertMessage = MZLocalizedString("This action will clear all of your private data, including history from your synced devices.", tableName: "ClearHistoryConfirm", comment: "Description of the confirmation dialog shown when a user tries to clear history that's synced to another device.")
+    public static let ClearSyncedHistoryAlertMessage = MZLocalizedString("This action will clear all of your private data, including history from your synced devices.", tableName: "ClearHistoryConfirm", comment: "Description of the confirmation dialog shown when a user tries to clear history that's synced to another device.", lastEditedIn: .unknown)
     // TODO: these look like the same as in ClearPrivateDataAlert, I think we can remove them
-    public static let ClearSyncedHistoryAlertCancel = MZLocalizedString("Cancel", tableName: "ClearHistoryConfirm", comment: "The cancel button when confirming clear history.")
-    public static let ClearSyncedHistoryAlertOk = MZLocalizedString("OK", tableName: "ClearHistoryConfirm", comment: "The confirmation button that clears history even when Sync is connected.")
+    public static let ClearSyncedHistoryAlertCancel = MZLocalizedString("Cancel", tableName: "ClearHistoryConfirm", comment: "The cancel button when confirming clear history.", lastEditedIn: .unknown)
+    public static let ClearSyncedHistoryAlertOk = MZLocalizedString("OK", tableName: "ClearHistoryConfirm", comment: "The confirmation button that clears history even when Sync is connected.", lastEditedIn: .unknown)
 }
 
 // MARK: - DeleteLoginAlert
 extension String {
-    public static let DeleteLoginAlertTitle = MZLocalizedString("Are you sure?", tableName: "LoginManager", comment: "Prompt title when deleting logins")
-    public static let DeleteLoginAlertSyncedMessage = MZLocalizedString("Logins will be removed from all connected devices.", tableName: "LoginManager", comment: "Prompt message warning the user that deleted logins will remove logins from all connected devices")
-    public static let DeleteLoginAlertLocalMessage = MZLocalizedString("Logins will be permanently removed.", tableName: "LoginManager", comment: "Prompt message warning the user that deleting non-synced logins will permanently remove them")
-    public static let DeleteLoginAlertCancel = MZLocalizedString("Cancel", tableName: "LoginManager", comment: "Prompt option for cancelling out of deletion")
-    public static let DeleteLoginAlertDelete = MZLocalizedString("Delete", tableName: "LoginManager", comment: "Label for the button used to delete the current login.")
+    public static let DeleteLoginAlertTitle = MZLocalizedString("Are you sure?", tableName: "LoginManager", comment: "Prompt title when deleting logins", lastEditedIn: .unknown)
+    public static let DeleteLoginAlertSyncedMessage = MZLocalizedString("Logins will be removed from all connected devices.", tableName: "LoginManager", comment: "Prompt message warning the user that deleted logins will remove logins from all connected devices", lastEditedIn: .unknown)
+    public static let DeleteLoginAlertLocalMessage = MZLocalizedString("Logins will be permanently removed.", tableName: "LoginManager", comment: "Prompt message warning the user that deleting non-synced logins will permanently remove them", lastEditedIn: .unknown)
+    public static let DeleteLoginAlertCancel = MZLocalizedString("Cancel", tableName: "LoginManager", comment: "Prompt option for cancelling out of deletion", lastEditedIn: .unknown)
+    public static let DeleteLoginAlertDelete = MZLocalizedString("Delete", tableName: "LoginManager", comment: "Label for the button used to delete the current login.", lastEditedIn: .unknown)
 }
 
 // MARK: - Strings used in multiple areas within the Authentication Manager
 extension String {
-    public static let AuthenticationPasscode = MZLocalizedString("Passcode For Logins", tableName: "AuthenticationManager", comment: "Label for the Passcode item in Settings")
-    public static let AuthenticationTouchIDPasscodeSetting = MZLocalizedString("Touch ID & Passcode", tableName: "AuthenticationManager", comment: "Label for the Touch ID/Passcode item in Settings")
-    public static let AuthenticationFaceIDPasscodeSetting = MZLocalizedString("Face ID & Passcode", tableName: "AuthenticationManager", comment: "Label for the Face ID/Passcode item in Settings")
-    public static let AuthenticationRequirePasscode = MZLocalizedString("Require Passcode", tableName: "AuthenticationManager", comment: "Text displayed in the 'Interval' section, followed by the current interval setting, e.g. 'Immediately'")
-    public static let AuthenticationEnterAPasscode = MZLocalizedString("Enter a passcode", tableName: "AuthenticationManager", comment: "Text displayed above the input field when entering a new passcode")
-    public static let AuthenticationEnterPasscodeTitle = MZLocalizedString("Enter Passcode", tableName: "AuthenticationManager", comment: "Title of the dialog used to request the passcode")
-    public static let AuthenticationEnterPasscode = MZLocalizedString("Enter passcode", tableName: "AuthenticationManager", comment: "Text displayed above the input field when changing the existing passcode")
-    public static let AuthenticationReenterPasscode = MZLocalizedString("Re-enter passcode", tableName: "AuthenticationManager", comment: "Text displayed above the input field when confirming a passcode")
-    public static let AuthenticationSetPasscode = MZLocalizedString("Set Passcode", tableName: "AuthenticationManager", comment: "Title of the dialog used to set a passcode")
-    public static let AuthenticationTurnOffPasscode = MZLocalizedString("Turn Passcode Off", tableName: "AuthenticationManager", comment: "Label used as a setting item to turn off passcode")
-    public static let AuthenticationTurnOnPasscode = MZLocalizedString("Turn Passcode On", tableName: "AuthenticationManager", comment: "Label used as a setting item to turn on passcode")
-    public static let AuthenticationChangePasscode = MZLocalizedString("Change Passcode", tableName: "AuthenticationManager", comment: "Label used as a setting item and title of the following screen to change the current passcode")
-    public static let AuthenticationEnterNewPasscode = MZLocalizedString("Enter a new passcode", tableName: "AuthenticationManager", comment: "Text displayed above the input field when changing the existing passcode")
-    public static let AuthenticationImmediately = MZLocalizedString("Immediately", tableName: "AuthenticationManager", comment: "'Immediately' interval item for selecting when to require passcode")
-    public static let AuthenticationOneMinute = MZLocalizedString("After 1 minute", tableName: "AuthenticationManager", comment: "'After 1 minute' interval item for selecting when to require passcode")
-    public static let AuthenticationFiveMinutes = MZLocalizedString("After 5 minutes", tableName: "AuthenticationManager", comment: "'After 5 minutes' interval item for selecting when to require passcode")
-    public static let AuthenticationTenMinutes = MZLocalizedString("After 10 minutes", tableName: "AuthenticationManager", comment: "'After 10 minutes' interval item for selecting when to require passcode")
-    public static let AuthenticationFifteenMinutes = MZLocalizedString("After 15 minutes", tableName: "AuthenticationManager", comment: "'After 15 minutes' interval item for selecting when to require passcode")
-    public static let AuthenticationOneHour = MZLocalizedString("After 1 hour", tableName: "AuthenticationManager", comment: "'After 1 hour' interval item for selecting when to require passcode")
-    public static let AuthenticationLoginsTouchReason = MZLocalizedString("Use your fingerprint to access Logins now.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when accessing logins")
-    public static let AuthenticationRequirePasscodeTouchReason = MZLocalizedString("touchid.require.passcode.reason.label", tableName: "AuthenticationManager", value: "Use your fingerprint to access configuring your required passcode interval.", comment: "Touch ID prompt subtitle when accessing the require passcode setting")
-    public static let AuthenticationDisableTouchReason = MZLocalizedString("touchid.disable.reason.label", tableName: "AuthenticationManager", value: "Use your fingerprint to disable Touch ID.", comment: "Touch ID prompt subtitle when disabling Touch ID")
-    public static let AuthenticationWrongPasscodeError = MZLocalizedString("Incorrect passcode. Try again.", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode when trying to enter a protected section of the app")
-    public static let AuthenticationIncorrectAttemptsRemaining = MZLocalizedString("Incorrect passcode. Try again (Attempts remaining: %d).", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode when trying to enter a protected section of the app with attempts remaining")
-    public static let AuthenticationMaximumAttemptsReached = MZLocalizedString("Maximum attempts reached. Please try again in an hour.", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode and has reached the maximum number of attempts.")
-    public static let AuthenticationMaximumAttemptsReachedNoTime = MZLocalizedString("Maximum attempts reached. Please try again later.", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode and has reached the maximum number of attempts.")
-    public static let AuthenticationMismatchPasscodeError = MZLocalizedString("Passcodes didn’t match. Try again.", tableName: "AuthenticationManager", comment: "Error message displayed to user when their confirming passcode doesn't match the first code.")
-    public static let AuthenticationUseNewPasscodeError = MZLocalizedString("New passcode must be different than existing code.", tableName: "AuthenticationManager", comment: "Error message displayed when user tries to enter the same passcode as their existing code when changing it.")
+    public static let AuthenticationPasscode = MZLocalizedString("Passcode For Logins", tableName: "AuthenticationManager", comment: "Label for the Passcode item in Settings", lastEditedIn: .unknown)
+    public static let AuthenticationTouchIDPasscodeSetting = MZLocalizedString("Touch ID & Passcode", tableName: "AuthenticationManager", comment: "Label for the Touch ID/Passcode item in Settings", lastEditedIn: .unknown)
+    public static let AuthenticationFaceIDPasscodeSetting = MZLocalizedString("Face ID & Passcode", tableName: "AuthenticationManager", comment: "Label for the Face ID/Passcode item in Settings", lastEditedIn: .unknown)
+    public static let AuthenticationRequirePasscode = MZLocalizedString("Require Passcode", tableName: "AuthenticationManager", comment: "Text displayed in the 'Interval' section, followed by the current interval setting, e.g. 'Immediately'", lastEditedIn: .unknown)
+    public static let AuthenticationEnterAPasscode = MZLocalizedString("Enter a passcode", tableName: "AuthenticationManager", comment: "Text displayed above the input field when entering a new passcode", lastEditedIn: .unknown)
+    public static let AuthenticationEnterPasscodeTitle = MZLocalizedString("Enter Passcode", tableName: "AuthenticationManager", comment: "Title of the dialog used to request the passcode", lastEditedIn: .unknown)
+    public static let AuthenticationEnterPasscode = MZLocalizedString("Enter passcode", tableName: "AuthenticationManager", comment: "Text displayed above the input field when changing the existing passcode", lastEditedIn: .unknown)
+    public static let AuthenticationReenterPasscode = MZLocalizedString("Re-enter passcode", tableName: "AuthenticationManager", comment: "Text displayed above the input field when confirming a passcode", lastEditedIn: .unknown)
+    public static let AuthenticationSetPasscode = MZLocalizedString("Set Passcode", tableName: "AuthenticationManager", comment: "Title of the dialog used to set a passcode", lastEditedIn: .unknown)
+    public static let AuthenticationTurnOffPasscode = MZLocalizedString("Turn Passcode Off", tableName: "AuthenticationManager", comment: "Label used as a setting item to turn off passcode", lastEditedIn: .unknown)
+    public static let AuthenticationTurnOnPasscode = MZLocalizedString("Turn Passcode On", tableName: "AuthenticationManager", comment: "Label used as a setting item to turn on passcode", lastEditedIn: .unknown)
+    public static let AuthenticationChangePasscode = MZLocalizedString("Change Passcode", tableName: "AuthenticationManager", comment: "Label used as a setting item and title of the following screen to change the current passcode", lastEditedIn: .unknown)
+    public static let AuthenticationEnterNewPasscode = MZLocalizedString("Enter a new passcode", tableName: "AuthenticationManager", comment: "Text displayed above the input field when changing the existing passcode", lastEditedIn: .unknown)
+    public static let AuthenticationImmediately = MZLocalizedString("Immediately", tableName: "AuthenticationManager", comment: "'Immediately' interval item for selecting when to require passcode", lastEditedIn: .unknown)
+    public static let AuthenticationOneMinute = MZLocalizedString("After 1 minute", tableName: "AuthenticationManager", comment: "'After 1 minute' interval item for selecting when to require passcode", lastEditedIn: .unknown)
+    public static let AuthenticationFiveMinutes = MZLocalizedString("After 5 minutes", tableName: "AuthenticationManager", comment: "'After 5 minutes' interval item for selecting when to require passcode", lastEditedIn: .unknown)
+    public static let AuthenticationTenMinutes = MZLocalizedString("After 10 minutes", tableName: "AuthenticationManager", comment: "'After 10 minutes' interval item for selecting when to require passcode", lastEditedIn: .unknown)
+    public static let AuthenticationFifteenMinutes = MZLocalizedString("After 15 minutes", tableName: "AuthenticationManager", comment: "'After 15 minutes' interval item for selecting when to require passcode", lastEditedIn: .unknown)
+    public static let AuthenticationOneHour = MZLocalizedString("After 1 hour", tableName: "AuthenticationManager", comment: "'After 1 hour' interval item for selecting when to require passcode", lastEditedIn: .unknown)
+    public static let AuthenticationLoginsTouchReason = MZLocalizedString("Use your fingerprint to access Logins now.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when accessing logins", lastEditedIn: .unknown)
+    public static let AuthenticationRequirePasscodeTouchReason = MZLocalizedString("touchid.require.passcode.reason.label", tableName: "AuthenticationManager", value: "Use your fingerprint to access configuring your required passcode interval.", comment: "Touch ID prompt subtitle when accessing the require passcode setting", lastEditedIn: .unknown)
+    public static let AuthenticationDisableTouchReason = MZLocalizedString("touchid.disable.reason.label", tableName: "AuthenticationManager", value: "Use your fingerprint to disable Touch ID.", comment: "Touch ID prompt subtitle when disabling Touch ID", lastEditedIn: .unknown)
+    public static let AuthenticationWrongPasscodeError = MZLocalizedString("Incorrect passcode. Try again.", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode when trying to enter a protected section of the app", lastEditedIn: .unknown)
+    public static let AuthenticationIncorrectAttemptsRemaining = MZLocalizedString("Incorrect passcode. Try again (Attempts remaining: %d).", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode when trying to enter a protected section of the app with attempts remaining", lastEditedIn: .unknown)
+    public static let AuthenticationMaximumAttemptsReached = MZLocalizedString("Maximum attempts reached. Please try again in an hour.", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode and has reached the maximum number of attempts.", lastEditedIn: .unknown)
+    public static let AuthenticationMaximumAttemptsReachedNoTime = MZLocalizedString("Maximum attempts reached. Please try again later.", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode and has reached the maximum number of attempts.", lastEditedIn: .unknown)
+    public static let AuthenticationMismatchPasscodeError = MZLocalizedString("Passcodes didn’t match. Try again.", tableName: "AuthenticationManager", comment: "Error message displayed to user when their confirming passcode doesn't match the first code.", lastEditedIn: .unknown)
+    public static let AuthenticationUseNewPasscodeError = MZLocalizedString("New passcode must be different than existing code.", tableName: "AuthenticationManager", comment: "Error message displayed when user tries to enter the same passcode as their existing code when changing it.", lastEditedIn: .unknown)
 }
 
 // MARK: - Authenticator strings
 extension String {
-    public static let AuthenticatorCancel = MZLocalizedString("Cancel", comment: "Label for Cancel button")
-    public static let AuthenticatorLogin = MZLocalizedString("Log in", comment: "Authentication prompt log in button")
-    public static let AuthenticatorPromptTitle = MZLocalizedString("Authentication required", comment: "Authentication prompt title")
-    public static let AuthenticatorPromptRealmMessage = MZLocalizedString("A username and password are being requested by %@. The site says: %@", comment: "Authentication prompt message with a realm. First parameter is the hostname. Second is the realm string")
-    public static let AuthenticatorPromptEmptyRealmMessage = MZLocalizedString("A username and password are being requested by %@.", comment: "Authentication prompt message with no realm. Parameter is the hostname of the site")
-    public static let AuthenticatorUsernamePlaceholder = MZLocalizedString("Username", comment: "Username textbox in Authentication prompt")
-    public static let AuthenticatorPasswordPlaceholder = MZLocalizedString("Password", comment: "Password textbox in Authentication prompt")
+    public static let AuthenticatorCancel = MZLocalizedString("Cancel", comment: "Label for Cancel button", lastEditedIn: .unknown)
+    public static let AuthenticatorLogin = MZLocalizedString("Log in", comment: "Authentication prompt log in button", lastEditedIn: .unknown)
+    public static let AuthenticatorPromptTitle = MZLocalizedString("Authentication required", comment: "Authentication prompt title", lastEditedIn: .unknown)
+    public static let AuthenticatorPromptRealmMessage = MZLocalizedString("A username and password are being requested by %@. The site says: %@", comment: "Authentication prompt message with a realm. First parameter is the hostname. Second is the realm string", lastEditedIn: .unknown)
+    public static let AuthenticatorPromptEmptyRealmMessage = MZLocalizedString("A username and password are being requested by %@.", comment: "Authentication prompt message with no realm. Parameter is the hostname of the site", lastEditedIn: .unknown)
+    public static let AuthenticatorUsernamePlaceholder = MZLocalizedString("Username", comment: "Username textbox in Authentication prompt", lastEditedIn: .unknown)
+    public static let AuthenticatorPasswordPlaceholder = MZLocalizedString("Password", comment: "Password textbox in Authentication prompt", lastEditedIn: .unknown)
 }
 
 // MARK: - BrowserViewController
 extension String {
-    public static let ReaderModeAddPageGeneralErrorAccessibilityLabel = MZLocalizedString("Could not add page to Reading list", comment: "Accessibility message e.g. spoken by VoiceOver after adding current webpage to the Reading List failed.")
-    public static let ReaderModeAddPageSuccessAcessibilityLabel = MZLocalizedString("Added page to Reading List", comment: "Accessibility message e.g. spoken by VoiceOver after the current page gets added to the Reading List using the Reader View button, e.g. by long-pressing it or by its accessibility custom action.")
-    public static let ReaderModeAddPageMaybeExistsErrorAccessibilityLabel = MZLocalizedString("Could not add page to Reading List. Maybe it’s already there?", comment: "Accessibility message e.g. spoken by VoiceOver after the user wanted to add current page to the Reading List and this was not done, likely because it already was in the Reading List, but perhaps also because of real failures.")
-    public static let WebViewAccessibilityLabel = MZLocalizedString("Web content", comment: "Accessibility label for the main web content view")
+    public static let ReaderModeAddPageGeneralErrorAccessibilityLabel = MZLocalizedString("Could not add page to Reading list", comment: "Accessibility message e.g. spoken by VoiceOver after adding current webpage to the Reading List failed.", lastEditedIn: .unknown)
+    public static let ReaderModeAddPageSuccessAcessibilityLabel = MZLocalizedString("Added page to Reading List", comment: "Accessibility message e.g. spoken by VoiceOver after the current page gets added to the Reading List using the Reader View button, e.g. by long-pressing it or by its accessibility custom action.", lastEditedIn: .unknown)
+    public static let ReaderModeAddPageMaybeExistsErrorAccessibilityLabel = MZLocalizedString("Could not add page to Reading List. Maybe it’s already there?", comment: "Accessibility message e.g. spoken by VoiceOver after the user wanted to add current page to the Reading List and this was not done, likely because it already was in the Reading List, but perhaps also because of real failures.", lastEditedIn: .unknown)
+    public static let WebViewAccessibilityLabel = MZLocalizedString("Web content", comment: "Accessibility label for the main web content view", lastEditedIn: .unknown)
 }
 
 // MARK: - Find in page
 extension String {
-    public static let FindInPagePreviousAccessibilityLabel = MZLocalizedString("Previous in-page result", tableName: "FindInPage", comment: "Accessibility label for previous result button in Find in Page Toolbar.")
-    public static let FindInPageNextAccessibilityLabel = MZLocalizedString("Next in-page result", tableName: "FindInPage", comment: "Accessibility label for next result button in Find in Page Toolbar.")
-    public static let FindInPageDoneAccessibilityLabel = MZLocalizedString("Done", tableName: "FindInPage", comment: "Done button in Find in Page Toolbar.")
+    public static let FindInPagePreviousAccessibilityLabel = MZLocalizedString("Previous in-page result", tableName: "FindInPage", comment: "Accessibility label for previous result button in Find in Page Toolbar.", lastEditedIn: .unknown)
+    public static let FindInPageNextAccessibilityLabel = MZLocalizedString("Next in-page result", tableName: "FindInPage", comment: "Accessibility label for next result button in Find in Page Toolbar.", lastEditedIn: .unknown)
+    public static let FindInPageDoneAccessibilityLabel = MZLocalizedString("Done", tableName: "FindInPage", comment: "Done button in Find in Page Toolbar.", lastEditedIn: .unknown)
 }
 
 // MARK: - Reader Mode Bar
 extension String {
-    public static let ReaderModeBarMarkAsRead = MZLocalizedString("Mark as Read", comment: "Name for Mark as read button in reader mode")
-    public static let ReaderModeBarMarkAsUnread = MZLocalizedString("Mark as Unread", comment: "Name for Mark as unread button in reader mode")
-    public static let ReaderModeBarSettings = MZLocalizedString("Display Settings", comment: "Name for display settings button in reader mode. Display in the meaning of presentation, not monitor.")
-    public static let ReaderModeBarAddToReadingList = MZLocalizedString("Add to Reading List", comment: "Name for button adding current article to reading list in reader mode")
-    public static let ReaderModeBarRemoveFromReadingList = MZLocalizedString("Remove from Reading List", comment: "Name for button removing current article from reading list in reader mode")
+    public static let ReaderModeBarMarkAsRead = MZLocalizedString("Mark as Read", comment: "Name for Mark as read button in reader mode", lastEditedIn: .unknown)
+    public static let ReaderModeBarMarkAsUnread = MZLocalizedString("Mark as Unread", comment: "Name for Mark as unread button in reader mode", lastEditedIn: .unknown)
+    public static let ReaderModeBarSettings = MZLocalizedString("Display Settings", comment: "Name for display settings button in reader mode. Display in the meaning of presentation, not monitor.", lastEditedIn: .unknown)
+    public static let ReaderModeBarAddToReadingList = MZLocalizedString("Add to Reading List", comment: "Name for button adding current article to reading list in reader mode", lastEditedIn: .unknown)
+    public static let ReaderModeBarRemoveFromReadingList = MZLocalizedString("Remove from Reading List", comment: "Name for button removing current article from reading list in reader mode", lastEditedIn: .unknown)
 }
 
 // MARK: - SearchViewController
 extension String {
-    public static let SearchSettingsAccessibilityLabel = MZLocalizedString("Search Settings", tableName: "Search", comment: "Label for search settings button.")
-    public static let SearchSearchEngineAccessibilityLabel = MZLocalizedString("%@ search", tableName: "Search", comment: "Label for search engine buttons. The argument corresponds to the name of the search engine.")
-    public static let SearchSearchEngineSuggestionAccessibilityLabel = MZLocalizedString("Search suggestions from %@", tableName: "Search", comment: "Accessibility label for image of default search engine displayed left to the actual search suggestions from the engine. The parameter substituted for \"%@\" is the name of the search engine. E.g.: Search suggestions from Google")
-    public static let SearchSearchSuggestionTapAccessibilityHint = MZLocalizedString("Searches for the suggestion", comment: "Accessibility hint describing the action performed when a search suggestion is clicked")
-    public static let SearchSuggestionCellSwitchToTabLabel = MZLocalizedString("Search.Awesomebar.SwitchToTab", value: "Switch to tab", comment: "Search suggestion cell label that allows user to switch to tab which they searched for in url bar")
+    public static let SearchSettingsAccessibilityLabel = MZLocalizedString("Search Settings", tableName: "Search", comment: "Label for search settings button.", lastEditedIn: .unknown)
+    public static let SearchSearchEngineAccessibilityLabel = MZLocalizedString("%@ search", tableName: "Search", comment: "Label for search engine buttons. The argument corresponds to the name of the search engine.", lastEditedIn: .unknown)
+    public static let SearchSearchEngineSuggestionAccessibilityLabel = MZLocalizedString("Search suggestions from %@", tableName: "Search", comment: "Accessibility label for image of default search engine displayed left to the actual search suggestions from the engine. The parameter substituted for \"%@\" is the name of the search engine. E.g.: Search suggestions from Google", lastEditedIn: .unknown)
+    public static let SearchSearchSuggestionTapAccessibilityHint = MZLocalizedString("Searches for the suggestion", comment: "Accessibility hint describing the action performed when a search suggestion is clicked", lastEditedIn: .unknown)
+    public static let SearchSuggestionCellSwitchToTabLabel = MZLocalizedString("Search.Awesomebar.SwitchToTab", value: "Switch to tab", comment: "Search suggestion cell label that allows user to switch to tab which they searched for in url bar", lastEditedIn: .unknown)
 }
 
 // MARK: - Tab Location View
 extension String {
-    public static let TabLocationURLPlaceholder = MZLocalizedString("Search or enter address", comment: "The text shown in the URL bar on about:home")
-    public static let TabLocationLockIconAccessibilityLabel = MZLocalizedString("Secure connection", comment: "Accessibility label for the lock icon, which is only present if the connection is secure")
-    public static let TabLocationReaderModeAccessibilityLabel = MZLocalizedString("Reader View", comment: "Accessibility label for the Reader View button")
-    public static let TabLocationReaderModeAddToReadingListAccessibilityLabel = MZLocalizedString("Add to Reading List", comment: "Accessibility label for action adding current page to reading list.")
-    public static let TabLocationReloadAccessibilityLabel = MZLocalizedString("Reload page", comment: "Accessibility label for the reload button")
-    public static let TabLocationPageOptionsAccessibilityLabel = MZLocalizedString("Page Options Menu", comment: "Accessibility label for the Page Options menu button")
+    public static let TabLocationURLPlaceholder = MZLocalizedString("Search or enter address", comment: "The text shown in the URL bar on about:home", lastEditedIn: .unknown)
+    public static let TabLocationLockIconAccessibilityLabel = MZLocalizedString("Secure connection", comment: "Accessibility label for the lock icon, which is only present if the connection is secure", lastEditedIn: .unknown)
+    public static let TabLocationReaderModeAccessibilityLabel = MZLocalizedString("Reader View", comment: "Accessibility label for the Reader View button", lastEditedIn: .unknown)
+    public static let TabLocationReaderModeAddToReadingListAccessibilityLabel = MZLocalizedString("Add to Reading List", comment: "Accessibility label for action adding current page to reading list.", lastEditedIn: .unknown)
+    public static let TabLocationReloadAccessibilityLabel = MZLocalizedString("Reload page", comment: "Accessibility label for the reload button", lastEditedIn: .unknown)
+    public static let TabLocationPageOptionsAccessibilityLabel = MZLocalizedString("Page Options Menu", comment: "Accessibility label for the Page Options menu button", lastEditedIn: .unknown)
 }
 
 // MARK: - TabPeekViewController
 extension String {
-    public static let TabPeekAddToBookmarks = MZLocalizedString("Add to Bookmarks", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to add current tab to Bookmarks")
-    public static let TabPeekCopyUrl = MZLocalizedString("Copy URL", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to copy the URL of the current tab to clipboard")
-    public static let TabPeekCloseTab = MZLocalizedString("Close Tab", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to close the current tab")
-    public static let TabPeekPreviewAccessibilityLabel = MZLocalizedString("Preview of %@", tableName: "3DTouchActions", comment: "Accessibility label, associated to the 3D Touch action on the current tab in the tab tray, used to display a larger preview of the tab.")
+    public static let TabPeekAddToBookmarks = MZLocalizedString("Add to Bookmarks", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to add current tab to Bookmarks", lastEditedIn: .unknown)
+    public static let TabPeekCopyUrl = MZLocalizedString("Copy URL", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to copy the URL of the current tab to clipboard", lastEditedIn: .unknown)
+    public static let TabPeekCloseTab = MZLocalizedString("Close Tab", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to close the current tab", lastEditedIn: .unknown)
+    public static let TabPeekPreviewAccessibilityLabel = MZLocalizedString("Preview of %@", tableName: "3DTouchActions", comment: "Accessibility label, associated to the 3D Touch action on the current tab in the tab tray, used to display a larger preview of the tab.", lastEditedIn: .unknown)
 }
 
 // MARK: - Tab Toolbar
 extension String {
-    public static let TabToolbarReloadAccessibilityLabel = MZLocalizedString("Reload", comment: "Accessibility Label for the tab toolbar Reload button")
-    public static let TabToolbarStopAccessibilityLabel = MZLocalizedString("Stop", comment: "Accessibility Label for the tab toolbar Stop button")
-    public static let TabToolbarSearchAccessibilityLabel = MZLocalizedString("Search", comment: "Accessibility Label for the tab toolbar Search button")
-    public static let TabToolbarNewTabAccessibilityLabel = MZLocalizedString("New Tab", comment: "Accessibility Label for the tab toolbar New tab button")
-    public static let TabToolbarBackAccessibilityLabel = MZLocalizedString("Back", comment: "Accessibility label for the Back button in the tab toolbar.")
-    public static let TabToolbarForwardAccessibilityLabel = MZLocalizedString("Forward", comment: "Accessibility Label for the tab toolbar Forward button")
-    public static let TabToolbarNavigationToolbarAccessibilityLabel = MZLocalizedString("Navigation Toolbar", comment: "Accessibility label for the navigation toolbar displayed at the bottom of the screen.")
+    public static let TabToolbarReloadAccessibilityLabel = MZLocalizedString("Reload", comment: "Accessibility Label for the tab toolbar Reload button", lastEditedIn: .unknown)
+    public static let TabToolbarStopAccessibilityLabel = MZLocalizedString("Stop", comment: "Accessibility Label for the tab toolbar Stop button", lastEditedIn: .unknown)
+    public static let TabToolbarSearchAccessibilityLabel = MZLocalizedString("Search", comment: "Accessibility Label for the tab toolbar Search button", lastEditedIn: .unknown)
+    public static let TabToolbarNewTabAccessibilityLabel = MZLocalizedString("New Tab", comment: "Accessibility Label for the tab toolbar New tab button", lastEditedIn: .unknown)
+    public static let TabToolbarBackAccessibilityLabel = MZLocalizedString("Back", comment: "Accessibility label for the Back button in the tab toolbar.", lastEditedIn: .unknown)
+    public static let TabToolbarForwardAccessibilityLabel = MZLocalizedString("Forward", comment: "Accessibility Label for the tab toolbar Forward button", lastEditedIn: .unknown)
+    public static let TabToolbarNavigationToolbarAccessibilityLabel = MZLocalizedString("Navigation Toolbar", comment: "Accessibility label for the navigation toolbar displayed at the bottom of the screen.", lastEditedIn: .unknown)
 }
 
 // MARK: - Tab Tray v1
 extension String {
-    public static let TabTrayToggleAccessibilityLabel = MZLocalizedString("Private Mode", tableName: "PrivateBrowsing", comment: "Accessibility label for toggling on/off private mode")
-    public static let TabTrayToggleAccessibilityHint = MZLocalizedString("Turns private mode on or off", tableName: "PrivateBrowsing", comment: "Accessiblity hint for toggling on/off private mode")
-    public static let TabTrayToggleAccessibilityValueOn = MZLocalizedString("On", tableName: "PrivateBrowsing", comment: "Toggled ON accessibility value")
-    public static let TabTrayToggleAccessibilityValueOff = MZLocalizedString("Off", tableName: "PrivateBrowsing", comment: "Toggled OFF accessibility value")
-    public static let TabTrayViewAccessibilityLabel = MZLocalizedString("Tabs Tray", comment: "Accessibility label for the Tabs Tray view.")
-    public static let TabTrayNoTabsAccessibilityHint = MZLocalizedString("No tabs", comment: "Message spoken by VoiceOver to indicate that there are no tabs in the Tabs Tray")
-    public static let TabTrayVisibleTabRangeAccessibilityHint = MZLocalizedString("Tab %@ of %@", comment: "Message spoken by VoiceOver saying the position of the single currently visible tab in Tabs Tray, along with the total number of tabs. E.g. \"Tab 2 of 5\" says that tab 2 is visible (and is the only visible tab), out of 5 tabs total.")
-    public static let TabTrayVisiblePartialRangeAccessibilityHint = MZLocalizedString("Tabs %@ to %@ of %@", comment: "Message spoken by VoiceOver saying the range of tabs that are currently visible in Tabs Tray, along with the total number of tabs. E.g. \"Tabs 8 to 10 of 15\" says tabs 8, 9 and 10 are visible, out of 15 tabs total.")
-    public static let TabTrayClosingTabAccessibilityMessage =  MZLocalizedString("Closing tab", comment: "Accessibility label (used by assistive technology) notifying the user that the tab is being closed.")
-    public static let TabTrayCloseAllTabsPromptCancel = MZLocalizedString("Cancel", comment: "Label for Cancel button")
-    public static let TabTrayPrivateLearnMore = MZLocalizedString("Learn More", tableName: "PrivateBrowsing", comment: "Text button displayed when there are no tabs open while in private mode")
-    public static let TabTrayPrivateBrowsingTitle = MZLocalizedString("Private Browsing", tableName: "PrivateBrowsing", comment: "Title displayed for when there are no open tabs while in private mode")
-    public static let TabTrayPrivateBrowsingDescription =  MZLocalizedString("Firefox won’t remember any of your history or cookies, but new bookmarks will be saved.", tableName: "PrivateBrowsing", comment: "Description text displayed when there are no open tabs while in private mode")
-    public static let TabTrayAddTabAccessibilityLabel = MZLocalizedString("Add Tab", comment: "Accessibility label for the Add Tab button in the Tab Tray.")
-    public static let TabTrayCloseAccessibilityCustomAction = MZLocalizedString("Close", comment: "Accessibility label for action denoting closing a tab in tab list (tray)")
-    public static let TabTraySwipeToCloseAccessibilityHint = MZLocalizedString("Swipe right or left with three fingers to close the tab.", comment: "Accessibility hint for tab tray's displayed tab.")
-    public static let TabTrayCurrentlySelectedTabAccessibilityLabel = MZLocalizedString("TabTray.CurrentSelectedTab.A11Y", value: "Currently selected tab.", comment: "Accessibility label for the currently selected tab.")
+    public static let TabTrayToggleAccessibilityLabel = MZLocalizedString("Private Mode", tableName: "PrivateBrowsing", comment: "Accessibility label for toggling on/off private mode", lastEditedIn: .unknown)
+    public static let TabTrayToggleAccessibilityHint = MZLocalizedString("Turns private mode on or off", tableName: "PrivateBrowsing", comment: "Accessiblity hint for toggling on/off private mode", lastEditedIn: .unknown)
+    public static let TabTrayToggleAccessibilityValueOn = MZLocalizedString("On", tableName: "PrivateBrowsing", comment: "Toggled ON accessibility value", lastEditedIn: .unknown)
+    public static let TabTrayToggleAccessibilityValueOff = MZLocalizedString("Off", tableName: "PrivateBrowsing", comment: "Toggled OFF accessibility value", lastEditedIn: .unknown)
+    public static let TabTrayViewAccessibilityLabel = MZLocalizedString("Tabs Tray", comment: "Accessibility label for the Tabs Tray view.", lastEditedIn: .unknown)
+    public static let TabTrayNoTabsAccessibilityHint = MZLocalizedString("No tabs", comment: "Message spoken by VoiceOver to indicate that there are no tabs in the Tabs Tray", lastEditedIn: .unknown)
+    public static let TabTrayVisibleTabRangeAccessibilityHint = MZLocalizedString("Tab %@ of %@", comment: "Message spoken by VoiceOver saying the position of the single currently visible tab in Tabs Tray, along with the total number of tabs. E.g. \"Tab 2 of 5\" says that tab 2 is visible (and is the only visible tab), out of 5 tabs total.", lastEditedIn: .unknown)
+    public static let TabTrayVisiblePartialRangeAccessibilityHint = MZLocalizedString("Tabs %@ to %@ of %@", comment: "Message spoken by VoiceOver saying the range of tabs that are currently visible in Tabs Tray, along with the total number of tabs. E.g. \"Tabs 8 to 10 of 15\" says tabs 8, 9 and 10 are visible, out of 15 tabs total.", lastEditedIn: .unknown)
+    public static let TabTrayClosingTabAccessibilityMessage =  MZLocalizedString("Closing tab", comment: "Accessibility label (used by assistive technology) notifying the user that the tab is being closed.", lastEditedIn: .unknown)
+    public static let TabTrayCloseAllTabsPromptCancel = MZLocalizedString("Cancel", comment: "Label for Cancel button", lastEditedIn: .unknown)
+    public static let TabTrayPrivateLearnMore = MZLocalizedString("Learn More", tableName: "PrivateBrowsing", comment: "Text button displayed when there are no tabs open while in private mode", lastEditedIn: .unknown)
+    public static let TabTrayPrivateBrowsingTitle = MZLocalizedString("Private Browsing", tableName: "PrivateBrowsing", comment: "Title displayed for when there are no open tabs while in private mode", lastEditedIn: .unknown)
+    public static let TabTrayPrivateBrowsingDescription =  MZLocalizedString("Firefox won’t remember any of your history or cookies, but new bookmarks will be saved.", tableName: "PrivateBrowsing", comment: "Description text displayed when there are no open tabs while in private mode", lastEditedIn: .unknown)
+    public static let TabTrayAddTabAccessibilityLabel = MZLocalizedString("Add Tab", comment: "Accessibility label for the Add Tab button in the Tab Tray.", lastEditedIn: .unknown)
+    public static let TabTrayCloseAccessibilityCustomAction = MZLocalizedString("Close", comment: "Accessibility label for action denoting closing a tab in tab list (tray)", lastEditedIn: .unknown)
+    public static let TabTraySwipeToCloseAccessibilityHint = MZLocalizedString("Swipe right or left with three fingers to close the tab.", comment: "Accessibility hint for tab tray's displayed tab.", lastEditedIn: .unknown)
+    public static let TabTrayCurrentlySelectedTabAccessibilityLabel = MZLocalizedString("TabTray.CurrentSelectedTab.A11Y", value: "Currently selected tab.", comment: "Accessibility label for the currently selected tab.", lastEditedIn: .unknown)
 }
 
 // MARK: - URL Bar
 extension String {
-    public static let URLBarLocationAccessibilityLabel = MZLocalizedString("Address and Search", comment: "Accessibility label for address and search field, both words (Address, Search) are therefore nouns.")
+    public static let URLBarLocationAccessibilityLabel = MZLocalizedString("Address and Search", comment: "Accessibility label for address and search field, both words (Address, Search) are therefore nouns.", lastEditedIn: .unknown)
 }
 
 // MARK: - Error Pages
 extension String {
-    public static let ErrorPageTryAgain = MZLocalizedString("Try again", tableName: "ErrorPages", comment: "Shown in error pages on a button that will try to load the page again")
-    public static let ErrorPageOpenInSafari = MZLocalizedString("Open in Safari", tableName: "ErrorPages", comment: "Shown in error pages for files that can't be shown and need to be downloaded.")
+    public static let ErrorPageTryAgain = MZLocalizedString("Try again", tableName: "ErrorPages", comment: "Shown in error pages on a button that will try to load the page again", lastEditedIn: .unknown)
+    public static let ErrorPageOpenInSafari = MZLocalizedString("Open in Safari", tableName: "ErrorPages", comment: "Shown in error pages for files that can't be shown and need to be downloaded.", lastEditedIn: .unknown)
 }
 
 // MARK: - LibraryPanel
 extension String {
-    public static let LibraryPanelBookmarksAccessibilityLabel = MZLocalizedString("Bookmarks", comment: "Panel accessibility label")
-    public static let LibraryPanelHistoryAccessibilityLabel = MZLocalizedString("History", comment: "Panel accessibility label")
-    public static let LibraryPanelReadingListAccessibilityLabel = MZLocalizedString("Reading list", comment: "Panel accessibility label")
-    public static let LibraryPanelDownloadsAccessibilityLabel = MZLocalizedString("Downloads", comment: "Panel accessibility label")
-    public static let LibraryPanelSyncedTabsAccessibilityLabel = MZLocalizedString("Synced Tabs", comment: "Panel accessibility label")
+    public static let LibraryPanelBookmarksAccessibilityLabel = MZLocalizedString("Bookmarks", comment: "Panel accessibility label", lastEditedIn: .unknown)
+    public static let LibraryPanelHistoryAccessibilityLabel = MZLocalizedString("History", comment: "Panel accessibility label", lastEditedIn: .unknown)
+    public static let LibraryPanelReadingListAccessibilityLabel = MZLocalizedString("Reading list", comment: "Panel accessibility label", lastEditedIn: .unknown)
+    public static let LibraryPanelDownloadsAccessibilityLabel = MZLocalizedString("Downloads", comment: "Panel accessibility label", lastEditedIn: .unknown)
+    public static let LibraryPanelSyncedTabsAccessibilityLabel = MZLocalizedString("Synced Tabs", comment: "Panel accessibility label", lastEditedIn: .unknown)
 }
 
 // MARK: - LibraryViewController
 extension String {
-    public static let LibraryPanelChooserAccessibilityLabel = MZLocalizedString("Panel Chooser", comment: "Accessibility label for the Library panel's bottom toolbar containing a list of the home panels (top sites, bookmarks, history, remote tabs, reading list).")
+    public static let LibraryPanelChooserAccessibilityLabel = MZLocalizedString("Panel Chooser", comment: "Accessibility label for the Library panel's bottom toolbar containing a list of the home panels (top sites, bookmarks, history, remote tabs, reading list).", lastEditedIn: .unknown)
 }
 
 // MARK: - ReaderPanel
 extension String {
-    public static let ReaderPanelRemove = MZLocalizedString("Remove", comment: "Title for the button that removes a reading list item")
-    public static let ReaderPanelMarkAsRead = MZLocalizedString("Mark as Read", comment: "Title for the button that marks a reading list item as read")
-    public static let ReaderPanelMarkAsUnread =  MZLocalizedString("Mark as Unread", comment: "Title for the button that marks a reading list item as unread")
-    public static let ReaderPanelUnreadAccessibilityLabel = MZLocalizedString("unread", comment: "Accessibility label for unread article in reading list. It's a past participle - functions as an adjective.")
-    public static let ReaderPanelReadAccessibilityLabel = MZLocalizedString("read", comment: "Accessibility label for read article in reading list. It's a past participle - functions as an adjective.")
-    public static let ReaderPanelWelcome = MZLocalizedString("Welcome to your Reading List", comment: "See http://mzl.la/1LXbDOL")
-    public static let ReaderPanelReadingModeDescription = MZLocalizedString("Open articles in Reader View by tapping the book icon when it appears in the title bar.", comment: "See http://mzl.la/1LXbDOL")
-    public static let ReaderPanelReadingListDescription = MZLocalizedString("Save pages to your Reading List by tapping the book plus icon in the Reader View controls.", comment: "See http://mzl.la/1LXbDOL")
+    public static let ReaderPanelRemove = MZLocalizedString("Remove", comment: "Title for the button that removes a reading list item", lastEditedIn: .unknown)
+    public static let ReaderPanelMarkAsRead = MZLocalizedString("Mark as Read", comment: "Title for the button that marks a reading list item as read", lastEditedIn: .unknown)
+    public static let ReaderPanelMarkAsUnread =  MZLocalizedString("Mark as Unread", comment: "Title for the button that marks a reading list item as unread", lastEditedIn: .unknown)
+    public static let ReaderPanelUnreadAccessibilityLabel = MZLocalizedString("unread", comment: "Accessibility label for unread article in reading list. It's a past participle - functions as an adjective.", lastEditedIn: .unknown)
+    public static let ReaderPanelReadAccessibilityLabel = MZLocalizedString("read", comment: "Accessibility label for read article in reading list. It's a past participle - functions as an adjective.", lastEditedIn: .unknown)
+    public static let ReaderPanelWelcome = MZLocalizedString("Welcome to your Reading List", comment: "See http://mzl.la/1LXbDOL", lastEditedIn: .unknown)
+    public static let ReaderPanelReadingModeDescription = MZLocalizedString("Open articles in Reader View by tapping the book icon when it appears in the title bar.", comment: "See http://mzl.la/1LXbDOL", lastEditedIn: .unknown)
+    public static let ReaderPanelReadingListDescription = MZLocalizedString("Save pages to your Reading List by tapping the book plus icon in the Reader View controls.", comment: "See http://mzl.la/1LXbDOL", lastEditedIn: .unknown)
 }
 
 // MARK: - Remote Tabs Panel
 extension String {
     // Backup and active strings added in Bug 1205294.
-    public static let RemoteTabEmptyStateInstructionsSyncTabsPasswordsBookmarksString = MZLocalizedString("Sync your tabs, bookmarks, passwords and more.", comment: "Text displayed when the Sync home panel is empty, describing the features provided by Sync to invite the user to log in.")
-    public static let RemoteTabEmptyStateInstructionsSyncTabsPasswordsString = MZLocalizedString("Sync your tabs, passwords and more.", comment: "Text displayed when the Sync home panel is empty, describing the features provided by Sync to invite the user to log in.")
-    public static let RemoteTabEmptyStateInstructionsGetTabsBookmarksPasswordsString = MZLocalizedString("Get your open tabs, bookmarks, and passwords from your other devices.", comment: "A re-worded offer about Sync, displayed when the Sync home panel is empty, that emphasizes one-way data transfer, not syncing.")
+    public static let RemoteTabEmptyStateInstructionsSyncTabsPasswordsBookmarksString = MZLocalizedString("Sync your tabs, bookmarks, passwords and more.", comment: "Text displayed when the Sync home panel is empty, describing the features provided by Sync to invite the user to log in.", lastEditedIn: .unknown)
+    public static let RemoteTabEmptyStateInstructionsSyncTabsPasswordsString = MZLocalizedString("Sync your tabs, passwords and more.", comment: "Text displayed when the Sync home panel is empty, describing the features provided by Sync to invite the user to log in.", lastEditedIn: .unknown)
+    public static let RemoteTabEmptyStateInstructionsGetTabsBookmarksPasswordsString = MZLocalizedString("Get your open tabs, bookmarks, and passwords from your other devices.", comment: "A re-worded offer about Sync, displayed when the Sync home panel is empty, that emphasizes one-way data transfer, not syncing.", lastEditedIn: .unknown)
 
-    public static let RemoteTabErrorNoTabs = MZLocalizedString("You don’t have any tabs open in Firefox on your other devices.", comment: "Error message in the remote tabs panel")
-    public static let RemoteTabErrorFailedToSync = MZLocalizedString("There was a problem accessing tabs from your other devices. Try again in a few moments.", comment: "Error message in the remote tabs panel")
-    public static let RemoteTabLastSync = MZLocalizedString("Last synced: %@", comment: "Remote tabs last synced time. Argument is the relative date string.")
-    public static let RemoteTabComputerAccessibilityLabel = MZLocalizedString("computer", comment: "Accessibility label for Desktop Computer (PC) image in remote tabs list")
-    public static let RemoteTabMobileAccessibilityLabel =  MZLocalizedString("mobile device", comment: "Accessibility label for Mobile Device image in remote tabs list")
-    public static let RemoteTabCreateAccount = MZLocalizedString("Create an account", comment: "See http://mzl.la/1Qtkf0j")
+    public static let RemoteTabErrorNoTabs = MZLocalizedString("You don’t have any tabs open in Firefox on your other devices.", comment: "Error message in the remote tabs panel", lastEditedIn: .unknown)
+    public static let RemoteTabErrorFailedToSync = MZLocalizedString("There was a problem accessing tabs from your other devices. Try again in a few moments.", comment: "Error message in the remote tabs panel", lastEditedIn: .unknown)
+    public static let RemoteTabLastSync = MZLocalizedString("Last synced: %@", comment: "Remote tabs last synced time. Argument is the relative date string.", lastEditedIn: .unknown)
+    public static let RemoteTabComputerAccessibilityLabel = MZLocalizedString("computer", comment: "Accessibility label for Desktop Computer (PC) image in remote tabs list", lastEditedIn: .unknown)
+    public static let RemoteTabMobileAccessibilityLabel =  MZLocalizedString("mobile device", comment: "Accessibility label for Mobile Device image in remote tabs list", lastEditedIn: .unknown)
+    public static let RemoteTabCreateAccount = MZLocalizedString("Create an account", comment: "See http://mzl.la/1Qtkf0j", lastEditedIn: .unknown)
 }
 
 // MARK: - Login list
 extension String {
-    public static let LoginListDeselctAll = MZLocalizedString("Deselect All", tableName: "LoginManager", comment: "Label for the button used to deselect all logins.")
-    public static let LoginListSelctAll = MZLocalizedString("Select All", tableName: "LoginManager", comment: "Label for the button used to select all logins.")
-    public static let LoginListDelete = MZLocalizedString("Delete", tableName: "LoginManager", comment: "Label for the button used to delete the current login.")
+    public static let LoginListDeselctAll = MZLocalizedString("Deselect All", tableName: "LoginManager", comment: "Label for the button used to deselect all logins.", lastEditedIn: .unknown)
+    public static let LoginListSelctAll = MZLocalizedString("Select All", tableName: "LoginManager", comment: "Label for the button used to select all logins.", lastEditedIn: .unknown)
+    public static let LoginListDelete = MZLocalizedString("Delete", tableName: "LoginManager", comment: "Label for the button used to delete the current login.", lastEditedIn: .unknown)
 }
 
 // MARK: - Login Detail
 extension String {
-    public static let LoginDetailUsername = MZLocalizedString("Username", tableName: "LoginManager", comment: "Label displayed above the username row in Login Detail View.")
-    public static let LoginDetailPassword = MZLocalizedString("Password", tableName: "LoginManager", comment: "Label displayed above the password row in Login Detail View.")
-    public static let LoginDetailWebsite = MZLocalizedString("Website", tableName: "LoginManager", comment: "Label displayed above the website row in Login Detail View.")
-    public static let LoginDetailCreatedAt =  MZLocalizedString("Created %@", tableName: "LoginManager", comment: "Label describing when the current login was created with the timestamp as the parameter.")
-    public static let LoginDetailModifiedAt = MZLocalizedString("Modified %@", tableName: "LoginManager", comment: "Label describing when the current login was last modified with the timestamp as the parameter.")
-    public static let LoginDetailDelete = MZLocalizedString("Delete", tableName: "LoginManager", comment: "Label for the button used to delete the current login.")
+    public static let LoginDetailUsername = MZLocalizedString("Username", tableName: "LoginManager", comment: "Label displayed above the username row in Login Detail View.", lastEditedIn: .unknown)
+    public static let LoginDetailPassword = MZLocalizedString("Password", tableName: "LoginManager", comment: "Label displayed above the password row in Login Detail View.", lastEditedIn: .unknown)
+    public static let LoginDetailWebsite = MZLocalizedString("Website", tableName: "LoginManager", comment: "Label displayed above the website row in Login Detail View.", lastEditedIn: .unknown)
+    public static let LoginDetailCreatedAt =  MZLocalizedString("Created %@", tableName: "LoginManager", comment: "Label describing when the current login was created with the timestamp as the parameter.", lastEditedIn: .unknown)
+    public static let LoginDetailModifiedAt = MZLocalizedString("Modified %@", tableName: "LoginManager", comment: "Label describing when the current login was last modified with the timestamp as the parameter.", lastEditedIn: .unknown)
+    public static let LoginDetailDelete = MZLocalizedString("Delete", tableName: "LoginManager", comment: "Label for the button used to delete the current login.", lastEditedIn: .unknown)
 }
 
 // MARK: - No Logins View
 extension String {
-    public static let NoLoginsFound = MZLocalizedString("No logins found", tableName: "LoginManager", comment: "Label displayed when no logins are found after searching.")
+    public static let NoLoginsFound = MZLocalizedString("No logins found", tableName: "LoginManager", comment: "Label displayed when no logins are found after searching.", lastEditedIn: .unknown)
 }
 
 // MARK: - Reader Mode Handler
 extension String {
-    public static let ReaderModeHandlerLoadingContent = MZLocalizedString("Loading content…", comment: "Message displayed when the reader mode page is loading. This message will appear only when sharing to Firefox reader mode from another app.")
-    public static let ReaderModeHandlerPageCantDisplay = MZLocalizedString("The page could not be displayed in Reader View.", comment: "Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Firefox reader mode from another app.")
-    public static let ReaderModeHandlerLoadOriginalPage = MZLocalizedString("Load original page", comment: "Link for going to the non-reader page when the reader view could not be loaded. This message will appear only when sharing to Firefox reader mode from another app.")
-    public static let ReaderModeHandlerError = MZLocalizedString("There was an error converting the page", comment: "Error displayed when reader mode cannot be enabled")
+    public static let ReaderModeHandlerLoadingContent = MZLocalizedString("Loading content…", comment: "Message displayed when the reader mode page is loading. This message will appear only when sharing to Firefox reader mode from another app.", lastEditedIn: .unknown)
+    public static let ReaderModeHandlerPageCantDisplay = MZLocalizedString("The page could not be displayed in Reader View.", comment: "Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Firefox reader mode from another app.", lastEditedIn: .unknown)
+    public static let ReaderModeHandlerLoadOriginalPage = MZLocalizedString("Load original page", comment: "Link for going to the non-reader page when the reader view could not be loaded. This message will appear only when sharing to Firefox reader mode from another app.", lastEditedIn: .unknown)
+    public static let ReaderModeHandlerError = MZLocalizedString("There was an error converting the page", comment: "Error displayed when reader mode cannot be enabled", lastEditedIn: .unknown)
 }
 
 // MARK: - ReaderModeStyle
 extension String {
-    public static let ReaderModeStyleBrightnessAccessibilityLabel = MZLocalizedString("Brightness", comment: "Accessibility label for brightness adjustment slider in Reader Mode display settings")
-    public static let ReaderModeStyleFontTypeAccessibilityLabel = MZLocalizedString("Changes font type.", comment: "Accessibility hint for the font type buttons in reader mode display settings")
-    public static let ReaderModeStyleSansSerifFontType = MZLocalizedString("Sans-serif", comment: "Font type setting in the reading view settings")
-    public static let ReaderModeStyleSerifFontType = MZLocalizedString("Serif", comment: "Font type setting in the reading view settings")
-    public static let ReaderModeStyleSmallerLabel = MZLocalizedString("-", comment: "Button for smaller reader font size. Keep this extremely short! This is shown in the reader mode toolbar.")
-    public static let ReaderModeStyleSmallerAccessibilityLabel = MZLocalizedString("Decrease text size", comment: "Accessibility label for button decreasing font size in display settings of reader mode")
-    public static let ReaderModeStyleLargerLabel = MZLocalizedString("+", comment: "Button for larger reader font size. Keep this extremely short! This is shown in the reader mode toolbar.")
-    public static let ReaderModeStyleLargerAccessibilityLabel = MZLocalizedString("Increase text size", comment: "Accessibility label for button increasing font size in display settings of reader mode")
-    public static let ReaderModeStyleFontSize = MZLocalizedString("Aa", comment: "Button for reader mode font size. Keep this extremely short! This is shown in the reader mode toolbar.")
-    public static let ReaderModeStyleChangeColorSchemeAccessibilityHint = MZLocalizedString("Changes color theme.", comment: "Accessibility hint for the color theme setting buttons in reader mode display settings")
-    public static let ReaderModeStyleLightLabel = MZLocalizedString("Light", comment: "Light theme setting in Reading View settings")
-    public static let ReaderModeStyleDarkLabel = MZLocalizedString("Dark", comment: "Dark theme setting in Reading View settings")
-    public static let ReaderModeStyleSepiaLabel = MZLocalizedString("Sepia", comment: "Sepia theme setting in Reading View settings")
+    public static let ReaderModeStyleBrightnessAccessibilityLabel = MZLocalizedString("Brightness", comment: "Accessibility label for brightness adjustment slider in Reader Mode display settings", lastEditedIn: .unknown)
+    public static let ReaderModeStyleFontTypeAccessibilityLabel = MZLocalizedString("Changes font type.", comment: "Accessibility hint for the font type buttons in reader mode display settings", lastEditedIn: .unknown)
+    public static let ReaderModeStyleSansSerifFontType = MZLocalizedString("Sans-serif", comment: "Font type setting in the reading view settings", lastEditedIn: .unknown)
+    public static let ReaderModeStyleSerifFontType = MZLocalizedString("Serif", comment: "Font type setting in the reading view settings", lastEditedIn: .unknown)
+    public static let ReaderModeStyleSmallerLabel = MZLocalizedString("-", comment: "Button for smaller reader font size. Keep this extremely short! This is shown in the reader mode toolbar.", lastEditedIn: .unknown)
+    public static let ReaderModeStyleSmallerAccessibilityLabel = MZLocalizedString("Decrease text size", comment: "Accessibility label for button decreasing font size in display settings of reader mode", lastEditedIn: .unknown)
+    public static let ReaderModeStyleLargerLabel = MZLocalizedString("+", comment: "Button for larger reader font size. Keep this extremely short! This is shown in the reader mode toolbar.", lastEditedIn: .unknown)
+    public static let ReaderModeStyleLargerAccessibilityLabel = MZLocalizedString("Increase text size", comment: "Accessibility label for button increasing font size in display settings of reader mode", lastEditedIn: .unknown)
+    public static let ReaderModeStyleFontSize = MZLocalizedString("Aa", comment: "Button for reader mode font size. Keep this extremely short! This is shown in the reader mode toolbar.", lastEditedIn: .unknown)
+    public static let ReaderModeStyleChangeColorSchemeAccessibilityHint = MZLocalizedString("Changes color theme.", comment: "Accessibility hint for the color theme setting buttons in reader mode display settings", lastEditedIn: .unknown)
+    public static let ReaderModeStyleLightLabel = MZLocalizedString("Light", comment: "Light theme setting in Reading View settings", lastEditedIn: .unknown)
+    public static let ReaderModeStyleDarkLabel = MZLocalizedString("Dark", comment: "Dark theme setting in Reading View settings", lastEditedIn: .unknown)
+    public static let ReaderModeStyleSepiaLabel = MZLocalizedString("Sepia", comment: "Sepia theme setting in Reading View settings", lastEditedIn: .unknown)
 }
 
 // MARK: - Empty Private tab view
 extension String {
-    public static let PrivateBrowsingLearnMore = MZLocalizedString("Learn More", tableName: "PrivateBrowsing", comment: "Text button displayed when there are no tabs open while in private mode")
-    public static let PrivateBrowsingTitle = MZLocalizedString("Private Browsing", tableName: "PrivateBrowsing", comment: "Title displayed for when there are no open tabs while in private mode")
-    public static let PrivateBrowsingDescription = MZLocalizedString("Firefox won’t remember any of your history or cookies, but new bookmarks will be saved.", tableName: "PrivateBrowsing", comment: "Description text displayed when there are no open tabs while in private mode")
+    public static let PrivateBrowsingLearnMore = MZLocalizedString("Learn More", tableName: "PrivateBrowsing", comment: "Text button displayed when there are no tabs open while in private mode", lastEditedIn: .unknown)
+    public static let PrivateBrowsingTitle = MZLocalizedString("Private Browsing", tableName: "PrivateBrowsing", comment: "Title displayed for when there are no open tabs while in private mode", lastEditedIn: .unknown)
+    public static let PrivateBrowsingDescription = MZLocalizedString("Firefox won’t remember any of your history or cookies, but new bookmarks will be saved.", tableName: "PrivateBrowsing", comment: "Description text displayed when there are no open tabs while in private mode", lastEditedIn: .unknown)
 }
 
 // MARK: - Advanced Account Setting
 extension String {
-    public static let AdvancedAccountUseStageServer = MZLocalizedString("Use stage servers", comment: "Debug option")
+    public static let AdvancedAccountUseStageServer = MZLocalizedString("Use stage servers", comment: "Debug option", lastEditedIn: .unknown)
 }
 
 // MARK: - App Settings
 extension String {
-    public static let AppSettingsLicenses = MZLocalizedString("Licenses", comment: "Settings item that opens a tab containing the licenses. See http://mzl.la/1NSAWCG")
-    public static let AppSettingsYourRights = MZLocalizedString("Your Rights", comment: "Your Rights settings section title")
-    public static let AppSettingsShowTour = MZLocalizedString("Show Tour", comment: "Show the on-boarding screen again from the settings")
-    public static let AppSettingsSendFeedback = MZLocalizedString("Send Feedback", comment: "Menu item in settings used to open input.mozilla.org where people can submit feedback")
-    public static let AppSettingsHelp = MZLocalizedString("Help", comment: "Show the SUMO support page from the Support section in the settings. see http://mzl.la/1dmM8tZ")
-    public static let AppSettingsSearch = MZLocalizedString("Search", comment: "Open search section of settings")
-    public static let AppSettingsPrivacyPolicy = MZLocalizedString("Privacy Policy", comment: "Show Firefox Browser Privacy Policy page from the Privacy section in the settings. See https://www.mozilla.org/privacy/firefox/")
+    public static let AppSettingsLicenses = MZLocalizedString("Licenses", comment: "Settings item that opens a tab containing the licenses. See http://mzl.la/1NSAWCG", lastEditedIn: .unknown)
+    public static let AppSettingsYourRights = MZLocalizedString("Your Rights", comment: "Your Rights settings section title", lastEditedIn: .unknown)
+    public static let AppSettingsShowTour = MZLocalizedString("Show Tour", comment: "Show the on-boarding screen again from the settings", lastEditedIn: .unknown)
+    public static let AppSettingsSendFeedback = MZLocalizedString("Send Feedback", comment: "Menu item in settings used to open input.mozilla.org where people can submit feedback", lastEditedIn: .unknown)
+    public static let AppSettingsHelp = MZLocalizedString("Help", comment: "Show the SUMO support page from the Support section in the settings. see http://mzl.la/1dmM8tZ", lastEditedIn: .unknown)
+    public static let AppSettingsSearch = MZLocalizedString("Search", comment: "Open search section of settings", lastEditedIn: .unknown)
+    public static let AppSettingsPrivacyPolicy = MZLocalizedString("Privacy Policy", comment: "Show Firefox Browser Privacy Policy page from the Privacy section in the settings. See https://www.mozilla.org/privacy/firefox/", lastEditedIn: .unknown)
     
-    public static let AppSettingsTitle = MZLocalizedString("Settings", comment: "Title in the settings view controller title bar")
-    public static let AppSettingsDone = MZLocalizedString("Done", comment: "Done button on left side of the Settings view controller title bar")
-    public static let AppSettingsPrivacyTitle = MZLocalizedString("Privacy", comment: "Privacy section title")
-    public static let AppSettingsBlockPopups = MZLocalizedString("Block Pop-up Windows", comment: "Block pop-up windows setting")
-    public static let AppSettingsClosePrivateTabsTitle = MZLocalizedString("Close Private Tabs", tableName: "PrivateBrowsing", comment: "Setting for closing private tabs")
-    public static let AppSettingsClosePrivateTabsDescription = MZLocalizedString("When Leaving Private Browsing", tableName: "PrivateBrowsing", comment: "Will be displayed in Settings under 'Close Private Tabs'")
-    public static let AppSettingsSupport = MZLocalizedString("Support", comment: "Support section title")
-    public static let AppSettingsAbout = MZLocalizedString("About", comment: "About settings section title")
+    public static let AppSettingsTitle = MZLocalizedString("Settings", comment: "Title in the settings view controller title bar", lastEditedIn: .unknown)
+    public static let AppSettingsDone = MZLocalizedString("Done", comment: "Done button on left side of the Settings view controller title bar", lastEditedIn: .unknown)
+    public static let AppSettingsPrivacyTitle = MZLocalizedString("Privacy", comment: "Privacy section title", lastEditedIn: .unknown)
+    public static let AppSettingsBlockPopups = MZLocalizedString("Block Pop-up Windows", comment: "Block pop-up windows setting", lastEditedIn: .unknown)
+    public static let AppSettingsClosePrivateTabsTitle = MZLocalizedString("Close Private Tabs", tableName: "PrivateBrowsing", comment: "Setting for closing private tabs", lastEditedIn: .unknown)
+    public static let AppSettingsClosePrivateTabsDescription = MZLocalizedString("When Leaving Private Browsing", tableName: "PrivateBrowsing", comment: "Will be displayed in Settings under 'Close Private Tabs'", lastEditedIn: .unknown)
+    public static let AppSettingsSupport = MZLocalizedString("Support", comment: "Support section title", lastEditedIn: .unknown)
+    public static let AppSettingsAbout = MZLocalizedString("About", comment: "About settings section title", lastEditedIn: .unknown)
 }
 
 // MARK: - Clearables
 extension String {
     // Removed Clearables as part of Bug 1226654, but keeping the string around.
-    private static let removedSavedLoginsLabel = MZLocalizedString("Saved Logins", tableName: "ClearPrivateData", comment: "Settings item for clearing passwords and login data")
+    private static let removedSavedLoginsLabel = MZLocalizedString("Saved Logins", tableName: "ClearPrivateData", comment: "Settings item for clearing passwords and login data", lastEditedIn: .unknown)
     
-    public static let ClearableHistory = MZLocalizedString("Browsing History", tableName: "ClearPrivateData", comment: "Settings item for clearing browsing history")
-    public static let ClearableCache = MZLocalizedString("Cache", tableName: "ClearPrivateData", comment: "Settings item for clearing the cache")
-    public static let ClearableOfflineData = MZLocalizedString("Offline Website Data", tableName: "ClearPrivateData", comment: "Settings item for clearing website data")
-    public static let ClearableCookies = MZLocalizedString("Cookies", tableName: "ClearPrivateData", comment: "Settings item for clearing cookies")
-    public static let ClearableDownloads = MZLocalizedString("Downloaded Files", tableName: "ClearPrivateData", comment: "Settings item for deleting downloaded files")
-    public static let ClearableSpotlight = MZLocalizedString("Spotlight Index", tableName: "ClearPrivateData", comment: "Settings item for deleting the iOS search index of browsed webpages")
+    public static let ClearableHistory = MZLocalizedString("Browsing History", tableName: "ClearPrivateData", comment: "Settings item for clearing browsing history", lastEditedIn: .unknown)
+    public static let ClearableCache = MZLocalizedString("Cache", tableName: "ClearPrivateData", comment: "Settings item for clearing the cache", lastEditedIn: .unknown)
+    public static let ClearableOfflineData = MZLocalizedString("Offline Website Data", tableName: "ClearPrivateData", comment: "Settings item for clearing website data", lastEditedIn: .unknown)
+    public static let ClearableCookies = MZLocalizedString("Cookies", tableName: "ClearPrivateData", comment: "Settings item for clearing cookies", lastEditedIn: .unknown)
+    public static let ClearableDownloads = MZLocalizedString("Downloaded Files", tableName: "ClearPrivateData", comment: "Settings item for deleting downloaded files", lastEditedIn: .unknown)
 }
 
 // MARK: - SearchEngine Picker
 extension String {
-    public static let SearchEnginePickerTitle = MZLocalizedString("Default Search Engine", comment: "Title for default search engine picker.")
-    public static let SearchEnginePickerCancel = MZLocalizedString("Cancel", comment: "Label for Cancel button")
+    public static let SearchEnginePickerTitle = MZLocalizedString("Default Search Engine", comment: "Title for default search engine picker.", lastEditedIn: .unknown)
+    public static let SearchEnginePickerCancel = MZLocalizedString("Cancel", comment: "Label for Cancel button", lastEditedIn: .unknown)
 }
 
 // MARK: - SearchSettings
 extension String {
-    public static let SearchSettingsTitle = MZLocalizedString("Search", comment: "Navigation title for search settings.")
-    public static let SearchSettingsDefaultSearchEngineAccessibilityLabel = MZLocalizedString("Default Search Engine", comment: "Accessibility label for default search engine setting.")
-    public static let SearchSettingsShowSearchSuggestions = MZLocalizedString("Show Search Suggestions", comment: "Label for show search suggestions setting.")
-    public static let SearchSettingsDefaultSearchEngineTitle = MZLocalizedString("Default Search Engine", comment: "Title for default search engine settings section.")
-    public static let SearchSettingsQuickSearchEnginesTitle = MZLocalizedString("Quick-Search Engines", comment: "Title for quick-search engines settings section.")
+    public static let SearchSettingsTitle = MZLocalizedString("Search", comment: "Navigation title for search settings.", lastEditedIn: .unknown)
+    public static let SearchSettingsDefaultSearchEngineAccessibilityLabel = MZLocalizedString("Default Search Engine", comment: "Accessibility label for default search engine setting.", lastEditedIn: .unknown)
+    public static let SearchSettingsShowSearchSuggestions = MZLocalizedString("Show Search Suggestions", comment: "Label for show search suggestions setting.", lastEditedIn: .unknown)
+    public static let SearchSettingsDefaultSearchEngineTitle = MZLocalizedString("Default Search Engine", comment: "Title for default search engine settings section.", lastEditedIn: .unknown)
+    public static let SearchSettingsQuickSearchEnginesTitle = MZLocalizedString("Quick-Search Engines", comment: "Title for quick-search engines settings section.", lastEditedIn: .unknown)
 }
 
 // MARK: - SettingsContent
 extension String {
-    public static let SettingsContentPageLoadError = MZLocalizedString("Could not load page.", comment: "Error message that is shown in settings when there was a problem loading")
+    public static let SettingsContentPageLoadError = MZLocalizedString("Could not load page.", comment: "Error message that is shown in settings when there was a problem loading", lastEditedIn: .unknown)
 }
 
 // MARK: - SearchInput
 extension String {
-    public static let SearchInputAccessibilityLabel = MZLocalizedString("Search Input Field", tableName: "LoginManager", comment: "Accessibility label for the search input field in the Logins list")
-    public static let SearchInputTitle = MZLocalizedString("Search", tableName: "LoginManager", comment: "Title for the search field at the top of the Logins list screen")
-    public static let SearchInputClearAccessibilityLabel = MZLocalizedString("Clear Search", tableName: "LoginManager", comment: "Accessibility message e.g. spoken by VoiceOver after the user taps the close button in the search field to clear the search and exit search mode")
-    public static let SearchInputEnterSearchMode = MZLocalizedString("Enter Search Mode", tableName: "LoginManager", comment: "Accessibility label for entering search mode for logins")
+    public static let SearchInputAccessibilityLabel = MZLocalizedString("Search Input Field", tableName: "LoginManager", comment: "Accessibility label for the search input field in the Logins list", lastEditedIn: .unknown)
+    public static let SearchInputTitle = MZLocalizedString("Search", tableName: "LoginManager", comment: "Title for the search field at the top of the Logins list screen", lastEditedIn: .unknown)
+    public static let SearchInputClearAccessibilityLabel = MZLocalizedString("Clear Search", tableName: "LoginManager", comment: "Accessibility message e.g. spoken by VoiceOver after the user taps the close button in the search field to clear the search and exit search mode", lastEditedIn: .unknown)
+    public static let SearchInputEnterSearchMode = MZLocalizedString("Enter Search Mode", tableName: "LoginManager", comment: "Accessibility label for entering search mode for logins", lastEditedIn: .unknown)
 }
 
 // MARK: - TabsButton
 extension String {
-    public static let TabsButtonShowTabsAccessibilityLabel = MZLocalizedString("Show Tabs", comment: "Accessibility label for the tabs button in the (top) tab toolbar")
+    public static let TabsButtonShowTabsAccessibilityLabel = MZLocalizedString("Show Tabs", comment: "Accessibility label for the tabs button in the (top) tab toolbar", lastEditedIn: .unknown)
 }
 
 // MARK: - TabTrayButtons
 extension String {
-    public static let TabTrayButtonNewTabAccessibilityLabel = MZLocalizedString("New Tab", comment: "Accessibility label for the New Tab button in the tab toolbar.")
-    public static let TabTrayButtonShowTabsAccessibilityLabel = MZLocalizedString("Show Tabs", comment: "Accessibility Label for the tabs button in the tab toolbar")
+    public static let TabTrayButtonNewTabAccessibilityLabel = MZLocalizedString("New Tab", comment: "Accessibility label for the New Tab button in the tab toolbar.", lastEditedIn: .unknown)
+    public static let TabTrayButtonShowTabsAccessibilityLabel = MZLocalizedString("Show Tabs", comment: "Accessibility Label for the tabs button in the tab toolbar", lastEditedIn: .unknown)
 }
 
 // MARK: - MenuHelper
 extension String {
-    public static let MenuHelperPasteAndGo = MZLocalizedString("UIMenuItem.PasteGo", value: "Paste & Go", comment: "The menu item that pastes the current contents of the clipboard into the URL bar and navigates to the page")
-    public static let MenuHelperReveal = MZLocalizedString("Reveal", tableName: "LoginManager", comment: "Reveal password text selection menu item")
-    public static let MenuHelperHide =  MZLocalizedString("Hide", tableName: "LoginManager", comment: "Hide password text selection menu item")
-    public static let MenuHelperCopy = MZLocalizedString("Copy", tableName: "LoginManager", comment: "Copy password text selection menu item")
-    public static let MenuHelperOpenAndFill = MZLocalizedString("Open & Fill", tableName: "LoginManager", comment: "Open and Fill website text selection menu item")
-    public static let MenuHelperFindInPage = MZLocalizedString("Find in Page", tableName: "FindInPage", comment: "Text selection menu item")
-    public static let MenuHelperSearchWithFirefox = MZLocalizedString("UIMenuItem.SearchWithFirefox", value: "Search with Firefox", comment: "Search in New Tab Text selection menu item")
+    public static let MenuHelperPasteAndGo = MZLocalizedString("UIMenuItem.PasteGo", value: "Paste & Go", comment: "The menu item that pastes the current contents of the clipboard into the URL bar and navigates to the page", lastEditedIn: .unknown)
+    public static let MenuHelperReveal = MZLocalizedString("Reveal", tableName: "LoginManager", comment: "Reveal password text selection menu item", lastEditedIn: .unknown)
+    public static let MenuHelperHide =  MZLocalizedString("Hide", tableName: "LoginManager", comment: "Hide password text selection menu item", lastEditedIn: .unknown)
+    public static let MenuHelperCopy = MZLocalizedString("Copy", tableName: "LoginManager", comment: "Copy password text selection menu item", lastEditedIn: .unknown)
+    public static let MenuHelperOpenAndFill = MZLocalizedString("Open & Fill", tableName: "LoginManager", comment: "Open and Fill website text selection menu item", lastEditedIn: .unknown)
+    public static let MenuHelperFindInPage = MZLocalizedString("Find in Page", tableName: "FindInPage", comment: "Text selection menu item", lastEditedIn: .unknown)
+    public static let MenuHelperSearchWithFirefox = MZLocalizedString("UIMenuItem.SearchWithFirefox", value: "Search with Firefox", comment: "Search in New Tab Text selection menu item", lastEditedIn: .unknown)
 }
 
 // MARK: - DeviceInfo
 extension String {
-    public static let DeviceInfoClientNameDescription = MZLocalizedString("%@ on %@", tableName: "Shared", comment: "A brief descriptive name for this app on this device, used for Send Tab and Synced Tabs. The first argument is the app name. The second argument is the device name.")
+    public static let DeviceInfoClientNameDescription = MZLocalizedString("%@ on %@", tableName: "Shared", comment: "A brief descriptive name for this app on this device, used for Send Tab and Synced Tabs. The first argument is the app name. The second argument is the device name.", lastEditedIn: .unknown)
 }
 
 // MARK: - TimeConstants
 extension String {
-    public static let TimeConstantMoreThanAMonth = MZLocalizedString("more than a month ago", comment: "Relative date for dates older than a month and less than two months.")
-    public static let TimeConstantMoreThanAWeek = MZLocalizedString("more than a week ago", comment: "Description for a date more than a week ago, but less than a month ago.")
-    public static let TimeConstantYesterday = MZLocalizedString("yesterday", comment: "Relative date for yesterday.")
-    public static let TimeConstantThisWeek = MZLocalizedString("this week", comment: "Relative date for date in past week.")
-    public static let TimeConstantRelativeToday = MZLocalizedString("today at %@", comment: "Relative date for date older than a minute.")
-    public static let TimeConstantJustNow = MZLocalizedString("just now", comment: "Relative time for a tab that was visited within the last few moments.")
+    public static let TimeConstantMoreThanAMonth = MZLocalizedString("more than a month ago", comment: "Relative date for dates older than a month and less than two months.", lastEditedIn: .unknown)
+    public static let TimeConstantMoreThanAWeek = MZLocalizedString("more than a week ago", comment: "Description for a date more than a week ago, but less than a month ago.", lastEditedIn: .unknown)
+    public static let TimeConstantYesterday = MZLocalizedString("yesterday", comment: "Relative date for yesterday.", lastEditedIn: .unknown)
+    public static let TimeConstantThisWeek = MZLocalizedString("this week", comment: "Relative date for date in past week.", lastEditedIn: .unknown)
+    public static let TimeConstantRelativeToday = MZLocalizedString("today at %@", comment: "Relative date for date older than a minute.", lastEditedIn: .unknown)
+    public static let TimeConstantJustNow = MZLocalizedString("just now", comment: "Relative time for a tab that was visited within the last few moments.", lastEditedIn: .unknown)
 }
 
 // MARK: - Default Suggested Site
 extension String {
-    public static let DefaultSuggestedFacebook = MZLocalizedString("Facebook", comment: "Tile title for Facebook")
-    public static let DefaultSuggestedYouTube = MZLocalizedString("YouTube", comment: "Tile title for YouTube")
-    public static let DefaultSuggestedAmazon = MZLocalizedString("Amazon", comment: "Tile title for Amazon")
-    public static let DefaultSuggestedWikipedia = MZLocalizedString("Wikipedia", comment: "Tile title for Wikipedia")
-    public static let DefaultSuggestedTwitter = MZLocalizedString("Twitter", comment: "Tile title for Twitter")
+    public static let DefaultSuggestedFacebook = MZLocalizedString("Facebook", comment: "Tile title for Facebook", lastEditedIn: .unknown)
+    public static let DefaultSuggestedYouTube = MZLocalizedString("YouTube", comment: "Tile title for YouTube", lastEditedIn: .unknown)
+    public static let DefaultSuggestedAmazon = MZLocalizedString("Amazon", comment: "Tile title for Amazon", lastEditedIn: .unknown)
+    public static let DefaultSuggestedWikipedia = MZLocalizedString("Wikipedia", comment: "Tile title for Wikipedia", lastEditedIn: .unknown)
+    public static let DefaultSuggestedTwitter = MZLocalizedString("Twitter", comment: "Tile title for Twitter", lastEditedIn: .unknown)
 }
 
 // MARK: - MR1 Strings
 extension String {
-    public static let AwesomeBarSearchWithEngineButtonTitle = MZLocalizedString("Awesomebar.SearchWithEngine.Title", value: "Search with %@", comment: "Title for button to suggest searching with a search engine. First argument is the name of the search engine to select")
-    public static let AwesomeBarSearchWithEngineButtonDescription = MZLocalizedString("Awesomebar.SearchWithEngine.Description", value: "Search %@ directly from the address bar", comment: "Description for button to suggest searching with a search engine. First argument is the name of the search engine to select")
+    public static let AwesomeBarSearchWithEngineButtonTitle = MZLocalizedString("Awesomebar.SearchWithEngine.Title", value: "Search with %@", comment: "Title for button to suggest searching with a search engine. First argument is the name of the search engine to select", lastEditedIn: .unknown)
+    public static let AwesomeBarSearchWithEngineButtonDescription = MZLocalizedString("Awesomebar.SearchWithEngine.Description", value: "Search %@ directly from the address bar", comment: "Description for button to suggest searching with a search engine. First argument is the name of the search engine to select", lastEditedIn: .unknown)
 }
 
 // MARK: - Credential Provider
 extension String {
-    public static let LoginsWelcomeViewTitle = MZLocalizedString("Logins.WelcomeView.Title", value: "Take your passwords everywhere", comment: "Label displaying welcome view title")
-    public static let LoginsListSearchCancel = MZLocalizedString("LoginsList.Search.Cancel", value: "Cancel", comment: "title for cancel button for user to stop searching for a particular login")
-    public static let LoginsListSearchPlaceholder = MZLocalizedString("LoginsList.Search.Placeholder", value: "Search logins", comment: "Placeholder text for search field")
-    public static let LoginsListSelectPasswordTitle = MZLocalizedString("LoginsList.SelectPassword.Title", value: "Select a password to fill", comment: "Label displaying select a password to fill instruction")
-    public static let LoginsListNoMatchingResultTitle = MZLocalizedString("LoginsList.NoMatchingResult.Title", value: "No matching logins", comment: "Label displayed when a user searches and no matches can be found against the search query")
-    public static let LoginsListNoMatchingResultSubtitle = MZLocalizedString("LoginsList.NoMatchingResult.Subtitle", value: "There are no results matching your search.", comment: "Label that appears after the search if there are no logins matching the search")
-    public static let LoginsListNoLoginsFoundDescription = MZLocalizedString("LoginsList.NoLoginsFound.Description", value: "Saved logins will show up here. If you saved your logins to Firefox on a different device, sign in to your Firefox Account.", comment: "Label shown when there are no logins to list")
+    public static let LoginsWelcomeViewTitle = MZLocalizedString("Logins.WelcomeView.Title", value: "Take your passwords everywhere", comment: "Label displaying welcome view title", lastEditedIn: .unknown)
+    public static let LoginsListSearchCancel = MZLocalizedString("LoginsList.Search.Cancel", value: "Cancel", comment: "Cancel button title", lastEditedIn: .unknown)
+    public static let LoginsListSearchPlaceholder = MZLocalizedString("LoginsList.Search.Placeholder", value: "Search logins", comment: "Placeholder text for search field", lastEditedIn: .unknown)
+    public static let LoginsListSelectPasswordTitle = MZLocalizedString("LoginsList.SelectPassword.Title", value: "Select a password to fill", comment: "Label displaying select a password to fill instruction", lastEditedIn: .unknown)
+    public static let LoginsListNoMatchingResultTitle = MZLocalizedString("LoginsList.NoMatchingResult.Title", value: "No matching logins", comment: "Label displayed when a user searches and no matches can be found against the search query", lastEditedIn: .unknown)
+    public static let LoginsListNoMatchingResultSubtitle = MZLocalizedString("LoginsList.NoMatchingResult.Subtitle", value: "There are no results matching your search.", comment: "Label that appears after the search if there are no logins matching the search", lastEditedIn: .unknown)
+    public static let LoginsListNoLoginsFoundDescription = MZLocalizedString("LoginsList.NoLoginsFound.Description", value: "Saved logins will show up here. If you saved your logins to Firefox on a different device, sign in to your Firefox Account.", comment: "Label shown when there are no logins to list", lastEditedIn: .unknown)
 }
 
 // MARK: - v35 Strings
 extension String {
-    public static let FirefoxHomeJumpBackInSectionTitle = MZLocalizedString("ActivityStream.JumpBackIn.SectionTitle", value: "Jump Back In", comment: "Title for the Jump Back In section. This section allows users to jump back in to a recently viewed tab")
-    public static let FirefoxHomeRecentlySavedSectionTitle = MZLocalizedString("ActivityStream.RecentlySaved.SectionTitle", value: "Recently Saved", comment: "Section title for the Recently Saved section. This shows websites that have had a save action. Right now it is just bookmarks but it could be used for other things like the reading list in the future.")
-    public static let FirefoxHomeShowAll = MZLocalizedString("ActivityStream.RecentlySaved.ShowAll", value: "Show all", comment: "This button will open the library showing all the users bookmarks")
-    public static let TabsTrayInactiveTabsSectionTitle = MZLocalizedString("TabTray.InactiveTabs.SectionTitle", value: "Inactive Tabs", comment: "Title for the inactive tabs section. This section groups all tabs that haven't been used in a while.")
-    public static let TabsTrayRecentlyCloseTabsSectionTitle = MZLocalizedString("TabTray.RecentlyClosed.SectionTitle", value: "Recently closed", comment: "Title for the recently closed tabs section. This section shows a list of all the tabs that have been recently closed.")
-    public static let TabsTrayRecentlyClosedTabsDescritpion = MZLocalizedString("TabTray.RecentlyClosed.Description", value: "Tabs are available here for 30 days. After that time, tabs will be automatically closed.", comment: "Describes what the Recently Closed tabs behavior is for users unfamiliar with it.")
+    public static let FirefoxHomeJumpBackInSectionTitle = MZLocalizedString("ActivityStream.JumpBackIn.SectionTitle", value: "Jump Back In", comment: "Title for the Jump Back In section. This section allows users to jump back in to a recently viewed tab", lastEditedIn: .v350)
+    public static let FirefoxHomeRecentlySavedSectionTitle = MZLocalizedString("ActivityStream.RecentlySaved.SectionTitle", value: "Recently Saved", comment: "Section title for the Recently Saved section. This shows websites that have had a save action. Right now it is just bookmarks but it could be used for other things like the reading list in the future.", lastEditedIn: .v350)
+    public static let FirefoxHomeShowAll = MZLocalizedString("ActivityStream.RecentlySaved.ShowAll", value: "Show all", comment: "This button will open the library showing all the users bookmarks", lastEditedIn: .v350)
+    public static let TabsTrayInactiveTabsSectionTitle = MZLocalizedString("TabTray.InactiveTabs.SectionTitle", value: "Inactive Tabs", comment: "Title for the inactive tabs section. This section groups all tabs that haven't been used in a while.", lastEditedIn: .v350)
+    public static let TabsTrayRecentlyCloseTabsSectionTitle = MZLocalizedString("TabTray.RecentlyClosed.SectionTitle", value: "Recently closed", comment: "Title for the recently closed tabs section. This section shows a list of all the tabs that have been recently closed.", lastEditedIn: .v350)
+    public static let TabsTrayRecentlyClosedTabsDescritpion = MZLocalizedString("TabTray.RecentlyClosed.Description", value: "Tabs are available here for 30 days. After that time, tabs will be automatically closed.", comment: "Describes what the Recently Closed tabs behavior is for users unfamiliar with it.", lastEditedIn: .v350)
 }
 
 // MARK: - v36 Strings
 extension String {
-    public static let ProtectionStatusSheetConnectionSecure = MZLocalizedString("ProtectionStatusSheet.SecureConnection", value: "Secure Connection", comment: "value for label to indicate user is on a secure ssl connection")
-    public static let ProtectionStatusSheetConnectionInsecure = MZLocalizedString("ProtectionStatusSheet.InsecureConnection", value: "Insecure Connection", comment: "value for label to indicate user is on an unencrypted website")
+    public static let ProtectionStatusSheetConnectionSecure = MZLocalizedString("ProtectionStatusSheet.SecureConnection", value: "Secure Connection", comment: "value for label to indicate user is on a secure ssl connection", lastEditedIn: .v360)
+    public static let ProtectionStatusSheetConnectionInsecure = MZLocalizedString("ProtectionStatusSheet.InsecureConnection", value: "Insecure Connection", comment: "value for label to indicate user is on an unencrypted website", lastEditedIn: .v360)
 }

--- a/Client/Frontend/Update/UpdateCoverSheetTableViewCell.swift
+++ b/Client/Frontend/Update/UpdateCoverSheetTableViewCell.swift
@@ -30,7 +30,7 @@ class UpdateCoverSheetTableViewCell: UITableViewCell {
     }()
     var updateCoverSheetCellDescriptionLabel: UILabel = {
         let label = UILabel()
-        label.text = Strings.CoverSheetV22DarkModeTitle
+        label.text = .CoverSheetV22DarkModeTitle
         label.textColor = .black
         label.font = UIFont.systemFont(ofSize: 20, weight: .regular)
         label.textAlignment = .left

--- a/Client/Frontend/Update/UpdateViewController.swift
+++ b/Client/Frontend/Update/UpdateViewController.swift
@@ -104,14 +104,14 @@ class UpdateViewController: UIViewController {
     }()
     private var doneButton: UIButton = {
         let button = UIButton()
-        button.setTitle(Strings.SettingsSearchDoneButton, for: .normal)
+        button.setTitle(.SettingsSearchDoneButton, for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .regular)
         button.setTitleColor(UIColor.systemBlue, for: .normal)
         return button
     }()
     private lazy var startBrowsingButton: UIButton = {
         let button = UIButton()
-        button.setTitle(Strings.StartBrowsingButtonTitle, for: .normal)
+        button.setTitle(.StartBrowsingButtonTitle, for: .normal)
         button.titleLabel?.font = UpdateViewControllerUX.StartBrowsingButton.font
         button.layer.cornerRadius = UpdateViewControllerUX.StartBrowsingButton.cornerRadius
         button.setTitleColor(.white, for: .normal)

--- a/Client/Frontend/Update/UpdateViewController.swift
+++ b/Client/Frontend/Update/UpdateViewController.swift
@@ -104,7 +104,7 @@ class UpdateViewController: UIViewController {
     }()
     private var doneButton: UIButton = {
         let button = UIButton()
-        button.setTitle(.SettingsSearchDoneButton, for: .normal)
+        button.setTitle(.Settings.SearchDoneButton, for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .regular)
         button.setTitleColor(UIColor.systemBlue, for: .normal)
         return button

--- a/Client/Frontend/Update/UpdateViewModel.swift
+++ b/Client/Frontend/Update/UpdateViewModel.swift
@@ -11,7 +11,7 @@ class UpdateViewModel {
     var startBrowsing: (() -> Void)?
     
     // Constants
-    let updates: [Update] = [Update(updateImage: #imageLiteral(resourceName: "darkModeUpdate"), updateText: "\(Strings.CoverSheetV22DarkModeTitle)\n\n\(Strings.CoverSheetV22DarkModeDescription)")]
+    let updates: [Update] = [Update(updateImage: #imageLiteral(resourceName: "darkModeUpdate"), updateText: "\(String.CoverSheetV22DarkModeTitle)\n\n\(String.CoverSheetV22DarkModeDescription)")]
     
     // We only show coversheet for specific app updates and not all. The list below is for the version(s)
     // we would like to show the coversheet for.
@@ -22,7 +22,7 @@ class UpdateViewModel {
     }
 
     private func setupUpdateModel() {
-        updateCoverSheetModel = UpdateCoverSheetModel(titleImage: #imageLiteral(resourceName: "splash"), titleText: Strings.WhatsNewString, updates: updates)
+        updateCoverSheetModel = UpdateCoverSheetModel(titleImage: #imageLiteral(resourceName: "splash"), titleText: .WhatsNewString, updates: updates)
     }
     
     static func isCleanInstall(userPrefs: Prefs) -> Bool {

--- a/Client/Frontend/Update/UpdateViewModel.swift
+++ b/Client/Frontend/Update/UpdateViewModel.swift
@@ -22,7 +22,7 @@ class UpdateViewModel {
     }
 
     private func setupUpdateModel() {
-        updateCoverSheetModel = UpdateCoverSheetModel(titleImage: #imageLiteral(resourceName: "splash"), titleText: .WhatsNewString, updates: updates)
+        updateCoverSheetModel = UpdateCoverSheetModel(titleImage: #imageLiteral(resourceName: "splash"), titleText: .AppMenu.WhatsNewString, updates: updates)
     }
     
     static func isCleanInstall(userPrefs: Prefs) -> Bool {

--- a/Client/Frontend/Widgets/HistoryBackButton.swift
+++ b/Client/Frontend/Widgets/HistoryBackButton.swift
@@ -14,7 +14,7 @@ private struct HistoryBackButtonUX {
 class HistoryBackButton: UIButton, Themeable {
     lazy var title: UILabel = {
         let label = UILabel()
-        label.text = Strings.HistoryBackButtonTitle
+        label.text = .HistoryBackButtonTitle
         return label
     }()
 

--- a/Client/Frontend/Widgets/PhotonActionSheet/AppMenu.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/AppMenu.swift
@@ -10,19 +10,19 @@ extension PhotonActionSheetProtocol {
     //Returns a list of actions which is used to build a menu
     //OpenURL is a closure that can open a given URL in some view controller. It is up to the class using the menu to know how to open it
     func getLibraryActions(vcDelegate: PageOptionsVC) -> [PhotonActionSheetItem] {
-        let bookmarks = PhotonActionSheetItem(title: Strings.AppMenuBookmarks, iconString: "menu-panel-Bookmarks") { _, _ in
+        let bookmarks = PhotonActionSheetItem(title: .AppMenuBookmarks, iconString: "menu-panel-Bookmarks") { _, _ in
             let bvc = vcDelegate as? BrowserViewController
             bvc?.showLibrary(panel: .bookmarks)
         }
-        let history = PhotonActionSheetItem(title: Strings.AppMenuHistory, iconString: "menu-panel-History") { _, _ in
+        let history = PhotonActionSheetItem(title: .AppMenuHistory, iconString: "menu-panel-History") { _, _ in
             let bvc = vcDelegate as? BrowserViewController
             bvc?.showLibrary(panel: .history)
         }
-        let downloads = PhotonActionSheetItem(title: Strings.AppMenuDownloads, iconString: "menu-panel-Downloads") { _, _ in
+        let downloads = PhotonActionSheetItem(title: .AppMenuDownloads, iconString: "menu-panel-Downloads") { _, _ in
             let bvc = vcDelegate as? BrowserViewController
             bvc?.showLibrary(panel: .downloads)
         }
-        let readingList = PhotonActionSheetItem(title: Strings.AppMenuReadingList, iconString: "menu-panel-ReadingList") { _, _ in
+        let readingList = PhotonActionSheetItem(title: .AppMenuReadingList, iconString: "menu-panel-ReadingList") { _, _ in
             let bvc = vcDelegate as? BrowserViewController
             bvc?.showLibrary(panel: .readingList)
         }
@@ -33,7 +33,7 @@ extension PhotonActionSheetProtocol {
     func getHomeAction(vcDelegate: Self.PageOptionsVC) -> [PhotonActionSheetItem] {
         guard let tab = self.tabManager.selectedTab else { return [] }
         
-        let openHomePage = PhotonActionSheetItem(title: Strings.AppMenuOpenHomePageTitleString, iconString: "menu-Home") { _, _ in
+        let openHomePage = PhotonActionSheetItem(title: .AppMenuOpenHomePageTitleString, iconString: "menu-Home") { _, _ in
             let page = NewTabAccessors.getHomePage(self.profile.prefs)
             if page == .homePage, let homePageURL = HomeButtonHomePageAccessors.getHomePage(self.profile.prefs) {
                 tab.loadRequest(PrivilegedRequest(url: homePageURL) as URLRequest)
@@ -52,7 +52,7 @@ extension PhotonActionSheetProtocol {
         let variables = Experiments.shared.getVariables(featureId: .nimbusValidation)
         // Get the title and icon for this feature from nimbus.
         // We need to provide defaults if Nimbus doesn't provide them.
-        let title = variables.getText("settings-title") ?? Strings.AppMenuSettingsTitleString
+        let title = variables.getText("settings-title") ?? .AppMenuSettingsTitleString
         let icon = variables.getString("settings-icon") ?? "menu-Settings"
 
         let openSettings = PhotonActionSheetItem(title: title, iconString: icon) { _, _ in
@@ -81,7 +81,7 @@ extension PhotonActionSheetProtocol {
     func getOtherPanelActions(vcDelegate: PageOptionsVC) -> [PhotonActionSheetItem] {
         var items: [PhotonActionSheetItem] = []
         let noImageEnabled = NoImageModeHelper.isActivated(profile.prefs)
-        let imageModeTitle = noImageEnabled ? Strings.AppMenuShowImageMode : Strings.AppMenuNoImageMode
+        let imageModeTitle = noImageEnabled ? String.AppMenuShowImageMode : String.AppMenuNoImageMode
         let iconString = noImageEnabled ? "menu-ShowImages" : "menu-NoImageMode"
         let noImageMode = PhotonActionSheetItem(title: imageModeTitle, iconString: iconString, isEnabled: noImageEnabled) { action,_ in
             NoImageModeHelper.toggle(isEnabled: action.isEnabled, profile: self.profile, tabManager: self.tabManager)
@@ -95,7 +95,7 @@ extension PhotonActionSheetProtocol {
         items.append(noImageMode)
 
         let nightModeEnabled = NightModeHelper.isActivated(profile.prefs)
-        let nightModeTitle = nightModeEnabled ? Strings.AppMenuTurnOffNightMode : Strings.AppMenuTurnOnNightMode
+        let nightModeTitle = nightModeEnabled ? String.AppMenuTurnOffNightMode : String.AppMenuTurnOnNightMode
         let nightMode = PhotonActionSheetItem(title: nightModeTitle, iconString: "menu-NightMode", isEnabled: nightModeEnabled) { _, _ in
             NightModeHelper.toggle(self.profile.prefs, tabManager: self.tabManager)
 
@@ -134,11 +134,11 @@ extension PhotonActionSheetProtocol {
         let needsReauth = rustAccount.accountNeedsReauth()
 
         guard let userProfile = rustAccount.userProfile else {
-            return PhotonActionSheetItem(title: Strings.AppMenuBackUpAndSyncData, iconString: "menu-sync", handler: action)
+            return PhotonActionSheetItem(title: .AppMenuBackUpAndSyncData, iconString: "menu-sync", handler: action)
         }
         let title: String = {
             if rustAccount.accountNeedsReauth() {
-                return Strings.FxAAccountVerifyPassword
+                return .FxAAccountVerifyPassword
             }
             return userProfile.displayName ?? userProfile.email
         }()

--- a/Client/Frontend/Widgets/PhotonActionSheet/AppMenu.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/AppMenu.swift
@@ -10,19 +10,19 @@ extension PhotonActionSheetProtocol {
     //Returns a list of actions which is used to build a menu
     //OpenURL is a closure that can open a given URL in some view controller. It is up to the class using the menu to know how to open it
     func getLibraryActions(vcDelegate: PageOptionsVC) -> [PhotonActionSheetItem] {
-        let bookmarks = PhotonActionSheetItem(title: .AppMenuBookmarks, iconString: "menu-panel-Bookmarks") { _, _ in
+        let bookmarks = PhotonActionSheetItem(title: .AppMenu.Bookmarks, iconString: "menu-panel-Bookmarks") { _, _ in
             let bvc = vcDelegate as? BrowserViewController
             bvc?.showLibrary(panel: .bookmarks)
         }
-        let history = PhotonActionSheetItem(title: .AppMenuHistory, iconString: "menu-panel-History") { _, _ in
+        let history = PhotonActionSheetItem(title: .AppMenu.History, iconString: "menu-panel-History") { _, _ in
             let bvc = vcDelegate as? BrowserViewController
             bvc?.showLibrary(panel: .history)
         }
-        let downloads = PhotonActionSheetItem(title: .AppMenuDownloads, iconString: "menu-panel-Downloads") { _, _ in
+        let downloads = PhotonActionSheetItem(title: .AppMenu.Downloads, iconString: "menu-panel-Downloads") { _, _ in
             let bvc = vcDelegate as? BrowserViewController
             bvc?.showLibrary(panel: .downloads)
         }
-        let readingList = PhotonActionSheetItem(title: .AppMenuReadingList, iconString: "menu-panel-ReadingList") { _, _ in
+        let readingList = PhotonActionSheetItem(title: .AppMenu.ReadingList, iconString: "menu-panel-ReadingList") { _, _ in
             let bvc = vcDelegate as? BrowserViewController
             bvc?.showLibrary(panel: .readingList)
         }
@@ -33,7 +33,7 @@ extension PhotonActionSheetProtocol {
     func getHomeAction(vcDelegate: Self.PageOptionsVC) -> [PhotonActionSheetItem] {
         guard let tab = self.tabManager.selectedTab else { return [] }
         
-        let openHomePage = PhotonActionSheetItem(title: .AppMenuOpenHomePageTitleString, iconString: "menu-Home") { _, _ in
+        let openHomePage = PhotonActionSheetItem(title: .AppMenu.OpenHomePageTitleString, iconString: "menu-Home") { _, _ in
             let page = NewTabAccessors.getHomePage(self.profile.prefs)
             if page == .homePage, let homePageURL = HomeButtonHomePageAccessors.getHomePage(self.profile.prefs) {
                 tab.loadRequest(PrivilegedRequest(url: homePageURL) as URLRequest)
@@ -52,7 +52,7 @@ extension PhotonActionSheetProtocol {
         let variables = Experiments.shared.getVariables(featureId: .nimbusValidation)
         // Get the title and icon for this feature from nimbus.
         // We need to provide defaults if Nimbus doesn't provide them.
-        let title = variables.getText("settings-title") ?? .AppMenuSettingsTitleString
+        let title = variables.getText("settings-title") ?? .AppMenu.SettingsTitleString
         let icon = variables.getString("settings-icon") ?? "menu-Settings"
 
         let openSettings = PhotonActionSheetItem(title: title, iconString: icon) { _, _ in
@@ -81,7 +81,7 @@ extension PhotonActionSheetProtocol {
     func getOtherPanelActions(vcDelegate: PageOptionsVC) -> [PhotonActionSheetItem] {
         var items: [PhotonActionSheetItem] = []
         let noImageEnabled = NoImageModeHelper.isActivated(profile.prefs)
-        let imageModeTitle = noImageEnabled ? String.AppMenuShowImageMode : String.AppMenuNoImageMode
+        let imageModeTitle = noImageEnabled ? String.AppMenu.ShowImageMode : String.AppMenu.NoImageMode
         let iconString = noImageEnabled ? "menu-ShowImages" : "menu-NoImageMode"
         let noImageMode = PhotonActionSheetItem(title: imageModeTitle, iconString: iconString, isEnabled: noImageEnabled) { action,_ in
             NoImageModeHelper.toggle(isEnabled: action.isEnabled, profile: self.profile, tabManager: self.tabManager)
@@ -95,7 +95,7 @@ extension PhotonActionSheetProtocol {
         items.append(noImageMode)
 
         let nightModeEnabled = NightModeHelper.isActivated(profile.prefs)
-        let nightModeTitle = nightModeEnabled ? String.AppMenuTurnOffNightMode : String.AppMenuTurnOnNightMode
+        let nightModeTitle = nightModeEnabled ? String.AppMenu.TurnOffNightMode : String.AppMenu.TurnOnNightMode
         let nightMode = PhotonActionSheetItem(title: nightModeTitle, iconString: "menu-NightMode", isEnabled: nightModeEnabled) { _, _ in
             NightModeHelper.toggle(self.profile.prefs, tabManager: self.tabManager)
 
@@ -134,7 +134,7 @@ extension PhotonActionSheetProtocol {
         let needsReauth = rustAccount.accountNeedsReauth()
 
         guard let userProfile = rustAccount.userProfile else {
-            return PhotonActionSheetItem(title: .AppMenuBackUpAndSyncData, iconString: "menu-sync", handler: action)
+            return PhotonActionSheetItem(title: .AppMenu.BackUpAndSyncData, iconString: "menu-sync", handler: action)
         }
         let title: String = {
             if rustAccount.accountNeedsReauth() {

--- a/Client/Frontend/Widgets/PhotonActionSheet/PageActionMenu.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PageActionMenu.swift
@@ -41,7 +41,7 @@ extension PhotonActionSheetProtocol {
                        shouldShowNewTabButton: Bool,
                        success: @escaping (String, ButtonToastAction) -> Void) -> Array<[PhotonActionSheetItem]> {
         if tab.url?.isFileURL ?? false {
-            let shareFile = PhotonActionSheetItem(title: .AppMenuSharePageTitleString, iconString: "action_share") {  _,_ in
+            let shareFile = PhotonActionSheetItem(title: .AppMenu.SharePageTitleString, iconString: "action_share") {  _,_ in
                 guard let url = tab.url else { return }
 
                 self.share(fileURL: url, buttonView: buttonView, presentableVC: presentableVC)
@@ -55,12 +55,12 @@ extension PhotonActionSheetProtocol {
         let toggleActionIcon: String
         let siteTypeTelemetryObject: TelemetryWrapper.EventObject
         if defaultUAisDesktop {
-            toggleActionTitle = tab.changedUserAgent ? .AppMenuViewDesktopSiteTitleString : .AppMenuViewMobileSiteTitleString
+            toggleActionTitle = tab.changedUserAgent ? .AppMenu.ViewDesktopSiteTitleString : .AppMenu.ViewMobileSiteTitleString
             toggleActionIcon = tab.changedUserAgent ?
                 "menu-RequestDesktopSite" : "menu-ViewMobile"
             siteTypeTelemetryObject = .requestDesktopSite
         } else {
-            toggleActionTitle = tab.changedUserAgent ? .AppMenuViewMobileSiteTitleString : .AppMenuViewDesktopSiteTitleString
+            toggleActionTitle = tab.changedUserAgent ? .AppMenu.ViewMobileSiteTitleString : .AppMenu.ViewDesktopSiteTitleString
             toggleActionIcon = tab.changedUserAgent ?
                 "menu-ViewMobile" : "menu-RequestDesktopSite"
             siteTypeTelemetryObject = .requestMobileSite
@@ -73,15 +73,15 @@ extension PhotonActionSheetProtocol {
             }
         }
 
-        let addReadingList = PhotonActionSheetItem(title: .AppMenuAddToReadingListTitleString, iconString: "addToReadingList") { _,_  in
+        let addReadingList = PhotonActionSheetItem(title: .AppMenu.AddToReadingListTitleString, iconString: "addToReadingList") { _,_  in
             guard let url = tab.url?.displayURL else { return }
 
             self.profile.readingList.createRecordWithURL(url.absoluteString, title: tab.title ?? "", addedBy: UIDevice.current.name)
             TelemetryWrapper.recordEvent(category: .action, method: .add, object: .readingListItem, value: .pageActionMenu)
-            success(.AppMenuAddToReadingListConfirmMessage, .addToReadingList)
+            success(.AppMenu.AddToReadingListConfirmMessage, .addToReadingList)
         }
 
-        let bookmarkPage = PhotonActionSheetItem(title: .AppMenuAddBookmarkTitleString2, iconString: "menu-Bookmark") { _,_  in
+        let bookmarkPage = PhotonActionSheetItem(title: .AppMenu.AddBookmarkTitleString2, iconString: "menu-Bookmark") { _,_  in
             guard let url = tab.canonicalURL?.displayURL,
                 let bvc = presentableVC as? BrowserViewController else {
                     return
@@ -90,12 +90,12 @@ extension PhotonActionSheetProtocol {
             TelemetryWrapper.recordEvent(category: .action, method: .add, object: .bookmark, value: .pageActionMenu)
         }
 
-        let removeBookmark = PhotonActionSheetItem(title: .AppMenuRemoveBookmarkTitleString, iconString: "menu-Bookmark-Remove") { _,_  in
+        let removeBookmark = PhotonActionSheetItem(title: .AppMenu.RemoveBookmarkTitleString, iconString: "menu-Bookmark-Remove") { _,_  in
             guard let url = tab.url?.displayURL else { return }
 
             self.profile.places.deleteBookmarksWithURL(url: url.absoluteString).uponQueue(.main) { result in
                 if result.isSuccess {
-                    success(.AppMenuRemoveBookmarkConfirmMessage, .removeBookmark)
+                    success(.AppMenu.RemoveBookmarkConfirmMessage, .removeBookmark)
                 }
             }
 
@@ -112,7 +112,7 @@ extension PhotonActionSheetProtocol {
                 return self.profile.history.addPinnedTopSite(site)
             }.uponQueue(.main) { result in
                 if result.isSuccess {
-                    success(.AppMenuAddPinToShortcutsConfirmMessage, .pinPage)
+                    success(.AppMenu.AddPinToShortcutsConfirmMessage, .pinPage)
                 }
             }
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .pinToTopSites)
@@ -129,13 +129,13 @@ extension PhotonActionSheetProtocol {
                 return self.profile.history.removeFromPinnedTopSites(site)
             }.uponQueue(.main) { result in
                 if result.isSuccess {
-                    success(.AppMenuRemovePinFromShortcutsConfirmMessage, .removePinPage)
+                    success(.AppMenu.RemovePinFromShortcutsConfirmMessage, .removePinPage)
                 }
             }
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .removePinnedSite)
         }
 
-        let sendToDevice = PhotonActionSheetItem(title: .SendLinkToDeviceTitle, iconString: "menu-Send-to-Device") { _,_  in
+        let sendToDevice = PhotonActionSheetItem(title: .AppMenu.SendLinkToDeviceTitle, iconString: "menu-Send-to-Device") { _,_  in
             guard let bvc = presentableVC as? PresentableVC & InstructionsViewControllerDelegate & DevicePickerViewControllerDelegate else { return }
             if !self.profile.hasAccount() {
                 let instructionsViewController = InstructionsViewController()
@@ -175,11 +175,11 @@ extension PhotonActionSheetProtocol {
             }
         }
 
-        let copyURL = PhotonActionSheetItem(title: .AppMenuCopyLinkTitleString, iconString: "menu-Copy-Link") { _,_ in
+        let copyURL = PhotonActionSheetItem(title: .AppMenu.CopyLinkTitleString, iconString: "menu-Copy-Link") { _,_ in
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .copyAddress)
             if let url = tab.canonicalURL?.displayURL {
                 UIPasteboard.general.url = url
-                success(.AppMenuCopyURLConfirmMessage, .copyUrl)
+                success(.AppMenu.CopyURLConfirmMessage, .copyUrl)
             }
         }
         
@@ -187,7 +187,7 @@ extension PhotonActionSheetProtocol {
             self.tabManager.selectedTab?.reload()
         }
         
-        let stopRefreshPage = PhotonActionSheetItem(title: .StopReloadPageTitle, iconString: "nav-stop") { _,_ in
+        let stopRefreshPage = PhotonActionSheetItem(title: .AppMenu.StopReloadPageTitle, iconString: "nav-stop") { _,_ in
             self.tabManager.selectedTab?.stop()
         }
         
@@ -224,12 +224,12 @@ extension PhotonActionSheetProtocol {
 
         // Disable find in page and report site issue if document is pdf.
         if tab.mimeType != MIMEType.PDF {
-            let findInPageAction = PhotonActionSheetItem(title: .AppMenuFindInPageTitleString, iconString: "menu-FindInPage") { _,_ in
+            let findInPageAction = PhotonActionSheetItem(title: .AppMenu.FindInPageTitleString, iconString: "menu-FindInPage") { _,_ in
                 findInPage()
             }
             section2.insert(findInPageAction, at: 0)
             
-            let reportSiteIssueAction = PhotonActionSheetItem(title: .AppMenuReportSiteIssueTitleString, iconString: "menu-reportSiteIssue") { _,_ in
+            let reportSiteIssueAction = PhotonActionSheetItem(title: .AppMenu.ReportSiteIssueTitleString, iconString: "menu-reportSiteIssue") { _,_ in
                 reportSiteIssue()
             }
             section2.append(reportSiteIssueAction)

--- a/Client/Frontend/Widgets/PhotonActionSheet/PageActionMenu.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PageActionMenu.swift
@@ -41,7 +41,7 @@ extension PhotonActionSheetProtocol {
                        shouldShowNewTabButton: Bool,
                        success: @escaping (String, ButtonToastAction) -> Void) -> Array<[PhotonActionSheetItem]> {
         if tab.url?.isFileURL ?? false {
-            let shareFile = PhotonActionSheetItem(title: Strings.AppMenuSharePageTitleString, iconString: "action_share") {  _,_ in
+            let shareFile = PhotonActionSheetItem(title: .AppMenuSharePageTitleString, iconString: "action_share") {  _,_ in
                 guard let url = tab.url else { return }
 
                 self.share(fileURL: url, buttonView: buttonView, presentableVC: presentableVC)
@@ -55,12 +55,12 @@ extension PhotonActionSheetProtocol {
         let toggleActionIcon: String
         let siteTypeTelemetryObject: TelemetryWrapper.EventObject
         if defaultUAisDesktop {
-            toggleActionTitle = tab.changedUserAgent ? Strings.AppMenuViewDesktopSiteTitleString : Strings.AppMenuViewMobileSiteTitleString
+            toggleActionTitle = tab.changedUserAgent ? .AppMenuViewDesktopSiteTitleString : .AppMenuViewMobileSiteTitleString
             toggleActionIcon = tab.changedUserAgent ?
                 "menu-RequestDesktopSite" : "menu-ViewMobile"
             siteTypeTelemetryObject = .requestDesktopSite
         } else {
-            toggleActionTitle = tab.changedUserAgent ? Strings.AppMenuViewMobileSiteTitleString : Strings.AppMenuViewDesktopSiteTitleString
+            toggleActionTitle = tab.changedUserAgent ? .AppMenuViewMobileSiteTitleString : .AppMenuViewDesktopSiteTitleString
             toggleActionIcon = tab.changedUserAgent ?
                 "menu-ViewMobile" : "menu-RequestDesktopSite"
             siteTypeTelemetryObject = .requestMobileSite
@@ -73,15 +73,15 @@ extension PhotonActionSheetProtocol {
             }
         }
 
-        let addReadingList = PhotonActionSheetItem(title: Strings.AppMenuAddToReadingListTitleString, iconString: "addToReadingList") { _,_  in
+        let addReadingList = PhotonActionSheetItem(title: .AppMenuAddToReadingListTitleString, iconString: "addToReadingList") { _,_  in
             guard let url = tab.url?.displayURL else { return }
 
             self.profile.readingList.createRecordWithURL(url.absoluteString, title: tab.title ?? "", addedBy: UIDevice.current.name)
             TelemetryWrapper.recordEvent(category: .action, method: .add, object: .readingListItem, value: .pageActionMenu)
-            success(Strings.AppMenuAddToReadingListConfirmMessage, .addToReadingList)
+            success(.AppMenuAddToReadingListConfirmMessage, .addToReadingList)
         }
 
-        let bookmarkPage = PhotonActionSheetItem(title: Strings.AppMenuAddBookmarkTitleString2, iconString: "menu-Bookmark") { _,_  in
+        let bookmarkPage = PhotonActionSheetItem(title: .AppMenuAddBookmarkTitleString2, iconString: "menu-Bookmark") { _,_  in
             guard let url = tab.canonicalURL?.displayURL,
                 let bvc = presentableVC as? BrowserViewController else {
                     return
@@ -90,19 +90,19 @@ extension PhotonActionSheetProtocol {
             TelemetryWrapper.recordEvent(category: .action, method: .add, object: .bookmark, value: .pageActionMenu)
         }
 
-        let removeBookmark = PhotonActionSheetItem(title: Strings.AppMenuRemoveBookmarkTitleString, iconString: "menu-Bookmark-Remove") { _,_  in
+        let removeBookmark = PhotonActionSheetItem(title: .AppMenuRemoveBookmarkTitleString, iconString: "menu-Bookmark-Remove") { _,_  in
             guard let url = tab.url?.displayURL else { return }
 
             self.profile.places.deleteBookmarksWithURL(url: url.absoluteString).uponQueue(.main) { result in
                 if result.isSuccess {
-                    success(Strings.AppMenuRemoveBookmarkConfirmMessage, .removeBookmark)
+                    success(.AppMenuRemoveBookmarkConfirmMessage, .removeBookmark)
                 }
             }
 
             TelemetryWrapper.recordEvent(category: .action, method: .delete, object: .bookmark, value: .pageActionMenu)
         }
 
-        let addToShortcuts = PhotonActionSheetItem(title: Strings.AddToShortcutsActionTitle, iconString: "action_pin") { _,_  in
+        let addToShortcuts = PhotonActionSheetItem(title: .AddToShortcutsActionTitle, iconString: "action_pin") { _,_  in
             guard let url = tab.url?.displayURL, let sql = self.profile.history as? SQLiteHistory else { return }
 
             sql.getSites(forURLs: [url.absoluteString]).bind { val -> Success in
@@ -112,13 +112,13 @@ extension PhotonActionSheetProtocol {
                 return self.profile.history.addPinnedTopSite(site)
             }.uponQueue(.main) { result in
                 if result.isSuccess {
-                    success(Strings.AppMenuAddPinToShortcutsConfirmMessage, .pinPage)
+                    success(.AppMenuAddPinToShortcutsConfirmMessage, .pinPage)
                 }
             }
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .pinToTopSites)
         }
 
-        let removeFromShortcuts = PhotonActionSheetItem(title: Strings.RemoveFromShortcutsActionTitle, iconString: "action_unpin") { _,_  in
+        let removeFromShortcuts = PhotonActionSheetItem(title: .RemoveFromShortcutsActionTitle, iconString: "action_unpin") { _,_  in
             guard let url = tab.url?.displayURL, let sql = self.profile.history as? SQLiteHistory else { return }
 
             sql.getSites(forURLs: [url.absoluteString]).bind { val -> Success in
@@ -129,13 +129,13 @@ extension PhotonActionSheetProtocol {
                 return self.profile.history.removeFromPinnedTopSites(site)
             }.uponQueue(.main) { result in
                 if result.isSuccess {
-                    success(Strings.AppMenuRemovePinFromShortcutsConfirmMessage, .removePinPage)
+                    success(.AppMenuRemovePinFromShortcutsConfirmMessage, .removePinPage)
                 }
             }
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .removePinnedSite)
         }
 
-        let sendToDevice = PhotonActionSheetItem(title: Strings.SendLinkToDeviceTitle, iconString: "menu-Send-to-Device") { _,_  in
+        let sendToDevice = PhotonActionSheetItem(title: .SendLinkToDeviceTitle, iconString: "menu-Send-to-Device") { _,_  in
             guard let bvc = presentableVC as? PresentableVC & InstructionsViewControllerDelegate & DevicePickerViewControllerDelegate else { return }
             if !self.profile.hasAccount() {
                 let instructionsViewController = InstructionsViewController()
@@ -156,7 +156,7 @@ extension PhotonActionSheetProtocol {
             bvc.present(navigationController, animated: true, completion: nil)
         }
 
-        let sharePage = PhotonActionSheetItem(title: Strings.ShareContextMenuTitle, iconString: "action_share") { _,_  in
+        let sharePage = PhotonActionSheetItem(title: .ShareContextMenuTitle, iconString: "action_share") { _,_  in
             guard let url = tab.canonicalURL?.displayURL else { return }
 
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .sharePageWith)
@@ -175,19 +175,19 @@ extension PhotonActionSheetProtocol {
             }
         }
 
-        let copyURL = PhotonActionSheetItem(title: Strings.AppMenuCopyLinkTitleString, iconString: "menu-Copy-Link") { _,_ in
+        let copyURL = PhotonActionSheetItem(title: .AppMenuCopyLinkTitleString, iconString: "menu-Copy-Link") { _,_ in
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .copyAddress)
             if let url = tab.canonicalURL?.displayURL {
                 UIPasteboard.general.url = url
-                success(Strings.AppMenuCopyURLConfirmMessage, .copyUrl)
+                success(.AppMenuCopyURLConfirmMessage, .copyUrl)
             }
         }
         
-        let refreshPage = PhotonActionSheetItem(title: Strings.ReloadPageTitle, iconString: "nav-refresh") { _,_ in
+        let refreshPage = PhotonActionSheetItem(title: .ReloadPageTitle, iconString: "nav-refresh") { _,_ in
             self.tabManager.selectedTab?.reload()
         }
         
-        let stopRefreshPage = PhotonActionSheetItem(title: Strings.StopReloadPageTitle, iconString: "nav-stop") { _,_ in
+        let stopRefreshPage = PhotonActionSheetItem(title: .StopReloadPageTitle, iconString: "nav-stop") { _,_ in
             self.tabManager.selectedTab?.stop()
         }
         
@@ -197,7 +197,7 @@ extension PhotonActionSheetProtocol {
         if let url = tab.webView?.url, let helper = tab.contentBlocker, helper.isEnabled, helper.blockingStrengthPref == .strict {
             let isSafelisted = helper.status == .safelisted
             
-            let title = !isSafelisted ? Strings.TrackingProtectionReloadWithout : Strings.TrackingProtectionReloadWith
+            let title = !isSafelisted ? String.TrackingProtectionReloadWithout : String.TrackingProtectionReloadWith
             let imageName = helper.isEnabled ? "menu-TrackingProtection-Off" : "menu-TrackingProtection"
             let toggleTP = PhotonActionSheetItem(title: title, iconString: imageName) { _,_ in
                 ContentBlocker.shared.safelist(enable: !isSafelisted, url: url) {
@@ -224,12 +224,12 @@ extension PhotonActionSheetProtocol {
 
         // Disable find in page and report site issue if document is pdf.
         if tab.mimeType != MIMEType.PDF {
-            let findInPageAction = PhotonActionSheetItem(title: Strings.AppMenuFindInPageTitleString, iconString: "menu-FindInPage") { _,_ in
+            let findInPageAction = PhotonActionSheetItem(title: .AppMenuFindInPageTitleString, iconString: "menu-FindInPage") { _,_ in
                 findInPage()
             }
             section2.insert(findInPageAction, at: 0)
             
-            let reportSiteIssueAction = PhotonActionSheetItem(title: Strings.AppMenuReportSiteIssueTitleString, iconString: "menu-reportSiteIssue") { _,_ in
+            let reportSiteIssueAction = PhotonActionSheetItem(title: .AppMenuReportSiteIssueTitleString, iconString: "menu-reportSiteIssue") { _,_ in
                 reportSiteIssue()
             }
             section2.append(reportSiteIssueAction)

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -29,7 +29,7 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
 
     lazy var closeButton: UIButton = {
         let button = UIButton()
-        button.setTitle(Strings.CloseButtonTitle, for: .normal)
+        button.setTitle(.CloseButtonTitle, for: .normal)
         button.setTitleColor(UIConstants.SystemBlueColor, for: .normal)
         button.layer.cornerRadius = PhotonActionSheetUX.CornerRadius
         button.titleLabel?.font = DynamicFontHelper.defaultHelper.DeviceFontExtraLargeBold
@@ -44,7 +44,7 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
         }
     }
 
-    init(site: Site, actions: [PhotonActionSheetItem], closeButtonTitle: String = Strings.CloseButtonTitle) {
+    init(site: Site, actions: [PhotonActionSheetItem], closeButtonTitle: String = .CloseButtonTitle) {
         self.site = site
         self.actions = [actions]
         self.style = .centered
@@ -52,7 +52,7 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
         self.closeButton.setTitle(closeButtonTitle, for: .normal)
     }
 
-    init(title: String? = nil, actions: [[PhotonActionSheetItem]], closeButtonTitle: String = Strings.CloseButtonTitle, style presentationStyle: UIModalPresentationStyle? = nil) {
+    init(title: String? = nil, actions: [[PhotonActionSheetItem]], closeButtonTitle: String = .CloseButtonTitle, style presentationStyle: UIModalPresentationStyle? = nil) {
         self.actions = actions
         if let presentationStyle = presentationStyle {
             self.style = presentationStyle == .popover ? .popover : .bottom

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -58,7 +58,7 @@ extension PhotonActionSheetProtocol {
         let copyAddressAction = PhotonActionSheetItem(title: .CopyAddressTitle, iconString: "menu-Copy-Link") { _, _ in
             if let url = self.tabManager.selectedTab?.canonicalURL?.displayURL ?? urlBar.currentURL {
                 UIPasteboard.general.url = url
-                SimpleToast().showAlertWithText(.AppMenuCopyURLConfirmMessage, bottomContainer: webViewContainer)
+                SimpleToast().showAlertWithText(.AppMenu.CopyURLConfirmMessage, bottomContainer: webViewContainer)
             }
         }
         if UIPasteboard.general.string != nil {
@@ -76,9 +76,9 @@ extension PhotonActionSheetProtocol {
         let defaultUAisDesktop = UserAgent.isDesktop(ua: UserAgent.getUserAgent())
         let toggleActionTitle: String
         if defaultUAisDesktop {
-            toggleActionTitle = tab.changedUserAgent ? .AppMenuViewDesktopSiteTitleString : .AppMenuViewMobileSiteTitleString
+            toggleActionTitle = tab.changedUserAgent ? .AppMenu.ViewDesktopSiteTitleString : .AppMenu.ViewMobileSiteTitleString
         } else {
-            toggleActionTitle = tab.changedUserAgent ? .AppMenuViewMobileSiteTitleString : .AppMenuViewDesktopSiteTitleString
+            toggleActionTitle = tab.changedUserAgent ? .AppMenu.ViewMobileSiteTitleString : .AppMenu.ViewDesktopSiteTitleString
         }
         let toggleDesktopSite = PhotonActionSheetItem(title: toggleActionTitle, iconString: "menu-RequestDesktopSite") { _, _ in
 

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -19,7 +19,7 @@ extension PhotonActionSheetProtocol {
     typealias IsPrivateTab = Bool
     typealias URLOpenAction = (URL?, IsPrivateTab) -> Void
 
-    func presentSheetWith(title: String? = nil, actions: [[PhotonActionSheetItem]], on viewController: PresentableVC, from view: UIView, closeButtonTitle: String = Strings.CloseButtonTitle, suppressPopover: Bool? = false) {
+    func presentSheetWith(title: String? = nil, actions: [[PhotonActionSheetItem]], on viewController: PresentableVC, from view: UIView, closeButtonTitle: String = .CloseButtonTitle, suppressPopover: Bool? = false) {
         let style: UIModalPresentationStyle =  !(suppressPopover ?? false) ? .popover : .overCurrentContext
         let sheet = PhotonActionSheet(title: title, actions: actions, closeButtonTitle: closeButtonTitle, style: style)
         sheet.modalPresentationStyle = style
@@ -45,20 +45,20 @@ extension PhotonActionSheetProtocol {
     }
 
     func getLongPressLocationBarActions(with urlBar: URLBarView, webViewContainer: UIView) -> [PhotonActionSheetItem] {
-        let pasteGoAction = PhotonActionSheetItem(title: Strings.PasteAndGoTitle, iconString: "menu-PasteAndGo") { _, _ in
+        let pasteGoAction = PhotonActionSheetItem(title: .PasteAndGoTitle, iconString: "menu-PasteAndGo") { _, _ in
             if let pasteboardContents = UIPasteboard.general.string {
                 urlBar.delegate?.urlBar(urlBar, didSubmitText: pasteboardContents)
             }
         }
-        let pasteAction = PhotonActionSheetItem(title: Strings.PasteTitle, iconString: "menu-Paste") { _, _ in
+        let pasteAction = PhotonActionSheetItem(title: .PasteTitle, iconString: "menu-Paste") { _, _ in
             if let pasteboardContents = UIPasteboard.general.string {
                 urlBar.enterOverlayMode(pasteboardContents, pasted: true, search: true)
             }
         }
-        let copyAddressAction = PhotonActionSheetItem(title: Strings.CopyAddressTitle, iconString: "menu-Copy-Link") { _, _ in
+        let copyAddressAction = PhotonActionSheetItem(title: .CopyAddressTitle, iconString: "menu-Copy-Link") { _, _ in
             if let url = self.tabManager.selectedTab?.canonicalURL?.displayURL ?? urlBar.currentURL {
                 UIPasteboard.general.url = url
-                SimpleToast().showAlertWithText(Strings.AppMenuCopyURLConfirmMessage, bottomContainer: webViewContainer)
+                SimpleToast().showAlertWithText(.AppMenuCopyURLConfirmMessage, bottomContainer: webViewContainer)
             }
         }
         if UIPasteboard.general.string != nil {
@@ -76,9 +76,9 @@ extension PhotonActionSheetProtocol {
         let defaultUAisDesktop = UserAgent.isDesktop(ua: UserAgent.getUserAgent())
         let toggleActionTitle: String
         if defaultUAisDesktop {
-            toggleActionTitle = tab.changedUserAgent ? Strings.AppMenuViewDesktopSiteTitleString : Strings.AppMenuViewMobileSiteTitleString
+            toggleActionTitle = tab.changedUserAgent ? .AppMenuViewDesktopSiteTitleString : .AppMenuViewMobileSiteTitleString
         } else {
-            toggleActionTitle = tab.changedUserAgent ? Strings.AppMenuViewMobileSiteTitleString : Strings.AppMenuViewDesktopSiteTitleString
+            toggleActionTitle = tab.changedUserAgent ? .AppMenuViewMobileSiteTitleString : .AppMenuViewDesktopSiteTitleString
         }
         let toggleDesktopSite = PhotonActionSheetItem(title: toggleActionTitle, iconString: "menu-RequestDesktopSite") { _, _ in
 
@@ -91,7 +91,7 @@ extension PhotonActionSheetProtocol {
         if let url = tab.webView?.url, let helper = tab.contentBlocker, helper.isEnabled, helper.blockingStrengthPref == .strict {
             let isSafelisted = helper.status == .safelisted
 
-            let title = !isSafelisted ? Strings.TrackingProtectionReloadWithout : Strings.TrackingProtectionReloadWith
+            let title = !isSafelisted ? String.TrackingProtectionReloadWithout : .TrackingProtectionReloadWith
             let imageName = helper.isEnabled ? "menu-TrackingProtection-Off" : "menu-TrackingProtection"
             let toggleTP = PhotonActionSheetItem(title: title, iconString: imageName) { _, _ in
                 ContentBlocker.shared.safelist(enable: !isSafelisted, url: url) {

--- a/Client/Frontend/Widgets/PhotonActionSheet/TrackingProtectionMenu.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/TrackingProtectionMenu.swift
@@ -41,7 +41,7 @@ fileprivate var nestedTableViewDomainList: NestedTableViewDelegate?
 extension PhotonActionSheetProtocol {
     @available(iOS 11.0, *)
     private func menuActionsForNotBlocking() -> [PhotonActionSheetItem] {
-        return [PhotonActionSheetItem(title: .SettingsTrackingProtectionSectionName, text: .TPNoBlockingDescription, iconString: "menu-TrackingProtection")]
+        return [PhotonActionSheetItem(title: .SettingsTrackingProtectionSectionName, text: .TrackingProtection.NoBlockingDescription, iconString: "menu-TrackingProtection")]
     }
 
     @available(iOS 11.0, *)
@@ -63,12 +63,12 @@ extension PhotonActionSheetProtocol {
 
     @available(iOS 11.0, *)
     private func menuActionsForTrackingProtectionDisabled(for tab: Tab) -> [[PhotonActionSheetItem]] {
-        let enableTP = PhotonActionSheetItem(title: .EnableTPBlockingGlobally, iconString: "menu-TrackingProtection") { _, _ in
+        let enableTP = PhotonActionSheetItem(title: .TrackingProtection.EnableTPBlockingGlobally, iconString: "menu-TrackingProtection") { _, _ in
             FirefoxTabContentBlocker.toggleTrackingProtectionEnabled(prefs: self.profile.prefs)
             tab.reload()
         }
 
-        var moreInfo = PhotonActionSheetItem(title: "", text: .TPBlockingMoreInfo, iconString: "menu-Info") { _, _ in
+        var moreInfo = PhotonActionSheetItem(title: "", text: .TrackingProtection.BlockingMoreInfo, iconString: "menu-Info") { _, _ in
             let url = SupportUtils.URLForTopic("tracking-protection-ios")!
             tab.loadRequest(URLRequest(url: url))
         }
@@ -138,7 +138,7 @@ extension PhotonActionSheetProtocol {
             return []
         }
 
-        var blockedtitle = PhotonActionSheetItem(title: .TPPageMenuBlockedTitle, accessory: .Text, bold: true)
+        var blockedtitle = PhotonActionSheetItem(title: .TrackingProtection.PageMenuTitles.BlockedTitle, accessory: .Text, bold: true)
         blockedtitle.customRender = { label, _ in
             label.font = DynamicFontHelper.defaultHelper.DeviceFontSmallBold
         }
@@ -146,7 +146,7 @@ extension PhotonActionSheetProtocol {
             return PhotonActionSheetUX.RowHeight - 10
         }
 
-        var addToSafelistSwitch = PhotonActionSheetItem(title: .ETPOn, isEnabled: !isSafelisted, accessory: .Switch) { _, cell in
+        var addToSafelistSwitch = PhotonActionSheetItem(title: .TrackingProtection.ETPOn, isEnabled: !isSafelisted, accessory: .Switch) { _, cell in
             TelemetryWrapper.recordEvent(category: .action, method: .add, object: .trackingProtectionSafelist)
             ContentBlocker.shared.safelist(enable: tab.contentBlocker?.status != .safelisted, url: currentURL) {
                 tab.reload()
@@ -156,9 +156,9 @@ extension PhotonActionSheetProtocol {
         }
         addToSafelistSwitch.customRender = { title, _ in
             if tab.contentBlocker?.status == .safelisted {
-                title.text = .ETPOff
+                title.text = .TrackingProtection.ETPOff
             } else {
-                title.text = .ETPOn
+                title.text = .TrackingProtection.ETPOn
             }
         }
         addToSafelistSwitch.accessibilityId = "tp.add-to-safelist"
@@ -166,7 +166,7 @@ extension PhotonActionSheetProtocol {
             return PhotonActionSheetUX.RowHeight + 20
         }
         
-        var addToSafelistNoSwitch = PhotonActionSheetItem(title: .ETPOn, accessory: .Text)
+        var addToSafelistNoSwitch = PhotonActionSheetItem(title: .TrackingProtection.ETPOn, accessory: .Text)
         addToSafelistNoSwitch.customHeight = { _ in
             return PhotonActionSheetUX.RowHeight + 20
         }
@@ -176,11 +176,11 @@ extension PhotonActionSheetProtocol {
 
         let blockersDescriptionString: String = {
             if blocker.blockingStrengthPref == .strict {
-                return .StrictETPWithITP
+                return .TrackingProtection.StrictETPWithITP
             } else if blocker.blockingStrengthPref == .basic {
-                return .StandardETPWithITP
+                return .TrackingProtection.StandardETPWithITP
             } else {
-                return .TPPageMenuNoTrackersBlocked
+                return .TrackingProtection.PageMenuTitles.NoTrackersBlocked
             }
         }()
         
@@ -192,7 +192,7 @@ extension PhotonActionSheetProtocol {
             return PhotonActionSheetUX.RowHeight + 70
         }
 
-        let settings = PhotonActionSheetItem(title: .TPProtectionSettings, iconString: "settings") { _, _ in
+        let settings = PhotonActionSheetItem(title: .TrackingProtection.ProtectionSettings, iconString: "settings") { _, _ in
             let settingsTableViewController = AppSettingsTableViewController()
             settingsTableViewController.profile = self.profile
             settingsTableViewController.tabManager = self.tabManager
@@ -216,7 +216,7 @@ extension PhotonActionSheetProtocol {
             label.numberOfLines = 0
             label.textAlignment = .center
             label.textColor = UIColor.theme.tableView.headerTextLight
-            label.text = .TPPageMenuNoTrackersBlocked
+            label.text = .TrackingProtection.PageMenuTitles.NoTrackersBlocked
             label.accessibilityIdentifier = "tp.no-trackers-blocked"
             contentView.addSubview(label)
             label.snp.makeConstraints { make in
@@ -254,7 +254,7 @@ extension PhotonActionSheetProtocol {
             return []
         }
 
-        let removeFromSafelist = PhotonActionSheetItem(title: .TPSafeListRemove, iconString: "menu-TrackingProtection") { _, _ in
+        let removeFromSafelist = PhotonActionSheetItem(title: .TrackingProtection.SafeListRemove, iconString: "menu-TrackingProtection") { _, _ in
             ContentBlocker.shared.safelist(enable: false, url: currentURL) {
                 tab.reload()
             }

--- a/Client/Frontend/Widgets/PhotonActionSheet/TrackingProtectionMenu.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/TrackingProtectionMenu.swift
@@ -41,7 +41,7 @@ fileprivate var nestedTableViewDomainList: NestedTableViewDelegate?
 extension PhotonActionSheetProtocol {
     @available(iOS 11.0, *)
     private func menuActionsForNotBlocking() -> [PhotonActionSheetItem] {
-        return [PhotonActionSheetItem(title: Strings.SettingsTrackingProtectionSectionName, text: Strings.TPNoBlockingDescription, iconString: "menu-TrackingProtection")]
+        return [PhotonActionSheetItem(title: .SettingsTrackingProtectionSectionName, text: .TPNoBlockingDescription, iconString: "menu-TrackingProtection")]
     }
 
     @available(iOS 11.0, *)
@@ -63,12 +63,12 @@ extension PhotonActionSheetProtocol {
 
     @available(iOS 11.0, *)
     private func menuActionsForTrackingProtectionDisabled(for tab: Tab) -> [[PhotonActionSheetItem]] {
-        let enableTP = PhotonActionSheetItem(title: Strings.EnableTPBlockingGlobally, iconString: "menu-TrackingProtection") { _, _ in
+        let enableTP = PhotonActionSheetItem(title: .EnableTPBlockingGlobally, iconString: "menu-TrackingProtection") { _, _ in
             FirefoxTabContentBlocker.toggleTrackingProtectionEnabled(prefs: self.profile.prefs)
             tab.reload()
         }
 
-        var moreInfo = PhotonActionSheetItem(title: "", text: Strings.TPBlockingMoreInfo, iconString: "menu-Info") { _, _ in
+        var moreInfo = PhotonActionSheetItem(title: "", text: .TPBlockingMoreInfo, iconString: "menu-Info") { _, _ in
             let url = SupportUtils.URLForTopic("tracking-protection-ios")!
             tab.loadRequest(URLRequest(url: url))
         }
@@ -114,7 +114,7 @@ extension PhotonActionSheetProtocol {
             return PhotonActionSheetUX.RowHeight * 5
         }
 
-        let back = PhotonActionSheetItem(title: Strings.BackTitle, iconString: "goBack") { _, _ in
+        let back = PhotonActionSheetItem(title: .BackTitle, iconString: "goBack") { _, _ in
             guard let urlbar = (self as? BrowserViewController)?.urlBar else { return }
             (self as? BrowserViewController)?.urlBarDidTapShield(urlbar)
         }
@@ -138,7 +138,7 @@ extension PhotonActionSheetProtocol {
             return []
         }
 
-        var blockedtitle = PhotonActionSheetItem(title: Strings.TPPageMenuBlockedTitle, accessory: .Text, bold: true)
+        var blockedtitle = PhotonActionSheetItem(title: .TPPageMenuBlockedTitle, accessory: .Text, bold: true)
         blockedtitle.customRender = { label, _ in
             label.font = DynamicFontHelper.defaultHelper.DeviceFontSmallBold
         }
@@ -146,7 +146,7 @@ extension PhotonActionSheetProtocol {
             return PhotonActionSheetUX.RowHeight - 10
         }
 
-        var addToSafelistSwitch = PhotonActionSheetItem(title: Strings.ETPOn, isEnabled: !isSafelisted, accessory: .Switch) { _, cell in
+        var addToSafelistSwitch = PhotonActionSheetItem(title: .ETPOn, isEnabled: !isSafelisted, accessory: .Switch) { _, cell in
             TelemetryWrapper.recordEvent(category: .action, method: .add, object: .trackingProtectionSafelist)
             ContentBlocker.shared.safelist(enable: tab.contentBlocker?.status != .safelisted, url: currentURL) {
                 tab.reload()
@@ -156,9 +156,9 @@ extension PhotonActionSheetProtocol {
         }
         addToSafelistSwitch.customRender = { title, _ in
             if tab.contentBlocker?.status == .safelisted {
-                title.text = Strings.ETPOff
+                title.text = .ETPOff
             } else {
-                title.text = Strings.ETPOn
+                title.text = .ETPOn
             }
         }
         addToSafelistSwitch.accessibilityId = "tp.add-to-safelist"
@@ -166,7 +166,7 @@ extension PhotonActionSheetProtocol {
             return PhotonActionSheetUX.RowHeight + 20
         }
         
-        var addToSafelistNoSwitch = PhotonActionSheetItem(title: Strings.ETPOn, accessory: .Text)
+        var addToSafelistNoSwitch = PhotonActionSheetItem(title: .ETPOn, accessory: .Text)
         addToSafelistNoSwitch.customHeight = { _ in
             return PhotonActionSheetUX.RowHeight + 20
         }
@@ -176,11 +176,11 @@ extension PhotonActionSheetProtocol {
 
         let blockersDescriptionString: String = {
             if blocker.blockingStrengthPref == .strict {
-                return Strings.StrictETPWithITP
+                return .StrictETPWithITP
             } else if blocker.blockingStrengthPref == .basic {
-                return Strings.StandardETPWithITP
+                return .StandardETPWithITP
             } else {
-                return Strings.TPPageMenuNoTrackersBlocked
+                return .TPPageMenuNoTrackersBlocked
             }
         }()
         
@@ -192,7 +192,7 @@ extension PhotonActionSheetProtocol {
             return PhotonActionSheetUX.RowHeight + 70
         }
 
-        let settings = PhotonActionSheetItem(title: Strings.TPProtectionSettings, iconString: "settings") { _, _ in
+        let settings = PhotonActionSheetItem(title: .TPProtectionSettings, iconString: "settings") { _, _ in
             let settingsTableViewController = AppSettingsTableViewController()
             settingsTableViewController.profile = self.profile
             settingsTableViewController.tabManager = self.tabManager
@@ -216,7 +216,7 @@ extension PhotonActionSheetProtocol {
             label.numberOfLines = 0
             label.textAlignment = .center
             label.textColor = UIColor.theme.tableView.headerTextLight
-            label.text = Strings.TPPageMenuNoTrackersBlocked
+            label.text = .TPPageMenuNoTrackersBlocked
             label.accessibilityIdentifier = "tp.no-trackers-blocked"
             contentView.addSubview(label)
             label.snp.makeConstraints { make in
@@ -254,7 +254,7 @@ extension PhotonActionSheetProtocol {
             return []
         }
 
-        let removeFromSafelist = PhotonActionSheetItem(title: Strings.TPSafeListRemove, iconString: "menu-TrackingProtection") { _, _ in
+        let removeFromSafelist = PhotonActionSheetItem(title: .TPSafeListRemove, iconString: "menu-TrackingProtection") { _, _ in
             ContentBlocker.shared.safelist(enable: false, url: currentURL) {
                 tab.reload()
             }

--- a/Client/Frontend/Widgets/SnackBar.swift
+++ b/Client/Frontend/Widgets/SnackBar.swift
@@ -222,13 +222,13 @@ class TimerSnackBar: SnackBar {
     }
 
     static func showAppStoreConfirmationBar(forTab tab: Tab, appStoreURL: URL, completion: @escaping (Bool) -> Void) {
-        let bar = TimerSnackBar(text: Strings.ExternalLinkAppStoreConfirmationTitle, img: UIImage(named: "defaultFavicon")?.withRenderingMode(.alwaysOriginal))
-        let openAppStore = SnackButton(title: Strings.AppStoreString, accessibilityIdentifier: "ConfirmOpenInAppStore", bold: true) { bar in
+        let bar = TimerSnackBar(text: .ExternalLinkAppStoreConfirmationTitle, img: UIImage(named: "defaultFavicon")?.withRenderingMode(.alwaysOriginal))
+        let openAppStore = SnackButton(title: .AppStoreString, accessibilityIdentifier: "ConfirmOpenInAppStore", bold: true) { bar in
             tab.removeSnackbar(bar)
             UIApplication.shared.open(appStoreURL, options: [:])
             completion(true)
         }
-        let cancelButton = SnackButton(title: Strings.NotNowString, accessibilityIdentifier: "CancelOpenInAppStore", bold: false) { bar in
+        let cancelButton = SnackButton(title: .NotNowString, accessibilityIdentifier: "CancelOpenInAppStore", bold: false) { bar in
             tab.removeSnackbar(bar)
             completion(false)
         }

--- a/Client/Frontend/Widgets/SnackBar.swift
+++ b/Client/Frontend/Widgets/SnackBar.swift
@@ -222,13 +222,13 @@ class TimerSnackBar: SnackBar {
     }
 
     static func showAppStoreConfirmationBar(forTab tab: Tab, appStoreURL: URL, completion: @escaping (Bool) -> Void) {
-        let bar = TimerSnackBar(text: .ExternalLinkAppStoreConfirmationTitle, img: UIImage(named: "defaultFavicon")?.withRenderingMode(.alwaysOriginal))
-        let openAppStore = SnackButton(title: .AppStoreString, accessibilityIdentifier: "ConfirmOpenInAppStore", bold: true) { bar in
+        let bar = TimerSnackBar(text: .Snackbar.ExternalLinks.AppStoreConfirmationTitle, img: UIImage(named: "defaultFavicon")?.withRenderingMode(.alwaysOriginal))
+        let openAppStore = SnackButton(title: .General.AppStoreString, accessibilityIdentifier: "ConfirmOpenInAppStore", bold: true) { bar in
             tab.removeSnackbar(bar)
             UIApplication.shared.open(appStoreURL, options: [:])
             completion(true)
         }
-        let cancelButton = SnackButton(title: .NotNowString, accessibilityIdentifier: "CancelOpenInAppStore", bold: false) { bar in
+        let cancelButton = SnackButton(title: .General.NotNowString, accessibilityIdentifier: "CancelOpenInAppStore", bold: false) { bar in
             tab.removeSnackbar(bar)
             completion(false)
         }

--- a/Client/Helpers/MenuHelper.swift
+++ b/Client/Helpers/MenuHelper.swift
@@ -31,13 +31,13 @@ open class MenuHelper: NSObject {
     }
 
     open func setItems() {
-        let pasteAndGoItem = UIMenuItem(title: .MenuHelperPasteAndGo, action: MenuHelper.SelectorPasteAndGo)
-        let revealPasswordItem = UIMenuItem(title: .MenuHelperReveal, action: MenuHelper.SelectorReveal)
-        let hidePasswordItem = UIMenuItem(title: .MenuHelperHide, action: MenuHelper.SelectorHide)
-        let copyItem = UIMenuItem(title: .MenuHelperCopy, action: MenuHelper.SelectorCopy)
-        let openAndFillItem = UIMenuItem(title: .MenuHelperOpenAndFill, action: MenuHelper.SelectorOpenAndFill)
-        let findInPageItem = UIMenuItem(title: .MenuHelperFindInPage, action: MenuHelper.SelectorFindInPage)
-        let searchItem = UIMenuItem(title: .MenuHelperSearchWithFirefox, action: MenuHelper.SelectorSearchWithFirefox)
+        let pasteAndGoItem = UIMenuItem(title: .MenuHelper.PasteAndGo, action: MenuHelper.SelectorPasteAndGo)
+        let revealPasswordItem = UIMenuItem(title: .MenuHelper.Reveal, action: MenuHelper.SelectorReveal)
+        let hidePasswordItem = UIMenuItem(title: .MenuHelper.Hide, action: MenuHelper.SelectorHide)
+        let copyItem = UIMenuItem(title: .MenuHelper.Copy, action: MenuHelper.SelectorCopy)
+        let openAndFillItem = UIMenuItem(title: .MenuHelper.OpenAndFill, action: MenuHelper.SelectorOpenAndFill)
+        let findInPageItem = UIMenuItem(title: .MenuHelper.FindInPage, action: MenuHelper.SelectorFindInPage)
+        let searchItem = UIMenuItem(title: .MenuHelper.SearchWithFirefox, action: MenuHelper.SelectorSearchWithFirefox)
       
         UIMenuController.shared.menuItems = [pasteAndGoItem, copyItem, revealPasswordItem, hidePasswordItem, openAndFillItem, findInPageItem, searchItem]
     }

--- a/ClientTests/SyncStatusResolverTests.swift
+++ b/ClientTests/SyncStatusResolverTests.swift
@@ -49,7 +49,7 @@ class SyncStatusResolverTests: XCTestCase {
         let maybeResults = Maybe(success: results)
 
         let resolver = SyncStatusResolver(engineResults: maybeResults)
-        XCTAssertTrue(resolver.resolveResults() == SyncDisplayState.warning(message: Strings.FirefoxSyncOfflineTitle))
+        XCTAssertTrue(resolver.resolveResults() == SyncDisplayState.warning(message: .FirefoxSyncOfflineTitle))
     }
 
     func testAllCompletedExceptNotStartedBecauseOffline() {
@@ -60,7 +60,7 @@ class SyncStatusResolverTests: XCTestCase {
         let maybeResults = Maybe(success: results)
 
         let resolver = SyncStatusResolver(engineResults: maybeResults)
-        XCTAssertTrue(resolver.resolveResults() == SyncDisplayState.bad(message: Strings.FirefoxSyncOfflineTitle))
+        XCTAssertTrue(resolver.resolveResults() == SyncDisplayState.bad(message: .FirefoxSyncOfflineTitle))
     }
 
     func testOfflineAndNoAccount() {
@@ -72,7 +72,7 @@ class SyncStatusResolverTests: XCTestCase {
         let maybeResults = Maybe(success: results)
 
         let resolver = SyncStatusResolver(engineResults: maybeResults)
-        XCTAssertTrue(resolver.resolveResults() == SyncDisplayState.bad(message: Strings.FirefoxSyncOfflineTitle))
+        XCTAssertTrue(resolver.resolveResults() == SyncDisplayState.bad(message: .FirefoxSyncOfflineTitle))
     }
 
     func testAllPartial() {

--- a/ClientTests/SyncStatusResolverTests.swift
+++ b/ClientTests/SyncStatusResolverTests.swift
@@ -49,7 +49,7 @@ class SyncStatusResolverTests: XCTestCase {
         let maybeResults = Maybe(success: results)
 
         let resolver = SyncStatusResolver(engineResults: maybeResults)
-        XCTAssertTrue(resolver.resolveResults() == SyncDisplayState.warning(message: .FirefoxSyncOfflineTitle))
+        XCTAssertTrue(resolver.resolveResults() == SyncDisplayState.warning(message: .Syncing.FirefoxSync.OfflineTitle))
     }
 
     func testAllCompletedExceptNotStartedBecauseOffline() {
@@ -60,7 +60,7 @@ class SyncStatusResolverTests: XCTestCase {
         let maybeResults = Maybe(success: results)
 
         let resolver = SyncStatusResolver(engineResults: maybeResults)
-        XCTAssertTrue(resolver.resolveResults() == SyncDisplayState.bad(message: .FirefoxSyncOfflineTitle))
+        XCTAssertTrue(resolver.resolveResults() == SyncDisplayState.bad(message: .Syncing.FirefoxSync.OfflineTitle))
     }
 
     func testOfflineAndNoAccount() {
@@ -72,7 +72,7 @@ class SyncStatusResolverTests: XCTestCase {
         let maybeResults = Maybe(success: results)
 
         let resolver = SyncStatusResolver(engineResults: maybeResults)
-        XCTAssertTrue(resolver.resolveResults() == SyncDisplayState.bad(message: .FirefoxSyncOfflineTitle))
+        XCTAssertTrue(resolver.resolveResults() == SyncDisplayState.bad(message: .Syncing.FirefoxSync.OfflineTitle))
     }
 
     func testAllPartial() {

--- a/Extensions/NotificationService/NotificationService.swift
+++ b/Extensions/NotificationService/NotificationService.swift
@@ -116,45 +116,45 @@ class SyncDataDisplay {
 
 extension SyncDataDisplay {
     func displayDeviceConnectedNotification(_ deviceName: String) {
-        presentNotification(title: Strings.FxAPush_DeviceConnected_title,
-                            body: Strings.FxAPush_DeviceConnected_body,
+        presentNotification(title: .FxAPush_DeviceConnected_title,
+                            body: .FxAPush_DeviceConnected_body,
                             bodyArg: deviceName)
     }
 
     func displayDeviceDisconnectedNotification(_ deviceName: String?) {
         if let deviceName = deviceName {
-            presentNotification(title: Strings.FxAPush_DeviceDisconnected_title,
-                                body: Strings.FxAPush_DeviceDisconnected_body,
+            presentNotification(title: .FxAPush_DeviceDisconnected_title,
+                                body: .FxAPush_DeviceDisconnected_body,
                                 bodyArg: deviceName)
         } else {
             // We should never see this branch
-            presentNotification(title: Strings.FxAPush_DeviceDisconnected_title,
-                                body: Strings.FxAPush_DeviceDisconnected_UnknownDevice_body)
+            presentNotification(title: .FxAPush_DeviceDisconnected_title,
+                                body: .FxAPush_DeviceDisconnected_UnknownDevice_body)
         }
     }
 
     func displayThisDeviceDisconnectedNotification() {
-        presentNotification(title: Strings.FxAPush_DeviceDisconnected_ThisDevice_title,
-                            body: Strings.FxAPush_DeviceDisconnected_ThisDevice_body)
+        presentNotification(title: .FxAPush_DeviceDisconnected_ThisDevice_title,
+                            body: .FxAPush_DeviceDisconnected_ThisDevice_body)
     }
 
     func displayAccountVerifiedNotification() {
         Sentry.shared.send(message: "SentTab error: account not verified")
         #if MOZ_CHANNEL_BETA || DEBUG
-            presentNotification(title: Strings.SentTab_NoTabArrivingNotification_title, body: "DEBUG: Account Verified")
+            presentNotification(title: .SentTab_NoTabArrivingNotification_title, body: "DEBUG: Account Verified")
             return
         #endif
-        presentNotification(title: Strings.SentTab_NoTabArrivingNotification_title, body: Strings.SentTab_NoTabArrivingNotification_body)
+        presentNotification(title: .SentTab_NoTabArrivingNotification_title, body: .SentTab_NoTabArrivingNotification_body)
     }
 
     func displayUnknownMessageNotification(debugInfo: String) {
         Sentry.shared.send(message: "SentTab error: \(debugInfo)")
         #if MOZ_CHANNEL_BETA || DEBUG
-            presentNotification(title: Strings.SentTab_NoTabArrivingNotification_title, body: "DEBUG: " + debugInfo)
+            presentNotification(title: .SentTab_NoTabArrivingNotification_title, body: "DEBUG: " + debugInfo)
             return
         #endif
 
-        presentNotification(title: Strings.SentTab_NoTabArrivingNotification_title, body: Strings.SentTab_NoTabArrivingNotification_body)
+        presentNotification(title: .SentTab_NoTabArrivingNotification_title, body: .SentTab_NoTabArrivingNotification_body)
     }
 }
 
@@ -174,7 +174,7 @@ extension SyncDataDisplay {
             let item = ShareItem(url: urlString, title: title, favicon: nil)
             _ = tabQueue?.addToQueue(item).value // Force synchronous.
 
-            presentNotification(title: Strings.SentTab_TabArrivingNotification_NoDevice_title, body: url.absoluteDisplayExternalString)
+            presentNotification(title: .SentTab_TabArrivingNotification_NoDevice_title, body: url.absoluteDisplayExternalString)
         }
     }
 }
@@ -185,19 +185,19 @@ extension SyncDataDisplay {
         let body: String
 
         if tabs.count == 0 {
-            title = Strings.SentTab_NoTabArrivingNotification_title
+            title = .SentTab_NoTabArrivingNotification_title
             #if MOZ_CHANNEL_BETA || DEBUG
                 body = "DEBUG: Sent Tabs with no tab"
             #else
-                body = Strings.SentTab_NoTabArrivingNotification_body
+                body = .SentTab_NoTabArrivingNotification_body
             #endif
             Sentry.shared.send(message: "SentTab error: no tab")
         } else {
             let deviceNames = Set(tabs.compactMap { $0["deviceName"] as? String })
             if let deviceName = deviceNames.first, deviceNames.count == 1 {
-                title = String(format: Strings.SentTab_TabArrivingNotification_WithDevice_title, deviceName)
+                title = String(format: .SentTab_TabArrivingNotification_WithDevice_title, deviceName)
             } else {
-                title = Strings.SentTab_TabArrivingNotification_NoDevice_title
+                title = .SentTab_TabArrivingNotification_NoDevice_title
             }
 
             if tabs.count == 1 {
@@ -206,9 +206,9 @@ extension SyncDataDisplay {
                 body = (tabs[0]["displayURL"] as? String) ??
                     (tabs[0]["url"] as! String)
             } else if deviceNames.count == 0 {
-                body = Strings.SentTab_TabArrivingNotification_NoDevice_body
+                body = .SentTab_TabArrivingNotification_NoDevice_body
             } else {
-                body = String(format: Strings.SentTab_TabArrivingNotification_WithDevice_body, AppInfo.displayName)
+                body = String(format: .SentTab_TabArrivingNotification_WithDevice_body, AppInfo.displayName)
             }
         }
 

--- a/Extensions/NotificationService/NotificationService.swift
+++ b/Extensions/NotificationService/NotificationService.swift
@@ -116,45 +116,45 @@ class SyncDataDisplay {
 
 extension SyncDataDisplay {
     func displayDeviceConnectedNotification(_ deviceName: String) {
-        presentNotification(title: .FxAPush_DeviceConnected_title,
-                            body: .FxAPush_DeviceConnected_body,
+        presentNotification(title: .FirefoxAccount.Push.DeviceConnected.Title,
+                            body: .FirefoxAccount.Push.DeviceConnected.Body,
                             bodyArg: deviceName)
     }
 
     func displayDeviceDisconnectedNotification(_ deviceName: String?) {
         if let deviceName = deviceName {
-            presentNotification(title: .FxAPush_DeviceDisconnected_title,
-                                body: .FxAPush_DeviceDisconnected_body,
+            presentNotification(title: .FirefoxAccount.Push.DeviceDisconnected.NamedDeviceTitle,
+                                body: .FirefoxAccount.Push.DeviceDisconnected.NamedDeviceBody,
                                 bodyArg: deviceName)
         } else {
             // We should never see this branch
-            presentNotification(title: .FxAPush_DeviceDisconnected_title,
-                                body: .FxAPush_DeviceDisconnected_UnknownDevice_body)
+            presentNotification(title: .FirefoxAccount.Push.DeviceDisconnected.NamedDeviceTitle,
+                                body: .FirefoxAccount.Push.DeviceDisconnected.UnknownDeviceBody)
         }
     }
 
     func displayThisDeviceDisconnectedNotification() {
-        presentNotification(title: .FxAPush_DeviceDisconnected_ThisDevice_title,
-                            body: .FxAPush_DeviceDisconnected_ThisDevice_body)
+        presentNotification(title: .FirefoxAccount.Push.DeviceDisconnected.ThisDeviceTitle,
+                            body: .FirefoxAccount.Push.DeviceDisconnected.ThisDeviceBody)
     }
 
     func displayAccountVerifiedNotification() {
         Sentry.shared.send(message: "SentTab error: account not verified")
         #if MOZ_CHANNEL_BETA || DEBUG
-            presentNotification(title: .SentTab_NoTabArrivingNotification_title, body: "DEBUG: Account Verified")
+        presentNotification(title: .Notifications.SentTab.NoTabArrivingTitle, body: "DEBUG: Account Verified")
             return
         #endif
-        presentNotification(title: .SentTab_NoTabArrivingNotification_title, body: .SentTab_NoTabArrivingNotification_body)
+        presentNotification(title: .Notifications.SentTab.NoTabArrivingTitle, body: .Notifications.SentTab.NoTabArrivingBody)
     }
 
     func displayUnknownMessageNotification(debugInfo: String) {
         Sentry.shared.send(message: "SentTab error: \(debugInfo)")
         #if MOZ_CHANNEL_BETA || DEBUG
-            presentNotification(title: .SentTab_NoTabArrivingNotification_title, body: "DEBUG: " + debugInfo)
+        presentNotification(title: .Notifications.SentTab.NoTabArrivingTitle, body: "DEBUG: " + debugInfo)
             return
         #endif
 
-        presentNotification(title: .SentTab_NoTabArrivingNotification_title, body: .SentTab_NoTabArrivingNotification_body)
+        presentNotification(title: .Notifications.SentTab.NoTabArrivingTitle, body: .Notifications.SentTab.NoTabArrivingBody)
     }
 }
 
@@ -174,7 +174,7 @@ extension SyncDataDisplay {
             let item = ShareItem(url: urlString, title: title, favicon: nil)
             _ = tabQueue?.addToQueue(item).value // Force synchronous.
 
-            presentNotification(title: .SentTab_TabArrivingNotification_NoDevice_title, body: url.absoluteDisplayExternalString)
+            presentNotification(title: .Notifications.SentTab.TabArrivingNoDeviceTitle, body: url.absoluteDisplayExternalString)
         }
     }
 }
@@ -185,7 +185,7 @@ extension SyncDataDisplay {
         let body: String
 
         if tabs.count == 0 {
-            title = .SentTab_NoTabArrivingNotification_title
+            title = .Notifications.SentTab.NoTabArrivingTitle
             #if MOZ_CHANNEL_BETA || DEBUG
                 body = "DEBUG: Sent Tabs with no tab"
             #else
@@ -195,9 +195,9 @@ extension SyncDataDisplay {
         } else {
             let deviceNames = Set(tabs.compactMap { $0["deviceName"] as? String })
             if let deviceName = deviceNames.first, deviceNames.count == 1 {
-                title = String(format: .SentTab_TabArrivingNotification_WithDevice_title, deviceName)
+                title = String(format: .Notifications.SentTab.TabArrivingWithDeviceTitle, deviceName)
             } else {
-                title = .SentTab_TabArrivingNotification_NoDevice_title
+                title = .Notifications.SentTab.TabArrivingNoDeviceTitle
             }
 
             if tabs.count == 1 {
@@ -206,9 +206,9 @@ extension SyncDataDisplay {
                 body = (tabs[0]["displayURL"] as? String) ??
                     (tabs[0]["url"] as! String)
             } else if deviceNames.count == 0 {
-                body = .SentTab_TabArrivingNotification_NoDevice_body
+                body = .Notifications.SentTab.TabArrivingNoDeviceBody
             } else {
-                body = String(format: .SentTab_TabArrivingNotification_WithDevice_body, AppInfo.displayName)
+                body = String(format: .Notifications.SentTab.TabArrivingWithDeviceBody, AppInfo.displayName)
             }
         }
 

--- a/Extensions/ShareTo/InitialViewController.swift
+++ b/Extensions/ShareTo/InitialViewController.swift
@@ -105,8 +105,8 @@ class InitialViewController: UIViewController {
 
         getShareItem().uponQueue(.main) { shareItem in
             guard let shareItem = shareItem else {
-                let alert = UIAlertController(title: .SendToErrorTitle, message: .SendToErrorMessage, preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: .SendToErrorOKButton, style: .default) { _ in self.finish(afterDelay: 0) })
+                let alert = UIAlertController(title: .ShareExtension.SendTo.ErrorTitle, message: .ShareExtension.SendTo.ErrorMessage, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: .ShareExtension.SendTo.ErrorOKButton, style: .default) { _ in self.finish(afterDelay: 0) })
                 self.present(alert, animated: true, completion: nil)
                 return
             }

--- a/Extensions/ShareTo/InitialViewController.swift
+++ b/Extensions/ShareTo/InitialViewController.swift
@@ -105,8 +105,8 @@ class InitialViewController: UIViewController {
 
         getShareItem().uponQueue(.main) { shareItem in
             guard let shareItem = shareItem else {
-                let alert = UIAlertController(title: Strings.SendToErrorTitle, message: Strings.SendToErrorMessage, preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: Strings.SendToErrorOKButton, style: .default) { _ in self.finish(afterDelay: 0) })
+                let alert = UIAlertController(title: .SendToErrorTitle, message: .SendToErrorMessage, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: .SendToErrorOKButton, style: .default) { _ in self.finish(afterDelay: 0) })
                 self.present(alert, animated: true, completion: nil)
                 return
             }

--- a/Extensions/ShareTo/ShareViewController.swift
+++ b/Extensions/ShareTo/ShareViewController.swift
@@ -117,15 +117,15 @@ class ShareViewController: UIViewController {
         makeSeparator(addTo: stackView)
 
         if shareItem?.isUrlType() ?? true {
-            makeActionRow(addTo: stackView, label: .ShareOpenInFirefox, imageName: "open-in-firefox", action: #selector(actionOpenInFirefoxNow), hasNavigation: false)
-            makeActionRow(addTo: stackView, label: .ShareLoadInBackground, imageName: "menu-Show-Tabs", action: #selector(actionLoadInBackground), hasNavigation: false)
-            makeActionRow(addTo: stackView, label: .ShareBookmarkThisPage, imageName: "AddToBookmarks", action: #selector(actionBookmarkThisPage), hasNavigation: false)
-            makeActionRow(addTo: stackView, label: .ShareAddToReadingList, imageName: "AddToReadingList", action: #selector(actionAddToReadingList), hasNavigation: false)
+            makeActionRow(addTo: stackView, label: .ShareExtension.OpenInFirefox, imageName: "open-in-firefox", action: #selector(actionOpenInFirefoxNow), hasNavigation: false)
+            makeActionRow(addTo: stackView, label: .ShareExtension.LoadInBackground, imageName: "menu-Show-Tabs", action: #selector(actionLoadInBackground), hasNavigation: false)
+            makeActionRow(addTo: stackView, label: .ShareExtension.BookmarkThisPage, imageName: "AddToBookmarks", action: #selector(actionBookmarkThisPage), hasNavigation: false)
+            makeActionRow(addTo: stackView, label: .ShareExtension.AddToReadingList, imageName: "AddToReadingList", action: #selector(actionAddToReadingList), hasNavigation: false)
             makeSeparator(addTo: stackView)
-            makeActionRow(addTo: stackView, label: .ShareSendToDevice, imageName: "menu-Send-to-Device", action: #selector(actionSendToDevice), hasNavigation: true)
+            makeActionRow(addTo: stackView, label: .ShareExtension.SendTo.Device, imageName: "menu-Send-to-Device", action: #selector(actionSendToDevice), hasNavigation: true)
         } else {
             pageInfoRowUrlLabel?.removeFromSuperview()
-            makeActionRow(addTo: stackView, label: .ShareSearchInFirefox, imageName: "quickSearch", action: #selector(actionSearchInFirefox), hasNavigation: false)
+            makeActionRow(addTo: stackView, label: .ShareExtension.SearchInFirefox, imageName: "quickSearch", action: #selector(actionSearchInFirefox), hasNavigation: false)
         }
 
         let footerSpaceRow = UIView()
@@ -296,7 +296,7 @@ class ShareViewController: UIViewController {
         navigationController?.navigationBar.setValue(true, forKey: "hidesShadow") // hide separator line
         navigationItem.titleView = UIImageView(image: UIImage(named: "Icon-Small"))
         navigationItem.titleView?.contentMode = .scaleAspectFit
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: .SendToCancelButton, style: .plain, target: self, action: #selector(finish))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: .ShareExtension.SendTo.CancelButton, style: .plain, target: self, action: #selector(finish))
         navigationController?.navigationBar.barTintColor = Theme.defaultBackground.color
     }
 
@@ -315,7 +315,7 @@ extension ShareViewController {
     @objc func actionLoadInBackground(gesture: UIGestureRecognizer) {
         // To avoid re-rentry from double tap, each action function disables the gesture
         gesture.isEnabled = false
-        animateToActionDoneView(withTitle: .ShareLoadInBackgroundDone)
+        animateToActionDoneView(withTitle: .ShareExtension.LoadInBackgroundDone)
 
         if let shareItem = shareItem, case .shareItem(let item) = shareItem {
             let profile = BrowserProfile(localName: "profile")
@@ -331,7 +331,7 @@ extension ShareViewController {
 
     @objc func actionBookmarkThisPage(gesture: UIGestureRecognizer) {
         gesture.isEnabled = false
-        animateToActionDoneView(withTitle: .ShareBookmarkThisPageDone)
+        animateToActionDoneView(withTitle: .ShareExtension.BookmarkThisPageDone)
 
         if let shareItem = shareItem, case .shareItem(let item) = shareItem {
             let profile = BrowserProfile(localName: "profile")
@@ -347,7 +347,7 @@ extension ShareViewController {
 
     @objc func actionAddToReadingList(gesture: UIGestureRecognizer) {
         gesture.isEnabled = false
-        animateToActionDoneView(withTitle: .ShareAddToReadingListDone)
+        animateToActionDoneView(withTitle: .ShareExtension.AddToReadingListDone)
 
         if let shareItem = shareItem, case .shareItem(let item) = shareItem {
             let profile = BrowserProfile(localName: "profile")

--- a/Extensions/ShareTo/ShareViewController.swift
+++ b/Extensions/ShareTo/ShareViewController.swift
@@ -117,15 +117,15 @@ class ShareViewController: UIViewController {
         makeSeparator(addTo: stackView)
 
         if shareItem?.isUrlType() ?? true {
-            makeActionRow(addTo: stackView, label: Strings.ShareOpenInFirefox, imageName: "open-in-firefox", action: #selector(actionOpenInFirefoxNow), hasNavigation: false)
-            makeActionRow(addTo: stackView, label: Strings.ShareLoadInBackground, imageName: "menu-Show-Tabs", action: #selector(actionLoadInBackground), hasNavigation: false)
-            makeActionRow(addTo: stackView, label: Strings.ShareBookmarkThisPage, imageName: "AddToBookmarks", action: #selector(actionBookmarkThisPage), hasNavigation: false)
-            makeActionRow(addTo: stackView, label: Strings.ShareAddToReadingList, imageName: "AddToReadingList", action: #selector(actionAddToReadingList), hasNavigation: false)
+            makeActionRow(addTo: stackView, label: .ShareOpenInFirefox, imageName: "open-in-firefox", action: #selector(actionOpenInFirefoxNow), hasNavigation: false)
+            makeActionRow(addTo: stackView, label: .ShareLoadInBackground, imageName: "menu-Show-Tabs", action: #selector(actionLoadInBackground), hasNavigation: false)
+            makeActionRow(addTo: stackView, label: .ShareBookmarkThisPage, imageName: "AddToBookmarks", action: #selector(actionBookmarkThisPage), hasNavigation: false)
+            makeActionRow(addTo: stackView, label: .ShareAddToReadingList, imageName: "AddToReadingList", action: #selector(actionAddToReadingList), hasNavigation: false)
             makeSeparator(addTo: stackView)
-            makeActionRow(addTo: stackView, label: Strings.ShareSendToDevice, imageName: "menu-Send-to-Device", action: #selector(actionSendToDevice), hasNavigation: true)
+            makeActionRow(addTo: stackView, label: .ShareSendToDevice, imageName: "menu-Send-to-Device", action: #selector(actionSendToDevice), hasNavigation: true)
         } else {
             pageInfoRowUrlLabel?.removeFromSuperview()
-            makeActionRow(addTo: stackView, label: Strings.ShareSearchInFirefox, imageName: "quickSearch", action: #selector(actionSearchInFirefox), hasNavigation: false)
+            makeActionRow(addTo: stackView, label: .ShareSearchInFirefox, imageName: "quickSearch", action: #selector(actionSearchInFirefox), hasNavigation: false)
         }
 
         let footerSpaceRow = UIView()
@@ -296,7 +296,7 @@ class ShareViewController: UIViewController {
         navigationController?.navigationBar.setValue(true, forKey: "hidesShadow") // hide separator line
         navigationItem.titleView = UIImageView(image: UIImage(named: "Icon-Small"))
         navigationItem.titleView?.contentMode = .scaleAspectFit
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: Strings.SendToCancelButton, style: .plain, target: self, action: #selector(finish))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: .SendToCancelButton, style: .plain, target: self, action: #selector(finish))
         navigationController?.navigationBar.barTintColor = Theme.defaultBackground.color
     }
 
@@ -315,7 +315,7 @@ extension ShareViewController {
     @objc func actionLoadInBackground(gesture: UIGestureRecognizer) {
         // To avoid re-rentry from double tap, each action function disables the gesture
         gesture.isEnabled = false
-        animateToActionDoneView(withTitle: Strings.ShareLoadInBackgroundDone)
+        animateToActionDoneView(withTitle: .ShareLoadInBackgroundDone)
 
         if let shareItem = shareItem, case .shareItem(let item) = shareItem {
             let profile = BrowserProfile(localName: "profile")
@@ -331,7 +331,7 @@ extension ShareViewController {
 
     @objc func actionBookmarkThisPage(gesture: UIGestureRecognizer) {
         gesture.isEnabled = false
-        animateToActionDoneView(withTitle: Strings.ShareBookmarkThisPageDone)
+        animateToActionDoneView(withTitle: .ShareBookmarkThisPageDone)
 
         if let shareItem = shareItem, case .shareItem(let item) = shareItem {
             let profile = BrowserProfile(localName: "profile")
@@ -347,7 +347,7 @@ extension ShareViewController {
 
     @objc func actionAddToReadingList(gesture: UIGestureRecognizer) {
         gesture.isEnabled = false
-        animateToActionDoneView(withTitle: Strings.ShareAddToReadingListDone)
+        animateToActionDoneView(withTitle: .ShareAddToReadingListDone)
 
         if let shareItem = shareItem, case .shareItem(let item) = shareItem {
             let profile = BrowserProfile(localName: "profile")

--- a/Providers/SyncStatusResolver.swift
+++ b/Providers/SyncStatusResolver.swift
@@ -68,9 +68,9 @@ public struct SyncStatusResolver {
             case .notStarted(let reason):
                 switch reason {
                 case .offline:
-                    return .bad(message: Strings.FirefoxSyncOfflineTitle)
+                    return .bad(message: .FirefoxSyncOfflineTitle)
                 case .noAccount:
-                    return .warning(message: Strings.FirefoxSyncOfflineTitle)
+                    return .warning(message: .FirefoxSyncOfflineTitle)
                 case .backoff(_):
                     return .good
                 case .engineRemotelyNotEnabled(_):

--- a/Providers/SyncStatusResolver.swift
+++ b/Providers/SyncStatusResolver.swift
@@ -68,9 +68,9 @@ public struct SyncStatusResolver {
             case .notStarted(let reason):
                 switch reason {
                 case .offline:
-                    return .bad(message: .FirefoxSyncOfflineTitle)
+                    return .bad(message: .Syncing.FirefoxSync.OfflineTitle)
                 case .noAccount:
-                    return .warning(message: .FirefoxSyncOfflineTitle)
+                    return .warning(message: .Syncing.FirefoxSync.OfflineTitle)
                 case .backoff(_):
                     return .good
                 case .engineRemotelyNotEnabled(_):

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -27,7 +27,7 @@ class FirefoxAccountSignInViewController: UIViewController {
         label.textAlignment = .center
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
-        label.text = Strings.FxASignin_Subtitle
+        label.text = .FxASignin_Subtitle
         label.font = DynamicFontHelper().LargeSizeHeavyFontAS
         return label
     }()
@@ -51,7 +51,7 @@ class FirefoxAccountSignInViewController: UIViewController {
             manager.getPairingAuthorityURL { result in
                 guard let url = try? result.get(), let host = url.host else { return }
                 let shortUrl = host + url.path // "firefox.com" + "/pair"
-                let msg = Strings.FxASignin_QRInstructions.replaceFirstOccurrence(of: placeholder, with: shortUrl)
+                let msg = String.FxASignin_QRInstructions.replaceFirstOccurrence(of: placeholder, with: shortUrl)
                 label.attributedText = msg.attributedText(boldString: shortUrl, font: DynamicFontHelper().MediumSizeRegularWeightAS)
             }
         }
@@ -66,7 +66,7 @@ class FirefoxAccountSignInViewController: UIViewController {
         button.setImage(UIImage(named: "qr-code-icon-white")?.tinted(withColor: .white), for: .normal)
         button.setImage(UIImage(named: "qr-code-icon-white")?.tinted(withColor: .white), for: .highlighted)
         let imageWidth = button.imageView?.frame.width ?? 0.0
-        button.setTitle(Strings.FxASignin_QRScanSignin, for: .normal)
+        button.setTitle(.FxASignin_QRScanSignin, for: .normal)
         button.accessibilityIdentifier = "QRCodeSignIn.button"
         button.titleLabel?.font = DynamicFontHelper().MediumSizeBoldFontAS
         button.titleEdgeInsets = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 0)
@@ -81,7 +81,7 @@ class FirefoxAccountSignInViewController: UIViewController {
         button.layer.borderColor = UIColor.Photon.Grey30.cgColor
         button.layer.borderWidth = 1
         button.layer.cornerRadius = 8
-        button.setTitle(Strings.FxASignin_EmailSignin, for: .normal)
+        button.setTitle(.FxASignin_EmailSignin, for: .normal)
         button.accessibilityIdentifier = "EmailSignIn.button"
         button.addTarget(self, action: #selector(emailLoginTapped), for: .touchUpInside)
         button.titleLabel?.font = DynamicFontHelper().MediumSizeBoldFontAS
@@ -134,7 +134,7 @@ class FirefoxAccountSignInViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
-        title = Strings.FxASignin_Title
+        title = .FxASignin_Title
         accessibilityLabel = "FxASingin.navBar"
         addSubviews()
         addViewConstraints()

--- a/RustFxA/FxAWebViewController.swift
+++ b/RustFxA/FxAWebViewController.swift
@@ -136,7 +136,7 @@ extension FxAWebViewController: WKUIDelegate {
         helpBrowser = wv
         helpBrowser?.navigationDelegate = self
 
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: Strings.BackTitle, style: .plain, target: self, action: #selector(closeHelpBrowser))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: .BackTitle, style: .plain, target: self, action: #selector(closeHelpBrowser))
 
         return helpBrowser
     }

--- a/Shared/AuthenticationKeychainInfo.swift
+++ b/Shared/AuthenticationKeychainInfo.swift
@@ -19,12 +19,12 @@ public enum PasscodeInterval: Int {
     
     public var settingTitle: String {
         switch self {
-        case .immediately:      return .AuthenticationImmediately
-        case .oneMinute:        return .AuthenticationOneMinute
-        case .fiveMinutes:      return .AuthenticationFiveMinutes
-        case .tenMinutes:       return .AuthenticationTenMinutes
-        case .fifteenMinutes:   return .AuthenticationFifteenMinutes
-        case .oneHour:          return .AuthenticationOneHour
+        case .immediately:      return .AuthenticationManager.Immediately
+        case .oneMinute:        return .AuthenticationManager.OneMinute
+        case .fiveMinutes:      return .AuthenticationManager.FiveMinutes
+        case .tenMinutes:       return .AuthenticationManager.TenMinutes
+        case .fifteenMinutes:   return .AuthenticationManager.FifteenMinutes
+        case .oneHour:          return .AuthenticationManager.OneHour
         }
     }
 }

--- a/Shared/DeviceInfo.swift
+++ b/Shared/DeviceInfo.swift
@@ -29,10 +29,10 @@ open class DeviceInfo {
     /// Return the client name, which can be either "Fennec on Stefan's iPod" or simply "Stefan's iPod" if the application display name cannot be obtained.
     open class func defaultClientName() -> String {
         if ProcessInfo.processInfo.arguments.contains(LaunchArguments.DeviceName) {
-            return String(format: .DeviceInfoClientNameDescription, AppInfo.displayName, "iOS")
+            return String(format: .DeviceInfo.ClientNameDescription, AppInfo.displayName, "iOS")
         }
 
-        return String(format: .DeviceInfoClientNameDescription, AppInfo.displayName, UIDevice.current.name)
+        return String(format: .DeviceInfo.ClientNameDescription, AppInfo.displayName, UIDevice.current.name)
     }
 
     open class func clientIdentifier(_ prefs: Prefs) -> String {

--- a/Shared/TimeConstants.swift
+++ b/Shared/TimeConstants.swift
@@ -77,7 +77,7 @@ extension Date {
         }
 
         if components.month == 1 {
-            return String(format: .TimeConstantMoreThanAMonth)
+            return String(format: .TimeConstants.MoreThanAMonth)
         }
 
         if components.month ?? 0 > 1 {
@@ -85,25 +85,25 @@ extension Date {
         }
 
         if components.weekOfYear ?? 0 > 0 {
-            return String(format: .TimeConstantMoreThanAWeek)
+            return String(format: .TimeConstants.MoreThanAWeek)
         }
 
         if components.day == 1 {
-            return String(format: .TimeConstantYesterday)
+            return String(format: .TimeConstants.Yesterday)
         }
 
         if components.day ?? 0 > 1 {
-            return String(format: .TimeConstantThisWeek, String(describing: components.day))
+            return String(format: .TimeConstants.ThisWeek, String(describing: components.day))
         }
 
         if components.hour ?? 0 > 0 || components.minute ?? 0 > 0 {
             // Can't have no time specified for this formatting case.
             let timeStyle = timeStyle != .none ? timeStyle : .short
             let absoluteTime = DateFormatter.localizedString(from: self, dateStyle: .none, timeStyle: timeStyle)
-            return String(format: .TimeConstantRelativeToday, absoluteTime)
+            return String(format: .TimeConstants.RelativeToday, absoluteTime)
         }
 
-        return String(format: .TimeConstantJustNow)
+        return String(format: .TimeConstants.JustNow)
     }
 
     public func toRFC822String() -> String {

--- a/Storage/DefaultSuggestedSites.swift
+++ b/Storage/DefaultSuggestedSites.swift
@@ -41,7 +41,7 @@ open class DefaultSuggestedSites {
                 imageUrl: "asset://suggestedsites_facebook",
                 faviconUrl: "asset://defaultFavicon",
                 trackingId: 632,
-                title: .DefaultSuggestedFacebook
+                title: .DefaultSuggestedSites.Facebook
             ),
             SuggestedSiteData(
                 url: "https://m.youtube.com/",
@@ -49,7 +49,7 @@ open class DefaultSuggestedSites {
                 imageUrl: "asset://suggestedsites_youtube",
                 faviconUrl: "asset://defaultFavicon",
                 trackingId: 631,
-                title: .DefaultSuggestedYouTube
+                title: .DefaultSuggestedSites.YouTube
             ),
             SuggestedSiteData(
                 url: "https://www.amazon.com/",
@@ -57,7 +57,7 @@ open class DefaultSuggestedSites {
                 imageUrl: "asset://suggestedsites_amazon",
                 faviconUrl: "asset://defaultFavicon",
                 trackingId: 630,
-                title: .DefaultSuggestedAmazon
+                title: .DefaultSuggestedSites.Amazon
             ),
             SuggestedSiteData(
                 url: "https://www.wikipedia.org/",
@@ -65,7 +65,7 @@ open class DefaultSuggestedSites {
                 imageUrl: "asset://suggestedsites_wikipedia",
                 faviconUrl: "asset://defaultFavicon",
                 trackingId: 629,
-                title: .DefaultSuggestedWikipedia
+                title: .DefaultSuggestedSites.Wikipedia
             ),
             SuggestedSiteData(
                 url: "https://mobile.twitter.com/",
@@ -73,7 +73,7 @@ open class DefaultSuggestedSites {
                 imageUrl: "asset://suggestedsites_twitter",
                 faviconUrl: "asset://defaultFavicon",
                 trackingId: 628,
-                title: .DefaultSuggestedTwitter
+                title: .DefaultSuggestedSites.Twitter
             )
         ],
         "zh_CN": [

--- a/StorageTests/TestSQLiteHistory.swift
+++ b/StorageTests/TestSQLiteHistory.swift
@@ -93,10 +93,10 @@ class BrowserSchemaV6: BaseHistoricalBrowserSchema {
         let type = 2 // "folder"
         let root = 0
 
-        let titleMobile = Strings.BookmarksFolderTitleMobile
-        let titleMenu = Strings.BookmarksFolderTitleMenu
-        let titleToolbar = Strings.BookmarksFolderTitleToolbar
-        let titleUnsorted = Strings.BookmarksFolderTitleUnsorted
+        let titleMobile = .BookmarksFolderTitleMobile
+        let titleMenu = .BookmarksFolderTitleMenu
+        let titleToolbar = .BookmarksFolderTitleToolbar
+        let titleUnsorted = .BookmarksFolderTitleUnsorted
 
         let args: Args = [
             root, BookmarkRoots.RootGUID, type, "Root", root,
@@ -272,10 +272,10 @@ class BrowserSchemaV7: BaseHistoricalBrowserSchema {
         let type = 2 // "folder"
         let root = 0
 
-        let titleMobile = Strings.BookmarksFolderTitleMobile
-        let titleMenu = Strings.BookmarksFolderTitleMenu
-        let titleToolbar = Strings.BookmarksFolderTitleToolbar
-        let titleUnsorted = Strings.BookmarksFolderTitleUnsorted
+        let titleMobile = .BookmarksFolderTitleMobile
+        let titleMenu = .BookmarksFolderTitleMenu
+        let titleToolbar = .BookmarksFolderTitleToolbar
+        let titleUnsorted = .BookmarksFolderTitleUnsorted
 
         let args: Args = [
             root, BookmarkRoots.RootGUID, type, "Root", root,
@@ -456,10 +456,10 @@ class BrowserSchemaV8: BaseHistoricalBrowserSchema {
         let type = 2 // "folder"
         let root = 0
 
-        let titleMobile = Strings.BookmarksFolderTitleMobile
-        let titleMenu = Strings.BookmarksFolderTitleMenu
-        let titleToolbar = Strings.BookmarksFolderTitleToolbar
-        let titleUnsorted = Strings.BookmarksFolderTitleUnsorted
+        let titleMobile = .BookmarksFolderTitleMobile
+        let titleMenu = .BookmarksFolderTitleMenu
+        let titleToolbar = .BookmarksFolderTitleToolbar
+        let titleUnsorted = .BookmarksFolderTitleUnsorted
 
         let args: Args = [
             root, BookmarkRoots.RootGUID, type, "Root", root,
@@ -655,10 +655,10 @@ class BrowserSchemaV10: BaseHistoricalBrowserSchema {
         let type = 2 // "folder"
         let root = 0
 
-        let titleMobile = Strings.BookmarksFolderTitleMobile
-        let titleMenu = Strings.BookmarksFolderTitleMenu
-        let titleToolbar = Strings.BookmarksFolderTitleToolbar
-        let titleUnsorted = Strings.BookmarksFolderTitleUnsorted
+        let titleMobile = .BookmarksFolderTitleMobile
+        let titleMenu = .BookmarksFolderTitleMenu
+        let titleToolbar = .BookmarksFolderTitleToolbar
+        let titleUnsorted = .BookmarksFolderTitleUnsorted
 
         let args: Args = [
             root, BookmarkRoots.RootGUID, type, "Root", root,

--- a/StorageTests/TestSQLiteHistory.swift
+++ b/StorageTests/TestSQLiteHistory.swift
@@ -93,10 +93,10 @@ class BrowserSchemaV6: BaseHistoricalBrowserSchema {
         let type = 2 // "folder"
         let root = 0
 
-        let titleMobile = .BookmarksFolderTitleMobile
-        let titleMenu = .BookmarksFolderTitleMenu
-        let titleToolbar = .BookmarksFolderTitleToolbar
-        let titleUnsorted = .BookmarksFolderTitleUnsorted
+        let titleMobile: String = .Bookmarks.FolderTitle.Mobile
+        let titleMenu: String = .Bookmarks.FolderTitle.Menu
+        let titleToolbar: String = .Bookmarks.FolderTitle.Toolbar
+        let titleUnsorted: String = .Bookmarks.FolderTitle.Unsorted
 
         let args: Args = [
             root, BookmarkRoots.RootGUID, type, "Root", root,
@@ -272,10 +272,10 @@ class BrowserSchemaV7: BaseHistoricalBrowserSchema {
         let type = 2 // "folder"
         let root = 0
 
-        let titleMobile = .BookmarksFolderTitleMobile
-        let titleMenu = .BookmarksFolderTitleMenu
-        let titleToolbar = .BookmarksFolderTitleToolbar
-        let titleUnsorted = .BookmarksFolderTitleUnsorted
+        let titleMobile: String = .Bookmarks.FolderTitle.Mobile
+        let titleMenu: String = .Bookmarks.FolderTitle.Menu
+        let titleToolbar: String = .Bookmarks.FolderTitle.Toolbar
+        let titleUnsorted: String = .Bookmarks.FolderTitle.Unsorted
 
         let args: Args = [
             root, BookmarkRoots.RootGUID, type, "Root", root,
@@ -456,10 +456,10 @@ class BrowserSchemaV8: BaseHistoricalBrowserSchema {
         let type = 2 // "folder"
         let root = 0
 
-        let titleMobile = .BookmarksFolderTitleMobile
-        let titleMenu = .BookmarksFolderTitleMenu
-        let titleToolbar = .BookmarksFolderTitleToolbar
-        let titleUnsorted = .BookmarksFolderTitleUnsorted
+        let titleMobile: String = .Bookmarks.FolderTitle.Mobile
+        let titleMenu: String = .Bookmarks.FolderTitle.Menu
+        let titleToolbar: String = .Bookmarks.FolderTitle.Toolbar
+        let titleUnsorted: String = .Bookmarks.FolderTitle.Unsorted
 
         let args: Args = [
             root, BookmarkRoots.RootGUID, type, "Root", root,
@@ -655,10 +655,10 @@ class BrowserSchemaV10: BaseHistoricalBrowserSchema {
         let type = 2 // "folder"
         let root = 0
 
-        let titleMobile = .BookmarksFolderTitleMobile
-        let titleMenu = .BookmarksFolderTitleMenu
-        let titleToolbar = .BookmarksFolderTitleToolbar
-        let titleUnsorted = .BookmarksFolderTitleUnsorted
+        let titleMobile: String = .Bookmarks.FolderTitle.Mobile
+        let titleMenu: String = .Bookmarks.FolderTitle.Menu
+        let titleToolbar: String = .Bookmarks.FolderTitle.Toolbar
+        let titleUnsorted: String = .Bookmarks.FolderTitle.Unsorted
 
         let args: Args = [
             root, BookmarkRoots.RootGUID, type, "Root", root,


### PR DESCRIPTION
This sets up the string refactor work by:

- Adding a `lastEditedIn: AppVersionTag` parameter to `MZLocalizedString` allowing us to update each string as needed and mark what version it was updated in to track for localization changes
- Removing `Strings` and making all strings an extension of the `String` type
- Alphabetizing strings according to their current sections
- Starting a reorganization of the strings into Structs, allowing for shorter string names and more logical layout for adding future strings
- Creating a `Deprecated` section. Before removing strings, they're moved here first to make sure we're not using them and decisions about removing them can be made later on

Note: while this PR changes a lot of files, the review should really focus on `Strings.swift` as the other files are just updating the respective strings throughout the app.

Note, the second: Strings themselves have not been changed.