### PR TITLE
Bumps application services to 91.1.0

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -13783,7 +13783,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 91.0.1;
+				version = 91.1.0;
 			};
 		};
 		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/mozilla/rust-components-swift.git",
         "state": {
           "branch": null,
-          "revision": "001d704cd61ee0b88f078cc125caefecd8180467",
-          "version": "91.0.1"
+          "revision": "29772c84fd7dd17c9f2981c51ea4ccc04e353b32",
+          "version": "91.1.0"
         }
       },
       {

--- a/bin/nimbus-fml.sh
+++ b/bin/nimbus-fml.sh
@@ -60,7 +60,7 @@ helptext() {
 MANIFEST_PATH=
 OUTPUT_DIR="${SOURCE_ROOT}/${PROJECT}/Generated"
 NAMESPACE=
-AS_VERSION=v91.0.1
+AS_VERSION=v91.1.0
 
 while (( "$#" )); do
     case "$1" in


### PR DESCRIPTION
Mostly includes bug fixes for nimbus and exposes APIs to support the messaging work

Changelog:

# v91.1.0 (_2022-02-11_)

[Full Changelog](https://github.com/mozilla/application-services/compare/v91.0.1...v91.1.0)

## ⛅️🔬🔭 Nimbus SDK

### What's fixed

- Fixes a bug where disabling studies did not disable rollouts. ([#4807](https://github.com/mozilla/application-services/pull/4807))

### ✨ What's New ✨

- A message helper is now available to apps wanting to build a Messaging System on both Android and iOS. Both of these access the variables
  provided by Nimbus, and can have app-specific variables added. This provides two functions:
  - JEXL evaluation ([#4813](https://github.com/mozilla/application-services/pull/4813)) which evaluates boolean expressions.
  - String interpolation ([#4831](https://github.com/mozilla/application-services/pull/4831)) which builds strings with templates at runtime.

## Xcode

- Bumped Xcode version from 13.1.0 -> 13.2.1

## Nimbus FML
### What's fixed
- Fixes a bug where each time the fml is run, the ordering of features in the experimenter json is changed. ([#4819](https://github.com/mozilla/application-services/pull/4819))

