### PR TITLE
Bugfix #9541 [v98] Fix crash when open new tab with js alert shown

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -485,6 +485,7 @@
 		8AEE62C92756BA34003207D1 /* LoginsHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 8AEE62C62756BA34003207D1 /* LoginsHelper.js */; };
 		8AEE62CA2756BA34003207D1 /* TrackingProtectionStats.js in Resources */ = {isa = PBXBuildFile; fileRef = 8AEE62C72756BA34003207D1 /* TrackingProtectionStats.js */; };
 		8AEE62CB2756BA34003207D1 /* DownloadHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 8AEE62C82756BA34003207D1 /* DownloadHelper.js */; };
+		8AF0CFF527A0B0ED00C1A4A2 /* QuickActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF0CFF427A0B0ED00C1A4A2 /* QuickActionsTests.swift */; };
 		8AFE4C2127480D0C00B97C65 /* TabTrayViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFE4C2027480D0B00B97C65 /* TabTrayViewControllerTests.swift */; };
 		8D8251811F4DE67F00780643 /* AdvancedAccountSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8251721F4DE67E00780643 /* AdvancedAccountSettingViewController.swift */; };
 		8DCD3BCD1ED5B7FA00446D38 /* FxADeepLinkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DCD3BCC1ED5B7FA00446D38 /* FxADeepLinkingTests.swift */; };
@@ -2730,6 +2731,7 @@
 		8AEE62C62756BA34003207D1 /* LoginsHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = LoginsHelper.js; path = AllFrames/AtDocumentStart/LoginsHelper.js; sourceTree = "<group>"; };
 		8AEE62C72756BA34003207D1 /* TrackingProtectionStats.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = TrackingProtectionStats.js; path = AllFrames/AtDocumentStart/TrackingProtectionStats.js; sourceTree = "<group>"; };
 		8AEE62C82756BA34003207D1 /* DownloadHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = DownloadHelper.js; path = AllFrames/AtDocumentStart/DownloadHelper.js; sourceTree = "<group>"; };
+		8AF0CFF427A0B0ED00C1A4A2 /* QuickActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionsTests.swift; sourceTree = "<group>"; };
 		8AFE4C2027480D0B00B97C65 /* TabTrayViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabTrayViewControllerTests.swift; sourceTree = "<group>"; };
 		8B3245D190D4FA80C3B46EC8 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Search.strings"; sourceTree = "<group>"; };
 		8B674438A5487ABCD2DD7CA5 /* ses */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ses; path = ses.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -6480,6 +6482,7 @@
 				F84B21D91A090F8100AAB793 /* ClientTests.swift */,
 				3B39EDB91E16E18900EF029F /* CustomSearchEnginesTest.swift */,
 				8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */,
+				8AF0CFF427A0B0ED00C1A4A2 /* QuickActionsTests.swift */,
 				D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */,
 				3943A81C1E9807C700D4F6DC /* FxAPushMessageTest.swift */,
 				8A2825342760399B00395E66 /* KeyboardPressesHandlerTests.swift */,
@@ -8943,6 +8946,7 @@
 				F84B21DA1A090F8100AAB793 /* ClientTests.swift in Sources */,
 				281B2BEA1ADF4D90002917DC /* MockProfile.swift in Sources */,
 				2F697F7E1A9FD22D009E03AE /* SearchEnginesTests.swift in Sources */,
+				8AF0CFF527A0B0ED00C1A4A2 /* QuickActionsTests.swift in Sources */,
 				2F44FA1B1A9D426A00FD20CC /* TestHashExtensions.swift in Sources */,
 				8ADED7EC27691351009C19E6 /* CalendarExtensionsTests.swift in Sources */,
 				3B39EDBA1E16E18900EF029F /* CustomSearchEnginesTest.swift in Sources */,

--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -240,11 +240,11 @@ enum NavigationPath {
 
     private static func handleClosePrivateTabs(with bvc: BrowserViewController, tray: GridTabViewController) {
         bvc.tabManager.removeTabs(bvc.tabManager.privateTabs)
-         guard let tab = mostRecentTab(inTabs: bvc.tabManager.normalTabs) else {
-             bvc.tabManager.selectTab(bvc.tabManager.addTab())
-             return
-         }
-         bvc.tabManager.selectTab(tab)
+        guard let tab = mostRecentTab(inTabs: bvc.tabManager.normalTabs) else {
+            bvc.tabManager.selectTab(bvc.tabManager.addTab())
+            return
+        }
+        bvc.tabManager.selectTab(tab)
     }
 
     private static func handleGlean(url: URL) {
@@ -344,6 +344,8 @@ func == (lhs: NavigationPath, rhs: NavigationPath) -> Bool {
         return lhs.query == rhs.query
     case let (.deepLink(lhs), .deepLink(rhs)):
         return lhs == rhs
+    case (.closePrivateTabs, .closePrivateTabs):
+        return true
     default:
         return false
     }

--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -105,8 +105,6 @@ class QuickActions: NSObject {
             handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: false)
         case .newPrivateTab:
             handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: true)
-        // even though we're removing OpenLastTab, it's possible that someone will use an existing last tab quick action to open the app
-        // the first time after upgrading, so we should still handle it
         case .openLastBookmark:
             if let urlToOpen = (userData?[QuickActions.TabURLKey] as? String)?.asURL {
                 handleOpenURL(withBrowserViewController: browserViewController, urlToOpen: urlToOpen)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -170,8 +170,6 @@ class BrowserViewController: UIViewController {
         tabManager.addDelegate(self)
         tabManager.addNavigationDelegate(self)
         downloadQueue.delegate = self
-
-        NotificationCenter.default.addObserver(self, selector: #selector(displayThemeChanged), name: .DisplayThemeChanged, object: nil)
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -308,7 +306,7 @@ class BrowserViewController: UIViewController {
             self.displayedPopoverController = nil
         }
 
-        // If we are displying a private tab, hide any elements in the tab that we wouldn't want shown
+        // If we are displaying a private tab, hide any elements in the tab that we wouldn't want shown
         // when the app is in the home switcher
         guard let privateTab = tabManager.selectedTab, privateTab.isPrivate else {
             return
@@ -354,11 +352,79 @@ class BrowserViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        NotificationCenter.default.addObserver(self, selector: #selector(appWillResignActiveNotification), name: UIApplication.willResignActiveNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActiveNotification), name: UIApplication.didBecomeActiveNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(appDidEnterBackgroundNotification), name: UIApplication.didEnterBackgroundNotification, object: nil)
         KeyboardHelper.defaultHelper.addDelegate(self)
 
+        setupNotifications()
+        addSubviews()
+
+        // UIAccessibilityCustomAction subclass holding an AccessibleAction instance does not work,
+        // thus unable to generate AccessibleActions and UIAccessibilityCustomActions "on-demand" and need
+        // to make them "persistent" e.g. by being stored in BVC
+        pasteGoAction = AccessibleAction(name: .PasteAndGoTitle, handler: { () -> Bool in
+            if let pasteboardContents = UIPasteboard.general.string {
+                self.urlBar(self.urlBar, didSubmitText: pasteboardContents)
+                return true
+            }
+            return false
+        })
+        pasteAction = AccessibleAction(name: .PasteTitle, handler: { () -> Bool in
+            if let pasteboardContents = UIPasteboard.general.string {
+                // Enter overlay mode and make the search controller appear.
+                self.urlBar.enterOverlayMode(pasteboardContents, pasted: true, search: true)
+
+                return true
+            }
+            return false
+        })
+        copyAddressAction = AccessibleAction(name: .CopyAddressTitle, handler: { () -> Bool in
+            if let url = self.tabManager.selectedTab?.canonicalURL?.displayURL ?? self.urlBar.currentURL {
+                UIPasteboard.general.url = url
+            }
+            return true
+        })
+
+        clipboardBarDisplayHandler = ClipboardBarDisplayHandler(prefs: profile.prefs, tabManager: tabManager)
+        clipboardBarDisplayHandler?.delegate = self
+
+        scrollController.urlBar = urlBar
+        scrollController.readerModeBar = readerModeBar
+        scrollController.header = header
+        scrollController.footer = footer
+        scrollController.snackBars = alertStackView
+
+        updateToolbarStateForTraitCollection(traitCollection)
+
+        setupConstraints()
+
+        // Setup UIDropInteraction to handle dragging and dropping
+        // links into the view from other apps.
+        let dropInteraction = UIDropInteraction(delegate: self)
+        view.addInteraction(dropInteraction)
+
+        if !NightModeHelper.isActivated(profile.prefs) && LegacyThemeManager.instance.systemThemeIsOn {
+            let userInterfaceStyle = traitCollection.userInterfaceStyle
+            LegacyThemeManager.instance.current = userInterfaceStyle == .dark ? DarkTheme() : NormalTheme()
+        }
+
+        // Setup chron tabs A/B test
+        chronTabsUserResearch = ChronTabsUserResearch()
+        searchTelemetry = SearchTelemetry()
+    }
+
+    private func setupNotifications() {
+        NotificationCenter.default.addObserver(self, selector: #selector(appWillResignActiveNotification),
+                                               name: UIApplication.willResignActiveNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActiveNotification),
+                                               name: UIApplication.didBecomeActiveNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(appDidEnterBackgroundNotification),
+                                               name: UIApplication.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(appMenuBadgeUpdate),
+                                               name: .FirefoxAccountStateChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(displayThemeChanged),
+                                               name: .DisplayThemeChanged, object: nil)
+    }
+
+    func addSubviews() {
         webViewContainerBackdrop = UIView()
         webViewContainerBackdrop.backgroundColor = UIColor.Photon.Ink90
         webViewContainerBackdrop.alpha = 0
@@ -386,64 +452,11 @@ class BrowserViewController: UIViewController {
         urlBarTopTabsContainer.addSubview(topTabsContainer)
         view.addSubview(header)
 
-        // UIAccessibilityCustomAction subclass holding an AccessibleAction instance does not work, thus unable to generate AccessibleActions and UIAccessibilityCustomActions "on-demand" and need to make them "persistent" e.g. by being stored in BVC
-        pasteGoAction = AccessibleAction(name: .PasteAndGoTitle, handler: { () -> Bool in
-            if let pasteboardContents = UIPasteboard.general.string {
-                self.urlBar(self.urlBar, didSubmitText: pasteboardContents)
-                return true
-            }
-            return false
-        })
-        pasteAction = AccessibleAction(name: .PasteTitle, handler: { () -> Bool in
-            if let pasteboardContents = UIPasteboard.general.string {
-                // Enter overlay mode and make the search controller appear.
-                self.urlBar.enterOverlayMode(pasteboardContents, pasted: true, search: true)
-
-                return true
-            }
-            return false
-        })
-        copyAddressAction = AccessibleAction(name: .CopyAddressTitle, handler: { () -> Bool in
-            if let url = self.tabManager.selectedTab?.canonicalURL?.displayURL ?? self.urlBar.currentURL {
-                UIPasteboard.general.url = url
-            }
-            return true
-        })
-
         view.addSubview(alertStackView)
         footer = UIView()
         view.addSubview(footer)
         alertStackView.axis = .vertical
         alertStackView.alignment = .center
-
-        clipboardBarDisplayHandler = ClipboardBarDisplayHandler(prefs: profile.prefs, tabManager: tabManager)
-        clipboardBarDisplayHandler?.delegate = self
-
-        scrollController.urlBar = urlBar
-        scrollController.readerModeBar = readerModeBar
-        scrollController.header = header
-        scrollController.footer = footer
-        scrollController.snackBars = alertStackView
-
-        self.updateToolbarStateForTraitCollection(self.traitCollection)
-
-        setupConstraints()
-
-        // Setup UIDropInteraction to handle dragging and dropping
-        // links into the view from other apps.
-        let dropInteraction = UIDropInteraction(delegate: self)
-        view.addInteraction(dropInteraction)
-
-        if !NightModeHelper.isActivated(profile.prefs) && LegacyThemeManager.instance.systemThemeIsOn {
-            let userInterfaceStyle = traitCollection.userInterfaceStyle
-            LegacyThemeManager.instance.current = userInterfaceStyle == .dark ? DarkTheme() : NormalTheme()
-        }
-
-        NotificationCenter.default.addObserver(self, selector: #selector(self.appMenuBadgeUpdate), name: .FirefoxAccountStateChange, object: nil)
-
-        // Setup chron tabs A/B test
-        chronTabsUserResearch = ChronTabsUserResearch()
-        searchTelemetry = SearchTelemetry()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -1136,27 +1149,17 @@ class BrowserViewController: UIViewController {
         topTabsViewController?.applyUIMode(isPrivate: isPrivate)
     }
 
-    func switchToTabForURLOrOpen(_ url: URL, isPrivate: Bool = false) {
+    func switchToTabForURLOrOpen(_ url: URL, uuid: String? = nil, isPrivate: Bool = false) {
         guard !isCrashAlertShowing else {
             urlFromAnotherApp = UrlToOpenModel(url: url, isPrivate: isPrivate)
             return
         }
         popToBVC()
         openedUrlFromExternalSource = true
-        if let tab = tabManager.getTabForURL(url) {
-            tabManager.selectTab(tab)
-        } else {
-            openURLInNewTab(url, isPrivate: isPrivate)
-        }
-    }
 
-    func switchToTabForURLOrOpen(_ url: URL, uuid: String,  isPrivate: Bool = false) {
-        guard !isCrashAlertShowing else {
-            urlFromAnotherApp = UrlToOpenModel(url: url, isPrivate: isPrivate)
-            return
-        }
-        popToBVC()
-        if let tab = tabManager.getTabForUUID(uuid: uuid) {
+        if let uuid = uuid, let tab = tabManager.getTabForUUID(uuid: uuid) {
+            tabManager.selectTab(tab)
+        } else if let tab = tabManager.getTabForURL(url) {
             tabManager.selectTab(tab)
         } else {
             openURLInNewTab(url, isPrivate: isPrivate)
@@ -1193,6 +1196,7 @@ class BrowserViewController: UIViewController {
 
     func openBlankNewTab(focusLocationField: Bool, isPrivate: Bool = false, searchFor searchText: String? = nil) {
         popToBVC()
+        openedUrlFromExternalSource = true
         openURLInNewTab(nil, isPrivate: isPrivate)
         let freshTab = tabManager.selectedTab
         freshTab?.updateTimerAndObserving(state: .newTab)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1155,6 +1155,10 @@ class BrowserViewController: UIViewController {
             return
         }
         popToBVC()
+        guard isShowingJSAlert() else {
+            tabManager.addTab(URLRequest(url: url), isPrivate: isPrivate)
+            return
+        }
         openedUrlFromExternalSource = true
 
         if let uuid = uuid, let tab = tabManager.getTabForUUID(uuid: uuid) {
@@ -1196,7 +1200,12 @@ class BrowserViewController: UIViewController {
 
     func openBlankNewTab(focusLocationField: Bool, isPrivate: Bool = false, searchFor searchText: String? = nil) {
         popToBVC()
+        guard isShowingJSAlert() else {
+            tabManager.addTab(nil, isPrivate: isPrivate)
+            return
+        }
         openedUrlFromExternalSource = true
+
         openURLInNewTab(nil, isPrivate: isPrivate)
         let freshTab = tabManager.selectedTab
         freshTab?.updateTimerAndObserving(state: .newTab)
@@ -1224,12 +1233,23 @@ class BrowserViewController: UIViewController {
         guard let currentViewController = navigationController?.topViewController else {
             return
         }
-        currentViewController.dismiss(animated: true, completion: nil)
+        // Avoid dismissing JSPromptAlert that causes the crash because completionHandler was not called
+        if isShowingJSAlert() {
+            currentViewController.dismiss(animated: true, completion: nil)
+        }
+
         if currentViewController != self {
             _ = self.navigationController?.popViewController(animated: true)
         } else if urlBar.inOverlayMode {
             urlBar.didClickCancel()
         }
+    }
+
+    private func isShowingJSAlert() -> Bool {
+        guard let _ = navigationController?.topViewController?.presentedViewController as? JSPromptAlertController else {
+            return true
+        }
+        return false
     }
 
     func presentActivityViewController(_ url: URL, tab: Tab? = nil, sourceView: UIView?, sourceRect: CGRect, arrowDirection: UIPopoverArrowDirection) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1155,7 +1155,7 @@ class BrowserViewController: UIViewController {
             return
         }
         popToBVC()
-        guard isShowingJSAlert() else {
+        guard !isShowingJSPromptAlert() else {
             tabManager.addTab(URLRequest(url: url), isPrivate: isPrivate)
             return
         }
@@ -1200,7 +1200,7 @@ class BrowserViewController: UIViewController {
 
     func openBlankNewTab(focusLocationField: Bool, isPrivate: Bool = false, searchFor searchText: String? = nil) {
         popToBVC()
-        guard isShowingJSAlert() else {
+        guard !isShowingJSPromptAlert() else {
             tabManager.addTab(nil, isPrivate: isPrivate)
             return
         }
@@ -1234,7 +1234,7 @@ class BrowserViewController: UIViewController {
             return
         }
         // Avoid dismissing JSPromptAlert that causes the crash because completionHandler was not called
-        if isShowingJSAlert() {
+        if !isShowingJSPromptAlert() {
             currentViewController.dismiss(animated: true, completion: nil)
         }
 
@@ -1245,11 +1245,8 @@ class BrowserViewController: UIViewController {
         }
     }
 
-    private func isShowingJSAlert() -> Bool {
-        guard let _ = navigationController?.topViewController?.presentedViewController as? JSPromptAlertController else {
-            return true
-        }
-        return false
+    private func isShowingJSPromptAlert() -> Bool {
+        return navigationController?.topViewController?.presentedViewController as? JSPromptAlertController != nil
     }
 
     func presentActivityViewController(_ url: URL, tab: Tab? = nil, sourceView: UIView?, sourceRect: CGRect, arrowDirection: UIPopoverArrowDirection) {

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -160,7 +160,6 @@ class TabManager: NSObject, FeatureFlagsProtocol {
     var lastSessionWasPrivate: Bool {
         return UserDefaults.standard.bool(forKey: "wasLastSessionPrivate")
     }
-    
 
     // MARK: - Initializer
     init(profile: Profile, imageStore: DiskImageStore?) {

--- a/ClientTests/QuickActionsTests.swift
+++ b/ClientTests/QuickActionsTests.swift
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+@testable import Client
+
+import XCTest
+
+class QuickActionsTest: XCTestCase {
+
+    private var browserViewController: SpyBrowserViewController!
+    private var quickActions: QuickActions!
+    private var profile: TabManagerMockProfile!
+    private var tabManager: TabManager!
+
+    override func setUp() {
+        super.setUp()
+        profile = TabManagerMockProfile()
+        tabManager = TabManager(profile: profile, imageStore: nil)
+        browserViewController = SpyBrowserViewController(profile: profile, tabManager: tabManager)
+        browserViewController.addSubviews()
+        quickActions = QuickActions.sharedInstance
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        profile = nil
+        tabManager = nil
+        browserViewController = nil
+        quickActions = nil
+    }
+
+    func testNewTabShortcut_externalSourceIsTrue() {
+        let shortcutItem = UIApplicationShortcutItem(type: ShortcutType.newTab.rawValue, localizedTitle: "")
+        handleShortcutAndWait(shortcutItem: shortcutItem)
+    }
+
+    func testNewPrivateTabShortcut_externalSourceIsTrue() {
+        let shortcutItem = UIApplicationShortcutItem(type: ShortcutType.newPrivateTab.rawValue, localizedTitle: "")
+        handleShortcutAndWait(shortcutItem: shortcutItem)
+    }
+
+    func testOpenBookmarkShortcut_externalSourceIsTrue() {
+        let shortcutItem = BookmarkShortcutItem()
+        handleShortcutAndWait(shortcutItem: shortcutItem)
+    }
+}
+
+// MARK: - Helper methods
+
+private extension QuickActionsTest {
+    /// Wait for openedUrlFromExternalSource to be set true, testing the start at home edge case
+    func handleShortcutAndWait(shortcutItem: UIApplicationShortcutItem) {
+        let expectation = expectation(description: "Completion URL of SpyBrowserViewController should be called")
+        browserViewController.completionURL = {
+            XCTAssertTrue(self.browserViewController.openedUrlFromExternalSource, "openedUrlFromExternalSource needs to be true for start at home feature")
+            expectation.fulfill()
+        }
+
+        quickActions.handleShortCutItem(shortcutItem, withBrowserViewController: browserViewController)
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+}
+
+private class BookmarkShortcutItem: UIApplicationShortcutItem {
+    convenience init() {
+        self.init(type: ShortcutType.openLastBookmark.rawValue, localizedTitle: "")
+    }
+
+    override var userInfo: [String : NSSecureCoding]? {
+        return [QuickActions.TabURLKey: "https://www.mozilla.org/en-CA/" as NSSecureCoding]
+    }
+}
+
+private class SpyBrowserViewController: BrowserViewController {
+    var completionURL: (() -> Void)?
+
+    override func openBlankNewTab(focusLocationField: Bool, isPrivate: Bool = false, searchFor searchText: String? = nil) {
+        super.openBlankNewTab(focusLocationField: focusLocationField, isPrivate: isPrivate, searchFor: searchText)
+        completionURL?()
+    }
+
+    override func switchToTabForURLOrOpen(_ url: URL, uuid: String? = nil, isPrivate: Bool = false) {
+        super.switchToTabForURLOrOpen(url, uuid: uuid, isPrivate: isPrivate)
+        completionURL?()
+    }
+}

--- a/ClientTests/TabEventHandlerTests.swift
+++ b/ClientTests/TabEventHandlerTests.swift
@@ -48,7 +48,7 @@ class TabEventHandlerTests: XCTestCase {
         BrowserViewController.foregroundBVC().profile.prefs.setBool(false, forKey: PrefsKeys.KeyBlockPopups)
         BrowserViewController.foregroundBVC().tabManager.addTab(URLRequest(url: URL(string: "\(webServerBase)/blankpopup")!))
 
-        let exists = NSPredicate() { obj,_ in
+        let exists = NSPredicate() { obj, _ in
             let tabManager = obj as! TabManager
             return tabManager.tabs.count > 2
         }
@@ -59,7 +59,7 @@ class TabEventHandlerTests: XCTestCase {
             return true
         }
 
-        waitForExpectations(timeout: 20, handler: nil)
+        waitForExpectations(timeout: 30, handler: nil)
     }
 }
 

--- a/ClientTests/TabManagerStoreTests.swift
+++ b/ClientTests/TabManagerStoreTests.swift
@@ -58,7 +58,7 @@ class TabManagerStoreTests: XCTestCase {
             XCTAssertEqual(self.manager.testTabCountOnDisk(), 2)
             e.fulfill()
         }
-        waitForExpectations(timeout: 2, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
 
     // Test disabled due to Issue:https://github.com/mozilla-mobile/firefox-ios/issues/7867

--- a/WidgetKit/OpenTabs/OpenTabsWidget.swift
+++ b/WidgetKit/OpenTabs/OpenTabsWidget.swift
@@ -10,7 +10,7 @@ import Combine
 struct OpenTabsWidget: Widget {
     private let kind: String = "Quick View"
 
-     var body: some WidgetConfiguration {
+    var body: some WidgetConfiguration {
         StaticConfiguration(kind: kind, provider: TabProvider()) { entry in
             OpenTabsView(entry: entry)
         }


### PR DESCRIPTION

# Issue #9541
- Includes #9869 that is already merged in main 
- Avoid dismiss presented view controller in `popBVC` when `JSPromptAlertController` is shown that was causing the crash
- If a `JSPromptAlertController` is presented add the new tab in background and avoid switching tabs