### PR TITLE
Bugfix #10134 [v101] ⁃ Attentive mode should be dismissed when home page interacted with

### DIFF
--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -98,6 +98,10 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, GleanPlu
         collectionView?.backgroundColor = .clear
         view.addSubview(wallpaperView)
 
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+
         if shouldDisplayHomeTabBanner {
             showHomeTabBanner()
         }
@@ -197,6 +201,10 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, GleanPlu
     }
 
     override func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        dismissKeyboard()
+    }
+
+    @objc private func dismissKeyboard() {
         currentTab?.lastKnownUrl?.absoluteString.hasPrefix("internal://") ?? false ? BrowserViewController.foregroundBVC().urlBar.leaveOverlayMode() : nil
     }
 

--- a/XCUITests/NavigationTest.swift
+++ b/XCUITests/NavigationTest.swift
@@ -416,7 +416,7 @@ class NavigationTest: BaseTestCase {
         XCTAssert(app.keyboards.count > 0, "The keyboard is not shown")
         app.typeText("example.com\n")
 
-        waitUntilPageLoad()
+//        waitUntilPageLoad()
         waitForValueContains(urlBar, value: "example.com/")
         XCTAssertFalse(app.keyboards.count > 0, "The keyboard is shown")
     }


### PR DESCRIPTION
Issue #10134 

Add tap gesture to collection view to leave attentive mode
