### PR TITLE
Opts users out of experiments when opting out of telemetry

### DIFF
--- a/Client/Experiments/Experiments.swift
+++ b/Client/Experiments/Experiments.swift
@@ -64,7 +64,30 @@ enum Experiments {
             }
         }
     }
-
+    
+    private static var studiesSetting: Bool? = nil;
+    private static var telemetrySetting: Bool? = nil;
+    
+    static func setStudiesSetting(_ setting: Bool) {
+        studiesSetting = setting
+        updateGlobalUserParticipation()
+    }
+    
+    static func setTelemetrySetting(_ setting: Bool) {
+        telemetrySetting = setting
+        updateGlobalUserParticipation()
+    }
+    
+    private static func updateGlobalUserParticipation() {
+        // we only want to reset the globalUserParticipation flag if both settings have been
+        // initialized.
+        if let studiesSetting = studiesSetting, let telemetrySetting = telemetrySetting {
+            // we only enable experiments if users are opting in BOTH
+            // telemetry and studies. If either is opted-out, we make
+            // sure users are not enrolled in any experiments
+            shared.globalUserParticipation = studiesSetting && telemetrySetting
+        }
+    }
     static func setLocalExperimentData(payload: String?, storage: UserDefaults = .standard) {
         guard let payload = payload else {
             storage.removeObject(forKey: NIMBUS_LOCAL_DATA_KEY)

--- a/Client/Experiments/Experiments.swift
+++ b/Client/Experiments/Experiments.swift
@@ -75,6 +75,9 @@ enum Experiments {
     
     static func setTelemetrySetting(_ setting: Bool) {
         telemetrySetting = setting
+        if !setting {
+            shared.resetTelemetryIdentifiers()
+        }
         updateGlobalUserParticipation()
     }
     

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -793,7 +793,6 @@ class SendAnonymousUsageDataSetting: BoolSetting {
                 AdjustHelper.setEnabled($0)
                 Glean.shared.setUploadEnabled($0)
                 Experiments.setTelemetrySetting($0)
-                Experiments.shared.resetTelemetryIdentifiers()
             }
         )
         // We make sure to set this on initialization, in case the setting is turned off

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -792,9 +792,13 @@ class SendAnonymousUsageDataSetting: BoolSetting {
             settingDidChange: {
                 AdjustHelper.setEnabled($0)
                 Glean.shared.setUploadEnabled($0)
+                Experiments.setTelemetrySetting($0)
                 Experiments.shared.resetTelemetryIdentifiers()
             }
         )
+        // We make sure to set this on initialization, in case the setting is turned off
+        // in which case, we would to make sure that users are opted out of experiments
+        Experiments.setTelemetrySetting(prefs.boolForKey(AppConstants.PrefSendUsageData) ?? true)
     }
 
     override var accessibilityIdentifier: String? { return "SendAnonymousUsageData" }
@@ -819,10 +823,13 @@ class StudiesToggleSetting: BoolSetting {
             prefs: prefs, prefKey: AppConstants.PrefStudiesToggle, defaultValue: true,
             attributedTitleText: NSAttributedString(string: .SettingsStudiesToggleTitle),
             attributedStatusText: statusText,
-            settingDidChange: { enabled in
-                Experiments.shared.globalUserParticipation = enabled
+            settingDidChange: {
+                Experiments.setStudiesSetting($0)
             }
         )
+        // We make sure to set this on initialization, in case the setting is turned off
+        // in which case, we would to make sure that users are opted out of experiments
+        Experiments.setStudiesSetting(prefs.boolForKey(AppConstants.PrefStudiesToggle) ?? true)
     }
 
     override var accessibilityIdentifier: String? { return "StudiesToggle" }


### PR DESCRIPTION
Fixes https://mozilla-hub.atlassian.net/browse/EXP-2118

Makes sure that when users opt out of either studies or telemetry, they are opted out of experimentation.

I manually tested that for experiments to be enrolled both options have to be enabled. It's a small patch, but relatively complicated. For example, we need to make sure to get the correct state of the settings on initialization and pass them down.

I'd happily take and apply any suggestions to make this cleaner, less coupled or more "swifty"! 
