### PR TITLE
Bugfix fx4241 [v101] Opening setting from contextual menu doesn't update the sponsored tiles state

### DIFF
--- a/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -15,6 +15,11 @@ class TopSitesSettingsViewController: SettingsTableViewController, FeatureFlagga
         self.navigationController?.navigationBar.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.Shortcuts.settingsPage
     }
 
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        NotificationCenter.default.post(name: .HomePanelPrefsChanged, object: nil)
+    }
+
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")


### PR DESCRIPTION
# Issue #10755
- Post notification in case we're opening top sites settings page from contextual menu