### PR TITLE
#9604 Firefox home improvements

### DIFF
--- a/Client/Frontend/Home/FirefoxHomeRecentlySavedViewModel.swift
+++ b/Client/Frontend/Home/FirefoxHomeRecentlySavedViewModel.swift
@@ -23,6 +23,7 @@ class FirefoxHomeRecentlySavedViewModel {
     private lazy var siteImageHelper = SiteImageHelper(profile: profile)
     private var readingListItems = [ReadingListItem]()
     private var recentBookmarks = [BookmarkItem]()
+    private let dataQueue = DispatchQueue(label: "recentlySavedDataQueue")
 
     init(isZeroSearch: Bool, profile: Profile) {
         self.isZeroSearch = isZeroSearch
@@ -46,7 +47,7 @@ class FirefoxHomeRecentlySavedViewModel {
     func updateData(completion: @escaping () -> Void) {
         let group = DispatchGroup()
         group.enter()
-        profile.places.getRecentBookmarks(limit: RecentlySavedCollectionCellUX.bookmarkItemsLimit).uponQueue(.main, block: { [weak self] result in
+        profile.places.getRecentBookmarks(limit: RecentlySavedCollectionCellUX.bookmarkItemsLimit).uponQueue(dataQueue, block: { [weak self] result in
             self?.updateRecentBookmarks(bookmarks: result.successValue ?? [])
             group.leave()
         })

--- a/Client/Frontend/Home/FirefoxHomeRecentlySavedViewModel.swift
+++ b/Client/Frontend/Home/FirefoxHomeRecentlySavedViewModel.swift
@@ -23,7 +23,7 @@ class FirefoxHomeRecentlySavedViewModel {
     private lazy var siteImageHelper = SiteImageHelper(profile: profile)
     private var readingListItems = [ReadingListItem]()
     private var recentBookmarks = [BookmarkItem]()
-    private let dataQueue = DispatchQueue(label: "recentlySavedDataQueue")
+    private let dataQueue = DispatchQueue(label: "com.moz.recentlySaved.queue")
 
     init(isZeroSearch: Bool, profile: Profile) {
         self.isZeroSearch = isZeroSearch

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -225,11 +225,14 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
     }
 
     var isRecentlySavedSectionEnabled: Bool {
-        guard featureFlags.isFeatureActiveForBuild(.recentlySaved),
-              homescreen.sectionsEnabled[.recentlySaved] == true,
-              featureFlags.userPreferenceFor(.recentlySaved) == UserFeaturePreference.enabled
-        else { return false }
+        return featureFlags.isFeatureActiveForBuild(.recentlySaved)
+        && homescreen.sectionsEnabled[.recentlySaved] == true
+        && featureFlags.userPreferenceFor(.recentlySaved) == UserFeaturePreference.enabled
+    }
 
+    // Recently saved section can be enabled but not shown if it has no data - Data is loaded asynchronous
+    var isRecentlySavedSectionShown: Bool {
+        guard isRecentlySavedSectionEnabled else { return false }
         return recentlySavedViewModel.hasData
     }
 
@@ -760,7 +763,7 @@ extension FirefoxHomeViewController: UICollectionViewDelegateFlowLayout {
         case .historyHighlights:
             return isHistoryHightlightsSectionEnabled ? getHeaderSize(forSection: section) : .zero
         case .recentlySaved:
-            return isRecentlySavedSectionEnabled ? getHeaderSize(forSection: section) : .zero
+            return isRecentlySavedSectionShown ? getHeaderSize(forSection: section) : .zero
         case .customizeHome:
             return .zero
         }
@@ -811,7 +814,7 @@ extension FirefoxHomeViewController {
         case .jumpBackIn:
             return isJumpBackInSectionEnabled ? 1 : 0
         case .recentlySaved:
-            return isRecentlySavedSectionEnabled ? 1 : 0
+            return isRecentlySavedSectionShown ? 1 : 0
         case .historyHighlights:
             return isHistoryHightlightsSectionEnabled ? 1 : 0
         case .libraryShortcuts:
@@ -936,8 +939,13 @@ extension FirefoxHomeViewController: DataObserverDelegate {
         // TODO: Reload with a protocol comformance once all sections are standardized
         // Idea is that each section will load it's data from it's own view model
         if shouldUpdateData {
-            recentlySavedViewModel.updateData {}
-            jumpBackInViewModel.updateData {}
+            if isRecentlySavedSectionEnabled {
+                recentlySavedViewModel.updateData {}
+            }
+
+            if isJumpBackInSectionEnabled {
+                jumpBackInViewModel.updateData {}
+            }
         }
 
         collectionView?.reloadData()

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -230,8 +230,8 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
         && featureFlags.userPreferenceFor(.recentlySaved) == UserFeaturePreference.enabled
     }
 
-    // Recently saved section can be enabled but not shown if it has no data - Data is loaded asynchronous
-    var isRecentlySavedSectionShown: Bool {
+    // Recently saved section can be enabled but not shown if it has no data - Data is loaded asynchronously
+    var shouldShowRecentlySavedSection: Bool {
         guard isRecentlySavedSectionEnabled else { return false }
         return recentlySavedViewModel.hasData
     }
@@ -763,7 +763,7 @@ extension FirefoxHomeViewController: UICollectionViewDelegateFlowLayout {
         case .historyHighlights:
             return isHistoryHightlightsSectionEnabled ? getHeaderSize(forSection: section) : .zero
         case .recentlySaved:
-            return isRecentlySavedSectionShown ? getHeaderSize(forSection: section) : .zero
+            return shouldShowRecentlySavedSection ? getHeaderSize(forSection: section) : .zero
         case .customizeHome:
             return .zero
         }
@@ -814,7 +814,7 @@ extension FirefoxHomeViewController {
         case .jumpBackIn:
             return isJumpBackInSectionEnabled ? 1 : 0
         case .recentlySaved:
-            return isRecentlySavedSectionShown ? 1 : 0
+            return shouldShowRecentlySavedSection ? 1 : 0
         case .historyHighlights:
             return isHistoryHightlightsSectionEnabled ? 1 : 0
         case .libraryShortcuts:


### PR DESCRIPTION
Possible improvements for the v40 issue #9604 with the following changes on Firefox Home View controller: 
- Only `updateData` for jumpBackIn and recentlySaved sections when they are enabled
- Load data on the Recently saved section on a queue instead of `.main`