### PR TITLE
Refactor FX-11266 [v104] Change iOS simulator version to have snapshots tests running

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -872,7 +872,7 @@ workflows:
             set -e
             # debug log
             set -x
-            # workaround until 2.187 version is installed. Error with 2.186
+            fastlane -v
 
             ./l10n-screenshots.sh en-US
         title: Generate screenshots

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -893,7 +893,7 @@ workflows:
       This Workflow is to run L10n tests in one locale and then share the bundle with the rest of the builds
     meta:
       bitrise.io:
-        stack: osx-xcode-13.4.x
+        stack: osx-xcode-13.3.x
         machine_type_id: g2.4core
 
   L10nScreenshotsTests:
@@ -972,7 +972,7 @@ workflows:
       This Workflow is to run L10n tests for all locales
     meta:
       bitrise.io:
-        stack: osx-xcode-13.4.x
+        stack: osx-xcode-13.3.x
         machine_type_id: g2.4core
 
   RunUnitTests:
@@ -1390,6 +1390,6 @@ trigger_map:
 - push_branch: v103.0
   workflow: SPM_Deploy_Prod_Beta
 - pull_request_target_branch: main
-  pipeline: pipeline_multiple_shards
+  workflow: L10nBuild
 - pull_request_target_branch: epic-branch/*
   pipeline: pipeline_multiple_shards

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1390,6 +1390,6 @@ trigger_map:
 - push_branch: v103.0
   workflow: SPM_Deploy_Prod_Beta
 - pull_request_target_branch: main
-  workflow: L10nBuild
+  pipeline: pipeline_multiple_shards
 - pull_request_target_branch: epic-branch/*
   pipeline: pipeline_multiple_shards

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -893,7 +893,7 @@ workflows:
       This Workflow is to run L10n tests in one locale and then share the bundle with the rest of the builds
     meta:
       bitrise.io:
-        stack: osx-xcode-13.3.x
+        stack: osx-xcode-13.4.x
         machine_type_id: g2.4core
 
   L10nScreenshotsTests:
@@ -972,7 +972,7 @@ workflows:
       This Workflow is to run L10n tests for all locales
     meta:
       bitrise.io:
-        stack: osx-xcode-13.3.x
+        stack: osx-xcode-13.4.x
         machine_type_id: g2.4core
 
   RunUnitTests:

--- a/l10n-screenshots.sh
+++ b/l10n-screenshots.sh
@@ -42,7 +42,7 @@ for lang in $LOCALES; do
         --skip_open_summary \
         --xcargs "-maximum-parallel-testing-workers 2" \
         --derived_data_path l10n-screenshots-dd \
-        --ios_version "15.2" \
+        --ios_version "14.5" \
         --erase_simulator --localize_simulator \
         --devices "iPhone 8" --languages "$lang" \
         --output_directory "l10n-screenshots/$lang" \

--- a/l10n-screenshots.sh
+++ b/l10n-screenshots.sh
@@ -42,6 +42,7 @@ for lang in $LOCALES; do
         --skip_open_summary \
         --xcargs "-maximum-parallel-testing-workers 2" \
         --derived_data_path l10n-screenshots-dd \
+        --ios_version "15.2" \
         --erase_simulator --localize_simulator \
         --devices "iPhone 8" --languages "$lang" \
         --output_directory "l10n-screenshots/$lang" \


### PR DESCRIPTION
Testing the L10nBuild workflow with xcode 13.3 since screenshots tests are not working on 13.4. I would like to check the result in this stack while investigating...