### PR TITLE
 Removing SnapKit Pt3  -  #9496 

### DIFF
--- a/CredentialProvider/CredentialListViewController.swift
+++ b/CredentialProvider/CredentialListViewController.swift
@@ -126,14 +126,18 @@ class CredentialListViewController: UIViewController, CredentialListViewProtocol
     
     private func addViewConstraints() {
         view.addSubview(tableView)
-        tableView.snp.makeConstraints { make in
-            make.edges.equalTo(self.view)
-        }
         
-        cancelButton.snp.makeConstraints { make in
-            make.width.equalTo(60)
-        }
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: self.view.topAnchor),
+            tableView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+            tableView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor)
+        ])
         
+        NSLayoutConstraint.activate([
+            cancelButton.widthAnchor.constraint(equalToConstant: 60)
+        ])
+                
     }
     
     private func registerCells() {


### PR DESCRIPTION
Removed _SnapKit_ from the file 

1)  **CredentialListViewController.swift.**

A while back @nishant2718 said that [it's okay if I remove a SnapKit from a single file](https://github.com/mozilla-mobile/firefox-ios/issues/9410#issuecomment-976818983). 