### PR TITLE
FXIOS-3120: reload button in locationBar shows in iphone landscape

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -430,7 +430,7 @@ class URLBarView: UIView {
         if !toolbarIsShowing {
             updateConstraintsIfNeeded()
         }
-        locationView.reloadButton.isHidden = toolbarIsShowing
+        locationView.reloadButton.isHidden = false
         updateViewsForOverlayModeAndToolbarChanges()
     }
 
@@ -452,12 +452,7 @@ class URLBarView: UIView {
 
     func updateReaderModeState(_ state: ReaderModeState) {
         locationView.readerModeState = state
-        switch state {
-        case .active, .available:
-            locationView.reloadButton.isHidden = false
-        case .unavailable:
-            if (!toolbarIsShowing) { locationView.reloadButton.isHidden = false }
-        }
+        locationView.reloadButton.isHidden = false
     }
 
     func setAutocompleteSuggestion(_ suggestion: String?) {
@@ -714,7 +709,8 @@ extension URLBarView: TabLocationViewDelegate {
     }
 
     func tabLocationViewDidTapReload(_ tabLocationView: TabLocationView) {
-        let state = locationView.reloadButton.reloadButtonState
+        let state = locationView.reloadButton.isHidden ? locationView.reloadButton.reloadButtonState : .reload
+        
         switch state {
         case .reload:
             delegate?.urlBarDidPressReload(self)


### PR DESCRIPTION
# Overview
This PR addresses [this JIRA ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-3120) and https://github.com/mozilla-mobile/firefox-ios/issues/9052.

## Testing
Follow steps in the issue above, and make sure reload shows. 