### PR TITLE
FXIOS-3281: Fixes the reader mode toolbar being displayed after visiting google search

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -824,21 +824,7 @@ class BrowserViewController: UIViewController {
                 }
             } else if !url.absoluteString.hasPrefix("\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)") {
                 hideFirefoxHome()
-                
-                // Reader-mode check is required to correctly display reader-mode and refresh button on urlbar
-                if let readerMode = self.tabManager.selectedTab?.getContentScript(name: ReaderMode.name()) as? ReaderMode {
-                    urlBar.updateReaderModeState(readerMode.state)
-                    switch readerMode.state {
-                    case .active, .available:
-                        showReaderModeBar(animated: false)
-                    case .unavailable:
-                        hideReaderModeBar(animated: false)
-                    }
-                } else {
-                    urlBar.updateReaderModeState(ReaderModeState.unavailable)
-                    hideReaderModeBar(animated: false)
-                }
-
+                urlBar.shouldHideReloadButton(false)
             }
 
         } else if isAboutHomeURL {

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -454,6 +454,10 @@ class URLBarView: UIView {
         locationView.readerModeState = state
         locationView.reloadButton.isHidden = false
     }
+    
+    func shouldHideReloadButton(_ isHidden: Bool) {
+        locationView.reloadButton.isHidden = isHidden
+    }
 
     func setAutocompleteSuggestion(_ suggestion: String?) {
         locationTextField?.setAutocompleteSuggestion(suggestion)


### PR DESCRIPTION
This is a tone down version of another [PR](https://github.com/mozilla-mobile/firefox-ios/pull/9273) which was fixing a issue where reload button wouldn't show up but also touched on reader mode.