### PR TITLE
For #9466 - Mobile Test Eng: Standarize Slack Notifications - Part1

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -118,6 +118,10 @@ workflows:
     - slack@3.1:
         inputs:
         - webhook_url: "$WEBHOOK_SLACK_TOKEN"
+        - footer_icon: https://emoji.slack-edge.com/T027LFU12/testops-notify/d350cecb43e9e630.png
+        - footer: Created by Mobile Test Engineering
+        - pretext_on_error: "*Firefox-iOS* :firefox: *Build/XCUITests* :x:"
+        - pretext: "*Firefox-iOS* :firefox: *Build/XCUITests* :white_check_mark:"
   4_B_xcode_build_and_test_Fennec_Enterprise_XCUITests:
     steps:
     - xcode-build-for-simulator@0.11:


### PR DESCRIPTION
Fixes #9466
This PR adds a new header:
![Captura de pantalla 2021-11-04 a las 13 05 23](https://user-images.githubusercontent.com/1897507/140310532-ffc680c3-4dc0-4d6a-b217-002beba1a141.png)

And a new footer:
![Captura de pantalla 2021-11-04 a las 13 05 13](https://user-images.githubusercontent.com/1897507/140310537-f9eef7cd-c5d6-4f51-b6d3-68dd6428755e.png)

