### PR TITLE
Bugfix #9726 [v99] Reading list filtering date bug

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -450,6 +450,7 @@
 		8A2783F1275FFDC50080D29D /* KeyboardPressesHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2783F0275FFDC50080D29D /* KeyboardPressesHandler.swift */; };
 		8A2825352760399B00395E66 /* KeyboardPressesHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2825342760399B00395E66 /* KeyboardPressesHandlerTests.swift */; };
 		8A35497227BD672700534A65 /* ToggleSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A35497127BD672700534A65 /* ToggleSwitch.swift */; };
+		8A355E5E27D267A400B9AF34 /* RecentItemsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */; };
 		8A56955227C68AE00077A89E /* UILabelExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A56955127C68AE00077A89E /* UILabelExtensions.swift */; };
 		8A57519927AD80B800A84DBF /* ReaderModeStyleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A57519827AD80B800A84DBF /* ReaderModeStyleViewModel.swift */; };
 		8A86DAD8277298DE00D7BFFF /* ClosedTabsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A86DAD7277298DE00D7BFFF /* ClosedTabsStoreTests.swift */; };
@@ -2710,6 +2711,7 @@
 		8A2783F0275FFDC50080D29D /* KeyboardPressesHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPressesHandler.swift; sourceTree = "<group>"; };
 		8A2825342760399B00395E66 /* KeyboardPressesHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPressesHandlerTests.swift; sourceTree = "<group>"; };
 		8A35497127BD672700534A65 /* ToggleSwitch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleSwitch.swift; sourceTree = "<group>"; };
+		8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentItemsHelperTests.swift; sourceTree = "<group>"; };
 		8A5143D6BF179870414566ED /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Search.strings; sourceTree = "<group>"; };
 		8A56955127C68AE00077A89E /* UILabelExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UILabelExtensions.swift; sourceTree = "<group>"; };
 		8A57519827AD80B800A84DBF /* ReaderModeStyleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeStyleViewModel.swift; sourceTree = "<group>"; };
@@ -6635,6 +6637,7 @@
 				C8445AD026443C7F00B83F53 /* LibraryPanelViewStateTests.swift */,
 				DFA514822761012D00266AA0 /* HistoryHighlightsManagerTests.swift */,
 				213B67A727CE721E000542F5 /* StartAtHomeHelperTests.swift */,
+				8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -9042,6 +9045,7 @@
 				CA7BD568248189E800A0A61B /* BreachAlertsTests.swift in Sources */,
 				4A59B58AD11B5EE1F80BBDEB /* TestHistory.swift in Sources */,
 				A83E5B1D1C1DA8D80026D912 /* UIPasteboardExtensionsTests.swift in Sources */,
+				8A355E5E27D267A400B9AF34 /* RecentItemsHelperTests.swift in Sources */,
 				8AFE4C2127480D0C00B97C65 /* TabTrayViewControllerTests.swift in Sources */,
 				28D52E2F1BCDF53900187A1D /* ResetTests.swift in Sources */,
 				8A2825352760399B00395E66 /* KeyboardPressesHandlerTests.swift in Sources */,

--- a/ClientTests/RecentItemsHelperTests.swift
+++ b/ClientTests/RecentItemsHelperTests.swift
@@ -1,0 +1,193 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+import XCTest
+import Storage
+import Shared
+
+class RecentItemsHelperTests: XCTestCase {
+
+    private let bookmarkCutoffDate = 10
+    private let readingListCutoffdate = 7
+
+    func testEmptyRecentItems_returnsEmpty() {
+        let recentItemsHelper = RecentItemsHelper()
+        let result = recentItemsHelper.filterStaleItems(recentItems: [])
+        XCTAssertEqual(result.count, 0)
+    }
+
+    // MARK: Bookmarks
+
+    func testBookmarkItem_withNowDate() {
+        let recentItemsHelper = RecentItemsHelper()
+        let bookmarksItems = [createBookmarkItem()]
+        let result = recentItemsHelper.filterStaleItems(recentItems: bookmarksItems)
+        XCTAssertEqual(result.count, 1)
+    }
+
+    func testMultipleBookmarkItems_withNowDate() {
+        let recentItemsHelper = RecentItemsHelper()
+        let bookmarksItems = createBookmarksItems(count: 10)
+        let result = recentItemsHelper.filterStaleItems(recentItems: bookmarksItems)
+        XCTAssertEqual(result.count, 10)
+    }
+
+    func testBookmarkItem_withExactCutoffDate() {
+        let recentItemsHelper = RecentItemsHelper()
+        let exactDate = Calendar.current.add(numberOfDays: -bookmarkCutoffDate, to: Date())!
+        let bookmarksItems = [createBookmarkItem(date: exactDate)]
+        let result = recentItemsHelper.filterStaleItems(recentItems: bookmarksItems)
+        XCTAssertEqual(result.count, 1)
+    }
+
+    func testBookmarkItem_withPastDatePastCutoff() {
+        let recentItemsHelper = RecentItemsHelper()
+        let pastDate = Calendar.current.add(numberOfDays: -bookmarkCutoffDate - 1, to: Date())!
+        let bookmarksItems = [createBookmarkItem(date: pastDate)]
+        let result = recentItemsHelper.filterStaleItems(recentItems: bookmarksItems)
+        XCTAssertEqual(result.count, 0)
+    }
+
+    func testBookmarkItem_withPastDateBeforeCutoff() {
+        let recentItemsHelper = RecentItemsHelper()
+        let beforeCutoff = Calendar.current.add(numberOfDays: -bookmarkCutoffDate + 1, to: Date())!
+        let bookmarksItems = [createBookmarkItem(date: beforeCutoff)]
+        let result = recentItemsHelper.filterStaleItems(recentItems: bookmarksItems)
+        XCTAssertEqual(result.count, 1)
+    }
+
+    func testBookmarkItem_withFutureDate() {
+        let recentItemsHelper = RecentItemsHelper()
+        let futureDate = Calendar.current.add(numberOfDays: bookmarkCutoffDate, to: Date())!
+        let bookmarksItems = [createBookmarkItem(date: futureDate)]
+        let result = recentItemsHelper.filterStaleItems(recentItems: bookmarksItems)
+        XCTAssertEqual(result.count, 1)
+    }
+
+    func testMultipleBookmarkItems_withMixedDates() {
+        let recentItemsHelper = RecentItemsHelper()
+        let pastDate = Calendar.current.add(numberOfDays: -bookmarkCutoffDate - 1, to: Date())!
+        let pastBookmarksItems = createBookmarksItems(count: 2, date: pastDate)
+
+        let futureDate = Calendar.current.add(numberOfDays: bookmarkCutoffDate, to: Date())!
+        let futureBookmarksItems = createBookmarksItems(count: 2, date: futureDate)
+
+        let beforeCutoff = Calendar.current.add(numberOfDays: -bookmarkCutoffDate + 1, to: Date())!
+        let beforeCutoffBookmarksItems = createBookmarksItems(count: 2, date: beforeCutoff)
+
+        let exactDate = Calendar.current.add(numberOfDays: -bookmarkCutoffDate, to: Date())!
+        let exactDateBookmarksItems = createBookmarksItems(count: 2, date: exactDate)
+
+        var bookmarksItems = pastBookmarksItems
+        bookmarksItems.append(contentsOf: futureBookmarksItems)
+        bookmarksItems.append(contentsOf: beforeCutoffBookmarksItems)
+        bookmarksItems.append(contentsOf: exactDateBookmarksItems)
+
+        let result = recentItemsHelper.filterStaleItems(recentItems: bookmarksItems)
+        XCTAssertEqual(result.count, 6)
+    }
+
+    // MARK: Reading List
+
+    func testReadingListItem_withNowDate() {
+        let recentItemsHelper = RecentItemsHelper()
+        let readingListItems = [createReadingListItem()]
+        let result = recentItemsHelper.filterStaleItems(recentItems: readingListItems)
+        XCTAssertEqual(result.count, 1)
+    }
+
+    func testMultipleReadingListItem_withNowDate() {
+        let recentItemsHelper = RecentItemsHelper()
+        let readingListItems = createReadingListItems(count: 10)
+        let result = recentItemsHelper.filterStaleItems(recentItems: readingListItems)
+        XCTAssertEqual(result.count, 10)
+    }
+
+    func testReadingListItem_withExactCutoffDate() {
+        let recentItemsHelper = RecentItemsHelper()
+        let exactDate = Calendar.current.add(numberOfDays: -readingListCutoffdate, to: Date())!
+        let readingListItems = [createReadingListItem(date: exactDate)]
+        let result = recentItemsHelper.filterStaleItems(recentItems: readingListItems)
+        XCTAssertEqual(result.count, 1)
+    }
+
+    func testReadingListItem_withPastDatePastCutoff() {
+        let recentItemsHelper = RecentItemsHelper()
+        let pastDate = Calendar.current.add(numberOfDays: -readingListCutoffdate - 1, to: Date())!
+        let readingListItems = [createReadingListItem(date: pastDate)]
+        let result = recentItemsHelper.filterStaleItems(recentItems: readingListItems)
+        XCTAssertEqual(result.count, 0)
+    }
+
+    func testReadingListItem_withPastDateBeforeCutoff() {
+        let recentItemsHelper = RecentItemsHelper()
+        let beforeCutoff = Calendar.current.add(numberOfDays: -readingListCutoffdate + 1, to: Date())!
+        let readingListItems = [createReadingListItem(date: beforeCutoff)]
+        let result = recentItemsHelper.filterStaleItems(recentItems: readingListItems)
+        XCTAssertEqual(result.count, 1)
+    }
+
+    func testReadingListItem_withFutureDate() {
+        let recentItemsHelper = RecentItemsHelper()
+        let futureDate = Calendar.current.add(numberOfDays: readingListCutoffdate, to: Date())!
+        let readingListItems = [createReadingListItem(date: futureDate)]
+        let result = recentItemsHelper.filterStaleItems(recentItems: readingListItems)
+        XCTAssertEqual(result.count, 1)
+    }
+
+    func testMultipleRecentlySavedItems_withMixedDates() {
+        let recentItemsHelper = RecentItemsHelper()
+        let pastDate = Calendar.current.add(numberOfDays: -readingListCutoffdate - 1, to: Date())!
+        let pastRecentlySavedItems = createReadingListItems(count: 2, date: pastDate)
+
+        let futureDate = Calendar.current.add(numberOfDays: readingListCutoffdate, to: Date())!
+        let futureRecentlySavedItems = createReadingListItems(count: 2, date: futureDate)
+
+        let beforeCutoff = Calendar.current.add(numberOfDays: -readingListCutoffdate + 1, to: Date())!
+        let beforeCutoffRecentlySavedItems = createReadingListItems(count: 2, date: beforeCutoff)
+
+        let exactDate = Calendar.current.add(numberOfDays: -readingListCutoffdate, to: Date())!
+        let exactDateRecentlySavedItems = createReadingListItems(count: 2, date: exactDate)
+
+        var readingListItems = pastRecentlySavedItems
+        readingListItems.append(contentsOf: futureRecentlySavedItems)
+        readingListItems.append(contentsOf: beforeCutoffRecentlySavedItems)
+        readingListItems.append(contentsOf: exactDateRecentlySavedItems)
+
+        let result = recentItemsHelper.filterStaleItems(recentItems: readingListItems)
+        XCTAssertEqual(result.count, 6)
+    }
+}
+
+private extension RecentItemsHelperTests {
+
+    func createBookmarksItems(count: Int, date: Date = Date()) -> [BookmarkItemData] {
+        var items = [BookmarkItemData]()
+        for _ in 0..<count {
+            items.append(createBookmarkItem(date: date))
+        }
+        return items
+    }
+
+    func createBookmarkItem(date: Date = Date()) -> BookmarkItemData {
+        let dateAdded = Int64(date.toTimestamp())
+        return BookmarkItemData(guid: "", dateAdded: dateAdded, lastModified: 0, parentGUID: "", position: 0, url: "", title: "")
+    }
+
+    func createReadingListItems(count: Int, date: Date = Date()) -> [ReadingListItem] {
+        var items = [ReadingListItem]()
+        for _ in 0..<count {
+            items.append(createReadingListItem(date: date))
+        }
+        return items
+    }
+
+    func createReadingListItem(date: Date = Date()) -> ReadingListItem {
+        // Reading list items are saved with timeIntervalSinceReferenceDate timestamp
+        let lastModified = UInt64(1000 * date.timeIntervalSinceReferenceDate)
+        return ReadingListItem(id: 0, lastModified: lastModified, url: "", title: "", addedBy: "")
+    }
+}


### PR DESCRIPTION
# Issue #9726
- Add unit tests for recent items filtering
- Small refactor to use protocol so we don't have to unwrap `[ReadingListItem]` and `[BookmarkItemData]` from an array of `[RecentlySavedItem]` (and get type checks) 
- Fix date bug with timeIntervalSinceReferenceDate (was using timeIntervalSince1970 instead). Reason is that Reading List items are saved in SQLite using timeIntervalSinceReferenceDate. We were reconstructing the timestamp with timeIntervalSince1970. Since this was giving us the wrong date, there was a workaround in place, but I think this is what was causing the bug. The bug was filed beginning of January. The workaround probably worked most of the time but close to a new year it make sense that it wouldn't work. Since we're now using the correct timestamp format this shouldn't happen anymore 🤞