### PR TITLE
Fixed #8960: Browser incorrect session when closing single tab in private mode 

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -92,7 +92,7 @@ class TabDisplayManager: NSObject, FeatureFlagsProtocol {
     }
     
     private var tabsToDisplay: [Tab] {
-        if shouldEnableInactiveTabs { return retriveTabsAndupdateInactiveState() }
+        if shouldEnableInactiveTabs { return getTabsAndupdateInactiveState() }
         let allTabs = self.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
         return allTabs
     }
@@ -161,7 +161,7 @@ class TabDisplayManager: NSObject, FeatureFlagsProtocol {
     /// This is a helper method to update inactive tab state and should not be called directly
     /// Even when we have inactive tabs enabled try to call `tabsToDisplay`
     /// `tabsToDisplay` will make sure to get the correct set ot tabs and also check if feature is enabled
-    private func retriveTabsAndupdateInactiveState() -> [Tab] {
+    private func getTabsAndupdateInactiveState() -> [Tab] {
         let allTabs = self.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
         guard allTabs.count > 0, let inactiveViewModel = inactiveViewModel else { return [Tab]() }
         guard allTabs.count > 1 else { return allTabs }

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -92,7 +92,7 @@ class TabDisplayManager: NSObject, FeatureFlagsProtocol {
     }
     
     private var tabsToDisplay: [Tab] {
-        if shouldEnableInactiveTabs { return getTabsAndupdateInactiveState() }
+        if shouldEnableInactiveTabs { return getTabsAndUpdateInactiveState() }
         let allTabs = self.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
         return allTabs
     }
@@ -161,7 +161,7 @@ class TabDisplayManager: NSObject, FeatureFlagsProtocol {
     /// This is a helper method to update inactive tab state and should not be called directly
     /// Even when we have inactive tabs enabled try to call `tabsToDisplay`
     /// `tabsToDisplay` will make sure to get the correct set ot tabs and also check if feature is enabled
-    private func getTabsAndupdateInactiveState() -> [Tab] {
+    private func getTabsAndUpdateInactiveState() -> [Tab] {
         let allTabs = self.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
         guard allTabs.count > 0, let inactiveViewModel = inactiveViewModel else { return [Tab]() }
         guard allTabs.count > 1 else { return allTabs }

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -159,8 +159,8 @@ class TabDisplayManager: NSObject, FeatureFlagsProtocol {
     }
     
     /// This is a helper method to update inactive tab state and should not be called directly
-    /// Even when we have inactive tabs enabled try always to call `tabsToDisplay`
-    /// `tabsToDisplay` will make sure to get the correct set ot tabs
+    /// Even when we have inactive tabs enabled try to call `tabsToDisplay`
+    /// `tabsToDisplay` will make sure to get the correct set ot tabs and also check if feature is enabled
     private func retriveTabsAndupdateInactiveState() -> [Tab] {
         let allTabs = self.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
         guard allTabs.count > 0, let inactiveViewModel = inactiveViewModel else { return [Tab]() }

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -92,7 +92,7 @@ class TabDisplayManager: NSObject, FeatureFlagsProtocol {
     }
     
     private var tabsToDisplay: [Tab] {
-        if shouldEnableInactiveTabs { return getTabsToDisplay() }
+        if shouldEnableInactiveTabs { return retriveTabsAndupdateInactiveState() }
         let allTabs = self.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
         return allTabs
     }
@@ -158,7 +158,10 @@ class TabDisplayManager: NSObject, FeatureFlagsProtocol {
         }
     }
     
-    private func getTabsToDisplay() -> [Tab] {
+    /// This is a helper method to update inactive tab state and should not be called directly
+    /// Even when we have inactive tabs enabled try always to call `tabsToDisplay`
+    /// `tabsToDisplay` will make sure to get the correct set ot tabs
+    private func retriveTabsAndupdateInactiveState() -> [Tab] {
         let allTabs = self.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
         guard allTabs.count > 0, let inactiveViewModel = inactiveViewModel else { return [Tab]() }
         guard allTabs.count > 1 else { return allTabs }

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -244,12 +244,12 @@ class TabDisplayManager: NSObject, FeatureFlagsProtocol {
             return
         }
         
-        if getTabsToDisplay().count == 1 {
+        if self.isPrivate == false, tabsToDisplay.count == 1 {
             tabManager.removeTabs([tab])
             tabManager.selectTab(tabManager.addTab())
             return
         }
-        
+
         tabManager.removeTabAndUpdateSelectedIndex(tab)
     }
 

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -158,7 +158,7 @@ class TabDisplayManager: NSObject, FeatureFlagsProtocol {
         }
     }
     
-    func getTabsToDisplay() -> [Tab] {
+    private func getTabsToDisplay() -> [Tab] {
         let allTabs = self.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
         guard allTabs.count > 0, let inactiveViewModel = inactiveViewModel else { return [Tab]() }
         guard allTabs.count > 1 else { return allTabs }


### PR DESCRIPTION
`getTabsToDisplay` was being directly called in all cases including private mode, which should not be the case and we should always call `tabsToDisplay` 

This was a miss during cleanup. I have added a comment and also updated the method definition.
