### PR TITLE
#9288 Bottom toolbar icon size shrinks

### DIFF
--- a/Client/UIWindowExtensions.swift
+++ b/Client/UIWindowExtensions.swift
@@ -7,7 +7,7 @@ import Foundation
 extension UIWindow {
     static var keyWindow: UIWindow? {
         return UIApplication.shared.connectedScenes
-            .filter { $0.activationState == .foregroundActive }
+            .filter { $0.activationState == .foregroundActive || $0.activationState == .foregroundInactive }
             .first(where: { $0 is UIWindowScene })
             .flatMap({ $0 as? UIWindowScene })?.windows
             .first(where: \.isKeyWindow)


### PR DESCRIPTION
Check for inactive scenes in keyWindow so during app loading the window is retrieved. Background scenes still ignored.

This will fix bottom toolbar [issue](https://github.com/mozilla-mobile/firefox-ios/issues/9288) since we were trying to fetch the bottomInset for the BottomToolbarHeight at launch, and was set to 0 instead since the window was inactive.