### PR TITLE
Fx 10027 2

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -224,11 +224,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             shouldPerformAdditionalDelegateHandling = false
         }
 
-        // Force the ToolbarTextField in LTR mode - without this change the UITextField's clear
-        // button will be in the incorrect position and overlap with the input text. Not clear if
-        // that is an iOS bug or not.
-        AutocompleteTextField.appearance().semanticContentAttribute = .forceLeftToRight
-
         pushNotificationSetup()
 
         // user research variable setup for Chron tabs user research

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -247,7 +247,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         label.textAlignment = .left
 
         let enteredTextSize = self.attributedText?.boundingRect(with: self.frame.size, options: NSStringDrawingOptions.usesLineFragmentOrigin, context: nil)
-        frame.origin.x = (enteredTextSize?.width.rounded() ?? 0)
+        frame.origin.x = (enteredTextSize?.width.rounded() ?? 0) + textRect(forBounds: bounds).origin.x
         frame.size.width = self.frame.size.width - frame.origin.x
         frame.size.height = self.frame.size.height
         label.frame = frame


### PR DESCRIPTION
This PR fixes the clear button being on the wrong side for RTL languages. In AppDelegate.swift, there is a comment that says:
>       // Force the ToolbarTextField in LTR mode - without this change the UITextField's clear
>       // button will be in the incorrect position and overlap with the input text. Not clear if
>       // that is an iOS bug or not.

I'm assuming this comment is referring to the autocomplete text and not the user text. #10027 