### PR TITLE
Bugfix FXIOS-3673 [v103] show previously closed private tabs for a fraction of a second when opening new private browsing tabs

### DIFF
--- a/Client/Frontend/Browser/TabCell.swift
+++ b/Client/Frontend/Browser/TabCell.swift
@@ -216,6 +216,7 @@ class TabCell: UICollectionViewCell, TabTrayCell, ReusableCell {
     override func prepareForReuse() {
         // Reset any close animations.
         super.prepareForReuse()
+        screenshotView.image = nil
         backgroundHolder.transform = .identity
         backgroundHolder.alpha = 1
         self.titleText.font = DynamicFontHelper.defaultHelper.DefaultSmallFontBold


### PR DESCRIPTION
Reset screenshot image on cell prepareForReuse to avoid showing previous one
