### PR TITLE
Fix sharing wrong link after visiting certain URL resources

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -381,8 +381,6 @@ extension BrowserViewController: WKNavigationDelegate {
             return
         }
         
-        tab.temporaryDocument = nil
-        
         if tab == tabManager.selectedTab, navigationAction.navigationType == .linkActivated, tab.adsTelemetryUrlList.count > 0 {
             let adUrl = url.absoluteString
             if tab.adsTelemetryUrlList.contains(adUrl) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -381,6 +381,8 @@ extension BrowserViewController: WKNavigationDelegate {
             return
         }
         
+        tab.temporaryDocument = nil
+        
         if tab == tabManager.selectedTab, navigationAction.navigationType == .linkActivated, tab.adsTelemetryUrlList.count > 0 {
             let adUrl = url.absoluteString
             if tab.adsTelemetryUrlList.contains(adUrl) {

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -303,6 +303,7 @@ class Tab: NSObject {
         super.init()
         self.isPrivate = isPrivate
         debugTabCount += 1
+        observeURLChanges(delegate: self)
 
         TelemetryWrapper.recordEvent(category: .action, method: .add, object: .tab, value: isPrivate ? .privateTab : .normalTab)
     }
@@ -938,6 +939,12 @@ private class TabContentScriptManager: NSObject, WKScriptMessageHandler {
 
     func getContentScript(_ name: String) -> TabContentScript? {
         return helpers[name]
+    }
+}
+
+extension Tab : URLChangeDelegate {
+    func tab(_ tab: Tab, urlDidChangeTo url: URL) {
+        tab.temporaryDocument = nil
     }
 }
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -942,7 +942,7 @@ private class TabContentScriptManager: NSObject, WKScriptMessageHandler {
     }
 }
 
-extension Tab : URLChangeDelegate {
+extension Tab: URLChangeDelegate {
     func tab(_ tab: Tab, urlDidChangeTo url: URL) {
         tab.temporaryDocument = nil
     }


### PR DESCRIPTION
This PR fixes the issue where the wrong link would be shared after visiting certain URLs with a resource type such as PDF, image, etc, and then navigating back. #8626