### PR TITLE
#9426 Recently saved section with compositional layout

### DIFF
--- a/Client/Frontend/Home/FxHomeRecentlySavedCollectionCell.swift
+++ b/Client/Frontend/Home/FxHomeRecentlySavedCollectionCell.swift
@@ -46,7 +46,6 @@ class FxHomeRecentlySavedCollectionCell: UICollectionViewCell {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: compositionalLayout)
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.showsHorizontalScrollIndicator = false
-        collectionView.alwaysBounceHorizontal = true
         collectionView.backgroundColor = UIColor.clear
         collectionView.dataSource = self
         collectionView.delegate = self

--- a/Client/Frontend/Home/FxHomeRecentlySavedCollectionCell.swift
+++ b/Client/Frontend/Home/FxHomeRecentlySavedCollectionCell.swift
@@ -190,7 +190,8 @@ extension FxHomeRecentlySavedCollectionCell: UICollectionViewDelegate {
 
 private struct RecentlySavedCellUX {
     static let generalCornerRadius: CGFloat = 12
-    static let bookmarkTitleMaxFontSize: CGFloat = 43 // Style caption1 - AX5
+    // TODO: Limiting font size to AX2 until we use compositional layout in all Firefox HomePage. Should be AX5.
+    static let bookmarkTitleMaxFontSize: CGFloat = 26 // Style caption1 - AX2
     static let generalSpacing: CGFloat = 8
     static let heroImageHeight: CGFloat = 92
     static let heroImageWidth: CGFloat = 110

--- a/Client/Frontend/Home/FxHomeRecentlySavedCollectionCell.swift
+++ b/Client/Frontend/Home/FxHomeRecentlySavedCollectionCell.swift
@@ -43,10 +43,7 @@ class FxHomeRecentlySavedCollectionCell: UICollectionViewCell {
     
     // UI
     lazy var collectionView: UICollectionView = {
-        let layout = UICollectionViewFlowLayout()
-        layout.scrollDirection = .horizontal
-        
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: compositionalLayout)
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.alwaysBounceHorizontal = true
@@ -56,6 +53,30 @@ class FxHomeRecentlySavedCollectionCell: UICollectionViewCell {
         collectionView.register(RecentlySavedCell.self, forCellWithReuseIdentifier: RecentlySavedCell.cellIdentifier)
         
         return collectionView
+    }()
+
+    private lazy var compositionalLayout: UICollectionViewCompositionalLayout = {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: NSCollectionLayoutDimension.absolute(RecentlySavedCollectionCellUX.cellWidth),
+            heightDimension: NSCollectionLayoutDimension.estimated(RecentlySavedCollectionCellUX.cellHeight)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        item.contentInsets = NSDirectionalEdgeInsets(top: RecentlySavedCollectionCellUX.generalSpacing,
+                                                     leading: RecentlySavedCollectionCellUX.sectionInsetSpacing,
+                                                     bottom: RecentlySavedCollectionCellUX.generalSpacing,
+                                                     trailing: RecentlySavedCollectionCellUX.sectionInsetSpacing)
+
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: NSCollectionLayoutDimension.absolute(RecentlySavedCollectionCellUX.cellWidth),
+            heightDimension: NSCollectionLayoutDimension.fractionalHeight(1)
+        )
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = RecentlySavedCollectionCellUX.generalSpacing
+        section.orthogonalScrollingBehavior = .continuous
+
+        return UICollectionViewCompositionalLayout(section: section)
     }()
     
     // MARK: - Inits
@@ -168,33 +189,14 @@ extension FxHomeRecentlySavedCollectionCell: UICollectionViewDelegate {
     }
 }
 
-extension FxHomeRecentlySavedCollectionCell: UICollectionViewDelegateFlowLayout {
-    
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: RecentlySavedCollectionCellUX.cellWidth, height: RecentlySavedCollectionCellUX.cellHeight)
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        return UIEdgeInsets(top: RecentlySavedCollectionCellUX.generalSpacing,
-                            left: RecentlySavedCollectionCellUX.sectionInsetSpacing,
-                            bottom: RecentlySavedCollectionCellUX.generalSpacing,
-                            right: RecentlySavedCollectionCellUX.sectionInsetSpacing)
-    }
-
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        return RecentlySavedCollectionCellUX.generalSpacing
-    }
-    
-}
-
 private struct RecentlySavedCellUX {
     static let generalCornerRadius: CGFloat = 12
-    static let bookmarkTitleFontSize: CGFloat = 17
-    static let bookmarkDetailsFontSize: CGFloat = 12
-    static let labelsWrapperSpacing: CGFloat = 4
-    static let bookmarkStackViewSpacing: CGFloat = 8
-    static let bookmarkStackViewShadowRadius: CGFloat = 4
-    static let bookmarkStackViewShadowOffset: CGFloat = 2
+    static let bookmarkTitleMaxFontSize: CGFloat = 43 // Style caption1 - AX5
+    static let generalSpacing: CGFloat = 8
+    static let heroImageHeight: CGFloat = 92
+    static let heroImageWidth: CGFloat = 110
+    static let recentlySavedCellShadowRadius: CGFloat = 4
+    static let recentlySavedCellShadowOffset: CGFloat = 2
 }
 
 /// A cell used in FxHomeScreen's Recently Saved section. It holds bookmarks and reading list items.
@@ -212,9 +214,11 @@ class RecentlySavedCell: UICollectionViewCell, NotificationThemeable {
         imageView.layer.cornerRadius = RecentlySavedCellUX.generalCornerRadius
         imageView.backgroundColor = .systemBackground
     }
+
     let itemTitle: UILabel = .build { label in
-        label.adjustsFontSizeToFitWidth = false
-        label.font = UIFont.systemFont(ofSize: RecentlySavedCellUX.bookmarkTitleFontSize)
+        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
+                                                                   maxSize: RecentlySavedCellUX.bookmarkTitleMaxFontSize)
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = .label
     }
     
@@ -240,8 +244,8 @@ class RecentlySavedCell: UICollectionViewCell, NotificationThemeable {
     
     private func setupLayout() {
         contentView.layer.cornerRadius = RecentlySavedCellUX.generalCornerRadius
-        contentView.layer.shadowRadius = RecentlySavedCellUX.bookmarkStackViewShadowRadius
-        contentView.layer.shadowOffset = CGSize(width: 0, height: RecentlySavedCellUX.bookmarkStackViewShadowOffset)
+        contentView.layer.shadowRadius = RecentlySavedCellUX.recentlySavedCellShadowRadius
+        contentView.layer.shadowOffset = CGSize(width: 0, height: RecentlySavedCellUX.recentlySavedCellShadowOffset)
         contentView.layer.shadowColor = UIColor.theme.homePanel.shortcutShadowColor
         contentView.layer.shadowOpacity = UIColor.theme.homePanel.shortcutShadowOpacity
         
@@ -251,12 +255,12 @@ class RecentlySavedCell: UICollectionViewCell, NotificationThemeable {
             heroImage.topAnchor.constraint(equalTo: contentView.topAnchor),
             heroImage.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             heroImage.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            heroImage.heightAnchor.constraint(equalToConstant: 92),
-            heroImage.widthAnchor.constraint(equalToConstant: 110),
+            heroImage.heightAnchor.constraint(equalToConstant: RecentlySavedCellUX.heroImageHeight),
+            heroImage.widthAnchor.constraint(equalToConstant: RecentlySavedCellUX.heroImageWidth),
             
-            itemTitle.topAnchor.constraint(equalTo: heroImage.bottomAnchor, constant: 8),
+            itemTitle.topAnchor.constraint(equalTo: heroImage.bottomAnchor, constant: RecentlySavedCellUX.generalSpacing),
             itemTitle.leadingAnchor.constraint(equalTo: heroImage.leadingAnchor),
-            itemTitle.trailingAnchor.constraint(equalTo: heroImage.trailingAnchor, constant: -2)
+            itemTitle.trailingAnchor.constraint(equalTo: heroImage.trailingAnchor)
         ])
     }
     


### PR DESCRIPTION
Introducing dynamic font for the Recently Saved section in the home page by using a compositional layout for the collection view instead of a flow layout. Since there's still the flow layout with fixed height sections in `FirefoxHomeViewController`, the easiest intermediate way to have dynamic font enabled is to limit the size to AX2 usage. This way, user can still grow their font size without having the text cut off at the bottom. This is for task https://github.com/mozilla-mobile/firefox-ios/issues/9426

Other sections to come later.

Here's how it looks on iPhone with normal font size:
![iPhone - Normal size](https://user-images.githubusercontent.com/11338480/141874269-c46c1b92-cf08-420f-a4a3-acb2e50847d7.png)

Here's how it looks on iPhone with big font size:
![iPhone - Large font](https://user-images.githubusercontent.com/11338480/141874275-9b9cde60-556e-406a-ae97-cab6473bcee0.png)

Here's how it looks on iPad with normal font size:
![iPad - Normal size](https://user-images.githubusercontent.com/11338480/141874286-82f5d28f-0217-4f3b-8aee-b6ba2988168c.png)

Here's how it looks on iPad with big font size:
![iPad - Large font](https://user-images.githubusercontent.com/11338480/141874295-afa51d1e-d797-4bdd-978a-ba5d30ea172c.png)
