### PR TITLE
Refactor FXIOS-4722 [v105] Clean up homepage

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -87,8 +87,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         profile.syncManager.applicationDidBecomeActive()
         webServerUtil?.setUpWebServer()
 
-        browserViewController.homepageViewController?.reloadAll()
-
         /// When transitioning to scenes, each scene's BVC needs to resume its file download queue.
         browserViewController.downloadQueue.resumeAll()
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -887,7 +887,7 @@ class BrowserViewController: UIViewController {
 
         // Hack to force updates on the view
         homepageViewController?.view.alpha = 0.001
-        homepageViewController?.reloadAll()
+        homepageViewController?.reloadView()
 
         UIView.animate(withDuration: 0.2, animations: { () -> Void in
             self.homepageViewController?.view.alpha = 1
@@ -1005,12 +1005,6 @@ class BrowserViewController: UIViewController {
 
         let controller: DismissableNavigationViewController
         controller = DismissableNavigationViewController(rootViewController: libraryViewController)
-        controller.onViewWillDisappear = {
-            self.homepageViewController?.reloadAll()
-        }
-        controller.onViewDismissed = {
-            self.homepageViewController?.reloadAll()
-        }
         self.present(controller, animated: true, completion: nil)
     }
 

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
@@ -227,7 +227,7 @@ extension HistoryHighlightsViewModel: HomepageViewModelProtocol, FeatureFlaggabl
         return !historyItems.isEmpty
     }
 
-    func updateData(completion: @escaping () -> Void) {
+    func updateData() {
         historyItems = historyHighlightsDataAdaptor.getHistoryHightlights()
     }
 

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
@@ -379,10 +379,10 @@ extension HistoryHighlightsViewModel: HomepageSectionHandler {
         let site = Site(url: itemURL, title: item.displayTitle)
 
         let cellOptions = HistoryHighlightsModel(title: item.displayTitle,
-                                                     description: nil,
-                                                     shouldHideBottomLine: hideBottomLine,
-                                                     with: cornersToRound,
-                                                     shouldAddShadow: shouldAddShadow)
+                                                 description: nil,
+                                                 shouldHideBottomLine: hideBottomLine,
+                                                 with: cornersToRound,
+                                                 shouldAddShadow: shouldAddShadow)
 
         cell.updateCell(with: cellOptions)
 
@@ -402,10 +402,10 @@ extension HistoryHighlightsViewModel: HomepageSectionHandler {
         guard let cell = cell as? HistoryHighlightsCell else { return UICollectionViewCell() }
 
         let cellOptions = HistoryHighlightsModel(title: item.displayTitle,
-                                                     description: item.description,
-                                                     shouldHideBottomLine: hideBottomLine,
-                                                     with: cornersToRound,
-                                                     shouldAddShadow: shouldAddShadow)
+                                                 description: item.description,
+                                                 shouldHideBottomLine: hideBottomLine,
+                                                 with: cornersToRound,
+                                                 shouldAddShadow: shouldAddShadow)
 
         cell.updateCell(with: cellOptions)
 
@@ -421,8 +421,8 @@ extension HistoryHighlightsViewModel: HomepageSectionHandler {
         guard let cell = cell as? HistoryHighlightsCell else { return UICollectionViewCell() }
 
         let cellOptions = HistoryHighlightsModel(shouldHideBottomLine: hideBottomLine,
-                                                     with: cornersToRound,
-                                                     shouldAddShadow: shouldAddShadow)
+                                                 with: cornersToRound,
+                                                 shouldAddShadow: shouldAddShadow)
 
         cell.updateCell(with: cellOptions)
         return cell

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
@@ -435,6 +435,7 @@ extension HistoryHighlightsViewModel: HistoryHighlightsDelegate {
     func didLoadNewData() {
         ensureMainThread {
             self.historyItems = self.historyHighlightsDataAdaptor.getHistoryHightlights()
+            guard self.isEnabled else { return }
             self.delegate?.reloadView()
         }
     }

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
@@ -227,10 +227,6 @@ extension HistoryHighlightsViewModel: HomepageViewModelProtocol, FeatureFlaggabl
         return !historyItems.isEmpty
     }
 
-    func updateData() {
-        historyItems = historyHighlightsDataAdaptor.getHistoryHightlights()
-    }
-
     func updatePrivacyConcernedSection(isPrivate: Bool) {
         self.isPrivate = isPrivate
     }

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -102,7 +102,7 @@ class HomepageViewController: UIViewController, HomePanel {
 
         applyTheme()
         setupSectionsAction()
-        reloadAll()
+        reloadView()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -237,8 +237,7 @@ class HomepageViewController: UIViewController, HomePanel {
         else { return }
 
         viewModel.isPrivate = isPrivate
-        viewModel.updateEnabledSections()
-        reloadAll()
+        reloadView()
     }
 
     func applyTheme() {
@@ -363,16 +362,6 @@ extension HomepageViewController: UICollectionViewDelegate, UICollectionViewData
     }
 }
 
-// MARK: - Data Management
-
-extension HomepageViewController {
-
-    /// Reload all data including refreshing cells content and fetching data from backend
-    func reloadAll() {
-        viewModel.updateData()
-    }
-}
-
 // MARK: - Actions Handling
 
 private extension HomepageViewController {
@@ -387,8 +376,7 @@ private extension HomepageViewController {
 
         // Message card
         viewModel.messageCardViewModel.dismissClosure = { [weak self] in
-            self?.viewModel.updateEnabledSections()
-            self?.reloadAll()
+            self?.reloadView()
         }
 
         // Top sites
@@ -622,6 +610,7 @@ extension HomepageViewController: UIPopoverPresentationControllerDelegate {
 // MARK: FirefoxHomeViewModelDelegate
 extension HomepageViewController: HomepageViewModelDelegate {
     func reloadView() {
+        viewModel.updateEnabledSections()
         ensureMainThread { [weak self] in
             guard let self = self,
                   self.view.alpha != 0
@@ -637,14 +626,12 @@ extension HomepageViewController: Notifiable {
         ensureMainThread { [weak self] in
             guard let self = self else { return }
 
-            self.viewModel.updateEnabledSections()
-
             switch notification.name {
             case .TabsPrivacyModeChanged:
                 self.adjustPrivacySensitiveSections(notification: notification)
 
             case .HomePanelPrefsChanged:
-                self.reloadAll()
+                self.reloadView()
 
             default: break
             }

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -610,11 +610,11 @@ extension HomepageViewController: UIPopoverPresentationControllerDelegate {
 // MARK: FirefoxHomeViewModelDelegate
 extension HomepageViewController: HomepageViewModelDelegate {
     func reloadView() {
-        viewModel.updateEnabledSections()
         ensureMainThread { [weak self] in
             guard let self = self,
                   self.view.alpha != 0
             else { return }
+            self.viewModel.updateEnabledSections()
             self.collectionView.reloadData()
         }
     }

--- a/Client/Frontend/Home/HomepageViewModel.swift
+++ b/Client/Frontend/Home/HomepageViewModel.swift
@@ -175,13 +175,13 @@ class HomepageViewModel: FeatureFlaggable {
 
     // MARK: - Fetch section data
 
-    func updateData() {
-        childViewModels.forEach { section in
-            guard section.isEnabled else { return }
-            section.updateData()
-        }
-        reloadView()
-    }
+//    func updateData() {
+//        childViewModels.forEach { section in
+//            guard section.isEnabled else { return }
+//            section.updateData()
+//        }
+//        reloadView()
+//    }
 
     // MARK: - Manage sections
 

--- a/Client/Frontend/Home/HomepageViewModel.swift
+++ b/Client/Frontend/Home/HomepageViewModel.swift
@@ -173,16 +173,6 @@ class HomepageViewModel: FeatureFlaggable {
         viewAppeared = false
     }
 
-    // MARK: - Fetch section data
-
-//    func updateData() {
-//        childViewModels.forEach { section in
-//            guard section.isEnabled else { return }
-//            section.updateData()
-//        }
-//        reloadView()
-//    }
-
     // MARK: - Manage sections
 
     func updateEnabledSections() {
@@ -204,7 +194,6 @@ class HomepageViewModel: FeatureFlaggable {
 // MARK: - HomepageDataModelDelegate
 extension HomepageViewModel: HomepageDataModelDelegate {
     func reloadView() {
-        updateEnabledSections()
         delegate?.reloadView()
     }
 }

--- a/Client/Frontend/Home/HomepageViewModel.swift
+++ b/Client/Frontend/Home/HomepageViewModel.swift
@@ -178,37 +178,12 @@ class HomepageViewModel: FeatureFlaggable {
     func updateData() {
         childViewModels.forEach { section in
             guard section.isEnabled else { return }
-            self.updateData(section: section)
+            section.updateData()
         }
+        reloadView()
     }
 
-    private func updateData(section: HomepageViewModelProtocol) {
-        section.updateData {
-            self.reloadView()
-        }
-    }
-
-    // MARK: - Manage sections and order
-
-    func addShownSection(section: HomepageSectionType) {
-        let positionToInsert = getPositionToInsert(section: section)
-        if positionToInsert >= shownSections.count {
-            shownSections.append(section)
-        } else {
-            shownSections.insert(section, at: positionToInsert)
-        }
-    }
-
-    func removeShownSection(section: HomepageSectionType) {
-        if let index = shownSections.firstIndex(of: section) {
-            shownSections.remove(at: index)
-        }
-    }
-
-    func getPositionToInsert(section: HomepageSectionType) -> Int {
-        let indexes = shownSections.filter { $0.rawValue < section.rawValue }
-        return indexes.count
-    }
+    // MARK: - Manage sections
 
     func updateEnabledSections() {
         shownSections.removeAll()
@@ -223,10 +198,6 @@ class HomepageViewModel: FeatureFlaggable {
     func getSectionViewModel(shownSection: Int) -> HomepageViewModelProtocol? {
         guard let actualSectionNumber = shownSections[safe: shownSection]?.rawValue else { return nil }
         return childViewModels[safe: actualSectionNumber]
-    }
-
-    func indexOfShownSection(_ type: HomepageSectionType) -> Int? {
-        return shownSections.firstIndex(of: type)
     }
 }
 

--- a/Client/Frontend/Home/HomepageViewModelProtocol.swift
+++ b/Client/Frontend/Home/HomepageViewModelProtocol.swift
@@ -27,7 +27,7 @@ protocol HomepageViewModelProtocol {
     var shouldShow: Bool { get }
 
     // Update section data from backend, completes when data has finished loading
-    func updateData(completion: @escaping () -> Void)
+    func updateData()
 
     // Refresh data after reloadOnRotation, so layout can be adjusted
     // Can also be used to prepare data for a specific trait collection when UI is ready to show
@@ -44,9 +44,8 @@ extension HomepageViewModelProtocol {
         return isEnabled && hasData
     }
 
-    func updateData(completion: @escaping () -> Void) {
-        // When no data has to be loaded for a section, call completion right away
-        completion()
+    func updateData() {
+        // When no data has to be loaded for a section
     }
 
     func refreshData(for traitCollection: UITraitCollection) {}

--- a/Client/Frontend/Home/HomepageViewModelProtocol.swift
+++ b/Client/Frontend/Home/HomepageViewModelProtocol.swift
@@ -26,9 +26,6 @@ protocol HomepageViewModelProtocol {
     // Returns true when section has data and is enabled
     var shouldShow: Bool { get }
 
-    // Update section data from backend, completes when data has finished loading
-    func updateData()
-
     // Refresh data after reloadOnRotation, so layout can be adjusted
     // Can also be used to prepare data for a specific trait collection when UI is ready to show
     func refreshData(for traitCollection: UITraitCollection)
@@ -42,10 +39,6 @@ extension HomepageViewModelProtocol {
 
     var shouldShow: Bool {
         return isEnabled && hasData
-    }
-
-    func updateData() {
-        // When no data has to be loaded for a section
     }
 
     func refreshData(for traitCollection: UITraitCollection) {}

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -346,9 +346,7 @@ extension JumpBackInViewModel: HomepageSectionHandler {
         if let jumpBackInItemRow = sectionLayout.indexOfJumpBackInItem(for: indexPath) {
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: JumpBackInCell.cellIdentifier,
                                                           for: indexPath)
-            guard let jumpBackInCell = cell as? JumpBackInCell else {
-                return UICollectionViewCell()
-            }
+            guard let jumpBackInCell = cell as? JumpBackInCell else { return UICollectionViewCell() }
 
             if jumpBackInItemRow == (jumpBackInList.itemsToDisplay - 1),
                let group = jumpBackInList.group {
@@ -364,9 +362,7 @@ extension JumpBackInViewModel: HomepageSectionHandler {
                                                           for: indexPath)
             guard let syncedTabCell = cell as? SyncedTabCell,
                     let mostRecentSyncedTab = mostRecentSyncedTab
-            else {
-                return UICollectionViewCell()
-            }
+            else { return UICollectionViewCell() }
             configureSyncedTabCellForTab(item: mostRecentSyncedTab, cell: syncedTabCell, indexPath: indexPath)
             return syncedTabCell
         }

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -320,11 +320,6 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
         return hasJumpBackIn || hasSyncedTab
     }
 
-    func updateData() {
-        jumpBackInList = jumpBackInDataAdaptor.getJumpBackInData()
-        mostRecentSyncedTab = jumpBackInDataAdaptor.getSyncedTabData()
-    }
-
     func refreshData(for traitCollection: UITraitCollection,
                      device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
         let maxItemToDisplay = sectionLayout.maxItemsToDisplay(

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -320,10 +320,9 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
         return hasJumpBackIn || hasSyncedTab
     }
 
-    func updateData(completion: @escaping () -> Void) {
+    func updateData() {
         jumpBackInList = jumpBackInDataAdaptor.getJumpBackInData()
         mostRecentSyncedTab = jumpBackInDataAdaptor.getSyncedTabData()
-        completion()
     }
 
     func refreshData(for traitCollection: UITraitCollection,

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -346,7 +346,9 @@ extension JumpBackInViewModel: HomepageSectionHandler {
         if let jumpBackInItemRow = sectionLayout.indexOfJumpBackInItem(for: indexPath) {
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: JumpBackInCell.cellIdentifier,
                                                           for: indexPath)
-            guard let jumpBackInCell = cell as? JumpBackInCell else { return UICollectionViewCell() }
+            guard let jumpBackInCell = cell as? JumpBackInCell else {
+                return UICollectionViewCell()
+            }
 
             if jumpBackInItemRow == (jumpBackInList.itemsToDisplay - 1),
                let group = jumpBackInList.group {
@@ -362,7 +364,9 @@ extension JumpBackInViewModel: HomepageSectionHandler {
                                                           for: indexPath)
             guard let syncedTabCell = cell as? SyncedTabCell,
                     let mostRecentSyncedTab = mostRecentSyncedTab
-            else { return UICollectionViewCell() }
+            else {
+                return UICollectionViewCell()
+            }
             configureSyncedTabCellForTab(item: mostRecentSyncedTab, cell: syncedTabCell, indexPath: indexPath)
             return syncedTabCell
         }
@@ -401,6 +405,7 @@ extension JumpBackInViewModel: JumpBackInDelegate {
         ensureMainThread {
             self.jumpBackInList = self.jumpBackInDataAdaptor.getJumpBackInData()
             self.mostRecentSyncedTab = self.jumpBackInDataAdaptor.getSyncedTabData()
+            guard self.isEnabled else { return }
             self.delegate?.reloadView()
         }
     }

--- a/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
+++ b/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
@@ -88,10 +88,6 @@ extension HomepageMessageCardViewModel: HomepageViewModelProtocol {
     var hasData: Bool {
         return shouldDisplayMessageCard
     }
-
-    func updateData() {
-        message = dataAdaptor.getMessageCardData()
-    }
 }
 
 // MARK: - HomepageSectionHandler

--- a/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
+++ b/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
@@ -89,9 +89,8 @@ extension HomepageMessageCardViewModel: HomepageViewModelProtocol {
         return shouldDisplayMessageCard
     }
 
-    func updateData(completion: @escaping () -> Void) {
+    func updateData() {
         message = dataAdaptor.getMessageCardData()
-        completion()
     }
 }
 

--- a/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
+++ b/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
@@ -108,6 +108,7 @@ extension HomepageMessageCardViewModel: MessageCardDelegate {
     func didLoadNewData() {
         ensureMainThread {
             self.message = self.dataAdaptor.getMessageCardData()
+            guard self.isEnabled else { return }
             self.delegate?.reloadView()
             self.handleMessageDisplayed()
         }

--- a/Client/Frontend/Home/Pocket/PocketViewModel.swift
+++ b/Client/Frontend/Home/Pocket/PocketViewModel.swift
@@ -96,6 +96,15 @@ class PocketViewModel {
     private func showDiscoverMore() {
         onTapTileAction?(PocketProvider.MoreStoriesURL)
     }
+
+    private func updateData() {
+        let stories = dataAdaptor.getPocketData()
+        pocketStoriesViewModels = []
+        // Add the story in the view models list
+        for story in stories {
+            bind(pocketStoryViewModel: .init(story: story))
+        }
+    }
 }
 
 // MARK: HomeViewModelProtocol
@@ -164,15 +173,6 @@ extension PocketViewModel: HomepageViewModelProtocol, FeatureFlaggable {
 
     var hasData: Bool {
         return !pocketStoriesViewModels.isEmpty
-    }
-
-    func updateData() {
-        let stories = dataAdaptor.getPocketData()
-        pocketStoriesViewModels = []
-        // Add the story in the view models list
-        for story in stories {
-            bind(pocketStoryViewModel: .init(story: story))
-        }
     }
 }
 

--- a/Client/Frontend/Home/Pocket/PocketViewModel.swift
+++ b/Client/Frontend/Home/Pocket/PocketViewModel.swift
@@ -83,15 +83,6 @@ class PocketViewModel {
 
     // MARK: - Private
 
-    private func updateData() {
-        let stories = dataAdaptor.getPocketData()
-        pocketStoriesViewModels = []
-        // Add the story in the view models list
-        for story in stories {
-            bind(pocketStoryViewModel: .init(story: story))
-        }
-    }
-
     private func bind(pocketStoryViewModel: PocketStandardCellViewModel) {
         pocketStoryViewModel.onTap = { [weak self] indexPath in
             self?.recordTapOnStory(index: indexPath.row)
@@ -175,9 +166,13 @@ extension PocketViewModel: HomepageViewModelProtocol, FeatureFlaggable {
         return !pocketStoriesViewModels.isEmpty
     }
 
-    func updateData(completion: @escaping () -> Void) {
-        updateData()
-        completion()
+    func updateData() {
+        let stories = dataAdaptor.getPocketData()
+        pocketStoriesViewModels = []
+        // Add the story in the view models list
+        for story in stories {
+            bind(pocketStoryViewModel: .init(story: story))
+        }
     }
 }
 

--- a/Client/Frontend/Home/Pocket/PocketViewModel.swift
+++ b/Client/Frontend/Home/Pocket/PocketViewModel.swift
@@ -229,6 +229,7 @@ extension PocketViewModel: PocketDelegate {
     func didLoadNewData() {
         ensureMainThread {
             self.updateData()
+            guard self.isEnabled else { return }
             self.delegate?.reloadView()
         }
     }

--- a/Client/Frontend/Home/Pocket/PocketViewModel.swift
+++ b/Client/Frontend/Home/Pocket/PocketViewModel.swift
@@ -83,6 +83,15 @@ class PocketViewModel {
 
     // MARK: - Private
 
+    private func updateData() {
+        let stories = dataAdaptor.getPocketData()
+        pocketStoriesViewModels = []
+        // Add the story in the view models list
+        for story in stories {
+            bind(pocketStoryViewModel: .init(story: story))
+        }
+    }
+
     private func bind(pocketStoryViewModel: PocketStandardCellViewModel) {
         pocketStoryViewModel.onTap = { [weak self] indexPath in
             self?.recordTapOnStory(index: indexPath.row)
@@ -95,15 +104,6 @@ class PocketViewModel {
 
     private func showDiscoverMore() {
         onTapTileAction?(PocketProvider.MoreStoriesURL)
-    }
-
-    private func updateData() {
-        let stories = dataAdaptor.getPocketData()
-        pocketStoriesViewModels = []
-        // Add the story in the view models list
-        for story in stories {
-            bind(pocketStoryViewModel: .init(story: story))
-        }
     }
 }
 

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
@@ -100,9 +100,8 @@ extension RecentlySavedCellViewModel: HomepageViewModelProtocol, FeatureFlaggabl
     }
 
     /// Using dispatch group to know when data has completely loaded for both sources (recent bookmarks and reading list items)
-    func updateData(completion: @escaping () -> Void) {
+    func updateData() {
         recentItems = recentlySavedDataAdaptor.getRecentlySavedData()
-        completion()
     }
 }
 

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
@@ -151,6 +151,7 @@ extension RecentlySavedCellViewModel: RecentlySavedDelegate {
     func didLoadNewData() {
         ensureMainThread {
             self.recentItems = self.recentlySavedDataAdaptor.getRecentlySavedData()
+            guard self.isEnabled else { return }
             self.delegate?.reloadView()
         }
     }

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
@@ -98,11 +98,6 @@ extension RecentlySavedCellViewModel: HomepageViewModelProtocol, FeatureFlaggabl
     var hasData: Bool {
         return !recentItems.isEmpty
     }
-
-    /// Using dispatch group to know when data has completely loaded for both sources (recent bookmarks and reading list items)
-    func updateData() {
-        recentItems = recentlySavedDataAdaptor.getRecentlySavedData()
-    }
 }
 
 // MARK: FxHomeSectionHandler

--- a/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -174,10 +174,6 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
         return !topSites.isEmpty
     }
 
-    func updateData() {
-        topSites = topSitesDataAdaptor.getTopSitesData()
-    }
-
     func refreshData(for traitCollection: UITraitCollection) {
         let interface = TopSitesUIInterface(trait: traitCollection)
         let sectionDimension = dimensionManager.getSectionDimension(for: topSites,

--- a/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -189,6 +189,7 @@ extension TopSitesViewModel: TopSitesManagerDelegate {
     func didLoadNewData() {
         ensureMainThread {
             self.topSites = self.topSitesDataAdaptor.getTopSitesData()
+            guard self.isEnabled else { return }
             self.delegate?.reloadView()
         }
     }

--- a/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -174,9 +174,8 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
         return !topSites.isEmpty
     }
 
-    func updateData(completion: @escaping () -> Void) {
+    func updateData() {
         topSites = topSitesDataAdaptor.getTopSitesData()
-        completion()
     }
 
     func refreshData(for traitCollection: UITraitCollection) {

--- a/Tests/ClientTests/Frontend/Home/FirefoxHomeViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/FirefoxHomeViewModelTests.swift
@@ -8,7 +8,6 @@ import XCTest
 
 class FirefoxHomeViewModelTests: XCTestCase {
 
-    var reloadSectionCompleted: ((HomepageViewModelProtocol) -> Void)?
     var profile: MockProfile!
 
     override func setUp() {
@@ -26,11 +25,11 @@ class FirefoxHomeViewModelTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         profile = nil
-        reloadSectionCompleted = nil
     }
 
     // MARK: Number of sections
-    func testNumberOfSection_withoutUpdatingData() {
+
+    func testNumberOfSection_withoutUpdatingData_has3Sections() {
         let viewModel = HomepageViewModel(profile: profile,
                                           isPrivate: false,
                                           tabManager: MockTabManager(),
@@ -40,118 +39,4 @@ class FirefoxHomeViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.shownSections[1], HomepageSectionType.messageCard)
         XCTAssertEqual(viewModel.shownSections[2], HomepageSectionType.customizeHome)
     }
-
-    func testNumberOfSection_updatingData_adds2Sections() throws {
-        throw XCTSkip("Disabled until homepage's reload issue is solved")
-//        let collectionView = UICollectionView(frame: CGRect.zero,
-//                                              collectionViewLayout: UICollectionViewLayout())
-//        let viewModel = FirefoxHomeViewModel(profile: profile,
-//                                             isPrivate: false)
-//        viewModel.delegate = self
-//        viewModel.updateData()
-//
-//        let expectation = expectation(description: "Wait for sections to be reloaded")
-//        expectation.expectedFulfillmentCount = 2
-//        reloadSectionCompleted = { section in
-//            ensureMainThread {
-//                viewModel.reloadSection(section, with: collectionView)
-//                expectation.fulfill()
-//            }
-//        }
-//
-//        waitForExpectations(timeout: 1.0, handler: nil)
-//
-//        XCTAssertEqual(viewModel.shownSections.count, 4)
-    }
-
-    // MARK: Orders of sections
-    func testSectionOrder_addingJumpBackIn() {
-        let viewModel = HomepageViewModel(profile: profile,
-                                          isPrivate: false,
-                                          tabManager: MockTabManager(),
-                                          urlBar: URLBarView(profile: profile))
-
-        viewModel.addShownSection(section: HomepageSectionType.jumpBackIn)
-        viewModel.removeShownSection(section: .messageCard)
-        XCTAssertEqual(viewModel.shownSections.count, 3)
-        XCTAssertEqual(viewModel.shownSections[0], HomepageSectionType.logoHeader)
-        XCTAssertEqual(viewModel.shownSections[1], HomepageSectionType.jumpBackIn)
-        XCTAssertEqual(viewModel.shownSections[2], HomepageSectionType.customizeHome)
-    }
-
-    func testMessageOrder_AfterMessageDismiss() {
-        let viewModel = HomepageViewModel(profile: profile,
-                                          isPrivate: false,
-                                          tabManager: MockTabManager(),
-                                          urlBar: URLBarView(profile: profile))
-
-        viewModel.messageCardViewModel.handleMessageDismiss()
-        viewModel.reloadView()
-        XCTAssertEqual(viewModel.shownSections.count, 2)
-        XCTAssertEqual(viewModel.shownSections[0], HomepageSectionType.logoHeader)
-        XCTAssertEqual(viewModel.shownSections[1], HomepageSectionType.customizeHome)
-    }
-
-    func testSectionOrder_addingTwoSections() {
-        let viewModel = HomepageViewModel(profile: profile,
-                                          isPrivate: false,
-                                          tabManager: MockTabManager(),
-                                          urlBar: URLBarView(profile: profile))
-
-        viewModel.removeShownSection(section: .messageCard)
-        viewModel.addShownSection(section: HomepageSectionType.jumpBackIn)
-        viewModel.addShownSection(section: HomepageSectionType.pocket)
-
-        XCTAssertEqual(viewModel.shownSections.count, 4)
-        XCTAssertEqual(viewModel.shownSections[0], HomepageSectionType.logoHeader)
-        XCTAssertEqual(viewModel.shownSections[1], HomepageSectionType.jumpBackIn)
-        XCTAssertEqual(viewModel.shownSections[2], HomepageSectionType.pocket)
-        XCTAssertEqual(viewModel.shownSections[3], HomepageSectionType.customizeHome)
-    }
-
-    func testSectionOrder_addingAndRemovingSections() {
-        let viewModel = HomepageViewModel(profile: profile,
-                                          isPrivate: false,
-                                          tabManager: MockTabManager(),
-                                          urlBar: URLBarView(profile: profile))
-
-        viewModel.removeShownSection(section: HomepageSectionType.messageCard)
-        viewModel.addShownSection(section: HomepageSectionType.jumpBackIn)
-        viewModel.addShownSection(section: HomepageSectionType.pocket)
-        viewModel.removeShownSection(section: HomepageSectionType.customizeHome)
-        XCTAssertEqual(viewModel.shownSections.count, 3)
-        XCTAssertEqual(viewModel.shownSections[0], HomepageSectionType.logoHeader)
-        XCTAssertEqual(viewModel.shownSections[1], HomepageSectionType.jumpBackIn)
-        XCTAssertEqual(viewModel.shownSections[2], HomepageSectionType.pocket)
-    }
-
-    func testSectionOrder_addingAndRemovingMoreSections() {
-        let viewModel = HomepageViewModel(profile: profile,
-                                          isPrivate: false,
-                                          tabManager: MockTabManager(),
-                                          urlBar: URLBarView(profile: profile))
-
-        viewModel.addShownSection(section: HomepageSectionType.jumpBackIn)
-        viewModel.addShownSection(section: HomepageSectionType.pocket)
-        viewModel.addShownSection(section: HomepageSectionType.historyHighlights)
-        viewModel.removeShownSection(section: HomepageSectionType.messageCard)
-        viewModel.removeShownSection(section: HomepageSectionType.customizeHome)
-        XCTAssertEqual(viewModel.shownSections.count, 4)
-        XCTAssertEqual(viewModel.shownSections[0], HomepageSectionType.logoHeader)
-        XCTAssertEqual(viewModel.shownSections[1], HomepageSectionType.jumpBackIn)
-        XCTAssertEqual(viewModel.shownSections[2], HomepageSectionType.historyHighlights)
-        XCTAssertEqual(viewModel.shownSections[3], HomepageSectionType.pocket)
-
-        viewModel.removeShownSection(section: HomepageSectionType.historyHighlights)
-
-        XCTAssertEqual(viewModel.shownSections.count, 3)
-        XCTAssertEqual(viewModel.shownSections[0], HomepageSectionType.logoHeader)
-        XCTAssertEqual(viewModel.shownSections[1], HomepageSectionType.jumpBackIn)
-        XCTAssertEqual(viewModel.shownSections[2], HomepageSectionType.pocket)
-    }
-}
-
-// MARK: - FirefoxHomeViewModelDelegate
-extension FirefoxHomeViewModelTests: HomepageViewModelDelegate {
-    func reloadView() {}
 }

--- a/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -181,12 +181,11 @@ class JumpBackInViewModelTests: XCTestCase {
         let sut = createSut()
         sut.featureFlags.set(feature: .jumpBackInSyncedTab, to: true)
         adaptor.syncedTab = JumpBackInSyncedTab(client: remoteClient, tab: remoteTab)
-        sut.updateData()
 
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .compact
         trait.overridenVerticalSizeClass = .regular
-
+        sut.refreshData(for: trait)
         sut.updateSectionLayout(for: trait, isPortrait: false, device: .pad)
         let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
                                                                      hasAccount: true,
@@ -201,12 +200,11 @@ class JumpBackInViewModelTests: XCTestCase {
         adaptor.syncedTab = JumpBackInSyncedTab(client: remoteClient, tab: remoteTab)
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
-        sut.updateData()
 
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .compact
         trait.overridenVerticalSizeClass = .regular
-
+        sut.refreshData(for: trait)
         sut.updateSectionLayout(for: trait, isPortrait: false, device: .pad)
         let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
                                                                      hasAccount: true,
@@ -220,12 +218,11 @@ class JumpBackInViewModelTests: XCTestCase {
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
         adaptor.mockHasSyncedTabFeatureEnabled = false
-        sut.updateData()
 
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
-
+        sut.refreshData(for: trait)
         sut.updateSectionLayout(for: trait, isPortrait: true, device: .phone)
         let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
                                                                      hasAccount: true,
@@ -239,12 +236,11 @@ class JumpBackInViewModelTests: XCTestCase {
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
         adaptor.mockHasSyncedTabFeatureEnabled = false
-        sut.updateData()
 
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
-
+        sut.refreshData(for: trait)
         sut.updateSectionLayout(for: trait, isPortrait: true, device: .pad)
         let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
                                                                      hasAccount: true,
@@ -258,12 +254,11 @@ class JumpBackInViewModelTests: XCTestCase {
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
         adaptor.syncedTab = JumpBackInSyncedTab(client: remoteClient, tab: remoteTab)
-        sut.updateData()
 
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
-
+        sut.refreshData(for: trait)
         sut.updateSectionLayout(for: trait, isPortrait: true, device: .phone)
         let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
                                                                      hasAccount: true,
@@ -277,12 +272,11 @@ class JumpBackInViewModelTests: XCTestCase {
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
         adaptor.syncedTab = JumpBackInSyncedTab(client: remoteClient, tab: remoteTab)
-        sut.updateData()
 
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
-
+        sut.refreshData(for: trait)
         sut.updateSectionLayout(for: trait, isPortrait: true, device: .pad)
         let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
                                                                      hasAccount: true,
@@ -295,12 +289,11 @@ class JumpBackInViewModelTests: XCTestCase {
         let sut = createSut()
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
-        sut.updateData()
 
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
-
+        sut.refreshData(for: trait)
         sut.updateSectionLayout(for: trait, isPortrait: true, device: .phone)
         let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
                                                                      hasAccount: true,
@@ -313,12 +306,11 @@ class JumpBackInViewModelTests: XCTestCase {
         let sut = createSut()
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
-        sut.updateData()
 
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
-
+        sut.refreshData(for: trait)
         sut.updateSectionLayout(for: trait, isPortrait: true, device: .pad)
         let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
                                                                      hasAccount: true,

--- a/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -181,7 +181,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let sut = createSut()
         sut.featureFlags.set(feature: .jumpBackInSyncedTab, to: true)
         adaptor.syncedTab = JumpBackInSyncedTab(client: remoteClient, tab: remoteTab)
-        sut.updateData {}
+        sut.updateData()
 
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .compact
@@ -201,7 +201,7 @@ class JumpBackInViewModelTests: XCTestCase {
         adaptor.syncedTab = JumpBackInSyncedTab(client: remoteClient, tab: remoteTab)
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
-        sut.updateData {}
+        sut.updateData()
 
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .compact
@@ -220,7 +220,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
         adaptor.mockHasSyncedTabFeatureEnabled = false
-        sut.updateData {}
+        sut.updateData()
 
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
@@ -239,7 +239,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
         adaptor.mockHasSyncedTabFeatureEnabled = false
-        sut.updateData {}
+        sut.updateData()
 
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
@@ -258,7 +258,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
         adaptor.syncedTab = JumpBackInSyncedTab(client: remoteClient, tab: remoteTab)
-        sut.updateData {}
+        sut.updateData()
 
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
@@ -277,7 +277,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
         adaptor.syncedTab = JumpBackInSyncedTab(client: remoteClient, tab: remoteTab)
-        sut.updateData {}
+        sut.updateData()
 
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
@@ -295,7 +295,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let sut = createSut()
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
-        sut.updateData {}
+        sut.updateData()
 
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
@@ -313,7 +313,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let sut = createSut()
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
-        sut.updateData {}
+        sut.updateData()
 
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular


### PR DESCRIPTION
# [FXIOS-4722](https://mozilla-hub.atlassian.net/browse/FXIOS-4722) https://github.com/mozilla-mobile/firefox-ios/issues/11541
* Remove completion from updateData from HomepageViewModel and remove unused code in that view model
* Remove updateData, data is now updated from adaptors entirely. No need for extra triggers
* Clean up to make sure updateEnabledSections is called once only
* Do not trigger a reload for a view that isn't shown (i.e. if it's disabled by the user or through Nimbus).

Note: this still doesn't fix a crash in the jump back in section when closing tabs, this will be in a another PR.