### PR TITLE
Update carthage commands

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,14 +13,23 @@
 # Use the --importLocales option to fetch and update locales only
 #
 
-getLocale()
-{
+getLocale() {
   echo "Getting locale..."
   git clone https://github.com/boek/ios-l10n-scripts.git -b new_tool || exit 1
 
   echo "Creating firefoxios-l10n Git repo"
   rm -rf firefoxios-l10n
   git clone --depth 1 https://github.com/mozilla-l10n/firefoxios-l10n firefoxios-l10n || exit 1
+}
+
+# Useful to check if previous command was successful - quit if it wasn't
+# Pass the error message as a parameter of the function with 'verifyExitCode "message"'
+verifyExitCode() {
+  EXIT_CODE=$?
+  if [ $EXIT_CODE == 0 ]; then
+    echo "$1"
+    exit 0
+  fi
 }
 
 if [ "$1" == "--force" ]; then
@@ -45,6 +54,7 @@ fi
 
 # Run carthage
 ./carthage_command.sh
+verifyExitCode "Exit due to carthage_command.sh"
 
 # Move Glean script to source folder from MozillaAppServices.framework
 # as we don't want to ship our app with this Glean script inside framework

--- a/carthage_command.sh
+++ b/carthage_command.sh
@@ -1,7 +1,7 @@
 xcodesdk=`xcodebuild -scheme Firefox  -showBuildSettings  | grep -i 'SDK_VERSION =' | sed 's/[ ]*SDK_VERSION = //' | colrm 3`
 echo Xcode SDK: "$xcodesdk"
-if [[ "$xcodesdk" != "13" ]]; then
-  echo XCode 12 version detected! ••• Please ensure this is correct. ••• 
+if [[ "$xcodesdk" != "15" ]]; then
+  echo Xcode 13 version was not detected! ••• Please ensure this is correct. ••• 
 echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64 arm64e armv7 armv7s armv6 armv8' > /tmp/tmp.xcconfig
 echo 'EXCLUDED_ARCHS=$(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))' >> /tmp/tmp.xcconfig
 echo 'IPHONEOS_DEPLOYMENT_TARGET=11.4' >> /tmp/tmp.xcconfig
@@ -11,11 +11,3 @@ export XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig
 fi
 
 carthage bootstrap $CARTHAGE_VERBOSE --platform ios --color auto --cache-builds
-
-# if [[ -d Carthage/Build/iOS/Static/MozillaAppServices.framework ]]; then
-#  echo Move local build of AppServices from Static
-#  rm -rf Carthage/Build/iOS/MozillaAppServices.framework
-#  cp -r Carthage/Build/iOS/Static/MozillaAppServices.framework Carthage/Build/iOS/MozillaAppServices.framework
-# fi
-
-

--- a/carthage_command.sh
+++ b/carthage_command.sh
@@ -1,13 +1,18 @@
 xcodesdk=`xcodebuild -scheme Firefox  -showBuildSettings  | grep -i 'SDK_VERSION =' | sed 's/[ ]*SDK_VERSION = //' | colrm 3`
-echo Xcode SDK: "$xcodesdk"
-if [[ "$xcodesdk" != "15" ]]; then
-  echo Xcode 13 version was not detected! ••• Please ensure this is correct. ••• 
+echo Xcode SDK: $(($xcodesdk+0))
+
+# Make sure we're on Xcode greater than 12
+if [[ 13 -gt $(($xcodesdk+0)) ]]; then
+  echo Xcode 12 version \(SDK 13\) or more should be used! 
+  exit 0
+fi
+
 echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64 arm64e armv7 armv7s armv6 armv8' > /tmp/tmp.xcconfig
 echo 'EXCLUDED_ARCHS=$(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))' >> /tmp/tmp.xcconfig
 echo 'IPHONEOS_DEPLOYMENT_TARGET=11.4' >> /tmp/tmp.xcconfig
 echo 'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig
 echo 'GCC_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig
 export XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig
-fi
 
 carthage bootstrap $CARTHAGE_VERBOSE --platform ios --color auto --cache-builds
+exit 1


### PR DESCRIPTION
Suggestion for the cartage_command.sh script - I think we should stop running if user is on a wrong xcode version. At the moment, "wrong" is defined as less than Xcode 12 (sdk 13), but let me know if you think it should be otherwise.