### PR TITLE
Add FXIOS-3099 [v96]: Add 'older' section to historyPanel, and 1 new string

### DIFF
--- a/Client/Frontend/Library/DownloadsPanel.swift
+++ b/Client/Frontend/Library/DownloadsPanel.swift
@@ -316,13 +316,13 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
 
         switch section {
         case 0:
-            header?.textLabel?.text = .TableDateSectionTitleToday
+            header?.textLabel?.text = .LibraryPanel.Sections.Today
         case 1:
-            header?.textLabel?.text = .TableDateSectionTitleYesterday
+            header?.textLabel?.text = .LibraryPanel.Sections.Yesterday
         case 2:
-            header?.textLabel?.text = .TableDateSectionTitleLastWeek
+            header?.textLabel?.text = .LibraryPanel.Sections.LastWeek
         case 3:
-            header?.textLabel?.text = .TableDateSectionTitleLastMonth
+            header?.textLabel?.text = .LibraryPanel.Sections.LastMonth
         default:
             assertionFailure("Invalid Downloads section \(section)")
         }

--- a/Client/Frontend/Library/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel.swift
@@ -31,19 +31,22 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
         case yesterday
         case lastWeek
         case lastMonth
+        case older
 
-        static let count = 5
+        static let count = 6
 
         var title: String? {
             switch self {
             case .today:
-                return .TableDateSectionTitleToday
+                return .LibraryPanel.Sections.Today
             case .yesterday:
-                return .TableDateSectionTitleYesterday
+                return .LibraryPanel.Sections.Yesterday
             case .lastWeek:
-                return .TableDateSectionTitleLastWeek
+                return .LibraryPanel.Sections.LastWeek
             case .lastMonth:
-                return .TableDateSectionTitleLastMonth
+                return .LibraryPanel.Sections.LastMonth
+            case .older:
+                return .LibraryPanel.Sections.Older
             default:
                 return nil
             }

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -13,7 +13,8 @@ public struct Strings {
 
 // MARK: - String last updated app version
 
-// Used as a helper enum to keep track of what app version strings were last updated in.
+// Used as a helper enum to keep track of what app version strings were last updated in. Updates
+// are considered .unknown unless the string's Key is updated, or of course a new string is introduced.
 fileprivate enum StringLastUpdatedAppVersion {
     case v39
     case v96
@@ -199,6 +200,14 @@ extension String {
 // MARK: - Library Panel
 extension String {
     public struct LibraryPanel {
+        
+        public struct Sections {
+            public static let Today = MZLocalizedString("Today", value: "Today", comment: "This label is meant to signify the section containing a group of items from the current day.", lastUpdated: .unknown)
+            public static let Yesterday = MZLocalizedString("Yesterday", value: "Yesterday", comment: "This label is meant to signify the section containing a group of items from the past 24 hours.", lastUpdated: .unknown)
+            public static let LastWeek = MZLocalizedString("Last week", value: "Last week", comment: "This label is meant to signify the section containing a group of items from the past seven days.", lastUpdated: .unknown)
+            public static let LastMonth = MZLocalizedString("Last month", value: "Last month", comment: "This label is meant to signify the section containing a group of items from the past thirty days.", lastUpdated: .unknown)
+            public static let Older = MZLocalizedString("Section.HistoryPanel.Older", value: "Older", comment: "This label is meant to signify the section containing a group of items that are older than thirty days.", lastUpdated: .v96)
+        }
 
         public struct Bookmarks {
 
@@ -355,14 +364,6 @@ extension String {
     public static let AppStoreString = MZLocalizedString("Toasts.OpenAppStore", value: "Open App Store", comment: "Open App Store button", lastUpdated: .unknown)
     public static let UndoString = MZLocalizedString("Toasts.Undo", value: "Undo", comment: "Label for button to undo the action just performed", lastUpdated: .unknown)
     public static let OpenSettingsString = MZLocalizedString("Open Settings", comment: "See http://mzl.la/1G7uHo7", lastUpdated: .unknown)
-}
-
-// MARK: - Table date section titles
-extension String {
-    public static let TableDateSectionTitleToday = MZLocalizedString("Today", comment: "History tableview section header", lastUpdated: .unknown)
-    public static let TableDateSectionTitleYesterday = MZLocalizedString("Yesterday", comment: "History tableview section header", lastUpdated: .unknown)
-    public static let TableDateSectionTitleLastWeek = MZLocalizedString("Last week", comment: "History tableview section header", lastUpdated: .unknown)
-    public static let TableDateSectionTitleLastMonth = MZLocalizedString("Last month", comment: "History tableview section header", lastUpdated: .unknown)
 }
 
 // MARK: - Top Sites

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -206,7 +206,7 @@ extension String {
             public static let Yesterday = MZLocalizedString("Yesterday", value: "Yesterday", comment: "This label is meant to signify the section containing a group of items from the past 24 hours.", lastUpdated: .unknown)
             public static let LastWeek = MZLocalizedString("Last week", value: "Last week", comment: "This label is meant to signify the section containing a group of items from the past seven days.", lastUpdated: .unknown)
             public static let LastMonth = MZLocalizedString("Last month", value: "Last month", comment: "This label is meant to signify the section containing a group of items from the past thirty days.", lastUpdated: .unknown)
-            public static let Older = MZLocalizedString("Section.HistoryPanel.Older", value: "Older", comment: "This label is meant to signify the section containing a group of items that are older than thirty days.", lastUpdated: .v96)
+            public static let Older = MZLocalizedString("LibraryPanel.Section.Older", value: "Older", comment: "This label is meant to signify the section containing a group of items that are older than thirty days.", lastUpdated: .v96)
         }
 
         public struct Bookmarks {

--- a/Shared/DateGroupedTableData.swift
+++ b/Shared/DateGroupedTableData.swift
@@ -15,14 +15,16 @@ public struct DateGroupedTableData<T: Equatable> {
     let todayTimestamp = getDate(dayOffset: 0).timeIntervalSince1970
     let yesterdayTimestamp = getDate(dayOffset: -1).timeIntervalSince1970
     let lastWeekTimestamp = getDate(dayOffset: -7).timeIntervalSince1970
+    let lastMonthTimestamp = getDate(dayOffset: -30).timeIntervalSince1970
 
     var today: [(T, TimeInterval)] = []
     var yesterday: [(T, TimeInterval)] = []
     var lastWeek: [(T, TimeInterval)] = []
+    var lastMonth: [(T, TimeInterval)] = []
     var older: [(T, TimeInterval)] = []
 
     public var isEmpty: Bool {
-        return today.isEmpty && yesterday.isEmpty && lastWeek.isEmpty && older.isEmpty
+        return today.isEmpty && yesterday.isEmpty && lastWeek.isEmpty && lastMonth.isEmpty && older.isEmpty
     }
 
     public init() {}
@@ -37,9 +39,12 @@ public struct DateGroupedTableData<T: Equatable> {
         } else if timestamp > lastWeekTimestamp {
             lastWeek.append((item, timestamp))
             return IndexPath(row: lastWeek.count - 1, section: 2)
+        } else if timestamp > lastMonthTimestamp {
+            lastMonth.append((item, timestamp))
+            return IndexPath(row: lastMonth.count - 1, section: 3)
         } else {
             older.append((item, timestamp))
-            return IndexPath(row: older.count - 1, section: 3)
+            return IndexPath(row: older.count - 1, section: 4)
         }
     }
 
@@ -50,6 +55,8 @@ public struct DateGroupedTableData<T: Equatable> {
             yesterday.remove(at: index)
         } else if let index = lastWeek.firstIndex(where: { item == $0.0 }) {
             lastWeek.remove(at: index)
+        } else if let index = lastMonth.firstIndex(where: { item == $0.0 }) {
+            lastMonth.remove(at: index)
         } else if let index = older.firstIndex(where: { item == $0.0 }) {
             older.remove(at: index)
         }
@@ -63,6 +70,8 @@ public struct DateGroupedTableData<T: Equatable> {
             return yesterday.count
         case 2:
             return lastWeek.count
+        case 3:
+            return lastMonth.count
         default:
             return older.count
         }
@@ -76,6 +85,8 @@ public struct DateGroupedTableData<T: Equatable> {
             return yesterday.map({ $0.0 })
         case 2:
             return lastWeek.map({ $0.0 })
+        case 3:
+            return lastMonth.map({ $0.0 })
         default:
             return older.map({ $0.0 })
         }


### PR DESCRIPTION
# Overview

This PR is in reference to [this JIRA ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-3099). It adds the section "older" to the history panel. It also generalizes some strings in the library panel used in different panels, and there's one NEW string "Older" to support the ticket. 