### PR TITLE
Add #11022 [v101] Improve DownloadHelper

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -413,6 +413,7 @@
 		6669B5E2211418A200CA117B /* WebsiteDataSearchResultsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6669B5E1211418A200CA117B /* WebsiteDataSearchResultsViewController.swift */; };
 		66CE54A820FCF6CF00CC310B /* WebsiteDataManagementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CE54A720FCF6CF00CC310B /* WebsiteDataManagementViewController.swift */; };
 		6A3E5D8A283831D1001E706E /* DownloadQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A3E5D89283831D0001E706E /* DownloadQueueTests.swift */; };
+		6ADB651B285C03B100947EA4 /* DownloadHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ADB651A285C03B100947EA4 /* DownloadHelperTests.swift */; };
 		742A56391D80B54A00BDB803 /* PhotonActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742A56381D80B54A00BDB803 /* PhotonActionSheet.swift */; };
 		744B0FFE1B4F172E00100422 /* ToolbarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 744B0FFD1B4F172E00100422 /* ToolbarTests.swift */; };
 		744ED5611DBFEB8D00A2B5BE /* MailtoLinkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 744ED5601DBFEB8D00A2B5BE /* MailtoLinkHandler.swift */; };
@@ -2579,6 +2580,7 @@
 		6A8B40A7B8B0933B706C84B0 /* or */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = or; path = or.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		6A954888A18B54ED87980F19 /* af */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/Intro.strings; sourceTree = "<group>"; };
 		6AD94362821BDAD94165D610 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/Intro.strings"; sourceTree = "<group>"; };
+		6ADB651A285C03B100947EA4 /* DownloadHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadHelperTests.swift; sourceTree = "<group>"; };
 		6B0545D197CACC8F242FBBC4 /* lt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lt; path = lt.lproj/Search.strings; sourceTree = "<group>"; };
 		6B3544D1B561ECE6950C5377 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		6B894CC2AD9132680E071DB1 /* bs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bs; path = bs.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -7042,6 +7044,7 @@
 				C8501F5028510DA1003B09AB /* WallpaperMigrationUtilityTests.swift */,
 				E4CD9F1C1A6D9C2800318571 /* WebServerTests.swift */,
 				D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */,
+				6ADB651A285C03B100947EA4 /* DownloadHelperTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -9593,6 +9596,7 @@
 				8A5C3BC5282ABF8E003A8CCF /* RemoteTabsPanelTests.swift in Sources */,
 				D8EFFA261FF702A8001D3A09 /* NavigationRouterTests.swift in Sources */,
 				63306D452110BAF000F25400 /* TabManagerStoreTests.swift in Sources */,
+				6ADB651B285C03B100947EA4 /* DownloadHelperTests.swift in Sources */,
 				8A6B77CC2811C468001110D2 /* URLProtocolStub.swift in Sources */,
 				8AB1128C2820496500C3A820 /* SiteImageHelperTests.swift in Sources */,
 				CA7BD568248189E800A0A61B /* BreachAlertsTests.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -611,13 +611,19 @@ extension BrowserViewController: WKNavigationDelegate {
         }
 
         // Check if this response should be downloaded.
-        if let downloadHelper = DownloadHelper(request: request, response: response, cookieStore: cookieStore, canShowInWebView: canShowInWebView, forceDownload: forceDownload, browserViewController: self) {
+        if let downloadHelper = DownloadHelper(request: request, response: response, cookieStore: cookieStore, canShowInWebView: canShowInWebView, forceDownload: forceDownload) {
             // Clear the pending download web view so that subsequent navigations from the same
             // web view don't invoke another download.
             pendingDownloadWebView = nil
 
+            let downloadAction: (HTTPDownload) -> Void = { [weak self] download in
+                self?.downloadQueue.enqueue(download)
+            }
+
             // Open our helper and cancel this response from the webview.
-            downloadHelper.open()
+            if let downloadViewModel = downloadHelper.downloadViewModel(okAction: downloadAction) {
+                presentSheetWith(viewModel: downloadViewModel, on: self, from: urlBar)
+            }
             decisionHandler(.cancel)
             return
         }

--- a/ClientTests/DownloadHelperTests.swift
+++ b/ClientTests/DownloadHelperTests.swift
@@ -70,6 +70,15 @@ class DownloadHelperTests: XCTestCase {
         XCTAssertNil(downloadViewModel)
     }
 
+    func test_downloadViewModel_deliversCorrectTitle() {
+        let response = anyResponse(urlString: "http://some-domain.com/some-image.jpg")
+        let sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: true, forceDownload: false)
+
+        let downloadViewModel = sut?.downloadViewModel(okAction: { _ in })
+
+        XCTAssertEqual(downloadViewModel!.title!, "some-image.jpg")
+    }
+
     // MARK: - Helpers
 
     private func anyRequest(urlString: String = "http://any-url.com") -> URLRequest {
@@ -78,6 +87,10 @@ class DownloadHelperTests: XCTestCase {
 
     private func anyResponse(mimeType: String?) -> URLResponse {
         return URLResponse(url: URL(string: "http://any-url.com")!, mimeType: mimeType, expectedContentLength: 10, textEncodingName: nil)
+    }
+
+    private func anyResponse(urlString: String) -> URLResponse {
+        return URLResponse(url: URL(string: urlString)!, mimeType: nil, expectedContentLength: 10, textEncodingName: nil)
     }
 
     private func cookieStore() -> WKHTTPCookieStore {

--- a/ClientTests/DownloadHelperTests.swift
+++ b/ClientTests/DownloadHelperTests.swift
@@ -79,6 +79,14 @@ class DownloadHelperTests: XCTestCase {
         XCTAssertEqual(downloadViewModel!.title!, "some-image.jpg")
     }
 
+    func test_downloadViewModel_deliversCorrectCancelButtonTitle() {
+        let sut = DownloadHelper(request: anyRequest(), response: anyResponse(mimeType: nil), cookieStore: cookieStore(), canShowInWebView: true, forceDownload: false)
+
+        let downloadViewModel = sut?.downloadViewModel(okAction: { _ in })
+
+        XCTAssertEqual(downloadViewModel!.closeButtonTitle, .CancelString)
+    }
+
     // MARK: - Helpers
 
     private func anyRequest(urlString: String = "http://any-url.com") -> URLRequest {

--- a/ClientTests/DownloadHelperTests.swift
+++ b/ClientTests/DownloadHelperTests.swift
@@ -1,0 +1,99 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Foundation
+import WebKit
+@testable import Client
+
+class DownloadHelperTests: XCTestCase {
+
+    func test_init_whenMIMETypeIsNil_initializeCorrectly() {
+        let response = anyResponse(mimeType: nil)
+
+        var sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: true, forceDownload: false)
+        XCTAssertNotNil(sut)
+
+        sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: false, forceDownload: true)
+        XCTAssertNotNil(sut)
+
+        sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: false, forceDownload: false)
+        XCTAssertNotNil(sut)
+
+        sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: true, forceDownload: true)
+        XCTAssertNotNil(sut)
+    }
+
+    func test_init_whenMIMETypeIsNotOctetStream_initializeCorrectly() {
+        for mimeType in allMIMETypes() {
+            if mimeType == MIMEType.OctetStream { continue }
+
+            let response = anyResponse(mimeType: mimeType)
+
+            var sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: true, forceDownload: false)
+            XCTAssertNil(sut)
+
+            sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: false, forceDownload: true)
+            XCTAssertNotNil(sut)
+
+            sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: false, forceDownload: false)
+            XCTAssertNotNil(sut)
+
+            sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: true, forceDownload: true)
+            XCTAssertNotNil(sut)
+        }
+    }
+
+    func test_init_whenMIMETypeIsOctetStream_initializeCorrectly() {
+        let response = anyResponse(mimeType: MIMEType.OctetStream)
+
+        var sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: true, forceDownload: false)
+        XCTAssertNotNil(sut)
+
+        sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: false, forceDownload: true)
+        XCTAssertNotNil(sut)
+
+        sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: true, forceDownload: true)
+        XCTAssertNotNil(sut)
+
+        sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: false, forceDownload: false)
+        XCTAssertNotNil(sut)
+    }
+
+    // MARK: - Helpers
+
+    private func anyRequest() -> URLRequest {
+        return URLRequest(url: URL(string: "http://any-url.com")!, cachePolicy: anyCachePolicy(), timeoutInterval: 60.0)
+    }
+
+    private func anyResponse(mimeType: String?) -> URLResponse {
+        return URLResponse(url: URL(string: "http://any-url.com")!, mimeType: mimeType, expectedContentLength: 10, textEncodingName: nil)
+    }
+
+    private func cookieStore() -> WKHTTPCookieStore {
+        return WKWebsiteDataStore.`default`().httpCookieStore
+    }
+
+    private func anyCachePolicy() -> URLRequest.CachePolicy {
+        return .useProtocolCachePolicy
+    }
+
+    private func allMIMETypes() -> [String] {
+        return [MIMEType.Bitmap,
+                MIMEType.CSS,
+                MIMEType.GIF,
+                MIMEType.JavaScript,
+                MIMEType.JPEG,
+                MIMEType.HTML,
+                MIMEType.OctetStream,
+                MIMEType.Passbook,
+                MIMEType.PDF,
+                MIMEType.PlainText,
+                MIMEType.PNG,
+                MIMEType.WebP,
+                MIMEType.Calendar,
+                MIMEType.USDZ,
+                MIMEType.Reality]
+    }
+}

--- a/ClientTests/DownloadHelperTests.swift
+++ b/ClientTests/DownloadHelperTests.swift
@@ -61,10 +61,19 @@ class DownloadHelperTests: XCTestCase {
         XCTAssertNotNil(sut)
     }
 
+    func test_downloadViewModel_whenRequestURLIsWrong_deliversEmptyResult() {
+        let request = anyRequest(urlString: "wrong-url.com")
+        let sut = DownloadHelper(request: request, response: anyResponse(mimeType: nil), cookieStore: cookieStore(), canShowInWebView: true, forceDownload: false)
+
+        let downloadViewModel = sut?.downloadViewModel(okAction: { _ in })
+
+        XCTAssertNil(downloadViewModel)
+    }
+
     // MARK: - Helpers
 
-    private func anyRequest() -> URLRequest {
-        return URLRequest(url: URL(string: "http://any-url.com")!, cachePolicy: anyCachePolicy(), timeoutInterval: 60.0)
+    private func anyRequest(urlString: String = "http://any-url.com") -> URLRequest {
+        return URLRequest(url: URL(string: urlString)!, cachePolicy: anyCachePolicy(), timeoutInterval: 60.0)
     }
 
     private func anyResponse(mimeType: String?) -> URLResponse {


### PR DESCRIPTION
Reference: https://github.com/mozilla-mobile/firefox-ios/issues/11022

- Improve DownloadHelper by decoupling it from BrowserViewController and injecting a closure instead, for download button action. This also makes the component more easy to test.

- Implement unit test for DownloadHelper.