### PR TITLE
Bugfix #10145 [v99] Clear deleted Website Data immediately

### DIFF
--- a/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
@@ -20,6 +20,7 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
     private var tableView: UITableView!
 
     private var filteredSiteRecords = [WKWebsiteDataRecord]()
+    private var currentSearchText = ""
     
     init(viewModel: WebsiteDataManagementViewModel) {
         self.viewModel = viewModel
@@ -55,8 +56,9 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
     }
     
     func reloadData() {
-        guard let tableView = tableView else { return }
-        tableView.reloadData()
+        guard let _ = tableView else { return }
+        // to update filteredSiteRecords before reloading the tableView
+        filterContentForSearchText(currentSearchText)
     }
     
     func numberOfSections(in tableView: UITableView) -> Int {
@@ -170,7 +172,8 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
 
 extension WebsiteDataSearchResultsViewController: UISearchResultsUpdating {
     func updateSearchResults(for searchController: UISearchController) {
-        filterContentForSearchText(searchController.searchBar.text!)
+        currentSearchText = searchController.searchBar.text ?? ""
+        filterContentForSearchText(currentSearchText)
     }
 }
 


### PR DESCRIPTION
Clear deleted Website Data immediately (see #10145)
The problem was, that `filteredSiteRecords` wasn't updated before the Table View in `WebsiteDataSearchResultsViewController` was reloaded.

https://user-images.githubusercontent.com/46824694/156623129-c0455e7e-cec4-4946-bd88-4e2edd3d736d.mov
