### PR TITLE
Bump #11155 [v104]: Bump versionings for v104 soft freeze

### DIFF
--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -24,7 +24,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>103.0</string>
+	<string>104.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CredentialProvider/Info.plist
+++ b/CredentialProvider/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>103.0</string>
+	<string>104.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>MozDevelopmentTeam</key>

--- a/Extensions/NotificationService/Info.plist
+++ b/Extensions/NotificationService/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>103.0</string>
+	<string>104.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSExtension</key>

--- a/Extensions/ShareTo/Info.plist
+++ b/Extensions/ShareTo/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>103.0</string>
+	<string>104.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Extensions/Today/Info.plist
+++ b/Extensions/Today/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>103.0</string>
+	<string>104.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/WidgetKit/Info.plist
+++ b/WidgetKit/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>103.0</string>
+	<string>104.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>MozDevelopmentTeam</key>

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1373,10 +1373,10 @@ app:
     BITRISE_NIGHTLY_VERSION: '9000'
   - opts:
       is_expand: false
-    BITRISE_RELEASE_VERSION: '103.0'
+    BITRISE_RELEASE_VERSION: '104.0'
   - opts:
       is_expand: false
-    BITRISE_BETA_VERSION: '103.0'
+    BITRISE_BETA_VERSION: '104.0'
 
 meta:
   bitrise.io:
@@ -1388,7 +1388,7 @@ trigger_map:
   pipeline: pipeline_multiple_shards
 - push_branch: epic-branch/*
   pipeline: pipeline_multiple_shards
-- push_branch: v103.0
+- push_branch: v104.0
   workflow: SPM_Deploy_Prod_Beta
 - pull_request_target_branch: main
   pipeline: pipeline_multiple_shards


### PR DESCRIPTION
# #11155: v104 Soft Freeze Tasks

Following the [release checklist from the Wiki](https://github.com/mozilla-mobile/firefox-ios/wiki/Release-Checklist-(Devs)), this PR updates the necessary versionings for v104.0.