### PR TITLE
Add #9422 [v98] Bottom search bar 

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -457,6 +457,9 @@
 		8ADED7F0276A7788009C19E6 /* CumulativeDaysOfUseCounterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADED7EF276A7788009C19E6 /* CumulativeDaysOfUseCounterTests.swift */; };
 		8AE1E1CB27B18F560024C45E /* SearchBarSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1E1CA27B18F560024C45E /* SearchBarSettingsViewController.swift */; };
 		8AE1E1CD27B191110024C45E /* SearchBarSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1E1CC27B191110024C45E /* SearchBarSettingsViewModel.swift */; };
+		8AE1E1D227B1ADC40024C45E /* TopBottomInterchangeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1E1D127B1ADC40024C45E /* TopBottomInterchangeable.swift */; };
+		8AE1E1D527B1AEED0024C45E /* TabLocationContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1E1D427B1AEED0024C45E /* TabLocationContainerView.swift */; };
+		8AE1E1D727B1AF020024C45E /* ToolbarTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1E1D627B1AF020024C45E /* ToolbarTextField.swift */; };
 		8AED23C527AC1F9500DE7E97 /* BaseContentStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AED23C427AC1F9500DE7E97 /* BaseContentStackView.swift */; };
 		8AEE284B276A973400C7104D /* RatingPromptManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE284A276A973400C7104D /* RatingPromptManagerTests.swift */; };
 		8AEE62C92756BA34003207D1 /* LoginsHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 8AEE62C62756BA34003207D1 /* LoginsHelper.js */; };
@@ -2697,6 +2700,9 @@
 		8ADED7EF276A7788009C19E6 /* CumulativeDaysOfUseCounterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CumulativeDaysOfUseCounterTests.swift; sourceTree = "<group>"; };
 		8AE1E1CA27B18F560024C45E /* SearchBarSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarSettingsViewController.swift; sourceTree = "<group>"; };
 		8AE1E1CC27B191110024C45E /* SearchBarSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarSettingsViewModel.swift; sourceTree = "<group>"; };
+		8AE1E1D127B1ADC40024C45E /* TopBottomInterchangeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBottomInterchangeable.swift; sourceTree = "<group>"; };
+		8AE1E1D427B1AEED0024C45E /* TabLocationContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabLocationContainerView.swift; sourceTree = "<group>"; };
+		8AE1E1D627B1AF020024C45E /* ToolbarTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarTextField.swift; sourceTree = "<group>"; };
 		8AED23C427AC1F9500DE7E97 /* BaseContentStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseContentStackView.swift; sourceTree = "<group>"; };
 		8AEE284A276A973400C7104D /* RatingPromptManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingPromptManagerTests.swift; sourceTree = "<group>"; };
 		8AEE62C62756BA34003207D1 /* LoginsHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = LoginsHelper.js; path = AllFrames/AtDocumentStart/LoginsHelper.js; sourceTree = "<group>"; };
@@ -5327,6 +5333,16 @@
 			path = SearchBar;
 			sourceTree = "<group>";
 		};
+		8AE1E1D327B1AED30024C45E /* URLBar */ = {
+			isa = PBXGroup;
+			children = (
+				0BF0DB931A8545800039F300 /* URLBarView.swift */,
+				8AE1E1D427B1AEED0024C45E /* TabLocationContainerView.swift */,
+				8AE1E1D627B1AF020024C45E /* ToolbarTextField.swift */,
+			);
+			path = URLBar;
+			sourceTree = "<group>";
+		};
 		8AED23C327AC1F8700DE7E97 /* Components */ = {
 			isa = PBXGroup;
 			children = (
@@ -5773,6 +5789,7 @@
 		D3A994941A368691008AD1AC /* Browser */ = {
 			isa = PBXGroup;
 			children = (
+				8AE1E1D327B1AED30024C45E /* URLBar */,
 				C849E45F26B9C36600260F0B /* EnhancedTrackingProtection */,
 				23F2C365244E44FA00FA4496 /* Tabs */,
 				D38F02D01C05127100175932 /* Authenticator.swift */,
@@ -5841,7 +5858,6 @@
 				C4E3983C1D21F1E7004E89BA /* TopTabsViews.swift */,
 				D3C744CC1A687D6C004CE85D /* URIFixup.swift */,
 				884CA7482344A301002E4711 /* TextContentDetector.swift */,
-				0BF0DB931A8545800039F300 /* URLBarView.swift */,
 				D0FCF7F41FE45842004A7995 /* UserScriptManager.swift */,
 				63306D3821103EAE00F25400 /* SavedTab.swift */,
 				1DA3CE6224EEE83200422BB2 /* SavedTab+ConfigureExtension.swift */,
@@ -5918,6 +5934,7 @@
 			isa = PBXGroup;
 			children = (
 				DFACDFAE274D4D6D00A94EEC /* ReusableCell.swift */,
+				8AE1E1D127B1ADC40024C45E /* TopBottomInterchangeable.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -8502,6 +8519,7 @@
 				96F627002669B0D100C82340 /* FxHomeRecentlySavedCollectionCell.swift in Sources */,
 				43446CEA2412066500F5C643 /* UIViewControllerExtension.swift in Sources */,
 				D301AAEE1A3A55B70078DD1D /* GridTabViewController.swift in Sources */,
+				8AE1E1D527B1AEED0024C45E /* TabLocationContainerView.swift in Sources */,
 				EB9A179B20E69A7F00B12184 /* LegacyThemeManager.swift in Sources */,
 				EBFDB790211C83A5005CCA2F /* BrowserViewController+FindInPage.swift in Sources */,
 				C8A012F126AB07D70096A7A7 /* FxHomeJumpBackInViewModel.swift in Sources */,
@@ -8571,6 +8589,7 @@
 				CA90753824929B22005B794D /* NoLoginsView.swift in Sources */,
 				E4B423BE1AB9FE6A007E66C8 /* ReaderModeCache.swift in Sources */,
 				396CDB55203C5B870034A3A3 /* TabTrayController+KeyCommands.swift in Sources */,
+				8AE1E1D727B1AF020024C45E /* ToolbarTextField.swift in Sources */,
 				74E36D781B71323500D69DA1 /* SettingsContentViewController.swift in Sources */,
 				EBB8950C21939E4100EB91A0 /* FirefoxTabContentBlocker.swift in Sources */,
 				43E69EC3254D081D00B591C2 /* SimpleTab.swift in Sources */,
@@ -8630,6 +8649,7 @@
 				C849E46326B9C3AF00260F0B /* EnhancedTrackingProtectionVM.swift in Sources */,
 				D0E55C4F1FB4FD23006DC274 /* FormPostHelper.swift in Sources */,
 				E650754E1E37F6AE006961AC /* GeometryExtensions.swift in Sources */,
+				8AE1E1D227B1ADC40024C45E /* TopBottomInterchangeable.swift in Sources */,
 				D3972BF41C22412B00035B87 /* TitleActivityItemProvider.swift in Sources */,
 				D38A1BEE1A9FA2CA00F6A386 /* SiteTableViewController.swift in Sources */,
 				7BA0601B1C0F4DE200DFADB6 /* TabPeekViewController.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -455,6 +455,8 @@
 		8ADED7EC27691351009C19E6 /* CalendarExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADED7EB27691351009C19E6 /* CalendarExtensionsTests.swift */; };
 		8ADED7EE276A7750009C19E6 /* CumulativeDaysOfUseCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADED7ED276A7750009C19E6 /* CumulativeDaysOfUseCounter.swift */; };
 		8ADED7F0276A7788009C19E6 /* CumulativeDaysOfUseCounterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADED7EF276A7788009C19E6 /* CumulativeDaysOfUseCounterTests.swift */; };
+		8AE1E1CB27B18F560024C45E /* SearchBarSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1E1CA27B18F560024C45E /* SearchBarSettingsViewController.swift */; };
+		8AE1E1CD27B191110024C45E /* SearchBarSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1E1CC27B191110024C45E /* SearchBarSettingsViewModel.swift */; };
 		8AED23C527AC1F9500DE7E97 /* BaseContentStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AED23C427AC1F9500DE7E97 /* BaseContentStackView.swift */; };
 		8AEE284B276A973400C7104D /* RatingPromptManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE284A276A973400C7104D /* RatingPromptManagerTests.swift */; };
 		8AEE62C92756BA34003207D1 /* LoginsHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 8AEE62C62756BA34003207D1 /* LoginsHelper.js */; };
@@ -2693,6 +2695,8 @@
 		8ADED7EB27691351009C19E6 /* CalendarExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarExtensionsTests.swift; sourceTree = "<group>"; };
 		8ADED7ED276A7750009C19E6 /* CumulativeDaysOfUseCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CumulativeDaysOfUseCounter.swift; sourceTree = "<group>"; };
 		8ADED7EF276A7788009C19E6 /* CumulativeDaysOfUseCounterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CumulativeDaysOfUseCounterTests.swift; sourceTree = "<group>"; };
+		8AE1E1CA27B18F560024C45E /* SearchBarSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarSettingsViewController.swift; sourceTree = "<group>"; };
+		8AE1E1CC27B191110024C45E /* SearchBarSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarSettingsViewModel.swift; sourceTree = "<group>"; };
 		8AED23C427AC1F9500DE7E97 /* BaseContentStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseContentStackView.swift; sourceTree = "<group>"; };
 		8AEE284A276A973400C7104D /* RatingPromptManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingPromptManagerTests.swift; sourceTree = "<group>"; };
 		8AEE62C62756BA34003207D1 /* LoginsHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = LoginsHelper.js; path = AllFrames/AtDocumentStart/LoginsHelper.js; sourceTree = "<group>"; };
@@ -4861,6 +4865,7 @@
 				F85C7F0D2711C555004BDBA4 /* SettingsViewController.swift */,
 				D821E9052141B71C00452C55 /* SiriSettingsViewController.swift */,
 				CEFA977D1FAA6B490016F365 /* SyncContentSettingsViewController.swift */,
+				8AE1E1CE27B191160024C45E /* SearchBar */,
 				EB9A178D20E525DF00B12184 /* ThemeSettingsController.swift */,
 				66CE54A720FCF6CF00CC310B /* WebsiteDataManagementViewController.swift */,
 				6669B5E1211418A200CA117B /* WebsiteDataSearchResultsViewController.swift */,
@@ -5311,6 +5316,15 @@
 				7B42406D1CA04CAC009B5C28 /* Menu.xcassets */,
 			);
 			path = Menu;
+			sourceTree = "<group>";
+		};
+		8AE1E1CE27B191160024C45E /* SearchBar */ = {
+			isa = PBXGroup;
+			children = (
+				8AE1E1CA27B18F560024C45E /* SearchBarSettingsViewController.swift */,
+				8AE1E1CC27B191110024C45E /* SearchBarSettingsViewModel.swift */,
+			);
+			path = SearchBar;
 			sourceTree = "<group>";
 		};
 		8AED23C327AC1F8700DE7E97 /* Components */ = {
@@ -8591,6 +8605,7 @@
 				43AB6FA425DC53D30016B015 /* ASHeaderView.swift in Sources */,
 				C8163851268A0899004C7160 /* AddCredentialViewController.swift in Sources */,
 				CA520E7A24913C1B00CCAB48 /* LoginListViewModel.swift in Sources */,
+				8AE1E1CD27B191110024C45E /* SearchBarSettingsViewModel.swift in Sources */,
 				E65075521E37F6D1006961AC /* UIViewExtensions.swift in Sources */,
 				8A01891C275E9C2A00923EFE /* ClearHistoryHelper.swift in Sources */,
 				C8F457A81F1FD75A000CB895 /* BrowserViewController+WebViewDelegates.swift in Sources */,
@@ -8744,6 +8759,7 @@
 				437A9B682681256800FB41C1 /* InactiveTabCell.swift in Sources */,
 				439B008B26E6CE2300DFAF14 /* GroupedTabCell.swift in Sources */,
 				E4C358551AF144BA00299F7E /* FSReadingList.m in Sources */,
+				8AE1E1CB27B18F560024C45E /* SearchBarSettingsViewController.swift in Sources */,
 				9609F4CA26B57CE800F81493 /* CalendarExtensions.swift in Sources */,
 				E663D5781BB341C4001EF30E /* ToggleButton.swift in Sources */,
 				EBA3B2D22268F57E00728BDB /* BadgeIcon.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -460,6 +460,8 @@
 		8AE1E1D227B1ADC40024C45E /* TopBottomInterchangeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1E1D127B1ADC40024C45E /* TopBottomInterchangeable.swift */; };
 		8AE1E1D527B1AEED0024C45E /* TabLocationContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1E1D427B1AEED0024C45E /* TabLocationContainerView.swift */; };
 		8AE1E1D727B1AF020024C45E /* ToolbarTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1E1D627B1AF020024C45E /* ToolbarTextField.swift */; };
+		8AE1E1D927B1BD380024C45E /* UIStackViewExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1E1D827B1BD380024C45E /* UIStackViewExtensionsTests.swift */; };
+		8AE1E1DB27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1E1DA27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift */; };
 		8AED23C527AC1F9500DE7E97 /* BaseContentStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AED23C427AC1F9500DE7E97 /* BaseContentStackView.swift */; };
 		8AEE284B276A973400C7104D /* RatingPromptManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE284A276A973400C7104D /* RatingPromptManagerTests.swift */; };
 		8AEE62C92756BA34003207D1 /* LoginsHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 8AEE62C62756BA34003207D1 /* LoginsHelper.js */; };
@@ -2703,6 +2705,8 @@
 		8AE1E1D127B1ADC40024C45E /* TopBottomInterchangeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBottomInterchangeable.swift; sourceTree = "<group>"; };
 		8AE1E1D427B1AEED0024C45E /* TabLocationContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabLocationContainerView.swift; sourceTree = "<group>"; };
 		8AE1E1D627B1AF020024C45E /* ToolbarTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarTextField.swift; sourceTree = "<group>"; };
+		8AE1E1D827B1BD380024C45E /* UIStackViewExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStackViewExtensionsTests.swift; sourceTree = "<group>"; };
+		8AE1E1DA27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarSettingsViewModelTests.swift; sourceTree = "<group>"; };
 		8AED23C427AC1F9500DE7E97 /* BaseContentStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseContentStackView.swift; sourceTree = "<group>"; };
 		8AEE284A276A973400C7104D /* RatingPromptManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingPromptManagerTests.swift; sourceTree = "<group>"; };
 		8AEE62C62756BA34003207D1 /* LoginsHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = LoginsHelper.js; path = AllFrames/AtDocumentStart/LoginsHelper.js; sourceTree = "<group>"; };
@@ -6483,6 +6487,7 @@
 				D82ED2631FEB3C420059570B /* DefaultSearchPrefsTests.swift */,
 				8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */,
 				E60D03291D5118DB002FE3F6 /* SyncStatusResolverTests.swift */,
+				8AE1E1DA27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift */,
 				7BBFEE731BB405D900A305AA /* TabManagerTests.swift */,
 				8A8A05E32746ACAC004267A0 /* TabDisplayManagerTests.swift */,
 				0BA8964A1A250E6500C1010C /* TestBookmarks.swift */,
@@ -6491,6 +6496,7 @@
 				4A59BF410BBD9B3BE71F4C7C /* TestHistory.swift */,
 				A83E5B1C1C1DA8D80026D912 /* UIPasteboardExtensionsTests.swift */,
 				3BFCBF1F1E04B1C50070C042 /* UIImageViewExtensionsTests.swift */,
+				8AE1E1D827B1BD380024C45E /* UIStackViewExtensionsTests.swift */,
 				E4CD9F1C1A6D9C2800318571 /* WebServerTests.swift */,
 				D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */,
 				F84B21D71A090F8100AAB793 /* Supporting Files */,
@@ -8847,6 +8853,7 @@
 				D8BA1790206D47830023AC00 /* DeferredTestUtils.swift in Sources */,
 				2F13E79B1AC0C02700D75081 /* StringExtensionsTests.swift in Sources */,
 				CA24B52224ABD7D40093848C /* LoginsListViewModelTests.swift in Sources */,
+				8AE1E1DB27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift in Sources */,
 				CA24B53924ABFE250093848C /* LoginsListSelectionHelperTests.swift in Sources */,
 				2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */,
 				D525DFB325FBE5E000B18763 /* TabTests.swift in Sources */,
@@ -8864,6 +8871,7 @@
 				CA24B53B24ABFE5D0093848C /* LoginsListDataSourceHelperTests.swift in Sources */,
 				3B61CD591F2A750800D38DE1 /* PocketFeedTests.swift in Sources */,
 				43446CF02412DDBE00F5C643 /* UpdateCoverSheetViewModelTests.swift in Sources */,
+				8AE1E1D927B1BD380024C45E /* UIStackViewExtensionsTests.swift in Sources */,
 				3B6F40181DC7849C00656CC6 /* FirefoxHomeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -441,6 +441,7 @@
 		8A11C8132731E54800AC7318 /* DictionaryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */; };
 		8A2783F1275FFDC50080D29D /* KeyboardPressesHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2783F0275FFDC50080D29D /* KeyboardPressesHandler.swift */; };
 		8A2825352760399B00395E66 /* KeyboardPressesHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2825342760399B00395E66 /* KeyboardPressesHandlerTests.swift */; };
+		8A57519927AD80B800A84DBF /* ReaderModeStyleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A57519827AD80B800A84DBF /* ReaderModeStyleViewModel.swift */; };
 		8A86DAD8277298DE00D7BFFF /* ClosedTabsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A86DAD7277298DE00D7BFFF /* ClosedTabsStoreTests.swift */; };
 		8A8A05E42746ACAC004267A0 /* TabDisplayManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8A05E32746ACAC004267A0 /* TabDisplayManagerTests.swift */; };
 		8A8DDEBF276259A900E7B97A /* RatingPromptManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8DDEBE276259A900E7B97A /* RatingPromptManager.swift */; };
@@ -2675,6 +2676,7 @@
 		8A2783F0275FFDC50080D29D /* KeyboardPressesHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPressesHandler.swift; sourceTree = "<group>"; };
 		8A2825342760399B00395E66 /* KeyboardPressesHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPressesHandlerTests.swift; sourceTree = "<group>"; };
 		8A5143D6BF179870414566ED /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Search.strings; sourceTree = "<group>"; };
+		8A57519827AD80B800A84DBF /* ReaderModeStyleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeStyleViewModel.swift; sourceTree = "<group>"; };
 		8A86DAD7277298DE00D7BFFF /* ClosedTabsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedTabsStoreTests.swift; sourceTree = "<group>"; };
 		8A8A05E32746ACAC004267A0 /* TabDisplayManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDisplayManagerTests.swift; sourceTree = "<group>"; };
 		8A8DDEBE276259A900E7B97A /* RatingPromptManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingPromptManager.swift; sourceTree = "<group>"; };
@@ -5797,7 +5799,6 @@
 				FA6B2AC11D41F02D00429414 /* Punycode.swift */,
 				FA9294001D6584A200AC8D33 /* QRCode.xcassets */,
 				FA9293D31D6580E100AC8D33 /* QRCodeViewController.swift */,
-				E47616C61AB74CA600E7DD25 /* ReaderModeBarView.swift */,
 				D31F95E81AC226CB005C9F3B /* ScreenshotHelper.swift */,
 				D308E4E31A5306F500842685 /* SearchEngines.swift */,
 				DDA24A341FD84D620098F159 /* DefaultSearchPrefs.swift */,
@@ -6570,6 +6571,7 @@
 		F84B21F51A0910F600AAB793 /* Reader */ = {
 			isa = PBXGroup;
 			children = (
+				E47616C61AB74CA600E7DD25 /* ReaderModeBarView.swift */,
 				E4CD9E901A6897FB00318571 /* ReaderMode.swift */,
 				E4A960051ABB9C450069AD6F /* ReaderModeUtils.swift */,
 				E4B423BD1AB9FE6A007E66C8 /* ReaderModeCache.swift */,
@@ -6577,6 +6579,7 @@
 				E4CD9F531A71506400318571 /* Reader.html */,
 				E4CD9F5A1A71506C00318571 /* Reader.css */,
 				E4CD9F6C1A77DD2800318571 /* ReaderModeStyleViewController.swift */,
+				8A57519827AD80B800A84DBF /* ReaderModeStyleViewModel.swift */,
 				E4A961171AC041C40069AD6F /* ReadabilityService.swift */,
 				E4A961371AC06FA50069AD6F /* ReaderViewLoading.html */,
 				E4C358541AF144BA00299F7E /* FSReadingList.m */,
@@ -8604,6 +8607,7 @@
 				4345441D26D2E52600D5EEAA /* SearchTermGroupsManager.swift in Sources */,
 				EBA3B2D02268F40C00728BDB /* SyncMenuButton.swift in Sources */,
 				D31A0FC71A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */,
+				8A57519927AD80B800A84DBF /* ReaderModeStyleViewModel.swift in Sources */,
 				435D7CC5246209AA0043ACB9 /* IntroViewController.swift in Sources */,
 				CA4ACE4924C8C91600F55894 /* BreachAlertsDetailView.swift in Sources */,
 				A83E5AB71C1D993D0026D912 /* UIPasteboardExtensions.swift in Sources */,

--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -95,5 +95,11 @@ public struct AccessibilityIdentifiers {
         struct ClearData {
             static let clearPrivatedata = "ClearPrivateData"
         }
+
+        struct SearchBar {
+            static let searchBarSetting = "SearchBarSetting"
+            static let topSetting = "TopSearchBar"
+            static let bottomSetting = "BottomSearchBar"
+        }
     }
 }

--- a/Client/FeatureFlags/FeatureFlagsManager.swift
+++ b/Client/FeatureFlags/FeatureFlagsManager.swift
@@ -31,6 +31,7 @@ enum FeatureFlagName: String, CaseIterable {
     case startAtHome
     case reportSiteIssue
     case adjustEnvironmentProd
+    case bottomSearchBar
 }
 
 /// Manages feature flags for the application.
@@ -189,5 +190,10 @@ class FeatureFlagsManager {
                                                      and: profile,
                                                      enabledFor: [.release])
         features[.adjustEnvironmentProd] = adjustEnvironmentProd
+
+        let bottomSearchBar = FlaggableFeature(withID: .bottomSearchBar,
+                                               and: profile,
+                                               enabledFor: [.release, .beta, .developer])
+        features[.bottomSearchBar] = bottomSearchBar
     }
 }

--- a/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -75,7 +75,10 @@ class BackForwardListViewController: UIViewController, UITableViewDataSource, UI
         super.viewDidLoad()
         view.addSubview(shadow)
         view.addSubview(tableView)
-        snappedToBottom = bvc?.shouldShowToolbarForTraitCollection(traitCollection) ?? false
+
+        let toolBarShouldShow = bvc?.shouldShowToolbarForTraitCollection(traitCollection) ?? false
+        let isBottomSearchBar = bvc?.isBottomSearchBar ?? false
+        snappedToBottom = toolBarShouldShow || isBottomSearchBar
 
         tableView.snp.makeConstraints { make in
             make.height.equalTo(0)
@@ -150,7 +153,7 @@ class BackForwardListViewController: UIViewController, UITableViewDataSource, UI
         guard let bvc = self.bvc else {
             return
         }
-        if bvc.shouldShowToolbarForTraitCollection(newCollection) != snappedToBottom {
+        if bvc.shouldShowToolbarForTraitCollection(newCollection) != snappedToBottom, !bvc.isBottomSearchBar {
             tableView.snp.updateConstraints { make in
                 if snappedToBottom {
                     make.bottom.equalTo(self.view).offset(0)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -614,43 +614,43 @@ class BrowserViewController: UIViewController {
             make.bottom.equalTo(footer.snp.top)
         }
 
-        bottomContentStackView.snp.remakeConstraints  { make in
-            adjustBottomContentStackView(make)
+        bottomContentStackView.snp.remakeConstraints { remake in
+            adjustBottomContentStackView(remake)
         }
 
         adjustBottomSearchBarForKeyboard()
     }
 
-    private func adjustBottomContentStackView(_ make: ConstraintMaker) {
-        make.left.right.equalTo(view)
-        make.centerX.equalTo(view)
-        make.width.equalTo(view.safeArea.width)
+    private func adjustBottomContentStackView(_ remake: ConstraintMaker) {
+        remake.left.right.equalTo(view)
+        remake.centerX.equalTo(view)
+        remake.width.equalTo(view.safeArea.width)
 
         // Height is set by content - this removes run time error
-        make.height.greaterThanOrEqualTo(0)
+        remake.height.greaterThanOrEqualTo(0)
         bottomContentStackView.setContentHuggingPriority(.defaultHigh, for: .vertical)
 
         if isBottomSearchBar {
-            adjustBottomContentBottomSearchBar(make)
+            adjustBottomContentBottomSearchBar(remake)
         } else {
-            adjustBottomContentTopSearchBar(make)
+            adjustBottomContentTopSearchBar(remake)
         }
     }
 
-    private func adjustBottomContentTopSearchBar(_ make: ConstraintMaker) {
+    private func adjustBottomContentTopSearchBar(_ remake: ConstraintMaker) {
         if let keyboardHeight = keyboardState?.intersectionHeightForView(view), keyboardHeight > 0 {
-            make.bottom.equalTo(view).offset(-keyboardHeight)
+            remake.bottom.equalTo(view).offset(-keyboardHeight)
         } else if !toolbar.isHidden {
-            make.bottom.lessThanOrEqualTo(footer.snp.top)
-            make.bottom.lessThanOrEqualTo(view.safeArea.bottom)
+            remake.bottom.lessThanOrEqualTo(footer.snp.top)
+            remake.bottom.lessThanOrEqualTo(view.safeArea.bottom)
         } else {
-            make.bottom.equalTo(view.safeArea.bottom)
+            remake.bottom.equalTo(view.safeArea.bottom)
         }
     }
 
-    private func adjustBottomContentBottomSearchBar(_ make: ConstraintMaker) {
-        make.bottom.lessThanOrEqualTo(footer.snp.top)
-        make.bottom.lessThanOrEqualTo(view.safeArea.bottom)
+    private func adjustBottomContentBottomSearchBar(_ remake: ConstraintMaker) {
+        remake.bottom.lessThanOrEqualTo(footer.snp.top)
+        remake.bottom.lessThanOrEqualTo(view.safeArea.bottom)
     }
 
     private func adjustBottomSearchBarForKeyboard() {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -441,6 +441,7 @@ class BrowserViewController: UIViewController {
         view.addSubview(footer)
 
         // Laurie - Remove, used to debug
+        statusBarOverlay.accessibilityLabel = "OVERLAY"
         header.accessibilityLabel = "HEADER"
         footer.accessibilityLabel = "FOOTER"
         bottomContentStackView.accessibilityLabel = "ALERT STACKVIEW"
@@ -548,7 +549,8 @@ class BrowserViewController: UIViewController {
         header.snp.makeConstraints { make in
             if isBottomSearchBar {
                 make.left.right.top.equalTo(self.view)
-                make.height.equalTo(0) // Setting to 0 since no content will be added to the top
+                // Making sure we cover at least the status bar
+                make.bottom.equalTo(self.view.safeArea.top)
             } else {
                 scrollController.headerTopConstraint = make.top.equalTo(self.view.safeArea.top).constraint
                 make.left.right.equalTo(self.view)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -885,7 +885,8 @@ class BrowserViewController: UIViewController {
         }
 
         let isPrivate = tabManager.selectedTab?.isPrivate ?? false
-        let searchController = SearchViewController(profile: profile, isPrivate: isPrivate, tabManager: tabManager)
+        let searchViewModel = SearchViewModel(isPrivate: isPrivate, isBottomSearchBar: isBottomSearchBar)
+        let searchController = SearchViewController(profile: profile, viewModel: searchViewModel, tabManager: tabManager)
         searchController.searchEngines = profile.searchEngines
         searchController.searchDelegate = self
 
@@ -907,14 +908,10 @@ class BrowserViewController: UIViewController {
         view.addSubview(searchController.view)
         searchController.view.snp.makeConstraints { make in
             make.top.equalTo(header.snp.bottom)
-            make.left.right.bottom.equalTo(view)
-            // TODO: Laurie - make it possible for search bar
-//            make.left.right.equalTo(view)
+            make.left.right.equalTo(view)
 
-//            // Account for search bar if at bottom
-//            let urlBarHeight = urlBarHeightConstraintValue ?? 0
-//            let offSet = isBottomSearchBar ? urlBarHeight : 0
-//            make.bottom.equalTo(view).offset(-offSet)
+            let constraintTarget = isBottomSearchBar ? footer.snp.top : view.snp.bottom
+            make.bottom.equalTo(constraintTarget)
         }
 
         firefoxHomeViewController?.view?.isHidden = true

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -612,6 +612,14 @@ class BrowserViewController: UIViewController {
         make.height.greaterThanOrEqualTo(0)
         bottomContentStackView.setContentHuggingPriority(.defaultHigh, for: .vertical)
 
+        if isBottomSearchBar {
+            adjustBottomContentBottomSearchBar(make)
+        } else {
+            adjustBottomContentTopSearchBar(make)
+        }
+    }
+
+    private func adjustBottomContentTopSearchBar(_ make: ConstraintMaker) {
         if let keyboardHeight = keyboardState?.intersectionHeightForView(view), keyboardHeight > 0 {
             let searchBarAdjustment = isBottomSearchBar ? urlBarHeightConstraintValue ?? 0 : 0
             make.bottom.equalTo(view).offset(-keyboardHeight - searchBarAdjustment)
@@ -621,6 +629,11 @@ class BrowserViewController: UIViewController {
         } else {
             make.bottom.equalTo(view.safeArea.bottom)
         }
+    }
+
+    private func adjustBottomContentBottomSearchBar(_ make: ConstraintMaker) {
+        make.bottom.lessThanOrEqualTo(footer.snp.top)
+        make.bottom.lessThanOrEqualTo(view.safeArea.bottom)
     }
 
     private func adjustBottomSearchBarForKeyboard() {
@@ -633,7 +646,8 @@ class BrowserViewController: UIViewController {
         let showToolBar = shouldShowToolbarForTraitCollection(traitCollection)
         let toolBarHeight = showToolBar ? UIConstants.BottomToolbarHeight : 0
         let spacerHeight = keyboardHeight - toolBarHeight
-        footer.addKeyboardSpacer(at: 1, spacerHeight: spacerHeight)
+        let index = readerModeBar == nil ? 1 : 2
+        footer.addKeyboardSpacer(at: index, spacerHeight: spacerHeight)
     }
 
     /// Used for dynamic type height adjustment

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -591,7 +591,7 @@ class BrowserViewController: UIViewController {
             if let keyboardHeight = keyboardState?.intersectionHeightForView(view), keyboardHeight > 0 {
                 make.bottom.equalTo(view).offset(-keyboardHeight)
             } else if !toolbar.isHidden {
-                make.bottom.lessThanOrEqualTo(toolbar.snp.top)
+                make.bottom.lessThanOrEqualTo(footer.snp.top)
                 make.bottom.lessThanOrEqualTo(view.safeArea.bottom)
             } else {
                 make.bottom.equalTo(view.safeArea.bottom)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -630,7 +630,9 @@ class BrowserViewController: UIViewController {
             return
         }
 
-        let spacerHeight = keyboardHeight - UIConstants.BottomToolbarHeight
+        let showToolBar = shouldShowToolbarForTraitCollection(traitCollection)
+        let toolBarHeight = showToolBar ? UIConstants.BottomToolbarHeight : 0
+        let spacerHeight = keyboardHeight - toolBarHeight
         footer.addSpacer(at: 1, spacerHeight: spacerHeight)
     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -209,7 +209,7 @@ class BrowserViewController: UIViewController {
         toolbar.warningMenuBadge(setVisible: showWarningBadge)
     }
 
-    let isBottomSearchBar = false // TODO: #9419 Laurie - This will be a setting, only available to iPhone
+    let isBottomSearchBar = true // TODO: #9419 Laurie - This will be a setting, only available to iPhone
     func updateToolbarStateForTraitCollection(_ newCollection: UITraitCollection) {
         let showToolbar = shouldShowToolbarForTraitCollection(newCollection)
         let showTopTabs = shouldShowTopTabsForTraitCollection(newCollection)
@@ -626,21 +626,32 @@ class BrowserViewController: UIViewController {
     private func adjustBottomSearchBarForKeyboard() {
         guard isBottomSearchBar else { return }
         guard let keyboardHeight = keyboardState?.intersectionHeightForView(view), keyboardHeight > 0 else {
-            footer.removeSpacer()
+            footer.removeKeyboardSpacer()
             return
         }
 
         let showToolBar = shouldShowToolbarForTraitCollection(traitCollection)
         let toolBarHeight = showToolBar ? UIConstants.BottomToolbarHeight : 0
         let spacerHeight = keyboardHeight - toolBarHeight
-        footer.addSpacer(at: 1, spacerHeight: spacerHeight)
+        footer.addKeyboardSpacer(at: 1, spacerHeight: spacerHeight)
     }
 
+    /// Used for dynamic type height adjustment
     private func adjustURLBarHeightBasedOnLocationViewHeight() {
         // Make sure that we have a height to actually base our calculations on
         guard urlBar.locationContainer.bounds.height != 0 else { return }
         let locationViewHeight = urlBar.locationView.bounds.height
         let heightWithPadding = locationViewHeight + 10
+
+        // Adjustment for landscape on the urlbar
+        // need to account for inset and remove it when keyboard is showing
+        let showToolBar = shouldShowToolbarForTraitCollection(traitCollection)
+        let isKeyboardShowing = keyboardState != nil
+        if !showToolBar && isBottomSearchBar && !isKeyboardShowing {
+            footer.addBottomInsetSpacer(spacerHeight: UIConstants.BottomInset)
+        } else {
+            footer.removeBottomInsetSpacer()
+        }
 
         // We have to deactivate the original constraint, and remake the constraint
         // or else funky conflicts happen

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -189,7 +189,8 @@ class BrowserViewController: UIViewController {
 
     @objc func searchBarPositionDidChange(notification: Notification) {
         guard let dict = notification.object as? NSDictionary,
-              let newSearchBarPosition = dict[PrefsKeys.KeySearchBarPosition] as? SearchBarPosition else { return }
+              let newSearchBarPosition = dict[PrefsKeys.KeySearchBarPosition] as? SearchBarPosition,
+              urlBar != nil else { return }
 
         let newParent = newSearchBarPosition == .bottom ? footer : header
         urlBar.removeFromParent()

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -846,35 +846,30 @@ class BrowserViewController: UIViewController {
 
     func updateInContentHomePanel(_ url: URL?, focusUrlBar: Bool = false) {
         let isAboutHomeURL = url.flatMap { InternalURL($0)?.isAboutHomeURL } ?? false
-        if !urlBar.inOverlayMode {
-            guard let url = url else {
-                hideFirefoxHome()
-                urlBar.locationView.reloadButton.reloadButtonState = .disabled
-                return
-            }
+        guard let url = url else {
+            hideFirefoxHome()
+            urlBar.locationView.reloadButton.reloadButtonState = .disabled
+            return
+        }
 
-            if isAboutHomeURL {
-                showFirefoxHome(inline: true)
+        if isAboutHomeURL {
+            showFirefoxHome(inline: true)
 
-                if focusUrlBar {
-                    if let viewcontroller = presentedViewController as? OnViewDismissable {
-                        viewcontroller.onViewDismissed = { [weak self] in
-                            let shouldEnterOverlay = self?.tabManager.selectedTab?.url.flatMap { InternalURL($0)?.isAboutHomeURL } ?? false
-                            if shouldEnterOverlay {
-                                self?.urlBar.enterOverlayMode(nil, pasted: false, search: false)
-                            }
+            if focusUrlBar {
+                if let viewcontroller = presentedViewController as? OnViewDismissable {
+                    viewcontroller.onViewDismissed = { [weak self] in
+                        let shouldEnterOverlay = self?.tabManager.selectedTab?.url.flatMap { InternalURL($0)?.isAboutHomeURL } ?? false
+                        if shouldEnterOverlay {
+                            self?.urlBar.enterOverlayMode(nil, pasted: false, search: false)
                         }
-                    } else {
-                        self.urlBar.enterOverlayMode(nil, pasted: false, search: false)
                     }
+                } else {
+                    self.urlBar.enterOverlayMode(nil, pasted: false, search: false)
                 }
-            } else if !url.absoluteString.hasPrefix("\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)") {
-                hideFirefoxHome()
-                urlBar.shouldHideReloadButton(false)
             }
-
-        } else if isAboutHomeURL {
-            showFirefoxHome(inline: false)
+        } else if !url.absoluteString.hasPrefix("\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)") {
+            hideFirefoxHome()
+            urlBar.shouldHideReloadButton(false)
         }
 
         if UIDevice.current.userInterfaceIdiom == .pad {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -94,10 +94,10 @@ class BrowserViewController: UIViewController {
     var header: BaseAlphaStackView = .build { _ in }
     var footer: BaseAlphaStackView = .build { _ in }
 
-    var isBottomSearchBar: Bool {
-        guard SearchBarSettingsViewModel.isEnabled else { return false}
+    lazy var isBottomSearchBar: Bool = {
+        guard SearchBarSettingsViewModel.isEnabled else { return false }
         return SearchBarSettingsViewModel(prefs: profile.prefs).searchBarPosition == .bottom
-    }
+    }()
 
     // Alert content that appears on top of the footer should be added to this view.
     // ex: Find In Page, SnackBars
@@ -192,7 +192,8 @@ class BrowserViewController: UIViewController {
               let newSearchBarPosition = dict[PrefsKeys.KeySearchBarPosition] as? SearchBarPosition,
               urlBar != nil else { return }
 
-        let newParent = newSearchBarPosition == .bottom ? footer : header
+        let newPositionIsBottom = newSearchBarPosition == .bottom
+        let newParent = newPositionIsBottom ? footer : header
         urlBar.removeFromParent()
         urlBar.addToParent(parent: newParent)
 
@@ -201,6 +202,7 @@ class BrowserViewController: UIViewController {
             readerModeBar.addToParent(parent: newParent, addToTop: newSearchBarPosition == .bottom)
         }
 
+        isBottomSearchBar = newPositionIsBottom
         updateViewConstraints()
         toolbar.setNeedsDisplay()
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -805,6 +805,10 @@ class BrowserViewController: UIViewController {
             firefoxHomeViewController.didMove(toParent: self)
         }
 
+        if self.readerModeBar != nil {
+            hideReaderModeBar(animated: false)
+        }
+
         firefoxHomeViewController?.applyTheme()
 
         // We have to run this animation, even if the view is already showing

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -70,9 +70,9 @@ extension BrowserViewController {
             readerModeBar.isBottomPresented = isBottomSearchBar
             readerModeBar.delegate = self
             if isBottomSearchBar {
-                footer.addArrangedViewToTop(readerModeBar, completion: {})
+                footer.addArrangedViewToTop(readerModeBar)
             } else {
-                header.addArrangedViewToBottom(readerModeBar, completion: {})
+                header.addArrangedViewToBottom(readerModeBar)
             }
 
             self.readerModeBar = readerModeBar
@@ -177,7 +177,6 @@ extension BrowserViewController: ReaderModeBarViewDelegate {
                 readerModeStyle = style
             }
 
-            // TODO: Laurie - isBottomPresented
             let readerModeViewModel = ReaderModeStyleViewModel(isBottomPresented: isBottomSearchBar,
                                                                readerModeStyle: readerModeStyle)
             let readerModeStyleViewController = ReaderModeStyleViewController.initReaderModeViewController(viewModel: readerModeViewModel)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -53,7 +53,6 @@ extension BrowserViewController: ReaderModeStyleViewControllerDelegate {
     }
 }
 
-// Laurie - dummy change to retrigger BR - to remove
 extension BrowserViewController {
     func updateReaderModeBar() {
         guard let readerModeBar = readerModeBar else { return }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -85,7 +85,11 @@ extension BrowserViewController {
 
     func hideReaderModeBar(animated: Bool) {
         guard let readerModeBar = readerModeBar else { return }
-        header.removeArrangedView(readerModeBar)
+        if isBottomSearchBar {
+            footer.removeArrangedView(readerModeBar)
+        } else {
+            header.removeArrangedView(readerModeBar)
+        }
         self.readerModeBar = nil
         updateViewConstraints()
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -67,8 +67,14 @@ extension BrowserViewController {
     func showReaderModeBar(animated: Bool) {
         if self.readerModeBar == nil {
             let readerModeBar = ReaderModeBarView(frame: CGRect.zero)
+            readerModeBar.isBottomPresented = isBottomSearchBar
             readerModeBar.delegate = self
-            header.addArrangedViewToBottom(readerModeBar, completion: {})
+            if isBottomSearchBar {
+                footer.addArrangedViewToTop(readerModeBar, completion: {})
+            } else {
+                header.addArrangedViewToBottom(readerModeBar, completion: {})
+            }
+
             self.readerModeBar = readerModeBar
         }
 
@@ -171,19 +177,25 @@ extension BrowserViewController: ReaderModeBarViewDelegate {
                 readerModeStyle = style
             }
 
-            let readerModeStyleViewController = ReaderModeStyleViewController()
+            // TODO: Laurie - isBottomPresented
+            let readerModeViewModel = ReaderModeStyleViewModel(isBottomPresented: isBottomSearchBar,
+                                                               readerModeStyle: readerModeStyle)
+            let readerModeStyleViewController = ReaderModeStyleViewController.initReaderModeViewController(viewModel: readerModeViewModel)
             readerModeStyleViewController.delegate = self
-            readerModeStyleViewController.readerModeStyle = readerModeStyle
             readerModeStyleViewController.modalPresentationStyle = .popover
 
             let setupPopover = { [unowned self] in
                 guard let popoverPresentationController = readerModeStyleViewController.popoverPresentationController else { return }
 
+                let arrowDirection: UIPopoverArrowDirection = isBottomSearchBar ? .down : .up
+                let ySpacing = isBottomSearchBar ? -1 : UIConstants.ToolbarHeight
+
                 popoverPresentationController.backgroundColor = UIColor.Photon.White100
                 popoverPresentationController.delegate = self
                 popoverPresentationController.sourceView = readerModeBar
-                popoverPresentationController.sourceRect = CGRect(x: readerModeBar.frame.width/2, y: UIConstants.ToolbarHeight, width: 1, height: 1)
-                popoverPresentationController.permittedArrowDirections = .up
+                popoverPresentationController.sourceRect = CGRect(x: readerModeBar.frame.width/2, y: ySpacing,
+                                                                  width: 1, height: 1)
+                popoverPresentationController.permittedArrowDirections = arrowDirection
             }
 
             setupPopover()

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -105,7 +105,8 @@ extension BrowserViewController {
         let backList = webView.backForwardList.backList
         let forwardList = webView.backForwardList.forwardList
 
-        guard let currentURL = webView.backForwardList.currentItem?.url, let readerModeURL = currentURL.encodeReaderModeURL(WebServer.sharedInstance.baseReaderModeURL()) else { return }
+        guard let currentURL = webView.backForwardList.currentItem?.url,
+                let readerModeURL = currentURL.encodeReaderModeURL(WebServer.sharedInstance.baseReaderModeURL()) else { return }
 
         if backList.count > 1 && backList.last?.url == readerModeURL {
             webView.go(to: backList.last!)
@@ -144,7 +145,7 @@ extension BrowserViewController {
         } else if forwardList.count > 0 && forwardList.first?.url == originalURL {
             webView.go(to: forwardList.first!)
         } else if let nav = webView.load(URLRequest(url: originalURL)) {
-            self.ignoreNavigationInTab(tab, navigation: nav)
+            ignoreNavigationInTab(tab, navigation: nav)
         }
     }
 
@@ -156,10 +157,11 @@ extension BrowserViewController {
            let style = ReaderModeStyle(dict: dict as [String: AnyObject]) {
             readerModeStyle = style
         }
+
         readerModeStyle.fontSize = ReaderModeFontSize.defaultSize
-        self.readerModeStyleViewController(ReaderModeStyleViewController(),
-                                           didConfigureStyle: readerModeStyle,
-                                           isUsingUserDefinedColor: false)
+        readerModeStyleViewController(ReaderModeStyleViewController(),
+                                      didConfigureStyle: readerModeStyle,
+                                      isUsingUserDefinedColor: false)
     }
     
     func appyThemeForPreferences(_ preferences: Prefs, contentScript: TabContentScript) {
@@ -173,7 +175,8 @@ extension BrowserViewController: ReaderModeBarViewDelegate {
 
         switch buttonType {
         case .settings:
-            guard let readerMode = tabManager.selectedTab?.getContentScript(name: "ReaderMode") as? ReaderMode, readerMode.state == ReaderModeState.active else { return }
+            guard let readerMode = tabManager.selectedTab?.getContentScript(name: "ReaderMode") as? ReaderMode,
+                    readerMode.state == ReaderModeState.active else { break }
 
             var readerModeStyle = DefaultReaderModeStyle
             if let dict = profile.prefs.dictionaryForKey(ReaderModeProfileKeyStyle),
@@ -208,17 +211,18 @@ extension BrowserViewController: ReaderModeBarViewDelegate {
                 updateDisplayedPopoverProperties = setupPopover
             }
 
-            self.present(readerModeStyleViewController, animated: true, completion: nil)
+            present(readerModeStyleViewController, animated: true, completion: nil)
 
         case .markAsRead:
             guard let url = self.tabManager.selectedTab?.url?.displayURL?.absoluteString,
-                  let record = profile.readingList.getRecordWithURL(url).value.successValue else { return }
+                  let record = profile.readingList.getRecordWithURL(url).value.successValue else { break }
 
             profile.readingList.updateRecord(record, unread: false) // TODO Check result, can this fail?
             readerModeBar.unread = false
 
         case .markAsUnread:
-            guard let url = self.tabManager.selectedTab?.url?.displayURL?.absoluteString, let record = profile.readingList.getRecordWithURL(url).value.successValue else { return }
+            guard let url = self.tabManager.selectedTab?.url?.displayURL?.absoluteString,
+                    let record = profile.readingList.getRecordWithURL(url).value.successValue else { break }
 
             profile.readingList.updateRecord(record, unread: true) // TODO Check result, can this fail?
             readerModeBar.unread = true
@@ -226,7 +230,7 @@ extension BrowserViewController: ReaderModeBarViewDelegate {
         case .addToReadingList:
             guard let tab = tabManager.selectedTab,
                   let rawURL = tab.url, rawURL.isReaderModeURL,
-                  let url = rawURL.decodeReaderModeURL else { return }
+                  let url = rawURL.decodeReaderModeURL else { break }
 
             profile.readingList.createRecordWithURL(url.absoluteString,
                                                     title: tab.title ?? "",
@@ -236,7 +240,7 @@ extension BrowserViewController: ReaderModeBarViewDelegate {
 
         case .removeFromReadingList:
             guard let url = self.tabManager.selectedTab?.url?.displayURL?.absoluteString,
-                  let record = profile.readingList.getRecordWithURL(url).value.successValue else { return }
+                  let record = profile.readingList.getRecordWithURL(url).value.successValue else { break }
 
             profile.readingList.deleteRecord(record) // TODO Check result, can this fail?
             readerModeBar.added = false

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -71,7 +71,6 @@ extension BrowserViewController {
     func showReaderModeBar(animated: Bool) {
         if self.readerModeBar == nil {
             let readerModeBar = ReaderModeBarView(frame: CGRect.zero)
-            readerModeBar.isBottomPresented = isBottomSearchBar
             readerModeBar.delegate = self
             if isBottomSearchBar {
                 footer.addArrangedViewToTop(readerModeBar)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -14,8 +14,12 @@ extension BrowserViewController: ReaderModeDelegate {
     }
 
     func readerMode(_ readerMode: ReaderMode, didDisplayReaderizedContentForTab tab: Tab) {
-        self.showReaderModeBar(animated: true)
-        tab.showContent(true)
+        // If this reader mode availability state change is for the tab that we currently show, then update
+        // the button. Otherwise do nothing and the button will be updated when the tab is made active.
+        if tabManager.selectedTab === tab {
+            self.showReaderModeBar(animated: true)
+            tab.showContent(true)
+        }
     }
 
     func readerMode(_ readerMode: ReaderMode, didParseReadabilityResult readabilityResult: ReadabilityResult, forTab tab: Tab) {

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -575,7 +575,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
                 oneLineCell.leftImageView.tintColor = LegacyThemeManager.instance.currentName == .dark ? UIColor.white : UIColor.black
                 oneLineCell.leftImageView.backgroundColor = nil
                 let appendButton = UIButton(type: .roundedRect)
-                appendButton.setImage(UIImage(named: SearchViewControllerUX.SearchAppendImage)?.withRenderingMode(.alwaysTemplate), for: .normal)
+                appendButton.setImage(searchAppendImage?.withRenderingMode(.alwaysTemplate), for: .normal)
                 appendButton.addTarget(self, action: #selector(append(_ :)), for: .touchUpInside)
                 appendButton.tintColor = LegacyThemeManager.instance.currentName == .dark ? UIColor.white : UIColor.black
                 appendButton.sizeToFit()
@@ -642,6 +642,19 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
             searchDelegate?.searchViewController(self, didAppend: newQuery + " ")
             searchQuery = newQuery + " "
         }
+    }
+
+    private var searchAppendImage: UIImage? {
+        var searchAppendImage = UIImage(named: SearchViewControllerUX.SearchAppendImage)
+
+        if viewModel.isBottomSearchBar, let image = searchAppendImage, let cgImage = image.cgImage {
+            searchAppendImage = UIImage(
+                cgImage: cgImage,
+                scale: image.scale,
+                orientation: .downMirrored
+            )
+        }
+        return searchAppendImage
     }
 }
 

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -50,30 +50,36 @@ struct ClientTabsSearchWrapper {
     var tab: RemoteTab
 }
 
+struct SearchViewModel {
+    let isPrivate: Bool
+    let isBottomSearchBar: Bool
+    // TODO: Move logic in view model
+}
+
 class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, LoaderListener {
     var searchDelegate: SearchViewControllerDelegate?
     var currentTheme: BuiltinThemeName {
         return BuiltinThemeName(rawValue: LegacyThemeManager.instance.current.name) ?? .normal
     }
-    fileprivate let isPrivate: Bool
-    fileprivate var suggestClient: SearchSuggestClient?
-    fileprivate var remoteClientTabs = [ClientTabsSearchWrapper]()
-    fileprivate var filteredRemoteClientTabs = [ClientTabsSearchWrapper]()
-    fileprivate var openedTabs = [Tab]()
-    fileprivate var filteredOpenedTabs = [Tab]()
-    fileprivate var tabManager: TabManager
+    private let viewModel: SearchViewModel
+    private var suggestClient: SearchSuggestClient?
+    private var remoteClientTabs = [ClientTabsSearchWrapper]()
+    private var filteredRemoteClientTabs = [ClientTabsSearchWrapper]()
+    private var openedTabs = [Tab]()
+    private var filteredOpenedTabs = [Tab]()
+    private var tabManager: TabManager
     
     // Views for displaying the bottom scrollable search engine list. searchEngineScrollView is the
     // scrollable container; searchEngineScrollViewContent contains the actual set of search engine buttons.
-    fileprivate let searchEngineContainerView = UIView()
-    fileprivate let searchEngineScrollView = ButtonScrollView()
-    fileprivate let searchEngineScrollViewContent = UIView()
+    private let searchEngineContainerView = UIView()
+    private let searchEngineScrollView = ButtonScrollView()
+    private let searchEngineScrollViewContent = UIView()
 
-    fileprivate lazy var bookmarkedBadge: UIImage = {
+    private lazy var bookmarkedBadge: UIImage = {
         return UIImage(named: "bookmark_results")!
     }()
     
-    fileprivate lazy var openAndSyncTabBadge: UIImage = {
+    private lazy var openAndSyncTabBadge: UIImage = {
         return UIImage(named: "sync_open_tab")!
     }()
 
@@ -82,9 +88,8 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     var experimental: Variables?
     static var userAgent: String?
 
-    
-    init(profile: Profile, isPrivate: Bool, tabManager: TabManager) {
-        self.isPrivate = isPrivate
+    init(profile: Profile, viewModel: SearchViewModel, tabManager: TabManager) {
+        self.viewModel = viewModel
         self.tabManager = tabManager
         self.experimental = Experiments.shared.getVariables(featureId: .search).getVariables("awesome-bar")
         super.init(profile: profile)
@@ -148,19 +153,20 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         reloadData()
     }
 
-    fileprivate func layoutSearchEngineScrollView() {
+    private func layoutSearchEngineScrollView() {
         let keyboardHeight = KeyboardHelper.defaultHelper.currentState?.intersectionHeightForView(self.view) ?? 0
         searchEngineScrollView.snp.remakeConstraints { make in
             make.left.right.top.equalToSuperview()
             if keyboardHeight == 0 {
                 make.bottom.equalTo(view.safeArea.bottom)
             } else {
-                make.bottom.equalTo(view).offset(-keyboardHeight)
+                let offset = viewModel.isBottomSearchBar ? 0 : keyboardHeight
+                make.bottom.equalTo(view).offset(-offset)
             }
         }
     }
 
-    fileprivate func layoutSearchEngineScrollViewContent() {
+    private func layoutSearchEngineScrollViewContent() {
         searchEngineScrollViewContent.snp.remakeConstraints { make in
             make.center.equalTo(self.searchEngineScrollView).priority(10)
             //left-align the engines on iphones, center on ipad
@@ -183,7 +189,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
             querySuggestClient()
 
             // Show the default search engine first.
-            if !isPrivate {
+            if !viewModel.isPrivate {
                 let ua = SearchViewController.userAgent ?? "FxSearch"
                 suggestClient = SearchSuggestClient(searchEngine: searchEngines.defaultEngine, userAgent: ua)
             }
@@ -193,12 +199,12 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         }
     }
 
-    fileprivate var quickSearchEngines: [OpenSearchEngine] {
+    private var quickSearchEngines: [OpenSearchEngine] {
         var engines = searchEngines.quickSearchEngines
 
         // If we're not showing search suggestions, the default search engine won't be visible
         // at the top of the table. Show it with the others in the bottom search bar.
-        if isPrivate || !searchEngines.shouldShowSearchSuggestions {
+        if viewModel.isPrivate || !searchEngines.shouldShowSearchSuggestions {
             engines?.insert(searchEngines.defaultEngine, at: 0)
         }
 
@@ -216,7 +222,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         querySuggestClient()
     }
 
-    fileprivate func layoutTable() {
+    private func layoutTable() {
         tableView.snp.remakeConstraints { make in
             make.top.equalTo(self.view.snp.top)
             make.leading.trailing.equalTo(self.view)
@@ -321,7 +327,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         }, completion: nil)
     }
 
-    fileprivate func animateSearchEnginesWithKeyboard(_ keyboardState: KeyboardState) {
+    private func animateSearchEnginesWithKeyboard(_ keyboardState: KeyboardState) {
         layoutSearchEngineScrollView()
 
         UIView.animate(withDuration: keyboardState.animationDuration, delay: 0,
@@ -330,7 +336,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         })
     }
     
-    fileprivate func getCachedTabs() {
+    private func getCachedTabs() {
         assert(Thread.isMainThread)
         // Short circuit if the user is not logged in
         guard profile.hasSyncableAccount() else { return }
@@ -350,7 +356,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     }
     
     func searchTabs(for searchString: String) {
-        let currentTabs = self.isPrivate ? self.tabManager.privateTabs : self.tabManager.normalTabs
+        let currentTabs = viewModel.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
 
         // Small helper function to do case insensitive searching.
         // We split the search query by spaces so we can simulate full text search.
@@ -410,7 +416,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         }
     }
     
-    fileprivate func querySuggestClient() {
+    private func querySuggestClient() {
         suggestClient?.cancelPendingRequest()
 
         if searchQuery.isEmpty || !searchEngines.shouldShowSearchSuggestions || searchQuery.looksLikeAURL() {
@@ -461,6 +467,8 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         self.data = data
         tableView.reloadData()
     }
+
+    // MARK: - Table view delegate
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         switch SearchListSection(rawValue: indexPath.section)! {
@@ -552,7 +560,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         return attributedString
     }
     
-    fileprivate func getCellForSection(_ twoLineCell: TwoLineImageOverlayCell, oneLineCell: OneLineTableViewCell, for section: SearchListSection, _ indexPath: IndexPath) -> UITableViewCell {
+    private func getCellForSection(_ twoLineCell: TwoLineImageOverlayCell, oneLineCell: OneLineTableViewCell, for section: SearchListSection, _ indexPath: IndexPath) -> UITableViewCell {
         var cell = UITableViewCell()
         switch section {
         case .searchSuggestions:
@@ -637,6 +645,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     }
 }
 
+// MARK: - Keyboard shortcuts
 extension SearchViewController {
     func handleKeyCommands(sender: UIKeyCommand) {
         let initialSection = SearchListSection.bookmarksAndHistory.rawValue
@@ -713,7 +722,7 @@ fileprivate extension String {
  * UIScrollView that prevents buttons from interfering with scroll.
  */
 fileprivate class ButtonScrollView: UIScrollView {
-    fileprivate override func touchesShouldCancel(in view: UIView) -> Bool {
+    override func touchesShouldCancel(in view: UIView) -> Bool {
         return true
     }
 }

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -53,7 +53,6 @@ struct ClientTabsSearchWrapper {
 struct SearchViewModel {
     let isPrivate: Bool
     let isBottomSearchBar: Bool
-    // TODO: Move logic in view model
 }
 
 class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, LoaderListener {

--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -28,6 +28,7 @@ class TabScrollingController: NSObject, FeatureFlagsProtocol {
         didSet {
             self.scrollView?.addGestureRecognizer(panGesture)
             scrollView?.delegate = self
+            scrollView?.keyboardDismissMode = .onDrag
             featureFlags.isFeatureActiveForBuild(.pullToRefresh) ? configureRefreshControl() : nil
         }
     }
@@ -234,7 +235,6 @@ private extension TabScrollingController {
         footerBottomOffset = clamp(updatedOffset, min: 0, max: bottomScrollHeight)
 
         header?.updateAlphaForSubviews(scrollAlpha)
-        footer?.updateAlphaForSubviews(scrollAlpha)
     }
 
     func isHeaderDisplayedForGivenOffset(_ offset: CGFloat) -> Bool {
@@ -266,7 +266,6 @@ private extension TabScrollingController {
             self.headerTopOffset = headerOffset
             self.footerBottomOffset = footerOffset
             self.header?.updateAlphaForSubviews(alpha)
-            self.footer?.updateAlphaForSubviews(alpha)
             self.header?.superview?.layoutIfNeeded()
         }
 

--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -37,7 +37,9 @@ class TabScrollingController: NSObject, FeatureFlagsProtocol {
 
     var footerBottomConstraint: Constraint?
     var headerTopConstraint: Constraint?
-    var toolbarsShowing: Bool { return headerTopOffset == 0 }
+    var toolbarsShowing: Bool {
+        return isBottomSearchBar ? headerTopOffset == 0 : footerBottomOffset == 0
+    }
 
     fileprivate var isZoomedOut: Bool = false
     fileprivate var lastZoomedScale: CGFloat = 0
@@ -68,15 +70,15 @@ class TabScrollingController: NSObject, FeatureFlagsProtocol {
     fileprivate var contentOffset: CGPoint { return scrollView?.contentOffset ?? .zero }
     fileprivate var contentSize: CGSize { return scrollView?.contentSize ?? .zero }
     fileprivate var scrollViewHeight: CGFloat { return scrollView?.frame.height ?? 0 }
-    fileprivate var topScrollHeight: CGFloat {
-        guard let headerHeight = header?.frame.height else { return 0 }
-        return headerHeight
-    }
+    fileprivate var topScrollHeight: CGFloat { header?.frame.height ?? 0 }
     fileprivate var bottomScrollHeight: CGFloat { return footer?.frame.height ?? 0 }
 
     fileprivate var lastContentOffset: CGFloat = 0
     fileprivate var scrollDirection: ScrollDirection = .down
     fileprivate var toolbarState: ToolbarState = .visible
+    private var isBottomSearchBar: Bool {
+        return BrowserViewController.foregroundBVC().isBottomSearchBar
+    }
 
     override init() {
         super.init()
@@ -99,8 +101,8 @@ class TabScrollingController: NSObject, FeatureFlagsProtocol {
             return
         }
         toolbarState = .visible
-        let durationRatio = abs(headerTopOffset / topScrollHeight)
-        let actualDuration = TimeInterval(ToolbarBaseAnimationDuration * durationRatio)
+
+        let actualDuration = TimeInterval(ToolbarBaseAnimationDuration * showDurationRatio)
         self.animateToolbarsWithOffsets(
             animated,
             duration: actualDuration,
@@ -116,8 +118,8 @@ class TabScrollingController: NSObject, FeatureFlagsProtocol {
             return
         }
         toolbarState = .collapsed
-        let durationRatio = abs((topScrollHeight + headerTopOffset) / topScrollHeight)
-        let actualDuration = TimeInterval(ToolbarBaseAnimationDuration * durationRatio)
+
+        let actualDuration = TimeInterval(ToolbarBaseAnimationDuration * hideDurationRation)
         self.animateToolbarsWithOffsets(
             animated,
             duration: actualDuration,
@@ -231,9 +233,8 @@ private extension TabScrollingController {
         updatedOffset = footerBottomOffset + delta
         footerBottomOffset = clamp(updatedOffset, min: 0, max: bottomScrollHeight)
 
-        let alpha = 1 - abs(headerTopOffset / topScrollHeight)
-        header?.updateAlphaForSubviews(alpha)
-        footer?.updateAlphaForSubviews(alpha)
+        header?.updateAlphaForSubviews(scrollAlpha)
+        footer?.updateAlphaForSubviews(scrollAlpha)
     }
 
     func isHeaderDisplayedForGivenOffset(_ offset: CGFloat) -> Bool {
@@ -279,6 +280,36 @@ private extension TabScrollingController {
 
     func checkScrollHeightIsLargeEnoughForScrolling() -> Bool {
         return (UIScreen.main.bounds.size.height + 2 * UIConstants.ToolbarHeight) < scrollView?.contentSize.height ?? 0
+    }
+
+    var showDurationRatio: CGFloat {
+        var durationRatio: CGFloat
+        if isBottomSearchBar {
+            durationRatio = abs(footerBottomOffset / bottomScrollHeight)
+        } else {
+            durationRatio = abs(headerTopOffset / topScrollHeight)
+        }
+        return durationRatio
+    }
+
+    var hideDurationRation: CGFloat {
+        var durationRatio: CGFloat
+        if isBottomSearchBar {
+            durationRatio = abs((bottomScrollHeight + footerBottomOffset) / bottomScrollHeight)
+        } else {
+            durationRatio = abs((topScrollHeight + headerTopOffset) / topScrollHeight)
+        }
+        return durationRatio
+    }
+
+    var scrollAlpha: CGFloat {
+        var alpha: CGFloat
+        if isBottomSearchBar {
+            alpha = 1 - abs(footerBottomOffset / bottomScrollHeight)
+        } else {
+            alpha = 1 - abs(headerTopOffset / topScrollHeight)
+        }
+        return alpha
     }
 }
 

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -296,6 +296,9 @@ class TabToolbar: UIView {
 
     var helper: TabToolbarHelper?
     private let contentView = UIStackView()
+    private var isBottomSearchBar: Bool {
+        return BrowserViewController.foregroundBVC().isBottomSearchBar
+    }
 
     fileprivate override init(frame: CGRect) {
         actionButtons = [backButton, forwardButton, multiStateButton, addNewTabButton, tabsButton, appMenuButton]
@@ -347,7 +350,7 @@ class TabToolbar: UIView {
 
     override func draw(_ rect: CGRect) {
         // No line when the search bar is on top of the toolbar
-        guard !BrowserViewController.foregroundBVC().isBottomSearchBar else { return }
+        guard !isBottomSearchBar else { return }
         if let context = UIGraphicsGetCurrentContext() {
             drawLine(context, start: .zero, end: CGPoint(x: frame.width, y: 0))
         }

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -346,6 +346,8 @@ class TabToolbar: UIView {
     }
 
     override func draw(_ rect: CGRect) {
+        // No line when the search bar is on top of the toolbar
+        guard !BrowserViewController.foregroundBVC().isBottomSearchBar else { return }
         if let context = UIGraphicsGetCurrentContext() {
             drawLine(context, start: .zero, end: CGPoint(x: frame.width, y: 0))
         }

--- a/Client/Frontend/Browser/URLBar/TabLocationContainerView.swift
+++ b/Client/Frontend/Browser/URLBar/TabLocationContainerView.swift
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+// We need a subclass so we can setup the shadows correctly
+// This subclass creates a strong shadow on the URLBar
+class TabLocationContainerView: UIView {
+
+    private struct LocationContainerUX {
+        static let CornerRadius: CGFloat = 8
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        let layer = self.layer
+        layer.cornerRadius = LocationContainerUX.CornerRadius
+        layer.masksToBounds = false
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Client/Frontend/Browser/URLBar/ToolbarTextField.swift
+++ b/Client/Frontend/Browser/URLBar/ToolbarTextField.swift
@@ -1,0 +1,68 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+class ToolbarTextField: AutocompleteTextField {
+
+    @objc dynamic var clearButtonTintColor: UIColor? {
+        didSet {
+            // Clear previous tinted image that's cache and ask for a relayout
+            tintedClearImage = nil
+            setNeedsLayout()
+        }
+    }
+
+    fileprivate var tintedClearImage: UIImage?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        guard let image = UIImage.templateImageNamed("topTabs-closeTabs") else { return }
+        if tintedClearImage == nil {
+            if let clearButtonTintColor = clearButtonTintColor {
+                tintedClearImage = image.tinted(withColor: clearButtonTintColor)
+            } else {
+                tintedClearImage = image
+            }
+        }
+        // Since we're unable to change the tint color of the clear image, we need to iterate through the
+        // subviews, find the clear button, and tint it ourselves.
+        // https://stackoverflow.com/questions/55046917/clear-button-on-text-field-not-accessible-with-voice-over-swift
+        if let clearButton = value(forKey: "_clearButton") as? UIButton {
+            clearButton.setImage(tintedClearImage, for: [])
+
+        }
+    }
+
+    // The default button size is 19x19, make this larger
+    override func clearButtonRect(forBounds bounds: CGRect) -> CGRect {
+        let r = super.clearButtonRect(forBounds: bounds)
+        let grow: CGFloat = 16
+        let r2 = CGRect(x: r.minX - grow/2, y:r.minY - grow/2, width: r.width + grow, height: r.height + grow)
+        return r2
+    }
+}
+
+extension ToolbarTextField: NotificationThemeable {
+    func applyTheme() {
+        backgroundColor = UIColor.theme.textField.backgroundInOverlay
+        textColor = UIColor.theme.textField.textAndTint
+        clearButtonTintColor = textColor
+        tintColor = AutocompleteTextField.textSelectionColor.textFieldMode
+    }
+
+    // ToolbarTextField is created on-demand, so the textSelectionColor is a static prop for use when created
+    static func applyUIMode(isPrivate: Bool) {
+       textSelectionColor = UIColor.theme.urlbar.textSelectionHighlight(isPrivate)
+    }
+}

--- a/Client/Frontend/Browser/URLBar/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBar/URLBarView.swift
@@ -49,7 +49,7 @@ protocol URLBarDelegate: AnyObject {
     func urlBarDidBeginDragInteraction(_ urlBar: URLBarView)
 }
 
-class URLBarView: UIView, AlphaDimmable {
+class URLBarView: UIView, AlphaDimmable, TopBottomInterchangeable {
     // Additional UIAppearance-configurable properties
     @objc dynamic var locationBorderColor: UIColor = URLBarViewUX.TextFieldBorderColor {
         didSet {
@@ -65,6 +65,8 @@ class URLBarView: UIView, AlphaDimmable {
             }
         }
     }
+
+    var parent: UIStackView?
     var searchEngines: SearchEngines?
     weak var delegate: URLBarDelegate?
     weak var tabToolbarDelegate: TabToolbarDelegate?
@@ -191,6 +193,9 @@ class URLBarView: UIView, AlphaDimmable {
     }
 
     var profile: Profile? = nil
+    private var isBottomSearchBar: Bool {
+        BrowserViewController.foregroundBVC().isBottomSearchBar
+    }
     
     fileprivate let privateModeBadge = BadgeWithBackdrop(imageName: "privateModeBadge", backdropCircleColor: UIColor.Defaults.MobilePrivatePurple)
     fileprivate let appMenuBadge = BadgeWithBackdrop(imageName: "menuBadge")
@@ -237,24 +242,13 @@ class URLBarView: UIView, AlphaDimmable {
 
     fileprivate func setupConstraints() {
 
-        line.snp.makeConstraints { make in
-            if BrowserViewController.foregroundBVC().isBottomSearchBar {
-                make.top.equalTo(self).offset(1)
-            } else {
-                make.bottom.equalTo(self)
-            }
-
-            make.leading.trailing.equalTo(self)
-            make.height.equalTo(1)
-        }
-
         scrollToTopButton.snp.makeConstraints { make in
             make.top.equalTo(self)
             make.left.right.equalTo(locationContainer)
         }
 
         progressBar.snp.makeConstraints { make in
-            if BrowserViewController.foregroundBVC().isBottomSearchBar {
+            if isBottomSearchBar {
                 make.bottom.equalTo(snp.top).inset(URLBarViewUX.ProgressBarHeight / 2)
             } else {
                 make.top.equalTo(snp.bottom).inset(URLBarViewUX.ProgressBarHeight / 2)
@@ -343,6 +337,18 @@ class URLBarView: UIView, AlphaDimmable {
 
     override func updateConstraints() {
         super.updateConstraints()
+
+        line.snp.remakeConstraints { make in
+            if isBottomSearchBar {
+                make.top.equalTo(self).offset(1)
+            } else {
+                make.bottom.equalTo(self)
+            }
+
+            make.leading.trailing.equalTo(self)
+            make.height.equalTo(1)
+        }
+
         if inOverlayMode {
             searchIconImageView.alpha = 1
             // In overlay mode, we always show the location view full width
@@ -811,6 +817,7 @@ extension URLBarView {
 
 }
 
+// MARK: - NotificationThemeable
 extension URLBarView: NotificationThemeable {
     func applyTheme() {
         locationView.applyTheme()
@@ -835,6 +842,7 @@ extension URLBarView: NotificationThemeable {
     }
 }
 
+// MARK: - PrivateModeUI
 extension URLBarView: PrivateModeUI {
     func applyUIMode(isPrivate: Bool) {
         if UIDevice.current.userInterfaceIdiom != .pad {
@@ -846,88 +854,5 @@ extension URLBarView: PrivateModeUI {
         ToolbarTextField.applyUIMode(isPrivate: isPrivate)
 
         applyTheme()
-    }
-}
-
-// We need a subclass so we can setup the shadows correctly
-// This subclass creates a strong shadow on the URLBar
-class TabLocationContainerView: UIView {
-
-    private struct LocationContainerUX {
-        static let CornerRadius: CGFloat = 8
-    }
-
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        let layer = self.layer
-        layer.cornerRadius = LocationContainerUX.CornerRadius
-        layer.masksToBounds = false
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-}
-
-class ToolbarTextField: AutocompleteTextField {
-
-    @objc dynamic var clearButtonTintColor: UIColor? {
-        didSet {
-            // Clear previous tinted image that's cache and ask for a relayout
-            tintedClearImage = nil
-            setNeedsLayout()
-        }
-    }
-
-    fileprivate var tintedClearImage: UIImage?
-
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func layoutSubviews() {
-        super.layoutSubviews()
-
-        guard let image = UIImage.templateImageNamed("topTabs-closeTabs") else { return }
-        if tintedClearImage == nil {
-            if let clearButtonTintColor = clearButtonTintColor {
-                tintedClearImage = image.tinted(withColor: clearButtonTintColor)
-            } else {
-                tintedClearImage = image
-            }
-        }
-        // Since we're unable to change the tint color of the clear image, we need to iterate through the
-        // subviews, find the clear button, and tint it ourselves.
-        // https://stackoverflow.com/questions/55046917/clear-button-on-text-field-not-accessible-with-voice-over-swift
-        if let clearButton = value(forKey: "_clearButton") as? UIButton {
-            clearButton.setImage(tintedClearImage, for: [])
-
-        }
-    }
-
-    // The default button size is 19x19, make this larger
-    override func clearButtonRect(forBounds bounds: CGRect) -> CGRect {
-        let r = super.clearButtonRect(forBounds: bounds)
-        let grow: CGFloat = 16
-        let r2 = CGRect(x: r.minX - grow/2, y:r.minY - grow/2, width: r.width + grow, height: r.height + grow)
-        return r2
-    }
-}
-
-extension ToolbarTextField: NotificationThemeable {
-    func applyTheme() {
-        backgroundColor = UIColor.theme.textField.backgroundInOverlay
-        textColor = UIColor.theme.textField.textAndTint
-        clearButtonTintColor = textColor
-        tintColor = AutocompleteTextField.textSelectionColor.textFieldMode
-    }
-
-    // ToolbarTextField is created on-demand, so the textSelectionColor is a static prop for use when created
-    static func applyUIMode(isPrivate: Bool) {
-       textSelectionColor = UIColor.theme.urlbar.textSelectionHighlight(isPrivate)
     }
 }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -207,6 +207,7 @@ class URLBarView: UIView, AlphaDimmable {
         super.init(coder: aDecoder)
         commonInit()
     }
+
     func updateSearchEngineImage() {
         guard let profile = profile else { return }
         self.searchIconImageView.image = profile.searchEngines.defaultEngine.image
@@ -216,11 +217,11 @@ class URLBarView: UIView, AlphaDimmable {
         locationContainer.addSubview(locationView)
         
         [scrollToTopButton, line, tabsButton, progressBar, cancelButton, showQRScannerButton,
-         homeButton, bookmarksButton, appMenuButton, addNewTabButton, forwardButton, backButton, multiStateButton, locationContainer].forEach {
+         homeButton, bookmarksButton, appMenuButton, addNewTabButton, forwardButton, backButton,
+         multiStateButton, locationContainer, searchIconImageView].forEach {
             addSubview($0)
         }
 
-        addSubview(searchIconImageView)
         updateSearchEngineImage()
         
         privateModeBadge.add(toParent: self)
@@ -237,20 +238,26 @@ class URLBarView: UIView, AlphaDimmable {
     fileprivate func setupConstraints() {
 
         line.snp.makeConstraints { make in
-            make.bottom.leading.trailing.equalTo(self)
+            if BrowserViewController.foregroundBVC().isBottomSearchBar {
+                make.top.equalTo(self).offset(1)
+            } else {
+                make.bottom.equalTo(self)
+            }
+
+            make.leading.trailing.equalTo(self)
             make.height.equalTo(1)
         }
 
         scrollToTopButton.snp.makeConstraints { make in
             make.top.equalTo(self)
-            make.left.right.equalTo(self.locationContainer)
+            make.left.right.equalTo(locationContainer)
         }
 
         progressBar.snp.makeConstraints { make in
             if BrowserViewController.foregroundBVC().isBottomSearchBar {
-                make.bottom.equalTo(self.snp.top).inset(URLBarViewUX.ProgressBarHeight / 2)
+                make.bottom.equalTo(snp.top).inset(URLBarViewUX.ProgressBarHeight / 2)
             } else {
-                make.top.equalTo(self.snp.bottom).inset(URLBarViewUX.ProgressBarHeight / 2)
+                make.top.equalTo(snp.bottom).inset(URLBarViewUX.ProgressBarHeight / 2)
             }
 
             make.height.equalTo(URLBarViewUX.ProgressBarHeight)

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -247,7 +247,12 @@ class URLBarView: UIView, AlphaDimmable {
         }
 
         progressBar.snp.makeConstraints { make in
-            make.top.equalTo(self.snp.bottom).inset(URLBarViewUX.ProgressBarHeight / 2)
+            if BrowserViewController.foregroundBVC().isBottomSearchBar {
+                make.bottom.equalTo(self.snp.top).inset(URLBarViewUX.ProgressBarHeight / 2)
+            } else {
+                make.top.equalTo(self.snp.bottom).inset(URLBarViewUX.ProgressBarHeight / 2)
+            }
+
             make.height.equalTo(URLBarViewUX.ProgressBarHeight)
             make.left.right.equalTo(self)
         }

--- a/Client/Frontend/Components/BaseContentStackView.swift
+++ b/Client/Frontend/Components/BaseContentStackView.swift
@@ -48,7 +48,7 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable {
 
         keyboardSpacer = UIView()
         setKeyboardSpacerHeight(height: spacerHeight)
-        insertArrangedView(keyboardSpacer!, position: 1)
+        insertArrangedView(keyboardSpacer!, position: index)
     }
 
     func removeKeyboardSpacer() {

--- a/Client/Frontend/Components/BaseContentStackView.swift
+++ b/Client/Frontend/Components/BaseContentStackView.swift
@@ -12,7 +12,10 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+
+        applyTheme()
         setupStyle()
+        setupObservers()
     }
 
     required init(coder: NSCoder) {
@@ -27,8 +30,48 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable {
     }
 
     private func setupStyle() {
-        backgroundColor = .clear
         axis = .vertical
         distribution = .fillProportionally
+    }
+
+    // MARK: - Spacer view
+
+    private var keyboardSpacer: UIView?
+
+    func addSpacer(at index: Int, spacerHeight: CGFloat) {
+        guard keyboardSpacer == nil else { return }
+
+        keyboardSpacer = UIView()
+        keyboardSpacer?.backgroundColor = .clear
+        keyboardSpacer!.snp.makeConstraints { make in
+            make.height.equalTo(spacerHeight)
+        }
+        insertArrangedView(keyboardSpacer!, position: 1)
+    }
+
+    func removeSpacer() {
+        guard let keyboardSpacer = self.keyboardSpacer else { return }
+        removeArrangedView(keyboardSpacer)
+        self.keyboardSpacer = nil
+    }
+
+    // MARK: - NotificationThemeable
+
+    private func setupObservers() {
+        NotificationCenter.default.addObserver(self, selector: #selector(handleNotifications), name: .DisplayThemeChanged, object: nil)
+    }
+
+    @objc private func handleNotifications(_ notification: Notification) {
+        switch notification.name {
+        case .DisplayThemeChanged:
+            applyTheme()
+        default: break
+        }
+    }
+}
+
+extension BaseAlphaStackView: NotificationThemeable {
+    func applyTheme() {
+        backgroundColor = UIColor.theme.browser.background
     }
 }

--- a/Client/Frontend/Components/BaseContentStackView.swift
+++ b/Client/Frontend/Components/BaseContentStackView.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import SnapKit
 
 protocol AlphaDimmable {
     func updateAlphaForSubviews(_ alpha: CGFloat)
@@ -36,23 +37,33 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable {
 
     // MARK: - Spacer view
 
+    private var keyboardSpacerHeight: Constraint!
     private var keyboardSpacer: UIView?
 
     func addSpacer(at index: Int, spacerHeight: CGFloat) {
-        guard keyboardSpacer == nil else { return }
+        guard keyboardSpacer == nil else {
+            setKeyboardSpacerHeight(height: spacerHeight)
+            return
+        }
 
         keyboardSpacer = UIView()
         keyboardSpacer?.backgroundColor = .clear
-        keyboardSpacer!.snp.makeConstraints { make in
-            make.height.equalTo(spacerHeight)
-        }
+        setKeyboardSpacerHeight(height: spacerHeight)
         insertArrangedView(keyboardSpacer!, position: 1)
     }
 
     func removeSpacer() {
         guard let keyboardSpacer = self.keyboardSpacer else { return }
         removeArrangedView(keyboardSpacer)
+        keyboardSpacerHeight = nil
         self.keyboardSpacer = nil
+    }
+
+    private func setKeyboardSpacerHeight(height: CGFloat) {
+        guard let keyboardSpacer = self.keyboardSpacer else { return }
+        keyboardSpacer.snp.makeConstraints { make in
+            keyboardSpacerHeight = make.height.equalTo(height).constraint
+        }
     }
 
     // MARK: - NotificationThemeable

--- a/Client/Frontend/Components/BaseContentStackView.swift
+++ b/Client/Frontend/Components/BaseContentStackView.swift
@@ -40,19 +40,18 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable {
     private var keyboardSpacerHeight: Constraint!
     private var keyboardSpacer: UIView?
 
-    func addSpacer(at index: Int, spacerHeight: CGFloat) {
+    func addKeyboardSpacer(at index: Int, spacerHeight: CGFloat) {
         guard keyboardSpacer == nil else {
             setKeyboardSpacerHeight(height: spacerHeight)
             return
         }
 
         keyboardSpacer = UIView()
-        keyboardSpacer?.backgroundColor = .clear
         setKeyboardSpacerHeight(height: spacerHeight)
         insertArrangedView(keyboardSpacer!, position: 1)
     }
 
-    func removeSpacer() {
+    func removeKeyboardSpacer() {
         guard let keyboardSpacer = self.keyboardSpacer else { return }
         removeArrangedView(keyboardSpacer)
         keyboardSpacerHeight = nil
@@ -64,6 +63,28 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable {
         keyboardSpacer.snp.makeConstraints { make in
             keyboardSpacerHeight = make.height.equalTo(height).constraint
         }
+    }
+
+    // MARK: - Spacer view
+
+    private var insetSpacer: UIView?
+
+    func addBottomInsetSpacer(spacerHeight: CGFloat) {
+        guard insetSpacer == nil else { return }
+
+        insetSpacer = UIView()
+        insetSpacer!.snp.makeConstraints { make in
+            make.height.equalTo(spacerHeight)
+        }
+        addArrangedViewToBottom(insetSpacer!)
+    }
+
+    func removeBottomInsetSpacer() {
+        guard let insetSpacer = self.insetSpacer else { return }
+
+        removeArrangedView(insetSpacer)
+        self.insetSpacer = nil
+        self.layoutIfNeeded()
     }
 
     // MARK: - NotificationThemeable
@@ -82,7 +103,10 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable {
 }
 
 extension BaseAlphaStackView: NotificationThemeable {
+
     func applyTheme() {
         backgroundColor = UIColor.theme.browser.background
+        keyboardSpacer?.backgroundColor = UIColor.theme.browser.background
+        insetSpacer?.backgroundColor = UIColor.theme.browser.background
     }
 }

--- a/Client/Frontend/Contextual Hint/ContextualHintViewController.swift
+++ b/Client/Frontend/Contextual Hint/ContextualHintViewController.swift
@@ -16,9 +16,6 @@ class ContextualHintViewController: UIViewController, OnViewDismissable {
     // MARK: - Properties
     
     var onViewDismissed: (() -> Void)? = nil
-    
-    // Orientation independent screen size
-    private let screenSize = DeviceInfo.screenSizeOrientationIndependent()
 
     // UI
     private lazy var closeButton: UIButton = .build { [weak self] button in

--- a/Client/Frontend/Contextual Hint/ContextualHintViewModel.swift
+++ b/Client/Frontend/Contextual Hint/ContextualHintViewModel.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Shared
+import UIKit
 
 enum ContextualHintViewType {
     typealias ContextualHints = String.ContextualHints.FirefoxHomepage
@@ -28,7 +29,7 @@ class ContextualHintViewModel {
     }
     
     func shouldPresentContextualHint(profile: Profile) -> Bool {
-        guard let type = hintType else { return false }
+        guard let type = hintType, isDeviceHintReady else { return false }
         switch type {
         case .jumpBackIn:
             guard let contextualHintData = profile.prefs.boolForKey(PrefsKeys.ContextualHintJumpBackinKey) else {
@@ -44,5 +45,10 @@ class ContextualHintViewModel {
         case .jumpBackIn:
             profile.prefs.setBool(false, forKey: PrefsKeys.ContextualHintJumpBackinKey)
         }
+    }
+
+    // Do not present contextual hint in landscape on iPhone
+    private var isDeviceHintReady: Bool {
+        !UIWindow.isLandscape || UIDevice.current.userInterfaceIdiom == .pad
     }
 }

--- a/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -185,10 +185,6 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
         NotificationCenter.default.addObserver(self, selector: #selector(updateTheme), name: .DisplayThemeChanged, object: nil)
     }
     
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-    }
-    
     private func setupView() {
         
         let textOffset = screenSize.height > 668 ? DBOnboardingUX.textOffset : DBOnboardingUX.textOffsetSmall

--- a/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -45,21 +45,26 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
     // Public constants
     let viewModel = DefaultBrowserOnboardingViewModel()
     let theme = LegacyThemeManager.instance
+
     // Private vars
     private var fxTextThemeColour: UIColor {
         // For dark theme we want to show light colours and for light we want to show dark colours
         return theme.currentName == .dark ? .white : .black
     }
+
     private var fxBackgroundThemeColour: UIColor = UIColor.theme.onboarding.backgroundColor
+
     private var descriptionFontSize: CGFloat {
         return screenSize.height > 1000 ? DBOnboardingUX.fontSizeXSmall :
                screenSize.height > 668 ? DBOnboardingUX.fontSize :
                screenSize.height > 640 ? DBOnboardingUX.fontSizeSmall : DBOnboardingUX.fontSizeXSmall
     }
+
     private var titleFontSize: CGFloat {
         return screenSize.height > 1000 ? DBOnboardingUX.titleSizeLarge :
                screenSize.height > 640 ? DBOnboardingUX.titleSize : DBOnboardingUX.titleSizeSmall
     }
+
     // Orientation independent screen size
     private let screenSize = DeviceInfo.screenSizeOrientationIndependent()
 
@@ -69,7 +74,9 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
         button.tintColor = .secondaryLabel
         button.addTarget(self, action: #selector(self?.dismissAnimated), for: .touchUpInside)
     }
+
     private let textView: UIView = .build { view in }
+
     private lazy var titleLabel: UILabel = .build { [weak self] label in
         guard let self = self else { return }
         label.text = self.viewModel.model?.titleText
@@ -77,6 +84,7 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
         label.textAlignment = .center
         label.numberOfLines = 2
     }
+
     private lazy var descriptionText: UILabel = .build { [weak self] label in
         guard let self = self else { return }
         label.text = self.viewModel.model?.descriptionText[0]
@@ -85,6 +93,7 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
         label.numberOfLines = 5
         label.adjustsFontSizeToFitWidth = true
     }
+
     private lazy var descriptionLabel1: UILabel = .build() { [weak self] label in
         guard let self = self else { return }
         label.text = self.viewModel.model?.descriptionText[1]
@@ -93,6 +102,7 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
         label.numberOfLines = 0
         label.adjustsFontSizeToFitWidth = true
     }
+
     private lazy var descriptionLabel2: UILabel = .build { [weak self] label in
         guard let self = self else { return }
         label.text = self.viewModel.model?.descriptionText[2]
@@ -101,6 +111,7 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
         label.numberOfLines = 0
         label.adjustsFontSizeToFitWidth = true
     }
+
     private lazy var descriptionLabel3: UILabel = .build { [weak self] label in
         guard let self = self else { return }
         label.text = self.viewModel.model?.descriptionText[3]
@@ -109,6 +120,7 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
         label.numberOfLines = 0
         label.adjustsFontSizeToFitWidth = true
     }
+
     private lazy var goToSettingsButton: UIButton = .build { [weak self] button in
         guard let self = self else { return }
         button.setTitle(.CoverSheetETPSettingsButton, for: .normal)

--- a/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewModel.swift
+++ b/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewModel.swift
@@ -42,30 +42,42 @@ struct DefaultBrowserOnboardingModel {
 }
 
 class DefaultBrowserOnboardingViewModel {
-    //  Internal vars
-    var model: DefaultBrowserOnboardingModel?
+
     var goToSettings: (() -> Void)?
+    var model: DefaultBrowserOnboardingModel?
+
+    private static let maxSessionCount = 3
 
     init() {
-        setupUpdateModel()
+        setupModel()
     }
     
-    private func setupUpdateModel() {
-        model = DefaultBrowserOnboardingModel(titleText: String.DefaultBrowserCardTitle, descriptionText: [String.DefaultBrowserCardDescription, String.DefaultBrowserOnboardingDescriptionStep1, String.DefaultBrowserOnboardingDescriptionStep2, String.DefaultBrowserOnboardingDescriptionStep3], imageText: String.DefaultBrowserOnboardingScreenshot)
+    private func setupModel() {
+        model = DefaultBrowserOnboardingModel(
+            titleText: String.DefaultBrowserCardTitle,
+            descriptionText: descriptionText,
+            imageText: String.DefaultBrowserOnboardingScreenshot
+        )
+    }
+
+    private var descriptionText: [String] {
+        [String.DefaultBrowserCardDescription,
+         String.DefaultBrowserOnboardingDescriptionStep1,
+         String.DefaultBrowserOnboardingDescriptionStep2,
+         String.DefaultBrowserOnboardingDescriptionStep3]
     }
     
     static func shouldShowDefaultBrowserOnboarding(userPrefs: Prefs) -> Bool {
         // Only show on fresh install
         guard InstallType.get() == .fresh else { return false }
-        // Show on 3rd session
-        let maxSessionCount = 3
+
+        let didShow = UserDefaults.standard.bool(forKey: PrefsKeys.KeyDidShowDefaultBrowserOnboarding)
+        guard !didShow else { return false }
+
         var shouldShow = false
         // Get the session count from preferences
         let currentSessionCount = userPrefs.intForKey(PrefsKeys.SessionCount) ?? 0
-        let didShow = UserDefaults.standard.bool(forKey: PrefsKeys.KeyDidShowDefaultBrowserOnboarding)
-        guard !didShow else { return false }
-        
-        if currentSessionCount == maxSessionCount {
+        if currentSessionCount == DefaultBrowserOnboardingViewModel.maxSessionCount {
             shouldShow = true
             UserDefaults.standard.set(true, forKey: PrefsKeys.KeyDidShowDefaultBrowserOnboarding)
         }

--- a/Client/Frontend/Home/DefaultBrowserCard.swift
+++ b/Client/Frontend/Home/DefaultBrowserCard.swift
@@ -4,6 +4,13 @@
 
 import Storage
 import Shared
+import UIKit
+
+struct DefaultBrowserCardUX {
+    static let cardSize = CGSize(width: 360, height: 224)
+    static let logoSize = CGSize(width: 64, height: 64)
+    static let learnHowButtonSize: CGSize = CGSize(width: 304, height: 44)
+}
 
 class DefaultBrowserCard: UIView {
     
@@ -19,6 +26,7 @@ class DefaultBrowserCard: UIView {
         label.font = UIFont.systemFont(ofSize: 20, weight: .bold)
         label.textColor = UIColor.theme.defaultBrowserCard.textColor
     }
+
     private lazy var descriptionText: UILabel = .build { label in
         label.text = String.DefaultBrowserCardDescription
         label.numberOfLines = 4
@@ -27,6 +35,7 @@ class DefaultBrowserCard: UIView {
         label.font = UIFont.systemFont(ofSize: 15, weight: .regular)
         label.textColor = UIColor.theme.defaultBrowserCard.textColor
     }
+
     private lazy var learnHowButton: UIButton = .build { [weak self] button in
         button.setTitle(String.PrivateBrowsingLearnMore, for: .normal) // TODO update string
         button.backgroundColor = UIColor.Photon.Blue50
@@ -37,16 +46,27 @@ class DefaultBrowserCard: UIView {
         button.accessibilityIdentifier = "Home.learnMoreDefaultBrowserbutton"
         button.addTarget(self, action: #selector(self?.showOnboarding), for: .touchUpInside)
     }
+
     private lazy var image: UIImageView = .build { imageView in
         imageView.image = UIImage(named: "splash")
         imageView.contentMode = .scaleAspectFit
     }
+
     private lazy var closeButton: UIButton = .build { [weak self] button in
         button.setImage(UIImage(named: "nav-stop")?.withRenderingMode(.alwaysTemplate), for: .normal)
         button.imageView?.tintColor = UIColor.theme.defaultBrowserCard.textColor
         button.addTarget(self, action: #selector(self?.dismissCard), for: .touchUpInside)
     }
+
+    private lazy var scrollView: UIScrollView = .build { view in
+        view.backgroundColor = .clear
+    }
+
     private lazy var containerView: UIView = .build { view in
+        view.backgroundColor = .clear
+    }
+
+    private lazy var cardView: UIView = .build { view in
         view.backgroundColor = UIColor.theme.defaultBrowserCard.backgroundColor
         view.layer.cornerRadius = 12
         view.layer.masksToBounds = true
@@ -65,40 +85,71 @@ class DefaultBrowserCard: UIView {
     }
     
     private func setupLayout() {
-        containerView.addSubviews(learnHowButton, image, title, descriptionText, closeButton)
-        addSubview(containerView)
+        cardView.addSubviews(learnHowButton, image, title, descriptionText, closeButton)
+        containerView.addSubview(cardView)
+        scrollView.addSubview(containerView)
+        addSubview(scrollView)
+
+        let frameGuide = scrollView.frameLayoutGuide
+        let contentGuide = scrollView.contentLayoutGuide
         
         NSLayoutConstraint.activate([
-            containerView.topAnchor.constraint(equalTo: topAnchor, constant: 20),
-            containerView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
-            containerView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -20),
-            containerView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
-            containerView.heightAnchor.constraint(equalToConstant: 224),
+            // Constraints that set the size and position of the scroll view relative to its superview
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            scrollView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            scrollView.topAnchor.constraint(equalTo: containerView.topAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+            containerView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+
+            // Constraints that set the size of the scrollable content area inside the scrollview
+            frameGuide.leadingAnchor.constraint(equalTo: leadingAnchor),
+            frameGuide.topAnchor.constraint(equalTo: topAnchor),
+            frameGuide.trailingAnchor.constraint(equalTo: trailingAnchor),
+            frameGuide.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            contentGuide.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            contentGuide.topAnchor.constraint(equalTo: containerView.topAnchor),
+            contentGuide.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            contentGuide.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+            contentGuide.widthAnchor.constraint(equalTo: frameGuide.widthAnchor),
+
+            cardView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 20),
+            cardView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -20),
+            cardView.leadingAnchor.constraint(greaterThanOrEqualTo: containerView.leadingAnchor, constant: 20),
+            cardView.trailingAnchor.constraint(lessThanOrEqualTo: containerView.trailingAnchor, constant: -20),
+            cardView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
+            cardView.widthAnchor.constraint(equalToConstant: DefaultBrowserCardUX.cardSize.width),
+            cardView.heightAnchor.constraint(equalToConstant: DefaultBrowserCardUX.cardSize.height),
             
-            image.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 48),
-            image.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
-            image.widthAnchor.constraint(equalToConstant: 64),
-            image.heightAnchor.constraint(equalToConstant: 64),
-            
+            image.topAnchor.constraint(equalTo: cardView.topAnchor, constant: 48),
+            image.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: 16),
+            image.widthAnchor.constraint(equalToConstant: DefaultBrowserCardUX.logoSize.width),
+            image.heightAnchor.constraint(equalToConstant: DefaultBrowserCardUX.logoSize.height),
+
             title.topAnchor.constraint(equalTo: image.topAnchor, constant: -16),
             title.leadingAnchor.constraint(equalTo: image.trailingAnchor, constant: 16),
-            title.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-            
+            title.trailingAnchor.constraint(equalTo: cardView.trailingAnchor),
+
             descriptionText.topAnchor.constraint(equalTo: title.bottomAnchor),
             descriptionText.leadingAnchor.constraint(equalTo: title.leadingAnchor),
-            descriptionText.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -12),
-            
-            closeButton.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 16),
-            closeButton.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
+            descriptionText.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -12),
+            descriptionText.bottomAnchor.constraint(greaterThanOrEqualTo: learnHowButton.topAnchor, constant: -16),
+
+            closeButton.topAnchor.constraint(equalTo: cardView.topAnchor, constant: 16),
+            closeButton.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -16),
             closeButton.heightAnchor.constraint(equalToConstant: 16),
             closeButton.widthAnchor.constraint(equalToConstant: 16),
-            
-            learnHowButton.centerXAnchor.constraint(equalTo: centerXAnchor),
-            learnHowButton.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -16),
-            learnHowButton.widthAnchor.constraint(equalToConstant: 304),
-            learnHowButton.heightAnchor.constraint(equalToConstant: 44)
-        ])
 
+            learnHowButton.centerXAnchor.constraint(equalTo: cardView.centerXAnchor),
+            learnHowButton.bottomAnchor.constraint(equalTo: cardView.bottomAnchor, constant: -16),
+            learnHowButton.widthAnchor.constraint(equalToConstant: DefaultBrowserCardUX.learnHowButtonSize.width),
+            learnHowButton.heightAnchor.constraint(equalToConstant: DefaultBrowserCardUX.learnHowButtonSize.height)
+        ])
     }
     
     @objc private func dismissCard() {
@@ -116,10 +167,11 @@ class DefaultBrowserCard: UIView {
     }
     
     func applyTheme() {
-        containerView.backgroundColor = UIColor.theme.defaultBrowserCard.backgroundColor
+        cardView.backgroundColor = UIColor.theme.defaultBrowserCard.backgroundColor
         title.textColor = UIColor.theme.defaultBrowserCard.textColor
         descriptionText.textColor = UIColor.theme.defaultBrowserCard.textColor
         closeButton.imageView?.tintColor = UIColor.theme.defaultBrowserCard.textColor
+        containerView.backgroundColor = .clear
         backgroundColor = .clear
     }
 }

--- a/Client/Frontend/Reader/ReaderModeBarView.swift
+++ b/Client/Frontend/Reader/ReaderModeBarView.swift
@@ -46,6 +46,7 @@ protocol ReaderModeBarViewDelegate {
 class ReaderModeBarView: UIView, AlphaDimmable {
     var delegate: ReaderModeBarViewDelegate?
 
+    var isBottomPresented: Bool = false
     var readStatusButton: UIButton!
     var settingsButton: UIButton!
     var listStatusButton: UIButton!
@@ -93,11 +94,11 @@ class ReaderModeBarView: UIView, AlphaDimmable {
         super.draw(rect)
         guard let context = UIGraphicsGetCurrentContext() else { return }
         context.setLineWidth(0.5)
-        context.setStrokeColor(red: 0.1, green: 0.1, blue: 0.1, alpha: 1.0)
         context.setStrokeColor(UIColor.Photon.Grey50.cgColor)
         context.beginPath()
-        context.move(to: CGPoint(x: 0, y: frame.height))
-        context.addLine(to: CGPoint(x: frame.width, y: frame.height))
+        let yPosition = isBottomPresented ? 0 : frame.height
+        context.move(to: CGPoint(x: 0, y: yPosition))
+        context.addLine(to: CGPoint(x: frame.width, y: yPosition))
         context.strokePath()
     }
 

--- a/Client/Frontend/Reader/ReaderModeBarView.swift
+++ b/Client/Frontend/Reader/ReaderModeBarView.swift
@@ -43,10 +43,13 @@ protocol ReaderModeBarViewDelegate {
     func readerModeBar(_ readerModeBar: ReaderModeBarView, didSelectButton buttonType: ReaderModeBarButtonType)
 }
 
-class ReaderModeBarView: UIView, AlphaDimmable {
+class ReaderModeBarView: UIView, AlphaDimmable, TopBottomInterchangeable {
     var delegate: ReaderModeBarViewDelegate?
 
-    var isBottomPresented: Bool = false
+    var parent: UIStackView?
+    private var isBottomPresented: Bool {
+        BrowserViewController.foregroundBVC().isBottomSearchBar
+    }
     var readStatusButton: UIButton!
     var settingsButton: UIButton!
     var listStatusButton: UIButton!

--- a/Client/Frontend/Reader/ReaderModeStyleViewController.swift
+++ b/Client/Frontend/Reader/ReaderModeStyleViewController.swift
@@ -5,28 +5,7 @@
 import UIKit
 import Shared
 
-private struct ReaderModeStyleViewControllerUX {
-    static let RowHeight = 50.0
-    
-    static let SeparatorLineThickness = 1.0
-
-    static let Width = 270.0
-    static let Height = 4.0 * RowHeight + 3.0 * SeparatorLineThickness
-    
-    static let ThemeRowBackgroundColor = UIColor.Photon.White100
-    static let ThemeTitleColorLight = UIColor.Photon.Grey70
-    static let ThemeTitleColorDark = UIColor.Photon.White100
-    static let ThemeTitleColorSepia = UIColor.Photon.Grey70
-    static let ThemeBackgroundColorLight = UIColor.Photon.White100
-    static let ThemeBackgroundColorDark = UIColor.Photon.Grey80
-    static let ThemeBackgroundColorSepia = UIColor.Defaults.LightBeige
-
-    static let BrightnessSliderTintColor = UIColor.Photon.Orange60
-    static let BrightnessSliderWidth = 140
-    static let BrightnessIconOffset = 10
-}
-
-// MARK: -
+// MARK: - ReaderModeStyleViewControllerDelegate
 
 protocol ReaderModeStyleViewControllerDelegate {    
     // isUsingUserDefinedColor should be false by default unless we need to override the default color 
@@ -35,11 +14,10 @@ protocol ReaderModeStyleViewControllerDelegate {
                                        isUsingUserDefinedColor: Bool)
 }
 
-// MARK: -
+// MARK: - ReaderModeStyleViewController
 
 class ReaderModeStyleViewController: UIViewController, NotificationThemeable {
     var delegate: ReaderModeStyleViewControllerDelegate?
-    var readerModeStyle: ReaderModeStyle = DefaultReaderModeStyle
 
     fileprivate var fontTypeButtons: [FontTypeButton]!
     fileprivate var fontSizeLabel: FontSizeLabel!
@@ -53,11 +31,20 @@ class ReaderModeStyleViewController: UIViewController, NotificationThemeable {
     
     // Keeps user-defined reader color until reader mode is closed or reloaded
     fileprivate var isUsingUserDefinedColor = false
+
+    private var viewModel: ReaderModeStyleViewModel!
+
+    static func initReaderModeViewController(viewModel: ReaderModeStyleViewModel) -> ReaderModeStyleViewController {
+        let readerModeController = ReaderModeStyleViewController()
+        readerModeController.viewModel = viewModel
+
+        return readerModeController
+    }
     
     override func viewDidLoad() {
         // Our preferred content size has a fixed width and height based on the rows + padding
         super.viewDidLoad()
-        preferredContentSize = CGSize(width: ReaderModeStyleViewControllerUX.Width, height: ReaderModeStyleViewControllerUX.Height)
+        preferredContentSize = CGSize(width: ReaderModeStyleViewModel.Width, height: ReaderModeStyleViewModel.Height)
         popoverPresentationController?.backgroundColor = UIColor.theme.tableView.rowBackground
 
         // Font type row
@@ -66,9 +53,9 @@ class ReaderModeStyleViewController: UIViewController, NotificationThemeable {
         view.addSubview(fontTypeRow)
 
         fontTypeRow.snp.makeConstraints { (make) -> Void in
-            make.top.equalTo(self.view).offset(13)
+            make.top.equalTo(self.view).offset(viewModel.fontTypeOffset)
             make.left.right.equalTo(self.view)
-            make.height.equalTo(ReaderModeStyleViewControllerUX.RowHeight)
+            make.height.equalTo(ReaderModeStyleViewModel.RowHeight)
         }
 
         fontTypeButtons = [
@@ -89,7 +76,7 @@ class ReaderModeStyleViewController: UIViewController, NotificationThemeable {
         fontSizeRow.snp.makeConstraints { (make) -> Void in
             make.top.equalTo(separatorLines[0].snp.bottom)
             make.left.right.equalTo(self.view)
-            make.height.equalTo(ReaderModeStyleViewControllerUX.RowHeight)
+            make.height.equalTo(ReaderModeStyleViewModel.RowHeight)
         }
 
         fontSizeLabel = FontSizeLabel()
@@ -119,7 +106,7 @@ class ReaderModeStyleViewController: UIViewController, NotificationThemeable {
         themeRow.snp.makeConstraints { (make) -> Void in
             make.top.equalTo(separatorLines[1].snp.bottom)
             make.left.right.equalTo(self.view)
-            make.height.equalTo(ReaderModeStyleViewControllerUX.RowHeight)
+            make.height.equalTo(ReaderModeStyleViewModel.RowHeight)
         }
 
         themeButtons = [
@@ -141,18 +128,19 @@ class ReaderModeStyleViewController: UIViewController, NotificationThemeable {
         brightnessRow.snp.makeConstraints { (make) -> Void in
             make.top.equalTo(separatorLines[2].snp.bottom)
             make.left.right.equalTo(self.view)
-            make.height.equalTo(ReaderModeStyleViewControllerUX.RowHeight)
+            make.height.equalTo(ReaderModeStyleViewModel.RowHeight)
+            make.bottom.equalTo(self.view).offset(viewModel.brightnessRowOffset)
         }
 
         let slider = UISlider()
         brightnessRow.addSubview(slider)
         slider.accessibilityLabel = .ReaderModeStyleBrightnessAccessibilityLabel
-        slider.tintColor = ReaderModeStyleViewControllerUX.BrightnessSliderTintColor
+        slider.tintColor = ReaderModeStyleViewModel.BrightnessSliderTintColor
         slider.addTarget(self, action: #selector(changeBrightness), for: .valueChanged)
 
         slider.snp.makeConstraints { make in
             make.center.equalTo(brightnessRow)
-            make.width.equalTo(ReaderModeStyleViewControllerUX.BrightnessSliderWidth)
+            make.width.equalTo(ReaderModeStyleViewModel.BrightnessSliderWidth)
         }
 
         let brightnessMinImageView = UIImageView(image: UIImage(named: "brightnessMin"))
@@ -160,7 +148,7 @@ class ReaderModeStyleViewController: UIViewController, NotificationThemeable {
 
         brightnessMinImageView.snp.makeConstraints { (make) -> Void in
             make.centerY.equalTo(slider)
-            make.right.equalTo(slider.snp.left).offset(-ReaderModeStyleViewControllerUX.BrightnessIconOffset)
+            make.right.equalTo(slider.snp.left).offset(-ReaderModeStyleViewModel.BrightnessIconOffset)
         }
 
         let brightnessMaxImageView = UIImageView(image: UIImage(named: "brightnessMax"))
@@ -168,12 +156,12 @@ class ReaderModeStyleViewController: UIViewController, NotificationThemeable {
 
         brightnessMaxImageView.snp.makeConstraints { (make) -> Void in
             make.centerY.equalTo(slider)
-            make.left.equalTo(slider.snp.right).offset(ReaderModeStyleViewControllerUX.BrightnessIconOffset)
+            make.left.equalTo(slider.snp.right).offset(ReaderModeStyleViewModel.BrightnessIconOffset)
         }
 
-        selectFontType(readerModeStyle.fontType)
+        selectFontType(viewModel.readerModeStyle.fontType)
         updateFontSizeButtons()
-        selectTheme(readerModeStyle.theme)
+        selectTheme(viewModel.readerModeStyle.theme)
         slider.value = Float(UIScreen.main.brightness)
         
         applyTheme()
@@ -212,7 +200,7 @@ class ReaderModeStyleViewController: UIViewController, NotificationThemeable {
         fromView.snp.makeConstraints { (make) -> Void in
             make.top.equalTo(topConstraint.snp.bottom)
             make.left.right.equalTo(self.view)
-            make.height.equalTo(ReaderModeStyleViewControllerUX.SeparatorLineThickness)
+            make.height.equalTo(ReaderModeStyleViewModel.SeparatorLineThickness)
         }
     }
     
@@ -237,12 +225,12 @@ class ReaderModeStyleViewController: UIViewController, NotificationThemeable {
     @objc func changeFontType(_ button: FontTypeButton) {
         selectFontType(button.fontType)
         delegate?.readerModeStyleViewController(self, 
-                                                didConfigureStyle: readerModeStyle, 
+                                                didConfigureStyle: viewModel.readerModeStyle,
                                                 isUsingUserDefinedColor: isUsingUserDefinedColor)
     }
 
     fileprivate func selectFontType(_ fontType: ReaderModeFontType) {
-        readerModeStyle.fontType = fontType
+        viewModel.readerModeStyle.fontType = fontType
         for button in fontTypeButtons {
             button.isSelected = button.fontType.isSameFamily(fontType)
         }
@@ -255,16 +243,16 @@ class ReaderModeStyleViewController: UIViewController, NotificationThemeable {
     @objc func changeFontSize(_ button: FontSizeButton) {
         switch button.fontSizeAction {
         case .smaller:
-            readerModeStyle.fontSize = readerModeStyle.fontSize.smaller()
+            viewModel.readerModeStyle.fontSize = viewModel.readerModeStyle.fontSize.smaller()
         case .bigger:
-            readerModeStyle.fontSize = readerModeStyle.fontSize.bigger()
+            viewModel.readerModeStyle.fontSize = viewModel.readerModeStyle.fontSize.bigger()
         case .reset:
-            readerModeStyle.fontSize = ReaderModeFontSize.defaultSize
+            viewModel.readerModeStyle.fontSize = ReaderModeFontSize.defaultSize
         }
         updateFontSizeButtons()
 
         delegate?.readerModeStyleViewController(self, 
-                                                didConfigureStyle: readerModeStyle, 
+                                                didConfigureStyle: viewModel.readerModeStyle,
                                                 isUsingUserDefinedColor: isUsingUserDefinedColor)
     }
 
@@ -272,10 +260,10 @@ class ReaderModeStyleViewController: UIViewController, NotificationThemeable {
         for button in fontSizeButtons {
             switch button.fontSizeAction {
             case .bigger:
-                button.isEnabled = !readerModeStyle.fontSize.isLargest()
+                button.isEnabled = !viewModel.readerModeStyle.fontSize.isLargest()
                 break
             case .smaller:
-                button.isEnabled = !readerModeStyle.fontSize.isSmallest()
+                button.isEnabled = !viewModel.readerModeStyle.fontSize.isSmallest()
                 break
             case .reset:
                 break
@@ -287,12 +275,12 @@ class ReaderModeStyleViewController: UIViewController, NotificationThemeable {
         selectTheme(button.theme)
         isUsingUserDefinedColor = true
         delegate?.readerModeStyleViewController(self, 
-                                                didConfigureStyle: readerModeStyle, 
+                                                didConfigureStyle: viewModel.readerModeStyle,
                                                 isUsingUserDefinedColor: true)
     }
 
     fileprivate func selectTheme(_ theme: ReaderModeTheme) {
-        readerModeStyle.theme = theme
+        viewModel.readerModeStyle.theme = theme
     }
 
     @objc func changeBrightness(_ slider: UISlider) {
@@ -300,7 +288,7 @@ class ReaderModeStyleViewController: UIViewController, NotificationThemeable {
     }
 }
 
-// MARK: -
+// MARK: - FontTypeButton
 
 class FontTypeButton: UIButton {
     var fontType: ReaderModeFontType = .sansSerif
@@ -324,7 +312,7 @@ class FontTypeButton: UIButton {
     }
 }
 
-// MARK: -
+// MARK: - FontSizeAction
 
 enum FontSizeAction {
     case smaller
@@ -355,7 +343,7 @@ class FontSizeButton: UIButton {
     }
 }
 
-// MARK: -
+// MARK: - FontSizeLabel
 
 class FontSizeLabel: UILabel {
     override init(frame: CGRect) {
@@ -382,7 +370,7 @@ class FontSizeLabel: UILabel {
     }
 }
 
-// MARK: -
+// MARK: - ThemeButton
 
 class ThemeButton: UIButton {
     var theme: ReaderModeTheme!
@@ -398,16 +386,16 @@ class ThemeButton: UIButton {
         switch theme {
         case .light:
             setTitle(.ReaderModeStyleLightLabel, for: [])
-            setTitleColor(ReaderModeStyleViewControllerUX.ThemeTitleColorLight, for: .normal)
-            backgroundColor = ReaderModeStyleViewControllerUX.ThemeBackgroundColorLight
+            setTitleColor(ReaderModeStyleViewModel.ThemeTitleColorLight, for: .normal)
+            backgroundColor = ReaderModeStyleViewModel.ThemeBackgroundColorLight
         case .dark:
             setTitle(.ReaderModeStyleDarkLabel, for: [])
-            setTitleColor(ReaderModeStyleViewControllerUX.ThemeTitleColorDark, for: [])
-            backgroundColor = ReaderModeStyleViewControllerUX.ThemeBackgroundColorDark
+            setTitleColor(ReaderModeStyleViewModel.ThemeTitleColorDark, for: [])
+            backgroundColor = ReaderModeStyleViewModel.ThemeBackgroundColorDark
         case .sepia:
             setTitle(.ReaderModeStyleSepiaLabel, for: [])
-            setTitleColor(ReaderModeStyleViewControllerUX.ThemeTitleColorSepia, for: .normal)
-            backgroundColor = ReaderModeStyleViewControllerUX.ThemeBackgroundColorSepia
+            setTitleColor(ReaderModeStyleViewModel.ThemeTitleColorSepia, for: .normal)
+            backgroundColor = ReaderModeStyleViewModel.ThemeBackgroundColorSepia
         }
     }
 

--- a/Client/Frontend/Reader/ReaderModeStyleViewModel.swift
+++ b/Client/Frontend/Reader/ReaderModeStyleViewModel.swift
@@ -6,10 +6,10 @@ import Foundation
 
 // MARK: - ReaderModeStyleViewModel
 
-// TODO: move all logic from VC in this view model
 struct ReaderModeStyleViewModel {
     static let RowHeight = 50.0
-    static let PresentationSpace = 13.0 // For top or bottom presentation
+    // For top or bottom presentation
+    static let PresentationSpace = 13.0
 
     static let SeparatorLineThickness = 1.0
 

--- a/Client/Frontend/Reader/ReaderModeStyleViewModel.swift
+++ b/Client/Frontend/Reader/ReaderModeStyleViewModel.swift
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+// MARK: - ReaderModeStyleViewModel
+
+// TODO: move all logic from VC in this view model
+struct ReaderModeStyleViewModel {
+    static let RowHeight = 50.0
+    static let PresentationSpace = 13.0 // For top or bottom presentation
+
+    static let SeparatorLineThickness = 1.0
+
+    static let Width = 270.0
+    static let Height = 4.0 * RowHeight + 3.0 * SeparatorLineThickness
+
+    static let ThemeRowBackgroundColor = UIColor.Photon.White100
+    static let ThemeTitleColorLight = UIColor.Photon.Grey70
+    static let ThemeTitleColorDark = UIColor.Photon.White100
+    static let ThemeTitleColorSepia = UIColor.Photon.Grey70
+    static let ThemeBackgroundColorLight = UIColor.Photon.White100
+    static let ThemeBackgroundColorDark = UIColor.Photon.Grey80
+    static let ThemeBackgroundColorSepia = UIColor.Defaults.LightBeige
+
+    static let BrightnessSliderTintColor = UIColor.Photon.Orange60
+    static let BrightnessSliderWidth = 140
+    static let BrightnessIconOffset = 10
+
+    var isBottomPresented: Bool
+    var readerModeStyle: ReaderModeStyle = DefaultReaderModeStyle
+
+    var fontTypeOffset: CGFloat {
+        return isBottomPresented ? 0 : ReaderModeStyleViewModel.PresentationSpace
+    }
+
+    var brightnessRowOffset: CGFloat {
+        return isBottomPresented ? -ReaderModeStyleViewModel.PresentationSpace : 0
+    }
+}

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -1265,6 +1265,32 @@ class ThemeSetting: Setting {
     }
 }
 
+class SearchBarSetting: Setting {
+    let viewModel: SearchBarSettingsViewModel
+
+    override var accessoryView: UIImageView? { return disclosureIndicator }
+
+    override var accessibilityIdentifier: String? { return AccessibilityIdentifiers.Settings.SearchBar.searchBarSetting }
+
+    override var status: NSAttributedString {
+        return NSAttributedString(string: viewModel.searchBarTitle )
+    }
+
+    override var style: UITableViewCell.CellStyle { return .value1 }
+
+    init(settings: SettingsTableViewController) {
+        self.viewModel = SearchBarSettingsViewModel(prefs: settings.profile.prefs)
+        super.init(title: NSAttributedString(string: viewModel.title,
+                                             attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        let viewController = SearchBarSettingsViewController(viewModel: viewModel)
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
+
 extension BrowserViewController {
     /// ⚠️ !! WARNING !! ⚠️
     /// This function opens up x number of new tabs in the background.

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -71,7 +71,7 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagsP
                         titleText: .AppSettingsBlockPopups),
            ]
 
-        if featureFlags.isFeatureActiveForBuild(.bottomSearchBar) && SearchBarSettingsViewModel.isEnabled {
+        if SearchBarSettingsViewModel.isEnabled {
             generalSettings.insert(SearchBarSetting(settings: self), at: 5)
         }
 

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -66,11 +66,11 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagsP
             HomeSetting(settings: self),
             OpenWithSetting(settings: self),
             ThemeSetting(settings: self),
+            SearchBarSetting(settings: self),
+            SiriPageSetting(settings: self),
             BoolSetting(prefs: prefs, prefKey: PrefsKeys.KeyBlockPopups, defaultValue: true,
                         titleText: .AppSettingsBlockPopups),
            ]
-
-        generalSettings.insert(SiriPageSetting(settings: self), at: 5)
 
         if featureFlags.isFeatureActiveForBuild(.groupedTabs) || featureFlags.isFeatureActiveForBuild(.inactiveTabs) {
             generalSettings.insert(TabsSetting(), at: 3)

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -66,11 +66,14 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagsP
             HomeSetting(settings: self),
             OpenWithSetting(settings: self),
             ThemeSetting(settings: self),
-            SearchBarSetting(settings: self),
             SiriPageSetting(settings: self),
             BoolSetting(prefs: prefs, prefKey: PrefsKeys.KeyBlockPopups, defaultValue: true,
                         titleText: .AppSettingsBlockPopups),
            ]
+
+        if featureFlags.isFeatureActiveForBuild(.bottomSearchBar) && SearchBarSettingsViewModel.isEnabled {
+            generalSettings.insert(SearchBarSetting(settings: self), at: 5)
+        }
 
         if featureFlags.isFeatureActiveForBuild(.groupedTabs) || featureFlags.isFeatureActiveForBuild(.inactiveTabs) {
             generalSettings.insert(TabsSetting(), at: 3)

--- a/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewController.swift
+++ b/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewController.swift
@@ -30,12 +30,6 @@ class SearchBarSettingsViewController: SettingsTableViewController {
         return [section]
     }
 
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        // laurie - need to update?
-//        NotificationCenter.default.post(name: .HomePanelPrefsChanged, object: nil)
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.keyboardDismissMode = .onDrag

--- a/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewController.swift
+++ b/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewController.swift
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Shared
+
+class SearchBarSettingsViewController: SettingsTableViewController {
+
+    private let viewModel: SearchBarSettingsViewModel
+
+    init(viewModel: SearchBarSettingsViewModel) {
+        self.viewModel = viewModel
+        super.init(style: .grouped)
+        
+        title = viewModel.title
+        viewModel.delegate = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func generateSettings() -> [SettingSection] {
+        let showTop = viewModel.topSetting
+        let showBottom = viewModel.bottomSetting
+        let section = SettingSection(children: [showTop, showBottom])
+
+        return [section]
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        // laurie - need to update?
+//        NotificationCenter.default.post(name: .HomePanelPrefsChanged, object: nil)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.keyboardDismissMode = .onDrag
+    }
+}
+
+extension SearchBarSettingsViewController: SearchBarPreferenceDelegate {
+    func didUpdateSearchBarPositionPreference() {
+        tableView.reloadData()
+    }
+}

--- a/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
+++ b/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
@@ -33,6 +33,10 @@ final class SearchBarSettingsViewModel {
         self.prefs = prefs
     }
 
+    static var isEnabled: Bool {
+        return UIDevice.current.userInterfaceIdiom != .pad
+    }
+
     var searchBarTitle: String {
         searchBarPosition.getLocalizedTitle
     }
@@ -75,6 +79,9 @@ private extension SearchBarSettingsViewModel {
                         forKey: PrefsKeys.KeySearchBarPosition)
         delegate?.didUpdateSearchBarPositionPreference()
         recordPreferenceChange(searchBarPosition)
+
+        let notificationObject = [PrefsKeys.KeySearchBarPosition: searchBarPosition]
+        NotificationCenter.default.post(name: .SearchBarPositionDidChange, object: notificationObject)
     }
 
     /// New user defaults to bottom search bar, existing users keep their existing search bar position

--- a/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
+++ b/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
@@ -34,7 +34,9 @@ final class SearchBarSettingsViewModel {
     }
 
     static var isEnabled: Bool {
-        return UIDevice.current.userInterfaceIdiom != .pad
+        let isiPad = UIDevice.current.userInterfaceIdiom != .pad
+        let isFeatureEnabled = FeatureFlagsManager.shared.isFeatureActiveForBuild(.bottomSearchBar)
+        return !isiPad && isFeatureEnabled
     }
 
     var searchBarTitle: String {

--- a/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
+++ b/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
@@ -1,0 +1,90 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Shared
+
+enum SearchBarPosition: String {
+    case bottom
+    case top
+
+    var getLocalizedTitle: String {
+        switch self {
+        case .bottom:
+            return .Settings.Toolbar.Bottom
+        case .top:
+            return .Settings.Toolbar.Top
+        }
+    }
+}
+
+protocol SearchBarPreferenceDelegate: AnyObject {
+    func didUpdateSearchBarPositionPreference()
+}
+
+final class SearchBarSettingsViewModel {
+
+    var title: String = .Settings.Toolbar.Toolbar
+    weak var delegate: SearchBarPreferenceDelegate?
+
+    private let prefs: Prefs
+    init(prefs: Prefs) {
+        self.prefs = prefs
+    }
+
+    var searchBarTitle: String {
+        searchBarPosition.getLocalizedTitle
+    }
+
+    var searchBarPosition: SearchBarPosition {
+        let defaultPosition = getDefaultSearchPosition()
+        guard let raw = prefs.stringForKey(PrefsKeys.KeySearchBarPosition) else {
+            saveSearchBarPosition(defaultPosition)
+            return defaultPosition
+        }
+
+        let position = SearchBarPosition(rawValue: raw) ?? .bottom
+        return position
+    }
+
+    var topSetting: CheckmarkSetting {
+        return CheckmarkSetting(
+            title: NSAttributedString(string: SearchBarPosition.top.getLocalizedTitle), subtitle: nil,
+            accessibilityIdentifier: AccessibilityIdentifiers.Settings.SearchBar.topSetting,
+            isChecked: { return self.searchBarPosition == .top },
+            onChecked: { self.saveSearchBarPosition(SearchBarPosition.top)}
+        )
+    }
+
+    var bottomSetting: CheckmarkSetting {
+        return CheckmarkSetting(
+            title: NSAttributedString(string: SearchBarPosition.bottom.getLocalizedTitle), subtitle: nil,
+            accessibilityIdentifier: AccessibilityIdentifiers.Settings.SearchBar.bottomSetting,
+            isChecked: { return self.searchBarPosition == .bottom },
+            onChecked: { self.saveSearchBarPosition(SearchBarPosition.bottom) }
+        )
+    }
+}
+
+// MARK: Private
+private extension SearchBarSettingsViewModel {
+
+    func saveSearchBarPosition(_ searchBarPosition: SearchBarPosition) {
+        prefs.setString(searchBarPosition.rawValue,
+                        forKey: PrefsKeys.KeySearchBarPosition)
+        delegate?.didUpdateSearchBarPositionPreference()
+        recordPreferenceChange(searchBarPosition)
+    }
+
+    /// New user defaults to bottom search bar, existing users keep their existing search bar position
+    func getDefaultSearchPosition() -> SearchBarPosition {
+        return InstallType.get() == .fresh ? .bottom : .top
+    }
+
+    func recordPreferenceChange(_ searchBarPosition: SearchBarPosition) {
+        let extras = [TelemetryWrapper.EventExtraKey.preference.rawValue: PrefsKeys.KeySearchBarPosition,
+                      TelemetryWrapper.EventExtraKey.preferenceChanged.rawValue: searchBarPosition.rawValue]
+        TelemetryWrapper.recordEvent(category: .action, method: .change, object: .setting, extras: extras)
+    }
+}

--- a/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
+++ b/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
@@ -55,20 +55,20 @@ final class SearchBarSettingsViewModel {
     }
 
     var topSetting: CheckmarkSetting {
-        return CheckmarkSetting(
-            title: NSAttributedString(string: SearchBarPosition.top.getLocalizedTitle), subtitle: nil,
-            accessibilityIdentifier: AccessibilityIdentifiers.Settings.SearchBar.topSetting,
-            isChecked: { return self.searchBarPosition == .top },
-            onChecked: { self.saveSearchBarPosition(SearchBarPosition.top)}
+        return CheckmarkSetting(title: NSAttributedString(string: SearchBarPosition.top.getLocalizedTitle),
+                                subtitle: nil,
+                                accessibilityIdentifier: AccessibilityIdentifiers.Settings.SearchBar.topSetting,
+                                isChecked: { return self.searchBarPosition == .top },
+                                onChecked: { self.saveSearchBarPosition(SearchBarPosition.top)}
         )
     }
 
     var bottomSetting: CheckmarkSetting {
-        return CheckmarkSetting(
-            title: NSAttributedString(string: SearchBarPosition.bottom.getLocalizedTitle), subtitle: nil,
-            accessibilityIdentifier: AccessibilityIdentifiers.Settings.SearchBar.bottomSetting,
-            isChecked: { return self.searchBarPosition == .bottom },
-            onChecked: { self.saveSearchBarPosition(SearchBarPosition.bottom) }
+        return CheckmarkSetting(title: NSAttributedString(string: SearchBarPosition.bottom.getLocalizedTitle),
+                                subtitle: nil,
+                                accessibilityIdentifier: AccessibilityIdentifiers.Settings.SearchBar.bottomSetting,
+                                isChecked: { return self.searchBarPosition == .bottom },
+                                onChecked: { self.saveSearchBarPosition(SearchBarPosition.bottom) }
         )
     }
 }

--- a/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
+++ b/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
@@ -34,7 +34,7 @@ final class SearchBarSettingsViewModel {
     }
 
     static var isEnabled: Bool {
-        let isiPad = UIDevice.current.userInterfaceIdiom != .pad
+        let isiPad = UIDevice.current.userInterfaceIdiom == .pad
         let isFeatureEnabled = FeatureFlagsManager.shared.isFeatureActiveForBuild(.bottomSearchBar)
         return !isiPad && isFeatureEnabled
     }

--- a/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
+++ b/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
@@ -36,7 +36,7 @@ final class SearchBarSettingsViewModel {
     static var isEnabled: Bool {
         let isiPad = UIDevice.current.userInterfaceIdiom == .pad
         let isFeatureEnabled = FeatureFlagsManager.shared.isFeatureActiveForBuild(.bottomSearchBar)
-        return !isiPad && isFeatureEnabled
+        return !isiPad && isFeatureEnabled && !AppConstants.IsRunningTest
     }
 
     var searchBarTitle: String {

--- a/Client/Frontend/UIConstants+BottomInset.swift
+++ b/Client/Frontend/UIConstants+BottomInset.swift
@@ -7,11 +7,17 @@ import Foundation
 extension UIConstants {
     static var BottomToolbarHeight: CGFloat {
         get {
+            return ToolbarHeight + BottomInset
+        }
+    }
+
+    static var BottomInset: CGFloat {
+        get {
             var bottomInset: CGFloat = 0.0
             if let window = UIWindow.attachedKeyWindow {
                 bottomInset = window.safeAreaInsets.bottom
             }
-            return ToolbarHeight + bottomInset
+            return bottomInset
         }
     }
 }

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -12,7 +12,7 @@ extension UIColor {
         static let iOSTextHighlightBlue = UIColor(rgb: 0xccdded) // This color should exactly match the ios text highlight
         static let Purple60A30 = UIColor(rgba: 0x8000d74c)
         static let MobilePrivatePurple = UIColor.Photon.Purple60
-    // Reader Mode Sepia
+        // Reader Mode Sepia
         static let LightBeige = UIColor(rgb: 0xf0e6dc)
     }
 }

--- a/Client/Protocols/TopBottomInterchangeable.swift
+++ b/Client/Protocols/TopBottomInterchangeable.swift
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// A protocol to add and remove a view easily from a parent
+/// Used to changed search bar and reader mode bar from header to footer and vice versa
+protocol TopBottomInterchangeable: UIView {
+    var parent: UIStackView? { get set }
+    func removeFromParent()
+    func addToParent(parent: UIStackView, addToTop: Bool)
+}
+
+extension TopBottomInterchangeable {
+    func removeFromParent() {
+        parent?.removeArrangedView(self)
+    }
+
+    func addToParent(parent: UIStackView, addToTop: Bool = true) {
+        self.parent = parent
+        if addToTop {
+            parent.addArrangedViewToTop(self)
+        } else {
+            parent.addArrangedViewToBottom(self)
+        }
+        
+        updateConstraints()
+        setNeedsDisplay()
+    }
+}

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -494,7 +494,7 @@ extension TelemetryWrapper {
     static func gleanRecordEvent(category: EventCategory, method: EventMethod, object: EventObject, value: EventValue? = nil, extras: [String: Any]? = nil) {
         let value = value?.rawValue ?? ""
         switch (category, method, object, value, extras) {
-        // Bookmarks
+        // MARK: Bookmarks
         case (.action, .view, .bookmarksPanel, let from, _):
             GleanMetrics.Bookmarks.viewList[from].add()
         case (.action, .add, .bookmark, let from, _):
@@ -505,19 +505,19 @@ extension TelemetryWrapper {
             GleanMetrics.Bookmarks.open[from].add()
         case (.action, .change, .bookmark, let from, _):
             GleanMetrics.Bookmarks.edit[from].add()
-        // Reader Mode
+        // MARK: Reader Mode
         case (.action, .tap, .readerModeOpenButton, _, _):
             GleanMetrics.ReaderMode.open.add()
         case (.action, .tap, .readerModeCloseButton, _, _):
             GleanMetrics.ReaderMode.close.add()
-        // Reading List
+        // MARK: Reading List
         case (.action, .add, .readingListItem, let from, _):
             GleanMetrics.ReadingList.add[from].add()
         case (.action, .delete, .readingListItem, let from, _):
             GleanMetrics.ReadingList.delete[from].add()
         case (.action, .open, .readingListItem, _, _):
             GleanMetrics.ReadingList.open.add()
-        // Top Site
+        // MARK: Top Site
         case (.action, .tap, .topSiteTile, _, let extras):
             if let homePageOrigin = extras?[EventExtraKey.fxHomepageOrigin.rawValue] as? String {
                 GleanMetrics.TopSite.pressedTileOrigin[homePageOrigin].add()
@@ -529,7 +529,8 @@ extension TelemetryWrapper {
                 let msg = "Uninstrumented pref metric: \(category), \(method), \(object), \(value), \(String(describing: extras))"
                 Sentry.shared.send(message: msg, severity: .debug)
             }
-        // Preferences
+
+        // MARK: Preferences
         case (.action, .change, .setting, _, let extras):
             if let preference = extras?[EventExtraKey.preference.rawValue] as? String, let to = ((extras?[EventExtraKey.preferenceChanged.rawValue]) ?? "undefined") as? String {
                 GleanMetrics.Preferences.changed.record(GleanMetrics.Preferences.ChangedExtra(changedTo: to, preference: preference))
@@ -537,11 +538,13 @@ extension TelemetryWrapper {
                 let msg = "Uninstrumented pref metric: \(category), \(method), \(object), \(value), \(String(describing: extras))"
                 Sentry.shared.send(message: msg, severity: .debug)
             }
-        // QR Codes
+
+        // MARK: QR Codes
         case (.action, .scan, .qrCodeText, _, _),
              (.action, .scan, .qrCodeURL, _, _):
             GleanMetrics.QrCode.scanned.add()
-        // Tabs
+
+        // MARK: Tabs
         case (.action, .add, .tab, let privateOrNormal, _):
             GleanMetrics.Tabs.open[privateOrNormal].add()
         case (.action, .close, .tab, let privateOrNormal, _):
@@ -568,13 +571,16 @@ extension TelemetryWrapper {
             GleanMetrics.Tabs.navigateTabBackSwipe.add()
         case(.action, .tap, .reloadFromUrlBar, _, _):
             GleanMetrics.Tabs.reloadFromUrlBar.add()
-        // Settings Menu
+
+        // MARK: Settings Menu
         case (.action, .open, .settingsMenuSetAsDefaultBrowser, _, _):
             GleanMetrics.SettingsMenu.setAsDefaultBrowserPressed.add()
-        // Start Search Button
+
+        // MARK: Start Search Button
         case (.action, .tap, .startSearchButton, _, _):
             GleanMetrics.Search.startSearchPressed.add()
-        // Default Browser
+
+        // MARK: Default Browser
         case (.action, .tap, .dismissDefaultBrowserCard, _, _):
             GleanMetrics.DefaultBrowserCard.dismissPressed.add()
         case (.action, .tap, .goToSettingsDefaultBrowserCard, _, _):
@@ -585,7 +591,8 @@ extension TelemetryWrapper {
             GleanMetrics.DefaultBrowserOnboarding.dismissPressed.add()
         case (.action, .tap, .goToSettingsDefaultBrowserOnboarding, _, _):
             GleanMetrics.DefaultBrowserOnboarding.goToSettingsPressed.add()
-        // Onboarding
+
+        // MARK: Onboarding
         case (.action, .press, .dismissedOnboarding, _, let extras):
             if let slideNum = extras?["slide-num"] as? Int32 {
                 GleanMetrics.Onboarding.finish.record(GleanMetrics.Onboarding.FinishExtra(slideNum: slideNum))
@@ -609,7 +616,8 @@ extension TelemetryWrapper {
             GleanMetrics.Onboarding.syncScreenSignUp.add()
         case(.action, .press, .syncScreenStartBrowse, _, _):
             GleanMetrics.Onboarding.syncScreenBrowse.add()
-        // Widget
+
+        // MARK: Widget
         case (.action, .open, .mediumTabsOpenUrl, _, _):
             GleanMetrics.Widget.mTabsOpenUrl.add()
         case (.action, .open, .largeTabsOpenUrl, _, _):
@@ -627,7 +635,7 @@ extension TelemetryWrapper {
         case (.action, .open, .mediumTopSitesWidget, _, _):
             GleanMetrics.Widget.mTopSitesWidget.add()
 
-        // Pocket
+        // MARK: Pocket
         case (.action, .tap, .pocketStory, _, let extras):
             if let homePageOrigin = extras?[EventExtraKey.fxHomepageOrigin.rawValue] as? String {
                 GleanMetrics.Pocket.openStoryOrigin[homePageOrigin].add()
@@ -642,17 +650,18 @@ extension TelemetryWrapper {
         case (.action, .view, .pocketSectionImpression, _, _):
             GleanMetrics.Pocket.sectionImpressions.add()
 
-        // Library
+        // MARK: Library
         case (.action, .tap, .libraryPanel, let type, _):
             GleanMetrics.Library.panelPressed[type].add()
-        // Sync
+        // MARK: Sync
         case (.action, .open, .syncTab, _, _):
             GleanMetrics.Sync.openTab.add()
         case (.action, .tap, .syncSignIn, _, _):
             GleanMetrics.Sync.signInSyncPressed.add()
         case (.action, .tap, .syncCreateAccount, _, _):
             GleanMetrics.Sync.createAccountPressed.add()
-        // App menu
+
+        // MARK: App menu
         case (.action, .tap, .logins, _, _):
             GleanMetrics.AppMenu.logins.add()
         case (.action, .tap, .signIntoSync, _, _):
@@ -674,7 +683,7 @@ extension TelemetryWrapper {
         case (.action, .open, .settings, _, _):
             GleanMetrics.AppMenu.settings.add()
 
-        // Page Menu
+        // MARK: Page Menu
         case (.action, .tap, .sharePageWith, _, _):
             GleanMetrics.PageActionMenu.sharePageWith.add()
         case (.action, .tap, .sendToDevice, _, _):
@@ -694,7 +703,7 @@ extension TelemetryWrapper {
         case (.action, .tap, .requestMobileSite, _, _):
             GleanMetrics.PageActionMenu.requestMobileSite.add()
 
-        // Inactive Tab Tray
+        // MARK: Inactive Tab Tray
         case (.action, .tap, .inactiveTabTray, EventValue.openInactiveTab.rawValue, _):
             GleanMetrics.InactiveTabsTray.openInactiveTab.add()
         case (.action, .tap, .inactiveTabTray, EventValue.inactiveTabExpand.rawValue, _):
@@ -706,7 +715,7 @@ extension TelemetryWrapper {
         case (.action, .tap, .inactiveTabTray, EventValue.openRecentlyClosedTab.rawValue, _):
             GleanMetrics.InactiveTabsTray.openRecentlyClosedTab.add()
 
-        // Tab Groups
+        // MARK: Tab Groups
         case (.action, .view, .tabTray, EventValue.tabGroupWithExtras.rawValue, let extras):
            let groupedTabExtras = GleanMetrics.Tabs.GroupedTabExtra.init(averageTabsInAllGroups: extras?["\(EventExtraKey.averageTabsInAllGroups)"] as? Int32, groupsTwoTabsOnly: extras?["\(EventExtraKey.groupsWithTwoTabsOnly)"] as? Int32, groupsWithMoreThanTwoTab: extras?["\(EventExtraKey.groupsWithTwoMoreTab)"] as? Int32, totalNumOfGroups: extras?["\(EventExtraKey.totalNumberOfGroups)"] as? Int32, totalTabsInAllGroups: extras?["\(EventExtraKey.totalTabsInAllGroups)"] as? Int32)
             GleanMetrics.Tabs.groupedTab.record(groupedTabExtras)
@@ -715,7 +724,7 @@ extension TelemetryWrapper {
         case (.action, .tap, .groupedTabPerformSearch, _, _):
             GleanMetrics.Tabs.groupedTabSearch.add()
             
-        // Firefox Homepage
+        // MARK: Firefox Homepage
         case (.action, .view, .firefoxHomepage, EventValue.fxHomepageOrigin.rawValue, let extras):
             if let homePageOrigin = extras?[EventExtraKey.fxHomepageOrigin.rawValue] as? String {
                 GleanMetrics.FirefoxHomePage.firefoxHomepageOrigin[homePageOrigin].add()

--- a/Client/UIStackViewExtensions.swift
+++ b/Client/UIStackViewExtensions.swift
@@ -28,7 +28,7 @@ extension UIStackView {
     }
 
     func insertArrangedView(_ view: UIView, position: Int, animated: Bool = true, completion: (() -> Void)? = nil) {
-        guard position < arrangedSubviews.count, position >= 0 else {
+        guard position <= arrangedSubviews.count, position >= 0 else {
             log.warning("Couldn't insert subview \(view.debugDescription) into stackview \(self.debugDescription)")
             return
         }

--- a/ClientTests/DefaultBrowserOnboardingTests/DefaultBrowserOnboardingTests.swift
+++ b/ClientTests/DefaultBrowserOnboardingTests/DefaultBrowserOnboardingTests.swift
@@ -17,26 +17,65 @@ class DefaultBrowserOnboardingTests: XCTestCase {
 
     override func tearDown() {
         prefs.clearAll()
+        prefs = nil
         super.tearDown()
     }
-    
-    func testShouldNotShowCoverSheetFreshInstallSessionLessThan3() {
-        var sessionValue: Int32 = 0
-        let shouldShow = DefaultBrowserOnboardingViewModel.shouldShowDefaultBrowserOnboarding(userPrefs: prefs)
-        // The session value should increase from 0 to 1
-        sessionValue = prefs.intForKey(PrefsKeys.SessionCount) ?? 0
-        XCTAssertEqual(sessionValue, 0)
-        XCTAssert(!shouldShow)
+
+    func testInstallTypeIsUpgrade() {
+        setTestData(installType: .upgrade, sessionCount: 3, didShowOnboarding: false)
+        verify(expectedShouldShow: false)
+    }
+
+    func testInstallTypeIsUnknown() {
+        setTestData(installType: .unknown, sessionCount: 3, didShowOnboarding: false)
+        verify(expectedShouldShow: false)
     }
     
-    func testShouldShowCoverSheetCleanInstallSessionEqualTo3() {
-        var shouldShow: Bool = false
-        var didShow: Bool = false
-        prefs.setInt(3, forKey: PrefsKeys.SessionCount)
-        UserDefaults.standard.set(false, forKey: PrefsKeys.KeyDidShowDefaultBrowserOnboarding)
-        shouldShow = DefaultBrowserOnboardingViewModel.shouldShowDefaultBrowserOnboarding(userPrefs: prefs)
-        didShow = UserDefaults.standard.bool(forKey: PrefsKeys.KeyDidShowDefaultBrowserOnboarding)
-        XCTAssert(shouldShow)
-        XCTAssert(didShow)
+    func testInstallTypeFresh_alreadyShownOnboarding() {
+        setTestData(installType: .fresh, sessionCount: 3, didShowOnboarding: true)
+        verify(expectedShouldShow: false)
+    }
+
+    func testInstallTypeFresh_sessionCountIsLessThan3() {
+        setTestData(installType: .fresh, sessionCount: 0, didShowOnboarding: false)
+        verify(expectedShouldShow: false)
+    }
+
+    func testInstallTypeFresh_sessionCountIs3() {
+        setTestData(installType: .fresh, sessionCount: 3, didShowOnboarding: false)
+        verify(expectedShouldShow: true)
+    }
+
+    func testInstallTypeFresh_sessionCountIsMoreThan3() {
+        setTestData(installType: .fresh, sessionCount: 5, didShowOnboarding: false)
+        verify(expectedShouldShow: false)
+    }
+
+    func testViewModelChangePrefsOrNotAsExpected() {
+        let expectedSessionCount: Int32 = 3
+        let expectedDidShow = true
+
+        setTestData(installType: .fresh, sessionCount: expectedSessionCount, didShowOnboarding: false)
+        verify(expectedShouldShow: true)
+
+        let didShowPref = UserDefaults.standard.bool(forKey: PrefsKeys.KeyDidShowDefaultBrowserOnboarding)
+        XCTAssertEqual(didShowPref, expectedDidShow)
+
+        let sessionCount = prefs.intForKey(PrefsKeys.SessionCount)
+        XCTAssertEqual(sessionCount, expectedSessionCount)
+    }
+}
+
+private extension DefaultBrowserOnboardingTests {
+
+    func setTestData(installType: InstallType, sessionCount: Int32, didShowOnboarding: Bool) {
+        InstallType.set(type: installType)
+        prefs.setInt(sessionCount, forKey: PrefsKeys.SessionCount)
+        UserDefaults.standard.set(didShowOnboarding, forKey: PrefsKeys.KeyDidShowDefaultBrowserOnboarding)
+    }
+
+    func verify(expectedShouldShow: Bool, file: StaticString = #file, line: UInt = #line) {
+        let shouldShow = DefaultBrowserOnboardingViewModel.shouldShowDefaultBrowserOnboarding(userPrefs: prefs)
+        XCTAssertEqual(shouldShow, expectedShouldShow, file: file, line: line)
     }
 }

--- a/ClientTests/QuickActionsTests.swift
+++ b/ClientTests/QuickActionsTests.swift
@@ -19,7 +19,6 @@ class QuickActionsTest: XCTestCase {
         profile = TabManagerMockProfile()
         tabManager = TabManager(profile: profile, imageStore: nil)
         browserViewController = SpyBrowserViewController(profile: profile, tabManager: tabManager)
-        browserViewController.isBottomSearchBar = false
         browserViewController.addSubviews()
         quickActions = QuickActions.sharedInstance
     }

--- a/ClientTests/QuickActionsTests.swift
+++ b/ClientTests/QuickActionsTests.swift
@@ -19,6 +19,7 @@ class QuickActionsTest: XCTestCase {
         profile = TabManagerMockProfile()
         tabManager = TabManager(profile: profile, imageStore: nil)
         browserViewController = SpyBrowserViewController(profile: profile, tabManager: tabManager)
+        browserViewController.isBottomSearchBar = false
         browserViewController.addSubviews()
         quickActions = QuickActions.sharedInstance
     }

--- a/ClientTests/SearchBarSettingsViewModelTests.swift
+++ b/ClientTests/SearchBarSettingsViewModelTests.swift
@@ -1,0 +1,181 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import XCTest
+import Shared
+
+@testable import Client
+
+class SearchBarSettingsViewModelTests: XCTestCase {
+
+    private let expectationWaitTime: TimeInterval = 1
+
+    // MARK: Default
+
+    func testDefaultSearchPosition_freshInstall() {
+        InstallType.set(type: .fresh)
+        let viewModel = createViewModel()
+        XCTAssertEqual(viewModel.searchBarPosition, .bottom)
+    }
+
+    func testDefaultSearchPosition_upgrade() {
+        InstallType.set(type: .upgrade)
+        let viewModel = createViewModel()
+        XCTAssertEqual(viewModel.searchBarPosition, .top)
+    }
+
+    func testDefaultSearchPosition_unknown() {
+        InstallType.set(type: .unknown)
+        let viewModel = createViewModel()
+        XCTAssertEqual(viewModel.searchBarPosition, .top)
+    }
+
+    // MARK: Saved
+
+    func testSavedSearchPosition_onTopSavesOnTop() {
+        let viewModel = createViewModel()
+        callSetting(viewModel.topSetting)
+
+        XCTAssertEqual(viewModel.searchBarPosition, .top)
+    }
+
+    func testSavedSearchPosition_onBottomSavesOnBottom() {
+        let viewModel = createViewModel()
+        callSetting(viewModel.bottomSetting)
+
+        XCTAssertEqual(viewModel.searchBarPosition, .bottom)
+    }
+
+    // MARK: Checkmark
+
+    func testSavedSearchPosition_onTopSettingHasCheckmark() {
+        let viewModel = createViewModel()
+        callSetting(viewModel.topSetting)
+
+        XCTAssertEqual(viewModel.topSetting.isChecked(), true)
+        XCTAssertEqual(viewModel.bottomSetting.isChecked(), false)
+    }
+
+    func testSavedSearchPosition_onBottomSettingHasCheckmark() {
+        let viewModel = createViewModel()
+        callSetting(viewModel.bottomSetting)
+
+        XCTAssertEqual(viewModel.bottomSetting.isChecked(), true)
+        XCTAssertEqual(viewModel.topSetting.isChecked(), false)
+    }
+
+    // MARK: Delegate
+
+    private var delegate: SearchBarPreferenceDelegateMock?
+    func testSavedSearchPosition_onBottomSettingCallsDelegate() {
+        let expectation = expectation(description: "Delegate is called")
+        let viewModel = createViewModel(withDefaultPosition: .top)
+        delegate = SearchBarPreferenceDelegateMock(completion: {
+            expectation.fulfill()
+            XCTAssertEqual(viewModel.bottomSetting.isChecked(), true)
+        })
+        viewModel.delegate = delegate
+        callSetting(viewModel.bottomSetting)
+
+        waitForExpectations(timeout: expectationWaitTime, handler: nil)
+    }
+
+    func testSavedSearchPosition_onTopSettingCallsDelegate() {
+        let expectation = expectation(description: "Delegate is called")
+        let viewModel = createViewModel(withDefaultPosition: .bottom)
+        delegate = SearchBarPreferenceDelegateMock(completion: {
+            expectation.fulfill()
+            XCTAssertEqual(viewModel.topSetting.isChecked(), true)
+        })
+        viewModel.delegate = delegate
+        callSetting(viewModel.topSetting)
+
+        waitForExpectations(timeout: expectationWaitTime, handler: nil)
+    }
+
+    // MARK: Notification
+
+    func testNotificationSent() {
+        expectation(forNotification: .SearchBarPositionDidChange, object: nil, handler: nil)
+        let viewModel = createViewModel()
+        callSetting(viewModel.topSetting)
+
+        waitForExpectations(timeout: expectationWaitTime, handler: nil)
+    }
+
+    func testNotificationSent_topIsReceived() {
+        expectation(forNotification: .SearchBarPositionDidChange, object: nil, handler: { notification in
+            self.verifyNotification(expectedPosition: .top, notification: notification)
+        })
+        let viewModel = createViewModel()
+        callSetting(viewModel.topSetting)
+
+        waitForExpectations(timeout: expectationWaitTime, handler: nil)
+    }
+
+    func testNotificationSent_bottomIsReceived() {
+        expectation(forNotification: .SearchBarPositionDidChange, object: nil, handler: { notification in
+            self.verifyNotification(expectedPosition: .bottom, notification: notification)
+        })
+        let viewModel = createViewModel()
+        callSetting(viewModel.bottomSetting)
+
+        waitForExpectations(timeout: expectationWaitTime, handler: nil)
+    }
+}
+
+// MARK: Helper methods
+private extension SearchBarSettingsViewModelTests {
+
+    func createViewModel(withDefaultPosition defaultPosition: SearchBarPosition? = nil) -> SearchBarSettingsViewModel {
+        let mockPrefs = MockProfile().prefs
+        mockPrefs.clearAll()
+        let viewModel = SearchBarSettingsViewModel(prefs: mockPrefs)
+
+        switch defaultPosition {
+        case .bottom:
+            callSetting(viewModel.bottomSetting)
+        case .top:
+            callSetting(viewModel.topSetting)
+        case .none:
+            break
+        }
+
+        return SearchBarSettingsViewModel(prefs: mockPrefs)
+    }
+
+    func callSetting(_ setting: CheckmarkSetting) {
+        let dummyNavController = UINavigationController()
+        setting.onClick(dummyNavController)
+    }
+
+    func verifyNotification(expectedPosition: SearchBarPosition,
+                            notification: Notification,
+                            file: StaticString = #filePath,
+                            line: UInt = #line) -> Bool {
+
+        guard let dict = notification.object as? NSDictionary,
+              let newSearchBarPosition = dict[PrefsKeys.KeySearchBarPosition] as? SearchBarPosition
+        else {
+            XCTFail("Notification should be \(expectedPosition), instead of \(notification.debugDescription)", file: file, line: line)
+            return false
+        }
+
+        XCTAssertEqual(newSearchBarPosition, expectedPosition, file: file, line: line)
+        return true
+    }
+}
+
+private class SearchBarPreferenceDelegateMock: SearchBarPreferenceDelegate {
+
+    var completion: () -> Void
+    init(completion: @escaping () -> Void) {
+        self.completion = completion
+    }
+
+    func didUpdateSearchBarPositionPreference() {
+        completion()
+    }
+}

--- a/ClientTests/UIStackViewExtensionsTests.swift
+++ b/ClientTests/UIStackViewExtensionsTests.swift
@@ -1,0 +1,132 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import XCTest
+
+@testable import Client
+
+class UIStackViewExtensionsTests: XCTestCase {
+
+    // MARK: Top
+
+    func testAddArrangedViewToTop_whenEmpty() {
+        let stackView = UIStackView()
+        let view = UIView()
+        stackView.addArrangedViewToTop(view)
+
+        XCTAssertEqual(stackView.arrangedSubviews.count, 1)
+    }
+
+    func testAddArrangedViewToTop_withTwoViews() {
+        let stackView = UIStackView()
+        let firstView = UIView()
+        let secondView = UIView()
+        stackView.addArrangedViewToTop(firstView)
+        stackView.addArrangedViewToTop(secondView)
+
+        XCTAssertEqual(stackView.arrangedSubviews[0], secondView)
+        XCTAssertEqual(stackView.arrangedSubviews[1], firstView)
+    }
+
+    func testAddArrangedViewToTop_thenRemove() {
+        let stackView = UIStackView()
+        let firstView = UIView()
+        let secondView = UIView()
+        stackView.addArrangedViewToTop(firstView)
+        stackView.addArrangedViewToTop(secondView)
+        stackView.removeArrangedView(firstView)
+
+        XCTAssertEqual(stackView.arrangedSubviews.count, 1)
+        XCTAssertEqual(stackView.arrangedSubviews[0], secondView)
+    }
+
+    func testAddArrangedViewToTop_thenRemoveAll() {
+        let stackView = UIStackView()
+        let firstView = UIView()
+        let secondView = UIView()
+        stackView.addArrangedViewToTop(firstView)
+        stackView.addArrangedViewToTop(secondView)
+        stackView.removeAllArrangedViews()
+
+        XCTAssertEqual(stackView.arrangedSubviews.count, 0)
+    }
+
+    // MARK: Bottom
+
+    func testAddArrangedViewToBottom_whenEmpty() {
+        let stackView = UIStackView()
+        let view = UIView()
+        stackView.addArrangedViewToBottom(view)
+
+        XCTAssertEqual(stackView.arrangedSubviews.count, 1)
+    }
+
+    func testAddArrangedViewToBottom_withTwoViews() {
+        let stackView = UIStackView()
+        let firstView = UIView()
+        let secondView = UIView()
+        stackView.addArrangedViewToBottom(firstView)
+        stackView.addArrangedViewToBottom(secondView)
+
+        XCTAssertEqual(stackView.arrangedSubviews[0], firstView)
+        XCTAssertEqual(stackView.arrangedSubviews[1], secondView)
+    }
+
+    // MARK: Insert
+
+    func testInsertArrangedView_whenEmptyAt0() {
+        let stackView = UIStackView()
+        let view = UIView()
+        stackView.insertArrangedView(view, position: 0)
+
+        XCTAssertEqual(stackView.arrangedSubviews.count, 1)
+    }
+
+    func testInsertArrangedView_lessThan0DoesNothing() {
+        let stackView = UIStackView()
+        let view = UIView()
+        stackView.insertArrangedView(view, position: -1)
+
+        XCTAssertEqual(stackView.arrangedSubviews.count, 0)
+    }
+
+    func testInsertArrangedView_greaterThanCountDoesNothing() {
+        let stackView = UIStackView()
+        let view = UIView()
+        stackView.insertArrangedView(view, position: 5)
+
+        XCTAssertEqual(stackView.arrangedSubviews.count, 0)
+    }
+
+    func testInsertArrangezdView_insertAtSubsequentPosition() {
+        let stackView = UIStackView()
+        let firstView = UIView()
+        let secondView = UIView()
+        stackView.insertArrangedView(firstView, position: 0)
+        stackView.insertArrangedView(secondView, position: 1)
+
+        XCTAssertEqual(stackView.arrangedSubviews.count, 2)
+    }
+
+    func testInsertArrangedView_insertAtSamePosition() {
+        let stackView = UIStackView()
+        let firstView = UIView()
+        let secondView = UIView()
+        stackView.insertArrangedView(firstView, position: 0)
+        stackView.insertArrangedView(secondView, position: 0)
+
+        XCTAssertEqual(stackView.arrangedSubviews.count, 2)
+    }
+
+    func testInsertArrangedView_insertOneTooFar() {
+        let stackView = UIStackView()
+        let firstView = UIView()
+        let secondView = UIView()
+        stackView.insertArrangedView(firstView, position: 0)
+        stackView.insertArrangedView(secondView, position: 2)
+
+        XCTAssertEqual(stackView.arrangedSubviews.count, 1)
+    }
+}

--- a/Shared/NotificationConstants.swift
+++ b/Shared/NotificationConstants.swift
@@ -58,6 +58,8 @@ extension Notification.Name {
 
     public static let DisplayThemeChanged = Notification.Name("DisplayThemeChanged")
 
+    public static let SearchBarPositionDidChange = Notification.Name("SearchBarPositionDidChange")
+
     public static let WallpaperDidChange = Notification.Name("WallpaperDidChange")
 
     public static let TabClosed = Notification.Name("TabClosed")

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -40,6 +40,7 @@ public struct PrefsKeys {
     public static let KeySecondRun = "SecondRun"
     public static let StartAtHome = "startAtHome"
     public static let PullToRefresh = "pullToRefresh"
+    public static let KeySearchBarPosition = "SearchBarPosition"
 
     // Firefox contextual hint
     public static let ContextualHintJumpBackinKey = "ContextualHintJumpBackin"


### PR DESCRIPTION
# Feature #9422
- Setting in place to add the change the bottom search bar - available on iPhone only
- New users get the bottom search bar, old user can go in settings to change their preferences
- Feature flag in place
- ***Lots*** of edge cases to handle
- Unit tests in place for view model and stack view extensions
- Telemetry when we change the search bar position preference. This is reusing preferences change that we already had in place. Should there be a data review if it's using the telemetry already in place? cc: @dnarcese - let me know if it should be different.

Once this is merged in the epic branch I'll do a Nightly so we test all changes before merging in main.

@nbhasin2 I didn't clean the snapkit stuff, kind of out of time 😭 But I know the area better at least now!