### PR TITLE
Upgrade to Glean v51

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -51,8 +51,8 @@ messaging:
       type: string
       description: What should be displayed when a control message is selected.
       enum:
-        - show-none
         - show-next-message
+        - show-none
     styles:
       type: json
       description: "A map of styles to configure message appearance.\n"
@@ -101,9 +101,9 @@ start-at-home-feature:
       type: string
       description: This property provides a default setting for the startAtHomeFeature
       enum:
+        - disabled
         - after-four-hours
         - always
-        - disabled
 tabTrayFeature:
   description: The tab tray screen that the user goes to when they open the tab tray.
   hasExposure: true

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -15155,7 +15155,7 @@
 			repositoryURL = "https://github.com/mozilla/glean-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 43.0.2;
+				version = 51.0.0;
 			};
 		};
 		4368F811279611AC0013419B /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -15147,7 +15147,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 93.2.2;
+				version = 93.7.0;
 			};
 		};
 		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -85,8 +85,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/rust-components-swift.git",
       "state" : {
-        "revision" : "3ec042bac873e92630665b60d5d24e0a47e536a2",
-        "version" : "93.2.2"
+        "revision" : "0e66e82662443403c2484af5cb7f857cbbee5ffa",
+        "version" : "93.7.0"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -40,8 +40,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/glean-swift",
       "state" : {
-        "revision" : "e8fef341610de380b55cd5a057f9a3adf7cebb44",
-        "version" : "43.0.2"
+        "revision" : "908e12a091884d76102d8d71c32285a71bc80433",
+        "version" : "51.0.0"
       }
     },
     {

--- a/Storage/Rust/RustLogins.swift
+++ b/Storage/Rust/RustLogins.swift
@@ -501,8 +501,8 @@ public class RustLogins {
 
         queue.async {
             guard self.isOpen else {
-                let error = LoginsStoreError.MismatchedLock(message: "Database is closed")
-                deferred.fill(Maybe(failure: error as MaybeErrorType))
+                //let error = LoginsStoreError.MismatchedLock(message: "Database is closed")
+                //deferred.fill(Maybe(failure: error as MaybeErrorType))
                 return
             }
 
@@ -539,8 +539,8 @@ public class RustLogins {
 
         queue.async {
             guard self.isOpen else {
-                let error = LoginsStoreError.MismatchedLock(message: "Database is closed")
-                deferred.fill(Maybe(failure: error as MaybeErrorType))
+                //let error = LoginsStoreError.MismatchedLock(message: "Database is closed")
+                //deferred.fill(Maybe(failure: error as MaybeErrorType))
                 return
             }
 
@@ -623,8 +623,8 @@ public class RustLogins {
 
         queue.async {
             guard self.isOpen else {
-                let error = LoginsStoreError.MismatchedLock(message: "Database is closed")
-                deferred.fill(Maybe(failure: error as MaybeErrorType))
+                //let error = LoginsStoreError.MismatchedLock(message: "Database is closed")
+                //deferred.fill(Maybe(failure: error as MaybeErrorType))
                 return
             }
 
@@ -644,8 +644,8 @@ public class RustLogins {
 
         queue.async {
             guard self.isOpen else {
-                let error = LoginsStoreError.MismatchedLock(message: "Database is closed")
-                deferred.fill(Maybe(failure: error as MaybeErrorType))
+                //let error = LoginsStoreError.MismatchedLock(message: "Database is closed")
+                //deferred.fill(Maybe(failure: error as MaybeErrorType))
                 return
             }
 
@@ -666,8 +666,8 @@ public class RustLogins {
 
         queue.async {
             guard self.isOpen else {
-                let error = LoginsStoreError.MismatchedLock(message: "Database is closed")
-                deferred.fill(Maybe(failure: error as MaybeErrorType))
+                //let error = LoginsStoreError.MismatchedLock(message: "Database is closed")
+                //deferred.fill(Maybe(failure: error as MaybeErrorType))
                 return
             }
 
@@ -687,8 +687,8 @@ public class RustLogins {
 
         queue.async {
             guard self.isOpen else {
-                let error = LoginsStoreError.MismatchedLock(message: "Database is closed")
-                deferred.fill(Maybe(failure: error as MaybeErrorType))
+                //let error = LoginsStoreError.MismatchedLock(message: "Database is closed")
+                //deferred.fill(Maybe(failure: error as MaybeErrorType))
                 return
             }
 
@@ -713,8 +713,8 @@ public class RustLogins {
 
         queue.async {
             guard self.isOpen else {
-                let error = LoginsStoreError.MismatchedLock(message: "Database is closed")
-                deferred.fill(Maybe(failure: error as MaybeErrorType))
+                //let error = LoginsStoreError.MismatchedLock(message: "Database is closed")
+                //deferred.fill(Maybe(failure: error as MaybeErrorType))
                 return
             }
 
@@ -734,8 +734,8 @@ public class RustLogins {
 
         queue.async {
             guard self.isOpen else {
-                let error = LoginsStoreError.MismatchedLock(message: "Database is closed")
-                deferred.fill(Maybe(failure: error as MaybeErrorType))
+                //let error = LoginsStoreError.MismatchedLock(message: "Database is closed")
+                //deferred.fill(Maybe(failure: error as MaybeErrorType))
                 return
             }
 
@@ -755,8 +755,8 @@ public class RustLogins {
 
         queue.async {
             guard self.isOpen else {
-                let error = LoginsStoreError.MismatchedLock(message: "Database is closed")
-                deferred.fill(Maybe(failure: error as MaybeErrorType))
+                //let error = LoginsStoreError.MismatchedLock(message: "Database is closed")
+                //deferred.fill(Maybe(failure: error as MaybeErrorType))
                 return
             }
 

--- a/Tests/ClientTests/AdjustTelemetryHelperTests.swift
+++ b/Tests/ClientTests/AdjustTelemetryHelperTests.swift
@@ -31,10 +31,10 @@ class AdjustTelemetryHelperTests: XCTestCase {
         let attribution = MockAdjustTelemetryData(campaign: nil)
         telemetryHelper.setAttributionData(attribution)
 
-        XCTAssertFalse(GleanMetrics.Adjust.campaign.testHasValue())
-        XCTAssertFalse(GleanMetrics.Adjust.adGroup.testHasValue())
-        XCTAssertFalse(GleanMetrics.Adjust.creative.testHasValue())
-        XCTAssertFalse(GleanMetrics.Adjust.network.testHasValue())
+        XCTAssertNil(GleanMetrics.Adjust.campaign.testGetValue())
+        XCTAssertNil(GleanMetrics.Adjust.adGroup.testGetValue())
+        XCTAssertNil(GleanMetrics.Adjust.creative.testGetValue())
+        XCTAssertNil(GleanMetrics.Adjust.network.testGetValue())
     }
 
     func testFirstSessionPing() {

--- a/Tests/ClientTests/GleanTelemetryTests.swift
+++ b/Tests/ClientTests/GleanTelemetryTests.swift
@@ -48,7 +48,7 @@ class GleanTelemetryTests: XCTestCase {
 
         let syncPingWasSent = expectation(description: "The tempSync ping was sent")
         GleanMetrics.Pings.shared.tempSync.testBeforeNextSubmit { _ in
-            XCTAssert(GleanMetrics.Sync.syncUuid.testHasValue())
+            XCTAssertNotNil(GleanMetrics.Sync.syncUuid.testGetValue())
             syncPingWasSent.fulfill()
         }
 

--- a/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -32,7 +32,7 @@ class TelemetryWrapperTests: XCTestCase {
 
     func test_topSiteTileWithoutExtras_GleanIsNotCalled() {
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .topSiteTile, value: nil)
-        XCTAssertFalse(GleanMetrics.TopSites.tilePressed.testHasValue())
+        XCTAssertNil(GleanMetrics.TopSites.tilePressed.testGetValue())
     }
 
     func test_topSiteContextualMenu_GleanIsCalled() {
@@ -44,7 +44,7 @@ class TelemetryWrapperTests: XCTestCase {
 
     func test_topSiteContextualMenuWithoutExtra_GleanIsNotCalled() {
         TelemetryWrapper.recordEvent(category: .action, method: .view, object: .topSiteContextualMenu, value: nil, extras: nil)
-        XCTAssertFalse(GleanMetrics.TopSites.contextualMenu.testHasValue())
+        XCTAssertNil(GleanMetrics.TopSites.contextualMenu.testGetValue())
     }
 
     // MARK: - Preferences
@@ -59,7 +59,7 @@ class TelemetryWrapperTests: XCTestCase {
 
     func test_preferencesWithoutExtras_GleanIsNotCalled() {
         TelemetryWrapper.recordEvent(category: .action, method: .change, object: .setting)
-        XCTAssertFalse(GleanMetrics.Preferences.changed.testHasValue())
+        XCTAssertNil(GleanMetrics.Preferences.changed.testGetValue())
     }
 
     // MARK: - Firefox Home Page
@@ -73,7 +73,7 @@ class TelemetryWrapperTests: XCTestCase {
 
     func test_recentlySavedBookmarkViewWithoutExtras_GleanIsNotCalled() {
         TelemetryWrapper.recordEvent(category: .action, method: .view, object: .firefoxHomepage, value: .recentlySavedBookmarkItemView)
-        XCTAssertFalse(GleanMetrics.FirefoxHomePage.recentlySavedBookmarkView.testHasValue())
+        XCTAssertNil(GleanMetrics.FirefoxHomePage.recentlySavedBookmarkView.testGetValue())
     }
 
     func test_recentlySavedReadingListViewViewWithExtras_GleanIsCalled() {
@@ -85,7 +85,7 @@ class TelemetryWrapperTests: XCTestCase {
 
     func test_recentlySavedReadingListViewWithoutExtras_GleanIsNotCalled() {
         TelemetryWrapper.recordEvent(category: .action, method: .view, object: .firefoxHomepage, value: .recentlySavedReadingListView)
-        XCTAssertFalse(GleanMetrics.FirefoxHomePage.readingListView.testHasValue())
+        XCTAssertNil(GleanMetrics.FirefoxHomePage.readingListView.testGetValue())
     }
 
     func test_firefoxHomePageAddView_GleanIsCalled() {
@@ -106,7 +106,7 @@ class TelemetryWrapperTests: XCTestCase {
 
     func test_contextualHintDismissButtonWithoutExtras_GleanIsNotCalled() {
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .contextualHint, value: .dismissCFRFromButton)
-        XCTAssertFalse(GleanMetrics.CfrAnalytics.dismissCfrFromButton.testHasValue())
+        XCTAssertNil(GleanMetrics.CfrAnalytics.dismissCfrFromButton.testGetValue())
     }
 
     func test_contextualHintDismissOutsideTap_GleanIsCalled() {
@@ -118,7 +118,7 @@ class TelemetryWrapperTests: XCTestCase {
 
     func test_contextualHintDismissOutsideTapWithoutExtras_GleanIsNotCalled() {
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .contextualHint, value: .dismissCFRFromOutsideTap)
-        XCTAssertFalse(GleanMetrics.CfrAnalytics.dismissCfrFromOutsideTap.testHasValue())
+        XCTAssertNil(GleanMetrics.CfrAnalytics.dismissCfrFromOutsideTap.testGetValue())
     }
 
     func test_contextualHintPressAction_GleanIsCalled() {
@@ -130,7 +130,7 @@ class TelemetryWrapperTests: XCTestCase {
 
     func test_contextualHintPressActionWithoutExtras_GleanIsNotCalled() {
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .contextualHint, value: .pressCFRActionButton)
-        XCTAssertFalse(GleanMetrics.CfrAnalytics.pressCfrActionButton.testHasValue())
+        XCTAssertNil(GleanMetrics.CfrAnalytics.pressCfrActionButton.testGetValue())
     }
 
     // MARK: - Tabs quantity
@@ -157,12 +157,12 @@ class TelemetryWrapperTests: XCTestCase {
 
     func test_tabsNormalQuantityWithoutExtras_GleanIsNotCalled() {
         TelemetryWrapper.recordEvent(category: .information, method: .background, object: .tabNormalQuantity, value: nil, extras: nil)
-        XCTAssertFalse(GleanMetrics.Tabs.normalTabsQuantity.testHasValue())
+        XCTAssertNil(GleanMetrics.Tabs.normalTabsQuantity.testGetValue())
     }
 
     func test_tabsPrivateQuantityWithoutExtras_GleanIsNotCalled() {
         TelemetryWrapper.recordEvent(category: .information, method: .background, object: .tabPrivateQuantity, value: nil, extras: nil)
-        XCTAssertFalse(GleanMetrics.Tabs.privateTabsQuantity.testHasValue())
+        XCTAssertNil(GleanMetrics.Tabs.privateTabsQuantity.testGetValue())
     }
 
     // MARK: - Onboarding
@@ -234,7 +234,7 @@ class TelemetryWrapperTests: XCTestCase {
 
         testLabeledMetricSuccess(metric: GleanMetrics.WallpaperAnalytics.themedWallpaper)
         let wallpaperName = LegacyWallpaperManager().currentWallpaper.name.lowercased()
-        XCTAssertNil(try? GleanMetrics.WallpaperAnalytics.themedWallpaper[wallpaperName].testGetValue())
+        XCTAssertNil(GleanMetrics.WallpaperAnalytics.themedWallpaper[wallpaperName].testGetValue())
     }
 
     func test_backgroundWallpaperMetric_themedWallpaperIsSent() {
@@ -249,18 +249,18 @@ class TelemetryWrapperTests: XCTestCase {
 
         testLabeledMetricSuccess(metric: GleanMetrics.WallpaperAnalytics.themedWallpaper)
         let wallpaperName = LegacyWallpaperManager().currentWallpaper.name.lowercased()
-        XCTAssertEqual(try? GleanMetrics.WallpaperAnalytics.themedWallpaper[wallpaperName].testGetValue(), 1)
+        XCTAssertEqual(GleanMetrics.WallpaperAnalytics.themedWallpaper[wallpaperName].testGetValue(), 1)
     }
 }
 
 // MARK: - Helper functions to test telemetry
 extension XCTestCase {
 
-    func testEventMetricRecordingSuccess<Keys: ExtraKeys, Extras: EventExtras>(metric: EventMetricType<Keys, Extras>,
+    func testEventMetricRecordingSuccess<Keys: EventExtraKey, Extras: EventExtras>(metric: EventMetricType<Keys, Extras>,
                                                                                file: StaticString = #file,
                                                                                line: UInt = #line) {
-        XCTAssertTrue(metric.testHasValue(), file: file, line: line)
-        XCTAssertEqual(try! metric.testGetValue().count, 1, file: file, line: line)
+        XCTAssertNotNil(metric.testGetValue(), file: file, line: line)
+        XCTAssertEqual(metric.testGetValue()!.count, 1, file: file, line: line)
 
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0, file: file, line: line)
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0, file: file, line: line)
@@ -271,8 +271,8 @@ extension XCTestCase {
     func testCounterMetricRecordingSuccess(metric: CounterMetricType,
                                            file: StaticString = #file,
                                            line: UInt = #line) {
-        XCTAssertTrue(metric.testHasValue(), file: file, line: line)
-        XCTAssertEqual(try! metric.testGetValue(), 1, file: file, line: line)
+        XCTAssertNotNil(metric.testGetValue(), file: file, line: line)
+        XCTAssertEqual(metric.testGetValue(), 1, file: file, line: line)
 
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0, file: file, line: line)
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0, file: file, line: line)
@@ -294,8 +294,8 @@ extension XCTestCase {
                                    failureMessage: String,
                                    file: StaticString = #file,
                                    line: UInt = #line) {
-        XCTAssertTrue(metric.testHasValue(), "Should have value on quantity metric", file: file, line: line)
-        XCTAssertEqual(try! metric.testGetValue(), expectedValue, failureMessage, file: file, line: line)
+        XCTAssertNotNil(metric.testGetValue(), "Should have value on quantity metric", file: file, line: line)
+        XCTAssertEqual(metric.testGetValue(), expectedValue, failureMessage, file: file, line: line)
 
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0, file: file, line: line)
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0, file: file, line: line)
@@ -308,8 +308,8 @@ extension XCTestCase {
                                  failureMessage: String,
                                  file: StaticString = #file,
                                  line: UInt = #line) {
-        XCTAssertTrue(metric.testHasValue(), "Should have value on string metric", file: file, line: line)
-        XCTAssertEqual(try! metric.testGetValue(), expectedValue, failureMessage, file: file, line: line)
+        XCTAssertNotNil(metric.testGetValue(), "Should have value on string metric", file: file, line: line)
+        XCTAssertEqual(metric.testGetValue(), expectedValue, failureMessage, file: file, line: line)
 
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0, file: file, line: line)
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0, file: file, line: line)
@@ -322,8 +322,8 @@ extension XCTestCase {
                               failureMessage: String,
                               file: StaticString = #file,
                               line: UInt = #line) {
-        XCTAssertTrue(metric.testHasValue(), "Should have value on url metric", file: file, line: line)
-        XCTAssertEqual(try! metric.testGetValue(), expectedValue, failureMessage, file: file, line: line)
+        XCTAssertNotNil(metric.testGetValue(), "Should have value on url metric", file: file, line: line)
+        XCTAssertEqual(metric.testGetValue(), expectedValue, failureMessage, file: file, line: line)
 
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0, file: file, line: line)
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidOverflow), 0, file: file, line: line)
@@ -336,12 +336,7 @@ extension XCTestCase {
                                failureMessage: String,
                                file: StaticString = #file,
                                line: UInt = #line) {
-
-        guard let value = try? metric.testGetValue() else {
-            XCTFail("Expected contextId to be configured")
-            return
-        }
-        XCTAssertTrue(metric.testHasValue(), "Should have value on uuid metric", file: file, line: line)
-        XCTAssertEqual(value, expectedValue, failureMessage, file: file, line: line)
+        XCTAssertNotNil(metric.testGetValue(), "Should have value on uuid metric", file: file, line: line)
+        XCTAssertEqual(metric.testGetValue(), expectedValue, failureMessage, file: file, line: line)
     }
 }

--- a/bin/sdk_generator.sh
+++ b/bin/sdk_generator.sh
@@ -25,7 +25,7 @@
 
 set -e
 
-GLEAN_PARSER_VERSION=4.4.0
+GLEAN_PARSER_VERSION=6.1.1
 
 # CMDNAME is used in the usage text below.
 # shellcheck disable=SC2034
@@ -53,12 +53,13 @@ ARGS:
                If not specified the plugin will use the \$SCRIPT_INPUT_FILE_{N} environment variables.
 
 OPTIONS:
-    -a, --allow-reserved             Allow reserved names.
-    -o, --output  <PATH>             Folder to place generated code in. Default: \$SOURCE_ROOT/\$PROJECT/Generated
-    -g, --glean-namespace <NAME>     The Glean namespace to use in generated code.
-    -m, --markdown <PATH>            Generate markdown documentation in provided directory.
-    -b, --build-date <TEXT>          Set a specific build date or disable build date generation with `0`.
-    -h, --help                       Display this help message.
+    -a, --allow-reserved               Allow reserved names.
+    -o, --output  <PATH>               Folder to place generated code in. Default: \$SOURCE_ROOT/\$PROJECT/Generated
+    -g, --glean-namespace <NAME>       The Glean namespace to use in generated code.
+    -m, --markdown <PATH>              Generate markdown documentation in provided directory.
+    -b, --build-date <TEXT>            Set a specific build date or disable build date generation with `0`.
+        --expire-by-version <INTEGER>  Expire metrics by version, with the provided major version.
+    -h, --help                         Display this help message.
 HEREDOC
 )
 
@@ -71,6 +72,7 @@ ALLOW_RESERVED=""
 GLEAN_NAMESPACE=Glean
 DOCS_DIRECTORY=""
 BUILD_DATE=""
+EXPIRE_VERSION=""
 declare -a YAML_FILES=()
 OUTPUT_DIR="${SOURCE_ROOT}/${PROJECT}/Generated"
 
@@ -94,6 +96,10 @@ while (( "$#" )); do
             ;;
         -b|--build-date)
             BUILD_DATE="--option build_date=$2"
+            shift 2
+            ;;
+        --expire-by-version)
+            EXPIRE_VERSION="--expire-by-version $2"
             shift 2
             ;;
         -h|--help)
@@ -170,6 +176,7 @@ PARSER_OUTPUT=$("${VENVDIR}"/bin/python -m glean_parser \
     -o "${OUTPUT_DIR}" \
     -s "glean_namespace=${GLEAN_NAMESPACE}" \
     $BUILD_DATE \
+    $EXPIRE_VERSION \
     $ALLOW_RESERVED \
     "${YAML_FILES[@]}" 2>&1) || { echo "$PARSER_OUTPUT"; echo "error: glean_parser failed. See errors above."; exit 1; }
 


### PR DESCRIPTION
Upgrades Glean to v51 and includes #11344 to bring them in sync.

[v50 was a major release](https://github.com/mozilla/glean/releases/tag/v50.0.0).
v51 dropped some deprecated functionality. We never deployed v50 on iOS, so we just skip the deprecated stuff and remove usage of them right away here.

cc @travis79 