### PR TITLE
Bugfix fx3590 [v101] - "CMD+" does not zoom in

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -346,7 +346,7 @@ extension BrowserViewController {
             UIKeyCommand(action: #selector(findInPageAgainKeyCommand), input: "g", modifierFlags: .command, discoverabilityTitle: shortcuts.FindAgain),
 
             // View
-            UIKeyCommand(action: #selector(zoomIn), input: "+", modifierFlags: .command, discoverabilityTitle: shortcuts.ZoomIn),
+            UIKeyCommand(action: #selector(zoomIn), input: "=", modifierFlags: .command, discoverabilityTitle: shortcuts.ZoomIn),
             UIKeyCommand(action: #selector(zoomOut), input: "-", modifierFlags: .command, discoverabilityTitle: shortcuts.ZoomOut),
             UIKeyCommand(action: #selector(resetZoom), input: "0", modifierFlags: .command, discoverabilityTitle: shortcuts.ActualSize),
             UIKeyCommand(action: #selector(reloadTabKeyCommand), input: "r", modifierFlags: .command, discoverabilityTitle: shortcuts.ReloadPage),


### PR DESCRIPTION
Action didn't get triggered when "CMD+" was tapped, in the KeyboardPressesHandler that action was identified as "CMD=".

I changed UIKeyCommand to trigger when "CMD=" is tapped