### PR TITLE
Refactor [v104] Move sponsored color to LegacyTheme

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -51,8 +51,8 @@ messaging:
       type: string
       description: What should be displayed when a control message is selected.
       enum:
-        - show-next-message
         - show-none
+        - show-next-message
     styles:
       type: json
       description: "A map of styles to configure message appearance.\n"

--- a/Client/Frontend/Home/TopSites/TopSiteItemCell.swift
+++ b/Client/Frontend/Home/TopSites/TopSiteItemCell.swift
@@ -234,9 +234,7 @@ extension TopSiteItemCell: NotificationThemeable {
         titleLabel.textColor = UIColor.theme.homePanel.topSiteDomain
         faviconBG.backgroundColor = UIColor.theme.homePanel.shortcutBackground
         faviconBG.layer.shadowColor = UIColor.theme.homePanel.shortcutShadowColor
-
-        let theme = BuiltinThemeName(rawValue: LegacyThemeManager.instance.current.name) ?? .normal
-        sponsoredLabel.textColor = theme == .dark ? UIColor.Photon.LightGrey40 : UIColor.Photon.DarkGrey05
+        sponsoredLabel.textColor = UIColor.theme.homePanel.sponsored
     }
 }
 

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
@@ -141,7 +141,7 @@ private class DarkHomePanelColor: HomePanelColor {
 
     override var customizeHomepageButtonBackground: UIColor { return UIColor.Photon.DarkGrey50 }
     override var customizeHomepageButtonText: UIColor { return UIColor.Photon.LightGrey10 }
-    
+
     override var sponsored: UIColor { return UIColor.Photon.LightGrey40 }
 }
 

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
@@ -141,6 +141,8 @@ private class DarkHomePanelColor: HomePanelColor {
 
     override var customizeHomepageButtonBackground: UIColor { return UIColor.Photon.DarkGrey50 }
     override var customizeHomepageButtonText: UIColor { return UIColor.Photon.LightGrey10 }
+    
+    override var sponsored: UIColor { return UIColor.Photon.LightGrey40 }
 }
 
 private class DarkSnackBarColor: SnackBarColor {

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
@@ -212,7 +212,7 @@ class HomePanelColor {
 
     var customizeHomepageButtonBackground: UIColor { return UIColor.Photon.LightGrey30 }
     var customizeHomepageButtonText: UIColor { return UIColor.Photon.DarkGrey90 }
-    
+
     var sponsored: UIColor { return UIColor.Photon.DarkGrey05 }
 }
 

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
@@ -212,6 +212,8 @@ class HomePanelColor {
 
     var customizeHomepageButtonBackground: UIColor { return UIColor.Photon.LightGrey30 }
     var customizeHomepageButtonText: UIColor { return UIColor.Photon.DarkGrey90 }
+    
+    var sponsored: UIColor { return UIColor.Photon.DarkGrey05 }
 }
 
 class SnackBarColor {


### PR DESCRIPTION
This PR moves the sponsored label color to Theme instead of creating it ad hoc in applyTheme(). #11374 