### PR TITLE
Try quotes around Xcode 13 in contributor workflow

### DIFF
--- a/.github/workflows/build-contributor-pr.yml
+++ b/.github/workflows/build-contributor-pr.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.9]
-        xcode: [13.0]
+        xcode: ["13.0"]
         run-config: 
         - { scheme: 'Fennec_Enterprise_XCUITests', destination: 'platform=iOS Simulator,OS=latest,name=iPhone 11', testplan: 'SmokeXCUITests' }
     name: Run UI Smoketests


### PR DESCRIPTION
Might need quotes around "13.0"

From https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md

13.0	13A233	/Applications/Xcode_13.0.app

but I see `Run sudo xcode-select -s /Applications/Xcode_13.app` in the latest Github Action run after changing to 13 yesterday, maybe it just needs quotes?

