### PR TITLE
#9370 #9204 Tab selector in tab tray

### DIFF
--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -16,4 +16,8 @@ public struct AccessibilityIdentifiers {
     struct BottomToolbar {
         static let settingsMenuButton = "TabToolbar.menuButton"
     }
+
+    struct TabTray {
+        static let filteredTabs = "filteredTabs"
+    }
 }

--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -19,5 +19,6 @@ public struct AccessibilityIdentifiers {
 
     struct TabTray {
         static let filteredTabs = "filteredTabs"
+        static let deleteCloseAllButton = "TabTrayController.deleteButton.closeAll"
     }
 }

--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -20,5 +20,6 @@ public struct AccessibilityIdentifiers {
     struct TabTray {
         static let filteredTabs = "filteredTabs"
         static let deleteCloseAllButton = "TabTrayController.deleteButton.closeAll"
+        static let deleteCancelButton = "TabTrayController.deleteButton.cancel"
     }
 }

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -611,7 +611,7 @@ extension GridTabViewController {
         }
 
         let controller = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        controller.addAction(UIAlertAction(title: Strings.AppMenuCloseAllTabsTitleString, style: .default, handler: { _ in self.closeTabsForCurrentTray() }), accessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
+        controller.addAction(UIAlertAction(title: Strings.AppMenuCloseAllTabsTitleString, style: .default, handler: { _ in self.closeTabsForCurrentTray() }), accessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)
         controller.addAction(UIAlertAction(title: .TabTrayCloseAllTabsPromptCancel, style: .cancel, handler: nil), accessibilityIdentifier: "TabTrayController.deleteButton.cancel")
         controller.popoverPresentationController?.barButtonItem = sender
         present(controller, animated: true, completion: nil)

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -37,7 +37,7 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
     let profile: Profile
     weak var delegate: TabTrayDelegate?
     var tabDisplayManager: TabDisplayManager!
-    var tabCellIdentifer: TabDisplayer.TabCellIdentifer = TabCell.Identifier
+    var tabCellIdentifer: TabDisplayer.TabCellIdentifer = TabCell.reuseIdentifier
     static let independentTabsHeaderIdentifier = "IndependentTabs"
     var otherBrowsingModeOffset = CGPoint.zero
     // Backdrop used for displaying greyed background for private tabs
@@ -73,11 +73,11 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
         self.tabToFocus = tabToFocus
         super.init(nibName: nil, bundle: nil)
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
-        collectionView.register(TabCell.self, forCellWithReuseIdentifier: TabCell.Identifier)
+        collectionView.register(TabCell.self, forCellWithReuseIdentifier: TabCell.reuseIdentifier)
         collectionView.register(GroupedTabCell.self, forCellWithReuseIdentifier: GroupedTabCell.Identifier)
         collectionView.register(InactiveTabCell.self, forCellWithReuseIdentifier: InactiveTabCell.Identifier)
         collectionView.register(ASHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: GridTabViewController.independentTabsHeaderIdentifier)
-        tabDisplayManager = TabDisplayManager(collectionView: self.collectionView, tabManager: self.tabManager, tabDisplayer: self, reuseID: TabCell.Identifier, tabDisplayType: .TabGrid, profile: profile)
+        tabDisplayManager = TabDisplayManager(collectionView: self.collectionView, tabManager: self.tabManager, tabDisplayer: self, reuseID: TabCell.reuseIdentifier, tabDisplayType: .TabGrid, profile: profile)
         collectionView.dataSource = tabDisplayManager
         collectionView.delegate = tabLayoutDelegate
 
@@ -778,8 +778,8 @@ class TabCell: UICollectionViewCell, TabTrayCell {
         case dark
     }
 
-    static let Identifier = "TabCellIdentifier"
-    static let BorderWidth: CGFloat = 3
+    static let reuseIdentifier = "TabCellIdentifier"
+    static let borderWidth: CGFloat = 3
 
     lazy var backgroundHolder: UIView = {
         let view = UIView()
@@ -892,8 +892,8 @@ class TabCell: UICollectionViewCell, TabTrayCell {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        let shadowPath = CGRect(width: layer.frame.width + (TabCell.BorderWidth * 2), height: layer.frame.height + (TabCell.BorderWidth * 2))
-        layer.shadowPath = UIBezierPath(roundedRect: shadowPath, cornerRadius: GridTabTrayControllerUX.CornerRadius+TabCell.BorderWidth).cgPath
+        let shadowPath = CGRect(width: layer.frame.width + (TabCell.borderWidth * 2), height: layer.frame.height + (TabCell.borderWidth * 2))
+        layer.shadowPath = UIBezierPath(roundedRect: shadowPath, cornerRadius: GridTabTrayControllerUX.CornerRadius+TabCell.borderWidth).cgPath
     }
 
     func configureWith(tab: Tab, isSelected selected: Bool) {
@@ -967,9 +967,9 @@ class TabCell: UICollectionViewCell, TabTrayCell {
         layer.shadowRadius = 0 // A 0 radius creates a solid border instead of a gradient blur
         layer.masksToBounds = false
         // create a frame that is "BorderWidth" size bigger than the cell
-        layer.shadowOffset = CGSize(width: -TabCell.BorderWidth, height: -TabCell.BorderWidth)
-        let shadowPath = CGRect(width: layer.frame.width + (TabCell.BorderWidth * 2), height: layer.frame.height + (TabCell.BorderWidth * 2))
-        layer.shadowPath = UIBezierPath(roundedRect: shadowPath, cornerRadius: GridTabTrayControllerUX.CornerRadius+TabCell.BorderWidth).cgPath
+        layer.shadowOffset = CGSize(width: -TabCell.borderWidth, height: -TabCell.borderWidth)
+        let shadowPath = CGRect(width: layer.frame.width + (TabCell.borderWidth * 2), height: layer.frame.height + (TabCell.borderWidth * 2))
+        layer.shadowPath = UIBezierPath(roundedRect: shadowPath, cornerRadius: GridTabTrayControllerUX.CornerRadius+TabCell.borderWidth).cgPath
     }
 }
 

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -611,8 +611,10 @@ extension GridTabViewController {
         }
 
         let controller = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        controller.addAction(UIAlertAction(title: Strings.AppMenuCloseAllTabsTitleString, style: .default, handler: { _ in self.closeTabsForCurrentTray() }), accessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)
-        controller.addAction(UIAlertAction(title: .TabTrayCloseAllTabsPromptCancel, style: .cancel, handler: nil), accessibilityIdentifier: "TabTrayController.deleteButton.cancel")
+        controller.addAction(UIAlertAction(title: Strings.AppMenuCloseAllTabsTitleString, style: .default, handler: { _ in self.closeTabsForCurrentTray() }),
+                             accessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)
+        controller.addAction(UIAlertAction(title: .TabTrayCloseAllTabsPromptCancel, style: .cancel, handler: nil),
+                             accessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCancelButton)
         controller.popoverPresentationController?.barButtonItem = sender
         present(controller, animated: true, completion: nil)
     }

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -39,7 +39,6 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
     var tabDisplayManager: TabDisplayManager!
     var tabCellIdentifer: TabDisplayer.TabCellIdentifer = TabCell.Identifier
     static let independentTabsHeaderIdentifier = "IndependentTabs"
-    static let filteredTabsAccessibilityIdentifier = "filteredTabs"
     var otherBrowsingModeOffset = CGPoint.zero
     // Backdrop used for displaying greyed background for private tabs
     var webViewContainerBackdrop: UIView!
@@ -165,7 +164,7 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
         guard notification.name == .DynamicFontChanged else { return }
     }
 
-// MARK: View Controller Callbacks
+    // MARK: View Controller Callbacks
     override func viewDidLoad() {
         super.viewDidLoad()
         tabManager.addDelegate(self)

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -109,7 +109,7 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
 
     /// The main interface for scrolling to an item, whether that is a group or an individual tab
     ///
-    /// This method checks for the existence of a tab to focus on other than the seleceted tab,
+    /// This method checks for the existence of a tab to focus on other than the selected tab,
     /// and then, focuses on that tab. The byproduct is that if the tab is in a group, the
     /// user would then be looking at the group. Generally, if focusing on a group and
     /// NOT the selected tab, it is advised to pass in the first tab of that group as
@@ -877,7 +877,7 @@ class TabCell: UICollectionViewCell {
     }
 
     func setTabSelected(_ isPrivate: Bool) {
-        // This creates a border around a tabcell. Using the shadow craetes a border _outside_ of the tab frame.
+        // This creates a border around a tabcell. Using the shadow creates a border _outside_ of the tab frame.
         layer.shadowColor = (isPrivate ? UIColor.theme.tabTray.privateModePurple : UIConstants.SystemBlueColor).cgColor
         layer.shadowOpacity = 1
         layer.shadowRadius = 0 // A 0 radius creates a solid border instead of a gradient blur

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -100,7 +100,7 @@ class Tab: NSObject {
 
     var consecutiveCrashes: UInt = 0
     
-    // Setting defualt page as topsites
+    // Setting default page as topsites
     var newTabPageType: NewTabPage = .topSites
     var tabUUID: String = UUID().uuidString
     private var screenshotUUIDString: String?

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -770,7 +770,7 @@ extension TabDisplayManager: TabManagerDelegate {
 
         updateWith(animationType: .addTab) { [unowned self] in
             // place new tab at the end by default unless it has been opened from parent tab
-            var indexToPlaceTab = dataStore.count - 1 > 0 ? dataStore.count - 1 : 0
+            var indexToPlaceTab = dataStore.count - 1 > 0 ? dataStore.count : 0
 
             // open a link from website next to it
             if placeNextToParentTab, let selectedTabUUID = tabManager.selectedTab?.tabUUID {

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -458,7 +458,7 @@ extension TabDisplayManager: UICollectionViewDataSource {
             view.title = .TabTrayOtherTabsSectionHeader
             view.titleLabel.font = .systemFont(ofSize: GroupedTabCellProperties.CellUX.titleFontSize, weight: .semibold)
             view.moreButton.isHidden = true
-            view.titleLabel.accessibilityIdentifier = GridTabViewController.filteredTabsAccessibilityIdentifier
+            view.titleLabel.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.filteredTabs
             
             return view
         }

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -79,6 +79,7 @@ struct TabDisplayOrder: Codable {
 }
 
 class TabDisplayManager: NSObject, FeatureFlagsProtocol {
+
     // MARK: - Variables
     var performingChainedOperations = false
     var inactiveViewModel: InactiveTabViewModel?
@@ -184,8 +185,6 @@ class TabDisplayManager: NSObject, FeatureFlagsProtocol {
 
         return isActive
     }
-
-
 
     init(collectionView: UICollectionView, tabManager: TabManager, tabDisplayer: TabDisplayer, reuseID: String, tabDisplayType: TabDisplayType, profile: Profile) {
         self.collectionView = collectionView

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -718,9 +718,10 @@ extension TabDisplayManager: TabEventHandler {
 
         updateWith(animationType: .updateTab) { [weak self] in
             guard let index = self?.dataStore.index(of: tab) else { return }
+            let section = self?.tabDisplayType == .TopTabTray ? 0 : TabDisplaySection.regularTabs.rawValue
 
             var indexPaths = [IndexPath]()
-            indexPaths.append(IndexPath(row: index, section: TabDisplaySection.regularTabs.rawValue))
+            indexPaths.append(IndexPath(row: index, section: section))
 
             if selectedTabChanged {
                 self?.tabDisplayer?.focusSelectedTab()
@@ -728,7 +729,6 @@ extension TabDisplayManager: TabEventHandler {
                 // Append the previously selected tab to refresh it's state. Useful when the selected tab has change.
                 // This method avoids relying on the state of the "previous" selected tab,
                 // instead it iterates the displayed tabs to see which appears selected.
-                let section = self?.tabDisplayType == .TopTabTray ? 0 : TabDisplaySection.regularTabs.rawValue
                 if let previousSelectedIndexPath = self?.indexOfCellDrawnAsPreviouslySelectedTab(currentlySelected: selectedTab,
                                                                                                  inSection: section) {
                     indexPaths.append(previousSelectedIndexPath)

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -333,10 +333,10 @@ class TabDisplayManager: NSObject, FeatureFlagsProtocol {
 
     // The collection is showing this Tab as selected
     private func indexOfCellDrawnAsPreviouslySelectedTab(currentlySelected: Tab) -> IndexPath? {
-        for i in 0..<collectionView.numberOfItems(inSection: TabDisplaySection.regularTabs.rawValue) {
-            if let cell = collectionView.cellForItem(at: IndexPath(row: i, section: TabDisplaySection.regularTabs.rawValue)) as? TopTabCell, cell.selectedTab {
+        for i in 0..<collectionView.numberOfItems(inSection: 0) {
+            if let cell = collectionView.cellForItem(at: IndexPath(row: i, section: 0)) as? TopTabCell, cell.selectedTab {
                 if let tab = dataStore.at(i), tab != currentlySelected {
-                    return IndexPath(row: i, section: TabDisplaySection.regularTabs.rawValue)
+                    return IndexPath(row: i, section: 0)
                 } else {
                     return nil
                 }
@@ -361,8 +361,8 @@ class TabDisplayManager: NSObject, FeatureFlagsProtocol {
                 // Avoid calling with evenIfHidden=true, as it can cause a blink effect as the cell is updated.
                 // The cause of the blinking effect is unknown (and unusual).
                 var indexPaths = [IndexPath]()
-                for i in 0..<self.collectionView.numberOfItems(inSection: TabDisplaySection.groupedTabs.rawValue) {
-                    indexPaths.append(IndexPath(item: i, section: TabDisplaySection.groupedTabs.rawValue))
+                for i in 0..<self.collectionView.numberOfItems(inSection: 0) {
+                    indexPaths.append(IndexPath(item: i, section: 0))
                 }
                 self.collectionView.reloadItems(at: indexPaths)
             }

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -333,10 +333,10 @@ class TabDisplayManager: NSObject, FeatureFlagsProtocol {
 
     // The collection is showing this Tab as selected
     func indexOfCellDrawnAsPreviouslySelectedTab(currentlySelected: Tab) -> IndexPath? {
-        for i in 0..<collectionView.numberOfItems(inSection: 0) {
-            if let cell = collectionView.cellForItem(at: IndexPath(row: i, section: 0)) as? TopTabCell, cell.selectedTab {
+        for i in 0..<collectionView.numberOfItems(inSection: TabDisplaySection.regularTabs.rawValue) {
+            if let cell = collectionView.cellForItem(at: IndexPath(row: i, section: TabDisplaySection.regularTabs.rawValue)) as? TopTabCell, cell.selectedTab {
                 if let tab = dataStore.at(i), tab != currentlySelected {
-                    return IndexPath(row: i, section: 0)
+                    return IndexPath(row: i, section: TabDisplaySection.regularTabs.rawValue)
                 } else {
                     return nil
                 }
@@ -361,8 +361,8 @@ class TabDisplayManager: NSObject, FeatureFlagsProtocol {
                 // Avoid calling with evenIfHidden=true, as it can cause a blink effect as the cell is updated.
                 // The cause of the blinking effect is unknown (and unusual).
                 var indexPaths = [IndexPath]()
-                for i in 0..<self.collectionView.numberOfItems(inSection: 0) {
-                    indexPaths.append(IndexPath(item: i, section: 0))
+                for i in 0..<self.collectionView.numberOfItems(inSection: TabDisplaySection.groupedTabs.rawValue) {
+                    indexPaths.append(IndexPath(item: i, section: TabDisplaySection.groupedTabs.rawValue))
                 }
                 self.collectionView.reloadItems(at: indexPaths)
             }

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -721,9 +721,7 @@ extension TabDisplayManager: TabEventHandler {
                 }
 
                 let isSelected = (indexPath.row == index && tab == self?.tabManager.selectedTab)
-                if let tabCell = cell as? TabCell {
-                    tabCell.configureWith(tab: tab, is: isSelected)
-                } else if let tabCell = cell as? TopTabCell {
+                if let tabCell = cell as? TabTrayCell {
                     tabCell.configureWith(tab: tab, isSelected: isSelected)
                 }
             }

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -332,7 +332,7 @@ class TabDisplayManager: NSObject, FeatureFlagsProtocol {
     }
 
     // The collection is showing this Tab as selected
-    func indexOfCellDrawnAsPreviouslySelectedTab(currentlySelected: Tab) -> IndexPath? {
+    private func indexOfCellDrawnAsPreviouslySelectedTab(currentlySelected: Tab) -> IndexPath? {
         for i in 0..<collectionView.numberOfItems(inSection: TabDisplaySection.regularTabs.rawValue) {
             if let cell = collectionView.cellForItem(at: IndexPath(row: i, section: TabDisplaySection.regularTabs.rawValue)) as? TopTabCell, cell.selectedTab {
                 if let tab = dataStore.at(i), tab != currentlySelected {

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -695,33 +695,36 @@ extension TabDisplayManager: UICollectionViewDropDelegate {
 }
 
 extension TabDisplayManager: TabEventHandler {
+
     private func updateCellFor(tab: Tab, selectedTabChanged: Bool) {
         let selectedTab = tabManager.selectedTab
 
         updateWith(animationType: .updateTab) { [weak self] in
             guard let index = self?.dataStore.index(of: tab) else { return }
 
-            var items = [IndexPath]()
-            items.append(IndexPath(row: index, section: 0))
+            var indexPaths = [IndexPath]()
+            indexPaths.append(IndexPath(row: index, section: TabDisplaySection.regularTabs.rawValue))
 
             if selectedTabChanged {
                 self?.tabDisplayer?.focusSelectedTab()
                 // Check if the selected tab has changed. This method avoids relying on the state of the "previous" selected tab,
                 // instead it iterates the displayed tabs to see which appears selected.
                 // See also `didSelectedTabChange` for more info on why this is a good approach.
-                if let selectedTab = selectedTab, let previousSelectedIndex = self?.indexOfCellDrawnAsPreviouslySelectedTab(currentlySelected: selectedTab) {
-                    items.append(previousSelectedIndex)
+                if let selectedTab = selectedTab, let previousSelectedIndexPath = self?.indexOfCellDrawnAsPreviouslySelectedTab(currentlySelected: selectedTab) {
+                    indexPaths.append(previousSelectedIndexPath)
                 }
             }
 
-            for item in items {
-                if let cell = self?.collectionView.cellForItem(at: item), let tab = self?.dataStore.at(item.row) {
-                    let isSelected = (item.row == index && tab == self?.tabManager.selectedTab)
-                    if let tabCell = cell as? TabCell {
-                        tabCell.configureWith(tab: tab, is: isSelected)
-                    } else if let tabCell = cell as? TopTabCell {
-                        tabCell.configureWith(tab: tab, isSelected: isSelected)
-                    }
+            for indexPath in indexPaths {
+                guard let cell = self?.collectionView.cellForItem(at: indexPath), let tab = self?.dataStore.at(indexPath.row) else {
+                    return
+                }
+
+                let isSelected = (indexPath.row == index && tab == self?.tabManager.selectedTab)
+                if let tabCell = cell as? TabCell {
+                    tabCell.configureWith(tab: tab, is: isSelected)
+                } else if let tabCell = cell as? TopTabCell {
+                    tabCell.configureWith(tab: tab, isSelected: isSelected)
                 }
             }
         }

--- a/Client/Frontend/Browser/Tabs/ChronologicalTabsViewController.swift
+++ b/Client/Frontend/Browser/Tabs/ChronologicalTabsViewController.swift
@@ -147,7 +147,7 @@ extension ChronologicalTabsViewController {
 
     func didTapToolbarDelete(_ sender: UIBarButtonItem) {
         let controller = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        controller.addAction(UIAlertAction(title: Strings.AppMenuCloseAllTabsTitleString, style: .default, handler: { _ in self.viewModel.closeTabsForCurrentTray() }), accessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
+        controller.addAction(UIAlertAction(title: Strings.AppMenuCloseAllTabsTitleString, style: .default, handler: { _ in self.viewModel.closeTabsForCurrentTray() }), accessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)
         controller.addAction(UIAlertAction(title: Strings.CancelString, style: .cancel, handler: nil), accessibilityIdentifier: "TabTrayController.deleteButton.cancel")
         controller.popoverPresentationController?.barButtonItem = sender
         present(controller, animated: true, completion: nil)

--- a/Client/Frontend/Browser/Tabs/ChronologicalTabsViewController.swift
+++ b/Client/Frontend/Browser/Tabs/ChronologicalTabsViewController.swift
@@ -148,7 +148,7 @@ extension ChronologicalTabsViewController {
     func didTapToolbarDelete(_ sender: UIBarButtonItem) {
         let controller = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         controller.addAction(UIAlertAction(title: Strings.AppMenuCloseAllTabsTitleString, style: .default, handler: { _ in self.viewModel.closeTabsForCurrentTray() }), accessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)
-        controller.addAction(UIAlertAction(title: Strings.CancelString, style: .cancel, handler: nil), accessibilityIdentifier: "TabTrayController.deleteButton.cancel")
+        controller.addAction(UIAlertAction(title: Strings.CancelString, style: .cancel, handler: nil), accessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCancelButton)
         controller.popoverPresentationController?.barButtonItem = sender
         present(controller, animated: true, completion: nil)
         TelemetryWrapper.recordEvent(category: .action, method: .deleteAll, object: .tab, value: viewModel.isInPrivateMode ? .privateTab : .normalTab)

--- a/Client/Frontend/Browser/Tabs/GroupedTabCell.swift
+++ b/Client/Frontend/Browser/Tabs/GroupedTabCell.swift
@@ -359,7 +359,7 @@ class GroupedTabContainerCell: UITableViewCell, UICollectionViewDelegateFlowLayo
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: singleTabCellIdentifier, for: indexPath)
         guard let tabCell = cell as? TabCell, let tab = tabs?[indexPath.item] else { return cell }
         tabCell.delegate = self
-        tabCell.configureWith(tab: tab, is: selectedTab == tab)
+        tabCell.configureWith(tab: tab, isSelected: selectedTab == tab)
         tabCell.animator = nil
         return tabCell
     }

--- a/Client/Frontend/Browser/TopTabsViews.swift
+++ b/Client/Frontend/Browser/TopTabsViews.swift
@@ -5,19 +5,19 @@
 import Foundation
 import Shared
 
-class TopTabCell: UICollectionViewCell, NotificationThemeable {
+class TopTabCell: UICollectionViewCell, NotificationThemeable, TabTrayCell {
 
     static let Identifier = "TopTabCellIdentifier"
     static let ShadowOffsetSize: CGFloat = 2 //The shadow is used to hide the tab separator
 
-    var selectedTab = false {
+    var isSelectedTab = false {
         didSet {
             backgroundColor = .clear
             titleText.textColor = UIColor.theme.topTabs.tabForegroundSelected
             closeButton.tintColor = UIColor.theme.topTabs.closeButtonSelectedTab
             closeButton.backgroundColor = backgroundColor
             closeButton.layer.shadowColor = backgroundColor?.cgColor
-            selectedBackground.isHidden = !selectedTab
+            selectedBackground.isHidden = !isSelectedTab
         }
     }
 
@@ -101,7 +101,7 @@ class TopTabCell: UICollectionViewCell, NotificationThemeable {
         self.clipsToBounds = false
     }
 
-    func configureWith(tab: Tab, isSelected: Bool) {
+    func configureWith(tab: Tab, isSelected selected: Bool) {
         self.titleText.text = tab.displayTitle
 
         if tab.displayTitle.isEmpty {
@@ -118,9 +118,9 @@ class TopTabCell: UICollectionViewCell, NotificationThemeable {
             self.closeButton.accessibilityLabel = String(format: Strings.TopSitesRemoveButtonAccessibilityLabel, tab.displayTitle)
         }
 
-        self.selectedTab = isSelected
+        self.isSelectedTab = selected
 
-        let hideCloseButton = frame.width < 148 && !isSelected
+        let hideCloseButton = frame.width < 148 && !selected
         closeButton.isHidden = hideCloseButton
 
         if let siteURL = tab.url?.displayURL {

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -234,7 +234,7 @@ class BrowserUtils {
         tester.tapView(withAccessibilityLabel: "smallPrivateMask")
 
         tester.tapView(withAccessibilityIdentifier: "closeAllTabsButtonTabTray")
-        tester.tapView(withAccessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
+        tester.tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)
 
         tester.wait(forTimeInterval: 3)
         /* go to Normal mode */
@@ -244,7 +244,7 @@ class BrowserUtils {
             tester.tapView(withAccessibilityLabel: "1")
         }
         tester.tapView(withAccessibilityIdentifier: "closeAllTabsButtonTabTray")
-        tester.tapView(withAccessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
+        tester.tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)
     }
 
     class func dismissFirstRunUI(_ tester: KIFUITestActor) {

--- a/UITests/LoginManagerTests.swift
+++ b/UITests/LoginManagerTests.swift
@@ -226,7 +226,7 @@ class LoginManagerTests: KIFTestCase {
         // Workaround
         tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
         tester().tapView(withAccessibilityIdentifier: "closeAllTabsButtonTabTray")
-        tester().tapView(withAccessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
+        tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)
         tester().tapView(withAccessibilityIdentifier: "urlBar-cancel")
     }
 
@@ -251,7 +251,7 @@ class LoginManagerTests: KIFTestCase {
         // Workaround
         tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
         tester().tapView(withAccessibilityIdentifier: "closeAllTabsButtonTabTray")
-        tester().tapView(withAccessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
+        tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)
         tester().tapView(withAccessibilityIdentifier: "urlBar-cancel")
     }
     // This test is disabled until bug 1486243 is fixed

--- a/UITests/ReopenLastTabTests.swift
+++ b/UITests/ReopenLastTabTests.swift
@@ -13,7 +13,7 @@ class ReopenLastTabTests: KIFTestCase {
     
     var closeButtonMatchers: [GREYMatcher] {
         return [
-            grey_accessibilityID("TabTrayController.deleteButton.closeAll"),
+            grey_accessibilityID(AccessibilityIdentifiers.TabTray.deleteCloseAllButton),
             grey_kindOfClass(NSClassFromString("_UIAlertControllerActionView")!)
         ]
     }

--- a/UITests/SecurityTests.swift
+++ b/UITests/SecurityTests.swift
@@ -81,7 +81,7 @@ class SecurityTests: KIFTestCase {
         // Workaround number of tabs not updated
         tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
         tester().tapView(withAccessibilityIdentifier: "closeAllTabsButtonTabTray")
-        tester().tapView(withAccessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
+        tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)
         tester().tapView(withAccessibilityIdentifier: "urlBar-cancel")
     }
 
@@ -102,7 +102,7 @@ class SecurityTests: KIFTestCase {
         // Workaround number of tabs not updated
         tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
         tester().tapView(withAccessibilityIdentifier: "closeAllTabsButtonTabTray")
-        tester().tapView(withAccessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
+        tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)
         tester().tapView(withAccessibilityIdentifier: "urlBar-cancel")
         tester().wait(forTimeInterval: 5)
     }
@@ -135,7 +135,7 @@ class SecurityTests: KIFTestCase {
       func closeAllTabs() {
         tester().tapView(withAccessibilityIdentifier: "TabTrayController.removeTabsButton")
         tester().waitForAnimationsToFinish(withTimeout: 3)
-        tester().tapView(withAccessibilityIdentifier: "TabTrayController.deleteButton.closeAll")
+        tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)
         
       }
 

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -924,7 +924,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     map.addScreenState(CloseTabMenu) { screenState in
-        screenState.tap(app.sheets.buttons["TabTrayController.deleteButton.closeAll"], forAction: Action.AcceptRemovingAllTabs, transitionTo: HomePanelsScreen)
+        screenState.tap(app.sheets.buttons[AccessibilityIdentifiers.TabTray.deleteCloseAllButton], forAction: Action.AcceptRemovingAllTabs, transitionTo: HomePanelsScreen)
         screenState.backAction = cancelBackAction
     }
 


### PR DESCRIPTION
This PR includes fixes for both https://github.com/mozilla-mobile/firefox-ios/issues/9204 and https://github.com/mozilla-mobile/firefox-ios/issues/9370
- Selected tab wasn't updated when a tab was removed due to code searching in section: 0 instead of using the TabDisplaySection
- When a tab was added, it was added at `dataStore.count - 1` which was making it appear second to last instead of the last one
- Added TabTrayCell protocol so TopTabCell and TabCell has common functionality which simplifies code (avoid casting in each cell type)

Also includes other things such as:
- Accessibility identifiers in the AccessibilityIdentifiers file
- Variables renamed with a lower case
- Typos

Commit order should make this clear, let me know if it's not!