### PR TITLE
Add #11305 [v106]: Synced tab in JumpBackIn CFR

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -6,7 +6,7 @@ contextual-hint-feature:
   variables:
     features-enabled:
       type: json
-      description: This property provides a lookup table of whether specific context hints are enabled.
+      description: This property provides a lookup table of whether specific contextual hints are enabled.
 general-app-features:
   description: The feature that contains feature flags for the entire application
   hasExposure: true

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -612,12 +612,15 @@
 		8D8251811F4DE67F00780643 /* AdvancedAccountSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8251721F4DE67E00780643 /* AdvancedAccountSettingViewController.swift */; };
 		8DCD3BCD1ED5B7FA00446D38 /* FxADeepLinkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DCD3BCC1ED5B7FA00446D38 /* FxADeepLinkingTests.swift */; };
 		9609F4CA26B57CE800F81493 /* CalendarExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609F4C926B57CE800F81493 /* CalendarExtensions.swift */; };
+		9614BF4228A53FDF00D3F7EA /* ContextualHintEligibilityUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9614BF4028A53F7C00D3F7EA /* ContextualHintEligibilityUtilityTests.swift */; };
 		962F394A2672D57A006BDA2A /* RecentItemsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962F39492672D57A006BDA2A /* RecentItemsHelper.swift */; };
 		9636D92827F5D72D00771F5E /* GleanPlumbMessageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9636D92727F5D72D00771F5E /* GleanPlumbMessageManager.swift */; };
 		9636D92A27F767EC00771F5E /* GleanPlumbMessageUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9636D92927F767EC00771F5E /* GleanPlumbMessageUtility.swift */; };
 		9636D92C27F9E50100771F5E /* GleanPlumbMessageStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9636D92B27F9E50100771F5E /* GleanPlumbMessageStore.swift */; };
 		9636D92E27F9E5D900771F5E /* GleanPlumbMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9636D92D27F9E5D900771F5E /* GleanPlumbMessage.swift */; };
 		9638332327E14ACC0011EEFC /* AccessibilityIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84266742728462900382274 /* AccessibilityIdentifiers.swift */; };
+		964FA97528A1A8F20024BB3B /* ContextualHintEligibilityUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964FA97428A1A8F20024BB3B /* ContextualHintEligibilityUtility.swift */; };
+		964FA97728A2A55C0024BB3B /* ContextualHintPrefsKeysProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964FA97628A2A55C0024BB3B /* ContextualHintPrefsKeysProvider.swift */; };
 		966206CD2698DE1E005C0A55 /* RecentlySavedCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966206CC2698DE1E005C0A55 /* RecentlySavedCellViewModel.swift */; };
 		968BD7EB27DFF0F8003148B3 /* ASGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 968BD7EA27DFF0F8003148B3 /* ASGroup.swift */; };
 		9699F77326F39E5100C5FA47 /* SiteImageHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9699F77226F39E5100C5FA47 /* SiteImageHelper.swift */; };
@@ -3190,12 +3193,15 @@
 		95E1479BB09F1395795E7A42 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Storage.strings; sourceTree = "<group>"; };
 		95FD4D8DB09F3540CC7651A1 /* fil */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fil; path = fil.lproj/Intro.strings; sourceTree = "<group>"; };
 		9609F4C926B57CE800F81493 /* CalendarExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarExtensions.swift; sourceTree = "<group>"; };
+		9614BF4028A53F7C00D3F7EA /* ContextualHintEligibilityUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualHintEligibilityUtilityTests.swift; sourceTree = "<group>"; };
 		962A450E9186BF349E535413 /* sat-Olck */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "sat-Olck"; path = "sat-Olck.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		962F39492672D57A006BDA2A /* RecentItemsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentItemsHelper.swift; sourceTree = "<group>"; };
 		9636D92727F5D72D00771F5E /* GleanPlumbMessageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanPlumbMessageManager.swift; sourceTree = "<group>"; };
 		9636D92927F767EC00771F5E /* GleanPlumbMessageUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanPlumbMessageUtility.swift; sourceTree = "<group>"; };
 		9636D92B27F9E50100771F5E /* GleanPlumbMessageStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanPlumbMessageStore.swift; sourceTree = "<group>"; };
 		9636D92D27F9E5D900771F5E /* GleanPlumbMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanPlumbMessage.swift; sourceTree = "<group>"; };
+		964FA97428A1A8F20024BB3B /* ContextualHintEligibilityUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualHintEligibilityUtility.swift; sourceTree = "<group>"; };
+		964FA97628A2A55C0024BB3B /* ContextualHintPrefsKeysProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualHintPrefsKeysProvider.swift; sourceTree = "<group>"; };
 		966206CC2698DE1E005C0A55 /* RecentlySavedCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentlySavedCellViewModel.swift; sourceTree = "<group>"; };
 		967AF157275FF4C60099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		967AF158275FF4C60099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
@@ -5758,6 +5764,8 @@
 			children = (
 				4331A9BA27193DEF005E8080 /* ContextualHintViewController.swift */,
 				4331A9BC271D267E005E8080 /* ContextualHintViewModel.swift */,
+				964FA97428A1A8F20024BB3B /* ContextualHintEligibilityUtility.swift */,
+				964FA97628A2A55C0024BB3B /* ContextualHintPrefsKeysProvider.swift */,
 			);
 			path = "Contextual Hint";
 			sourceTree = "<group>";
@@ -6109,6 +6117,14 @@
 				217AEF7728480844004EED37 /* ResizableButton.swift */,
 			);
 			path = Components;
+			sourceTree = "<group>";
+		};
+		9614BF3F28A53F2000D3F7EA /* ContextualHints */ = {
+			isa = PBXGroup;
+			children = (
+				9614BF4028A53F7C00D3F7EA /* ContextualHintEligibilityUtilityTests.swift */,
+			);
+			path = ContextualHints;
 			sourceTree = "<group>";
 		};
 		9636D92627F5D71A00771F5E /* Messaging */ = {
@@ -7045,6 +7061,7 @@
 			isa = PBXGroup;
 			children = (
 				E1AEC173286E0CF500062E29 /* Browser */,
+				9614BF3F28A53F2000D3F7EA /* ContextualHints */,
 				E1AEC16E286E0CF500062E29 /* Home */,
 			);
 			path = Frontend;
@@ -10005,6 +10022,7 @@
 				8AED23C527AC1F9500DE7E97 /* BaseContentStackView.swift in Sources */,
 				C8699131289176A5007ACC5C /* WallpaperNetworking.swift in Sources */,
 				5A271ABD2860B0D700471CE4 /* WebServerUtil.swift in Sources */,
+				964FA97528A1A8F20024BB3B /* ContextualHintEligibilityUtility.swift in Sources */,
 				C84656052888373100861B4A /* WallpaperDataProvider.swift in Sources */,
 				DA9FD88924E213E500168D1E /* QuickLinkSelection.intentdefinition in Sources */,
 				CA7FC7D324A6A9B70012F347 /* LoginListDataSourceHelper.swift in Sources */,
@@ -10017,6 +10035,7 @@
 				E65075521E37F6D1006961AC /* UIViewExtensions.swift in Sources */,
 				8A01891C275E9C2A00923EFE /* ClearHistoryHelper.swift in Sources */,
 				C8F457A81F1FD75A000CB895 /* BrowserViewController+WebViewDelegates.swift in Sources */,
+				964FA97728A2A55C0024BB3B /* ContextualHintPrefsKeysProvider.swift in Sources */,
 				E6927EC01C7B6FB800D03F75 /* ErrorToast.swift in Sources */,
 				8AE80BB32891AD9200BC12EA /* DispatchGroupInterface.swift in Sources */,
 				96EB6C4327DC205D00A9D159 /* SearchGroupedItemsViewModel.swift in Sources */,
@@ -10321,7 +10340,6 @@
 				8DCD3BCD1ED5B7FA00446D38 /* FxADeepLinkingTests.swift in Sources */,
 				8A11C8112731CFD700AC7318 /* ReaderModeStyleTests.swift in Sources */,
 				8ABA9C8E28931288002C0077 /* JumpBackInDataAdaptorTests.swift in Sources */,
-				C84655F228873D3400861B4A /* WallpaperDataServiceMock.swift in Sources */,
 				3943A81D1E9807C700D4F6DC /* FxAPushMessageTest.swift in Sources */,
 				E60D032A1D5118DB002FE3F6 /* SyncStatusResolverTests.swift in Sources */,
 				8ADED7F0276A7788009C19E6 /* CumulativeDaysOfUseCounterTests.swift in Sources */,
@@ -10363,6 +10381,7 @@
 				8A5C3BC5282ABF8E003A8CCF /* RemoteTabsPanelTests.swift in Sources */,
 				D8EFFA261FF702A8001D3A09 /* NavigationRouterTests.swift in Sources */,
 				63306D452110BAF000F25400 /* TabManagerStoreTests.swift in Sources */,
+				9614BF4228A53FDF00D3F7EA /* ContextualHintEligibilityUtilityTests.swift in Sources */,
 				6ADB651B285C03B100947EA4 /* DownloadHelperTests.swift in Sources */,
 				8A6B77CC2811C468001110D2 /* URLProtocolStub.swift in Sources */,
 				8AB1128C2820496500C3A820 /* SiteImageHelperTests.swift in Sources */,

--- a/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -12,6 +12,7 @@ import UIKit
 enum NimbusFeatureFlagID: String, CaseIterable {
     case bottomSearchBar
     case contextualHintForToolbar
+    case contextualHintForJumpBackInSyncedTab
     case historyHighlights
     case historyGroups
     case inactiveTabs
@@ -80,7 +81,8 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
             return FlagKeys.CustomWallpaper
 
         // Cases where users do not have the option to manipulate a setting.
-        case .contextualHintForToolbar,
+        case .contextualHintForJumpBackInSyncedTab,
+                .contextualHintForToolbar,
                 .reportSiteIssue,
                 .shakeToRestore,
                 .searchHighlights,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -463,6 +463,8 @@ class BrowserViewController: UIViewController {
                                                name: .SearchBarPositionDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(didTapUndoCloseAllTabToast),
                                                name: .DidTapUndoCloseAllTabToast, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(homePanelDidPresentContextualHintWith),
+                                               name: .DidPresentContextualHint, object: nil)
     }
 
     func addSubviews() {
@@ -1819,12 +1821,27 @@ extension BrowserViewController: HomePanelDelegate {
         showTabTray(withFocusOnUnselectedTab: tabToFocus, focusedSegment: focusedSegment)
     }
 
-    func homePanelDidPresentContextualHintOf(type: ContextualHintViewType) {
+    func homePanelDidPresentContextualHintOf(type: ContextualHintType) {
         switch type {
         case .jumpBackIn,
+                .jumpBackInSyncedTab,
                 .toolbarLocation:
             self.urlBar.leaveOverlayMode()
         default: break
+        }
+    }
+
+    /// We leave overlay mode this way when a contextual hint is too far out of reach from
+    /// accessing `homePanelDidPresentContextualHintOf(type: ContextualHintType)`
+    @objc func homePanelDidPresentContextualHintWith(notification: NSNotification) {
+        guard let userInfo = notification.userInfo,
+              let hint = userInfo["contextualHint"] as? ContextualHintType
+        else { return }
+
+        switch hint {
+        case .jumpBackIn, .jumpBackInSyncedTab, .toolbarLocation:
+            self.urlBar.leaveOverlayMode()
+        case .inactiveTabs: break
         }
     }
 

--- a/Client/Frontend/Contextual Hint/ContextualHintEligibilityUtility.swift
+++ b/Client/Frontend/Contextual Hint/ContextualHintEligibilityUtility.swift
@@ -1,0 +1,112 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Public interface for contextual hint consumers
+protocol ContextualHintEligibilityUtilityProtocol {
+    func canPresent(_ hint: ContextualHintType) -> Bool
+}
+
+struct ContextualHintEligibilityUtility: ContextualHintEligibilityUtilityProtocol, ContextualHintPrefsKeysProvider {
+
+    var profile: Profile
+
+    init(with profile: Profile) {
+        self.profile = profile
+    }
+
+    /// Determine if this hint is eligible to present.
+    func canPresent(_ hintType: ContextualHintType) -> Bool {
+        guard isDeviceReady else { return false }
+
+        var hintTypeShouldBePresented = false
+
+        switch hintType {
+        case .jumpBackIn:
+            hintTypeShouldBePresented = canJumpBackInBePresented
+        case .jumpBackInSyncedTab:
+            hintTypeShouldBePresented = canPresentJumpBackInSyncedTab
+        case .toolbarLocation:
+            hintTypeShouldBePresented = SearchBarSettingsViewModel.isEnabled
+        case .inactiveTabs:
+            hintTypeShouldBePresented = true
+        }
+
+        return hintTypeShouldBePresented && !hasAlreadyBeenPresented(hintType)
+    }
+
+    // MARK: - Private helpers
+
+    // Do not present contextual hint in landscape on iPhone
+    private var isDeviceReady: Bool {
+        !UIWindow.isLandscape || UIDevice.current.userInterfaceIdiom == .pad
+    }
+
+    /// Determine if the CFR for Jump Back In is presentable.
+    ///
+    /// It's presentable on these conditions:
+    /// - this CFR should not be presented on iPad
+    /// - the Toolbar CFR has already been presented
+    /// - the JumpBackInSyncedTab CFR has NOT been presented already
+    /// - the JumpBackIn CFR has NOT been presented yet
+    private var canJumpBackInBePresented: Bool {
+        guard UIDevice.current.userInterfaceIdiom != .pad,
+              let hasPresentedToolbarCFR = profile.prefs.boolForKey(CFRPrefsKeys.ToolbarOnboardingKey.rawValue),
+              hasPresentedToolbarCFR,
+              !hasHintBeenConfigured(.jumpBackInSyncedTab),
+              !hasAlreadyBeenPresented(.jumpBackInSyncedTab)
+        else { return false }
+
+        return true
+    }
+
+    /// Determine if the CFR for SyncedTab in JumpBackIn is presentable.
+    ///
+    /// The context hint is presentable when certain conditions are met:
+    /// - A synced tab appears in Jump Back In
+    /// - The Toolbar CFR has been presented
+    /// - This CFR hasn't already been presented
+    /// - The Home Tab Banner isn't being displayed (not specified by Product, but the CFR might show when the anchor point isn't on screen)
+    private var canPresentJumpBackInSyncedTab: Bool {
+        guard let hasPresentedToolbarCFR = profile.prefs.boolForKey(CFRPrefsKeys.ToolbarOnboardingKey.rawValue),
+              hasPresentedToolbarCFR else { return false }
+
+        return true
+    }
+
+    private func hasAlreadyBeenPresented(_ hintType: ContextualHintType) -> Bool {
+        guard let contextualHintData = profile.prefs.boolForKey(prefsKey(for: hintType)) else { return false }
+
+        return contextualHintData
+    }
+
+    /// In cases where hints need to be made aware of each other, this will inform of configured ones.
+    ///
+    /// Hints are configured when the anchor point is visible on screen. Sometimes, multiple hints can become
+    /// configured and be eligible to present together. One hint can affect whether or not another should be
+    /// presented, but currently hints are unaware of each other.
+    ///
+    /// With this method, if `hintA` needs to be aware of `hintB`, `hintA` can query for whether `hintB`
+    /// has been configured. Then, `hintA` can react accordingly.
+    ///
+    /// This is a workaround for hints becoming aware of each other until we have a proper CFR system in place.
+    private func hasHintBeenConfigured(_ hintType: ContextualHintType) -> Bool {
+
+        var hintConfigured = false
+
+        switch hintType {
+        case .jumpBackIn:
+            guard let jumpBackInConfigured = profile.prefs.boolForKey(CFRPrefsKeys.JumpBackInConfiguredKey.rawValue) else { return false }
+            hintConfigured = jumpBackInConfigured
+        case .jumpBackInSyncedTab:
+            guard let syncedTabConfigured = profile.prefs.boolForKey(CFRPrefsKeys.jumpBackInSyncedTabConfiguredKey.rawValue) else { return false }
+            hintConfigured = syncedTabConfigured
+        default: break
+        }
+
+        return hintConfigured
+    }
+
+}

--- a/Client/Frontend/Contextual Hint/ContextualHintPrefsKeysProvider.swift
+++ b/Client/Frontend/Contextual Hint/ContextualHintPrefsKeysProvider.swift
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Shared
+
+protocol ContextualHintPrefsKeysProvider {
+    func prefsKey(for hintType: ContextualHintType) -> String
+}
+
+extension ContextualHintPrefsKeysProvider {
+    typealias CFRPrefsKeys = PrefsKeys.ContextualHints
+
+    func prefsKey(for hintType: ContextualHintType) -> String {
+        switch hintType {
+        case .inactiveTabs: return CFRPrefsKeys.InactiveTabsKey.rawValue
+        case .jumpBackIn: return CFRPrefsKeys.JumpBackinKey.rawValue
+        case .jumpBackInSyncedTab: return CFRPrefsKeys.JumpBackInSyncedTabKey.rawValue
+        case .toolbarLocation: return CFRPrefsKeys.ToolbarOnboardingKey.rawValue
+        }
+    }
+
+}

--- a/Client/Frontend/Contextual Hint/ContextualHintViewController.swift
+++ b/Client/Frontend/Contextual Hint/ContextualHintViewController.swift
@@ -77,6 +77,7 @@ class ContextualHintViewController: UIViewController, OnViewDismissable {
 
     // MARK: - Properties
     private var viewModel: ContextualHintViewModel
+
     private var onViewSummoned: (() -> Void)?
     var onViewDismissed: (() -> Void)?
     private var onActionTapped: (() -> Void)?
@@ -264,7 +265,8 @@ class ContextualHintViewController: UIViewController, OnViewDismissable {
         withActionBeforeAppearing preAction: (() -> Void)? = nil,
         actionOnDismiss postAction: (() -> Void)? = nil,
         andActionForButton buttonAction: (() -> Void)? = nil,
-        andShouldStartTimerRightAway shouldStartTimer: Bool = true
+        andShouldStartTimerRightAway shouldStartTimer: Bool = true,
+        onHintConfigured completion: (() -> Void)? = nil
     ) {
         stopTimer()
         self.modalPresentationStyle = .popover
@@ -282,6 +284,8 @@ class ContextualHintViewController: UIViewController, OnViewDismissable {
         if viewModel.shouldPresentContextualHint() && shouldStartTimer {
             viewModel.startTimer()
         }
+
+        completion?()
     }
 
     public func stopTimer() {

--- a/Client/Frontend/Contextual Hint/ContextualHintViewModel.swift
+++ b/Client/Frontend/Contextual Hint/ContextualHintViewModel.swift
@@ -12,80 +12,49 @@ enum CFRTelemetryEvent {
     case performAction
 }
 
-enum ContextualHintViewType: String {
+enum ContextualHintType: String {
     case jumpBackIn = "JumpBackIn"
+    case jumpBackInSyncedTab = "JumpBackInSyncedTab"
     case inactiveTabs = "InactiveTabs"
     case toolbarLocation = "ToolbarLocation"
 }
 
-class ContextualHintViewModel {
-    typealias CFRStrings = String.ContextualHints
+class ContextualHintViewModel: ContextualHintPrefsKeysProvider {
     typealias CFRPrefsKeys = PrefsKeys.ContextualHints
+    typealias CFRStrings = String.ContextualHints
 
     // MARK: - Properties
-    var hintType: ContextualHintViewType
+    var hintType: ContextualHintType
     var timer: Timer?
     var presentFromTimer: (() -> Void)?
     private var profile: Profile
     private var hasSentTelemetryEvent = false
-
     var arrowDirection = UIPopoverArrowDirection.down
-    private var hasAlreadyBeenPresented: Bool {
-        guard let contextualHintData = profile.prefs.boolForKey(prefsKey) else { return false }
-
-        return contextualHintData
-    }
-
-    // Prevent JumpBackIn CFR from being presented if the onboarding
-    // CFR has not yet been presented. On iPad we don't present the onboarding CFR
-    private var canJumpBackInBePresented: Bool {
-        guard UIDevice.current.userInterfaceIdiom != .pad else { return true }
-
-        if let hasShownOnboardingCFR = profile.prefs.boolForKey(CFRPrefsKeys.ToolbarOnboardingKey.rawValue),
-           hasShownOnboardingCFR {
-            return true
-        }
-
-        return false
-    }
-
-    // Do not present contextual hint in landscape on iPhone
-    private var isDeviceHintReady: Bool {
-        !UIWindow.isLandscape || UIDevice.current.userInterfaceIdiom == .pad
-    }
-
-    private var prefsKey: String {
-        switch hintType {
-        case .inactiveTabs: return CFRPrefsKeys.InactiveTabsKey.rawValue
-        case .jumpBackIn: return CFRPrefsKeys.JumpBackinKey.rawValue
-        case .toolbarLocation: return CFRPrefsKeys.ToolbarOnboardingKey.rawValue
-        }
-    }
 
     // MARK: - Initializers
-    init(forHintType hintType: ContextualHintViewType, with profile: Profile) {
+
+    init(forHintType hintType: ContextualHintType, with profile: Profile) {
         self.hintType = hintType
         self.profile = profile
     }
 
     // MARK: - Interface
+
     func shouldPresentContextualHint() -> Bool {
-        guard isDeviceHintReady else { return false }
+        let contextualHintPresLogic = ContextualHintEligibilityUtility(with: profile)
 
-        switch hintType {
-        case .jumpBackIn:
-            return canJumpBackInBePresented && !hasAlreadyBeenPresented
-
-        case .toolbarLocation:
-            return SearchBarSettingsViewModel.isEnabled && !hasAlreadyBeenPresented
-
-        default:
-            return !hasAlreadyBeenPresented
-        }
+        return contextualHintPresLogic.canPresent(hintType)
     }
 
     func markContextualHintPresented() {
-        profile.prefs.setBool(true, forKey: prefsKey)
+        switch hintType {
+        // If JumpBackInSyncedTab CFR was shown, don't present JumpBackIn CFR (both convey similar info)
+        case .jumpBackInSyncedTab:
+            profile.prefs.setBool(true, forKey: CFRPrefsKeys.JumpBackInSyncedTabKey.rawValue)
+            profile.prefs.setBool(true, forKey: CFRPrefsKeys.JumpBackinKey.rawValue)
+        default:
+            profile.prefs.setBool(true, forKey: prefsKey(for: hintType))
+        }
     }
 
     func startTimer() {
@@ -99,11 +68,12 @@ class ContextualHintViewModel {
 
         timer?.invalidate()
 
-        timer = Timer.scheduledTimer(timeInterval: timeInterval,
-                                     target: self,
-                                     selector: #selector(presentHint),
-                                     userInfo: nil,
-                                     repeats: false)
+        timer = Timer.scheduledTimer(
+            timeInterval: timeInterval,
+            target: self,
+            selector: #selector(presentHint),
+            userInfo: nil,
+            repeats: false)
     }
 
     func stopTimer() {
@@ -117,6 +87,7 @@ class ContextualHintViewModel {
         switch hintType {
         case .inactiveTabs: return CFRStrings.TabsTray.InactiveTabs.Body
         case .jumpBackIn: return CFRStrings.FirefoxHomepage.JumpBackIn.PersonalizedHome
+        case .jumpBackInSyncedTab: return CFRStrings.FirefoxHomepage.JumpBackIn.SyncedTab
 
         case .toolbarLocation:
             switch arrowDirection {

--- a/Client/Frontend/Home/HomePanelDelegate.swift
+++ b/Client/Frontend/Home/HomePanelDelegate.swift
@@ -11,7 +11,7 @@ protocol HomePanelDelegate: AnyObject {
     func homePanelDidRequestToOpenLibrary(panel: LibraryPanelType)
     func homePanelDidRequestToOpenTabTray(withFocusedTab tabToFocus: Tab?, focusedSegment: TabTrayViewModel.Segment?)
     func homePanelDidRequestToOpenSettings(at settingsPage: AppSettingsDeeplinkOption)
-    func homePanelDidPresentContextualHintOf(type: ContextualHintViewType)
+    func homePanelDidPresentContextualHintOf(type: ContextualHintType)
 }
 
 extension HomePanelDelegate {

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -171,15 +171,21 @@ private extension JumpBackInViewModel {
         let descriptionText = item.client.name
         let image = UIImage(named: ImageIdentifiers.syncedDevicesIcon)
 
-        let cellViewModel = SyncedTabCellViewModel(titleText: site.title,
-                                                         descriptionText: descriptionText,
-                                                         url: item.tab.URL,
-                                                         syncedDeviceImage: image,
-                                                         heroImage: jumpBackInDataAdaptor.getHeroImage(forSite: site),
-                                                         fallbackFaviconImage: jumpBackInDataAdaptor.getFaviconImage(forSite: site))
-        cell.configure(viewModel: cellViewModel,
-                       onTapShowAllAction: syncedTabsShowAllAction,
-                       onOpenSyncedTabAction: openSyncedTabAction)
+        let cellViewModel = SyncedTabCellViewModel(
+            profile: profile,
+            titleText: site.title,
+            descriptionText: descriptionText,
+            url: item.tab.URL,
+            syncedDeviceImage: image,
+            heroImage: jumpBackInDataAdaptor.getHeroImage(forSite: site),
+            fallbackFaviconImage: jumpBackInDataAdaptor.getFaviconImage(forSite: site)
+        )
+
+        cell.configure(
+            viewModel: cellViewModel,
+            onTapShowAllAction: syncedTabsShowAllAction,
+            onOpenSyncedTabAction: openSyncedTabAction
+        )
     }
 
     private func defaultSection(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -149,6 +149,12 @@ extension String {
                     value: "Your personalized Firefox homepage now makes it easier to pick up where you left off. Find your recent tabs, bookmarks, and search results.",
                     comment: "Contextual hints are little popups that appear for the users informing them of new features. This one talks about the more personalized home feature.",
                     lastUpdated: .v39)
+                public static let SyncedTab = MZLocalizedString(
+                    "ContextualHints.FirefoxHomepage.JumpBackIn.SyncedTab.v106",
+                    tableName: "JumpBackIn",
+                    value: "Your tabs are syncing! Pick up where you left off on your other device.",
+                    comment: "Contextual hints are little popups that appear for the users informing them of new features. When a user is logged in and has a tab synced from desktop, this popup indicates which tab that is within the Jump Back In section.",
+                    lastUpdated: .v106)
             }
         }
 

--- a/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -31,7 +31,7 @@ final class NimbusFeatureFlagLayer {
         case .jumpBackInSyncedTab:
             return checkNimbusForJumpBackInSyncedTabFeature(using: nimbus)
 
-        case .contextualHintForToolbar:
+        case .contextualHintForJumpBackInSyncedTab, .contextualHintForToolbar:
             return checkNimbusForContextualHintsFeature(for: featureID, from: nimbus)
 
         case .sponsoredPocket:
@@ -126,6 +126,7 @@ final class NimbusFeatureFlagLayer {
 
         switch featureID {
         case .contextualHintForToolbar: nimbusID = ContextualHint.toolbarContextualHint
+        case .contextualHintForJumpBackInSyncedTab: nimbusID = ContextualHint.jumpBackInSyncedTabContextualHint
         default: return false
         }
 

--- a/Shared/NotificationConstants.swift
+++ b/Shared/NotificationConstants.swift
@@ -78,6 +78,8 @@ extension Notification.Name {
 
     public static let LibraryPanelStateDidChange = Notification.Name("LibraryPanelStateDidChange")
 
+    public static let DidPresentContextualHint = Notification.Name("DidPresentContextualHint")
+
     // MARK: Tab manager
 
     // Tab manager creates a toast for undo recently closed tabs and a notification is

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -79,6 +79,9 @@ public struct PrefsKeys {
     // Firefox contextual hint
     public enum ContextualHints: String, CaseIterable {
         case JumpBackinKey = "ContextualHintJumpBackin"
+        case JumpBackInConfiguredKey = "JumpBackInConfigured"
+        case JumpBackInSyncedTabKey = "ContextualHintJumpBackInSyncedTab"
+        case jumpBackInSyncedTabConfiguredKey = "JumpBackInSyncedTabConfigured"
         case InactiveTabsKey = "ContextualHintInactiveTabs"
         case ToolbarOnboardingKey = "ContextualHintToolbarOnboardingKey"
     }

--- a/Tests/ClientTests/Frontend/ContextualHints/ContextualHintEligibilityUtilityTests.swift
+++ b/Tests/ClientTests/Frontend/ContextualHints/ContextualHintEligibilityUtilityTests.swift
@@ -1,0 +1,82 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import XCTest
+import Shared
+@testable import Client
+
+class ContextualHintEligibilityUtilityTests: XCTestCase {
+    typealias CFRPrefsKeys = PrefsKeys.ContextualHints
+
+    var profile: MockProfile!
+    var subject: ContextualHintEligibilityUtility!
+
+    override func setUp() {
+        super.setUp()
+
+        profile = MockProfile()
+        subject = ContextualHintEligibilityUtility(with: profile)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        profile._shutdown()
+        profile = nil
+        subject = nil
+    }
+
+    // MARK: - Test should Present cases
+
+    func test_shouldPresentInactiveTabsHint() {
+        let result = subject.canPresent(.inactiveTabs)
+        XCTAssertTrue(result)
+    }
+
+    func test_shouldPresentJumpBackHint() {
+        profile.prefs.setBool(true, forKey: CFRPrefsKeys.ToolbarOnboardingKey.rawValue)
+
+        let result = subject.canPresent(.jumpBackIn)
+        XCTAssertTrue(result)
+    }
+
+    func test_shouldPresentSyncedTabHint() {
+        profile.prefs.setBool(true, forKey: CFRPrefsKeys.ToolbarOnboardingKey.rawValue)
+
+        let result = subject.canPresent(.jumpBackInSyncedTab)
+        XCTAssertTrue(result)
+    }
+
+    // MARK: - Test should NOT Present cases
+
+    func test_shouldNotPresentInactiveTabsHint() {
+        profile.prefs.setBool(true, forKey: CFRPrefsKeys.InactiveTabsKey.rawValue)
+
+        let result = subject.canPresent(.inactiveTabs)
+        XCTAssertFalse(result)
+    }
+
+    func test_shouldNotPresentJumpBackInHint() {
+        profile.prefs.setBool(true, forKey: CFRPrefsKeys.JumpBackinKey.rawValue)
+
+        let result = subject.canPresent(.jumpBackIn)
+        XCTAssertFalse(result)
+    }
+
+    func test_shouldNotPresentJumpBackInWhenSyncedTabConfigured() {
+        profile.prefs.setBool(true, forKey: CFRPrefsKeys.jumpBackInSyncedTabConfiguredKey.rawValue)
+
+        let result = subject.canPresent(.jumpBackIn)
+        XCTAssertFalse(result)
+    }
+
+    func test_shouldNotPresentSyncedTabHint() {
+        profile.prefs.setBool(true, forKey: CFRPrefsKeys.JumpBackInSyncedTabKey.rawValue)
+
+        let result = subject.canPresent(.jumpBackInSyncedTab)
+        XCTAssertFalse(result)
+    }
+
+}

--- a/Tests/ClientTests/Frontend/Home/JumpBackIn/SyncedTabCellTests.swift
+++ b/Tests/ClientTests/Frontend/Home/JumpBackIn/SyncedTabCellTests.swift
@@ -10,9 +10,13 @@ class SyncedTabCellTests: XCTestCase {
 
     func testConfigureSyncTab_hasNoLeaks() {
         let testUrl = URL(string: "www.test.com")!
-        let viewModel = SyncedTabCellViewModel(titleText: "Title",
-                                               descriptionText: "Description",
-                                               url: testUrl)
+
+        let viewModel = SyncedTabCellViewModel(
+            profile: MockProfile(),
+            titleText: "Title",
+            descriptionText: "Description",
+            url: testUrl
+        )
 
         let testButton = UIButton(frame: CGRect.zero)
         let syncedTabsShowAllAction = { button in

--- a/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -98,7 +98,7 @@ class TelemetryWrapperTests: XCTestCase {
     // MARK: - CFR Analytics
 
     func test_contextualHintDismissButton_GleanIsCalled() {
-        let extra = [TelemetryWrapper.EventExtraKey.cfrType.rawValue: ContextualHintViewType.toolbarLocation.rawValue]
+        let extra = [TelemetryWrapper.EventExtraKey.cfrType.rawValue: ContextualHintType.toolbarLocation.rawValue]
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .contextualHint, value: .dismissCFRFromButton, extras: extra)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.CfrAnalytics.dismissCfrFromButton)
@@ -110,7 +110,7 @@ class TelemetryWrapperTests: XCTestCase {
     }
 
     func test_contextualHintDismissOutsideTap_GleanIsCalled() {
-        let extra = [TelemetryWrapper.EventExtraKey.cfrType.rawValue: ContextualHintViewType.toolbarLocation.rawValue]
+        let extra = [TelemetryWrapper.EventExtraKey.cfrType.rawValue: ContextualHintType.toolbarLocation.rawValue]
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .contextualHint, value: .dismissCFRFromOutsideTap, extras: extra)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.CfrAnalytics.dismissCfrFromOutsideTap)
@@ -122,7 +122,7 @@ class TelemetryWrapperTests: XCTestCase {
     }
 
     func test_contextualHintPressAction_GleanIsCalled() {
-        let extra = [TelemetryWrapper.EventExtraKey.cfrType.rawValue: ContextualHintViewType.toolbarLocation.rawValue]
+        let extra = [TelemetryWrapper.EventExtraKey.cfrType.rawValue: ContextualHintType.toolbarLocation.rawValue]
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .contextualHint, value: .pressCFRActionButton, extras: extra)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.CfrAnalytics.pressCfrActionButton)

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -251,16 +251,27 @@ features:
     description: This set holds all features pertaining to the usage of contextual hints, whether it's to introduce new features or remind users of existing ones.
     variables:
       features-enabled:
-        description: This property provides a lookup table of whether specific context hints are enabled.
+        description: This property provides a lookup table of whether specific contextual hints are enabled.
         type: Map<ContextualHint, Boolean>
         default: 
         {
-          "toolbar-contextual-hint": true
+          "toolbar-contextual-hint": true,
+          "jump-back-in-synced-tab-contextual-hint": false
         }
     defaults:
+      - channel: beta
+        value: {
+          "features-enabled": {
+            "toolbar-contextual-hint": true,
+            "jump-back-in-synced-tab-contextual-hint": true
+          }
+        }
       - channel: developer
         value: {
-          "toolbar-contextual-hint": true
+          "features-enabled": {
+            "toolbar-contextual-hint": true,
+            "jump-back-in-synced-tab-contextual-hint": true
+          }
         }
 
   messaging:
@@ -598,6 +609,8 @@ types:
       variants:
         toolbar-contextual-hint:
           description: The contextual hint bubble that appears to indicate that the toolbar location is adjustable.
+        jump-back-in-synced-tab-contextual-hint:
+          description: The contextual hint bubble that appears to indicate a synced tab has appeared within the Jump Back In section.
 
     SearchTermGroups:
       description: The identifiers for the different types of search term groups.


### PR DESCRIPTION
# #11305 | [FXIOS-4566](https://mozilla-hub.atlassian.net/browse/FXIOS-4566)

This PR adds the Synced tab CFR. Some presentation logic for JumpBackIn CFR was also impacted. 

PENDING:
- Proposal of an AppSessionManager, for accessing isHomeTabBannerDisplayed elsewhere