### PR TITLE
Cleanup FXIOS-3966 [v103] Add app launch utility

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -394,6 +394,7 @@
 		59A68FD5260B8D520F890F4A /* ReaderPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A685F4EAD19EDEC854BCA4 /* ReaderPanel.swift */; };
 		5A271ABD2860B0D700471CE4 /* WebServerUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A271ABC2860B0D700471CE4 /* WebServerUtil.swift */; };
 		5A430D792853DFDD00782BFF /* OrientationLockUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A430D782853DFDD00782BFF /* OrientationLockUtility.swift */; };
+		5A47CFF52860FB8900B2B7BF /* AppLaunchUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A47CFF42860FB8900B2B7BF /* AppLaunchUtil.swift */; };
 		5F130D2E2483508E00B0F7D0 /* FxAWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F130D2D2483508E00B0F7D0 /* FxAWebViewModel.swift */; };
 		5F97DD5F27FB0FE800AD3C60 /* GleanTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F97DD5E27FB0FE800AD3C60 /* GleanTelemetryTests.swift */; };
 		5FA2233C27F74071005B3D87 /* Glean in Frameworks */ = {isa = PBXBuildFile; productRef = 5FA2233B27F74071005B3D87 /* Glean */; };
@@ -2452,6 +2453,7 @@
 		5A1D409EB92D8E6AB8FC8813 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
 		5A271ABC2860B0D700471CE4 /* WebServerUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebServerUtil.swift; sourceTree = "<group>"; };
 		5A430D782853DFDD00782BFF /* OrientationLockUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrientationLockUtility.swift; sourceTree = "<group>"; };
+		5A47CFF42860FB8900B2B7BF /* AppLaunchUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchUtil.swift; sourceTree = "<group>"; };
 		5ABD40B68B3D03806BC6819C /* es-AR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-AR"; path = "es-AR.lproj/LoginManager.strings"; sourceTree = "<group>"; };
 		5AC24B85BF0D2FCC2F1EB6D3 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		5AC549C0BA565EB2B08B87EC /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
@@ -7084,6 +7086,7 @@
 				D8EFFA0B1FF5B1FA001D3A09 /* NavigationRouter.swift */,
 				C84266742728462900382274 /* AccessibilityIdentifiers.swift */,
 				8A9F0B5527C595F300FE09AE /* ImageIdentifiers.swift */,
+				5A47CFF42860FB8900B2B7BF /* AppLaunchUtil.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -9117,6 +9120,7 @@
 			files = (
 				602A2B9827F6256200C3CB78 /* FxNimbus.swift in Sources */,
 				602A2B9727F6243A00C3CB78 /* Metrics.swift in Sources */,
+				5A47CFF52860FB8900B2B7BF /* AppLaunchUtil.swift in Sources */,
 				C8B0F5ED283B7C9F007AE65D /* PocketStandardCell.swift in Sources */,
 				D04CD74A216CF86B004FF5B0 /* SiriShortcuts.swift in Sources */,
 				EB9A179F20E6C1A200B12184 /* ThemedWidgets.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -10,21 +10,15 @@ import MessageUI
 import SDWebImage
 import SyncTelemetry
 import LocalAuthentication
-import SyncTelemetry
 import Sync
 import CoreSpotlight
 import UserNotifications
 import Account
-
-#if canImport(BackgroundTasks)
- import BackgroundTasks
-#endif
+import BackgroundTasks
 
 private let log = Logger.browserLogger
 
 let LatestAppVersionProfileKey = "latestAppVersion"
-let AllowThirdPartyKeyboardsKey = "settings.allowThirdPartyKeyboards"
-private let InitialPingSentKey = "initialPingSent"
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
@@ -32,76 +26,27 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var browserViewController: BrowserViewController!
     var rootViewController: UIViewController!
     var tabManager: TabManager!
-    var applicationCleanlyBackgrounded = true
     var receivedURLs = [URL]()
     var orientationLock = UIInterfaceOrientationMask.all
     weak var profile: Profile?
-    weak var application: UIApplication?
     private var shutdownWebServer: DispatchSourceTimer?
-    private var launchOptions: [AnyHashable: Any]?
     private var telemetry: TelemetryWrapper?
     private var adjustHelper: AdjustHelper?
     private var webServerUtil: WebServerUtil?
+    private var appLaunchUtil: AppLaunchUtil?
 
-    func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        //
-        // Determine if the application cleanly exited last time it was used. We default to true in
-        // case we have never done this before. Then check if the "ApplicationCleanlyBackgrounded" user
-        // default exists and whether was properly set to true on app exit.
-        //
-        // Then we always set the user default to false. It will be set to true when we the application
-        // is backgrounded.
-        //
+    func application(_ application: UIApplication,
+                     willFinishLaunchingWithOptions
+                     launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
-        self.applicationCleanlyBackgrounded = true
+        log.info("startApplication begin")
 
-        let defaults = UserDefaults()
-        if defaults.object(forKey: "ApplicationCleanlyBackgrounded") != nil {
-            self.applicationCleanlyBackgrounded = defaults.bool(forKey: "ApplicationCleanlyBackgrounded")
-        }
-        defaults.set(false, forKey: "ApplicationCleanlyBackgrounded")
-
-        // Hold references to willFinishLaunching parameters for delayed app launch
-        self.application = application
-        self.launchOptions = launchOptions
+        appLaunchUtil = AppLaunchUtil()
+        appLaunchUtil?.setUpAppLaunchDependencies()
 
         self.window = UIWindow(frame: UIScreen.main.bounds)
 
-        // If the 'Save logs to Files app on next launch' toggle
-        // is turned on in the Settings app, copy over old logs.
-        if DebugSettingsBundleOptions.saveLogsToDocuments {
-            Logger.copyPreviousLogsToDocuments()
-        }
-
-        return startApplication(application, withLaunchOptions: launchOptions)
-    }
-
-    private func startApplication(_ application: UIApplication, withLaunchOptions launchOptions: [AnyHashable: Any]?) -> Bool {
-        log.info("startApplication begin")
-
-        // Need to get "settings.sendUsageData" this way so that Sentry can be initialized
-        // before getting the Profile.
-        let sendUsageData = NSUserDefaultsPrefs(prefix: "profile").boolForKey(AppConstants.PrefSendUsageData) ?? true
-        SentryIntegration.shared.setup(sendUsageData: sendUsageData)
-
-        // Set the Firefox UA for browsing.
-        setUserAgent()
-
-        // Start the keyboard helper to monitor and cache keyboard state.
-        KeyboardHelper.defaultHelper.startObserving()
-
-        DynamicFontHelper.defaultHelper.startObserving()
-
-        MenuHelper.defaultHelper.setItems()
-
-        let logDate = Date()
-        // Create a new sync log file on cold app launch. Note that this doesn't roll old logs.
-        Logger.syncLogger.newLogWithDate(logDate)
-
-        Logger.browserLogger.newLogWithDate(logDate)
-
         let profile = getProfile(application)
-
         telemetry = TelemetryWrapper(profile: profile)
 
         // Initialize the feature flag subsytem.
@@ -149,25 +94,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         RustFirefoxAccounts.startup(prefs: profile.prefs).uponQueue(.main) { _ in
             print("RustFirefoxAccounts started")
         }
+
         log.info("startApplication end")
+
         return true
-    }
-
-    // TODO: Move to scene controller for iOS 13
-    private func setupRootViewController() {
-        if !LegacyThemeManager.instance.systemThemeIsOn {
-            self.window?.overrideUserInterfaceStyle = LegacyThemeManager.instance.userInterfaceStyle
-        }
-
-        browserViewController = BrowserViewController(profile: self.profile!, tabManager: self.tabManager)
-        browserViewController.edgesForExtendedLayout = []
-
-        let navigationController = UINavigationController(rootViewController: browserViewController)
-        navigationController.isNavigationBarHidden = true
-        navigationController.edgesForExtendedLayout = UIRectEdge(rawValue: 0)
-        rootViewController = navigationController
-
-        self.window!.rootViewController = rootViewController
     }
 
     func applicationWillTerminate(_ application: UIApplication) {
@@ -310,14 +240,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         shutdownWebServer?.cancel()
         shutdownWebServer = nil
 
-        //
-        // We are back in the foreground, so set CleanlyBackgrounded to false so that we can detect that
-        // the application was cleanly backgrounded later.
-        //
-
-        let defaults = UserDefaults()
-        defaults.set(false, forKey: "ApplicationCleanlyBackgrounded")
-
         if let profile = self.profile {
             profile._reopen()
 
@@ -363,15 +285,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {
-        //
-        // At this point we are happy to mark the app as CleanlyBackgrounded. If a crash happens in background
-        // sync then that crash will still be reported. But we won't bother the user with the Restore Tabs
-        // dialog. We don't have to because at this point we already saved the tab state properly.
-        //
-
-        let defaults = UserDefaults()
-        defaults.set(true, forKey: "ApplicationCleanlyBackgrounded")
-
         // Pause file downloads.
         // TODO: iOS 13 needs to iterate all the BVCs.
         browserViewController.downloadQueue.pauseAll()
@@ -410,25 +323,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         profile?._shutdown()
-    }
-
-    fileprivate func setUserAgent() {
-        let firefoxUA = UserAgent.getUserAgent()
-
-        // Set the UA for WKWebView (via defaults), the favicon fetcher, and the image loader.
-        // This only needs to be done once per runtime. Note that we use defaults here that are
-        // readable from extensions, so they can just use the cached identifier.
-
-        SDWebImageDownloader.shared.setValue(firefoxUA, forHTTPHeaderField: "User-Agent")
-        // SDWebImage is setting accept headers that report we support webp. We don't
-        SDWebImageDownloader.shared.setValue("image/*;q=0.8", forHTTPHeaderField: "Accept")
-
-        // Record the user agent for use by search suggestion clients.
-        SearchViewController.userAgent = firefoxUA
-
-        // Some sites will only serve HTML that points to .ico files.
-        // The FaviconFetcher is explicitly for getting high-res icons, so use the desktop user agent.
-        FaviconFetcher.userAgent = UserAgent.desktopUserAgent()
     }
 
     /// When a user presses and holds the app icon from the Home Screen, we present quick actions / shortcut items (see QuickActions).
@@ -492,7 +386,9 @@ extension AppDelegate {
         return self.orientationLock
     }
 
-    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+    func application(_ application: UIApplication,
+                     continue userActivity: NSUserActivity,
+                     restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         if userActivity.activityType == SiriShortcuts.activityType.openURL.rawValue {
             browserViewController.openBlankNewTab(focusLocationField: false)
             return true
@@ -533,5 +429,21 @@ extension AppDelegate {
         }
 
         return false
+    }
+
+    private func setupRootViewController() {
+        if !LegacyThemeManager.instance.systemThemeIsOn {
+            self.window?.overrideUserInterfaceStyle = LegacyThemeManager.instance.userInterfaceStyle
+        }
+
+        browserViewController = BrowserViewController(profile: self.profile!, tabManager: self.tabManager)
+        browserViewController.edgesForExtendedLayout = []
+
+        let navigationController = UINavigationController(rootViewController: browserViewController)
+        navigationController.isNavigationBarHidden = true
+        navigationController.edgesForExtendedLayout = UIRectEdge(rawValue: 0)
+        rootViewController = navigationController
+
+        self.window!.rootViewController = rootViewController
     }
 }

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -433,10 +433,10 @@ extension AppDelegate {
 
     private func setupRootViewController() {
         if !LegacyThemeManager.instance.systemThemeIsOn {
-            self.window?.overrideUserInterfaceStyle = LegacyThemeManager.instance.userInterfaceStyle
+            window?.overrideUserInterfaceStyle = LegacyThemeManager.instance.userInterfaceStyle
         }
 
-        browserViewController = BrowserViewController(profile: self.profile!, tabManager: self.tabManager)
+        browserViewController = BrowserViewController(profile: profile!, tabManager: tabManager)
         browserViewController.edgesForExtendedLayout = []
 
         let navigationController = UINavigationController(rootViewController: browserViewController)
@@ -444,6 +444,6 @@ extension AppDelegate {
         navigationController.edgesForExtendedLayout = UIRectEdge(rawValue: 0)
         rootViewController = navigationController
 
-        self.window!.rootViewController = rootViewController
+        window!.rootViewController = rootViewController
     }
 }

--- a/Client/Application/AppLaunchUtil.swift
+++ b/Client/Application/AppLaunchUtil.swift
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Shared
+import SDWebImage
+
+class AppLaunchUtil {
+
+    func setUpAppLaunchDependencies() {
+        // If the 'Save logs to Files app on next launch' toggle
+        // is turned on in the Settings app, copy over old logs.
+        if DebugSettingsBundleOptions.saveLogsToDocuments {
+            Logger.copyPreviousLogsToDocuments()
+        }
+
+        // Need to get "settings.sendUsageData" this way so that Sentry can be initialized
+        // before getting the Profile.
+        let sendUsageData = NSUserDefaultsPrefs(prefix: "profile").boolForKey(AppConstants.PrefSendUsageData) ?? true
+        SentryIntegration.shared.setup(sendUsageData: sendUsageData)
+
+        setUserAgent()
+
+        KeyboardHelper.defaultHelper.startObserving()
+        DynamicFontHelper.defaultHelper.startObserving()
+        MenuHelper.defaultHelper.setItems()
+
+        let logDate = Date()
+        // Create a new sync log file on cold app launch. Note that this doesn't roll old logs.
+        Logger.syncLogger.newLogWithDate(logDate)
+        Logger.browserLogger.newLogWithDate(logDate)
+    }
+
+    private func setUserAgent() {
+        let firefoxUA = UserAgent.getUserAgent()
+
+        // Set the UA for WKWebView (via defaults), the favicon fetcher, and the image loader.
+        // This only needs to be done once per runtime. Note that we use defaults here that are
+        // readable from extensions, so they can just use the cached identifier.
+
+        SDWebImageDownloader.shared.setValue(firefoxUA, forHTTPHeaderField: "User-Agent")
+        // SDWebImage is setting accept headers that report we support webp. We don't
+        SDWebImageDownloader.shared.setValue("image/*;q=0.8", forHTTPHeaderField: "Accept")
+
+        // Record the user agent for use by search suggestion clients.
+        SearchViewController.userAgent = firefoxUA
+
+        // Some sites will only serve HTML that points to .ico files.
+        // The FaviconFetcher is explicitly for getting high-res icons, so use the desktop user agent.
+        FaviconFetcher.userAgent = UserAgent.desktopUserAgent()
+    }
+}

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -810,7 +810,6 @@ class BrowserViewController: UIViewController {
         return SentryIntegration.shared.crashedLastLaunch
     }
 
-
     fileprivate func showRestoreTabsAlert() {
         guard tabManager.hasTabsToRestoreAtStartup() else {
             tabManager.selectTab(tabManager.addTab())

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -511,7 +511,7 @@ class BrowserViewController: UIViewController {
             self.view.alpha = (profile.prefs.intForKey(PrefsKeys.IntroSeen) != nil) ? 1.0 : 0.0
         }
 
-        if !displayedRestoreTabsAlert && !cleanlyBackgrounded() && crashedLastLaunch() {
+        if !displayedRestoreTabsAlert && crashedLastLaunch() {
             displayedRestoreTabsAlert = true
             showRestoreTabsAlert()
         } else {
@@ -810,12 +810,6 @@ class BrowserViewController: UIViewController {
         return SentryIntegration.shared.crashedLastLaunch
     }
 
-    fileprivate func cleanlyBackgrounded() -> Bool {
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
-            return false
-        }
-        return appDelegate.applicationCleanlyBackgrounded
-    }
 
     fileprivate func showRestoreTabsAlert() {
         guard tabManager.hasTabsToRestoreAtStartup() else {


### PR DESCRIPTION
I had created a new object to manage the whole ApplicationCleanlyBackgrounded logic to take it out of the app delegate entirely but during testing I discovered this logic doesn't actually work and where it is used in the browser view controller is only every actually using the info from Sentry for if the app crashed on previous launch. The Sentry code is sufficient to achieve the goal of being able to display the restore tabs pop up so I just completely removed the ApplicationCleanlyBackgrounded logic.

There are still a bunch of other things that I want to move into the AppLaunchUtil but the remaining items mostly deal with the profile object, so I would like to refactor how that is handled first before continuing with the rest.

Apart from the ApplicationCleanlyBackgrounded logic, everything else still happens in the same order, it's just been pulled out of the app delegate, so there should be little chance of any regression issues being introduced by this.