### PR TITLE
Fix #9650 [v96] Jump back in crash - section was not updated

### DIFF
--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -285,7 +285,7 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
         collectionView?.addGestureRecognizer(longPressRecognizer)
         currentTab?.lastKnownUrl?.absoluteString.hasPrefix("internal://") ?? false ? collectionView?.addGestureRecognizer(tapGestureRecognizer) : nil
 
-        let refreshEvents: [Notification.Name] = [.DynamicFontChanged, .HomePanelPrefsChanged, .DisplayThemeChanged]
+        let refreshEvents: [Notification.Name] = [.DynamicFontChanged, .HomePanelPrefsChanged, .DisplayThemeChanged, .TabClosed]
         refreshEvents.forEach { NotificationCenter.default.addObserver(self, selector: #selector(reload), name: $0, object: nil) }
     }
 

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -230,6 +230,11 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
             && !tabManager.recentlyAccessedNormalTabs.isEmpty
     }
 
+    var shouldShowJumpBackInSection: Bool {
+        guard isJumpBackInSectionEnabled else { return false }
+        return jumpBackInViewModel.jumpBackInList.itemsToDisplay != 0
+    }
+
     var isRecentlySavedSectionEnabled: Bool {
         return featureFlags.isFeatureActiveForBuild(.recentlySaved)
         && homescreen.sectionsEnabled[.recentlySaved] == true
@@ -643,8 +648,7 @@ extension FirefoxHomeViewController: UICollectionViewDelegateFlowLayout {
 
             case .jumpBackIn:
                 if !hasSentJumpBackInSectionEvent
-                    && isJumpBackInSectionEnabled
-                    && !(jumpBackInViewModel.jumpBackInList.itemsToDisplay == 0) {
+                    && shouldShowJumpBackInSection {
                     TelemetryWrapper.recordEvent(category: .action, method: .view, object: .jumpBackInImpressions, value: nil, extras: nil)
                     hasSentJumpBackInSectionEvent = true
                 }
@@ -765,7 +769,7 @@ extension FirefoxHomeViewController: UICollectionViewDelegateFlowLayout {
         case .libraryShortcuts:
             return isYourLibrarySectionEnabled ? getHeaderSize(forSection: section) : .zero
         case .jumpBackIn:
-            return isJumpBackInSectionEnabled ? getHeaderSize(forSection: section) : .zero
+            return shouldShowJumpBackInSection ? getHeaderSize(forSection: section) : .zero
         case .historyHighlights:
             return isHistoryHightlightsSectionEnabled ? getHeaderSize(forSection: section) : .zero
         case .recentlySaved:
@@ -818,7 +822,7 @@ extension FirefoxHomeViewController {
             // There should always be a full row of pocket stories (numItems) otherwise don't show them
             return pocketStories.count
         case .jumpBackIn:
-            return isJumpBackInSectionEnabled ? 1 : 0
+            return shouldShowJumpBackInSection ? 1 : 0
         case .recentlySaved:
             return shouldShowRecentlySavedSection ? 1 : 0
         case .historyHighlights:

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -285,6 +285,7 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
         collectionView?.addGestureRecognizer(longPressRecognizer)
         currentTab?.lastKnownUrl?.absoluteString.hasPrefix("internal://") ?? false ? collectionView?.addGestureRecognizer(tapGestureRecognizer) : nil
 
+        // TODO: .TabClosed notif should be in JumpBackIn view only to reload it's data, but can't right now since doesn't self-size
         let refreshEvents: [Notification.Name] = [.DynamicFontChanged, .HomePanelPrefsChanged, .DisplayThemeChanged, .TabClosed]
         refreshEvents.forEach { NotificationCenter.default.addObserver(self, selector: #selector(reload), name: $0, object: nil) }
     }

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -946,16 +946,20 @@ extension FirefoxHomeViewController: DataObserverDelegate {
 
         loadTopSitesData()
 
+        if shouldUpdateData {
+            reloadSectionsData()
+        }
+    }
+
+    private func reloadSectionsData() {
         // TODO: Reload with a protocol comformance once all sections are standardized
         // Idea is that each section will load it's data from it's own view model
-        if shouldUpdateData {
-            if isRecentlySavedSectionEnabled {
-                recentlySavedViewModel.updateData {}
-            }
+        if isRecentlySavedSectionEnabled {
+            recentlySavedViewModel.updateData {}
+        }
 
-            if isJumpBackInSectionEnabled {
-                jumpBackInViewModel.updateData {}
-            }
+        if isJumpBackInSectionEnabled {
+            jumpBackInViewModel.updateData {}
         }
     }
 


### PR DESCRIPTION
## Issue #9650
- Add shouldShowJumpBackInSection to avoid showing the section when data isn't loaded
- Refresh sections when tab is removed. We should only reload the sections that needs the latest tab information. Wanted to do that within the jumpBackIn section, which would work apart than the section doesn't reload due to the parent collection view fixed height (in FirefoxHomeViewController). Added a TODO so we improve that once we get the self-sizing sections.