### PR TITLE
Bugfix FXIOS-3889 [v102] - Toolbar Action menu has an empty space on xcode 13.3

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -274,7 +274,9 @@ class PhotonActionSheet: UIViewController {
                                change: [NSKeyValueChangeKey: Any]?,
                                context: UnsafeMutableRawPointer?) {
         if viewModel.presentationStyle == .popover && !wasHeightOverriden {
-            preferredContentSize = tableView.contentSize
+            var size = tableView.contentSize
+            size.height = tableView.contentSize.height - UX.TablePadding - UX.Spacing
+            preferredContentSize = size
         }
     }
 


### PR DESCRIPTION
This PR removes empty space from menu for Xcode 13.3
Note: This will impact menu layout on older versions of xcode, so we want to make sure to merge it when Xcode 13.3 is the new lowest supported version. I could not find a fix that will work on older versions of xcode and also on version 13.3.
In the future we can make the transition to native UIMenu to solve this kind of issues.

<img width="781" alt="Screen Shot 2022-05-18 at 4 42 12 PM" src="https://user-images.githubusercontent.com/46751540/169280614-54331b2e-c4c4-45b6-a4c0-21bce264ed70.png">


<img width="564" alt="Screen Shot 2022-05-18 at 4 38 35 PM" src="https://user-images.githubusercontent.com/46751540/169280644-f8b91c7a-f726-4b06-aa1c-b492487b2648.png">

