### PR TITLE
FXIOS-2948: Fixes favicons overlap with the text in "Recently Closed" list

### DIFF
--- a/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -87,18 +87,19 @@ class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {
         }
         let tab = recentlyClosedTabs[indexPath.row]
         let displayURL = tab.url.displayURL ?? tab.url
+        let site: Favicon? = (tab.faviconURL != nil) ? Favicon(url: tab.faviconURL!) : nil
         twoLineCell.descriptionLabel.isHidden = false
         twoLineCell.titleLabel.text = tab.title
         twoLineCell.titleLabel.isHidden = tab.title?.isEmpty ?? true ? true : false
-        twoLineCell.descriptionLabel.text = displayURL.absoluteDisplayString
-        let site: Favicon? = (tab.faviconURL != nil) ? Favicon(url: tab.faviconURL!) : nil
-        cell.imageView?.layer.borderColor = RecentlyClosedPanelUX.IconBorderColor.cgColor
-        cell.imageView?.layer.borderWidth = RecentlyClosedPanelUX.IconBorderWidth
-        cell.imageView?.contentMode = .center
-        cell.imageView?.setImageAndBackground(forIcon: site, website: displayURL) { [weak cell] in
-            cell?.imageView?.image = cell?.imageView?.image?.createScaled(RecentlyClosedPanelUX.IconSize)
+        twoLineCell.descriptionLabel.text = displayURL.absoluteDisplayString        
+        twoLineCell.leftImageView.layer.borderColor = RecentlyClosedPanelUX.IconBorderColor.cgColor
+        twoLineCell.leftImageView.layer.borderWidth = RecentlyClosedPanelUX.IconBorderWidth
+        twoLineCell.leftImageView.contentMode = .center
+        twoLineCell.leftImageView.setImageAndBackground(forIcon: site, website: displayURL) { [weak twoLineCell] in
+            twoLineCell?.leftImageView.image = twoLineCell?.leftImageView.image?.createScaled(RecentlyClosedPanelUX.IconSize)
         }
-        return cell
+        
+        return twoLineCell
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/Client/Frontend/Widgets/TwoLineCellAndFooter.swift
+++ b/Client/Frontend/Widgets/TwoLineCellAndFooter.swift
@@ -76,6 +76,7 @@ class TwoLineImageOverlayCell: UITableViewCell, Themeable {
 
         containerView.addSubview(leftOverlayImageView)
         addSubview(containerView)
+        contentView.addSubview(containerView)
         bringSubviewToFront(containerView)
 
         containerView.snp.makeConstraints { make in


### PR DESCRIPTION
<table>
  <tr>
     <td> Before </td>
      <td> After // Fixed</td>
  </tr> 
  <tr>
      <td><img src="https://user-images.githubusercontent.com/8919439/127416504-dcb92d76-03ae-4511-be2b-12583ab7f89f.png" alt="3" width = 710px></td>
     <td> <img src="https://user-images.githubusercontent.com/8919439/127416159-3f3072e1-a82b-4c21-a6a1-a649db274317.png" alt="1" width = 710px> </td>
  </tr> 

</table>