### PR TITLE
Add FX10946 [v103] Tabs Integration Telemetry

### DIFF
--- a/ClientTests/GleanTelemetryTests.swift
+++ b/ClientTests/GleanTelemetryTests.swift
@@ -50,7 +50,7 @@ class GleanTelemetryTests: XCTestCase {
 
         _ = syncManager.syncNamedCollections(
             why: SyncReason.didLogin,
-            names: ["tabs", "logins", "bookmarks", "history"]
+            names: ["tabs", "logins", "bookmarks", "history", "clients"]
         )
 
         waitForExpectations(timeout: 5.0)

--- a/Sync/SyncTelemetryUtils.swift
+++ b/Sync/SyncTelemetryUtils.swift
@@ -438,8 +438,8 @@ public class GleanSyncOperationHelper {
 
         switch engineName {
         case "tabs":
-            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.TabsSync.incoming[l].add(Int32(v))}
-            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.TabsSync.outgoing[l].add(Int32(v)) }
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.RustTabsSync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.RustTabsSync.outgoing[l].add(Int32(v)) }
         case "bookmarks":
             incomingLabelsToValue.forEach { (l, v) in GleanMetrics.BookmarksSync.incoming[l].add(Int32(v))}
             outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.BookmarksSync.outgoing[l].add(Int32(v)) }
@@ -449,6 +449,9 @@ public class GleanSyncOperationHelper {
         case "logins":
             incomingLabelsToValue.forEach { (l, v) in GleanMetrics.LoginsSync.incoming[l].add(Int32(v))}
             outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.LoginsSync.outgoing[l].add(Int32(v)) }
+        case "clients":
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.ClientsSync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.ClientsSync.outgoing[l].add(Int32(v)) }
         default:
             break
         }
@@ -458,10 +461,11 @@ public class GleanSyncOperationHelper {
         let correctedReson = String(reason.dropFirst("sync.not_started.reason.".count))
 
         switch engineName {
-        case "tabs": GleanMetrics.TabsSync.failureReason[correctedReson].add()
+        case "tabs": GleanMetrics.RustTabsSync.failureReason[correctedReson].add()
         case "bookmarks": GleanMetrics.BookmarksSync.failureReason[correctedReson].add()
         case "history": GleanMetrics.HistorySync.failureReason[correctedReson].add()
         case "logins": GleanMetrics.LoginsSync.failureReason[correctedReson].add()
+        case "clients": GleanMetrics.ClientsSync.failureReason[correctedReson].add()
         default:
             break
         }
@@ -469,10 +473,11 @@ public class GleanSyncOperationHelper {
 
     private func submitSyncEnginePing(_ engineName: String) {
         switch engineName {
-        case "tabs": GleanMetrics.Pings.shared.tempTabsSync.submit()
+        case "tabs": GleanMetrics.Pings.shared.tempRustTabsSync.submit()
         case "bookmarks": GleanMetrics.Pings.shared.tempBookmarksSync.submit()
         case "history": GleanMetrics.Pings.shared.tempHistorySync.submit()
         case "logins": GleanMetrics.Pings.shared.tempLoginsSync.submit()
+        case "clients": GleanMetrics.Pings.shared.tempClientsSync.submit()
         default:
             break
         }

--- a/Sync/metrics.yaml
+++ b/Sync/metrics.yaml
@@ -417,3 +417,185 @@ tabs_sync:
       - sync-core@mozilla.com
     expires: 2023-01-01
     lifetime: ping
+
+rust_tabs_sync:
+  uid:
+    type: string
+    description: >
+      The user's hashed Firefox Account ID.
+    send_in_pings:
+      - temp-rust-tabs-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3170
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10915#issuecomment-1155681760
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-07
+    lifetime: ping
+  incoming:
+    type: labeled_counter
+    labels:
+      - applied
+      - failed_to_apply
+      - reconciled
+    description: >
+      Records incoming tabs record counts. `applied` is the number of
+      incoming records that were successfully stored or updated in the
+      local database. `failed_to_apply` is the number of records that were
+      ignored due to errors. `reconciled` is the number of merged records.
+    send_in_pings:
+      - temp-rust-tabs-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3170
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10915#issuecomment-1155681760
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-07
+    lifetime: ping
+  outgoing:
+    type: labeled_counter
+    labels:
+      - uploaded
+      - failed_to_upload
+    description: >
+      Records outgoing tabs record counts. `uploaded` is the number of
+      records that were successfully sent to the server. `failed_to_upload`
+      is the number of records that weren't uploaded, and will be retried
+      on the next sync.
+    send_in_pings:
+      - temp-rust-tabs-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3170
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10915#issuecomment-1155681760
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-07
+    lifetime: ping
+  failure_reason:
+    type: labeled_counter
+    labels:
+      - no_account
+      - offline
+      - backoff
+      - remotely_not_enabled
+      - format_outdated
+      - format_too_new
+      - storage_format_outdated
+      - storage_format_too_new
+      - state_machine_not_ready
+      - red_light
+      - unknown
+    description: >
+      Records why the tabs sync failed.
+    send_in_pings:
+      - temp-rust-tabs-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3170
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10915#issuecomment-1155681760
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-07
+    lifetime: ping
+
+clients_sync:
+  uid:
+    type: string
+    description: >
+      The user's hashed Firefox Account ID.
+    send_in_pings:
+      - temp-clients-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3170
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10915#issuecomment-1155681760
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-07
+    lifetime: ping
+  incoming:
+    type: labeled_counter
+    labels:
+      - applied
+      - failed_to_apply
+      - reconciled
+    description: >
+      Records incoming clients record counts. `applied` is the number of
+      incoming records that were successfully stored or updated in the
+      local database. `failed_to_apply` is the number of records that were
+      ignored due to errors. `reconciled` is the number of merged records.
+    send_in_pings:
+      - temp-clients-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3170
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10915#issuecomment-1155681760
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-07
+    lifetime: ping
+  outgoing:
+    type: labeled_counter
+    labels:
+      - uploaded
+      - failed_to_upload
+    description: >
+      Records outgoing clients record counts. `uploaded` is the number of
+      records that were successfully sent to the server. `failed_to_upload`
+      is the number of records that weren't uploaded, and will be retried
+      on the next sync.
+    send_in_pings:
+      - temp-clients-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3170
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10915#issuecomment-1155681760
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-07
+    lifetime: ping
+  failure_reason:
+    type: labeled_counter
+    labels:
+      - no_account
+      - offline
+      - backoff
+      - remotely_not_enabled
+      - format_outdated
+      - format_too_new
+      - storage_format_outdated
+      - storage_format_too_new
+      - state_machine_not_ready
+      - red_light
+      - unknown
+    description: >
+      Records why the clients sync failed.
+    send_in_pings:
+      - temp-clients-sync
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-3170
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10915#issuecomment-1155681760
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-core@mozilla.com
+    expires: 2023-01-07
+    lifetime: ping

--- a/Sync/pings.yaml
+++ b/Sync/pings.yaml
@@ -75,3 +75,29 @@ temp-tabs-sync:
     - sync-core@mozilla.com
   data_reviews:
     - https://github.com/mozilla-mobile/firefox-ios/pull/10353#issuecomment-1087532698
+temp-rust-tabs-sync:
+  description: >
+    A ping sent for every Tabs engine sync performed by the
+    application services tabs component.
+    It doesn't include the `client_id` because it reports
+    a hashed version of the user's Firefox Account ID.
+  include_client_id: false
+  bugs:
+    - https://mozilla-hub.atlassian.net/browse/SYNC-3170
+  notification_emails:
+    - sync-core@mozilla.com
+  data_reviews:
+    - https://github.com/mozilla-mobile/firefox-ios/pull/10915#issuecomment-1155681760
+temp-clients-sync:
+  description: >
+    A ping sent for every Clients engine sync performed by the
+    application services clients component.
+    It doesn't include the `client_id` because it reports
+    a hashed version of the user's Firefox Account ID.
+  include_client_id: false
+  bugs:
+    - https://mozilla-hub.atlassian.net/browse/SYNC-3170
+  notification_emails:
+    - sync-core@mozilla.com
+  data_reviews:
+    - https://github.com/mozilla-mobile/firefox-ios/pull/10915#issuecomment-1155681760


### PR DESCRIPTION
This PR is based on #10553 and should only be merged after that PR has been merged. This PR creates telemetry to help track the sync success metrics of the appservices tabs component and the native clients engine.
