### PR TITLE
Bugfix #9967 [v99] Pasted from [app]" banner is repeatedly displayed when dismissing Settings menu

### DIFF
--- a/Client/Extensions/UIPasteboardExtensions.swift
+++ b/Client/Extensions/UIPasteboardExtensions.swift
@@ -36,6 +36,13 @@ extension UIPasteboard {
             return UIPasteboard.general.string
         }
     }
+    
+    func asyncURL2(completion: @escaping (URL?) -> ()) {
+        DispatchQueue.global().async {
+            let url = UIPasteboard.general.url
+            completion(url)
+        }
+    }
 
     /// Preferred method to get URLs out of the clipboard.
     /// We use Deferred<Maybe<T?>> to fit in to the rest of the Deferred<Maybe> tools

--- a/Client/Extensions/UIPasteboardExtensions.swift
+++ b/Client/Extensions/UIPasteboardExtensions.swift
@@ -36,13 +36,6 @@ extension UIPasteboard {
             return UIPasteboard.general.string
         }
     }
-    
-    func asyncURL2(completion: @escaping (URL?) -> ()) {
-        DispatchQueue.global().async {
-            let url = UIPasteboard.general.url
-            completion(url)
-        }
-    }
 
     /// Preferred method to get URLs out of the clipboard.
     /// We use Deferred<Maybe<T?>> to fit in to the rest of the Deferred<Maybe> tools

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -499,7 +499,6 @@ class BrowserViewController: UIViewController {
         }
 
         updateTabCountUsingTabManager(tabManager, animated: false)
-        clipboardBarDisplayHandler?.checkIfShouldDisplayBar()
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -119,39 +119,30 @@ class ClipboardBarDisplayHandler: NSObject, URLChangeDelegate {
         return false
     }
     
-    
-    
-     func checkIfShouldDisplayBar() {
-         // There's no point in doing any of this work unless the
-         // user has asked for it in settings.
-         guard self.prefs.boolForKey("showClipboardBar") ?? false else { return }
-         
-         guard UIPasteboard.general.hasURLs else { return }
-                 
-         UIPasteboard.general.asyncURL2 { url in
+    func checkIfShouldDisplayBar() {
+        // There's no point in doing any of this work unless the
+        // user has asked for it in settings.
+        guard self.prefs.boolForKey("showClipboardBar") ?? false else { return }
 
-            guard let url = url else { return }
-
-            guard self.shouldDisplayBar(url.absoluteString) else {
-                return
-            }
-
-            self.lastDisplayedURL = url.absoluteString
-
-            self.clipboardToast =
-                ButtonToast(
-                    labelText: .GoToCopiedLink,
-                    descriptionText: url.absoluteDisplayString,
-                    buttonText: .GoButtonTittle,
-                    completion: { buttonPressed in
-                        if buttonPressed {
-                            self.delegate?.settingsOpenURLInNewTab(url)
-                        }
+        guard UIPasteboard.general.hasURLs,
+              let url = UIPasteboard.general.url,
+              self.shouldDisplayBar(url.absoluteString) else { return }
+        
+        self.lastDisplayedURL = url.absoluteString
+        
+        self.clipboardToast =
+        ButtonToast(
+            labelText: .GoToCopiedLink,
+            descriptionText: url.absoluteDisplayString,
+            buttonText: .GoButtonTittle,
+            completion: { buttonPressed in
+                if buttonPressed {
+                    self.delegate?.settingsOpenURLInNewTab(url)
+                }
             })
-
-            if let toast = self.clipboardToast {
-                self.delegate?.shouldDisplay(clipboardBar: toast)
-            }
+        
+        if let toast = self.clipboardToast {
+            self.delegate?.shouldDisplay(clipboardBar: toast)
         }
     }
 }

--- a/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -118,26 +118,25 @@ class ClipboardBarDisplayHandler: NSObject, URLChangeDelegate {
         }
         return false
     }
+    
+    
+    
+     func checkIfShouldDisplayBar() {
+         // There's no point in doing any of this work unless the
+         // user has asked for it in settings.
+         guard self.prefs.boolForKey("showClipboardBar") ?? false else { return }
+         
+         guard UIPasteboard.general.hasURLs else { return }
+                 
+         UIPasteboard.general.asyncURL2 { url in
 
-    func checkIfShouldDisplayBar() {
-        guard self.prefs.boolForKey("showClipboardBar") ?? false else {
-            // There's no point in doing any of this work unless the
-            // user has asked for it in settings.
-            return
-        }
-        UIPasteboard.general.asyncURL().uponQueue(.main) { res in
-            guard let copiedURL: URL? = res.successValue,
-                let url = copiedURL else {
+            guard let url = url else { return }
+
+            guard self.shouldDisplayBar(url.absoluteString) else {
                 return
             }
 
-            let absoluteString = url.absoluteString
-
-            guard self.shouldDisplayBar(absoluteString) else {
-                return
-            }
-
-            self.lastDisplayedURL = absoluteString
+            self.lastDisplayedURL = url.absoluteString
 
             self.clipboardToast =
                 ButtonToast(

--- a/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -120,8 +120,7 @@ class ClipboardBarDisplayHandler: NSObject, URLChangeDelegate {
     }
     
     func checkIfShouldDisplayBar() {
-        // There's no point in doing any of this work unless the
-        // user has asked for it in settings.
+        // Clipboard bar feature needs to be enabled by users to be activated in the user settings
         guard self.prefs.boolForKey("showClipboardBar") ?? false else { return }
 
         guard UIPasteboard.general.hasURLs,

--- a/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -121,11 +121,11 @@ class ClipboardBarDisplayHandler: NSObject, URLChangeDelegate {
     
     func checkIfShouldDisplayBar() {
         // Clipboard bar feature needs to be enabled by users to be activated in the user settings
-        guard self.prefs.boolForKey("showClipboardBar") ?? false else { return }
+        guard prefs.boolForKey("showClipboardBar") ?? false else { return }
 
         guard UIPasteboard.general.hasURLs,
               let url = UIPasteboard.general.url,
-              self.shouldDisplayBar(url.absoluteString) else { return }
+              shouldDisplayBar(url.absoluteString) else { return }
         
         self.lastDisplayedURL = url.absoluteString
         
@@ -141,7 +141,7 @@ class ClipboardBarDisplayHandler: NSObject, URLChangeDelegate {
             })
         
         if let toast = self.clipboardToast {
-            self.delegate?.shouldDisplay(clipboardBar: toast)
+            delegate?.shouldDisplay(clipboardBar: toast)
         }
     }
 }

--- a/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -49,6 +49,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlagsPr
         super.init(style: .grouped)
 
         self.title = .SettingsHomePageSectionName
+        self.navigationController?.navigationBar.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Homepage.homePageNavigationBar
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/XCUITests/HomePageSettingsUITest.swift
+++ b/XCUITests/HomePageSettingsUITest.swift
@@ -215,12 +215,15 @@ class HomePageSettingsUITests: BaseTestCase {
     func testCustomizeHomepage() {
         if !iPad() {
             navigator.performAction(Action.CloseURLBarOpen)
+            waitForExistence(app.cells.otherElements["Bookmarks"], timeout: 5)
             app.cells.otherElements["Bookmarks"].swipeUp()
-            waitForExistence(app.cells.otherElements.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.customizeHomePage])
+            waitForExistence(app.collectionViews.scrollViews.firstMatch, timeout: 5)
+            app.collectionViews.scrollViews.firstMatch.swipeUp()
+            waitForExistence(app.cells.otherElements.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.customizeHomePage], timeout: 5)
         }
         app.cells.otherElements.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.customizeHomePage].tap()
         // Verify default settings
-        waitForExistence(app.navigationBars[AccessibilityIdentifiers.Settings.Homepage.homePageNavigationBar], timeout: 3)
+        waitForExistence(app.navigationBars[AccessibilityIdentifiers.Settings.Homepage.homePageNavigationBar], timeout: 20)
         XCTAssertTrue(app.tables.cells[AccessibilityIdentifiers.Settings.Homepage.StartAtHome.always].exists)
         XCTAssertTrue(app.tables.cells[AccessibilityIdentifiers.Settings.Homepage.StartAtHome.disabled].exists)
         XCTAssertTrue(app.tables.cells[AccessibilityIdentifiers.Settings.Homepage.StartAtHome.afterFourHours].exists)


### PR DESCRIPTION
Issue #9967 
- Remove call from `BrowserViewController` from `viewWillAppear` 
- Use `UIPasteboard.general.url `to get coppied url and check `UIPasteboard.general.hasURLs` before according to Apple implementation