### PR TITLE
Force updates the FML when it is out of date

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -8300,6 +8300,7 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/nimbus.fml.yaml",
+				"$(SRCROOT)/bin/nimbus-fml.sh",
 			);
 			name = "Nimbus Feature Manifest Generator Script";
 			outputFileListPaths = (

--- a/bin/nimbus-fml.sh
+++ b/bin/nimbus-fml.sh
@@ -61,6 +61,7 @@ MANIFEST_PATH=
 OUTPUT_DIR="${SOURCE_ROOT}/${PROJECT}/Generated"
 NAMESPACE=
 AS_VERSION=v93.0.4
+AS_DOWNLOAD_URL="https://github.com/mozilla/application-services/releases/download/$AS_VERSION"
 FRESHEN_FML=
 
 while (( "$#" )); do
@@ -129,15 +130,25 @@ fi
 ## We create the nimbus-fml directory, which is gitignored, we use -p to make sure this doesn't fail if it already exists
 FML_DIR="$SOURCE_ROOT/build/nimbus-tools"
 
+if [[ -f $FML_DIR/nimbus-fml.sha256 ]]; then
+    echo "Checking if we need to redownload the FML"
+    NEW_CHECKSUM=$(curl -L $AS_DOWNLOAD_URL/nimbus-fml.sha256)
+    OLD_CHECKSUM=$(cat $FML_DIR/nimbus-fml.sha256)
+    if [ ! "$OLD_CHECKSUM" == "$NEW_CHECKSUM" ]; then
+        echo "The checksums don't match, redownloading the new FML"
+        FRESHEN_FML="true"
+    fi
+fi
+
 if [ ! -z $FRESHEN_FML ]; then
     rm -Rf "$FML_DIR"
 fi
 mkdir -p "$FML_DIR"
 if [[ ! -f "$FML_DIR/nimbus-fml.zip" ]] ; then
     # We now download the nimbus-fml from the github release
-    curl -L https://github.com/mozilla/application-services/releases/download/${AS_VERSION}/nimbus-fml.zip --output "$FML_DIR/nimbus-fml.zip"
+    curl -L $AS_DOWNLOAD_URL/nimbus-fml.zip --output "$FML_DIR/nimbus-fml.zip"
     # We also download the checksum
-    curl -L https://github.com/mozilla/application-services/releases/download/${AS_VERSION}/nimbus-fml.sha256 --output "$FML_DIR/nimbus-fml.sha256"
+    curl -L $AS_DOWNLOAD_URL/nimbus-fml.sha256 --output "$FML_DIR/nimbus-fml.sha256"
     pushd "${FML_DIR}"
     shasum --check nimbus-fml.sha256
     popd


### PR DESCRIPTION
FML mismatches caused local build failures for iOS developers, this patch aims to make sure that if a developer has an outdated FML cached, we download a new one

- The addition of `"$(SRCROOT)/bin/nimbus-fml.sh"` as an input file makes sure the job re-runs every time the FML script is updated (including when the version is bumped)
- The additional changes in the script compare the checksum on the a-s release with the checksum of the cached FML. If they mismatch we delete the old FML and download a new one

There might be a smarter way of doing this, so happy to take suggestions!

cc @electricRGB @jhugman 
