### PR TITLE
#9426 Self sizing header for dynamic type in firefox homepage

### DIFF
--- a/Client/Frontend/Browser/Tabs/InactiveTabCell.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabCell.swift
@@ -255,7 +255,7 @@ class InactiveTabHeader: UITableViewHeaderFooterView, Themeable {
 
     var titleInsets: CGFloat {
         get {
-            return UIScreen.main.bounds.size.width == self.frame.size.width && UIDevice.current.userInterfaceIdiom == .pad ? FirefoxHomeHeaderViewUX.Insets : FirefoxHomeUX.MinimumInsets
+            return UIScreen.main.bounds.size.width == self.frame.size.width && UIDevice.current.userInterfaceIdiom == .pad ? FirefoxHomeHeaderViewUX.Insets : FirefoxHomeUX.minimumInsets
         }
     }
 

--- a/Client/Frontend/Browser/Tabs/InactiveTabCell.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabCell.swift
@@ -255,7 +255,7 @@ class InactiveTabHeader: UITableViewHeaderFooterView, Themeable {
 
     var titleInsets: CGFloat {
         get {
-            return UIScreen.main.bounds.size.width == self.frame.size.width && UIDevice.current.userInterfaceIdiom == .pad ? FirefoxHomeHeaderViewUX.Insets : FirefoxHomeUX.minimumInsets
+            return UIScreen.main.bounds.size.width == self.frame.size.width && UIDevice.current.userInterfaceIdiom == .pad ? FirefoxHomeHeaderViewUX.insets : FirefoxHomeUX.minimumInsets
         }
     }
 

--- a/Client/Frontend/Home/ASHeaderView.swift
+++ b/Client/Frontend/Home/ASHeaderView.swift
@@ -6,7 +6,7 @@ import UIKit
 
 // MARK: - Section Header View
 public struct FirefoxHomeHeaderViewUX {
-    static let Insets: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? FirefoxHomeUX.SectionInsetsForIpad + FirefoxHomeUX.MinimumInsets : FirefoxHomeUX.MinimumInsets
+    static let Insets: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? FirefoxHomeUX.sectionInsetsForIpad + FirefoxHomeUX.minimumInsets : FirefoxHomeUX.minimumInsets
     static let TitleTopInset: CGFloat = 5
     static let sectionHeaderSize: CGFloat = 20
 }
@@ -46,7 +46,7 @@ class ASHeaderView: UICollectionReusableView {
 
     var titleInsets: CGFloat {
         get {
-            return UIScreen.main.bounds.size.width == self.frame.size.width && UIDevice.current.userInterfaceIdiom == .pad ? FirefoxHomeHeaderViewUX.Insets : FirefoxHomeUX.MinimumInsets
+            return UIScreen.main.bounds.size.width == self.frame.size.width && UIDevice.current.userInterfaceIdiom == .pad ? FirefoxHomeHeaderViewUX.Insets : FirefoxHomeUX.minimumInsets
         }
     }
 

--- a/Client/Frontend/Home/ASHeaderView.swift
+++ b/Client/Frontend/Home/ASHeaderView.swift
@@ -9,6 +9,8 @@ public struct FirefoxHomeHeaderViewUX {
     static let Insets: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? FirefoxHomeUX.sectionInsetsForIpad + FirefoxHomeUX.minimumInsets : FirefoxHomeUX.minimumInsets
     static let TitleTopInset: CGFloat = 5
     static let sectionHeaderSize: CGFloat = 20
+    static let maxTitleLabelTextSize: CGFloat = 43 // Style title3 - AX3
+    static let maxMoreButtonTextSize: CGFloat = 36 // Style subheadline - AX3
 }
 
 enum ASHeaderViewType {
@@ -24,15 +26,17 @@ class ASHeaderView: UICollectionReusableView {
     lazy var titleLabel: UILabel = .build { label in
         label.text = self.title
         label.textColor = UIColor.theme.homePanel.activityStreamHeaderText
-        label.font = UIFont.systemFont(ofSize: FirefoxHomeHeaderViewUX.sectionHeaderSize, weight: .bold)
-        label.minimumScaleFactor = 0.6
-        label.numberOfLines = 1
-        label.adjustsFontSizeToFitWidth = true
+        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .title3,
+                                                                       maxSize: FirefoxHomeHeaderViewUX.maxTitleLabelTextSize)
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
     }
 
     lazy var moreButton: UIButton = .build { button in
         button.isHidden = true
-        button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .subheadline)
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
+        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
+                                                                                maxSize: FirefoxHomeHeaderViewUX.maxMoreButtonTextSize)
         button.contentHorizontalAlignment = .right
         button.setTitleColor(UIColor.theme.homePanel.activityStreamHeaderButton, for: .normal)
         button.setTitleColor(UIColor.Photon.Grey50, for: .highlighted)
@@ -54,7 +58,7 @@ class ASHeaderView: UICollectionReusableView {
         super.prepareForReuse()
         moreButton.isHidden = true
         moreButton.setTitle(nil, for: .normal)
-        moreButton.accessibilityIdentifier = nil;
+        moreButton.accessibilityIdentifier = nil
         titleLabel.text = nil
         moreButton.removeTarget(nil, action: nil, for: .allEvents)
         titleLabel.textColor = UIColor.theme.homePanel.activityStreamHeaderText
@@ -74,6 +78,7 @@ class ASHeaderView: UICollectionReusableView {
             titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10),
         ])
         moreButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+        titleLabel.setContentHuggingPriority(.fittingSizeLevel, for: .horizontal)
 
         titleLeadingConstraint = titleLabel.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: titleInsets)
         titleLeadingConstraint?.isActive = true

--- a/Client/Frontend/Home/ASHeaderView.swift
+++ b/Client/Frontend/Home/ASHeaderView.swift
@@ -9,8 +9,8 @@ public struct FirefoxHomeHeaderViewUX {
     static let insets: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? FirefoxHomeUX.sectionInsetsForIpad + FirefoxHomeUX.minimumInsets : FirefoxHomeUX.minimumInsets
     static let titleTopInset: CGFloat = 5
     static let sectionHeaderSize: CGFloat = 20
-    static let maxTitleLabelTextSize: CGFloat = 43 // Style title3 - AX3
-    static let maxMoreButtonTextSize: CGFloat = 36 // Style subheadline - AX3
+    static let maxTitleLabelTextSize: CGFloat = 55 // Style title3 - AX5
+    static let maxMoreButtonTextSize: CGFloat = 49 // Style subheadline - AX5
 }
 
 enum ASHeaderViewType {
@@ -18,6 +18,7 @@ enum ASHeaderViewType {
     case normal
 }
 
+// Activity Stream header view
 class ASHeaderView: UICollectionReusableView {
     static let verticalInsets: CGFloat = 4
     var sectionType: ASHeaderViewType = .normal
@@ -74,6 +75,7 @@ class ASHeaderView: UICollectionReusableView {
             moreButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6),
             moreButton.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -titleInsets),
 
+            titleLabel.topAnchor.constraint(equalTo: topAnchor),
             titleLabel.trailingAnchor.constraint(equalTo: moreButton.leadingAnchor, constant: -FirefoxHomeHeaderViewUX.titleTopInset),
             titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10),
         ])

--- a/Client/Frontend/Home/ASHeaderView.swift
+++ b/Client/Frontend/Home/ASHeaderView.swift
@@ -6,8 +6,8 @@ import UIKit
 
 // MARK: - Section Header View
 public struct FirefoxHomeHeaderViewUX {
-    static let Insets: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? FirefoxHomeUX.sectionInsetsForIpad + FirefoxHomeUX.minimumInsets : FirefoxHomeUX.minimumInsets
-    static let TitleTopInset: CGFloat = 5
+    static let insets: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? FirefoxHomeUX.sectionInsetsForIpad + FirefoxHomeUX.minimumInsets : FirefoxHomeUX.minimumInsets
+    static let titleTopInset: CGFloat = 5
     static let sectionHeaderSize: CGFloat = 20
     static let maxTitleLabelTextSize: CGFloat = 43 // Style title3 - AX3
     static let maxMoreButtonTextSize: CGFloat = 36 // Style subheadline - AX3
@@ -50,7 +50,7 @@ class ASHeaderView: UICollectionReusableView {
 
     var titleInsets: CGFloat {
         get {
-            return UIScreen.main.bounds.size.width == self.frame.size.width && UIDevice.current.userInterfaceIdiom == .pad ? FirefoxHomeHeaderViewUX.Insets : FirefoxHomeUX.minimumInsets
+            return UIScreen.main.bounds.size.width == self.frame.size.width && UIDevice.current.userInterfaceIdiom == .pad ? FirefoxHomeHeaderViewUX.insets : FirefoxHomeUX.minimumInsets
         }
     }
 
@@ -74,7 +74,7 @@ class ASHeaderView: UICollectionReusableView {
             moreButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6),
             moreButton.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -titleInsets),
 
-            titleLabel.trailingAnchor.constraint(equalTo: moreButton.leadingAnchor, constant: -FirefoxHomeHeaderViewUX.TitleTopInset),
+            titleLabel.trailingAnchor.constraint(equalTo: moreButton.leadingAnchor, constant: -FirefoxHomeHeaderViewUX.titleTopInset),
             titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10),
         ])
         moreButton.setContentCompressionResistancePriority(.required, for: .horizontal)

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -471,6 +471,16 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
     @objc func presentContextualOverlay() {
         presentContextualHint()
     }
+
+    private func getHeaderSize(forSection section: Int) -> CGSize {
+        let indexPath = IndexPath(row: 0, section: section)
+        let headerView = self.collectionView(collectionView, viewForSupplementaryElementOfKind: UICollectionView.elementKindSectionHeader, at: indexPath)
+        let size = CGSize(width: collectionView.frame.width, height: UIView.layoutFittingExpandedSize.height)
+
+        return headerView.systemLayoutSizeFitting(size,
+                                                  withHorizontalFittingPriority: .required,
+                                                  verticalFittingPriority: .fittingSizeLevel)
+    }
 }
 
 // MARK: -  Section Management
@@ -494,10 +504,6 @@ extension FirefoxHomeViewController {
             case .libraryShortcuts: return Strings.AppMenuLibraryTitleString
             case .customizeHome: return nil
             }
-        }
-
-        var headerHeight: CGSize {
-            return CGSize(width: 50, height: 40)
         }
 
         var headerImage: UIImage? {
@@ -619,9 +625,9 @@ extension FirefoxHomeViewController: UICollectionViewDelegateFlowLayout {
     override func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         switch kind {
         case UICollectionView.elementKindSectionHeader:
-            let view = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: "Header", for: indexPath) as! ASHeaderView
+            let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: "Header", for: indexPath) as! ASHeaderView
             let title = Section(indexPath.section).title
-            view.title = title
+            headerView.title = title
 
             switch Section(indexPath.section) {
             case .pocket:
@@ -630,11 +636,11 @@ extension FirefoxHomeViewController: UICollectionViewDelegateFlowLayout {
                     TelemetryWrapper.recordEvent(category: .action, method: .view, object: .pocketSectionImpression, value: nil, extras: nil)
                     hasSentPocketSectionEvent = true
                 }
-                view.moreButton.isHidden = false
-                view.moreButton.setTitle(Strings.PocketMoreStoriesText, for: .normal)
-                view.moreButton.addTarget(self, action: #selector(showMorePocketStories), for: .touchUpInside)
-                view.titleLabel.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.SectionTitles.pocket
-                return view
+                headerView.moreButton.isHidden = false
+                headerView.moreButton.setTitle(Strings.PocketMoreStoriesText, for: .normal)
+                headerView.moreButton.addTarget(self, action: #selector(showMorePocketStories), for: .touchUpInside)
+                headerView.titleLabel.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.SectionTitles.pocket
+                return headerView
             case .jumpBackIn:
                 if !hasSentJumpBackInSectionEvent
                     && isJumpBackInSectionEnabled
@@ -642,42 +648,42 @@ extension FirefoxHomeViewController: UICollectionViewDelegateFlowLayout {
                     TelemetryWrapper.recordEvent(category: .action, method: .view, object: .jumpBackInImpressions, value: nil, extras: nil)
                     hasSentJumpBackInSectionEvent = true
                 }
-                view.moreButton.isHidden = false
-                view.moreButton.setTitle(Strings.RecentlySavedShowAllText, for: .normal)
-                view.moreButton.addTarget(self, action: #selector(openTabTray), for: .touchUpInside)
-                view.moreButton.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.MoreButtons.jumpBackIn
-                view.titleLabel.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.SectionTitles.jumpBackIn
+                headerView.moreButton.isHidden = false
+                headerView.moreButton.setTitle(Strings.RecentlySavedShowAllText, for: .normal)
+                headerView.moreButton.addTarget(self, action: #selector(openTabTray), for: .touchUpInside)
+                headerView.moreButton.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.MoreButtons.jumpBackIn
+                headerView.titleLabel.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.SectionTitles.jumpBackIn
                 let attributes = collectionView.layoutAttributesForItem(at: indexPath)
-                    if let frame = attributes?.frame, view.convert(frame, from: collectionView).height > 1 {
+                    if let frame = attributes?.frame, headerView.convert(frame, from: collectionView).height > 1 {
                         // Using a timer for the first presentation of contextual hint due to many reloads that happen on the collection view. Invalidating the timer prevents from showing contextual hint at the wrong position.
                         timer?.invalidate()
                         if didRotate && hasPresentedContextualHint {
-                            contextualSourceView = view.titleLabel
+                            contextualSourceView = headerView.titleLabel
                             didRotate = false
                         } else if !hasPresentedContextualHint && contextualHintViewController.viewModel.shouldPresentContextualHint(profile: profile) {
-                            contextualSourceView = view.titleLabel
+                            contextualSourceView = headerView.titleLabel
                             contextualHintPresentTimer()
                         }
                 }
-                return view
+                return headerView
             case .recentlySaved:
-                view.moreButton.isHidden = false
-                view.moreButton.setTitle(Strings.RecentlySavedShowAllText, for: .normal)
-                view.moreButton.addTarget(self, action: #selector(openBookmarks), for: .touchUpInside)
-                view.moreButton.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.MoreButtons.recentlySaved
-                view.titleLabel.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.SectionTitles.recentlySaved
-                return view
+                headerView.moreButton.isHidden = false
+                headerView.moreButton.setTitle(Strings.RecentlySavedShowAllText, for: .normal)
+                headerView.moreButton.addTarget(self, action: #selector(openBookmarks), for: .touchUpInside)
+                headerView.moreButton.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.MoreButtons.recentlySaved
+                headerView.titleLabel.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.SectionTitles.recentlySaved
+                return headerView
             case .topSites:
-                view.titleLabel.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.SectionTitles.topSites
-                view.moreButton.isHidden = true
-                return view
+                headerView.titleLabel.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.SectionTitles.topSites
+                headerView.moreButton.isHidden = true
+                return headerView
             case .libraryShortcuts:
-                view.moreButton.isHidden = true
-                view.titleLabel.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.SectionTitles.library
-                return view
+                headerView.moreButton.isHidden = true
+                headerView.titleLabel.accessibilityIdentifier = FxHomeAccessibilityIdentifiers.SectionTitles.library
+                return headerView
             case .customizeHome:
-                view.moreButton.isHidden = true
-                return view
+                headerView.moreButton.isHidden = true
+                return headerView
         }
         default:
             return UICollectionReusableView()
@@ -716,17 +722,18 @@ extension FirefoxHomeViewController: UICollectionViewDelegateFlowLayout {
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+
         switch Section(section) {
         case .pocket:
-            return pocketStories.isEmpty ? .zero : Section(section).headerHeight
+            return pocketStories.isEmpty ? .zero : getHeaderSize(forSection: section)
         case .topSites:
-            return isTopSitesSectionEnabled ? Section(section).headerHeight : .zero
+            return isTopSitesSectionEnabled ? getHeaderSize(forSection: section) : .zero
         case .libraryShortcuts:
-            return isYourLibrarySectionEnabled ? Section(section).headerHeight : .zero
+            return isYourLibrarySectionEnabled ? getHeaderSize(forSection: section) : .zero
         case .jumpBackIn:
-            return isJumpBackInSectionEnabled ? Section(section).headerHeight : .zero
+            return isJumpBackInSectionEnabled ? getHeaderSize(forSection: section) : .zero
         case .recentlySaved:
-            return isRecentlySavedSectionEnabled ? Section(section).headerHeight : .zero
+            return isRecentlySavedSectionEnabled ? getHeaderSize(forSection: section) : .zero
         case .customizeHome:
             return .zero
         }

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -156,7 +156,7 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
     weak var homePanelDelegate: HomePanelDelegate?
     weak var libraryPanelDelegate: LibraryPanelDelegate?
     fileprivate var hasPresentedContextualHint = false
-    fileprivate var didRoate = false
+    fileprivate var didRotate = false
     fileprivate let profile: Profile
     fileprivate let pocketAPI = Pocket()
     fileprivate let flowLayout = UICollectionViewFlowLayout()
@@ -341,14 +341,14 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         coordinator.animate(alongsideTransition: {context in
-            //The AS context menu does not behave correctly. Dismiss it when rotating.
+            // The AS context menu does not behave correctly. Dismiss it when rotating.
             if let _ = self.presentedViewController as? PhotonActionSheet {
                 self.presentedViewController?.dismiss(animated: true, completion: nil)
             }
             self.collectionViewLayout.invalidateLayout()
             self.collectionView?.reloadData()
         }, completion: { _ in
-            if !self.didRoate { self.didRoate = true }
+            if !self.didRotate { self.didRotate = true }
             // Workaround: label positions are not correct without additional reload
             self.collectionView?.reloadData()
         })
@@ -651,9 +651,9 @@ extension FirefoxHomeViewController: UICollectionViewDelegateFlowLayout {
                     if let frame = attributes?.frame, view.convert(frame, from: collectionView).height > 1 {
                         // Using a timer for the first presentation of contextual hint due to many reloads that happen on the collection view. Invalidating the timer prevents from showing contextual hint at the wrong position.
                         timer?.invalidate()
-                        if didRoate && hasPresentedContextualHint {
+                        if didRotate && hasPresentedContextualHint {
                             contextualSourceView = view.titleLabel
-                            didRoate = false
+                            didRotate = false
                         } else if !hasPresentedContextualHint && contextualHintViewController.viewModel.shouldPresentContextualHint(profile: profile) {
                             contextualSourceView = view.titleLabel
                             contextualHintPresentTimer()

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -20,10 +20,10 @@ struct FirefoxHomeUX {
     static let sectionInsetsForSizeClass = UXSizeClasses(compact: 0, regular: 101, other: 15)
     static let numberOfItemsPerRowForSizeClassIpad = UXSizeClasses(compact: 3, regular: 4, other: 2)
     static let spacingBetweenSections: CGFloat = 24
-    static let SectionInsetsForIpad: CGFloat = 101
-    static let MinimumInsets: CGFloat = 15
-    static let LibraryShortcutsHeight: CGFloat = 90
-    static let LibraryShortcutsMaxWidth: CGFloat = 375
+    static let sectionInsetsForIpad: CGFloat = 101
+    static let minimumInsets: CGFloat = 15
+    static let libraryShortcutsHeight: CGFloat = 90
+    static let libraryShortcutsMaxWidth: CGFloat = 375
     static let customizeHomeHeight: CGFloat = 100
 }
 
@@ -196,6 +196,7 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
         customCell.delegate = self.topSitesManager
         return customCell
     }()
+
     lazy var defaultBrowserCard: DefaultBrowserCard = .build { card in
         card.backgroundColor = UIColor.theme.homePanel.topSitesBackground
     }
@@ -521,7 +522,7 @@ extension FirefoxHomeViewController {
             case .jumpBackIn: return FirefoxHomeUX.jumpBackInCellHeight
             case .recentlySaved: return FirefoxHomeUX.recentlySavedCellHeight
             case .topSites: return 0 //calculated dynamically
-            case .libraryShortcuts: return FirefoxHomeUX.LibraryShortcutsHeight
+            case .libraryShortcuts: return FirefoxHomeUX.libraryShortcutsHeight
             case .customizeHome: return FirefoxHomeUX.customizeHomeHeight
             }
         }
@@ -539,7 +540,7 @@ extension FirefoxHomeViewController {
             var insets = FirefoxHomeUX.sectionInsetsForSizeClass[currentTraits.horizontalSizeClass]
             let window = UIApplication.shared.keyWindow
             let safeAreaInsets = window?.safeAreaInsets.left ?? 0
-            insets += FirefoxHomeUX.MinimumInsets + safeAreaInsets
+            insets += FirefoxHomeUX.minimumInsets + safeAreaInsets
             return insets
         }
 
@@ -567,7 +568,7 @@ extension FirefoxHomeViewController {
             switch self {
             case .pocket:
                 let numItems = numberOfItemsForRow(traits)
-                return CGSize(width: floor(((frameWidth - inset) - (FirefoxHomeUX.MinimumInsets * (numItems - 1))) / numItems), height: height)
+                return CGSize(width: floor(((frameWidth - inset) - (FirefoxHomeUX.minimumInsets * (numItems - 1))) / numItems), height: height)
             case .topSites, .libraryShortcuts, .jumpBackIn, .recentlySaved, .customizeHome:
                 return CGSize(width: frameWidth - inset, height: height)
             }
@@ -707,7 +708,7 @@ extension FirefoxHomeViewController: UICollectionViewDelegateFlowLayout {
             }
             return cellSize
         case .libraryShortcuts:
-            let width = min(FirefoxHomeUX.LibraryShortcutsMaxWidth, cellSize.width)
+            let width = min(FirefoxHomeUX.libraryShortcutsMaxWidth, cellSize.width)
             return CGSize(width: width, height: cellSize.height)
         case .customizeHome, .pocket, .recentlySaved:
             return cellSize

--- a/Client/Helpers/DynamicFontHelper.swift
+++ b/Client/Helpers/DynamicFontHelper.swift
@@ -210,9 +210,29 @@ class DynamicFontHelper: NSObject {
         NotificationCenter.default.post(notification)
     }
     
-    /// Return a font with the minimum size.
+    /// Return a font that will dynamically scale up to a certain size
+    /// - Parameters:
+    ///   - textStyle: The desired textStyle for the font
+    ///   - maxSize: The maximum size the font can scale - Refer to the human interface guidelines for more information on sizes for each style
+    ///              https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/typography/
+    /// - Returns: The UIFont with the specified font size and style
     func preferredFont(withTextStyle textStyle: UIFont.TextStyle, maxSize: CGFloat) -> UIFont {
         let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: textStyle)
         return UIFont(descriptor: fontDescriptor, size: min(fontDescriptor.pointSize, maxSize))
+    }
+
+    /// Return a bold font that will dynamically scale up to a certain size
+    /// Parameters:
+    ///   - textStyle: The desired textStyle for the font
+    ///   - maxSize: The maximum size the font can scale - Refer to the human interface guidelines for more information on sizes for each style
+    ///              https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/typography/
+    /// - Returns: The UIFont with the specified bold font size and style
+    func preferredBoldFont(withTextStyle textStyle: UIFont.TextStyle, maxSize: CGFloat) -> UIFont {
+        let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: textStyle)
+        if let boldFontDescriptor = fontDescriptor.withSymbolicTraits(.traitBold) {
+            return UIFont(descriptor: boldFontDescriptor, size: min(boldFontDescriptor.pointSize, maxSize))
+        } else {
+            return UIFont(descriptor: fontDescriptor, size: min(fontDescriptor.pointSize, maxSize))
+        }
     }
 }

--- a/Client/Helpers/DynamicFontHelper.swift
+++ b/Client/Helpers/DynamicFontHelper.swift
@@ -222,7 +222,7 @@ class DynamicFontHelper: NSObject {
     }
 
     /// Return a bold font that will dynamically scale up to a certain size
-    /// Parameters:
+    /// - Parameters:
     ///   - textStyle: The desired textStyle for the font
     ///   - maxSize: The maximum size the font can scale - Refer to the human interface guidelines for more information on sizes for each style
     ///              https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/typography/


### PR DESCRIPTION
- Pull requests to start fixing https://github.com/mozilla-mobile/firefox-ios/issues/9426
- This fixes the header on the firefox home page so it can adjust to dynamic type (so header doesn't have a fixed height anymore)
- Added a function to get the preferred bold font (was only possible to get the standard font)
- Fixed some typos at the same time

