### PR TITLE
Record and submit Glean data for sync operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ python-env/
 Carthage/
 # Required for Glean
 /Client/Generated
+/Sync/Generated
 .venv/
 
 ThirdParty/google-breakpad

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -399,6 +399,8 @@
 		59A68E0B4ABBF55E14819668 /* BookmarksPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A6839879D615FC1C0D71CE /* BookmarksPanel.swift */; };
 		59A68FD5260B8D520F890F4A /* ReaderPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A685F4EAD19EDEC854BCA4 /* ReaderPanel.swift */; };
 		5F130D2E2483508E00B0F7D0 /* FxAWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F130D2D2483508E00B0F7D0 /* FxAWebViewModel.swift */; };
+		5F97DD5F27FB0FE800AD3C60 /* GleanTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F97DD5E27FB0FE800AD3C60 /* GleanTelemetryTests.swift */; };
+		5FA2233C27F74071005B3D87 /* Glean in Frameworks */ = {isa = PBXBuildFile; productRef = 5FA2233B27F74071005B3D87 /* Glean */; };
 		6025B109267B6BB300F59F6B /* NoSearchResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6025B107267B6BB300F59F6B /* NoSearchResultCell.swift */; };
 		6025B10A267B6BB300F59F6B /* SelectPasswordCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6025B108267B6BB300F59F6B /* SelectPasswordCell.swift */; };
 		6025B10C267B6BEA00F59F6B /* LoginRecordExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6025B10B267B6BEA00F59F6B /* LoginRecordExtension.swift */; };
@@ -1251,6 +1253,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 4368F86F27966E810013419B;
 			remoteInfo = SDWebImage;
+		};
+		5FA2233627F73E28005B3D87 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2827315D1ABC9BE600AA1954;
+			remoteInfo = Sync;
 		};
 		7B9BF92E1E435DE400CB24F4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -2415,6 +2424,7 @@
 		5F130D2D2483508E00B0F7D0 /* FxAWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxAWebViewModel.swift; sourceTree = "<group>"; };
 		5F194C3596E08BAB72BC6879 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		5F684EB59A149BD03A1E5247 /* sq */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sq; path = sq.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		5F97DD5E27FB0FE800AD3C60 /* GleanTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanTelemetryTests.swift; sourceTree = "<group>"; };
 		5FAD4F1A8770848F48AF6023 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Today.strings; sourceTree = "<group>"; };
 		5FCB495FBF06EA94CC67B800 /* es-MX */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-MX"; path = "es-MX.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		5FDA464827F20C9C0060E924 /* FxNimbus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxNimbus.swift; sourceTree = "<group>"; };
@@ -4669,6 +4679,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		5FA2233A27F74067005B3D87 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5FA2233C27F74071005B3D87 /* Glean in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7BEB64461C7345600092C02E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -6808,6 +6826,7 @@
 				215B458327DA87FC00E5E800 /* TabMetadataManagerTests.swift */,
 				8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */,
 				8AD08D1627E91AC800B8E907 /* TabsQuantityTelemetryTests.swift */,
+				5F97DD5E27FB0FE800AD3C60 /* GleanTelemetryTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -7442,14 +7461,19 @@
 			buildConfigurationList = E69DB0921E97DEAA008A67E6 /* Build configuration list for PBXNativeTarget "SyncTelemetryTests" */;
 			buildPhases = (
 				E69DB0791E97DEA9008A67E6 /* Sources */,
+				5FA2233A27F74067005B3D87 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				5FA2233727F73E28005B3D87 /* PBXTargetDependency */,
 				E69DB0801E97DEAA008A67E6 /* PBXTargetDependency */,
 				E69DB0821E97DEAA008A67E6 /* PBXTargetDependency */,
 			);
 			name = SyncTelemetryTests;
+			packageProductDependencies = (
+				5FA2233B27F74071005B3D87 /* Glean */,
+			);
 			productName = SyncTelemetryTests;
 			productReference = E69DB07D1E97DEA9008A67E6 /* SyncTelemetryTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -8226,7 +8250,7 @@
 		};
 		5FA2232C27F6FA69005B3D87 /* Nimbus Feature Manifest Generator Script */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 12;
 			files = (
 			);
 			inputFileListPaths = (
@@ -9256,6 +9280,7 @@
 				D3BA41681BD82F2200DA5457 /* XCTestCaseExtensions.swift in Sources */,
 				8A86DAD8277298DE00D7BFFF /* ClosedTabsStoreTests.swift in Sources */,
 				554867231DC3935A00183DAA /* HomePageTests.swift in Sources */,
+				5F97DD5F27FB0FE800AD3C60 /* GleanTelemetryTests.swift in Sources */,
 				DACDE996225E537900C8F37F /* VersionSettingTests.swift in Sources */,
 				DFA51484276103A000266AA0 /* HistoryHighlightsManagerTests.swift in Sources */,
 				3BFCBF201E04B1C50070C042 /* UIImageViewExtensionsTests.swift in Sources */,
@@ -9465,6 +9490,11 @@
 		43EFA63E2786562600400DF0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			productRef = 43EFA63D2786562600400DF0 /* Places */;
+		};
+		5FA2233727F73E28005B3D87 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2827315D1ABC9BE600AA1954 /* Sync */;
+			targetProxy = 5FA2233627F73E28005B3D87 /* PBXContainerItemProxy */;
 		};
 		7B9BF92F1E435DE400CB24F4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -14225,6 +14255,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 1BE9ECAA271765C800D729BB /* XCRemoteSwiftPackageReference "rust-components-swift" */;
 			productName = Places;
+		};
+		5FA2233B27F74071005B3D87 /* Glean */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */;
+			productName = Glean;
 		};
 		D433852B27ABC8150069DD33 /* MappaMundi */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -386,7 +386,6 @@
 		43F93C2627A86831009833D9 /* SDWebImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4368F87B27966E810013419B /* SDWebImage.framework */; };
 		43F93C2827A8683E009833D9 /* RustMozillaAppServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43BE578A278BA4D900491291 /* RustMozillaAppServices.framework */; };
 		43F93C2927A868FF009833D9 /* SDWebImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4368F87B27966E810013419B /* SDWebImage.framework */; };
-		455880A127B42F720078DEBB /* FxNimbus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455880A027B42F720078DEBB /* FxNimbus.swift */; };
 		4A59B58AD11B5EE1F80BBDEB /* TestHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A59BF410BBD9B3BE71F4C7C /* TestHistory.swift */; };
 		4F2A06BE26F8E46E0017DA05 /* TabCounterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2A06BD26F8E46E0017DA05 /* TabCounterTests.swift */; };
 		4F514FD41ACD8F2C0022D7EA /* HistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F514FD31ACD8F2C0022D7EA /* HistoryTests.swift */; };
@@ -407,6 +406,9 @@
 		6025B10E267B6C7F00F59F6B /* LoginRecordExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6025B10B267B6BEA00F59F6B /* LoginRecordExtension.swift */; };
 		6025B10F267B6C7F00F59F6B /* LoginRecordExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6025B10B267B6BEA00F59F6B /* LoginRecordExtension.swift */; };
 		6025B111267B6EE100F59F6B /* CredentialWelcomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6025B110267B6EE100F59F6B /* CredentialWelcomeViewController.swift */; };
+		602A2B9727F6243A00C3CB78 /* Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86E4F702493BA8E0087BFD9 /* Metrics.swift */; };
+		602A2B9827F6256200C3CB78 /* FxNimbus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455880A027B42F720078DEBB /* FxNimbus.swift */; };
+		602A2BA527F6298600C3CB78 /* Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602A2BA427F6298600C3CB78 /* Metrics.swift */; };
 		60CE80C12667780D004026C7 /* CredentialListPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60CE80C02667780C004026C7 /* CredentialListPresenter.swift */; };
 		60D71AEC26AAF45E00355588 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D71AEB26AAF45E00355588 /* UIColorExtension.swift */; };
 		63306D3921103EAE00F25400 /* SavedTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63306D3821103EAE00F25400 /* SavedTab.swift */; };
@@ -603,7 +605,6 @@
 		C8656D75270F834600E199EA /* FlaggableFeatureOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8656D74270F834600E199EA /* FlaggableFeatureOptions.swift */; };
 		C8656D77270F858900E199EA /* TabsSettingsViewControler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8656D76270F858900E199EA /* TabsSettingsViewControler.swift */; };
 		C8656D79270F866700E199EA /* FxHomeCustomizeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8656D78270F866700E199EA /* FxHomeCustomizeView.swift */; };
-		C86E4F712493BA8E0087BFD9 /* Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86E4F702493BA8E0087BFD9 /* Metrics.swift */; };
 		C874FB3A2660E8B900EBE86E /* CredentialProviderPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C874FB392660E8B900EBE86E /* CredentialProviderPresenter.swift */; };
 		C874FC2826612BFF00EBE86E /* AlertControllerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C874FC2726612BFF00EBE86E /* AlertControllerView.swift */; };
 		C874FC652661367900EBE86E /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C874FC642661367900EBE86E /* MainInterface.storyboard */; };
@@ -2416,11 +2417,14 @@
 		5F684EB59A149BD03A1E5247 /* sq */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sq; path = sq.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		5FAD4F1A8770848F48AF6023 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Today.strings; sourceTree = "<group>"; };
 		5FCB495FBF06EA94CC67B800 /* es-MX */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-MX"; path = "es-MX.lproj/Default Browser.strings"; sourceTree = "<group>"; };
+		5FDA464827F20C9C0060E924 /* FxNimbus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxNimbus.swift; sourceTree = "<group>"; };
+		5FDA464927F20C9C0060E924 /* Metrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Metrics.swift; sourceTree = "<group>"; };
 		5FE34931820AAF71C31C383E /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
 		6025B107267B6BB300F59F6B /* NoSearchResultCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoSearchResultCell.swift; sourceTree = "<group>"; };
 		6025B108267B6BB300F59F6B /* SelectPasswordCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectPasswordCell.swift; sourceTree = "<group>"; };
 		6025B10B267B6BEA00F59F6B /* LoginRecordExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginRecordExtension.swift; sourceTree = "<group>"; };
 		6025B110267B6EE100F59F6B /* CredentialWelcomeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CredentialWelcomeViewController.swift; sourceTree = "<group>"; };
+		602A2BA427F6298600C3CB78 /* Metrics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Metrics.swift; path = Generated/Metrics.swift; sourceTree = "<group>"; };
 		604B4E078B7907FA2595345D /* lt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lt; path = lt.lproj/Shared.strings; sourceTree = "<group>"; };
 		605D466193C1DA0CDACFA4AC /* ast */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ast; path = ast.lproj/Intro.strings; sourceTree = "<group>"; };
 		6075454195BAE1F144470192 /* bn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bn; path = bn.lproj/Search.strings; sourceTree = "<group>"; };
@@ -5381,6 +5385,15 @@
 			path = EnhancedTrackingProtection;
 			sourceTree = "<group>";
 		};
+		5FDA464727F20C9C0060E924 /* Generated */ = {
+			isa = PBXGroup;
+			children = (
+				5FDA464827F20C9C0060E924 /* FxNimbus.swift */,
+				5FDA464927F20C9C0060E924 /* Metrics.swift */,
+			);
+			path = Generated;
+			sourceTree = "<group>";
+		};
 		7B0B1B9C1C1B69F500DF4AB5 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -6249,6 +6262,7 @@
 		E4E0BB141AFBC9E4008D6260 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				5FDA464727F20C9C0060E924 /* Generated */,
 				514A4C83AE17612AF3025498 /* 3DTouchActions.strings */,
 				E65075621E37F7AB006961AC /* Accessibility.swift */,
 				EB7FFFBF20A9D38C003E1E34 /* AlertController.swift */,
@@ -6460,6 +6474,7 @@
 		E69DB0B31E97E0E4008A67E6 /* Telemetry */ = {
 			isa = PBXGroup;
 			children = (
+				602A2BA427F6298600C3CB78 /* Metrics.swift */,
 				EBA31D7C1F79996E0055463D /* SyncTelemetryUtils.swift */,
 			);
 			name = Telemetry;
@@ -7013,6 +7028,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 282731971ABC9BE800AA1954 /* Build configuration list for PBXNativeTarget "Sync" */;
 			buildPhases = (
+				60F653B827F61F7A0060D806 /* Glean SDK Generator Script */,
 				282731591ABC9BE600AA1954 /* Sources */,
 				2827315A1ABC9BE600AA1954 /* Frameworks */,
 				2827315C1ABC9BE600AA1954 /* Resources */,
@@ -7485,8 +7501,8 @@
 			buildConfigurationList = F84B21DD1A090F8100AAB793 /* Build configuration list for PBXNativeTarget "Client" */;
 			buildPhases = (
 				C874A4E327F62C5B006F54E5 /* Swiftlint */,
-				CDF3D3002461D92F00A93748 /* Glean SDK Generator Script */,
-				4558809F27B42E920078DEBB /* Nimbus Feature Manifest Generator Script */,
+				5FA2232B27F6FA00005B3D87 /* Glean SDK Generator Script */,
+				5FA2232C27F6FA69005B3D87 /* Nimbus Feature Manifest Generator Script */,
 				F84B21BA1A090F8100AAB793 /* Sources */,
 				F84B21BC1A090F8100AAB793 /* Resources */,
 				28CE83DE1A1D1E7C00576538 /* Frameworks */,
@@ -8188,7 +8204,27 @@
 			shellPath = /bin/sh;
 			shellScript = "movedFrameworks=()\n        cd \"${CODESIGNING_FOLDER_PATH}/Frameworks/\"\n        for framework in *; do\n            if [ -d \"$framework\" ]; then\n                if [ -d \"${framework}/Frameworks\" ]; then\n                    echo \"Moving nested frameworks from ${framework}/Frameworks/ to ${PRODUCT_NAME}.app/Frameworks/\"\n        \n                    cd \"${framework}/Frameworks/\"\n                    for nestedFramework in *; do\n                        echo \"- nested: ${nestedFramework}\"\n                        movedFrameworks+=(\"${nestedFramework}\")\n                    done\n                    cd ..\n                    cd ..\n        \n                    cp -R \"${framework}/Frameworks/\" .\n                    rm -rf \"${framework}/Frameworks\"\n                fi\n            fi\n        done\n        \n        if [ \"${CONFIGURATION}\" == \"Debug\" ] & [ \"${PLATFORM_NAME}\" != \"iphonesimulator\" ] ; then\n            for movedFramework in \"${movedFrameworks[@]}\"\n            do\n                codesign --force --deep --sign \"${EXPANDED_CODE_SIGN_IDENTITY}\" --preserve-metadata=identifier,entitlements --timestamp=none \"${movedFramework}\"\n            done\n        else\n            echo \"Info: CODESIGNING is only needed for Debug on device (will be re-signed anyway when archiving) \"\n        fi\n";
 		};
-		4558809F27B42E920078DEBB /* Nimbus Feature Manifest Generator Script */ = {
+		5FA2232B27F6FA00005B3D87 /* Glean SDK Generator Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Client/metrics.yaml",
+			);
+			name = "Glean SDK Generator Script";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/Client/Generated/Metrics.swift",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "rm -rf .venv; bash $PWD/bin/sdk_generator.sh -g Glean\n";
+		};
+		5FA2232C27F6FA69005B3D87 /* Nimbus Feature Manifest Generator Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -8206,7 +8242,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ $ACTION != \"indexbuild\" ]; then\n   bash $PWD/bin/nimbus-fml.sh -n MozillaAppServices\nfi\n";
+			shellScript = "if [ $ACTION != \\\"indexbuild\\\" ]; then\n   bash $PWD/bin/nimbus-fml.sh -n MozillaAppServices\nfi\n";
 		};
 		C874A4E327F62C5B006F54E5 /* Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -8226,7 +8262,7 @@
 			shellPath = /bin/sh;
 			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftlint > /dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
-		CDF3D3002461D92F00A93748 /* Glean SDK Generator Script */ = {
+		60F653B827F61F7A0060D806 /* Glean SDK Generator Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -8234,17 +8270,18 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/Client/metrics.yaml",
+				"$(SRCROOT)/Sync/metrics.yaml",
+				"$(SRCROOT)/Sync/pings.yaml",
 			);
 			name = "Glean SDK Generator Script";
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(SRCROOT)/Client/Generated/Metrics.swift",
+				"$(SRCROOT)/Sync/Generated/Metrics.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "rm -rf .venv; bash $PWD/bin/sdk_generator.sh -g Glean\n";
+			shellScript = "rm -rf .venv; bash $PWD/bin/sdk_generator.sh -g Glean -o $SRCROOT/Sync/Generated\n";
 		};
 		E6639F191BF11E3A002D0853 /* Conditionally Add Settings Bundle */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -8316,6 +8353,7 @@
 				2885023F1AC117A500E7F670 /* SyncStateMachine.swift in Sources */,
 				EBA31D7D1F79996E0055463D /* SyncTelemetryUtils.swift in Sources */,
 				2894C1691AE89DDC00F1F92F /* ClientsSynchronizer.swift in Sources */,
+				602A2BA527F6298600C3CB78 /* Metrics.swift in Sources */,
 				28E91E751B443AD5009DF274 /* SyncConstants.swift in Sources */,
 				2F3724E91ABF3C19007607FA /* Synchronizer.swift in Sources */,
 				28ED02021B26123E003948B2 /* LoginPayload.swift in Sources */,
@@ -8789,6 +8827,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				602A2B9827F6256200C3CB78 /* FxNimbus.swift in Sources */,
+				602A2B9727F6243A00C3CB78 /* Metrics.swift in Sources */,
 				D04CD74A216CF86B004FF5B0 /* SiriShortcuts.swift in Sources */,
 				EB9A179F20E6C1A200B12184 /* ThemedWidgets.swift in Sources */,
 				E68E39BE1C46F42000B85F42 /* AppSettingsTableViewController.swift in Sources */,
@@ -8934,7 +8974,6 @@
 				0BB5B30B1AC0AD1F0052877D /* LoginsHelper.swift in Sources */,
 				C87DF9DB267247190097E707 /* UIConstants+BottomInset.swift in Sources */,
 				8AD08D1527E9198E00B8E907 /* TabsQuantityTelemetry.swift in Sources */,
-				C86E4F712493BA8E0087BFD9 /* Metrics.swift in Sources */,
 				1DA3CE6324EEE83200422BB2 /* SavedTab+ConfigureExtension.swift in Sources */,
 				C87DC85627B2C8B0006EFCE2 /* WallpaperNetworkUtility.swift in Sources */,
 				43E9BDFB255E0904005BCB91 /* TabMoreMenuHeader.swift in Sources */,
@@ -9140,7 +9179,6 @@
 				43162A2F2492DB7800F91658 /* EmptyPrivateTabsView.swift in Sources */,
 				DFF95955279B021700ECC572 /* WallpaperDataManager.swift in Sources */,
 				D0625C98208E87F10081F3B2 /* DownloadQueue.swift in Sources */,
-				455880A127B42F720078DEBB /* FxNimbus.swift in Sources */,
 				8D8251811F4DE67F00780643 /* AdvancedAccountSettingViewController.swift in Sources */,
 				E633E2DA1C21EAF8001FFF6C /* LoginDetailViewController.swift in Sources */,
 				8A9AC46B276D11280047F5B0 /* FxHomePocketViewModel.swift in Sources */,

--- a/ClientTests/GleanTelemetryTests.swift
+++ b/ClientTests/GleanTelemetryTests.swift
@@ -1,0 +1,59 @@
+//// This Source Code Form is subject to the terms of the Mozilla Public
+//// License, v. 2.0. If a copy of the MPL was not distributed with this
+//// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+import Account
+import Storage
+import Shared
+@testable import Sync
+import MozillaAppServices
+
+import Foundation
+import SwiftyJSON
+import XCTest
+
+import Glean
+
+class MockSyncDelegate: SyncDelegate {
+    func displaySentTab(for url: URL, title: String, from deviceName: String?) {
+    }
+}
+
+class MockBrowserSyncManager: BrowserProfile.BrowserSyncManager {
+    override func getProfileAndDeviceId() -> (MozillaAppServices.Profile, String) {
+        return (MozillaAppServices.Profile(
+            uid: "test",
+            email: "test@test.test",
+            displayName: nil,
+            avatar: "",
+            isDefaultAvatar: true
+        ), "test")
+    }
+}
+
+class GleanTelemetryTests: XCTestCase {
+    override func setUpWithError() throws {
+        Glean.shared.resetGlean(clearStores: true)
+    }
+    
+    let profile = MockBrowserProfile(localName: "GleanTelemetryTests")
+
+    func testSyncPingIsSentOnSyncOperation() throws {
+        let syncManager = MockBrowserSyncManager(profile: profile)
+        
+        let syncPingWasSent = expectation(description: "The tempSync ping was sent")
+        GleanMetrics.Pings.shared.tempSync.testBeforeNextSubmit { _ in
+            XCTAssert(GleanMetrics.Sync.syncUuid.testHasValue())
+            syncPingWasSent.fulfill()
+        }
+
+        _ = syncManager.syncNamedCollections(
+            why: SyncReason.didLogin,
+            names: ["tabs", "logins", "bookmarks", "history"]
+        )
+        
+        waitForExpectations(timeout: 5.0)
+    }
+}
+

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -1161,11 +1161,14 @@ open class BrowserProfile: Profile {
                     return self.syncWith(synchronizers: remaining, statsSession: statsSession, why: why) >>== { deferMaybe(statuses + $0) }
                 }
 
+                let gleanHelper = GleanSyncOperationHelper()
+
                 reducer.terminal.upon { results in
                     let result = SyncOperationResult(
                         engineResults: results,
                         stats: statsSession.hasStarted() ? statsSession.end() : nil
                     )
+                    gleanHelper.end(result)
                     self.endSyncing(result)
                 }
 
@@ -1173,6 +1176,7 @@ open class BrowserProfile: Profile {
                 // the synchronizers to the reducer below.
                 self.syncReducer = reducer
                 self.beginSyncing()
+                gleanHelper.start()
             }
 
             do {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -1126,6 +1126,14 @@ open class BrowserProfile: Profile {
             return syncSeveral(why: why, synchronizers: synchronizers)
         }
 
+        func getProfileAndDeviceId() -> (MozillaAppServices.Profile, String)? {
+            guard let fxa = RustFirefoxAccounts.shared.accountManager.peek(), let profile = fxa.accountProfile(), let deviceID = fxa.deviceConstellation()?.state()?.localDevice?.id else {
+                return nil
+            }
+            
+            return (profile, deviceID)
+        }
+
         /**
          * Runs each of the provided synchronization functions with the same inputs.
          * Returns an array of IDs and SyncStatuses at least length as the input.
@@ -1136,7 +1144,7 @@ open class BrowserProfile: Profile {
             syncLock.lock()
             defer { syncLock.unlock() }
 
-            guard let fxa = RustFirefoxAccounts.shared.accountManager.peek(), let profile = fxa.accountProfile(), let deviceID = fxa.deviceConstellation()?.state()?.localDevice?.id else {
+            guard let (profile, deviceID) = self.getProfileAndDeviceId() else {
                 return deferMaybe(NoAccountError())
             }
 

--- a/Sync/metrics.yaml
+++ b/Sync/metrics.yaml
@@ -1,0 +1,419 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+sync:
+  sync_uuid:
+    type: uuid
+    description: >
+      Unique identifier for this sync, used to correlate together
+      individual pings for data types that were synchronized together
+      (history, bookmarks, logins).
+      If a data type is synchronized by itself via the legacy 'sync' API
+      (as opposed to the Sync Manager),
+      then this field will not be set on the corresponding ping.
+    send_in_pings:
+      - temp-sync
+      - temp-history-sync
+      - temp-bookmarks-sync
+      - temp-logins-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-01
+    lifetime: ping
+  failure_reason:
+    type: labeled_counter
+    labels:
+      - httperror
+      - unexpectederror
+      - sqlerror
+      - othererror
+    description: >
+      Records why sync failed.
+    send_in_pings:
+      - temp-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-01
+    lifetime: ping
+
+# `history-sync`, `logins-sync`, `bookmarks-sync`, `creditcards-sync`,
+# `addresses-sync` and `tabs-sync` metrics
+# mostly use the same structure, with some minor variability,
+# but must be specified individually. We can't define them once and use
+# `send_in_pings` because the stores might be synced in parallel, and we can't
+# guarantee that a ping for one store would be sent before the others.
+history_sync:
+  uid:
+    type: string
+    description: >
+      The user's hashed Firefox Account ID.
+    send_in_pings:
+      - temp-history-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-01
+    lifetime: ping
+  incoming:
+    type: labeled_counter
+    labels:
+      - applied
+      - failed_to_apply
+      - reconciled
+    description: >
+      Records incoming history record counts. `applied` is the number of
+      incoming history pages that were successfully stored or updated in the
+      local database. `failed_to_apply` is the number of pages that were
+      ignored due to errors. `reconciled` is the number of pages with new visits
+      locally and remotely, and had their visits merged.
+    send_in_pings:
+      - temp-history-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-01
+    lifetime: ping
+  outgoing:
+    type: labeled_counter
+    labels:
+      - uploaded
+      - failed_to_upload
+    description: >
+      Records outgoing history record counts. `uploaded` is the number of
+      records that were successfully sent to the server. `failed_to_upload`
+      is the number of records that weren't uploaded, and will be retried
+      on the next sync.
+    send_in_pings:
+      - temp-history-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-01
+    lifetime: ping
+  failure_reason:
+    type: labeled_counter
+    labels:
+      - no_account
+      - offline
+      - backoff
+      - remotely_not_enabled
+      - format_outdated
+      - format_too_new
+      - storage_format_outdated
+      - storage_format_too_new
+      - state_machine_not_ready
+      - red_light
+      - unknown
+    description: >
+      Records why the history sync failed.
+    send_in_pings:
+      - temp-history-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-01
+    lifetime: ping
+
+logins_sync:
+  uid:
+    type: string
+    description: >
+      The user's hashed Firefox Account ID.
+    send_in_pings:
+      - temp-logins-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-01
+    lifetime: ping
+  incoming:
+    type: labeled_counter
+    labels:
+      - applied
+      - failed_to_apply
+      - reconciled
+    description: >
+      Records incoming passwords record counts. `applied` is the number of
+      incoming passwords entries that were successfully stored or updated in the
+      local database. `failed_to_apply` is the number of entries that were
+      ignored due to errors. `reconciled` is the number of entries with changes
+      both locally and remotely that were merged.
+    send_in_pings:
+      - temp-logins-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-01
+    lifetime: ping
+  outgoing:
+    type: labeled_counter
+    labels:
+      - uploaded
+      - failed_to_upload
+    description: >
+      Records outgoing passwords record counts. `uploaded` is the number of
+      records that were successfully sent to the server. `failed_to_upload`
+      is the number of records that weren't uploaded, and will be retried
+      on the next sync.
+    send_in_pings:
+      - temp-logins-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-01
+    lifetime: ping
+  failure_reason:
+    type: labeled_counter
+    labels:
+      - no_account
+      - offline
+      - backoff
+      - remotely_not_enabled
+      - format_outdated
+      - format_too_new
+      - storage_format_outdated
+      - storage_format_too_new
+      - state_machine_not_ready
+      - red_light
+      - unknown
+    description: >
+      Records why the passwords sync failed.
+    send_in_pings:
+      - temp-logins-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-01
+    lifetime: ping
+
+bookmarks_sync:
+  uid:
+    type: string
+    description: >
+      The user's hashed Firefox Account ID.
+    send_in_pings:
+      - temp-bookmarks-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-01
+    lifetime: ping
+  incoming:
+    type: labeled_counter
+    labels:
+      - applied
+      - failed_to_apply
+      - reconciled
+    description: >
+      Records incoming bookmark record counts.
+    send_in_pings:
+      - temp-bookmarks-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-01
+    lifetime: ping
+  outgoing:
+    type: labeled_counter
+    labels:
+      - uploaded
+      - failed_to_upload
+    description: >
+      Records outgoing bookmark record counts.
+    send_in_pings:
+      - temp-bookmarks-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-01
+    lifetime: ping
+  failure_reason:
+    type: labeled_counter
+    labels:
+      - no_account
+      - offline
+      - backoff
+      - remotely_not_enabled
+      - format_outdated
+      - format_too_new
+      - storage_format_outdated
+      - storage_format_too_new
+      - state_machine_not_ready
+      - red_light
+      - unknown
+    description: >
+      Records bookmark sync failure reasons.
+    send_in_pings:
+      - temp-bookmarks-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-01
+    lifetime: ping
+
+tabs_sync:
+  uid:
+    type: string
+    description: >
+      The user's hashed Firefox Account ID.
+    send_in_pings:
+      - temp-tabs-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-01
+    lifetime: ping
+  incoming:
+    type: labeled_counter
+    labels:
+      - applied
+      - failed_to_apply
+      - reconciled
+    description: >
+      Records incoming tabs record counts. `applied` is the number of
+      incoming records that were successfully stored or updated in the
+      local database. `failed_to_apply` is the number of records that were
+      ignored due to errors. `reconciled` is the number of merged records.
+    send_in_pings:
+      - temp-tabs-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-01
+    lifetime: ping
+  outgoing:
+    type: labeled_counter
+    labels:
+      - uploaded
+      - failed_to_upload
+    description: >
+      Records outgoing tabs record counts. `uploaded` is the number of
+      records that were successfully sent to the server. `failed_to_upload`
+      is the number of records that weren't uploaded, and will be retried
+      on the next sync.
+    send_in_pings:
+      - temp-tabs-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-01
+    lifetime: ping
+  failure_reason:
+    type: labeled_counter
+    labels:
+      - no_account
+      - offline
+      - backoff
+      - remotely_not_enabled
+      - format_outdated
+      - format_too_new
+      - storage_format_outdated
+      - storage_format_too_new
+      - state_machine_not_ready
+      - red_light
+      - unknown
+    description: >
+      Records why the tabs sync failed.
+    send_in_pings:
+      - temp-tabs-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-01
+    lifetime: ping

--- a/Sync/metrics.yaml
+++ b/Sync/metrics.yaml
@@ -23,7 +23,7 @@ sync:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/SYNC-3008
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
     data_sensitivity:
       - technical
     notification_emails:
@@ -44,7 +44,7 @@ sync:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/SYNC-3008
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
     data_sensitivity:
       - interaction
     notification_emails:
@@ -68,7 +68,7 @@ history_sync:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/SYNC-3008
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
     data_sensitivity:
       - interaction
     notification_emails:
@@ -92,7 +92,7 @@ history_sync:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/SYNC-3008
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
     data_sensitivity:
       - interaction
     notification_emails:
@@ -114,7 +114,7 @@ history_sync:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/SYNC-3008
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
     data_sensitivity:
       - interaction
     notification_emails:
@@ -142,7 +142,7 @@ history_sync:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/SYNC-3008
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
     data_sensitivity:
       - interaction
     notification_emails:
@@ -160,7 +160,7 @@ logins_sync:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/SYNC-3008
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
     data_sensitivity:
       - interaction
     notification_emails:
@@ -184,7 +184,7 @@ logins_sync:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/SYNC-3008
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
     data_sensitivity:
       - interaction
     notification_emails:
@@ -206,7 +206,7 @@ logins_sync:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/SYNC-3008
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
     data_sensitivity:
       - interaction
     notification_emails:
@@ -234,7 +234,7 @@ logins_sync:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/SYNC-3008
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
     data_sensitivity:
       - interaction
     notification_emails:
@@ -252,7 +252,7 @@ bookmarks_sync:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/SYNC-3008
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
     data_sensitivity:
       - interaction
     notification_emails:
@@ -272,7 +272,7 @@ bookmarks_sync:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/SYNC-3008
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
     data_sensitivity:
       - interaction
     notification_emails:
@@ -291,7 +291,7 @@ bookmarks_sync:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/SYNC-3008
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
     data_sensitivity:
       - interaction
     notification_emails:
@@ -319,7 +319,7 @@ bookmarks_sync:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/SYNC-3008
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
     data_sensitivity:
       - interaction
     notification_emails:
@@ -337,7 +337,7 @@ tabs_sync:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/SYNC-3008
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
     data_sensitivity:
       - interaction
     notification_emails:
@@ -360,7 +360,7 @@ tabs_sync:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/SYNC-3008
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
     data_sensitivity:
       - interaction
     notification_emails:
@@ -382,7 +382,7 @@ tabs_sync:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/SYNC-3008
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
     data_sensitivity:
       - interaction
     notification_emails:
@@ -410,7 +410,7 @@ tabs_sync:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/SYNC-3008
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
     data_sensitivity:
       - interaction
     notification_emails:

--- a/Sync/pings.yaml
+++ b/Sync/pings.yaml
@@ -28,7 +28,7 @@ temp-sync:
   notification_emails:
     - sync-core@mozilla.com
   data_reviews:
-    - TODO
+    - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
 temp-history-sync:
   description: >
     A ping sent for every history sync. It doesn't include the `client_id`
@@ -39,7 +39,7 @@ temp-history-sync:
   notification_emails:
     - sync-core@mozilla.com
   data_reviews:
-    - TODO https://github.com/mozilla-mobile/android-components/pull/3092
+    - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
 temp-bookmarks-sync:
   description: >
     A ping sent for every bookmarks sync. It doesn't include the `client_id`
@@ -50,7 +50,7 @@ temp-bookmarks-sync:
   notification_emails:
     - sync-core@mozilla.com
   data_reviews:
-    - TODO
+    - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
 temp-logins-sync:
   description: >
     A ping sent for every logins/passwords sync.
@@ -62,7 +62,7 @@ temp-logins-sync:
   notification_emails:
     - sync-core@mozilla.com
   data_reviews:
-    - TODO
+    - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
 temp-tabs-sync:
   description: >
     A ping sent for every Tabs engine sync.
@@ -74,4 +74,4 @@ temp-tabs-sync:
   notification_emails:
     - sync-core@mozilla.com
   data_reviews:
-    - TODO
+    - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698

--- a/Sync/pings.yaml
+++ b/Sync/pings.yaml
@@ -1,0 +1,77 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+
+$schema: moz://mozilla.org/schemas/glean/pings/2-0-0
+
+temp-sync:
+  description: >
+    A summary ping, sent every time a sync is performed.
+    During each Sync one or more data types could be synchronized,
+    depending on which data types user configured to sync.
+    Alongside with 'sync' ping one or more individual data type specific
+    pings will be sent.
+    For example, if history and bookmarks data types
+    are configured to be synchronized, the following pings will be sent:
+    'sync', 'history-sync' and 'bookmarks-sync'.
+    Alternatively, if only history is configured to be synchronized
+    then 'sync' and 'history-sync' pings will be sent.
+    In case of a "global failure" where none of the data type syncs
+    could even start, e.g. device is offline,
+    only the 'sync' ping will be sent.
+    This ping doesn't include the `client_id`
+    because it reports a hashed version of the user's Firefox Account ID.
+  include_client_id: false
+  bugs:
+    - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+  notification_emails:
+    - sync-core@mozilla.com
+  data_reviews:
+    - TODO
+temp-history-sync:
+  description: >
+    A ping sent for every history sync. It doesn't include the `client_id`
+    because it reports a hashed version of the user's Firefox Account ID.
+  include_client_id: false
+  bugs:
+    - https://github.com/mozilla-mobile/android-components/pull/3092
+  notification_emails:
+    - sync-core@mozilla.com
+  data_reviews:
+    - TODO https://github.com/mozilla-mobile/android-components/pull/3092
+temp-bookmarks-sync:
+  description: >
+    A ping sent for every bookmarks sync. It doesn't include the `client_id`
+    because it reports a hashed version of the user's Firefox Account ID.
+  include_client_id: false
+  bugs:
+    - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+  notification_emails:
+    - sync-core@mozilla.com
+  data_reviews:
+    - TODO
+temp-logins-sync:
+  description: >
+    A ping sent for every logins/passwords sync.
+    It doesn't include the `client_id` because it reports
+    a hashed version of the user's Firefox Account ID.
+  include_client_id: false
+  bugs:
+    - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+  notification_emails:
+    - sync-core@mozilla.com
+  data_reviews:
+    - TODO
+temp-tabs-sync:
+  description: >
+    A ping sent for every Tabs engine sync.
+    It doesn't include the `client_id` because it reports
+    a hashed version of the user's Firefox Account ID.
+  include_client_id: false
+  bugs:
+    - https://mozilla-hub.atlassian.net/browse/SYNC-3008
+  notification_emails:
+    - sync-core@mozilla.com
+  data_reviews:
+    - TODO


### PR DESCRIPTION
These changes are related to https://mozilla-hub.atlassian.net/browse/SYNC-3008

I copied the way sync data is collected on Android, but removed most of the metrics that I found were not necessary here. (https://github.com/mozilla-mobile/android-components/blob/main/components/support/sync-telemetry/metrics.yaml). Essentially, I just left all the counters :D

A demo of the pings can be checked out at: https://debug-ping-preview.firebaseapp.com/pings/bea-sync-test. You may notice not all pings were sent, but it seems like not all engines are synchronized everytime. Is that expected?

Still need to:

- [x] Write tests for the new collection
  - I wrote some _very minimal_ tests just to check that the sync ping is sent on each sync operation. Anything fancier than that would require a lot of complex mocking that felt like overkill for this fix.
- [x] Request data-review. @travis79 I wonder if I can reuse the data collection from Android, since I am copying the metrics that are recorded there.
- [ ] ~Make a new release of glean_parser with https://github.com/mozilla/glean_parser/pull/469 and update the Swift SDK with it.~
   - Changes were unnecessary, thanks @travis79 for the help in figuring this out :D

