### PR TITLE
Add fx3833 [v100] Sponsored tile UI

### DIFF
--- a/Client/Frontend/Home/TopSites/HomeTopSite.swift
+++ b/Client/Frontend/Home/TopSites/HomeTopSite.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Storage
+import Shared
 
 // Top site UI class, used in the home top site section
 final class HomeTopSite {
@@ -11,6 +12,14 @@ final class HomeTopSite {
     var site: Site
     var title: String
     var image: UIImage?
+
+    var sponsoredText: String {
+        return .FirefoxHomepage.Shortcuts.Sponsored
+    }
+
+    var accessibilityLabel: String? {
+        return isSponsoredTile ? "\(title), \(sponsoredText)" : title
+    }
 
     var isPinned: Bool {
         return (site as? PinnedSite) != nil
@@ -42,6 +51,7 @@ final class HomeTopSite {
         } else {
             title = site.tileURL.shortDisplayString
         }
+        title.capitalizeFirstLetter()
 
         let imageHelper = SiteImageHelper(profile: profile)
         imageHelper.fetchImageFor(site: site,

--- a/Client/Frontend/Home/TopSites/TopSiteItemCell.swift
+++ b/Client/Frontend/Home/TopSites/TopSiteItemCell.swift
@@ -38,8 +38,16 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
         imageView.layer.masksToBounds = true
     }
 
-    private lazy var titleWrapper: UIView = .build { view in
+    // Holds the title and the pin image of the top site
+    private lazy var titlePinWrapper: UIView = .build { view in
         view.backgroundColor = .clear
+    }
+
+    // Holds the titlePinWrapper and the Sponsored text for a sponsored tile
+    private lazy var descriptionWrapper: UIStackView = .build { stackView in
+        stackView.backgroundColor = .clear
+        stackView.axis = .vertical
+        stackView.alignment = .center
     }
 
     private lazy var pinViewHolder: UIView = .build { view in
@@ -57,6 +65,17 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
                                                                         maxSize: 18)
         titleLabel.preferredMaxLayoutWidth = UX.imageBackgroundSize.width + TopSiteItemCell.UX.shadowRadius
         titleLabel.numberOfLines = 2
+        titleLabel.backgroundColor = UIColor.clear
+    }
+
+    private lazy var sponsoredLabel: UILabel = .build { sponsoredLabel in
+        sponsoredLabel.textAlignment = .center
+        // Limiting max size to accomodate for non-self-sizing parent cell.
+        sponsoredLabel.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
+                                                                            maxSize: 18)
+        sponsoredLabel.preferredMaxLayoutWidth = UX.imageBackgroundSize.width + TopSiteItemCell.UX.shadowRadius
+        sponsoredLabel.numberOfLines = 1
+        sponsoredLabel.isHidden = true
     }
 
     private lazy var faviconBG: UIView = .build { view in
@@ -117,9 +136,10 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
         imageView.image = nil
         imageView.backgroundColor = UIColor.clear
 
+        titleLabel.numberOfLines = 2
         titleLabel.text = nil
         titleLabelLeadingConstraint?.isActive = true
-
+        sponsoredLabel.isHidden = true
         pinViewHolder.isHidden = true
         pinImageView.removeFromSuperview()
     }
@@ -134,7 +154,7 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
     func configure(_ topSite: HomeTopSite) {
         homeTopSite = topSite
         titleLabel.text = topSite.title
-        accessibilityLabel = titleLabel.text
+        accessibilityLabel = topSite.accessibilityLabel
 
         imageView.image = topSite.image
         topSite.imageLoaded = { image in
@@ -144,25 +164,29 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
         }
 
         configurePinnedSite(topSite)
+        configureSponsoredSite(topSite)
+
         applyTheme()
     }
 
     // MARK: - Setup Helper methods
 
     private func setupLayout() {
-        titleWrapper.addSubview(titleLabel)
-        titleWrapper.addSubview(pinViewHolder)
-        contentView.addSubview(titleWrapper)
+        titlePinWrapper.addSubview(titleLabel)
+        titlePinWrapper.addSubview(pinViewHolder)
+        descriptionWrapper.addArrangedSubview(titlePinWrapper)
+        descriptionWrapper.addArrangedSubview(sponsoredLabel)
+        contentView.addSubview(descriptionWrapper)
         faviconBG.addSubview(imageView)
         contentView.addSubview(faviconBG)
         contentView.addSubview(selectedOverlay)
 
         NSLayoutConstraint.activate([
-            titleWrapper.topAnchor.constraint(equalTo: faviconBG.bottomAnchor, constant: UX.Spacing),
-            titleWrapper.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-            titleWrapper.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
-            titleWrapper.widthAnchor.constraint(greaterThanOrEqualToConstant: UX.imageBackgroundSize.width),
-            titleWrapper.widthAnchor.constraint(lessThanOrEqualToConstant: contentView.frame.width - UX.widthSafeSpace),
+            descriptionWrapper.topAnchor.constraint(equalTo: faviconBG.bottomAnchor, constant: UX.Spacing),
+            descriptionWrapper.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor),
+            descriptionWrapper.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            descriptionWrapper.widthAnchor.constraint(greaterThanOrEqualToConstant: UX.imageBackgroundSize.width),
+            descriptionWrapper.widthAnchor.constraint(lessThanOrEqualToConstant: contentView.frame.width - UX.widthSafeSpace),
 
             faviconBG.topAnchor.constraint(equalTo: contentView.topAnchor),
             faviconBG.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
@@ -179,17 +203,18 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
             selectedOverlay.trailingAnchor.constraint(equalTo: faviconBG.trailingAnchor),
             selectedOverlay.bottomAnchor.constraint(equalTo: faviconBG.bottomAnchor),
 
-            pinViewHolder.leadingAnchor.constraint(equalTo: titleWrapper.leadingAnchor),
+            pinViewHolder.leadingAnchor.constraint(equalTo: titlePinWrapper.leadingAnchor),
             pinViewHolder.bottomAnchor.constraint(equalTo: titleLabel.firstBaselineAnchor, constant: UX.pinAlignmentSpacing),
 
-            titleLabel.topAnchor.constraint(equalTo: titleWrapper.topAnchor),
+            titleLabel.topAnchor.constraint(equalTo: titlePinWrapper.topAnchor),
             titleLabel.leadingAnchor.constraint(equalTo: pinViewHolder.trailingAnchor),
-            titleLabel.trailingAnchor.constraint(equalTo: titleWrapper.trailingAnchor),
-            titleLabel.bottomAnchor.constraint(lessThanOrEqualTo: titleWrapper.bottomAnchor)
+            titleLabel.trailingAnchor.constraint(equalTo: titlePinWrapper.trailingAnchor),
+            titleLabel.bottomAnchor.constraint(lessThanOrEqualTo: titlePinWrapper.bottomAnchor)
         ])
 
         titleLabel.setContentHuggingPriority(UILayoutPriority(1000), for: .vertical)
-        titleLabelLeadingConstraint = titleLabel.leadingAnchor.constraint(equalTo: titleWrapper.leadingAnchor)
+        titlePinWrapper.setContentHuggingPriority(UILayoutPriority(1000), for: .vertical)
+        titleLabelLeadingConstraint = titleLabel.leadingAnchor.constraint(equalTo: titlePinWrapper.leadingAnchor)
         titleLabelLeadingConstraint?.isActive = true
     }
 
@@ -209,6 +234,14 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
             pinImageView.heightAnchor.constraint(equalToConstant: UX.pinIconSize.height),
         ])
     }
+
+    private func configureSponsoredSite(_ topSite: HomeTopSite) {
+        guard topSite.isSponsoredTile else { return }
+
+        titleLabel.numberOfLines = 1
+        sponsoredLabel.text = topSite.sponsoredText
+        sponsoredLabel.isHidden = false
+    }
 }
 
 // MARK: NotificationThemeable
@@ -218,7 +251,13 @@ extension TopSiteItemCell: NotificationThemeable {
         titleLabel.textColor = UIColor.theme.homePanel.topSiteDomain
         faviconBG.backgroundColor = UIColor.theme.homePanel.shortcutBackground
         faviconBG.layer.shadowColor = UIColor.theme.homePanel.shortcutShadowColor
-        titleLabel.backgroundColor = UIColor.clear
+
+        let theme = BuiltinThemeName(rawValue: LegacyThemeManager.instance.current.name) ?? .normal
+        if theme == .dark {
+            sponsoredLabel.textColor = UIColor.Photon.LightGrey40
+        } else {
+            sponsoredLabel.textColor = UIColor.Photon.DarkGrey05
+        }
     }
 }
 

--- a/CredentialProvider/Extensions/UIImageExtension.swift
+++ b/CredentialProvider/Extensions/UIImageExtension.swift
@@ -6,19 +6,19 @@ import UIKit
 
 extension UIImage {
     func tinted(_ color: UIColor) -> UIImage? {
-           UIGraphicsBeginImageContextWithOptions(size, false, scale)
-           defer { UIGraphicsEndImageContext() }
-           color.set()
-           draw(in: CGRect(origin: .zero, size: size))
-           return UIGraphicsGetImageFromCurrentImageContext()
-       }
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        defer { UIGraphicsEndImageContext() }
+        color.set()
+        draw(in: CGRect(origin: .zero, size: size))
+        return UIGraphicsGetImageFromCurrentImageContext()
+    }
 
-       static func color(_ color: UIColor, size: CGSize=CGSize(width: 1, height: 1)) -> UIImage? {
-           UIGraphicsBeginImageContextWithOptions(size, false, 0)
-           color.setFill()
-           UIRectFill(CGRect(origin: CGPoint.zero, size: size))
-           let image = UIGraphicsGetImageFromCurrentImageContext()
-           UIGraphicsEndImageContext()
-           return image
-       }
+    static func color(_ color: UIColor, size: CGSize=CGSize(width: 1, height: 1)) -> UIImage? {
+        UIGraphicsBeginImageContextWithOptions(size, false, 0)
+        color.setFill()
+        UIRectFill(CGRect(origin: CGPoint.zero, size: size))
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return image
+    }
 }

--- a/Providers/PocketFeed.swift
+++ b/Providers/PocketFeed.swift
@@ -148,7 +148,7 @@ class Pocket: FeatureFlagsProtocol {
     }
 
     private var shouldUseMockData: Bool {
-        return featureFlags.isFeatureActiveForBuild(.useMockData) && pocketKey == nil
+        return featureFlags.isFeatureActiveForBuild(.useMockData) && (pocketKey == "" || pocketKey == nil)
     }
 
     private func getMockDataFeed(items: Int = 2) -> Deferred<Array<PocketStory>> {

--- a/Shared/Extensions/StringExtensions.swift
+++ b/Shared/Extensions/StringExtensions.swift
@@ -131,4 +131,14 @@ public extension String {
         attributedString.addAttributes(boldFontAttribute, range: range)
         return attributedString
     }
+
+    // Capitalize first letter of a string
+    func capitalizingFirstLetter() -> String {
+        return prefix(1).capitalized + dropFirst()
+    }
+
+    // Capitalize first letter of a string in place
+    mutating func capitalizeFirstLetter() {
+        self = self.capitalizingFirstLetter()
+    }
 }


### PR DESCRIPTION
Issue: https://mozilla-hub.atlassian.net/browse/FXIOS-3833
- Add the sponsored tile UI label in the tiles UI
- Note that sponsored tile won't appear unless you provide mock data in ContileProviderMock
- Fix the pocket feed as well, forgot to check on empty string for the key
- Fix indentation in a file