### PR TITLE
Add #9633 [v96] Select tabs and Zoom keyboard shortcuts

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -207,15 +207,27 @@ extension BrowserViewController {
     // MARK: Zoom
 
     @objc private func zoomIn() {
+        guard let currentTab = tabManager.selectedTab else {
+            return
+        }
 
+        currentTab.zoomIn()
     }
 
     @objc private func zoomOut() {
+        guard let currentTab = tabManager.selectedTab else {
+            return
+        }
 
+        currentTab.zoomOut()
     }
 
     @objc private func resetZoom() {
+        guard let currentTab = tabManager.selectedTab else {
+            return
+        }
 
+        currentTab.resetZoom()
     }
 
     /// Select a certain tab number - If number is greater than the present number of tabs, select the last tab

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -122,9 +122,7 @@ extension BrowserViewController {
     }
 
     @objc private func moveURLCompletionKeyCommand(sender: UIKeyCommand) {
-        guard let searchController = self.searchController else {
-            return
-        }
+        guard let searchController = self.searchController else { return }
 
         searchController.handleKeyCommands(sender: sender)
     }
@@ -229,25 +227,19 @@ extension BrowserViewController {
     // MARK: Zoom
 
     @objc private func zoomIn() {
-        guard let currentTab = tabManager.selectedTab else {
-            return
-        }
+        guard let currentTab = tabManager.selectedTab else { return }
 
         currentTab.zoomIn()
     }
 
     @objc private func zoomOut() {
-        guard let currentTab = tabManager.selectedTab else {
-            return
-        }
+        guard let currentTab = tabManager.selectedTab else { return }
 
         currentTab.zoomOut()
     }
 
     @objc private func resetZoom() {
-        guard let currentTab = tabManager.selectedTab else {
-            return
-        }
+        guard let currentTab = tabManager.selectedTab else { return }
 
         currentTab.resetZoom()
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -53,28 +53,43 @@ extension BrowserViewController {
     }
 
     @objc private func reloadTabKeyCommand() {
-        TelemetryWrapper.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "reload"])
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .press,
+                                     object: .keyCommand,
+                                     extras: ["action": "reload"])
+
         if let tab = tabManager.selectedTab, firefoxHomeViewController == nil {
             tab.reload()
         }
     }
 
     @objc private func goBackKeyCommand() {
-        TelemetryWrapper.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "go-back"])
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .press,
+                                     object: .keyCommand,
+                                     extras: ["action": "go-back"])
+
         if let tab = tabManager.selectedTab, tab.canGoBack, firefoxHomeViewController == nil {
             tab.goBack()
         }
     }
 
     @objc private func goForwardKeyCommand() {
-        TelemetryWrapper.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "go-forward"])
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .press,
+                                     object: .keyCommand,
+                                     extras: ["action": "go-forward"])
+
         if let tab = tabManager.selectedTab, tab.canGoForward {
             tab.goForward()
         }
     }
 
     @objc private func findInPageKeyCommand() {
-        TelemetryWrapper.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "find-in-page"])
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .press,
+                                     object: .keyCommand,
+                                     extras: ["action": "find-in-page"])
         findInPage(withText: "")
     }
 
@@ -89,13 +104,19 @@ extension BrowserViewController {
     }
 
     @objc private func selectLocationBarKeyCommand() {
-        TelemetryWrapper.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "select-location-bar"])
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .press,
+                                     object: .keyCommand,
+                                     extras: ["action": "select-location-bar"])
         scrollController.showToolbars(animated: true)
         urlBar.tabLocationViewDidTapLocation(urlBar.locationView)
     }
 
     @objc private func newTabKeyCommand() {
-        TelemetryWrapper.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "new-tab"])
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .press,
+                                     object: .keyCommand,
+                                     extras: ["action": "new-tab"])
         let isPrivate = tabManager.selectedTab?.isPrivate ?? false
         openBlankNewTab(focusLocationField: true, isPrivate: isPrivate)
     }
@@ -103,13 +124,19 @@ extension BrowserViewController {
     @objc private func newPrivateTabKeyCommand() {
         // NOTE: We cannot and should not distinguish between "new-tab" and "new-private-tab"
         // when recording telemetry for key commands.
-        TelemetryWrapper.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "new-tab"])
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .press,
+                                     object: .keyCommand,
+                                     extras: ["action": "new-tab"])
         openBlankNewTab(focusLocationField: true, isPrivate: true)
         keyboardPressesHandler.reset()
     }
 
     @objc private func closeTabKeyCommand() {
-        TelemetryWrapper.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "close-tab"])
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .press,
+                                     object: .keyCommand,
+                                     extras: ["action": "close-tab"])
         guard let currentTab = tabManager.selectedTab else {
             return
         }
@@ -117,7 +144,10 @@ extension BrowserViewController {
     }
 
     @objc private func showTabTrayKeyCommand() {
-        TelemetryWrapper.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "show-tab-tray"])
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .press,
+                                     object: .keyCommand,
+                                     extras: ["action": "show-tab-tray"])
         showTabTray()
     }
 
@@ -130,7 +160,10 @@ extension BrowserViewController {
     // MARK: - Tab selection
 
     @objc private func nextTabKeyCommand() {
-        TelemetryWrapper.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "next-tab"])
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .press,
+                                     object: .keyCommand,
+                                     extras: ["action": "next-tab"])
         guard let currentTab = tabManager.selectedTab else {
             return
         }
@@ -146,7 +179,10 @@ extension BrowserViewController {
     }
 
     @objc private func previousTabKeyCommand() {
-        TelemetryWrapper.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "previous-tab"])
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .press,
+                                     object: .keyCommand,
+                                     extras: ["action": "previous-tab"])
         guard let currentTab = tabManager.selectedTab else {
             return
         }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -161,6 +161,69 @@ extension BrowserViewController {
         searchController.handleKeyCommands(sender: sender)
     }
 
+    @objc private func selectFirstTab() {
+        selectTab(number: 0)
+    }
+
+    @objc private func selectTabTwo() {
+        selectTab(number: 1)
+    }
+
+    @objc private func selectTabThree() {
+        selectTab(number: 2)
+    }
+
+    @objc private func selectTabFour() {
+        selectTab(number: 3)
+    }
+
+    @objc private func selectTabFive() {
+        selectTab(number: 4)
+    }
+
+    @objc private func selectTabSix() {
+        selectTab(number: 5)
+    }
+
+    @objc private func selectTabSeven() {
+        selectTab(number: 6)
+    }
+
+    @objc private func selectTabEight() {
+        selectTab(number: 7)
+    }
+
+    @objc private func selectLastTab() {
+        guard let currentTab = tabManager.selectedTab else {
+            return
+        }
+
+        let tabs = currentTab.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
+        selectTab(number: tabs.count - 1)
+    }
+
+    /// Select a certain tab number - If number is greater than the present number of tabs, select the last tab
+    /// - Parameter number: The 0 indexed tab number to select
+    private func selectTab(number: Int) {
+        guard let currentTab = tabManager.selectedTab else {
+            return
+        }
+
+        let tabs = currentTab.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
+        // Do not continue if the index of the new tab to select is the current one
+        guard let currentTabIndex = tabs.firstIndex(of: currentTab), currentTabIndex != number else {
+            return
+        }
+
+        if tabs.count > number {
+            tabManager.selectTab(tabs[number])
+            keyboardPressesHandler.reset()
+        } else if let lastTab = tabs.last {
+            tabManager.selectTab(lastTab)
+            keyboardPressesHandler.reset()
+        }
+    }
+
     override var keyCommands: [UIKeyCommand]? {
         let searchLocationCommands = [
             // Navigate the suggestions
@@ -224,8 +287,16 @@ extension BrowserViewController {
 
             // Tools
             UIKeyCommand(action: #selector(showDownloadsKeyCommand), input: "j", modifierFlags: .command, discoverabilityTitle: shortcuts.ShowDownloads),
+            UIKeyCommand(action: #selector(selectFirstTab), input: "1", modifierFlags: .command, discoverabilityTitle: shortcuts.ShowFirstTab),
+            UIKeyCommand(action: #selector(selectTabTwo), input: "2", modifierFlags: .command),
+            UIKeyCommand(action: #selector(selectTabThree), input: "3", modifierFlags: .command),
+            UIKeyCommand(action: #selector(selectTabFour), input: "4", modifierFlags: .command),
+            UIKeyCommand(action: #selector(selectTabFive), input: "5", modifierFlags: .command),
+            UIKeyCommand(action: #selector(selectTabSix), input: "6", modifierFlags: .command),
+            UIKeyCommand(action: #selector(selectTabSeven), input: "7", modifierFlags: .command),
+            UIKeyCommand(action: #selector(selectTabEight), input: "8", modifierFlags: .command),
+            UIKeyCommand(action: #selector(selectLastTab), input: "9", modifierFlags: .command, discoverabilityTitle: shortcuts.ShowLastTab),
 
-            // TODO: Show tab # 1-9 - Command + 1-9
         ] + windowShortcuts
 
         let isEditingText = tabManager.selectedTab?.isEditing ?? false

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -116,6 +116,21 @@ extension BrowserViewController {
         tabManager.removeTab(currentTab)
     }
 
+    @objc private func showTabTrayKeyCommand() {
+        TelemetryWrapper.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "show-tab-tray"])
+        showTabTray()
+    }
+
+    @objc private func moveURLCompletionKeyCommand(sender: UIKeyCommand) {
+        guard let searchController = self.searchController else {
+            return
+        }
+
+        searchController.handleKeyCommands(sender: sender)
+    }
+
+    // MARK: - Tab selection
+
     @objc private func nextTabKeyCommand() {
         TelemetryWrapper.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "next-tab"])
         guard let currentTab = tabManager.selectedTab else {
@@ -146,19 +161,6 @@ extension BrowserViewController {
         }
 
         keyboardPressesHandler.reset()
-    }
-
-    @objc private func showTabTrayKeyCommand() {
-        TelemetryWrapper.recordEvent(category: .action, method: .press, object: .keyCommand, extras: ["action": "show-tab-tray"])
-        showTabTray()
-    }
-
-    @objc private func moveURLCompletionKeyCommand(sender: UIKeyCommand) {
-        guard let searchController = self.searchController else {
-            return
-        }
-
-        searchController.handleKeyCommands(sender: sender)
     }
 
     @objc private func selectFirstTab() {
@@ -200,6 +202,20 @@ extension BrowserViewController {
 
         let tabs = currentTab.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
         selectTab(number: tabs.count - 1)
+    }
+
+    // MARK: Zoom
+
+    @objc private func zoomIn() {
+
+    }
+
+    @objc private func zoomOut() {
+
+    }
+
+    @objc private func resetZoom() {
+
     }
 
     /// Select a certain tab number - If number is greater than the present number of tabs, select the last tab
@@ -270,9 +286,9 @@ extension BrowserViewController {
             UIKeyCommand(action: #selector(findInPageAgainKeyCommand), input: "g", modifierFlags: .command, discoverabilityTitle: shortcuts.FindAgain),
 
             // View
-            // TODO: Zoom in - Command + +
-            // TODO: Zoom out - Command + -
-            // TODO: Actual size - Command + 0
+            UIKeyCommand(action: #selector(zoomIn), input: "+", modifierFlags: .command, discoverabilityTitle: shortcuts.ZoomIn),
+            UIKeyCommand(action: #selector(zoomOut), input: "-", modifierFlags: .command, discoverabilityTitle: shortcuts.ZoomOut),
+            UIKeyCommand(action: #selector(resetZoom), input: "0", modifierFlags: .command, discoverabilityTitle: shortcuts.ActualSize),
             UIKeyCommand(action: #selector(reloadTabKeyCommand), input: "r", modifierFlags: .command, discoverabilityTitle: shortcuts.ReloadPage),
             
             // History

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -227,19 +227,22 @@ extension BrowserViewController {
     // MARK: Zoom
 
     @objc private func zoomIn() {
-        guard let currentTab = tabManager.selectedTab else { return }
+        guard let currentTab = tabManager.selectedTab,
+              firefoxHomeViewController == nil else { return }
 
         currentTab.zoomIn()
     }
 
     @objc private func zoomOut() {
-        guard let currentTab = tabManager.selectedTab else { return }
+        guard let currentTab = tabManager.selectedTab,
+              firefoxHomeViewController == nil else { return }
 
         currentTab.zoomOut()
     }
 
     @objc private func resetZoom() {
-        guard let currentTab = tabManager.selectedTab else { return }
+        guard let currentTab = tabManager.selectedTab,
+              firefoxHomeViewController == nil else { return }
 
         currentTab.resetZoom()
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -204,6 +204,28 @@ extension BrowserViewController {
         selectTab(number: tabs.count - 1)
     }
 
+    /// Select a certain tab number - If number is greater than the present number of tabs, select the last tab
+    /// - Parameter number: The 0 indexed tab number to select
+    private func selectTab(number: Int) {
+        guard let currentTab = tabManager.selectedTab else {
+            return
+        }
+
+        let tabs = currentTab.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
+        // Do not continue if the index of the new tab to select is the current one
+        guard let currentTabIndex = tabs.firstIndex(of: currentTab), currentTabIndex != number else {
+            return
+        }
+
+        if tabs.count > number {
+            tabManager.selectTab(tabs[number])
+            keyboardPressesHandler.reset()
+        } else if let lastTab = tabs.last {
+            tabManager.selectTab(lastTab)
+            keyboardPressesHandler.reset()
+        }
+    }
+
     // MARK: Zoom
 
     @objc private func zoomIn() {
@@ -230,27 +252,7 @@ extension BrowserViewController {
         currentTab.resetZoom()
     }
 
-    /// Select a certain tab number - If number is greater than the present number of tabs, select the last tab
-    /// - Parameter number: The 0 indexed tab number to select
-    private func selectTab(number: Int) {
-        guard let currentTab = tabManager.selectedTab else {
-            return
-        }
-
-        let tabs = currentTab.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
-        // Do not continue if the index of the new tab to select is the current one
-        guard let currentTabIndex = tabs.firstIndex(of: currentTab), currentTabIndex != number else {
-            return
-        }
-
-        if tabs.count > number {
-            tabManager.selectTab(tabs[number])
-            keyboardPressesHandler.reset()
-        } else if let lastTab = tabs.last {
-            tabManager.selectTab(lastTab)
-            keyboardPressesHandler.reset()
-        }
-    }
+    // MARK: - KeyCommands
 
     override var keyCommands: [UIKeyCommand]? {
         let searchLocationCommands = [

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -638,34 +638,36 @@ class Tab: NSObject {
     }
     
 
-    func zoomIn() {
-        if pageZoom == 0.75 {
+    @objc func zoomIn() {
+        switch pageZoom {
+        case 0.75:
             pageZoom = 0.85
-        } else if pageZoom == 0.85 {
+        case 0.85:
             pageZoom = 1.0
-        } else if pageZoom == 1.0 {
+        case 1.0:
             pageZoom = 1.15
-        } else if pageZoom == 1.15 {
+        case 1.15:
             pageZoom = 1.25
-        } else if pageZoom == 3.0 {
+        case 3.0:
             return
-        } else {
+        default:
             pageZoom += 0.25
         }
     }
 
-    func zoomOut() {
-        if pageZoom == 0.5 {
+    @objc func zoomOut() {
+        switch pageZoom {
+        case 0.5:
             return
-        } else if pageZoom == 0.85 {
+        case 0.85:
             pageZoom = 0.75
-        } else if pageZoom == 1.0 {
+        case 1.0:
             pageZoom = 0.85
-        } else if pageZoom == 1.15 {
+        case 1.15:
             pageZoom = 1.0
-        } else if pageZoom == 1.25 {
+        case 1.25:
             pageZoom = 1.15
-        } else {
+        default:
             pageZoom -= 0.25
         }
     }

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -672,6 +672,10 @@ class Tab: NSObject {
         }
     }
 
+    func resetZoom() {
+        pageZoom = 1.0
+    }
+
     func addContentScript(_ helper: TabContentScript, name: String) {
         contentScriptManager.addContentScript(helper, name: name, forTab: self)
     }

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -267,6 +267,12 @@ class Tab: NSObject {
         return false
     }
 
+    fileprivate(set) var pageZoom: CGFloat = 1.0 {
+        didSet {
+            webView?.setValue(pageZoom, forKey: "viewScale")
+        }
+    }
+
     fileprivate(set) var screenshot: UIImage?
 
     // If this tab has been opened from another, its parent will point to the tab from which it was opened
@@ -631,6 +637,39 @@ class Tab: NSObject {
         self.webView?.scrollView.refreshControl?.endRefreshing()
     }
     
+
+    func zoomIn() {
+        if pageZoom == 0.75 {
+            pageZoom = 0.85
+        } else if pageZoom == 0.85 {
+            pageZoom = 1.0
+        } else if pageZoom == 1.0 {
+            pageZoom = 1.15
+        } else if pageZoom == 1.15 {
+            pageZoom = 1.25
+        } else if pageZoom == 3.0 {
+            return
+        } else {
+            pageZoom += 0.25
+        }
+    }
+
+    func zoomOut() {
+        if pageZoom == 0.5 {
+            return
+        } else if pageZoom == 0.85 {
+            pageZoom = 0.75
+        } else if pageZoom == 1.0 {
+            pageZoom = 0.85
+        } else if pageZoom == 1.15 {
+            pageZoom = 1.0
+        } else if pageZoom == 1.25 {
+            pageZoom = 1.15
+        } else {
+            pageZoom -= 0.25
+        }
+    }
+
     func addContentScript(_ helper: TabContentScript, name: String) {
         contentScriptManager.addContentScript(helper, name: name, forTab: self)
     }


### PR DESCRIPTION
# Keyboard shortcuts #9633

## Tab selection
Behavior is the same as in Safari. 
- User can select the first and last tab by pressing ⌘ + 1 and ⌘ + 9
- User can select the tab numbers from 1 to 8 using ⌘ + 1 to ⌘ + 8.
- If there's less tabs than the number selected, then it goes to the last tab.

## Zoom on a tab
Contribution from @q2r5 from PR https://github.com/mozilla-mobile/firefox-ios/pull/8230
The zoom levels are the same as Safari as stated in this PR. 
Hopefully we can integrate this through the menu soon, but for now it will at least be available through keyboard shortcuts.