### PR TITLE
FXIOS-3011: added onboarding telemetry counts

### DIFF
--- a/Client/Frontend/Intro/IntroScreenSyncView.swift
+++ b/Client/Frontend/Intro/IntroScreenSyncView.swift
@@ -181,13 +181,13 @@ class IntroScreenSyncView: UIView, CardTheme {
     // MARK: Button Actions
     @objc private func signUpAction() {
         TelemetryWrapper.recordEvent(category: .action, method: .press, object: .dismissedOnboardingSignUp, extras: ["slide-num": 1])
-        print("Sign up")
+        TelemetryWrapper.recordEvent(category: .action, method: .press, object: .syncScreenSignUp)
         signUp?()
     }
     
     @objc private func startBrowsingAction() {
         TelemetryWrapper.recordEvent(category: .action, method: .press, object: .dismissedOnboarding, extras: ["slide-num": 1])
-        print("Start Browsing")
+        TelemetryWrapper.recordEvent(category: .action, method: .press, object: .syncScreenStartBrowse)
         startBrowsing?()
     }
 }

--- a/Client/Frontend/Intro/IntroScreenWelcomeView.swift
+++ b/Client/Frontend/Intro/IntroScreenWelcomeView.swift
@@ -105,7 +105,9 @@ class IntroScreenWelcomeView: UIView, CardTheme {
     // MARK: Initializer
     override init(frame: CGRect) {
         super.init(frame: frame)
+        
         initialViewSetup()
+        TelemetryWrapper.recordEvent(category: .action, method: .view, object: .welcomeScreenView)
     }
     
     // MARK: View setup
@@ -169,7 +171,7 @@ class IntroScreenWelcomeView: UIView, CardTheme {
             make.height.equalTo(buttonHeight)
         }
         addSubview(closeButton)
-        closeButton.addTarget(self, action: #selector(startBrowsing), for: .touchUpInside)
+        closeButton.addTarget(self, action: #selector(handleCloseButtonTapped), for: .touchUpInside)
         closeButton.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(buttonEdgeInset)
             make.right.equalToSuperview().inset(buttonEdgeInset)
@@ -179,22 +181,26 @@ class IntroScreenWelcomeView: UIView, CardTheme {
     }
     
     // MARK: Button Actions
-    @objc func startBrowsing() {
+    @objc func handleCloseButtonTapped() {
         TelemetryWrapper.recordEvent(category: .action, method: .press, object: .dismissedOnboarding, extras: ["slide-num": currentPage])
+        TelemetryWrapper.recordEvent(category: .action, method: .press, object: .welcomeScreenClose)
         closeClosure?()
     }
 
     @objc func showEmailLoginFlow() {
         TelemetryWrapper.recordEvent(category: .action, method: .press, object: .dismissedOnboardingEmailLogin, extras: ["slide-num": currentPage])
+        TelemetryWrapper.recordEvent(category: .action, method: .press, object: .welcomeScreenSignIn)
         signInClosure?()
     }
 
     @objc func showSignUpFlow() {
         TelemetryWrapper.recordEvent(category: .action, method: .press, object: .dismissedOnboardingSignUp, extras: ["slide-num": currentPage])
+        TelemetryWrapper.recordEvent(category: .action, method: .press, object: .welcomeScreenSignUp)
         signUpClosure?()
     }
     
     @objc private func nextAction() {
+        TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .welcomeScreenNext)
         nextClosure?()
     }
     

--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -61,6 +61,7 @@ class IntroViewController: UIViewController, OnViewDismissable {
                 self.welcomeCard.alpha = 0
             }) { _ in
                 self.welcomeCard.isHidden = true
+                TelemetryWrapper.recordEvent(category: .action, method: .view, object: .syncScreenView)
             }
         }
         // Close button action

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -317,9 +317,6 @@ extension TelemetryWrapper {
         case dismissedETPCoverSheet = "dismissed-etp-sheet"
         case dismissETPCoverSheetAndStartBrowsing = "dismissed-etp-cover-sheet-and-start-browsing"
         case dismissETPCoverSheetAndGoToSettings = "dismissed-update-cover-sheet-and-go-to-settings"
-        case dismissedOnboarding = "dismissed-onboarding"
-        case dismissedOnboardingEmailLogin = "dismissed-onboarding-email-login"
-        case dismissedOnboardingSignUp = "dismissed-onboarding-sign-up"
         case privateBrowsingButton = "private-browsing-button"
         case startSearchButton = "start-search-button"
         case addNewTabButton = "add-new-tab-button"
@@ -333,6 +330,17 @@ extension TelemetryWrapper {
         case settings = "settings"
         case settingsMenuSetAsDefaultBrowser = "set-as-default-browser-menu-go-to-settings"
         case onboarding = "onboarding"
+        case welcomeScreenView = "welcome-screen-view"
+        case welcomeScreenClose = "welcome-screen-close"
+        case welcomeScreenSignIn = "welcome-screen-sign-in"
+        case welcomeScreenSignUp = "welcome-screen-sign-up"
+        case welcomeScreenNext = "welcome-screen-next"
+        case syncScreenView = "sync-screen-view"
+        case syncScreenSignUp = "sync-screen-sign-up"
+        case syncScreenStartBrowse = "sync-screen-start-browse"
+        case dismissedOnboarding = "dismissed-onboarding"
+        case dismissedOnboardingSignUp = "dismissed-onboarding-sign-up"
+        case dismissedOnboardingEmailLogin = "dismissed-onboarding-email-login"
         case dismissDefaultBrowserCard = "default-browser-card"
         case goToSettingsDefaultBrowserCard = "default-browser-card-go-to-settings"
         case dismissDefaultBrowserOnboarding = "default-browser-onboarding"
@@ -525,6 +533,22 @@ extension TelemetryWrapper {
                 let msg = "Missing slide-num in onboarding metric: \(category), \(method), \(object), \(value), \(String(describing: extras))"
                 Sentry.shared.send(message: msg, severity: .debug)
             }
+        case (.action, .view, .welcomeScreenView, _, _):
+            GleanMetrics.Onboarding.welcomeScreen.add()
+        case(.action, .press, .welcomeScreenSignUp, _, _):
+            GleanMetrics.Onboarding.welcomeScreenSignUp.add()
+        case (.action, .press, .welcomeScreenSignIn, _, _):
+            GleanMetrics.Onboarding.welcomeScreenSignIn.add()
+        case(.action, .press, .welcomeScreenNext, _, _):
+            GleanMetrics.Onboarding.welcomeScreenNext.add()
+        case(.action, .press, .welcomeScreenClose, _, _):
+            GleanMetrics.Onboarding.welcomeScreenClose.add()
+        case(.action, .view, .syncScreenView, _, _):
+            GleanMetrics.Onboarding.syncScreen.add()
+        case(.action, .press, .syncScreenSignUp, _, _):
+            GleanMetrics.Onboarding.syncScreenSignUp.add()
+        case(.action, .press, .syncScreenStartBrowse, _, _):
+            GleanMetrics.Onboarding.syncScreenBrowse.add()
         // Widget
         case (.action, .open, .mediumTabsOpenUrl, _, _):
             GleanMetrics.Widget.mTabsOpenUrl.add()

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -325,6 +325,102 @@ onboarding:
           The current onboarding slide number being viewed when
           onboarding is dismissed.
         type: quantity
+  welcome_screen:
+    type: counter
+    description: |
+      The number of times a user is shown the first screen, the
+      welcome screen, from the onboarding process.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-3011
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/9016
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2022-01-01"
+  welcome_screen_sign_up:
+    type: counter
+    description: |
+      The number of times a user taps the sign up button in
+      onboarding's first screen, the welcome screen.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-3011
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/9016
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2022-01-01"
+  welcome_screen_sign_in:
+    type: counter
+    description: |
+      The number of times a user taps on the Sign In button in
+      onboarding's first screen, the welcome screen.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-3011
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/9016
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2022-01-01"
+  welcome_screen_next:
+    type: counter
+    description: |
+      The number of times a user taps on the next button in
+      onboarding's first screen, the welcome screen.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-3011
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/9016
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2022-01-01"
+  welcome_screen_close:
+    type: counter
+    description: |
+      The number of times a user taps on the close button in
+      onboarding's first screen, the welcome screen.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-3011
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/9016
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2022-01-01"
+  sync_screen:
+    type: counter
+    description: |
+      The number of times a user is shown the second screen, the
+      Sync Screen, from the onboarding process.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-3011
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/9016
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2022-01-01"
+  sync_screen_sign_up:
+    type: counter
+    description: |
+      The number of times a user taps on the sign up button in
+      onboarding's second screen, the Sync Screen.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-3011
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/9016
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2022-01-01"
+  sync_screen_browse:
+    type: counter
+    description: |
+      The number of times a user taps on the start browsing button
+      in onboarding's second screen, the Sync Screen.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-3011
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/9016
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2022-01-01"
 
 # Top Site
 top_site:


### PR DESCRIPTION
# Overview

This ticket addresses this [JIRA ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-3011) & [this issue](https://github.com/mozilla-mobile/firefox-ios/issues/8927). 

Note that there are some existing telemetry items for some of the items, but only `.dismissedOnboarding` is reported. They're also not in the count format that product has requested. For context about the one being reported, see https://github.com/mozilla-mobile/firefox-ios/pull/8904 .

Instead of removing those existing ones, I've added new events on top. 