### PR TITLE
Change up the nimbus-fml.sh script and split up the nimbus.fml.yaml file.

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -9765,7 +9765,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ $ACTION != \"indexbuild\" ]; then\n   bash $PWD/bin/nimbus-fml.sh -n MozillaAppServices\nfi\n";
+			shellScript = "if [ $ACTION != \"indexbuild\" ]; then\n   bash $PWD/bin/nimbus-fml.sh --verbose\nfi\n";
 		};
 		60F653B827F61F7A0060D806 /* Glean SDK Generator Script */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/bin/nimbus-fml-configuration.sh
+++ b/bin/nimbus-fml-configuration.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Local modifications/additions can be made in `nimbus-fml-configuration.local.sh`
+
+## Set the channel that is used to generate the Swift code.
+## The `CONFIGURATION` to derive the channel used in the feature manifest.
+CHANNEL=
+case "${CONFIGURATION}" in
+    Fennec)
+        CHANNEL="developer"
+        ;;
+    FirefoxBeta)
+        CHANNEL="beta"
+        ;;
+    Firefox)
+        CHANNEL="release"
+        ;;
+    *) # The channel must match up with the channels listed in APP_FML_FILE.
+        CHANNEL="$CONFIGURATION"
+        ;;
+esac
+export CHANNEL
+
+## Set the name of the Swift module that contains the Nimbus SDK.
+## Default: MozillaAppServices
+# export MOZ_APPSERVICES_MODULE=
+fml_file=nimbus.fml.yaml
+
+## Set the list of directories to scan for *.fml.yaml files.
+## This can have individual files, but are relative to SOURCE_ROOT
+## Default: $PROJECT
+export MODULES=$fml_file
+
+## Set the directory where the generated files are placed.
+## This is relative to SOURCE_ROOT.
+## By default this is $MODULE/Generated
+# export GENERATED_SRC_DIR=
+
+## Set the root level nimbus.fml.yaml file. This is used to generate the experimenter file for the whole app.
+## This is relative to SOURCE_ROOT.
+## Default: $PROJECT/nimbus.fml.yaml
+export APP_FML_FILE=$fml_file
+
+## Set the list of repo files.
+## This gives the FML the branches/tags/locations for the dependencies that may have FML files in them.
+## These can be absolute, relative to SOURCE_ROOT, a URL to a JSON/YAML file, or a URL shortcut.
+## Default: is empty.
+# export REPO_FILES=dependency-versions.json
+
+## Set the directory where FMLs from other repos will be downloaded.
+## Default: build/nimbus/fml-cache
+# export CACHE_DIR=
+
+## Set the path for where the experimenter manifest is generated. This can be json or yaml.
+## This is relative to SOURCE_ROOT.
+## Default: .experimenter.yaml
+# export EXPERIMENTER_MANIFEST=
+
+## Set the version of the Application Services' Nimbus FML is downloaded from. This version does includes the 'v'
+## By default, this is derived from the Swift Package Manager.
+# export AS_VERSION=
+
+## Set the directory of the app-services directory. This is useful for local development of `nimbus-fml`.
+## By default, this is empty, and a pre-built version of `nimbus-fml` will downloaded.
+# export MOZ_APPSERVICES_LOCAL=

--- a/bin/nimbus-fml.sh
+++ b/bin/nimbus-fml.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -13,24 +12,24 @@
 #
 # To use it in a Swift project, follow these steps:
 # 1. Import the `nimbus-fml.sh` script into your project.
-# 2. Add a `<NAME>.yaml` feature manifest file. Check out https://experimenter.info/fml-spec for the spec.
-# 3. Add a new "Run Script" build step and set the command to `bash $PWD/nimbus-fml.sh`
-# 4. Add your FML filee as an Input File for the "Run Script" step.
-# 5. Run the build.
-# 6. Add the "FML.swift" file in the `Generated` folder to your project.
-# 7. Add the same "FML.swift" from the `Generated` folder as Output Files of the newly created "Run SCript" step.
-# 8. Start using the generated feature code.
+# 2. Edit the `nimbus-fml-configuration.sh` file to suit your project.
+# 3. Add a `<NAME>.fml.yaml` feature manifest file. Check out https://experimenter.info/fml-spec for the spec.
+# 4. Test the new file by running this file from SOURCE_ROOT.
+# 5. Add a new "Run Script" build step and set the command to `bash $PWD/nimbus-fml.sh`.
+# 6. Run the build.
+# 7. Add the "FML.swift" file in the `Generated` folder to your project.
+# 8. Add the same "FML.swift" from the `Generated` folder as Output Files of the newly created "Run Script" step.
+# 9. Start using the generated feature code.
 
-set -e
+DIRNAME=$(dirname "$0")
 
 # CMDNAME is used in the usage text below.
 # shellcheck disable=SC2034
 CMDNAME=$(basename "$0")
-USAGE=$(cat <<'HEREDOC'
-$(CMDNAME)
-Tarik Eshaq <teshaq@mozilla.com>
+USAGE=$(cat <<HEREDOC
+${CMDNAME}
 
-Nimbus Feature Manifest Language generator.
+Nimbus Feature Manifest Language generator initializer.
 
 This script generates the code needed to interact with Nimbus, exposing features which are experimentable.
 
@@ -38,18 +37,20 @@ For more infomration, check out https://experimenter.info/fml-spec
 
 The script structure was adopted from the similar script "sdk_generator.sh" written by the Glean team.
 
-This script should be executed as a "Run Build Script" phase from Xcode.
+This script should be executed as a "Run Build Script" phase from Xcode, but you can run it from the command line
+if you define "PROJECT", "CONFIGURATION" and "SOURCE_ROOT" environment variables.
+
+Application-specific configuration options for this script has moved to ./nimbus-fml-configuration.sh alongside this file.
+
+Local developer specific configuration should go in ./nimbus-fml-configuration.local.sh and not checked into to source control.
 
 USAGE:
-    ${CMDNAME} [OPTIONS] <MANIFEST_PATH>
-
-ARGS:
-    <MANIFEST_PATH>  The path to the FML yaml file to parse. default: \$SCRIPT_INPUT_FILE_0 environment variable.
+    ${CMDNAME} [OPTIONS]
 
 OPTIONS:
-    -o, --output  <PATH>             Folder to place generated FML code in. Default: \$SOURCE_ROOT/\$PROJECT/Generated
-    -n, --namespace <NIMBUS_NAMESPACE> The module where Nimbus is imported from. Default: no external module
-    -h, --help                       Display this help message.
+    -a, --use-fml-version <REF>      Version or reference of nimbus-fml to use. Default is v${AS_VERSION}.
+    -F, --fresh                      Re-download the nimbus-fml binary.
+    -h, --help                       display this help message.
 HEREDOC
 )
 
@@ -57,21 +58,57 @@ helptext() {
     echo "$USAGE"
 }
 
-MANIFEST_PATH=
-OUTPUT_DIR="${SOURCE_ROOT}/${PROJECT}/Generated"
-NAMESPACE=
-AS_VERSION=v94.1.0
-AS_DOWNLOAD_URL="https://github.com/mozilla/application-services/releases/download/$AS_VERSION"
+if [ -z "$CONFIGURATION" ] ; then
+    echo "Error: No \$CONFIGURATION defined."
+    echo "Execute this script as a build step in Xcode."
+    exit 2
+fi
+
+if [ -z "$SOURCE_ROOT" ] ; then
+    echo "Error: No \$SOURCE_ROOT defined."
+    echo "Execute this script as a build step in Xcode."
+    exit 2
+fi
+
+if [ -z "$PROJECT" ]; then
+    echo "Error: No \$PROJECT defined."
+    echo "Execute this script as a build step in Xcode."
+    exit 2
+fi
+
+# We can derive the version we need by looking at the project file.
+number_string=$(grep -A 3 $'https://github.com/mozilla/rust-components-swift' "$SOURCE_ROOT/$PROJECT.xcodeproj/project.pbxproj" | grep -E -o "\d+\.\d+\.\d+")
+
+if [ -z "$number_string" ]; then
+    echo "Error: No https://github.com/mozilla/rust-components-swift package was detected."
+    echo "The package must be added as a project dependency."
+    exit 2
+fi
+
+AS_VERSION="v$number_string"
 FRESHEN_FML=
+NIMBUS_DIR="$SOURCE_ROOT/build/nimbus"
+
+export CACHE_DIR="$NIMBUS_DIR/fml-cache"
+export APP_FML_FILE="$PROJECT/nimbus.fml.yaml"
+export GENERATED_SRC_DIR=
+export MOZ_APPSERVICES_MODULE=MozillaAppServices
+export MODULES=$PROJECT
+export EXPERIMENTER_MANIFEST=".experimenter.yaml"
+
+# shellcheck disable=SC1091
+source "$DIRNAME/nimbus-fml-configuration.sh"
+
+local_config="$DIRNAME/nimbus-fml-configuration.local.sh"
+if [ -f "$local_config" ] ; then
+    # shellcheck disable=SC1090
+    source "$local_config"
+fi
 
 while (( "$#" )); do
     case "$1" in
         -o|--output)
-            OUTPUT_DIR=$2
-            shift 2
-            ;;
-        -n|--namespace)
-            NAMESPACE=$2
+            GENERATED_SRC_DIR=$2
             shift 2
             ;;
         -h|--help)
@@ -87,6 +124,10 @@ while (( "$#" )); do
             FRESHEN_FML="true"
             shift 2
             ;;
+        --verbose)
+            set -x
+            shift 1
+            ;;
         --) # end argument parsing
             shift
             break
@@ -96,127 +137,116 @@ while (( "$#" )); do
             exit 1
             ;;
         *) # preserve positional arguments
-            MANIFEST_PATH=$1
+            APP_FML_FILE=$1
             shift
             ;;
     esac
 done
 
-if [ -z $MANIFEST_PATH ]; then
+if [ -z "$APP_FML_FILE" ]; then
     if [ -z "$SCRIPT_INPUT_FILE_COUNT" ] || [ "$SCRIPT_INPUT_FILE_COUNT" -eq 0 ]; then
         echo "Error: No input files provided for the Nimbus Feature Manifest."
         exit 2
     fi
-    MANIFEST_PATH=$SCRIPT_INPUT_FILE_0
+    APP_FML_FILE=$SCRIPT_INPUT_FILE_0
 fi
 
-if [ -z "$SOURCE_ROOT" ]; then
-    echo "Error: No \$SOURCE_ROOT defined."
-    echo "Execute this script as a build step in Xcode."
-    exit 2
-fi
+if [ -n "$MOZ_APPSERVICES_LOCAL" ] ; then
+    # If we've specified where app-services lives, perhaps we can run from a local copy.
+    LOCAL_FML_DIR="$MOZ_APPSERVICES_LOCAL/components/support/nimbus-fml"
+    export BINARY_PATH="$HOME/.cargo/bin/cargo run --manifest-path $LOCAL_FML_DIR/Cargo.toml --"
+else
+    # Otherwise, we should download a pre-built copy from github.com/mozilla/application-services/releases
+    FML_DIR="$NIMBUS_DIR/bin"
+    export BINARY_PATH="$FML_DIR/nimbus-fml"
+    AS_DOWNLOAD_URL="https://github.com/mozilla/application-services/releases/download/$AS_VERSION"
+    # Check whether the cached copy is still the right one to use.
+    if [[ -f $FML_DIR/nimbus-fml.sha256 ]]; then
+        echo "Checking if we need to redownload the FML"
+        NEW_CHECKSUM=$(curl -L "$AS_DOWNLOAD_URL/nimbus-fml.sha256")
+        OLD_CHECKSUM=$(cat "$FML_DIR/nimbus-fml.sha256")
+        if [ ! "$OLD_CHECKSUM" == "$NEW_CHECKSUM" ]; then
+            FRESHEN_FML="true"
+            echo "The checksums don't match, redownloading the new FML"
+        fi
+    fi
 
-if [ -z "$PROJECT" ]; then
-    echo "Error: No \$PROJECT defined."
-    echo "Execute this script as a build step in Xcode."
-    exit 2
-fi
-if [ -z "$CONFIGURATION" ]; then
-    echo "Error: No \$CONFIGURATION defined."
-    echo "Execute this script as a build step in Xcode."
-    exit 2
-fi
+    if [ -n "$FRESHEN_FML" ]; then
+        rm -Rf "$FML_DIR"
+    fi
+    mkdir -p "$FML_DIR"
+    if [[ ! -f "$FML_DIR/nimbus-fml.zip" ]] ; then
+        # We now download the nimbus-fml from the github release
+        curl -L "$AS_DOWNLOAD_URL/nimbus-fml.zip" --output "$FML_DIR/nimbus-fml.zip"
+        # We also download the checksum
+        curl -L "$AS_DOWNLOAD_URL/nimbus-fml.sha256" --output "$FML_DIR/nimbus-fml.sha256"
+        pushd "${FML_DIR}"
+        shasum --check nimbus-fml.sha256
+        popd
+    fi
 
-## We create the nimbus-fml directory, which is gitignored, we use -p to make sure this doesn't fail if it already exists
-FML_DIR="$SOURCE_ROOT/build/nimbus-tools"
-
-if [[ -f $FML_DIR/nimbus-fml.sha256 ]]; then
-    echo "Checking if we need to redownload the FML"
-    NEW_CHECKSUM=$(curl -L $AS_DOWNLOAD_URL/nimbus-fml.sha256)
-    OLD_CHECKSUM=$(cat $FML_DIR/nimbus-fml.sha256)
-    if [ ! "$OLD_CHECKSUM" == "$NEW_CHECKSUM" ]; then
-        echo "The checksums don't match, redownloading the new FML"
-        FRESHEN_FML="true"
+    ## We definitely have a zip file on disk, but we might already have done the work of unzipping it.
+    if [[ ! -f "$BINARY_PATH" ]] ; then
+        ## So we've looked and there's no executable file of that name
+        ## Now work out what arch version of the executable we want.
+        ARCH=$(uname -m)
+        if [[ "$ARCH" == 'x86_64' ]]
+        then
+            EXE_ARCH=x86_64-apple-darwin
+        elif [[ "$ARCH" == 'arm64' ]]
+        then
+            EXE_ARCH=aarch64-apple-darwin
+        else
+            echo "Error: Unsupported architecture. This script can only run on Mac devices running x86_64 or arm64"
+            exit 2
+        fi
+        # -o overwrites a file (if the file existed but isn't executable)
+        # -j junks the path, so we don't have to have $EXE_ARCH/release/ in our directory
+        # -d outputs to the directory of our choice.
+        unzip -o -j "$FML_DIR/nimbus-fml.zip" $EXE_ARCH/release/nimbus-fml -d "$FML_DIR"
     fi
 fi
 
-if [ ! -z $FRESHEN_FML ]; then
-    rm -Rf "$FML_DIR"
-fi
-mkdir -p "$FML_DIR"
-if [[ ! -f "$FML_DIR/nimbus-fml.zip" ]] ; then
-    # We now download the nimbus-fml from the github release
-    curl -L $AS_DOWNLOAD_URL/nimbus-fml.zip --output "$FML_DIR/nimbus-fml.zip"
-    # We also download the checksum
-    curl -L $AS_DOWNLOAD_URL/nimbus-fml.sha256 --output "$FML_DIR/nimbus-fml.sha256"
-    pushd "${FML_DIR}"
-    shasum --check nimbus-fml.sha256
-    popd
-fi
-
-## We definitely have a zip file on disk, but we might already have done the work of unzipping it.
-BINARY_PATH="$FML_DIR/nimbus-fml"
-if [[ ! -f "$BINARY_PATH" ]] ; then
-    ## So we've looked and there's no executable file of that name
-    ## Now work out what arch version of the executable we want.
-    ARCH=$(uname -m)
-    if [[ "$ARCH" == 'x86_64' ]]
-    then
-        EXE_ARCH=x86_64-apple-darwin
-    elif [[ "$ARCH" == 'arm64' ]]
-    then
-        EXE_ARCH=aarch64-apple-darwin
-    else
-        echo "Error: Unsupported architecture. This script can only run on Mac devices running x86_64 or arm64"
-        exit 2
-    fi
-    # -o overwrites a file (if the file existed but isn't executable)
-    # -j junks the path, so we don't have to have $EXE_ARCH/release/ in our directory
-    # -d outputs to the directory of our choice.
-    unzip -o -j "$FML_DIR/nimbus-fml.zip" $EXE_ARCH/release/nimbus-fml -d "$FML_DIR"
-fi
-
-#SCHEME=${MOZ_BUNDLE_DISPLAY_NAME%% *}
-SCHEME=${CONFIGURATION}
-## The `CONFIGURATION` to derive the channel used in the feature manifest.
-CHANNEL=
-case "${SCHEME}" in
-    Fennec)
-        CHANNEL="developer"
-        ;;
-    FirefoxBeta)
-        CHANNEL="beta"
-        ;;
-    Firefox)
-        CHANNEL="release"
-        ;;
-    *) # preserve positional arguments
-        CHANNEL="unknown"
-        ;;
-esac
-
-##################
-## Construct and run the command.
-##################
-# We'll generate the command, and output some nice copy/pastable version of the command to the Build console…
-CMD="$BINARY_PATH $MANIFEST_PATH -o $OUTPUT_DIR/FxNimbus.swift ios features --classname FxNimbus --channel $CHANNEL"
 echo "SOURCE_ROOT=$SOURCE_ROOT"
-# …truncating the absolute paths into something easier to read.
-echo ${CMD//"$SOURCE_ROOT"/\$SOURCE_ROOT}
-$CMD
+pushd "${SOURCE_ROOT}" > /dev/null
+# We're going to assemble the repo args from the repo files that
+repo_args=
+for repo_file in $REPO_FILES ; do
+    repo_args="$repo_args --repo-file $repo_file"
+done
 
 # Now generate the YAML that the `experimenter` server will use to keep up to date.
 # This file, `.experimenter.yaml` **must** be checked into source control, and kept up-to-date.
 # Experimenter will download it regularly/nightly.
-# (FWIW: I don't think the `channel` is needed in this command, but if it is, we need the release version).
-CMD="$BINARY_PATH $MANIFEST_PATH -o $SOURCE_ROOT/.experimenter.yaml experimenter --channel release"
-echo ${CMD//"$SOURCE_ROOT"/\$SOURCE_ROOT}
+CMD="$BINARY_PATH generate-experimenter --channel $CHANNEL --cache-dir $CACHE_DIR $APP_FML_FILE $EXPERIMENTER_MANIFEST"
+display=${CMD//"$SOURCE_ROOT"/\$SOURCE_ROOT}
+echo "$display"
 $CMD
-
-# The FML doesn't currenlty support adding a custom import, so we do this in this script.
-# See: https://mozilla-hub.atlassian.net/browse/EXP-2199
-if [[ ! -z $NAMESPACE ]]; then
-    echo -e "import $NAMESPACE\n$(cat $OUTPUT_DIR/FxNimbus.swift)" > $OUTPUT_DIR/FxNimbus.swift
+if [ $? != 0 ] ; then
+    exit 1
 fi
 
-exit 0
+# We'll generate the command, and output some nice copy/pastable version of the command to the Build console…
+for module in $MODULES ; do
+    output_dir=""
+    input_pattern="$module"
+    if [ -z "$GENERATED_SRC_DIR" ] ; then
+        output_dir="${module}/Generated"
+    else
+        output_dir="$GENERATED_SRC_DIR"
+    fi
+    if [ ! -f "$input_pattern" ] ; then
+        mkdir -p "$output_dir"
+    else
+        output_dir="$PROJECT/Generated"
+    fi
+    CMD="$BINARY_PATH generate $repo_args --channel $CHANNEL --language swift  --cache-dir $CACHE_DIR $input_pattern $output_dir"
+    # …truncating the absolute paths into something easier to read.
+    display=${CMD//"$SOURCE_ROOT"/\$SOURCE_ROOT}
+    echo "$display"
+    $CMD
+    if [ $? != 0 ] ; then
+        exit 1
+    fi
+done
+popd > /dev/null

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -1,4 +1,9 @@
 ---
+about:
+  description: The root level Feature Manifest for Firefox for iOS
+  ios:
+    class: FxNimbus
+    module: Client
 channels:
   - developer
   - beta


### PR DESCRIPTION
This PR is now ready to merge, but for when firefox-ios takes the (currently unreleased) upgrade which contains the [EXP-2333](https://mozilla-hub.atlassian.net/browse/EXP-2333) epic implementing the [FML Imports and Includes proposal](https://experimenter.info/fml-imports-and-includes/).

This PR does not go very far in splitting up the `nimbus.fml.yaml` file; I could go further, but would like to get some feedback before proceeding.

The last PR this was waiting for was https://github.com/mozilla/application-services/pull/5042 , which was released as part of [App Services release v93.7.0](https://github.com/mozilla/application-services/releases/tag/v93.7.0) .

This PR splits out the app-specific configuration of the `nimbus-fml` call, into two config files: 

- `nimbus-fml-configuration.sh`, and optionally:
- `nimbus-fml-configuration.local.sh`. This file overrides anything in the first, and is intended for local development.

It also derives the version of App Services, ensuring that the version of the megazord and FML stay in sync.

--- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Please make sure you've run the test scheme and all the tests pass. If your changes affect existing tests please make sure to update the tests as well.

Below is the PR naming guidelines we follow:

https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide
