### PR TITLE
Refactor #10614 [v101]: Removing most DefaultBrowserCard fragments

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -25,8 +25,8 @@ messaging:
       type: string
       description: What should be displayed when a control message is selected.
       enum:
-        - show-next-message
         - show-none
+        - show-next-message
     styles:
       type: json
       description: "A map of styles to configure message appearance.\n"

--- a/Client/Frontend/Browser/Tabs/TabMoreMenuHeader.swift
+++ b/Client/Frontend/Browser/Tabs/TabMoreMenuHeader.swift
@@ -21,17 +21,17 @@ class TabMoreMenuHeader: UIView {
         title.numberOfLines = 2
         title.lineBreakMode = .byTruncatingTail
         title.font = UIFont.systemFont(ofSize: 17, weight: .regular)
-        title.textColor = UIColor.theme.defaultBrowserCard.textColor
+        title.textColor = UIColor.theme.homeTabBanner.textColor
         return title
     }()
 
     lazy var descriptionLabel: UILabel = {
         let descriptionText = UILabel()
-        descriptionText.text = String.DefaultBrowserCardDescription
+        descriptionText.text = String.FirefoxHomepage.HomeTabBanner.EvergreenMessage.DefaultBrowserDescription
         descriptionText.numberOfLines = 0
         descriptionText.lineBreakMode = .byWordWrapping
         descriptionText.font = UIFont.systemFont(ofSize: 14, weight: .regular)
-        descriptionText.textColor = UIColor.theme.defaultBrowserCard.textColor
+        descriptionText.textColor = UIColor.theme.homeTabBanner.textColor
         return descriptionText
     }()
 

--- a/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -250,7 +250,7 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
 
     @objc private func goToSettings() {
         viewModel.goToSettings?()
-        UserDefaults.standard.set(true, forKey: "DidDismissDefaultBrowserCard") // Don't show default browser card if this button is clicked
+        UserDefaults.standard.set(true, forKey: PrefsKeys.DidDismissDefaultBrowserMessage) // Don't show default browser card if this button is clicked
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .goToSettingsDefaultBrowserOnboarding)
     }
 

--- a/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewModel.swift
+++ b/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewModel.swift
@@ -54,14 +54,14 @@ class DefaultBrowserOnboardingViewModel {
 
     private func setupModel() {
         model = DefaultBrowserOnboardingModel(
-            titleText: String.DefaultBrowserCardTitle,
+            titleText: String.FirefoxHomepage.HomeTabBanner.EvergreenMessage.DefaultBrowserTitle,
             descriptionText: descriptionText,
             imageText: String.DefaultBrowserOnboardingScreenshot
         )
     }
 
     private var descriptionText: [String] {
-        [String.DefaultBrowserCardDescription,
+        [String.FirefoxHomepage.HomeTabBanner.EvergreenMessage.DefaultBrowserDescription,
          String.DefaultBrowserOnboardingDescriptionStep1,
          String.DefaultBrowserOnboardingDescriptionStep2,
          String.DefaultBrowserOnboardingDescriptionStep3]

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -245,7 +245,7 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, GleanPlu
 
     private var shouldDisplayHomeTabBanner: Bool {
         let message = messagingManager.getNextMessage(for: .newTabCard)
-        if #available(iOS 14.0, *), message != nil || !UserDefaults.standard.bool(forKey: PrefsKeys.DidDismissDefaultBrowserCard) {
+        if #available(iOS 14.0, *), message != nil || !UserDefaults.standard.bool(forKey: PrefsKeys.DidDismissDefaultBrowserMessage) {
             return true
         } else {
             return false

--- a/Client/Frontend/Home/HomeTabBanner.swift
+++ b/Client/Frontend/Home/HomeTabBanner.swift
@@ -14,6 +14,7 @@ import UIKit
 class HomeTabBanner: UIView, GleanPlumbMessageManagable {
 
     typealias a11y = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner
+    typealias BannerCopy = String.FirefoxHomepage.HomeTabBanner.EvergreenMessage
 
     struct UX {
         static let cardSize = CGSize(width: 360, height: 224)
@@ -31,7 +32,7 @@ class HomeTabBanner: UIView, GleanPlumbMessageManagable {
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
         label.font = UIFont.systemFont(ofSize: 20, weight: .bold)
-        label.textColor = UIColor.theme.defaultBrowserCard.textColor
+        label.textColor = UIColor.theme.homeTabBanner.textColor
     }
 
     private lazy var descriptionText: UILabel = .build { label in
@@ -39,7 +40,7 @@ class HomeTabBanner: UIView, GleanPlumbMessageManagable {
         label.lineBreakMode = .byWordWrapping
         label.adjustsFontSizeToFitWidth = true
         label.font = UIFont.systemFont(ofSize: 15, weight: .regular)
-        label.textColor = UIColor.theme.defaultBrowserCard.textColor
+        label.textColor = UIColor.theme.homeTabBanner.textColor
     }
 
     private lazy var ctaButton: UIButton = .build { [weak self] button in
@@ -59,7 +60,7 @@ class HomeTabBanner: UIView, GleanPlumbMessageManagable {
 
     private lazy var dismissButton: UIButton = .build { [weak self] button in
         button.setImage(UIImage(named: ImageIdentifiers.xMark)?.withRenderingMode(.alwaysTemplate), for: .normal)
-        button.imageView?.tintColor = UIColor.theme.defaultBrowserCard.textColor
+        button.imageView?.tintColor = UIColor.theme.homeTabBanner.textColor
         button.addTarget(self, action: #selector(self?.dismissCard), for: .touchUpInside)
     }
 
@@ -81,7 +82,7 @@ class HomeTabBanner: UIView, GleanPlumbMessageManagable {
     }
 
     private lazy var cardView: UIView = .build { view in
-        view.backgroundColor = UIColor.theme.defaultBrowserCard.backgroundColor
+        view.backgroundColor = UIColor.theme.homeTabBanner.backgroundColor
         view.layer.cornerRadius = 12
         view.layer.masksToBounds = true
     }
@@ -164,9 +165,9 @@ class HomeTabBanner: UIView, GleanPlumbMessageManagable {
     private func applyMessage() {
         /// If no messages exist, continue using our evergreen message.
         guard let message = message else {
-            bannerTitle.text = String.DefaultBrowserCardTitle
-            descriptionText.text = String.DefaultBrowserCardDescription
-            ctaButton.setTitle(String.DefaultBrowserCardButton, for: .normal)
+            bannerTitle.text = BannerCopy.DefaultBrowserTitle
+            descriptionText.text = BannerCopy.DefaultBrowserDescription
+            ctaButton.setTitle(BannerCopy.DefaultBrowserButton, for: .normal)
 
             TelemetryWrapper.recordEvent(category: .information, method: .view, object: .homeTabBannerEvergreen)
             return
@@ -197,7 +198,7 @@ class HomeTabBanner: UIView, GleanPlumbMessageManagable {
 
         guard let message = message else {
             /// If we're here, that means we've shown the evergreen. Handle it as we always did.
-            UserDefaults.standard.set(true, forKey: PrefsKeys.DidDismissDefaultBrowserCard)
+            UserDefaults.standard.set(true, forKey: PrefsKeys.DidDismissDefaultBrowserMessage)
             TelemetryWrapper.gleanRecordEvent(category: .action, method: .tap, object: .dismissDefaultBrowserCard)
 
             return
@@ -223,10 +224,10 @@ class HomeTabBanner: UIView, GleanPlumbMessageManagable {
     }
 
     func applyTheme() {
-        cardView.backgroundColor = UIColor.theme.defaultBrowserCard.backgroundColor
-        bannerTitle.textColor = UIColor.theme.defaultBrowserCard.textColor
-        descriptionText.textColor = UIColor.theme.defaultBrowserCard.textColor
-        dismissButton.imageView?.tintColor = UIColor.theme.defaultBrowserCard.textColor
+        cardView.backgroundColor = UIColor.theme.homeTabBanner.backgroundColor
+        bannerTitle.textColor = UIColor.theme.homeTabBanner.textColor
+        descriptionText.textColor = UIColor.theme.homeTabBanner.textColor
+        dismissButton.imageView?.tintColor = UIColor.theme.homeTabBanner.textColor
         containerView.backgroundColor = .clear
         backgroundColor = .clear
     }

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -148,7 +148,8 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagsP
 
         if #available(iOS 14.0, *) {
             settings += [
-                SettingSection(footerTitle: NSAttributedString(string: String.DefaultBrowserCardDescription), children: [DefaultBrowserSetting()])
+                SettingSection(footerTitle: NSAttributedString(string: String.FirefoxHomepage.HomeTabBanner.EvergreenMessage.DefaultBrowserDescription),
+                               children: [DefaultBrowserSetting()])
             ]
         }
 

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -148,6 +148,14 @@ extension String {
             public static let ButtonTitle = MZLocalizedString("FirefoxHome.CustomizeHomeButton.Title", value: "Customize Homepage", comment: "A button at bottom of the Firefox homepage that, when clicked, takes users straight to the settings options, where they can customize the Firefox Home page", lastUpdated: .v39)
         }
 
+        public struct HomeTabBanner {
+            public struct EvergreenMessage {
+                public static let DefaultBrowserTitle = MZLocalizedString("DefaultBrowserCard.Title", tableName: "Default Browser", value: "Switch Your Default Browser", comment: "Title for small card shown that allows user to switch their default browser to Firefox.", lastUpdated: .unknown)
+                public static let DefaultBrowserDescription = MZLocalizedString("DefaultBrowserCard.Description", tableName: "Default Browser", value: "Set links from websites, emails, and Messages to open automatically in Firefox.", comment: "Description for small card shown that allows user to switch their default browser to Firefox.", lastUpdated: .unknown)
+                public static let DefaultBrowserButton = MZLocalizedString("DefaultBrowserCard.Button.v2", tableName: "Default Browser", value: "Learn How", comment: "Button string to learn how to set your default browser.", lastUpdated: .unknown)
+            }
+        }
+
         public struct JumpBackIn {
             public static let GroupSiteCount = MZLocalizedString("ActivityStream.JumpBackIn.TabGroup.SiteCount", value: "Tabs: %d", comment: "On the Firefox homepage in the Jump Back In section, if a Tab group item - a collection of grouped tabs from a related search - exists underneath the search term for the tab group, there will be a subtitle with a number for how many tabs are in that group. The placeholder is for a number. It will read 'Tabs: 5' or similar.", lastUpdated: .v39)
             public static let GroupTitle = MZLocalizedString("ActivityStream.JumpBackIn.TabGroup.Title", value: "Your search for \"%@\"", comment: "On the Firefox homepage in the Jump Back In section, if a Tab group item - a collection of grouped tabs from a related search - exists, the Tab Group item title will be 'Your search for \"video games\"'. The %@ sign is a placeholder for the actual search the user did.", lastUpdated: .v39)
@@ -1391,9 +1399,6 @@ extension String {
 
 // MARK: - Default Browser
 extension String {
-    public static let DefaultBrowserCardTitle = MZLocalizedString("DefaultBrowserCard.Title", tableName: "Default Browser", value: "Switch Your Default Browser", comment: "Title for small card shown that allows user to switch their default browser to Firefox.", lastUpdated: .unknown)
-    public static let DefaultBrowserCardDescription = MZLocalizedString("DefaultBrowserCard.Description", tableName: "Default Browser", value: "Set links from websites, emails, and Messages to open automatically in Firefox.", comment: "Description for small card shown that allows user to switch their default browser to Firefox.", lastUpdated: .unknown)
-    public static let DefaultBrowserCardButton = MZLocalizedString("DefaultBrowserCard.Button.v2", tableName: "Default Browser", value: "Learn How", comment: "Button string to learn how to set your default browser.", lastUpdated: .unknown)
     public static let DefaultBrowserMenuItem = MZLocalizedString("Settings.DefaultBrowserMenuItem", tableName: "Default Browser", value: "Set as Default Browser", comment: "Menu option for setting Firefox as default browser.", lastUpdated: .unknown)
     public static let DefaultBrowserOnboardingScreenshot = MZLocalizedString("DefaultBrowserOnboarding.Screenshot", tableName: "Default Browser", value: "Default Browser App", comment: "Text for the screenshot of the iOS system settings page for Firefox.", lastUpdated: .unknown)
     public static let DefaultBrowserOnboardingDescriptionStep1 = MZLocalizedString("DefaultBrowserOnboarding.Description1", tableName: "Default Browser", value: "1. Go to Settings", comment: "Description for default browser onboarding card.", lastUpdated: .unknown)

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
@@ -153,7 +153,7 @@ fileprivate class DarkGeneralColor: GeneralColor {
     override var switchToggle: UIColor { return UIColor.Photon.Grey40 }
 }
 
-class DarkDefaultBrowserCardColor: DefaultBrowserCardColor {
+class DarkHomeTabBannerColor: HomeTabBannerColor {
     override var backgroundColor: UIColor { return UIColor.Photon.Grey60 }
     override var textColor: UIColor { return UIColor.white }
     override var closeButtonBackground: UIColor { return UIColor.Photon.Grey80 }
@@ -182,7 +182,7 @@ class DarkTheme: NormalTheme {
     override var snackbar: SnackBarColor { return DarkSnackBarColor() }
     override var general: GeneralColor { return DarkGeneralColor() }
     override var actionMenu: ActionMenuColor { return DarkActionMenuColor() }
-    override var defaultBrowserCard: DefaultBrowserCardColor { return DarkDefaultBrowserCardColor() }
+    override var homeTabBanner: HomeTabBannerColor { return DarkHomeTabBannerColor() }
     override var onboarding: OnboardingColor { return DarkOnboardingColor() }
     override var remotePanel: RemoteTabTrayColor { return DarkRemoteTabTrayColor() }
 }

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
@@ -225,7 +225,7 @@ class GeneralColor {
     var switchToggle: UIColor { return UIColor.Photon.Grey90A40 }
 }
 
-class DefaultBrowserCardColor {
+class HomeTabBannerColor {
     var backgroundColor: UIColor { return UIColor.Photon.Grey30 }
     var textColor: UIColor { return UIColor.black }
     var closeButtonBackground: UIColor { return UIColor.Photon.Grey20 }
@@ -256,7 +256,7 @@ protocol LegacyTheme {
     var general: GeneralColor { get }
     var actionMenu: ActionMenuColor { get }
     var switchToggleTheme: GeneralColor { get }
-    var defaultBrowserCard: DefaultBrowserCardColor { get }
+    var homeTabBanner: HomeTabBannerColor { get }
     var onboarding: OnboardingColor { get }
     var remotePanel: RemoteTabTrayColor { get }
 }
@@ -277,7 +277,7 @@ class NormalTheme: LegacyTheme {
     var general: GeneralColor { return GeneralColor() }
     var actionMenu: ActionMenuColor { return ActionMenuColor() }
     var switchToggleTheme: GeneralColor { return GeneralColor() }
-    var defaultBrowserCard: DefaultBrowserCardColor { return DefaultBrowserCardColor() }
+    var homeTabBanner: HomeTabBannerColor { return HomeTabBannerColor() }
     var onboarding: OnboardingColor { return OnboardingColor() }
     var remotePanel: RemoteTabTrayColor { return RemoteTabTrayColor() }
 }

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -28,7 +28,7 @@ public struct PrefsKeys {
     public static let KeyInstallSession = "installSessionNumber"
     public static let KeyETPCoverSheetShowType = "etpCoverSheetShowType"
     public static let KeyDefaultBrowserCardShowType = "defaultBrowserCardShowType"
-    public static let DidDismissDefaultBrowserCard = "DidDismissDefaultBrowserCard"
+    public static let DidDismissDefaultBrowserMessage = "DidDismissDefaultBrowserCard"
     public static let KeyDidShowDefaultBrowserOnboarding = "didShowDefaultBrowserOnboarding"
     public static let ContextMenuShowLinkPreviews = "showLinkPreviews"
     public static let NewTabCustomUrlPrefKey = "HomePageURLPref"


### PR DESCRIPTION
# Overview

Addresses #10614 , and this [JIRA ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-4167).

Note: We can't replace ALL references to default browser card. Since the evergreen message for the HomeTabBanner (default browser card) can't be provided from NimbusFML (we can't track who the default browser is yet), the remaining references NEED to stay as is.  