### PR TITLE
FX #10036 Fix Punycode encoding

### DIFF
--- a/Client/Frontend/Browser/Punycode.swift
+++ b/Client/Frontend/Browser/Punycode.swift
@@ -123,7 +123,7 @@ extension String {
         var n = initialN
         var bias = initialBias
         var pos = 0
-        if let ipos = input.firstIndex(of: delimiter) {
+        if let ipos = input.lastIndex(of: delimiter) {
             pos = ipos
             output.append(contentsOf: input[0 ..< pos])
             pos += 1


### PR DESCRIPTION
This PR fixes Punycode encoding for URLs with a dash. According to the [Punycode specification](https://datatracker.ietf.org/doc/html/rfc3492), the last occurrence of the delimiter "-" is used, but the decoding routine uses the first, so it crashes if there happens to be another dash in the URL.