### PR TITLE
FXIOS-3121: fix toolbar reload button so that it reloads and stops we…

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -18,6 +18,27 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     func tabToolbarDidPressLibrary(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
     }
     
+    func tabToolbarDidPressReload(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
+        tabManager.selectedTab?.reload()
+    }
+    
+    func tabToolbarDidLongPressReload(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
+        guard let tab = tabManager.selectedTab else { return }
+        
+        let urlActions = self.getRefreshLongPressMenu(for: tab)
+        guard !urlActions.isEmpty else { return }
+        
+        let generator = UIImpactFeedbackGenerator(style: .heavy)
+        generator.impactOccurred()
+        let shouldSuppress = UIDevice.current.userInterfaceIdiom != .pad
+        
+        presentSheetWith(actions: [urlActions], on: self, from: button, suppressPopover: shouldSuppress)
+    }
+    
+    func tabToolbarDidPressStop(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
+        tabManager.selectedTab?.stop()
+    }
+    
     func tabToolbarDidPressBack(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
         tabManager.selectedTab?.goBack()
     }

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -32,6 +32,9 @@ protocol TabToolbarDelegate: AnyObject {
     func tabToolbarDidPressForward(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidLongPressBack(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidLongPressForward(_ tabToolbar: TabToolbarProtocol, button: UIButton)
+    func tabToolbarDidPressReload(_ tabToolbar: TabToolbarProtocol, button: UIButton)
+    func tabToolbarDidLongPressReload(_ tabToolbar: TabToolbarProtocol, button: UIButton)
+    func tabToolbarDidPressStop(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressHome(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressMenu(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressBookmarks(_ tabToolbar: TabToolbarProtocol, button: UIButton)
@@ -63,6 +66,14 @@ open class TabToolbarHelper: NSObject {
             middleButtonState = .search
             toolbar.multiStateButton.setImage(ImageSearch, for: .normal)
             toolbar.multiStateButton.accessibilityLabel = .TabToolbarSearchAccessibilityLabel
+        case .reload:
+            middleButtonState = .reload
+            toolbar.multiStateButton.setImage(ImageReload, for: .normal)
+            toolbar.multiStateButton.accessibilityLabel = .TabToolbarReloadAccessibilityLabel
+        case .stop:
+            middleButtonState = .stop
+            toolbar.multiStateButton.setImage(ImageStop, for: .normal)
+            toolbar.multiStateButton.accessibilityLabel = .TabToolbarStopAccessibilityLabel
         default:
             toolbar.multiStateButton.setImage(ImageHome, for: .normal)
             toolbar.multiStateButton.accessibilityLabel = .TabToolbarSearchAccessibilityLabel
@@ -95,6 +106,9 @@ open class TabToolbarHelper: NSObject {
 
         toolbar.multiStateButton.setImage(UIImage.templateImageNamed("nav-refresh"), for: .normal)
         toolbar.multiStateButton.accessibilityLabel = .TabToolbarReloadAccessibilityLabel
+        
+        let longPressMultiStateButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressMultiStateButton))
+        toolbar.multiStateButton.addGestureRecognizer(longPressMultiStateButton)
 
         toolbar.multiStateButton.addTarget(self, action: #selector(didPressMultiStateButton), for: .touchUpInside)
 
@@ -181,7 +195,21 @@ open class TabToolbarHelper: NSObject {
         case .search:
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .startSearchButton)
             toolbar.tabToolbarDelegate?.tabToolbarDidPressSearch(toolbar, button: toolbar.multiStateButton)
-        default: break;
+        case .stop:
+            toolbar.tabToolbarDelegate?.tabToolbarDidPressStop(toolbar, button: toolbar.multiStateButton)
+        case .reload:
+            toolbar.tabToolbarDelegate?.tabToolbarDidPressReload(toolbar, button: toolbar.multiStateButton)
+        }
+    }
+    
+    func didLongPressMultiStateButton(_ recognizer: UILongPressGestureRecognizer) {
+        switch middleButtonState {
+        case .search:
+            return
+        default:
+            if recognizer.state == .began {
+                toolbar.tabToolbarDelegate?.tabToolbarDidLongPressReload(toolbar, button: toolbar.multiStateButton)
+            }
         }
     }
 }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -453,10 +453,8 @@ class URLBarView: UIView {
     func updateReaderModeState(_ state: ReaderModeState) {
         locationView.readerModeState = state
         switch state {
-        case .active:
-            locationView.reloadButton.isHidden = true
-        case .available:
-            locationView.reloadButton.isHidden = true
+        case .active, .available:
+            locationView.reloadButton.isHidden = false
         case .unavailable:
             if (!toolbarIsShowing) { locationView.reloadButton.isHidden = false }
         }

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1139,6 +1139,7 @@ extension String {
     public static let TabToolbarNewTabAccessibilityLabel = MZLocalizedString("New Tab", comment: "Accessibility Label for the tab toolbar New tab button")
     public static let TabToolbarBackAccessibilityLabel = MZLocalizedString("Back", comment: "Accessibility label for the Back button in the tab toolbar.")
     public static let TabToolbarForwardAccessibilityLabel = MZLocalizedString("Forward", comment: "Accessibility Label for the tab toolbar Forward button")
+    public static let TabToolbarHomeAccessibilityLabel = MZLocalizedString("Home", comment: "Accessibility label for the tab toolbar indicating the Home button.")
     public static let TabToolbarNavigationToolbarAccessibilityLabel = MZLocalizedString("Navigation Toolbar", comment: "Accessibility label for the navigation toolbar displayed at the bottom of the screen.")
 }
 


### PR DESCRIPTION
# Overview

This PR addresses [this JIRA](https://mozilla-hub.atlassian.net/browse/FXIOS-3121) and https://github.com/mozilla-mobile/firefox-ios/issues/9053. 

This PR reverts some work from [this commit](https://github.com/mozilla-mobile/firefox-ios/commit/0a0d6952b12e422b87f33ac566c8ec19a452ecef#diff-f7109d74ed152889db5fae8c5d15e3f22e076d71c120d3a3de6378461865f95f).

# Testing
Check on iPad and iPhone landscape mode. 

NOTE: 
Long press on reload is pending, but this PR hits the core blocker issue. 