### PR TITLE
Add fxiOS-4225 [v103] Pass Adjust attribution parameters to the first session ping in Firefox iOS

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -6972,6 +6972,7 @@
 		F84B21D61A090F8100AAB793 /* ClientTests */ = {
 			isa = PBXGroup;
 			children = (
+				2165B2BF2860BB41004C0786 /* AdjustTelemetryHelperTests.swift */,
 				CA7BD564248185B500A0A61B /* BreachAlertsTests.swift */,
 				8ADED7EB27691351009C19E6 /* CalendarExtensionsTests.swift */,
 				F84B21D91A090F8100AAB793 /* ClientTests.swift */,
@@ -7050,7 +7051,6 @@
 				C8501F5028510DA1003B09AB /* WallpaperMigrationUtilityTests.swift */,
 				E4CD9F1C1A6D9C2800318571 /* WebServerTests.swift */,
 				D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */,
-				2165B2BF2860BB41004C0786 /* AdjustTelemetryHelperTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -78,6 +78,9 @@
 		215B458027D7FD7D00E5E800 /* TabGroupData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215B457E27D7FD4B00E5E800 /* TabGroupData.swift */; };
 		215B458227DA420400E5E800 /* TabMetadataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215B458127DA420400E5E800 /* TabMetadataManager.swift */; };
 		215B458427DA87FC00E5E800 /* TabMetadataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215B458327DA87FC00E5E800 /* TabMetadataManagerTests.swift */; };
+		2165B2C02860BB41004C0786 /* AdjustTelemetryHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2165B2BF2860BB41004C0786 /* AdjustTelemetryHelperTests.swift */; };
+		2165B2C22860C2F4004C0786 /* AdjustTelemetryHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2165B2C12860C2F4004C0786 /* AdjustTelemetryHelper.swift */; };
+		2165B2C42860CB34004C0786 /* MockAdjustTelemetryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2165B2C32860CB34004C0786 /* MockAdjustTelemetryData.swift */; };
 		217AEF76284666D4004EED37 /* IntroViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217AEF75284666D4004EED37 /* IntroViewModelTests.swift */; };
 		217AEF7828480844004EED37 /* ResizableButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217AEF7728480844004EED37 /* ResizableButton.swift */; };
 		21A7C44E283539170071D996 /* IntroViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A7C44D283539170071D996 /* IntroViewModel.swift */; };
@@ -1800,6 +1803,9 @@
 		215B457E27D7FD4B00E5E800 /* TabGroupData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabGroupData.swift; sourceTree = "<group>"; };
 		215B458127DA420400E5E800 /* TabMetadataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabMetadataManager.swift; sourceTree = "<group>"; };
 		215B458327DA87FC00E5E800 /* TabMetadataManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabMetadataManagerTests.swift; sourceTree = "<group>"; };
+		2165B2BF2860BB41004C0786 /* AdjustTelemetryHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustTelemetryHelperTests.swift; sourceTree = "<group>"; };
+		2165B2C12860C2F4004C0786 /* AdjustTelemetryHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustTelemetryHelper.swift; sourceTree = "<group>"; };
+		2165B2C32860CB34004C0786 /* MockAdjustTelemetryData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAdjustTelemetryData.swift; sourceTree = "<group>"; };
 		217AEF75284666D4004EED37 /* IntroViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewModelTests.swift; sourceTree = "<group>"; };
 		217AEF7728480844004EED37 /* ResizableButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizableButton.swift; sourceTree = "<group>"; };
 		2194437EA9B44A00EDC037FA /* gu-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "gu-IN"; path = "gu-IN.lproj/FindInPage.strings"; sourceTree = "<group>"; };
@@ -5314,6 +5320,7 @@
 			isa = PBXGroup;
 			children = (
 				8A07910E278F62F2005529CB /* AdjustHelper.swift */,
+				2165B2C12860C2F4004C0786 /* AdjustTelemetryHelper.swift */,
 				E65075531E37F6FC006961AC /* DynamicFontHelper.swift */,
 				E65075601E37F77D006961AC /* MenuHelper.swift */,
 				39455F761FC83F430088A22C /* TabEventHandler.swift */,
@@ -5987,6 +5994,7 @@
 			children = (
 				E683F0A51E92E0820035D990 /* MockableHistory.swift */,
 				281B2BE91ADF4D90002917DC /* MockProfile.swift */,
+				2165B2C32860CB34004C0786 /* MockAdjustTelemetryData.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -7042,6 +7050,7 @@
 				C8501F5028510DA1003B09AB /* WallpaperMigrationUtilityTests.swift */,
 				E4CD9F1C1A6D9C2800318571 /* WebServerTests.swift */,
 				D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */,
+				2165B2BF2860BB41004C0786 /* AdjustTelemetryHelperTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -9402,6 +9411,7 @@
 				D3FEC38D1AC4B42F00494F45 /* AutocompleteTextField.swift in Sources */,
 				C849E46526B9C3DD00260F0B /* SlideoverPresentationController.swift in Sources */,
 				D5D0532E2645B3A700759F85 /* ExperimentsTableView.swift in Sources */,
+				2165B2C22860C2F4004C0786 /* AdjustTelemetryHelper.swift in Sources */,
 				8A2D593E27DC0AA100713EC9 /* TopSite.swift in Sources */,
 				434E733725EED32E006D3BDE /* BrowserViewController+URLBarDelegate.swift in Sources */,
 				EBE26B57220C959D00D1D99A /* BrowserViewController+TabToolbarDelegate.swift in Sources */,
@@ -9532,6 +9542,7 @@
 				431C0D1E25C9DC4D00395CE4 /* DefaultBrowserOnboardingTests.swift in Sources */,
 				213B67A827CE721E000542F5 /* StartAtHomeHelperTests.swift in Sources */,
 				D3D488591ABB54CD00A93597 /* FileAccessorTests.swift in Sources */,
+				2165B2C42860CB34004C0786 /* MockAdjustTelemetryData.swift in Sources */,
 				0BA8964B1A250E6500C1010C /* ProfileTest.swift in Sources */,
 				03CCC9181AF05E7300DBF30D /* RelativeDatesTests.swift in Sources */,
 				F84B21DA1A090F8100AAB793 /* ClientTests.swift in Sources */,
@@ -9588,6 +9599,7 @@
 				8A11C8132731E54800AC7318 /* DictionaryExtensionsTests.swift in Sources */,
 				8A7A93EE2810ADF2005E7E1B /* ContileProviderTests.swift in Sources */,
 				8A33221F27DFE318008F809E /* FxHomeTopSitesManagerTests.swift in Sources */,
+				2165B2C02860BB41004C0786 /* AdjustTelemetryHelperTests.swift in Sources */,
 				C807CCCC28367446008E6A5A /* FeatureFlagManagerTests.swift in Sources */,
 				8ABC5AF028456DD800FEA552 /* FirefoxHomeViewModelTests.swift in Sources */,
 				8A5C3BC5282ABF8E003A8CCF /* RemoteTabsPanelTests.swift in Sources */,

--- a/Client/AdjustHelper.swift
+++ b/Client/AdjustHelper.swift
@@ -33,7 +33,7 @@ final class AdjustHelper: FeatureFlaggable {
         // If adjust should be enabled and attribution is not yet set
         // edge case to set attribution data for existing users
         if shouldEnable {
-            _ = telemetryHelper.setAttribution(Adjust.attribution())
+            telemetryHelper.setAttribution(Adjust.attribution())
         }
     }
 
@@ -101,7 +101,7 @@ extension AdjustHelper: AdjustDelegate {
             AdjustHelper.setEnabled(false)
         }
 
-        _ = telemetryHelper.setAttribution(attribution)
+        telemetryHelper.setAttribution(attribution)
     }
 
     func adjustDeeplinkResponse(_ deeplink: URL?) -> Bool {

--- a/Client/AdjustTelemetryHelper.swift
+++ b/Client/AdjustTelemetryHelper.swift
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Adjust
+import Glean
+
+protocol AdjustTelemetryData {
+    var campaign: String? { get set }
+    var adgroup: String? { get set }
+    var creative: String? { get set }
+    var network: String? { get set }
+}
+
+extension ADJAttribution: AdjustTelemetryData {
+}
+
+protocol AdjustTelemetryProtocol {
+    func setAttribution(_ attribution: AdjustTelemetryData?) -> Bool
+    func sendDeeplinkTelemetry(url: URL)
+}
+
+class AdjustTelemetryHelper: AdjustTelemetryProtocol {
+
+    // MARK: - UserDefaults
+
+    private enum UserDefaultsKey: String {
+        case hasSetAttributionData = "com.moz.adjust.hasSetAttributionData.key"
+    }
+
+    var hasSetAttributionData: Bool {
+        get { UserDefaults.standard.object(forKey: UserDefaultsKey.hasSetAttributionData.rawValue) as? Bool ?? false }
+        set { UserDefaults.standard.set(newValue, forKey: UserDefaultsKey.hasSetAttributionData.rawValue) }
+    }
+
+    func sendDeeplinkTelemetry(url: URL) {
+        let extra = [TelemetryWrapper.EventExtraKey.deeplinkURL.rawValue: url.absoluteString]
+
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .applicationOpenUrl,
+                                     object: .deeplinkReceived,
+                                     value: nil,
+                                     extras: extra)
+    }
+
+    @discardableResult
+    func setAttribution(_ attribution: AdjustTelemetryData?) -> Bool {
+        guard !hasSetAttributionData else { return false }
+
+        guard let campaign = attribution?.campaign,
+              let adgroup = attribution?.adgroup,
+              let creative = attribution?.creative,
+              let network = attribution?.network else { return false}
+
+        GleanMetrics.Adjust.campaign.set(campaign)
+        GleanMetrics.Adjust.adGroup.set(adgroup)
+        GleanMetrics.Adjust.creative.set(creative)
+        GleanMetrics.Adjust.network.set(network)
+
+        hasSetAttributionData = true
+        return true
+    }
+}

--- a/Client/AdjustTelemetryHelper.swift
+++ b/Client/AdjustTelemetryHelper.swift
@@ -17,7 +17,7 @@ extension ADJAttribution: AdjustTelemetryData {
 }
 
 protocol AdjustTelemetryProtocol {
-    func setAttribution(_ attribution: AdjustTelemetryData?) -> Bool
+    func setAttribution(_ attribution: AdjustTelemetryData?)
     func sendDeeplinkTelemetry(url: URL)
 }
 
@@ -44,14 +44,13 @@ class AdjustTelemetryHelper: AdjustTelemetryProtocol {
                                      extras: extra)
     }
 
-    @discardableResult
-    func setAttribution(_ attribution: AdjustTelemetryData?) -> Bool {
-        guard !hasSetAttributionData else { return false }
+    func setAttribution(_ attribution: AdjustTelemetryData?) {
+        guard !hasSetAttributionData else { return }
 
         guard let campaign = attribution?.campaign,
               let adgroup = attribution?.adgroup,
               let creative = attribution?.creative,
-              let network = attribution?.network else { return false}
+              let network = attribution?.network else { return }
 
         GleanMetrics.Adjust.campaign.set(campaign)
         GleanMetrics.Adjust.adGroup.set(adgroup)
@@ -59,6 +58,5 @@ class AdjustTelemetryHelper: AdjustTelemetryProtocol {
         GleanMetrics.Adjust.network.set(network)
 
         hasSetAttributionData = true
-        return true
     }
 }

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -423,6 +423,7 @@ extension TelemetryWrapper {
         case fxaConfirmSignInToken = "fxa-confirm-signin-token"
         case awesomebarLocation = "awesomebar-position"
         case searchHighlights = "search-highlights"
+        case deeplinkReceived = "deeplink_received"
     }
 
     public enum EventValue: String {
@@ -547,6 +548,9 @@ extension TelemetryWrapper {
 
         // Onboarding
         case cardType = "card-type"
+
+        // Adjust
+        case deeplinkURL = "deeplink-url"
     }
 
     public static func recordEvent(category: EventCategory, method: EventMethod, object: EventObject, value: EventValue? = nil, extras: [String: Any]? = nil) {
@@ -1106,6 +1110,12 @@ extension TelemetryWrapper {
             if let messageId = extras?[EventExtraKey.messageKey.rawValue] as? String {
                 GleanMetrics.Messaging.malformed.record(
                     GleanMetrics.Messaging.MalformedExtra(messageKey: messageId)
+                )
+            }
+        case(.action, .applicationOpenUrl, .deeplinkReceived, _, let extras):
+            if let url = extras?[EventExtraKey.deeplinkURL.rawValue] as? String {
+                GleanMetrics.Adjust.deeplinkReceived.record(
+                    GleanMetrics.Adjust.DeeplinkReceivedExtra(receivedUrl: url)
                 )
             }
 

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -2701,3 +2701,89 @@ messaging:
     data_sensitivity:
       - technical
     expires: "2023-10-17"
+adjust:
+  deeplink_received:
+    type: event
+    description: |
+      Send for Adjust callback for deeplink.
+    extra_keys:
+      received_url:
+        description: The deeplink url
+        type: string
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-4225
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10417
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    data_sensitivity:
+      - technical
+    expires: "2023-01-01"
+  campaign:
+    type: string
+    lifetime: application
+    description: |
+      A string containing the Adjust campaign ID from which the user installed
+      Firefox-iOS.
+    send_in_pings:
+      - metrics
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-4225
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/5579
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-01-01"
+  ad_group:
+    type: string
+    lifetime: application
+    description: |
+      A string containing the Adjust ad group ID from which the user installed
+      Firefox-iOS.
+    send_in_pings:
+      - metrics
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-4225
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/9253
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-01-01"
+  creative:
+    type: string
+    lifetime: application
+    description: |
+      A string containing the Adjust creative ID from which the user installed
+      Firefox-iOS.
+    send_in_pings:
+      - metrics
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-4225
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/9253
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-01-01"
+  network:
+    type: string
+    lifetime: application
+    description: |
+      A string containing the Adjust network ID from which the user installed
+      Firefox-iOS.
+    send_in_pings:
+      - metrics
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-4225
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/9253
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-01-01"

--- a/ClientTests/AdjustTelemetryHelperTests.swift
+++ b/ClientTests/AdjustTelemetryHelperTests.swift
@@ -29,20 +29,15 @@ class AdjustTelemetryHelperTests: XCTestCase {
 
     func testShouldSetAttribution() {
         telemetryHelper.hasSetAttributionData = false
-        let savedState = telemetryHelper.setAttribution(MockAdjustTelemetryData())
-        XCTAssertTrue(savedState)
+        telemetryHelper.setAttribution(MockAdjustTelemetryData())
+        XCTAssertTrue(telemetryHelper.hasSetAttributionData)
     }
 
     func testFailSetAttribution_WithNilData() {
+        telemetryHelper.hasSetAttributionData = false
         let attribution = MockAdjustTelemetryData(campaign: nil)
-        let savedState = telemetryHelper.setAttribution(attribution)
-        XCTAssertFalse(savedState)
-    }
-
-    func testFailSetAttribution_AlreadySet() {
-        telemetryHelper.hasSetAttributionData = true
-        let savedState = telemetryHelper.setAttribution(MockAdjustTelemetryData())
-        XCTAssertFalse(savedState)
+        telemetryHelper.setAttribution(attribution)
+        XCTAssertFalse(telemetryHelper.hasSetAttributionData)
     }
 
     func testHandleDeeplink() {

--- a/ClientTests/AdjustTelemetryHelperTests.swift
+++ b/ClientTests/AdjustTelemetryHelperTests.swift
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Glean
+
+@testable import Client
+
+class AdjustTelemetryHelperTests: XCTestCase {
+
+    var telemetryHelper: AdjustTelemetryHelper!
+    var profile: MockProfile!
+
+    override func setUp() {
+        super.setUp()
+
+        // Setup mock profile
+        profile = MockProfile(databasePrefix: "adjust-helper-test")
+        telemetryHelper = AdjustTelemetryHelper()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        self.profile._shutdown()
+        self.profile = nil
+    }
+
+    func testShouldSetAttribution() {
+        telemetryHelper.hasSetAttributionData = false
+        let savedState = telemetryHelper.setAttribution(MockAdjustTelemetryData())
+        XCTAssertTrue(savedState)
+    }
+
+    func testFailSetAttribution_WithNilData() {
+        let attribution = MockAdjustTelemetryData(campaign: nil)
+        let savedState = telemetryHelper.setAttribution(attribution)
+        XCTAssertFalse(savedState)
+    }
+
+    func testFailSetAttribution_AlreadySet() {
+        telemetryHelper.hasSetAttributionData = true
+        let savedState = telemetryHelper.setAttribution(MockAdjustTelemetryData())
+        XCTAssertFalse(savedState)
+    }
+
+    func testHandleDeeplink() {
+        if let url = URL(string: "https://testurl.com") {
+            telemetryHelper.sendDeeplinkTelemetry(url: url)
+            testEventMetricRecordingSuccess(metric: GleanMetrics.Adjust.deeplinkReceived)
+        }
+    }
+}

--- a/ClientTests/Mocks/MockAdjustTelemetryData.swift
+++ b/ClientTests/Mocks/MockAdjustTelemetryData.swift
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+@testable import Client
+
+class MockAdjustTelemetryData: AdjustTelemetryData {
+    var campaign: String?
+    var adgroup: String?
+    var creative: String?
+    var network: String?
+
+    init(campaign: String? = "test_campaing",
+         adgroup: String? =  "test_adgroup",
+         creative: String? = "test_creative",
+         network: String? = "test_network") {
+        self.campaign = campaign
+        self.adgroup = adgroup
+        self.creative = creative
+        self.network = network
+    }
+}

--- a/ClientTests/TelemetryWrapperTests.swift
+++ b/ClientTests/TelemetryWrapperTests.swift
@@ -208,6 +208,18 @@ class TelemetryWrapperTests: XCTestCase {
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.closeTap)
     }
+
+    func test_handleDeeplinkWithExtra_GleanIsCalled() {
+        let deeplinkUrlKey = TelemetryWrapper.EventExtraKey.deeplinkURL.rawValue
+        let extras = [deeplinkUrlKey: "https://testURL.com"]
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .applicationOpenUrl,
+                                     object: .deeplinkReceived,
+                                     value: nil,
+                                     extras: extras)
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Adjust.deeplinkReceived)
+    }
 }
 
 // MARK: - Helper functions to test telemetry


### PR DESCRIPTION
- Add AdjustTelemetryHelper to set attribution data and send deeplinkReceived event
- Add unit test for telemetry events and helper class
