### PR TITLE
FXIOS-3116: Set pull to refresh ON by default in prod

### DIFF
--- a/Client/FeatureFlags/FeatureFlagsManager.swift
+++ b/Client/FeatureFlags/FeatureFlagsManager.swift
@@ -82,7 +82,7 @@ class FeatureFlagsManager {
         let nimbus = FlaggableFeature(withID: .nimbus, and: profile, enabledFor: [.release, .beta, .developer])
         features[.nimbus] = nimbus
         
-        let pullToRefresh = FlaggableFeature(withID: .pullToRefresh, and: profile, enabledFor: [.beta, .developer])
+        let pullToRefresh = FlaggableFeature(withID: .pullToRefresh, and: profile, enabledFor: [.release ,.beta, .developer])
         features[.pullToRefresh] = pullToRefresh
 
         let recentlySaved = FlaggableFeature(withID: .recentlySaved, and: profile, enabledFor: [.beta, .developer])


### PR DESCRIPTION
# Overview

PR in reference to https://github.com/mozilla-mobile/firefox-ios/issues/9118. Consider it a part 2, just to enable this feature ON by default in Prod. 