### PR TITLE
Bugfix #10611 [v100] - History list appears empty after clearing the History search bar

### DIFF
--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
@@ -68,10 +68,6 @@ class HistoryPanelViewModel: Loggable, FeatureFlagsProtocol {
         return !isSearchInProgress ? .HistoryPanelEmptyStateTitle : .LibraryPanel.History.NoHistoryResult
     }
 
-    var shouldShowEmptyState: Bool {
-        return isSearchInProgress ? searchResultSites.isEmpty : groupedSites.isEmpty
-    }
-
     let historyPanelNotifications = [Notification.Name.FirefoxAccountChanged,
                                      Notification.Name.PrivateDataClearedHistory,
                                      Notification.Name.DynamicFontChanged,
@@ -131,6 +127,13 @@ class HistoryPanelViewModel: Loggable, FeatureFlagsProtocol {
             self.searchResultSites = results
             completion(!results.isEmpty)
         }
+    }
+
+    func shouldShowEmptyState(searchText: String) -> Bool {
+        guard isSearchInProgress else { return groupedSites.isEmpty }
+
+        // if the search text is empty we show the regular history so the empty should not show
+        return !searchText.isEmpty ? searchResultSites.isEmpty : false
     }
 
     func updateSearchOffset() {

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
@@ -53,10 +53,13 @@ class HistoryPanelViewModel: Loggable, FeatureFlagsProtocol {
     let historyActionables = HistoryActionablesModel.activeActionables
 
     var visibleSections: [Sections] = []
+    // Groups items we should have a single datasource containing sites and groups
     var searchTermGroups: [ASGroup<Site>] = []
+    // Only individual sites
+    var groupedSites = DateGroupedTableData<Site>()
     var isFetchInProgress = false
     var isSearchInProgress = false
-    var groupedSites = DateGroupedTableData<Site>()
+
     var searchResultSites = [Site]()
     var searchHistoryPlaceholder: String = .LibraryPanel.History.SearchHistoryPlaceholder
 
@@ -130,7 +133,7 @@ class HistoryPanelViewModel: Loggable, FeatureFlagsProtocol {
     }
 
     func shouldShowEmptyState(searchText: String) -> Bool {
-        guard isSearchInProgress else { return groupedSites.isEmpty }
+        guard isSearchInProgress else { return groupedSites.isEmpty && searchTermGroups.isEmpty }
 
         // if the search text is empty we show the regular history so the empty should not show
         return !searchText.isEmpty ? searchResultSites.isEmpty : false

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups+Search.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups+Search.swift
@@ -19,8 +19,7 @@ extension HistoryPanelWithGroups: UISearchBarDelegate {
 
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         guard let searchText = searchBar.text, !searchText.isEmpty else {
-            viewModel.searchResultSites.removeAll()
-            applySearchSnapshot()
+            handleEmptySearch()
             return
         }
 
@@ -50,7 +49,7 @@ extension HistoryPanelWithGroups: UISearchBarDelegate {
             }
 
             self.applySearchSnapshot()
-            self.toggleEmptyState()
+            self.updateEmptyPanelState()
         }
     }
 
@@ -64,7 +63,13 @@ extension HistoryPanelWithGroups: UISearchBarDelegate {
 
     private func handleNoResults() {
         applySearchSnapshot()
-        toggleEmptyState()
+        updateEmptyPanelState()
+    }
+
+    private func handleEmptySearch() {
+        viewModel.searchResultSites.removeAll()
+        applySnapshot()
+        updateEmptyPanelState()
     }
 }
 

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups.swift
@@ -390,7 +390,7 @@ class HistoryPanelWithGroups: UIViewController, LibraryPanel, Loggable, Notifica
         snapshot.appendItems(viewModel.historyActionables, toSection: .additionalHistoryActions)
 
         diffableDatasource?.apply(snapshot, animatingDifferences: animatingDifferences, completion: nil)
-        self.updateEmptyPanelState()
+        updateEmptyPanelState()
     }
 
     // MARK: - Swipe Action helpers
@@ -537,6 +537,8 @@ extension HistoryPanelWithGroups: UITableViewDelegate {
     }
 
     private func handleASGroupItemTapped(asGroupItem: ASGroup<Site>) {
+        exitSearchState()
+
         let asGroupListViewModel = SearchGroupedItemsViewModel(asGroup: asGroupItem, presenter: .historyPanel)
         let asGroupListVC = SearchGroupedItemsViewController(viewModel: asGroupListViewModel, profile: profile)
         asGroupListVC.libraryPanelDelegate = libraryPanelDelegate

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups.swift
@@ -51,10 +51,7 @@ class HistoryPanelWithGroups: UIViewController, LibraryPanel, Loggable, Notifica
     private var hasRecentlyClosed: Bool { profile.recentlyClosedTabs.tabs.count > 0 }
 
     // UI
-    var overKeyboardContainer: BaseAlphaStackView = .build { _ in }
-    var bottomStackView: BaseAlphaStackView = .build { stackview in
-        stackview.isClearBackground = true
-    }
+    var bottomStackView: BaseAlphaStackView = .build { _ in }
 
     lazy var searchbar: UISearchBar = .build { searchbar in
         searchbar.searchTextField.placeholder = self.viewModel.searchHistoryPlaceholder
@@ -84,6 +81,14 @@ class HistoryPanelWithGroups: UIViewController, LibraryPanel, Loggable, Notifica
     }()
 
     lazy var emptyStateOverlayView: UIView = createEmptyStateOverlayView()
+    lazy var welcomeLabel: UILabel = .build { label in
+        label.text = self.viewModel.emptyStateText
+        label.textAlignment = .center
+        label.font = DynamicFontHelper.defaultHelper.DeviceFontLight
+        label.textColor = UIColor.theme.homePanel.welcomeScreenText
+        label.numberOfLines = 0
+        label.adjustsFontSizeToFitWidth = true
+    }
     var refreshControl: UIRefreshControl?
     var clearHistoryCell: OneLineTableViewCell?
 
@@ -156,7 +161,6 @@ class HistoryPanelWithGroups: UIViewController, LibraryPanel, Loggable, Notifica
 
             DispatchQueue.main.async {
                 self?.applySnapshot(animatingDifferences: animating)
-                self?.toggleEmptyState()
             }
         }
     }
@@ -386,6 +390,7 @@ class HistoryPanelWithGroups: UIViewController, LibraryPanel, Loggable, Notifica
         snapshot.appendItems(viewModel.historyActionables, toSection: .additionalHistoryActions)
 
         diffableDatasource?.apply(snapshot, animatingDifferences: animatingDifferences, completion: nil)
+        self.updateEmptyPanelState()
     }
 
     // MARK: - Swipe Action helpers
@@ -394,8 +399,6 @@ class HistoryPanelWithGroups: UIViewController, LibraryPanel, Loggable, Notifica
         guard let historyItem = diffableDatasource?.itemIdentifier(for: indexPath) else { return }
 
         viewModel.removeHistoryItems(item: historyItem, at: indexPath.section)
-
-        updateEmptyPanelState()
 
         if let historyActionableCell = clearHistoryCell {
             setTappableStateAndStyle(with: HistoryActionablesModel.activeActionables.first, on: historyActionableCell)
@@ -425,8 +428,9 @@ class HistoryPanelWithGroups: UIViewController, LibraryPanel, Loggable, Notifica
 
     // MARK: - Empty State helpers
 
-    private func updateEmptyPanelState() {
-        if viewModel.shouldShowEmptyState, emptyStateOverlayView.superview == nil {
+    func updateEmptyPanelState() {
+        if viewModel.shouldShowEmptyState(searchText: searchbar.text ?? "") {
+            welcomeLabel.text = viewModel.emptyStateText
             tableView.tableFooterView = emptyStateOverlayView
         } else {
             tableView.alwaysBounceVertical = true
@@ -449,14 +453,6 @@ class HistoryPanelWithGroups: UIViewController, LibraryPanel, Loggable, Notifica
             bgColor.widthAnchor.constraint(equalTo: overlayView.widthAnchor)
         ])
 
-        let welcomeLabel: UILabel = .build { label in
-            label.text = self.viewModel.emptyStateText
-            label.textAlignment = .center
-            label.font = DynamicFontHelper.defaultHelper.DeviceFontLight
-            label.textColor = UIColor.theme.homePanel.welcomeScreenText
-            label.numberOfLines = 0
-            label.adjustsFontSizeToFitWidth = true
-        }
         overlayView.addSubview(welcomeLabel)
 
         let welcomeLabelPriority = UILayoutPriority(100)
@@ -471,18 +467,10 @@ class HistoryPanelWithGroups: UIViewController, LibraryPanel, Loggable, Notifica
         return overlayView
     }
 
-    func toggleEmptyState() {
-        if emptyStateOverlayView.superview != nil {
-            emptyStateOverlayView.removeFromSuperview()
-        }
-        emptyStateOverlayView = createEmptyStateOverlayView()
-        updateEmptyPanelState()
-    }
-
     // MARK: - Themeable
 
     func applyTheme() {
-        toggleEmptyState()
+        updateEmptyPanelState()
 
         tableView.backgroundColor = UIColor.theme.homePanel.panelBackground
         searchbar.backgroundColor = UIColor.theme.textField.backgroundInOverlay

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -308,7 +308,7 @@ class LibraryViewController: UIViewController {
 
         } else if selectedPanel == .history {
             if panel.viewControllers.count > 1 {
-                if viewModel.currentPanelState == .history(state: .mainView) {
+                if viewModel.currentPanelState == .history(state: .mainView) || viewModel.currentPanelState == .history(state: .search) {
                     viewModel.currentPanelState = .history(state: .inFolder)
                 }
             } else if viewModel.currentPanelState != .history(state: .search) {


### PR DESCRIPTION
Issue #10613 &  #10611
handle empty search term to show regular history + refactor empty state footer


