### PR TITLE
Bump [v96] Matrix Xcode version to 13.1

### DIFF
--- a/.github/workflows/build-contributor-pr.yml
+++ b/.github/workflows/build-contributor-pr.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.9]
-        xcode: ["13.0"]
+        xcode: ["13.1"]
         run-config: 
         - { scheme: 'Fennec_Enterprise_XCUITests', destination: 'platform=iOS Simulator,OS=latest,name=iPhone 11', testplan: 'SmokeXCUITests' }
     name: Run UI Smoketests


### PR DESCRIPTION
Run UI Smoketests are failing at the moment due to a import SwiftyJSON error.

![Screen Shot 2021-12-07 at 9 42 33 AM](https://user-images.githubusercontent.com/11338480/145050572-b346a401-0fcf-482d-a792-f71142f845fe.png)

I think this is caused by the tests still running on Xcode 13.0. So this PR is bumping the Matrix Xcode version to 13.1 as our Bitrise.
![Screen Shot 2021-12-07 at 9 45 35 AM](https://user-images.githubusercontent.com/11338480/145050449-d762da08-3888-4545-9b63-cc5d1ef15304.png)


