### PR TITLE
FXIOS-3276: Missing screenshot in Tab Tray 

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1154,7 +1154,6 @@ class BrowserViewController: UIViewController {
     func openURLInNewTab(_ url: URL?, isPrivate: Bool = false) {
         if let selectedTab = tabManager.selectedTab {
             screenshotHelper.takeScreenshot(selectedTab)
-//            tabManager.storeScreenshot(tab: selectedTab)
         }
         let request: URLRequest?
         if let url = url {
@@ -1312,7 +1311,6 @@ class BrowserViewController: UIViewController {
                 // Issue created: https://github.com/mozilla-mobile/firefox-ios/issues/7003
                 DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
                     self.screenshotHelper.takeScreenshot(tab)
-//                    self.tabManager.storeScreenshot(tab: tab)
                     if webView.superview == self.view {
                         webView.removeFromSuperview()
                     }
@@ -1323,32 +1321,6 @@ class BrowserViewController: UIViewController {
                 }
             }
         }
-        
-        /*
-        switch webViewStatus {
-        case .title, .url, .finishedNavigation:
-            if tab !== tabManager.selectedTab, let webView = tab.webView {
-                // To Screenshot a tab that is hidden we must add the webView,
-                // then wait enough time for the webview to render.
-                view.insertSubview(webView, at: 0)
-                // This is kind of a hacky fix for Bug 1476637 to prevent webpages from focusing the
-                // touch-screen keyboard from the background even though they shouldn't be able to.
-                webView.resignFirstResponder()
-
-                // We need a better way of identifying when webviews are finished rendering
-                // There are cases in which the page will still show a loading animation or nothing when the screenshot is being taken,
-                // depending on internet connection
-                // Issue created: https://github.com/mozilla-mobile/firefox-ios/issues/7003
-                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(2000)) {
-                    self.screenshotHelper.takeScreenshot(tab)
-                    self.tabManager.storeScreenshot(tab: tab)
-                    if webView.superview == self.view {
-                        webView.removeFromSuperview()
-                    }
-                }
-            }
-        }
-        */
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -619,7 +619,6 @@ class BrowserViewController: UIViewController {
         presentDBOnboardingViewController()
         presentUpdateViewController()
         screenshotHelper.viewIsVisible = true
-//        screenshotHelper.takePendingScreenshots(tabManager.tabs)
 
         super.viewDidAppear(animated)
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1296,6 +1296,10 @@ class BrowserViewController: UIViewController {
         // Represents WebView observation or delegate update that called this function
         
         if webViewStatus == .finishedNavigation {
+            // A delay of 500 milliseconds is added when we take screenshot
+            // as we don't know exactly when wkwebview is rendered
+            let delayedTimeInterval = DispatchTimeInterval.milliseconds(500)
+
             if tab !== tabManager.selectedTab, let webView = tab.webView {
                 // To Screenshot a tab that is hidden we must add the webView,
                 // then wait enough time for the webview to render.
@@ -1308,14 +1312,14 @@ class BrowserViewController: UIViewController {
                 // There are cases in which the page will still show a loading animation or nothing when the screenshot is being taken,
                 // depending on internet connection
                 // Issue created: https://github.com/mozilla-mobile/firefox-ios/issues/7003
-                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + delayedTimeInterval) {
                     self.screenshotHelper.takeScreenshot(tab)
                     if webView.superview == self.view {
                         webView.removeFromSuperview()
                     }
                 }
-            } else if let webView = tab.webView {
-                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
+            } else if tab.webView != nil {
+                DispatchQueue.main.asyncAfter(deadline: .now() + delayedTimeInterval) {
                     self.screenshotHelper.takeScreenshot(tab)
                 }
             }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -68,7 +68,7 @@ extension BrowserViewController: URLBarDelegate, FeatureFlagsProtocol {
 
         if let tab = tabManager.selectedTab {
             screenshotHelper.takeScreenshot(tab)
-            tabManager.storeScreenshot(tab: tab)
+//            tabManager.storeScreenshot(tab: tab)
         }
         TelemetryWrapper.recordEvent(category: .action, method: .open, object: .tabTray)
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -68,7 +68,6 @@ extension BrowserViewController: URLBarDelegate, FeatureFlagsProtocol {
 
         if let tab = tabManager.selectedTab {
             screenshotHelper.takeScreenshot(tab)
-//            tabManager.storeScreenshot(tab: tab)
         }
         TelemetryWrapper.recordEvent(category: .action, method: .open, object: .tabTray)
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -29,7 +29,6 @@ extension BrowserViewController: WKUIDelegate {
 
         if let currentTab = tabManager.selectedTab {
             screenshotHelper.takeScreenshot(currentTab)
-//            tabManager.storeScreenshot(tab: currentTab)
         }
 
         guard let bvc = parentTab.browserViewController else { return nil }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -29,7 +29,7 @@ extension BrowserViewController: WKUIDelegate {
 
         if let currentTab = tabManager.selectedTab {
             screenshotHelper.takeScreenshot(currentTab)
-            tabManager.storeScreenshot(tab: currentTab)
+//            tabManager.storeScreenshot(tab: currentTab)
         }
 
         guard let bvc = parentTab.browserViewController else { return nil }

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -931,7 +931,24 @@ class TabCell: UICollectionViewCell, TabTrayCell {
             layer.shadowPath = nil
             layer.shadowOpacity = 0
         }
-        screenshotView.image = tab.screenshot
+        
+        if let url = tab.url, let tabScreenshot = tab.screenshot, (url.absoluteString.starts(with: "internal") &&
+            tab.isHomeScreenshot) {
+            screenshotView.image = tabScreenshot
+        } else if let url = tab.url, (!url.absoluteString.starts(with: "internal") &&
+            tab.isHomeScreenshot) {
+            if let domainUrl = self.getTabDomainUrl(tab: tab) {
+                // Set Favicon from domain url when screenshot from tab is empty
+                self.screenshotView.setImageAndBackground(forIcon: tab.displayFavicon, website: domainUrl) {}
+            }
+        } else if let tabScreenshot = tab.screenshot {
+            screenshotView.image = tabScreenshot
+        } else {
+            if let domainUrl = self.getTabDomainUrl(tab: tab) {
+                // Set Favicon from domain url when screenshot from tab is empty
+                self.screenshotView.setImageAndBackground(forIcon: tab.displayFavicon, website: domainUrl) {}
+            }
+        }
     }
 
     override func prepareForReuse() {
@@ -974,6 +991,13 @@ class TabCell: UICollectionViewCell, TabTrayCell {
         layer.shadowOffset = CGSize(width: -TabCell.borderWidth, height: -TabCell.borderWidth)
         let shadowPath = CGRect(width: layer.frame.width + (TabCell.borderWidth * 2), height: layer.frame.height + (TabCell.borderWidth * 2))
         layer.shadowPath = UIBezierPath(roundedRect: shadowPath, cornerRadius: GridTabTrayControllerUX.CornerRadius+TabCell.borderWidth).cgPath
+    }
+    
+    func getTabDomainUrl(tab: Tab) -> URL? {
+        guard tab.url != nil else {
+            return tab.sessionData?.urls.last?.domainURL
+        }
+        return tab.url?.domainURL
     }
 }
 

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -933,10 +933,10 @@ class TabCell: UICollectionViewCell, TabTrayCell {
         }
         
         if let url = tab.url, let tabScreenshot = tab.screenshot, (url.absoluteString.starts(with: "internal") &&
-            tab.isHomeScreenshot) {
+            tab.hasHomeScreenshot) {
             screenshotView.image = tabScreenshot
         } else if let url = tab.url, (!url.absoluteString.starts(with: "internal") &&
-            tab.isHomeScreenshot) {
+            tab.hasHomeScreenshot) {
             if let domainUrl = self.getTabDomainUrl(tab: tab) {
                 // Set Favicon from domain url when screenshot from tab is empty
                 self.screenshotView.setImageAndBackground(forIcon: tab.displayFavicon, website: domainUrl) {}

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -1032,14 +1032,7 @@ class TabCell: UICollectionViewCell, TabTrayCell {
         let shadowPath = CGRect(width: layer.frame.width + (TabCell.borderWidth * 2), height: layer.frame.height + (TabCell.borderWidth * 2))
         layer.shadowPath = UIBezierPath(roundedRect: shadowPath, cornerRadius: GridTabTrayControllerUX.CornerRadius+TabCell.borderWidth).cgPath
     }
-    
-    func getTabDomainUrl(tab: Tab) -> URL? {
-        guard tab.url != nil else {
-            return tab.sessionData?.urls.last?.domainURL
-        }
-        return tab.url?.domainURL
-    }
-    
+
     func setFaviconImage(for tab: Tab, with imageView: UIImageView) {
         if let url = tab.url?.domainURL ?? tab.sessionData?.urls.last?.domainURL {
             imageView.setImageAndBackground(forIcon: tab.displayFavicon, website: url) {}

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -791,6 +791,20 @@ class TabCell: UICollectionViewCell, TabTrayCell {
         view.clipsToBounds = true
         view.backgroundColor = UIColor.theme.tabTray.cellBackground
         return view
+        
+    }()
+
+    lazy private var faviconBG: UIView = {
+        let view = UIView()
+        view.layer.cornerRadius = TopSiteCellUX.CellCornerRadius
+        view.layer.borderWidth = TopSiteCellUX.BorderWidth
+        view.layer.shadowOffset = CGSize(width: 0, height: 2)
+        view.layer.shadowRadius = TopSiteCellUX.ShadowRadius
+        view.backgroundColor = UIColor.theme.homePanel.shortcutBackground
+        view.layer.borderColor = TopSiteCellUX.BorderColor.cgColor
+        view.layer.shadowColor = UIColor.theme.homePanel.shortcutShadowColor
+        view.layer.shadowOpacity = UIColor.theme.homePanel.shortcutShadowOpacity
+        return view
     }()
 
     lazy var screenshotView: UIImageView = {
@@ -799,6 +813,17 @@ class TabCell: UICollectionViewCell, TabTrayCell {
         view.clipsToBounds = true
         view.isUserInteractionEnabled = false
         view.backgroundColor = UIColor.theme.tabTray.screenshotBackground
+        return view
+    }()
+    
+    lazy var smallFaviconView: UIImageView = {
+        let view = UIImageView()
+        view.contentMode = .scaleAspectFill
+        view.clipsToBounds = true
+        view.isUserInteractionEnabled = false
+        view.backgroundColor = UIColor.clear
+        view.layer.cornerRadius = TopSiteCellUX.IconCornerRadius
+        view.layer.masksToBounds = true
         return view
     }()
 
@@ -845,12 +870,13 @@ class TabCell: UICollectionViewCell, TabTrayCell {
         self.closeButton.addTarget(self, action: #selector(close), for: .touchUpInside)
 
         contentView.addSubview(backgroundHolder)
-
+        
         backgroundHolder.snp.makeConstraints { make in
             make.edges.equalTo(contentView)
         }
 
-        backgroundHolder.addSubview(self.screenshotView)
+        faviconBG.addSubview(smallFaviconView)
+        backgroundHolder.addSubviews(screenshotView, faviconBG)
 
         self.accessibilityCustomActions = [
             UIAccessibilityCustomAction(name: .TabTrayCloseAccessibilityCustomAction, target: self.animator, selector: #selector(SwipeAnimator.closeWithoutGesture))
@@ -887,6 +913,17 @@ class TabCell: UICollectionViewCell, TabTrayCell {
             make.top.equalToSuperview()
             make.left.right.equalTo(backgroundHolder)
             make.bottom.equalTo(backgroundHolder.snp.bottom)
+        }
+        
+        faviconBG.snp.makeConstraints { make in
+            make.centerY.equalToSuperview().offset(10)
+            make.centerX.equalToSuperview()
+            make.size.equalTo(TopSiteCellUX.BackgroundSize)
+        }
+        
+        smallFaviconView.snp.makeConstraints { make in
+            make.size.equalTo(TopSiteCellUX.IconSize)
+            make.center.equalTo(faviconBG)
         }
     }
 
@@ -931,7 +968,9 @@ class TabCell: UICollectionViewCell, TabTrayCell {
             layer.shadowPath = nil
             layer.shadowOpacity = 0
         }
-        
+
+        faviconBG.isHidden = true
+
         if let url = tab.url, let tabScreenshot = tab.screenshot, (url.absoluteString.starts(with: "internal") &&
             tab.hasHomeScreenshot) {
             screenshotView.image = tabScreenshot
@@ -939,14 +978,18 @@ class TabCell: UICollectionViewCell, TabTrayCell {
             tab.hasHomeScreenshot) {
             if let domainUrl = self.getTabDomainUrl(tab: tab) {
                 // Set Favicon from domain url when screenshot from tab is empty
-                self.screenshotView.setImageAndBackground(forIcon: tab.displayFavicon, website: domainUrl) {}
+                self.smallFaviconView.setImageAndBackground(forIcon: tab.displayFavicon, website: domainUrl) {}
+                faviconBG.isHidden = false
+                screenshotView.image = nil
             }
         } else if let tabScreenshot = tab.screenshot {
             screenshotView.image = tabScreenshot
         } else {
             if let domainUrl = self.getTabDomainUrl(tab: tab) {
                 // Set Favicon from domain url when screenshot from tab is empty
-                self.screenshotView.setImageAndBackground(forIcon: tab.displayFavicon, website: domainUrl) {}
+                self.smallFaviconView.setImageAndBackground(forIcon: tab.displayFavicon, website: domainUrl) {}
+                faviconBG.isHidden = false
+                screenshotView.image = nil
             }
         }
     }

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -971,26 +971,23 @@ class TabCell: UICollectionViewCell, TabTrayCell {
 
         faviconBG.isHidden = true
 
+        // Regular screenshot for home or internal url when tab has home screenshot
         if let url = tab.url, let tabScreenshot = tab.screenshot, (url.absoluteString.starts(with: "internal") &&
             tab.hasHomeScreenshot) {
             screenshotView.image = tabScreenshot
+
+        // Favicon or letter image when home screenshot is present for a regular (non-internal) url
         } else if let url = tab.url, (!url.absoluteString.starts(with: "internal") &&
             tab.hasHomeScreenshot) {
-            if let domainUrl = self.getTabDomainUrl(tab: tab) {
-                // Set Favicon from domain url when screenshot from tab is empty
-                self.smallFaviconView.setImageAndBackground(forIcon: tab.displayFavicon, website: domainUrl) {}
-                faviconBG.isHidden = false
-                screenshotView.image = nil
-            }
+            setFaviconImage(for: tab, with: smallFaviconView)
+
+        // Tab screenshot when available
         } else if let tabScreenshot = tab.screenshot {
             screenshotView.image = tabScreenshot
+
+        // Favicon or letter when tab screenshot isn't available
         } else {
-            if let domainUrl = self.getTabDomainUrl(tab: tab) {
-                // Set Favicon from domain url when screenshot from tab is empty
-                self.smallFaviconView.setImageAndBackground(forIcon: tab.displayFavicon, website: domainUrl) {}
-                faviconBG.isHidden = false
-                screenshotView.image = nil
-            }
+            setFaviconImage(for: tab, with: smallFaviconView)
         }
     }
 
@@ -1041,6 +1038,21 @@ class TabCell: UICollectionViewCell, TabTrayCell {
             return tab.sessionData?.urls.last?.domainURL
         }
         return tab.url?.domainURL
+    }
+    
+    func setFaviconImage(for tab: Tab, with imageView: UIImageView) {
+        if let url = tab.url?.domainURL ?? tab.sessionData?.urls.last?.domainURL {
+            imageView.setImageAndBackground(forIcon: tab.displayFavicon, website: url) {}
+            faviconBG.isHidden = false
+            screenshotView.image = nil
+        }
+//        let sessionDomainUrl = tab.sessionData?.urls.last?.domainURL
+//        if let url = tab.url?.domainURL {
+//            // Set Favicon from domain url when screenshot from tab is empty
+//            imageView.setImageAndBackground(forIcon: tab.displayFavicon, website: url) {}
+//            faviconBG.isHidden = false
+//            screenshotView.image = nil
+//        }
     }
 }
 

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -985,7 +985,7 @@ class TabCell: UICollectionViewCell, TabTrayCell {
         } else if let tabScreenshot = tab.screenshot {
             screenshotView.image = tabScreenshot
 
-        // Favicon or letter when tab screenshot isn't available
+        // Favicon or letter image when tab screenshot isn't available
         } else {
             setFaviconImage(for: tab, with: smallFaviconView)
         }
@@ -1046,13 +1046,6 @@ class TabCell: UICollectionViewCell, TabTrayCell {
             faviconBG.isHidden = false
             screenshotView.image = nil
         }
-//        let sessionDomainUrl = tab.sessionData?.urls.last?.domainURL
-//        if let url = tab.url?.domainURL {
-//            // Set Favicon from domain url when screenshot from tab is empty
-//            imageView.setImageAndBackground(forIcon: tab.displayFavicon, website: url) {}
-//            faviconBG.isHidden = false
-//            screenshotView.image = nil
-//        }
     }
 }
 

--- a/Client/Frontend/Browser/SavedTab+ConfigureExtension.swift
+++ b/Client/Frontend/Browser/SavedTab+ConfigureExtension.swift
@@ -28,7 +28,7 @@ extension SavedTab {
             }
         }
         
-        self.init(screenshotUUID: tab.screenshotUUID, isSelected: isSelected, title: tab.title ?? tab.lastTitle, isPrivate: tab.isPrivate, faviconURL: tab.displayFavicon?.url, url: tab.url, sessionData: sessionData, uuid: tab.tabUUID, tabGroupData: tab.tabGroupData, createdAt: tab.firstCreatedTime)
+        self.init(screenshotUUID: tab.screenshotUUID, isSelected: isSelected, title: tab.title ?? tab.lastTitle, isPrivate: tab.isPrivate, faviconURL: tab.displayFavicon?.url, url: tab.url, sessionData: sessionData, uuid: tab.tabUUID, tabGroupData: tab.tabGroupData, createdAt: tab.firstCreatedTime, hasHomeScreenshot: tab.hasHomeScreenshot)
     }
     
     func configureSavedTabUsing(_ tab: Tab, imageStore: DiskImageStore? = nil) -> Tab {
@@ -58,6 +58,7 @@ extension SavedTab {
         tab.tabGroupData = tabGroupData ?? tab.tabGroupData
         tab.screenshotUUID = screenshotUUID
         tab.firstCreatedTime = createdAt ?? sessionData?.lastUsedTime ?? Date.now()
+        tab.hasHomeScreenshot = hasHomeScreenshot
         return tab
     }
 }

--- a/Client/Frontend/Browser/SavedTab.swift
+++ b/Client/Frontend/Browser/SavedTab.swift
@@ -18,7 +18,8 @@ class SavedTab: NSObject, NSCoding {
     var UUID: String?
     var tabGroupData: TabGroupData?
     var createdAt: Timestamp?
-    
+    var hasHomeScreenshot: Bool
+
     var jsonDictionary: [String: AnyObject] {
         let title: String = self.title ?? "null"
         let faviconURL: String = self.faviconURL ?? "null"
@@ -34,6 +35,7 @@ class SavedTab: NSObject, NSCoding {
             "UUID": self.UUID as AnyObject,
             "tabGroupData": self.tabGroupData as AnyObject,
             "createdAt": self.createdAt as AnyObject,
+            "hasHomeScreenshot": String(self.hasHomeScreenshot) as AnyObject
         ]
         
         if let sessionDataInfo = self.sessionData?.jsonDictionary {
@@ -43,7 +45,7 @@ class SavedTab: NSObject, NSCoding {
         return json
     }
     
-    init?(screenshotUUID: UUID?, isSelected: Bool, title: String?, isPrivate: Bool, faviconURL: String?, url: URL?, sessionData: SessionData?, uuid: String, tabGroupData: TabGroupData?, createdAt: Timestamp?) {
+    init?(screenshotUUID: UUID?, isSelected: Bool, title: String?, isPrivate: Bool, faviconURL: String?, url: URL?, sessionData: SessionData?, uuid: String, tabGroupData: TabGroupData?, createdAt: Timestamp?, hasHomeScreenshot: Bool) {
 
         self.screenshotUUID = screenshotUUID
         self.isSelected = isSelected
@@ -55,7 +57,8 @@ class SavedTab: NSObject, NSCoding {
         self.UUID = uuid
         self.tabGroupData = tabGroupData
         self.createdAt = createdAt
-        
+        self.hasHomeScreenshot = hasHomeScreenshot
+
         super.init()
     }
     
@@ -70,6 +73,7 @@ class SavedTab: NSObject, NSCoding {
         self.UUID = coder.decodeObject(forKey: "UUID") as? String
         self.tabGroupData = coder.decodeObject(forKey: "tabGroupData") as? TabGroupData
         self.createdAt = coder.decodeObject(forKey: "createdAt") as? Timestamp
+        self.hasHomeScreenshot = coder.decodeBool(forKey: "hasHomeScreenshot")
     }
     
     func encode(with coder: NSCoder) {
@@ -83,6 +87,7 @@ class SavedTab: NSObject, NSCoding {
         coder.encode(UUID, forKey: "UUID")
         coder.encode(tabGroupData, forKey: "tabGroupData")
         coder.encode(createdAt, forKey: "createdAt")
+        coder.encode(hasHomeScreenshot, forKey: "hasHomeScreenshot")
     }
 }
 

--- a/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -32,7 +32,7 @@ class ScreenshotHelper {
         if InternalURL(url)?.isAboutHomeURL ?? false {
             if let homePanel = controller?.firefoxHomeViewController {
                 let screenshot = homePanel.view.screenshot(quality: UIConstants.ActiveScreenshotQuality)
-                tab.isHomeScreenshot = true
+                tab.hasHomeScreenshot = true
                 tab.setScreenshot(screenshot)
                 TabEvent.post(.didSetScreenshot(isHome: true) , for: tab)
             }
@@ -44,7 +44,7 @@ class ScreenshotHelper {
             
             webView.takeSnapshot(with: configuration) { image, error in
                 if let image = image {
-                    tab.isHomeScreenshot = false
+                    tab.hasHomeScreenshot = false
                     tab.setScreenshot(image)
                     TabEvent.post(.didSetScreenshot(isHome: false) , for: tab)
                 } else if let error = error {

--- a/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -32,7 +32,9 @@ class ScreenshotHelper {
         if InternalURL(url)?.isAboutHomeURL ?? false {
             if let homePanel = controller?.firefoxHomeViewController {
                 let screenshot = homePanel.view.screenshot(quality: UIConstants.ActiveScreenshotQuality)
+                tab.isHomeScreenshot = true
                 tab.setScreenshot(screenshot)
+                TabEvent.post(.didSetScreenshot(isHome: true) , for: tab)
             }
         //Handle webview screenshots
         } else {
@@ -42,7 +44,9 @@ class ScreenshotHelper {
             
             webView.takeSnapshot(with: configuration) { image, error in
                 if let image = image {
+                    tab.isHomeScreenshot = false
                     tab.setScreenshot(image)
+                    TabEvent.post(.didSetScreenshot(isHome: false) , for: tab)
                 } else if let error = error {
                     Sentry.shared.send(message: "Tab snapshot error", tag: .tabManager, severity: .debug, description: error.localizedDescription)
                 } else {

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -116,7 +116,7 @@ class Tab: NSObject {
     
     var adsTelemetryUrlList: [String] = [String]()
     var adsProviderName: String = ""
-    var isHomeScreenshot: Bool = false
+    var hasHomeScreenshot: Bool = false
 
     // To check if current URL is the starting page i.e. either blank page or internal page like topsites
     var isURLStartingPage: Bool {
@@ -688,11 +688,11 @@ class Tab: NSObject {
         // check if screenshot is all solid color
         if let val = screenshot, let avgColor = val.averageColor {
             let backgroundColor = LegacyThemeManager.instance.current.browser.background
-            if avgColor.isEqual(backgroundColor) {
+            guard !avgColor.isEqual(backgroundColor) else {
                 self.screenshot = nil
-            } else {
-                self.screenshot = screenshot
+                return
             }
+            self.screenshot = screenshot
         }
     }
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -685,7 +685,7 @@ class Tab: NSObject {
     }
 
     func setScreenshot(_ screenshot: UIImage?) {
-        // check if screenshot is all solid color
+        // check if screenshot is same color as background
         if let val = screenshot, let avgColor = val.averageColor {
             let backgroundColor = LegacyThemeManager.instance.current.browser.background
             guard !avgColor.isEqual(backgroundColor) else {

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -686,7 +686,7 @@ class Tab: NSObject {
 
     func setScreenshot(_ screenshot: UIImage?) {
         // check if screenshot is same color as background
-        if let val = screenshot, let avgColor = val.averageColor {
+        if let val = screenshot, let avgColor = val.averageColor() {
             let backgroundColor = LegacyThemeManager.instance.current.browser.background
             guard !avgColor.isEqual(backgroundColor) else {
                 self.screenshot = nil

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -693,7 +693,6 @@ class Tab: NSObject {
             } else {
                 self.screenshot = screenshot
             }
-            print("TAKE SCR - BG COLOR - \(backgroundColor) - AVG COLOR - \(avgColor) - EQ - \(avgColor.isEqual(backgroundColor))")
         }
     }
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -116,7 +116,8 @@ class Tab: NSObject {
     
     var adsTelemetryUrlList: [String] = [String]()
     var adsProviderName: String = ""
-    
+    var isHomeScreenshot: Bool = false
+
     // To check if current URL is the starting page i.e. either blank page or internal page like topsites
     var isURLStartingPage: Bool {
         guard url != nil else { return true }
@@ -684,7 +685,16 @@ class Tab: NSObject {
     }
 
     func setScreenshot(_ screenshot: UIImage?) {
-        self.screenshot = screenshot
+        // check if screenshot is all solid color
+        if let val = screenshot, let avgColor = val.averageColor {
+            let backgroundColor = LegacyThemeManager.instance.current.browser.background
+            if avgColor.isEqual(backgroundColor) {
+                self.screenshot = nil
+            } else {
+                self.screenshot = screenshot
+            }
+            print("TAKE SCR - BG COLOR - \(backgroundColor) - AVG COLOR - \(avgColor) - EQ - \(avgColor.isEqual(backgroundColor))")
+        }
     }
 
     func toggleChangeUserAgent() {

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -709,7 +709,7 @@ extension TabDisplayManager: TabEventHandler {
         updateCellFor(tab: tab, selectedTabChanged: false)
     }
     
-    func tabDidSetScreenshot(_ tab: Tab, isHomeScreenshot: Bool) {
+    func tabDidSetScreenshot(_ tab: Tab, hasHomeScreenshot: Bool) {
         updateCellFor(tab: tab, selectedTabChanged: false)
     }
 

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -198,7 +198,7 @@ class TabDisplayManager: NSObject, FeatureFlagsProtocol {
         self.setupExperiment()
         self.inactiveViewModel = InactiveTabViewModel()
         tabManager.addDelegate(self)
-        register(self, forTabEvents: .didLoadFavicon, .didChangeURL)
+        register(self, forTabEvents: .didLoadFavicon, .didChangeURL, .didSetScreenshot)
         self.dataStore.removeAll()
         getTabsAndUpdateInactiveState { tabGroup, tabsToDisplay in
             guard tabsToDisplay.count > 0 else { return }
@@ -706,6 +706,10 @@ extension TabDisplayManager: UICollectionViewDropDelegate {
 extension TabDisplayManager: TabEventHandler {
 
     func tab(_ tab: Tab, didLoadFavicon favicon: Favicon?, with: Data?) {
+        updateCellFor(tab: tab, selectedTabChanged: false)
+    }
+    
+    func tabDidSetScreenshot(_ tab: Tab, isHomeScreenshot: Bool) {
         updateCellFor(tab: tab, selectedTabChanged: false)
     }
 

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -38,7 +38,13 @@ extension TabManager: TabEventHandler {
         store.preserveTabs(tabs, selectedTab: selectedTab)
     }
     
-    func tabDidSetScreenshot(_ tab: Tab, isHomeScreenshot: Bool) {
+    func tabDidSetScreenshot(_ tab: Tab, hasHomeScreenshot: Bool) {
+        guard tab.screenshot != nil else {
+            // Remove screenshot from image store so we can use favicon
+            // when a screenshot isn't available for the associated tab url
+            removeScreenshot(tab: tab)
+            return
+        }
         storeScreenshot(tab: tab)
     }
 }
@@ -226,6 +232,11 @@ class TabManager: NSObject, FeatureFlagsProtocol {
 
     func storeScreenshot(tab: Tab) {
         store.preserveScreenshot(forTab: tab)
+        storeChanges()
+    }
+    
+    func removeScreenshot(tab: Tab) {
+        store.removeScreenshot(forTab: tab)
         storeChanges()
     }
 

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -37,6 +37,10 @@ extension TabManager: TabEventHandler {
     func tab(_ tab: Tab, didLoadFavicon favicon: Favicon?, with: Data?) {
         store.preserveTabs(tabs, selectedTab: selectedTab)
     }
+    
+    func tabDidSetScreenshot(_ tab: Tab, isHomeScreenshot: Bool) {
+        storeScreenshot(tab: tab)
+    }
 }
 
 // TabManager must extend NSObjectProtocol in order to implement WKNavigationDelegate
@@ -153,7 +157,7 @@ class TabManager: NSObject, FeatureFlagsProtocol {
         self.store = TabManagerStore(imageStore: imageStore, prefs: profile.prefs)
         super.init()
 
-        register(self, forTabEvents: .didLoadFavicon)
+        register(self, forTabEvents: .didLoadFavicon, .didSetScreenshot)
 
         addNavigationDelegate(self)
 
@@ -222,6 +226,7 @@ class TabManager: NSObject, FeatureFlagsProtocol {
 
     func storeScreenshot(tab: Tab) {
         store.preserveScreenshot(forTab: tab)
+        storeChanges()
     }
 
     // This function updates the _selectedIndex.

--- a/Client/Frontend/Browser/TabManagerStore.swift
+++ b/Client/Frontend/Browser/TabManagerStore.swift
@@ -100,6 +100,12 @@ class TabManagerStore: FeatureFlagsProtocol {
             imageStore?.put(uuidString, image: screenshot)
         }
     }
+    
+    func removeScreenshot(forTab tab: Tab?) {
+        if let tab = tab, let screenshotUUID = tab.screenshotUUID {
+            imageStore?.removeImage(screenshotUUID.uuidString)
+        }
+    }
 
     // Async write of the tab state. In most cases, code doesn't care about performing an operation
     // after this completes. Deferred completion is called always, regardless of Data.write return value.

--- a/Client/Frontend/Home/FirefoxHomeTopSitesCell.swift
+++ b/Client/Frontend/Home/FirefoxHomeTopSitesCell.swift
@@ -7,7 +7,7 @@ import Shared
 import SDWebImage
 import Storage
 
-private struct TopSiteCellUX {
+struct TopSiteCellUX {
     static let TitleHeight: CGFloat = 20
     static let SelectedOverlayColor = UIColor(white: 0.0, alpha: 0.25)
     static let CellCornerRadius: CGFloat = 8

--- a/Client/Helpers/TabEventHandler.swift
+++ b/Client/Helpers/TabEventHandler.swift
@@ -60,6 +60,7 @@ protocol TabEventHandler: AnyObject {
     func tabDidClose(_ tab: Tab)
     func tabDidToggleDesktopMode(_ tab: Tab)
     func tabDidChangeContentBlocking(_ tab: Tab)
+    func tabDidSetScreenshot(_ tab: Tab, isHomeScreenshot: Bool)
 }
 
 // Provide default implmentations, because we don't want to litter the code with
@@ -75,6 +76,7 @@ extension TabEventHandler {
     func tabDidClose(_ tab: Tab) {}
     func tabDidToggleDesktopMode(_ tab: Tab) {}
     func tabDidChangeContentBlocking(_ tab: Tab) {}
+    func tabDidSetScreenshot(_ tab: Tab, isHomeScreenshot: Bool) {}
 }
 
 enum TabEventLabel: String {
@@ -88,6 +90,7 @@ enum TabEventLabel: String {
     case didClose
     case didToggleDesktopMode
     case didChangeContentBlocking
+    case didSetScreenshot
 }
 
 // Names of events must be unique!
@@ -102,6 +105,7 @@ enum TabEvent {
     case didClose
     case didToggleDesktopMode
     case didChangeContentBlocking
+    case didSetScreenshot(isHome: Bool)
 
     var label: TabEventLabel {
         let str = "\(self)".components(separatedBy: "(")[0] // Will grab just the name from 'didChangeURL(...)'
@@ -133,6 +137,8 @@ enum TabEvent {
             handler.tabDidToggleDesktopMode(tab)
         case .didChangeContentBlocking:
             handler.tabDidChangeContentBlocking(tab)
+        case .didSetScreenshot(let isHomeScreenshot):
+            handler.tabDidSetScreenshot(tab, isHomeScreenshot: isHomeScreenshot)
         }
     }
 }

--- a/Client/Helpers/TabEventHandler.swift
+++ b/Client/Helpers/TabEventHandler.swift
@@ -60,7 +60,7 @@ protocol TabEventHandler: AnyObject {
     func tabDidClose(_ tab: Tab)
     func tabDidToggleDesktopMode(_ tab: Tab)
     func tabDidChangeContentBlocking(_ tab: Tab)
-    func tabDidSetScreenshot(_ tab: Tab, isHomeScreenshot: Bool)
+    func tabDidSetScreenshot(_ tab: Tab, hasHomeScreenshot: Bool)
 }
 
 // Provide default implmentations, because we don't want to litter the code with
@@ -76,7 +76,7 @@ extension TabEventHandler {
     func tabDidClose(_ tab: Tab) {}
     func tabDidToggleDesktopMode(_ tab: Tab) {}
     func tabDidChangeContentBlocking(_ tab: Tab) {}
-    func tabDidSetScreenshot(_ tab: Tab, isHomeScreenshot: Bool) {}
+    func tabDidSetScreenshot(_ tab: Tab, hasHomeScreenshot: Bool) {}
 }
 
 enum TabEventLabel: String {
@@ -137,8 +137,8 @@ enum TabEvent {
             handler.tabDidToggleDesktopMode(tab)
         case .didChangeContentBlocking:
             handler.tabDidChangeContentBlocking(tab)
-        case .didSetScreenshot(let isHomeScreenshot):
-            handler.tabDidSetScreenshot(tab, isHomeScreenshot: isHomeScreenshot)
+        case .didSetScreenshot(let hasHomeScreenshot):
+            handler.tabDidSetScreenshot(tab, hasHomeScreenshot: hasHomeScreenshot)
         }
     }
 }

--- a/Storage/DiskImageStore.swift
+++ b/Storage/DiskImageStore.swift
@@ -96,4 +96,19 @@ open class DiskImageStore {
             return succeed()
         }
     }
+    
+    /// Remove image with provided key
+    open func removeImage(_ key: String) -> Success {
+        return deferDispatchAsync(queue) { () -> Success in
+            let url = URL(fileURLWithPath: self.filesDir).appendingPathComponent(key)
+
+            do {
+                try FileManager.default.removeItem(at: url)
+            } catch {
+                log.warning("Failed to remove DiskImageStore item at \(url.absoluteString): \(error)")
+            }
+
+            return succeed()
+        }
+    }
 }

--- a/ThirdParty/UIImageColors.swift
+++ b/ThirdParty/UIImageColors.swift
@@ -276,13 +276,17 @@ extension UIImage {
         return result
     }
     
-    var averageColor: UIColor? {
+    // Courtesy: https://www.hackingwithswift.com/example-code/media/how-to-read-the-average-color-of-a-uiimage-using-ciareaaverage
+    public func averageColor() -> UIColor? {
         guard let inputImage = CIImage(image: self) else { return nil }
         let extentVector = CIVector(x: inputImage.extent.origin.x, y: inputImage.extent.origin.y, z: inputImage.extent.size.width, w: inputImage.extent.size.height)
 
+        // core image filter that resamples an image down to 1x1 pixels
+        // so you can read the most dominant color in an imagage
         guard let filter = CIFilter(name: "CIAreaAverage", parameters: [kCIInputImageKey: inputImage, kCIInputExtentKey: extentVector]) else { return nil }
         guard let outputImage = filter.outputImage else { return nil }
 
+        // reads each of the color values into a UIColor, and sends it back
         var bitmap = [UInt8](repeating: 0, count: 4)
         let context = CIContext(options: [.workingColorSpace: kCFNull])
         context.render(outputImage, toBitmap: &bitmap, rowBytes: 4, bounds: CGRect(x: 0, y: 0, width: 1, height: 1), format: .RGBA8, colorSpace: nil)

--- a/ThirdParty/UIImageColors.swift
+++ b/ThirdParty/UIImageColors.swift
@@ -275,4 +275,18 @@ extension UIImage {
 
         return result
     }
+    
+    var averageColor: UIColor? {
+        guard let inputImage = CIImage(image: self) else { return nil }
+        let extentVector = CIVector(x: inputImage.extent.origin.x, y: inputImage.extent.origin.y, z: inputImage.extent.size.width, w: inputImage.extent.size.height)
+
+        guard let filter = CIFilter(name: "CIAreaAverage", parameters: [kCIInputImageKey: inputImage, kCIInputExtentKey: extentVector]) else { return nil }
+        guard let outputImage = filter.outputImage else { return nil }
+
+        var bitmap = [UInt8](repeating: 0, count: 4)
+        let context = CIContext(options: [.workingColorSpace: kCFNull])
+        context.render(outputImage, toBitmap: &bitmap, rowBytes: 4, bounds: CGRect(x: 0, y: 0, width: 1, height: 1), format: .RGBA8, colorSpace: nil)
+
+        return UIColor(red: CGFloat(bitmap[0]) / 255, green: CGFloat(bitmap[1]) / 255, blue: CGFloat(bitmap[2]) / 255, alpha: CGFloat(bitmap[3]) / 255)
+    }
 }


### PR DESCRIPTION
Added initial workings for showing Favicon when screenshot is missing or is same color as background.

**Left**: Tab screenshot failed to load or is taking too long hence we show favicon
**Right**: Tab screenshot loaded

<img width="353" alt="image" src="https://user-images.githubusercontent.com/8919439/142963760-0e2d6245-9d92-4ce1-b778-d08f14c4d43c.png">


Whats left: 

- [x] Cleanup 