### PR TITLE
Bugfix #10364 [v100] Adjust sentry log level + Setup releaseName

### DIFF
--- a/Client/Application/AppDelegate+PushNotifications.swift
+++ b/Client/Application/AppDelegate+PushNotifications.swift
@@ -111,6 +111,6 @@ extension AppDelegate {
 
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         print("failed to register. \(error)")
-        Sentry.shared.send(message: "Failed to register for APNS")
+        SentryIntegration.shared.send(message: "Failed to register for APNS")
     }
 }

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -82,7 +82,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Need to get "settings.sendUsageData" this way so that Sentry can be initialized
         // before getting the Profile.
         let sendUsageData = NSUserDefaultsPrefs(prefix: "profile").boolForKey(AppConstants.PrefSendUsageData) ?? true
-        Sentry.shared.setup(sendUsageData: sendUsageData)
+        SentryIntegration.shared.setup(sendUsageData: sendUsageData)
 
         // Set the Firefox UA for browsing.
         setUserAgent()

--- a/Client/Experiments/Experiments.swift
+++ b/Client/Experiments/Experiments.swift
@@ -185,7 +185,7 @@ enum Experiments {
         )
 
         let errorReporter: NimbusErrorReporter = { err in
-            Sentry.shared.sendWithStacktrace(
+            SentryIntegration.shared.sendWithStacktrace(
                 message: "Error in Nimbus SDK",
                 tag: SentryTag.nimbus,
                 severity: .error,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1153,7 +1153,7 @@ class BrowserViewController: UIViewController {
             return
         }
         guard let kp = keyPath, let path = KVOConstants(rawValue: kp) else {
-            Sentry.shared.send(message: "BVC observeValue webpage unhandled KVO", tag: .general,
+            SentryIntegration.shared.send(message: "BVC observeValue webpage unhandled KVO", tag: .general,
                                severity: .error,
                                description: "Unhandled KVO key: \(keyPath ?? "nil")")
             return

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -786,7 +786,7 @@ class BrowserViewController: UIViewController {
     var displayedRestoreTabsAlert = false
 
     fileprivate func crashedLastLaunch() -> Bool {
-        return Sentry.shared.crashedLastLaunch
+        return SentryIntegration.shared.crashedLastLaunch
     }
 
     fileprivate func cleanlyBackgrounded() -> Bool {

--- a/Client/Frontend/Browser/QRCodeViewController.swift
+++ b/Client/Frontend/Browser/QRCodeViewController.swift
@@ -284,7 +284,7 @@ extension QRCodeViewController: AVCaptureMetadataOutputObjectsDelegate {
             stopScanLineAnimation()
             self.dismiss(animated: true, completion: {
                 guard let metaData = metadataObjects.first as? AVMetadataMachineReadableCodeObject, let qrCodeDelegate = self.qrCodeDelegate, let text = metaData.stringValue else {
-                        Sentry.shared.sendWithStacktrace(message: "Unable to scan QR code", tag: .general)
+                        SentryIntegration.shared.sendWithStacktrace(message: "Unable to scan QR code", tag: .general)
                         return
                 }
 

--- a/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -25,7 +25,7 @@ class ScreenshotHelper {
      */
     func takeScreenshot(_ tab: Tab) {
         guard let webView = tab.webView, let url = tab.url else {
-            Sentry.shared.send(message: "Tab Snapshot Error", tag: .tabManager, severity: .debug, description: "Tab webView or url is nil")
+            SentryIntegration.shared.send(message: "Tab Snapshot Error", tag: .tabManager, severity: .debug, description: "Tab webView or url is nil")
             return
         }
         //Handle home page snapshots, can not use Apple API snapshot function for this
@@ -48,9 +48,9 @@ class ScreenshotHelper {
                     tab.setScreenshot(image)
                     TabEvent.post(.didSetScreenshot(isHome: false), for: tab)
                 } else if let error = error {
-                    Sentry.shared.send(message: "Tab snapshot error", tag: .tabManager, severity: .debug, description: error.localizedDescription)
+                    SentryIntegration.shared.send(message: "Tab snapshot error", tag: .tabManager, severity: .debug, description: error.localizedDescription)
                 } else {
-                    Sentry.shared.send(message: "Tab snapshot error", tag: .tabManager, severity: .debug, description: "No error description")
+                    SentryIntegration.shared.send(message: "Tab snapshot error", tag: .tabManager, severity: .debug, description: "No error description")
                 }
             }
         }

--- a/Client/Frontend/Browser/SiteArchiver.swift
+++ b/Client/Frontend/Browser/SiteArchiver.swift
@@ -23,7 +23,7 @@ struct SiteArchiver {
         unarchiver.setClass(SessionData.self, forClassName: "Client.SessionData")
         unarchiver.decodingFailurePolicy = .setErrorAndReturn
         guard let tabs = unarchiver.decodeObject(forKey: "tabs") as? [SavedTab] else {
-            Sentry.shared.send( message: "Failed to restore tabs", tag: .tabManager, severity: .error, description: "\(unarchiver.error ??? "nil")")
+            SentryIntegration.shared.send( message: "Failed to restore tabs", tag: .tabManager, severity: .error, description: "\(unarchiver.error ??? "nil")")
             SimpleTab.saveSimpleTab(tabs: nil)
             return ([SavedTab](), simpleTabsDict)
         }

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -1018,7 +1018,7 @@ extension TabDisplayOrder {
                 return order
             }
             catch let error as NSError {
-                Sentry.shared.send(message: "Error: Unable to decode tab display order", tag: SentryTag.tabDisplayManager, severity: .error, description: error.debugDescription)
+                SentryIntegration.shared.send(message: "Error: Unable to decode tab display order", tag: SentryTag.tabDisplayManager, severity: .error, description: error.debugDescription)
             }
         }
         return nil

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -618,7 +618,7 @@ class TabManager: NSObject, FeatureFlagsProtocol {
     fileprivate func removeTab(_ tab: Tab, flushToDisk: Bool) {
 
         guard let removalIndex = tabs.firstIndex(where: { $0 === tab }) else {
-            Sentry.shared.sendWithStacktrace(message: "Could not find index of tab to remove", tag: .tabManager, severity: .fatal, description: "Tab count: \(count)")
+            SentryIntegration.shared.sendWithStacktrace(message: "Could not find index of tab to remove", tag: .tabManager, severity: .fatal, description: "Tab count: \(count)")
             return
         }
 

--- a/Client/Frontend/Browser/TabMetadataManager.swift
+++ b/Client/Frontend/Browser/TabMetadataManager.swift
@@ -95,6 +95,8 @@ class TabMetadataManager {
                                          completion: (() -> ())?) {
         guard let profile = profile else { return }
 
+        guard !key.url.isEmpty else { return }
+
         profile.places.noteHistoryMetadataObservation(key: key, observation: observation).uponQueue(.main) { _ in
             completion?()
         }

--- a/Client/Frontend/Browser/TopTabsLayout.swift
+++ b/Client/Frontend/Browser/TopTabsLayout.swift
@@ -72,7 +72,7 @@ class TopTabsViewLayout: UICollectionViewFlowLayout {
         attributes?.zIndex = SeparatorZIndex
         return attributes
     }
-    
+
     override var flipsHorizontallyInOppositeLayoutDirection: Bool {
         return true
     }

--- a/Client/Frontend/EnhancedTrackingProtection/ETPViewModel.swift
+++ b/Client/Frontend/EnhancedTrackingProtection/ETPViewModel.swift
@@ -23,7 +23,7 @@ class ETPViewModel {
         etpCoverSheetmodel = ETPCoverSheetModel(titleImage: #imageLiteral(resourceName: "shield"), titleText: .CoverSheetETPTitle, descriptionText: .CoverSheetETPDescription)
     }
 
-    static func shouldShowETPCoverSheet(userPrefs: Prefs, currentAppVersion: String = VersionSetting.appVersion, isCleanInstall: Bool, supportedAppVersions: [String] = etpCoverSheetSupportedAppVersion) -> Bool {
+    static func shouldShowETPCoverSheet(userPrefs: Prefs, currentAppVersion: String = AppInfo.appVersion, isCleanInstall: Bool, supportedAppVersions: [String] = etpCoverSheetSupportedAppVersion) -> Bool {
         // 0,1,2 so we show on 3rd session as a requirement on Github #6012
         let maxSessionCount = 2
         var shouldShow = false

--- a/Client/Frontend/Login Management/BreachAlertsClient.swift
+++ b/Client/Frontend/Login Management/BreachAlertsClient.swift
@@ -34,7 +34,7 @@ public class BreachAlertsClient: BreachAlertsClientProtocol {
         dataTask = URLSession.shared.dataTask(with: request) { _, response, _ in
             guard let response = response as? HTTPURLResponse else { return }
             guard response.statusCode < 400 else {
-                Sentry.shared.send(message: "BreachAlerts: fetchEtag: HTTP status code: \(response.statusCode)")
+                SentryIntegration.shared.send(message: "BreachAlerts: fetchEtag: HTTP status code: \(response.statusCode)")
                 completion(nil)
                 return
             }
@@ -58,17 +58,17 @@ public class BreachAlertsClient: BreachAlertsClientProtocol {
         dataTask = URLSession.shared.dataTask(with: url) { data, response, error in
             guard let response = response as? HTTPURLResponse else { return }
             guard response.statusCode < 400 else {
-                Sentry.shared.send(message: "BreachAlerts: fetchData: HTTP status code: \(response.statusCode)")
+                SentryIntegration.shared.send(message: "BreachAlerts: fetchData: HTTP status code: \(response.statusCode)")
                 return
             }
             if let error = error {
                 completion(Maybe(failure: BreachAlertsError(description: error.localizedDescription)))
-                Sentry.shared.send(message: "BreachAlerts: fetchData: \(error)")
+                SentryIntegration.shared.send(message: "BreachAlerts: fetchData: \(error)")
                 return
             }
             guard let data = data else {
                 completion(Maybe(failure: BreachAlertsError(description: "invalid data")))
-                Sentry.shared.send(message: "BreachAlerts: fetchData: invalid data")
+                SentryIntegration.shared.send(message: "BreachAlerts: fetchData: invalid data")
                 assert(false)
                 return
             }

--- a/Client/Frontend/Login Management/BreachAlertsManager.swift
+++ b/Client/Frontend/Login Management/BreachAlertsManager.swift
@@ -63,7 +63,7 @@ final public class BreachAlertsManager {
         // 1b. local file exists, so load from that
         guard let fileData = FileManager.default.contents(atPath: cacheURL.path) else {
             completion(Maybe(failure: BreachAlertsError(description: "failed to get data from breach.json")))
-            Sentry.shared.send(message: "BreachAlerts: failed to get data from breach.json")
+            SentryIntegration.shared.send(message: "BreachAlerts: failed to get data from breach.json")
             try? FileManager.default.removeItem(at: cacheURL) // bad file, so delete it
             self.fetchAndSaveBreaches(completion)
             return

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -665,15 +665,7 @@ class VersionSetting: Setting {
     }
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: "\(AppName.longName) \(VersionSetting.appVersion) (\(VersionSetting.appBuildNumber))", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
-    }
-
-    public static var appVersion: String {
-        return Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
-    }
-
-    public static var appBuildNumber: String {
-        return Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as! String
+        return NSAttributedString(string: "\(AppName.longName) \(AppInfo.appVersion) (\(AppInfo.buildNumber))", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override func onConfigureCell(_ cell: UITableViewCell) {

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -464,7 +464,7 @@ class ForceCrashSetting: HiddenSetting {
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        Sentry.shared.crash()
+        SentryIntegration.shared.crash()
     }
 }
 

--- a/Client/Frontend/Update/UpdateViewModel.swift
+++ b/Client/Frontend/Update/UpdateViewModel.swift
@@ -32,7 +32,7 @@ class UpdateViewModel {
         return false
     }
 
-    static func shouldShowUpdateSheet(userPrefs: Prefs, currentAppVersion: String = VersionSetting.appVersion, isCleanInstall: Bool, supportedAppVersions: [String] = []) -> Bool {
+    static func shouldShowUpdateSheet(userPrefs: Prefs, currentAppVersion: String = AppInfo.appVersion, isCleanInstall: Bool, supportedAppVersions: [String] = []) -> Bool {
         var willShow = false
         if isCleanInstall {
             // We don't show it but save the currentVersion number

--- a/Client/RatingPromptManager.swift
+++ b/Client/RatingPromptManager.swift
@@ -33,7 +33,7 @@ final class RatingPromptManager {
     ///   - sentry: Sentry protocol to override in Unit test
     init(profile: Profile,
          daysOfUseCounter: CumulativeDaysOfUseCounter = CumulativeDaysOfUseCounter(),
-         sentry: SentryProtocol = Sentry.shared) {
+         sentry: SentryProtocol = SentryIntegration.shared) {
         self.profile = profile
         self.daysOfUseCounter = daysOfUseCounter
         self.sentry = sentry

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -924,7 +924,7 @@ extension TelemetryWrapper {
         extras: [String: Any]?
     ) {
         let msg = "Uninstrumented metric recorded: \(category), \(method), \(object), \(String(describing: value)), \(String(describing: extras))"
-        SentryIntegration.shared.send(message: msg, severity: .debug)
+        SentryIntegration.shared.send(message: msg, severity: .info)
     }
 }
 

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -41,7 +41,7 @@ class TelemetryWrapper {
     }
 
     init(profile: Profile) {
-        crashedLastLaunch = Sentry.shared.crashedLastLaunch
+        crashedLastLaunch = SentryIntegration.shared.crashedLastLaunch
 
         migratePathComponentInDocumentsDirectory("MozTelemetry-Default-core", to: .cachesDirectory)
         migratePathComponentInDocumentsDirectory("MozTelemetry-Default-mobile-event", to: .cachesDirectory)
@@ -254,7 +254,7 @@ class TelemetryWrapper {
 
     @objc func uploadError(notification: NSNotification) {
         guard !DeviceInfo.isSimulator(), let error = notification.userInfo?["error"] as? NSError else { return }
-        Sentry.shared.send(message: "Upload Error", tag: SentryTag.unifiedTelemetry, severity: .info, description: error.debugDescription)
+        SentryIntegration.shared.send(message: "Upload Error", tag: SentryTag.unifiedTelemetry, severity: .info, description: error.debugDescription)
     }
 }
 
@@ -924,7 +924,7 @@ extension TelemetryWrapper {
         extras: [String: Any]?
     ) {
         let msg = "Uninstrumented metric recorded: \(category), \(method), \(object), \(String(describing: value)), \(String(describing: extras))"
-        Sentry.shared.send(message: msg, severity: .debug)
+        SentryIntegration.shared.send(message: msg, severity: .debug)
     }
 }
 

--- a/Client/UIScrollViewSwizzled.swift
+++ b/Client/UIScrollViewSwizzled.swift
@@ -30,7 +30,7 @@ extension UIScrollView {
         let validBounds = [bounds.size.width, bounds.size.height].every({ $0 >= 0 })
 
         guard validBounds && validSize && !bounds.isInfinite else {
-            Sentry.shared.send(message: "Bad scrollview bounds detected [negative size].")
+            SentryIntegration.shared.send(message: "Bad scrollview bounds detected [negative size].")
             return
         }
         self.swizzle_setBounds(bounds: bounds)

--- a/Client/Utils/FaviconFetcher.swift
+++ b/Client/Utils/FaviconFetcher.swift
@@ -208,7 +208,7 @@ open class FaviconFetcher: NSObject, XMLParserDelegate {
             }
           }
         } catch let error as NSError {
-            Sentry.shared.send(message: "Favicon cache directory creation failed", tag: .general, severity: .error, description: error.description)
+            SentryIntegration.shared.send(message: "Favicon cache directory creation failed", tag: .general, severity: .error, description: error.description)
         }
     }
 

--- a/Extensions/NotificationService/NotificationService.swift
+++ b/Extensions/NotificationService/NotificationService.swift
@@ -90,7 +90,7 @@ class SyncDataDisplay {
         self.contentHandler = contentHandler
         self.notificationContent = content
         self.tabQueue = tabQueue
-        Sentry.shared.setup(sendUsageData: true)
+        SentryIntegration.shared.setup(sendUsageData: true)
     }
 
     func displayNotification(_ message: PushMessage? = nil, profile: ExtensionProfile?, with error: PushMessageError? = nil) {
@@ -139,7 +139,7 @@ extension SyncDataDisplay {
     }
 
     func displayAccountVerifiedNotification() {
-        Sentry.shared.send(message: "SentTab error: account not verified")
+        SentryIntegration.shared.send(message: "SentTab error: account not verified")
         #if MOZ_CHANNEL_BETA || DEBUG
             presentNotification(title: .SentTab_NoTabArrivingNotification_title, body: "DEBUG: Account Verified")
             return
@@ -149,7 +149,7 @@ extension SyncDataDisplay {
     }
 
     func displayUnknownMessageNotification(debugInfo: String) {
-        Sentry.shared.send(message: "SentTab error: \(debugInfo)")
+        SentryIntegration.shared.send(message: "SentTab error: \(debugInfo)")
         #if MOZ_CHANNEL_BETA || DEBUG
             presentNotification(title: .SentTab_NoTabArrivingNotification_title, body: "DEBUG: " + debugInfo)
             return
@@ -192,7 +192,7 @@ extension SyncDataDisplay {
             #else
                 body = .SentTab_NoTabArrivingNotification_body
             #endif
-            Sentry.shared.send(message: "SentTab error: no tab")
+            SentryIntegration.shared.send(message: "SentTab error: no tab")
         } else {
             let deviceNames = Set(tabs.compactMap { $0["deviceName"] as? String })
             if let deviceName = deviceNames.first, deviceNames.count == 1 {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -309,7 +309,7 @@ open class BrowserProfile: Profile {
             case .warn:
                 log.warning(logString)
             case .error:
-                Sentry.shared.sendWithStacktrace(message: logString, tag: .rustLog, severity: .error)
+                SentryIntegration.shared.sendWithStacktrace(message: logString, tag: .rustLog, severity: .error)
                 log.error(logString)
             }
 
@@ -1035,7 +1035,7 @@ open class BrowserProfile: Profile {
                         }
 
                         guard let encryptionKey = try? self.profile.logins.getStoredKey() else {
-                            Sentry.shared.sendWithStacktrace(message: "Stored logins encryption could not be retrieved", tag: SentryTag.rustLogins, severity: .warning)
+                            SentryIntegration.shared.sendWithStacktrace(message: "Stored logins encryption could not be retrieved", tag: SentryTag.rustLogins, severity: .warning)
                             d.fill(Maybe(failure: EncryptionKeyError()))
                             return
                         }

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -189,7 +189,7 @@ extension FirefoxAccountSignInViewController: QRCodeViewControllerDelegate {
     }
 
     func didScanQRCodeWithText(_ text: String) {
-        Sentry.shared.send(message: "FirefoxAccountSignInVC Error: `didScanQRCodeWithText` should not be called")
+        SentryIntegration.shared.send(message: "FirefoxAccountSignInVC Error: `didScanQRCodeWithText` should not be called")
     }
 }
 

--- a/RustFxA/FxAWebViewController.swift
+++ b/RustFxA/FxAWebViewController.swift
@@ -236,8 +236,8 @@ extension FxAWebViewController {
     }
 
     private func sendSentryObserveValueError(forKeyPath keyPath: String?) {
-        Sentry.shared.send(message: "FxA webpage unhandled KVO", tag: .rustLog,
-                           severity: .error,
-                           description: "Unhandled KVO key: \(keyPath ?? "nil")")
+        SentryIntegration.shared.send(message: "FxA webpage unhandled KVO", tag: .rustLog,
+                                      severity: .error,
+                                      description: "Unhandled KVO key: \(keyPath ?? "nil")")
     }
 }

--- a/RustFxA/RustFirefoxAccounts.swift
+++ b/RustFxA/RustFirefoxAccounts.swift
@@ -181,7 +181,7 @@ open class RustFirefoxAccounts {
             if let error = notification.userInfo?["error"] as? Error {
                 info = error.localizedDescription
             }
-            Sentry.shared.send(message: "RustFxa failed account migration", tag: .rustLog, severity: .error, description: info)
+            SentryIntegration.shared.send(message: "RustFxa failed account migration", tag: .rustLog, severity: .error, description: info)
             self?.accountMigrationFailed = true
             NotificationCenter.default.post(name: .FirefoxAccountStateChange, object: nil)
         }

--- a/Shared/AppInfo.swift
+++ b/Shared/AppInfo.swift
@@ -21,6 +21,10 @@ open class AppInfo {
         }
     }
 
+    public static var bundleIdentifier: String {
+        return applicationBundle.object(forInfoDictionaryKey: "CFBundleIdentifier") as! String
+    }
+
     public static var displayName: String {
         return applicationBundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as! String
     }

--- a/Shared/SentryIntegration.swift
+++ b/Shared/SentryIntegration.swift
@@ -24,14 +24,14 @@ public protocol SentryProtocol {
     var crashedLastLaunch: Bool { get }
 }
 
-public class Sentry: SentryProtocol {
-
+public class SentryIntegration: SentryProtocol {
+    
     enum Environment: String {
         case nightly = "Nightly"
         case production = "Production"
     }
-
-    public static let shared = Sentry()
+    
+    public static let shared = SentryIntegration()
 
     private let SentryDSNKey = "SentryCloudDSN"
     private let SentryDeviceAppHashKey = "SentryDeviceAppHash"
@@ -127,28 +127,21 @@ public class Sentry: SentryProtocol {
         SentrySDK.capture(error: error)
     }
 
-    public func send(message: String, tag: SentryTag = .general, severity: SentryLevel = .info, extra: [String: Any]? = nil, description: String? = nil, completion: SentryRequestFinished? = nil) {
-        // Build the dictionary
-        var extraEvents: [String: Any] = [:]
-        if let paramEvents = extra {
-            extraEvents = extraEvents.merge(with: paramEvents)
-        }
-        if let extraString = description {
-            extraEvents = extraEvents.merge(with: ["errorDescription": extraString])
-        }
-        printMessage(message: message, extra: extraEvents)
-
-        // Only report fatal - errors on release
-        guard shouldSendEventFor(severity) else {
-            completion?(nil)
-            return
-        }
-
-        let event = makeEvent(message: message, tag: tag.rawValue, severity: severity, extra: extraEvents)
-        captureEvent(event: event)
+    public func send(message: String,
+                     tag: SentryTag = .general,
+                     severity: SentryLevel = .info,
+                     extra: [String: Any]? = nil,
+                     description: String? = nil,
+                     completion: SentryRequestFinished? = nil) {
+        sendWithStacktrace(message: message, tag: tag, severity: severity, extra: extra, description: description, completion: completion)
     }
 
-    public func sendWithStacktrace(message: String, tag: SentryTag = .general, severity: SentryLevel = .info, extra: [String: Any]? = nil, description: String? = nil, completion: SentryRequestFinished? = nil) {
+    public func sendWithStacktrace(message: String,
+                                   tag: SentryTag = .general,
+                                   severity: SentryLevel = .info,
+                                   extra: [String: Any]? = nil,
+                                   description: String? = nil,
+                                   completion: SentryRequestFinished? = nil) {
         var extraEvents: [String: Any] = [:]
         if let paramEvents = extra {
             extraEvents = extraEvents.merge(with: paramEvents)
@@ -185,10 +178,10 @@ public class Sentry: SentryProtocol {
                    .info .error .severe
          Debug      n      n       n
          Beta       y      y       y
-         Release    n      y       y
+         Release    n      n       y
      */
     private func shouldSendEventFor(_ severity: SentryLevel) -> Bool {
-        let shouldSendRelease = AppConstants.BuildChannel == .release && severity.rawValue >= SentryLevel.error.rawValue
+        let shouldSendRelease = AppConstants.BuildChannel == .release && severity.rawValue >= SentryLevel.fatal.rawValue
         let shouldSendBeta = AppConstants.BuildChannel == .beta && severity.rawValue >= SentryLevel.info.rawValue
 
         return shouldSendBeta || shouldSendRelease

--- a/Shared/SentryIntegration.swift
+++ b/Shared/SentryIntegration.swift
@@ -25,12 +25,12 @@ public protocol SentryProtocol {
 }
 
 public class SentryIntegration: SentryProtocol {
-    
+
     enum Environment: String {
         case nightly = "Nightly"
         case production = "Production"
     }
-    
+
     public static let shared = SentryIntegration()
 
     private let SentryDSNKey = "SentryCloudDSN"
@@ -46,8 +46,13 @@ public class SentryIntegration: SentryProtocol {
         return SentrySDK.crashedLastRun
     }
 
+    private var releaseName: String {
+        return "\(AppInfo.bundleIdentifier)@\(AppInfo.appVersion)+(\(AppInfo.buildNumber))"
+    }
+
     public func setup(sendUsageData: Bool) {
-        assert(!enabled, "Sentry.setup() should only be called once")
+        // Setup should only be called once
+        guard !enabled else { return }
 
         if DeviceInfo.isSimulator() {
             Logger.browserLogger.debug("Not enabling Sentry; Running in Simulator")
@@ -75,6 +80,7 @@ public class SentryIntegration: SentryProtocol {
         SentrySDK.start { options in
             options.dsn = dsn
             options.environment = environment.rawValue
+            options.releaseName = self.releaseName
             options.beforeSend = { event in
                 let attributes = event.extra ?? [:]
                 self.attributes = attributes.merge(with: self.attributes)

--- a/Storage/Rust/RustLogins.swift
+++ b/Storage/Rust/RustLogins.swift
@@ -358,7 +358,7 @@ public class RustLoginEncryptionKeys {
 
             return secret
         } catch let err as NSError {
-            Sentry.shared.sendWithStacktrace(message: "Error creating logins encryption key", tag: SentryTag.rustLogins, severity: .error, description: err.localizedDescription)
+            SentryIntegration.shared.sendWithStacktrace(message: "Error creating logins encryption key", tag: SentryTag.rustLogins, severity: .error, description: err.localizedDescription)
             throw LoginEncryptionKeyError.noKeyCreated
         }
     }
@@ -371,7 +371,7 @@ public class RustLoginEncryptionKeys {
         do {
             return try decryptLogin(login: login, encryptionKey: key)
         } catch let err as NSError {
-            Sentry.shared.sendWithStacktrace(message: "Error decrypting login", tag: SentryTag.rustLogins, severity: .error, description: err.localizedDescription)
+            SentryIntegration.shared.sendWithStacktrace(message: "Error decrypting login", tag: SentryTag.rustLogins, severity: .error, description: err.localizedDescription)
             return nil
         }
     }
@@ -384,7 +384,7 @@ public class RustLoginEncryptionKeys {
         do {
             return try encryptLogin(login: login, encryptionKey: key)
         } catch let err as NSError {
-            Sentry.shared.sendWithStacktrace(message: "Error encrypting login", tag: SentryTag.rustLogins, severity: .error, description: err.localizedDescription)
+            SentryIntegration.shared.sendWithStacktrace(message: "Error encrypting login", tag: SentryTag.rustLogins, severity: .error, description: err.localizedDescription)
             return nil
         }
     }
@@ -428,9 +428,9 @@ public class RustLogins {
                 // This is an unrecoverable
                 // state unless we can move the existing file to a backup
                 // location and start over.
-                Sentry.shared.sendWithStacktrace(message: "Unspecified or other error when opening Rust Logins database", tag: SentryTag.rustLogins, severity: .error, description: loginsStoreError.localizedDescription)
+                SentryIntegration.shared.sendWithStacktrace(message: "Unspecified or other error when opening Rust Logins database", tag: SentryTag.rustLogins, severity: .error, description: loginsStoreError.localizedDescription)
             } else {
-                Sentry.shared.sendWithStacktrace(message: "Unknown error when opening Rust Logins database", tag: SentryTag.rustLogins, severity: .error, description: err.localizedDescription)
+                SentryIntegration.shared.sendWithStacktrace(message: "Unknown error when opening Rust Logins database", tag: SentryTag.rustLogins, severity: .error, description: err.localizedDescription)
             }
 
             if !didAttemptToMoveToBackup {
@@ -490,9 +490,9 @@ public class RustLogins {
                 if let loginsStoreError = err as? LoginsStoreError {
                     switch loginsStoreError {
                     case let .SyncAuthInvalid(message):
-                        Sentry.shared.sendWithStacktrace(message: "Panicked when syncing Logins database", tag: SentryTag.rustLogins, severity: .error, description: message)
+                        SentryIntegration.shared.sendWithStacktrace(message: "Panicked when syncing Logins database", tag: SentryTag.rustLogins, severity: .error, description: message)
                     default:
-                        Sentry.shared.sendWithStacktrace(message: "Unspecified or other error when syncing Logins database", tag: SentryTag.rustLogins, severity: .error, description: loginsStoreError.localizedDescription)
+                        SentryIntegration.shared.sendWithStacktrace(message: "Unspecified or other error when syncing Logins database", tag: SentryTag.rustLogins, severity: .error, description: loginsStoreError.localizedDescription)
                     }
                 }
 
@@ -779,17 +779,17 @@ public class RustLogins {
                     if canaryIsValid {
                         return key!
                     } else {
-                        Sentry.shared.sendWithStacktrace(message: "Logins key was corrupted, new one generated", tag: SentryTag.rustLogins, severity: .warning)
+                        SentryIntegration.shared.sendWithStacktrace(message: "Logins key was corrupted, new one generated", tag: SentryTag.rustLogins, severity: .warning)
                         _ = self.wipeLocalEngine()
                         return try rustKeys.createAndStoreKey()
                     }
                 } catch let err as NSError {
-                    Sentry.shared.sendWithStacktrace(message: "Error retrieving logins encryption key", tag: SentryTag.rustLogins, severity: .error, description: err.localizedDescription)
+                    SentryIntegration.shared.sendWithStacktrace(message: "Error retrieving logins encryption key", tag: SentryTag.rustLogins, severity: .error, description: err.localizedDescription)
                 }
             case (.some(key), .none):
                 // The key is present, but we didn't expect it to be there.
                 do {
-                    Sentry.shared.sendWithStacktrace(message: "Logins key lost due to storage malfunction, new one generated", tag: SentryTag.rustLogins, severity: .warning)
+                    SentryIntegration.shared.sendWithStacktrace(message: "Logins key lost due to storage malfunction, new one generated", tag: SentryTag.rustLogins, severity: .warning)
                     _ = self.wipeLocalEngine()
                     return try rustKeys.createAndStoreKey()
                 } catch let err as NSError {
@@ -798,7 +798,7 @@ public class RustLogins {
             case (.none, .some(encryptedCanaryPhrase)):
                 // We expected the key to be present, but it's gone missing on us.
                 do {
-                    Sentry.shared.sendWithStacktrace(message: "Logins key lost, new one generated", tag: SentryTag.rustLogins, severity: .warning)
+                    SentryIntegration.shared.sendWithStacktrace(message: "Logins key lost, new one generated", tag: SentryTag.rustLogins, severity: .warning)
                     _ = self.wipeLocalEngine()
                     return try rustKeys.createAndStoreKey()
                 } catch let err as NSError {

--- a/Storage/Rust/RustPlaces.swift
+++ b/Storage/Rust/RustPlaces.swift
@@ -39,12 +39,12 @@ public class RustPlaces {
             if let placesError = err as? PlacesError {
                 switch placesError {
                 case .InternalPanic(let message):
-                    Sentry.shared.sendWithStacktrace(message: "Panicked when opening Rust Places database", tag: SentryTag.rustPlaces, severity: .error, description: message)
+                    SentryIntegration.shared.sendWithStacktrace(message: "Panicked when opening Rust Places database", tag: SentryTag.rustPlaces, severity: .error, description: message)
                 default:
-                    Sentry.shared.sendWithStacktrace(message: "Unspecified or other error when opening Rust Places database", tag: SentryTag.rustPlaces, severity: .error, description: placesError.localizedDescription)
+                    SentryIntegration.shared.sendWithStacktrace(message: "Unspecified or other error when opening Rust Places database", tag: SentryTag.rustPlaces, severity: .error, description: placesError.localizedDescription)
                 }
             } else {
-                Sentry.shared.sendWithStacktrace(message: "Unknown error when opening Rust Places database", tag: SentryTag.rustPlaces, severity: .error, description: err.localizedDescription)
+                SentryIntegration.shared.sendWithStacktrace(message: "Unknown error when opening Rust Places database", tag: SentryTag.rustPlaces, severity: .error, description: err.localizedDescription)
             }
 
             return err
@@ -144,7 +144,7 @@ public class RustPlaces {
         do {
             try api?.migrateBookmarksFromBrowserDb(path: browserDB.databasePath)
         } catch let err as NSError {
-            Sentry.shared.sendWithStacktrace(message: "Error encountered while migrating bookmarks from BrowserDB", tag: SentryTag.rustPlaces, severity: .error, description: err.localizedDescription)
+            SentryIntegration.shared.sendWithStacktrace(message: "Error encountered while migrating bookmarks from BrowserDB", tag: SentryTag.rustPlaces, severity: .error, description: err.localizedDescription)
         }
     }
 
@@ -301,9 +301,9 @@ public class RustPlaces {
                 if let placesError = err as? PlacesError {
                     switch placesError {
                     case .InternalPanic(let message):
-                        Sentry.shared.sendWithStacktrace(message: "Panicked when syncing Places database", tag: SentryTag.rustPlaces, severity: .error, description: message)
+                        SentryIntegration.shared.sendWithStacktrace(message: "Panicked when syncing Places database", tag: SentryTag.rustPlaces, severity: .error, description: message)
                     default:
-                        Sentry.shared.sendWithStacktrace(message: "Unspecified or other error when syncing Places database", tag: SentryTag.rustPlaces, severity: .error, description: placesError.localizedDescription)
+                        SentryIntegration.shared.sendWithStacktrace(message: "Unspecified or other error when syncing Places database", tag: SentryTag.rustPlaces, severity: .error, description: placesError.localizedDescription)
                     }
                 }
 

--- a/Storage/Rust/RustShared.swift
+++ b/Storage/Rust/RustShared.swift
@@ -16,11 +16,11 @@ public class RustShared {
         // Attempt to make a backup as long as the database file still exists.
         guard FileManager.default.fileExists(atPath: databasePath) else {
             // No backup was attempted since the database file did not exist.
-            Sentry.shared.sendWithStacktrace(message: "The Rust database was deleted while in use", tag: SentryTag.rustLogins)
+            SentryIntegration.shared.sendWithStacktrace(message: "The Rust database was deleted while in use", tag: SentryTag.rustLogins)
             return
         }
 
-        Sentry.shared.sendWithStacktrace(message: "Unable to open Rust database", tag: SentryTag.rustLogins, severity: .warning, description: "Attempting to move '\(baseFilename)'")
+        SentryIntegration.shared.sendWithStacktrace(message: "Unable to open Rust database", tag: SentryTag.rustLogins, severity: .warning, description: "Attempting to move '\(baseFilename)'")
 
         // Note that a backup file might already exist! We append a counter to avoid this.
         var bakCounter = 0
@@ -53,7 +53,7 @@ public class RustShared {
 
             log.debug("Finished moving Rust database (\(baseFilename)) successfully.")
         } catch let error as NSError {
-            Sentry.shared.sendWithStacktrace(message: "Unable to move Rust database to backup location", tag: SentryTag.rustLogins, severity: .error, description: "Attempted to move to '\(bakBaseFilename)'. \(error.localizedDescription)")
+            SentryIntegration.shared.sendWithStacktrace(message: "Unable to move Rust database to backup location", tag: SentryTag.rustLogins, severity: .error, description: "Attempted to move to '\(bakBaseFilename)'. \(error.localizedDescription)")
         }
     }
 }

--- a/Storage/SQL/BrowserSchema.swift
+++ b/Storage/SQL/BrowserSchema.swift
@@ -1469,7 +1469,7 @@ open class BrowserSchema: Schema {
         do {
             try db.executeChange(sql)
         } catch let err as NSError {
-            Sentry.shared.sendWithStacktrace(message: "Error dropping tableList table", tag: SentryTag.browserDB, severity: .error, description: "\(err.localizedDescription)")
+            SentryIntegration.shared.sendWithStacktrace(message: "Error dropping tableList table", tag: SentryTag.browserDB, severity: .error, description: "\(err.localizedDescription)")
             return false
         }
 
@@ -1478,7 +1478,7 @@ open class BrowserSchema: Schema {
         do {
             try db.setVersion(previousVersion)
         } catch let err as NSError {
-            Sentry.shared.sendWithStacktrace(message: "Error setting database version", tag: SentryTag.browserDB, severity: .error, description: "\(err.localizedDescription)")
+            SentryIntegration.shared.sendWithStacktrace(message: "Error setting database version", tag: SentryTag.browserDB, severity: .error, description: "\(err.localizedDescription)")
             return false
         }
 
@@ -1523,7 +1523,7 @@ open class BrowserSchema: Schema {
             } catch let err as NSError {
                 log.error("Error altering clients table: \(err.localizedDescription); SQL was \(sql)")
                 let extra = ["table": "clients", "errorDescription": "\(err.localizedDescription)", "sql": "\(sql)"]
-                Sentry.shared.sendWithStacktrace(message: "Error altering table", tag: SentryTag.browserDB, severity: .error, extra: extra)
+                SentryIntegration.shared.sendWithStacktrace(message: "Error altering table", tag: SentryTag.browserDB, severity: .error, extra: extra)
                 return .failure
             }
         }
@@ -1535,7 +1535,7 @@ open class BrowserSchema: Schema {
             } catch let err as NSError {
                 log.error("Error altering clients table: \(err.localizedDescription); SQL was \(sql)")
                 let extra = ["table": "clients", "errorDescription": "\(err.localizedDescription)", "sql": "\(sql)"]
-                Sentry.shared.sendWithStacktrace(message: "Error altering table", tag: SentryTag.browserDB, severity: .error, extra: extra)
+                SentryIntegration.shared.sendWithStacktrace(message: "Error altering table", tag: SentryTag.browserDB, severity: .error, extra: extra)
                 return .failure
             }
         }

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -479,7 +479,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         // into using a `FailedSQLiteDBConnection` so we can retry opening again later.
         if !doOpen() {
             let extra = ["filename" : filename]
-            Sentry.shared.sendWithStacktrace(message: "Cannot open a database connection.", tag: SentryTag.swiftData, severity: .error, extra: extra)
+            SentryIntegration.shared.sendWithStacktrace(message: "Cannot open a database connection.", tag: SentryTag.swiftData, severity: .error, extra: extra)
             return nil
         }
 
@@ -495,17 +495,17 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         case .success:
             log.debug("Database successfully created or updated.")
         case .failure:
-            Sentry.shared.sendWithStacktrace(message: "Failed to create or update the database schema.", tag: SentryTag.swiftData, severity: .error)
+            SentryIntegration.shared.sendWithStacktrace(message: "Failed to create or update the database schema.", tag: SentryTag.swiftData, severity: .error)
             return nil
         case .needsRecovery:
-            Sentry.shared.sendWithStacktrace(message: "Database schema cannot be created or updated due to an unrecoverable error.", tag: SentryTag.swiftData, severity: .error)
+            SentryIntegration.shared.sendWithStacktrace(message: "Database schema cannot be created or updated due to an unrecoverable error.", tag: SentryTag.swiftData, severity: .error)
 
             // We need to close this new connection before we can move the database file to
             // its backup location. If we cannot even close the connection, something has
             // gone really wrong. In that case, bail out and return `nil` to force SwiftData
             // into using a `FailedSQLiteDBConnection` so we can retry again later.
             if let error = self.closeCustomConnection(immediately: true) {
-                Sentry.shared.sendWithStacktrace(message: "Cannot close the database connection to begin recovery.", tag: SentryTag.swiftData, severity: .error, description: error.localizedDescription)
+                SentryIntegration.shared.sendWithStacktrace(message: "Cannot close the database connection to begin recovery.", tag: SentryTag.swiftData, severity: .error, description: error.localizedDescription)
                 return nil
             }
 
@@ -517,7 +517,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             // retry opening again later.
             if !doOpen() {
                 log.error("Cannot re-open a database connection to the new database file to begin recovery.")
-                Sentry.shared.sendWithStacktrace(message: "Cannot re-open a database connection to the new database file to begin recovery.", tag: SentryTag.swiftData, severity: .error)
+                SentryIntegration.shared.sendWithStacktrace(message: "Cannot re-open a database connection to the new database file to begin recovery.", tag: SentryTag.swiftData, severity: .error)
                 return nil
             }
 
@@ -534,7 +534,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             // again later.
             if self.prepareSchema() != .success {
                 log.error("Cannot re-create the schema in the new database file to complete recovery.")
-                Sentry.shared.sendWithStacktrace(message: "Cannot re-create the schema in the new database file to complete recovery.", tag: SentryTag.swiftData, severity: .error)
+                SentryIntegration.shared.sendWithStacktrace(message: "Cannot re-create the schema in the new database file to complete recovery.", tag: SentryTag.swiftData, severity: .error)
                 return nil
             }
         }
@@ -711,7 +711,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             return .success
         }
 
-        Sentry.shared.addAttributes(["dbSchema.\(schema.name).version": schema.version])
+        SentryIntegration.shared.addAttributes(["dbSchema.\(schema.name).version": schema.version])
 
         // Get the current schema version for the database.
         let currentVersion = self.version
@@ -727,13 +727,13 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
 
         // Set an attribute for Sentry to include with any future error/crash
         // logs to indicate what schema version we're coming from and going to.
-        Sentry.shared.addAttributes(["dbUpgrade.\(self.schema.name).from": currentVersion, "dbUpgrade.\(self.schema.name).to": self.schema.version])
+        SentryIntegration.shared.addAttributes(["dbUpgrade.\(self.schema.name).from": currentVersion, "dbUpgrade.\(self.schema.name).to": self.schema.version])
 
         // This should not ever happen since the schema version should always be
         // increasing whenever a structural change is made in an app update.
         guard currentVersion <= schema.version else {
             let errorString = "\(self.schema.name) cannot be downgraded from version \(currentVersion) to \(self.schema.version)."
-            Sentry.shared.sendWithStacktrace(message: "Schema cannot be downgraded.", tag: SentryTag.swiftData, severity: .error, description: errorString)
+            SentryIntegration.shared.sendWithStacktrace(message: "Schema cannot be downgraded.", tag: SentryTag.swiftData, severity: .error, description: errorString)
             return .failure
         }
 
@@ -764,7 +764,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
                     }
                 }
 
-                Sentry.shared.send(message: "Attempting to update schema", tag: SentryTag.swiftData, severity: .info, description: "\(currentVersion) to \(self.schema.version).")
+                SentryIntegration.shared.send(message: "Attempting to update schema", tag: SentryTag.swiftData, severity: .info, description: "\(currentVersion) to \(self.schema.version).")
 
                 // If we can't create a brand new schema from scratch, we must
                 // call `updateSchema()` to go through the update process.
@@ -777,12 +777,12 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
                 // If we failed to update the schema, we'll drop everything from the DB
                 // and create everything again from scratch. Assuming our schema upgrade
                 // code is correct, this *shouldn't* happen. If it does, log it to Sentry.
-                Sentry.shared.sendWithStacktrace(message: "Update failed for schema. Dropping and re-creating.", tag: SentryTag.swiftData, severity: .error, description: "\(self.schema.name) from version \(currentVersion) to \(self.schema.version)")
+                SentryIntegration.shared.sendWithStacktrace(message: "Update failed for schema. Dropping and re-creating.", tag: SentryTag.swiftData, severity: .error, description: "\(self.schema.name) from version \(currentVersion) to \(self.schema.version)")
 
                 // If we can't even drop the schema here, something has gone really wrong, so
                 // return `false` which should force us into recovery.
                 if !self.dropSchema() {
-                    Sentry.shared.sendWithStacktrace(message: "Unable to drop schema.", tag: SentryTag.swiftData, severity: .error, description: "\(self.schema.name) from version \(currentVersion).")
+                    SentryIntegration.shared.sendWithStacktrace(message: "Unable to drop schema.", tag: SentryTag.swiftData, severity: .error, description: "\(self.schema.name) from version \(currentVersion).")
                     success = false
                     return success
                 }
@@ -796,7 +796,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             // If we got an error trying to get a transaction, then we either bail out early and return
             // `.failure` if we think we can retry later or return `.needsRecovery` if the error is not
             // recoverable.
-            Sentry.shared.sendWithStacktrace(message: "Unable to get a transaction", tag: SentryTag.swiftData, severity: .error, description: "\(error.localizedDescription)")
+            SentryIntegration.shared.sendWithStacktrace(message: "Unable to get a transaction", tag: SentryTag.swiftData, severity: .error, description: "\(error.localizedDescription)")
 
             // Check if the error we got is recoverable (e.g. SQLITE_BUSY, SQLITE_LOCK, SQLITE_FULL).
             // If so, just return `.failure` so we can retry preparing the schema again later.
@@ -826,7 +826,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
 
         // Attempt to make a backup as long as the database file still exists.
         if files.exists(baseFilename) {
-            Sentry.shared.sendWithStacktrace(message: "Couldn't create or update schema. Attempted to move db to another location.", tag: SentryTag.swiftData, severity: .warning, description: "Attempting to move '\(baseFilename)' for schema '\(self.schema.name)'")
+            SentryIntegration.shared.sendWithStacktrace(message: "Couldn't create or update schema. Attempted to move db to another location.", tag: SentryTag.swiftData, severity: .warning, description: "Attempting to move '\(baseFilename)' for schema '\(self.schema.name)'")
 
             // Note that a backup file might already exist! We append a counter to avoid this.
             var bakCounter = 0
@@ -853,11 +853,11 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
 
                 log.debug("Finished moving database \(baseFilename) successfully.")
             } catch let error as NSError {
-                Sentry.shared.sendWithStacktrace(message: "Unable to move db to another location", tag: SentryTag.swiftData, severity: .error, description: "DB file '\(baseFilename)'. \(error.localizedDescription)")
+                SentryIntegration.shared.sendWithStacktrace(message: "Unable to move db to another location", tag: SentryTag.swiftData, severity: .error, description: "DB file '\(baseFilename)'. \(error.localizedDescription)")
             }
         } else {
             // No backup was attempted since the database file did not exist.
-            Sentry.shared.sendWithStacktrace(message: "The database file has been deleted while previously in use.", tag: SentryTag.swiftData, description: "DB file '\(baseFilename)'")
+            SentryIntegration.shared.sendWithStacktrace(message: "The database file has been deleted while previously in use.", tag: SentryTag.swiftData, description: "DB file '\(baseFilename)'")
         }
     }
 
@@ -997,7 +997,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         var status = sqlite3_close(db)
 
         if status != SQLITE_OK {
-            Sentry.shared.sendWithStacktrace(message: "Got error status while attempting to close.", tag: SentryTag.swiftData, severity: .error, description: "SQLite status: \(status)")
+            SentryIntegration.shared.sendWithStacktrace(message: "Got error status while attempting to close.", tag: SentryTag.swiftData, severity: .error, description: "SQLite status: \(status)")
 
             if immediately {
                 return createErr("During: closing database with flags", status: Int(status))
@@ -1010,7 +1010,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             if status != SQLITE_OK {
 
                 // Based on the above comment regarding sqlite3_close_v2, this shouldn't happen.
-                Sentry.shared.sendWithStacktrace(message: "Got error status while attempting to close_v2.", tag: SentryTag.swiftData, severity: .error, description: "SQLite status: \(status)")
+                SentryIntegration.shared.sendWithStacktrace(message: "Got error status while attempting to close_v2.", tag: SentryTag.swiftData, severity: .error, description: "SQLite status: \(status)")
                 return createErr("During: closing database with flags", status: Int(status))
             }
         }
@@ -1050,11 +1050,11 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             // Special case: Write additional info to the database log in the case of a database corruption.
             if error.code == Int(SQLITE_CORRUPT) {
                 writeCorruptionInfoForDBNamed(filename, toLogger: Logger.corruptLogger)
-                Sentry.shared.sendWithStacktrace(message: "SQLITE_CORRUPT", tag: SentryTag.swiftData, severity: .error, description: "DB file '\(filename)'. \(error.localizedDescription)")
+                SentryIntegration.shared.sendWithStacktrace(message: "SQLITE_CORRUPT", tag: SentryTag.swiftData, severity: .error, description: "DB file '\(filename)'. \(error.localizedDescription)")
             }
 
             let message = "Error code: \(error.code), \(error) for SQL \(String(sqlStr.prefix(500)))."
-            Sentry.shared.sendWithStacktrace(message: "SQL error", tag: SentryTag.swiftData, severity: .error, description: message)
+            SentryIntegration.shared.sendWithStacktrace(message: "SQL error", tag: SentryTag.swiftData, severity: .error, description: message)
 
             throw error
         }
@@ -1094,7 +1094,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         } catch let error1 as NSError {
             error = error1
             statement = nil
-            Sentry.shared.sendWithStacktrace(message: "Execute error DBStatement", tag: SentryTag.swiftData, severity: .error, description: error1.localizedDescription)
+            SentryIntegration.shared.sendWithStacktrace(message: "Execute error DBStatement", tag: SentryTag.swiftData, severity: .error, description: error1.localizedDescription)
             return Cursor<T>(err: error1)
         }
 
@@ -1106,14 +1106,14 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             // Special case: Write additional info to the database log in the case of a database corruption.
             if error.code == Int(SQLITE_CORRUPT) {
                 writeCorruptionInfoForDBNamed(filename, toLogger: Logger.corruptLogger)
-                Sentry.shared.sendWithStacktrace(message: "SQLITE_CORRUPT", tag: SentryTag.swiftData, severity: .error, description: "DB file '\(filename)'. \(error.localizedDescription)")
+                SentryIntegration.shared.sendWithStacktrace(message: "SQLITE_CORRUPT", tag: SentryTag.swiftData, severity: .error, description: "DB file '\(filename)'. \(error.localizedDescription)")
             }
             // Don't log errors caused by `sqlite3_interrupt()` to Sentry.
             if error.code != Int(SQLITE_INTERRUPT) {
-                Sentry.shared.sendWithStacktrace(message: "SQL error", tag: SentryTag.swiftData, severity: .error, description: "Error code: \(error.code), \(error) for SQL \(String(sqlStr.prefix(500))).")
+                SentryIntegration.shared.sendWithStacktrace(message: "SQL error", tag: SentryTag.swiftData, severity: .error, description: "Error code: \(error.code), \(error) for SQL \(String(sqlStr.prefix(500))).")
             }
             
-            Sentry.shared.sendWithStacktrace(message: "Execute error", tag: SentryTag.swiftData, severity: .error, description: error.localizedDescription)
+            SentryIntegration.shared.sendWithStacktrace(message: "Execute error", tag: SentryTag.swiftData, severity: .error, description: error.localizedDescription)
 
             return Cursor<T>(err: error)
         }
@@ -1198,7 +1198,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         do {
             try executeChange("BEGIN EXCLUSIVE")
         } catch let err as NSError {
-            Sentry.shared.sendWithStacktrace(message: "BEGIN EXCLUSIVE failed.", tag: SentryTag.swiftData, severity: .error, description: "\(err.code), \(err)")
+            SentryIntegration.shared.sendWithStacktrace(message: "BEGIN EXCLUSIVE failed.", tag: SentryTag.swiftData, severity: .error, description: "\(err.code), \(err)")
             throw err
         }
 
@@ -1208,12 +1208,12 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             result = try transactionClosure(self)
         } catch let err as NSError {
             log.error("Op in transaction threw an error. Rolling back.")
-            Sentry.shared.sendWithStacktrace(message: "Op in transaction threw an error. Rolling back.", tag: SentryTag.swiftData, severity: .error)
+            SentryIntegration.shared.sendWithStacktrace(message: "Op in transaction threw an error. Rolling back.", tag: SentryTag.swiftData, severity: .error)
 
             do {
                 try executeChange("ROLLBACK")
             } catch let err as NSError {
-                Sentry.shared.sendWithStacktrace(message: "ROLLBACK after errored op in transaction failed", tag: SentryTag.swiftData, severity: .error, description: "\(err.code), \(err)")
+                SentryIntegration.shared.sendWithStacktrace(message: "ROLLBACK after errored op in transaction failed", tag: SentryTag.swiftData, severity: .error, description: "\(err.code), \(err)")
                 throw err
             }
 
@@ -1225,12 +1225,12 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         do {
             try executeChange("COMMIT")
         } catch let err as NSError {
-            Sentry.shared.sendWithStacktrace(message: "COMMIT failed. Rolling back.", tag: SentryTag.swiftData, severity: .error, description: "\(err.code), \(err)")
+            SentryIntegration.shared.sendWithStacktrace(message: "COMMIT failed. Rolling back.", tag: SentryTag.swiftData, severity: .error, description: "\(err.code), \(err)")
 
             do {
                 try executeChange("ROLLBACK")
             } catch let err as NSError {
-                Sentry.shared.sendWithStacktrace(message: "ROLLBACK after failed COMMIT failed.", tag: SentryTag.swiftData, severity: .error, description: "\(err.code), \(err)")
+                SentryIntegration.shared.sendWithStacktrace(message: "ROLLBACK after failed COMMIT failed.", tag: SentryTag.swiftData, severity: .error, description: "\(err.code), \(err)")
                 throw err
             }
 


### PR DESCRIPTION
- Remove sending sentry logs for error level on release
- Rename Sentry to SentryIntegration to match filename
- Avoid update observation for empty url that triggers Rust error logged multiple times
- Set release name to enable commit culprit on Sentry