### PR TITLE
FX-9774 Fix history cells changing in height

### DIFF
--- a/Client/Frontend/Widgets/TwoLineCellAndFooter.swift
+++ b/Client/Frontend/Widgets/TwoLineCellAndFooter.swift
@@ -146,7 +146,7 @@ class TwoLineImageOverlayCell: UITableViewCell, NotificationThemeable {
     override func layoutSubviews() {
         super.layoutSubviews()
         containerView.snp.remakeConstraints { make in
-            make.height.equalTo(55)
+            make.height.equalTo(58)
             make.top.bottom.equalToSuperview()
             make.leading.equalToSuperview()
             make.trailing.equalTo(accessoryView?.snp.leading ?? snp.trailing)


### PR DESCRIPTION
This PR fixes cells in the library panel changing heights when scrolling. (#9774)