### PR TITLE
Bugfix #9856 [v100] Bookmarks folder resetting to main folder issue

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -967,11 +967,9 @@ class BrowserViewController: UIViewController {
         controller = DismissableNavigationViewController(rootViewController: libraryViewController)
         controller.onViewWillDisappear = {
             self.firefoxHomeViewController?.reloadAll()
-            self.libraryViewController = nil
         }
         controller.onViewDismissed = {
             self.firefoxHomeViewController?.reloadAll()
-            self.libraryViewController = nil
         }
         self.present(controller, animated: true, completion: nil)
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -955,6 +955,7 @@ class BrowserViewController: UIViewController {
             presentedViewController.dismiss(animated: true, completion: nil)
         }
 
+        // We should not set libraryViewController to nil because the library panel losses the currentStat
         let libraryViewController = self.libraryViewController ?? LibraryViewController(profile: profile, tabManager: tabManager)
         libraryViewController.delegate = self
         self.libraryViewController = libraryViewController

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -26,12 +26,7 @@ extension BrowserViewController {
     }
 
     private func showPanel(_ panel: LibraryPanelType) {
-        guard let libraryViewController = self.libraryViewController else {
-            showLibrary(panel: panel)
-            return
-        }
-
-        libraryViewController.selectedPanel = panel
+        showLibrary(panel: panel)
     }
 
     @objc private func openClearHistoryPanelKeyCommand() {


### PR DESCRIPTION
Issue #9856 

Remove setting LibraryViewController to nil that causes to loose Bookmark state, resetting to main view everytime
