### PR TITLE
Bugfix #10043 [v100] Fix suggestions being cut off in landscape for RTL languages

### DIFF
--- a/Client/Frontend/Widgets/TwoLineCellAndFooter.swift
+++ b/Client/Frontend/Widgets/TwoLineCellAndFooter.swift
@@ -83,7 +83,11 @@ class TwoLineImageOverlayCell: UITableViewCell, NotificationThemeable {
             make.height.equalTo(58)
             make.top.bottom.equalToSuperview()
             make.leading.equalToSuperview()
-            make.trailing.equalTo(accessoryView?.snp.leading ?? snp.trailing)
+            if let accessoryView = accessoryView {
+                make.trailing.equalTo(accessoryView.snp.leading)
+            } else {
+                make.trailing.equalToSuperview()
+            }
         }
 
         leftImageView.snp.makeConstraints { make in
@@ -149,7 +153,11 @@ class TwoLineImageOverlayCell: UITableViewCell, NotificationThemeable {
             make.height.equalTo(58)
             make.top.bottom.equalToSuperview()
             make.leading.equalToSuperview()
-            make.trailing.equalTo(accessoryView?.snp.leading ?? snp.trailing)
+            if let accessoryView = accessoryView {
+                make.trailing.equalTo(accessoryView.snp.leading)
+            } else {
+                make.trailing.equalToSuperview()
+            }
         }
     }
 }


### PR DESCRIPTION
This PR fixes suggestions being cut off in landscape for RTL languages (https://github.com/mozilla-mobile/firefox-ios/issues/10043)
![Simulator Screen Shot - iPhone 13 Pro - 2022-02-16 at 07 38 07](https://user-images.githubusercontent.com/66826029/154299859-3a3c96ac-9209-4a13-824e-d6fbc83dbd45.png)
.