### PR TITLE
Fix #10027 Fix URL bar for RTL languages

### DIFF
--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -362,7 +362,7 @@ class URLBarView: UIView, AlphaDimmable, TopBottomInterchangeable {
                 make.centerY.equalTo(self)
             }
             self.locationView.snp.remakeConstraints { make in
-                make.top.bottom.right.equalTo(self.locationContainer).inset(UIEdgeInsets(equalInset: URLBarViewUX.TextFieldBorderWidthSelected))
+                make.top.bottom.trailing.equalTo(self.locationContainer).inset(UIEdgeInsets(equalInset: URLBarViewUX.TextFieldBorderWidthSelected))
                 make.leading.equalTo(self.searchIconImageView.snp.trailing)
             }
             self.locationTextField?.snp.remakeConstraints { make in


### PR DESCRIPTION
This PR fixes the URL bar overlapping the toolbar for RTL languages when the input is longer than the width of the textfield. The clear button being on the wrong side is a separate issue. #10027