### PR TITLE
Bugfix FXIOS-4494 [v102.1] Has data needs to account for sponsored tiles & google

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -258,7 +258,7 @@
 		3B61CD591F2A750800D38DE1 /* PocketFeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B61CD581F2A750800D38DE1 /* PocketFeedTests.swift */; };
 		3B61CD631F2A769D00D38DE1 /* pocketglobalfeed.json in Resources */ = {isa = PBXBuildFile; fileRef = 3B61CD621F2A769D00D38DE1 /* pocketglobalfeed.json */; };
 		3B6889C51D66950E002AC85E /* UIImageColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6889C41D66950E002AC85E /* UIImageColors.swift */; };
-		3B6F40181DC7849C00656CC6 /* FxHomeTopSitesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6F40171DC7849C00656CC6 /* FxHomeTopSitesViewModelTests.swift */; };
+		3B6F40181DC7849C00656CC6 /* TopSitesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6F40171DC7849C00656CC6 /* TopSitesViewModelTests.swift */; };
 		3BB50E111D6274CD004B33DF /* TopSiteItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB50E101D6274CD004B33DF /* TopSiteItemCell.swift */; };
 		3BB50E201D627539004B33DF /* HomepageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB50E1F1D627539004B33DF /* HomepageViewController.swift */; };
 		3BC659491E5BA4AE006D560F /* TopSites in Resources */ = {isa = PBXBuildFile; fileRef = 3BC659481E5BA4AE006D560F /* TopSites */; };
@@ -485,7 +485,7 @@
 		8A2B1A5E28216C4D0061216B /* Common.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 8A2B1A5B28216C4C0061216B /* Common.xcconfig */; };
 		8A2B1A5F28216C4D0061216B /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 8A2B1A5C28216C4D0061216B /* Release.xcconfig */; };
 		8A2D593E27DC0AA100713EC9 /* TopSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2D593D27DC0AA100713EC9 /* TopSite.swift */; };
-		8A33221F27DFE318008F809E /* FxHomeTopSitesManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A33221E27DFE318008F809E /* FxHomeTopSitesManagerTests.swift */; };
+		8A33221F27DFE318008F809E /* TopSitesManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A33221E27DFE318008F809E /* TopSitesManagerTests.swift */; };
 		8A33222227DFE658008F809E /* NimbusMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A33222127DFE658008F809E /* NimbusMock.swift */; };
 		8A35497227BD672700534A65 /* ToggleSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A35497127BD672700534A65 /* ToggleSwitch.swift */; };
 		8A355E5E27D267A400B9AF34 /* RecentItemsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */; };
@@ -2201,7 +2201,7 @@
 		3B61CD581F2A750800D38DE1 /* PocketFeedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketFeedTests.swift; sourceTree = "<group>"; };
 		3B61CD621F2A769D00D38DE1 /* pocketglobalfeed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = pocketglobalfeed.json; sourceTree = "<group>"; };
 		3B6889C41D66950E002AC85E /* UIImageColors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIImageColors.swift; path = ThirdParty/UIImageColors.swift; sourceTree = "<group>"; };
-		3B6F40171DC7849C00656CC6 /* FxHomeTopSitesViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxHomeTopSitesViewModelTests.swift; sourceTree = "<group>"; };
+		3B6F40171DC7849C00656CC6 /* TopSitesViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopSitesViewModelTests.swift; sourceTree = "<group>"; };
 		3B704751960D3C7E442AFBAE /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Search.strings; sourceTree = "<group>"; };
 		3B9A4BDF8865C6533212FC6C /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/Menu.strings; sourceTree = "<group>"; };
 		3BB50E101D6274CD004B33DF /* TopSiteItemCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopSiteItemCell.swift; sourceTree = "<group>"; };
@@ -2890,7 +2890,7 @@
 		8A2B1A5B28216C4C0061216B /* Common.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Common.xcconfig; path = Configuration/Common.xcconfig; sourceTree = "<group>"; };
 		8A2B1A5C28216C4D0061216B /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Configuration/Release.xcconfig; sourceTree = "<group>"; };
 		8A2D593D27DC0AA100713EC9 /* TopSite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSite.swift; sourceTree = "<group>"; };
-		8A33221E27DFE318008F809E /* FxHomeTopSitesManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxHomeTopSitesManagerTests.swift; sourceTree = "<group>"; };
+		8A33221E27DFE318008F809E /* TopSitesManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesManagerTests.swift; sourceTree = "<group>"; };
 		8A33222127DFE658008F809E /* NimbusMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusMock.swift; sourceTree = "<group>"; };
 		8A35497127BD672700534A65 /* ToggleSwitch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleSwitch.swift; sourceTree = "<group>"; };
 		8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentItemsHelperTests.swift; sourceTree = "<group>"; };
@@ -7126,8 +7126,8 @@
 				D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */,
 				8DCD3BCC1ED5B7FA00446D38 /* FxADeepLinkingTests.swift */,
 				3943A81C1E9807C700D4F6DC /* FxAPushMessageTest.swift */,
-				8A33221E27DFE318008F809E /* FxHomeTopSitesManagerTests.swift */,
-				3B6F40171DC7849C00656CC6 /* FxHomeTopSitesViewModelTests.swift */,
+				8A33221E27DFE318008F809E /* TopSitesManagerTests.swift */,
+				3B6F40171DC7849C00656CC6 /* TopSitesViewModelTests.swift */,
 				5F97DD5E27FB0FE800AD3C60 /* GleanTelemetryTests.swift */,
 				C8E78BDC27F4A1E700C48BAA /* HistoryDeletionUtilityTests.swift */,
 				C889D7D32858CD4500121E1D /* HistoryHighlights */,
@@ -9788,7 +9788,7 @@
 				C8E78BDD27F4A1E700C48BAA /* HistoryDeletionUtilityTests.swift in Sources */,
 				8A11C8132731E54800AC7318 /* DictionaryExtensionsTests.swift in Sources */,
 				8A7A93EE2810ADF2005E7E1B /* ContileProviderTests.swift in Sources */,
-				8A33221F27DFE318008F809E /* FxHomeTopSitesManagerTests.swift in Sources */,
+				8A33221F27DFE318008F809E /* TopSitesManagerTests.swift in Sources */,
 				2165B2C02860BB41004C0786 /* AdjustTelemetryHelperTests.swift in Sources */,
 				C807CCCC28367446008E6A5A /* FeatureFlagManagerTests.swift in Sources */,
 				8A5C3BC5282ABF8E003A8CCF /* RemoteTabsPanelTests.swift in Sources */,
@@ -9813,7 +9813,7 @@
 				C8D0D6F4281C231200AFAED9 /* FeatureFlagsUserPrefsMigrationUtilityTests.swift in Sources */,
 				43446CF02412DDBE00F5C643 /* UpdateCoverSheetViewModelTests.swift in Sources */,
 				8AE1E1D927B1BD380024C45E /* UIStackViewExtensionsTests.swift in Sources */,
-				3B6F40181DC7849C00656CC6 /* FxHomeTopSitesViewModelTests.swift in Sources */,
+				3B6F40181DC7849C00656CC6 /* TopSitesViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -362,6 +362,7 @@ extension GridTabViewController {
         } else if self.tabManager.normalTabs.count == 1, let tab = self.tabManager.normalTabs.first {
             self.tabManager.selectTab(tab)
             self.dismissTabTray()
+            notificationCenter.post(name: .TabsTrayDidClose, object: nil)
         }
     }
 

--- a/Client/Frontend/Home/TopSites/DataManagement/GoogleTopSiteManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/GoogleTopSiteManager.swift
@@ -72,9 +72,9 @@ class GoogleTopSiteManager {
 
     // Once Google top site is added, we don't remove unless it's explicitly unpinned
     // Add it when pinned websites are less than max pinned sites
-    func shouldAddGoogleTopSite(availableSpacesCount: Int) -> Bool {
+    func shouldAddGoogleTopSite(hasSpace: Bool) -> Bool {
         let shouldShow = !isHidden && suggestedSiteData() != nil
-        return shouldShow && (hasAdded || availableSpacesCount > 0)
+        return shouldShow && (hasAdded || hasSpace)
     }
 
     func removeGoogleTopSite(site: Site) {

--- a/Client/Frontend/Home/TopSites/DataManagement/TopSitesManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/TopSitesManager.swift
@@ -125,6 +125,9 @@ class TopSitesManager: FeatureFlaggable, HasNimbusSponsoredTiles {
         refreshIfNeeded(forceTopSites: false)
     }
 
+    /// Get available space count for the sponsored tiles and Google tiles
+    /// - Parameter numberOfTilesPerRow: Comes from top sites view model and accounts for different layout (landscape, portrait, iPhone, iPad, etc).
+    /// - Returns: The available space count for the rest of the calculation
     private func getAvailableSpaceCount(numberOfTilesPerRow: Int) -> Int {
         let pinnedSiteCount = countPinnedSites(sites: historySites)
         let totalNumberOfShownTiles = numberOfTilesPerRow * numberOfRows

--- a/Client/Frontend/Home/TopSites/DataManagement/TopSitesManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/TopSitesManager.swift
@@ -41,7 +41,10 @@ class TopSitesManager: FeatureFlaggable, HasNimbusSponsoredTiles {
     }
 
     var hasData: Bool {
-        return !historySites.isEmpty
+        // We cannot simply look if there's contiles data to look for other data since it won't necessarely show
+        // depending on the different contiles rules
+        let hasOtherData = shouldAddSponsoredTiles || googleTopSiteManager.shouldAddGoogleTopSite(hasSpace: true)
+        return !historySites.isEmpty || (historySites.isEmpty && hasOtherData)
     }
 
     var siteCount: Int {
@@ -87,6 +90,7 @@ class TopSitesManager: FeatureFlaggable, HasNimbusSponsoredTiles {
 
     private func loadTopSites(group: DispatchGroup) {
         group.enter()
+
         topSiteHistoryManager.getTopSites { [weak self] sites in
             self?.historySites = sites
             group.leave()
@@ -101,12 +105,20 @@ class TopSitesManager: FeatureFlaggable, HasNimbusSponsoredTiles {
     /// - Parameter numberOfTilesPerRow: The number of tiles per row shown to the user
     func calculateTopSiteData(numberOfTilesPerRow: Int) {
         var sites = historySites
-        let pinnedSiteCount = countPinnedSites(sites: sites)
-        let totalNumberOfShownTiles = numberOfTilesPerRow * numberOfRows
-        let availableSpacesCount = totalNumberOfShownTiles - pinnedSiteCount
+        let availableSpaceCount = getAvailableSpaceCount(numberOfTilesPerRow: numberOfTilesPerRow)
+        let shouldAddGoogle = shouldAddGoogle(availableSpaceCount: availableSpaceCount)
 
-        addSponsoredTiles(sites: &sites, availableSpacesCount: availableSpacesCount)
-        addGoogleTopSite(sites: &sites, availableSpacesCount: availableSpacesCount)
+        // Add Sponsored tile
+        if shouldAddSponsoredTiles {
+            addSponsoredTiles(sites: &sites,
+                              shouldAddGoogle: shouldAddGoogle,
+                              availableSpaceCount: availableSpaceCount)
+        }
+
+        // Add Google Tile
+        if shouldAddGoogle {
+            addGoogleTopSite(sites: &sites)
+        }
 
         sites.removeDuplicates()
 
@@ -114,6 +126,12 @@ class TopSitesManager: FeatureFlaggable, HasNimbusSponsoredTiles {
 
         // Refresh data in the background so we'll have fresh data next time we show
         refreshIfNeeded(forceTopSites: false)
+    }
+
+    private func getAvailableSpaceCount(numberOfTilesPerRow: Int) -> Int {
+        let pinnedSiteCount = countPinnedSites(sites: historySites)
+        let totalNumberOfShownTiles = numberOfTilesPerRow * numberOfRows
+        return totalNumberOfShownTiles - pinnedSiteCount
     }
 
     // The number of rows the user wants.
@@ -124,23 +142,16 @@ class TopSitesManager: FeatureFlaggable, HasNimbusSponsoredTiles {
         return Int(preferredNumberOfRows ?? defaultNumberOfRows)
     }
 
-    func addSponsoredTiles(sites: inout [Site], availableSpacesCount: Int) {
-        guard shouldShowSponsoredTiles else { return }
+    func addSponsoredTiles(sites: inout [Site], shouldAddGoogle: Bool, availableSpaceCount: Int) {
+        let sponsoredTileSpaces = getSponsoredNumberTiles(shouldAddGoogle: shouldAddGoogle,
+                                                          availableSpaceCount: availableSpaceCount)
 
-        // Google tile has precedence over Sponsored Tiles, if Google tile is present
-        let shouldAddGoogleTopSite = googleTopSiteManager.shouldAddGoogleTopSite(availableSpacesCount: availableSpacesCount)
-        let sponsoredTileSpaces = shouldAddGoogleTopSite ? availableSpacesCount - GoogleTopSiteManager.Constants.reservedSpaceCount : availableSpacesCount
         if sponsoredTileSpaces > 0 {
             let maxNumberOfTiles = nimbusSponoredTiles.getMaxNumberOfTiles()
             sites.addSponsoredTiles(sponsoredTileSpaces: sponsoredTileSpaces,
                                     contiles: contiles,
                                     maxNumberOfSponsoredTile: maxNumberOfTiles)
         }
-    }
-
-    private func addGoogleTopSite(sites: inout [Site], availableSpacesCount: Int) {
-        guard googleTopSiteManager.shouldAddGoogleTopSite(availableSpacesCount: availableSpacesCount) else { return }
-        googleTopSiteManager.addGoogleTopSite(sites: &sites)
     }
 
     private func countPinnedSites(sites: [Site]) -> Int {
@@ -151,14 +162,30 @@ class TopSitesManager: FeatureFlaggable, HasNimbusSponsoredTiles {
         return pinnedSites
     }
 
+    // MARK: - Google Tile
+
+    private func shouldAddGoogle(availableSpaceCount: Int) -> Bool {
+        googleTopSiteManager.shouldAddGoogleTopSite(hasSpace: availableSpaceCount > 0)
+    }
+
+    private func addGoogleTopSite(sites: inout [Site]) {
+        googleTopSiteManager.addGoogleTopSite(sites: &sites)
+    }
+
     // MARK: - Sponsored tiles (Contiles)
 
     private var shouldLoadSponsoredTiles: Bool {
         return featureFlags.isFeatureEnabled(.sponsoredTiles, checking: .buildAndUser)
     }
 
-    private var shouldShowSponsoredTiles: Bool {
+    private var shouldAddSponsoredTiles: Bool {
         return !contiles.isEmpty && shouldLoadSponsoredTiles
+    }
+
+    /// Google tile has precedence over Sponsored Tiles, if Google tile is present
+    private func getSponsoredNumberTiles(shouldAddGoogle: Bool, availableSpaceCount: Int) -> Int {
+        let googleAdjustedSpaceCount = availableSpaceCount - GoogleTopSiteManager.Constants.reservedSpaceCount
+        return shouldAddGoogle ? googleAdjustedSpaceCount : availableSpaceCount
     }
 }
 

--- a/Client/Frontend/Home/TopSites/DataManagement/TopSitesManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/TopSitesManager.swift
@@ -41,10 +41,7 @@ class TopSitesManager: FeatureFlaggable, HasNimbusSponsoredTiles {
     }
 
     var hasData: Bool {
-        // We cannot simply look if there's contiles data to look for other data since it won't necessarely show
-        // depending on the different contiles rules
-        let hasOtherData = shouldAddSponsoredTiles || googleTopSiteManager.shouldAddGoogleTopSite(hasSpace: true)
-        return !historySites.isEmpty || (historySites.isEmpty && hasOtherData)
+        return !topSites.isEmpty
     }
 
     var siteCount: Int {

--- a/Tests/ClientTests/Frontend/Home/FirefoxHomeViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/FirefoxHomeViewModelTests.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
-import Shared
 
 @testable import Client
 
@@ -13,27 +12,19 @@ class FirefoxHomeViewModelTests: XCTestCase {
 
     // MARK: Number of sections
     func testNumberOfSection_withoutUpdatingData() {
-        let profile = createProfile()
-
+        let profile = MockProfile()
         let viewModel = HomepageViewModel(profile: profile,
-                                          isPrivate: false)
-        XCTAssertEqual(viewModel.shownSections.count, 2, "Has fx logo header and customize homepage sections")
+                                             isPrivate: false)
+        XCTAssertEqual(viewModel.shownSections.count, 2)
     }
 
-    func testNumberOfSection_withoutUpdatingData_withGoogleTopSite() {
-        let profile = createProfile(hasGoogleTopSite: true)
-        let viewModel = HomepageViewModel(profile: profile,
-                                          isPrivate: false)
-        XCTAssertEqual(viewModel.shownSections.count, 3, "Has fx logo, topsites and customize home page sections")
-    }
-
-    func testNumberOfSection_updatingData_adds2Sections() throws {
-        throw XCTSkip("Disabled until homepage's reload issue is solved")
+// TODO: Disabled until homepage's reload issue is solved next sprint.
+//    func testNumberOfSection_updatingData_adds2Sections() {
 //        let collectionView = UICollectionView(frame: CGRect.zero,
 //                                              collectionViewLayout: UICollectionViewLayout())
-//        let profile = createProfile()
-//        let viewModel = HomepageViewModel(profile: profile,
-//                                          isPrivate: false)
+//        let profile = MockProfile()
+//        let viewModel = FirefoxHomeViewModel(profile: profile,
+//                                             isPrivate: false)
 //        viewModel.delegate = self
 //        viewModel.updateData()
 //
@@ -49,13 +40,13 @@ class FirefoxHomeViewModelTests: XCTestCase {
 //        waitForExpectations(timeout: 1.0, handler: nil)
 //
 //        XCTAssertEqual(viewModel.shownSections.count, 4)
-    }
+//    }
 
     // MARK: Orders of sections
     func testSectionOrder_addingJumpBackIn() {
-        let profile = createProfile()
+        let profile = MockProfile()
         let viewModel = HomepageViewModel(profile: profile,
-                                          isPrivate: false)
+                                             isPrivate: false)
 
         viewModel.addShownSection(section: HomepageSectionType.jumpBackIn)
         XCTAssertEqual(viewModel.shownSections.count, 3)
@@ -65,9 +56,9 @@ class FirefoxHomeViewModelTests: XCTestCase {
     }
 
     func testSectionOrder_addingTwoSections() {
-        let profile = createProfile()
+        let profile = MockProfile()
         let viewModel = HomepageViewModel(profile: profile,
-                                          isPrivate: false)
+                                             isPrivate: false)
 
         viewModel.addShownSection(section: HomepageSectionType.jumpBackIn)
         viewModel.addShownSection(section: HomepageSectionType.pocket)
@@ -79,9 +70,9 @@ class FirefoxHomeViewModelTests: XCTestCase {
     }
 
     func testSectionOrder_addingAndRemovingSections() {
-        let profile = createProfile()
+        let profile = MockProfile()
         let viewModel = HomepageViewModel(profile: profile,
-                                          isPrivate: false)
+                                             isPrivate: false)
 
         viewModel.addShownSection(section: HomepageSectionType.jumpBackIn)
         viewModel.addShownSection(section: HomepageSectionType.pocket)
@@ -93,9 +84,9 @@ class FirefoxHomeViewModelTests: XCTestCase {
     }
 
     func testSectionOrder_addingAndRemovingMoreSections() {
-        let profile = createProfile()
+        let profile = MockProfile()
         let viewModel = HomepageViewModel(profile: profile,
-                                          isPrivate: false)
+                                             isPrivate: false)
 
         viewModel.addShownSection(section: HomepageSectionType.jumpBackIn)
         viewModel.addShownSection(section: HomepageSectionType.pocket)
@@ -118,15 +109,6 @@ class FirefoxHomeViewModelTests: XCTestCase {
 
 // MARK: - FirefoxHomeViewModelDelegate
 extension FirefoxHomeViewModelTests: HomepageViewModelDelegate {
-
-    // Without fetching history from backend, we know we'll show top sites if Google top sites needs to show
-    func createProfile(hasGoogleTopSite: Bool = false) -> Profile {
-        let profile = MockProfile()
-        profile.prefs.setBool(!hasGoogleTopSite, forKey: PrefsKeys.GoogleTopSiteAddedKey)
-        profile.prefs.setBool(!hasGoogleTopSite, forKey: PrefsKeys.GoogleTopSiteHideKey)
-
-        return profile
-    }
 
     func reloadSection(section: HomepageViewModelProtocol) {
         reloadSectionCompleted?(section)

--- a/Tests/ClientTests/Frontend/Home/FirefoxHomeViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/FirefoxHomeViewModelTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
+import Shared
 
 @testable import Client
 
@@ -12,19 +13,27 @@ class FirefoxHomeViewModelTests: XCTestCase {
 
     // MARK: Number of sections
     func testNumberOfSection_withoutUpdatingData() {
-        let profile = MockProfile()
+        let profile = createProfile()
+
         let viewModel = HomepageViewModel(profile: profile,
-                                             isPrivate: false)
-        XCTAssertEqual(viewModel.shownSections.count, 2)
+                                          isPrivate: false)
+        XCTAssertEqual(viewModel.shownSections.count, 2, "Has fx logo header and customize homepage sections")
     }
 
-// TODO: Disabled until homepage's reload issue is solved next sprint.
-//    func testNumberOfSection_updatingData_adds2Sections() {
+    func testNumberOfSection_withoutUpdatingData_withGoogleTopSite() {
+        let profile = createProfile(hasGoogleTopSite: true)
+        let viewModel = HomepageViewModel(profile: profile,
+                                          isPrivate: false)
+        XCTAssertEqual(viewModel.shownSections.count, 3, "Has fx logo, topsites and customize home page sections")
+    }
+
+    func testNumberOfSection_updatingData_adds2Sections() throws {
+        throw XCTSkip("Disabled until homepage's reload issue is solved")
 //        let collectionView = UICollectionView(frame: CGRect.zero,
 //                                              collectionViewLayout: UICollectionViewLayout())
-//        let profile = MockProfile()
-//        let viewModel = FirefoxHomeViewModel(profile: profile,
-//                                             isPrivate: false)
+//        let profile = createProfile()
+//        let viewModel = HomepageViewModel(profile: profile,
+//                                          isPrivate: false)
 //        viewModel.delegate = self
 //        viewModel.updateData()
 //
@@ -40,13 +49,13 @@ class FirefoxHomeViewModelTests: XCTestCase {
 //        waitForExpectations(timeout: 1.0, handler: nil)
 //
 //        XCTAssertEqual(viewModel.shownSections.count, 4)
-//    }
+    }
 
     // MARK: Orders of sections
     func testSectionOrder_addingJumpBackIn() {
-        let profile = MockProfile()
+        let profile = createProfile()
         let viewModel = HomepageViewModel(profile: profile,
-                                             isPrivate: false)
+                                          isPrivate: false)
 
         viewModel.addShownSection(section: HomepageSectionType.jumpBackIn)
         XCTAssertEqual(viewModel.shownSections.count, 3)
@@ -56,9 +65,9 @@ class FirefoxHomeViewModelTests: XCTestCase {
     }
 
     func testSectionOrder_addingTwoSections() {
-        let profile = MockProfile()
+        let profile = createProfile()
         let viewModel = HomepageViewModel(profile: profile,
-                                             isPrivate: false)
+                                          isPrivate: false)
 
         viewModel.addShownSection(section: HomepageSectionType.jumpBackIn)
         viewModel.addShownSection(section: HomepageSectionType.pocket)
@@ -70,9 +79,9 @@ class FirefoxHomeViewModelTests: XCTestCase {
     }
 
     func testSectionOrder_addingAndRemovingSections() {
-        let profile = MockProfile()
+        let profile = createProfile()
         let viewModel = HomepageViewModel(profile: profile,
-                                             isPrivate: false)
+                                          isPrivate: false)
 
         viewModel.addShownSection(section: HomepageSectionType.jumpBackIn)
         viewModel.addShownSection(section: HomepageSectionType.pocket)
@@ -84,9 +93,9 @@ class FirefoxHomeViewModelTests: XCTestCase {
     }
 
     func testSectionOrder_addingAndRemovingMoreSections() {
-        let profile = MockProfile()
+        let profile = createProfile()
         let viewModel = HomepageViewModel(profile: profile,
-                                             isPrivate: false)
+                                          isPrivate: false)
 
         viewModel.addShownSection(section: HomepageSectionType.jumpBackIn)
         viewModel.addShownSection(section: HomepageSectionType.pocket)
@@ -109,6 +118,15 @@ class FirefoxHomeViewModelTests: XCTestCase {
 
 // MARK: - FirefoxHomeViewModelDelegate
 extension FirefoxHomeViewModelTests: HomepageViewModelDelegate {
+
+    // Without fetching history from backend, we know we'll show top sites if Google top sites needs to show
+    func createProfile(hasGoogleTopSite: Bool = false) -> Profile {
+        let profile = MockProfile()
+        profile.prefs.setBool(!hasGoogleTopSite, forKey: PrefsKeys.GoogleTopSiteAddedKey)
+        profile.prefs.setBool(!hasGoogleTopSite, forKey: PrefsKeys.GoogleTopSiteHideKey)
+
+        return profile
+    }
 
     func reloadSection(section: HomepageViewModelProtocol) {
         reloadSectionCompleted?(section)

--- a/Tests/ClientTests/TopSitesManagerTests.swift
+++ b/Tests/ClientTests/TopSitesManagerTests.swift
@@ -32,17 +32,9 @@ class TopSitesManagerTests: XCTestCase, FeatureFlaggable {
     }
 
     func testEmptyData_whenNotLoaded() {
-        profile.prefs.setBool(true, forKey: PrefsKeys.GoogleTopSiteAddedKey)
-        profile.prefs.setBool(true, forKey: PrefsKeys.GoogleTopSiteHideKey)
-
         let manager = TopSitesManager(profile: profile)
         XCTAssertFalse(manager.hasData)
         XCTAssertEqual(manager.siteCount, 0)
-    }
-
-    func testNotEmptyData_whenNotLoaded_accountingForGoogle() {
-        let manager = TopSitesManager(profile: profile)
-        XCTAssertTrue(manager.hasData)
     }
 
     func testEmptyData_getSites() {

--- a/Tests/ClientTests/TopSitesManagerTests.swift
+++ b/Tests/ClientTests/TopSitesManagerTests.swift
@@ -8,7 +8,7 @@ import Shared
 import Storage
 import XCTest
 
-class FxHomeTopSitesManagerTests: XCTestCase, FeatureFlaggable {
+class TopSitesManagerTests: XCTestCase, FeatureFlaggable {
 
     private var profile: MockProfile!
     private var contileProviderMock: ContileProviderMock!
@@ -32,9 +32,17 @@ class FxHomeTopSitesManagerTests: XCTestCase, FeatureFlaggable {
     }
 
     func testEmptyData_whenNotLoaded() {
+        profile.prefs.setBool(true, forKey: PrefsKeys.GoogleTopSiteAddedKey)
+        profile.prefs.setBool(true, forKey: PrefsKeys.GoogleTopSiteHideKey)
+
         let manager = TopSitesManager(profile: profile)
         XCTAssertFalse(manager.hasData)
         XCTAssertEqual(manager.siteCount, 0)
+    }
+
+    func testNotEmptyData_whenNotLoaded_accountingForGoogle() {
+        let manager = TopSitesManager(profile: profile)
+        XCTAssertTrue(manager.hasData)
     }
 
     func testEmptyData_getSites() {
@@ -140,6 +148,18 @@ class FxHomeTopSitesManagerTests: XCTestCase, FeatureFlaggable {
     }
 
     // MARK: Sponsored tiles
+
+    func testLoadTopSitesData_hasDataAccountsForSponsoredTiles() {
+        featureFlags.set(feature: .sponsoredTiles, to: true)
+        profile.prefs.setBool(true, forKey: PrefsKeys.GoogleTopSiteAddedKey)
+        profile.prefs.setBool(true, forKey: PrefsKeys.GoogleTopSiteHideKey)
+
+        let expectedContileResult = ContileResult.success(ContileProviderMock.defaultSuccessData)
+        let manager = createManager(siteCount: 0, expectedContileResult: expectedContileResult)
+        testLoadData(manager: manager, numberOfTilesPerRow: nil) {
+            XCTAssertTrue(manager.hasData)
+        }
+    }
 
     func testLoadTopSitesData_addSponsoredTile() {
         featureFlags.set(feature: .sponsoredTiles, to: true)
@@ -287,7 +307,7 @@ class FxHomeTopSitesManagerTests: XCTestCase, FeatureFlaggable {
         let manager = createManager(expectedContileResult: expectedContileResult)
         testLoadData(manager: manager, numberOfTilesPerRow: nil) {
             var sites: [Site] = []
-            manager.addSponsoredTiles(sites: &sites, availableSpacesCount: 10)
+            manager.addSponsoredTiles(sites: &sites, shouldAddGoogle: true, availableSpaceCount: 10)
 
             XCTAssertEqual(sites.count, 2, "Added two contiles")
             XCTAssertEqual(sites[0].title, "Firefox")
@@ -301,7 +321,7 @@ class FxHomeTopSitesManagerTests: XCTestCase, FeatureFlaggable {
         let manager = createManager(expectedContileResult: expectedContileResult)
         testLoadData(manager: manager, numberOfTilesPerRow: nil) {
             var sites: [Site] = []
-            manager.addSponsoredTiles(sites: &sites, availableSpacesCount: 2)
+            manager.addSponsoredTiles(sites: &sites, shouldAddGoogle: true, availableSpaceCount: 2)
 
             XCTAssertEqual(sites.count, 1, "Added one contile")
             XCTAssertEqual(sites[0].title, "Firefox")
@@ -315,7 +335,7 @@ class FxHomeTopSitesManagerTests: XCTestCase, FeatureFlaggable {
         testLoadData(manager: manager, numberOfTilesPerRow: nil) {
             var sites: [Site] = [Site(url: "www.test.com", title: "A test"),
                                  Site(url: "www.test2.com", title: "A test2")]
-            manager.addSponsoredTiles(sites: &sites, availableSpacesCount: 10)
+            manager.addSponsoredTiles(sites: &sites, shouldAddGoogle: true, availableSpaceCount: 10)
 
             XCTAssertEqual(sites.count, 4, "Added two contiles and two sites")
             XCTAssertEqual(sites[0].title, "Firefox")
@@ -325,14 +345,12 @@ class FxHomeTopSitesManagerTests: XCTestCase, FeatureFlaggable {
 
     func testSponsoredTile_GoogleTopSiteDoesntCountInSponsoredTilesCount_IfHidden() {
         featureFlags.set(feature: .sponsoredTiles, to: true)
-        profile.prefs.setBool(true, forKey: PrefsKeys.GoogleTopSiteAddedKey)
-        profile.prefs.setBool(true, forKey: PrefsKeys.GoogleTopSiteHideKey)
 
         let expectedContileResult = ContileResult.success(ContileProviderMock.defaultSuccessData)
         let manager = createManager(expectedContileResult: expectedContileResult)
         testLoadData(manager: manager, numberOfTilesPerRow: nil) {
             var sites: [Site] = []
-            manager.addSponsoredTiles(sites: &sites, availableSpacesCount: 2)
+            manager.addSponsoredTiles(sites: &sites, shouldAddGoogle: false, availableSpaceCount: 2)
 
             XCTAssertEqual(sites.count, 2, "Added two contiles, no Google spot taken")
             XCTAssertEqual(sites[0].title, "Firefox")
@@ -347,7 +365,7 @@ class FxHomeTopSitesManagerTests: XCTestCase, FeatureFlaggable {
         let manager = createManager(expectedContileResult: expectedContileResult)
         testLoadData(manager: manager, numberOfTilesPerRow: nil) {
             var sites: [Site] = []
-            manager.addSponsoredTiles(sites: &sites, availableSpacesCount: 2)
+            manager.addSponsoredTiles(sites: &sites, shouldAddGoogle: true, availableSpaceCount: 2)
 
             XCTAssertEqual(sites.count, 1, "Added only one contile, Google tile count is taken into account")
             XCTAssertEqual(sites[0].title, "Firefox")
@@ -530,8 +548,8 @@ extension ContileProviderMock {
     }
 }
 
-// MARK: FxHomeTopSitesManagerTests
-extension FxHomeTopSitesManagerTests {
+// MARK: TopSitesManagerTests
+extension TopSitesManagerTests {
 
     func createManager(addPinnedSiteCount: Int = 0,
                        siteCount: Int = 10,

--- a/Tests/ClientTests/TopSitesViewModelTests.swift
+++ b/Tests/ClientTests/TopSitesViewModelTests.swift
@@ -9,7 +9,7 @@ import Shared
 import Storage
 import SyncTelemetry
 
-class FxHomeTopSitesViewModelTests: XCTestCase {
+class TopSitesViewModelTests: XCTestCase {
     var profile: MockProfile!
 
     override func setUp() {
@@ -168,13 +168,13 @@ class FxHomeTopSitesViewModelTests: XCTestCase {
 }
 
 // MARK: Helper methods
-extension FxHomeTopSitesViewModelTests {
+extension TopSitesViewModelTests {
 
     func createViewModel(overridenSiteCount: Int = 40, overridenNumberOfRows: Int = 2) -> TopSitesViewModel {
         let viewModel = TopSitesViewModel(profile: self.profile,
                                                 isZeroSearch: false)
 
-        let managerStub = FxHomeTopSitesManagerStub(profile: profile)
+        let managerStub = TopSitesManagerStub(profile: profile)
         managerStub.overridenSiteCount = overridenSiteCount
         managerStub.overridenNumberOfRows = overridenNumberOfRows
         viewModel.tileManager = managerStub
@@ -202,8 +202,8 @@ class FakeTraitCollection: UITraitCollection {
     }
 }
 
-// MARK: FxHomeTopSitesManagerStub
-private class FxHomeTopSitesManagerStub: TopSitesManager {
+// MARK: TopSitesManagerStub
+private class TopSitesManagerStub: TopSitesManager {
 
     var overridenSiteCount = 40
     override var siteCount: Int {


### PR DESCRIPTION
# [FXIOS-4494](https://mozilla-hub.atlassian.net/browse/FXIOS-4494) https://github.com/mozilla-mobile/firefox-ios/issues/11193
- `hasData` needs to account for sponsored tiles & google top site otherwise if there's no history we end up with a difference between number of shown tiles and data we're showing
- Also fixed an issue where closing all tabs from tab tray wasn't updating the home page