### PR TITLE
FXIOS-2583-2922: duplicate tabs opening fix

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -133,7 +133,7 @@ class BrowserViewController: UIViewController {
     weak var pendingDownloadWebView: WKWebView?
 
     let downloadQueue = DownloadQueue()
-    var isCmdClickForNewTab = false
+    var isOnlyCmdPressed = false
 
     fileprivate var shouldShowIntroScreen: Bool { profile.prefs.intForKey(PrefsKeys.IntroSeen) == nil }
 
@@ -2142,20 +2142,24 @@ extension BrowserViewController: ContextMenuHelperDelegate {
         }
     }
     
-    //Support for CMD+ Click on link to open in a new tab
-     override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
-         super.pressesBegan(presses, with: event)
-         if #available(iOS 13.4, *) {
-             guard let key = presses.first?.key, (key.keyCode == .keyboardLeftGUI || key.keyCode == .keyboardRightGUI) else { return } //GUI buttons = CMD buttons on ipad/mac
-             self.isCmdClickForNewTab = true
-         }
+    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        // Temporary solution to support CMD + Click to open an unselected new tab
+        if #available(iOS 13.4, *) {
+            if let event = event, event.allPresses.count > 1 {
+                isOnlyCmdPressed = false
+            } else if let key = presses.first?.key, (key.keyCode == .keyboardLeftGUI || key.keyCode == .keyboardRightGUI) { // GUI equates to CMD key on physical keyboard
+                isOnlyCmdPressed = true
+            }
+        }
+        
+        super.pressesBegan(presses, with: event)
     }
     
     override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
         super.pressesEnded(presses, with: event)
         if #available(iOS 13.4, *) {
             guard let key = presses.first?.key, (key.keyCode == .keyboardLeftGUI || key.keyCode == .keyboardRightGUI) else { return }
-            self.isCmdClickForNewTab = false
+            isOnlyCmdPressed = false
         }
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -575,10 +575,10 @@ extension BrowserViewController: WKNavigationDelegate {
             tab.mimeType = response.mimeType
         }
         
-        if isCmdClickForNewTab {
+        if isOnlyCmdPressed {
             guard let url = webView.url, let isPrivate = self.tabManager.selectedTab?.isPrivate else { return }
             homePanelDidRequestToOpenInNewTab(url, isPrivate: isPrivate)
-            self.isCmdClickForNewTab = false
+            isOnlyCmdPressed = false
             decisionHandler(.cancel)
         }
 


### PR DESCRIPTION
# Overview

This PR is in reference to this [JIRA ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-2583) and [this ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-2922). 

It's also in reference to https://github.com/mozilla-mobile/firefox-ios/issues/7519 and https://github.com/mozilla-mobile/firefox-ios/issues/8790. 

## How to Test
You'll need an external keyboard connected. Try opening a tab with CMD + T and make sure there's no duplicate home opening. Also, try CMD + R on a tab at least 2 times and make sure not duplicate of that tab opens while it reloads. 