### PR TITLE
Add x4143 [v101] Search highlights Nimbus integration

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -95,9 +95,9 @@ start-at-home-feature:
       type: string
       description: This property provides a default setting for the startAtHomeFeature
       enum:
+        - always
         - disabled
         - after-four-hours
-        - always
 tabTrayFeature:
   description: The tab tray screen that the user goes to when they open the tab tray.
   hasExposure: true

--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -10,9 +10,6 @@ general-app-features:
     report-site-issue:
       type: json
       description: This property defines whether or not the feature is enabled
-    search-bar-position:
-      type: json
-      description: "This property defines whether or not the feature is enabled, and the position of the search bar"
     shake-to-restore:
       type: json
       description: This property defines whether or not the feature is enabled

--- a/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -19,6 +19,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case pullToRefresh
     case recentlySaved
     case reportSiteIssue
+    case searchHighlights
     case shakeToRestore
     case sponsoredTiles
     case startAtHome
@@ -71,14 +72,15 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
         case .wallpapers:
             return FlagKeys.CustomWallpaper
 
+        // Cases where users do not have the option to manipulate a setting.
         case .reportSiteIssue,
-                .shakeToRestore:
+                .shakeToRestore,
+                .searchHighlights:
             return nil
         }
     }
 
     // MARK: - Initializers
-
     init(withID featureID: NimbusFeatureFlagID, and profile: Profile) {
         self.featureID = featureID
         self.profile = profile

--- a/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -12,11 +12,14 @@ final class NimbusFeatureFlagLayer {
                                      from nimbus: FxNimbus = FxNimbus.shared
     ) -> Bool {
         switch featureID {
-        case .bottomSearchBar,
-                .pullToRefresh,
+        case .pullToRefresh,
                 .reportSiteIssue,
                 .shakeToRestore:
             return checkGeneralFeature(for: featureID, from: nimbus)
+
+        case .bottomSearchBar,
+                .searchHighlights:
+            return checkAwesomeBarFeature(for: featureID, from: nimbus)
 
         case .jumpBackIn,
                 .pocket,
@@ -62,10 +65,22 @@ final class NimbusFeatureFlagLayer {
         let config = nimbus.features.generalAppFeatures.value()
 
         switch featureID {
-        case .bottomSearchBar: return config.searchBarPosition.status
         case .pullToRefresh: return config.pullToRefresh.status
         case .reportSiteIssue: return config.reportSiteIssue.status
         case .shakeToRestore: return config.shakeToRestore.status
+        default: return false
+        }
+    }
+
+    private func checkAwesomeBarFeature(for featureID: NimbusFeatureFlagID,
+                                        from nimbus: FxNimbus
+    ) -> Bool {
+
+        let config = nimbus.features.search.value().awesomeBar
+
+        switch featureID {
+        case .bottomSearchBar: return config.position.isPositionFeatureEnabled
+        case .searchHighlights: return config.searchHighlights
         default: return false
         }
     }

--- a/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -61,7 +61,6 @@ final class NimbusFeatureFlagLayer {
     private func checkGeneralFeature(for featureID: NimbusFeatureFlagID,
                                      from nimbus: FxNimbus
     ) -> Bool {
-
         let config = nimbus.features.generalAppFeatures.value()
 
         switch featureID {
@@ -75,7 +74,6 @@ final class NimbusFeatureFlagLayer {
     private func checkAwesomeBarFeature(for featureID: NimbusFeatureFlagID,
                                         from nimbus: FxNimbus
     ) -> Bool {
-
         let config = nimbus.features.search.value().awesomeBar
 
         switch featureID {
@@ -88,7 +86,6 @@ final class NimbusFeatureFlagLayer {
     private func checkHomescreenFeature(for featureID: NimbusFeatureFlagID,
                                         from nimbus: FxNimbus
     ) -> Bool {
-
         let config = nimbus.features.homescreenFeature.value()
         var nimbusID: HomeScreenSection
 
@@ -112,7 +109,6 @@ final class NimbusFeatureFlagLayer {
     }
 
     private func checkSponsoredTilesFeature(from nimbus: FxNimbus) -> Bool {
-
         let config = nimbus.features.homescreenFeature.value()
 
         return config.sponsoredTiles.status
@@ -121,7 +117,6 @@ final class NimbusFeatureFlagLayer {
     private func checkTabTrayFeature(for featureID: NimbusFeatureFlagID,
                                      from nimbus: FxNimbus
     ) -> Bool {
-
         let config = nimbus.features.tabTrayFeature.value()
         var nimbusID: TabTraySection
 
@@ -138,7 +133,6 @@ final class NimbusFeatureFlagLayer {
     private func checkGroupingFeature(for featureID: NimbusFeatureFlagID,
                                      from nimbus: FxNimbus
     ) -> Bool {
-
         let config = nimbus.features.searchTermGroupsFeature.value()
         var nimbusID: SearchTermGroups
 

--- a/Client/Nimbus/NimbusSearchBarLayer.swift
+++ b/Client/Nimbus/NimbusSearchBarLayer.swift
@@ -8,7 +8,7 @@ final class NimbusSearchBarLayer {
 
     // MARK: - Public methods
     public func getDefaultPosition(from nimbus: FxNimbus = FxNimbus.shared) -> SearchBarPosition {
-        let isAtBottom = nimbus.features.generalAppFeatures.value().searchBarPosition.isBottom
+        let isAtBottom = nimbus.features.search.value().awesomeBar.position.isBottom
 
         return isAtBottom ? .bottom : .top
     }

--- a/ClientTests/FeatureFlagManagerTests.swift
+++ b/ClientTests/FeatureFlagManagerTests.swift
@@ -55,6 +55,8 @@ class FeatureFlagManagerTests: XCTestCase, FeatureFlaggable {
         XCTAssertTrue(featureFlags.isFeatureEnabled(.recentlySaved, checking: .userOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.reportSiteIssue, checking: .buildOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.reportSiteIssue, checking: .userOnly))
+        XCTAssertTrue(featureFlags.isFeatureEnabled(.searchHighlights, checking: .buildOnly))
+        XCTAssertTrue(featureFlags.isFeatureEnabled(.searchHighlights, checking: .userOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.shakeToRestore, checking: .buildOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.shakeToRestore, checking: .userOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.sponsoredTiles, checking: .buildOnly))

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -7,15 +7,6 @@ features:
   general-app-features:
     description: The feature that contains feature flags for the entire application
     variables:
-      search-bar-position:
-        description: "This property defines whether or not the feature is
-        enabled, and the position of the search bar"
-        type: BottomSearchBar
-        default:
-          {
-            "status": true,
-            "is-bottom": true
-          }
       pull-to-refresh:
         description: "This property defines whether or not the feature is enabled"
         type: GeneralFeature
@@ -40,10 +31,6 @@ features:
     defaults:
       - channel: beta
         value: {
-          "search-bar-position": {
-            "status": true,
-            "is-bottom": true
-          },
           "pull-to-refresh": {
             "status": true
           },
@@ -94,7 +81,12 @@ features:
         type: AwesomeBar
         default:
           {
-            "use-page-content": false
+            "use-page-content": false,
+            "search-highlights": false,
+            "position": {
+              "is-position-feature-enabled": true,
+              "is-bottom": true
+            }
           }
       spotlight:
         description: "This property is covers the properties related to the spotlight"
@@ -107,7 +99,27 @@ features:
             "icon": "letter",
             "keep-for-days": null
           }
-    defaults: null
+    defaults:
+      - channel: beta
+        value: {
+          "awesome-bar": {
+            "search-highlights": true,
+            "position": {
+              "is-position-feature-enabled": true,
+              "is-bottom": true
+            }
+          }
+        }
+      - channel: developer
+        value: {
+          "awesome-bar": {
+            "search-highlights": true,
+            "position": {
+              "is-position-feature-enabled": true,
+              "is-bottom": true
+            }
+          }
+        }
   nimbus-validation:
     description: "A feature that does not correspond to an application feature suitable for showing
       that Nimbus is working."
@@ -124,6 +136,7 @@ features:
         description: The drawable displayed in the app menu for Settings
         type: String
         default: "menu-Settings"
+
   homescreenFeature:
     description: The homescreen that the user goes to when they press home or new tab.
     variables:
@@ -337,10 +350,33 @@ types:
           type: Boolean
           description: Whether or not the feature is enabled
           default: false
-    BottomSearchBar:
+
+    AwesomeBar:
+      description: "Represents the awesome bar object"
+      fields:
+        use-page-content:
+          description: "Whether or not to use page content"
+          type: Boolean
+          default: false
+          required: true
+        search-highlights:
+          description: "Whether or not search highlights are enabled"
+          type: Boolean
+          default: false
+        position:
+          description: "This property defines whether or not the feature is
+          enabled, and the position of the search bar"
+          type: SearchBarPositionFeature
+          default:
+            {
+              "is-position-feature-enabled": true,
+              "is-bottom": true
+            }
+
+    SearchBarPositionFeature:
       description: "The configuration for the bottom search bar on the homescreen"
       fields:
-        status:
+        is-position-feature-enabled:
           type: Boolean
           description: Whether or not the feature is enabled
           default: true
@@ -348,6 +384,7 @@ types:
           type: Boolean
           description: Whether or not the default position is at the bottom
           default: true
+
     SponsoredTiles:
       description: "The configuration for the sponsored tile on the homescreen"
       fields:
@@ -359,6 +396,7 @@ types:
           type: Int
           description: The maximum number of sponsored tiles a user can see
           default: 2
+
     MessageData:
       description: >
         An object to describe a message. It uses human
@@ -410,6 +448,7 @@ types:
           description: Each message will tell us the surface it is targeting with this.
           # To start, we default to the new-tab-card
           default: new-tab-card
+
     StyleData:
       description: >
         A group of properities (predominantly visual) to
@@ -428,14 +467,6 @@ types:
             before it is expired.
           default: 5
 
-    AwesomeBar:
-      description: "Represents the awesome bar object"
-      fields:
-        use-page-content:
-          description: "Whether or not to use page content"
-          type: Boolean
-          default: false
-          required: true
     Spotlight:
       description: "An object representing the spotlight"
       fields:
@@ -463,6 +494,7 @@ types:
           default: null
           description: "Number of days to keep"
           required: true
+
   enums:
     IconType:
       description: The different types of icons
@@ -473,6 +505,7 @@ types:
           description: A favicon icon
         letter:
           description: A letter icon
+
     MessageSurfaceId:
       description: >
         For messaging, we would like to have a message tell us which surface its associated with.
@@ -482,6 +515,7 @@ types:
           description: This is the card that appears at the top on the Firefox Home Page.
         Unknown:
           description: A message has NOT declared its target surface.
+
     StartAtHome:
       description: The identifiers for the different types of options for StartAtHome
       variants:
@@ -491,6 +525,7 @@ types:
           description: App opens to a new homepage tab after four hours of inactivity
         always:
           description: App opens to a new homepage tab after five minutes of inactiviny
+
     HomeScreenSection:
       description: The identifiers for the sections of the homescreen.
       variants:
@@ -504,11 +539,13 @@ types:
           description: The tab groups
         pocket:
           description: The pocket section. This should only be available in the US.
+
     TabTraySection:
       description: The identifiers for the sections of the tab tray.
       variants:
         inactive-tabs:
           description: Tabs that have been automatically closed for the user.
+
     SearchTermGroups:
       description: The identifiers for the different types of search term groups.
       variants:
@@ -516,6 +553,7 @@ types:
           description: Grouping for items in History and RecentlyVisited
         tab-tray-groups:
           description: Grouping for items in the Tab Tray and in JumpBackIn
+
     ControlMessageBehavior:
       description: An enum to influence what should be displayed when a control message is selected.
       variants:

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -43,10 +43,6 @@ features:
         }
       - channel: developer
         value: {
-          "search-bar-position": {
-            "status": true,
-            "is-bottom": true
-          },
           "pull-to-refresh": {
             "status": true
           },


### PR DESCRIPTION
[JIRA reference](https://mozilla-hub.atlassian.net/browse/FXIOS-4143)
#10573 

This PR is marked for v101 as it moves around the search bar position in the nimbus.fml to a place that seems to make more sense, now that we're integrating more Nimbus into the search bar. The reason it needs to be in 101 is because the experiment might carry over to 102 and that would require the same Nimbus experimenter setup. This ensure that.