### PR TITLE
FXIOS-1739: removed feature flag on start at home. ON by default now

### DIFF
--- a/Client/FeatureFlags/FeatureFlagsManager.swift
+++ b/Client/FeatureFlags/FeatureFlagsManager.swift
@@ -83,7 +83,7 @@ class FeatureFlagsManager {
         let shakeToRestore = FlaggableFeature(withID: .shakeToRestore, and: profile, enabledFor: [.beta, .developer, .other])
         features[.shakeToRestore] = shakeToRestore
         
-        let startAtHome = FlaggableFeature(withID: .startAtHome, and: profile, enabledFor: [.beta, .developer])
+        let startAtHome = FlaggableFeature(withID: .startAtHome, and: profile, enabledFor: [.release, .beta, .developer])
         features[.startAtHome] = startAtHome
     }
 }

--- a/Client/Frontend/Browser/TabManagerStore.swift
+++ b/Client/Frontend/Browser/TabManagerStore.swift
@@ -153,7 +153,7 @@ class TabManagerStore: FeatureFlagsProtocol {
             }
             
             fxHomeTab = tab.isFxHomeTab ? tab : nil
-            customHomeTab = tab.isCustomHomeTab ? customHomeTab : nil
+            customHomeTab = tab.isCustomHomeTab ? tab : nil
         }
 
         if tabToSelect == nil {


### PR DESCRIPTION
# Overview

This PR is in reference to this [JIRA ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-1739). Also, fixed a bug where customHomeTab was incorrectly nil, causing it to open a new home tab instead of using the current home tab from the list of restored tabs. 