### PR TITLE
FXIOS-3142 Treat search term with only one dot not host name.

### DIFF
--- a/Client/Frontend/Browser/URIFixup.swift
+++ b/Client/Frontend/Browser/URIFixup.swift
@@ -27,10 +27,10 @@ class URIFixup {
         }
 
         // If there's no scheme, we're going to prepend "http://". First,
-        // make sure there's at least one "." in the host. This means
+        // make sure there's at least two "." in the host. This means
         // we'll allow single-word searches (e.g., "foo") at the expense
         // of breaking single-word hosts without a scheme (e.g., "localhost").
-        if trimmed.range(of: ".") == nil {
+        if trimmed.components(separatedBy: ".").count <= 2 {
             return nil
         }
 

--- a/Client/Frontend/Browser/URIFixup.swift
+++ b/Client/Frontend/Browser/URIFixup.swift
@@ -27,10 +27,15 @@ class URIFixup {
         }
 
         // If there's no scheme, we're going to prepend "http://". First,
-        // make sure there's at least two "." in the host. This means
+        // make sure there's at least one "." in the host. This means
         // we'll allow single-word searches (e.g., "foo") at the expense
         // of breaking single-word hosts without a scheme (e.g., "localhost").
-        if trimmed.components(separatedBy: ".").count <= 2 {
+        if trimmed.range(of: ".") == nil {
+            return nil
+        }
+
+        // For number like "123.45", we'd rather not fixup as "123.0.0.45"
+        if Double(trimmed) != nil {
             return nil
         }
 

--- a/ClientTests/SearchTests.swift
+++ b/ClientTests/SearchTests.swift
@@ -38,6 +38,8 @@ class SearchTests: XCTestCase {
         checkInvalidURL("foo bar")
         checkInvalidURL("mozilla. org")
         checkInvalidURL("123")
+        checkInvalidURL("123.45")
+        checkInvalidURL("-9.0")
         checkInvalidURL("a/b")
         checkInvalidURL("创业咖啡")
         checkInvalidURL("创业咖啡 中国")


### PR DESCRIPTION
Make URIFixup not return URL if entry text has 1 or 0 `.` character.