### PR TITLE
FXIOS-2936: disallow toast when closing all private tabs from gridView

### DIFF
--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -306,7 +306,7 @@ extension GridTabViewController {
     func closeTabsForCurrentTray() {
         let tabs = self.tabDisplayManager.dataStore.compactMap { $0 }
         let maxTabs = 100
-        if tabs.count >= maxTabs {
+        if tabs.count >= maxTabs || tabs.first?.isPrivate ?? false {
             self.tabManager.removeTabsAndAddNormalTab(tabs)
         } else {
             self.tabManager.removeTabsWithToast(tabs)


### PR DESCRIPTION
# Overview

PR in reference to [this JIRA](https://mozilla-hub.atlassian.net/browse/FXIOS-2936), and https://github.com/mozilla-mobile/firefox-ios/issues/8818.

## Testing
Press the trash icon in gridTabView in private tabs, and see to it there's no toast allowing you to undo that action. 