### PR TITLE
Fixes #9089 - Capture telemetry about installed Mozilla products

### DIFF
--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -246,8 +246,8 @@ class TelemetryWrapper {
         // System theme enabled
         GleanMetrics.Theme.useSystemTheme.set(ThemeManager.instance.systemThemeIsOn)
         // Installed Mozilla applications
-        GleanMetrics.MozillaProducts.focus.set(UIApplication.shared.canOpenURL(URL(string: "firefox-focus://")!))
-        GleanMetrics.MozillaProducts.klar.set(UIApplication.shared.canOpenURL(URL(string: "firefox-klar://")!))
+        GleanMetrics.InstalledMozillaProducts.focus.set(UIApplication.shared.canOpenURL(URL(string: "firefox-focus://")!))
+        GleanMetrics.InstalledMozillaProducts.klar.set(UIApplication.shared.canOpenURL(URL(string: "firefox-klar://")!))
     }
 
     @objc func uploadError(notification: NSNotification) {

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -245,6 +245,9 @@ class TelemetryWrapper {
         }
         // System theme enabled
         GleanMetrics.Theme.useSystemTheme.set(ThemeManager.instance.systemThemeIsOn)
+        // Installed Mozilla applications
+        GleanMetrics.MozillaProducts.focus.set(UIApplication.shared.canOpenURL(URL(string: "firefox-focus://")!))
+        GleanMetrics.MozillaProducts.klar.set(UIApplication.shared.canOpenURL(URL(string: "firefox-klar://")!))
     }
 
     @objc func uploadError(notification: NSNotification) {

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -1444,3 +1444,35 @@ browser_search:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2022-02-09"
+
+mozilla_products:
+  klar:
+    type: boolean
+    lifetime: application
+    description: |
+       If Klar is installed on the users's device.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/9089
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+    data_sensitivity:
+      - technical
+      - interaction
+    notification_emails:
+      - firefox-ios@mozilla.com
+    expires: "2022-09-01"
+  focus:
+    type: boolean
+    lifetime: application
+    description: |
+       If Focus is installed on the users's device.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/9089
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+    data_sensitivity:
+      - technical
+      - interaction
+    notification_emails:
+      - firefox-ios@mozilla.com
+    expires: "2022-09-01"

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -1445,7 +1445,7 @@ browser_search:
       - fx-ios-data-stewards@mozilla.com
     expires: "2022-02-09"
 
-mozilla_products:
+installed_mozilla_products:
   klar:
     type: boolean
     lifetime: application

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -1454,12 +1454,12 @@ mozilla_products:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/9089
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/9090
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - firefox-ios@mozilla.com
+      - fx-ios-data-stewards@mozilla.com
     expires: "2022-09-01"
   focus:
     type: boolean
@@ -1469,10 +1469,10 @@ mozilla_products:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/9089
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/9090
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - firefox-ios@mozilla.com
+      - fx-ios-data-stewards@mozilla.com
     expires: "2022-09-01"


### PR DESCRIPTION
This patch introduces the `installed_mozilla_products.focus` and `installed_mozilla_products.klar` metrics that allow us to understand if users of FIrefox iOS also have Focus or Klar installed.

I've added the recording of these metrics to `TelemetryWrapper.recordPreferenceMetrics`, which will run on background to make sure we do not add any additional time to startup.

# Request for data collection review form

**All questions are mandatory. You must receive review from a data steward peer on your responses to these questions before shipping new data collection.**

_1) What questions will you answer with this data?_

This will answer the question if Focus users also have Focus or Klar installed.

_2) Why does Mozilla need to answer these questions?  Are there benefits for users? Do we need this information to address product or business requirements?_

This will provide us with info regarding the user base for Firefox.

_3) What alternative methods did you consider to answer these questions? Why were they not sufficient?_

This is the only way.

_4) Can current instrumentation answer these questions?_

No. We need a new specific event for a specific app feature.

_5) List all proposed measurements and indicate the category of data collection for each measurement, using the [Firefox data collection categories](https://wiki.mozilla.org/Firefox/Data_Collection) found on the Mozilla wiki._

_**Note that the data steward reviewing your request will characterize your data collection based on the highest (and most sensitive) category.**_

<table>
  <tr>
    <td>Measurement Description</td>
    <td>Data Collection Category</td>
    <td>Tracking Bug #</td>
  </tr>
  <tr>
    <td>Is Focus installed</td>
    <td>Category 2</td>
    <td>#9089</td>
  </tr>
  <tr>
    <td>Is Klar installed</td>
    <td>Category 2</td>
    <td>#9089</td>
  </tr>
</table>

_6) How long will this data be collected?  Choose one of the following:_

Until 2022-09-01.

_7) What populations will you measure?_

All release channels and locales.

_8) If this data collection is default on, what is the opt-out mechanism for users?_

Users can opt of of data collection by disabling Usage and technical data from _Settings → Send Usage Data_.

_9) Please provide a general description of how you will analyze this data._

Glean 

_10) Where do you intend to share the results of your analysis?_

Only on Glean, mobile teams and BD have internal access.

_12) Is there a third-party tool (i.e. not Telemetry) that you are proposing to use for this data collection?_

No.
