### PR TITLE
Update app delegate access levels

### DIFF
--- a/Client/Application/AppDelegate+SyncSentTabs.swift
+++ b/Client/Application/AppDelegate+SyncSentTabs.swift
@@ -24,7 +24,7 @@ extension UIApplication {
  when the app performs a sync.
  */
 class AppSyncDelegate: SyncDelegate {
-    let app: UIApplication
+    private let app: UIApplication
 
     init(app: UIApplication) {
         self.app = app

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -31,17 +31,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     var browserViewController: BrowserViewController!
     var rootViewController: UIViewController!
-    weak var profile: Profile?
     var tabManager: TabManager!
     var applicationCleanlyBackgrounded = true
-    var shutdownWebServer: DispatchSourceTimer?
-    var orientationLock = UIInterfaceOrientationMask.all
-    weak var application: UIApplication?
-    var launchOptions: [AnyHashable: Any]?
-
     var receivedURLs = [URL]()
-    var telemetry: TelemetryWrapper?
-    var adjustHelper: AdjustHelper?
+
+    weak var profile: Profile?
+    weak var application: UIApplication?
+
+    private var shutdownWebServer: DispatchSourceTimer?
+    private var orientationLock = UIInterfaceOrientationMask.all
+    private var launchOptions: [AnyHashable: Any]?
+    private var telemetry: TelemetryWrapper?
+    private var adjustHelper: AdjustHelper?
 
     func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         //
@@ -76,7 +77,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return startApplication(application, withLaunchOptions: launchOptions)
     }
 
-    func startApplication(_ application: UIApplication, withLaunchOptions launchOptions: [AnyHashable: Any]?) -> Bool {
+    private func startApplication(_ application: UIApplication, withLaunchOptions launchOptions: [AnyHashable: Any]?) -> Bool {
         log.info("startApplication begin")
 
         // Need to get "settings.sendUsageData" this way so that Sentry can be initialized
@@ -291,7 +292,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return shouldPerformAdditionalDelegateHandling
     }
 
-    func updateSessionCount() {
+    private func updateSessionCount() {
         var sessionCount: Int32 = 0
 
         // Get the session count from preferences


### PR DESCRIPTION
Minor change to the app delegate to update the access levels of it's variables and functions.
Makes it a little easier to read what is just being used locally and what's being used by the wider app.