### PR TITLE
Add #8969 [v96] Keyboard shortcuts with Link Taps

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -390,6 +390,8 @@
 		8A11C80F2731916E00AC7318 /* defaultOnlyTestList.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A11C80D2731916E00AC7318 /* defaultOnlyTestList.json */; };
 		8A11C8112731CFD700AC7318 /* ReaderModeStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */; };
 		8A11C8132731E54800AC7318 /* DictionaryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */; };
+		8A2783F1275FFDC50080D29D /* KeyboardPressesHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2783F0275FFDC50080D29D /* KeyboardPressesHandler.swift */; };
+		8A2825352760399B00395E66 /* KeyboardPressesHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2825342760399B00395E66 /* KeyboardPressesHandlerTests.swift */; };
 		8A8A05E42746ACAC004267A0 /* TabDisplayManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8A05E32746ACAC004267A0 /* TabDisplayManagerTests.swift */; };
 		8AA6ADB52742B567004EEE23 /* TelemetryWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA6ADB42742B567004EEE23 /* TelemetryWrapperTests.swift */; };
 		8AEE62C92756BA34003207D1 /* LoginsHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 8AEE62C62756BA34003207D1 /* LoginsHelper.js */; };
@@ -2543,6 +2545,8 @@
 		8A11C80D2731916E00AC7318 /* defaultOnlyTestList.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = defaultOnlyTestList.json; sourceTree = "<group>"; };
 		8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeStyleTests.swift; sourceTree = "<group>"; };
 		8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryExtensionsTests.swift; sourceTree = "<group>"; };
+		8A2783F0275FFDC50080D29D /* KeyboardPressesHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPressesHandler.swift; sourceTree = "<group>"; };
+		8A2825342760399B00395E66 /* KeyboardPressesHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPressesHandlerTests.swift; sourceTree = "<group>"; };
 		8A5143D6BF179870414566ED /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Search.strings; sourceTree = "<group>"; };
 		8A8A05E32746ACAC004267A0 /* TabDisplayManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDisplayManagerTests.swift; sourceTree = "<group>"; };
 		8AA6ADB42742B567004EEE23 /* TelemetryWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryWrapperTests.swift; sourceTree = "<group>"; };
@@ -5562,6 +5566,7 @@
 				39F4C1092045DB2E00746155 /* FocusHelper.swift */,
 				D0E55C4E1FB4FD23006DC274 /* FormPostHelper.swift */,
 				39DD030C1CD53E1900BC09B3 /* HomePageHelper.swift */,
+				8A2783F0275FFDC50080D29D /* KeyboardPressesHandler.swift */,
 				D3C3696D1CC6B78800348A61 /* LocalRequestHelper.swift */,
 				0BB5B30A1AC0AD1F0052877D /* LoginsHelper.swift */,
 				7482205B1DBAB56300EEEA72 /* MailProviders.swift */,
@@ -6175,6 +6180,7 @@
 				8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */,
 				D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */,
 				3943A81C1E9807C700D4F6DC /* FxAPushMessageTest.swift */,
+				8A2825342760399B00395E66 /* KeyboardPressesHandlerTests.swift */,
 				281B2BE91ADF4D90002917DC /* MockProfile.swift */,
 				E683F0A51E92E0820035D990 /* MockableHistory.swift */,
 				3B61CD581F2A750800D38DE1 /* PocketFeedTests.swift */,
@@ -8088,6 +8094,7 @@
 				D87F84AC20B891160091F2DA /* TabDisplayManager.swift in Sources */,
 				D0C95EF6201A55A800E4E51C /* BrowserViewController+UIDropInteractionDelegate.swift in Sources */,
 				D31CF65C1CC1959A001D0BD0 /* PrivilegedRequest.swift in Sources */,
+				8A2783F1275FFDC50080D29D /* KeyboardPressesHandler.swift in Sources */,
 				D8D33A7D1FBD080300A20A28 /* SnapKitExtensions.swift in Sources */,
 				E650755C1E37F747006961AC /* Swizzling.m in Sources */,
 				74821FC51DB56A2500EEEA72 /* OpenWithSettingsViewController.swift in Sources */,
@@ -8357,6 +8364,7 @@
 				A83E5B1D1C1DA8D80026D912 /* UIPasteboardExtensionsTests.swift in Sources */,
 				8AFE4C2127480D0C00B97C65 /* TabTrayViewControllerTests.swift in Sources */,
 				28D52E2F1BCDF53900187A1D /* ResetTests.swift in Sources */,
+				8A2825352760399B00395E66 /* KeyboardPressesHandlerTests.swift in Sources */,
 				E1D8BC7A21FF7A0000B100BD /* TPStatsBlocklistsTests.swift in Sources */,
 				D82ED2641FEB3C420059570B /* DefaultSearchPrefsTests.swift in Sources */,
 				CA24B53B24ABFE5D0093848C /* LoginsListDataSourceHelperTests.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1561,6 +1561,13 @@ extension BrowserViewController: LibraryPanelDelegate {
 
     func libraryPanel(didSelectURL url: URL, visitType: VisitType) {
         guard let tab = tabManager.selectedTab else { return }
+
+        // Handle keyboard shortcuts from homepage with url selection (ex: Cmd + Tap on Link; which is a cell in this case)
+        if navigateLinkShortcutIfNeeded(url: url) {
+            libraryDrawerViewController?.close()
+            return
+        }
+
         finishEditingAndSubmit(url, visitType: visitType, forTab: tab)
         libraryDrawerViewController?.close()
     }
@@ -1613,6 +1620,12 @@ extension BrowserViewController: HomePanelDelegate {
             tab.urlType = .googleTopSite
             searchTelemetry?.shouldSetGoogleTopSiteSearch = true
         }
+
+        // Handle keyboard shortcuts from homepage with url selection (ex: Cmd + Tap on Link; which is a cell in this case)
+        if navigateLinkShortcutIfNeeded(url: url) {
+            return
+        }
+
         finishEditingAndSubmit(url, visitType: visitType, forTab: tab)
     }
 
@@ -2221,18 +2234,13 @@ extension BrowserViewController: ContextMenuHelperDelegate {
     }
 
     override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
-        keyboardPressesHandler.handleKeyPress(presses, with: event)
         super.pressesBegan(presses, with: event)
-    }
-
-    override func pressesCancelled(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
-        keyboardPressesHandler.handleKeyRelease(presses, with: event)
-        super.pressesCancelled(presses, with: event)
+        keyboardPressesHandler.handlePressesBegan(presses, with: event)
     }
 
     override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
-        keyboardPressesHandler.handleKeyRelease(presses, with: event)
-        super.pressesBegan(presses, with: event)
+        super.pressesEnded(presses, with: event)
+        keyboardPressesHandler.handlePressesEnded(presses, with: event)
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -104,6 +104,7 @@ extension BrowserViewController {
         // when recording telemetry for key commands.
         TelemetryWrapper.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "new-tab"])
         openBlankNewTab(focusLocationField: true, isPrivate: true)
+        keyboardPressesHandler.reset()
     }
 
     @objc private func closeTabKeyCommand() {
@@ -126,6 +127,8 @@ extension BrowserViewController {
         } else if let firstTab = tabs.first {
             tabManager.selectTab(firstTab)
         }
+
+        keyboardPressesHandler.reset()
     }
 
     @objc private func previousTabKeyCommand() {
@@ -140,6 +143,8 @@ extension BrowserViewController {
         } else if let lastTab = tabs.last {
             tabManager.selectTab(lastTab)
         }
+
+        keyboardPressesHandler.reset()
     }
 
     @objc private func showTabTrayKeyCommand() {
@@ -233,9 +238,9 @@ extension BrowserViewController {
         return commands
     }
 
-    // MARK: Link shortcuts
+    // MARK: Keyboards + Link click shortcuts
 
-    func navigateLinkShortcut(url: URL) -> Bool {
+    func navigateLinkShortcutIfNeeded(url: URL) -> Bool {
         var shouldCancelHandler = false
 
         // Open tab in background || Open in new tab

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -214,8 +214,10 @@ extension BrowserViewController {
             UIKeyCommand(action: #selector(showDownloadsKeyCommand), input: "j", modifierFlags: .command, discoverabilityTitle: "Show Downloads"),
 
             // Window
-            UIKeyCommand(action: #selector(nextTabKeyCommand), input: "]", modifierFlags: [.command, .shift], discoverabilityTitle: .ShowNextTabTitle),
-            UIKeyCommand(action: #selector(previousTabKeyCommand), input: "[", modifierFlags: [.command, .shift], discoverabilityTitle: .ShowPreviousTabTitle),
+            UIKeyCommand(action: #selector(nextTabKeyCommand), input: "]", modifierFlags: [.command, .shift]),
+            UIKeyCommand(action: #selector(previousTabKeyCommand), input: "[", modifierFlags: [.command, .shift]),
+            UIKeyCommand(action: #selector(nextTabKeyCommand), input: "\t", modifierFlags: .control, discoverabilityTitle: .ShowNextTabTitle),
+            UIKeyCommand(action: #selector(previousTabKeyCommand), input: "\t", modifierFlags: [.control, .shift], discoverabilityTitle: .ShowPreviousTabTitle),
             UIKeyCommand(action: #selector(showTabTrayKeyCommand), input: "\\", modifierFlags: [.command, .shift], discoverabilityTitle: .ShowTabTrayFromTabKeyCodeTitle),
             UIKeyCommand(action: #selector(showTabTrayKeyCommand), input: "\t", modifierFlags: [.command, .alternate]),
             // TODO: Show tab # 1-9 - Command + 1-9

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -187,7 +187,7 @@ extension BrowserViewController: WKUIDelegate {
                 TelemetryWrapper.recordEvent(category: .action, method: .add, object: .bookmark, value: .contextMenu)
             })
 
-            actions.append(UIAction(title: .ContextMenuDownloadLink, image: UIImage.templateImageNamed("menu-panel-Downloads"), identifier: UIAction.Identifier("linkContextMenu.download")) {_ in
+            actions.append(UIAction(title: .ContextMenuDownloadLink, image: UIImage.templateImageNamed("menu-panel-Downloads"), identifier: UIAction.Identifier("linkContextMenu.download")) { _ in
                 // This checks if download is a blob, if yes, begin blob download process
                 if !DownloadContentScript.requestBlobDownload(url: url, tab: currentTab) {
                     //if not a blob, set pendingDownloadWebView and load the request in the webview, which will trigger the WKWebView navigationResponse delegate function and eventually downloadHelper.open()

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -467,6 +467,12 @@ extension BrowserViewController: WKNavigationDelegate {
             return
         }
 
+        // Handle keyboard shortcuts on link presses from webpage navigation (ex: Cmd + Tap on Link)
+        if navigationAction.navigationType == .linkActivated, navigateLinkShortcutIfNeeded(url: url) {
+            decisionHandler(.cancel)
+            return
+        }
+
         // This is the normal case, opening a http or https url, which we handle by loading them in this WKWebView. We
         // always allow this. Additionally, data URIs are also handled just like normal web pages.
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -581,13 +581,6 @@ extension BrowserViewController: WKNavigationDelegate {
 
             tab.mimeType = response.mimeType
         }
-        
-        if isOnlyCmdPressed {
-            guard let url = webView.url, let isPrivate = self.tabManager.selectedTab?.isPrivate else { return }
-            homePanelDidRequestToOpenInNewTab(url, isPrivate: isPrivate)
-            isOnlyCmdPressed = false
-            decisionHandler(.cancel)
-        }
 
         // If none of our helpers are responsible for handling this response,
         // just let the webview handle it as normal.

--- a/Client/Frontend/Browser/KeyboardPressesHandler.swift
+++ b/Client/Frontend/Browser/KeyboardPressesHandler.swift
@@ -17,13 +17,8 @@ class KeyboardPressesHandler {
     @available(iOS 13.4, *)
     private lazy var keysPressed: [UIKeyboardHIDUsage] = []
 
-    // When a user clicks on a cell on the home page, the navigation type isn't a WKNavigationType.link type. Since WKNavigationDelegate decidePolicyFor is
-    // called multiple times for a navigation action of type WKNavigationType.other, we need a way to only open one tab if the CMD key is still pressed.
-    // User will be able to reuse the command once the delegate calls didFinish. This edge case only applies to the homepage.
-    var enableHomePageCmdPress: Bool = true
-
     var isOnlyCmdPressed: Bool {
-        return isCmdPressed && !isShiftPressed && enableHomePageCmdPress
+        return isCmdPressed && !isShiftPressed
     }
 
     var isCmdAndShiftPressed: Bool {
@@ -34,12 +29,19 @@ class KeyboardPressesHandler {
         return isOptionPressed && !isCmdPressed
     }
 
-    func handleKeyPress(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+    func handlePressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
         handlePress(presses, with: event, pressedIfFound: true)
     }
 
-    func handleKeyRelease(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+    func handlePressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
         handlePress(presses, with: event, pressedIfFound: false)
+    }
+
+    // Needed on some UIKeyCommands shortcuts - when a tab changed is involved
+    func reset() {
+        if #available(iOS 13.4, *) {
+            keysPressed.removeAll()
+        }
     }
 
     // MARK: Private

--- a/Client/Frontend/Browser/KeyboardPressesHandler.swift
+++ b/Client/Frontend/Browser/KeyboardPressesHandler.swift
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import UIKit
+
+/// Handler to detect keyboard presses for shortcut taps on links
+/// - Cmd + Tap on Link -> Open link in Background
+/// - Cmd + Shift + Tap on Link -> Open link in New Tab
+/// - Option + Tap on Link -> Download Link
+///
+/// A better solution would be using pointer:
+/// https://developer.apple.com/documentation/uikit/pointer_interactions/integrating_pointer_interactions_into_your_ipad_app
+class KeyboardPressesHandler {
+
+    @available(iOS 13.4, *)
+    private lazy var keysPressed: [UIKeyboardHIDUsage] = []
+
+    // When a user clicks on a cell on the home page, the navigation type isn't a WKNavigationType.link type. Since WKNavigationDelegate decidePolicyFor is
+    // called multiple times for a navigation action of type WKNavigationType.other, we need a way to only open one tab if the CMD key is still pressed.
+    // User will be able to reuse the command once the delegate calls didFinish. This edge case only applies to the homepage.
+    var enableHomePageCmdPress: Bool = true
+
+    var isOnlyCmdPressed: Bool {
+        return isCmdPressed && !isShiftPressed && enableHomePageCmdPress
+    }
+
+    var isCmdAndShiftPressed: Bool {
+        return isCmdPressed && isShiftPressed
+    }
+
+    var isOnlyOptionPressed: Bool {
+        return isOptionPressed && !isCmdPressed
+    }
+
+    func handleKeyPress(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        handlePress(presses, with: event, pressedIfFound: true)
+    }
+
+    func handleKeyRelease(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        handlePress(presses, with: event, pressedIfFound: false)
+    }
+
+    // MARK: Private
+
+    private var isCmdPressed: Bool {
+        if #available(iOS 13.4, *) {
+            return keysPressed.contains(.keyboardLeftGUI) || keysPressed.contains(.keyboardRightGUI)
+        } else {
+            return false
+        }
+    }
+
+    private var isShiftPressed: Bool {
+        if #available(iOS 13.4, *) {
+            return keysPressed.contains(.keyboardLeftShift) || keysPressed.contains(.keyboardRightShift)
+        } else {
+            return false
+        }
+    }
+
+    private var isOptionPressed: Bool {
+        if #available(iOS 13.4, *) {
+            return keysPressed.contains(.keyboardLeftAlt) || keysPressed.contains(.keyboardRightAlt)
+        } else {
+            return false
+        }
+    }
+
+    /// Handle keyboard presses to determine certain commands
+    /// - Parameters:
+    ///   - presses: A set of UIPress instances that represent the presses that occurred
+    ///   - event: The event to which the presses belong
+    ///   - pressedIfFound: Determines if we should press or not the keys that were found
+    private func handlePress(_ presses: Set<UIPress>, with event: UIPressesEvent?, pressedIfFound: Bool) {
+        guard #available(iOS 13.4, *) else { return }
+
+        for press in presses {
+            guard let key = press.key?.keyCode else { continue }
+            if pressedIfFound {
+                keysPressed.append(key)
+            } else {
+                keysPressed.removeAll(where: { $0 == key })
+            }
+        }
+    }
+}

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -69,13 +69,19 @@ struct UXSizeClasses {
 // MARK: - Home Panel
 
 protocol HomePanelDelegate: AnyObject {
-    func homePanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool)
+    func homePanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool, selectNewTab: Bool)
     func homePanel(didSelectURL url: URL, visitType: VisitType, isGoogleTopSite: Bool)
     func homePanelDidRequestToOpenLibrary(panel: LibraryPanelType)
     func homePanelDidRequestToOpenTabTray(withFocusedTab tabToFocus: Tab?)
     func homePanelDidRequestToCustomizeHomeSettings()
     func homePanelDidPresentContextualHint(type: ContextualHintViewType)
     func homePanelDidDismissContextualHint(type: ContextualHintViewType)
+}
+
+extension HomePanelDelegate {
+    func homePanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool, selectNewTab: Bool = false) {
+        homePanelDidRequestToOpenInNewTab(url, isPrivate: isPrivate, selectNewTab: selectNewTab)
+    }
 }
 
 protocol HomePanel: NotificationThemeable {

--- a/ClientTests/KeyboardPressesHandlerTests.swift
+++ b/ClientTests/KeyboardPressesHandlerTests.swift
@@ -1,0 +1,264 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+@testable import Client
+
+import XCTest
+
+@available(iOS 13.4, *)
+class KeyboardPressesHandlerTests: XCTestCase {
+
+    func testDefaultsPressedAreFalse() {
+        let handler = KeyboardPressesHandler()
+        XCTAssertEqual(handler.isOnlyCmdPressed, false)
+        XCTAssertEqual(handler.isOnlyOptionPressed, false)
+        XCTAssertEqual(handler.isCmdAndShiftPressed, false)
+        handler.handlePressesBegan(Set(), with: nil)
+    }
+
+    func testPressedAreFalse_withEmptyPresses() {
+        let handler = KeyboardPressesHandler()
+        handler.handlePressesBegan(Set(), with: nil)
+
+        XCTAssertEqual(handler.isOnlyCmdPressed, false)
+        XCTAssertEqual(handler.isOnlyOptionPressed, false)
+        XCTAssertEqual(handler.isCmdAndShiftPressed, false)
+    }
+
+    func testPressedAreFalse_withRandomKeyPress() {
+        let handler = KeyboardPressesHandler()
+        let randomPress = createPress(keyCode: .keyboard0)
+        handler.handlePressesBegan(Set([randomPress]), with: nil)
+
+        XCTAssertEqual(handler.isOnlyCmdPressed, false)
+        XCTAssertEqual(handler.isOnlyOptionPressed, false)
+        XCTAssertEqual(handler.isCmdAndShiftPressed, false)
+    }
+
+    // MARK: isOnlyCmdPressed
+
+    func testCmdTrue_withLeftCmdPress() {
+        let handler = KeyboardPressesHandler()
+        let cmdPress = createPress(keyCode: .keyboardLeftGUI)
+        handler.handlePressesBegan(Set([cmdPress]), with: nil)
+
+        XCTAssertEqual(handler.isOnlyCmdPressed, true)
+        XCTAssertEqual(handler.isOnlyOptionPressed, false)
+        XCTAssertEqual(handler.isCmdAndShiftPressed, false)
+    }
+
+    func testCmdTrue_withRightCmdPress() {
+        let handler = KeyboardPressesHandler()
+        let cmdPress = createPress(keyCode: .keyboardRightGUI)
+        handler.handlePressesBegan(Set([cmdPress]), with: nil)
+
+        XCTAssertEqual(handler.isOnlyCmdPressed, true)
+        XCTAssertEqual(handler.isOnlyOptionPressed, false)
+        XCTAssertEqual(handler.isCmdAndShiftPressed, false)
+    }
+
+    func testCmdFalse_withCmdShiftPressed() {
+        let handler = KeyboardPressesHandler()
+        let cmdPress = createPress(keyCode: .keyboardLeftGUI)
+        let shiftPress = createPress(keyCode: .keyboardLeftShift)
+        handler.handlePressesBegan(Set([cmdPress, shiftPress]), with: nil)
+
+        XCTAssertEqual(handler.isOnlyCmdPressed, false)
+        XCTAssertEqual(handler.isOnlyOptionPressed, false)
+        XCTAssertEqual(handler.isCmdAndShiftPressed, true)
+    }
+
+    func testCmdTrue_withCmdOptionPressed() {
+        let handler = KeyboardPressesHandler()
+        let cmdPress = createPress(keyCode: .keyboardLeftGUI)
+        let altPress = createPress(keyCode: .keyboardLeftAlt)
+        handler.handlePressesBegan(Set([cmdPress, altPress]), with: nil)
+
+        XCTAssertEqual(handler.isOnlyCmdPressed, true)
+        XCTAssertEqual(handler.isOnlyOptionPressed, false)
+        XCTAssertEqual(handler.isCmdAndShiftPressed, false)
+    }
+
+    func testCmdFalse_withCmdPressedAndRelease() {
+        let handler = KeyboardPressesHandler()
+        let cmdPress = createPress(keyCode: .keyboardLeftGUI)
+        handler.handlePressesBegan(Set([cmdPress]), with: nil)
+        handler.handlePressesEnded(Set([cmdPress]), with: nil)
+
+        XCTAssertEqual(handler.isOnlyCmdPressed, false)
+        XCTAssertEqual(handler.isOnlyOptionPressed, false)
+        XCTAssertEqual(handler.isCmdAndShiftPressed, false)
+    }
+
+    func testCmdTrue_withRandomKeyReleased() {
+        let handler = KeyboardPressesHandler()
+        let cmdPress = createPress(keyCode: .keyboardLeftGUI)
+        let randomPress = createPress(keyCode: .keyboard0)
+        handler.handlePressesBegan(Set([cmdPress, randomPress]), with: nil)
+        handler.handlePressesEnded(Set([randomPress]), with: nil)
+
+        XCTAssertEqual(handler.isOnlyCmdPressed, true)
+        XCTAssertEqual(handler.isOnlyOptionPressed, false)
+        XCTAssertEqual(handler.isCmdAndShiftPressed, false)
+    }
+
+    // MARK: isCmdAndShiftPressed
+
+    func testCmdAndShiftTrue_withLeftPresses() {
+        let handler = KeyboardPressesHandler()
+        let cmdPress = createPress(keyCode: .keyboardLeftGUI)
+        let shiftPress = createPress(keyCode: .keyboardLeftShift)
+        handler.handlePressesBegan(Set([cmdPress, shiftPress]), with: nil)
+
+        XCTAssertEqual(handler.isOnlyCmdPressed, false)
+        XCTAssertEqual(handler.isOnlyOptionPressed, false)
+        XCTAssertEqual(handler.isCmdAndShiftPressed, true)
+    }
+
+    func testCmdAndShiftTrue_withRightPresses() {
+        let handler = KeyboardPressesHandler()
+        let cmdPress = createPress(keyCode: .keyboardRightGUI)
+        let shiftPress = createPress(keyCode: .keyboardRightShift)
+        handler.handlePressesBegan(Set([cmdPress, shiftPress]), with: nil)
+
+        XCTAssertEqual(handler.isOnlyCmdPressed, false)
+        XCTAssertEqual(handler.isOnlyOptionPressed, false)
+        XCTAssertEqual(handler.isCmdAndShiftPressed, true)
+    }
+
+    func testCmdAndShiftTrue_withCmdOptionPressed() {
+        let handler = KeyboardPressesHandler()
+        let cmdPress = createPress(keyCode: .keyboardLeftGUI)
+        let shiftPress = createPress(keyCode: .keyboardLeftShift)
+        let optionPress = createPress(keyCode: .keyboardLeftAlt)
+        handler.handlePressesBegan(Set([cmdPress, shiftPress, optionPress]), with: nil)
+
+        XCTAssertEqual(handler.isOnlyCmdPressed, false)
+        XCTAssertEqual(handler.isOnlyOptionPressed, false)
+        XCTAssertEqual(handler.isCmdAndShiftPressed, true)
+    }
+
+    func testCmdAndShiftFalse_withCmdShiftPressedAndRelease() {
+        let handler = KeyboardPressesHandler()
+        let cmdPress = createPress(keyCode: .keyboardLeftGUI)
+        let shiftPress = createPress(keyCode: .keyboardLeftShift)
+        handler.handlePressesBegan(Set([cmdPress, shiftPress]), with: nil)
+        handler.handlePressesEnded(Set([cmdPress, shiftPress]), with: nil)
+
+        XCTAssertEqual(handler.isOnlyCmdPressed, false)
+        XCTAssertEqual(handler.isOnlyOptionPressed, false)
+        XCTAssertEqual(handler.isCmdAndShiftPressed, false)
+    }
+
+    func testCmdAndShiftTrue_withReversedOrderPress() {
+        let handler = KeyboardPressesHandler()
+        let cmdPress = createPress(keyCode: .keyboardLeftGUI)
+        let shiftPress = createPress(keyCode: .keyboardLeftShift)
+        handler.handlePressesBegan(Set([shiftPress, cmdPress]), with: nil)
+
+        XCTAssertEqual(handler.isOnlyCmdPressed, false)
+        XCTAssertEqual(handler.isOnlyOptionPressed, false)
+        XCTAssertEqual(handler.isCmdAndShiftPressed, true)
+    }
+
+    func testCmdAndShiftTrue_withRandomKeyReleased() {
+        let handler = KeyboardPressesHandler()
+        let cmdPress = createPress(keyCode: .keyboardLeftGUI)
+        let shiftPress = createPress(keyCode: .keyboardLeftShift)
+        let randomPress = createPress(keyCode: .keyboard0)
+        handler.handlePressesBegan(Set([cmdPress, shiftPress, randomPress]), with: nil)
+        handler.handlePressesEnded(Set([randomPress]), with: nil)
+
+        XCTAssertEqual(handler.isOnlyCmdPressed, false)
+        XCTAssertEqual(handler.isOnlyOptionPressed, false)
+        XCTAssertEqual(handler.isCmdAndShiftPressed, true)
+    }
+
+    // MARK: isOnlyOptionPressed
+
+    func testOptionTrue_withLeftPress() {
+        let handler = KeyboardPressesHandler()
+        let altPress = createPress(keyCode: .keyboardLeftAlt)
+        handler.handlePressesBegan(Set([altPress]), with: nil)
+
+        XCTAssertEqual(handler.isOnlyCmdPressed, false)
+        XCTAssertEqual(handler.isOnlyOptionPressed, true)
+        XCTAssertEqual(handler.isCmdAndShiftPressed, false)
+    }
+
+    func testOptionTrue_withRightPress() {
+        let handler = KeyboardPressesHandler()
+        let altPress = createPress(keyCode: .keyboardRightAlt)
+        handler.handlePressesBegan(Set([altPress]), with: nil)
+
+        XCTAssertEqual(handler.isOnlyCmdPressed, false)
+        XCTAssertEqual(handler.isOnlyOptionPressed, true)
+        XCTAssertEqual(handler.isCmdAndShiftPressed, false)
+    }
+
+    func testOptionFalse_withPressedAndReleased() {
+        let handler = KeyboardPressesHandler()
+        let altPress = createPress(keyCode: .keyboardRightAlt)
+        handler.handlePressesBegan(Set([altPress]), with: nil)
+        handler.handlePressesEnded(Set([altPress]), with: nil)
+
+        XCTAssertEqual(handler.isOnlyCmdPressed, false)
+        XCTAssertEqual(handler.isOnlyOptionPressed, false)
+        XCTAssertEqual(handler.isCmdAndShiftPressed, false)
+    }
+
+    func testOptionTrue_withRandomKeyReleased() {
+        let handler = KeyboardPressesHandler()
+        let altPress = createPress(keyCode: .keyboardRightAlt)
+        let randomPress = createPress(keyCode: .keyboard0)
+        handler.handlePressesBegan(Set([altPress, randomPress]), with: nil)
+        handler.handlePressesEnded(Set([randomPress]), with: nil)
+
+        XCTAssertEqual(handler.isOnlyCmdPressed, false)
+        XCTAssertEqual(handler.isOnlyOptionPressed, true)
+        XCTAssertEqual(handler.isCmdAndShiftPressed, false)
+    }
+}
+
+// MARK: Helpers
+@available(iOS 13.4, *)
+extension KeyboardPressesHandlerTests {
+    func createPress(keyCode: UIKeyboardHIDUsage) -> MockPress {
+        let key = MockKey(keyCode: keyCode)
+        return MockPress(mockKey: key)
+    }
+}
+
+@available(iOS 13.4, *)
+class MockKey: UIKey {
+
+    let mockKeyCode: UIKeyboardHIDUsage
+    override var keyCode: UIKeyboardHIDUsage {
+        return mockKeyCode
+    }
+
+    init(keyCode: UIKeyboardHIDUsage) {
+        self.mockKeyCode = keyCode
+        super.init()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+@available(iOS 13.4, *)
+class MockPress: UIPress {
+
+    let mockKey: MockKey
+    override var key: UIKey {
+        return mockKey
+    }
+
+    init(mockKey: MockKey) {
+        self.mockKey = mockKey
+    }
+}


### PR DESCRIPTION
PR for the following shortcuts for #8969:
- Open link in background -> Command + Tap link
- Open link in new tab -> Command + Shift + Tap link
- Download link -> Option + Tap link

We have a new KeyboardPressesHandler to help us handle those shortcuts.

Note: Command + Tap link was already implemented, but I changed the behavior as following:
- Links opened from webpage are handled in `BrowserViewController+WebViewDelegates`with navigation link `.linkActivated`
- 'Links' opened from firefox home page are handled differently, since handling them in decidePolicyFor:decidePolicyFor was opening the door for multiple issues (tab opening in double/when we don't want it to, so we needed flags to disable that and it wasn't working all of the time)