### PR TITLE
Bugfix #9532 [v96] Ctrl+tab and ctrl-shift+tab shortcuts

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -176,7 +176,6 @@ extension BrowserViewController {
         ]
 
         let windowShortcuts = [
-            // Window
             UIKeyCommand(action: #selector(nextTabKeyCommand), input: "\t", modifierFlags: .control, discoverabilityTitle: shortcuts.ShowNextTab),
             UIKeyCommand(action: #selector(previousTabKeyCommand), input: "\t", modifierFlags: [.control, .shift], discoverabilityTitle: shortcuts.ShowPreviousTab),
             UIKeyCommand(action: #selector(nextTabKeyCommand), input: "]", modifierFlags: [.command, .shift]),

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -175,10 +175,17 @@ extension BrowserViewController {
             UIKeyCommand(action: #selector(goForwardKeyCommand), input: UIKeyCommand.inputRightArrow, modifierFlags: .command),
         ]
 
+        let keyboards = [
+            // Window
+            UIKeyCommand(action: #selector(nextTabKeyCommand), input: "\t", modifierFlags: .control, discoverabilityTitle: shortcuts.ShowNextTab),
+            UIKeyCommand(action: #selector(previousTabKeyCommand), input: "\t", modifierFlags: [.control, .shift], discoverabilityTitle: shortcuts.ShowPreviousTab),
+        ]
+
         // In iOS 15+, certain keys events are delivered to the text input or focus systems first, unless specified otherwise
         if #available(iOS 15, *) {
             searchLocationCommands.forEach { $0.wantsPriorityOverSystemBehavior = true }
             overridesTextEditing.forEach { $0.wantsPriorityOverSystemBehavior = true }
+            keyboards.forEach { $0.wantsPriorityOverSystemBehavior = true }
         }
 
         let commands = [
@@ -215,14 +222,12 @@ extension BrowserViewController {
             UIKeyCommand(action: #selector(showDownloadsKeyCommand), input: "j", modifierFlags: .command, discoverabilityTitle: shortcuts.ShowDownloads),
 
             // Window
-            UIKeyCommand(action: #selector(nextTabKeyCommand), input: "\t", modifierFlags: .control, discoverabilityTitle: shortcuts.ShowNextTab),
             UIKeyCommand(action: #selector(nextTabKeyCommand), input: "]", modifierFlags: [.command, .shift]),
-            UIKeyCommand(action: #selector(previousTabKeyCommand), input: "\t", modifierFlags: [.control, .shift], discoverabilityTitle: shortcuts.ShowPreviousTab),
             UIKeyCommand(action: #selector(previousTabKeyCommand), input: "[", modifierFlags: [.command, .shift]),
             UIKeyCommand(action: #selector(showTabTrayKeyCommand), input: "\t", modifierFlags: [.command, .alternate], discoverabilityTitle: shortcuts.ShowTabTray),
             UIKeyCommand(action: #selector(showTabTrayKeyCommand), input: "\\", modifierFlags: [.command, .shift]),
             // TODO: Show tab # 1-9 - Command + 1-9
-        ]
+        ] + keyboards
 
         let isEditingText = tabManager.selectedTab?.isEditing ?? false
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -175,17 +175,21 @@ extension BrowserViewController {
             UIKeyCommand(action: #selector(goForwardKeyCommand), input: UIKeyCommand.inputRightArrow, modifierFlags: .command),
         ]
 
-        let keyboards = [
+        let windowShortcuts = [
             // Window
             UIKeyCommand(action: #selector(nextTabKeyCommand), input: "\t", modifierFlags: .control, discoverabilityTitle: shortcuts.ShowNextTab),
             UIKeyCommand(action: #selector(previousTabKeyCommand), input: "\t", modifierFlags: [.control, .shift], discoverabilityTitle: shortcuts.ShowPreviousTab),
+            UIKeyCommand(action: #selector(nextTabKeyCommand), input: "]", modifierFlags: [.command, .shift]),
+            UIKeyCommand(action: #selector(previousTabKeyCommand), input: "[", modifierFlags: [.command, .shift]),
+            UIKeyCommand(action: #selector(showTabTrayKeyCommand), input: "\t", modifierFlags: [.command, .alternate], discoverabilityTitle: shortcuts.ShowTabTray),
+            UIKeyCommand(action: #selector(showTabTrayKeyCommand), input: "\\", modifierFlags: [.command, .shift]),
         ]
 
         // In iOS 15+, certain keys events are delivered to the text input or focus systems first, unless specified otherwise
         if #available(iOS 15, *) {
             searchLocationCommands.forEach { $0.wantsPriorityOverSystemBehavior = true }
             overridesTextEditing.forEach { $0.wantsPriorityOverSystemBehavior = true }
-            keyboards.forEach { $0.wantsPriorityOverSystemBehavior = true }
+            windowShortcuts.forEach { $0.wantsPriorityOverSystemBehavior = true }
         }
 
         let commands = [
@@ -221,13 +225,8 @@ extension BrowserViewController {
             // Tools
             UIKeyCommand(action: #selector(showDownloadsKeyCommand), input: "j", modifierFlags: .command, discoverabilityTitle: shortcuts.ShowDownloads),
 
-            // Window
-            UIKeyCommand(action: #selector(nextTabKeyCommand), input: "]", modifierFlags: [.command, .shift]),
-            UIKeyCommand(action: #selector(previousTabKeyCommand), input: "[", modifierFlags: [.command, .shift]),
-            UIKeyCommand(action: #selector(showTabTrayKeyCommand), input: "\t", modifierFlags: [.command, .alternate], discoverabilityTitle: shortcuts.ShowTabTray),
-            UIKeyCommand(action: #selector(showTabTrayKeyCommand), input: "\\", modifierFlags: [.command, .shift]),
             // TODO: Show tab # 1-9 - Command + 1-9
-        ] + keyboards
+        ] + windowShortcuts
 
         let isEditingText = tabManager.selectedTab?.isEditing ?? false
 


### PR DESCRIPTION
I think I found the issue for #9532 why those shortcuts were not behaving as intended anymore. It needs wantsPriorityOverSystemBehavior for iOS.

