### PR TITLE
[Nimbus] Runs fetch then apply on the first run

### DIFF
--- a/Client/Application/AppDelegate+Experiments.swift
+++ b/Client/Application/AppDelegate+Experiments.swift
@@ -10,36 +10,31 @@ import Foundation
 
 extension AppDelegate {
     func initializeExperiments() {
-        let defaults = UserDefaults.standard
-        let nimbusFirstRun = "NimbusFirstRun"
-        let isFirstRun = defaults.object(forKey: nimbusFirstRun) == nil
-        defaults.set(false, forKey: nimbusFirstRun)
-        Experiments.customTargetingAttributes =  ["isFirstRun": "\(isFirstRun)"]
+        Experiments.customTargetingAttributes =  ["isFirstRun": "\(Experiments.isFirstRun)"]
         let initialExperiments = Bundle.main.url(forResource: "initial_experiments", withExtension: "json")
         let serverURL = Experiments.remoteSettingsURL
         let savedOptions = Experiments.getLocalExperimentData()
         let options: Experiments.InitializationOptions
-        switch (savedOptions, isFirstRun, initialExperiments, serverURL) {
+        switch (savedOptions, initialExperiments, serverURL) {
         // QA testing case: experiments come from the Experiments setting screen.
-        case (let payload, _, _, _) where payload != nil:
+        case (let payload, _, _) where payload != nil:
             log.info("Nimbus: Loading from experiments provided by settings screen")
             options = Experiments.InitializationOptions.testing(localPayload: payload!)
-        // First startup case:
-        case (nil, true, let file, _) where file != nil:
-            log.info("Nimbus: Loading from experiments from bundle, at first startup")
-            options = Experiments.InitializationOptions.preload(fileUrl: file!)
         // Local development case: load from the bundled initial_experiments.json
-        case (_, _, let file, let url) where file != nil && url == nil:
+        case (_, let file, let url) where file != nil && url == nil:
             log.info("Nimbus: Loading from experiments from bundle, with no URL")
-            options = Experiments.InitializationOptions.preload(fileUrl: file!)
-        case (_, _, _, let url) where url != nil:
+            options = Experiments.InitializationOptions.dev(fileUrl: file!)
+        case (_, _, let url) where url != nil:
             log.info("Nimbus: server exists")
             options = Experiments.InitializationOptions.normal
         default:
             log.info("Nimbus: server does not exist")
             options = Experiments.InitializationOptions.normal
         }
-
-        Experiments.intialize(options)
+        if Experiments.isFirstRun {
+            Experiments.initializeFirstRun(options)
+        } else {
+            Experiments.intialize(options)
+        }
     }
 }

--- a/Client/Experiments/ExperimentConstants.swift
+++ b/Client/Experiments/ExperimentConstants.swift
@@ -11,7 +11,7 @@ import Foundation
 /// each feature is documented in `Docs/features.md`.
 ///
 enum NimbusFeatureId: String {
-    case nimbusValidation = "nimbus-validation"
+    case nimbusValidation = "nimbusValidation"
     case onboardingDefaultBrowser = "onboarding-default-browser"
     case inactiveTabs = "inactiveTabs"
     case search = "search"


### PR DESCRIPTION
### What is this
To target first run on mobile, the application must be able to retrieve the experiment data on the first run. This PR does the following: 
- Allow the application to run `fetchExperiments` followed by `applyPendingExperiments` in the **first run**, this has no effect on any other run of the app. 
- Additionally, this PR exposes a new API `onExperimentsApplied` which is a convenience API that ensures a callback will only be executed once the experiments have been applied.


**I'm having this as a draft until we get the final OK that the delay in experiment data availability associated with the fetch->apply on the first run is okay.. I have a demo that I'm recording that will show the timing of things**


#### Notes
- This PR also added a few clean ups with adding the fetch->apply:
   - for example, we no longer need to load experiments from file on the first run if the server's URL is available (i.e in non-dev modes)
   - To allow experiment creators to check if it's the app's first run, this PR exposes the `isFirstRun` field so that it can be reused
- I noticed that our `featureId` for the validation experiment was off? CC: @travis79 I changed it to be `nimbusValidation` because that's what I saw experimenter generating, not sure what implications this has
- For the `onExperimentsApplied` API, I use a list of callbacks and a boolean flag - it's possible to get race conditions **IF** the caller calls this API outside the main thread, I added a warning there. The alternative is to use an atomic flag, but that creates its own can of worms (if the caller is on the main thread, it might block, and I wanted to avoid that)



