### PR TITLE
FX-6541 Fix checkmark in Tracking Protection settings for RTL languages

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -492,8 +492,14 @@ class CheckmarkSetting: Setting {
             cell.tintColor = UIColor.theme.tableView.rowActionAccessory // Sets accessory color only
 
             let checkColor = isChecked() ? UIColor.theme.tableView.rowActionAccessory : UIColor.clear
-            let check = UILabel(frame: CGRect(x: 20, y: 10, width: 24, height: 20))
+            let check = UILabel()
             cell.contentView.addSubview(check)
+            check.snp.makeConstraints { make in
+                make.height.equalTo(20)
+                make.width.equalTo(24)
+                make.top.equalToSuperview().offset(10)
+                make.leading.equalToSuperview().offset(20)
+            }
             check.text = "\u{2713}"
             check.font = UIFont.systemFont(ofSize: 20)
             check.textColor = checkColor


### PR DESCRIPTION
This PR corrects the checkmark position in Tracking Protection settings for RTL languages such as Arabic or Hebrew. (#6541)
![simulator_screenshot_D1AB2E6A-CD66-45B6-B0BF-9C6FBD092622](https://user-images.githubusercontent.com/66826029/151423068-47ea3647-f225-4eb0-b528-0ec917840053.png)