### PR TITLE
Bugfix #9550 [v99] - Cannot properly correct a typo in the middle of search word/phrase

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -286,9 +286,8 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         hideCursor = autocompleteTextLabel != nil
         removeCompletion()
 
-        let isAtEnd = selectedTextRange?.start == endOfDocument
         let isKeyboardReplacingText = lastReplacement != nil
-        if isKeyboardReplacingText, isAtEnd, markedTextRange == nil {
+        if isKeyboardReplacingText, markedTextRange == nil {
             notifyTextChanged?()
         } else {
             hideCursor = false


### PR DESCRIPTION
Remove check to send `notifyTextChanged` only when the update is at the end of the search term