### PR TITLE
Bugfix #9724 [v96]: shortcuts title overlap fix

### DIFF
--- a/Client/Frontend/Home/FirefoxHomeTopSitesCell.swift
+++ b/Client/Frontend/Home/FirefoxHomeTopSitesCell.swift
@@ -91,6 +91,7 @@ class TopSiteItemCell: UICollectionViewCell, NotificationThemeable {
         titleLabel.snp.makeConstraints { make in
             make.top.equalTo(titleWrapper)
             make.leading.trailing.equalTo(titleWrapper)
+            make.width.equalTo(TopSiteCellUX.backgroundSize.width + 4)
         }
 
         imageView.snp.makeConstraints { make in


### PR DESCRIPTION
# Overview

This PR addresses [this JIRA ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-3582) and #9724. 

## Testing
On iPad & iPhone, follow the steps outlined in #9724. 