### PR TITLE
Bugfix FXIOS-4231 [v102] Firefox crashes when switching between Private browsing and normal browsing tabs

### DIFF
--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -282,7 +282,8 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
         // we clear out all of the private tabs
         let exitingPrivateMode = !tabDisplayManager.isPrivate && tabManager.shouldClearPrivateTabs()
 
-        collectionView.layoutSubviews()
+        collectionView.setNeedsLayout()
+        collectionView.layoutIfNeeded()
 
         let toView: UIView
         if !privateTabsAreEmpty(), let newSnapshot = collectionView.snapshotView(afterScreenUpdates: !exitingPrivateMode) {

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -228,8 +228,11 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
             SearchTermGroupsUtility.getTabGroups(with: profile,
                                                  from: tabsToBuildFrom,
                                                  using: .orderedAscending) { tabGroups, filteredActiveTabs  in
-                self.tabsSetupHelper(tabGroups: tabGroups, filteredTabs: filteredActiveTabs)
-                completion(tabGroups, filteredActiveTabs)
+
+                ensureMainThread { [weak self] in
+                    self?.tabsSetupHelper(tabGroups: tabGroups, filteredTabs: filteredActiveTabs)
+                    completion(tabGroups, filteredActiveTabs)
+                }
             }
             return
         }

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -286,6 +286,7 @@ class TabTrayViewController: UIViewController {
         updateToolbarItems(forSyncTabs: viewModel.profile.hasSyncableAccount())
         viewModel.tabTrayView.didTogglePrivateMode(privateMode)
         updatePrivateUIState()
+        updateTitle()
     }
 
     private func showPanel(_ panel: UIViewController) {


### PR DESCRIPTION
Issue #10738
- Run completion on main thread 
- Call updateTitle when switching between private and normal mode

