### PR TITLE
Fix #8864: Can't open links from other apps with capitalised scheme

### DIFF
--- a/Client/Configuration/Common.xcconfig
+++ b/Client/Configuration/Common.xcconfig
@@ -18,6 +18,7 @@ HEADER_SEARCH_PATHS = $(inherited) /Applications/Xcode.app/Contents/Developer/To
 INCLUDE_SETTINGS_BUNDLE = NO
 IPHONEOS_DEPLOYMENT_TARGET = 13.0
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../../Frameworks @executable_path/Frameworks @loader_path/Frameworks
+MOZ_PUBLIC_URL_SCHEME = firefox
 MOZ_TODAY_WIDGET_SEARCH_DISPLAY_NAME = Firefox - Search
 OTHER_LDFLAGS = -ObjC -lxml2
 OTHER_SWIFT_FLAGS_common = -DMOZ_TARGET_CLIENT

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -34,7 +34,7 @@
 			<string>org.mozilla.Client</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>firefox</string>
+				<string>$(MOZ_PUBLIC_URL_SCHEME)</string>
 				<string>$(MOZ_INTERNAL_URL_SCHEME)</string>
 				<string>http</string>
 				<string>https</string>
@@ -73,6 +73,10 @@
 	<true/>
 	<key>MozDevelopmentTeam</key>
 	<string>$(DEVELOPMENT_TEAM)</string>
+	<key>MozInternalURLScheme</key>
+	<string>$(MOZ_INTERNAL_URL_SCHEME)</string>
+	<key>MozPublicURLScheme</key>
+	<string>$(MOZ_PUBLIC_URL_SCHEME)</string>
 	<key>MozWhatsNewTopic</key>
 	<string>whats-new-ios-18</string>
 	<key>NSAppTransportSecurity</key>

--- a/Extensions/Today/Info.plist
+++ b/Extensions/Today/Info.plist
@@ -33,5 +33,7 @@
 	</dict>
 	<key>MozInternalURLScheme</key>
 	<string>$(MOZ_INTERNAL_URL_SCHEME)</string>
+	<key>MozPublicURLScheme</key>
+	<string>$(MOZ_PUBLIC_URL_SCHEME)</string>
 </dict>
 </plist>

--- a/Extensions/Today/TodayModel.swift
+++ b/Extensions/Today/TodayModel.swift
@@ -3,16 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import Shared
 
 struct TodayModel {
     static var copiedURL: URL?
     static var searchedText: String?
 
     var scheme: String {
-        guard let string = Bundle.main.object(forInfoDictionaryKey: "MozInternalURLScheme") as? String else {
-            // Something went wrong/weird, but we should fallback to the public one.
-            return "firefox"
-        }
-        return string
+        return URL.mozInternalScheme
     }
 }

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -351,6 +351,27 @@ extension URL {
     }
 }
 
+// MARK: - Exported URL Schemes
+
+extension URL {
+
+    public static var mozPublicScheme: String = {
+        guard let string = Bundle.main.object(forInfoDictionaryKey: "MozPublicURLScheme") as? String, !string.isEmpty else {
+            // Something went wrong/weird, fall back to hard-coded.
+            return "firefox"
+        }
+        return string
+    }()
+
+    public static var mozInternalScheme: String = {
+        guard let string = Bundle.main.object(forInfoDictionaryKey: "MozInternalURLScheme") as? String, !string.isEmpty else {
+            // Something went wrong/weird, fallback to the public one.
+            return Self.mozPublicScheme
+        }
+        return string
+    }()
+}
+
 // Helpers to deal with ErrorPage URLs
 
 public struct InternalURL {

--- a/WidgetKit/Helpers.swift
+++ b/WidgetKit/Helpers.swift
@@ -5,12 +5,10 @@
 import Foundation
 import SwiftUI
 import UIKit
+import Shared
 
 var scheme: String {
-    guard let string = Bundle.main.object(forInfoDictionaryKey: "MozInternalURLScheme") as? String else {
-        return "firefox"
-    }
-    return string
+    return URL.mozInternalScheme
 }
 
 func linkToContainingApp(_ urlSuffix: String = "", query: String) -> URL {

--- a/WidgetKit/Info.plist
+++ b/WidgetKit/Info.plist
@@ -24,6 +24,8 @@
 	<string>$(DEVELOPMENT_TEAM)</string>
 	<key>MozInternalURLScheme</key>
 	<string>$(MOZ_INTERNAL_URL_SCHEME)</string>
+	<key>MozPublicURLScheme</key>
+	<string>$(MOZ_PUBLIC_URL_SCHEME)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
NavigationPath.init was unable to cope with incoming URLs where the scheme was not all lowercase. As such, attempting to open a url such as "Http://www.apple.com" from the Notes app (or elsewhere) would fail when we are the Default Browser.

NavigationPath.init was too eager to handle 'normal' http[s] URLs as internal ones. i.e "http://glean.mywindows.com" would try to create a glean-based NavigationPath, instead of treating it as a web-url. Now all of our internal URLs have to have a scheme of "firefox" or "$(MozInternalURLScheme)" AND the (lowercased) host of that URL has be an exact match for what we are testing.

As part of this, a new build variable was added, $(MOZ_PUBLIC_URL_SCHEME), which is used instead of hard-coding "firefox" as our public scheme. Its use is analogous to $(MOZ_INTERNAL_URL_SCHEME). An extension to URL was added to read either the public or internal scheme and was used wherever the code used to check the plist itself.
