### PR TITLE
Fix flaky unit test

### DIFF
--- a/ClientTests/RatingPromptManagerTests.swift
+++ b/ClientTests/RatingPromptManagerTests.swift
@@ -20,6 +20,9 @@ class RatingPromptManagerTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
+        if let bundleID = Bundle.main.bundleIdentifier {
+            UserDefaults.standard.removePersistentDomain(forName: bundleID)
+        }
         urlOpenerSpy = URLOpenerSpy()
     }
 


### PR DESCRIPTION
One of the tests in RatingPromptManagerTests was failing for me aprox 1 in 3 times. It seems the NSUserDefaults are not being reset so some tests can impact other tests. This change resets it before each test in this class.