### PR TITLE
FX-9080 Don't show menu when long pressing home button

### DIFF
--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -215,6 +215,8 @@ open class TabToolbarHelper: NSObject {
         switch middleButtonState {
         case .search:
             return
+        case .home:
+            return
         default:
             if recognizer.state == .began {
                 toolbar.tabToolbarDelegate?.tabToolbarDidLongPressReload(toolbar, button: toolbar.multiStateButton)

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -213,9 +213,7 @@ open class TabToolbarHelper: NSObject {
     
     func didLongPressMultiStateButton(_ recognizer: UILongPressGestureRecognizer) {
         switch middleButtonState {
-        case .search:
-            return
-        case .home:
+        case .search, .home:
             return
         default:
             if recognizer.state == .began {


### PR DESCRIPTION
This PR fixes the issue where the "Request desktop site" menu is shown when the home button is long pressed. (#9080)