### PR TITLE
FXIOS-3166: Pull to refresh pages

### DIFF
--- a/Client/FeatureFlags/FeatureFlagsManager.swift
+++ b/Client/FeatureFlags/FeatureFlagsManager.swift
@@ -20,6 +20,7 @@ enum FeatureFlagName: String, CaseIterable {
     case groupedTabs
     case jumpBackIn
     case nimbus
+    case pullToRefresh
     case recentlySaved
     case shakeToRestore
     case startAtHome
@@ -80,6 +81,9 @@ class FeatureFlagsManager {
         /// `Experiments.shared` provides access to Nimbus. If false, it is a dummy object.
         let nimbus = FlaggableFeature(withID: .nimbus, and: profile, enabledFor: [.release, .beta, .developer])
         features[.nimbus] = nimbus
+        
+        let pullToRefresh = FlaggableFeature(withID: .pullToRefresh, and: profile, enabledFor: [.beta, .developer])
+        features[.pullToRefresh] = pullToRefresh
 
         let recentlySaved = FlaggableFeature(withID: .recentlySaved, and: profile, enabledFor: [.beta, .developer])
         features[.recentlySaved] = recentlySaved

--- a/Client/FeatureFlags/FlaggableFeature.swift
+++ b/Client/FeatureFlags/FlaggableFeature.swift
@@ -67,6 +67,8 @@ struct FlaggableFeature {
             return PrefsKeys.KeyEnableGroupedTabs
         case .jumpBackIn:
             return PrefsKeys.jumpBackInSectionEnabled
+        case .pullToRefresh:
+            return PrefsKeys.PullToRefresh
         case .recentlySaved:
             return PrefsKeys.recentlySavedSectionEnabled
         case .startAtHome:

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -610,7 +610,12 @@ class Tab: NSObject {
             restore(webView)
         }
     }
-
+    
+    @objc func reloadPage() {
+        reload()
+        self.webView?.scrollView.refreshControl?.endRefreshing()
+    }
+    
     func addContentScript(_ helper: TabContentScript, name: String) {
         contentScriptManager.addContentScript(helper, name: name, forTab: self)
     }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -601,6 +601,25 @@ class ToggleJumpBackInSection: HiddenSetting, FeatureFlagsProtocol {
     }
 }
 
+class TogglePullToRefresh: HiddenSetting, FeatureFlagsProtocol {
+    override var title: NSAttributedString? {
+        let toNewStatus = featureFlags.isFeatureActive(.pullToRefresh) ? "OFF" : "ON"
+        return NSAttributedString(string: "Debug: Toggle Pull to Refresh \(toNewStatus)",
+                                  attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        featureFlags.toggle(.pullToRefresh)
+        updateCell(navigationController)
+    }
+
+    func updateCell(_ navigationController: UINavigationController?) {
+        let controller = navigationController?.topViewController
+        let tableView = (controller as? AppSettingsTableViewController)?.tableView
+        tableView?.reloadData()
+    }
+}
+
 class ToggleRecentlySavedSection: HiddenSetting, FeatureFlagsProtocol {
     override var title: NSAttributedString? {
         let toNewStatus = featureFlags.isFeatureActive(.recentlySaved) ? "OFF" : "ON"

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -144,6 +144,7 @@ class AppSettingsTableViewController: SettingsTableViewController {
                 ToggleChronTabs(settings: self),
                 ToggleJumpBackInSection(settings: self),
                 ToggleRecentlySavedSection(settings: self),
+                TogglePullToRefresh(settings: self),
                 ToggleStartAtHome(settings: self),
                 ToggleInactiveTabs(settings: self),
                 ToggleGroupedTabs(settings: self),

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -280,6 +280,7 @@ extension TelemetryWrapper {
         case foreground = "foreground"
         case open = "open"
         case press = "press"
+        case pull = "pull"
         case scan = "scan"
         case share = "share"
         case tap = "tap"
@@ -386,6 +387,7 @@ extension TelemetryWrapper {
         case recentlySavedBookmarkImpressions = "recently-saved-bookmark-impressions"
         case recentlySavedReadingItemImpressions = "recently-saved-reading-items-impressions"
         case inactiveTabTray = "inactiveTabTray"
+        case reload = "reload"
     }
 
     public enum EventValue: String {
@@ -511,6 +513,8 @@ extension TelemetryWrapper {
             GleanMetrics.Tabs.openTabTray.record()
         case (.action, .close, .tabTray, _, _):
             GleanMetrics.Tabs.closeTabTray.record()
+        case(.action, .pull, .reload, _, _):
+            GleanMetrics.Tabs.pullToRefresh.add()
         // Settings Menu
         case (.action, .open, .settingsMenuSetAsDefaultBrowser, _, _):
             GleanMetrics.SettingsMenu.setAsDefaultBrowserPressed.add()

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -1220,6 +1220,18 @@ tabs:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2022-01-01"
+  pull_to_refresh:
+    type: counter
+    description: |
+      Record the number of times a user pulls down
+      on a page to reload.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-3166
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/9136
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2022-01-01"
 
 # Theme metrics
 theme:

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -39,6 +39,7 @@ public struct PrefsKeys {
     public static let KeyCurrentInstallVersion = "KeyCurrentInstallVersion"
     public static let KeySecondRun = "SecondRun"
     public static let StartAtHome = "startAtHome"
+    public static let PullToRefresh = "pullToRefresh"
     
     // Activity Stream
     public static let KeyTopSitesCacheIsValid = "topSitesCacheIsValid"


### PR DESCRIPTION
# Overview

PR in reference to this [JIRA ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-3166) and https://github.com/mozilla-mobile/firefox-ios/issues/9118.

Pull down from the top of a webpage to refresh. 