### PR TITLE
Fix QRCodeViewController presentation bug (#9755)

### DIFF
--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -134,6 +134,7 @@ class QuickActions: NSObject {
         let qrCodeViewController = QRCodeViewController()
         qrCodeViewController.qrCodeDelegate = vc
         let controller = UINavigationController(rootViewController: qrCodeViewController)
+        vc.presentedViewController?.dismiss(animated: true)
         vc.present(controller, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
A potentially presented ViewController gets dismissed before the `QRCodeViewController` is being presented see (#9755 for reference).

