### PR TITLE
FXIOS-3140: Fix missing quick search engine icons

### DIFF
--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -117,12 +117,10 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
         super.viewDidLoad()
 
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        ])
+        tableView.snp.makeConstraints { make in
+            make.edges.equalTo(self.view)
+            return
+        }
     }
 
     deinit {


### PR DESCRIPTION
# Overview

This PR fixes [this JIRA](https://mozilla-hub.atlassian.net/browse/FXIOS-3140) and https://github.com/mozilla-mobile/firefox-ios/issues/9084. 

We had to revert part of layout anchors work to bring it back, https://github.com/mozilla-mobile/firefox-ios/commit/e961bfdb5d2acd7a30f094538002f08b67908337. I need to dig more, but it's possible that bringToFront might help. But there's a lot of Snapkit related items to remove in searchVC, and it could take a bit. 

So here's a temp fix for that major regression. 