### PR TITLE
#9516 Tab count was wrong after a tab removal

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -388,6 +388,7 @@
 		8A11C80F2731916E00AC7318 /* defaultOnlyTestList.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A11C80D2731916E00AC7318 /* defaultOnlyTestList.json */; };
 		8A11C8112731CFD700AC7318 /* ReaderModeStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */; };
 		8A11C8132731E54800AC7318 /* DictionaryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */; };
+		8A8A05E927470556004267A0 /* TabTrayViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8A05E827470556004267A0 /* TabTrayViewControllerTests.swift */; };
 		8AA6ADB52742B567004EEE23 /* TelemetryWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA6ADB42742B567004EEE23 /* TelemetryWrapperTests.swift */; };
 		8D8251811F4DE67F00780643 /* AdvancedAccountSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8251721F4DE67E00780643 /* AdvancedAccountSettingViewController.swift */; };
 		8DCD3BCD1ED5B7FA00446D38 /* FxADeepLinkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DCD3BCC1ED5B7FA00446D38 /* FxADeepLinkingTests.swift */; };
@@ -2545,6 +2546,7 @@
 		8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeStyleTests.swift; sourceTree = "<group>"; };
 		8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryExtensionsTests.swift; sourceTree = "<group>"; };
 		8A5143D6BF179870414566ED /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Search.strings; sourceTree = "<group>"; };
+		8A8A05E827470556004267A0 /* TabTrayViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabTrayViewControllerTests.swift; sourceTree = "<group>"; };
 		8AA6ADB42742B567004EEE23 /* TelemetryWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryWrapperTests.swift; sourceTree = "<group>"; };
 		8AAD4900BB6F4DF6056B581F /* ml */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ml; path = ml.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		8AB04613B101195AADCC1F1B /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = "cs.lproj/Default Browser.strings"; sourceTree = "<group>"; };
@@ -6224,6 +6226,7 @@
 				D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */,
 				F84B21D71A090F8100AAB793 /* Supporting Files */,
 				554867221DC3935A00183DAA /* HomePageTests.swift */,
+				8A8A05E827470556004267A0 /* TabTrayViewControllerTests.swift */,
 				39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */,
 				D8EFFA251FF702A8001D3A09 /* NavigationRouterTests.swift */,
 				39C137962655798A003DC662 /* NimbusIntegrationTests.swift */,
@@ -8385,6 +8388,7 @@
 				E1D8BC7A21FF7A0000B100BD /* TPStatsBlocklistsTests.swift in Sources */,
 				D82ED2641FEB3C420059570B /* DefaultSearchPrefsTests.swift in Sources */,
 				CA24B53B24ABFE5D0093848C /* LoginsListDataSourceHelperTests.swift in Sources */,
+				8A8A05E927470556004267A0 /* TabTrayViewControllerTests.swift in Sources */,
 				3B61CD591F2A750800D38DE1 /* PocketFeedTests.swift in Sources */,
 				43446CF02412DDBE00F5C643 /* UpdateCoverSheetViewModelTests.swift in Sources */,
 				3B6F40181DC7849C00656CC6 /* FirefoxHomeTests.swift in Sources */,

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -308,7 +308,9 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
 extension GridTabViewController: TabManagerDelegate {
     func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?, isRestoring: Bool) {}
     func tabManager(_ tabManager: TabManager, didAddTab tab: Tab, placeNextToParentTab: Bool, isRestoring: Bool) {}
-    func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool) {}
+    func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool) {
+        NotificationCenter.default.post(name: .TabClosed, object: nil)
+    }
     func tabManagerDidAddTabs(_ tabManager: TabManager) {}
 
     func tabManagerDidRestoreTabs(_ tabManager: TabManager) {

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -137,10 +137,20 @@ class TabTrayViewController: UIViewController {
     }
 
     // Initializers
-    init(tabTrayDelegate: TabTrayDelegate? = nil, profile: Profile, showChronTabs: Bool = false, tabToFocus: Tab? = nil) {
-        self.viewModel = TabTrayViewModel(tabTrayDelegate: tabTrayDelegate, profile: profile, showChronTabs: showChronTabs, tabToFocus: tabToFocus)
+    init(tabTrayDelegate: TabTrayDelegate? = nil,
+         profile: Profile,
+         showChronTabs: Bool = false,
+         tabToFocus: Tab? = nil,
+         tabManager: TabManager = BrowserViewController.foregroundBVC().tabManager) {
+
+        self.viewModel = TabTrayViewModel(tabTrayDelegate: tabTrayDelegate,
+                                          profile: profile,
+                                          showChronTabs: showChronTabs,
+                                          tabToFocus: tabToFocus,
+                                          tabManager: tabManager)
 
         super.init(nibName: nil, bundle: nil)
+        setupNotifications()
     }
 
     required init?(coder: NSCoder) {
@@ -154,9 +164,9 @@ class TabTrayViewController: UIViewController {
     // Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
+
         viewSetup()
         applyTheme()
-        setupNotifications()
         updatePrivateUIState()
     }
 

--- a/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
@@ -18,9 +18,13 @@ class TabTrayViewModel {
         (tabManager.normalTabs.count < 100) ? tabManager.normalTabs.count.description : "\u{221E}"
     }
 
-    init(tabTrayDelegate: TabTrayDelegate? = nil, profile: Profile, showChronTabs: Bool = false, tabToFocus: Tab? = nil) {
+    init(tabTrayDelegate: TabTrayDelegate? = nil,
+         profile: Profile,
+         showChronTabs: Bool = false,
+         tabToFocus: Tab? = nil,
+         tabManager: TabManager) {
         self.profile = profile
-        self.tabManager = BrowserViewController.foregroundBVC().tabManager
+        self.tabManager = tabManager
 
         if showChronTabs {
             self.tabTrayView = ChronologicalTabsViewController(tabTrayDelegate: tabTrayDelegate, profile: self.profile)

--- a/ClientTests/TabTrayViewControllerTests.swift
+++ b/ClientTests/TabTrayViewControllerTests.swift
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+@testable import Client
+
+import XCTest
+
+class TabTrayViewControllerTests: XCTestCase {
+
+    var profile: TabManagerMockProfile!
+    var manager: TabManager!
+    var tabTray: TabTrayViewController!
+    var gridTab: GridTabViewController!
+
+    override func setUp() {
+        super.setUp()
+
+        profile = TabManagerMockProfile()
+        manager = TabManager(profile: profile, imageStore: nil)
+        tabTray = TabTrayViewController(tabTrayDelegate: nil, profile: profile, showChronTabs: false, tabToFocus: nil, tabManager: manager)
+        gridTab = GridTabViewController(tabManager: manager, profile: profile)
+        manager.addDelegate(gridTab)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        profile = nil
+        manager = nil
+        tabTray = nil
+        gridTab = nil
+    }
+
+    func testCountUpdatesAfterTabRemoval() {
+        let tabToRemove = manager.addTab()
+        manager.addTab()
+
+        XCTAssertEqual(tabTray.viewModel.normalTabsCount, "2")
+        XCTAssertEqual(tabTray.countLabel.text, "2")
+
+        // Wait for notification of .TabClosed when tab is removed
+        weak var expectation = self.expectation(description: "notificationReceived")
+        NotificationCenter.default.addObserver(forName: .TabClosed, object: nil, queue: nil) { notification in
+            expectation?.fulfill()
+        }
+        manager.removeTabAndUpdateSelectedIndex(tabToRemove)
+        waitForExpectations(timeout: 1.0, handler: nil)
+
+        XCTAssertEqual(tabTray.viewModel.normalTabsCount, "1")
+        XCTAssertEqual(tabTray.countLabel.text, "1")
+    }
+}


### PR DESCRIPTION
Bug fix #9516 - Tab count was wrong after a tab removal
- Issue was that the notification was not sent to the TabTrayViewController, so the count wasn't adjusted
- Added unit tests as well
- Injection of the TabTrayViewModel of the tabManager