### PR TITLE
Add fx10825 XRViewer-v2 Include NSLocalNetworkUsageDescription in Info.plist

### DIFF
--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -95,6 +95,8 @@
 	<string>This lets you save photos.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This lets you save and upload photos.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>This lets you access websites on your local network, usually for developers testing their websites.</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>org.mozilla.ios.xrviewer.browsing</string>


### PR DESCRIPTION
Needed for testing WebXR sites running on the local network. 

As discussed in https://github.com/mozilla-mobile/firefox-ios/discussions/10811 and #10825.