### PR TITLE
Add FXIOS-4273 v102 Suggest passwords when manually adding new password entries

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -563,6 +563,7 @@
 		96EB6C4327DC205D00A9D159 /* SearchGroupedItemsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96EB6C4227DC205D00A9D159 /* SearchGroupedItemsViewModel.swift */; };
 		96F627002669B0D100C82340 /* FxHomeRecentlySavedCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F626FF2669B0D100C82340 /* FxHomeRecentlySavedCollectionCell.swift */; };
 		96F8DA49280452CA00E53239 /* GleanPlumbContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F8DA48280452CA00E53239 /* GleanPlumbContextProvider.swift */; };
+		9B62CBB228393F2100A9786B /* PasswordManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B62CBB128393F2100A9786B /* PasswordManager.swift */; };
 		A83E5AB71C1D993D0026D912 /* UIPasteboardExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83E5AB61C1D993D0026D912 /* UIPasteboardExtensions.swift */; };
 		A83E5B1A1C1DA8BF0026D912 /* image.gif in Resources */ = {isa = PBXBuildFile; fileRef = A83E5B181C1DA8BF0026D912 /* image.gif */; };
 		A83E5B1B1C1DA8BF0026D912 /* image.png in Resources */ = {isa = PBXBuildFile; fileRef = A83E5B191C1DA8BF0026D912 /* image.png */; };
@@ -3056,6 +3057,7 @@
 		9B2A427086AAB7D6B5301167 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/HistoryPanel.strings; sourceTree = "<group>"; };
 		9B314EEDBB87E85AFF6339D5 /* fa */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fa; path = fa.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		9B504676B0CA6CCD05D1639F /* dsb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = dsb; path = "dsb.lproj/Default Browser.strings"; sourceTree = "<group>"; };
+		9B62CBB128393F2100A9786B /* PasswordManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordManager.swift; sourceTree = "<group>"; };
 		9BA0422985D5448896A3EC26 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = "uk.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		9BAB4C0A93050A8433505859 /* dsb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = dsb; path = dsb.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		9BCB46C0B4A2E1E8E41F84C2 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -6413,6 +6415,7 @@
 				C8DFFE482294AAB600296DB1 /* NetworkUtils.swift */,
 				E65075891E37F7AB006961AC /* NotificationConstants.swift */,
 				43B137F123A181A200CB7FA0 /* NSUserDefaultsPrefs.swift */,
+				9B62CBB128393F2100A9786B /* PasswordManager.swift */,
 				E650758B1E37F7AB006961AC /* Prefs.swift */,
 				8DFA42FBB7C25AC38ACEEA0D /* PrivateBrowsing.strings */,
 				CE7F115E1F3CCEF900ABFC0B /* RemoteDevices.swift */,
@@ -8572,6 +8575,7 @@
 				E65075A51E37F7AB006961AC /* NSFileManagerExtensions.swift in Sources */,
 				E65075A11E37F7AB006961AC /* HashExtensions.swift in Sources */,
 				3964B09A1EA8F06F00F2EEF4 /* FeatureSwitch.swift in Sources */,
+				9B62CBB328393F2100A9786B /* PasswordManager.swift in Sources */,
 				E65075981E37F7AB006961AC /* Bytes.swift in Sources */,
 				E65075B11E37F7AB006961AC /* FSUtils.m in Sources */,
 				CE7F11941F3CEEC800ABFC0B /* RemoteDevices.swift in Sources */,
@@ -9324,6 +9328,7 @@
 				213B67A627CE682B000542F5 /* StartAtHomeHelper.swift in Sources */,
 				8AB8574A27D97CE90075C173 /* HomePanelDelegate.swift in Sources */,
 				3B39EDCB1E16E1AA00EF029F /* CustomSearchViewController.swift in Sources */,
+				9B62CBB228393F2100A9786B /* PasswordManager.swift in Sources */,
 				96A562A027D6D0E80045144A /* ContileProvider.swift in Sources */,
 				E65075571E37F714006961AC /* FaviconFetcher.swift in Sources */,
 				9699F77326F39E5100C5FA47 /* SiteImageHelper.swift in Sources */,

--- a/Client/Frontend/Login Management/AddCredentialViewController.swift
+++ b/Client/Frontend/Login Management/AddCredentialViewController.swift
@@ -139,6 +139,7 @@ extension AddCredentialViewController: UITableViewDataSource {
             loginCell.isEditingFieldData = true
             passwordField = loginCell.descriptionLabel
             passwordField?.accessibilityIdentifier = "passwordField"
+            passwordField?.inputAccessoryView = createSuggestedPasswordButton()
             return loginCell
 
         case .websiteItem:
@@ -252,5 +253,24 @@ extension AddCredentialViewController: LoginDetailTableViewCellDelegate {
             return item
         }
         return nil
+    }
+}
+
+// MARK: - Secure Password Generation
+
+extension AddCredentialViewController {
+    private func createSuggestedPasswordButton() -> UIButton {
+        let buttonFrame = CGRect(x: 0, y: 0, width: view.frame.size.width, height: 60)
+        let button = UIButton(frame: buttonFrame)
+        button.backgroundColor = .secondarySystemGroupedBackground
+        button.setTitle(.PasswordManager.GenerateSecurePasswordButtonTitle, for: .normal)
+        button.setTitleColor(.label, for: .normal)
+        button.addTarget(self, action: #selector(onSuggestedPasswordButtonPressed), for: .touchUpInside)
+        return button
+    }
+
+    @objc func onSuggestedPasswordButtonPressed() {
+        passwordField?.text = PasswordManager.generateSecurePassword()
+        passwordField?.endEditing(false)
     }
 }

--- a/Client/Frontend/Login Management/AddCredentialViewController.swift
+++ b/Client/Frontend/Login Management/AddCredentialViewController.swift
@@ -113,6 +113,15 @@ class AddCredentialViewController: UIViewController {
             return "https://" + website
         }
     }
+
+    private func refreshSaveButtonEnabledStatus() {
+        let enableSave =
+            !(websiteField.text?.isEmpty ?? true) &&
+            !(usernameField.text?.isEmpty ?? true) &&
+            !(passwordField.text?.isEmpty ?? true)
+
+        saveButton.isEnabled = enableSave
+    }
 }
 
 // MARK: - UITableViewDataSource
@@ -189,18 +198,15 @@ extension AddCredentialViewController: KeyboardHelperDelegate {
 // MARK: - Cell Delegate
 extension AddCredentialViewController: LoginDetailTableViewCellDelegate {
     func textFieldDidEndEditing(_ cell: LoginDetailTableViewCell) {
+        refreshSaveButtonEnabledStatus()
+
         guard cell.descriptionLabel == websiteField, let website = websiteField?.text else { return }
         websiteField.text = normalize(website: website)
     }
 
     func textFieldDidChange(_ cell: LoginDetailTableViewCell) {
         // TODO: Add validation if necessary
-        let enableSave =
-            !(websiteField.text?.isEmpty ?? true) &&
-            !(usernameField.text?.isEmpty ?? true) &&
-            !(passwordField.text?.isEmpty ?? true)
-
-        saveButton.isEnabled = enableSave
+        refreshSaveButtonEnabledStatus()
     }
 
     func canPerform(action: Selector, for cell: LoginDetailTableViewCell) -> Bool {

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -293,6 +293,13 @@ extension String {
     }
 }
 
+// MARK: - PasswordManager
+extension String {
+    public struct PasswordManager {
+        public static let GenerateSecurePasswordButtonTitle = MZLocalizedString("Generate Secure Password", comment: "This is the text that will appear on a button that can be pressed to have the app suggest a random, securely-generated password when manually entering new password entries", lastUpdated: .v102)
+    }
+}
+
 // MARK: - Passwords and Logins
 extension String {
     public struct PasswordsAndLogins {

--- a/Shared/PasswordManager.swift
+++ b/Shared/PasswordManager.swift
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+// MARK: - PasswordManager
+
+/// Class for handling the creation (and eventually other uses) of secure passwords.
+public class PasswordManager {
+
+    /// Generates a new, secure password.
+    /// The password format is modeled after Apple's securely-generated passwords:
+    /// xxxxxx-xxxxxx-xxxxxx
+    /// where one x is an uppercase letter, one x is a numeric digit, and the rest are lowercase letters.
+    public static func generateSecurePassword() -> String {
+        let numberOfAlphanumericPositions = 18
+        let separatorPositions = [6, 13]
+        var capitalLetterPosition = Int.random(in: 0..<numberOfAlphanumericPositions)
+        var numberPosition = Int.random(in: 0..<numberOfAlphanumericPositions)
+
+        // If capitalLetterPosition and numberPosition are the same, pick a new numberPosition
+        while capitalLetterPosition == numberPosition {
+            numberPosition = Int.random(in: 0..<numberOfAlphanumericPositions)
+        }
+
+        capitalLetterPosition.adjustForPasswordDashes()
+        numberPosition.adjustForPasswordDashes()
+
+        let lowercaseLetters = "abcdefghijklmnopqrstuvwxyz"
+        let uppercaseLetters = lowercaseLetters.uppercased()
+
+        var password = ""
+        for index in 0..<20 {
+            switch index {
+            case capitalLetterPosition: password.append(uppercaseLetters.randomElement()!)
+            case numberPosition: password.append("\(Int.random(in: 0...9))")
+            case let x where separatorPositions.contains(x): password.append("-")
+            default: password.append(lowercaseLetters.randomElement()!)
+            }
+        }
+
+        return password
+    }
+}
+
+extension Int {
+    /// Helper function that shifts an int to account for dashes in passwords
+    /// with the format xxxxxx-xxxxxx-xxxxxx.
+    fileprivate mutating func adjustForPasswordDashes() {
+        switch self {
+        case 12...: self += 2
+        case 6...11: self += 1
+        default: return
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a "Generate Secure Password" button above the keyboard when manually adding new password entries. To get here:

- open the hamburger menu,
- choose Passwords,
- authenticate (in the simulator you can just enter any characters for the passcode),
- tap the + button,
- then tap inside the "Password" field.

You should now see a "Generate Secure Password" button above the keyboard. When you press it, a secure password should be entered, and the keyboard should be dismissed. I modeled the password format on iOS's suggested passwords, as seen in the Settings app -> Passwords -> + button. The format is as follows:

xxxxxx-xxxxxx-xxxxxx

where one x is an uppercase letter, one x is a numeric digit, and the rest are lowercase letters.

This addresses the following feature request:

[https://github.com/mozilla-mobile/firefox-ios/issues/10810](https://github.com/mozilla-mobile/firefox-ios/issues/10810)