### PR TITLE
Handle web browsing handoff events

### DIFF
--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -97,6 +97,7 @@
 		<string>QuickActionIntent</string>
 		<string>QuickLinkSelectionIntent</string>
 		<string>org.mozilla.ios.firefox.browsing</string>
+		<string>NSUserActivityTypeBrowsingWeb</string>
 	</array>
 	<key>PocketEnvironmentAPIKey</key>
 	<string>$(POCKET_API_KEY)</string>


### PR DESCRIPTION
This allows the iOS client to handle handoff from firefox desktop as described in #9513.

