### PR TITLE
Upgrades rust-components-swift to 93.1.0 exposing deleteVisitFor

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14192,7 +14192,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 93.0.4;
+				version = 93.1.0;
 			};
 		};
 		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/mozilla/rust-components-swift.git",
         "state": {
           "branch": null,
-          "revision": "dfd17f5d50d0d61efa9d026004fbf9ce7f77295b",
-          "version": "93.0.4"
+          "revision": "ab137933f942e9bf76d82dde590f80832e726625",
+          "version": "93.1.0"
         }
       },
       {

--- a/Storage/Rust/RustPlaces.swift
+++ b/Storage/Rust/RustPlaces.swift
@@ -366,4 +366,10 @@ public class RustPlaces {
             return try connection.deleteHistoryMetadata(key: key)
         }
     }
+
+    public func deleteVisitsFor(url: Url) -> Deferred<Maybe<Void>> {
+        return withWriter { connection in
+            return try connection.deleteVisitsFor(url: url)
+        }
+    }
 }

--- a/bin/nimbus-fml.sh
+++ b/bin/nimbus-fml.sh
@@ -60,7 +60,7 @@ helptext() {
 MANIFEST_PATH=
 OUTPUT_DIR="${SOURCE_ROOT}/${PROJECT}/Generated"
 NAMESPACE=
-AS_VERSION=v93.0.4
+AS_VERSION=v93.1.0
 AS_DOWNLOAD_URL="https://github.com/mozilla/application-services/releases/download/$AS_VERSION"
 FRESHEN_FML=
 


### PR DESCRIPTION
Upgrades application services to 93.1.0

Changelog: 
# v93.1.0 (_2022-05-06_)

[Full Changelog](https://github.com/mozilla/application-services/compare/v93.0.4...v93.1.0)

## Nimbus ⛅️🔬🔭

### What's New
  - New API in the `FeatureHolder`, both iOS and Android to control the output of the `value()` call:
    - to cache the values given to callers; this can be cleared with `FxNimbus.invalidatedCachedValues()`
    - to add a custom initializer with `with(initializer:_)`/`withInitializer(_)`.
## Places
### What's Fixed:
- Fixed a bug in Android where non-fatal errors were crashing. ([#4941](https://github.com/mozilla/application-services/pull/4941))
- Fixed a bug where querying history metadata would return a sql error instead of the result ([4940](https://github.com/mozilla/application-services/pull/4940))
### What's new:
- Exposed the `deleteVisitsFor` function in iOS, the function can be used to delete history metadata. ([#4946](https://github.com/mozilla/application-services/pull/4946))
  - Note: The API is meant to delete all history, however, iOS does **not** use the `places` Rust component for regular history yet.