### PR TITLE
FXIOS-3333: theming fixes (manual theming) for jumpBack and recentlySaved

### DIFF
--- a/Client/Frontend/Home/FxHomeJumpBackInView.swift
+++ b/Client/Frontend/Home/FxHomeJumpBackInView.swift
@@ -119,7 +119,7 @@ extension FxHomeJumpBackInCollectionCell: UICollectionViewDataSource {
 
         cell.itemTitle.text = group.searchTerm.localizedCapitalized
         cell.itemDetails.text = String(format: .FirefoxHomeJumpBackInSectionGroupSiteCount, group.groupedItems.count)
-        cell.faviconImage.image = UIImage(imageLiteralResourceName: "recently_closed").withTintColor(.label)
+        cell.faviconImage.image = UIImage(imageLiteralResourceName: "recently_closed").withRenderingMode(.alwaysTemplate)
         cell.siteNameLabel.text = String.localizedStringWithFormat(.FirefoxHomeJumpBackInSectionGroupSiteCount, group.groupedItems.count)
     }
     
@@ -263,6 +263,10 @@ class JumpBackInCell: UICollectionViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
 
     // MARK: - Helpers
     private func setupObservers() {
@@ -309,9 +313,17 @@ class JumpBackInCell: UICollectionViewCell {
 }
 
 extension JumpBackInCell: Themeable {
+    
     func applyTheme() {
-        contentView.backgroundColor = UIColor.theme.homePanel.recentlySavedBookmarkCellBackground
-        itemDetails.textColor = UIColor.theme.homePanel.activityStreamCellDescription
-        heroImage.tintColor = UIColor.theme.homePanel.jumpbackInGroupIconColour
+        if ThemeManager.instance.currentName == .dark {
+            [itemTitle, siteNameLabel, itemDetails].forEach { $0.textColor = UIColor.Photon.LightGrey10 }
+            faviconImage.tintColor = UIColor.Photon.LightGrey10
+            contentView.backgroundColor = UIColor.theme.homePanel.recentlySavedBookmarkCellBackground
+        } else {
+            [itemTitle, siteNameLabel, itemDetails].forEach { $0.textColor = UIColor.Photon.DarkGrey90 }
+            faviconImage.tintColor = UIColor.Photon.DarkGrey90
+            contentView.backgroundColor = UIColor.theme.homePanel.recentlySavedBookmarkCellBackground
+        }
     }
+    
 }

--- a/Client/Frontend/Home/FxHomeRecentlySavedCollectionCell.swift
+++ b/Client/Frontend/Home/FxHomeRecentlySavedCollectionCell.swift
@@ -190,7 +190,7 @@ private struct RecentlySavedCellUX {
 }
 
 /// A cell used in FxHomeScreen's Recently Saved section. It holds bookmarks and reading list items.
-class RecentlySavedCell: UICollectionViewCell {
+class RecentlySavedCell: UICollectionViewCell, Themeable {
     
     // MARK: - Properties
     
@@ -216,10 +216,16 @@ class RecentlySavedCell: UICollectionViewCell {
         super.init(frame: .zero)
         
         setupLayout()
+        setupNotifications()
+        applyTheme()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
     
     // MARK: - Helpers
@@ -244,6 +250,27 @@ class RecentlySavedCell: UICollectionViewCell {
             itemTitle.leadingAnchor.constraint(equalTo: heroImage.leadingAnchor),
             itemTitle.trailingAnchor.constraint(equalTo: heroImage.trailingAnchor, constant: -2)
         ])
+    }
+    
+    private func setupNotifications() {
+        NotificationCenter.default.addObserver(self, selector: #selector(handleNotifications), name: .DisplayThemeChanged, object: nil)
+    }
+    
+    @objc private func handleNotifications(_ notification: Notification) {
+        switch notification.name {
+        case .DisplayThemeChanged:
+            applyTheme()
+        default:
+            break
+        }
+    }
+    
+    func applyTheme() {
+        if ThemeManager.instance.currentName == .dark {
+            itemTitle.textColor = UIColor.Photon.LightGrey10
+        } else {
+            itemTitle.textColor = UIColor.Photon.DarkGrey90
+        }
     }
     
 }

--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -125,7 +125,6 @@ fileprivate class DarkHomePanelColor: HomePanelColor {
     override var shortcutShadowOpacity: Float { return 0.5 }
     
     override var recentlySavedBookmarkCellBackground: UIColor { return UIColor.Photon.DarkGrey30 }
-    override var jumpbackInGroupIconColour: UIColor { return UIColor.white } 
 
     override var downloadedFileIcon: UIColor { return UIColor.Photon.Grey30 }
 

--- a/Client/Frontend/Theme/Theme.swift
+++ b/Client/Frontend/Theme/Theme.swift
@@ -185,8 +185,6 @@ class HomePanelColor {
     
     var recentlySavedBookmarkCellBackground: UIColor { return .white}
 
-    var jumpbackInGroupIconColour: UIColor { return UIColor.Photon.DarkGrey90}
-
     var activityStreamHeaderText: UIColor { return UIColor.Photon.DarkGrey90 }
     var activityStreamHeaderButton: UIColor { return UIColor.Photon.Blue50 }
     var activityStreamCellTitle: UIColor { return UIColor.Photon.DarkGrey90 }


### PR DESCRIPTION
# Overview

This PR addresses [this JIRA ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-3333) and https://github.com/mozilla-mobile/firefox-ios/issues/9372.

Note:
The jumpBackIn favicon tint color (when it's a group) does not adjust properly when manually selecting a theme or directly selecting night mode from the settings menu. This is because I left 

`cell.faviconImage.image = UIImage(imageLiteralResourceName: "recently_closed").withTintColor(.label)`

But I'd rather have it behave according to the system theme, assuming more users expect/use that over night mode.