### PR TITLE
String fixes for Credential Provider

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1622,8 +1622,8 @@ extension String {
 
 // MARK: - Credential Provider
 extension String {
-    public static let LoginsWelcomeViewTitle2 = MZLocalizedString("Logins.WelcomeView.Title", value: "AutoFill Firefox Passwords", comment: "Label displaying welcome view title", lastUpdated: .unknown)
-    public static let LoginsWelcomeViewTagline = MZLocalizedString("Logins.WelcomeView.Title", value: "Take your passwords everywhere", comment: "Label displaying welcome view tagline under the title", lastUpdated: .unknown)
+    public static let LoginsWelcomeViewTitle2 = MZLocalizedString("Logins.WelcomeView.Title2", value: "AutoFill Firefox Passwords", comment: "Label displaying welcome view title", lastUpdated: .unknown)
+    public static let LoginsWelcomeViewTagline = MZLocalizedString("Logins.WelcomeView.Tagline", value: "Take your passwords everywhere", comment: "Label displaying welcome view tagline under the title", lastUpdated: .unknown)
     public static let LoginsWelcomeTurnOnAutoFillButtonTitle = MZLocalizedString("Logins.WelcomeView.TurnOnAutoFill", value: "Turn on AutoFill", comment: "Title of the big blue button to enable AutoFill", lastUpdated: .unknown)
     public static let LoginsListSearchCancel = MZLocalizedString("LoginsList.Search.Cancel", value: "Cancel", comment: "Title for cancel button for user to stop searching for a particular login", lastUpdated: .unknown)
     public static let LoginsListSearchPlaceholderCredential = MZLocalizedString("LoginsList.Search.Placeholder", value: "Search logins", comment: "Placeholder text for search field", lastUpdated: .unknown)


### PR DESCRIPTION
This patch resolves the issues reported on the String Export for v95.

 - `Logins.WelcomeView.Title` becomes `Logins.WelcomeView.Title2` (it changed and already existed)
 - The double comment is because there was a duplicate ID. The duplicate is now called `Logins.WelcomeView.Tagline`
