### PR TITLE
Bugfix fxios-4534 [v103] Revert use of profile from AppContainer from Dip in TabMetadataManager

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -368,7 +368,7 @@ class Tab: NSObject {
         self.nightMode = false
         self.noImageMode = false
         self.browserViewController = bvc
-        self.metadataManager = TabMetadataManager()
+        self.metadataManager = TabMetadataManager(profile: bvc.profile)
         super.init()
         self.isPrivate = isPrivate
         debugTabCount += 1

--- a/Client/Frontend/Browser/TabMetadataManager.swift
+++ b/Client/Frontend/Browser/TabMetadataManager.swift
@@ -20,7 +20,7 @@ class TabMetadataManager {
         tabGroupData.tabHistoryCurrentState == TabGroupTimerState.openURLOnly.rawValue
     }
 
-    init(profile: Profile = AppContainer.shared.resolve(type: Profile.self)) {
+    init(profile: Profile) {
         self.profile = profile
     }
 


### PR DESCRIPTION
Issue #11256 

It might fix: #11184

Revert use of Profile from Dip
