### PR TITLE
Bugfix #11244 - Adjust image scaling of logo button

### DIFF
--- a/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
+++ b/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
@@ -26,7 +26,7 @@ class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
             button.backgroundColor = .clear
             button.contentEdgeInsets = .zero
         }
-        
+
         button.accessibilityIdentifier = a11y.logoButton
         button.accessibilityLabel = .Settings.Homepage.Wallpaper.AccessibilityLabels.FxHomepageWallpaperButton
     }

--- a/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
+++ b/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
@@ -16,8 +16,17 @@ class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
 
     // MARK: - UI Elements
     lazy var logoButton: ActionButton = .build { button in
-        button.setTitle("", for: .normal)
-        button.backgroundColor = .clear
+        if #available(iOS 15.0, *) {
+            var config = UIButton.Configuration.plain()
+            config.title = ""
+            config.contentInsets = .zero
+            button.configuration = config
+        } else {
+            button.setTitle("", for: .normal)
+            button.backgroundColor = .clear
+            button.contentEdgeInsets = .zero
+        }
+        
         button.accessibilityIdentifier = a11y.logoButton
         button.accessibilityLabel = .Settings.Homepage.Wallpaper.AccessibilityLabels.FxHomepageWallpaperButton
     }


### PR DESCRIPTION
I have included the `#available(iOS 15.0, *)` check because `contentEdgeInsets` is deprecated since iOS 15.  

**Before:**  
![Before](https://user-images.githubusercontent.com/46824694/178750765-a0fdb3fc-93b5-41d0-aba6-6a2e17a62eae.png)  

**After:**  
![After](https://user-images.githubusercontent.com/46824694/178750799-18c93a5b-f7fe-4b0b-9eda-91f5d0ce499f.png)  
____
**Debug View Hierarchy - Before:**  
![Before_DebugViewHierarchy](https://user-images.githubusercontent.com/46824694/178756412-a81d7123-9135-417f-afd6-5773cea95873.png)

**Debug View Hierarchy - After:**  
![After_DebugViewHierarchy](https://user-images.githubusercontent.com/46824694/178756211-e889f77b-a685-444d-938a-4d4a3f3971b2.png)


See #11244 for reference