### PR TITLE
Bugfix FXIOS-4617/4616 [v105] Access Control change from open to public

### DIFF
--- a/Shared/Extensions/NSCoderExtensions.swift
+++ b/Shared/Extensions/NSCoderExtensions.swift
@@ -15,27 +15,27 @@ extension NSCoder {
     /**
     * Decode as Int regardless of which Swift version was used to encode it
     **/
-    open func decodeAsInt(forKey key: String) -> Int {
+    public func decodeAsInt(forKey key: String) -> Int {
         return self.decodeObject(forKey: key) as? Int ?? self.decodeInteger(forKey: key)
     }
     /**
      * Decode as UInt64 regardless of which Swift version was used to encode it
      **/
-    open func decodeAsUInt64(forKey key: String) -> UInt64 {
+    public func decodeAsUInt64(forKey key: String) -> UInt64 {
         return (self.decodeObject(forKey: key)  as? NSNumber)?.uint64Value ?? UInt64(self.decodeInt64(forKey: key))
     }
 
     /**
      * Decode as Bool regardless of which Swift version was used to encode it
      **/
-    open func decodeAsBool(forKey key: String) -> Bool {
+    public func decodeAsBool(forKey key: String) -> Bool {
         return self.decodeObject(forKey: key) as? Bool ?? self.decodeBool(forKey: key)
     }
 
     /**
      * Decode as Double regardless of which Swift version was used to encode it
      **/
-    open func decodeAsDouble(forKey key: String) -> Double {
+    public func decodeAsDouble(forKey key: String) -> Double {
         return (self.decodeObject(forKey: key) as? NSNumber)?.doubleValue ?? self.decodeDouble(forKey: key)
     }
 }

--- a/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
+++ b/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
@@ -232,7 +232,7 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
 }
 
 extension SQLiteRemoteClientsAndTabs: RemoteDevices {
-    open func replaceRemoteDevices(_ remoteDevices: [RemoteDevice]) -> Success {
+    public func replaceRemoteDevices(_ remoteDevices: [RemoteDevice]) -> Success {
         // Drop corrupted records and our own record too.
         let remoteDevices = remoteDevices.filter { $0.id != nil && $0.type != nil && !$0.isCurrentDevice }
 


### PR DESCRIPTION
This  pull request changes the access level from "open" to "public" to clear the warning below:

`Non-'@objc' instance method in extensions cannot be overriden; use 'public' instead`

for the issues  #11378 & #11379