### PR TITLE
Bugfix FXIOS-4713 [v104] Return after we setNeedsUpdateConstraints on the view

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -876,6 +876,7 @@ class BrowserViewController: UIViewController {
         }
 
         homepageViewController?.view.layer.removeAllAnimations()
+        view.setNeedsUpdateConstraints()
 
         // Return early if the home page is already showing
         guard homepageViewController?.view.alpha != 1 else { return }
@@ -894,7 +895,6 @@ class BrowserViewController: UIViewController {
             self.webViewContainer.accessibilityElementsHidden = true
             UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: nil)
         })
-        view.setNeedsUpdateConstraints()
         urlBar.locationView.reloadButton.reloadButtonState = .disabled
     }
 


### PR DESCRIPTION
# [FXIOS-4713](https://mozilla-hub.atlassian.net/browse/FXIOS-4713) https://github.com/mozilla-mobile/firefox-ios/issues/11526
On fresh install, the homepage constraints weren't set properly (hence url bar was hidden behind the homepage). The homepage gets created after the `updateViewConstraints` gets called, so constraints are never properly set. It seems that the mechanism that was in place to alleviate this issue is calling due `view.setNeedsUpdateConstraints()` in the `showHomepage` method to make sure the homepage gets it's constraints sets. Since we just added a new guard:
```
        // Return early if the home page is already showing
        guard homepageViewController?.view.alpha != 1 else { return }
```
we were never calling `view.setNeedsUpdateConstraints()`.

This PR moves the `setNeedsUpdateConstraints` call before the guard, to make sure we have proper constrains on the homepage.