### PR TITLE
Bugfix #10603 [v100.1] The scroll in the History list doesn't behave correctly

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -968,11 +968,10 @@ class BrowserViewController: UIViewController {
             libraryViewController.selectedPanel = panel
         }
 
-        if panel == .history {
-            let panelIndex = libraryViewController.viewModel.panelDescriptors[panel?.rawValue ?? 1]
-            if let vcPanel = panelIndex.viewController as? HistoryPanelWithGroups {
-                vcPanel.viewModel.resetHistory()
-            }
+        // Reset history panel pagination to get latest history visit
+        if let historyPanel = libraryViewController.viewModel.panelDescriptors.first(where: {$0.panelType == .history}),
+           let vcPanel = historyPanel.viewController as? HistoryPanelWithGroups {
+            vcPanel.viewModel.shouldResetHistory = true //resetHistory()
         }
 
         let controller: DismissableNavigationViewController

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -959,13 +959,20 @@ class BrowserViewController: UIViewController {
             presentedViewController.dismiss(animated: true, completion: nil)
         }
 
-        // We should not set libraryViewController to nil because the library panel losses the currentStat
+        // We should not set libraryViewController to nil because the library panel losses the currentState
         let libraryViewController = self.libraryViewController ?? LibraryViewController(profile: profile, tabManager: tabManager)
         libraryViewController.delegate = self
         self.libraryViewController = libraryViewController
 
         if panel != nil {
             libraryViewController.selectedPanel = panel
+        }
+
+        if panel == .history {
+            let panelIndex = libraryViewController.viewModel.panelDescriptors[panel?.rawValue ?? 1]
+            if let vcPanel = panelIndex.viewController as? HistoryPanelWithGroups {
+                vcPanel.viewModel.resetHistory()
+            }
         }
 
         let controller: DismissableNavigationViewController

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
@@ -45,7 +45,7 @@ class HistoryPanelViewModel: Loggable, FeatureFlagsProtocol {
     // MARK: - Properties
 
     private let profile: Profile
-    private let queryFetchLimit = 10
+    private let queryFetchLimit = 100
     private var currentFetchOffset = 0
     // Search offset and Limit
     private let searchQueryFetchLimit = 50
@@ -122,20 +122,6 @@ class HistoryPanelViewModel: Loggable, FeatureFlagsProtocol {
         }
     }
 
-    func resetHistory() {
-        currentFetchOffset = 0
-        searchTermGroups.removeAll()
-        groupedSites = DateGroupedTableData<Site>()
-        shouldResetHistory = false
-    }
-
-    private func buildVisibleSections() {
-        self.visibleSections = Sections.allCases.filter { section in
-            self.groupedSites.numberOfItemsForSection(section.rawValue - 1) > 0
-            || !self.groupsForSection(section: section).isEmpty
-        }
-    }
-
     // Add completion to reload on finish
     func performSearch(term: String, completion: @escaping (Bool) -> Void) {
         isFetchInProgress = true
@@ -174,6 +160,20 @@ class HistoryPanelViewModel: Loggable, FeatureFlagsProtocol {
             }
 
             return deferMaybe(result)
+        }
+    }
+
+    private func resetHistory() {
+        currentFetchOffset = 0
+        searchTermGroups.removeAll()
+        groupedSites = DateGroupedTableData<Site>()
+        shouldResetHistory = false
+    }
+
+    private func buildVisibleSections() {
+        self.visibleSections = Sections.allCases.filter { section in
+            self.groupedSites.numberOfItemsForSection(section.rawValue - 1) > 0
+            || !self.groupsForSection(section: section).isEmpty
         }
     }
 

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
@@ -45,7 +45,7 @@ class HistoryPanelViewModel: Loggable, FeatureFlagsProtocol {
     // MARK: - Properties
 
     private let profile: Profile
-    private let queryFetchLimit = 100
+    private let queryFetchLimit = 10
     private var currentFetchOffset = 0
     // Search offset and Limit
     private let searchQueryFetchLimit = 50
@@ -99,23 +99,34 @@ class HistoryPanelViewModel: Loggable, FeatureFlagsProtocol {
         }
 
         fetchData().uponQueue(.global(qos: .userInteractive)) { result in
-            if let sites = result.successValue {
-                let fetchedSites = sites.asArray()
-
-                self.populateHistorySites(fetchedSites: fetchedSites)
-
-                if self.featureFlags.isFeatureActiveForBuild(.historyGroups) {
-                    self.populateASGroups()
-                }
-
-                self.visibleSections = Sections.allCases.filter { section in
-                    self.groupedSites.numberOfItemsForSection(section.rawValue - 1) > 0
-                    || !self.groupsForSection(section: section).isEmpty
-                }
-                completion(true)
-            } else {
+            guard let fetchedSites = result.successValue?.asArray(), !fetchedSites.isEmpty else {
                 completion(false)
+                return
             }
+
+            self.currentFetchOffset += self.queryFetchLimit
+            if self.featureFlags.isFeatureActiveForBuild(.historyGroups) {
+                self.populateASGroups(fetchedSites: fetchedSites) {
+                    self.buildVisibleSections()
+                    completion(true)
+                }
+            } else {
+                self.populateHistorySites(fetchedSites: fetchedSites)
+                completion(true)
+            }
+        }
+    }
+
+    func resetHistory() {
+        currentFetchOffset = 0
+        searchTermGroups.removeAll()
+        groupedSites = DateGroupedTableData<Site>()
+    }
+
+    private func buildVisibleSections() {
+        self.visibleSections = Sections.allCases.filter { section in
+            self.groupedSites.numberOfItemsForSection(section.rawValue - 1) > 0
+            || !self.groupsForSection(section: section).isEmpty
         }
     }
 
@@ -177,21 +188,18 @@ class HistoryPanelViewModel: Loggable, FeatureFlagsProtocol {
     }
 
     /// Provide groups for curruently fetched history items.
-    private func populateASGroups() {
-        SearchTermGroupsManager.getSiteGroups(with: self.profile, from: self.groupedSites.allItems(), using: .orderedDescending) { group, filteredItems in
-            guard var searchTermGrouping = group else { return }
-
-            // Remove overlapping history & STG items
-            searchTermGrouping.forEach { group in
-                group.groupedItems.forEach { self.groupedSites.remove($0) }
-            }
-
-            // Remove overlapping STGs. This happens when the queryFetchLimit is too low - then STGManager makes duplicate groups.
-            self.searchTermGroups.forEach { group in
-                searchTermGrouping = searchTermGrouping.filter { $0.displayTitle != group.displayTitle }
-            }
+    private func populateASGroups(fetchedSites: [Site], completion: @escaping () -> Void) {
+        SearchTermGroupsManager.getSiteGroups(with: self.profile, from: fetchedSites, using: .orderedDescending) { group, filteredItems in
+            guard let searchTermGrouping = group else { return }
 
             self.searchTermGroups.append(contentsOf: searchTermGrouping)
+
+            filteredItems.forEach { site in
+                if let latestVisit = site.latestVisit {
+                    self.groupedSites.add(site, timestamp: TimeInterval.fromMicrosecondTimestamp(latestVisit.date))
+                }
+            }
+            completion()
         }
     }
 

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
@@ -59,6 +59,7 @@ class HistoryPanelViewModel: Loggable, FeatureFlagsProtocol {
     var groupedSites = DateGroupedTableData<Site>()
     var isFetchInProgress = false
     var isSearchInProgress = false
+    var shouldResetHistory = false
 
     var searchResultSites = [Site]()
     var searchHistoryPlaceholder: String = .LibraryPanel.History.SearchHistoryPlaceholder
@@ -98,6 +99,10 @@ class HistoryPanelViewModel: Loggable, FeatureFlagsProtocol {
             return
         }
 
+        if shouldResetHistory {
+            resetHistory()
+        }
+
         fetchData().uponQueue(.global(qos: .userInteractive)) { result in
             guard let fetchedSites = result.successValue?.asArray(), !fetchedSites.isEmpty else {
                 completion(false)
@@ -121,6 +126,7 @@ class HistoryPanelViewModel: Loggable, FeatureFlagsProtocol {
         currentFetchOffset = 0
         searchTermGroups.removeAll()
         groupedSites = DateGroupedTableData<Site>()
+        shouldResetHistory = false
     }
 
     private func buildVisibleSections() {

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelWithGroups.swift
@@ -258,6 +258,10 @@ class HistoryPanelWithGroups: UIViewController, LibraryPanel, Loggable, Notifica
                 fetchDataAndUpdateLayout(animating: true)
             }
         case .OpenClearRecentHistory:
+            if viewModel.isSearchInProgress {
+                exitSearchState()
+            }
+
             showClearRecentHistory()
         default:
             // no need to do anything at all

--- a/Client/Frontend/Library/LibraryPanels.swift
+++ b/Client/Frontend/Library/LibraryPanels.swift
@@ -57,8 +57,9 @@ class LibraryPanelDescriptor {
     let activeImageName: String
     let accessibilityLabel: String
     let accessibilityIdentifier: String
+    let panelType: LibraryPanelType
 
-    init(makeViewController: @escaping ((_ profile: Profile, _ tabManager: TabManager) -> UIViewController), profile: Profile, tabManager: TabManager, imageName: String, accessibilityLabel: String, accessibilityIdentifier: String) {
+    init(makeViewController: @escaping ((_ profile: Profile, _ tabManager: TabManager) -> UIViewController), profile: Profile, tabManager: TabManager, imageName: String, accessibilityLabel: String, accessibilityIdentifier: String, panelType: LibraryPanelType) {
         self.makeViewController = makeViewController
         self.profile = profile
         self.tabManager = tabManager
@@ -66,6 +67,7 @@ class LibraryPanelDescriptor {
         self.activeImageName = self.imageName + "-active"
         self.accessibilityLabel = accessibilityLabel
         self.accessibilityIdentifier = accessibilityIdentifier
+        self.panelType = panelType
     }
 
     func setup() {
@@ -94,7 +96,8 @@ class LibraryPanels: FeatureFlagsProtocol {
             tabManager: tabManager,
             imageName: "Bookmarks",
             accessibilityLabel: .LibraryPanelBookmarksAccessibilityLabel,
-            accessibilityIdentifier: "LibraryPanels.Bookmarks"),
+            accessibilityIdentifier: "LibraryPanels.Bookmarks",
+            panelType: .bookmarks),
 
         LibraryPanelDescriptor(
             makeViewController: { profile, tabManager in
@@ -111,7 +114,8 @@ class LibraryPanels: FeatureFlagsProtocol {
             tabManager: tabManager,
             imageName: "History",
             accessibilityLabel: .LibraryPanelHistoryAccessibilityLabel,
-            accessibilityIdentifier: "LibraryPanels.History"),
+            accessibilityIdentifier: "LibraryPanels.History",
+            panelType: .history),
 
         LibraryPanelDescriptor(
             makeViewController: { profile, tabManager in
@@ -121,7 +125,8 @@ class LibraryPanels: FeatureFlagsProtocol {
             tabManager: tabManager,
             imageName: "Downloads",
             accessibilityLabel: .LibraryPanelDownloadsAccessibilityLabel,
-            accessibilityIdentifier: "LibraryPanels.Downloads"),
+            accessibilityIdentifier: "LibraryPanels.Downloads",
+            panelType: .downloads),
 
         LibraryPanelDescriptor(
             makeViewController: { profile, tabManager in
@@ -131,6 +136,7 @@ class LibraryPanels: FeatureFlagsProtocol {
             tabManager: tabManager,
             imageName: "ReadingList",
             accessibilityLabel: .LibraryPanelReadingListAccessibilityLabel,
-            accessibilityIdentifier: "LibraryPanels.ReadingList")
+            accessibilityIdentifier: "LibraryPanels.ReadingList",
+            panelType: .readingList)
     ]
 }

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController+ToolbarActions.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController+ToolbarActions.swift
@@ -96,6 +96,9 @@ extension LibraryViewController {
     }
 
     @objc func bottomDeleteButtonAction() {
+        // Leave search mode when clearing history
+        viewModel.currentPanelState = .history(state: .mainView)
+
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .deleteHistory)
         NotificationCenter.default.post(name: .OpenClearRecentHistory, object: nil)
     }


### PR DESCRIPTION
 Issue #10603
 
- Update fetch logic and use the result from SearchTermGroupsManager.getSiteGroups to populate history with groups and individual sites.
- Bring back pagination to get more history results adding the option to reset when LibraryViewController is open to get latest results