### PR TITLE
Adjust Empty State View to stay in center of empty Reading List

### DIFF
--- a/Client/Frontend/Library/DownloadsPanel.swift
+++ b/Client/Frontend/Library/DownloadsPanel.swift
@@ -7,8 +7,9 @@ import Shared
 import Storage
 
 private struct DownloadsPanelUX {
+    static let WelcomeScreenTopPadding: CGFloat = 120
     static let WelcomeScreenPadding: CGFloat = 15
-    static let WelcomeScreenItemWidth = 170
+    static let WelcomeScreenItemWidth: CGFloat = 170
     static let HeaderHeight: CGFloat = 28
 }
 
@@ -272,14 +273,14 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
         overlayView.addSubview(welcomeLabel)
         
         NSLayoutConstraint.activate([
-            logoImageView.topAnchor.constraint(equalTo: overlayView.topAnchor, constant: 120),
+            logoImageView.topAnchor.constraint(equalTo: overlayView.topAnchor, constant: DownloadsPanelUX.WelcomeScreenTopPadding),
             logoImageView.centerXAnchor.constraint(equalTo: overlayView.centerXAnchor),
             logoImageView.heightAnchor.constraint(equalToConstant: 60),
             logoImageView.widthAnchor.constraint(equalToConstant: 60),
             
             welcomeLabel.centerXAnchor.constraint(equalTo: overlayView.centerXAnchor),
-            welcomeLabel.topAnchor.constraint(equalTo: logoImageView.bottomAnchor, constant: CGFloat(DownloadsPanelUX.WelcomeScreenPadding)),
-            welcomeLabel.widthAnchor.constraint(equalToConstant: CGFloat(DownloadsPanelUX.WelcomeScreenItemWidth))
+            welcomeLabel.topAnchor.constraint(equalTo: logoImageView.bottomAnchor, constant: DownloadsPanelUX.WelcomeScreenPadding),
+            welcomeLabel.widthAnchor.constraint(equalToConstant: DownloadsPanelUX.WelcomeScreenItemWidth)
         ])
 
         return overlayView

--- a/Client/Frontend/Library/ReaderPanel.swift
+++ b/Client/Frontend/Library/ReaderPanel.swift
@@ -33,14 +33,13 @@ private struct ReadingListTableViewCellUX {
 
 private struct ReadingListPanelUX {
     // Welcome Screen
-    static let WelcomeScreenTopPadding: CGFloat = 50
     static let WelcomeScreenPadding: CGFloat = 15
     static let WelcomeScreenHorizontalMinPadding: CGFloat = 40
     
     static let WelcomeScreenMaxWidth: CGFloat = 400
     static let WelcomeScreenItemImageWidth: CGFloat = 20
     
-    static let WelcomeScreenVerticalOffset: CGFloat = -20
+    static let WelcomeScreenTopPadding: CGFloat = 120
 }
 
 class ReadingListTableViewCell: UITableViewCell, NotificationThemeable {
@@ -309,7 +308,7 @@ class ReadingListPanel: UITableViewController, LibraryPanel {
             emptyStateViewWrapper.widthAnchor.constraint(lessThanOrEqualToConstant: ReadingListPanelUX.WelcomeScreenMaxWidth),
             
             emptyStateViewWrapper.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            emptyStateViewWrapper.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: ReadingListPanelUX.WelcomeScreenVerticalOffset)
+            emptyStateViewWrapper.topAnchor.constraint(equalTo: view.topAnchor, constant: ReadingListPanelUX.WelcomeScreenTopPadding)
         ])
         
         return view


### PR DESCRIPTION
This PR adjust the Empty State View for an empty Reading List so that it stays in the center. See #9870 for reference.
New Empty State View:

![Simulator Screen Shot - iPhone 13 - 2022-01-26 at 22 27 52](https://user-images.githubusercontent.com/46824694/151249959-52fb0c42-e227-4854-9b77-73fabda5f7b6.png)

![Simulator Screen Shot - iPhone 13 - 2022-01-26 at 22 27 47](https://user-images.githubusercontent.com/46824694/151249962-aa9f86d2-73f2-499c-bda5-d931cfa7395f.png)

