### PR TITLE
Bugfix FXIOS-4637 [v104] Homepage displayed instead of visited page after restoring from background

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -356,7 +356,6 @@ class BrowserViewController: UIViewController {
         webViewContainerBackdrop.alpha = 1
         webViewContainer.alpha = 0
         urlBar.locationContainer.alpha = 0
-        homepageViewController?.view.alpha = 0
         topTabsViewController?.switchForegroundStatus(isInForeground: false)
         presentedViewController?.popoverPresentationController?.containerView?.alpha = 0
         presentedViewController?.view.alpha = 0
@@ -368,7 +367,6 @@ class BrowserViewController: UIViewController {
         UIView.animate(withDuration: 0.2, delay: 0, options: UIView.AnimationOptions(), animations: {
             self.webViewContainer.alpha = 1
             self.urlBar.locationContainer.alpha = 1
-            self.homepageViewController?.view.alpha = 1
             self.topTabsViewController?.switchForegroundStatus(isInForeground: true)
             self.presentedViewController?.popoverPresentationController?.containerView?.alpha = 1
             self.presentedViewController?.view.alpha = 1


### PR DESCRIPTION
# [FXIOS-4637](https://mozilla-hub.atlassian.net/browse/FXIOS-4637) https://github.com/mozilla-mobile/firefox-ios/issues/11416
When we were coming back from background, the homepage alpha was always set to 1. Since the homepage isn't necessarily nil anymore, this was an issue as homepage is always on top of the webview. So coming from backgroung, the homepage was showing when it shouldn't. The fix is that we already handle the homepage alpha in `showHomepage` and `hideHomepage` BVC methods, so we should let the logic there takes care of it. Note: I double checked that private mode was properly hiding information when we're going to background.