### PR TITLE
UITableViewRowAction deprecations fix in Library Panels

### DIFF
--- a/Client/Frontend/Library/BookmarksPanel.swift
+++ b/Client/Frontend/Library/BookmarksPanel.swift
@@ -57,8 +57,8 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
 
         super.init(profile: profile)
 
-        [ Notification.Name.FirefoxAccountChanged,
-          Notification.Name.DynamicFontChanged ].forEach {
+        [Notification.Name.FirefoxAccountChanged,
+         Notification.Name.DynamicFontChanged].forEach {
             NotificationCenter.default.addObserver(self, selector: #selector(notificationReceived), name: $0, object: nil)
         }
 
@@ -69,6 +69,10 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     override func viewDidLoad() {
@@ -433,10 +437,6 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
         return true
     }
 
-    func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        // Intentionally blank. Required to use UITableViewRowActions
-    }
-
     func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
         // Root folders cannot be moved.
         guard let bookmarkFolder = self.bookmarkFolder, bookmarkFolder.guid != BookmarkRoots.RootGUID else {
@@ -457,17 +457,19 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
         bookmarkNodes.insert(bookmarkNode, at: destinationIndexPath.row)
     }
 
-    func tableView(_ tableView: UITableView, editingStyleForRowAtIndexPath indexPath: IndexPath) -> UITableViewCell.EditingStyle {
-        return .delete
-    }
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        let deleteAction = UIContextualAction(style: .destructive, title: .BookmarksPanelDeleteTableAction) { [weak self] (_, _, completion) in
+            guard let strongSelf = self else {
+                completion(false)
+                return
+            }
 
-    func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
-        let delete = UITableViewRowAction(style: .default, title: .BookmarksPanelDeleteTableAction, handler: { (action, indexPath) in
-            self.deleteBookmarkNodeAtIndexPath(indexPath)
+            strongSelf.deleteBookmarkNodeAtIndexPath(indexPath)
             TelemetryWrapper.recordEvent(category: .action, method: .delete, object: .bookmark, value: .bookmarksPanel, extras: ["gesture": "swipe"])
-        })
+            completion(true)
+        }
 
-        return [delete]
+        return UISwipeActionsConfiguration(actions: [deleteAction])
     }
 }
 

--- a/Client/Frontend/Library/BookmarksPanel.swift
+++ b/Client/Frontend/Library/BookmarksPanel.swift
@@ -459,10 +459,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel {
 
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let deleteAction = UIContextualAction(style: .destructive, title: .BookmarksPanelDeleteTableAction) { [weak self] (_, _, completion) in
-            guard let strongSelf = self else {
-                completion(false)
-                return
-            }
+            guard let strongSelf = self else { completion(false); return }
 
             strongSelf.deleteBookmarkNodeAtIndexPath(indexPath)
             TelemetryWrapper.recordEvent(category: .action, method: .delete, object: .bookmark, value: .bookmarksPanel, extras: ["gesture": "swipe"])

--- a/Client/Frontend/Library/DownloadsPanel.swift
+++ b/Client/Frontend/Library/DownloadsPanel.swift
@@ -42,7 +42,7 @@ struct DownloadedFile: Equatable {
     }
 }
 
-class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSource, LibraryPanel, UIDocumentInteractionControllerDelegate {
+class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSource, LibraryPanel {
     weak var libraryPanelDelegate: LibraryPanelDelegate?
     let TwoLineImageOverlayCellIdentifier = "TwoLineImageOverlayCellIdentifier"
     let SiteTableViewHeaderIdentifier = "SiteTableViewHeaderIdentifier"
@@ -379,41 +379,55 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
         return groupedDownloadedFiles.numberOfItemsForSection(section)
     }
 
-    func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        // Intentionally blank. Required to use UITableViewRowActions
-    }
-
-    func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
-        let deleteTitle: String = .DownloadsPanelDeleteTitle
-        let shareTitle: String = .DownloadsPanelShareTitle
-        let delete = UITableViewRowAction(style: .destructive, title: deleteTitle, handler: { (action, indexPath) in
-            if let downloadedFile = self.downloadedFileForIndexPath(indexPath) {
-                if self.deleteDownloadedFile(downloadedFile) {
-                    self.tableView.beginUpdates()
-                    self.groupedDownloadedFiles.remove(downloadedFile)
-                    self.tableView.deleteRows(at: [indexPath], with: .right)
-                    self.tableView.endUpdates()
-                    self.updateEmptyPanelState()
-                    TelemetryWrapper.recordEvent(category: .action, method: .delete, object: .download, value: .downloadsPanel)
-                }
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        let deleteAction = UIContextualAction(style: .destructive, title: .DownloadsPanelDeleteTitle) { [weak self] (_, _, completion) in
+            guard let strongSelf = self else {
+                completion(false)
+                return
             }
-        })
-        let share = UITableViewRowAction(style: .normal, title: shareTitle, handler: { (action, indexPath) in
-            if let downloadedFile = self.downloadedFileForIndexPath(indexPath) {
-                self.shareDownloadedFile(downloadedFile, indexPath: indexPath)
+
+            if let downloadedFile = strongSelf.downloadedFileForIndexPath(indexPath),
+               strongSelf.deleteDownloadedFile(downloadedFile) {
+                strongSelf.tableView.beginUpdates()
+                strongSelf.groupedDownloadedFiles.remove(downloadedFile)
+                strongSelf.tableView.deleteRows(at: [indexPath], with: .right)
+                strongSelf.tableView.endUpdates()
+                strongSelf.updateEmptyPanelState()
+                TelemetryWrapper.recordEvent(category: .action, method: .delete, object: .download, value: .downloadsPanel)
+                completion(true)
+            } else {
+                completion(false)
+            }
+        }
+
+        let shareAction = UIContextualAction(style: .normal, title: .DownloadsPanelShareTitle) { [weak self] (_, view, completion) in
+            guard let strongSelf = self else {
+                completion(false)
+                return
+            }
+
+            view.backgroundColor = strongSelf.view.tintColor
+            if let downloadedFile = strongSelf.downloadedFileForIndexPath(indexPath) {
+                strongSelf.shareDownloadedFile(downloadedFile, indexPath: indexPath)
                 TelemetryWrapper.recordEvent(category: .action, method: .share, object: .download, value: .downloadsPanel)
+                completion(true)
+            } else {
+                completion(false)
             }
-        })
-        share.backgroundColor = view.tintColor
-        return [delete, share]
-    }
-    // MARK: - UIDocumentInteractionControllerDelegate
+        }
 
+        return UISwipeActionsConfiguration(actions: [deleteAction, shareAction])
+    }
+}
+
+// MARK: - UIDocumentInteractionControllerDelegate
+extension DownloadsPanel: UIDocumentInteractionControllerDelegate {
     func documentInteractionControllerViewControllerForPreview(_ controller: UIDocumentInteractionController) -> UIViewController {
         return self
     }
 }
 
+// MARK: - NotificationThemeable
 extension DownloadsPanel: NotificationThemeable {
     func applyTheme() {
         emptyStateOverlayView.removeFromSuperview()

--- a/Client/Frontend/Library/DownloadsPanel.swift
+++ b/Client/Frontend/Library/DownloadsPanel.swift
@@ -381,10 +381,7 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
 
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let deleteAction = UIContextualAction(style: .destructive, title: .DownloadsPanelDeleteTitle) { [weak self] (_, _, completion) in
-            guard let strongSelf = self else {
-                completion(false)
-                return
-            }
+            guard let strongSelf = self else { completion(false); return }
 
             if let downloadedFile = strongSelf.downloadedFileForIndexPath(indexPath),
                strongSelf.deleteDownloadedFile(downloadedFile) {
@@ -401,10 +398,7 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
         }
 
         let shareAction = UIContextualAction(style: .normal, title: .DownloadsPanelShareTitle) { [weak self] (_, view, completion) in
-            guard let strongSelf = self else {
-                completion(false)
-                return
-            }
+            guard let strongSelf = self else { completion(false); return }
 
             view.backgroundColor = strongSelf.view.tintColor
             if let downloadedFile = strongSelf.downloadedFileForIndexPath(indexPath) {

--- a/Client/Frontend/Library/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel.swift
@@ -515,20 +515,22 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
         return super.tableView(tableView, heightForHeaderInSection: section)
     }
 
-    func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        // Intentionally blank. Required to use UITableViewRowActions
-    }
-
-    func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
-        if indexPath.section == Section.additionalHistoryActions.rawValue {
-            return []
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        guard indexPath.section != Section.additionalHistoryActions.rawValue else {
+            return nil
         }
-        let title: String = .HistoryPanelDelete
 
-        let delete = UITableViewRowAction(style: .default, title: title, handler: { (action, indexPath) in
-            self.removeHistoryForURLAtIndexPath(indexPath: indexPath)
-        })
-        return [delete]
+        let deleteAction = UIContextualAction(style: .destructive, title: .HistoryPanelDelete) { [weak self] (_, _, completion) in
+            guard let strongSelf = self else {
+                completion(false)
+                return
+            }
+
+            strongSelf.removeHistoryForURLAtIndexPath(indexPath: indexPath)
+            completion(true)
+        }
+
+        return UISwipeActionsConfiguration(actions: [deleteAction])
     }
 
     // MARK: - Empty State

--- a/Client/Frontend/Library/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel.swift
@@ -521,10 +521,7 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
         }
 
         let deleteAction = UIContextualAction(style: .destructive, title: .HistoryPanelDelete) { [weak self] (_, _, completion) in
-            guard let strongSelf = self else {
-                completion(false)
-                return
-            }
+            guard let strongSelf = self else { completion(false); return }
 
             strongSelf.removeHistoryForURLAtIndexPath(indexPath: indexPath)
             completion(true)

--- a/Client/Frontend/Library/ReaderPanel.swift
+++ b/Client/Frontend/Library/ReaderPanel.swift
@@ -317,22 +317,28 @@ class ReadingListPanel: UITableViewController, LibraryPanel {
         return cell
     }
 
-    override func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+    override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         guard let record = records?[indexPath.row] else {
-            return []
+            return nil
         }
 
-        let delete = UITableViewRowAction(style: .default, title: .ReaderPanelRemove) { [weak self] action, index in
-            self?.deleteItem(atIndex: index)
+        let deleteAction = UIContextualAction(style: .destructive, title: .ReaderPanelRemove) { [weak self] (_, _, completion) in
+            guard let strongSelf = self else { completion(false); return }
+
+            strongSelf.deleteItem(atIndex: indexPath)
+            completion(true)
         }
 
         let toggleText: String = record.unread ? .ReaderPanelMarkAsRead : .ReaderModeBarMarkAsUnread
-        let unreadToggle = UITableViewRowAction(style: .normal, title: toggleText.stringSplitWithNewline()) { [weak self] (action, index) in
-            self?.toggleItem(atIndex: index)
-        }
-        unreadToggle.backgroundColor = ReadingListTableViewCellUX.MarkAsReadButtonBackgroundColor
+        let unreadToggleAction = UIContextualAction(style: .normal, title: toggleText.stringSplitWithNewline()) { [weak self] (_, view, completion) in
+            guard let strongSelf = self else { completion(false); return }
 
-        return [unreadToggle, delete]
+            view.backgroundColor = ReadingListTableViewCellUX.MarkAsReadButtonBackgroundColor
+            strongSelf.toggleItem(atIndex: indexPath)
+            completion(true)
+        }
+
+        return UISwipeActionsConfiguration(actions: [unreadToggleAction, deleteAction])
     }
 
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {


### PR DESCRIPTION
Fixing UITableViewRowAction deprecation in Bookmarks, History, Downloads and Reading List panels. There should be no behavior change.

Bookmarks
![Screen Shot 2021-11-23 at 4 10 02 PM](https://user-images.githubusercontent.com/11338480/143128710-b2d69bb2-1d53-4288-8f3e-4b19508068fe.png)

Downloads
![Screen Shot 2021-11-23 at 3 54 48 PM](https://user-images.githubusercontent.com/11338480/143128048-61e4ad37-b02c-4989-a396-67c6d054498d.png)

History
![Screen Shot 2021-11-23 at 3 58 58 PM](https://user-images.githubusercontent.com/11338480/143128143-56577c9e-400a-451e-80a2-b43ed23daa05.png)

Reading List
![Screen Shot 2021-11-23 at 4 07 42 PM](https://user-images.githubusercontent.com/11338480/143128931-8b137ba6-dfcb-4778-8159-5d630696b838.png)
![Screen Shot 2021-11-23 at 4 07 51 PM](https://user-images.githubusercontent.com/11338480/143128939-196bd9e0-454f-4f45-8535-b4c2ee46f8cc.png)


