### PR TITLE
Bugfix #9282 [v97] iPad home button when multitasking

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1013,13 +1013,9 @@ class BrowserViewController: UIViewController {
         if isLoading {
             state = .stop
         } else {
-            if UIDevice.current.userInterfaceIdiom == .phone {
-                state = .home
-
-            } else {
-                state = .reload
-            }
+            state = .home
         }
+
         navigationToolbar.updateMiddleButtonState(state)
         if toolbar != nil {
             urlBar.locationView.reloadButton.reloadButtonState = isLoading ? .stop : .reload


### PR DESCRIPTION
# Issue #9282
Middle button state should be home instead of reload when we're in multitasking view on iPad.

Screenshot of the fix:
![simulator_screenshot_805E3338-4315-4F77-B7C1-AD82B817E57E](https://user-images.githubusercontent.com/11338480/149557157-5df97295-939c-46bc-bf32-a65f625df109.png)

