### PR TITLE
Add #11329 [v105]: Toolbar CFR updates

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -1,4 +1,12 @@
 ---
+contextual-hint-feature:
+  description: "This set holds all features pertaining to the usage of contextual hints, whether it's to introduce new features or remind users of existing ones."
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    features-enabled:
+      type: json
+      description: This property provides a lookup table of whether specific context hints are enabled.
 general-app-features:
   description: The feature that contains feature flags for the entire application
   hasExposure: true
@@ -101,9 +109,9 @@ start-at-home-feature:
       type: string
       description: This property provides a default setting for the startAtHomeFeature
       enum:
-        - always
         - disabled
         - after-four-hours
+        - always
 tabTrayFeature:
   description: The tab tray screen that the user goes to when they open the tab tray.
   hasExposure: true

--- a/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -11,6 +11,7 @@ import UIKit
 /// Please add new features alphabetically.
 enum NimbusFeatureFlagID: String, CaseIterable {
     case bottomSearchBar
+    case contextualHintForToolbar
     case historyHighlights
     case historyGroups
     case inactiveTabs
@@ -77,7 +78,8 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
             return FlagKeys.CustomWallpaper
 
         // Cases where users do not have the option to manipulate a setting.
-        case .reportSiteIssue,
+        case .contextualHintForToolbar,
+                .reportSiteIssue,
                 .shakeToRestore,
                 .searchHighlights,
                 .jumpBackInSyncedTab:

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -536,7 +536,9 @@ class BrowserViewController: UIViewController {
     }
 
     private func prepareURLOnboardingContextualHint() {
-        guard contextHintVC.shouldPresentHint() else { return }
+        guard contextHintVC.shouldPresentHint(),
+              featureFlags.isFeatureEnabled(.contextualHintForToolbar, checking: .buildOnly)
+        else { return }
 
         contextHintVC.configure(
             anchor: urlBar,

--- a/Client/Frontend/Contextual Hint/ContextualHintViewModel.swift
+++ b/Client/Frontend/Contextual Hint/ContextualHintViewModel.swift
@@ -121,7 +121,7 @@ class ContextualHintViewModel {
         case .toolbarLocation:
             switch arrowDirection {
             case .up:
-                return CFRStrings.Toolbar.SearchBarPlacementForExistingUsers
+                return CFRStrings.Toolbar.SearchBarTopPlacement
             default:
                 return CFRStrings.Toolbar.SearchBarPlacementForNewUsers
             }

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -25,7 +25,7 @@ public struct Strings {
 // Used as a helper enum to keep track of what app version strings were last updated in. Updates
 // are considered .unknown unless the string's Key is updated, or of course a new string is introduced.
 private enum StringLastUpdatedAppVersion {
-    case v39, v96, v97, v98, v99, v100, v101, v102, v103, v104, v105
+    case v39, v96, v97, v98, v99, v100, v101, v102, v103, v104, v105, v106
 
     // Used for all cases before version 39.
     case unknown
@@ -183,8 +183,13 @@ extension String {
                 value: "Toolbar Settings",
                 comment: "Contextual hints are little popups that appear for the users informing them of new features. This one is a call to action for the popup describing search bar placement. It indicates a user can navigate to the settings page that allows them to customize the placement of the search bar.",
                 lastUpdated: .v98)
+            public static let SearchBarTopPlacement = MZLocalizedString(
+                "ContextualHints.Toolbar.Top.Description.v106",
+                tableName: "ToolbarLocation",
+                value: "Move the toolbar to the bottom in settings if that's more your style.",
+                comment: "Contextual hints are little popups that appear for the users informing them of new features. It indicates a user can navigate to the settings page that allows them to customize the placement of the search bar. ",
+                lastUpdated: .v106)
         }
-
     }
 }
 

--- a/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -31,6 +31,9 @@ final class NimbusFeatureFlagLayer {
         case .jumpBackInSyncedTab:
             return checkNimbusForJumpBackInSyncedTabFeature(using: nimbus)
 
+        case .contextualHintForToolbar:
+            return checkNimbusForContextualHintsFeature(for: featureID, from: nimbus)
+
         case .wallpapers:
             return checkNimbusForWallpapersFeature(using: nimbus)
 
@@ -111,6 +114,22 @@ final class NimbusFeatureFlagLayer {
 
     private func checkNimbusForJumpBackInSyncedTabFeature(using nimbus: FxNimbus) -> Bool {
         return nimbus.features.homescreenFeature.value().jumpBackInSyncedTab
+    }
+
+    private func checkNimbusForContextualHintsFeature(
+        for featureID: NimbusFeatureFlagID,
+        from nimbus: FxNimbus
+    ) -> Bool {
+        let config = nimbus.features.contextualHintFeature.value()
+        var nimbusID: ContextualHint
+
+        switch featureID {
+        case .contextualHintForToolbar: nimbusID = ContextualHint.toolbarContextualHint
+        default: return false
+        }
+
+        guard let status = config.featuresEnabled[nimbusID] else { return false }
+        return status
     }
 
     private func checkNimbusForWallpapersFeature(using nimbus: FxNimbus) -> Bool {

--- a/Tests/ClientTests/FeatureFlagManagerTests.swift
+++ b/Tests/ClientTests/FeatureFlagManagerTests.swift
@@ -71,7 +71,7 @@ class FeatureFlagManagerTests: XCTestCase, FeatureFlaggable {
     }
 
     func testDefaultNimbusCustomFlags() {
-        XCTAssertEqual(featureFlags.getCustomState(for: .searchBarPosition), SearchBarPosition.bottom)
+        XCTAssertEqual(featureFlags.getCustomState(for: .searchBarPosition), SearchBarPosition.top)
         XCTAssertEqual(featureFlags.getCustomState(for: .startAtHome), StartAtHomeSetting.afterFourHours)
     }
 
@@ -98,11 +98,13 @@ class FeatureFlagManagerTests: XCTestCase, FeatureFlaggable {
         mockProfile.prefs.clearAll()
         FeatureFlagsManager.shared.initializeDeveloperFeatures(with: mockProfile)
 
-        XCTAssertEqual(featureFlags.getCustomState(for: .searchBarPosition), SearchBarPosition.bottom)
-        mockProfile.prefs.setString(SearchBarPosition.top.rawValue,
-                                    forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        // Search Bar position
         XCTAssertEqual(featureFlags.getCustomState(for: .searchBarPosition), SearchBarPosition.top)
+        mockProfile.prefs.setString(SearchBarPosition.bottom.rawValue,
+                                    forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        XCTAssertEqual(featureFlags.getCustomState(for: .searchBarPosition), SearchBarPosition.bottom)
 
+        // StartAtHome
         XCTAssertEqual(featureFlags.getCustomState(for: .startAtHome), StartAtHomeSetting.afterFourHours)
         mockProfile.prefs.setString(StartAtHomeSetting.always.rawValue,
                                     forKey: PrefsKeys.FeatureFlags.StartAtHome)
@@ -119,9 +121,9 @@ class FeatureFlagManagerTests: XCTestCase, FeatureFlaggable {
 
     func testManagerInterfaceForUpdatingCustomFlags() {
         // Search Bar
-        XCTAssertEqual(featureFlags.getCustomState(for: .searchBarPosition), SearchBarPosition.bottom)
-        featureFlags.set(feature: .searchBarPosition, to: SearchBarPosition.top)
         XCTAssertEqual(featureFlags.getCustomState(for: .searchBarPosition), SearchBarPosition.top)
+        featureFlags.set(feature: .searchBarPosition, to: SearchBarPosition.bottom)
+        XCTAssertEqual(featureFlags.getCustomState(for: .searchBarPosition), SearchBarPosition.bottom)
 
         // StartAtHome
         XCTAssertEqual(featureFlags.getCustomState(for: .startAtHome), StartAtHomeSetting.afterFourHours)

--- a/Tests/ClientTests/SearchBarSettingsViewModelTests.swift
+++ b/Tests/ClientTests/SearchBarSettingsViewModelTests.swift
@@ -29,7 +29,7 @@ class SearchBarSettingsViewModelTests: XCTestCase {
     // MARK: Default
     func testDefaultSearchPosition() {
         let viewModel = createViewModel()
-        XCTAssertEqual(viewModel.searchBarPosition, .bottom)
+        XCTAssertEqual(viewModel.searchBarPosition, .top)
     }
 
     // MARK: Saved
@@ -97,7 +97,7 @@ class SearchBarSettingsViewModelTests: XCTestCase {
         let viewModel = createViewModel(notificationCenter: spyNotificationCenter)
         let searchBarPosition = viewModel.searchBarPosition
 
-        XCTAssertEqual(searchBarPosition, .bottom)
+        XCTAssertEqual(searchBarPosition, .top)
         XCTAssertNil(spyNotificationCenter.notificationNameSent)
         XCTAssertNil(spyNotificationCenter.notificationObjectSent)
     }

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -125,14 +125,14 @@ features:
             search-highlights: true
             position:
               is-position-feature-enabled: true
-              is-bottom: true
+              is-bottom: false
       - channel: beta
         value:
           awesome-bar:
             search-highlights: true
             position:
               is-position-feature-enabled: true
-              is-bottom: true
+              is-bottom: false
   homescreenFeature:
     description: The homescreen that the user goes to when they press home or new tab.
     variables:
@@ -256,6 +256,22 @@ features:
           {
             "inactive-tabs": true,
           }
+  contextual-hint-feature:
+    description: This set holds all features pertaining to the usage of contextual hints, whether it's to introduce new features or remind users of existing ones.
+    variables:
+      features-enabled:
+        description: This property provides a lookup table of whether specific context hints are enabled.
+        type: Map<ContextualHint, Boolean>
+        default: 
+        {
+          "toolbar-contextual-hint": true
+        }
+    defaults:
+      - channel: developer
+        value: {
+          "toolbar-contextual-hint": true
+        }
+
   messaging:
     description: >
       Configuration for the messaging system.
@@ -546,6 +562,12 @@ types:
       variants:
         inactive-tabs:
           description: Tabs that have been automatically closed for the user.
+    
+    ContextualHint:
+      description: The identifiers for a individual contextual hints.
+      variants:
+        toolbar-contextual-hint:
+          description: The contextual hint bubble that appears to indicate that the toolbar location is adjustable.
 
     SearchTermGroups:
       description: The identifiers for the different types of search term groups.


### PR DESCRIPTION
# #11329 | [FXIOS-4588](https://mozilla-hub.atlassian.net/browse/FXIOS-4588)

## Overview
This PR addresses updates on the toolbar CFR. It places the presentation of the contextual hint behind Nimbus's feature flagging system, and also has a copy update (the copy update is included in this PR).

## Details
This CFR, along with JumpBackIn and SyncedTabInJumpBackIn (In Progress), are now required to be placed behind a MR onboarding feature flag in Nimbus.  

## Testing
In Dev, the CFR is set to top by default. Setting to top by default for all release channels is a [task for a separate ticket.](https://mozilla-hub.atlassian.net/browse/FXIOS-4628) 

- Pull the branch
- Delete the app and do a fresh install
- Run run run run run run run run urn RUN!!!
- Observe

## Screenshots
<img width="435" alt="image" src="https://user-images.githubusercontent.com/36939381/182232323-ccc85665-4989-4c5b-97b8-0b7020c28771.png">
