### PR TITLE
FX-6538 Fix navigation buttons for RTL languages

### DIFF
--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -93,13 +93,13 @@ open class TabToolbarHelper: NSObject {
         self.toolbar = toolbar
         super.init()
 
-        toolbar.backButton.setImage(UIImage.templateImageNamed("nav-back"), for: .normal)
+        toolbar.backButton.setImage(UIImage.templateImageNamed("nav-back")?.imageFlippedForRightToLeftLayoutDirection(), for: .normal)
         toolbar.backButton.accessibilityLabel = .TabToolbarBackAccessibilityLabel
         let longPressGestureBackButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressBack))
         toolbar.backButton.addGestureRecognizer(longPressGestureBackButton)
         toolbar.backButton.addTarget(self, action: #selector(didClickBack), for: .touchUpInside)
 
-        toolbar.forwardButton.setImage(UIImage.templateImageNamed("nav-forward"), for: .normal)
+        toolbar.forwardButton.setImage(UIImage.templateImageNamed("nav-forward")?.imageFlippedForRightToLeftLayoutDirection(), for: .normal)
         toolbar.forwardButton.accessibilityLabel = .TabToolbarForwardAccessibilityLabel
         let longPressGestureForwardButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressForward))
         toolbar.forwardButton.addGestureRecognizer(longPressGestureForwardButton)

--- a/ClientTests/TabToolbarHelperTests.swift
+++ b/ClientTests/TabToolbarHelperTests.swift
@@ -10,8 +10,8 @@ class TabToolbarHelperTests: XCTestCase {
     var subject: TabToolbarHelper!
     var mockToolbar: MockTabToolbar!
 
-    let backButtonImage = UIImage.templateImageNamed("nav-back")
-    let forwardButtonImage = UIImage.templateImageNamed("nav-forward")
+    let backButtonImage = UIImage.templateImageNamed("nav-back")?.imageFlippedForRightToLeftLayoutDirection()
+    let forwardButtonImage = UIImage.templateImageNamed("nav-forward")?.imageFlippedForRightToLeftLayoutDirection()
     let menuButtonImage = UIImage.templateImageNamed("nav-menu")
     let libraryButtonImage = UIImage.templateImageNamed("menu-library")
     let searchButtonImage = UIImage.templateImageNamed("search")


### PR DESCRIPTION
This PR fixes the back and forward buttons for RTL languages such as Hebrew and Arabic. (#6538)
![simulator_screenshot_5DB7FE85-85D8-4586-8DA8-EECBAE9C4FC5](https://user-images.githubusercontent.com/66826029/151427633-94d901d2-1813-49cd-95dd-481f090e0ccf.png)

