### PR TITLE
Fix #10171 - "x" icon is disappearing intermittently when typing text in the URL bar

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -248,7 +248,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
 
         let enteredTextSize = self.attributedText?.boundingRect(with: self.frame.size, options: NSStringDrawingOptions.usesLineFragmentOrigin, context: nil)
         frame.origin.x = (enteredTextSize?.width.rounded() ?? 0) + textRect(forBounds: bounds).origin.x
-        frame.size.width = self.frame.size.width - frame.origin.x
+        frame.size.width = self.frame.size.width - clearButtonRect(forBounds: self.frame).size.width - frame.origin.x
         frame.size.height = self.frame.size.height
         label.frame = frame
         return label


### PR DESCRIPTION
The autocomplete text label wasn't accounting for the size of the clearButton when calculating its width, so it would obscure it.

*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Please make sure you've run the test scheme and all the tests pass. If your changes affect existing tests please make sure to update the tests as well.

