### PR TITLE
Add FXIOS-4152 [v104]: Have Profile resolve from the container

### DIFF
--- a/Client/AdjustHelper.swift
+++ b/Client/AdjustHelper.swift
@@ -15,8 +15,10 @@ final class AdjustHelper: FeatureFlaggable {
     private let profile: Profile
     private let telemetryHelper: AdjustTelemetryProtocol
 
-    init(profile: Profile,
-         telemetryHelper: AdjustTelemetryProtocol = AdjustTelemetryHelper()) {
+    init(
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        telemetryHelper: AdjustTelemetryProtocol = AdjustTelemetryHelper()
+    ) {
         self.profile = profile
         self.telemetryHelper = telemetryHelper
     }

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -26,24 +26,27 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var tabManager: TabManager!
     var receivedURLs = [URL]()
     var orientationLock = UIInterfaceOrientationMask.all
-    lazy var profile: Profile = BrowserProfile(localName: "profile",
-                                               syncDelegate: UIApplication.shared.syncDelegate)
-    private let log = Logger.browserLogger
+    var profile: Profile = AppContainer.shared.resolve(type: Profile.self)
+
     private var shutdownWebServer: DispatchSourceTimer?
     private var webServerUtil: WebServerUtil?
     private var appLaunchUtil: AppLaunchUtil?
-    func application(_ application: UIApplication,
-                     willFinishLaunchingWithOptions
-                     launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+    private let log = Logger.browserLogger
+
+    func application(
+        _ application: UIApplication,
+        willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
         log.info("startApplication begin")
 
         self.window = UIWindow(frame: UIScreen.main.bounds)
 
-        appLaunchUtil = AppLaunchUtil(profile: profile)
+        appLaunchUtil = AppLaunchUtil()
         appLaunchUtil?.setUpPreLaunchDependencies()
 
         // Set up a web server that serves us static content. Do this early so that it is ready when the UI is presented.
-        webServerUtil = WebServerUtil(profile: profile)
+        webServerUtil = WebServerUtil()
         webServerUtil?.setUpWebServer()
 
         let imageStore = DiskImageStore(files: profile.files, namespace: "TabManagerScreenshots", quality: UIConstants.ScreenshotQuality)
@@ -333,7 +336,7 @@ extension AppDelegate {
             window?.overrideUserInterfaceStyle = LegacyThemeManager.instance.userInterfaceStyle
         }
 
-        browserViewController = BrowserViewController(profile: profile, tabManager: tabManager)
+        browserViewController = BrowserViewController(tabManager: tabManager)
         browserViewController.edgesForExtendedLayout = []
 
         let navigationController = UINavigationController(rootViewController: browserViewController)

--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -287,10 +287,9 @@ enum NavigationPath {
     }
 
     private static func handleSettings(settings: SettingsPage, with rootNav: UINavigationController, baseSettingsVC: AppSettingsTableViewController, and bvc: BrowserViewController) {
+        let profile = baseSettingsVC.profile
 
-        guard let profile = baseSettingsVC.profile,
-              let tabManager = baseSettingsVC.tabManager
-        else { return }
+        guard let tabManager = baseSettingsVC.tabManager else { return }
 
         let controller = ThemedNavigationController(rootViewController: baseSettingsVC)
         controller.presentingModalViewControllerDelegate = bvc
@@ -305,24 +304,22 @@ enum NavigationPath {
             viewController.profile = profile
             controller.pushViewController(viewController, animated: true)
         case .homepage:
-            let viewController = HomePageSettingViewController(prefs: baseSettingsVC.profile.prefs)
+            let viewController = HomePageSettingViewController()
             viewController.profile = profile
             controller.pushViewController(viewController, animated: true)
         case .mailto:
-            let viewController = OpenWithSettingsViewController(prefs: profile.prefs)
+            let viewController = OpenWithSettingsViewController()
             controller.pushViewController(viewController, animated: true)
         case .search:
             let viewController = SearchSettingsTableViewController()
             viewController.model = profile.searchEngines
-            viewController.profile = profile
             controller.pushViewController(viewController, animated: true)
         case .clearPrivateData:
             let viewController = ClearPrivateDataTableViewController()
-            viewController.profile = profile
             viewController.tabManager = tabManager
             controller.pushViewController(viewController, animated: true)
         case .fxa:
-            let viewController = FirefoxAccountSignInViewController.getSignInOrFxASettingsVC(flowType: .emailLoginFlow, referringPage: .settings, profile: bvc.profile)
+            let viewController = FirefoxAccountSignInViewController.getSignInOrFxASettingsVC(flowType: .emailLoginFlow, referringPage: .settings)
             controller.pushViewController(viewController, animated: true)
         case .theme:
             controller.pushViewController(ThemeSettingsController(), animated: true)

--- a/Client/Application/WebServerUtil.swift
+++ b/Client/Application/WebServerUtil.swift
@@ -8,22 +8,21 @@ import Shared
 
 class WebServerUtil {
 
-    private var readerModeHander: ReaderModeHandlersProtocol
+    private var readerModeHandler: ReaderModeHandlersProtocol
     private var webServer: WebServerProtocol
-    private var profile: Profile
 
-    init(readerModeHander: ReaderModeHandlersProtocol = ReaderModeHandlers(),
-         webServer: WebServer = WebServer.sharedInstance,
-         profile: Profile) {
-        self.readerModeHander = readerModeHander
+    init(
+        readerModeHander: ReaderModeHandlersProtocol = ReaderModeHandlers(),
+        webServer: WebServer = WebServer.sharedInstance
+    ) {
+        self.readerModeHandler = readerModeHander
         self.webServer = webServer
-        self.profile = profile
     }
 
     func setUpWebServer() {
         guard !webServer.server.isRunning else { return }
 
-        readerModeHander.register(webServer, profile: profile)
+        readerModeHandler.register(webServer)
 
         let responders: [(String, InternalSchemeResponse)] =
              [(AboutHomeHandler.path, AboutHomeHandler()),

--- a/Client/FeatureFlags/FeatureFlagUserPrefsMigrationUtility.swift
+++ b/Client/FeatureFlags/FeatureFlagUserPrefsMigrationUtility.swift
@@ -29,7 +29,10 @@ final class FeatureFlagUserPrefsMigrationUtility {
     }
 
     // MARK: - Initializers
-    init(with profile: Profile, and userDefaults: UserDefaults = .standard) {
+    init(
+        with profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        and userDefaults: UserDefaults = .standard
+    ) {
         self.profile = profile
         self.userDefaults = userDefaults
     }

--- a/Client/FeatureFlags/FeatureFlagsManager.swift
+++ b/Client/FeatureFlags/FeatureFlagsManager.swift
@@ -128,7 +128,7 @@ class FeatureFlagsManager: HasNimbusFeatureFlags {
     ///
     /// This should ONLY be called when instatiating the feature flag system,
     /// and never again.
-    public func initializeDeveloperFeatures(with profile: Profile) {
+    public func initializeDeveloperFeatures(with profile: Profile = AppContainer.shared.resolve(type: Profile.self)) {
         self.profile = profile
 
         coreFeatures.removeAll()

--- a/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -86,7 +86,10 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
     }
 
     // MARK: - Initializers
-    init(withID featureID: NimbusFeatureFlagID, and profile: Profile) {
+    init(
+        withID featureID: NimbusFeatureFlagID,
+        and profile: Profile = AppContainer.shared.resolve(type: Profile.self)
+    ) {
         self.featureID = featureID
         self.profile = profile
     }

--- a/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -61,7 +61,10 @@ class BackForwardListViewController: UIViewController, UITableViewDataSource, UI
 
     var snappedToBottom: Bool = true
 
-    init(profile: Profile, backForwardList: WKBackForwardList) {
+    init(
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        backForwardList: WKBackForwardList
+    ) {
         self.profile = profile
         super.init(nibName: nil, bundle: nil)
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -31,7 +31,7 @@ extension BrowserViewController {
 
     @objc private func openClearHistoryPanelKeyCommand() {
         guard let libraryViewController = self.libraryViewController else {
-            let clearHistoryHelper = ClearHistoryHelper(profile: profile, tabManager: tabManager)
+            let clearHistoryHelper = ClearHistoryHelper(tabManager: tabManager)
             clearHistoryHelper.showClearRecentHistory(onViewController: self, didComplete: nil)
             return
         }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -82,8 +82,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
         libraryDrawerViewController?.close(immediately: true)
 
-        let menuHelper = MainMenuActionHelper(profile: profile,
-                                              tabManager: tabManager,
+        let menuHelper = MainMenuActionHelper(tabManager: tabManager,
                                               buttonView: button,
                                               showFXASyncAction: presentSignInViewController)
         menuHelper.delegate = self
@@ -173,7 +172,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
 
     func showBackForwardList() {
         if let backForwardList = tabManager.selectedTab?.webView?.backForwardList {
-            let backForwardViewController = BackForwardListViewController(profile: profile, backForwardList: backForwardList)
+            let backForwardViewController = BackForwardListViewController(backForwardList: backForwardList)
             backForwardViewController.tabManager = tabManager
             backForwardViewController.bvc = self
             backForwardViewController.modalPresentationStyle = .overCurrentContext

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -34,7 +34,6 @@ extension BrowserViewController: URLBarDelegate {
 
         self.tabTrayViewController = TabTrayViewController(
             tabTrayDelegate: self,
-            profile: profile,
             tabToFocus: tabToFocus,
             tabManager: tabManager)
 
@@ -86,7 +85,7 @@ extension BrowserViewController: URLBarDelegate {
 
     func urlBarDidTapShield(_ urlBar: URLBarView) {
         if let tab = self.tabManager.selectedTab {
-            let etpViewModel = EnhancedTrackingProtectionMenuVM(tab: tab, profile: profile, tabManager: tabManager)
+            let etpViewModel = EnhancedTrackingProtectionMenuVM(tab: tab, tabManager: tabManager)
             etpViewModel.onOpenSettingsTapped = {
                 let settingsTableViewController = AppSettingsTableViewController(
                     with: self.profile,

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -707,7 +707,7 @@ extension BrowserViewController: WKNavigationDelegate {
         }
 
         if let url = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL {
-            ErrorPageHelper(certStore: profile.certStore).loadPage(error, forUrl: url, inWebView: webView)
+            ErrorPageHelper().loadPage(error, forUrl: url, inWebView: webView)
         }
     }
 

--- a/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -25,7 +25,10 @@ class ClipboardBarDisplayHandler: NSObject, URLChangeDelegate {
     private weak var firstTab: Tab?
     var clipboardToast: ButtonToast?
 
-    init(prefs: Prefs, tabManager: TabManager) {
+    init(
+        prefs: Prefs = AppContainer.shared.resolve(type: Profile.self).prefs,
+        tabManager: TabManager
+    ) {
         self.prefs = prefs
         self.tabManager = tabManager
 

--- a/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVM.swift
+++ b/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVM.swift
@@ -51,7 +51,11 @@ class EnhancedTrackingProtectionMenuVM {
 
     // MARK: - Initializers
 
-    init(tab: Tab, profile: Profile, tabManager: TabManager) {
+    init(
+        tab: Tab,
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        tabManager: TabManager
+    ) {
         self.tab = tab
         self.profile = profile
         self.tabManager = tabManager

--- a/Client/Frontend/Browser/FirefoxTabContentBlocker.swift
+++ b/Client/Frontend/Browser/FirefoxTabContentBlocker.swift
@@ -58,7 +58,10 @@ class FirefoxTabContentBlocker: TabContentBlocker, TabContentScript {
         return userPrefs.stringForKey(ContentBlockingConfig.Prefs.StrengthKey).flatMap(BlockingStrength.init) ?? .basic
     }
 
-    init(tab: ContentBlockerTab, prefs: Prefs) {
+    init(
+        tab: ContentBlockerTab,
+        prefs: Prefs = AppContainer.shared.resolve(type: Profile.self).prefs
+    ) {
         userPrefs = prefs
         super.init(tab: tab)
         setupForTab()

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -73,11 +73,12 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
     }
 
     // MARK: - Inits
-    init(tabManager: TabManager,
-         profile: Profile,
-         tabTrayDelegate: TabTrayDelegate? = nil,
-         tabToFocus: Tab? = nil,
-         notificationCenter: NotificationCenter = NotificationCenter.default
+    init(
+        tabManager: TabManager,
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        tabTrayDelegate: TabTrayDelegate? = nil,
+        tabToFocus: Tab? = nil,
+        notificationCenter: NotificationCenter = NotificationCenter.default
     ) {
         self.tabManager = tabManager
         self.profile = profile
@@ -85,8 +86,7 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
         self.tabToFocus = tabToFocus
         self.notificationCenter = notificationCenter
 
-        let contextualViewModel = ContextualHintViewModel(forHintType: .inactiveTabs,
-                                                          with: profile)
+        let contextualViewModel = ContextualHintViewModel(forHintType: .inactiveTabs)
         self.contextualHintViewController = ContextualHintViewController(with: contextualViewModel)
 
         super.init(nibName: nil, bundle: nil)
@@ -103,13 +103,15 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
             LabelButtonHeaderView.self,
             forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
             withReuseIdentifier: GridTabViewController.independentTabsHeaderIdentifier)
-        tabDisplayManager = TabDisplayManager(collectionView: self.collectionView,
-                                              tabManager: self.tabManager,
-                                              tabDisplayer: self,
-                                              reuseID: TabCell.cellIdentifier,
-                                              tabDisplayType: .TabGrid,
-                                              profile: profile,
-                                              cfrDelegate: self)
+
+        tabDisplayManager = TabDisplayManager(
+            collectionView: self.collectionView,
+            tabManager: self.tabManager,
+            tabDisplayer: self,
+            reuseID: TabCell.cellIdentifier,
+            tabDisplayType: .TabGrid,
+            cfrDelegate: self)
+
         collectionView.dataSource = tabDisplayManager
         collectionView.delegate = tabLayoutDelegate
 
@@ -745,9 +747,8 @@ private class TabLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout, U
         else { return nil }
 
         let tabVC = TabPeekViewController(tab: tab, delegate: tabPeekDelegate)
-        if let browserProfile = tabDisplayManager.profile as? BrowserProfile,
-           let pickerDelegate = tabPeekDelegate as? DevicePickerViewControllerDelegate {
-            tabVC.setState(withProfile: browserProfile, clientPickerDelegate: pickerDelegate)
+        if let pickerDelegate = tabPeekDelegate as? DevicePickerViewControllerDelegate {
+            tabVC.setState(clientPickerDelegate: pickerDelegate)
         }
 
         return UIContextMenuConfiguration(identifier: nil, previewProvider: { return tabVC }, actionProvider: tabVC.contextActions(defaultActions:))

--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -62,11 +62,12 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
     ///   - tabManager: the tab manager
     ///   - buttonView: the view from which the menu will be shown
     ///   - showFXASyncAction: the closure that will be executed for the sync action in the library section
-    init(profile: Profile,
-         tabManager: TabManager,
-         buttonView: UIButton,
-         showFXASyncAction: @escaping (FXASyncClosure) -> Void) {
-
+    init(
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        tabManager: TabManager,
+        buttonView: UIButton,
+        showFXASyncAction: @escaping (FXASyncClosure) -> Void
+    ) {
         self.profile = profile
         self.tabManager = tabManager
         self.buttonView = buttonView
@@ -805,12 +806,15 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
 
     private func showLoginListVC(navigationHandler: @escaping NavigationHandlerType, navigationController: UINavigationController) {
         guard let menuActionDelegate = menuActionDelegate else { return }
-        LoginListViewController.create(authenticateInNavigationController: navigationController,
-                                       profile: self.profile,
-                                       settingsDelegate: menuActionDelegate,
-                                       webpageNavigationHandler: navigationHandler).uponQueue(.main) { loginsVC in
+
+        LoginListViewController.create(
+            authenticateInNavigationController: navigationController,
+            settingsDelegate: menuActionDelegate,
+            webpageNavigationHandler: navigationHandler
+        ).uponQueue(.main) { loginsVC in
             self.presentLoginList(loginsVC)
         }
+
     }
 
     private func presentLoginList(_ loginsVC: LoginListViewController?) {

--- a/Client/Frontend/Browser/OpenWithSettingsViewController.swift
+++ b/Client/Frontend/Browser/OpenWithSettingsViewController.swift
@@ -12,7 +12,7 @@ class OpenWithSettingsViewController: ThemedTableViewController {
     fileprivate let prefs: Prefs
     fileprivate var currentChoice: String = "mailto"
 
-    init(prefs: Prefs) {
+    init(prefs: Prefs = AppContainer.shared.resolve(type: Profile.self).prefs) {
         self.prefs = prefs
         super.init()
     }

--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -22,7 +22,10 @@ class SearchLoader: Loader<Cursor<Site>, SearchViewController>, FeatureFlaggable
 
     private var skipNextAutocomplete: Bool
 
-    init(profile: Profile, urlBar: URLBarView) {
+    init(
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        urlBar: URLBarView
+    ) {
         self.profile = profile
         self.urlBar = urlBar
         self.frecentHistory = profile.history.getFrecentHistory()

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -97,7 +97,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         self.viewModel = viewModel
         self.tabManager = tabManager
         self.searchFeature = featureConfig
-        super.init(profile: profile)
+        super.init()
 
         if #available(iOS 15.0, *) {
             tableView.sectionHeaderTopPadding = 0

--- a/Client/Frontend/Browser/StartAtHomeHelper.swift
+++ b/Client/Frontend/Browser/StartAtHomeHelper.swift
@@ -5,13 +5,20 @@
 import Shared
 
 class StartAtHomeHelper: FeatureFlaggable {
+
+    private let profile: Profile
     private var isRestoringTabs: Bool
+
     // Override only for unit test to test `shouldSkipStartHome` logic
     private var isRunningTest: Bool
     lazy var startAtHomeSetting: StartAtHomeSetting? = featureFlags.getCustomState(for: .startAtHome)
 
-    init(isRestoringTabs: Bool,
-         isRunnigTest: Bool = AppConstants.IsRunningTest) {
+    init(
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        isRestoringTabs: Bool,
+        isRunnigTest: Bool = AppConstants.IsRunningTest
+    ) {
+        self.profile = profile
         self.isRestoringTabs = isRestoringTabs
         self.isRunningTest = isRunnigTest
     }
@@ -57,9 +64,8 @@ class StartAtHomeHelper: FeatureFlaggable {
     ///   - tabs: The tabs to be scanned, either private, or normal, based on the last session
     ///   - profilePreferences: Preferences stored in the user's `Profile`
     /// - Returns: An optional tab, that matches the user's new tab preferences.
-    public func scanForExistingHomeTab(in tabs: [Tab],
-                                       with profilePreferences: Prefs) -> Tab? {
-        let pagePreferences = NewTabAccessors.getHomePage(profilePreferences)
+    public func scanForExistingHomeTab(in tabs: [Tab]) -> Tab? {
+        let pagePreferences = NewTabAccessors.getHomePage(profile.prefs)
 
         switch pagePreferences {
         case .homePage:

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -77,7 +77,6 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
     fileprivate weak var tabDisplayer: TabDisplayer?
     private let tabReuseIdentifer: String
     private var hasSentInactiveTabShownEvent: Bool = false
-    var profile: Profile
     var cfrDelegate: InactiveTabsCFRProtocol?
     private var nimbus: FxNimbus?
     var notificationCenter: NotificationCenter
@@ -177,7 +176,6 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
          tabDisplayer: TabDisplayer,
          reuseID: String,
          tabDisplayType: TabDisplayType,
-         profile: Profile,
          cfrDelegate: InactiveTabsCFRProtocol? = nil,
          nimbus: FxNimbus = FxNimbus.shared
     ) {
@@ -187,7 +185,6 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
         self.isPrivate = tabManager.selectedTab?.isPrivate ?? false
         self.tabReuseIdentifer = reuseID
         self.tabDisplayType = tabDisplayType
-        self.profile = profile
         self.cfrDelegate = cfrDelegate
         self.nimbus = nimbus
         self.notificationCenter = NotificationCenter.default
@@ -228,7 +225,7 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
 
         // build groups
         if shouldEnableGroupedTabs {
-            SearchTermGroupsUtility.getTabGroups(with: profile,
+            SearchTermGroupsUtility.getTabGroups(with: AppContainer.shared.resolve(type: Profile.self),
                                                  from: tabsToBuildFrom,
                                                  using: .orderedAscending) { tabGroups, filteredActiveTabs  in
 

--- a/Client/Frontend/Browser/TabManagerStore.swift
+++ b/Client/Frontend/Browser/TabManagerStore.swift
@@ -21,7 +21,11 @@ class TabManagerStore: FeatureFlaggable {
         return SiteArchiver.tabsToRestore(tabsStateArchivePath: tabsStateArchivePath())
     }()
 
-    init(imageStore: DiskImageStore?, _ fileManager: FileManager = FileManager.default, prefs: Prefs) {
+    init(
+        imageStore: DiskImageStore?,
+        _ fileManager: FileManager = FileManager.default,
+        prefs: Prefs = AppContainer.shared.resolve(type: Profile.self).prefs
+    ) {
         self.fileManager = fileManager
         self.imageStore = imageStore
         self.prefs = prefs

--- a/Client/Frontend/Browser/TabMetadataManager.swift
+++ b/Client/Frontend/Browser/TabMetadataManager.swift
@@ -6,7 +6,7 @@ import MozillaAppServices
 
 class TabMetadataManager {
 
-    let profile: Profile?
+    let profile: Profile
 
     // Tab Groups
     var tabGroupData = TabGroupData()
@@ -93,11 +93,11 @@ class TabMetadataManager {
 
     // MARK: - Private
 
-    private func updateObservationForKey(key: HistoryMetadataKey,
-                                         observation: HistoryMetadataObservation,
-                                         completion: (() -> Void)?) {
-        guard let profile = profile else { return }
-
+    private func updateObservationForKey(
+        key: HistoryMetadataKey,
+        observation: HistoryMetadataObservation,
+        completion: (() -> Void)?
+    ) {
         guard !key.url.isEmpty else { return }
 
         profile.places.noteHistoryMetadataObservation(key: key, observation: observation).uponQueue(.main) { _ in

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -155,7 +155,6 @@ class TabTrayViewController: UIViewController {
 
     // MARK: - Initializers
     init(tabTrayDelegate: TabTrayDelegate? = nil,
-         profile: Profile,
          tabToFocus: Tab? = nil,
          tabManager: TabManager,
          and notificationCenter: NotificationCenter = NotificationCenter.default,
@@ -164,7 +163,6 @@ class TabTrayViewController: UIViewController {
         self.nimbus = nimbus
         self.notificationCenter = notificationCenter
         self.viewModel = TabTrayViewModel(tabTrayDelegate: tabTrayDelegate,
-                                          profile: profile,
                                           tabToFocus: tabToFocus,
                                           tabManager: tabManager)
 
@@ -467,7 +465,7 @@ extension TabTrayViewController: RemotePanelDelegate {
     // Sign In and Create Account Helper
     func fxaSignInOrCreateAccountHelper() {
         let fxaParams = FxALaunchParams(query: ["entrypoint": "homepanel"])
-        let controller = FirefoxAccountSignInViewController.getSignInOrFxASettingsVC(fxaParams, flowType: .emailLoginFlow, referringPage: .tabTray, profile: viewModel.profile)
+        let controller = FirefoxAccountSignInViewController.getSignInOrFxASettingsVC(fxaParams, flowType: .emailLoginFlow, referringPage: .tabTray)
         (controller as? FirefoxAccountSignInViewController)?.shouldReload = { [weak self] in
             self?.viewModel.reloadRemoteTabs()
         }

--- a/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
@@ -19,14 +19,14 @@ class TabTrayViewModel {
     }
 
     init(tabTrayDelegate: TabTrayDelegate? = nil,
-         profile: Profile,
+         profile: Profile = AppContainer.shared.resolve(type: Profile.self),
          tabToFocus: Tab? = nil,
          tabManager: TabManager) {
         self.profile = profile
         self.tabManager = tabManager
 
-        self.tabTrayView = GridTabViewController(tabManager: self.tabManager, profile: profile, tabTrayDelegate: tabTrayDelegate, tabToFocus: tabToFocus)
-        self.syncedTabsController = RemoteTabsPanel(profile: self.profile)
+        self.tabTrayView = GridTabViewController(tabManager: self.tabManager, tabTrayDelegate: tabTrayDelegate, tabToFocus: tabToFocus)
+        self.syncedTabsController = RemoteTabsPanel()
     }
 
     func navTitle(for segmentIndex: Int, foriPhone: Bool) -> String? {

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -36,7 +36,6 @@ class TopTabsViewController: UIViewController {
     weak var delegate: TopTabsDelegate?
     fileprivate var topTabDisplayManager: TabDisplayManager!
     var tabCellIdentifer: TabDisplayer.TabCellIdentifer = TopTabCell.cellIdentifier
-    var profile: Profile
 
     // MARK: - UI ELements
     lazy var collectionView: UICollectionView = {
@@ -91,17 +90,17 @@ class TopTabsViewController: UIViewController {
     }()
 
     // MARK: - Inits
-    init(tabManager: TabManager, profile: Profile) {
+    init(tabManager: TabManager) {
         self.tabManager = tabManager
-        self.profile = profile
         super.init(nibName: nil, bundle: nil)
 
-        topTabDisplayManager = TabDisplayManager(collectionView: self.collectionView,
-                                                 tabManager: self.tabManager,
-                                                 tabDisplayer: self,
-                                                 reuseID: TopTabCell.cellIdentifier,
-                                                 tabDisplayType: .TopTabTray,
-                                                 profile: profile)
+        topTabDisplayManager = TabDisplayManager(
+            collectionView: self.collectionView,
+            tabManager: self.tabManager,
+            tabDisplayer: self,
+            reuseID: TopTabCell.cellIdentifier,
+            tabDisplayType: .TopTabTray)
+
         collectionView.dataSource = topTabDisplayManager
         collectionView.delegate = tabLayoutDelegate
     }

--- a/Client/Frontend/Contextual Hint/ContextualHintViewModel.swift
+++ b/Client/Frontend/Contextual Hint/ContextualHintViewModel.swift
@@ -63,7 +63,10 @@ class ContextualHintViewModel {
     }
 
     // MARK: - Initializers
-    init(forHintType hintType: ContextualHintViewType, with profile: Profile) {
+    init(
+        forHintType hintType: ContextualHintViewType,
+        with profile: Profile = AppContainer.shared.resolve(type: Profile.self)
+    ) {
         self.hintType = hintType
         self.profile = profile
     }
@@ -180,7 +183,7 @@ class ContextualHintViewModel {
 
     private func getToolbarLocation() -> String {
         guard SearchBarSettingsViewModel.isEnabled,
-              SearchBarSettingsViewModel(prefs: profile.prefs).searchBarPosition == .bottom
+              SearchBarSettingsViewModel().searchBarPosition == .bottom 
         else { return "ToolbarLocationTop" }
 
         return "ToolbarLocationBottom"

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHightlightsViewModel.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHightlightsViewModel.swift
@@ -26,7 +26,7 @@ class HistoryHightlightsViewModel {
     private var isPrivate: Bool
     private var tabManager: TabManager
     private var foregroundBVC: BrowserViewController
-    private lazy var siteImageHelper = SiteImageHelper(profile: profile)
+    private lazy var siteImageHelper = SiteImageHelper()
     private var hasSentSectionEvent = false
 
     var onTapItem: ((HighlightItem) -> Void)?
@@ -66,10 +66,12 @@ class HistoryHightlightsViewModel {
     }
 
     // MARK: - Inits
-    init(with profile: Profile,
-         isPrivate: Bool,
-         tabManager: TabManager = BrowserViewController.foregroundBVC().tabManager,
-         foregroundBVC: BrowserViewController = BrowserViewController.foregroundBVC()) {
+    init(
+        with profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        isPrivate: Bool,
+        tabManager: TabManager = BrowserViewController.foregroundBVC().tabManager,
+        foregroundBVC: BrowserViewController = BrowserViewController.foregroundBVC()
+    ) {
         self.profile = profile
         self.isPrivate = isPrivate
         self.tabManager = tabManager
@@ -115,7 +117,7 @@ class HistoryHightlightsViewModel {
     }
 
     func delete(_ item: HighlightItem) {
-        let deletionUtility = HistoryDeletionUtility(with: profile)
+        let deletionUtility = HistoryDeletionUtility()
         let urls = extractDeletableURLs(from: item)
 
         deletionUtility.delete(urls) { [weak self] success in

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -47,26 +47,33 @@ class HomepageViewController: UIViewController, HomePanel, GleanPlumbMessageMana
     }
 
     // MARK: - Initializers
-    init(profile: Profile,
-         tabManager: TabManager,
-         isZeroSearch: Bool = false,
-         wallpaperManager: WallpaperManager = WallpaperManager()
+    init(
+        tabManager: TabManager,
+        isZeroSearch: Bool = false,
+        wallpaperManager: WallpaperManager = WallpaperManager()
     ) {
         self.isZeroSearch = isZeroSearch
-        self.tabManager = tabManager
-        self.wallpaperManager = wallpaperManager
-        let isPrivate = tabManager.selectedTab?.isPrivate ?? true
-        self.viewModel = HomepageViewModel(profile: profile,
-                                           isZeroSearch: isZeroSearch,
-                                           isPrivate: isPrivate)
 
-        let contextualViewModel = ContextualHintViewModel(forHintType: .jumpBackIn,
-                                                          with: viewModel.profile)
+        self.tabManager = tabManager
+
+        self.wallpaperManager = wallpaperManager
+
+        let isPrivate = tabManager.selectedTab?.isPrivate ?? true
+
+        self.viewModel = HomepageViewModel(
+            isZeroSearch: isZeroSearch,
+            isPrivate: isPrivate)
+
+        let contextualViewModel = ContextualHintViewModel(forHintType: .jumpBackIn)
+
         self.contextualHintViewController = ContextualHintViewController(with: contextualViewModel)
+
         self.contextMenuHelper = HomepageContextMenuHelper(viewModel: viewModel)
+
         super.init(nibName: nil, bundle: nil)
 
         contextMenuHelper.delegate = self
+
         contextMenuHelper.getPopoverSourceRect = { [weak self] popoverView in
             guard let self = self else { return CGRect() }
             return self.getPopoverSourceRect(sourceView: popoverView)
@@ -509,7 +516,7 @@ private extension HomepageViewController {
         let groupSite = ASGroup<Site>(searchTerm: item.displayTitle, groupedItems: groupedSites, timestamp: Date.now())
 
         let asGroupListViewModel = SearchGroupedItemsViewModel(asGroup: groupSite, presenter: .recentlyVisited)
-        let asGroupListVC = SearchGroupedItemsViewController(viewModel: asGroupListViewModel, profile: viewModel.profile)
+        let asGroupListVC = SearchGroupedItemsViewController(viewModel: asGroupListViewModel)
 
         let dismissableController: DismissableNavigationViewController
         dismissableController = DismissableNavigationViewController(rootViewController: asGroupListVC)

--- a/Client/Frontend/Home/HomepageViewModel.swift
+++ b/Client/Frontend/Home/HomepageViewModel.swift
@@ -60,41 +60,49 @@ class HomepageViewModel: FeatureFlaggable {
     var customizeButtonViewModel: CustomizeHomepageSectionViewModel
 
     // MARK: - Initializers
-    init(profile: Profile,
-         isZeroSearch: Bool = false,
-         isPrivate: Bool,
-         nimbus: FxNimbus = FxNimbus.shared) {
+    init(
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        isZeroSearch: Bool = false,
+        isPrivate: Bool,
+        nimbus: FxNimbus = FxNimbus.shared
+    ) {
         self.profile = profile
+
         self.isZeroSearch = isZeroSearch
 
-        self.headerViewModel = HomeLogoHeaderViewModel(profile: profile)
-        self.topSiteViewModel = TopSitesViewModel(
-            profile: profile,
-            isZeroSearch: isZeroSearch)
+        self.headerViewModel = HomeLogoHeaderViewModel()
+
+        self.topSiteViewModel = TopSitesViewModel(isZeroSearch: isZeroSearch)
+
         self.jumpBackInViewModel = JumpBackInViewModel(
             isZeroSearch: isZeroSearch,
-            profile: profile,
-            isPrivate: isPrivate)
-        self.recentlySavedViewModel = RecentlySavedCellViewModel(
-            isZeroSearch: isZeroSearch,
-            profile: profile)
-        self.historyHighlightsViewModel = HistoryHightlightsViewModel(
-            with: profile,
-            isPrivate: isPrivate)
-        self.pocketViewModel = PocketViewModel(
-            isZeroSearch: isZeroSearch)
+            isPrivate: isPrivate
+        )
+
+        self.recentlySavedViewModel = RecentlySavedCellViewModel(isZeroSearch: isZeroSearch)
+
+        self.historyHighlightsViewModel = HistoryHightlightsViewModel(isPrivate: isPrivate)
+
+        self.pocketViewModel = PocketViewModel(isZeroSearch: isZeroSearch)
+
         self.customizeButtonViewModel = CustomizeHomepageSectionViewModel()
-        self.childViewModels = [headerViewModel,
-                                topSiteViewModel,
-                                jumpBackInViewModel,
-                                recentlySavedViewModel,
-                                historyHighlightsViewModel,
-                                pocketViewModel,
-                                customizeButtonViewModel]
+
+        self.childViewModels = [
+            headerViewModel,
+            topSiteViewModel,
+            jumpBackInViewModel,
+            recentlySavedViewModel,
+            historyHighlightsViewModel,
+            pocketViewModel,
+            customizeButtonViewModel
+        ]
+
         self.isPrivate = isPrivate
 
         self.nimbus = nimbus
+
         topSiteViewModel.delegate = self
+
         historyHighlightsViewModel.delegate = self
 
         updateEnabledSections()

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -49,7 +49,7 @@ class JumpBackInViewModel: FeatureFlaggable {
     var mostRecentSyncedTab: JumpBackInSyncedTab?
 
     private var recentTabs: [Tab] = [Tab]()
-    private lazy var siteImageHelper = SiteImageHelper(profile: profile)
+    private lazy var siteImageHelper = SiteImageHelper()
 
     private var recentGroups: [ASGroup<Tab>]?
 
@@ -61,7 +61,7 @@ class JumpBackInViewModel: FeatureFlaggable {
 
     init(
         isZeroSearch: Bool = false,
-        profile: Profile,
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self),
         isPrivate: Bool,
         tabManager: TabManagerProtocol = BrowserViewController.foregroundBVC().tabManager
     ) {

--- a/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
+++ b/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
@@ -11,12 +11,7 @@ class HomeLogoHeaderViewModel {
         static let botttomSpacing: CGFloat = 12
     }
 
-    private let profile: Profile
     var onTapAction: ((UIButton) -> Void)?
-
-    init(profile: Profile) {
-        self.profile = profile
-    }
 }
 
 // MARK: HomeViewModelProtocol

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
@@ -21,7 +21,7 @@ class RecentlySavedCellViewModel {
     var isZeroSearch: Bool
     private let profile: Profile
 
-    private lazy var siteImageHelper = SiteImageHelper(profile: profile)
+    private lazy var siteImageHelper = SiteImageHelper()
     private var readingListItems = [ReadingListItem]()
     private var recentBookmarks = [BookmarkItemData]()
     private let recentItemsHelper = RecentItemsHelper()
@@ -29,7 +29,10 @@ class RecentlySavedCellViewModel {
 
     var headerButtonAction: ((UIButton) -> Void)?
 
-    init(isZeroSearch: Bool, profile: Profile) {
+    init(
+        isZeroSearch: Bool,
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self)
+    ) {
         self.isZeroSearch = isZeroSearch
         self.profile = profile
     }

--- a/Client/Frontend/Home/TopSites/DataManagement/GoogleTopSiteManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/GoogleTopSiteManager.swift
@@ -58,7 +58,7 @@ class GoogleTopSiteManager {
         }
     }
 
-    init(prefs: Prefs) {
+    init(prefs: Prefs = AppContainer.shared.resolve(type: Profile.self).prefs) {
         self.prefs = prefs
     }
 

--- a/Client/Frontend/Home/TopSites/DataManagement/TopSiteHistoryManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/TopSiteHistoryManager.swift
@@ -17,7 +17,7 @@ class TopSiteHistoryManager: DataObserver, Loggable {
     private let events: [Notification.Name] = [.FirefoxAccountChanged, .ProfileDidFinishSyncing, .PrivateDataClearedHistory]
     private let dataQueue = DispatchQueue(label: "com.moz.topSiteHistory.queue")
 
-    init(profile: Profile) {
+    init(profile: Profile = AppContainer.shared.resolve(type: Profile.self)) {
         self.profile = profile
         self.profile.history.setTopSitesCacheSize(ActivityStreamTopSiteCacheSize)
 

--- a/Client/Frontend/Home/TopSites/DataManagement/TopSitesManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/TopSitesManager.swift
@@ -21,11 +21,11 @@ class TopSitesManager: FeatureFlaggable, HasNimbusSponsoredTiles {
     private var contiles: [Contile] = []
 
     weak var delegate: TopSitesManagerDelegate?
-    lazy var topSiteHistoryManager = TopSiteHistoryManager(profile: profile)
-    lazy var googleTopSiteManager = GoogleTopSiteManager(prefs: profile.prefs)
+    lazy var topSiteHistoryManager = TopSiteHistoryManager()
+    lazy var googleTopSiteManager = GoogleTopSiteManager()
     lazy var contileProvider: ContileProviderInterface = ContileProvider()
 
-    init(profile: Profile) {
+    init(profile: Profile = AppContainer.shared.resolve(type: Profile.self)) {
         self.profile = profile
         topSiteHistoryManager.delegate = self
     }

--- a/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -40,10 +40,13 @@ class TopSitesViewModel {
     weak var delegate: TopSitesViewModelDelegate?
 
     lazy var tileManager: TopSitesManager = {
-        return TopSitesManager(profile: profile)
+        return TopSitesManager()
     }()
 
-    init(profile: Profile, isZeroSearch: Bool) {
+    init(
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        isZeroSearch: Bool
+    ) {
         self.profile = profile
         self.isZeroSearch = isZeroSearch
         tileManager.delegate = self

--- a/Client/Frontend/Home/Wallpapers/Utilities/WallpaperMigrationUtility.swift
+++ b/Client/Frontend/Home/Wallpapers/Utilities/WallpaperMigrationUtility.swift
@@ -20,7 +20,7 @@ class WallpaperMigrationUtility {
         return false
     }
 
-    init(with profile: Profile) {
+    init(with profile: Profile = AppContainer.shared.resolve(type: Profile.self)) {
         self.profile = profile
     }
 

--- a/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
+++ b/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
@@ -226,7 +226,7 @@ class ErrorPageHelper {
 
     fileprivate weak var certStore: CertStore?
 
-    init(certStore: CertStore?) {
+    init(certStore: CertStore? = AppContainer.shared.resolve(type: Profile.self).certStore) {
         self.certStore = certStore
     }
 

--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -8,6 +8,7 @@ import Shared
 
 class IntroViewController: UIViewController, OnViewDismissable {
     var onViewDismissed: (() -> Void)?
+
     private var viewModel: IntroViewModel
     private let profile: Profile
     private var onboardingCards = [OnboardingCardViewController]()
@@ -48,7 +49,10 @@ class IntroViewController: UIViewController, OnViewDismissable {
     var didFinishClosure: ((IntroViewController, FxAPageType?) -> Void)?
 
     // MARK: Initializer
-    init(viewModel: IntroViewModel, profile: Profile) {
+    init(
+        viewModel: IntroViewModel,
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self)
+    ) {
         self.viewModel = viewModel
         self.profile = profile
         super.init(nibName: nil, bundle: nil)
@@ -64,6 +68,10 @@ class IntroViewController: UIViewController, OnViewDismissable {
         view.backgroundColor = UIColor.theme.browser.background
         setupPageController()
         setupLayout()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        profile.prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -204,8 +212,7 @@ extension IntroViewController: OnboardingCardDelegate {
                                   referringPage: ReferringPage = .onboarding) {
         let singInSyncVC = FirefoxAccountSignInViewController.getSignInOrFxASettingsVC(fxaOptions,
                                                                                       flowType: flowType,
-                                                                                      referringPage: referringPage,
-                                                                                      profile: profile)
+                                                                                      referringPage: referringPage)
         let controller: DismissableNavigationViewController
         let buttonItem = UIBarButtonItem(title: .SettingsSearchDoneButton,
                                          style: .plain,

--- a/Client/Frontend/Library/BookmarkDetailPanel.swift
+++ b/Client/Frontend/Library/BookmarkDetailPanel.swift
@@ -84,7 +84,12 @@ class BookmarkDetailPanel: SiteTableViewController {
     }()
 
     // MARK: - Initializers
-    convenience init(profile: Profile, bookmarkNode: BookmarkNodeData, parentBookmarkFolder: BookmarkFolderData, presentedFromToast fromToast: Bool = false) {
+
+    convenience init(
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        bookmarkNode: BookmarkNodeData, parentBookmarkFolder: BookmarkFolderData,
+        presentedFromToast fromToast: Bool = false
+    ) {
         self.init(profile: profile, bookmarkNodeGUID: bookmarkNode.guid, bookmarkNodeType: bookmarkNode.type, parentBookmarkFolder: parentBookmarkFolder)
 
         self.isPresentedFromToast = fromToast
@@ -102,7 +107,11 @@ class BookmarkDetailPanel: SiteTableViewController {
         }
     }
 
-    convenience init(profile: Profile, withNewBookmarkNodeType bookmarkNodeType: BookmarkNodeType, parentBookmarkFolder: BookmarkFolderData) {
+    convenience init(
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        withNewBookmarkNodeType bookmarkNodeType: BookmarkNodeType,
+        parentBookmarkFolder: BookmarkFolderData
+    ) {
         self.init(profile: profile, bookmarkNodeGUID: nil, bookmarkNodeType: bookmarkNodeType, parentBookmarkFolder: parentBookmarkFolder)
 
         if bookmarkNodeType == .bookmark {
@@ -117,7 +126,7 @@ class BookmarkDetailPanel: SiteTableViewController {
         }
     }
 
-    private init(profile: Profile, bookmarkNodeGUID: GUID?, bookmarkNodeType: BookmarkNodeType, parentBookmarkFolder: BookmarkFolderData) {
+    private init(profile: Profile = AppContainer.shared.resolve(type: Profile.self), bookmarkNodeGUID: GUID?, bookmarkNodeType: BookmarkNodeType, parentBookmarkFolder: BookmarkFolderData) {
         self.bookmarkNodeGUID = bookmarkNodeGUID
         self.bookmarkNodeType = bookmarkNodeType
         self.parentBookmarkFolder = parentBookmarkFolder

--- a/Client/Frontend/Library/BookmarksPanel.swift
+++ b/Client/Frontend/Library/BookmarksPanel.swift
@@ -53,7 +53,10 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel, CanRemoveQuickActio
     fileprivate lazy var bookmarkFolderIconNormal = UIImage(named: "bookmarkFolder")?.createScaled(BookmarksPanelUX.FolderIconSize).tinted(withColor: UIColor.Photon.Grey90)
     fileprivate lazy var bookmarkFolderIconDark = UIImage(named: "bookmarkFolder")?.createScaled(BookmarksPanelUX.FolderIconSize).tinted(withColor: UIColor.Photon.Grey10)
 
-    init(profile: Profile, bookmarkFolderGUID: GUID = BookmarkRoots.RootGUID) {
+    init(
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        bookmarkFolderGUID: GUID = BookmarkRoots.RootGUID
+    ) {
         self.bookmarkFolderGUID = bookmarkFolderGUID
 
         super.init(profile: profile)
@@ -90,14 +93,14 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel, CanRemoveQuickActio
         let newBookmark = SingleActionViewModel(title: .BookmarksNewBookmark, iconString: ImageIdentifiers.actionAddBookmark, tapHandler: { _ in
             guard let bookmarkFolder = self.bookmarkFolder else { return }
 
-            let detailController = BookmarkDetailPanel(profile: self.profile, withNewBookmarkNodeType: .bookmark, parentBookmarkFolder: bookmarkFolder)
+            let detailController = BookmarkDetailPanel(withNewBookmarkNodeType: .bookmark, parentBookmarkFolder: bookmarkFolder)
             self.navigationController?.pushViewController(detailController, animated: true)
         }).items
 
         let newFolder = SingleActionViewModel(title: .BookmarksNewFolder, iconString: "bookmarkFolder", tapHandler: { _ in
             guard let bookmarkFolder = self.bookmarkFolder else { return }
 
-            let detailController = BookmarkDetailPanel(profile: self.profile, withNewBookmarkNodeType: .folder, parentBookmarkFolder: bookmarkFolder)
+            let detailController = BookmarkDetailPanel(withNewBookmarkNodeType: .folder, parentBookmarkFolder: bookmarkFolder)
             self.navigationController?.pushViewController(detailController, animated: true)
         }).items
 
@@ -301,7 +304,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel, CanRemoveQuickActio
         guard !tableView.isEditing else {
             TelemetryWrapper.recordEvent(category: .action, method: .change, object: .bookmark, value: .bookmarksPanel)
             if let bookmarkFolder = self.bookmarkFolder, !(bookmarkNode is BookmarkSeparatorData) {
-                let detailController = BookmarkDetailPanel(profile: profile, bookmarkNode: bookmarkNode, parentBookmarkFolder: bookmarkFolder)
+                let detailController = BookmarkDetailPanel(bookmarkNode: bookmarkNode, parentBookmarkFolder: bookmarkFolder)
                 navigationController?.pushViewController(detailController, animated: true)
             }
             return
@@ -309,7 +312,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel, CanRemoveQuickActio
 
         switch bookmarkNode {
         case let bookmarkFolder as BookmarkFolderData:
-            let nextController = BookmarksPanel(profile: profile, bookmarkFolderGUID: bookmarkFolder.guid)
+            let nextController = BookmarksPanel(bookmarkFolderGUID: bookmarkFolder.guid)
             if bookmarkFolder.isRoot, let localizedString = LocalizedRootBookmarkFolderStrings[bookmarkFolder.guid] {
                 nextController.title = localizedString
             } else {

--- a/Client/Frontend/Library/ClearHistoryHelper.swift
+++ b/Client/Frontend/Library/ClearHistoryHelper.swift
@@ -16,7 +16,10 @@ class ClearHistoryHelper {
     private let profile: Profile
     private let tabManager: TabManager
 
-    init(profile: Profile, tabManager: TabManager) {
+    init(
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        tabManager: TabManager
+    ) {
         self.profile = profile
         self.tabManager = tabManager
     }

--- a/Client/Frontend/Library/DownloadsPanel.swift
+++ b/Client/Frontend/Library/DownloadsPanel.swift
@@ -47,7 +47,7 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
     weak var libraryPanelDelegate: LibraryPanelDelegate?
     let TwoLineImageOverlayCellIdentifier = "TwoLineImageOverlayCellIdentifier"
     let SiteTableViewHeaderIdentifier = "SiteTableViewHeaderIdentifier"
-    let profile: Profile
+
     lazy var tableView: UITableView = .build { [weak self] tableView in
         guard let self = self else { return }
         tableView.delegate = self
@@ -71,8 +71,7 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
     private var fileExtensionIcons: [String: UIImage] = [:]
 
     // MARK: - Lifecycle
-    init(profile: Profile) {
-        self.profile = profile
+    init() {
         super.init(nibName: nil, bundle: nil)
         events.forEach { NotificationCenter.default.addObserver(self, selector: #selector(notificationReceived), name: $0, object: nil) }
     }

--- a/Client/Frontend/Library/HistoryPanel/GeneralizedTableView/SearchGroupedItemsViewController.swift
+++ b/Client/Frontend/Library/HistoryPanel/GeneralizedTableView/SearchGroupedItemsViewController.swift
@@ -21,10 +21,9 @@ class SearchGroupedItemsViewController: UIViewController, Loggable {
         case main
     }
 
-    let profile: Profile
     let viewModel: SearchGroupedItemsViewModel
     var libraryPanelDelegate: LibraryPanelDelegate? // Set this at the creation site!
-    private lazy var siteImageHelper = SiteImageHelper(profile: profile)
+    private let siteImageHelper = SiteImageHelper()
 
     lazy private var tableView: UITableView = .build { [weak self] tableView in
         guard let self = self else { return }
@@ -49,9 +48,8 @@ class SearchGroupedItemsViewController: UIViewController, Loggable {
 
     // MARK: - Inits
 
-    init(viewModel: SearchGroupedItemsViewModel, profile: Profile) {
+    init(viewModel: SearchGroupedItemsViewModel) {
         self.viewModel = viewModel
-        self.profile = profile
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -110,7 +108,10 @@ class SearchGroupedItemsViewController: UIViewController, Loggable {
             guard let self = self else { return nil }
 
             if let site = item as? Site {
-                guard let cell = tableView.dequeueReusableCell(withIdentifier: TwoLineImageOverlayCell.cellIdentifier, for: indexPath) as? TwoLineImageOverlayCell else {
+                guard let cell = tableView.dequeueReusableCell(
+                    withIdentifier: TwoLineImageOverlayCell.cellIdentifier,
+                    for: indexPath
+                ) as? TwoLineImageOverlayCell else {
                     self.browserLog.error("GeneralizedHistoryItems - Could not dequeue a TwoLineImageOverlayCell!")
                     return nil
                 }
@@ -190,11 +191,13 @@ extension SearchGroupedItemsViewController: UITableViewDelegate {
 
         libraryPanelDelegate?.libraryPanel(didSelectURL: url, visitType: .typed)
 
-        TelemetryWrapper.recordEvent(category: .action,
-                                     method: .tap,
-                                     object: .selectedHistoryItem,
-                                     value: .historyPanelGroupedItem,
-                                     extras: nil)
+        TelemetryWrapper.recordEvent(
+            category: .action,
+            method: .tap,
+            object: .selectedHistoryItem,
+            value: .historyPanelGroupedItem,
+            extras: nil
+        )
 
         if viewModel.presenter == .recentlyVisited {
             dismiss(animated: true, completion: nil)

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -39,7 +39,7 @@ class HistoryPanel: UIViewController, LibraryPanel, Loggable, NotificationThemea
     let viewModel: HistoryPanelViewModel
     private let clearHistoryHelper: ClearHistoryHelper
     var keyboardState: KeyboardState?
-    private lazy var siteImageHelper = SiteImageHelper(profile: profile)
+    private lazy var siteImageHelper = SiteImageHelper()
     var chevronImage = UIImage(named: ImageIdentifiers.menuChevron)
 
     // We'll be able to prefetch more often the higher this number is. But remember, it's expensive!
@@ -92,9 +92,12 @@ class HistoryPanel: UIViewController, LibraryPanel, Loggable, NotificationThemea
 
     // MARK: - Inits
 
-    init(profile: Profile, tabManager: TabManager) {
-        self.clearHistoryHelper = ClearHistoryHelper(profile: profile, tabManager: tabManager)
-        self.viewModel = HistoryPanelViewModel(profile: profile)
+    init(
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        tabManager: TabManager
+    ) {
+        self.clearHistoryHelper = ClearHistoryHelper(tabManager: tabManager)
+        self.viewModel = HistoryPanelViewModel()
         self.profile = profile
 
         super.init(nibName: nil, bundle: nil)
@@ -542,7 +545,7 @@ extension HistoryPanel: UITableViewDelegate {
         exitSearchState()
 
         let asGroupListViewModel = SearchGroupedItemsViewModel(asGroup: asGroupItem, presenter: .historyPanel)
-        let asGroupListVC = SearchGroupedItemsViewController(viewModel: asGroupListViewModel, profile: profile)
+        let asGroupListVC = SearchGroupedItemsViewController(viewModel: asGroupListViewModel)
         asGroupListVC.libraryPanelDelegate = libraryPanelDelegate
         asGroupListVC.title = asGroupItem.displayTitle
 
@@ -651,7 +654,7 @@ extension HistoryPanel {
     private func navigateToRecentlyClosed() {
         guard hasRecentlyClosed else { return }
 
-        let nextController = RecentlyClosedTabsPanel(profile: profile)
+        let nextController = RecentlyClosedTabsPanel()
         nextController.title = .RecentlyClosedTabsPanelTitle
         nextController.libraryPanelDelegate = libraryPanelDelegate
         nextController.recentlyClosedTabsDelegate = BrowserViewController.foregroundBVC()

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
@@ -82,7 +82,7 @@ class HistoryPanelViewModel: Loggable, FeatureFlaggable {
 
     // MARK: - Inits
 
-    init(profile: Profile) {
+    init(profile: Profile = AppContainer.shared.resolve(type: Profile.self)) {
         self.profile = profile
     }
 

--- a/Client/Frontend/Library/LibraryPanels.swift
+++ b/Client/Frontend/Library/LibraryPanels.swift
@@ -49,8 +49,7 @@ class LibraryPanelDescriptor {
     var viewController: UIViewController?
     var navigationController: UINavigationController?
 
-    fileprivate let makeViewController: (_ profile: Profile, _ tabManager: TabManager) -> UIViewController
-    fileprivate let profile: Profile
+    fileprivate let makeViewController: (_ tabManager: TabManager) -> UIViewController
     fileprivate let tabManager: TabManager
 
     let accessibilityLabel: String
@@ -58,15 +57,13 @@ class LibraryPanelDescriptor {
     let panelType: LibraryPanelType
 
     init(
-        makeViewController: @escaping ((_ profile: Profile, _ tabManager: TabManager) -> UIViewController),
-        profile: Profile,
+        makeViewController: @escaping ((_ tabManager: TabManager) -> UIViewController),
         tabManager: TabManager,
         accessibilityLabel: String,
         accessibilityIdentifier: String,
         panelType: LibraryPanelType
     ) {
         self.makeViewController = makeViewController
-        self.profile = profile
         self.tabManager = tabManager
         self.accessibilityLabel = accessibilityLabel
         self.accessibilityIdentifier = accessibilityIdentifier
@@ -75,57 +72,51 @@ class LibraryPanelDescriptor {
 
     func setup() {
         guard viewController == nil else { return }
-        let viewController = makeViewController(profile, tabManager)
+        let viewController = makeViewController(tabManager)
         self.viewController = viewController
         navigationController = ThemedNavigationController(rootViewController: viewController)
     }
 }
 
 class LibraryPanels: FeatureFlaggable {
-    fileprivate let profile: Profile
     fileprivate let tabManager: TabManager
 
-    init(profile: Profile, tabManager: TabManager) {
-        self.profile = profile
+    init(tabManager: TabManager) {
         self.tabManager = tabManager
     }
 
     lazy var enabledPanels = [
         LibraryPanelDescriptor(
-            makeViewController: { profile, tabManager  in
-                return BookmarksPanel(profile: profile)
+            makeViewController: { tabManager  in
+                return BookmarksPanel()
             },
-            profile: profile,
             tabManager: tabManager,
             accessibilityLabel: .LibraryPanelBookmarksAccessibilityLabel,
             accessibilityIdentifier: AccessibilityIdentifiers.LibraryPanels.bookmarksView,
             panelType: .bookmarks),
 
         LibraryPanelDescriptor(
-            makeViewController: { profile, tabManager in
-                return HistoryPanel(profile: profile, tabManager: tabManager)
+            makeViewController: { tabManager in
+                return HistoryPanel(tabManager: tabManager)
             },
-            profile: profile,
             tabManager: tabManager,
             accessibilityLabel: .LibraryPanelHistoryAccessibilityLabel,
             accessibilityIdentifier: AccessibilityIdentifiers.LibraryPanels.historyView,
             panelType: .history),
 
         LibraryPanelDescriptor(
-            makeViewController: { profile, tabManager in
-                return DownloadsPanel(profile: profile)
+            makeViewController: { tabManager in
+                return DownloadsPanel()
             },
-            profile: profile,
             tabManager: tabManager,
             accessibilityLabel: .LibraryPanelDownloadsAccessibilityLabel,
             accessibilityIdentifier: AccessibilityIdentifiers.LibraryPanels.downloadsView,
             panelType: .downloads),
 
         LibraryPanelDescriptor(
-            makeViewController: { profile, tabManager in
-                return ReadingListPanel(profile: profile)
+            makeViewController: { tabManager in
+                return ReadingListPanel()
             },
-            profile: profile,
             tabManager: tabManager,
             accessibilityLabel: .LibraryPanelReadingListAccessibilityLabel,
             accessibilityIdentifier: AccessibilityIdentifiers.LibraryPanels.readingListView,

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -112,8 +112,8 @@ class LibraryViewController: UIViewController {
     }()
 
     // MARK: - Initializers
-    init(profile: Profile, tabManager: TabManager) {
-        self.viewModel = LibraryViewModel(withProfile: profile, tabManager: tabManager)
+    init(tabManager: TabManager) {
+        self.viewModel = LibraryViewModel(tabManager: tabManager)
 
         super.init(nibName: nil, bundle: nil)
     }

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewModel.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewModel.swift
@@ -27,9 +27,12 @@ class LibraryViewModel: FeatureFlaggable {
          UIImage(named: ImageIdentifiers.libraryReadingList) ?? UIImage()]
     }
 
-    init(withProfile profile: Profile, tabManager: TabManager) {
+    init(
+        withProfile profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        tabManager: TabManager
+    ) {
         self.profile = profile
         self.tabManager = tabManager
-        self.panelDescriptors = LibraryPanels(profile: profile, tabManager: tabManager).enabledPanels
+        self.panelDescriptors = LibraryPanels(tabManager: tabManager).enabledPanels
     }
 }

--- a/Client/Frontend/Library/ReaderPanel.swift
+++ b/Client/Frontend/Library/ReaderPanel.swift
@@ -171,7 +171,7 @@ class ReadingListPanel: UITableViewController, LibraryPanel {
 
     fileprivate var records: [ReadingListItem]?
 
-    init(profile: Profile) {
+    init(profile: Profile = AppContainer.shared.resolve(type: Profile.self)) {
         self.profile = profile
         super.init(nibName: nil, bundle: nil)
 

--- a/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -26,9 +26,9 @@ class RecentlyClosedTabsPanel: UIViewController, LibraryPanel {
     var recentlyClosedTabsDelegate: RecentlyClosedPanelDelegate?
     let profile: Profile
 
-    fileprivate lazy var tableViewController = RecentlyClosedTabsPanelSiteTableViewController(profile: profile)
+    fileprivate lazy var tableViewController = RecentlyClosedTabsPanelSiteTableViewController()
 
-    init(profile: Profile) {
+    init(profile: Profile = AppContainer.shared.resolve(type: Profile.self)) {
         self.profile = profile
         super.init(nibName: nil, bundle: nil)
     }

--- a/Client/Frontend/Login Management/DevicePasscodeRequiredViewController.swift
+++ b/Client/Frontend/Login Management/DevicePasscodeRequiredViewController.swift
@@ -27,8 +27,8 @@ class DevicePasscodeRequiredViewController: SettingsViewController {
         return button
     }()
 
-    init(profile: Profile? = nil, tabManager: TabManager? = nil, shownFromAppMenu: Bool = false) {
-        super.init(profile: profile, tabManager: tabManager)
+    init(tabManager: TabManager? = nil, shownFromAppMenu: Bool = false) {
+        super.init(tabManager: tabManager)
         self.shownFromAppMenu = shownFromAppMenu
     }
 

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -52,16 +52,15 @@ class LoginListViewController: SensitiveViewController {
 
     static func create(
         authenticateInNavigationController navigationController: UINavigationController,
-        profile: Profile,
         settingsDelegate: SettingsDelegate,
         webpageNavigationHandler: ((_ url: URL?) -> Void)?
     ) -> Deferred<LoginListViewController?> {
+
         let deferred = Deferred<LoginListViewController?>()
 
         func fillDeferred(ok: Bool) {
             if ok {
-                let viewController = LoginListViewController(profile: profile,
-                                                             webpageNavigationHandler: webpageNavigationHandler)
+                let viewController = LoginListViewController(webpageNavigationHandler: webpageNavigationHandler)
                 viewController.settingsDelegate = settingsDelegate
                 deferred.fill(viewController)
             } else {
@@ -81,10 +80,11 @@ class LoginListViewController: SensitiveViewController {
         return deferred
     }
 
-    private init(profile: Profile, webpageNavigationHandler: ((_ url: URL?) -> Void)?) {
-        self.viewModel = LoginListViewModel(profile: profile, searchController: searchController)
+    private init(webpageNavigationHandler: ((_ url: URL?) -> Void)?) {
+        self.viewModel = LoginListViewModel(searchController: searchController)
         self.loginDataSource = LoginDataSource(viewModel: self.viewModel)
         self.webpageNavigationHandler = webpageNavigationHandler
+
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -393,7 +393,7 @@ extension LoginListViewController: UITableViewDelegate {
             toggleDeleteBarButton()
         } else if let login = viewModel.loginAtIndexPath(indexPath) {
             tableView.deselectRow(at: indexPath, animated: true)
-            let detailViewController = LoginDetailViewController(profile: viewModel.profile, login: login, webpageNavigationHandler: webpageNavigationHandler)
+            let detailViewController = LoginDetailViewController(login: login, webpageNavigationHandler: webpageNavigationHandler)
             if viewModel.breachIndexPath.contains(indexPath) {
                 guard let login = viewModel.loginAtIndexPath(indexPath) else { return }
                 let breach = viewModel.breachAlertsManager.breachRecordForLogin(login)

--- a/Client/Frontend/Login Management/LoginListViewModel.swift
+++ b/Client/Frontend/Login Management/LoginListViewModel.swift
@@ -30,7 +30,7 @@ final class LoginListViewModel {
     }
     fileprivate let helper = LoginListDataSourceHelper()
     private(set) lazy var breachAlertsManager: BreachAlertsManager = {
-        return BreachAlertsManager(profile: self.profile)
+        return BreachAlertsManager()
     }()
     private(set) var userBreaches: Set<LoginRecord>?
     private(set) var breachIndexPath = Set<IndexPath>() {
@@ -39,7 +39,11 @@ final class LoginListViewModel {
         }
     }
     var hasLoadedBreaches: Bool = false
-    init(profile: Profile, searchController: UISearchController) {
+
+    init(
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        searchController: UISearchController
+    ) {
         self.profile = profile
         self.searchController = searchController
     }
@@ -159,7 +163,7 @@ final class LoginListViewModel {
     }
 
     func setBreachAlertsManager(_ client: BreachAlertsClientProtocol) {
-        self.breachAlertsManager = BreachAlertsManager(client, profile: profile)
+        self.breachAlertsManager = BreachAlertsManager(client)
     }
 
     // MARK: - UX Constants

--- a/Client/Frontend/Login Management/LoginOnboardingViewController.swift
+++ b/Client/Frontend/Login Management/LoginOnboardingViewController.swift
@@ -42,8 +42,8 @@ class LoginOnboardingViewController: SettingsViewController {
     var doneHandler: () -> Void = {}
     var proceedHandler: () -> Void = {}
 
-    init(profile: Profile? = nil, tabManager: TabManager? = nil, shownFromAppMenu: Bool = false) {
-        super.init(profile: profile, tabManager: tabManager)
+    init(tabManager: TabManager? = nil, shownFromAppMenu: Bool = false) {
+        super.init(tabManager: tabManager)
         self.shownFromAppMenu = shownFromAppMenu
     }
 

--- a/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -6,15 +6,21 @@ import Foundation
 import GCDWebServers
 
 protocol ReaderModeHandlersProtocol {
-    func register(_ webServer: WebServerProtocol, profile: Profile)
+    func register(_ webServer: WebServerProtocol)
 }
 
 struct ReaderModeHandlers: ReaderModeHandlersProtocol {
+    private var profile: Profile
+
     static let ReaderModeStyleHash = "sha256-L2W8+0446ay9/L1oMrgucknQXag570zwgQrHwE68qbQ="
 
     static var readerModeCache: ReaderModeCache = DiskReaderModeCache.sharedInstance
 
-    func register(_ webServer: WebServerProtocol, profile: Profile) {
+    init(profile: Profile = AppContainer.shared.resolve(type: Profile.self)) {
+        self.profile = profile
+    }
+
+    func register(_ webServer: WebServerProtocol) {
         // Temporary hacky casting to allow for gradual movement to protocol oriented programming
         guard let webServer = webServer as? WebServer else { return }
         ReaderModeHandlers.register(webServer, profile: profile)

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -21,10 +21,12 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
     var deeplinkTo: AppSettingsDeeplinkOption?
 
     // MARK: - Initializers
-    init(with profile: Profile,
-         and tabManager: TabManager,
-         delegate: SettingsDelegate?,
-         deeplinkingTo destination: AppSettingsDeeplinkOption? = nil) {
+    init(
+        with profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        and tabManager: TabManager,
+        delegate: SettingsDelegate?,
+        deeplinkingTo destination: AppSettingsDeeplinkOption? = nil
+    ) {
         self.deeplinkTo = destination
 
         super.init()
@@ -63,17 +65,17 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
 
         switch deeplink {
         case .contentBlocker:
-            viewController = ContentBlockerSettingViewController(prefs: profile.prefs)
+            viewController = ContentBlockerSettingViewController()
             viewController.tabManager = tabManager
 
         case .customizeHomepage:
-            viewController = HomePageSettingViewController(prefs: profile.prefs)
+            viewController = HomePageSettingViewController()
 
         case .customizeTabs:
             viewController = TabsSettingsViewController()
 
         case .customizeToolbar:
-            let viewModel = SearchBarSettingsViewModel(prefs: profile.prefs)
+            let viewModel = SearchBarSettingsViewModel()
             viewController = SearchBarSettingsViewController(viewModel: viewModel)
 
         case .wallpaper:
@@ -87,7 +89,6 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
             viewController = TopSitesSettingsViewController()
         }
 
-        viewController.profile = profile
         navigationController?.pushViewController(viewController, animated: false)
         // Add a done button from this view
         viewController.navigationItem.rightBarButtonItem = navigationItem.rightBarButtonItem
@@ -154,7 +155,7 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
         settings += [
             SettingSection(title: accountSectionTitle, footerTitle: footerText, children: [
                 // Without a Firefox Account:
-                ConnectSetting(settings: self),
+                ConnectSetting(),
                 AdvancedAccountSetting(settings: self),
                 // With a Firefox Account:
                 AccountStatusSetting(settings: self),

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -19,7 +19,7 @@ private let HistoryClearableIndex = 0
 class ClearPrivateDataTableViewController: ThemedTableViewController {
     fileprivate var clearButton: UITableViewCell?
 
-    var profile: Profile!
+    var profile: Profile
     var tabManager: TabManager!
 
     fileprivate typealias DefaultCheckedState = Bool
@@ -30,7 +30,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
     // Bug 1445687 -- https://bugzilla.mozilla.org/show_bug.cgi?id=1445687
     fileprivate lazy var clearables: [(clearable: Clearable, checked: DefaultCheckedState)] = {
         var items: [(clearable: Clearable, checked: DefaultCheckedState)] = [
-            (HistoryClearable(profile: self.profile, tabManager: tabManager), true),
+            (HistoryClearable(tabManager: tabManager), true),
             (CacheClearable(tabManager: self.tabManager), true),
             (CookiesClearable(tabManager: self.tabManager), true),
             (SiteDataClearable(tabManager: self.tabManager), true),
@@ -60,6 +60,16 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
         didSet {
             clearButton?.textLabel?.textColor = clearButtonEnabled ? UIColor.theme.general.destructiveRed : UIColor.theme.tableView.disabledRowText
         }
+    }
+
+    init(profile: Profile = AppContainer.shared.resolve(type: Profile.self)) {
+        self.profile = profile
+
+        super.init()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
     override func viewDidLoad() {

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -31,7 +31,10 @@ class HistoryClearable: Clearable {
     let profile: Profile
     let tabManager: TabManager
 
-    init(profile: Profile, tabManager: TabManager) {
+    init(
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        tabManager: TabManager
+    ) {
         self.profile = profile
         self.tabManager = tabManager
     }

--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -142,12 +142,12 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
     let prefs: Prefs
     var currentBlockingStrength: BlockingStrength
 
-    init(prefs: Prefs) {
+    init(prefs: Prefs = AppContainer.shared.resolve(type: Profile.self).prefs) {
         self.prefs = prefs
 
         currentBlockingStrength = prefs.stringForKey(ContentBlockingConfig.Prefs.StrengthKey).flatMap({BlockingStrength(rawValue: $0)}) ?? .basic
 
-        super.init(style: .grouped)
+        super.init()
 
         self.title = .SettingsTrackingProtectionSectionName
     }
@@ -200,15 +200,15 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
         }
 
         let enabledSetting = BoolSetting(
-            prefs: profile.prefs,
             prefKey: ContentBlockingConfig.Prefs.EnabledKey,
             defaultValue: ContentBlockingConfig.Defaults.NormalBrowsing,
-            attributedTitleText: NSAttributedString(string: .TrackingProtectionEnableTitle)) { [weak self] enabled in
-                TabContentBlocker.prefsChanged()
-                strengthSetting.forEach { item in
-                    item.enabled = enabled
-                }
-                self?.tableView.reloadData()
+            attributedTitleText: NSAttributedString(string: .TrackingProtectionEnableTitle)
+        ) { [weak self] enabled in
+            TabContentBlocker.prefsChanged()
+            strengthSetting.forEach { item in
+                item.enabled = enabled
+            }
+            self?.tableView.reloadData()
         }
 
         let firstSection = SettingSection(title: nil, footerTitle: NSAttributedString(string: .TrackingProtectionCellFooter), children: [enabledSetting])

--- a/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -39,9 +39,9 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
     }
 
     // MARK: - Initializers
-    init(prefs: Prefs) {
+    init(prefs: Prefs = AppContainer.shared.resolve(type: Profile.self).prefs) {
         self.prefs = prefs
-        super.init(style: .grouped)
+        super.init()
 
         self.title = .SettingsHomePageSectionName
         self.navigationController?.navigationBar.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Homepage.homePageNavigationBar
@@ -143,10 +143,10 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
         let historyHighlightsSetting = BoolSetting(with: .historyHighlights,
                                                    titleText: NSAttributedString(string: .Settings.Homepage.CustomizeFirefoxHome.RecentlyVisited))
 
-        let wallpaperSetting = WallpaperSettings(settings: self)
+        let wallpaperSetting = WallpaperSettings()
 
         // Section ordering
-        sectionItems.append(TopSitesSettings(settings: self))
+        sectionItems.append(TopSitesSettings())
 
         if isJumpBackInSectionEnabled {
             sectionItems.append(jumpBackInSetting)
@@ -247,8 +247,8 @@ extension HomePageSettingViewController {
             return NSAttributedString(string: String(format: status))
         }
 
-        init(settings: SettingsTableViewController) {
-            self.profile = settings.profile
+        init(profile: Profile = AppContainer.shared.resolve(type: Profile.self)) {
+            self.profile = profile
             super.init(title: NSAttributedString(string: .Settings.Homepage.Shortcuts.ShortcutsPageTitle))
         }
 
@@ -271,11 +271,13 @@ extension HomePageSettingViewController {
         override var accessibilityIdentifier: String? { return AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.wallpaper }
         override var style: UITableViewCell.CellStyle { return .value1 }
 
-        init(settings: SettingsTableViewController,
-             and tabManager: TabManager = BrowserViewController.foregroundBVC().tabManager
+        init(
+            profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+            and tabManager: TabManager = BrowserViewController.foregroundBVC().tabManager
         ) {
-            self.profile = settings.profile
+            self.profile = profile
             self.tabManager = tabManager
+
             super.init(title: NSAttributedString(string: .Settings.Homepage.CustomizeFirefoxHome.Wallpaper))
         }
 

--- a/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
@@ -11,10 +11,11 @@ class TopSitesRowCountSettingsController: SettingsTableViewController {
     var numberOfRows: Int32
     static let defaultNumberOfRows: Int32 = 2
 
-    init(prefs: Prefs) {
+    init(prefs: Prefs = AppContainer.shared.resolve(type: Profile.self).prefs) {
         self.prefs = prefs
         numberOfRows = self.prefs.intForKey(PrefsKeys.NumberOfTopSiteRows) ?? TopSitesRowCountSettingsController.defaultNumberOfRows
-        super.init(style: .grouped)
+
+        super.init()
         self.title = .Settings.Homepage.Shortcuts.RowsPageTitle
     }
 

--- a/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -9,7 +9,7 @@ class TopSitesSettingsViewController: SettingsTableViewController, FeatureFlagga
 
     // MARK: - Initializers
     init() {
-        super.init(style: .grouped)
+        super.init()
 
         self.title = .Settings.Homepage.Shortcuts.ShortcutsPageTitle
         self.navigationController?.navigationBar.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.Shortcuts.settingsPage
@@ -41,7 +41,7 @@ class TopSitesSettingsViewController: SettingsTableViewController, FeatureFlagga
         let toggleSection = SettingSection(title: nil,
                                            children: sections)
 
-        let rowSetting = RowSettings(settings: self)
+        let rowSetting = RowSettings()
         let rowSection = SettingSection(title: nil, children: [rowSetting])
 
         return [toggleSection, rowSection]
@@ -62,14 +62,19 @@ extension TopSitesSettingsViewController {
         override var accessibilityIdentifier: String? { return AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.Shortcuts.topSitesRows }
         override var style: UITableViewCell.CellStyle { return .value1 }
 
-        init(settings: SettingsTableViewController) {
-            self.profile = settings.profile
-            super.init(title: NSAttributedString(string: .Settings.Homepage.Shortcuts.Rows,
-                                                 attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        init(profile: Profile = AppContainer.shared.resolve(type: Profile.self)) {
+            self.profile = profile
+
+            super.init(
+                title: NSAttributedString(
+                    string: .Settings.Homepage.Shortcuts.Rows,
+                    attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+            )
+
         }
 
         override func onClick(_ navigationController: UINavigationController?) {
-            let viewController = TopSitesRowCountSettingsController(prefs: profile.prefs)
+            let viewController = TopSitesRowCountSettingsController()
             viewController.profile = profile
             navigationController?.pushViewController(viewController, animated: true)
         }

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -73,7 +73,11 @@ class LoginDetailViewController: SensitiveViewController {
         }
     }
 
-    init(profile: Profile, login: LoginRecord, webpageNavigationHandler: ((_ url: URL?) -> Void)?) {
+    init(
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        login: LoginRecord,
+        webpageNavigationHandler: ((_ url: URL?) -> Void)?
+    ) {
         self.login = login
         self.profile = profile
         self.webpageNavigationHandler = webpageNavigationHandler

--- a/Client/Frontend/Settings/NewTabContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/NewTabContentSettingsViewController.swift
@@ -11,9 +11,9 @@ class NewTabContentSettingsViewController: SettingsTableViewController {
     let prefs: Prefs
     var currentChoice: NewTabPage!
     var hasHomePage = false
-    init(prefs: Prefs) {
+    init(prefs: Prefs = AppContainer.shared.resolve(type: Profile.self).prefs) {
         self.prefs = prefs
-        super.init(style: .grouped)
+        super.init()
 
         self.title = .SettingsNewTabTitle
     }

--- a/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewController.swift
+++ b/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewController.swift
@@ -11,7 +11,7 @@ class SearchBarSettingsViewController: SettingsTableViewController {
 
     init(viewModel: SearchBarSettingsViewModel) {
         self.viewModel = viewModel
-        super.init(style: .grouped)
+        super.init()
 
         title = viewModel.title
         viewModel.delegate = self

--- a/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
+++ b/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
@@ -35,7 +35,8 @@ final class SearchBarSettingsViewModel: FeatureFlaggable {
     weak var delegate: SearchBarPreferenceDelegate?
 
     private let prefs: Prefs
-    init(prefs: Prefs) {
+
+    init(prefs: Prefs = AppContainer.shared.resolve(type: Profile.self).prefs) {
         self.prefs = prefs
     }
 

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -22,7 +22,6 @@ class SearchSettingsTableViewController: ThemedTableViewController {
 
     fileprivate var showDeletion = false
 
-    var profile: Profile?
     var tabManager: TabManager?
 
     var updateSearchIcon: (() -> Void)?
@@ -157,7 +156,6 @@ class SearchSettingsTableViewController: ThemedTableViewController {
             navigationController?.pushViewController(searchEnginePicker, animated: true)
         } else if indexPath.item + 1 == model.orderedEngines.count {
             let customSearchEngineForm = CustomSearchViewController()
-            customSearchEngineForm.profile = self.profile
             customSearchEngineForm.successCallback = {
                 guard let window = self.view.window else { return }
                 SimpleToast().showAlertWithText(.ThirdPartySearchEngineAdded, bottomContainer: window)

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -196,7 +196,7 @@ class BoolSetting: Setting, FeatureFlaggable {
     fileprivate let featureFlagName: NimbusFeatureFlagID?
 
     init(
-        prefs: Prefs?,
+        prefs: Prefs? = AppContainer.shared.resolve(type: Profile.self).prefs,
         prefKey: String? = nil,
         defaultValue: Bool?,
         attributedTitleText: NSAttributedString,
@@ -639,22 +639,18 @@ class ButtonSetting: Setting {
 // A helper class for prefs that deal with sync. Handles reloading the tableView data if changes to
 // the fxAccount happen.
 class AccountSetting: Setting {
-    unowned var settings: SettingsTableViewController
-
-    var profile: Profile {
-        return settings.profile
-    }
+    var profile: Profile
 
     override var title: NSAttributedString? { return nil }
 
-    init(settings: SettingsTableViewController) {
-        self.settings = settings
+    init(profile: Profile = AppContainer.shared.resolve(type: Profile.self)) {
+        self.profile = profile
         super.init(title: nil)
     }
 
     override func onConfigureCell(_ cell: UITableViewCell) {
         super.onConfigureCell(cell)
-        if settings.profile.rustFxA.userProfile != nil {
+        if profile.rustFxA.userProfile != nil {
             cell.selectionStyle = .none
         }
     }
@@ -686,7 +682,7 @@ class SettingsTableViewController: ThemedTableViewController {
 
     weak var settingsDelegate: SettingsDelegate?
 
-    var profile: Profile!
+    var profile: Profile
     var tabManager: TabManager!
 
     /// Used to calculate cell heights.
@@ -695,6 +691,16 @@ class SettingsTableViewController: ThemedTableViewController {
         cell.accessoryView = UISwitchThemed()
         return cell
     }()
+
+    init(profile: Profile = AppContainer.shared.resolve(type: Profile.self)) {
+        self.profile = profile
+
+        super.init(style: .grouped)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -7,14 +7,12 @@ import UIKit
 class SettingsViewController: UIViewController {
     weak var settingsDelegate: SettingsDelegate?
 
-    var profile: Profile!
     var tabManager: TabManager!
 
     let theme = LegacyThemeManager.instance
 
-    init(profile: Profile? = nil, tabManager: TabManager? = nil) {
+    init(tabManager: TabManager? = nil) {
         super.init(nibName: nil, bundle: nil)
-        self.profile = profile
         self.tabManager = tabManager
     }
 

--- a/Client/Frontend/Settings/SiriSettingsViewController.swift
+++ b/Client/Frontend/Settings/SiriSettingsViewController.swift
@@ -10,9 +10,9 @@ import IntentsUI
 class SiriSettingsViewController: SettingsTableViewController {
     let prefs: Prefs
 
-    init(prefs: Prefs) {
+    init(prefs: Prefs = AppContainer.shared.resolve(type: Profile.self).prefs) {
         self.prefs = prefs
-        super.init(style: .grouped)
+        super.init()
 
         self.title = .SettingsSiriSectionName
     }

--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -8,20 +8,23 @@ import Sync
 import Account
 
 class ManageFxAccountSetting: Setting {
-    let profile: Profile
-
     override var accessoryType: UITableViewCell.AccessoryType { return .disclosureIndicator }
-
     override var accessibilityIdentifier: String? { return "Manage" }
 
     init(settings: SettingsTableViewController) {
-        self.profile = settings.profile
-
-        super.init(title: NSAttributedString(string: .FxAManageAccount, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(
+            string: .FxAManageAccount,
+            attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]
+        ))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        let viewController = FxAWebViewController(pageType: .settingsPage, profile: profile, dismissalStyle: .popToRootVC, deepLinkParams: nil)
+        let viewController = FxAWebViewController(
+            pageType: .settingsPage,
+            dismissalStyle: .popToRootVC,
+            deepLinkParams: nil
+        )
+
         navigationController?.pushViewController(viewController, animated: true)
     }
 }
@@ -36,9 +39,12 @@ class DisconnectSetting: Setting {
         return NSAttributedString(string: .SettingsDisconnectSyncButton, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.general.destructiveRed])
     }
 
-    init(settings: SettingsTableViewController) {
+    init(
+        settings: SettingsTableViewController,
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self)
+    ) {
         self.settingsVC = settings
-        self.profile = settings.profile
+        self.profile = profile
     }
 
     override var accessibilityIdentifier: String? { return "SignOut" }
@@ -121,8 +127,7 @@ class SyncContentSettingsViewController: SettingsTableViewController {
     fileprivate var enginesToSyncOnExit: Set<String> = Set()
 
     init() {
-        super.init(style: .grouped)
-
+        super.init()
         self.title = .FxASettingsTitle
 
         RustFirefoxAccounts.shared.accountManager.peek()?.deviceConstellation()?.refreshState()
@@ -158,28 +163,24 @@ class SyncContentSettingsViewController: SettingsTableViewController {
         let manageSection = SettingSection(title: nil, footerTitle: nil, children: [manage])
 
         let bookmarks = BoolSetting(
-            prefs: profile.prefs,
             prefKey: "sync.engine.bookmarks.enabled",
             defaultValue: true,
             attributedTitleText: NSAttributedString(string: .FirefoxSyncBookmarksEngine),
             attributedStatusText: nil,
             settingDidChange: engineSettingChanged("bookmarks"))
         let history = BoolSetting(
-            prefs: profile.prefs,
             prefKey: "sync.engine.history.enabled",
             defaultValue: true,
             attributedTitleText: NSAttributedString(string: .FirefoxSyncHistoryEngine),
             attributedStatusText: nil,
             settingDidChange: engineSettingChanged("history"))
         let tabs = BoolSetting(
-            prefs: profile.prefs,
             prefKey: "sync.engine.tabs.enabled",
             defaultValue: true,
             attributedTitleText: NSAttributedString(string: .FirefoxSyncTabsEngine),
             attributedStatusText: nil,
             settingDidChange: engineSettingChanged("tabs"))
         let passwords = BoolSetting(
-            prefs: profile.prefs,
             prefKey: "sync.engine.passwords.enabled",
             defaultValue: true,
             attributedTitleText: NSAttributedString(string: .FirefoxSyncLoginsEngine),

--- a/Client/Frontend/Settings/TabsSettingsViewControler.swift
+++ b/Client/Frontend/Settings/TabsSettingsViewControler.swift
@@ -8,7 +8,7 @@ import Shared
 class TabsSettingsViewController: SettingsTableViewController, FeatureFlaggable {
 
     init() {
-        super.init(style: .grouped)
+        super.init()
 
         self.title = .Settings.SectionTitles.TabsTitle
     }

--- a/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -24,7 +24,10 @@ class LoginsHelper: TabContentScript {
         return "LoginsHelper"
     }
 
-    required init(tab: Tab, profile: Profile) {
+    required init(
+        tab: Tab,
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self)
+    ) {
         self.tab = tab
         self.profile = profile
     }

--- a/Client/Frontend/Theme/ThemeManager.swift
+++ b/Client/Frontend/Theme/ThemeManager.swift
@@ -26,7 +26,7 @@ final class ThemeManager {
     static let shared = ThemeManager()
 
     // MARK: - Variables
-    private var profile: Profile!
+    private var profile: Profile
 
     /// The theme key of the current set theme. If no custom theme is set, then
     /// this will return the `defaultThemeKey`
@@ -36,6 +36,10 @@ final class ThemeManager {
     }
 
     private let defaultThemeKey = "FxDefaultThemeThemeManagerKey"
+
+    init(profile: Profile = AppContainer.shared.resolve(type: Profile.self)) {
+        self.profile = profile
+    }
 
     /// The current theme set in the application.
     ///
@@ -51,14 +55,6 @@ final class ThemeManager {
     }
 
     // MARK: - Public methods
-
-    /// This is `ThemeManager`s initializer, essentially, as we require the profile
-    /// to save custom themes to disk.
-    ///
-    /// This should only be called in AppDelegate.
-    public func updateProfile(with profile: Profile) {
-        self.profile = profile
-    }
 
     // IMPORTANT NOTE:
     // The methods below are not finished. They are sketches for how updating themes

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -199,13 +199,13 @@ class URLBarView: UIView, AlphaDimmable, TopBottomInterchangeable {
         }
     }
 
-    var profile: Profile
+    private let profile: Profile
 
     fileprivate let privateModeBadge = BadgeWithBackdrop(imageName: "privateModeBadge", backdropCircleColor: UIColor.Defaults.MobilePrivatePurple)
     fileprivate let appMenuBadge = BadgeWithBackdrop(imageName: "menuBadge")
     fileprivate let warningMenuBadge = BadgeWithBackdrop(imageName: "menuWarning", imageMask: "warning-mask")
 
-    init(profile: Profile) {
+    init(profile: Profile = AppContainer.shared.resolve(type: Profile.self)) {
         self.profile = profile
         self.searchEngines = SearchEngines(prefs: profile.prefs, files: profile.files)
         super.init(frame: CGRect())
@@ -222,7 +222,7 @@ class URLBarView: UIView, AlphaDimmable, TopBottomInterchangeable {
 
     private func isBottomSearchBar() -> Bool {
         guard SearchBarSettingsViewModel.isEnabled else { return false }
-        return SearchBarSettingsViewModel(prefs: profile.prefs).searchBarPosition == .bottom
+        return SearchBarSettingsViewModel().searchBarPosition == .bottom
     }
 
     fileprivate func commonInit() {

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -132,12 +132,9 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
         }
     }
 
-    private override init(nibName: String?, bundle: Bundle?) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    init(profile: Profile) {
+    init(profile: Profile = AppContainer.shared.resolve(type: Profile.self)) {
         self.profile = profile
+
         super.init(nibName: nil, bundle: nil)
         applyTheme()
     }

--- a/Client/RatingPromptManager.swift
+++ b/Client/RatingPromptManager.swift
@@ -31,9 +31,11 @@ final class RatingPromptManager {
     ///   - profile: User's profile data
     ///   - daysOfUseCounter: Counter for the cumulative days of use of the application by the user
     ///   - sentry: Sentry protocol to override in Unit test
-    init(profile: Profile,
-         daysOfUseCounter: CumulativeDaysOfUseCounter = CumulativeDaysOfUseCounter(),
-         sentry: SentryProtocol = SentryIntegration.shared) {
+    init(
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        daysOfUseCounter: CumulativeDaysOfUseCounter = CumulativeDaysOfUseCounter(),
+        sentry: SentryProtocol = SentryIntegration.shared
+    ) {
         self.profile = profile
         self.daysOfUseCounter = daysOfUseCounter
         self.sentry = sentry

--- a/Client/SiteImageHelper.swift
+++ b/Client/SiteImageHelper.swift
@@ -25,11 +25,7 @@ class SiteImageHelper {
     private let throttler = Throttler(seconds: 0.5, on: .main)
     private let faviconFetcher: Favicons
 
-    convenience init(profile: Profile) {
-        self.init(faviconFetcher: profile.favicons)
-    }
-
-    init(faviconFetcher: Favicons) {
+    init(faviconFetcher: Favicons = AppContainer.shared.resolve(type: Profile.self).favicons) {
         self.faviconFetcher = faviconFetcher
     }
 

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -48,7 +48,7 @@ class TelemetryWrapper {
         }
     }
 
-    init(profile: Profile) {
+    init(profile: Profile = AppContainer.shared.resolve(type: Profile.self)) {
         crashedLastLaunch = SentryIntegration.shared.crashedLastLaunch
 
         migratePathComponentInDocumentsDirectory("MozTelemetry-Default-core", to: .cachesDirectory)

--- a/Client/Utils/HistoryDeletionUtility.swift
+++ b/Client/Utils/HistoryDeletionUtility.swift
@@ -9,7 +9,7 @@ class HistoryDeletionUtility {
 
     private var profile: Profile
 
-    init(with profile: Profile) {
+    init(with profile: Profile = AppContainer.shared.resolve(type: Profile.self)) {
         self.profile = profile
     }
 

--- a/RustFxA/FxAWebViewController.swift
+++ b/RustFxA/FxAWebViewController.swift
@@ -33,9 +33,13 @@ class FxAWebViewController: UIViewController {
      - parameter dismissalStyle: depending on how this was presented, it uses modal dismissal, or if part of a UINavigationController stack it will pop to the root.
      - parameter deepLinkParams: URL args passed in from deep link that propagate to FxA web view
      */
-    init(pageType: FxAPageType, profile: Profile, dismissalStyle: DismissType, deepLinkParams: FxALaunchParams?) {
-        self.viewModel = FxAWebViewModel(pageType: pageType, profile: profile, deepLinkParams: deepLinkParams)
-
+    init(
+        pageType: FxAPageType,
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        dismissalStyle: DismissType,
+        deepLinkParams: FxALaunchParams?
+    ) {
+        self.viewModel = FxAWebViewModel(pageType: pageType, deepLinkParams: deepLinkParams)
         self.dismissType = dismissalStyle
 
         let contentController = WKUserContentController()

--- a/RustFxA/FxAWebViewModel.swift
+++ b/RustFxA/FxAWebViewModel.swift
@@ -55,7 +55,11 @@ class FxAWebViewModel {
     - parameter profile: a Profile.
     - parameter deepLinkParams: url parameters that originate from a deep link
     */
-    required init(pageType: FxAPageType, profile: Profile, deepLinkParams: FxALaunchParams?) {
+    required init(
+        pageType: FxAPageType,
+        profile: Profile = AppContainer.shared.resolve(type: Profile.self),
+        deepLinkParams: FxALaunchParams?
+    ) {
         self.pageType = pageType
         self.profile = profile
         self.deepLinkParams = deepLinkParams

--- a/Tests/ClientTests/BreachAlertsTests.swift
+++ b/Tests/ClientTests/BreachAlertsTests.swift
@@ -32,10 +32,10 @@ let unbreachedLogin = LoginRecord(fromJSONDict: ["hostname": "http://unbreached.
 let breachedLogin = LoginRecord(fromJSONDict: ["hostname": "http://blockbuster.com", "timePasswordChanged": 46800000])
 
 class MockBreachAlertsClient: BreachAlertsClientProtocol {
-    func fetchEtag(endpoint: BreachAlertsClient.Endpoint, profile: Client.Profile, completion: @escaping (String?) -> Void) {
+    func fetchEtag(endpoint: BreachAlertsClient.Endpoint, completion: @escaping (String?) -> Void) {
         completion("33a64df551425fcc55e4d42a148795d9f25f89d4")
     }
-    func fetchData(endpoint: BreachAlertsClient.Endpoint, profile: Client.Profile, completion: @escaping (Maybe<Data>) -> Void) {
+    func fetchData(endpoint: BreachAlertsClient.Endpoint, completion: @escaping (Maybe<Data>) -> Void) {
         guard let mockData = try? JSONEncoder().encode([blockbusterBreach, longBreach, lipsumBreach].self) else {
             completion(Maybe(failure: BreachAlertsError(description: "failed to encode mockRecord")))
             return

--- a/Tests/ClientTests/Frontend/Home/FirefoxHomeViewControllerTests.swift
+++ b/Tests/ClientTests/Frontend/Home/FirefoxHomeViewControllerTests.swift
@@ -32,7 +32,7 @@ class FirefoxHomeViewControllerTests: XCTestCase {
     func testFirefoxHomeViewController_simpleCreation_hasNoLeaks() {
         let profile = MockProfile()
         let tabManager = TabManager(profile: profile, imageStore: nil)
-        let firefoxHomeViewController = HomepageViewController(profile: profile, tabManager: tabManager)
+        let firefoxHomeViewController = HomepageViewController(tabManager: tabManager)
 
         trackForMemoryLeaks(firefoxHomeViewController)
     }

--- a/Tests/ClientTests/StartAtHomeHelperTests.swift
+++ b/Tests/ClientTests/StartAtHomeHelperTests.swift
@@ -75,7 +75,7 @@ class StartAtHomeHelperTests: XCTestCase {
 
     func testScanForExistingHomeTab_ForEmptyTabs() {
         setupHelper()
-        let homeTab = helper.scanForExistingHomeTab(in: [], with: profile.prefs)
+        let homeTab = helper.scanForExistingHomeTab(in: [])
         XCTAssertNil(homeTab, "Expected to fail for disabled state")
     }
 
@@ -87,7 +87,7 @@ class StartAtHomeHelperTests: XCTestCase {
         let urlRequest = URLRequest(url: url!)
         let tab = tabManager.addTab(urlRequest)
 
-        let homeTab = helper.scanForExistingHomeTab(in: [tab], with: profile.prefs)
+        let homeTab = helper.scanForExistingHomeTab(in: [tab])
         XCTAssertNotNil(homeTab, "Expected to have a existing tab")
     }
 
@@ -99,14 +99,18 @@ class StartAtHomeHelperTests: XCTestCase {
         let urlRequest = URLRequest(url: url!)
         let tab = tabManager.addTab(urlRequest)
 
-        let homeTab = helper.scanForExistingHomeTab(in: [tab], with: profile.prefs)
+        let homeTab = helper.scanForExistingHomeTab(in: [tab])
         XCTAssertNil(homeTab, "Expected to fail for disabled state")
     }
 
     // MARK: - Private
     private func setupHelper(isRestoringTabs: Bool = false) {
-        helper = StartAtHomeHelper(isRestoringTabs: isRestoringTabs,
-                                   isRunnigTest: false)
+        helper = StartAtHomeHelper(
+            profile: profile,
+            isRestoringTabs: isRestoringTabs,
+            isRunnigTest: false
+        )
+
         helper.startAtHomeSetting = .afterFourHours
     }
 

--- a/Tests/ClientTests/TabDisplayManagerTests.swift
+++ b/Tests/ClientTests/TabDisplayManagerTests.swift
@@ -247,12 +247,14 @@ extension TabDisplayManagerTests {
     }
 
     func createTabDisplayManager(useMockDataStore: Bool = true) -> TabDisplayManager {
-        let tabDisplayManager = TabDisplayManager(collectionView: collectionView,
-                                                  tabManager: manager,
-                                                  tabDisplayer: self,
-                                                  reuseID: TopTabCell.cellIdentifier,
-                                                  tabDisplayType: .TopTabTray,
-                                                  profile: profile)
+        let tabDisplayManager = TabDisplayManager(
+            collectionView: collectionView,
+            tabManager: manager,
+            tabDisplayer: self,
+            reuseID: TopTabCell.cellIdentifier,
+            tabDisplayType: .TopTabTray
+        )
+
         collectionView.dataSource = tabDisplayManager
         tabDisplayManager.dataStore = useMockDataStore ? mockDataStore : dataStore
         return tabDisplayManager

--- a/Tests/ClientTests/TabEventHandlerTests.swift
+++ b/Tests/ClientTests/TabEventHandlerTests.swift
@@ -24,6 +24,7 @@ class TabEventHandlerTests: XCTestCase {
         XCTAssertFalse(handler.isFocused!)
     }
 
+    // TODO: Need help fixing this!
     func testBlankPopupURL() {
         let manager = BrowserViewController.foregroundBVC().tabManager
         let prefs = BrowserViewController.foregroundBVC().profile.prefs

--- a/Tests/ClientTests/TabTrayViewControllerTests.swift
+++ b/Tests/ClientTests/TabTrayViewControllerTests.swift
@@ -20,7 +20,7 @@ class TabTrayViewControllerTests: XCTestCase {
 
         profile = TabManagerMockProfile()
         manager = TabManager(profile: profile, imageStore: nil)
-        tabTray = TabTrayViewController(tabTrayDelegate: nil, profile: profile, tabToFocus: nil, tabManager: manager)
+        tabTray = TabTrayViewController(tabTrayDelegate: nil, tabToFocus: nil, tabManager: manager)
         gridTab = GridTabViewController(tabManager: manager, profile: profile)
         manager.addDelegate(gridTab)
     }

--- a/Tests/ClientTests/TopSitesManagerTests.swift
+++ b/Tests/ClientTests/TopSitesManagerTests.swift
@@ -551,6 +551,8 @@ extension TopSitesManagerTests {
                        line: UInt = #line) -> TopSitesManager {
 
         let topSitesManager = TopSitesManager(profile: profile)
+        let googleTopSiteManager = GoogleTopSiteManager(prefs: profile.prefs)
+        topSitesManager.googleTopSiteManager = googleTopSiteManager
 
         let historyStub = TopSiteHistoryManagerStub(profile: profile)
         historyStub.siteCount = siteCount

--- a/Tests/ClientTests/VersionSettingTests.swift
+++ b/Tests/ClientTests/VersionSettingTests.swift
@@ -9,7 +9,7 @@ class VersionSettingTests: XCTestCase {
 
     func testCopyAppVersion() {
         // MARK: - given
-        let settingsTable = SettingsTableViewController(style: .grouped)
+        let settingsTable = SettingsTableViewController()
         let navigationController = UINavigationController(rootViewController: settingsTable)
         let versionSetting = VersionSetting(settings: settingsTable)
 


### PR DESCRIPTION
# Overview

With Dip introduced as our dependency management solution, we'll now have certain services get picked from its container. 

This PR has clients resolve `Profile` from there.

## Details

### The Problem(s)
- A tight coupling b/w clients exists because of the chain of dependency passes
- A dependency exists inside a client SOLELY for the purpose of passing it down. This doesn't seem necessary.
- Constructor injection helps us see how much a client is doing, and we can think over whether its worth letting it continue doing that much. We should make a client's responsibilities more clear with this approach. 

Clients should be responsible for services it needs. One client should not be responsible for providing dependencies another client needs (within reason). They should resolve from the container.

If previously, `Profile` existed solely to be passed down a layer, this PR removes that step and instead injects `Profile` at the destination. 

I noticed sometimes, `Profile` was in the `init` but unused. In those cases, I remove profile from that area.

## Remaining
What's left for another time:
- Static methods were left alone. We need to discuss what to do with those
- Sync related - let's address that specifically another time in its own ticket
- Client + some other target; we're keeping it to Client only for now

## Testing
If there are issues, you'd see them at runtime. I recommend testing by doing random user flows while signed in and out.

Regarding Unit / UI tests, it seems like occasionally there's reliance on foregroundBVC. The assumption that this access pattern will continue existing needs to be fixed as well, probably in this PR 😱 . 

## References
**Documents**
- [Services list](https://docs.google.com/document/d/1a6EPFWipAHh2W-0De3Ufe6U7US28VhSfnQpGJgTpwYo/edit?usp=sharing)
- [iPad epic](https://docs.google.com/document/d/16CkeBm5Y-g95tF-BVqi_b38KV5JfC8yQJVlOawhTKjk/edit?usp=sharing)
- [DI w/ Containers overview](https://docs.google.com/document/d/1SOOmg5-75se65F1dx47KA8xGrsVjoIUt4G1Kz27NC1E/edit?usp=sharing)
- [ForegroundBVC doc](https://docs.google.com/document/d/1xngMTUXH6LeypvZ0SM04AYHC_o_yxzZr1kzMZRE3duk/edit?usp=sharing), since we can address those cases with the approach from this PR.

**PRs & some:**
- [Introducing Dip](https://github.com/mozilla-mobile/firefox-ios/pull/11135)

