### PR TITLE
EXP-2407 Fixup message under experiment never showing

### DIFF
--- a/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -263,24 +263,23 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
         FxNimbus.shared.features.messaging.recordExposure()
         let onControlActions = onControl
 
-        if message.data.isControl {
-            switch onControlActions {
-            case .showNone:
-                return nil
-            case .showNextMessage:
-                return messages.first { message in
-                    do {
-                        return try messagingUtility.isMessageEligible(message, messageHelper: helper)
-                        && !message.data.isControl
-                    } catch {
-                        onMalformedMessage(messageKey: message.id)
-                        return false
-                    }
+        if !message.data.isControl {
+            return message
+        }
+        switch onControlActions {
+        case .showNone:
+            return nil
+        case .showNextMessage:
+            return messages.first { message in
+                do {
+                    return try messagingUtility.isMessageEligible(message, messageHelper: helper)
+                    && !message.data.isControl
+                } catch {
+                    onMalformedMessage(messageKey: message.id)
+                    return false
                 }
             }
         }
-
-        return nil
     }
 
 }

--- a/Client/Experiments/initial_experiments.json
+++ b/Client/Experiments/initial_experiments.json
@@ -1,216 +1,111 @@
 {
-    "data": [{
-            "slug": "ios-search-full-text",
-            "appId": "org.mozilla.ios.Fennec",
-            "appName": "firefox_ios",
-            "channel": "nightly",
-            "branches": [{
-                    "slug": "control",
-                    "ratio": 100,
-                    "feature": {
-                        "value": {},
-                        "enabled": true,
-                        "featureId": "search"
-                    }
-                },
-                {
-                    "slug": "open-tabs-only",
-                    "ratio": 0,
-                    "feature": {
-                        "value": {
-                            "awesome-bar": {
-                                "use-page-content": true
-                            },
-                            "spotlight": {
-                                "enabled": false
-                            }
-                        },
-                        "enabled": true,
-                        "featureId": "search"
-                    }
-                },
-                {
-                    "slug": "spotlight-only",
-                    "ratio": 0,
-                    "feature": {
-                        "value": {
-                            "spotlight": {
-                                "description": "excerpt",
-                                "use-html-content": true,
-                                "icon": "screenshot",
-                                "keep-for-days": 28
-                            }
-                        },
-                        "enabled": true,
-                        "featureId": "search"
-                    }
-                },
-
-                {
-                    "slug": "spotlight-letter",
-                    "ratio": 0,
-                    "feature": {
-                        "value": {
-                            "spotlight": {
-                                "enabled": true,
-                                "icon": "letter"
-                            }
-                        },
-                        "enabled": true,
-                        "featureId": "search"
-                    }
-                },
-                {
-                    "slug": "spotlight-favicon",
-                    "ratio": 0,
-                    "feature": {
-                        "value": {
-                            "spotlight": {
-                                "enabled": true,
-                                "icon": "favicon"
-                            }
-                        },
-                        "enabled": true,
-                        "featureId": "search"
-                    }
-                },
-                {
-                    "slug": "spotlight-and-open-tabs",
-                    "ratio": 0,
-                    "feature": {
-                        "value": {
-                            "spotlight": {
-                                "enabled": true,
-                                "description": "excerpt",
-                                "icon": "screenshot",
-                                "use-html-content": true,
-                                "keep-for-days": 28
-                            },
-                            "awesome-bar": {
-                                "use-page-content": true
-                            }
-                        },
-                        "enabled": true,
-                        "featureId": "search"
-                    }
-                }
-            ],
-            "outcomes": [],
-            "arguments": {},
-            "probeSets": [],
-            "startDate": null,
-            "targeting": "true",
-            "featureIds": [
-                "nimbus-validation"
-            ],
-            "application": "org.mozilla.ios.Fennec",
-            "bucketConfig": {
-                "count": 0,
-                "start": 0,
-                "total": 10000,
-                "namespace": "nimbus-validation-2",
-                "randomizationUnit": "nimbus_id"
-            },
-            "schemaVersion": "1.5.0",
-            "userFacingName": "Full text searching with Readbility and Spotlight",
-            "referenceBranch": "control",
-            "proposedDuration": 14,
-            "isEnrollmentPaused": false,
-            "proposedEnrollment": 7,
-            "userFacingDescription": "Does making full-text available to spotlight or open tabs drive CDOU?",
-            "last_modified": 1621443780172
-        },
+    "data": [
         {
-                "slug": "mr2-homescreen-experiment",
-                "appId": "org.mozilla.ios.Fennec",
-                "appName": "firefox_ios",
-                "channel": "nightly",
-                "branches": [
-                    {
-                        "slug": "control",
-                        "ratio": 0,
-                        "feature": {
-                            "value": {},
-                            "enabled": true,
-                            "featureId": "homescreen"
-                        }
-                    },
-                    {
-                        "slug": "no-mr2",
-                        "ratio": 0,
-                        "feature": {
-                            "value": {
-                                "sections-enabled": {
-                                    "topSites": true,
-                                    "jumpBackIn": false,
-                                    "recentlySaved": false,
-                                    "pocket": false,
-                                    "libraryShortcuts": true
-                                }
-                             },
-                            "enabled": true,
-                            "featureId": "homescreen"
-                        }
-                    },
-                    {
-                        "slug": "full-mr2",
-                        "ratio": 100,
-                        "feature": {
-                            "value": {
-                                "sections-enabled": {
-                                    "topSites": true,
-                                    "jumpBackIn": true,
-                                    "recentlySaved": true,
-                                    "pocket": true,
-                                    "libraryShortcuts": true
-                                }
-                             },
-                            "enabled": true,
-                            "featureId": "homescreen"
-                        }
-                    },
-                    {
-                        "slug": "distraction-free",
-                        "ratio": 0,
-                        "feature": {
-                            "value": {
-                                "sections-enabled": {
-                                    "topSites": false,
-                                    "jumpBackIn": false,
-                                    "recentlySaved": false,
-                                    "pocket": false,
-                                    "libraryShortcuts": false
-                                }
-                             },
-                            "enabled": true,
-                            "featureId": "homescreen"
-                        }
+          "appId": "org.mozilla.ios.Fennec",
+          "appName": "firefox_ios",
+          "application": "org.mozilla.ios.Fennec",
+          "arguments": {},
+          "branches": [
+            {
+              "feature": {
+                "enabled": true,
+                "featureId": "messaging",
+                "value": {
+                  "message-under-experiment": "cmuresan-test-1",
+                  "messages": {
+                    "cmuresan-test-1": {
+                      "action": "https://en.wikipedia.org/wiki/Berserk_(manga)",
+                      "button-label": "Click here for Kentaro Miura masterpiece!",
+                      "text": "We don't talk about Berserk 2016.",
+                      "trigger": [
+                        "ALWAYS"
+                      ]
                     }
-                ],
-                "outcomes": [],
-                "arguments": {},
-                "probeSets": [],
-                "startDate": null,
-                "targeting": "true",
-                "featureIds": [
-                    "homescreen"
-                ],
-                "application": "org.mozilla.firefox_beta",
-                "bucketConfig": {
-                    "count": 10000,
-                    "start": 0,
-                    "total": 10000,
-                    "namespace": "nimbus-validation-2",
-                    "randomizationUnit": "nimbus_id"
-                },
-                "schemaVersion": "1.5.0",
-                "userFacingName": "Home screen sections test",
-                "referenceBranch": "control",
-                "proposedDuration": 14,
-                "isEnrollmentPaused": false,
-                "proposedEnrollment": 7,
-                "userFacingDescription": "Experiment to test the home screen configurations",
-                "last_modified": 1621443780172
+                  }
+                }
+              },
+              "ratio": 1,
+              "slug": "control"
+            },
+            {
+              "feature": {
+                "enabled": true,
+                "featureId": "messaging",
+                "value": {
+                  "message-under-experiment": "cmuresan-test-2",
+                  "messages": {
+                    "cmuresan-test-2": {
+                      "action": "OPEN_SETTINGS",
+                      "button-label": "Click here for Kentaro Miura masterpiece!",
+                      "text": "We don't talk about Berserk 2016.",
+                      "trigger": [
+                        "ALWAYS"
+                      ]
+                    }
+                  }
+                }
+              },
+              "ratio": 1,
+              "slug": "treatment-a"
+            },
+            {
+              "feature": {
+                "enabled": true,
+                "featureId": "messaging",
+                "value": {
+                  "actions": {
+                    "OPEN_SETTINGS": "://deep-link?url=settings/general"
+                  },
+                  "message-under-experiment": "cmuresan-test-message-2",
+                  "messages": {
+                    "cmuresan-test-message-2": {
+                      "action": "OPEN_SETTINGS",
+                      "button-label": "this is a test label",
+                      "text": "test message",
+                      "trigger": [
+                        "ALWAYS"
+                      ]
+                    }
+                  },
+                  "triggers": {
+                    "ALWAYS": "true"
+                  }
+                }
+              },
+              "ratio": 1,
+              "slug": "treatment-b"
             }
+          ],
+          "bucketConfig": {
+            "count": 10000,
+            "namespace": "ios-messaging-nightly-6",
+            "randomizationUnit": "nimbus_id",
+            "start": 0,
+            "total": 10000
+          },
+          "channel": "nightly",
+          "endDate": null,
+          "featureIds": [
+            "messaging"
+          ],
+          "id": "cmuresanios-messaging-system-test-030522-simple-v3",
+          "isEnrollmentPaused": false,
+          "outcomes": [
+            {
+              "priority": "primary",
+              "slug": "default_browser"
+            }
+          ],
+          "probeSets": [],
+          "proposedDuration": 30,
+          "proposedEnrollment": 30,
+          "referenceBranch": "control",
+          "schemaVersion": "1.7.0",
+          "slug": "cmuresanios-messaging-system-test-030522-simple-v3",
+          "startDate": null,
+          "targeting": "true",
+          "userFacingDescription": "hope not",
+          "userFacingName": "[cmuresan][ios] messaging system test 03/05/22 Simple v3"
+        }
     ]
 }


### PR DESCRIPTION
If the message was under experiment, but not the control, then `nil` was being returned; thus messages under experiment were never displayed.

Fixes [EXP-2407][1].

[1]: https://mozilla-hub.atlassian.net/browse/EXP-2407

*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Please make sure you've run the test scheme and all the tests pass. If your changes affect existing tests please make sure to update the tests as well.

Below is the PR naming guidelines we follow:

https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide
