### PR TITLE
Bugfix #10142 [v99] iPad JumpBackIn crash fix with closed tab

### DIFF
--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -266,6 +266,7 @@ extension TopTabsViewController: TabDisplayer {
 
 extension TopTabsViewController: TopTabCellDelegate {
     func tabCellDidClose(_ cell: UICollectionViewCell) {
+        NotificationCenter.default.post(name: .TabClosed, object: nil)
         topTabDisplayManager.closeActionPerformed(forCell: cell)
     }
 }

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -266,8 +266,8 @@ extension TopTabsViewController: TabDisplayer {
 
 extension TopTabsViewController: TopTabCellDelegate {
     func tabCellDidClose(_ cell: UICollectionViewCell) {
-        NotificationCenter.default.post(name: .TabClosed, object: nil)
         topTabDisplayManager.closeActionPerformed(forCell: cell)
+        NotificationCenter.default.post(name: .TabClosed, object: nil)
     }
 }
 


### PR DESCRIPTION
# Issue  #10142
Send notification that top tabs has closed a tab, so firefox home view controller can react
