### PR TITLE
Fix #10197 - Add Done Button in Tab Tray for iPhone

### DIFF
--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -227,6 +227,8 @@ class TabTrayViewController: UIViewController {
     }
 
     fileprivate func iPhoneViewSetup() {
+        navigationItem.rightBarButtonItem = doneButton
+        
         view.addSubview(navigationToolbar)
 
         navigationToolbar.snp.makeConstraints { make in
@@ -243,7 +245,7 @@ class TabTrayViewController: UIViewController {
     fileprivate func updateTitle() {
         if let newTitle = viewModel.navTitle(for: navigationMenu.selectedSegmentIndex,
                                              foriPhone: !shouldUseiPadSetup()) {
-            navigationItem.title  = newTitle
+            navigationItem.title = newTitle
         }
     }
 


### PR DESCRIPTION
Adds Done Button in Tab Tray for iPhone (see #10197 for reference):
New:

![Screenshot 2022-03-10 at 17 36 18](https://user-images.githubusercontent.com/46824694/157710713-149c749a-3b90-4fb5-bf18-7c6b8a70f426.png)

