### PR TITLE
Bugfix FXIOS-4313 [v102] - Change sponsored shortcut 'context_id' telemetry

### DIFF
--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -685,7 +685,7 @@ top_site:
       A UUID that is unjoinable with other browser metrics. This ID will not be
       shared with AdM, only for internal uses. This ID is shared across all
       contextual services features.
-    lifetime: ping
+    lifetime: application
     send_in_pings:
       - topsites-impression
     bugs:

--- a/ClientTests/SponsoredTileTelemetryTests.swift
+++ b/ClientTests/SponsoredTileTelemetryTests.swift
@@ -120,7 +120,7 @@ class SponsoredTileTelemetryTests: XCTestCase {
                 return
             }
 
-            self.testUuidMetricMetricSuccess(metric: GleanMetrics.TopSite.contextId,
+            self.testUuidMetricSuccess(metric: GleanMetrics.TopSite.contextId,
                                              expectedValue: uuid,
                                              failureMessage: "Should have contextId of \(uuid)")
             expectation.fulfill()

--- a/ClientTests/SponsoredTileTelemetryTests.swift
+++ b/ClientTests/SponsoredTileTelemetryTests.swift
@@ -104,6 +104,31 @@ class SponsoredTileTelemetryTests: XCTestCase {
 
         waitForExpectations(timeout: 5.0)
     }
+
+    // MARK: ContexId
+    func testContextIdImpressionTopSite() {
+        SponsoredTileTelemetry.setupContextId()
+        let contile = ContileProviderMock.defaultSuccessData[0]
+        let topSite = SponsoredTile(contile: contile)
+
+        let expectation = expectation(description: "The top sites ping was sent")
+        GleanMetrics.Pings.shared.topsitesImpression.testBeforeNextSubmit { _ in
+
+            guard let contextId =  SponsoredTileTelemetry.contextId,
+                    let uuid = UUID(uuidString: contextId) else {
+                XCTFail("Expected contextId to be configured")
+                return
+            }
+
+            self.testUuidMetricMetricSuccess(metric: GleanMetrics.TopSite.contextId,
+                                             expectedValue: uuid,
+                                             failureMessage: "Should have contextId of \(uuid)")
+            expectation.fulfill()
+        }
+
+        SponsoredTileTelemetry.sendImpressionTelemetry(tile: topSite, position: 2)
+        waitForExpectations(timeout: 5.0)
+    }
 }
 
 // MARK: Helper methods

--- a/ClientTests/TelemetryWrapperTests.swift
+++ b/ClientTests/TelemetryWrapperTests.swift
@@ -239,4 +239,13 @@ extension XCTestCase {
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidState), 0)
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidValue), 0)
     }
+
+    func testUuidMetricMetricSuccess(metric: UuidMetricType,
+                              expectedValue: UUID,
+                              failureMessage: String,
+                              file: StaticString = #file,
+                              line: UInt = #line) {
+        XCTAssertTrue(metric.testHasValue(), "Should have value on uuid metric")
+        XCTAssertEqual(try! metric.testGetValue(), expectedValue, failureMessage)
+    }
 }

--- a/ClientTests/TelemetryWrapperTests.swift
+++ b/ClientTests/TelemetryWrapperTests.swift
@@ -240,7 +240,7 @@ extension XCTestCase {
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidValue), 0)
     }
 
-    func testUuidMetricMetricSuccess(metric: UuidMetricType,
+    func testUuidMetricSuccess(metric: UuidMetricType,
                               expectedValue: UUID,
                               failureMessage: String,
                               file: StaticString = #file,


### PR DESCRIPTION
Issue #10889
- Change contextId lifetime to application 
- Add unit test for UUID metric
