### PR TITLE
FXIOS-3122: remove home button from app menu

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -91,10 +91,9 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
             }
         }
         
-        let section0 = getHomeAction(vcDelegate: self)
-        var section1 = getLibraryActions(vcDelegate: self)
-        var section2 = getOtherPanelActions(vcDelegate: self)
-        let section3 = getSettingsAction(vcDelegate: self)
+        let section0 = getLibraryActions(vcDelegate: self)
+        var section1 = getOtherPanelActions(vcDelegate: self)
+        let section2 = getSettingsAction(vcDelegate: self)
         
         let optionalActions = [viewLogins, syncAction].compactMap { $0 }
         if !optionalActions.isEmpty {
@@ -102,10 +101,10 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         }
         
         if let whatsNewAction = whatsNewAction {
-            section2.append(whatsNewAction)
+            section1.append(whatsNewAction)
         }
         
-        actions.append(contentsOf: [section0, section1, section2, section3])
+        actions.append(contentsOf: [section0, section1, section2])
 
         presentSheetWith(actions: actions, on: self, from: button)
     }

--- a/Client/Frontend/Widgets/PhotonActionSheet/AppMenu.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/AppMenu.swift
@@ -30,6 +30,7 @@ extension PhotonActionSheetProtocol {
         return [bookmarks, history, downloads, readingList]
     }
     
+    // Not part of AppMenu, but left for future use. 
     func getHomeAction(vcDelegate: Self.PageOptionsVC) -> [PhotonActionSheetItem] {
         guard let tab = self.tabManager.selectedTab else { return [] }
         


### PR DESCRIPTION
# Overview

This PR addresses [this JIRA ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-3122) and https://github.com/mozilla-mobile/firefox-ios/issues/9054.

## Testing
Run the app and hit the app menu icon. Home should not appear in the list. 