### PR TITLE
Bugfix #9438 [v100] fix search history flow

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -25,8 +25,8 @@ messaging:
       type: string
       description: What should be displayed when a control message is selected.
       enum:
-        - show-none
         - show-next-message
+        - show-none
     styles:
       type: json
       description: "A map of styles to configure message appearance.\n"

--- a/Client/FeatureFlags/FlaggableFeature.swift
+++ b/Client/FeatureFlags/FlaggableFeature.swift
@@ -106,7 +106,7 @@ struct FlaggableFeature {
             return UserFeaturePreference.enabled.rawValue
 
         // Nimbus default options
-        case .jumpBackIn, .pocket, .recentlySaved:
+        case .jumpBackIn, .pocket, .recentlySaved, .historyHighlights:
             return checkNimbusHomepageFeatures(from: nimbusLayer).rawValue
         case .inactiveTabs:
             return checkNimbusTabTrayFeatures(from: nimbusLayer).rawValue

--- a/Client/Frontend/Library/ClearHistoryHelper.swift
+++ b/Client/Frontend/Library/ClearHistoryHelper.swift
@@ -54,9 +54,12 @@ class ClearHistoryHelper {
         alert.addAction(UIAlertAction(title: .ClearHistoryMenuOptionEverything, style: .destructive, handler: { _ in
             let types = WKWebsiteDataStore.allWebsiteDataTypes()
             WKWebsiteDataStore.default().removeData(ofTypes: types, modifiedSince: .distantPast, completionHandler: {})
-            self.profile.history.clearHistory().uponQueue(.global(qos: .userInteractive)) { item in
-                guard let completion = didComplete else { return }
-                completion(nil)
+            self.profile.history.clearHistory().uponQueue(.global(qos: .userInteractive)) { _ in
+                // INT64_MAX represents the oldest possible time that AS would have
+                self.profile.places.deleteHistoryMetadataOlderThan(olderThan: INT64_MAX).uponQueue(.global(qos: .userInteractive)) { _ in
+                    guard let completion = didComplete else { return }
+                    completion(nil)
+                }
             }
             self.profile.recentlyClosedTabs.clearTabs()
             self.tabManager.clearAllTabsHistory()

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
@@ -145,7 +145,6 @@ class HistoryPanelViewModel: Loggable, FeatureFlagsProtocol {
             // Force 100ms delay between resolution of the last batch of results
             // and the next time `fetchData()` can be called.
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
-                self.currentFetchOffset += self.queryFetchLimit
                 self.isFetchInProgress = false
 
                 self.browserLog.debug("currentFetchOffset is: \(self.currentFetchOffset)")

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
@@ -91,10 +91,11 @@ class HistoryPanelViewModel: Loggable, FeatureFlagsProtocol {
     // MARK: - Private helpers
 
     /// Begin the process of fetching history data, and creating ASGroups from them. A prefetch also triggers this.
-    func reloadData() {
+    func reloadData(completion: @escaping (Bool) -> Void) {
         // Can be called while app backgrounded and the db closed, don't try to reload the data source in this case
         guard !profile.isShutdown, !isFetchInProgress else {
             browserLog.debug("HistoryPanel tableView data could NOT be reloaded! Either the profile wasn't shut down, or there's a fetch in progress.")
+            completion(false)
             return
         }
 
@@ -112,6 +113,9 @@ class HistoryPanelViewModel: Loggable, FeatureFlagsProtocol {
                     self.groupedSites.numberOfItemsForSection(section.rawValue - 1) > 0
                     || !self.groupsForSection(section: section).isEmpty
                 }
+                completion(true)
+            } else {
+                completion(false)
             }
         }
     }

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
@@ -226,7 +226,7 @@ class HistoryPanelViewModel: Loggable, FeatureFlagsProtocol {
     /// This will remove entire sections of data on triggering the Clear History flow.
     func removeVisibleSectionFor(date: Date) {
         // handle the past one hour later
-        var sectionToRemove: [Sections]
+        var sectionToRemove: [Sections]?
 
         // Selecting today and every option after gives us a date of the day before... So we adjust.
         let adjustedDate = date.dayAfter
@@ -235,11 +235,9 @@ class HistoryPanelViewModel: Loggable, FeatureFlagsProtocol {
             sectionToRemove = [.today]
         } else if adjustedDate.isYesterday() {
             sectionToRemove = [.today, .yesterday]
-        } else {
-            sectionToRemove = Sections.allCases
         }
 
-        sectionToRemove.forEach { section in
+        sectionToRemove?.forEach { section in
             visibleSections = visibleSections.filter { $0 != section }
         }
     }

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups+Search.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups+Search.swift
@@ -37,6 +37,7 @@ extension HistoryPanelWithGroups: UISearchBarDelegate {
     func exitSearchState() {
         viewModel.isSearchInProgress = false
         applySnapshot()
+        self.searchbar.text = ""
         self.searchbar.resignFirstResponder()
         bottomStackView.isHidden = true
     }

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups+Search.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups+Search.swift
@@ -30,7 +30,6 @@ extension HistoryPanelWithGroups: UISearchBarDelegate {
 
     func startSearchState() {
         bottomStackView.isHidden = false
-        searchbar.text = ""
         searchbar.becomeFirstResponder()
         viewModel.isSearchInProgress = true
     }

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups+Search.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups+Search.swift
@@ -28,11 +28,18 @@ extension HistoryPanelWithGroups: UISearchBarDelegate {
         performSearch(term: searchText)
     }
 
+    func startSearchState() {
+        bottomStackView.isHidden = false
+        searchbar.text = ""
+        searchbar.becomeFirstResponder()
+        viewModel.isSearchInProgress = true
+    }
+
     func exitSearchState() {
+        viewModel.isSearchInProgress = false
         applySnapshot()
         self.searchbar.resignFirstResponder()
-        viewModel.isSearchInProgress = false
-        toggleEmptyState()
+        bottomStackView.isHidden = true
     }
 
     func performSearch(term: String) {

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups.swift
@@ -118,13 +118,13 @@ class HistoryPanelWithGroups: UIViewController, LibraryPanel, Loggable, Notifica
         handleRefreshControl()
         setupLayout()
         configureDatasource()
-        fetchDataAndUpdateLayout()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
         bottomStackView.isHidden = !viewModel.isSearchInProgress
+        fetchDataAndUpdateLayout()
     }
 
     // MARK: - Private helpers
@@ -153,8 +153,11 @@ class HistoryPanelWithGroups: UIViewController, LibraryPanel, Loggable, Notifica
 
         viewModel.reloadData() { [weak self] success in
             guard success else { return }
-
-            self?.applySnapshot(animatingDifferences: animating)
+            
+            DispatchQueue.main.async {
+                self?.applySnapshot(animatingDifferences: animating)
+                self?.toggleEmptyState()
+            }
         }
     }
 
@@ -466,6 +469,14 @@ class HistoryPanelWithGroups: UIViewController, LibraryPanel, Loggable, Notifica
         return overlayView
     }
 
+    func toggleEmptyState() {
+        if emptyStateOverlayView.superview != nil {
+            emptyStateOverlayView.removeFromSuperview()
+        }
+        emptyStateOverlayView = createEmptyStateOverlayView()
+        updateEmptyPanelState()
+    }
+
     // MARK: - Themeable
 
     func applyTheme() {
@@ -479,12 +490,6 @@ class HistoryPanelWithGroups: UIViewController, LibraryPanel, Loggable, Notifica
         searchbar.tintColor = UIColor.theme.textField.textAndTint
 
         tableView.reloadData()
-    }
-
-    func toggleEmptyState() {
-        emptyStateOverlayView.removeFromSuperview()
-        emptyStateOverlayView = createEmptyStateOverlayView()
-        updateEmptyPanelState()
     }
 }
 

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups.swift
@@ -204,14 +204,9 @@ class HistoryPanelWithGroups: UIViewController, LibraryPanel, Loggable, Notifica
 
     private func showClearRecentHistory() {
         clearHistoryHelper.showClearRecentHistory(onViewController: self, didComplete: { [weak self] date in
-            if let date = date {
-                self?.viewModel.removeVisibleSectionFor(date: date)
-            } else {
-                // The only time there's no date is when we are deleting everything.
-                self?.viewModel.visibleSections = []
-            }
-
-            self?.applySnapshot()
+            // Clearing groupedSites and refetch from database
+            self?.viewModel.groupedSites = DateGroupedTableData<Site>()
+            self?.fetchDataAndUpdateLayout()
 
             if let cell = self?.clearHistoryCell {
                 self?.setTappableStateAndStyle(
@@ -335,12 +330,10 @@ class HistoryPanelWithGroups: UIViewController, LibraryPanel, Loggable, Notifica
         }
 
         cell.titleLabel.text = asGroup.displayTitle
-        cell.leftImageView.layer.borderWidth = 0
-        cell.leftImageView.contentMode = .center
         cell.chevronAccessoryView.isHidden = false
         cell.leftImageView.contentMode = .scaleAspectFit
-        cell.leftImageView.image = UIImage(named: ImageIdentifiers.stackedTabsIcon)
-        cell.leftImageView.backgroundColor = UIColor.theme.general.faviconBackground
+        cell.leftImageView.image = UIImage(named: ImageIdentifiers.stackedTabsIcon)?.withTintColor(ThemeManager.shared.currentTheme.colours.iconSecondary)
+        cell.leftImageView.backgroundColor = .theme.homePanel.historyHeaderIconsBackground
 
         return cell
     }

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups.swift
@@ -401,6 +401,9 @@ class HistoryPanelWithGroups: UIViewController, LibraryPanel, Loggable, Notifica
 
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
 
+        // Adding support to delete item during search in next ticket
+        guard !viewModel.isSearchInProgress else { return nil }
+
         // For UX consistency, every cell in history panel SHOULD have a trailing action.
         let deleteAction = UIContextualAction(style: .destructive, title: .HistoryPanelDelete) { [weak self] (_, _, completion) in
             guard let self = self else {
@@ -667,12 +670,6 @@ extension HistoryPanelWithGroups: UITableViewDataSourcePrefetching {
     // Happens WAY too often. We should consider fetching the next set when the user HITS the bottom instead.
     func tableView(_ tableView: UITableView, prefetchRowsAt indexPaths: [IndexPath]) {
         guard !viewModel.isFetchInProgress, indexPaths.contains(where: shouldLoadRow) else { return }
-
-        guard !viewModel.isSearchInProgress else {
-            viewModel.updateSearchOffset()
-            performSearch(term: searchbar.text ?? "")
-            return
-        }
 
         fetchDataAndUpdateLayout(animating: false)
     }

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups.swift
@@ -153,7 +153,7 @@ class HistoryPanelWithGroups: UIViewController, LibraryPanel, Loggable, Notifica
 
         viewModel.reloadData() { [weak self] success in
             guard success else { return }
-            
+
             DispatchQueue.main.async {
                 self?.applySnapshot(animatingDifferences: animating)
                 self?.toggleEmptyState()
@@ -211,7 +211,7 @@ class HistoryPanelWithGroups: UIViewController, LibraryPanel, Loggable, Notifica
                 self?.viewModel.visibleSections = []
             }
 
-            self?.fetchDataAndUpdateLayout(animating: true)
+            self?.applySnapshot()
 
             if let cell = self?.clearHistoryCell {
                 self?.setTappableStateAndStyle(

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController+ToolbarActions.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController+ToolbarActions.swift
@@ -90,8 +90,8 @@ extension LibraryViewController {
               let historyPanel = panel.viewControllers.last as? HistoryPanelWithGroups else { return }
 
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .searchHistory)
-        viewModel.currentPanelState = .history(state: .search)
 
+        viewModel.currentPanelState = .history(state: .search)
         historyPanel.startSearchState()
     }
 

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -370,7 +370,7 @@ class LibraryViewController: UIViewController {
         switch viewModel.currentPanelState {
         case .bookmarks(state: .inFolderEditMode):
             setToolbarItems(bottomToolbarItemsBothButtons, animated: true)
-        case .history(state: .mainView):
+        case .history:
             if viewModel.shouldShowSearch {
                 setToolbarItems(bottomToolbarHistoryItemsButton, animated: true)
             }

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -310,8 +310,8 @@ class LibraryViewController: UIViewController {
                 if viewModel.currentPanelState == .history(state: .mainView) {
                     viewModel.currentPanelState = .history(state: .inFolder)
                 }
-            } else {
-                viewModel.currentPanelState = .history(state: .mainView)
+            } else if viewModel.currentPanelState != .history(state: .search) {
+                 viewModel.currentPanelState = .history(state: .mainView)
             }
         }
     }

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -125,6 +125,7 @@ class LibraryViewController: UIViewController {
     // MARK: - View setup & lifecycle
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+        // Needed to update toolbar on panel changes
         updateViewWithState()
     }
 
@@ -198,7 +199,7 @@ class LibraryViewController: UIViewController {
     fileprivate func shouldShowBottomToolbar() {
         switch viewModel.currentPanelState {
         case .bookmarks(state: let subState):
-            navigationController?.setToolbarHidden(subState == .mainView, animated: true)
+            navigationController?.setToolbarHidden(subState == .mainView, animated: false)
         case .history:
             let shouldShowSearch = viewModel.shouldShowSearch
             navigationController?.setToolbarHidden(!shouldShowSearch, animated: true)

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewModel.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewModel.swift
@@ -16,14 +16,14 @@ class LibraryViewModel: FeatureFlagsProtocol {
         set { panelState.currentState = newValue }
     }
 
+    var shouldShowSearch: Bool {
+        return self.featureFlags.isFeatureActiveForBuild(.historyGroups) &&
+        currentPanelState == .history(state: .mainView) || currentPanelState == .history(state: .search)
+    }
+
     init(withProfile profile: Profile, tabManager: TabManager) {
         self.profile = profile
         self.tabManager = tabManager
         self.panelDescriptors = LibraryPanels(profile: profile, tabManager: tabManager).enabledPanels
-    }
-
-    var shouldShowSearch: Bool {
-        return self.featureFlags.isFeatureActiveForBuild(.historyGroups) &&
-        currentPanelState == .history(state: .mainView) || currentPanelState == .history(state: .search)
     }
 }

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewModel.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewModel.swift
@@ -23,6 +23,7 @@ class LibraryViewModel: FeatureFlagsProtocol {
     }
 
     var shouldShowSearch: Bool {
-        return self.featureFlags.isFeatureActiveForBuild(.historyGroups) && currentPanelState == .history(state: .mainView)
+        return self.featureFlags.isFeatureActiveForBuild(.historyGroups) &&
+        currentPanelState == .history(state: .mainView) || currentPanelState == .history(state: .search)
     }
 }

--- a/XCUITests/HomePageSettingsUITest.swift
+++ b/XCUITests/HomePageSettingsUITest.swift
@@ -230,7 +230,7 @@ class HomePageSettingsUITests: BaseTestCase {
         // Commented due to experimental features
         // XCTAssertEqual(app.cells.switches[AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.jumpBackIn].value as! String, "1")
         // XCTAssertEqual(app.cells.switches[AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.recentlySaved].value as! String, "1")
-        XCTAssertEqual(app.cells.switches[AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.recentVisited].value as! String, "0")
+        XCTAssertEqual(app.cells.switches[AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.recentVisited].value as! String, "1")
         XCTAssertEqual(app.cells.switches[AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.recommendedByPocket].value as! String, "1")
     }
 }


### PR DESCRIPTION
Issue #9438 
Includes fix for: #10534, #10282 & #10532

- Refactor HistoryPanelWithGroups applySnapshot and reload tableview logic
- Centralize logic to reload in a single function and avoid refreshing if search is in progress
- Fetch data on viewWillAppear to get the latest history for #10534