### PR TITLE
Fix #9366 Display correct Block Image icon

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
@@ -214,8 +214,8 @@ class PhotonActionSheetCell: UITableViewCell {
             case .URL:
                 let image = UIImage(named: iconName)?.createScaled(PhotonActionSheetUX.IconSize)
                 statusIcon.layer.cornerRadius = PhotonActionSheetUX.IconSize.width / 2
-                statusIcon.sd_setImage(with: action.iconURL, placeholderImage: image, options: []) { (img, err, _, _) in
-                    if let img = img {
+                statusIcon.sd_setImage(with: action.iconURL, placeholderImage: image, options: [.avoidAutoSetImage]) { (img, err, _, _) in
+                    if let img = img, self.accessibilityLabel == action.title {
                         self.statusIcon.image = img.createScaled(PhotonActionSheetUX.IconSize)
                         self.statusIcon.layer.cornerRadius = PhotonActionSheetUX.IconSize.width / 2
                     }


### PR DESCRIPTION
This PR fixes the bug where the account image icon is shown instead of the Block Image icon in the hamburger menu. #9366