### PR TITLE
Bugfix: Use `none` as the code in metric labels

### DIFF
--- a/Client/Telemetry/SearchTelemetry.swift
+++ b/Client/Telemetry/SearchTelemetry.swift
@@ -16,9 +16,9 @@ struct SearchPartner {
     static func getCode(searchEngine: SearchEngine, region: String) -> String {
         switch(searchEngine) {
         case .google:
-            return google[region] ?? ""
+            return google[region] ?? "none"
         case .none:
-            return ""
+            return "none"
         }
     }
 }


### PR DESCRIPTION
The search code is used as a suffix in a label for the labeled counter
`search.in_content`.
In case of an unknown search engine the empty string is used.
This ultimatively results in the label ending with a dot (`.`), which is
not allowed.
Labels need to end with an alphanumeric character instead.

We can simple tackle on the string `"none"` to fix that and not cause
further Glean metric recording errors.

Fixes #8724

