### PR TITLE
FXIOS-4382 - Update linker settings to come from the XCConfig files

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -13085,11 +13085,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E60961891B62B8C800DD640F /* Firefox.xcconfig */;
 			buildSettings = {
-				OTHER_LDFLAGS = (
-					"-ObjC",
-					"-lxml2",
-					"-fprofile-instr-generate",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				VALIDATE_WORKSPACE = YES;
 			};
 			name = Firefox;
@@ -13383,11 +13379,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E6DCC1ED1DCBB6AA00CEC4B7 /* Fennec.enterprise.xcconfig */;
 			buildSettings = {
-				OTHER_LDFLAGS = (
-					"-ObjC",
-					"-lxml2",
-					"-fprofile-instr-generate",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				VALIDATE_WORKSPACE = YES;
 			};
 			name = Fennec_Enterprise;
@@ -13647,11 +13639,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E6FCC43C1C40565200DF6113 /* FirefoxBeta.xcconfig */;
 			buildSettings = {
-				OTHER_LDFLAGS = (
-					"-ObjC",
-					"-lxml2",
-					"-fprofile-instr-generate",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				VALIDATE_WORKSPACE = YES;
 			};
 			name = FirefoxBeta;
@@ -14136,11 +14124,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E60961861B62B8A700DD640F /* Fennec.xcconfig */;
 			buildSettings = {
-				OTHER_LDFLAGS = (
-					"-ObjC",
-					"-lxml2",
-					"-fprofile-instr-generate",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				VALIDATE_WORKSPACE = YES;
 			};
 			name = Fennec;

--- a/Client/Configuration/Fennec.xcconfig
+++ b/Client/Configuration/Fennec.xcconfig
@@ -14,3 +14,4 @@ MOZ_TODAY_WIDGET_SEARCH_DISPLAY_NAME = Firefox - Search
 CODE_SIGN_ENTITLEMENTS = Client/Entitlements/FennecApplication.entitlements
 OTHER_SWIFT_FLAGS = $(OTHER_SWIFT_FLAGS_common) -DMOZ_CHANNEL_FENNEC
 MOZ_INTERNAL_URL_SCHEME = fennec
+OTHER_LDFLAGS = -ObjC -lxml2 -fprofile-instr-generate


### PR DESCRIPTION
Addresses #11006 
Set the project settings to use $(inherited) and moved the linker settings to the XCConfig files.
