### PR TITLE
Bugfix #7573 [v98]: Clear tab history after clearing ALL history

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -877,7 +877,7 @@ class BrowserViewController: UIViewController {
             presentedViewController.dismiss(animated: true, completion: nil)
         }
 
-        let libraryViewController = self.libraryViewController ?? LibraryViewController(profile: profile)
+        let libraryViewController = self.libraryViewController ?? LibraryViewController(profile: profile, tabManager: tabManager)
         libraryViewController.delegate = self
         self.libraryViewController = libraryViewController
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -36,7 +36,7 @@ extension BrowserViewController {
 
     @objc private func openClearHistoryPanelKeyCommand() {
         guard let libraryViewController = self.libraryViewController else {
-            let clearHistoryHelper = ClearHistoryHelper(profile: profile)
+            let clearHistoryHelper = ClearHistoryHelper(profile: profile, tabManager: tabManager)
             clearHistoryHelper.showClearRecentHistory(onViewController: self, didComplete: {})
             return
         }

--- a/Client/Frontend/Browser/SessionData.swift
+++ b/Client/Frontend/Browser/SessionData.swift
@@ -40,8 +40,8 @@ private func migrate(urls: [URL]) -> [URL] {
 
 class SessionData: NSObject, NSCoding {
     let currentPage: Int
-    let urls: [URL]
     let lastUsedTime: Timestamp
+    let urls: [URL]
 
     var jsonDictionary: [String: Any] {
         return [

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -492,6 +492,18 @@ class Tab: NSObject {
         checkTabCount(failures: 0)
         #endif
     }
+    
+    /// When a user clears ALL history, `sessionData` and `historyList` need to be purged, and close the webView.
+    func clearAndResetTabHistory() {
+        guard let currentlyOpenUrl = lastKnownUrl ?? historyList.last else { return }
+        
+        url = currentlyOpenUrl
+        sessionData = SessionData(currentPage: 0, urls: [currentlyOpenUrl], lastUsedTime: Date.now())
+        historyList = [currentlyOpenUrl]
+        webView = nil
+        
+        close()
+    }
 
     func close() {
         contentScriptManager.uninstall(tab: self)
@@ -524,12 +536,18 @@ class Tab: NSObject {
     }
 
     var historyList: [URL] {
-        func listToUrl(_ item: WKBackForwardListItem) -> URL { return item.url }
-        var tabs = self.backList?.map(listToUrl) ?? [URL]()
-        if let url = url {
-            tabs.append(url)
+        get {
+            func listToUrl(_ item: WKBackForwardListItem) -> URL { return item.url }
+            
+            var historyUrls = self.backList?.map(listToUrl) ?? [URL]()
+            if let url = url {
+                historyUrls.append(url)
+            }
+            return historyUrls
         }
-        return tabs
+        
+        set { }
+        
     }
 
     var title: String? {
@@ -909,9 +927,8 @@ private class TabContentScriptManager: NSObject, WKScriptMessageHandler {
     }
 
     func addContentScript(_ helper: TabContentScript, name: String, forTab tab: Tab) {
-        if let _ = helpers[name] {
-            assertionFailure("Duplicate helper added: \(name)")
-        }
+        // If a helper script already exists on a tab, skip adding this duplicate.
+        guard helpers[name] == nil else { return }
 
         helpers[name] = helper
 
@@ -923,9 +940,8 @@ private class TabContentScriptManager: NSObject, WKScriptMessageHandler {
     }
 
     func addContentScriptToPage(_ helper: TabContentScript, name: String, forTab tab: Tab) {
-        if let _ = helpers[name] {
-            assertionFailure("Duplicate helper added: \(name)")
-        }
+        // If a helper script already exists on the page, skip adding this duplicate.
+        guard helpers[name] == nil else { return }
 
         helpers[name] = helper
 

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -679,6 +679,31 @@ class TabManager: NSObject, FeatureFlagsProtocol {
         assert(Thread.isMainThread)
         configuration.processPool = WKProcessPool()
     }
+    
+    /// When all history gets deleted, we use this special way to handle Tab History deletion. To make it appear like
+    /// the currently open tab also has its history deleted, we close the tab and reload that URL in a new tab.
+    /// We handle it this way because, as far as I can tell, clearing history REQUIRES we nil the webView. The backForwardList
+    /// is not directly mutable. When niling out the webView, we should properly close it since it affects KVO.
+    func clearAllTabsHistory() {
+        guard let selectedTab = selectedTab, let url = selectedTab.url else { return }
+        
+        for tab in tabs where tab !== selectedTab {
+            tab.clearAndResetTabHistory()
+        }
+        
+        removeTab(selectedTab)
+        
+        let tabToSelect: Tab
+        if url.isFxHomeUrl {
+            tabToSelect = addTab(PrivilegedRequest(url: url) as URLRequest, isPrivate: selectedTab.isPrivate)
+        } else {
+            let request = URLRequest(url: url)
+            tabToSelect = addTab(request, isPrivate: selectedTab.isPrivate)
+        }
+        
+        selectTab(tabToSelect)
+    }
+    
 }
 
 extension TabManager {

--- a/Client/Frontend/Library/ClearHistoryHelper.swift
+++ b/Client/Frontend/Library/ClearHistoryHelper.swift
@@ -8,9 +8,11 @@ import WebKit
 class ClearHistoryHelper {
 
     private let profile: Profile
-
-    init(profile: Profile) {
+    private let tabManager: TabManager
+    
+    init(profile: Profile, tabManager: TabManager) {
         self.profile = profile
+        self.tabManager = tabManager
     }
 
     /// Present a prompt that will enable the user to choose how he wants to clear his recent history
@@ -55,6 +57,8 @@ class ClearHistoryHelper {
                 didComplete()
             }
             self.profile.recentlyClosedTabs.clearTabs()
+            self.tabManager.clearAllTabsHistory()
+            NotificationCenter.default.post(name: .PrivateDataClearedHistory, object: nil)
         }))
         let cancelAction = UIAlertAction(title: .CancelString, style: .cancel)
         alert.addAction(cancelAction)

--- a/Client/Frontend/Library/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel.swift
@@ -99,8 +99,8 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
     }()
 
     // MARK: - Lifecycle
-    override init(profile: Profile) {
-        self.clearHistoryHelper = ClearHistoryHelper(profile: profile)
+    init(profile: Profile, tabManager: TabManager) {
+        self.clearHistoryHelper = ClearHistoryHelper(profile: profile, tabManager: tabManager)
         super.init(profile: profile)
 
         [ Notification.Name.FirefoxAccountChanged,
@@ -333,6 +333,7 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
     func onNotificationReceived(_ notification: Notification) {
         switch notification.name {
         case .FirefoxAccountChanged, .PrivateDataClearedHistory:
+            groupedSites = DateGroupedTableData<Site>()
             reloadData()
 
             if profile.hasSyncableAccount() {

--- a/Client/Frontend/Library/LibraryPanels.swift
+++ b/Client/Frontend/Library/LibraryPanels.swift
@@ -49,17 +49,19 @@ class LibraryPanelDescriptor {
     var viewController: UIViewController?
     var navigationController: UINavigationController?
 
-    fileprivate let makeViewController: (_ profile: Profile) -> UIViewController
+    fileprivate let makeViewController: (_ profile: Profile, _ tabManager: TabManager) -> UIViewController
     fileprivate let profile: Profile
+    fileprivate let tabManager: TabManager
 
     let imageName: String
     let activeImageName: String
     let accessibilityLabel: String
     let accessibilityIdentifier: String
 
-    init(makeViewController: @escaping ((_ profile: Profile) -> UIViewController), profile: Profile, imageName: String, accessibilityLabel: String, accessibilityIdentifier: String) {
+    init(makeViewController: @escaping ((_ profile: Profile, _ tabManager: TabManager) -> UIViewController), profile: Profile, tabManager: TabManager, imageName: String, accessibilityLabel: String, accessibilityIdentifier: String) {
         self.makeViewController = makeViewController
         self.profile = profile
+        self.tabManager = tabManager
         self.imageName = "panelIcon" + imageName
         self.activeImageName = self.imageName + "-active"
         self.accessibilityLabel = accessibilityLabel
@@ -68,7 +70,7 @@ class LibraryPanelDescriptor {
 
     func setup() {
         guard viewController == nil else { return }
-        let viewController = makeViewController(profile)
+        let viewController = makeViewController(profile, tabManager)
         self.viewController = viewController
         navigationController = ThemedNavigationController(rootViewController: viewController)
     }
@@ -76,44 +78,50 @@ class LibraryPanelDescriptor {
 
 class LibraryPanels {
     fileprivate let profile: Profile
+    fileprivate let tabManager: TabManager
 
-    init(profile: Profile) {
+    init(profile: Profile, tabManager: TabManager) {
         self.profile = profile
+        self.tabManager = tabManager
     }
 
     lazy var enabledPanels = [
         LibraryPanelDescriptor(
-            makeViewController: { profile in
+            makeViewController: { profile, tabManager  in
                 return BookmarksPanel(profile: profile)
             },
             profile: profile,
+            tabManager: tabManager,
             imageName: "Bookmarks",
             accessibilityLabel: .LibraryPanelBookmarksAccessibilityLabel,
             accessibilityIdentifier: "LibraryPanels.Bookmarks"),
 
         LibraryPanelDescriptor(
-            makeViewController: { profile in
-                return HistoryPanel(profile: profile)
+            makeViewController: { profile, tabManager in
+                return HistoryPanel(profile: profile, tabManager: tabManager)
             },
             profile: profile,
+            tabManager: tabManager,
             imageName: "History",
             accessibilityLabel: .LibraryPanelHistoryAccessibilityLabel,
             accessibilityIdentifier: "LibraryPanels.History"),
 
         LibraryPanelDescriptor(
-            makeViewController: { profile in
+            makeViewController: { profile, tabManager in
                 return DownloadsPanel(profile: profile)
             },
             profile: profile,
+            tabManager: tabManager,
             imageName: "Downloads",
             accessibilityLabel: .LibraryPanelDownloadsAccessibilityLabel,
             accessibilityIdentifier: "LibraryPanels.Downloads"),
 
         LibraryPanelDescriptor(
-            makeViewController: { profile in
+            makeViewController: { profile, tabManager in
                 return ReadingListPanel(profile: profile)
             },
             profile: profile,
+            tabManager: tabManager,
             imageName: "ReadingList",
             accessibilityLabel: .LibraryPanelReadingListAccessibilityLabel,
             accessibilityIdentifier: "LibraryPanels.ReadingList")

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -86,8 +86,8 @@ class LibraryViewController: UIViewController {
     }()
 
     // MARK: - Initializers
-    init(profile: Profile) {
-        self.viewModel = LibraryViewModel(withProfile: profile)
+    init(profile: Profile, tabManager: TabManager) {
+        self.viewModel = LibraryViewModel(withProfile: profile, tabManager: tabManager)
 
         super.init(nibName: nil, bundle: nil)
     }

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewModel.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewModel.swift
@@ -7,6 +7,7 @@ import Foundation
 class LibraryViewModel {
 
     let profile: Profile
+    let tabManager: TabManager
     let panelDescriptors: [LibraryPanelDescriptor]
 
     fileprivate var panelState = LibraryPanelViewState()
@@ -15,8 +16,9 @@ class LibraryViewModel {
         set { panelState.currentState = newValue }
     }
 
-    init(withProfile profile: Profile) {
+    init(withProfile profile: Profile, tabManager: TabManager) {
         self.profile = profile
-        self.panelDescriptors = LibraryPanels(profile: profile).enabledPanels
+        self.tabManager = tabManager
+        self.panelDescriptors = LibraryPanels(profile: profile, tabManager: tabManager).enabledPanels
     }
 }

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -30,7 +30,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
     // Bug 1445687 -- https://bugzilla.mozilla.org/show_bug.cgi?id=1445687
     fileprivate lazy var clearables: [(clearable: Clearable, checked: DefaultCheckedState)] = {
         var items: [(clearable: Clearable, checked: DefaultCheckedState)] = [
-            (HistoryClearable(profile: self.profile), true),
+            (HistoryClearable(profile: self.profile, tabManager: tabManager), true),
             (CacheClearable(tabManager: self.tabManager), true),
             (CookiesClearable(tabManager: self.tabManager), true),
             (SiteDataClearable(tabManager: self.tabManager), true),

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -28,8 +28,11 @@ class ClearableError: MaybeErrorType {
 // Clears our browsing history, including favicons and thumbnails.
 class HistoryClearable: Clearable {
     let profile: Profile
-    init(profile: Profile) {
+    let tabManager: TabManager
+    
+    init(profile: Profile, tabManager: TabManager) {
         self.profile = profile
+        self.tabManager = tabManager
     }
 
     var label: String { .ClearableHistory }
@@ -46,6 +49,9 @@ class HistoryClearable: Clearable {
             CSSearchableIndex.default().deleteAllSearchableItems()
             NotificationCenter.default.post(name: .PrivateDataClearedHistory, object: nil)
             log.debug("HistoryClearable succeeded: \(success).")
+            
+            self.tabManager.clearAllTabsHistory()
+            
             return Deferred(value: success)
         }
     }

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -316,6 +316,11 @@ extension URL {
         }
         return urls[0] == urls[1]
     }
+    
+    public var isFxHomeUrl: Bool {
+        return absoluteString.hasPrefix("internal://local/about/home")
+    }
+    
 }
 
 // Extensions to deal with ReaderMode URLs


### PR DESCRIPTION
# Overview
PR for [this JIRA ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-2603) and #7573.

## Testing
Follow the steps in #7573, but be able to clear tab history.

## NOTE
Clearing ALL history from the current tab is handled differently. The currently selected tab is closed, and a new tab opened in its place. 