### PR TITLE
FX-9884 Fix transparent navigation bar in Send to Device when not signed in

### DIFF
--- a/Client/Frontend/Extensions/InstructionsViewController.swift
+++ b/Client/Frontend/Extensions/InstructionsViewController.swift
@@ -37,7 +37,7 @@ func setupHelpView(_ view: UIView, introText: String, showMeText: String) {
     imageView.image = UIImage(named: "emptySync")
     view.addSubview(imageView)
     imageView.snp.makeConstraints { (make) -> Void in
-        make.top.equalTo(view).offset(InstructionsViewControllerUX.TopPadding)
+        make.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(InstructionsViewControllerUX.TopPadding)
         make.centerX.equalTo(view)
     }
 
@@ -75,7 +75,6 @@ class InstructionsViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        edgesForExtendedLayout = []
         view.backgroundColor = UIColor.Photon.White100
 
         navigationItem.leftBarButtonItem = UIBarButtonItem(title: .SendToCloseButton, style: .done, target: self, action: #selector(close))


### PR DESCRIPTION
This PR fixes the transparent navigation bar in Send to Device when not signed in to a Firefox Account. #9884
![simulator_screenshot_C0F3FF9C-A727-4A61-8A96-D0A767A79794](https://user-images.githubusercontent.com/66826029/151593377-dbbd6a77-40f9-4edc-a36a-364ca2924f58.png) 