### PR TITLE
Refactor FXIOS-2040 [v104] Removed SnapKit from TabLocationView, TabToolbar, and TabToolbarHelper

### DIFF
--- a/Client/Extensions/UIViewExtensions.swift
+++ b/Client/Extensions/UIViewExtensions.swift
@@ -67,7 +67,6 @@ extension UIView {
         maskLayer.path = maskPath.cgPath
         layer.mask = maskLayer
     }
-    
     /// Makes the edge constraints (`topAnchor`, `bottomAnchor`, `leadingAnchor`, `trailingAnchor`) of a view equaled to the edge constraints of another view.
     /// - Parameters:
     ///   - view: The view that we are constraining the current view's edges to.
@@ -82,7 +81,6 @@ extension UIView {
             trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -padding)
         ])
     }
-    
     /// Makes the center x and y anchors of a view equaled to the center x and y anchors of another view.
     /// - Parameter view: The view that we're constraining the current view's center anchors to.
     /// For example : `currentView.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true`

--- a/Client/Extensions/UIViewExtensions.swift
+++ b/Client/Extensions/UIViewExtensions.swift
@@ -83,10 +83,10 @@ extension UIView {
     /**
      * Makes x and y anchors of a view equaled to that of another view.
      */
-    func center(equalTo view: UIView, constant: CGFloat = 0) {
+    func center(equalTo view: UIView) {
         NSLayoutConstraint.activate([
-            centerXAnchor.constraint(equalTo: view.centerXAnchor, constant: constant),
-            centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: constant),
+            centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            centerYAnchor.constraint(equalTo: view.centerYAnchor)
         ])
     }
 

--- a/Client/Extensions/UIViewExtensions.swift
+++ b/Client/Extensions/UIViewExtensions.swift
@@ -67,6 +67,18 @@ extension UIView {
         maskLayer.path = maskPath.cgPath
         layer.mask = maskLayer
     }
+    
+    /**
+     * Makes the edge constraints (`topAnchor`, `bottomAnchor`, `leadingAnchor`, `trailingAnchor`) of a view equaled to the edge constrains of another view.
+     */
+    func edges(equalTo view: UIView, constant: CGFloat = 0) {
+        NSLayoutConstraint.activate([
+            topAnchor.constraint(equalTo: view.topAnchor, constant: constant),
+            bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: constant),
+            leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: constant),
+            trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: constant)
+        ])
+    }
 
     /**
      This allows us to find the view in a current view hierarchy that is currently the first responder

--- a/Client/Extensions/UIViewExtensions.swift
+++ b/Client/Extensions/UIViewExtensions.swift
@@ -79,6 +79,16 @@ extension UIView {
             trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: constant)
         ])
     }
+    
+    /**
+     * Makes x and y anchors of a view equaled to that of another view.
+     */
+    func center(equalTo view: UIView, constant: CGFloat = 0) {
+        NSLayoutConstraint.activate([
+            centerXAnchor.constraint(equalTo: view.centerXAnchor, constant: constant),
+            centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: constant),
+        ])
+    }
 
     /**
      This allows us to find the view in a current view hierarchy that is currently the first responder

--- a/Client/Extensions/UIViewExtensions.swift
+++ b/Client/Extensions/UIViewExtensions.swift
@@ -68,21 +68,24 @@ extension UIView {
         layer.mask = maskLayer
     }
     
-    /**
-     * Makes the edge constraints (`topAnchor`, `bottomAnchor`, `leadingAnchor`, `trailingAnchor`) of a view equaled to the edge constrains of another view.
-     */
-    func edges(equalTo view: UIView, constant: CGFloat = 0) {
+    /// Makes the edge constraints (`topAnchor`, `bottomAnchor`, `leadingAnchor`, `trailingAnchor`) of a view equaled to the edge constraints of another view.
+    /// - Parameters:
+    ///   - view: The view that we are constraining the current view's edges to.
+    ///   For example : `currentView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true`
+    ///   - padding: An equal amount of spacing between each edge of the current view  and `view`.
+    ///   In a superview and subview relationship, `padding` is the equal space that surrounds the subview inside of the superview.
+    func edges(equalTo view: UIView, padding: CGFloat = 0) {
         NSLayoutConstraint.activate([
-            topAnchor.constraint(equalTo: view.topAnchor, constant: constant),
-            bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: constant),
-            leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: constant),
-            trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: constant)
+            topAnchor.constraint(equalTo: view.topAnchor, constant: padding),
+            bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -padding),
+            leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: padding),
+            trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -padding)
         ])
     }
     
-    /**
-     * Makes x and y anchors of a view equaled to that of another view.
-     */
+    /// Makes the center x and y anchors of a view equaled to the center x and y anchors of another view.
+    /// - Parameter view: The view that we're constraining the current view's center anchors to.
+    /// For example : `currentView.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true`
     func center(equalTo view: UIView) {
         NSLayoutConstraint.activate([
             centerXAnchor.constraint(equalTo: view.centerXAnchor),

--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -141,6 +141,7 @@ class TabLocationView: UIView {
         contentView = UIStackView(arrangedSubviews: subviews)
         contentView.distribution = .fill
         contentView.alignment = .center
+        contentView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(contentView)
 
         contentView.edges(equalTo: self)

--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -4,7 +4,6 @@
 
 import UIKit
 import Shared
-import SnapKit
 
 protocol TabLocationViewDelegate: AnyObject {
     func tabLocationViewDidTapLocation(_ tabLocationView: TabLocationView)
@@ -65,9 +64,7 @@ class TabLocationView: UIView {
         return NSAttributedString(string: .TabLocationURLPlaceholder, attributes: [NSAttributedString.Key.foregroundColor: UIColor.Photon.Grey50])
     }()
 
-    lazy var urlTextField: URLTextField = {
-        let urlTextField = URLTextField()
-
+    lazy var urlTextField: URLTextField = .build { urlTextField in
         // Prevent the field from compressing the toolbar buttons on the 4S in landscape.
         urlTextField.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 250), for: .horizontal)
         urlTextField.attributedPlaceholder = self.placeholder
@@ -84,24 +81,19 @@ class TabLocationView: UIView {
         if let dropInteraction = urlTextField.textDropInteraction {
             urlTextField.removeInteraction(dropInteraction)
         }
+    }
 
-        return urlTextField
-    }()
-
-    lazy var trackingProtectionButton: LockButton = {
-        let trackingProtectionButton = LockButton()
-        trackingProtectionButton.addTarget(self, action: #selector(didPressTPShieldButton(_:)), for: .touchUpInside)
+    lazy var trackingProtectionButton: LockButton = .build { trackingProtectionButton in
+        trackingProtectionButton.addTarget(self, action: #selector(self.didPressTPShieldButton(_:)), for: .touchUpInside)
         trackingProtectionButton.clipsToBounds = false
         trackingProtectionButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.trackingProtection
-        return trackingProtectionButton
-    }()
+    }
 
-    private lazy var readerModeButton: ReaderModeButton = {
-        let readerModeButton = ReaderModeButton()
-        readerModeButton.addTarget(self, action: #selector(tapReaderModeButton), for: .touchUpInside)
+    private lazy var readerModeButton: ReaderModeButton = .build { readerModeButton in
+        readerModeButton.addTarget(self, action: #selector(self.tapReaderModeButton), for: .touchUpInside)
         readerModeButton.addGestureRecognizer(
             UILongPressGestureRecognizer(target: self,
-                                         action: #selector(longPressReaderModeButton)))
+                                         action: #selector(self.longPressReaderModeButton)))
         readerModeButton.isAccessibilityElement = true
         readerModeButton.isHidden = true
         readerModeButton.accessibilityLabel = .TabLocationReaderModeAccessibilityLabel
@@ -110,9 +102,8 @@ class TabLocationView: UIView {
             UIAccessibilityCustomAction(
                 name: .TabLocationReaderModeAddToReadingListAccessibilityLabel,
                 target: self,
-                selector: #selector(readerModeCustomAction))]
-        return readerModeButton
-    }()
+                selector: #selector(self.readerModeCustomAction))]
+    }
 
     lazy var reloadButton: StatefulButton = {
         let reloadButton = StatefulButton(frame: .zero, state: .disabled)
@@ -125,6 +116,7 @@ class TabLocationView: UIView {
         reloadButton.accessibilityLabel = .TabLocationReloadAccessibilityLabel
         reloadButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.reloadButton
         reloadButton.isAccessibilityElement = true
+        reloadButton.translatesAutoresizingMaskIntoConstraints = false
         return reloadButton
     }()
 
@@ -142,10 +134,8 @@ class TabLocationView: UIView {
         addGestureRecognizer(longPressRecognizer)
         addGestureRecognizer(tapRecognizer)
 
-        let space1px = UIView()
-        space1px.snp.makeConstraints { make in
-            make.width.equalTo(1)
-        }
+        let space1px = UIView.build()
+        space1px.widthAnchor.constraint(equalToConstant: 1).isActive = true
 
         let subviews = [trackingProtectionButton, space1px, urlTextField, readerModeButton, reloadButton]
         contentView = UIStackView(arrangedSubviews: subviews)
@@ -153,24 +143,16 @@ class TabLocationView: UIView {
         contentView.alignment = .center
         addSubview(contentView)
 
-        contentView.snp.makeConstraints { make in
-            make.edges.equalTo(self)
-        }
+        contentView.edges(equalTo: self)
 
-        trackingProtectionButton.snp.makeConstraints { make in
-            make.width.equalTo(TabLocationViewUX.TPIconSize)
-            make.height.equalTo(TabLocationViewUX.ButtonSize)
-        }
-
-        readerModeButton.snp.makeConstraints { make in
-            make.width.equalTo(TabLocationViewUX.ReaderModeButtonWidth)
-            make.height.equalTo(TabLocationViewUX.ButtonSize)
-        }
-
-        reloadButton.snp.makeConstraints { make in
-            make.width.equalTo(TabLocationViewUX.ReaderModeButtonWidth)
-            make.height.equalTo(TabLocationViewUX.ButtonSize)
-        }
+        NSLayoutConstraint.activate([
+            trackingProtectionButton.widthAnchor.constraint(equalToConstant: TabLocationViewUX.TPIconSize),
+            trackingProtectionButton.heightAnchor.constraint(equalToConstant: TabLocationViewUX.ButtonSize),
+            readerModeButton.widthAnchor.constraint(equalToConstant: TabLocationViewUX.ReaderModeButtonWidth),
+            readerModeButton.heightAnchor.constraint(equalToConstant: TabLocationViewUX.ButtonSize),
+            reloadButton.widthAnchor.constraint(equalToConstant: TabLocationViewUX.ReaderModeButtonWidth),
+            reloadButton.heightAnchor.constraint(equalToConstant: TabLocationViewUX.ButtonSize),
+        ])
 
         // Setup UIDragInteraction to handle dragging the location
         // bar for dropping its URL into other apps.

--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -149,10 +149,8 @@ class TabLocationView: UIView {
         NSLayoutConstraint.activate([
             trackingProtectionButton.widthAnchor.constraint(equalToConstant: TabLocationViewUX.TPIconSize),
             trackingProtectionButton.heightAnchor.constraint(equalToConstant: TabLocationViewUX.ButtonSize),
-            
             readerModeButton.widthAnchor.constraint(equalToConstant: TabLocationViewUX.ReaderModeButtonWidth),
             readerModeButton.heightAnchor.constraint(equalToConstant: TabLocationViewUX.ButtonSize),
-            
             reloadButton.widthAnchor.constraint(equalToConstant: TabLocationViewUX.ReaderModeButtonWidth),
             reloadButton.heightAnchor.constraint(equalToConstant: TabLocationViewUX.ButtonSize),
         ])

--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -149,8 +149,10 @@ class TabLocationView: UIView {
         NSLayoutConstraint.activate([
             trackingProtectionButton.widthAnchor.constraint(equalToConstant: TabLocationViewUX.TPIconSize),
             trackingProtectionButton.heightAnchor.constraint(equalToConstant: TabLocationViewUX.ButtonSize),
+            
             readerModeButton.widthAnchor.constraint(equalToConstant: TabLocationViewUX.ReaderModeButtonWidth),
             readerModeButton.heightAnchor.constraint(equalToConstant: TabLocationViewUX.ButtonSize),
+            
             reloadButton.widthAnchor.constraint(equalToConstant: TabLocationViewUX.ReaderModeButtonWidth),
             reloadButton.heightAnchor.constraint(equalToConstant: TabLocationViewUX.ButtonSize),
         ])

--- a/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
 import UIKit
-import SnapKit
 import Shared
 
 class TabToolbar: UIView, FeatureFlaggable {
@@ -54,6 +53,7 @@ class TabToolbar: UIView, FeatureFlaggable {
 
         contentView.axis = .horizontal
         contentView.distribution = .fillEqually
+        contentView.translatesAutoresizingMaskIntoConstraints = false
     }
 
     required init(coder aDecoder: NSCoder) {
@@ -67,10 +67,12 @@ class TabToolbar: UIView, FeatureFlaggable {
         appMenuBadge.layout(onButton: appMenuButton)
         warningMenuBadge.layout(onButton: appMenuButton)
 
-        contentView.snp.makeConstraints { make in
-            make.leading.trailing.top.equalTo(self)
-            make.bottom.equalTo(self.safeArea.bottom)
-        }
+        NSLayoutConstraint.activate([
+            contentView.topAnchor.constraint(equalTo: topAnchor),
+            contentView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            contentView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor)
+        ])
         super.updateConstraints()
     }
 

--- a/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
-import SnapKit
 import Shared
 
 protocol TabToolbarProtocol: AnyObject {


### PR DESCRIPTION
Related to https://github.com/mozilla-mobile/firefox-ios/issues/8592

This PR includes replacement for SnapKit in TabLocationView, TabToolbar, and TabToolbarHelper. 

Additionally, this PR includes two helper functions in UIView extensions:
- `edges(equalTo: UIView, padding: CGFloat)` - Makes the edge constraints of a view equaled to the edge constrains of another view.
-  `center(equalTo: UIView)` - Makes x and y anchors of a view equaled to that of another view.
