### PR TITLE
Refactor FXIOS-3966 [v103] Move profile to be owned by the app delegate

### DIFF
--- a/Client/Application/AppDelegate+PushNotifications.swift
+++ b/Client/Application/AppDelegate+PushNotifications.swift
@@ -93,8 +93,8 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     // Called when the user receives a tab (or any other notification) while in foreground.
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
 
-        if profile?.prefs.boolForKey(PendingAccountDisconnectedKey) ?? false {
-            profile?.removeAccount()
+        if profile.prefs.boolForKey(PendingAccountDisconnectedKey) ?? false {
+            profile.removeAccount()
 
             // show the notification
             completionHandler([.alert, .sound])

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -28,7 +28,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var tabManager: TabManager!
     var receivedURLs = [URL]()
     var orientationLock = UIInterfaceOrientationMask.all
-    weak var profile: Profile?
+    lazy var profile: Profile = BrowserProfile(localName: "profile",
+                                               syncDelegate: UIApplication.shared.syncDelegate)
     private var shutdownWebServer: DispatchSourceTimer?
     private var telemetry: TelemetryWrapper?
     private var adjustHelper: AdjustHelper?
@@ -46,7 +47,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         self.window = UIWindow(frame: UIScreen.main.bounds)
 
-        let profile = getProfile(application)
         telemetry = TelemetryWrapper(profile: profile)
 
         // Initialize the feature flag subsytem.
@@ -82,7 +82,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         NotificationCenter.default.addObserver(forName: .FSReadingListAddReadingListItem, object: nil, queue: nil) { (notification) -> Void in
             if let userInfo = notification.userInfo, let url = userInfo["URL"] as? URL {
                 let title = (userInfo["Title"] as? String) ?? ""
-                profile.readingList.createRecordWithURL(url.absoluteString, title: title, addedBy: UIDevice.current.name)
+                self.profile.readingList.createRecordWithURL(url.absoluteString, title: title, addedBy: UIDevice.current.name)
             }
         }
 
@@ -102,32 +102,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationWillTerminate(_ application: UIApplication) {
         // We have only five seconds here, so let's hope this doesn't take too long.
-        profile?._shutdown()
+        profile._shutdown()
 
         // Allow deinitializers to close our database connections.
-        profile = nil
         tabManager = nil
         browserViewController = nil
         rootViewController = nil
-    }
-
-    /**
-     * We maintain a weak reference to the profile so that we can pause timed
-     * syncs when we're backgrounded.
-     *
-     * The long-lasting ref to the profile lives in BrowserViewController,
-     * which we set in application:willFinishLaunchingWithOptions:.
-     *
-     * If that ever disappears, we won't be able to grab the profile to stop
-     * syncing... but in that case the profile's deinit will take care of things.
-     */
-    func getProfile(_ application: UIApplication) -> Profile {
-        if let profile = self.profile {
-            return profile
-        }
-        let p = BrowserProfile(localName: "profile", syncDelegate: application.syncDelegate)
-        self.profile = p
-        return p
     }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
@@ -143,38 +123,36 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         pushNotificationSetup()
 
-        if let profile = self.profile {
-            let persistedCurrentVersion = InstallType.persistedCurrentVersion()
-            let introScreen = profile.prefs.intForKey(PrefsKeys.IntroSeen)
-            // upgrade install - Intro screen shown & persisted current version does not match
-            if introScreen != nil && persistedCurrentVersion != AppInfo.appVersion {
-                InstallType.set(type: .upgrade)
-                InstallType.updateCurrentVersion(version: AppInfo.appVersion)
-            }
+        let persistedCurrentVersion = InstallType.persistedCurrentVersion()
+        let introScreen = profile.prefs.intForKey(PrefsKeys.IntroSeen)
+        // upgrade install - Intro screen shown & persisted current version does not match
+        if introScreen != nil && persistedCurrentVersion != AppInfo.appVersion {
+            InstallType.set(type: .upgrade)
+            InstallType.updateCurrentVersion(version: AppInfo.appVersion)
+        }
 
-            // We need to check if the app is a clean install to use for
-            // preventing the What's New URL from appearing.
-            if introScreen == nil {
-                // fresh install - Intro screen not yet shown
-                InstallType.set(type: .fresh)
-                InstallType.updateCurrentVersion(version: AppInfo.appVersion)
-                // Profile setup
-                profile.prefs.setString(AppInfo.appVersion, forKey: LatestAppVersionProfileKey)
+        // We need to check if the app is a clean install to use for
+        // preventing the What's New URL from appearing.
+        if introScreen == nil {
+            // fresh install - Intro screen not yet shown
+            InstallType.set(type: .fresh)
+            InstallType.updateCurrentVersion(version: AppInfo.appVersion)
+            // Profile setup
+            profile.prefs.setString(AppInfo.appVersion, forKey: LatestAppVersionProfileKey)
 
-            } else if profile.prefs.boolForKey(PrefsKeys.KeySecondRun) == nil {
-                profile.prefs.setBool(true, forKey: PrefsKeys.KeySecondRun)
-            }
+        } else if profile.prefs.boolForKey(PrefsKeys.KeySecondRun) == nil {
+            profile.prefs.setBool(true, forKey: PrefsKeys.KeySecondRun)
         }
 
         BGTaskScheduler.shared.register(forTaskWithIdentifier: "org.mozilla.ios.sync.part1", using: DispatchQueue.global()) { task in
-            guard self.profile?.hasSyncableAccount() ?? false else {
+            guard self.profile.hasSyncableAccount() else {
                 self.shutdownProfileWhenNotActive(application)
                 return
             }
 
             NSLog("background sync part 1") // NSLog to see in device console
             let collection = ["bookmarks", "history"]
-            self.profile?.syncManager.syncNamedCollections(why: .backgrounded, names: collection).uponQueue(.main) { _ in
+            self.profile.syncManager.syncNamedCollections(why: .backgrounded, names: collection).uponQueue(.main) { _ in
                 task.setTaskCompleted(success: true)
                 let request = BGProcessingTaskRequest(identifier: "org.mozilla.ios.sync.part2")
                 request.earliestBeginDate = Date(timeIntervalSinceNow: 1)
@@ -192,7 +170,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         BGTaskScheduler.shared.register(forTaskWithIdentifier: "org.mozilla.ios.sync.part2", using: DispatchQueue.global()) { task in
             NSLog("background sync part 2") // NSLog to see in device console
             let collection = ["tabs", "logins", "clients"]
-            self.profile?.syncManager.syncNamedCollections(why: .backgrounded, names: collection).uponQueue(.main) { _ in
+            self.profile.syncManager.syncNamedCollections(why: .backgrounded, names: collection).uponQueue(.main) { _ in
                 self.shutdownProfileWhenNotActive(application)
                 task.setTaskCompleted(success: true)
             }
@@ -207,11 +185,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         var sessionCount: Int32 = 0
 
         // Get the session count from preferences
-        if let currentSessionCount = profile?.prefs.intForKey(PrefsKeys.SessionCount) {
+        if let currentSessionCount = profile.prefs.intForKey(PrefsKeys.SessionCount) {
             sessionCount = currentSessionCount
         }
         // increase session count value
-        profile?.prefs.setInt(sessionCount + 1, forKey: PrefsKeys.SessionCount)
+        profile.prefs.setInt(sessionCount + 1, forKey: PrefsKeys.SessionCount)
     }
 
     func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
@@ -219,7 +197,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return false
         }
 
-        if let profile = profile, let _ = profile.prefs.boolForKey(PrefsKeys.AppExtensionTelemetryOpenUrl) {
+        if let _ = profile.prefs.boolForKey(PrefsKeys.AppExtensionTelemetryOpenUrl) {
             profile.prefs.removeObjectForKey(PrefsKeys.AppExtensionTelemetryOpenUrl)
             var object = TelemetryWrapper.EventObject.url
             if case .text = routerpath {
@@ -240,16 +218,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         shutdownWebServer?.cancel()
         shutdownWebServer = nil
 
-        if let profile = self.profile {
-            profile._reopen()
+        profile._reopen()
 
-            if profile.prefs.boolForKey(PendingAccountDisconnectedKey) ?? false {
-                profile.removeAccount()
-            }
-
-            profile.syncManager.applicationDidBecomeActive()
-            webServerUtil?.setUpWebServer()
+        if profile.prefs.boolForKey(PendingAccountDisconnectedKey) ?? false {
+            profile.removeAccount()
         }
+
+        profile.syncManager.applicationDidBecomeActive()
+        webServerUtil?.setUpWebServer()
 
         browserViewController.firefoxHomeViewController?.reloadAll()
 
@@ -274,7 +250,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Cleanup can be a heavy operation, take it out of the startup path. Instead check after a few seconds.
         DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
-            self.profile?.cleanupHistoryIfNeeded()
+            self.profile.cleanupHistoryIfNeeded()
             self.browserViewController.ratingPromptManager.updateData()
         }
     }
@@ -311,7 +287,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Since we only need the topSites data in the archiver, let's write it
         // only if iOS 14 is available.
         if #available(iOS 14.0, *) {
-            guard let profile = profile else { return }
             TopSitesHelper.writeWidgetKitTopSites(profile: profile)
         }
     }
@@ -322,7 +297,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return
         }
 
-        profile?._shutdown()
+        profile._shutdown()
     }
 
     /// When a user presses and holds the app icon from the Home Screen, we present quick actions / shortcut items (see QuickActions).
@@ -339,7 +314,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     private func scheduleBGSync(application: UIApplication) {
-        if profile?.syncManager.isSyncing ?? false {
+        if profile.syncManager.isSyncing {
             // If syncing, create a bg task because _shutdown() is blocking and might take a few seconds to complete
             var taskId = UIBackgroundTaskIdentifier(rawValue: 0)
             taskId = application.beginBackgroundTask(expirationHandler: {
@@ -353,7 +328,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         } else {
             // Blocking call, however without sync running it should be instantaneous
-            profile?._shutdown()
+            profile._shutdown()
 
             let request = BGProcessingTaskRequest(identifier: "org.mozilla.ios.sync.part1")
             request.earliestBeginDate = Date(timeIntervalSinceNow: 1)
@@ -436,7 +411,7 @@ extension AppDelegate {
             window?.overrideUserInterfaceStyle = LegacyThemeManager.instance.userInterfaceStyle
         }
 
-        browserViewController = BrowserViewController(profile: profile!, tabManager: tabManager)
+        browserViewController = BrowserViewController(profile: profile, tabManager: tabManager)
         browserViewController.edgesForExtendedLayout = []
 
         let navigationController = UINavigationController(rootViewController: browserViewController)

--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -13,8 +13,19 @@ class TestAppDelegate: AppDelegate, FeatureFlaggable {
 
     lazy var dirForTestProfile = { return "\(self.appRootDir())/profile.testProfile" }()
 
-    override func getProfile(_ application: UIApplication) -> Profile {
-        if let profile = self.profile {
+    private var internalProfile: Profile?
+
+    override var profile: Profile {
+        get {
+            getProfile(UIApplication.shared)
+        }
+        set {
+            internalProfile = newValue
+        }
+    }
+
+    func getProfile(_ application: UIApplication) -> Profile {
+        if let profile = self.internalProfile {
             return profile
         }
 

--- a/Client/Frontend/Browser/FaviconHandler.swift
+++ b/Client/Frontend/Browser/FaviconHandler.swift
@@ -36,11 +36,13 @@ class FaviconHandler {
         let onSuccess: (Favicon, Data?) -> Void = { [weak tab] (favicon, data) -> Void in
             tab?.favicons.append(favicon)
 
-            guard !(tab?.isPrivate ?? true), let appDelegate = UIApplication.shared.delegate as? AppDelegate, let profile = appDelegate.profile else {
+            guard !(tab?.isPrivate ?? true), let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
                 deferred.fill(Maybe(success: (favicon, data)))
                 return
             }
 
+            let profile = appDelegate.profile
+            
             profile.favicons.addFavicon(favicon, forSite: site) >>> {
                 deferred.fill(Maybe(success: (favicon, data)))
             }

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetWidgets.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetWidgets.swift
@@ -173,7 +173,8 @@ class PhotonActionSheetSiteHeaderView: UITableViewHeaderFooterView {
             self.siteImageView.setFavicon(forSite: site) {
                 self.siteImageView.image = self.siteImageView.image?.createScaled(PhotonActionSheet.UX.IconSize)
             }
-        } else if let appDelegate = UIApplication.shared.delegate as? AppDelegate, let profile = appDelegate.profile {
+        } else if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+            let profile = appDelegate.profile
             profile.favicons.getFaviconImage(forSite: site).uponQueue(.main) { result in
                 guard let image = result.successValue else {
                     return


### PR DESCRIPTION
This is a small change but it's a risky one because it could have unforeseen consequences. Because of this I would like 2 approvals before merging. 

I have moved the Profile object to be created and owned by the AppDelegate instead of BrowserViewController. The reason behind this change is that in the near future we will want to support multiple instances of BVC but will still only need one instance of Profile, so they need to be decoupled first. 