### PR TITLE
Tab tray UX and crash fixes

### DIFF
--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -100,16 +100,33 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
     }
     
     func focusTab() {
-        guard let currentTab = tabManager.selectedTab, let index = self.tabDisplayManager.dataStore.index(of: currentTab) else { return }
-        let indexPath = IndexPath(item: index, section: 0)
-        guard var rect = self.collectionView.layoutAttributesForItem(at: indexPath)?.frame else { return }
-        if index >= self.tabDisplayManager.dataStore.count - 2 {
+        guard let selectedTab = tabManager.selectedTab else { return }
+
+        // scroll to group
+        if let tabGroup = tabDisplayManager.tabGroups, tabGroup.count > 0, let tabIndex = tabDisplayManager.indexOfGroupTab(tab: selectedTab) {
+            let groupName = tabIndex.groupName            
+            let indexOfTabGroup: Int = Array(tabGroup.keys).firstIndex(of: groupName) ?? 0
+            let offSet =  Int(GroupedTabCell.defaultCellHeight) * indexOfTabGroup
+            let rect = CGRect(origin: CGPoint(x: 0, y: offSet), size: CGSize(width:  self.collectionView.frame.width, height: self.collectionView.frame.height))
             DispatchQueue.main.async {
-                rect.origin.y += 10
                 self.collectionView.scrollRectToVisible(rect, animated: false)
+
             }
-        } else {
-            self.collectionView.scrollToItem(at: indexPath, at: [.centeredVertically, .centeredHorizontally] , animated: false)
+            return
+        }
+
+        // scroll to regular tab
+        if let indexOfRegularTab = tabDisplayManager.indexOfRegularTab(tab: selectedTab) {
+            let indexPath = IndexPath(item: indexOfRegularTab, section: TabDisplaySection.regularTabs.rawValue)
+            guard var rect = self.collectionView.layoutAttributesForItem(at: indexPath)?.frame else { return }
+            if indexOfRegularTab >= self.tabDisplayManager.dataStore.count - 2 {
+                DispatchQueue.main.async {
+                    rect.origin.y += 10
+                    self.collectionView.scrollRectToVisible(rect, animated: false)
+                }
+            } else {
+                self.collectionView.scrollToItem(at: indexPath, at: [.centeredVertically, .centeredHorizontally] , animated: false)
+            }
         }
     }
 

--- a/Client/Frontend/Browser/Tabs/GroupedTabCell.swift
+++ b/Client/Frontend/Browser/Tabs/GroupedTabCell.swift
@@ -222,12 +222,12 @@ class GroupedTabContainerCell: UITableViewCell, UICollectionViewDelegateFlowLayo
         bringSubviewToFront(containerView)
         
         containerView.snp.makeConstraints { make in
-            make.height.equalTo(230)
+            make.height.equalTo(233)
             make.edges.equalToSuperview()
         }
         
         titleLabel.snp.makeConstraints { make in
-            make.height.equalTo(20)
+            make.height.equalTo(23)
             make.top.equalToSuperview().offset(30)
             make.leading.equalTo(self.safeArea.leading).inset(20)
             make.centerX.equalToSuperview()
@@ -292,7 +292,7 @@ class GroupedTabContainerCell: UITableViewCell, UICollectionViewDelegateFlowLayo
         let isIpad = UIDevice.current.userInterfaceIdiom == .pad
         let padding = isIpad && !UIWindow.isLandscape ? 75 : (isIpad && UIWindow.isLandscape) ? 105 : 10
         let width = (Int(cellWidth) - padding) >= 0 ? Int(cellWidth) - padding : 0
-        return CGSize(width: width, height: 185)
+        return CGSize(width: width, height: 188)
     }
 
     @objc func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {


### PR DESCRIPTION
- Fixed crash when regular tab is moved in tab tray
- Fixed height for tab groups title
- Disabled group dragging in tab tray

