### PR TITLE
Bugfix FXIOS-4494 [v102.1] Has data needs to account for sponsored tiles & google

### DIFF
--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -362,6 +362,7 @@ extension GridTabViewController {
         } else if self.tabManager.normalTabs.count == 1, let tab = self.tabManager.normalTabs.first {
             self.tabManager.selectTab(tab)
             self.dismissTabTray()
+            notificationCenter.post(name: .TabsTrayDidClose, object: nil)
         }
     }
 

--- a/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/FxHomeTopSitesManager.swift
@@ -41,7 +41,7 @@ class FxHomeTopSitesManager: FeatureFlaggable, HasNimbusSponsoredTiles {
     }
 
     var hasData: Bool {
-        return !historySites.isEmpty
+        return !topSites.isEmpty
     }
 
     var siteCount: Int {


### PR DESCRIPTION
# [FXIOS-4494](https://mozilla-hub.atlassian.net/browse/FXIOS-4494) https://github.com/mozilla-mobile/firefox-ios/issues/11193
Bringing bug fixing changes for v102.1 from https://github.com/mozilla-mobile/firefox-ios/pull/11202 but removing any extra fluff (small refactor and name changes) so we avoid conflicts on v102.1 branch. 

Changes are the same:
- hasData needs to account for sponsored tiles & google top site otherwise if there's no history we end up with a difference between number of shown tiles and data we're showing. We do that by using `topSites` calculated data.
- Also fixed an issue where closing all tabs from tab tray wasn't updating the home page
