### PR TITLE
Bugfix #9754 Reenable save button in Custom Search Engine settings after attempting to save blank fields

### DIFF
--- a/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -167,6 +167,8 @@ class CustomSearchViewController: SettingsTableViewController {
         navigationItem.rightBarButtonItem?.isEnabled = false
         if let url = self.urlString {
             self.addSearchEngine(url, title: self.engineTitle)
+        } else {
+            navigationItem.rightBarButtonItem?.isEnabled = true
         }
     }
 }

--- a/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -164,11 +164,9 @@ class CustomSearchViewController: SettingsTableViewController {
 
     @objc func addCustomSearchEngine(_ nav: UINavigationController?) {
         self.view.endEditing(true)
-        navigationItem.rightBarButtonItem?.isEnabled = false
         if let url = self.urlString {
+            navigationItem.rightBarButtonItem?.isEnabled = false
             self.addSearchEngine(url, title: self.engineTitle)
-        } else {
-            navigationItem.rightBarButtonItem?.isEnabled = true
         }
     }
 }


### PR DESCRIPTION
This PR is a temporary solution to the save button being disabled in the Custom Search Engine settings after attempting to add an entry with a blank URL. A more robust solution would be to show an error alert or enabling/disabling the save button upon valid/invalid input. (#9754)