### PR TITLE
Bumps AS megazord and FML to 93.0.4

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -25,8 +25,8 @@ messaging:
       type: string
       description: What should be displayed when a control message is selected.
       enum:
-        - show-none
         - show-next-message
+        - show-none
     styles:
       type: json
       description: "A map of styles to configure message appearance.\n"

--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -25,8 +25,8 @@ messaging:
       type: string
       description: What should be displayed when a control message is selected.
       enum:
-        - show-next-message
         - show-none
+        - show-next-message
     styles:
       type: json
       description: "A map of styles to configure message appearance.\n"

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14155,7 +14155,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 92.0.0;
+				version = 92.0.1;
 			};
 		};
 		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14147,7 +14147,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 92.0.1;
+				version = 93.0.1;
 			};
 		};
 		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {
@@ -14301,7 +14301,6 @@
 		};
 		43EFA63D2786562600400DF0 /* Places */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1BE9ECAA271765C800D729BB /* XCRemoteSwiftPackageReference "rust-components-swift" */;
 			productName = Places;
 		};
 		5FA2233B27F74071005B3D87 /* Glean */ = {

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14118,14 +14118,6 @@
 				version = 1.18.0;
 			};
 		};
-		1BE9ECAA271765C800D729BB /* XCRemoteSwiftPackageReference "rust-components-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/mozilla/rust-components-swift";
-			requirement = {
-				kind = exactVersion;
-				version = 92.0.0;
-			};
-		};
 		432BD0222790EBD000A0F3C3 /* XCRemoteSwiftPackageReference "ios_sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/adjust/ios_sdk.git";

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14123,7 +14123,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 91.0.1;
+				version = 92.0.0;
 			};
 		};
 		432BD0222790EBD000A0F3C3 /* XCRemoteSwiftPackageReference "ios_sdk" */ = {
@@ -14155,7 +14155,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 91.1.0;
+				version = 92.0.0;
 			};
 		};
 		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14147,7 +14147,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 93.0.2;
+				version = 93.0.4;
 			};
 		};
 		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14147,7 +14147,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 93.0.1;
+				version = 93.0.2;
 			};
 		};
 		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/mozilla/rust-components-swift.git",
         "state": {
           "branch": null,
-          "revision": "543268694abee0415ea09a90880cfc5e891c1314",
-          "version": "92.0.0"
+          "revision": "603262d1e1448c8dd00000552dcc051b320b7074",
+          "version": "92.0.1"
         }
       },
       {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/mozilla/rust-components-swift.git",
         "state": {
           "branch": null,
-          "revision": "be7deba341d03d5d7049649504092264f4a6a8f0",
-          "version": "93.0.2"
+          "revision": "dfd17f5d50d0d61efa9d026004fbf9ce7f77295b",
+          "version": "93.0.4"
         }
       },
       {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/nbhasin2/GCDWebServer.git",
         "state": {
           "branch": "master",
-          "revision": "7674c93e79ee5aac17681acace324761325e7346",
+          "revision": "14f9eedb296c5b71fec971d8256ef3bfc20a2245",
           "version": null
         }
       },
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/mozilla/rust-components-swift.git",
         "state": {
           "branch": null,
-          "revision": "29772c84fd7dd17c9f2981c51ea4ccc04e353b32",
-          "version": "91.1.0"
+          "revision": "543268694abee0415ea09a90880cfc5e891c1314",
+          "version": "92.0.0"
         }
       },
       {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/mozilla/rust-components-swift.git",
         "state": {
           "branch": null,
-          "revision": "c53e3ccb0fa791bfc4f807be7e2d0f19f59af046",
-          "version": "93.0.1"
+          "revision": "be7deba341d03d5d7049649504092264f4a6a8f0",
+          "version": "93.0.2"
         }
       },
       {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/mozilla/rust-components-swift.git",
         "state": {
           "branch": null,
-          "revision": "603262d1e1448c8dd00000552dcc051b320b7074",
-          "version": "92.0.1"
+          "revision": "c53e3ccb0fa791bfc4f807be7e2d0f19f59af046",
+          "version": "93.0.1"
         }
       },
       {

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -5,7 +5,7 @@
 import UIKit
 import Shared
 import Storage
-import MozillaAppServices
+import Glean
 import Telemetry
 
 private enum SearchListSection: Int, CaseIterable {

--- a/Storage/Rust/RustPlaces.swift
+++ b/Storage/Rust/RustPlaces.swift
@@ -37,12 +37,7 @@ public class RustPlaces {
             return nil
         } catch let err as NSError {
             if let placesError = err as? PlacesError {
-                switch placesError {
-                case .InternalPanic(let message):
-                    SentryIntegration.shared.sendWithStacktrace(message: "Panicked when opening Rust Places database", tag: SentryTag.rustPlaces, severity: .error, description: message)
-                default:
-                    SentryIntegration.shared.sendWithStacktrace(message: "Unspecified or other error when opening Rust Places database", tag: SentryTag.rustPlaces, severity: .error, description: placesError.localizedDescription)
-                }
+                Sentry.shared.sendWithStacktrace(message: "Places error when opening Rust Places database", tag: SentryTag.rustPlaces, severity: .error, description: placesError.localizedDescription)
             } else {
                 SentryIntegration.shared.sendWithStacktrace(message: "Unknown error when opening Rust Places database", tag: SentryTag.rustPlaces, severity: .error, description: err.localizedDescription)
             }
@@ -267,14 +262,9 @@ public class RustPlaces {
         return error
     }
 
-    public func interrupt() {
-        api?.interrupt()
-    }
-
     public func forceClose() -> NSError? {
         var error: NSError? = nil
 
-        api?.interrupt()
 
         writerQueue.sync {
             guard isOpen else { return }
@@ -299,12 +289,9 @@ public class RustPlaces {
                 deferred.fill(Maybe(success: ()))
             } catch let err as NSError {
                 if let placesError = err as? PlacesError {
-                    switch placesError {
-                    case .InternalPanic(let message):
-                        SentryIntegration.shared.sendWithStacktrace(message: "Panicked when syncing Places database", tag: SentryTag.rustPlaces, severity: .error, description: message)
-                    default:
-                        SentryIntegration.shared.sendWithStacktrace(message: "Unspecified or other error when syncing Places database", tag: SentryTag.rustPlaces, severity: .error, description: placesError.localizedDescription)
-                    }
+                    Sentry.shared.sendWithStacktrace(message: "Places error when syncing Places database", tag: SentryTag.rustPlaces, severity: .error, description: placesError.localizedDescription)
+                } else {
+                    Sentry.shared.sendWithStacktrace(message: "Unknown error when opening Rust Places database", tag: SentryTag.rustPlaces, severity: .error, description: err.localizedDescription)
                 }
 
                 deferred.fill(Maybe(failure: err))

--- a/Storage/Rust/RustPlaces.swift
+++ b/Storage/Rust/RustPlaces.swift
@@ -37,7 +37,7 @@ public class RustPlaces {
             return nil
         } catch let err as NSError {
             if let placesError = err as? PlacesError {
-                Sentry.shared.sendWithStacktrace(message: "Places error when opening Rust Places database", tag: SentryTag.rustPlaces, severity: .error, description: placesError.localizedDescription)
+                SentryIntegration.shared.sendWithStacktrace(message: "Places error when opening Rust Places database", tag: SentryTag.rustPlaces, severity: .error, description: placesError.localizedDescription)
             } else {
                 SentryIntegration.shared.sendWithStacktrace(message: "Unknown error when opening Rust Places database", tag: SentryTag.rustPlaces, severity: .error, description: err.localizedDescription)
             }
@@ -289,9 +289,9 @@ public class RustPlaces {
                 deferred.fill(Maybe(success: ()))
             } catch let err as NSError {
                 if let placesError = err as? PlacesError {
-                    Sentry.shared.sendWithStacktrace(message: "Places error when syncing Places database", tag: SentryTag.rustPlaces, severity: .error, description: placesError.localizedDescription)
+                    SentryIntegration.shared.sendWithStacktrace(message: "Places error when syncing Places database", tag: SentryTag.rustPlaces, severity: .error, description: placesError.localizedDescription)
                 } else {
-                    Sentry.shared.sendWithStacktrace(message: "Unknown error when opening Rust Places database", tag: SentryTag.rustPlaces, severity: .error, description: err.localizedDescription)
+                    SentryIntegration.shared.sendWithStacktrace(message: "Unknown error when opening Rust Places database", tag: SentryTag.rustPlaces, severity: .error, description: err.localizedDescription)
                 }
 
                 deferred.fill(Maybe(failure: err))

--- a/Storage/Rust/RustPlaces.swift
+++ b/Storage/Rust/RustPlaces.swift
@@ -265,7 +265,6 @@ public class RustPlaces {
     public func forceClose() -> NSError? {
         var error: NSError? = nil
 
-
         writerQueue.sync {
             guard isOpen else { return }
 

--- a/bin/nimbus-fml.sh
+++ b/bin/nimbus-fml.sh
@@ -60,7 +60,7 @@ helptext() {
 MANIFEST_PATH=
 OUTPUT_DIR="${SOURCE_ROOT}/${PROJECT}/Generated"
 NAMESPACE=
-AS_VERSION=v93.0.2
+AS_VERSION=v93.0.4
 FRESHEN_FML=
 
 while (( "$#" )); do

--- a/bin/nimbus-fml.sh
+++ b/bin/nimbus-fml.sh
@@ -60,7 +60,7 @@ helptext() {
 MANIFEST_PATH=
 OUTPUT_DIR="${SOURCE_ROOT}/${PROJECT}/Generated"
 NAMESPACE=
-AS_VERSION=v92.0.1
+AS_VERSION=v93.0.1
 FRESHEN_FML=
 
 while (( "$#" )); do

--- a/bin/nimbus-fml.sh
+++ b/bin/nimbus-fml.sh
@@ -60,7 +60,7 @@ helptext() {
 MANIFEST_PATH=
 OUTPUT_DIR="${SOURCE_ROOT}/${PROJECT}/Generated"
 NAMESPACE=
-AS_VERSION=v93.0.1
+AS_VERSION=v93.0.2
 FRESHEN_FML=
 
 while (( "$#" )); do


### PR DESCRIPTION
Bumps both the application services megazord and the FML to 93.0.4

There were a couple of breaking changes, but no changes in behaviour with those ones.

For the `InternalPanic` error, it was deceiving, it was **not** catching panics. I filed a bug on our side to [expose the panics](
https://github.com/mozilla/uniffi-rs/issues/1192), but for now, cleared up the error messages to reflect what the errors are.

Relevant changelogs for this PR: 
# v93.0.4 (_2022-04-28_)

[Full Changelog](https://github.com/mozilla/application-services/compare/v93.0.3...v93.0.4)

## Places
### What's New
- The `delete_visits_for()` function now deletes all history metadata even when the item is
  bookmarked.

## Nimbus
### What's fixed
- Fixed a bug where the visibility of `GetSdk` was internal and it was used in generated FML code. ([#4927](https://github.com/mozilla/application-services/pull/4927))

# v93.0.3 (_2022-04-27_)

[Full Changelog](https://github.com/mozilla/application-services/compare/v93.0.2...v93.0.3)

## Nimbus ⛅️🔭🔬

### What's New
  - Added targeting attributes for `language` and `region`, based upon the `locale`. [#4919](https://github.com/mozilla/application-services/pull/4919)
    - This also comes with an update in the JEXL evaluator to handle cases where `region` is not available.

### What's Changed
  - Fixed: A crash was detected by the iOS team, which was traced to `FeatureHolder.swift`. ([#4924](https://github.com/mozilla/application-services/pull/4924))
    - Regression tests added, and FeatureHolder made stateless in both Swift and Kotlin.

# v93.0.2 (_2022-04-25_)

[Full Changelog](https://github.com/mozilla/application-services/compare/v93.0.1...v93.0.2)

## Nimbus FML
### What's fixed
- (iOS only) Made the extensions on `String` and `Variables` public. The extended functions are used in the generated code and that didn't compile in consumers when internal.

# v93.0.1 (_2022-04-20_)

[Full Changelog](https://github.com/mozilla/application-services/compare/v93.0.0...v93.0.1)

## Nimbus FML ⛅️🔬🔭🔧

### What's Fixed
  - Handling of optional types which require a mapping to a usable type. ([#4915](https://github.com/mozilla/application-services/pull/4915))

## Places

- Downgraded places `get_registered_sync_engine` `log:error` to `log:warn` to fix an issue where places was unnecessarily creating sentry noise. This change was also cherry-picked to [v91.1.2](#v9112-2022-04-19)

# v93.0.0 (_2022-04-13_)

[Full Changelog](https://github.com/mozilla/application-services/compare/v92.0.1...v93.0.0)

## Nimbus ⛅️🔭🔬 + Nimbus FML ⛅️🔬🔭🔧

### What's New

- Add support for bundled resources in the FML in Swift. This corresponds to the `Image` and `Text` types. [#4892](https://github.com/mozilla/application-services/pull/4892)
  - This must include an update to the megazord, as well re-downloading the `nimbus-fml` binary.
  - Kotlin support for the same has also changed to match the Swift implementation, which has increased performance.

 # v92.0.0 (_2022-03-17_)

[Full Changelog](https://github.com/mozilla/application-services/compare/v91.1.0...v92.0.0)

## Places
### ⚠️ Breaking Changes ⚠️
- Removed some functions related to sync interruption.  These were never really completed and don't seem to be in use by iOS/Android code:
  - `PlacesApi.new_sync_conn_interrupt_handle()`
  - Swift only: `PlacesAPI.interrupt()`
- The exception variant `InternalPanic` was removed. It's only use was replaced by the already existing `UnexpectedPlacesException`. ([#4847](https://github.com/mozilla/application-services/pull/4847))
### What's New
- The Places component will report more error variants to telemetry. ([#4847](https://github.com/mozilla/application-services/pull/4847))
## Autofill / Logins / Places / Sync Manager, Webext-Storage
### What's Changed
- Updated interruption handling and added support for shutdown-mode which interrupts all operations.

## Glean
### ⚠️ Breaking Changes ⚠️
### Swift
- GleanMetrics should be imported under `import Glean` instead of importing via `MozillaRustComponents`
