### PR TITLE
Increased time it takes for CFR to show

### DIFF
--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -464,7 +464,7 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
     }
 
     func contextualHintPresentTimer() {
-        timer = Timer.scheduledTimer(timeInterval: 0.5, target: self, selector: #selector(presentContextualOverlay), userInfo: nil, repeats: false)
+        timer = Timer.scheduledTimer(timeInterval: 1.25, target: self, selector: #selector(presentContextualOverlay), userInfo: nil, repeats: false)
     }
     
     @objc func presentContextualOverlay() {


### PR DESCRIPTION
Due to reloading of collectionview the CFR section can at times get anchored to incorrect position and for that this change basically increase time for CFR to load.