### PR TITLE
Bugfix #5981 [v101] Only update cursor when necessary

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -227,8 +227,13 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         autocompleteTextLabel = createAutocompleteLabelWith(autocompleteText)
         if let l = autocompleteTextLabel {
             addSubview(l)
-            hideCursor = true
-            forceResetCursor()
+            // Only call forceResetCursor() if `hideCursor` changes.
+            // Because forceResetCursor() auto accept iOS user's text replacement
+            // (e.g. mu->μ) which makes user unable to type "mu".
+            if !hideCursor {
+                hideCursor = true
+                forceResetCursor()
+            }
         }
     }
 


### PR DESCRIPTION
The cause of [this issue](https://github.com/mozilla-mobile/firefox-ios/issues/5981) is within `func setAutocompleteSuggestion(_ suggestion: String?)` of `AutocompleteTextField.swift`. When `forceResetCursor()` is called each time there is an auto complete suggestion, this action triggers auto accept of iOS user defined "Text Replacement" feature.

e.g. user has "mu"->"μ" mapping, when trying typing murrayscheese.com, after 'u' is pressed, 'mu' becomes 'μ' automatically because of excessive call of forceResetCursor().

During debugging, I couldn't reproduce this with simulator, only reproducible on my iPhone 14.8. So I haven't run XCUITest yet. Given forceResetCursor() is only called in two places, this PR shouldn't break other expected behavior.