### PR TITLE
Bugfix EXP-2417 [v101]: GleanPlumb messages should dismiss after hitting CTA

### DIFF
--- a/Client/Experiments/initial_experiments.json
+++ b/Client/Experiments/initial_experiments.json
@@ -11,69 +11,35 @@
                 "enabled": true,
                 "featureId": "messaging",
                 "value": {
-                  "message-under-experiment": "cmuresan-test-1",
-                  "messages": {
-                    "cmuresan-test-1": {
-                      "action": "https://en.wikipedia.org/wiki/Berserk_(manga)",
-                      "button-label": "Click here for Kentaro Miura masterpiece!",
-                      "text": "We don't talk about Berserk 2016.",
-                      "trigger": [
-                        "ALWAYS"
-                      ]
-                    }
-                  }
-                }
-              },
-              "ratio": 1,
-              "slug": "control"
-            },
-            {
-              "feature": {
-                "enabled": true,
-                "featureId": "messaging",
-                "value": {
-                  "message-under-experiment": "cmuresan-test-2",
-                  "messages": {
-                    "cmuresan-test-2": {
-                      "action": "OPEN_SETTINGS",
-                      "button-label": "Click here for Kentaro Miura masterpiece!",
-                      "text": "We don't talk about Berserk 2016.",
-                      "trigger": [
-                        "ALWAYS"
-                      ]
-                    }
-                  }
-                }
-              },
-              "ratio": 1,
-              "slug": "treatment-a"
-            },
-            {
-              "feature": {
-                "enabled": true,
-                "featureId": "messaging",
-                "value": {
-                  "actions": {
-                    "OPEN_SETTINGS": "://deep-link?url=settings/general"
-                  },
-                  "message-under-experiment": "cmuresan-test-message-2",
-                  "messages": {
-                    "cmuresan-test-message-2": {
-                      "action": "OPEN_SETTINGS",
-                      "button-label": "this is a test label",
-                      "text": "test message",
-                      "trigger": [
-                        "ALWAYS"
-                      ]
-                    }
-                  },
+                  "on-control": "show-next-message",
+                  "message-under-experiment": "may12-2022-943am",
                   "triggers": {
-                    "ALWAYS": "true"
+                      "ALWAYS": "true"
+                    },
+                  "actions": {
+                      "OPEN_LINK": "https://www.google.com/search?client=firefox-b-1-d&q=google&id={uuid}"
+                    },
+                  "styles": {
+                      "PPOPY": [
+                        "priority: 50",
+                        "max-display-count: 3"
+                      ]
+                    },
+                  "messages": {
+                    "may12-2022-1648": {
+                      "action": "OPEN_SETTINGS_THEME",
+                      "button-label": "PPOP",
+                      "style": "URGENT",
+                      "text": "Can you see the string?",
+                      "trigger": [
+                        "ALWAYS"
+                      ]
+                    }
                   }
                 }
               },
-              "ratio": 1,
-              "slug": "treatment-b"
+              "ratio": 0,
+              "slug": "control"
             }
           ],
           "bucketConfig": {

--- a/Client/Frontend/Home/HomeTabBanner.swift
+++ b/Client/Frontend/Home/HomeTabBanner.swift
@@ -210,10 +210,15 @@ class HomeTabBanner: UIView, GleanPlumbMessageManagable {
 
     /// The surface needs to handle CTAs a certain way when there's a message OR the evergreen.
     @objc func handleCTA() {
+        self.dismissClosure?()
+
         guard let message = message else {
             /// If we're here, that means we've shown the evergreen. Handle it as we always did.
             BrowserViewController.foregroundBVC().presentDBOnboardingViewController(true)
             TelemetryWrapper.gleanRecordEvent(category: .action, method: .tap, object: .goToSettingsDefaultBrowserCard)
+
+            /// The evergreen needs to be treated like the other messages - once interacted with, don't show it.
+            UserDefaults.standard.set(true, forKey: PrefsKeys.DidDismissDefaultBrowserMessage)
 
             // Set default browser onboarding did show to true so it will not show again after user clicks this button
             UserDefaults.standard.set(true, forKey: PrefsKeys.KeyDidShowDefaultBrowserOnboarding)


### PR DESCRIPTION
# Overview

Addresses [this EXP ticket](https://mozilla-hub.atlassian.net/browse/EXP-2417).