### PR TITLE
Bugfix #9668 [v98] Private tab widget start at home

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -408,6 +408,7 @@
 		8AEE62C92756BA34003207D1 /* LoginsHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 8AEE62C62756BA34003207D1 /* LoginsHelper.js */; };
 		8AEE62CA2756BA34003207D1 /* TrackingProtectionStats.js in Resources */ = {isa = PBXBuildFile; fileRef = 8AEE62C72756BA34003207D1 /* TrackingProtectionStats.js */; };
 		8AEE62CB2756BA34003207D1 /* DownloadHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 8AEE62C82756BA34003207D1 /* DownloadHelper.js */; };
+		8AF0CFF527A0B0ED00C1A4A2 /* QuickActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF0CFF427A0B0ED00C1A4A2 /* QuickActionsTests.swift */; };
 		8AFE4C2127480D0C00B97C65 /* TabTrayViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFE4C2027480D0B00B97C65 /* TabTrayViewControllerTests.swift */; };
 		8D8251811F4DE67F00780643 /* AdvancedAccountSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8251721F4DE67E00780643 /* AdvancedAccountSettingViewController.swift */; };
 		8DCD3BCD1ED5B7FA00446D38 /* FxADeepLinkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DCD3BCC1ED5B7FA00446D38 /* FxADeepLinkingTests.swift */; };
@@ -2582,6 +2583,7 @@
 		8AEE62C62756BA34003207D1 /* LoginsHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = LoginsHelper.js; path = AllFrames/AtDocumentStart/LoginsHelper.js; sourceTree = "<group>"; };
 		8AEE62C72756BA34003207D1 /* TrackingProtectionStats.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = TrackingProtectionStats.js; path = AllFrames/AtDocumentStart/TrackingProtectionStats.js; sourceTree = "<group>"; };
 		8AEE62C82756BA34003207D1 /* DownloadHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = DownloadHelper.js; path = AllFrames/AtDocumentStart/DownloadHelper.js; sourceTree = "<group>"; };
+		8AF0CFF427A0B0ED00C1A4A2 /* QuickActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionsTests.swift; sourceTree = "<group>"; };
 		8AFE4C2027480D0B00B97C65 /* TabTrayViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabTrayViewControllerTests.swift; sourceTree = "<group>"; };
 		8B3245D190D4FA80C3B46EC8 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Search.strings"; sourceTree = "<group>"; };
 		8B674438A5487ABCD2DD7CA5 /* ses */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ses; path = ses.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -6240,6 +6242,7 @@
 				F84B21D91A090F8100AAB793 /* ClientTests.swift */,
 				3B39EDB91E16E18900EF029F /* CustomSearchEnginesTest.swift */,
 				8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */,
+				8AF0CFF427A0B0ED00C1A4A2 /* QuickActionsTests.swift */,
 				D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */,
 				3943A81C1E9807C700D4F6DC /* FxAPushMessageTest.swift */,
 				8A2825342760399B00395E66 /* KeyboardPressesHandlerTests.swift */,
@@ -8408,6 +8411,7 @@
 				F84B21DA1A090F8100AAB793 /* ClientTests.swift in Sources */,
 				281B2BEA1ADF4D90002917DC /* MockProfile.swift in Sources */,
 				2F697F7E1A9FD22D009E03AE /* SearchEnginesTests.swift in Sources */,
+				8AF0CFF527A0B0ED00C1A4A2 /* QuickActionsTests.swift in Sources */,
 				2F44FA1B1A9D426A00FD20CC /* TestHashExtensions.swift in Sources */,
 				8ADED7EC27691351009C19E6 /* CalendarExtensionsTests.swift in Sources */,
 				3B39EDBA1E16E18900EF029F /* CustomSearchEnginesTest.swift in Sources */,

--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -344,6 +344,8 @@ func == (lhs: NavigationPath, rhs: NavigationPath) -> Bool {
         return lhs.query == rhs.query
     case let (.deepLink(lhs), .deepLink(rhs)):
         return lhs == rhs
+    case (.closePrivateTabs, .closePrivateTabs):
+        return true
     default:
         return false
     }

--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -240,11 +240,11 @@ enum NavigationPath {
 
     private static func handleClosePrivateTabs(with bvc: BrowserViewController, tray: GridTabViewController) {
         bvc.tabManager.removeTabs(bvc.tabManager.privateTabs)
-         guard let tab = mostRecentTab(inTabs: bvc.tabManager.normalTabs) else {
-             bvc.tabManager.selectTab(bvc.tabManager.addTab())
-             return
-         }
-         bvc.tabManager.selectTab(tab)
+        guard let tab = mostRecentTab(inTabs: bvc.tabManager.normalTabs) else {
+            bvc.tabManager.selectTab(bvc.tabManager.addTab())
+            return
+        }
+        bvc.tabManager.selectTab(tab)
     }
 
     private static func handleGlean(url: URL) {

--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -105,8 +105,6 @@ class QuickActions: NSObject {
             handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: false)
         case .newPrivateTab:
             handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: true)
-        // even though we're removing OpenLastTab, it's possible that someone will use an existing last tab quick action to open the app
-        // the first time after upgrading, so we should still handle it
         case .openLastBookmark:
             if let urlToOpen = (userData?[QuickActions.TabURLKey] as? String)?.asURL {
                 handleOpenURL(withBrowserViewController: browserViewController, urlToOpen: urlToOpen)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -171,8 +171,6 @@ class BrowserViewController: UIViewController {
         tabManager.addDelegate(self)
         tabManager.addNavigationDelegate(self)
         downloadQueue.delegate = self
-
-        NotificationCenter.default.addObserver(self, selector: #selector(displayThemeChanged), name: .DisplayThemeChanged, object: nil)
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -355,17 +353,9 @@ class BrowserViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        NotificationCenter.default.addObserver(self, selector: #selector(appWillResignActiveNotification),
-                                               name: UIApplication.willResignActiveNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActiveNotification),
-                                               name: UIApplication.didBecomeActiveNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(appDidEnterBackgroundNotification),
-                                               name: UIApplication.didEnterBackgroundNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(appMenuBadgeUpdate),
-                                               name: .FirefoxAccountStateChange, object: nil)
-
         KeyboardHelper.defaultHelper.addDelegate(self)
 
+        setupNotifications()
         addSubviews()
 
         // UIAccessibilityCustomAction subclass holding an AccessibleAction instance does not work,
@@ -420,6 +410,19 @@ class BrowserViewController: UIViewController {
         // Setup chron tabs A/B test
         chronTabsUserResearch = ChronTabsUserResearch()
         searchTelemetry = SearchTelemetry()
+    }
+
+    private func setupNotifications() {
+        NotificationCenter.default.addObserver(self, selector: #selector(appWillResignActiveNotification),
+                                               name: UIApplication.willResignActiveNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActiveNotification),
+                                               name: UIApplication.didBecomeActiveNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(appDidEnterBackgroundNotification),
+                                               name: UIApplication.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(appMenuBadgeUpdate),
+                                               name: .FirefoxAccountStateChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(displayThemeChanged),
+                                               name: .DisplayThemeChanged, object: nil)
     }
 
     func addSubviews() {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -309,7 +309,7 @@ class BrowserViewController: UIViewController {
             self.displayedPopoverController = nil
         }
 
-        // If we are displying a private tab, hide any elements in the tab that we wouldn't want shown
+        // If we are displaying a private tab, hide any elements in the tab that we wouldn't want shown
         // when the app is in the home switcher
         guard let privateTab = tabManager.selectedTab, privateTab.isPrivate else {
             return
@@ -1194,6 +1194,7 @@ class BrowserViewController: UIViewController {
 
     func openBlankNewTab(focusLocationField: Bool, isPrivate: Bool = false, searchFor searchText: String? = nil) {
         popToBVC()
+        openedUrlFromExternalSource = true
         openURLInNewTab(nil, isPrivate: isPrivate)
         let freshTab = tabManager.selectedTab
         freshTab?.updateTimerAndObserving(state: .newTab)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -355,11 +355,74 @@ class BrowserViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        NotificationCenter.default.addObserver(self, selector: #selector(appWillResignActiveNotification), name: UIApplication.willResignActiveNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActiveNotification), name: UIApplication.didBecomeActiveNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(appDidEnterBackgroundNotification), name: UIApplication.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(appWillResignActiveNotification),
+                                               name: UIApplication.willResignActiveNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActiveNotification),
+                                               name: UIApplication.didBecomeActiveNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(appDidEnterBackgroundNotification),
+                                               name: UIApplication.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(appMenuBadgeUpdate),
+                                               name: .FirefoxAccountStateChange, object: nil)
+
         KeyboardHelper.defaultHelper.addDelegate(self)
 
+        addSubviews()
+
+        // UIAccessibilityCustomAction subclass holding an AccessibleAction instance does not work,
+        // thus unable to generate AccessibleActions and UIAccessibilityCustomActions "on-demand" and need
+        // to make them "persistent" e.g. by being stored in BVC
+        pasteGoAction = AccessibleAction(name: .PasteAndGoTitle, handler: { () -> Bool in
+            if let pasteboardContents = UIPasteboard.general.string {
+                self.urlBar(self.urlBar, didSubmitText: pasteboardContents)
+                return true
+            }
+            return false
+        })
+        pasteAction = AccessibleAction(name: .PasteTitle, handler: { () -> Bool in
+            if let pasteboardContents = UIPasteboard.general.string {
+                // Enter overlay mode and make the search controller appear.
+                self.urlBar.enterOverlayMode(pasteboardContents, pasted: true, search: true)
+
+                return true
+            }
+            return false
+        })
+        copyAddressAction = AccessibleAction(name: .CopyAddressTitle, handler: { () -> Bool in
+            if let url = self.tabManager.selectedTab?.canonicalURL?.displayURL ?? self.urlBar.currentURL {
+                UIPasteboard.general.url = url
+            }
+            return true
+        })
+
+        clipboardBarDisplayHandler = ClipboardBarDisplayHandler(prefs: profile.prefs, tabManager: tabManager)
+        clipboardBarDisplayHandler?.delegate = self
+
+        scrollController.urlBar = urlBar
+        scrollController.readerModeBar = readerModeBar
+        scrollController.header = header
+        scrollController.footer = footer
+        scrollController.snackBars = alertStackView
+
+        updateToolbarStateForTraitCollection(traitCollection)
+
+        setupConstraints()
+
+        // Setup UIDropInteraction to handle dragging and dropping
+        // links into the view from other apps.
+        let dropInteraction = UIDropInteraction(delegate: self)
+        view.addInteraction(dropInteraction)
+
+        if !NightModeHelper.isActivated(profile.prefs) && LegacyThemeManager.instance.systemThemeIsOn {
+            let userInterfaceStyle = traitCollection.userInterfaceStyle
+            LegacyThemeManager.instance.current = userInterfaceStyle == .dark ? DarkTheme() : NormalTheme()
+        }
+
+        // Setup chron tabs A/B test
+        chronTabsUserResearch = ChronTabsUserResearch()
+        searchTelemetry = SearchTelemetry()
+    }
+
+    func addSubviews() {
         webViewContainerBackdrop = UIView()
         webViewContainerBackdrop.backgroundColor = UIColor.Photon.Ink90
         webViewContainerBackdrop.alpha = 0
@@ -387,64 +450,11 @@ class BrowserViewController: UIViewController {
         urlBarTopTabsContainer.addSubview(topTabsContainer)
         view.addSubview(header)
 
-        // UIAccessibilityCustomAction subclass holding an AccessibleAction instance does not work, thus unable to generate AccessibleActions and UIAccessibilityCustomActions "on-demand" and need to make them "persistent" e.g. by being stored in BVC
-        pasteGoAction = AccessibleAction(name: .PasteAndGoTitle, handler: { () -> Bool in
-            if let pasteboardContents = UIPasteboard.general.string {
-                self.urlBar(self.urlBar, didSubmitText: pasteboardContents)
-                return true
-            }
-            return false
-        })
-        pasteAction = AccessibleAction(name: .PasteTitle, handler: { () -> Bool in
-            if let pasteboardContents = UIPasteboard.general.string {
-                // Enter overlay mode and make the search controller appear.
-                self.urlBar.enterOverlayMode(pasteboardContents, pasted: true, search: true)
-
-                return true
-            }
-            return false
-        })
-        copyAddressAction = AccessibleAction(name: .CopyAddressTitle, handler: { () -> Bool in
-            if let url = self.tabManager.selectedTab?.canonicalURL?.displayURL ?? self.urlBar.currentURL {
-                UIPasteboard.general.url = url
-            }
-            return true
-        })
-
         view.addSubview(alertStackView)
         footer = UIView()
         view.addSubview(footer)
         alertStackView.axis = .vertical
         alertStackView.alignment = .center
-
-        clipboardBarDisplayHandler = ClipboardBarDisplayHandler(prefs: profile.prefs, tabManager: tabManager)
-        clipboardBarDisplayHandler?.delegate = self
-
-        scrollController.urlBar = urlBar
-        scrollController.readerModeBar = readerModeBar
-        scrollController.header = header
-        scrollController.footer = footer
-        scrollController.snackBars = alertStackView
-
-        self.updateToolbarStateForTraitCollection(self.traitCollection)
-
-        setupConstraints()
-
-        // Setup UIDropInteraction to handle dragging and dropping
-        // links into the view from other apps.
-        let dropInteraction = UIDropInteraction(delegate: self)
-        view.addInteraction(dropInteraction)
-
-        if !NightModeHelper.isActivated(profile.prefs) && LegacyThemeManager.instance.systemThemeIsOn {
-            let userInterfaceStyle = traitCollection.userInterfaceStyle
-            LegacyThemeManager.instance.current = userInterfaceStyle == .dark ? DarkTheme() : NormalTheme()
-        }
-
-        NotificationCenter.default.addObserver(self, selector: #selector(self.appMenuBadgeUpdate), name: .FirefoxAccountStateChange, object: nil)
-
-        // Setup chron tabs A/B test
-        chronTabsUserResearch = ChronTabsUserResearch()
-        searchTelemetry = SearchTelemetry()
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1147,27 +1147,17 @@ class BrowserViewController: UIViewController {
         topTabsViewController?.applyUIMode(isPrivate: isPrivate)
     }
 
-    func switchToTabForURLOrOpen(_ url: URL, isPrivate: Bool = false) {
+    func switchToTabForURLOrOpen(_ url: URL, uuid: String? = nil, isPrivate: Bool = false) {
         guard !isCrashAlertShowing else {
             urlFromAnotherApp = UrlToOpenModel(url: url, isPrivate: isPrivate)
             return
         }
         popToBVC()
         openedUrlFromExternalSource = true
-        if let tab = tabManager.getTabForURL(url) {
-            tabManager.selectTab(tab)
-        } else {
-            openURLInNewTab(url, isPrivate: isPrivate)
-        }
-    }
 
-    func switchToTabForURLOrOpen(_ url: URL, uuid: String,  isPrivate: Bool = false) {
-        guard !isCrashAlertShowing else {
-            urlFromAnotherApp = UrlToOpenModel(url: url, isPrivate: isPrivate)
-            return
-        }
-        popToBVC()
-        if let tab = tabManager.getTabForUUID(uuid: uuid) {
+        if let uuid = uuid, let tab = tabManager.getTabForUUID(uuid: uuid) {
+            tabManager.selectTab(tab)
+        } else if let tab = tabManager.getTabForURL(url) {
             tabManager.selectTab(tab)
         } else {
             openURLInNewTab(url, isPrivate: isPrivate)

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -160,7 +160,6 @@ class TabManager: NSObject, FeatureFlagsProtocol {
     var lastSessionWasPrivate: Bool {
         return UserDefaults.standard.bool(forKey: "wasLastSessionPrivate")
     }
-    
 
     // MARK: - Initializer
     init(profile: Profile, imageStore: DiskImageStore?) {

--- a/ClientTests/NavigationRouterTests.swift
+++ b/ClientTests/NavigationRouterTests.swift
@@ -86,41 +86,41 @@ class NavigationRouterTests: XCTestCase {
 
     // MARK: - Widget
 
-    func testOpenURLWidget_normalTab() {
+    func testOpenURLWidget_normalTabPath() {
         let path = buildNavigationPath(url: "widget-medium-quicklink-open-url?private=true")
         XCTAssertEqual(path, NavigationPath.url(webURL: nil, isPrivate: true))
     }
 
-    func testOpenURLWidget_privateTab() {
+    func testOpenURLWidget_privateTabPath() {
         let path = buildNavigationPath(url: "widget-medium-quicklink-open-url?private=false")
         XCTAssertEqual(path, NavigationPath.url(webURL: nil, isPrivate: false))
     }
 
-    func testCloseTabsSmallWidget_privateTab() {
+    func testCloseTabsSmallWidget_privateTabPath() {
         let path = buildNavigationPath(url: "widget-small-quicklink-close-private-tabs")
         XCTAssertEqual(path, NavigationPath.closePrivateTabs)
     }
 
-    func testCloseTabsMediumWidget_privateTab() {
+    func testCloseTabsMediumWidget_privateTabPath() {
         let path = buildNavigationPath(url: "widget-medium-quicklink-close-private-tabs")
         XCTAssertEqual(path, NavigationPath.closePrivateTabs)
     }
 
-    func testNavigationPath_handleNormalTab() {
+    func testNavigationPath_handleNormalTab_isExternalSourceTrue() {
         let path = buildNavigationPath(url: "widget-medium-quicklink-open-url?private=false")
         NavigationPath.handle(nav: path, with: browserViewController, tray: gridTab)
 
         XCTAssertTrue(browserViewController.openedUrlFromExternalSource, "openedUrlFromExternalSource needs to be true for start at home feature")
     }
 
-    func testNavigationPath_handlePrivateTab() {
+    func testNavigationPath_handlePrivateTab_isExternalSourceTrue() {
         let path = buildNavigationPath(url: "widget-medium-quicklink-open-url?private=true")
         NavigationPath.handle(nav: path, with: browserViewController, tray: gridTab)
 
         XCTAssertTrue(browserViewController.openedUrlFromExternalSource, "openedUrlFromExternalSource needs to be true for start at home feature")
     }
 
-    func testNavigationPath_handleClosingPrivateTabs(){
+    func testNavigationPath_handleClosingPrivateTabs_tabsAreDeleted(){
         browserViewController.tabManager.addTab(isPrivate: true)
         XCTAssertEqual(browserViewController.tabManager.privateTabs.count, 1, "There should be one private tab")
 

--- a/ClientTests/NavigationRouterTests.swift
+++ b/ClientTests/NavigationRouterTests.swift
@@ -10,7 +10,25 @@ import XCTest
 
 class NavigationRouterTests: XCTestCase {
 
-    var appScheme: String {
+    private var profile: TabManagerMockProfile!
+    private var browserViewController: BrowserViewController!
+    private var gridTab: GridTabViewController!
+
+    override func setUp() {
+        super.setUp()
+        profile = TabManagerMockProfile()
+        browserViewController = BrowserViewController.foregroundBVC()
+        gridTab = GridTabViewController(tabManager: browserViewController.tabManager, profile: profile)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        profile = nil
+        browserViewController = nil
+        gridTab = nil
+    }
+
+    private var appScheme: String {
         return URL.mozInternalScheme
     }
 
@@ -64,5 +82,60 @@ class NavigationRouterTests: XCTestCase {
         // http[s] URLs stay as NavigationPath.url, even if their non-scheme components would match another type of NavigationPath
         XCTAssertEqual(NavigationPath(url: URL(string: "https://deep-link?url=/settings/newTab")!), NavigationPath.url(webURL: URL(string: "https://deep-link?url=/settings/newTab")!, isPrivate: false))
 
+    }
+
+    // MARK: - Widget
+
+    func testOpenURLWidget_normalTab() {
+        let path = buildNavigationPath(url: "widget-medium-quicklink-open-url?private=true")
+        XCTAssertEqual(path, NavigationPath.url(webURL: nil, isPrivate: true))
+    }
+
+    func testOpenURLWidget_privateTab() {
+        let path = buildNavigationPath(url: "widget-medium-quicklink-open-url?private=false")
+        XCTAssertEqual(path, NavigationPath.url(webURL: nil, isPrivate: false))
+    }
+
+    func testCloseTabsSmallWidget_privateTab() {
+        let path = buildNavigationPath(url: "widget-small-quicklink-close-private-tabs")
+        XCTAssertEqual(path, NavigationPath.closePrivateTabs)
+    }
+
+    func testCloseTabsMediumWidget_privateTab() {
+        let path = buildNavigationPath(url: "widget-medium-quicklink-close-private-tabs")
+        XCTAssertEqual(path, NavigationPath.closePrivateTabs)
+    }
+
+    func testNavigationPath_handleNormalTab() {
+        let path = buildNavigationPath(url: "widget-medium-quicklink-open-url?private=false")
+        NavigationPath.handle(nav: path, with: browserViewController, tray: gridTab)
+
+        XCTAssertTrue(browserViewController.openedUrlFromExternalSource, "openedUrlFromExternalSource needs to be true for start at home feature")
+    }
+
+    func testNavigationPath_handlePrivateTab() {
+        let path = buildNavigationPath(url: "widget-medium-quicklink-open-url?private=true")
+        NavigationPath.handle(nav: path, with: browserViewController, tray: gridTab)
+
+        XCTAssertTrue(browserViewController.openedUrlFromExternalSource, "openedUrlFromExternalSource needs to be true for start at home feature")
+    }
+
+    func testNavigationPath_handleClosingPrivateTabs(){
+        browserViewController.tabManager.addTab(isPrivate: true)
+        XCTAssertEqual(browserViewController.tabManager.privateTabs.count, 1, "There should be one private tab")
+
+        let path = buildNavigationPath(url: "widget-medium-quicklink-close-private-tabs")
+        NavigationPath.handle(nav: path, with: browserViewController, tray: gridTab)
+
+        XCTAssertEqual(browserViewController.tabManager.privateTabs.count, 0, "There should be no private tab anymore")
+    }
+}
+
+// MARK: - Helper methods
+private extension NavigationRouterTests {
+
+    func buildNavigationPath(url: String) -> NavigationPath {
+        let appURL = "\(appScheme)://\(url)"
+        return NavigationPath(url: URL(string: appURL)!)!
     }
 }

--- a/ClientTests/QuickActionsTests.swift
+++ b/ClientTests/QuickActionsTests.swift
@@ -50,6 +50,7 @@ class QuickActionsTest: XCTestCase {
 // MARK: - Helper methods
 
 private extension QuickActionsTest {
+    /// Wait for openedUrlFromExternalSource to be set true, testing the start at home edge case
     func handleShortcutAndWait(shortcutItem: UIApplicationShortcutItem) {
         let expectation = expectation(description: "Completion URL of SpyBrowserViewController should be called")
         browserViewController.completionURL = {

--- a/ClientTests/QuickActionsTests.swift
+++ b/ClientTests/QuickActionsTests.swift
@@ -31,47 +31,36 @@ class QuickActionsTest: XCTestCase {
         quickActions = nil
     }
 
-    func testNewTabShortcut() {
-        let expectation = expectation(description: "New tab is opened")
-        browserViewController.handleOpenNewTab = {
-            XCTAssertTrue(self.browserViewController.openedUrlFromExternalSource,
-                          "openedUrlFromExternalSource needs to be true for start at home feature")
-            expectation.fulfill()
-        }
-
+    func testNewTabShortcut_externalSourceIsTrue() {
         let shortcutItem = UIApplicationShortcutItem(type: ShortcutType.newTab.rawValue, localizedTitle: "")
-        quickActions.handleShortCutItem(shortcutItem, withBrowserViewController: browserViewController)
-        waitForExpectations(timeout: 5, handler: nil)
+        handleShortcutAndWait(shortcutItem: shortcutItem)
     }
 
-    func testNewPrivateTabShortcut() {
-        let expectation = expectation(description: "New private tab is opened")
-        browserViewController.handleOpenNewTab = {
-            XCTAssertTrue(self.browserViewController.openedUrlFromExternalSource,
-                          "openedUrlFromExternalSource needs to be true for start at home feature")
-            expectation.fulfill()
-        }
-
+    func testNewPrivateTabShortcut_externalSourceIsTrue() {
         let shortcutItem = UIApplicationShortcutItem(type: ShortcutType.newPrivateTab.rawValue, localizedTitle: "")
-        quickActions.handleShortCutItem(shortcutItem, withBrowserViewController: browserViewController)
-        waitForExpectations(timeout: 5, handler: nil)
+        handleShortcutAndWait(shortcutItem: shortcutItem)
     }
 
-    func testOpenBookmark() {
-        let expectation = expectation(description: "Last bookmark is opened")
-        browserViewController.handleOpenURL = {
-            XCTAssertTrue(self.browserViewController.openedUrlFromExternalSource,
-                          "openedUrlFromExternalSource needs to be true for start at home feature")
-            expectation.fulfill()
-        }
-
+    func testOpenBookmarkShortcut_externalSourceIsTrue() {
         let shortcutItem = BookmarkShortcutItem()
-        quickActions.handleShortCutItem(shortcutItem, withBrowserViewController: browserViewController)
-        waitForExpectations(timeout: 5, handler: nil)
+        handleShortcutAndWait(shortcutItem: shortcutItem)
     }
 }
 
 // MARK: - Helper methods
+
+private extension QuickActionsTest {
+    func handleShortcutAndWait(shortcutItem: UIApplicationShortcutItem) {
+        let expectation = expectation(description: "Completion URL of SpyBrowserViewController should be called")
+        browserViewController.completionURL = {
+            XCTAssertTrue(self.browserViewController.openedUrlFromExternalSource, "openedUrlFromExternalSource needs to be true for start at home feature")
+            expectation.fulfill()
+        }
+
+        quickActions.handleShortCutItem(shortcutItem, withBrowserViewController: browserViewController)
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+}
 
 private class BookmarkShortcutItem: UIApplicationShortcutItem {
     convenience init() {
@@ -84,16 +73,15 @@ private class BookmarkShortcutItem: UIApplicationShortcutItem {
 }
 
 private class SpyBrowserViewController: BrowserViewController {
-    var handleOpenNewTab: (() -> Void)?
-    var handleOpenURL: (() -> Void)?
+    var completionURL: (() -> Void)?
 
     override func openBlankNewTab(focusLocationField: Bool, isPrivate: Bool = false, searchFor searchText: String? = nil) {
         super.openBlankNewTab(focusLocationField: focusLocationField, isPrivate: isPrivate, searchFor: searchText)
-        handleOpenNewTab?()
+        completionURL?()
     }
 
     override func switchToTabForURLOrOpen(_ url: URL, isPrivate: Bool = false) {
         super.switchToTabForURLOrOpen(url, isPrivate: isPrivate)
-        handleOpenURL?()
+        completionURL?()
     }
 }

--- a/ClientTests/QuickActionsTests.swift
+++ b/ClientTests/QuickActionsTests.swift
@@ -1,0 +1,99 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+@testable import Client
+
+import XCTest
+
+class QuickActionsTest: XCTestCase {
+
+    private var browserViewController: SpyBrowserViewController!
+    private var quickActions: QuickActions!
+    private var profile: TabManagerMockProfile!
+    private var tabManager: TabManager!
+
+    override func setUp() {
+        super.setUp()
+        profile = TabManagerMockProfile()
+        tabManager = TabManager(profile: profile, imageStore: nil)
+        browserViewController = SpyBrowserViewController(profile: profile, tabManager: tabManager)
+        browserViewController.addSubviews()
+        quickActions = QuickActions.sharedInstance
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        profile = nil
+        tabManager = nil
+        browserViewController = nil
+        quickActions = nil
+    }
+
+    func testNewTabShortcut() {
+        let expectation = expectation(description: "New tab is opened")
+        browserViewController.handleOpenNewTab = {
+            XCTAssertTrue(self.browserViewController.openedUrlFromExternalSource,
+                          "openedUrlFromExternalSource needs to be true for start at home feature")
+            expectation.fulfill()
+        }
+
+        let shortcutItem = UIApplicationShortcutItem(type: ShortcutType.newTab.rawValue, localizedTitle: "")
+        quickActions.handleShortCutItem(shortcutItem, withBrowserViewController: browserViewController)
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+
+    func testNewPrivateTabShortcut() {
+        let expectation = expectation(description: "New private tab is opened")
+        browserViewController.handleOpenNewTab = {
+            XCTAssertTrue(self.browserViewController.openedUrlFromExternalSource,
+                          "openedUrlFromExternalSource needs to be true for start at home feature")
+            expectation.fulfill()
+        }
+
+        let shortcutItem = UIApplicationShortcutItem(type: ShortcutType.newPrivateTab.rawValue, localizedTitle: "")
+        quickActions.handleShortCutItem(shortcutItem, withBrowserViewController: browserViewController)
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+
+    func testOpenBookmark() {
+        let expectation = expectation(description: "Last bookmark is opened")
+        browserViewController.handleOpenURL = {
+            XCTAssertTrue(self.browserViewController.openedUrlFromExternalSource,
+                          "openedUrlFromExternalSource needs to be true for start at home feature")
+            expectation.fulfill()
+        }
+
+        let shortcutItem = BookmarkShortcutItem()
+        quickActions.handleShortCutItem(shortcutItem, withBrowserViewController: browserViewController)
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+}
+
+// MARK: - Helper methods
+
+private class BookmarkShortcutItem: UIApplicationShortcutItem {
+    convenience init() {
+        self.init(type: ShortcutType.openLastBookmark.rawValue, localizedTitle: "")
+    }
+
+    override var userInfo: [String : NSSecureCoding]? {
+        return [QuickActions.TabURLKey: "https://www.mozilla.org/en-CA/" as NSSecureCoding]
+    }
+}
+
+private class SpyBrowserViewController: BrowserViewController {
+    var handleOpenNewTab: (() -> Void)?
+    var handleOpenURL: (() -> Void)?
+
+    override func openBlankNewTab(focusLocationField: Bool, isPrivate: Bool = false, searchFor searchText: String? = nil) {
+        super.openBlankNewTab(focusLocationField: focusLocationField, isPrivate: isPrivate, searchFor: searchText)
+        handleOpenNewTab?()
+    }
+
+    override func switchToTabForURLOrOpen(_ url: URL, isPrivate: Bool = false) {
+        super.switchToTabForURLOrOpen(url, isPrivate: isPrivate)
+        handleOpenURL?()
+    }
+}

--- a/ClientTests/QuickActionsTests.swift
+++ b/ClientTests/QuickActionsTests.swift
@@ -80,8 +80,8 @@ private class SpyBrowserViewController: BrowserViewController {
         completionURL?()
     }
 
-    override func switchToTabForURLOrOpen(_ url: URL, isPrivate: Bool = false) {
-        super.switchToTabForURLOrOpen(url, isPrivate: isPrivate)
+    override func switchToTabForURLOrOpen(_ url: URL, uuid: String? = nil, isPrivate: Bool = false) {
+        super.switchToTabForURLOrOpen(url, uuid: uuid, isPrivate: isPrivate)
         completionURL?()
     }
 }

--- a/ClientTests/TabEventHandlerTests.swift
+++ b/ClientTests/TabEventHandlerTests.swift
@@ -48,7 +48,7 @@ class TabEventHandlerTests: XCTestCase {
         BrowserViewController.foregroundBVC().profile.prefs.setBool(false, forKey: PrefsKeys.KeyBlockPopups)
         BrowserViewController.foregroundBVC().tabManager.addTab(URLRequest(url: URL(string: "\(webServerBase)/blankpopup")!))
 
-        let exists = NSPredicate() { obj,_ in
+        let exists = NSPredicate() { obj, _ in
             let tabManager = obj as! TabManager
             return tabManager.tabs.count > 2
         }
@@ -59,7 +59,7 @@ class TabEventHandlerTests: XCTestCase {
             return true
         }
 
-        waitForExpectations(timeout: 20, handler: nil)
+        waitForExpectations(timeout: 30, handler: nil)
     }
 }
 

--- a/ClientTests/TabManagerStoreTests.swift
+++ b/ClientTests/TabManagerStoreTests.swift
@@ -58,7 +58,7 @@ class TabManagerStoreTests: XCTestCase {
             XCTAssertEqual(self.manager.testTabCountOnDisk(), 2)
             e.fulfill()
         }
-        waitForExpectations(timeout: 2, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
 
     // Test disabled due to Issue:https://github.com/mozilla-mobile/firefox-ios/issues/7867

--- a/WidgetKit/OpenTabs/OpenTabsWidget.swift
+++ b/WidgetKit/OpenTabs/OpenTabsWidget.swift
@@ -10,7 +10,7 @@ import Combine
 struct OpenTabsWidget: Widget {
     private let kind: String = "Quick View"
 
-     var body: some WidgetConfiguration {
+    var body: some WidgetConfiguration {
         StaticConfiguration(kind: kind, provider: TabProvider()) { entry in
             OpenTabsView(entry: entry)
         }


### PR DESCRIPTION
- Fix bug #9668 relating to widget with start at home feature
- Add tests for Quick Actions
- Add tests for Navigation Router
- For testing purpose code in the `viewDidLoad` method relating to adding subviews is now in a `addSubviews` method.
- Combined the method `func switchToTabForURLOrOpen(_ url: URL, isPrivate: Bool = false) {`and `func switchToTabForURLOrOpen(_ url: URL, uuid: String? = nil, isPrivate: Bool = false) {` which were doing the almost same thing and duplicated code.
- Fix indentation and typos