### PR TITLE
Bugfix #10407 [v100] Remove spacing at the top of tabs tray

### DIFF
--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -748,7 +748,11 @@ fileprivate class TabLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayou
 
             return UIEdgeInsets(equalInset: GridTabTrayControllerUX.Margin)
 
-        default:
+        case .groupedTabs:
+            guard tabDisplayManager.shouldEnableGroupedTabs,
+                  tabDisplayManager.tabGroups?.count ?? 0 > 0
+            else { return .zero }
+
             return UIEdgeInsets(equalInset: GridTabTrayControllerUX.Margin)
         }
     }

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -472,6 +472,8 @@ extension TabDisplayManager: UICollectionViewDataSource {
             guard let vm = inactiveViewModel, vm.inactiveTabs.count > 0 else { return 0 }
             return shouldEnableInactiveTabs ? (isPrivate ? 0 : 1) : 0
         case .groupedTabs:
+            // Hide grouped tab section if there are no grouped tabs
+            guard let groups = tabGroups, groups.count > 0 else { return 0 }
             return shouldEnableGroupedTabs ? (isPrivate ? 0 : 1) : 0
         case .regularTabs:
             return dataStore.count


### PR DESCRIPTION
This removes the extra spacing in the tab tray for normal tabs.
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-04-08 at 17 38 10](https://user-images.githubusercontent.com/650804/162535857-8e5f6e23-ae68-42ed-8c8b-e728d386b6a8.png)
 