### PR TITLE
Bugfix fx3641 [v100] Sign in to sync error when app is in background

### DIFF
--- a/RustFxA/FxAWebViewController.swift
+++ b/RustFxA/FxAWebViewController.swift
@@ -116,9 +116,9 @@ class FxAWebViewController: UIViewController {
             return
         }
 
-        backgroundTaskID = UIApplication.shared.beginBackgroundTask(withName: backgroundTaskName) {
-            self.webView.stopLoading()
-            self.endPairingConnectionBackgroundTask()
+        backgroundTaskID = UIApplication.shared.beginBackgroundTask(withName: backgroundTaskName) { [weak self] in
+            self?.webView.stopLoading()
+            self?.endPairingConnectionBackgroundTask()
         }
 
         webView.load(request)

--- a/RustFxA/FxAWebViewController.swift
+++ b/RustFxA/FxAWebViewController.swift
@@ -99,6 +99,7 @@ class FxAWebViewController: UIViewController {
 
     deinit {
         webView.removeObserver(self, forKeyPath: KVOConstants.URL.rawValue)
+        endPairingConnectionBackgroundTask()
     }
 
     // MARK: Background task


### PR DESCRIPTION
# Issue #9807
Goal is to able to finish the pairing process after switching back from the authenticator app. One way to improve on this is to start a background task so Apple doesn't suspend the app (and socket connection) when Firefox iOS is send to background.

Also reorder some MARK in that class.