### PR TITLE
FXIOS-2621: dismiss overlay mode when tapped, allow first taps to dismiss

### DIFF
--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -171,6 +171,7 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
     private var tapGestureRecognizer: UITapGestureRecognizer {
         let dismissOverlay = UITapGestureRecognizer(target: self, action: #selector(dismissOverlayMode))
         dismissOverlay.name = FxHomeDevStrings.GestureRecognizers.dismissOverlay
+        dismissOverlay.cancelsTouchesInView = false
         
         return dismissOverlay
     }


### PR DESCRIPTION
# Overview
This PR addresses [this JIRA ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-2621) and https://github.com/mozilla-mobile/firefox-ios/issues/7608. 

This is a part 2 PR to https://github.com/mozilla-mobile/firefox-ios/pull/9059.

## Testing
In FirefoxHomeVC, in overlay mode, tap anywhere outside the cells (but still in the collectionView) to exit overlay mode. You can also scroll to dismiss it. 