### PR TITLE
Refactor FXIOS-4367 [v101.1] Use `top_sites` rather than `top_site` as the key for all Top Sites telemetry

### DIFF
--- a/Client/Telemetry/SponsoredTileTelemetry.swift
+++ b/Client/Telemetry/SponsoredTileTelemetry.swift
@@ -28,31 +28,31 @@ class SponsoredTileTelemetry {
     static func setupContextId() {
         // Use existing client UUID, if doesn't exists create a new one
         if let stringContextId = contextId, let clientUUID = UUID(uuidString: stringContextId) {
-            GleanMetrics.TopSite.contextId.set(clientUUID)
+            GleanMetrics.TopSites.contextId.set(clientUUID)
         } else {
             let newUUID = UUID()
-            GleanMetrics.TopSite.contextId.set(newUUID)
+            GleanMetrics.TopSites.contextId.set(newUUID)
             contextId = newUUID.uuidString
         }
     }
 
     static func sendImpressionTelemetry(tile: SponsoredTile, position: Int) {
-        let extra = GleanMetrics.TopSite.ContileImpressionExtra(position: Int32(position), source: SponsoredTileTelemetry.source)
-        GleanMetrics.TopSite.contileImpression.record(extra)
+        let extra = GleanMetrics.TopSites.ContileImpressionExtra(position: Int32(position), source: SponsoredTileTelemetry.source)
+        GleanMetrics.TopSites.contileImpression.record(extra)
 
-        GleanMetrics.TopSite.contileTileId.set(Int64(tile.tileId))
-        GleanMetrics.TopSite.contileAdvertiser.set(tile.title)
-        GleanMetrics.TopSite.contileReportingUrl.set(tile.impressionURL)
+        GleanMetrics.TopSites.contileTileId.set(Int64(tile.tileId))
+        GleanMetrics.TopSites.contileAdvertiser.set(tile.title)
+        GleanMetrics.TopSites.contileReportingUrl.set(tile.impressionURL)
         GleanMetrics.Pings.shared.topsitesImpression.submit()
     }
 
     static func sendClickTelemetry(tile: SponsoredTile, position: Int) {
-        let extra = GleanMetrics.TopSite.ContileClickExtra(position: Int32(position), source: SponsoredTileTelemetry.source)
-        GleanMetrics.TopSite.contileClick.record(extra)
+        let extra = GleanMetrics.TopSites.ContileClickExtra(position: Int32(position), source: SponsoredTileTelemetry.source)
+        GleanMetrics.TopSites.contileClick.record(extra)
 
-        GleanMetrics.TopSite.contileTileId.set(Int64(tile.tileId))
-        GleanMetrics.TopSite.contileAdvertiser.set(tile.title)
-        GleanMetrics.TopSite.contileReportingUrl.set(tile.clickURL)
+        GleanMetrics.TopSites.contileTileId.set(Int64(tile.tileId))
+        GleanMetrics.TopSites.contileAdvertiser.set(tile.title)
+        GleanMetrics.TopSites.contileReportingUrl.set(tile.clickURL)
         GleanMetrics.Pings.shared.topsitesImpression.submit()
     }
 }

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -584,18 +584,18 @@ extension TelemetryWrapper {
         // MARK: Top Site
         case (.action, .tap, .topSiteTile, _, let extras):
             if let homePageOrigin = extras?[EventExtraKey.fxHomepageOrigin.rawValue] as? String {
-                GleanMetrics.TopSite.pressedTileOrigin[homePageOrigin].add()
+                GleanMetrics.TopSites.pressedTileOrigin[homePageOrigin].add()
             }
 
             if let position = extras?[EventExtraKey.topSitePosition.rawValue] as? String, let tileType = extras?[EventExtraKey.topSiteTileType.rawValue] as? String {
-                GleanMetrics.TopSite.tilePressed.record(GleanMetrics.TopSite.TilePressedExtra(position: position, tileType: tileType))
+                GleanMetrics.TopSites.tilePressed.record(GleanMetrics.TopSites.TilePressedExtra(position: position, tileType: tileType))
             } else {
                 recordUninstrumentedMetrics(category: category, method: method, object: object, value: value, extras: extras)
             }
 
         case (.action, .view, .topSiteContextualMenu, _, let extras):
             if let type = extras?[EventExtraKey.contextualMenuType.rawValue] as? String {
-                GleanMetrics.TopSite.contextualMenu.record(GleanMetrics.TopSite.ContextualMenuExtra(type: type))
+                GleanMetrics.TopSites.contextualMenu.record(GleanMetrics.TopSites.ContextualMenuExtra(type: type))
             } else {
                 recordUninstrumentedMetrics(category: category, method: method, object: object, value: value, extras: extras)
             }

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -623,7 +623,7 @@ onboarding:
     expires: "2023-01-01"
 
 # Top Site
-top_site:
+top_sites:
   tile_pressed:
     type: event
     description: |


### PR DESCRIPTION
Use `top_sites` rather than `top_site` as the key for all Top Sites telemetry