### PR TITLE
Bugfix FXIOS-4385 [v102] Jump back in crash

### DIFF
--- a/Client/Frontend/Home/FirefoxHomeViewModel.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewModel.swift
@@ -121,9 +121,6 @@ class FirefoxHomeViewModel: FeatureFlaggable {
 
     private func updateData(section: FXHomeViewModelProtocol) {
         section.updateData {
-            // Once section has data loaded with new data, we check if it needs to show
-            guard section.shouldShow else { return }
-
             self.delegate?.reloadSection(section: section)
         }
     }

--- a/Client/Frontend/Home/JumpBackIn/FxHomeJumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/FxHomeJumpBackInViewModel.swift
@@ -319,8 +319,10 @@ extension FirefoxHomeJumpBackInViewModel: FxHomeSectionHandler {
         if indexPath.row == (jumpBackInList.itemsToDisplay - 1),
            let group = jumpBackInList.group {
             configureCellForGroups(group: group, cell: jumpBackInCell, indexPath: indexPath)
+        } else if let item = jumpBackInList.tabs[safe: indexPath.row] {
+            configureCellForTab(item: item, cell: jumpBackInCell, indexPath: indexPath)
         } else {
-            configureCellForTab(item: jumpBackInList.tabs[indexPath.row], cell: jumpBackInCell, indexPath: indexPath)
+            return UICollectionViewCell()
         }
 
         return cell


### PR DESCRIPTION
# [FXIOS-4385](https://github.com/mozilla-mobile/firefox-ios/issues/11010)
- Safe unwrap cell index
- Reload section to remove it if it has no data, should show check needs to be removed
