### PR TITLE
Bugfix FXIOS-4634 [v104] - The "X" icon is not displayed after changing device orientation

### DIFF
--- a/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -108,7 +108,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel, CanRemoveQuickActio
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         if tableView.isEditing {
-            disableEditMode()
+            self.tableView.setEditing(false, animated: true)
         }
         super.viewWillTransition(to: size, with: coordinator)
     }


### PR DESCRIPTION
Issue #11413 
Jira [4634](https://mozilla-hub.atlassian.net/browse/FXIOS-4634)

- Disable only table view edit mode on viewWillTransition
