### PR TITLE
FX-9865 Fix landscape layout for remote tabs panel

### DIFF
--- a/Client/Frontend/Widgets/TwoLineCellAndFooter.swift
+++ b/Client/Frontend/Widgets/TwoLineCellAndFooter.swift
@@ -198,7 +198,7 @@ class SimpleTwoLineCell: UITableViewCell, NotificationThemeable {
         midView.addSubview(descriptionLabel)
         let containerView = UIView()
         containerView.addSubview(midView)
-        addSubview(containerView)
+        contentView.addSubview(containerView)
         
         containerView.snp.makeConstraints { make in
             make.height.equalTo(65)


### PR DESCRIPTION
This PR fixes the layout for the remote tabs panel in landscape on recent iPhones with screen cutouts. (#9003, #9865)