### PR TITLE
Bugfix FXIOS-4561 [v105] Reload button is not functional after focusing the URL bar #11298

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -894,7 +894,6 @@ class BrowserViewController: UIViewController {
             self.webViewContainer.accessibilityElementsHidden = true
             UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: nil)
         })
-        urlBar.locationView.reloadButton.reloadButtonState = .disabled
     }
 
     /// Once the homepage is created, browserViewController keeps a reference to it, never setting it to nil during


### PR DESCRIPTION
[FXIOS-4561](https://mozilla-hub.atlassian.net/browse/FXIOS-4561) https://github.com/mozilla-mobile/firefox-ios/issues/11298

Reload button is not functional after focusing the URL bar