### PR TITLE
Bugfix #9541 [v98] Fix crash when open new tab with js alert shown

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1155,6 +1155,10 @@ class BrowserViewController: UIViewController {
             return
         }
         popToBVC()
+        guard isShowingJSAlert() else {
+            tabManager.addTab(URLRequest(url: url), isPrivate: isPrivate)
+            return
+        }
         openedUrlFromExternalSource = true
 
         if let uuid = uuid, let tab = tabManager.getTabForUUID(uuid: uuid) {
@@ -1196,7 +1200,12 @@ class BrowserViewController: UIViewController {
 
     func openBlankNewTab(focusLocationField: Bool, isPrivate: Bool = false, searchFor searchText: String? = nil) {
         popToBVC()
+        guard isShowingJSAlert() else {
+            tabManager.addTab(nil, isPrivate: isPrivate)
+            return
+        }
         openedUrlFromExternalSource = true
+
         openURLInNewTab(nil, isPrivate: isPrivate)
         let freshTab = tabManager.selectedTab
         freshTab?.updateTimerAndObserving(state: .newTab)
@@ -1224,12 +1233,23 @@ class BrowserViewController: UIViewController {
         guard let currentViewController = navigationController?.topViewController else {
             return
         }
-        currentViewController.dismiss(animated: true, completion: nil)
+        // Avoid dismissing JSPromptAlert that causes the crash because completionHandler was not called
+        if isShowingJSAlert() {
+            currentViewController.dismiss(animated: true, completion: nil)
+        }
+
         if currentViewController != self {
             _ = self.navigationController?.popViewController(animated: true)
         } else if urlBar.inOverlayMode {
             urlBar.didClickCancel()
         }
+    }
+
+    private func isShowingJSAlert() -> Bool {
+        guard let _ = navigationController?.topViewController?.presentedViewController as? JSPromptAlertController else {
+            return true
+        }
+        return false
     }
 
     func presentActivityViewController(_ url: URL, tab: Tab? = nil, sourceView: UIView?, sourceRect: CGRect, arrowDirection: UIPopoverArrowDirection) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1155,7 +1155,7 @@ class BrowserViewController: UIViewController {
             return
         }
         popToBVC()
-        guard isShowingJSAlert() else {
+        guard !isShowingJSPromptAlert() else {
             tabManager.addTab(URLRequest(url: url), isPrivate: isPrivate)
             return
         }
@@ -1200,7 +1200,7 @@ class BrowserViewController: UIViewController {
 
     func openBlankNewTab(focusLocationField: Bool, isPrivate: Bool = false, searchFor searchText: String? = nil) {
         popToBVC()
-        guard isShowingJSAlert() else {
+        guard !isShowingJSPromptAlert() else {
             tabManager.addTab(nil, isPrivate: isPrivate)
             return
         }
@@ -1234,7 +1234,7 @@ class BrowserViewController: UIViewController {
             return
         }
         // Avoid dismissing JSPromptAlert that causes the crash because completionHandler was not called
-        if isShowingJSAlert() {
+        if !isShowingJSPromptAlert() {
             currentViewController.dismiss(animated: true, completion: nil)
         }
 
@@ -1245,11 +1245,8 @@ class BrowserViewController: UIViewController {
         }
     }
 
-    private func isShowingJSAlert() -> Bool {
-        guard let _ = navigationController?.topViewController?.presentedViewController as? JSPromptAlertController else {
-            return true
-        }
-        return false
+    private func isShowingJSPromptAlert() -> Bool {
+        return navigationController?.topViewController?.presentedViewController as? JSPromptAlertController != nil
     }
 
     func presentActivityViewController(_ url: URL, tab: Tab? = nil, sourceView: UIView?, sourceRect: CGRect, arrowDirection: UIPopoverArrowDirection) {


### PR DESCRIPTION
# Issue #9541

- Avoid dismiss presented view controller in popBVC when JSPromptAlertController is shown that was causing the crash
- If a JSPromptAlertController is presented add the new tab in background and avoid switching tabs


