### PR TITLE
Refactor #11411 [v104] Fix github action to import strings

### DIFF
--- a/.github/workflows/import-strings.yml
+++ b/.github/workflows/import-strings.yml
@@ -5,12 +5,12 @@ on:
 
 jobs:
   build:
-    runs-on: macos-11
+    runs-on: macos-12
     strategy:
       max-parallel: 4
       matrix:
         python-version: [3.9]
-        xcode: ["13.0"]
+        xcode: ["13.4.1"]
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Fixes #11411 by updating macos and xcode used by the github action