### PR TITLE
Add fx4130 [v101] Filter duplication on short domain (without eTLD) for top sites 

### DIFF
--- a/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
@@ -193,8 +193,10 @@ private extension Array where Element == Site {
     mutating func removeDuplicates() {
         var alreadyThere = Set<Site>()
         let uniqueSites = compactMap { (site) -> Site? in
-            let shouldAddSite = alreadyThere.first(where: { $0.url.asURL?.domainURL == site.url.asURL?.domainURL } ) == nil
-            guard shouldAddSite else { return nil }
+            let siteDomain = site.url.asURL?.shortDomain
+            let shouldAddSite = alreadyThere.first(where: { $0.url.asURL?.shortDomain == siteDomain } ) == nil
+            // If shouldAddSite or site domain was not found, then insert the site
+            guard shouldAddSite || siteDomain == nil else { return nil }
             alreadyThere.insert(site)
             return site
         }
@@ -204,7 +206,8 @@ private extension Array where Element == Site {
 
     // We don't add a sponsored tile if that domain site is already pinned by the user.
     private func siteIsAlreadyPresent(site: Site) -> Bool {
-        return filter { ($0.url.asURL?.domainURL == site.url.asURL?.domainURL) && (($0 as? PinnedSite) != nil) }.count > 0
+        let siteDomain = site.url.asURL?.shortDomain
+        return filter { ($0.url.asURL?.shortDomain == siteDomain) && (($0 as? PinnedSite) != nil) }.count > 0
     }
 }
 

--- a/ClientTests/FxHomeTopSitesManagerTests.swift
+++ b/ClientTests/FxHomeTopSitesManagerTests.swift
@@ -320,7 +320,7 @@ class FxHomeTopSitesManagerTests: XCTestCase, FeatureFlagsProtocol {
         let manager = createManager(addPinnedSiteCount: 1, siteCount: 3, duplicatePinnedSiteURL: true)
 
         testLoadData(manager: manager, numberOfTilesPerRow: 4) {
-            XCTAssertEqual(manager.siteCount, 4)
+            XCTAssertEqual(manager.siteCount, 4, "Should have 3 sites and 1 pinned")
             XCTAssertTrue(manager.getSite(index: 0)!.isGoogleURL)
 
             let tile1 = manager.getSite(index: 1)
@@ -399,9 +399,9 @@ extension ContileProviderMock {
     }
 
     static let pinnedTitle = "A pinned title %@"
-    static let pinnedURL = "www.a-pinned-url-%@.com"
+    static let pinnedURL = "https://www.apinnedurl%@.com"
     static let title = "A title %@"
-    static let url = "www.a-url-%@.com"
+    static let url = "https://www.aurl%@.com"
 
     static var pinnedDuplicateTile: Contile {
         return Contile(id: 1,

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -272,6 +272,12 @@ extension URL {
         return host.flatMap { publicSuffixFromHost($0, withAdditionalParts: 0) }
     }
 
+    /// Creates a short domain version of a link's url
+    /// e.g. url: http://www.foosite.com  =>  "foosite"
+    public var shortDomain: String? {
+        return host.flatMap { shortDomain($0, etld: publicSuffix ?? "") }
+    }
+
     public func isWebPage(includeDataURIs: Bool = true) -> Bool {
         let schemes = includeDataURIs ? ["http", "https", "data"] : ["http", "https"]
         return scheme.map { schemes.contains($0) } ?? false
@@ -499,9 +505,29 @@ public struct InternalURL {
     }
 }
 
-//MARK: Private Helpers
+// MARK: Private Helpers
 private extension URL {
-    func publicSuffixFromHost( _ host: String, withAdditionalParts additionalPartCount: Int) -> String? {
+
+    /// Creates a short domain version of a link's url
+    /// e.g. url: http://www.foosite.com  =>  "foosite"
+    /// - Parameters:
+    ///   - host: hostname
+    ///   - etld: top level domain to remove from host
+    /// - Returns: The short version of the domain
+    func shortDomain(_ host: String, etld: String) -> String? {
+        // Check edge case where the host is either a single or double '.'.
+        if host.isEmpty || NSString(string: host).lastPathComponent == "." {
+            return ""
+        }
+
+        // Clean up the url by removing www.
+        var hostname = host.replacingOccurrences(of: "www.", with: "")
+        hostname = hostname.replacingOccurrences(of: ".\(etld)", with: "")
+
+        return hostname
+    }
+
+    func publicSuffixFromHost(_ host: String, withAdditionalParts additionalPartCount: Int) -> String? {
         if host.isEmpty {
             return nil
         }


### PR DESCRIPTION
# Issue [fx4130](https://mozilla-hub.atlassian.net/browse/FXIOS-4130)
Based on [desktop code](https://searchfox.org/mozilla-central/source/browser/components/newtab/lib/ShortURL.jsm#48-81)
