### PR TITLE
Bugfix FXIOS-4673 [v105]: unnecessary argument parentheses

### DIFF
--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -1316,7 +1316,7 @@ open class SDRow: Sequence {
     // Allow iterating through the row.
     public func makeIterator() -> AnyIterator<Any> {
         let nextIndex = 0
-        return AnyIterator() {
+        return AnyIterator {
             if nextIndex < self.columnNames.count {
                 return self.getValue(nextIndex)
             }

--- a/Tests/UITests/TrackingProtectionTests.swift
+++ b/Tests/UITests/TrackingProtectionTests.swift
@@ -37,7 +37,7 @@ class TrackingProtectionTests: KIFTestCase, TabEventHandler {
         wait(for: [setup], timeout: 5)
 
         let clear = self.expectation(description: "clearing")
-        ContentBlocker.shared.clearSafelist() { clear.fulfill() }
+        ContentBlocker.shared.clearSafelist { clear.fulfill() }
         waitForExpectations(timeout: 15, handler: nil)
 
         register(self, forTabEvents: .didChangeContentBlocking)
@@ -160,7 +160,7 @@ class TrackingProtectionTests: KIFTestCase, TabEventHandler {
         let url = URL(string: "http://localhost")!
 
         let clear = self.expectation(description: "clearing")
-        ContentBlocker.shared.clearSafelist() { clear.fulfill() }
+        ContentBlocker.shared.clearSafelist { clear.fulfill() }
         waitForExpectations(timeout: 10, handler: nil)
         checkStrictTrackingProtection(isBlocking: true)
 
@@ -182,7 +182,7 @@ class TrackingProtectionTests: KIFTestCase, TabEventHandler {
         checkStrictTrackingProtection(isBlocking: false)
 
         let clear1 = self.expectation(description: "clearing")
-        ContentBlocker.shared.clearSafelist() { clear1.fulfill() }
+        ContentBlocker.shared.clearSafelist { clear1.fulfill() }
         waitForExpectations(timeout: 10, handler: nil)
         checkStrictTrackingProtection(isBlocking: true)
         openTPSetting()

--- a/ThirdParty/Deferred/Deferred/Deferred.swift
+++ b/ThirdParty/Deferred/Deferred/Deferred.swift
@@ -41,7 +41,7 @@ open class Deferred<T> {
             return (data.protectedValue!, blocks)
         }
         for (queue, block) in blocks {
-            queue.async() { block(filledValue) }
+            queue.async { block(filledValue) }
         }
     }
 
@@ -65,7 +65,7 @@ open class Deferred<T> {
             return data.protectedValue
         }
         if let value = maybeValue {
-            queue.async() { block(value) }
+            queue.async { block(value) }
         }
     }
 }

--- a/ThirdParty/Deferred/Deferred/ReadWriteLock.swift
+++ b/ThirdParty/Deferred/Deferred/ReadWriteLock.swift
@@ -20,7 +20,7 @@ public final class GCDReadWriteLock: ReadWriteLock {
 
     public func withReadLock<T>(block: () -> T) -> T {
         var result: T!
-        queue.sync() {
+        queue.sync {
             result = block()
         }
         return result


### PR DESCRIPTION
This PR removes unnecessary empty argument parentheses after function calls where trailing closures are used