### PR TITLE
FX #10033 Fix back arrow pointing wrong direction in QR code scanner for RTL languages

### DIFF
--- a/Client/Frontend/Browser/QRCodeViewController.swift
+++ b/Client/Frontend/Browser/QRCodeViewController.swift
@@ -64,7 +64,7 @@ class QRCodeViewController: UIViewController {
         self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor: QRCodeViewControllerUX.navigationBarTitleColor]
 
         // Setup the NavigationItem
-        self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "qrcode-goBack"), style: .plain, target: self, action: #selector(goBack))
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "qrcode-goBack")?.imageFlippedForRightToLeftLayoutDirection(), style: .plain, target: self, action: #selector(goBack))
         self.navigationItem.leftBarButtonItem?.tintColor = UIColor.Photon.White100
 
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(named: "qrcode-light"), style: .plain, target: self, action: #selector(openLight))


### PR DESCRIPTION
This PR fixes the back arrow pointing in the wrong direction in the QR code scanner for RTL languages. (#10033)