### PR TITLE
FXIOS-3175 Fix incorrect add button trailing alignment.

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -307,7 +307,7 @@ class URLBarView: UIView {
         }
         
         addNewTabButton.snp.makeConstraints { make in
-            make.trailing.equalTo(self.homeButton.snp.leading)
+            make.trailing.equalTo(self.tabsButton.snp.leading)
             make.centerY.equalTo(self)
             make.size.equalTo(URLBarViewUX.ButtonHeight)
         }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -521,7 +521,7 @@ class URLBarView: UIView {
         cancelButton.isHidden = false
         showQRScannerButton.isHidden = false
         progressBar.isHidden = false
-        addNewTabButton.isHidden = !toolbarIsShowing || !topTabsIsShowing
+        addNewTabButton.isHidden = !toolbarIsShowing || topTabsIsShowing
         appMenuButton.isHidden = !toolbarIsShowing
         homeButton.isHidden = !toolbarIsShowing || !topTabsIsShowing
         bookmarksButton.isHidden = !toolbarIsShowing || !topTabsIsShowing
@@ -569,7 +569,7 @@ class URLBarView: UIView {
         cancelButton.isHidden = !inOverlayMode
         showQRScannerButton.isHidden = !inOverlayMode
         progressBar.isHidden = inOverlayMode
-        addNewTabButton.isHidden = !toolbarIsShowing || inOverlayMode
+        addNewTabButton.isHidden = !toolbarIsShowing || topTabsIsShowing || inOverlayMode
         appMenuButton.isHidden = !toolbarIsShowing || inOverlayMode
         bookmarksButton.isHidden = !toolbarIsShowing || inOverlayMode || !topTabsIsShowing
         forwardButton.isHidden = !toolbarIsShowing || inOverlayMode


### PR DESCRIPTION
### Overview

This PR is in reference to [this issue](https://github.com/mozilla-mobile/firefox-ios/issues/9130)

The fix updated an incorrect alignment between Add button and Tabs button on URL bar.

![Simulator Screen Shot - iPhone 11 - 2021-09-19 at 20 57 24](https://user-images.githubusercontent.com/283495/133925061-2e58e07d-6490-4b27-9ce3-a50a17bc2efa.png)
