### PR TITLE
Add #11306 [v106]: Jump Back In contextual hint updates

### DIFF
--- a/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -12,6 +12,7 @@ import UIKit
 enum NimbusFeatureFlagID: String, CaseIterable {
     case bottomSearchBar
     case contextualHintForToolbar
+    case contextualHintForJumpBackIn
     case contextualHintForJumpBackInSyncedTab
     case historyHighlights
     case historyGroups
@@ -81,7 +82,8 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
             return FlagKeys.CustomWallpaper
 
         // Cases where users do not have the option to manipulate a setting.
-        case .contextualHintForJumpBackInSyncedTab,
+        case .contextualHintForJumpBackIn,
+                .contextualHintForJumpBackInSyncedTab,
                 .contextualHintForToolbar,
                 .reportSiteIssue,
                 .shakeToRestore,

--- a/Client/Frontend/Contextual Hint/ContextualHintEligibilityUtility.swift
+++ b/Client/Frontend/Contextual Hint/ContextualHintEligibilityUtility.swift
@@ -17,7 +17,7 @@ struct ContextualHintEligibilityUtility: ContextualHintEligibilityUtilityProtoco
         self.profile = profile
     }
 
-    /// Determine if this hint is eligible to present.
+    /// Determine if this hint is eligible to present, outside of Nimbus flag settings.
     func canPresent(_ hintType: ContextualHintType) -> Bool {
         guard isDeviceReady else { return false }
 
@@ -52,8 +52,7 @@ struct ContextualHintEligibilityUtility: ContextualHintEligibilityUtilityProtoco
     /// - the JumpBackInSyncedTab CFR has NOT been presented already
     /// - the JumpBackIn CFR has NOT been presented yet
     private var canJumpBackInBePresented: Bool {
-        guard UIDevice.current.userInterfaceIdiom != .pad,
-              let hasPresentedToolbarCFR = profile.prefs.boolForKey(CFRPrefsKeys.ToolbarOnboardingKey.rawValue),
+        guard let hasPresentedToolbarCFR = profile.prefs.boolForKey(CFRPrefsKeys.ToolbarOnboardingKey.rawValue),
               hasPresentedToolbarCFR,
               !hasHintBeenConfigured(.jumpBackInSyncedTab),
               !hasAlreadyBeenPresented(.jumpBackInSyncedTab)

--- a/Client/Frontend/Contextual Hint/ContextualHintViewModel.swift
+++ b/Client/Frontend/Contextual Hint/ContextualHintViewModel.swift
@@ -41,9 +41,9 @@ class ContextualHintViewModel: ContextualHintPrefsKeysProvider {
     // MARK: - Interface
 
     func shouldPresentContextualHint() -> Bool {
-        let contextualHintPresLogic = ContextualHintEligibilityUtility(with: profile)
+        let hintEligibilityUtility = ContextualHintEligibilityUtility(with: profile)
 
-        return contextualHintPresLogic.canPresent(hintType)
+        return hintEligibilityUtility.canPresent(hintType)
     }
 
     func markContextualHintPresented() {

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -290,6 +290,7 @@ class HomepageViewController: UIViewController, HomePanel {
     // MARK: - Contextual hint
     private func prepareJumpBackInContextualHint(onView headerView: LabelButtonHeaderView) {
         guard contextualHintViewController.shouldPresentHint(),
+              viewModel.jumpBackInViewModel.isFlagForHintEnabled(),
               !viewModel.shouldDisplayHomeTabBanner
         else { return }
 

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -128,6 +128,10 @@ class JumpBackInViewModel: FeatureFlaggable {
         }
     }
 
+    func isFlagForHintEnabled() -> Bool {
+        return featureFlags.isFeatureEnabled(.contextualHintForJumpBackIn, checking: .buildOnly)
+    }
+
     private var hasSyncedTab: Bool {
         return jumpBackInDataAdaptor.hasSyncedTabFeatureEnabled && mostRecentSyncedTab != nil
     }

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -145,10 +145,11 @@ extension String {
         public struct FirefoxHomepage {
             public struct JumpBackIn {
                 public static let PersonalizedHome = MZLocalizedString(
-                    "ContextualHints.Homepage.PersonalizedHome",
-                    value: "Your personalized Firefox homepage now makes it easier to pick up where you left off. Find your recent tabs, bookmarks, and search results.",
-                    comment: "Contextual hints are little popups that appear for the users informing them of new features. This one talks about the more personalized home feature.",
-                    lastUpdated: .v39)
+                    "ContextualHints.FirefoxHomepage.JumpBackIn.PersonalizedHome",
+                    tableName: "JumpBackIn",
+                    value: "Meet your personalized homepage. Recent tabs, bookmarks, and search results will appear here.",
+                    comment: "Contextual hints are little popups that appear for the users informing them of new features. This one talks about additions to the Firefox homepage regarding a more personalized experience.",
+                    lastUpdated: .v106)
                 public static let SyncedTab = MZLocalizedString(
                     "ContextualHints.FirefoxHomepage.JumpBackIn.SyncedTab.v106",
                     tableName: "JumpBackIn",

--- a/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -31,7 +31,9 @@ final class NimbusFeatureFlagLayer {
         case .jumpBackInSyncedTab:
             return checkNimbusForJumpBackInSyncedTabFeature(using: nimbus)
 
-        case .contextualHintForJumpBackInSyncedTab, .contextualHintForToolbar:
+        case .contextualHintForJumpBackIn,
+                .contextualHintForJumpBackInSyncedTab,
+                .contextualHintForToolbar:
             return checkNimbusForContextualHintsFeature(for: featureID, from: nimbus)
 
         case .sponsoredPocket:
@@ -126,6 +128,7 @@ final class NimbusFeatureFlagLayer {
 
         switch featureID {
         case .contextualHintForToolbar: nimbusID = ContextualHint.toolbarContextualHint
+        case .contextualHintForJumpBackIn: nimbusID = ContextualHint.jumpBackInContextualHint
         case .contextualHintForJumpBackInSyncedTab: nimbusID = ContextualHint.jumpBackInSyncedTabContextualHint
         default: return false
         }

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -256,6 +256,7 @@ features:
         default: 
         {
           "toolbar-contextual-hint": true,
+          "jump-back-in-contextual-hint": true,
           "jump-back-in-synced-tab-contextual-hint": false
         }
     defaults:
@@ -263,6 +264,7 @@ features:
         value: {
           "features-enabled": {
             "toolbar-contextual-hint": true,
+            "jump-back-in-contextual-hint": true,
             "jump-back-in-synced-tab-contextual-hint": true
           }
         }
@@ -270,6 +272,7 @@ features:
         value: {
           "features-enabled": {
             "toolbar-contextual-hint": true,
+            "jump-back-in-contextual-hint": true,
             "jump-back-in-synced-tab-contextual-hint": true
           }
         }
@@ -609,6 +612,8 @@ types:
       variants:
         toolbar-contextual-hint:
           description: The contextual hint bubble that appears to indicate that the toolbar location is adjustable.
+        jump-back-in-contextual-hint:
+          description: The contextual hint bubble that appears to indicate new additions to the firefox homepage, like the Jump Back In section.
         jump-back-in-synced-tab-contextual-hint:
           description: The contextual hint bubble that appears to indicate a synced tab has appeared within the Jump Back In section.
 


### PR DESCRIPTION
# #11306 | [FXIOS-4567](https://mozilla-hub.atlassian.net/browse/FXIOS-4567)

## Overview
Jump Back In contextual hint updates; these updates are specifically on copy and to add a Nimbus flag to it. 

## Testing
Make sure you haven't seen the hint before on your build. You may have to delete your app and do a fresh install. Then: 
- Dismiss the Home Tab banner
- navigate to a page, open a new tab. 
- Open the grid tab tray view and hit done
- Observe. The hint will appear.

## Related
https://github.com/mozilla-mobile/firefox-ios/pull/11527 had some updates to presentation eligibility of JumpBackIn hint. 
Design updates [are here](https://www.figma.com/file/7J6gh5D8DbGTExxskKdn3T/Mobile-Onboarding?node-id=1950%3A64274).
## Screenshot
<img width="428" alt="image" src="https://user-images.githubusercontent.com/36939381/184447699-0e76b7c0-4ba3-41e1-906c-7b9463207f14.png">
