### PR TITLE
#8942 favicon disappearing from top tab tray on app restart

### DIFF
--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -14,7 +14,6 @@ struct TopTabsUX {
     static let MaxTabWidth: CGFloat = 220
     static let FaderPading: CGFloat = 8
     static let SeparatorWidth: CGFloat = 1
-    static let HighlightLineWidth: CGFloat = 3
     static let TabNudge: CGFloat = 1 // Nudge the favicon and close button by 1px
     static let TabTitlePadding: CGFloat = 10
     static let AnimationSpeed: TimeInterval = 0.1

--- a/Client/Frontend/Browser/TopTabsViews.swift
+++ b/Client/Frontend/Browser/TopTabsViews.swift
@@ -123,15 +123,8 @@ class TopTabCell: UICollectionViewCell, NotificationThemeable, TabTrayCell {
         let hideCloseButton = frame.width < 148 && !selected
         closeButton.isHidden = hideCloseButton
 
-        if let siteURL = tab.url?.displayURL {
-            self.favicon.contentMode = .center
-            self.favicon.setImageAndBackground(forIcon: tab.displayFavicon, website: siteURL) { [weak self] in
-                guard let self = self else { return }
-                self.favicon.image = self.favicon.image?.createScaled(CGSize(width: 15, height: 15))
-                if self.favicon.backgroundColor == .clear {
-                    self.favicon.backgroundColor = .white
-                }
-            }
+        if let favIcon = tab.displayFavicon, let url = URL(string: favIcon.url) {
+            favicon.sd_setImage(with: url, placeholderImage: UIImage(named: "defaultFavicon"), options: [], completed: nil)
         } else {
             self.favicon.image = UIImage(named: "defaultFavicon")
             self.favicon.tintColor = UIColor.theme.tabTray.faviconTint

--- a/Client/Frontend/Browser/TopTabsViews.swift
+++ b/Client/Frontend/Browser/TopTabsViews.swift
@@ -106,19 +106,19 @@ class TopTabCell: UICollectionViewCell, NotificationThemeable, TabTrayCell {
 
         if tab.displayTitle.isEmpty {
             if let url = tab.webView?.url, let internalScheme = InternalURL(url) {
-                self.titleText.text = .AppMenuNewTabTitleString
-                self.accessibilityLabel = internalScheme.aboutComponent
+                titleText.text = .AppMenuNewTabTitleString
+                accessibilityLabel = internalScheme.aboutComponent
             } else {
-                self.titleText.text = tab.webView?.url?.absoluteDisplayString
+                titleText.text = tab.webView?.url?.absoluteDisplayString
             }
             
-            self.closeButton.accessibilityLabel = String(format: .TopSitesRemoveButtonAccessibilityLabel, self.titleText.text ?? "")
+            closeButton.accessibilityLabel = String(format: .TopSitesRemoveButtonAccessibilityLabel, self.titleText.text ?? "")
         } else {
-            self.accessibilityLabel = tab.displayTitle
-            self.closeButton.accessibilityLabel = String(format: .TopSitesRemoveButtonAccessibilityLabel, tab.displayTitle)
+            accessibilityLabel = tab.displayTitle
+            closeButton.accessibilityLabel = String(format: .TopSitesRemoveButtonAccessibilityLabel, tab.displayTitle)
         }
 
-        self.isSelectedTab = selected
+        isSelectedTab = selected
 
         let hideCloseButton = frame.width < 148 && !selected
         closeButton.isHidden = hideCloseButton
@@ -126,10 +126,10 @@ class TopTabCell: UICollectionViewCell, NotificationThemeable, TabTrayCell {
         if let favIcon = tab.displayFavicon, let url = URL(string: favIcon.url) {
             favicon.sd_setImage(with: url, placeholderImage: UIImage(named: "defaultFavicon"), options: [], completed: nil)
         } else {
-            self.favicon.image = UIImage(named: "defaultFavicon")
-            self.favicon.tintColor = UIColor.theme.tabTray.faviconTint
-            self.favicon.contentMode = .scaleAspectFit
-            self.favicon.backgroundColor = .clear
+            favicon.image = UIImage(named: "defaultFavicon")
+            favicon.tintColor = UIColor.theme.tabTray.faviconTint
+            favicon.contentMode = .scaleAspectFit
+            favicon.backgroundColor = .clear
         }
     }
 


### PR DESCRIPTION
First step for issue https://github.com/mozilla-mobile/firefox-ios/issues/8942
This is fixing the favicon disappearing in the top tab tray on a restart of the app. Title disappearing from the tabs will be in a separate PR, so issue is still not completely done.