### PR TITLE
Fix #7476 Stop Voiceover from reading pasting message in URL Bar repeatedly

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -262,7 +262,7 @@ extension BrowserViewController: URLBarDelegate, FeatureFlagsProtocol {
     }
 
     func locationActionsForURLBar(_ urlBar: URLBarView) -> [AccessibleAction] {
-        if UIPasteboard.general.string != nil {
+        if UIPasteboard.general.hasStrings {
             return [pasteGoAction, pasteAction, copyAddressAction]
         } else {
             return [copyAddressAction]


### PR DESCRIPTION
This PR stops Voiceover from reading the "Firefox pasted from X" message repeatedly when VoiceOver is enabled. #7476