### PR TITLE
Bugfix #9863: "Send to Device" option from the Tab Peek menu doesn't work

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1312,7 +1312,7 @@ class BrowserViewController: UIViewController {
         }
 
         // Represents WebView observation or delegate update that called this function
-        
+
         if webViewStatus == .finishedNavigation {
             // A delay of 500 milliseconds is added when we take screenshot
             // as we don't know exactly when wkwebview is rendered
@@ -1667,11 +1667,11 @@ extension BrowserViewController: HomePanelDelegate {
         controller.presentingModalViewControllerDelegate = self
         self.present(controller, animated: true, completion: nil)
     }
-    
+
     func homePanelDidPresentContextualHint(type: ContextualHintViewType) {
         self.urlBar.locationTextField?.resignFirstResponder()
     }
-    
+
     func homePanelDidDismissContextualHint(type: ContextualHintViewType) {
         self.urlBar.locationTextField?.becomeFirstResponder()
     }
@@ -2311,10 +2311,6 @@ extension BrowserViewController: TabTrayDelegate {
     func tabTrayDidAddToReadingList(_ tab: Tab) -> ReadingListItem? {
         guard let url = tab.url?.absoluteString, !url.isEmpty else { return nil }
         return profile.readingList.createRecordWithURL(url, title: tab.title ?? url, addedBy: UIDevice.current.name).value.successValue
-    }
-
-    func tabTrayRequestsPresentationOf(_ viewController: UIViewController) {
-        self.present(viewController, animated: false, completion: nil)
     }
 }
 

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -28,7 +28,6 @@ protocol TabTrayDelegate: AnyObject {
     func tabTrayDidAddTab(_ tabTray: GridTabViewController, tab: Tab)
     func tabTrayDidAddBookmark(_ tab: Tab)
     func tabTrayDidAddToReadingList(_ tab: Tab) -> ReadingListItem?
-    func tabTrayRequestsPresentationOf(_ viewController: UIViewController)
     func tabTrayOpenRecentlyClosedTab(_ url: URL)
 }
 

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -512,7 +512,7 @@ extension GridTabViewController: TabPeekDelegate {
     }
 
     func tabPeekRequestsPresentationOf(_ viewController: UIViewController) {
-        delegate?.tabTrayRequestsPresentationOf(viewController)
+        present(viewController, animated: true, completion: nil)
     }
 }
 


### PR DESCRIPTION
Issue #9863.

This was failing to work as it was trying to have the `BrowserViewController` present the device picker while it was also presenting the tab tray.
