### PR TITLE
Bugfix #6539 [v100] Reverse top tab layout for RTL languages

### DIFF
--- a/Client/Frontend/Browser/TopTabsLayout.swift
+++ b/Client/Frontend/Browser/TopTabsLayout.swift
@@ -72,4 +72,8 @@ class TopTabsViewLayout: UICollectionViewFlowLayout {
         attributes?.zIndex = SeparatorZIndex
         return attributes
     }
+    
+    override var flipsHorizontallyInOppositeLayoutDirection: Bool {
+        return true
+    }
 }

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -45,7 +45,6 @@ class TopTabsViewController: UIViewController {
         collectionView.bounces = false
         collectionView.clipsToBounds = true
         collectionView.accessibilityIdentifier = "Top Tabs View"
-        collectionView.semanticContentAttribute = .forceLeftToRight
         return collectionView
     }()
 

--- a/Client/Frontend/Browser/TopTabsViews.swift
+++ b/Client/Frontend/Browser/TopTabsViews.swift
@@ -37,7 +37,7 @@ class TopTabCell: UICollectionViewCell, NotificationThemeable, TabTrayCell {
 
     let titleText: UILabel = {
         let titleText = UILabel()
-        titleText.textAlignment = .left
+        titleText.textAlignment = .natural
         titleText.isUserInteractionEnabled = false
         titleText.numberOfLines = 1
         titleText.lineBreakMode = .byCharWrapping


### PR DESCRIPTION
This PR reverses the top tab layout for RTL languages. #6539 
![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-02-16 at 18 20 25](https://user-images.githubusercontent.com/66826029/154589634-68473936-3816-4a91-8077-e59d78447af5.png)

