### PR TITLE
Bugfix FXIOS-2583 [v101] - Improve key pressed-ended logic to avoid issue where cmd key acts as pressed

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -114,6 +114,7 @@ extension BrowserViewController {
                                      extras: ["action": "new-tab"])
         let isPrivate = tabManager.selectedTab?.isPrivate ?? false
         openBlankNewTab(focusLocationField: true, isPrivate: isPrivate)
+        keyboardPressesHandler.reset()
     }
 
     @objc private func newPrivateTabKeyCommand() {

--- a/Client/Frontend/Browser/KeyboardPressesHandler.swift
+++ b/Client/Frontend/Browser/KeyboardPressesHandler.swift
@@ -80,10 +80,11 @@ class KeyboardPressesHandler {
 
         for press in presses {
             guard let key = press.key?.keyCode else { continue }
-            if pressedIfFound {
-                keysPressed.append(key)
-            } else {
+
+            if !pressedIfFound {
                 keysPressed.removeAll(where: { $0 == key })
+            } else if !keysPressed.contains(key) {
+                keysPressed.append(key)
             }
         }
     }

--- a/ClientTests/KeyboardPressesHandlerTests.swift
+++ b/ClientTests/KeyboardPressesHandlerTests.swift
@@ -177,6 +177,16 @@ class KeyboardPressesHandlerTests: XCTestCase {
         XCTAssertEqual(handler.isCmdAndShiftPressed, true)
     }
 
+    func testOnlyOneCmd_withCmdPressedMultipleTimes() {
+        let handler = KeyboardPressesHandler()
+        let cmdPress = createPress(keyCode: .keyboardLeftGUI)
+        handler.handlePressesBegan(Set([cmdPress]), with: nil)
+        handler.handlePressesBegan(Set([cmdPress]), with: nil)
+        handler.handlePressesEnded(Set([cmdPress]), with: nil)
+
+        XCTAssertEqual(handler.isCmdAndShiftPressed, false)
+    }
+
     // MARK: isOnlyOptionPressed
 
     func testOptionTrue_withLeftPress() {


### PR DESCRIPTION
Issue #7519
- The current issues is not related to the ticket title anymore, the new problem is when using the shortcuts to open a new tab (cmd + t)or close it (cmd + w) the command remains as pressed when is not  

- Reset key pressed after open new tab + avoid adding key if already exist
