### PR TITLE
Fix Glean metrics event type deprecation warnings

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -388,6 +388,7 @@
 		8A11C80F2731916E00AC7318 /* defaultOnlyTestList.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A11C80D2731916E00AC7318 /* defaultOnlyTestList.json */; };
 		8A11C8112731CFD700AC7318 /* ReaderModeStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */; };
 		8A11C8132731E54800AC7318 /* DictionaryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */; };
+		8AA6ADB52742B567004EEE23 /* TelemetryWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA6ADB42742B567004EEE23 /* TelemetryWrapperTests.swift */; };
 		8D8251811F4DE67F00780643 /* AdvancedAccountSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8251721F4DE67E00780643 /* AdvancedAccountSettingViewController.swift */; };
 		8DCD3BCD1ED5B7FA00446D38 /* FxADeepLinkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DCD3BCC1ED5B7FA00446D38 /* FxADeepLinkingTests.swift */; };
 		9609F4CA26B57CE800F81493 /* CalendarExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609F4C926B57CE800F81493 /* CalendarExtensions.swift */; };
@@ -2544,6 +2545,7 @@
 		8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeStyleTests.swift; sourceTree = "<group>"; };
 		8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryExtensionsTests.swift; sourceTree = "<group>"; };
 		8A5143D6BF179870414566ED /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Search.strings; sourceTree = "<group>"; };
+		8AA6ADB42742B567004EEE23 /* TelemetryWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryWrapperTests.swift; sourceTree = "<group>"; };
 		8AAD4900BB6F4DF6056B581F /* ml */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ml; path = ml.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		8AB04613B101195AADCC1F1B /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = "cs.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		8AD440CBBF202B15E74E186D /* ur */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ur; path = ur.lproj/Search.strings; sourceTree = "<group>"; };
@@ -6226,6 +6228,7 @@
 				D8EFFA251FF702A8001D3A09 /* NavigationRouterTests.swift */,
 				39C137962655798A003DC662 /* NimbusIntegrationTests.swift */,
 				63306D442110BAF000F25400 /* TabManagerStoreTests.swift */,
+				8AA6ADB42742B567004EEE23 /* TelemetryWrapperTests.swift */,
 				E1D8BC7921FF7A0000B100BD /* TPStatsBlocklistsTests.swift */,
 				DACDE995225E537900C8F37F /* VersionSettingTests.swift */,
 				D815A3A724A53F3200AAB221 /* TabToolbarHelperTests.swift */,
@@ -8346,6 +8349,7 @@
 				2F697F7E1A9FD22D009E03AE /* SearchEnginesTests.swift in Sources */,
 				2F44FA1B1A9D426A00FD20CC /* TestHashExtensions.swift in Sources */,
 				3B39EDBA1E16E18900EF029F /* CustomSearchEnginesTest.swift in Sources */,
+				8AA6ADB52742B567004EEE23 /* TelemetryWrapperTests.swift in Sources */,
 				43446CF32412F9FF00F5C643 /* ETPCoverSheetTests.swift in Sources */,
 				D3FA777B1A43B2990010CD32 /* SearchTests.swift in Sources */,
 				D3BA41681BD82F2200DA5457 /* XCTestCaseExtensions.swift in Sources */,

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -431,7 +431,7 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
         if let readingList = profile.readingList.getAvailableRecords().value.successValue?.prefix(RecentlySavedCollectionCellUX.readingListItemsLimit) {
             var readingListItems = Array(readingList)
             readingListItems = RecentItemsHelper.filterStaleItems(recentItems: readingListItems,
-                                                                       since: Date()) as! [ReadingListItem]
+                                                                  since: Date()) as! [ReadingListItem]
             self.hasReadingListitems = !readingListItems.isEmpty
 
             TelemetryWrapper.recordEvent(category: .action,

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -422,7 +422,7 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
                                              method: .view,
                                              object: .firefoxHomepage,
                                              value: .recentlySavedBookmarkItemView,
-                                             extras: [TelemetryWrapper.EventObject.recentlySavedBookmarkImpressions.rawValue: bookmarks.count])
+                                             extras: [TelemetryWrapper.EventObject.recentlySavedBookmarkImpressions.rawValue: "\(bookmarks.count)"])
             }
 
             self?.collectionView.reloadData()
@@ -437,8 +437,8 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
             TelemetryWrapper.recordEvent(category: .action,
                                          method: .view,
                                          object: .firefoxHomepage,
-                                         value: .recentlySavedBookmarkItemView,
-                                         extras: [TelemetryWrapper.EventObject.recentlySavedReadingItemImpressions.rawValue: readingListItems.count])
+                                         value: .recentlySavedReadingListView,
+                                         extras: [TelemetryWrapper.EventObject.recentlySavedReadingItemImpressions.rawValue: "\(readingListItems.count)"])
 
             self.collectionView.reloadData()
         }

--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -166,8 +166,10 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
                 self.prefs.setString(self.currentBlockingStrength.rawValue, forKey: ContentBlockingConfig.Prefs.StrengthKey)
                 TabContentBlocker.prefsChanged()
                 self.tableView.reloadData()
-                
-                TelemetryWrapper.recordEvent(category: .action, method: .change, object: .setting, extras: ["pref": "ETP-strength", "to": option.rawValue])
+
+                let extras = [TelemetryWrapper.EventExtraKey.preference.rawValue: "ETP-strength",
+                              TelemetryWrapper.EventExtraKey.preferenceChanged.rawValue: option.rawValue]
+                TelemetryWrapper.recordEvent(category: .action, method: .change, object: .setting, extras: extras)
                 
                 if option == .strict {
                     let alert = UIAlertController(title: .TrackerProtectionAlertTitle, message: .TrackerProtectionAlertDescription, preferredStyle: .alert)

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -339,7 +339,10 @@ extension SearchSettingsTableViewController: SearchEnginePickerDelegate {
             model.defaultEngine = engine
             updateSearchIcon?()
             self.tableView.reloadData()
-            TelemetryWrapper.recordEvent(category: .action, method: .change, object: .setting, extras: ["pref": "defaultSearchEngine", "to": engine.engineID ?? "custom"])
+
+            let extras = [TelemetryWrapper.EventExtraKey.preference.rawValue: "defaultSearchEngine",
+                          TelemetryWrapper.EventExtraKey.preferenceChanged.rawValue: engine.engineID ?? "custom"]
+            TelemetryWrapper.recordEvent(category: .action, method: .change, object: .setting, extras: extras)
         }
         _ = navigationController?.popViewController(animated: true)
     }

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -453,6 +453,9 @@ extension TelemetryWrapper {
         case pocketTilePosition = "pocketTilePosition"
         case fxHomepageOrigin = "fxHomepageOrigin"
 
+        case preference = "pref"
+        case preferenceChanged = "to"
+
         // Grouped Tab
         case groupsWithTwoTabsOnly = "groupsWithTwoTabsOnly"
         case groupsWithTwoMoreTab = "groupsWithTwoMoreTab"
@@ -506,7 +509,7 @@ extension TelemetryWrapper {
             }
         // Preferences
         case (.action, .change, .setting, _, let extras):
-            if let preference = extras?["pref"] as? String, let to = (extras?["to"] ?? "undefined") as? String {
+            if let preference = extras?[EventExtraKey.preference.rawValue] as? String, let to = ((extras?[EventExtraKey.preferenceChanged.rawValue]) ?? "undefined") as? String {
                 GleanMetrics.Preferences.changed.record(GleanMetrics.Preferences.ChangedExtra(changedTo: to, preference: preference))
             } else {
                 let msg = "Uninstrumented pref metric: \(category), \(method), \(object), \(value), \(String(describing: extras))"

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -507,9 +507,7 @@ extension TelemetryWrapper {
         // Preferences
         case (.action, .change, .setting, _, let extras):
             if let preference = extras?["pref"] as? String, let to = (extras?["to"] ?? "undefined") as? String {
-                GleanMetrics.Preferences.changed.record(
-                extra: [GleanMetrics.Preferences.ChangedKeys.preference: preference,
-                        GleanMetrics.Preferences.ChangedKeys.changedTo: to])
+                GleanMetrics.Preferences.changed.record(GleanMetrics.Preferences.ChangedExtra(changedTo: to, preference: preference))
             } else {
                 let msg = "Uninstrumented pref metric: \(category), \(method), \(object), \(value), \(String(describing: extras))"
                 Sentry.shared.send(message: msg, severity: .debug)
@@ -692,7 +690,7 @@ extension TelemetryWrapper {
 
         case (.action, .view, .firefoxHomepage, EventValue.recentlySavedBookmarkItemView.rawValue, let extras):
             if let bookmarksCount = extras?[EventObject.recentlySavedBookmarkImpressions.rawValue] as? String {
-                GleanMetrics.FirefoxHomePage.recentlySavedBookmarkView.record(GleanMetrics.FirefoxHomePage.RecentlySavedBookmarkViewExtra(bookmarkCount: bookmarksCount)
+                GleanMetrics.FirefoxHomePage.recentlySavedBookmarkView.record(GleanMetrics.FirefoxHomePage.RecentlySavedBookmarkViewExtra(bookmarkCount: bookmarksCount))
             }
         case (.action, .view, .firefoxHomepage, EventValue.recentlySavedReadingListView.rawValue, let extras):
             if let readingListItemsCount = extras?[EventObject.recentlySavedReadingItemImpressions.rawValue] as? String {

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -499,7 +499,7 @@ extension TelemetryWrapper {
         // Top Site
         case (.action, .tap, .topSiteTile, _, let extras):
             if let position = extras?[EventExtraKey.topSitePosition.rawValue] as? String, let tileType = extras?[EventExtraKey.topSiteTileType.rawValue] as? String {
-                GleanMetrics.TopSite.tilePressed.record(extra: [GleanMetrics.TopSite.TilePressedKeys.position : position, GleanMetrics.TopSite.TilePressedKeys.tileType : tileType])
+                GleanMetrics.TopSite.tilePressed.record(GleanMetrics.TopSite.TilePressedExtra(position: position, tileType: tileType))
             } else {
                 let msg = "Uninstrumented pref metric: \(category), \(method), \(object), \(value), \(String(describing: extras))"
                 Sentry.shared.send(message: msg, severity: .debug)
@@ -692,11 +692,11 @@ extension TelemetryWrapper {
 
         case (.action, .view, .firefoxHomepage, EventValue.recentlySavedBookmarkItemView.rawValue, let extras):
             if let bookmarksCount = extras?[EventObject.recentlySavedBookmarkImpressions.rawValue] as? String {
-                GleanMetrics.FirefoxHomePage.recentlySavedBookmarkView.record(extra: [.bookmarkCount : bookmarksCount])
+                GleanMetrics.FirefoxHomePage.recentlySavedBookmarkView.record(GleanMetrics.FirefoxHomePage.RecentlySavedBookmarkViewExtra(bookmarkCount: bookmarksCount)
             }
         case (.action, .view, .firefoxHomepage, EventValue.recentlySavedReadingListView.rawValue, let extras):
             if let readingListItemsCount = extras?[EventObject.recentlySavedReadingItemImpressions.rawValue] as? String {
-                GleanMetrics.FirefoxHomePage.readingListView.record(extra: [.readingListCount: readingListItemsCount])
+                GleanMetrics.FirefoxHomePage.readingListView.record(GleanMetrics.FirefoxHomePage.ReadingListViewExtra(readingListCount: readingListItemsCount))
             }
         case (.action, .tap, .firefoxHomepage, EventValue.recentlySavedSectionShowAll.rawValue, _):
             GleanMetrics.FirefoxHomePage.recentlySavedShowAll.add()

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -853,9 +853,11 @@ preferences:
       recorded in the extra keys.
     extra_keys:
       preference:
+        type: string
         description: |
           The preference that was changed.
       changed_to:
+        type: string
         description: |
           The value the preference was changed to.
     bugs:

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -435,6 +435,7 @@ top_site:
           Type of tile pressed (Ex: google,
           suggested, user-added or history-based)
       position:
+        type: string
         description: |
           Position of top site.
     bugs:

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -430,6 +430,7 @@ top_site:
       Records an event when user taps on top site tile.
     extra_keys:
       tile_type:
+        type: string
         description: |
           Type of tile pressed (Ex: google,
           suggested, user-added or history-based)
@@ -519,6 +520,7 @@ firefox_home_page:
       in the Recently Saved section on the home page.
     extra_keys:
       bookmark_count:
+        type: string
         description: |
           The number of bookmarked items in the
           Recently Saved section.
@@ -537,6 +539,7 @@ firefox_home_page:
       on the Firefox home page.
     extra_keys:
       reading_list_count:
+        type: string
         description: |
           The number of reading list items in the
           Recently Saved section.

--- a/ClientTests/TelemetryWrapperTests.swift
+++ b/ClientTests/TelemetryWrapperTests.swift
@@ -1,0 +1,107 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+import MozillaAppServices
+import XCTest
+
+class TelemetryWrapperTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+
+        Glean.shared.resetGlean(clearStores: true)
+    }
+
+    // MARK: Top Site
+
+    func test_topSiteTileWithExtras_GleanIsCalled() {
+        let topSitePositionKey = TelemetryWrapper.EventExtraKey.topSitePosition.rawValue
+        let topSiteTileTypeKey = TelemetryWrapper.EventExtraKey.topSiteTileType.rawValue
+        let extras = [topSitePositionKey : "\(1)", topSiteTileTypeKey: "history-based"]
+        TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .topSiteTile, value: nil, extras: extras)
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.TopSite.tilePressed)
+    }
+
+    func test_topSiteTileWithoutExtras_GleanIsNotCalled() {
+        TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .topSiteTile, value: nil)
+        XCTAssertFalse(GleanMetrics.TopSite.tilePressed.testHasValue())
+    }
+
+    // MARK: Preferences
+
+    func test_preferencesWithExtras_GleanIsCalled() {
+        let extras: [String : Any] = [TelemetryWrapper.EventExtraKey.preference.rawValue: "ETP-strength",
+                                      TelemetryWrapper.EventExtraKey.preferenceChanged.rawValue: BlockingStrength.strict.rawValue]
+        TelemetryWrapper.recordEvent(category: .action, method: .change, object: .setting, extras: extras)
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Preferences.changed)
+    }
+
+    func test_preferencesWithoutExtras_GleanIsNotCalled() {
+        TelemetryWrapper.recordEvent(category: .action, method: .change, object: .setting)
+        XCTAssertFalse(GleanMetrics.Preferences.changed.testHasValue())
+    }
+
+    // MARK: Firefox Home Page
+
+    func test_recentlySavedBookmarkViewWithExtras_GleanIsCalled() {
+        let extras: [String : Any] = [TelemetryWrapper.EventObject.recentlySavedBookmarkImpressions.rawValue: "\([].count)"]
+        TelemetryWrapper.recordEvent(category: .action, method: .view, object: .firefoxHomepage, value: .recentlySavedBookmarkItemView, extras: extras)
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.FirefoxHomePage.recentlySavedBookmarkView)
+    }
+
+    func test_recentlySavedBookmarkViewWithoutExtras_GleanIsNotCalled() {
+        TelemetryWrapper.recordEvent(category: .action, method: .view, object: .firefoxHomepage, value: .recentlySavedBookmarkItemView)
+        XCTAssertFalse(GleanMetrics.FirefoxHomePage.recentlySavedBookmarkView.testHasValue())
+    }
+
+    func test_recentlySavedReadingListViewViewWithExtras_GleanIsCalled() {
+        let extras: [String : Any] = [TelemetryWrapper.EventObject.recentlySavedReadingItemImpressions.rawValue: "\([].count)"]
+        TelemetryWrapper.recordEvent(category: .action, method: .view, object: .firefoxHomepage, value: .recentlySavedReadingListView, extras: extras)
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.FirefoxHomePage.readingListView)
+    }
+
+    func test_recentlySavedReadingListViewWithoutExtras_GleanIsNotCalled() {
+        TelemetryWrapper.recordEvent(category: .action, method: .view, object: .firefoxHomepage, value: .recentlySavedReadingListView)
+        XCTAssertFalse(GleanMetrics.FirefoxHomePage.readingListView.testHasValue())
+    }
+
+    func test_firefoxHomePageAddView_GleanIsCalled() {
+        TelemetryWrapper.recordEvent(category: .action, method: .view, object: .firefoxHomepage, value: .fxHomepageOrigin)
+        testCounterMetricRecordingSuccess(metric: GleanMetrics.FirefoxHomePage.firefoxHomepageView)
+    }
+}
+
+// Helper functions
+extension TelemetryWrapperTests {
+
+    func testEventMetricRecordingSuccess<Keys: ExtraKeys, Extras: EventExtras>(metric: EventMetricType<Keys, Extras>,
+                                                                               file: StaticString = #file,
+                                                                               line: UInt = #line) {
+        XCTAssertTrue(metric.testHasValue())
+        XCTAssertEqual(try! metric.testGetValue().count, 1)
+
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidState), 0)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidValue), 0)
+    }
+
+    func testCounterMetricRecordingSuccess(metric: CounterMetricType,
+                                           file: StaticString = #file,
+                                           line: UInt = #line) {
+        XCTAssertTrue(metric.testHasValue())
+        XCTAssertEqual(try! metric.testGetValue(), 1)
+
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidState), 0)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidValue), 0)
+    }
+}

--- a/ClientTests/TelemetryWrapperTests.swift
+++ b/ClientTests/TelemetryWrapperTests.swift
@@ -73,8 +73,10 @@ class TelemetryWrapperTests: XCTestCase {
     }
 
     func test_firefoxHomePageAddView_GleanIsCalled() {
-        TelemetryWrapper.recordEvent(category: .action, method: .view, object: .firefoxHomepage, value: .fxHomepageOrigin)
-        testCounterMetricRecordingSuccess(metric: GleanMetrics.FirefoxHomePage.firefoxHomepageView)
+        let extras = [TelemetryWrapper.EventExtraKey.fxHomepageOrigin.rawValue: TelemetryWrapper.EventValue.fxHomepageOriginZeroSearch.rawValue]
+        TelemetryWrapper.recordEvent(category: .action, method: .view, object: .firefoxHomepage, value: .fxHomepageOrigin, extras: extras)
+
+        testLabeledMetricSuccess(metric: GleanMetrics.FirefoxHomePage.firefoxHomepageOrigin)
     }
 }
 
@@ -99,6 +101,15 @@ extension TelemetryWrapperTests {
         XCTAssertTrue(metric.testHasValue())
         XCTAssertEqual(try! metric.testGetValue(), 1)
 
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidState), 0)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidValue), 0)
+    }
+
+    func testLabeledMetricSuccess(metric: LabeledMetricType<CounterMetricType>,
+                                  file: StaticString = #file,
+                                  line: UInt = #line) {
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0)
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0)
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidState), 0)


### PR DESCRIPTION
PR to fix deprecation warnings using the Glean library.

The important part from the [documentation](https://mozilla.github.io/glean/book/reference/metrics/event.html#extra-metric-parameters) about recording event is the following:
![Screen Shot 2021-11-09 at 12 09 50 PM](https://user-images.githubusercontent.com/11338480/140972196-40cf384b-1b01-478c-8df4-8d8d5dc0ad34.png)

We need now to specify the type of the extra that is recorded to be able to use the latest API. The `record:extra` call is now deprecated. By specifying the type, we can use the new API since Glean will generate the required struct for us to use with the `record` call.