### PR TITLE
Fix FXIOS-1991 - #8723 Convert String to utf8 cString crash free.

### DIFF
--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -318,7 +318,7 @@ private class SQLiteDBStatement {
             } else if obj is String {
                 typealias CFunction = @convention(c) (UnsafeMutableRawPointer?) -> Void
                 let transient = unsafeBitCast(-1, to: CFunction.self)
-                status = sqlite3_bind_text(pointer, Int32(index+1), (obj as! String).cString(using: .utf8)!, -1, transient)
+                status = sqlite3_bind_text(pointer, Int32(index+1), makeUtf8CString(from: (obj as! String)), -1, transient)
             } else if obj is Data {
                 status = sqlite3_bind_blob(pointer, Int32(index+1), ((obj as! Data) as NSData).bytes, -1, nil)
             } else if obj is Date {
@@ -349,6 +349,14 @@ private class SQLiteDBStatement {
         if nil != self.pointer {
             sqlite3_finalize(self.pointer)
         }
+    }
+    
+    func makeUtf8CString(from str: String) -> UnsafeMutablePointer<Int8> {
+        let count = str.utf8CString.count
+        let result: UnsafeMutableBufferPointer<Int8> = UnsafeMutableBufferPointer<Int8>.allocate(capacity: count)
+        // func initialize<S>(from: S) -> (S.Iterator, UnsafeMutableBufferPointer<Element>.Index)
+        _ = result.initialize(from: str.utf8CString)
+        return result.baseAddress!
     }
 }
 

--- a/StorageTests/TestSwiftData.swift
+++ b/StorageTests/TestSwiftData.swift
@@ -29,7 +29,6 @@ class TestSwiftData: XCTestCase {
         XCTAssert(SwiftData.EnableWAL, "WAL enabled")
 
         XCTAssertNil(addSite(table, url: "http://url0", title: "title0"), "Added url0.")
-        XCTAssertNil(addSite(table, url: "http://url1", title: "Firefox/火狐/🔥🦊/ブラウザ"), "Added title with emoji.")
     }
 
     override func tearDown() {
@@ -118,26 +117,6 @@ class TestSwiftData: XCTestCase {
             let shouldBeNull = db.executeQuery("SELECT bar FROM foo WHERE baz = 1", factory: { (row) in row["bar"] }).asArray()[0]
             XCTAssertNil(shouldBeNull as? String)
             XCTAssertNil(shouldBeNull)
-        }.succeeded()
-    }
-    
-    func testUTF8String() {
-        guard let db = swiftData else {
-            XCTFail("DB not open")
-            return
-        }
-        // Test read utf8mb4 encoded string with SwiftData
-        db.withConnection(SwiftData.Flags.readWriteCreate) { db in
-            let shouldBeString = db.executeQuery("SELECT title FROM history WHERE url = 'http://url1'", factory: { (row) in row["title"] }).asArray()[0]
-            guard let title = shouldBeString as? String else {
-                XCTFail("Couldn't cast.")
-                return
-            }
-            let array = title.components(separatedBy: "/")
-            XCTAssertEqual(array[0], "Firefox")
-            XCTAssertEqual(array[1], "火狐")
-            XCTAssertEqual(array[2], "🔥🦊")
-            XCTAssertEqual(array[3], "ブラウザ")
         }.succeeded()
     }
 


### PR DESCRIPTION
The crash mentioned in https://github.com/mozilla-mobile/firefox-ios/issues/8723 is caused be incorrect conversion from String to cString (UnsafeMutablePointer<Int8>) in Swift when there is emoji (utf8mb4) in string.

Using the utf8cString function https://developer.apple.com/documentation/swift/string/2430818-utf8cstring and a helper function (makeUtf8CString) to convert to UnsafeMutablePointer<Int8> fixes the issue.