### PR TITLE
Fixes #9969 - Adding accessibility header traits on headers on Firefox homepage

### DIFF
--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -663,6 +663,7 @@ extension FirefoxHomeViewController: UICollectionViewDelegateFlowLayout {
             let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: "Header", for: indexPath) as! ASHeaderView
             let title = Section(indexPath.section).title
             headerView.title = title
+            headerView.titleLabel.accessibilityTraits = .header
 
             switch Section(indexPath.section) {
             case .pocket:


### PR DESCRIPTION
This PR adds the header accessibility traits on headers on Firefox homepage #9969

Here is the video that shows the VoiceOver rotor recognizes the headers on the homepage: 

https://user-images.githubusercontent.com/30552772/153282277-09ac28fc-df19-4927-a210-881f73fa8954.mov





