### PR TITLE
Bugfix FXIOS-4583 [v104] Scrolling to bottom in mobile folder, Editing desktop folder when shouldn't

### DIFF
--- a/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -344,12 +344,11 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel, CanRemoveQuickActio
         else { return }
 
         guard !tableView.isEditing else {
-            TelemetryWrapper.recordEvent(category: .action, method: .change, object: .bookmark, value: .bookmarksPanel)
-            if let bookmarkFolder = self.viewModel.bookmarkFolder, !(node is BookmarkSeparatorData) {
-                let detailController = BookmarkDetailPanel(profile: profile, bookmarkNode: node,
-                                                           parentBookmarkFolder: bookmarkFolder)
-                updatePanelState(newState: .bookmarks(state: .itemEditMode))
-                navigationController?.pushViewController(detailController, animated: true)
+            if let bookmarkFolder = self.viewModel.bookmarkFolder,
+                !(node is BookmarkSeparatorData),
+                isCurrentFolderEditable(at: indexPath) {
+                // Only show detail controller for editable nodes
+                showBookmarkDetailController(for: node, folder: bookmarkFolder)
             }
             return
         }
@@ -411,6 +410,15 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel, CanRemoveQuickActio
 
     func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
         return isCurrentFolderEditable(at: indexPath)
+    }
+
+    private func showBookmarkDetailController(for node: FxBookmarkNode, folder: FxBookmarkNode) {
+        TelemetryWrapper.recordEvent(category: .action, method: .change, object: .bookmark, value: .bookmarksPanel)
+        let detailController = BookmarkDetailPanel(profile: profile,
+                                                   bookmarkNode: node,
+                                                   parentBookmarkFolder: folder)
+        updatePanelState(newState: .bookmarks(state: .itemEditMode))
+        navigationController?.pushViewController(detailController, animated: true)
     }
 
     /// Root folders and local desktop folder cannot be moved or edited

--- a/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -272,8 +272,9 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel, CanRemoveQuickActio
     // MARK: - Utility
 
     private func indexPathIsValid(_ indexPath: IndexPath) -> Bool {
-        return indexPath.section < numberOfSections(in: tableView) &&
-        indexPath.row < tableView(tableView, numberOfRowsInSection: indexPath.section)
+        return indexPath.section < numberOfSections(in: tableView)
+        && indexPath.row < tableView(tableView, numberOfRowsInSection: indexPath.section)
+        && viewModel.bookmarkFolderGUID != BookmarkRoots.MobileFolderGUID
     }
 
     private func numberOfSections(in tableView: UITableView) -> Int {

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -26,10 +26,10 @@ class LibraryViewController: UIViewController {
     var onViewDismissed: (() -> Void)?
 
     // Views
-    fileprivate var controllerContainerView: UIView = .build { view in }
+    private var controllerContainerView: UIView = .build { view in }
 
     // UI Elements
-    lazy var librarySegmentControl: UISegmentedControl = {
+    private lazy var librarySegmentControl: UISegmentedControl = {
         var librarySegmentControl: UISegmentedControl
         librarySegmentControl = UISegmentedControl(items: viewModel.segmentedControlItems)
         librarySegmentControl.accessibilityIdentifier = AccessibilityIdentifiers.LibraryPanels.segmentedControl
@@ -39,7 +39,7 @@ class LibraryViewController: UIViewController {
         return librarySegmentControl
     }()
 
-    lazy var navigationToolbar: UIToolbar = .build { [weak self] toolbar in
+    private lazy var segmentControlToolbar: UIToolbar = .build { [weak self] toolbar in
         guard let self = self else { return }
         toolbar.delegate = self
         toolbar.setItems([UIBarButtonItem(customView: self.librarySegmentControl)], animated: false)
@@ -102,17 +102,17 @@ class LibraryViewController: UIViewController {
         }
 
         navigationItem.rightBarButtonItem = topRightButton
-        view.addSubviews(controllerContainerView, navigationToolbar)
+        view.addSubviews(controllerContainerView, segmentControlToolbar)
 
         NSLayoutConstraint.activate([
-            navigationToolbar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            navigationToolbar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            navigationToolbar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            segmentControlToolbar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            segmentControlToolbar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            segmentControlToolbar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
 
             librarySegmentControl.widthAnchor.constraint(equalToConstant: UX.NavigationMenu.width),
             librarySegmentControl.heightAnchor.constraint(equalToConstant: UX.NavigationMenu.height),
 
-            controllerContainerView.topAnchor.constraint(equalTo: navigationToolbar.bottomAnchor),
+            controllerContainerView.topAnchor.constraint(equalTo: segmentControlToolbar.bottomAnchor),
             controllerContainerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             controllerContainerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             controllerContainerView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
@@ -222,12 +222,12 @@ class LibraryViewController: UIViewController {
         addChild(libraryPanel)
         libraryPanel.beginAppearanceTransition(true, animated: false)
         controllerContainerView.addSubview(libraryPanel.view)
-        view.bringSubviewToFront(navigationToolbar)
+        view.bringSubviewToFront(segmentControlToolbar)
         libraryPanel.endAppearanceTransition()
 
         libraryPanel.view.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            libraryPanel.view.topAnchor.constraint(equalTo: navigationToolbar.bottomAnchor),
+            libraryPanel.view.topAnchor.constraint(equalTo: segmentControlToolbar.bottomAnchor),
             libraryPanel.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             libraryPanel.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             libraryPanel.view.trailingAnchor.constraint(equalTo: view.trailingAnchor)
@@ -309,9 +309,9 @@ extension LibraryViewController: NotificationThemeable, Notifiable {
         navigationController?.navigationBar.backgroundColor = UIColor.theme.tabTray.toolbar
         navigationController?.toolbar.barTintColor = UIColor.theme.tabTray.toolbar
         navigationController?.toolbar.tintColor = .systemBlue
-        navigationToolbar.barTintColor = UIColor.theme.tabTray.toolbar
-        navigationToolbar.tintColor = UIColor.theme.tabTray.toolbarButtonTint
-        navigationToolbar.isTranslucent = false
+        segmentControlToolbar.barTintColor = UIColor.theme.tabTray.toolbar
+        segmentControlToolbar.tintColor = UIColor.theme.tabTray.toolbarButtonTint
+        segmentControlToolbar.isTranslucent = false
 
         setNeedsStatusBarAppearanceUpdate()
     }


### PR DESCRIPTION
# [FXIOS-4583](https://mozilla-hub.atlassian.net/browse/FXIOS-4583) #11324
FYI this points to the epic branch, this is not going to `main`and is fixing issues so we can make a new build for QA before this epic branch gets merged to main.
- FXIOS-4583 -> Fix view scrolling to bottom in mobile folder, since order is inverted
- Found another issue at the same time where Desktop folder was clickable in edit mode. We could "modify" this folder which is something that shouldn't happen
- LibrarySegmentControl rename + put things private