### PR TITLE
Bugfix FXIOS-4198 [v104] Wallpaper labeled counter telemetry

### DIFF
--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -273,7 +273,8 @@ class TelemetryWrapper {
         let currentWallpaper = LegacyWallpaperManager().currentWallpaper
 
         if case .themed = currentWallpaper.type {
-            // Need to lowercase the name for labeled counter
+            // Need to lowercase the name for labeled counter. Ref:
+            // https://mozilla.github.io/glean/book/reference/metrics/index.html#label-format)
             GleanMetrics.WallpaperAnalytics.themedWallpaper[currentWallpaper.name.lowercased()].add()
         }
 

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -273,7 +273,8 @@ class TelemetryWrapper {
         let currentWallpaper = LegacyWallpaperManager().currentWallpaper
 
         if case .themed = currentWallpaper.type {
-            GleanMetrics.WallpaperAnalytics.themedWallpaper[currentWallpaper.name].add()
+            // Need to lowercase the name for labeled counter
+            GleanMetrics.WallpaperAnalytics.themedWallpaper[currentWallpaper.name.lowercased()].add()
         }
 
     }

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -2353,8 +2353,6 @@ wallpaper_analytics:
     description: |
       Recorded when the user enters the background. This reports
       the currently selected wallpaper if it's not the default.
-    labels:
-      - name
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/10669
     data_reviews:

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -2353,6 +2353,8 @@ wallpaper_analytics:
     description: |
       Recorded when the user enters the background. This reports
       the currently selected wallpaper if it's not the default.
+    labels:
+      - name
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/10669
     data_reviews:

--- a/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -248,34 +248,34 @@ extension XCTestCase {
     func testEventMetricRecordingSuccess<Keys: ExtraKeys, Extras: EventExtras>(metric: EventMetricType<Keys, Extras>,
                                                                                file: StaticString = #file,
                                                                                line: UInt = #line) {
-        XCTAssertTrue(metric.testHasValue())
-        XCTAssertEqual(try! metric.testGetValue().count, 1)
+        XCTAssertTrue(metric.testHasValue(), file: file, line: line)
+        XCTAssertEqual(try! metric.testGetValue().count, 1, file: file, line: line)
 
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0)
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0)
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidState), 0)
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidValue), 0)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0, file: file, line: line)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0, file: file, line: line)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidState), 0, file: file, line: line)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidValue), 0, file: file, line: line)
     }
 
     func testCounterMetricRecordingSuccess(metric: CounterMetricType,
                                            file: StaticString = #file,
                                            line: UInt = #line) {
-        XCTAssertTrue(metric.testHasValue())
-        XCTAssertEqual(try! metric.testGetValue(), 1)
+        XCTAssertTrue(metric.testHasValue(), file: file, line: line)
+        XCTAssertEqual(try! metric.testGetValue(), 1, file: file, line: line)
 
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0)
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0)
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidState), 0)
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidValue), 0)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0, file: file, line: line)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0, file: file, line: line)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidState), 0, file: file, line: line)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidValue), 0, file: file, line: line)
     }
 
     func testLabeledMetricSuccess(metric: LabeledMetricType<CounterMetricType>,
                                   file: StaticString = #file,
                                   line: UInt = #line) {
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0)
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0)
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidState), 0)
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidValue), 0)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0, file: file, line: line)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0, file: file, line: line)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidState), 0, file: file, line: line)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidValue), 0, file: file, line: line)
     }
 
     func testQuantityMetricSuccess(metric: QuantityMetricType,
@@ -283,13 +283,13 @@ extension XCTestCase {
                                    failureMessage: String,
                                    file: StaticString = #file,
                                    line: UInt = #line) {
-        XCTAssertTrue(metric.testHasValue(), "Should have value on quantity metric")
-        XCTAssertEqual(try! metric.testGetValue(), expectedValue, failureMessage)
+        XCTAssertTrue(metric.testHasValue(), "Should have value on quantity metric", file: file, line: line)
+        XCTAssertEqual(try! metric.testGetValue(), expectedValue, failureMessage, file: file, line: line)
 
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0)
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0)
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidState), 0)
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidValue), 0)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0, file: file, line: line)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0, file: file, line: line)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidState), 0, file: file, line: line)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidValue), 0, file: file, line: line)
     }
 
     func testStringMetricSuccess(metric: StringMetricType,
@@ -297,13 +297,13 @@ extension XCTestCase {
                                  failureMessage: String,
                                  file: StaticString = #file,
                                  line: UInt = #line) {
-        XCTAssertTrue(metric.testHasValue(), "Should have value on string metric")
-        XCTAssertEqual(try! metric.testGetValue(), expectedValue, failureMessage)
+        XCTAssertTrue(metric.testHasValue(), "Should have value on string metric", file: file, line: line)
+        XCTAssertEqual(try! metric.testGetValue(), expectedValue, failureMessage, file: file, line: line)
 
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0)
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0)
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidState), 0)
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidValue), 0)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0, file: file, line: line)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0, file: file, line: line)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidState), 0, file: file, line: line)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidValue), 0, file: file, line: line)
     }
 
     func testUrlMetricSuccess(metric: UrlMetricType,
@@ -311,13 +311,13 @@ extension XCTestCase {
                               failureMessage: String,
                               file: StaticString = #file,
                               line: UInt = #line) {
-        XCTAssertTrue(metric.testHasValue(), "Should have value on url metric")
-        XCTAssertEqual(try! metric.testGetValue(), expectedValue, failureMessage)
+        XCTAssertTrue(metric.testHasValue(), "Should have value on url metric", file: file, line: line)
+        XCTAssertEqual(try! metric.testGetValue(), expectedValue, failureMessage, file: file, line: line)
 
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0)
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0)
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidState), 0)
-        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidValue), 0)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0, file: file, line: line)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0, file: file, line: line)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidState), 0, file: file, line: line)
+        XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidValue), 0, file: file, line: line)
     }
 
     func testUuidMetricSuccess(metric: UuidMetricType,
@@ -330,7 +330,7 @@ extension XCTestCase {
             XCTFail("Expected contextId to be configured")
             return
         }
-        XCTAssertTrue(metric.testHasValue(), "Should have value on uuid metric")
-        XCTAssertEqual(value, expectedValue, failureMessage)
+        XCTAssertTrue(metric.testHasValue(), "Should have value on uuid metric", file: file, line: line)
+        XCTAssertEqual(value, expectedValue, failureMessage, file: file, line: line)
     }
 }

--- a/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -227,6 +227,8 @@ class TelemetryWrapperTests: XCTestCase {
         wrapper.recordEnteredBackgroundPreferenceMetrics(notification: fakeNotif)
 
         testLabeledMetricSuccess(metric: GleanMetrics.WallpaperAnalytics.themedWallpaper)
+        let wallpaperName = LegacyWallpaperManager().currentWallpaper.name
+        XCTAssertNil(try? GleanMetrics.WallpaperAnalytics.themedWallpaper[wallpaperName].testGetValue())
     }
 
     func test_backgroundWallpaperMetric_themedWallpaperIsSent() {
@@ -239,6 +241,8 @@ class TelemetryWrapperTests: XCTestCase {
         wrapper.recordEnteredBackgroundPreferenceMetrics(notification: fakeNotif)
 
         testLabeledMetricSuccess(metric: GleanMetrics.WallpaperAnalytics.themedWallpaper)
+        let wallpaperName = LegacyWallpaperManager().currentWallpaper.name
+        XCTAssertEqual(try? GleanMetrics.WallpaperAnalytics.themedWallpaper[wallpaperName].testGetValue(), 1)
     }
 }
 

--- a/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -11,9 +11,13 @@ class TelemetryWrapperTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-
         Glean.shared.resetGlean(clearStores: true)
         Glean.shared.enableTestingMode()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        Glean.shared.resetGlean(clearStores: true)
     }
 
     // MARK: - Top Site
@@ -219,15 +223,18 @@ class TelemetryWrapperTests: XCTestCase {
 
     // MARK: Wallpapers
 
-    func test_backgroundWallpaperMetric_defaultBackgroundIsNotSentAndHasNoError() {
+    func test_backgroundWallpaperMetric_defaultBackgroundIsNotSent() {
         let profile = MockProfile()
         let wrapper = TelemetryWrapper(profile: profile)
+
+        LegacyWallpaperManager().updateSelectedWallpaperIndex(to: 0)
+        XCTAssertEqual(LegacyWallpaperManager().currentWallpaper.type, .defaultBackground)
 
         let fakeNotif = NSNotification(name: UIApplication.didEnterBackgroundNotification, object: nil)
         wrapper.recordEnteredBackgroundPreferenceMetrics(notification: fakeNotif)
 
         testLabeledMetricSuccess(metric: GleanMetrics.WallpaperAnalytics.themedWallpaper)
-        let wallpaperName = LegacyWallpaperManager().currentWallpaper.name
+        let wallpaperName = LegacyWallpaperManager().currentWallpaper.name.lowercased()
         XCTAssertNil(try? GleanMetrics.WallpaperAnalytics.themedWallpaper[wallpaperName].testGetValue())
     }
 
@@ -236,12 +243,13 @@ class TelemetryWrapperTests: XCTestCase {
         let wrapper = TelemetryWrapper(profile: profile)
 
         LegacyWallpaperManager().updateSelectedWallpaperIndex(to: 1)
+        XCTAssertNotEqual(LegacyWallpaperManager().currentWallpaper.type, .defaultBackground)
 
         let fakeNotif = NSNotification(name: UIApplication.didEnterBackgroundNotification, object: nil)
         wrapper.recordEnteredBackgroundPreferenceMetrics(notification: fakeNotif)
 
         testLabeledMetricSuccess(metric: GleanMetrics.WallpaperAnalytics.themedWallpaper)
-        let wallpaperName = LegacyWallpaperManager().currentWallpaper.name
+        let wallpaperName = LegacyWallpaperManager().currentWallpaper.name.lowercased()
         XCTAssertEqual(try? GleanMetrics.WallpaperAnalytics.themedWallpaper[wallpaperName].testGetValue(), 1)
     }
 }

--- a/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -12,7 +12,6 @@ class TelemetryWrapperTests: XCTestCase {
     override func setUp() {
         super.setUp()
         Glean.shared.resetGlean(clearStores: true)
-        Glean.shared.enableTestingMode()
     }
 
     override func tearDown() {

--- a/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -216,6 +216,30 @@ class TelemetryWrapperTests: XCTestCase {
         TelemetryWrapper.recordEvent(category: .information, method: .delete, object: .clearSDWebImageCache)
         testCounterMetricRecordingSuccess(metric: GleanMetrics.Migration.imageSdCacheCleanup)
     }
+
+    // MARK: Wallpapers
+
+    func test_backgroundWallpaperMetric_defaultBackgroundIsNotSentAndHasNoError() {
+        let profile = MockProfile()
+        let wrapper = TelemetryWrapper(profile: profile)
+
+        let fakeNotif = NSNotification(name: UIApplication.didEnterBackgroundNotification, object: nil)
+        wrapper.recordEnteredBackgroundPreferenceMetrics(notification: fakeNotif)
+
+        testLabeledMetricSuccess(metric: GleanMetrics.WallpaperAnalytics.themedWallpaper)
+    }
+
+    func test_backgroundWallpaperMetric_themedWallpaperIsSent() {
+        let profile = MockProfile()
+        let wrapper = TelemetryWrapper(profile: profile)
+
+        LegacyWallpaperManager().updateSelectedWallpaperIndex(to: 1)
+
+        let fakeNotif = NSNotification(name: UIApplication.didEnterBackgroundNotification, object: nil)
+        wrapper.recordEnteredBackgroundPreferenceMetrics(notification: fakeNotif)
+
+        testLabeledMetricSuccess(metric: GleanMetrics.WallpaperAnalytics.themedWallpaper)
+    }
 }
 
 // MARK: - Helper functions to test telemetry


### PR DESCRIPTION
# [FXIOS-4198](https://mozilla-hub.atlassian.net/browse/FXIOS-4198) #10669
- Add unit tests for wallpaper to reproduce invalidLabel error
- Add an extra metric parameters to the label counter following [Labeled counters documentation](https://mozilla.github.io/glean/book/reference/metrics/labeled_counters.html#extra-metric-parameters)
- Took the opportunity to pass in file and line to assertions in test as I had forgotten before, oups!

Tagging @travis79 here as I'm not sure if this is the expected behavior of labeled counter? It seems with the doc that `labels` parameter are optionals and we should have been able to call that telemetry with that [code](https://github.com/mozilla-mobile/firefox-ios/blob/7b3bbfe59b72f8542a19ddc5c0d896d174d0a402/Client/Telemetry/TelemetryWrapper.swift#L276)? Also, it seems labeled counter doesn't have `.testGetValue()` available, it would be great to have it!