### PR TITLE
Fix for contile test failing on M1

### DIFF
--- a/ClientTests/ContileProviderTests.swift
+++ b/ClientTests/ContileProviderTests.swift
@@ -180,7 +180,7 @@ private extension ContileProviderTests {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [URLProtocolStub.self]
         let session = URLSession(configuration: configuration)
-        let cache = URLCache(memoryCapacity: 1000, diskCapacity: 1000, directory: URL(string: "/dev/null"))
+        let cache = URLCache(memoryCapacity: 100000, diskCapacity: 1000, directory: URL(string: "/dev/null"))
 
         let provider = ContileProvider()
         provider.urlSession = session


### PR DESCRIPTION
I have no idea why but on an M1 Mac the memory capacity set seemed to be insufficient. 
Increasing it causes the "testCaching_succeedsFromCache" test to pass.