### PR TITLE
Bugfix fx4299 [v102] Shortcut deduping pinned tiles

### DIFF
--- a/Client/Frontend/Browser/TopSitesHelper.swift
+++ b/Client/Frontend/Browser/TopSitesHelper.swift
@@ -30,13 +30,14 @@ struct TopSitesHelper {
 
             // Fetch the default sites
             let defaultSites = defaultTopSites(profile)
-            // create PinnedSite objects. used by the view layer to tell topsites apart
+            // Create PinnedSite objects. Used by the view layer to tell topsites apart
             let pinnedSites: [Site] = pinned.map({ PinnedSite(site: $0) })
 
             // Merge default topsites with a user's topsites.
             let mergedSites = mySites.union(defaultSites, f: unionOnURL)
-            // Merge pinnedSites with sites from the previous step
-            let allSites = pinnedSites.union(mergedSites, f: unionOnURL)
+            // Filter out duplicates in merged sites, but do not remove duplicates within pinned sites
+            let duplicateFreeList = pinnedSites.union(mergedSites, f: unionOnURL).filter { $0 as? PinnedSite == nil }
+            let allSites = pinnedSites + duplicateFreeList
 
             // Favour topsites from defaultSites as they have better favicons. But keep PinnedSites
             let newSites = allSites.map { site -> Site in

--- a/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
@@ -194,6 +194,12 @@ private extension Array where Element == Site {
     mutating func removeDuplicates() {
         var alreadyThere = Set<Site>()
         let uniqueSites = compactMap { (site) -> Site? in
+            // Do not remove sponsored tiles or pinned tiles duplicates
+            guard (site as? SponsoredTile) == nil && (site as? PinnedSite) == nil else {
+                alreadyThere.insert(site)
+                return site
+            }
+
             let siteDomain = site.url.asURL?.shortDomain
             let shouldAddSite = alreadyThere.first(where: { $0.url.asURL?.shortDomain == siteDomain }) == nil
             // If shouldAddSite or site domain was not found, then insert the site

--- a/ClientTests/FxHomeTopSitesManagerTests.swift
+++ b/ClientTests/FxHomeTopSitesManagerTests.swift
@@ -63,7 +63,7 @@ class FxHomeTopSitesManagerTests: XCTestCase, FeatureFlaggable {
 
         testLoadData(manager: manager, numberOfTilesPerRow: nil) {
             XCTAssertTrue(manager.hasData)
-            XCTAssertEqual(manager.siteCount, 11)
+            XCTAssertEqual(manager.siteCount, 11, "Expects 1 google site, 10 history sites")
         }
     }
 
@@ -72,7 +72,7 @@ class FxHomeTopSitesManagerTests: XCTestCase, FeatureFlaggable {
 
         testLoadData(manager: manager, numberOfTilesPerRow: 6) {
             XCTAssertTrue(manager.hasData)
-            XCTAssertEqual(manager.siteCount, 11)
+            XCTAssertEqual(manager.siteCount, 11, "Expects 1 google site, 10 history sites")
         }
     }
 
@@ -149,7 +149,7 @@ class FxHomeTopSitesManagerTests: XCTestCase, FeatureFlaggable {
 
         testLoadData(manager: manager, numberOfTilesPerRow: 6) {
             XCTAssertTrue(manager.hasData)
-            XCTAssertEqual(manager.siteCount, 12)
+            XCTAssertEqual(manager.siteCount, 12, "Expects 1 google site, 1 contile, 10 history sites")
         }
     }
 
@@ -340,6 +340,26 @@ class FxHomeTopSitesManagerTests: XCTestCase, FeatureFlaggable {
         }
     }
 
+    // Pinned vs another Pinned of same domain
+    func testDuplicates_PinnedTilesOfSameDomainIsntDeduped() {
+        featureFlags.set(feature: .sponsoredTiles, to: true)
+
+        let manager = createManager(addPinnedSiteCount: 2, siteCount: 0)
+
+        testLoadData(manager: manager, numberOfTilesPerRow: 6) {
+            XCTAssertEqual(manager.siteCount, 3, "Should have google site and 2 pinned sites")
+            XCTAssertTrue(manager.getSite(index: 0)!.isGoogleURL)
+
+            XCTAssertFalse(manager.getSite(index: 1)!.isSponsoredTile)
+            XCTAssertTrue(manager.getSite(index: 1)!.isPinned)
+            XCTAssertEqual(manager.getSite(index: 1)!.site.url, "https://www.apinnedurl.com/pinned0")
+
+            XCTAssertFalse(manager.getSite(index: 2)!.isSponsoredTile)
+            XCTAssertTrue(manager.getSite(index: 2)!.isPinned)
+            XCTAssertEqual(manager.getSite(index: 2)!.site.url, "https://www.apinnedurl.com/pinned1")
+        }
+    }
+
     func testTopSiteManager_hasNoLeaks() {
         let topSitesManager = FxHomeTopSitesManager(profile: profile)
         let historyStub = TopSiteHistoryManagerStub(profile: profile)
@@ -410,7 +430,7 @@ extension ContileProviderMock {
     }
 
     static let pinnedTitle = "A pinned title %@"
-    static let pinnedURL = "https://www.apinnedurl%@.com"
+    static let pinnedURL = "https://www.apinnedurl.com/pinned%@"
     static let title = "A title %@"
     static let url = "https://www.aurl%@.com"
 


### PR DESCRIPTION
# Issue #10859
- Pinned sites were filtered to remove duplicates in TopSiteHelper when fetching history sites
- Made sure they are also not dedupped when filtering with Sponsored tiles in top sites manager

Following is now valid case of having multiple pinned sites of the same domain (example here with three wikipedia pinned webpage)
![Screen Shot 2022-05-26 at 2 23 20 PM](https://user-images.githubusercontent.com/11338480/170551864-aa7e68e4-5e58-446e-a15c-c3efd116cd9b.png)
 