### PR TITLE
Updated GCDWebserver package which removed un-supported woff font

### DIFF
--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/nbhasin2/GCDWebServer.git",
         "state": {
           "branch": "master",
-          "revision": "14f9eedb296c5b71fec971d8256ef3bfc20a2245",
+          "revision": "7674c93e79ee5aac17681acace324761325e7346",
           "version": null
         }
       },


### PR DESCRIPTION
Fixes: 

<img width="790" alt="image" src="https://user-images.githubusercontent.com/8919439/155789406-40e7d82d-8566-403a-8622-0a0917152b55.png">
