### PR TITLE
FX #6543 Fix alignment for search engines for RTL languages

### DIFF
--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -134,7 +134,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         }
     
         searchEngineContainerView.snp.makeConstraints { make in
-            make.left.right.bottom.equalToSuperview()
+            make.leading.trailing.bottom.equalToSuperview()
         }
 
         NotificationCenter.default.addObserver(self, selector: #selector(dynamicFontChanged), name: .DynamicFontChanged, object: nil)
@@ -155,7 +155,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     private func layoutSearchEngineScrollView() {
         let keyboardHeight = KeyboardHelper.defaultHelper.currentState?.intersectionHeightForView(self.view) ?? 0
         searchEngineScrollView.snp.remakeConstraints { make in
-            make.left.right.top.equalToSuperview()
+            make.leading.trailing.top.equalToSuperview()
             if keyboardHeight == 0 {
                 make.bottom.equalTo(view.safeArea.bottom)
             } else {
@@ -167,14 +167,15 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
 
     private func layoutSearchEngineScrollViewContent() {
         searchEngineScrollViewContent.snp.remakeConstraints { make in
-            make.center.equalTo(self.searchEngineScrollView).priority(10)
+            make.width.greaterThanOrEqualTo(self.view)
+            make.centerY.equalTo(self.searchEngineScrollView).priority(10)
             //left-align the engines on iphones, center on ipad
             if UIScreen.main.traitCollection.horizontalSizeClass == .compact {
-                make.left.equalTo(self.searchEngineScrollView).priority(1000)
+                make.leading.equalTo(self.searchEngineScrollView).priority(1000)
             } else {
-                make.left.greaterThanOrEqualTo(self.searchEngineScrollView).priority(1000)
+                make.leading.greaterThanOrEqualTo(self.searchEngineScrollView).priority(1000)
             }
-            make.right.lessThanOrEqualTo(self.searchEngineScrollView).priority(1000)
+            make.trailing.lessThanOrEqualTo(self.searchEngineScrollView).priority(1000)
             make.top.equalTo(self.searchEngineScrollView)
             make.bottom.equalTo(self.searchEngineScrollView)
         }
@@ -231,7 +232,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
 
     func reloadSearchEngines() {
         searchEngineScrollViewContent.subviews.forEach { $0.removeFromSuperview() }
-        var leftEdge = searchEngineScrollViewContent.snp.left
+        var leftEdge = searchEngineScrollViewContent.snp.leading
 
         //search settings icon
         let searchButton = UIButton()
@@ -245,13 +246,13 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         searchButton.snp.makeConstraints { make in
             make.size.equalTo(SearchViewControllerUX.FaviconSize)
             //offset the left edge to align with search results
-            make.left.equalTo(leftEdge).offset(SearchViewControllerUX.SuggestionMargin * 2)
+            make.leading.equalTo(leftEdge).offset(SearchViewControllerUX.SuggestionMargin * 2)
             make.top.equalTo(self.searchEngineScrollViewContent).offset(SearchViewControllerUX.SuggestionMargin)
             make.bottom.equalTo(self.searchEngineScrollViewContent).offset(-SearchViewControllerUX.SuggestionMargin)
         }
 
         //search engines
-        leftEdge = searchButton.snp.right
+        leftEdge = searchButton.snp.trailing
         for engine in quickSearchEngines {
             let engineButton = UIButton()
             engineButton.setImage(engine.image, for: [])
@@ -270,14 +271,14 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
             engineButton.snp.makeConstraints { make in
                 make.width.equalTo(SearchViewControllerUX.EngineButtonWidth)
                 make.height.equalTo(SearchViewControllerUX.EngineButtonHeight)
-                make.left.equalTo(leftEdge)
+                make.leading.equalTo(leftEdge)
                 make.top.equalTo(self.searchEngineScrollViewContent)
                 make.bottom.equalTo(self.searchEngineScrollViewContent)
                 if engine === self.searchEngines.quickSearchEngines.last {
-                    make.right.equalTo(self.searchEngineScrollViewContent)
+                    make.trailing.lessThanOrEqualTo(self.searchEngineScrollViewContent)
                 }
             }
-            leftEdge = engineButton.snp.right
+            leftEdge = engineButton.snp.trailing
         }
     }
 

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -167,11 +167,11 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
 
     private func layoutSearchEngineScrollViewContent() {
         searchEngineScrollViewContent.snp.remakeConstraints { make in
-            make.width.greaterThanOrEqualTo(self.view)
-            make.centerY.equalTo(self.searchEngineScrollView).priority(10)
+            make.center.equalTo(self.searchEngineScrollView).priority(10)
             //left-align the engines on iphones, center on ipad
             if UIScreen.main.traitCollection.horizontalSizeClass == .compact {
                 make.leading.equalTo(self.searchEngineScrollView).priority(1000)
+                make.width.greaterThanOrEqualTo(self.view)
             } else {
                 make.leading.greaterThanOrEqualTo(self.searchEngineScrollView).priority(1000)
             }


### PR DESCRIPTION
This PR reverses the search engine list so that the magnifying glass starts at the right and the list of search engines goes to the left for RTL languages. #6543 
![Simulator Screen Shot - iPhone 13 Pro - 2022-02-16 at 10 50 14](https://user-images.githubusercontent.com/66826029/154336757-33a0d8ce-b4aa-4e9b-b27d-99a6480f50a7.png)
