### PR TITLE
Bugfix FXIOS-4632 [v105] Remove animated transitions which gets cancelled on repeated taps

### DIFF
--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -130,7 +130,7 @@ class IntroViewController: UIViewController, OnViewDismissable {
     private func moveToNextPage(cardType: IntroViewModel.OnboardingCards) {
         if let nextViewController = getNextOnboardingCard(index: cardType.rawValue, goForward: true) {
             pageControl.currentPage = cardType.rawValue + 1
-            pageController.setViewControllers([nextViewController], direction: .forward, animated: true)
+            pageController.setViewControllers([nextViewController], direction: .forward, animated: false)
         }
     }
 


### PR DESCRIPTION
 Issue #11409
 Jira [4632](https://mozilla-hub.atlassian.net/browse/FXIOS-4632)
 
 Remove animation when setting view controller on button tap because setViewController gets cancelled on multiple taps leaving the scrollview on a weird state 