### PR TITLE
FXIOS-2790 Check webView before add print activity

### DIFF
--- a/Client/Frontend/Browser/TabPrintPageRenderer.swift
+++ b/Client/Frontend/Browser/TabPrintPageRenderer.swift
@@ -27,8 +27,8 @@ class TabPrintPageRenderer: UIPrintPageRenderer {
         self.footerHeight = PrintedPageUX.PageMarginScale * PrintedPageUX.PageInsets
         self.headerHeight = PrintedPageUX.PageMarginScale * PrintedPageUX.PageInsets
 
-        if let tab = self.tab {
-            let formatter = tab.webView!.viewPrintFormatter()
+        if let tab = self.tab, let webview = tab.webView {
+            let formatter = webview.viewPrintFormatter()
             formatter.perPageContentInsets = UIEdgeInsets(top: PrintedPageUX.PageInsets, left: PrintedPageUX.PageInsets, bottom: PrintedPageUX.PageInsets, right: PrintedPageUX.PageInsets)
             addPrintFormatter(formatter, startingAtPageAt: 0)
         }

--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -31,7 +31,8 @@ class ShareExtensionHelper: NSObject {
         printInfo.outputType = .general
         activityItems.append(printInfo)
 
-        if let tab = selectedTab {
+        // when tab is not loaded (webView != nil) don't show print activity
+        if let tab = selectedTab, tab.webView != nil {
             activityItems.append(TabPrintPageRenderer(tab: tab))
         }
 


### PR DESCRIPTION
Force unwrap of `tab.webView` causes crash when share an unloaded tab.

A nil check is added in `ShareExtensionHelp`. When tab.webView is nil the Print Activity won't be added.

Also nil check added in `TabPrintPageRenderer` in case this is called from other places without webView==nil check. When this happens, blank print page is generated without crashing the app.