### PR TITLE
Add FXIOS-4556 [v105] delete searched items from history (show options Menu after long press)

### DIFF
--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel+Search.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel+Search.swift
@@ -16,6 +16,8 @@ extension HistoryPanel: UISearchBarDelegate {
     }
 
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        viewModel.isSearchInProgress = !searchText.isEmpty
+
         guard let searchText = searchBar.text, !searchText.isEmpty else {
             handleEmptySearch()
             return
@@ -28,7 +30,6 @@ extension HistoryPanel: UISearchBarDelegate {
     func startSearchState() {
         bottomStackView.isHidden = false
         searchbar.becomeFirstResponder()
-        viewModel.isSearchInProgress = true
     }
 
     func exitSearchState() {
@@ -51,7 +52,7 @@ extension HistoryPanel: UISearchBarDelegate {
         }
     }
 
-    private func applySearchSnapshot() {
+    func applySearchSnapshot() {
         // Create search results snapshot and apply
         var snapshot = NSDiffableDataSourceSnapshot<HistoryPanelSections, AnyHashable>()
         snapshot.appendSections([HistoryPanelSections.searchResults])

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel+Search.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel+Search.swift
@@ -41,12 +41,7 @@ extension HistoryPanel: UISearchBarDelegate {
     }
 
     func performSearch(term: String) {
-        viewModel.performSearch(term: term.lowercased()) { hasResults in
-            guard hasResults else {
-                self.handleNoResults()
-                return
-            }
-
+        viewModel.performSearch(term: term.lowercased()) { _ in
             self.applySearchSnapshot()
             self.updateEmptyPanelState()
         }
@@ -58,11 +53,10 @@ extension HistoryPanel: UISearchBarDelegate {
         snapshot.appendSections([HistoryPanelSections.searchResults])
         snapshot.appendItems(self.viewModel.searchResultSites)
         self.diffableDatasource?.apply(snapshot, animatingDifferences: false)
-    }
 
-    private func handleNoResults() {
-        applySearchSnapshot()
-        updateEmptyPanelState()
+        if self.viewModel.searchResultSites.isEmpty {
+            updateEmptyPanelState()
+        }
     }
 
     private func handleEmptySearch() {

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel+Search.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel+Search.swift
@@ -43,7 +43,6 @@ extension HistoryPanel: UISearchBarDelegate {
     func performSearch(term: String) {
         viewModel.performSearch(term: term.lowercased()) { _ in
             self.applySearchSnapshot()
-            self.updateEmptyPanelState()
         }
     }
 
@@ -53,10 +52,7 @@ extension HistoryPanel: UISearchBarDelegate {
         snapshot.appendSections([HistoryPanelSections.searchResults])
         snapshot.appendItems(self.viewModel.searchResultSites)
         self.diffableDatasource?.apply(snapshot, animatingDifferences: false)
-
-        if self.viewModel.searchResultSites.isEmpty {
-            updateEmptyPanelState()
-        }
+        self.updateEmptyPanelState()
     }
 
     private func handleEmptySearch() {

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -406,13 +406,14 @@ class HistoryPanel: UIViewController, LibraryPanel, Loggable, NotificationThemea
 
         viewModel.removeHistoryItems(item: [historyItem], at: indexPath.section)
 
-        applySnapshot(animatingDifferences: true)
+        if viewModel.isSearchInProgress {
+            applySearchSnapshot()
+        } else {
+            applySnapshot(animatingDifferences: true)
+        }
     }
 
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-
-        // Adding support to delete item during search in next ticket
-        guard !viewModel.isSearchInProgress else { return nil }
 
         // For UX consistency, every cell in history panel SHOULD have a trailing action.
         let deleteAction = UIContextualAction(style: .destructive, title: .HistoryPanelDelete) { [weak self] (_, _, completion) in
@@ -664,9 +665,10 @@ extension HistoryPanel {
         let touchPoint = longPressGestureRecognizer.location(in: tableView)
         guard let indexPath = tableView.indexPathForRow(at: touchPoint) else { return }
 
-        if indexPath.section != HistoryPanelSections.additionalHistoryActions.rawValue {
-            presentContextMenu(for: indexPath)
+        if let _ = diffableDatasource?.itemIdentifier(for: indexPath) as? HistoryActionablesModel {
+            return
         }
+        presentContextMenu(for: indexPath)
     }
 
     @objc private func onRefreshPulled() {

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
@@ -319,6 +319,10 @@ class HistoryPanelViewModel: Loggable, FeatureFlaggable {
     private func deleteSingle(site: Site) {
         groupedSites.remove(site)
         profile.history.removeHistoryForURL(site.url)
+
+        if isSearchInProgress, let indexToRemove = searchResultSites.firstIndex(of: site) {
+            searchResultSites.remove(at: indexToRemove)
+        }
     }
 
     private func getDeletableSection(date: Date) -> [Sections]? {


### PR DESCRIPTION
Until now it was not possible to delete searched items in the History Panel (i.e. Swipe to delete or Context Menu on Long press was restricted to non search view only).    
---
**The following might be caused by the fact, that I only tested the Swipe Gesture on a simulator with a M1 Mac! (https://developer.apple.com/forums/thread/696832):**
Please note that it seems like Swipe to delete in the History Panel is broken on the main branch right now. So you can only test this PR by using the Context Menu on Long Press. But since both options (Context Menu and Swipe to delete use the same method (`removeHistoryItem(at indexPath: IndexPath)`) it should work for Swipe to delete as well

**New behaviour:**    


https://user-images.githubusercontent.com/46824694/179355755-580b7fbb-ca78-4f30-bf7e-c5ef571e1ffe.mov



See #11290 for reference
