### PR TITLE
Add [v101] Improve contile provider with empty data check

### DIFF
--- a/Client/Frontend/Home/TopSites/DataManagement/ContileProvider.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/ContileProvider.swift
@@ -62,11 +62,12 @@ class ContileProvider: ContileProviderInterface, Loggable, URLCaching {
 
             if let error = error {
                 self.browserLog.debug("An error occurred while fetching data: \(error)")
-                completion(Result.failure(Error.failure))
+                completion(.failure(Error.failure))
                 return
             }
 
-            guard let response = validatedHTTPResponse(response, statusCode: 200..<300), let data = data else {
+            guard let response = validatedHTTPResponse(response, statusCode: 200..<300), let data = data, !data.isEmpty else {
+                self.browserLog.debug("Response isn't proper: \(response.debugDescription), with data \(String(describing: data))")
                 completion(.failure(Error.failure))
                 return
             }


### PR DESCRIPTION
Turns out that we get empty data now with local build since our User agent string has the version 0.0.1, this means we get no sponsored tiles on developer builds.

Adding a check for empty data since wasn't part of the validatedHTTPResponse method check.