### PR TITLE
Remove #9616 Extra collectionView.reload

### DIFF
--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -947,8 +947,6 @@ extension FirefoxHomeViewController: DataObserverDelegate {
                 jumpBackInViewModel.updateData {}
             }
         }
-
-        collectionView?.reloadData()
     }
 
     // Reloads both highlights and top sites data from their respective caches. Does not invalidate the cache.


### PR DESCRIPTION
In PR https://github.com/mozilla-mobile/firefox-ios/pull/9564/files I introduced by mistake an extra `collectionView.reload` in the `reloadAll()` function of `FirefoxHomeViewController`. There's already a `collectionView.reload` in the `loadTopSitesData` function, so could be the cause of the problem seeing the crash log of #9616? By removing this extra reload, all is good as it was before.