### PR TITLE
FX #10051 Remove app menu margin in landscape for RTL languages

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -109,6 +109,7 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
             tableView.snp.makeConstraints { make in
                 make.top.bottom.equalTo(self.view)
                 make.width.equalTo(width)
+                make.leading.equalTo(self.view.safeArea.leading)
             }
         } else {
             tableView.snp.makeConstraints { make in


### PR DESCRIPTION
This PR removes the margin in the app menu for landscape for RTL languages on iPhone. #10051