### PR TITLE
Bugfix #10042 [v100] Fix title and close button not showing in tab grid view for RTL languages

### DIFF
--- a/Client/Frontend/Browser/TabCell.swift
+++ b/Client/Frontend/Browser/TabCell.swift
@@ -134,7 +134,7 @@ class TabCell: UICollectionViewCell, TabTrayCell, ReusableCell {
             closeButton.heightAnchor.constraint(equalToConstant: GridTabTrayControllerUX.CloseButtonSize),
             closeButton.widthAnchor.constraint(equalToConstant: GridTabTrayControllerUX.CloseButtonSize),
             closeButton.centerYAnchor.constraint(equalTo: title.contentView.centerYAnchor),
-            closeButton.rightAnchor.constraint(equalTo: title.rightAnchor),
+            closeButton.trailingAnchor.constraint(equalTo: title.trailingAnchor),
 
             titleText.leadingAnchor.constraint(equalTo: favicon.trailingAnchor, constant: 6),
             titleText.trailingAnchor.constraint(equalTo: closeButton.leadingAnchor, constant: 6),


### PR DESCRIPTION
This PR fixes the title and close button so that they are visible for RTL languages in the tab grid view. (#10042)