### PR TITLE
For #9359 - XCUITests use default tab tray

### DIFF
--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -111,7 +111,7 @@ class TestAppDelegate: AppDelegate {
 
         // Change to 0 to deactivate chron tabs
         if launchArguments.contains(LaunchArguments.ChronTabs) {
-                   profile.prefs.setInt(1, forKey: PrefsKeys.ChronTabsPrefKey)
+            profile.prefs.setInt(0, forKey: PrefsKeys.ChronTabsPrefKey)
         }
 
         if launchArguments.contains(LaunchArguments.StageServer) {

--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -179,8 +179,8 @@ class ActivityStreamTest: BaseTestCase {
             waitForExistence(app.cells.staticTexts["Wikipedia"], timeout: 5)
             numTabsOpen = app.collectionViews.element(boundBy: 2).cells.count
         } else {
-            waitForExistence(app.cells.staticTexts["wikipedia.org"], timeout: 5)
-            numTabsOpen = app.tables.cells.count
+            waitForExistence(app.collectionViews.cells.staticTexts["Wikipedia"], timeout: 5)
+            numTabsOpen = app.collectionViews.element(boundBy: 1).cells.count
         }
         XCTAssertEqual(numTabsOpen, 2, "New tab not open")
     }
@@ -210,7 +210,7 @@ class ActivityStreamTest: BaseTestCase {
         if iPad() {
             waitForExistence(app.collectionViews.cells.staticTexts["Apple"], timeout: 5)
         } else {
-            waitForExistence(app.tables.cells.staticTexts["Apple"], timeout: 5)
+            waitForExistence(app.collectionViews.cells.staticTexts["Apple"], timeout: 5)
         }
         app.cells.staticTexts["Apple"].firstMatch.tap()
 
@@ -241,7 +241,7 @@ class ActivityStreamTest: BaseTestCase {
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
         waitForExistence(app.cells.staticTexts[defaultTopSite["bookmarkLabel"]!])
-        var numTabsOpen = userState.numTabs
+        var numTabsOpen = app.collectionViews.element(boundBy: 0).cells.count
         if iPad() {
             navigator.goto(TabTray)
             numTabsOpen = app.collectionViews.element(boundBy: 1).cells.count

--- a/XCUITests/BaseTestCase.swift
+++ b/XCUITests/BaseTestCase.swift
@@ -21,7 +21,7 @@ class BaseTestCase: XCTestCase {
 
     // These are used during setUp(). Change them prior to setUp() for the app to launch with different args,
     // or, use restart() to re-launch with custom args.
-    var launchArguments = [LaunchArguments.ClearProfile, LaunchArguments.SkipIntro, LaunchArguments.SkipWhatsNew, LaunchArguments.SkipETPCoverSheet, LaunchArguments.StageServer, LaunchArguments.SkipDefaultBrowserOnboarding, LaunchArguments.DeviceName, "\(LaunchArguments.ServerPort)\(serverPort)", LaunchArguments.SkipContextualHintJumpBackIn]
+    var launchArguments = [LaunchArguments.ClearProfile, LaunchArguments.SkipIntro, LaunchArguments.SkipWhatsNew, LaunchArguments.SkipETPCoverSheet, LaunchArguments.StageServer, LaunchArguments.SkipDefaultBrowserOnboarding, LaunchArguments.DeviceName, "\(LaunchArguments.ServerPort)\(serverPort)", LaunchArguments.SkipContextualHintJumpBackIn, LaunchArguments.ChronTabs]
 
     func setUpScreenGraph() {
         navigator = createScreenGraph(for: self, with: app).navigator()

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -910,7 +910,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             if isTablet {
                 userState.numTabs = Int(app.collectionViews["Top Tabs View"].cells.count)
             } else {
-                userState.numTabs = Int(app.tables.cells.count)
+                userState.numTabs = Int(app.collectionViews.element(boundBy: 1).cells.count)
             }
         }
     }

--- a/XCUITests/HomePageSettingsUITest.swift
+++ b/XCUITests/HomePageSettingsUITest.swift
@@ -174,12 +174,12 @@ class HomePageSettingsUITests: BaseTestCase {
         enterWebPageAsHomepage(text: websiteUrl1)
         waitForValueContains(app.textFields["HomeAsCustomURLTextField"], value: "mozilla")
         navigator.goto(SettingsScreen)
-        XCTAssertEqual(app.tables.cells["Home"].label, "Home, Homepage")
+        XCTAssertEqual(app.tables.cells["Home"].label, "Homepage, Homepage")
         //Switch to FXHome and check label
         navigator.performAction(Action.SelectHomeAsFirefoxHomePage)
         navigator.nowAt(HomeSettings)
         navigator.goto(SettingsScreen)
-        XCTAssertEqual(app.tables.cells["Home"].label, "Home, Firefox Home")
+        XCTAssertEqual(app.tables.cells["Home"].label, "Homepage, Firefox Home")
     }
     //Function to check the number of top sites shown given a selected number of rows
     private func checkNumberOfExpectedTopSites(numberOfExpectedTopSites: Int) {

--- a/XCUITests/TopTabsTest.swift
+++ b/XCUITests/TopTabsTest.swift
@@ -189,7 +189,7 @@ class TopTabsTest: BaseTestCase {
         if iPad() {
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
         } else {
-            checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 3)
+            checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
         }
         // Close all tabs, undo it and check that the number of tabs is correct
         navigator.performAction(Action.AcceptRemovingAllTabs)
@@ -240,7 +240,7 @@ class TopTabsTest: BaseTestCase {
         if iPad() {
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
         } else {
-            checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 3)
+            checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
         }
         // Close all tabs and check that the number of tabs is correct
         navigator.performAction(Action.AcceptRemovingAllTabs)
@@ -328,6 +328,7 @@ fileprivate extension BaseTestCase {
         if iPad() {
             numTabsOpen = app.collectionViews.firstMatch.cells.count
         }
+        print(app.debugDescription)
         XCTAssertEqual(numTabsOpen, expectedNumberOfTabsOpen, "The number of tabs open is not correct")
     }
 
@@ -373,20 +374,18 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
     // This test only runs for iPhone see bug 1409750
     func testAddTabByLongPressTabsButton() {
         if skipPlatform { return }
-        navigator.goto(URLBarOpen)
-        navigator.back()
+        navigator.performAction(Action.CloseURLBarOpen)
         waitForTabsButton()
         navigator.performAction(Action.OpenNewTabLongPressTabsButton)
         navigator.goto(URLBarOpen)
         navigator.back()
-        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
+        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 3)
     }
 
     // This test only runs for iPhone see bug 1409750
     func testAddPrivateTabByLongPressTabsButton() {
         if skipPlatform { return }
-        navigator.goto(URLBarOpen)
-        navigator.back()
+        navigator.performAction(Action.CloseURLBarOpen)
         waitForTabsButton()
         navigator.performAction(Action.OpenPrivateTabLongPressTabsButton)
         navigator.goto(URLBarOpen)
@@ -438,7 +437,7 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
         XCTAssertTrue(app.links["RFC 2606"].exists)
         waitForExistence(app.buttons["Show Tabs"])
         let numPrivTab = app.buttons["Show Tabs"].value as? String
-        XCTAssertEqual("3", numPrivTab)
+        XCTAssertEqual("2", numPrivTab)
     }
 
     // This test is disabled for iPad because the toast menu is not shown there


### PR DESCRIPTION
Fixes #9359 by enabling regular tab tray in debug builds instead of the cron tab one. 

In this PR the smoketest is fixed but we will need a follow up to fix the full functional tests