### PR TITLE
Add [v100]: Increment nimbus-fml version to v92.0.0

### DIFF
--- a/bin/nimbus-fml.sh
+++ b/bin/nimbus-fml.sh
@@ -60,7 +60,7 @@ helptext() {
 MANIFEST_PATH=
 OUTPUT_DIR="${SOURCE_ROOT}/${PROJECT}/Generated"
 NAMESPACE=
-AS_VERSION=v91.1.0
+AS_VERSION=v92.0.0
 
 while (( "$#" )); do
     case "$1" in


### PR DESCRIPTION
This will be of most importance to the GleanPlumb messaging work, but also of interest to anything using nimbus.

Changelog:

- Papercut fixes for nicer developer experience [#4867](https://github.com/mozilla/application-services/pull/4867)
  - More helpful validation error reporting
  - Better handling of defaults in objects and enum maps
  - More YAML syntactic checking.
- Allow experimenter to output to a YAML file, as well as JSON. [#4874](https://github.com/mozilla/application-services/pull/4874)
  - If the file extension is `yaml`, then output as YAML, otherwise, output as JSON.