### PR TITLE
Bugfix FXIOS-4356 [v102] The onboarding bullets are selected incorrectly when swiping to change to the next slide

### DIFF
--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -192,6 +192,15 @@ extension IntroViewController: OnboardingCardDelegate {
         }
     }
 
+    // Extra step to make sure pageControl.currentPage is the right index card
+    // because UIPageViewControllerDataSource call fails
+    func pageChanged(_ cardType: IntroViewModel.OnboardingCards) {
+        if let cardIndex = viewModel.enabledCards.firstIndex(of: cardType),
+           cardIndex != pageControl.currentPage {
+            pageControl.currentPage = cardIndex
+        }
+    }
+
     private func presentSignToSync(_ fxaOptions: FxALaunchParams? = nil,
                                   flowType: FxAPageType = .emailLoginFlow,
                                   referringPage: ReferringPage = .onboarding) {

--- a/Client/Frontend/Intro/OnboardingCardViewController.swift
+++ b/Client/Frontend/Intro/OnboardingCardViewController.swift
@@ -7,6 +7,7 @@ import UIKit
 protocol OnboardingCardDelegate: AnyObject {
     func showNextPage(_ cardType: IntroViewModel.OnboardingCards)
     func primaryAction(_ cardType: IntroViewModel.OnboardingCards)
+    func pageChanged(_ cardType: IntroViewModel.OnboardingCards)
 }
 
 class OnboardingCardViewController: UIViewController {
@@ -144,6 +145,7 @@ class OnboardingCardViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
+        delegate?.pageChanged(viewModel.cardType)
         viewModel.sendCardViewTelemetry()
     }
 


### PR DESCRIPTION
Issue #10953 

- Sync pageControl.currentPage with delegate from viewWillAppear
- Fix limitation with UIPageViewController where delegates functions were not called when scrolling fast
- Another possible solution is to use `presentationCount` & `presentationIndex` usign embeded UIPageControl from UIPageViewController but the appearance can't be easily customized