### PR TITLE
Refactor FXIOS-11469 [v105] Rename `migrateLoginsWithMetrics` function

### DIFF
--- a/Storage/Rust/RustLogins.swift
+++ b/Storage/Rust/RustLogins.swift
@@ -782,7 +782,7 @@ public class RustLogins {
             return
         }
 
-        let migrationSucceeded = migrateLoginsWithMetrics(
+        let migrationSucceeded = migrateLoginsFromSqlcipher(
             path: self.perFieldDatabasePath,
             newEncryptionKey: key,
             sqlcipherPath: self.sqlCipherDatabasePath,


### PR DESCRIPTION
Fixes #11469 by renaming the `migrateLoginsWithMetrics` to `migrateLoginsFromSqlcipher` to reflect the naming change in AS since this function no longer reports metrics.

Note: This won't pass until an AS release with [AS PR #5064](https://github.com/mozilla/application-services/pull/5064) is available.