### PR TITLE
For #9408 - XCUITests re-enable logins tests

### DIFF
--- a/XCUITests/Fennec_Enterprise_XCUITests.xctestplan
+++ b/XCUITests/Fennec_Enterprise_XCUITests.xctestplan
@@ -91,7 +91,6 @@
         "ReaderViewTest\/testAddToReaderListOptions()",
         "ReaderViewTest\/testAddToReadingList()",
         "ReaderViewTest\/testLoadReaderContent()",
-        "SaveLoginTest",
         "SaveLoginTest\/testCreateLoginManually()",
         "SaveLoginTest\/testEditOneLoginEntry()",
         "SaveLoginTest\/testSaveLogin()",

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -104,6 +104,7 @@ let allHomePanels = [
 ]
 
 let iOS_Settings = XCUIApplication(bundleIdentifier: "com.apple.Preferences")
+let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
 
 class Action {
     static let LoadURL = "LoadURL"
@@ -587,7 +588,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.tap(table.cells["OpenWith.Setting"], to: OpenWithSettings)
         screenState.tap(table.cells["DisplayThemeOption"], to: DisplaySettings)
         screenState.tap(table.cells["SiriSettings"], to: SiriSettings)
-        screenState.tap(table.cells["Logins"], to: LoginsSettings, if: "passcode == nil")
+        screenState.tap(table.cells["Logins"], to: LoginsSettings)
         screenState.tap(table.cells["Logins"], to: LockedLoginsSettings, if: "passcode != nil")
         screenState.tap(table.cells["ClearPrivateData"], to: ClearPrivateDataSettings)
         screenState.tap(table.cells["TrackingProtection"], to: TrackingProtectionSettings)

--- a/XCUITests/SaveLoginsTests.swift
+++ b/XCUITests/SaveLoginsTests.swift
@@ -22,6 +22,10 @@ let defaultNumRowsEmptyFilterList = 0
 class SaveLoginTest: BaseTestCase {
 
     private func saveLogin(givenUrl: String) {
+        if iPad() {
+            navigator.performAction(Action.CloseURLBarOpen)
+            navigator.nowAt(NewTabScreen)
+        }
         navigator.openURL(givenUrl)
         waitUntilPageLoad()
         waitForExistence(app.buttons["submit"], timeout: 3)
@@ -31,72 +35,73 @@ class SaveLoginTest: BaseTestCase {
 
     private func openLoginsSettings() {
         navigator.goto(SettingsScreen)
+        app.cells["SignInToSync"].swipeUp()
         navigator.goto(LoginsSettings)
+
+        // This only appears the first time
+        if app.otherElements.buttons["Continue"].exists {
+            app.otherElements.buttons["Continue"].tap()
+        }
+
+        unlockLoginsView()
         waitForExistence(app.tables["Login List"])
     }
-    
+
+    private func unlockLoginsView() {
+        let passcodeInput = springboard.secureTextFields.firstMatch
+        waitForExistence(passcodeInput, timeout: 20)
+        passcodeInput.tap()
+        passcodeInput.typeText("foo\n")
+
+    }
+
     func testLoginsListFromBrowserTabMenu() {
         closeURLBar()
         //Make sure you can access empty Login List from Browser Tab Menu
         navigator.goto(LoginsSettings)
+        unlockLoginsView()
         waitForExistence(app.tables["Login List"])
         XCTAssertTrue(app.searchFields["Filter"].exists)
         XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
         saveLogin(givenUrl: testLoginPage)
         //Make sure you can access populated Login List from Browser Tab Menu
         navigator.goto(LoginsSettings)
+        unlockLoginsView()
         waitForExistence(app.tables["Login List"])
         XCTAssertTrue(app.searchFields["Filter"].exists)
         XCTAssertTrue(app.staticTexts[domain].exists)
         XCTAssertTrue(app.staticTexts[domainLogin].exists)
         XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 1)
     }
-    
-    func testPasscodeLoginsListFromBrowserTabMenu() {
+
+    // Smoketest
+    func testSaveLogin() {
         closeURLBar()
-        navigator.performAction(Action.SetPasscode)
-        navigator.nowAt(PasscodeSettings)
-        navigator.goto(SettingsScreen)
-
-        //Make sure you can access empty Login List from Browser Tab Menu
-        navigator.goto(LockedLoginsSettings)
-        navigator.performAction(Action.UnlockLoginsSettings)
-        waitForExistence(app.tables["Login List"])
-        XCTAssertTrue(app.searchFields["Filter"].exists)
+        // Initially the login list should be empty
+        openLoginsSettings()
         XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList)
+        // Save a login and check that it appears on the list
         saveLogin(givenUrl: testLoginPage)
-        //Make sure you can access populated Login List from Browser Tab Menu
-        navigator.goto(LockedLoginsSettings)
-        navigator.performAction(Action.UnlockLoginsSettings)
+        openLoginsSettings()
         waitForExistence(app.tables["Login List"])
-        XCTAssertTrue(app.searchFields["Filter"].exists)
         XCTAssertTrue(app.staticTexts[domain].exists)
         XCTAssertTrue(app.staticTexts[domainLogin].exists)
         XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 1)
+        //Check to see how it works with multiple entries in the list- in this case, two for now
+        saveLogin(givenUrl: testSecondLoginPage)
+        openLoginsSettings()
+        waitForExistence(app.tables["Login List"])
+        XCTAssertTrue(app.staticTexts[domain].exists)
+        XCTAssertTrue(app.staticTexts[domainSecondLogin].exists)
+        XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 2)
     }
-
-//    func testSaveLogin() {
-//        closeURLBar()
-//        // Initially the login list should be empty
-//        openLoginsSettings()
-//        XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList)
-//        // Save a login and check that it appears on the list
-//        saveLogin(givenUrl: testLoginPage)
-//        openLoginsSettings()
-//        waitForExistence(app.tables["Login List"])
-//        XCTAssertTrue(app.staticTexts[domain].exists)
-//        XCTAssertTrue(app.staticTexts[domainLogin].exists)
-//        XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 1)
-//        //Check to see how it works with multiple entries in the list- in this case, two for now
-//        saveLogin(givenUrl: testSecondLoginPage)
-//        openLoginsSettings()
-//        waitForExistence(app.tables["Login List"])
-//        XCTAssertTrue(app.staticTexts[domain].exists)
-//        XCTAssertTrue(app.staticTexts[domainSecondLogin].exists)
-//        XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 2)
-//    }
 
     func testDoNotSaveLogin() {
+        if iPad() {
+            navigator.performAction(Action.CloseURLBarOpen)
+            navigator.nowAt(NewTabScreen)
+        }
         navigator.openURL(testLoginPage)
         waitUntilPageLoad()
         app.buttons["submit"].tap()
@@ -175,6 +180,10 @@ class SaveLoginTest: BaseTestCase {
 
     // Smoketest
     func testSavedLoginAutofilled() {
+        if iPad() {
+            navigator.performAction(Action.CloseURLBarOpen)
+            navigator.nowAt(NewTabScreen)
+        }
         navigator.openURL(urlLogin)
         waitUntilPageLoad()
         // Provided text fields are completely empty
@@ -198,6 +207,10 @@ class SaveLoginTest: BaseTestCase {
         
         navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)
+        if iPad() {
+            navigator.performAction(Action.CloseURLBarOpen)
+            navigator.nowAt(NewTabScreen)
+        }
         navigator.openURL(urlLogin)
         waitUntilPageLoad()
         waitForExistence(app.webViews.textFields.element(boundBy: 0), timeout: 3)
@@ -211,6 +224,11 @@ class SaveLoginTest: BaseTestCase {
     func testCreateLoginManually() {
         closeURLBar()
         navigator.goto(LoginsSettings)
+        // This only appears the first time
+        if app.otherElements.buttons["Continue"].exists {
+            app.otherElements.buttons["Continue"].tap()
+        }
+        unlockLoginsView()
         waitForExistence(app.tables["Login List"])
         app.buttons["Add"].tap()
         waitForExistence(app.tables["Add Credential"], timeout: 3)

--- a/XCUITests/SmokeXCUITests.xctestplan
+++ b/XCUITests/SmokeXCUITests.xctestplan
@@ -131,7 +131,6 @@
         "ReaderViewTest\/testRemoveFromReadingList()",
         "ReaderViewTest\/testRemoveFromReadingView()",
         "ReaderViewTest\/testRemoveSavedForReadingLongPress()",
-        "SaveLoginTest",
         "SaveLoginTest\/testDeleteLogin()",
         "SaveLoginTest\/testDoNotSaveLogin()",
         "SaveLoginTest\/testLoginsListFromBrowserTabMenu()",


### PR DESCRIPTION
Fixes #9408 by enabling again these tests that were disabled when the logins flow changed.
It would be good to have these tests back as the Password manager is going to be released soon 