### PR TITLE
Localize #9379 [v96] Importing v96 strings, including two new locales bo and tt

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -2641,6 +2641,29 @@
 		962A450E9186BF349E535413 /* sat-Olck */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "sat-Olck"; path = "sat-Olck.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		962F39492672D57A006BDA2A /* RecentItemsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentItemsHelper.swift; sourceTree = "<group>"; };
 		966206CC2698DE1E005C0A55 /* FirefoxHomeRecentlySavedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirefoxHomeRecentlySavedViewModel.swift; sourceTree = "<group>"; };
+		967AF157275FF4C60099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		967AF158275FF4C60099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
+		967AF159275FF4C60099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
+		967AF15A275FF4C60099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
+		967AF15B275FF4C70099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
+		967AF15C275FF4C70099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
+		967AF15D275FF4C70099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = "tt.lproj/Default Browser.strings"; sourceTree = "<group>"; };
+		967AF15E275FF4C70099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/ErrorPages.strings; sourceTree = "<group>"; };
+		967AF15F275FF4C70099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/FindInPage.strings; sourceTree = "<group>"; };
+		967AF160275FF4C70099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/HistoryPanel.strings; sourceTree = "<group>"; };
+		967AF161275FF4C70099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/Intro.strings; sourceTree = "<group>"; };
+		967AF162275FF4C70099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/Localizable.strings; sourceTree = "<group>"; };
+		967AF163275FF4C70099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/LoginManager.strings; sourceTree = "<group>"; };
+		967AF164275FF4C70099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/Menu.strings; sourceTree = "<group>"; };
+		967AF165275FF4C70099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
+		967AF166275FF4C70099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/Search.strings; sourceTree = "<group>"; };
+		967AF167275FF4C70099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/Shared.strings; sourceTree = "<group>"; };
+		967AF168275FF4C70099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/Storage.strings; sourceTree = "<group>"; };
+		967AF169275FF4C70099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/Today.strings; sourceTree = "<group>"; };
+		967AF16A275FF4C70099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/BookmarkPanel.strings; sourceTree = "<group>"; };
+		967AF16B275FF4C70099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/BookmarkPanelDeleteConfirm.strings; sourceTree = "<group>"; };
+		967AF16C275FF4C70099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		967AF16D275FF4C70099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/Localizable.strings; sourceTree = "<group>"; };
 		967E47FAA3AD30920D37AF79 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		968545D0846EC3C9425305FC /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = "he.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		9699F77226F39E5100C5FA47 /* SiteImageHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteImageHelper.swift; sourceTree = "<group>"; };
@@ -7080,6 +7103,7 @@
 				rm,
 				ca,
 				gd,
+				tt,
 			);
 			mainGroup = F84B21B51A090F8100AAB793;
 			productRefGroup = F84B21BF1A090F8100AAB793 /* Products */;
@@ -8676,6 +8700,7 @@
 				4C5B4496946C61BE1A11D022 /* rm */,
 				62DF49B9976D5863CADF6EAA /* ca */,
 				25404EFD8E59C9EBCF4AFBBE /* gd */,
+				967AF164275FF4C70099E161 /* tt */,
 			);
 			name = Menu.strings;
 			sourceTree = "<group>";
@@ -8773,6 +8798,7 @@
 				4CEA4A57A7720000ADBA117E /* rm */,
 				F013431EA44E12FB0FCFF807 /* ca */,
 				F0F74D48BA3563210D53E2A4 /* gd */,
+				967AF167275FF4C70099E161 /* tt */,
 			);
 			name = Shared.strings;
 			sourceTree = "<group>";
@@ -8853,6 +8879,7 @@
 				43EB00C3265861E8009A5F61 /* az */,
 				D5E343802697613600A57583 /* bg */,
 				DF46B9A32755297000657F75 /* ne-NP */,
+				967AF169275FF4C70099E161 /* tt */,
 			);
 			name = Today.strings;
 			sourceTree = "<group>";
@@ -8952,6 +8979,7 @@
 				14414FC6B3D6B0FB70546914 /* rm */,
 				460B4C81BC2444F2F06702D6 /* ca */,
 				54D046DA913D533F26A8E3AC /* gd */,
+				967AF159275FF4C60099E161 /* tt */,
 			);
 			name = AuthenticationManager.strings;
 			sourceTree = "<group>";
@@ -9052,6 +9080,7 @@
 				E6C64CCF918A53B1EB0FAF01 /* rm */,
 				126A40A4A5AFDFD655B0FDF4 /* ca */,
 				ACCB429B86B8D1BC8BF2FDE0 /* gd */,
+				967AF15A275FF4C60099E161 /* tt */,
 			);
 			name = ClearHistoryConfirm.strings;
 			sourceTree = "<group>";
@@ -9151,6 +9180,7 @@
 				B96B4B91820FE6A76C6634DA /* ca */,
 				E7C4451C8940941CAEB33DED /* gd */,
 				D5311CB2261FC9F400A2FC94 /* ast */,
+				967AF158275FF4C60099E161 /* tt */,
 			);
 			name = 3DTouchActions.strings;
 			sourceTree = "<group>";
@@ -9250,6 +9280,7 @@
 				F8324EB3B9CEED437A3D68A6 /* rm */,
 				5FE34931820AAF71C31C383E /* ca */,
 				9C8043F3BB77DF533FF48412 /* gd */,
+				967AF15B275FF4C70099E161 /* tt */,
 			);
 			name = ClearPrivateData.strings;
 			sourceTree = "<group>";
@@ -9348,6 +9379,7 @@
 				3AF84166A66FBDC08B34BAEA /* rm */,
 				CF634CC3A39BA96DE19D497A /* ca */,
 				E8BE4A4597EDD74CD5B3A8D5 /* gd */,
+				967AF160275FF4C70099E161 /* tt */,
 			);
 			name = HistoryPanel.strings;
 			sourceTree = "<group>";
@@ -9448,6 +9480,7 @@
 				9957493598D1C5300577F4B1 /* rm */,
 				1C9741FFBED06E49F8B5F64F /* ca */,
 				0FD346178E1DE90491548540 /* gd */,
+				967AF162275FF4C70099E161 /* tt */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -9549,6 +9582,7 @@
 				2A27421AA33866C98964FD63 /* rm */,
 				C8A74FF69C3971EDBE73157F /* ca */,
 				51614CF895A46ADD3C81ACC1 /* gd */,
+				967AF157275FF4C60099E161 /* tt */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";
@@ -9647,6 +9681,7 @@
 				58D24BDBAD6AEA47E56D5065 /* rm */,
 				5B7A4C3C85CE0BB43E25B018 /* ca */,
 				10844A96ACD90B58C90F247E /* gd */,
+				967AF165275FF4C70099E161 /* tt */,
 			);
 			name = PrivateBrowsing.strings;
 			sourceTree = "<group>";
@@ -9746,6 +9781,7 @@
 				754D4984846140D16B44C9DC /* rm */,
 				546F4E7DA6D98552425B3F9B /* ca */,
 				0E524676A2657BD8147C072A /* gd */,
+				967AF15E275FF4C70099E161 /* tt */,
 			);
 			name = ErrorPages.strings;
 			sourceTree = "<group>";
@@ -9843,6 +9879,7 @@
 				871E495BAD9F7C0E02A38247 /* rm */,
 				95E1479BB09F1395795E7A42 /* ca */,
 				1A9E45AFB6CA6B5F1B760337 /* gd */,
+				967AF168275FF4C70099E161 /* tt */,
 			);
 			name = Storage.strings;
 			sourceTree = "<group>";
@@ -9922,6 +9959,7 @@
 				D574BCC52672F294001D191D /* anp */,
 				43D72DB226FCE3550069BDE9 /* mr */,
 				433E0DEC26FCE37C00B78CC5 /* ne-NP */,
+				967AF15D275FF4C70099E161 /* tt */,
 			);
 			name = "Default Browser.strings";
 			sourceTree = "<group>";
@@ -10020,6 +10058,7 @@
 				D76D487D985DD7579B5F0861 /* rm */,
 				7EDC48EDAD21358996E3971E /* ca */,
 				57F145E2AD7AF2643AD94B98 /* gd */,
+				967AF161275FF4C70099E161 /* tt */,
 			);
 			name = Intro.strings;
 			sourceTree = "<group>";
@@ -10118,6 +10157,7 @@
 				F4874C1AA645072C469D830E /* rm */,
 				28364DEE903FF42ED740A978 /* ca */,
 				9A444D57B233A146581D56F5 /* gd */,
+				967AF163275FF4C70099E161 /* tt */,
 			);
 			name = LoginManager.strings;
 			sourceTree = "<group>";
@@ -10214,6 +10254,7 @@
 				C14343D394A0611E4D96C725 /* rm */,
 				0C3947E0A085F03473EBA539 /* ca */,
 				406E4E6094EB97EBD3574628 /* gd */,
+				967AF166275FF4C70099E161 /* tt */,
 			);
 			name = Search.strings;
 			sourceTree = "<group>";
@@ -10313,6 +10354,7 @@
 				F0274B0C93DBD0B387D06FA0 /* rm */,
 				DCE149E4A889E70038840A11 /* ca */,
 				31654B22BF8241FC6F4B2B78 /* gd */,
+				967AF15F275FF4C70099E161 /* tt */,
 			);
 			name = FindInPage.strings;
 			sourceTree = "<group>";
@@ -10385,6 +10427,7 @@
 				D5E79E94263C729200D1E356 /* te */,
 				D594AB18269761C500F9B437 /* gd */,
 				DF46B9A42755297000657F75 /* ne-NP */,
+				967AF16A275FF4C70099E161 /* tt */,
 			);
 			name = BookmarkPanel.strings;
 			sourceTree = "<group>";
@@ -10454,6 +10497,7 @@
 				D55C98AD263C72250000DA62 /* he */,
 				D594AB1B269761C500F9B437 /* gd */,
 				DF46B9A72755297000657F75 /* ne-NP */,
+				967AF16D275FF4C70099E161 /* tt */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -10526,6 +10570,7 @@
 				D5E79E95263C729200D1E356 /* te */,
 				D594AB19269761C500F9B437 /* gd */,
 				DF46B9A52755297000657F75 /* ne-NP */,
+				967AF16B275FF4C70099E161 /* tt */,
 			);
 			name = BookmarkPanelDeleteConfirm.strings;
 			sourceTree = "<group>";
@@ -10597,6 +10642,7 @@
 				D5E79E97263C729200D1E356 /* te */,
 				D594AB1A269761C500F9B437 /* gd */,
 				DF46B9A62755297000657F75 /* ne-NP */,
+				967AF16C275FF4C70099E161 /* tt */,
 			);
 			name = WidgetIntents.intentdefinition;
 			sourceTree = "<group>";
@@ -10697,6 +10743,7 @@
 				941640DBAD9C3DF9DB2F11D5 /* rm */,
 				383D47EEAB4E12E6B657C8CB /* ca */,
 				1C0D49279DC88F974E4BE1CB /* gd */,
+				967AF15C275FF4C70099E161 /* tt */,
 			);
 			name = ClearPrivateDataConfirm.strings;
 			sourceTree = "<group>";

--- a/Client/bo.lproj/InfoPlist.strings
+++ b/Client/bo.lproj/InfoPlist.strings
@@ -1,9 +1,7 @@
 /* Privacy - Camera Usage Description */
 "NSCameraUsageDescription" = "This lets you take and upload photos.";
 
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0
+/* Privacy - Location When In Use Usage Description */
 "NSLocationWhenInUseUsageDescription" = "Websites you visit may request your location.";
 
 /* Privacy - Microphone Usage Description */

--- a/Client/tt.lproj/InfoPlist.strings
+++ b/Client/tt.lproj/InfoPlist.strings
@@ -1,0 +1,18 @@
+/* Privacy - Face ID Usage Description */
+"NSFaceIDUsageDescription" = "Firefox сакланган логиннарыгызга ирешү өчен Face ID таләп итә.";
+
+/* Privacy - Location When In Use Usage Description */
+"NSLocationWhenInUseUsageDescription" = "Зиярат ителгән вебсайтлар урнашуыгызны сорый ала.";
+
+/* Privacy - Photo Library Additions Usage Description */
+"NSPhotoLibraryAddUsageDescription" = "Фотоларны саклау өчен сез моны куллана аласыз.";
+
+/* (No Comment) */
+"ShortcutItemTitleNewPrivateTab" = "Яңа хосусый таб";
+
+/* (No Comment) */
+"ShortcutItemTitleNewTab" = "Яңа таб";
+
+/* (No Comment) */
+"ShortcutItemTitleQRCode" = "QR кодны сканерлау";
+

--- a/Shared/Supporting Files/tt.lproj/BookmarkPanel.strings
+++ b/Shared/Supporting Files/tt.lproj/BookmarkPanel.strings
@@ -1,0 +1,3 @@
+/* Action button for deleting bookmarks in the bookmarks panel. */
+"Delete" = "Бетерү";
+

--- a/Shared/Supporting Files/tt.lproj/BookmarkPanelDeleteConfirm.strings
+++ b/Shared/Supporting Files/tt.lproj/BookmarkPanelDeleteConfirm.strings
@@ -1,0 +1,9 @@
+/* Button label to cancel deletion when the user tried to delete a non-empty folder. */
+"Bookmarks.DeleteFolderWarning.CancelButton.Label" = "Баш тарту";
+
+/* Button label for the button that deletes a folder and all of its children. */
+"Bookmarks.DeleteFolderWarning.DeleteButton.Label" = "Бетерү";
+
+/* Title of the confirmation alert when the user tries to delete a folder that still contains bookmarks and/or folders. */
+"Bookmarks.DeleteFolderWarning.Title" = "Бу папка буш түгел.";
+

--- a/Shared/bn.lproj/ClearPrivateData.strings
+++ b/Shared/bn.lproj/ClearPrivateData.strings
@@ -16,3 +16,6 @@
 /* Settings item for clearing passwords and login data */
 "Saved Logins" = "সংরক্ষিত লগইন";
 
+/* A settings item that allows a user to use Apple's \"Spotlight Search\" in Data Management's Website Data option to search for and select an item to delete. */
+"Spotlight Index" = "Spotlight সূচক";
+

--- a/Shared/bn.lproj/Localizable.strings
+++ b/Shared/bn.lproj/Localizable.strings
@@ -16,17 +16,41 @@
 /* About settings section title */
 "About" = "সম্পর্কে";
 
+/* The title for the pinning a shortcut action */
+"ActivityStream.ContextMenu.AddToShortcuts" = "শর্টকাটে যুক্ত করুন";
+
 /* The title for the pinning a topsite action */
 "ActivityStream.ContextMenu.PinTopsite" = "শীর্ষ সাইটে পিন করুন";
 
+/* The title for the pinning a topsite action */
+"ActivityStream.ContextMenu.PinTopsite2" = "পিন";
+
+/* The title for removing a shortcut action */
+"ActivityStream.ContextMenu.RemoveFromShortcuts" = "শর্টকাট থেকে সরিয়ে ফেলুন";
+
 /* The title for removing a pinned topsite action */
 "ActivityStream.ContextMenu.RemovePinTopsite" = "পিনকৃত সাইট অপসারণ করুন";
+
+/* The title for the unpinning a topsite action */
+"ActivityStream.ContextMenu.UnpinTopsite" = "আনপিন করুন";
 
 /* The description of a highlight if it is a site the user has bookmarked */
 "ActivityStream.Highlights.Bookmark" = "বুকমার্ক করা হয়েছে";
 
 /* The description of a highlight if it is a site the user has visited */
 "ActivityStream.Highlights.Visited" = "পরিদর্শিত";
+
+/* Title for the Jump Back In section. This section allows users to jump back in to a recently viewed tab */
+"ActivityStream.JumpBackIn.SectionTitle" = "পূর্বাবস্থায় ফিরে যান";
+
+/* On the Firefox homepage in the Jump Back In section, if a Tab group item - a collection of grouped tabs from a related search - exists underneath the search term for the tab group, there will be a subtitle with a number for how many tabs are in that group. The placeholder is for a number. It will read 'Tabs: 5' or similar. */
+"ActivityStream.JumpBackIn.TabGroup.SiteCount" = "ট্যাব: %d";
+
+/* On the Firefox homepage in the Jump Back In section, if a Tab group item - a collection of grouped tabs from a related search - exists, the Tab Group item title will be 'Your search for \"video games\"'. The %@ sign is a placeholder for the actual search the user did. */
+"ActivityStream.JumpBackIn.TabGroup.Title" = "\"%@\" এর জন্য আপনার অনুসন্ধান";
+
+/* A string used to signify the start of the Recently Saved section in Home Screen. */
+"ActivityStream.Library.Title" = "সম্প্রতি সংরক্ষিত";
 
 /* Section title label for recently bookmarked websites */
 "ActivityStream.NewRecentBookmarks.Title" = "সাম্প্রতিক বুকমার্ক";
@@ -37,11 +61,26 @@
 /* Section title label for Recommended by Pocket section */
 "ActivityStream.Pocket.SectionTitle" = "Pocket থেকে সুপারিশকৃত";
 
+/* Section title label for Recommended by Pocket section */
+"ActivityStream.Pocket.SectionTitle2" = "Pocket থেকে সুপারিশকৃত";
+
 /* The description of a Pocket Story */
 "ActivityStream.Pocket.Trending" = "জনপ্রিয়";
 
 /* Section title label for recently visited websites */
 "ActivityStream.RecentHistory.Title" = "সম্প্রতি পরিদর্শিত";
+
+/* Section title for the Recently Saved section. This shows websites that have had a save action. Right now it is just bookmarks but it could be used for other things like the reading list in the future. */
+"ActivityStream.RecentlySaved.SectionTitle" = "সম্প্রতি সংরক্ষিত";
+
+/* This button will open the library showing all the users bookmarks */
+"ActivityStream.RecentlySaved.ShowAll" = "সব দেখুন";
+
+/* When long pressing an item in the Recently Visited section, this is the title of the button that appears, letting the user know to remove that particular item from the menu. */
+"ActivityStream.RecentlyVisited.RemoveButton.Title" = "অপসারণ করুন";
+
+/* Section title label for Shortcuts */
+"ActivityStream.Shortcuts.SectionTitle" = "শর্টকাট";
 
 /* label showing how many rows of topsites are shown. %d represents a number */
 "ActivityStream.TopSites.RowCount" = "সারি: %d";
@@ -82,6 +121,12 @@
 
 /* Authentication prompt title */
 "Authentication required" = "অনুমোদন প্রয়োজন";
+
+/* Description for button to suggest searching with a search engine. First argument is the name of the search engine to select */
+"Awesomebar.SearchWithEngine.Description" = "এড্রেস বার থেকে সরাসরি %@ অনুসন্ধান করুন";
+
+/* Title for button to suggest searching with a search engine. First argument is the name of the search engine to select */
+"Awesomebar.SearchWithEngine.Title" = "%@ দিয়ে অনুসন্ধান করুন";
 
 /* Accessibility label for the Back button in the tab toolbar. */
 "Back" = "পূর্বে";
@@ -211,6 +256,12 @@
 
 /* Context menu item for opening a link in a new tab */
 "ContextMenu.OpenInNewTabButtonTitle" = "নতুন ট্যাবে খুলুন";
+
+/* Context menu item for opening a link in a new private tab */
+"ContextMenu.OpenLinkInNewPrivateTabButtonTitle" = "নতুন ব্যক্তিগত ট্যাবে লিঙ্ক খুলুন";
+
+/* Context menu item for opening a link in a new tab */
+"ContextMenu.OpenLinkInNewTabButtonTitle" = "নতুন ট্যাবে লিঙ্ক খুলুন";
 
 /* Context menu item for saving an image */
 "ContextMenu.SaveImageButtonTitle" = "ছবি সংরক্ষণ করুন";
@@ -508,6 +559,9 @@
 /* Title for the Synced Tabs Cell in the History Panel */
 "HistoryPanel.SyncedTabsCell.Title" = "সিঙ্ক করা ডিভাইসগুলি";
 
+/* Accessibility label for the tab toolbar indicating the Home button. */
+"Home" = "হোম";
+
 /* Button cancelling changes setting the home page for the first time. */
 "HomePage.Set.Dialog.Cancel" = "বাতিল করুন";
 
@@ -652,6 +706,15 @@
 /* Placeholder test for search box in logins list view. */
 "LoginsList.LoginsListSearchPlaceholder" = "ফিল্টার";
 
+/* Label displayed when a user searches and no matches can be found against the search query */
+"LoginsList.NoMatchingResult.Title" = "কোন লগইন মিলেনি";
+
+/* Title for cancel button for user to stop searching for a particular login */
+"LoginsList.Search.Cancel" = "বাতিল";
+
+/* Placeholder text for search field */
+"LoginsList.Search.Placeholder" = "লগইন অনুসন্ধান করুন";
+
 /* Title for the list of logins */
 "LoginsList.Title" = "সংরক্ষিত লগইন";
 
@@ -672,14 +735,23 @@
 /* Toast displayed to the user after adding the item to the Top Sites. */
 "Menu.AddPin.Confirm" = "টপ সাইটগুলোতে পিন করা হয়েছে";
 
+/* Toast displayed to the user after adding the item to the Shortcuts. */
+"Menu.AddPin.Confirm2" = "শর্টকাট যুক্ত হয়েছে";
+
 /* Toast displayed to the user after adding the item to their reading list. */
 "Menu.AddToReadingList.Confirm" = "পঠন তালিকায় যোগ করা হয়েছে";
+
+/* Label for the button, displayed in the menu, takes you to to bookmarks screen when pressed. */
+"Menu.Bookmarks.Label" = "বুকমার্ক";
 
 /* The title for the button that lets you copy the url from the location bar. */
 "Menu.Copy.Title" = "ঠিকানা কপি করুন";
 
 /* Toast displayed to user after copy url pressed. */
 "Menu.CopyURL.Confirm" = "URL ক্লিপবোর্ডে কপি করা হয়েছে";
+
+/* Label for the button, displayed in the menu, takes you to to Downloads screen when pressed. */
+"Menu.Downloads.Label" = "ডাউনলোড";
 
 /* A switch to disable enhanced tracking protection inside the menu. */
 "Menu.EnhancedTrackingProtectionOff.Title" = "উন্নত ট্র্যাকিং সুরক্ষা এখন এই সাইটের জন্য বন্ধ আছে।";
@@ -693,23 +765,44 @@
 /* Description for having strict ETP protection with ITP offered in iOS14+ */
 "Menu.EnhancedTrackingProtectionStrictWithITP.Title" = "Firefox ক্রস-সাইট ট্র্যাকার, সোশ্যাল ট্র্যাকার, ক্রিপ্টোমিনিয়ারস, ফিঙ্গারপ্রিন্টারগুলি ও ট্র্যাকিং কন্টেন্টকে অবরুদ্ধ করে।";
 
+/* Label for the button, displayed in the menu, takes you to to History screen when pressed. */
+"Menu.History.Label" = "ইতিহাস";
+
 /* Label for the button displayed in the menu used to stop the reload of the webpage */
 "Menu.Library.StopReload" = "থামুন";
+
+/* Label for the button, displayed in the menu, takes you to screen to manage account when pressed. First argument is the display name for the current account */
+"Menu.ManageAccount.Label" = "অ্যাকাউন্ট পরিচালনা করুন %@";
+
+/* Label for the button, displayed in the menu, turns off night mode. */
+"Menu.NightModeTurnOff.Label2" = "নাইট মোড বন্ধ করুন";
 
 /* Label for the button, displayed in the menu, turns on night mode. */
 "Menu.NightModeTurnOn.Label" = "নাইট মোড সক্রিয় করুন";
 
+/* Label for the button, displayed in the menu, turns on night mode. */
+"Menu.NightModeTurnOn.Label2" = "নাইট মোড চালু করুন";
+
 /* Label for the button, displayed in the menu, hides images on the webpage when pressed. */
 "Menu.NoImageModeBlockImages.Label" = "চিত্র ব্লক করুন";
 
+/* Label for the button, displayed in the menu, shows images on the webpage when pressed. */
+"Menu.NoImageModeShowImages.Label" = "ছবি প্রদর্শন করুন";
+
 /* Label for title in page action menu. */
 "Menu.PageActions.Title" = "পেজ একশন";
+
+/* Label for the button, displayed in the menu, takes you to to passwords screen when pressed. */
+"Menu.Passwords.Label" = "পাসওয়ার্ড";
 
 /* The title for the button that lets you paste into the location bar */
 "Menu.Paste.Title" = "পেস্ট";
 
 /* The title for the button that lets you paste and go to a URL */
 "Menu.PasteAndGo.Title" = "পেস্ট করুন এবং যান";
+
+/* Label for the button, displayed in the menu, takes you to to Reading List screen when pressed. */
+"Menu.ReadingList.Label" = "পড়ার তালিকা";
 
 /* Label for the button, displayed in the menu, used to reload the current website without Tracking Protection */
 "Menu.ReloadWithoutTrackingProtection.Title" = "ট্র্যাকিং সুরক্ষা ছাড়া পুনরায় লোড করুন";
@@ -722,6 +815,9 @@
 
 /* Toast displayed to the user after removing the item from the Top Sites. */
 "Menu.RemovePin.Confirm" = "টপ সাইটগুলো থেকে সরানো হয়েছে";
+
+/* Toast displayed to the user after removing the item to the Shortcuts. */
+"Menu.RemovePin.Confirm2" = "শর্টকাট থেকে সরানো হয়েছে";
 
 /* Toast displayed to the user after a tab has been sent successfully. */
 "Menu.TabSent.Confirm" = "ট্যাব প্রেরিত";
@@ -971,6 +1067,9 @@
 
 /* The text shown in the URL bar on about:home */
 "Search or enter address" = "অনুসন্ধান করুন অথবা ঠিকানা প্রবেশ করুন";
+
+/* Search suggestion cell label that allows user to switch to tab which they searched for in url bar */
+"Search.Awesomebar.SwitchToTab" = "ট্যাবে সুইচ করুন";
 
 /* The message that asks the user to Add the search provider explaining where the search engine will appear */
 "Search.ThirdPartyEngines.AddMessage" = "নতুন অনুসন্ধানের ইঞ্জিন কুইক সার্চ বারে থাকবে।";
@@ -1259,6 +1358,9 @@
 /* The footer for the section to customize top sites in the new tab settings page. */
 "Settings.NewTab.Option.CustomizeFooter" = "আপনার সবচেয়ে বেশি দেখা সাইট";
 
+/* The footer for the section to customize top sites in the new tab settings page. */
+"Settings.NewTab.Option.CustomizeFooter2" = "আপনার সংরক্ষণকৃত বা ভিজিট করা সাইট";
+
 /* The title for the section to customize top sites in the new tab settings page. */
 "Settings.NewTab.Option.CustomizeTitle" = "Firefox Home কাস্টমাইজ করুন";
 
@@ -1285,6 +1387,9 @@
 
 /* Option in settings to show reading list when you open a new tab */
 "Settings.NewTab.Option.ReadingList" = "আপনার পড়ার তালিকা দেখান";
+
+/* Option in settings to turn on off pocket recommendations First argument is the pocket brand name */
+"Settings.NewTab.Option.RecommendedByPocket" = "সুপারিশ করেছে %@";
 
 /* Label used as an item in Settings. When touched it will open a dialog to configure the new tab behavior. */
 "Settings.NewTab.SectionName" = "নতুন ট্যাব";
@@ -1345,6 +1450,33 @@
 
 /* The option that takes you to the siri shortcuts settings page */
 "Settings.Siri.SectionName" = "Siri শর্টকাটসমূহ";
+
+/* Section title for all studies that are currently active */
+"Settings.Studies.Active.SectionName" = "সক্রিয়";
+
+/* Section title for all studies that are completed */
+"Settings.Studies.Completed.SectionName" = "সম্পন্ন হয়েছে";
+
+/* Button title displayed next to each study allowing the user to opt-out of the study */
+"Settings.Studies.Remove.Button" = "অপসারণ করুন";
+
+/* Title displayed in header of the Studies panel */
+"Settings.Studies.SectionName" = "অধ্যয়ন";
+
+/* Label used as an item in Settings. Tapping on this item takes you to the Studies panel */
+"Settings.Studies.Title" = "অধ্যয়ন";
+
+/* Title for a link that explains what Mozilla means by Studies */
+"Settings.Studies.Toggle.Link" = "আরও জানুন।";
+
+/* Toggled OFF to opt-out of studies */
+"Settings.Studies.Toggle.Off" = "বন্ধ";
+
+/* Toggled ON to participate in studies */
+"Settings.Studies.Toggle.On" = "চালু";
+
+/* Label used as a toggle item in Settings. When this is off, the user is opting out of all studies. */
+"Settings.Studies.Toggle.Title" = "অধ্যয়ন";
 
 /* Dismiss button for the tracker protection alert. */
 "Settings.TrackingProtection.Alert.Button" = "ঠিক আছে, বুঝেছি";
@@ -1578,6 +1710,9 @@
 /* Hardware shortcut to close the selected tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down. */
 "TabTray.CloseTab.KeyCodeTitle" = "নির্বাচিত ট্যাব বন্ধ করুন";
 
+/* Accessibility label for the currently selected tab. */
+"TabTray.CurrentSelectedTab.A11Y" = "বর্তমানে নির্বাচিত ট্যাব।";
+
 /* The section header for tabs opened last week */
 "TabTray.LastWeek.Header" = "গত সপ্তাহ";
 
@@ -1592,6 +1727,18 @@
 
 /* Hardware shortcut open the selected tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down. */
 "TabTray.OpenSelectedTab.KeyCodeTitle" = "নির্বাচিত ট্যাব খুলুন";
+
+/* The title for the tab tray in private mode */
+"TabTray.PrivateTitle" = "ব্যক্তিগত ট্যাব";
+
+/* The title on the button to look at private tabs. */
+"TabTray.SegmentedControlTitles.PrivateTabs" = "ব্যক্তিগত";
+
+/* The title on the button to look at synced tabs. */
+"TabTray.SegmentedControlTitles.SyncedTabs" = "সিঙ্ক হয়েছে";
+
+/* The title on the button to look at regular tabs. */
+"TabTray.SegmentedControlTitles.Tabs" = "ট্যাব";
 
 /* The button title to see more options to perform on the tab. */
 "TabTray.SwipeMenu.More" = "আরো";

--- a/Shared/bn.lproj/Menu.strings
+++ b/Shared/bn.lproj/Menu.strings
@@ -1,6 +1,9 @@
 /* Label for the button, displayed in the menu, used to create a bookmark for the current website. */
 "Menu.AddBookmarkAction.Title" = "বুকমার্ক যোগ করুন";
 
+/* Label for the button, displayed in the menu, used to create a bookmark for the current website. */
+"Menu.AddBookmarkAction2.Title" = "বুকমার্ক যোগ করুন";
+
 /* Label for the button, displayed in the menu, used to add a page to the reading list. */
 "Menu.AddToReadingList.Title" = "পাঠ্য তালিকায় যোগ করুন";
 
@@ -9,6 +12,9 @@
 
 /* Label for the button, displayed in the menu, used to copy the page url to the clipboard. */
 "Menu.CopyAddress.Title" = "ঠিকানা কপি করুন";
+
+/* Label for the button, displayed in the menu, used to copy the current page link to the clipboard. */
+"Menu.CopyLink.Title" = "লিংক কপি করুন";
 
 /* Label for the button, displayed in the menu, used to open the toolbar to search for text within the current page. */
 "Menu.FindInPageAction.Title" = "পাতাটিতে খুঁজুন";

--- a/Shared/bn.lproj/Today.strings
+++ b/Shared/bn.lproj/Today.strings
@@ -118,8 +118,14 @@
 /* Title for top sites widget to add Firefox top sites shotcuts to home screen */
 "TodayWidget.TopSitesGalleryTitle" = "শীর্ষ সাইটগুলি";
 
+/* Title for top sites widget to add Firefox top sites shotcuts to home screen */
+"TodayWidget.TopSitesGalleryTitleV2" = "ওয়েবসাইটের শর্টকাট";
+
 /* Sub label for Top Sites widget */
 "TodayWidget.TopSitesSubLabel" = "Firefox - শীর্ষ সাইটগুলি";
+
+/* Sub label for Shortcuts widget */
+"TodayWidget.TopSitesSubLabel2" = "Firefox - ওয়েবসাইট শর্টকাট";
 
 /* View More for Quick View widget in Gallery View where we don't know how many tabs might be opened */
 "TodayWidget.ViewMore" = "আরও দেখুন";

--- a/Shared/co.lproj/Localizable.strings
+++ b/Shared/co.lproj/Localizable.strings
@@ -914,10 +914,10 @@
 "Menu.TrackingProtectionBlockingDisabled.Description" = "Bluccà i perseguitatori in linea";
 
 /* The title that shows the number of cross-site cookies blocked */
-"Menu.TrackingProtectionCrossSiteCookies.Title" = "Canistrelli impiegati per u spiunagiu tra i siti";
+"Menu.TrackingProtectionCrossSiteCookies.Title" = "Canistrelli impiegati per u spiunagiu intersiti";
 
 /* The title that shows the number of cross-site URLs blocked */
-"Menu.TrackingProtectionCrossSiteTrackers.Title" = "Perseguitatori d’un situ à l’altru";
+"Menu.TrackingProtectionCrossSiteTrackers.Title" = "Perseguitatori intersiti";
 
 /* The title that shows the number of cryptomining scripts blocked */
 "Menu.TrackingProtectionCryptominersBlocked.Title" = "Minatori di crittomuneta";
@@ -956,7 +956,7 @@
 "Menu.TrackingProtectionFingerprintersBlocked.Title" = "Detettori d’impronta numerica";
 
 /* Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners` */
-"Menu.TrackingProtectionListTitle.CrossSiteCookies" = "Canistrelli di spiunagiu tra i siti bluccati";
+"Menu.TrackingProtectionListTitle.CrossSiteCookies" = "Canistrelli di spiunagiu intersiti bluccati";
 
 /* Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners` */
 "Menu.TrackingProtectionListTitle.Cryptominers" = "Minatori di crittomuneta bluccati";

--- a/Shared/cs.lproj/Localizable.strings
+++ b/Shared/cs.lproj/Localizable.strings
@@ -839,7 +839,7 @@
 "Menu.PageActions.Title" = "Akce stránky";
 
 /* Label for the button, displayed in the menu, takes you to to passwords screen when pressed. */
-"Menu.Passwords.Label" = "Hesla";
+"Menu.Passwords.Label" = "Přihlašovací údaje";
 
 /* The title for the button that lets you paste into the location bar */
 "Menu.Paste.Title" = "Vložit";

--- a/Shared/gd.lproj/ClearPrivateData.strings
+++ b/Shared/gd.lproj/ClearPrivateData.strings
@@ -16,3 +16,6 @@
 /* Settings item for clearing passwords and login data */
 "Saved Logins" = "Clàraidhean a-steach sàbhailte";
 
+/* A settings item that allows a user to use Apple's \"Spotlight Search\" in Data Management's Website Data option to search for and select an item to delete. */
+"Spotlight Index" = "Inneacs na prosbaige";
+

--- a/Shared/gd.lproj/Localizable.strings
+++ b/Shared/gd.lproj/Localizable.strings
@@ -43,6 +43,12 @@
 /* Title for the Jump Back In section. This section allows users to jump back in to a recently viewed tab */
 "ActivityStream.JumpBackIn.SectionTitle" = "Till gu far an robh thu";
 
+/* On the Firefox homepage in the Jump Back In section, if a Tab group item - a collection of grouped tabs from a related search - exists underneath the search term for the tab group, there will be a subtitle with a number for how many tabs are in that group. The placeholder is for a number. It will read 'Tabs: 5' or similar. */
+"ActivityStream.JumpBackIn.TabGroup.SiteCount" = "Tabaichean: %d";
+
+/* On the Firefox homepage in the Jump Back In section, if a Tab group item - a collection of grouped tabs from a related search - exists, the Tab Group item title will be 'Your search for \"video games\"'. The %@ sign is a placeholder for the actual search the user did. */
+"ActivityStream.JumpBackIn.TabGroup.Title" = "Lorg a rinn thu airson “%@”";
+
 /* A string used to signify the start of the Recently Saved section in Home Screen. */
 "ActivityStream.Library.Title" = "Air a shàbhaladh o chionn goirid";
 
@@ -69,6 +75,9 @@
 
 /* This button will open the library showing all the users bookmarks */
 "ActivityStream.RecentlySaved.ShowAll" = "Seall na h-uile";
+
+/* When long pressing an item in the Recently Visited section, this is the title of the button that appears, letting the user know to remove that particular item from the menu. */
+"ActivityStream.RecentlyVisited.RemoveButton.Title" = "Thoir air falbh";
 
 /* Section title label for Shortcuts */
 "ActivityStream.Shortcuts.SectionTitle" = "Ath-ghoiridean";
@@ -260,6 +269,13 @@
 /* Context menu item for sharing a link URL */
 "ContextMenu.ShareLinkButtonTitle" = "Co-roinn an ceangal";
 
+/* Contextual hints are little popups that appear for the users informing them of new features. This one talks about the more personalized home feature. */
+"ContextualHints.Homepage.PersonalizedHome" = "Leis gu bheil duilleag-dhachaigh phearsantaichte agad ann am Firefox a-nis, tha e nas fhasa cumail a’ dol far an do stad thu roimhe. Faigh greim air na tabaichean, comharran-lìn is toraidhean-luirg a bh’ agad o chionn goirid.";
+
+/* Contextual hints are little popups that appear for the users informing them of new features. This one is the call to action for the inactive tabs contextual popup.
+   Contextual hints are little popups that appear for the users informing them of new features. This one talks about the inactive tabs feature. */
+"ContextualHints.TabTray.InactiveTabs" = "Thèid tabaichean nach tug thu sùil orra fad cola-deug a ghluasad an-seo.";
+
 /* Accessibility message e.g. spoken by VoiceOver after adding current webpage to the Reading List failed. */
 "Could not add page to Reading list" = "Cha b’ urrainn dhuinn an duilleag a chur ris an liosta-leughaidh";
 
@@ -393,6 +409,9 @@
 
 /* Title for firefox about:home page in tab history list */
 "Firefox.HomePage.Title" = "Duilleag mhòr Firefox";
+
+/* A button at bottom of the Firefox homepage that, when clicked, takes users straight to the settings options, where they can customize the Firefox Home page */
+"FirefoxHome.CustomizeHomeButton.Title" = "Gnàthaich an duilleag-dhachaigh";
 
 /* Accessibility Label for the tab toolbar Forward button */
 "Forward" = "Air adhart";
@@ -550,6 +569,9 @@
 /* Title for the Synced Tabs Cell in the History Panel */
 "HistoryPanel.SyncedTabsCell.Title" = "Uidheaman sioncronaichte";
 
+/* Accessibility label for the tab toolbar indicating the Home button. */
+"Home" = "Dhachaigh";
+
 /* Button cancelling changes setting the home page for the first time. */
 "HomePage.Set.Dialog.Cancel" = "Sguir dheth";
 
@@ -619,6 +641,18 @@
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "Hotkeys.ShowPreviousTab.DiscoveryTitle" = "Seall an taba roimhe";
 
+/* In the Tabs Tray, in the Inactive Tabs section, a prompt may come up about auto-closing tabs. This string is for the button the user must tap in order to turn on the Auto close feature */
+"InactiveTabs.TabTray.AutoClosePrompt.ButtonTitle" = "Cuir gleus an fhèin-dùnaidh air";
+
+/* In the Tabs Tray, in the Inactive Tabs section, a prompt may come up about auto-closing tabs. This string describes what happens if you elect to turn on this option. */
+"InactiveTabs.TabTray.AutoClosePrompt.Content" = "Dùnaidh Firefox tabaichean nach tug thu sùil orra thairis air a’ mhìos seo chaidh.";
+
+/* In the Tabs Tray, in the Inactive Tabs section, a prompt may come up about auto-closing tabs. This is the title of that Auto Close prompt */
+"InactiveTabs.TabTray.AutoClosePrompt.Title" = "A bheil thu airson an dùnadh an dèidh mìos?";
+
+/* In the Tabs Tray, in the Inactive Tabs section, this is the button the user must tap in order to close all inactive tabs. */
+"InactiveTabs.TabTray.CloseButtonTitle" = "Dùin gach taba neo-ghnìomhach";
+
 /* Accessibility label for button increasing font size in display settings of reader mode */
 "Increase text size" = "Meudaich an cruth-clò";
 
@@ -651,6 +685,33 @@
 
 /* Toggle logins syncing setting */
 "Logins" = "Clàraidhean a-steach";
+
+/* Title of the Learn More button that links to a support page about device passcode requirements. */
+"Logins.DevicePasscodeRequired.LearnMoreButtonTitle" = "Barrachd fiosrachaidh";
+
+/* Message shown when you enter Logins & Passwords without having a device passcode set. */
+"Logins.DevicePasscodeRequired.Message" = "Airson clàraidhean a-steach is faclan-faire a shàbhaladh, cuir ID aodainn, ID suathaidh no còd-faire uidheim an comas.";
+
+/* Title of the Continue button. */
+"Logins.Onboarding.ContinueButtonTitle" = "Lean air adhart";
+
+/* Title of the Learn More button that links to a support page about device passcode requirements. */
+"Logins.Onboarding.LearnMoreButtonTitle" = "Barrachd fiosrachaidh";
+
+/* Message shown when you enter Logins & Passwords for the first time. */
+"Logins.Onboarding.Message" = "Tha na clàraidhean a-steach is faclan-faire agad gan dìon le ID aodainn, ID suathaidh no còd-faire uidheim a-nis.";
+
+/* Warning message shown when you try to enable or use native AutoFill without a device passcode setup */
+"Logins.PasscodeRequirement.Warning" = "Feumaidh còd-faire uidheim a bhith an comas agad mus urrainn dhut gleus an fhèin-lìonaidh aig Firefox a chleachdadh.";
+
+/* Label displaying welcome view tagline under the title */
+"Logins.WelcomeView.Tagline" = "Thoir leat na faclan-faire agad ge be càit an tèid thu";
+
+/* Label displaying welcome view title */
+"Logins.WelcomeView.Title2" = "Fèin-lìon faclan-faire Firefox";
+
+/* Title of the big blue button to enable AutoFill */
+"Logins.WelcomeView.TurnOnAutoFill" = "Cuir gleus an fhèin-lìonaidh air";
 
 /* Login detail view field name for the last modified date */
 "LoginsDetailView.LoginModified" = "Air atharrachadh";
@@ -693,6 +754,27 @@
 
 /* Placeholder test for search box in logins list view. */
 "LoginsList.LoginsListSearchPlaceholder" = "Criathrag";
+
+/* Label shown when there are no logins to list */
+"LoginsList.NoLoginsFound.Description" = "Nochdaidh clàraidhean a-steach a shàbhail thu an-seo. Ma shàbhail thu clàradh a-steach ann am Firefox air uidheam eile, clàraich a-steach dhan chunntas Firefox agad.";
+
+/* Label shown when there are no logins saved */
+"LoginsList.NoLoginsFound.Title" = "Cha deach clàradh a-steach a lorg";
+
+/* Label that appears after the search if there are no logins matching the search */
+"LoginsList.NoMatchingResult.Subtitle" = "Chan eil toradh ann a tha a’ freagairt ris na lorg thu.";
+
+/* Label displayed when a user searches and no matches can be found against the search query */
+"LoginsList.NoMatchingResult.Title" = "Chan eil clàradh a-steach ann a tha a’ freagairt ris na lorg thu";
+
+/* Title for cancel button for user to stop searching for a particular login */
+"LoginsList.Search.Cancel" = "Sguir dheth";
+
+/* Placeholder text for search field */
+"LoginsList.Search.Placeholder" = "Lorg sna clàraidhean a-steach";
+
+/* Label displaying select a password to fill instruction */
+"LoginsList.SelectPassword.Title" = "Tagh facal-faire airson a lìonadh";
 
 /* Title for the list of logins */
 "LoginsList.Title" = "CLÀRAIDHEAN A-STEACH A SHÀBHAILEADH";
@@ -806,6 +888,9 @@
 
 /* Title on tracking protection menu for blocked items. */
 "Menu.TrackingProtection.BlockedTitle" = "Air a bhacadh";
+
+/* String to let users know the site verifier, where the placeholder represents the SSL certificate signer. */
+"Menu.TrackingProtection.Details.Verifier" = "Air a dhearbhadh le %@";
 
 /* Message in menu when no trackers blocked. */
 "Menu.TrackingProtection.NoTrackersBlockedTitle" = "Cha do mhothaich sinn do thracaiche as aithne dha Firefox air an duilleag seo.";
@@ -925,6 +1010,31 @@
 /* Restore Tabs Affirmative Action */
 "Okay" = "Ceart ma-thà";
 
+/* On the onboarding card letting users know what's new in this version of Firefox, this is the title for the button, on the bottom of the card, used to get back to browsing on Firefox by dismissing the onboarding card */
+"Onboarding.WhatsNew.Button.Title" = "Tòisich air brabhsadh";
+
+/* On the onboarding card, letting users know what's new in this version of Firefox, this is a general description that appears under the title for what the card is about. */
+"Onboarding.WhatsNew.Description" = "Tha e nas fhasa a-nis leantainn ort far an robh thu roimhe.";
+
+/* On the onboarding card, letting users know what's new in this version of Firefox, this is the description for the Jump Back In bullet point */
+"Onboarding.WhatsNew.PersonalizedHome.Description" = "Leum gu na tabaichean fosgailte, comharran-lìn is eachdraidh a’ bhrabhsaidh agad.";
+
+/* On the onboarding card letting users know what's new in this version of Firefox, this is the descripion of the Recent Searches bullet point on the card */
+"Onboarding.WhatsNew.RecentSearches.Description" = "Ath-thadhail air na luirg a rinn thu o chionn goirid air an duilleag-dhachaigh agad.";
+
+/* On the onboarding card letting users know what's new in this version of Firefox, this is the title for the Recent Searches bullet point on the card */
+"Onboarding.WhatsNew.RecentSearches.Title" = "Luirg o chionn goirid";
+
+/* On the onboarding card letting users know what's new in this version of Firefox, this is the description for the Tab Group bullet point on the card */
+"Onboarding.WhatsNew.TabGroups.Description" = "Duilleagan on aon lorg còmhla ann am buidheann.";
+
+/* On the onboarding card, letting users know what's new in this version of Firefox, this is the title for the Tab Group bullet point on the card */
+"Onboarding.WhatsNew.TabGroups.Title" = "Buidhnean thabaichean nas sgiobalta";
+
+/* On the onboarding card, letting users know what's new in this version of Firefox, this is the title for the Jump Back In bullet point on the card
+   The title for the new onboarding card letting users know what is new in Firefox iOS */
+"Onboarding.WhatsNew.Title" = "Na tha ùr ann am Firefox";
+
 /* Title for prompt displayed to user after the app crashes */
 "Oops! Firefox crashed" = "Ìoc! Thuislich Firefox";
 
@@ -975,6 +1085,12 @@
 
 /* Show Firefox Browser Privacy Policy page from the Privacy section in the settings. See https://www.mozilla.org/privacy/firefox/ */
 "Privacy Policy" = "Am poileasaidh prìobhaideachd";
+
+/* This is the value for a label that indicates if a user is on an unencrypted website. */
+"ProtectionStatus.NotSecure" = "Chan eil an ceangal tèarainte";
+
+/* This is the value for a label that indicates if a user is on a secure https connection. */
+"ProtectionStatus.Secure" = "Tha an ceangal tèarainte";
 
 /* Title for quick-search engines settings section. */
 "Quick-Search Engines" = "Einnseanan grad-luirg";
@@ -1301,6 +1417,45 @@
 /* General settings section title */
 "Settings.General.SectionName" = "Coitcheann";
 
+/* In the settings menu, on the Firefox homepage customization section, this is the description below the section, describing what the options in the section are for. */
+"Settings.Home.Option.Description" = "Tagh susbaint a chì thu air duilleag-dhachaigh Firefox.";
+
+/* In the settings menu, in the Firefox homepage customization section, this is the title for the option that allows users to toggle the Jump Back In section on homepage on or off */
+"Settings.Home.Option.JumpBackIn" = "Till gu far an robh thu";
+
+/* In the settings menu, in the Firefox homepage customization section, this is the title for the option that allows users to turn the Pocket Recommendations section on the Firefox homepage on or off */
+"Settings.Home.Option.Pocket" = "Air a mholadh le Pocket";
+
+/* In the settings menu, in the Firefox homepage customization section, this is the title for the option that allows users to toggle Recently Saved section on the Firefox homepage on or off */
+"Settings.Home.Option.RecentlySaved" = "Air a shàbhaladh o chionn goirid";
+
+/* In the settings menu, in the Firefox homepage customization section, this is the title for the option that allows users to toggle Recently Visited section on the Firfox homepage on or off */
+"Settings.Home.Option.RecentlyVisited" = "Air tadhal orra o chionn goirid";
+
+/* In the settings menu, in the Firefox homepage customization section, this is the title for the option that allows users to toggle Recent Searches section on the Firefox homepage on or off */
+"Settings.Home.Option.RecentSearches" = "Luirg o chionn goirid";
+
+/* In the settings menu, in the Firefox homepage customization section, this is the title for the option that allows users to toggle Shortcuts section on the Firefox homepage on or off */
+"Settings.Home.Option.Shortcuts" = "Ath-ghoiridean";
+
+/* In the settings menu, on the Start at Home homepage customization option, this allows users to set this setting to return to the Homepage after four hours of inactivity. */
+"Settings.Home.Option.StartAtHome.AfterFourHours" = "An duilleag-dhachaigh an dèidh ceithir uairean a thìde gun ghnìomhachd";
+
+/* In the settings menu, on the Start at Home homepage customization option, this allows users to set this setting to return to the Homepage every time they open up Firefox */
+"Settings.Home.Option.StartAtHome.Always" = "Duilleag-dhachaigh";
+
+/* In the settings menu, in the Start at Home customization options, this is text that appears below the section, describing what the section settings do. */
+"Settings.Home.Option.StartAtHome.Description" = "Tagh na chì thu nuair a thilleas tu gu Firefox.";
+
+/* In the settings menu, on the Start at Home homepage customization option, this allows users to set this setting to return to the last tab they were on, every time they open up Firefox */
+"Settings.Home.Option.StartAtHome.Never" = "An taba mu dheireadh";
+
+/* Title for the section in the settings menu where users can configure the behaviour of the Start at Home feature on the Firefox Homepage. */
+"Settings.Home.Option.StartAtHome.Title" = "An sgrìn fosglaidh";
+
+/* In the settings menu, this is the title of the Firefox Homepage customization settings section */
+"Settings.Home.Option.Title" = "Duilleag-dhachaigh Firefox";
+
 /* Button in settings to clear the home page. */
 "Settings.HomePage.Clear.Button" = "Falamhaich";
 
@@ -1471,6 +1626,18 @@
 
 /* Label used as a toggle item in Settings. When this is off, the user is opting out of all studies. */
 "Settings.Studies.Toggle.Title" = "Rannsachadh";
+
+/* In the settings menu, in the Tabs customization section, this is the title for the setting that toggles the Inactive Tabs feature, a separate section of inactive tabs that appears in the Tab Tray, on or off */
+"Settings.Tabs.CustomizeTabsSection.InactiveTabs" = "Tabaichean neo-ghnìomhach";
+
+/* In the settings menu, in the Tabs customization section, this is the title for the setting that toggles the Tab Groups feature - where tabs from related searches are grouped - on or off */
+"Settings.Tabs.CustomizeTabsSection.TabGroups" = "Buidhnean thabaichean";
+
+/* In the settings menu, in the Tabs customization section, this is the title for the Tabs Tray customization section. The tabs tray is accessed from firefox hompage */
+"Settings.Tabs.CustomizeTabsSection.Title" = "Gnàthaich treidhe nan taba";
+
+/* In the settings menu, this is the title for the Tabs customization section option */
+"Settings.Tabs.Title" = "Tabaichean";
 
 /* Dismiss button for the tracker protection alert. */
 "Settings.TrackingProtection.Alert.Button" = "Ceart, tha mi agaibh";
@@ -1710,6 +1877,9 @@
 /* Accessibility label for the currently selected tab. */
 "TabTray.CurrentSelectedTab.A11Y" = "An taba a thagh thu.";
 
+/* In the tab tray, when tab groups appear and there exist tabs that don't belong to any group, those tabs are listed under this header as \"Others\" */
+"TabTray.Header.FilteredTabs.SectionHeader" = "Eile";
+
 /* Title for the inactive tabs section. This section groups all tabs that haven't been used in a while. */
 "TabTray.InactiveTabs.SectionTitle" = "Tabaichean neo-ghnìomhach";
 
@@ -1728,11 +1898,17 @@
 /* Hardware shortcut open the selected tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down. */
 "TabTray.OpenSelectedTab.KeyCodeTitle" = "Fosgail an taba a thagh thu";
 
+/* In the Tabs Tray, summoned from the homepage, the title for the section containing non-grouped tabs, which will appear below grouped tabs */
+"TabTray.OtherTabs.Title" = "Tabaichean eile";
+
 /* The title for the tab tray in private mode */
 "TabTray.PrivateTitle" = "Tabaichean prìobhaideach";
 
 /* Describes what the Recently Closed tabs behavior is for users unfamiliar with it. */
 "TabTray.RecentlyClosed.Description" = "Bidh na tabaichean ri làimh dhut an-seo fad 30 latha. Thèid na tabaichean a dhùnadh gu fèin-obrachail an uairsin.";
+
+/* Title for the recently closed tabs section. This section shows a list of all the tabs that have been recently closed. */
+"TabTray.RecentlyClosed.SectionTitle" = "Air an dùnadh o chionn goirid";
 
 /* The title on the button to look at private tabs. */
 "TabTray.SegmentedControlTitles.PrivateTabs" = "Prìobhaideach";

--- a/Shared/km.lproj/Localizable.strings
+++ b/Shared/km.lproj/Localizable.strings
@@ -291,6 +291,9 @@
 /* Title for the new dark mode change in the version 22 app release. */
 "CoverSheet.v22.DarkMode.Title" = "ឥឡូវនេះ រចនាប័ទ្ម​ងងឹតរួម​បញ្ចូល​ទាំង​ក្តារ​ចុច​ងងឹត ​និង​អេក្រង់​ស្វាគមន៍​ងងឹត។";
 
+/* Description for the new ETP mode i.e. standard vs strict */
+"CoverSheet.v24.ETP.Description" = "ការការពារ​ការតាមដាន​កែលម្អ​ដែលបានបង្កើត​​ជួយ​បញ្ឈប់​ការផ្សាយពាណិជ្ជកម្ម​ពី​ការតាមដាន​ជុំវិញ​អ្នក។ បើក​ការរឹតបន្តឹង​ដើម្បីទប់ស្កាត់​ទោះបីជា​មាន​កម្មវិធី​តាមដាន ការផ្សាយពាណិជ្ជកម្ម និង​ព័ត៌មាន​លេចឡើង​កាន់តែច្រើន​ក៏ដោយ។";
+
 /* Text for the new ETP settings button */
 "CoverSheet.v24.ETP.Settings.Button" = "ចូល​ទៅ​កាន់​ការ​កំណត់";
 
@@ -406,6 +409,9 @@
 
 /* Title for firefox about:home page in tab history list */
 "Firefox.HomePage.Title" = "ទំព័រដើម Firefox";
+
+/* A button at bottom of the Firefox homepage that, when clicked, takes users straight to the settings options, where they can customize the Firefox Home page */
+"FirefoxHome.CustomizeHomeButton.Title" = "កែ​គេហទំព័រ​តាមបំណង";
 
 /* Accessibility Label for the tab toolbar Forward button */
 "Forward" = "បញ្ជូន​បន្ត";
@@ -539,6 +545,9 @@
 /* Title for the Synced Tabs Cell in the History Panel */
 "HistoryPanel.SyncedTabsCell.Title" = "ឧបករណ៍​ដែល​បាន​ធ្វើ​សមកាលកម្ម";
 
+/* Accessibility label for the tab toolbar indicating the Home button. */
+"Home" = "ទំព័រ​ដើម";
+
 /* Button cancelling changes setting the home page for the first time. */
 "HomePage.Set.Dialog.Cancel" = "បោះបង់​";
 
@@ -608,6 +617,18 @@
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "Hotkeys.ShowPreviousTab.DiscoveryTitle" = "បង្ហាញ​ផ្ទាំង​មុន​";
 
+/* In the Tabs Tray, in the Inactive Tabs section, a prompt may come up about auto-closing tabs. This string is for the button the user must tap in order to turn on the Auto close feature */
+"InactiveTabs.TabTray.AutoClosePrompt.ButtonTitle" = "បើក​ការបិទ​ស្វ័យប្រវត្តិ";
+
+/* In the Tabs Tray, in the Inactive Tabs section, a prompt may come up about auto-closing tabs. This string describes what happens if you elect to turn on this option. */
+"InactiveTabs.TabTray.AutoClosePrompt.Content" = "Firefox នឹង​បិទ​ផ្ទាំង​ដែល​អ្នក​មិន​បាន​មើល​ជាងមួយ​ខែ​មុន។";
+
+/* In the Tabs Tray, in the Inactive Tabs section, a prompt may come up about auto-closing tabs. This is the title of that Auto Close prompt */
+"InactiveTabs.TabTray.AutoClosePrompt.Title" = "បិទ​ស្វ័យប្រវត្តិ​បន្ទាប់​ពី​មួយខែ​ឬ?";
+
+/* In the Tabs Tray, in the Inactive Tabs section, this is the button the user must tap in order to close all inactive tabs. */
+"InactiveTabs.TabTray.CloseButtonTitle" = "បិទ​ផ្ទាំងអសកម្ម​ទាំងអស់​";
+
 /* Accessibility label for button increasing font size in display settings of reader mode */
 "Increase text size" = "បង្កើន​ទំហំ​អត្ថបទ";
 
@@ -640,6 +661,21 @@
 
 /* Toggle logins syncing setting */
 "Logins" = "ចូល";
+
+/* Title of the Learn More button that links to a support page about device passcode requirements. */
+"Logins.DevicePasscodeRequired.LearnMoreButtonTitle" = "ស្វែងយល់​បន្ថែម";
+
+/* Message shown when you enter Logins & Passwords without having a device passcode set. */
+"Logins.DevicePasscodeRequired.Message" = "ដើម្បីរក្សាទុក និង​បំពេញ​ការចូល និង​ពាក្យសម្ងាត់​ស្វ័យប្រវត្តិ​ សូមបើក​ដំណើរការ​ការសម្គាល់​មុខ សម្គាល់​ការបេះ ឬ​លេខ​កូដ​ចូលឧបករណ៍។";
+
+/* Title of the Continue button. */
+"Logins.Onboarding.ContinueButtonTitle" = "បន្ត";
+
+/* Title of the Learn More button that links to a support page about device passcode requirements. */
+"Logins.Onboarding.LearnMoreButtonTitle" = "ស្វែងយល់បន្ថែម";
+
+/* Message shown when you enter Logins & Passwords for the first time. */
+"Logins.Onboarding.Message" = "ឥឡូវនេះ ការចូល និង​ពាក្យសម្ងាត់​របស់អ្នក​ត្រូវបាន​ការពារ​ដោយ​ការសម្គាល់​មុខ ការសម្គាល់​ការប៉ះ ឬ​លេខកូដ​ចូលឧបករណ៍។";
 
 /* Login detail view field name for the last modified date */
 "LoginsDetailView.LoginModified" = "បាន​កែប្រែ";

--- a/Shared/sat-Olck.lproj/Localizable.strings
+++ b/Shared/sat-Olck.lproj/Localizable.strings
@@ -43,6 +43,12 @@
 /* Title for the Jump Back In section. This section allows users to jump back in to a recently viewed tab */
 "ActivityStream.JumpBackIn.SectionTitle" = "ᱦᱮᱡ ᱨᱩᱟᱹᱲᱚᱜ ᱢᱮ";
 
+/* On the Firefox homepage in the Jump Back In section, if a Tab group item - a collection of grouped tabs from a related search - exists underneath the search term for the tab group, there will be a subtitle with a number for how many tabs are in that group. The placeholder is for a number. It will read 'Tabs: 5' or similar. */
+"ActivityStream.JumpBackIn.TabGroup.SiteCount" = "ᱴᱮᱵᱽ ᱠᱚ:%d";
+
+/* On the Firefox homepage in the Jump Back In section, if a Tab group item - a collection of grouped tabs from a related search - exists, the Tab Group item title will be 'Your search for \"video games\"'. The %@ sign is a placeholder for the actual search the user did. */
+"ActivityStream.JumpBackIn.TabGroup.Title" = "\"%@\" ᱞᱟᱹᱜᱤᱜ ᱟᱢᱟᱜ ᱥᱮᱸᱫᱽᱨᱟ";
+
 /* A string used to signify the start of the Recently Saved section in Home Screen. */
 "ActivityStream.Library.Title" = "ᱦᱟᱞᱮᱜᱮ ᱨᱩᱠᱷᱭᱟᱹ ᱟᱠᱟᱱᱟ";
 
@@ -69,6 +75,9 @@
 
 /* This button will open the library showing all the users bookmarks */
 "ActivityStream.RecentlySaved.ShowAll" = "ᱡᱚᱛᱚ ᱧᱮᱞ ᱢᱟ";
+
+/* When long pressing an item in the Recently Visited section, this is the title of the button that appears, letting the user know to remove that particular item from the menu. */
+"ActivityStream.RecentlyVisited.RemoveButton.Title" = "ᱚᱪᱚᱜᱽ ᱢᱮ";
 
 /* Section title label for Shortcuts */
 "ActivityStream.Shortcuts.SectionTitle" = "ᱠᱷᱟᱴᱚᱢᱟᱪᱷᱟ";
@@ -394,6 +403,9 @@
 /* Title for firefox about:home page in tab history list */
 "Firefox.HomePage.Title" = "Firefox ᱚᱲᱟᱜ ᱥᱟᱦᱟᱴᱟ";
 
+/* A button at bottom of the Firefox homepage that, when clicked, takes users straight to the settings options, where they can customize the Firefox Home page */
+"FirefoxHome.CustomizeHomeButton.Title" = "ᱚᱲᱟᱜᱥᱟᱦᱴᱟ ᱠᱩᱥᱤᱛᱮ ᱫᱚᱦᱚᱭ ᱢᱮ";
+
 /* Accessibility Label for the tab toolbar Forward button */
 "Forward" = "ᱢᱟᱲᱟᱝ";
 
@@ -654,6 +666,18 @@
 
 /* Toggle logins syncing setting */
 "Logins" = "ᱵᱚᱞᱚ ᱠᱚ";
+
+/* Title of the Learn More button that links to a support page about device passcode requirements. */
+"Logins.DevicePasscodeRequired.LearnMoreButtonTitle" = "ᱰᱷᱮᱨ ᱥᱮᱬᱟᱭ ᱢᱮ";
+
+/* Title of the Continue button. */
+"Logins.Onboarding.ContinueButtonTitle" = "ᱞᱟᱦᱟᱜ ᱢᱮ";
+
+/* Title of the Learn More button that links to a support page about device passcode requirements. */
+"Logins.Onboarding.LearnMoreButtonTitle" = "ᱰᱷᱮᱨ ᱥᱮᱬᱟᱭ ᱢᱮ";
+
+/* Title of the big blue button to enable AutoFill */
+"Logins.WelcomeView.TurnOnAutoFill" = "AutoFill ᱮᱢ ᱪᱷᱚᱭ ᱢᱮ";
 
 /* Login detail view field name for the last modified date */
 "LoginsDetailView.LoginModified" = "ᱵᱚᱫᱚᱞᱟᱠ";
@@ -951,6 +975,9 @@
 
 /* Restore Tabs Affirmative Action */
 "Okay" = "ᱴᱷᱤᱠ ᱜᱮ";
+
+/* On the onboarding card letting users know what's new in this version of Firefox, this is the title for the button, on the bottom of the card, used to get back to browsing on Firefox by dismissing the onboarding card */
+"Onboarding.WhatsNew.Button.Title" = "ᱯᱟᱱᱛᱮᱭᱟᱜ ᱮᱦᱚᱵ ᱢᱮ";
 
 /* Title for prompt displayed to user after the app crashes */
 "Oops! Firefox crashed" = "ᱚᱦᱟᱭ! Firefox ᱨᱚᱯᱩᱫᱮᱱᱟ";
@@ -1505,6 +1532,9 @@
 /* Label used as a toggle item in Settings. When this is off, the user is opting out of all studies. */
 "Settings.Studies.Toggle.Title" = "ᱯᱟᱲᱦᱟᱣ ᱠᱚ";
 
+/* In the settings menu, this is the title for the Tabs customization section option */
+"Settings.Tabs.Title" = "ᱴᱮᱵᱽ ᱠᱚ";
+
 /* Dismiss button for the tracker protection alert. */
 "Settings.TrackingProtection.Alert.Button" = "ᱴᱷᱤᱠ, ᱭᱟᱢᱮᱱᱟ";
 
@@ -1743,6 +1773,9 @@
 /* Accessibility label for the currently selected tab. */
 "TabTray.CurrentSelectedTab.A11Y" = "ᱱᱤᱛᱚᱜ ᱵᱟᱪᱷᱟᱣ ᱟᱠᱟᱱ ᱴᱮᱵᱽ ᱾";
 
+/* In the tab tray, when tab groups appear and there exist tabs that don't belong to any group, those tabs are listed under this header as \"Others\" */
+"TabTray.Header.FilteredTabs.SectionHeader" = "ᱮᱴᱟᱜᱽ-ᱟᱜ";
+
 /* Title for the inactive tabs section. This section groups all tabs that haven't been used in a while. */
 "TabTray.InactiveTabs.SectionTitle" = "ᱵᱟᱝ ᱩᱥᱨᱟᱹᱣ ᱴᱮᱵᱽᱥ";
 
@@ -1760,6 +1793,9 @@
 
 /* Hardware shortcut open the selected tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down. */
 "TabTray.OpenSelectedTab.KeyCodeTitle" = "ᱵᱟᱪᱷᱟᱣᱟᱠ ᱴᱮᱵ ᱠᱷᱩᱞᱟᱹᱭ ᱢᱮ";
+
+/* In the Tabs Tray, summoned from the homepage, the title for the section containing non-grouped tabs, which will appear below grouped tabs */
+"TabTray.OtherTabs.Title" = "ᱵᱷᱮᱜᱟᱨ ᱴᱮᱵᱽ ᱠᱚ";
 
 /* The title for the tab tray in private mode */
 "TabTray.PrivateTitle" = "ᱯᱨᱟᱭᱣᱮᱴ ᱴᱮᱵᱽ ᱠᱚ";

--- a/Shared/sat-Olck.lproj/Menu.strings
+++ b/Shared/sat-Olck.lproj/Menu.strings
@@ -88,3 +88,6 @@
 /* Label for the button, displayed in the menu, used to request the mobile version of the current website. */
 "Menu.ViewMobileSiteAction.Title" = "ᱢᱚᱵᱟᱤᱞ ᱥᱟᱤᱴ ᱱᱮᱦᱚᱨ ᱢᱮ";
 
+/* Label for the button, displayed in the menu, used to navigate to the home page. */
+"SettingsMenu.OpenHomePageAction.Title" = "ᱚᱲᱟᱜ ᱥᱟᱦᱴᱟ";
+

--- a/Shared/th.lproj/Localizable.strings
+++ b/Shared/th.lproj/Localizable.strings
@@ -689,14 +689,29 @@
 /* Title of the Learn More button that links to a support page about device passcode requirements. */
 "Logins.DevicePasscodeRequired.LearnMoreButtonTitle" = "เรียนรู้เพิ่มเติม";
 
+/* Message shown when you enter Logins & Passwords without having a device passcode set. */
+"Logins.DevicePasscodeRequired.Message" = "หากต้องการบันทึกและป้อนการเข้าสู่ระบบและรหัสผ่านอัตโนมัติ ให้เปิดใช้งาน Face ID, Touch ID หรือรหัสผ่านของอุปกรณ์";
+
 /* Title of the Continue button. */
 "Logins.Onboarding.ContinueButtonTitle" = "ดำเนินการต่อ";
 
 /* Title of the Learn More button that links to a support page about device passcode requirements. */
 "Logins.Onboarding.LearnMoreButtonTitle" = "เรียนรู้เพิ่มเติม";
 
+/* Message shown when you enter Logins & Passwords for the first time. */
+"Logins.Onboarding.Message" = "การเข้าสู่ระบบและรหัสผ่านของคุณได้รับการปกป้องโดย Face ID, Touch ID หรือรหัสผ่านของอุปกรณ์";
+
+/* Warning message shown when you try to enable or use native AutoFill without a device passcode setup */
+"Logins.PasscodeRequirement.Warning" = "ในการใช้คุณสมบัติป้อนอัตโนมัติสำหรับ Firefox คุณต้องเปิดใช้งานรหัสผ่านของอุปกรณ์";
+
 /* Label displaying welcome view tagline under the title */
 "Logins.WelcomeView.Tagline" = "นำรหัสผ่านของคุณไปทุกที่";
+
+/* Label displaying welcome view title */
+"Logins.WelcomeView.Title2" = "ป้อนรหัสผ่าน Firefox อัตโนมัติ";
+
+/* Title of the big blue button to enable AutoFill */
+"Logins.WelcomeView.TurnOnAutoFill" = "เปิดการป้อนอัตโนมัติ";
 
 /* Login detail view field name for the last modified date */
 "LoginsDetailView.LoginModified" = "เปลี่ยนแปลงเมื่อ";

--- a/Shared/tt.lproj/3DTouchActions.strings
+++ b/Shared/tt.lproj/3DTouchActions.strings
@@ -1,24 +1,21 @@
 /* Label for preview action on Tab Tray Tab to add current tab to Bookmarks */
-"Add to Bookmarks" = "বুকমার্কে যোগ করুন";
+"Add to Bookmarks" = "Кыстыргычларга өстәү";
 
 /* Label for preview action on Tab Tray Tab to close the current tab */
-"Close Tab" = "ট্যাব বন্ধ করুন";
+"Close Tab" = "Табны ябу";
 
 /* Label for preview action on Tab Tray Tab to copy the URL of the current tab to clipboard */
-"Copy URL" = "URL কপি করুন";
-
-/* Label for preview action on Tab Tray Tab to send the current link to another device */
-"Menu.SendLinkToDevice" = "ডিভাইসে লিঙ্ক পাঠান";
+"Copy URL" = "URL-ны күчереп алу";
 
 /* String describing the action of opening the last added bookmark from the home screen Quick Actions via 3D Touch */
-"Open Last Bookmark" = "শেষ বুকমার্কটি খুলুন";
+"Open Last Bookmark" = "Соңгы кыстыргычны ачу";
 
 /* String describing the action of opening the last tab sent to Firefox from the home screen Quick Actions via 3D Touch */
-"Open Last Tab" = "শেষ ট্যাবটি খুলুন";
+"Open Last Tab" = "Соңгы табны ачу";
 
 /* Accessibility label, associated to the 3D Touch action on the current tab in the tab tray, used to display a larger preview of the tab. */
-"Preview of %@" = "%@ এর প্রাকদর্শন";
+"Preview of %@" = "%@ табының күренеше";
 
 /* Label for preview action on Tab Tray Tab to send the current tab to another device */
-"Send to Device" = "ডিভাইস এ প্রেরণ করুন";
+"Send to Device" = "Җиһазга җибәрү";
 

--- a/Shared/tt.lproj/AuthenticationManager.strings
+++ b/Shared/tt.lproj/AuthenticationManager.strings
@@ -1,0 +1,90 @@
+/* 'After 1 hour' interval item for selecting when to require passcode */
+"After 1 hour" = "1 сәгатьтән соң";
+
+/* 'After 1 minute' interval item for selecting when to require passcode */
+"After 1 minute" = "1 минуттан соң";
+
+/* 'After 5 minutes' interval item for selecting when to require passcode */
+"After 5 minutes" = "5 минуттан соң";
+
+/* 'After 10 minutes' interval item for selecting when to require passcode */
+"After 10 minutes" = "10 минуттан соң";
+
+/* 'After 15 minutes' interval item for selecting when to require passcode */
+"After 15 minutes" = "15 минуттан соң";
+
+/* Label used as a setting item and title of the following screen to change the current passcode */
+"Change Passcode" = "Серсүзне үзгәртү";
+
+/* Text displayed above the input field when changing the existing passcode */
+"Enter a new passcode" = "Яңа бер серсүз языгыз";
+
+/* Text displayed above the input field when entering a new passcode */
+"Enter a passcode" = "Бер серсүз языгыз";
+
+/* Text displayed above the input field when changing the existing passcode */
+"Enter passcode" = "Серсүзне кертү";
+
+/* Title of the dialog used to request the passcode */
+"Enter Passcode" = "Серсүзне кертү";
+
+/* Label for the Face ID/Passcode item in Settings */
+"Face ID & Passcode" = "Face ID һәм Серсүз";
+
+/* 'Immediately' interval item for selecting when to require passcode */
+"Immediately" = "Хәзер үк";
+
+/* Error message displayed when user enters incorrect passcode when trying to enter a protected section of the app with attempts remaining */
+"Incorrect passcode. Try again (Attempts remaining: %d)." = "Серсүз хаталы. Янәдән тырышып карагыз (%d мөмкинлек калды).";
+
+/* Error message displayed when user enters incorrect passcode when trying to enter a protected section of the app */
+"Incorrect passcode. Try again." = "Серсүз хаталы. Тагын бер тырышып карагыз.";
+
+/* Error message displayed when user enters incorrect passcode and has reached the maximum number of attempts. */
+"Maximum attempts reached. Please try again in an hour." = "Омтылышлар саны чиккә җитте. Зинһар, бер сәгатьтән соң тырышып карагыз.";
+
+/* Error message displayed when user enters incorrect passcode and has reached the maximum number of attempts. */
+"Maximum attempts reached. Please try again later." = "Омтылышлар саны чиккә җитте. Зинһар соңрак тырышып карагыз.";
+
+/* Error message displayed when user tries to enter the same passcode as their existing code when changing it. */
+"New passcode must be different than existing code." = "Яңа серсүз хәзерге серсүздән үзгә булырга тиеш.";
+
+/* Label for the Passcode item in Settings */
+"Passcode For Logins" = "Логиннар өчен серсүз";
+
+/* Error message displayed to user when their confirming passcode doesn't match the first code. */
+"Passcodes didn’t match. Try again." = "Серсүзләр туры килмәде. Тагын бер тырышып карагыз.";
+
+/* Text displayed above the input field when confirming a passcode */
+"Re-enter passcode" = "Серсүзне янәдән кертегез";
+
+/* Text displayed in the 'Interval' section, followed by the current interval setting, e.g. 'Immediately' */
+"Require Passcode" = "Серсүз таләп итү";
+
+/* Title of the dialog used to set a passcode */
+"Set Passcode" = "Серсүзне урнаштыру";
+
+/* Label for the Touch ID/Passcode item in Settings */
+"Touch ID & Passcode" = "Touch ID һәм серсүз";
+
+/* Touch ID prompt subtitle when disabling Touch ID */
+"touchid.disable.reason.label" = "Touch ID-ны сүндерү өчен бармак эзегезне кулланыгыз.";
+
+/* Touch ID prompt subtitle when accessing the require passcode setting */
+"touchid.require.passcode.reason.label" = "Серсүзне яңарту вакытын билгеләү өчен бармак эзегезне кулланыгыз.";
+
+/* Label used as a setting item to turn off passcode */
+"Turn Passcode Off" = "Серсүзне сүндерү";
+
+/* Label used as a setting item to turn on passcode */
+"Turn Passcode On" = "Серсүзне кабызу";
+
+/* List section title for when to use Face ID */
+"Use Face ID" = "Face ID куллану";
+
+/* List section title for when to use Touch ID */
+"Use Touch ID" = "Touch ID куллану";
+
+/* Touch ID prompt subtitle when accessing logins */
+"Use your fingerprint to access Logins now." = "Логиннарга ирешү өчен хәзер бармак эзегезне кулланыгыз.";
+

--- a/Shared/tt.lproj/ClearHistoryConfirm.strings
+++ b/Shared/tt.lproj/ClearHistoryConfirm.strings
@@ -1,0 +1,9 @@
+/* The cancel button when confirming clear history. */
+"Cancel" = "Баш тарту";
+
+/* The confirmation button that clears history even when Sync is connected. */
+"OK" = "ОК";
+
+/* Description of the confirmation dialog shown when a user tries to clear history that's synced to another device. */
+"This action will clear all of your private data, including history from your synced devices." = "Бу гамәл барлык хосусый мәгълүматларыгызны, синхронланган җиһазлар тарихын да кертеп, бетерәчәк.";
+

--- a/Shared/tt.lproj/ClearPrivateData.strings
+++ b/Shared/tt.lproj/ClearPrivateData.strings
@@ -1,0 +1,18 @@
+/* Settings item for clearing browsing history */
+"Browsing History" = "Гизү тарихы";
+
+/* Settings item for clearing the cache */
+"Cache" = "Кэш";
+
+/* Settings item for clearing cookies */
+"Cookies" = "Кукилар";
+
+/* Settings item for deleting downloaded files */
+"Downloaded Files" = "Йөкләнгән файллар";
+
+/* Settings item for clearing website data */
+"Offline Website Data" = "Оффлайн сайт мәгълүматлары";
+
+/* Settings item for clearing passwords and login data */
+"Saved Logins" = "Сакланган логиннар";
+

--- a/Shared/tt.lproj/ClearPrivateDataConfirm.strings
+++ b/Shared/tt.lproj/ClearPrivateDataConfirm.strings
@@ -1,0 +1,9 @@
+/* The cancel button when confirming clear private data. */
+"Cancel" = "Баш тарту";
+
+/* The button that clears private data. */
+"OK" = "ОК";
+
+/* Description of the confirmation dialog shown when a user tries to clear their private data. */
+"This action will clear all of your private data. It cannot be undone." = "Бу гамәл барлык хосусый мәгълүматларыгызны чистартачак. Бу гамәлне кире кайтарып булмый.";
+

--- a/Shared/tt.lproj/Default Browser.strings
+++ b/Shared/tt.lproj/Default Browser.strings
@@ -1,0 +1,30 @@
+/* Button string to open settings that allows user to switch their default browser to Firefox. */
+"DefaultBrowserCard.Button" = "Көйләүләргә күчү";
+
+/* Button string to learn how to set your default browser. */
+"DefaultBrowserCard.Button.v2" = "Ничеклеген белү";
+
+/* Description for small card shown that allows user to switch their default browser to Firefox. */
+"DefaultBrowserCard.Description" = "Вебсайтлардан, эл. почталардан һәм хәбәрләрдән сылтамаларны автоматик рәвештә Firefox'та ачу.";
+
+/* Title for small card shown that allows user to switch their default browser to Firefox. */
+"DefaultBrowserCard.Title" = "Башка браузерны төп браузер итү";
+
+/* Button string to open settings that allows user to switch their default browser to Firefox. */
+"DefaultBrowserOnboarding.Button" = "Көйләүләргә күчү";
+
+/* Description for default browser onboarding card. */
+"DefaultBrowserOnboarding.Description1" = "1. Көйләүләргә күчү";
+
+/* Description for default browser onboarding card. */
+"DefaultBrowserOnboarding.Description2" = "2. Төп браузер кушымтасына басыгыз";
+
+/* Description for default browser onboarding card. */
+"DefaultBrowserOnboarding.Description3" = "3. Firefox-ны сайлагыз";
+
+/* Text for the screenshot of the iOS system settings page for Firefox. */
+"DefaultBrowserOnboarding.Screenshot" = "Төп браузер кушымтасы";
+
+/* Menu option for setting Firefox as default browser. */
+"Settings.DefaultBrowserMenuItem" = "Стандарт браузер итеп билгеләү";
+

--- a/Shared/tt.lproj/ErrorPages.strings
+++ b/Shared/tt.lproj/ErrorPages.strings
@@ -1,0 +1,6 @@
+/* Shown in error pages for files that can't be shown and need to be downloaded. */
+"Open in Safari" = "Safari-дә ачу";
+
+/* Shown in error pages on a button that will try to load the page again */
+"Try again" = "Янәдән тырышып карау";
+

--- a/Shared/tt.lproj/FindInPage.strings
+++ b/Shared/tt.lproj/FindInPage.strings
@@ -1,0 +1,12 @@
+/* Done button in Find in Page Toolbar. */
+"Done" = "Әзер";
+
+/* Text selection menu item */
+"Find in Page" = "Биттән табу";
+
+/* Accessibility label for next result button in Find in Page Toolbar. */
+"Next in-page result" = "Биттәге киләсе нәтиҗә";
+
+/* Accessibility label for previous result button in Find in Page Toolbar. */
+"Previous in-page result" = "Биттәге үткән нәтиҗә";
+

--- a/Shared/tt.lproj/HistoryPanel.strings
+++ b/Shared/tt.lproj/HistoryPanel.strings
@@ -1,0 +1,3 @@
+/* Action button for deleting history entries in the history panel. */
+"Delete" = "Бетерү";
+

--- a/Shared/tt.lproj/Intro.strings
+++ b/Shared/tt.lproj/Intro.strings
@@ -1,0 +1,69 @@
+/* Description for the first item in the table related to automatic privacy */
+"Intro.Slides.Automatic.Privacy.Description" = "Күзәтүдән көчәйтелгән саклау зыянлы программаларны блоклый һәм күзәтүчеләрне туктата.";
+
+/* Title for the first item in the table related to automatic privacy */
+"Intro.Slides.Automatic.Privacy.Title" = "Автоматик хосусыйлык";
+
+/* Next button on the first intro screen. */
+"Intro.Slides.Button.Next" = "Киләсе";
+
+/* Sign in to Firefox account button on second intro screen. */
+"Intro.Slides.Button.SignIn" = "Керү";
+
+/* Sign up to Firefox account button on second intro screen. */
+"Intro.Slides.Button.SignUp" = "Теркәлү";
+
+/* Description for the second item in the table related to fast searching via address bar */
+"Intro.Slides.Fast.Search.Description" = "Эзләү тәкъдимнәре вебсайтларга тизрәк илтә.";
+
+/* Title for the second item in the table related to fast searching via address bar */
+"Intro.Slides.Fast.Search.Title" = "Тиз эзләү";
+
+/* Description for the first item in the table related to syncing data (bookmarks, history) via firefox account between devices */
+"Intro.Slides.Firefox.Account.Sync.Description" = "Бу җиһаздагы Firefox-ка кыстыргычлар, тарих һәм серсүзләрне китерү.";
+
+/* Title for the first item in the table related to syncing data (bookmarks, history) via firefox account between devices */
+"Intro.Slides.Firefox.Account.Sync.Title" = "Firefox-ны җиһазлар арасында синхронлау";
+
+/* Description for the 'Mail' panel in the First Run tour. */
+"Intro.Slides.Mail.Description" = "Firefox белән теләсә кайсы эл. почта кушымтасын куллана аласыз — Mail-ны гына түгел.";
+
+/* Title for the fourth panel 'Mail' in the First Run tour. */
+"Intro.Slides.Mail.Title" = "Почтагызны көйләп була";
+
+/* Description for the 'Private Browsing' panel in the First Run tour. */
+"Intro.Slides.Private.Description" = "Хосусый гизү режимына күчү өчен битлек тамгасына басыгыз.";
+
+/* Title for the third panel 'Private Browsing' in the First Run tour. */
+"Intro.Slides.Private.Title" = "Күзәтеп торалар дип борчылмыйча гизегез";
+
+/* Description for the third item in the table related to safe syncing with a firefox account */
+"Intro.Slides.Safe.Sync.Description" = "Сез Firefox-ны кулланган һәр җирдә дә логиннарыгыз һәм мәгълүматларыгыз имин булсын.";
+
+/* Title for the third item in the table related to safe syncing with a firefox account */
+"Intro.Slides.Safe.Sync.Title" = "Хәвефсез синхронлау";
+
+/* Description for the 'Favorite Search Engine' panel in the First Run tour. */
+"Intro.Slides.Search.Description" = "Башка берәр нәрсә эзлисезме? Көйләүләргә кереп, стандарт итеп башка бер эзләү системасын сайлый (яки үзегезнекен өсти) аласыз.";
+
+/* Title for the second  panel 'Search' in the First Run tour. */
+"Intro.Slides.Search.Title" = "Сезнең эзләү, cезнең кагыйдәләр";
+
+/* Description for the 'Sync' panel in the First Run tour. */
+"Intro.Slides.TrailheadSync.Description" = "Синхронлау һәм күбрәк мөмкинлекләргә ирешү өчен хисабыгызга керегез.";
+
+/* Title for the second panel 'Sync' in the First Run tour. */
+"Intro.Slides.TrailheadSync.Title.v2" = "Кыстыргычларыгыз, тарих һәм серсүзләрегезне телефоныгызга синхронлагыз.";
+
+/* Description for the 'Welcome' panel in the First Run tour. */
+"Intro.Slides.Welcome.Description.v2" = "Тиз, хосусый һәм сезнең яклы.";
+
+/* Title for the first panel 'Welcome' in the First Run tour. */
+"Intro.Slides.Welcome.Title.v2" = "Firefox-ка рәхим итегез";
+
+/* See http://mzl.la/1T8gxwo */
+"Start Browsing" = "Гизүне башлау";
+
+/* The button that opens the sign in page for sync. See http://mzl.la/1T8gxwo */
+"Turn on Sync…" = "Синхронлауны кабызу…";
+

--- a/Shared/tt.lproj/Localizable.strings
+++ b/Shared/tt.lproj/Localizable.strings
@@ -1,0 +1,1481 @@
+/* Button for smaller reader font size. Keep this extremely short! This is shown in the reader mode toolbar. */
+"-" = "-";
+
+/* Button for larger reader font size. Keep this extremely short! This is shown in the reader mode toolbar. */
+"+" = "+";
+
+/* Authentication prompt message with no realm. Parameter is the hostname of the site */
+"A username and password are being requested by %@." = "%@ кулланучы исемен һәм серсүзен сорый.";
+
+/* Authentication prompt message with a realm. First parameter is the hostname. Second is the realm string */
+"A username and password are being requested by %@. The site says: %@" = "%1$@ кулланучы исемен һәм серсүзен сорый. Сайт әйтә: %2$@";
+
+/* Button for reader mode font size. Keep this extremely short! This is shown in the reader mode toolbar. */
+"Aa" = "Аа";
+
+/* About settings section title */
+"About" = "Хакында";
+
+/* The title for the pinning a topsite action */
+"ActivityStream.ContextMenu.PinTopsite" = "Төп сайтларга беркетү";
+
+/* The title for removing a pinned topsite action */
+"ActivityStream.ContextMenu.RemovePinTopsite" = "Беркетелгән сайтны бетерү";
+
+/* The description of a highlight if it is a site the user has bookmarked */
+"ActivityStream.Highlights.Bookmark" = "Кыстыргычларга өстәлде";
+
+/* The description of a highlight if it is a site the user has visited */
+"ActivityStream.Highlights.Visited" = "Каралган";
+
+/* Section title label for recently bookmarked websites */
+"ActivityStream.NewRecentBookmarks.Title" = "Соңгы кыстыргычлар";
+
+/* The link that shows more Pocket trending stories */
+"ActivityStream.Pocket.MoreLink" = "Күбрәк";
+
+/* Section title label for Recommended by Pocket section */
+"ActivityStream.Pocket.SectionTitle" = "Pocket-та популяр";
+
+/* The description of a Pocket Story */
+"ActivityStream.Pocket.Trending" = "Популяр";
+
+/* Section title label for recently visited websites */
+"ActivityStream.RecentHistory.Title" = "Соңгы каралган";
+
+/* label showing how many rows of topsites are shown. %d represents a number */
+"ActivityStream.TopSites.RowCount" = "Юллар: %d";
+
+/* The title for the setting page which lets you select the number of top site rows */
+"ActivityStream.TopSites.RowSettingFooter" = "Юллар саны";
+
+/* Section title label for Top Sites */
+"ActivityStream.TopSites.SectionTitle" = "Еш каралганнар";
+
+/* Accessibility label for the Add Tab button in the Tab Tray. */
+"Add Tab" = "Таб өстәү";
+
+/* Accessibility label for action adding current page to reading list.
+   Name for button adding current article to reading list in reader mode */
+"Add to Reading List" = "Уку исемлегенә өстәү";
+
+/* Accessibility message e.g. spoken by VoiceOver after the current page gets added to the Reading List using the Reader View button, e.g. by long-pressing it or by its accessibility custom action. */
+"Added page to Reading List" = "Сәһифә уку исемлегенә өстәлде";
+
+/* Button to dismiss the 'Add Pass Failed' alert.  See https://support.apple.com/HT204003 for context on Wallet. */
+"AddPass.Error.Dismiss" = "ОК";
+
+/* Text of the 'Add Pass Failed' alert.  See https://support.apple.com/HT204003 for context on Wallet. */
+"AddPass.Error.Message" = "Серсүзне Wallet-ка өстәгәндә хата килеп чыкты. Зинһар соңрак тагын бер кат тырышып карагыз.";
+
+/* Title of the 'Add Pass Failed' alert. See https://support.apple.com/HT204003 for context on Wallet. */
+"AddPass.Error.Title" = "Серсүзне өстәп булмады";
+
+/* Accessibility label for address and search field, both words (Address, Search) are therefore nouns. */
+"Address and Search" = "Адрес һәм Эзләү";
+
+/* Used as a button label for crash dialog prompt */
+"Always Send" = "Һәрвакыт җибәрү";
+
+/* Tile title for Amazon */
+"Amazon" = "Amazon";
+
+/* Authentication prompt title */
+"Authentication required" = "Аутентификация таләп ителә";
+
+/* Accessibility label for the Back button in the tab toolbar. */
+"Back" = "Кире";
+
+/* Block pop-up windows setting */
+"Block Pop-up Windows" = "Калкып чыгучы тәрәзәләрне блоклау";
+
+/* The header title for the fields when editing a Bookmark */
+"Bookmark.BookmarkDetail.FieldsHeader.Bookmark.Title" = "Кыстыргыч";
+
+/* The header title for the fields when editing a Folder */
+"Bookmark.BookmarkDetail.FieldsHeader.Folder.Title" = "Папка";
+
+/* The label for the Title field when editing a bookmark */
+"Bookmark.DetailFieldTitle.Label" = "Исем";
+
+/* The label for the URL field when editing a bookmark */
+"Bookmark.DetailFieldURL.Label" = "URL";
+
+/* Toggle bookmarks syncing setting */
+"Bookmarks" = "Кыстыргычлар";
+
+/* The button on the snackbar to edit a bookmark after adding it. */
+"Bookmarks.Edit.Button" = "Үзгәртү";
+
+/* The button to edit a bookmark */
+"Bookmarks.EditBookmark.Label" = "Кыстыргычны үзгәртү";
+
+/* The button to edit a folder */
+"Bookmarks.EditFolder.Label" = "Папканы үзгәртү";
+
+/* The label to show the location of the folder where the bookmark is located */
+"Bookmarks.Folder.Label" = "Папка";
+
+/* The label for the location of the new folder */
+"Bookmarks.FolderLocation.Label" = "Урнашу";
+
+/* The label for the title of the new folder */
+"Bookmarks.FolderName.Label" = "Папка исеме";
+
+/* The button to create a new bookmark */
+"Bookmarks.NewBookmark.Label" = "Яңа кыстыргыч";
+
+/* The button to create a new folder */
+"Bookmarks.NewFolder.Label" = "Яңа папка";
+
+/* The button to create a new separator */
+"Bookmarks.NewSeparator.Label" = "Яңа аергыч";
+
+/* The label for the title of a bookmark */
+"Bookmarks.Title.Label" = "Баш исем";
+
+/* The label for the URL of a bookmark */
+"Bookmarks.URL.Label" = "URL";
+
+/* Status label for the empty Bookmarks state. */
+"BookmarksPanel.EmptyState.Title" = "Сез саклаган кыстыргычлар монда күрсәтеләчәк.";
+
+/* Describes the date on which the breach occurred */
+"BreachAlerts.BreachDate" = "Бу югалту килеп чыккан вакыт";
+
+/* Link to monitor.firefox.com to learn more about breached passwords */
+"BreachAlerts.LearnMoreButton" = "Күбрәк белү";
+
+/* Leads to a link to the breached website */
+"BreachAlerts.Link" = "Күчү";
+
+/* Title for the Breached Login Detail View. */
+"BreachAlerts.Title" = "Вебсайтның бозылуы";
+
+/* Accessibility label for brightness adjustment slider in Reader Mode display settings */
+"Brightness" = "Яктылык";
+
+/* Label for Cancel button */
+"Cancel" = "Баш тарту";
+
+/* Accessibility hint for the color theme setting buttons in reader mode display settings */
+"Changes color theme." = "Төс темасын үзгәртә.";
+
+/* Accessibility hint for the font type buttons in reader mode display settings */
+"Changes font type." = "Шрифт төрен үзгәртә.";
+
+/* The button to open a new tab with the copied link */
+"ClipboardToast.GoToCopiedLink.Button" = "Күчү";
+
+/* Message displayed when the user has a copied link on the clipboard */
+"ClipboardToast.GoToCopiedLink.Title" = "Копияләнгән сылтамага күчәргәме?";
+
+/* Accessibility label for action denoting closing a tab in tab list (tray) */
+"Close" = "Ябу";
+
+/* Accessibility label (used by assistive technology) notifying the user that the tab is being closed. */
+"Closing tab" = "Таб ябыла";
+
+/* Accessibility label for Desktop Computer (PC) image in remote tabs list */
+"computer" = "компьютер";
+
+/* Context menu item for bookmarking a link URL */
+"ContextMenu.BookmarkLinkButtonTitle" = "Кыстыргычларга өстәү";
+
+/* The button text in the Button Toast for switching to a fresh New Private Tab. */
+"ContextMenu.ButtonToast.NewPrivateTabOpened.ButtonText" = "Күчү";
+
+/* The label text in the Button Toast for switching to a fresh New Private Tab. */
+"ContextMenu.ButtonToast.NewPrivateTabOpened.LabelText" = "Яңа хосусый таб ачылды";
+
+/* The button text in the Button Toast for switching to a fresh New Tab. */
+"ContextMenu.ButtonToast.NewTabOpened.ButtonText" = "Күчү";
+
+/* The label text in the Button Toast for switching to a fresh New Tab. */
+"ContextMenu.ButtonToast.NewTabOpened.LabelText" = "Яңа таб ачылды";
+
+/* Context menu item for copying an image to the clipboard */
+"ContextMenu.CopyImageButtonTitle" = "Рәсемне күчереп алу";
+
+/* Context menu item for copying an image URL to the clipboard */
+"ContextMenu.CopyImageLinkButtonTitle" = "Рәсем сылтамасын копияләү";
+
+/* Context menu item for copying a link URL to the clipboard */
+"ContextMenu.CopyLinkButtonTitle" = "Сылтаманы күчереп алу";
+
+/* Context menu item for downloading a link URL */
+"ContextMenu.DownloadLinkButtonTitle" = "Сылтаманы йөкләп алу";
+
+/* Context menu item for opening a link in a new tab */
+"ContextMenu.OpenInNewTabButtonTitle" = "Яңа табта ачу";
+
+/* Context menu item for saving an image */
+"ContextMenu.SaveImageButtonTitle" = "Рәсемне саклау";
+
+/* Context menu item for sharing a link URL */
+"ContextMenu.ShareLinkButtonTitle" = "Сылтаманы уртаклашу";
+
+/* Accessibility message e.g. spoken by VoiceOver after adding current webpage to the Reading List failed. */
+"Could not add page to Reading list" = "Cәхифәне уку исемлегенә өстәп булмады";
+
+/* Accessibility message e.g. spoken by VoiceOver after the user wanted to add current page to the Reading List and this was not done, likely because it already was in the Reading List, but perhaps also because of real failures. */
+"Could not add page to Reading List. Maybe it’s already there?" = "Cәхифәне уку исемлегенә өстәп булмады. Бәлки ул анда инде өстәлгән булгандыр?";
+
+/* Error message that is shown in settings when there was a problem loading */
+"Could not load page." = "Битне йөкләп булмады.";
+
+/* Title for the new dark mode change in the version 22 app release. */
+"CoverSheet.v22.DarkMode.Title" = "Караңгы тема хәзер үз эченә караңгы клавиатура һәм караңгы башлангыч экранны да ала.";
+
+/* Description for the new ETP mode i.e. standard vs strict */
+"CoverSheet.v24.ETP.Description" = "Программа эчендә булган Күзәтүдән көчәйтелгән сак рекламаның артыгыздан йөрүен туктатырга ярдәм итә. Тагын да күбрәк күзәтүчеләрне, рекламаларны, калкыч чыгучы тәрәзәләрне блоклау өчен, «Катгый» режимын кабызыгыз.";
+
+/* Text for the new ETP settings button */
+"CoverSheet.v24.ETP.Settings.Button" = "Көйләүләргә күчү";
+
+/* Title for the new ETP mode i.e. standard vs strict */
+"CoverSheet.v24.ETP.Title" = "Реклама күзәтүеннән саклау";
+
+/* See http://mzl.la/1Qtkf0j */
+"Create an account" = "Хисап булдыру";
+
+/* Dark theme setting in Reading View settings */
+"Dark" = "Караңгы";
+
+/* Accessibility label for button decreasing font size in display settings of reader mode */
+"Decrease text size" = "Текст үлчәмен кечерәйтү";
+
+/* Accessibility label for default search engine setting.
+   Title for default search engine picker.
+   Title for default search engine settings section. */
+"Default Search Engine" = "Стандарт эзләү системасы";
+
+/* Name for display settings button in reader mode. Display in the meaning of presentation, not monitor. */
+"Display Settings" = "Күрсәтелү көйләүләре";
+
+/* Used as a button label for crash dialog prompt */
+"Don’t Send" = "Җибәрмәү";
+
+/* Done button on left side of the Settings view controller title bar */
+"Done" = "Әзер";
+
+/* Panel accessibility label */
+"Downloads" = "Йөкләп алулар";
+
+/* The label of the button the user will press to start downloading a file */
+"Downloads.Alert.DownloadNow" = "Хәзер йөкләү";
+
+/* Button confirming the cancellation of the download. */
+"Downloads.CancelDialog.Cancel" = "Баш тарту";
+
+/* Alert dialog body when the user taps the cancel download icon. */
+"Downloads.CancelDialog.Message" = "Бу йөкләүдән баш тартуны раслыйсызмы?";
+
+/* Button declining the cancellation of the download. */
+"Downloads.CancelDialog.Resume" = "Дәвам итү";
+
+/* Alert dialog title when the user taps the cancel download icon. */
+"Downloads.CancelDialog.Title" = "Йөкләүдән баш тарту";
+
+/* The message displayed to a user when they try and perform the download of an asset that Firefox cannot currently handle. */
+"Downloads.Error.Message" = "Firefox-та йөкләп алулар әлегә эшләми.";
+
+/* The label text in the Download Cancelled toast for showing confirmation that the download was cancelled. */
+"Downloads.Toast.Cancelled.LabelText" = "Йөкләп алудан баш тартылды";
+
+/* The label text in the Download Failed toast for showing confirmation that the download has failed. */
+"Downloads.Toast.Failed.LabelText" = "Йөкләп алып булмады";
+
+/* The button to retry a failed download from the Download Failed toast. */
+"Downloads.Toast.Failed.RetryButton" = "Янәдән";
+
+/* The button to open a new tab with the Downloads home panel */
+"Downloads.Toast.GoToDownloads.Button" = "Йөкләп алулар";
+
+/* The description text in the Download progress toast for showing the number of files when multiple files are downloading. */
+"Downloads.Toast.MultipleFiles.DescriptionText" = "1 / %d файл";
+
+/* The description text in the Download progress toast for showing the number of files (1$) and download progress (2$). This string only consists of two placeholders for purposes of displaying two other strings side-by-side where 1$ is Downloads.Toast.MultipleFiles.DescriptionText and 2$ is Downloads.Toast.Progress.DescriptionText. This string should only consist of the two placeholders side-by-side separated by a single space and 1$ should come before 2$ everywhere except for right-to-left locales. */
+"Downloads.Toast.MultipleFilesAndProgress.DescriptionText" = "%1$@ %2$@";
+
+/* The description text in the Download progress toast for showing the downloaded file size (1$) out of the total expected file size (2$). */
+"Downloads.Toast.Progress.DescriptionText" = "%1$@/%2$@";
+
+/* Action button for deleting downloaded files in the Downloads panel. */
+"DownloadsPanel.Delete.Title" = "Бетерү";
+
+/* Title for the Downloads Panel empty state. */
+"DownloadsPanel.EmptyState.Title" = "Йөкләнгән файллар монда күрсәтеләчәк.";
+
+/* Action button for sharing downloaded files in the Downloads panel. */
+"DownloadsPanel.Share.Title" = "Уртаклашу";
+
+/* Text message in the settings table view */
+"Enter your password to connect" = "Тоташу өчен серсүзне кертегез";
+
+/* Label for button to perform advanced actions on the error page */
+"ErrorPages.Advanced.Button" = "Киңәйтелгән";
+
+/* Warning text when clicking the Advanced button on error pages */
+"ErrorPages.AdvancedWarning1.Text" = "Кисәтү: бу сайтка бәйләнеш хәвефсез булуын раслый алмыйбыз.";
+
+/* Title on the certificate error page */
+"ErrorPages.CertWarning.Title" = "Бу бәйләнеш ышанычсыз";
+
+/* Label for button to go back from the error page */
+"ErrorPages.GoBack.Button" = "Кире кайту";
+
+/* Button label to temporarily continue to the site from the certificate error page */
+"ErrorPages.VisitOnce.Button" = "Cайтны барыбер ачу";
+
+/* Question shown to user when tapping a link that opens the App Store app */
+"ExternalLink.AppStore.ConfirmationTitle" = "Бу сылтаманы App Store-да ачу кирәкме?";
+
+/* Question shown to user when tapping an SMS or MailTo link that opens the external app for those. */
+"ExternalLink.AppStore.GenericConfirmationTitle" = "Бу сылтаманы тышкы кушымтада ачу кирәкме?";
+
+/* Tile title for Facebook */
+"Facebook" = "Facebook";
+
+/* Title for firefox about:home page in tab history list */
+"Firefox.HomePage.Title" = "Firefox баш бит";
+
+/* Accessibility Label for the tab toolbar Forward button */
+"Forward" = "Алга";
+
+/* Label stating how to disconnect account */
+"FxA.AccountVerificationDetails" = "Ялгыш эл. почтамы? Түбәндәрәк элемтәне өзеп, янәдән башлагыз.";
+
+/* Label stating your account is not verified */
+"FxA.AccountVerificationRequired" = "Хисапны раслау кирәк";
+
+/* Message explaining that user needs to check email for Firefox Account verfication link. */
+"FxA.AccountVerificationRequiredSurface" = "%@ адресын раслау кирәк. Firefox җибәргән раслау сылтамасы өчен эл. почтагызны тикшерегез.";
+
+/* Button label to connect another device to Sync */
+"FxA.ConnectAnotherDevice" = "Башка бер җиһазны тоташтыру";
+
+/* Settings section title for Firefox Account */
+"FxA.FirefoxAccount" = "Firefox Хисабы";
+
+/* Button label to go to Firefox Account settings */
+"FxA.ManageAccount" = "Хисап һәм җиһазлар белән идарә итү";
+
+/* Label when no internet is present */
+"FxA.NoInternetConnection" = "Интернетка тоташу юк";
+
+/* Button label to open Sync preferences */
+"FxA.OpenSyncPreferences" = "Синхронлау көйләүләрен ачу";
+
+/* Instructions shown on qr code scanning view */
+"fxa.qr-scanning-view.instructions" = "<b>firefox.com/pair</b> адресында күрсәтелгән QR кодны сканерлагыз";
+
+/* Remove button is displayed on firefox account page under certain scenarios where user would like to remove their account. */
+"FxA.RemoveAccount" = "Бетерү";
+
+/* Description string for alert view that gets presented when user tries to remove an account. */
+"FxA.RemoveAccountAlertMessage" = "Башка кулланучы буларак керү өчен, бу җиһаз белән бәйле Firefox хисап язмасын бетерегез.";
+
+/* Remove account alert is the final confirmation before user removes their firefox account */
+"FxA.RemoveAccountAlertTitle" = "Хисапны бетерү";
+
+/* Button label to resend email */
+"FxA.ResendEmail" = "Хатны яңадан җибәрү";
+
+/* FxA sign in view subtitle */
+"fxa.signin.camera-signin" = "Камерагыз ярдәмендә керегез";
+
+/* FxA sign in create account label. */
+"fxa.signin.create-account-pt-1" = "Хисап булдырып Сез Firefox-ны җиһазлар арасында синхронлый аласыз.";
+
+/* FxA sign in create account label. This will be linked to the site to create an account. */
+"fxa.signin.create-account-pt-2" = "Firefox хисабын булдыру.";
+
+/* FxA sign in view qr code instructions */
+"fxa.signin.qr-link-instruction" = "Компьютерыгызда Firefox-ны ачыгыз һәм firefox.com/pair адресына күчегез";
+
+/* FxA sign in view qr code scan button */
+"fxa.signin.ready-to-scan" = "Сканерларга әзер";
+
+/* FxA sign in view title */
+"fxa.signin.turn-on-sync" = "Синхронлауны кабызу";
+
+/* FxA sign in view email login button */
+"fxa.signin.use-email-instead" = "Моның урынына эл. почта куллану";
+
+/* Button label to sign into Sync */
+"FxA.SignIntoSync" = "Синхронлауга керү";
+
+/* Label explaining what sync does */
+"FxA.SyncExplain" = "Башка җиһазларыгыздан таб, кыстыргыч һәм серсүзләрегезне алу.";
+
+/* Button label to Sync your Firefox Account */
+"FxA.SyncNow" = "Хәзер синхронлау";
+
+/* Call to action for sign into sync button */
+"FxA.TakeYourWebWithYou" = "Интернетыгызны үзегез белән алыгыз";
+
+/* Title of a notification displayed when another device has connected to FxA. %@ refers to the name of the newly connected device. */
+"FxAPush_DeviceConnected_body" = "Firefox Синхронлау яңа җиһазга тоташтырылды: %@";
+
+/* Title of a notification displayed when another device has connected to FxA. */
+"FxAPush_DeviceConnected_title" = "Синхронлау тоташтырылды";
+
+/* Body of a notification displayed when named device has been disconnected from FxA. %@ refers to the name of the disconnected device. */
+"FxAPush_DeviceDisconnected_body" = "%@ уңышлы өзелде.";
+
+/* Body of a notification displayed when this device has been disconnected from FxA by another device. */
+"FxAPush_DeviceDisconnected_ThisDevice_body" = "Бу җиһаз Firefox синхронлау хезмәтеннән өзелде.";
+
+/* Title of a notification displayed when this device has been disconnected by another device. */
+"FxAPush_DeviceDisconnected_ThisDevice_title" = "Синхронлау тоташмаган";
+
+/* Title of a notification displayed when named device has been disconnected from FxA. */
+"FxAPush_DeviceDisconnected_title" = "Синхронлау тоташмаган";
+
+/* Body of a notification displayed when unnamed device has been disconnected from FxA. */
+"FxAPush_DeviceDisconnected_UnknownDevice_body" = "Җиһаз Firefox синхронлау хезмәтеннән өзелде";
+
+/* A re-worded offer about Sync, displayed when the Sync home panel is empty, that emphasizes one-way data transfer, not syncing. */
+"Get your open tabs, bookmarks, and passwords from your other devices." = "Башка җиһазларыгыздан ачык таб, кыстыргыч һәм серүзләрегезне алу.";
+
+/* Show the SUMO support page from the Support section in the settings. see http://mzl.la/1dmM8tZ */
+"Help" = "Ярдәм";
+
+/* Toggle history syncing setting */
+"History" = "Тарих";
+
+/* Title for button in the history panel to clear recent history */
+"HistoryPanel.ClearHistoryButtonTitle" = "Соңгы тарихны чистарту…";
+
+/* Option title to clear all browsing history. */
+"HistoryPanel.ClearHistoryMenuOptionEverything" = "Барысын да";
+
+/* Button to perform action to clear history for the last hour */
+"HistoryPanel.ClearHistoryMenuOptionTheLastHour" = "Соңгы сәгать";
+
+/* Button to perform action to clear history for today only */
+"HistoryPanel.ClearHistoryMenuOptionToday" = "Бүген";
+
+/* Button to perform action to clear history for yesterday and today */
+"HistoryPanel.ClearHistoryMenuOptionTodayAndYesterday" = "Бүген һәм кичә";
+
+/* Title for popup action menu to clear recent history. */
+"HistoryPanel.ClearHistoryMenuTitle" = "Соңгы тарихны чистарту гизү тарихын, кукиларны һәм башка браузер мәгълүматларын бетерәчәк.";
+
+/* Title for the History Panel empty state. */
+"HistoryPanel.EmptyState.Title" = "Соңгы каралган вебсайтлар монда күрсәтеләчәк.";
+
+/* Description for the empty synced tabs null state in the History Panel */
+"HistoryPanel.EmptySyncedTabsNullState.Description" = "Башка җиһазларыгыздан табларыгыз монда күрсәтеләчәк.";
+
+/* Description for the empty synced tabs 'not signed in' state in the History Panel */
+"HistoryPanel.EmptySyncedTabsPanelNotSignedInState.Description" = "Башка җиһазларыгыздагы таблар исемлеген карау өчен керегез.";
+
+/* Description for the empty synced tabs 'not yet verified' state in the History Panel */
+"HistoryPanel.EmptySyncedTabsPanelNotYetVerifiedState.Description" = "Хисабыгызны раслау кирәк.";
+
+/* Description for the empty synced tabs 'single device Sync' state in the History Panel */
+"HistoryPanel.EmptySyncedTabsPanelSingleDeviceSyncState.Description" = "Башка җиһазларыгыздагы табларны монда күрәсегез киләме?";
+
+/* Description for the empty synced tabs 'tab sync disabled' state in the History Panel */
+"HistoryPanel.EmptySyncedTabsPanelTabSyncDisabledState.Description" = "Башка җиһазларыгыздагы таблар исемлеген карау өчен табларны синхронлауны кабызыгыз.";
+
+/* Title for the empty synced tabs state in the History Panel */
+"HistoryPanel.EmptySyncedTabsState.Title" = "Firefox Sync";
+
+/* Title for the Back to History button in the History Panel */
+"HistoryPanel.HistoryBackButton.Title" = "Тарих";
+
+/* Title for the Recently Closed button in the History Panel */
+"HistoryPanel.RecentlyClosedTabsButton.Title" = "Күптән түгел ябылган";
+
+/* Description that corresponds with a number of devices connected for the Synced Tabs Cell in the History Panel */
+"HistoryPanel.SyncedTabsCell.Description.Pluralized" = "%d җиһаз тоташкан";
+
+/* Title for the Synced Tabs Cell in the History Panel */
+"HistoryPanel.SyncedTabsCell.Title" = "Синхронланган җиһазлар";
+
+/* Button cancelling changes setting the home page for the first time. */
+"HomePage.Set.Dialog.Cancel" = "Баш тарту";
+
+/* Alert dialog body when the user opens the home page for the first time. */
+"HomePage.Set.Dialog.Message" = "Моны Сез һәрвакыт Көйләүләрдә үзгәртә аласыз";
+
+/* Button accepting changes setting the home page for the first time. */
+"HomePage.Set.Dialog.OK" = "Баш битне урнаштыру";
+
+/* Alert dialog title when the user opens the home page for the first time. */
+"HomePage.Set.Dialog.Title" = "Бу веб-битне баш битегез буларак кулланасыгыз киләме?";
+
+/* The title for the Bookmark context menu action for sites in Home Panels */
+"HomePanel.ContextMenu.Bookmark" = "Кыстыргыч";
+
+/* The title for the Delete from History context menu action for sites in Home Panels */
+"HomePanel.ContextMenu.DeleteFromHistory" = "Тарихтан бетерү";
+
+/* The title for the Open in New Private Tab context menu action for sites in Home Panels */
+"HomePanel.ContextMenu.OpenInNewPrivateTab" = "Яңа хосусый табта ачу";
+
+/* The title for the Open in New Tab context menu action for sites in Home Panels */
+"HomePanel.ContextMenu.OpenInNewTab" = "Яңа табта ачу";
+
+/* The title for the Remove context menu action for sites in Home Panels */
+"HomePanel.ContextMenu.Remove" = "Бетерү";
+
+/* The title for the Remove Bookmark context menu action for sites in Home Panels */
+"HomePanel.ContextMenu.RemoveBookmark" = "Кыстыргычны бетерү";
+
+/* The title for the Share context menu action for sites in Home Panels */
+"HomePanel.ContextMenu.Share" = "Уртаклашу";
+
+/* Label to display in the Discoverability overlay for keyboard shortcuts */
+"Hotkeys.Back.DiscoveryTitle" = "Кире";
+
+/* Label to display in the Discoverability overlay for keyboard shortcuts */
+"Hotkeys.CloseTab.DiscoveryTitle" = "Битне ябу";
+
+/* Label to display in the Discoverability overlay for keyboard shortcuts */
+"Hotkeys.Find.DiscoveryTitle" = "Табу";
+
+/* Label to display in the Discoverability overlay for keyboard shortcuts */
+"Hotkeys.Forward.DiscoveryTitle" = "Алга";
+
+/* Label to display in the Discoverability overlay for keyboard shortcuts */
+"Hotkeys.NewPrivateTab.DiscoveryTitle" = "Яңа хосусый таб";
+
+/* Label to display in the Discoverability overlay for keyboard shortcuts */
+"Hotkeys.NewTab.DiscoveryTitle" = "Яңа таб";
+
+/* Label to switch to normal browsing mode */
+"Hotkeys.NormalMode.DiscoveryTitle" = "Нормаль гизү режимы";
+
+/* Label to switch to private browsing mode */
+"Hotkeys.PrivateMode.DiscoveryTitle" = "Хосусый гизү режимы";
+
+/* Label to display in the Discoverability overlay for keyboard shortcuts */
+"Hotkeys.Reload.DiscoveryTitle" = "Битне яңадан йөкләү";
+
+/* Label to display in the Discoverability overlay for keyboard shortcuts */
+"Hotkeys.SelectLocationBar.DiscoveryTitle" = "Адрес юлын сайлау";
+
+/* Label to display in the Discoverability overlay for keyboard shortcuts */
+"Hotkeys.ShowNextTab.DiscoveryTitle" = "Киләсе табны күрсәтү";
+
+/* Label to display in the Discoverability overlay for keyboard shortcuts */
+"Hotkeys.ShowPreviousTab.DiscoveryTitle" = "Үткән табны күрсәтү";
+
+/* Accessibility label for button increasing font size in display settings of reader mode */
+"Increase text size" = "Текст үлчәмен зурайту";
+
+/* Relative time for a tab that was visited within the last few moments. */
+"just now" = "хәзер генә";
+
+/* History tableview section header */
+"Last month" = "Үткән айда";
+
+/* Remote tabs last synced time. Argument is the relative date string. */
+"Last synced: %@" = "Соңгы синхронлау: %@";
+
+/* History tableview section header */
+"Last week" = "Үткән атнада";
+
+/* Settings item that opens a tab containing the licenses. See http://mzl.la/1NSAWCG */
+"Licenses" = "Лицензияләр";
+
+/* Light theme setting in Reading View settings */
+"Light" = "Ачык";
+
+/* Link for going to the non-reader page when the reader view could not be loaded. This message will appear only when sharing to Firefox reader mode from another app. */
+"Load original page" = "Башлангыч битне йөкләү";
+
+/* Message displayed when the reader mode page is loading. This message will appear only when sharing to Firefox reader mode from another app. */
+"Loading content…" = "Эчтәлекне йөкләү…";
+
+/* Authentication prompt log in button */
+"Log in" = "Керү";
+
+/* Toggle logins syncing setting */
+"Logins" = "Логиннар";
+
+/* Login detail view field name for the last modified date */
+"LoginsDetailView.LoginModified" = "Үзгәртелгән";
+
+/* Title for the login detail view */
+"LoginsDetailView.LoginTitle" = "Логин";
+
+/* Button to not save the user's password */
+"LoginsHelper.DontSave.Button" = "Сакламау";
+
+/* Button to not update the user's password */
+"LoginsHelper.DontUpdate.Button" = "Яңартмау";
+
+/* Prompt for saving a login. The first parameter is the username being saved. The second parameter is the hostname of the site. */
+"LoginsHelper.PromptSaveLogin.Title" = "%2$@ өчен %1$@ логины саклансынмы?";
+
+/* Prompt for saving a password with no username. The parameter is the hostname of the site. */
+"LoginsHelper.PromptSavePassword.Title" = "%@ өчен серсүз саклансынмы?";
+
+/* Prompt for updating a login. The first parameter is the hostname for which the password will be updated for. */
+"LoginsHelper.PromptUpdateLogin.Title.OneArg" = "%@ өчен логинны яңарту кирәкме?";
+
+/* Prompt for updating a login. The first parameter is the username for which the password will be updated for. The second parameter is the hostname of the site. */
+"LoginsHelper.PromptUpdateLogin.Title.TwoArg" = "%2$@ өчен %1$@ логины яңартылсынмы?";
+
+/* Button to save the user's password */
+"LoginsHelper.SaveLogin.Button" = "Логинны саклау";
+
+/* Button to update the user's password */
+"LoginsHelper.Update.Button" = "Яңарту";
+
+/* For filtering the login list, search only the login names */
+"LoginsList.LoginsListFilterLogin" = "Логин";
+
+/* For filtering the login list, search both website and login names. */
+"LoginsList.LoginsListFilterSearchAll" = "Бөтенесе";
+
+/* For filtering the login list, search only the website names */
+"LoginsList.LoginsListFilterWebsite" = "Вебсайт";
+
+/* Placeholder test for search box in logins list view. */
+"LoginsList.LoginsListSearchPlaceholder" = "Сөзгеч";
+
+/* Title for the list of logins */
+"LoginsList.Title" = "САКЛАНГАН ЛОГИННАР";
+
+/* Restore Tabs Prompt Description */
+"Looks like Firefox crashed previously. Would you like to restore your tabs?" = "Моңарчы Firefox ватылып алды ахрысы. Табларыгыз яңадан торгызылсынмы?";
+
+/* Name for Mark as read button in reader mode
+   Title for the button that marks a reading list item as read */
+"Mark as Read" = "Укылган дип билгеләү";
+
+/* Name for Mark as unread button in reader mode
+   Title for the button that marks a reading list item as unread */
+"Mark as Unread" = "Укылмаган дип билгеләү";
+
+/* Toast displayed to the user after a bookmark has been added. */
+"Menu.AddBookmark.Confirm" = "Кыстаргыч өстәлде";
+
+/* Toast displayed to the user after adding the item to the Top Sites. */
+"Menu.AddPin.Confirm" = "Төп сайтларга беркетелгән";
+
+/* Toast displayed to the user after adding the item to their reading list. */
+"Menu.AddToReadingList.Confirm" = "Уку исемлегенә өстәлде";
+
+/* The title for the button that lets you copy the url from the location bar. */
+"Menu.Copy.Title" = "Адресны күчереп алу";
+
+/* Toast displayed to user after copy url pressed. */
+"Menu.CopyURL.Confirm" = "URL алмашу буферына копияләнде";
+
+/* A switch to disable enhanced tracking protection inside the menu. */
+"Menu.EnhancedTrackingProtectionOff.Title" = "Бу сайт өчен Күзәтелүдән көчәйтелгән саклау СҮНДЕРЕЛГӘН.";
+
+/* A switch to enable enhanced tracking protection inside the menu. */
+"Menu.EnhancedTrackingProtectionOn.Title" = "Бу сайт өчен Күзәтелүдән көчәйтелгән саклау КАБЫНГАН.";
+
+/* Description for having standard ETP protection with ITP offered in iOS14+ */
+"Menu.EnhancedTrackingProtectionStandardWithITP.Title" = "Firefox cайт-ара һәм социаль челтәр күзәтүчеләрен, криптомайнерләрне һәм браузерның «бармак эзләрен» җыючыларны блоклый.";
+
+/* Description for having strict ETP protection with ITP offered in iOS14+ */
+"Menu.EnhancedTrackingProtectionStrictWithITP.Title" = "Firefox cайт-ара һәм социаль челтәр күзәтүчеләрен, криптомайнерләрне, браузернең «бармак эзләрен җыючыларны һәм күзәтүче эчтәлекләрне блоклый.";
+
+/* Label for the button displayed in the menu used to stop the reload of the webpage */
+"Menu.Library.StopReload" = "Туктату";
+
+/* Label for the button, displayed in the menu, turns on night mode. */
+"Menu.NightModeTurnOn.Label" = "Төнге режимны кабызу";
+
+/* Label for the button, displayed in the menu, hides images on the webpage when pressed. */
+"Menu.NoImageModeBlockImages.Label" = "Рәсемнәрне блоклау";
+
+/* Label for title in page action menu. */
+"Menu.PageActions.Title" = "Бит гамәлләре";
+
+/* The title for the button that lets you paste into the location bar */
+"Menu.Paste.Title" = "Ябыштыру";
+
+/* The title for the button that lets you paste and go to a URL */
+"Menu.PasteAndGo.Title" = "Ябыштыру һәм күчү";
+
+/* Label for the button, displayed in the menu, used to reload the current website without Tracking Protection */
+"Menu.ReloadWithoutTrackingProtection.Title" = "Күзәтелүдән cаклауны сүндереп, әлеге сайтны яңадан ачу";
+
+/* Label for the button, displayed in the menu, used to reload the current website with Tracking Protection enabled */
+"Menu.ReloadWithTrackingProtection.Title" = "Күзәтелүдән саклауны кабызып, сайтны яңадан ачу";
+
+/* Toast displayed to the user after a bookmark has been removed. */
+"Menu.RemoveBookmark.Confirm" = "Кыстаргыч бетерелде";
+
+/* Toast displayed to the user after removing the item from the Top Sites. */
+"Menu.RemovePin.Confirm" = "Төп сайтлардан бетерелде";
+
+/* Toast displayed to the user after a tab has been sent successfully. */
+"Menu.TabSent.Confirm" = "Таб җибәрелде";
+
+/* Title on tracking protection menu for blocked items. */
+"Menu.TrackingProtection.BlockedTitle" = "Блокланган";
+
+/* Message in menu when no trackers blocked. */
+"Menu.TrackingProtection.NoTrackersBlockedTitle" = "Бу биттә билгеле Firefox күзәтүчеләре табылмады.";
+
+/* The title for tracking protection settings */
+"Menu.TrackingProtection.ProtectionSettings.Title" = "Саклау көйләүләре";
+
+/* Title on tracking protection menu showing the domain. eg. Protections for mozilla.org */
+"Menu.TrackingProtection.TitlePrefix" = "%@ өчен саклау";
+
+/* The title that shows the number of content cookies blocked */
+"Menu.TrackingProtectionBlockedContent.Title" = "Күзәтүче эчтәлек";
+
+/* The title that shows the number of social URLs blocked */
+"Menu.TrackingProtectionBlockedSocial.Title" = "Социаль челтәр күзәтүчеләре";
+
+/* Description of the Tracking protection menu when TP is blocking parts of the page */
+"Menu.TrackingProtectionBlocking.Description" = "Firefox бу битнең Сезне күзәтеп торырга мөмкин өлешләрен блоклый.";
+
+/* The description of the Tracking Protection menu item when tracking is enabled */
+"Menu.TrackingProtectionBlockingDisabled.Description" = "Онлайн күзәтүчеләрне блоклау";
+
+/* The title that shows the number of cross-site cookies blocked */
+"Menu.TrackingProtectionCrossSiteCookies.Title" = "Сайт-ара күзәтүче сookie файллары";
+
+/* The title that shows the number of cross-site URLs blocked */
+"Menu.TrackingProtectionCrossSiteTrackers.Title" = "Сайт-ара күзәтеп торучылар";
+
+/* The title that shows the number of cryptomining scripts blocked */
+"Menu.TrackingProtectionCryptominersBlocked.Title" = "Криптомайнерләр";
+
+/* The button that disabled TP for a site. */
+"Menu.TrackingProtectionDisable1.Title" = "Бу сайт өчен сүндерелгән";
+
+/* The confirmation toast once tracking protection has been disabled */
+"Menu.TrackingProtectionDisabled.Title" = "Бу сайт өчен Күзәтелүдән Саклау хәзер сүндерелгән.";
+
+/* A button to enable tracking protection inside the menu. */
+"Menu.TrackingProtectionEnable.Title" = "Күзәтелүдән саклауны кабызу";
+
+/* A button to enable tracking protection inside the menu. */
+"Menu.TrackingProtectionEnable1.Title" = "Бу сайт өчен кабызылган";
+
+/* The confirmation toast once tracking protection has been enabled */
+"Menu.TrackingProtectionEnabled.Title" = "Бу сайт өчен Күзәтелүдән Саклау кабызылган.";
+
+/* The title that shows the number of fingerprinting scripts blocked */
+"Menu.TrackingProtectionFingerprintersBlocked.Title" = "Бармак эзләрен җыючылар (идентификаторлар)";
+
+/* Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners` */
+"Menu.TrackingProtectionListTitle.CrossSiteCookies" = "Блокланган сайт-ара күзәтүче сookie файллары";
+
+/* Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners` */
+"Menu.TrackingProtectionListTitle.Cryptominers" = "Блокланган криптомайнерләр";
+
+/* Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners` */
+"Menu.TrackingProtectionListTitle.Fingerprinters" = "Блокланган бармак эзләрен җыючылар";
+
+/* Title for list of domains blocked by category type. eg.  Blocked `CryptoMiners` */
+"Menu.TrackingProtectionListTitle.Social" = "Блокланган cоциаль челтәр күзәтүчеләре";
+
+/* The description of the Tracking Protection menu item when no scripts are blocked but tracking protection is enabled. */
+"Menu.TrackingProtectionNoBlocking.Description" = "Бу биттә күзәтүче элементлар табылмады.";
+
+/* label for the menu item to show when the website is whitelisted from blocking trackers. */
+"Menu.TrackingProtectionOption.WhiteListOnDescription" = "Бу сайтта Сезнең гамәлләрегезне күзәтеп торырга мөмкин элементлар бар. Алардан саклау сүндерелгән.";
+
+/* label for the menu item that lets you remove a website from the tracking protection whitelist */
+"Menu.TrackingProtectionWhitelistRemove.Title" = "Бу сайт өчен кабызу";
+
+/* The title for the option to view the What's new page. */
+"Menu.WhatsNew.Title" = "Яңалыклар";
+
+/* Accessibility label for Mobile Device image in remote tabs list */
+"mobile device" = "мобиль җиһаз";
+
+/* Accessibility label for the navigation toolbar displayed at the bottom of the screen. */
+"Navigation Toolbar" = "Навигация панеле";
+
+/* Accessibility label for the New Tab button in the tab toolbar.
+   Accessibility Label for the tab toolbar New tab button */
+"New Tab" = "Яңа таб";
+
+/* Restore Tabs Negative Action */
+"No" = "Юк";
+
+/* Message spoken by VoiceOver to indicate that there are no tabs in the Tabs Tray */
+"No tabs" = "Таблар юк";
+
+/* OK button */
+"OK" = "ОК";
+
+/* Restore Tabs Affirmative Action */
+"Okay" = "Ярар";
+
+/* Title for prompt displayed to user after the app crashes */
+"Oops! Firefox crashed" = "Абау! Firefox ватылды";
+
+/* See http://mzl.la/1LXbDOL */
+"Open articles in Reader View by tapping the book icon when it appears in the title bar." = "Мәкаләләрне уку режимында ачу өчен, исем юлында китап тамгачыгы пәйда булгач, аңа басыгыз.";
+
+/* See http://mzl.la/1G7uHo7 */
+"Open Settings" = "Көйләүләрне ачу";
+
+/* Toggle tabs syncing setting */
+"Open Tabs" = "Ачык таблар";
+
+/* Title of the message shown when the user attempts to navigate to an invalid link. */
+"OpenURL.Error.Title" = "Битне ачып булмый";
+
+/* Accessibility label for the Page Options menu button */
+"Page Options Menu" = "Бит көйләүләре менюсы";
+
+/* Password textbox in Authentication prompt */
+"Password" = "Серсүз";
+
+/* Header for the list of credentials table */
+"PasswordAutoFill.PasswordsListTitle" = "Кулланырлык хисап мәгълүматлары:";
+
+/* Title of the extension that shows firefox passwords */
+"PasswordAutoFill.SectionTitle" = "Firefox хисап мәгълүматлары";
+
+/* Button for closing the menu action sheet */
+"PhotonMenu.close" = "Ябу";
+
+/* Privacy section title */
+"Privacy" = "Хосусыйлык";
+
+/* Show Firefox Browser Privacy Policy page from the Privacy section in the settings. See https://www.mozilla.org/privacy/firefox/ */
+"Privacy Policy" = "Хосусыйлык сәясәте";
+
+/* Title for quick-search engines settings section. */
+"Quick-Search Engines" = "Тиз эзләү системалары";
+
+/* Accessibility label for read article in reading list. It's a past participle - functions as an adjective. */
+"read" = "укылган";
+
+/* Accessibility label for the Reader View button */
+"Reader View" = "Уку режимы";
+
+/* Accessibility message e.g. spoken by VoiceOver when Reader Mode becomes available. */
+"ReaderMode.Available.VoiceOverAnnouncement" = "Уку режимы бар";
+
+/* Panel accessibility label */
+"Reading list" = "Уку исемлеге";
+
+/* Title for the Recently Closed Tabs Panel */
+"RecentlyClosedTabsPanel.Title" = "Күптән түгел ябылган";
+
+/* Accessibility Label for the tab toolbar Reload button */
+"Reload" = "Яңарту";
+
+/* Accessibility label for the reload button */
+"Reload page" = "Битне яңадан йөкләү";
+
+/* Title for the button that removes a reading list item */
+"Remove" = "Бетерү";
+
+/* Name for button removing current article from reading list in reader mode */
+"Remove from Reading List" = "Уку исемлегеннән алып ташлау";
+
+/* Cancel button text shown in reopen-alert at home page. */
+"ReopenAlert.Actions.Cancel" = "Баш тарту";
+
+/* Reopen button text shown in reopen-alert at home page. */
+"ReopenAlert.Actions.Reopen" = "Яңадан ачу";
+
+/* Reopen alert title shown at home page. */
+"ReopenAlert.Title" = "Соңгы ябылган табны яңадан ачу";
+
+/* Hardware shortcut to reopen the last closed tab, from the tab or the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down. */
+"ReopenClosedTab.KeyCodeTitle" = "Ябылган табны яңадан ачу";
+
+/* Accessibility label for button resetting font size in display settings of reader mode */
+"Reset text size" = "Текст үлчәмен ташлату";
+
+/* Font type setting in the reading view settings */
+"Sans-serif" = "Sans-serif";
+
+/* OK button to dismiss the error prompt. */
+"ScanQRCode.Error.OK.Button" = "ОК";
+
+/* Text of the prompt that is shown to the user when the data is invalid */
+"ScanQRCode.InvalidDataError.Message" = "Мәгълүмат яраксыз";
+
+/* Title for the QR code scanner view. */
+"ScanQRCode.View.Title" = "QR кодны сканерлау";
+
+/* Accessibility Label for the tab toolbar Search button
+   Navigation title for search settings.
+   Open search section of settings */
+"Search" = "Эзләү";
+
+/* The text shown in the URL bar on about:home */
+"Search or enter address" = "Эзләү яки адрес язу";
+
+/* The success message that appears after a user sucessfully adds a new search engine */
+"Search.ThirdPartyEngines.AddSuccess" = "Эзләү системасы өстәлде!";
+
+/* The cancel button if you do not want to add a search engine. */
+"Search.ThirdPartyEngines.Cancel" = "Баш тарту";
+
+/* A title stating that we failed to add custom search engine. */
+"Search.ThirdPartyEngines.DuplicateErrorTitle" = "Уңышсыз";
+
+/* A title explaining that we failed to add a search engine */
+"Search.ThirdPartyEngines.FailedTitle" = "Уңышсыз";
+
+/* A title stating that we failed to add custom search engine. */
+"Search.ThirdPartyEngines.FormErrorTitle" = "Уңышсыз";
+
+/* The confirmation button */
+"Search.ThirdPartyEngines.OK" = "ОК";
+
+/* Accessibility label for the lock icon, which is only present if the connection is secure */
+"Secure connection" = "Хәвефсез бәйләнеш";
+
+/* Menu item in settings used to open input.mozilla.org where people can submit feedback */
+"Send Feedback" = "Кире элемтә хәбәрен җибәрү";
+
+/* Used as a button label for crash dialog prompt */
+"Send Report" = "Хисап җибәрү";
+
+/* Button title for cancelling share screen
+   Close button in top navigation bar */
+"SendTo.Cancel.Button" = "Баш тарту";
+
+/* Header for the list of devices table */
+"SendTo.DeviceList.Text" = "Кулланырлык җиһазлар:";
+
+/* OK button to dismiss the error prompt. */
+"SendTo.Error.OK.Button" = "ОК";
+
+/* Title of the dialog that allows you to send a tab to a different device */
+"SendTo.NavBar.Title" = "Табны җибәрү";
+
+/* Navigation bar button to Send the current page to a device */
+"SendTo.SendAction.Text" = "Җибәрү";
+
+/* The text for the button on the Send to Device page if you are not signed in to Firefox Accounts. */
+"SendTo.SignIn.Button" = "Firefox-ка керү";
+
+/* Body of notification shown when the device is sent one or more tabs from an unnamed device. */
+"SentTab_TabArrivingNotification_NoDevice_body" = "Башка җиһаздан яңа бер таб килде.";
+
+/* Title of notification shown when the device is sent one or more tabs from an unnamed device. */
+"SentTab_TabArrivingNotification_NoDevice_title" = "Таб кабул ителде";
+
+/* Body of notification shown when the device is sent one or more tabs from the named device. %@ is the placeholder for the app name. */
+"SentTab_TabArrivingNotification_WithDevice_body" = "%@ браузерына яңа таб килде";
+
+/* Title of notification shown when the device is sent one or more tabs from the named device. %@ is the placeholder for the device name. This device name will be localized by that device. */
+"SentTab_TabArrivingNotification_WithDevice_title" = "%@ бер таб җибәрде";
+
+/* Label for an action used to add one or more tabs recieved from a notification to the reading list. */
+"SentTab.AddToReadingListAction.Title" = "Уку исемлегенә өстәү";
+
+/* Label for an action used to bookmark one or more tabs from a notification. */
+"SentTab.BookmarkAction.title" = "Кыстырып кую";
+
+/* Body of notification received after a spurious message from FxA has been received. */
+"SentTab.NoTabArrivingNotification.body" = "Башлау өчен басыгыз";
+
+/* Title of notification received after a spurious message from FxA has been received. */
+"SentTab.NoTabArrivingNotification.title" = "Firefox Sync";
+
+/* Label for an action used to view one or more tabs from a notification. */
+"SentTab.ViewAction.title" = "Карап чыгу";
+
+/* Sepia theme setting in Reading View settings */
+"Sepia" = "Сепия";
+
+/* Font type setting in the reading view settings */
+"Serif" = "Serif";
+
+/* Title in the settings view controller title bar */
+"Settings" = "Көйләүләр";
+
+/* The button text in Search Settings that opens the Custom Search Engine view. */
+"Settings.AddCustomEngine" = "Эзләү системасын өстәү";
+
+/* The text on the Save button when saving a custom search engine */
+"Settings.AddCustomEngine.SaveButtonText" = "Саклау";
+
+/* The title of the  Custom Search Engine view. */
+"Settings.AddCustomEngine.Title" = "Эзләү системасын өстәү";
+
+/* The title for the field which sets the title for a custom search engine. */
+"Settings.AddCustomEngine.TitleLabel" = "Исем";
+
+/* The placeholder for Title Field when saving a custom search engine. */
+"Settings.AddCustomEngine.TitlePlaceholder" = "Эзләү системасы";
+
+/* The title for URL Field */
+"Settings.AddCustomEngine.URLLabel" = "URL";
+
+/* Button in Data Management that clears private data for the selected items. */
+"Settings.ClearAllWebsiteData.Clear.Button" = "Вебсайтның барлык мәгълүматларын чистарту";
+
+/* Button in settings that clears private data for the selected items. */
+"Settings.ClearPrivateData.Clear.Button" = "Хосусый мәгълүматны чистарту";
+
+/* Label used as an item in Settings. When touched it will open a dialog prompting the user to make sure they want to clear all of their private data. */
+"Settings.ClearPrivateData.SectionName" = "Хосусый мәгълүматны чистарту";
+
+/* Title displayed in header of the setting panel. */
+"Settings.ClearPrivateData.Title" = "Хосусый мәгълүматны чистарту";
+
+/* Copy app version alert shown in settings. */
+"Settings.CopyAppVersion.Title" = "Алмашу буферына күчермәләнде";
+
+/* Default text in search bar for Data Management */
+"Settings.DataManagement.SearchLabel" = "Cайтларны фильтрлау";
+
+/* Label used as an item in Settings. When touched it will open a dialog prompting the user to make sure they want to clear all of their private data. */
+"Settings.DataManagement.SectionName" = "Мәгълүмат белән идарә итү";
+
+/* Title displayed in header of the setting panel. */
+"Settings.DataManagement.Title" = "Мәгълүмат белән идарә итү";
+
+/* Button displayed at the bottom of settings page allowing users to Disconnect from FxA */
+"Settings.Disconnect.Button" = "Синхронлауны өзү";
+
+/* Cancel action button in alert when user is prompted for disconnect */
+"Settings.Disconnect.CancelButton" = "Баш тарту";
+
+/* Destructive action button in alert when user is prompted for disconnect */
+"Settings.Disconnect.DestructiveButton" = "Өзү";
+
+/* Title of the alert when prompting the user asking to disconnect. */
+"Settings.Disconnect.Title" = "Синхронлауны өзү кирәкме?";
+
+/* Section header for brightness slider. */
+"Settings.DisplayTheme.BrightnessThreshold.SectionHeader" = "Бусага";
+
+/* Display (theme) settings label to show if manually switch theme is enabled. */
+"Settings.DisplayTheme.Manual.StatusLabel" = "Кулдан";
+
+/* Display (theme) setting to choose the theme manually. */
+"Settings.DisplayTheme.Manual.SwitchTitle" = "Кулдан";
+
+/* Option choice in display theme settings for dark theme */
+"Settings.DisplayTheme.OptionDark" = "Караңгы";
+
+/* Option choice in display theme settings for light theme */
+"Settings.DisplayTheme.OptionLight" = "Ачык";
+
+/* Switch mode settings section title */
+"Settings.DisplayTheme.SwitchMode.SectionHeader" = "Режимны авыштыру";
+
+/* Display (theme) settings label to show if automatically switch theme is enabled.
+   Display (theme) settings switch to choose whether to set the dark mode manually, or automatically based on the brightness slider. */
+"Settings.DisplayTheme.SwitchTitle" = "Автоматик";
+
+/* System theme settings section title */
+"Settings.DisplayTheme.SystemTheme.SectionHeader" = "Система темасы";
+
+/* Theme picker settings section title */
+"Settings.DisplayTheme.ThemePicker.SectionHeader" = "Тема сайлагыч";
+
+/* Title in main app settings for Theme settings */
+"Settings.DisplayTheme.Title.v2" = "Тема";
+
+/* DNT Settings option for always on */
+"Settings.DNT.OptionAlwaysOn" = "Һәрвакыт";
+
+/* Label used for the device name settings section. */
+"Settings.FxA.DeviceName" = "Җиһаз исеме";
+
+/* Label used as a section title in the Firefox Accounts Settings screen. */
+"Settings.FxA.Sync.SectionName" = "Синхронлау көйләүләре";
+
+/* Title displayed in header of the FxA settings panel. */
+"Settings.FxA.Title" = "Firefox Хисабы";
+
+/* General settings section title */
+"Settings.General.SectionName" = "Гомуми";
+
+/* Button in settings to clear the home page. */
+"Settings.HomePage.Clear.Button" = "Чистарту";
+
+/* Label used as an item in Settings. When touched it will open a dialog to configure the home page and its uses. */
+"Settings.HomePage.SectionName" = "Баш бит";
+
+/* Title displayed in header of the setting panel. */
+"Settings.HomePage.Title" = "Баш бит көйләүләре";
+
+/* Placeholder text in the homepage setting when no homepage has been set. */
+"Settings.HomePage.URL.Placeholder" = "Веб-битне кертү";
+
+/* Title of the setting section containing the URL of the current home page. */
+"Settings.HomePage.URL.Title" = "Хәзерге баш бит";
+
+/* Button in settings to use the current link on the clipboard as home page. */
+"Settings.HomePage.UseCopiedLink.Button" = "Копияләнгән сылтаманы куллану";
+
+/* Button in settings to use the current page as home page. */
+"Settings.HomePage.UseCurrent.Button" = "Хәзерге битне куллану";
+
+/* Button in settings to use the default home page. If no default is set, then this button isn't shown. */
+"Settings.HomePage.UseDefault.Button" = "Килешенгәнне куллану";
+
+/* Title for the logins and passwords screen. Translation could just use 'Logins' if the title is too long */
+"Settings.LoginsAndPasswordsTitle" = "Хисаплар & серсүзләр";
+
+/* Label used to set a custom url as the new tab option (homepage). */
+"Settings.NewTab.CustomURL" = "Үзгә URL";
+
+/* The title of the section in newtab that lets you modify the topsites panel */
+"Settings.NewTab.Option.ASTitle" = "Төп сайтларны яраклаштыру";
+
+/* Option in settings to show a blank page when you open a new tab */
+"Settings.NewTab.Option.BlankPage" = "Буш бит ";
+
+/* Option in settings to show bookmarks when you open a new tab */
+"Settings.NewTab.Option.Bookmarks" = "Кыстыргычлар";
+
+/* The title for the section to customize top sites in the new tab settings page. */
+"Settings.NewTab.Option.CustomizeTitle" = "Firefox-ның баш битен көйләү";
+
+/* Option in settings to show Firefox Home when you open a new tab */
+"Settings.NewTab.Option.FirefoxHome" = "Firefox баш бит";
+
+/* Option in the settings to turn off recent bookmarks in the Highlights section */
+"Settings.NewTab.Option.HighlightsBookmarks" = "Соңгы кыстыргычлар";
+
+/* Option in settings to turn off history in the highlights section */
+"Settings.NewTab.Option.HighlightsHistory" = "Каралган";
+
+/* Option in settings to show history when you open a new tab */
+"Settings.NewTab.Option.History" = "Тарих";
+
+/* Option in settings to show your homepage when you open a new tab */
+"Settings.NewTab.Option.HomePage" = "Баш бит";
+
+/* Option in settings to turn on off pocket recommendations */
+"Settings.NewTab.Option.Pocket" = "Pocket-та популяр";
+
+/* Option in settings to show reading list when you open a new tab */
+"Settings.NewTab.Option.ReadingList" = "Уку исемлегегезне күрсәтү";
+
+/* Label used as an item in Settings. When touched it will open a dialog to configure the new tab behavior. */
+"Settings.NewTab.SectionName" = "Яңа таб";
+
+/* Title displayed in header of the setting panel. */
+"Settings.NewTab.Title" = "Яңа таб";
+
+/* Label at the top of the New Tab screen after entering New Tab in settings */
+"Settings.NewTab.TopSectionName" = "Күрсәтү";
+
+/* Description displayed under the ”Offer to Open Copied Link” option. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349 */
+"Settings.OfferClipboardBar.Status" = "Firefox ачылганда";
+
+/* Title for Open With Settings */
+"Settings.OpenWith.PageTitle" = "Почта сылтамаларын моның белән ач: ";
+
+/* Label used as an item in Settings. When touched it will open a dialog to configure the open with (mail links) behavior. */
+"Settings.OpenWith.SectionName" = "Эл. почта кушымтасы";
+
+/* Setting to enable the built-in password manager */
+"Settings.SaveLogins.Title" = "Логиннарны саклау";
+
+/* Button displayed at the top of the search settings. */
+"Settings.Search.Done.Button" = "Әзер";
+
+/* Button displayed at the top of the search settings. */
+"Settings.Search.Edit.Button" = "Үзгәртү";
+
+/* title for a link that explains how mozilla collects telemetry */
+"Settings.SendUsage.Link" = "Күбрәк белү.";
+
+/* A short description that explains why mozilla collects usage data. */
+"Settings.SendUsage.Message" = "Mozilla, Firefox'ны һәркемгә дә тәкъдим итү һәм яхшырту өчен кирәкле мәгълүматларны гына җыярга тырыша.";
+
+/* The title for the setting to send usage data. */
+"Settings.SendUsage.Title" = "Куллану мәгълүматларын җибәрү";
+
+/* Title of setting to enable link previews when long-pressing links. */
+"Settings.ShowLinkPreviews.Title" = "Сылтамалар өчен алдан карап алуларны кабызу";
+
+/* Setting to show Logins & Passwords quick access in the application menu */
+"Settings.ShowLoginsInAppMenu.Title" = "Кушымта менюсында күрсәтү";
+
+/* The description of the open new tab siri shortcut */
+"Settings.Siri.OpenTabShortcut" = "Яңа табны ачу";
+
+/* The option that takes you to the siri shortcuts settings page */
+"Settings.Siri.SectionName" = "Siri ярлыклары";
+
+/* Dismiss button for the tracker protection alert. */
+"Settings.TrackingProtection.Alert.Button" = "Яхшы, аңладым";
+
+/* Title for the tracker protection alert. */
+"Settings.TrackingProtection.Alert.Title" = "Игътибар!";
+
+/* The Title on info view which shows a list of all blocked websites */
+"Settings.TrackingProtection.Info.BlocksTitle" = "БЛОКЛАНДЫ";
+
+/* 'Learn more' info link on the Tracking Protection settings screen. */
+"Settings.TrackingProtection.LearnMore" = "Күбрәк белү";
+
+/* 'More Info' link on the Tracking Protection settings screen. */
+"Settings.TrackingProtection.MoreInfo" = "Күбрәк белү…";
+
+/* Title for tracking protection options section where level can be selected. */
+"Settings.TrackingProtection.ProtectionLevelTitle" = "Cаклау дәрәҗәсе";
+
+/* Row in top-level of settings that gets tapped to show the tracking protection settings detail view. */
+"Settings.TrackingProtection.SectionName" = "Күзәтелүдән саклау";
+
+/* Tracking protection settings option for using the basic blocklist. */
+"Settings.TrackingProtectionOption.BasicBlockList" = "Стандарт (килешенгәнчә)";
+
+/* Tracking protection settings option for using the strict blocklist. */
+"Settings.TrackingProtectionOption.BlockListStrict" = "Катгый";
+
+/* Settings option to specify that Tracking Protection is on */
+"Settings.TrackingProtectionOption.NormalBrowsingLabelOn" = "Күзәтелүдән Көчәйтелгән Саклау";
+
+/* Translation settings section title */
+"Settings.TranslateSnackBar.SectionHeader" = "Хезмәтләр";
+
+/* Switch to choose if the language of a page is detected and offer to translate. */
+"Settings.TranslateSnackBar.SwitchTitle" = "Тәрҗемә тәкъдим итү";
+
+/* Title in main app settings for Translation toast settings */
+"Settings.TranslateSnackBar.Title" = "Тәрҗемә";
+
+/* Title of link to help page to find out how to solve Sync issues */
+"Settings.TroubleShootSync.Title" = "Хаталарны төзәтү";
+
+/* Button to delete website in search results */
+"Settings.WebsiteData.ButtonDelete" = "Бетерү";
+
+/* Button to exit edit website search results */
+"Settings.WebsiteData.ButtonDone" = "Әзер";
+
+/* Button to edit website search results */
+"Settings.WebsiteData.ButtonEdit" = "Үзгәртү";
+
+/* Button shows all websites on website data tableview */
+"Settings.WebsiteData.ButtonShowMore" = "Күбрәк күрсәтү";
+
+/* Title displayed in header of the Data Management panel. */
+"Settings.WebsiteData.Title" = "Вебсайт мәгълүматлары";
+
+/* Action label on share extension to add page to the Firefox reading list. */
+"ShareExtension.AddToReadingListAction.Title" = "Уку исемлегенә өстәү";
+
+/* Share extension label shown after user has performed 'Add to Reading List' action. */
+"ShareExtension.AddToReadingListActionDone.Title" = "Уку исемлегенә өстәлде";
+
+/* Action label on share extension to bookmark the page in Firefox. */
+"ShareExtension.BookmarkThisPageAction.Title" = "Бу битне кыстыргычларга өстәү";
+
+/* Share extension label shown after user has performed 'Bookmark this Page' action. */
+"ShareExtension.BookmarkThisPageActionDone.Title" = "Кыстыргычларга өстәлде";
+
+/* Action label on share extension to load the page in Firefox when user switches apps to bring it to foreground. */
+"ShareExtension.LoadInBackgroundAction.Title" = "Фонда йөкләү";
+
+/* Share extension label shown after user has performed 'Load in Background' action. */
+"ShareExtension.LoadInBackgroundActionDone.Title" = "Firefox-та йөкләнә";
+
+/* Action label on share extension to immediately open page in Firefox. */
+"ShareExtension.OpenInFirefoxAction.Title" = "Firefox-та ачу";
+
+/* Action label on share extension to immediately open page in Firefox in private mode. */
+"ShareExtension.OpenInPrivateModeAction.Title" = "Хосусый режимда ачу";
+
+/* Action label on share extension to search for the selected text in Firefox. */
+"ShareExtension.SeachInFirefoxAction.Title" = "Firefox-та эзләү";
+
+/* Label for show search suggestions setting. */
+"Show Search Suggestions" = "Эзләү тәкъдимнәрен күрсәтү";
+
+/* Accessibility label for the tabs button in the (top) tab toolbar
+   Accessibility Label for the tabs button in the tab toolbar */
+"Show Tabs" = "Табларны күрсәтү";
+
+/* Show the on-boarding screen again from the settings */
+"Show Tour" = "Турны күрсәтү";
+
+/* Accessibility Label for the tab toolbar Stop button */
+"Stop" = "Туктату";
+
+/* Support section title */
+"Support" = "Техник ярдәм";
+
+/* Accessibility hint for tab tray's displayed tab. */
+"Swipe right or left with three fingers to close the tab." = "Табны ябу өчен өч бармак белән уңга яки сулга сөйрәгез.";
+
+/* Hardware shortcut for non-private tab or tab. Shown in the Discoverability overlay when the hardware Command Key is held down. */
+"SwitchToNonPBM.KeyCodeTitle" = "Нормаль гизү режимы";
+
+/* Hardware shortcut switch to the private browsing tab or tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down. */
+"SwitchToPBM.KeyCodeTitle" = "Хосусый гизү режимы";
+
+/* Text displayed when the Sync home panel is empty, describing the features provided by Sync to invite the user to log in. */
+"Sync your tabs, bookmarks, passwords and more." = "Табларыгыз, кыстыргычларыгыз, серсүзләрегез һәм башкаларны cинхронлау.";
+
+/* Text displayed when the Sync home panel is empty, describing the features provided by Sync to invite the user to log in. */
+"Sync your tabs, passwords and more." = "Табларыгыз, серсүзләрегез һәм башкаларны cинхронлау.";
+
+/* Message displayed when the user's account is syncing with no ellipsis */
+"Sync.Syncing.Label" = "Синхронлау";
+
+/* Message displayed when the user's account is syncing with ellipsis at the end */
+"Sync.SyncingEllipsis.Label" = "Синхронлау…";
+
+/* Panel accessibility label */
+"Synced Tabs" = "Синхронланган таблар";
+
+/* The Bookmark sync component, used in SyncState.Partial.Title */
+"SyncState.Bookmark.Title" = "Кыстыргычлар";
+
+/* The History sync component, used in SyncState.Partial.Title */
+"SyncState.History.Title" = "Тарих";
+
+/* The Logins sync component, used in SyncState.Partial.Title */
+"SyncState.Logins.Title" = "Логиннар";
+
+/* The Tabs sync component, used in SyncState.Partial.Title */
+"SyncState.Tabs.Title" = "Таблар";
+
+/* Message spoken by VoiceOver saying the position of the single currently visible tab in Tabs Tray, along with the total number of tabs. E.g. \"Tab 2 of 5\" says that tab 2 is visible (and is the only visible tab), out of 5 tabs total. */
+"Tab %@ of %@" = "Таб: %1$@ / %2$@";
+
+/* Hardware shortcut to open the tab tray from a tab. Shown in the Discoverability overlay when the hardware Command Key is held down. */
+"Tab.ShowTabTray.KeyCodeTitle" = "Барлык табларны да күрсәтү";
+
+/* Message spoken by VoiceOver saying the range of tabs that are currently visible in Tabs Tray, along with the total number of tabs. E.g. \"Tabs 8 to 10 of 15\" says tabs 8, 9 and 10 are visible, out of 15 tabs total. */
+"Tabs %@ to %@ of %@" = "Таблар: %3$@ табның %1$@ белән %2$@ арасындагылары";
+
+/* The button to undo the delete all tabs */
+"Tabs.DeleteAllUndo.Button" = "Кире алу";
+
+/* The label indicating that all the tabs were closed */
+"Tabs.DeleteAllUndo.Title" = "%d таб ябылды";
+
+/* The placeholder text for the tab search bar */
+"Tabs.Search.PlaceholderText" = "Таблардан эзләү";
+
+/* Accessibility label for the Add Tab button in the Tab Tray. */
+"TabTray.AddTab.Button" = "Таб өстәү";
+
+/* Hardware shortcut to close all tabs from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down. */
+"TabTray.CloseAllTabs.KeyCodeTitle" = "Барлык табларны да ябу";
+
+/* Hardware shortcut to close the selected tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down. */
+"TabTray.CloseTab.KeyCodeTitle" = "Сайланган табны ябу";
+
+/* The section header for tabs opened last week */
+"TabTray.LastWeek.Header" = "Үткән атнада";
+
+/* The title on the button to copy the tab address. */
+"TabTray.MoreMenu.Copy" = "Күчереп алу";
+
+/* The section header for tabs opened before last week */
+"TabTray.Older.Header" = "Искерәк";
+
+/* Hardware shortcut to open a new tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down. */
+"TabTray.OpenNewTab.KeyCodeTitle" = "Яңа таб ачу";
+
+/* Hardware shortcut open the selected tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down. */
+"TabTray.OpenSelectedTab.KeyCodeTitle" = "Сайланган табны ачу";
+
+/* The button title to see more options to perform on the tab. */
+"TabTray.SwipeMenu.More" = "Күбрәк";
+
+/* The title for the tab tray */
+"TabTray.Title" = "Ачык таблар";
+
+/* The section header for tabs opened today */
+"TabTray.Today.Header" = "Бүген";
+
+/* The section header for tabs opened yesterday */
+"TabTray.Yesterday.Header" = "Кичә";
+
+/* Relative date for date in past week. */
+"this week" = "бу атна";
+
+/* label for Not Now button */
+"Toasts.NotNow" = "Хәзер түгел";
+
+/* Open App Store button */
+"Toasts.OpenAppStore" = "App Store-ны ачу";
+
+/* Label for button to undo the action just performed */
+"Toasts.Undo" = "Кире алу";
+
+/* History tableview section header */
+"Today" = "Бүген";
+
+/* Relative date for date older than a minute. */
+"today at %@" = "бүген: %@";
+
+/* Accessibility label for the Menu button. */
+"Toolbar.Menu.AccessibilityLabel" = "Меню";
+
+/* Accessibility label for the Close All Tabs menu button. */
+"Toolbar.Menu.CloseAllTabs" = "Барлык табларны да ябу";
+
+/* The title for the empty Top Sites state */
+"TopSites.EmptyState.Title" = "Төп сайтларга рәхим итегез";
+
+/* Button shown in editing mode to remove this site from the top sites panel. */
+"TopSites.RemovePage.Button" = "Битне бетерү — %@";
+
+/* Button to disallow the page to be translated to the user locale language */
+"TranslationToastHandler.PromptTranslate.Cancel" = "Юк";
+
+/* Button to allow the page to be translated to the user locale language */
+"TranslationToastHandler.PromptTranslate.OK" = "Әйе";
+
+/* Tile title for Twitter */
+"Twitter" = "Twitter";
+
+/* The menu item that pastes the current contents of the clipboard into the URL bar and navigates to the page */
+"UIMenuItem.PasteGo" = "Ябыштыру һәм күчү";
+
+/* Search in New Tab Text selection menu item */
+"UIMenuItem.SearchWithFirefox" = "Firefox белән эзләү";
+
+/* Accessibility label for unread article in reading list. It's a past participle - functions as an adjective. */
+"unread" = "укылмаган";
+
+/* Text message in the settings table view */
+"Upgrade Firefox to connect" = "Тоташу өчен Firefox-ны яңартыгыз";
+
+/* Username textbox in Authentication prompt */
+"Username" = "Кулланучы исеме";
+
+/* Text message in the settings table view */
+"Verify your email address" = "Эл. почта адресыгызны раслагыз";
+
+/* Version number of Firefox shown in settings */
+"Version %@ (%@)" = "Версия: %1$@ (%2$@)";
+
+/* Accessibility label for the main web content view */
+"Web content" = "Веб-эчтәлек";
+
+/* See http://mzl.la/1LXbDOL */
+"Welcome to your Reading List" = "Уку исемлегегезгә рәхим итегез";
+
+/* Tile title for Wikipedia */
+"Wikipedia" = "Wikipedia";
+
+/* Relative date for yesterday. */
+"yesterday" = "кичә";
+
+/* History tableview section header */
+"Yesterday" = "Кичә";
+
+/* Error message in the remote tabs panel */
+"You don’t have any tabs open in Firefox on your other devices." = "Башка җиһазларыгыздагы Firefox-ларда ачык таблар юк.";
+
+/* Your Rights settings section title */
+"Your Rights" = "Хокукларыгыз";
+
+/* Tile title for YouTube */
+"YouTube" = "YouTube";
+

--- a/Shared/tt.lproj/LoginManager.strings
+++ b/Shared/tt.lproj/LoginManager.strings
@@ -1,0 +1,54 @@
+/* Prompt title when deleting logins */
+"Are you sure?" = "Моны раслыйсызмы?";
+
+/* Prompt option for cancelling out of deletion */
+"Cancel" = "Баш тарту";
+
+/* Accessibility message e.g. spoken by VoiceOver after the user taps the close button in the search field to clear the search and exit search mode */
+"Clear Search" = "Эзләүне чистарту";
+
+/* Copy password text selection menu item */
+"Copy" = "Күчереп алу";
+
+/* Label describing when the current login was created with the timestamp as the parameter. */
+"Created %@" = "Ясалган %@";
+
+/* Label for the button used to delete the current login. */
+"Delete" = "Бетерү";
+
+/* Label for the button used to deselect all logins. */
+"Deselect All" = "Берсен дә сайламау";
+
+/* Accessibility label for entering search mode for logins */
+"Enter Search Mode" = "Эзләү режимын кертү";
+
+/* Hide password text selection menu item */
+"Hide" = "Яшерү";
+
+/* Label describing when the current login was last modified with the timestamp as the parameter. */
+"Modified %@" = "Үзгәртелгән %@";
+
+/* Label displayed when no logins are found after searching. */
+"No logins found" = "Логиннар табылмады";
+
+/* Open and Fill website text selection menu item */
+"Open & Fill" = "Aчу һәм тутыру";
+
+/* Label displayed above the password row in Login Detail View. */
+"Password" = "Серсүз";
+
+/* Reveal password text selection menu item */
+"Reveal" = "Күрсәтү";
+
+/* Title for the search field at the top of the Logins list screen */
+"Search" = "Эзләү";
+
+/* Label for the button used to select all logins. */
+"Select All" = "Барысын да сайлау";
+
+/* Label displayed above the username row in Login Detail View. */
+"Username" = "Кулланучы исеме";
+
+/* Label displayed above the website row in Login Detail View. */
+"Website" = "Веб-сайт";
+

--- a/Shared/tt.lproj/Menu.strings
+++ b/Shared/tt.lproj/Menu.strings
@@ -1,93 +1,72 @@
 /* Label for the button, displayed in the menu, used to create a bookmark for the current website. */
-"Menu.AddBookmarkAction.Title" = "Dèan comharra-lìn dhen duilleag seo";
-
-/* Label for the button, displayed in the menu, used to create a bookmark for the current website. */
-"Menu.AddBookmarkAction2.Title" = "Cuir comharra-lìn ris";
+"Menu.AddBookmarkAction.Title" = "Бу битне кыстыргычларга өстәү";
 
 /* Label for the button, displayed in the menu, used to add a page to the reading list. */
-"Menu.AddToReadingList.Title" = "Cuir ris an liosta-leughaidh";
+"Menu.AddToReadingList.Title" = "Уку исемлегенә өстәү";
 
 /* Label for the button, displayed in the menu, used to close all tabs currently open. */
-"Menu.CloseAllTabsAction.Title" = "Dùin a h&#x2011;uile taba";
+"Menu.CloseAllTabsAction.Title" = "Барлык табларны да ябу";
 
 /* Label for the button, displayed in the menu, used to copy the page url to the clipboard. */
-"Menu.CopyAddress.Title" = "Dèan lethbhreac dhen t-seòladh";
-
-/* Label for the button, displayed in the menu, used to copy the current page link to the clipboard. */
-"Menu.CopyLink.Title" = "Dèan lethbhreac dhen cheangal";
+"Menu.CopyAddress.Title" = "Адресны күчереп алу";
 
 /* Label for the button, displayed in the menu, used to open the toolbar to search for text within the current page. */
-"Menu.FindInPageAction.Title" = "Lorg san duilleag";
+"Menu.FindInPageAction.Title" = "Биттән табу";
 
 /* Label for the button, displayed in the menu, used to Reload the webpage */
-"Menu.Library.Reload" = "Ath-luchdaich";
+"Menu.Library.Reload" = "Яңарту";
 
 /* Label for the button, displayed in the menu, used to open the Library */
-"Menu.Library.Title" = "An leabhar-lann agad";
+"Menu.Library.Title" = "Китапханәгез";
 
 /* Label for the button, displayed in the menu, used to open a new private tab. */
-"Menu.NewPrivateTabAction.Title" = "Fosgail taba prìobhaideach ùr";
+"Menu.NewPrivateTabAction.Title" = "Яңа хосусый таб ачу";
 
 /* Label for the button, displayed in the menu, used to open a new tab */
-"Menu.NewTabAction.Title" = "Fosgail taba ùr";
+"Menu.NewTabAction.Title" = "Яңа таб ачу";
 
 /* Accessibility label for the button, displayed in the menu, used to open the Bookmarks home panel. Please keep as short as possible, <15 chars of space available. */
-"Menu.OpenBookmarksAction.AccessibilityLabel.v2" = "Comharran-lìn";
+"Menu.OpenBookmarksAction.AccessibilityLabel.v2" = "Кыстыргычлар";
 
 /* Accessibility label for the button, displayed in the menu, used to open the Downloads home panel. Please keep as short as possible, <15 chars of space available. */
-"Menu.OpenDownloadsAction.AccessibilityLabel.v2" = "Luchdaidhean a-nuas";
+"Menu.OpenDownloadsAction.AccessibilityLabel.v2" = "Йөкләп алулар";
 
 /* Accessibility label for the button, displayed in the menu, used to open the History home panel. Please keep as short as possible, <15 chars of space available. */
-"Menu.OpenHistoryAction.AccessibilityLabel.v2" = "An eachdraidh";
+"Menu.OpenHistoryAction.AccessibilityLabel.v2" = "Тарих";
 
 /* Label for the button, displayed in the menu, used to navigate to the home page. */
-"Menu.OpenHomePageAction.Title" = "Dhachaigh";
+"Menu.OpenHomePageAction.Title" = "Өйгә";
 
 /* Accessibility label for the button, displayed in the menu, used to open the Reading list home panel. Please keep as short as possible, <15 chars of space available. */
-"Menu.OpenReadingListAction.AccessibilityLabel.v2" = "An liosta-leughaidh";
+"Menu.OpenReadingListAction.AccessibilityLabel.v2" = "Уку исемлеге";
 
 /* Label for the button, displayed in the menu, used to open the Settings menu. */
-"Menu.OpenSettingsAction.Title" = "Roghainnean";
+"Menu.OpenSettingsAction.Title" = "Көйләүләр";
 
 /* Accessibility label for the button, displayed in the menu, used to open the Synced Tabs home panel. Please keep as short as possible, <15 chars of space available. */
-"Menu.OpenSyncedTabsAction.AccessibilityLabel.v2" = "Tabaichean sioncronaichte";
+"Menu.OpenSyncedTabsAction.AccessibilityLabel.v2" = "Синхронланган таблар";
 
 /* Accessibility label for the button, displayed in the menu, used to open the Top Sites home panel. */
-"Menu.OpenTopSitesAction.AccessibilityLabel" = "Brod nan làrach";
-
-/* Label for the button, displayed in the menu, used to show the html page source */
-"Menu.PageSourceAction.Title" = "Seall bun-tùs na duilleige";
-
-/* A string used to signify the start of the Recently Saved section in Home Screen. */
-"Menu.RecentlySaved.Title" = "Air a shàbhaladh o chionn goirid";
+"Menu.OpenTopSitesAction.AccessibilityLabel" = "Төп сайтлар";
 
 /* Label for the button, displayed in the menu, used to delete an existing bookmark for the current website. */
-"Menu.RemoveBookmarkAction.Title" = "Thoir an comharra-lìn air falbh";
+"Menu.RemoveBookmarkAction.Title" = "Кыстыргычны бетерү";
 
 /* Label for the button, displayed in the menu, used to report a compatibility issue with the current page. */
-"Menu.ReportSiteIssueAction.Title" = "Dèan aithris air duilgheadas leis an làrach";
+"Menu.ReportSiteIssueAction.Title" = "Сайттагы проблема турында хәбәр итү";
 
 /* Label for the button, displayed in the menu, used to open the QR code scanner. */
-"Menu.ScanQRCodeAction.Title" = "Sganaich an còd QR";
+"Menu.ScanQRCodeAction.Title" = "QR кодны сканерлау";
 
 /* Label for the button, displayed in Firefox Home, used to see all Library panels. */
-"Menu.SeeAllAction.Title" = "Seall na h-uile";
-
-/* Label for the button, displayed in the menu, used to open the share dialog. */
-"Menu.SharePageAction.Title" = "Co-roinn an duilleag le...";
+"Menu.SeeAllAction.Title" = "Барысын да карау";
 
 /* Label for the button, displayed in the menu, used to open the tabs tray */
-"Menu.ShowTabs.Title" = "Seall na tabaichean";
+"Menu.ShowTabs.Title" = "Табларны күрсәтү";
 
 /* Label for the button, displayed in the menu, used to translate the current page. */
-"Menu.TranslatePageAction.Title" = "Eadar-theangaich an duilleag";
+"Menu.TranslatePageAction.Title" = "Битне тәрҗемә итү";
 
 /* Label for the button, displayed in the menu, used to request the desktop version of the current website. */
-"Menu.ViewDekstopSiteAction.Title" = "Iarr an làrach desktop";
-
-/* Label for the button, displayed in the menu, used to request the mobile version of the current website. */
-"Menu.ViewMobileSiteAction.Title" = "Iarr na làrach mobile";
-
-/* Label for the button, displayed in the menu, used to navigate to the home page. */
-"SettingsMenu.OpenHomePageAction.Title" = "An duilleag-dhachaigh";
+"Menu.ViewDekstopSiteAction.Title" = "Сайтның тулы версиясен сорау";
 

--- a/Shared/tt.lproj/PrivateBrowsing.strings
+++ b/Shared/tt.lproj/PrivateBrowsing.strings
@@ -1,0 +1,21 @@
+/* Setting for closing private tabs */
+"Close Private Tabs" = "Хосусый табларны ябу";
+
+/* Context menu option for opening a link in a new private tab */
+"ContextMenu.OpenInNewPrivateTabButtonTitle" = "Яңа хосусый табта ачу";
+
+/* Text button displayed when there are no tabs open while in private mode */
+"Learn More" = "Күбрәк белү";
+
+/* Toggled OFF accessibility value */
+"Off" = "Сүнгән";
+
+/* Toggled ON accessibility value */
+"On" = "Кабынган";
+
+/* Title displayed for when there are no open tabs while in private mode */
+"Private Browsing" = "Хосусый гизү";
+
+/* Accessibility label for toggling on/off private mode */
+"Private Mode" = "Хосусый режим";
+

--- a/Shared/tt.lproj/Search.strings
+++ b/Shared/tt.lproj/Search.strings
@@ -1,0 +1,6 @@
+/* Label for search engine buttons. The argument corresponds to the name of the search engine. */
+"%@ search" = "%@ эзләү";
+
+/* Label for search settings button. */
+"Search Settings" = "Эзләү көйләүләре";
+

--- a/Shared/tt.lproj/Shared.strings
+++ b/Shared/tt.lproj/Shared.strings
@@ -1,0 +1,3 @@
+/* A brief descriptive name for this app on this device, used for Send Tab and Synced Tabs. The first argument is the app name. The second argument is the device name. */
+"%@ on %@" = "%2$@ җиһазындагы %1$@";
+

--- a/Shared/tt.lproj/Storage.strings
+++ b/Shared/tt.lproj/Storage.strings
@@ -1,0 +1,12 @@
+/* The name of the folder that contains desktop bookmarks in the menu. This should match bookmarks.folder.menu.label on Android. */
+"Bookmarks Menu" = "Кыстыргычлар менюсы";
+
+/* The name of the folder that contains desktop bookmarks in the toolbar. This should match bookmarks.folder.toolbar.label on Android. */
+"Bookmarks Toolbar" = "Кыстыргычлар панеле";
+
+/* The title of the folder that contains mobile bookmarks. This should match bookmarks.folder.mobile.label on Android. */
+"Mobile Bookmarks" = "Мобиль Кыстыргычлар";
+
+/* The name of the folder that contains unsorted desktop bookmarks. This should match bookmarks.folder.unfiled.label on Android. */
+"Unsorted Bookmarks" = "Тәртипкә салынмаган кыстыргычлар";
+

--- a/Shared/tt.lproj/Today.strings
+++ b/Shared/tt.lproj/Today.strings
@@ -1,0 +1,114 @@
+/* Close Private Tabs button label */
+"TodayWidget.ClosePrivateTabsButton" = "Хосусый табларны ябу";
+
+/* Close Private Tabs */
+"TodayWidget.ClosePrivateTabsLabelV2" = "Хосусый\nтабларны ябу";
+
+/* Close Private Tabs */
+"TodayWidget.ClosePrivateTabsLabelV3" = "Хосусый\nтабларны\nябу";
+
+/* Copied Link from clipboard displayed */
+"TodayWidget.CopiedLinkLabelFromPasteBoardV1" = "Сылтама алмашу буферыннан күчерелде";
+
+/* Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands */
+"TodayWidget.DropDownMenuItemClearPrivateTabs" = "Хосусый табларны чистарту";
+
+/* Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands */
+"TodayWidget.DropDownMenuItemGoToCopiedLink" = "Копияләнгән сылтамага күчү";
+
+/* Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands */
+"TodayWidget.DropDownMenuItemNewPrivateSearch" = "Яңа хосусый эзләү";
+
+/* Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands */
+"TodayWidget.DropDownMenuItemNewSearch" = "Яңа эзләү";
+
+/* Description for medium size widget to add Firefox Shortcut to home screen */
+"TodayWidget.FirefoxShortcutGalleryDescription" = "Өй экранына Firefox ярлыкларын өстәгез.";
+
+/* Go to link pasted on the clipboard */
+"TodayWidget.GoToCopiedLinkLabelV1" = "Копияләнгән сылтамага күчү";
+
+/* Go to copied link */
+"TodayWidget.GoToCopiedLinkLabelV2" = "Копияләнгән\nсылтамага күчү";
+
+/* Go To Copied Link text pasted on the clipboard but this string doesn't have new line character */
+"TodayWidget.GoToCopiedLinkLabelV3" = "Копияләнгән сылтамага күчү";
+
+/* Go to copied link */
+"TodayWidget.GoToCopiedLinkLabelV4" = "Копияләнгән\nсылтамага\nкүчү";
+
+/* %d represents number and it becomes something like +5 more where 5 is the number of open tabs in tab tray beyond what is displayed in the widget */
+"TodayWidget.MoreTabsLabel" = "тагын +%d…";
+
+/* Open New Private Tab button label for medium size action */
+"TodayWidget.NewPrivateTabButtonLabelV2" = "Хосусый табта эзләү";
+
+/* Open New Tab button label */
+"TodayWidget.NewSearchButtonLabelV1" = "Firefox-та эзләү";
+
+/* Open New Tab button label */
+"TodayWidget.NewTabButtonLabelV1" = "Яңа эзләү";
+
+/* Label that is shown when there are no tabs opened in tab tray i.e. Empty State */
+"TodayWidget.NoOpenTabsLabel" = "Ачык таблар юк.";
+
+/* Label that is shown when there are no tabs opened in tab tray i.e. Empty State */
+"TodayWidget.NoOpenTabsLabelV2" = "Ачык таблар юк";
+
+/* Open Firefox when there are no tabs opened in tab tray i.e. Empty State */
+"TodayWidget.OpenFirefoxLabel" = "Firefox-ны ачу";
+
+/* Sub label for medium size Firefox Pocket stories widge widget. Pocket is the name of another app. */
+"TodayWidget.PocketWidgetSubLabel" = "Firefox - Pocket тарафыннан тәкъдим ителә";
+
+/* Title for Firefox Pocket stories widget in Gallery View where user can add it to home screen. Pocket is the name of another app. */
+"TodayWidget.PocketWidgetTitle" = "Pocket тарафыннан тәкъдим ителә";
+
+/* Open New Private Tab button label */
+"TodayWidget.PrivateTabButtonLabelV1" = "Хосусый эзләү";
+
+/* Quick Actions left label text for dropdown menu when widget enters edit mode */
+"TodayWidget.QuickActionDropDownMenu" = "Тиз гамәл";
+
+/* Quick Actions title when widget enters edit mode */
+"TodayWidget.QuickActionsGalleryTitle" = "Тиз гамәлләр";
+
+/* Firefox shortcuts title when widget enters edit mode. Do not translate the word Firefox. */
+"TodayWidget.QuickActionsGalleryTitleV2" = "Firefox ярлыклары";
+
+/* Sub label for medium size quick action widget */
+"TodayWidget.QuickActionsSubLabel" = "Firefox - Тиз гамәлләр";
+
+/* Description for Quick View widget in Gallery View where user can add it to home screen */
+"TodayWidget.QuickViewGalleryDescriptionV2" = "Ачык табларыгызга ярлыклар өстәгез.";
+
+/* Title for Quick View widget in Gallery View where user can add it to home screen */
+"TodayWidget.QuickViewGalleryTitle" = "Тиз карау";
+
+/* Description for Quick View widget in Gallery View where user can add it to home screen */
+"TodayWidget.QuickViewLargeGalleryDescription" = "Ачык табларыгызга ярлыклар өстәгез.";
+
+/* Sub label for Top Sites widget */
+"TodayWidget.QuickViewOpenTabsSubLabel" = "Firefox - Ачык таблар";
+
+/* Title for small size widget which allows users to search in Firefox. Do not translate the word Firefox. */
+"TodayWidget.SearchInFirefoxTitle" = "Firefox-та эзләү";
+
+/* Search in Firefox. Do not translate the word Firefox */
+"TodayWidget.SearchInFirefoxV2" = "Firefox-та\nэзләү";
+
+/* Search in private tab */
+"TodayWidget.SearchInPrivateTabLabelV2" = "Хосусый\nтабта эзләү";
+
+/* Title for top sites widget to add Firefox top sites shotcuts to home screen */
+"TodayWidget.TopSitesGalleryTitle" = "Төп сайтлар";
+
+/* Sub label for Top Sites widget */
+"TodayWidget.TopSitesSubLabel" = "Firefox - Төп сайтлар";
+
+/* View More for Quick View widget in Gallery View where we don't know how many tabs might be opened */
+"TodayWidget.ViewMore" = "Күбрәк карау";
+
+/* View More… for Firefox Pocket stories widget where we don't know how many articles are available. */
+"TodayWidget.ViewMoreDots" = "Күбрәк карау…";
+

--- a/Shared/uk.lproj/Intro.strings
+++ b/Shared/uk.lproj/Intro.strings
@@ -59,7 +59,7 @@
 "Intro.Slides.Welcome.Description.v2" = "Швидкий, приватний і ваш.";
 
 /* Title for the first panel 'Welcome' in the First Run tour. */
-"Intro.Slides.Welcome.Title.v2" = "Ласкаво просимо у Firefox";
+"Intro.Slides.Welcome.Title.v2" = "Вітаємо у Firefox";
 
 /* See http://mzl.la/1T8gxwo */
 "Start Browsing" = "Почати перегляд";

--- a/Shared/uk.lproj/Localizable.strings
+++ b/Shared/uk.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "ActivityStream.Pocket.SectionTitle" = "Популярне в Pocket";
 
 /* Section title label for Recommended by Pocket section */
-"ActivityStream.Pocket.SectionTitle2" = "Рекомендовано Pocket";
+"ActivityStream.Pocket.SectionTitle2" = "Рекомендації від Pocket";
 
 /* The description of a Pocket Story */
 "ActivityStream.Pocket.Trending" = "Популярне";
@@ -315,7 +315,7 @@
 "Default Search Engine" = "Типовий засіб пошуку";
 
 /* Name for display settings button in reader mode. Display in the meaning of presentation, not monitor. */
-"Display Settings" = "Параметри відображення";
+"Display Settings" = "Параметри вигляду";
 
 /* Used as a button label for crash dialog prompt */
 "Don’t Send" = "Не надсилати";
@@ -438,7 +438,7 @@
 "FxA.NoInternetConnection" = "Немає з’єднання з Інтернетом";
 
 /* Button label to open Sync preferences */
-"FxA.OpenSyncPreferences" = "Відкрити налаштування синхронізації";
+"FxA.OpenSyncPreferences" = "Відкрити параметри синхронізації";
 
 /* Instructions shown on qr code scanning view */
 "fxa.qr-scanning-view.instructions" = "Скануйте QR-код, показаний на firefox.com/pair";
@@ -576,7 +576,7 @@
 "HomePage.Set.Dialog.Cancel" = "Скасувати";
 
 /* Alert dialog body when the user opens the home page for the first time. */
-"HomePage.Set.Dialog.Message" = "Ви можете пізніше змінити це в Параметрах";
+"HomePage.Set.Dialog.Message" = "Ви можете пізніше змінити це в параметрах";
 
 /* Button accepting changes setting the home page for the first time. */
 "HomePage.Set.Dialog.OK" = "Встановити домівку";
@@ -896,7 +896,7 @@
 "Menu.TrackingProtection.NoTrackersBlockedTitle" = "На цій сторінці Firefox не виявив жодного відомого йому стеження.";
 
 /* The title for tracking protection settings */
-"Menu.TrackingProtection.ProtectionSettings.Title" = "Налаштування захисту";
+"Menu.TrackingProtection.ProtectionSettings.Title" = "Параметри захисту";
 
 /* Title on tracking protection menu showing the domain. eg. Protections for mozilla.org */
 "Menu.TrackingProtection.TitlePrefix" = "Захист для %@";
@@ -1388,7 +1388,7 @@
 "Settings.DisplayTheme.SystemTheme.SectionHeader" = "Системна тема";
 
 /* System theme settings switch to choose whether to use the same theme as the system */
-"Settings.DisplayTheme.SystemTheme.SwitchTitle" = "Системна світла / темна тема";
+"Settings.DisplayTheme.SystemTheme.SwitchTitle" = "Повторювати тему системи";
 
 /* Theme picker settings section title */
 "Settings.DisplayTheme.ThemePicker.SectionHeader" = "Вибір теми";
@@ -1409,7 +1409,7 @@
 "Settings.FxA.DeviceName" = "Назва пристрою";
 
 /* Label used as a section title in the Firefox Accounts Settings screen. */
-"Settings.FxA.Sync.SectionName" = "Налаштування синхронізації";
+"Settings.FxA.Sync.SectionName" = "Параметри синхронізації";
 
 /* Title displayed in header of the FxA settings panel. */
 "Settings.FxA.Title" = "Обліковий запис Firefox";
@@ -1424,7 +1424,7 @@
 "Settings.Home.Option.JumpBackIn" = "Назад до";
 
 /* In the settings menu, in the Firefox homepage customization section, this is the title for the option that allows users to turn the Pocket Recommendations section on the Firefox homepage on or off */
-"Settings.Home.Option.Pocket" = "Рекомендовано Pocket";
+"Settings.Home.Option.Pocket" = "Рекомендації від Pocket";
 
 /* In the settings menu, in the Firefox homepage customization section, this is the title for the option that allows users to toggle Recently Saved section on the Firefox homepage on or off */
 "Settings.Home.Option.RecentlySaved" = "Недавно збережені";
@@ -1532,10 +1532,10 @@
 "Settings.NewTab.Option.ReadingList" = "Показувати список читання";
 
 /* Option in settings to turn on off pocket recommendations First argument is the pocket brand name */
-"Settings.NewTab.Option.RecommendedByPocket" = "Рекомендовано %@";
+"Settings.NewTab.Option.RecommendedByPocket" = "Рекомендації від %@";
 
 /* Descriptoin for the option in settings to turn on off pocket recommendations. First argument is the pocket brand name, second argument is the pocket product name. */
-"Settings.NewTab.Option.RecommendedByPocketDescription" = "Винятковий вміст, керований %1$@, що належить до родини %2$@";
+"Settings.NewTab.Option.RecommendedByPocketDescription" = "Добірні матеріали від %1$@, що належить до родини %2$@";
 
 /* Label used as an item in Settings. When touched it will open a dialog to configure the new tab behavior. */
 "Settings.NewTab.SectionName" = "Нова вкладка";

--- a/Shared/uk.lproj/Today.strings
+++ b/Shared/uk.lproj/Today.strings
@@ -62,10 +62,10 @@
 "TodayWidget.PocketWidgetGalleryDescription" = "Знаходьте захопливі історії та розповіді, що змушують задуматися, з усієї мережі, відібрані Pocket.";
 
 /* Sub label for medium size Firefox Pocket stories widge widget. Pocket is the name of another app. */
-"TodayWidget.PocketWidgetSubLabel" = "Firefox - рекомендовано Pocket";
+"TodayWidget.PocketWidgetSubLabel" = "Firefox - рекомендації від Pocket";
 
 /* Title for Firefox Pocket stories widget in Gallery View where user can add it to home screen. Pocket is the name of another app. */
-"TodayWidget.PocketWidgetTitle" = "Рекомендовано Pocket";
+"TodayWidget.PocketWidgetTitle" = "Рекомендації від Pocket";
 
 /* Open New Private Tab button label */
 "TodayWidget.PrivateTabButtonLabelV1" = "Приватний пошук";

--- a/Shared/vi.lproj/Localizable.strings
+++ b/Shared/vi.lproj/Localizable.strings
@@ -1439,7 +1439,7 @@
 "Settings.Home.Option.Shortcuts" = "Lối tắt";
 
 /* In the settings menu, on the Start at Home homepage customization option, this allows users to set this setting to return to the Homepage after four hours of inactivity. */
-"Settings.Home.Option.StartAtHome.AfterFourHours" = "Trang chủ sau bốn giờ không hoạt động";
+"Settings.Home.Option.StartAtHome.AfterFourHours" = "Trang chủ sau bốn tiếng không hoạt động";
 
 /* In the settings menu, on the Start at Home homepage customization option, this allows users to set this setting to return to the Homepage every time they open up Firefox */
 "Settings.Home.Option.StartAtHome.Always" = "Trang chủ";

--- a/WidgetKit/tt.lproj/Localizable.strings
+++ b/WidgetKit/tt.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+/* No comment provided by engineer. */
+"Open Firefox" = "Firefox-ны ачу";
+

--- a/WidgetKit/tt.lproj/WidgetIntents.strings
+++ b/WidgetKit/tt.lproj/WidgetIntents.strings
@@ -1,0 +1,33 @@
+/* (No Comment) */
+"2GqvPe" = "Копияләнгән сылтамага күчү";
+
+/* (No Comment) */
+"eHmH1H" = "Хосусый табларны ябу";
+
+/* (No Comment) */
+"eqyNJg" = "Тиз гамәл";
+
+/* (No Comment) */
+"eV8mOT" = "Тиз гамәл төре";
+
+/* (No Comment) */
+"PzSrmZ-2GqvPe" = "\"Копияләнгән сылтаманы ачу\"ны раслыйсызмы?";
+
+/* (No Comment) */
+"PzSrmZ-eHmH1H" = "\"Хосусый табларны чистарту\"ны раслыйсызмы?";
+
+/* (No Comment) */
+"PzSrmZ-scEmjs" = "\"Яңа хосусый эзләү\"не раслыйсызмы?";
+
+/* (No Comment) */
+"PzSrmZ-xRJbBP" = "\"Яңа эзләү\"не раслыйсызмы?";
+
+/* (No Comment) */
+"scEmjs" = "Яңа хосусый эзләү";
+
+/* (No Comment) */
+"w9jdPK" = "Тиз гамәл";
+
+/* (No Comment) */
+"xRJbBP" = "Яңа эзләү";
+

--- a/shipping_locales.txt
+++ b/shipping_locales.txt
@@ -6,6 +6,7 @@ ast
 az
 bg
 bn
+bo
 br
 bs
 ca
@@ -82,6 +83,7 @@ te
 th
 tl
 tr
+tt
 uk
 ur
 uz


### PR DESCRIPTION
# Overview

PR addresses https://github.com/mozilla-mobile/firefox-ios/issues/9379. 

This PR both updates shipping_locales.txt and also imports new localizations for `bo` (Tibetan) & `tt` (Tartar). Note that the rule for localization now is to support all languages that have >0% localizations done.  