### PR TITLE
#9204 Added tab index in tab tray

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -388,6 +388,7 @@
 		8A11C80F2731916E00AC7318 /* defaultOnlyTestList.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A11C80D2731916E00AC7318 /* defaultOnlyTestList.json */; };
 		8A11C8112731CFD700AC7318 /* ReaderModeStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */; };
 		8A11C8132731E54800AC7318 /* DictionaryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */; };
+		8A8A05E42746ACAC004267A0 /* TabDisplayManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8A05E32746ACAC004267A0 /* TabDisplayManagerTests.swift */; };
 		8AA6ADB52742B567004EEE23 /* TelemetryWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA6ADB42742B567004EEE23 /* TelemetryWrapperTests.swift */; };
 		8D8251811F4DE67F00780643 /* AdvancedAccountSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8251721F4DE67E00780643 /* AdvancedAccountSettingViewController.swift */; };
 		8DCD3BCD1ED5B7FA00446D38 /* FxADeepLinkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DCD3BCC1ED5B7FA00446D38 /* FxADeepLinkingTests.swift */; };
@@ -2545,6 +2546,7 @@
 		8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeStyleTests.swift; sourceTree = "<group>"; };
 		8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryExtensionsTests.swift; sourceTree = "<group>"; };
 		8A5143D6BF179870414566ED /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Search.strings; sourceTree = "<group>"; };
+		8A8A05E32746ACAC004267A0 /* TabDisplayManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDisplayManagerTests.swift; sourceTree = "<group>"; };
 		8AA6ADB42742B567004EEE23 /* TelemetryWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryWrapperTests.swift; sourceTree = "<group>"; };
 		8AAD4900BB6F4DF6056B581F /* ml */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ml; path = ml.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		8AB04613B101195AADCC1F1B /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = "cs.lproj/Default Browser.strings"; sourceTree = "<group>"; };
@@ -6214,6 +6216,7 @@
 				8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */,
 				E60D03291D5118DB002FE3F6 /* SyncStatusResolverTests.swift */,
 				7BBFEE731BB405D900A305AA /* TabManagerTests.swift */,
+				8A8A05E32746ACAC004267A0 /* TabDisplayManagerTests.swift */,
 				0BA8964A1A250E6500C1010C /* TestBookmarks.swift */,
 				0BF42D4E1A7CD09600889E28 /* TestFavicons.swift */,
 				2F44FA1A1A9D426A00FD20CC /* TestHashExtensions.swift */,
@@ -8351,6 +8354,7 @@
 				3B39EDBA1E16E18900EF029F /* CustomSearchEnginesTest.swift in Sources */,
 				8AA6ADB52742B567004EEE23 /* TelemetryWrapperTests.swift in Sources */,
 				43446CF32412F9FF00F5C643 /* ETPCoverSheetTests.swift in Sources */,
+				8A8A05E42746ACAC004267A0 /* TabDisplayManagerTests.swift in Sources */,
 				D3FA777B1A43B2990010CD32 /* SearchTests.swift in Sources */,
 				D3BA41681BD82F2200DA5457 /* XCTestCaseExtensions.swift in Sources */,
 				554867231DC3935A00183DAA /* HomePageTests.swift in Sources */,

--- a/ClientTests/TabDisplayManagerTests.swift
+++ b/ClientTests/TabDisplayManagerTests.swift
@@ -1,0 +1,239 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+import WebKit
+import Shared
+import XCTest
+
+class TabDisplayManagerTests: XCTestCase {
+
+    var tabCellIdentifer: TabDisplayer.TabCellIdentifer = TopTabCell.Identifier
+
+    var mockDataStore = WeakListMock<Tab>()
+    var dataStore = WeakList<Tab>()
+    var collectionView: MockCollectionView!
+    var profile: TabManagerMockProfile!
+    var manager: TabManager!
+
+    override func setUp() {
+        super.setUp()
+
+        profile = TabManagerMockProfile()
+        manager = TabManager(profile: profile, imageStore: nil)
+        collectionView = MockCollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        profile._shutdown()
+        manager.removeAll()
+        manager.testClearArchive()
+        profile = nil
+        manager = nil
+        collectionView = nil
+        dataStore.removeAll()
+        mockDataStore.removeAll()
+    }
+
+    // MARK: Index to place tab
+
+    func testIndexToPlaceTab_countAtZero_placeAtZero() {
+        mockDataStore.countToReturn = 0
+        let tabDisplayManager = createTabDisplayManager()
+        let index = tabDisplayManager.getIndexToPlaceTab(placeNextToParentTab: false)
+
+        XCTAssertEqual(index, 0)
+    }
+
+    func testIndexToPlaceTab_countAtOne_placeAtOne() {
+        mockDataStore.countToReturn = 1
+        let tabDisplayManager = createTabDisplayManager()
+        let index = tabDisplayManager.getIndexToPlaceTab(placeNextToParentTab: false)
+
+        XCTAssertEqual(index, 1)
+    }
+
+    func testIndexToPlaceTab_countAtTwo_placeAtTwo() {
+        mockDataStore.countToReturn = 2
+        let tabDisplayManager = createTabDisplayManager()
+        let index = tabDisplayManager.getIndexToPlaceTab(placeNextToParentTab: false)
+
+        XCTAssertEqual(index, 2)
+    }
+
+    func testIndexToPlaceTab_countAtMinusOne_placeAtZero() {
+        mockDataStore.countToReturn = -1
+        let tabDisplayManager = createTabDisplayManager()
+        let index = tabDisplayManager.getIndexToPlaceTab(placeNextToParentTab: false)
+
+        XCTAssertEqual(index, 0)
+    }
+
+    func testIndexToPlaceTab_hasOneTab_newTabAtIndex1() {
+        let tabDisplayManager = createTabDisplayManager(useMockDataStore: false)
+
+        // Add one tab
+        let selectedTab = manager.addTab()
+        manager.selectTab(selectedTab)
+        XCTAssertEqual(tabDisplayManager.dataStore.count, 1)
+
+        // Add new tab
+        let newTab = manager.addTab()
+
+        XCTAssertEqual(tabDisplayManager.dataStore.count, 2)
+        XCTAssertEqual(manager.tabs[1].tabUUID, newTab.tabUUID, "New tab should be placed at last position, at index 1")
+        XCTAssertEqual(tabDisplayManager.dataStore.at(1)?.tabUUID, newTab.tabUUID, "New tab should be placed at last position, at index 1")
+    }
+
+    func testIndexToPlaceTab_hasThreeTabsLastSelected_newTabAtIndex3() {
+        let tabDisplayManager = createTabDisplayManager(useMockDataStore: false)
+
+        // Add three tab
+        manager.addTab()
+        manager.addTab()
+        let selectedTab = manager.addTab()
+        manager.selectTab(selectedTab)
+        XCTAssertEqual(tabDisplayManager.dataStore.count, 3)
+
+        // Add new tab
+        let newTab = manager.addTab()
+
+        XCTAssertEqual(tabDisplayManager.dataStore.count, 4)
+        XCTAssertEqual(manager.tabs[3].tabUUID, newTab.tabUUID, "New tab should be placed at last position, at index 3")
+        XCTAssertEqual(tabDisplayManager.dataStore.at(3)?.tabUUID, newTab.tabUUID, "New tab should be placed at last position, at index 3")
+    }
+
+    func testIndexToPlaceTab_hasThreeTabsFirstSelected_newTabAtIndex3() {
+        let tabDisplayManager = createTabDisplayManager(useMockDataStore: false)
+
+        // Add three tab
+        manager.addTab()
+        manager.addTab()
+        let selectedTab = manager.addTab()
+        manager.selectTab(selectedTab)
+        XCTAssertEqual(tabDisplayManager.dataStore.count, 3)
+
+        // Add new tab
+        let newTab = manager.addTab()
+
+        XCTAssertEqual(tabDisplayManager.dataStore.count, 4)
+        XCTAssertEqual(manager.tabs[3].tabUUID, newTab.tabUUID, "New tab should be placed at last position, at index 3")
+        XCTAssertEqual(tabDisplayManager.dataStore.at(3)?.tabUUID, newTab.tabUUID, "New tab should be placed at last position, at index 3")
+    }
+
+    // MARK: Place tab next to parent tab
+
+    func testPlaceNextToParentTab_parentWasLastTab_newTabPlaceIsLast() {
+        let tabDisplayManager = createTabDisplayManager(useMockDataStore: false)
+
+        // Add three tabs with parent at last position
+        manager.addTab()
+        manager.addTab()
+        let parentTab = manager.addTab()
+        manager.selectTab(parentTab)
+        XCTAssertEqual(tabDisplayManager.dataStore.count, 3)
+
+        // Add child tab after parent
+        let childTab = manager.addTab(afterTab: parentTab)
+
+        XCTAssertEqual(tabDisplayManager.dataStore.count, 4)
+        XCTAssertEqual(manager.tabs[3].tabUUID, childTab.tabUUID, "Child tab should be placed after the parent tab, at index 3")
+        XCTAssertEqual(tabDisplayManager.dataStore.at(3)?.tabUUID, childTab.tabUUID, "Child tab should be placed after the parent tab, at index 3")
+    }
+
+    func testPlaceNextToParentTab_parentWasNotLastTab_newTabPlaceIsAfterParent() {
+        let tabDisplayManager = createTabDisplayManager(useMockDataStore: false)
+
+        // Add three tabs with parent at second position, not last
+        manager.addTab()
+        let parentTab = manager.addTab()
+        manager.addTab()
+        manager.selectTab(parentTab)
+        XCTAssertEqual(tabDisplayManager.dataStore.count, 3)
+
+        // Add child tab after parent
+        let childTab = manager.addTab(afterTab: parentTab)
+
+        XCTAssertEqual(tabDisplayManager.dataStore.count, 4)
+        XCTAssertEqual(manager.tabs[2].tabUUID, childTab.tabUUID, "Child tab should be placed after the parent tab, at index 2")
+        XCTAssertEqual(tabDisplayManager.dataStore.at(2)?.tabUUID, childTab.tabUUID, "Child tab should be placed after the parent tab, at index 2")
+    }
+
+    func testPlaceNextToParentTab_parentWasFirstTab_newTabPlaceIsAfterParent() {
+        let tabDisplayManager = createTabDisplayManager(useMockDataStore: false)
+
+        // Add three tabs with parent at first position
+        let parentTab = manager.addTab()
+        manager.addTab()
+        manager.addTab()
+        manager.selectTab(parentTab)
+        XCTAssertEqual(tabDisplayManager.dataStore.count, 3)
+
+        // Add child tab after parent
+        let childTab = manager.addTab(afterTab: parentTab)
+
+        XCTAssertEqual(tabDisplayManager.dataStore.count, 4)
+        XCTAssertEqual(manager.tabs[1].tabUUID, childTab.tabUUID, "Child tab should be placed after the parent tab, at index 1")
+        XCTAssertEqual(tabDisplayManager.dataStore.at(1)?.tabUUID, childTab.tabUUID, "Child tab should be placed after the parent tab, at index 1")
+    }
+}
+
+// Helper methods
+extension TabDisplayManagerTests {
+
+    func createTabDisplayManager(useMockDataStore: Bool = true) -> TabDisplayManager {
+        let tabDisplayManager = TabDisplayManager(collectionView: collectionView,
+                                                  tabManager: manager,
+                                                  tabDisplayer: self,
+                                                  reuseID: TopTabCell.Identifier,
+                                                  tabDisplayType: .TopTabTray,
+                                                  profile: profile)
+        collectionView.dataSource = tabDisplayManager
+        tabDisplayManager.dataStore = useMockDataStore ? mockDataStore : dataStore
+        return tabDisplayManager
+    }
+}
+
+extension TabDisplayManagerTests: TabDisplayer {
+
+    func focusSelectedTab() {}
+
+    func cellFactory(for cell: UICollectionViewCell, using tab: Tab) -> UICollectionViewCell {
+        guard let tabCell = cell as? TopTabCell else { return UICollectionViewCell() }
+        let isSelected = (tab == manager.selectedTab)
+        tabCell.configureWith(tab: tab, isSelected: isSelected)
+        tabCell.applyTheme()
+        return tabCell
+    }
+}
+
+class WeakListMock<T: AnyObject>: WeakList<T> {
+
+    var countToReturn: Int = 0
+    override var count: Int {
+        return countToReturn
+    }
+}
+
+class MockCollectionView: UICollectionView {
+
+    override init(frame: CGRect, collectionViewLayout: UICollectionViewLayout) {
+        super.init(frame: frame, collectionViewLayout: collectionViewLayout)
+
+        register(TopTabCell.self, forCellWithReuseIdentifier: TopTabCell.Identifier)
+        register(InactiveTabCell.self, forCellWithReuseIdentifier: InactiveTabCell.Identifier)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func performBatchUpdates(_ updates: (() -> Void)?, completion: ((Bool) -> Void)? = nil) {
+        updates?()
+        completion?(true)
+    }
+}


### PR DESCRIPTION
Fix issue #9204 where if tab count was at 1, then the tab was placed at the first position instead of the second
- Adjusted the `var indexToPlaceTab` so it accounts for this use case
- Added unit tests for this indexToPlaceTab as well as placeNextToParentTab

