### PR TITLE
FollowUp on Issue 9466 to standarize Slack Notifications

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -122,6 +122,16 @@ workflows:
         - footer: Created by Mobile Test Engineering
         - pretext_on_error: "*Firefox-iOS* :firefox: *Build/XCUITests* :x:"
         - pretext: "*Firefox-iOS* :firefox: *Build/XCUITests* :white_check_mark:"
+        - fields: |
+            Task | ${BITRISE_BUILD_URL}
+            Owner | ${GIT_CLONE_COMMIT_AUTHOR_NAME}
+            Commit | ${GIT_CLONE_COMMIT_MESSAGE_SUBJECT}
+            Source-Workflow | ${BITRISE_TRIGGERED_WORKFLOW_TITLE}
+            Branch | ${BITRISE_GIT_BRANCH}
+        - buttons: |+
+            App|${BITRISE_APP_URL}
+            #mobile-testeng|https://mozilla.slack.com/archives/C02KDDS9QM9
+            Mana|https://mana.mozilla.org/wiki/display/MTE/Mobile+Test+Engineering
   4_B_xcode_build_and_test_Fennec_Enterprise_XCUITests:
     steps:
     - xcode-build-for-simulator@0.11:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -117,11 +117,14 @@ workflows:
         is_always_run: true
     - slack@3.1:
         inputs:
+        - title: ''
+        - author_name: ''
         - webhook_url: "$WEBHOOK_SLACK_TOKEN"
         - footer_icon: https://emoji.slack-edge.com/T027LFU12/testops-notify/d350cecb43e9e630.png
         - footer: Created by Mobile Test Engineering
         - pretext_on_error: "*Firefox-iOS* :firefox: *Build/XCUITests* :x:"
         - pretext: "*Firefox-iOS* :firefox: *Build/XCUITests* :white_check_mark:"
+        - timestamp: 'no'
         - fields: |
             Task | ${BITRISE_BUILD_URL}
             Owner | ${GIT_CLONE_COMMIT_AUTHOR_NAME}


### PR DESCRIPTION
Changing the notification payload to something like: 
![Captura de pantalla 2021-11-05 a las 17 03 53](https://user-images.githubusercontent.com/1897507/140541446-b2cff43c-bf1b-4dad-b3fd-e2535565000f.png)
