### PR TITLE
Upgrade FML and be smarter about downloading nimbus-fml

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -8178,7 +8178,6 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/nimbus.fml.yaml",
-				"$(SRCROOT)/bin/nimbus-fml.sh",
 			);
 			name = "Nimbus Feature Manifest Generator Script";
 			outputFileListPaths = (


### PR DESCRIPTION
Fixes [EXP-2309][1].

This incorporates the fix for option chaining (`[String: String]` dictionaries) which was fixed in https://github.com/mozilla/application-services/pull/4885 and released in https://github.com/mozilla/application-services/pull/4887 .

This does *not* upgrade the megazord.

[1]: https://mozilla-hub.atlassian.net/browse/EXP-2309

*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Please make sure you've run the test scheme and all the tests pass. If your changes affect existing tests please make sure to update the tests as well.

