### PR TITLE
Refactor [v105] Improve how the home screen reloads

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -875,12 +875,18 @@ class BrowserViewController: UIViewController {
             hideReaderModeBar(animated: false)
         }
 
+        homepageViewController?.view.layer.removeAllAnimations()
+
+        // Return early if the home page is already showing
+        guard homepageViewController?.view.alpha != 1 else { return }
+
         homepageViewController?.applyTheme()
         homepageViewController?.recordHomepageAppeared(isZeroSearch: !inline)
 
-        // We have to run this animation, even if the view is already showing
-        // because there may be a hide animation running and we want to be sure
-        // to override its results.
+        // Hack to force updates on the view
+        homepageViewController?.view.alpha = 0.001
+        homepageViewController?.reloadAll()
+
         UIView.animate(withDuration: 0.2, animations: { () -> Void in
             self.homepageViewController?.view.alpha = 1
         }, completion: { finished in
@@ -911,6 +917,11 @@ class BrowserViewController: UIViewController {
 
     func hideHomepage(completion: (() -> Void)? = nil) {
         guard let homepageViewController = self.homepageViewController else { return }
+
+        self.homepageViewController?.view.layer.removeAllAnimations()
+
+        // Return early if the home page is already hidden
+        guard self.homepageViewController?.view.alpha != 0 else { return }
 
         homepageViewController.recordHomepageDisappeared()
         UIView.animate(withDuration: 0.2, delay: 0, options: .beginFromCurrentState, animations: { () -> Void in

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -649,7 +649,8 @@ extension HomepageViewController: HomepageViewModelDelegate {
     func reloadView() {
         ensureMainThread { [weak self] in
             guard let self = self,
-                  self.view.alpha != 0 else { return }
+                  self.view.alpha != 0
+            else { return }
             self.collectionView.reloadData()
         }
     }

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -243,13 +243,9 @@ class HomepageViewController: UIViewController, HomePanel, GleanPlumbMessageMana
             presentedViewController?.dismiss(animated: false, completion: nil)
         }
 
-        // reload JumpBackIn section as the order of cells and their size can change depending on size class
-        if let index = viewModel.indexOfShownSection(.jumpBackIn) {
-            collectionView.reloadSections(IndexSet([index]))
-        }
-
-        // Adjust layout for rotation, cells need to re-layout
+        // Force the entire collectionview to re-layout
         collectionView.collectionViewLayout.invalidateLayout()
+        reloadView()
     }
 
     private func adjustPrivacySensitiveSections(notification: Notification) {
@@ -650,18 +646,11 @@ extension HomepageViewController: UIPopoverPresentationControllerDelegate {
 
 // MARK: FirefoxHomeViewModelDelegate
 extension HomepageViewController: HomepageViewModelDelegate {
-
-    func reloadSection(section: HomepageViewModelProtocol) {
+    func reloadView() {
         ensureMainThread { [weak self] in
-            guard let self = self else { return }
-            self.viewModel.updateEnabledSections()
-            self.viewModel.reloadSection(section, with: self.collectionView)
-        }
-    }
-
-    func reloadData() {
-        ensureMainThread { [weak self] in
-            self?.collectionView.reloadData()
+            guard let self = self,
+                  self.view.alpha != 0 else { return }
+            self.collectionView.reloadData()
         }
     }
 }

--- a/Client/Frontend/Home/HomepageViewModel.swift
+++ b/Client/Frontend/Home/HomepageViewModel.swift
@@ -5,12 +5,11 @@
 import MozillaAppServices
 
 protocol HomepageViewModelDelegate: AnyObject {
-    func reloadSection(section: HomepageViewModelProtocol)
-    func reloadData()
+    func reloadView()
 }
 
 protocol HomepageDataModelDelegate: AnyObject {
-    func reloadData()
+    func reloadView()
 }
 
 class HomepageViewModel: FeatureFlaggable {
@@ -158,20 +157,11 @@ class HomepageViewModel: FeatureFlaggable {
 
     private func updateData(section: HomepageViewModelProtocol) {
         section.updateData {
-            self.delegate?.reloadSection(section: section)
+            self.reloadView()
         }
     }
 
     // MARK: - Manage sections and order
-
-    /// Add the section if it doesn't
-    func reloadSection(_ section: HomepageViewModelProtocol, with collectionView: UICollectionView) {
-        if !shownSections.contains(section.sectionType) {
-            addShownSection(section: section.sectionType)
-        }
-
-        collectionView.reloadData()
-    }
 
     func addShownSection(section: HomepageSectionType) {
         let positionToInsert = getPositionToInsert(section: section)
@@ -222,10 +212,8 @@ extension HomepageViewModel: HomeHistoryHighlightsDelegate {
 
 // MARK: - HomepageDataModelDelegate
 extension HomepageViewModel: HomepageDataModelDelegate {
-    func reloadData() {
-        ensureMainThread {
-            self.updateEnabledSections()
-            self.delegate?.reloadData()
-        }
+    func reloadView() {
+        self.updateEnabledSections()
+        self.delegate?.reloadView()
     }
 }

--- a/Client/Frontend/Home/HomepageViewModel.swift
+++ b/Client/Frontend/Home/HomepageViewModel.swift
@@ -213,7 +213,7 @@ extension HomepageViewModel: HomeHistoryHighlightsDelegate {
 // MARK: - HomepageDataModelDelegate
 extension HomepageViewModel: HomepageDataModelDelegate {
     func reloadView() {
-        self.updateEnabledSections()
-        self.delegate?.reloadView()
+        updateEnabledSections()
+        delegate?.reloadView()
     }
 }

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
@@ -155,7 +155,9 @@ extension RecentlySavedCellViewModel: HomepageSectionHandler {
 
 extension RecentlySavedCellViewModel: RecentlySavedDelegate {
     func didLoadNewData() {
-        recentItems = recentlySavedDataAdaptor.getRecentlySavedData()
-        delegate?.reloadData()
+        ensureMainThread {
+            self.recentItems = self.recentlySavedDataAdaptor.getRecentlySavedData()
+            self.delegate?.reloadView()
+        }
     }
 }

--- a/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -192,8 +192,10 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
 // MARK: - FxHomeTopSitesManagerDelegate
 extension TopSitesViewModel: TopSitesManagerDelegate {
     func didLoadNewData() {
-        topSites = topSitesDataAdaptor.getTopSitesData()
-        delegate?.reloadData()
+        ensureMainThread {
+            self.topSites = self.topSitesDataAdaptor.getTopSitesData()
+            self.delegate?.reloadView()
+        }
     }
 }
 

--- a/Tests/ClientTests/Frontend/Home/FirefoxHomeViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/FirefoxHomeViewModelTests.swift
@@ -119,10 +119,5 @@ class FirefoxHomeViewModelTests: XCTestCase {
 
 // MARK: - FirefoxHomeViewModelDelegate
 extension FirefoxHomeViewModelTests: HomepageViewModelDelegate {
-
-    func reloadSection(section: HomepageViewModelProtocol) {
-        reloadSectionCompleted?(section)
-    }
-
-    func reloadData() {}
+    func reloadView() {}
 }


### PR DESCRIPTION
This PR is an update to address the issue that crashing is increasing on Lauries PR. I can repo the same crash on main but it happens at a much lower rate, I suspect because Lauries PR increases the number of times an update is triggered. I have it as it's own PR instead of adding to Lauries because the changes are not connected to her work so they'll be easier to review as stand alone and some of it is potentially controversial so easier to manage conversation in a separate PR.

After some research I have discovered it is a known issue that collection views can act unpredictably when updates are performed on them while they are not visible. This seems to be particularly common when coupled with compositional layout. So in this PR I refactored the home page view controller to only update if it is visible.
The solution to this is a little hacky, but this is because the home page visibility is handled by setting the alpha of the view instead of managing it via the navigation or view stack, which is itself a little hacky. I see addressing this as out of scope for now so I'm ok with a hacky solution to work around it for the time being.

I also made sure the data updates in the section view models are only happening on the main thread, ensuring there is no change in the middle of an ongoing reload cycle.

The crash still occurs on this PR, but it should go away once I merge this change into Lauries PR.