### PR TITLE
Fix Mergify strict mode deprecation

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,4 +15,3 @@ pull_request_rules:
         message: Github-action[bot] 💪
       merge:
         method: squash
-        strict: false


### PR DESCRIPTION
[Strict mode is now deprecated on Mergify.](https://blog.mergify.com/strict-mode-deprecation/)

Following [documentation](https://docs.mergify.com/actions/merge/), strict-mode is false by default, so we should be ok to remove it.