### PR TITLE
Bugfix #10296 [v99] Fix Nimbus argument correlation

### DIFF
--- a/Client/FeatureFlags/FlaggableFeature.swift
+++ b/Client/FeatureFlags/FlaggableFeature.swift
@@ -163,7 +163,7 @@ extension FlaggableFeature {
     ) -> UserFeaturePreference {
         guard let sectionID = sectionID else { return UserFeaturePreference.disabled }
 
-        let nimbusHomepageConfig = nimbus.features.homescreenFeature.value()
+        let nimbusHomepageConfig = nimbus.features.homescreen.value()
 
         if let sectionIsEnabled = nimbusHomepageConfig.sectionsEnabled[sectionID],
            sectionIsEnabled {

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -112,7 +112,7 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel {
     }
 
     override func viewDidAppear(_ animated: Bool) {
-        viewModel.nimbus.features.homescreenFeature.recordExposure()
+        viewModel.nimbus.features.homescreen.recordExposure()
         animateFirefoxLogo()
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .view,

--- a/Client/Frontend/Home/FirefoxHomeViewModel.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewModel.swift
@@ -52,7 +52,7 @@ class FirefoxHomeViewModel: FeatureFlagsProtocol {
     var historyHighlightsViewModel: FxHomeHistoryHightlightsViewModel
     var pocketViewModel: FxHomePocketViewModel
 
-    lazy var homescreen = nimbus.features.homescreenFeature.value()
+    lazy var homescreen = nimbus.features.homescreen.value()
 
     // MARK: - Section availability variables
 

--- a/Client/Frontend/Home/JumpBackIn/FxHomeJumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/FxHomeJumpBackInViewModel.swift
@@ -37,7 +37,7 @@ class FirefoxHomeJumpBackInViewModel: FeatureFlagsProtocol {
     private lazy var siteImageHelper = SiteImageHelper(profile: profile)
     private var isPrivate: Bool
 
-    private lazy var homescreen = nimbus.features.homescreenFeature.value()
+    private lazy var homescreen = nimbus.features.homescreen.value()
 
     init(isZeroSearch: Bool = false,
          profile: Profile,

--- a/Client/Frontend/Home/RecentlySaved/FirefoxHomeRecentlySavedViewModel.swift
+++ b/Client/Frontend/Home/RecentlySaved/FirefoxHomeRecentlySavedViewModel.swift
@@ -25,7 +25,7 @@ class FirefoxHomeRecentlySavedViewModel {
         self.nimbus = nimbus
     }
 
-    private lazy var homescreen = nimbus.features.homescreenFeature.value()
+    private lazy var homescreen = nimbus.features.homescreen.value()
 
     var recentItems: [RecentlySavedItem] {
         var items = [RecentlySavedItem]()

--- a/Client/Frontend/Home/TopSites/FxHomeTopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/FxHomeTopSitesViewModel.swift
@@ -49,7 +49,7 @@ class FxHomeTopSitesViewModel {
     // TODO: https://github.com/mozilla-mobile/firefox-ios/issues/10241
     var topSitesShownInSection: Int = 0
 
-    private lazy var homescreen = nimbus.features.homescreenFeature.value()
+    private lazy var homescreen = nimbus.features.homescreen.value()
 
     init(profile: Profile, isZeroSearch: Bool, nimbus: FxNimbus) {
         self.profile = profile

--- a/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -15,7 +15,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlagsPr
     var currentStartAtHomeSetting: StartAtHomeSetting!
     var hasHomePage = false
 
-    lazy var homescreen = nimbus.features.homescreenFeature.value()
+    lazy var homescreen = nimbus.features.homescreen.value()
 
     var isJumpBackInSectionEnabled: Bool {
         let isFeatureEnabled = featureFlags.isFeatureActiveForBuild(.jumpBackIn)

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -42,7 +42,7 @@ features:
         description: The drawable displayed in the app menu for Settings
         type: String
         default: "menu-Settings"
-  homescreenFeature:
+  homescreen:
     description: The homescreen that the user goes to when they press home or new tab.
     variables:
       sections-enabled:


### PR DESCRIPTION
Experimenter has a different experiment argument running than our new nimbus standard fml. Adapting the FML to get this in line with what's on Experimenter. There's already a [JIRA ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-3997) for undoing this work.

for #10296 