### PR TITLE
Add [v104] Update expired metrics dates

### DIFF
--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -1515,7 +1515,7 @@ preferences:
       - https://github.com/mozilla-mobile/firefox-ios/pull/9673
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2022-07-01"
+    expires: "2023-01-01"
   private_browsing_button_tapped:
     type: event
     description: |
@@ -2109,7 +2109,7 @@ tabs:
       - https://github.com/mozilla-mobile/firefox-ios/pull/9785
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2022-07-01"
+    expires: "2023-01-01"
   press_tab_toolbar:
     type: event
     description: |


### PR DESCRIPTION
# Request for Data Collection Renewal

** This form is for the renewal of an existing, reviewed data collection.**

** All questions are mandatory.
You must receive Data Review from a
[Data Steward](https://wiki.mozilla.org/Data_Collection)
on a filled-out Request before shipping your renewed data collection.**

1) Provide a link to the initial Data Collection Review Request for this collection.
[Tabs](https://github.com/mozilla-mobile/firefox-ios/commit/f69c127bde16ee121f80b483721b2fa6a2ced4e8)
[Reload from URL](https://github.com/mozilla-mobile/firefox-ios/commit/8630b3da4420c7bc750d791ad1b7c55b6a2baaae)

2) When will this collection now expire?
Both items will expire on Jan 1, 2023.

3) Why was the initial period of collection insufficient?
We are requesting more time to collect the data in order to see how users are interacting with the feature.