### PR TITLE
Do not fulfill previous query with a success when replacing password search with a new term

### DIFF
--- a/Client/Frontend/Login Management/LoginListViewModel.swift
+++ b/Client/Frontend/Login Management/LoginListViewModel.swift
@@ -7,6 +7,10 @@ import Storage
 import Shared
 import AuthenticationServices
 
+struct NewSearchInProgressError: MaybeErrorType {
+    public let description: String
+}
+
 // MARK: - Main View Model
 // Login List View Model
 final class LoginListViewModel {
@@ -42,7 +46,7 @@ final class LoginListViewModel {
 
     func loadLogins(_ query: String? = nil, loginDataSource: LoginDataSource) {
         // Fill in an in-flight query and re-query
-        activeLoginQuery?.fillIfUnfilled(Maybe(success: []))
+        activeLoginQuery?.fillIfUnfilled(Maybe(failure: NewSearchInProgressError(description: "Updated search string provided")))
         activeLoginQuery = queryLogins(query ?? "")
         activeLoginQuery! >>== self.setLogins
         // Loading breaches is a heavy operation hence loading it once per opening logins screen


### PR DESCRIPTION
When multiple searches are created the previous query is cancelled with an empty success result. This causes the UI to stop displaying a loading screen. This is very confusing to users, as it makes them believe the search is not working properly. 

Closes #9666 and closes #9477

