### PR TITLE
#8942 Title disappearing from tabs

### DIFF
--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -775,6 +775,30 @@ protocol TabTrayCell where Self: UICollectionViewCell {
     func configureWith(tab: Tab, isSelected selected: Bool)
 }
 
+extension TabTrayCell {
+
+    /// Use the display title unless it's an empty string, then use the base domain from the url
+    func getTabTrayTitle(tab: Tab) -> String? {
+        let baseDomain = tab.sessionData?.urls.last?.baseDomain ?? tab.url?.baseDomain
+        let urlLabel = baseDomain != nil ? baseDomain!.contains("local") ? "" : baseDomain : ""
+        return tab.displayTitle.isEmpty ? urlLabel : tab.displayTitle
+    }
+
+    func getA11yTitleLabel(tab: Tab) -> String? {
+        var aboutComponent = ""
+        if let url = tab.url, let about = InternalURL(url)?.aboutComponent { aboutComponent = about }
+        let baseName = tab.displayTitle.isEmpty ? aboutComponent.isEmpty ? getTabTrayTitle(tab: tab) : aboutComponent : tab.displayTitle
+
+        if isSelectedTab, let baseName = baseName {
+            return baseName + ". " + String.TabTrayCurrentlySelectedTabAccessibilityLabel
+        } else if isSelectedTab {
+            return String.TabTrayCurrentlySelectedTabAccessibilityLabel
+        } else {
+            return baseName
+        }
+    }
+}
+
 class TabCell: UICollectionViewCell, TabTrayCell {
 
     enum Style {
@@ -902,18 +926,9 @@ class TabCell: UICollectionViewCell, TabTrayCell {
 
     func configureWith(tab: Tab, isSelected selected: Bool) {
         isSelectedTab = selected
-        titleText.text = tab.displayTitle
 
-        if selected {
-            accessibilityLabel = tab.displayTitle + ". " + String.TabTrayCurrentlySelectedTabAccessibilityLabel
-        } else if !tab.displayTitle.isEmpty {
-            accessibilityLabel = tab.displayTitle
-        } else if let url = tab.url, let about = InternalURL(url)?.aboutComponent {
-            accessibilityLabel = about
-        } else {
-            accessibilityLabel = ""
-        }
-
+        titleText.text = getTabTrayTitle(tab: tab)
+        accessibilityLabel = getA11yTitleLabel(tab: tab)
         isAccessibilityElement = true
         accessibilityHint = .TabTraySwipeToCloseAccessibilityHint
 

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -789,7 +789,7 @@ extension TabTrayCell {
         if let url = tab.url, let about = InternalURL(url)?.aboutComponent { aboutComponent = about }
         let baseName = tab.displayTitle.isEmpty ? aboutComponent.isEmpty ? getTabTrayTitle(tab: tab) : aboutComponent : tab.displayTitle
 
-        if isSelectedTab, let baseName = baseName {
+        if isSelectedTab, let baseName = baseName, !baseName.isEmpty {
             return baseName + ". " + String.TabTrayCurrentlySelectedTabAccessibilityLabel
         } else if isSelectedTab {
             return String.TabTrayCurrentlySelectedTabAccessibilityLabel

--- a/Client/Frontend/Browser/TopTabsViews.swift
+++ b/Client/Frontend/Browser/TopTabsViews.swift
@@ -102,23 +102,12 @@ class TopTabCell: UICollectionViewCell, NotificationThemeable, TabTrayCell {
     }
 
     func configureWith(tab: Tab, isSelected selected: Bool) {
-        self.titleText.text = tab.displayTitle
-
-        if tab.displayTitle.isEmpty {
-            if let url = tab.webView?.url, let internalScheme = InternalURL(url) {
-                titleText.text = .AppMenuNewTabTitleString
-                accessibilityLabel = internalScheme.aboutComponent
-            } else {
-                titleText.text = tab.webView?.url?.absoluteDisplayString
-            }
-            
-            closeButton.accessibilityLabel = String(format: .TopSitesRemoveButtonAccessibilityLabel, self.titleText.text ?? "")
-        } else {
-            accessibilityLabel = tab.displayTitle
-            closeButton.accessibilityLabel = String(format: .TopSitesRemoveButtonAccessibilityLabel, tab.displayTitle)
-        }
-
         isSelectedTab = selected
+
+        titleText.text = getTabTrayTitle(tab: tab)
+        accessibilityLabel = getA11yTitleLabel(tab: tab)
+
+        closeButton.accessibilityLabel = String(format: .TopSitesRemoveButtonAccessibilityLabel, self.titleText.text ?? "")
 
         let hideCloseButton = frame.width < 148 && !selected
         closeButton.isHidden = hideCloseButton

--- a/Client/Frontend/Browser/TopTabsViews.swift
+++ b/Client/Frontend/Browser/TopTabsViews.swift
@@ -43,6 +43,7 @@ class TopTabCell: UICollectionViewCell, NotificationThemeable, TabTrayCell {
         titleText.lineBreakMode = .byCharWrapping
         titleText.font = DynamicFontHelper.defaultHelper.DefaultSmallFont
         titleText.semanticContentAttribute = .forceLeftToRight
+        titleText.isAccessibilityElement = false
         return titleText
     }()
 
@@ -106,6 +107,7 @@ class TopTabCell: UICollectionViewCell, NotificationThemeable, TabTrayCell {
 
         titleText.text = getTabTrayTitle(tab: tab)
         accessibilityLabel = getA11yTitleLabel(tab: tab)
+        isAccessibilityElement = true
 
         closeButton.accessibilityLabel = String(format: .TopSitesRemoveButtonAccessibilityLabel, self.titleText.text ?? "")
 


### PR DESCRIPTION
In top tab tray and tab tray for issue https://github.com/mozilla-mobile/firefox-ios/issues/8942
- Using the display title unless it's empty, then use the base domain from the URL
- Standardize a11y for VoiceOver (Top tab tray wasn't reading that the tab was selected)
- Fix that top tab tray selected tab had no title with VoiceOver (whole cell has the a11yLabel and should be read out loud, not the titleText)