### PR TITLE
Add fx4130 [v101] Top sites tiles precedence

### DIFF
--- a/Client/Frontend/Home/TopSites/DataManagement/Contile.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/Contile.swift
@@ -21,4 +21,3 @@ struct Contile: Codable, Equatable {
 struct Contiles: Codable {
     let tiles: [Contile]
 }
-

--- a/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
@@ -108,6 +108,8 @@ class FxHomeTopSitesManager: FeatureFlagsProtocol {
         addSponsoredTiles(sites: &sites, availableSpacesCount: availableSpacesCount)
         addGoogleTopSite(sites: &sites, availableSpacesCount: availableSpacesCount)
 
+        sites.removeDuplicates()
+
         topSites = sites.map { HomeTopSite(site: $0, profile: profile) }
 
         // Refresh data in the background so we'll have fresh data next time we show
@@ -185,9 +187,24 @@ private extension Array where Element == Site {
         }
     }
 
-    // Check to ensure a site isn't already existing in the pinned top sites
+    // Keeping the order of the sites, we remove duplicate tiles.
+    // Ex: If a sponsored tile is present then it has precedence over the history sites.
+    // Ex: A default site is present but user has recent history site of the same site. That recent history tile won't be added.
+    mutating func removeDuplicates() {
+        var alreadyThere = Set<Site>()
+        let uniqueSites = compactMap { (site) -> Site? in
+            let shouldAddSite = alreadyThere.first(where: { $0.url.asURL?.domainURL == site.url.asURL?.domainURL } ) == nil
+            guard shouldAddSite else { return nil }
+            alreadyThere.insert(site)
+            return site
+        }
+
+        self = uniqueSites
+    }
+
+    // We don't add a sponsored tile if that domain site is already pinned by the user.
     private func siteIsAlreadyPresent(site: Site) -> Bool {
-        return filter { $0.url == site.url && ($0 as? PinnedSite) != nil }.count > 0
+        return filter { $0.url.asURL?.domainURL == site.url.asURL?.domainURL && ($0 as? PinnedSite) != nil }.count > 0
     }
 }
 

--- a/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
@@ -204,7 +204,7 @@ private extension Array where Element == Site {
 
     // We don't add a sponsored tile if that domain site is already pinned by the user.
     private func siteIsAlreadyPresent(site: Site) -> Bool {
-        return filter { $0.url.asURL?.domainURL == site.url.asURL?.domainURL && ($0 as? PinnedSite) != nil }.count > 0
+        return filter { ($0.url.asURL?.domainURL == site.url.asURL?.domainURL) && (($0 as? PinnedSite) != nil) }.count > 0
     }
 }
 

--- a/ClientTests/FxHomeTopSitesManagerTests.swift
+++ b/ClientTests/FxHomeTopSitesManagerTests.swift
@@ -33,7 +33,7 @@ class FxHomeTopSitesManagerTests: XCTestCase {
 
     func testEmptyData_whenNotLoaded() {
         let manager = FxHomeTopSitesManager(profile: profile)
-        XCTAssertEqual(manager.hasData, false)
+        XCTAssertFalse(manager.hasData)
         XCTAssertEqual(manager.siteCount, 0)
     }
 
@@ -62,7 +62,7 @@ class FxHomeTopSitesManagerTests: XCTestCase {
         let manager = createManager()
 
         testLoadData(manager: manager, numberOfTilesPerRow: nil) {
-            XCTAssertEqual(manager.hasData, true)
+            XCTAssertTrue(manager.hasData)
             XCTAssertEqual(manager.siteCount, 11)
         }
     }
@@ -71,7 +71,7 @@ class FxHomeTopSitesManagerTests: XCTestCase {
         let manager = createManager()
 
         testLoadData(manager: manager, numberOfTilesPerRow: 6) {
-            XCTAssertEqual(manager.hasData, true)
+            XCTAssertTrue(manager.hasData)
             XCTAssertEqual(manager.siteCount, 11)
         }
     }
@@ -99,8 +99,8 @@ class FxHomeTopSitesManagerTests: XCTestCase {
 
         // We test that without a pref, google is added
         testLoadData(manager: manager, numberOfTilesPerRow: 6) {
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, true)
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, true)
+            XCTAssertTrue(manager.getSite(index: 0)!.isGoogleURL)
+            XCTAssertTrue(manager.getSite(index: 0)!.isGoogleGUID)
         }
     }
 
@@ -109,8 +109,8 @@ class FxHomeTopSitesManagerTests: XCTestCase {
 
         // We test that without a pref, google is added even with pinned tiles
         testLoadData(manager: manager, numberOfTilesPerRow: 1) {
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, true)
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, true)
+            XCTAssertTrue(manager.getSite(index: 0)!.isGoogleURL)
+            XCTAssertTrue(manager.getSite(index: 0)!.isGoogleGUID)
         }
     }
 
@@ -122,8 +122,8 @@ class FxHomeTopSitesManagerTests: XCTestCase {
 
         // We test that having more pinned than available tiles, google tile isn't put in
         testLoadData(manager: manager, numberOfTilesPerRow: 1) {
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, false)
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, false)
+            XCTAssertFalse(manager.getSite(index: 0)!.isGoogleURL)
+            XCTAssertFalse(manager.getSite(index: 0)!.isGoogleGUID)
         }
     }
 
@@ -133,135 +133,184 @@ class FxHomeTopSitesManagerTests: XCTestCase {
         let manager = createManager(addPinnedSiteCount: 3)
 
         testLoadData(manager: manager, numberOfTilesPerRow: 6) {
-            XCTAssertEqual(manager.hasData, true)
+            XCTAssertTrue(manager.hasData)
             XCTAssertEqual(manager.siteCount, 14)
-            XCTAssertEqual(manager.getSite(index: 0)?.isPinned, true)
+            XCTAssertTrue(manager.getSite(index: 0)!.isPinned)
         }
     }
 
     // MARK: Sponsored tiles
 
     func testLoadTopSitesData_addSponsoredTile() {
-        let manager = createManager()
-        addContiles(manager: manager, shouldSucceed: true, contilesCount: 1)
+        let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 1)
+        let manager = createManager(expectedContileResult: ContileResult.success(expectedContileResult))
 
         testLoadData(manager: manager, numberOfTilesPerRow: 6) {
-            XCTAssertEqual(manager.hasData, true)
+            XCTAssertTrue(manager.hasData)
             XCTAssertEqual(manager.siteCount, 12)
         }
     }
 
     func testCalculateTopSitesData_addSponsoredTileAfterGoogle() {
-        let manager = createManager()
-        addContiles(manager: manager, shouldSucceed: true, contilesCount: 1)
+        let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 1)
+        let manager = createManager(expectedContileResult: ContileResult.success(expectedContileResult))
 
         testLoadData(manager: manager, numberOfTilesPerRow: 6) {
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, true)
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, true)
-            XCTAssertEqual(manager.getSite(index: 1)?.isSponsoredTile, true)
-            XCTAssertEqual(manager.getSite(index: 2)?.isSponsoredTile, false)
+            XCTAssertTrue(manager.getSite(index: 0)!.isGoogleURL)
+            XCTAssertTrue(manager.getSite(index: 1)!.isSponsoredTile)
+            XCTAssertFalse(manager.getSite(index: 2)!.isSponsoredTile)
         }
     }
 
     func testCalculateTopSitesData_doesNotAddSponsoredTileIfError() {
-        let manager = createManager()
-        addContiles(manager: manager, shouldSucceed: false, contilesCount: 1)
+        let expectedContileResult = ContileResult.failure(ContileProvider.Error.failure)
+        let manager = createManager(expectedContileResult: expectedContileResult)
 
         testLoadData(manager: manager, numberOfTilesPerRow: 6) {
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, true)
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, true)
-            XCTAssertEqual(manager.getSite(index: 1)?.isSponsoredTile, false)
-            XCTAssertEqual(manager.getSite(index: 2)?.isSponsoredTile, false)
+            XCTAssertTrue(manager.getSite(index: 0)!.isGoogleURL)
+            XCTAssertFalse(manager.getSite(index: 1)!.isSponsoredTile)
+            XCTAssertFalse(manager.getSite(index: 2)!.isSponsoredTile)
         }
     }
 
     func testCalculateTopSitesData_doesNotAddSponsoredTileIfSuccessEmpty() {
-        let manager = createManager()
-        addContiles(manager: manager, shouldSucceed: true, contilesCount: 0)
+        let expectedContileResult = ContileResult.success([])
+        let manager = createManager(expectedContileResult: expectedContileResult)
 
         testLoadData(manager: manager, numberOfTilesPerRow: 6) {
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, true)
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, true)
-            XCTAssertEqual(manager.getSite(index: 1)?.isSponsoredTile, false)
-            XCTAssertEqual(manager.getSite(index: 2)?.isSponsoredTile, false)
+            XCTAssertTrue(manager.getSite(index: 0)!.isGoogleURL)
+            XCTAssertFalse(manager.getSite(index: 1)!.isSponsoredTile)
+            XCTAssertFalse(manager.getSite(index: 2)!.isSponsoredTile)
         }
     }
 
     func testCalculateTopSitesData_doesNotAddMoreSponsoredTileThanMaximum() {
-        let manager = createManager()
         // Max contiles is currently at 2, so it should add 2 contiles only
-        addContiles(manager: manager, shouldSucceed: true, contilesCount: 3)
+        let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 3)
+        let manager = createManager(expectedContileResult: ContileResult.success(expectedContileResult))
 
         testLoadData(manager: manager, numberOfTilesPerRow: 6) {
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, true)
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, true)
-            XCTAssertEqual(manager.getSite(index: 1)?.isSponsoredTile, true)
-            XCTAssertEqual(manager.getSite(index: 2)?.isSponsoredTile, true)
-            XCTAssertEqual(manager.getSite(index: 3)?.isSponsoredTile, false)
+            XCTAssertTrue(manager.getSite(index: 0)!.isGoogleURL)
+            XCTAssertTrue(manager.getSite(index: 1)!.isSponsoredTile)
+            XCTAssertTrue(manager.getSite(index: 2)!.isSponsoredTile)
+            XCTAssertFalse(manager.getSite(index: 3)!.isSponsoredTile)
         }
     }
 
     func testCalculateTopSitesData_doesNotAddSponsoredTileIfDuplicatePinned() {
-        let manager = createManager(addPinnedSiteCount: 1)
-        addContiles(manager: manager, shouldSucceed: true, contilesCount: 1, duplicateFirstTile: true, pinnedDuplicateTile: true)
+        let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 1,
+                                                                    duplicateFirstTile: true,
+                                                                    pinnedDuplicateTile: true)
+        let manager = createManager(addPinnedSiteCount: 1, expectedContileResult: ContileResult.success(expectedContileResult))
 
         testLoadData(manager: manager, numberOfTilesPerRow: 6) {
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, true)
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, true)
-            XCTAssertEqual(manager.getSite(index: 1)?.isSponsoredTile, false)
-            XCTAssertEqual(manager.getSite(index: 2)?.isSponsoredTile, false)
+            XCTAssertTrue(manager.getSite(index: 0)!.isGoogleURL)
+            XCTAssertFalse(manager.getSite(index: 1)!.isSponsoredTile)
+            XCTAssertFalse(manager.getSite(index: 2)!.isSponsoredTile)
         }
     }
 
     func testCalculateTopSitesData_addSponsoredTileIfDuplicateIsNotPinned() {
-        let manager = createManager(addPinnedSiteCount: 1)
-        addContiles(manager: manager, shouldSucceed: true, contilesCount: 1, duplicateFirstTile: true)
+        let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 1,
+                                                                    duplicateFirstTile: true)
+        let manager = createManager(addPinnedSiteCount: 1, expectedContileResult: ContileResult.success(expectedContileResult))
 
         testLoadData(manager: manager, numberOfTilesPerRow: 6) {
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, true)
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, true)
-            XCTAssertEqual(manager.getSite(index: 1)?.isSponsoredTile, true)
-            XCTAssertEqual(manager.getSite(index: 2)?.isSponsoredTile, false)
+            XCTAssertTrue(manager.getSite(index: 0)!.isGoogleURL)
+            XCTAssertTrue(manager.getSite(index: 1)!.isSponsoredTile)
+            XCTAssertFalse(manager.getSite(index: 2)!.isSponsoredTile)
         }
     }
 
     func testCalculateTopSitesData_addNextTileIfSponsoredTileIsDuplicate() {
-        let manager = createManager(addPinnedSiteCount: 1)
-        addContiles(manager: manager, shouldSucceed: true, contilesCount: 2, duplicateFirstTile: true, pinnedDuplicateTile: true)
+        let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 2,
+                                                                    duplicateFirstTile: true,
+                                                                    pinnedDuplicateTile: true)
+        let manager = createManager(addPinnedSiteCount: 1, expectedContileResult: ContileResult.success(expectedContileResult))
 
         testLoadData(manager: manager, numberOfTilesPerRow: 6) {
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, true)
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, true)
-            XCTAssertEqual(manager.getSite(index: 1)?.isSponsoredTile, true)
-            XCTAssertEqual(manager.getSite(index: 1)?.title, ContileProviderMock.defaultSuccessData[0].name)
-            XCTAssertEqual(manager.getSite(index: 2)?.isSponsoredTile, false)
+            XCTAssertTrue(manager.getSite(index: 0)!.isGoogleURL)
+            XCTAssertTrue(manager.getSite(index: 1)!.isSponsoredTile)
+            XCTAssertEqual(manager.getSite(index: 1)!.title, ContileProviderMock.defaultSuccessData[0].name)
+            XCTAssertFalse(manager.getSite(index: 2)!.isSponsoredTile)
         }
     }
 
     func testCalculateTopSitesData_doesNotAddTileIfAllSpacesArePinned() {
-        let manager = createManager(addPinnedSiteCount: 12)
-        addContiles(manager: manager, shouldSucceed: true, contilesCount: 0)
+        let expectedContileResult = ContileResult.success([])
+        let manager = createManager(addPinnedSiteCount: 12, expectedContileResult: expectedContileResult)
 
         profile.prefs.setBool(true, forKey: PrefsKeys.GoogleTopSiteAddedKey)
         profile.prefs.setBool(true, forKey: PrefsKeys.GoogleTopSiteHideKey)
 
         testLoadData(manager: manager, numberOfTilesPerRow: 6) {
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, false)
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, false)
-            XCTAssertEqual(manager.getSite(index: 1)?.isSponsoredTile, false)
-            XCTAssertEqual(manager.getSite(index: 2)?.isSponsoredTile, false)
+            XCTAssertFalse(manager.getSite(index: 0)!.isGoogleURL)
+            XCTAssertFalse(manager.getSite(index: 1)!.isSponsoredTile)
+            XCTAssertFalse(manager.getSite(index: 2)!.isSponsoredTile)
         }
     }
 
     func testCalculateTopSitesData_doesNotAddTileIfAllSpacesArePinnedAndGoogleIsThere() {
-        let manager = createManager(addPinnedSiteCount: 11)
-        addContiles(manager: manager, shouldSucceed: true, contilesCount: 0)
+        let expectedContileResult = ContileResult.success([])
+        let manager = createManager(addPinnedSiteCount: 11, expectedContileResult: expectedContileResult)
 
         testLoadData(manager: manager, numberOfTilesPerRow: 6) {
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleURL, true)
-            XCTAssertEqual(manager.getSite(index: 0)?.isGoogleGUID, true)
-            XCTAssertEqual(manager.getSite(index: 1)?.isSponsoredTile, false)
-            XCTAssertEqual(manager.getSite(index: 2)?.isSponsoredTile, false)
+            XCTAssertTrue(manager.getSite(index: 0)!.isGoogleURL)
+            XCTAssertFalse(manager.getSite(index: 1)!.isSponsoredTile)
+            XCTAssertFalse(manager.getSite(index: 2)!.isSponsoredTile)
+        }
+    }
+
+    // MARK: Duplicates
+
+    // Sponsored > Frequency
+    func testDuplicates_SponsoredTileHasPrecedenceOnFrequencyTiles() {
+        let manager = createManager(expectedContileResult: ContileResult.success([ContileProviderMock.duplicateTile]))
+
+        testLoadData(manager: manager, numberOfTilesPerRow: 6) {
+            XCTAssertTrue(manager.getSite(index: 0)!.isGoogleURL)
+            XCTAssertEqual(manager.getSite(index: 1)!.title, ContileProviderMock.duplicateTile.name)
+            XCTAssertTrue(manager.getSite(index: 1)!.isSponsoredTile)
+            XCTAssertFalse(manager.getSite(index: 2)!.isSponsoredTile)
+        }
+    }
+
+    // Pinned > Sponsored
+    func testDuplicates_PinnedTilesHasPrecedenceOnSponsoredTiles() {
+        let manager = createManager(addPinnedSiteCount: 1, expectedContileResult: ContileResult.success([ContileProviderMock.pinnedDuplicateTile]))
+
+        testLoadData(manager: manager, numberOfTilesPerRow: 6) {
+            XCTAssertTrue(manager.getSite(index: 0)!.isGoogleURL)
+            XCTAssertFalse(manager.getSite(index: 1)!.isSponsoredTile)
+            XCTAssertTrue(manager.getSite(index: 1)!.isPinned)
+            XCTAssertFalse(manager.getSite(index: 2)!.isSponsoredTile)
+            XCTAssertFalse(manager.getSite(index: 2)!.isPinned)
+        }
+    }
+
+    // Pinned > Frequency
+    func testDuplicates_PinnedTilesHasPrecedenceOnFrequencyTiles() {
+        let expectedPinnedURL = String(format: ContileProviderMock.url, "0")
+        let manager = createManager(addPinnedSiteCount: 1, siteCount: 3, duplicatePinnedSiteURL: true)
+
+        testLoadData(manager: manager, numberOfTilesPerRow: 4) {
+            XCTAssertEqual(manager.siteCount, 4)
+            XCTAssertTrue(manager.getSite(index: 0)!.isGoogleURL)
+
+            let tile1 = manager.getSite(index: 1)
+            XCTAssertFalse(tile1!.isSponsoredTile)
+            XCTAssertTrue(tile1!.isPinned)
+            XCTAssertEqual(tile1!.site.url, expectedPinnedURL)
+
+            let tile2 = manager.getSite(index: 2)
+            XCTAssertFalse(tile2!.isSponsoredTile)
+            XCTAssertFalse(tile2!.isPinned)
+            XCTAssertNotEqual(tile2!.title, expectedPinnedURL)
+
+            let tile3 = manager.getSite(index: 3)
+            XCTAssertFalse(tile3!.isSponsoredTile)
+            XCTAssertFalse(tile3!.isPinned)
+            XCTAssertNotEqual(tile3!.title, expectedPinnedURL)
         }
     }
 }
@@ -298,7 +347,7 @@ class ContileProviderMock: ContileProviderInterface {
                         position: 3)]
     }
 
-    init(result: ContileResult = .success([])) {
+    init(result: ContileResult) {
         self.result = result
     }
 
@@ -310,8 +359,8 @@ class ContileProviderMock: ContileProviderInterface {
 extension ContileProviderMock {
 
     static func getContiles(contilesCount: Int,
-                            duplicateFirstTile: Bool,
-                            pinnedDuplicateTile: Bool) -> [Contile] {
+                            duplicateFirstTile: Bool = false,
+                            pinnedDuplicateTile: Bool = false) -> [Contile] {
 
         var defaultData = ContileProviderMock.defaultSuccessData
 
@@ -354,14 +403,19 @@ extension ContileProviderMock {
 // MARK: FxHomeTopSitesManagerTests
 extension FxHomeTopSitesManagerTests {
 
-    func createManager(addPinnedSiteCount: Int = 0) -> FxHomeTopSitesManager {
+    func createManager(addPinnedSiteCount: Int = 0,
+                       siteCount: Int = 10,
+                       duplicatePinnedSiteURL: Bool = false,
+                       expectedContileResult: ContileResult = .success([])) -> FxHomeTopSitesManager {
         let topSitesManager = FxHomeTopSitesManager(profile: profile)
 
         let historyStub = TopSiteHistoryManagerStub(profile: profile)
+        historyStub.siteCount = siteCount
         historyStub.addPinnedSiteCount = addPinnedSiteCount
+        historyStub.duplicatePinnedSiteURL = duplicatePinnedSiteURL
         topSitesManager.topSiteHistoryManager = historyStub
 
-        contileProviderMock = ContileProviderMock()
+        contileProviderMock = ContileProviderMock(result: expectedContileResult)
         topSitesManager.contileProvider = contileProviderMock
 
         return topSitesManager
@@ -380,22 +434,6 @@ extension FxHomeTopSitesManagerTests {
 
         waitForExpectations(timeout: 0.1, handler: nil)
     }
-
-    func addContiles(manager: FxHomeTopSitesManager,
-                     shouldSucceed: Bool,
-                     contilesCount: Int = 0,
-                     duplicateFirstTile: Bool = false,
-                     pinnedDuplicateTile: Bool = false) {
-
-        let resultContile = ContileProviderMock.getContiles(contilesCount: contilesCount,
-                                                            duplicateFirstTile: duplicateFirstTile,
-                                                            pinnedDuplicateTile: pinnedDuplicateTile)
-
-        let result = shouldSucceed ? ContileResult.success(resultContile) : ContileResult.failure(ContileProvider.Error.failure)
-
-        contileProviderMock = ContileProviderMock(result: result)
-        manager.contileProvider = contileProviderMock
-    }
 }
 
 // MARK: TopSiteHistoryManagerStub
@@ -407,12 +445,14 @@ class TopSiteHistoryManagerStub: TopSiteHistoryManager {
 
     var siteCount = 10
     var addPinnedSiteCount: Int = 0
+    var duplicatePinnedSiteURL = false
 
     func createHistorySites() -> [Site] {
         var sites = [Site]()
 
         (0..<addPinnedSiteCount).forEach {
-            let site = Site(url: String(format: ContileProviderMock.pinnedURL, "\($0)"), title: String(format: ContileProviderMock.pinnedTitle, "\($0)"))
+            let pinnedSiteURL = duplicatePinnedSiteURL ? String(format: ContileProviderMock.url, "\($0)"): String(format: ContileProviderMock.pinnedURL, "\($0)")
+            let site = Site(url: pinnedSiteURL, title: String(format: ContileProviderMock.pinnedTitle, "\($0)"))
             sites.append(PinnedSite(site: site))
         }
 


### PR DESCRIPTION
# Issue [FXIOS-4130](https://mozilla-hub.atlassian.net/browse/FXIOS-4130)
- This PR is basically to ensure that tiles are shown with the following precedence Pinned > Sponsored > Frequency. If a tile URL is already being showned (checking with URL domain) then we don't show it again.
- Added tests to cover those use cases
- Cleaned up test code
- Fix Swiftlint issue