### PR TITLE
Bugfix FXIOS-3706 [v103] Updated close button color in ETP menu

### DIFF
--- a/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
+++ b/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
@@ -66,7 +66,6 @@ class EnhancedTrackingProtectionMenuVC: UIViewController {
     }
 
     private var closeButton: UIButton = .build { button in
-        button.backgroundColor = .Photon.LightGrey50
         button.layer.cornerRadius = 0.5 * ETPMenuUX.UX.closeButtonSize
         button.clipsToBounds = true
         button.setImage(UIImage(named: "close-medium"), for: .normal)
@@ -429,6 +428,7 @@ extension EnhancedTrackingProtectionMenuVC: NotificationThemeable {
     @objc func applyTheme() {
         overrideUserInterfaceStyle =  LegacyThemeManager.instance.userInterfaceStyle
         view.backgroundColor = UIColor.theme.etpMenu.background
+        closeButton.backgroundColor = UIColor.theme.etpMenu.closeButtonColor
         connectionView.backgroundColor = UIColor.theme.etpMenu.sectionColor
         connectionImage.image = viewModel.connectionStatusImage
         connectionDetailArrow.tintColor = UIColor.theme.etpMenu.defaultImageTints

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
@@ -72,6 +72,7 @@ private class DarkEnhancedTrackingProtectionMenuColor: EnhancedTrackingProtectio
     override var sectionColor: UIColor { return UIColor.Photon.DarkGrey65 }
     override var switchAndButtonTint: UIColor { return UIColor.Photon.Blue20 }
     override var subtextColor: UIColor { return UIColor.Photon.LightGrey05 }
+    override var closeButtonColor: UIColor { return UIColor.Photon.DarkGrey65 }
 }
 
 private class DarkTopTabsColor: TopTabsColor {

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
@@ -129,6 +129,7 @@ class EnhancedTrackingProtectionMenuColor {
     var sectionColor: UIColor { return .white }
     var switchAndButtonTint: UIColor { return UIColor.Photon.Blue50 }
     var subtextColor: UIColor { return UIColor.Photon.Grey75A60}
+    var closeButtonColor: UIColor { return UIColor.Photon.LightGrey30 }
 }
 
 class TopTabsColor {


### PR DESCRIPTION
Resolves https://github.com/mozilla-mobile/firefox-ios/issues/9926

Updated the color of the close button in Enhanced Tracking Protection View Controller. Added support for both dark mode and light mode with `UIColor.Photon.DarkGrey65` (\#2C2C2E) for dark theme and `UIColor.Photon.LightGrey30` (\#E0E0E6) for light theme.



<img width="1792" alt="Screen Shot 2022-06-24 at 7 20 11 PM" src="https://user-images.githubusercontent.com/35638500/175752076-201ec000-325c-4b60-8d7c-fc6d6f92bc5c.png">
