### PR TITLE
Add fx4033 [v101] Add description to settings for inactive tabs

### DIFF
--- a/Client/Frontend/Settings/TabsSettingsViewControler.swift
+++ b/Client/Frontend/Settings/TabsSettingsViewControler.swift
@@ -19,7 +19,7 @@ class TabsSettingsViewController: SettingsTableViewController, FeatureFlagsProto
 
     override func generateSettings() -> [SettingSection] {
 
-        var sectionItems = [Setting]()
+        var sectionItems = [SettingSection]()
 
         let inactiveTabsSetting = BoolSetting(with: .inactiveTabs,
                                               titleText: NSAttributedString(string: .Settings.Tabs.InactiveTabs))
@@ -29,15 +29,16 @@ class TabsSettingsViewController: SettingsTableViewController, FeatureFlagsProto
 
         if featureFlags.isFeatureActiveForBuild(.inactiveTabs),
            featureFlags.isFeatureActiveForNimbus(.inactiveTabs) {
-            sectionItems.append(inactiveTabsSetting)
+            sectionItems.append(SettingSection(title: NSAttributedString(string: .Settings.Tabs.TabsSectionTitle),
+                                               footerTitle: NSAttributedString(string: .Settings.Tabs.InactiveTabsDescription),
+                                               children: [inactiveTabsSetting]))
         }
 
         if featureFlags.isFeatureActiveForBuild(.tabTrayGroups) {
-            sectionItems.append(tabGroupsSetting)
+            sectionItems.append(SettingSection(children: [tabGroupsSetting]))
         }
 
-        return [SettingSection(title: NSAttributedString(string: .Settings.Tabs.TabsSectionTitle),
-                               children: sectionItems)]
+        return sectionItems
     }
 
     override func viewDidDisappear(_ animated: Bool) {


### PR DESCRIPTION
# Issue #10368
- Add a description for inactive tabs section in the settings
- Separate group tabs toggle from inactive tabs (visual change only), so inactive tabs description only apply to that one