### PR TITLE
Remove #9428 [v96] Rating prompt

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -384,7 +384,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Cleanup can be a heavy operation, take it out of the startup path. Instead check after a few seconds.
         DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
             self.profile?.cleanupHistoryIfNeeded()
-            self.browserViewController.ratingPromptManager.updateData()
         }
     }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -70,9 +70,6 @@ extension BrowserViewController: URLBarDelegate, FeatureFlagsProtocol {
             screenshotHelper.takeScreenshot(tab)
         }
         TelemetryWrapper.recordEvent(category: .action, method: .open, object: .tabTray)
-
-        // App store review in-app prompt
-        ratingPromptManager.showRatingPromptIfNeeded()
     }
 
     private func shouldShowChronTabs() -> Bool {


### PR DESCRIPTION
Removing the Rating prompt from v96 for issue #9428
The Setting item to go to the App Store will stay in thought.