### PR TITLE
Refactor FXIOS-4400 [v103] Replaced Snapkit in `CredentialProvider/Cell`

### DIFF
--- a/CredentialProvider/Cells/EmptyPlaceholderCell.swift
+++ b/CredentialProvider/Cells/EmptyPlaceholderCell.swift
@@ -8,40 +8,33 @@ class EmptyPlaceholderCell: UITableViewCell {
 
     static let identifier = "emptyPlaceholderCell"
 
-    lazy private var titleLabel: UILabel = {
-        let label = UILabel()
+    lazy private var titleLabel: UILabel = .build { label in
         label.textColor = UIColor.CredentialProvider.titleColor
         label.text = .LoginsListNoLoginsFoundTitle
         label.font = UIFont.systemFont(ofSize: 15)
-        return label
-    }()
+    }
 
-    lazy private var descriptionLabel: UILabel = {
-        let label = UILabel()
+    lazy private var descriptionLabel: UILabel = .build { label in
         label.text = .LoginsListNoLoginsFoundDescription
         label.font = UIFont.systemFont(ofSize: 13)
         label.textColor = .systemGray
         label.textAlignment = .center
         label.numberOfLines = 0
-        return label
-    }()
+    }
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         selectionStyle = .none
         backgroundColor = UIColor.CredentialProvider.tableViewBackgroundColor
 
-        contentView.addSubview(titleLabel)
-        titleLabel.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.top.equalToSuperview().offset(55)
-        }
-        contentView.addSubview(descriptionLabel)
-        descriptionLabel.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.width.equalTo(280)
-            make.top.equalTo(titleLabel.snp_bottomMargin).offset(20)
-        }
+        contentView.addSubviews(titleLabel, descriptionLabel)
+        NSLayoutConstraint.activate([
+            titleLabel.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 55),
+            descriptionLabel.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            descriptionLabel.widthAnchor.constraint(equalToConstant: 280),
+            descriptionLabel.topAnchor.constraint(equalTo: titleLabel.layoutMarginsGuide.bottomAnchor, constant: 20),
+        ])
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/CredentialProvider/Cells/ItemListCell.swift
+++ b/CredentialProvider/Cells/ItemListCell.swift
@@ -8,48 +8,35 @@ class ItemListCell: UITableViewCell {
 
     static let identifier = "itemListCell"
 
-    lazy var titleLabel: UILabel = {
-        let label = UILabel()
+    lazy var titleLabel: UILabel = .build { label in
         label.textColor = UIColor.CredentialProvider.titleColor
         label.font = .systemFont(ofSize: 16)
-        return label
-    }()
+    }
 
-    lazy var detailLabel: UILabel = {
-        let label = UILabel()
+    lazy var detailLabel: UILabel = .build { label in
         label.textColor = .systemGray
         label.font = .systemFont(ofSize: 13)
-        return label
-    }()
+    }
 
-    lazy var separatorView: UIView = {
-        let view = UIView()
+    lazy var separatorView: UIView = .build { view in
         view.backgroundColor = .lightGray
         view.alpha = 0.6
-        return view
-    }()
+    }
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
         backgroundColor = UIColor.CredentialProvider.cellBackgroundColor
-        contentView.addSubview(titleLabel)
-        titleLabel.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(14)
-            make.top.equalToSuperview().offset(10)
-        }
-        contentView.addSubview(detailLabel)
-        detailLabel.snp.makeConstraints { make in
-            make.top.equalTo(titleLabel.snp_bottomMargin).offset(8)
-            make.leading.equalToSuperview().offset(14)
-        }
-
-        contentView.addSubview(separatorView)
-        separatorView.snp.makeConstraints { make in
-            make.bottom.equalToSuperview()
-            make.width.equalToSuperview()
-            make.height.equalTo(0.8)
-        }
+        contentView.addSubviews(titleLabel, detailLabel, separatorView)
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 14),
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 10),
+            detailLabel.topAnchor.constraint(equalTo: titleLabel.layoutMarginsGuide.bottomAnchor, constant: 8),
+            detailLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 14),
+            separatorView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            separatorView.widthAnchor.constraint(equalTo: contentView.widthAnchor),
+            separatorView.heightAnchor.constraint(equalToConstant: 0.8)
+        ])
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/CredentialProvider/Cells/NoSearchResultCell.swift
+++ b/CredentialProvider/Cells/NoSearchResultCell.swift
@@ -8,23 +8,19 @@ class NoSearchResultCell: UITableViewCell {
 
     static let identifier = "noSearchResultCell"
 
-    lazy private var titleLabel: UILabel = {
-        let label = UILabel()
+    lazy private var titleLabel: UILabel = .build { label in
         label.textColor = UIColor.CredentialProvider.titleColor
         label.text = .LoginsListNoMatchingResultTitle
         label.font = UIFont.systemFont(ofSize: 15)
-        return label
-    }()
+    }
 
-    lazy private var descriptionLabel: UILabel = {
-        let label = UILabel()
+    lazy private var descriptionLabel: UILabel = .build { label in
         label.text = .LoginsListNoMatchingResultSubtitle
         label.textColor = .systemGray
         label.font = UIFont.systemFont(ofSize: 13)
         label.textAlignment = .center
         label.numberOfLines = 0
-        return label
-    }()
+    }
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -32,16 +28,13 @@ class NoSearchResultCell: UITableViewCell {
         selectionStyle = .none
         backgroundColor = UIColor.CredentialProvider.tableViewBackgroundColor
 
-        contentView.addSubview(titleLabel)
-        titleLabel.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.top.equalToSuperview().offset(55)
-        }
-        contentView.addSubview(descriptionLabel)
-        descriptionLabel.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.top.equalTo(titleLabel.snp_bottomMargin).offset(15)
-        }
+        contentView.addSubviews(titleLabel, descriptionLabel)
+        NSLayoutConstraint.activate([
+            titleLabel.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 55),
+            descriptionLabel.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            descriptionLabel.topAnchor.constraint(equalTo: titleLabel.layoutMarginsGuide.bottomAnchor, constant: 15),
+        ])
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/CredentialProvider/Cells/SelectPasswordCell.swift
+++ b/CredentialProvider/Cells/SelectPasswordCell.swift
@@ -8,13 +8,11 @@ class SelectPasswordCell: UITableViewCell {
 
     static let identifier = "selectPasswordCell"
 
-    lazy private var selectLabel: UILabel = {
-        let label = UILabel()
+    lazy private var selectLabel: UILabel = .build { label in
         label.text = .LoginsListSelectPasswordTitle.uppercased()
         label.font = UIFont.systemFont(ofSize: 13)
         label.textColor = .systemGray
-        return label
-    }()
+    }
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -22,10 +20,10 @@ class SelectPasswordCell: UITableViewCell {
         backgroundColor = UIColor.CredentialProvider.tableViewBackgroundColor
 
         contentView.addSubview(selectLabel)
-        selectLabel.snp.makeConstraints { make in
-            make.centerY.equalToSuperview().multipliedBy(1.4)
-            make.leading.equalToSuperview().offset(14)
-        }
+        NSLayoutConstraint.activate([
+            selectLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor, multiplier: 1.4),
+            selectLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 14)
+        ])
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
Related to https://github.com/mozilla-mobile/firefox-ios/issues/8592

This PR includes replacement for Snapkit in EmptyPlaceholderCell.swift, NoSearchResultCell.swift, SelectPasswordCell.swift, and ItemListCell.swift.