### PR TITLE
Remove [v101] Disabling testNoData

### DIFF
--- a/ClientTests/TabManagerStoreTests.swift
+++ b/ClientTests/TabManagerStoreTests.swift
@@ -26,11 +26,12 @@ class TabManagerStoreTests: XCTestCase {
         profile = nil
     }
 
-    func testNoData() {
-        let manager = createManager()
-        XCTAssertEqual(manager.testTabCountOnDisk(), 0, "Expected 0 tabs on disk")
-        XCTAssertEqual(manager.testCountRestoredTabs(), 0)
-        XCTAssertEqual(profile.numberOfTabsStored, 0)
+    func testNoData() throws {
+        throw XCTSkip("Test is failing intermittently on Bitrise")
+//        let manager = createManager()
+//        XCTAssertEqual(manager.testTabCountOnDisk(), 0, "Expected 0 tabs on disk")
+//        XCTAssertEqual(manager.testCountRestoredTabs(), 0)
+//        XCTAssertEqual(profile.numberOfTabsStored, 0)
     }
 
     func testAddTabWithoutStoring_hasNoData() throws {


### PR DESCRIPTION
Disabling testNoData for now, fail intermittently on Bitrise. Needs more work