### PR TITLE
FXIOS-3116: toggle label adjustments for languages on etp menu

### DIFF
--- a/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
+++ b/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
@@ -108,7 +108,8 @@ class EnhancedTrackingProtectionMenuVC: UIViewController {
 
     private let toggleLabel: UILabel = .build { label in
         label.font = ETPMenuUX.Fonts.viewTitleLabels
-        label.numberOfLines = 0
+        label.adjustsFontSizeToFitWidth = true
+        label.numberOfLines = 2
     }
 
     private let toggleSwitch: UISwitch = .build { toggleSwitch in
@@ -279,7 +280,8 @@ class EnhancedTrackingProtectionMenuVC: UIViewController {
             toggleContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             toggleContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             toggleContainer.topAnchor.constraint(equalTo: connectionView.bottomAnchor, constant: 32),
-            toggleContainer.heightAnchor.constraint(greaterThanOrEqualToConstant: 92),
+            toggleContainer.heightAnchor.constraint(equalToConstant: 92),
+            toggleContainer.widthAnchor.constraint(equalTo: view.widthAnchor),
 
             toggleView.leadingAnchor.constraint(equalTo: toggleContainer.leadingAnchor, constant: ETPMenuUX.UX.gutterDistance),
             toggleView.trailingAnchor.constraint(equalTo: toggleContainer.trailingAnchor, constant: -ETPMenuUX.UX.gutterDistance),
@@ -291,6 +293,7 @@ class EnhancedTrackingProtectionMenuVC: UIViewController {
             toggleLabel.centerYAnchor.constraint(equalTo: toggleView.centerYAnchor),
             toggleLabel.topAnchor.constraint(equalTo: toggleView.topAnchor, constant: 11),
             toggleLabel.bottomAnchor.constraint(equalTo: toggleView.bottomAnchor, constant: -11),
+            toggleLabel.widthAnchor.constraint(equalTo: toggleView.widthAnchor, multiplier: 0.80),
 
             toggleSwitch.centerYAnchor.constraint(equalTo: toggleView.centerYAnchor),
             toggleSwitch.trailingAnchor.constraint(equalTo: toggleView.trailingAnchor, constant: -ETPMenuUX.UX.gutterDistance),


### PR DESCRIPTION
# Overview
This PR addresses [this JIRA ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-3116) and https://github.com/mozilla-mobile/firefox-ios/issues/9048. 

## Testing
Hit the lock icon and check the label. 