### PR TITLE
Refactor - change trigger map for epic branch

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1011,7 +1011,7 @@ workflows:
       in master
     meta:
       bitrise.io:
-        stack: osx-xcode-13.2.x
+        stack: osx-xcode-13.4.x
         machine_type_id: g2.8core
     before_run:
     - 1_git_clone_and_post_clone
@@ -1386,10 +1386,10 @@ trigger_map:
 - push_branch: main
   pipeline: pipeline_multiple_shards
 - push_branch: epic-branch/*
-  workflow: RunUnitTests
+  workflow: pipeline_multiple_shards
 - push_branch: v103.0
   workflow: SPM_Deploy_Prod_Beta
 - pull_request_target_branch: main
   pipeline: pipeline_multiple_shards
 - pull_request_target_branch: epic-branch/*
-  workflow: RunUnitTests
+  workflow: pipeline_multiple_shards


### PR DESCRIPTION
Push and PRs on epic branch were failing because the trigger was the RunUnitTest workflow which was using older xcode13.2
In this PR I'm changing the trigger to use pipelines workflow and also updating the xcode version in case that workflow is used.