### PR TITLE
FXIOS-2934: fix UI issues on Home

### DIFF
--- a/Client/Frontend/Home/FxHomeRecentlySavedCollectionCell.swift
+++ b/Client/Frontend/Home/FxHomeRecentlySavedCollectionCell.swift
@@ -260,7 +260,8 @@ class RecentlySavedCell: UICollectionViewCell {
             bookmarkTitle.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -8),
             
             bookmarkDetails.topAnchor.constraint(equalTo: bookmarkTitle.bottomAnchor, constant: 2),
-            bookmarkDetails.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16)
+            bookmarkDetails.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            bookmarkDetails.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -8)
         ])
     }
     

--- a/Client/Frontend/Home/LibraryShortcutView.swift
+++ b/Client/Frontend/Home/LibraryShortcutView.swift
@@ -46,12 +46,11 @@ class LibraryShortcutView: UIView {
             make.size.equalTo(60)
             make.centerX.equalToSuperview()
             make.top.equalToSuperview()
-            make.bottom.equalTo(titleLabel.snp.top)
         }
 
         titleLabel.snp.makeConstraints { make in
-            make.top.equalTo(button.snp.bottom)
-            make.leading.trailing.centerX.bottom.equalToSuperview()
+            make.top.equalTo(button.snp.bottom).offset(8)
+            make.leading.trailing.centerX.equalToSuperview()
         }
     }
 


### PR DESCRIPTION
# Overview
This PR addresses this [JIRA ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-2934), and #8814 . Cutoff text on Library & Recently Saved section. 

# How to Test
Use an iPhone 8 or iPhone 6. Switch language to one where text specified in the ticket is cut off (Spanish). See results.

# Screenshots

<img width="389" alt="image" src="https://user-images.githubusercontent.com/36939381/127352551-82a2319d-a172-46be-b28e-6dfe30d4d1eb.png">

<img width="386" alt="image" src="https://user-images.githubusercontent.com/36939381/127352695-8dad953d-f686-44d1-a5d3-c8c9a416afff.png">
