### PR TITLE
#9288 Bottom toolbar shrinked

### DIFF
--- a/Client/Frontend/UIConstants+BottomInset.swift
+++ b/Client/Frontend/UIConstants+BottomInset.swift
@@ -8,7 +8,7 @@ extension UIConstants {
     static var BottomToolbarHeight: CGFloat {
         get {
             var bottomInset: CGFloat = 0.0
-            if let window = UIWindow.keyWindow {
+            if let window = UIWindow.attachedKeyWindow {
                 bottomInset = window.safeAreaInsets.bottom
             }
             return ToolbarHeight + bottomInset

--- a/Client/UIWindowExtensions.swift
+++ b/Client/UIWindowExtensions.swift
@@ -7,7 +7,7 @@ import Foundation
 extension UIWindow {
     static var keyWindow: UIWindow? {
         return UIApplication.shared.connectedScenes
-            .filter { $0.activationState == .foregroundActive }
+            .filter { $0.activationState == .foregroundActive || $0.activationState == .foregroundInactive }
             .first(where: { $0 is UIWindowScene })
             .flatMap({ $0 as? UIWindowScene })?.windows
             .first(where: \.isKeyWindow)

--- a/Client/UIWindowExtensions.swift
+++ b/Client/UIWindowExtensions.swift
@@ -7,7 +7,16 @@ import Foundation
 extension UIWindow {
     static var keyWindow: UIWindow? {
         return UIApplication.shared.connectedScenes
-            .filter { $0.activationState == .foregroundActive || $0.activationState == .foregroundInactive }
+            .filter { $0.activationState == .foregroundActive }
+            .first(where: { $0 is UIWindowScene })
+            .flatMap({ $0 as? UIWindowScene })?.windows
+            .first(where: \.isKeyWindow)
+    }
+
+    /// Filter for any scenes that is attached (i.e. active, inactive and background)
+    static var attachedKeyWindow: UIWindow? {
+        return UIApplication.shared.connectedScenes
+            .filter { $0.activationState != .unattached }
             .first(where: { $0 is UIWindowScene })
             .flatMap({ $0 as? UIWindowScene })?.windows
             .first(where: \.isKeyWindow)

--- a/Client/UIWindowExtensions.swift
+++ b/Client/UIWindowExtensions.swift
@@ -7,7 +7,7 @@ import Foundation
 extension UIWindow {
     static var keyWindow: UIWindow? {
         return UIApplication.shared.connectedScenes
-            .filter { $0.activationState == .foregroundActive || $0.activationState == .foregroundInactive }
+            .filter { $0.activationState == .foregroundActive }
             .first(where: { $0 is UIWindowScene })
             .flatMap({ $0 as? UIWindowScene })?.windows
             .first(where: \.isKeyWindow)

--- a/Client/UIWindowExtensions.swift
+++ b/Client/UIWindowExtensions.swift
@@ -13,7 +13,7 @@ extension UIWindow {
             .first(where: \.isKeyWindow)
     }
 
-    /// Filter for any scenes that is attached (i.e. active, inactive and background)
+    /// Filter for any scenes that are attached, regardless of state (i.e. active, inactive and background)
     static var attachedKeyWindow: UIWindow? {
         return UIApplication.shared.connectedScenes
             .filter { $0.activationState != .unattached }


### PR DESCRIPTION
Testing on real device, the window can be retrieved in background while setting the `BottomToolbarHeight`. I reverted my changes from https://github.com/mozilla-mobile/firefox-ios/pull/9520, so `BottomToolbarHeight` uses `attachedKeyWindow` instead of `keyWindow`. That way only the bottom tool bar filter for background window, and tool bar has the required height.
