### PR TITLE
Refactor FXIOS-11563 [v106] Unit tests should be the same running via…

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
@@ -331,7 +331,13 @@
                   Identifier = "ETPCoverSheetTests">
                </Test>
                <Test
+                  Identifier = "TabManagerTests/testPrivatePreference_togglePBMDeletesPrivate()">
+               </Test>
+               <Test
                   Identifier = "TestFavicons/testFaviconFetcherParse()">
+               </Test>
+               <Test
+                  Identifier = "VersionSettingTests/testCopyAppVersion()">
                </Test>
             </SkippedTests>
          </TestableReference>

--- a/Tests/UnitTest.xctestplan
+++ b/Tests/UnitTest.xctestplan
@@ -21,15 +21,10 @@
     },
     {
       "skippedTests" : [
-        "AdjustTelemetryHelperTests\/testDeeplinkHandleEvent_GleanCalled()",
-        "AdjustTelemetryHelperTests\/testFirstSessionPing()",
         "ETPCoverSheetTests",
         "TabManagerTests\/testDeleteSelectedTab()",
         "TabManagerTests\/testPrivatePreference_togglePBMDeletesPrivate()",
         "TestFavicons\/testFaviconFetcherParse()",
-        "UIPasteboardExtensionsTests",
-        "UIPasteboardExtensionsTests\/testAddGIFImage()",
-        "UIPasteboardExtensionsTests\/testAddPNGImage()",
         "VersionSettingTests",
         "VersionSettingTests\/testCopyAppVersion()"
       ],


### PR DESCRIPTION
… different ways
This would fix #11563
The CMD+U runs the tests enabled in Fennec scheme
Bitrise runs the unit tests in the Unit Test test plan defined for the Fennec_Enterprise_XCUITests scheme

Let's fix this for now by enabling/disabling the same tests on both scenarios and try to have the Unit Test working for the Fennec scheme which will maybe simplify things in the future (we need to verify that we can build the app for one scheme, Fennec_Enterprise_XCUITests, on Bitrise's pipelines and run the tests for a different one, Fennec )