### PR TITLE
Refactor FXIOS-4575 [v104] Add data adaptor for recently saved

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -412,6 +412,7 @@
 		59A68FD5260B8D520F890F4A /* ReaderPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A685F4EAD19EDEC854BCA4 /* ReaderPanel.swift */; };
 		5A271ABD2860B0D700471CE4 /* WebServerUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A271ABC2860B0D700471CE4 /* WebServerUtil.swift */; };
 		5A3A2A0D287F742C00B79EAC /* BackgroundSyncUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A3A2A0C287F742C00B79EAC /* BackgroundSyncUtil.swift */; };
+		5A3A7DCE2886F7880065F81A /* RecentlySavedDataAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A3A7DCD2886F7880065F81A /* RecentlySavedDataAdaptor.swift */; };
 		5A430D792853DFDD00782BFF /* OrientationLockUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A430D782853DFDD00782BFF /* OrientationLockUtility.swift */; };
 		5A47CFF52860FB8900B2B7BF /* AppLaunchUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A47CFF42860FB8900B2B7BF /* AppLaunchUtil.swift */; };
 		5F130D2E2483508E00B0F7D0 /* FxAWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F130D2D2483508E00B0F7D0 /* FxAWebViewModel.swift */; };
@@ -2527,6 +2528,7 @@
 		5A1D409EB92D8E6AB8FC8813 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
 		5A271ABC2860B0D700471CE4 /* WebServerUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebServerUtil.swift; sourceTree = "<group>"; };
 		5A3A2A0C287F742C00B79EAC /* BackgroundSyncUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundSyncUtil.swift; sourceTree = "<group>"; };
+		5A3A7DCD2886F7880065F81A /* RecentlySavedDataAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentlySavedDataAdaptor.swift; sourceTree = "<group>"; };
 		5A430D782853DFDD00782BFF /* OrientationLockUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrientationLockUtility.swift; sourceTree = "<group>"; };
 		5A47CFF42860FB8900B2B7BF /* AppLaunchUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchUtil.swift; sourceTree = "<group>"; };
 		5ABD40B68B3D03806BC6819C /* es-AR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-AR"; path = "es-AR.lproj/LoginManager.strings"; sourceTree = "<group>"; };
@@ -6118,6 +6120,7 @@
 			children = (
 				8AB5958728413F6C0090F4AE /* RecentlySavedCell.swift */,
 				966206CC2698DE1E005C0A55 /* RecentlySavedCellViewModel.swift */,
+				5A3A7DCD2886F7880065F81A /* RecentlySavedDataAdaptor.swift */,
 			);
 			path = RecentlySaved;
 			sourceTree = "<group>";
@@ -9414,6 +9417,7 @@
 				F018F84C2719AE8300B9A52D /* ThemedDefaultNavigationController.swift in Sources */,
 				8ADED7EE276A7750009C19E6 /* CumulativeDaysOfUseCounter.swift in Sources */,
 				8A5BD95C2878AA74000FE773 /* PinnedSite.swift in Sources */,
+				5A3A7DCE2886F7880065F81A /* RecentlySavedDataAdaptor.swift in Sources */,
 				D3B6923F1B9F9A58004B87A4 /* FindInPageHelper.swift in Sources */,
 				F85C7F122721048E004BDBA4 /* Layout.swift in Sources */,
 				DF036E43274FD434002E834E /* HistoryHighlightsCell.swift in Sources */,

--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -49,6 +49,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
     private let tabUrl: URL?
     private let isFileURL: Bool
     private let showFXASyncAction: (FXASyncClosure) -> Void
+    private let notificationCenter: NotificationCenter
 
     let profile: Profile
     let tabManager: TabManager
@@ -65,11 +66,13 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
     init(profile: Profile,
          tabManager: TabManager,
          buttonView: UIButton,
+         notificationCenter: NotificationCenter = NotificationCenter.default,
          showFXASyncAction: @escaping (FXASyncClosure) -> Void) {
 
         self.profile = profile
         self.tabManager = tabManager
         self.buttonView = buttonView
+        self.notificationCenter = notificationCenter
         self.showFXASyncAction = showFXASyncAction
 
         self.selectedTab = tabManager.selectedTab
@@ -627,6 +630,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
             self.profile.readingList.createRecordWithURL(url.absoluteString, title: tab.title ?? "", addedBy: UIDevice.current.name)
             TelemetryWrapper.recordEvent(category: .action, method: .add, object: .readingListItem, value: .pageActionMenu)
             self.delegate?.showToast(message: .AppMenu.AddToReadingListConfirmMessage, toastAction: .addToReadingList, url: nil)
+            self.notificationCenter.post(name: .ReadingListUpdated, object: self)
         }
     }
 
@@ -642,6 +646,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
             self.profile.readingList.deleteRecord(record)
             self.delegate?.showToast(message: .AppMenu.RemoveFromReadingListConfirmMessage, toastAction: .removeFromReadingList, url: nil)
             TelemetryWrapper.recordEvent(category: .action, method: .delete, object: .readingListItem, value: .pageActionMenu)
+            self.notificationCenter.post(name: .ReadingListUpdated, object: self)
         }
     }
 
@@ -682,6 +687,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
             // The method in BVC also handles the toast for this use case
             self.delegate?.addBookmark(url: url.absoluteString, title: tab.title, favicon: tab.displayFavicon)
             TelemetryWrapper.recordEvent(category: .action, method: .add, object: .bookmark, value: .pageActionMenu)
+            self.notificationCenter.post(name: .BookmarksUpdated, object: self)
         }
     }
 
@@ -699,6 +705,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
             }
 
             TelemetryWrapper.recordEvent(category: .action, method: .delete, object: .bookmark, value: .pageActionMenu)
+            self.notificationCenter.post(name: .BookmarksUpdated, object: self)
         }
     }
 

--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -49,7 +49,6 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
     private let tabUrl: URL?
     private let isFileURL: Bool
     private let showFXASyncAction: (FXASyncClosure) -> Void
-    private let notificationCenter: NotificationCenter
 
     let profile: Profile
     let tabManager: TabManager
@@ -66,13 +65,11 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
     init(profile: Profile,
          tabManager: TabManager,
          buttonView: UIButton,
-         notificationCenter: NotificationCenter = NotificationCenter.default,
          showFXASyncAction: @escaping (FXASyncClosure) -> Void) {
 
         self.profile = profile
         self.tabManager = tabManager
         self.buttonView = buttonView
-        self.notificationCenter = notificationCenter
         self.showFXASyncAction = showFXASyncAction
 
         self.selectedTab = tabManager.selectedTab
@@ -630,7 +627,6 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
             self.profile.readingList.createRecordWithURL(url.absoluteString, title: tab.title ?? "", addedBy: UIDevice.current.name)
             TelemetryWrapper.recordEvent(category: .action, method: .add, object: .readingListItem, value: .pageActionMenu)
             self.delegate?.showToast(message: .AppMenu.AddToReadingListConfirmMessage, toastAction: .addToReadingList, url: nil)
-            self.notificationCenter.post(name: .ReadingListUpdated, object: self)
         }
     }
 
@@ -646,7 +642,6 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
             self.profile.readingList.deleteRecord(record)
             self.delegate?.showToast(message: .AppMenu.RemoveFromReadingListConfirmMessage, toastAction: .removeFromReadingList, url: nil)
             TelemetryWrapper.recordEvent(category: .action, method: .delete, object: .readingListItem, value: .pageActionMenu)
-            self.notificationCenter.post(name: .ReadingListUpdated, object: self)
         }
     }
 
@@ -687,7 +682,6 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
             // The method in BVC also handles the toast for this use case
             self.delegate?.addBookmark(url: url.absoluteString, title: tab.title, favicon: tab.displayFavicon)
             TelemetryWrapper.recordEvent(category: .action, method: .add, object: .bookmark, value: .pageActionMenu)
-            self.notificationCenter.post(name: .BookmarksUpdated, object: self)
         }
     }
 
@@ -705,7 +699,6 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
             }
 
             TelemetryWrapper.recordEvent(category: .action, method: .delete, object: .bookmark, value: .pageActionMenu)
-            self.notificationCenter.post(name: .BookmarksUpdated, object: self)
         }
     }
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -75,8 +75,6 @@ class HomepageViewController: UIViewController, HomePanel, GleanPlumbMessageMana
             return self.getPopoverSourceRect(sourceView: popoverView)
         }
 
-        viewModel.delegate = self
-
         setupNotifications(forObserver: self,
                            observing: [.HomePanelPrefsChanged,
                                        .TopTabsTabClosed,
@@ -102,6 +100,9 @@ class HomepageViewController: UIViewController, HomePanel, GleanPlumbMessageMana
         configureWallpaperView()
         configureContentStackView()
         configureCollectionView()
+
+        // Delay setting up the view model delegate to ensure the views have been configured first
+        viewModel.delegate = self
 
         let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         tap.cancelsTouchesInView = false
@@ -644,6 +645,10 @@ extension HomepageViewController: HomepageViewModelDelegate {
             self.viewModel.updateEnabledSections()
             self.viewModel.reloadSection(section, with: self.collectionView)
         }
+    }
+
+    func reloadData() {
+        collectionView.reloadData()
     }
 }
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -648,7 +648,9 @@ extension HomepageViewController: HomepageViewModelDelegate {
     }
 
     func reloadData() {
-        collectionView.reloadData()
+        ensureMainThread { [weak self] in
+            self?.collectionView.reloadData()
+        }
     }
 }
 

--- a/Client/Frontend/Home/HomepageViewModel.swift
+++ b/Client/Frontend/Home/HomepageViewModel.swift
@@ -6,6 +6,11 @@ import MozillaAppServices
 
 protocol HomepageViewModelDelegate: AnyObject {
     func reloadSection(section: HomepageViewModelProtocol)
+    func reloadData()
+}
+
+protocol HomepageDataModelDelegate: AnyObject {
+    func reloadData()
 }
 
 class HomepageViewModel: FeatureFlaggable {
@@ -104,6 +109,7 @@ class HomepageViewModel: FeatureFlaggable {
         self.nimbus = nimbus
         topSiteViewModel.delegate = self
         historyHighlightsViewModel.delegate = self
+        recentlySavedViewModel.delegate = self
 
         updateEnabledSections()
     }
@@ -191,5 +197,11 @@ extension HomepageViewModel: TopSitesViewModelDelegate {
 extension HomepageViewModel: HomeHistoryHighlightsDelegate {
     func reloadHighlights() {
         updateData(section: historyHighlightsViewModel)
+    }
+}
+
+extension HomepageViewModel: HomepageDataModelDelegate {
+    func reloadData() {
+        delegate?.reloadData()
     }
 }

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
@@ -127,7 +127,7 @@ extension RecentlySavedCellViewModel: HomepageSectionHandler {
                        homePanelDelegate: HomePanelDelegate?,
                        libraryPanelDelegate: LibraryPanelDelegate?) {
 
-        if let item = recentItems[safe: indexPath.row] as? BookmarkItemData {
+        if let item = recentItems[safe: indexPath.row] as? RecentlySavedBookmark {
             guard let url = URIFixup.getURL(item.url) else { return }
 
             homePanelDelegate?.homePanel(didSelectURL: url, visitType: .bookmark, isGoogleTopSite: false)

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
@@ -95,7 +95,7 @@ extension RecentlySavedCellViewModel: HomepageViewModelProtocol, FeatureFlaggabl
     }
 
     var hasData: Bool {
-        return false
+        return !recentItems.isEmpty
     }
 
     /// Using dispatch group to know when data has completely loaded for both sources (recent bookmarks and reading list items)

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
@@ -8,8 +8,6 @@ import Storage
 class RecentlySavedCellViewModel {
 
     struct UX {
-        static let bookmarkItemsLimit: UInt = 5
-        static let readingListItemsLimit: Int = 5
         static let cellWidth: CGFloat = 150
         static let cellHeight: CGFloat = 110
         static let generalSpacing: CGFloat = 8
@@ -20,78 +18,23 @@ class RecentlySavedCellViewModel {
 
     var isZeroSearch: Bool
     private let profile: Profile
-
-    private lazy var siteImageHelper = SiteImageHelper(profile: profile)
-    private var readingListItems = [ReadingListItem]()
-    private var recentBookmarks = [BookmarkItemData]()
-    private let recentItemsHelper = RecentItemsHelper()
-    private let dataQueue = DispatchQueue(label: "com.moz.recentlySaved.queue")
-
+    private var recentlySavedDataAdaptor: RecentlySavedDataAdaptor
+    private var recentItems = [RecentlySavedItem]()
     var headerButtonAction: ((UIButton) -> Void)?
 
-    init(isZeroSearch: Bool, profile: Profile) {
+    weak var delegate: HomepageDataModelDelegate?
+
+    init(isZeroSearch: Bool,
+         profile: Profile) {
+
         self.isZeroSearch = isZeroSearch
         self.profile = profile
-    }
+        let siteImageHelper = SiteImageHelper(profile: profile)
+        let adaptor = RecentlySavedDataAdaptorImplementation(siteImageHelper: siteImageHelper,
+                                                             profile: profile)
+        self.recentlySavedDataAdaptor = adaptor
 
-    var recentItems: [RecentlySavedItem] {
-        var items = [RecentlySavedItem]()
-        items.append(contentsOf: recentBookmarks)
-        items.append(contentsOf: readingListItems)
-
-        return items
-    }
-
-    func getHeroImage(forSite site: Site, completion: @escaping (UIImage?) -> Void) {
-        siteImageHelper.fetchImageFor(site: site, imageType: .heroImage, shouldFallback: true) { image in
-            completion(image)
-        }
-    }
-
-    // MARK: - Reading list
-
-    private func getReadingLists(group: DispatchGroup) {
-        group.enter()
-        let maxItems = UX.readingListItemsLimit
-        profile.readingList.getAvailableRecords().uponQueue(dataQueue, block: { [weak self] result in
-            let items = result.successValue?.prefix(maxItems) ?? []
-            self?.updateReadingList(readingList: Array(items))
-            group.leave()
-        })
-    }
-
-    private func updateReadingList(readingList: [ReadingListItem]) {
-        readingListItems = recentItemsHelper.filterStaleItems(recentItems: readingList) as? [ReadingListItem] ?? []
-
-        let extra = [TelemetryWrapper.EventObject.recentlySavedReadingItemImpressions.rawValue: "\(readingListItems.count)"]
-        TelemetryWrapper.recordEvent(category: .action,
-                                     method: .view,
-                                     object: .firefoxHomepage,
-                                     value: .recentlySavedReadingListView,
-                                     extras: extra)
-    }
-
-    // MARK: - Bookmarks
-
-    private func getRecentBookmarks(group: DispatchGroup) {
-        group.enter()
-        profile.places.getRecentBookmarks(limit: UX.bookmarkItemsLimit).uponQueue(dataQueue, block: { [weak self] result in
-            self?.updateRecentBookmarks(bookmarks: result.successValue ?? [])
-            group.leave()
-        })
-    }
-
-    private func updateRecentBookmarks(bookmarks: [BookmarkItemData]) {
-        recentBookmarks = recentItemsHelper.filterStaleItems(recentItems: bookmarks) as? [BookmarkItemData] ?? []
-
-        // Send telemetry if bookmarks aren't empty
-        if !recentBookmarks.isEmpty {
-            TelemetryWrapper.recordEvent(category: .action,
-                                         method: .view,
-                                         object: .firefoxHomepage,
-                                         value: .recentlySavedBookmarkItemView,
-                                         extras: [TelemetryWrapper.EventObject.recentlySavedBookmarkImpressions.rawValue: "\(bookmarks.count)"])
-        }
+        adaptor.delegate = self
     }
 }
 
@@ -152,18 +95,13 @@ extension RecentlySavedCellViewModel: HomepageViewModelProtocol, FeatureFlaggabl
     }
 
     var hasData: Bool {
-        return !recentBookmarks.isEmpty || !readingListItems.isEmpty
+        return false
     }
 
     /// Using dispatch group to know when data has completely loaded for both sources (recent bookmarks and reading list items)
     func updateData(completion: @escaping () -> Void) {
-        let group = DispatchGroup()
-        getRecentBookmarks(group: group)
-        getReadingLists(group: group)
-
-        group.notify(queue: .main) {
-            completion()
-        }
+        recentItems = recentlySavedDataAdaptor.getRecentlySavedData()
+        completion()
     }
 }
 
@@ -174,15 +112,12 @@ extension RecentlySavedCellViewModel: HomepageSectionHandler {
                    at indexPath: IndexPath) -> UICollectionViewCell {
 
         guard let recentlySavedCell = cell as? RecentlySavedCell else { return UICollectionViewCell() }
-        recentlySavedCell.tag = indexPath.row
 
         if let item = recentItems[safe: indexPath.row] {
             let site = Site(url: item.url, title: item.title, bookmarked: true)
             recentlySavedCell.itemTitle.text = site.title
-            getHeroImage(forSite: site) { image in
-                guard cell.tag == indexPath.row else { return }
-                recentlySavedCell.heroImage.image = image
-            }
+            let image = recentlySavedDataAdaptor.getHeroImage(forSite: site)
+            recentlySavedCell.heroImage.image = image
         }
 
         return recentlySavedCell
@@ -214,5 +149,11 @@ extension RecentlySavedCellViewModel: HomepageSectionHandler {
                                          value: .recentlySavedReadingListAction,
                                          extras: TelemetryWrapper.getOriginExtras(isZeroSearch: isZeroSearch))
         }
+    }
+}
+
+extension RecentlySavedCellViewModel: RecentlySavedDelegate {
+    func didLoadNewData() {
+        delegate?.reloadData()
     }
 }

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedDataAdaptor.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedDataAdaptor.swift
@@ -1,0 +1,131 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Storage
+
+protocol RecentlySavedDataAdaptor {
+    var recentItems: [RecentlySavedItem] { get }
+    func getHeroImage(forSite site: Site) -> UIImage?
+    func getRecentlySavedData() -> [RecentlySavedItem]
+}
+
+protocol RecentlySavedDelegate: AnyObject {
+    func didLoadNewData()
+}
+
+class RecentlySavedDataAdaptorImplementation: RecentlySavedDataAdaptor, Notifiable {
+
+    var notificationCenter: NotificationCenter
+    private let bookmarkItemsLimit: UInt = 5
+    private let readingListItemsLimit: Int = 5
+    private let dataQueue = DispatchQueue(label: "com.moz.recentlySaved.queue")
+    private let recentItemsHelper = RecentItemsHelper()
+    private var siteImageHelper: SiteImageHelper
+    private var profile: Profile
+    private var recentBookmarks = [RecentlySavedBookmark]()
+    private var readingListItems = [ReadingListItem]()
+    private var heroImages = [String: UIImage]() {
+        didSet {
+            delegate?.didLoadNewData()
+        }
+    }
+
+    var recentItems: [RecentlySavedItem] {
+        var items = [RecentlySavedItem]()
+        items.append(contentsOf: recentBookmarks)
+        items.append(contentsOf: readingListItems)
+
+        return items
+    }
+
+    weak var delegate: RecentlySavedDelegate?
+
+    init(siteImageHelper: SiteImageHelper,
+         profile: Profile,
+         notificationCenter: NotificationCenter = NotificationCenter.default) {
+        self.siteImageHelper = siteImageHelper
+        self.profile = profile
+        self.notificationCenter = notificationCenter
+
+        getRecentBookmarks()
+        getReadingLists()
+    }
+
+    func getHeroImage(forSite site: Site) -> UIImage? {
+        if let heroImage = heroImages[site.url] {
+            return heroImage
+        }
+        siteImageHelper.fetchImageFor(site: site, imageType: .heroImage, shouldFallback: true) { image in
+            self.heroImages[site.url] = image
+        }
+        return nil
+    }
+
+    func getRecentlySavedData() -> [RecentlySavedItem] {
+        var items = [RecentlySavedItem]()
+        items.append(contentsOf: recentBookmarks)
+        items.append(contentsOf: readingListItems)
+
+        return items
+    }
+
+    // MARK: - Bookmarks
+
+    private func getRecentBookmarks() {
+        profile.places.getRecentBookmarks(limit: bookmarkItemsLimit).uponQueue(dataQueue, block: { [weak self] result in
+            let resultBookmarks: [BookmarkItemData] = result.successValue ?? []
+            let bookmarks = resultBookmarks.map { RecentlySavedBookmark(bookmark: $0) }
+            self?.updateRecentBookmarks(bookmarks: bookmarks)
+        })
+    }
+
+    private func updateRecentBookmarks(bookmarks: [RecentlySavedBookmark]) {
+        recentBookmarks = recentItemsHelper.filterStaleItems(recentItems: bookmarks) as? [RecentlySavedBookmark] ?? []
+        delegate?.didLoadNewData()
+
+        // Send telemetry if bookmarks aren't empty
+        if !recentBookmarks.isEmpty {
+            TelemetryWrapper.recordEvent(category: .action,
+                                         method: .view,
+                                         object: .firefoxHomepage,
+                                         value: .recentlySavedBookmarkItemView,
+                                         extras: [TelemetryWrapper.EventObject.recentlySavedBookmarkImpressions.rawValue: "\(bookmarks.count)"])
+        }
+    }
+
+    // MARK: - Reading list
+
+    private func getReadingLists() {
+        let maxItems = readingListItemsLimit
+        profile.readingList.getAvailableRecords().uponQueue(dataQueue, block: { [weak self] result in
+            let items = result.successValue?.prefix(maxItems) ?? []
+            self?.updateReadingList(readingList: Array(items))
+        })
+    }
+
+    private func updateReadingList(readingList: [ReadingListItem]) {
+        readingListItems = recentItemsHelper.filterStaleItems(recentItems: readingList) as? [ReadingListItem] ?? []
+        delegate?.didLoadNewData()
+
+        let extra = [TelemetryWrapper.EventObject.recentlySavedReadingItemImpressions.rawValue: "\(readingListItems.count)"]
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .view,
+                                     object: .firefoxHomepage,
+                                     value: .recentlySavedReadingListView,
+                                     extras: extra)
+    }
+
+    // MARK: - Notifiable
+
+    func handleNotifications(_ notification: Notification) {
+        switch notification.name {
+        case .ReadingListUpdated:
+            getReadingLists()
+        case .BookmarksUpdated:
+            getRecentBookmarks()
+        default: break
+        }
+    }
+}

--- a/Client/RecentItemsHelper.swift
+++ b/Client/RecentItemsHelper.swift
@@ -38,6 +38,25 @@ extension BookmarkItemData: RecentlySavedItem {
     }
 }
 
+// This is an intermediary object to allow us to more easily use this data in a thread safe way.
+// Thread safety is difficult to ensure when passing classes around by reference.
+struct RecentlySavedBookmark: RecentlySavedItem {
+    var title: String
+    var url: String
+    var dateAdded: Timestamp
+    var numberOfDaysBeforeStale: Int { return 10 }
+
+    init(bookmark: BookmarkItemData) {
+        self.title = bookmark.title
+        self.url = bookmark.url
+        self.dateAdded = Timestamp(bookmark.dateAdded)
+    }
+
+    func getItemDate() -> Date {
+        return Date.fromTimestamp(dateAdded)
+    }
+}
+
 class RecentItemsHelper {
 
     private let calendar = Calendar.current

--- a/Shared/NotificationConstants.swift
+++ b/Shared/NotificationConstants.swift
@@ -79,4 +79,9 @@ extension Notification.Name {
     // Tab manager creates a toast for undo recently closed tabs and a notification is
     // fired when user taps on undo button on Toast
     public static let DidTapUndoCloseAllTabToast = Notification.Name("DidTapUndoCloseAllTabToast")
+
+    // MARK: Settings
+
+    public static let ReadingListUpdated = Notification.Name("ReadingListUpdated")
+    public static let BookmarksUpdated = Notification.Name("BookmarksUpdated")
 }

--- a/Storage/Rust/RustPlaces.swift
+++ b/Storage/Rust/RustPlaces.swift
@@ -22,10 +22,13 @@ public class RustPlaces {
     public fileprivate(set) var isOpen: Bool = false
 
     private var didAttemptToMoveToBackup = false
+    private var notificationCenter: NotificationCenter
 
-    public init(databasePath: String) {
+    public init(databasePath: String,
+                notificationCenter: NotificationCenter = NotificationCenter.default) {
         self.databasePath = databasePath
-
+        self.notificationCenter = notificationCenter
+        
         self.writerQueue = DispatchQueue(label: "RustPlaces writer queue: \(databasePath)", attributes: [])
         self.readerQueue = DispatchQueue(label: "RustPlaces reader queue: \(databasePath)", attributes: [])
     }
@@ -232,6 +235,7 @@ public class RustPlaces {
                     return deferMaybe(error)
                 }
 
+                self.notificationCenter.post(name: .BookmarksUpdated, object: self)
                 return succeed()
             }
         }
@@ -251,6 +255,7 @@ public class RustPlaces {
 
     @discardableResult
     public func createBookmark(parentGUID: GUID, url: String, title: String?, position: UInt32? = nil) -> Deferred<Maybe<GUID>> {
+        notificationCenter.post(name: .BookmarksUpdated, object: self)
         return withWriter { connection in
             return try connection.createBookmark(parentGUID: parentGUID, url: url, title: title, position: position)
         }

--- a/Storage/Rust/RustPlaces.swift
+++ b/Storage/Rust/RustPlaces.swift
@@ -28,7 +28,6 @@ public class RustPlaces {
                 notificationCenter: NotificationCenter = NotificationCenter.default) {
         self.databasePath = databasePath
         self.notificationCenter = notificationCenter
-        
         self.writerQueue = DispatchQueue(label: "RustPlaces writer queue: \(databasePath)", attributes: [])
         self.readerQueue = DispatchQueue(label: "RustPlaces reader queue: \(databasePath)", attributes: [])
     }

--- a/Storage/SQL/SQLiteReadingList.swift
+++ b/Storage/SQL/SQLiteReadingList.swift
@@ -22,9 +22,12 @@ open class SQLiteReadingList {
     let db: BrowserDB
 
     let allColumns = ["client_id", "client_last_modified", "id", "last_modified", "url", "title", "added_by", "archived", "favorite", "unread"].joined(separator: ",")
+    let notificationCenter: NotificationCenter
 
-    required public init(db: BrowserDB) {
+    required public init(db: BrowserDB,
+                         notificationCenter: NotificationCenter = NotificationCenter.default) {
         self.db = db
+        self.notificationCenter = notificationCenter
     }
 }
 
@@ -37,12 +40,14 @@ extension SQLiteReadingList: ReadingList {
     }
 
     public func deleteRecord(_ record: ReadingListItem) -> Success {
+        notificationCenter.post(name: .ReadingListUpdated, object: self)
         let sql = "DELETE FROM items WHERE client_id = ?"
         let args: Args = [record.id]
         return db.run(sql, withArgs: args)
     }
 
     public func deleteAllRecords() -> Success {
+        notificationCenter.post(name: .ReadingListUpdated, object: self)
         let sql = "DELETE FROM items"
         return db.run(sql)
     }
@@ -66,6 +71,7 @@ extension SQLiteReadingList: ReadingList {
 
             let items = cursor.asArray()
             if let item = items.first {
+                self.notificationCenter.post(name: .ReadingListUpdated, object: self)
                 return item
             } else {
                 throw ReadingListStorageError("Unable to get inserted ReadingListItem")
@@ -100,6 +106,7 @@ extension SQLiteReadingList: ReadingList {
 
             let items = cursor.asArray()
             if let item = items.first {
+                self.notificationCenter.post(name: .ReadingListUpdated, object: self)
                 return item
             } else {
                 throw ReadingListStorageError("Unable to get updated ReadingListItem")

--- a/Tests/ClientTests/Frontend/Home/FirefoxHomeViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/FirefoxHomeViewModelTests.swift
@@ -123,4 +123,6 @@ extension FirefoxHomeViewModelTests: HomepageViewModelDelegate {
     func reloadSection(section: HomepageViewModelProtocol) {
         reloadSectionCompleted?(section)
     }
+
+    func reloadData() {}
 }


### PR DESCRIPTION
I still need to do a bit of testing to make sure I didn't break anything so opening a draft PR for now just to get some feedback.

@electricRGB For context, the goal here is to abstract the data out into it's own layer that can ideally manage it's own triggers for updating that is disconnected from the view itself reloading. When the view reloads by default it will just use the most recently cached data.