### PR TITLE
Add `.experimenter.yaml` file generation to the build.

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -1,0 +1,42 @@
+---
+homescreenFeature:
+  description: The homescreen that the user goes to when they press home or new tab.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    sections-enabled:
+      type: json
+      description: "This property provides a lookup table of whether or not the given section should be enabled. If the section is enabled, it should be toggleable in the settings screen, and on by default."
+nimbus-validation:
+  description: A feature that does not correspond to an application feature suitable for showing that Nimbus is working.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    settings-icon:
+      type: string
+      description: The drawable displayed in the app menu for Settings
+    settings-title:
+      type: string
+      description: The title of displayed in the Settings screen and app menu.
+    settings-title-punctuation:
+      type: string
+      description: The emoji displayed in the Settings screen title.
+search:
+  description: The search feature
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    awesome-bar:
+      type: json
+      description: This property is covers the properties related to the awesome-bar
+    spotlight:
+      type: json
+      description: This property is covers the properties related to the spotlight
+tabTrayFeature:
+  description: The tab tray screen that the user goes to when they open the tab tray.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    sections-enabled:
+      type: json
+      description: "This property provides a lookup table of whether or not the given section should be enabled. If the section is enabled, it should be toggleable in the settings screen, and on by default."

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -1,8 +1,9 @@
 ---
 channels:
-  - Fennec
-  - FirefoxBeta
-  - Firefox
+  - release
+  - beta
+  - nightly
+  - developer
 features:
   search:
     description: The search feature
@@ -59,7 +60,7 @@ features:
             "libraryShortcuts": true
           }
     defaults:
-      - channel: Fennec
+      - channel: developer
         value: {
           "sections-enabled": {
             "topSites": true,
@@ -82,7 +83,7 @@ features:
             "inactive-tabs": false,
           }
     defaults:
-      - channel: Fennec
+      - channel: developer
         value: {
           "sections-enabled": {
             "inactive-tabs": true

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -2,7 +2,6 @@
 channels:
   - release
   - beta
-  - nightly
   - developer
 features:
   search:


### PR DESCRIPTION
This generates a version of the nimbus manifest suitable for ingestion by the Experimenter service.

It also changes the channels in the FML file in order to align with the channels already registered in Experimenter.

*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Please make sure you've run the test scheme and all the tests pass. If your changes affect existing tests please make sure to update the tests as well.

