### PR TITLE
Refactor XCUITests remove sleeps

### DIFF
--- a/XCUITests/ActivityStreamTest.swift
+++ b/XCUITests/ActivityStreamTest.swift
@@ -50,9 +50,9 @@ class ActivityStreamTest: BaseTestCase {
 
     // Smoketest
     func testDefaultSites() throws {
-        sleep(15)
-        XCTExpectFailure("The app was not launched", strict: false)
-        waitForExistence(TopSiteCellgroup, timeout: 60)
+        XCTExpectFailure("The app was not launched", strict: false) {
+            waitForExistence(TopSiteCellgroup, timeout: 60)
+        }
         XCTAssertTrue(app.collectionViews[AccessibilityIdentifiers.FirefoxHomepage.collectionView].exists)
         // There should be 5 top sites by default
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
@@ -153,9 +153,9 @@ class ActivityStreamTest: BaseTestCase {
 
     // Smoketest
     func testTopSitesOpenInNewPrivateTab() throws {
-        sleep(5)
-        XCTExpectFailure("The app was not launched", strict: false)
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 35)
+        XCTExpectFailure("The app was not launched", strict: false) {
+            waitForExistence(app.buttons["urlBar-cancel"], timeout: 35)
+        }
         navigator.performAction(Action.CloseURLBarOpen)
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 5)
         // Long tap on apple top site, second cell
@@ -181,8 +181,9 @@ class ActivityStreamTest: BaseTestCase {
 
     // Smoketest
     func testTopSitesOpenInNewPrivateTabDefaultTopSite() {
-        sleep(3)
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 35)
+        XCTExpectFailure("The app was not launched", strict: false) {
+            waitForExistence(app.buttons["urlBar-cancel"], timeout: 35)
+        }
         navigator.performAction(Action.CloseURLBarOpen)
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 5)
         navigator.nowAt(NewTabScreen)

--- a/XCUITests/HistoryTests.swift
+++ b/XCUITests/HistoryTests.swift
@@ -81,9 +81,9 @@ class HistoryTests: BaseTestCase {
 
     // Smoketest
     func testClearPrivateDataButtonDisabled() throws {
-        sleep(15)
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 35)
-        XCTExpectFailure("The app was not launched", strict: false)
+        XCTExpectFailure("The app was not launched", strict: false) {
+            waitForExistence(app.buttons["urlBar-cancel"], timeout: 45)
+        }
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 5)

--- a/XCUITests/ReaderViewUITest.swift
+++ b/XCUITests/ReaderViewUITest.swift
@@ -43,7 +43,9 @@ class ReaderViewTest: BaseTestCase {
 
     // Smoketest
     func testAddToReadingList() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 25)
+        XCTExpectFailure("The app was not launched", strict: false) {
+            waitForExistence(app.buttons["urlBar-cancel"], timeout: 25)
+        }
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         // Navigate to reading list
@@ -225,9 +227,9 @@ class ReaderViewTest: BaseTestCase {
 
     // Smoketest
     func testAddToReaderListOptions() throws {
-        sleep(15)
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 45)
-        XCTExpectFailure("The app was not launched", strict: false)
+        XCTExpectFailure("The app was not launched", strict: false) {
+            waitForExistence(app.buttons["urlBar-cancel"], timeout: 45)
+        }
         addContentToReaderView()
         // Check that Settings layouts options are shown
         waitForExistence(app.buttons["ReaderModeBarView.settingsButton"], timeout: 10)

--- a/XCUITests/TopTabsTest.swift
+++ b/XCUITests/TopTabsTest.swift
@@ -18,9 +18,9 @@ let toastUrl = ["url": "twitter.com", "link": "About", "urlLabel": "about"]
 
 class TopTabsTest: BaseTestCase {
     func testAddTabFromTabTray() throws {
-        sleep(15)
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 45)
-        XCTExpectFailure("The app was not launched", strict: false)
+        XCTExpectFailure("The app was not launched", strict: false) {
+            waitForExistence(app.buttons["urlBar-cancel"], timeout: 45)
+        }
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()


### PR DESCRIPTION
Let's remove the sleeps calls and wrap the expected failure due to the time it takes to launch the tests so that if the test fails for another reason, it will be reported. Only if the test is not launched due to a long time to start the app, it will be skipped as an expected failure