### PR TITLE
Bugfix fx4272 [v101] Adjust when impression telemetry is sent for sponsored tiles

### DIFF
--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -19,7 +19,6 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, GleanPlu
 
     private let flowLayout = UICollectionViewFlowLayout()
     private var hasSentJumpBackInSectionEvent = false
-    private var hasSentHistoryHighlightsSectionEvent = false
     private var isZeroSearch: Bool
     private var viewModel: FirefoxHomeViewModel
     private var contextMenuHelper: FirefoxHomeContextMenuHelper

--- a/Client/Frontend/Home/TopSites/FxHomeTopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/FxHomeTopSitesViewModel.swift
@@ -133,6 +133,20 @@ class FxHomeTopSitesViewModel {
         }
     }
 
+    func topSiteImpressionTelemetry(_ homeTopSite: HomeTopSite, position: Int) {
+        guard !hasSentImpressionForTile(homeTopSite) else { return }
+        homeTopSite.impressionTracking(position: position)
+    }
+
+    private var sentImpressionTelemetry = [String: Bool]()
+    private func hasSentImpressionForTile(_ homeTopSite: HomeTopSite) -> Bool {
+        guard sentImpressionTelemetry[homeTopSite.site.url] != nil else {
+            sentImpressionTelemetry[homeTopSite.site.url] = true
+            return false
+        }
+        return true
+    }
+
     // MARK: - Context actions
 
     func hideURLFromTopSites(_ site: Site) {

--- a/Client/Frontend/Home/TopSites/FxHomeTopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/FxHomeTopSitesViewModel.swift
@@ -31,6 +31,7 @@ class FxHomeTopSitesViewModel {
 
     private let profile: Profile
     private let isZeroSearch: Bool
+    private var sentImpressionTelemetry = [String: Bool]()
 
     var sectionDimension: SectionDimension = FxHomeTopSitesViewModel.defaultDimension
     static var defaultDimension = SectionDimension(numberOfRows: 2, numberOfTilesPerRow: 6)
@@ -138,7 +139,6 @@ class FxHomeTopSitesViewModel {
         homeTopSite.impressionTracking(position: position)
     }
 
-    private var sentImpressionTelemetry = [String: Bool]()
     private func hasSentImpressionForTile(_ homeTopSite: HomeTopSite) -> Bool {
         guard sentImpressionTelemetry[homeTopSite.site.url] != nil else {
             sentImpressionTelemetry[homeTopSite.site.url] = true

--- a/Client/Frontend/Home/TopSites/HomeTopSite.swift
+++ b/Client/Frontend/Home/TopSites/HomeTopSite.swift
@@ -54,13 +54,11 @@ final class HomeTopSite {
 
     // MARK: Telemetry
 
-    private var sentSiteImpressionTelemetry = false
-
     func impressionTracking(position: Int) {
-        guard !sentSiteImpressionTelemetry, let tile = site as? SponsoredTile else { return }
+        // Only sending sponsored tile impressions for now
+        guard let tile = site as? SponsoredTile else { return }
 
         SponsoredTileTelemetry.sendImpressionTelemetry(tile: tile, position: position)
-        sentSiteImpressionTelemetry = true
     }
 
     func getTelemetrySiteType() -> String {

--- a/Client/Frontend/Home/TopSites/TopSiteCollectionCell.swift
+++ b/Client/Frontend/Home/TopSites/TopSiteCollectionCell.swift
@@ -112,6 +112,7 @@ extension TopSiteCollectionCell: UICollectionViewDelegate, UICollectionViewDataS
         if let cell = collectionView.dequeueReusableCell(cellType: TopSiteItemCell.self, for: indexPath),
            let contentItem = viewModel?.tileManager.getSite(index: indexPath.row) {
             cell.configure(contentItem, position: indexPath.row)
+            viewModel?.topSiteImpressionTelemetry(contentItem, position: indexPath.row)
             return cell
 
         } else if let cell = collectionView.dequeueReusableCell(cellType: EmptyTopSiteCell.self, for: indexPath) {

--- a/Client/Frontend/Home/TopSites/TopSiteItemCell.swift
+++ b/Client/Frontend/Home/TopSites/TopSiteItemCell.swift
@@ -161,8 +161,6 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
         configureSponsoredSite(topSite)
 
         applyTheme()
-
-        topSite.impressionTracking(position: position)
     }
 
     // MARK: - Setup Helper methods


### PR DESCRIPTION
# Issue https://github.com/mozilla-mobile/firefox-ios/issues/10813
- Adjust when impression telemetry is sent for sponsored tiles