### PR TITLE
Bugfix fx3948 [v99] Reloading data after long press action on top sites

### DIFF
--- a/Client/Frontend/Home/FirefoxHomeViewModel.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewModel.swift
@@ -144,7 +144,6 @@ class FirefoxHomeViewModel: FeatureFlagsProtocol {
 
 extension FirefoxHomeViewModel: FxHomeTopSitesViewModelDelegate {
     func reloadTopSites() {
-        let index = enabledSections.firstIndex(of: FirefoxHomeSectionType.topSites)
-        delegate?.reloadSection(index: index)
+        update(section: topSiteViewModel)
     }
 }


### PR DESCRIPTION
# Issue #10278
Fixing reload of top sites when we do long presses. 