### PR TITLE
Refactor #10507 [v101] Improve automatic string import

### DIFF
--- a/.github/workflows/import-strings.yml
+++ b/.github/workflows/import-strings.yml
@@ -29,6 +29,7 @@ jobs:
     - name: Update new strings
       run: |-
         git diff || (git add Shared/*/*.lproj/* Shared/*.lproj/* WidgetKit/*.lproj/* Client/*/*.lproj/* Client/*.lproj/*)
+        git restore Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       with:


### PR DESCRIPTION
This will fix #10507 by undoing the changes in the package.resolved file when the import-string.sh script runs.

This is already working on focus. In the action logs, you can see that the file is changed:
https://github.com/mozilla-mobile/focus-ios/runs/6085989467?check_suite_focus=true#step:7:8

But after doing the `git restore file`, the file does not appear as modified to be commited:
https://github.com/mozilla-mobile/focus-ios/runs/6085989467?check_suite_focus=true#step:8:42

Let's give this a try and see if that works here too