### PR TITLE
Bugfix #9669 [v96] Overlay not dismissed

### DIFF
--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -473,9 +473,10 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
     }
 
     @objc func presentContextualOverlay() {
-        guard BrowserViewController.foregroundBVC().searchController == nil else {
-            timer?.invalidate()
-            return
+        guard BrowserViewController.foregroundBVC().searchController == nil,
+              presentedViewController == nil else {
+                  timer?.invalidate()
+                  return
         }
         presentContextualHint()
     }


### PR DESCRIPTION
# Issue #9669 
Add a check before presentation so nothing is already being presented before showing the contextual hint for jump back in section. If there's no check we try to show it, it fails, but the overlay is unhidden and can't be dismissed unless the page is killed (since the contextual hint dismiss call back can never be called).