### PR TITLE
Bugfix fx3510 [v100.1] Recently closed tab bug

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1978,7 +1978,7 @@ extension BrowserViewController: TabManagerDelegate {
 
     func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool) {
         if let url = tab.lastKnownUrl, !(InternalURL(url)?.isAboutURL ?? false), !tab.isPrivate {
-            profile.recentlyClosedTabs.addTab(url as URL, title: tab.lastTitle, faviconURL: tab.displayFavicon?.url)
+            profile.recentlyClosedTabs.addTab(url as URL, title: tab.lastTitle, faviconURL: tab.displayFavicon?.url, lastExecutedTime: tab.lastExecutedTime)
         }
         updateTabCountUsingTabManager(tabManager)
     }

--- a/Client/Frontend/Library/ClearHistoryHelper.swift
+++ b/Client/Frontend/Library/ClearHistoryHelper.swift
@@ -27,6 +27,7 @@ class ClearHistoryHelper {
 
                 self.profile.history.removeHistoryFromDate(date).uponQueue(.global(qos: .userInteractive)) { _ in
                     guard let completion = didComplete else { return }
+                    self.profile.recentlyClosedTabs.removeTabsFromDate(date)
                     completion(date)
                 }
             }

--- a/Storage/RecentlyClosedTabs.swift
+++ b/Storage/RecentlyClosedTabs.swift
@@ -25,14 +25,14 @@ open class ClosedTabsStore {
         self.prefs = prefs
     }
 
-    open func addTab(_ url: URL, title: String?, faviconURL: String?) {
-        let recentlyClosedTab = ClosedTab(url: url, title: title ?? "", faviconURL: faviconURL ?? "")
+    open func addTab(_ url: URL, title: String?, faviconURL: String?, lastExecutedTime: Timestamp?) {
+        let recentlyClosedTab = ClosedTab(url: url, title: title, faviconURL: faviconURL, lastExecutedTime: lastExecutedTime)
         tabs.insert(recentlyClosedTab, at: 0)
         if tabs.count > maxNumberOfStoredClosedTabs {
             tabs.removeLast()
         }
-        let archivedTabsArray = try? NSKeyedArchiver.archivedData(withRootObject: tabs, requiringSecureCoding: true)
-        prefs.setObject(archivedTabsArray, forKey: KeyedArchiverKeys.recentlyClosedTabs.rawValue)
+
+        saveTabs(tabs)
     }
 
     open func popFirstTab() -> ClosedTab? {
@@ -44,45 +44,54 @@ open class ClosedTabsStore {
         prefs.removeObjectForKey(KeyedArchiverKeys.recentlyClosedTabs.rawValue)
         tabs = []
     }
+
+    open func removeTabsFromDate(_ date: Date) {
+        let timestampToRemoveFrom = date.toTimestamp()
+        // If lastExecutedTime wasn't present on tab, we do not delete that tab since information isn't available
+        tabs = tabs.filter {
+            return $0.lastExecutedTime ?? UINT64_MAX < timestampToRemoveFrom
+        }
+
+        saveTabs(tabs)
+    }
+
+    private func saveTabs(_ tabs: [ClosedTab]) {
+        let archivedTabsArray = try? NSKeyedArchiver.archivedData(withRootObject: tabs, requiringSecureCoding: true)
+        prefs.setObject(archivedTabsArray, forKey: KeyedArchiverKeys.recentlyClosedTabs.rawValue)
+    }
 }
 
 open class ClosedTab: NSObject, NSCoding {
 
     enum CodingKeys: String {
-        case url, title, faviconURL
+        case url, title, faviconURL, lastExecutedTime
     }
 
     public let url: URL
     public let title: String?
     public let faviconURL: String?
+    public let lastExecutedTime: Timestamp?
 
-    var jsonDictionary: [String: Any] {
-        let title = (self.title ?? "")
-        let faviconURL = (self.faviconURL ?? "")
-        let json: [String: Any] = [CodingKeys.title.rawValue: title,
-                                   CodingKeys.url.rawValue: url,
-                                   CodingKeys.faviconURL.rawValue: faviconURL]
-        return json
-    }
-
-    init(url: URL, title: String?, faviconURL: String?) {
-        assert(Thread.isMainThread)
+    init(url: URL, title: String?, faviconURL: String?, lastExecutedTime: Timestamp?) {
         self.title = title
         self.url = url
         self.faviconURL = faviconURL
+        self.lastExecutedTime = lastExecutedTime
         super.init()
     }
 
     required convenience public init?(coder: NSCoder) {
         guard let url = coder.decodeObject(forKey: CodingKeys.url.rawValue) as? URL,
               let faviconURL = coder.decodeObject(forKey: CodingKeys.faviconURL.rawValue) as? String,
-              let title = coder.decodeObject(forKey: CodingKeys.title.rawValue) as? String
+              let title = coder.decodeObject(forKey: CodingKeys.title.rawValue) as? String,
+              let date = coder.decodeObject(forKey: CodingKeys.lastExecutedTime.rawValue) as? Timestamp
         else { return nil }
 
         self.init(
             url: url,
             title: title,
-            faviconURL: faviconURL
+            faviconURL: faviconURL,
+            lastExecutedTime: date
         )
     }
 
@@ -90,5 +99,6 @@ open class ClosedTab: NSObject, NSCoding {
         coder.encode(url, forKey: CodingKeys.url.rawValue)
         coder.encode(faviconURL, forKey: CodingKeys.faviconURL.rawValue)
         coder.encode(title, forKey: CodingKeys.title.rawValue)
+        coder.encode(lastExecutedTime, forKey: CodingKeys.lastExecutedTime.rawValue)
     }
 }

--- a/Storage/RecentlyClosedTabs.swift
+++ b/Storage/RecentlyClosedTabs.swift
@@ -48,9 +48,7 @@ open class ClosedTabsStore {
     open func removeTabsFromDate(_ date: Date) {
         let timestampToRemoveFrom = date.toTimestamp()
         // If lastExecutedTime wasn't present on tab, we do not delete that tab since information isn't available
-        tabs = tabs.filter {
-            return $0.lastExecutedTime ?? UINT64_MAX < timestampToRemoveFrom
-        }
+        tabs = tabs.filter { $0.lastExecutedTime ?? 0 < timestampToRemoveFrom }
 
         saveTabs(tabs)
     }


### PR DESCRIPTION
# Issue #9624 
- Remove recently closed tabs when clearing history if they are in that range
- Remove history cell that isn't used anymore (it's now in bottom bar)
- Refresh recently closed cell when we're clearing history (maybe there's no more recently closed tabs in there)
- Add test cases to cover new function to remove tabs from a certain date
- Remove jsonDictionary in ClosedTab class that wasn't used

Note: Removing `Everything` from history was already properly clearing the Recently Closed tabs store. It was just the `Last hour`, `Today` and `Today & Yesterday` option that needed adjustments.