### PR TITLE
Bugfix #11433 [v105] - Reenable edit mode after orientation change

### DIFF
--- a/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -109,10 +109,8 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel, CanRemoveQuickActio
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
-        coordinator.animate(alongsideTransition: nil) { _ in
-            if self.state == .bookmarks(state: .inFolderEditMode) {
-                self.tableView.setEditing(true, animated: true)
-            }
+        if self.state == .bookmarks(state: .inFolderEditMode) {
+            self.tableView.setEditing(true, animated: true)
         }
     }
 

--- a/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -107,10 +107,13 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel, CanRemoveQuickActio
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        if tableView.isEditing {
-            self.tableView.setEditing(false, animated: true)
-        }
         super.viewWillTransition(to: size, with: coordinator)
+
+        coordinator.animate(alongsideTransition: nil) { _ in
+            if self.state == .bookmarks(state: .inFolderEditMode) {
+                self.tableView.setEditing(true, animated: true)
+            }
+        }
     }
 
     override func applyTheme() {


### PR DESCRIPTION
Jira [4645](https://mozilla-hub.atlassian.net/browse/FXIOS-4645)
As I have described in my comment in #11433, now the editing mode gets reenabled after device orientation change.
Review: @yoanarios 