### PR TITLE
Bugfix EXP-2427 [v101]: GleanPlumb messages with blank text should report malformed

### DIFF
--- a/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -203,6 +203,9 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
     /// Reporting a malformed message is done at the call site when reacting to a `nil`.
     private func createMessage(messageId: String, message: MessageData, lookupTables: Messaging) -> GleanPlumbMessage? {
 
+        /// Guard against a message with a blank `text` property. 
+        if message.text.isEmpty { return nil }
+
         /// Ascertain a Message's style, to know priority and max impressions.
         guard let style = lookupTables.styles[message.style] else { return nil }
 


### PR DESCRIPTION
# Overview

This PR refers to a message on the EXP board - [see this](https://mozilla-hub.atlassian.net/browse/EXP-2427).