### PR TITLE
#FX-9003 Landscape full width library panel

### DIFF
--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -130,8 +130,8 @@ class LibraryViewController: UIViewController {
 
         NSLayoutConstraint.activate([
             navigationToolbar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            navigationToolbar.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            navigationToolbar.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            navigationToolbar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            navigationToolbar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             
             librarySegmentControl.widthAnchor.constraint(equalToConstant: 343),
             librarySegmentControl.heightAnchor.constraint(equalToConstant: CGFloat(ChronologicalTabsControllerUX.navigationMenuHeight)),
@@ -273,9 +273,9 @@ class LibraryViewController: UIViewController {
         libraryPanel.view.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             libraryPanel.view.topAnchor.constraint(equalTo: navigationToolbar.bottomAnchor),
-            libraryPanel.view.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            libraryPanel.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
-            libraryPanel.view.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
+            libraryPanel.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            libraryPanel.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            libraryPanel.view.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
         libraryPanel.didMove(toParent: self)
         updateTitle()

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -31,6 +31,8 @@ class SiteTableViewHeader: UITableViewHeaderFooterView, NotificationThemeable {
 
         bordersHelper.initBorders(view: self.contentView)
         setDefaultBordersValues()
+        
+        backgroundView = UIView()
 
         NSLayoutConstraint.activate([
             titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: CGFloat(SiteTableViewControllerUX.HeaderTextMargin)),
@@ -52,7 +54,7 @@ class SiteTableViewHeader: UITableViewHeaderFooterView, NotificationThemeable {
 
     func applyTheme() {
         titleLabel.textColor = UIColor.theme.tableView.headerTextDark
-        contentView.backgroundColor = UIColor.theme.tableView.selectedBackground
+        backgroundView?.backgroundColor = UIColor.theme.tableView.selectedBackground
         bordersHelper.applyTheme()
     }
 

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -92,7 +92,6 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
         table.cellLayoutMarginsFollowReadableWidth = false
         table.estimatedRowHeight = SiteTableViewControllerUX.RowHeight
         table.setEditing(false, animated: false)
-        table.separatorInsetReference = .fromAutomaticInsets
         
         if let _ = self as? HomePanelContextMenu {
             table.dragDelegate = self

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -92,6 +92,7 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
         table.cellLayoutMarginsFollowReadableWidth = false
         table.estimatedRowHeight = SiteTableViewControllerUX.RowHeight
         table.setEditing(false, animated: false)
+        table.separatorInsetReference = .fromAutomaticInsets
         
         if let _ = self as? HomePanelContextMenu {
             table.dragDelegate = self


### PR DESCRIPTION
This PR makes the library panel full width in landscape on iOS devices with a screen cutout. (#9003)

Before: 
![Simulator Screen Shot - iPhone 13 Pro - 2022-01-25 at 08 51 09](https://user-images.githubusercontent.com/66826029/151025198-b2761a2e-8da2-4a00-bb64-f8ec4fe29739.png)

After:
![simulator_screenshot_1306FFBD-1E66-47AB-8C14-80DAF3A2C23A](https://user-images.githubusercontent.com/66826029/151028326-3f874ef7-30a3-4936-99af-619adaee4004.png)

