### PR TITLE
Refactor #10215 [v99] fix sync int test bookmark

### DIFF
--- a/XCUITests/IntegrationTests.swift
+++ b/XCUITests/IntegrationTests.swift
@@ -134,6 +134,7 @@ class IntegrationTests: BaseTestCase {
         navigator.nowAt(BrowserTab)
         // This is only to check that the device's name changed
         navigator.goto(SettingsScreen)
+        waitForExistence(app.tables.cells.element(boundBy: 1), timeout: 10)
         app.tables.cells.element(boundBy: 1).tap()
         waitForExistence(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"], timeout: 10)
         XCTAssertEqual(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"].value! as! String, "Fennec (administrator) on iOS")

--- a/XCUITests/IntegrationTests.swift
+++ b/XCUITests/IntegrationTests.swift
@@ -13,7 +13,7 @@ private let tabOpenInDesktop = "http://example.com/"
 
 class IntegrationTests: BaseTestCase {
 
-    let testWithDB = ["testFxASyncHistory", "testFxASyncBookmark"]
+    let testWithDB = ["testFxASyncHistory"]
     let testFxAChinaServer = ["testFxASyncPageUsingChinaFxA"]
 
     // This DB contains 1 entry example.com
@@ -101,6 +101,12 @@ class IntegrationTests: BaseTestCase {
         // Bookmark is added by the DB
         // Sign into Firefox Accounts
         app.buttons["urlBar-cancel"].tap()
+        navigator.openURL("example.com")
+        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection], timeout: 5)
+        navigator.goto(BrowserTabMenu)
+        waitForExistence(app.tables.otherElements[ImageIdentifiers.addToBookmark], timeout: 15)
+        app.tables.otherElements[ImageIdentifiers.addToBookmark].tap()
+        navigator.nowAt(BrowserTab)
         signInFxAccounts()
 
         // Wait for initial sync to complete


### PR DESCRIPTION
Workaround to fix the sync int tests that starts by bookmarking  site in mobile.
The pre-load database with the site bookmarked does not work, so let's manually bookmark it to get the test working while that issue is investigated