### PR TITLE
Fix #10057 Fix context menus not opening with right click when using mouse on iPad

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentEnd/ContextMenu.js
+++ b/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentEnd/ContextMenu.js
@@ -8,7 +8,7 @@
 // Ensure this module only gets included once. This is
 // required for user scripts injected into all frames.
 window.__firefox__.includeOnce("ContextMenu", function() {
-  window.addEventListener("touchstart", function(evt) {
+  window.addEventListener("pointerdown", function(evt) {
     var target = evt.target;
 
     var targetLink = target.closest("a");
@@ -20,8 +20,8 @@ window.__firefox__.includeOnce("ContextMenu", function() {
 
     var data = {};
 
-    data.touchX = evt.changedTouches[0].pageX - window.scrollX;
-    data.touchY = evt.changedTouches[0].pageY - window.scrollY;
+    data.touchX = evt.pageX - window.scrollX;
+    data.touchY = evt.pageY - window.scrollY;
 
     if (targetLink) {
       data.link = targetLink.href;


### PR DESCRIPTION
This PR fixes context menus not opening with a right click on iPad. Note that before, no context menu would appear if the user did not touch the screen beforehand, since the code checks for a tapped link. However, since WebKit doesn't trigger the correct event when initially right clicking a link, sometimes the wrong menu items appear or the right ones don't. (#10057, #10026)