### PR TITLE
Bugfix FXIOS-4467 [v104] Fix bookmarks/library tests that were dependent on appDelegate setup

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -249,8 +249,8 @@ class PhotonActionSheet: UIViewController {
     }
 
     private func applyBackgroundBlur() {
-        let appDelegate = UIApplication.shared.delegate as! AppDelegate
-        guard let screenshot = appDelegate.window?.screenshot() else { return }
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
+              let screenshot = appDelegate.window?.screenshot() else { return }
 
         let blurredImage = screenshot.applyBlur(withRadius: 5,
                                                 blurType: BOXFILTER,

--- a/Tests/ClientTests/LibraryViewModelTests.swift
+++ b/Tests/ClientTests/LibraryViewModelTests.swift
@@ -17,6 +17,9 @@ class LibraryViewModelTests: XCTestCase {
         profile = MockProfile(databasePrefix: "historyHighlights_tests")
         profile._reopen()
         tabManager = TabManager(profile: profile, imageStore: nil)
+
+        ThemeManager.shared.updateProfile(with: profile)
+        FeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
     }
 
     override func tearDown() {


### PR DESCRIPTION
# [FXIOS-4467](https://mozilla-hub.atlassian.net/browse/FXIOS-4467)  #11140
- Tests were crashing due to:
    - Force unwrap of app delegate in Photon Action sheet. App delegate doesn't exist anymore during unit tests
    - ThemeManager and FeatureFlagsManager methods were called. Those are hidden dependencies from Library panels usage since they are singleton. Setting them up with the mockProfile fix the problem for now.