### PR TITLE
Bugfix #9538 [v97]: Deleted tab is now not shown when moving tabs in tab grid view

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -694,6 +694,13 @@ extension TabDisplayManager: UICollectionViewDropDelegate {
             return
         }
 
+        // This enforces that filtered tabs, and tabs manager are in sync
+        if tab.isPrivate {
+            filteredTabs = tabManager.privateTabs.filter { filteredTabs.contains($0) }
+        } else {
+            filteredTabs = tabManager.normalTabs.filter { filteredTabs.contains($0) }
+        }
+        
         recordEventAndBreadcrumb(object: .tab, method: .drop)
 
         coordinator.drop(dragItem, toItemAt: destinationIndexPath)


### PR DESCRIPTION
# Overview
This PR addresses [this JIRA ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-3446) and #9538. This avoids a crash when the ghost tab reappears, and a user taps it. 

## Testing
- Open 3 unique tabs (each at a different web page). 
- Access tabs via the grid tab tray. 
- Delete any tab.
- Move any available tabs around
- Make sure no extra tabs appear. 

Repeat the above with tab groups, and on iPad as well. 