### PR TITLE
Fixes #9381 - SettingsViewController doesn't listen to theme changes

### DIFF
--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -10,6 +10,8 @@ class SettingsViewController: UIViewController {
     var profile: Profile!
     var tabManager: TabManager!
     
+    let theme = ThemeManager.instance
+
     init(profile: Profile? = nil, tabManager: TabManager? = nil) {
         super.init(nibName: nil, bundle: nil)
         self.profile = profile
@@ -22,6 +24,15 @@ class SettingsViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = .white
+        updateTheme()
+        NotificationCenter.default.addObserver(self, selector: #selector(updateTheme), name: .DisplayThemeChanged, object: nil)
+    }
+    
+    @objc func updateTheme() {
+        view.backgroundColor = theme.current.tableView.headerBackground
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 }


### PR DESCRIPTION
This patch makes `SettingsViewController` aware of theme changes so that the background colour properly adjusts.

This results in the theme correctly changing on the two new screens for Logins & Passwords. But only if they are opened from the hamburger application menu. If they are part of the settings, then theming does not work in general. I think that is unrelated to this new work and simply an old bug. I filed #9383 for that.