### PR TITLE
Bugfix [v99] Remove duplicate .historyGroups for history

### DIFF
--- a/Client/FeatureFlags/FeatureFlagsManager.swift
+++ b/Client/FeatureFlags/FeatureFlagsManager.swift
@@ -191,11 +191,6 @@ class FeatureFlagsManager {
 
         features[.reportSiteIssue] = reportSiteIssue
 
-        let historySearchTermGroups = FlaggableFeature(withID: .historyGroups,
-                                                       and: profile,
-                                                       enabledFor: [.developer])
-        features[.historyGroups] = historySearchTermGroups
-
         let shakeToRestore = FlaggableFeature(withID: .shakeToRestore,
                                               and: profile,
                                               enabledFor: [.beta, .developer, .other])

--- a/Client/Frontend/Library/LibraryPanels.swift
+++ b/Client/Frontend/Library/LibraryPanels.swift
@@ -76,8 +76,6 @@ class LibraryPanelDescriptor {
     }
 }
 
-//featureFlags.isFeatureActiveForBuild(.historyGroups)
-
 class LibraryPanels: FeatureFlagsProtocol {
     fileprivate let profile: Profile
     fileprivate let tabManager: TabManager


### PR DESCRIPTION
Remove duplicate feature flag for .historyGroups + remove commented code