### PR TITLE
Refactor #9797 v[97] - Reduce warnings related to xcuitests

### DIFF
--- a/L10nSnapshotTests/L10nBaseSnapshotTests.swift
+++ b/L10nSnapshotTests/L10nBaseSnapshotTests.swift
@@ -48,7 +48,10 @@ class L10nBaseSnapshotTests: XCTestCase {
             let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
             if result != .completed {
                 let message = description ?? "Expect predicate \(predicateString) for \(element.description)"
-                self.recordFailure(withDescription: message, inFile: file, atLine: Int(line), expected: false)
+                var issue = XCTIssue(type: .assertionFailure, compactDescription: message)
+                let location = XCTSourceCodeLocation(filePath: file, lineNumber: Int(line))
+                issue.sourceCodeContext = XCTSourceCodeContext(location: location)
+                self.record(issue)
             }
         }
 

--- a/XCUITests/BaseTestCase.swift
+++ b/XCUITests/BaseTestCase.swift
@@ -87,12 +87,16 @@ class BaseTestCase: XCTestCase {
     }
 
     private func waitFor(_ element: XCUIElement, with predicateString: String, description: String? = nil, timeout: TimeInterval = 5.0, file: String, line: UInt) {
+
         let predicate = NSPredicate(format: predicateString)
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
         let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
         if result != .completed {
             let message = description ?? "Expect predicate \(predicateString) for \(element.description)"
-            self.recordFailure(withDescription: message, inFile: file, atLine: Int(line), expected: false)
+            var issue = XCTIssue(type: .assertionFailure, compactDescription: message)
+            let location = XCTSourceCodeLocation(filePath: file, lineNumber: Int(line))
+            issue.sourceCodeContext = XCTSourceCodeContext(location: location)
+            self.record(issue)
         }
     }
 

--- a/XCUITests/DomainAutocompleteTest.swift
+++ b/XCUITests/DomainAutocompleteTest.swift
@@ -75,13 +75,13 @@ class DomainAutocompleteTest: BaseTestCase {
     // Ensure that the scheme is included in the autocompletion.
     func test4EnsureSchemeIncludedAutocompletion() throws {
         throw XCTSkip("Skipping this test due intermittent failures")
-        navigator.openURL(websiteExample["url"]!)
-        waitUntilPageLoad()
-        navigator.goto(URLBarOpen)
-        app.textFields["address"].typeText("http")
-        waitForValueContains(app.textFields["address"], value: "example")
-        let value = app.textFields["address"].value
-        XCTAssertEqual(value as? String, "http://www.example.com", "Wrong autocompletion")
+//        navigator.openURL(websiteExample["url"]!)
+//        waitUntilPageLoad()
+//        navigator.goto(URLBarOpen)
+//        app.textFields["address"].typeText("http")
+//        waitForValueContains(app.textFields["address"], value: "example")
+//        let value = app.textFields["address"].value
+//        XCTAssertEqual(value as? String, "http://www.example.com", "Wrong autocompletion")
     }
     // Non-matches.
     func test5NoMatches() {

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -270,7 +270,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     var i = 0
     let introLast = allIntroPages.count - 1
     for intro in allIntroPages {
-        let prev = i == 0 ? nil : allIntroPages[i - 1]
+        _ = i == 0 ? nil : allIntroPages[i - 1]
         let next = i == introLast ? nil : allIntroPages[i + 1]
 
         map.addScreenState(intro) { screenState in
@@ -284,8 +284,6 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
         i += 1
     }
-
-    let noopAction = {}
 
     // Some internally useful screen states.
     let WebPageLoading = "WebPageLoading"
@@ -449,7 +447,6 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     map.addScreenState(LibraryPanel_Bookmarks) { screenState in
-        let bookmarkCell = app.tables["Bookmarks List"].cells.element(boundBy: 0)
 
         screenState.tap(app.cells.staticTexts["Mobile Bookmarks"], to: MobileBookmarks)
         screenState.gesture(forAction: Action.CloseBookmarkPanel, transitionTo: HomePanelsScreen) { userState in

--- a/XCUITests/HomePageSettingsUITest.swift
+++ b/XCUITests/HomePageSettingsUITest.swift
@@ -190,23 +190,23 @@ class HomePageSettingsUITests: BaseTestCase {
 
     func testJumpBackIn() throws {
         throw XCTSkip("Disabled failing in BR - investigating") 
-        navigator.openURL(path(forTestPage: exampleUrl))
-        waitUntilPageLoad()
-        navigator.goto(TabTray)
-        navigator.performAction(Action.OpenNewTabFromTabTray)
-        navigator.nowAt(NewTabScreen)
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
-        navigator.performAction(Action.CloseURLBarOpen)
-        waitForExistence(app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn], timeout: 5)
-        // Swipe up needed to see the content below the Jump Back In section
-        app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn].swipeUp()
-        XCTAssertTrue(app.cells.collectionViews.staticTexts["Example Domain"].exists)
-        // Swipe down to be able to click on Show all option
-        app.buttons["More"].swipeDown()
-        waitForExistence(app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn], timeout: 5)
-        app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn].tap()
-        // Tab tray is open with recently open tab
-        waitForExistence(app.cells.staticTexts["Example Domain"], timeout: 3)
+//        navigator.openURL(path(forTestPage: exampleUrl))
+//        waitUntilPageLoad()
+//        navigator.goto(TabTray)
+//        navigator.performAction(Action.OpenNewTabFromTabTray)
+//        navigator.nowAt(NewTabScreen)
+//        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
+//        navigator.performAction(Action.CloseURLBarOpen)
+//        waitForExistence(app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn], timeout: 5)
+//        // Swipe up needed to see the content below the Jump Back In section
+//        app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn].swipeUp()
+//        XCTAssertTrue(app.cells.collectionViews.staticTexts["Example Domain"].exists)
+//        // Swipe down to be able to click on Show all option
+//        app.buttons["More"].swipeDown()
+//        waitForExistence(app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn], timeout: 5)
+//        app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn].tap()
+//        // Tab tray is open with recently open tab
+//        waitForExistence(app.cells.staticTexts["Example Domain"], timeout: 3)
     }
 
     func testCustomizeHomepage() {

--- a/XCUITests/PhotonActionSheetTest.swift
+++ b/XCUITests/PhotonActionSheetTest.swift
@@ -8,27 +8,27 @@ class PhotonActionSheetTest: BaseTestCase {
     // Smoketest
     func testPinToTop() throws {
         throw XCTSkip("Skipping this test due to issue 8715")
-        navigator.openURL("http://example.com")
-        waitUntilPageLoad()
-        // Open Page Action Menu Sheet and Pin the site
-        navigator.performAction(Action.PinToTopSitesPAM)
-
-        // Navigate to topsites to verify that the site has been pinned
-        navigator.nowAt(BrowserTab)
-        navigator.performAction(Action.OpenNewTabFromTabTray)
-
-        // Verify that the site is pinned to top
-        waitForExistence(app.cells["example"])
-        let cell = app.cells["example"]
-        waitForExistence(cell)
-
-        // Remove pin
-        app.cells["example"].press(forDuration: 2)
-        app.cells["action_unpin"].tap()
-
-        // Check that it has been unpinned
-        cell.press(forDuration: 2)
-        waitForExistence(app.cells["action_pin"])
+//        navigator.openURL("http://example.com")
+//        waitUntilPageLoad()
+//        // Open Page Action Menu Sheet and Pin the site
+//        navigator.performAction(Action.PinToTopSitesPAM)
+//
+//        // Navigate to topsites to verify that the site has been pinned
+//        navigator.nowAt(BrowserTab)
+//        navigator.performAction(Action.OpenNewTabFromTabTray)
+//
+//        // Verify that the site is pinned to top
+//        waitForExistence(app.cells["example"])
+//        let cell = app.cells["example"]
+//        waitForExistence(cell)
+//
+//        // Remove pin
+//        app.cells["example"].press(forDuration: 2)
+//        app.cells["action_unpin"].tap()
+//
+//        // Check that it has been unpinned
+//        cell.press(forDuration: 2)
+//        waitForExistence(app.cells["action_pin"])
     }
 
     func testShareOptionIsShown() {

--- a/XCUITests/PocketTests.swift
+++ b/XCUITests/PocketTests.swift
@@ -8,31 +8,31 @@ class PocketTest: BaseTestCase {
 
     func testPocketEnabledByDefault() throws {
         throw XCTSkip("Disabled due to #7855")
-        navigator.goto(NewTabScreen)
-        waitForExistence(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket])
-        XCTAssertEqual(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket].label, "Trending on Pocket")
-
-        // There should be two stories on iPhone and three on iPad
-        let numPocketStories = app.collectionViews.containing(.cell, identifier:"TopSitesCell").children(matching: .cell).count-1
-        if iPad() {
-            XCTAssertEqual(numPocketStories, 9)
-        } else {
-            XCTAssertEqual(numPocketStories, 3)
-        }
-
-        // Disable Pocket
-        navigator.performAction(Action.TogglePocketInNewTab)
-        navigator.goto(NewTabScreen)
-        waitForNoExistence(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket])
-        // Enable it again
-        navigator.performAction(Action.TogglePocketInNewTab)
-        navigator.goto(NewTabScreen)
-        waitForExistence(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket])
-
-        // Tap on the first Pocket element
-        app.collectionViews.containing(.cell, identifier:"TopSitesCell").children(matching: .cell).element(boundBy: 1).tap()
-        waitUntilPageLoad()
-        // The url textField is not empty
-        XCTAssertNotEqual(app.textFields["url"].value as! String, "", "The url textField is empty")
+//        navigator.goto(NewTabScreen)
+//        waitForExistence(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket])
+//        XCTAssertEqual(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket].label, "Trending on Pocket")
+//
+//        // There should be two stories on iPhone and three on iPad
+//        let numPocketStories = app.collectionViews.containing(.cell, identifier:"TopSitesCell").children(matching: .cell).count-1
+//        if iPad() {
+//            XCTAssertEqual(numPocketStories, 9)
+//        } else {
+//            XCTAssertEqual(numPocketStories, 3)
+//        }
+//
+//        // Disable Pocket
+//        navigator.performAction(Action.TogglePocketInNewTab)
+//        navigator.goto(NewTabScreen)
+//        waitForNoExistence(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket])
+//        // Enable it again
+//        navigator.performAction(Action.TogglePocketInNewTab)
+//        navigator.goto(NewTabScreen)
+//        waitForExistence(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket])
+//
+//        // Tap on the first Pocket element
+//        app.collectionViews.containing(.cell, identifier:"TopSitesCell").children(matching: .cell).element(boundBy: 1).tap()
+//        waitUntilPageLoad()
+//        // The url textField is not empty
+//        XCTAssertNotEqual(app.textFields["url"].value as! String, "", "The url textField is empty")
     }
 }

--- a/XCUITests/ScreenGraphTest.swift
+++ b/XCUITests/ScreenGraphTest.swift
@@ -76,31 +76,6 @@ extension ScreenGraphTest {
         XCTAssertFalse(navigator.userState.nightMode)
         XCTAssertEqual(navigator.screenState, BrowserTabMenu)
     }
-
-    func testChainedActionPerf1() throws {
-        throw XCTSkip("Skipping this test due intermittent failures")
-        let navigator = self.navigator!
-        measure {
-            navigator.userState.url = defaultURL
-            wait(forElement: app.textFields.firstMatch, timeout: 3)
-            navigator.performAction(TestActions.LoadURLByPasting)
-            XCTAssertEqual(navigator.screenState, WebPageLoading)
-        }
-    }
-
-    func testChainedActionPerf2() throws {
-        throw XCTSkip("Skipping this test due intermittent failures")
-        let navigator = self.navigator!
-        measure {
-            navigator.userState.url = defaultURL
-            navigator.performAction(TestActions.LoadURLByPasting)
-            XCTAssertEqual(navigator.screenState, WebPageLoading)
-        }
-
-        navigator.userState.url = defaultURL
-        navigator.performAction(TestActions.LoadURL)
-        XCTAssertEqual(navigator.screenState, WebPageLoading)
-    }
 }
 
 

--- a/XCUITests/TopTabsTest.swift
+++ b/XCUITests/TopTabsTest.swift
@@ -274,53 +274,53 @@ class TopTabsTest: BaseTestCase {
     // Smoketest
     func testLongTapTabCounter() throws {
         throw XCTSkip("This test is failing. Isabel will be looking into it")
-        if !iPad() {
-            waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
-            // Long tap on Tab Counter should show the correct options
-            navigator.performAction(Action.CloseURLBarOpen)
-            navigator.nowAt(NewTabScreen)
-            waitForExistence(app.buttons["Show Tabs"], timeout: 10)
-            app.buttons["Show Tabs"].press(forDuration: 1)
-            waitForExistence(app.cells["quick_action_new_tab"])
-            XCTAssertTrue(app.cells["quick_action_new_tab"].exists)
-            XCTAssertTrue(app.cells["tab_close"].exists)
-
-            // Open New Tab
-            app.cells["quick_action_new_tab"].tap()
-            navigator.performAction(Action.CloseURLBarOpen)
-
-            waitForTabsButton()
-            checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
-            waitForExistence(app.cells.staticTexts["Home"])
-            app.cells.staticTexts["Home"].firstMatch.tap()
-
-            // Close tab
-            navigator.nowAt(HomePanelsScreen)
-            navigator.performAction(Action.CloseURLBarOpen)
-            navigator.nowAt(NewTabScreen)
-
-            waitForExistence(app.buttons["Show Tabs"])
-            app.buttons["Show Tabs"].press(forDuration: 1)
-            waitForExistence(app.cells["quick_action_new_tab"])
-            app.cells["tab_close"].tap()
-            navigator.performAction(Action.CloseURLBarOpen)
-            navigator.nowAt(NewTabScreen)
-            checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
-
-            // Go to Private Mode
-            waitForExistence(app.cells.staticTexts["Home"])
-            app.cells.staticTexts["Home"].firstMatch.tap()
-            navigator.nowAt(HomePanelsScreen)
-            navigator.performAction(Action.CloseURLBarOpen)
-            navigator.nowAt(NewTabScreen)
-            waitForExistence(app.buttons["Show Tabs"])
-            app.buttons["Show Tabs"].press(forDuration: 1)
-            waitForExistence(app.cells["nav-tabcounter"])
-            app.cells["nav-tabcounter"].tap()
-            navigator.performAction(Action.CloseURLBarOpen)
-            navigator.nowAt(NewTabScreen)
-            checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
-        }
+//        if !iPad() {
+//            waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
+//            // Long tap on Tab Counter should show the correct options
+//            navigator.performAction(Action.CloseURLBarOpen)
+//            navigator.nowAt(NewTabScreen)
+//            waitForExistence(app.buttons["Show Tabs"], timeout: 10)
+//            app.buttons["Show Tabs"].press(forDuration: 1)
+//            waitForExistence(app.cells["quick_action_new_tab"])
+//            XCTAssertTrue(app.cells["quick_action_new_tab"].exists)
+//            XCTAssertTrue(app.cells["tab_close"].exists)
+//
+//            // Open New Tab
+//            app.cells["quick_action_new_tab"].tap()
+//            navigator.performAction(Action.CloseURLBarOpen)
+//
+//            waitForTabsButton()
+//            checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
+//            waitForExistence(app.cells.staticTexts["Home"])
+//            app.cells.staticTexts["Home"].firstMatch.tap()
+//
+//            // Close tab
+//            navigator.nowAt(HomePanelsScreen)
+//            navigator.performAction(Action.CloseURLBarOpen)
+//            navigator.nowAt(NewTabScreen)
+//
+//            waitForExistence(app.buttons["Show Tabs"])
+//            app.buttons["Show Tabs"].press(forDuration: 1)
+//            waitForExistence(app.cells["quick_action_new_tab"])
+//            app.cells["tab_close"].tap()
+//            navigator.performAction(Action.CloseURLBarOpen)
+//            navigator.nowAt(NewTabScreen)
+//            checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
+//
+//            // Go to Private Mode
+//            waitForExistence(app.cells.staticTexts["Home"])
+//            app.cells.staticTexts["Home"].firstMatch.tap()
+//            navigator.nowAt(HomePanelsScreen)
+//            navigator.performAction(Action.CloseURLBarOpen)
+//            navigator.nowAt(NewTabScreen)
+//            waitForExistence(app.buttons["Show Tabs"])
+//            app.buttons["Show Tabs"].press(forDuration: 1)
+//            waitForExistence(app.cells["nav-tabcounter"])
+//            app.cells["nav-tabcounter"].tap()
+//            navigator.performAction(Action.CloseURLBarOpen)
+//            navigator.nowAt(NewTabScreen)
+//            checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
+//        }
     }
 }
 
@@ -344,33 +344,33 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
 
     func testCloseTabFromLongPressTabsButton() throws {
         throw XCTSkip("This test is failing. Isabel will be looking into it")
-        if skipPlatform { return }
-        navigator.goto(URLBarOpen)
-        navigator.back()
-        waitForTabsButton()
-        // This menu is available in HomeScreen or NewTabScreen, so no need to open new websites
-        navigator.performAction(Action.OpenNewTabFromTabTray)
-        navigator.performAction(Action.CloseURLBarOpen)
-        navigator.nowAt(NewTabScreen)
-        waitForTabsButton()
-        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
-        closeTabTrayView(goBackToBrowserTab: "Home")
-        navigator.performAction(Action.CloseURLBarOpen)
-        navigator.nowAt(NewTabScreen)
-        navigator.performAction(Action.CloseTabFromTabTrayLongPressMenu)
-        navigator.performAction(Action.CloseURLBarOpen)
-        navigator.nowAt(NewTabScreen)
-        waitForTabsButton()
-        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
-        closeTabTrayView(goBackToBrowserTab: "Home")
-        navigator.performAction(Action.CloseURLBarOpen)
-        navigator.nowAt(NewTabScreen)
-        navigator.performAction(Action.CloseTabFromTabTrayLongPressMenu)
-        navigator.performAction(Action.CloseURLBarOpen)
-        navigator.nowAt(NewTabScreen)
-        waitForTabsButton()
-        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
-        closeTabTrayView(goBackToBrowserTab: "Home")
+//        if skipPlatform { return }
+//        navigator.goto(URLBarOpen)
+//        navigator.back()
+//        waitForTabsButton()
+//        // This menu is available in HomeScreen or NewTabScreen, so no need to open new websites
+//        navigator.performAction(Action.OpenNewTabFromTabTray)
+//        navigator.performAction(Action.CloseURLBarOpen)
+//        navigator.nowAt(NewTabScreen)
+//        waitForTabsButton()
+//        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
+//        closeTabTrayView(goBackToBrowserTab: "Home")
+//        navigator.performAction(Action.CloseURLBarOpen)
+//        navigator.nowAt(NewTabScreen)
+//        navigator.performAction(Action.CloseTabFromTabTrayLongPressMenu)
+//        navigator.performAction(Action.CloseURLBarOpen)
+//        navigator.nowAt(NewTabScreen)
+//        waitForTabsButton()
+//        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
+//        closeTabTrayView(goBackToBrowserTab: "Home")
+//        navigator.performAction(Action.CloseURLBarOpen)
+//        navigator.nowAt(NewTabScreen)
+//        navigator.performAction(Action.CloseTabFromTabTrayLongPressMenu)
+//        navigator.performAction(Action.CloseURLBarOpen)
+//        navigator.nowAt(NewTabScreen)
+//        waitForTabsButton()
+//        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
+//        closeTabTrayView(goBackToBrowserTab: "Home")
     }
 
     // This test only runs for iPhone see bug 1409750
@@ -495,33 +495,33 @@ class TopTabsTestIpad: IpadOnlyTestCase {
     func testTopSitesScrollToVisible() throws {
         throw XCTSkip("Not sure about new behaviour with urlBar focused")
 
-        if skipPlatform { return }
-
-        // This first cell gets closed during the test
-        navigator.openURL(urlValueLong)
-
-        // Create enough tabs that tabs bar needs to scroll
-        for _ in 0..<6 {
-            navigator.createNewTab()
-        }
-
-        // This is the selected tab for the duration of this test
-        navigator.openNewURL(urlString: urlValueLongExample)
-
-        waitUntilPageLoad()
-
-        // This is the index of the last visible cell, it doesn't change during the test
-        let lastCell = app.collectionViews["Top Tabs View"].cells.count - 1
-
-        cellIsSelectedTab(index: lastCell, url: urlValueLongExample, title: urlLabelExample)
-
-        // Scroll to first tab and delete it, swipe twice to ensure we are fully scrolled.
-        app.collectionViews["Top Tabs View"].cells.element(boundBy: lastCell).swipeRight()
-        app.collectionViews["Top Tabs View"].cells.element(boundBy: lastCell).swipeRight()
-        app.collectionViews["Top Tabs View"].cells[urlLabel].buttons.element(boundBy: 0).tap()
-        // Confirm the view did not scroll to the selected cell
-        XCTAssertEqual(app.collectionViews["Top Tabs View"].cells.element(boundBy: lastCell).label, "Home")
-        // Confirm the url bar still has selected cell value
-        waitForValueContains(app.textFields["url"], value: urlValueLongExample)
+//        if skipPlatform { return }
+//
+//        // This first cell gets closed during the test
+//        navigator.openURL(urlValueLong)
+//
+//        // Create enough tabs that tabs bar needs to scroll
+//        for _ in 0..<6 {
+//            navigator.createNewTab()
+//        }
+//
+//        // This is the selected tab for the duration of this test
+//        navigator.openNewURL(urlString: urlValueLongExample)
+//
+//        waitUntilPageLoad()
+//
+//        // This is the index of the last visible cell, it doesn't change during the test
+//        let lastCell = app.collectionViews["Top Tabs View"].cells.count - 1
+//
+//        cellIsSelectedTab(index: lastCell, url: urlValueLongExample, title: urlLabelExample)
+//
+//        // Scroll to first tab and delete it, swipe twice to ensure we are fully scrolled.
+//        app.collectionViews["Top Tabs View"].cells.element(boundBy: lastCell).swipeRight()
+//        app.collectionViews["Top Tabs View"].cells.element(boundBy: lastCell).swipeRight()
+//        app.collectionViews["Top Tabs View"].cells[urlLabel].buttons.element(boundBy: 0).tap()
+//        // Confirm the view did not scroll to the selected cell
+//        XCTAssertEqual(app.collectionViews["Top Tabs View"].cells.element(boundBy: lastCell).label, "Home")
+//        // Confirm the url bar still has selected cell value
+//        waitForValueContains(app.textFields["url"], value: urlValueLongExample)
     }
 }

--- a/test-fixtures/generate-metrics.sh
+++ b/test-fixtures/generate-metrics.sh
@@ -4,8 +4,8 @@ set -e
 
 BUILD_LOG_FILE="$1"
 TYPE_LOG_FILE="$2"
-THREESHOLD_UNIT_TEST=310
-THREESHOLD_XCUITEST=850
+THREESHOLD_UNIT_TEST=250
+THREESHOLD_XCUITEST=750
 
 
 WARNING_COUNT=`egrep '^(\/.+:[0-9+:[0-9]+:.|warning:|ld: warning:|<unknown>:0: warning:|fatal|===)' "$BUILD_LOG_FILE" | uniq | wc -l`

--- a/test-fixtures/generate-metrics.sh
+++ b/test-fixtures/generate-metrics.sh
@@ -4,8 +4,8 @@ set -e
 
 BUILD_LOG_FILE="$1"
 TYPE_LOG_FILE="$2"
-THREESHOLD_UNIT_TEST=250
-THREESHOLD_XCUITEST=750
+THREESHOLD_UNIT_TEST=150
+THREESHOLD_XCUITEST=700
 
 
 WARNING_COUNT=`egrep '^(\/.+:[0-9+:[0-9]+:.|warning:|ld: warning:|<unknown>:0: warning:|fatal|===)' "$BUILD_LOG_FILE" | uniq | wc -l`


### PR DESCRIPTION
PR would fix #9797 
There are some warnings like: `code after throw will never be executed`
See for example:
```
// Smoketest
    func testLongTapTabCounter() throws {
        throw XCTSkip("This test is failing. Isabel will be looking into it")
```

We use it when we need to skip a test... will try to look for another way to do that or to hide that warning on Bitrise.

