### PR TITLE
Add #8969 [v96] New keyboard shortcuts

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -386,6 +386,7 @@
 		7BF5A1EA1B41640500EA9DD8 /* SyncQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5A1E91B41640500EA9DD8 /* SyncQueue.swift */; };
 		7BF5A1EE1B429B3100EA9DD8 /* SyncCommandsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5A1ED1B429B3100EA9DD8 /* SyncCommandsTests.swift */; };
 		884CA7492344A301002E4711 /* TextContentDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884CA7482344A301002E4711 /* TextContentDetector.swift */; };
+		8A01891C275E9C2A00923EFE /* ClearHistoryHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A01891B275E9C2A00923EFE /* ClearHistoryHelper.swift */; };
 		8A11C80F2731916E00AC7318 /* defaultOnlyTestList.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A11C80D2731916E00AC7318 /* defaultOnlyTestList.json */; };
 		8A11C8112731CFD700AC7318 /* ReaderModeStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */; };
 		8A11C8132731E54800AC7318 /* DictionaryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */; };
@@ -2537,6 +2538,7 @@
 		88D54F3084E96EFC11C8C7DB /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/HistoryPanel.strings; sourceTree = "<group>"; };
 		890045908C7B76449D0FEA78 /* lt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lt; path = lt.lproj/Localizable.strings; sourceTree = "<group>"; };
 		89AE47D2B80AF49BFB9763BA /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/LoginManager.strings; sourceTree = "<group>"; };
+		8A01891B275E9C2A00923EFE /* ClearHistoryHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearHistoryHelper.swift; sourceTree = "<group>"; };
 		8A0F46E89E106C66C6C29F07 /* bn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bn; path = bn.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		8A11C80D2731916E00AC7318 /* defaultOnlyTestList.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = defaultOnlyTestList.json; sourceTree = "<group>"; };
 		8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeStyleTests.swift; sourceTree = "<group>"; };
@@ -5343,6 +5345,7 @@
 				59A6839879D615FC1C0D71CE /* BookmarksPanel.swift */,
 				D0E89A2820910917001CE5C7 /* DownloadsPanel.swift */,
 				59A6825233896FC846499289 /* HistoryPanel.swift */,
+				8A01891B275E9C2A00923EFE /* ClearHistoryHelper.swift */,
 				D30B101D1AA7F9C600C01CA3 /* LibraryPanels.swift */,
 				274A36D1239EBAD600A21587 /* LibraryViewController */,
 				59A685F4EAD19EDEC854BCA4 /* ReaderPanel.swift */,
@@ -8140,6 +8143,7 @@
 				C8163851268A0899004C7160 /* AddCredentialViewController.swift in Sources */,
 				CA520E7A24913C1B00CCAB48 /* LoginListViewModel.swift in Sources */,
 				E65075521E37F6D1006961AC /* UIViewExtensions.swift in Sources */,
+				8A01891C275E9C2A00923EFE /* ClearHistoryHelper.swift in Sources */,
 				C8F457A81F1FD75A000CB895 /* BrowserViewController+WebViewDelegates.swift in Sources */,
 				E6927EC01C7B6FB800D03F75 /* ErrorToast.swift in Sources */,
 				D30B101E1AA7F9C600C01CA3 /* LibraryPanels.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -853,9 +853,11 @@ class BrowserViewController: UIViewController {
         controller = DismissableNavigationViewController(rootViewController: libraryViewController)
         controller.onViewWillDisappear = {
             self.firefoxHomeViewController?.reloadAll()
+            self.libraryViewController = nil
         }
         controller.onViewDismissed = {
             self.firefoxHomeViewController?.reloadAll()
+            self.libraryViewController = nil
         }
         self.present(controller, animated: true, completion: nil)
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1247,6 +1247,10 @@ class BrowserViewController: UIViewController {
     @objc func openSettings() {
         assert(Thread.isMainThread, "Opening settings requires being invoked on the main thread")
 
+        if let presentedViewController = self.presentedViewController {
+            presentedViewController.dismiss(animated: true, completion: nil)
+        }
+
         let settingsTableViewController = AppSettingsTableViewController()
         settingsTableViewController.profile = profile
         settingsTableViewController.tabManager = tabManager

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1242,7 +1242,7 @@ class BrowserViewController: UIViewController {
         present(controller, animated: true, completion: nil)
     }
 
-    @objc fileprivate func openSettings() {
+    @objc func openSettings() {
         assert(Thread.isMainThread, "Opening settings requires being invoked on the main thread")
 
         let settingsTableViewController = AppSettingsTableViewController()

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -59,8 +59,16 @@ extension BrowserViewController {
 
     @objc private func findInPageKeyCommand() {
         TelemetryWrapper.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "find-in-page"])
+        findInPage(withText: "")
+    }
+
+    @objc private func findInPageAgainKeyCommand() {
+        findInPage(withText: FindInPageBar.retrieveSavedText ?? "")
+    }
+
+    private func findInPage(withText text: String) {
         if let tab = tabManager.selectedTab, firefoxHomeViewController == nil {
-            self.tab(tab, didSelectFindInPageForSelection: "")
+            self.tab(tab, didSelectFindInPageForSelection: text)
         }
     }
 
@@ -162,11 +170,11 @@ extension BrowserViewController {
             UIKeyCommand(action: #selector(newPrivateTabKeyCommand), input: "p", modifierFlags: [.command, .shift], discoverabilityTitle: .NewPrivateTabTitle),
             UIKeyCommand(action: #selector(selectLocationBarKeyCommand), input: "l", modifierFlags: .command, discoverabilityTitle: .SelectLocationBarTitle),
             UIKeyCommand(action: #selector(closeTabKeyCommand), input: "w", modifierFlags: .command, discoverabilityTitle: .CloseTabTitle),
-            // TODO: Save page as - Command + S
 
             // Edit
             UIKeyCommand(action: #selector(findInPageKeyCommand), input: "f", modifierFlags: .command, discoverabilityTitle: .FindTitle),
-            // TODO: Find again - Command + G
+            // TODO: String KeyboardShortcuts.FindAgain
+            UIKeyCommand(action: #selector(findInPageAgainKeyCommand), input: "g", modifierFlags: .command, discoverabilityTitle: "Find again"),
 
             // View
             UIKeyCommand(action: #selector(reloadTabKeyCommand), input: "r", modifierFlags: .command, discoverabilityTitle: .ReloadPageTitle),

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -187,12 +187,10 @@ extension BrowserViewController {
             UIKeyCommand(action: #selector(showDownloads), input: "j", modifierFlags: .command, discoverabilityTitle: "Show Downloads"),
 
             // Window
-            UIKeyCommand(action: #selector(showTabTrayKeyCommand), input: "\\", modifierFlags: [.command, .shift]), // Safari on macOS
-            UIKeyCommand(action: #selector(nextTabKeyCommand), input: "]", modifierFlags: [.command, .shift]),
-            UIKeyCommand(action: #selector(previousTabKeyCommand), input: "[", modifierFlags: [.command, .shift]),
-            UIKeyCommand(action: #selector(nextTabKeyCommand), input: "\t", modifierFlags: .control, discoverabilityTitle: .ShowNextTabTitle),
-            UIKeyCommand(action: #selector(previousTabKeyCommand), input: "\t", modifierFlags: [.control, .shift],  discoverabilityTitle: .ShowPreviousTabTitle),
-            UIKeyCommand(action: #selector(showTabTrayKeyCommand), input: "\t", modifierFlags: [.command, .alternate], discoverabilityTitle: .ShowTabTrayFromTabKeyCodeTitle),
+            UIKeyCommand(action: #selector(nextTabKeyCommand), input: "]", modifierFlags: [.command, .shift], discoverabilityTitle: .ShowNextTabTitle),
+            UIKeyCommand(action: #selector(previousTabKeyCommand), input: "[", modifierFlags: [.command, .shift], discoverabilityTitle: .ShowPreviousTabTitle),
+            UIKeyCommand(action: #selector(showTabTrayKeyCommand), input: "\\", modifierFlags: [.command, .shift], discoverabilityTitle: .ShowTabTrayFromTabKeyCodeTitle),
+            UIKeyCommand(action: #selector(showTabTrayKeyCommand), input: "\t", modifierFlags: [.command, .alternate]),
             // TODO: Show tab # 1-9 - Command + 1-9
         ]
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -13,15 +13,24 @@ extension BrowserViewController {
     }
 
     @objc private func showHistoryKeyCommand() {
-        showLibrary(panel: .history)
+        showPanel(.history)
     }
 
     @objc private func showDownloadsKeyCommand() {
-        showLibrary(panel: .downloads)
+        showPanel(.downloads)
     }
 
     @objc private func showBookmarksKeyCommand() {
-        showLibrary(panel: .bookmarks)
+        showPanel(.bookmarks)
+    }
+
+    private func showPanel(_ panel: LibraryPanelType) {
+        guard let libraryViewController = self.libraryViewController else {
+            showLibrary(panel: panel)
+            return
+        }
+
+        libraryViewController.selectedPanel = panel
     }
 
     @objc private func openClearHistoryPanelKeyCommand() {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -125,7 +125,8 @@ extension BrowserViewController {
 
         let tabNavigation = [
             // Settings
-            // TODO: Open settings - Command + ,
+            // TODO: DiscoverabilityTitle for open settings - KeyboardShortcuts.Settings from Nishant's PR
+            UIKeyCommand(action: #selector(openSettings), input: ",", modifierFlags: .command, discoverabilityTitle: "KeyboardShortcuts.Settings"),
 
             // File
             UIKeyCommand(action: #selector(newTabKeyCommand), input: "t", modifierFlags: .command, discoverabilityTitle: .NewTabTitle),

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -25,8 +25,14 @@ extension BrowserViewController {
     }
 
     @objc private func openClearHistoryPanelKeyCommand() {
-        let clearHistoryHelper = ClearHistoryHelper(profile: profile)
-        clearHistoryHelper.showClearRecentHistory(onViewController: self, didComplete: {})
+        guard let libraryViewController = self.libraryViewController else {
+            let clearHistoryHelper = ClearHistoryHelper(profile: profile)
+            clearHistoryHelper.showClearRecentHistory(onViewController: self, didComplete: {})
+            return
+        }
+
+        libraryViewController.selectedPanel = .history
+        NotificationCenter.default.post(name: .OpenClearRecentHistory, object: nil)
     }
 
     @objc private func addBookmarkKeyCommand() {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -124,24 +124,51 @@ extension BrowserViewController {
         }
 
         let tabNavigation = [
-            UIKeyCommand(action: #selector(reloadTabKeyCommand), input: "r", modifierFlags: .command, discoverabilityTitle: .ReloadPageTitle),
-            UIKeyCommand(action: #selector(goBackKeyCommand), input: "[", modifierFlags: .command, discoverabilityTitle: .BackTitle),
-            UIKeyCommand(action: #selector(goForwardKeyCommand), input: "]", modifierFlags: .command, discoverabilityTitle: .ForwardTitle),
-            UIKeyCommand(action: #selector(findInPageKeyCommand), input: "f", modifierFlags: .command, discoverabilityTitle: .FindTitle),
-            UIKeyCommand(action: #selector(selectLocationBarKeyCommand), input: "l", modifierFlags: .command, discoverabilityTitle: .SelectLocationBarTitle),
+            // Settings
+            // TODO: Open settings - Command + ,
+
+            // File
             UIKeyCommand(action: #selector(newTabKeyCommand), input: "t", modifierFlags: .command, discoverabilityTitle: .NewTabTitle),
             UIKeyCommand(action: #selector(newPrivateTabKeyCommand), input: "p", modifierFlags: [.command, .shift], discoverabilityTitle: .NewPrivateTabTitle),
+            UIKeyCommand(action: #selector(selectLocationBarKeyCommand), input: "l", modifierFlags: .command, discoverabilityTitle: .SelectLocationBarTitle),
+            // TODO: Open link in background - Command + Tap link
+            // TODO: Open link in background - Command + Shift + Tap link
             UIKeyCommand(action: #selector(closeTabKeyCommand), input: "w", modifierFlags: .command, discoverabilityTitle: .CloseTabTitle),
-            UIKeyCommand(action: #selector(nextTabKeyCommand), input: "\t", modifierFlags: .control, discoverabilityTitle: .ShowNextTabTitle),
-            UIKeyCommand(action: #selector(previousTabKeyCommand), input: "\t", modifierFlags: [.control, .shift],  discoverabilityTitle: .ShowPreviousTabTitle),
+            // TODO: Save page as - Command + S
+            // TODO: Download link - Option + Tap link
 
-            // Switch tab to match Safari on iOS.
+            // Edit
+            UIKeyCommand(action: #selector(findInPageKeyCommand), input: "f", modifierFlags: .command, discoverabilityTitle: .FindTitle),
+            // TODO: Find again - Command + G
+
+            // View
+            UIKeyCommand(action: #selector(reloadTabKeyCommand), input: "r", modifierFlags: .command, discoverabilityTitle: .ReloadPageTitle),
+            // TODO: Zoom in - Command + +
+            // TODO: Zoom out - Command + -
+            // TODO: Actual size - Command + 0
+
+            // History
+            // TODO: Show history - Command + Y
+            UIKeyCommand(action: #selector(goBackKeyCommand), input: "[", modifierFlags: .command, discoverabilityTitle: .BackTitle),
+            UIKeyCommand(action: #selector(goForwardKeyCommand), input: "]", modifierFlags: .command, discoverabilityTitle: .ForwardTitle),
+            // TODO: Add back and forward arrow keys shortcuts for goBackKeyCommand and goForwardKeyCommand
+            // TODO: Clear recent history - Shift + Command + Back Arrow
+
+            // Bookmarks
+            // TODO: Show bookmarks - Command + Y
+            // TODO: Add Bookmark - Command + D -> Only in overridesTextEditing
+
+            // Tools
+            // TODO: Show downloads - Command + J
+
+            // Window
+            UIKeyCommand(action: #selector(showTabTrayKeyCommand), input: "\\", modifierFlags: [.command, .shift]), // Safari on macOS
             UIKeyCommand(action: #selector(nextTabKeyCommand), input: "]", modifierFlags: [.command, .shift]),
             UIKeyCommand(action: #selector(previousTabKeyCommand), input: "[", modifierFlags: [.command, .shift]),
-
-            UIKeyCommand(action: #selector(showTabTrayKeyCommand), input: "\\", modifierFlags: [.command, .shift]), // Safari on macOS
+            UIKeyCommand(action: #selector(nextTabKeyCommand), input: "\t", modifierFlags: .control, discoverabilityTitle: .ShowNextTabTitle),
+            UIKeyCommand(action: #selector(previousTabKeyCommand), input: "\t", modifierFlags: [.control, .shift],  discoverabilityTitle: .ShowPreviousTabTitle),
             UIKeyCommand(action: #selector(showTabTrayKeyCommand), input: "\t", modifierFlags: [.command, .alternate], discoverabilityTitle: .ShowTabTrayFromTabKeyCodeTitle),
-
+            // TODO: Show tab # 1-9 - Command + 1-9
         ]
 
         let isEditingText = tabManager.selectedTab?.isEditing ?? false

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -29,7 +29,7 @@ extension BrowserViewController {
         clearHistoryHelper.showClearRecentHistory(onViewController: self, didComplete: {})
     }
 
-    @objc private func addTabKeyCommand() {
+    @objc private func addBookmarkKeyCommand() {
         if let tab = tabManager.selectedTab, firefoxHomeViewController == nil {
             guard let url = tab.canonicalURL?.displayURL else { return }
             addBookmark(url: url.absoluteString, title: tab.title, favicon: tab.displayFavicon)
@@ -192,7 +192,7 @@ extension BrowserViewController {
             // Bookmarks
             // TODO: String KeyboardShortcuts.ShowBookmarks & KeyboardShortcuts.AddBookmark
             UIKeyCommand(action: #selector(showBookmarksKeyCommand), input: "o", modifierFlags: [.shift, .command], discoverabilityTitle: "Show Bookmarks"),
-            UIKeyCommand(action: #selector(addTabKeyCommand), input: "d", modifierFlags: .command, discoverabilityTitle: "Add Bookmark"),
+            UIKeyCommand(action: #selector(addBookmarkKeyCommand), input: "d", modifierFlags: .command, discoverabilityTitle: "Add Bookmark"),
 
             // Tools
             // TODO: String KeyboardShortcuts.ShowDownloads

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -105,15 +105,24 @@ extension BrowserViewController {
 
     override var keyCommands: [UIKeyCommand]? {
         let searchLocationCommands = [
-            UIKeyCommand(input: UIKeyCommand.inputDownArrow, modifierFlags: [], action: #selector(moveURLCompletionKeyCommand(sender:))),
-            UIKeyCommand(input: UIKeyCommand.inputUpArrow, modifierFlags: [], action: #selector(moveURLCompletionKeyCommand(sender:))),
+            // Navigate the suggestions
+            UIKeyCommand(action: #selector(moveURLCompletionKeyCommand(sender:)), input: UIKeyCommand.inputDownArrow),
+            UIKeyCommand(action: #selector(moveURLCompletionKeyCommand(sender:)), input: UIKeyCommand.inputUpArrow),
         ]
-        let overidesTextEditing = [
-            UIKeyCommand(input: UIKeyCommand.inputRightArrow, modifierFlags: [.command, .shift], action: #selector(nextTabKeyCommand)),
-            UIKeyCommand(input: UIKeyCommand.inputLeftArrow, modifierFlags: [.command, .shift], action: #selector(previousTabKeyCommand)),
-            UIKeyCommand(input: UIKeyCommand.inputLeftArrow, modifierFlags: .command, action: #selector(goBackKeyCommand)),
-            UIKeyCommand(input: UIKeyCommand.inputRightArrow, modifierFlags: .command, action: #selector(goForwardKeyCommand)),
+
+        let overridesTextEditing = [
+            UIKeyCommand(action: #selector(nextTabKeyCommand), input: UIKeyCommand.inputRightArrow, modifierFlags: [.command, .shift]),
+            UIKeyCommand(action: #selector(previousTabKeyCommand), input: UIKeyCommand.inputLeftArrow, modifierFlags: [.command, .shift]),
+            UIKeyCommand(action: #selector(goBackKeyCommand), input: UIKeyCommand.inputLeftArrow, modifierFlags: .command),
+            UIKeyCommand(action: #selector(goForwardKeyCommand), input: UIKeyCommand.inputRightArrow, modifierFlags: .command),
         ]
+
+        // In iOS 15 and later, physical keyboard events are delivered to the text input or focus systems first, unless specified otherwise
+        if #available(iOS 15, *) {
+            searchLocationCommands.forEach { $0.wantsPriorityOverSystemBehavior = true }
+            overridesTextEditing.forEach { $0.wantsPriorityOverSystemBehavior = true }
+        }
+
         let tabNavigation = [
             UIKeyCommand(action: #selector(reloadTabKeyCommand), input: "r", modifierFlags: .command, discoverabilityTitle: .ReloadPageTitle),
             UIKeyCommand(action: #selector(goBackKeyCommand), input: "[", modifierFlags: .command, discoverabilityTitle: .BackTitle),
@@ -127,11 +136,11 @@ extension BrowserViewController {
             UIKeyCommand(action: #selector(previousTabKeyCommand), input: "\t", modifierFlags: [.control, .shift],  discoverabilityTitle: .ShowPreviousTabTitle),
 
             // Switch tab to match Safari on iOS.
-            UIKeyCommand(input: "]", modifierFlags: [.command, .shift], action: #selector(nextTabKeyCommand)),
-            UIKeyCommand(input: "[", modifierFlags: [.command, .shift], action: #selector(previousTabKeyCommand)),
+            UIKeyCommand(action: #selector(nextTabKeyCommand), input: "]", modifierFlags: [.command, .shift]),
+            UIKeyCommand(action: #selector(previousTabKeyCommand), input: "[", modifierFlags: [.command, .shift]),
 
-            UIKeyCommand(input: "\\", modifierFlags: [.command, .shift], action: #selector(showTabTrayKeyCommand)), // Safari on macOS
-            UIKeyCommand(action: #selector(showTabTrayKeyCommand), input: "\t", modifierFlags: [.command, .alternate], discoverabilityTitle: .ShowTabTrayFromTabKeyCodeTitle)
+            UIKeyCommand(action: #selector(showTabTrayKeyCommand), input: "\\", modifierFlags: [.command, .shift]), // Safari on macOS
+            UIKeyCommand(action: #selector(showTabTrayKeyCommand), input: "\t", modifierFlags: [.command, .alternate], discoverabilityTitle: .ShowTabTrayFromTabKeyCodeTitle),
 
         ]
 
@@ -140,7 +149,7 @@ extension BrowserViewController {
         if urlBar.inOverlayMode {
             return tabNavigation + searchLocationCommands
         } else if !isEditingText {
-            return tabNavigation + overidesTextEditing
+            return tabNavigation + overridesTextEditing
         }
         return tabNavigation
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -8,24 +8,28 @@ import UIKit
 // Naming functions: use the suffix 'KeyCommand' for an additional level of namespacing (bug 1415830)
 extension BrowserViewController {
 
-    @objc private func showHistory() {
+    @objc private func openSettingsKeyCommand() {
+        openSettings()
+    }
+
+    @objc private func showHistoryKeyCommand() {
         showLibrary(panel: .history)
     }
 
-    @objc private func showDownloads() {
+    @objc private func showDownloadsKeyCommand() {
         showLibrary(panel: .downloads)
     }
 
-    @objc private func showBookmarks() {
+    @objc private func showBookmarksKeyCommand() {
         showLibrary(panel: .bookmarks)
     }
 
-    @objc private func openClearHistoryPanel() {
+    @objc private func openClearHistoryPanelKeyCommand() {
         let clearHistoryHelper = ClearHistoryHelper(profile: profile)
         clearHistoryHelper.showClearRecentHistory(onViewController: self, didComplete: {})
     }
 
-    @objc private func addCurrentTabToBookmarks() {
+    @objc private func addTabKeyCommand() {
         if let tab = tabManager.selectedTab, firefoxHomeViewController == nil {
             guard let url = tab.canonicalURL?.displayURL else { return }
             addBookmark(url: url.absoluteString, title: tab.title, favicon: tab.displayFavicon)
@@ -151,7 +155,7 @@ extension BrowserViewController {
         let commands = [
             // Settings
             // TODO: String KeyboardShortcuts.Settings
-            UIKeyCommand(action: #selector(openSettings), input: ",", modifierFlags: .command, discoverabilityTitle: "Settings"),
+            UIKeyCommand(action: #selector(openSettingsKeyCommand), input: ",", modifierFlags: .command, discoverabilityTitle: "Settings"),
 
             // File
             UIKeyCommand(action: #selector(newTabKeyCommand), input: "t", modifierFlags: .command, discoverabilityTitle: .NewTabTitle),
@@ -172,19 +176,19 @@ extension BrowserViewController {
 
             // History
             // TODO: String KeyboardShortcuts.ShowHistory & KeyboardShortcuts.ClearRecentHistory
-            UIKeyCommand(action: #selector(showHistory), input: "y", modifierFlags: .command, discoverabilityTitle: "Show History"),
+            UIKeyCommand(action: #selector(showHistoryKeyCommand), input: "y", modifierFlags: .command, discoverabilityTitle: "Show History"),
             UIKeyCommand(action: #selector(goBackKeyCommand), input: "[", modifierFlags: .command, discoverabilityTitle: .BackTitle),
             UIKeyCommand(action: #selector(goForwardKeyCommand), input: "]", modifierFlags: .command, discoverabilityTitle: .ForwardTitle),
-            UIKeyCommand(action: #selector(openClearHistoryPanel), input: "\u{8}", modifierFlags: [.shift, .command], discoverabilityTitle: "Clear history"),
+            UIKeyCommand(action: #selector(openClearHistoryPanelKeyCommand), input: "\u{8}", modifierFlags: [.shift, .command], discoverabilityTitle: "Clear history"),
 
             // Bookmarks
             // TODO: String KeyboardShortcuts.ShowBookmarks & KeyboardShortcuts.AddBookmark
-            UIKeyCommand(action: #selector(showBookmarks), input: "o", modifierFlags: [.shift, .command], discoverabilityTitle: "Show Bookmarks"),
-            UIKeyCommand(action: #selector(addCurrentTabToBookmarks), input: "d", modifierFlags: .command, discoverabilityTitle: "Add Bookmark"),
+            UIKeyCommand(action: #selector(showBookmarksKeyCommand), input: "o", modifierFlags: [.shift, .command], discoverabilityTitle: "Show Bookmarks"),
+            UIKeyCommand(action: #selector(addTabKeyCommand), input: "d", modifierFlags: .command, discoverabilityTitle: "Add Bookmark"),
 
             // Tools
             // TODO: String KeyboardShortcuts.ShowDownloads
-            UIKeyCommand(action: #selector(showDownloads), input: "j", modifierFlags: .command, discoverabilityTitle: "Show Downloads"),
+            UIKeyCommand(action: #selector(showDownloadsKeyCommand), input: "j", modifierFlags: .command, discoverabilityTitle: "Show Downloads"),
 
             // Window
             UIKeyCommand(action: #selector(nextTabKeyCommand), input: "]", modifierFlags: [.command, .shift], discoverabilityTitle: .ShowNextTabTitle),

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -117,7 +117,7 @@ extension BrowserViewController {
             UIKeyCommand(action: #selector(goForwardKeyCommand), input: UIKeyCommand.inputRightArrow, modifierFlags: .command),
         ]
 
-        // In iOS 15 and later, physical keyboard events are delivered to the text input or focus systems first, unless specified otherwise
+        // In iOS 15+, certain keys events are delivered to the text input or focus systems first, unless specified otherwise
         if #available(iOS 15, *) {
             searchLocationCommands.forEach { $0.wantsPriorityOverSystemBehavior = true }
             overridesTextEditing.forEach { $0.wantsPriorityOverSystemBehavior = true }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -19,6 +19,11 @@ extension BrowserViewController {
         showLibrary(panel: .bookmarks)
     }
 
+    @objc private func openClearHistoryPanel() {
+        let clearHistoryHelper = ClearHistoryHelper(profile: profile)
+        clearHistoryHelper.showClearRecentHistory(onViewController: self, didComplete: {})
+    }
+
     @objc private func reloadTabKeyCommand() {
         TelemetryWrapper.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "reload"])
         if let tab = tabManager.selectedTab, firefoxHomeViewController == nil {
@@ -156,17 +161,16 @@ extension BrowserViewController {
 
             // View
             UIKeyCommand(action: #selector(reloadTabKeyCommand), input: "r", modifierFlags: .command, discoverabilityTitle: .ReloadPageTitle),
-            // TODO: Zoom in - Command + + -> Only in overridesTextEditing?
-            // TODO: Zoom out - Command + - -> Only in overridesTextEditing?
-            // TODO: Actual size - Command + 0 -> Only in overridesTextEditing?
+            // TODO: Zoom in - Command + +
+            // TODO: Zoom out - Command + -
+            // TODO: Actual size - Command + 0
 
             // History
-            // TODO: String KeyboardShortcuts.ShowHistory
+            // TODO: String KeyboardShortcuts.ShowHistory & KeyboardShortcuts.ClearRecentHistory
             UIKeyCommand(action: #selector(showHistory), input: "y", modifierFlags: .command, discoverabilityTitle: "Show History"),
             UIKeyCommand(action: #selector(goBackKeyCommand), input: "[", modifierFlags: .command, discoverabilityTitle: .BackTitle),
             UIKeyCommand(action: #selector(goForwardKeyCommand), input: "]", modifierFlags: .command, discoverabilityTitle: .ForwardTitle),
-            // TODO: Add back and forward arrow keys shortcuts for goBackKeyCommand and goForwardKeyCommand
-            // TODO: Clear recent history - Shift + Command + Back Arrow
+            UIKeyCommand(action: #selector(openClearHistoryPanel), input: "\u{8}", modifierFlags: [.shift, .command], discoverabilityTitle: "Clear history"),
 
             // Bookmarks
             // TODO: String KeyboardShortcuts.ShowBookmarks

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
 import Shared
+import UIKit
 
 // Naming functions: use the suffix 'KeyCommand' for an additional level of namespacing (bug 1415830)
 extension BrowserViewController {
@@ -22,6 +23,13 @@ extension BrowserViewController {
     @objc private func openClearHistoryPanel() {
         let clearHistoryHelper = ClearHistoryHelper(profile: profile)
         clearHistoryHelper.showClearRecentHistory(onViewController: self, didComplete: {})
+    }
+
+    @objc private func addCurrentTabToBookmarks() {
+        if let tab = tabManager.selectedTab, firefoxHomeViewController == nil {
+            guard let url = tab.canonicalURL?.displayURL else { return }
+            addBookmark(url: url.absoluteString, title: tab.title, favicon: tab.displayFavicon)
+        }
     }
 
     @objc private func reloadTabKeyCommand() {
@@ -140,7 +148,7 @@ extension BrowserViewController {
             overridesTextEditing.forEach { $0.wantsPriorityOverSystemBehavior = true }
         }
 
-        let tabNavigation = [
+        let commands = [
             // Settings
             // TODO: String KeyboardShortcuts.Settings
             UIKeyCommand(action: #selector(openSettings), input: ",", modifierFlags: .command, discoverabilityTitle: "Settings"),
@@ -149,11 +157,8 @@ extension BrowserViewController {
             UIKeyCommand(action: #selector(newTabKeyCommand), input: "t", modifierFlags: .command, discoverabilityTitle: .NewTabTitle),
             UIKeyCommand(action: #selector(newPrivateTabKeyCommand), input: "p", modifierFlags: [.command, .shift], discoverabilityTitle: .NewPrivateTabTitle),
             UIKeyCommand(action: #selector(selectLocationBarKeyCommand), input: "l", modifierFlags: .command, discoverabilityTitle: .SelectLocationBarTitle),
-            // TODO: Open link in background - Command + Tap link
-            // TODO: Open link in background - Command + Shift + Tap link
             UIKeyCommand(action: #selector(closeTabKeyCommand), input: "w", modifierFlags: .command, discoverabilityTitle: .CloseTabTitle),
             // TODO: Save page as - Command + S
-            // TODO: Download link - Option + Tap link
 
             // Edit
             UIKeyCommand(action: #selector(findInPageKeyCommand), input: "f", modifierFlags: .command, discoverabilityTitle: .FindTitle),
@@ -173,9 +178,9 @@ extension BrowserViewController {
             UIKeyCommand(action: #selector(openClearHistoryPanel), input: "\u{8}", modifierFlags: [.shift, .command], discoverabilityTitle: "Clear history"),
 
             // Bookmarks
-            // TODO: String KeyboardShortcuts.ShowBookmarks
+            // TODO: String KeyboardShortcuts.ShowBookmarks & KeyboardShortcuts.AddBookmark
             UIKeyCommand(action: #selector(showBookmarks), input: "o", modifierFlags: [.shift, .command], discoverabilityTitle: "Show Bookmarks"),
-            // TODO: Add Bookmark - Command + D -> Only in overridesTextEditing?
+            UIKeyCommand(action: #selector(addCurrentTabToBookmarks), input: "d", modifierFlags: .command, discoverabilityTitle: "Add Bookmark"),
 
             // Tools
             // TODO: String KeyboardShortcuts.ShowDownloads
@@ -194,10 +199,10 @@ extension BrowserViewController {
         let isEditingText = tabManager.selectedTab?.isEditing ?? false
 
         if urlBar.inOverlayMode {
-            return tabNavigation + searchLocationCommands
+            return commands + searchLocationCommands
         } else if !isEditingText {
-            return tabNavigation + overridesTextEditing
+            return commands + overridesTextEditing
         }
-        return tabNavigation
+        return commands
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -7,6 +7,18 @@ import Shared
 // Naming functions: use the suffix 'KeyCommand' for an additional level of namespacing (bug 1415830)
 extension BrowserViewController {
 
+    @objc private func showHistory() {
+        showLibrary(panel: .history)
+    }
+
+    @objc private func showDownloads() {
+        showLibrary(panel: .downloads)
+    }
+
+    @objc private func showBookmarks() {
+        showLibrary(panel: .bookmarks)
+    }
+
     @objc private func reloadTabKeyCommand() {
         TelemetryWrapper.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "reload"])
         if let tab = tabManager.selectedTab, firefoxHomeViewController == nil {
@@ -125,8 +137,8 @@ extension BrowserViewController {
 
         let tabNavigation = [
             // Settings
-            // TODO: DiscoverabilityTitle for open settings - KeyboardShortcuts.Settings from Nishant's PR
-            UIKeyCommand(action: #selector(openSettings), input: ",", modifierFlags: .command, discoverabilityTitle: "KeyboardShortcuts.Settings"),
+            // TODO: String KeyboardShortcuts.Settings
+            UIKeyCommand(action: #selector(openSettings), input: ",", modifierFlags: .command, discoverabilityTitle: "Settings"),
 
             // File
             UIKeyCommand(action: #selector(newTabKeyCommand), input: "t", modifierFlags: .command, discoverabilityTitle: .NewTabTitle),
@@ -144,23 +156,26 @@ extension BrowserViewController {
 
             // View
             UIKeyCommand(action: #selector(reloadTabKeyCommand), input: "r", modifierFlags: .command, discoverabilityTitle: .ReloadPageTitle),
-            // TODO: Zoom in - Command + +
-            // TODO: Zoom out - Command + -
-            // TODO: Actual size - Command + 0
+            // TODO: Zoom in - Command + + -> Only in overridesTextEditing?
+            // TODO: Zoom out - Command + - -> Only in overridesTextEditing?
+            // TODO: Actual size - Command + 0 -> Only in overridesTextEditing?
 
             // History
-            // TODO: Show history - Command + Y
+            // TODO: String KeyboardShortcuts.ShowHistory
+            UIKeyCommand(action: #selector(showHistory), input: "y", modifierFlags: .command, discoverabilityTitle: "Show History"),
             UIKeyCommand(action: #selector(goBackKeyCommand), input: "[", modifierFlags: .command, discoverabilityTitle: .BackTitle),
             UIKeyCommand(action: #selector(goForwardKeyCommand), input: "]", modifierFlags: .command, discoverabilityTitle: .ForwardTitle),
             // TODO: Add back and forward arrow keys shortcuts for goBackKeyCommand and goForwardKeyCommand
             // TODO: Clear recent history - Shift + Command + Back Arrow
 
             // Bookmarks
-            // TODO: Show bookmarks - Command + Y
-            // TODO: Add Bookmark - Command + D -> Only in overridesTextEditing
+            // TODO: String KeyboardShortcuts.ShowBookmarks
+            UIKeyCommand(action: #selector(showBookmarks), input: "o", modifierFlags: [.shift, .command], discoverabilityTitle: "Show Bookmarks"),
+            // TODO: Add Bookmark - Command + D -> Only in overridesTextEditing?
 
             // Tools
-            // TODO: Show downloads - Command + J
+            // TODO: String KeyboardShortcuts.ShowDownloads
+            UIKeyCommand(action: #selector(showDownloads), input: "j", modifierFlags: .command, discoverabilityTitle: "Show Downloads"),
 
             // Window
             UIKeyCommand(action: #selector(showTabTrayKeyCommand), input: "\\", modifierFlags: [.command, .shift]), // Safari on macOS

--- a/Client/Frontend/Browser/FindInPageBar.swift
+++ b/Client/Frontend/Browser/FindInPageBar.swift
@@ -28,6 +28,8 @@ class FindInPageBar: UIView {
     fileprivate let previousButton = UIButton()
     fileprivate let nextButton = UIButton()
 
+    private static let savedTextKey = "findInPageSavedTextKey"
+
     var currentResult = 0 {
         didSet {
             if totalResults > 500 {
@@ -167,11 +169,21 @@ class FindInPageBar: UIView {
 
     @objc fileprivate func didTextChange(_ sender: UITextField) {
         matchCountView.isHidden = searchText.text?.trimmingCharacters(in: .whitespaces).isEmpty ?? true
+        saveSearchText(searchText.text)
         delegate?.findInPage(self, didTextChange: searchText.text ?? "")
     }
 
     @objc fileprivate func didPressClose(_ sender: UIButton) {
         delegate?.findInPageDidPressClose(self)
+    }
+
+    private func saveSearchText(_ searchText: String?) {
+        guard let text = searchText, !text.isEmpty else { return }
+        UserDefaults.standard.set(text, forKey: FindInPageBar.savedTextKey)
+    }
+
+    static var retrieveSavedText: String? {
+        return UserDefaults.standard.object(forKey: FindInPageBar.savedTextKey) as? String
     }
 }
 

--- a/Client/Frontend/Browser/TabTrayController+KeyCommands.swift
+++ b/Client/Frontend/Browser/TabTrayController+KeyCommands.swift
@@ -16,12 +16,19 @@ extension GridTabViewController {
             UIKeyCommand(input: "\\", modifierFlags: [.command, .shift], action: #selector(didEnterTabKeyCommand)),
             UIKeyCommand(input: "\t", modifierFlags: [.command, .alternate], action: #selector(didEnterTabKeyCommand)),
             UIKeyCommand(action: #selector(didOpenNewTabKeyCommand), input: "t", modifierFlags: .command, discoverabilityTitle: .OpenNewTabFromTabTrayKeyCodeTitle),
+        ]
 
+        let arrowKeysCommands = [
             UIKeyCommand(input: UIKeyCommand.inputDownArrow, modifierFlags: [], action: #selector(didChangeSelectedTabKeyCommand(sender:))),
             UIKeyCommand(input: UIKeyCommand.inputUpArrow, modifierFlags: [], action: #selector(didChangeSelectedTabKeyCommand(sender:))),
         ]
 
-        return commands
+        // In iOS 15+, certain keys events are delivered to the text input or focus systems first, unless specified otherwise
+        if #available(iOS 15, *) {
+            arrowKeysCommands.forEach { $0.wantsPriorityOverSystemBehavior = true }
+        }
+
+        return commands + arrowKeysCommands
     }
 
     @objc func didTogglePrivateModeKeyCommand() {

--- a/Client/Frontend/Library/ClearHistoryHelper.swift
+++ b/Client/Frontend/Library/ClearHistoryHelper.swift
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import WebKit
+
+class ClearHistoryHelper {
+
+    private let profile: Profile
+
+    init(profile: Profile) {
+        self.profile = profile
+    }
+
+    /// Present a prompt that will enable the user to choose how he wants to clear his recent history
+    /// - Parameters:
+    ///   - viewController: The view controller the clear history prompt is shown on
+    ///   - didComplete: Did complete a recent history clear up action
+    func showClearRecentHistory(onViewController viewController: UIViewController, didComplete: @escaping () -> Void) {
+        func remove(hoursAgo: Int) {
+            if let date = Calendar.current.date(byAdding: .hour, value: -hoursAgo, to: Date()) {
+                let types = WKWebsiteDataStore.allWebsiteDataTypes()
+                WKWebsiteDataStore.default().removeData(ofTypes: types, modifiedSince: date, completionHandler: {})
+
+                self.profile.history.removeHistoryFromDate(date).uponQueue(.main) { _ in
+                    didComplete()
+                }
+            }
+        }
+
+        let alert = UIAlertController(title: .ClearHistoryMenuTitle, message: nil, preferredStyle: .actionSheet)
+
+        // This will run on the iPad-only, and sets the alert to be centered with no arrow.
+        guard let view = viewController.view else { return }
+        if let popoverController = alert.popoverPresentationController {
+            popoverController.sourceView = view
+            popoverController.sourceRect = CGRect(x: view.bounds.midX, y: view.bounds.midY, width: 0, height: 0)
+            popoverController.permittedArrowDirections = []
+        }
+
+        [(String.ClearHistoryMenuOptionTheLastHour, 1),
+         (String.ClearHistoryMenuOptionToday, 24),
+         (String.ClearHistoryMenuOptionTodayAndYesterday, 48)].forEach {
+            (name, time) in
+            let action = UIAlertAction(title: name, style: .destructive) { _ in
+                remove(hoursAgo: time)
+            }
+            alert.addAction(action)
+        }
+        alert.addAction(UIAlertAction(title: .ClearHistoryMenuOptionEverything, style: .destructive, handler: { _ in
+            let types = WKWebsiteDataStore.allWebsiteDataTypes()
+            WKWebsiteDataStore.default().removeData(ofTypes: types, modifiedSince: .distantPast, completionHandler: {})
+            self.profile.history.clearHistory().uponQueue(.main) { _ in
+                didComplete()
+            }
+            self.profile.recentlyClosedTabs.clearTabs()
+        }))
+        let cancelAction = UIAlertAction(title: .CancelString, style: .cancel)
+        alert.addAction(cancelAction)
+        viewController.present(alert, animated: true)
+    }
+}

--- a/Client/Frontend/Library/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel.swift
@@ -103,7 +103,8 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
         [ Notification.Name.FirefoxAccountChanged,
           Notification.Name.PrivateDataClearedHistory,
           Notification.Name.DynamicFontChanged,
-          Notification.Name.DatabaseWasReopened ].forEach {
+          Notification.Name.DatabaseWasReopened,
+          Notification.Name.OpenClearRecentHistory].forEach {
             NotificationCenter.default.addObserver(self, selector: #selector(onNotificationReceived), name: $0, object: nil)
         }
     }
@@ -258,6 +259,12 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
         navigationController?.pushViewController(nextController, animated: true)
     }
 
+    private func showClearRecentHistory() {
+        clearHistoryHelper.showClearRecentHistory(onViewController: self, didComplete: { [weak self] in
+            self?.reloadData()
+        })
+    }
+
     // MARK: - Cell configuration
 
     func siteForIndexPath(_ indexPath: IndexPath) -> Site? {
@@ -340,6 +347,8 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
             if let dbName = notification.object as? String, dbName == "browser.db" {
                 reloadData()
             }
+        case .OpenClearRecentHistory:
+            showClearRecentHistory()
         default:
             // no need to do anything at all
             print("Error: Received unexpected notification \(notification.name)")
@@ -426,6 +435,7 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
                 clearHistoryHelper.showClearRecentHistory(onViewController: self, didComplete: { [weak self] in
                     self?.reloadData()
                 })
+                showClearRecentHistory()
 
             default:
                 navigateToRecentlyClosed()

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -79,12 +79,22 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     }
 
     override var keyCommands: [UIKeyCommand]? {
-        return [
+        let commands = [
+            UIKeyCommand(input: copyShortcutKey, modifierFlags: .command, action: #selector(self.handleKeyCommand(sender:)))
+        ]
+
+        let arrowKeysCommands = [
             UIKeyCommand(input: UIKeyCommand.inputLeftArrow, modifierFlags: [], action: #selector(self.handleKeyCommand(sender:))),
             UIKeyCommand(input: UIKeyCommand.inputRightArrow, modifierFlags: [], action: #selector(self.handleKeyCommand(sender:))),
             UIKeyCommand(input: UIKeyCommand.inputEscape, modifierFlags: [], action: #selector(self.handleKeyCommand(sender:))),
-            UIKeyCommand(input: copyShortcutKey, modifierFlags: .command, action: #selector(self.handleKeyCommand(sender:)))
         ]
+
+        // In iOS 15+, certain keys events are delivered to the text input or focus systems first, unless specified otherwise
+        if #available(iOS 15, *) {
+            arrowKeysCommands.forEach { $0.wantsPriorityOverSystemBehavior = true }
+        }
+
+        return arrowKeysCommands + commands
     }
 
     @objc func handleKeyCommand(sender: UIKeyCommand) {

--- a/Shared/NotificationConstants.swift
+++ b/Shared/NotificationConstants.swift
@@ -59,4 +59,6 @@ extension Notification.Name {
     public static let DisplayThemeChanged = Notification.Name("DisplayThemeChanged")
 
     public static let TabClosed = Notification.Name("TabClosed")
+
+    public static let OpenClearRecentHistory = Notification.Name("OpenClearRecentHistory")
 }


### PR DESCRIPTION
First PR for keyboard shortcuts #8969. PR was getting big so preferred to do it splitted.
- Strings aren't implemented but marked as TODO since PR https://github.com/mozilla-mobile/firefox-ios/pull/9592 is needed
- Fixed some shortcuts for iOS 15.0 (needed wantsPriorityOverSystemBehavior to be specified)
- Shortcuts implemented in this PR are:
  - Settings (Command + ,)
  - Open panels downloads (Command + j), bookmarks (Shift + Command + o), history (Command + y)
  - Clear history (Shift + Command + delete)
  - Add bookmark, which adds the current one -> (Command + d)
  - Find in page again, which is persisted so next session you can do the same search again (Command + g)
- Some fixes to make sure calling a shortcut, and then another one works (Example you have bookmarks panel, and wants to go to settings. The bookmarks panel is dismissed and settings is shown). 


**Next PR will be for shortcuts:**
- Open link in background - Command + Tap link
- Open link in new tab - Command + Shift + Tap link
- Download link - Option + Tap link
- Show tab # 1-9 - Command + 1-9
- Zoom in - Command + +
- Zoom out - Command + -
- Actual size - Command + 0