### PR TITLE
Fix #10565 - WebServer.start() tries alternate ports if preferred is unavailable.

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -410,7 +410,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // 2 seconds is ample for a localhost request to be completed by GCDWebServer. <500ms is expected on newer devices.
         singleShotTimer.schedule(deadline: .now() + 2.0, repeating: .never)
         singleShotTimer.setEventHandler {
-            WebServer.sharedInstance.server.stop()
+            if WebServer.sharedInstance.server.isRunning {
+                // Ensure it is actually running, otherwise stop() will abort in debug builds.
+                WebServer.sharedInstance.server.stop()
+            }
             self.shutdownWebServer = nil
         }
         singleShotTimer.resume()

--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -24,8 +24,8 @@ class TestAppDelegate: AppDelegate {
         launchArguments.forEach { arg in
             if arg.starts(with: LaunchArguments.ServerPort) {
                 let portString = arg.replacingOccurrences(of: LaunchArguments.ServerPort, with: "")
-                if let port = Int(portString) {
-                    AppInfo.webserverPort = port
+                if let port = UInt16(portString) {
+                    AppInfo.preferredWebserverPort = port
                 } else {
                     fatalError("Failed to set web server port override.")
                 }

--- a/Client/Application/WebServer.swift
+++ b/Client/Application/WebServer.swift
@@ -34,7 +34,7 @@ class WebServer {
     }
 
     @discardableResult func start() throws -> Bool {
-        if server.isRunning {
+        guard !server.isRunning else {
             return true
         }
 

--- a/Shared/AppInfo.swift
+++ b/Shared/AppInfo.swift
@@ -97,8 +97,16 @@ open class AppInfo {
         return Bundle.main.object(forInfoDictionaryKey: "CFBundlePackageType") as! String == "APPL"
     }
 
-    // The port for the internal webserver, tests can change this
-    public static var webserverPort = 6571
+    // The port for the internal webserver, tests can change this by setting preferredWebserverPort
+    public static var webserverPort: UInt16 {
+        return mostRecentlyUsedWebserverPort ?? preferredWebserverPort
+    }
+
+    // The preferred port to use for the internal webserver, tests can change this.
+    // The actual port used may be different if the preferred one is unavailable.
+    public static var preferredWebserverPort: UInt16 = 6571
+    // Do not access this directly. Used internally here and in WebServer
+    public static var mostRecentlyUsedWebserverPort: UInt16?
 
     public static var isChinaEdition: Bool = {
         if UserDefaults.standard.bool(forKey: debugPrefIsChinaEdition) {


### PR DESCRIPTION
- WebServer.start() is now more resilient to the port not being available. It will try the 20 ports from the preferred one upwards until it finds one, only throwing if none could be used. This allows us to co-exist with other apps using overlapping ports numbers.

- Fixed a minor issue in debug builds if the web server hadn't been started before attempting to stop it. GCDWebServer would abort in this case.
