### PR TITLE
Add fx3465 fx3469 [v101] Add settings to enable/disable top sites and sponsored tiles

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -526,6 +526,7 @@
 		8ADED7EC27691351009C19E6 /* CalendarExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADED7EB27691351009C19E6 /* CalendarExtensionsTests.swift */; };
 		8ADED7EE276A7750009C19E6 /* CumulativeDaysOfUseCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADED7ED276A7750009C19E6 /* CumulativeDaysOfUseCounter.swift */; };
 		8ADED7F0276A7788009C19E6 /* CumulativeDaysOfUseCounterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADED7EF276A7788009C19E6 /* CumulativeDaysOfUseCounterTests.swift */; };
+		8AE0BF4F2819B10E00F33EC4 /* TopSitesSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE0BF4E2819B10E00F33EC4 /* TopSitesSettingsViewController.swift */; };
 		8AE1E1CB27B18F560024C45E /* SearchBarSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1E1CA27B18F560024C45E /* SearchBarSettingsViewController.swift */; };
 		8AE1E1CD27B191110024C45E /* SearchBarSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1E1CC27B191110024C45E /* SearchBarSettingsViewModel.swift */; };
 		8AE1E1D227B1ADC40024C45E /* TopBottomInterchangeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1E1D127B1ADC40024C45E /* TopBottomInterchangeable.swift */; };
@@ -2840,6 +2841,7 @@
 		8ADED7EB27691351009C19E6 /* CalendarExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarExtensionsTests.swift; sourceTree = "<group>"; };
 		8ADED7ED276A7750009C19E6 /* CumulativeDaysOfUseCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CumulativeDaysOfUseCounter.swift; sourceTree = "<group>"; };
 		8ADED7EF276A7788009C19E6 /* CumulativeDaysOfUseCounterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CumulativeDaysOfUseCounterTests.swift; sourceTree = "<group>"; };
+		8AE0BF4E2819B10E00F33EC4 /* TopSitesSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesSettingsViewController.swift; sourceTree = "<group>"; };
 		8AE1E1CA27B18F560024C45E /* SearchBarSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarSettingsViewController.swift; sourceTree = "<group>"; };
 		8AE1E1CC27B191110024C45E /* SearchBarSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarSettingsViewModel.swift; sourceTree = "<group>"; };
 		8AE1E1D127B1ADC40024C45E /* TopBottomInterchangeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBottomInterchangeable.swift; sourceTree = "<group>"; };
@@ -5599,6 +5601,15 @@
 			path = TabContentsScripts;
 			sourceTree = "<group>";
 		};
+		8AE0BF4B2819B08D00F33EC4 /* TopSitesSettings */ = {
+			isa = PBXGroup;
+			children = (
+				8AE0BF4E2819B10E00F33EC4 /* TopSitesSettingsViewController.swift */,
+				DFACBF84277B9B5B003D5F41 /* TopSitesRowCountSettingsController.swift */,
+			);
+			path = TopSitesSettings;
+			sourceTree = "<group>";
+		};
 		8AE1E1CE27B191160024C45E /* SearchBar */ = {
 			isa = PBXGroup;
 			children = (
@@ -6252,9 +6263,9 @@
 		DFACBF83277B9B36003D5F41 /* HomepageSettings */ = {
 			isa = PBXGroup;
 			children = (
+				8AE0BF4B2819B08D00F33EC4 /* TopSitesSettings */,
 				DFB2610E277CC5CD00DDDD38 /* WallpaperSettings */,
 				D8AA923321A602DC002605C0 /* HomePageSettingViewController.swift */,
-				DFACBF84277B9B5B003D5F41 /* TopSitesRowCountSettingsController.swift */,
 			);
 			path = HomepageSettings;
 			sourceTree = "<group>";
@@ -9221,6 +9232,7 @@
 				D863C8F21F68BFC20058D95F /* GradientProgressBar.swift in Sources */,
 				C8445A14264428DC00B83F53 /* LibraryPanelViewState.swift in Sources */,
 				D5D052D92645ABF400759F85 /* ExperimentsSettingsView.swift in Sources */,
+				8AE0BF4F2819B10E00F33EC4 /* TopSitesSettingsViewController.swift in Sources */,
 				8A8DDEBF276259A900E7B97A /* RatingPromptManager.swift in Sources */,
 				8AB8571D27D929350075C173 /* FxHomeTopSitesViewModel.swift in Sources */,
 				D59431ED25E9912900F0BA82 /* WidgetIntents.intentdefinition in Sources */,

--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -96,7 +96,7 @@ public struct AccessibilityIdentifiers {
                 static let recentlySaved = "Recently Saved"
                 static let recentVisited = "Recently Visited"
                 static let recommendedByPocket = "Recommended by Pocket"
-                static let wallPaper = "WallpaperSettings"
+                static let wallpaper = "WallpaperSettings"
             }
         }
 

--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -87,11 +87,16 @@ public struct AccessibilityIdentifiers {
             }
 
             struct CustomizeFirefox {
-                static let shortcuts = ""
+                struct Shortcuts {
+                    static let settingsPage = "TopSitesSettings"
+                    static let topSitesRows = "TopSitesRows"
+                }
+
                 static let jumpBackIn = "Jump Back In"
                 static let recentlySaved = "Recently Saved"
                 static let recentVisited = "Recently Visited"
                 static let recommendedByPocket = "Recommended by Pocket"
+                static let wallPaper = "WallpaperSettings"
             }
         }
 

--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -9,7 +9,7 @@ import XCGLogger
 
 private let log = Logger.browserLogger
 
-class TestAppDelegate: AppDelegate {
+class TestAppDelegate: AppDelegate, FeatureFlagsProtocol {
 
     lazy var dirForTestProfile = { return "\(self.appRootDir())/profile.testProfile" }()
 
@@ -98,7 +98,7 @@ class TestAppDelegate: AppDelegate {
         }
 
         if launchArguments.contains(LaunchArguments.SkipSponsoredShortcuts) {
-            profile.prefs.setBool(false, forKey: PrefsKeys.KeyShowSponsoredShortcuts)
+            featureFlags.setUserPreferenceFor(.sponsoredTiles, to: UserFeaturePreference.disabled)
         }
 
         // Don't show the What's New page.

--- a/Client/FeatureFlags/FlaggableFeature.swift
+++ b/Client/FeatureFlags/FlaggableFeature.swift
@@ -36,6 +36,10 @@ struct FlaggableFeature {
             return FlagKeys.StartAtHome
         case .tabTrayGroups:
             return FlagKeys.TabTrayGroups
+        case .topSites:
+            return FlagKeys.TopSiteSection
+        case .sponsoredTiles:
+            return FlagKeys.SponsoredShortcuts
         case .wallpapers:
             return FlagKeys.CustomWallpaper
         default: return nil
@@ -100,9 +104,8 @@ struct FlaggableFeature {
         switch featureID {
         case .startAtHome:
             return StartAtHomeSetting.afterFourHours.rawValue
-        case .wallpapers:
-            // In this case, we want to enable the tap banner to cycle through
-            // wallpapers behaviour by default.
+        case .wallpapers, .topSites:
+            // Features that are on by default
             return UserFeaturePreference.enabled.rawValue
 
         // Nimbus default options

--- a/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
@@ -151,10 +151,10 @@ class FxHomeTopSitesManager: FeatureFlagsProtocol {
 
     static let maximumNumberOfSponsoredTile = 2
 
-    // TODO: Check for settings user preference with https://mozilla-hub.atlassian.net/browse/FXIOS-3469
     // TODO: Check for nimbus with https://mozilla-hub.atlassian.net/browse/FXIOS-3468
     private var shouldLoadSponsoredTiles: Bool {
-        return featureFlags.isFeatureActiveForBuild(.sponsoredTiles) && profile.prefs.boolForKey(PrefsKeys.KeyShowSponsoredShortcuts) ?? true
+        return featureFlags.isFeatureActiveForBuild(.sponsoredTiles)
+        && featureFlags.userPreferenceFor(.sponsoredTiles) == UserFeaturePreference.enabled
     }
 
     private var shouldShowSponsoredTiles: Bool {

--- a/Client/Frontend/Home/TopSites/FxHomeTopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/FxHomeTopSitesViewModel.swift
@@ -171,7 +171,7 @@ extension FxHomeTopSitesViewModel: FXHomeViewModelProtocol, FeatureFlagsProtocol
     }
 
     var isEnabled: Bool {
-        return featureFlags.isFeatureActiveForNimbus(.topSites)
+        return featureFlags.isFeatureActiveForNimbus(.topSites) && featureFlags.userPreferenceFor(.topSites) == UserFeaturePreference.enabled
     }
 
     var hasData: Bool {

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -88,11 +88,7 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagsP
             return
 
         case .customizeTopSites:
-            let topSitesVC = TopSitesRowCountSettingsController(prefs: profile.prefs)
-            topSitesVC.profile = profile
-            // Push top sites settings view controller directly as its not of type settings viewcontroller
-            navigationController?.pushViewController(topSitesVC, animated: false)
-            return
+            viewController = TopSitesSettingsViewController()
         }
 
         viewController.profile = profile

--- a/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -207,28 +207,28 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlagsPr
 
 // MARK: - TopSitesSettings
 extension HomePageSettingViewController {
-    class TopSitesSettings: Setting {
-        let profile: Profile
+    class TopSitesSettings: Setting, FeatureFlagsProtocol {
+        var profile: Profile
 
         override var accessoryType: UITableViewCell.AccessoryType { return .disclosureIndicator }
-        override var status: NSAttributedString {
-            let num = self.profile.prefs.intForKey(PrefsKeys.NumberOfTopSiteRows) ?? TopSitesRowCountSettingsController.defaultNumberOfRows
-            return NSAttributedString(string: String(format: .Settings.Homepage.Shortcuts.RowCount, num))
-        }
-
-        override var accessibilityIdentifier: String? { return "TopSitesRows" }
+        override var accessibilityIdentifier: String? { return AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.Shortcuts.settingsPage }
         override var style: UITableViewCell.CellStyle { return .value1 }
+
+        override var status: NSAttributedString {
+            let areShortcutsOn = featureFlags.userPreferenceFor(.topSites) == UserFeaturePreference.enabled
+            let status: String = areShortcutsOn ? .Settings.Homepage.Shortcuts.ToggleOn : .Settings.Homepage.Shortcuts.ToggleOff
+            return NSAttributedString(string: String(format: status))
+        }
 
         init(settings: SettingsTableViewController) {
             self.profile = settings.profile
-            super.init(title: NSAttributedString(string: .Settings.Homepage.CustomizeFirefoxHome.Shortcuts,
-                                                 attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+            super.init(title: NSAttributedString(string: .Settings.Homepage.Shortcuts.ShortcutsPageTitle))
         }
 
         override func onClick(_ navigationController: UINavigationController?) {
-            let viewController = TopSitesRowCountSettingsController(prefs: profile.prefs)
-            viewController.profile = profile
-            navigationController?.pushViewController(viewController, animated: true)
+            let topSitesVC = TopSitesSettingsViewController()
+            topSitesVC.profile = profile
+            navigationController?.pushViewController(topSitesVC, animated: true)
         }
     }
 }
@@ -241,7 +241,7 @@ extension HomePageSettingViewController {
         var tabManager: TabManager
 
         override var accessoryType: UITableViewCell.AccessoryType { return .disclosureIndicator }
-        override var accessibilityIdentifier: String? { return "WallpaperSettings" }
+        override var accessibilityIdentifier: String? { return AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.wallPaper }
         override var style: UITableViewCell.CellStyle { return .value1 }
 
         init(settings: SettingsTableViewController,

--- a/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -241,7 +241,7 @@ extension HomePageSettingViewController {
         var tabManager: TabManager
 
         override var accessoryType: UITableViewCell.AccessoryType { return .disclosureIndicator }
-        override var accessibilityIdentifier: String? { return AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.wallPaper }
+        override var accessibilityIdentifier: String? { return AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.wallpaper }
         override var style: UITableViewCell.CellStyle { return .value1 }
 
         init(settings: SettingsTableViewController,

--- a/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
@@ -6,6 +6,7 @@ import Foundation
 import Shared
 
 class TopSitesRowCountSettingsController: SettingsTableViewController {
+
     let prefs: Prefs
     var numberOfRows: Int32
     static let defaultNumberOfRows: Int32 = 2
@@ -14,7 +15,7 @@ class TopSitesRowCountSettingsController: SettingsTableViewController {
         self.prefs = prefs
         numberOfRows = self.prefs.intForKey(PrefsKeys.NumberOfTopSiteRows) ?? TopSitesRowCountSettingsController.defaultNumberOfRows
         super.init(style: .grouped)
-        self.title = .AppMenu.AppMenuTopSitesTitleString
+        self.title = .Settings.Homepage.Shortcuts.RowsPageTitle
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -1,0 +1,68 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Shared
+
+class TopSitesSettingsViewController: SettingsTableViewController {
+
+    // MARK: - Initializers
+    init() {
+        super.init(style: .grouped)
+
+        self.title = .Settings.Homepage.Shortcuts.ShortcutsPageTitle
+        self.navigationController?.navigationBar.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.Shortcuts.settingsPage
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Methods
+    override func generateSettings() -> [SettingSection] {
+        let topSitesSetting = BoolSetting(with: .topSites,
+                                          titleText: NSAttributedString(string: .Settings.Homepage.Shortcuts.ShortcutsToggle))
+
+        // TODO: Only show setting if Nimbus enabled https://mozilla-hub.atlassian.net/browse/FXIOS-3468
+        let sponsoredShortcutSetting = BoolSetting(with: .sponsoredTiles,
+                                                   titleText: NSAttributedString(string: .Settings.Homepage.Shortcuts.SponsoredShortcutsToggle))
+
+        let toggleSection = SettingSection(title: nil,
+                                           children: [topSitesSetting, sponsoredShortcutSetting])
+
+        let rowSetting = RowSettings(settings: self)
+        let rowSection = SettingSection(title: nil, children: [rowSetting])
+
+        return [toggleSection, rowSection]
+    }
+}
+
+// MARK: - TopSitesSettings
+extension TopSitesSettingsViewController {
+    class RowSettings: Setting {
+        let profile: Profile
+
+        override var accessoryType: UITableViewCell.AccessoryType { return .disclosureIndicator }
+        override var status: NSAttributedString {
+            let numberOfRows = profile.prefs.intForKey(PrefsKeys.NumberOfTopSiteRows) ?? TopSitesRowCountSettingsController.defaultNumberOfRows
+            return NSAttributedString(string: String(format: "%d", numberOfRows))
+        }
+
+        override var accessibilityIdentifier: String? { return AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.Shortcuts.topSitesRows }
+        override var style: UITableViewCell.CellStyle { return .value1 }
+
+        init(settings: SettingsTableViewController) {
+            self.profile = settings.profile
+            super.init(title: NSAttributedString(string: .Settings.Homepage.Shortcuts.Rows,
+                                                 attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        }
+
+        override func onClick(_ navigationController: UINavigationController?) {
+            let viewController = TopSitesRowCountSettingsController(prefs: profile.prefs)
+            viewController.profile = profile
+            navigationController?.pushViewController(viewController, animated: true)
+        }
+    }
+}

--- a/ClientTests/FxHomeTopSitesManagerTests.swift
+++ b/ClientTests/FxHomeTopSitesManagerTests.swift
@@ -8,7 +8,7 @@ import Shared
 import Storage
 import XCTest
 
-class FxHomeTopSitesManagerTests: XCTestCase {
+class FxHomeTopSitesManagerTests: XCTestCase, FeatureFlagsProtocol {
 
     private var profile: MockProfile!
     private var contileProviderMock: ContileProviderMock!
@@ -142,6 +142,8 @@ class FxHomeTopSitesManagerTests: XCTestCase {
     // MARK: Sponsored tiles
 
     func testLoadTopSitesData_addSponsoredTile() {
+        featureFlags.setUserPreferenceFor(.sponsoredTiles, to: UserFeaturePreference.enabled)
+
         let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 1)
         let manager = createManager(expectedContileResult: ContileResult.success(expectedContileResult))
 
@@ -152,6 +154,8 @@ class FxHomeTopSitesManagerTests: XCTestCase {
     }
 
     func testCalculateTopSitesData_addSponsoredTileAfterGoogle() {
+        featureFlags.setUserPreferenceFor(.sponsoredTiles, to: UserFeaturePreference.enabled)
+
         let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 1)
         let manager = createManager(expectedContileResult: ContileResult.success(expectedContileResult))
 
@@ -163,6 +167,8 @@ class FxHomeTopSitesManagerTests: XCTestCase {
     }
 
     func testCalculateTopSitesData_doesNotAddSponsoredTileIfError() {
+        featureFlags.setUserPreferenceFor(.sponsoredTiles, to: UserFeaturePreference.enabled)
+
         let expectedContileResult = ContileResult.failure(ContileProvider.Error.failure)
         let manager = createManager(expectedContileResult: expectedContileResult)
 
@@ -174,6 +180,8 @@ class FxHomeTopSitesManagerTests: XCTestCase {
     }
 
     func testCalculateTopSitesData_doesNotAddSponsoredTileIfSuccessEmpty() {
+        featureFlags.setUserPreferenceFor(.sponsoredTiles, to: UserFeaturePreference.enabled)
+
         let expectedContileResult = ContileResult.success([])
         let manager = createManager(expectedContileResult: expectedContileResult)
 
@@ -185,6 +193,8 @@ class FxHomeTopSitesManagerTests: XCTestCase {
     }
 
     func testCalculateTopSitesData_doesNotAddMoreSponsoredTileThanMaximum() {
+        featureFlags.setUserPreferenceFor(.sponsoredTiles, to: UserFeaturePreference.enabled)
+
         // Max contiles is currently at 2, so it should add 2 contiles only
         let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 3)
         let manager = createManager(expectedContileResult: ContileResult.success(expectedContileResult))
@@ -198,6 +208,8 @@ class FxHomeTopSitesManagerTests: XCTestCase {
     }
 
     func testCalculateTopSitesData_doesNotAddSponsoredTileIfDuplicatePinned() {
+        featureFlags.setUserPreferenceFor(.sponsoredTiles, to: UserFeaturePreference.enabled)
+
         let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 1,
                                                                     duplicateFirstTile: true,
                                                                     pinnedDuplicateTile: true)
@@ -211,6 +223,8 @@ class FxHomeTopSitesManagerTests: XCTestCase {
     }
 
     func testCalculateTopSitesData_addSponsoredTileIfDuplicateIsNotPinned() {
+        featureFlags.setUserPreferenceFor(.sponsoredTiles, to: UserFeaturePreference.enabled)
+
         let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 1,
                                                                     duplicateFirstTile: true)
         let manager = createManager(addPinnedSiteCount: 1, expectedContileResult: ContileResult.success(expectedContileResult))
@@ -223,6 +237,8 @@ class FxHomeTopSitesManagerTests: XCTestCase {
     }
 
     func testCalculateTopSitesData_addNextTileIfSponsoredTileIsDuplicate() {
+        featureFlags.setUserPreferenceFor(.sponsoredTiles, to: UserFeaturePreference.enabled)
+
         let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 2,
                                                                     duplicateFirstTile: true,
                                                                     pinnedDuplicateTile: true)
@@ -237,6 +253,8 @@ class FxHomeTopSitesManagerTests: XCTestCase {
     }
 
     func testCalculateTopSitesData_doesNotAddTileIfAllSpacesArePinned() {
+        featureFlags.setUserPreferenceFor(.sponsoredTiles, to: UserFeaturePreference.enabled)
+
         let expectedContileResult = ContileResult.success([])
         let manager = createManager(addPinnedSiteCount: 12, expectedContileResult: expectedContileResult)
 
@@ -251,6 +269,8 @@ class FxHomeTopSitesManagerTests: XCTestCase {
     }
 
     func testCalculateTopSitesData_doesNotAddTileIfAllSpacesArePinnedAndGoogleIsThere() {
+        featureFlags.setUserPreferenceFor(.sponsoredTiles, to: UserFeaturePreference.enabled)
+
         let expectedContileResult = ContileResult.success([])
         let manager = createManager(addPinnedSiteCount: 11, expectedContileResult: expectedContileResult)
 
@@ -265,6 +285,8 @@ class FxHomeTopSitesManagerTests: XCTestCase {
 
     // Sponsored > Frequency
     func testDuplicates_SponsoredTileHasPrecedenceOnFrequencyTiles() {
+        featureFlags.setUserPreferenceFor(.sponsoredTiles, to: UserFeaturePreference.enabled)
+
         let manager = createManager(expectedContileResult: ContileResult.success([ContileProviderMock.duplicateTile]))
 
         testLoadData(manager: manager, numberOfTilesPerRow: 6) {
@@ -277,6 +299,8 @@ class FxHomeTopSitesManagerTests: XCTestCase {
 
     // Pinned > Sponsored
     func testDuplicates_PinnedTilesHasPrecedenceOnSponsoredTiles() {
+        featureFlags.setUserPreferenceFor(.sponsoredTiles, to: UserFeaturePreference.enabled)
+
         let manager = createManager(addPinnedSiteCount: 1, expectedContileResult: ContileResult.success([ContileProviderMock.pinnedDuplicateTile]))
 
         testLoadData(manager: manager, numberOfTilesPerRow: 6) {
@@ -290,6 +314,8 @@ class FxHomeTopSitesManagerTests: XCTestCase {
 
     // Pinned > Frequency
     func testDuplicates_PinnedTilesHasPrecedenceOnFrequencyTiles() {
+        featureFlags.setUserPreferenceFor(.sponsoredTiles, to: UserFeaturePreference.enabled)
+
         let expectedPinnedURL = String(format: ContileProviderMock.url, "0")
         let manager = createManager(addPinnedSiteCount: 1, siteCount: 3, duplicatePinnedSiteURL: true)
 

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 
+// New keys should follow the name: "[nameOfTheFeature]Key" written with camel case
 public struct PrefsKeys {
     // When this pref is set (by the user) it overrides default behaviour which is just based on app locale.
     public static let KeyEnableChinaSyncService = "useChinaSyncService"
@@ -50,6 +51,8 @@ public struct PrefsKeys {
         public static let RecentlySavedSection = "recentlySavedSectionEnabled"
         public static let StartAtHome = "startAtHome"
         public static let TabTrayGroups = "KeyEnableGroupedTabsKey"
+        public static let SponsoredShortcuts = "sponsoredShortcutsKey"
+        public static let TopSiteSection = "topSitesKey"
     }
 
     // Firefox contextual hint
@@ -74,7 +77,6 @@ public struct PrefsKeys {
     public static let AppExtensionTelemetryOpenUrl = "AppExtensionTelemetryOpenUrl"
     public static let AppExtensionTelemetryEventArray = "AppExtensionTelemetryEvents"
     public static let KeyBlockPopups = "blockPopups"
-    public static let KeyShowSponsoredShortcuts = "showSponsoredShortcuts"
 
     // Tabs Tray
     public static let KeyInactiveTabsModel = "KeyInactiveTabsModelKey"


### PR DESCRIPTION
# [FXIOS-3465](https://mozilla-hub.atlassian.net/browse/FXIOS-3465) & [FXIOS-3469](https://mozilla-hub.atlassian.net/browse/FXIOS-3469)
- Add setting to enable/disable top sites (on by default)
- Add setting to enable/disable sponsored shortcuts (off by default)
- Customize number of rows in top sites is in this new setting page as well