### PR TITLE
Bugfix #8395 Firefox no longer offers to open copied links

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1474,7 +1474,7 @@ extension BrowserViewController: TabDelegate {
 
         let sessionRestoreHelper = SessionRestoreHelper(tab: tab)
         sessionRestoreHelper.delegate = self
-        tab.addContentScript(sessionRestoreHelper, name: SessionRestoreHelper.name())
+        tab.addContentScriptToPage(sessionRestoreHelper, name: SessionRestoreHelper.name())
 
         let findInPageHelper = FindInPageHelper(tab: tab)
         findInPageHelper.delegate = self


### PR DESCRIPTION
# Issue #8395
The root cause is using new 
```
func add(_ scriptMessageHandler: WKScriptMessageHandler, 
contentWorld world: WKContentWorld, 
    name: String)
```
interface with default client content world parameter stopped SessionRestoreHelper from calling `BrowserViewController.sessionRestoreHelper`, so offer of opening copied link stopped working.

I added a new interface to be able to install a script message handler in page content world.

