### PR TITLE
Add [v100] fx3832 Sponsored tiles manager logic

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -5486,8 +5486,8 @@
 			children = (
 				8AD3271627E3D12300EAF033 /* ContileProviderMock.swift */,
 				8AB8572B27D945FA0075C173 /* FxHomeTopSitesManager.swift */,
-				43AB6FA125DC53D30016B015 /* TopSiteHistoryManager.swift */,
 				43AB6F9C25DC53D20016B015 /* GoogleTopSiteManager.swift */,
+				43AB6FA125DC53D30016B015 /* TopSiteHistoryManager.swift */,
 			);
 			path = DataManagement;
 			sourceTree = "<group>";

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -500,6 +500,7 @@
 		8AD08D1727E91AC800B8E907 /* TabsQuantityTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1627E91AC800B8E907 /* TabsQuantityTelemetryTests.swift */; };
 		8AD1980F27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */; };
 		8AD3271527E3B45D00EAF033 /* SponsoredTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD3271427E3B45D00EAF033 /* SponsoredTile.swift */; };
+		8AD3271727E3D12300EAF033 /* ContileProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD3271627E3D12300EAF033 /* ContileProviderMock.swift */; };
 		8AD40FC527BADC1F00672675 /* TabToolbarHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD40FC427BADC1E00672675 /* TabToolbarHelper.swift */; };
 		8AD40FC727BADC3400672675 /* ToolbarTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD40FC627BADC3400672675 /* ToolbarTextField.swift */; };
 		8AD40FCA27BADC4B00672675 /* ReaderModeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD40FC827BADC4B00672675 /* ReaderModeButton.swift */; };
@@ -2791,6 +2792,7 @@
 		8AD08D1627E91AC800B8E907 /* TabsQuantityTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsQuantityTelemetryTests.swift; sourceTree = "<group>"; };
 		8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotonActionSheetViewModel.swift; sourceTree = "<group>"; };
 		8AD3271427E3B45D00EAF033 /* SponsoredTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SponsoredTile.swift; sourceTree = "<group>"; };
+		8AD3271627E3D12300EAF033 /* ContileProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContileProviderMock.swift; sourceTree = "<group>"; };
 		8AD40FC427BADC1E00672675 /* TabToolbarHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabToolbarHelper.swift; sourceTree = "<group>"; };
 		8AD40FC627BADC3400672675 /* ToolbarTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolbarTextField.swift; sourceTree = "<group>"; };
 		8AD40FC827BADC4B00672675 /* ReaderModeButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderModeButton.swift; sourceTree = "<group>"; };
@@ -5482,6 +5484,7 @@
 		8AB8572A27D944B70075C173 /* DataManagement */ = {
 			isa = PBXGroup;
 			children = (
+				8AD3271627E3D12300EAF033 /* ContileProviderMock.swift */,
 				8AB8572B27D945FA0075C173 /* FxHomeTopSitesManager.swift */,
 				43AB6FA125DC53D30016B015 /* TopSiteHistoryManager.swift */,
 				43AB6F9C25DC53D20016B015 /* GoogleTopSiteManager.swift */,
@@ -8826,6 +8829,7 @@
 				DFACDFAF274D4D6D00A94EEC /* ReusableCell.swift in Sources */,
 				1D0BA05C24F46A0400D731B5 /* TopSitesHelper.swift in Sources */,
 				0BF0DB941A8545800039F300 /* URLBarView.swift in Sources */,
+				8AD3271727E3D12300EAF033 /* ContileProviderMock.swift in Sources */,
 				DFACBF7F277B5F7B003D5F41 /* WallpaperBackgroundView.swift in Sources */,
 				D01017F5219CB6BD009CBB5A /* DownloadContentScript.swift in Sources */,
 				D5D052EF2645ACBF00759F85 /* View.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -499,6 +499,7 @@
 		8AD08D1527E9198E00B8E907 /* TabsQuantityTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1427E9198E00B8E907 /* TabsQuantityTelemetry.swift */; };
 		8AD08D1727E91AC800B8E907 /* TabsQuantityTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1627E91AC800B8E907 /* TabsQuantityTelemetryTests.swift */; };
 		8AD1980F27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */; };
+		8AD3271527E3B45D00EAF033 /* SponsoredTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD3271427E3B45D00EAF033 /* SponsoredTile.swift */; };
 		8AD40FC527BADC1F00672675 /* TabToolbarHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD40FC427BADC1E00672675 /* TabToolbarHelper.swift */; };
 		8AD40FC727BADC3400672675 /* ToolbarTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD40FC627BADC3400672675 /* ToolbarTextField.swift */; };
 		8AD40FCA27BADC4B00672675 /* ReaderModeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD40FC827BADC4B00672675 /* ReaderModeButton.swift */; };
@@ -2789,6 +2790,7 @@
 		8AD08D1427E9198E00B8E907 /* TabsQuantityTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsQuantityTelemetry.swift; sourceTree = "<group>"; };
 		8AD08D1627E91AC800B8E907 /* TabsQuantityTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsQuantityTelemetryTests.swift; sourceTree = "<group>"; };
 		8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotonActionSheetViewModel.swift; sourceTree = "<group>"; };
+		8AD3271427E3B45D00EAF033 /* SponsoredTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SponsoredTile.swift; sourceTree = "<group>"; };
 		8AD40FC427BADC1E00672675 /* TabToolbarHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabToolbarHelper.swift; sourceTree = "<group>"; };
 		8AD40FC627BADC3400672675 /* ToolbarTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolbarTextField.swift; sourceTree = "<group>"; };
 		8AD40FC827BADC4B00672675 /* ReaderModeButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderModeButton.swift; sourceTree = "<group>"; };
@@ -5460,6 +5462,7 @@
 				8AB8571E27D931B40075C173 /* EmptyTopSiteCell.swift */,
 				8AB8571C27D929350075C173 /* FxHomeTopSitesViewModel.swift */,
 				8A2D593D27DC0AA100713EC9 /* HomeTopSite.swift */,
+				8AD3271427E3B45D00EAF033 /* SponsoredTile.swift */,
 				8AB8572227D935ED0075C173 /* TopSiteCollectionCell.swift */,
 				3BB50E101D6274CD004B33DF /* TopSiteItemCell.swift */,
 			);
@@ -8932,6 +8935,7 @@
 				D0625CA8208FC47A0081F3B2 /* BrowserViewController+DownloadQueueDelegate.swift in Sources */,
 				8A56955227C68AE00077A89E /* UILabelExtensions.swift in Sources */,
 				2F44FCC71A9E8CF500FD20CC /* SearchSettingsTableViewController.swift in Sources */,
+				8AD3271527E3B45D00EAF033 /* SponsoredTile.swift in Sources */,
 				C8417D222657F0600010B877 /* LibraryViewModel.swift in Sources */,
 				39A359E41BFCCE94006B9E87 /* UserActivityHandler.swift in Sources */,
 				4331A9BD271D267E005E8080 /* ContextualHintViewModel.swift in Sources */,

--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -97,6 +97,10 @@ class TestAppDelegate: AppDelegate {
             profile.prefs.setString(ETPCoverSheetShowType.DoNotShow.rawValue, forKey: PrefsKeys.KeyETPCoverSheetShowType)
         }
 
+        if launchArguments.contains(LaunchArguments.SkipSponsoredShortcuts) {
+            profile.prefs.setBool(true, forKey: PrefsKeys.KeyShowSponsoredShortcuts)
+        }
+
         // Don't show the What's New page.
         if launchArguments.contains(LaunchArguments.SkipWhatsNew) {
             profile.prefs.setInt(1, forKey: PrefsKeys.KeyLastVersionNumber)

--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -98,7 +98,7 @@ class TestAppDelegate: AppDelegate {
         }
 
         if launchArguments.contains(LaunchArguments.SkipSponsoredShortcuts) {
-            profile.prefs.setBool(true, forKey: PrefsKeys.KeyShowSponsoredShortcuts)
+            profile.prefs.setBool(false, forKey: PrefsKeys.KeyShowSponsoredShortcuts)
         }
 
         // Don't show the What's New page.

--- a/Client/FeatureFlags/FeatureFlagsManager.swift
+++ b/Client/FeatureFlags/FeatureFlagsManager.swift
@@ -30,6 +30,7 @@ enum FeatureFlagName: String, CaseIterable {
     case recentlySaved
     case reportSiteIssue
     case shakeToRestore
+    case sponsoredTiles
     case startAtHome
     case tabTrayGroups
     case wallpapers
@@ -195,6 +196,11 @@ class FeatureFlagsManager {
                                               and: profile,
                                               enabledFor: [.beta, .developer, .other])
         features[.shakeToRestore] = shakeToRestore
+
+        let sponsoredTiles = FlaggableFeature(withID: .sponsoredTiles,
+                                              and: profile,
+                                              enabledFor: [.developer])
+        features[.sponsoredTiles] = sponsoredTiles
 
         let startAtHome = FlaggableFeature(withID: .startAtHome,
                                            and: profile,

--- a/Client/Frontend/Home/TopSites/DataManagement/ContileProviderMock.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/ContileProviderMock.swift
@@ -25,12 +25,9 @@ struct Contile: Codable {
 // TODO: Use in tests only when provider exists
 class ContileProviderMock: ContileProvider {
 
-    var shouldSucceed: Bool = true
-    private var successData: [Contile]
-    private var failureResult = Result.failure(Error.invalidData)
-    private var successResult: ContileProvider.Result
+    private var result: ContileProvider.Result
 
-    static var mockSuccessData: [Contile] {
+    static var defaultSuccessData: [Contile] {
         return [Contile(id: 1,
                         name: "Firefox",
                         url: "https://firefox.com",
@@ -49,13 +46,12 @@ class ContileProviderMock: ContileProvider {
                         position: 2)]
     }
 
-    init(successData: [Contile] = []) {
-        self.successData = successData
-        self.successResult = Result.success(successData)
+    init(result: ContileProvider.Result = .success([])) {
+        self.result = result
     }
 
     func fetchContiles(completion: @escaping (ContileProvider.Result) -> Void) {
-        completion(shouldSucceed ? successResult : failureResult)
+        completion(result)
     }
 
     enum Error: Swift.Error {

--- a/Client/Frontend/Home/TopSites/DataManagement/ContileProviderMock.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/ContileProviderMock.swift
@@ -43,7 +43,15 @@ class ContileProviderMock: ContileProvider {
                         imageURL: "https://test.com/image2.jpg",
                         imageSize: 200,
                         impressionUrl: "https://example.com",
-                        position: 2)]
+                        position: 2),
+                Contile(id: 3,
+                        name: "Focus",
+                        url: "https://support.mozilla.org/en-US/kb/firefox-focus-ios",
+                        clickUrl: "https://support.mozilla.org/en-US/kb/firefox-focus-ios/click",
+                        imageURL: "https://test.com/image3.jpg",
+                        imageSize: 200,
+                        impressionUrl: "https://another-example.com",
+                        position: 3)]
     }
 
     init(result: ContileProvider.Result = .success([])) {

--- a/Client/Frontend/Home/TopSites/DataManagement/ContileProviderMock.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/ContileProviderMock.swift
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// To be cleaned up once https://github.com/mozilla-mobile/firefox-ios/pull/10182/files is merged
+protocol ContileProvider {
+    typealias Result = Swift.Result<[Contile], Error>
+
+    func fetchContiles(completion: @escaping (Result) -> Void)
+}
+
+struct Contile: Codable {
+    let id: Int
+    let name: String
+    let url: String
+    let clickUrl: String
+    let imageURL: String
+    let imageSize: Int
+    let impressionUrl: String
+    let position: Int?
+}
+
+// TODO: Use in tests only when provider exists
+class ContileProviderMock: ContileProvider {
+
+    var shouldSucceed: Bool = true
+    private var successData: [Contile]
+    private var failureResult = Result.failure(Error.invalidData)
+    private var successResult: ContileProvider.Result
+
+    static var mockSuccessData: [Contile] {
+        return [Contile(id: 1,
+                        name: "Firefox",
+                        url: "https://firefox.com",
+                        clickUrl: "https://firefox.com/click",
+                        imageURL: "https://test.com/image1.jpg",
+                        imageSize: 200,
+                        impressionUrl: "https://test.com",
+                        position: 1),
+                Contile(id: 2,
+                        name: "Mozilla",
+                        url: "https://mozilla.com",
+                        clickUrl: "https://mozilla.com/click",
+                        imageURL: "https://test.com/image2.jpg",
+                        imageSize: 200,
+                        impressionUrl: "https://example.com",
+                        position: 2)]
+    }
+
+    init(successData: [Contile] = []) {
+        self.successData = successData
+        self.successResult = Result.success(successData)
+    }
+
+    func fetchContiles(completion: @escaping (ContileProvider.Result) -> Void) {
+        completion(shouldSucceed ? successResult : failureResult)
+    }
+
+    enum Error: Swift.Error {
+        case invalidData
+    }
+}

--- a/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
@@ -142,7 +142,7 @@ class FxHomeTopSitesManager: FeatureFlagsProtocol {
 
     // MARK: - Sponsored tiles (Contiles)
 
-    static let maximumNumberOfSponsoredTile = 1
+    static let maximumNumberOfSponsoredTile = 2
 
     // TODO: Check for settings user preference with https://mozilla-hub.atlassian.net/browse/FXIOS-3469
     // TODO: Check for nimbus with https://mozilla-hub.atlassian.net/browse/FXIOS-3468

--- a/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
@@ -6,66 +6,6 @@ import Foundation
 import Shared
 import Storage
 
-/// To be cleaned up once https://github.com/mozilla-mobile/firefox-ios/pull/10182/files is merged
-protocol ContileProvider {
-    typealias Result = Swift.Result<[Contile], Error>
-
-    func fetchContiles(completion: @escaping (Result) -> Void)
-}
-
-struct Contile: Codable {
-    let id: Int
-    let name: String
-    let url: String
-    let clickUrl: String
-    let imageURL: String
-    let imageSize: Int
-    let impressionUrl: String
-    let position: Int?
-}
-
-// TODO: Use in tests only when provider exists
-class ContileProviderMock: ContileProvider {
-
-    var shouldSucceed: Bool = true
-    private var successData: [Contile]
-    private var failureResult = Result.failure(Error.invalidData)
-    private var successResult: ContileProvider.Result
-
-    static var mockSuccessData: [Contile] {
-        return [Contile(id: 1,
-                        name: "Firefox",
-                        url: "https://firefox.com",
-                        clickUrl: "https://firefox.com/click",
-                        imageURL: "https://test.com/image1.jpg",
-                        imageSize: 200,
-                        impressionUrl: "https://test.com",
-                        position: 1),
-                Contile(id: 2,
-                        name: "Mozilla",
-                        url: "https://mozilla.com",
-                        clickUrl: "https://mozilla.com/click",
-                        imageURL: "https://test.com/image2.jpg",
-                        imageSize: 200,
-                        impressionUrl: "https://example.com",
-                        position: 2)]
-    }
-
-    init(successData: [Contile] = []) {
-        self.successData = successData
-        self.successResult = Result.success(successData)
-    }
-
-    func fetchContiles(completion: @escaping (ContileProvider.Result) -> Void) {
-        completion(shouldSucceed ? successResult : failureResult)
-    }
-
-    enum Error: Swift.Error {
-        case invalidData
-    }
-}
-/// End of code to clean up
-
 protocol FxHomeTopSitesManagerDelegate: AnyObject {
     func reloadTopSites()
 }

--- a/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
@@ -160,7 +160,7 @@ private extension Array where Element == Site {
     ///   - sites: The top sites to add the sponsored tile to
     mutating func addSponsoredTiles(sponsoredTileSpaces: Int, contiles: [Contile]) {
         var siteAdded = 0
-        for index in (0..<FxHomeTopSitesManager.maximumNumberOfSponsoredTile) {
+        for index in (0..<contiles.count) {
 
             guard siteAdded < sponsoredTileSpaces, let contile = contiles[safe: index] else { return }
             let site = SponsoredTile(contile: contile)
@@ -170,6 +170,9 @@ private extension Array where Element == Site {
 
             insert(site, at: 0)
             siteAdded += 1
+
+            // Do not add more sponsored tile if we reach the maximum
+            guard siteAdded < FxHomeTopSitesManager.maximumNumberOfSponsoredTile else { break }
         }
     }
 

--- a/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
@@ -14,7 +14,7 @@ class FxHomeTopSitesManager: FeatureFlagsProtocol {
 
     private let profile: Profile
     private var topSites: [HomeTopSite] = []
-    private let dataQueue = DispatchQueue(label: "com.moz.topSitesManager.queue")
+    private let dataQueue = DispatchQueue(label: "com.moz.topSitesManager.queue", qos: .userInteractive)
 
     // Raw data to build top sites with
     private var historySites: [Site] = []
@@ -71,6 +71,8 @@ class FxHomeTopSitesManager: FeatureFlagsProtocol {
     }
 
     private func loadContiles(group: DispatchGroup) {
+        guard shouldLoadSponsoredTiles else { return }
+
         group.enter()
         contileProvider.fetchContiles { result in
             if case .success(let contiles) = result {
@@ -146,8 +148,12 @@ class FxHomeTopSitesManager: FeatureFlagsProtocol {
 
     // TODO: Check for settings user preference with https://mozilla-hub.atlassian.net/browse/FXIOS-3469
     // TODO: Check for nimbus with https://mozilla-hub.atlassian.net/browse/FXIOS-3468
+    private var shouldLoadSponsoredTiles: Bool {
+        return featureFlags.isFeatureActiveForBuild(.sponsoredTiles) && profile.prefs.boolForKey(PrefsKeys.KeyShowSponsoredShortcuts) ?? true
+    }
+
     private var shouldShowSponsoredTiles: Bool {
-        return !contiles.isEmpty && featureFlags.isFeatureActiveForBuild(.sponsoredTiles)
+        return !contiles.isEmpty && shouldLoadSponsoredTiles
     }
 }
 

--- a/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
@@ -66,6 +66,9 @@ class FxHomeTopSitesManager: FeatureFlagsProtocol {
         loadTopSites(group: group)
 
         group.notify(queue: dataQueue) {
+            // Pre-loading the data with a default number of tiles so we always show section when needed
+            self.calculateTopSiteData(numberOfTilesPerRow: 4)
+
             dataLoadingCompletion?()
         }
     }

--- a/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
@@ -160,7 +160,7 @@ private extension Array where Element == Site {
     ///   - sites: The top sites to add the sponsored tile to
     mutating func addSponsoredTiles(sponsoredTileSpaces: Int, contiles: [Contile]) {
         var siteAdded = 0
-        for index in (0..<contiles.count) {
+        for (index, _) in contiles.enumerated() {
 
             guard siteAdded < sponsoredTileSpaces, let contile = contiles[safe: index] else { return }
             let site = SponsoredTile(contile: contile)

--- a/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
@@ -41,7 +41,7 @@ class FxHomeTopSitesManager: FeatureFlagsProtocol {
     }
 
     var hasData: Bool {
-        return !topSites.isEmpty
+        return !historySites.isEmpty
     }
 
     var siteCount: Int {

--- a/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
@@ -6,23 +6,88 @@ import Foundation
 import Shared
 import Storage
 
+/// To be cleaned up once https://github.com/mozilla-mobile/firefox-ios/pull/10182/files is merged
+protocol ContileProvider {
+    typealias Result = Swift.Result<[Contile], Error>
+
+    func fetchContiles(completion: @escaping (Result) -> Void)
+}
+
+struct Contile: Codable {
+    let id: Int
+    let name: String
+    let url: String
+    let clickUrl: String
+    let imageURL: String
+    let imageSize: Int
+    let impressionUrl: String
+    let position: Int?
+}
+
+// TODO: Use in tests only when provider exists
+class ContileProviderMock: ContileProvider {
+
+    var shouldSucceed: Bool = true
+    private var successData: [Contile]
+    private var failureResult = Result.failure(Error.invalidData)
+    private var successResult: ContileProvider.Result
+
+    static var mockSuccessData: [Contile] {
+        return [Contile(id: 1,
+                        name: "Firefox",
+                        url: "https://firefox.com",
+                        clickUrl: "https://firefox.com/click",
+                        imageURL: "https://test.com/image1.jpg",
+                        imageSize: 200,
+                        impressionUrl: "https://test.com",
+                        position: 1),
+                Contile(id: 2,
+                        name: "Mozilla",
+                        url: "https://mozilla.com",
+                        clickUrl: "https://mozilla.com/click",
+                        imageURL: "https://test.com/image2.jpg",
+                        imageSize: 200,
+                        impressionUrl: "https://example.com",
+                        position: 2)]
+    }
+
+    init(successData: [Contile] = []) {
+        self.successData = successData
+        self.successResult = Result.success(successData)
+    }
+
+    func fetchContiles(completion: @escaping (ContileProvider.Result) -> Void) {
+        completion(shouldSucceed ? successResult : failureResult)
+    }
+
+    enum Error: Swift.Error {
+        case invalidData
+    }
+}
+/// End of code to clean up
+
 protocol FxHomeTopSitesManagerDelegate: AnyObject {
     func reloadTopSites()
 }
 
 class FxHomeTopSitesManager {
 
+    private let contileProvider: ContileProvider
     private let googleTopSiteManager: GoogleTopSiteManager
     private let profile: Profile
+
     private var topSites: [HomeTopSite] = []
     private var historySites: [Site] = []
+    private var contiles: [Contile] = []
 
+    private let dataQueue = DispatchQueue(label: "com.moz.topSitesManager.queue")
     weak var delegate: FxHomeTopSitesManagerDelegate?
     lazy var topSiteHistoryManager = TopSiteHistoryManager(profile: profile)
     
     init(profile: Profile) {
         self.profile = profile
         self.googleTopSiteManager = GoogleTopSiteManager(prefs: profile.prefs)
+        self.contileProvider = ContileProviderMock(successData: ContileProviderMock.mockSuccessData)
         topSiteHistoryManager.delegate = self
     }
 
@@ -53,23 +118,56 @@ class FxHomeTopSitesManager {
         topSiteHistoryManager.refreshIfNeeded(forceTopSites: forceTopSites)
     }
 
+    // MARK: - Data loading
+
     // Loads the data source of top sites
-    func loadTopSitesData(completion: (() -> Void)? = nil) {
-        topSiteHistoryManager.getTopSites { sites in
-            self.historySites = sites
-            completion?()
+    func loadTopSitesData(dataLoadingCompletion: (() -> Void)? = nil) {
+        let group = DispatchGroup()
+        loadContiles(group: group)
+        loadTopSites(group: group)
+
+        group.notify(queue: dataQueue) {
+            dataLoadingCompletion?()
         }
     }
 
-    // Top sites are composed of pinned sites, history and Google top site
+    private func loadContiles(group: DispatchGroup) {
+        group.enter()
+        contileProvider.fetchContiles { result in
+            if case .success(let contiles) = result {
+                self.contiles = contiles
+            }
+            group.leave()
+        }
+    }
+
+    private func loadTopSites(group: DispatchGroup) {
+        group.enter()
+        topSiteHistoryManager.getTopSites { sites in
+            self.historySites = sites
+            group.leave()
+        }
+    }
+
+    // MARK: - Tiles placement calculation
+
+    /// Top sites are composed of pinned sites, history, Contiles and Google top site.
+    /// Google top site is always first, then comes the contiles, pinned sites and history top sites.
+    /// We only add Google top site or Contiles if number of pins doesn't exeeds the available number shown of tiles.
+    /// - Parameter numberOfTilesPerRow: The number of tiles per row shown to the user
     func calculateTopSiteData(numberOfTilesPerRow: Int) {
         var sites = historySites
         let pinnedSiteCount = countPinnedSites(sites: sites)
-        let maxItems = numberOfTilesPerRow * numberOfRows
+        let totalNumberOfShownTiles = numberOfTilesPerRow * numberOfRows
+
+        if shouldAddSponsoredTiles(pinnedSiteCount: pinnedSiteCount,
+                             totalNumberOfShownTiles: totalNumberOfShownTiles) {
+            addSponsoredTiles(sites: &sites)
+        }
 
         if googleTopSiteManager.shouldAddGoogleTopSite(pinnedSiteCount: pinnedSiteCount,
-                                                       maxItems: maxItems) {
-            googleTopSiteManager.addGoogleTopSite(maxItems: maxItems, sites: &sites)
+                                                       totalNumberOfShownTiles: totalNumberOfShownTiles) {
+            googleTopSiteManager.addGoogleTopSite(maxItems: totalNumberOfShownTiles, sites: &sites)
         }
 
         topSites = sites.map { HomeTopSite(site: $0, profile: profile) }
@@ -83,9 +181,7 @@ class FxHomeTopSitesManager {
     var numberOfRows: Int {
         let preferredNumberOfRows = profile.prefs.intForKey(PrefsKeys.NumberOfTopSiteRows)
         let defaultNumberOfRows = TopSitesRowCountSettingsController.defaultNumberOfRows
-        // TODO: When updating the top sites settings, investigate if topsites can be 0. From current settings
-        // it can be a minimum of 1.
-        return Int(max(preferredNumberOfRows ?? defaultNumberOfRows, 1))
+        return Int(preferredNumberOfRows ?? defaultNumberOfRows)
     }
 
     private func countPinnedSites(sites: [Site]) -> Int {
@@ -94,6 +190,34 @@ class FxHomeTopSitesManager {
             if let _ = $0 as? PinnedSite { pinnedSites += 1 }
         }
         return pinnedSites
+    }
+
+    // MARK: - Sponsored tiles (Contiles)
+
+    static let maximumNumberOfSponsoredTile = 1
+
+    /// Check if Sponsored Tiles can be added to the top sites.
+    /// We don't add contiles if number of pins exeeds the available top sites spaces available and
+    /// ensure that Google tile has precedence over Sponsored Tiles
+    /// - Parameters:
+    ///   - pinnedSiteCount: The number of sites that are pinned
+    ///   - totalNumberOfShownTiles: The total number of tiles shown to the user
+    /// - Returns: True when contiles can be added
+    func shouldAddSponsoredTiles(pinnedSiteCount: Int, totalNumberOfShownTiles: Int) -> Bool {
+        // TODO: Will check for user preference here with https://mozilla-hub.atlassian.net/browse/FXIOS-3469
+        // TODO: Feature flag check
+        return !contiles.isEmpty && (pinnedSiteCount < totalNumberOfShownTiles - GoogleTopSiteManager.Constants.reservedSpaceCount)
+    }
+
+    /// Add a sponsored tiles to the top sites.
+    /// - Parameters:
+    ///   - sites: The top sites to add the sponsored tile to
+    func addSponsoredTiles(sites: inout [Site]) {
+        // TODO: Add check to ensure tile doesn't exists (don't duplicate). Check with URL
+        // TODO: Logic to support only one contile (the first one)
+        // TODO: Should I order depending on the position of the Contile? Asked Loren.
+        let site = SponsoredTile(contile: contiles[0])
+        sites.insert(site, at: 0)
     }
 }
 

--- a/Client/Frontend/Home/TopSites/DataManagement/GoogleTopSiteManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/GoogleTopSiteManager.swift
@@ -12,9 +12,12 @@ class GoogleTopSiteManager {
     struct Constants {
         // A guid is required in the case the site might become a pinned site
         static let googleGUID = "DefaultGoogleGUID"
+
         // US and rest of the world google urls
         static let usUrl = "https://www.google.com/webhp?client=firefox-b-1-m&channel=ts"
         static let rowUrl = "https://www.google.com/webhp?client=firefox-b-m&channel=ts"
+
+        // The number of tiles taken by Google top site manager
         static let reservedSpaceCount = 1
     }
 

--- a/Client/Frontend/Home/TopSites/DataManagement/GoogleTopSiteManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/GoogleTopSiteManager.swift
@@ -15,6 +15,7 @@ class GoogleTopSiteManager {
         // US and rest of the world google urls
         static let usUrl = "https://www.google.com/webhp?client=firefox-b-1-m&channel=ts"
         static let rowUrl = "https://www.google.com/webhp?client=firefox-b-m&channel=ts"
+        static let reservedSpaceCount = 1
     }
 
     // No Google Top Site, it should be removed, if it already exists for invalid region
@@ -68,9 +69,9 @@ class GoogleTopSiteManager {
         return pinnedSite
     }
 
-    func shouldAddGoogleTopSite(pinnedSiteCount: Int, maxItems: Int) -> Bool {
+    func shouldAddGoogleTopSite(pinnedSiteCount: Int, totalNumberOfShownTiles: Int) -> Bool {
         let shouldShow = !isHidden && suggestedSiteData() != nil
-        return shouldShow && (hasAdded || pinnedSiteCount < maxItems)
+        return shouldShow && (hasAdded || pinnedSiteCount < totalNumberOfShownTiles)
     }
 
     func removeGoogleTopSite(site: Site) {

--- a/Client/Frontend/Home/TopSites/DataManagement/GoogleTopSiteManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/GoogleTopSiteManager.swift
@@ -69,9 +69,11 @@ class GoogleTopSiteManager {
         return pinnedSite
     }
 
-    func shouldAddGoogleTopSite(pinnedSiteCount: Int, totalNumberOfShownTiles: Int) -> Bool {
+    // Once Google top site is added, we don't remove unless it's explicitly unpinned
+    // Add it when pinned websites are less than max pinned sites
+    func shouldAddGoogleTopSite(availableSpacesCount: Int) -> Bool {
         let shouldShow = !isHidden && suggestedSiteData() != nil
-        return shouldShow && (hasAdded || pinnedSiteCount < totalNumberOfShownTiles)
+        return shouldShow && (hasAdded || availableSpacesCount > 0)
     }
 
     func removeGoogleTopSite(site: Site) {
@@ -79,9 +81,7 @@ class GoogleTopSiteManager {
         isHidden = true
     }
 
-    // Once Google top site is added, we don't remove unless it's explicitly unpinned
-    // Add it when pinned websites are less than max pinned sites
-    func addGoogleTopSite(maxItems: Int, sites: inout [Site]) {
+    func addGoogleTopSite(sites: inout [Site]) {
         guard let googleSite = suggestedSiteData() else { return }
         sites.insert(googleSite, at: 0)
         hasAdded = true

--- a/Client/Frontend/Home/TopSites/FxHomeTopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/FxHomeTopSitesViewModel.swift
@@ -220,7 +220,7 @@ extension FxHomeTopSitesViewModel: FXHomeViewModelProtocol, FeatureFlagsProtocol
     }
 
     func updateData(completion: @escaping () -> Void) {
-        tileManager.loadTopSitesData { completion() }
+        tileManager.loadTopSitesData(dataLoadingCompletion: completion)
     }
 }
 

--- a/Client/Frontend/Home/TopSites/FxHomeTopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/FxHomeTopSitesViewModel.swift
@@ -220,7 +220,7 @@ extension FxHomeTopSitesViewModel: FXHomeViewModelProtocol, FeatureFlagsProtocol
     }
 
     func updateData(completion: @escaping () -> Void) {
-        tileManager.loadTopSitesData(completion: completion)
+        tileManager.loadTopSitesData { completion() }
     }
 }
 

--- a/Client/Frontend/Home/TopSites/HomeTopSite.swift
+++ b/Client/Frontend/Home/TopSites/HomeTopSite.swift
@@ -6,7 +6,7 @@ import Foundation
 import Storage
 
 // Top site UI class, used in the home top site section
-class HomeTopSite {
+final class HomeTopSite {
 
     var site: Site
     var title: String
@@ -18,6 +18,10 @@ class HomeTopSite {
 
     var isSuggested: Bool {
         return (site as? SuggestedSite) != nil
+    }
+
+    var isSponsoredTile: Bool {
+        return (site as? SponsoredTile) != nil
     }
 
     var isGoogleGUID: Bool {

--- a/Client/Frontend/Home/TopSites/SponsoredTile.swift
+++ b/Client/Frontend/Home/TopSites/SponsoredTile.swift
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Storage
+
+final class SponsoredTile: Site {
+
+    init(contile: Contile) {
+        super.init(url: contile.url, title: contile.name, bookmarked: nil)
+        // A guid is required in case the site might become a pinned site
+        self.guid = "default" + contile.name
+    }
+}

--- a/ClientTests/FxHomeTopSitesManagerTests.swift
+++ b/ClientTests/FxHomeTopSitesManagerTests.swift
@@ -170,13 +170,15 @@ class FxHomeTopSitesManagerTests: XCTestCase {
 
     func testCalculateTopSitesData_doesNotAddMoreSponsoredTileThanMaximum() {
         let manager = createManager()
-        manager.addContiles(shouldSucceed: true, contilesCount: 2)
+        // Max contiles is currently at 2, so it should add 2 contiles only
+        manager.addContiles(shouldSucceed: true, contilesCount: 3)
 
         testLoadData(manager: manager, numberOfTilesPerRow: 6) {
             XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, true)
             XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, true)
             XCTAssertEqual(manager.getSite(index: 1)?.isSponsoredTile, true)
-            XCTAssertEqual(manager.getSite(index: 2)?.isSponsoredTile, false)
+            XCTAssertEqual(manager.getSite(index: 2)?.isSponsoredTile, true)
+            XCTAssertEqual(manager.getSite(index: 3)?.isSponsoredTile, false)
         }
     }
 

--- a/ClientTests/FxHomeTopSitesManagerTests.swift
+++ b/ClientTests/FxHomeTopSitesManagerTests.swift
@@ -53,6 +53,15 @@ class FxHomeTopSitesManagerTests: XCTestCase {
         XCTAssertEqual(manager.numberOfRows, 3)
     }
 
+    func testLoadTopSitesData_withoutCalculationHasData() {
+        let manager = createManager()
+
+        testLoadData(manager: manager, numberOfTilesPerRow: nil) {
+            XCTAssertEqual(manager.hasData, true)
+            XCTAssertEqual(manager.siteCount, 0)
+        }
+    }
+
     func testLoadTopSitesData() {
         let manager = createManager()
 
@@ -299,11 +308,13 @@ extension FxHomeTopSitesManagerTests {
         return topSitesManager
     }
 
-    func testLoadData(manager: FxHomeTopSitesManager, numberOfTilesPerRow: Int, completion: @escaping () -> Void) {
+    func testLoadData(manager: FxHomeTopSitesManager, numberOfTilesPerRow: Int?, completion: @escaping () -> Void) {
         let expectation = expectation(description: "Top sites data should be loaded")
 
         manager.loadTopSitesData {
-            manager.calculateTopSiteData(numberOfTilesPerRow: numberOfTilesPerRow)
+            if let numberOfTilesPerRow = numberOfTilesPerRow {
+                manager.calculateTopSiteData(numberOfTilesPerRow: numberOfTilesPerRow)
+            }
             completion()
             expectation.fulfill()
         }

--- a/ClientTests/FxHomeTopSitesManagerTests.swift
+++ b/ClientTests/FxHomeTopSitesManagerTests.swift
@@ -168,6 +168,18 @@ class FxHomeTopSitesManagerTests: XCTestCase {
         }
     }
 
+    func testCalculateTopSitesData_doesNotAddMoreSponsoredTileThanMaximum() {
+        let manager = createManager()
+        manager.addContiles(shouldSucceed: true, contilesCount: 2)
+
+        testLoadData(manager: manager, numberOfTilesPerRow: 6) {
+            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, true)
+            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, true)
+            XCTAssertEqual(manager.getSite(index: 1)?.isSponsoredTile, true)
+            XCTAssertEqual(manager.getSite(index: 2)?.isSponsoredTile, false)
+        }
+    }
+
     func testCalculateTopSitesData_doesNotAddSponsoredTileIfDuplicatePinned() {
         let manager = createManager(addPinnedSiteCount: 1)
         manager.addContiles(shouldSucceed: true, contilesCount: 1, duplicateFirstTile: true, pinnedDuplicateTile: true)
@@ -193,13 +205,14 @@ class FxHomeTopSitesManagerTests: XCTestCase {
     }
 
     func testCalculateTopSitesData_addNextTileIfContileIsDuplicate() {
-        let manager = createManager()
+        let manager = createManager(addPinnedSiteCount: 1)
         manager.addContiles(shouldSucceed: true, contilesCount: 2, duplicateFirstTile: true, pinnedDuplicateTile: true)
 
         testLoadData(manager: manager, numberOfTilesPerRow: 6) {
             XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, true)
             XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, true)
             XCTAssertEqual(manager.getSite(index: 1)?.isSponsoredTile, true)
+            XCTAssertEqual(manager.getSite(index: 1)?.title, ContileProviderMock.defaultSuccessData[0].name.lowercased())
             XCTAssertEqual(manager.getSite(index: 2)?.isSponsoredTile, false)
         }
     }

--- a/ClientTests/FxHomeTopSitesManagerTests.swift
+++ b/ClientTests/FxHomeTopSitesManagerTests.swift
@@ -58,7 +58,7 @@ class FxHomeTopSitesManagerTests: XCTestCase {
 
         testLoadData(manager: manager, numberOfTilesPerRow: 6) {
             XCTAssertEqual(manager.hasData, true)
-            XCTAssertEqual(manager.siteCount, 10)
+            XCTAssertEqual(manager.siteCount, 11)
         }
     }
 
@@ -69,12 +69,12 @@ class FxHomeTopSitesManagerTests: XCTestCase {
             XCTAssertNotNil(manager.getSite(index: 0))
             XCTAssertNil(manager.getSite(index: -1))
             XCTAssertNotNil(manager.getSite(index: 10))
-            XCTAssertNil(manager.getSite(index: 12))
+            XCTAssertNil(manager.getSite(index: 15))
 
             XCTAssertNotNil(manager.getSiteDetail(index: 0))
             XCTAssertNil(manager.getSiteDetail(index: -1))
             XCTAssertNotNil(manager.getSiteDetail(index: 10))
-            XCTAssertNil(manager.getSiteDetail(index: 12))
+            XCTAssertNil(manager.getSiteDetail(index: 15))
         }
     }
 
@@ -90,7 +90,7 @@ class FxHomeTopSitesManagerTests: XCTestCase {
     }
 
     func testCalculateTopSitesData_hasNotGoogleTopSite() {
-        let manager = createManager(addPinnedSite: true)
+        let manager = createManager(addPinnedSiteCount: 3)
 
         // We test that having more pinned than available tiles, google tile isn't put in
         testLoadData(manager: manager, numberOfTilesPerRow: 1) {
@@ -102,28 +102,205 @@ class FxHomeTopSitesManagerTests: XCTestCase {
     // MARK: Pinned site
 
     func testCalculateTopSitesData_pinnedSites() {
-        let manager = createManager(addPinnedSite: true)
+        let manager = createManager(addPinnedSiteCount: 3)
 
         testLoadData(manager: manager, numberOfTilesPerRow: 6) {
             XCTAssertEqual(manager.hasData, true)
-            XCTAssertEqual(manager.siteCount, 13)
+            XCTAssertEqual(manager.siteCount, 14)
             XCTAssertEqual(manager.getSite(index: 0)?.isPinned, true)
+        }
+    }
+
+    // MARK: Sponsored tiles
+
+    func testLoadTopSitesData_addContile() {
+        let manager = createManager()
+        manager.addContiles(shouldSucceed: true, contilesCount: 1)
+
+        testLoadData(manager: manager, numberOfTilesPerRow: 6) {
+            XCTAssertEqual(manager.hasData, true)
+            XCTAssertEqual(manager.siteCount, 12)
+        }
+    }
+
+    func testCalculateTopSitesData_addContileAfterGoogle() {
+        let manager = createManager()
+        manager.addContiles(shouldSucceed: true, contilesCount: 1)
+
+        testLoadData(manager: manager, numberOfTilesPerRow: 6) {
+            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, true)
+            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, true)
+            XCTAssertEqual(manager.getSite(index: 1)?.isSponsoredTile, true)
+            XCTAssertEqual(manager.getSite(index: 2)?.isSponsoredTile, false)
+        }
+    }
+
+    func testCalculateTopSitesData_doesNotAddContileIfError() {
+        let manager = createManager()
+        manager.addContiles(shouldSucceed: false, contilesCount: 1)
+
+        testLoadData(manager: manager, numberOfTilesPerRow: 6) {
+            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, true)
+            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, true)
+            XCTAssertEqual(manager.getSite(index: 1)?.isSponsoredTile, false)
+            XCTAssertEqual(manager.getSite(index: 2)?.isSponsoredTile, false)
+        }
+    }
+
+    func testCalculateTopSitesData_doesNotAddContileIfSuccessEmpty() {
+        let manager = createManager()
+        manager.addContiles(shouldSucceed: true, contilesCount: 0)
+
+        testLoadData(manager: manager, numberOfTilesPerRow: 6) {
+            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, true)
+            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, true)
+            XCTAssertEqual(manager.getSite(index: 1)?.isSponsoredTile, false)
+            XCTAssertEqual(manager.getSite(index: 2)?.isSponsoredTile, false)
+        }
+    }
+
+    func testCalculateTopSitesData_doesNotAddSponsoredTileIfDuplicatePinned() {
+        let manager = createManager(addPinnedSiteCount: 1)
+        manager.addContiles(shouldSucceed: true, contilesCount: 1, duplicateFirstTile: true, pinnedDuplicateTile: true)
+
+        testLoadData(manager: manager, numberOfTilesPerRow: 6) {
+            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, true)
+            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, true)
+            XCTAssertEqual(manager.getSite(index: 1)?.isSponsoredTile, false)
+            XCTAssertEqual(manager.getSite(index: 2)?.isSponsoredTile, false)
+        }
+    }
+
+    func testCalculateTopSitesData_addSponsoredTileIfDuplicateIsNotPinned() {
+        let manager = createManager(addPinnedSiteCount: 1)
+        manager.addContiles(shouldSucceed: true, contilesCount: 1, duplicateFirstTile: true)
+
+        testLoadData(manager: manager, numberOfTilesPerRow: 6) {
+            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, true)
+            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, true)
+            XCTAssertEqual(manager.getSite(index: 1)?.isSponsoredTile, true)
+            XCTAssertEqual(manager.getSite(index: 2)?.isSponsoredTile, false)
+        }
+    }
+
+    func testCalculateTopSitesData_addNextTileIfContileIsDuplicate() {
+        let manager = createManager()
+        manager.addContiles(shouldSucceed: true, contilesCount: 2, duplicateFirstTile: true, pinnedDuplicateTile: true)
+
+        testLoadData(manager: manager, numberOfTilesPerRow: 6) {
+            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, true)
+            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, true)
+            XCTAssertEqual(manager.getSite(index: 1)?.isSponsoredTile, true)
+            XCTAssertEqual(manager.getSite(index: 2)?.isSponsoredTile, false)
+        }
+    }
+
+    func testCalculateTopSitesData_doesNotAddTileIfAllSpacesArePinned() {
+        let manager = createManager(addPinnedSiteCount: 12)
+        manager.addContiles(shouldSucceed: true, contilesCount: 0)
+
+        testLoadData(manager: manager, numberOfTilesPerRow: 6) {
+            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, false)
+            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, false)
+            XCTAssertEqual(manager.getSite(index: 1)?.isSponsoredTile, false)
+            XCTAssertEqual(manager.getSite(index: 2)?.isSponsoredTile, false)
+        }
+    }
+
+    func testCalculateTopSitesData_doesNotAddTileIfAllSpacesArePinnedAndGoogleIsThere() {
+        let manager = createManager(addPinnedSiteCount: 11)
+        manager.addContiles(shouldSucceed: true, contilesCount: 0)
+
+        testLoadData(manager: manager, numberOfTilesPerRow: 6) {
+            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, true)
+            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, true)
+            XCTAssertEqual(manager.getSite(index: 1)?.isSponsoredTile, false)
+            XCTAssertEqual(manager.getSite(index: 2)?.isSponsoredTile, false)
         }
     }
 }
 
-// MARK: Helper methods
+// MARK: - Helper methods
+
+// MARK: ContileProviderMock
+extension ContileProviderMock {
+
+    static func getContiles(contilesCount: Int,
+                            duplicateFirstTile: Bool,
+                            pinnedDuplicateTile: Bool) -> [Contile] {
+
+        var defaultData = ContileProviderMock.defaultSuccessData
+
+        if duplicateFirstTile {
+            let duplicateTile = pinnedDuplicateTile ? ContileProviderMock.pinnedDuplicateTile : ContileProviderMock.duplicateTile
+            defaultData.insert(duplicateTile, at: 0)
+        }
+
+        return Array(defaultData.prefix(contilesCount))
+    }
+
+    static let pinnedTitle = "A pinned title %@"
+    static let pinnedURL = "www.a-pinned-url-%@.com"
+    static let title = "A title %@"
+    static let url = "www.a-url-%@.com"
+
+    static var pinnedDuplicateTile: Contile {
+        return Contile(id: 1,
+                       name: String(format: ContileProviderMock.pinnedTitle, "0"),
+                       url: String(format: ContileProviderMock.pinnedURL, "0"),
+                       clickUrl: "https://www.test.com/click",
+                       imageURL: "https://test.com/image0.jpg",
+                       imageSize: 200,
+                       impressionUrl: "https://test.com",
+                       position: 1)
+    }
+
+    static var duplicateTile: Contile {
+        return Contile(id: 1,
+                       name: String(format: ContileProviderMock.title, "0"),
+                       url: String(format: ContileProviderMock.url, "0"),
+                       clickUrl: "https://www.test.com/click",
+                       imageURL: "https://test.com/image0.jpg",
+                       imageSize: 200,
+                       impressionUrl: "https://test.com",
+                       position: 1)
+    }
+}
+
+// MARK: FxHomeTopSitesManager
+extension FxHomeTopSitesManager {
+
+    func addContiles(shouldSucceed: Bool,
+                     contilesCount: Int = 0,
+                     duplicateFirstTile: Bool = false,
+                     pinnedDuplicateTile: Bool = false) {
+
+        let resultContile = ContileProviderMock.getContiles(contilesCount: contilesCount,
+                                                            duplicateFirstTile: duplicateFirstTile,
+                                                            pinnedDuplicateTile: pinnedDuplicateTile)
+
+        let result = shouldSucceed ? ContileProvider.Result.success(resultContile) : ContileProvider.Result.failure(ContileProviderMock.Error.invalidData)
+
+        let contileProviderMock = ContileProviderMock(result: result)
+        contileProvider = contileProviderMock
+    }
+}
+
+// MARK: FxHomeTopSitesManagerTests
 extension FxHomeTopSitesManagerTests {
-    func createManager(addPinnedSite: Bool = false) -> FxHomeTopSitesManager {
+
+    func createManager(addPinnedSiteCount: Int = 0) -> FxHomeTopSitesManager {
         let topSitesManager = FxHomeTopSitesManager(profile: profile)
+
         let historyStub = TopSiteHistoryManagerStub(profile: profile)
-        historyStub.addThreePinnedSite = addPinnedSite
+        historyStub.addPinnedSiteCount = addPinnedSiteCount
         topSitesManager.topSiteHistoryManager = historyStub
+
         return topSitesManager
     }
 
     func testLoadData(manager: FxHomeTopSitesManager, numberOfTilesPerRow: Int, completion: @escaping () -> Void) {
-        let expectation = self.expectation(description: "Top sites data should be loaded")
+        let expectation = expectation(description: "Top sites data should be loaded")
 
         manager.loadTopSitesData {
             manager.calculateTopSiteData(numberOfTilesPerRow: numberOfTilesPerRow)
@@ -131,31 +308,31 @@ extension FxHomeTopSitesManagerTests {
             expectation.fulfill()
         }
 
-        waitForExpectations(timeout: 2, handler: nil)
+        waitForExpectations(timeout: 0.1, handler: nil)
     }
 }
 
 // MARK: TopSiteHistoryManagerStub
 class TopSiteHistoryManagerStub: TopSiteHistoryManager {
+
     override func getTopSites(completion: @escaping ([Site]) -> Void) {
         completion(createHistorySites())
     }
 
     var siteCount = 10
-    var addThreePinnedSite: Bool = false
+    var addPinnedSiteCount: Int = 0
 
     func createHistorySites() -> [Site] {
         var sites = [Site]()
 
-        if addThreePinnedSite {
-            (0..<3).forEach {
-                let site = Site(url: "www.a-pinned-url-\($0).com", title: "A pinned title\($0)")
-                sites.append(PinnedSite(site: site))
-            }
+        (0..<addPinnedSiteCount).forEach {
+            let site = Site(url: String(format: ContileProviderMock.pinnedURL, "\($0)"), title: String(format: ContileProviderMock.pinnedTitle, "\($0)"))
+            sites.append(PinnedSite(site: site))
         }
 
         (0..<siteCount).forEach {
-            sites.append(Site(url: "www.a-url-\($0).com", title: "A title\($0)"))
+            let site = Site(url: String(format: ContileProviderMock.url, "\($0)"), title: String(format: ContileProviderMock.title, "\($0)"))
+            sites.append(site)
         }
 
         return sites

--- a/Shared/LaunchArguments.swift
+++ b/Shared/LaunchArguments.swift
@@ -11,6 +11,7 @@ public struct LaunchArguments {
     public static let SkipWhatsNew = "FIREFOX_SKIP_WHATS_NEW"
     public static let SkipETPCoverSheet = "FIREFOX_SKIP_ETP_COVER_SHEET"
     public static let SkipContextualHints = "FIREFOX_SKIP_CONTEXTUAL_HINTS"
+    public static let SkipSponsoredShortcuts = "FIREFOX_SKIP_SPONSORED_SHORTCUTS"
     public static let ClearProfile = "FIREFOX_CLEAR_PROFILE"
     public static let StageServer = "FIREFOX_USE_STAGE_SERVER"
     public static let FxAChinaServer = "FIREFOX_USE_FXA_CHINA_SERVER"

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -74,6 +74,7 @@ public struct PrefsKeys {
     public static let AppExtensionTelemetryOpenUrl = "AppExtensionTelemetryOpenUrl"
     public static let AppExtensionTelemetryEventArray = "AppExtensionTelemetryEvents"
     public static let KeyBlockPopups = "blockPopups"
+    public static let KeyShowSponsoredShortcuts = "showSponsoredShortcuts"
 
     // Tabs Tray
     public static let KeyInactiveTabsModel = "KeyInactiveTabsModelKey"

--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -28,13 +28,15 @@ class ActivityStreamTest: BaseTestCase {
                                    LaunchArguments.SkipWhatsNew,
                                    LaunchArguments.SkipETPCoverSheet,
                                    LaunchArguments.LoadDatabasePrefix + pagesVisitediPad,
-                                   LaunchArguments.SkipContextualHints]
+                                   LaunchArguments.SkipContextualHints,
+                                   LaunchArguments.SkipSponsoredShortcuts]
             } else {
                 launchArguments = [LaunchArguments.SkipIntro,
                                    LaunchArguments.SkipWhatsNew,
                                    LaunchArguments.SkipETPCoverSheet,
                                    LaunchArguments.LoadDatabasePrefix + pagesVisitediPhone,
-                                   LaunchArguments.SkipContextualHints]
+                                   LaunchArguments.SkipContextualHints,
+                                   LaunchArguments.SkipSponsoredShortcuts]
             }
         }
         launchArguments.append(LaunchArguments.SkipAddingGoogleTopSite)

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -312,7 +312,7 @@ workflows:
     - 5_deploy_and_slack
     meta:
       bitrise.io:
-        stack: osx-xcode-13.1.x
+        stack: osx-xcode-13.2.x
         machine_type_id: g2.4core
   RunSmokeXCUITestsiPad:
     steps:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -585,7 +585,7 @@ workflows:
       in master
     meta:
       bitrise.io:
-        stack: osx-xcode-13.1.x
+        stack: osx-xcode-13.2.x
         machine_type_id: g2.4core
     before_run:
     - 1_git_clone_and_post_clone


### PR DESCRIPTION
Issue [FXIOS-3832](https://mozilla-hub.atlassian.net/browse/FXIOS-3832)
- Adding logic for sponsored tiles management for Top Sites - Using mock data for now. 
- Use feature flag to make sure code is protected from affecting anything else than develop builds
- Unit tests for logic 