### PR TITLE
Add FXIOS-3591 [v97]: Populate history with only the most recent visi…

### DIFF
--- a/Client/Frontend/Library/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel.swift
@@ -167,13 +167,16 @@ class HistoryPanel: SiteTableViewController, LibraryPanel {
         if profile.isShutdown { return }
         guard !isFetchInProgress else { return }
         groupedSites = DateGroupedTableData<Site>()
+        let allGroupedSites = groupedSites.allSites()
 
         currentFetchOffset = 0
         fetchData().uponQueue(.main) { result in
             if let sites = result.successValue {
                 for site in sites {
                     if let site = site, let latestVisit = site.latestVisit {
-                        self.groupedSites.add(site, timestamp: TimeInterval.fromMicrosecondTimestamp(latestVisit.date))
+                        if !allGroupedSites.contains(site) {
+                            self.groupedSites.add(site, timestamp: TimeInterval.fromMicrosecondTimestamp(latestVisit.date))
+                        }
                     }
                 }
 

--- a/Shared/DateGroupedTableData.swift
+++ b/Shared/DateGroupedTableData.swift
@@ -91,4 +91,12 @@ public struct DateGroupedTableData<T: Equatable> {
             return older.map({ $0.0 })
         }
     }
+    
+    /// This will give you all currently fetched (and grouped) Sites.
+    public func allSites() -> [T] {
+        let allHistory = today + yesterday + lastWeek + lastMonth + older
+        let allSites = allHistory.map { $0.0 }
+        
+        return allSites
+    }
 }


### PR DESCRIPTION
# Overview

This PR is for [this JIRA ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-3591) (no associated Github issue). 

We want to show only the most recent time a user has visited a site in the history panel. A site should appear only in one section. 

## Testing
- Visit a site.
- Kill the app.
- Change the device's date to anytime in the future in Device settings. 
- View the history panel and see that your original visit is listed in the past.
- Tap that link
- Open history panel and see the site in listed under Today (no duplicates of this site should exist).