### PR TITLE
Update comment on legacy IDs in metrics.yaml

### DIFF
--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -630,7 +630,7 @@ library:
       - fx-ios-data-stewards@mozilla.com
     expires: "2022-01-01"
 
-# Legacy IDs for deletion-request purposes
+# Legacy IDs for continuity and for deletion-request
 legacy.ids:
   client_id:
     type: uuid


### PR DESCRIPTION
The comment about legacy IDs being for deletion-request pings makes it difficult to understand that we are now sending the legacy ID in metrics pings as well.

There was recently some discussion in Slack about missing legacy ID for connecting users across the telemetry migration. We didn't realize that FXIOS-1415 was already fully satisfied.
