### PR TITLE
Add FXIOS-4739 - Add Github action workflow to update Nimbus' initial experiments

### DIFF
--- a/.github/workflows/update-nimbus-experiments.yml
+++ b/.github/workflows/update-nimbus-experiments.yml
@@ -1,9 +1,8 @@
 name: "Update Nimbus Experiments"
 
 on:
-  # schedule:
-  #   - cron: '*/30 * * * *'
-  pull_request: {}
+  schedule:
+    - cron: '*/30 * * * *'
 
 jobs:
   update-nimbus-experiments:
@@ -21,8 +20,7 @@ jobs:
         with:
           repo-path: firefox-ios
           output-path: Client/Experiments/initial_experiments.json
-          # experimenter-url: https://experimenter.services.mozilla.com/api/v6/experiments/?is_first_run=true
-          experimenter-url: https://stage.experimenter.nonprod.dataops.mozgcp.net/api/v6/experiments/?is_first_run=true
+          experimenter-url: https://experimenter.services.mozilla.com/api/v6/experiments/?is_first_run=true
           app-name: firefox_ios
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
@@ -35,3 +33,4 @@ jobs:
           title: "Update initial experiments JSON for Nimbus"
           body: "This (automated) PR updates the initial_experiments.json on the `main` branch"
           delete-branch: true
+          labels: Needs Code Review

--- a/.github/workflows/update-nimbus-experiments.yml
+++ b/.github/workflows/update-nimbus-experiments.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: firefox-ios
-          branch: automation/test-experiments-update
+          branch: automation/update-nimbus-experiments
           commit-message: "update initial_experiments.json based on the current first-run experiments in experimenter"
           title: "Update initial experiments JSON for Nimbus"
           body: "This (automated) PR updates the initial_experiments.json on the `main` branch"

--- a/.github/workflows/update-nimbus-experiments.yml
+++ b/.github/workflows/update-nimbus-experiments.yml
@@ -1,0 +1,37 @@
+name: "Update Nimbus Experiments"
+
+on:
+  # schedule:
+  #   - cron: '*/30 * * * *'
+  pull_request: {}
+
+jobs:
+  update-nimbus-experiments:
+    name: "Update Nimbus Experiments"
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Checkout Main Branch"
+        uses: actions/checkout@v2
+        with:
+          path: firefox-ios
+          ref: main
+      - name: "Update Experiments JSON"
+        id: update-experiments-json
+        uses: jeddai/update-initial-experiments@v1
+        with:
+          repo-path: firefox-ios
+          output-path: Client/Experiments/initial_experiments.json
+          # experimenter-url: https://experimenter.services.mozilla.com/api/v6/experiments/?is_first_run=true
+          experimenter-url: https://stage.experimenter.nonprod.dataops.mozgcp.net/api/v6/experiments/?is_first_run=true
+          app-name: firefox_ios
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        if: steps.update-experiments-json.outputs.changed == 1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: firefox-ios
+          branch: automation/test-experiments-update
+          commit-message: "update initial_experiments.json based on the current first-run experiments in experimenter"
+          title: "Update initial experiments JSON for Nimbus"
+          body: "This (automated) PR updates the initial_experiments.json on the `main` branch"
+          delete-branch: true

--- a/.github/workflows/update-nimbus-experiments.yml
+++ b/.github/workflows/update-nimbus-experiments.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-nimbus-experiments:
     name: "Update Nimbus Experiments"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: "Checkout Main Branch"
         uses: actions/checkout@v2
@@ -16,7 +16,7 @@ jobs:
           ref: main
       - name: "Update Experiments JSON"
         id: update-experiments-json
-        uses: jeddai/update-initial-experiments@v1
+        uses: mozilla-mobile/update-initial-experiments@v1
         with:
           repo-path: firefox-ios
           output-path: Client/Experiments/initial_experiments.json


### PR DESCRIPTION
This will add a github action on a cron schedule that will fetch the current firefox_ios first run experiments from the experimenter service, and write them to the `initial_experiments.json` file. If there are changes, it will open a PR for them! On PR closure or merge it will automatically delete the branch.

Issue: #11563 

Examples of it working can be found on my fork: https://github.com/jeddai/firefox-ios/pulls