### PR TITLE
Bugfix #8891 #9656 [v96] Shortcuts fixes

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -199,6 +199,7 @@ extension BrowserViewController {
             UIKeyCommand(action: #selector(newTabKeyCommand), input: "t", modifierFlags: .command, discoverabilityTitle: shortcuts.NewTab),
             UIKeyCommand(action: #selector(selectLocationBarKeyCommand), input: "l", modifierFlags: .command, discoverabilityTitle: shortcuts.SelectLocationBar),
             UIKeyCommand(action: #selector(newPrivateTabKeyCommand), input: "p", modifierFlags: [.command, .shift], discoverabilityTitle: shortcuts.NewPrivateTab),
+            UIKeyCommand(action: #selector(newPrivateTabKeyCommand), input: "n", modifierFlags: [.command, .shift]),
             UIKeyCommand(action: #selector(closeTabKeyCommand), input: "w", modifierFlags: .command, discoverabilityTitle: shortcuts.CloseCurrentTab),
 
             // Edit

--- a/Client/Frontend/Browser/TabTrayController+KeyCommands.swift
+++ b/Client/Frontend/Browser/TabTrayController+KeyCommands.swift
@@ -50,7 +50,7 @@ extension GridTabViewController {
 
     @objc func didEnterTabKeyCommand() {
         TelemetryWrapper.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "enter-tab"])
-        _ = self.navigationController?.popViewController(animated: true)
+        dismissVC()
     }
 
     @objc func didOpenNewTabKeyCommand() {


### PR DESCRIPTION
#8891
- Fix that the tab tray was not dismissing by pressing the keyboard shortcut (either Command+Shift+\ or Command+Alt+Tab)

#9656
- New private tab can be opened with Command+Shift+N as per design