### PR TITLE
Bitrise - wait until logs are ready for L10n

### DIFF
--- a/taskcluster/scripts/bitrise-schedule.py
+++ b/taskcluster/scripts/bitrise-schedule.py
@@ -176,7 +176,15 @@ async def download_log(client, build_slug, artifacts_directory):
     suffix = f"builds/{build_slug}/log"
     url = BITRISE_URL_TEMPLATE.format(suffix=suffix)
 
-    response = await do_http_request_json(client, url)
+    while True:
+        response = await do_http_request_json(client, url)
+        if response["is_archived"] == True:
+            log.info("Log is now ready")
+            break
+        else:
+            log.info("Log is still running. Waiting another minute...")
+            await asyncio.sleep(60)
+
     download_url = response["expiring_raw_log_url"]
     if download_url:
         await download_file(download_url, os.path.join(artifacts_directory, "bitrise.log"))


### PR DESCRIPTION
Something similar happened on Focus after latest changes on Bitrise. The GET requests logs but they are not ready yet and so the [Taskcluster task](https://firefox-ci-tc.services.mozilla.com/tasks/OmHuvWvMQleiVdqPWcVDog/runs/1/logs/public/logs/live.log) fails even though the [Bitrise build](https://app.bitrise.io/build/d41e167f-7c92-4d2c-80b1-d0a8438bf74a#?tab=log) was successful.
We added this retry mechanism to be sure the logs are ready before moving to the next step.
