### PR TITLE
For #9704 - XCUITest remove pocket test

### DIFF
--- a/XCUITests/PocketTests.swift
+++ b/XCUITests/PocketTests.swift
@@ -35,13 +35,4 @@ class PocketTest: BaseTestCase {
         // The url textField is not empty
         XCTAssertNotEqual(app.textFields["url"].value as! String, "", "The url textField is empty")
     }
-
-    func testTapOnMore() {
-        waitForExistence(app.buttons["More"], timeout: 5)
-        app.buttons["More"].tap()
-        waitUntilPageLoad()
-        navigator.nowAt(BrowserTab)
-        waitForExistence(app.textFields["url"], timeout: 15)
-        waitForValueContains(app.textFields["url"], value: "getpocket.com/explore")
-    }
 }


### PR DESCRIPTION
Fixes #9704 by removing the test that does not apply anymore due to the new design that does not have the More button
