### PR TITLE
Bugfix #9698 [v98] Update counter for rating prompt each time app is opened

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -140,10 +140,7 @@ class BrowserViewController: UIViewController {
         self.profile = profile
         self.tabManager = tabManager
         self.readerModeCache = DiskReaderModeCache.sharedInstance
-
-        let daysOfUseCounter = CumulativeDaysOfUseCounter()
-        daysOfUseCounter.updateCounter()
-        self.ratingPromptManager = RatingPromptManager(profile: profile, daysOfUseCounter: daysOfUseCounter)
+        self.ratingPromptManager = RatingPromptManager(profile: profile)
 
         super.init(nibName: nil, bundle: nil)
         didInit()

--- a/Client/RatingPromptManager.swift
+++ b/Client/RatingPromptManager.swift
@@ -33,7 +33,7 @@ final class RatingPromptManager {
     ///   - profile: User's profile data
     ///   - daysOfUseCounter: Counter for the cumulative days of use of the application by the user
     init(profile: Profile,
-         daysOfUseCounter: CumulativeDaysOfUseCounter) {
+         daysOfUseCounter: CumulativeDaysOfUseCounter = CumulativeDaysOfUseCounter()) {
         self.profile = profile
         self.daysOfUseCounter = daysOfUseCounter
     }
@@ -46,9 +46,11 @@ final class RatingPromptManager {
         }
     }
 
-    /// Updates bookmark and pinned site data asynchronously.
+    /// Update rating prompt data. Bookmarks and pinned sites data is loaded asynchronously.
     /// - Parameter dataLoadingCompletion: Complete when the loading of data from the profile is done - Used in unit tests
     func updateData(dataLoadingCompletion: (() -> Void)? = nil) {
+        daysOfUseCounter.updateCounter()
+
         let group = DispatchGroup()
         updateBookmarksCount(group: group)
         updateUserPinnedSitesCount(group: group)


### PR DESCRIPTION
# Issue https://github.com/mozilla-mobile/firefox-ios/issues/9698
Found an issue where counter data would only be update if app was killed. This change makes sure the date counter is updated each time the app is opened (and not necessarily killed).