### PR TITLE
Bugfix #10472 [v100] Reload only jump back in section for TabClosed notification

### DIFF
--- a/Client/Frontend/Browser/TopTabsLayout.swift
+++ b/Client/Frontend/Browser/TopTabsLayout.swift
@@ -72,7 +72,7 @@ class TopTabsViewLayout: UICollectionViewFlowLayout {
         attributes?.zIndex = SeparatorZIndex
         return attributes
     }
-    
+
     override var flipsHorizontallyInOppositeLayoutDirection: Bool {
         return true
     }

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -179,7 +179,7 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel {
             reloadAll()
         }
     }
-    
+
     private func updateJumpBackIn() {
         if let jumpBackIndex = viewModel.enabledSections.firstIndex(of: FirefoxHomeSectionType.jumpBackIn) {
             let indexSet = IndexSet([jumpBackIndex])

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -179,6 +179,13 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel {
             reloadAll()
         }
     }
+    
+    private func updateJumpBackIn() {
+        if let jumpBackIndex = viewModel.enabledSections.firstIndex(of: FirefoxHomeSectionType.jumpBackIn) {
+            let indexSet = IndexSet([jumpBackIndex])
+            collectionView.reloadSections(indexSet)
+        }
+    }
 
     func applyTheme() {
         defaultBrowserCard.applyTheme()
@@ -775,6 +782,8 @@ extension FirefoxHomeViewController: Notifiable {
         switch notification.name {
         case .TabsPrivacyModeChanged:
             adjustPrivacySensitiveSections(notification: notification)
+        case  .TabClosed:
+            updateJumpBackIn()
         default:
             reloadAll()
         }


### PR DESCRIPTION
Reload only JumpBackIn section when tabs are closed in TabTray
