### PR TITLE
Bugfix FXIOS-4759 [v105] Reload icon is displayed on home page tab

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -896,6 +896,9 @@ class BrowserViewController: UIViewController {
             self.webViewContainer.accessibilityElementsHidden = true
             UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: nil)
         })
+
+        // Make sure reload button is hidden on homepage
+        urlBar.locationView.reloadButton.reloadButtonState = .disabled
     }
 
     /// Once the homepage is created, browserViewController keeps a reference to it, never setting it to nil during
@@ -936,6 +939,9 @@ class BrowserViewController: UIViewController {
             }
             completion?()
         })
+
+        // Make sure reload button is working after leaving homepage
+        urlBar.locationView.reloadButton.reloadButtonState = .reload
     }
 
     func updateInContentHomePanel(_ url: URL?, focusUrlBar: Bool = false) {


### PR DESCRIPTION
# [FXIOS-4759](https://mozilla-hub.atlassian.net/browse/FXIOS-4759) #11590
Make sure reload button has proper state when entering and leaving homepage. Reverts change from PR https://github.com/mozilla-mobile/firefox-ios/pull/11576 and add a fix for the original bug https://github.com/mozilla-mobile/firefox-ios/issues/11298.