### PR TITLE
Bugfix #10551 [v100] - Recently Visited group is changing when the homepage is reloaded

### DIFF
--- a/Client/Frontend/Browser/Tabs/SearchTermGroupsManager.swift
+++ b/Client/Frontend/Browser/Tabs/SearchTermGroupsManager.swift
@@ -215,6 +215,11 @@ class SearchTermGroupsManager {
                     timestamp = tab.firstCreatedTime ?? 0
                 }
 
+                // Base timestamp on score to order historyHighlight properly
+                if let firstItem = orderedItems.first, let highlight = firstItem as? HistoryHighlight {
+                    timestamp = Date.now() - Timestamp(highlight.score)
+                }
+
                 return ASGroup<T>(searchTerm: $0.key.capitalized, groupedItems: orderedItems, timestamp: timestamp)
         }
     }

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsManager.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsManager.swift
@@ -118,7 +118,8 @@ class HistoryHighlightsManager {
                 highlightItems.insert(group, at: insertIndex)
             } else {
                 // insert remaining items
-                highlightItems.append(contentsOf: groups.suffix(index))
+                let restOfGroups = Array(groups[index..<groups.count])
+                highlightItems.append(contentsOf: restOfGroups)
                 break
             }
         }

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsManager.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsManager.swift
@@ -114,10 +114,11 @@ class HistoryHighlightsManager {
 
         for (index, group) in groups.enumerated() {
             let insertIndex = (index * 2) + 1
-            if insertIndex < highlightItems.count {
+            if insertIndex <= highlightItems.count {
                 highlightItems.insert(group, at: insertIndex)
             } else {
-                highlightItems.append(contentsOf: groups)
+                // insert remaining items
+                highlightItems.append(contentsOf: groups.suffix(index))
                 break
             }
         }

--- a/ClientTests/HistoryHighlightsManagerTests.swift
+++ b/ClientTests/HistoryHighlightsManagerTests.swift
@@ -151,19 +151,19 @@ class HistoryHighlightsTests: XCTestCase {
         waitForExpectations(timeout: 5, handler: nil)
     }
 
-    func testSingleHistoryHighlightCount_withGroupingEnabled() {
+    func testSingleHistoryHighlight_withGroupingEnabled() {
         emptyDB()
 
         let testSites = [("mozilla", ""),
                          ("wikipedia", ""),
                          ("amazon", ""),
-                         ("mozilla", "group"),
-                         ("amazon", "group")]
+                         ("mozilla", "/group"),
+                         ("amazon", "/group")]
         createHistoryEntry(siteEntry: testSites)
-
-        let expectation = expectation(description: "Highlights")
         // 2 groups and 1 invidual item
         let expectedCount = 3
+
+        let expectation = expectation(description: "Highlights")
 
         manager.getHighlightsData(with: profile, and: [Tab](), shouldGroupHighlights: true) { highlights in
 
@@ -173,21 +173,24 @@ class HistoryHighlightsTests: XCTestCase {
             }
 
             XCTAssertEqual(highlights.count, expectedCount, "There should be three history highlight")
+            XCTAssertNotNil((highlights[0] as? HistoryHighlight), "Expected History highlight as the first item")
+            XCTAssertNotNil((highlights[1] as? ASGroup<HistoryHighlight>), "Expected group as second item")
+            XCTAssertNotNil((highlights[2] as? ASGroup<HistoryHighlight>), "Expected group as second item")
             expectation.fulfill()
         }
 
         waitForExpectations(timeout: 5, handler: nil)
     }
 
-    func testSingleHistoryHighlightOrder_withGroupingEnabled() {
+    func testSingleHistoryHighlightOrder_withMoreSingleItemEach() {
         emptyDB()
 
         let testSites = [("mozilla", ""),
                          ("wikipedia", ""),
-                         ("amazon", ""),
-                         ("mozilla", "/group"),
-                         ("amazon", "/group")]
+                         ("apple", ""),
+                         ("mozilla", "/group")]
         createHistoryEntry(siteEntry: testSites)
+        let expectedCount = 3
 
         let expectation = expectation(description: "Highlights")
 
@@ -198,9 +201,101 @@ class HistoryHighlightsTests: XCTestCase {
                 return
             }
 
+            XCTAssertEqual(highlights.count, expectedCount, "There should be two history highlight")
             XCTAssertNotNil((highlights[0] as? HistoryHighlight), "Expected History highlight as the first item")
             XCTAssertNotNil((highlights[1] as? ASGroup<HistoryHighlight>), "Expected group as second item")
-            XCTAssertNotNil((highlights[2] as? ASGroup<HistoryHighlight>), "Expected group as second item")
+            XCTAssertNotNil((highlights[2] as? HistoryHighlight), "Expected History highlight as the first item")
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+
+    func testSingleHistoryHighlightOrder_withTwoItemEach() {
+        emptyDB()
+
+        let testSites = [("mozilla", ""),
+                         ("wikipedia", ""),
+                         ("apple", ""),
+                         ("mozilla", "/group"),
+                         ("apple", "/group"),
+                         ("google", "/group")]
+        createHistoryEntry(siteEntry: testSites)
+        let expectedCount = 4
+
+        let expectation = expectation(description: "Highlights")
+
+        manager.getHighlightsData(with: profile, and: [Tab](), shouldGroupHighlights: true) { highlights in
+
+            guard let highlights = highlights else {
+                XCTFail("Highlights should not be nil.")
+                return
+            }
+
+            XCTAssertEqual(highlights.count, expectedCount, "There should be two history highlight")
+            XCTAssertNotNil((highlights[0] as? HistoryHighlight), "Expected History highlight as the first item")
+            XCTAssertNotNil((highlights[1] as? ASGroup<HistoryHighlight>), "Expected group as second item")
+            XCTAssertNotNil((highlights[2] as? HistoryHighlight), "Expected History highlight as the first item")
+            XCTAssertNotNil((highlights[3] as? ASGroup<HistoryHighlight>), "Expected group as second item")
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+
+    func testSingleHistoryHighlightOrder_OnlySingleItems() {
+        emptyDB()
+
+        let testSites = [("mozilla", ""),
+                         ("wikipedia", ""),
+                         ("apple", "")]
+        createHistoryEntry(siteEntry: testSites)
+        let expectedCount = 3
+
+        let expectation = expectation(description: "Highlights")
+
+        manager.getHighlightsData(with: profile, and: [Tab](), shouldGroupHighlights: true) { highlights in
+
+            guard let highlights = highlights else {
+                XCTFail("Highlights should not be nil.")
+                return
+            }
+
+            XCTAssertEqual(highlights.count, expectedCount, "There should be two history highlight")
+            XCTAssertNotNil((highlights[0] as? HistoryHighlight), "Expected History highlight as the first item")
+            XCTAssertNotNil((highlights[1] as? HistoryHighlight), "Expected History highlight as second item")
+            XCTAssertNotNil((highlights[2] as? HistoryHighlight), "Expected History highlight as the first item")
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+
+    func testSingleHistoryHighlightOrder_OnlyGroupItems() {
+        emptyDB()
+
+        let testSites = [("mozilla", ""),
+                         ("mozilla", "/group"),
+                         ("wikipedia", ""),
+                         ("wikipedia", "/group"),
+                         ("apple", ""),
+                         ("apple", "/group")]
+        createHistoryEntry(siteEntry: testSites)
+        let expectedCount = 3
+
+        let expectation = expectation(description: "Highlights")
+
+        manager.getHighlightsData(with: profile, and: [Tab](), shouldGroupHighlights: true) { highlights in
+
+            guard let highlights = highlights else {
+                XCTFail("Highlights should not be nil.")
+                return
+            }
+
+            XCTAssertEqual(highlights.count, expectedCount, "There should be two history highlight")
+            XCTAssertNotNil((highlights[0] as? ASGroup<HistoryHighlight>), "Expected group as the first item")
+            XCTAssertNotNil((highlights[1] as? ASGroup<HistoryHighlight>), "Expected group as second item")
+            XCTAssertNotNil((highlights[2] as? ASGroup<HistoryHighlight>), "Expected group as the first item")
             expectation.fulfill()
         }
 


### PR DESCRIPTION
Fix mixing groups and single items result and ordering of group items