### PR TITLE
Disabled chron tabs by default in debug

### DIFF
--- a/Client/FeatureFlags/FeatureFlagsManager.swift
+++ b/Client/FeatureFlags/FeatureFlagsManager.swift
@@ -116,7 +116,7 @@ class FeatureFlagsManager {
 
         let chronTabs = FlaggableFeature(withID: .chronologicalTabs,
                                          and: profile,
-                                         enabledFor: [.developer])
+                                         enabledFor: [])
         features[.chronologicalTabs] = chronTabs
 
         let inactiveTabs = FlaggableFeature(withID: .inactiveTabs,

--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -217,7 +217,7 @@ class ActivityStreamTest: BaseTestCase {
             app.buttons["Show Tabs"].tap()
         }
         navigator.nowAt(TabTray)
-        waitForExistence(app.collectionViews.cells.staticTexts["Apple"], timeout: 7)
+        waitForExistence(app.collectionViews.cells.staticTexts["Apple"], timeout: 5)
         app.cells.staticTexts["Apple"].firstMatch.tap()
 
         // The website is open

--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -217,11 +217,7 @@ class ActivityStreamTest: BaseTestCase {
             app.buttons["Show Tabs"].tap()
         }
         navigator.nowAt(TabTray)
-        if iPad() {
-            waitForExistence(app.collectionViews.cells.staticTexts["Apple"], timeout: 5)
-        } else {
-            waitForExistence(app.collectionViews.cells.staticTexts["Apple"], timeout: 5)
-        }
+        waitForExistence(app.collectionViews.cells.staticTexts["Apple"], timeout: 7)
         app.cells.staticTexts["Apple"].firstMatch.tap()
 
         // The website is open


### PR DESCRIPTION
We don't use chron tabs and hence disabling it by default. If we need to test it then the debug menu option still exists.