### PR TITLE
Bugfix #9444 Remove extra padding in bookmarks and history on iOS 15

### DIFF
--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -97,6 +97,10 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
         
         // Set an empty footer to prevent empty cells from appearing in the list.
         table.tableFooterView = UIView()
+        
+        if #available(iOS 15.0, *) {
+            table.sectionHeaderTopPadding = 0
+        }
     }
 
     private override init(nibName: String?, bundle: Bundle?) {


### PR DESCRIPTION
This PR fixes the extra padding in the Bookmarks and History panel on devices running iOS 15 or later. (#9444)

Before:
![Simulator Screen Shot - iPhone 13 Pro - 2022-01-17 at 19 28 12](https://user-images.githubusercontent.com/66826029/149990342-2f29b53a-6a5f-4f39-853c-7c1d33beeb02.png)
After:
![Simulator Screen Shot - iPhone 13 Pro - 2022-01-17 at 19 24 02](https://user-images.githubusercontent.com/66826029/149990350-eacb82d6-7d50-4a08-8a5d-294b32120753.png)


