### PR TITLE
Bugfix FXIOS-3142 [vXXX] URIFixup does not handle invalid URLs correctly

### DIFF
--- a/ClientTests/SearchTests.swift
+++ b/ClientTests/SearchTests.swift
@@ -29,9 +29,13 @@ class SearchTests: XCTestCase {
         checkValidURL("about: config", afterFixup: "about:%20config")
         checkValidURL("file:///f/o/o", afterFixup: "file:///f/o/o")
         checkValidURL("ftp://ftp.mozilla.org", afterFixup: "ftp://ftp.mozilla.org")
-        checkValidURL("foo.bar", afterFixup: "http://foo.bar")
+        checkValidURL("foo.Bar", afterFixup: "http://foo.Bar")
         checkValidURL(" foo.bar ", afterFixup: "http://foo.bar")
         checkValidURL("1.2.3", afterFixup: "http://1.2.3")
+        checkValidURL("iconic.sydney", afterFixup: "http://iconic.sydney")
+        checkValidURL("localhost:4242/test-fixture/test-example.html", afterFixup: "http://localhost:4242/test-fixture/test-example.html")
+        checkValidURL("localhost", afterFixup: "http://localhost")
+        checkValidURL("LoCalhOsT/foo", afterFixup: "http://LoCalhOsT/foo")
 
         // Check invalid URLs. These are passed along to the default search engine.
         checkInvalidURL("foobar")
@@ -45,7 +49,11 @@ class SearchTests: XCTestCase {
         checkInvalidURL("about:")
         checkInvalidURL("javascript:")
         checkInvalidURL("ftp:")
-        
+        checkInvalidURL("127.1")
+        checkInvalidURL("999.")
+        checkInvalidURL("-.05")
+        checkInvalidURL("+2.1.0")
+        checkInvalidURL("apple.iphone") // suffix not in Public Suffix List
     }
 
     func testURIFixupPunyCode() {


### PR DESCRIPTION
This PR fixes issue #9085 . The following rules applied.

* Enable "localhost" as valid URI host (copy default desktop FF setting).
* Do not fixup URI if entry is valid floating number.
* Do not fixup URI if entry's suffix is in Public Suffix List (while it's not a likely IPv4 address)