### PR TITLE
Refactor [v102.2] FXIOS-4558 - Browser sync manager crash in Sync in sync serveral items

### DIFF
--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -1169,10 +1169,14 @@ open class BrowserProfile: Profile {
          * Runs the single provided synchronization function and returns its status.
          */
         fileprivate func sync(_ label: EngineIdentifier, function: @escaping SyncFunction) -> SyncResult {
-            return syncSeveral(why: .user, synchronizers: [(label, function)]) >>== { statuses in
-                let status = statuses.find { label == $0.0 }?.1
-                return deferMaybe(status ?? .notStarted(.unknown))
+            let syncSeveralItems: SyncResult = syncSeveral(why: .user, synchronizers: [(label, function)]) >>== { statuses in
+                if let status = statuses.find({ label == $0.0 }) {
+                    return deferMaybe(status.1)
+                }
+                return deferMaybe(.notStarted(.unknown))
             }
+
+            return syncSeveralItems
         }
 
         /**


### PR DESCRIPTION
This is a partial refactor to fix the issue where sync several was returning nil for some items. In this case we'll be able to better pin point where the crash is happening and most likely fix it too.