### PR TITLE
Fix unexpected white color in chronological tabs close confirm menu

### DIFF
--- a/Client/Frontend/Browser/Tabs/ChronologicalTabsViewController.swift
+++ b/Client/Frontend/Browser/Tabs/ChronologicalTabsViewController.swift
@@ -151,7 +151,6 @@ extension ChronologicalTabsViewController {
         let controller = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         controller.addAction(UIAlertAction(title: Strings.AppMenuCloseAllTabsTitleString, style: .default, handler: { _ in self.viewModel.closeTabsForCurrentTray() }), accessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
         controller.addAction(UIAlertAction(title: Strings.CancelString, style: .cancel, handler: nil), accessibilityIdentifier: "TabTrayController.deleteButton.cancel")
-        controller.view.tintColor = UIColor.white
         controller.popoverPresentationController?.barButtonItem = sender
         present(controller, animated: true, completion: nil)
         TelemetryWrapper.recordEvent(category: .action, method: .deleteAll, object: .tab, value: viewModel.isInPrivateMode ? .privateTab : .normalTab)


### PR DESCRIPTION
Wrong menu color can be seen when tapping delete tabs button on chronological tabs view.

This PR tries to fix this issue, just making it the default tint color, identical with grid tabs view.

![IMG_0002](https://user-images.githubusercontent.com/8158163/132101877-4f413ba6-7e24-495b-9eb7-e697a1a9a304.PNG)