### PR TITLE
Use lowercase characters only in label for `pocket.open_story_position` metric

### DIFF
--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -546,7 +546,7 @@ extension TelemetryWrapper {
         // Pocket
         case (.action, .tap, .pocketStory, _, let extras):
             if let position = extras?[EventExtraKey.pocketTilePosition.rawValue] as? String {
-                GleanMetrics.Pocket.openStoryPosition["Position-"+position].add()
+                GleanMetrics.Pocket.openStoryPosition["position-"+position].add()
             } else {
                 let msg = "Uninstrumented pref metric: \(category), \(method), \(object), \(value), \(String(describing: extras))"
                 Sentry.shared.send(message: msg, severity: .debug)


### PR DESCRIPTION
This fixes #8795, which was initially tackled in #8878, however it used an uppercase letter, which is still not correct and all values will still land in the `__other__` bucket.

