### PR TITLE
Bugfix #8994 Download Apple Wallet Pass with cookies

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -549,9 +549,10 @@ extension BrowserViewController: WKNavigationDelegate {
         // download via the context menu.
         let canShowInWebView = navigationResponse.canShowMIMEType && (webView != pendingDownloadWebView)
         let forceDownload = webView == pendingDownloadWebView
+        let cookieStore = webView.configuration.websiteDataStore.httpCookieStore
 
         // Check if this response should be handed off to Passbook.
-        if let passbookHelper = OpenPassBookHelper(request: request, response: response, canShowInWebView: canShowInWebView, forceDownload: forceDownload, browserViewController: self) {
+        if let passbookHelper = OpenPassBookHelper(request: request, response: response, cookieStore: cookieStore, canShowInWebView: canShowInWebView, forceDownload: forceDownload, browserViewController: self) {
             // Open our helper and cancel this response from the webview.
             passbookHelper.open()
             decisionHandler(.cancel)
@@ -580,7 +581,6 @@ extension BrowserViewController: WKNavigationDelegate {
         }
 
         // Check if this response should be downloaded.
-        let cookieStore = webView.configuration.websiteDataStore.httpCookieStore
         if let downloadHelper = DownloadHelper(request: request, response: response, cookieStore: cookieStore, canShowInWebView: canShowInWebView, forceDownload: forceDownload, browserViewController: self) {
             // Clear the pending download web view so that subsequent navigations from the same
             // web view don't invoke another download.

--- a/Client/Frontend/Browser/OpenInHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper.swift
@@ -140,7 +140,8 @@ class OpenPassBookHelper: NSObject {
 
     func open() {
         // add webview cookies to download session
-        self.cookieStore.getAllCookies { [self] cookies in
+        self.cookieStore.getAllCookies { [weak self] cookies in
+            guard let self = self else { return }
             for cookie in cookies {
                 self.session.configuration.httpCookieStorage?.setCookie(cookie)
             }
@@ -179,7 +180,7 @@ class OpenPassBookHelper: NSObject {
         let message = .UnableToAddPassErrorMessage + detail
         let alertController = UIAlertController(title: .UnableToAddPassErrorTitle, message: message, preferredStyle: .alert)
         alertController.addAction(UIAlertAction(title: .UnableToAddPassErrorDismiss, style: .cancel) { (action) in
-                // Do nothing.
+            // Do nothing.
         })
         browserViewController.present(alertController, animated: true, completion: nil)
     }

--- a/Client/Frontend/Browser/OpenInHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper.swift
@@ -126,18 +126,35 @@ class OpenPassBookHelper: NSObject {
     fileprivate var url: URL
 
     fileprivate let browserViewController: BrowserViewController
+    fileprivate let cookieStore: WKHTTPCookieStore
+    fileprivate lazy var session = makeURLSession(userAgent: UserAgent.fxaUserAgent, configuration: .ephemeral)
 
-    required init?(request: URLRequest?, response: URLResponse, canShowInWebView: Bool, forceDownload: Bool, browserViewController: BrowserViewController) {
+    required init?(request: URLRequest?, response: URLResponse, cookieStore: WKHTTPCookieStore, canShowInWebView: Bool, forceDownload: Bool, browserViewController: BrowserViewController) {
         guard let mimeType = response.mimeType, mimeType == MIMEType.Passbook, PKAddPassesViewController.canAddPasses(),
             let responseURL = response.url, !forceDownload else { return nil }
         self.url = responseURL
         self.browserViewController = browserViewController
+        self.cookieStore = cookieStore
         super.init()
     }
 
     func open() {
-        guard let passData = try? Data(contentsOf: url) else { return }
-
+        // add webview cookies to download session
+        self.cookieStore.getAllCookies { [self] cookies in
+            for cookie in cookies {
+                self.session.configuration.httpCookieStorage?.setCookie(cookie)
+            }
+            self.session.dataTask(with: self.url) { (data, response, error) in
+                guard let _ = validatedHTTPResponse(response, statusCode: 200..<300), let data = data else {
+                    self.presentErrorAlert()
+                    return
+                }
+                self.open(passData: data)
+            }.resume()
+        }
+    }
+    
+    private func open(passData: Data) {
         do {
             let pass = try PKPass(data: passData)
 
@@ -147,16 +164,24 @@ class OpenPassBookHelper: NSObject {
             } else {
                 if let addController = PKAddPassesViewController(pass: pass) {
                     browserViewController.present(addController, animated: true, completion: nil)
+                } else {
+                    presentErrorAlert(pass: pass)
                 }
             }
         } catch {
-            let alertController = UIAlertController(title: .UnableToAddPassErrorTitle, message: .UnableToAddPassErrorMessage, preferredStyle: .alert)
-            alertController.addAction(UIAlertAction(title: .UnableToAddPassErrorDismiss, style: .cancel) { (action) in
-                    // Do nothing.
-            })
-            browserViewController.present(alertController, animated: true, completion: nil)
+            presentErrorAlert()
             return
         }
+    }
+    
+    private func presentErrorAlert(pass: PKPass? = nil) {
+        let detail = pass == nil ? "" : " \(pass!.localizedName) \(pass!.localizedDescription)"
+        let message = .UnableToAddPassErrorMessage + detail
+        let alertController = UIAlertController(title: .UnableToAddPassErrorTitle, message: message, preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: .UnableToAddPassErrorDismiss, style: .cancel) { (action) in
+                // Do nothing.
+        })
+        browserViewController.present(alertController, animated: true, completion: nil)
     }
 }
 


### PR DESCRIPTION
# Issue #8994
After some test, I found my COVID19 immunization certificate (a PassKit pass) couldn't be downloaded because of missing cookie.

I added cookies from WebView's WKHTTPCookieStore to the pass download URLSession so the pass get downloaded correctly.

If a pass is downloaded and created but couldn't be presented with PKAddPassesViewController, name and description of the pass is added to the end of error message for better troubleshooting.