### PR TITLE
Increased detail arrow icon size in EnhancedTrackingProtectionMenuVC.swift

### DIFF
--- a/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
+++ b/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
@@ -258,8 +258,8 @@ class EnhancedTrackingProtectionMenuVC: UIViewController {
 
             connectionDetailArrow.trailingAnchor.constraint(equalTo: connectionView.trailingAnchor, constant: -ETPMenuUX.UX.gutterDistance),
             connectionDetailArrow.centerYAnchor.constraint(equalTo: connectionView.centerYAnchor),
-            connectionDetailArrow.heightAnchor.constraint(equalToConstant: 12),
-            connectionDetailArrow.widthAnchor.constraint(equalToConstant: 7),
+            connectionDetailArrow.heightAnchor.constraint(equalToConstant: 20),
+            connectionDetailArrow.widthAnchor.constraint(equalToConstant: 20),
 
             connectionButton.leadingAnchor.constraint(equalTo: connectionView.leadingAnchor),
             connectionButton.topAnchor.constraint(equalTo: connectionView.topAnchor),


### PR DESCRIPTION
Resolves #9927

Increased image size of `connectionDetailArrow` in EnhancedTrackingProtectionMenuVC.swift. Changed the icon height and width anchor to the same size as the Connection Image (Lock Icon to the left of the page).

```
connectionDetailArrow.heightAnchor.constraint(equalToConstant: 20),
connectionDetailArrow.widthAnchor.constraint(equalToConstant: 20),
```

![Screen Shot 2022-02-03 at 8 07 50 PM](https://user-images.githubusercontent.com/35638500/152457094-40dec099-c54f-4936-a0f0-05b0a591d278.jpg)

