### PR TITLE
Revert changes to search term for Tab grouping

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -336,9 +336,8 @@ class Tab: NSObject {
                 shouldResetTabGroupData = true
             // To also capture any server redirects we check if user spent less than 7 sec on the same website before moving to another one
             } else if tabGroupData.tabAssociatedNextUrl.isEmpty || tabGroupsTimerHelper.elapsedTime < 7 {
-                if tabGroupData.tabHistoryMetadatakey().referrerUrl != nextUrl {
-                    tabGroupData.tabAssociatedSearchUrl = nextUrl
-                    let key = tabGroupData.tabHistoryMetadatakey()
+                let key = tabGroupData.tabHistoryMetadatakey()
+                if key.referrerUrl != nextUrl {
                     let observation = HistoryMetadataObservation(url: key.url, referrerUrl: key.referrerUrl, searchTerm: key.searchTerm, viewTime: tabGroupsTimerHelper.elapsedTime, documentType: nil, title: nil)
                     updateObservationForKey(key: key, observation: observation)
                     tabGroupData.tabAssociatedNextUrl = nextUrl


### PR DESCRIPTION
We were accidentally catching non-search URLs in search term groups.