### PR TITLE
Add FXIOS-4321 [v104] SDWebImage clear disk cashe on background and add counter for tracking KF migration

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -343,6 +343,7 @@
 		437A857827E43FE100E42764 /* FxAWebViewTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 437A857727E43FE100E42764 /* FxAWebViewTelemetry.swift */; };
 		437A9B682681256800FB41C1 /* InactiveTabCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 437A9B672681256800FB41C1 /* InactiveTabCell.swift */; };
 		437A9B6A2681257F00FB41C1 /* InactiveTabViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 437A9B692681257F00FB41C1 /* InactiveTabViewModel.swift */; };
+		439086AB286CE61600897904 /* SDWebImageCacheExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 439086AA286CE61600897904 /* SDWebImageCacheExtension.swift */; };
 		4390F7FF246DAFBE00570811 /* FirefoxColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4390F7FE246DAFBE00570811 /* FirefoxColors.swift */; };
 		4392FB20252EC49D00AD3D23 /* SessionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C027441B2A348C001B1E88 /* SessionData.swift */; };
 		4392FB34252EC4CE00AD3D23 /* SessionRestoreHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBC4869C2195F58300CDA48D /* SessionRestoreHandler.swift */; };
@@ -386,6 +387,7 @@
 		43DDB96A240994370058A068 /* ETPCoverSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DDB969240994360058A068 /* ETPCoverSheetViewController.swift */; };
 		43DDB96C240995A70058A068 /* ETPModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DDB96B240995A70058A068 /* ETPModel.swift */; };
 		43DDB97624099F200058A068 /* ETPViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DDB97524099F200058A068 /* ETPViewModel.swift */; };
+		43DF9D992874C0690038F33A /* ImageLoadingHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DF9D982874C0690038F33A /* ImageLoadingHandlerTests.swift */; };
 		43E69EC3254D081D00B591C2 /* SimpleTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E69EAF254D064E00B591C2 /* SimpleTab.swift */; };
 		43E69ED7254D081F00B591C2 /* SimpleTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E69EAF254D064E00B591C2 /* SimpleTab.swift */; };
 		43F7952525795F69005AEE40 /* SearchTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F7952425795F69005AEE40 /* SearchTelemetry.swift */; };
@@ -2315,6 +2317,7 @@
 		437A9B672681256800FB41C1 /* InactiveTabCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactiveTabCell.swift; sourceTree = "<group>"; };
 		437A9B692681257F00FB41C1 /* InactiveTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactiveTabViewModel.swift; sourceTree = "<group>"; };
 		43904ED28118BAD713896491 /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/HistoryPanel.strings; sourceTree = "<group>"; };
+		439086AA286CE61600897904 /* SDWebImageCacheExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDWebImageCacheExtension.swift; sourceTree = "<group>"; };
 		4390F7FE246DAFBE00570811 /* FirefoxColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirefoxColors.swift; sourceTree = "<group>"; };
 		439B008A26E6CE2100DFAF14 /* GroupedTabCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedTabCell.swift; sourceTree = "<group>"; };
 		43A5643523CD1E1B00B6857D /* UpdateViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdateViewController.swift; sourceTree = "<group>"; };
@@ -2337,6 +2340,7 @@
 		43DDB969240994360058A068 /* ETPCoverSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ETPCoverSheetViewController.swift; sourceTree = "<group>"; };
 		43DDB96B240995A70058A068 /* ETPModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ETPModel.swift; sourceTree = "<group>"; };
 		43DDB97524099F200058A068 /* ETPViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ETPViewModel.swift; sourceTree = "<group>"; };
+		43DF9D982874C0690038F33A /* ImageLoadingHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoadingHandlerTests.swift; sourceTree = "<group>"; };
 		43E448868CEE068E52298FEC /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/HistoryPanel.strings"; sourceTree = "<group>"; };
 		43E69EAF254D064E00B591C2 /* SimpleTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleTab.swift; sourceTree = "<group>"; };
 		43EB00C2265861E8009A5F61 /* az */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = az; path = "az.lproj/Default Browser.strings"; sourceTree = "<group>"; };
@@ -5208,6 +5212,7 @@
 				EB9A178D20E525DF00B12184 /* ThemeSettingsController.swift */,
 				66CE54A720FCF6CF00CC310B /* WebsiteDataManagementViewController.swift */,
 				6669B5E1211418A200CA117B /* WebsiteDataSearchResultsViewController.swift */,
+				439086AA286CE61600897904 /* SDWebImageCacheExtension.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -7187,6 +7192,7 @@
 				E4CD9F1C1A6D9C2800318571 /* WebServerTests.swift */,
 				D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */,
 				6ADB651A285C03B100947EA4 /* DownloadHelperTests.swift */,
+				43DF9D982874C0690038F33A /* ImageLoadingHandlerTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -9592,6 +9598,7 @@
 				E65075541E37F6FC006961AC /* DynamicFontHelper.swift in Sources */,
 				C82CDD47233E8996002E2743 /* Tab+ChangeUserAgent.swift in Sources */,
 				C4E3984C1D21F2FD004E89BA /* TabTrayButtonExtensions.swift in Sources */,
+				439086AB286CE61600897904 /* SDWebImageCacheExtension.swift in Sources */,
 				437A857827E43FE100E42764 /* FxAWebViewTelemetry.swift in Sources */,
 				D3FEC38D1AC4B42F00494F45 /* AutocompleteTextField.swift in Sources */,
 				C849E46526B9C3DD00260F0B /* SlideoverPresentationController.swift in Sources */,
@@ -9784,6 +9791,7 @@
 				8AE1E1DB27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift in Sources */,
 				CA24B53924ABFE250093848C /* LoginsListSelectionHelperTests.swift in Sources */,
 				2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */,
+				43DF9D992874C0690038F33A /* ImageLoadingHandlerTests.swift in Sources */,
 				D525DFB325FBE5E000B18763 /* TabTests.swift in Sources */,
 				C8E78BDD27F4A1E700C48BAA /* HistoryDeletionUtilityTests.swift in Sources */,
 				8A11C8132731E54800AC7318 /* DictionaryExtensionsTests.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -14,6 +14,7 @@ import CoreSpotlight
 import UserNotifications
 import Account
 import BackgroundTasks
+import SDWebImage
 
 let LatestAppVersionProfileKey = "latestAppVersion"
 
@@ -178,6 +179,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         scheduleBGSync(application: application)
 
         tabManager.preserveTabs()
+
+        // send glean telemetry and clear cache
+        // we do this to remove any disk cache
+        // that the app might have built over the
+        // time which is taking up un-necessary space
+        SDImageCache.shared.clearDiskCache { _ in }
     }
 
     private func updateTopSitesWidget() {

--- a/Client/Frontend/Settings/SDWebImageCacheExtension.swift
+++ b/Client/Frontend/Settings/SDWebImageCacheExtension.swift
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Glean
+import SDWebImage
+
+// TODO: This file and all its methods should be removed once we are ready to remove SDWebImage from our app
+struct SDWebImageCacheKey {
+    public static let hasClearedCacheKey = "HasClearedCacheKey"
+}
+
+extension SDImageCache {
+
+    func clearDiskCache(completion: @escaping (Bool) -> Void) {
+        let defaults = UserDefaults.standard
+        let hasClearedDiskCache = defaults.bool(forKey: SDWebImageCacheKey.hasClearedCacheKey)
+        guard !hasClearedDiskCache else {
+            completion(false)
+            return
+        }
+
+        SDImageCache.shared.clear(with: .disk) {
+            //Send glean telemetry when cache is cleared
+            TelemetryWrapper.recordEvent(category: .information, method: .delete, object: .clearSDWebImageCache)
+
+            //Set the userdefaults value so we don't clear disk cache again once cleared
+            defaults.set(true, forKey: SDWebImageCacheKey.hasClearedCacheKey)
+
+            completion(true)
+        }
+    }
+}

--- a/Client/Frontend/Settings/SDWebImageCacheExtension.swift
+++ b/Client/Frontend/Settings/SDWebImageCacheExtension.swift
@@ -22,10 +22,10 @@ extension SDImageCache {
         }
 
         SDImageCache.shared.clear(with: .disk) {
-            //Send glean telemetry when cache is cleared
+            // Send glean telemetry when cache is cleared
             TelemetryWrapper.recordEvent(category: .information, method: .delete, object: .clearSDWebImageCache)
 
-            //Set the userdefaults value so we don't clear disk cache again once cleared
+            // Set the userdefaults value so we don't clear disk cache again once cleared
             defaults.set(true, forKey: SDWebImageCacheKey.hasClearedCacheKey)
 
             completion(true)

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -439,6 +439,7 @@ extension TelemetryWrapper {
         case fxaConfirmSignInToken = "fxa-confirm-signin-token"
         case awesomebarLocation = "awesomebar-position"
         case searchHighlights = "search-highlights"
+        case clearSDWebImageCache = "clear-sd-webimage-cache"
     }
 
     public enum EventValue: String {
@@ -1132,6 +1133,8 @@ extension TelemetryWrapper {
                     GleanMetrics.Messaging.MalformedExtra(messageKey: messageId)
                 )
             }
+        case (.information, .delete, .clearSDWebImageCache, _, _):
+            GleanMetrics.Migration.imageSdCacheCleanup.add()
 
         default:
             recordUninstrumentedMetrics(category: category, method: method, object: object, value: value, extras: extras)

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -2802,3 +2802,16 @@ adjust:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2023-01-01"
+migration:
+  image_sd_cache_cleanup:
+    type: counter
+    description: |
+        Counts the number of times a user runs the
+        sd web image library cache cleanup
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/10903
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/11169
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-01-01"

--- a/Tests/ClientTests/ImageLoadingHandlerTests.swift
+++ b/Tests/ClientTests/ImageLoadingHandlerTests.swift
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+@testable import Client
+
+import XCTest
+import SDWebImage
+
+class ImageLoadingHandlerTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: SDWebImageCacheKey.hasClearedCacheKey)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func test_SDWebImageDiskCacheClear() {
+        let expectation = expectation(description: "Wait for SDWebImage disk cache to clear")
+
+        SDImageCache.shared.clearDiskCache { didClear in
+            XCTAssertTrue(didClear)
+            let defaults = UserDefaults.standard
+            let hasClearedDiskCache = defaults.bool(forKey: SDWebImageCacheKey.hasClearedCacheKey)
+            XCTAssertTrue(hasClearedDiskCache)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 3.0)
+    }
+}

--- a/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -209,6 +209,13 @@ class TelemetryWrapperTests: XCTestCase {
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.closeTap)
     }
+
+    // MARK: - Migration
+
+    func test_SDWebImageDiskCacheClear_GleanIsCalled() {
+        TelemetryWrapper.recordEvent(category: .information, method: .delete, object: .clearSDWebImageCache)
+        testCounterMetricRecordingSuccess(metric: GleanMetrics.Migration.imageSdCacheCleanup)
+    }
 }
 
 // MARK: - Helper functions to test telemetry


### PR DESCRIPTION
When the app enters the background we will run a method to clean up any disk cache that SDWebImage might have. 

This will only run once per app session and we'll monitor it via Glean telemetry. Once an acceptable number has been reached we can then have a follow-up PR to remove all instances of SDWebImage library.

