### PR TITLE
Bugfix fx3777 [v98] Unit tests adjustments + filter instead of compact map

### DIFF
--- a/Client/RatingPromptManager.swift
+++ b/Client/RatingPromptManager.swift
@@ -137,7 +137,7 @@ final class RatingPromptManager {
                 return
             }
 
-            let bookmarksCounts = children.compactMap { $0.type == .bookmark }.count
+            let bookmarksCounts = children.filter { $0.type == .bookmark }.count
             strongSelf.hasMinimumMobileBookmarksCount = bookmarksCounts >= strongSelf.minimumMobileBookmarksCount
             group.leave()
         }


### PR DESCRIPTION
# Issue [FXIOS-3777](https://mozilla-hub.atlassian.net/browse/FXIOS-3777)
- filter instead of compact map to count bookmarks. Unit tests had DB issues so it didn't detect that. Now supposed to be all good.