### PR TITLE
Fixes #9205 - Website field in AddCredentialViewController should show a URL entry keyboard

### DIFF
--- a/Client/Frontend/Login Management/AddCredentialViewController.swift
+++ b/Client/Frontend/Login Management/AddCredentialViewController.swift
@@ -147,6 +147,7 @@ extension AddCredentialViewController: UITableViewDataSource {
             websiteField = loginCell.descriptionLabel
             loginCell.placeholder = "https://www.example.com"
             websiteField?.accessibilityIdentifier = "websiteField"
+            websiteField?.keyboardType = .URL
             loginCell.isEditingFieldData = true
             return loginCell
         }


### PR DESCRIPTION
This patch changes the `keyboardType` to `.URL` for the website field in the form that lets you add a new login manually.