### PR TITLE
Refactor [v97] Fix NSKeyedUnarchiver deprecation warnings

### DIFF
--- a/Client/Frontend/Browser/SavedTab.swift
+++ b/Client/Frontend/Browser/SavedTab.swift
@@ -7,7 +7,10 @@ import WebKit
 import Shared
 import MozillaAppServices
 
-class SavedTab: NSObject, NSCoding {
+class SavedTab: NSObject, NSCoding, NSSecureCoding {
+
+    static var supportsSecureCoding: Bool = true
+
     var isSelected: Bool
     var title: String?
     var url: URL?

--- a/Client/Frontend/Browser/SavedTab.swift
+++ b/Client/Frontend/Browser/SavedTab.swift
@@ -23,32 +23,48 @@ class SavedTab: NSObject, NSCoding, NSSecureCoding {
     var createdAt: Timestamp?
     var hasHomeScreenshot: Bool
 
+    private enum Keys: String {
+        case isSelected
+        case title
+        case url
+        case isPrivate
+        case sessionData
+        case screenshotUUID
+        case faviconURL
+        case UUID
+        case tabGroupData
+        case createdAt
+        case hasHomeScreenshot
+    }
+
     var jsonDictionary: [String: AnyObject] {
         let title: String = self.title ?? "null"
         let faviconURL: String = self.faviconURL ?? "null"
         let uuid: String = self.screenshotUUID?.uuidString ?? "null"
         
         var json: [String: AnyObject] = [
-            "title": title as AnyObject,
-            "isPrivate": String(self.isPrivate) as AnyObject,
-            "isSelected": String(self.isSelected) as AnyObject,
-            "faviconURL": faviconURL as AnyObject,
-            "screenshotUUID": uuid as AnyObject,
-            "url": url as AnyObject,
-            "UUID": self.UUID as AnyObject,
-            "tabGroupData": self.tabGroupData as AnyObject,
-            "createdAt": self.createdAt as AnyObject,
-            "hasHomeScreenshot": String(self.hasHomeScreenshot) as AnyObject
+            Keys.title.rawValue: title as AnyObject,
+            Keys.isPrivate.rawValue: String(self.isPrivate) as AnyObject,
+            Keys.isSelected.rawValue: String(self.isSelected) as AnyObject,
+            Keys.faviconURL.rawValue: faviconURL as AnyObject,
+            Keys.screenshotUUID.rawValue: uuid as AnyObject,
+            Keys.url.rawValue: url as AnyObject,
+            Keys.UUID.rawValue: self.UUID as AnyObject,
+            Keys.tabGroupData.rawValue: self.tabGroupData as AnyObject,
+            Keys.createdAt.rawValue: self.createdAt as AnyObject,
+            Keys.hasHomeScreenshot.rawValue: String(self.hasHomeScreenshot) as AnyObject,
         ]
         
         if let sessionDataInfo = self.sessionData?.jsonDictionary {
-            json["sessionData"] = sessionDataInfo as AnyObject?
+            json[Keys.sessionData.rawValue] = sessionDataInfo as AnyObject?
         }
         
         return json
     }
-    
-    init?(screenshotUUID: UUID?, isSelected: Bool, title: String?, isPrivate: Bool, faviconURL: String?, url: URL?, sessionData: SessionData?, uuid: String, tabGroupData: TabGroupData?, createdAt: Timestamp?, hasHomeScreenshot: Bool) {
+
+    init?(screenshotUUID: UUID?, isSelected: Bool, title: String?,
+          isPrivate: Bool, faviconURL: String?, url: URL?, sessionData: SessionData?,
+          uuid: String, tabGroupData: TabGroupData?, createdAt: Timestamp?, hasHomeScreenshot: Bool) {
 
         self.screenshotUUID = screenshotUUID
         self.isSelected = isSelected
@@ -66,35 +82,44 @@ class SavedTab: NSObject, NSCoding, NSSecureCoding {
     }
     
     required init?(coder: NSCoder) {
-        self.sessionData = coder.decodeObject(forKey: "sessionData") as? SessionData
-        self.screenshotUUID = coder.decodeObject(forKey: "screenshotUUID") as? UUID
-        self.isSelected = coder.decodeBool(forKey: "isSelected")
-        self.title = coder.decodeObject(forKey: "title") as? String
-        self.isPrivate = coder.decodeBool(forKey: "isPrivate")
-        self.faviconURL = coder.decodeObject(forKey: "faviconURL") as? String
-        self.url = coder.decodeObject(forKey: "url") as? URL
-        self.UUID = coder.decodeObject(forKey: "UUID") as? String
-        self.tabGroupData = coder.decodeObject(forKey: "tabGroupData") as? TabGroupData
-        self.createdAt = coder.decodeObject(forKey: "createdAt") as? Timestamp
-        self.hasHomeScreenshot = coder.decodeBool(forKey: "hasHomeScreenshot")
+        self.sessionData = coder.decodeObject(forKey: Keys.sessionData.rawValue) as? SessionData
+        self.screenshotUUID = coder.decodeObject(forKey: Keys.screenshotUUID.rawValue) as? UUID
+        self.isSelected = coder.decodeBool(forKey: Keys.isSelected.rawValue)
+        self.title = coder.decodeObject(forKey: Keys.title.rawValue) as? String
+        self.isPrivate = coder.decodeBool(forKey: Keys.isPrivate.rawValue)
+        self.faviconURL = coder.decodeObject(forKey: Keys.faviconURL.rawValue) as? String
+        self.url = coder.decodeObject(forKey: Keys.url.rawValue) as? URL
+        self.UUID = coder.decodeObject(forKey: Keys.UUID.rawValue) as? String
+        self.tabGroupData = coder.decodeObject(forKey: Keys.tabGroupData.rawValue) as? TabGroupData
+        self.createdAt = coder.decodeObject(forKey: Keys.createdAt.rawValue) as? Timestamp
+        self.hasHomeScreenshot = coder.decodeBool(forKey: Keys.hasHomeScreenshot.rawValue)
     }
     
     func encode(with coder: NSCoder) {
-        coder.encode(sessionData, forKey: "sessionData")
-        coder.encode(screenshotUUID, forKey: "screenshotUUID")
-        coder.encode(isSelected, forKey: "isSelected")
-        coder.encode(title, forKey: "title")
-        coder.encode(isPrivate, forKey: "isPrivate")
-        coder.encode(faviconURL, forKey: "faviconURL")
-        coder.encode(url, forKey: "url")
-        coder.encode(UUID, forKey: "UUID")
-        coder.encode(tabGroupData, forKey: "tabGroupData")
-        coder.encode(createdAt, forKey: "createdAt")
-        coder.encode(hasHomeScreenshot, forKey: "hasHomeScreenshot")
+        coder.encode(sessionData, forKey: Keys.sessionData.rawValue)
+        coder.encode(screenshotUUID, forKey: Keys.screenshotUUID.rawValue)
+        coder.encode(isSelected, forKey: Keys.isSelected.rawValue)
+        coder.encode(title, forKey: Keys.title.rawValue)
+        coder.encode(isPrivate, forKey: Keys.isPrivate.rawValue)
+        coder.encode(faviconURL, forKey: Keys.faviconURL.rawValue)
+        coder.encode(url, forKey: Keys.url.rawValue)
+        coder.encode(UUID, forKey: Keys.UUID.rawValue)
+        coder.encode(tabGroupData, forKey: Keys.tabGroupData.rawValue)
+        coder.encode(createdAt, forKey: Keys.createdAt.rawValue)
+        coder.encode(hasHomeScreenshot, forKey: Keys.hasHomeScreenshot.rawValue)
     }
 }
 
 public class TabGroupData: NSObject, NSCoding {
+
+    private enum Keys: String {
+        case tabAssociatedSearchTerm
+        case tabAssociatedSearchUrl
+        case tabAssociatedNextUrl
+        case tabHistoryCurrentState
+        case tabGroupTimerState
+    }
+
     var tabAssociatedSearchTerm: String = ""
     var tabAssociatedSearchUrl: String = ""
     var tabAssociatedNextUrl: String = ""
@@ -112,11 +137,11 @@ public class TabGroupData: NSObject, NSCoding {
     
     var jsonDictionary: [String: Any] {
         return [
-            "tabAssociatedSearchTerm": String(self.tabAssociatedSearchTerm),
-            "tabAssociatedSearchUrl": String(self.tabAssociatedSearchUrl),
-            "tabAssociatedNextUrl": String(self.tabAssociatedNextUrl),
-            "tabHistoryCurrentState": String(self.tabHistoryCurrentState),
-            "tabGroupTimerState": String(self.tabGroupTimerState),
+            Keys.tabAssociatedSearchTerm.rawValue: String(self.tabAssociatedSearchTerm),
+            Keys.tabAssociatedSearchUrl.rawValue: String(self.tabAssociatedSearchUrl),
+            Keys.tabAssociatedNextUrl.rawValue: String(self.tabAssociatedNextUrl),
+            Keys.tabHistoryCurrentState.rawValue: String(self.tabHistoryCurrentState),
+            Keys.tabGroupTimerState.rawValue: String(self.tabGroupTimerState),
         ]
     }
 
@@ -129,18 +154,18 @@ public class TabGroupData: NSObject, NSCoding {
     }
 
     required public init?(coder: NSCoder) {
-        self.tabAssociatedSearchTerm = coder.decodeObject(forKey: "tabAssociatedSearchTerm") as? String ?? ""
-        self.tabAssociatedSearchUrl = coder.decodeObject(forKey: "tabAssociatedSearchUrl") as? String ?? ""
-        self.tabAssociatedNextUrl = coder.decodeObject(forKey: "tabAssociatedNextUrl") as? String ?? ""
-        self.tabHistoryCurrentState = coder.decodeObject(forKey: "tabHistoryCurrentState") as? String ?? ""
-        self.tabGroupTimerState = coder.decodeObject(forKey: "tabGroupTimerState") as? String ?? ""
+        self.tabAssociatedSearchTerm = coder.decodeObject(forKey: Keys.tabAssociatedSearchTerm.rawValue) as? String ?? ""
+        self.tabAssociatedSearchUrl = coder.decodeObject(forKey: Keys.tabAssociatedSearchUrl.rawValue) as? String ?? ""
+        self.tabAssociatedNextUrl = coder.decodeObject(forKey: Keys.tabAssociatedNextUrl.rawValue) as? String ?? ""
+        self.tabHistoryCurrentState = coder.decodeObject(forKey: Keys.tabHistoryCurrentState.rawValue) as? String ?? ""
+        self.tabGroupTimerState = coder.decodeObject(forKey: Keys.tabGroupTimerState.rawValue) as? String ?? ""
     }
 
     public func encode(with coder: NSCoder) {
-        coder.encode(tabAssociatedSearchTerm, forKey: "tabAssociatedSearchTerm")
-        coder.encode(tabAssociatedSearchUrl, forKey: "tabAssociatedSearchUrl")
-        coder.encode(tabAssociatedNextUrl, forKey: "tabAssociatedNextUrl")
-        coder.encode(tabHistoryCurrentState, forKey: "tabHistoryCurrentState")
-        coder.encode(tabGroupTimerState, forKey: "tabGroupTimerState")
+        coder.encode(tabAssociatedSearchTerm, forKey: Keys.tabAssociatedSearchTerm.rawValue)
+        coder.encode(tabAssociatedSearchUrl, forKey: Keys.tabAssociatedSearchUrl.rawValue)
+        coder.encode(tabAssociatedNextUrl, forKey: Keys.tabAssociatedNextUrl.rawValue)
+        coder.encode(tabHistoryCurrentState, forKey: Keys.tabHistoryCurrentState.rawValue)
+        coder.encode(tabGroupTimerState, forKey: Keys.tabGroupTimerState.rawValue)
     }
 }

--- a/Client/Frontend/Browser/SiteArchiver.swift
+++ b/Client/Frontend/Browser/SiteArchiver.swift
@@ -18,7 +18,11 @@ struct SiteArchiver {
             return ([SavedTab](), simpleTabsDict)
         }
 
-        let unarchiver = try NSKeyedUnarchiver(forReadingWith: tabData)
+        guard let unarchiver = try? NSKeyedUnarchiver(forReadingFrom: tabData) else {
+            SimpleTab.saveSimpleTab(tabs: nil)
+            return ([SavedTab](), simpleTabsDict)
+        }
+        
         unarchiver.setClass(SavedTab.self, forClassName: "Client.SavedTab")
         unarchiver.setClass(SessionData.self, forClassName: "Client.SessionData")
         unarchiver.decodingFailurePolicy = .setErrorAndReturn

--- a/Client/Frontend/Browser/SiteArchiver.swift
+++ b/Client/Frontend/Browser/SiteArchiver.swift
@@ -8,6 +8,8 @@ import Shared
 
 // Struct that retrives saved tabs and simple tabs dictionary for WidgetKit
 struct SiteArchiver {
+    static let tabsKey = "tabs"
+
     static func tabsToRestore(tabsStateArchivePath: String?) -> ([SavedTab], [String: SimpleTab]) {
         // Get simple tabs for widgetkit
         let simpleTabsDict = SimpleTab.getSimpleTabs()
@@ -22,16 +24,16 @@ struct SiteArchiver {
             SimpleTab.saveSimpleTab(tabs: nil)
             return ([SavedTab](), simpleTabsDict)
         }
-        
+
         unarchiver.setClass(SavedTab.self, forClassName: "Client.SavedTab")
         unarchiver.setClass(SessionData.self, forClassName: "Client.SessionData")
-        unarchiver.decodingFailurePolicy = .setErrorAndReturn
-        guard let tabs = unarchiver.decodeObject(forKey: "tabs") as? [SavedTab] else {
-            Sentry.shared.send( message: "Failed to restore tabs", tag: .tabManager, severity: .error, description: "\(unarchiver.error ??? "nil")")
+        guard let tabs = unarchiver.decodeObject(of: [NSArray.self, SavedTab.self], forKey: SiteArchiver.tabsKey) as? [SavedTab] else {
+            Sentry.shared.send(message: "Failed to restore tabs", tag: .tabManager, severity: .error, description: "\(unarchiver.error ??? "nil")")
             SimpleTab.saveSimpleTab(tabs: nil)
             return ([SavedTab](), simpleTabsDict)
         }
-        
+
+        unarchiver.finishDecoding()
         return (tabs, simpleTabsDict)
     }
 }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -695,9 +695,9 @@ extension TabManager {
         }
     }
 
-    @discardableResult func storeChanges() -> Success {
+    @discardableResult func storeChanges(writeCompletion: (() -> Void)? = nil) -> Success {
         saveTabs(toProfile: profile, normalTabs)
-        return store.preserveTabs(tabs, selectedTab: selectedTab)
+        return store.preserveTabs(tabs, selectedTab: selectedTab, writeCompletion: writeCompletion)
     }
 
     func hasTabsToRestoreAtStartup() -> Bool {

--- a/Client/Frontend/Browser/TabManagerStore.swift
+++ b/Client/Frontend/Browser/TabManagerStore.swift
@@ -16,6 +16,8 @@ class TabManagerStore: FeatureFlagsProtocol {
     fileprivate let serialQueue = DispatchQueue(label: "tab-manager-write-queue")
     fileprivate var writeOperation = DispatchWorkItem {}
 
+    private let profilePath: String?
+
     // Init this at startup with the tabs on disk, and then on each save, update the in-memory tab state.
     fileprivate lazy var archivedStartupTabs = {
         return SiteArchiver.tabsToRestore(tabsStateArchivePath: tabsStateArchivePath())
@@ -25,6 +27,12 @@ class TabManagerStore: FeatureFlagsProtocol {
         self.fileManager = fileManager
         self.imageStore = imageStore
         self.prefs = prefs
+
+        if AppConstants.IsRunningTest || AppConstants.IsRunningPerfTest {
+            profilePath = (UIApplication.shared.delegate as? TestAppDelegate)?.dirForTestProfile
+        } else {
+            profilePath = fileManager.containerURL( forSecurityApplicationGroupIdentifier: AppInfo.sharedContainerIdentifier)?.appendingPathComponent("profile.profile").path
+        }
     }
 
     var isRestoringTabs: Bool {
@@ -36,12 +44,6 @@ class TabManagerStore: FeatureFlagsProtocol {
     }
 
     fileprivate func tabsStateArchivePath() -> String? {
-        let profilePath: String?
-        if  AppConstants.IsRunningTest || AppConstants.IsRunningPerfTest {
-            profilePath = (UIApplication.shared.delegate as? TestAppDelegate)?.dirForTestProfile
-        } else {
-            profilePath = fileManager.containerURL( forSecurityApplicationGroupIdentifier: AppInfo.sharedContainerIdentifier)?.appendingPathComponent("profile.profile").path
-        }
         guard let path = profilePath else { return nil }
         return URL(fileURLWithPath: path).appendingPathComponent("tabsState.archive").path
     }

--- a/Client/Frontend/Browser/TabManagerStore.swift
+++ b/Client/Frontend/Browser/TabManagerStore.swift
@@ -90,7 +90,6 @@ class TabManagerStore: FeatureFlagsProtocol {
     /// - Returns: Success when the write operation is on the queue
     @discardableResult func preserveTabs(_ tabs: [Tab], selectedTab: Tab?, writeCompletion: (() -> Void)? = nil) -> Success {
         assert(Thread.isMainThread)
-        log.debug("Preserving tabs with existing tabs count: \(tabs.count)")
         guard let savedTabs = prepareSavedTabs(fromTabs: tabs, selectedTab: selectedTab), let path = tabsStateArchivePath() else {
             clearArchive()
             return succeed()

--- a/Client/Frontend/Browser/TabManagerStore.swift
+++ b/Client/Frontend/Browser/TabManagerStore.swift
@@ -85,13 +85,11 @@ class TabManagerStore: FeatureFlagsProtocol {
     ///   - tabs: The tabs to preserve
     ///   - selectedTab: One of the saved tabs will be saved as the selected tab.
     ///   - writeCompletion: Used to know the write operation has completed - Used in unit tests
-    /// - Returns: <#description#>
+    /// - Returns: Success when the write operation is on the queue
     @discardableResult func preserveTabs(_ tabs: [Tab], selectedTab: Tab?, writeCompletion: (() -> Void)? = nil) -> Success {
         assert(Thread.isMainThread)
-        log.debug("preserve tabs!, existing tabs: \(tabs.count)")
-        guard let savedTabs = prepareSavedTabs(fromTabs: tabs, selectedTab: selectedTab),
-              let path = tabsStateArchivePath()
-        else {
+        log.debug("Preserving tabs with existing tabs count: \(tabs.count)")
+        guard let savedTabs = prepareSavedTabs(fromTabs: tabs, selectedTab: selectedTab), let path = tabsStateArchivePath() else {
             clearArchive()
             return succeed()
         }

--- a/ClientTests/TabManagerStoreTests.swift
+++ b/ClientTests/TabManagerStoreTests.swift
@@ -91,7 +91,7 @@ extension TabManagerStoreTests {
         }
 
         waitForExpectations(timeout: 5) { error in
-            if let error = error { XCTFail("\(error)", file: file, line: line) }
+            if let error = error { XCTFail("waitForExpectations failed with \(error): \(error.localizedDescription)", file: file, line: line) }
         }
     }
 }

--- a/ClientTests/TabManagerStoreTests.swift
+++ b/ClientTests/TabManagerStoreTests.swift
@@ -67,7 +67,7 @@ class TabManagerStoreTests: XCTestCase {
         waitForStoreChanged(tabCountOnDisk: 2)
 
         // Add 2 more tabs
-        addTabsWithSessionData(numberOfTabs: 2)
+        addTabsWithSessionData(numberOfTabs: 2, expectedTabsNumber: 4)
         waitForStoreChanged(tabCountOnDisk: 4)
     }
 
@@ -99,8 +99,12 @@ class TabManagerStoreTests: XCTestCase {
 // Helper functions for TabManagerStoreTests
 extension TabManagerStoreTests {
 
-    // Without session data, a Tab can't become a SavedTab and get archived
     func addTabsWithSessionData(numberOfTabs: Int = 1, isPrivate: Bool = false, file: StaticString = #file, line: UInt = #line) {
+        addTabsWithSessionData(numberOfTabs: numberOfTabs, expectedTabsNumber: numberOfTabs, isPrivate: isPrivate, file: file, line: line)
+    }
+
+    // Without session data, a Tab can't become a SavedTab and get archived
+    func addTabsWithSessionData(numberOfTabs: Int = 1, expectedTabsNumber: Int, isPrivate: Bool = false, file: StaticString = #file, line: UInt = #line) {
         for _ in 0..<numberOfTabs {
             let tab = Tab(bvc: BrowserViewController.foregroundBVC(), configuration: configuration, isPrivate: isPrivate)
             tab.url = URL(string: "http://yahoo.com")!
@@ -108,7 +112,7 @@ extension TabManagerStoreTests {
             tab.sessionData = SessionData(currentPage: 0, urls: [tab.url!], lastUsedTime: Date.now())
         }
 
-        XCTAssertEqual(manager.tabs.count, numberOfTabs, "Expected \(numberOfTabs) tabs in manager", file: file, line: line)
+        XCTAssertEqual(manager.tabs.count, expectedTabsNumber, "Expected \(expectedTabsNumber) tabs in manager", file: file, line: line)
     }
 
     func waitForStoreChanged(tabCountOnDisk: Int, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
@muhasturk took the initiative of fixing the deprecation warning for NSKeyedUnarchiver in our SiteArchiver 🙌. There was a minor change missing for the unit tests to pass, and I took the opportunity to add some Keys in our SavedTab and TabGroupData at the same time.

Also, I reworked the TabManagerStoreTests and re-enabled the problematic `testAddedTabsAreStored` unit test. Hoping with my changes this will resolve https://github.com/mozilla-mobile/firefox-ios/issues/7867 at the same time.