### PR TITLE
 Bugfix FXIOS-2583 [v101] - Improve key pressed-ended logic to avoid issue where cmd key acts as pressed

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2379,13 +2379,13 @@ extension BrowserViewController: ContextMenuHelperDelegate {
     }
 
     override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
-        super.pressesBegan(presses, with: event)
         keyboardPressesHandler.handlePressesBegan(presses, with: event)
+        super.pressesBegan(presses, with: event)
     }
 
     override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
-        super.pressesEnded(presses, with: event)
         keyboardPressesHandler.handlePressesEnded(presses, with: event)
+        super.pressesEnded(presses, with: event)
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -146,6 +146,7 @@ extension BrowserViewController {
             return
         }
         tabManager.removeTab(currentTab)
+        keyboardPressesHandler.reset()
     }
 
     @objc private func undoLastTabClosedKeyCommand() {


### PR DESCRIPTION
Issue https://github.com/mozilla-mobile/firefox-ios/issues/7519

The current issues is not related to the ticket title anymore, the new problem is when using the shortcuts to open a new tab (cmd + t)or close it (cmd + w) the command remains as pressed when is not

Handle keyboard press before calling super and reseting on close tab