### PR TITLE
#9576 ⁃ [Refactor] [v96] - search ad count

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -127,19 +127,19 @@ extension BrowserViewController: WKUIDelegate {
             let isPrivate = currentTab.isPrivate
             var setAddTabAdSearchParam = false
             let addTab = { (rURL: URL, isPrivate: Bool) in
+                let adUrl = rURL.absoluteString
                 if currentTab == self.tabManager.selectedTab, currentTab.adsTelemetryUrlList.count > 0,
                     currentTab.adsTelemetryUrlList.contains(adUrl),
                     !currentTab.adsProviderName.isEmpty {
-                    
-                    AdsTelemetryHelper.trackAdsClickedOnPage(providerName: currentTab.adsProviderName) }
+
+                    AdsTelemetryHelper.trackAdsClickedOnPage(providerName: currentTab.adsProviderName)
                         currentTab.adsTelemetryUrlList.removeAll()
                         currentTab.adsTelemetryRedirectUrlList.removeAll()
                         currentTab.adsProviderName = ""
 
-                    // Set the tab search param from current tab considering we need the values in order to cope with ad redirects
-                    } else if !currentTab.adsProviderName.isEmpty {
-                        setAddTabAdSearchParam = true
-                    }
+                // Set the tab search param from current tab considering we need the values in order to cope with ad redirects
+                } else if !currentTab.adsProviderName.isEmpty {
+                    setAddTabAdSearchParam = true
                 }
                 
                 let tab = self.tabManager.addTab(URLRequest(url: rURL as URL), afterTab: currentTab, isPrivate: isPrivate)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -723,7 +723,7 @@ extension BrowserViewController: WKNavigationDelegate {
         }
 
         // When tab url changes after web content starts loading on the page
-        // We notify the contect blocker change so that content blocker status can be correctly shown on beside the URL bar
+        // We notify the content blocker change so that content blocker status can be correctly shown on beside the URL bar
         tab.contentBlocker?.notifyContentBlockingChanged()
         self.scrollController.resetZoomState()
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -121,7 +121,13 @@ class Tab: NSObject {
         }
     }
     
-    var adsTelemetryUrlList: [String] = [String]()
+    var adsTelemetryUrlList: [String] = [String]() {
+        didSet {
+            startingSearchUrlWithAds = url
+        }
+    }
+    var adsTelemetryRedirectUrlList: [URL] = [URL]()
+    var startingSearchUrlWithAds: URL?
     var adsProviderName: String = ""
     var hasHomeScreenshot: Bool = false
 
@@ -525,9 +531,9 @@ class Tab: NSObject {
     var displayTitle: String {
         if let title = webView?.title, !title.isEmpty {
             let key = tabGroupData.tabHistoryMetadatakey()
-            if  lastObservation.keyUrl == key.url &&
-                    lastObservation.referrerUrl == key.referrerUrl &&
-                    lastObservation.searchTerm == key.searchTerm {
+            if lastObservation.keyUrl == key.url &&
+                lastObservation.referrerUrl == key.referrerUrl &&
+                lastObservation.searchTerm == key.searchTerm {
                 return title
             } else if tabGroupData.tabHistoryCurrentState == TabGroupTimerState.navSearchLoaded.rawValue ||
                 tabGroupData.tabHistoryCurrentState == TabGroupTimerState.tabNavigatedToDifferentUrl.rawValue ||

--- a/Client/Telemetry/AdsTelemetryHelper.swift
+++ b/Client/Telemetry/AdsTelemetryHelper.swift
@@ -122,6 +122,7 @@ class AdsTelemetryHelper: TabContentScript {
             AdsTelemetryHelper.trackAdsFoundOnPage(providerName: provider.name)
             tab?.adsProviderName = provider.name
             tab?.adsTelemetryUrlList = adUrls
+            tab?.adsTelemetryRedirectUrlList.removeAll()
         }
     }
     


### PR DESCRIPTION
This is the first improvement to our ad search count.

It no longer relies on redirects when the user taps on an ad and rather checks the last host to compare with all other redirects. This way we don't need to play catch with capturing redirect urls that are associated with a particular search engine. 

If we want to become more strict then we can easily add checks for ad redirect url and see if they are part of a specific search engine. 

What's working: 
- Regular `g` ads should now track fine even if they have redirects. 
- If you are on `g` and open an ad on a new page then that should also track fine. 
Overall, I'd rate it working as 8~9 / 10 times.

What can be improved in the future: 
- If for some reason wkwebview server redirect does not capture redirect then we are out of luck here.
- Move the code to its own package or a framework