### PR TITLE
FXIOS-3143 Show "not secure" icon for domain with added certificate.

### DIFF
--- a/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVM.swift
+++ b/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVM.swift
@@ -33,7 +33,7 @@ class EnhancedTrackingProtectionMenuVM {
     }
 
     var connectionSecure: Bool {
-        return tab.webView?.hasOnlySecureContent ?? false
+        return tab.isSecureConnection
     }
 
     var isSiteETPEnabled: Bool {

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -187,6 +187,13 @@ class Tab: NSObject {
         }
         return false
     }
+    
+    var isSecureConnection: Bool {
+        let secure = webView?.hasOnlySecureContent ?? false
+        guard let profile = self.browserViewController?.profile,
+              let origin = webView?.url?.originForCertificate else { return secure }
+        return secure && (!profile.certStore.hasAddedCertificate(forOrigin: origin))
+    }
 
     var mimeType: String?
     var isEditing: Bool = false

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -385,7 +385,7 @@ extension TabLocationView: TabEventHandler {
 
         var lockImage: UIImage
         let imageID = ThemeManager.instance.currentName == .dark ? "lock_blocked_dark" : "lock_blocked"
-        if !(tab.webView?.hasOnlySecureContent ?? false) {
+        if !(tab.isSecureConnection) {
             lockImage = UIImage(imageLiteralResourceName: imageID)
 
         } else {

--- a/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
+++ b/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
@@ -299,8 +299,7 @@ extension ErrorPageHelper: TabContentScript {
             UIApplication.shared.open(originalURL, options: [:])
         case MessageCertVisitOnce:
             if let cert = certFromErrorURL(errorURL),
-                let host = originalURL.host {
-                let origin = "\(host):\(originalURL.port ?? 443)"
+                let origin = originalURL.originForCertificate {
                 certStore?.addCertificate(cert, forOrigin: origin)
                 message.webView?.replaceLocation(with: originalURL)
                 // webview.reload will not change the error URL back to the original URL

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -136,6 +136,13 @@ extension URL {
         return nil
     }
 
+    public var originForCertificate: String? {
+        if let host = self.host {
+            return "\(host):\(port ?? 443)"
+        }
+        return nil
+    }
+
     public var origin: String? {
         guard isWebPage(includeDataURIs: false), let hostPort = self.hostPort, let scheme = scheme else {
             return nil

--- a/Storage/CertStore.swift
+++ b/Storage/CertStore.swift
@@ -23,6 +23,13 @@ open class CertStore {
         return keys.contains(key)
     }
 
+    open func hasAddedCertificate(forOrigin origin: String) -> Bool {
+        return keys.first(where: { key in
+            let subs = key.split(separator: "/")
+            return subs.count > 0 ? (subs[0] == origin) : false
+        }) != nil
+    }
+
     fileprivate func keyForData(_ data: Data, origin: String) -> String {
         return "\(origin)/\(data.sha256.hexEncodedString)"
     }


### PR DESCRIPTION
Currently only `WebView.hasOnlySecureContent` is used for checking connection is secure or not. This returns true if certificate is added by user (via error page: Advanced - Visit site anyway).

A check function of origin added by user to `CertStore` is added. If so, unlocked icon is displayed when checking with newly added `Tab.isSecureConnection`.