### PR TITLE
Adds first run targeting for the Nimbus SDK

### DIFF
--- a/Client/Application/AppDelegate+Experiments.swift
+++ b/Client/Application/AppDelegate+Experiments.swift
@@ -10,17 +10,16 @@ import Foundation
 
 extension AppDelegate {
     func initializeExperiments() {
-
         let defaults = UserDefaults.standard
         let nimbusFirstRun = "NimbusFirstRun"
-        let firstRun = defaults.bool(forKey: nimbusFirstRun) != false
+        let isFirstRun = defaults.object(forKey: nimbusFirstRun) == nil
         defaults.set(false, forKey: nimbusFirstRun)
-
+        Experiments.customTargetingAttributes =  ["isFirstRun": "\(isFirstRun)"]
         let initialExperiments = Bundle.main.url(forResource: "initial_experiments", withExtension: "json")
         let serverURL = Experiments.remoteSettingsURL
         let savedOptions = Experiments.getLocalExperimentData()
         let options: Experiments.InitializationOptions
-        switch (savedOptions, firstRun, initialExperiments, serverURL) {
+        switch (savedOptions, isFirstRun, initialExperiments, serverURL) {
         // QA testing case: experiments come from the Experiments setting screen.
         case (let payload, _, _, _) where payload != nil:
             log.info("Nimbus: Loading from experiments provided by settings screen")

--- a/Client/Experiments/Experiments.swift
+++ b/Client/Experiments/Experiments.swift
@@ -116,6 +116,8 @@ enum Experiments {
     static func usePreviewCollection(storage: UserDefaults = .standard) -> Bool {
         storage.bool(forKey: NIMBUS_USE_PREVIEW_COLLECTION_KEY)
     }
+    
+    static var customTargetingAttributes: [String: String] = [:]
 
     static var serverSettings: NimbusServerSettings? = {
         // If no URL is specified, or it's not valid continue with as if
@@ -152,7 +154,8 @@ enum Experiments {
         // thinks it is.
         let appSettings = NimbusAppSettings(
             appName: nimbusAppName,
-            channel: AppConstants.BuildChannel.nimbusString
+            channel: AppConstants.BuildChannel.nimbusString,
+            customTargetingAttributes: Experiments.customTargetingAttributes
         )
 
         let errorReporter: NimbusErrorReporter = { err in


### PR DESCRIPTION
fixes https://mozilla-hub.atlassian.net/browse/SDK-343

This change adds the ability to target users who are on their first run for nimbus experiments.

It also exposes the `customTargetingAttributes` at the top level of initializing experiments, so future targeting attributes can be added easily without blocking on the Nimbus SDK. I could easily drop down the creation of the attributes a couple of layers closer to Nimbus if we feel this is exposing too much at a high level.

A couple of notes: I opted here to just use a custom default to define the first run, to align better with [Desktop's first startup ](https://searchfox.org/mozilla-central/source/toolkit/modules/FirstStartup.jsm) and the work we have on [android](https://github.com/mozilla-mobile/fenix/pull/20642/files). It was either this or using [the pref that indicates if users saw onboarding](https://github.com/mozilla-mobile/firefox-ios/blob/main/Client/Frontend/Browser/BrowserViewController.swift) (thanks @boek for pointing this one out!), but that deviates a little from the first startup definition 

