### PR TITLE
Bug 1689162 - Update to metrics schema v2

### DIFF
--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -10,7 +10,7 @@
 # for easy navigation
 
 ---
-$schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
 
 # App menu
 app_menu:


### PR DESCRIPTION
No functional changes, just a little bit of cleanup.
[Schema v2 has landed about a year ago](https://github.com/mozilla/glean_parser/blob/fd23d588ce0bced4d496ac642e6f98ee2659fa88/CHANGELOG.md#200-2021-02-05).
Firefox iOS is already compatible with it without further changes.