### PR TITLE
Bugfix FXIOS-4353 [v102] Reload on rotation done after trait collection changed on iPhone, keep the same for iPad

### DIFF
--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -132,7 +132,10 @@ class FirefoxHomeViewController: UIViewController, HomePanel, GleanPlumbMessageM
         super.viewWillTransition(to: size, with: coordinator)
 
         wallpaperView.updateImageForOrientationChange()
-        reloadOnRotation()
+
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            reloadOnRotation()
+        }
 
         // Adjust home tab banner height on rotation
         homeTabBanner?.adjustMaxHeight(size.height * 0.6)
@@ -141,6 +144,11 @@ class FirefoxHomeViewController: UIViewController, HomePanel, GleanPlumbMessageM
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         applyTheme()
+
+        if previousTraitCollection?.horizontalSizeClass != traitCollection.horizontalSizeClass
+            || previousTraitCollection?.verticalSizeClass != traitCollection.verticalSizeClass {
+            reloadOnRotation()
+        }
     }
 
     // MARK: - Layout
@@ -222,6 +230,9 @@ class FirefoxHomeViewController: UIViewController, HomePanel, GleanPlumbMessageM
 
     // MARK: - Helpers
 
+    /// On iPhone, we call reloadOnRotation when the trait collection has changed, to ensure calculation
+    /// is done with the new trait. On iPad, trait collection doesn't change from portrait to landscape (and vice-verse)
+    /// since it's `.regular` on both. We reloadOnRotation from viewWillTransition in that case.
     private func reloadOnRotation() {
         if let _ = self.presentedViewController as? PhotonActionSheet {
             presentedViewController?.dismiss(animated: false, completion: nil)

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -231,7 +231,7 @@ class FirefoxHomeViewController: UIViewController, HomePanel, GleanPlumbMessageM
     // MARK: - Helpers
 
     /// On iPhone, we call reloadOnRotation when the trait collection has changed, to ensure calculation
-    /// is done with the new trait. On iPad, trait collection doesn't change from portrait to landscape (and vice-verse)
+    /// is done with the new trait. On iPad, trait collection doesn't change from portrait to landscape (and vice-versa)
     /// since it's `.regular` on both. We reloadOnRotation from viewWillTransition in that case.
     private func reloadOnRotation() {
         if let _ = self.presentedViewController as? PhotonActionSheet {


### PR DESCRIPTION
# Issue #10949    
### Original problem
We were calling reloadOnRotation to invalidate layout of the collection view on viewWillTransition. The thing is that, at that point the trait collection hasn't changed yet so new layout is calculated with the wrong trait. The collection view then expected a certain number of cells and was crashing because of that. Could easily be reproduced on iPhone 12, on iPhone 11 was harder to reproduce for some reasons. 

### Proposed solution
On iPhone, we call reloadOnRotation when the trait collection has changed, to ensure calculation is done with the new trait. On iPad, trait collection doesn't change from portrait to landscape (and vice-versa) since it's `.regular` on both. We reloadOnRotation from viewWillTransition in that case.