### PR TITLE
#9548 Top tab title and clean ups

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -390,6 +390,9 @@
 		8A11C8132731E54800AC7318 /* DictionaryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */; };
 		8A8A05E42746ACAC004267A0 /* TabDisplayManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8A05E32746ACAC004267A0 /* TabDisplayManagerTests.swift */; };
 		8AA6ADB52742B567004EEE23 /* TelemetryWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA6ADB42742B567004EEE23 /* TelemetryWrapperTests.swift */; };
+		8AEE62C92756BA34003207D1 /* LoginsHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 8AEE62C62756BA34003207D1 /* LoginsHelper.js */; };
+		8AEE62CA2756BA34003207D1 /* TrackingProtectionStats.js in Resources */ = {isa = PBXBuildFile; fileRef = 8AEE62C72756BA34003207D1 /* TrackingProtectionStats.js */; };
+		8AEE62CB2756BA34003207D1 /* DownloadHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 8AEE62C82756BA34003207D1 /* DownloadHelper.js */; };
 		8AFE4C2127480D0C00B97C65 /* TabTrayViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFE4C2027480D0B00B97C65 /* TabTrayViewControllerTests.swift */; };
 		8D8251811F4DE67F00780643 /* AdvancedAccountSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8251721F4DE67E00780643 /* AdvancedAccountSettingViewController.swift */; };
 		8DCD3BCD1ED5B7FA00446D38 /* FxADeepLinkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DCD3BCC1ED5B7FA00446D38 /* FxADeepLinkingTests.swift */; };
@@ -2542,6 +2545,9 @@
 		8AAD4900BB6F4DF6056B581F /* ml */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ml; path = ml.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		8AB04613B101195AADCC1F1B /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = "cs.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		8AD440CBBF202B15E74E186D /* ur */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ur; path = ur.lproj/Search.strings; sourceTree = "<group>"; };
+		8AEE62C62756BA34003207D1 /* LoginsHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = LoginsHelper.js; path = AllFrames/AtDocumentStart/LoginsHelper.js; sourceTree = "<group>"; };
+		8AEE62C72756BA34003207D1 /* TrackingProtectionStats.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = TrackingProtectionStats.js; path = AllFrames/AtDocumentStart/TrackingProtectionStats.js; sourceTree = "<group>"; };
+		8AEE62C82756BA34003207D1 /* DownloadHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = DownloadHelper.js; path = AllFrames/AtDocumentStart/DownloadHelper.js; sourceTree = "<group>"; };
 		8AFE4C2027480D0B00B97C65 /* TabTrayViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabTrayViewControllerTests.swift; sourceTree = "<group>"; };
 		8B3245D190D4FA80C3B46EC8 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Search.strings"; sourceTree = "<group>"; };
 		8B674438A5487ABCD2DD7CA5 /* ses */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ses; path = ses.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -5358,6 +5364,9 @@
 		D0FCF7E71FE44CA9004A7995 /* UserScripts */ = {
 			isa = PBXGroup;
 			children = (
+				8AEE62C82756BA34003207D1 /* DownloadHelper.js */,
+				8AEE62C62756BA34003207D1 /* LoginsHelper.js */,
+				8AEE62C72756BA34003207D1 /* TrackingProtectionStats.js */,
 				D0FCF7E81FE44D8F004A7995 /* AllFrames */,
 				D0FCF7E91FE44DA2004A7995 /* MainFrame */,
 			);
@@ -7286,6 +7295,8 @@
 			files = (
 				39D056382665235700FBEE59 /* initial_experiments.json in Resources */,
 				D38A1EE01CB458EC0080C842 /* CertError.html in Resources */,
+				8AEE62CB2756BA34003207D1 /* DownloadHelper.js in Resources */,
+				8AEE62CA2756BA34003207D1 /* TrackingProtectionStats.js in Resources */,
 				0BA1E0301B051A07007675AF /* NetError.css in Resources */,
 				3BC659491E5BA4AE006D560F /* TopSites in Resources */,
 				E4B7B77E1A793CF20022C5E0 /* FiraSans-SemiBold.ttf in Resources */,
@@ -7332,6 +7343,7 @@
 				EBE7635820ADCB7600E27F2D /* SendTo.xcassets in Resources */,
 				E4ECCDAE1AB131770005E717 /* FiraSans-Medium.ttf in Resources */,
 				C8954A4C2729AD31001C7283 /* FxColours.xcassets in Resources */,
+				8AEE62C92756BA34003207D1 /* LoginsHelper.js in Resources */,
 				EBC9D38922D4D56F0011D881 /* disconnect-block-cookies-advertising.json in Resources */,
 				D0E17FB6201F847600F1FCB5 /* FxASignIn.js in Resources */,
 				E4424B3C1AC71FB400F44C38 /* FiraSans-Book.ttf in Resources */,

--- a/Client/Application/main.swift
+++ b/Client/Application/main.swift
@@ -6,7 +6,8 @@ import Shared
 
 private var appDelegate: AppDelegate.Type
 
-if AppConstants.IsRunningTest || AppConstants.IsRunningPerfTest {     appDelegate = TestAppDelegate.self
+if AppConstants.IsRunningTest || AppConstants.IsRunningPerfTest {
+    appDelegate = TestAppDelegate.self
 } else {
     appDelegate = AppDelegate.self
 }

--- a/Client/FeatureFlags/FeatureFlagsManager.swift
+++ b/Client/FeatureFlags/FeatureFlagsManager.swift
@@ -116,7 +116,7 @@ class FeatureFlagsManager {
 
         let chronTabs = FlaggableFeature(withID: .chronologicalTabs,
                                          and: profile,
-                                         enabledFor: [.developer])
+                                         enabledFor: [])
         features[.chronologicalTabs] = chronTabs
 
         let inactiveTabs = FlaggableFeature(withID: .inactiveTabs,

--- a/Client/FeatureFlags/FeatureFlagsManager.swift
+++ b/Client/FeatureFlags/FeatureFlagsManager.swift
@@ -116,7 +116,7 @@ class FeatureFlagsManager {
 
         let chronTabs = FlaggableFeature(withID: .chronologicalTabs,
                                          and: profile,
-                                         enabledFor: [])
+                                         enabledFor: [.developer])
         features[.chronologicalTabs] = chronTabs
 
         let inactiveTabs = FlaggableFeature(withID: .inactiveTabs,

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -782,14 +782,20 @@ extension TabTrayCell {
     /// Use the display title unless it's an empty string, then use the base domain from the url
     func getTabTrayTitle(tab: Tab) -> String? {
         let baseDomain = tab.sessionData?.urls.last?.baseDomain ?? tab.url?.baseDomain
-        let urlLabel = baseDomain != nil ? baseDomain!.contains("local") ? "" : baseDomain : ""
-        return tab.displayTitle.isEmpty ? urlLabel : tab.displayTitle
+        let backUpName: String // In case display title is empty
+        if let baseDomain = baseDomain {
+            backUpName = baseDomain.contains("local") ? .AppMenuOpenHomePageTitleString : baseDomain
+        } else {
+            backUpName = ""
+        }
+        return tab.displayTitle.isEmpty ? backUpName : tab.displayTitle
     }
 
     func getA11yTitleLabel(tab: Tab) -> String? {
         var aboutComponent = ""
         if let url = tab.url, let about = InternalURL(url)?.aboutComponent { aboutComponent = about }
-        let baseName = tab.displayTitle.isEmpty ? aboutComponent.isEmpty ? getTabTrayTitle(tab: tab) : aboutComponent : tab.displayTitle
+        let backUpName = aboutComponent.isEmpty ? getTabTrayTitle(tab: tab) : aboutComponent
+        let baseName = tab.displayTitle.isEmpty ? backUpName : tab.displayTitle
 
         if isSelectedTab, let baseName = baseName, !baseName.isEmpty {
             return baseName + ". " + String.TabTrayCurrentlySelectedTabAccessibilityLabel

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -782,20 +782,17 @@ extension TabTrayCell {
     /// Use the display title unless it's an empty string, then use the base domain from the url
     func getTabTrayTitle(tab: Tab) -> String? {
         let baseDomain = tab.sessionData?.urls.last?.baseDomain ?? tab.url?.baseDomain
-        let backUpName: String // In case display title is empty
+        var backUpName: String = "" // In case display title is empty
         if let baseDomain = baseDomain {
             backUpName = baseDomain.contains("local") ? .AppMenuOpenHomePageTitleString : baseDomain
-        } else {
-            backUpName = ""
+        } else if let url = tab.url, let about = InternalURL(url)?.aboutComponent {
+            backUpName = about
         }
         return tab.displayTitle.isEmpty ? backUpName : tab.displayTitle
     }
 
     func getA11yTitleLabel(tab: Tab) -> String? {
-        var aboutComponent = ""
-        if let url = tab.url, let about = InternalURL(url)?.aboutComponent { aboutComponent = about }
-        let backUpName = aboutComponent.isEmpty ? getTabTrayTitle(tab: tab) : aboutComponent
-        let baseName = tab.displayTitle.isEmpty ? backUpName : tab.displayTitle
+        let baseName = getTabTrayTitle(tab: tab)
 
         if isSelectedTab, let baseName = baseName, !baseName.isEmpty {
             return baseName + ". " + String.TabTrayCurrentlySelectedTabAccessibilityLabel

--- a/RustFxA/FxAWebViewController.swift
+++ b/RustFxA/FxAWebViewController.swift
@@ -87,7 +87,6 @@ class FxAWebViewController: UIViewController, WKNavigationDelegate {
         if dismissType == .dismiss {
             super.dismiss(animated: animated, completion: completion)
         } else if dismissType == .popToTabTray {
-            print("SOMETHING")
             shouldDismissFxASignInViewController?()
         } else {
             navigationController?.popToRootViewController(animated: true)


### PR DESCRIPTION
- Wanted to do some quick clean up of code: Indentation fix, removing extra print, adding missing project files
- Setting grid tabs by default on develop since that's the one we always use. Chron tabs feature needs to be activated to be used.
- Removed double ternary operators, and realized at the same time how to fix #9548 (tab title was missing after clicking on the top tab tray)

After a restart of the app, the top tabs will be looking like this when we reload them:

https://user-images.githubusercontent.com/11338480/144132704-28ee3b12-ef48-42e4-b054-9aa43f3c0711.mov


