### PR TITLE
Fix #8567 Firefox crashes when scaning a specified QR Code

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1336,16 +1336,22 @@ extension BrowserViewController: QRCodeViewControllerDelegate {
 
     func didScanQRCodeWithText(_ text: String) {
         TelemetryWrapper.recordEvent(category: .action, method: .scan, object: .qrCodeText)
+        func defaultAction() {
+            guard let tab = tabManager.selectedTab else { return }
+            submitSearchText(text, forTab: tab)
+        }
         let content = TextContentDetector.detectTextContent(text)
         switch content {
         case .some(.link(let url)):
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         case .some(.phoneNumber(let phoneNumber)):
-            let url = URL(string: "tel:\(phoneNumber)")!
-            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            if let url = URL(string: "tel:\(phoneNumber)") {
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            } else {
+                defaultAction()
+            }
         default:
-            guard let tab = tabManager.selectedTab else { return }
-            submitSearchText(text, forTab: tab)
+            defaultAction()
         }
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1336,9 +1336,9 @@ extension BrowserViewController: QRCodeViewControllerDelegate {
 
     func didScanQRCodeWithText(_ text: String) {
         TelemetryWrapper.recordEvent(category: .action, method: .scan, object: .qrCodeText)
-        func defaultAction() {
-            guard let tab = tabManager.selectedTab else { return }
-            submitSearchText(text, forTab: tab)
+        let defaultAction: () -> Void = { [weak self] in
+            guard let tab = self?.tabManager.selectedTab else { return }
+            self?.submitSearchText(text, forTab: tab)
         }
         let content = TextContentDetector.detectTextContent(text)
         switch content {


### PR DESCRIPTION
Do not force tel string as URL, NSDataDetector can be failed.

Fixes: https://github.com/mozilla-mobile/firefox-ios/issues/8567