### PR TITLE
Update the Desktop User Agent to better match Safari

### DIFF
--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -49,7 +49,7 @@ open class UserAgent {
     }
 
     public static func desktopUserAgent() -> String {
-        return "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15"
+        return "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/\(UIDevice.current.systemVersion) Safari/605.1.15"
     }
 
     public static func mobileUserAgent() -> String {


### PR DESCRIPTION
Updates the macOS version to match [WebKit](https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/platform/ios/UserAgentIOS.mm#L88) and remove the hard-coded iOS version.