### PR TITLE
Refactor FXIOS-2931 [v99]: Bring back the old history panel

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -394,7 +394,7 @@
 		5002717C41BC7C50F67F1CAD /* StateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50027345B49B967409DDA348 /* StateTests.swift */; };
 		554867231DC3935A00183DAA /* HomePageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 554867221DC3935A00183DAA /* HomePageTests.swift */; };
 		580B0C4221748CFE00448DF8 /* DataManagementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580B0C4121748CFE00448DF8 /* DataManagementTests.swift */; };
-		59A68B280D62462B85CF57A4 /* HistoryPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A6825233896FC846499289 /* HistoryPanel.swift */; };
+		59A68B280D62462B85CF57A4 /* HistoryPanelV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A6825233896FC846499289 /* HistoryPanelV2.swift */; };
 		59A68D66379CFA85C4EAF00B /* TwoLineCellAndFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A68B1F857A8638598A63A0 /* TwoLineCellAndFooter.swift */; };
 		59A68E0B4ABBF55E14819668 /* BookmarksPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A6839879D615FC1C0D71CE /* BookmarksPanel.swift */; };
 		59A68FD5260B8D520F890F4A /* ReaderPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A685F4EAD19EDEC854BCA4 /* ReaderPanel.swift */; };
@@ -527,6 +527,7 @@
 		962F394A2672D57A006BDA2A /* RecentItemsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962F39492672D57A006BDA2A /* RecentItemsHelper.swift */; };
 		9638332327E14ACC0011EEFC /* AccessibilityIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84266742728462900382274 /* AccessibilityIdentifiers.swift */; };
 		966206CD2698DE1E005C0A55 /* FirefoxHomeRecentlySavedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966206CC2698DE1E005C0A55 /* FirefoxHomeRecentlySavedViewModel.swift */; };
+		966ECDAC27E4FA89006C93C8 /* HistoryPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966ECDAB27E4FA89006C93C8 /* HistoryPanel.swift */; };
 		968BD7EB27DFF0F8003148B3 /* ASGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 968BD7EA27DFF0F8003148B3 /* ASGroup.swift */; };
 		9699F77326F39E5100C5FA47 /* SiteImageHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9699F77226F39E5100C5FA47 /* SiteImageHelper.swift */; };
 		96D95016270238500079D39D /* Throttler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D95015270238500079D39D /* Throttler.swift */; };
@@ -2364,7 +2365,7 @@
 		58D84139B5071C0CCFDEA8C0 /* ka */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ka; path = ka.lproj/Localizable.strings; sourceTree = "<group>"; };
 		58EC442DAEFF1132932BDAB5 /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		59704663991C80BA05B0525B /* anp */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = anp; path = anp.lproj/Shared.strings; sourceTree = "<group>"; };
-		59A6825233896FC846499289 /* HistoryPanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = HistoryPanel.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		59A6825233896FC846499289 /* HistoryPanelV2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = HistoryPanelV2.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		59A6839879D615FC1C0D71CE /* BookmarksPanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksPanel.swift; sourceTree = "<group>"; };
 		59A685F4EAD19EDEC854BCA4 /* ReaderPanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderPanel.swift; sourceTree = "<group>"; };
 		59A68B1F857A8638598A63A0 /* TwoLineCellAndFooter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TwoLineCellAndFooter.swift; sourceTree = "<group>"; };
@@ -2897,6 +2898,7 @@
 		962A450E9186BF349E535413 /* sat-Olck */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "sat-Olck"; path = "sat-Olck.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		962F39492672D57A006BDA2A /* RecentItemsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentItemsHelper.swift; sourceTree = "<group>"; };
 		966206CC2698DE1E005C0A55 /* FirefoxHomeRecentlySavedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirefoxHomeRecentlySavedViewModel.swift; sourceTree = "<group>"; };
+		966ECDAB27E4FA89006C93C8 /* HistoryPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryPanel.swift; sourceTree = "<group>"; };
 		967AF157275FF4C60099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		967AF158275FF4C60099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		967AF159275FF4C60099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
@@ -5539,10 +5541,11 @@
 			isa = PBXGroup;
 			children = (
 				96EB6C4127DBF00E00A9D159 /* GeneralizedTableView */,
-				59A6825233896FC846499289 /* HistoryPanel.swift */,
+				59A6825233896FC846499289 /* HistoryPanelV2.swift */,
 				96EB6C3727D821B800A9D159 /* HistoryPanelViewModel.swift */,
 				96EB6C3B27D82AEA00A9D159 /* HistoryPanel+ContextMenuExtensions.swift */,
 				96EB6C3D27D9266500A9D159 /* HistoryActionables.swift */,
+				966ECDAB27E4FA89006C93C8 /* HistoryPanel.swift */,
 			);
 			path = HistoryPanel;
 			sourceTree = "<group>";
@@ -8919,6 +8922,7 @@
 				D88FDAAF1F4E2BA000FD9709 /* PhotonActionSheetAnimator.swift in Sources */,
 				C83432FE26BAD30D00ABAAA6 /* EnhancedTrackingProtectionDetailsVC.swift in Sources */,
 				E698FFDA1B4AADF40001F623 /* TabScrollController.swift in Sources */,
+				966ECDAC27E4FA89006C93C8 /* HistoryPanel.swift in Sources */,
 				D34510881ACF415700EC27F0 /* SearchLoader.swift in Sources */,
 				C80685D126A0C93900DCD895 /* UserResearch.swift in Sources */,
 				8AED23C527AC1F9500DE7E97 /* BaseContentStackView.swift in Sources */,
@@ -9089,7 +9093,7 @@
 				8D8251811F4DE67F00780643 /* AdvancedAccountSettingViewController.swift in Sources */,
 				E633E2DA1C21EAF8001FFF6C /* LoginDetailViewController.swift in Sources */,
 				8A9AC46B276D11280047F5B0 /* FxHomePocketViewModel.swift in Sources */,
-				59A68B280D62462B85CF57A4 /* HistoryPanel.swift in Sources */,
+				59A68B280D62462B85CF57A4 /* HistoryPanelV2.swift in Sources */,
 				C400467C1CF4E43E00B08303 /* BackForwardListViewController.swift in Sources */,
 				D5D237782640BBA600326204 /* ExperimentsSettingsViewController.swift in Sources */,
 				C826BD4A26973895006BBE24 /* FxHomeJumpBackInView.swift in Sources */,

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel+ContextMenuExtensions.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel+ContextMenuExtensions.swift
@@ -5,7 +5,7 @@
 import UIKit
 import Storage
 
-extension HistoryPanel: LibraryPanelContextMenu {
+extension HistoryPanelV2: LibraryPanelContextMenu {
     func presentContextMenu(for site: Site, with indexPath: IndexPath, completionHandler: @escaping () -> PhotonActionSheet?) {
         guard let contextMenu = completionHandler() else { return }
         

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+// TODO: HistoryPanel AND HistoryPanelV2 currently coexist until v100. Revert https://github.com/mozilla-mobile/firefox-ios/pull/10259 in v100.
+// Related to: https://mozilla-hub.atlassian.net/browse/FXIOS-2931 
+
 import UIKit
 import Shared
 import Storage

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -1,17 +1,15 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
 import Shared
 import Storage
 import XCGLogger
 import WebKit
-import os.log
 
 private struct HistoryPanelUX {
     static let WelcomeScreenItemWidth = 170
-    static let HeaderHeight = CGFloat(32)
     static let IconSize = 23
     static let IconBorderColor = UIColor.Photon.Grey30
     static let IconBorderWidth: CGFloat = 0.5
@@ -25,82 +23,108 @@ private class FetchInProgressError: MaybeErrorType {
 }
 
 @objcMembers
-class HistoryPanel: UIViewController, LibraryPanel, Loggable, NotificationThemeable {
+class HistoryPanel: SiteTableViewController, LibraryPanel {
     
-    // MARK: - Properties
+    typealias HistoryPanelStrings = String.LibraryPanel.History
     
-    typealias HistoryPanelSections = HistoryPanelViewModel.Sections
-    typealias a11yIds = AccessibilityIdentifiers.LibraryPanels.HistoryPanel
-    
-    var libraryPanelDelegate: LibraryPanelDelegate?
-    var recentlyClosedTabsDelegate: RecentlyClosedPanelDelegate?
-    
-    let profile: Profile
-    let viewModel: HistoryPanelViewModel
-    private let clearHistoryHelper: ClearHistoryHelper
-    
-    // We'll be able to prefetch more often the higher this number is. But remember, it's expensive!
-    private let historyPanelPrefetchOffset = 8
+    enum Section: Int {
+        // Showing showing recently closed, and clearing recent history are action rows of this type.
+        case additionalHistoryActions
+        case today
+        case yesterday
+        case lastWeek
+        case lastMonth
+        case older
 
-    private var diffableDatasource: UITableViewDiffableDataSource<HistoryPanelSections, AnyHashable>?
-    private var hasRecentlyClosed: Bool { profile.recentlyClosedTabs.tabs.count > 0 }
-    
-    // UI
-    lazy private var tableView: UITableView = .build { [weak self] tableView in
-        guard let self = self else { return }
-        tableView.dataSource = self.diffableDatasource
-        tableView.addGestureRecognizer(self.longPressRecognizer)
-        tableView.accessibilityIdentifier = a11yIds.tableView
-        tableView.prefetchDataSource = self
-        tableView.delegate = self
-        tableView.register(TwoLineImageOverlayCell.self, forCellReuseIdentifier: TwoLineImageOverlayCell.cellIdentifier)
-        tableView.register(TwoLineImageOverlayCell.self, forCellReuseIdentifier: TwoLineImageOverlayCell.accessoryUsageReuseIdentifier)
-        tableView.register(OneLineTableViewCell.self, forCellReuseIdentifier: OneLineTableViewCell.cellIdentifier)
-        tableView.register(SiteTableViewHeader.self, forHeaderFooterViewReuseIdentifier: SiteTableViewHeader.cellIdentifier)
-        
-        if #available(iOS 15.0, *) {
-            tableView.sectionHeaderTopPadding = 0
+        static let count = 6
+
+        var title: String? {
+            switch self {
+            case .today:
+                return .LibraryPanel.Sections.Today
+            case .yesterday:
+                return .LibraryPanel.Sections.Yesterday
+            case .lastWeek:
+                return .LibraryPanel.Sections.LastWeek
+            case .lastMonth:
+                return .LibraryPanel.Sections.LastMonth
+            case .older:
+                return .LibraryPanel.Sections.Older
+            default:
+                return nil
+            }
         }
     }
-    
-    lazy var longPressRecognizer: UILongPressGestureRecognizer = {
-        UILongPressGestureRecognizer(target: self, action: #selector(onLongPressGestureRecognized))
-    }()
-    
-    lazy var emptyStateOverlayView: UIView = createEmptyStateOverlayView()
+
+    enum AdditionalHistoryActionRow: Int {
+        case clearRecent
+        case showRecentlyClosedTabs
+
+        // Use to enable/disable the additional history action rows.
+        static func setStyle(enabled: Bool, forCell cell: OneLineTableViewCell) {
+            if enabled {
+                cell.titleLabel.alpha = 1.0
+                cell.leftImageView.alpha = 1.0
+                cell.selectionStyle = .default
+                cell.isUserInteractionEnabled = true
+            } else {
+                cell.titleLabel.alpha = 0.5
+                cell.leftImageView.alpha = 0.5
+                cell.selectionStyle = .none
+                cell.isUserInteractionEnabled = false
+            }
+        }
+    }
+
+    let QueryLimitPerFetch = 100
+
+    var libraryPanelDelegate: LibraryPanelDelegate?
+    var recentlyClosedTabsDelegate: RecentlyClosedPanelDelegate?
+
+    var groupedSites = DateGroupedTableData<Site>()
+
     var refreshControl: UIRefreshControl?
+
+    var currentFetchOffset = 0
+    var isFetchInProgress = false
+
     var clearHistoryCell: OneLineTableViewCell?
-    
-    // MARK: - Inits
-    
+    private let clearHistoryHelper: ClearHistoryHelper
+
+    var hasRecentlyClosed: Bool {
+        return profile.recentlyClosedTabs.tabs.count > 0
+    }
+
+    lazy var emptyStateOverlayView: UIView = createEmptyStateOverlayView()
+
+    lazy var longPressRecognizer: UILongPressGestureRecognizer = {
+        return UILongPressGestureRecognizer(target: self, action: #selector(onLongPressGestureRecognized))
+    }()
+
+    // MARK: - Lifecycle
     init(profile: Profile, tabManager: TabManager) {
         self.clearHistoryHelper = ClearHistoryHelper(profile: profile, tabManager: tabManager)
-        self.viewModel = HistoryPanelViewModel(profile: profile)
-        self.profile = profile
-        
-        super.init(nibName: nil, bundle: nil)
+        super.init(profile: profile)
+
+        [ Notification.Name.FirefoxAccountChanged,
+          Notification.Name.PrivateDataClearedHistory,
+          Notification.Name.DynamicFontChanged,
+          Notification.Name.DatabaseWasReopened,
+          Notification.Name.OpenClearRecentHistory].forEach {
+            NotificationCenter.default.addObserver(self, selector: #selector(onNotificationReceived), name: $0, object: nil)
+        }
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    deinit {
-        browserLog.debug("HistoryPanel Deinitialized.")
-    }
 
-    // MARK: - Lifecycle
-    
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        viewModel.viewDidLoad()
-        viewModel.historyPanelNotifications.forEach {
-            NotificationCenter.default.addObserver(self, selector: #selector(handleNotifications), name: $0, object: nil)
-        }
-        
-        setupLayout()
-        configureDatasource()
+        tableView.addGestureRecognizer(longPressRecognizer)
+        tableView.accessibilityIdentifier = "History List"
+        tableView.prefetchDataSource = self
+        tableView.backgroundColor = UIColor.theme.homePanel.panelBackground
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -108,103 +132,215 @@ class HistoryPanel: UIViewController, LibraryPanel, Loggable, NotificationThemea
 
         // Add a refresh control if the user is logged in and the control was not added before. If the user is not
         // logged in, remove any existing control.
-        handleRefreshControl()
-        applySnapshot()
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        // Since the reload operation to fetch STG completes LATE, we need to apply snapshot again here :(
-        // Especially in the case where you navigate to the history panel from another panel.
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
-            self.applySnapshot(animatingDifferences: true)
+        if profile.hasSyncableAccount() && refreshControl == nil {
+            addRefreshControl()
+        } else if !profile.hasSyncableAccount() && refreshControl != nil {
+            removeRefreshControl()
         }
-        
     }
-    
-    // MARK: - Misc. helpers
-    
-    private func setupLayout() {
-        view.addSubview(tableView)
-        
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
-        ])
+
+    // MARK: - Refreshing TableView
+    func addRefreshControl() {
+        let control = UIRefreshControl()
+        control.addTarget(self, action: #selector(onRefreshPulled), for: .valueChanged)
+        refreshControl = control
+        tableView.refreshControl = control
     }
-    
-    // Use to enable/disable the additional history action rows. `HistoryActionablesModel`
-    private func setTappableStateAndStyle(with item: AnyHashable, on cell: OneLineTableViewCell) {
-        var isEnabled: Bool = false
-        
-        if let actionableItem = item as? HistoryActionablesModel {
-            switch actionableItem.itemIdentity {
-            case .clearHistory:
-                viewModel.groupedSites.isEmpty ? (isEnabled = false) : (isEnabled = true)
-            case .recentlyClosed:
-                isEnabled = hasRecentlyClosed
-            default: break
+
+    func removeRefreshControl() {
+        tableView.refreshControl = nil
+        refreshControl = nil
+    }
+
+    func endRefreshing() {
+        // Always end refreshing, even if we failed!
+        refreshControl?.endRefreshing()
+
+        // Remove the refresh control if the user has logged out in the meantime
+        if !profile.hasSyncableAccount() {
+            removeRefreshControl()
+        }
+    }
+
+    // MARK: - Loading data
+    override func reloadData() {
+        // Can be called while app backgrounded and the db closed, don't try to reload the data source in this case
+        guard !profile.isShutdown, !isFetchInProgress else { return }
+
+        fetchData().uponQueue(.main) { result in
+            if let sites = result.successValue {
+                let fetchedSites = sites.asArray()
+                let allCurrentGroupedSites = self.groupedSites.allItems()
+                let allUniquedSitesToAdd = (allCurrentGroupedSites + fetchedSites).uniqued().filter {
+                    !allCurrentGroupedSites.contains($0)
+                }
+
+                allUniquedSitesToAdd.forEach { site in
+                    if let latestVisit = site.latestVisit {
+                        self.groupedSites.add(site, timestamp: TimeInterval.fromMicrosecondTimestamp(latestVisit.date))
+                    }
+                }
+
+                self.tableView.reloadData()
+                self.updateEmptyPanelState()
+
+                if let cell = self.clearHistoryCell {
+                    AdditionalHistoryActionRow.setStyle(enabled: !self.groupedSites.isEmpty, forCell: cell)
+                }
             }
         }
-        
-        // Set interaction behavior and style
-        if isEnabled {
-            cell.titleLabel.alpha = 1.0
-            cell.leftImageView.alpha = 1.0
-            cell.selectionStyle = .default
-            cell.isUserInteractionEnabled = true
-        } else {
-            cell.titleLabel.alpha = 0.5
-            cell.leftImageView.alpha = 0.5
-            cell.selectionStyle = .none
-            cell.isUserInteractionEnabled = false
-        }
-        
     }
-    
-    // MARK: - Datasource helpers
-    
-    func siteAt(indexPath: IndexPath) -> Site? {
-        guard let siteItem = diffableDatasource?.itemIdentifier(for: indexPath) as? Site else { return nil }
-        
-        return siteItem
+
+    func fetchData() -> Deferred<Maybe<Cursor<Site>>> {
+        guard !isFetchInProgress else {
+            return deferMaybe(FetchInProgressError())
+        }
+
+        isFetchInProgress = true
+
+        return profile.history.getSitesByLastVisit(limit: QueryLimitPerFetch, offset: currentFetchOffset) >>== { result in
+            // Force 100ms delay between resolution of the last batch of results
+            // and the next time `fetchData()` can be called.
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
+                self.currentFetchOffset += self.QueryLimitPerFetch
+                self.isFetchInProgress = false
+            }
+
+            return deferMaybe(result)
+        }
+    }
+
+    func resyncHistory() {
+        profile.syncManager.syncHistory().uponQueue(.main) { syncResult in
+            self.endRefreshing()
+
+            if syncResult.isSuccess {
+                self.reloadData()
+            }
+        }
+    }
+
+    // MARK: - Actions
+    func removeHistoryForURLAtIndexPath(indexPath: IndexPath) {
+        guard let site = siteForIndexPath(indexPath) else {
+            return
+        }
+
+        profile.history.removeHistoryForURL(site.url).uponQueue(.main) { result in
+            guard site == self.siteForIndexPath(indexPath) else {
+                self.reloadData()
+                return
+            }
+            self.tableView.beginUpdates()
+            self.groupedSites.remove(site)
+            self.tableView.deleteRows(at: [indexPath], with: .right)
+            self.tableView.endUpdates()
+            self.updateEmptyPanelState()
+
+            if let cell = self.clearHistoryCell {
+                AdditionalHistoryActionRow.setStyle(enabled: !self.groupedSites.isEmpty, forCell: cell)
+            }
+        }
+    }
+
+    func pinToTopSites(_ site: Site) {
+        profile.history.addPinnedTopSite(site).uponQueue(.main) { result in
+            if result.isSuccess {
+                SimpleToast().showAlertWithText(.AppMenu.AddPinToShortcutsConfirmMessage, bottomContainer: self.view)
+            }
+        }
+    }
+
+    func navigateToRecentlyClosed() {
+        guard hasRecentlyClosed else {
+            return
+        }
+
+        let nextController = RecentlyClosedTabsPanel(profile: profile)
+        nextController.title = .RecentlyClosedTabsPanelTitle
+        nextController.libraryPanelDelegate = libraryPanelDelegate
+        nextController.recentlyClosedTabsDelegate = BrowserViewController.foregroundBVC()
+        refreshControl?.endRefreshing()
+        navigationController?.pushViewController(nextController, animated: true)
     }
 
     private func showClearRecentHistory() {
-        clearHistoryHelper.showClearRecentHistory(onViewController: self, didComplete: { [weak self] date in
-            if let date = date {
-                self?.viewModel.removeVisibleSectionFor(date: date)
-            } else {
-                // The only time there's no date is when we are deleting everything.
-                self?.viewModel.visibleSections = []
-            }
-            
-            self?.viewModel.reloadData()
-            self?.applySnapshot(animatingDifferences: true)
-            
-            if let cell = self?.clearHistoryCell {
-                self?.setTappableStateAndStyle(
-                    with: HistoryActionablesModel.activeActionables.first(where: { $0.itemIdentity == .clearHistory }),
-                    on: cell)
-            }
+        clearHistoryHelper.showClearRecentHistory(onViewController: self, didComplete: { [weak self] _ in
+            self?.reloadData()
         })
-        
     }
 
-    func handleNotifications(_ notification: Notification) {
+    // MARK: - Cell configuration
+    func siteForIndexPath(_ indexPath: IndexPath) -> Site? {
+        // First section is reserved for recently closed.
+        guard indexPath.section > Section.additionalHistoryActions.rawValue else {
+            return nil
+        }
+
+        let sitesInSection = groupedSites.itemsForSection(indexPath.section - 1)
+        return sitesInSection[safe: indexPath.row]
+    }
+
+    func configureClearHistory(_ cell: OneLineTableViewCell, for indexPath: IndexPath) -> OneLineTableViewCell {
+        clearHistoryCell = cell
+        cell.titleLabel.text = HistoryPanelStrings.HistoryPanelClearHistoryButtonTitle
+        cell.leftImageView.image = UIImage.templateImageNamed("forget")
+        cell.leftImageView.tintColor = UIColor.theme.browser.tint
+        cell.leftImageView.backgroundColor = UIColor.theme.homePanel.historyHeaderIconsBackground
+        cell.accessibilityIdentifier = "HistoryPanel.clearHistory"
+
+        var isEmpty = true
+        for i in Section.today.rawValue..<tableView.numberOfSections {
+            if tableView.numberOfRows(inSection: i) > 0 {
+                isEmpty = false
+            }
+        }
+        AdditionalHistoryActionRow.setStyle(enabled: !isEmpty, forCell: cell)
+
+        return cell
+    }
+
+    func configureRecentlyClosed(_ cell: OneLineTableViewCell, for indexPath: IndexPath) -> OneLineTableViewCell {
+        cell.accessoryType = .disclosureIndicator
+        cell.titleLabel.text = HistoryPanelStrings.RecentlyClosedTabsButtonTitle
+        cell.leftImageView.image = UIImage.templateImageNamed("recently_closed")
+        cell.leftImageView.tintColor = UIColor.theme.browser.tint
+        cell.leftImageView.backgroundColor = UIColor.theme.homePanel.historyHeaderIconsBackground
+        AdditionalHistoryActionRow.setStyle(enabled: hasRecentlyClosed, forCell: cell)
+        cell.accessibilityIdentifier = "HistoryPanel.recentlyClosedCell"
+        return cell
+    }
+
+    func configureSite(_ cell: UITableViewCell, for indexPath: IndexPath) -> UITableViewCell {
+        if let site = siteForIndexPath(indexPath), let cell = cell as? TwoLineImageOverlayCell {
+            cell.titleLabel.text = site.title
+            cell.titleLabel.isHidden = site.title.isEmpty ? true : false
+            cell.descriptionLabel.isHidden = false
+            cell.descriptionLabel.text = site.url
+            cell.leftImageView.layer.borderColor = HistoryPanelUX.IconBorderColor.cgColor
+            cell.leftImageView.layer.borderWidth = HistoryPanelUX.IconBorderWidth
+            cell.leftImageView.contentMode = .center
+            cell.leftImageView.setImageAndBackground(forIcon: site.icon, website: site.tileURL) { [weak cell] in
+                cell?.leftImageView.image = cell?.leftImageView.image?.createScaled(CGSize(width: HistoryPanelUX.IconSize, height: HistoryPanelUX.IconSize))
+            }
+        }
+        return cell
+    }
+
+    // MARK: - Selector callbacks
+    func onNotificationReceived(_ notification: Notification) {
         switch notification.name {
         case .FirefoxAccountChanged, .PrivateDataClearedHistory:
-            viewModel.groupedSites = DateGroupedTableData<Site>()
-            
-            viewModel.reloadData()
-            applySnapshot(animatingDifferences: true)
+            groupedSites = DateGroupedTableData<Site>()
+            reloadData()
 
             if profile.hasSyncableAccount() {
                 resyncHistory()
             }
             break
         case .DynamicFontChanged:
+            reloadData()
+
             if emptyStateOverlayView.superview != nil {
                 emptyStateOverlayView.removeFromSuperview()
             }
@@ -213,192 +349,176 @@ class HistoryPanel: UIViewController, LibraryPanel, Loggable, NotificationThemea
             break
         case .DatabaseWasReopened:
             if let dbName = notification.object as? String, dbName == "browser.db" {
-                viewModel.reloadData()
-                applySnapshot(animatingDifferences: true)
+                reloadData()
             }
         case .OpenClearRecentHistory:
             showClearRecentHistory()
         default:
             // no need to do anything at all
-            browserLog.error("Error: Received unexpected notification \(notification.name)")
+            print("Error: Received unexpected notification \(notification.name)")
             break
         }
     }
 
+    func onLongPressGestureRecognized(_ longPressGestureRecognizer: UILongPressGestureRecognizer) {
+        guard longPressGestureRecognizer.state == .began else { return }
+        let touchPoint = longPressGestureRecognizer.location(in: tableView)
+        guard let indexPath = tableView.indexPathForRow(at: touchPoint) else { return }
+
+        if indexPath.section != Section.additionalHistoryActions.rawValue {
+            presentContextMenu(for: indexPath)
+        }
+    }
+
+    func onRefreshPulled() {
+        refreshControl?.beginRefreshing()
+        resyncHistory()
+    }
+
     // MARK: - UITableViewDataSource
-    
-    private func configureHistoryActionableCell(_ historyActionable: HistoryActionablesModel, _ cell: OneLineTableViewCell) -> OneLineTableViewCell {
-        cell.titleLabel.text = historyActionable.itemTitle
-        cell.leftImageView.image = historyActionable.itemImage
-        cell.leftImageView.tintColor = .theme.browser.tint
-        cell.leftImageView.backgroundColor = .theme.homePanel.historyHeaderIconsBackground
-        cell.accessibilityIdentifier = historyActionable.itemA11yId
-        self.setTappableStateAndStyle(with: historyActionable, on: cell)
-        
-        return cell
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return Section.count
     }
-    
-    private func configureSiteCell(_ site: Site, _ cell: TwoLineImageOverlayCell) -> TwoLineImageOverlayCell {
-        cell.titleLabel.text = site.title
-        cell.titleLabel.isHidden = site.title.isEmpty
-        cell.descriptionLabel.text = site.url
-        cell.descriptionLabel.isHidden = false
-        cell.leftImageView.layer.borderColor = HistoryPanelUX.IconBorderColor.cgColor
-        cell.leftImageView.layer.borderWidth = HistoryPanelUX.IconBorderWidth
-        cell.leftImageView.contentMode = .center
-        cell.leftImageView.setImageAndBackground(forIcon: site.icon, website: site.tileURL) { [weak cell] in
-            cell?.leftImageView.image = cell?.leftImageView.image?.createScaled(CGSize(width: HistoryPanelUX.IconSize, height: HistoryPanelUX.IconSize))
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        // First section is for recently closed and always has 1 row.
+        guard section > Section.additionalHistoryActions.rawValue else {
+            return 2
         }
-        
-        return cell
+
+        return groupedSites.numberOfItemsForSection(section - 1)
     }
-    
-    private func configureASGroupCell(_ asGroup: ASGroup<Site>, _ cell: TwoLineImageOverlayCell) -> TwoLineImageOverlayCell {
-        if let groupCount = asGroup.description {
-            cell.descriptionLabel.text = "\(groupCount) sites"
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        // First section is for recently closed and has no title.
+        guard section > Section.additionalHistoryActions.rawValue else {
+            return nil
         }
-        
-        cell.titleLabel.text = asGroup.displayTitle
-        cell.leftImageView.layer.borderWidth = 0
-        cell.leftImageView.contentMode = .center
-        cell.chevronAccessoryView.isHidden = false
-        cell.leftImageView.setImageAndBackground(forIcon: nil, website: nil) { [weak cell] in
-            cell?.leftImageView.image = cell?.leftImageView.image?.createScaled(CGSize(width: HistoryPanelUX.IconSize, height: HistoryPanelUX.IconSize))
-            cell?.leftImageView.image = UIImage(named: ImageIdentifiers.stackedTabsIcon)
+
+        // Ensure there are rows in this section.
+        guard groupedSites.numberOfItemsForSection(section - 1) > 0 else {
+            return nil
         }
-        
-        return cell
+
+        return Section(rawValue: section)?.title
     }
-    
-    /// Handles dequeuing the appropriate type of cell when needed.
-    private func configureDatasource() {
-        diffableDatasource = UITableViewDiffableDataSource<HistoryPanelSections, AnyHashable>(tableView: tableView) { [weak self] (tableView, indexPath, item) -> UITableViewCell? in
-            guard let self = self else {
-                Logger.browserLogger.error("History Panel - self became nil inside diffableDatasource!")
-                return nil
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = super.tableView(tableView, cellForRowAt: indexPath) as! TwoLineImageOverlayCell
+        cell.accessoryType = .none
+        // First section is reserved for recently closed.
+        guard indexPath.section > Section.additionalHistoryActions.rawValue else {
+            cell.leftImageView.layer.borderWidth = 0
+
+            guard let row = AdditionalHistoryActionRow(rawValue: indexPath.row) else {
+                assertionFailure("Bad row number")
+                return cell
             }
-            
-            if let historyActionable = item as? HistoryActionablesModel {
-                guard let cell = tableView.dequeueReusableCell(withIdentifier: OneLineTableViewCell.cellIdentifier, for: indexPath) as? OneLineTableViewCell else {
-                    self.browserLog.error("History Panel - cannot create OneLineTableViewCell for historyActionable!")
-                    return nil
-                }
-                
-                let actionableCell = self.configureHistoryActionableCell(historyActionable, cell)
-                return actionableCell
-            }
-            
-            if let site = item as? Site {
-                guard let cell = tableView.dequeueReusableCell(withIdentifier: TwoLineImageOverlayCell.cellIdentifier, for: indexPath) as? TwoLineImageOverlayCell else {
-                    self.browserLog.error("History Panel - cannot create TwoLineImageOverlayCell for site!")
-                    return nil
-                }
-                
-                let siteCell = self.configureSiteCell(site, cell)
-                return siteCell
-            }
-            
-            if let searchTermGroup = item as? ASGroup<Site> {
-                guard let cell = tableView.dequeueReusableCell(withIdentifier: TwoLineImageOverlayCell.accessoryUsageReuseIdentifier, for: indexPath) as? TwoLineImageOverlayCell else {
-                    self.browserLog.error("History Panel - cannot create TwoLineImageOverlayCell for STG!")
-                    return nil
-                }
-                
-                let asGroupCell = self.configureASGroupCell(searchTermGroup, cell)
-                return asGroupCell
-            }
-            
-            // This should never happen! You will have an empty row!
-            return UITableViewCell()
-        }
-        
-    }
-    
-    /// The data source gets populated here for your choice of section.
-    fileprivate func applySnapshot(animatingDifferences: Bool = false) {
-        var snapshot = NSDiffableDataSourceSnapshot<HistoryPanelSections, AnyHashable>()
-        
-        snapshot.appendSections(viewModel.visibleSections)
-        
-        snapshot.sectionIdentifiers.forEach { section in
-            snapshot.appendItems(viewModel.groupedSites.itemsForSection(section.rawValue - 1), toSection: section)
-        }
-        
-        // Insert the ASGroup at the correct spot!
-        viewModel.searchTermGroups.forEach { grouping in
-            if let groupSection = viewModel.groupBelongsToSection(asGroup: grouping), viewModel.visibleSections.contains(groupSection) {
-                guard let individualItem = grouping.groupedItems.last, let lastVisit = individualItem.latestVisit else { return }
-                
-                let groupTimeInterval = TimeInterval.fromMicrosecondTimestamp(lastVisit.date)
-                
-                if let groupPlacedAfterItem = (viewModel.groupedSites.itemsForSection(groupSection.rawValue - 1)).first(where : { site in
-                    guard let lastVisit = site.latestVisit else { return false }
-                    return groupTimeInterval > TimeInterval.fromMicrosecondTimestamp(lastVisit.date)
-                }) {
-                    // In this case, we have Site items AND a group in the section.
-                    snapshot.insertItems([grouping], beforeItem: groupPlacedAfterItem)
-                } else {
-                    // Looks like this group's the only item in the section
-                    snapshot.appendItems([grouping], toSection: groupSection)
-                }
+
+            let oneLineCell = tableView.dequeueReusableCell(withIdentifier: OneLineCellIdentifier, for: indexPath) as! OneLineTableViewCell
+            switch row {
+            case .clearRecent:
+                return configureClearHistory(oneLineCell, for: indexPath)
+            case .showRecentlyClosedTabs:
+                return configureRecentlyClosed(oneLineCell, for: indexPath)
             }
         }
-        
-        // Insert your fixed first section and data
-        if let historySection = snapshot.sectionIdentifiers.first, historySection != .additionalHistoryActions {
-            snapshot.insertSections([.additionalHistoryActions], beforeSection: historySection)
-        } else {
-            snapshot.appendSections([.additionalHistoryActions])
-        }
-        snapshot.appendItems(viewModel.historyActionables, toSection: .additionalHistoryActions)
-        
-        diffableDatasource?.apply(snapshot, animatingDifferences: animatingDifferences, completion: nil)
+
+        return configureSite(cell, for: indexPath)
     }
-    
-    // MARK: - Swipe Action helpers
-    
-    func removeHistoryItem(at indexPath: IndexPath) {
-        guard let historyItem = diffableDatasource?.itemIdentifier(for: indexPath) else { return }
-        
-        viewModel.removeHistoryItems(item: historyItem, at: indexPath.section)
-        
-        updateEmptyPanelState()
-        
-        if let historyActionableCell = clearHistoryCell {
-            setTappableStateAndStyle(with: HistoryActionablesModel.activeActionables.first, on: historyActionableCell)
+
+    // MARK: - UITableViewDelegate
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        // First section is reserved for recently closed.
+        defer {
+            tableView.deselectRow(at: indexPath, animated: true)
         }
-        
-        applySnapshot(animatingDifferences: true)
+        guard indexPath.section > Section.additionalHistoryActions.rawValue else {
+            switch indexPath.row {
+            case 0:
+                clearHistoryHelper.showClearRecentHistory(onViewController: self, didComplete: { [weak self] _ in
+                    self?.reloadData()
+                })
+                showClearRecentHistory()
+
+            default:
+                navigateToRecentlyClosed()
+            }
+            return
+        }
+
+        if let site = siteForIndexPath(indexPath), let url = URL(string: site.url) {
+            if let libraryPanelDelegate = libraryPanelDelegate {
+                libraryPanelDelegate.libraryPanel(didSelectURL: url, visitType: VisitType.typed)
+            }
+            return
+        }
+        print("Error: No site or no URL when selecting row.")
     }
-    
+
+    override func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        if let header = view as? UITableViewHeaderFooterView {
+            header.textLabel?.textColor = UIColor.theme.tableView.headerTextDark
+            header.contentView.backgroundColor = UIColor.theme.tableView.selectedBackground
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        // First section is for recently closed and its header has no view.
+        guard section > Section.additionalHistoryActions.rawValue else {
+            return nil
+        }
+
+        // Ensure there are rows in this section.
+        guard groupedSites.numberOfItemsForSection(section - 1) > 0 else {
+            return nil
+        }
+
+        return super.tableView(tableView, viewForHeaderInSection: section)
+    }
+
+    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        // First section is for recently closed and its header has no height.
+        guard section > Section.additionalHistoryActions.rawValue else {
+            return 0
+        }
+
+        // Ensure there are rows in this section.
+        guard groupedSites.numberOfItemsForSection(section - 1) > 0 else {
+            return 0
+        }
+
+        return super.tableView(tableView, heightForHeaderInSection: section)
+    }
+
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        
-        // For UX consistency, every cell in history panel SHOULD have a trailing action.
-        let deleteAction = UIContextualAction(style: .destructive, title: .HistoryPanelDelete) { [weak self] (_, _, completion) in
-            guard let self = self else {
-                Logger.browserLogger.error("History Panel - self became nil inside SwipeActionConfiguration!")
-                completion(false)
-                return
-            }
-            
-            self.removeHistoryItem(at: indexPath)
+        guard indexPath.section != Section.additionalHistoryActions.rawValue else {
+            return nil
         }
-        
+
+        let deleteAction = UIContextualAction(style: .destructive, title: .HistoryPanelDelete) { [weak self] (_, _, completion) in
+            guard let strongSelf = self else { completion(false); return }
+
+            strongSelf.removeHistoryForURLAtIndexPath(indexPath: indexPath)
+            completion(true)
+        }
+
         return UISwipeActionsConfiguration(actions: [deleteAction])
     }
 
-    // MARK: - Empty State helpers
-    
-    private func updateEmptyPanelState() {
-        if viewModel.groupedSites.isEmpty, emptyStateOverlayView.superview == nil {
-            tableView.tableFooterView = emptyStateOverlayView
+    // MARK: - Empty State
+    func updateEmptyPanelState() {
+        if groupedSites.isEmpty {
+            if emptyStateOverlayView.superview == nil {
+                tableView.tableFooterView = emptyStateOverlayView
+            }
         } else {
             tableView.alwaysBounceVertical = true
             tableView.tableFooterView = nil
         }
     }
 
-    private func createEmptyStateOverlayView() -> UIView {
+    func createEmptyStateOverlayView() -> UIView {
         let overlayView = UIView()
 
         // overlayView becomes the footer view, and for unknown reason, setting the bgcolor is ignored.
@@ -432,213 +552,53 @@ class HistoryPanel: UIViewController, LibraryPanel, Loggable, NotificationThemea
         return overlayView
     }
 
-    // MARK: - Themeable
-    
-    func applyTheme() {
+    override func applyTheme() {
         emptyStateOverlayView.removeFromSuperview()
         emptyStateOverlayView = createEmptyStateOverlayView()
         updateEmptyPanelState()
-        
-        tableView.backgroundColor = UIColor.theme.homePanel.panelBackground
-        tableView.separatorColor = UIColor.theme.tableView.separator
-        
-        tableView.reloadData()
-    }
-    
-}
 
-// MARK: - UITableViewDelegate related helpers
-
-extension HistoryPanel: UITableViewDelegate {
-    
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
-        
-        guard let item = diffableDatasource?.itemIdentifier(for: indexPath) else { return }
-        
-        if let site = item as? Site {
-            handleSiteItemTapped(site: site)
-        }
-        
-        if let historyActionable = item as? HistoryActionablesModel {
-            handleHistoryActionableTapped(historyActionable: historyActionable)
-        }
-        
-        if let asGroupItem = item as? ASGroup<Site> {
-            handleASGroupItemTapped(asGroupItem: asGroupItem)
-        }
+        super.applyTheme()
     }
-    
-    private func handleSiteItemTapped(site: Site) {
-        guard let url = URL(string: site.url) else {
-            browserLog.error("Couldn't navigate to site: \(site.url)")
-            return
-        }
-        
-        libraryPanelDelegate?.libraryPanel(didSelectURL: url, visitType: .typed)
-        
-        TelemetryWrapper.recordEvent(category: .action,
-                                     method: .tap,
-                                     object: .selectedHistoryItem,
-                                     value: .historyPanelNonGroupItem,
-                                     extras: nil)
-    }
-    
-    private func handleHistoryActionableTapped(historyActionable: HistoryActionablesModel) {
-        switch historyActionable.itemIdentity {
-        case .clearHistory:
-            showClearRecentHistory()
-        case .recentlyClosed:
-            navigateToRecentlyClosed()
-        default: break
-        }
-    }
-    
-    private func handleASGroupItemTapped(asGroupItem: ASGroup<Site>) {
-        let asGroupListViewModel = GroupedHistoryItemsViewModel(asGroup: asGroupItem)
-        let asGroupListVC = GroupedHistoryItemsViewController(profile: profile, viewModel: asGroupListViewModel)
-        asGroupListVC.libraryPanelDelegate = libraryPanelDelegate
-        asGroupListVC.title = asGroupItem.displayTitle
-        
-        navigationController?.pushViewController(asGroupListVC, animated: true)
-    }
-    
-}
-
-/// Refresh controls helpers
-extension HistoryPanel {
-    private func handleRefreshControl() {
-        if profile.hasSyncableAccount() && refreshControl == nil {
-            let control = UIRefreshControl()
-            control.addTarget(self, action: #selector(onRefreshPulled), for: .valueChanged)
-            refreshControl = control
-            tableView.refreshControl = control
-        } else if !profile.hasSyncableAccount() && refreshControl != nil {
-            tableView.refreshControl = nil
-            refreshControl = nil
-        }
-    }
-
-    private func endRefreshing() {
-        // Always end refreshing, even if we failed!
-        refreshControl?.endRefreshing()
-
-        // Remove the refresh control if the user has logged out in the meantime
-        handleRefreshControl()
-    }
-    
-    private func resyncHistory() {
-        profile.syncManager.syncHistory().uponQueue(.main) { syncResult in
-            self.endRefreshing()
-
-            if syncResult.isSuccess {
-                self.viewModel.reloadData()
-                self.applySnapshot(animatingDifferences: true)
-            }
-            
-        }
-        
-    }
-    
-}
-
-/// User actions helpers
-extension HistoryPanel {
-    // MARK: - User Interactions
-    
-    /// When long pressed, a menu appears giving the choice of pinning as a Top Site.
-    func pinToTopSites(_ site: Site) {
-        profile.history.addPinnedTopSite(site).uponQueue(.main) { result in
-            if result.isSuccess {
-                SimpleToast().showAlertWithText(.AppMenu.AddPinToShortcutsConfirmMessage, bottomContainer: self.view)
-            }
-        }
-    }
-
-    private func navigateToRecentlyClosed() {
-        guard hasRecentlyClosed else { return }
-
-        let nextController = RecentlyClosedTabsPanel(profile: profile)
-        nextController.title = .RecentlyClosedTabsPanelTitle
-        nextController.libraryPanelDelegate = libraryPanelDelegate
-        nextController.recentlyClosedTabsDelegate = BrowserViewController.foregroundBVC()
-        refreshControl?.endRefreshing()
-        navigationController?.pushViewController(nextController, animated: true)
-    }
-    
-    @objc private func onLongPressGestureRecognized(_ longPressGestureRecognizer: UILongPressGestureRecognizer) {
-        guard longPressGestureRecognizer.state == .began else { return }
-        let touchPoint = longPressGestureRecognizer.location(in: tableView)
-        guard let indexPath = tableView.indexPathForRow(at: touchPoint) else { return }
-        
-        if indexPath.section != HistoryPanelSections.additionalHistoryActions.rawValue {
-            presentContextMenu(for: indexPath)
-        }
-    }
-
-    @objc private func onRefreshPulled() {
-        refreshControl?.beginRefreshing()
-        resyncHistory()
-    }
-    
-}
-
-// MARK: - TableView's Header & Footer view helpers
-extension HistoryPanel {
-        
-    func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
-        if let header = view as? SiteTableViewHeader, let actualSection = viewModel.visibleSections[safe: section - 1] {
-            
-            header.textLabel?.textColor = UIColor.theme.tableView.headerTextDark
-            header.contentView.backgroundColor = UIColor.theme.tableView.selectedBackground
-            header.textLabel?.text = actualSection.title // At worst, we have a header with no text.
-            
-            let historySectionsWithGroups = viewModel.searchTermGroups.map { group in
-                viewModel.groupBelongsToSection(asGroup: group)
-            }
-            
-            // NOTE: Uncomment this when we support showing the Show all button and its functionality in a later time.
-            // let visibleSectionsWithGroups = viewModel.visibleSections.filter { historySectionsWithGroups.contains($0) }
-            // header.headerActionButton.isHidden = !visibleSectionsWithGroups.contains(actualSection)
-        }
-        
-    }
-
-    // viewForHeaderInSection REQUIRES implementing heightForHeaderInSection
-    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        // First section is for recently closed and its header has no view.
-        guard HistoryPanelSections(rawValue: section) != .additionalHistoryActions else {
-            return nil
-        }
-
-        return tableView.dequeueReusableHeaderFooterView(withIdentifier: SiteTableViewHeader.cellIdentifier)
-    }
-
-    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        // First section is for recently closed and its header has no height.
-        guard HistoryPanelSections(rawValue: section) != .additionalHistoryActions else {
-            return 0
-        }
-
-        return HistoryPanelUX.HeaderHeight
-    }
-    
 }
 
 extension HistoryPanel: UITableViewDataSourcePrefetching {
-    
-    // Happens WAY too often. We should consider fetching the next set when the user HITS the bottom instead.
     func tableView(_ tableView: UITableView, prefetchRowsAt indexPaths: [IndexPath]) {
-        guard !viewModel.isFetchInProgress, indexPaths.contains(where: shouldLoadRow) else { return }
+        guard !isFetchInProgress, indexPaths.contains(where: shouldLoadRow) else { return }
 
-        viewModel.reloadData()
-        applySnapshot(animatingDifferences: false)
+        reloadData()
     }
 
     func shouldLoadRow(for indexPath: IndexPath) -> Bool {
-        guard HistoryPanelSections(rawValue: indexPath.section) != .additionalHistoryActions else { return false }
+        guard indexPath.section > Section.additionalHistoryActions.rawValue else {
+            return false
+        }
 
-        return indexPath.row >= viewModel.groupedSites.numberOfItemsForSection(indexPath.section - 1) - historyPanelPrefetchOffset
+        return indexPath.row >= groupedSites.numberOfItemsForSection(indexPath.section - 1) - 1
     }
-    
+}
+
+extension HistoryPanel: LibraryPanelContextMenu {
+    func presentContextMenu(for site: Site, with indexPath: IndexPath, completionHandler: @escaping () -> PhotonActionSheet?) {
+        guard let contextMenu = completionHandler() else { return }
+        present(contextMenu, animated: true, completion: nil)
+    }
+
+    func getSiteDetails(for indexPath: IndexPath) -> Site? {
+        return siteForIndexPath(indexPath)
+    }
+
+    func getContextMenuActions(for site: Site, with indexPath: IndexPath) -> [PhotonRowActions]? {
+        guard var actions = getDefaultContextMenuActions(for: site, libraryPanelDelegate: libraryPanelDelegate) else { return nil }
+
+        let removeAction = SingleActionViewModel(title: .DeleteFromHistoryContextMenuTitle, iconString: "action_delete", tapHandler: { _ in
+            self.removeHistoryForURLAtIndexPath(indexPath: indexPath)
+        })
+
+        let pinTopSite = SingleActionViewModel(title: .AddToShortcutsActionTitle, iconString: ImageIdentifiers.addShortcut, tapHandler: { _ in
+            self.pinToTopSites(site)
+        })
+        actions.append(PhotonRowActions(pinTopSite))
+        actions.append(PhotonRowActions(removeAction))
+        return actions
+    }
 }

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelV2.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelV2.swift
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
+// TODO: HistoryPanel AND HistoryPanelV2 currently coexist until v100. Revert https://github.com/mozilla-mobile/firefox-ios/pull/10259 in v100.
+// Related to: https://mozilla-hub.atlassian.net/browse/FXIOS-2931 
+
 import UIKit
 import Shared
 import Storage

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelV2.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelV2.swift
@@ -1,0 +1,644 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0
+
+import UIKit
+import Shared
+import Storage
+import XCGLogger
+import WebKit
+import os.log
+
+private struct HistoryPanelUX {
+    static let WelcomeScreenItemWidth = 170
+    static let HeaderHeight = CGFloat(32)
+    static let IconSize = 23
+    static let IconBorderColor = UIColor.Photon.Grey30
+    static let IconBorderWidth: CGFloat = 0.5
+    static let actionIconColor = UIColor.Photon.Grey40 // Works for light and dark theme.
+}
+
+private class FetchInProgressError: MaybeErrorType {
+    internal var description: String {
+        return "Fetch is already in-progress"
+    }
+}
+
+@objcMembers
+class HistoryPanelV2: UIViewController, LibraryPanel, Loggable, NotificationThemeable {
+    
+    // MARK: - Properties
+    
+    typealias HistoryPanelSections = HistoryPanelViewModel.Sections
+    typealias a11yIds = AccessibilityIdentifiers.LibraryPanels.HistoryPanel
+    
+    var libraryPanelDelegate: LibraryPanelDelegate?
+    var recentlyClosedTabsDelegate: RecentlyClosedPanelDelegate?
+    
+    let profile: Profile
+    let viewModel: HistoryPanelViewModel
+    private let clearHistoryHelper: ClearHistoryHelper
+    
+    // We'll be able to prefetch more often the higher this number is. But remember, it's expensive!
+    private let historyPanelPrefetchOffset = 8
+
+    private var diffableDatasource: UITableViewDiffableDataSource<HistoryPanelSections, AnyHashable>?
+    private var hasRecentlyClosed: Bool { profile.recentlyClosedTabs.tabs.count > 0 }
+    
+    // UI
+    lazy private var tableView: UITableView = .build { [weak self] tableView in
+        guard let self = self else { return }
+        tableView.dataSource = self.diffableDatasource
+        tableView.addGestureRecognizer(self.longPressRecognizer)
+        tableView.accessibilityIdentifier = a11yIds.tableView
+        tableView.prefetchDataSource = self
+        tableView.delegate = self
+        tableView.register(TwoLineImageOverlayCell.self, forCellReuseIdentifier: TwoLineImageOverlayCell.cellIdentifier)
+        tableView.register(TwoLineImageOverlayCell.self, forCellReuseIdentifier: TwoLineImageOverlayCell.accessoryUsageReuseIdentifier)
+        tableView.register(OneLineTableViewCell.self, forCellReuseIdentifier: OneLineTableViewCell.cellIdentifier)
+        tableView.register(SiteTableViewHeader.self, forHeaderFooterViewReuseIdentifier: SiteTableViewHeader.cellIdentifier)
+        
+        if #available(iOS 15.0, *) {
+            tableView.sectionHeaderTopPadding = 0
+        }
+    }
+    
+    lazy var longPressRecognizer: UILongPressGestureRecognizer = {
+        UILongPressGestureRecognizer(target: self, action: #selector(onLongPressGestureRecognized))
+    }()
+    
+    lazy var emptyStateOverlayView: UIView = createEmptyStateOverlayView()
+    var refreshControl: UIRefreshControl?
+    var clearHistoryCell: OneLineTableViewCell?
+    
+    // MARK: - Inits
+    
+    init(profile: Profile, tabManager: TabManager) {
+        self.clearHistoryHelper = ClearHistoryHelper(profile: profile, tabManager: tabManager)
+        self.viewModel = HistoryPanelViewModel(profile: profile)
+        self.profile = profile
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    deinit {
+        browserLog.debug("HistoryPanel Deinitialized.")
+    }
+
+    // MARK: - Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        viewModel.viewDidLoad()
+        viewModel.historyPanelNotifications.forEach {
+            NotificationCenter.default.addObserver(self, selector: #selector(handleNotifications), name: $0, object: nil)
+        }
+        
+        setupLayout()
+        configureDatasource()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        // Add a refresh control if the user is logged in and the control was not added before. If the user is not
+        // logged in, remove any existing control.
+        handleRefreshControl()
+        applySnapshot()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        // Since the reload operation to fetch STG completes LATE, we need to apply snapshot again here :(
+        // Especially in the case where you navigate to the history panel from another panel.
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
+            self.applySnapshot(animatingDifferences: true)
+        }
+        
+    }
+    
+    // MARK: - Misc. helpers
+    
+    private func setupLayout() {
+        view.addSubview(tableView)
+        
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
+        ])
+    }
+    
+    // Use to enable/disable the additional history action rows. `HistoryActionablesModel`
+    private func setTappableStateAndStyle(with item: AnyHashable, on cell: OneLineTableViewCell) {
+        var isEnabled: Bool = false
+        
+        if let actionableItem = item as? HistoryActionablesModel {
+            switch actionableItem.itemIdentity {
+            case .clearHistory:
+                viewModel.groupedSites.isEmpty ? (isEnabled = false) : (isEnabled = true)
+            case .recentlyClosed:
+                isEnabled = hasRecentlyClosed
+            default: break
+            }
+        }
+        
+        // Set interaction behavior and style
+        if isEnabled {
+            cell.titleLabel.alpha = 1.0
+            cell.leftImageView.alpha = 1.0
+            cell.selectionStyle = .default
+            cell.isUserInteractionEnabled = true
+        } else {
+            cell.titleLabel.alpha = 0.5
+            cell.leftImageView.alpha = 0.5
+            cell.selectionStyle = .none
+            cell.isUserInteractionEnabled = false
+        }
+        
+    }
+    
+    // MARK: - Datasource helpers
+    
+    func siteAt(indexPath: IndexPath) -> Site? {
+        guard let siteItem = diffableDatasource?.itemIdentifier(for: indexPath) as? Site else { return nil }
+        
+        return siteItem
+    }
+
+    private func showClearRecentHistory() {
+        clearHistoryHelper.showClearRecentHistory(onViewController: self, didComplete: { [weak self] date in
+            if let date = date {
+                self?.viewModel.removeVisibleSectionFor(date: date)
+            } else {
+                // The only time there's no date is when we are deleting everything.
+                self?.viewModel.visibleSections = []
+            }
+            
+            self?.viewModel.reloadData()
+            self?.applySnapshot(animatingDifferences: true)
+            
+            if let cell = self?.clearHistoryCell {
+                self?.setTappableStateAndStyle(
+                    with: HistoryActionablesModel.activeActionables.first(where: { $0.itemIdentity == .clearHistory }),
+                    on: cell)
+            }
+        })
+        
+    }
+
+    func handleNotifications(_ notification: Notification) {
+        switch notification.name {
+        case .FirefoxAccountChanged, .PrivateDataClearedHistory:
+            viewModel.groupedSites = DateGroupedTableData<Site>()
+            
+            viewModel.reloadData()
+            applySnapshot(animatingDifferences: true)
+
+            if profile.hasSyncableAccount() {
+                resyncHistory()
+            }
+            break
+        case .DynamicFontChanged:
+            if emptyStateOverlayView.superview != nil {
+                emptyStateOverlayView.removeFromSuperview()
+            }
+            emptyStateOverlayView = createEmptyStateOverlayView()
+            resyncHistory()
+            break
+        case .DatabaseWasReopened:
+            if let dbName = notification.object as? String, dbName == "browser.db" {
+                viewModel.reloadData()
+                applySnapshot(animatingDifferences: true)
+            }
+        case .OpenClearRecentHistory:
+            showClearRecentHistory()
+        default:
+            // no need to do anything at all
+            browserLog.error("Error: Received unexpected notification \(notification.name)")
+            break
+        }
+    }
+
+    // MARK: - UITableViewDataSource
+    
+    private func configureHistoryActionableCell(_ historyActionable: HistoryActionablesModel, _ cell: OneLineTableViewCell) -> OneLineTableViewCell {
+        cell.titleLabel.text = historyActionable.itemTitle
+        cell.leftImageView.image = historyActionable.itemImage
+        cell.leftImageView.tintColor = .theme.browser.tint
+        cell.leftImageView.backgroundColor = .theme.homePanel.historyHeaderIconsBackground
+        cell.accessibilityIdentifier = historyActionable.itemA11yId
+        self.setTappableStateAndStyle(with: historyActionable, on: cell)
+        
+        return cell
+    }
+    
+    private func configureSiteCell(_ site: Site, _ cell: TwoLineImageOverlayCell) -> TwoLineImageOverlayCell {
+        cell.titleLabel.text = site.title
+        cell.titleLabel.isHidden = site.title.isEmpty
+        cell.descriptionLabel.text = site.url
+        cell.descriptionLabel.isHidden = false
+        cell.leftImageView.layer.borderColor = HistoryPanelUX.IconBorderColor.cgColor
+        cell.leftImageView.layer.borderWidth = HistoryPanelUX.IconBorderWidth
+        cell.leftImageView.contentMode = .center
+        cell.leftImageView.setImageAndBackground(forIcon: site.icon, website: site.tileURL) { [weak cell] in
+            cell?.leftImageView.image = cell?.leftImageView.image?.createScaled(CGSize(width: HistoryPanelUX.IconSize, height: HistoryPanelUX.IconSize))
+        }
+        
+        return cell
+    }
+    
+    private func configureASGroupCell(_ asGroup: ASGroup<Site>, _ cell: TwoLineImageOverlayCell) -> TwoLineImageOverlayCell {
+        if let groupCount = asGroup.description {
+            cell.descriptionLabel.text = "\(groupCount) sites"
+        }
+        
+        cell.titleLabel.text = asGroup.displayTitle
+        cell.leftImageView.layer.borderWidth = 0
+        cell.leftImageView.contentMode = .center
+        cell.chevronAccessoryView.isHidden = false
+        cell.leftImageView.setImageAndBackground(forIcon: nil, website: nil) { [weak cell] in
+            cell?.leftImageView.image = cell?.leftImageView.image?.createScaled(CGSize(width: HistoryPanelUX.IconSize, height: HistoryPanelUX.IconSize))
+            cell?.leftImageView.image = UIImage(named: ImageIdentifiers.stackedTabsIcon)
+        }
+        
+        return cell
+    }
+    
+    /// Handles dequeuing the appropriate type of cell when needed.
+    private func configureDatasource() {
+        diffableDatasource = UITableViewDiffableDataSource<HistoryPanelSections, AnyHashable>(tableView: tableView) { [weak self] (tableView, indexPath, item) -> UITableViewCell? in
+            guard let self = self else {
+                Logger.browserLogger.error("History Panel - self became nil inside diffableDatasource!")
+                return nil
+            }
+            
+            if let historyActionable = item as? HistoryActionablesModel {
+                guard let cell = tableView.dequeueReusableCell(withIdentifier: OneLineTableViewCell.cellIdentifier, for: indexPath) as? OneLineTableViewCell else {
+                    self.browserLog.error("History Panel - cannot create OneLineTableViewCell for historyActionable!")
+                    return nil
+                }
+                
+                let actionableCell = self.configureHistoryActionableCell(historyActionable, cell)
+                return actionableCell
+            }
+            
+            if let site = item as? Site {
+                guard let cell = tableView.dequeueReusableCell(withIdentifier: TwoLineImageOverlayCell.cellIdentifier, for: indexPath) as? TwoLineImageOverlayCell else {
+                    self.browserLog.error("History Panel - cannot create TwoLineImageOverlayCell for site!")
+                    return nil
+                }
+                
+                let siteCell = self.configureSiteCell(site, cell)
+                return siteCell
+            }
+            
+            if let searchTermGroup = item as? ASGroup<Site> {
+                guard let cell = tableView.dequeueReusableCell(withIdentifier: TwoLineImageOverlayCell.accessoryUsageReuseIdentifier, for: indexPath) as? TwoLineImageOverlayCell else {
+                    self.browserLog.error("History Panel - cannot create TwoLineImageOverlayCell for STG!")
+                    return nil
+                }
+                
+                let asGroupCell = self.configureASGroupCell(searchTermGroup, cell)
+                return asGroupCell
+            }
+            
+            // This should never happen! You will have an empty row!
+            return UITableViewCell()
+        }
+        
+    }
+    
+    /// The data source gets populated here for your choice of section.
+    fileprivate func applySnapshot(animatingDifferences: Bool = false) {
+        var snapshot = NSDiffableDataSourceSnapshot<HistoryPanelSections, AnyHashable>()
+        
+        snapshot.appendSections(viewModel.visibleSections)
+        
+        snapshot.sectionIdentifiers.forEach { section in
+            snapshot.appendItems(viewModel.groupedSites.itemsForSection(section.rawValue - 1), toSection: section)
+        }
+        
+        // Insert the ASGroup at the correct spot!
+        viewModel.searchTermGroups.forEach { grouping in
+            if let groupSection = viewModel.groupBelongsToSection(asGroup: grouping), viewModel.visibleSections.contains(groupSection) {
+                guard let individualItem = grouping.groupedItems.last, let lastVisit = individualItem.latestVisit else { return }
+                
+                let groupTimeInterval = TimeInterval.fromMicrosecondTimestamp(lastVisit.date)
+                
+                if let groupPlacedAfterItem = (viewModel.groupedSites.itemsForSection(groupSection.rawValue - 1)).first(where : { site in
+                    guard let lastVisit = site.latestVisit else { return false }
+                    return groupTimeInterval > TimeInterval.fromMicrosecondTimestamp(lastVisit.date)
+                }) {
+                    // In this case, we have Site items AND a group in the section.
+                    snapshot.insertItems([grouping], beforeItem: groupPlacedAfterItem)
+                } else {
+                    // Looks like this group's the only item in the section
+                    snapshot.appendItems([grouping], toSection: groupSection)
+                }
+            }
+        }
+        
+        // Insert your fixed first section and data
+        if let historySection = snapshot.sectionIdentifiers.first, historySection != .additionalHistoryActions {
+            snapshot.insertSections([.additionalHistoryActions], beforeSection: historySection)
+        } else {
+            snapshot.appendSections([.additionalHistoryActions])
+        }
+        snapshot.appendItems(viewModel.historyActionables, toSection: .additionalHistoryActions)
+        
+        diffableDatasource?.apply(snapshot, animatingDifferences: animatingDifferences, completion: nil)
+    }
+    
+    // MARK: - Swipe Action helpers
+    
+    func removeHistoryItem(at indexPath: IndexPath) {
+        guard let historyItem = diffableDatasource?.itemIdentifier(for: indexPath) else { return }
+        
+        viewModel.removeHistoryItems(item: historyItem, at: indexPath.section)
+        
+        updateEmptyPanelState()
+        
+        if let historyActionableCell = clearHistoryCell {
+            setTappableStateAndStyle(with: HistoryActionablesModel.activeActionables.first, on: historyActionableCell)
+        }
+        
+        applySnapshot(animatingDifferences: true)
+    }
+    
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        
+        // For UX consistency, every cell in history panel SHOULD have a trailing action.
+        let deleteAction = UIContextualAction(style: .destructive, title: .HistoryPanelDelete) { [weak self] (_, _, completion) in
+            guard let self = self else {
+                Logger.browserLogger.error("History Panel - self became nil inside SwipeActionConfiguration!")
+                completion(false)
+                return
+            }
+            
+            self.removeHistoryItem(at: indexPath)
+        }
+        
+        return UISwipeActionsConfiguration(actions: [deleteAction])
+    }
+
+    // MARK: - Empty State helpers
+    
+    private func updateEmptyPanelState() {
+        if viewModel.groupedSites.isEmpty, emptyStateOverlayView.superview == nil {
+            tableView.tableFooterView = emptyStateOverlayView
+        } else {
+            tableView.alwaysBounceVertical = true
+            tableView.tableFooterView = nil
+        }
+    }
+
+    private func createEmptyStateOverlayView() -> UIView {
+        let overlayView = UIView()
+
+        // overlayView becomes the footer view, and for unknown reason, setting the bgcolor is ignored.
+        // Create an explicit view for setting the color.
+        let bgColor = UIView()
+        bgColor.backgroundColor = UIColor.theme.homePanel.panelBackground
+        overlayView.addSubview(bgColor)
+        bgColor.snp.makeConstraints { make in
+            // Height behaves oddly: equalToSuperview fails in this case, as does setting top.equalToSuperview(), simply setting this to ample height works.
+            make.height.equalTo(UIScreen.main.bounds.height)
+            make.width.equalToSuperview()
+        }
+
+        let welcomeLabel = UILabel()
+        overlayView.addSubview(welcomeLabel)
+        welcomeLabel.text = .HistoryPanelEmptyStateTitle
+        welcomeLabel.textAlignment = .center
+        welcomeLabel.font = DynamicFontHelper.defaultHelper.DeviceFontLight
+        welcomeLabel.textColor = UIColor.theme.homePanel.welcomeScreenText
+        welcomeLabel.numberOfLines = 0
+        welcomeLabel.adjustsFontSizeToFitWidth = true
+
+        welcomeLabel.snp.makeConstraints { make in
+            make.centerX.equalTo(overlayView)
+            // Sets proper top constraint for iPhone 6 in portait and for iPad.
+            make.centerY.equalTo(overlayView).offset(LibraryPanelUX.EmptyTabContentOffset).priority(100)
+            // Sets proper top constraint for iPhone 4, 5 in portrait.
+            make.top.greaterThanOrEqualTo(overlayView).offset(50)
+            make.width.equalTo(HistoryPanelUX.WelcomeScreenItemWidth)
+        }
+        return overlayView
+    }
+
+    // MARK: - Themeable
+    
+    func applyTheme() {
+        emptyStateOverlayView.removeFromSuperview()
+        emptyStateOverlayView = createEmptyStateOverlayView()
+        updateEmptyPanelState()
+        
+        tableView.backgroundColor = UIColor.theme.homePanel.panelBackground
+        tableView.separatorColor = UIColor.theme.tableView.separator
+        
+        tableView.reloadData()
+    }
+    
+}
+
+// MARK: - UITableViewDelegate related helpers
+
+extension HistoryPanelV2: UITableViewDelegate {
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        
+        guard let item = diffableDatasource?.itemIdentifier(for: indexPath) else { return }
+        
+        if let site = item as? Site {
+            handleSiteItemTapped(site: site)
+        }
+        
+        if let historyActionable = item as? HistoryActionablesModel {
+            handleHistoryActionableTapped(historyActionable: historyActionable)
+        }
+        
+        if let asGroupItem = item as? ASGroup<Site> {
+            handleASGroupItemTapped(asGroupItem: asGroupItem)
+        }
+    }
+    
+    private func handleSiteItemTapped(site: Site) {
+        guard let url = URL(string: site.url) else {
+            browserLog.error("Couldn't navigate to site: \(site.url)")
+            return
+        }
+        
+        libraryPanelDelegate?.libraryPanel(didSelectURL: url, visitType: .typed)
+        
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .tap,
+                                     object: .selectedHistoryItem,
+                                     value: .historyPanelNonGroupItem,
+                                     extras: nil)
+    }
+    
+    private func handleHistoryActionableTapped(historyActionable: HistoryActionablesModel) {
+        switch historyActionable.itemIdentity {
+        case .clearHistory:
+            showClearRecentHistory()
+        case .recentlyClosed:
+            navigateToRecentlyClosed()
+        default: break
+        }
+    }
+    
+    private func handleASGroupItemTapped(asGroupItem: ASGroup<Site>) {
+        let asGroupListViewModel = GroupedHistoryItemsViewModel(asGroup: asGroupItem)
+        let asGroupListVC = GroupedHistoryItemsViewController(profile: profile, viewModel: asGroupListViewModel)
+        asGroupListVC.libraryPanelDelegate = libraryPanelDelegate
+        asGroupListVC.title = asGroupItem.displayTitle
+        
+        navigationController?.pushViewController(asGroupListVC, animated: true)
+    }
+    
+}
+
+/// Refresh controls helpers
+extension HistoryPanelV2 {
+    private func handleRefreshControl() {
+        if profile.hasSyncableAccount() && refreshControl == nil {
+            let control = UIRefreshControl()
+            control.addTarget(self, action: #selector(onRefreshPulled), for: .valueChanged)
+            refreshControl = control
+            tableView.refreshControl = control
+        } else if !profile.hasSyncableAccount() && refreshControl != nil {
+            tableView.refreshControl = nil
+            refreshControl = nil
+        }
+    }
+
+    private func endRefreshing() {
+        // Always end refreshing, even if we failed!
+        refreshControl?.endRefreshing()
+
+        // Remove the refresh control if the user has logged out in the meantime
+        handleRefreshControl()
+    }
+    
+    private func resyncHistory() {
+        profile.syncManager.syncHistory().uponQueue(.main) { syncResult in
+            self.endRefreshing()
+
+            if syncResult.isSuccess {
+                self.viewModel.reloadData()
+                self.applySnapshot(animatingDifferences: true)
+            }
+            
+        }
+        
+    }
+    
+}
+
+/// User actions helpers
+extension HistoryPanelV2 {
+    // MARK: - User Interactions
+    
+    /// When long pressed, a menu appears giving the choice of pinning as a Top Site.
+    func pinToTopSites(_ site: Site) {
+        profile.history.addPinnedTopSite(site).uponQueue(.main) { result in
+            if result.isSuccess {
+                SimpleToast().showAlertWithText(.AppMenu.AddPinToShortcutsConfirmMessage, bottomContainer: self.view)
+            }
+        }
+    }
+
+    private func navigateToRecentlyClosed() {
+        guard hasRecentlyClosed else { return }
+
+        let nextController = RecentlyClosedTabsPanel(profile: profile)
+        nextController.title = .RecentlyClosedTabsPanelTitle
+        nextController.libraryPanelDelegate = libraryPanelDelegate
+        nextController.recentlyClosedTabsDelegate = BrowserViewController.foregroundBVC()
+        refreshControl?.endRefreshing()
+        navigationController?.pushViewController(nextController, animated: true)
+    }
+    
+    @objc private func onLongPressGestureRecognized(_ longPressGestureRecognizer: UILongPressGestureRecognizer) {
+        guard longPressGestureRecognizer.state == .began else { return }
+        let touchPoint = longPressGestureRecognizer.location(in: tableView)
+        guard let indexPath = tableView.indexPathForRow(at: touchPoint) else { return }
+        
+        if indexPath.section != HistoryPanelSections.additionalHistoryActions.rawValue {
+            presentContextMenu(for: indexPath)
+        }
+    }
+
+    @objc private func onRefreshPulled() {
+        refreshControl?.beginRefreshing()
+        resyncHistory()
+    }
+    
+}
+
+// MARK: - TableView's Header & Footer view helpers
+extension HistoryPanelV2 {
+        
+    func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        if let header = view as? SiteTableViewHeader, let actualSection = viewModel.visibleSections[safe: section - 1] {
+            
+            header.textLabel?.textColor = UIColor.theme.tableView.headerTextDark
+            header.contentView.backgroundColor = UIColor.theme.tableView.selectedBackground
+            header.textLabel?.text = actualSection.title // At worst, we have a header with no text.
+            
+            let historySectionsWithGroups = viewModel.searchTermGroups.map { group in
+                viewModel.groupBelongsToSection(asGroup: group)
+            }
+            
+            // NOTE: Uncomment this when we support showing the Show all button and its functionality in a later time.
+            // let visibleSectionsWithGroups = viewModel.visibleSections.filter { historySectionsWithGroups.contains($0) }
+            // header.headerActionButton.isHidden = !visibleSectionsWithGroups.contains(actualSection)
+        }
+        
+    }
+
+    // viewForHeaderInSection REQUIRES implementing heightForHeaderInSection
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        // First section is for recently closed and its header has no view.
+        guard HistoryPanelSections(rawValue: section) != .additionalHistoryActions else {
+            return nil
+        }
+
+        return tableView.dequeueReusableHeaderFooterView(withIdentifier: SiteTableViewHeader.cellIdentifier)
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        // First section is for recently closed and its header has no height.
+        guard HistoryPanelSections(rawValue: section) != .additionalHistoryActions else {
+            return 0
+        }
+
+        return HistoryPanelUX.HeaderHeight
+    }
+    
+}
+
+extension HistoryPanelV2: UITableViewDataSourcePrefetching {
+    
+    // Happens WAY too often. We should consider fetching the next set when the user HITS the bottom instead.
+    func tableView(_ tableView: UITableView, prefetchRowsAt indexPaths: [IndexPath]) {
+        guard !viewModel.isFetchInProgress, indexPaths.contains(where: shouldLoadRow) else { return }
+
+        viewModel.reloadData()
+        applySnapshot(animatingDifferences: false)
+    }
+
+    func shouldLoadRow(for indexPath: IndexPath) -> Bool {
+        guard HistoryPanelSections(rawValue: indexPath.section) != .additionalHistoryActions else { return false }
+
+        return indexPath.row >= viewModel.groupedSites.numberOfItemsForSection(indexPath.section - 1) - historyPanelPrefetchOffset
+    }
+    
+}

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
@@ -204,9 +204,12 @@ class HistoryPanelViewModel: Loggable, FeatureFlagsProtocol {
         // handle the past one hour later
         var sectionToRemove: [Sections]
         
-        if date.isToday() {
+        // Selecting today and every option after gives us a date of the day before... So we adjust.
+        let adjustedDate = date.dayAfter
+        
+        if adjustedDate.isToday() {
             sectionToRemove = [.today]
-        } else if date.isYesterday() {
+        } else if adjustedDate.isYesterday() {
             sectionToRemove = [.today, .yesterday]
         } else {
             sectionToRemove = Sections.allCases

--- a/Client/Frontend/Library/LibraryPanels.swift
+++ b/Client/Frontend/Library/LibraryPanels.swift
@@ -76,7 +76,9 @@ class LibraryPanelDescriptor {
     }
 }
 
-class LibraryPanels {
+//featureFlags.isFeatureActiveForBuild(.historyGroups)
+
+class LibraryPanels: FeatureFlagsProtocol {
     fileprivate let profile: Profile
     fileprivate let tabManager: TabManager
 
@@ -98,7 +100,14 @@ class LibraryPanels {
 
         LibraryPanelDescriptor(
             makeViewController: { profile, tabManager in
-                return HistoryPanel(profile: profile, tabManager: tabManager)
+                
+                // NOTE: Switch to HistoryPanelV2 from v100 onwards.
+                if self.featureFlags.isFeatureActiveForBuild(.historyGroups) {
+                    return HistoryPanelV2(profile: profile, tabManager: tabManager)
+                } else {
+                    return HistoryPanel(profile: profile, tabManager: tabManager)
+                }
+                
             },
             profile: profile,
             tabManager: tabManager,


### PR DESCRIPTION
# Overview

The new history panel (HistoryPanelV2) has data source changes that affect pre-existing functionality. To reduce the risk of introducing regressions in v99, we will bring back the OLD historyPanel. 

The OLD historyPanel is chosen for all builds NOT Fennec. Dev builds will continue using the new history panel, with STGs. 