### PR TITLE
Bugfix FXIOS-4448 [v102] Fix crash when switching to private mode on iPad

### DIFF
--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -415,10 +415,7 @@ extension HomepageViewController {
 
     /// Reload all data including refreshing cells content and fetching data from backend
     func reloadAll() {
-
-        DispatchQueue.global(qos: .userInteractive).async { [weak self] in
-            self?.viewModel.updateData()
-        }
+        viewModel.updateData()
     }
 }
 


### PR DESCRIPTION
This change will likely have some performance regressions on slower devices.
For now this fix should address the crashing but going forward we need a more holistic approach to address performance on this screen without introducing potential race conditions and crashes.