### PR TITLE
Bugfix fx4259 [v102] Leave overlay mode after undoing closed tabs

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -201,6 +201,10 @@ class BrowserViewController: UIViewController {
         applyTheme()
     }
 
+    @objc func didTapUndoCloseAllTabToast(notification: Notification) {
+        leaveOverlayMode(didCancel: true)
+    }
+
     @objc func searchBarPositionDidChange(notification: Notification) {
         guard let dict = notification.object as? NSDictionary,
               let newSearchBarPosition = dict[PrefsKeys.FeatureFlags.SearchBarPosition] as? SearchBarPosition,
@@ -450,6 +454,8 @@ class BrowserViewController: UIViewController {
                                                name: .DisplayThemeChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(searchBarPositionDidChange),
                                                name: .SearchBarPositionDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(didTapUndoCloseAllTabToast),
+                                               name: .DidTapUndoCloseAllTabToast, object: nil)
     }
 
     func addSubviews() {


### PR DESCRIPTION
After the user will tap undo for the close all tabs option, the tabs will be restore and the url bar will not be focused anymore and the keyboard will not be displayed.

## Commit message 

Bugfix FXIOS-4259 [v102] -The URL is focused and the keyboard is displayed after undoing closed tabs