### PR TITLE
Search credential list improvements

### DIFF
--- a/CredentialProvider/CredentialListPresenter.swift
+++ b/CredentialProvider/CredentialListPresenter.swift
@@ -24,7 +24,7 @@ class CredentialListPresenter {
     
     func filterCredentials(for searchText: String) {
         filteredCredentials = loginsData.filter { item in
-            item.0.serviceIdentifier.identifier.lowercased().contains(searchText.lowercased())
+            item.0.serviceIdentifier.identifier.titleFromHostname.lowercased().contains(searchText.lowercased()) || item.0.user.lowercased().contains(searchText.lowercased())
         }
     }
     

--- a/CredentialProvider/CredentialListViewController.swift
+++ b/CredentialProvider/CredentialListViewController.swift
@@ -208,7 +208,13 @@ extension CredentialListViewController: UITableViewDelegate {
         case .none:
             return 44
         }
-    }    
+    }
+    
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        if  let searchBar = searchController?.searchBar, searchBar.isFirstResponder {
+            searchBar.resignFirstResponder()
+        }
+    }
 }
 
 


### PR DESCRIPTION
Fixes for  #8940 and #8941
- Added the username to search criteria. (Now the search includes hostname and username).
- Dismiss keyboard during scroll when search is active. In this way, user will be able to scroll the list to the last login.
