### PR TITLE
Add fx3514 [v99] Add telemetry for tabs quantity

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -493,6 +493,8 @@
 		8AB8574627D97CB00075C173 /* HomePanelContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8574527D97CB00075C173 /* HomePanelContextMenu.swift */; };
 		8AB8574827D97CD40075C173 /* HomePanelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8574727D97CD40075C173 /* HomePanelType.swift */; };
 		8AB8574A27D97CE90075C173 /* HomePanelDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8574927D97CE90075C173 /* HomePanelDelegate.swift */; };
+		8AD08D1527E9198E00B8E907 /* TabsQuantityTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1427E9198E00B8E907 /* TabsQuantityTelemetry.swift */; };
+		8AD08D1727E91AC800B8E907 /* TabsQuantityTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1627E91AC800B8E907 /* TabsQuantityTelemetryTests.swift */; };
 		8AD1980F27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */; };
 		8AD40FC527BADC1F00672675 /* TabToolbarHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD40FC427BADC1E00672675 /* TabToolbarHelper.swift */; };
 		8AD40FC727BADC3400672675 /* ToolbarTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD40FC627BADC3400672675 /* ToolbarTextField.swift */; };
@@ -2778,6 +2780,8 @@
 		8AB8574527D97CB00075C173 /* HomePanelContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePanelContextMenu.swift; sourceTree = "<group>"; };
 		8AB8574727D97CD40075C173 /* HomePanelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePanelType.swift; sourceTree = "<group>"; };
 		8AB8574927D97CE90075C173 /* HomePanelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePanelDelegate.swift; sourceTree = "<group>"; };
+		8AD08D1427E9198E00B8E907 /* TabsQuantityTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsQuantityTelemetry.swift; sourceTree = "<group>"; };
+		8AD08D1627E91AC800B8E907 /* TabsQuantityTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsQuantityTelemetryTests.swift; sourceTree = "<group>"; };
 		8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotonActionSheetViewModel.swift; sourceTree = "<group>"; };
 		8AD40FC427BADC1E00672675 /* TabToolbarHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabToolbarHelper.swift; sourceTree = "<group>"; };
 		8AD40FC627BADC3400672675 /* ToolbarTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolbarTextField.swift; sourceTree = "<group>"; };
@@ -6452,6 +6456,7 @@
 				43175DB726B87D2C00C41C31 /* AdsTelemetryHelper.swift */,
 				43F7952425795F69005AEE40 /* SearchTelemetry.swift */,
 				EBF47E6F1F7979DF00899189 /* TelemetryWrapper.swift */,
+				8AD08D1427E9198E00B8E907 /* TabsQuantityTelemetry.swift */,
 			);
 			path = Telemetry;
 			sourceTree = "<group>";
@@ -6763,6 +6768,7 @@
 				213B67A727CE721E000542F5 /* StartAtHomeHelperTests.swift */,
 				215B458327DA87FC00E5E800 /* TabMetadataManagerTests.swift */,
 				8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */,
+				8AD08D1627E91AC800B8E907 /* TabsQuantityTelemetryTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -8882,6 +8888,7 @@
 				C8364D7927AAC46700D0A4F0 /* WallpaperSettingsViewModel.swift in Sources */,
 				0BB5B30B1AC0AD1F0052877D /* LoginsHelper.swift in Sources */,
 				C87DF9DB267247190097E707 /* UIConstants+BottomInset.swift in Sources */,
+				8AD08D1527E9198E00B8E907 /* TabsQuantityTelemetry.swift in Sources */,
 				C86E4F712493BA8E0087BFD9 /* Metrics.swift in Sources */,
 				1DA3CE6324EEE83200422BB2 /* SavedTab+ConfigureExtension.swift in Sources */,
 				C87DC85627B2C8B0006EFCE2 /* WallpaperNetworkUtility.swift in Sources */,
@@ -9172,6 +9179,7 @@
 				E60D032A1D5118DB002FE3F6 /* SyncStatusResolverTests.swift in Sources */,
 				8ADED7F0276A7788009C19E6 /* CumulativeDaysOfUseCounterTests.swift in Sources */,
 				E683F0A61E92E0820035D990 /* MockableHistory.swift in Sources */,
+				8AD08D1727E91AC800B8E907 /* TabsQuantityTelemetryTests.swift in Sources */,
 				D815A3A824A53F3200AAB221 /* TabToolbarHelperTests.swift in Sources */,
 				C8445AD126443C7F00B83F53 /* LibraryPanelViewStateTests.swift in Sources */,
 				A83E5B1E1C1DAAAA0026D912 /* UIPasteboardExtensions.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -172,6 +172,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationWillTerminate(_ application: UIApplication) {
+        TelemetryWrapper.recordWillTerminatePreferenceMetrics()
+
         // We have only five seconds here, so let's hope this doesn't take too long.
         profile?._shutdown()
 

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -286,8 +286,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         updateSessionCount()
         adjustHelper?.setupAdjust()
 
-        
-
         return shouldPerformAdditionalDelegateHandling
     }
 

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -172,8 +172,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationWillTerminate(_ application: UIApplication) {
-        TelemetryWrapper.recordWillTerminatePreferenceMetrics()
-
         // We have only five seconds here, so let's hope this doesn't take too long.
         profile?._shutdown()
 
@@ -287,6 +285,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         updateSessionCount()
         adjustHelper?.setupAdjust()
+
+        
 
         return shouldPerformAdditionalDelegateHandling
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -87,6 +87,8 @@ class BrowserViewController: UIViewController {
     weak var gridTabTrayController: GridTabViewController?
     weak var chronTabTrayController: ChronologicalTabsViewController?
     var tabTrayViewController: TabTrayViewController?
+    private var tabsQuantityTelemetry = TabsQuantityTelemetry()
+
     let profile: Profile
     let tabManager: TabManager
     let ratingPromptManager: RatingPromptManager
@@ -516,6 +518,8 @@ class BrowserViewController: UIViewController {
         showQueuedAlertIfAvailable()
 
         prepareURLOnboardingContextualHint()
+
+        tabsQuantityTelemetry.trackTabsQuantity(tabManager: tabManager)
     }
 
     private func prepareURLOnboardingContextualHint() {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -87,7 +87,6 @@ class BrowserViewController: UIViewController {
     weak var gridTabTrayController: GridTabViewController?
     weak var chronTabTrayController: ChronologicalTabsViewController?
     var tabTrayViewController: TabTrayViewController?
-    private var tabsQuantityTelemetry = TabsQuantityTelemetry()
 
     let profile: Profile
     let tabManager: TabManager
@@ -519,7 +518,7 @@ class BrowserViewController: UIViewController {
 
         prepareURLOnboardingContextualHint()
 
-        tabsQuantityTelemetry.trackTabsQuantity(tabManager: tabManager)
+        TabsQuantityTelemetry.trackTabsQuantity(tabManager: tabManager)
     }
 
     private func prepareURLOnboardingContextualHint() {

--- a/Client/Telemetry/TabsQuantityTelemetry.swift
+++ b/Client/Telemetry/TabsQuantityTelemetry.swift
@@ -4,21 +4,9 @@
 
 import Foundation
 
-final class TabsQuantityTelemetry {
+struct TabsQuantityTelemetry {
 
-    var notificationCenter = NotificationCenter.default
-
-    init() {
-        setupNotifications(forObserver: self, observing: [UIApplication.didFinishLaunchingNotification])
-    }
-
-    deinit {
-        notificationCenter.removeObserver(self)
-    }
-
-    func trackTabsQuantity(tabManager: TabManager) {
-        guard !TabsQuantityTelemetry.quantitySent else { return }
-
+    static func trackTabsQuantity(tabManager: TabManager) {
         let privateExtra = [TelemetryWrapper.EventExtraKey.tabsQuantity.rawValue: Int64(tabManager.privateTabs.count)]
         TelemetryWrapper.recordEvent(category: .information,
                                      method: .background,
@@ -30,31 +18,5 @@ final class TabsQuantityTelemetry {
                                      method: .background,
                                      object: .tabNormalQuantity,
                                      extras: normalExtra)
-
-        TabsQuantityTelemetry.quantitySent = true
-    }
-
-
-    // MARK: UserDefaults
-
-    /// Make sure we only send the tabs quantity once per app lifecycle
-    static var quantitySent: Bool {
-        get { UserDefaults.standard.object(forKey: UserDefaultsKey.tabsQuantitySent.rawValue) as? Bool ?? false }
-        set { UserDefaults.standard.set(newValue, forKey: UserDefaultsKey.tabsQuantitySent.rawValue) }
-    }
-
-    private enum UserDefaultsKey: String {
-        case tabsQuantitySent = "com.moz.tabsQuantitySent.key"
-    }
-}
-
-// MARK: - Notifiable
-extension TabsQuantityTelemetry: Notifiable {
-    func handleNotifications(_ notification: Notification) {
-        switch notification.name {
-        case UIApplication.didFinishLaunchingNotification:
-            TabsQuantityTelemetry.quantitySent = false
-        default: break
-        }
     }
 }

--- a/Client/Telemetry/TabsQuantityTelemetry.swift
+++ b/Client/Telemetry/TabsQuantityTelemetry.swift
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+final class TabsQuantityTelemetry {
+
+    var notificationCenter = NotificationCenter.default
+
+    init() {
+        setupNotifications(forObserver: self, observing: [UIApplication.didFinishLaunchingNotification])
+    }
+
+    deinit {
+        notificationCenter.removeObserver(self)
+    }
+
+    func trackTabsQuantity(tabManager: TabManager) {
+        guard !TabsQuantityTelemetry.quantitySent else { return }
+
+        let privateExtra = [TelemetryWrapper.EventExtraKey.tabsQuantity.rawValue: Int64(tabManager.privateTabs.count)]
+        TelemetryWrapper.recordEvent(category: .information,
+                                     method: .background,
+                                     object: .tabPrivateQuantity,
+                                     extras: privateExtra)
+
+        let normalExtra = [TelemetryWrapper.EventExtraKey.tabsQuantity.rawValue: Int64(tabManager.normalTabs.count)]
+        TelemetryWrapper.recordEvent(category: .information,
+                                     method: .background,
+                                     object: .tabNormalQuantity,
+                                     extras: normalExtra)
+
+        TabsQuantityTelemetry.quantitySent = true
+    }
+
+
+    // MARK: UserDefaults
+
+    /// Make sure we only send the tabs quantity once per app lifecycle
+    static var quantitySent: Bool {
+        get { UserDefaults.standard.object(forKey: UserDefaultsKey.tabsQuantitySent.rawValue) as? Bool ?? false }
+        set { UserDefaults.standard.set(newValue, forKey: UserDefaultsKey.tabsQuantitySent.rawValue) }
+    }
+
+    private enum UserDefaultsKey: String {
+        case tabsQuantitySent = "com.moz.tabsQuantitySent.key"
+    }
+}
+
+// MARK: - Notifiable
+extension TabsQuantityTelemetry: Notifiable {
+    func handleNotifications(_ notification: Notification) {
+        switch notification.name {
+        case UIApplication.didFinishLaunchingNotification:
+            TabsQuantityTelemetry.quantitySent = false
+        default: break
+        }
+    }
+}

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -151,7 +151,7 @@ class TelemetryWrapper {
         // record on going to background rather than during initialization.
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(recordPreferenceMetrics(notification:)),
+            selector: #selector(recordEnteredBackgroundPreferenceMetrics(notification:)),
             name: UIApplication.didEnterBackgroundNotification,
             object: nil
         )
@@ -172,7 +172,7 @@ class TelemetryWrapper {
 
     // Function for recording metrics that are better recorded when going to background due
     // to the particular measurement, or availability of the information.
-    @objc func recordPreferenceMetrics(notification: NSNotification) {
+    @objc func recordEnteredBackgroundPreferenceMetrics(notification: NSNotification) {
         guard let profile = self.profile else { assert(false); return; }
 
         // Record default search engine setting
@@ -250,6 +250,19 @@ class TelemetryWrapper {
         GleanMetrics.InstalledMozillaProducts.klar.set(UIApplication.shared.canOpenURL(URL(string: "firefox-klar://")!))
         // Device Authentication
         GleanMetrics.Device.authentication.set(AppAuthenticator.canAuthenticateDeviceOwner())
+    }
+
+    // Function for recording metrics that are better recorded when terminating the application
+    static func recordWillTerminatePreferenceMetrics() {
+
+        let delegate = UIApplication.shared.delegate as? AppDelegate
+        if let normalTabsQuantity = delegate?.tabManager.normalTabs.count {
+            GleanMetrics.Tabs.normalTabsQuantity.set(Int64(normalTabsQuantity))
+        }
+
+        if let privateTabsQuantity = delegate?.tabManager.privateTabs.count {
+            GleanMetrics.Tabs.privateTabsQuantity.set(Int64(privateTabsQuantity))
+        }
     }
 
     @objc func uploadError(notification: NSNotification) {

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -1437,6 +1437,32 @@ sync:
 
 # Tab metrics
 tabs:
+  normal_tabs_quantity:
+    type: quantity
+    description: |
+      A snapshot of how many normal tabs a user has opened when he
+      closes the application.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/9627
+    data_reviews:
+      - TODO
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2022-09-21"
+    unit: quantity of normal tabs
+  private_tabs_quantity:
+    type: quantity
+    description: |
+      A snapshot of how many private tabs a user has opened when he
+      closes the application.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/9627
+    data_reviews:
+      - TODO
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2022-09-21"
+    unit: quantity of private tabs
   cumulative_count:
     type: counter
     description: |

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -1445,7 +1445,7 @@ tabs:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/9627
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10272
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2022-09-21"
@@ -1458,7 +1458,7 @@ tabs:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/9627
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10272
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2022-09-21"

--- a/ClientTests/TabsQuantityTelemetryTests.swift
+++ b/ClientTests/TabsQuantityTelemetryTests.swift
@@ -15,8 +15,8 @@ class TabsQuantityTelemetryTests: XCTestCase {
 
         TabsQuantityTelemetry.trackTabsQuantity(tabManager: tabManager)
 
-        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.privateTabsQuantity, expectedValue: 0)
-        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.normalTabsQuantity, expectedValue: 1)
+        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.privateTabsQuantity, expectedValue: 0, "Should have 0 private tabs")
+        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.normalTabsQuantity, expectedValue: 1, "Should have 1 normal tab")
     }
 
     func testTrackTabsQuantity_withPrivateTab_gleanIsCalled() {
@@ -25,7 +25,7 @@ class TabsQuantityTelemetryTests: XCTestCase {
 
         TabsQuantityTelemetry.trackTabsQuantity(tabManager: tabManager)
 
-        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.privateTabsQuantity, expectedValue: 1)
-        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.normalTabsQuantity, expectedValue: 0)
+        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.privateTabsQuantity, expectedValue: 1, "Should have 1 private tab")
+        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.normalTabsQuantity, expectedValue: 0, "Should have 0 normal tabs")
     }
 }

--- a/ClientTests/TabsQuantityTelemetryTests.swift
+++ b/ClientTests/TabsQuantityTelemetryTests.swift
@@ -15,8 +15,13 @@ class TabsQuantityTelemetryTests: XCTestCase {
 
         TabsQuantityTelemetry.trackTabsQuantity(tabManager: tabManager)
 
-        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.privateTabsQuantity, expectedValue: 0, "Should have 0 private tabs")
-        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.normalTabsQuantity, expectedValue: 1, "Should have 1 normal tab")
+        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.privateTabsQuantity,
+                                  expectedValue: 0,
+                                  failureMessage: "Should have 0 private tabs")
+
+        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.normalTabsQuantity,
+                                  expectedValue: 1,
+                                  failureMessage: "Should have 1 normal tab")
     }
 
     func testTrackTabsQuantity_withPrivateTab_gleanIsCalled() {
@@ -25,7 +30,12 @@ class TabsQuantityTelemetryTests: XCTestCase {
 
         TabsQuantityTelemetry.trackTabsQuantity(tabManager: tabManager)
 
-        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.privateTabsQuantity, expectedValue: 1, "Should have 1 private tab")
-        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.normalTabsQuantity, expectedValue: 0, "Should have 0 normal tabs")
+        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.privateTabsQuantity,
+                                  expectedValue: 1,
+                                  failureMessage: "Should have 1 private tab")
+
+        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.normalTabsQuantity,
+                                  expectedValue: 0,
+                                  failureMessage: "Should have 0 normal tabs")
     }
 }

--- a/ClientTests/TabsQuantityTelemetryTests.swift
+++ b/ClientTests/TabsQuantityTelemetryTests.swift
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+import Glean
+import XCTest
+
+class TabsQuantityTelemetryTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        TabsQuantityTelemetry.quantitySent = false
+    }
+
+    func testTrackTabsQuantity_withNormalTab_gleanIsCalled() {
+        let tabManager = TabManager(profile: MockProfile(), imageStore: nil)
+        tabManager.addTab()
+
+        TabsQuantityTelemetry().trackTabsQuantity(tabManager: tabManager)
+
+        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.privateTabsQuantity, expectedValue: 0)
+        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.normalTabsQuantity, expectedValue: 1)
+    }
+
+    func testTrackTabsQuantity_withPrivateTab_gleanIsCalled() {
+        let tabManager = TabManager(profile: MockProfile(), imageStore: nil)
+        tabManager.addTab(isPrivate: true)
+
+        TabsQuantityTelemetry().trackTabsQuantity(tabManager: tabManager)
+
+        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.privateTabsQuantity, expectedValue: 1)
+        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.normalTabsQuantity, expectedValue: 0)
+    }
+
+    func testTrackTabsQuantity_quantityUserDefaultIsSet() {
+        let tabManager = TabManager(profile: MockProfile(), imageStore: nil)
+        XCTAssertFalse(TabsQuantityTelemetry.quantitySent)
+
+        TabsQuantityTelemetry().trackTabsQuantity(tabManager: tabManager)
+        XCTAssertTrue(TabsQuantityTelemetry.quantitySent)
+    }
+
+    func testTrackTabsQuantity_notificationResetQuantitySetUserDefault() {
+        expectation(forNotification: UIApplication.didFinishLaunchingNotification, object: nil, handler: nil)
+
+        let tabManager = TabManager(profile: MockProfile(), imageStore: nil)
+        TabsQuantityTelemetry().trackTabsQuantity(tabManager: tabManager)
+        XCTAssertTrue(TabsQuantityTelemetry.quantitySent)
+
+        NotificationCenter.default.post(name: UIApplication.didFinishLaunchingNotification, object: nil)
+        waitForExpectations(timeout: 0.1, handler: nil)
+
+        XCTAssertFalse(TabsQuantityTelemetry.quantitySent)
+    }
+}

--- a/ClientTests/TabsQuantityTelemetryTests.swift
+++ b/ClientTests/TabsQuantityTelemetryTests.swift
@@ -9,16 +9,11 @@ import XCTest
 
 class TabsQuantityTelemetryTests: XCTestCase {
 
-    override func setUp() {
-        super.setUp()
-        TabsQuantityTelemetry.quantitySent = false
-    }
-
     func testTrackTabsQuantity_withNormalTab_gleanIsCalled() {
         let tabManager = TabManager(profile: MockProfile(), imageStore: nil)
         tabManager.addTab()
 
-        TabsQuantityTelemetry().trackTabsQuantity(tabManager: tabManager)
+        TabsQuantityTelemetry.trackTabsQuantity(tabManager: tabManager)
 
         testQuantityMetricSuccess(metric: GleanMetrics.Tabs.privateTabsQuantity, expectedValue: 0)
         testQuantityMetricSuccess(metric: GleanMetrics.Tabs.normalTabsQuantity, expectedValue: 1)
@@ -28,30 +23,9 @@ class TabsQuantityTelemetryTests: XCTestCase {
         let tabManager = TabManager(profile: MockProfile(), imageStore: nil)
         tabManager.addTab(isPrivate: true)
 
-        TabsQuantityTelemetry().trackTabsQuantity(tabManager: tabManager)
+        TabsQuantityTelemetry.trackTabsQuantity(tabManager: tabManager)
 
         testQuantityMetricSuccess(metric: GleanMetrics.Tabs.privateTabsQuantity, expectedValue: 1)
         testQuantityMetricSuccess(metric: GleanMetrics.Tabs.normalTabsQuantity, expectedValue: 0)
-    }
-
-    func testTrackTabsQuantity_quantityUserDefaultIsSet() {
-        let tabManager = TabManager(profile: MockProfile(), imageStore: nil)
-        XCTAssertFalse(TabsQuantityTelemetry.quantitySent)
-
-        TabsQuantityTelemetry().trackTabsQuantity(tabManager: tabManager)
-        XCTAssertTrue(TabsQuantityTelemetry.quantitySent)
-    }
-
-    func testTrackTabsQuantity_notificationResetQuantitySetUserDefault() {
-        expectation(forNotification: UIApplication.didFinishLaunchingNotification, object: nil, handler: nil)
-
-        let tabManager = TabManager(profile: MockProfile(), imageStore: nil)
-        TabsQuantityTelemetry().trackTabsQuantity(tabManager: tabManager)
-        XCTAssertTrue(TabsQuantityTelemetry.quantitySent)
-
-        NotificationCenter.default.post(name: UIApplication.didFinishLaunchingNotification, object: nil)
-        waitForExpectations(timeout: 0.1, handler: nil)
-
-        XCTAssertFalse(TabsQuantityTelemetry.quantitySent)
     }
 }

--- a/ClientTests/TabsQuantityTelemetryTests.swift
+++ b/ClientTests/TabsQuantityTelemetryTests.swift
@@ -9,6 +9,12 @@ import XCTest
 
 class TabsQuantityTelemetryTests: XCTestCase {
 
+    override func setUp() {
+        super.setUp()
+
+        Glean.shared.resetGlean(clearStores: true)
+    }
+
     func testTrackTabsQuantity_withNormalTab_gleanIsCalled() {
         let tabManager = TabManager(profile: MockProfile(), imageStore: nil)
         tabManager.addTab()

--- a/ClientTests/TelemetryWrapperTests.swift
+++ b/ClientTests/TelemetryWrapperTests.swift
@@ -123,15 +123,35 @@ class TelemetryWrapperTests: XCTestCase {
 
     // MARK: - Tabs quantity
 
-    func test_tabsQuantityAreRecorded() {
-        TelemetryWrapper.recordWillTerminatePreferenceMetrics()
-        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.normalTabsQuantity, expectedValue: 0)
-        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.privateTabsQuantity, expectedValue: 0)
+    func test_tabsNormalQuantity_GleanIsCalled() {
+        let expectTabCount: Int64 = 80
+        let extra = [TelemetryWrapper.EventExtraKey.tabsQuantity.rawValue: expectTabCount]
+        TelemetryWrapper.recordEvent(category: .information, method: .background, object: .tabNormalQuantity, value: nil, extras: extra)
+
+        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.normalTabsQuantity, expectedValue: expectTabCount)
+    }
+
+    func test_tabsPrivateQuantity_GleanIsCalled() {
+        let expectTabCount: Int64 = 60
+        let extra = [TelemetryWrapper.EventExtraKey.tabsQuantity.rawValue: expectTabCount]
+        TelemetryWrapper.recordEvent(category: .information, method: .background, object: .tabPrivateQuantity, value: nil, extras: extra)
+
+        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.privateTabsQuantity, expectedValue: expectTabCount)
+    }
+
+    func test_tabsNormalQuantityWithoutExtras_GleanIsNotCalled() {
+        TelemetryWrapper.recordEvent(category: .information, method: .background, object: .tabNormalQuantity, value: nil, extras: nil)
+        XCTAssertFalse(GleanMetrics.Tabs.normalTabsQuantity.testHasValue())
+    }
+
+    func test_tabsPrivateQuantityWithoutExtras_GleanIsNotCalled() {
+        TelemetryWrapper.recordEvent(category: .information, method: .background, object: .tabPrivateQuantity, value: nil, extras: nil)
+        XCTAssertFalse(GleanMetrics.Tabs.privateTabsQuantity.testHasValue())
     }
 }
 
-// MARK: - Helper functions
-extension TelemetryWrapperTests {
+// MARK: - Helper functions to test telemetry
+extension XCTestCase {
 
     func testEventMetricRecordingSuccess<Keys: ExtraKeys, Extras: EventExtras>(metric: EventMetricType<Keys, Extras>,
                                                                                file: StaticString = #file,

--- a/ClientTests/TelemetryWrapperTests.swift
+++ b/ClientTests/TelemetryWrapperTests.swift
@@ -128,7 +128,9 @@ class TelemetryWrapperTests: XCTestCase {
         let extra = [TelemetryWrapper.EventExtraKey.tabsQuantity.rawValue: expectTabCount]
         TelemetryWrapper.recordEvent(category: .information, method: .background, object: .tabNormalQuantity, value: nil, extras: extra)
 
-        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.normalTabsQuantity, expectedValue: expectTabCount)
+        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.normalTabsQuantity,
+                                  expectedValue: expectTabCount,
+                                  failureMessage: "Should have \(expectTabCount) tabs for normal tabs")
     }
 
     func test_tabsPrivateQuantity_GleanIsCalled() {
@@ -136,7 +138,9 @@ class TelemetryWrapperTests: XCTestCase {
         let extra = [TelemetryWrapper.EventExtraKey.tabsQuantity.rawValue: expectTabCount]
         TelemetryWrapper.recordEvent(category: .information, method: .background, object: .tabPrivateQuantity, value: nil, extras: extra)
 
-        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.privateTabsQuantity, expectedValue: expectTabCount)
+        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.privateTabsQuantity,
+                                  expectedValue: expectTabCount,
+                                  failureMessage: "Should have \(expectTabCount) tabs for private tabs")
     }
 
     func test_tabsNormalQuantityWithoutExtras_GleanIsNotCalled() {
@@ -188,10 +192,11 @@ extension XCTestCase {
 
     func testQuantityMetricSuccess(metric: QuantityMetricType,
                                    expectedValue: Int64,
+                                   failureMessage: String,
                                    file: StaticString = #file,
                                    line: UInt = #line) {
-        XCTAssertTrue(metric.testHasValue())
-        XCTAssertEqual(try! metric.testGetValue(), expectedValue)
+        XCTAssertTrue(metric.testHasValue(), "Should have value on quantity metric")
+        XCTAssertEqual(try! metric.testGetValue(), expectedValue, failureMessage)
 
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0)
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0)

--- a/ClientTests/TelemetryWrapperTests.swift
+++ b/ClientTests/TelemetryWrapperTests.swift
@@ -15,7 +15,7 @@ class TelemetryWrapperTests: XCTestCase {
         Glean.shared.resetGlean(clearStores: true)
     }
 
-    // MARK: Top Site
+    // MARK: - Top Site
 
     func test_topSiteTileWithExtras_GleanIsCalled() {
         let topSitePositionKey = TelemetryWrapper.EventExtraKey.topSitePosition.rawValue
@@ -31,7 +31,7 @@ class TelemetryWrapperTests: XCTestCase {
         XCTAssertFalse(GleanMetrics.TopSite.tilePressed.testHasValue())
     }
 
-    // MARK: Preferences
+    // MARK: - Preferences
 
     func test_preferencesWithExtras_GleanIsCalled() {
         let extras: [String : Any] = [TelemetryWrapper.EventExtraKey.preference.rawValue: "ETP-strength",
@@ -46,7 +46,7 @@ class TelemetryWrapperTests: XCTestCase {
         XCTAssertFalse(GleanMetrics.Preferences.changed.testHasValue())
     }
 
-    // MARK: Firefox Home Page
+    // MARK: - Firefox Home Page
 
     func test_recentlySavedBookmarkViewWithExtras_GleanIsCalled() {
         let extras: [String : Any] = [TelemetryWrapper.EventObject.recentlySavedBookmarkImpressions.rawValue: "\([].count)"]
@@ -79,7 +79,7 @@ class TelemetryWrapperTests: XCTestCase {
         testLabeledMetricSuccess(metric: GleanMetrics.FirefoxHomePage.firefoxHomepageOrigin)
     }
 
-    // MARK: CFR Analytics
+    // MARK: - CFR Analytics
 
     func test_contextualHintDismissButton_GleanIsCalled() {
         let extra = [TelemetryWrapper.EventExtraKey.cfrType.rawValue: ContextualHintViewType.toolbarLocation.rawValue]
@@ -116,9 +116,17 @@ class TelemetryWrapperTests: XCTestCase {
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .contextualHint, value: .pressCFRActionButton)
         XCTAssertFalse(GleanMetrics.CfrAnalytics.pressCfrActionButton.testHasValue())
     }
+
+    // MARK: - Tabs quantity
+
+    func test_tabsQuantityAreRecorded() {
+        TelemetryWrapper.recordWillTerminatePreferenceMetrics()
+        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.normalTabsQuantity, expectedValue: 1)
+        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.privateTabsQuantity, expectedValue: 0)
+    }
 }
 
-// Helper functions
+// MARK: - Helper functions
 extension TelemetryWrapperTests {
 
     func testEventMetricRecordingSuccess<Keys: ExtraKeys, Extras: EventExtras>(metric: EventMetricType<Keys, Extras>,
@@ -148,6 +156,19 @@ extension TelemetryWrapperTests {
     func testLabeledMetricSuccess(metric: LabeledMetricType<CounterMetricType>,
                                   file: StaticString = #file,
                                   line: UInt = #line) {
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidState), 0)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidValue), 0)
+    }
+
+    func testQuantityMetricSuccess(metric: QuantityMetricType,
+                                   expectedValue: Int64,
+                                   file: StaticString = #file,
+                                   line: UInt = #line) {
+        XCTAssertTrue(metric.testHasValue())
+        XCTAssertEqual(try! metric.testGetValue(), expectedValue)
+
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0)
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0)
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidState), 0)

--- a/ClientTests/TelemetryWrapperTests.swift
+++ b/ClientTests/TelemetryWrapperTests.swift
@@ -13,10 +13,6 @@ class TelemetryWrapperTests: XCTestCase {
         super.setUp()
 
         Glean.shared.resetGlean(clearStores: true)
-
-        // Ensure tab manager has clean state for tests
-        let delegate = UIApplication.shared.delegate as? AppDelegate
-        delegate?.tabManager.removeAll()
     }
 
     // MARK: - Top Site

--- a/ClientTests/TelemetryWrapperTests.swift
+++ b/ClientTests/TelemetryWrapperTests.swift
@@ -125,7 +125,7 @@ class TelemetryWrapperTests: XCTestCase {
 
     func test_tabsQuantityAreRecorded() {
         TelemetryWrapper.recordWillTerminatePreferenceMetrics()
-        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.normalTabsQuantity, expectedValue: 1)
+        testQuantityMetricSuccess(metric: GleanMetrics.Tabs.normalTabsQuantity, expectedValue: 0)
         testQuantityMetricSuccess(metric: GleanMetrics.Tabs.privateTabsQuantity, expectedValue: 0)
     }
 }

--- a/ClientTests/TelemetryWrapperTests.swift
+++ b/ClientTests/TelemetryWrapperTests.swift
@@ -13,6 +13,10 @@ class TelemetryWrapperTests: XCTestCase {
         super.setUp()
 
         Glean.shared.resetGlean(clearStores: true)
+
+        // Ensure tab manager has clean state for tests
+        let delegate = UIApplication.shared.delegate as? AppDelegate
+        delegate?.tabManager.removeAll()
     }
 
     // MARK: - Top Site


### PR DESCRIPTION
# Issue [#9627](https://github.com/mozilla-mobile/firefox-ios/issues/9627)
- Adding quantity telemetry for normal and private tabs
- Only sending when killing the app to avoid sending too much to Glean (so once per app lifecycle)