### PR TITLE
[Improvement] [v40.1] - Made tab tray screenshot setup more async

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -675,17 +675,27 @@ class Tab: NSObject {
     }
 
     func setScreenshot(_ screenshot: UIImage?) {
-        // check if screenshot is same color as background
-        if let val = screenshot, let avgColor = val.averageColor() {
-            let backgroundColor = LegacyThemeManager.instance.current.browser.background
-            guard !avgColor.isEqual(backgroundColor) else {
-                self.screenshot = nil
-                return
+        // Added an async queue queue
+        let queueName = "com.moz.tabscreenshot.queue"
+        DispatchQueue(label: queueName).async {
+            if let val = screenshot {
+                val.averageColor(completion: { color in
+                    DispatchQueue.main.async {
+                        // check if screenshot is same color as background
+                        if let avgColor = color {
+                            let backgroundColor = LegacyThemeManager.instance.current.browser.background
+                            guard !avgColor.isEqual(backgroundColor) else {
+                                self.screenshot = nil
+                                    return
+                            }
+                            self.screenshot = screenshot
+                        }
+                    }
+                })
             }
-            self.screenshot = screenshot
         }
     }
-
+    
     func toggleChangeUserAgent() {
         changedUserAgent = !changedUserAgent
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -146,7 +146,6 @@ class Tab: NSObject {
     }
 
     var userActivity: NSUserActivity?
-
     var webView: WKWebView?
     var tabDelegate: TabDelegate?
     weak var urlDidChangeDelegate: URLChangeDelegate?     // TODO: generalize this.
@@ -195,6 +194,10 @@ class Tab: NSObject {
         }
         return false
     }
+
+    // Added an async queue queue
+    let queueName = "com.moz.tabscreenshot.queue"
+    let tabScreenshotQueue = OperationQueue()
 
     var mimeType: String?
     var isEditing: Bool = false
@@ -281,6 +284,8 @@ class Tab: NSObject {
         self.nightMode = false
         self.noImageMode = false
         self.browserViewController = bvc
+        self.tabScreenshotQueue.name = queueName
+        self.tabScreenshotQueue.qualityOfService = .userInteractive
         super.init()
         self.isPrivate = isPrivate
         debugTabCount += 1
@@ -470,6 +475,8 @@ class Tab: NSObject {
         }
         checkTabCount(failures: 0)
         #endif
+        
+        tabScreenshotQueue.cancelAllOperations()
     }
 
     func close() {
@@ -675,9 +682,7 @@ class Tab: NSObject {
     }
 
     func setScreenshot(_ screenshot: UIImage?) {
-        // Added an async queue queue
-        let queueName = "com.moz.tabscreenshot.queue"
-        DispatchQueue(label: queueName).async {
+        tabScreenshotQueue.addOperation {
             guard let val = screenshot else { return }
             val.averageColor(completion: { color in
                 DispatchQueue.main.async {

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -678,21 +678,19 @@ class Tab: NSObject {
         // Added an async queue queue
         let queueName = "com.moz.tabscreenshot.queue"
         DispatchQueue(label: queueName).async {
-            if let val = screenshot {
-                val.averageColor(completion: { color in
-                    DispatchQueue.main.async {
-                        // check if screenshot is same color as background
-                        if let avgColor = color {
-                            let backgroundColor = LegacyThemeManager.instance.current.browser.background
-                            guard !avgColor.isEqual(backgroundColor) else {
-                                self.screenshot = nil
-                                    return
-                            }
-                            self.screenshot = screenshot
-                        }
+            guard let val = screenshot else { return }
+            val.averageColor(completion: { color in
+                DispatchQueue.main.async {
+                    // check if screenshot is same color as background
+                    guard let avgColor = color else { return }
+                    let backgroundColor = LegacyThemeManager.instance.current.browser.background
+                    guard !avgColor.isEqual(backgroundColor) else {
+                        self.screenshot = nil
+                            return
                     }
-                })
-            }
+                    self.screenshot = screenshot
+                }
+            })
         }
     }
     

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -686,7 +686,7 @@ class Tab: NSObject {
                     let backgroundColor = LegacyThemeManager.instance.current.browser.background
                     guard !avgColor.isEqual(backgroundColor) else {
                         self.screenshot = nil
-                            return
+                        return
                     }
                     self.screenshot = screenshot
                 }

--- a/ThirdParty/UIImageColors.swift
+++ b/ThirdParty/UIImageColors.swift
@@ -286,11 +286,7 @@ extension UIImage {
 
         // core image filter that resamples an image down to 1x1 pixels
         // so you can read the most dominant color in an imagage
-        guard let filter = CIFilter(name: "CIAreaAverage", parameters: [kCIInputImageKey: inputImage, kCIInputExtentKey: extentVector]) else {
-            completion(nil)
-            return
-        }
-        guard let outputImage = filter.outputImage else {
+        guard let filter = CIFilter(name: "CIAreaAverage", parameters: [kCIInputImageKey: inputImage, kCIInputExtentKey: extentVector]), let outputImage = filter.outputImage else {
             completion(nil)
             return
         }

--- a/ThirdParty/UIImageColors.swift
+++ b/ThirdParty/UIImageColors.swift
@@ -277,22 +277,34 @@ extension UIImage {
     }
     
     // Courtesy: https://www.hackingwithswift.com/example-code/media/how-to-read-the-average-color-of-a-uiimage-using-ciareaaverage
-    public func averageColor() -> UIColor? {
-        guard let inputImage = CIImage(image: self) else { return nil }
+    public func averageColor(completion: @escaping (UIColor?) -> Void) {
+        guard let inputImage = CIImage(image: self) else {
+            completion(nil)
+            return
+        }
         let extentVector = CIVector(x: inputImage.extent.origin.x, y: inputImage.extent.origin.y, z: inputImage.extent.size.width, w: inputImage.extent.size.height)
 
         // core image filter that resamples an image down to 1x1 pixels
-        // so you can read the most dominant color in an image
-        guard let filter = CIFilter(name: "CIAreaAverage", parameters: [kCIInputImageKey: inputImage, kCIInputExtentKey: extentVector]) else { return nil }
-        guard let outputImage = filter.outputImage else { return nil }
+        // so you can read the most dominant color in an imagage
+        guard let filter = CIFilter(name: "CIAreaAverage", parameters: [kCIInputImageKey: inputImage, kCIInputExtentKey: extentVector]) else {
+            completion(nil)
+            return
+        }
+        guard let outputImage = filter.outputImage else {
+            completion(nil)
+            return
+        }
 
         // reads each of the color values into a UIColor, and sends it back
         var bitmap = [UInt8](repeating: 0, count: 4)
+        guard let kCFNull = kCFNull else {
+            completion(nil)
+            return
+        }
 
-        guard let kCFNull = kCFNull else { return nil }
         let context = CIContext(options: [.workingColorSpace: kCFNull])
         context.render(outputImage, toBitmap: &bitmap, rowBytes: 4, bounds: CGRect(x: 0, y: 0, width: 1, height: 1), format: .RGBA8, colorSpace: nil)
 
-        return UIColor(red: CGFloat(bitmap[0]) / 255, green: CGFloat(bitmap[1]) / 255, blue: CGFloat(bitmap[2]) / 255, alpha: CGFloat(bitmap[3]) / 255)
+        completion(UIColor(red: CGFloat(bitmap[0]) / 255, green: CGFloat(bitmap[1]) / 255, blue: CGFloat(bitmap[2]) / 255, alpha: CGFloat(bitmap[3]) / 255))
     }
 }


### PR DESCRIPTION
Our screenshot setup was being performed on the main thread directly which could cause it to block. Even if we add `DispatchQueue.main.asyn` then also there is a chance that it'll take a while for a heavy operation. Hence adding it to the custom operation queue (﻿tabScreenshotQueue).
