### PR TITLE
Bugfix #9729 Private mode jump back in

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1155,7 +1155,7 @@ class BrowserViewController: UIViewController {
 
     // MARK: Opening New Tabs
     func switchToPrivacyMode(isPrivate: Bool) {
-         if let tabTrayController = self.gridTabTrayController, tabTrayController.tabDisplayManager.isPrivate != isPrivate {
+        if let tabTrayController = self.gridTabTrayController, tabTrayController.tabDisplayManager.isPrivate != isPrivate {
             tabTrayController.didTogglePrivateMode(isPrivate)
         }
         topTabsViewController?.applyUIMode(isPrivate: isPrivate)

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -297,6 +297,12 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
             return
         }
 
+        // Ensure Firefox home page is refreshed if privacy mode was changed
+        if tabManager.selectedTab?.isPrivate != isPrivate {
+            let notificationObject = [Tab.privateModeKey: isPrivate]
+            NotificationCenter.default.post(name: .TabsPrivacyModeChanged, object: notificationObject)
+        }
+
         tabManager.selectTab(tabManager.addTab(request, isPrivate: isPrivate))
     }
 }

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -69,6 +69,8 @@ enum TabUrlType: String {
 }
 
 class Tab: NSObject {
+
+    static let privateModeKey = "PrivateModeKey"
     fileprivate var _isPrivate: Bool = false
     internal fileprivate(set) var isPrivate: Bool {
         get {

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -324,12 +324,15 @@ class TabDisplayManager: NSObject, FeatureFlagsProtocol {
                 tabManager.addTab(isPrivate: true)
             }
         }
+
         getTabsAndUpdateInactiveState { tabGroup, tabsToDisplay in
             let tab = mostRecentTab(inTabs: tabsToDisplay) ?? tabsToDisplay.last
             if let tab = tab {
                 self.tabManager.selectTab(tab)
             }
         }
+
+        NotificationCenter.default.post(name: .TabsPrivacyModeChanged, object: nil)
     }
 
     /// Find the previously selected cell, which is still displayed as selected

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -332,7 +332,8 @@ class TabDisplayManager: NSObject, FeatureFlagsProtocol {
             }
         }
 
-        NotificationCenter.default.post(name: .TabsPrivacyModeChanged, object: nil)
+        let notificationObject = [Tab.privateModeKey: isPrivate]
+        NotificationCenter.default.post(name: .TabsPrivacyModeChanged, object: notificationObject)
     }
 
     /// Find the previously selected cell, which is still displayed as selected

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -460,16 +460,15 @@ class TabManager: NSObject, FeatureFlagsProtocol {
 
         if selectedTab.isPrivate {
             nextSelectedTab = mostRecentTab(inTabs: normalTabs)
+        } else if privateTabs.isEmpty {
+            nextSelectedTab = addTab(isPrivate: true)
+            result = .createdNewTab
         } else {
-            if privateTabs.isEmpty {
-                nextSelectedTab = addTab(isPrivate: true)
-                result = .createdNewTab
-            } else {
-                nextSelectedTab = mostRecentTab(inTabs: privateTabs)
-            }
+            nextSelectedTab = mostRecentTab(inTabs: privateTabs)
         }
 
         selectTab(nextSelectedTab)
+        NotificationCenter.default.post(name: .TabsPrivacyModeChanged, object: nil)
         return result
     }
 

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -468,7 +468,9 @@ class TabManager: NSObject, FeatureFlagsProtocol {
         }
 
         selectTab(nextSelectedTab)
-        NotificationCenter.default.post(name: .TabsPrivacyModeChanged, object: nil)
+
+        let notificationObject = [Tab.privateModeKey: nextSelectedTab?.isPrivate ?? true]
+        NotificationCenter.default.post(name: .TabsPrivacyModeChanged, object: notificationObject)
         return result
     }
 

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -164,6 +164,11 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
     fileprivate var contextualSourceView = UIView()
     fileprivate var isZeroSearch: Bool
     fileprivate var wallpaperManager: WallpaperManager
+
+    // Privacy of home page is controlled throught notifications since tab manager selected tab
+    // isn't always the proper privacy mode that should be reflected on the home page
+    private var isPrivate: Bool
+
     var recentlySavedViewModel: FirefoxHomeRecentlySavedViewModel
     var jumpBackInViewModel: FirefoxHomeJumpBackInViewModel
     var historyHighlightsViewModel: FxHomeHistoryHightlightsVM
@@ -233,8 +238,7 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
         else { return false }
 
         let tabManager = BrowserViewController.foregroundBVC().tabManager
-        return !(tabManager.selectedTab?.isPrivate ?? false)
-            && !tabManager.recentlyAccessedNormalTabs.isEmpty
+        return !isPrivate && !tabManager.recentlyAccessedNormalTabs.isEmpty
     }
 
     var shouldShowJumpBackInSection: Bool {
@@ -290,6 +294,7 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
         self.profile = profile
         self.isZeroSearch = isZeroSearch
         self.wallpaperManager = wallpaperManager
+        self.isPrivate = BrowserViewController.foregroundBVC().tabManager.selectedTab?.isPrivate ?? true
 
         self.jumpBackInViewModel = FirefoxHomeJumpBackInViewModel(isZeroSearch: isZeroSearch, profile: profile)
         self.recentlySavedViewModel = FirefoxHomeRecentlySavedViewModel(isZeroSearch: isZeroSearch, profile: profile)
@@ -453,11 +458,24 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
         switch notification.name {
         case .DisplayThemeChanged,
                 .DynamicFontChanged,
-                .WallpaperDidChange,
-                .TabsPrivacyModeChanged:
+                .WallpaperDidChange:
             reloadAll(shouldUpdateData: false)
+        case .TabsPrivacyModeChanged:
+            adjustPrivacySensitiveSections(notification: notification)
         default:
             reloadAll()
+        }
+    }
+
+    private func adjustPrivacySensitiveSections(notification: Notification) {
+        guard let dict = notification.object as? NSDictionary,
+              let isPrivate = dict[Tab.privateModeKey] as? Bool
+        else { return }
+
+        self.isPrivate = isPrivate
+        if let jumpbackInSection = jumpBackInViewModel.parentCollectionViewIndex?.section {
+            let indexSet = IndexSet([jumpbackInSection])
+            collectionView.reloadSections(indexSet)
         }
     }
 
@@ -939,6 +957,7 @@ extension FirefoxHomeViewController {
         jumpBackInViewModel.onTapGroup = { [weak self] tab in
             self?.homePanelDelegate?.homePanelDidRequestToOpenTabTray(withFocusedTab: tab)
         }
+        jumpBackInViewModel.parentCollectionViewIndex = indexPath
         jumpBackInCell.reloadLayout()
         jumpBackInCell.setNeedsLayout()
 

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -318,7 +318,8 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
                                                   .HomePanelPrefsChanged,
                                                   .DisplayThemeChanged,
                                                   .TabClosed,
-                                                  .WallpaperDidChange]
+                                                  .WallpaperDidChange,
+                                                  .TabsPrivacyModeChanged]
         refreshEvents.forEach { NotificationCenter.default.addObserver(self, selector: #selector(reload), name: $0, object: nil) }
     }
 
@@ -452,7 +453,8 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
         switch notification.name {
         case .DisplayThemeChanged,
                 .DynamicFontChanged,
-                .WallpaperDidChange:
+                .WallpaperDidChange,
+                .TabsPrivacyModeChanged:
             reloadAll(shouldUpdateData: false)
         default:
             reloadAll()

--- a/Client/Frontend/Home/JumpBackIn/FxHomeJumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/FxHomeJumpBackInViewModel.swift
@@ -27,6 +27,7 @@ class FirefoxHomeJumpBackInViewModel: FeatureFlagsProtocol {
     // MARK: - Properties
     var onTapGroup: ((Tab) -> Void)?
     var jumpBackInList = JumpBackInList(group: nil, tabs: [Tab]())
+    var parentCollectionViewIndex: IndexPath?
 
     private var recentTabs: [Tab] = [Tab]()
     private var recentGroups: [ASGroup<Tab>]?

--- a/Shared/NotificationConstants.swift
+++ b/Shared/NotificationConstants.swift
@@ -62,5 +62,7 @@ extension Notification.Name {
 
     public static let TabClosed = Notification.Name("TabClosed")
 
+    public static let TabsPrivacyModeChanged = Notification.Name("TabsPrivacyModeChanged")
+
     public static let OpenClearRecentHistory = Notification.Name("OpenClearRecentHistory")
 }


### PR DESCRIPTION
# Issue #9729
We only have **one** `FirefoxHomeViewController`, which is referenced in BVC. That `FirefoxHomeViewController` has privacy sensitive sections like jump back in that needs to be hidden when we're in private mode. 

Two things with that:
1. Since there's only one `FirefoxHomeViewController`, it wasn't always updated when privacy mode was changed (no sections reload or anything). Hence we would get a behavior where when we created a new `FirefoxHomeViewController`, we would have the proper privacy mode. But if it was the existing `FirefoxHomeViewController`, privacy wasn't ok.
2. We were looking at the `tabManager.selectedTab?.isPrivate` to know if we should have a private `FirefoxHomeViewController` or not. Selected tab isn't always the private mode we should be looking at (sometimes we're changing mode and it's not there the selected tab that is private).

So because of that:
- We now update privacy sensitive sections on `FirefoxHomeViewController` when needed. 
- We update the isPrivate var through a notification since we need to update before we show the home page.