### PR TITLE
Bugfix FXIOS-4689 [v105] Removing redundant return

### DIFF
--- a/Account/HawkHelper.swift
+++ b/Account/HawkHelper.swift
@@ -58,7 +58,7 @@ open class HawkHelper {
     }
 
     class func getSignatureFor(_ input: Data, key: Data) -> String {
-        return input.hmacSha256WithKey(key).base64EncodedString
+        input.hmacSha256WithKey(key).base64EncodedString
     }
 
     class func getRequestStringFor(_ request: URLRequest, timestampString: String, nonce: String, hash: String, extra: String) -> String {
@@ -131,11 +131,11 @@ open class HawkHelper {
     }
 
     class func escapeExtraHeaderAttribute(_ extra: String) -> String {
-        return extra.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
+        extra.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
     }
 
     class func escapeExtraString(_ extra: String) -> String {
-        return extra.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\n", with: "\\n")
+        extra.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\n", with: "\\n")
     }
 }
 

--- a/Account/KeyBundle.swift
+++ b/Account/KeyBundle.swift
@@ -12,8 +12,8 @@ open class KeyBundle: Hashable {
     public let hmacKey: Data
 
     open class func fromKSync(_ kSync: Data) -> KeyBundle {
-        return KeyBundle(encKey: kSync.subdata(in: 0..<KeyLength),
-                         hmacKey: kSync.subdata(in: KeyLength..<(2 * KeyLength)))
+        KeyBundle(encKey: kSync.subdata(in: 0..<KeyLength),
+                hmacKey: kSync.subdata(in: KeyLength..<(2 * KeyLength)))
     }
 
     open class func random() -> KeyBundle {
@@ -21,11 +21,11 @@ open class KeyBundle: Hashable {
         // on iOS is populated by the OS from kernel-level sources of entropy.
         // That should mean that we don't need to seed or initialize anything before calling
         // this. That is probably not true on (some versions of) OS X.
-        return KeyBundle(encKey: Bytes.generateRandomBytes(32), hmacKey: Bytes.generateRandomBytes(32))
+        KeyBundle(encKey: Bytes.generateRandomBytes(32), hmacKey: Bytes.generateRandomBytes(32))
     }
 
     open class var invalid: KeyBundle {
-        return KeyBundle(encKeyB64: "deadbeef", hmacKeyB64: "deadbeef")!
+        KeyBundle(encKeyB64: "deadbeef", hmacKeyB64: "deadbeef")!
     }
 
     public init?(encKeyB64: String, hmacKeyB64: String) {
@@ -133,7 +133,7 @@ open class KeyBundle: Hashable {
     }
 
     open func asPair() -> [String] {
-        return [self.encKey.base64EncodedString, self.hmacKey.base64EncodedString]
+        [self.encKey.base64EncodedString, self.hmacKey.base64EncodedString]
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -142,6 +142,6 @@ open class KeyBundle: Hashable {
     }
 
     public static func == (lhs: KeyBundle, rhs: KeyBundle) -> Bool {
-        return lhs.encKey == rhs.encKey && lhs.hmacKey == rhs.hmacKey
+        lhs.encKey == rhs.encKey && lhs.hmacKey == rhs.hmacKey
     }
 }

--- a/Account/SyncAuthState.swift
+++ b/Account/SyncAuthState.swift
@@ -44,18 +44,18 @@ public struct RemoteError {
     let info: String?
 
     var isUpgradeRequired: Bool {
-        return errno == FxAccountRemoteError.EndpointIsNoLongerSupported
-            || errno == FxAccountRemoteError.IncorrectLoginMethodForThisAccount
-            || errno == FxAccountRemoteError.IncorrectKeyRetrievalMethodForThisAccount
-            || errno == FxAccountRemoteError.IncorrectAPIVersionForThisAccount
+        errno == FxAccountRemoteError.EndpointIsNoLongerSupported
+                || errno == FxAccountRemoteError.IncorrectLoginMethodForThisAccount
+                || errno == FxAccountRemoteError.IncorrectKeyRetrievalMethodForThisAccount
+                || errno == FxAccountRemoteError.IncorrectAPIVersionForThisAccount
     }
 
     var isInvalidAuthentication: Bool {
-        return code == 401
+        code == 401
     }
 
     var isUnverified: Bool {
-        return errno == FxAccountRemoteError.AttemptToOperateOnAnUnverifiedAccount
+        errno == FxAccountRemoteError.AttemptToOperateOnAnUnverifiedAccount
     }
 }
 
@@ -94,7 +94,7 @@ public func syncAuthStateCachefromJSON(_ json: JSON) -> SyncAuthStateCache? {
 
 extension SyncAuthStateCache: JSONLiteralConvertible {
     public func asJSON() -> JSON {
-        return JSON([
+        JSON([
             "version": CurrentSyncAuthStateCacheVersion,
             "token": token.asJSON(),
             "forKey": forKey.hexEncodedString,

--- a/Account/TokenServerClient.swift
+++ b/Account/TokenServerClient.swift
@@ -25,8 +25,8 @@ public struct TokenServerToken {
      * Return true if this token points to the same place as the other token.
      */
     public func sameDestination(_ other: TokenServerToken) -> Bool {
-        return self.uid == other.uid &&
-               self.api_endpoint == other.api_endpoint
+        self.uid == other.uid &&
+                self.api_endpoint == other.api_endpoint
     }
 
     public static func fromJSON(_ json: JSON) -> TokenServerToken? {

--- a/Client/AdjustHelper.swift
+++ b/Client/AdjustHelper.swift
@@ -61,12 +61,12 @@ final class AdjustHelper: FeatureFlaggable {
     /// Return true if Adjust should be enabled. If the user has disabled the Send Anonymous Usage Data then we only do one ping
     /// to get the attribution and turn it off (i.e. we only enable it if we have not seen the attribution data yet).
     private var shouldEnable: Bool {
-        return shouldTrackRetention || !hasAttribution
+        shouldTrackRetention || !hasAttribution
     }
 
     /// Return true if retention (session) tracking should be enabled. This follows the Send Anonymous Usage Data setting.
     private var shouldTrackRetention: Bool {
-        return profile.prefs.boolForKey(AppConstants.PrefSendUsageData) ?? true
+        profile.prefs.boolForKey(AppConstants.PrefSendUsageData) ?? true
     }
 
     // MARK: - UserDefaults

--- a/Client/Application/AppContainer.swift
+++ b/Client/Application/AppContainer.swift
@@ -42,24 +42,24 @@ class AppContainer: ServiceProvider {
     /// Prepares the container by registering all services for the app session.
     /// - Returns: A bootstrapped `DependencyContainer`.
     private func bootstrapContainer() -> DependencyContainer {
-        return DependencyContainer { container in
+        DependencyContainer { container in
             do {
                 unowned let container = container
 
                 container.register(.eagerSingleton) {
                     BrowserProfile(
-                        localName: "profile",
-                        syncDelegate: UIApplication.shared.syncDelegate) as Profile
+                            localName: "profile",
+                            syncDelegate: UIApplication.shared.syncDelegate) as Profile
                 }
 
                 /// TabManager can remain a singleton until we support multiple scenes.
                 container.register(.singleton) {
                     TabManager(
-                        profile: try container.resolve(),
-                        imageStore: DiskImageStore(
-                            files: (try container.resolve() as Profile).files,
-                            namespace: "TabManagerScreenshots",
-                            quality: UIConstants.ScreenshotQuality))
+                            profile: try container.resolve(),
+                            imageStore: DiskImageStore(
+                                    files: (try container.resolve() as Profile).files,
+                                    namespace: "TabManagerScreenshots",
+                                    quality: UIConstants.ScreenshotQuality))
                 }
 
                 try container.bootstrap()

--- a/Client/Application/AppDelegate+SyncSentTabs.swift
+++ b/Client/Application/AppDelegate+SyncSentTabs.swift
@@ -13,7 +13,7 @@ private let log = Logger.browserLogger
 
 extension UIApplication {
     var syncDelegate: SyncDelegate {
-        return AppSyncDelegate(app: self)
+        AppSyncDelegate(app: self)
     }
 }
 

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -188,7 +188,7 @@ extension AppDelegate {
     // Orientation lock for views that use new modal presenter
     func application(_ application: UIApplication,
                      supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
-        return self.orientationLock
+        self.orientationLock
     }
 
     func application(_ application: UIApplication,

--- a/Client/Application/DebugSettingsBundleOptions.swift
+++ b/Client/Application/DebugSettingsBundleOptions.swift
@@ -8,11 +8,11 @@ struct DebugSettingsBundleOptions {
 
     /// Save logs to `~/Documents` folder
     static var saveLogsToDocuments: Bool {
-        return UserDefaults.standard.bool(forKey: "SettingsBundleSaveLogsToDocuments")
+        UserDefaults.standard.bool(forKey: "SettingsBundleSaveLogsToDocuments")
     }
 
     /// Don't restore tabs on app launch
     static var skipSessionRestore: Bool {
-        return UserDefaults.standard.bool(forKey: "SettingsBundleSkipSessionRestore")
+        UserDefaults.standard.bool(forKey: "SettingsBundleSkipSessionRestore")
     }
 }

--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -67,7 +67,10 @@ enum DeepLink {
 extension URLComponents {
     // Return the first query parameter that matches
     func valueForQuery(_ param: String) -> String? {
-        return self.queryItems?.first { $0.name == param }?.value
+        self.queryItems?.first {
+                    $0.name == param
+                }?
+                .value
     }
 }
 

--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -21,7 +21,7 @@ enum ShortcutType: String {
     }
 
     var type: String {
-        return Bundle.main.bundleIdentifier! + ".\(self.rawValue)"
+        Bundle.main.bundleIdentifier! + ".\(self.rawValue)"
     }
 }
 

--- a/Client/Application/UITestAppDelegate.swift
+++ b/Client/Application/UITestAppDelegate.swift
@@ -12,7 +12,9 @@ private let log = Logger.browserLogger
 
 class UITestAppDelegate: AppDelegate, FeatureFlaggable {
 
-    lazy var dirForTestProfile = { return "\(self.appRootDir())/profile.testProfile" }()
+    lazy var dirForTestProfile = {
+        "\(self.appRootDir())/profile.testProfile"
+    }()
 
     private var internalProfile: Profile?
 

--- a/Client/Application/WebServer.swift
+++ b/Client/Application/WebServer.swift
@@ -17,13 +17,13 @@ class WebServer: WebServerProtocol {
     static let WebServerSharedInstance = WebServer()
 
     class var sharedInstance: WebServer {
-        return WebServerSharedInstance
+        WebServerSharedInstance
     }
 
     let server: GCDWebServer = GCDWebServer()
 
     var base: String {
-        return "http://localhost:\(server.port)"
+        "http://localhost:\(server.port)"
     }
 
     /// The private credentials for accessing resources on this Web server.
@@ -84,10 +84,10 @@ class WebServer: WebServerProtocol {
 
     /// Return a full url, as a string, for a resource in a module. No check is done to find out if the resource actually exist.
     func URLForResource(_ resource: String, module: String) -> String {
-        return "\(base)/\(module)/\(resource)"
+        "\(base)/\(module)/\(resource)"
     }
 
     func baseReaderModeURL() -> String {
-        return WebServer.sharedInstance.URLForResource("page", module: "reader-mode")
+        WebServer.sharedInstance.URLForResource("page", module: "reader-mode")
     }
 }

--- a/Client/BottomSheet/BottomSheetViewController.swift
+++ b/Client/BottomSheet/BottomSheetViewController.swift
@@ -23,10 +23,10 @@ class BottomSheetViewController: UIViewController, NotificationThemeable {
     var delegate: BottomSheetDelegate?
     private var currentState: BottomSheetState = .none
     private var isLandscape: Bool {
-        return UIWindow.isLandscape
+        UIWindow.isLandscape
     }
     private var orientationBasedHeight: CGFloat {
-        return isLandscape ? DeviceInfo.screenSizeOrientationIndependent().width : DeviceInfo.screenSizeOrientationIndependent().height
+        isLandscape ? DeviceInfo.screenSizeOrientationIndependent().width : DeviceInfo.screenSizeOrientationIndependent().height
     }
     // shows how much bottom sheet should be visible
     // 1 = full, 0.5 = half, 0 = hidden
@@ -41,19 +41,19 @@ class BottomSheetViewController: UIViewController, NotificationThemeable {
         return specifier
     }
     private var navHeight: CGFloat {
-        return navigationController?.navigationBar.frame.height ?? 0
+        navigationController?.navigationBar.frame.height ?? 0
     }
     private var fullHeight: CGFloat {
-        return orientationBasedHeight - navHeight
+        orientationBasedHeight - navHeight
     }
     private var partialHeight: CGFloat {
-        return fullHeight * heightSpecifier
+        fullHeight * heightSpecifier
     }
     private var maxY: CGFloat {
-        return fullHeight - partialHeight
+        fullHeight - partialHeight
     }
     private var minY: CGFloat {
-        return orientationBasedHeight
+        orientationBasedHeight
     }
     private var endedYVal: CGFloat = 0
     private var endedTranslationYVal: CGFloat = 0

--- a/Client/CalendarExtensions.swift
+++ b/Client/CalendarExtensions.swift
@@ -15,6 +15,6 @@ extension Calendar {
     }
 
     func add(numberOfDays: Int, to date: Date) -> Date? {
-        return self.date(byAdding: .day, value: numberOfDays, to: date)
+        self.date(byAdding: .day, value: numberOfDays, to: date)
     }
 }

--- a/Client/Experiments/Experiments.swift
+++ b/Client/Experiments/Experiments.swift
@@ -101,7 +101,7 @@ enum Experiments {
     }
 
     static func getLocalExperimentData(storage: UserDefaults = .standard) -> String? {
-        return storage.string(forKey: NIMBUS_LOCAL_DATA_KEY)
+        storage.string(forKey: NIMBUS_LOCAL_DATA_KEY)
     }
 
     static var dbPath: String? {

--- a/Client/Experiments/Messaging/GleanPlumbContextProvider.swift
+++ b/Client/Experiments/Messaging/GleanPlumbContextProvider.swift
@@ -20,7 +20,7 @@ class GleanPlumbContextProvider {
     }
 
     private var isDefaultBrowser: Bool {
-        return UserDefaults.standard.bool(forKey: RatingPromptManager.UserDefaultsKey.keyIsBrowserDefault.rawValue)
+        UserDefaults.standard.bool(forKey: RatingPromptManager.UserDefaultsKey.keyIsBrowserDefault.rawValue)
     }
 
     /// JEXLs are more accurately evaluated when given certain details about the app on device.
@@ -28,7 +28,7 @@ class GleanPlumbContextProvider {
     /// - https://experimenter.info/mobile-messaging/#list-of-attributes
     /// We should pass as much device context as possible.
     func createAdditionalDeviceContext() -> [String: Any] {
-        return [ContextKey.todayDate.rawValue: todaysDate,
-                ContextKey.isDefaultBrowser.rawValue: isDefaultBrowser]
+        [ContextKey.todayDate.rawValue: todaysDate,
+         ContextKey.isDefaultBrowser.rawValue: isDefaultBrowser]
     }
 }

--- a/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -11,7 +11,7 @@ protocol GleanPlumbMessageManagable { }
 
 extension GleanPlumbMessageManagable {
     var messagingManager: GleanPlumbMessageManager {
-        return GleanPlumbMessageManager.shared
+        GleanPlumbMessageManager.shared
     }
 }
 
@@ -82,7 +82,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
     func onStartup() { }
 
     func hasMessage(for surface: MessageSurfaceId) -> Bool {
-        return getNextMessage(for: surface) != nil
+        getNextMessage(for: surface) != nil
     }
 
     /// Returns the next valid and triggered message for the surface, if one exists.

--- a/Client/Experiments/Messaging/GleanPlumbMessageStore.swift
+++ b/Client/Experiments/Messaging/GleanPlumbMessageStore.swift
@@ -103,7 +103,7 @@ class GleanPlumbMessageStore: GleanPlumbMessageStoreProtocol {
     /// Collisions can happen if a message key string and a string elsewhere in the codebase happen to be the same.
     /// We prevent it by prepending `GleanPlumb.Messages.` to the message key.
     private func generateKey(from key: String) -> String {
-        return "\(GleanPlumbMessageStore.rootKey)\(key)"
+        "\(GleanPlumbMessageStore.rootKey)\(key)"
     }
 
     /// Persist a message's metadata.

--- a/Client/Experiments/Settings/ExperimentsBranchesViewController.swift
+++ b/Client/Experiments/Settings/ExperimentsBranchesViewController.swift
@@ -32,7 +32,7 @@ class ExperimentsBranchesViewController: UIViewController {
 
 extension ExperimentsBranchesViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return experiment.branches.count
+        experiment.branches.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/Client/Experiments/Settings/ExperimentsViewController.swift
+++ b/Client/Experiments/Settings/ExperimentsViewController.swift
@@ -61,7 +61,7 @@ class ExperimentsViewController: UIViewController {
 
 extension ExperimentsViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return availableExperiments.count
+        availableExperiments.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/Client/Experiments/UserResearch.swift
+++ b/Client/Experiments/UserResearch.swift
@@ -12,6 +12,6 @@ protocol UserResearch {
 
 extension UserResearch {
     var experiments: NimbusApi {
-        return Experiments.shared
+        Experiments.shared
     }
 }

--- a/Client/Extensions/GeometryExtensions.swift
+++ b/Client/Extensions/GeometryExtensions.swift
@@ -7,7 +7,7 @@ import UIKit
 extension CGRect {
     var center: CGPoint {
         get {
-            return CGPoint(x: size.width / 2, y: size.height / 2)
+            CGPoint(x: size.width / 2, y: size.height / 2)
         }
         set {
             self.origin = CGPoint(x: newValue.x - size.width / 2, y: newValue.y - size.height / 2)

--- a/Client/Extensions/SnapKitExtensions.swift
+++ b/Client/Extensions/SnapKitExtensions.swift
@@ -8,6 +8,6 @@ import SnapKit
 extension UIView {
 
     var safeArea: ConstraintBasicAttributesDSL {
-        return self.safeAreaLayoutGuide.snp
+        self.safeAreaLayoutGuide.snp
     }
 }

--- a/Client/Extensions/UIImageViewExtensions.swift
+++ b/Client/Extensions/UIImageViewExtensions.swift
@@ -18,7 +18,7 @@ extension UIColor {
     }
 
     func image(_ size: CGSize = CGSize(width: 1, height: 1)) -> UIImage {
-        return UIGraphicsImageRenderer(size: size).image { rendererContext in
+        UIGraphicsImageRenderer(size: size).image { rendererContext in
             self.setFill()
             rendererContext.fill(CGRect(origin: .zero, size: size))
         }

--- a/Client/Extensions/UIPasteboardExtensions.swift
+++ b/Client/Extensions/UIPasteboardExtensions.swift
@@ -18,12 +18,14 @@ extension UIPasteboard {
     }
 
     fileprivate func imageTypeKey(_ isGIF: Bool) -> String {
-        return (isGIF ? kUTTypeGIF : kUTTypePNG) as String
+        (isGIF ? kUTTypeGIF : kUTTypePNG) as String
     }
 
     private var syncURL: URL? {
-        return UIPasteboard.general.string.flatMap {
-            guard let url = URL(string: $0), url.isWebPage() else { return nil }
+        UIPasteboard.general.string.flatMap {
+            guard let url = URL(string: $0), url.isWebPage() else {
+                return nil
+            }
 
             return url
         }
@@ -33,8 +35,8 @@ extension UIPasteboard {
     /// When iCloud pasteboards are enabled, the usually fast, synchronous calls
     /// become slow and synchronous causing very slow start up times.
     func asyncString() -> Deferred<Maybe<String?>> {
-        return fetchAsync {
-            return UIPasteboard.general.string
+        fetchAsync {
+            UIPasteboard.general.string
         }
     }
 
@@ -43,8 +45,8 @@ extension UIPasteboard {
     /// we already use; but use optionals instead of errorTypes, because not having a URL
     /// on the clipboard isn't an error.
     func asyncURL() -> Deferred<Maybe<URL?>> {
-        return fetchAsync {
-            return self.syncURL
+        fetchAsync {
+            self.syncURL
         }
     }
 

--- a/Client/Extensions/UIViewExtensions.swift
+++ b/Client/Extensions/UIViewExtensions.swift
@@ -144,6 +144,6 @@ protocol CardTheme {
 
 extension CardTheme {
     var theme: BuiltinThemeName {
-        return BuiltinThemeName(rawValue: LegacyThemeManager.instance.current.name) ?? .normal
+        BuiltinThemeName(rawValue: LegacyThemeManager.instance.current.name) ?? .normal
     }
 }

--- a/Client/FeatureFlags/FeatureFlagsManager.swift
+++ b/Client/FeatureFlags/FeatureFlagsManager.swift
@@ -9,7 +9,7 @@ protocol FeatureFlaggable { }
 
 extension FeatureFlaggable {
     var featureFlags: FeatureFlagsManager {
-        return FeatureFlagsManager.shared
+        FeatureFlagsManager.shared
     }
 }
 

--- a/Client/Frontend/Accessors/HomePageAccessors.swift
+++ b/Client/Frontend/Accessors/HomePageAccessors.swift
@@ -20,7 +20,7 @@ class NewTabHomePageAccessors {
     }
 
     static func getDefaultHomePageString(_ prefs: Prefs) -> String? {
-        return prefs.stringForKey(HomePageConstants.DefaultHomePageURLPrefKey)
+        prefs.stringForKey(HomePageConstants.DefaultHomePageURLPrefKey)
     }
 }
 

--- a/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
+++ b/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
@@ -43,6 +43,6 @@ class AppAuthenticator {
     }
 
     static func canAuthenticateDeviceOwner() -> Bool {
-        return LAContext().canEvaluatePolicy(.deviceOwnerAuthentication, error: nil)
+        LAContext().canEvaluatePolicy(.deviceOwnerAuthentication, error: nil)
     }
 }

--- a/Client/Frontend/Browser/BackForwardListAnimator.swift
+++ b/Client/Frontend/Browser/BackForwardListAnimator.swift
@@ -26,7 +26,7 @@ class BackForwardListAnimator: NSObject, UIViewControllerAnimatedTransitioning {
     }
 
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
-        return animationDuration
+        animationDuration
     }
 }
 

--- a/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -224,7 +224,7 @@ class BackForwardListViewController: UIViewController, UITableViewDataSource, UI
 
     // MARK: - Table view
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return listData.count
+        listData.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -260,6 +260,6 @@ class BackForwardListViewController: UIViewController, UITableViewDataSource, UI
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt  indexPath: IndexPath) -> CGFloat {
-        return BackForwardViewUX.RowHeight
+        BackForwardViewUX.RowHeight
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -113,7 +113,7 @@ class BrowserViewController: UIViewController {
     private var topTouchArea: UIButton!
 
     var topTabsVisible: Bool {
-        return topTabsViewController != nil
+        topTabsViewController != nil
     }
     // Backdrop used for displaying greyed background for private tabs
     var webViewContainerBackdrop: UIView!
@@ -136,7 +136,7 @@ class BrowserViewController: UIViewController {
     var typedNavigation = [WKNavigation: VisitType]()
     var toolbar = TabToolbar()
     var navigationToolbar: TabToolbarProtocol {
-        return toolbar.isHidden ? urlBar : toolbar
+        toolbar.isHidden ? urlBar : toolbar
     }
 
     var topTabsViewController: TopTabsViewController?
@@ -184,7 +184,7 @@ class BrowserViewController: UIViewController {
     }
 
     override var prefersStatusBarHidden: Bool {
-        return false
+        false
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
@@ -237,11 +237,11 @@ class BrowserViewController: UIViewController {
     }
 
     func shouldShowToolbarForTraitCollection(_ previousTraitCollection: UITraitCollection) -> Bool {
-        return previousTraitCollection.verticalSizeClass != .compact && previousTraitCollection.horizontalSizeClass != .regular
+        previousTraitCollection.verticalSizeClass != .compact && previousTraitCollection.horizontalSizeClass != .regular
     }
 
     func shouldShowTopTabsForTraitCollection(_ newTraitCollection: UITraitCollection) -> Bool {
-        return newTraitCollection.verticalSizeClass == .regular && newTraitCollection.horizontalSizeClass == .regular
+        newTraitCollection.verticalSizeClass == .regular && newTraitCollection.horizontalSizeClass == .regular
     }
 
     fileprivate func constraintsForLibraryDrawerView(_ make: SnapKit.ConstraintMaker) {
@@ -808,7 +808,7 @@ class BrowserViewController: UIViewController {
     var displayedRestoreTabsAlert = false
 
     fileprivate func crashedLastLaunch() -> Bool {
-        return SentryIntegration.shared.crashedLastLaunch
+        SentryIntegration.shared.crashedLastLaunch
     }
 
     fileprivate func showRestoreTabsAlert() {
@@ -1388,7 +1388,7 @@ class BrowserViewController: UIViewController {
     }
 
     private func isShowingJSPromptAlert() -> Bool {
-        return navigationController?.topViewController?.presentedViewController as? JSPromptAlertController != nil
+        navigationController?.topViewController?.presentedViewController as? JSPromptAlertController != nil
     }
 
     func presentActivityViewController(_ url: URL, tab: Tab? = nil, sourceView: UIView?, sourceRect: CGRect, arrowDirection: UIPopoverArrowDirection) {
@@ -2076,7 +2076,7 @@ extension BrowserViewController: UIAdaptivePresentationControllerDelegate {
     // Returning None here makes sure that the Popover is actually presented as a Popover and
     // not as a full-screen modal, which is the default on compact device classes.
     func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
-        return .none
+        .none
     }
 }
 
@@ -2627,7 +2627,7 @@ extension BrowserViewController {
 
 extension BrowserViewController: BrowserBarViewDelegate {
     var inOverlayMode: Bool {
-        return urlBar.inOverlayMode
+        urlBar.inOverlayMode
     }
 
     func leaveOverlayMode(didCancel cancel: Bool) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+UIDropInteractionDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+UIDropInteractionDelegate.swift
@@ -16,7 +16,7 @@ extension BrowserViewController: UIDropInteractionDelegate {
     }
 
     func dropInteraction(_ interaction: UIDropInteraction, sessionDidUpdate session: UIDropSession) -> UIDropProposal {
-        return UIDropProposal(operation: .copy)
+        UIDropProposal(operation: .copy)
     }
 
     func dropInteraction(_ interaction: UIDropInteraction, performDrop session: UIDropSession) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -224,7 +224,9 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBarLocationAccessibilityActions(_ urlBar: URLBarView) -> [UIAccessibilityCustomAction]? {
-        return locationActionsForURLBar(urlBar).map { $0.accessibilityCustomAction }
+        locationActionsForURLBar(urlBar).map {
+            $0.accessibilityCustomAction
+        }
     }
 
     func urlBar(_ urlBar: URLBarView, didRestoreText text: String) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -58,7 +58,7 @@ extension BrowserViewController: WKUIDelegate {
 
     fileprivate func shouldDisplayJSAlertForWebView(_ webView: WKWebView) -> Bool {
         // Only display a JS Alert if we are selected and there isn't anything being shown
-        return ((tabManager.selectedTab == nil ? false : tabManager.selectedTab!.webView == webView)) && (self.presentedViewController == nil)
+        ((tabManager.selectedTab == nil ? false : tabManager.selectedTab!.webView == webView)) && (self.presentedViewController == nil)
     }
 
     func webView(_ webView: WKWebView, runJavaScriptAlertPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping () -> Void) {

--- a/Client/Frontend/Browser/DefaultSearchPrefs.swift
+++ b/Client/Frontend/Browser/DefaultSearchPrefs.swift
@@ -78,14 +78,14 @@ final class DefaultSearchPrefs {
      Create a list of these and return the last one. The globalDefault acts as the fallback in case the list is empty.
      */
     public func searchDefault(for possibleLocales: [String], and region: String) -> String {
-        return possibleLocales
-            .compactMap {
-                locales?[$0] as? [String: Any]
-            }
-            .reduce(globalDefaultEngine) {
-                (defaultEngine, localeJSON) -> String in
-                let inner = localeJSON[region] as? [String: Any]
-                return inner?["searchDefault"] as? String ?? defaultEngine
-        }
+        possibleLocales
+                .compactMap {
+                    locales?[$0] as? [String: Any]
+                }
+                .reduce(globalDefaultEngine) {
+                    (defaultEngine, localeJSON) -> String in
+                    let inner = localeJSON[region] as? [String: Any]
+                    return inner?["searchDefault"] as? String ?? defaultEngine
+                }
     }
 }

--- a/Client/Frontend/Browser/DownloadQueue.swift
+++ b/Client/Frontend/Browser/DownloadQueue.swift
@@ -61,7 +61,7 @@ class HTTPDownload: Download {
     let request: URLRequest
 
     var state: URLSessionTask.State {
-        return task?.state ?? .suspended
+        task?.state ?? .suspended
     }
 
     fileprivate(set) var session: URLSession?
@@ -203,7 +203,7 @@ class DownloadQueue {
     var delegate: DownloadQueueDelegate?
 
     var isEmpty: Bool {
-        return downloads.isEmpty
+        downloads.isEmpty
     }
 
     fileprivate var combinedBytesDownloaded: Int64 = 0

--- a/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
+++ b/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
@@ -140,7 +140,7 @@ class EnhancedTrackingProtectionMenuVC: UIViewController {
     var asPopover: Bool = false
 
     private var toggleContainerShouldBeHidden: Bool {
-        return !viewModel.globalETPIsEnabled
+        !viewModel.globalETPIsEnabled
     }
 
     private var protectionViewTopConstraint: NSLayoutConstraint?

--- a/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVM.swift
+++ b/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVM.swift
@@ -14,7 +14,7 @@ class EnhancedTrackingProtectionMenuVM {
     var onOpenSettingsTapped: (() -> Void)?
 
     var websiteTitle: String {
-        return tab.url?.baseDomain ?? ""
+        tab.url?.baseDomain ?? ""
     }
 
     var favIcon: URL? {
@@ -23,7 +23,7 @@ class EnhancedTrackingProtectionMenuVM {
     }
 
     var connectionStatusString: String {
-        return connectionSecure ? .ProtectionStatusSecure : .ProtectionStatusNotSecure
+        connectionSecure ? .ProtectionStatusSecure : .ProtectionStatusNotSecure
     }
 
     var connectionStatusImage: UIImage {
@@ -33,7 +33,7 @@ class EnhancedTrackingProtectionMenuVM {
     }
 
     var connectionSecure: Bool {
-        return tab.webView?.hasOnlySecureContent ?? false
+        tab.webView?.hasOnlySecureContent ?? false
     }
 
     var isSiteETPEnabled: Bool {
@@ -46,7 +46,7 @@ class EnhancedTrackingProtectionMenuVM {
     }
 
     var globalETPIsEnabled: Bool {
-        return FirefoxTabContentBlocker.isTrackingProtectionEnabled(prefs: profile.prefs)
+        FirefoxTabContentBlocker.isTrackingProtectionEnabled(prefs: profile.prefs)
     }
 
     // MARK: - Initializers

--- a/Client/Frontend/Browser/FindInPageBar.swift
+++ b/Client/Frontend/Browser/FindInPageBar.swift
@@ -54,7 +54,7 @@ class FindInPageBar: UIView {
 
     var text: String? {
         get {
-            return searchText.text
+            searchText.text
         }
 
         set {
@@ -183,7 +183,7 @@ class FindInPageBar: UIView {
     }
 
     static var retrieveSavedText: String? {
-        return UserDefaults.standard.object(forKey: FindInPageBar.savedTextKey) as? String
+        UserDefaults.standard.object(forKey: FindInPageBar.savedTextKey) as? String
     }
 }
 

--- a/Client/Frontend/Browser/FirefoxTabContentBlocker.swift
+++ b/Client/Frontend/Browser/FirefoxTabContentBlocker.swift
@@ -30,7 +30,7 @@ class FirefoxTabContentBlocker: TabContentBlocker, TabContentScript {
     let userPrefs: Prefs
 
     class func name() -> String {
-        return "TrackingProtectionStats"
+        "TrackingProtectionStats"
     }
 
     var isUserEnabled: Bool? {
@@ -51,11 +51,11 @@ class FirefoxTabContentBlocker: TabContentBlocker, TabContentScript {
     }
 
     var isEnabledInPref: Bool {
-        return userPrefs.boolForKey(ContentBlockingConfig.Prefs.EnabledKey) ?? ContentBlockingConfig.Defaults.NormalBrowsing
+        userPrefs.boolForKey(ContentBlockingConfig.Prefs.EnabledKey) ?? ContentBlockingConfig.Defaults.NormalBrowsing
     }
 
     var blockingStrengthPref: BlockingStrength {
-        return userPrefs.stringForKey(ContentBlockingConfig.Prefs.StrengthKey).flatMap(BlockingStrength.init) ?? .basic
+        userPrefs.stringForKey(ContentBlockingConfig.Prefs.StrengthKey).flatMap(BlockingStrength.init) ?? .basic
     }
 
     init(tab: ContentBlockerTab, prefs: Prefs) {
@@ -78,7 +78,7 @@ class FirefoxTabContentBlocker: TabContentBlocker, TabContentScript {
     }
 
     override func currentlyEnabledLists() -> [BlocklistFileName] {
-        return BlocklistFileName.listsForMode(strict: blockingStrengthPref == .strict)
+        BlocklistFileName.listsForMode(strict: blockingStrengthPref == .strict)
     }
 
     override func notifyContentBlockingChanged() {
@@ -101,7 +101,7 @@ extension FirefoxTabContentBlocker {
     }
 
     static func isTrackingProtectionEnabled(prefs: Prefs) -> Bool {
-        return prefs.boolForKey(ContentBlockingConfig.Prefs.EnabledKey) ?? ContentBlockingConfig.Defaults.NormalBrowsing
+        prefs.boolForKey(ContentBlockingConfig.Prefs.EnabledKey) ?? ContentBlockingConfig.Defaults.NormalBrowsing
     }
 
     static func toggleTrackingProtectionEnabled(prefs: Prefs) {

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -52,7 +52,7 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
     var tabToFocus: Tab?
 
     override var canBecomeFirstResponder: Bool {
-        return true
+        true
     }
 
     fileprivate lazy var emptyPrivateTabsView: EmptyPrivateTabsView = {
@@ -69,7 +69,7 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
     }()
 
     var numberOfColumns: Int {
-        return tabLayoutDelegate.numberOfColumns
+        tabLayoutDelegate.numberOfColumns
     }
 
     // MARK: - Inits
@@ -264,7 +264,7 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
     }
 
     fileprivate func privateTabsAreEmpty() -> Bool {
-        return tabDisplayManager.isPrivate && tabManager.privateTabs.isEmpty
+        tabDisplayManager.isPrivate && tabManager.privateTabs.isEmpty
     }
 
     func openNewTab(_ request: URLRequest? = nil, isPrivate: Bool) {
@@ -428,7 +428,7 @@ extension GridTabViewController: UIScrollViewAccessibilityDelegate {
 
         let cells = visibleCells.map { self.collectionView.indexPath(for: $0)! }
         let indexPaths = cells.sorted { (a: IndexPath, b: IndexPath) -> Bool in
-            return a.section < b.section || (a.section == b.section && a.row < b.row)
+            a.section < b.section || (a.section == b.section && a.row < b.row)
         }
 
         guard !indexPaths.isEmpty else {
@@ -461,7 +461,7 @@ extension GridTabViewController: SwipeAnimatorDelegate {
 
     // Disable swipe delete while drag reordering
     func swipeAnimatorIsAnimateAwayEnabled(_ animator: SwipeAnimator) -> Bool {
-        return !tabDisplayManager.isDragging
+        !tabDisplayManager.isDragging
     }
 }
 
@@ -480,7 +480,7 @@ extension GridTabViewController: TabPeekDelegate {
     }
 
     func tabPeekDidAddToReadingList(_ tab: Tab) -> ReadingListItem? {
-        return delegate?.tabTrayDidAddToReadingList(tab)
+        delegate?.tabTrayDidAddToReadingList(tab)
     }
 
     func tabPeekDidCloseTab(_ tab: Tab) {
@@ -640,7 +640,7 @@ private class TabLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout, U
         _ gestureRecognizer: UIGestureRecognizer,
         shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
     ) -> Bool {
-        return true
+        true
     }
 
     @objc func collectionView(
@@ -648,7 +648,7 @@ private class TabLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout, U
         layout collectionViewLayout: UICollectionViewLayout,
         minimumInteritemSpacingForSectionAt section: Int
     ) -> CGFloat {
-        return GridTabTrayControllerUX.Margin
+        GridTabTrayControllerUX.Margin
     }
 
     @objc func collectionView(
@@ -732,7 +732,7 @@ private class TabLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout, U
     }
 
     @objc func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        return GridTabTrayControllerUX.Margin
+        GridTabTrayControllerUX.Margin
     }
 
     @objc func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
@@ -750,7 +750,7 @@ private class TabLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout, U
             tabVC.setState(withProfile: browserProfile, clientPickerDelegate: pickerDelegate)
         }
 
-        return UIContextMenuConfiguration(identifier: nil, previewProvider: { return tabVC }, actionProvider: tabVC.contextActions(defaultActions:))
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: { tabVC }, actionProvider: tabVC.contextActions(defaultActions:))
     }
 }
 
@@ -773,7 +773,7 @@ extension GridTabViewController: UIAdaptivePresentationControllerDelegate, UIPop
     // Returning None here makes sure that the Popover is actually presented as a Popover and
     // not as a full-screen modal, which is the default on compact device classes.
     func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
-        return .none
+        .none
     }
 }
 

--- a/Client/Frontend/Browser/HomePageHelper.swift
+++ b/Client/Frontend/Browser/HomePageHelper.swift
@@ -19,7 +19,7 @@ class HomePageHelper {
 
     var currentURL: URL? {
         get {
-            return NewTabHomePageAccessors.getHomePage(prefs)
+            NewTabHomePageAccessors.getHomePage(prefs)
         }
         set {
             if let url = newValue, url.isWebPage(includeDataURIs: false) && !InternalURL.isValid(url: url) {
@@ -31,10 +31,12 @@ class HomePageHelper {
     }
 
     var defaultURLString: String? {
-        return NewTabHomePageAccessors.getDefaultHomePageString(prefs)
+        NewTabHomePageAccessors.getDefaultHomePageString(prefs)
     }
 
-    var isHomePageAvailable: Bool { return currentURL != nil }
+    var isHomePageAvailable: Bool {
+        currentURL != nil
+    }
 
     init(prefs: Prefs) {
         self.prefs = prefs

--- a/Client/Frontend/Browser/KeyboardPressesHandler.swift
+++ b/Client/Frontend/Browser/KeyboardPressesHandler.swift
@@ -18,15 +18,15 @@ class KeyboardPressesHandler {
     private lazy var keysPressed: [UIKeyboardHIDUsage] = []
 
     var isOnlyCmdPressed: Bool {
-        return isCmdPressed && !isShiftPressed
+        isCmdPressed && !isShiftPressed
     }
 
     var isCmdAndShiftPressed: Bool {
-        return isCmdPressed && isShiftPressed
+        isCmdPressed && isShiftPressed
     }
 
     var isOnlyOptionPressed: Bool {
-        return isOptionPressed && !isCmdPressed
+        isOptionPressed && !isCmdPressed
     }
 
     func handlePressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
@@ -45,15 +45,15 @@ class KeyboardPressesHandler {
     // MARK: Private
 
     private var isCmdPressed: Bool {
-        return keysPressed.contains(.keyboardLeftGUI) || keysPressed.contains(.keyboardRightGUI)
+        keysPressed.contains(.keyboardLeftGUI) || keysPressed.contains(.keyboardRightGUI)
     }
 
     private var isShiftPressed: Bool {
-        return keysPressed.contains(.keyboardLeftShift) || keysPressed.contains(.keyboardRightShift)
+        keysPressed.contains(.keyboardLeftShift) || keysPressed.contains(.keyboardRightShift)
     }
 
     private var isOptionPressed: Bool {
-        return keysPressed.contains(.keyboardLeftAlt) || keysPressed.contains(.keyboardRightAlt)
+        keysPressed.contains(.keyboardLeftAlt) || keysPressed.contains(.keyboardRightAlt)
     }
 
     /// Handle keyboard presses to determine certain commands

--- a/Client/Frontend/Browser/MailProviders.swift
+++ b/Client/Frontend/Browser/MailProviders.swift
@@ -53,7 +53,7 @@ class ReaddleSparkIntegration: MailProvider {
     ]
 
     func newEmailURLFromMetadata(_ metadata: MailToMetadata) -> URL? {
-        return constructEmailURLString(beginningScheme, metadata: metadata, supportedHeaders: supportedHeaders, bodyHName: "textbody", toHName: "recipient").asURL
+        constructEmailURLString(beginningScheme, metadata: metadata, supportedHeaders: supportedHeaders, bodyHName: "textbody", toHName: "recipient").asURL
     }
 }
 
@@ -70,7 +70,7 @@ class AirmailIntegration: MailProvider {
     ]
 
     func newEmailURLFromMetadata(_ metadata: MailToMetadata) -> URL? {
-        return constructEmailURLString(beginningScheme, metadata: metadata, supportedHeaders: supportedHeaders, bodyHName: "htmlBody").asURL
+        constructEmailURLString(beginningScheme, metadata: metadata, supportedHeaders: supportedHeaders, bodyHName: "htmlBody").asURL
     }
 }
 
@@ -85,7 +85,7 @@ class MyMailIntegration: MailProvider {
     ]
 
     func newEmailURLFromMetadata(_ metadata: MailToMetadata) -> URL? {
-        return constructEmailURLString(beginningScheme, metadata: metadata, supportedHeaders: supportedHeaders).asURL
+        constructEmailURLString(beginningScheme, metadata: metadata, supportedHeaders: supportedHeaders).asURL
     }
 }
 
@@ -107,7 +107,7 @@ class MSOutlookIntegration: MailProvider {
     ]
 
     func newEmailURLFromMetadata(_ metadata: MailToMetadata) -> URL? {
-        return constructEmailURLString(beginningScheme, metadata: metadata, supportedHeaders: supportedHeaders).asURL
+        constructEmailURLString(beginningScheme, metadata: metadata, supportedHeaders: supportedHeaders).asURL
     }
 }
 
@@ -121,7 +121,7 @@ class YMailIntegration: MailProvider {
     ]
 
     func newEmailURLFromMetadata(_ metadata: MailToMetadata) -> URL? {
-        return constructEmailURLString(beginningScheme, metadata: metadata, supportedHeaders: supportedHeaders).asURL
+        constructEmailURLString(beginningScheme, metadata: metadata, supportedHeaders: supportedHeaders).asURL
     }
 }
 
@@ -136,7 +136,7 @@ class GoogleGmailIntegration: MailProvider {
     ]
 
     func newEmailURLFromMetadata(_ metadata: MailToMetadata) -> URL? {
-        return constructEmailURLString(beginningScheme, metadata: metadata, supportedHeaders: supportedHeaders).asURL
+        constructEmailURLString(beginningScheme, metadata: metadata, supportedHeaders: supportedHeaders).asURL
     }
 }
 
@@ -151,6 +151,6 @@ class FastmailIntegration: MailProvider {
     ]
 
     func newEmailURLFromMetadata(_ metadata: MailToMetadata) -> URL? {
-        return constructEmailURLString(beginningScheme, metadata: metadata, supportedHeaders: supportedHeaders).asURL
+        constructEmailURLString(beginningScheme, metadata: metadata, supportedHeaders: supportedHeaders).asURL
     }
 }

--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -273,34 +273,38 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
     // MARK: - Actions
 
     private func getNewTabAction() -> PhotonRowActions {
-        return SingleActionViewModel(title: .AppMenu.NewTab,
-                                     iconString: ImageIdentifiers.newTab) { _ in
+        SingleActionViewModel(title: .AppMenu.NewTab,
+                iconString: ImageIdentifiers.newTab) { _ in
 
             let shouldFocusLocationField = NewTabAccessors.getNewTabPage(self.profile.prefs) == .blankPage
             self.delegate?.openBlankNewTab(focusLocationField: shouldFocusLocationField, isPrivate: false, searchFor: nil)
-        }.items
+        }
+                .items
     }
 
     private func getHistoryLibraryAction() -> PhotonRowActions {
-        return SingleActionViewModel(title: .AppMenu.AppMenuHistory,
-                                     iconString: ImageIdentifiers.history) { _ in
+        SingleActionViewModel(title: .AppMenu.AppMenuHistory,
+                iconString: ImageIdentifiers.history) { _ in
             self.delegate?.showLibrary(panel: .history)
-        }.items
+        }
+                .items
     }
 
     private func getDownloadsLibraryAction() -> PhotonRowActions {
-        return SingleActionViewModel(title: .AppMenu.AppMenuDownloads,
-                                     iconString: ImageIdentifiers.downloads) { _ in
+        SingleActionViewModel(title: .AppMenu.AppMenuDownloads,
+                iconString: ImageIdentifiers.downloads) { _ in
             self.delegate?.showLibrary(panel: .downloads)
-        }.items
+        }
+                .items
     }
 
     private func getFindInPageAction() -> PhotonRowActions {
-        return SingleActionViewModel(title: .AppMenu.AppMenuFindInPageTitleString,
-                                     iconString: ImageIdentifiers.findInPage) { _ in
+        SingleActionViewModel(title: .AppMenu.AppMenuFindInPageTitleString,
+                iconString: ImageIdentifiers.findInPage) { _ in
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .findInPage)
             self.delegate?.showFindInPage()
-        }.items
+        }
+                .items
     }
 
     private func getRequestDesktopSiteAction() -> PhotonRowActions? {
@@ -332,21 +336,24 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
     }
 
     private func getCopyAction() -> PhotonRowActions? {
-        return SingleActionViewModel(title: .AppMenu.AppMenuCopyLinkTitleString,
-                                     iconString: ImageIdentifiers.copyLink) { _ in
+        SingleActionViewModel(title: .AppMenu.AppMenuCopyLinkTitleString,
+                iconString: ImageIdentifiers.copyLink) { _ in
 
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .copyAddress)
             if let url = self.selectedTab?.canonicalURL?.displayURL {
                 UIPasteboard.general.url = url
                 self.delegate?.showToast(message: .AppMenu.AppMenuCopyURLConfirmMessage, toastAction: .copyUrl, url: nil)
             }
-        }.items
+        }
+                .items
     }
 
     private func getSendToDevice() -> PhotonRowActions {
-        return SingleActionViewModel(title: .AppMenu.TouchActions.SendLinkToDeviceTitle,
-                                     iconString: ImageIdentifiers.sendToDevice) { _ in
-            guard let bvc = self.menuActionDelegate as? InstructionsViewControllerDelegate & DevicePickerViewControllerDelegate else { return }
+        SingleActionViewModel(title: .AppMenu.TouchActions.SendLinkToDeviceTitle,
+                iconString: ImageIdentifiers.sendToDevice) { _ in
+            guard let bvc = self.menuActionDelegate as? InstructionsViewControllerDelegate & DevicePickerViewControllerDelegate else {
+                return
+            }
 
             if !self.profile.hasAccount() {
                 let instructionsViewController = InstructionsViewController()
@@ -365,7 +372,8 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
             navigationController.modalPresentationStyle = .formSheet
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .sendToDevice)
             self.delegate?.showViewController(viewController: navigationController)
-        }.items
+        }
+                .items
     }
 
     private func getReportSiteIssueAction() -> PhotonRowActions? {
@@ -380,20 +388,22 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
     }
 
     private func getHelpAction() -> PhotonRowActions {
-        return SingleActionViewModel(title: .AppMenu.Help,
-                                     iconString: ImageIdentifiers.help) { _ in
+        SingleActionViewModel(title: .AppMenu.Help,
+                iconString: ImageIdentifiers.help) { _ in
 
             if let url = URL(string: "https://support.mozilla.org/products/ios") {
                 self.delegate?.openURLInNewTab(url, isPrivate: false)
             }
-        }.items
+        }
+                .items
     }
 
     private func getCustomizeHomePageAction() -> PhotonRowActions? {
-        return SingleActionViewModel(title: .AppMenu.CustomizeHomePage,
-                                     iconString: ImageIdentifiers.edit) { _ in
+        SingleActionViewModel(title: .AppMenu.CustomizeHomePage,
+                iconString: ImageIdentifiers.edit) { _ in
             self.delegate?.showCustomizeHomePage()
-        }.items
+        }
+                .items
     }
 
     private func getSettingsAction() -> PhotonRowActions {
@@ -537,23 +547,28 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
     // MARK: Share
 
     private func getShareFileAction() -> PhotonRowActions {
-        return SingleActionViewModel(title: .AppMenu.AppMenuSharePageTitleString,
-                                     iconString: ImageIdentifiers.share) { _ in
+        SingleActionViewModel(title: .AppMenu.AppMenuSharePageTitleString,
+                iconString: ImageIdentifiers.share) { _ in
 
             guard let tab = self.selectedTab,
                   let url = tab.canonicalURL?.displayURL,
                   let presentableVC = self.menuActionDelegate as? PresentableVC
-            else { return }
+            else {
+                return
+            }
 
             self.share(fileURL: url, buttonView: self.buttonView, presentableVC: presentableVC)
-        }.items
+        }
+                .items
     }
 
     private func getShareAction() -> PhotonRowActions {
-        return SingleActionViewModel(title: .AppMenu.Share,
-                                     iconString: ImageIdentifiers.share) { _ in
+        SingleActionViewModel(title: .AppMenu.Share,
+                iconString: ImageIdentifiers.share) { _ in
 
-            guard let tab = self.selectedTab, let url = tab.canonicalURL?.displayURL else { return }
+            guard let tab = self.selectedTab, let url = tab.canonicalURL?.displayURL else {
+                return
+            }
 
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .sharePageWith)
             if let temporaryDocument = tab.temporaryDocument {
@@ -561,7 +576,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
                     // If we successfully got a temp file URL, share it like a downloaded file,
                     // otherwise present the ordinary share menu for the web URL.
                     if tempDocURL.isFileURL,
-                        let presentableVC = self.menuActionDelegate as? PresentableVC {
+                       let presentableVC = self.menuActionDelegate as? PresentableVC {
                         self.share(fileURL: tempDocURL, buttonView: self.buttonView, presentableVC: presentableVC)
                     } else {
                         self.delegate?.showMenuPresenter(url: url, tab: tab, view: self.buttonView)
@@ -570,7 +585,8 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
             } else {
                 self.delegate?.showMenuPresenter(url: url, tab: tab, view: self.buttonView)
             }
-        }.items
+        }
+                .items
     }
 
     private func share(fileURL: URL, buttonView: UIView, presentableVC: PresentableVC) {
@@ -605,24 +621,26 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
     }
 
     private func getReadingListLibraryAction() -> SingleActionViewModel {
-        return SingleActionViewModel(title: .AppMenu.ReadingList,
-                                     iconString: ImageIdentifiers.readingList) { _ in
+        SingleActionViewModel(title: .AppMenu.ReadingList,
+                iconString: ImageIdentifiers.readingList) { _ in
             self.delegate?.showLibrary(panel: .readingList)
         }
     }
 
     private func getReadingListAction() -> SingleActionViewModel {
-        return isInReadingList ? getRemoveReadingListAction() : getAddReadingListAction()
+        isInReadingList ? getRemoveReadingListAction() : getAddReadingListAction()
     }
 
     private func getAddReadingListAction() -> SingleActionViewModel {
-        return SingleActionViewModel(title: .AppMenu.AddReadingList,
-                                     alternateTitle: .AppMenu.AddReadingListAlternateTitle,
-                                     iconString: ImageIdentifiers.addToReadingList) { _ in
+        SingleActionViewModel(title: .AppMenu.AddReadingList,
+                alternateTitle: .AppMenu.AddReadingListAlternateTitle,
+                iconString: ImageIdentifiers.addToReadingList) { _ in
 
             guard let tab = self.selectedTab,
                   let url = self.tabUrl?.displayURL
-            else { return }
+            else {
+                return
+            }
 
             self.profile.readingList.createRecordWithURL(url.absoluteString, title: tab.title ?? "", addedBy: UIDevice.current.name)
             TelemetryWrapper.recordEvent(category: .action, method: .add, object: .readingListItem, value: .pageActionMenu)
@@ -631,13 +649,15 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
     }
 
     private func getRemoveReadingListAction() -> SingleActionViewModel {
-        return SingleActionViewModel(title: .AppMenu.RemoveReadingList,
-                                     alternateTitle: .AppMenu.RemoveReadingListAlternateTitle,
-                                     iconString: ImageIdentifiers.removeFromReadingList) { _ in
+        SingleActionViewModel(title: .AppMenu.RemoveReadingList,
+                alternateTitle: .AppMenu.RemoveReadingListAlternateTitle,
+                iconString: ImageIdentifiers.removeFromReadingList) { _ in
 
             guard let url = self.tabUrl?.displayURL?.absoluteString,
                   let record = self.profile.readingList.getRecordWithURL(url).value.successValue
-            else { return }
+            else {
+                return
+            }
 
             self.profile.readingList.deleteRecord(record, completion: nil)
             self.delegate?.showToast(message: .AppMenu.RemoveFromReadingListConfirmMessage, toastAction: .removeFromReadingList, url: nil)
@@ -660,24 +680,26 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
     }
 
     private func getBookmarkLibraryAction() -> SingleActionViewModel {
-        return SingleActionViewModel(title: .AppMenu.Bookmarks,
-                                     iconString: ImageIdentifiers.bookmarks) { _ in
+        SingleActionViewModel(title: .AppMenu.Bookmarks,
+                iconString: ImageIdentifiers.bookmarks) { _ in
             self.delegate?.showLibrary(panel: .bookmarks)
         }
     }
 
     private func getBookmarkAction() -> SingleActionViewModel {
-        return isBookmarked ? getRemoveBookmarkAction() : getAddBookmarkAction()
+        isBookmarked ? getRemoveBookmarkAction() : getAddBookmarkAction()
     }
 
     private func getAddBookmarkAction() -> SingleActionViewModel {
-        return SingleActionViewModel(title: .AppMenu.AddBookmark,
-                                     alternateTitle: .AppMenu.AddBookmarkAlternateTitle,
-                                     iconString: ImageIdentifiers.addToBookmark) { _ in
+        SingleActionViewModel(title: .AppMenu.AddBookmark,
+                alternateTitle: .AppMenu.AddBookmarkAlternateTitle,
+                iconString: ImageIdentifiers.addToBookmark) { _ in
 
             guard let tab = self.selectedTab,
                   let url = tab.canonicalURL?.displayURL
-            else { return }
+            else {
+                return
+            }
 
             // The method in BVC also handles the toast for this use case
             self.delegate?.addBookmark(url: url.absoluteString, title: tab.title, favicon: tab.displayFavicon)
@@ -686,14 +708,18 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
     }
 
     private func getRemoveBookmarkAction() -> SingleActionViewModel {
-        return SingleActionViewModel(title: .AppMenu.RemoveBookmark,
-                                     alternateTitle: .AppMenu.RemoveBookmarkAlternateTitle,
-                                     iconString: ImageIdentifiers.removeFromBookmark) { _ in
+        SingleActionViewModel(title: .AppMenu.RemoveBookmark,
+                alternateTitle: .AppMenu.RemoveBookmarkAlternateTitle,
+                iconString: ImageIdentifiers.removeFromBookmark) { _ in
 
-            guard let url = self.tabUrl?.displayURL else { return }
+            guard let url = self.tabUrl?.displayURL else {
+                return
+            }
 
             self.profile.places.deleteBookmarksWithURL(url: url.absoluteString).uponQueue(.main) { result in
-                guard result.isSuccess else { return }
+                guard result.isSuccess else {
+                    return
+                }
                 self.delegate?.showToast(message: .AppMenu.RemoveBookmarkConfirmMessage, toastAction: .removeBookmark, url: url.absoluteString)
                 self.removeBookmarkShortcut()
             }
@@ -705,49 +731,57 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
     // MARK: Shortcut
 
     private func getShortcutAction() -> PhotonRowActions {
-        return isPinned ? getRemoveShortcutAction().items : getAddShortcutAction().items
+        isPinned ? getRemoveShortcutAction().items : getAddShortcutAction().items
     }
 
     private func getAddShortcutAction() -> SingleActionViewModel {
-        return SingleActionViewModel(title: .AddToShortcutsActionTitle,
-                                     iconString: ImageIdentifiers.addShortcut) { _ in
+        SingleActionViewModel(title: .AddToShortcutsActionTitle,
+                iconString: ImageIdentifiers.addShortcut) { _ in
 
             guard let url = self.selectedTab?.url?.displayURL,
                   let sql = self.profile.history as? SQLiteHistory
-            else { return }
+            else {
+                return
+            }
 
             sql.getSites(forURLs: [url.absoluteString]).bind { val -> Success in
-                guard let site = val.successValue?.asArray().first?.flatMap({ $0 }) else {
-                    return succeed()
-                }
-                return self.profile.history.addPinnedTopSite(site)
+                        guard let site = val.successValue?.asArray().first?.flatMap({ $0 }) else {
+                            return succeed()
+                        }
+                        return self.profile.history.addPinnedTopSite(site)
 
-            }.uponQueue(.main) { result in
-                guard result.isSuccess else { return }
-                self.delegate?.showToast(message: .AppMenu.AddPinToShortcutsConfirmMessage, toastAction: .pinPage, url: nil)
-            }
+                    }
+                    .uponQueue(.main) { result in
+                        guard result.isSuccess else {
+                            return
+                        }
+                        self.delegate?.showToast(message: .AppMenu.AddPinToShortcutsConfirmMessage, toastAction: .pinPage, url: nil)
+                    }
 
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .pinToTopSites)
         }
     }
 
     private func getRemoveShortcutAction() -> SingleActionViewModel {
-        return SingleActionViewModel(title: .AppMenu.RemoveFromShortcuts,
-                                     iconString: ImageIdentifiers.removeFromShortcut) { _ in
+        SingleActionViewModel(title: .AppMenu.RemoveFromShortcuts,
+                iconString: ImageIdentifiers.removeFromShortcut) { _ in
 
-            guard let url = self.selectedTab?.url?.displayURL, let sql = self.profile.history as? SQLiteHistory else { return }
+            guard let url = self.selectedTab?.url?.displayURL, let sql = self.profile.history as? SQLiteHistory else {
+                return
+            }
 
             sql.getSites(forURLs: [url.absoluteString]).bind { val -> Success in
-                guard let site = val.successValue?.asArray().first?.flatMap({ $0 }) else {
-                    return succeed()
-                }
+                        guard let site = val.successValue?.asArray().first?.flatMap({ $0 }) else {
+                            return succeed()
+                        }
 
-                return self.profile.history.removeFromPinnedTopSites(site)
-            }.uponQueue(.main) { result in
-                if result.isSuccess {
-                    self.delegate?.showToast(message: .AppMenu.RemovePinFromShortcutsConfirmMessage, toastAction: .removePinPage, url: nil)
-                }
-            }
+                        return self.profile.history.removeFromPinnedTopSites(site)
+                    }
+                    .uponQueue(.main) { result in
+                        if result.isSuccess {
+                            self.delegate?.showToast(message: .AppMenu.RemovePinFromShortcutsConfirmMessage, toastAction: .removePinPage, url: nil)
+                        }
+                    }
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .removePinnedSite)
         }
     }

--- a/Client/Frontend/Browser/OpenInHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper.swift
@@ -37,7 +37,7 @@ struct MIMEType {
         MIMEType.WebP]
 
     static func canShowInWebView(_ mimeType: String) -> Bool {
-        return webViewViewableTypes.contains(mimeType.lowercased())
+        webViewViewableTypes.contains(mimeType.lowercased())
     }
 
     static func mimeTypeFromFileExtension(_ fileExtension: String) -> String {
@@ -112,7 +112,7 @@ class DownloadHelper: NSObject {
             filenameItem = SingleActionViewModel(title: download.filename, text: host, iconString: "file", iconAlignment: .right, bold: true)
         }
         filenameItem.customHeight = { _ in
-            return 80
+            80
         }
         filenameItem.customRender = { label, contentView in
             label.numberOfLines = 2
@@ -233,10 +233,10 @@ class OpenQLPreviewHelper: NSObject, QLPreviewControllerDataSource {
     }
 
     func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
-        return 1
+        1
     }
 
     func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> QLPreviewItem {
-        return self.url
+        self.url
     }
 }

--- a/Client/Frontend/Browser/OpenSearch.swift
+++ b/Client/Frontend/Browser/OpenSearch.swift
@@ -65,7 +65,7 @@ class OpenSearchEngine: NSObject, NSCoding {
      * Returns the search URL for the given query.
      */
     func searchURLForQuery(_ query: String) -> URL? {
-        return getURLFromTemplate(searchTemplate, query: query)
+        getURLFromTemplate(searchTemplate, query: query)
     }
 
     /**
@@ -92,7 +92,7 @@ class OpenSearchEngine: NSObject, NSCoding {
 
     fileprivate func extractQueryArg(in queryItems: [URLQueryItem]?, for placeholder: String) -> String? {
         let searchTerm = queryItems?.filter { item in
-            return item.value == placeholder
+            item.value == placeholder
         }
         return searchTerm?.first?.name
     }

--- a/Client/Frontend/Browser/OpenWithSettingsViewController.swift
+++ b/Client/Frontend/Browser/OpenWithSettingsViewController.swift
@@ -99,7 +99,7 @@ class OpenWithSettingsViewController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return mailProviderSource.count
+        mailProviderSource.count
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -115,7 +115,7 @@ class OpenWithSettingsViewController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return UITableView.automaticDimension
+        UITableView.automaticDimension
     }
 
     override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
@@ -124,6 +124,6 @@ class OpenWithSettingsViewController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return UITableView.automaticDimension
+        UITableView.automaticDimension
     }
 }

--- a/Client/Frontend/Browser/Punycode.swift
+++ b/Client/Frontend/Browser/Punycode.swift
@@ -15,11 +15,11 @@ private let asciiPunycode = Array("abcdefghijklmnopqrstuvwxyz0123456789")
 
 extension String {
     fileprivate func toValue(_ index: Int) -> Character {
-        return asciiPunycode[index]
+        asciiPunycode[index]
     }
 
     fileprivate func toIndex(_ value: Character) -> Int {
-        return asciiPunycode.firstIndex(of: value)!
+        asciiPunycode.firstIndex(of: value)!
     }
 
     fileprivate func adapt(_ delta: Int, numPoints: Int, firstTime: Bool) -> Int {
@@ -166,7 +166,7 @@ extension String {
     }
 
     fileprivate func isValidPunycodeScala(_ s: String) -> Bool {
-        return s.hasPrefix(prefixPunycode)
+        s.hasPrefix(prefixPunycode)
     }
 
     public func utf8HostToAscii() -> String {

--- a/Client/Frontend/Browser/QRCodeViewController.swift
+++ b/Client/Frontend/Browser/QRCodeViewController.swift
@@ -30,7 +30,7 @@ class QRCodeViewController: UIViewController {
     }()
 
     private lazy var captureDevice: AVCaptureDevice? = {
-        return AVCaptureDevice.default(for: AVMediaType.video)
+        AVCaptureDevice.default(for: AVMediaType.video)
     }()
 
     private var videoPreviewLayer: AVCaptureVideoPreviewLayer?
@@ -309,6 +309,6 @@ extension QRCodeViewController: AVCaptureMetadataOutputObjectsDelegate {
 
 class QRCodeNavigationController: UINavigationController {
     override open var preferredStatusBarStyle: UIStatusBarStyle {
-        return .lightContent
+        .lightContent
     }
 }

--- a/Client/Frontend/Browser/SearchEngines.swift
+++ b/Client/Frontend/Browser/SearchEngines.swift
@@ -51,7 +51,7 @@ class SearchEngines {
 
     var defaultEngine: OpenSearchEngine {
         get {
-            return self.orderedEngines[0]
+            self.orderedEngines[0]
         }
 
         set(defaultEngine) {
@@ -65,7 +65,7 @@ class SearchEngines {
     }
 
     func isEngineDefault(_ engine: OpenSearchEngine) -> Bool {
-        return defaultEngine.shortName == engine.shortName
+        defaultEngine.shortName == engine.shortName
     }
 
     // The keys of this dictionary are used as a set.
@@ -83,7 +83,7 @@ class SearchEngines {
 
     var quickSearchEngines: [OpenSearchEngine]! {
         get {
-            return self.orderedEngines.filter({ (engine) in !self.isEngineDefault(engine) && self.isEngineEnabled(engine) })
+            self.orderedEngines.filter({ (engine) in !self.isEngineDefault(engine) && self.isEngineEnabled(engine) })
         }
     }
 
@@ -94,7 +94,7 @@ class SearchEngines {
     }
 
     func isEngineEnabled(_ engine: OpenSearchEngine) -> Bool {
-        return disabledEngineNames.index(forKey: engine.shortName) == nil
+        disabledEngineNames.index(forKey: engine.shortName) == nil
     }
 
     func enableEngine(_ engine: OpenSearchEngine) {
@@ -153,7 +153,7 @@ class SearchEngines {
     }
 
     fileprivate lazy var customEngines: [OpenSearchEngine] = {
-        return NSKeyedUnarchiver.unarchiveObject(withFile: self.customEngineFilePath()) as? [OpenSearchEngine] ?? []
+        NSKeyedUnarchiver.unarchiveObject(withFile: self.customEngineFilePath()) as? [OpenSearchEngine] ?? []
     }()
 
     fileprivate func saveCustomEngines() {

--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -42,7 +42,7 @@ class SearchLoader: Loader<Cursor<Site>, SearchViewController>, FeatureFlaggable
     private weak var currentDeferredHistoryQuery: CancellableDeferred<Maybe<Cursor<Site>>>?
 
     fileprivate func getBookmarksAsSites(matchingSearchQuery query: String, limit: Int) -> Deferred<Maybe<Cursor<Site>>> {
-        return profile.places.searchBookmarks(query: query, limit: 5).bind { result in
+        profile.places.searchBookmarks(query: query, limit: 5).bind { result in
             guard let bookmarkItems = result.successValue else {
                 return deferMaybe(ArrayCursor(data: []))
             }

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -17,7 +17,9 @@ private enum SearchListSection: Int, CaseIterable {
 }
 
 private struct SearchViewControllerUX {
-    static var SearchEngineScrollViewBackgroundColor: CGColor { return UIColor.theme.homePanel.toolbarBackground.withAlphaComponent(0.8).cgColor }
+    static var SearchEngineScrollViewBackgroundColor: CGColor {
+        UIColor.theme.homePanel.toolbarBackground.withAlphaComponent(0.8).cgColor
+    }
     static let SearchEngineScrollViewBorderColor = UIColor.black.withAlphaComponent(0.2).cgColor
 
     // TODO: This should use ToolbarHeight in BVC. Fix this when we create a shared theming file.
@@ -59,7 +61,7 @@ struct SearchViewModel {
 class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, LoaderListener, FeatureFlaggable {
     var searchDelegate: SearchViewControllerDelegate?
     var currentTheme: BuiltinThemeName {
-        return BuiltinThemeName(rawValue: LegacyThemeManager.instance.current.name) ?? .normal
+        BuiltinThemeName(rawValue: LegacyThemeManager.instance.current.name) ?? .normal
     }
     private let viewModel: SearchViewModel
     private var suggestClient: SearchSuggestClient?
@@ -77,11 +79,11 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     private let searchEngineScrollViewContent = UIView()
 
     private lazy var bookmarkedBadge: UIImage = {
-        return UIImage(named: "bookmark_results")!
+        UIImage(named: "bookmark_results")!
     }()
 
     private lazy var openAndSyncTabBadge: UIImage = {
-        return UIImage(named: "sync_open_tab")!
+        UIImage(named: "sync_open_tab")!
     }()
 
     var suggestions: [String]? = []
@@ -546,7 +548,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     }
 
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return super.tableView(tableView, heightForRowAt: indexPath)
+        super.tableView(tableView, heightForRowAt: indexPath)
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
@@ -591,7 +593,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        return SearchListSection.allCases.count
+        SearchListSection.allCases.count
     }
 
     func tableView(_ tableView: UITableView, didHighlightRowAt indexPath: IndexPath) {
@@ -841,7 +843,7 @@ fileprivate extension String {
         // The assumption here is that if the user is typing in a forward slash and there are no spaces
         // involved, it's going to be a URL. If we type a space, any url would be invalid.
         // See https://bugzilla.mozilla.org/show_bug.cgi?id=1192155 for additional details.
-        return self.contains("/") && !self.contains(" ")
+        self.contains("/") && !self.contains(" ")
     }
 }
 
@@ -850,6 +852,6 @@ fileprivate extension String {
  */
 private class ButtonScrollView: UIScrollView {
     override func touchesShouldCancel(in view: UIView) -> Bool {
-        return true
+        true
     }
 }

--- a/Client/Frontend/Browser/SessionData.swift
+++ b/Client/Frontend/Browser/SessionData.swift
@@ -13,12 +13,12 @@ import Shared
 /// reduces security risk. Also, this particular method helps in cleaning up / migrating
 /// old localhost:6571 URLs to internal: SessionData urls 
 private func migrate(urls: [URL]) -> [URL] {
-    return urls.compactMap { url in
+    urls.compactMap { url in
         var url = url
         let port = AppInfo.webserverPort
         [("http://localhost:\(port)/errors/error.html?url=", "\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)?url=")
-            // TODO: handle reader pages ("http://localhost:6571/reader-mode/page?url=", "\(InternalScheme.url)/\(ReaderModeHandler.path)?url=")
-            ].forEach {
+         // TODO: handle reader pages ("http://localhost:6571/reader-mode/page?url=", "\(InternalScheme.url)/\(ReaderModeHandler.path)?url=")
+        ].forEach {
             oldItem, newItem in
             if url.absoluteString.hasPrefix(oldItem) {
                 var urlStr = url.absoluteString.replacingOccurrences(of: oldItem, with: newItem)
@@ -46,10 +46,12 @@ class SessionData: NSObject, NSCoding {
     let urls: [URL]
 
     var jsonDictionary: [String: Any] {
-        return [
+        [
             "currentPage": String(self.currentPage),
             "lastUsedTime": String(self.lastUsedTime),
-            "urls": urls.map { $0.absoluteString }
+            "urls": urls.map {
+                $0.absoluteString
+            }
         ]
     }
 

--- a/Client/Frontend/Browser/StartAtHomeHelper.swift
+++ b/Client/Frontend/Browser/StartAtHomeHelper.swift
@@ -17,9 +17,9 @@ class StartAtHomeHelper: FeatureFlaggable {
     }
 
     var shouldSkipStartHome: Bool {
-        return isRunningUITest ||
-              DebugSettingsBundleOptions.skipSessionRestore ||
-              isRestoringTabs
+        isRunningUITest ||
+                DebugSettingsBundleOptions.skipSessionRestore ||
+                isRestoringTabs
     }
 
     /// Determines whether the Start at Home feature is enabled, how long it has been since

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -63,7 +63,7 @@ class Tab: NSObject {
     fileprivate var _isPrivate: Bool = false
     internal fileprivate(set) var isPrivate: Bool {
         get {
-            return _isPrivate
+            _isPrivate
         }
         set {
             if _isPrivate != newValue {
@@ -73,7 +73,7 @@ class Tab: NSObject {
     }
     var urlType: TabUrlType = .regular
     var tabState: TabState {
-        return TabState(isPrivate: _isPrivate, url: url, title: displayTitle, favicon: displayFavicon)
+        TabState(isPrivate: _isPrivate, url: url, title: displayTitle, favicon: displayFavicon)
     }
 
     var timerPerWebsite: [String: StopWatchTimer] = [:]
@@ -141,24 +141,26 @@ class Tab: NSObject {
     }
 
     var loading: Bool {
-        return webView?.isLoading ?? false
+        webView?.isLoading ?? false
     }
 
     var estimatedProgress: Double {
-        return webView?.estimatedProgress ?? 0
+        webView?.estimatedProgress ?? 0
     }
 
     var backList: [WKBackForwardListItem]? {
-        return webView?.backForwardList.backList
+        webView?.backForwardList.backList
     }
 
     var forwardList: [WKBackForwardListItem]? {
-        return webView?.backForwardList.forwardList
+        webView?.backForwardList.forwardList
     }
 
     var historyList: [URL] {
         get {
-            func listToUrl(_ item: WKBackForwardListItem) -> URL { return item.url }
+            func listToUrl(_ item: WKBackForwardListItem) -> URL {
+                item.url
+            }
 
             var historyUrls = self.backList?.map(listToUrl) ?? [URL]()
             if let url = url {
@@ -171,7 +173,7 @@ class Tab: NSObject {
     }
 
     var title: String? {
-        return webView?.title
+        webView?.title
     }
 
     var displayTitle: String {
@@ -216,15 +218,17 @@ class Tab: NSObject {
     }
 
     var displayFavicon: Favicon? {
-        return favicons.max { $0.width! < $1.width! }
+        favicons.max {
+            $0.width! < $1.width!
+        }
     }
 
     var canGoBack: Bool {
-        return webView?.canGoBack ?? false
+        webView?.canGoBack ?? false
     }
 
     var canGoForward: Bool {
-        return webView?.canGoForward ?? false
+        webView?.canGoForward ?? false
     }
 
     var userActivity: NSUserActivity?
@@ -631,7 +635,7 @@ class Tab: NSObject {
     }
 
     func getContentScript(name: String) -> TabContentScript? {
-        return contentScriptManager.getContentScript(name)
+        contentScriptManager.getContentScript(name)
     }
 
     func hideContent(_ animated: Bool = false) {
@@ -733,7 +737,12 @@ class Tab: NSObject {
     }
 
     func isDescendentOf(_ ancestor: Tab) -> Bool {
-        return sequence(first: parent) { $0?.parent }.contains { $0 == ancestor }
+        sequence(first: parent) {
+            $0?.parent
+        }
+                .contains {
+                    $0 == ancestor
+                }
     }
 
     func observeURLChanges(delegate: URLChangeDelegate) {
@@ -781,7 +790,7 @@ class Tab: NSObject {
 extension Tab: UIGestureRecognizerDelegate, Loggable {
     // This prevents the recognition of one gesture recognizer from blocking another
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        return true
+        true
     }
 
     func configureEdgeSwipeGestureRecognizers() {
@@ -817,15 +826,15 @@ extension Tab: TabWebViewDelegate {
 
 extension Tab: ContentBlockerTab {
     func currentURL() -> URL? {
-        return url
+        url
     }
 
     func currentWebView() -> WKWebView? {
-        return webView
+        webView
     }
 
     func imageContentBlockingEnabled() -> Bool {
-        return noImageMode
+        noImageMode
     }
 }
 
@@ -877,7 +886,7 @@ private class TabContentScriptManager: NSObject, WKScriptMessageHandler {
     }
 
     func getContentScript(_ name: String) -> TabContentScript? {
-        return helpers[name]
+        helpers[name]
     }
 }
 
@@ -899,7 +908,7 @@ class TabWebView: WKWebView, MenuHelperInterface {
     }
 
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-        return super.canPerformAction(action, withSender: sender) || action == MenuHelper.SelectorFindInPage
+        super.canPerformAction(action, withSender: sender) || action == MenuHelper.SelectorFindInPage
     }
 
     func menuHelperFindInPage() {

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -86,15 +86,15 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
     var tabDisplayOrder: TabDisplayOrder = TabDisplayOrder()
 
     var shouldEnableGroupedTabs: Bool {
-        return featureFlags.isFeatureEnabled(.tabTrayGroups, checking: .buildAndUser)
+        featureFlags.isFeatureEnabled(.tabTrayGroups, checking: .buildAndUser)
     }
 
     var shouldEnableInactiveTabs: Bool {
-        return featureFlags.isFeatureEnabled(.inactiveTabs, checking: .buildAndUser)
+        featureFlags.isFeatureEnabled(.inactiveTabs, checking: .buildAndUser)
     }
 
     var orderedTabs: [Tab] {
-        return filteredTabs
+        filteredTabs
     }
 
     func getRegularOrderedTabs() -> [Tab]? {
@@ -144,7 +144,7 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
     // Dragging on the collection view is either an 'active drag' where the item is moved, or
     // that the item has been long pressed on (and not moved yet), and this gesture recognizer has been triggered
     var isDragging: Bool {
-        return collectionView.hasActiveDrag || isLongPressGestureStarted
+        collectionView.hasActiveDrag || isLongPressGestureStarted
     }
 
     fileprivate var isLongPressGestureStarted: Bool {
@@ -310,7 +310,7 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
     }
 
     func indexOfRegularTab(tab: Tab) -> Int? {
-        return filteredTabs.firstIndex(of: tab)
+        filteredTabs.firstIndex(of: tab)
     }
 
     func togglePrivateMode(isOn: Bool, createTabOnEmptyPrivateMode: Bool,
@@ -713,7 +713,7 @@ extension TabDisplayManager: UIDropInteractionDelegate {
     }
 
     func dropInteraction(_ interaction: UIDropInteraction, sessionDidUpdate session: UIDropSession) -> UIDropProposal {
-        return UIDropProposal(operation: .copy)
+        UIDropProposal(operation: .copy)
     }
 
     func dropInteraction(_ interaction: UIDropInteraction, performDrop session: UIDropSession) {
@@ -772,11 +772,11 @@ extension TabDisplayManager: UICollectionViewDropDelegate {
     }
 
     func collectionView(_ collectionView: UICollectionView, dragPreviewParametersForItemAt indexPath: IndexPath) -> UIDragPreviewParameters? {
-        return dragPreviewParameters(collectionView, dragPreviewParametersForItemAt: indexPath)
+        dragPreviewParameters(collectionView, dragPreviewParametersForItemAt: indexPath)
     }
 
     func collectionView(_ collectionView: UICollectionView, dropPreviewParametersForItemAt indexPath: IndexPath) -> UIDragPreviewParameters? {
-        return dragPreviewParameters(collectionView, dragPreviewParametersForItemAt: indexPath)
+        dragPreviewParameters(collectionView, dragPreviewParametersForItemAt: indexPath)
     }
 
     func collectionView(_ collectionView: UICollectionView, performDropWith coordinator: UICollectionViewDropCoordinator) {

--- a/Client/Frontend/Browser/TabGroupData.swift
+++ b/Client/Frontend/Browser/TabGroupData.swift
@@ -23,11 +23,11 @@ public class TabGroupData: NSObject, NSCoding {
     var tabHistoryCurrentState = ""
 
     func tabHistoryMetadatakey() -> HistoryMetadataKey {
-        return HistoryMetadataKey(url: tabAssociatedSearchUrl, searchTerm: tabAssociatedSearchTerm, referrerUrl: tabAssociatedNextUrl)
+        HistoryMetadataKey(url: tabAssociatedSearchUrl, searchTerm: tabAssociatedSearchTerm, referrerUrl: tabAssociatedNextUrl)
     }
 
     var jsonDictionary: [String: Any] {
-        return [
+        [
             "tabAssociatedSearchTerm": String(self.tabAssociatedSearchTerm),
             "tabAssociatedSearchUrl": String(self.tabAssociatedSearchUrl),
             "tabAssociatedNextUrl": String(self.tabAssociatedNextUrl),

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -30,7 +30,7 @@ class WeakTabManagerDelegate {
     }
 
     func get() -> TabManagerDelegate? {
-        return value
+        value
     }
 }
 
@@ -111,28 +111,34 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
 
     // A WKWebViewConfiguration used for normal tabs
     lazy fileprivate var configuration: WKWebViewConfiguration = {
-        return TabManager.makeWebViewConfig(isPrivate: false, prefs: profile.prefs)
+        TabManager.makeWebViewConfig(isPrivate: false, prefs: profile.prefs)
     }()
 
     // A WKWebViewConfiguration used for private mode tabs
     lazy fileprivate var privateConfiguration: WKWebViewConfiguration = {
-        return TabManager.makeWebViewConfig(isPrivate: true, prefs: profile.prefs)
+        TabManager.makeWebViewConfig(isPrivate: true, prefs: profile.prefs)
     }()
 
     var didChangedPanelSelection: Bool = true
     var didAddNewTab: Bool = true
 
-    var selectedIndex: Int { return _selectedIndex }
+    var selectedIndex: Int {
+        _selectedIndex
+    }
 
     // Enables undo of recently closed tabs
     var recentlyClosedForUndo = [SavedTab]()
 
     var normalTabs: [Tab] {
-        return tabs.filter { !$0.isPrivate }
+        tabs.filter {
+            !$0.isPrivate
+        }
     }
 
     var privateTabs: [Tab] {
-        return tabs.filter { $0.isPrivate }
+        tabs.filter {
+            $0.isPrivate
+        }
     }
 
     /// This variable returns all normal tabs, sorted chronologically, excluding any
@@ -168,7 +174,7 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
     }
 
     var lastSessionWasPrivate: Bool {
-        return UserDefaults.standard.bool(forKey: "wasLastSessionPrivate")
+        UserDefaults.standard.bool(forKey: "wasLastSessionPrivate")
     }
 
     // MARK: - Initializer
@@ -193,7 +199,7 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
     }
 
     var count: Int {
-        return tabs.count
+        tabs.count
     }
 
     var selectedTab: Tab? {
@@ -291,7 +297,7 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
     }
 
     func shouldClearPrivateTabs() -> Bool {
-        return profile.prefs.boolForKey("settings.closePrivateTabs") ?? false
+        profile.prefs.boolForKey("settings.closePrivateTabs") ?? false
     }
 
     // Called by other classes to signal that they are entering/exiting private mode
@@ -331,12 +337,12 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
                                    zombie: Bool = false,
                                    isPrivate: Bool = false)
     -> Tab {
-        return self.addTab(request,
-                           configuration: configuration,
-                           afterTab: afterTab,
-                           flushToDisk: true,
-                           zombie: zombie,
-                           isPrivate: isPrivate)
+        self.addTab(request,
+                configuration: configuration,
+                afterTab: afterTab,
+                flushToDisk: true,
+                zombie: zombie,
+                isPrivate: isPrivate)
     }
 
     func addTabsForURLs(_ urls: [URL], zombie: Bool) {
@@ -780,7 +786,7 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
 
     func getTabForURL(_ url: URL) -> Tab? {
 
-        return tabs.filter({ $0.webView?.url == url }).first
+        tabs.filter({ $0.webView?.url == url }).first
     }
 
     func getTabForUUID(uuid: String) -> Tab? {
@@ -866,7 +872,7 @@ extension TabManager {
     }
 
     func hasTabsToRestoreAtStartup() -> Bool {
-        return store.hasTabsToRestoreAtStartup
+        store.hasTabsToRestoreAtStartup
     }
 
     func restoreTabs(_ forced: Bool = false) {

--- a/Client/Frontend/Browser/TabManagerNavDelegate.swift
+++ b/Client/Frontend/Browser/TabManagerNavDelegate.swift
@@ -46,7 +46,7 @@ class TabManagerNavDelegate: NSObject, WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         let authenticatingDelegates = delegates.filter { wv in
-            return wv.responds(to: #selector(webView(_:didReceive:completionHandler:)))
+            wv.responds(to: #selector(webView(_:didReceive:completionHandler:)))
         }
 
         guard let firstAuthenticatingDelegate = authenticatingDelegates.first else {

--- a/Client/Frontend/Browser/TabManagerStore.swift
+++ b/Client/Frontend/Browser/TabManagerStore.swift
@@ -18,7 +18,7 @@ class TabManagerStore: FeatureFlaggable {
 
     // Init this at startup with the tabs on disk, and then on each save, update the in-memory tab state.
     fileprivate lazy var archivedStartupTabs = {
-        return SiteArchiver.tabsToRestore(tabsStateArchivePath: tabsStateArchivePath())
+        SiteArchiver.tabsToRestore(tabsStateArchivePath: tabsStateArchivePath())
     }()
 
     init(imageStore: DiskImageStore?, _ fileManager: FileManager = FileManager.default, prefs: Prefs) {
@@ -28,11 +28,11 @@ class TabManagerStore: FeatureFlaggable {
     }
 
     var isRestoringTabs: Bool {
-        return lockedForReading
+        lockedForReading
     }
 
     var hasTabsToRestoreAtStartup: Bool {
-        return !archivedStartupTabs.0.isEmpty
+        !archivedStartupTabs.0.isEmpty
     }
 
     fileprivate func tabsStateArchivePath() -> String? {

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -31,7 +31,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
     // Preview action items.
     override var previewActionItems: [UIPreviewActionItem] {
         get {
-            return previewActions
+            previewActions
         }
     }
 

--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -78,10 +78,18 @@ class TabScrollingController: NSObject, FeatureFlaggable {
         return panGesture
     }()
 
-    private var scrollView: UIScrollView? { return tab?.webView?.scrollView }
-    private var contentOffset: CGPoint { return scrollView?.contentOffset ?? .zero }
-    private var contentSize: CGSize { return scrollView?.contentSize ?? .zero }
-    private var scrollViewHeight: CGFloat { return scrollView?.frame.height ?? 0 }
+    private var scrollView: UIScrollView? {
+        tab?.webView?.scrollView
+    }
+    private var contentOffset: CGPoint {
+        scrollView?.contentOffset ?? .zero
+    }
+    private var contentSize: CGSize {
+        scrollView?.contentSize ?? .zero
+    }
+    private var scrollViewHeight: CGFloat {
+        scrollView?.frame.height ?? 0
+    }
     private var topScrollHeight: CGFloat { header?.frame.height ?? 0 }
 
     // Over keyboard content and bottom content
@@ -99,7 +107,7 @@ class TabScrollingController: NSObject, FeatureFlaggable {
     private var scrollDirection: ScrollDirection = .down
     private var toolbarState: ToolbarState = .visible
     private var isBottomSearchBar: Bool {
-        return BrowserViewController.foregroundBVC().isBottomSearchBar
+        BrowserViewController.foregroundBVC().isBottomSearchBar
     }
 
     override init() {
@@ -183,11 +191,11 @@ private extension TabScrollingController {
     }
 
     func roundNum(_ num: CGFloat) -> CGFloat {
-        return round(100 * num) / 100
+        round(100 * num) / 100
     }
 
     func tabIsLoading() -> Bool {
-        return tab?.loading ?? true
+        tab?.loading ?? true
     }
 
     func isBouncingAtBottom() -> Bool {
@@ -236,7 +244,7 @@ private extension TabScrollingController {
     }
 
     func checkRubberbandingForDelta(_ delta: CGFloat) -> Bool {
-        return !((delta < 0 && contentOffset.y + scrollViewHeight > contentSize.height &&
+        !((delta < 0 && contentOffset.y + scrollViewHeight > contentSize.height &&
                 scrollViewHeight < contentSize.height) ||
                 contentOffset.y < delta)
     }
@@ -262,7 +270,7 @@ private extension TabScrollingController {
     }
 
     func isHeaderDisplayedForGivenOffset(_ offset: CGFloat) -> Bool {
-        return offset > -topScrollHeight && offset < 0
+        offset > -topScrollHeight && offset < 0
     }
 
     func clamp(_ y: CGFloat, min: CGFloat, max: CGFloat) -> CGFloat {
@@ -309,7 +317,7 @@ private extension TabScrollingController {
     }
 
     func checkScrollHeightIsLargeEnoughForScrolling() -> Bool {
-        return (UIScreen.main.bounds.size.height + 2 * UIConstants.ToolbarHeight) < scrollView?.contentSize.height ?? 0
+        (UIScreen.main.bounds.size.height + 2 * UIConstants.ToolbarHeight) < scrollView?.contentSize.height ?? 0
     }
 
     // Duration for hiding bottom containers is taken from overKeyboard since it's longer to hide
@@ -337,14 +345,14 @@ private extension TabScrollingController {
     // Scroll alpha is only for header views since status bar has an overlay
     // Bottom content doesn't have alpha since it's completely hidden
     var scrollAlpha: CGFloat {
-        return 1 - abs(headerTopOffset / topScrollHeight)
+        1 - abs(headerTopOffset / topScrollHeight)
     }
 }
 
 extension TabScrollingController: UIGestureRecognizerDelegate {
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
                            shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        return true
+        true
     }
 }
 

--- a/Client/Frontend/Browser/Tabs/ASGroup.swift
+++ b/Client/Frontend/Browser/Tabs/ASGroup.swift
@@ -22,22 +22,22 @@ struct ASGroup<T>: Hashable {
 
 extension ASGroup: HighlightItem {
     var group: [HighlightItem]? {
-        return groupedItems as? [HighlightItem]
+        groupedItems as? [HighlightItem]
     }
 
     var type: HighlightItemType {
-        return .group
+        .group
     }
 
     var displayTitle: String {
-        return searchTerm
+        searchTerm
     }
 
     var description: String? {
-        return String.localizedStringWithFormat(.FirefoxHomepage.Common.SitesCount, groupedItems.count)
+        String.localizedStringWithFormat(.FirefoxHomepage.Common.SitesCount, groupedItems.count)
     }
 
     var siteUrl: URL? {
-        return nil
+        nil
     }
 }

--- a/Client/Frontend/Browser/Tabs/GroupedTabCell.swift
+++ b/Client/Frontend/Browser/Tabs/GroupedTabCell.swift
@@ -78,15 +78,15 @@ class GroupedTabCell: UICollectionViewCell, NotificationThemeable, UITableViewDa
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
+        1
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return tabGroups?.count ?? 0
+        tabGroups?.count ?? 0
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return GroupedTabCellProperties.CellUX.defaultCellHeight
+        GroupedTabCellProperties.CellUX.defaultCellHeight
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -103,7 +103,7 @@ class GroupedTabCell: UICollectionViewCell, NotificationThemeable, UITableViewDa
     }
 
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return 0
+        0
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -118,11 +118,11 @@ class GroupedTabCell: UICollectionViewCell, NotificationThemeable, UITableViewDa
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return CGFloat.leastNormalMagnitude
+        CGFloat.leastNormalMagnitude
     }
 
     func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
-        return CGFloat.leastNormalMagnitude
+        CGFloat.leastNormalMagnitude
     }
 
     func getTabDomainUrl(tab: Tab) -> URL? {
@@ -308,7 +308,7 @@ class GroupedTabContainerCell: UITableViewCell, UICollectionViewDelegateFlowLayo
     }
 
     @objc func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
-        return GridTabTrayControllerUX.Margin
+        GridTabTrayControllerUX.Margin
     }
 
     @objc func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
@@ -320,11 +320,11 @@ class GroupedTabContainerCell: UITableViewCell, UICollectionViewDelegateFlowLayo
     }
 
     @objc func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        return UIEdgeInsets(equalInset: GridTabTrayControllerUX.Margin)
+        UIEdgeInsets(equalInset: GridTabTrayControllerUX.Margin)
     }
 
     @objc func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        return GridTabTrayControllerUX.Margin
+        GridTabTrayControllerUX.Margin
     }
 
     @objc func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
@@ -339,7 +339,7 @@ class GroupedTabContainerCell: UITableViewCell, UICollectionViewDelegateFlowLayo
     }
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return tabs?.count ?? 0
+        tabs?.count ?? 0
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {

--- a/Client/Frontend/Browser/Tabs/InactiveTabCell.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabCell.swift
@@ -102,7 +102,7 @@ class InactiveTabCell: UICollectionViewCell, ReusableCell {
 
 extension InactiveTabCell: UITableViewDataSource, UITableViewDelegate {
     func numberOfSections(in tableView: UITableView) -> Int {
-        return InactiveTabSection.allCases.count
+        InactiveTabSection.allCases.count
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -255,7 +255,7 @@ extension InactiveTabCell: UITableViewDataSource, UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return UITableView.automaticDimension
+        UITableView.automaticDimension
     }
 
     func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {

--- a/Client/Frontend/Browser/Tabs/InactiveTabItemCellModel.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabItemCellModel.swift
@@ -19,7 +19,7 @@ struct InactiveTabItemCellModel {
     }
 
     var fontForLabel: UIFont {
-        return DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, maxSize: 17)
+        DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, maxSize: 17)
     }
 
     var title: String?

--- a/Client/Frontend/Browser/Tabs/InactiveTabViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabViewModel.swift
@@ -32,7 +32,9 @@ struct InactiveTabModel: Codable {
     /// Check to see if we ever ran this feature before, this is mainly
     /// to avoid tabs automatically going to their state on their first ever run
     static var hasRunInactiveTabFeatureBefore: Bool {
-        get { return userDefaults.bool(forKey: PrefsKeys.KeyInactiveTabsFirstTimeRun) }
+        get {
+            userDefaults.bool(forKey: PrefsKeys.KeyInactiveTabsFirstTimeRun)
+        }
         set(value) { userDefaults.setValue(value, forKey: PrefsKeys.KeyInactiveTabsFirstTimeRun) }
     }
 

--- a/Client/Frontend/Browser/Tabs/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabsPanel.swift
@@ -133,7 +133,7 @@ class RemoteTabsPanelClientAndTabsDataSource: NSObject, RemoteTabsPanelDataSourc
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        return self.clientAndTabs.count
+        self.clientAndTabs.count
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -145,11 +145,11 @@ class RemoteTabsPanelClientAndTabsDataSource: NSObject, RemoteTabsPanelDataSourc
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return UITableView.automaticDimension
+        UITableView.automaticDimension
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return UX.HeaderHeight
+        UX.HeaderHeight
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
@@ -186,7 +186,7 @@ class RemoteTabsPanelClientAndTabsDataSource: NSObject, RemoteTabsPanelDataSourc
     }
 
     func tabAtIndexPath(_ indexPath: IndexPath) -> RemoteTab {
-        return clientAndTabs[indexPath.section].tabs[indexPath.item]
+        clientAndTabs[indexPath.section].tabs[indexPath.item]
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -242,11 +242,11 @@ class RemoteTabsPanelErrorDataSource: NSObject, RemoteTabsPanelDataSource {
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
+        1
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 1
+        1
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -258,11 +258,11 @@ class RemoteTabsPanelErrorDataSource: NSObject, RemoteTabsPanelDataSource {
 
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         // Making the footer height as small as possible because it will disable button tappability if too high.
-        return 1
+        1
     }
 
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        return UIView()
+        UIView()
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -530,7 +530,7 @@ class RemoteTabsTableViewController: UITableViewController {
     }
 
     fileprivate lazy var longPressRecognizer: UILongPressGestureRecognizer = {
-        return UILongPressGestureRecognizer(target: self, action: #selector(longPress))
+        UILongPressGestureRecognizer(target: self, action: #selector(longPress))
     }()
 
     override func viewDidLoad() {
@@ -705,6 +705,6 @@ extension RemoteTabsTableViewController: LibraryPanelContextMenu {
     }
 
     func getContextMenuActions(for site: Site, with indexPath: IndexPath) -> [PhotonRowActions]? {
-        return getRemoteTabContexMenuActions(for: site, remotePanelDelegate: remoteTabsPanel?.remotePanelDelegate)
+        getRemoteTabContexMenuActions(for: site, remotePanelDelegate: remoteTabsPanel?.remotePanelDelegate)
     }
 }

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -84,9 +84,9 @@ class TabTrayViewController: UIViewController {
     }()
 
     lazy var flexibleSpace: UIBarButtonItem = {
-        return UIBarButtonItem(barButtonSystemItem: .flexibleSpace,
-                               target: nil,
-                               action: nil)
+        UIBarButtonItem(barButtonSystemItem: .flexibleSpace,
+                target: nil,
+                action: nil)
     }()
 
     lazy var fixedSpace: UIBarButtonItem = {
@@ -107,11 +107,11 @@ class TabTrayViewController: UIViewController {
     }()
 
     lazy var bottomToolbarItems: [UIBarButtonItem] = {
-        return [deleteButton, flexibleSpace, newTabButton]
+        [deleteButton, flexibleSpace, newTabButton]
     }()
 
     lazy var bottomToolbarItemsForSync: [UIBarButtonItem] = {
-        return [flexibleSpace, syncTabButton]
+        [flexibleSpace, syncTabButton]
     }()
 
     lazy var navigationMenu: UISegmentedControl = {
@@ -134,11 +134,13 @@ class TabTrayViewController: UIViewController {
     }()
 
     lazy var iPadNavigationMenuIdentifiers: UISegmentedControl = {
-        return UISegmentedControl(items: TabTrayViewModel.Segment.allCases.map { $0.label })
+        UISegmentedControl(items: TabTrayViewModel.Segment.allCases.map {
+            $0.label
+        })
     }()
 
     lazy var iPhoneNavigationMenuIdentifiers: UISegmentedControl = {
-        return UISegmentedControl(items: [
+        UISegmentedControl(items: [
             TabTrayViewModel.Segment.tabs.image!.overlayWith(image: countLabel),
             TabTrayViewModel.Segment.privateTabs.image!,
             TabTrayViewModel.Segment.syncedTabs.image!])
@@ -154,7 +156,7 @@ class TabTrayViewController: UIViewController {
     }()
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return .lightContent
+        .lightContent
     }
 
     // MARK: - Initializers
@@ -407,7 +409,7 @@ extension TabTrayViewController: NotificationThemeable {
 // MARK: - UIToolbarDelegate
 extension TabTrayViewController: UIToolbarDelegate {
     func position(for bar: UIBarPositioning) -> UIBarPosition {
-        return .topAttached
+        .topAttached
     }
 }
 

--- a/Client/Frontend/Browser/ThirdPartySearchAlerts.swift
+++ b/Client/Frontend/Browser/ThirdPartySearchAlerts.swift
@@ -11,7 +11,7 @@ class ThirdPartySearchAlerts: UIAlertController {
     Allows the keyboard to pop back up after an alertview.
     **/
     override var canBecomeFirstResponder: Bool {
-        return false
+        false
     }
 
     /**
@@ -54,18 +54,18 @@ class ThirdPartySearchAlerts: UIAlertController {
      **/
 
     static func failedToAddThirdPartySearch() -> UIAlertController {
-        return searchAlertWithOK(title: .ThirdPartySearchFailedTitle,
-                                 message: .ThirdPartySearchFailedMessage)
+        searchAlertWithOK(title: .ThirdPartySearchFailedTitle,
+                message: .ThirdPartySearchFailedMessage)
     }
 
     static func incorrectCustomEngineForm() -> UIAlertController {
-        return searchAlertWithOK(title: .CustomEngineFormErrorTitle,
-                                      message: .CustomEngineFormErrorMessage)
+        searchAlertWithOK(title: .CustomEngineFormErrorTitle,
+                message: .CustomEngineFormErrorMessage)
     }
 
     static func duplicateCustomEngine() -> UIAlertController {
-        return searchAlertWithOK(title: .CustomEngineDuplicateErrorTitle,
-                                 message: .CustomEngineDuplicateErrorMessage)
+        searchAlertWithOK(title: .CustomEngineDuplicateErrorTitle,
+                message: .CustomEngineDuplicateErrorMessage)
     }
 
     private static func searchAlertWithOK(title: String, message: String) -> UIAlertController {

--- a/Client/Frontend/Browser/TopTabsLayout.swift
+++ b/Client/Frontend/Browser/TopTabsLayout.swift
@@ -13,7 +13,7 @@ class TopTabsLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout {
     let HeaderFooterWidth = TopTabsUX.SeparatorWidth + TopTabsUX.FaderPading
 
     @objc func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
-        return TopTabsUX.SeparatorWidth
+        TopTabsUX.SeparatorWidth
     }
 
     @objc func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
@@ -24,11 +24,11 @@ class TopTabsLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout {
     }
 
     @objc func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        return .zero
+        .zero
     }
 
     @objc func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        return TopTabsUX.SeparatorWidth
+        TopTabsUX.SeparatorWidth
     }
 
     @objc func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
@@ -36,11 +36,11 @@ class TopTabsLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout {
     }
 
     @objc func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
-        return CGSize(width: 0, height: 0)
+        CGSize(width: 0, height: 0)
     }
 
     @objc func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
-        return CGSize(width: 0, height: 0)
+        CGSize(width: 0, height: 0)
     }
 }
 
@@ -74,6 +74,6 @@ class TopTabsViewLayout: UICollectionViewFlowLayout {
     }
 
     override var flipsHorizontallyInOppositeLayoutDirection: Bool {
-        return true
+        true
     }
 }

--- a/Client/Frontend/Browser/URIFixup.swift
+++ b/Client/Frontend/Browser/URIFixup.swift
@@ -58,7 +58,7 @@ class URIFixup {
     }
 
     static func replaceBrackets(url: String) -> String {
-        return url.replacingOccurrences(of: "[", with: "%5B").replacingOccurrences(of: "]", with: "%5D")
+        url.replacingOccurrences(of: "[", with: "%5B").replacingOccurrences(of: "]", with: "%5D")
     }
 
     static func replaceHashMarks(url: String) -> String {

--- a/Client/Frontend/Browser/WebView/WebViewNavigationHandler.swift
+++ b/Client/Frontend/Browser/WebView/WebViewNavigationHandler.swift
@@ -40,7 +40,7 @@ struct WebViewNavigationHandlerImplementation: WebViewNavigationHandler {
     }
 
     func shouldFilterDataScheme(url: URL) -> Bool {
-        return url.scheme == WebViewNavigationHandlerImplementation.Scheme.data.rawValue
+        url.scheme == WebViewNavigationHandlerImplementation.Scheme.data.rawValue
     }
 
     func filterDataScheme(url: URL,

--- a/Client/Frontend/Components/FadeScrollView.swift
+++ b/Client/Frontend/Components/FadeScrollView.swift
@@ -14,15 +14,15 @@ class FadeScrollView: UIScrollView, UIScrollViewDelegate {
     private let opaqueColor = UIColor.black.cgColor
 
     private var needsToScroll: Bool {
-        return frame.size.height >= contentSize.height
+        frame.size.height >= contentSize.height
     }
 
     private var isAtBottom: Bool {
-        return contentOffset.y + frame.size.height >= contentSize.height
+        contentOffset.y + frame.size.height >= contentSize.height
     }
 
     private var isAtTop: Bool {
-        return contentOffset.y <= 0
+        contentOffset.y <= 0
     }
 
     private var topOpacity: CGColor {

--- a/Client/Frontend/Components/LabelButtonHeaderView.swift
+++ b/Client/Frontend/Components/LabelButtonHeaderView.swift
@@ -15,7 +15,7 @@ struct LabelButtonHeaderViewModel {
     var buttonA11yIdentifier: String?
 
     static var emptyHeader: LabelButtonHeaderViewModel {
-        return LabelButtonHeaderViewModel(title: nil, isButtonHidden: true)
+        LabelButtonHeaderViewModel(title: nil, isButtonHidden: true)
     }
 }
 

--- a/Client/Frontend/Contextual Hint/ContextualHintViewController.swift
+++ b/Client/Frontend/Contextual Hint/ContextualHintViewController.swift
@@ -253,7 +253,7 @@ class ContextualHintViewController: UIViewController, OnViewDismissable {
 
     // MARK: - Interface
     public func shouldPresentHint() -> Bool {
-        return viewModel.shouldPresentContextualHint()
+        viewModel.shouldPresentContextualHint()
     }
 
     public func configure(

--- a/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -49,20 +49,20 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
     // Private vars
     private var fxTextThemeColour: UIColor {
         // For dark theme we want to show light colours and for light we want to show dark colours
-        return theme.currentName == .dark ? .white : .black
+        theme.currentName == .dark ? .white : .black
     }
 
     private var fxBackgroundThemeColour: UIColor = UIColor.theme.onboarding.backgroundColor
 
     private var descriptionFontSize: CGFloat {
-        return screenSize.height > 1000 ? DBOnboardingUX.fontSizeXSmall :
-               screenSize.height > 668 ? DBOnboardingUX.fontSize :
-               screenSize.height > 640 ? DBOnboardingUX.fontSizeSmall : DBOnboardingUX.fontSizeXSmall
+        screenSize.height > 1000 ? DBOnboardingUX.fontSizeXSmall :
+                screenSize.height > 668 ? DBOnboardingUX.fontSize :
+                screenSize.height > 640 ? DBOnboardingUX.fontSizeSmall : DBOnboardingUX.fontSizeXSmall
     }
 
     private var titleFontSize: CGFloat {
-        return screenSize.height > 1000 ? DBOnboardingUX.titleSizeLarge :
-               screenSize.height > 640 ? DBOnboardingUX.titleSize : DBOnboardingUX.titleSizeSmall
+        screenSize.height > 1000 ? DBOnboardingUX.titleSizeLarge :
+                screenSize.height > 640 ? DBOnboardingUX.titleSize : DBOnboardingUX.titleSizeSmall
     }
 
     // Orientation independent screen size

--- a/Client/Frontend/EnhancedTrackingProtection/ETPCoverSheetViewController.swift
+++ b/Client/Frontend/EnhancedTrackingProtection/ETPCoverSheetViewController.swift
@@ -35,10 +35,10 @@ class ETPCoverSheetViewController: UIViewController {
     // Private vars
     private var fxTextThemeColour: UIColor {
         // For dark theme we want to show light colours and for light we want to show dark colours
-        return ETPCoverSheetViewController.theme == .dark ? .white : .black
+        ETPCoverSheetViewController.theme == .dark ? .white : .black
     }
     private var fxBackgroundThemeColour: UIColor {
-        return ETPCoverSheetViewController.theme == .dark ? .black : .white
+        ETPCoverSheetViewController.theme == .dark ? .black : .white
     }
     private var doneButton: UIButton = {
         let button = UIButton()
@@ -194,12 +194,12 @@ class ETPCoverSheetViewController: UIViewController {
 // UIViewController setup to keep it in portrait mode
 extension ETPCoverSheetViewController {
     override var shouldAutorotate: Bool {
-        return false
+        false
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         // This actually does the right thing on iPad where the modally
         // presented version happily rotates with the iPad orientation.
-        return .portrait
+        .portrait
     }
 }

--- a/Client/Frontend/Extensions/DevicePickerViewController.swift
+++ b/Client/Frontend/Extensions/DevicePickerViewController.swift
@@ -164,7 +164,7 @@ class DevicePickerViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
-         return indexPath.section != 0
+        indexPath.section != 0
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionViewModel.swift
+++ b/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionViewModel.swift
@@ -13,11 +13,11 @@ class CustomizeHomepageSectionViewModel {
 extension CustomizeHomepageSectionViewModel: HomepageViewModelProtocol {
 
     var sectionType: HomepageSectionType {
-        return .customizeHome
+        .customizeHome
     }
 
     var headerViewModel: LabelButtonHeaderViewModel {
-        return .emptyHeader
+        .emptyHeader
     }
 
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
@@ -37,11 +37,11 @@ extension CustomizeHomepageSectionViewModel: HomepageViewModelProtocol {
     }
 
     func numberOfItemsInSection(for traitCollection: UITraitCollection) -> Int {
-        return 1
+        1
     }
 
     var isEnabled: Bool {
-        return true
+        true
     }
 }
 

--- a/Client/Frontend/Home/HistoryHighlights/HighlightItem.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HighlightItem.swift
@@ -20,22 +20,22 @@ protocol HighlightItem {
 extension HistoryHighlight: HighlightItem {
 
     var group: [HighlightItem]? {
-        return nil
+        nil
     }
 
     var type: HighlightItemType {
-        return .item
+        .item
     }
 
     var displayTitle: String {
-        return title ?? url
+        title ?? url
     }
 
     var description: String? {
-        return nil
+        nil
     }
 
     var siteUrl: URL? {
-        return URL(string: url)
+        URL(string: url)
     }
 }

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsManager.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsManager.swift
@@ -9,7 +9,7 @@ import MozillaAppServices
 
 extension HistoryHighlight {
     var urlFromString: URL? {
-        return URL(string: url)
+        URL(string: url)
     }
 }
 

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHightlightsViewModel.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHightlightsViewModel.swift
@@ -152,16 +152,16 @@ class HistoryHightlightsViewModel {
 extension HistoryHightlightsViewModel: HomepageViewModelProtocol, FeatureFlaggable {
 
     var sectionType: HomepageSectionType {
-        return .historyHighlights
+        .historyHighlights
     }
 
     var headerViewModel: LabelButtonHeaderViewModel {
-        return LabelButtonHeaderViewModel(title: HomepageSectionType.historyHighlights.title,
-                                          titleA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.historyHighlights,
-                                          isButtonHidden: false,
-                                          buttonTitle: .RecentlySavedShowAllText,
-                                          buttonAction: headerButtonAction,
-                                          buttonA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.historyHighlights)
+        LabelButtonHeaderViewModel(title: HomepageSectionType.historyHighlights.title,
+                titleA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.historyHighlights,
+                isButtonHidden: false,
+                buttonTitle: .RecentlySavedShowAllText,
+                buttonAction: headerButtonAction,
+                buttonA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.historyHighlights)
     }
 
     var isEnabled: Bool {
@@ -214,7 +214,7 @@ extension HistoryHightlightsViewModel: HomepageViewModelProtocol, FeatureFlaggab
     }
 
     var hasData: Bool {
-        return !(historyItems?.isEmpty ?? true)
+        !(historyItems?.isEmpty ?? true)
     }
 
     func updateData(completion: @escaping () -> Void) {
@@ -325,7 +325,7 @@ extension HistoryHightlightsViewModel: HomepageSectionHandler {
     }
 
     private func isTopLeftCell(index: Int) -> Bool {
-        return index == 0
+        index == 0
     }
 
     private func isTopRightCell(index: Int, totalItems: Int) -> Bool {

--- a/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -79,21 +79,23 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
     // MARK: - Default actions
 
     func getOpenInNewPrivateTabAction(siteURL: URL) -> PhotonRowActions {
-        return SingleActionViewModel(title: .OpenInNewPrivateTabContextMenuTitle, iconString: ImageIdentifiers.newPrivateTab) { _ in
+        SingleActionViewModel(title: .OpenInNewPrivateTabContextMenuTitle, iconString: ImageIdentifiers.newPrivateTab) { _ in
             self.delegate?.homePanelDidRequestToOpenInNewTab(siteURL, isPrivate: true)
-        }.items
+        }
+                .items
     }
 
     // MARK: - History Highlights
 
     private func getHistoryHighlightsActions(for highlightItem: HighlightItem) -> [PhotonRowActions]? {
-        return [SingleActionViewModel(title: .RemoveContextMenuTitle,
-                                      iconString: ImageIdentifiers.actionRemove,
-                                      tapHandler: { _ in
+        [SingleActionViewModel(title: .RemoveContextMenuTitle,
+                iconString: ImageIdentifiers.actionRemove,
+                tapHandler: { _ in
 
-            self.viewModel.historyHighlightsViewModel.delete(highlightItem)
-            self.sendHistoryHighlightContextualTelemetry(type: .remove)
-        }).items]
+                    self.viewModel.historyHighlightsViewModel.delete(highlightItem)
+                    self.sendHistoryHighlightContextualTelemetry(type: .remove)
+                })
+                .items]
     }
 
     // MARK: - Pocket
@@ -110,17 +112,18 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
     }
 
     private func getOpenInNewTabAction(siteURL: URL, sectionType: HomepageSectionType) -> PhotonRowActions {
-        return SingleActionViewModel(title: .OpenInNewTabContextMenuTitle, iconString: ImageIdentifiers.newTab) { _ in
+        SingleActionViewModel(title: .OpenInNewTabContextMenuTitle, iconString: ImageIdentifiers.newTab) { _ in
             self.delegate?.homePanelDidRequestToOpenInNewTab(siteURL, isPrivate: false)
 
             if sectionType == .pocket {
                 let originExtras = TelemetryWrapper.getOriginExtras(isZeroSearch: self.viewModel.isZeroSearch)
                 TelemetryWrapper.recordEvent(category: .action,
-                                             method: .tap,
-                                             object: .pocketStory,
-                                             extras: originExtras)
+                        method: .tap,
+                        object: .pocketStory,
+                        extras: originExtras)
             }
-        }.items
+        }
+                .items
     }
 
     private func getBookmarkAction(site: Site) -> PhotonRowActions {
@@ -134,7 +137,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
     }
 
     private func getRemoveBookmarkAction(site: Site) -> SingleActionViewModel {
-        return SingleActionViewModel(title: .RemoveBookmarkContextMenuTitle, iconString: ImageIdentifiers.actionRemoveBookmark, tapHandler: { _ in
+        SingleActionViewModel(title: .RemoveBookmarkContextMenuTitle, iconString: ImageIdentifiers.actionRemoveBookmark, tapHandler: { _ in
             self.viewModel.profile.places.deleteBookmarksWithURL(url: site.url) >>== {
                 site.setBookmarked(false)
             }
@@ -144,7 +147,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
     }
 
     private func getAddBookmarkAction(site: Site) -> SingleActionViewModel {
-        return SingleActionViewModel(title: .BookmarkContextMenuTitle, iconString: ImageIdentifiers.actionAddBookmark, tapHandler: { _ in
+        SingleActionViewModel(title: .BookmarkContextMenuTitle, iconString: ImageIdentifiers.actionAddBookmark, tapHandler: { _ in
             let shareItem = ShareItem(url: site.url, title: site.title, favicon: site.icon)
             _ = self.viewModel.profile.places.createBookmark(parentGUID: BookmarkRoots.MobileFolderGUID, url: shareItem.url, title: shareItem.title)
 
@@ -153,17 +156,18 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
                 userData[QuickActions.TabTitleKey] = title
             }
             QuickActions.sharedInstance.addDynamicApplicationShortcutItemOfType(.openLastBookmark,
-                                                                                withUserData: userData,
-                                                                                toApplication: .shared)
+                    withUserData: userData,
+                    toApplication: .shared)
             site.setBookmarked(true)
             TelemetryWrapper.recordEvent(category: .action, method: .add, object: .bookmark, value: .activityStream)
         })
     }
 
     private func getShareAction(siteURL: URL, sourceView: UIView?) -> PhotonRowActions {
-        return SingleActionViewModel(title: .ShareContextMenuTitle, iconString: ImageIdentifiers.share, tapHandler: { _ in
+        SingleActionViewModel(title: .ShareContextMenuTitle, iconString: ImageIdentifiers.share, tapHandler: { _ in
             let helper = ShareExtensionHelper(url: siteURL, tab: nil)
-            let controller = helper.createActivityViewController { (_, _) in }
+            let controller = helper.createActivityViewController { (_, _) in
+            }
             if UIDevice.current.userInterfaceIdiom == .pad,
                let popoverController = controller.popoverPresentationController,
                let getSourceRect = self.getPopoverSourceRect {
@@ -175,7 +179,8 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
             }
 
             self.delegate?.presentWithModalDismissIfNeeded(controller, animated: true)
-        }).items
+        })
+                .items
     }
 
     // MARK: - Top sites
@@ -204,51 +209,58 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
 
     // Removes the site out of the top sites. If site is pinned it removes it from pinned and remove
     private func getRemoveTopSiteAction(site: Site) -> PhotonRowActions {
-        return SingleActionViewModel(title: .RemoveContextMenuTitle,
-                                     iconString: ImageIdentifiers.actionRemove,
-                                     tapHandler: { _ in
+        SingleActionViewModel(title: .RemoveContextMenuTitle,
+                iconString: ImageIdentifiers.actionRemove,
+                tapHandler: { _ in
 
-            self.viewModel.topSiteViewModel.removePinTopSite(site)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-                self?.viewModel.topSiteViewModel.hideURLFromTopSites(site)
-            }
+                    self.viewModel.topSiteViewModel.removePinTopSite(site)
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+                        self?.viewModel.topSiteViewModel.hideURLFromTopSites(site)
+                    }
 
-            self.sendTopSiteContextualTelemetry(type: .remove)
-        }).items
+                    self.sendTopSiteContextualTelemetry(type: .remove)
+                })
+                .items
     }
 
     private func getPinTopSiteAction(site: Site) -> PhotonRowActions {
-        return SingleActionViewModel(title: .PinTopsiteActionTitle2,
-                                     iconString: ImageIdentifiers.addShortcut,
-                                     tapHandler: { _ in
-            self.viewModel.topSiteViewModel.pinTopSite(site)
-            self.sendTopSiteContextualTelemetry(type: .pin)
-        }).items
+        SingleActionViewModel(title: .PinTopsiteActionTitle2,
+                iconString: ImageIdentifiers.addShortcut,
+                tapHandler: { _ in
+                    self.viewModel.topSiteViewModel.pinTopSite(site)
+                    self.sendTopSiteContextualTelemetry(type: .pin)
+                })
+                .items
     }
 
     // Unpin removes it from the location it's in. Still can appear in the top sites as unpin
     private func getRemovePinTopSiteAction(site: Site) -> PhotonRowActions {
-        return SingleActionViewModel(title: .UnpinTopsiteActionTitle2,
-                                     iconString: ImageIdentifiers.removeFromShortcut,
-                                     tapHandler: { _ in
-            self.viewModel.topSiteViewModel.removePinTopSite(site)
-            self.sendTopSiteContextualTelemetry(type: .unpin)
-        }).items
+        SingleActionViewModel(title: .UnpinTopsiteActionTitle2,
+                iconString: ImageIdentifiers.removeFromShortcut,
+                tapHandler: { _ in
+                    self.viewModel.topSiteViewModel.removePinTopSite(site)
+                    self.sendTopSiteContextualTelemetry(type: .unpin)
+                })
+                .items
     }
 
     private func getSettingsAction() -> PhotonRowActions {
-        return SingleActionViewModel(title: .FirefoxHomepage.ContextualMenu.Settings, iconString: ImageIdentifiers.settings, tapHandler: { _ in
+        SingleActionViewModel(title: .FirefoxHomepage.ContextualMenu.Settings, iconString: ImageIdentifiers.settings, tapHandler: { _ in
             self.delegate?.homePanelDidRequestToOpenSettings(at: .customizeTopSites)
             self.sendTopSiteContextualTelemetry(type: .settings)
-        }).items
+        })
+                .items
     }
 
     private func getSponsoredContentAction() -> PhotonRowActions {
-        return SingleActionViewModel(title: .FirefoxHomepage.ContextualMenu.SponsoredContent, iconString: ImageIdentifiers.help, tapHandler: { _ in
-            guard let url = SupportUtils.URLForTopic("sponsor-privacy") else { return }
+        SingleActionViewModel(title: .FirefoxHomepage.ContextualMenu.SponsoredContent, iconString: ImageIdentifiers.help, tapHandler: { _ in
+            guard let url = SupportUtils.URLForTopic("sponsor-privacy") else {
+                return
+            }
             self.delegate?.homePanelDidRequestToOpenInNewTab(url, isPrivate: false, selectNewTab: true)
             self.sendTopSiteContextualTelemetry(type: .sponsoredSupport)
-        }).items
+        })
+                .items
     }
 
     private func fetchBookmarkStatus(for site: Site, completionHandler: @escaping () -> Void) {

--- a/Client/Frontend/Home/HomepageContextMenuProtocol.swift
+++ b/Client/Frontend/Home/HomepageContextMenuProtocol.swift
@@ -21,7 +21,7 @@ extension HomepageContextMenuProtocol {
     // MARK: Site
     func presentContextMenu(for site: Site, with sourceView: UIView?, sectionType: HomepageSectionType) {
         presentContextMenu(for: site, with: sourceView, sectionType: sectionType, completionHandler: {
-            return self.contextMenu(for: site, with: sourceView, sectionType: sectionType)
+            self.contextMenu(for: site, with: sourceView, sectionType: sectionType)
         })
     }
 
@@ -46,7 +46,7 @@ extension HomepageContextMenuProtocol {
     // MARK: - Highlight Item
     func presentContextMenu(for highlightItem: HighlightItem, with sourceView: UIView?, sectionType: HomepageSectionType) {
         presentContextMenu(for: highlightItem, with: sourceView, sectionType: sectionType, completionHandler: {
-            return self.contextMenu(for: highlightItem, with: sourceView, sectionType: sectionType)
+            self.contextMenu(for: highlightItem, with: sourceView, sectionType: sectionType)
         })
     }
     func contextMenu(for highlightItem: HighlightItem, with sourceView: UIView?, sectionType: HomepageSectionType) -> PhotonActionSheet? {

--- a/Client/Frontend/Home/HomepageSectionType.swift
+++ b/Client/Frontend/Home/HomepageSectionType.swift
@@ -37,16 +37,16 @@ enum HomepageSectionType: Int, CaseIterable {
     }
 
     static var cellTypes: [ReusableCell.Type] {
-        return [HomeLogoHeaderCell.self,
-                TopSiteItemCell.self,
-                EmptyTopSiteCell.self,
-                HomeHorizontalCell.self,
-                PocketDiscoverCell.self,
-                PocketStandardCell.self,
-                RecentlySavedCell.self,
-                HistoryHighlightsCell.self,
-                CustomizeHomepageSectionView.self,
-                SyncedTabCell.self
+        [HomeLogoHeaderCell.self,
+         TopSiteItemCell.self,
+         EmptyTopSiteCell.self,
+         HomeHorizontalCell.self,
+         PocketDiscoverCell.self,
+         PocketStandardCell.self,
+         RecentlySavedCell.self,
+         HistoryHighlightsCell.self,
+         CustomizeHomepageSectionView.self,
+         SyncedTabCell.self
         ]
     }
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -43,7 +43,7 @@ class HomepageViewController: UIViewController, HomePanel, GleanPlumbMessageMana
     }
 
     var currentTab: Tab? {
-        return tabManager.selectedTab
+        tabManager.selectedTab
     }
 
     // MARK: - Initializers
@@ -209,7 +209,7 @@ class HomepageViewController: UIViewController, HomePanel, GleanPlumbMessageMana
     // MARK: Long press
 
     private lazy var longPressRecognizer: UILongPressGestureRecognizer = {
-        return UILongPressGestureRecognizer(target: self, action: #selector(longPress))
+        UILongPressGestureRecognizer(target: self, action: #selector(longPress))
     }()
 
     @objc fileprivate func longPress(_ longPressGestureRecognizer: UILongPressGestureRecognizer) {
@@ -340,7 +340,7 @@ class HomepageViewController: UIViewController, HomePanel, GleanPlumbMessageMana
     // MARK: - Home Tab Banner
 
     private var shouldDisplayHomeTabBanner: Bool {
-        return messagingManager.hasMessage(for: .newTabCard)
+        messagingManager.hasMessage(for: .newTabCard)
     }
 
     private func showHomeTabBanner() {
@@ -397,11 +397,11 @@ extension HomepageViewController: UICollectionViewDelegate, UICollectionViewData
     }
 
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return viewModel.shownSections.count
+        viewModel.shownSections.count
     }
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return viewModel.getSectionViewModel(shownSection: section)?.numberOfItemsInSection(for: traitCollection) ?? 0
+        viewModel.getSectionViewModel(shownSection: section)?.numberOfItemsInSection(for: traitCollection) ?? 0
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -640,11 +640,11 @@ extension HomepageViewController: UIPopoverPresentationControllerDelegate {
     }
 
     func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
-        return .none
+        .none
     }
 
     func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
-        return true
+        true
     }
 }
 

--- a/Client/Frontend/Home/HomepageViewModel.swift
+++ b/Client/Frontend/Home/HomepageViewModel.swift
@@ -209,7 +209,7 @@ class HomepageViewModel: FeatureFlaggable {
     }
 
     func indexOfShownSection(_ type: HomepageSectionType) -> Int? {
-        return shownSections.firstIndex(of: type)
+        shownSections.firstIndex(of: type)
     }
 }
 

--- a/Client/Frontend/Home/HomepageViewModelProtocol.swift
+++ b/Client/Frontend/Home/HomepageViewModelProtocol.swift
@@ -38,10 +38,12 @@ protocol HomepageViewModelProtocol {
 }
 
 extension HomepageViewModelProtocol {
-    var hasData: Bool { return true }
+    var hasData: Bool {
+        true
+    }
 
     var shouldShow: Bool {
-        return isEnabled && hasData
+        isEnabled && hasData
     }
 
     func updateData(completion: @escaping () -> Void) {

--- a/Client/Frontend/Home/JumpBackIn/HomeHorizontalCell.swift
+++ b/Client/Frontend/Home/JumpBackIn/HomeHorizontalCell.swift
@@ -14,7 +14,7 @@ struct FxHomeHorizontalCellViewModel {
     var favIconImage: UIImage?
     var heroImage: UIImage?
     var accessibilityLabel: String {
-        return "\(titleText), \(descriptionText)"
+        "\(titleText), \(descriptionText)"
     }
 }
 

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -213,7 +213,7 @@ class JumpBackInViewModel: FeatureFlaggable {
 private extension JumpBackInViewModel {
 
     var hasJumpBackIn: Bool {
-        return !recentTabs.isEmpty || !(recentGroups?.isEmpty ?? true)
+        !recentTabs.isEmpty || !(recentGroups?.isEmpty ?? true)
     }
 
     func createJumpBackInList(
@@ -280,12 +280,12 @@ private extension JumpBackInViewModel {
 private extension JumpBackInViewModel {
 
     var hasSyncedTabFeatureEnabled: Bool {
-        return profile.hasSyncableAccount() &&
+        profile.hasSyncableAccount() &&
                 featureFlags.isFeatureEnabled(.jumpBackInSyncedTab, checking: .buildOnly)
     }
 
     var hasSyncedTab: Bool {
-        return hasSyncedTabFeatureEnabled && mostRecentSyncedTab != nil
+        hasSyncedTabFeatureEnabled && mostRecentSyncedTab != nil
     }
 
     func updateRemoteTabs(completion: @escaping () -> Void) {
@@ -529,17 +529,17 @@ private extension JumpBackInViewModel {
 extension JumpBackInViewModel: HomepageViewModelProtocol {
 
     var sectionType: HomepageSectionType {
-        return .jumpBackIn
+        .jumpBackIn
     }
 
     var headerViewModel: LabelButtonHeaderViewModel {
-        return LabelButtonHeaderViewModel(trailingInset: 0,
-                                          title: HomepageSectionType.jumpBackIn.title,
-                                          titleA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.jumpBackIn,
-                                          isButtonHidden: false,
-                                          buttonTitle: .RecentlySavedShowAllText,
-                                          buttonAction: headerButtonAction,
-                                          buttonA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn)
+        LabelButtonHeaderViewModel(trailingInset: 0,
+                title: HomepageSectionType.jumpBackIn.title,
+                titleA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.jumpBackIn,
+                isButtonHidden: false,
+                buttonTitle: .RecentlySavedShowAllText,
+                buttonAction: headerButtonAction,
+                buttonA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn)
     }
 
     var isEnabled: Bool {
@@ -585,7 +585,7 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
     }
 
     var hasData: Bool {
-        return hasJumpBackIn || hasSyncedTab
+        hasJumpBackIn || hasSyncedTab
     }
 
     func updateData(completion: @escaping () -> Void) {
@@ -671,7 +671,7 @@ extension JumpBackInViewModel: HomepageSectionHandler {
     func configure(_ cell: UICollectionViewCell,
                    at indexPath: IndexPath) -> UICollectionViewCell {
         // Setup is done through configure(collectionView:indexPath:), shouldn't be called
-        return UICollectionViewCell()
+        UICollectionViewCell()
     }
 
     func didSelectItem(at indexPath: IndexPath,

--- a/Client/Frontend/Home/JumpBackIn/SyncedTabCell.swift
+++ b/Client/Frontend/Home/JumpBackIn/SyncedTabCell.swift
@@ -12,13 +12,13 @@ struct FxHomeSyncedTabCellViewModel {
     var syncedDeviceImage: UIImage?
     var heroImage: UIImage?
     var accessibilityLabel: String {
-        return "\(cardTitleText): \(titleText), \(descriptionText)"
+        "\(cardTitleText): \(titleText), \(descriptionText)"
     }
     var cardTitleText: String {
-        return .FirefoxHomepage.JumpBackIn.SyncedTabTitle
+        .FirefoxHomepage.JumpBackIn.SyncedTabTitle
     }
     var syncedTabsButtonText: String {
-        return .FirefoxHomepage.JumpBackIn.SyncedTabShowAllButtonTitle
+        .FirefoxHomepage.JumpBackIn.SyncedTabShowAllButtonTitle
     }
 }
 

--- a/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
+++ b/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
@@ -23,11 +23,11 @@ class HomeLogoHeaderViewModel {
 extension HomeLogoHeaderViewModel: HomepageViewModelProtocol, FeatureFlaggable {
 
     var sectionType: HomepageSectionType {
-        return .logoHeader
+        .logoHeader
     }
 
     var headerViewModel: LabelButtonHeaderViewModel {
-        return .emptyHeader
+        .emptyHeader
     }
 
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
@@ -49,11 +49,11 @@ extension HomeLogoHeaderViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 
     func numberOfItemsInSection(for traitCollection: UITraitCollection) -> Int {
-        return 1
+        1
     }
 
     var isEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.wallpapers, checking: .buildOnly)
+        featureFlags.isFeatureEnabled(.wallpapers, checking: .buildOnly)
     }
 }
 

--- a/Client/Frontend/Home/Pocket/PocketStandardCell.swift
+++ b/Client/Frontend/Home/Pocket/PocketStandardCell.swift
@@ -17,7 +17,7 @@ class PocketStandardCellViewModel {
         }
     }
     var accessibilityLabel: String {
-        return "\(title), \(description)"
+        "\(title), \(description)"
     }
 
     var onTap: (IndexPath) -> Void = { _ in }

--- a/Client/Frontend/Home/Pocket/PocketViewModel.swift
+++ b/Client/Frontend/Home/Pocket/PocketViewModel.swift
@@ -66,11 +66,11 @@ class PocketViewModel {
     }
 
     var numberOfCells: Int {
-        return !pocketStoriesViewModels.isEmpty ? pocketStoriesViewModels.count + 1 : 0
+        !pocketStoriesViewModels.isEmpty ? pocketStoriesViewModels.count + 1 : 0
     }
 
     func isStoryCell(index: Int) -> Bool {
-        return index < pocketStoriesViewModels.count
+        index < pocketStoriesViewModels.count
     }
 
     func getSitesDetail(for index: Int) -> Site {
@@ -122,13 +122,13 @@ class PocketViewModel {
 extension PocketViewModel: HomepageViewModelProtocol, FeatureFlaggable {
 
     var sectionType: HomepageSectionType {
-        return .pocket
+        .pocket
     }
 
     var headerViewModel: LabelButtonHeaderViewModel {
-        return LabelButtonHeaderViewModel(title: HomepageSectionType.pocket.title,
-                                          titleA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket,
-                                          isButtonHidden: true)
+        LabelButtonHeaderViewModel(title: HomepageSectionType.pocket.title,
+                titleA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket,
+                isButtonHidden: true)
     }
 
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
@@ -168,7 +168,7 @@ extension PocketViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 
     func numberOfItemsInSection(for traitCollection: UITraitCollection) -> Int {
-        return numberOfCells
+        numberOfCells
     }
 
     var isEnabled: Bool {
@@ -181,7 +181,7 @@ extension PocketViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 
     var hasData: Bool {
-        return !pocketStoriesViewModels.isEmpty
+        !pocketStoriesViewModels.isEmpty
     }
 
     func updateData(completion: @escaping () -> Void) {
@@ -215,7 +215,7 @@ extension PocketViewModel: HomepageSectionHandler {
     func configure(_ cell: UICollectionViewCell,
                    at indexPath: IndexPath) -> UICollectionViewCell {
         // Setup is done through configure(collectionView:indexPath:), shouldn't be called
-        return UICollectionViewCell()
+        UICollectionViewCell()
     }
 
     func didSelectItem(at indexPath: IndexPath,

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
@@ -43,16 +43,16 @@ class RecentlySavedCellViewModel {
 extension RecentlySavedCellViewModel: HomepageViewModelProtocol, FeatureFlaggable {
 
     var sectionType: HomepageSectionType {
-        return .recentlySaved
+        .recentlySaved
     }
 
     var headerViewModel: LabelButtonHeaderViewModel {
-        return LabelButtonHeaderViewModel(title: HomepageSectionType.recentlySaved.title,
-                                          titleA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.recentlySaved,
-                                          isButtonHidden: false,
-                                          buttonTitle: .RecentlySavedShowAllText,
-                                          buttonAction: headerButtonAction,
-                                          buttonA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.recentlySaved)
+        LabelButtonHeaderViewModel(title: HomepageSectionType.recentlySaved.title,
+                titleA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.recentlySaved,
+                isButtonHidden: false,
+                buttonTitle: .RecentlySavedShowAllText,
+                buttonAction: headerButtonAction,
+                buttonA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.recentlySaved)
     }
 
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
@@ -88,15 +88,15 @@ extension RecentlySavedCellViewModel: HomepageViewModelProtocol, FeatureFlaggabl
     }
 
     func numberOfItemsInSection(for traitCollection: UITraitCollection) -> Int {
-        return recentItems.count
+        recentItems.count
     }
 
     var isEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.recentlySaved, checking: .buildAndUser)
+        featureFlags.isFeatureEnabled(.recentlySaved, checking: .buildAndUser)
     }
 
     var hasData: Bool {
-        return !recentItems.isEmpty
+        !recentItems.isEmpty
     }
 
     /// Using dispatch group to know when data has completely loaded for both sources (recent bookmarks and reading list items)

--- a/Client/Frontend/Home/TopSites/DataManagement/ContileProvider.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/ContileProvider.swift
@@ -32,7 +32,7 @@ class ContileProvider: ContileProviderInterface, Loggable, URLCaching, FeatureFl
                                          configuration: URLSessionConfiguration.default)
 
     lazy var urlCache: URLCache = {
-        return URLCache.shared
+        URLCache.shared
     }()
 
     enum Error: Swift.Error {

--- a/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
@@ -82,7 +82,7 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable, 
     }
 
     func getTopSitesData() -> [TopSite] {
-        return topSites
+        topSites
     }
 
     func recalculateTopSiteData(for numberOfTilesPerRow: Int) {
@@ -196,11 +196,11 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable, 
     // MARK: - Sponsored tiles (Contiles)
 
     private var shouldLoadSponsoredTiles: Bool {
-        return featureFlags.isFeatureEnabled(.sponsoredTiles, checking: .buildAndUser)
+        featureFlags.isFeatureEnabled(.sponsoredTiles, checking: .buildAndUser)
     }
 
     private var shouldAddSponsoredTiles: Bool {
-        return !contiles.isEmpty && shouldLoadSponsoredTiles
+        !contiles.isEmpty && shouldLoadSponsoredTiles
     }
 
     /// Google tile has precedence over Sponsored Tiles, if Google tile is present

--- a/Client/Frontend/Home/TopSites/TopSite.swift
+++ b/Client/Frontend/Home/TopSites/TopSite.swift
@@ -13,31 +13,31 @@ final class TopSite {
     var title: String
 
     var sponsoredText: String {
-        return .FirefoxHomepage.Shortcuts.Sponsored
+        .FirefoxHomepage.Shortcuts.Sponsored
     }
 
     var accessibilityLabel: String? {
-        return isSponsoredTile ? "\(title), \(sponsoredText)" : title
+        isSponsoredTile ? "\(title), \(sponsoredText)" : title
     }
 
     var isPinned: Bool {
-        return (site as? PinnedSite) != nil
+        (site as? PinnedSite) != nil
     }
 
     var isSuggested: Bool {
-        return (site as? SuggestedSite) != nil
+        (site as? SuggestedSite) != nil
     }
 
     var isSponsoredTile: Bool {
-        return (site as? SponsoredTile) != nil
+        (site as? SponsoredTile) != nil
     }
 
     var isGoogleGUID: Bool {
-        return site.guid == GoogleTopSiteManager.Constants.googleGUID
+        site.guid == GoogleTopSiteManager.Constants.googleGUID
     }
 
     var isGoogleURL: Bool {
-        return site.url == GoogleTopSiteManager.Constants.usUrl || site.url == GoogleTopSiteManager.Constants.rowUrl
+        site.url == GoogleTopSiteManager.Constants.usUrl || site.url == GoogleTopSiteManager.Constants.rowUrl
     }
 
     var imageLoaded: ((UIImage?) -> Void)?

--- a/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -116,7 +116,7 @@ class TopSitesViewModel {
 extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
 
     var sectionType: HomepageSectionType {
-        return .topSites
+        .topSites
     }
 
     var headerViewModel: LabelButtonHeaderViewModel {
@@ -128,7 +128,7 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 
     var isEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.topSites, checking: .buildAndUser)
+        featureFlags.isFeatureEnabled(.topSites, checking: .buildAndUser)
     }
 
     func numberOfItemsInSection(for traitCollection: UITraitCollection) -> Int {
@@ -171,7 +171,7 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 
     var hasData: Bool {
-        return !topSites.isEmpty
+        !topSites.isEmpty
     }
 
     func updateData(completion: @escaping () -> Void) {
@@ -218,7 +218,7 @@ extension TopSitesViewModel: HomepageSectionHandler {
     func configure(_ cell: UICollectionViewCell,
                    at indexPath: IndexPath) -> UICollectionViewCell {
         // Setup is done through configure(collectionView:indexPath:), shouldn't be called
-        return UICollectionViewCell()
+        UICollectionViewCell()
     }
 
     func didSelectItem(at indexPath: IndexPath,

--- a/Client/Frontend/Home/Wallpapers/Legacy/LegacyWallpaperDataManager.swift
+++ b/Client/Frontend/Home/Wallpapers/Legacy/LegacyWallpaperDataManager.swift
@@ -73,7 +73,7 @@ struct LegacyWallpaperDataManager {
     }
 
     public func getImageSet(at index: Int) -> LegacyWallpaperImageSet {
-        return resourceManager.getImageSet(for: availableWallpapers[index])
+        resourceManager.getImageSet(for: availableWallpapers[index])
     }
 
     // MARK: - Wallpaper data
@@ -122,16 +122,16 @@ struct LegacyWallpaperDataManager {
     }
 
     private func firefoxDefaultCollection() -> [LegacyWallpaperCollection] {
-        return [LegacyWallpaperCollection(
-            wallpaperFileNames: [WallpaperID(name: "fxSunrise",
-                                             accessibilityLabel: accessibilityIDs.FxSunriseWallpaper)],
-            ofType: .themed(type: .firefox)),
-                LegacyWallpaperCollection(
-            wallpaperFileNames: [WallpaperID(name: "fxCerulean",
-                                             accessibilityLabel: accessibilityIDs.FxCeruleanWallpaper),
-                                 WallpaperID(name: "fxAmethyst",
-                                             accessibilityLabel: accessibilityIDs.FxAmethystWallpaper)],
-            ofType: .themed(type: .firefoxOverlay))]
+        [LegacyWallpaperCollection(
+                wallpaperFileNames: [WallpaperID(name: "fxSunrise",
+                        accessibilityLabel: accessibilityIDs.FxSunriseWallpaper)],
+                ofType: .themed(type: .firefox)),
+            LegacyWallpaperCollection(
+                    wallpaperFileNames: [WallpaperID(name: "fxCerulean",
+                            accessibilityLabel: accessibilityIDs.FxCeruleanWallpaper),
+                        WallpaperID(name: "fxAmethyst",
+                                accessibilityLabel: accessibilityIDs.FxAmethystWallpaper)],
+                    ofType: .themed(type: .firefoxOverlay))]
     }
 
     private func allSpecialCollections() -> [LegacyWallpaperCollection]? {
@@ -173,11 +173,11 @@ extension LegacyWallpaperDataManager {
     }
 
     private func v100CelebrationCollection() -> LegacyWallpaperCollection {
-        return LegacyWallpaperCollection(
-            wallpaperFileNames: [WallpaperID(name: "beachVibes",
-                                             accessibilityLabel: accessibilityIDs.FxBeachHillsWallpaper),
-                                 WallpaperID(name: "twilightHills",
-                                             accessibilityLabel: accessibilityIDs.FxTwilightHillsWallpaper)],
-            ofType: .themed(type: .v100Celebration))
+        LegacyWallpaperCollection(
+                wallpaperFileNames: [WallpaperID(name: "beachVibes",
+                        accessibilityLabel: accessibilityIDs.FxBeachHillsWallpaper),
+                    WallpaperID(name: "twilightHills",
+                            accessibilityLabel: accessibilityIDs.FxTwilightHillsWallpaper)],
+                ofType: .themed(type: .v100Celebration))
     }
 }

--- a/Client/Frontend/Home/Wallpapers/Legacy/LegacyWallpaperManager.swift
+++ b/Client/Frontend/Home/Wallpapers/Legacy/LegacyWallpaperManager.swift
@@ -14,11 +14,11 @@ struct LegacyWallpaperManager {
     private let storageManager: LegacyWallpaperStorageUtility
 
     var numberOfWallpapers: Int {
-        return dataManager.availableWallpapers.count
+        dataManager.availableWallpapers.count
     }
 
     var currentWallpaperImage: UIImage? {
-        return storageManager.getCurrentWallpaperImage()
+        storageManager.getCurrentWallpaperImage()
     }
 
     var currentWallpaper: LegacyWallpaper {
@@ -53,7 +53,9 @@ struct LegacyWallpaperManager {
     /// being turned on, as `false` is what UserDefaults returns when a bool does not
     /// exist for a key.
     var switchWallpaperFromLogoEnabled: Bool {
-        get { return !userDefaults.bool(forKey: PrefsKeys.WallpaperManagerLogoSwitchPreference) }
+        get {
+            !userDefaults.bool(forKey: PrefsKeys.WallpaperManagerLogoSwitchPreference)
+        }
         set { userDefaults.set(!newValue, forKey: PrefsKeys.WallpaperManagerLogoSwitchPreference) }
     }
 
@@ -87,11 +89,11 @@ struct LegacyWallpaperManager {
     }
 
     public func getWallpaperTelemetryAt(index: Int) -> [String: String] {
-        return dataManager.availableWallpapers[index].telemetryMetadata
+        dataManager.availableWallpapers[index].telemetryMetadata
     }
 
     public func getAccessibilityLabelForWallpaper(at index: Int) -> String {
-        return dataManager.availableWallpapers[index].accessibilityLabel
+        dataManager.availableWallpapers[index].accessibilityLabel
     }
 
     public func runResourceVerification() {

--- a/Client/Frontend/Home/Wallpapers/Legacy/LegacyWallpaperResourceManager.swift
+++ b/Client/Frontend/Home/Wallpapers/Legacy/LegacyWallpaperResourceManager.swift
@@ -20,11 +20,11 @@ struct LegacyWallpaperImageResourceName {
     let landscape: String
 
     var portraitPath: String {
-        return "\(folder)/\(portrait)"
+        "\(folder)/\(portrait)"
     }
 
     var landscapePath: String {
-        return "\(folder)/\(landscape)"
+        "\(folder)/\(landscape)"
     }
 
     init(folder: String, portrait: String, landscape: String) {

--- a/Client/Frontend/Home/Wallpapers/Legacy/Utilities/LegacyWallpaperNetworkUtility.swift
+++ b/Client/Frontend/Home/Wallpapers/Legacy/Utilities/LegacyWallpaperNetworkUtility.swift
@@ -16,7 +16,7 @@ class LegacyWallpaperNetworkUtility: LegacyWallpaperFilePathProtocol, Loggable {
     // MARK: - Variables
     private static let wallpaperURLScheme = "MozWallpaperURLScheme"
     lazy var downloadProtocol: LegacyWallpaperDownloadProtocol = {
-        return URLSession.shared
+        URLSession.shared
     }()
 
     // MARK: - Public interfaces

--- a/Client/Frontend/Home/Wallpapers/v2/NetworkServices/WallpaperNetworkModule.swift
+++ b/Client/Frontend/Home/Wallpapers/v2/NetworkServices/WallpaperNetworkModule.swift
@@ -15,29 +15,30 @@ class WallpaperNetworkingModule: WallpaperNetworking {
 
     /// A basic async/await wrapper
     func data(from url: URL) async throws -> (Data, URLResponse) {
-        return try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             urlSession.dataTaskWith(url) { data, response, error in
 
-                if let error = error {
-                    continuation.resume(throwing: error)
-                    return
-                }
+                        if let error = error {
+                            continuation.resume(throwing: error)
+                            return
+                        }
 
-                guard let response = validatedHTTPResponse(response, statusCode: 200..<300) else {
-                    continuation.resume(throwing: URLError(.badServerResponse))
-                    return
-                }
+                        guard let response = validatedHTTPResponse(response, statusCode: 200..<300) else {
+                            continuation.resume(throwing: URLError(.badServerResponse))
+                            return
+                        }
 
-                guard let data = data,
-                      !data.isEmpty
-                else {
-                    continuation.resume(throwing: WallpaperServiceError.dataUnavailable)
-                    return
-                }
+                        guard let data = data,
+                              !data.isEmpty
+                        else {
+                            continuation.resume(throwing: WallpaperServiceError.dataUnavailable)
+                            return
+                        }
 
-                continuation.resume(returning: (data, response))
+                        continuation.resume(returning: (data, response))
 
-            }.resume()
+                    }
+                    .resume()
         }
     }
 }

--- a/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
+++ b/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
@@ -281,11 +281,11 @@ class ErrorPageHelper {
 
 extension ErrorPageHelper: TabContentScript {
     static func name() -> String {
-        return "ErrorPageHelper"
+        "ErrorPageHelper"
     }
 
     func scriptMessageHandlerName() -> String? {
-        return "errorPageHelperMessageManager"
+        "errorPageHelperMessageManager"
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {

--- a/Client/Frontend/InternalSchemeHandler/InternalSchemeHandler.swift
+++ b/Client/Frontend/InternalSchemeHandler/InternalSchemeHandler.swift
@@ -19,7 +19,7 @@ protocol InternalSchemeResponse {
 class InternalSchemeHandler: NSObject, WKURLSchemeHandler {
 
     static func response(forUrl url: URL) -> URLResponse {
-        return URLResponse(url: url, mimeType: "text/html", expectedContentLength: -1, textEncodingName: "utf-8")
+        URLResponse(url: url, mimeType: "text/html", expectedContentLength: -1, textEncodingName: "utf-8")
     }
 
     // Responders are looked up based on the path component, for instance responder["about/license"] is used for 'internal://local/about/license'

--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -224,16 +224,16 @@ extension IntroViewController: OnboardingCardDelegate {
 // MARK: UIViewController setup
 extension IntroViewController {
     override var prefersStatusBarHidden: Bool {
-        return true
+        true
     }
 
     override var shouldAutorotate: Bool {
-        return false
+        false
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         // This actually does the right thing on iPad where the modally
         // presented version happily rotates with the iPad orientation.
-        return .portrait
+        .portrait
     }
 }

--- a/Client/Frontend/Intro/OnboardingCardViewController.swift
+++ b/Client/Frontend/Intro/OnboardingCardViewController.swift
@@ -30,7 +30,7 @@ class OnboardingCardViewController: UIViewController {
     weak var delegate: OnboardingCardDelegate?
 
     var shouldUseSmallDeviceLayout: Bool {
-        return view.frame.height < 600
+        view.frame.height < 600
     }
 
     private lazy var scrollView: UIScrollView = .build { view in

--- a/Client/Frontend/Intro/WallpapersCardViewController.swift
+++ b/Client/Frontend/Intro/WallpapersCardViewController.swift
@@ -115,7 +115,7 @@ class WallpaperCardViewController: OnboardingCardViewController {
 
 extension WallpaperCardViewController: UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return wallpaperManager.numberOfWallpapers
+        wallpaperManager.numberOfWallpapers
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {

--- a/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
@@ -57,7 +57,7 @@ class BookmarkDetailPanel: SiteTableViewController {
     var bookmarkItemURL: String?
 
     var isNew: Bool {
-        return bookmarkNodeGUID == nil
+        bookmarkNodeGUID == nil
     }
 
     var isFolderListExpanded = false
@@ -67,7 +67,7 @@ class BookmarkDetailPanel: SiteTableViewController {
     var bookmarkFolders: [(folder: BookmarkFolderData, indent: Int)] = []
 
     private var maxIndentationLevel: Int {
-        return Int(floor((view.frame.width - BookmarkDetailPanelUX.MinIndentedContentWidth) / BookmarkDetailPanelUX.IndentationWidth))
+        Int(floor((view.frame.width - BookmarkDetailPanelUX.MinIndentedContentWidth) / BookmarkDetailPanelUX.IndentationWidth))
     }
 
     // Additional UI elements only used if `BookmarkDetailPanel` is called from the toast button
@@ -251,7 +251,7 @@ class BookmarkDetailPanel: SiteTableViewController {
                 }
 
                 return profile.places.createBookmark(parentGUID: parentBookmarkFolder.guid, url: bookmarkItemURL, title: bookmarkItemOrFolderTitle).bind({ result in
-                    return result.isFailure ? deferMaybe(BookmarkDetailPanelError()) : succeed()
+                    result.isFailure ? deferMaybe(BookmarkDetailPanelError()) : succeed()
                 })
             } else if bookmarkNodeType == .folder {
                 guard let bookmarkItemOrFolderTitle = self.bookmarkItemOrFolderTitle else {
@@ -259,7 +259,7 @@ class BookmarkDetailPanel: SiteTableViewController {
                 }
 
                 return profile.places.createFolder(parentGUID: parentBookmarkFolder.guid, title: bookmarkItemOrFolderTitle).bind({ result in
-                    return result.isFailure ? deferMaybe(BookmarkDetailPanelError()) : succeed()
+                    result.isFailure ? deferMaybe(BookmarkDetailPanelError()) : succeed()
                 })
             }
         } else {
@@ -304,7 +304,7 @@ class BookmarkDetailPanel: SiteTableViewController {
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        return BookmarkDetailSection.allCases.count
+        BookmarkDetailSection.allCases.count
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/Client/Frontend/Library/Bookmarks/BookmarksFolderCell.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksFolderCell.swift
@@ -99,22 +99,22 @@ extension BookmarkItemData: BookmarksFolderCell {
 extension FxBookmarkNode {
 
     var leftImageView: UIImage? {
-        return LegacyThemeManager.instance.currentName == .dark ? bookmarkFolderIconDark : bookmarkFolderIconNormal
+        LegacyThemeManager.instance.currentName == .dark ? bookmarkFolderIconDark : bookmarkFolderIconNormal
     }
 
     var chevronImage: UIImage? {
-        return UIImage(named: ImageIdentifiers.menuChevron)
+        UIImage(named: ImageIdentifiers.menuChevron)
     }
 
     private var bookmarkFolderIconNormal: UIImage? {
-        return UIImage(named: ImageIdentifiers.bookmarkFolder)?
-            .createScaled(BookmarksPanel.UX.FolderIconSize)
-            .tinted(withColor: UIColor.Photon.Grey90)
+        UIImage(named: ImageIdentifiers.bookmarkFolder)?
+                .createScaled(BookmarksPanel.UX.FolderIconSize)
+                .tinted(withColor: UIColor.Photon.Grey90)
     }
 
     private var bookmarkFolderIconDark: UIImage? {
-        return UIImage(named: ImageIdentifiers.bookmarkFolder)?
-            .createScaled(BookmarksPanel.UX.FolderIconSize)
-            .tinted(withColor: UIColor.Photon.Grey10)
+        UIImage(named: ImageIdentifiers.bookmarkFolder)?
+                .createScaled(BookmarksPanel.UX.FolderIconSize)
+                .tinted(withColor: UIColor.Photon.Grey10)
     }
 }

--- a/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -147,57 +147,66 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel, CanRemoveQuickActio
     }
 
     private func getNewBookmarkAction() -> PhotonRowActions {
-        return SingleActionViewModel(title: .BookmarksNewBookmark,
-                                     iconString: ImageIdentifiers.actionAddBookmark,
-                                     tapHandler: { _ in
-            guard let bookmarkFolder = self.viewModel.bookmarkFolder else { return }
+        SingleActionViewModel(title: .BookmarksNewBookmark,
+                iconString: ImageIdentifiers.actionAddBookmark,
+                tapHandler: { _ in
+                    guard let bookmarkFolder = self.viewModel.bookmarkFolder else {
+                        return
+                    }
 
-            self.updatePanelState(newState: .bookmarks(state: .itemEditMode))
-            let detailController = BookmarkDetailPanel(profile: self.profile,
-                                                       withNewBookmarkNodeType: .bookmark,
-                                                       parentBookmarkFolder: bookmarkFolder)
-            self.navigationController?.pushViewController(detailController, animated: true)
-        }).items
+                    self.updatePanelState(newState: .bookmarks(state: .itemEditMode))
+                    let detailController = BookmarkDetailPanel(profile: self.profile,
+                            withNewBookmarkNodeType: .bookmark,
+                            parentBookmarkFolder: bookmarkFolder)
+                    self.navigationController?.pushViewController(detailController, animated: true)
+                })
+                .items
     }
 
     private func getNewFolderAction() -> PhotonRowActions {
-        return SingleActionViewModel(title: .BookmarksNewFolder,
-                                     iconString: ImageIdentifiers.bookmarkFolder,
-                                     tapHandler: { _ in
-            guard let bookmarkFolder = self.viewModel.bookmarkFolder else { return }
+        SingleActionViewModel(title: .BookmarksNewFolder,
+                iconString: ImageIdentifiers.bookmarkFolder,
+                tapHandler: { _ in
+                    guard let bookmarkFolder = self.viewModel.bookmarkFolder else {
+                        return
+                    }
 
-            self.updatePanelState(newState: .bookmarks(state: .itemEditMode))
-            let detailController = BookmarkDetailPanel(profile: self.profile,
-                                                       withNewBookmarkNodeType: .folder,
-                                                       parentBookmarkFolder: bookmarkFolder)
-            self.navigationController?.pushViewController(detailController, animated: true)
-        }).items
+                    self.updatePanelState(newState: .bookmarks(state: .itemEditMode))
+                    let detailController = BookmarkDetailPanel(profile: self.profile,
+                            withNewBookmarkNodeType: .folder,
+                            parentBookmarkFolder: bookmarkFolder)
+                    self.navigationController?.pushViewController(detailController, animated: true)
+                })
+                .items
     }
 
     private func getNewSeparatorAction() -> PhotonRowActions {
-        return SingleActionViewModel(title: .BookmarksNewSeparator,
-                                     iconString: ImageIdentifiers.navMenu,
-                                     tapHandler: { _ in
-            let centerVisibleRow = self.centerVisibleRow()
+        SingleActionViewModel(title: .BookmarksNewSeparator,
+                iconString: ImageIdentifiers.navMenu,
+                tapHandler: { _ in
+                    let centerVisibleRow = self.centerVisibleRow()
 
-            self.profile.places.createSeparator(parentGUID: self.viewModel.bookmarkFolderGUID,
-                                                position: UInt32(centerVisibleRow)) >>== { guid in
-                self.profile.places.getBookmark(guid: guid).uponQueue(.main) { result in
-                    guard let bookmarkNode = result.successValue,
-                          let bookmarkSeparator = bookmarkNode as? BookmarkSeparatorData
-                    else { return }
+                    self.profile.places.createSeparator(parentGUID: self.viewModel.bookmarkFolderGUID,
+                            position: UInt32(centerVisibleRow)) >>== { guid in
+                        self.profile.places.getBookmark(guid: guid).uponQueue(.main) { result in
+                            guard let bookmarkNode = result.successValue,
+                                  let bookmarkSeparator = bookmarkNode as? BookmarkSeparatorData
+                            else {
+                                return
+                            }
 
-                    let indexPath = IndexPath(row: centerVisibleRow,
-                                              section: BookmarksPanelViewModel.BookmarksSection.bookmarks.rawValue)
-                    self.tableView.beginUpdates()
-                    self.viewModel.bookmarkNodes.insert(bookmarkSeparator, at: centerVisibleRow)
-                    self.tableView.insertRows(at: [indexPath], with: .automatic)
-                    self.tableView.endUpdates()
+                            let indexPath = IndexPath(row: centerVisibleRow,
+                                    section: BookmarksPanelViewModel.BookmarksSection.bookmarks.rawValue)
+                            self.tableView.beginUpdates()
+                            self.viewModel.bookmarkNodes.insert(bookmarkSeparator, at: centerVisibleRow)
+                            self.tableView.insertRows(at: [indexPath], with: .automatic)
+                            self.tableView.endUpdates()
 
-                    self.flashRow(at: indexPath)
-                }
-            }
-        }).items
+                            self.flashRow(at: indexPath)
+                        }
+                    }
+                })
+                .items
     }
 
     private func centerVisibleRow() -> Int {
@@ -273,9 +282,9 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel, CanRemoveQuickActio
     // MARK: - Utility
 
     private func indexPathIsValid(_ indexPath: IndexPath) -> Bool {
-        return indexPath.section < numberOfSections(in: tableView)
-        && indexPath.row < tableView(tableView, numberOfRowsInSection: indexPath.section)
-        && viewModel.bookmarkFolderGUID != BookmarkRoots.MobileFolderGUID
+        indexPath.section < numberOfSections(in: tableView)
+                && indexPath.row < tableView(tableView, numberOfRowsInSection: indexPath.section)
+                && viewModel.bookmarkFolderGUID != BookmarkRoots.MobileFolderGUID
     }
 
     private func numberOfSections(in tableView: UITableView) -> Int {
@@ -362,11 +371,11 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel, CanRemoveQuickActio
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.bookmarkNodes.count
+        viewModel.bookmarkNodes.count
     }
 
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return UITableView.automaticDimension
+        UITableView.automaticDimension
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -407,11 +416,11 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel, CanRemoveQuickActio
     }
 
     func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        return isCurrentFolderEditable(at: indexPath)
+        isCurrentFolderEditable(at: indexPath)
     }
 
     func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        return isCurrentFolderEditable(at: indexPath)
+        isCurrentFolderEditable(at: indexPath)
     }
 
     private func showBookmarkDetailController(for node: FxBookmarkNode, folder: FxBookmarkNode) {
@@ -464,7 +473,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel, CanRemoveQuickActio
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 0
+        0
     }
 }
 

--- a/Client/Frontend/Library/Bookmarks/BookmarksPanelViewModel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanelViewModel.swift
@@ -13,7 +13,7 @@ class BookmarksPanelViewModel {
     }
 
     var isRootNode: Bool {
-        return bookmarkFolderGUID == BookmarkRoots.MobileFolderGUID
+        bookmarkFolderGUID == BookmarkRoots.MobileFolderGUID
     }
 
     let profile: Profile

--- a/Client/Frontend/Library/Bookmarks/FxBookmarkNode.swift
+++ b/Client/Frontend/Library/Bookmarks/FxBookmarkNode.swift
@@ -29,7 +29,7 @@ extension BookmarkItemData: FxBookmarkNode {}
 extension BookmarkFolderData: FxBookmarkNode {
     // Convenience to be able to fetch children as an array of FxBookmarkNode
     var fxChildren: [FxBookmarkNode]? {
-        return self.children as? [FxBookmarkNode]
+        self.children as? [FxBookmarkNode]
     }
 }
 

--- a/Client/Frontend/Library/Bookmarks/LocalDesktopFolder.swift
+++ b/Client/Frontend/Library/Bookmarks/LocalDesktopFolder.swift
@@ -21,27 +21,27 @@ class LocalDesktopFolder: FxBookmarkNode {
     }
 
     var type: BookmarkNodeType {
-        return .folder
+        .folder
     }
 
     var guid: String {
-        return forcedGuid
+        forcedGuid
     }
 
     var parentGUID: String? {
-        return nil
+        nil
     }
 
     var position: UInt32 {
-        return 0
+        0
     }
 
     var isRoot: Bool {
-        return false
+        false
     }
 
     var title: String {
-        return ""
+        ""
     }
 }
 
@@ -50,11 +50,11 @@ extension LocalDesktopFolder: BookmarksFolderCell {
                       profile: Profile?,
                       completion: ((OneLineTableViewCellViewModel) -> Void)?)
     -> OneLineTableViewCellViewModel {
-        return OneLineTableViewCellViewModel(title: LocalizedRootBookmarkFolderStrings[guid],
-                                             leftImageView: leftImageView,
-                                             leftImageViewContentView: .center,
-                                             accessoryView: UIImageView(image: chevronImage),
-                                             accessoryType: .disclosureIndicator)
+        OneLineTableViewCellViewModel(title: LocalizedRootBookmarkFolderStrings[guid],
+                leftImageView: leftImageView,
+                leftImageViewContentView: .center,
+                accessoryView: UIImageView(image: chevronImage),
+                accessoryType: .disclosureIndicator)
     }
 
     func didSelect(profile: Profile,

--- a/Client/Frontend/Library/DownloadsPanel.swift
+++ b/Client/Frontend/Library/DownloadsPanel.swift
@@ -19,27 +19,27 @@ struct DownloadedFile: Equatable {
     let lastModified: Date
 
     var canShowInWebView: Bool {
-        return MIMEType.canShowInWebView(mimeType)
+        MIMEType.canShowInWebView(mimeType)
     }
 
     var filename: String {
-        return path.lastPathComponent
+        path.lastPathComponent
     }
 
     var fileExtension: String {
-        return path.pathExtension
+        path.pathExtension
     }
 
     var formattedSize: String {
-        return ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file)
+        ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file)
     }
 
     var mimeType: String {
-        return MIMEType.mimeTypeFromFileExtension(fileExtension)
+        MIMEType.mimeTypeFromFileExtension(fileExtension)
     }
 
     static public func == (lhs: DownloadedFile, rhs: DownloadedFile) -> Bool {
-        return lhs.path == rhs.path
+        lhs.path == rhs.path
     }
 }
 
@@ -172,7 +172,7 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
         }
 
         return downloadedFiles.sorted(by: { a, b -> Bool in
-            return a.lastModified > b.lastModified
+            a.lastModified > b.lastModified
         })
     }
 
@@ -393,11 +393,11 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 4
+        4
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return groupedDownloadedFiles.numberOfItemsForSection(section)
+        groupedDownloadedFiles.numberOfItemsForSection(section)
     }
 
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
@@ -438,7 +438,7 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
 // MARK: - UIDocumentInteractionControllerDelegate
 extension DownloadsPanel: UIDocumentInteractionControllerDelegate {
     func documentInteractionControllerViewControllerForPreview(_ controller: UIDocumentInteractionController) -> UIViewController {
-        return self
+        self
     }
 }
 

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel+ContextMenuExtensions.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel+ContextMenuExtensions.swift
@@ -13,7 +13,7 @@ extension HistoryPanel: LibraryPanelContextMenu {
     }
 
     func getSiteDetails(for indexPath: IndexPath) -> Site? {
-        return siteAt(indexPath: indexPath)
+        siteAt(indexPath: indexPath)
     }
 
     func getContextMenuActions(for site: Site, with indexPath: IndexPath) -> [PhotonRowActions]? {

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -11,7 +11,7 @@ import os.log
 
 private class FetchInProgressError: MaybeErrorType {
     internal var description: String {
-        return "Fetch is already in-progress"
+        "Fetch is already in-progress"
     }
 }
 
@@ -48,7 +48,7 @@ class HistoryPanel: UIViewController, LibraryPanel, Loggable, NotificationThemea
     var diffableDatasource: UITableViewDiffableDataSource<HistoryPanelSections, AnyHashable>?
 
     var shouldShowToolBar: Bool {
-        return state == .history(state: .mainView) || state == .history(state: .search)
+        state == .history(state: .mainView) || state == .history(state: .search)
     }
 
     var shouldShowSearch: Bool {

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 private class FetchInProgressError: MaybeErrorType {
     internal var description: String {
-        return "Fetch is already in-progress"
+        "Fetch is already in-progress"
     }
 }
 
@@ -68,11 +68,11 @@ class HistoryPanelViewModel: Loggable, FeatureFlaggable {
     var hiddenSections: [Sections] = []
 
     var hasRecentlyClosed: Bool {
-        return !profile.recentlyClosedTabs.tabs.isEmpty
+        !profile.recentlyClosedTabs.tabs.isEmpty
     }
 
     var emptyStateText: String {
-        return !isSearchInProgress ? .HistoryPanelEmptyStateTitle : .LibraryPanel.History.NoHistoryResult
+        !isSearchInProgress ? .HistoryPanelEmptyStateTitle : .LibraryPanel.History.NoHistoryResult
     }
 
     let historyPanelNotifications = [Notification.Name.FirefoxAccountChanged,
@@ -286,8 +286,8 @@ class HistoryPanelViewModel: Loggable, FeatureFlaggable {
 
     private func buildGroupsVisibleSections() {
         self.visibleSections = Sections.allCases.filter { section in
-            return self.groupedSites.numberOfItemsForSection(section.rawValue - 1) > 0
-            || !self.groupsForSection(section: section).isEmpty
+            self.groupedSites.numberOfItemsForSection(section.rawValue - 1) > 0
+                    || !self.groupsForSection(section: section).isEmpty
         }
     }
 

--- a/Client/Frontend/Library/LibraryPanelContextMenu.swift
+++ b/Client/Frontend/Library/LibraryPanelContextMenu.swift
@@ -17,7 +17,7 @@ extension LibraryPanelContextMenu {
         guard let site = getSiteDetails(for: indexPath) else { return }
 
         presentContextMenu(for: site, with: indexPath, completionHandler: {
-            return self.contextMenu(for: site, with: indexPath)
+            self.contextMenu(for: site, with: indexPath)
         })
     }
 

--- a/Client/Frontend/Library/LibraryPanelHelper.swift
+++ b/Client/Frontend/Library/LibraryPanelHelper.swift
@@ -26,7 +26,7 @@ protocol LibraryPanel: UIViewController, NotificationThemeable {
 
 extension LibraryPanel {
     var flexibleSpace: UIBarButtonItem {
-        return UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
     }
 
     func updatePanelState(newState: LibraryPanelMainState) {
@@ -34,7 +34,7 @@ extension LibraryPanel {
     }
 
     func shouldDismissOnDone() -> Bool {
-        return true
+        true
     }
 
     func handleLeftTopButton() {

--- a/Client/Frontend/Library/LibraryViewController/LibraryPanelViewState.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryPanelViewState.swift
@@ -88,7 +88,9 @@ enum LibraryPanelSubState {
 class LibraryPanelViewState {
     private var state: LibraryPanelMainState = .bookmarks(state: .mainView)
     var currentState: LibraryPanelMainState {
-        get { return state }
+        get {
+            state
+        }
         set {
             updateState(to: newValue)
         }

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -8,7 +8,7 @@ import Storage
 
 extension LibraryViewController: UIToolbarDelegate {
     func position(for bar: UIBarPositioning) -> UIBarPosition {
-        return .topAttached
+        .topAttached
     }
 }
 
@@ -141,7 +141,7 @@ class LibraryViewController: UIViewController {
     }
 
     private func shouldHideBottomToolbar(panel: LibraryPanel) -> Bool {
-        return panel.bottomToolbarItems.isEmpty
+        panel.bottomToolbarItems.isEmpty
     }
 
     func setupLibraryPanel(_ panel: UIViewController,

--- a/Client/Frontend/Library/ReaderPanel.swift
+++ b/Client/Frontend/Library/ReaderPanel.swift
@@ -169,7 +169,7 @@ class ReadingListPanel: UITableViewController, LibraryPanel {
     var bottomToolbarItems: [UIBarButtonItem] = [UIBarButtonItem]()
 
     private lazy var longPressRecognizer: UILongPressGestureRecognizer = {
-        return UILongPressGestureRecognizer(target: self, action: #selector(longPress))
+        UILongPressGestureRecognizer(target: self, action: #selector(longPress))
     }()
 
     private var records: [ReadingListItem]?
@@ -330,11 +330,11 @@ class ReadingListPanel: UITableViewController, LibraryPanel {
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
+        1
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return records?.count ?? 0
+        records?.count ?? 0
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -371,7 +371,7 @@ class ReadingListPanel: UITableViewController, LibraryPanel {
 
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         // the cells you would like the actions to appear needs to be editable
-        return true
+        true
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -70,7 +70,7 @@ class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {
     weak var recentlyClosedTabsPanel: RecentlyClosedTabsPanel?
 
     fileprivate lazy var longPressRecognizer: UILongPressGestureRecognizer = {
-        return UILongPressGestureRecognizer(target: self, action: #selector(RecentlyClosedTabsPanelSiteTableViewController.longPress))
+        UILongPressGestureRecognizer(target: self, action: #selector(RecentlyClosedTabsPanelSiteTableViewController.longPress))
     }()
 
     override func viewDidLoad() {
@@ -117,16 +117,16 @@ class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 0
+        0
     }
 
     // Functions that deal with showing header rows.
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
+        1
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return self.recentlyClosedTabs.count
+        self.recentlyClosedTabs.count
     }
 
     // MARK: - Libray Toolbar actions

--- a/Client/Frontend/Login Management/AddCredentialViewController.swift
+++ b/Client/Frontend/Login Management/AddCredentialViewController.swift
@@ -12,7 +12,7 @@ enum AddCredentialField: Int {
     case passwordItem
 
     var indexPath: IndexPath {
-        return IndexPath(row: rawValue, section: 0)
+        IndexPath(row: rawValue, section: 0)
     }
 }
 
@@ -161,14 +161,14 @@ extension AddCredentialViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 3
+        3
     }
 }
 
 // MARK: - UITableViewDelegate
 extension AddCredentialViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return LoginDetailUX.InfoRowHeight
+        LoginDetailUX.InfoRowHeight
     }
 }
 
@@ -227,7 +227,7 @@ extension AddCredentialViewController: LoginDetailTableViewCellDelegate {
     }
 
     fileprivate func cellForItem(_ item: AddCredentialField) -> LoginDetailTableViewCell? {
-        return tableView.cellForRow(at: item.indexPath) as? LoginDetailTableViewCell
+        tableView.cellForRow(at: item.indexPath) as? LoginDetailTableViewCell
     }
 
     func didSelectOpenAndFillForCell(_ cell: LoginDetailTableViewCell) { }

--- a/Client/Frontend/Login Management/BreachAlertsDetailView.swift
+++ b/Client/Frontend/Login Management/BreachAlertsDetailView.swift
@@ -10,7 +10,7 @@ class BreachAlertsDetailView: UIView {
     private let textColor = UIColor.white
     private let titleIconSize: CGFloat = 24
     private lazy var titleIconContainerSize: CGFloat = {
-        return titleIconSize + LoginTableViewCellUX.HorizontalMargin * 2
+        titleIconSize + LoginTableViewCellUX.HorizontalMargin * 2
     }()
 
     lazy var titleIcon: UIImageView = {

--- a/Client/Frontend/Login Management/LoginDetailTableViewCell.swift
+++ b/Client/Frontend/Login Management/LoginDetailTableViewCell.swift
@@ -35,11 +35,11 @@ class LoginDetailTableViewCell: ThemedTableViewCell {
 
     // In order for context menu handling, this is required
     override var canBecomeFirstResponder: Bool {
-        return true
+        true
     }
 
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-        return delegate?.canPerform(action: action, for: self) ?? false
+        delegate?.canPerform(action: action, for: self) ?? false
     }
 
     lazy var descriptionLabel: UITextField = .build { [weak self] label in
@@ -111,7 +111,7 @@ class LoginDetailTableViewCell: ThemedTableViewCell {
 
     var highlightedLabelTitle: String? {
         get {
-            return highlightedLabel.text
+            highlightedLabel.text
         }
         set(newTitle) {
             highlightedLabel.text = newTitle
@@ -199,7 +199,7 @@ extension LoginDetailTableViewCell {
 
 extension LoginDetailTableViewCell: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        return delegate?.shouldReturnAfterEditingDescription(self) ?? true
+        delegate?.shouldReturnAfterEditingDescription(self) ?? true
     }
 
     func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {

--- a/Client/Frontend/Login Management/LoginListSelectionHelper.swift
+++ b/Client/Frontend/Login Management/LoginListSelectionHelper.swift
@@ -10,7 +10,7 @@ public class LoginListSelectionHelper {
     private(set) var selectedIndexPaths = [IndexPath]()
 
     var selectedCount: Int {
-        return selectedIndexPaths.count
+        selectedIndexPaths.count
     }
 
     init(tableView: UITableView) {
@@ -22,8 +22,8 @@ public class LoginListSelectionHelper {
     }
 
     func indexPathIsSelected(_ indexPath: IndexPath) -> Bool {
-        return selectedIndexPaths.contains(indexPath) { path1, path2 in
-            return path1.row == path2.row && path1.section == path2.section
+        selectedIndexPaths.contains(indexPath) { path1, path2 in
+            path1.row == path2.row && path1.section == path2.section
         }
     }
 

--- a/Client/Frontend/Login Management/LoginListTableViewCell.swift
+++ b/Client/Frontend/Login Management/LoginListTableViewCell.swift
@@ -29,7 +29,7 @@ class LoginListTableViewCell: ThemedTableViewCell {
     }
 
     lazy var breachMargin: CGFloat = {
-        return breachAlertSize + LoginTableViewCellUX.HorizontalMargin * 2
+        breachAlertSize + LoginTableViewCellUX.HorizontalMargin * 2
     }()
 
     lazy var hostnameLabel: UILabel = .build { label in

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -8,7 +8,7 @@ import Shared
 
 private extension UITableView {
     var allLoginIndexPaths: [IndexPath] {
-        return ((LoginsSettingsSection + 1)..<self.numberOfSections).flatMap { sectionNum in
+        ((LoginsSettingsSection + 1)..<self.numberOfSections).flatMap { sectionNum in
             (0..<self.numberOfRows(inSection: sectionNum)).map {
                 IndexPath(row: $0, section: sectionNum)
             }
@@ -24,7 +24,7 @@ class LoginListViewController: SensitiveViewController {
     private let viewModel: LoginListViewModel
 
     fileprivate lazy var loginSelectionController: LoginListSelectionHelper = {
-        return LoginListSelectionHelper(tableView: self.tableView)
+        LoginListSelectionHelper(tableView: self.tableView)
     }()
 
     fileprivate var loginDataSource: LoginDataSource
@@ -46,7 +46,7 @@ class LoginListViewController: SensitiveViewController {
 
     static func shouldShowAppMenuShortcut(forPrefs prefs: Prefs) -> Bool {
         // default to on
-        return prefs.boolForKey(PrefsKeys.LoginsShowShortcutMenuItem) ?? true
+        prefs.boolForKey(PrefsKeys.LoginsShowShortcutMenuItem) ?? true
     }
 
     static func create(
@@ -338,7 +338,7 @@ private extension LoginListViewController {
         if loginSelectionController.selectedCount < viewModel.count {
             // Find all unselected indexPaths
             let unselectedPaths = tableView.allLoginIndexPaths.filter { indexPath in
-                return !loginSelectionController.indexPathIsSelected(indexPath)
+                !loginSelectionController.indexPathIsSelected(indexPath)
             }
             loginSelectionController.selectIndexPaths(unselectedPaths)
             unselectedPaths.forEach { indexPath in
@@ -363,7 +363,7 @@ private extension LoginListViewController {
 extension LoginListViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         // Headers are hidden except for the first login section, which has a title (see also viewForHeaderInSection)
-        return section == 1 ? UITableView.automaticDimension : 0
+        section == 1 ? UITableView.automaticDimension : 0
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
@@ -388,7 +388,7 @@ extension LoginListViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
-        return .none
+        .none
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/Client/Frontend/Login Management/LoginListViewModel.swift
+++ b/Client/Frontend/Login Management/LoginListViewModel.swift
@@ -31,7 +31,7 @@ final class LoginListViewModel {
     }
     fileprivate let helper = LoginListDataSourceHelper()
     private(set) lazy var breachAlertsManager: BreachAlertsManager = {
-        return BreachAlertsManager(profile: self.profile)
+        BreachAlertsManager(profile: self.profile)
     }()
     private(set) var userBreaches: Set<LoginRecord>?
     private(set) var breachIndexPath = Set<IndexPath>() {
@@ -154,7 +154,7 @@ final class LoginListViewModel {
     }
 
     public func save(loginRecord: LoginEntry) -> Deferred<Maybe<String>> {
-        return profile.logins.addLogin(login: loginRecord)
+        profile.logins.addLogin(login: loginRecord)
     }
 
     func setBreachIndexPath(indexPath: IndexPath) {

--- a/Client/Frontend/Login Management/LoginOnboarding.swift
+++ b/Client/Frontend/Login Management/LoginOnboarding.swift
@@ -8,7 +8,7 @@ struct LoginOnboarding {
     static let HasSeenLoginOnboardingKey = "HasSeenLoginOnboarding"
 
     static func shouldShow() -> Bool {
-        return UserDefaults.standard.bool(forKey: HasSeenLoginOnboardingKey) == false
+        UserDefaults.standard.bool(forKey: HasSeenLoginOnboardingKey) == false
     }
 
     static func setShown() {

--- a/Client/Frontend/Reader/ReadabilityService.swift
+++ b/Client/Frontend/Reader/ReadabilityService.swift
@@ -117,7 +117,7 @@ extension ReadabilityOperation: ReaderModeDelegate {
 
 class ReadabilityService {
     class var sharedInstance: ReadabilityService {
-        return ReadabilityServiceSharedInstance
+        ReadabilityServiceSharedInstance
     }
 
     var queue: OperationQueue

--- a/Client/Frontend/Reader/ReaderMode.swift
+++ b/Client/Frontend/Reader/ReaderMode.swift
@@ -80,7 +80,7 @@ enum ReaderModeFontType: String {
     }
 
     func isSameFamily(_ font: ReaderModeFontType) -> Bool {
-        return FontFamily.families.contains(where: { $0.contains(font) && $0.contains(self) })
+        FontFamily.families.contains(where: { $0.contains(font) && $0.contains(self) })
     }
 }
 
@@ -100,7 +100,7 @@ enum ReaderModeFontSize: Int {
     case size13 = 13
 
     func isSmallest() -> Bool {
-        return self == ReaderModeFontSize.size1
+        self == ReaderModeFontSize.size1
     }
 
     func smaller() -> ReaderModeFontSize {
@@ -112,7 +112,7 @@ enum ReaderModeFontSize: Int {
     }
 
     func isLargest() -> Bool {
-        return self == ReaderModeFontSize.size13
+        self == ReaderModeFontSize.size13
     }
 
     static var defaultSize: ReaderModeFontSize {
@@ -152,12 +152,12 @@ struct ReaderModeStyle {
 
     /// Encode the style to a JSON dictionary that can be passed to ReaderMode.js
     func encode() -> String {
-        return encodeAsDictionary().asString ?? ""
+        encodeAsDictionary().asString ?? ""
     }
 
     /// Encode the style to a dictionary that can be stored in the profile
     func encodeAsDictionary() -> [String: Any] {
-        return ["theme": theme.rawValue, "fontType": fontType.rawValue, "fontSize": fontSize.rawValue]
+        ["theme": theme.rawValue, "fontType": fontType.rawValue, "fontSize": fontSize.rawValue]
     }
 
     init(theme: ReaderModeTheme, fontType: ReaderModeFontType, fontSize: ReaderModeFontSize) {
@@ -262,7 +262,7 @@ struct ReadabilityResult {
 
     /// Encode to a dictionary, which can then for example be json encoded
     func encode() -> [String: Any] {
-        return ["domain": domain, "url": url, "content": content, "title": title, "credits": credits, "textContent": textContent, "excerpt": excerpt]
+        ["domain": domain, "url": url, "content": content, "title": title, "credits": credits, "textContent": textContent, "excerpt": excerpt]
     }
 
     /// Encode to a JSON encoded string
@@ -289,7 +289,7 @@ class ReaderMode: TabContentScript {
     fileprivate var originalURL: URL?
 
     class func name() -> String {
-        return "ReaderMode"
+        "ReaderMode"
     }
 
     required init(tab: Tab) {
@@ -297,7 +297,7 @@ class ReaderMode: TabContentScript {
     }
 
     func scriptMessageHandlerName() -> String? {
-        return "readerModeMessageHandler"
+        "readerModeMessageHandler"
     }
 
     fileprivate func handleReaderPageEvent(_ readerPageEvent: ReaderPageEvent) {
@@ -348,7 +348,6 @@ class ReaderMode: TabContentScript {
         didSet {
             if state == ReaderModeState.active {
                 tab?.webView?.evaluateJavascriptInDefaultContentWorld("\(ReaderModeNamespace).setStyle(\(style.encode()))") { object, error in
-                    return
                 }
             }
         }

--- a/Client/Frontend/Reader/ReaderModeCache.swift
+++ b/Client/Frontend/Reader/ReaderModeCache.swift
@@ -44,7 +44,7 @@ class MemoryReaderModeCache: ReaderModeCache {
     }
 
     class var sharedInstance: ReaderModeCache {
-        return MemoryReaderModeCacheSharedInstance
+        MemoryReaderModeCacheSharedInstance
     }
 
     func put(_ url: URL, _ readabilityResult: ReadabilityResult) throws {
@@ -63,7 +63,7 @@ class MemoryReaderModeCache: ReaderModeCache {
     }
 
     func contains(_ url: URL) -> Bool {
-        return cache.object(forKey: url as AnyObject) != nil
+        cache.object(forKey: url as AnyObject) != nil
     }
 
     func clear() {
@@ -79,7 +79,7 @@ class MemoryReaderModeCache: ReaderModeCache {
 /// and improve at a later time.
 class DiskReaderModeCache: ReaderModeCache {
     class var sharedInstance: ReaderModeCache {
-        return DiskReaderModeCacheSharedInstance
+        DiskReaderModeCacheSharedInstance
     }
 
     func put(_ url: URL, _ readabilityResult: ReadabilityResult) throws {
@@ -90,7 +90,6 @@ class DiskReaderModeCache: ReaderModeCache {
         try FileManager.default.createDirectory(atPath: cacheDirectoryPath, withIntermediateDirectories: true, attributes: nil)
         let string: String = readabilityResult.encode()
         try string.write(toFile: contentFilePath, atomically: true, encoding: .utf8)
-        return
     }
 
     func get(_ url: URL) throws -> ReadabilityResult {

--- a/Client/Frontend/Reader/ReaderModeStyleViewModel.swift
+++ b/Client/Frontend/Reader/ReaderModeStyleViewModel.swift
@@ -32,10 +32,10 @@ struct ReaderModeStyleViewModel {
     var readerModeStyle: ReaderModeStyle = DefaultReaderModeStyle
 
     var fontTypeOffset: CGFloat {
-        return isBottomPresented ? 0 : ReaderModeStyleViewModel.PresentationSpace
+        isBottomPresented ? 0 : ReaderModeStyleViewModel.PresentationSpace
     }
 
     var brightnessRowOffset: CGFloat {
-        return isBottomPresented ? -ReaderModeStyleViewModel.PresentationSpace : 0
+        isBottomPresented ? -ReaderModeStyleViewModel.PresentationSpace : 0
     }
 }

--- a/Client/Frontend/Reader/ReaderModeUtils.swift
+++ b/Client/Frontend/Reader/ReaderModeUtils.swift
@@ -9,9 +9,12 @@ struct ReaderModeUtils {
     static let DomainPrefixesToSimplify = ["www.", "mobile.", "m.", "blog."]
 
     static func simplifyDomain(_ domain: String) -> String {
-        return DomainPrefixesToSimplify.first { domain.hasPrefix($0) }.map {
-            String($0[$0.index($0.startIndex, offsetBy: $0.count)...])
-        } ?? domain
+        DomainPrefixesToSimplify.first {
+                    domain.hasPrefix($0)
+                }
+                .map {
+                    String($0[$0.index($0.startIndex, offsetBy: $0.count)...])
+                } ?? domain
     }
 
     static func generateReaderContent(_ readabilityResult: ReadabilityResult, initialStyle: ReaderModeStyle) -> String? {

--- a/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
+++ b/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
@@ -35,7 +35,9 @@ private class CustomFxAContentServerEnableSetting: BoolSetting {
         defaultValue: String? = nil,
         placeholder: String,
         accessibilityIdentifier: String,
-        isChecked: @escaping () -> Bool = { return false },
+        isChecked: @escaping () -> Bool = {
+            false
+        },
         settingDidChange: ((String?) -> Void)? = nil
       ) {
           super.init(prefs: prefs,

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -24,13 +24,17 @@ private var disclosureIndicator: UIImageView {
 // MARK: - ConnectSetting
 // Sync setting for connecting a Firefox Account. Shown when we don't have an account.
 class ConnectSetting: WithoutAccountSetting {
-    override var accessoryView: UIImageView? { return disclosureIndicator }
-
-    override var title: NSAttributedString? {
-        return NSAttributedString(string: .Settings.Sync.ButtonTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+    override var accessoryView: UIImageView? {
+        disclosureIndicator
     }
 
-    override var accessibilityIdentifier: String? { return "SignInToSync" }
+    override var title: NSAttributedString? {
+        NSAttributedString(string: .Settings.Sync.ButtonTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+    }
+
+    override var accessibilityIdentifier: String? {
+        "SignInToSync"
+    }
 
     override func onClick(_ navigationController: UINavigationController?) {
         let viewController = FirefoxAccountSignInViewController(profile: profile, parentType: .settings, deepLinkParams: nil)
@@ -112,7 +116,9 @@ class SyncNowSetting: WithAccountSetting {
         }
     }
 
-    override var accessoryType: UITableViewCell.AccessoryType { return .none }
+    override var accessoryType: UITableViewCell.AccessoryType {
+        .none
+    }
 
     override var image: UIImage? {
         guard let syncStatus = profile.syncManager.syncDisplayState else {
@@ -164,7 +170,9 @@ class SyncNowSetting: WithAccountSetting {
         return attributedString
     }
 
-    override var hidden: Bool { return !enabled }
+    override var hidden: Bool {
+        !enabled
+    }
 
     override var enabled: Bool {
         get {
@@ -310,7 +318,7 @@ class AccountStatusSetting: WithAccountSetting {
     }
 
     override var accessoryView: UIImageView? {
-        return disclosureIndicator
+        disclosureIndicator
     }
 
     override var title: NSAttributedString? {
@@ -388,7 +396,7 @@ class HiddenSetting: Setting {
     }
 
     override var hidden: Bool {
-        return !ShowDebugSettings
+        !ShowDebugSettings
     }
 
     func updateCell(_ navigationController: UINavigationController?) {
@@ -401,7 +409,7 @@ class HiddenSetting: Setting {
 class DeleteExportedDataSetting: HiddenSetting {
     override var title: NSAttributedString? {
         // Not localized for now.
-        return NSAttributedString(string: "Debug: delete exported databases", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        NSAttributedString(string: "Debug: delete exported databases", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -423,7 +431,7 @@ class DeleteExportedDataSetting: HiddenSetting {
 class ExportBrowserDataSetting: HiddenSetting {
     override var title: NSAttributedString? {
         // Not localized for now.
-        return NSAttributedString(string: "Debug: copy databases to app container", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        NSAttributedString(string: "Debug: copy databases to app container", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -443,7 +451,7 @@ class ExportBrowserDataSetting: HiddenSetting {
 class ExportLogDataSetting: HiddenSetting {
     override var title: NSAttributedString? {
         // Not localized for now.
-        return NSAttributedString(string: "Debug: copy log files to app container", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        NSAttributedString(string: "Debug: copy log files to app container", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -466,7 +474,7 @@ class FeatureSwitchSetting: BoolSetting {
     }
 
     override var hidden: Bool {
-        return !ShowDebugSettings
+        !ShowDebugSettings
     }
 
     override func displayBool(_ control: UISwitch) {
@@ -481,7 +489,7 @@ class FeatureSwitchSetting: BoolSetting {
 
 class ForceCrashSetting: HiddenSetting {
     override var title: NSAttributedString? {
-        return NSAttributedString(string: "💥 Debug: Force Crash", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        NSAttributedString(string: "💥 Debug: Force Crash", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -491,7 +499,7 @@ class ForceCrashSetting: HiddenSetting {
 
 class ChangeToChinaSetting: HiddenSetting {
     override var title: NSAttributedString? {
-        return NSAttributedString(string: "Debug: toggle China version (needs restart)", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        NSAttributedString(string: "Debug: toggle China version (needs restart)", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -505,7 +513,7 @@ class ChangeToChinaSetting: HiddenSetting {
 
 class SlowTheDatabase: HiddenSetting {
     override var title: NSAttributedString? {
-        return NSAttributedString(string: "Debug: simulate slow database operations", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        NSAttributedString(string: "Debug: simulate slow database operations", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -515,9 +523,9 @@ class SlowTheDatabase: HiddenSetting {
 
 class ForgetSyncAuthStateDebugSetting: HiddenSetting {
     override var title: NSAttributedString? {
-        return NSAttributedString(
-            string: "Debug: forget Sync auth state",
-            attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        NSAttributedString(
+                string: "Debug: forget Sync auth state",
+                attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -529,11 +537,11 @@ class ForgetSyncAuthStateDebugSetting: HiddenSetting {
 class SentryIDSetting: HiddenSetting {
     let deviceAppHash = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.string(forKey: "SentryDeviceAppHash") ?? "0000000000000000000000000000000000000000"
     override var title: NSAttributedString? {
-        return NSAttributedString(
-            string: "Sentry ID: \(deviceAppHash)",
-            attributes: [
-                NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText,
-                NSAttributedString.Key.font: UIFont.systemFont(ofSize: 10)])
+        NSAttributedString(
+                string: "Sentry ID: \(deviceAppHash)",
+                attributes: [
+                    NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText,
+                    NSAttributedString.Key.font: UIFont.systemFont(ofSize: 10)])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -564,7 +572,7 @@ class ShowEtpCoverSheet: HiddenSetting {
     let profile: Profile
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: "Debug: ETP Cover Sheet On", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        NSAttributedString(string: "Debug: ETP Cover Sheet On", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override init(settings: SettingsTableViewController) {
@@ -582,7 +590,9 @@ class ShowEtpCoverSheet: HiddenSetting {
 }
 
 class ExperimentsSettings: HiddenSetting {
-    override var title: NSAttributedString? { return NSAttributedString(string: "Experiments")}
+    override var title: NSAttributedString? {
+        NSAttributedString(string: "Experiments")
+    }
 
     override func onClick(_ navigationController: UINavigationController?) {
         navigationController?.pushViewController(ExperimentsViewController(), animated: true)
@@ -636,12 +646,14 @@ class ToggleHistoryGroups: HiddenSetting, FeatureFlaggable {
 class ResetContextualHints: HiddenSetting {
     let profile: Profile
 
-    override var accessibilityIdentifier: String? { return "ResetContextualHints.Setting" }
+    override var accessibilityIdentifier: String? {
+        "ResetContextualHints.Setting"
+    }
 
     override var title: NSAttributedString? {
-        return NSAttributedString(
-            string: "Reset all contextual hints",
-            attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        NSAttributedString(
+                string: "Reset all contextual hints",
+                attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override init(settings: SettingsTableViewController) {
@@ -658,10 +670,12 @@ class ResetContextualHints: HiddenSetting {
 
 class OpenFiftyTabsDebugOption: HiddenSetting {
 
-    override var accessibilityIdentifier: String? { return "OpenFiftyTabsOption.Setting" }
+    override var accessibilityIdentifier: String? {
+        "OpenFiftyTabsOption.Setting"
+    }
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: "⚠️ Open 50 `mozilla.org` tabs ⚠️", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        NSAttributedString(string: "⚠️ Open 50 `mozilla.org` tabs ⚠️", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -674,7 +688,9 @@ class OpenFiftyTabsDebugOption: HiddenSetting {
 class VersionSetting: Setting {
     unowned let settings: SettingsTableViewController
 
-    override var accessibilityIdentifier: String? { return "FxVersion" }
+    override var accessibilityIdentifier: String? {
+        "FxVersion"
+    }
 
     init(settings: SettingsTableViewController) {
         self.settings = settings
@@ -682,7 +698,7 @@ class VersionSetting: Setting {
     }
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: "\(AppName.shortName) \(AppInfo.appVersion) (\(AppInfo.buildNumber))", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        NSAttributedString(string: "\(AppName.shortName) \(AppInfo.appVersion) (\(AppInfo.buildNumber))", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override func onConfigureCell(_ cell: UITableViewCell) {
@@ -725,11 +741,11 @@ class VersionSetting: Setting {
 // Opens the license page in a new tab
 class LicenseAndAcknowledgementsSetting: Setting {
     override var title: NSAttributedString? {
-        return NSAttributedString(string: .AppSettingsLicenses, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        NSAttributedString(string: .AppSettingsLicenses, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override var url: URL? {
-        return URL(string: "\(InternalURL.baseUrl)/\(AboutLicenseHandler.path)")
+        URL(string: "\(InternalURL.baseUrl)/\(AboutLicenseHandler.path)")
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -741,7 +757,7 @@ class LicenseAndAcknowledgementsSetting: Setting {
 class AppStoreReviewSetting: Setting {
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: .Settings.About.RateOnAppStore, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        NSAttributedString(string: .Settings.About.RateOnAppStore, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -752,12 +768,12 @@ class AppStoreReviewSetting: Setting {
 // Opens about:rights page in the content view controller
 class YourRightsSetting: Setting {
     override var title: NSAttributedString? {
-        return NSAttributedString(string: .AppSettingsYourRights, attributes:
-            [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        NSAttributedString(string: .AppSettingsYourRights, attributes:
+        [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override var url: URL? {
-        return URL(string: "https://www.mozilla.org/about/legal/terms/firefox/")
+        URL(string: "https://www.mozilla.org/about/legal/terms/firefox/")
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -769,7 +785,9 @@ class YourRightsSetting: Setting {
 class ShowIntroductionSetting: Setting {
     let profile: Profile
 
-    override var accessibilityIdentifier: String? { return "ShowTour" }
+    override var accessibilityIdentifier: String? {
+        "ShowTour"
+    }
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
@@ -785,11 +803,11 @@ class ShowIntroductionSetting: Setting {
 
 class SendFeedbackSetting: Setting {
     override var title: NSAttributedString? {
-        return NSAttributedString(string: .AppSettingsSendFeedback, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        NSAttributedString(string: .AppSettingsSendFeedback, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override var url: URL? {
-        return URL(string: "https://connect.mozilla.org/")
+        URL(string: "https://connect.mozilla.org/")
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -819,10 +837,12 @@ class SendAnonymousUsageDataSetting: BoolSetting {
         Experiments.setTelemetrySetting(prefs.boolForKey(AppConstants.PrefSendUsageData) ?? true)
     }
 
-    override var accessibilityIdentifier: String? { return "SendAnonymousUsageData" }
+    override var accessibilityIdentifier: String? {
+        "SendAnonymousUsageData"
+    }
 
     override var url: URL? {
-        return SupportUtils.URLForTopic("adjust")
+        SupportUtils.URLForTopic("adjust")
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -850,10 +870,12 @@ class StudiesToggleSetting: BoolSetting {
         Experiments.setStudiesSetting(prefs.boolForKey(AppConstants.PrefStudiesToggle) ?? true)
     }
 
-    override var accessibilityIdentifier: String? { return "StudiesToggle" }
+    override var accessibilityIdentifier: String? {
+        "StudiesToggle"
+    }
 
         override var url: URL? {
-            return SupportUtils.URLForTopic("ios-studies")
+            SupportUtils.URLForTopic("ios-studies")
         }
 
         override func onClick(_ navigationController: UINavigationController?) {
@@ -881,13 +903,21 @@ class OpenSupportPageSetting: Setting {
 class SearchSetting: Setting {
     let profile: Profile
 
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? {
+        disclosureIndicator
+    }
 
-    override var style: UITableViewCell.CellStyle { return .value1 }
+    override var style: UITableViewCell.CellStyle {
+        .value1
+    }
 
-    override var status: NSAttributedString { return NSAttributedString(string: profile.searchEngines.defaultEngine.shortName) }
+    override var status: NSAttributedString {
+        NSAttributedString(string: profile.searchEngines.defaultEngine.shortName)
+    }
 
-    override var accessibilityIdentifier: String? { return "Search" }
+    override var accessibilityIdentifier: String? {
+        "Search"
+    }
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
@@ -908,9 +938,13 @@ class LoginsSetting: Setting {
     weak var navigationController: UINavigationController?
     weak var settings: AppSettingsTableViewController?
 
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? {
+        disclosureIndicator
+    }
 
-    override var accessibilityIdentifier: String? { return "Logins" }
+    override var accessibilityIdentifier: String? {
+        "Logins"
+    }
 
     init(settings: SettingsTableViewController, delegate: SettingsDelegate?) {
         self.profile = settings.profile
@@ -986,8 +1020,12 @@ class LoginsSetting: Setting {
 class ContentBlockerSetting: Setting {
     let profile: Profile
     var tabManager: TabManager!
-    override var accessoryView: UIImageView? { return disclosureIndicator }
-    override var accessibilityIdentifier: String? { return "TrackingProtection" }
+    override var accessoryView: UIImageView? {
+        disclosureIndicator
+    }
+    override var accessibilityIdentifier: String? {
+        "TrackingProtection"
+    }
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
@@ -1007,9 +1045,13 @@ class ClearPrivateDataSetting: Setting {
     let profile: Profile
     var tabManager: TabManager!
 
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? {
+        disclosureIndicator
+    }
 
-    override var accessibilityIdentifier: String? { return "ClearPrivateData" }
+    override var accessibilityIdentifier: String? {
+        "ClearPrivateData"
+    }
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
@@ -1029,11 +1071,11 @@ class ClearPrivateDataSetting: Setting {
 
 class PrivacyPolicySetting: Setting {
     override var title: NSAttributedString? {
-        return NSAttributedString(string: .AppSettingsPrivacyPolicy, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        NSAttributedString(string: .AppSettingsPrivacyPolicy, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override var url: URL? {
-        return URL(string: "https://www.mozilla.org/privacy/firefox/")
+        URL(string: "https://www.mozilla.org/privacy/firefox/")
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -1042,20 +1084,26 @@ class PrivacyPolicySetting: Setting {
 }
 
 class ChinaSyncServiceSetting: Setting {
-    override var accessoryType: UITableViewCell.AccessoryType { return .none }
-    var prefs: Prefs { return profile.prefs }
+    override var accessoryType: UITableViewCell.AccessoryType {
+        .none
+    }
+    var prefs: Prefs {
+        profile.prefs
+    }
     let prefKey = PrefsKeys.KeyEnableChinaSyncService
     let profile: Profile
     let settings: UIViewController
 
-    override var hidden: Bool { return !AppInfo.isChinaEdition }
+    override var hidden: Bool {
+        !AppInfo.isChinaEdition
+    }
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: "本地同步服务", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        NSAttributedString(string: "本地同步服务", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override var status: NSAttributedString? {
-        return NSAttributedString(string: "禁用后使用全球服务同步数据", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.headerTextLight])
+        NSAttributedString(string: "禁用后使用全球服务同步数据", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.headerTextLight])
     }
 
     init(settings: SettingsTableViewController) {
@@ -1102,15 +1150,21 @@ class ChinaSyncServiceSetting: Setting {
 class NewTabPageSetting: Setting {
     let profile: Profile
 
-    override var accessoryView: UIImageView? { return disclosureIndicator }
-
-    override var accessibilityIdentifier: String? { return "NewTab" }
-
-    override var status: NSAttributedString {
-        return NSAttributedString(string: NewTabAccessors.getNewTabPage(self.profile.prefs).settingTitle)
+    override var accessoryView: UIImageView? {
+        disclosureIndicator
     }
 
-    override var style: UITableViewCell.CellStyle { return .value1 }
+    override var accessibilityIdentifier: String? {
+        "NewTab"
+    }
+
+    override var status: NSAttributedString {
+        NSAttributedString(string: NewTabAccessors.getNewTabPage(self.profile.prefs).settingTitle)
+    }
+
+    override var style: UITableViewCell.CellStyle {
+        .value1
+    }
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
@@ -1127,15 +1181,21 @@ class NewTabPageSetting: Setting {
 class HomeSetting: Setting {
     let profile: Profile
 
-    override var accessoryView: UIImageView? { return disclosureIndicator }
-
-    override var accessibilityIdentifier: String? { return "Home" }
-
-    override var status: NSAttributedString {
-        return NSAttributedString(string: NewTabAccessors.getHomePage(self.profile.prefs).settingTitle)
+    override var accessoryView: UIImageView? {
+        disclosureIndicator
     }
 
-    override var style: UITableViewCell.CellStyle { return .value1 }
+    override var accessibilityIdentifier: String? {
+        "Home"
+    }
+
+    override var status: NSAttributedString {
+        NSAttributedString(string: NewTabAccessors.getHomePage(self.profile.prefs).settingTitle)
+    }
+
+    override var style: UITableViewCell.CellStyle {
+        .value1
+    }
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
@@ -1152,9 +1212,13 @@ class HomeSetting: Setting {
 
 class TabsSetting: Setting {
 
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? {
+        disclosureIndicator
+    }
 
-    override var accessibilityIdentifier: String? { return "TabsSetting" }
+    override var accessibilityIdentifier: String? {
+        "TabsSetting"
+    }
 
     init() {
         super.init(title: NSAttributedString(string: .Settings.SectionTitles.TabsTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
@@ -1169,9 +1233,13 @@ class TabsSetting: Setting {
 class SiriPageSetting: Setting {
     let profile: Profile
 
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? {
+        disclosureIndicator
+    }
 
-    override var accessibilityIdentifier: String? { return "SiriSettings" }
+    override var accessibilityIdentifier: String? {
+        "SiriSettings"
+    }
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
@@ -1208,12 +1276,16 @@ class NoImageModeSetting: BoolSetting {
         )
     }
 
-    override var accessibilityIdentifier: String? { return "NoImageMode" }
+    override var accessibilityIdentifier: String? {
+        "NoImageMode"
+    }
 }
 
 @available(iOS 14.0, *)
 class DefaultBrowserSetting: Setting {
-    override var accessibilityIdentifier: String? { return "DefaultBrowserSettings" }
+    override var accessibilityIdentifier: String? {
+        "DefaultBrowserSettings"
+    }
 
     init() {
         super.init(title: NSAttributedString(string: String.DefaultBrowserMenuItem, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowActionAccessory]))
@@ -1228,9 +1300,13 @@ class DefaultBrowserSetting: Setting {
 class OpenWithSetting: Setting {
     let profile: Profile
 
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? {
+        disclosureIndicator
+    }
 
-    override var accessibilityIdentifier: String? { return "OpenWith.Setting" }
+    override var accessibilityIdentifier: String? {
+        "OpenWith.Setting"
+    }
 
     override var status: NSAttributedString {
         guard let provider = self.profile.prefs.stringForKey(PrefsKeys.KeyMailToOption), provider != "mailto:" else {
@@ -1238,14 +1314,16 @@ class OpenWithSetting: Setting {
         }
         if let path = Bundle.main.path(forResource: "MailSchemes", ofType: "plist"), let dictRoot = NSArray(contentsOfFile: path) {
             let mailProvider = dictRoot.compactMap({$0 as? NSDictionary }).first { (dict) -> Bool in
-                return (dict["scheme"] as? String) == provider
+                (dict["scheme"] as? String) == provider
             }
             return NSAttributedString(string: (mailProvider?["name"] as? String) ?? "")
         }
         return NSAttributedString(string: "")
     }
 
-    override var style: UITableViewCell.CellStyle { return .value1 }
+    override var style: UITableViewCell.CellStyle {
+        .value1
+    }
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
@@ -1262,12 +1340,16 @@ class OpenWithSetting: Setting {
 class AdvancedAccountSetting: HiddenSetting {
     let profile: Profile
 
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? {
+        disclosureIndicator
+    }
 
-    override var accessibilityIdentifier: String? { return "AdvancedAccount.Setting" }
+    override var accessibilityIdentifier: String? {
+        "AdvancedAccount.Setting"
+    }
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: .SettingsAdvancedAccountTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        NSAttributedString(string: .SettingsAdvancedAccountTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override init(settings: SettingsTableViewController) {
@@ -1282,15 +1364,21 @@ class AdvancedAccountSetting: HiddenSetting {
     }
 
     override var hidden: Bool {
-        return !ShowDebugSettings || profile.hasAccount()
+        !ShowDebugSettings || profile.hasAccount()
     }
 }
 
 class ThemeSetting: Setting {
     let profile: Profile
-    override var accessoryView: UIImageView? { return disclosureIndicator }
-    override var style: UITableViewCell.CellStyle { return .value1 }
-    override var accessibilityIdentifier: String? { return "DisplayThemeOption" }
+    override var accessoryView: UIImageView? {
+        disclosureIndicator
+    }
+    override var style: UITableViewCell.CellStyle {
+        .value1
+    }
+    override var accessibilityIdentifier: String? {
+        "DisplayThemeOption"
+    }
 
     override var status: NSAttributedString {
         if LegacyThemeManager.instance.systemThemeIsOn {
@@ -1316,15 +1404,21 @@ class ThemeSetting: Setting {
 class SearchBarSetting: Setting {
     let viewModel: SearchBarSettingsViewModel
 
-    override var accessoryView: UIImageView? { return disclosureIndicator }
-
-    override var accessibilityIdentifier: String? { return AccessibilityIdentifiers.Settings.SearchBar.searchBarSetting }
-
-    override var status: NSAttributedString {
-        return NSAttributedString(string: viewModel.searchBarTitle )
+    override var accessoryView: UIImageView? {
+        disclosureIndicator
     }
 
-    override var style: UITableViewCell.CellStyle { return .value1 }
+    override var accessibilityIdentifier: String? {
+        AccessibilityIdentifiers.Settings.SearchBar.searchBarSetting
+    }
+
+    override var status: NSAttributedString {
+        NSAttributedString(string: viewModel.searchBarTitle)
+    }
+
+    override var style: UITableViewCell.CellStyle {
+        .value1
+    }
 
     init(settings: SettingsTableViewController) {
         self.viewModel = SearchBarSettingsViewModel(prefs: settings.profile.prefs)

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -104,7 +104,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return NumberOfSections
+        NumberOfSections
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -192,7 +192,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return UITableView.automaticDimension
+        UITableView.automaticDimension
     }
 
     @objc func switchValueChanged(_ toggle: UISwitch) {

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -23,7 +23,9 @@ class ClearableError: MaybeErrorType {
         self.msg = msg
     }
 
-    var description: String { return msg }
+    var description: String {
+        msg
+    }
 }
 
 // Clears our browsing history, including favicons and thumbnails.
@@ -74,7 +76,7 @@ struct ClearableErrorType: MaybeErrorType {
     }
 
     var description: String {
-        return "Couldn't clear: \(err)."
+        "Couldn't clear: \(err)."
     }
 }
 
@@ -173,7 +175,7 @@ class CookiesClearable: Clearable {
 class TrackingProtectionClearable: Clearable {
     // @TODO: re-using string because we are too late in cycle to change strings
     var label: String {
-        return .SettingsTrackingProtectionSectionName
+        .SettingsTrackingProtectionSectionName
     }
 
     func clear() -> Success {

--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -85,11 +85,11 @@ class TPAccessoryInfo: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 2
+        2
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return isStrictMode ? 5 : 4
+        isStrictMode ? 5 : 4
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -164,7 +164,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
                 style: .leftSide,
                 subtitle: NSAttributedString(string: option.settingSubtitle),
                 accessibilityIdentifier: id,
-                isChecked: { return option == self.currentBlockingStrength },
+                isChecked: { option == self.currentBlockingStrength },
                 onChecked: {
                     self.currentBlockingStrength = option
                     self.prefs.setString(self.currentBlockingStrength.rawValue,
@@ -257,7 +257,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return UITableView.automaticDimension
+        UITableView.automaticDimension
     }
 
     @objc func moreInfoTapped() {

--- a/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -18,7 +18,7 @@ class CustomSearchError: MaybeErrorType {
     var reason: Reason!
 
     internal var description: String {
-        return "Search Engine Not Added"
+        "Search Engine Not Added"
     }
 
     init(_ reason: Reason) {
@@ -103,8 +103,8 @@ class CustomSearchViewController: SettingsTableViewController {
     }
 
     private func engineExists(name: String, template: String) -> Bool {
-        return profile.searchEngines.orderedEngines.contains { (engine) -> Bool in
-            return engine.shortName == name || engine.searchTemplate == template
+        profile.searchEngines.orderedEngines.contains { (engine) -> Bool in
+            engine.shortName == name || engine.searchTemplate == template
         }
     }
 
@@ -147,7 +147,7 @@ class CustomSearchViewController: SettingsTableViewController {
         let urlField = CustomSearchEngineTextView(placeholder: .SettingsAddCustomEngineURLPlaceholder, height: 133,
             keyboardType: .URL, settingIsValid: { text in
             // Can check url text text validity here.
-            return true
+            true
         }, settingDidChange: {fieldText in
             self.urlString = fieldText
             self.updateSaveButton()
@@ -260,7 +260,7 @@ class CustomSearchEngineTextView: Setting, UITextViewDelegate {
     }
 
     func prepareValidValue(userInput value: String?) -> String? {
-        return value
+        value
     }
 
     func textViewDidBeginEditing(_ textView: UITextView) {

--- a/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -15,27 +15,27 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
     var hasHomePage = false
 
     var isJumpBackInSectionEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.jumpBackIn, checking: .buildOnly)
+        featureFlags.isFeatureEnabled(.jumpBackIn, checking: .buildOnly)
     }
 
     var isRecentlySavedSectionEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.recentlySaved, checking: .buildOnly)
+        featureFlags.isFeatureEnabled(.recentlySaved, checking: .buildOnly)
     }
 
     var isWallpaperSectionEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.wallpapers, checking: .buildOnly)
+        featureFlags.isFeatureEnabled(.wallpapers, checking: .buildOnly)
     }
 
     var isPocketSectionEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.pocket, checking: .buildOnly)
+        featureFlags.isFeatureEnabled(.pocket, checking: .buildOnly)
     }
 
     var isPocketSponsoredStoriesEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.sponsoredPocket, checking: .buildOnly)
+        featureFlags.isFeatureEnabled(.sponsoredPocket, checking: .buildOnly)
     }
 
     var isHistoryHighlightsSectionEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.historyHighlights, checking: .buildOnly)
+        featureFlags.isFeatureEnabled(.historyHighlights, checking: .buildOnly)
     }
 
     // MARK: - Initializers
@@ -90,7 +90,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
             title: NSAttributedString(string: .SettingsNewTabTopSites),
             subtitle: nil,
             accessibilityIdentifier: "HomeAsFirefoxHome",
-            isChecked: { return self.currentNewTabChoice == NewTabPage.topSites },
+            isChecked: { self.currentNewTabChoice == NewTabPage.topSites },
             onChecked: {
                 self.currentNewTabChoice = NewTabPage.topSites
                 onFinished()
@@ -101,7 +101,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
             defaultValue: nil,
             placeholder: .CustomNewPageURL,
             accessibilityIdentifier: "HomeAsCustomURL",
-            isChecked: { return !showTopSites.isChecked() },
+            isChecked: { !showTopSites.isChecked() },
             settingDidChange: { (string) in
                 self.currentNewTabChoice = NewTabPage.homePage
                 self.prefs.setString(self.currentNewTabChoice.rawValue, forKey: NewTabAccessors.HomePrefKey)
@@ -198,7 +198,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
             title: NSAttributedString(string: .Settings.Homepage.StartAtHome.AfterFourHours),
             subtitle: nil,
             accessibilityIdentifier: a11y.afterFourHours,
-            isChecked: { return self.currentStartAtHomeSetting == .afterFourHours },
+            isChecked: { self.currentStartAtHomeSetting == .afterFourHours },
             onChecked: {
                 self.currentStartAtHomeSetting = .afterFourHours
                 onOptionSelected(true, .afterFourHours)
@@ -208,7 +208,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
             title: NSAttributedString(string: .Settings.Homepage.StartAtHome.Always),
             subtitle: nil,
             accessibilityIdentifier: a11y.always,
-            isChecked: { return self.currentStartAtHomeSetting == .always },
+            isChecked: { self.currentStartAtHomeSetting == .always },
             onChecked: {
                 self.currentStartAtHomeSetting = .always
                 onOptionSelected(true, .always)
@@ -218,7 +218,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
             title: NSAttributedString(string: .Settings.Homepage.StartAtHome.Never),
             subtitle: nil,
             accessibilityIdentifier: a11y.disabled,
-            isChecked: { return self.currentStartAtHomeSetting == .disabled },
+            isChecked: { self.currentStartAtHomeSetting == .disabled },
             onChecked: {
                 self.currentStartAtHomeSetting = .disabled
                 onOptionSelected(false, .disabled)
@@ -237,9 +237,15 @@ extension HomePageSettingViewController {
     class TopSitesSettings: Setting, FeatureFlaggable {
         var profile: Profile
 
-        override var accessoryType: UITableViewCell.AccessoryType { return .disclosureIndicator }
-        override var accessibilityIdentifier: String? { return AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.Shortcuts.settingsPage }
-        override var style: UITableViewCell.CellStyle { return .value1 }
+        override var accessoryType: UITableViewCell.AccessoryType {
+            .disclosureIndicator
+        }
+        override var accessibilityIdentifier: String? {
+            AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.Shortcuts.settingsPage
+        }
+        override var style: UITableViewCell.CellStyle {
+            .value1
+        }
 
         override var status: NSAttributedString {
             let areShortcutsOn = featureFlags.isFeatureEnabled(.topSites, checking: .userOnly)
@@ -267,9 +273,15 @@ extension HomePageSettingViewController {
         var profile: Profile
         var tabManager: TabManager
 
-        override var accessoryType: UITableViewCell.AccessoryType { return .disclosureIndicator }
-        override var accessibilityIdentifier: String? { return AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.wallpaper }
-        override var style: UITableViewCell.CellStyle { return .value1 }
+        override var accessoryType: UITableViewCell.AccessoryType {
+            .disclosureIndicator
+        }
+        override var accessibilityIdentifier: String? {
+            AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.wallpaper
+        }
+        override var style: UITableViewCell.CellStyle {
+            .value1
+        }
 
         init(settings: SettingsTableViewController,
              and tabManager: TabManager = BrowserViewController.foregroundBVC().tabManager

--- a/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
@@ -25,7 +25,7 @@ class TopSitesRowCountSettingsController: SettingsTableViewController {
     override func generateSettings() -> [SettingSection] {
 
         let createSetting: (Int32) -> CheckmarkSetting = { num in
-            return CheckmarkSetting(title: NSAttributedString(string: "\(num)"), subtitle: nil, isChecked: { return num == self.numberOfRows }, onChecked: {
+            CheckmarkSetting(title: NSAttributedString(string: "\(num)"), subtitle: nil, isChecked: { num == self.numberOfRows }, onChecked: {
                 self.numberOfRows = num
                 self.prefs.setInt(Int32(num), forKey: PrefsKeys.NumberOfTopSiteRows)
                 self.tableView.reloadData()

--- a/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -53,14 +53,20 @@ extension TopSitesSettingsViewController {
     class RowSettings: Setting {
         let profile: Profile
 
-        override var accessoryType: UITableViewCell.AccessoryType { return .disclosureIndicator }
+        override var accessoryType: UITableViewCell.AccessoryType {
+            .disclosureIndicator
+        }
         override var status: NSAttributedString {
             let numberOfRows = profile.prefs.intForKey(PrefsKeys.NumberOfTopSiteRows) ?? TopSitesRowCountSettingsController.defaultNumberOfRows
             return NSAttributedString(string: String(format: "%d", numberOfRows))
         }
 
-        override var accessibilityIdentifier: String? { return AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.Shortcuts.topSitesRows }
-        override var style: UITableViewCell.CellStyle { return .value1 }
+        override var accessibilityIdentifier: String? {
+            AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.Shortcuts.topSitesRows
+        }
+        override var style: UITableViewCell.CellStyle {
+            .value1
+        }
 
         init(settings: SettingsTableViewController) {
             self.profile = settings.profile

--- a/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/LegacyWallpaperSettingsViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/LegacyWallpaperSettingsViewController.swift
@@ -285,7 +285,7 @@ extension LegacyWallpaperSettingsViewController: Notifiable {
 // MARK: - Collection View Data Source
 extension LegacyWallpaperSettingsViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return viewModel.wallpaperManager.numberOfWallpapers
+        viewModel.wallpaperManager.numberOfWallpapers
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -15,7 +15,7 @@ enum InfoItem: Int {
     case deleteItem
 
     var indexPath: IndexPath {
-        return IndexPath(row: rawValue, section: 0)
+        IndexPath(row: rawValue, section: 0)
     }
 }
 
@@ -229,7 +229,7 @@ extension LoginDetailViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 6
+        6
     }
 }
 
@@ -391,7 +391,7 @@ extension LoginDetailViewController: LoginDetailTableViewCellDelegate {
     }
 
     private func cellForItem(_ item: InfoItem) -> LoginDetailTableViewCell? {
-        return tableView.cellForRow(at: item.indexPath) as? LoginDetailTableViewCell
+        tableView.cellForRow(at: item.indexPath) as? LoginDetailTableViewCell
     }
 
     func didSelectOpenAndFillForCell(_ cell: LoginDetailTableViewCell) {

--- a/Client/Frontend/Settings/NewTabContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/NewTabContentSettingsViewController.swift
@@ -35,7 +35,7 @@ class NewTabContentSettingsViewController: SettingsTableViewController {
             title: NSAttributedString(string: .SettingsNewTabTopSites),
             subtitle: nil,
             accessibilityIdentifier: "NewTabAsFirefoxHome",
-            isChecked: {return self.currentChoice == NewTabPage.topSites},
+            isChecked: { self.currentChoice == NewTabPage.topSites },
             onChecked: {
                 self.currentChoice = NewTabPage.topSites
                 onFinished()
@@ -44,7 +44,7 @@ class NewTabContentSettingsViewController: SettingsTableViewController {
             title: NSAttributedString(string: .SettingsNewTabBlankPage),
             subtitle: nil,
             accessibilityIdentifier: "NewTabAsBlankPage",
-            isChecked: {return self.currentChoice == NewTabPage.blankPage},
+            isChecked: { self.currentChoice == NewTabPage.blankPage },
             onChecked: {
                 self.currentChoice = NewTabPage.blankPage
                 onFinished()
@@ -55,7 +55,7 @@ class NewTabContentSettingsViewController: SettingsTableViewController {
             defaultValue: nil,
             placeholder: .CustomNewPageURL,
             accessibilityIdentifier: "NewTabAsCustomURL",
-            isChecked: { return !showTopSites.isChecked() && !showBlankPage.isChecked() },
+            isChecked: { !showTopSites.isChecked() && !showBlankPage.isChecked() },
             settingDidChange: { (string) in
                 self.currentChoice = NewTabPage.homePage
                 self.prefs.setString(self.currentChoice.rawValue, forKey: NewTabAccessors.NewTabPrefKey)

--- a/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
+++ b/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
@@ -54,20 +54,20 @@ final class SearchBarSettingsViewModel: FeatureFlaggable {
     }
 
     var topSetting: CheckmarkSetting {
-        return CheckmarkSetting(title: NSAttributedString(string: SearchBarPosition.top.getLocalizedTitle),
-                                subtitle: nil,
-                                accessibilityIdentifier: AccessibilityIdentifiers.Settings.SearchBar.topSetting,
-                                isChecked: { return self.searchBarPosition == .top },
-                                onChecked: { self.saveSearchBarPosition(SearchBarPosition.top)}
+        CheckmarkSetting(title: NSAttributedString(string: SearchBarPosition.top.getLocalizedTitle),
+                subtitle: nil,
+                accessibilityIdentifier: AccessibilityIdentifiers.Settings.SearchBar.topSetting,
+                isChecked: { self.searchBarPosition == .top },
+                onChecked: { self.saveSearchBarPosition(SearchBarPosition.top) }
         )
     }
 
     var bottomSetting: CheckmarkSetting {
-        return CheckmarkSetting(title: NSAttributedString(string: SearchBarPosition.bottom.getLocalizedTitle),
-                                subtitle: nil,
-                                accessibilityIdentifier: AccessibilityIdentifiers.Settings.SearchBar.bottomSetting,
-                                isChecked: { return self.searchBarPosition == .bottom },
-                                onChecked: { self.saveSearchBarPosition(SearchBarPosition.bottom) }
+        CheckmarkSetting(title: NSAttributedString(string: SearchBarPosition.bottom.getLocalizedTitle),
+                subtitle: nil,
+                accessibilityIdentifier: AccessibilityIdentifiers.Settings.SearchBar.bottomSetting,
+                isChecked: { self.searchBarPosition == .bottom },
+                onChecked: { self.saveSearchBarPosition(SearchBarPosition.bottom) }
         )
     }
 }

--- a/Client/Frontend/Settings/SearchEnginePicker.swift
+++ b/Client/Frontend/Settings/SearchEnginePicker.swift
@@ -17,7 +17,7 @@ class SearchEnginePicker: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return engines.count
+        engines.count
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -133,7 +133,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return NumberOfSections
+        NumberOfSections
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -180,7 +180,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
 
     // Don't reserve space for the delete button on the left.
     override func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
-        return false
+        false
     }
 
     override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
@@ -203,11 +203,11 @@ class SearchSettingsTableViewController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return UITableView.automaticDimension
+        UITableView.automaticDimension
     }
 
     override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return 0
+        0
     }
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/Client/Frontend/Settings/SettingsNavigationController.swift
+++ b/Client/Frontend/Settings/SettingsNavigationController.swift
@@ -16,7 +16,7 @@ class ThemedNavigationController: DismissableNavigationViewController {
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return topViewController?.preferredStatusBarStyle ?? LegacyThemeManager.instance.statusBarStyle
+        topViewController?.preferredStatusBarStyle ?? LegacyThemeManager.instance.statusBarStyle
     }
 
     override func viewDidLoad() {
@@ -57,6 +57,6 @@ protocol PresentingModalViewControllerDelegate: AnyObject {
 
 class ModalSettingsNavigationController: UINavigationController {
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return .default
+        .default
     }
 }

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -45,29 +45,51 @@ class Setting: NSObject {
     weak var delegate: SettingsDelegate?
 
     // The url the SettingsContentViewController will show, e.g. Licenses and Privacy Policy.
-    var url: URL? { return nil }
+    var url: URL? {
+        nil
+    }
 
     // The title shown on the pref.
-    var title: NSAttributedString? { return _title }
-    var footerTitle: NSAttributedString? { return _footerTitle }
-    var cellHeight: CGFloat? { return _cellHeight}
+    var title: NSAttributedString? {
+        _title
+    }
+    var footerTitle: NSAttributedString? {
+        _footerTitle
+    }
+    var cellHeight: CGFloat? {
+        _cellHeight
+    }
     fileprivate(set) var accessibilityIdentifier: String?
 
     // An optional second line of text shown on the pref.
-    var status: NSAttributedString? { return nil }
+    var status: NSAttributedString? {
+        nil
+    }
 
     // Whether or not to show this pref.
-    var hidden: Bool { return false }
+    var hidden: Bool {
+        false
+    }
 
-    var style: UITableViewCell.CellStyle { return .subtitle }
+    var style: UITableViewCell.CellStyle {
+        .subtitle
+    }
 
-    var accessoryType: UITableViewCell.AccessoryType { return .none }
+    var accessoryType: UITableViewCell.AccessoryType {
+        .none
+    }
 
-    var accessoryView: UIImageView? { return nil }
+    var accessoryView: UIImageView? {
+        nil
+    }
 
-    var textAlignment: NSTextAlignment { return .natural }
+    var textAlignment: NSTextAlignment {
+        .natural
+    }
 
-    var image: UIImage? { return _image }
+    var image: UIImage? {
+        _image
+    }
 
     var enabled: Bool = true
 
@@ -114,10 +136,12 @@ class Setting: NSObject {
     }
 
     // Called when the pref is tapped.
-    func onClick(_ navigationController: UINavigationController?) { return }
+    func onClick(_ navigationController: UINavigationController?) {
+    }
 
     // Called when the pref is long-pressed.
-    func onLongPress(_ navigationController: UINavigationController?) { return }
+    func onLongPress(_ navigationController: UINavigationController?) {
+    }
 
     // Helper method to set up and push a SettingsContentViewController
     func setUpAndPushSettingsContentViewController(_ navigationController: UINavigationController?, _ url: URL? = nil) {
@@ -250,7 +274,7 @@ class BoolSetting: Setting, FeatureFlaggable {
     }
 
     override var status: NSAttributedString? {
-        return statusText
+        statusText
     }
 
     override func onConfigureCell(_ cell: UITableViewCell) {
@@ -329,7 +353,7 @@ class PrefPersister: SettingValuePersister {
     }
 
     func readPersistedValue() -> String? {
-        return prefs.stringForKey(prefKey)
+        prefs.stringForKey(prefKey)
     }
 
     func writePersistedValue(value: String?) {
@@ -369,7 +393,9 @@ class WebPageSetting: StringPrefSetting {
         defaultValue: String? = nil,
         placeholder: String,
         accessibilityIdentifier: String,
-        isChecked: @escaping () -> Bool = { return false },
+        isChecked: @escaping () -> Bool = {
+            false
+        },
         settingDidChange: ((String?) -> Void)? = nil
     ) {
         self.isChecked = isChecked
@@ -486,7 +512,7 @@ class StringSetting: Setting, UITextFieldDelegate {
     /// before it is saved or tested.
     /// Default implementation does nothing.
     func prepareValidValue(userInput value: String?) -> String? {
-        return value
+        value
     }
 
     @objc func textFieldDidChange(_ textField: UITextField) {
@@ -522,7 +548,7 @@ class CheckmarkSetting: Setting {
     let checkmarkStyle: CheckmarkSettingStyle
 
     override var status: NSAttributedString? {
-        return subtitle
+        subtitle
     }
 
     init(
@@ -642,10 +668,12 @@ class AccountSetting: Setting {
     unowned var settings: SettingsTableViewController
 
     var profile: Profile {
-        return settings.profile
+        settings.profile
     }
 
-    override var title: NSAttributedString? { return nil }
+    override var title: NSAttributedString? {
+        nil
+    }
 
     init(settings: SettingsTableViewController) {
         self.settings = settings
@@ -659,15 +687,21 @@ class AccountSetting: Setting {
         }
     }
 
-    override var accessoryType: UITableViewCell.AccessoryType { return .none }
+    override var accessoryType: UITableViewCell.AccessoryType {
+        .none
+    }
 }
 
 class WithAccountSetting: AccountSetting {
-    override var hidden: Bool { return !profile.hasAccount() }
+    override var hidden: Bool {
+        !profile.hasAccount()
+    }
 }
 
 class WithoutAccountSetting: AccountSetting {
-    override var hidden: Bool { return profile.hasAccount() }
+    override var hidden: Bool {
+        profile.hasAccount()
+    }
 }
 
 @objc
@@ -740,7 +774,7 @@ class SettingsTableViewController: ThemedTableViewController {
 
     // Override to provide settings in subclasses
     func generateSettings() -> [SettingSection] {
-        return []
+        []
     }
 
     @objc fileprivate func syncDidChangeState() {
@@ -781,7 +815,7 @@ class SettingsTableViewController: ThemedTableViewController {
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return settings.count
+        settings.count
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -825,7 +859,7 @@ class SettingsTableViewController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return UITableView.automaticDimension
+        UITableView.automaticDimension
     }
 
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {

--- a/Client/Frontend/Settings/SiriSettingsViewController.swift
+++ b/Client/Frontend/Settings/SiriSettingsViewController.swift
@@ -29,9 +29,13 @@ class SiriSettingsViewController: SettingsTableViewController {
 }
 
 class SiriOpenURLSetting: Setting {
-    override var accessoryType: UITableViewCell.AccessoryType { return .disclosureIndicator }
+    override var accessoryType: UITableViewCell.AccessoryType {
+        .disclosureIndicator
+    }
 
-    override var accessibilityIdentifier: String? { return "SiriSettings" }
+    override var accessibilityIdentifier: String? {
+        "SiriSettings"
+    }
 
     init(settings: SettingsTableViewController) {
         super.init(title: NSAttributedString(string: .SettingsSiriOpenURL, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))

--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -10,9 +10,13 @@ import Account
 class ManageFxAccountSetting: Setting {
     let profile: Profile
 
-    override var accessoryType: UITableViewCell.AccessoryType { return .disclosureIndicator }
+    override var accessoryType: UITableViewCell.AccessoryType {
+        .disclosureIndicator
+    }
 
-    override var accessibilityIdentifier: String? { return "Manage" }
+    override var accessibilityIdentifier: String? {
+        "Manage"
+    }
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
@@ -29,11 +33,15 @@ class ManageFxAccountSetting: Setting {
 class DisconnectSetting: Setting {
     let settingsVC: SettingsTableViewController
     let profile: Profile
-    override var accessoryType: UITableViewCell.AccessoryType { return .none }
-    override var textAlignment: NSTextAlignment { return .center }
+    override var accessoryType: UITableViewCell.AccessoryType {
+        .none
+    }
+    override var textAlignment: NSTextAlignment {
+        .center
+    }
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: .SettingsDisconnectSyncButton, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.general.destructiveRed])
+        NSAttributedString(string: .SettingsDisconnectSyncButton, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.general.destructiveRed])
     }
 
     init(settings: SettingsTableViewController) {
@@ -41,7 +49,9 @@ class DisconnectSetting: Setting {
         self.profile = settings.profile
     }
 
-    override var accessibilityIdentifier: String? { return "SignOut" }
+    override var accessibilityIdentifier: String? {
+        "SignOut"
+    }
 
     override func onClick(_ navigationController: UINavigationController?) {
         let alertController = UIAlertController(

--- a/Client/Frontend/Settings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettingsController.swift
@@ -27,11 +27,11 @@ class ThemeSettingsController: ThemedTableViewController {
     private let deviceBrightnessIndicatorColor = UIColor(white: 182/255, alpha: 1.0)
 
     var isAutoBrightnessOn: Bool {
-        return LegacyThemeManager.instance.automaticBrightnessIsOn
+        LegacyThemeManager.instance.automaticBrightnessIsOn
     }
 
     var isSystemThemeOn: Bool {
-        return LegacyThemeManager.instance.systemThemeIsOn
+        LegacyThemeManager.instance.systemThemeIsOn
     }
 
     private var shouldHideSystemThemeSection = false

--- a/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
@@ -207,7 +207,7 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        return Section.count
+        Section.count
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -314,7 +314,7 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
     }
 
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return 0
+        0
     }
 
     private func unfoldSearchbar() {

--- a/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
@@ -62,7 +62,7 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        return Section.count
+        Section.count
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -164,7 +164,7 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
 
     func filterContentForSearchText(_ searchText: String) {
         filteredSiteRecords = viewModel.siteRecords.filter({ siteRecord in
-            return siteRecord.displayName.lowercased().contains(searchText.lowercased())
+            siteRecord.displayName.lowercased().contains(searchText.lowercased())
         })
 
         tableView.reloadData()

--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -82,7 +82,7 @@ class ShareExtensionHelper: NSObject {
 
 extension ShareExtensionHelper: UIActivityItemSource {
     func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
-        return url
+        url
     }
 
     func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {

--- a/Client/Frontend/Share/TitleActivityItemProvider.swift
+++ b/Client/Frontend/Share/TitleActivityItemProvider.swift
@@ -34,6 +34,6 @@ class TitleActivityItemProvider: UIActivityItemProvider {
     }
 
     override func activityViewController(_ activityViewController: UIActivityViewController, subjectForActivityType activityType: UIActivity.ActivityType?) -> String {
-        return placeholderItem as! String
+        placeholderItem as! String
     }
 }

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -38,11 +38,11 @@ private func MZLocalizedString(_ key: String,
                                comment: String,
                                lastUpdated: StringLastUpdatedAppVersion
 ) -> String {
-    return NSLocalizedString(key,
-                             tableName: tableName,
-                             bundle: Strings.bundle,
-                             value: value,
-                             comment: comment)
+    NSLocalizedString(key,
+            tableName: tableName,
+            bundle: Strings.bundle,
+            value: value,
+            comment: comment)
 }
 
 /// This file contains all strings for Firefox iOS.

--- a/Client/Frontend/TabContentsScripts/ContextMenuHelper.swift
+++ b/Client/Frontend/TabContentsScripts/ContextMenuHelper.swift
@@ -42,7 +42,7 @@ class ContextMenuHelper: NSObject {
 @available(iOS, obsoleted: 14.0)
 extension ContextMenuHelper: UIGestureRecognizerDelegate {
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        return true
+        true
     }
 
     // BVC KVO events for all changes on the webview will call this. 
@@ -103,11 +103,11 @@ extension ContextMenuHelper: UIGestureRecognizerDelegate {
 
 extension ContextMenuHelper: TabContentScript {
     class func name() -> String {
-        return "ContextMenuHelper"
+        "ContextMenuHelper"
     }
 
     func scriptMessageHandlerName() -> String? {
-        return "contextMenuMessageHandler"
+        "contextMenuMessageHandler"
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {

--- a/Client/Frontend/TabContentsScripts/DownloadContentScript.swift
+++ b/Client/Frontend/TabContentsScripts/DownloadContentScript.swift
@@ -14,7 +14,7 @@ class DownloadContentScript: TabContentScript {
     fileprivate static var blobUrlForDownload: URL?
 
     class func name() -> String {
-        return "DownloadContentScript"
+        "DownloadContentScript"
     }
 
     required init(tab: Tab) {
@@ -22,7 +22,7 @@ class DownloadContentScript: TabContentScript {
     }
 
     func scriptMessageHandlerName() -> String? {
-        return "downloadManager"
+        "downloadManager"
     }
 
     /// This function handles blob downloads

--- a/Client/Frontend/TabContentsScripts/FindInPageHelper.swift
+++ b/Client/Frontend/TabContentsScripts/FindInPageHelper.swift
@@ -16,7 +16,7 @@ class FindInPageHelper: TabContentScript {
     fileprivate weak var tab: Tab?
 
     class func name() -> String {
-        return "FindInPage"
+        "FindInPage"
     }
 
     required init(tab: Tab) {
@@ -24,7 +24,7 @@ class FindInPageHelper: TabContentScript {
     }
 
     func scriptMessageHandlerName() -> String? {
-        return "findInPageHandler"
+        "findInPageHandler"
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {

--- a/Client/Frontend/TabContentsScripts/FocusHelper.swift
+++ b/Client/Frontend/TabContentsScripts/FocusHelper.swift
@@ -16,11 +16,11 @@ class FocusHelper: TabContentScript {
     }
 
     static func name() -> String {
-        return "FocusHelper"
+        "FocusHelper"
     }
 
     func scriptMessageHandlerName() -> String? {
-        return "focusHelper"
+        "focusHelper"
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {

--- a/Client/Frontend/TabContentsScripts/FormPostHelper.swift
+++ b/Client/Frontend/TabContentsScripts/FormPostHelper.swift
@@ -63,11 +63,11 @@ class FormPostHelper: TabContentScript {
     }
 
     static func name() -> String {
-        return "FormPostHelper"
+        "FormPostHelper"
     }
 
     func scriptMessageHandlerName() -> String? {
-        return "formPostHelper"
+        "formPostHelper"
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {

--- a/Client/Frontend/TabContentsScripts/LocalRequestHelper.swift
+++ b/Client/Frontend/TabContentsScripts/LocalRequestHelper.swift
@@ -8,7 +8,7 @@ import Shared
 
 class LocalRequestHelper: TabContentScript {
     func scriptMessageHandlerName() -> String? {
-        return "localRequestHelper"
+        "localRequestHelper"
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
@@ -38,6 +38,6 @@ class LocalRequestHelper: TabContentScript {
     }
 
     class func name() -> String {
-        return "LocalRequestHelper"
+        "LocalRequestHelper"
     }
 }

--- a/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -17,11 +17,11 @@ class LoginsHelper: TabContentScript {
 
     // Exposed for mocking purposes
     var logins: RustLogins {
-        return profile.logins
+        profile.logins
     }
 
     class func name() -> String {
-        return "LoginsHelper"
+        "LoginsHelper"
     }
 
     required init(tab: Tab, profile: Profile) {
@@ -30,7 +30,7 @@ class LoginsHelper: TabContentScript {
     }
 
     func scriptMessageHandlerName() -> String? {
-        return "loginsManagerMessageHandler"
+        "loginsManagerMessageHandler"
     }
 
     fileprivate func getOrigin(_ uriString: String, allowJS: Bool = false) -> String? {
@@ -244,7 +244,7 @@ class LoginsHelper: TabContentScript {
 
             let logins: [[String: Any]] = cursor.compactMap { login in
                 // `requestLogins` is for webpage forms, not for HTTP Auth, and the latter has httpRealm != nil; filter those out.
-                return login?.httpRealm == nil ? login?.toJSONDict() : nil
+                login?.httpRealm == nil ? login?.toJSONDict() : nil
             }
 
             log.debug("Found \(logins.count) logins.")

--- a/Client/Frontend/TabContentsScripts/NightModeHelper.swift
+++ b/Client/Frontend/TabContentsScripts/NightModeHelper.swift
@@ -20,11 +20,11 @@ class NightModeHelper: TabContentScript {
     }
 
     static func name() -> String {
-        return "NightMode"
+        "NightMode"
     }
 
     func scriptMessageHandlerName() -> String? {
-        return "NightMode"
+        "NightMode"
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
@@ -49,16 +49,16 @@ class NightModeHelper: TabContentScript {
     }
 
     static func hasEnabledDarkTheme(_ prefs: Prefs) -> Bool {
-        return prefs.boolForKey(NightModePrefsKey.NightModeEnabledDarkTheme) ?? false
+        prefs.boolForKey(NightModePrefsKey.NightModeEnabledDarkTheme) ?? false
     }
 
     static func isActivated(_ prefs: Prefs) -> Bool {
-        return prefs.boolForKey(NightModePrefsKey.NightModeStatus) ?? false
+        prefs.boolForKey(NightModePrefsKey.NightModeStatus) ?? false
     }
 }
 
 class NightModeAccessors {
     static func isNightMode(_ prefs: Prefs) -> Bool {
-        return prefs.boolForKey(NightModePrefsKey.NightModeStatus) ?? false
+        prefs.boolForKey(NightModePrefsKey.NightModeStatus) ?? false
     }
 }

--- a/Client/Frontend/TabContentsScripts/NoImageModeHelper.swift
+++ b/Client/Frontend/TabContentsScripts/NoImageModeHelper.swift
@@ -18,11 +18,11 @@ class NoImageModeHelper: TabContentScript {
     }
 
     static func name() -> String {
-        return "NoImageMode"
+        "NoImageMode"
     }
 
     func scriptMessageHandlerName() -> String? {
-        return "NoImageMode"
+        "NoImageMode"
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
@@ -30,7 +30,7 @@ class NoImageModeHelper: TabContentScript {
     }
 
     static func isActivated(_ prefs: Prefs) -> Bool {
-        return prefs.boolForKey(NoImageModePrefsKey.NoImageModeStatus) ?? false
+        prefs.boolForKey(NoImageModePrefsKey.NoImageModeStatus) ?? false
     }
 
     static func toggle(isEnabled: Bool, profile: Profile, tabManager: TabManager) {

--- a/Client/Frontend/TabContentsScripts/PrintHelper.swift
+++ b/Client/Frontend/TabContentsScripts/PrintHelper.swift
@@ -10,7 +10,7 @@ class PrintHelper: TabContentScript {
     fileprivate weak var tab: Tab?
 
     class func name() -> String {
-        return "PrintHelper"
+        "PrintHelper"
     }
 
     required init(tab: Tab) {
@@ -18,7 +18,7 @@ class PrintHelper: TabContentScript {
     }
 
     func scriptMessageHandlerName() -> String? {
-        return "printHandler"
+        "printHandler"
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {

--- a/Client/Frontend/TabContentsScripts/SessionRestoreHelper.swift
+++ b/Client/Frontend/TabContentsScripts/SessionRestoreHelper.swift
@@ -18,7 +18,7 @@ class SessionRestoreHelper: TabContentScript {
     }
 
     func scriptMessageHandlerName() -> String? {
-        return "sessionRestoreHelper"
+        "sessionRestoreHelper"
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
@@ -32,6 +32,6 @@ class SessionRestoreHelper: TabContentScript {
     }
 
     class func name() -> String {
-        return "SessionRestoreHelper"
+        "SessionRestoreHelper"
     }
 }

--- a/Client/Frontend/Theme/FxDefaultTheme.swift
+++ b/Client/Frontend/Theme/FxDefaultTheme.swift
@@ -17,35 +17,93 @@ private struct FxDefaultColourPalette: ThemeColourPalette {
     // Generally, force unwrapping should be avoided. However,
     // because we expect to ship these colours, we should force
     // unwrap to force a crash in case that these colours aren't found.
-    var actionPrimary: UIColor { return UIColor(named: "ActionPrimary")! }
-    var actionSecondary: UIColor { return UIColor(named: "ActionSecondary")! }
-    var borderDivider: UIColor { return UIColor(named: "BorderDivider")! }
-    var borderSelectedDefault: UIColor { return UIColor(named: "BorderSelectedDefault")! }
-    var borderSelectedPrivate: UIColor { return UIColor(named: "BorderSelectedPrivate")! }
-    var controlActive: UIColor { return UIColor(named: "ControlActive")! }
-    var controlBase: UIColor { return UIColor(named: "ControlBase")! }
-    var iconAccentBlue: UIColor { return UIColor(named: "IconAccentBlue")! }
-    var iconAccentGreen: UIColor { return UIColor(named: "IconAccentGreen")! }
-    var iconAccentPink: UIColor { return UIColor(named: "IconAccentPink")! }
-    var iconAccentViolet: UIColor { return UIColor(named: "IconAccentViolet")! }
-    var iconAccentYellow: UIColor { return UIColor(named: "IconAccentYellow")! }
-    var iconDisabled: UIColor { return UIColor(named: "IconDisabled")! }
-    var iconInverted: UIColor { return UIColor(named: "IconInverted")! }
-    var iconPrimary: UIColor { return UIColor(named: "IconPrimary")! }
-    var iconSecondary: UIColor { return UIColor(named: "IconSecondary")! }
-    var layer1: UIColor { return UIColor(named: "Layer1")! }
-    var layer2: UIColor { return UIColor(named: "Layer2")! }
-    var layer2Blur: UIColor { return UIColor(named: "Layer2Blur")! }
-    var layer3: UIColor { return UIColor(named: "Layer3")! }
-    var layer4: UIColor { return UIColor(named: "Layer4")! }
-    var layerEmphasis: UIColor { return UIColor(named: "LayerEmphasis")! }
-    var scrim: UIColor { return UIColor(named: "Scrim")! }
-    var textDisabled: UIColor { return UIColor(named: "TextDisabled")! }
-    var textInverted: UIColor { return UIColor(named: "TextInverted")! }
-    var textLink: UIColor { return UIColor(named: "TextLink")! }
-    var textPrimary: UIColor { return UIColor(named: "TextPrimary")! }
-    var textSecondary: UIColor { return UIColor(named: "TextSecondary")! }
-    var textWarning: UIColor { return UIColor(named: "TextWarning")! }
+    var actionPrimary: UIColor {
+        UIColor(named: "ActionPrimary")!
+    }
+    var actionSecondary: UIColor {
+        UIColor(named: "ActionSecondary")!
+    }
+    var borderDivider: UIColor {
+        UIColor(named: "BorderDivider")!
+    }
+    var borderSelectedDefault: UIColor {
+        UIColor(named: "BorderSelectedDefault")!
+    }
+    var borderSelectedPrivate: UIColor {
+        UIColor(named: "BorderSelectedPrivate")!
+    }
+    var controlActive: UIColor {
+        UIColor(named: "ControlActive")!
+    }
+    var controlBase: UIColor {
+        UIColor(named: "ControlBase")!
+    }
+    var iconAccentBlue: UIColor {
+        UIColor(named: "IconAccentBlue")!
+    }
+    var iconAccentGreen: UIColor {
+        UIColor(named: "IconAccentGreen")!
+    }
+    var iconAccentPink: UIColor {
+        UIColor(named: "IconAccentPink")!
+    }
+    var iconAccentViolet: UIColor {
+        UIColor(named: "IconAccentViolet")!
+    }
+    var iconAccentYellow: UIColor {
+        UIColor(named: "IconAccentYellow")!
+    }
+    var iconDisabled: UIColor {
+        UIColor(named: "IconDisabled")!
+    }
+    var iconInverted: UIColor {
+        UIColor(named: "IconInverted")!
+    }
+    var iconPrimary: UIColor {
+        UIColor(named: "IconPrimary")!
+    }
+    var iconSecondary: UIColor {
+        UIColor(named: "IconSecondary")!
+    }
+    var layer1: UIColor {
+        UIColor(named: "Layer1")!
+    }
+    var layer2: UIColor {
+        UIColor(named: "Layer2")!
+    }
+    var layer2Blur: UIColor {
+        UIColor(named: "Layer2Blur")!
+    }
+    var layer3: UIColor {
+        UIColor(named: "Layer3")!
+    }
+    var layer4: UIColor {
+        UIColor(named: "Layer4")!
+    }
+    var layerEmphasis: UIColor {
+        UIColor(named: "LayerEmphasis")!
+    }
+    var scrim: UIColor {
+        UIColor(named: "Scrim")!
+    }
+    var textDisabled: UIColor {
+        UIColor(named: "TextDisabled")!
+    }
+    var textInverted: UIColor {
+        UIColor(named: "TextInverted")!
+    }
+    var textLink: UIColor {
+        UIColor(named: "TextLink")!
+    }
+    var textPrimary: UIColor {
+        UIColor(named: "TextPrimary")!
+    }
+    var textSecondary: UIColor {
+        UIColor(named: "TextSecondary")!
+    }
+    var textWarning: UIColor {
+        UIColor(named: "TextWarning")!
+    }
 }
 
 private struct FxDefaultFontPalette: ThemeFontPalette {

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
@@ -10,24 +10,54 @@ private let defaultSeparator = UIColor.Photon.Grey60
 private let defaultTextAndTint = UIColor.Photon.Grey10
 
 private class DarkTableViewColor: TableViewColor {
-    override var rowBackground: UIColor { return UIColor.Photon.Grey70 }
-    override var rowText: UIColor { return defaultTextAndTint }
-    override var rowDetailText: UIColor { return UIColor.Photon.Grey30 }
-    override var disabledRowText: UIColor { return UIColor.Photon.Grey40 }
-    override var separator: UIColor { return UIColor.Photon.Grey60 }
-    override var headerBackground: UIColor { return UIColor.Photon.Grey80 }
-    override var headerTextLight: UIColor { return UIColor.Photon.Grey30 }
-    override var headerTextDark: UIColor { return UIColor.Photon.Grey30 }
-    override var syncText: UIColor { return defaultTextAndTint }
-    override var accessoryViewTint: UIColor { return UIColor.Photon.Grey40 }
-    override var selectedBackground: UIColor { return UIColor.Custom.selectedHighlightDark }
+    override var rowBackground: UIColor {
+        UIColor.Photon.Grey70
+    }
+    override var rowText: UIColor {
+        defaultTextAndTint
+    }
+    override var rowDetailText: UIColor {
+        UIColor.Photon.Grey30
+    }
+    override var disabledRowText: UIColor {
+        UIColor.Photon.Grey40
+    }
+    override var separator: UIColor {
+        UIColor.Photon.Grey60
+    }
+    override var headerBackground: UIColor {
+        UIColor.Photon.Grey80
+    }
+    override var headerTextLight: UIColor {
+        UIColor.Photon.Grey30
+    }
+    override var headerTextDark: UIColor {
+        UIColor.Photon.Grey30
+    }
+    override var syncText: UIColor {
+        defaultTextAndTint
+    }
+    override var accessoryViewTint: UIColor {
+        UIColor.Photon.Grey40
+    }
+    override var selectedBackground: UIColor {
+        UIColor.Custom.selectedHighlightDark
+    }
 }
 
 private class DarkActionMenuColor: ActionMenuColor {
-    override var foreground: UIColor { return UIColor.Photon.White100 }
-    override var iPhoneBackgroundBlurStyle: UIBlurEffect.Style { return UIBlurEffect.Style.dark }
-    override var iPhoneBackground: UIColor { return defaultBackground.withAlphaComponent(0.9) }
-    override var closeButtonBackground: UIColor { return defaultBackground }
+    override var foreground: UIColor {
+        UIColor.Photon.White100
+    }
+    override var iPhoneBackgroundBlurStyle: UIBlurEffect.Style {
+        UIBlurEffect.Style.dark
+    }
+    override var iPhoneBackground: UIColor {
+        defaultBackground.withAlphaComponent(0.9)
+    }
+    override var closeButtonBackground: UIColor {
+        defaultBackground
+    }
 }
 
 private class DarkURLBarColor: URLBarColor {
@@ -38,13 +68,17 @@ private class DarkURLBarColor: URLBarColor {
     }
 
     override func activeBorder(_ isPrivate: Bool) -> UIColor {
-        return !isPrivate ? UIColor.Photon.Blue20A40 : UIColor.Defaults.MobilePrivatePurple
+        !isPrivate ? UIColor.Photon.Blue20A40 : UIColor.Defaults.MobilePrivatePurple
     }
 }
 
 private class DarkBrowserColor: BrowserColor {
-    override var background: UIColor { return defaultBackground }
-    override var tint: UIColor { return defaultTextAndTint }
+    override var background: UIColor {
+        defaultBackground
+    }
+    override var tint: UIColor {
+        defaultTextAndTint
+    }
 }
 
 // The back/forward/refresh/menu button (bottom toolbar)
@@ -53,96 +87,224 @@ private class DarkToolbarButtonColor: ToolbarButtonColor {
 }
 
 private class DarkTabTrayColor: TabTrayColor {
-    override var tabTitleText: UIColor { return defaultTextAndTint }
-    override var tabTitleBlur: UIBlurEffect.Style { return UIBlurEffect.Style.dark }
-    override var background: UIColor { return UIColor.Photon.DarkGrey80 }
-    override var screenshotBackground: UIColor { return UIColor.Photon.DarkGrey30 }
-    override var cellBackground: UIColor { return defaultBackground }
-    override var toolbar: UIColor { return UIColor.Photon.Grey80 }
-    override var toolbarButtonTint: UIColor { return defaultTextAndTint }
-    override var cellCloseButton: UIColor { return defaultTextAndTint }
-    override var cellTitleBackground: UIColor { return UIColor.Photon.Grey70 }
-    override var faviconTint: UIColor { return UIColor.Photon.White100 }
-    override var searchBackground: UIColor { return UIColor.Photon.Grey60 }
+    override var tabTitleText: UIColor {
+        defaultTextAndTint
+    }
+    override var tabTitleBlur: UIBlurEffect.Style {
+        UIBlurEffect.Style.dark
+    }
+    override var background: UIColor {
+        UIColor.Photon.DarkGrey80
+    }
+    override var screenshotBackground: UIColor {
+        UIColor.Photon.DarkGrey30
+    }
+    override var cellBackground: UIColor {
+        defaultBackground
+    }
+    override var toolbar: UIColor {
+        UIColor.Photon.Grey80
+    }
+    override var toolbarButtonTint: UIColor {
+        defaultTextAndTint
+    }
+    override var cellCloseButton: UIColor {
+        defaultTextAndTint
+    }
+    override var cellTitleBackground: UIColor {
+        UIColor.Photon.Grey70
+    }
+    override var faviconTint: UIColor {
+        UIColor.Photon.White100
+    }
+    override var searchBackground: UIColor {
+        UIColor.Photon.Grey60
+    }
 }
 
 private class DarkEnhancedTrackingProtectionMenuColor: EnhancedTrackingProtectionMenuColor {
-    override var defaultImageTints: UIColor { return defaultTextAndTint }
-    override var background: UIColor { return UIColor.Photon.DarkGrey80 }
-    override var sectionColor: UIColor { return UIColor.Photon.DarkGrey65 }
-    override var switchAndButtonTint: UIColor { return UIColor.Photon.Blue20 }
-    override var subtextColor: UIColor { return UIColor.Photon.LightGrey05 }
-    override var closeButtonColor: UIColor { return UIColor.Photon.DarkGrey65 }
+    override var defaultImageTints: UIColor {
+        defaultTextAndTint
+    }
+    override var background: UIColor {
+        UIColor.Photon.DarkGrey80
+    }
+    override var sectionColor: UIColor {
+        UIColor.Photon.DarkGrey65
+    }
+    override var switchAndButtonTint: UIColor {
+        UIColor.Photon.Blue20
+    }
+    override var subtextColor: UIColor {
+        UIColor.Photon.LightGrey05
+    }
+    override var closeButtonColor: UIColor {
+        UIColor.Photon.DarkGrey65
+    }
 }
 
 private class DarkTopTabsColor: TopTabsColor {
     override var background: UIColor { UIColor.Photon.DarkGrey80 }
-    override var tabBackgroundSelected: UIColor { return UIColor.Photon.DarkGrey30 }
-    override var tabBackgroundUnselected: UIColor { return UIColor.Photon.Grey80 }
-    override var tabForegroundSelected: UIColor { return UIColor.Photon.Grey10 }
-    override var tabForegroundUnselected: UIColor { return UIColor.Photon.Grey40 }
-    override var closeButtonSelectedTab: UIColor { return tabForegroundSelected }
-    override var closeButtonUnselectedTab: UIColor { return tabForegroundUnselected }
-    override var separator: UIColor { return UIColor.Photon.Grey50 }
-    override var buttonTint: UIColor { return UIColor.Photon.Grey10 }
+    override var tabBackgroundSelected: UIColor {
+        UIColor.Photon.DarkGrey30
+    }
+    override var tabBackgroundUnselected: UIColor {
+        UIColor.Photon.Grey80
+    }
+    override var tabForegroundSelected: UIColor {
+        UIColor.Photon.Grey10
+    }
+    override var tabForegroundUnselected: UIColor {
+        UIColor.Photon.Grey40
+    }
+    override var closeButtonSelectedTab: UIColor {
+        tabForegroundSelected
+    }
+    override var closeButtonUnselectedTab: UIColor {
+        tabForegroundUnselected
+    }
+    override var separator: UIColor {
+        UIColor.Photon.Grey50
+    }
+    override var buttonTint: UIColor {
+        UIColor.Photon.Grey10
+    }
 }
 
 private class DarkTextFieldColor: TextFieldColor {
-    override var background: UIColor { return UIColor.Photon.DarkGrey80 }
-    override var backgroundInOverlay: UIColor { return self.background }
+    override var background: UIColor {
+        UIColor.Photon.DarkGrey80
+    }
+    override var backgroundInOverlay: UIColor {
+        self.background
+    }
 
-    override var textAndTint: UIColor { return defaultTextAndTint }
-    override var separator: UIColor { return super.separator.withAlphaComponent(0.3) }
+    override var textAndTint: UIColor {
+        defaultTextAndTint
+    }
+    override var separator: UIColor {
+        super.separator.withAlphaComponent(0.3)
+    }
 }
 
 private class DarkHomePanelColor: HomePanelColor {
-    override var toolbarBackground: UIColor { return defaultBackground }
-    override var toolbarHighlight: UIColor { return UIColor.Photon.Blue20 }
-    override var toolbarTint: UIColor { return UIColor.Photon.Grey30 }
-    override var topSiteHeaderTitle: UIColor { return UIColor.Photon.White100 }
-    override var panelBackground: UIColor { return UIColor.Photon.Grey80 }
-    override var separator: UIColor { return defaultSeparator }
-    override var border: UIColor { return UIColor.Photon.Grey60 }
-    override var buttonContainerBorder: UIColor { return separator }
+    override var toolbarBackground: UIColor {
+        defaultBackground
+    }
+    override var toolbarHighlight: UIColor {
+        UIColor.Photon.Blue20
+    }
+    override var toolbarTint: UIColor {
+        UIColor.Photon.Grey30
+    }
+    override var topSiteHeaderTitle: UIColor {
+        UIColor.Photon.White100
+    }
+    override var panelBackground: UIColor {
+        UIColor.Photon.Grey80
+    }
+    override var separator: UIColor {
+        defaultSeparator
+    }
+    override var border: UIColor {
+        UIColor.Photon.Grey60
+    }
+    override var buttonContainerBorder: UIColor {
+        separator
+    }
 
-    override var welcomeScreenText: UIColor { return UIColor.Photon.Grey30 }
-    override var bookmarkIconBorder: UIColor { return UIColor.Photon.Grey30 }
-    override var bookmarkFolderBackground: UIColor { return UIColor.Photon.Grey80 }
-    override var bookmarkFolderText: UIColor { return UIColor.Photon.White100 }
-    override var bookmarkCurrentFolderText: UIColor { return UIColor.Photon.White100 }
-    override var bookmarkBackNavCellBackground: UIColor { return UIColor.Photon.Grey70 }
+    override var welcomeScreenText: UIColor {
+        UIColor.Photon.Grey30
+    }
+    override var bookmarkIconBorder: UIColor {
+        UIColor.Photon.Grey30
+    }
+    override var bookmarkFolderBackground: UIColor {
+        UIColor.Photon.Grey80
+    }
+    override var bookmarkFolderText: UIColor {
+        UIColor.Photon.White100
+    }
+    override var bookmarkCurrentFolderText: UIColor {
+        UIColor.Photon.White100
+    }
+    override var bookmarkBackNavCellBackground: UIColor {
+        UIColor.Photon.Grey70
+    }
 
-    override var activityStreamHeaderText: UIColor { return UIColor.Photon.LightGrey05 }
-    override var activityStreamHeaderButton: UIColor { return UIColor.Photon.Blue20 }
-    override var activityStreamCellTitle: UIColor { return UIColor.Photon.LightGrey05 }
-    override var activityStreamCellDescription: UIColor { return UIColor.Photon.LightGrey50 }
+    override var activityStreamHeaderText: UIColor {
+        UIColor.Photon.LightGrey05
+    }
+    override var activityStreamHeaderButton: UIColor {
+        UIColor.Photon.Blue20
+    }
+    override var activityStreamCellTitle: UIColor {
+        UIColor.Photon.LightGrey05
+    }
+    override var activityStreamCellDescription: UIColor {
+        UIColor.Photon.LightGrey50
+    }
 
-    override var topSiteDomain: UIColor { return UIColor.Photon.LightGrey05 }
-    override var topSitePin: UIColor { return UIColor.Photon.LightGrey05 }
-    override var topSitesBackground: UIColor { return UIColor.Photon.DarkGrey60 }
+    override var topSiteDomain: UIColor {
+        UIColor.Photon.LightGrey05
+    }
+    override var topSitePin: UIColor {
+        UIColor.Photon.LightGrey05
+    }
+    override var topSitesBackground: UIColor {
+        UIColor.Photon.DarkGrey60
+    }
 
-    override var shortcutBackground: UIColor { return UIColor.Photon.DarkGrey30 }
-    override var shortcutShadowColor: CGColor { return UIColor(red: 0.11, green: 0.11, blue: 0.13, alpha: 1.0).cgColor }
-    override var shortcutShadowOpacity: Float { return 0.5 }
+    override var shortcutBackground: UIColor {
+        UIColor.Photon.DarkGrey30
+    }
+    override var shortcutShadowColor: CGColor {
+        UIColor(red: 0.11, green: 0.11, blue: 0.13, alpha: 1.0).cgColor
+    }
+    override var shortcutShadowOpacity: Float {
+        0.5
+    }
 
-    override var recentlySavedBookmarkCellBackground: UIColor { return UIColor.Photon.DarkGrey30 }
+    override var recentlySavedBookmarkCellBackground: UIColor {
+        UIColor.Photon.DarkGrey30
+    }
 
-    override var recentlyVisitedCellGroupImage: UIColor { return .white }
+    override var recentlyVisitedCellGroupImage: UIColor {
+        .white
+    }
 
-    override var downloadedFileIcon: UIColor { return UIColor.Photon.Grey30 }
+    override var downloadedFileIcon: UIColor {
+        UIColor.Photon.Grey30
+    }
 
-    override var historyHeaderIconsBackground: UIColor { return UIColor.clear }
+    override var historyHeaderIconsBackground: UIColor {
+        UIColor.clear
+    }
 
-    override var readingListActive: UIColor { return UIColor.Photon.Grey10 }
-    override var readingListDimmed: UIColor { return UIColor.Photon.Grey40 }
+    override var readingListActive: UIColor {
+        UIColor.Photon.Grey10
+    }
+    override var readingListDimmed: UIColor {
+        UIColor.Photon.Grey40
+    }
 
-    override var searchSuggestionPillBackground: UIColor { return UIColor.Photon.Grey70 }
-    override var searchSuggestionPillForeground: UIColor { return defaultTextAndTint }
+    override var searchSuggestionPillBackground: UIColor {
+        UIColor.Photon.Grey70
+    }
+    override var searchSuggestionPillForeground: UIColor {
+        defaultTextAndTint
+    }
 
-    override var customizeHomepageButtonBackground: UIColor { return UIColor.Photon.DarkGrey50 }
-    override var customizeHomepageButtonText: UIColor { return UIColor.Photon.LightGrey10 }
+    override var customizeHomepageButtonBackground: UIColor {
+        UIColor.Photon.DarkGrey50
+    }
+    override var customizeHomepageButtonText: UIColor {
+        UIColor.Photon.LightGrey10
+    }
 
-    override var sponsored: UIColor { return UIColor.Photon.LightGrey40 }
+    override var sponsored: UIColor {
+        UIColor.Photon.LightGrey40
+    }
 }
 
 private class DarkSnackBarColor: SnackBarColor {
@@ -150,42 +312,94 @@ private class DarkSnackBarColor: SnackBarColor {
 }
 
 private class DarkGeneralColor: GeneralColor {
-    override var settingsTextPlaceholder: UIColor { return UIColor.Photon.Grey40 }
-    override var faviconBackground: UIColor { return UIColor.Photon.White100 }
-    override var passcodeDot: UIColor { return UIColor.Photon.Grey40 }
-    override var switchToggle: UIColor { return UIColor.Photon.Grey40 }
+    override var settingsTextPlaceholder: UIColor {
+        UIColor.Photon.Grey40
+    }
+    override var faviconBackground: UIColor {
+        UIColor.Photon.White100
+    }
+    override var passcodeDot: UIColor {
+        UIColor.Photon.Grey40
+    }
+    override var switchToggle: UIColor {
+        UIColor.Photon.Grey40
+    }
 }
 
 class DarkHomeTabBannerColor: HomeTabBannerColor {
-    override var backgroundColor: UIColor { return UIColor.Photon.Grey60 }
-    override var textColor: UIColor { return UIColor.white }
-    override var closeButtonBackground: UIColor { return UIColor.Photon.Grey80 }
-    override var closeButton: UIColor { return UIColor.Photon.Grey20 }
+    override var backgroundColor: UIColor {
+        UIColor.Photon.Grey60
+    }
+    override var textColor: UIColor {
+        UIColor.white
+    }
+    override var closeButtonBackground: UIColor {
+        UIColor.Photon.Grey80
+    }
+    override var closeButton: UIColor {
+        UIColor.Photon.Grey20
+    }
 }
 
 class DarkOnboardingColor: OnboardingColor {
-    override var backgroundColor: UIColor { return UIColor.Photon.Grey90 }
+    override var backgroundColor: UIColor {
+        UIColor.Photon.Grey90
+    }
 }
 
 class DarkRemoteTabTrayColor: RemoteTabTrayColor {
-    override var background: UIColor { return UIColor.Photon.Grey70 }
+    override var background: UIColor {
+        UIColor.Photon.Grey70
+    }
 }
 
 class DarkTheme: NormalTheme {
-    override var name: String { return BuiltinThemeName.dark.rawValue }
-    override var tableView: TableViewColor { return DarkTableViewColor() }
-    override var urlbar: URLBarColor { return DarkURLBarColor() }
-    override var browser: BrowserColor { return DarkBrowserColor() }
-    override var toolbarButton: ToolbarButtonColor { return DarkToolbarButtonColor() }
-    override var tabTray: TabTrayColor { return DarkTabTrayColor() }
-    override var etpMenu: EnhancedTrackingProtectionMenuColor { return DarkEnhancedTrackingProtectionMenuColor() }
-    override var topTabs: TopTabsColor { return DarkTopTabsColor() }
-    override var textField: TextFieldColor { return DarkTextFieldColor() }
-    override var homePanel: HomePanelColor { return DarkHomePanelColor() }
-    override var snackbar: SnackBarColor { return DarkSnackBarColor() }
-    override var general: GeneralColor { return DarkGeneralColor() }
-    override var actionMenu: ActionMenuColor { return DarkActionMenuColor() }
-    override var homeTabBanner: HomeTabBannerColor { return DarkHomeTabBannerColor() }
-    override var onboarding: OnboardingColor { return DarkOnboardingColor() }
-    override var remotePanel: RemoteTabTrayColor { return DarkRemoteTabTrayColor() }
+    override var name: String {
+        BuiltinThemeName.dark.rawValue
+    }
+    override var tableView: TableViewColor {
+        DarkTableViewColor()
+    }
+    override var urlbar: URLBarColor {
+        DarkURLBarColor()
+    }
+    override var browser: BrowserColor {
+        DarkBrowserColor()
+    }
+    override var toolbarButton: ToolbarButtonColor {
+        DarkToolbarButtonColor()
+    }
+    override var tabTray: TabTrayColor {
+        DarkTabTrayColor()
+    }
+    override var etpMenu: EnhancedTrackingProtectionMenuColor {
+        DarkEnhancedTrackingProtectionMenuColor()
+    }
+    override var topTabs: TopTabsColor {
+        DarkTopTabsColor()
+    }
+    override var textField: TextFieldColor {
+        DarkTextFieldColor()
+    }
+    override var homePanel: HomePanelColor {
+        DarkHomePanelColor()
+    }
+    override var snackbar: SnackBarColor {
+        DarkSnackBarColor()
+    }
+    override var general: GeneralColor {
+        DarkGeneralColor()
+    }
+    override var actionMenu: ActionMenuColor {
+        DarkActionMenuColor()
+    }
+    override var homeTabBanner: HomeTabBannerColor {
+        DarkHomeTabBannerColor()
+    }
+    override var onboarding: OnboardingColor {
+        DarkOnboardingColor()
+    }
+    override var remotePanel: RemoteTabTrayColor {
+        DarkRemoteTabTrayColor()
+    }
 }

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
@@ -13,7 +13,7 @@ protocol PrivateModeUI {
 
 extension UIColor {
     static var theme: LegacyTheme {
-        return LegacyThemeManager.instance.current
+        LegacyThemeManager.instance.current
     }
 }
 
@@ -28,38 +28,80 @@ private let defaultSeparator = UIColor.Photon.Grey30
 private let defaultTextAndTint = UIColor.Photon.Grey80
 
 class TableViewColor {
-    var rowBackground: UIColor { return UIColor.Photon.White100 }
-    var rowText: UIColor { return UIColor.Photon.Grey90 }
-    var rowDetailText: UIColor { return UIColor.Photon.Grey60 }
-    var disabledRowText: UIColor { return UIColor.Photon.Grey40 }
-    var separator: UIColor { return defaultSeparator }
-    var headerBackground: UIColor { return defaultBackground }
+    var rowBackground: UIColor {
+        UIColor.Photon.White100
+    }
+    var rowText: UIColor {
+        UIColor.Photon.Grey90
+    }
+    var rowDetailText: UIColor {
+        UIColor.Photon.Grey60
+    }
+    var disabledRowText: UIColor {
+        UIColor.Photon.Grey40
+    }
+    var separator: UIColor {
+        defaultSeparator
+    }
+    var headerBackground: UIColor {
+        defaultBackground
+    }
     // Used for table headers in Settings and Photon menus
-    var headerTextLight: UIColor { return UIColor.Photon.Grey50 }
+    var headerTextLight: UIColor {
+        UIColor.Photon.Grey50
+    }
     // Used for table headers in home panel tables
-    var headerTextDark: UIColor { return UIColor.Photon.Grey90 }
-    var rowActionAccessory: UIColor { return UIColor.Photon.Blue40 }
-    var controlTint: UIColor { return rowActionAccessory }
-    var syncText: UIColor { return defaultTextAndTint }
-    var errorText: UIColor { return UIColor.Photon.Red50 }
-    var warningText: UIColor { return UIColor.Photon.Orange50 }
-    var accessoryViewTint: UIColor { return UIColor.Photon.Grey40 }
-    var selectedBackground: UIColor { return UIColor.Custom.selectedHighlightLight }
+    var headerTextDark: UIColor {
+        UIColor.Photon.Grey90
+    }
+    var rowActionAccessory: UIColor {
+        UIColor.Photon.Blue40
+    }
+    var controlTint: UIColor {
+        rowActionAccessory
+    }
+    var syncText: UIColor {
+        defaultTextAndTint
+    }
+    var errorText: UIColor {
+        UIColor.Photon.Red50
+    }
+    var warningText: UIColor {
+        UIColor.Photon.Orange50
+    }
+    var accessoryViewTint: UIColor {
+        UIColor.Photon.Grey40
+    }
+    var selectedBackground: UIColor {
+        UIColor.Custom.selectedHighlightLight
+    }
 }
 
 class ActionMenuColor {
-    var foreground: UIColor { return defaultTextAndTint }
-    var iPhoneBackgroundBlurStyle: UIBlurEffect.Style { return UIBlurEffect.Style.light }
-    var iPhoneBackground: UIColor { return defaultBackground.withAlphaComponent(0.9) }
-    var closeButtonBackground: UIColor { return defaultBackground }
+    var foreground: UIColor {
+        defaultTextAndTint
+    }
+    var iPhoneBackgroundBlurStyle: UIBlurEffect.Style {
+        UIBlurEffect.Style.light
+    }
+    var iPhoneBackground: UIColor {
+        defaultBackground.withAlphaComponent(0.9)
+    }
+    var closeButtonBackground: UIColor {
+        defaultBackground
+    }
 }
 
 class URLBarColor {
-    var border: UIColor { return UIColor.Photon.Grey90A10 }
-    func activeBorder(_ isPrivate: Bool) -> UIColor {
-        return !isPrivate ? UIColor.Photon.Blue20A40 : UIColor.Defaults.MobilePrivatePurple
+    var border: UIColor {
+        UIColor.Photon.Grey90A10
     }
-    var tint: UIColor { return UIColor.Photon.Blue40A30 }
+    func activeBorder(_ isPrivate: Bool) -> UIColor {
+        !isPrivate ? UIColor.Photon.Blue20A40 : UIColor.Defaults.MobilePrivatePurple
+    }
+    var tint: UIColor {
+        UIColor.Photon.Blue40A30
+    }
 
     // This text selection color is used in two ways:
     // 1) <UILabel>.background = textSelectionHighlight.withAlphaComponent(textSelectionHighlightAlpha)
@@ -78,175 +120,377 @@ class URLBarColor {
         }
     }
 
-    var readerModeButtonSelected: UIColor { return UIColor.Photon.Blue40 }
-    var readerModeButtonUnselected: UIColor { return UIColor.Photon.Grey50 }
-    var pageOptionsSelected: UIColor { return readerModeButtonSelected }
-    var pageOptionsUnselected: UIColor { return UIColor.theme.browser.tint }
+    var readerModeButtonSelected: UIColor {
+        UIColor.Photon.Blue40
+    }
+    var readerModeButtonUnselected: UIColor {
+        UIColor.Photon.Grey50
+    }
+    var pageOptionsSelected: UIColor {
+        readerModeButtonSelected
+    }
+    var pageOptionsUnselected: UIColor {
+        UIColor.theme.browser.tint
+    }
 }
 
 class BrowserColor {
-    var background: UIColor { return defaultBackground }
-    var urlBarDivider: UIColor { return UIColor.Photon.Grey90A10 }
-    var tint: UIColor { return defaultTextAndTint }
+    var background: UIColor {
+        defaultBackground
+    }
+    var urlBarDivider: UIColor {
+        UIColor.Photon.Grey90A10
+    }
+    var tint: UIColor {
+        defaultTextAndTint
+    }
 }
 
 // The back/forward/refresh/menu button (bottom toolbar)
 class ToolbarButtonColor {
-    var selectedTint: UIColor { return UIColor.Photon.Blue40 }
-    var disabledTint: UIColor { return UIColor.Photon.Grey30 }
+    var selectedTint: UIColor {
+        UIColor.Photon.Blue40
+    }
+    var disabledTint: UIColor {
+        UIColor.Photon.Grey30
+    }
 }
 
 class LoadingBarColor {
     func start(_ isPrivate: Bool) -> UIColor {
-        return !isPrivate ? UIColor.Photon.Violet50 : UIColor.Photon.Magenta60A30
+        !isPrivate ? UIColor.Photon.Violet50 : UIColor.Photon.Magenta60A30
     }
     // Adds middle color for loadingBar only in public browsing
     func middle(_ isPrivate: Bool) -> UIColor? {
-        return !isPrivate ? UIColor.Photon.Pink40 : nil
+        !isPrivate ? UIColor.Photon.Pink40 : nil
     }
 
     func end(_ isPrivate: Bool) -> UIColor {
-        return !isPrivate ? UIColor.Photon.Yellow40 : UIColor.Photon.Purple60
+        !isPrivate ? UIColor.Photon.Yellow40 : UIColor.Photon.Purple60
     }
 }
 
 class TabTrayColor {
-    var tabTitleText: UIColor { return UIColor.black }
-    var tabTitleBlur: UIBlurEffect.Style { return UIBlurEffect.Style.extraLight }
-    var background: UIColor { return UIColor.Photon.LightGrey30 }
-    var screenshotBackground: UIColor { return UIColor.Photon.Grey10 }
-    var cellBackground: UIColor { return defaultBackground }
-    var toolbar: UIColor { return defaultBackground }
-    var toolbarButtonTint: UIColor { return defaultTextAndTint }
-    var privateModeLearnMore: UIColor { return UIColor.Photon.Purple60 }
-    var privateModePurple: UIColor { return UIColor.Photon.Purple60 }
-    var privateModeButtonOffTint: UIColor { return toolbarButtonTint }
-    var privateModeButtonOnTint: UIColor { return UIColor.Photon.Grey10 }
-    var cellCloseButton: UIColor { return UIColor.Photon.Grey50 }
-    var cellTitleBackground: UIColor { return UIColor.clear }
-    var faviconTint: UIColor { return UIColor.black }
-    var searchBackground: UIColor { return UIColor.Photon.Grey30 }
+    var tabTitleText: UIColor {
+        UIColor.black
+    }
+    var tabTitleBlur: UIBlurEffect.Style {
+        UIBlurEffect.Style.extraLight
+    }
+    var background: UIColor {
+        UIColor.Photon.LightGrey30
+    }
+    var screenshotBackground: UIColor {
+        UIColor.Photon.Grey10
+    }
+    var cellBackground: UIColor {
+        defaultBackground
+    }
+    var toolbar: UIColor {
+        defaultBackground
+    }
+    var toolbarButtonTint: UIColor {
+        defaultTextAndTint
+    }
+    var privateModeLearnMore: UIColor {
+        UIColor.Photon.Purple60
+    }
+    var privateModePurple: UIColor {
+        UIColor.Photon.Purple60
+    }
+    var privateModeButtonOffTint: UIColor {
+        toolbarButtonTint
+    }
+    var privateModeButtonOnTint: UIColor {
+        UIColor.Photon.Grey10
+    }
+    var cellCloseButton: UIColor {
+        UIColor.Photon.Grey50
+    }
+    var cellTitleBackground: UIColor {
+        UIColor.clear
+    }
+    var faviconTint: UIColor {
+        UIColor.black
+    }
+    var searchBackground: UIColor {
+        UIColor.Photon.Grey30
+    }
 }
 
 class EnhancedTrackingProtectionMenuColor {
-    var defaultImageTints: UIColor { return defaultTextAndTint }
-    var background: UIColor { return UIColor.Photon.Grey12 }
-    var horizontalLine: UIColor { return UIColor.Photon.Grey75A39 }
-    var sectionColor: UIColor { return .white }
-    var switchAndButtonTint: UIColor { return UIColor.Photon.Blue50 }
-    var subtextColor: UIColor { return UIColor.Photon.Grey75A60}
-    var closeButtonColor: UIColor { return UIColor.Photon.LightGrey30 }
+    var defaultImageTints: UIColor {
+        defaultTextAndTint
+    }
+    var background: UIColor {
+        UIColor.Photon.Grey12
+    }
+    var horizontalLine: UIColor {
+        UIColor.Photon.Grey75A39
+    }
+    var sectionColor: UIColor {
+        .white
+    }
+    var switchAndButtonTint: UIColor {
+        UIColor.Photon.Blue50
+    }
+    var subtextColor: UIColor {
+        UIColor.Photon.Grey75A60
+    }
+    var closeButtonColor: UIColor {
+        UIColor.Photon.LightGrey30
+    }
 }
 
 class TopTabsColor {
-    var background: UIColor { return UIColor.Photon.LightGrey20 }
-    var tabBackgroundSelected: UIColor { return UIColor.Photon.Grey10 }
-    var tabBackgroundUnselected: UIColor { return UIColor.Photon.Grey80 }
-    var tabForegroundSelected: UIColor { return UIColor.Photon.Grey90 }
-    var tabForegroundUnselected: UIColor { return UIColor.Photon.Grey40 }
-    func tabSelectedIndicatorBar(_ isPrivate: Bool) -> UIColor {
-        return !isPrivate ? UIColor.Photon.Blue40 : UIColor.Photon.Purple60
+    var background: UIColor {
+        UIColor.Photon.LightGrey20
     }
-    var buttonTint: UIColor { return UIColor.Photon.Grey80 }
-    var privateModeButtonOffTint: UIColor { return buttonTint }
-    var privateModeButtonOnTint: UIColor { return UIColor.Photon.Grey10 }
-    var closeButtonSelectedTab: UIColor { return tabBackgroundUnselected }
-    var closeButtonUnselectedTab: UIColor { return tabBackgroundSelected }
-    var separator: UIColor { return UIColor.Photon.Grey70 }
+    var tabBackgroundSelected: UIColor {
+        UIColor.Photon.Grey10
+    }
+    var tabBackgroundUnselected: UIColor {
+        UIColor.Photon.Grey80
+    }
+    var tabForegroundSelected: UIColor {
+        UIColor.Photon.Grey90
+    }
+    var tabForegroundUnselected: UIColor {
+        UIColor.Photon.Grey40
+    }
+    func tabSelectedIndicatorBar(_ isPrivate: Bool) -> UIColor {
+        !isPrivate ? UIColor.Photon.Blue40 : UIColor.Photon.Purple60
+    }
+    var buttonTint: UIColor {
+        UIColor.Photon.Grey80
+    }
+    var privateModeButtonOffTint: UIColor {
+        buttonTint
+    }
+    var privateModeButtonOnTint: UIColor {
+        UIColor.Photon.Grey10
+    }
+    var closeButtonSelectedTab: UIColor {
+        tabBackgroundUnselected
+    }
+    var closeButtonUnselectedTab: UIColor {
+        tabBackgroundSelected
+    }
+    var separator: UIColor {
+        UIColor.Photon.Grey70
+    }
 }
 
 class TextFieldColor {
-    var background: UIColor { return UIColor.Photon.LightGrey20 }
-    var backgroundInOverlay: UIColor { return UIColor.Photon.LightGrey20 }
-    var textAndTint: UIColor { return defaultTextAndTint }
-    var separator: UIColor { return .white }
+    var background: UIColor {
+        UIColor.Photon.LightGrey20
+    }
+    var backgroundInOverlay: UIColor {
+        UIColor.Photon.LightGrey20
+    }
+    var textAndTint: UIColor {
+        defaultTextAndTint
+    }
+    var separator: UIColor {
+        .white
+    }
 }
 
 class HomePanelColor {
-    var toolbarBackground: UIColor { return defaultBackground }
-    var toolbarHighlight: UIColor { return UIColor.Photon.Blue40 }
-    var toolbarTint: UIColor { return UIColor.Photon.Grey50 }
-    var topSiteHeaderTitle: UIColor { return .black }
-    var panelBackground: UIColor { return UIColor.Photon.White100 }
+    var toolbarBackground: UIColor {
+        defaultBackground
+    }
+    var toolbarHighlight: UIColor {
+        UIColor.Photon.Blue40
+    }
+    var toolbarTint: UIColor {
+        UIColor.Photon.Grey50
+    }
+    var topSiteHeaderTitle: UIColor {
+        .black
+    }
+    var panelBackground: UIColor {
+        UIColor.Photon.White100
+    }
 
-    var separator: UIColor { return defaultSeparator }
-    var border: UIColor { return UIColor.Photon.Grey60 }
-    var buttonContainerBorder: UIColor { return separator }
+    var separator: UIColor {
+        defaultSeparator
+    }
+    var border: UIColor {
+        UIColor.Photon.Grey60
+    }
+    var buttonContainerBorder: UIColor {
+        separator
+    }
 
-    var welcomeScreenText: UIColor { return UIColor.Photon.Grey50 }
-    var bookmarkIconBorder: UIColor { return UIColor.Photon.Grey30 }
-    var bookmarkFolderBackground: UIColor { return UIColor.Photon.Grey10.withAlphaComponent(0.3) }
-    var bookmarkFolderText: UIColor { return UIColor.Photon.Grey80 }
-    var bookmarkCurrentFolderText: UIColor { return UIColor.Photon.Blue40 }
-    var bookmarkBackNavCellBackground: UIColor { return UIColor.clear }
+    var welcomeScreenText: UIColor {
+        UIColor.Photon.Grey50
+    }
+    var bookmarkIconBorder: UIColor {
+        UIColor.Photon.Grey30
+    }
+    var bookmarkFolderBackground: UIColor {
+        UIColor.Photon.Grey10.withAlphaComponent(0.3)
+    }
+    var bookmarkFolderText: UIColor {
+        UIColor.Photon.Grey80
+    }
+    var bookmarkCurrentFolderText: UIColor {
+        UIColor.Photon.Blue40
+    }
+    var bookmarkBackNavCellBackground: UIColor {
+        UIColor.clear
+    }
 
-    var siteTableHeaderBorder: UIColor { return UIColor.Photon.Grey30.withAlphaComponent(0.8) }
+    var siteTableHeaderBorder: UIColor {
+        UIColor.Photon.Grey30.withAlphaComponent(0.8)
+    }
 
-    var topSiteDomain: UIColor { return UIColor.Photon.DarkGrey90 }
-    var topSitePin: UIColor { return UIColor.Photon.DarkGrey05 }
-    var topSitesBackground: UIColor { return UIColor.Photon.LightGrey10 }
+    var topSiteDomain: UIColor {
+        UIColor.Photon.DarkGrey90
+    }
+    var topSitePin: UIColor {
+        UIColor.Photon.DarkGrey05
+    }
+    var topSitesBackground: UIColor {
+        UIColor.Photon.LightGrey10
+    }
 
-    var shortcutBackground: UIColor { return .white }
-    var shortcutShadowColor: CGColor { return UIColor(red: 0.23, green: 0.22, blue: 0.27, alpha: 1.0).cgColor }
-    var shortcutShadowOpacity: Float { return 0.2 }
+    var shortcutBackground: UIColor {
+        .white
+    }
+    var shortcutShadowColor: CGColor {
+        UIColor(red: 0.23, green: 0.22, blue: 0.27, alpha: 1.0).cgColor
+    }
+    var shortcutShadowOpacity: Float {
+        0.2
+    }
 
-    var recentlySavedBookmarkCellBackground: UIColor { return .white}
+    var recentlySavedBookmarkCellBackground: UIColor {
+        .white
+    }
 
-    var recentlyVisitedCellGroupImage: UIColor { return UIColor.Photon.DarkGrey90 }
-    var recentlyVisitedCellBottomLine: UIColor { return UIColor.Photon.LightGrey40 }
+    var recentlyVisitedCellGroupImage: UIColor {
+        UIColor.Photon.DarkGrey90
+    }
+    var recentlyVisitedCellBottomLine: UIColor {
+        UIColor.Photon.LightGrey40
+    }
 
-    var activityStreamHeaderText: UIColor { return UIColor.Photon.DarkGrey90 }
-    var activityStreamHeaderButton: UIColor { return UIColor.Photon.Blue50 }
-    var activityStreamCellTitle: UIColor { return UIColor.Photon.DarkGrey90 }
-    var activityStreamCellDescription: UIColor { return UIColor.Photon.DarkGrey05 }
+    var activityStreamHeaderText: UIColor {
+        UIColor.Photon.DarkGrey90
+    }
+    var activityStreamHeaderButton: UIColor {
+        UIColor.Photon.Blue50
+    }
+    var activityStreamCellTitle: UIColor {
+        UIColor.Photon.DarkGrey90
+    }
+    var activityStreamCellDescription: UIColor {
+        UIColor.Photon.DarkGrey05
+    }
 
-    var readingListActive: UIColor { return defaultTextAndTint }
-    var readingListDimmed: UIColor { return UIColor.Photon.Grey40 }
+    var readingListActive: UIColor {
+        defaultTextAndTint
+    }
+    var readingListDimmed: UIColor {
+        UIColor.Photon.Grey40
+    }
 
-    var downloadedFileIcon: UIColor { return UIColor.Photon.Grey60 }
+    var downloadedFileIcon: UIColor {
+        UIColor.Photon.Grey60
+    }
 
-    var historyHeaderIconsBackground: UIColor { return UIColor.Photon.White100 }
+    var historyHeaderIconsBackground: UIColor {
+        UIColor.Photon.White100
+    }
 
-    var searchSuggestionPillBackground: UIColor { return UIColor.Photon.White100 }
-    var searchSuggestionPillForeground: UIColor { return UIColor.Photon.Blue40 }
+    var searchSuggestionPillBackground: UIColor {
+        UIColor.Photon.White100
+    }
+    var searchSuggestionPillForeground: UIColor {
+        UIColor.Photon.Blue40
+    }
 
-    var customizeHomepageButtonBackground: UIColor { return UIColor.Photon.LightGrey30 }
-    var customizeHomepageButtonText: UIColor { return UIColor.Photon.DarkGrey90 }
+    var customizeHomepageButtonBackground: UIColor {
+        UIColor.Photon.LightGrey30
+    }
+    var customizeHomepageButtonText: UIColor {
+        UIColor.Photon.DarkGrey90
+    }
 
-    var sponsored: UIColor { return UIColor.Photon.DarkGrey05 }
+    var sponsored: UIColor {
+        UIColor.Photon.DarkGrey05
+    }
 }
 
 class SnackBarColor {
-    var highlight: UIColor { return UIColor.Defaults.iOSTextHighlightBlue.withAlphaComponent(0.9) }
-    var highlightText: UIColor { return UIColor.Photon.Blue40 }
-    var border: UIColor { return UIColor.Photon.Grey30 }
-    var title: UIColor { return UIColor.Photon.Blue40 }
+    var highlight: UIColor {
+        UIColor.Defaults.iOSTextHighlightBlue.withAlphaComponent(0.9)
+    }
+    var highlightText: UIColor {
+        UIColor.Photon.Blue40
+    }
+    var border: UIColor {
+        UIColor.Photon.Grey30
+    }
+    var title: UIColor {
+        UIColor.Photon.Blue40
+    }
 }
 
 class GeneralColor {
-    var faviconBackground: UIColor { return UIColor.clear }
-    var passcodeDot: UIColor { return UIColor.Photon.Grey60 }
-    var highlightBlue: UIColor { return UIColor.Photon.Blue40 }
-    var destructiveRed: UIColor { return UIColor.Photon.Red50 }
-    var separator: UIColor { return defaultSeparator }
-    var settingsTextPlaceholder: UIColor { return UIColor.Photon.Grey40 }
-    var controlTint: UIColor { return UIColor.Photon.Blue40 }
-    var switchToggle: UIColor { return UIColor.Photon.Grey90A40 }
+    var faviconBackground: UIColor {
+        UIColor.clear
+    }
+    var passcodeDot: UIColor {
+        UIColor.Photon.Grey60
+    }
+    var highlightBlue: UIColor {
+        UIColor.Photon.Blue40
+    }
+    var destructiveRed: UIColor {
+        UIColor.Photon.Red50
+    }
+    var separator: UIColor {
+        defaultSeparator
+    }
+    var settingsTextPlaceholder: UIColor {
+        UIColor.Photon.Grey40
+    }
+    var controlTint: UIColor {
+        UIColor.Photon.Blue40
+    }
+    var switchToggle: UIColor {
+        UIColor.Photon.Grey90A40
+    }
 }
 
 class HomeTabBannerColor {
-    var backgroundColor: UIColor { return UIColor.Photon.Grey30 }
-    var textColor: UIColor { return UIColor.black }
-    var closeButtonBackground: UIColor { return UIColor.Photon.Grey20 }
-    var closeButton: UIColor { return UIColor.Photon.Grey80 }
+    var backgroundColor: UIColor {
+        UIColor.Photon.Grey30
+    }
+    var textColor: UIColor {
+        UIColor.black
+    }
+    var closeButtonBackground: UIColor {
+        UIColor.Photon.Grey20
+    }
+    var closeButton: UIColor {
+        UIColor.Photon.Grey80
+    }
 }
 
 class OnboardingColor {
-    var backgroundColor: UIColor { return UIColor.white }
+    var backgroundColor: UIColor {
+        UIColor.white
+    }
 }
 
 class RemoteTabTrayColor {
-    var background: UIColor { return UIColor.white }
+    var background: UIColor {
+        UIColor.white
+    }
 }
 
 protocol LegacyTheme {
@@ -271,22 +515,58 @@ protocol LegacyTheme {
 }
 
 class NormalTheme: LegacyTheme {
-    var name: String { return BuiltinThemeName.normal.rawValue }
-    var tableView: TableViewColor { return TableViewColor() }
-    var urlbar: URLBarColor { return URLBarColor() }
-    var browser: BrowserColor { return BrowserColor() }
-    var toolbarButton: ToolbarButtonColor { return ToolbarButtonColor() }
-    var loadingBar: LoadingBarColor { return LoadingBarColor() }
-    var tabTray: TabTrayColor { return TabTrayColor() }
-    var topTabs: TopTabsColor { return TopTabsColor() }
-    var etpMenu: EnhancedTrackingProtectionMenuColor { return EnhancedTrackingProtectionMenuColor() }
-    var textField: TextFieldColor { return TextFieldColor() }
-    var homePanel: HomePanelColor { return HomePanelColor() }
-    var snackbar: SnackBarColor { return SnackBarColor() }
-    var general: GeneralColor { return GeneralColor() }
-    var actionMenu: ActionMenuColor { return ActionMenuColor() }
-    var switchToggleTheme: GeneralColor { return GeneralColor() }
-    var homeTabBanner: HomeTabBannerColor { return HomeTabBannerColor() }
-    var onboarding: OnboardingColor { return OnboardingColor() }
-    var remotePanel: RemoteTabTrayColor { return RemoteTabTrayColor() }
+    var name: String {
+        BuiltinThemeName.normal.rawValue
+    }
+    var tableView: TableViewColor {
+        TableViewColor()
+    }
+    var urlbar: URLBarColor {
+        URLBarColor()
+    }
+    var browser: BrowserColor {
+        BrowserColor()
+    }
+    var toolbarButton: ToolbarButtonColor {
+        ToolbarButtonColor()
+    }
+    var loadingBar: LoadingBarColor {
+        LoadingBarColor()
+    }
+    var tabTray: TabTrayColor {
+        TabTrayColor()
+    }
+    var topTabs: TopTabsColor {
+        TopTabsColor()
+    }
+    var etpMenu: EnhancedTrackingProtectionMenuColor {
+        EnhancedTrackingProtectionMenuColor()
+    }
+    var textField: TextFieldColor {
+        TextFieldColor()
+    }
+    var homePanel: HomePanelColor {
+        HomePanelColor()
+    }
+    var snackbar: SnackBarColor {
+        SnackBarColor()
+    }
+    var general: GeneralColor {
+        GeneralColor()
+    }
+    var actionMenu: ActionMenuColor {
+        ActionMenuColor()
+    }
+    var switchToggleTheme: GeneralColor {
+        GeneralColor()
+    }
+    var homeTabBanner: HomeTabBannerColor {
+        HomeTabBannerColor()
+    }
+    var onboarding: OnboardingColor {
+        OnboardingColor()
+    }
+    var remotePanel: RemoteTabTrayColor {
+        RemoteTabTrayColor()
+    }
 }

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyThemeManager.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyThemeManager.swift
@@ -21,7 +21,7 @@ class LegacyThemeManager {
     }
 
     var currentName: BuiltinThemeName {
-        return BuiltinThemeName(rawValue: LegacyThemeManager.instance.current.name) ?? .normal
+        BuiltinThemeName(rawValue: LegacyThemeManager.instance.current.name) ?? .normal
     }
 
     var automaticBrightnessValue: Float = UserDefaults.standard.float(forKey: LegacyThemeManagerPrefs.automaticSliderValue.rawValue) {
@@ -53,7 +53,7 @@ class LegacyThemeManager {
 
     // UIViewControllers / UINavigationControllers need to have `preferredStatusBarStyle` and call this.
     var statusBarStyle: UIStatusBarStyle {
-        return .default
+        .default
     }
 
     var userInterfaceStyle: UIUserInterfaceStyle {

--- a/Client/Frontend/Theme/ThemeManager.swift
+++ b/Client/Frontend/Theme/ThemeManager.swift
@@ -10,7 +10,9 @@ import Shared
 protocol Themeable { }
 
 extension Themeable {
-    var themeSystem: ThemeManager { return ThemeManager.shared }
+    var themeSystem: ThemeManager {
+        ThemeManager.shared
+    }
 }
 
 /// The `ThemeManager` will be responsible for providing the theme throughout the app
@@ -104,6 +106,6 @@ final class ThemeManager {
     /// in the future, this empty function is merely serving as a placeholder.
     private func verify(customTheme: CustomTheme) -> Theme? {
 
-        return nil
+        nil
     }
 }

--- a/Client/Frontend/Toolbar+URLBar/ReaderModeButton.swift
+++ b/Client/Frontend/Toolbar+URLBar/ReaderModeButton.swift
@@ -48,7 +48,7 @@ class ReaderModeButton: UIButton {
 
     var readerModeState: ReaderModeState {
         get {
-            return savedReaderModeState
+            savedReaderModeState
         }
         set (newReaderModeState) {
             savedReaderModeState = newReaderModeState

--- a/Client/Frontend/Toolbar+URLBar/StatefulButton.swift
+++ b/Client/Frontend/Toolbar+URLBar/StatefulButton.swift
@@ -32,7 +32,7 @@ class StatefulButton: UIButton {
 
     var reloadButtonState: ReloadButtonState {
         get {
-            return savedReloadButtonState
+            savedReloadButtonState
         }
         set (newReloadButtonState) {
             savedReloadButtonState = newReloadButtonState

--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -52,7 +52,7 @@ class TabLocationView: UIView {
 
     var readerModeState: ReaderModeState {
         get {
-            return readerModeButton.readerModeState
+            readerModeButton.readerModeState
         }
         set (newReaderModeState) {
             guard newReaderModeState != self.readerModeButton.readerModeState else { return }
@@ -61,7 +61,7 @@ class TabLocationView: UIView {
     }
 
     lazy var placeholder: NSAttributedString = {
-        return NSAttributedString(string: .TabLocationURLPlaceholder, attributes: [NSAttributedString.Key.foregroundColor: UIColor.Photon.Grey50])
+        NSAttributedString(string: .TabLocationURLPlaceholder, attributes: [NSAttributedString.Key.foregroundColor: UIColor.Photon.Grey50])
     }()
 
     lazy var urlTextField: URLTextField = .build { urlTextField in
@@ -175,7 +175,9 @@ class TabLocationView: UIView {
 
     override var accessibilityElements: [Any]? {
         get {
-            return _accessibilityElements.filter { !$0.isHidden }
+            _accessibilityElements.filter {
+                !$0.isHidden
+            }
         }
         set {
             super.accessibilityElements = newValue
@@ -225,7 +227,7 @@ class TabLocationView: UIView {
     }
 
     @objc func readerModeCustomAction() -> Bool {
-        return delegate?.tabLocationViewDidLongPressReaderMode(self) ?? false
+        delegate?.tabLocationViewDidLongPressReaderMode(self) ?? false
     }
 
     private func updateTextWithURL() {
@@ -269,12 +271,12 @@ private extension TabLocationView {
 extension TabLocationView: UIGestureRecognizerDelegate {
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         // When long pressing a button make sure the textfield's long press gesture is not triggered
-        return !(otherGestureRecognizer.view is UIButton)
+        !(otherGestureRecognizer.view is UIButton)
     }
 
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         // If the longPressRecognizer is active, fail the tap recognizer to avoid conflicts.
-        return gestureRecognizer == longPressRecognizer && otherGestureRecognizer == tapRecognizer
+        gestureRecognizer == longPressRecognizer && otherGestureRecognizer == tapRecognizer
     }
 }
 

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -197,7 +197,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
 
     var currentURL: URL? {
         get {
-            return locationView.url as URL?
+            locationView.url as URL?
         }
 
         set(newURL) {
@@ -447,7 +447,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
     }
 
     override func becomeFirstResponder() -> Bool {
-        return self.locationTextField?.becomeFirstResponder() ?? false
+        self.locationTextField?.becomeFirstResponder() ?? false
     }
 
     func removeLocationTextField() {
@@ -723,7 +723,7 @@ extension URLBarView: TabToolbarProtocol {
 
 extension URLBarView: TabLocationViewDelegate {
     func tabLocationViewDidLongPressReaderMode(_ tabLocationView: TabLocationView) -> Bool {
-        return delegate?.urlBarDidLongPressReaderMode(self) ?? false
+        delegate?.urlBarDidLongPressReaderMode(self) ?? false
     }
 
     func tabLocationViewDidLongPressReload(_ tabLocationView: TabLocationView) {
@@ -769,7 +769,7 @@ extension URLBarView: TabLocationViewDelegate {
     }
 
     func tabLocationViewLocationAccessibilityActions(_ tabLocationView: TabLocationView) -> [UIAccessibilityCustomAction]? {
-        return delegate?.urlBarLocationAccessibilityActions(self)
+        delegate?.urlBarLocationAccessibilityActions(self)
     }
 
     func tabLocationViewDidBeginDragInteraction(_ tabLocationView: TabLocationView) {
@@ -816,12 +816,16 @@ extension URLBarView: AutocompleteTextFieldDelegate {
 extension URLBarView {
 
     @objc dynamic var cancelTintColor: UIColor? {
-        get { return cancelButton.tintColor }
+        get {
+            cancelButton.tintColor
+        }
         set { return cancelButton.tintColor = newValue }
     }
 
     @objc dynamic var showQRButtonTintColor: UIColor? {
-        get { return showQRScannerButton.tintColor }
+        get {
+            showQRScannerButton.tintColor
+        }
         set { return showQRScannerButton.tintColor = newValue }
     }
 

--- a/Client/Frontend/Toolbar+URLBar/URLTextField.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLTextField.swift
@@ -10,7 +10,7 @@ class URLTextField: UITextField {
 
     override var accessibilityCustomActions: [UIAccessibilityCustomAction]? {
         get {
-            return accessibilityActionsSource?.accessibilityCustomActionsForView(self)
+            accessibilityActionsSource?.accessibilityCustomActionsForView(self)
         }
         set {
             super.accessibilityCustomActions = newValue
@@ -18,10 +18,10 @@ class URLTextField: UITextField {
     }
 
     override var canBecomeFirstResponder: Bool {
-        return false
+        false
     }
 
     override func textRect(forBounds bounds: CGRect) -> CGRect {
-        return bounds.insetBy(dx: TabLocationViewUX.Spacing, dy: 0)
+        bounds.insetBy(dx: TabLocationViewUX.Spacing, dy: 0)
     }
 }

--- a/Client/Frontend/UIConstants+BottomInset.swift
+++ b/Client/Frontend/UIConstants+BottomInset.swift
@@ -7,7 +7,7 @@ import Foundation
 extension UIConstants {
     static var BottomToolbarHeight: CGFloat {
         get {
-            return ToolbarHeight + BottomInset
+            ToolbarHeight + BottomInset
         }
     }
 

--- a/Client/Frontend/Update/UpdateViewController.swift
+++ b/Client/Frontend/Update/UpdateViewController.swift
@@ -72,10 +72,10 @@ class UpdateViewController: UIViewController {
     // Private vars
     private var fxTextThemeColour: UIColor {
         // For dark theme we want to show light colours and for light we want to show dark colours
-        return UpdateViewController.theme == .dark ? .white : .black
+        UpdateViewController.theme == .dark ? .white : .black
     }
     private var fxBackgroundThemeColour: UIColor {
-        return UpdateViewController.theme == .dark ? .black : .white
+        UpdateViewController.theme == .dark ? .black : .white
     }
     private lazy var updatesTableView: UITableView = {
         let tableView = UITableView(frame: CGRect.zero, style: .grouped)
@@ -217,15 +217,15 @@ class UpdateViewController: UIViewController {
 
 extension UpdateViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return CGFloat.leastNormalMagnitude
+        CGFloat.leastNormalMagnitude
     }
 
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return CGFloat.leastNormalMagnitude
+        CGFloat.leastNormalMagnitude
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.updates.count
+        viewModel.updates.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -28,7 +28,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     private let copyShortcutKey = "c"
 
     var isSelectionActive: Bool {
-        return autocompleteTextLabel != nil
+        autocompleteTextLabel != nil
     }
 
     // This variable is a solution to get the right behavior for refocusing
@@ -51,7 +51,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
 
     override var accessibilityValue: String? {
         get {
-            return (self.text ?? "") + (self.autocompleteTextLabel?.text ?? "")
+            (self.text ?? "") + (self.autocompleteTextLabel?.text ?? "")
         }
         set(value) {
             super.accessibilityValue = value
@@ -153,7 +153,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     }
 
     fileprivate func normalizeString(_ string: String) -> String {
-        return string.lowercased().stringByTrimmingLeadingCharactersInSet(CharacterSet.whitespaces)
+        string.lowercased().stringByTrimmingLeadingCharactersInSet(CharacterSet.whitespaces)
     }
 
     /// Commits the completion by setting the text and removing the highlight.
@@ -236,7 +236,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     }
 
     override func caretRect(for position: UITextPosition) -> CGRect {
-        return hideCursor ? CGRect.zero : super.caretRect(for: position)
+        hideCursor ? CGRect.zero : super.caretRect(for: position)
     }
 
     private func createAutocompleteLabelWith(_ autocompleteText: NSAttributedString) -> UILabel {

--- a/Client/Frontend/Widgets/ChevronView.swift
+++ b/Client/Frontend/Widgets/ChevronView.swift
@@ -85,27 +85,27 @@ class ChevronView: UIView {
     }
 
     fileprivate func drawUpChevronAt(_ origin: CGPoint, strokeLength: CGFloat) -> UIBezierPath {
-        return drawChevron(CGPoint(x: origin.x-strokeLength, y: origin.y+strokeLength),
-            head: CGPoint(x: origin.x, y: origin.y),
-            rightTip: CGPoint(x: origin.x+strokeLength, y: origin.y+strokeLength))
+        drawChevron(CGPoint(x: origin.x - strokeLength, y: origin.y + strokeLength),
+                head: CGPoint(x: origin.x, y: origin.y),
+                rightTip: CGPoint(x: origin.x + strokeLength, y: origin.y + strokeLength))
     }
 
     fileprivate func drawDownChevronAt(_ origin: CGPoint, strokeLength: CGFloat) -> UIBezierPath {
-        return drawChevron(CGPoint(x: origin.x-strokeLength, y: origin.y-strokeLength),
-            head: CGPoint(x: origin.x, y: origin.y),
-            rightTip: CGPoint(x: origin.x+strokeLength, y: origin.y-strokeLength))
+        drawChevron(CGPoint(x: origin.x - strokeLength, y: origin.y - strokeLength),
+                head: CGPoint(x: origin.x, y: origin.y),
+                rightTip: CGPoint(x: origin.x + strokeLength, y: origin.y - strokeLength))
     }
 
     fileprivate func drawLeftChevronAt(_ origin: CGPoint, strokeLength: CGFloat) -> UIBezierPath {
-        return drawChevron(CGPoint(x: origin.x+strokeLength, y: origin.y-strokeLength),
-            head: CGPoint(x: origin.x, y: origin.y),
-            rightTip: CGPoint(x: origin.x+strokeLength, y: origin.y+strokeLength))
+        drawChevron(CGPoint(x: origin.x + strokeLength, y: origin.y - strokeLength),
+                head: CGPoint(x: origin.x, y: origin.y),
+                rightTip: CGPoint(x: origin.x + strokeLength, y: origin.y + strokeLength))
     }
 
     fileprivate func drawRightChevronAt(_ origin: CGPoint, strokeLength: CGFloat) -> UIBezierPath {
-        return drawChevron(CGPoint(x: origin.x-strokeLength, y: origin.y+strokeLength),
-            head: CGPoint(x: origin.x, y: origin.y),
-            rightTip: CGPoint(x: origin.x-strokeLength, y: origin.y-strokeLength))
+        drawChevron(CGPoint(x: origin.x - strokeLength, y: origin.y + strokeLength),
+                head: CGPoint(x: origin.x, y: origin.y),
+                rightTip: CGPoint(x: origin.x - strokeLength, y: origin.y - strokeLength))
     }
 
     fileprivate func drawChevron(_ leftTip: CGPoint, head: CGPoint, rightTip: CGPoint) -> UIBezierPath {

--- a/Client/Frontend/Widgets/DrawerViewController.swift
+++ b/Client/Frontend/Widgets/DrawerViewController.swift
@@ -83,8 +83,8 @@ public class DrawerViewController: UIViewController, NotificationThemeable {
     }
 
     fileprivate var showingPadLayout: Bool {
-        return traitCollection.userInterfaceIdiom == .pad &&
-            traitCollection.horizontalSizeClass == .regular
+        traitCollection.userInterfaceIdiom == .pad &&
+                traitCollection.horizontalSizeClass == .regular
     }
 
     public init(childViewController: UIViewController) {

--- a/Client/Frontend/Widgets/GradientProgressBar.swift
+++ b/Client/Frontend/Widgets/GradientProgressBar.swift
@@ -179,6 +179,6 @@ open class GradientProgressBar: UIProgressView {
 
 extension CGRect {
     func updateWidth(byPercentage percentage: CGFloat) -> CGRect {
-        return CGRect(x: origin.x, y: origin.y, width: size.width * percentage, height: size.height)
+        CGRect(x: origin.x, y: origin.y, width: size.width * percentage, height: size.height)
     }
 }

--- a/Client/Frontend/Widgets/OneLineCellAndFooter.swift
+++ b/Client/Frontend/Widgets/OneLineCellAndFooter.swift
@@ -78,10 +78,10 @@ class OneLineTableViewCell: UITableViewCell, NotificationThemeable, ReusableCell
     var customization: OneLineTableViewCustomization = .regular
 
     private var defaultSeparatorInset: UIEdgeInsets {
-        return UIEdgeInsets(top: 0,
-                            left: OneLineCellUX.ImageSize + 2 * OneLineCellUX.BorderViewMargin,
-                            bottom: 0,
-                            right: 0)
+        UIEdgeInsets(top: 0,
+                left: OneLineCellUX.ImageSize + 2 * OneLineCellUX.BorderViewMargin,
+                bottom: 0,
+                right: 0)
     }
 
     func initialViewSetup() {

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -357,7 +357,10 @@ class PhotonActionSheet: UIViewController {
     }
 
     private func getViewsHeightSum(views: [UIView]) -> CGFloat {
-        return views.map { $0.frame.height }.reduce(0, +)
+        views.map {
+                    $0.frame.height
+                }
+                .reduce(0, +)
     }
 }
 
@@ -375,15 +378,15 @@ extension PhotonActionSheet: UITableViewDataSource, UITableViewDelegate {
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        return viewModel.actions.count
+        viewModel.actions.count
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.actions[section].count
+        viewModel.actions[section].count
     }
 
     func tableView(_ tableView: UITableView, hasFullWidthSeparatorForRowAtIndexPath indexPath: IndexPath) -> Bool {
-        return false
+        false
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -405,19 +408,19 @@ extension PhotonActionSheet: UITableViewDataSource, UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return 0
+        0
     }
 
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        return UIView()
+        UIView()
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return viewModel.getHeaderHeightForSection(section: section)
+        viewModel.getHeaderHeightForSection(section: section)
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        return viewModel.getViewHeader(tableView: tableView, section: section)
+        viewModel.getViewHeader(tableView: tableView, section: section)
     }
 }
 

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetAnimator.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetAnimator.swift
@@ -25,7 +25,7 @@ class PhotonActionSheetAnimator: NSObject, UIViewControllerAnimatedTransitioning
     }
 
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
-        return animationDuration
+        animationDuration
     }
 }
 

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetViewModel.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetViewModel.swift
@@ -17,7 +17,7 @@ class PhotonActionSheetViewModel {
     var tintColor = UIColor.theme.actionMenu.foreground
 
     var presentationStyle: PresentationStyle {
-        return modalStyle.getPhotonPresentationStyle()
+        modalStyle.getPhotonPresentationStyle()
     }
 
     private enum SheetStyle {
@@ -193,7 +193,7 @@ class PhotonActionSheetViewModel {
 
     // We use small size for iPhone and on iPad in multitasking mode
     static func isSmallSizeForTraitCollection(trait: UITraitCollection) -> Bool {
-        return trait.verticalSizeClass == .compact || trait.horizontalSizeClass == .compact
+        trait.verticalSizeClass == .compact || trait.horizontalSizeClass == .compact
     }
 
     func popOverWidthForTraitCollection(trait: UITraitCollection) -> CGFloat {

--- a/Client/Frontend/Widgets/PhotonActionSheet/SingleActionViewModel.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/SingleActionViewModel.swift
@@ -94,7 +94,7 @@ class SingleActionViewModel {
     // Current title looks at the layout direction
     // Horizontal uses the default title, vertical uses the alternate title
     var currentTitle: String {
-        return multipleItemsSetup.axis == .horizontal ? title : alternateTitle ?? title
+        multipleItemsSetup.axis == .horizontal ? title : alternateTitle ?? title
     }
 
     // The layout changes when there's multiple items in a row,
@@ -107,6 +107,6 @@ class SingleActionViewModel {
 
     // MARK: Conveniance
     var items: PhotonRowActions {
-        return PhotonRowActions(self)
+        PhotonRowActions(self)
     }
 }

--- a/Client/Frontend/Widgets/SearchInputView.swift
+++ b/Client/Frontend/Widgets/SearchInputView.swift
@@ -50,7 +50,7 @@ class SearchInputView: UIView, NotificationThemeable {
     }()
 
     lazy var searchIcon: UIImageView = {
-        return UIImageView(image: UIImage(named: "quickSearch"))
+        UIImageView(image: UIImage(named: "quickSearch"))
     }()
 
     fileprivate lazy var closeButton: UIButton = {

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -40,7 +40,7 @@ class SiteTableViewHeader: UITableViewHeaderFooterView, NotificationThemeable, R
     fileprivate let bordersHelper = ThemedHeaderFooterViewBordersHelper()
 
     override var textLabel: UILabel? {
-        return titleLabel
+        titleLabel
     }
 
     override init(reuseIdentifier: String?) {
@@ -194,7 +194,7 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return data.count
+        data.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -207,7 +207,7 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        return tableView.dequeueReusableHeaderFooterView(withIdentifier: HeaderIdentifier)
+        tableView.dequeueReusableHeaderFooterView(withIdentifier: HeaderIdentifier)
     }
 
     func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
@@ -218,15 +218,15 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return SiteTableViewControllerUX.HeaderHeight
+        SiteTableViewControllerUX.HeaderHeight
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return UITableView.automaticDimension
+        UITableView.automaticDimension
     }
 
     func tableView(_ tableView: UITableView, hasFullWidthSeparatorForRowAtIndexPath indexPath: IndexPath) -> Bool {
-        return false
+        false
     }
 
     func applyTheme() {

--- a/Client/Frontend/Widgets/SnackBar.swift
+++ b/Client/Frontend/Widgets/SnackBar.swift
@@ -165,7 +165,7 @@ class SnackBar: UIView {
      * - returns: true if the snackbar should be kept alive
      */
     func shouldPersist(_ tab: Tab) -> Bool {
-        return true
+        true
     }
 
     override func updateConstraints() {
@@ -184,7 +184,7 @@ class SnackBar: UIView {
     }
 
     var showing: Bool {
-        return alpha != 0 && self.superview != nil
+        alpha != 0 && self.superview != nil
     }
 
     func show() {

--- a/Client/Helpers/DynamicFontHelper.swift
+++ b/Client/Helpers/DynamicFontHelper.swift
@@ -43,46 +43,46 @@ class DynamicFontHelper: NSObject {
      */
     fileprivate var deviceFontSize: CGFloat
     var DeviceFontSize: CGFloat {
-        return deviceFontSize
+        deviceFontSize
     }
     var DeviceFont: UIFont {
-        return UIFont.systemFont(ofSize: deviceFontSize, weight: UIFont.Weight.medium)
+        UIFont.systemFont(ofSize: deviceFontSize, weight: UIFont.Weight.medium)
     }
     var DeviceFontLight: UIFont {
-        return UIFont.systemFont(ofSize: deviceFontSize, weight: UIFont.Weight.light)
+        UIFont.systemFont(ofSize: deviceFontSize, weight: UIFont.Weight.light)
     }
     var DeviceFontSmall: UIFont {
-        return UIFont.systemFont(ofSize: deviceFontSize - 1, weight: UIFont.Weight.medium)
+        UIFont.systemFont(ofSize: deviceFontSize - 1, weight: UIFont.Weight.medium)
     }
     var DeviceFontSmallLight: UIFont {
-        return UIFont.systemFont(ofSize: deviceFontSize - 1, weight: UIFont.Weight.light)
+        UIFont.systemFont(ofSize: deviceFontSize - 1, weight: UIFont.Weight.light)
     }
     var DeviceFontSmallHistoryPanel: UIFont {
-        return UIFont.systemFont(ofSize: deviceFontSize - 3, weight: UIFont.Weight.light)
+        UIFont.systemFont(ofSize: deviceFontSize - 3, weight: UIFont.Weight.light)
     }
     var DeviceFontHistoryPanel: UIFont {
-        return UIFont.systemFont(ofSize: deviceFontSize)
+        UIFont.systemFont(ofSize: deviceFontSize)
     }
     var DeviceFontSmallBold: UIFont {
-        return UIFont.boldSystemFont(ofSize: deviceFontSize - 1)
+        UIFont.boldSystemFont(ofSize: deviceFontSize - 1)
     }
     var DeviceFontLarge: UIFont {
-        return UIFont.systemFont(ofSize: deviceFontSize + 3)
+        UIFont.systemFont(ofSize: deviceFontSize + 3)
     }
     var DeviceFontExtraLarge: UIFont {
-        return UIFont.systemFont(ofSize: deviceFontSize + 4)
+        UIFont.systemFont(ofSize: deviceFontSize + 4)
     }
     var DeviceFontMedium: UIFont {
-        return UIFont.systemFont(ofSize: deviceFontSize + 1)
+        UIFont.systemFont(ofSize: deviceFontSize + 1)
     }
     var DeviceFontLargeBold: UIFont {
-        return UIFont.boldSystemFont(ofSize: deviceFontSize + 2)
+        UIFont.boldSystemFont(ofSize: deviceFontSize + 2)
     }
     var DeviceFontMediumBold: UIFont {
-        return UIFont.boldSystemFont(ofSize: deviceFontSize + 1)
+        UIFont.boldSystemFont(ofSize: deviceFontSize + 1)
     }
     var DeviceFontExtraLargeBold: UIFont {
-        return UIFont.boldSystemFont(ofSize: deviceFontSize + 4)
+        UIFont.boldSystemFont(ofSize: deviceFontSize + 4)
     }
 
     /*
@@ -140,13 +140,13 @@ class DynamicFontHelper: NSObject {
      */
     fileprivate var defaultSmallFontSize: CGFloat
     var DefaultSmallFontSize: CGFloat {
-        return defaultSmallFontSize
+        defaultSmallFontSize
     }
     var DefaultSmallFont: UIFont {
-        return UIFont.systemFont(ofSize: defaultSmallFontSize, weight: UIFont.Weight.regular)
+        UIFont.systemFont(ofSize: defaultSmallFontSize, weight: UIFont.Weight.regular)
     }
     var DefaultSmallFontBold: UIFont {
-        return UIFont.boldSystemFont(ofSize: defaultSmallFontSize)
+        UIFont.boldSystemFont(ofSize: defaultSmallFontSize)
     }
 
     /**
@@ -154,13 +154,13 @@ class DynamicFontHelper: NSObject {
      */
     fileprivate var defaultMediumFontSize: CGFloat
     var DefaultMediumFontSize: CGFloat {
-        return defaultMediumFontSize
+        defaultMediumFontSize
     }
     var DefaultMediumFont: UIFont {
-        return UIFont.systemFont(ofSize: defaultMediumFontSize, weight: UIFont.Weight.regular)
+        UIFont.systemFont(ofSize: defaultMediumFontSize, weight: UIFont.Weight.regular)
     }
     var DefaultMediumBoldFont: UIFont {
-        return UIFont.boldSystemFont(ofSize: defaultMediumFontSize)
+        UIFont.boldSystemFont(ofSize: defaultMediumFontSize)
     }
 
     /**
@@ -168,33 +168,33 @@ class DynamicFontHelper: NSObject {
      */
     fileprivate var defaultStandardFontSize: CGFloat
     var DefaultStandardFontSize: CGFloat {
-        return defaultStandardFontSize
+        defaultStandardFontSize
     }
     var DefaultStandardFont: UIFont {
-        return UIFont.systemFont(ofSize: defaultStandardFontSize, weight: UIFont.Weight.regular)
+        UIFont.systemFont(ofSize: defaultStandardFontSize, weight: UIFont.Weight.regular)
     }
     var DefaultStandardFontBold: UIFont {
-        return UIFont.boldSystemFont(ofSize: defaultStandardFontSize)
+        UIFont.boldSystemFont(ofSize: defaultStandardFontSize)
     }
 
     /**
      * Reader mode
      */
     var ReaderStandardFontSize: CGFloat {
-        return defaultStandardFontSize - 2
+        defaultStandardFontSize - 2
     }
     var ReaderBigFontSize: CGFloat {
-        return defaultStandardFontSize + 5
+        defaultStandardFontSize + 5
     }
 
     /**
      * Intro mode
      */
     var IntroStandardFontSize: CGFloat {
-        return min(defaultStandardFontSize - 1, 16)
+        min(defaultStandardFontSize - 1, 16)
     }
     var IntroBigFontSize: CGFloat {
-        return min(defaultStandardFontSize + 1, 18)
+        min(defaultStandardFontSize + 1, 18)
     }
 
     func refreshFonts() {
@@ -254,6 +254,6 @@ class DynamicFontHelper: NSObject {
     ///              https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/typography/
     /// - Returns: The UIFont with the specified bold font size and style
     func preferredBoldFont(withTextStyle textStyle: UIFont.TextStyle, maxSize: CGFloat? = nil) -> UIFont {
-        return preferredFont(withTextStyle: textStyle, weight: .bold, maxSize: maxSize)
+        preferredFont(withTextStyle: textStyle, weight: .bold, maxSize: maxSize)
     }
 }

--- a/Client/Helpers/TabEventHandler.swift
+++ b/Client/Helpers/TabEventHandler.swift
@@ -147,13 +147,13 @@ enum TabEvent {
 ////////////////////////////////////////////////////////////////////////////////////////
 extension TabEventLabel {
     var name: Notification.Name {
-        return Notification.Name(self.rawValue)
+        Notification.Name(self.rawValue)
     }
 }
 
 extension TabEvent {
     func notification(for tab: Tab) -> Notification {
-        return Notification(name: label.name, object: tab, userInfo: ["payload": self])
+        Notification(name: label.name, object: tab, userInfo: ["payload": self])
     }
 
     /// Use this method to post notifications to any concerned listeners.

--- a/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -110,7 +110,7 @@ final class NimbusFeatureFlagLayer {
     }
 
     private func checkNimbusForJumpBackInSyncedTabFeature(using nimbus: FxNimbus) -> Bool {
-        return nimbus.features.homescreenFeature.value().jumpBackInSyncedTab
+        nimbus.features.homescreenFeature.value().jumpBackInSyncedTab
     }
 
     private func checkNimbusForWallpapersFeature(using nimbus: FxNimbus) -> Bool {
@@ -119,7 +119,7 @@ final class NimbusFeatureFlagLayer {
     }
 
     private func checkNimbusForPocketSponsoredStoriesFeature(using nimbus: FxNimbus) -> Bool {
-        return nimbus.features.homescreenFeature.value().pocketSponsoredStories
+        nimbus.features.homescreenFeature.value().pocketSponsoredStories
     }
 
     private func checkSponsoredTilesFeature(from nimbus: FxNimbus) -> Bool {

--- a/Client/Nimbus/NimbusManager.swift
+++ b/Client/Nimbus/NimbusManager.swift
@@ -8,7 +8,7 @@ protocol HasNimbusFeatureFlags { }
 
 extension HasNimbusFeatureFlags {
     var nimbusFlags: NimbusFeatureFlagLayer {
-        return NimbusManager.shared.featureFlagLayer
+        NimbusManager.shared.featureFlagLayer
     }
 }
 
@@ -16,7 +16,7 @@ protocol HasNimbusSearchBar { }
 
 extension HasNimbusSearchBar {
     var nimbusSearchBar: NimbusSearchBarLayer {
-        return NimbusManager.shared.bottomSearchBarLayer
+        NimbusManager.shared.bottomSearchBarLayer
     }
 }
 
@@ -24,7 +24,7 @@ protocol HasNimbusSponsoredTiles { }
 
 extension HasNimbusSponsoredTiles {
     var nimbusSponoredTiles: NimbusSponsoredTileLayer {
-        return NimbusManager.shared.sponsoredTileLayer
+        NimbusManager.shared.sponsoredTileLayer
     }
 }
 

--- a/Client/Nimbus/NimbusSponsoredTileLayer.swift
+++ b/Client/Nimbus/NimbusSponsoredTileLayer.swift
@@ -8,6 +8,6 @@ final class NimbusSponsoredTileLayer {
 
     // MARK: - Public methods
     public func getMaxNumberOfTiles(from nimbus: FxNimbus = FxNimbus.shared) -> Int {
-        return nimbus.features.homescreenFeature.value().sponsoredTiles.maxNumberOfTiles
+        nimbus.features.homescreenFeature.value().sponsoredTiles.maxNumberOfTiles
     }
 }

--- a/Client/Protocols/Loggable.swift
+++ b/Client/Protocols/Loggable.swift
@@ -14,14 +14,14 @@ protocol Loggable {
 
 extension Loggable {
     var browserLog: RollingFileLogger {
-        return Logger.browserLogger
+        Logger.browserLogger
     }
 
     var keychainLog: XCGLogger {
-        return Logger.keychainLogger
+        Logger.keychainLogger
     }
 
     var syncLog: RollingFileLogger {
-        return Logger.syncLogger
+        Logger.syncLogger
     }
 }

--- a/Client/Protocols/ReusableCell.swift
+++ b/Client/Protocols/ReusableCell.swift
@@ -17,19 +17,27 @@ protocol ReusableCell: AnyObject {
 }
 
 extension ReusableCell where Self: UICollectionViewCell {
-    static var cellIdentifier: String { return String(describing: self) }
+    static var cellIdentifier: String {
+        String(describing: self)
+    }
 }
 
 extension ReusableCell where Self: UITableViewCell {
-    static var cellIdentifier: String { return String(describing: self) }
+    static var cellIdentifier: String {
+        String(describing: self)
+    }
 }
 
 extension ReusableCell where Self: UITableViewHeaderFooterView {
-    static var cellIdentifier: String { return String(describing: self) }
+    static var cellIdentifier: String {
+        String(describing: self)
+    }
 }
 
 extension ReusableCell where Self: UICollectionReusableView {
-    static var cellIdentifier: String { return String(describing: self) }
+    static var cellIdentifier: String {
+        String(describing: self)
+    }
 }
 
 extension UICollectionView: Loggable {

--- a/Client/RatingPromptManager.swift
+++ b/Client/RatingPromptManager.swift
@@ -75,7 +75,9 @@ final class RatingPromptManager {
     }
 
     private var lastRequestDate: Date? {
-        get { return UserDefaults.standard.object(forKey: UserDefaultsKey.keyRatingPromptLastRequestDate.rawValue) as? Date }
+        get {
+            UserDefaults.standard.object(forKey: UserDefaultsKey.keyRatingPromptLastRequestDate.rawValue) as? Date
+        }
         set { UserDefaults.standard.set(newValue, forKey: UserDefaultsKey.keyRatingPromptLastRequestDate.rawValue) }
     }
 

--- a/Client/RecentItemsHelper.swift
+++ b/Client/RecentItemsHelper.swift
@@ -17,24 +17,28 @@ protocol RecentlySavedItem {
 
 extension RecentlySavedItem {
     func getNumberOfDays(calendar: Calendar, date: Date) -> Int {
-        return calendar.numberOfDaysBetween(getItemDate(), and: date)
+        calendar.numberOfDaysBetween(getItemDate(), and: date)
     }
 }
 
 extension ReadingListItem: RecentlySavedItem {
-    var numberOfDaysBeforeStale: Int { return 7 }
+    var numberOfDaysBeforeStale: Int {
+        7
+    }
 
     func getItemDate() -> Date {
         // ReadingListItem is using timeIntervalSinceReferenceDate to save lastModified timestamp
-        return Date(timeIntervalSinceReferenceDate: Double(lastModified) / 1000)
+        Date(timeIntervalSinceReferenceDate: Double(lastModified) / 1000)
     }
 }
 
 extension BookmarkItemData: RecentlySavedItem {
-    var numberOfDaysBeforeStale: Int { return 10 }
+    var numberOfDaysBeforeStale: Int {
+        10
+    }
 
     func getItemDate() -> Date {
-        return Date.fromTimestamp(Timestamp(dateAdded))
+        Date.fromTimestamp(Timestamp(dateAdded))
     }
 }
 
@@ -44,7 +48,9 @@ struct RecentlySavedBookmark: RecentlySavedItem {
     var title: String
     var url: String
     var dateAdded: Timestamp
-    var numberOfDaysBeforeStale: Int { return 10 }
+    var numberOfDaysBeforeStale: Int {
+        10
+    }
 
     init(bookmark: BookmarkItemData) {
         self.title = bookmark.title
@@ -53,7 +59,7 @@ struct RecentlySavedBookmark: RecentlySavedItem {
     }
 
     func getItemDate() -> Date {
-        return Date.fromTimestamp(dateAdded)
+        Date.fromTimestamp(dateAdded)
     }
 }
 
@@ -67,8 +73,8 @@ class RecentItemsHelper {
     ///   - date: The date to filter against.
     /// - Returns: A filtered list of items that are within the cutoff date.
     func filterStaleItems(recentItems: [RecentlySavedItem], since date: Date = Date()) -> [RecentlySavedItem] {
-        return recentItems.filter {
-            return $0.getNumberOfDays(calendar: calendar, date: date) <= $0.numberOfDaysBeforeStale
+        recentItems.filter {
+            $0.getNumberOfDays(calendar: calendar, date: date) <= $0.numberOfDaysBeforeStale
         }
     }
 }

--- a/Client/SiteImageHelper.swift
+++ b/Client/SiteImageHelper.swift
@@ -10,11 +10,11 @@ enum SiteImageType: Int {
     case heroImage = 0, favicon
 
     func peek() -> Self? {
-        return SiteImageType(rawValue: rawValue + 1)
+        SiteImageType(rawValue: rawValue + 1)
     }
 
     mutating func next() -> Self? {
-        return SiteImageType(rawValue: rawValue + 1)
+        SiteImageType(rawValue: rawValue + 1)
     }
 }
 
@@ -78,7 +78,6 @@ class SiteImageHelper: SiteImageHelperProtocol {
                 didCompleteFetch = result ?? false
                 DispatchQueue.main.async {
                     completion(heroImage)
-                    return
                 }
             }
         case .favicon:
@@ -87,7 +86,6 @@ class SiteImageHelper: SiteImageHelperProtocol {
                 didCompleteFetch = result ?? false
                 DispatchQueue.main.async {
                     completion(favicon)
-                    return
                 }
             }
         }

--- a/Client/Telemetry/AdsTelemetryHelper.swift
+++ b/Client/Telemetry/AdsTelemetryHelper.swift
@@ -79,8 +79,8 @@ public struct SearchProviderModel {
 extension SearchProviderModel {
     func listAdUrls(urls: [String]) -> [String] {
         let predicates: [Predicate] = extraAdServersRegexps.map { regex in
-            return { url in
-                return url.range(of: regex, options: .regularExpression) != nil
+            { url in
+                url.range(of: regex, options: .regularExpression) != nil
             }
         }
 
@@ -101,7 +101,7 @@ class AdsTelemetryHelper: TabContentScript {
     fileprivate weak var tab: Tab?
 
     class func name() -> String {
-        return "Ads"
+        "Ads"
     }
 
     required init(tab: Tab) {
@@ -109,7 +109,7 @@ class AdsTelemetryHelper: TabContentScript {
     }
 
     func scriptMessageHandlerName() -> String? {
-        return "adsMessageHandler"
+        "adsMessageHandler"
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -556,7 +556,7 @@ extension TelemetryWrapper {
         case averageTabsInAllGroups = "averageTabsInAllGroups"
         case totalTabsInAllGroups = "totalTabsInAllGroups"
         var description: String {
-            return self.rawValue
+            self.rawValue
         }
 
         // Inactive Tab

--- a/Client/UIWindowExtensions.swift
+++ b/Client/UIWindowExtensions.swift
@@ -6,20 +6,24 @@ import Foundation
 
 extension UIWindow {
     static var keyWindow: UIWindow? {
-        return UIApplication.shared.connectedScenes
-            .filter { $0.activationState == .foregroundActive }
-            .first(where: { $0 is UIWindowScene })
-            .flatMap({ $0 as? UIWindowScene })?.windows
-            .first(where: \.isKeyWindow)
+        UIApplication.shared.connectedScenes
+                .filter {
+                    $0.activationState == .foregroundActive
+                }
+                .first(where: { $0 is UIWindowScene })
+                .flatMap({ $0 as? UIWindowScene })?.windows
+                .first(where: \.isKeyWindow)
     }
 
     /// Filter for any scenes that are attached, regardless of state (i.e. active, inactive and background)
     static var attachedKeyWindow: UIWindow? {
-        return UIApplication.shared.connectedScenes
-            .filter { $0.activationState != .unattached }
-            .first(where: { $0 is UIWindowScene })
-            .flatMap({ $0 as? UIWindowScene })?.windows
-            .first(where: \.isKeyWindow)
+        UIApplication.shared.connectedScenes
+                .filter {
+                    $0.activationState != .unattached
+                }
+                .first(where: { $0 is UIWindowScene })
+                .flatMap({ $0 as? UIWindowScene })?.windows
+                .first(where: \.isKeyWindow)
     }
 
     static var isLandscape: Bool {

--- a/Client/Utils/ConfigurableGradientView.swift
+++ b/Client/Utils/ConfigurableGradientView.swift
@@ -17,11 +17,11 @@ public class ConfigurableGradientView: UIView {
     }
 
     private var gradientLayer: CAGradientLayer {
-        return layer as! CAGradientLayer
+        layer as! CAGradientLayer
     }
 
     public override class var layerClass: AnyClass {
-        return CAGradientLayer.self
+        CAGradientLayer.self
     }
 
     /// The main interface through which the gradient view is configured.

--- a/Client/Utils/DynamicHeightCollectionView.swift
+++ b/Client/Utils/DynamicHeightCollectionView.swift
@@ -13,6 +13,6 @@ class DynamicHeightCollectionView: UICollectionView {
     }
 
     override var intrinsicContentSize: CGSize {
-        return contentSize
+        contentSize
     }
 }

--- a/Client/Utils/FaviconFetcher+Non-Bundled.swift
+++ b/Client/Utils/FaviconFetcher+Non-Bundled.swift
@@ -40,14 +40,13 @@ extension FaviconFetcher {
                 }
 
                 oldIcons = oldIcons.sorted {
-                    return $0.width! > $1.width!
+                    $0.width! > $1.width!
                 }
 
                 return deferMaybe(oldIcons)
             }).upon({ (result: Maybe<[Favicon]>) in
                 deferred.fill(result)
-                return
-            })
+                    })
         }
 
         return deferred
@@ -55,19 +54,21 @@ extension FaviconFetcher {
 
     // Loads and parses an html document and tries to find any known favicon-type tags for the page
     fileprivate func parseHTMLForFavicons(_ url: URL) -> Deferred<Maybe<[Favicon]>> {
-        return fetchDataForURL(url).bind({ result -> Deferred<Maybe<[Favicon]>> in
+        fetchDataForURL(url).bind({ result -> Deferred<Maybe<[Favicon]>> in
             var icons = [Favicon]()
             guard let data = result.successValue,
                   result.isSuccess,
                   let root = try? HTMLDocument(data: data as Data)
-            else { return deferMaybe([]) }
+            else {
+                return deferMaybe([])
+            }
 
             var reloadUrl: URL?
             for meta in root.xpath("//head/meta") {
                 if let refresh = meta["http-equiv"], refresh == "Refresh",
-                    let content = meta["content"],
-                    let index = content.range(of: "URL="),
-                    let url = NSURL(string: String(content[index.upperBound...])) {
+                   let content = meta["content"],
+                   let index = content.range(of: "URL="),
+                   let url = NSURL(string: String(content[index.upperBound...])) {
                     reloadUrl = url as URL
                 }
             }

--- a/Client/Utils/FaviconFetcher.swift
+++ b/Client/Utils/FaviconFetcher.swift
@@ -29,7 +29,7 @@ open class FaviconFetcher: NSObject, XMLParserDelegate {
 
     private static var characterToFaviconCache = [String: UIImage]()
     static var defaultFavicon: UIImage = {
-        return UIImage(named: "defaultFavicon")!
+        UIImage(named: "defaultFavicon")!
     }()
 
     typealias BundledIconType = (bgcolor: UIColor, filePath: String)
@@ -230,6 +230,6 @@ open class FaviconFetcher: NSObject, XMLParserDelegate {
 
 class FaviconError: MaybeErrorType {
     internal var description: String {
-        return "No Image Loaded"
+        "No Image Loaded"
     }
 }

--- a/Client/Utils/SearchTermGroupsUtility.swift
+++ b/Client/Utils/SearchTermGroupsUtility.swift
@@ -79,7 +79,7 @@ class SearchTermGroupsUtility {
     /// - Returns: A dictionary whose keys are search terms used for grouping
     private static func buildMetadataGroups(from ASMetadata: [HistoryMetadata]) -> [String: [HistoryMetadata]] {
 
-        let searchTerms = Set(ASMetadata.map({ return $0.searchTerm }))
+        let searchTerms = Set(ASMetadata.map({ $0.searchTerm }))
         var searchTermMetaDataGroup: [String: [HistoryMetadata]] = [:]
 
         for term in searchTerms {
@@ -196,7 +196,9 @@ class SearchTermGroupsUtility {
     /// - Returns: A filtered array of the original items, containing no items present in groups
     private static func filterDuplicate<T: Equatable>(itemsInGroups: [T], from items: [T]) -> [T] {
         // 4. Filter the tabs so it doesn't include same tabs as tab groups
-        return items.filter { item in !itemsInGroups.contains(item) }
+        items.filter { item in
+            !itemsInGroups.contains(item)
+        }
 
     }
 
@@ -208,19 +210,19 @@ class SearchTermGroupsUtility {
     /// - Parameter groupDictionary: Dictionary that is to be processed
     /// - Returns: An array of `ASGroup<T>`
     private static func createGroups<T: Equatable>(from groupDictionary: [String: [T]]) -> [ASGroup<T>] {
-        return groupDictionary.map {
-                let orderedItems = orderItemsIn(group: $0.value)
-                var timestamp: Timestamp = 0
-                if let firstItem = orderedItems.first, let tab = firstItem as? Tab {
-                    timestamp = tab.firstCreatedTime ?? 0
-                }
+        groupDictionary.map {
+            let orderedItems = orderItemsIn(group: $0.value)
+            var timestamp: Timestamp = 0
+            if let firstItem = orderedItems.first, let tab = firstItem as? Tab {
+                timestamp = tab.firstCreatedTime ?? 0
+            }
 
-                // Base timestamp on score to order historyHighlight properly
-                if let firstItem = orderedItems.first, let highlight = firstItem as? HistoryHighlight {
-                    timestamp = Date.now() - Timestamp(highlight.score)
-                }
+            // Base timestamp on score to order historyHighlight properly
+            if let firstItem = orderedItems.first, let highlight = firstItem as? HistoryHighlight {
+                timestamp = Date.now() - Timestamp(highlight.score)
+            }
 
-                return ASGroup<T>(searchTerm: $0.key.capitalized, groupedItems: orderedItems, timestamp: timestamp)
+            return ASGroup<T>(searchTerm: $0.key.capitalized, groupedItems: orderedItems, timestamp: timestamp)
         }
     }
 
@@ -229,7 +231,7 @@ class SearchTermGroupsUtility {
     /// - Parameter group: A group in which items must be sorted
     /// - Returns: The items in the group, sorted chronologically, in ascending order
     private static func orderItemsIn<T: Equatable>(group: [T]) -> [T] {
-        return group.sorted {
+        group.sorted {
             if let firstTab = $0 as? Tab, let secondTab = $1 as? Tab {
                 let firstTabTimestamp = firstTab.firstCreatedTime ?? 0
                 let secondTabTimestamp = secondTab.firstCreatedTime ?? 0

--- a/CredentialProvider/CredentialListViewController.swift
+++ b/CredentialProvider/CredentialListViewController.swift
@@ -46,7 +46,7 @@ class CredentialListViewController: UIViewController, CredentialListViewProtocol
     private var searchController: UISearchController?
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return UIStatusBarStyle.lightContent
+        UIStatusBarStyle.lightContent
     }
 
     var searchIsActive: Bool {
@@ -59,7 +59,7 @@ class CredentialListViewController: UIViewController, CredentialListViewProtocol
     }
 
     var credentialExtensionContext: ASCredentialProviderExtensionContext? {
-        return (navigationController?.parent as? CredentialProviderViewController)?.extensionContext
+        (navigationController?.parent as? CredentialProviderViewController)?.extensionContext
     }
 
     init() {

--- a/CredentialProvider/Extensions/UIColorExtension.swift
+++ b/CredentialProvider/Extensions/UIColorExtension.swift
@@ -7,17 +7,17 @@ import UIKit
 extension UIColor {
     struct CredentialProvider {
         static var titleColor: UIColor {
-            return UIColor(named: "labelColor") ?? UIColor.Photon.DarkGrey90
+            UIColor(named: "labelColor") ?? UIColor.Photon.DarkGrey90
         }
 
         static var cellBackgroundColor: UIColor {
-            return UIColor(named: "credentialCellColor") ?? UIColor.Photon.White100
+            UIColor(named: "credentialCellColor") ?? UIColor.Photon.White100
         }
 
         static var tableViewBackgroundColor: UIColor = .systemGroupedBackground
 
         static var welcomeScreenBackgroundColor: UIColor {
-            return UIColor(named: "launchScreenBackgroundColor") ?? UIColor.Photon.White100
+            UIColor(named: "launchScreenBackgroundColor") ?? UIColor.Photon.White100
         }
     }
 }

--- a/CredentialProvider/Extensions/UIFontExtension.swift
+++ b/CredentialProvider/Extensions/UIFontExtension.swift
@@ -11,8 +11,8 @@ extension UIFont {
      * Note: the font does *not* scale for different dynamic type settings.
      */
     static var navigationButtonFont: UIFont {
-        return self.preferredFont(forTextStyle: .body,
-                                  compatibleWith: UITraitCollection(preferredContentSizeCategory: .large))
+        self.preferredFont(forTextStyle: .body,
+                compatibleWith: UITraitCollection(preferredContentSizeCategory: .large))
     }
 
     /** Returns a font to be used for a title in a navigation bar.
@@ -20,7 +20,7 @@ extension UIFont {
      * Note: the font does *not* scale for different dynamic type settings.
      */
     static var navigationTitleFont: UIFont {
-        return self.preferredFont(forTextStyle: .headline,
-                                  compatibleWith: UITraitCollection(preferredContentSizeCategory: .large))
+        self.preferredFont(forTextStyle: .headline,
+                compatibleWith: UITraitCollection(preferredContentSizeCategory: .large))
     }
 }

--- a/Extensions/NotificationService/ExtensionProfile.swift
+++ b/Extensions/NotificationService/ExtensionProfile.swift
@@ -29,7 +29,7 @@ class ExtensionSyncManager: BrowserProfile.BrowserSyncManager {
 
     // We don't want to send ping data at all while we're in the extension.
     override func canSendUsageData() -> Bool {
-        return false
+        false
     }
 
     // We should probably only want to sync client commands while we're in the extension.
@@ -39,6 +39,6 @@ class ExtensionSyncManager: BrowserProfile.BrowserSyncManager {
     }
 
     override func takeActionsOnEngineStateChanges<T: EngineStateChanges>(_ changes: T) -> Deferred<Maybe<T>> {
-        return deferMaybe(changes)
+        deferMaybe(changes)
     }
 }

--- a/Extensions/ShareTo/InitialViewController.swift
+++ b/Extensions/ShareTo/InitialViewController.swift
@@ -166,7 +166,7 @@ extension InitialViewController: ShareControllerDelegate {
     }
 
     func getValidExtensionContext() -> NSExtensionContext? {
-        return extensionContext
+        extensionContext
     }
 
     // At startup, the extension may show an alert that it can't share. In this case for a better UI, rather than showing

--- a/Extensions/ShareTo/ShareTheme.swift
+++ b/Extensions/ShareTo/ShareTheme.swift
@@ -19,7 +19,7 @@ public struct ModernColor {
     }
 
     public var color: UIColor {
-        return UIColor { (traitCollection: UITraitCollection) -> UIColor in
+        UIColor { (traitCollection: UITraitCollection) -> UIColor in
             if traitCollection.userInterfaceStyle == .dark {
                 return self.color(for: .dark)
             } else {
@@ -29,7 +29,7 @@ public struct ModernColor {
     }
 
     private func color(for scheme: ColorScheme) -> UIColor {
-        return scheme == .dark ? darkColor : lightColor
+        scheme == .dark ? darkColor : lightColor
     }
 }
 

--- a/Extensions/ShareTo/ShareViewController.swift
+++ b/Extensions/ShareTo/ShareViewController.swift
@@ -78,7 +78,7 @@ class ShareViewController: UIViewController {
 
     override var extensionContext: NSExtensionContext? {
         get {
-            return delegate?.getValidExtensionContext()
+            delegate?.getValidExtensionContext()
         }
     }
 

--- a/Extensions/Today/TodayModel.swift
+++ b/Extensions/Today/TodayModel.swift
@@ -10,6 +10,6 @@ struct TodayModel {
     static var searchedText: String?
 
     var scheme: String {
-        return URL.mozInternalScheme
+        URL.mozInternalScheme
     }
 }

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -136,7 +136,7 @@ class TodayViewController: UIViewController, NCWidgetProviding, TodayWidgetAppea
     }
 
     func widgetMarginInsets(forProposedMarginInsets defaultMarginInsets: UIEdgeInsets) -> UIEdgeInsets {
-        return .zero
+        .zero
     }
 
     // MARK: Button behaviour

--- a/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -13,7 +13,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
                                      AccessibilityIdentifiers.Onboarding.signSyncCard]
     var currentScreen = 0
     var rootA11yId: String {
-        return onboardingAccessibilityId[currentScreen]
+        onboardingAccessibilityId[currentScreen]
     }
 
     override func setUp() {

--- a/MarketingUITests/MarketingUITests.swift
+++ b/MarketingUITests/MarketingUITests.swift
@@ -114,6 +114,6 @@ extension XCUIElementQuery {
     }
 
     func firstMatchingType( type: XCUIElementType) -> XCUIElement {
-        return self.childrenMatchingType(type).elementBoundByIndex(0)
+        self.childrenMatchingType(type).elementBoundByIndex(0)
     }
 }

--- a/Providers/LoginRecordExtension.swift
+++ b/Providers/LoginRecordExtension.swift
@@ -12,7 +12,7 @@ extension LoginRecord {
     }
 
     public var passwordCredential: ASPasswordCredential {
-        return ASPasswordCredential(user: self.decryptedUsername, password: self.decryptedPassword)
+        ASPasswordCredential(user: self.decryptedUsername, password: self.decryptedPassword)
     }
 }
 

--- a/Providers/Pocket/Model/PocketFeedStory.swift
+++ b/Providers/Pocket/Model/PocketFeedStory.swift
@@ -20,27 +20,30 @@ struct PocketFeedStory {
     let imageURL: URL
 
     static func parseJSON(list: [[String: Any]]) -> [PocketFeedStory] {
-        return list.compactMap({ (storyDict) -> PocketFeedStory? in
+        list.compactMap({ (storyDict) -> PocketFeedStory? in
             guard let urlS = storyDict["url"] as? String,
                   let domain = storyDict["domain"] as? String,
                   let imageURLS = storyDict["image_src"] as? String,
                   let title = storyDict["title"] as? String,
                   let timeToRead = storyDict["time_to_read"] as? Int64,
-                  let description = storyDict["excerpt"] as? String else {
-                      return nil
-                  }
+                  let description = storyDict["excerpt"] as? String
+            else {
+                return nil
+            }
 
             guard let url = URL(string: urlS),
                   let imageURL = URL(string: imageURLS)
-            else { return nil }
+            else {
+                return nil
+            }
 
             return PocketFeedStory(
-                title: title,
-                url: url,
-                domain: domain,
-                timeToRead: timeToRead,
-                storyDescription: description,
-                imageURL: imageURL
+                    title: title,
+                    url: url,
+                    domain: domain,
+                    timeToRead: timeToRead,
+                    storyDescription: description,
+                    imageURL: imageURL
             )
         })
     }

--- a/Providers/Pocket/PocketFeed.swift
+++ b/Providers/Pocket/PocketFeed.swift
@@ -15,7 +15,7 @@ protocol PocketStoriesProviding {
 
 extension PocketStoriesProviding {
     func fetchStories(items: Int) async throws -> [PocketFeedStory] {
-        return try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             fetchStories(items: items) { result in
                 continuation.resume(with: result)
             }
@@ -43,13 +43,13 @@ class Pocket: PocketStoriesProviding, FeatureFlaggable, URLCaching {
     }
 
     var urlCache: URLCache {
-        return URLCache.shared
+        URLCache.shared
     }
 
     lazy private var urlSession = makeURLSession(userAgent: UserAgent.defaultClientUserAgent, configuration: URLSessionConfiguration.default)
 
     private lazy var pocketKey: String? = {
-        return Bundle.main.object(forInfoDictionaryKey: PocketEnvAPIKey) as? String
+        Bundle.main.object(forInfoDictionaryKey: PocketEnvAPIKey) as? String
     }()
 
     enum Error: Swift.Error {
@@ -93,7 +93,7 @@ class Pocket: PocketStoriesProviding, FeatureFlaggable, URLCaching {
 
     // Returns nil if the locale is not supported
     static func IslocaleSupported(_ locale: String) -> Bool {
-        return Pocket.SupportedLocales.contains(locale)
+        Pocket.SupportedLocales.contains(locale)
     }
 
     // Create the URL request to query the Pocket API. The max items that the query can return is 20

--- a/Providers/Pocket/PocketSponsoredStoriesProvider.swift
+++ b/Providers/Pocket/PocketSponsoredStoriesProvider.swift
@@ -17,11 +17,11 @@ class PocketSponsoredStoriesProvider: PocketSponsoredStoriesProviding, FeatureFl
     lazy var urlSession: URLSession = makeURLSession(userAgent: UserAgent.defaultClientUserAgent, configuration: URLSessionConfiguration.default)
 
     private lazy var pocketKey: String = {
-        return Bundle.main.object(forInfoDictionaryKey: PocketSponsoredConstants.pocketEnvAPIKey) as? String ?? ""
+        Bundle.main.object(forInfoDictionaryKey: PocketSponsoredConstants.pocketEnvAPIKey) as? String ?? ""
     }()
 
     lazy var urlCache: URLCache = {
-        return URLCache.shared
+        URLCache.shared
     }()
 
     private lazy var pocketId: String = {

--- a/Providers/Pocket/PocketSponsoredStoriesProviding.swift
+++ b/Providers/Pocket/PocketSponsoredStoriesProviding.swift
@@ -14,7 +14,7 @@ protocol PocketSponsoredStoriesProviding {
 
 extension PocketSponsoredStoriesProviding {
     func fetchSponsoredStories(timestamp: Timestamp = Date.now()) async throws -> [PocketSponsoredStory] {
-        return try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             fetchSponsoredStories(timestamp: timestamp) { result in
                 continuation.resume(with: result)
             }

--- a/Providers/TopSitesProvider.swift
+++ b/Providers/TopSitesProvider.swift
@@ -37,15 +37,15 @@ extension TopSitesProvider {
     }
 
     static var numberOfMaxItems: Int {
-        return UIDevice.current.userInterfaceIdiom == .pad ? 32 : 16
+        UIDevice.current.userInterfaceIdiom == .pad ? 32 : 16
     }
 
     var hideWithSearchParam: String {
-        return "mfadid=adm"
+        "mfadid=adm"
     }
 
     var defaultSuggestedSitesKey: String {
-        return "topSites.deletedSuggestedSites"
+        "topSites.deletedSuggestedSites"
     }
 }
 
@@ -117,7 +117,7 @@ private extension TopSitesProviderImplementation {
         // How sites are merged together. We compare against the url's base domain.
         // Example m.youtube.com is compared against `youtube.com`
         let unionOnURL = { (site: Site) -> String in
-            return URL(string: site.url)?.normalizedHost ?? ""
+            URL(string: site.url)?.normalizedHost ?? ""
         }
 
         // Fetch the default sites

--- a/Push/PushRegistration.swift
+++ b/Push/PushRegistration.swift
@@ -15,7 +15,7 @@ public class PushRegistration: NSObject, NSCoding {
     fileprivate var subscriptions: [String: PushSubscription]
 
     public var defaultSubscription: PushSubscription {
-        return subscriptions[defaultSubscriptionID]!
+        subscriptions[defaultSubscriptionID]!
     }
 
     public init(uaid: String, secret: String, subscriptions: [String: PushSubscription] = [:]) {
@@ -122,6 +122,6 @@ public extension PushSubscription {
     }
 
     func aes128gcm(payload: String) -> String? {
-        return try? PushCrypto.sharedInstance.aes128gcm(payload: payload, decryptWith: p256dhPrivateKey, authenticateWith: authKey)
+        try? PushCrypto.sharedInstance.aes128gcm(payload: payload, decryptWith: p256dhPrivateKey, authenticateWith: authKey)
     }
 }

--- a/RustFxA/FxAWebViewModel.swift
+++ b/RustFxA/FxAWebViewModel.swift
@@ -68,7 +68,7 @@ class FxAWebViewModel {
     var onDismissController: (() -> Void)?
 
     func composeTitle(basedOn url: URL?, hasOnlySecureContent: Bool) -> String {
-        return (hasOnlySecureContent ? "🔒 " : "") + (url?.host ?? "")
+        (hasOnlySecureContent ? "🔒 " : "") + (url?.host ?? "")
     }
 
     func setupFirstPage(completion: @escaping (URLRequest, TelemetryWrapper.EventMethod?) -> Void) {
@@ -109,7 +109,7 @@ class FxAWebViewModel {
     private func makeRequest(_ url: URL) -> URLRequest {
         if let query = deepLinkParams?.query {
             let args = query.filter { $0.key.starts(with: "utm_") }.map {
-                return URLQueryItem(name: $0.key, value: $0.value)
+                        URLQueryItem(name: $0.key, value: $0.value)
             }
 
             var comp = URLComponents(url: url, resolvingAgainstBaseURL: false)

--- a/RustFxA/RustFirefoxAccounts.swift
+++ b/RustFxA/RustFirefoxAccounts.swift
@@ -36,7 +36,7 @@ open class RustFirefoxAccounts {
     // This is used so that if a migration failed, show a UI indicator for the user to manually log in to their account.
     public var accountMigrationFailed: Bool {
         get {
-            return UserDefaults.standard.bool(forKey: "fxaccount-migration-failed")
+            UserDefaults.standard.bool(forKey: "fxaccount-migration-failed")
         }
         set {
             UserDefaults.standard.set(newValue, forKey: "fxaccount-migration-failed")
@@ -112,7 +112,7 @@ open class RustFirefoxAccounts {
     }
 
     public var isChinaSyncServiceEnabled: Bool {
-        return RustFirefoxAccounts.prefs?.boolForKey(PrefsKeys.KeyEnableChinaSyncService) ?? AppInfo.isChinaEdition
+        RustFirefoxAccounts.prefs?.boolForKey(PrefsKeys.KeyEnableChinaSyncService) ?? AppInfo.isChinaEdition
     }
 
     private func createAccountManager() -> FxAccountManager {

--- a/Shared/Accessibility.swift
+++ b/Shared/Accessibility.swift
@@ -20,22 +20,22 @@ open class AccessibleAction: NSObject {
 
 extension AccessibleAction { // UIAccessibilityCustomAction
     @objc private func performAccessibilityAction() -> Bool {
-        return handler()
+        handler()
     }
 
     public var accessibilityCustomAction: UIAccessibilityCustomAction {
-        return UIAccessibilityCustomAction(name: name, target: self, selector: #selector(performAccessibilityAction))
+        UIAccessibilityCustomAction(name: name, target: self, selector: #selector(performAccessibilityAction))
     }
 }
 
 extension AccessibleAction { // UIAlertAction
     private var alertActionHandler: (UIAlertAction?) -> Void {
-        return { (_: UIAlertAction?) -> Void in
+        { (_: UIAlertAction?) -> Void in
             _ = self.handler()
         }
     }
 
     public func alertAction(style: UIAlertAction.Style) -> UIAlertAction {
-        return UIAlertAction(title: name, style: style, handler: alertActionHandler)
+        UIAlertAction(title: name, style: style, handler: alertActionHandler)
     }
 }

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -8,7 +8,7 @@ public enum AppName: String, CustomStringConvertible {
     case shortName = "Firefox"
 
     public var description: String {
-        return self.rawValue
+        self.rawValue
     }
 }
 

--- a/Shared/AppInfo.swift
+++ b/Shared/AppInfo.swift
@@ -22,23 +22,23 @@ open class AppInfo {
     }
 
     public static var bundleIdentifier: String {
-        return applicationBundle.object(forInfoDictionaryKey: "CFBundleIdentifier") as! String
+        applicationBundle.object(forInfoDictionaryKey: "CFBundleIdentifier") as! String
     }
 
     public static var displayName: String {
-        return applicationBundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as! String
+        applicationBundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as! String
     }
 
     public static var appVersion: String {
-        return applicationBundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
+        applicationBundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
     }
 
     public static var buildNumber: String {
-        return applicationBundle.object(forInfoDictionaryKey: String(kCFBundleVersionKey)) as! String
+        applicationBundle.object(forInfoDictionaryKey: String(kCFBundleVersionKey)) as! String
     }
 
     public static var majorAppVersion: String {
-        return appVersion.components(separatedBy: ".").first!
+        appVersion.components(separatedBy: ".").first!
     }
 
     /// Return the shared container identifier (also known as the app group) to be used with for example background
@@ -94,7 +94,7 @@ open class AppInfo {
 
     // Return whether the currently executing code is running in an Application
     public static var isApplication: Bool {
-        return Bundle.main.object(forInfoDictionaryKey: "CFBundlePackageType") as! String == "APPL"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundlePackageType") as! String == "APPL"
     }
 
     // The port for the internal webserver, tests can change this

--- a/Shared/AsyncReducer.swift
+++ b/Shared/AsyncReducer.swift
@@ -7,7 +7,7 @@ import Foundation
 public let DefaultDispatchQueue = DispatchQueue.global(qos: DispatchQoS.default.qosClass)
 
 public func asyncReducer<T, U>(_ initialValue: T, combine: @escaping (T, U) -> Deferred<Maybe<T>>) -> AsyncReducer<T, U> {
-    return AsyncReducer(initialValue: initialValue, combine: combine)
+    AsyncReducer(initialValue: initialValue, combine: combine)
 }
 
 /**
@@ -73,7 +73,7 @@ open class AsyncReducer<T, U> {
         func nextItem() -> U? {
             // Because popFirst is only available on array slices.
             // removeFirst is fine for range-replaceable collections.
-            return queuedItems.isEmpty ? nil : queuedItems.removeFirst()
+            queuedItems.isEmpty ? nil : queuedItems.removeFirst()
         }
 
         func continueMaybe(_ res: Maybe<T>) {
@@ -94,7 +94,7 @@ open class AsyncReducer<T, U> {
             }
 
             let combineItem = deferDispatchAsync(dispatchQueue) {
-                return self.combine(accumulator, item)
+                self.combine(accumulator, item)
             }
 
             queueNext(combineItem)
@@ -110,7 +110,7 @@ open class AsyncReducer<T, U> {
      * @throws AlreadyFilled if the queue has finished already.
      */
     open func append(_ items: U...) throws -> Deferred<Maybe<T>> {
-        return try append(items)
+        try append(items)
     }
 
     /**

--- a/Shared/Bytes.swift
+++ b/Shared/Bytes.swift
@@ -26,14 +26,14 @@ open class Bytes {
 
     open class func generateGUID() -> GUID {
         // Turns the standard NSData encoding into the URL-safe variant that Sync expects.
-        return generateRandomBytes(9)
-            .base64EncodedString(options: [])
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "+", with: "-")
+        generateRandomBytes(9)
+                .base64EncodedString(options: [])
+                .replacingOccurrences(of: "/", with: "_")
+                .replacingOccurrences(of: "+", with: "-")
     }
 
     open class func decodeBase64(_ b64: String) -> Data? {
-        return Data(base64Encoded: b64, options: [])
+        Data(base64Encoded: b64, options: [])
     }
 
     /**
@@ -41,11 +41,11 @@ open class Bytes {
      * This is to allow HMAC to be computed of the raw base64 string.
      */
     open class func dataFromBase64(_ b64: String) -> Data? {
-        return b64.data(using: .ascii, allowLossyConversion: false)
+        b64.data(using: .ascii, allowLossyConversion: false)
     }
 
     func fromHex(_ str: String) -> Data {
        // TODO
-        return Data()
+        Data()
     }
 }

--- a/Shared/DateGroupedTableData.swift
+++ b/Shared/DateGroupedTableData.swift
@@ -24,7 +24,7 @@ public struct DateGroupedTableData<T: Equatable> {
     var older: [(item: T, timing: TimeInterval)] = []
 
     public var isEmpty: Bool {
-        return today.isEmpty && yesterday.isEmpty && lastWeek.isEmpty && lastMonth.isEmpty && older.isEmpty
+        today.isEmpty && yesterday.isEmpty && lastWeek.isEmpty && lastMonth.isEmpty && older.isEmpty
     }
 
     public init() {}

--- a/Shared/DeviceInfo.swift
+++ b/Shared/DeviceInfo.swift
@@ -64,11 +64,11 @@ open class DeviceInfo {
     }
 
     open class func deviceModel() -> String {
-        return UIDevice.current.model
+        UIDevice.current.model
     }
 
     open class func isSimulator() -> Bool {
-        return ProcessInfo.processInfo.environment["SIMULATOR_ROOT"] != nil
+        ProcessInfo.processInfo.environment["SIMULATOR_ROOT"] != nil
     }
 
     open class func isBlurSupported() -> Bool {
@@ -77,7 +77,7 @@ open class DeviceInfo {
         // 1. http://stackoverflow.com/questions/21603475/how-can-i-detect-if-the-iphone-my-app-is-on-is-going-to-use-a-simple-transparen
         // 2. https://gist.github.com/conradev/8655650
         // Thus, testing has to take place on actual devices.
-        return !lowGraphicsQualityModels.contains(specificModelName)
+        !lowGraphicsQualityModels.contains(specificModelName)
     }
 
     open class func hasConnectivity() -> Bool {

--- a/Shared/Extensions/ArrayExtensions.swift
+++ b/Shared/Extensions/ArrayExtensions.swift
@@ -82,6 +82,6 @@ public extension Sequence {
 public extension Collection {
     /// Returns the element at the specified index iff it is within bounds, otherwise nil.
     subscript (safe index: Index) -> Element? {
-        return indices.contains(index) ? self[index] : nil
+        indices.contains(index) ? self[index] : nil
     }
 }

--- a/Shared/Extensions/DictionaryExtensions.swift
+++ b/Shared/Extensions/DictionaryExtensions.swift
@@ -5,7 +5,9 @@
 extension Dictionary {
 
     public func merge(with dictionary: Dictionary) -> Dictionary {
-        return self.merging(dictionary) { (_, new) in new }
+        self.merging(dictionary) { (_, new) in
+            new
+        }
     }
 
     public var asString: String? {

--- a/Shared/Extensions/HashExtensions.swift
+++ b/Shared/Extensions/HashExtensions.swift
@@ -47,12 +47,12 @@ extension Data {
 
 extension String {
     public var utf8EncodedData: Data {
-        return self.data(using: .utf8, allowLossyConversion: false)!
+        self.data(using: .utf8, allowLossyConversion: false)!
     }
 }
 
 extension Data {
     public var utf8EncodedString: String? {
-        return String(data: self, encoding: .utf8)
+        String(data: self, encoding: .utf8)
     }
 }

--- a/Shared/Extensions/HexExtensions.swift
+++ b/Shared/Extensions/HexExtensions.swift
@@ -70,6 +70,6 @@ extension Data {
 
 extension Data {
     public var base64EncodedString: String {
-        return self.base64EncodedString(options: [])
+        self.base64EncodedString(options: [])
     }
 }

--- a/Shared/Extensions/JSONExtensions.swift
+++ b/Shared/Extensions/JSONExtensions.swift
@@ -7,31 +7,31 @@ import SwiftyJSON
 
 public extension JSON {
     func isStringOrNull() -> Bool {
-        return self.isString() ||
-               self.isNull()
+        self.isString() ||
+                self.isNull()
     }
 
     func isError() -> Bool {
-        return self.error != nil
+        self.error != nil
     }
 
     func isString() -> Bool {
         // SwiftyJSON doesn't link values to types; it's possible for `self.type == .string` but
         // `self.string` to return `nil`. Validate both.
-        return self.type == .string &&
-               self.string != nil
+        self.type == .string &&
+                self.string != nil
     }
 
     func isBool() -> Bool {
-        return self.type == .bool
+        self.type == .bool
     }
 
     func isArray() -> Bool {
-        return self.type == .array
+        self.type == .array
     }
 
     func isDictionary() -> Bool {
-        return self.type == .dictionary
+        self.type == .dictionary
     }
 
     // Bear in mind that for this function to work you need to set the value to NSNull:
@@ -41,25 +41,25 @@ public extension JSON {
     // ```
     // This is… easy to get wrong.
     func isNull() -> Bool {
-        return self.type == .null
+        self.type == .null
     }
 
     func isInt() -> Bool {
-        return self.type == .number && self.int != nil
+        self.type == .number && self.int != nil
     }
 
     func isNumber() -> Bool {
-        return self.type == .number && self.number != nil
+        self.type == .number && self.number != nil
     }
 
     func isDouble() -> Bool {
-        return self.type == .number && self.double != nil
+        self.type == .number && self.double != nil
     }
 
     // SwiftyJSON pretty prints the string value by default. Since all of our
     // existing code required the string to not be pretty printed, this helper
     // can be used as a shorthand for non-pretty printed .
     func stringify() -> String? {
-        return self.rawString(.utf8, options: [])
+        self.rawString(.utf8, options: [])
     }
 }

--- a/Shared/Extensions/NSCoderExtensions.swift
+++ b/Shared/Extensions/NSCoderExtensions.swift
@@ -16,26 +16,26 @@ extension NSCoder {
     * Decode as Int regardless of which Swift version was used to encode it
     **/
     public func decodeAsInt(forKey key: String) -> Int {
-        return self.decodeObject(forKey: key) as? Int ?? self.decodeInteger(forKey: key)
+        self.decodeObject(forKey: key) as? Int ?? self.decodeInteger(forKey: key)
     }
     /**
      * Decode as UInt64 regardless of which Swift version was used to encode it
      **/
     public func decodeAsUInt64(forKey key: String) -> UInt64 {
-        return (self.decodeObject(forKey: key)  as? NSNumber)?.uint64Value ?? UInt64(self.decodeInt64(forKey: key))
+        (self.decodeObject(forKey: key) as? NSNumber)?.uint64Value ?? UInt64(self.decodeInt64(forKey: key))
     }
 
     /**
      * Decode as Bool regardless of which Swift version was used to encode it
      **/
     public func decodeAsBool(forKey key: String) -> Bool {
-        return self.decodeObject(forKey: key) as? Bool ?? self.decodeBool(forKey: key)
+        self.decodeObject(forKey: key) as? Bool ?? self.decodeBool(forKey: key)
     }
 
     /**
      * Decode as Double regardless of which Swift version was used to encode it
      **/
     public func decodeAsDouble(forKey key: String) -> Double {
-        return (self.decodeObject(forKey: key) as? NSNumber)?.doubleValue ?? self.decodeDouble(forKey: key)
+        (self.decodeObject(forKey: key) as? NSNumber)?.doubleValue ?? self.decodeDouble(forKey: key)
     }
 }

--- a/Shared/Extensions/NSFileManagerExtensions.swift
+++ b/Shared/Extensions/NSFileManagerExtensions.swift
@@ -84,9 +84,13 @@ public extension FileManager {
     }
 
     func contentsOfDirectoryAtPath(_ path: String, withFilenamePrefix prefix: String) throws -> [String] {
-        return try FileManager.default.contentsOfDirectory(atPath: path)
-            .filter { $0.hasPrefix("\(prefix).") }
-            .sorted { $0 < $1 }
+        try FileManager.default.contentsOfDirectory(atPath: path)
+                .filter {
+                    $0.hasPrefix("\(prefix).")
+                }
+                .sorted {
+                    $0 < $1
+                }
     }
 
     func removeItemInDirectory(_ directory: String, named: String) throws {

--- a/Shared/Extensions/OptionalExtensions.swift
+++ b/Shared/Extensions/OptionalExtensions.swift
@@ -14,5 +14,7 @@ import Foundation
 
 infix operator ???: NilCoalescingPrecedence
 public func ???<T> (optional: T?, defaultValue: @autoclosure () -> String) -> String {
-    return optional.map { String(describing: $0) } ?? defaultValue()
+    optional.map {
+        String(describing: $0)
+    } ?? defaultValue()
 }

--- a/Shared/Extensions/StringExtensions.swift
+++ b/Shared/Extensions/StringExtensions.swift
@@ -26,7 +26,7 @@ public extension String {
     }
 
     func unescape() -> String? {
-        return self.removingPercentEncoding
+        self.removingPercentEncoding
     }
 
     /**
@@ -50,7 +50,7 @@ public extension String {
     }
 
     private var stringWithAdditionalEscaping: String {
-        return self.replacingOccurrences(of: "|", with: "%7C")
+        self.replacingOccurrences(of: "|", with: "%7C")
     }
 
     var asURL: URL? {
@@ -58,8 +58,8 @@ public extension String {
         // Let's escape | for them.
         // We'd love to use one of the more sophisticated CFURL* or NSString.* functions, but
         // none seem to be quite suitable.
-        return URL(string: self) ??
-               URL(string: self.stringWithAdditionalEscaping)
+        URL(string: self) ??
+                URL(string: self.stringWithAdditionalEscaping)
     }
 
     /// Returns a new string made by removing the leading String characters contained
@@ -93,13 +93,13 @@ public extension String {
     }
 
     static func contentsOfFileWithResourceName(_ name: String, ofType type: String, fromBundle bundle: Bundle, encoding: String.Encoding, error: NSErrorPointer) -> String? {
-        return bundle.path(forResource: name, ofType: type).flatMap {
+        bundle.path(forResource: name, ofType: type).flatMap {
             try? String(contentsOfFile: $0, encoding: encoding)
         }
     }
 
     func remove(_ string: String?) -> String {
-        return self.replacingOccurrences(of: string ?? "", with: "")
+        self.replacingOccurrences(of: string ?? "", with: "")
     }
 
     func replaceFirstOccurrence(of original: String, with replacement: String) -> String {

--- a/Shared/Extensions/UIImageExtensions.swift
+++ b/Shared/Extensions/UIImageExtensions.swift
@@ -18,7 +18,7 @@ extension CGRect {
 
 extension Data {
     public var isGIF: Bool {
-        return [0x47, 0x49, 0x46].elementsEqual(prefix(3))
+        [0x47, 0x49, 0x46].elementsEqual(prefix(3))
     }
 }
 
@@ -47,7 +47,7 @@ extension UIImage {
     }
 
     public static func templateImageNamed(_ name: String) -> UIImage? {
-        return UIImage(named: name)?.withRenderingMode(.alwaysTemplate)
+        UIImage(named: name)?.withRenderingMode(.alwaysTemplate)
     }
 
     // Uses compositor blending to apply color to an image.

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -7,7 +7,9 @@ import UIKit
 private struct ETLDEntry: CustomStringConvertible {
     let entry: String
 
-    var isNormal: Bool { return isWild || !isException }
+    var isNormal: Bool {
+        isWild || !isException
+    }
     var isWild: Bool = false
     var isException: Bool = false
 
@@ -18,7 +20,7 @@ private struct ETLDEntry: CustomStringConvertible {
     }
 
     fileprivate var description: String {
-        return "{ Entry: \(entry), isWildcard: \(isWild), isException: \(isException) }"
+        "{ Entry: \(entry), isWildcard: \(isWild), isException: \(isException) }"
     }
 }
 
@@ -44,7 +46,7 @@ private func loadEntries() -> TLDEntryMap? {
 }
 
 private var etldEntries: TLDEntryMap? = {
-    return loadEntries()
+    loadEntries()
 }()
 
 // MARK: - Local Resource URL Extensions
@@ -52,9 +54,9 @@ extension URL {
 
     public func allocatedFileSize() -> Int64 {
         // First try to get the total allocated size and in failing that, get the file allocated size
-        return getResourceLongLongForKey(URLResourceKey.totalFileAllocatedSizeKey.rawValue)
-            ?? getResourceLongLongForKey(URLResourceKey.fileAllocatedSizeKey.rawValue)
-            ?? 0
+        getResourceLongLongForKey(URLResourceKey.totalFileAllocatedSizeKey.rawValue)
+                ?? getResourceLongLongForKey(URLResourceKey.fileAllocatedSizeKey.rawValue)
+                ?? 0
     }
 
     public func getResourceValueForKey(_ key: String) -> Any? {
@@ -72,19 +74,19 @@ extension URL {
     }
 
     public func getResourceLongLongForKey(_ key: String) -> Int64? {
-        return (getResourceValueForKey(key) as? NSNumber)?.int64Value
+        (getResourceValueForKey(key) as? NSNumber)?.int64Value
     }
 
     public func getResourceBoolForKey(_ key: String) -> Bool? {
-        return getResourceValueForKey(key) as? Bool
+        getResourceValueForKey(key) as? Bool
     }
 
     public var isRegularFile: Bool {
-        return getResourceBoolForKey(URLResourceKey.isRegularFileKey.rawValue) ?? false
+        getResourceBoolForKey(URLResourceKey.isRegularFileKey.rawValue) ?? false
     }
 
     public func lastComponentIsPrefixedBy(_ prefix: String) -> Bool {
-        return (pathComponents.last?.hasPrefix(prefix) ?? false)
+        (pathComponents.last?.hasPrefix(prefix) ?? false)
     }
 }
 
@@ -251,7 +253,9 @@ extension URL {
     }
 
     public var normalizedHostAndPath: String? {
-        return normalizedHost.flatMap { $0 + self.path }
+        normalizedHost.flatMap {
+            $0 + self.path
+        }
     }
 
     public var absoluteDisplayString: String {
@@ -271,7 +275,7 @@ extension URL {
     /// String suitable for displaying outside of the app, for example in notifications, were Data Detectors will
     /// linkify the text and make it into a openable-in-Safari link.
     public var absoluteDisplayExternalString: String {
-        return self.absoluteDisplayString.replacingOccurrences(of: ".", with: "\u{2024}")
+        self.absoluteDisplayString.replacingOccurrences(of: ".", with: "\u{2024}")
     }
 
     public var displayURL: URL? {
@@ -364,13 +368,17 @@ extension URL {
     :returns: The public suffix for within the given hostname.
     */
     public var publicSuffix: String? {
-        return host.flatMap { publicSuffixFromHost($0, withAdditionalParts: 0) }
+        host.flatMap {
+            publicSuffixFromHost($0, withAdditionalParts: 0)
+        }
     }
 
     /// Creates a short domain version of a link's url
     /// e.g. url: http://www.foosite.com  =>  "foosite"
     public var shortDomain: String? {
-        return host.flatMap { shortDomain($0, etld: publicSuffix ?? "") }
+        host.flatMap {
+            shortDomain($0, etld: publicSuffix ?? "")
+        }
     }
 
     public func isWebPage(includeDataURIs: Bool = true) -> Bool {
@@ -379,7 +387,7 @@ extension URL {
     }
 
     public var isIPv6: Bool {
-        return host?.contains(":") ?? false
+        host?.contains(":") ?? false
     }
 
     /**
@@ -419,7 +427,7 @@ extension URL {
     }
 
     public var isFxHomeUrl: Bool {
-        return absoluteString.hasPrefix("internal://local/about/home")
+        absoluteString.hasPrefix("internal://local/about/home")
     }
 
 }
@@ -433,7 +441,7 @@ extension URL {
     }
 
     public var isSyncedReaderModeURL: Bool {
-        return self.absoluteString.hasPrefix("about:reader?url=")
+        self.absoluteString.hasPrefix("about:reader?url=")
     }
 
     public var decodeReaderModeURL: URL? {
@@ -488,14 +496,16 @@ public struct InternalURL {
         case errorpage = "errorpage"
         case sessionrestore = "sessionrestore"
         func matches(_ string: String) -> Bool {
-            return string.range(of: "/?\(self.rawValue)", options: .regularExpression, range: nil, locale: nil) != nil
+            string.range(of: "/?\(self.rawValue)", options: .regularExpression, range: nil, locale: nil) != nil
         }
     }
 
     public enum Param: String {
         case uuidkey = "uuidkey"
         case url = "url"
-        func matches(_ string: String) -> Bool { return string == self.rawValue }
+        func matches(_ string: String) -> Bool {
+            string == self.rawValue
+        }
     }
 
     public let url: URL
@@ -520,7 +530,7 @@ public struct InternalURL {
     }
 
     public var isAuthorized: Bool {
-        return (url.getQuery()[InternalURL.Param.uuidkey.rawValue] ?? "") == InternalURL.uuid
+        (url.getQuery()[InternalURL.Param.uuidkey.rawValue] ?? "") == InternalURL.uuid
     }
 
     public var stripAuthorization: String {
@@ -547,7 +557,7 @@ public struct InternalURL {
     }
 
     public var isSessionRestore: Bool {
-        return url.absoluteString.hasPrefix(sessionRestoreHistoryItemBaseUrl)
+        url.absoluteString.hasPrefix(sessionRestoreHistoryItemBaseUrl)
     }
 
     public var isErrorPage: Bool {
@@ -581,7 +591,7 @@ public struct InternalURL {
     }
 
     public var isAboutURL: Bool {
-        return aboutComponent != nil
+        aboutComponent != nil
     }
 
     /// Return the path after "about/" in the URI.

--- a/Shared/FeatureSwitch.swift
+++ b/Shared/FeatureSwitch.swift
@@ -47,7 +47,7 @@ open class FeatureSwitch {
     /// Is this user always a member of the test set, whatever the percentage probability?
     /// This _only_ tests the probabilities, not the other conditions.
     open func alwaysMembership(_ prefs: Prefs) -> Bool {
-        return lowerCaseS(prefs) == 99
+        lowerCaseS(prefs) == 99
     }
 
     /// Reset the random component of this switch (`lowerCaseS`). This is primarily useful for testing.

--- a/Shared/Functions.swift
+++ b/Shared/Functions.swift
@@ -10,38 +10,38 @@ precedencegroup PipelinePrecedence {
 infix operator |> : PipelinePrecedence
 
 public func |> <T, U>(x: T, f: (T) -> U) -> U {
-    return f(x)
+    f(x)
 }
 
 // Basic currying.
 public func curry<A, B>(_ f: @escaping (A) -> B) -> (A) -> B {
-    return { a in
-        return f(a)
+    { a in
+        f(a)
     }
 }
 
 public func curry<A, B, C>(_ f: @escaping (A, B) -> C) -> (A) -> (B) -> C {
-    return { a in
-        return { b in
-            return f(a, b)
+    { a in
+        { b in
+            f(a, b)
         }
     }
 }
 
 public func curry<A, B, C, D>(_ f: @escaping (A, B, C) -> D) -> (A) -> (B) -> (C) -> D {
-    return { a in
-        return { b in
-            return { c in
-                return f(a, b, c)
+    { a in
+        { b in
+            { c in
+                f(a, b, c)
             }
         }
     }
 }
 
 public func curry<A, B, C, D, E>(_ f: @escaping (A, B, C, D) -> E) -> (A, B, C) -> (D) -> E {
-    return { (a, b, c) in
-        return { d in
-            return f(a, b, c, d)
+    { (a, b, c) in
+        { d in
+            f(a, b, c, d)
         }
     }
 }
@@ -50,18 +50,18 @@ public func curry<A, B, C, D, E>(_ f: @escaping (A, B, C, D) -> E) -> (A, B, C) 
 infix operator •
 
 public func •<T, U, V>(f: @escaping (T) -> U, g: @escaping (U) -> V) -> (T) -> V {
-    return { t in
-        return g(f(t))
+    { t in
+        g(f(t))
     }
 }
 public func •<T, V>(f: @escaping (T) -> Void, g: @escaping () -> V) -> (T) -> V {
-    return { t in
+    { t in
         f(t)
         return g()
     }
 }
 public func •<V>(f: @escaping () -> Void, g: @escaping () -> V) -> () -> V {
-    return {
+    {
         f()
         return g()
     }
@@ -174,7 +174,9 @@ public func optDictionaryEqual<K, V: Equatable>(_ lhs: [K: V]?, rhs: [K: V]?) ->
  * Return members of `a` that aren't nil, changing the type of the sequence accordingly.
  */
 public func optFilter<T>(_ a: [T?]) -> [T] {
-    return a.compactMap { $0 }
+    a.compactMap {
+        $0
+    }
 }
 
 /**
@@ -215,7 +217,9 @@ public func findOneValue<K, V>(_ map: [K: V], f: (V) -> Bool) -> V? {
  * It's usually convenient for this to accept an optional.
  */
 public func jsonsToStrings(_ arr: [JSON]?) -> [String]? {
-    return arr?.compactMap { $0.stringValue }
+    arr?.compactMap {
+        $0.stringValue
+    }
 }
 
 // Encapsulate a callback in a way that we can use it with NSTimer.

--- a/Shared/ImageLoadingHandler.swift
+++ b/Shared/ImageLoadingHandler.swift
@@ -85,7 +85,7 @@ public class ImageLoadingHandler: ImageFetcher {
     }
 
     public func isImageInCache(url: URL) -> Bool {
-        return ImageCache.default.isCached(forKey: url.absoluteString)
+        ImageCache.default.isCached(forKey: url.absoluteString)
     }
 
     public func downloadAndCacheImage(with url: URL, completion: @escaping (UIImage?, ImageLoadingError?) -> Void) {

--- a/Shared/NSUserDefaultsPrefs.swift
+++ b/Shared/NSUserDefaultsPrefs.swift
@@ -10,7 +10,7 @@ open class NSUserDefaultsPrefs: Prefs {
     fileprivate let userDefaults: UserDefaults
 
     open func getBranchPrefix() -> String {
-        return self.prefixWithDot
+        self.prefixWithDot
     }
 
     public init(prefix: String, userDefaults: UserDefaults) {
@@ -31,7 +31,7 @@ open class NSUserDefaultsPrefs: Prefs {
     // Preferences are qualified by the profile's local name.
     // Connecting a profile to a Firefox Account, or changing to another, won't alter this.
     fileprivate func qualifyKey(_ key: String) -> String {
-        return self.prefixWithDot + key
+        self.prefixWithDot + key
     }
 
     open func setInt(_ value: Int32, forKey defaultName: String) {
@@ -65,7 +65,7 @@ open class NSUserDefaultsPrefs: Prefs {
 
     open func stringForKey(_ defaultName: String) -> String? {
         // stringForKey converts numbers to strings, which is almost always a bug.
-        return userDefaults.object(forKey: qualifyKey(defaultName)) as? String
+        userDefaults.object(forKey: qualifyKey(defaultName)) as? String
     }
 
     open func setBool(_ value: Bool, forKey defaultName: String) {
@@ -81,27 +81,27 @@ open class NSUserDefaultsPrefs: Prefs {
     }
 
     fileprivate func nsNumberForKey(_ defaultName: String) -> NSNumber? {
-        return userDefaults.object(forKey: qualifyKey(defaultName)) as? NSNumber
+        userDefaults.object(forKey: qualifyKey(defaultName)) as? NSNumber
     }
 
     open func unsignedLongForKey(_ defaultName: String) -> UInt64? {
-        return nsNumberForKey(defaultName)?.uint64Value
+        nsNumberForKey(defaultName)?.uint64Value
     }
 
     open func timestampForKey(_ defaultName: String) -> Timestamp? {
-        return unsignedLongForKey(defaultName)
+        unsignedLongForKey(defaultName)
     }
 
     open func longForKey(_ defaultName: String) -> Int64? {
-        return nsNumberForKey(defaultName)?.int64Value
+        nsNumberForKey(defaultName)?.int64Value
     }
 
     open func objectForKey<T: Any>(_ defaultName: String) -> T? {
-        return userDefaults.object(forKey: qualifyKey(defaultName)) as? T
+        userDefaults.object(forKey: qualifyKey(defaultName)) as? T
     }
 
     open func intForKey(_ defaultName: String) -> Int32? {
-        return nsNumberForKey(defaultName)?.int32Value
+        nsNumberForKey(defaultName)?.int32Value
     }
 
     open func stringArrayForKey(_ defaultName: String) -> [String]? {
@@ -113,11 +113,11 @@ open class NSUserDefaultsPrefs: Prefs {
     }
 
     open func arrayForKey(_ defaultName: String) -> [Any]? {
-        return userDefaults.array(forKey: qualifyKey(defaultName)) as [Any]?
+        userDefaults.array(forKey: qualifyKey(defaultName)) as [Any]?
     }
 
     open func dictionaryForKey(_ defaultName: String) -> [String: Any]? {
-        return userDefaults.dictionary(forKey: qualifyKey(defaultName)) as [String: Any]?
+        userDefaults.dictionary(forKey: qualifyKey(defaultName)) as [String: Any]?
     }
 
     open func removeObjectForKey(_ defaultName: String) {

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -151,7 +151,7 @@ open class MockProfilePrefs: Prefs {
     let prefix: String
 
     open func getBranchPrefix() -> String {
-        return self.prefix
+        self.prefix
     }
 
     // Public for testing.
@@ -167,11 +167,11 @@ open class MockProfilePrefs: Prefs {
     }
 
     open func branch(_ branch: String) -> Prefs {
-        return MockProfilePrefs(things: self.things, prefix: self.prefix + branch + ".")
+        MockProfilePrefs(things: self.things, prefix: self.prefix + branch + ".")
     }
 
     private func name(_ name: String) -> String {
-        return self.prefix + name
+        self.prefix + name
     }
 
     open func setTimestamp(_ value: Timestamp, forKey defaultName: String) {
@@ -203,31 +203,31 @@ open class MockProfilePrefs: Prefs {
     }
 
     open func stringForKey(_ defaultName: String) -> String? {
-        return things[name(defaultName)] as? String
+        things[name(defaultName)] as? String
     }
 
     open func boolForKey(_ defaultName: String) -> Bool? {
-        return things[name(defaultName)] as? Bool
+        things[name(defaultName)] as? Bool
     }
 
     open func objectForKey<T: Any>(_ defaultName: String) -> T? {
-        return things[name(defaultName)] as? T
+        things[name(defaultName)] as? T
     }
 
     open func timestampForKey(_ defaultName: String) -> Timestamp? {
-        return unsignedLongForKey(defaultName)
+        unsignedLongForKey(defaultName)
     }
 
     open func unsignedLongForKey(_ defaultName: String) -> UInt64? {
-        return things[name(defaultName)] as? UInt64
+        things[name(defaultName)] as? UInt64
     }
 
     open func longForKey(_ defaultName: String) -> Int64? {
-        return things[name(defaultName)] as? Int64
+        things[name(defaultName)] as? Int64
     }
 
     open func intForKey(_ defaultName: String) -> Int32? {
-        return things[name(defaultName)] as? Int32
+        things[name(defaultName)] as? Int32
     }
 
     open func stringArrayForKey(_ defaultName: String) -> [String]? {
@@ -251,7 +251,7 @@ open class MockProfilePrefs: Prefs {
     }
 
     open func dictionaryForKey(_ defaultName: String) -> [String: Any]? {
-        return things.object(forKey: name(defaultName)) as? [String: Any]
+        things.object(forKey: name(defaultName)) as? [String: Any]
     }
 
     open func removeObjectForKey(_ defaultName: String) {

--- a/Shared/RollingFileLogger.swift
+++ b/Shared/RollingFileLogger.swift
@@ -110,6 +110,6 @@ open class RollingFileLogger: XCGLogger {
     }
 
     fileprivate func fileLogIdentifierWithRoot(_ root: String) -> String {
-        return "\(fileLogIdentifierPrefix).\(root)"
+        "\(fileLogIdentifierPrefix).\(root)"
     }
 }

--- a/Shared/SentryIntegration.swift
+++ b/Shared/SentryIntegration.swift
@@ -45,11 +45,11 @@ public class SentryIntegration: SentryProtocol {
     private var attributes: [String: Any] = [:]
 
     public var crashedLastLaunch: Bool {
-        return SentrySDK.crashedLastRun
+        SentrySDK.crashedLastRun
     }
 
     private var releaseName: String {
-        return "\(AppInfo.bundleIdentifier)@\(AppInfo.appVersion)+(\(AppInfo.buildNumber))"
+        "\(AppInfo.bundleIdentifier)@\(AppInfo.appVersion)+(\(AppInfo.buildNumber))"
     }
 
     public func setup(sendUsageData: Bool) {

--- a/Shared/TimeConstants.swift
+++ b/Shared/TimeConstants.swift
@@ -27,7 +27,7 @@ private let rfc822DateFormatter: DateFormatter = {
 
 extension TimeInterval {
     public static func fromMicrosecondTimestamp(_ microsecondTimestamp: MicrosecondTimestamp) -> TimeInterval {
-        return Double(microsecondTimestamp) / 1000000
+        Double(microsecondTimestamp) / 1000000
     }
 
     public static func timeIntervalSince1970ToDate(timeInterval: TimeInterval) -> Date {
@@ -37,37 +37,37 @@ extension TimeInterval {
 
 extension Timestamp {
     public static func uptimeInMilliseconds() -> Timestamp {
-        return Timestamp(DispatchTime.now().uptimeNanoseconds) / 1000000
+        Timestamp(DispatchTime.now().uptimeNanoseconds) / 1000000
     }
 }
 
 extension Date {
     public static func now() -> Timestamp {
-        return UInt64(1000 * Date().timeIntervalSince1970)
+        UInt64(1000 * Date().timeIntervalSince1970)
     }
 
     public func toMicrosecondTimestamp() -> MicrosecondTimestamp {
-        return UInt64(1_000_000 * timeIntervalSince1970)
+        UInt64(1_000_000 * timeIntervalSince1970)
     }
 
     public static func nowNumber() -> NSNumber {
-        return NSNumber(value: now() as UInt64)
+        NSNumber(value: now() as UInt64)
     }
 
     public static func nowMicroseconds() -> MicrosecondTimestamp {
-        return UInt64(1000000 * Date().timeIntervalSince1970)
+        UInt64(1000000 * Date().timeIntervalSince1970)
     }
 
     public static func fromTimestamp(_ timestamp: Timestamp) -> Date {
-        return Date(timeIntervalSince1970: Double(timestamp) / 1000)
+        Date(timeIntervalSince1970: Double(timestamp) / 1000)
     }
 
     public func toTimestamp() -> Timestamp {
-        return UInt64(1000 * timeIntervalSince1970)
+        UInt64(1000 * timeIntervalSince1970)
     }
 
     public static func fromMicrosecondTimestamp(_ microsecondTimestamp: MicrosecondTimestamp) -> Date {
-        return Date(timeIntervalSince1970: Double(microsecondTimestamp) / 1000000)
+        Date(timeIntervalSince1970: Double(microsecondTimestamp) / 1000000)
     }
 
     public func toRelativeTimeString(dateStyle: DateFormatter.Style = .short, timeStyle: DateFormatter.Style = .short) -> String {
@@ -111,7 +111,7 @@ extension Date {
     }
 
     public func toRFC822String() -> String {
-        return rfc822DateFormatter.string(from: self)
+        rfc822DateFormatter.string(from: self)
     }
 
     public static func difference(recent: Date, previous: Date) -> (month: Int?, day: Int?, hour: Int?, minute: Int?, second: Int?) {
@@ -125,46 +125,50 @@ extension Date {
     }
 
     static func - (lhs: Date, rhs: Date) -> TimeInterval {
-        return lhs.timeIntervalSinceReferenceDate - rhs.timeIntervalSinceReferenceDate
+        lhs.timeIntervalSinceReferenceDate - rhs.timeIntervalSinceReferenceDate
     }
 }
 
 extension Date {
-    public static var yesterday: Date { return Date().dayBefore }
-    public static var tomorrow: Date { return Date().dayAfter }
+    public static var yesterday: Date {
+        Date().dayBefore
+    }
+    public static var tomorrow: Date {
+        Date().dayAfter
+    }
     public var lastTwoWeek: Date {
-        return Calendar.current.date(byAdding: .day, value: -14, to: noon) ?? Date()
+        Calendar.current.date(byAdding: .day, value: -14, to: noon) ?? Date()
     }
     public var lastWeek: Date {
-        return Calendar.current.date(byAdding: .day, value: -8, to: noon) ?? Date()
+        Calendar.current.date(byAdding: .day, value: -8, to: noon) ?? Date()
     }
     public var older: Date {
-        return Calendar.current.date(byAdding: .day, value: -20, to: noon) ?? Date()
+        Calendar.current.date(byAdding: .day, value: -20, to: noon) ?? Date()
     }
     public var dayBefore: Date {
-        return Calendar.current.date(byAdding: .day, value: -1, to: noon) ?? Date()
+        Calendar.current.date(byAdding: .day, value: -1, to: noon) ?? Date()
     }
     public var dayAfter: Date {
-        return Calendar.current.date(byAdding: .day, value: 1, to: noon) ?? Date()
+        Calendar.current.date(byAdding: .day, value: 1, to: noon) ?? Date()
     }
     public var noon: Date {
-        return Calendar.current.date(bySettingHour: 12, minute: 0, second: 0, of: self) ?? Date()
+        Calendar.current.date(bySettingHour: 12, minute: 0, second: 0, of: self) ?? Date()
     }
 
     public func isToday() -> Bool {
-        return Calendar.current.isDateInToday(self)
+        Calendar.current.isDateInToday(self)
     }
 
     public func isYesterday() -> Bool {
-        return Calendar.current.isDateInYesterday(self)
+        Calendar.current.isDateInYesterday(self)
     }
 
     public func isWithinLast7Days() -> Bool {
-        return (Date().lastWeek ... Date()).contains(self)
+        (Date().lastWeek...Date()).contains(self)
     }
 
     public func isWithinLast14Days() -> Bool {
-        return (Date().lastTwoWeek ... Date()).contains(self)
+        (Date().lastTwoWeek...Date()).contains(self)
     }
 }
 

--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -29,31 +29,31 @@ open class UserAgent {
     }
 
     public static var syncUserAgent: String {
-        return clientUserAgent(prefix: "Firefox-iOS-Sync")
+        clientUserAgent(prefix: "Firefox-iOS-Sync")
     }
 
     public static var tokenServerClientUserAgent: String {
-        return clientUserAgent(prefix: "Firefox-iOS-Token")
+        clientUserAgent(prefix: "Firefox-iOS-Token")
     }
 
     public static var fxaUserAgent: String {
-        return clientUserAgent(prefix: "Firefox-iOS-FxA")
+        clientUserAgent(prefix: "Firefox-iOS-FxA")
     }
 
     public static var defaultClientUserAgent: String {
-        return clientUserAgent(prefix: "Firefox-iOS")
+        clientUserAgent(prefix: "Firefox-iOS")
     }
 
     public static func isDesktop(ua: String) -> Bool {
-        return ua.lowercased().contains("intel mac")
+        ua.lowercased().contains("intel mac")
     }
 
     public static func desktopUserAgent() -> String {
-        return "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15"
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15"
     }
 
     public static func mobileUserAgent() -> String {
-        return UserAgentBuilder.defaultMobileUserAgent().userAgent()
+        UserAgentBuilder.defaultMobileUserAgent().userAgent()
     }
 
     public static func oppositeUserAgent(domain: String) -> String {
@@ -132,24 +132,27 @@ public struct UserAgentBuilder {
 
     /// Helper method to remove the empty components from user agent string that contain only whitespaces or are just empty
     private func removeEmptyComponentsAndJoin(uaItems: [String]) -> String {
-        return uaItems.filter { !$0.isEmptyOrWhitespace() }.joined(separator: " ")
+        uaItems.filter {
+                    !$0.isEmptyOrWhitespace()
+                }
+                .joined(separator: " ")
     }
 
     public static func defaultMobileUserAgent() -> UserAgentBuilder {
-        return UserAgentBuilder(
-            product: UserAgent.product,
-            systemInfo: "(\(UIDevice.current.model); CPU iPhone OS \(UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")) like Mac OS X)",
-            platform: UserAgent.platform,
-            platformDetails: UserAgent.platformDetails,
-            extensions: "FxiOS/\(AppInfo.appVersion)  \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)")
+        UserAgentBuilder(
+                product: UserAgent.product,
+                systemInfo: "(\(UIDevice.current.model); CPU iPhone OS \(UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")) like Mac OS X)",
+                platform: UserAgent.platform,
+                platformDetails: UserAgent.platformDetails,
+                extensions: "FxiOS/\(AppInfo.appVersion)  \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)")
     }
 
     public static func defaultDesktopUserAgent() -> UserAgentBuilder {
-        return UserAgentBuilder(
-            product: UserAgent.product,
-            systemInfo: "(Macintosh; Intel Mac OS X 10.15)",
-            platform: UserAgent.platform,
-            platformDetails: UserAgent.platformDetails,
-            extensions: "FxiOS/\(AppInfo.appVersion) \(UserAgent.uaBitSafari)")
+        UserAgentBuilder(
+                product: UserAgent.product,
+                systemInfo: "(Macintosh; Intel Mac OS X 10.15)",
+                platform: UserAgent.platform,
+                platformDetails: UserAgent.platformDetails,
+                extensions: "FxiOS/\(AppInfo.appVersion) \(UserAgent.uaBitSafari)")
     }
 }

--- a/Shared/WeakList.swift
+++ b/Shared/WeakList.swift
@@ -39,11 +39,11 @@ open class WeakList<T: AnyObject>: Sequence {
     }
 
     open var count: Int {
-        return items.count
+        items.count
     }
 
     open var isEmpty: Bool {
-        return items.isEmpty
+        items.isEmpty
     }
 
     open func removeAll() {
@@ -57,15 +57,17 @@ open class WeakList<T: AnyObject>: Sequence {
     }
 
     open func at(_ index: Int) -> T? {
-        return items[safe: index]?.value
+        items[safe: index]?.value
     }
 
     open func index(of item: T) -> Int? {
-        return items.firstIndex { $0.value === item }
+        items.firstIndex {
+            $0.value === item
+        }
     }
 
     open func firstIndexDel(where predicate: (WeakRef<T>) -> Bool) -> Int? {
-        return items.firstIndex(where: predicate)
+        items.firstIndex(where: predicate)
     }
 
     open func makeIterator() -> AnyIterator<T> {

--- a/Storage/CertStore.swift
+++ b/Storage/CertStore.swift
@@ -24,6 +24,6 @@ open class CertStore {
     }
 
     fileprivate func keyForData(_ data: Data, origin: String) -> String {
-        return "\(origin)/\(data.sha256.hexEncodedString)"
+        "\(origin)/\(data.sha256.hexEncodedString)"
     }
 }

--- a/Storage/Clients.swift
+++ b/Storage/Clients.swift
@@ -58,22 +58,22 @@ public struct RemoteClient: Equatable {
 
 // TODO: should this really compare tabs?
 public func == (lhs: RemoteClient, rhs: RemoteClient) -> Bool {
-    return lhs.guid == rhs.guid &&
-        lhs.name == rhs.name &&
-        lhs.modified == rhs.modified &&
-        lhs.type == rhs.type &&
-        lhs.formfactor == rhs.formfactor &&
-        lhs.os == rhs.os &&
-        lhs.version == rhs.version &&
-        lhs.fxaDeviceId == rhs.fxaDeviceId
+    lhs.guid == rhs.guid &&
+            lhs.name == rhs.name &&
+            lhs.modified == rhs.modified &&
+            lhs.type == rhs.type &&
+            lhs.formfactor == rhs.formfactor &&
+            lhs.os == rhs.os &&
+            lhs.version == rhs.version &&
+            lhs.fxaDeviceId == rhs.fxaDeviceId
 }
 
 extension RemoteClient: CustomStringConvertible {
     public var description: String {
-        return """
-<RemoteClient GUID: \(guid ?? "nil"), name: \(name), modified: \(modified), \
-type: \(type ?? "nil"), formfactor: \(formfactor ?? "nil"), OS: \(os ?? "nil"), \
-version: \(version ?? "nil"), fxaDeviceId: \(fxaDeviceId ?? "nil")>
-"""
+        """
+        <RemoteClient GUID: \(guid ?? "nil"), name: \(name), modified: \(modified), \
+        type: \(type ?? "nil"), formfactor: \(formfactor ?? "nil"), OS: \(os ?? "nil"), \
+        version: \(version ?? "nil"), fxaDeviceId: \(fxaDeviceId ?? "nil")>
+        """
     }
 }

--- a/Storage/Cursor.swift
+++ b/Storage/Cursor.swift
@@ -27,7 +27,9 @@ public protocol TypedCursor: Sequence {
  */
 open class Cursor<T>: TypedCursor {
     open var count: Int {
-        get { return 0 }
+        get {
+            0
+        }
     }
 
     // Extra status information
@@ -46,7 +48,9 @@ open class Cursor<T>: TypedCursor {
 
     // Collection iteration and access functions
     open subscript(index: Int) -> T? {
-        get { return nil }
+        get {
+            nil
+        }
     }
 
     open func asArray() -> [T] {

--- a/Storage/DatabaseError.swift
+++ b/Storage/DatabaseError.swift
@@ -11,7 +11,7 @@ open class DatabaseError: MaybeErrorType {
     let err: NSError?
 
     open var description: String {
-        return err?.localizedDescription ?? "Unknown database error."
+        err?.localizedDescription ?? "Unknown database error."
     }
 
     public init(description: String) {

--- a/Storage/DiskImageStore.swift
+++ b/Storage/DiskImageStore.swift
@@ -42,14 +42,14 @@ open class DiskImageStore {
 
     /// Gets an image for the given key if it is in the store.
     open func get(_ key: String) -> Deferred<Maybe<UIImage>> {
-        return deferDispatchAsync(queue) { () -> Deferred<Maybe<UIImage>> in
+        deferDispatchAsync(queue) { () -> Deferred<Maybe<UIImage>> in
             if !self.keys.contains(key) {
                 return deferMaybe(DiskImageStoreErrorType(description: "Image key not found"))
             }
 
             let imagePath = URL(fileURLWithPath: self.filesDir).appendingPathComponent(key)
             if let data = try? Data(contentsOf: imagePath),
-                   let image = UIImage.imageFromDataThreadSafe(data) {
+               let image = UIImage.imageFromDataThreadSafe(data) {
                 return deferMaybe(image)
             }
 
@@ -61,7 +61,7 @@ open class DiskImageStore {
     /// This put is asynchronous; the image is not recorded in the cache until the write completes.
     /// Does nothing if this key already exists in the store.
     @discardableResult open func put(_ key: String, image: UIImage) -> Success {
-        return deferDispatchAsync(queue) { () -> Success in
+        deferDispatchAsync(queue) { () -> Success in
             let imageURL = URL(fileURLWithPath: self.filesDir).appendingPathComponent(key)
             if let data = image.jpegData(compressionQuality: self.quality) {
                 do {
@@ -79,7 +79,7 @@ open class DiskImageStore {
 
     /// Clears all images from the cache, excluding the given set of keys.
     open func clearExcluding(_ keys: Set<String>) -> Success {
-        return deferDispatchAsync(queue) { () -> Success in
+        deferDispatchAsync(queue) { () -> Success in
             let keysToDelete = self.keys.subtracting(keys)
 
             for key in keysToDelete {
@@ -99,7 +99,7 @@ open class DiskImageStore {
 
     /// Remove image with provided key
     open func removeImage(_ key: String) -> Success {
-        return deferDispatchAsync(queue) { () -> Success in
+        deferDispatchAsync(queue) { () -> Success in
             let url = URL(fileURLWithPath: self.filesDir).appendingPathComponent(key)
 
             do {

--- a/Storage/ExtensionUtils.swift
+++ b/Storage/ExtensionUtils.swift
@@ -6,8 +6,12 @@ import UIKit
 import MobileCoreServices
 
 extension NSItemProvider {
-    var isText: Bool { return hasItemConformingToTypeIdentifier(String(kUTTypeText)) }
-    var isUrl: Bool { return hasItemConformingToTypeIdentifier(String(kUTTypeURL)) }
+    var isText: Bool {
+        hasItemConformingToTypeIdentifier(String(kUTTypeText))
+    }
+    var isUrl: Bool {
+        hasItemConformingToTypeIdentifier(String(kUTTypeURL))
+    }
 
     func processText(completion: CompletionHandler?) {
         loadItem(forTypeIdentifier: String(kUTTypeText), options: nil, completionHandler: completion)

--- a/Storage/FileAccessor.swift
+++ b/Storage/FileAccessor.swift
@@ -48,7 +48,6 @@ open class FileAccessor {
         for file in files {
             try remove(URL(fileURLWithPath: relativePath).appendingPathComponent(file).path)
         }
-        return
     }
 
     /**
@@ -60,7 +59,7 @@ open class FileAccessor {
     }
 
     open func attributesForFileAt(relativePath: String) throws -> [FileAttributeKey: Any] {
-        return try FileManager.default.attributesOfItem(atPath: URL(fileURLWithPath: rootPath).appendingPathComponent(relativePath).path)
+        try FileManager.default.attributesOfItem(atPath: URL(fileURLWithPath: rootPath).appendingPathComponent(relativePath).path)
     }
 
     /**

--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -6,7 +6,7 @@ import Shared
 
 open class IgnoredSiteError: MaybeErrorType {
     open var description: String {
-        return "Ignored site."
+        "Ignored site."
     }
 }
 

--- a/Storage/ReadingList.swift
+++ b/Storage/ReadingList.swift
@@ -6,7 +6,7 @@ import Foundation
 import Shared
 
 func ReadingListNow() -> Timestamp {
-    return Timestamp(Date.timeIntervalSinceReferenceDate * 1000.0)
+    Timestamp(Date.timeIntervalSinceReferenceDate * 1000.0)
 }
 
 let ReadingListDefaultUnread: Bool = true
@@ -46,12 +46,12 @@ public struct ReadingListItem: Equatable {
 }
 
 public func == (lhs: ReadingListItem, rhs: ReadingListItem) -> Bool {
-    return lhs.id == rhs.id
-        && lhs.lastModified == rhs.lastModified
-        && lhs.url == rhs.url
-        && lhs.title == rhs.title
-        && lhs.addedBy == rhs.addedBy
-        && lhs.unread == rhs.unread
-        && lhs.archived == rhs.archived
-        && lhs.favorite == rhs.favorite
+    lhs.id == rhs.id
+            && lhs.lastModified == rhs.lastModified
+            && lhs.url == rhs.url
+            && lhs.title == rhs.title
+            && lhs.addedBy == rhs.addedBy
+            && lhs.unread == rhs.unread
+            && lhs.archived == rhs.archived
+            && lhs.favorite == rhs.favorite
 }

--- a/Storage/RemoteTabs.swift
+++ b/Storage/RemoteTabs.swift
@@ -10,7 +10,7 @@ public struct ClientAndTabs: Equatable, CustomStringConvertible {
     public let tabs: [RemoteTab]
 
     public var description: String {
-        return "<Client guid: \(client.guid ?? "nil"), \(tabs.count) tabs.>"
+        "<Client guid: \(client.guid ?? "nil"), \(tabs.count) tabs.>"
     }
 
     public init(client: RemoteClient, tabs: [RemoteTab]) {
@@ -20,8 +20,8 @@ public struct ClientAndTabs: Equatable, CustomStringConvertible {
 }
 
 public func == (lhs: ClientAndTabs, rhs: ClientAndTabs) -> Bool {
-    return (lhs.client == rhs.client) &&
-           (lhs.tabs == rhs.tabs)
+    (lhs.client == rhs.client) &&
+            (lhs.tabs == rhs.tabs)
 }
 
 public protocol RemoteClientsAndTabs: SyncCommands {
@@ -66,7 +66,7 @@ public struct RemoteTab: Equatable {
     }
 
     public func withClientGUID(_ clientGUID: String?) -> RemoteTab {
-        return RemoteTab(clientGUID: clientGUID, URL: URL, title: title, history: history, lastUsed: lastUsed, icon: icon)
+        RemoteTab(clientGUID: clientGUID, URL: URL, title: title, history: history, lastUsed: lastUsed, icon: icon)
     }
 
     public func toRemoteTabRecord() -> RemoteTabRecord {
@@ -80,16 +80,16 @@ public struct RemoteTab: Equatable {
 }
 
 public func == (lhs: RemoteTab, rhs: RemoteTab) -> Bool {
-    return lhs.clientGUID == rhs.clientGUID &&
-        lhs.URL == rhs.URL &&
-        lhs.title == rhs.title &&
-        lhs.history == rhs.history &&
-        lhs.lastUsed == rhs.lastUsed &&
-        lhs.icon == rhs.icon
+    lhs.clientGUID == rhs.clientGUID &&
+            lhs.URL == rhs.URL &&
+            lhs.title == rhs.title &&
+            lhs.history == rhs.history &&
+            lhs.lastUsed == rhs.lastUsed &&
+            lhs.icon == rhs.icon
 }
 
 extension RemoteTab: CustomStringConvertible {
     public var description: String {
-        return "<RemoteTab clientGUID: \(clientGUID ?? "nil"), URL: \(URL), title: \(title), lastUsed: \(lastUsed)>"
+        "<RemoteTab clientGUID: \(clientGUID ?? "nil"), URL: \(URL), title: \(title), lastUsed: \(lastUsed)>"
     }
 }

--- a/Storage/Rust/RustLogins.swift
+++ b/Storage/Rust/RustLogins.swift
@@ -40,7 +40,7 @@ public extension EncryptedLogin {
 
     var formSubmitUrl: String? {
         get {
-            return self.fields.formActionOrigin
+            self.fields.formActionOrigin
         }
         set (newValue) {
             self.fields.formActionOrigin = newValue
@@ -49,7 +49,7 @@ public extension EncryptedLogin {
 
     var httpRealm: String? {
         get {
-            return self.fields.httpRealm
+            self.fields.httpRealm
         }
         set (newValue) {
             self.fields.httpRealm = newValue
@@ -58,7 +58,7 @@ public extension EncryptedLogin {
 
     var hostname: String {
         get {
-            return self.fields.origin
+            self.fields.origin
         }
         set (newValue) {
             self.fields.origin = newValue
@@ -67,7 +67,7 @@ public extension EncryptedLogin {
 
     var usernameField: String {
         get {
-            return self.fields.usernameField
+            self.fields.usernameField
         }
         set (newValue) {
             self.fields.usernameField = newValue
@@ -76,7 +76,7 @@ public extension EncryptedLogin {
 
     var passwordField: String {
         get {
-            return self.fields.passwordField
+            self.fields.passwordField
         }
         set (newValue) {
             self.fields.passwordField = newValue
@@ -85,7 +85,7 @@ public extension EncryptedLogin {
 
     var id: String {
         get {
-            return self.record.id
+            self.record.id
         }
         set (newValue) {
             self.record.id = newValue
@@ -94,7 +94,7 @@ public extension EncryptedLogin {
 
     var timePasswordChanged: Int64 {
         get {
-            return self.record.timePasswordChanged
+            self.record.timePasswordChanged
         }
         set (newValue) {
             self.record.timePasswordChanged = newValue
@@ -103,7 +103,7 @@ public extension EncryptedLogin {
 
     var timeCreated: Int64 {
         get {
-            return self.record.timeCreated
+            self.record.timeCreated
         }
         set (newValue) {
             self.record.timeCreated = newValue
@@ -131,7 +131,7 @@ public extension EncryptedLogin {
     }
 
     var protectionSpace: URLProtectionSpace {
-        return URLProtectionSpace.fromOrigin(fields.origin)
+        URLProtectionSpace.fromOrigin(fields.origin)
     }
 
     var hasMalformedHostname: Bool {
@@ -285,7 +285,7 @@ public extension LoginEntry {
 
     var hostname: String {
         get {
-            return self.fields.origin
+            self.fields.origin
         }
         set (newValue) {
             self.fields.origin = newValue
@@ -294,7 +294,7 @@ public extension LoginEntry {
 
     var username: String {
         get {
-            return self.secFields.username
+            self.secFields.username
         }
         set (newValue) {
             self.secFields.username = newValue
@@ -303,7 +303,7 @@ public extension LoginEntry {
 
     var password: String {
         get {
-            return self.secFields.password
+            self.secFields.password
         }
         set (newValue) {
             self.secFields.password = newValue
@@ -311,11 +311,11 @@ public extension LoginEntry {
     }
 
     var protectionSpace: URLProtectionSpace {
-        return URLProtectionSpace.fromOrigin(fields.origin)
+        URLProtectionSpace.fromOrigin(fields.origin)
     }
 
     var credentials: URLCredential {
-        return URLCredential(user: self.secFields.username, password: self.secFields.password, persistence: .forSession)
+        URLCredential(user: self.secFields.username, password: self.secFields.password, persistence: .forSession)
     }
 
     var isValid: Maybe<Void> {
@@ -600,8 +600,8 @@ public class RustLogins {
                 }
             } else {
                 filteredRecords = records.filter {
-                    return $0.fields.origin == protectionSpace.urlString() ||
-                        $0.fields.origin == protectionSpace.host
+                    $0.fields.origin == protectionSpace.urlString() ||
+                            $0.fields.origin == protectionSpace.host
                 }
             }
             return deferMaybe(ArrayCursor(data: filteredRecords))
@@ -609,7 +609,7 @@ public class RustLogins {
     }
 
     public func hasSyncedLogins() -> Deferred<Maybe<Bool>> {
-        return listLogins().bind { result in
+        listLogins().bind { result in
             if let error = result.failureValue {
                 return deferMaybe(error)
             }
@@ -705,7 +705,9 @@ public class RustLogins {
     }
 
     public func deleteLogins(ids: [String]) -> Deferred<[Maybe<Bool>]> {
-        return all(ids.map { deleteLogin(id: $0) })
+        all(ids.map {
+            deleteLogin(id: $0)
+        })
     }
 
     public func deleteLogin(id: String) -> Deferred<Maybe<Bool>> {

--- a/Storage/Rust/RustPlaces.swift
+++ b/Storage/Rust/RustPlaces.swift
@@ -162,20 +162,20 @@ public class RustPlaces: BookmarksHandler {
     }
 
     public func getBookmarksTree(rootGUID: GUID, recursive: Bool) -> Deferred<Maybe<BookmarkNodeData?>> {
-        return withReader { connection in
-            return try connection.getBookmarksTree(rootGUID: rootGUID, recursive: recursive)
+        withReader { connection in
+            try connection.getBookmarksTree(rootGUID: rootGUID, recursive: recursive)
         }
     }
 
     public func getBookmark(guid: GUID) -> Deferred<Maybe<BookmarkNodeData?>> {
-        return withReader { connection in
-            return try connection.getBookmark(guid: guid)
+        withReader { connection in
+            try connection.getBookmark(guid: guid)
         }
     }
 
     public func getRecentBookmarks(limit: UInt, completion: @escaping ([BookmarkItemData]) -> Void) {
         let deferredResponse = withReader { connection in
-            return try connection.getRecentBookmarks(limit: limit)
+            try connection.getRecentBookmarks(limit: limit)
         }
 
         deferredResponse.upon { result in
@@ -184,25 +184,25 @@ public class RustPlaces: BookmarksHandler {
     }
 
     public func getRecentBookmarks(limit: UInt) -> Deferred<Maybe<[BookmarkItemData]>> {
-        return withReader { connection in
-            return try connection.getRecentBookmarks(limit: limit)
+        withReader { connection in
+            try connection.getRecentBookmarks(limit: limit)
         }
     }
 
     public func getBookmarkURLForKeyword(keyword: String) -> Deferred<Maybe<String?>> {
-        return withReader { connection in
-            return try connection.getBookmarkURLForKeyword(keyword: keyword)
+        withReader { connection in
+            try connection.getBookmarkURLForKeyword(keyword: keyword)
         }
     }
 
     public func getBookmarksWithURL(url: String) -> Deferred<Maybe<[BookmarkItemData]>> {
-        return withReader { connection in
-            return try connection.getBookmarksWithURL(url: url)
+        withReader { connection in
+            try connection.getBookmarksWithURL(url: url)
         }
     }
 
     public func isBookmarked(url: String) -> Deferred<Maybe<Bool>> {
-        return getBookmarksWithURL(url: url).bind { result in
+        getBookmarksWithURL(url: url).bind { result in
             guard let bookmarks = result.successValue else {
                 return deferMaybe(false)
             }
@@ -212,8 +212,8 @@ public class RustPlaces: BookmarksHandler {
     }
 
     public func searchBookmarks(query: String, limit: UInt) -> Deferred<Maybe<[BookmarkItemData]>> {
-        return withReader { connection in
-            return try connection.searchBookmarks(query: query, limit: limit)
+        withReader { connection in
+            try connection.searchBookmarks(query: query, limit: limit)
         }
     }
 
@@ -232,7 +232,7 @@ public class RustPlaces: BookmarksHandler {
     }
 
     public func deleteBookmarkNode(guid: GUID) -> Success {
-        return withWriter { connection in
+        withWriter { connection in
             let result = try connection.deleteBookmarkNode(guid: guid)
             if !result {
                 log.debug("Bookmark with GUID \(guid) does not exist.")
@@ -241,7 +241,7 @@ public class RustPlaces: BookmarksHandler {
     }
 
     public func deleteBookmarksWithURL(url: String) -> Success {
-        return getBookmarksWithURL(url: url) >>== { bookmarks in
+        getBookmarksWithURL(url: url) >>== { bookmarks in
             let deferreds = bookmarks.map({ self.deleteBookmarkNode(guid: $0.guid) })
             return all(deferreds).bind { results in
                 if let error = results.find({ $0.isFailure })?.failureValue {
@@ -255,20 +255,20 @@ public class RustPlaces: BookmarksHandler {
     }
 
     public func createFolder(parentGUID: GUID, title: String, position: UInt32? = nil) -> Deferred<Maybe<GUID>> {
-        return withWriter { connection in
-            return try connection.createFolder(parentGUID: parentGUID, title: title, position: position)
+        withWriter { connection in
+            try connection.createFolder(parentGUID: parentGUID, title: title, position: position)
         }
     }
 
     public func createSeparator(parentGUID: GUID, position: UInt32? = nil) -> Deferred<Maybe<GUID>> {
-        return withWriter { connection in
-            return try connection.createSeparator(parentGUID: parentGUID, position: position)
+        withWriter { connection in
+            try connection.createSeparator(parentGUID: parentGUID, position: position)
         }
     }
 
     @discardableResult
     public func createBookmark(parentGUID: GUID, url: String, title: String?, position: UInt32? = nil) -> Deferred<Maybe<GUID>> {
-        return withWriter { connection in
+        withWriter { connection in
             let response = try connection.createBookmark(parentGUID: parentGUID, url: url, title: title, position: position)
             self.notificationCenter.post(name: .BookmarksUpdated, object: self)
             return response
@@ -276,8 +276,8 @@ public class RustPlaces: BookmarksHandler {
     }
 
     public func updateBookmarkNode(guid: GUID, parentGUID: GUID? = nil, position: UInt32? = nil, title: String? = nil, url: String? = nil) -> Success {
-        return withWriter { connection in
-            return try connection.updateBookmarkNode(guid: guid, parentGUID: parentGUID, position: position, title: title, url: url)
+        withWriter { connection in
+            try connection.updateBookmarkNode(guid: guid, parentGUID: parentGUID, position: position, title: title, url: url)
         }
     }
 
@@ -360,20 +360,20 @@ public class RustPlaces: BookmarksHandler {
     }
 
     public func getHistoryMetadataSince(since: Int64) -> Deferred<Maybe<[HistoryMetadata]>> {
-        return withReader { connection in
-            return try connection.getHistoryMetadataSince(since: since)
+        withReader { connection in
+            try connection.getHistoryMetadataSince(since: since)
         }
     }
 
     public func getHighlights(weights: HistoryHighlightWeights, limit: Int32) -> Deferred<Maybe<[HistoryHighlight]>> {
-        return withReader { connection in
-            return try connection.getHighlights(weights: weights, limit: limit)
+        withReader { connection in
+            try connection.getHighlights(weights: weights, limit: limit)
         }
     }
 
     public func queryHistoryMetadata(query: String, limit: Int32) -> Deferred<Maybe<[HistoryMetadata]>> {
-        return withReader { connection in
-            return try connection.queryHistoryMetadata(query: query, limit: limit)
+        withReader { connection in
+            try connection.queryHistoryMetadata(query: query, limit: limit)
         }
     }
 
@@ -381,7 +381,7 @@ public class RustPlaces: BookmarksHandler {
         Title observations must be made first for any given url. Observe one fact at a time (e.g. just the viewTime, or just the documentType).
      */
     public func noteHistoryMetadataObservation(key: HistoryMetadataKey, observation: HistoryMetadataObservation) -> Deferred<Maybe<Void>> {
-        return withWriter { connection in
+        withWriter { connection in
             if let title = observation.title {
                 return try connection.noteHistoryMetadataObservationTitle(key: key, title: title)
             }
@@ -395,20 +395,20 @@ public class RustPlaces: BookmarksHandler {
     }
 
     public func deleteHistoryMetadataOlderThan(olderThan: Int64) -> Deferred<Maybe<Void>> {
-        return withWriter { connection in
-            return try connection.deleteHistoryMetadataOlderThan(olderThan: olderThan)
+        withWriter { connection in
+            try connection.deleteHistoryMetadataOlderThan(olderThan: olderThan)
         }
     }
 
     public func deleteHistoryMetadata(key: HistoryMetadataKey) -> Deferred<Maybe<Void>> {
-        return withWriter { connection in
-            return try connection.deleteHistoryMetadata(key: key)
+        withWriter { connection in
+            try connection.deleteHistoryMetadata(key: key)
         }
     }
 
     public func deleteVisitsFor(url: Url) -> Deferred<Maybe<Void>> {
-        return withWriter { connection in
-            return try connection.deleteVisitsFor(url: url)
+        withWriter { connection in
+            try connection.deleteVisitsFor(url: url)
         }
     }
 }

--- a/Storage/Rust/RustRemoteTabs.swift
+++ b/Storage/Rust/RustRemoteTabs.swift
@@ -170,6 +170,11 @@ public extension RemoteTabRecord {
 
 public extension ClientRemoteTabs {
     func toClientAndTabs(client: RemoteClient) -> ClientAndTabs {
-        return ClientAndTabs(client: client, tabs: self.remoteTabs.map { $0.toRemoteTab(client: client)}.compactMap { $0 })
+        ClientAndTabs(client: client, tabs: self.remoteTabs.map {
+                    $0.toRemoteTab(client: client)
+                }
+                .compactMap {
+                    $0
+                })
     }
 }

--- a/Storage/SQL/BrowserSchema.swift
+++ b/Storage/SQL/BrowserSchema.swift
@@ -145,8 +145,12 @@ private let log = Logger.syncLogger
 open class BrowserSchema: Schema {
     static let DefaultVersion = 41    // PR #10553.
 
-    public var name: String { return "BROWSER" }
-    public var version: Int { return BrowserSchema.DefaultVersion }
+    public var name: String {
+        "BROWSER"
+    }
+    public var version: Int {
+        BrowserSchema.DefaultVersion
+    }
 
     let sqliteVersion: Int32
     let supportsPartialIndices: Bool
@@ -202,7 +206,7 @@ open class BrowserSchema: Schema {
     }
 
     func runValidQueries(_ db: SQLiteDBConnection, queries: [String?]) -> Bool {
-        return self.run(db, queries: optFilter(queries))
+        self.run(db, queries: optFilter(queries))
     }
 
     func prepopulateRootFolders(_ db: SQLiteDBConnection) -> Bool {

--- a/Storage/SQL/ReadingListSchema.swift
+++ b/Storage/SQL/ReadingListSchema.swift
@@ -13,8 +13,12 @@ private let log = Logger.syncLogger
 open class ReadingListSchema: Schema {
     static let DefaultVersion = 1
 
-    public var name: String { return "READINGLIST" }
-    public var version: Int { return ReadingListSchema.DefaultVersion }
+    public var name: String {
+        "READINGLIST"
+    }
+    public var version: Int {
+        ReadingListSchema.DefaultVersion
+    }
 
     public init() {}
 
@@ -34,7 +38,7 @@ open class ReadingListSchema: Schema {
         """
 
     public func create(_ db: SQLiteDBConnection) -> Bool {
-        return self.run(db, queries: [itemsTableCreate])
+        self.run(db, queries: [itemsTableCreate])
     }
 
     public func update(_ db: SQLiteDBConnection, from: Int) -> Bool {

--- a/Storage/SQL/SQLiteFavicons.swift
+++ b/Storage/SQL/SQLiteFavicons.swift
@@ -61,7 +61,7 @@ open class SQLiteFavicons {
     }
 
     public func insertOrUpdateFavicon(_ favicon: Favicon) -> Deferred<Maybe<Int>> {
-        return db.withConnection { conn -> Int in
+        db.withConnection { conn -> Int in
             self.insertOrUpdateFaviconInTransaction(favicon, conn: conn) ?? 0
         }
     }

--- a/Storage/SQL/SQLiteHistoryFavicons.swift
+++ b/Storage/SQL/SQLiteHistoryFavicons.swift
@@ -17,7 +17,7 @@ private var urlSession: URLSession = makeURLSession(userAgent: UserAgent.desktop
 
 // If all else fails, this is the default "default" icon.
 private var defaultFavicon: UIImage = {
-    return UIImage(named: "defaultFavicon")!
+    UIImage(named: "defaultFavicon")!
 }()
 
 // An in-memory cache of "default" favicons keyed by the
@@ -58,7 +58,7 @@ class FaviconLookupError: MaybeErrorType {
         self.siteURL = siteURL
     }
     var description: String {
-        return "Unable to find favicon for site URL: \(siteURL)"
+        "Unable to find favicon for site URL: \(siteURL)"
     }
 }
 
@@ -68,7 +68,7 @@ class FaviconDownloadError: MaybeErrorType {
         self.faviconURL = faviconURL
     }
     internal var description: String {
-        return "Unable to download favicon at URL: \(faviconURL)"
+        "Unable to download favicon at URL: \(faviconURL)"
     }
 }
 
@@ -92,7 +92,7 @@ extension SQLiteHistory: Favicons {
     }
 
     public func addFavicon(_ icon: Favicon) -> Deferred<Maybe<Int>> {
-        return self.favicons.insertOrUpdateFavicon(icon)
+        self.favicons.insertOrUpdateFavicon(icon)
     }
 
     /**
@@ -101,7 +101,7 @@ extension SQLiteHistory: Favicons {
      */
     public func addFavicon(_ icon: Favicon, forSite site: Site) -> Deferred<Maybe<Int>> {
         func doChange(_ query: String, args: Args?) -> Deferred<Maybe<Int>> {
-            return db.withConnection { conn -> Int in
+            db.withConnection { conn -> Int in
                 // Blind! We don't see failure here.
                 let id = self.favicons.insertOrUpdateFaviconInTransaction(icon, conn: conn)
 
@@ -148,7 +148,7 @@ extension SQLiteHistory: Favicons {
 
     public func getFaviconImage(forSite site: Site) -> Deferred<Maybe<UIImage>> {
         // First, attempt to lookup the favicon from our bundled top sites.
-        return getTopSitesFaviconImage(forSite: site).bind { result in
+        getTopSitesFaviconImage(forSite: site).bind { result in
             guard let image = result.successValue else {
                 // Second, attempt to lookup the favicon URL from the database.
                 return self.lookupFaviconURLFromDatabase(forSite: site).bind { result in
@@ -323,7 +323,7 @@ extension SQLiteHistory: Favicons {
 
     // Scrapes the web page at the specified URL for its favicon URLs.
     fileprivate func getFaviconURLsFromWebPage(url: URL) -> Deferred<Maybe<[URL]>> {
-        return getHTMLDocumentFromWebPage(url: url).bind { result in
+        getHTMLDocumentFromWebPage(url: url).bind { result in
             guard let document = result.successValue else {
                 return deferMaybe(FaviconLookupError(siteURL: url.absoluteString))
             }
@@ -332,10 +332,10 @@ extension SQLiteHistory: Favicons {
             // URL, go to the redirected page for the favicon instead.
             for meta in document.xpath("//head/meta") {
                 if let refresh = meta["http-equiv"], refresh == "Refresh",
-                    let content = meta["content"],
-                    let index = content.range(of: "URL="),
-                    let reloadURL = URL(string: String(content[index.upperBound...])),
-                    reloadURL != url {
+                   let content = meta["content"],
+                   let index = content.range(of: "URL="),
+                   let reloadURL = URL(string: String(content[index.upperBound...])),
+                   reloadURL != url {
                     return self.getFaviconURLsFromWebPage(url: reloadURL)
                 }
             }

--- a/Storage/SQL/SQLiteQueue.swift
+++ b/Storage/SQL/SQLiteQueue.swift
@@ -21,14 +21,14 @@ open class SQLiteQueue: TabQueue {
     }
 
     fileprivate func factory(_ row: SDRow) -> ShareItem {
-        return ShareItem(url: row["url"] as! String, title: row["title"] as? String, favicon: nil)
+        ShareItem(url: row["url"] as! String, title: row["title"] as? String, favicon: nil)
     }
 
     open func getQueuedTabs() -> Deferred<Maybe<Cursor<ShareItem>>> {
-        return db.runQuery("SELECT url, title FROM queue", args: nil, factory: self.factory)
+        db.runQuery("SELECT url, title FROM queue", args: nil, factory: self.factory)
     }
 
     open func clearQueuedTabs() -> Success {
-        return db.run("DELETE FROM queue")
+        db.run("DELETE FROM queue")
     }
 }

--- a/Storage/SQL/SQLiteReadingList.swift
+++ b/Storage/SQL/SQLiteReadingList.swift
@@ -14,7 +14,7 @@ public class ReadingListStorageError: MaybeErrorType {
         self.message = message
     }
     public var description: String {
-        return message
+        message
     }
 }
 
@@ -36,7 +36,7 @@ extension SQLiteReadingList: ReadingList {
     public func getAvailableRecords(completion: @escaping ([ReadingListItem]) -> Void) {
         let sql = "SELECT \(allColumns) FROM items ORDER BY client_last_modified DESC"
         let deferredResponse = db.runQuery(sql, args: nil, factory: SQLiteReadingList.ReadingListItemFactory) >>== { cursor in
-            return deferMaybe(cursor.asArray())
+            deferMaybe(cursor.asArray())
         }
 
         deferredResponse.upon { result in
@@ -47,7 +47,7 @@ extension SQLiteReadingList: ReadingList {
     public func getAvailableRecords() -> Deferred<Maybe<[ReadingListItem]>> {
         let sql = "SELECT \(allColumns) FROM items ORDER BY client_last_modified DESC"
         return db.runQuery(sql, args: nil, factory: SQLiteReadingList.ReadingListItemFactory) >>== { cursor in
-            return deferMaybe(cursor.asArray())
+            deferMaybe(cursor.asArray())
         }
     }
 
@@ -63,7 +63,7 @@ extension SQLiteReadingList: ReadingList {
     }
 
     public func createRecordWithURL(_ url: String, title: String, addedBy: String) -> Deferred<Maybe<ReadingListItem>> {
-        return db.transaction { connection -> ReadingListItem in
+        db.transaction { connection -> ReadingListItem in
             let insertSQL = "INSERT OR REPLACE INTO items (client_last_modified, url, title, added_by) VALUES (?, ?, ?, ?)"
             let insertArgs: Args = [ReadingListNow(), url, title, addedBy]
             let lastInsertedRowID = connection.lastInsertedRowID
@@ -103,7 +103,7 @@ extension SQLiteReadingList: ReadingList {
     }
 
     public func updateRecord(_ record: ReadingListItem, unread: Bool) -> Deferred<Maybe<ReadingListItem>> {
-        return db.transaction { connection -> ReadingListItem in
+        db.transaction { connection -> ReadingListItem in
             let updateSQL = "UPDATE items SET unread = ? WHERE client_id = ?"
             let updateArgs: Args = [unread, record.id]
 

--- a/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
+++ b/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
@@ -56,13 +56,13 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
     }
 
     open func wipeClients() -> Success {
-        return db.run("DELETE FROM clients")
+        db.run("DELETE FROM clients")
     }
 
     open func insertOrUpdateClients(_ clients: [RemoteClient]) -> Deferred<Maybe<Int>> {
         // TODO: insert multiple clients in a single query.
         // ORM systems are foolish.
-        return db.transaction { connection -> Int in
+        db.transaction { connection -> Int in
             var succeeded = 0
 
             // Update or insert client records.
@@ -109,7 +109,7 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
     }
 
     open func insertOrUpdateClient(_ client: RemoteClient) -> Deferred<Maybe<Int>> {
-        return insertOrUpdateClients([client])
+        insertOrUpdateClients([client])
     }
 
     open func deleteClient(guid: GUID) -> Success {
@@ -134,10 +134,10 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
     }
 
     open func getClients() -> Deferred<Maybe<[RemoteClient]>> {
-        return db.withConnection { connection -> [RemoteClient] in
+        db.withConnection { connection -> [RemoteClient] in
             let cursor = connection.executeQuery(
-                "SELECT * FROM clients WHERE EXISTS (SELECT 1 FROM remote_devices rd WHERE rd.guid = fxaDeviceId) ORDER BY modified DESC",
-                factory: SQLiteRemoteClientsAndTabs.remoteClientFactory)
+                    "SELECT * FROM clients WHERE EXISTS (SELECT 1 FROM remote_devices rd WHERE rd.guid = fxaDeviceId) ORDER BY modified DESC",
+                    factory: SQLiteRemoteClientsAndTabs.remoteClientFactory)
             defer {
                 cursor.close()
             }
@@ -155,19 +155,19 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
     }
 
     open func deleteCommands() -> Success {
-        return db.run("DELETE FROM commands")
+        db.run("DELETE FROM commands")
     }
 
     open func deleteCommands(_ clientGUID: GUID) -> Success {
-        return db.run("DELETE FROM commands WHERE client_guid = ?", withArgs: [clientGUID] as Args)
+        db.run("DELETE FROM commands WHERE client_guid = ?", withArgs: [clientGUID] as Args)
     }
 
     open func insertCommand(_ command: SyncCommand, forClients clients: [RemoteClient]) -> Deferred<Maybe<Int>> {
-        return insertCommands([command], forClients: clients)
+        insertCommands([command], forClients: clients)
     }
 
     open func insertCommands(_ commands: [SyncCommand], forClients clients: [RemoteClient]) -> Deferred<Maybe<Int>> {
-        return db.transaction { connection -> Int in
+        db.transaction { connection -> Int in
             var numberOfInserts = 0
 
             // Update or insert client records.
@@ -192,12 +192,12 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
     }
 
     open func getCommands() -> Deferred<Maybe<[GUID: [SyncCommand]]>> {
-        return db.withConnection { connection -> [GUID: [SyncCommand]] in
+        db.withConnection { connection -> [GUID: [SyncCommand]] in
             let cursor = connection.executeQuery("SELECT * FROM commands", factory: { row -> SyncCommand in
                 SyncCommand(
-                    id: row["command_id"] as? Int,
-                    value: row["value"] as! String,
-                    clientGUID: row["client_guid"] as? GUID)
+                        id: row["command_id"] as? Int,
+                        value: row["value"] as! String,
+                        clientGUID: row["client_guid"] as? GUID)
             })
             defer {
                 cursor.close()
@@ -259,11 +259,11 @@ extension SQLiteRemoteClientsAndTabs: RemoteDevices {
 extension SQLiteRemoteClientsAndTabs: ResettableSyncStorage {
     public func resetClient() -> Success {
         // For this engine, resetting is equivalent to wiping.
-        return self.clear()
+        self.clear()
     }
 
     public func clear() -> Success {
-        return db.transaction { conn -> Void in
+        db.transaction { conn -> Void in
             try conn.executeChange("DELETE FROM tabs WHERE client_guid IS NOT NULL")
             try conn.executeChange("DELETE FROM clients")
         }

--- a/Storage/Sharing.swift
+++ b/Storage/Sharing.swift
@@ -20,7 +20,7 @@ public struct ShareItem {
 
     // We only support sharing HTTP and HTTPS URLs, as well as data URIs.
     public var isShareable: Bool {
-        return URL(string: url)?.isWebPage() ?? false
+        URL(string: url)?.isWebPage() ?? false
     }
 }
 

--- a/Storage/Site.swift
+++ b/Storage/Site.swift
@@ -10,7 +10,7 @@ public protocol Identifiable: Equatable {
 }
 
 public func ==<T> (lhs: T, rhs: T) -> Bool where T: Identifiable {
-    return lhs.id == rhs.id
+    lhs.id == rhs.id
 }
 
 open class Favicon: Identifiable {
@@ -34,12 +34,12 @@ open class Site: Identifiable {
     open var guid: String?
 
     open var tileURL: URL {
-        return URL(string: url)?.domainURL ?? URL(string: "about:blank")!
+        URL(string: url)?.domainURL ?? URL(string: "about:blank")!
     }
 
     // i.e. `http://www.example.com/` --> `example`
     open var secondLevelDomain: String? {
-        return URL(string: url)?.host?.components(separatedBy: ".").suffix(2).first
+        URL(string: url)?.host?.components(separatedBy: ".").suffix(2).first
     }
 
     public let url: String

--- a/Storage/SuggestedSites.swift
+++ b/Storage/SuggestedSites.swift
@@ -7,7 +7,7 @@ import Shared
 
 open class SuggestedSite: Site {
     override open var tileURL: URL {
-        return URL(string: url as String) ?? URL(string: "about:blank")!
+        URL(string: url as String) ?? URL(string: "about:blank")!
     }
 
     let trackingId: Int

--- a/Storage/SyncQueue.swift
+++ b/Storage/SyncQueue.swift
@@ -45,12 +45,12 @@ public struct SyncCommand: Equatable {
     }
 
     public func withClientGUID(_ clientGUID: String?) -> SyncCommand {
-        return SyncCommand(id: self.commandID, value: self.value, clientGUID: clientGUID)
+        SyncCommand(id: self.commandID, value: self.value, clientGUID: clientGUID)
     }
 }
 
 public func == (lhs: SyncCommand, rhs: SyncCommand) -> Bool {
-    return lhs.value == rhs.value
+    lhs.value == rhs.value
 }
 
 public protocol SyncCommands {

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -41,7 +41,7 @@ private let log = Logger.syncLogger
 
 public class DBOperationCancelled : MaybeErrorType {
     public var description: String {
-        return "Database operation cancelled"
+        "Database operation cancelled"
     }
 }
 
@@ -211,7 +211,7 @@ open class SwiftData {
      * The code block can return true if the transaction should be committed. False if we should roll back.
      */
     func transaction<T>(synchronous: Bool = false, _ transactionClosure: @escaping (_ connection: SQLiteDBConnection) throws -> T) -> Deferred<Maybe<T>> {
-        return withConnection(SwiftData.Flags.readWriteCreate, synchronous: synchronous) { connection in
+        withConnection(SwiftData.Flags.readWriteCreate, synchronous: synchronous) { connection in
             try connection.transaction(transactionClosure)
         }
     }
@@ -389,7 +389,7 @@ class FailedSQLiteDBConnection: SQLiteDBConnection {
     var version: Int = 0
 
     fileprivate func fail(_ str: String) -> NSError {
-        return NSError(domain: "mozilla", code: 0, userInfo: [NSLocalizedDescriptionKey: str])
+        NSError(domain: "mozilla", code: 0, userInfo: [NSLocalizedDescriptionKey: str])
     }
 
     func executeChange(_ sqlStr: String, withArgs args: Args?) throws -> Void {
@@ -400,13 +400,13 @@ class FailedSQLiteDBConnection: SQLiteDBConnection {
     }
 
     func executeQuery<T>(_ sqlStr: String, factory: @escaping (SDRow) -> T) -> Cursor<T> {
-        return Cursor<T>(err: fail("Non-open connection; can't execute query."))
+        Cursor<T>(err: fail("Non-open connection; can't execute query."))
     }
     func executeQuery<T>(_ sqlStr: String, factory: @escaping (SDRow) -> T, withArgs args: Args?) -> Cursor<T> {
-        return Cursor<T>(err: fail("Non-open connection; can't execute query."))
+        Cursor<T>(err: fail("Non-open connection; can't execute query."))
     }
     func executeQueryUnsafe<T>(_ sqlStr: String, factory: @escaping (SDRow) -> T, withArgs args: Args?) -> Cursor<T> {
-        return Cursor<T>(err: fail("Non-open connection; can't execute query."))
+        Cursor<T>(err: fail("Non-open connection; can't execute query."))
     }
 
     func transaction<T>(_ transactionClosure: @escaping (_ connection: SQLiteDBConnection) throws -> T) throws -> T {
@@ -427,19 +427,19 @@ class FailedSQLiteDBConnection: SQLiteDBConnection {
 
 open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
     open var lastInsertedRowID: Int64 {
-        return Int64(sqlite3_last_insert_rowid(sqliteDB))
+        Int64(sqlite3_last_insert_rowid(sqliteDB))
     }
 
     open var numberOfRowsModified: Int {
-        return Int(sqlite3_changes(sqliteDB))
+        Int(sqlite3_changes(sqliteDB))
     }
 
     open var version: Int {
-        return pragma("user_version", factory: IntFactory) ?? 0
+        pragma("user_version", factory: IntFactory) ?? 0
     }
 
     open var cipherVersion: String? {
-        return pragma("cipher_version", factory: StringFactory)
+        pragma("cipher_version", factory: StringFactory)
     }
 
     fileprivate var sqliteDB: OpaquePointer?
@@ -1067,14 +1067,14 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
     }
 
     public func executeQuery<T>(_ sqlStr: String, factory: @escaping (SDRow) -> T) -> Cursor<T> {
-        return self.executeQuery(sqlStr, factory: factory, withArgs: nil)
+        self.executeQuery(sqlStr, factory: factory, withArgs: nil)
     }
 
     func explain(query sqlStr: String, withArgs args: Args?) {
         do {
             let qp = try SQLiteDBStatement(connection: self, query: "EXPLAIN QUERY PLAN \(sqlStr)", args: args)
             let qpFactory: (SDRow) -> String = { row in
-                return "id: \(row[0] as! Int), order: \(row[1] as! Int), from: \(row[2] as! Int), details: \(row[3] as! String)"
+                "id: \(row[0] as! Int), order: \(row[1] as! Int), from: \(row[2] as! Int), details: \(row[3] as! String)"
             }
             let qpCursor = FilledSQLiteCursor<String>(statement: qp, factory: qpFactory)
             print("⦿ EXPLAIN QUERY (Columns: id, order, from, details) ---------------- ")
@@ -1243,12 +1243,12 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
 
 /// Helper for queries that return a single integer result.
 func IntFactory(_ row: SDRow) -> Int {
-    return row[0] as! Int
+    row[0] as! Int
 }
 
 /// Helper for queries that return a single String result.
 func StringFactory(_ row: SDRow) -> String {
-    return row[0] as! String
+    row[0] as! String
 }
 
 /// Wrapper around a statement for getting data from a row. This provides accessors for subscript indexing
@@ -1299,7 +1299,7 @@ open class SDRow: Sequence {
 
     // Accessor getting column 'key' in the row
     public subscript(key: Int) -> Any? {
-        return getValue(key)
+        getValue(key)
     }
 
     // Accessor getting a named column in the row. This (currently) depends on

--- a/Storage/Visit.swift
+++ b/Storage/Visit.swift
@@ -87,8 +87,8 @@ open class Visit: Hashable {
 }
 
 public func == (lhs: Visit, rhs: Visit) -> Bool {
-    return lhs.date == rhs.date &&
-           lhs.type == rhs.type
+    lhs.date == rhs.date &&
+            lhs.type == rhs.type
 }
 
 open class SiteVisit: Visit {

--- a/Sync/CleartextPayloadJSON.swift
+++ b/Sync/CleartextPayloadJSON.swift
@@ -18,13 +18,13 @@ open class BasePayloadJSON {
 
     // Override me.
     public func isValid() -> Bool {
-        return self.json.type != .unknown &&
-               self.json.error == nil
+        self.json.type != .unknown &&
+                self.json.error == nil
     }
 
     subscript(key: String) -> JSON {
         get {
-            return json[key]
+            json[key]
         }
     }
 }
@@ -45,11 +45,11 @@ open class CleartextPayloadJSON: BasePayloadJSON {
 
     // Override me.
     override open func isValid() -> Bool {
-        return super.isValid() && self["id"].isString()
+        super.isValid() && self["id"].isString()
     }
 
     open var id: String {
-        return self["id"].string!
+        self["id"].string!
     }
 
     open var deleted: Bool {
@@ -64,6 +64,6 @@ open class CleartextPayloadJSON: BasePayloadJSON {
     // Override me.
     // Doesn't check id. Should it?
     open func equalPayloads (_ obj: CleartextPayloadJSON) -> Bool {
-        return self.deleted == obj.deleted
+        self.deleted == obj.deleted
     }
 }

--- a/Sync/ClientPayload.swift
+++ b/Sync/ClientPayload.swift
@@ -21,15 +21,15 @@ open class ClientPayload: CleartextPayloadJSON {
     }
 
     var commands: [JSON] {
-        return self["commands"].array ?? []   // It might not be present at all.
+        self["commands"].array ?? []   // It might not be present at all.
     }
 
     var name: String {
-        return self["name"].stringValue
+        self["name"].stringValue
     }
 
     var clientType: String {
-        return self["type"].stringValue
+        self["type"].stringValue
     }
 
     override open func equalPayloads(_ obj: CleartextPayloadJSON) -> Bool {

--- a/Sync/EncryptedJSON.swift
+++ b/Sync/EncryptedJSON.swift
@@ -52,7 +52,7 @@ open class EncryptedJSON {
      * You probably want to call validate() and then use .ciphertext.
      */
     fileprivate var ciphertextBytes: Data? {
-        return Bytes.decodeBase64(self["ciphertext"].string!)
+        Bytes.decodeBase64(self["ciphertext"].string!)
     }
 
     fileprivate func validate() -> Bool {
@@ -102,7 +102,7 @@ open class EncryptedJSON {
     }
 
     open func isValid() -> Bool {
-        return !json.isError() && self.validate()
+        !json.isError() && self.validate()
     }
 
     /**
@@ -159,7 +159,7 @@ open class EncryptedJSON {
 
     subscript(key: String) -> JSON {
         get {
-            return json[key]
+            json[key]
         }
 
         set {

--- a/Sync/EnvelopeJSON.swift
+++ b/Sync/EnvelopeJSON.swift
@@ -18,22 +18,22 @@ open class EnvelopeJSON {
     }
 
     open func isValid() -> Bool {
-        return !self.json.isError() &&
-            self.json["id"].isString() &&
-            // self["collection"].isString &&
-            self.json["payload"].isString()
+        !self.json.isError() &&
+                self.json["id"].isString() &&
+                // self["collection"].isString &&
+                self.json["payload"].isString()
     }
 
     open var id: String {
-        return self.json["id"].string!
+        self.json["id"].string!
     }
 
     open var collection: String {
-        return self.json["collection"].string ?? ""
+        self.json["collection"].string ?? ""
     }
 
     open var payload: String {
-        return self.json["payload"].string!
+        self.json["payload"].string!
     }
 
     open var sortindex: Int {
@@ -54,7 +54,7 @@ open class EnvelopeJSON {
     }
 
     open func stringify() -> String {
-        return self.json.stringify()!
+        self.json.stringify()!
     }
 
     open func withModified(_ now: Timestamp) -> EnvelopeJSON {
@@ -68,6 +68,6 @@ open class EnvelopeJSON {
 
 extension EnvelopeJSON {
     func asJSON() -> JSON {
-        return self.json
+        self.json
     }
 }

--- a/Sync/HistoryPayload.swift
+++ b/Sync/HistoryPayload.swift
@@ -31,7 +31,7 @@ open class HistoryPayload: CleartextPayloadJSON {
     }
 
     open func asPlace() -> Place {
-        return Place(guid: self.id, url: self.histURI, title: self.title)
+        Place(guid: self.id, url: self.histURI, title: self.title)
     }
 
     var visits: [Visit] {
@@ -40,15 +40,15 @@ open class HistoryPayload: CleartextPayloadJSON {
     }
 
     fileprivate var histURI: String {
-        return self["histUri"].string!
+        self["histUri"].string!
     }
 
     var historyURI: URL {
-        return self.histURI.asURL!
+        self.histURI.asURL!
     }
 
     var title: String {
-        return self["title"].string ?? ""
+        self["title"].string ?? ""
     }
 
     override open func equalPayloads(_ obj: CleartextPayloadJSON) -> Bool {

--- a/Sync/Info.swift
+++ b/Sync/Info.swift
@@ -29,11 +29,11 @@ open class InfoCollections {
     }
 
     open func collectionNames() -> [String] {
-        return Array(self.collections.keys)
+        Array(self.collections.keys)
     }
 
     open func modified(_ collection: String) -> Timestamp? {
-        return self.collections[collection]
+        self.collections[collection]
     }
 
     // Two I/Cs are the same if they have the same modified times for a set of

--- a/Sync/Keys.swift
+++ b/Sync/Keys.swift
@@ -23,7 +23,7 @@ import SwiftyJSON
  * For this reason, be careful trying to simplify or improve this code.
  */
 public func keysPayloadFactory<T: CleartextPayloadJSON>(keyBundle: KeyBundle, _ f: @escaping (JSON) -> T) -> (String) -> T? {
-    return { (payload: String) -> T? in
+    { (payload: String) -> T? in
         let potential = EncryptedJSON(json: payload, keyBundle: keyBundle)
         if !potential.isValid() {
             return nil
@@ -39,7 +39,7 @@ public func keysPayloadFactory<T: CleartextPayloadJSON>(keyBundle: KeyBundle, _ 
 
 // TODO: how much do we want to move this into EncryptedJSON?
 public func keysPayloadSerializer<T: CleartextPayloadJSON>(keyBundle: KeyBundle, _ f: @escaping (T) -> JSON) -> (Record<T>) -> JSON? {
-    return { (record: Record<T>) -> JSON? in
+    { (record: Record<T>) -> JSON? in
         let json = f(record.payload)
         if json.isNull() {
             // This should never happen, but if it does, we don't want to leak this
@@ -51,7 +51,9 @@ public func keysPayloadSerializer<T: CleartextPayloadJSON>(keyBundle: KeyBundle,
         // `rawData` simply calls JSONSerialization.dataWithJSONObject:options:error, which
         // guarantees UTF-8 encoded output.
 
-        guard let bytes: Data = try? json.rawData(options: []) else { return nil }
+        guard let bytes: Data = try? json.rawData(options: []) else {
+            return nil
+        }
 
         // Given a valid non-null JSON object, we don't ever expect a round-trip to fail.
         assert(!JSON(bytes).isNull())
@@ -72,9 +74,9 @@ public func keysPayloadSerializer<T: CleartextPayloadJSON>(keyBundle: KeyBundle,
                 let obj = ["id": record.id,
                            "sortindex": record.sortindex,
                            // This is how SwiftyJSON wants us to express a null that we want to
-                    // serialize. Yes, this is gross.
-                    "ttl": record.ttl ?? NSNull(),
-                    "payload": payload]
+                           // serialize. Yes, this is gross.
+                           "ttl": record.ttl ?? NSNull(),
+                           "payload": payload]
                 return JSON(obj)
             }
         }
@@ -111,7 +113,7 @@ open class Keys: Equatable {
     }
 
     open class func random() -> Keys {
-        return Keys(defaultBundle: KeyBundle.random())
+        Keys(defaultBundle: KeyBundle.random())
     }
 
     open func forCollection(_ collection: String) -> KeyBundle {
@@ -122,7 +124,7 @@ open class Keys: Equatable {
     }
 
     open func encrypter<T>(_ collection: String, encoder: RecordEncoder<T>) -> RecordEncrypter<T> {
-        return RecordEncrypter(bundle: forCollection(collection), encoder: encoder)
+        RecordEncrypter(bundle: forCollection(collection), encoder: encoder)
     }
 
     open func asPayload() -> KeysPayload {
@@ -136,9 +138,9 @@ open class Keys: Equatable {
     }
 
     public static func == (lhs: Keys, rhs: Keys) -> Bool {
-        return lhs.valid == rhs.valid &&
-            lhs.defaultBundle == rhs.defaultBundle &&
-            lhs.collectionKeys == rhs.collectionKeys
+        lhs.valid == rhs.valid &&
+                lhs.defaultBundle == rhs.defaultBundle &&
+                lhs.collectionKeys == rhs.collectionKeys
     }
 }
 

--- a/Sync/KeysPayload.swift
+++ b/Sync/KeysPayload.swift
@@ -9,8 +9,8 @@ import SwiftyJSON
 
 open class KeysPayload: CleartextPayloadJSON {
     override open func isValid() -> Bool {
-        return super.isValid() &&
-               self["default"].isArray()
+        super.isValid() &&
+                self["default"].isArray()
     }
 
     fileprivate func keyBundleFromPair(_ input: JSON) -> KeyBundle? {
@@ -25,7 +25,7 @@ open class KeysPayload: CleartextPayloadJSON {
     }
 
     var defaultKeys: KeyBundle? {
-        return self.keyBundleFromPair(self["default"])
+        self.keyBundleFromPair(self["default"])
     }
 
     var collectionKeys: [String: KeyBundle] {

--- a/Sync/LoginPayload.swift
+++ b/Sync/LoginPayload.swift
@@ -80,31 +80,31 @@ open class LoginPayload: CleartextPayloadJSON {
     }
 
     open var hostname: String {
-        return self["hostname"].string!
+        self["hostname"].string!
     }
 
     open var username: String {
-        return self["username"].string!
+        self["username"].string!
     }
 
     open var password: String {
-        return self["password"].string!
+        self["password"].string!
     }
 
     open var usernameField: String {
-        return self["usernameField"].string!
+        self["usernameField"].string!
     }
 
     open var passwordField: String {
-        return self["passwordField"].string!
+        self["passwordField"].string!
     }
 
     open var formSubmitUrl: String? {
-        return self["formSubmitUrl"].string
+        self["formSubmitUrl"].string
     }
 
     open var httpRealm: String? {
-        return self["httpRealm"].string
+        self["httpRealm"].string
     }
 
     fileprivate func timestamp(_ field: String) -> Timestamp? {
@@ -116,19 +116,19 @@ open class LoginPayload: CleartextPayloadJSON {
     }
 
     open var timesUsed: Int? {
-        return self["timesUsed"].int
+        self["timesUsed"].int
     }
 
     open var timeCreated: Timestamp? {
-        return self.timestamp("timeCreated")
+        self.timestamp("timeCreated")
     }
 
     open var timeLastUsed: Timestamp? {
-        return self.timestamp("timeLastUsed")
+        self.timestamp("timeLastUsed")
     }
 
     open var timePasswordChanged: Timestamp? {
-        return self.timestamp("timePasswordChanged")
+        self.timestamp("timePasswordChanged")
     }
 
     override open func equalPayloads(_ obj: CleartextPayloadJSON) -> Bool {

--- a/Sync/Record.swift
+++ b/Sync/Record.swift
@@ -40,7 +40,7 @@ open class Record<T: CleartextPayloadJSON> {
     //
     // @seealso EncryptedRecord.
     open class func payloadFromPayloadString(_ envelope: EnvelopeJSON, payload: String) -> T? {
-        return T(payload)
+        T(payload)
     }
 
     // TODO: consider using error tuples.
@@ -82,17 +82,17 @@ open class Record<T: CleartextPayloadJSON> {
     }
 
     func equalIdentifiers(_ rec: Record) -> Bool {
-        return rec.id == self.id
+        rec.id == self.id
     }
 
     // Override me.
     func equalPayloads(_ rec: Record) -> Bool {
-        return equalIdentifiers(rec) && rec.payload.deleted == self.payload.deleted
+        equalIdentifiers(rec) && rec.payload.deleted == self.payload.deleted
     }
 
     func equals(_ rec: Record) -> Bool {
-        return rec.sortindex == self.sortindex &&
-               rec.modified == self.modified &&
-               equalPayloads(rec)
+        rec.sortindex == self.sortindex &&
+                rec.modified == self.modified &&
+                equalPayloads(rec)
     }
 }

--- a/Sync/State.swift
+++ b/Sync/State.swift
@@ -24,8 +24,8 @@ public struct Fetched<T: Equatable>: Equatable {
 }
 
 public func ==<T> (lhs: Fetched<T>, rhs: Fetched<T>) -> Bool {
-    return lhs.timestamp == rhs.timestamp &&
-           lhs.value == rhs.value
+    lhs.timestamp == rhs.timestamp &&
+            lhs.value == rhs.value
 }
 
 public enum LocalCommand: CustomStringConvertible, Hashable {
@@ -91,7 +91,7 @@ public enum LocalCommand: CustomStringConvertible, Hashable {
     }
 
     public var description: String {
-        return self.toJSON().description
+        self.toJSON().description
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -159,7 +159,7 @@ class PrefsBackoffStorage: BackoffStorage {
 
     var serverBackoffUntilLocalTimestamp: Timestamp? {
         get {
-            return self.prefs.unsignedLongForKey(self.key)
+            self.prefs.unsignedLongForKey(self.key)
         }
 
         set(value) {
@@ -305,7 +305,7 @@ open class Scratchpad {
         }
 
         open func build() -> Scratchpad {
-            return Scratchpad(
+            Scratchpad(
                     b: self.syncKeyBundle,
                     m: self.global,
                     k: self.keys,
@@ -323,11 +323,11 @@ open class Scratchpad {
     }
 
     open lazy var backoffStorage: BackoffStorage = {
-        return PrefsBackoffStorage(prefs: self.prefs.branch("backoff.storage"))
+        PrefsBackoffStorage(prefs: self.prefs.branch("backoff.storage"))
     }()
 
     open func evolve() -> Scratchpad.Builder {
-        return Scratchpad.Builder(p: self)
+        Scratchpad.Builder(p: self)
     }
 
     // This is never persisted.
@@ -431,11 +431,11 @@ open class Scratchpad {
 
     func freshStartWithGlobal(_ global: Fetched<MetaGlobal>) -> Scratchpad {
         // TODO: I *think* a new keyLabel is unnecessary.
-        return self.evolve()
-                   .setGlobal(global)
-                   .addLocalCommandsFromKeys(nil)
-                   .setKeys(nil)
-                   .build()
+        self.evolve()
+                .setGlobal(global)
+                .addLocalCommandsFromKeys(nil)
+                .setKeys(nil)
+                .build()
     }
 
     fileprivate class func unpickleV1FromPrefs(_ prefs: Prefs, syncKeyBundle: KeyBundle) -> Scratchpad {
@@ -556,7 +556,7 @@ open class Scratchpad {
      * overall pseudo-transaction is not atomic.
      */
     open func checkpoint() -> Scratchpad {
-        return pickle(self.prefs)
+        pickle(self.prefs)
     }
 
     func pickle(_ prefs: Prefs) -> Scratchpad {

--- a/Sync/StorageClient.swift
+++ b/Sync/StorageClient.swift
@@ -16,7 +16,7 @@ open class StorageResponseError<T>: MaybeErrorType, SyncPingFailureFormattable {
     public let response: StorageResponse<T>
 
     open var failureReasonName: SyncPingFailureReasonName {
-        return .httpError
+        .httpError
     }
 
     public init(_ response: StorageResponse<T>) {
@@ -24,17 +24,17 @@ open class StorageResponseError<T>: MaybeErrorType, SyncPingFailureFormattable {
     }
 
     open var description: String {
-        return "Error."
+        "Error."
     }
 }
 
 open class RequestError: MaybeErrorType, SyncPingFailureFormattable {
     open var failureReasonName: SyncPingFailureReasonName {
-        return .httpError
+        .httpError
     }
 
     open var description: String {
-        return "Request error."
+        "Request error."
     }
 }
 
@@ -47,13 +47,13 @@ open class BadRequestError<T>: StorageResponseError<T> {
     }
 
     override open var description: String {
-        return "Bad request."
+        "Bad request."
     }
 }
 
 open class ServerError<T>: StorageResponseError<T> {
     override open var description: String {
-        return "Server error."
+        "Server error."
     }
 
     override public init(_ response: StorageResponse<T>) {
@@ -63,7 +63,7 @@ open class ServerError<T>: StorageResponseError<T> {
 
 open class NotFound<T>: StorageResponseError<T> {
     override open var description: String {
-        return "Not found. (\(T.self))"
+        "Not found. (\(T.self))"
     }
 
     override public init(_ response: StorageResponse<T>) {
@@ -73,21 +73,21 @@ open class NotFound<T>: StorageResponseError<T> {
 
 open class RecordParseError: MaybeErrorType, SyncPingFailureFormattable {
     open var description: String {
-        return "Failed to parse record."
+        "Failed to parse record."
     }
 
     open var failureReasonName: SyncPingFailureReasonName {
-        return .otherError
+        .otherError
     }
 }
 
 open class MalformedMetaGlobalError: MaybeErrorType, SyncPingFailureFormattable {
     open var description: String {
-        return "Supplied meta/global for upload did not serialize to valid JSON."
+        "Supplied meta/global for upload did not serialize to valid JSON."
     }
 
     open var failureReasonName: SyncPingFailureReasonName {
-        return .otherError
+        .otherError
     }
 }
 
@@ -96,7 +96,7 @@ open class RecordTooLargeError: MaybeErrorType, SyncPingFailureFormattable {
     public let size: ByteCount
 
     open var failureReasonName: SyncPingFailureReasonName {
-        return .otherError
+        .otherError
     }
 
     public init(size: ByteCount, guid: GUID) {
@@ -105,7 +105,7 @@ open class RecordTooLargeError: MaybeErrorType, SyncPingFailureFormattable {
     }
 
     open var description: String {
-        return "Record \(self.guid) too large: \(size) bytes."
+        "Record \(self.guid) too large: \(size) bytes."
     }
 }
 
@@ -119,7 +119,7 @@ open class ServerInBackoffError: MaybeErrorType, SyncPingFailureFormattable {
     fileprivate let until: Timestamp
 
     open var failureReasonName: SyncPingFailureReasonName {
-        return .otherError
+        .otherError
     }
 
     open var description: String {
@@ -568,28 +568,28 @@ open class Sync15StorageClient {
     }
 
     fileprivate func getResource<T>(_ path: String, f: @escaping (JSON) -> T?) -> Deferred<Maybe<StorageResponse<T>>> {
-        return doOp(self.requestGET, path: path, f: f)
+        doOp(self.requestGET, path: path, f: f)
     }
 
     fileprivate func deleteResource<T>(_ path: String, f: @escaping (JSON) -> T?) -> Deferred<Maybe<StorageResponse<T>>> {
-        return doOp(self.requestDELETE, path: path, f: f)
+        doOp(self.requestDELETE, path: path, f: f)
     }
 
     func wipeStorage() -> Deferred<Maybe<StorageResponse<JSON>>> {
         // In Sync 1.5 it's preferred that we delete the root, not /storage.
-        return deleteResource("", f: { $0 })
+        deleteResource("", f: { $0 })
     }
 
     func deleteObject(collection: String, guid: String) -> Deferred<Maybe<StorageResponse<JSON>>> {
-        return deleteResource("storage/\(collection)/\(guid)", f: { $0 })
+        deleteResource("storage/\(collection)/\(guid)", f: { $0 })
     }
 
     func getInfoCollections() -> Deferred<Maybe<StorageResponse<InfoCollections>>> {
-        return getResource("info/collections", f: InfoCollections.fromJSON)
+        getResource("info/collections", f: InfoCollections.fromJSON)
     }
 
     func getMetaGlobal() -> Deferred<Maybe<StorageResponse<MetaGlobal>>> {
-        return getResource("storage/meta/global") { json in
+        getResource("storage/meta/global") { json in
             // We have an envelope.  Parse the meta/global record embedded in the 'payload' string.
             let envelope = EnvelopeJSON(json)
             if envelope.isValid() {
@@ -662,25 +662,25 @@ open class Sync15CollectionClient<T: CleartextPayloadJSON> {
 
     var maxBatchPostRecords: Int {
         get {
-            return infoConfig.maxPostRecords
+            infoConfig.maxPostRecords
         }
     }
 
     fileprivate func uriForRecord(_ guid: String) -> URL {
-        return self.collectionURI.appendingPathComponent(guid)
+        self.collectionURI.appendingPathComponent(guid)
     }
 
     open func newBatch(ifUnmodifiedSince: Timestamp? = nil, onCollectionUploaded: @escaping (POSTResult, Timestamp?) -> DeferredTimestamp) -> Sync15BatchClient<T> {
-        return Sync15BatchClient(config: infoConfig,
-                                 ifUnmodifiedSince: ifUnmodifiedSince,
-                                 serializeRecord: self.serializeRecord,
-                                 uploader: self.post,
-                                 onCollectionUploaded: onCollectionUploaded)
+        Sync15BatchClient(config: infoConfig,
+                ifUnmodifiedSince: ifUnmodifiedSince,
+                serializeRecord: self.serializeRecord,
+                uploader: self.post,
+                onCollectionUploaded: onCollectionUploaded)
     }
 
     // Exposed so we can batch by size.
     open func serializeRecord(_ record: Record<T>) -> String? {
-        return self.encrypter.serializer(record)?.stringify()
+        self.encrypter.serializer(record)?.stringify()
     }
 
     open func post(_ lines: [String], ifUnmodifiedSince: Timestamp?, queryParams: [URLQueryItem]? = nil) -> Deferred<Maybe<StorageResponse<POSTResult>>> {

--- a/Sync/SyncMeta.swift
+++ b/Sync/SyncMeta.swift
@@ -38,12 +38,12 @@ open class EngineConfiguration: Equatable {
 }
 
 public func == (lhs: EngineConfiguration, rhs: EngineConfiguration) -> Bool {
-    return Set(lhs.enabled) == Set(rhs.enabled)
+    Set(lhs.enabled) == Set(rhs.enabled)
 }
 
 extension EngineConfiguration: CustomStringConvertible {
     public var description: String {
-        return "EngineConfiguration(enabled: \(self.enabled.sorted()), declined: \(self.declined.sorted()))"
+        "EngineConfiguration(enabled: \(self.enabled.sorted()), declined: \(self.declined.sorted()))"
     }
 }
 
@@ -76,7 +76,7 @@ public struct EngineMeta: Equatable {
 }
 
 public func == (lhs: EngineMeta, rhs: EngineMeta) -> Bool {
-    return (lhs.version == rhs.version) && (lhs.syncID == rhs.syncID)
+    (lhs.version == rhs.version) && (lhs.syncID == rhs.syncID)
 }
 
 public struct MetaGlobal: Equatable {
@@ -105,7 +105,7 @@ public struct MetaGlobal: Equatable {
     }
 
     public func enginesPayload() -> JSON {
-        return JSON(mapValues(engines, f: { $0.toJSON() }))
+        JSON(mapValues(engines, f: { $0.toJSON() }))
     }
 
     // TODO: make a whole record JSON for this.
@@ -120,19 +120,19 @@ public struct MetaGlobal: Equatable {
     }
 
     public func withSyncID(_ syncID: String) -> MetaGlobal {
-        return MetaGlobal(syncID: syncID, storageVersion: self.storageVersion, engines: self.engines, declined: self.declined)
+        MetaGlobal(syncID: syncID, storageVersion: self.storageVersion, engines: self.engines, declined: self.declined)
     }
 
     public func engineConfiguration() -> EngineConfiguration {
-        return EngineConfiguration(enabled: Array(engines.keys), declined: declined)
+        EngineConfiguration(enabled: Array(engines.keys), declined: declined)
     }
 }
 
 public func == (lhs: MetaGlobal, rhs: MetaGlobal) -> Bool {
-    return (lhs.syncID == rhs.syncID) &&
-           (lhs.storageVersion == rhs.storageVersion) &&
-           optArrayEqual(lhs.declined, rhs: rhs.declined) &&
-           optDictionaryEqual(lhs.engines, rhs: rhs.engines)
+    (lhs.syncID == rhs.syncID) &&
+            (lhs.storageVersion == rhs.storageVersion) &&
+            optArrayEqual(lhs.declined, rhs: rhs.declined) &&
+            optDictionaryEqual(lhs.engines, rhs: rhs.engines)
 }
 
 /**

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -303,7 +303,9 @@ public protocol SyncState {
  * Base classes to avoid repeating initializers all over the place.
  */
 open class BaseSyncState: SyncState {
-    open var label: SyncStateLabel { return SyncStateLabel.Stub }
+    open var label: SyncStateLabel {
+        SyncStateLabel.Stub
+    }
 
     public let client: Sync15StorageClient!
     let token: TokenServerToken    // Maybe expired.
@@ -311,8 +313,8 @@ open class BaseSyncState: SyncState {
 
     // TODO: 304 for i/c.
     open func getInfoCollections() -> Deferred<Maybe<InfoCollections>> {
-        return chain(self.client.getInfoCollections(), f: {
-            return $0.value
+        chain(self.client.getInfoCollections(), f: {
+            $0.value
         })
     }
 
@@ -324,7 +326,7 @@ open class BaseSyncState: SyncState {
     }
 
     open func synchronizer<T: Synchronizer>(_ synchronizerClass: T.Type, delegate: SyncDelegate, prefs: Prefs, why: SyncReason) -> T {
-        return T(scratchpad: self.scratchpad, delegate: delegate, basePrefs: prefs, why: why)
+        T(scratchpad: self.scratchpad, delegate: delegate, basePrefs: prefs, why: why)
     }
 
     // This isn't a convenience initializer 'cos subclasses can't call convenience initializers.
@@ -340,7 +342,7 @@ open class BaseSyncState: SyncState {
     }
 
     open func advance() -> Deferred<Maybe<SyncState>> {
-        return deferMaybe(StubStateError())
+        deferMaybe(StubStateError())
     }
 }
 
@@ -365,37 +367,37 @@ public protocol SyncError: MaybeErrorType, SyncPingFailureFormattable {}
 
 extension SyncError {
     public var failureReasonName: SyncPingFailureReasonName {
-        return .unexpectedError
+        .unexpectedError
     }
 }
 
 open class UnknownError: SyncError {
     open var description: String {
-        return "Unknown error."
+        "Unknown error."
     }
 }
 
 open class StateMachineCycleError: SyncError {
     open var description: String {
-        return "The Sync state machine encountered a cycle. This is a coding error."
+        "The Sync state machine encountered a cycle. This is a coding error."
     }
 }
 
 open class CouldNotFetchMetaGlobalError: SyncError {
     open var description: String {
-        return "Could not fetch meta/global."
+        "Could not fetch meta/global."
     }
 }
 
 open class CouldNotFetchKeysError: SyncError {
     open var description: String {
-        return "Could not fetch crypto/keys."
+        "Could not fetch crypto/keys."
     }
 }
 
 open class StubStateError: SyncError {
     open var description: String {
-        return "Unexpectedly reached a stub state. This is a coding error."
+        "Unexpectedly reached a stub state. This is a coding error."
     }
 }
 
@@ -407,7 +409,7 @@ open class ClientUpgradeRequiredError: SyncError {
     }
 
     open var description: String {
-        return "Client upgrade required to work with storage version \(self.targetStorageVersion)."
+        "Client upgrade required to work with storage version \(self.targetStorageVersion)."
     }
 }
 
@@ -419,7 +421,7 @@ open class InvalidKeysError: SyncError {
     }
 
     open var description: String {
-        return "Downloaded crypto/keys, but couldn't parse them."
+        "Downloaded crypto/keys, but couldn't parse them."
     }
 }
 
@@ -433,7 +435,7 @@ open class DisallowedStateError: SyncError {
     }
 
     open var description: String {
-        return "Sync state machine reached \(String(describing: state)) state, which is disallowed. Legal states are: \(String(describing: allowedStates))"
+        "Sync state machine reached \(String(describing: state)) state, which is disallowed. Legal states are: \(String(describing: allowedStates))"
     }
 }
 
@@ -453,7 +455,9 @@ public protocol RecoverableSyncState: SyncState {
  * remotely, then we'll need to upload a new meta/global and sync that engine.
  */
 open class ChangedServerError: RecoverableSyncState {
-    open var label: SyncStateLabel { return SyncStateLabel.ChangedServer }
+    open var label: SyncStateLabel {
+        SyncStateLabel.ChangedServer
+    }
 
     let newToken: TokenServerToken
     let newScratchpad: Scratchpad
@@ -474,7 +478,9 @@ open class ChangedServerError: RecoverableSyncState {
  * Recovery: same as for changed server, but no need to upload a new meta/global.
  */
 open class SyncIDChangedError: RecoverableSyncState {
-    open var label: SyncStateLabel { return SyncStateLabel.SyncIDChanged }
+    open var label: SyncStateLabel {
+        SyncStateLabel.SyncIDChanged
+    }
 
     fileprivate let previousState: BaseSyncStateWithInfo
     fileprivate let newMetaGlobal: Fetched<MetaGlobal>
@@ -496,7 +502,9 @@ open class SyncIDChangedError: RecoverableSyncState {
  * Recovery: configure the server.
  */
 open class ServerConfigurationRequiredError: RecoverableSyncState {
-    open var label: SyncStateLabel { return SyncStateLabel.ServerConfigurationRequired }
+    open var label: SyncStateLabel {
+        SyncStateLabel.ServerConfigurationRequired
+    }
 
     fileprivate let previousState: BaseSyncStateWithInfo
 
@@ -523,8 +531,12 @@ open class ServerConfigurationRequiredError: RecoverableSyncState {
         }
         return client.uploadMetaGlobal(metaGlobal, ifUnmodifiedSince: nil)
             // ... and a new crypto/keys.
-            >>> { return client.uploadCryptoKeys(Keys.random(), withSyncKeyBundle: s.syncKeyBundle, ifUnmodifiedSince: nil) }
-            >>> { return deferMaybe(InitialWithLiveToken(client: client, scratchpad: s, token: self.previousState.token)) }
+            >>> {
+            client.uploadCryptoKeys(Keys.random(), withSyncKeyBundle: s.syncKeyBundle, ifUnmodifiedSince: nil)
+        }
+            >>> {
+            deferMaybe(InitialWithLiveToken(client: client, scratchpad: s, token: self.previousState.token))
+        }
     }
 }
 
@@ -532,7 +544,9 @@ open class ServerConfigurationRequiredError: RecoverableSyncState {
  * Recovery: wipe the server (perhaps unnecessarily) and proceed to configure the server.
  */
 open class FreshStartRequiredError: RecoverableSyncState {
-    open var label: SyncStateLabel { return SyncStateLabel.FreshStartRequired }
+    open var label: SyncStateLabel {
+        SyncStateLabel.FreshStartRequired
+    }
 
     fileprivate let previousState: BaseSyncStateWithInfo
 
@@ -543,12 +557,16 @@ open class FreshStartRequiredError: RecoverableSyncState {
     open func advance() -> Deferred<Maybe<SyncState>> {
         let client = self.previousState.client!
         return client.wipeStorage()
-            >>> { return deferMaybe(ServerConfigurationRequiredError(previousState: self.previousState)) }
+            >>> {
+            deferMaybe(ServerConfigurationRequiredError(previousState: self.previousState))
+        }
     }
 }
 
 open class MissingMetaGlobalError: RecoverableSyncState {
-    open var label: SyncStateLabel { return SyncStateLabel.MissingMetaGlobal }
+    open var label: SyncStateLabel {
+        SyncStateLabel.MissingMetaGlobal
+    }
 
     fileprivate let previousState: BaseSyncStateWithInfo
 
@@ -557,12 +575,14 @@ open class MissingMetaGlobalError: RecoverableSyncState {
     }
 
     open func advance() -> Deferred<Maybe<SyncState>> {
-        return deferMaybe(FreshStartRequiredError(previousState: self.previousState))
+        deferMaybe(FreshStartRequiredError(previousState: self.previousState))
     }
 }
 
 open class MissingCryptoKeysError: RecoverableSyncState {
-    open var label: SyncStateLabel { return SyncStateLabel.MissingCryptoKeys }
+    open var label: SyncStateLabel {
+        SyncStateLabel.MissingCryptoKeys
+    }
 
     fileprivate let previousState: BaseSyncStateWithInfo
 
@@ -571,12 +591,14 @@ open class MissingCryptoKeysError: RecoverableSyncState {
     }
 
     open func advance() -> Deferred<Maybe<SyncState>> {
-        return deferMaybe(FreshStartRequiredError(previousState: self.previousState))
+        deferMaybe(FreshStartRequiredError(previousState: self.previousState))
     }
 }
 
 open class RemoteUpgradeRequired: RecoverableSyncState {
-    open var label: SyncStateLabel { return SyncStateLabel.RemoteUpgradeRequired }
+    open var label: SyncStateLabel {
+        SyncStateLabel.RemoteUpgradeRequired
+    }
 
     fileprivate let previousState: BaseSyncStateWithInfo
 
@@ -585,12 +607,14 @@ open class RemoteUpgradeRequired: RecoverableSyncState {
     }
 
     open func advance() -> Deferred<Maybe<SyncState>> {
-        return deferMaybe(FreshStartRequiredError(previousState: self.previousState))
+        deferMaybe(FreshStartRequiredError(previousState: self.previousState))
     }
 }
 
 open class ClientUpgradeRequired: RecoverableSyncState {
-    open var label: SyncStateLabel { return SyncStateLabel.ClientUpgradeRequired }
+    open var label: SyncStateLabel {
+        SyncStateLabel.ClientUpgradeRequired
+    }
 
     fileprivate let previousState: BaseSyncStateWithInfo
     let targetStorageVersion: Int
@@ -601,7 +625,7 @@ open class ClientUpgradeRequired: RecoverableSyncState {
     }
 
     open func advance() -> Deferred<Maybe<SyncState>> {
-        return deferMaybe(ClientUpgradeRequiredError(target: self.targetStorageVersion))
+        deferMaybe(ClientUpgradeRequiredError(target: self.targetStorageVersion))
     }
 }
 
@@ -610,7 +634,9 @@ open class ClientUpgradeRequired: RecoverableSyncState {
  */
 
 open class InitialWithLiveToken: BaseSyncState {
-    open override var label: SyncStateLabel { return SyncStateLabel.InitialWithLiveToken }
+    open override var label: SyncStateLabel {
+        SyncStateLabel.InitialWithLiveToken
+    }
 
     // This looks totally redundant, but try taking it out, I dare you.
     public override init(scratchpad: Scratchpad, token: TokenServerToken) {
@@ -623,11 +649,11 @@ open class InitialWithLiveToken: BaseSyncState {
     }
 
     func advanceWithInfo(_ info: InfoCollections) -> SyncState {
-        return InitialWithLiveTokenAndInfo(scratchpad: self.scratchpad, token: self.token, info: info)
+        InitialWithLiveTokenAndInfo(scratchpad: self.scratchpad, token: self.token, info: info)
     }
 
     override open func advance() -> Deferred<Maybe<SyncState>> {
-        return chain(getInfoCollections(), f: self.advanceWithInfo)
+        chain(getInfoCollections(), f: self.advanceWithInfo)
     }
 }
 
@@ -654,10 +680,12 @@ open class ResolveMetaGlobalVersion: BaseSyncStateWithInfo {
         self.fetched = fetched
         super.init(client: client, scratchpad: scratchpad, token: token, info: info)
     }
-    open override var label: SyncStateLabel { return SyncStateLabel.ResolveMetaGlobalVersion }
+    open override var label: SyncStateLabel {
+        SyncStateLabel.ResolveMetaGlobalVersion
+    }
 
     class func fromState(_ state: BaseSyncStateWithInfo, fetched: Fetched<MetaGlobal>) -> ResolveMetaGlobalVersion {
-        return ResolveMetaGlobalVersion(fetched: fetched, client: state.client, scratchpad: state.scratchpad, token: state.token, info: state.info)
+        ResolveMetaGlobalVersion(fetched: fetched, client: state.client, scratchpad: state.scratchpad, token: state.token, info: state.info)
     }
 
     override open func advance() -> Deferred<Maybe<SyncState>> {
@@ -686,10 +714,12 @@ open class ResolveMetaGlobalContent: BaseSyncStateWithInfo {
         self.fetched = fetched
         super.init(client: client, scratchpad: scratchpad, token: token, info: info)
     }
-    open override var label: SyncStateLabel { return SyncStateLabel.ResolveMetaGlobalContent }
+    open override var label: SyncStateLabel {
+        SyncStateLabel.ResolveMetaGlobalContent
+    }
 
     class func fromState(_ state: BaseSyncStateWithInfo, fetched: Fetched<MetaGlobal>) -> ResolveMetaGlobalContent {
-        return ResolveMetaGlobalContent(fetched: fetched, client: state.client, scratchpad: state.scratchpad, token: state.token, info: state.info)
+        ResolveMetaGlobalContent(fetched: fetched, client: state.client, scratchpad: state.scratchpad, token: state.token, info: state.info)
     }
 
     override open func advance() -> Deferred<Maybe<SyncState>> {
@@ -761,7 +791,9 @@ private func processFailure(_ failure: MaybeErrorType?) -> MaybeErrorType {
 }
 
 open class InitialWithLiveTokenAndInfo: BaseSyncStateWithInfo {
-    open override var label: SyncStateLabel { return SyncStateLabel.InitialWithLiveTokenAndInfo }
+    open override var label: SyncStateLabel {
+        SyncStateLabel.InitialWithLiveTokenAndInfo
+    }
 
     // This method basically hops over HasMetaGlobal, because it's not a state
     // that we expect consumers to know about.
@@ -808,15 +840,17 @@ open class InitialWithLiveTokenAndInfo: BaseSyncStateWithInfo {
  * If we don't want to hit the network (e.g. from an extension), we should stop if we get to this state.
  */
 open class NeedsFreshMetaGlobal: BaseSyncStateWithInfo {
-    open override var label: SyncStateLabel { return SyncStateLabel.NeedsFreshMetaGlobal }
+    open override var label: SyncStateLabel {
+        SyncStateLabel.NeedsFreshMetaGlobal
+    }
 
     class func fromState(_ state: BaseSyncStateWithInfo) -> NeedsFreshMetaGlobal {
-        return NeedsFreshMetaGlobal(client: state.client, scratchpad: state.scratchpad, token: state.token, info: state.info)
+        NeedsFreshMetaGlobal(client: state.client, scratchpad: state.scratchpad, token: state.token, info: state.info)
     }
 
     override open func advance() -> Deferred<Maybe<SyncState>> {
         // Fetch.
-        return self.client.getMetaGlobal().bind { result in
+        self.client.getMetaGlobal().bind { result in
             if let resp = result.successValue {
                 // We use the server's timestamp, rather than the record's modified field.
                 // Either can be made to work, but the latter has suffered from bugs: see Bug 1210625.
@@ -838,14 +872,16 @@ open class NeedsFreshMetaGlobal: BaseSyncStateWithInfo {
 }
 
 open class HasMetaGlobal: BaseSyncStateWithInfo {
-    open override var label: SyncStateLabel { return SyncStateLabel.HasMetaGlobal }
+    open override var label: SyncStateLabel {
+        SyncStateLabel.HasMetaGlobal
+    }
 
     class func fromState(_ state: BaseSyncStateWithInfo) -> HasMetaGlobal {
-        return HasMetaGlobal(client: state.client, scratchpad: state.scratchpad, token: state.token, info: state.info)
+        HasMetaGlobal(client: state.client, scratchpad: state.scratchpad, token: state.token, info: state.info)
     }
 
     class func fromState(_ state: BaseSyncStateWithInfo, scratchpad: Scratchpad) -> HasMetaGlobal {
-        return HasMetaGlobal(client: state.client, scratchpad: scratchpad, token: state.token, info: state.info)
+        HasMetaGlobal(client: state.client, scratchpad: scratchpad, token: state.token, info: state.info)
     }
 
     override open func advance() -> Deferred<Maybe<SyncState>> {
@@ -897,11 +933,13 @@ open class HasMetaGlobal: BaseSyncStateWithInfo {
 }
 
 open class NeedsFreshCryptoKeys: BaseSyncStateWithInfo {
-    open override var label: SyncStateLabel { return SyncStateLabel.NeedsFreshCryptoKeys }
+    open override var label: SyncStateLabel {
+        SyncStateLabel.NeedsFreshCryptoKeys
+    }
     let staleCollectionKeys: Keys?
 
     class func fromState(_ state: BaseSyncStateWithInfo, scratchpad: Scratchpad, staleCollectionKeys: Keys?) -> NeedsFreshCryptoKeys {
-        return NeedsFreshCryptoKeys(client: state.client, scratchpad: scratchpad, token: state.token, info: state.info, keys: staleCollectionKeys)
+        NeedsFreshCryptoKeys(client: state.client, scratchpad: scratchpad, token: state.token, info: state.info, keys: staleCollectionKeys)
     }
 
     public init(client: Sync15StorageClient, scratchpad: Scratchpad, token: TokenServerToken, info: InfoCollections, keys: Keys?) {
@@ -911,7 +949,7 @@ open class NeedsFreshCryptoKeys: BaseSyncStateWithInfo {
 
     override open func advance() -> Deferred<Maybe<SyncState>> {
         // Fetch crypto/keys.
-        return self.client.getCryptoKeys(self.scratchpad.syncKeyBundle, ifUnmodifiedSince: nil).bind { result in
+        self.client.getCryptoKeys(self.scratchpad.syncKeyBundle, ifUnmodifiedSince: nil).bind { result in
             if let resp = result.successValue {
                 let collectionKeys = Keys(payload: resp.value.payload)
                 if !collectionKeys.valid {
@@ -939,11 +977,13 @@ open class NeedsFreshCryptoKeys: BaseSyncStateWithInfo {
 }
 
 open class HasFreshCryptoKeys: BaseSyncStateWithInfo {
-    open override var label: SyncStateLabel { return SyncStateLabel.HasFreshCryptoKeys }
+    open override var label: SyncStateLabel {
+        SyncStateLabel.HasFreshCryptoKeys
+    }
     let collectionKeys: Keys
 
     class func fromState(_ state: BaseSyncStateWithInfo, scratchpad: Scratchpad, collectionKeys: Keys) -> HasFreshCryptoKeys {
-        return HasFreshCryptoKeys(client: state.client, scratchpad: scratchpad, token: state.token, info: state.info, keys: collectionKeys)
+        HasFreshCryptoKeys(client: state.client, scratchpad: scratchpad, token: state.token, info: state.info, keys: collectionKeys)
     }
 
     public init(client: Sync15StorageClient, scratchpad: Scratchpad, token: TokenServerToken, info: InfoCollections, keys: Keys) {
@@ -952,7 +992,7 @@ open class HasFreshCryptoKeys: BaseSyncStateWithInfo {
     }
 
     override open func advance() -> Deferred<Maybe<SyncState>> {
-        return deferMaybe(Ready(client: self.client, scratchpad: self.scratchpad, token: self.token, info: self.info, keys: self.collectionKeys))
+        deferMaybe(Ready(client: self.client, scratchpad: self.scratchpad, token: self.token, info: self.info, keys: self.collectionKeys))
     }
 }
 
@@ -964,15 +1004,17 @@ public protocol EngineStateChanges {
 }
 
 open class Ready: BaseSyncStateWithInfo {
-    open override var label: SyncStateLabel { return SyncStateLabel.Ready }
+    open override var label: SyncStateLabel {
+        SyncStateLabel.Ready
+    }
     let collectionKeys: Keys
 
     public var hashedFxADeviceID: String {
-        return (scratchpad.fxaDeviceId + token.hashedFxAUID).sha256.hexEncodedString
+        (scratchpad.fxaDeviceId + token.hashedFxAUID).sha256.hexEncodedString
     }
 
     public var engineConfiguration: EngineConfiguration? {
-        return scratchpad.engineConfiguration
+        scratchpad.engineConfiguration
     }
 
     public init(client: Sync15StorageClient, scratchpad: Scratchpad, token: TokenServerToken, info: InfoCollections, keys: Keys) {

--- a/Sync/SyncTelemetryUtils.swift
+++ b/Sync/SyncTelemetryUtils.swift
@@ -41,13 +41,13 @@ public struct SyncUploadStats: Stats {
     var sentFailed: Int = 0
 
     public func hasData() -> Bool {
-        return sent > 0 || sentFailed > 0
+        sent > 0 || sentFailed > 0
     }
 }
 
 extension SyncUploadStats: DictionaryRepresentable {
     func asDictionary() -> [String: Any] {
-        return [
+        [
             "sent": sent,
             "failed": sentFailed
         ]
@@ -62,17 +62,17 @@ public struct SyncDownloadStats: Stats {
     var reconciled: Int = 0
 
     public func hasData() -> Bool {
-        return applied > 0 ||
-               succeeded > 0 ||
-               failed > 0 ||
-               newFailed > 0 ||
-               reconciled > 0
+        applied > 0 ||
+                succeeded > 0 ||
+                failed > 0 ||
+                newFailed > 0 ||
+                reconciled > 0
     }
 }
 
 extension SyncDownloadStats: DictionaryRepresentable {
     func asDictionary() -> [String: Any] {
-        return [
+        [
             "applied": applied,
             "succeeded": succeeded,
             "failed": failed,
@@ -88,7 +88,7 @@ public struct ValidationStats: Stats, DictionaryRepresentable {
     let checked: Int?
 
     public func hasData() -> Bool {
-        return !problems.isEmpty
+        !problems.isEmpty
     }
 
     func asDictionary() -> [String: Any] {
@@ -108,7 +108,7 @@ public struct ValidationProblem: DictionaryRepresentable {
     let count: Int
 
     func asDictionary() -> [String: Any] {
-        return ["name": name, "count": count]
+        ["name": name, "count": count]
     }
 }
 
@@ -124,7 +124,7 @@ public class StatsSession {
     }
 
     public func hasStarted() -> Bool {
-        return startUptimeNanos != nil
+        startUptimeNanos != nil
     }
 
     public func end() -> Self {
@@ -245,16 +245,16 @@ public struct SyncPing: SyncTelemetryPing {
     static func pingFields(prefs: Prefs, why: SyncPingReason) -> Deferred<Maybe<(token: TokenServerToken, fields: [String: Any])>> {
         // Grab our token so we can use the hashed_fxa_uid and clientGUID from our scratchpad for
         // our ping's identifiers
-        return RustFirefoxAccounts.shared.syncAuthState.token(Date.now(), canBeExpired: false) >>== { (token, kSync) in
+        RustFirefoxAccounts.shared.syncAuthState.token(Date.now(), canBeExpired: false) >>== { (token, kSync) in
             let scratchpadPrefs = prefs.branch("sync.scratchpad")
             guard let scratchpad = Scratchpad.restoreFromPrefs(scratchpadPrefs, syncKeyBundle: KeyBundle.fromKSync(kSync)) else {
                 return deferMaybe(SyncPingError.failedToRestoreScratchpad)
             }
 
             let ping: [String: Any] = pingCommonData(
-                why: why,
-                hashedUID: token.hashedFxAUID,
-                hashedDeviceID: (scratchpad.clientGUID + token.hashedFxAUID).sha256.hexEncodedString
+                    why: why,
+                    hashedUID: token.hashedFxAUID,
+                    hashedDeviceID: (scratchpad.clientGUID + token.hashedFxAUID).sha256.hexEncodedString
             )
 
             return deferMaybe((token, ping))
@@ -265,13 +265,15 @@ public struct SyncPing: SyncTelemetryPing {
                             remoteClientsAndTabs: RemoteClientsAndTabs,
                             prefs: Prefs,
                             why: SyncPingReason) -> Deferred<Maybe<SyncPing>> {
-        return pingFields(prefs: prefs, why: why) >>== { (token, fields) in
+        pingFields(prefs: prefs, why: why) >>== { (token, fields) in
             var ping = fields
 
             // TODO: We don't cache our sync pings so if it fails, it fails. Once we add
             // some kind of caching we'll want to make sure we don't dump the events if
             // the ping has failed.
-            let events = Event.takeAll(fromPrefs: prefs).map { $0.toArray() }
+            let events = Event.takeAll(fromPrefs: prefs).map {
+                $0.toArray()
+            }
             ping["events"] = events
 
             return dictionaryFrom(result: result, storage: remoteClientsAndTabs, token: token) >>== { syncDict in
@@ -294,24 +296,24 @@ public struct SyncPing: SyncTelemetryPing {
     }
 
     static func pingCommonData(why: SyncPingReason, hashedUID: String, hashedDeviceID: String) -> [String: Any] {
-         return [
-            "version": 1,
-            "why": why.rawValue,
-            "uid": hashedUID,
-            "deviceID": hashedDeviceID,
-            "os": [
-                "name": "iOS",
-                "version": UIDevice.current.systemVersion,
-                "locale": Locale.current.identifier
-            ]
-        ]
+        [
+           "version": 1,
+           "why": why.rawValue,
+           "uid": hashedUID,
+           "deviceID": hashedDeviceID,
+           "os": [
+               "name": "iOS",
+               "version": UIDevice.current.systemVersion,
+               "locale": Locale.current.identifier
+           ]
+       ]
     }
 
     // Generates a single sync ping payload that is stored in the 'syncs' list in the sync ping.
     private static func dictionaryFrom(result: SyncOperationResult,
                                        storage: RemoteClientsAndTabs,
                                        token: TokenServerToken) -> Deferred<Maybe<[String: Any]>> {
-        return connectedDevices(fromStorage: storage, token: token) >>== { devices in
+        connectedDevices(fromStorage: storage, token: token) >>== { devices in
             guard let stats = result.stats else {
                 return deferMaybe([String: Any]())
             }
@@ -359,7 +361,7 @@ public struct SyncPing: SyncTelemetryPing {
     }
 
     private static func enginePingDataFrom(engineResults: EngineResults) -> [[String: Any]] {
-        return engineResults.map { result in
+        engineResults.map { result in
             let (name, status) = result
             var engine: [String: Any] = [
                 "name": name

--- a/Sync/Synchronizers/ClientsSynchronizer.swift
+++ b/Sync/Synchronizers/ClientsSynchronizer.swift
@@ -25,15 +25,15 @@ public protocol Command {
 open class WipeCommand: Command {
 
     public init?(command: String, args: [JSON]) {
-        return nil
+        nil
     }
 
     open class func fromName(_ command: String, args: [JSON]) -> Command? {
-        return WipeCommand(command: command, args: args)
+        WipeCommand(command: command, args: args)
     }
 
     open func run(_ synchronizer: ClientsSynchronizer) -> Success {
-        return succeed()
+        succeed()
     }
 
     public static func commandFromSyncCommand(_ syncCommand: SyncCommand) -> Command? {
@@ -67,7 +67,7 @@ open class DisplayURICommand: Command {
     }
 
     open class func fromName(_ command: String, args: [JSON]) -> Command? {
-        return DisplayURICommand(command: command, args: args)
+        DisplayURICommand(command: command, args: args)
     }
 
     open func run(_ synchronizer: ClientsSynchronizer) -> Success {
@@ -81,7 +81,7 @@ open class DisplayURICommand: Command {
         }
 
         return sender >>== { client in
-            return display(client?.name)
+            display(client?.name)
         }
     }
 
@@ -114,7 +114,7 @@ open class ClientsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchro
     var clientGuidIsMigrated: Bool = false
 
     override var storageVersion: Int {
-        return ClientsStorageVersion
+        ClientsStorageVersion
     }
 
     var clientRecordLastUpload: Timestamp {
@@ -123,7 +123,7 @@ open class ClientsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchro
         }
 
         get {
-            return self.prefs.unsignedLongForKey("lastClientUpload") ?? 0
+            self.prefs.unsignedLongForKey("lastClientUpload") ?? 0
         }
     }
 
@@ -217,17 +217,18 @@ open class ClientsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchro
     }
 
     fileprivate func uploadClientCommands(toLocalClients localClients: RemoteClientsAndTabs, withServer storageClient: Sync15CollectionClient<ClientPayload>) -> Success {
-        return localClients.getCommands() >>== { clientCommands in
-            return clientCommands.map { (clientGUID, commands) -> Success in
-                self.syncClientCommands(clientGUID, commands: commands, clientsAndTabs: localClients, withServer: storageClient)
-            }.allSucceed()
+        localClients.getCommands() >>== { clientCommands in
+            clientCommands.map { (clientGUID, commands) -> Success in
+                        self.syncClientCommands(clientGUID, commands: commands, clientsAndTabs: localClients, withServer: storageClient)
+                    }
+                    .allSucceed()
         }
     }
 
     fileprivate func syncClientCommands(_ clientGUID: GUID, commands: [SyncCommand], clientsAndTabs: RemoteClientsAndTabs, withServer storageClient: Sync15CollectionClient<ClientPayload>) -> Success {
 
         let deleteCommands: () -> Success = {
-            return clientsAndTabs.deleteCommands(clientGUID).bind({ x in return succeed() })
+            clientsAndTabs.deleteCommands(clientGUID).bind({ x in succeed() })
         }
 
         log.debug("Fetching current client record for client \(clientGUID).")
@@ -411,10 +412,13 @@ open class ClientsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchro
         // clients since the beginning of time instead of looking at `self.lastFetched`.
         return clientsClient.getSince(0)
             >>== { response in
-                return self.maybeDeleteClients(response: response, withServer: storageClient)
-                    >>> { self.wipeIfNecessary(localClients)
-                                >>> { self.applyStorageResponse(response, toLocalClients: localClients, withServer: clientsClient, notifier: notifier) }
-                    }
+            self.maybeDeleteClients(response: response, withServer: storageClient)
+                >>> {
+                self.wipeIfNecessary(localClients)
+                        >>> {
+                    self.applyStorageResponse(response, toLocalClients: localClients, withServer: clientsClient, notifier: notifier)
+                }
+            }
 
             }
             >>> { deferMaybe(self.completedWithStats) }

--- a/Sync/Synchronizers/Downloader.swift
+++ b/Sync/Synchronizers/Downloader.swift
@@ -84,7 +84,7 @@ class BatchingDownloader<T: CleartextPayloadJSON> {
     // Set after each batch, from record timestamps.
     var baseTimestamp: Timestamp {
         get {
-            return self.prefs.timestampForKey("baseTimestamp") ?? 0
+            self.prefs.timestampForKey("baseTimestamp") ?? 0
         }
         set (value) {
             self.prefs.setTimestamp(value, forKey: "baseTimestamp")
@@ -94,7 +94,7 @@ class BatchingDownloader<T: CleartextPayloadJSON> {
     // Only set at the end of a batch, from headers.
     var lastModified: Timestamp {
         get {
-            return self.prefs.timestampForKey("lastModified") ?? 0
+            self.prefs.timestampForKey("lastModified") ?? 0
         }
         set (value) {
             self.prefs.setTimestamp(value, forKey: "lastModified")

--- a/Sync/Synchronizers/HistorySynchronizer.swift
+++ b/Sync/Synchronizers/HistorySynchronizer.swift
@@ -51,7 +51,7 @@ open class HistorySynchronizer: IndependentRecordSynchronizer, Synchronizer {
     }
 
     override var storageVersion: Int {
-        return HistoryStorageVersion
+        HistoryStorageVersion
     }
 
     fileprivate let batchSize: Int = 1000  // A balance between number of requests and per-request size.
@@ -137,7 +137,7 @@ open class HistorySynchronizer: IndependentRecordSynchronizer, Synchronizer {
             log.info("Uploading \(recs.count) history items…")
             return self.uploadRecords(recs, lastTimestamp: timestamp, storageClient: storageClient) { result, lastModified in
                 // We don't do anything with failed.
-                return storage.markAsSynchronized(result.success, modified: lastModified ?? timestamp)
+                storage.markAsSynchronized(result.success, modified: lastModified ?? timestamp)
             }
         }
 
@@ -212,8 +212,8 @@ open class HistorySynchronizer: IndependentRecordSynchronizer, Synchronizer {
         }
 
         func applyBatched() -> Success {
-            return self.applyIncomingToStorage(history, records: downloader.retrieve())
-               >>> effect(downloader.advance)
+            self.applyIncomingToStorage(history, records: downloader.retrieve())
+                    >>> effect(downloader.advance)
         }
 
         func onBatchResult(_ result: Maybe<DownloadEndState>) -> SyncResult {

--- a/Sync/Synchronizers/IndependentRecordSynchronizer.swift
+++ b/Sync/Synchronizers/IndependentRecordSynchronizer.swift
@@ -37,8 +37,8 @@ class Uploader {
 
 open class IndependentRecordSynchronizer: TimestampedSingleCollectionSynchronizer {
     private func reportApplyStatsWrap<T>(apply: @escaping (T) -> Success) -> (T) -> Success {
-        return { record in
-            return apply(record).bind({ result in
+        { record in
+            apply(record).bind({ result in
                 var stats = SyncDownloadStats()
                 stats.applied = 1
                 if result.isSuccess {

--- a/Sync/Synchronizers/Synchronizer.swift
+++ b/Sync/Synchronizers/Synchronizer.swift
@@ -166,7 +166,7 @@ open class FatalError: SyncError {
     }
 
     open var description: String {
-        return self.message
+        self.message
     }
 }
 
@@ -209,7 +209,7 @@ open class BaseCollectionSynchronizer {
 
     // Short-hand for returning .Complete status + recorded stats
     var completedWithStats: SyncStatus {
-        return .completed(statsSession.end())
+        .completed(statsSession.end())
     }
 
     open func reasonToNotSync(_ client: Sync15StorageClient) -> SyncNotStartedReason? {
@@ -242,7 +242,7 @@ open class BaseCollectionSynchronizer {
     }
 
     func encrypter<T>(_ encoder: RecordEncoder<T>) -> RecordEncrypter<T>? {
-        return self.scratchpad.keys?.value.encrypter(self.collection, encoder: encoder)
+        self.scratchpad.keys?.value.encrypter(self.collection, encoder: encoder)
     }
 
     func collectionClient<T>(_ encoder: RecordEncoder<T>, storageClient: Sync15StorageClient) -> Sync15CollectionClient<T>? {
@@ -265,7 +265,7 @@ open class TimestampedSingleCollectionSynchronizer: BaseCollectionSynchronizer, 
         }
 
         get {
-            return self.prefs.unsignedLongForKey("lastFetched") ?? 0
+            self.prefs.unsignedLongForKey("lastFetched") ?? 0
         }
     }
 
@@ -275,7 +275,7 @@ open class TimestampedSingleCollectionSynchronizer: BaseCollectionSynchronizer, 
     }
 
     open func remoteHasChanges(_ info: InfoCollections) -> Bool {
-        return info.modified(self.collection) ?? 0 > self.lastFetched
+        info.modified(self.collection) ?? 0 > self.lastFetched
     }
 }
 

--- a/Sync/TabsPayload.swift
+++ b/Sync/TabsPayload.swift
@@ -39,7 +39,7 @@ open class TabsPayload: CleartextPayloadJSON {
         }
 
         class func remoteTabFromJSON(_ json: JSON, clientGUID: GUID) -> RemoteTab? {
-            return fromJSON(json)?.toRemoteTabForClient(clientGUID)
+            fromJSON(json)?.toRemoteTabForClient(clientGUID)
         }
 
         class func fromJSON(_ json: JSON) -> Tab? {
@@ -122,11 +122,11 @@ open class TabsPayload: CleartextPayloadJSON {
     }
 
     var tabs: [Tab] {
-        return self["tabs"].arrayValue.compactMap(Tab.fromJSON)
+        self["tabs"].arrayValue.compactMap(Tab.fromJSON)
     }
 
     var clientName: String {
-        return self["clientName"].string!
+        self["clientName"].string!
     }
 
     override open func equalPayloads(_ obj: CleartextPayloadJSON) -> Bool {

--- a/SyncTelemetry/SyncTelemetryEvents.swift
+++ b/SyncTelemetry/SyncTelemetryEvents.swift
@@ -137,7 +137,7 @@ public struct Event: Decodable {
     }
 
     public func toArray() -> [Any] {
-        return [timestamp, category, method, object, value ?? NSNull(), extra ?? NSNull()]
+        [timestamp, category, method, object, value ?? NSNull(), extra ?? NSNull()]
     }
 
     public func record(intoPrefs prefs: Prefs) {
@@ -154,6 +154,6 @@ public struct Event: Decodable {
 
 extension Event: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return toArray().description
+        toArray().description
     }
 }

--- a/Tests/AccountTests/Push/PushClientTests.swift
+++ b/Tests/AccountTests/Push/PushClientTests.swift
@@ -10,7 +10,7 @@ import XCTest
 class PushClientTests: XCTestCase {
 
     var endpointURL: NSURL {
-        return FennecPushConfiguration().endpointURL
+        FennecPushConfiguration().endpointURL
     }
 
     func generateDeviceID() -> String {

--- a/Tests/AccountTests/TokenServerClientTests.swift
+++ b/Tests/AccountTests/TokenServerClientTests.swift
@@ -26,7 +26,7 @@ class TokenServerClientTests {
 
     func testAudienceForEndpoint() {
         func audienceFor(_ endpoint: String) -> String {
-            return TokenServerClient.getAudience(forURL: URL(string: endpoint)!)
+            TokenServerClient.getAudience(forURL: URL(string: endpoint)!)
         }
 
         // Sub-domains and path components.

--- a/Tests/ClientTests/DownloadHelperTests.swift
+++ b/Tests/ClientTests/DownloadHelperTests.swift
@@ -90,40 +90,40 @@ class DownloadHelperTests: XCTestCase {
     // MARK: - Helpers
 
     private func anyRequest(urlString: String = "http://any-url.com") -> URLRequest {
-        return URLRequest(url: URL(string: urlString)!, cachePolicy: anyCachePolicy(), timeoutInterval: 60.0)
+        URLRequest(url: URL(string: urlString)!, cachePolicy: anyCachePolicy(), timeoutInterval: 60.0)
     }
 
     private func anyResponse(mimeType: String?) -> URLResponse {
-        return URLResponse(url: URL(string: "http://any-url.com")!, mimeType: mimeType, expectedContentLength: 10, textEncodingName: nil)
+        URLResponse(url: URL(string: "http://any-url.com")!, mimeType: mimeType, expectedContentLength: 10, textEncodingName: nil)
     }
 
     private func anyResponse(urlString: String) -> URLResponse {
-        return URLResponse(url: URL(string: urlString)!, mimeType: nil, expectedContentLength: 10, textEncodingName: nil)
+        URLResponse(url: URL(string: urlString)!, mimeType: nil, expectedContentLength: 10, textEncodingName: nil)
     }
 
     private func cookieStore() -> WKHTTPCookieStore {
-        return WKWebsiteDataStore.`default`().httpCookieStore
+        WKWebsiteDataStore.`default`().httpCookieStore
     }
 
     private func anyCachePolicy() -> URLRequest.CachePolicy {
-        return .useProtocolCachePolicy
+        .useProtocolCachePolicy
     }
 
     private func allMIMETypes() -> [String] {
-        return [MIMEType.Bitmap,
-                MIMEType.CSS,
-                MIMEType.GIF,
-                MIMEType.JavaScript,
-                MIMEType.JPEG,
-                MIMEType.HTML,
-                MIMEType.OctetStream,
-                MIMEType.Passbook,
-                MIMEType.PDF,
-                MIMEType.PlainText,
-                MIMEType.PNG,
-                MIMEType.WebP,
-                MIMEType.Calendar,
-                MIMEType.USDZ,
-                MIMEType.Reality]
+        [MIMEType.Bitmap,
+         MIMEType.CSS,
+         MIMEType.GIF,
+         MIMEType.JavaScript,
+         MIMEType.JPEG,
+         MIMEType.HTML,
+         MIMEType.OctetStream,
+         MIMEType.Passbook,
+         MIMEType.PDF,
+         MIMEType.PlainText,
+         MIMEType.PNG,
+         MIMEType.WebP,
+         MIMEType.Calendar,
+         MIMEType.USDZ,
+         MIMEType.Reality]
     }
 }

--- a/Tests/ClientTests/Frontend/Browser/TopSitesHelperTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/TopSitesHelperTests.swift
@@ -175,13 +175,13 @@ class TopSitesHelperTests: XCTestCase {
 extension TopSitesHelperTests {
 
     var defaultPinnedSites: [PinnedSite] {
-        return [PinnedSite(site: Site(url: "https://apinnedsite.com/", title: "a pinned site title")),
-                PinnedSite(site: Site(url: "https://apinnedsite2.com/", title: "a pinned site title2"))]
+        [PinnedSite(site: Site(url: "https://apinnedsite.com/", title: "a pinned site title")),
+         PinnedSite(site: Site(url: "https://apinnedsite2.com/", title: "a pinned site title2"))]
     }
 
     var defaultFrecencySites: [Site] {
-        return [Site(url: "https://frecencySite.com/1/", title: "a frecency site"),
-                Site(url: "https://anotherWebSite.com/2/", title: "Another website")]
+        [Site(url: "https://frecencySite.com/1/", title: "a frecency site"),
+         Site(url: "https://anotherWebSite.com/2/", title: "Another website")]
     }
 }
 
@@ -190,7 +190,7 @@ class SiteCursorMock: Cursor<Site> {
 
     var sites = [Site]()
     override func asArray() -> [Site] {
-        return sites
+        sites
     }
 }
 

--- a/Tests/ClientTests/Frontend/Browser/WebView/WebViewNavigationHandlerTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/WebView/WebViewNavigationHandlerTests.swift
@@ -232,7 +232,7 @@ class WKNavigationActionMock: WKNavigationAction {
     var overridenTargetFrame: WKFrameInfoMock?
 
     override var targetFrame: WKFrameInfo? {
-        return overridenTargetFrame
+        overridenTargetFrame
     }
 }
 
@@ -246,6 +246,6 @@ class WKFrameInfoMock: WKFrameInfo {
     }
 
     override var isMainFrame: Bool {
-        return overridenTargetFrame
+        overridenTargetFrame
     }
 }

--- a/Tests/ClientTests/Frontend/Home/FirefoxHomeJumpBackInViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/FirefoxHomeJumpBackInViewModelTests.swift
@@ -344,25 +344,25 @@ class FirefoxHomeJumpBackInViewModelTests: XCTestCase {
 
 extension FirefoxHomeJumpBackInViewModelTests {
     var remoteClient: RemoteClient {
-        return RemoteClient(guid: nil,
-                            name: "Fake client",
-                            modified: 1,
-                            type: nil,
-                            formfactor: nil,
-                            os: nil,
-                            version: nil,
-                            fxaDeviceId: nil)
+        RemoteClient(guid: nil,
+                name: "Fake client",
+                modified: 1,
+                type: nil,
+                formfactor: nil,
+                os: nil,
+                version: nil,
+                fxaDeviceId: nil)
     }
 
     func remoteDesktopClient(name: String = "Fake client") -> RemoteClient {
-        return RemoteClient(guid: nil,
-                            name: name,
-                            modified: 1,
-                            type: "desktop",
-                            formfactor: nil,
-                            os: nil,
-                            version: nil,
-                            fxaDeviceId: nil)
+        RemoteClient(guid: nil,
+                name: name,
+                modified: 1,
+                type: "desktop",
+                formfactor: nil,
+                os: nil,
+                version: nil,
+                fxaDeviceId: nil)
     }
 
     func remoteTabs(idRange: ClosedRange<Int> = 1...1) -> [RemoteTab] {

--- a/Tests/ClientTests/Frontend/Home/RecentlySaved/ReadingListMock.swift
+++ b/Tests/ClientTests/Frontend/Home/RecentlySaved/ReadingListMock.swift
@@ -21,20 +21,20 @@ class ReadingListMock: ReadingList {
     }
 
     func getAvailableRecords() -> Deferred<Maybe<[ReadingListItem]>> {
-        return deferMaybe([])
+        deferMaybe([])
     }
 
     func deleteRecord(_ record: ReadingListItem, completion: ((Bool) -> Void)?) {}
 
     func createRecordWithURL(_ url: String, title: String, addedBy: String) -> Deferred<Maybe<ReadingListItem>> {
-        return deferMaybe(ReadingListStorageError("Function not mocked"))
+        deferMaybe(ReadingListStorageError("Function not mocked"))
     }
 
     func getRecordWithURL(_ url: String) -> Deferred<Maybe<ReadingListItem>> {
-        return deferMaybe(ReadingListStorageError("Function not mocked"))
+        deferMaybe(ReadingListStorageError("Function not mocked"))
     }
 
     func updateRecord(_ record: ReadingListItem, unread: Bool) -> Deferred<Maybe<ReadingListItem>> {
-        return deferMaybe(ReadingListStorageError("Function not mocked"))
+        deferMaybe(ReadingListStorageError("Function not mocked"))
     }
 }

--- a/Tests/ClientTests/Frontend/Home/TopSites/ContileProviderTests.swift
+++ b/Tests/ClientTests/Frontend/Home/TopSites/ContileProviderTests.swift
@@ -219,50 +219,50 @@ private extension ContileProviderTests {
     // MARK: - Mock responses
 
     var emptyArrayResponse: String {
-        return "{\"tiles\":[]}"
+        "{\"tiles\":[]}"
     }
 
     var emptyWrongResponse: String {
-        return "{\"tiles\":[{\"answer\":\"isBad\"}]}"
+        "{\"tiles\":[{\"answer\":\"isBad\"}]}"
     }
 
     var emptyResponse: String {
-        return "{}"
+        "{}"
     }
 
     var twoTilesWithOneNilPosition: String {
-        return "{\"tiles\":[\(oneTileEmptyPosition),\(oneTileWithPosition)]}"
+        "{\"tiles\":[\(oneTileEmptyPosition),\(oneTileWithPosition)]}"
     }
 
     var twoTilesWithOutOfOrderPositions: String {
-        return "{\"tiles\":[\(secondTileWithPosition),\(oneTileWithPosition)]}"
+        "{\"tiles\":[\(secondTileWithPosition),\(oneTileWithPosition)]}"
     }
 
     var oneTileEmptyPosition: String {
-        return """
-{\"id\":1,\"name\":\"TileNilPosition\",\"url\":\"https://www.website.com\",\"\
-click_url\":\"https://www.website.com\",\"image_url\":\"https://www.website.com\",\"\
-image_size\":200,\"impression_url\":\"https://www.website.com\"}
-"""
+        """
+        {\"id\":1,\"name\":\"TileNilPosition\",\"url\":\"https://www.website.com\",\"\
+        click_url\":\"https://www.website.com\",\"image_url\":\"https://www.website.com\",\"\
+        image_size\":200,\"impression_url\":\"https://www.website.com\"}
+        """
     }
 
     var oneTileWithPosition: String {
-        return """
-{\"id\":1,\"name\":\"Tile1\",\"url\":\"https://www.website.com\",\"click_url\":\"\
-https://www.website.com\",\"image_url\":\"https://www.website.com\",\"\
-image_size\":200,\"impression_url\":\"https://www.website.com\",\"position\":1}
-"""
+        """
+        {\"id\":1,\"name\":\"Tile1\",\"url\":\"https://www.website.com\",\"click_url\":\"\
+        https://www.website.com\",\"image_url\":\"https://www.website.com\",\"\
+        image_size\":200,\"impression_url\":\"https://www.website.com\",\"position\":1}
+        """
     }
 
     var secondTileWithPosition: String {
-        return """
-{\"id\":2,\"name\":\"Tile2\",\"url\":\"https://www.website2.com\",\"click_url\":\"\
-https://www.website2.com\",\"image_url\":\"https://www.website2.com\",\"\
-image_size\":200,\"impression_url\":\"https://www.website2.com\",\"position\":2}
-"""
+        """
+        {\"id\":2,\"name\":\"Tile2\",\"url\":\"https://www.website2.com\",\"click_url\":\"\
+        https://www.website2.com\",\"image_url\":\"https://www.website2.com\",\"\
+        image_size\":200,\"impression_url\":\"https://www.website2.com\",\"position\":2}
+        """
     }
 
     var anError: NSError {
-        return NSError(domain: "test error", code: 0)
+        NSError(domain: "test error", code: 0)
     }
 }

--- a/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
+++ b/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
@@ -412,30 +412,30 @@ class ContileProviderMock: ContileProviderInterface {
     private var result: ContileResult
 
     static var defaultSuccessData: [Contile] {
-        return [Contile(id: 1,
-                        name: "Firefox",
-                        url: "https://firefox.com",
-                        clickUrl: "https://firefox.com/click",
-                        imageUrl: "https://test.com/image1.jpg",
-                        imageSize: 200,
-                        impressionUrl: "https://test.com",
-                        position: 1),
-                Contile(id: 2,
-                        name: "Mozilla",
-                        url: "https://mozilla.com",
-                        clickUrl: "https://mozilla.com/click",
-                        imageUrl: "https://test.com/image2.jpg",
-                        imageSize: 200,
-                        impressionUrl: "https://example.com",
-                        position: 2),
-                Contile(id: 3,
-                        name: "Focus",
-                        url: "https://support.mozilla.org/en-US/kb/firefox-focus-ios",
-                        clickUrl: "https://support.mozilla.org/en-US/kb/firefox-focus-ios/click",
-                        imageUrl: "https://test.com/image3.jpg",
-                        imageSize: 200,
-                        impressionUrl: "https://another-example.com",
-                        position: 3)]
+        [Contile(id: 1,
+                name: "Firefox",
+                url: "https://firefox.com",
+                clickUrl: "https://firefox.com/click",
+                imageUrl: "https://test.com/image1.jpg",
+                imageSize: 200,
+                impressionUrl: "https://test.com",
+                position: 1),
+            Contile(id: 2,
+                    name: "Mozilla",
+                    url: "https://mozilla.com",
+                    clickUrl: "https://mozilla.com/click",
+                    imageUrl: "https://test.com/image2.jpg",
+                    imageSize: 200,
+                    impressionUrl: "https://example.com",
+                    position: 2),
+            Contile(id: 3,
+                    name: "Focus",
+                    url: "https://support.mozilla.org/en-US/kb/firefox-focus-ios",
+                    clickUrl: "https://support.mozilla.org/en-US/kb/firefox-focus-ios/click",
+                    imageUrl: "https://test.com/image3.jpg",
+                    imageSize: 200,
+                    impressionUrl: "https://another-example.com",
+                    position: 3)]
     }
 
     init(result: ContileResult) {
@@ -469,25 +469,25 @@ extension ContileProviderMock {
     static let url = "https://www.aurl%@.com"
 
     static var pinnedDuplicateTile: Contile {
-        return Contile(id: 1,
-                       name: String(format: ContileProviderMock.pinnedTitle, "0"),
-                       url: String(format: ContileProviderMock.pinnedURL, "0"),
-                       clickUrl: "https://www.test.com/click",
-                       imageUrl: "https://test.com/image0.jpg",
-                       imageSize: 200,
-                       impressionUrl: "https://test.com",
-                       position: 1)
+        Contile(id: 1,
+                name: String(format: ContileProviderMock.pinnedTitle, "0"),
+                url: String(format: ContileProviderMock.pinnedURL, "0"),
+                clickUrl: "https://www.test.com/click",
+                imageUrl: "https://test.com/image0.jpg",
+                imageSize: 200,
+                impressionUrl: "https://test.com",
+                position: 1)
     }
 
     static var duplicateTile: Contile {
-        return Contile(id: 1,
-                       name: String(format: ContileProviderMock.title, "0"),
-                       url: String(format: ContileProviderMock.url, "0"),
-                       clickUrl: "https://www.test.com/click",
-                       imageUrl: "https://test.com/image0.jpg",
-                       imageSize: 200,
-                       impressionUrl: "https://test.com",
-                       position: 1)
+        Contile(id: 1,
+                name: String(format: ContileProviderMock.title, "0"),
+                url: String(format: ContileProviderMock.url, "0"),
+                clickUrl: "https://www.test.com/click",
+                imageUrl: "https://test.com/image0.jpg",
+                imageSize: 200,
+                impressionUrl: "https://test.com",
+                position: 1)
     }
 }
 

--- a/Tests/ClientTests/Frontend/Home/TopSites/TopSitesViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/TopSites/TopSitesViewModelTests.swift
@@ -37,7 +37,7 @@ class TopSitesViewModelTests: XCTestCase {
         let newSites = topSitesProvider.defaultTopSites(profile.prefs)
 
         XCTAssertFalse(newSites.contains(siteToDelete, f: { (a, b) -> Bool in
-            return a.url == b.url
+            a.url == b.url
         }))
     }
 

--- a/Tests/ClientTests/FxAPushMessageTest.swift
+++ b/Tests/ClientTests/FxAPushMessageTest.swift
@@ -11,6 +11,6 @@ import XCTest
 class FxAPushMessageTest: XCTestCase {
     func createHandler(_ profile: Profile = MockProfile()) -> FxAPushMessageHandler {
 
-        return FxAPushMessageHandler(with: profile)
+        FxAPushMessageHandler(with: profile)
     }
 }

--- a/Tests/ClientTests/GleanPlumbMessageManagerTests.swift
+++ b/Tests/ClientTests/GleanPlumbMessageManagerTests.swift
@@ -105,7 +105,7 @@ class MockGleanPlumbMessageStore: GleanPlumbMessageStoreProtocol {
     }
 
     func getMessageMetadata(messageId: String) -> GleanPlumbMessageMetaData {
-        return metadata
+        metadata
     }
 
     func onMessageDisplayed(_ message: GleanPlumbMessage) {

--- a/Tests/ClientTests/GleanPlumbMessageStoreTests.swift
+++ b/Tests/ClientTests/GleanPlumbMessageStoreTests.swift
@@ -91,23 +91,23 @@ class GleanPlumbMessageStoreTests: XCTestCase {
 // MARK: - MockStyleData
 class MockMessageData: MessageDataProtocol {
     var surface: MessageSurfaceId {
-        return .newTabCard
+        .newTabCard
     }
 
     var isControl: Bool {
-        return false
+        false
     }
 
     var title: String? {
-        return "Title"
+        "Title"
     }
 
     var text: String {
-        return "text"
+        "text"
     }
 
     var buttonLabel: String? {
-        return "Tap"
+        "Tap"
     }
 }
 

--- a/Tests/ClientTests/GleanTelemetryTests.swift
+++ b/Tests/ClientTests/GleanTelemetryTests.swift
@@ -21,12 +21,12 @@ class MockSyncDelegate: SyncDelegate {
 
 class MockBrowserSyncManager: BrowserProfile.BrowserSyncManager {
     override func getProfileAndDeviceId() -> (MozillaAppServices.Profile, String) {
-        return (MozillaAppServices.Profile(
-            uid: "test",
-            email: "test@test.test",
-            displayName: nil,
-            avatar: "",
-            isDefaultAvatar: true
+        (MozillaAppServices.Profile(
+                uid: "test",
+                email: "test@test.test",
+                displayName: nil,
+                avatar: "",
+                isDefaultAvatar: true
         ), "test")
     }
 }

--- a/Tests/ClientTests/KeyboardPressesHandlerTests.swift
+++ b/Tests/ClientTests/KeyboardPressesHandlerTests.swift
@@ -247,7 +247,7 @@ class MockKey: UIKey {
 
     let mockKeyCode: UIKeyboardHIDUsage
     override var keyCode: UIKeyboardHIDUsage {
-        return mockKeyCode
+        mockKeyCode
     }
 
     init(keyCode: UIKeyboardHIDUsage) {
@@ -265,7 +265,7 @@ class MockPress: UIPress {
 
     let mockKey: MockKey
     override var key: UIKey {
-        return mockKey
+        mockKey
     }
 
     init(mockKey: MockKey) {

--- a/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/Tests/ClientTests/Mocks/MockProfile.swift
@@ -16,23 +16,33 @@ open class MockSyncManager: SyncManager {
     open var syncDisplayState: SyncDisplayState?
 
     open func hasSyncedHistory() -> Deferred<Maybe<Bool>> {
-        return deferMaybe(true)
+        deferMaybe(true)
     }
 
     private func completedWithStats(collection: String) -> Deferred<Maybe<SyncStatus>> {
-        return deferMaybe(SyncStatus.completed(SyncEngineStatsSession(collection: collection)))
+        deferMaybe(SyncStatus.completed(SyncEngineStatsSession(collection: collection)))
     }
 
-    open func syncClients() -> SyncResult { return completedWithStats(collection: "mock_clients") }
-    open func syncClientsThenTabs() -> SyncResult { return completedWithStats(collection: "mock_clientsandtabs") }
-    open func syncHistory() -> SyncResult { return completedWithStats(collection: "mock_history") }
-    open func syncLogins() -> SyncResult { return completedWithStats(collection: "mock_logins") }
-    open func syncBookmarks() -> SyncResult { return completedWithStats(collection: "mock_bookmarks") }
+    open func syncClients() -> SyncResult {
+        completedWithStats(collection: "mock_clients")
+    }
+    open func syncClientsThenTabs() -> SyncResult {
+        completedWithStats(collection: "mock_clientsandtabs")
+    }
+    open func syncHistory() -> SyncResult {
+        completedWithStats(collection: "mock_history")
+    }
+    open func syncLogins() -> SyncResult {
+        completedWithStats(collection: "mock_logins")
+    }
+    open func syncBookmarks() -> SyncResult {
+        completedWithStats(collection: "mock_bookmarks")
+    }
     open func syncEverything(why: SyncReason) -> Success {
-        return succeed()
+        succeed()
     }
     open func syncNamedCollections(why: SyncReason, names: [String]) -> Success {
-        return succeed()
+        succeed()
     }
     open func beginTimedSyncs() {}
     open func endTimedSyncs() {}
@@ -47,28 +57,28 @@ open class MockSyncManager: SyncManager {
     }
 
     open func onAddedAccount() -> Success {
-        return succeed()
+        succeed()
     }
     open func onRemovedAccount() -> Success {
-        return succeed()
+        succeed()
     }
 
     open func hasSyncedLogins() -> Deferred<Maybe<Bool>> {
-        return deferMaybe(true)
+        deferMaybe(true)
     }
 }
 
 open class MockTabQueue: TabQueue {
     open func addToQueue(_ tab: ShareItem) -> Success {
-        return succeed()
+        succeed()
     }
 
     open func getQueuedTabs() -> Deferred<Maybe<Cursor<ShareItem>>> {
-        return deferMaybe(ArrayCursor<ShareItem>(data: []))
+        deferMaybe(ArrayCursor<ShareItem>(data: []))
     }
 
     open func clearQueuedTabs() -> Success {
-        return succeed()
+        succeed()
     }
 }
 
@@ -81,7 +91,7 @@ class MockFiles: FileAccessor {
 
 open class MockProfile: Client.Profile {
     public var rustFxA: RustFirefoxAccounts {
-        return RustFirefoxAccounts.shared
+        RustFirefoxAccounts.shared
     }
 
     // Read/Writeable properties for mocking
@@ -127,7 +137,7 @@ open class MockProfile: Client.Profile {
     }
 
     public func localName() -> String {
-        return name
+        name
     }
 
     public func _reopen() {
@@ -151,56 +161,56 @@ open class MockProfile: Client.Profile {
     public var isShutdown: Bool = false
 
     public var favicons: Favicons {
-        return self.legacyPlaces
+        self.legacyPlaces
     }
 
     lazy public var queue: TabQueue = {
-        return MockTabQueue()
+        MockTabQueue()
     }()
 
     lazy public var metadata: Metadata = {
-        return SQLiteMetadata(db: self.db)
+        SQLiteMetadata(db: self.db)
     }()
 
     lazy public var isChinaEdition: Bool = {
-        return Locale.current.identifier == "zh_CN"
+        Locale.current.identifier == "zh_CN"
     }()
 
     lazy public var certStore: CertStore = {
-        return CertStore()
+        CertStore()
     }()
 
     lazy public var searchEngines: SearchEngines = {
-        return SearchEngines(prefs: self.prefs, files: self.files)
+        SearchEngines(prefs: self.prefs, files: self.files)
     }()
 
     lazy public var prefs: Prefs = {
-        return MockProfilePrefs()
+        MockProfilePrefs()
     }()
 
     lazy public var readingList: ReadingList = {
-        return SQLiteReadingList(db: self.readingListDB)
+        SQLiteReadingList(db: self.readingListDB)
     }()
 
     lazy public var recentlyClosedTabs: ClosedTabsStore = {
-        return ClosedTabsStore(prefs: self.prefs)
+        ClosedTabsStore(prefs: self.prefs)
     }()
 
     internal lazy var remoteClientsAndTabs: RemoteClientsAndTabs = {
-        return SQLiteRemoteClientsAndTabs(db: self.db)
+        SQLiteRemoteClientsAndTabs(db: self.db)
     }()
 
     fileprivate lazy var syncCommands: SyncCommands = {
-        return SQLiteRemoteClientsAndTabs(db: self.db)
+        SQLiteRemoteClientsAndTabs(db: self.db)
     }()
 
     public func hasAccount() -> Bool {
-        return true
+        true
     }
 
     var hasSyncableAccountMock: Bool = true
     public func hasSyncableAccount() -> Bool {
-        return hasSyncableAccountMock
+        hasSyncableAccountMock
     }
 
     public func flushAccount() {}
@@ -210,30 +220,30 @@ open class MockProfile: Client.Profile {
     }
 
     public func getClients() -> Deferred<Maybe<[RemoteClient]>> {
-        return deferMaybe([])
+        deferMaybe([])
     }
 
     public func getCachedClients() -> Deferred<Maybe<[RemoteClient]>> {
-        return deferMaybe([])
+        deferMaybe([])
     }
 
     public func getClientsAndTabs() -> Deferred<Maybe<[ClientAndTabs]>> {
-        return deferMaybe([])
+        deferMaybe([])
     }
 
     var mockClientAndTabs = [ClientAndTabs]()
     public func getCachedClientsAndTabs() -> Deferred<Maybe<[ClientAndTabs]>> {
-        return deferMaybe(mockClientAndTabs)
+        deferMaybe(mockClientAndTabs)
     }
 
     public func cleanupHistoryIfNeeded() {}
 
     public func storeTabs(_ tabs: [RemoteTab]) -> Deferred<Maybe<Int>> {
-        return deferMaybe(0)
+        deferMaybe(0)
     }
 
     public func sendItem(_ item: ShareItem, toDevices devices: [RemoteDevice]) -> Success {
-        return succeed()
+        succeed()
     }
 
     public func sendQueuedSyncEvents() {}

--- a/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -12,7 +12,7 @@ class MockTabManager: TabManagerProtocol {
     var nextRecentlyAccessedNormalTabs = [Tab]()
 
     var recentlyAccessedNormalTabs: [Tab] {
-        return nextRecentlyAccessedNormalTabs
+        nextRecentlyAccessedNormalTabs
     }
 
     var tabs = [Tab]()

--- a/Tests/ClientTests/Mocks/MockTraitCollection.swift
+++ b/Tests/ClientTests/Mocks/MockTraitCollection.swift
@@ -8,11 +8,11 @@ class MockTraitCollection: UITraitCollection {
 
     var overridenHorizontalSizeClass: UIUserInterfaceSizeClass = .regular
     override var horizontalSizeClass: UIUserInterfaceSizeClass {
-        return overridenHorizontalSizeClass
+        overridenHorizontalSizeClass
     }
 
     var overridenVerticalSizeClass: UIUserInterfaceSizeClass = .regular
     override var verticalSizeClass: UIUserInterfaceSizeClass {
-        return overridenVerticalSizeClass
+        overridenVerticalSizeClass
     }
 }

--- a/Tests/ClientTests/NavigationRouterTests.swift
+++ b/Tests/ClientTests/NavigationRouterTests.swift
@@ -34,7 +34,7 @@ class NavigationRouterTests: XCTestCase {
     }
 
     private var appScheme: String {
-        return URL.mozInternalScheme
+        URL.mozInternalScheme
     }
 
     func testOpenURLScheme() {

--- a/Tests/ClientTests/PocketFeedTests.swift
+++ b/Tests/ClientTests/PocketFeedTests.swift
@@ -20,7 +20,7 @@ class PocketStoriesTests: XCTestCase {
 
         webServer = GCDWebServer()
         webServer.addHandler(forMethod: "GET", path: "/pocketglobalfeed", request: GCDWebServerRequest.self) { (request) -> GCDWebServerResponse in
-            return GCDWebServerDataResponse(data: data, contentType: "application/json")
+            GCDWebServerDataResponse(data: data, contentType: "application/json")
         }
 
         if webServer.start(withPort: 0, bonjourName: nil) == false {

--- a/Tests/ClientTests/PocketSponsoredStoriesProviderTests.swift
+++ b/Tests/ClientTests/PocketSponsoredStoriesProviderTests.swift
@@ -197,7 +197,7 @@ private extension PocketSponsoredStoriesProviderTests {
     }
 
     var emptyResponse: String {
-        return "{}"
+        "{}"
     }
 
     var validSpocResponse: String {
@@ -282,6 +282,6 @@ private extension PocketSponsoredStoriesProviderTests {
     }
 
     var anError: NSError {
-        return NSError(domain: "test error", code: 0)
+        NSError(domain: "test error", code: 0)
     }
 }

--- a/Tests/ClientTests/PocketStoryProviderTests.swift
+++ b/Tests/ClientTests/PocketStoryProviderTests.swift
@@ -258,7 +258,6 @@ extension PocketStoryProviderTests {
             case .failure(let error):
                 completion(.failure(error))
             }
-            return
         }
 
     }

--- a/Tests/ClientTests/QuickActionsTests.swift
+++ b/Tests/ClientTests/QuickActionsTests.swift
@@ -72,7 +72,7 @@ private class BookmarkShortcutItem: UIApplicationShortcutItem {
     }
 
     override var userInfo: [String: NSSecureCoding]? {
-        return [QuickActions.TabURLKey: "https://www.mozilla.org/en-CA/" as NSSecureCoding]
+        [QuickActions.TabURLKey: "https://www.mozilla.org/en-CA/" as NSSecureCoding]
     }
 }
 

--- a/Tests/ClientTests/RatingPromptManagerTests.swift
+++ b/Tests/ClientTests/RatingPromptManagerTests.swift
@@ -281,7 +281,7 @@ class CumulativeDaysOfUseCounterMock: CumulativeDaysOfUseCounter {
     }
 
     override var hasRequiredCumulativeDaysOfUse: Bool {
-        return hasMockRequiredDaysOfUse
+        hasMockRequiredDaysOfUse
     }
 }
 
@@ -290,7 +290,7 @@ class CrashingMockSentryClient: SentryProtocol {
     var enableCrashOnLastLaunch = false
 
     var crashedLastLaunch: Bool {
-        return enableCrashOnLastLaunch
+        enableCrashOnLastLaunch
     }
 }
 

--- a/Tests/ClientTests/RemoteTabsPanelTests.swift
+++ b/Tests/ClientTests/RemoteTabsPanelTests.swift
@@ -87,23 +87,23 @@ class RemoteTabsPanelTests: XCTestCase {
 
 private extension RemoteTabsPanelTests {
     var remoteClient: RemoteClient {
-        return RemoteClient(guid: nil,
-                            name: "Fake client",
-                            modified: 1,
-                            type: nil,
-                            formfactor: nil,
-                            os: nil,
-                            version: nil,
-                            fxaDeviceId: nil)
+        RemoteClient(guid: nil,
+                name: "Fake client",
+                modified: 1,
+                type: nil,
+                formfactor: nil,
+                os: nil,
+                version: nil,
+                fxaDeviceId: nil)
     }
 
     var remoteTabs: [RemoteTab] {
-        return [RemoteTab(clientGUID: nil,
-                          URL: URL(string: "www.mozilla.org")!,
-                          title: "Mozilla",
-                          history: [],
-                          lastUsed: 1,
-                          icon: nil)]
+        [RemoteTab(clientGUID: nil,
+                URL: URL(string: "www.mozilla.org")!,
+                title: "Mozilla",
+                history: [],
+                lastUsed: 1,
+                icon: nil)]
     }
 
     func panelRefreshWithExpectation(panel: RemoteTabsPanel, completion: @escaping () -> Void) {

--- a/Tests/ClientTests/ResetTests.swift
+++ b/Tests/ClientTests/ResetTests.swift
@@ -142,11 +142,11 @@ extension ResetTests {
 // MARK: - MockBrowserProfile
 class MockBrowserProfile: BrowserProfile {
     var peekSyncManager: BrowserSyncManager {
-        return self.syncManager as! BrowserSyncManager
+        self.syncManager as! BrowserSyncManager
     }
 
     var peekTabs: SQLiteRemoteClientsAndTabs {
-        return self.remoteClientsAndTabs as! SQLiteRemoteClientsAndTabs
+        self.remoteClientsAndTabs as! SQLiteRemoteClientsAndTabs
     }
 }
 
@@ -158,15 +158,15 @@ class MockEngineStateChanges: EngineStateChanges {
     var clearLocalCommandsCount = 0
 
     func collectionsThatNeedLocalReset() -> [String] {
-        return self.collections
+        self.collections
     }
 
     func enginesEnabled() -> [String] {
-        return self.enabled
+        self.enabled
     }
 
     func enginesDisabled() -> [String] {
-        return self.disabled
+        self.disabled
     }
 
     func clearLocalCommands() {

--- a/Tests/ClientTests/SiteImageHelperTests.swift
+++ b/Tests/ClientTests/SiteImageHelperTests.swift
@@ -204,16 +204,16 @@ extension SiteImageHelperTests {
 
 class FaviconFetcherMock: Favicons {
     func addFavicon(_ icon: Favicon) -> Deferred<Maybe<Int>> {
-        return deferMaybe(0)
+        deferMaybe(0)
     }
 
     func addFavicon(_ icon: Favicon, forSite site: Site) -> Deferred<Maybe<Int>> {
-        return deferMaybe(0)
+        deferMaybe(0)
     }
 
     var shouldSucceed = true
     func getFaviconImage(forSite site: Site) -> Deferred<Maybe<UIImage>> {
-        return shouldSucceed ? deferMaybe(UIImage()) : Deferred(value: Maybe(failure: SiteImageHelperTests.TestError.invalidResult))
+        shouldSucceed ? deferMaybe(UIImage()) : Deferred(value: Maybe(failure: SiteImageHelperTests.TestError.invalidResult))
     }
 }
 

--- a/Tests/ClientTests/SyncStatusResolverTests.swift
+++ b/Tests/ClientTests/SyncStatusResolverTests.swift
@@ -16,7 +16,7 @@ private class RandomError: MaybeErrorType {
 class SyncStatusResolverTests: XCTestCase {
 
     private func mockStatsForCollection(collection: String) -> SyncEngineStatsSession {
-        return SyncEngineStatsSession(collection: collection)
+        SyncEngineStatsSession(collection: collection)
     }
 
     func testAllCompleted() {

--- a/Tests/ClientTests/TPStatsBlocklistsTests.swift
+++ b/Tests/ClientTests/TPStatsBlocklistsTests.swift
@@ -31,7 +31,7 @@ class TPStatsBlocklistsTests: XCTestCase {
         blocklists.load()
 
         let safelistedRegexs = ["*google.com"].compactMap { (domain) -> String? in
-            return wildcardContentBlockerDomainToRegex(domain: domain)
+            wildcardContentBlockerDomainToRegex(domain: domain)
         }
 
         self.measureMetrics([.wallClockTime], automaticallyStartMeasuring: true) {
@@ -47,7 +47,7 @@ class TPStatsBlocklistsTests: XCTestCase {
 
         func blocklist(_ urlString: String, _ mainDoc: String = "https://foo.com", _ safelistedDomains: [String] = []) -> BlocklistCategory? {
             let safelistedRegexs = safelistedDomains.compactMap { (domain) -> String? in
-                return wildcardContentBlockerDomainToRegex(domain: domain)
+                wildcardContentBlockerDomainToRegex(domain: domain)
             }
             let mainDoc = URL(string: mainDoc)!
             return blocklists.urlIsInList(URL(string: urlString)!, mainDocumentURL: mainDoc, safelistedDomains: safelistedRegexs)

--- a/Tests/ClientTests/TabDisplayManagerTests.swift
+++ b/Tests/ClientTests/TabDisplayManagerTests.swift
@@ -291,11 +291,11 @@ class WeakListMock<T: AnyObject>: WeakList<T> {
 
     var countToReturn: Int = 0
     override var count: Int {
-        return countToReturn
+        countToReturn
     }
 
     override var isEmpty: Bool {
-        return countToReturn <= 0
+        countToReturn <= 0
     }
 }
 

--- a/Tests/ClientTests/TabManagerNavDelegateTests.swift
+++ b/Tests/ClientTests/TabManagerNavDelegateTests.swift
@@ -132,11 +132,11 @@ private extension TabManagerNavDelegateTests {
     }
 
     func anyWebView() -> WKWebView {
-        return WKWebView(frame: CGRect(width: 100, height: 100))
+        WKWebView(frame: CGRect(width: 100, height: 100))
     }
 
     func anyError() -> NSError {
-        return NSError(domain: "any error", code: 0)
+        NSError(domain: "any error", code: 0)
     }
 }
 

--- a/Tests/ClientTests/TabToolbarHelperTests.swift
+++ b/Tests/ClientTests/TabToolbarHelperTests.swift
@@ -67,7 +67,9 @@ class MockToolbarButton: ToolbarButton {
 
 class MockTabToolbar: TabToolbarProtocol {
     var tabToolbarDelegate: TabToolbarDelegate? {
-        get { return nil }
+        get {
+            nil
+        }
         set { }
     }
 
@@ -100,7 +102,9 @@ class MockTabToolbar: TabToolbarProtocol {
     var _multiStateButton = MockToolbarButton()
     var multiStateButton: ToolbarButton { get { _multiStateButton } }
     var actionButtons: [NotificationThemeable & UIButton] {
-        get { return [] }
+        get {
+            []
+        }
     }
 
     func updateBackStatus(_ canGoBack: Bool) {

--- a/Tests/ClientTests/TestHistory.swift
+++ b/Tests/ClientTests/TestHistory.swift
@@ -215,7 +215,6 @@ class TestHistory: ProfileTest {
 
             self.measure({ () -> Void in
                 self.checkSites(h, urls: urls)
-                return
             })
 
             self.clear(h)

--- a/Tests/ClientTests/TestingHelperClasses/URLProtocolStub.swift
+++ b/Tests/ClientTests/TestingHelperClasses/URLProtocolStub.swift
@@ -23,11 +23,11 @@ class URLProtocolStub: URLProtocol {
     }
 
     override class func canInit(with request: URLRequest) -> Bool {
-        return true
+        true
     }
 
     override class func canonicalRequest(for request: URLRequest) -> URLRequest {
-        return request
+        request
     }
 
     override func startLoading() {

--- a/Tests/ClientTests/Wallpaper/TestDataAndTestDataProviders/Protocols/WallpaperMetadataTestProvider.swift
+++ b/Tests/ClientTests/Wallpaper/TestDataAndTestDataProviders/Protocols/WallpaperMetadataTestProvider.swift
@@ -11,10 +11,16 @@ protocol WallpaperMetadataTestProvider {
 }
 
 extension WallpaperMetadataTestProvider {
-    private var lastUpdatedDate: Date { return dateWith(year: 2001, month: 02, day: 03) }
-    private var startDate: Date { return dateWith(year: 2002, month: 11, day: 28) }
+    private var lastUpdatedDate: Date {
+        dateWith(year: 2001, month: 02, day: 03)
+    }
+    private var startDate: Date {
+        dateWith(year: 2002, month: 11, day: 28)
+    }
     private var endDate: Date { dateWith(year: 2022, month: 09, day: 10) }
-    private var textColour: UIColor { return UIColor(colorString: "0xADD8E6") }
+    private var textColour: UIColor {
+        UIColor(colorString: "0xADD8E6")
+    }
 
     func getExpectedMetadata(for jsonType: WallpaperJSONId) -> WallpaperMetadata {
         switch jsonType {
@@ -29,86 +35,86 @@ extension WallpaperMetadataTestProvider {
     }
 
     private func getInitialMetadata() -> WallpaperMetadata {
-        return WallpaperMetadata(
-            lastUpdated: lastUpdatedDate,
-            collections: [
-                WallpaperCollection(
-                    id: "firefox",
-                    availableLocales: ["en-US", "es-US", "en-CA", "fr-CA"],
-                    availability: WallpaperCollectionAvailability(
-                        start: startDate,
-                        end: endDate),
-                    wallpapers: [
-                        Wallpaper(id: "beachVibes",
-                                  textColour: textColour)
-                    ])
-            ])
+        WallpaperMetadata(
+                lastUpdated: lastUpdatedDate,
+                collections: [
+                    WallpaperCollection(
+                            id: "firefox",
+                            availableLocales: ["en-US", "es-US", "en-CA", "fr-CA"],
+                            availability: WallpaperCollectionAvailability(
+                                    start: startDate,
+                                    end: endDate),
+                            wallpapers: [
+                                Wallpaper(id: "beachVibes",
+                                        textColour: textColour)
+                            ])
+                ])
     }
 
     private func getFullAvailabilityMetadata() -> WallpaperMetadata {
-        return WallpaperMetadata(
-            lastUpdated: lastUpdatedDate,
-            collections: [
-                WallpaperCollection(
-                    id: "firefox",
-                    availableLocales: ["en-US", "es-US", "en-CA", "fr-CA"],
-                    availability: nil,
-                    wallpapers: [
-                        Wallpaper(id: "beachVibes",
-                                  textColour: textColour)
-                    ])
-            ])
+        WallpaperMetadata(
+                lastUpdated: lastUpdatedDate,
+                collections: [
+                    WallpaperCollection(
+                            id: "firefox",
+                            availableLocales: ["en-US", "es-US", "en-CA", "fr-CA"],
+                            availability: nil,
+                            wallpapers: [
+                                Wallpaper(id: "beachVibes",
+                                        textColour: textColour)
+                            ])
+                ])
     }
 
     private func getNoLocalesMetadata() -> WallpaperMetadata {
-        return WallpaperMetadata(
-            lastUpdated: lastUpdatedDate,
-            collections: [
-                WallpaperCollection(
-                    id: "firefox",
-                    availableLocales: nil,
-                    availability: WallpaperCollectionAvailability(
-                        start: startDate,
-                        end: endDate),
-                    wallpapers: [
-                        Wallpaper(id: "beachVibes",
-                                  textColour: textColour)
-                    ])
-            ])
+        WallpaperMetadata(
+                lastUpdated: lastUpdatedDate,
+                collections: [
+                    WallpaperCollection(
+                            id: "firefox",
+                            availableLocales: nil,
+                            availability: WallpaperCollectionAvailability(
+                                    start: startDate,
+                                    end: endDate),
+                            wallpapers: [
+                                Wallpaper(id: "beachVibes",
+                                        textColour: textColour)
+                            ])
+                ])
     }
 
     func getAvailabilityStartMetadata() -> WallpaperMetadata {
-        return WallpaperMetadata(
-            lastUpdated: lastUpdatedDate,
-            collections: [
-                WallpaperCollection(
-                    id: "firefox",
-                    availableLocales: ["en-US", "es-US", "en-CA", "fr-CA"],
-                    availability: WallpaperCollectionAvailability(
-                        start: startDate,
-                        end: nil),
-                    wallpapers: [
-                        Wallpaper(id: "beachVibes",
-                                  textColour: textColour)
-                    ])
-            ])
+        WallpaperMetadata(
+                lastUpdated: lastUpdatedDate,
+                collections: [
+                    WallpaperCollection(
+                            id: "firefox",
+                            availableLocales: ["en-US", "es-US", "en-CA", "fr-CA"],
+                            availability: WallpaperCollectionAvailability(
+                                    start: startDate,
+                                    end: nil),
+                            wallpapers: [
+                                Wallpaper(id: "beachVibes",
+                                        textColour: textColour)
+                            ])
+                ])
     }
 
     func getAvailabilityEndMetadata() -> WallpaperMetadata {
-        return WallpaperMetadata(
-            lastUpdated: lastUpdatedDate,
-            collections: [
-                WallpaperCollection(
-                    id: "firefox",
-                    availableLocales: ["en-US", "es-US", "en-CA", "fr-CA"],
-                    availability: WallpaperCollectionAvailability(
-                        start: nil,
-                        end: endDate),
-                    wallpapers: [
-                        Wallpaper(id: "beachVibes",
-                                  textColour: textColour)
-                    ])
-            ])
+        WallpaperMetadata(
+                lastUpdated: lastUpdatedDate,
+                collections: [
+                    WallpaperCollection(
+                            id: "firefox",
+                            availableLocales: ["en-US", "es-US", "en-CA", "fr-CA"],
+                            availability: WallpaperCollectionAvailability(
+                                    start: nil,
+                                    end: endDate),
+                            wallpapers: [
+                                Wallpaper(id: "beachVibes",
+                                        textColour: textColour)
+                            ])
+                ])
     }
 
     private func dateWith(year: Int, month: Int, day: Int) -> Date {

--- a/Tests/ClientTests/Wallpaper/WallpaperNetworkingModuleTests.swift
+++ b/Tests/ClientTests/Wallpaper/WallpaperNetworkingModuleTests.swift
@@ -102,9 +102,9 @@ class WallpaperNetworkingModuleTests: XCTestCase, WallpaperTestDataProvider {
 
 extension WallpaperNetworkingModuleTests {
     private func createResponseWith(statusCode: Int) -> HTTPURLResponse? {
-        return HTTPURLResponse(url: url,
-                               statusCode: statusCode,
-                               httpVersion: nil,
-                               headerFields: nil)
+        HTTPURLResponse(url: url,
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: nil)
     }
 }

--- a/Tests/ClientTests/WebServerTests.swift
+++ b/Tests/ClientTests/WebServerTests.swift
@@ -16,7 +16,7 @@ class WebServerTests: XCTestCase {
     fileprivate func setupWebServer() {
         webServer = GCDWebServer()
         webServer.addHandler(forMethod: "GET", path: "/hello", request: GCDWebServerRequest.self) { (request) -> GCDWebServerResponse in
-            return GCDWebServerDataResponse(html: "<html><body><p>Hello World</p></body></html>")!
+            GCDWebServerDataResponse(html: "<html><body><p>Hello World</p></body></html>")!
         }
         if webServer.start(withPort: 0, bonjourName: nil) == false {
             XCTFail("Can't start the GCDWebServer")

--- a/Tests/SharedTests/ArrayExtensionTests.swift
+++ b/Tests/SharedTests/ArrayExtensionTests.swift
@@ -17,35 +17,49 @@ class ArrayExtensionTests: XCTestCase {
 
     func testUnique() {
         let a = [1, 2, 3, 4, 5, 6, 1, 2]
-        let result = a.unique { return $0 }
+        let result = a.unique {
+            $0
+        }
         XCTAssertEqual(result, [1, 2, 3, 4, 5, 6])
 
         let b = [1, 2, 3]
-        let resultB = b.unique { return $0 }
+        let resultB = b.unique {
+            $0
+        }
         XCTAssertEqual(resultB, [1, 2, 3])
     }
 
     func testUnion() {
         let a = [1, 2, 3, 4, 5, 6]
         let b = [7, 8, 9, 10]
-        XCTAssertEqual(a.union(b) { return $0 },
+        XCTAssertEqual(a.union(b) {
+            $0
+        },
                        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
         let c = [1, 2, 3, 4, 5, 6]
         let d = [4, 5, 6, 7, 8, 9, 10]
-        XCTAssertEqual(c.union(d) { return $0 }, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        XCTAssertEqual(c.union(d) {
+            $0
+        }, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
         let e = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         let f = [4, 5, 6, 7, 8, 9, 10]
-        XCTAssertEqual(e.union(f) { return $0 }, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        XCTAssertEqual(e.union(f) {
+            $0
+        }, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
         let g = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         let h = [Int]()
-        XCTAssertEqual(g.union(h) { return $0 }, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        XCTAssertEqual(g.union(h) {
+            $0
+        }, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
         let i = [Int]()
         let j = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        XCTAssertEqual(i.union(j) { return $0 }, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        XCTAssertEqual(i.union(j) {
+            $0
+        }, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     }
 
     func testSameElements() {

--- a/Tests/SharedTests/AsyncReducerTests.swift
+++ b/Tests/SharedTests/AsyncReducerTests.swift
@@ -153,7 +153,7 @@ func delay(_ delay: Double, closure:@escaping () -> Void) {
 }
 
 private func simpleAdder(_ a: Int, b: Int) -> Deferred<Maybe<Int>> {
-    return deferMaybe(a + b)
+    deferMaybe(a + b)
 }
 
 private func waitingFillingAdder(_ a: Int, b: Int) -> Deferred<Maybe<Int>> {

--- a/Tests/SharedTests/DeferredTests.swift
+++ b/Tests/SharedTests/DeferredTests.swift
@@ -46,7 +46,7 @@ class DeferredTests: XCTestCase {
         let e2 = self.expectation(description: "Second.")
 
         let f1: () -> Deferred<Maybe<Int>> = {
-            return deferMaybe(5)
+            deferMaybe(5)
         }
 
         let f2: (_ x: Int) -> Deferred<Maybe<String>> = {
@@ -71,7 +71,7 @@ class DeferredTests: XCTestCase {
     func testPassAccumulate_andDoesntLeak() {
         let expectation = self.expectation(description: "Deinit is called")
         let accumulateCall: () -> Success = {
-            return succeed()
+            succeed()
         }
 
         var myclass: AccumulateTestClass? = AccumulateTestClass(expectation: expectation, accumulateCall: accumulateCall)
@@ -86,7 +86,7 @@ class DeferredTests: XCTestCase {
         let expectation = self.expectation(description: "Deinit is called")
 
         let accumulateCall: () -> Success = {
-            return Deferred(value: Maybe(failure: AccumulateTestClass.Error()))
+            Deferred(value: Maybe(failure: AccumulateTestClass.Error()))
         }
 
         var myclass: AccumulateTestClass? = AccumulateTestClass(expectation: expectation, accumulateCall: accumulateCall)

--- a/Tests/SharedTests/NSURLExtensionsTests.swift
+++ b/Tests/SharedTests/NSURLExtensionsTests.swift
@@ -204,7 +204,7 @@ class NSURLExtensionsTests: XCTestCase {
             ]
 
         checkUrls(goodurls: goodurls, badurls: badurls, checker: { url in
-            return url.isAboutHomeURL
+            url.isAboutHomeURL
         })
     }
 
@@ -221,7 +221,7 @@ class NSURLExtensionsTests: XCTestCase {
             ]
 
         checkUrls(goodurls: goodurls, badurls: badurls, checker: { url in
-            return url.isAboutURL
+            url.isAboutURL
         })
     }
 
@@ -236,7 +236,7 @@ class NSURLExtensionsTests: XCTestCase {
         ]
 
         checkUrls(goodurls: goodurls, badurls: badurls, checker: { url in
-            return url.isErrorPage
+            url.isErrorPage
         })
     }
 
@@ -266,7 +266,7 @@ class NSURLExtensionsTests: XCTestCase {
         ]
 
         checkUrls(goodurls: goodurls, badurls: badurls) { url in
-            return url.url.isReaderModeURL
+            url.url.isReaderModeURL
         }
     }
 

--- a/Tests/SharedTests/UtilsTests.swift
+++ b/Tests/SharedTests/UtilsTests.swift
@@ -13,7 +13,7 @@ class UtilsTests: XCTestCase {
     func testMapUtils() {
         let m: [String: Int] = ["foo": 123, "bar": 456]
         let f: (Int) -> Int? = { v in
-            return (v > 200) ? 999 : nil
+            (v > 200) ? 999 : nil
         }
 
         let o = mapValues(m, f: f)

--- a/Tests/StorageTests/StorageTestUtils.swift
+++ b/Tests/StorageTests/StorageTestUtils.swift
@@ -18,16 +18,16 @@ let baseInstantInMillis = Date.now() - threeMonthsInMillis
 let baseInstantInMicros = Date.nowMicroseconds() - threeMonthsInMicros
 
 func advanceTimestamp(_ timestamp: Timestamp, by: Int) -> Timestamp {
-    return timestamp + UInt64(by)
+    timestamp + UInt64(by)
 }
 
 func advanceMicrosecondTimestamp(_ timestamp: MicrosecondTimestamp, by: Int) -> MicrosecondTimestamp {
-    return timestamp + UInt64(by)
+    timestamp + UInt64(by)
 }
 
 extension Site {
     func asPlace() -> Place {
-        return Place(guid: self.guid!, url: self.url, title: self.title)
+        Place(guid: self.guid!, url: self.url, title: self.title)
     }
 }
 
@@ -71,7 +71,7 @@ extension BrowserDB {
 extension BrowserDB {
     func getGUIDs(_ sql: String) -> [GUID] {
         func guidFactory(_ row: SDRow) -> GUID {
-            return row[0] as! GUID
+            row[0] as! GUID
         }
 
         guard let cursor = self.runQuery(sql, args: nil, factory: guidFactory).value.successValue else {
@@ -84,7 +84,7 @@ extension BrowserDB {
     func getPositionsForChildrenOfParent(_ parent: GUID, fromTable table: String) -> [GUID: Int] {
         let args: Args = [parent]
         let factory: (SDRow) -> (GUID, Int) = {
-            return ($0["child"] as! GUID, $0["idx"] as! Int)
+            ($0["child"] as! GUID, $0["idx"] as! Int)
         }
         let cursor = self.runQuery("SELECT child, idx FROM \(table) WHERE parent = ?", args: args, factory: factory).value.successValue!
         return cursor.reduce([:], { (dict, pair) in

--- a/Tests/StorageTests/SyncCommandsTests.swift
+++ b/Tests/StorageTests/SyncCommandsTests.swift
@@ -11,11 +11,11 @@ import XCTest
 import SwiftyJSON
 
 func byValue(_ a: SyncCommand, b: SyncCommand) -> Bool {
-    return a.value < b.value
+    a.value < b.value
 }
 
 func byClient(_ a: RemoteClient, b: RemoteClient) -> Bool {
-    return a.guid! < b.guid!
+    a.guid! < b.guid!
 }
 
 class SyncCommandsTests: XCTestCase {
@@ -147,7 +147,7 @@ class SyncCommandsTests: XCTestCase {
     func testInsertWithMultipleCommands() {
         let e = self.expectation(description: "Insert.")
         let syncCommands = shareItems.map { item in
-            return SyncCommand.displayURIFromShareItem(item, asClient: "abcdefghijkl")
+            SyncCommand.displayURIFromShareItem(item, asClient: "abcdefghijkl")
         }
         clientsAndTabs.insertCommands(syncCommands, forClients: clients).upon {
             XCTAssertTrue($0.isSuccess)
@@ -169,7 +169,7 @@ class SyncCommandsTests: XCTestCase {
 
     func testGetForAllClients() {
         let syncCommands = shareItems.map { item in
-            return SyncCommand.displayURIFromShareItem(item, asClient: "abcdefghijkl")
+                    SyncCommand.displayURIFromShareItem(item, asClient: "abcdefghijkl")
         }.sorted(by: byValue)
         clientsAndTabs.insertCommands(syncCommands, forClients: clients).succeeded()
 
@@ -191,7 +191,7 @@ class SyncCommandsTests: XCTestCase {
 
     func testDeleteForValidClient() {
         let syncCommands = shareItems.map { item in
-            return SyncCommand.displayURIFromShareItem(item, asClient: "abcdefghijkl")
+                    SyncCommand.displayURIFromShareItem(item, asClient: "abcdefghijkl")
         }.sorted(by: byValue)
 
         var client = self.clients[0]
@@ -235,7 +235,7 @@ class SyncCommandsTests: XCTestCase {
 
     func testDeleteForAllClients() {
         let syncCommands = shareItems.map { item in
-            return SyncCommand.displayURIFromShareItem(item, asClient: "abcdefghijkl")
+            SyncCommand.displayURIFromShareItem(item, asClient: "abcdefghijkl")
         }
 
         let a = self.expectation(description: "Wipe for all clients.")

--- a/Tests/StorageTests/TestBrowserDB.swift
+++ b/Tests/StorageTests/TestBrowserDB.swift
@@ -33,16 +33,20 @@ class TestBrowserDB: XCTestCase {
     }
 
     class MockFailingSchema: Schema {
-        var name: String { return "FAILURE" }
-        var version: Int { return BrowserSchema.DefaultVersion + 1 }
+        var name: String {
+            "FAILURE"
+        }
+        var version: Int {
+            BrowserSchema.DefaultVersion + 1
+        }
         func drop(_ db: SQLiteDBConnection) -> Bool {
-            return true
+            true
         }
         func create(_ db: SQLiteDBConnection) -> Bool {
-            return false
+            false
         }
         func update(_ db: SQLiteDBConnection, from: Int) -> Bool {
-            return false
+            false
         }
     }
 

--- a/Tests/StorageTests/TestSQLiteHistory.swift
+++ b/Tests/StorageTests/TestSQLiteHistory.swift
@@ -10,19 +10,23 @@ import Shared
 import XCTest
 
 class BaseHistoricalBrowserSchema: Schema {
-    var name: String { return "BROWSER" }
-    var version: Int { return -1 }
+    var name: String {
+        "BROWSER"
+    }
+    var version: Int {
+        -1
+    }
 
     func update(_ db: SQLiteDBConnection, from: Int) -> Bool {
         fatalError("Should never be called.")
     }
 
     func create(_ db: SQLiteDBConnection) -> Bool {
-        return false
+        false
     }
 
     func drop(_ db: SQLiteDBConnection) -> Bool {
-        return false
+        false
     }
 
     var supportsPartialIndices: Bool {
@@ -87,7 +91,9 @@ class BaseHistoricalBrowserSchema: Schema {
 // These tests snapshot the table creation code at each of these points.
 
 class BrowserSchemaV6: BaseHistoricalBrowserSchema {
-    override var version: Int { return 6 }
+    override var version: Int {
+        6
+    }
 
     func prepopulateRootFolders(_ db: SQLiteDBConnection) -> Bool {
         let type = 2 // "folder"
@@ -266,7 +272,9 @@ class BrowserSchemaV6: BaseHistoricalBrowserSchema {
 }
 
 class BrowserSchemaV7: BaseHistoricalBrowserSchema {
-    override var version: Int { return 7 }
+    override var version: Int {
+        7
+    }
 
     func prepopulateRootFolders(_ db: SQLiteDBConnection) -> Bool {
         let type = 2 // "folder"
@@ -450,7 +458,9 @@ class BrowserSchemaV7: BaseHistoricalBrowserSchema {
 }
 
 class BrowserSchemaV8: BaseHistoricalBrowserSchema {
-    override var version: Int { return 8 }
+    override var version: Int {
+        8
+    }
 
     func prepopulateRootFolders(_ db: SQLiteDBConnection) -> Bool {
         let type = 2 // "folder"
@@ -649,7 +659,9 @@ class BrowserSchemaV8: BaseHistoricalBrowserSchema {
 }
 
 class BrowserSchemaV10: BaseHistoricalBrowserSchema {
-    override var version: Int { return 10 }
+    override var version: Int {
+        10
+    }
 
     func prepopulateRootFolders(_ db: SQLiteDBConnection) -> Bool {
         let type = 2 // "folder"
@@ -1112,17 +1124,17 @@ class TestSQLiteHistory: XCTestCase {
         let updateTopSites: [(String, Args?)] = [(clearTopSites, nil), (history.getFrecentHistory().updateTopSitesCacheQuery())]
 
         func countTopSites() -> Deferred<Maybe<Cursor<Int>>> {
-            return db.runQuery("SELECT count(*) FROM cached_top_sites", args: nil, factory: { sdrow -> Int in
-                return sdrow[0] as? Int ?? 0
+            db.runQuery("SELECT count(*) FROM cached_top_sites", args: nil, factory: { sdrow -> Int in
+                sdrow[0] as? Int ?? 0
             })
         }
 
         history.clearHistory().bind({ success in
-            return all([history.addLocalVisit(SiteVisit(site: site11, date: Date.nowMicroseconds(), type: VisitType.link)),
-                        history.addLocalVisit(SiteVisit(site: site12, date: Date.nowMicroseconds(), type: VisitType.link)),
-                        history.addLocalVisit(SiteVisit(site: site3, date: Date.nowMicroseconds(), type: VisitType.link))])
+                    all([history.addLocalVisit(SiteVisit(site: site11, date: Date.nowMicroseconds(), type: VisitType.link)),
+                         history.addLocalVisit(SiteVisit(site: site12, date: Date.nowMicroseconds(), type: VisitType.link)),
+                         history.addLocalVisit(SiteVisit(site: site3, date: Date.nowMicroseconds(), type: VisitType.link))])
         }).bind({ (results: [Maybe<()>]) in
-            return history.insertOrUpdatePlace(site13, modified: Date.nowMicroseconds())
+                    history.insertOrUpdatePlace(site13, modified: Date.nowMicroseconds())
         }).bind({ guid -> Success in
             XCTAssertEqual(guid.successValue!, initialGuid, "Guid is correct")
             return db.run(updateTopSites)
@@ -1145,7 +1157,6 @@ class TestSQLiteHistory: XCTestCase {
         })
 
         waitForExpectations(timeout: 10.0) { error in
-            return
         }
     }
 
@@ -1187,30 +1198,30 @@ class TestSQLiteHistory: XCTestCase {
         }
 
         func checkSitesByFrecency(_ f: @escaping (Cursor<Site>) -> Success) -> () -> Success {
-            return {
+            {
                 history.getFrecentHistory().getSites(matchingSearchQuery: nil, limit: 10)
-                    >>== f
+                        >>== f
             }
         }
 
         func checkSitesByDate(_ f: @escaping (Cursor<Site>) -> Success) -> () -> Success {
-            return {
+            {
                 history.getSitesByLastVisit(limit: 10, offset: 0)
-                >>== f
+                        >>== f
             }
         }
 
         func checkSitesWithFilter(_ filter: String, f: @escaping (Cursor<Site>) -> Success) -> () -> Success {
-            return {
+            {
                 history.getFrecentHistory().getSites(matchingSearchQuery: filter, limit: 10)
-                >>== f
+                        >>== f
             }
         }
 
         func checkDeletedCount(_ expected: Int) -> () -> Success {
-            return {
+            {
                 history.getDeletedHistoryToUpload()
-                >>== { guids in
+                        >>== { guids in
                     XCTAssertEqual(expected, guids.count)
                     return succeed()
                 }
@@ -1283,7 +1294,6 @@ class TestSQLiteHistory: XCTestCase {
             >>> done
 
         waitForExpectations(timeout: 10.0) { error in
-            return
         }
     }
 
@@ -1374,11 +1384,11 @@ class TestSQLiteHistory: XCTestCase {
         }
 
         func loadCache() -> Success {
-            return history.repopulate(invalidateTopSites: true) >>> succeed
+            history.repopulate(invalidateTopSites: true) >>> succeed
         }
 
         func checkTopSitesReturnsResults() -> Success {
-            return history.getTopSitesWithLimit(20) >>== { topSites in
+            history.getTopSitesWithLimit(20) >>== { topSites in
                 XCTAssertEqual(topSites.count, 20)
                 XCTAssertEqual(topSites[0]!.guid, "abc\(5)defhi")
                 return succeed()
@@ -1390,7 +1400,6 @@ class TestSQLiteHistory: XCTestCase {
             >>> done
 
         waitForExpectations(timeout: 10.0) { error in
-            return
         }
     }
 
@@ -1427,11 +1436,11 @@ class TestSQLiteHistory: XCTestCase {
         }
 
         func loadCache() -> Success {
-            return history.repopulate(invalidateTopSites: true) >>> succeed
+            history.repopulate(invalidateTopSites: true) >>> succeed
         }
 
         func checkTopSitesReturnsResults() -> Success {
-            return history.getTopSitesWithLimit(20) >>== { topSites in
+            history.getTopSitesWithLimit(20) >>== { topSites in
                 XCTAssertEqual(topSites[0]?.guid, "docsgoogle") // google docs should be the first topsite
                 // make sure all other google guids are not in the topsites array
                 topSites.forEach {
@@ -1448,7 +1457,6 @@ class TestSQLiteHistory: XCTestCase {
             >>> done
 
         waitForExpectations(timeout: 10.0) { error in
-            return
         }
     }
 
@@ -1478,11 +1486,11 @@ class TestSQLiteHistory: XCTestCase {
         }
 
         func loadCache() -> Success {
-            return history.repopulate(invalidateTopSites: true) >>> succeed
+            history.repopulate(invalidateTopSites: true) >>> succeed
         }
 
         func checkTopSitesReturnsResults() -> Success {
-            return history.getTopSitesWithLimit(20) >>== { topSites in
+            history.getTopSitesWithLimit(20) >>== { topSites in
                 XCTAssertEqual(topSites.count, 20)
                 XCTAssertEqual(topSites[0]!.guid, "abc\(5)def")
                 return succeed()
@@ -1490,8 +1498,8 @@ class TestSQLiteHistory: XCTestCase {
         }
 
         func invalidateIfNeededDoesntChangeResults() -> Success {
-            return history.repopulate(invalidateTopSites: true) >>> {
-                return history.getTopSitesWithLimit(20) >>== { topSites in
+            history.repopulate(invalidateTopSites: true) >>> {
+                history.getTopSitesWithLimit(20) >>== { topSites in
                     XCTAssertEqual(topSites.count, 20)
                     XCTAssertEqual(topSites[0]!.guid, "abc\(5)def")
                     return succeed()
@@ -1533,7 +1541,6 @@ class TestSQLiteHistory: XCTestCase {
             >>> done
 
         waitForExpectations(timeout: 10.0) { error in
-            return
         }
     }
 
@@ -1568,14 +1575,14 @@ class TestSQLiteHistory: XCTestCase {
         }
 
         func addPinnedSites() -> Success {
-            return history.addPinnedTopSite(site1) >>== {
+            history.addPinnedTopSite(site1) >>== {
                 sleep(1) // Sleep to prevent intermittent issue with sorting on the timestamp
                 return history.addPinnedTopSite(site2)
             }
         }
 
         func checkPinnedSites() -> Success {
-            return history.getPinnedTopSites() >>== { pinnedSites in
+            history.getPinnedTopSites() >>== { pinnedSites in
                 XCTAssertEqual(pinnedSites.count, 2)
                 XCTAssertEqual(pinnedSites[0]!.url, site2.url)
                 XCTAssertEqual(pinnedSites[1]!.url, site1.url, "The older pinned site should be last")
@@ -1584,8 +1591,8 @@ class TestSQLiteHistory: XCTestCase {
         }
 
         func removePinnedSites() -> Success {
-            return history.removeFromPinnedTopSites(site2) >>== {
-                return history.getPinnedTopSites() >>== { pinnedSites in
+            history.removeFromPinnedTopSites(site2) >>== {
+                history.getPinnedTopSites() >>== { pinnedSites in
                     XCTAssertEqual(pinnedSites.count, 1, "There should only be one pinned site")
                     XCTAssertEqual(pinnedSites[0]!.url, site1.url, "Site2 should be the only pin left")
                     return succeed()
@@ -1594,8 +1601,8 @@ class TestSQLiteHistory: XCTestCase {
         }
 
         func dupePinnedSite() -> Success {
-            return history.addPinnedTopSite(site1) >>== {
-                return history.getPinnedTopSites() >>== { pinnedSites in
+            history.addPinnedTopSite(site1) >>== {
+                history.getPinnedTopSites() >>== { pinnedSites in
                     XCTAssertEqual(pinnedSites.count, 1, "There should not be a dupe")
                     XCTAssertEqual(pinnedSites[0]!.url, site1.url, "Site2 should be the only pin left")
                     return succeed()
@@ -1604,8 +1611,8 @@ class TestSQLiteHistory: XCTestCase {
         }
 
         func removeHistory() -> Success {
-            return history.clearHistory() >>== {
-                return history.getPinnedTopSites() >>== { pinnedSites in
+            history.clearHistory() >>== {
+                history.getPinnedTopSites() >>== { pinnedSites in
                     XCTAssertEqual(pinnedSites.count, 1, "Pinned sites should exist after a history clear")
                     return succeed()
                 }
@@ -1620,7 +1627,6 @@ class TestSQLiteHistory: XCTestCase {
             >>> done
 
         waitForExpectations(timeout: 10.0) { error in
-            return
         }
 
     }
@@ -1651,14 +1657,14 @@ class TestSQLiteHistory: XCTestCase {
         }
 
         func addPinnedSites() -> Success {
-            return history.addPinnedTopSite(site1) >>== {
+            history.addPinnedTopSite(site1) >>== {
                 sleep(1) // Sleep to prevent intermittent issue with sorting on the timestamp
                 return history.addPinnedTopSite(site2)
             }
         }
 
         func checkPinnedSites() -> Success {
-            return history.getPinnedTopSites() >>== { pinnedSites in
+            history.getPinnedTopSites() >>== { pinnedSites in
                 XCTAssertEqual(pinnedSites.count, 2)
                 XCTAssertEqual(pinnedSites[0]!.url, site2.url)
                 XCTAssertEqual(pinnedSites[1]!.url, site1.url, "The older pinned site should be last")
@@ -1667,8 +1673,8 @@ class TestSQLiteHistory: XCTestCase {
         }
 
         func removePinnedSites() -> Success {
-            return history.removeFromPinnedTopSites(site2) >>== {
-                return history.getPinnedTopSites() >>== { pinnedSites in
+            history.removeFromPinnedTopSites(site2) >>== {
+                history.getPinnedTopSites() >>== { pinnedSites in
                     XCTAssertEqual(pinnedSites.count, 1, "There should only be one pinned site")
                     XCTAssertEqual(pinnedSites[0]!.url, site1.url, "Site2 should be the only pin left")
                     return succeed()
@@ -1677,8 +1683,8 @@ class TestSQLiteHistory: XCTestCase {
         }
 
         func removeHistory() -> Success {
-            return history.clearHistory() >>== {
-                return history.getPinnedTopSites() >>== { pinnedSites in
+            history.clearHistory() >>== {
+                history.getPinnedTopSites() >>== { pinnedSites in
                     XCTAssertEqual(pinnedSites.count, 2, "Pinned sites should exist after a history clear")
                     return succeed()
                 }
@@ -1691,7 +1697,6 @@ class TestSQLiteHistory: XCTestCase {
             >>> done
 
         waitForExpectations(timeout: 10.0) { error in
-            return
         }
     }
 }

--- a/Tests/StorageTests/TestSQLiteMetadata.swift
+++ b/Tests/StorageTests/TestSQLiteMetadata.swift
@@ -99,7 +99,7 @@ private func metadataFromDB(_ db: BrowserDB) -> Deferred<Maybe<Cursor<PageMetada
 }
 
 private func removeAllMetadata(_ db: BrowserDB) -> Success {
-    return db.run("DELETE FROM page_metadata")
+    db.run("DELETE FROM page_metadata")
 }
 
 private func pageMetadataFactory(_ row: SDRow) -> PageMetadata {

--- a/Tests/StorageTests/TestSQLiteRemoteClientsAndTabs.swift
+++ b/Tests/StorageTests/TestSQLiteRemoteClientsAndTabs.swift
@@ -74,54 +74,72 @@ open class MockRemoteClientsAndTabs: RemoteClientsAndTabs {
     }
 
     open func onRemovedAccount() -> Success {
-        return succeed()
+        succeed()
     }
 
     open func wipeClients() -> Success {
-        return succeed()
+        succeed()
     }
 
     open func insertOrUpdateClients(_ clients: [RemoteClient]) -> Deferred<Maybe<Int>> {
-        return deferMaybe(0)
+        deferMaybe(0)
     }
 
     open func insertOrUpdateClient(_ client: RemoteClient) -> Deferred<Maybe<Int>> {
-        return deferMaybe(0)
+        deferMaybe(0)
     }
 
     open func getClients() -> Deferred<Maybe<[RemoteClient]>> {
-        return deferMaybe(self.clientsAndTabs.map { $0.client })
+        deferMaybe(self.clientsAndTabs.map {
+            $0.client
+        })
     }
 
     public func getClient(guid: GUID) -> Deferred<Maybe<RemoteClient?>> {
-        return deferMaybe(self.clientsAndTabs.find { clientAndTabs in
-            return clientAndTabs.client.guid == guid
-        }?.client)
+        deferMaybe(self.clientsAndTabs.find { clientAndTabs in
+                    clientAndTabs.client.guid == guid
+                }?
+                .client)
     }
 
     public func getClient(fxaDeviceId: GUID) -> Deferred<Maybe<RemoteClient?>> {
-        return deferMaybe(self.clientsAndTabs.find { clientAndTabs in
-            return clientAndTabs.client.fxaDeviceId == fxaDeviceId
-            }?.client)
+        deferMaybe(self.clientsAndTabs.find { clientAndTabs in
+                    clientAndTabs.client.fxaDeviceId == fxaDeviceId
+                }?
+                .client)
     }
 
     open func getClientGUIDs() -> Deferred<Maybe<Set<GUID>>> {
-        return deferMaybe(Set<GUID>(optFilter(self.clientsAndTabs.map { $0.client.guid })))
+        deferMaybe(Set<GUID>(optFilter(self.clientsAndTabs.map {
+            $0.client.guid
+        })))
     }
 
-    open func deleteClient(guid: GUID) -> Success { return succeed() }
+    open func deleteClient(guid: GUID) -> Success {
+        succeed()
+    }
 
-    open func deleteCommands() -> Success { return succeed() }
-    open func deleteCommands(_ clientGUID: GUID) -> Success { return succeed() }
+    open func deleteCommands() -> Success {
+        succeed()
+    }
+    open func deleteCommands(_ clientGUID: GUID) -> Success {
+        succeed()
+    }
 
-    open func getCommands() -> Deferred<Maybe<[GUID: [SyncCommand]]>> { return deferMaybe([GUID: [SyncCommand]]()) }
+    open func getCommands() -> Deferred<Maybe<[GUID: [SyncCommand]]>> {
+        deferMaybe([GUID: [SyncCommand]]())
+    }
 
-    open func insertCommand(_ command: SyncCommand, forClients clients: [RemoteClient]) -> Deferred<Maybe<Int>> { return deferMaybe(0) }
-    open func insertCommands(_ commands: [SyncCommand], forClients clients: [RemoteClient]) -> Deferred<Maybe<Int>> { return deferMaybe(0) }
+    open func insertCommand(_ command: SyncCommand, forClients clients: [RemoteClient]) -> Deferred<Maybe<Int>> {
+        deferMaybe(0)
+    }
+    open func insertCommands(_ commands: [SyncCommand], forClients clients: [RemoteClient]) -> Deferred<Maybe<Int>> {
+        deferMaybe(0)
+    }
 }
 
 func removeLocalClient(_ a: ClientAndTabs) -> Bool {
-    return a.client.guid != nil
+    a.client.guid != nil
 }
 
 class SQLRemoteClientsAndTabsTests: XCTestCase {

--- a/Tests/SyncTelemetryTests/EventTests.swift
+++ b/Tests/SyncTelemetryTests/EventTests.swift
@@ -64,23 +64,23 @@ class EventTests: XCTestCase {
 // Builder methods for easier mocking of the pickled/unpickled events
 extension EventTests {
     fileprivate func basicEventString(timestamp: Timestamp) -> String {
-        return "[\(timestamp),\"test\",\"pickling\",\"this\",null,null]"
+        "[\(timestamp),\"test\",\"pickling\",\"this\",null,null]"
     }
 
     fileprivate func basicWithValueString(timestamp: Timestamp) -> String {
-        return "[\(timestamp),\"test\",\"pickling\",\"this\",\"value\",null]"
+        "[\(timestamp),\"test\",\"pickling\",\"this\",\"value\",null]"
     }
 
     fileprivate func extraEventString(timestamp: Timestamp) -> String {
-        return "[\(timestamp),\"test\",\"pickling\",\"this\",\"value\",{\"flowID\":\"testFlowID\"}]"
+        "[\(timestamp),\"test\",\"pickling\",\"this\",\"value\",{\"flowID\":\"testFlowID\"}]"
     }
 
     fileprivate func basicEvent(timestamp: Timestamp) -> Event {
-        return Event(timestamp: timestamp, category: "test", method: "pickling", object: "this")
+        Event(timestamp: timestamp, category: "test", method: "pickling", object: "this")
     }
 
     fileprivate func basicWithValueEvent(timestamp: Timestamp) -> Event {
-        return Event(timestamp: timestamp, category: "test", method: "pickling", object: "this", value: "value")
+        Event(timestamp: timestamp, category: "test", method: "pickling", object: "this", value: "value")
     }
 
     fileprivate func extraEvent(timestamp: Timestamp) -> Event {

--- a/Tests/SyncTests/BatchingClientTests.swift
+++ b/Tests/SyncTests/BatchingClientTests.swift
@@ -11,17 +11,17 @@ import SwiftyJSON
 
 // Always return a gigantic encoded payload.
 private func massivify<T>(_ record: Record<T>) -> JSON? {
-    return JSON([
+    JSON([
         "id": record.id,
         "foo": String(repeating: "X", count: Sync15StorageClient.maxRecordSizeBytes + 1)
     ])
 }
 
 private func basicSerializer<T>(record: Record<T>) -> String {
-    return JSON([
+    JSON([
         "id": record.id,
         "payload": record.payload.json.dictionaryObject as Any
-        ]).stringify()!
+    ]).stringify()!
 }
 
 // Create a basic record with an ID and a title that is the `Site$ID`.
@@ -62,7 +62,7 @@ private func deferEmptyResponse(token batchToken: BatchToken? = nil, lastModifie
 
 // Small helper operator for comparing query parameters below
 private func == (param1: NSURLQueryItem, param2: NSURLQueryItem) -> Bool {
-    return param1.name == param2.name && param1.value == param2.value
+    param1.name == param2.name && param1.value == param2.value
 }
 
 private let miniConfig = InfoConfiguration(maxRequestBytes: 1_048_576, maxPostRecords: 2, maxPostBytes: 1_048_576, maxTotalRecords: 10, maxTotalBytes: 104_857_600)
@@ -245,7 +245,7 @@ class Sync15BatchClientTests: XCTestCase {
         var linesSent = [String]()
 
         let allRecords: [Record<CleartextPayloadJSON>] = "ABCDEF".reduce([]) { list, char in
-            return list + [createRecordWithID(id: String(char))]
+            list + [createRecordWithID(id: String(char))]
         }
 
         // Since we never return a batch token, the batch client won't batch upload and default to single POSTs
@@ -322,7 +322,7 @@ class Sync15BatchClientTests: XCTestCase {
         var linesSent = [String]()
 
         let allRecords: [Record<CleartextPayloadJSON>] = "ABC".reduce([]) { list, char in
-            return list + [createRecordWithID(id: String(char))]
+            list + [createRecordWithID(id: String(char))]
         }
 
         // Since we never return a batch token, the batch client won't batch upload and default to single POSTs
@@ -393,7 +393,7 @@ class Sync15BatchClientTests: XCTestCase {
         var linesSent = [String]()
 
         let allRecords: [Record<CleartextPayloadJSON>] = "ABCDE".reduce([]) { list, char in
-            return list + [createRecordWithID(id: String(char))]
+            list + [createRecordWithID(id: String(char))]
         }
 
         // Since we never return a batch token, the batch client won't batch upload and default to single POSTs
@@ -526,7 +526,7 @@ class Sync15BatchClientTests: XCTestCase {
         var linesSent = [String]()
 
         let allRecords: [Record<CleartextPayloadJSON>] = "ABCDEFGHIJKL".reduce([]) { list, char in
-            return list + [createRecordWithID(id: String(char))]
+            list + [createRecordWithID(id: String(char))]
         }
 
         // For each upload, verify that we are getting the correct queryParams and records to be sent.

--- a/Tests/SyncTests/CryptoTests.swift
+++ b/Tests/SyncTests/CryptoTests.swift
@@ -54,7 +54,7 @@ c2l0cyI6W3siZGF0ZSI6MTMxOTE0OTAxMjM3MjQyNSwidHlwZSI6MX1dfQ==
     }
 
     func dataFromBase64(b64: String) -> Data {
-        return Bytes.dataFromBase64(b64)!
+        Bytes.dataFromBase64(b64)!
     }
 
     func testDecrypt() {

--- a/Tests/SyncTests/DownloadTests.swift
+++ b/Tests/SyncTests/DownloadTests.swift
@@ -9,7 +9,7 @@ import Shared
 import XCTest
 
 func identity<T>(x: T) -> T {
-    return x
+    x
 }
 
 class DownloadTests: XCTestCase {

--- a/Tests/SyncTests/HistorySynchronizerTests.swift
+++ b/Tests/SyncTests/HistorySynchronizerTests.swift
@@ -35,7 +35,9 @@ class MockSyncableHistory {
     }
 
     fileprivate func placeForURL(url: String) -> DBPlace? {
-        return findOneValue(places) { $0.url == url }
+        findOneValue(places) {
+            $0.url == url
+        }
     }
 }
 
@@ -148,35 +150,35 @@ extension MockSyncableHistory: SyncableHistory {
 
     func getModifiedHistoryToUpload() -> Deferred<Maybe<[(Place, [Visit])]>> {
         // TODO.
-        return deferMaybe([])
+        deferMaybe([])
     }
 
     func getDeletedHistoryToUpload() -> Deferred<Maybe<[GUID]>> {
         // TODO.
-        return deferMaybe([])
+        deferMaybe([])
     }
 
     func markAsSynchronized(_: [GUID], modified: Timestamp) -> Deferred<Maybe<Timestamp>> {
         // TODO
-        return deferMaybe(0)
+        deferMaybe(0)
     }
 
     func markAsDeleted(_: [GUID]) -> Success {
         // TODO
-        return succeed()
+        succeed()
     }
 
     func onRemovedAccount() -> Success {
         // TODO
-        return succeed()
+        succeed()
     }
 
     func doneApplyingRecordsAfterDownload() -> Success {
-        return succeed()
+        succeed()
     }
 
     func doneUpdatingMetadataAfterUpload() -> Success {
-        return succeed()
+        succeed()
     }
 }
 

--- a/Tests/SyncTests/MetaGlobalTests.swift
+++ b/Tests/SyncTests/MetaGlobalTests.swift
@@ -23,7 +23,7 @@ class MockSyncAuthState: SyncAuthState {
     let kSync: Data
 
     var deviceID: String? {
-        return "mock_device_id"
+        "mock_device_id"
     }
 
     init(serverRoot: String, kSync: Data) {

--- a/Tests/SyncTests/MockSyncServer.swift
+++ b/Tests/SyncTests/MockSyncServer.swift
@@ -95,7 +95,7 @@ struct SyncDeleteRequestSpec {
     static func fromRequest(request: GCDWebServerRequest) -> SyncDeleteRequestSpec? {
         // Input is "/1.5/user{/storage{/collection{/id}}}".
         // That means we get four, five, or six path components here, the first being empty.
-        return SyncDeleteRequestSpec.fromPath(path: request.path, withQuery: request.query! as [NSString: AnyObject])
+        SyncDeleteRequestSpec.fromPath(path: request.path, withQuery: request.query! as [NSString: AnyObject])
     }
 
     static func fromPath(path: String, withQuery query: [NSString: AnyObject]) -> SyncDeleteRequestSpec? {
@@ -200,7 +200,7 @@ class MockSyncServer {
     }
 
     private func splitArray<T>(items: [T], at: Int) -> ([T], [T]) {
-        return (Array(items.dropLast(items.count - at)), Array(items.dropFirst(at)))
+        (Array(items.dropLast(items.count - at)), Array(items.dropFirst(at)))
     }
 
     private func recordsMatchingSpec(spec: SyncRequestSpec) -> (records: [EnvelopeJSON], offsetID: String?)? {
@@ -286,7 +286,7 @@ class MockSyncServer {
     }
 
     func modifiedTimeForCollection(collection: String) -> Timestamp? {
-        return self.collections[collection]?.modified
+        self.collections[collection]?.modified
     }
 
     func removeAllItemsFromCollection(collection: String, atTime: Timestamp) {

--- a/Tests/SyncTests/Mocking.swift
+++ b/Tests/SyncTests/Mocking.swift
@@ -15,7 +15,7 @@ class MockBackoffStorage: BackoffStorage {
     }
 
     func isInBackoff(_ now: Timestamp) -> Timestamp? {
-        return nil
+        nil
     }
 }
 
@@ -35,11 +35,11 @@ class MockSyncCollectionClient<T: CleartextPayloadJSON>: Sync15CollectionClient<
     }
 
     override func newBatch(ifUnmodifiedSince: Timestamp? = nil, onCollectionUploaded: @escaping (POSTResult, Timestamp?) -> DeferredTimestamp) -> Sync15BatchClient<T> {
-        return Sync15BatchClient(config: self.infoConfig,
-                                 ifUnmodifiedSince: ifUnmodifiedSince,
-                                 serializeRecord: self.serializeRecord,
-                                 uploader: self.uploader,
-                                 onCollectionUploaded: onCollectionUploaded)
+        Sync15BatchClient(config: self.infoConfig,
+                ifUnmodifiedSince: ifUnmodifiedSince,
+                serializeRecord: self.serializeRecord,
+                uploader: self.uploader,
+                onCollectionUploaded: onCollectionUploaded)
     }
 }
 

--- a/Tests/SyncTests/RecordTests.swift
+++ b/Tests/SyncTests/RecordTests.swift
@@ -124,12 +124,12 @@ class RecordTests: XCTestCase {
 
         let cleartextClientsFactory: (String) -> ClientPayload? = {
             (s: String) -> ClientPayload? in
-            return ClientPayload(s)
+            ClientPayload(s)
         }
 
         let clearFactory: (String) -> CleartextPayloadJSON? = {
             (s: String) -> CleartextPayloadJSON? in
-            return CleartextPayloadJSON(s)
+            CleartextPayloadJSON(s)
         }
 
         print(clientPayload, terminator: "\n")
@@ -191,7 +191,7 @@ c2d37dac\\\"}\", \"id\": \"0-P9fabp9vJD\", \"modified\": 1326254123.65}
         let encryptClient = keysPayloadSerializer(keyBundle: keyBundle, { $0.json }) // It's already a JSON.
 
         let toRecord = {
-            return Record<CleartextPayloadJSON>.fromEnvelope($0, payloadFactory: decryptClient)
+            Record<CleartextPayloadJSON>.fromEnvelope($0, payloadFactory: decryptClient)
         }
 
         let envelope = EnvelopeJSON(inputString)

--- a/Tests/SyncTests/StateTests.swift
+++ b/Tests/SyncTests/StateTests.swift
@@ -64,7 +64,7 @@ class StateTests: XCTestCase {
     }
 
     func getEngineConfiguration() -> EngineConfiguration {
-        return EngineConfiguration(enabled: ["bookmarks", "clients"], declined: ["tabs"])
+        EngineConfiguration(enabled: ["bookmarks", "clients"], declined: ["tabs"])
     }
 
     func baseScratchpad() -> Scratchpad {

--- a/Tests/SyncTests/StorageClientTests.swift
+++ b/Tests/SyncTests/StorageClientTests.swift
@@ -12,7 +12,7 @@ import SwiftyJSON
 
 // Always return a gigantic encoded payload.
 func massivify(record: Record<CleartextPayloadJSON>) -> JSON? {
-    return JSON([
+    JSON([
         "id": record.id,
         "foo": String(repeating: "X", count: Sync15StorageClient.maxRecordSizeBytes + 1)
     ])

--- a/Tests/SyncTests/SyncTelemetryTests.swift
+++ b/Tests/SyncTests/SyncTelemetryTests.swift
@@ -13,7 +13,7 @@ private class MockFailure<T: CleartextPayloadJSON>: MaybeErrorType {
     let record: Record<T>
 
     var description: String {
-        return "Failed to store or upload record: \(record)"
+        "Failed to store or upload record: \(record)"
     }
 
     init(record: Record<T>) {
@@ -48,7 +48,7 @@ extension SyncTelemetryTests {
         let remoteRecords = [A, B]
 
         _ = synchronizer.applyIncomingRecords(remoteRecords) { record in
-            return record.id == "B" ? deferMaybe(MockFailure(record: record)) : succeed()
+                    record.id == "B" ? deferMaybe(MockFailure(record: record)) : succeed()
         }.value
 
         let session = synchronizer.statsSession.end()
@@ -73,7 +73,7 @@ extension SyncTelemetryTests {
         let records = [A, B]
 
         _ = synchronizer.applyIncomingToStorage(records, fetched: Date.now()) { record in
-            return record.id == "B" ? deferMaybe(MockFailure(record: record)) : succeed()
+                    record.id == "B" ? deferMaybe(MockFailure(record: record)) : succeed()
         }.value
 
         let session = synchronizer.statsSession.end()
@@ -108,7 +108,7 @@ extension SyncTelemetryTests {
         let miniConfig = InfoConfiguration(maxRequestBytes: 1_048_576, maxPostRecords: 2, maxPostBytes: 1_048_576, maxTotalRecords: 10, maxTotalBytes: 104_857_600)
         let collectionClient = MockSyncCollectionClient(uploader: uploader, infoConfig: miniConfig, collection: "mockdata", encrypter: getEncrypter())
         _ = synchronizer.uploadRecords(records, lastTimestamp: now, storageClient: collectionClient) { _, _ in
-            return deferMaybe(now)
+                    deferMaybe(now)
         }.value
 
         let uploadStats = synchronizer.statsSession.uploadStats

--- a/Tests/UITests/Global.swift
+++ b/Tests/UITests/Global.swift
@@ -13,11 +13,11 @@ let LabelAddressAndSearch = "Address and Search"
 
 extension XCTestCase {
     func tester(_ file: String = #file, _ line: Int = #line) -> KIFUITestActor {
-        return KIFUITestActor(inFile: file, atLine: line, delegate: self)
+        KIFUITestActor(inFile: file, atLine: line, delegate: self)
     }
 
     func system(_ file: String = #file, _ line: Int = #line) -> KIFSystemTestActor {
-        return KIFSystemTestActor(inFile: file, atLine: line, delegate: self)
+        KIFSystemTestActor(inFile: file, atLine: line, delegate: self)
     }
 }
 
@@ -25,7 +25,7 @@ extension KIFUITestActor {
     /// Looks for a view with the given accessibility hint.
     func tryFindingViewWithAccessibilityHint(_ hint: String) -> Bool {
         let element = UIApplication.shared.accessibilityElement { element in
-            return element?.accessibilityHint! == hint
+            element?.accessibilityHint! == hint
         }
 
         return element != nil
@@ -50,7 +50,7 @@ extension KIFUITestActor {
 
     func viewExistsWithLabelPrefixedBy(_ prefix: String) -> Bool {
         let element = UIApplication.shared.accessibilityElement { element in
-            return element?.accessibilityLabel?.hasPrefix(prefix) ?? false
+            element?.accessibilityLabel?.hasPrefix(prefix) ?? false
         }
         return element != nil
     }
@@ -61,7 +61,7 @@ extension KIFUITestActor {
 
         run { _ in
             element = UIApplication.shared.accessibilityElement { element in
-                return element?.accessibilityValue == value
+                element?.accessibilityValue == value
             }
 
             return (element == nil) ? KIFTestStepResult.wait : KIFTestStepResult.success
@@ -176,7 +176,9 @@ extension KIFUITestActor {
             stepResult = KIFTestStepResult.success
         }
 
-        run { _ in return stepResult }
+        run { _ in
+            stepResult
+        }
 
         return found
     }
@@ -186,7 +188,7 @@ extension KIFUITestActor {
 
         // Wait for the web view to stop loading.
         run { _ in
-            return webView.isLoading ? KIFTestStepResult.wait : KIFTestStepResult.success
+            webView.isLoading ? KIFTestStepResult.wait : KIFTestStepResult.success
         }
         var stepResult = KIFTestStepResult.wait
 
@@ -200,7 +202,9 @@ extension KIFUITestActor {
             stepResult = KIFTestStepResult.success
         }
 
-        run { _ in return stepResult }
+        run { _ in
+            stepResult
+        }
 
         return webView
     }
@@ -262,7 +266,7 @@ class BrowserUtils {
     }
     
     class func iPad() -> Bool {
-        return UIDevice.current.userInterfaceIdiom == .pad
+        UIDevice.current.userInterfaceIdiom == .pad
     }
 
     /// Injects a URL and title into the browser's history database.
@@ -391,7 +395,7 @@ class SimplePageServer {
 
         for page in ["findPage", "noTitle", "readablePage", "JSPrompt", "blobURL", "firefoxScheme"] {
             webServer.addHandler(forMethod: "GET", path: "/\(page).html", request: GCDWebServerRequest.self) { (request) -> GCDWebServerResponse? in
-                return GCDWebServerDataResponse(html: self.getPageData(page))
+                GCDWebServerDataResponse(html: self.getPageData(page))
             }
         }
 
@@ -413,19 +417,19 @@ class SimplePageServer {
         }
 
         webServer.addHandler(forMethod: "GET", path: "/readerContent.html", request: GCDWebServerRequest.self) { (request) -> GCDWebServerResponse? in
-            return GCDWebServerDataResponse(html: self.getPageData("readerContent"))
+            GCDWebServerDataResponse(html: self.getPageData("readerContent"))
         }
 
         webServer.addHandler(forMethod: "GET", path: "/loginForm.html", request: GCDWebServerRequest.self) { _ in
-            return GCDWebServerDataResponse(html: self.getPageData("loginForm"))
+            GCDWebServerDataResponse(html: self.getPageData("loginForm"))
         }
 
         webServer.addHandler(forMethod: "GET", path: "/navigationDelegate.html", request: GCDWebServerRequest.self) { _ in
-            return GCDWebServerDataResponse(html: self.getPageData("navigationDelegate"))
+            GCDWebServerDataResponse(html: self.getPageData("navigationDelegate"))
         }
 
         webServer.addHandler(forMethod: "GET", path: "/localhostLoad.html", request: GCDWebServerRequest.self) { _ in
-            return GCDWebServerDataResponse(html: self.getPageData("localhostLoad"))
+            GCDWebServerDataResponse(html: self.getPageData("localhostLoad"))
         }
 
         webServer.addHandler(forMethod: "GET", path: "/auth.html", request: GCDWebServerRequest.self) { (request: GCDWebServerRequest?) in
@@ -478,12 +482,12 @@ class SimplePageServer {
 
         // Add tracking protection check page
         webServer.addHandler(forMethod: "GET", path: "/tracking-protection-test.html", request: GCDWebServerRequest.self) { (request: GCDWebServerRequest?) in
-            return GCDWebServerDataResponse(html: htmlForImageBlockingTest(imageURL: "http://ymail.com/favicon.ico"))
+            GCDWebServerDataResponse(html: htmlForImageBlockingTest(imageURL: "http://ymail.com/favicon.ico"))
         }
 
         // Add image blocking test page
         webServer.addHandler(forMethod: "GET", path: "/hide-images-test.html", request: GCDWebServerRequest.self) { (request: GCDWebServerRequest?) in
-            return GCDWebServerDataResponse(html: htmlForImageBlockingTest(imageURL: "https://www.mozilla.com/favicon.ico"))
+            GCDWebServerDataResponse(html: htmlForImageBlockingTest(imageURL: "https://www.mozilla.com/favicon.ico"))
         }
 
 

--- a/Tests/UITests/LoginManagerTests.swift
+++ b/Tests/UITests/LoginManagerTests.swift
@@ -75,12 +75,15 @@ class LoginManagerTests: KIFTestCase {
     }
 
     fileprivate func generateStringListWithFormat(_ format: String, numRange: CountableRange<Int>, prefixes: String) -> [String] {
-        return prefixes.map { char in
+        prefixes.map { char in
 
-            return numRange.map { num in
-                return String(format: format, "\(char)", num)
-            }
-            } .flatMap { $0 }
+                    numRange.map { num in
+                        String(format: format, "\(char)", num)
+                    }
+                }
+                .flatMap {
+                    $0
+                }
     }
 
     fileprivate func clearLogins() {

--- a/Tests/XCUITests/BaseTestCase.swift
+++ b/Tests/XCUITests/BaseTestCase.swift
@@ -8,7 +8,7 @@ import XCTest
 let serverPort = Int.random(in: 1025..<65000)
 
 func path(forTestPage page: String) -> String {
-    return "http://localhost:\(serverPort)/test-fixture/\(page)"
+    "http://localhost:\(serverPort)/test-fixture/\(page)"
 }
 
 class BaseTestCase: XCTestCase {
@@ -174,7 +174,7 @@ class IphoneOnlyTestCase: BaseTestCase {
 
 extension BaseTestCase {
     func tabTrayButton(forApp app: XCUIApplication) -> XCUIElement {
-        return app.buttons["TopTabsViewController.tabsButton"].exists ? app.buttons["TopTabsViewController.tabsButton"] : app.buttons["TabToolbar.tabsButton"]
+        app.buttons["TopTabsViewController.tabsButton"].exists ? app.buttons["TopTabsViewController.tabsButton"] : app.buttons["TabToolbar.tabsButton"]
     }
 }
 

--- a/Tests/XCUITests/FirstRunTourTests.swift
+++ b/Tests/XCUITests/FirstRunTourTests.swift
@@ -7,7 +7,7 @@ class FirstRunTourTests: BaseTestCase {
                                      AccessibilityIdentifiers.Onboarding.signSyncCard]
     var currentScreen = 0
     var rootA11yId: String {
-        return onboardingAccessibilityId[currentScreen]
+        onboardingAccessibilityId[currentScreen]
     }
 
     override func setUp() {

--- a/Tests/XCUITests/ScreenGraphTest.swift
+++ b/Tests/XCUITests/ScreenGraphTest.swift
@@ -114,7 +114,7 @@ public var isTablet: Bool {
     // There is more value in a variable having the same name,
     // so it can be used in both predicates and in code
     // than avoiding the duplication of one line of code.
-    return UIDevice.current.userInterfaceIdiom == .pad
+    UIDevice.current.userInterfaceIdiom == .pad
 }
 
 private func createTestGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScreenGraph<TestUserState> {

--- a/ThirdParty/Deferred/Deferred/Deferred.swift
+++ b/ThirdParty/Deferred/Deferred/Deferred.swift
@@ -25,7 +25,9 @@ open class Deferred<T> {
 
     // Check whether or not the receiver is filled
     public var isFilled: Bool {
-        return protected.withReadLock { $0.protectedValue != nil }
+        protected.withReadLock {
+            $0.protectedValue != nil
+        }
     }
 
     private func _fill(value: T, assertIfFilled: Bool) {
@@ -54,7 +56,9 @@ open class Deferred<T> {
     }
 
     public func peek() -> T? {
-        return protected.withReadLock { $0.protectedValue }
+        protected.withReadLock {
+            $0.protectedValue
+        }
     }
 
     public func uponQueue(_ queue: DispatchQueue, block: @escaping (T) -> ()) {
@@ -99,7 +103,9 @@ extension Deferred {
     }
 
     public func mapQueue<U>(_ queue: DispatchQueue, f: @escaping (T) -> U) -> Deferred<U> {
-        return bindQueue(queue) { t in Deferred<U>(value: f(t)) }
+        bindQueue(queue) { t in
+            Deferred<U>(value: f(t))
+        }
     }
 }
 
@@ -109,17 +115,21 @@ extension Deferred {
     }
 
     public func bind<U>(_ f: @escaping (T) -> Deferred<U>) -> Deferred<U> {
-        return bindQueue(defaultQueue, f: f)
+        bindQueue(defaultQueue, f: f)
     }
 
     public func map<U>(_ f: @escaping (T) -> U) -> Deferred<U> {
-        return mapQueue(defaultQueue, f: f)
+        mapQueue(defaultQueue, f: f)
     }
 }
 
 extension Deferred {
     public func both<U>(_ other: Deferred<U>) -> Deferred<(T,U)> {
-        return self.bind { t in other.map { u in (t, u) } }
+        self.bind { t in
+            other.map { u in
+                (t, u)
+            }
+        }
     }
 }
 

--- a/ThirdParty/Deferred/Deferred/LockProtected.swift
+++ b/ThirdParty/Deferred/Deferred/LockProtected.swift
@@ -22,14 +22,14 @@ public final class LockProtected<T> {
     }
 
     public func withReadLock<U>(block: (T) -> U) -> U {
-        return lock.withReadLock { [unowned self] in
-            return block(self.item)
+        lock.withReadLock { [unowned self] in
+            block(self.item)
         }
     }
 
     public func withWriteLock<U>(block: (inout T) -> U) -> U {
-        return lock.withWriteLock { [unowned self] in
-            return block(&self.item)
+        lock.withWriteLock { [unowned self] in
+            block(&self.item)
         }
     }
 }

--- a/WidgetKit/Helpers.swift
+++ b/WidgetKit/Helpers.swift
@@ -8,7 +8,7 @@ import UIKit
 import Shared
 
 var scheme: String {
-    return URL.mozInternalScheme
+    URL.mozInternalScheme
 }
 
 func linkToContainingApp(_ urlSuffix: String = "", query: String) -> URL {

--- a/WidgetKit/OpenTabs/SimpleTab.swift
+++ b/WidgetKit/OpenTabs/SimpleTab.swift
@@ -14,7 +14,7 @@ struct SimpleTab: Hashable, Codable {
     var isPrivate: Bool = false
     var uuid: String = ""
     var imageKey: String {
-        return url?.baseDomain ?? ""
+        url?.baseDomain ?? ""
     }
 }
 

--- a/WidgetKit/SearchQuickLinksMedium/SearchQuickLinks.swift
+++ b/WidgetKit/SearchQuickLinksMedium/SearchQuickLinks.swift
@@ -8,7 +8,7 @@ import SwiftUI
 
 struct Provider: TimelineProvider {
     func placeholder(in context: Context) -> SimpleEntry {
-        return SimpleEntry(date: Date())
+        SimpleEntry(date: Date())
     }
 
     func getSnapshot(in context: Context, completion: @escaping (SimpleEntry) -> Void) {

--- a/WidgetKit/SearchQuickLinksSmall/SmallQuickLink.swift
+++ b/WidgetKit/SearchQuickLinksSmall/SmallQuickLink.swift
@@ -22,7 +22,7 @@ struct IntentProvider: IntentTimelineProvider {
     }
 
     func placeholder(in context: Context) -> QuickLinkEntry {
-        return QuickLinkEntry(date: Date(), link: .search)
+        QuickLinkEntry(date: Date(), link: .search)
     }
 }
 

--- a/WidgetKit/TopSites/TopSitesProvider.swift
+++ b/WidgetKit/TopSites/TopSitesProvider.swift
@@ -10,7 +10,7 @@ struct TopSitesProvider: TimelineProvider {
     public typealias Entry = TopSitesEntry
 
     func placeholder(in context: Context) -> TopSitesEntry {
-        return TopSitesEntry(date: Date(), favicons: [String: Image](), sites: [])
+        TopSitesEntry(date: Date(), favicons: [String: Image](), sites: [])
     }
 
     func getSnapshot(in context: Context, completion: @escaping (TopSitesEntry) -> Void) {

--- a/content-blocker-lib-ios/src/ContentBlocker.swift
+++ b/content-blocker-lib-ios/src/ContentBlocker.swift
@@ -41,13 +41,19 @@ enum BlocklistFileName: String, CaseIterable {
     // case contentCookies = "disconnect-block-cookies-content"
     case socialCookies = "disconnect-block-cookies-social"
 
-    var filename: String { return self.rawValue }
+    var filename: String {
+        self.rawValue
+    }
 
-    static var basic: [BlocklistFileName] { return [.advertisingCookies, .analyticsCookies, .socialCookies, .cryptomining, .fingerprinting] }
-    static var strict: [BlocklistFileName] { return [.advertisingURLs, .analyticsURLs, .socialURLs, cryptomining, fingerprinting] }
+    static var basic: [BlocklistFileName] {
+        [.advertisingCookies, .analyticsCookies, .socialCookies, .cryptomining, .fingerprinting]
+    }
+    static var strict: [BlocklistFileName] {
+        [.advertisingURLs, .analyticsURLs, .socialURLs, cryptomining, fingerprinting]
+    }
 
     static func listsForMode(strict: Bool) -> [BlocklistFileName] {
-        return strict ? BlocklistFileName.strict : BlocklistFileName.basic
+        strict ? BlocklistFileName.strict : BlocklistFileName.basic
     }
 }
 

--- a/content-blocker-lib-ios/src/TabContentBlocker.swift
+++ b/content-blocker-lib-ios/src/TabContentBlocker.swift
@@ -19,13 +19,13 @@ class TabContentBlocker {
     weak var tab: ContentBlockerTab?
 
     var isEnabled: Bool {
-        return false
+        false
     }
 
     @objc func notifiedTabSetupRequired() {}
 
     func currentlyEnabledLists() -> [BlocklistFileName] {
-        return []
+        []
     }
 
     func notifyContentBlockingChanged() {}
@@ -63,7 +63,7 @@ class TabContentBlocker {
     }
 
     func scriptMessageHandlerName() -> String? {
-        return "trackingProtectionStats"
+        "trackingProtectionStats"
     }
 
     class func prefsChanged() {

--- a/content-blocker-lib-ios/src/TrackingProtectionPageStats.swift
+++ b/content-blocker-lib-ios/src/TrackingProtectionPageStats.swift
@@ -25,7 +25,7 @@ struct TPPageStats {
     }
 
     func create(matchingBlocklist blocklistName: BlocklistCategory, host: String) -> TPPageStats {
-        return TPPageStats(domains: domains, blocklistName: blocklistName, host: host)
+        TPPageStats(domains: domains, blocklistName: blocklistName, host: host)
     }
 }
 
@@ -177,7 +177,7 @@ class TPStatsBlocklists {
                 }
 
                 let domainExceptionsRegex = (trigger["unless-domain"] as? [String])?.compactMap { domain in
-                    return wildcardContentBlockerDomainToRegex(domain: domain)
+                    wildcardContentBlockerDomainToRegex(domain: domain)
                 }
 
                 // Only "third-party" is supported; other types are not used in our block lists.

--- a/fastlane/SnapshotHelper.swift
+++ b/fastlane/SnapshotHelper.swift
@@ -57,7 +57,7 @@ open class Snapshot: NSObject {
     static var waitForAnimations = true
     static var cacheDirectory: URL?
     static var screenshotsDirectory: URL? {
-        return cacheDirectory?.appendingPathComponent("screenshots", isDirectory: true)
+        cacheDirectory?.appendingPathComponent("screenshots", isDirectory: true)
     }
 
     open class func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
@@ -300,7 +300,7 @@ private extension XCUIElementQuery {
 
 private extension CGFloat {
     func isBetween(_ numberA: CGFloat, and numberB: CGFloat) -> Bool {
-        return numberA...numberB ~= self
+        numberA...numberB ~= self
     }
 }
 


### PR DESCRIPTION
This PR removes the `return` keyword where it can be omitted, i.e., in all single-expression closures, getters, and functions.

Since Swift 5.1 the return keyword can now be omitted when declaring functions and computed properties that only contain a single expression, which is really nice since it matches the way closures work, thus resulting in improved consistency between properties, methods, and closures.