### PR TITLE
Bugfix FXIOS-3886 [v105] Preserve order of background tabs

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -65,6 +65,7 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
     fileprivate let store: TabManagerStore
     fileprivate let profile: Profile
     fileprivate var isRestoringTabs = false
+    var tabDisplayType: TabDisplayType = .TabGrid
 
     let delaySelectingNewPopupTab: TimeInterval = 0.1
 
@@ -389,12 +390,16 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
         var placeNextToParentTab = false
         if parent == nil || parent?.isPrivate != tab.isPrivate {
             tabs.append(tab)
+            
         } else if let parent = parent, var insertIndex = tabs.firstIndex(of: parent) {
             placeNextToParentTab = true
             insertIndex += 1
-            while insertIndex < tabs.count && tabs[insertIndex].isDescendentOf(parent) {
+            
+            // If we are on iPad (.TopTabTray), the new tab should be inserted immediately after the parent tab.
+            while insertIndex < tabs.count && tabs[insertIndex].isDescendentOf(parent) && tabDisplayType == .TabGrid {
                 insertIndex += 1
             }
+            
             tab.parent = parent
             tabs.insert(tab, at: insertIndex)
         }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -396,6 +396,7 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
             insertIndex += 1
             
             // If we are on iPad (.TopTabTray), the new tab should be inserted immediately after the parent tab.
+            // In this scenario the while loop shouldn't be executed.
             while insertIndex < tabs.count && tabs[insertIndex].isDescendentOf(parent) && tabDisplayType == .TabGrid {
                 insertIndex += 1
             }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -390,17 +390,17 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
         var placeNextToParentTab = false
         if parent == nil || parent?.isPrivate != tab.isPrivate {
             tabs.append(tab)
-            
+
         } else if let parent = parent, var insertIndex = tabs.firstIndex(of: parent) {
             placeNextToParentTab = true
             insertIndex += 1
-            
+
             // If we are on iPad (.TopTabTray), the new tab should be inserted immediately after the parent tab.
             // In this scenario the while loop shouldn't be executed.
             while insertIndex < tabs.count && tabs[insertIndex].isDescendentOf(parent) && tabDisplayType == .TabGrid {
                 insertIndex += 1
             }
-            
+
             tab.parent = parent
             tabs.insert(tab, at: insertIndex)
         }

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -102,7 +102,6 @@ class TopTabsViewController: UIViewController {
                                                  reuseID: TopTabCell.cellIdentifier,
                                                  tabDisplayType: .TopTabTray,
                                                  profile: profile)
-        topTabDisplayManager = TabDisplayManager(collectionView: self.collectionView, tabManager: self.tabManager, tabDisplayer: self, reuseID: TopTabCell.Identifier, tabDisplayType: .TopTabTray, profile: profile)
         tabManager.tabDisplayType = .TopTabTray
         collectionView.dataSource = topTabDisplayManager
         collectionView.delegate = tabLayoutDelegate

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -102,6 +102,8 @@ class TopTabsViewController: UIViewController {
                                                  reuseID: TopTabCell.cellIdentifier,
                                                  tabDisplayType: .TopTabTray,
                                                  profile: profile)
+        topTabDisplayManager = TabDisplayManager(collectionView: self.collectionView, tabManager: self.tabManager, tabDisplayer: self, reuseID: TopTabCell.Identifier, tabDisplayType: .TopTabTray, profile: profile)
+        tabManager.tabDisplayType = .TopTabTray
         collectionView.dataSource = topTabDisplayManager
         collectionView.delegate = tabLayoutDelegate
     }

--- a/Tests/ClientTests/TabManagerTests.swift
+++ b/Tests/ClientTests/TabManagerTests.swift
@@ -653,10 +653,10 @@ private extension TabManagerTests {
         // parentTab, childTab3, childTab2, childTab1
         
         XCTAssertEqual(manager.tabs.count, 4)
-        XCTAssertEqual(manager.tabs[0].tabUUID, parentTab.tabUUID, "")
-        XCTAssertEqual(manager.tabs[1].tabUUID, childTab3.tabUUID, "")
-        XCTAssertEqual(manager.tabs[2].tabUUID, childTab2.tabUUID, "")
-        XCTAssertEqual(manager.tabs[3].tabUUID, childTab1.tabUUID, "")
+        XCTAssertEqual(manager.tabs[0].tabUUID, parentTab.tabUUID)
+        XCTAssertEqual(manager.tabs[1].tabUUID, childTab3.tabUUID)
+        XCTAssertEqual(manager.tabs[2].tabUUID, childTab2.tabUUID)
+        XCTAssertEqual(manager.tabs[3].tabUUID, childTab1.tabUUID)
     }
     
     func testInsertMultipleTabsNextToParentTab_TabGrid() {
@@ -674,9 +674,9 @@ private extension TabManagerTests {
         // parentTab, childTab1, childTab2, childTab3
         
         XCTAssertEqual(manager.tabs.count, 4)
-        XCTAssertEqual(manager.tabs[0].tabUUID, parentTab.tabUUID, "")
-        XCTAssertEqual(manager.tabs[1].tabUUID, childTab1.tabUUID, "")
-        XCTAssertEqual(manager.tabs[2].tabUUID, childTab2.tabUUID, "")
-        XCTAssertEqual(manager.tabs[3].tabUUID, childTab3.tabUUID, "")
+        XCTAssertEqual(manager.tabs[0].tabUUID, parentTab.tabUUID)
+        XCTAssertEqual(manager.tabs[1].tabUUID, childTab1.tabUUID)
+        XCTAssertEqual(manager.tabs[2].tabUUID, childTab2.tabUUID)
+        XCTAssertEqual(manager.tabs[3].tabUUID, childTab3.tabUUID)
     }
 }

--- a/Tests/ClientTests/TabManagerTests.swift
+++ b/Tests/ClientTests/TabManagerTests.swift
@@ -635,4 +635,48 @@ private extension TabManagerTests {
         }
         waitForExpectations(timeout: 10.0, handler: nil)
     }
+    
+    // MARK: - Add multiple tabs next to parent
+    
+    func testInsertMultipleTabsNextToParentTab_TopTabTray() {
+        let manager = TabManager(profile: profile, imageStore: nil)
+        manager.tabDisplayType = .TopTabTray
+        
+        let parentTab = manager.addTab()
+        manager.selectTab(parentTab)
+        
+        let childTab1 = manager.addTab(afterTab: parentTab)
+        let childTab2 = manager.addTab(afterTab: parentTab)
+        let childTab3 = manager.addTab(afterTab: parentTab)
+        
+        // Expected Order:
+        // parentTab, childTab3, childTab2, childTab1
+        
+        XCTAssertEqual(manager.tabs.count, 4)
+        XCTAssertEqual(manager.tabs[0].tabUUID, parentTab.tabUUID, "")
+        XCTAssertEqual(manager.tabs[1].tabUUID, childTab3.tabUUID, "")
+        XCTAssertEqual(manager.tabs[2].tabUUID, childTab2.tabUUID, "")
+        XCTAssertEqual(manager.tabs[3].tabUUID, childTab1.tabUUID, "")
+    }
+    
+    func testInsertMultipleTabsNextToParentTab_TabGrid() {
+        let manager = TabManager(profile: profile, imageStore: nil)
+        manager.tabDisplayType = .TabGrid // <- default
+        
+        let parentTab = manager.addTab()
+        manager.selectTab(parentTab)
+        
+        let childTab1 = manager.addTab(afterTab: parentTab)
+        let childTab2 = manager.addTab(afterTab: parentTab)
+        let childTab3 = manager.addTab(afterTab: parentTab)
+        
+        // Expected Order:
+        // parentTab, childTab1, childTab2, childTab3
+        
+        XCTAssertEqual(manager.tabs.count, 4)
+        XCTAssertEqual(manager.tabs[0].tabUUID, parentTab.tabUUID, "")
+        XCTAssertEqual(manager.tabs[1].tabUUID, childTab1.tabUUID, "")
+        XCTAssertEqual(manager.tabs[2].tabUUID, childTab2.tabUUID, "")
+        XCTAssertEqual(manager.tabs[3].tabUUID, childTab3.tabUUID, "")
+    }
 }

--- a/Tests/ClientTests/TabManagerTests.swift
+++ b/Tests/ClientTests/TabManagerTests.swift
@@ -635,44 +635,44 @@ private extension TabManagerTests {
         }
         waitForExpectations(timeout: 10.0, handler: nil)
     }
-    
+
     // MARK: - Add multiple tabs next to parent
-    
+
     func testInsertMultipleTabsNextToParentTab_TopTabTray() {
         let manager = TabManager(profile: profile, imageStore: nil)
         manager.tabDisplayType = .TopTabTray
-        
+
         let parentTab = manager.addTab()
         manager.selectTab(parentTab)
-        
+
         let childTab1 = manager.addTab(afterTab: parentTab)
         let childTab2 = manager.addTab(afterTab: parentTab)
         let childTab3 = manager.addTab(afterTab: parentTab)
-        
+
         // Expected Order:
         // parentTab, childTab3, childTab2, childTab1
-        
+
         XCTAssertEqual(manager.tabs.count, 4)
         XCTAssertEqual(manager.tabs[0].tabUUID, parentTab.tabUUID)
         XCTAssertEqual(manager.tabs[1].tabUUID, childTab3.tabUUID)
         XCTAssertEqual(manager.tabs[2].tabUUID, childTab2.tabUUID)
         XCTAssertEqual(manager.tabs[3].tabUUID, childTab1.tabUUID)
     }
-    
+
     func testInsertMultipleTabsNextToParentTab_TabGrid() {
         let manager = TabManager(profile: profile, imageStore: nil)
         manager.tabDisplayType = .TabGrid // <- default
-        
+
         let parentTab = manager.addTab()
         manager.selectTab(parentTab)
-        
+
         let childTab1 = manager.addTab(afterTab: parentTab)
         let childTab2 = manager.addTab(afterTab: parentTab)
         let childTab3 = manager.addTab(afterTab: parentTab)
-        
+
         // Expected Order:
         // parentTab, childTab1, childTab2, childTab3
-        
+
         XCTAssertEqual(manager.tabs.count, 4)
         XCTAssertEqual(manager.tabs[0].tabUUID, parentTab.tabUUID)
         XCTAssertEqual(manager.tabs[1].tabUUID, childTab1.tabUUID)


### PR DESCRIPTION
The problem was, that the `TabManager` inserted new tabs (which were opened in the background) at the wrong position in the `tabs` array. I have added an additional check to make sure that if the `tabDisplayType` is `.TopTabTray` new background tabs are inserted at the right index (indexOfParent + 1).
New behaviour:

https://user-images.githubusercontent.com/46824694/158052405-8bc01d0a-c686-40ae-9727-3e29cbcb06f6.mov

See #10191 for reference (I think this PR fixes #10190 too).