### PR TITLE
Fixes #9357 - Disable autofill credential syncing on v39

### DIFF
--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -1056,9 +1056,6 @@ open class BrowserProfile: Profile {
                     }
 
                     let syncEngineStatsSession = SyncEngineStatsSession(collection: "logins")
-                    self?.profile.syncCredentialIdentities().upon { result in
-                        log.debug(result)
-                    }
                     return deferMaybe(SyncStatus.completed(syncEngineStatsSession))
                 })
             })


### PR DESCRIPTION
This patch disables the autofill provider credential syncing. I don't think the removed code will have any impact since the extension is not enabled in 39 but this will remove any risk before we've more widely tested this.