### PR TITLE
FXIOS-3117: fix constraints issue on ETP menu

### DIFF
--- a/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
+++ b/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
@@ -279,7 +279,7 @@ class EnhancedTrackingProtectionMenuVC: UIViewController {
             toggleContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             toggleContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             toggleContainer.topAnchor.constraint(equalTo: connectionView.bottomAnchor, constant: 32),
-            toggleContainer.heightAnchor.constraint(greaterThanOrEqualToConstant: 92),
+            toggleContainer.heightAnchor.constraint(equalToConstant: 92),
 
             toggleView.leadingAnchor.constraint(equalTo: toggleContainer.leadingAnchor, constant: ETPMenuUX.UX.gutterDistance),
             toggleView.trailingAnchor.constraint(equalTo: toggleContainer.trailingAnchor, constant: -ETPMenuUX.UX.gutterDistance),


### PR DESCRIPTION
# Overview
This PR addresses [this JIRA ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-3117) and https://github.com/mozilla-mobile/firefox-ios/issues/9049. 

## Testing
On iPhone, change orientation after hitting the lock button. 