### PR TITLE
Remove white border on Pocket Cells

### DIFF
--- a/Client/Frontend/Widgets/FirefoxHomeHighlightCell.swift
+++ b/Client/Frontend/Widgets/FirefoxHomeHighlightCell.swift
@@ -52,8 +52,6 @@ class FirefoxHomeHighlightCell: UICollectionViewCell, Themeable {
         siteImageView.clipsToBounds = true
         siteImageView.contentMode = .center
         siteImageView.layer.cornerRadius = FirefoxHomeHighlightCellUX.CornerRadius
-        siteImageView.layer.borderColor = FirefoxHomeHighlightCellUX.BorderColor.cgColor
-        siteImageView.layer.borderWidth = FirefoxHomeHighlightCellUX.BorderWidth
         siteImageView.layer.masksToBounds = true
         return siteImageView
     }()


### PR DESCRIPTION
Fixes #9311 

As described in [#9311](https://github.com/mozilla-mobile/firefox-ios/issues/9311), this issue was as simple as removing the following lines from `FirefoxHomeHighlightCell`

```
siteImageView.layer.borderColor = FirefoxHomeHighlightCellUX.BorderColor.cgColor
siteImageView.layer.borderWidth = FirefoxHomeHighlightCellUX.BorderWidth
```

Here's the home screen with these changes:

![simulator_screenshot_C9737FA2-881A-4637-8F9D-0FA91D0C12C6](https://user-images.githubusercontent.com/6620352/138962908-0eec4d76-c77f-47e6-8dc1-adfbfba21265.png)

And before these changes:

![IMG_9054](https://user-images.githubusercontent.com/6620352/138964312-88de6ff3-7f51-42bb-b328-113ce170c25e.PNG)