### PR TITLE
Refactor issue10293 v99 fix automate import strings

### DIFF
--- a/.github/workflows/import-strings.yml
+++ b/.github/workflows/import-strings.yml
@@ -1,0 +1,45 @@
+name: Create a PR with changes after importing strings
+
+permissions:
+  contents: write
+  pull-requests: write
+
+schedule:
+    - cron: '0 5 * * *'
+
+jobs:
+  build:
+    runs-on: macos-11
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.9]
+        xcode: ["13.0"]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        persist-credentials: false 
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Select Xcode ${{ matrix.xcode }}
+      run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Get the current date for PR title
+      run: echo "current_date=$(date +"%m-%d-%Y")" >> $GITHUB_ENV
+    - name: Run script to import strings
+      run: sh ./bootstrap.sh --importLocales
+    - name: Update new strings
+      run: |-
+        git diff || (git add Shared/*/*.lproj/* Shared/*.lproj/* WidgetKit/*.lproj/* Client/*/*.lproj/* Client/*.lproj/*)
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3
+      with:
+        author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+        committer: GitHub <noreply@github.com>
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: string-import-${{ env.current_date }}
+        title: "string-import-${{ env.current_date }}"
+        branch: string-import-${{ env.current_date }}
+        body: "This (automated) PR import string changes"

--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,9 @@ Client/Assets/*.js.LICENSE.txt
 /firefoxios-l10n
 /ios-l10n-scripts
 /shavar-prod-lists
+/LocalizationTools
+import-strings.log
+export-strings.log
 
 # Nimbus
 nimbus-fml/

--- a/Client/en.lproj/InfoPlist.strings
+++ b/Client/en.lproj/InfoPlist.strings
@@ -1,6 +1,3 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0
 
 NSLocationWhenInUseUsageDescription = "Websites you visit may request your location.";
 NSPhotoLibraryAddUsageDescription = "This lets you save photos.";

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,7 +10,8 @@
 
 getLocale() {
   echo "Getting locale..."
-  git clone https://github.com/boek/ios-l10n-scripts.git -b new_tool || exit 1
+  rm -rf LocalizationTools
+  git clone https://github.com/mozilla-mobile/LocalizationTools.git || exit 1
 
   echo "Creating firefoxios-l10n Git repo"
   rm -rf firefoxios-l10n
@@ -19,19 +20,19 @@ getLocale() {
 
 if [ "$1" == "--force" ]; then
     rm -rf firefoxios-l10n
-    rm -rf ios-l10n-scripts
+    rm -rf LocalizationTools
 fi
 
 if [ "$1" == "--importLocales" ]; then
   # Import locales
-  if [ -d "/firefoxios-l10n" ] && [ -d "/ios-l10n-scripts" ]; then
+  if [ -d "/firefoxios-l10n" ] && [ -d "/LocalizationTools" ]; then
       echo "l10n directories found. Not downloading scripts."
   else
       echo "l10n directory not found. Downloading repo and scripts."
       getLocale
   fi
 
-  ./ios-l10n-scripts/ios-l10n-tools --project-path Client.xcodeproj --l10n-project-path ./firefoxios-l10n --import
+  ./import-strings.sh
   exit 0
 fi
 

--- a/import-strings.sh
+++ b/import-strings.sh
@@ -1,0 +1,11 @@
+
+echo "\n\n[*] Building tools/Localizations"
+(cd LocalizationTools && swift build)
+
+echo "\n\n[*] Importing Strings - takes a minute. (output in import-strings.log)"
+(cd LocalizationTools && swift run LocalizationTools \
+  --import \
+  --project-path "$PWD/../Client.xcodeproj" \
+  --l10n-project-path "$PWD/../firefoxios-l10n") > import-strings.log 2>&1
+
+echo "\n\n[!] Strings have been imported. You can now create a PR."

--- a/shipping_locales.txt
+++ b/shipping_locales.txt
@@ -88,6 +88,5 @@ uk
 ur
 uz
 vi
-zgh
 zh-CN
 zh-TW


### PR DESCRIPTION
This will fix issue #10293. Currently the process to import the script is manual, following steps in the [wiki](https://github.com/mozilla-mobile/firefox-ios/wiki/Localization-Process). The automatic process described does not work as it is now. 
In addition, there is an unexpected change in `Client/local.lproj/Info.plist` that is fixed within this PR. 

Once this lands on main, we will be running daily the `./bootstrap.sh --importLocales` script and whenever a new string is detected, a PR will be created, please see as example: 
https://github.com/isabelrios/firefox-ios/pull/6