### PR TITLE
Bugfix fx4347 [v102] Fix show all button clicks on homepage

### DIFF
--- a/Client/Frontend/Components/ActionButton.swift
+++ b/Client/Frontend/Components/ActionButton.swift
@@ -6,7 +6,11 @@ import Foundation
 
 // A conveniance button class to add a closure as an action on a button instead of a selector
 class ActionButton: UIButton {
-    var touchUpAction: ((UIButton) -> Void)?
+    var touchUpAction: ((UIButton) -> Void)? {
+        didSet {
+            setupButton()
+        }
+    }
 
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:)") }
     override init(frame: CGRect) {
@@ -14,7 +18,7 @@ class ActionButton: UIButton {
         setupButton()
     }
 
-    func setupButton() {
+    private func setupButton() {
         addTarget(self, action: #selector(touchUpInside), for: .touchUpInside)
     }
 


### PR DESCRIPTION
Fix action not being set again on button. Target was removed on prepareForReuse, then action was not set again (even if the closure was set properly). Adding a didSet to fix that.