### PR TITLE
Bugfix #8850 [v97] Command+F with mouse bugfix

### DIFF
--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -50,6 +50,10 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
     // whereever we need to focus the user's attention.
     var tabToFocus: Tab? = nil
 
+    override var canBecomeFirstResponder: Bool {
+        return true
+    }
+
     fileprivate lazy var emptyPrivateTabsView: EmptyPrivateTabsView = {
         let emptyView = EmptyPrivateTabsView()
         emptyView.learnMoreButton.addTarget(self, action: #selector(didTapLearnMore), for: .touchUpInside)

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -930,7 +930,14 @@ class TabWebView: WKWebView, MenuHelperInterface {
 
     internal override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         // The find-in-page selection menu only appears if the webview is the first responder.
-        becomeFirstResponder()
+        if #available(iOS 13.4, *) {
+            // Do not becomeFirstResponder on a mouse event.
+            if let event = event, event.allTouches?.contains(where: { $0.type == .indirectPointer }) ?? false {
+                becomeFirstResponder()
+            }
+        } else {
+            becomeFirstResponder()
+        }
 
         return super.hitTest(point, with: event)
     }

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -180,6 +180,8 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UTImportedTypeDeclarations</key>
 	<array>
 		<dict>


### PR DESCRIPTION
- Bugfix for #8850 where mouse moving events where always overriding first responder of the find-in-page bar. A user could not use that shortcut properly if he had a mouse connected.
- Improvement for #8891 where GridTabViewController wasn't always first responder (and keyboard shortcuts weren't working).
