### PR TITLE
Bugfix FXIOS-4520 [v105] Jump back in crash

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -888,6 +888,7 @@ class BrowserViewController: UIViewController {
         // Hack to force updates on the view
         homepageViewController?.view.alpha = 0.001
         homepageViewController?.reloadView()
+        NotificationCenter.default.post(name: .ShowHomepage, object: nil)
 
         UIView.animate(withDuration: 0.2, animations: { () -> Void in
             self.homepageViewController?.view.alpha = 1

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -262,7 +262,6 @@ class TopTabsViewController: UIViewController {
 extension TopTabsViewController: TabDisplayer {
 
     func focusSelectedTab() {
-        NotificationCenter.default.post(name: .TopTabsTabSelected, object: nil)
         self.scrollToCurrentTab(true)
         self.handleFadeOutAfterTabSelection()
     }
@@ -282,7 +281,6 @@ extension TopTabsViewController: TabDisplayer {
 extension TopTabsViewController: TopTabCellDelegate {
     func tabCellDidClose(_ cell: UICollectionViewCell) {
         topTabDisplayManager.closeActionPerformed(forCell: cell)
-        NotificationCenter.default.post(name: .TopTabsTabClosed, object: nil)
     }
 }
 

--- a/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionViewModel.swift
+++ b/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionViewModel.swift
@@ -7,7 +7,6 @@ import Foundation
 /// Customize button is always present at the bottom of the page
 class CustomizeHomepageSectionViewModel {
     var onTapAction: ((UIButton) -> Void)?
-    var traitCollection: UITraitCollection?
 }
 
 // MARK: HomeViewModelProtocol
@@ -22,7 +21,6 @@ extension CustomizeHomepageSectionViewModel: HomepageViewModelProtocol {
     }
 
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
-        self.traitCollection = traitCollection
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                               heightDimension: .estimated(100))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)

--- a/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionViewModel.swift
+++ b/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionViewModel.swift
@@ -7,6 +7,7 @@ import Foundation
 /// Customize button is always present at the bottom of the page
 class CustomizeHomepageSectionViewModel {
     var onTapAction: ((UIButton) -> Void)?
+    var traitCollection: UITraitCollection?
 }
 
 // MARK: HomeViewModelProtocol
@@ -21,6 +22,7 @@ extension CustomizeHomepageSectionViewModel: HomepageViewModelProtocol {
     }
 
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
+        self.traitCollection = traitCollection
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                               heightDimension: .estimated(100))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
@@ -36,7 +38,7 @@ extension CustomizeHomepageSectionViewModel: HomepageViewModelProtocol {
         return section
     }
 
-    func numberOfItemsInSection(for traitCollection: UITraitCollection) -> Int {
+    func numberOfItemsInSection() -> Int {
         return 1
     }
 

--- a/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionViewModel.swift
+++ b/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionViewModel.swift
@@ -43,6 +43,10 @@ extension CustomizeHomepageSectionViewModel: HomepageViewModelProtocol {
     var isEnabled: Bool {
         return true
     }
+
+    func refreshData(for traitCollection: UITraitCollection,
+                     isPortrait: Bool = UIWindow.isPortrait,
+                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {}
 }
 
 // MARK: FxHomeSectionHandler

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
@@ -230,6 +230,10 @@ extension HistoryHighlightsViewModel: HomepageViewModelProtocol, FeatureFlaggabl
     func updatePrivacyConcernedSection(isPrivate: Bool) {
         self.isPrivate = isPrivate
     }
+
+    func refreshData(for traitCollection: UITraitCollection,
+                     isPortrait: Bool = UIWindow.isPortrait,
+                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {}
 }
 
 // MARK: FxHomeSectionHandler

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
@@ -73,6 +73,7 @@ class HistoryHighlightsViewModel {
     private lazy var siteImageHelper = SiteImageHelper(profile: profile)
     private var hasSentSectionEvent = false
     private var historyHighlightsDataAdaptor: HistoryHighlightsDataAdaptor
+    var traitCollection: UITraitCollection?
     var onTapItem: ((HighlightItem) -> Void)?
     var historyHighlightLongPressHandler: ((HighlightItem, UIView?) -> Void)?
     var headerButtonAction: ((UIButton) -> Void)?
@@ -183,6 +184,7 @@ extension HistoryHighlightsViewModel: HomepageViewModelProtocol, FeatureFlaggabl
     }
 
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
+        self.traitCollection = traitCollection
         let item = NSCollectionLayoutItem(
             layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                                heightDimension: .estimated(UX.estimatedCellHeight))
@@ -211,7 +213,7 @@ extension HistoryHighlightsViewModel: HomepageViewModelProtocol, FeatureFlaggabl
         return section
     }
 
-    func numberOfItemsInSection(for traitCollection: UITraitCollection) -> Int {
+    func numberOfItemsInSection() -> Int {
         // If there are less than or equal items to the max number of items allowed per column,
         // we can return the standard count, as we don't need to display filler cells.
         // However, if there's more items, filler cells needs to be accounted for, so sections

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
@@ -73,7 +73,6 @@ class HistoryHighlightsViewModel {
     private lazy var siteImageHelper = SiteImageHelper(profile: profile)
     private var hasSentSectionEvent = false
     private var historyHighlightsDataAdaptor: HistoryHighlightsDataAdaptor
-    var traitCollection: UITraitCollection?
     var onTapItem: ((HighlightItem) -> Void)?
     var historyHighlightLongPressHandler: ((HighlightItem, UIView?) -> Void)?
     var headerButtonAction: ((UIButton) -> Void)?
@@ -184,7 +183,6 @@ extension HistoryHighlightsViewModel: HomepageViewModelProtocol, FeatureFlaggabl
     }
 
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
-        self.traitCollection = traitCollection
         let item = NSCollectionLayoutItem(
             layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                                heightDimension: .estimated(UX.estimatedCellHeight))

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -613,6 +613,7 @@ extension HomepageViewController: HomepageViewModelDelegate {
             guard let self = self,
                   self.view.alpha != 0
             else { return }
+            self.viewModel.refreshData()
             self.viewModel.updateEnabledSections()
             self.collectionView.reloadData()
         }

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -613,7 +613,7 @@ extension HomepageViewController: HomepageViewModelDelegate {
             guard let self = self,
                   self.view.alpha != 0
             else { return }
-            self.viewModel.refreshData()
+            self.viewModel.refreshData(for: self.traitCollection)
             self.viewModel.updateEnabledSections()
             self.collectionView.reloadData()
         }

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -72,8 +72,7 @@ class HomepageViewController: UIViewController, HomePanel {
 
         setupNotifications(forObserver: self,
                            observing: [.HomePanelPrefsChanged,
-                                       .TabsPrivacyModeChanged,
-                                       .DynamicFontChanged])
+                                       .TabsPrivacyModeChanged])
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -344,7 +344,7 @@ extension HomepageViewController: UICollectionViewDelegate, UICollectionViewData
     }
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return viewModel.getSectionViewModel(shownSection: section)?.numberOfItemsInSection(for: traitCollection) ?? 0
+        return viewModel.getSectionViewModel(shownSection: section)?.numberOfItemsInSection() ?? 0
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {

--- a/Client/Frontend/Home/HomepageViewModel.swift
+++ b/Client/Frontend/Home/HomepageViewModel.swift
@@ -183,9 +183,9 @@ class HomepageViewModel: FeatureFlaggable {
         }
     }
 
-    func refreshData() {
+    func refreshData(for traitCollection: UITraitCollection) {
         childViewModels.forEach {
-            $0.refreshData()
+            $0.refreshData(for: traitCollection)
         }
     }
 

--- a/Client/Frontend/Home/HomepageViewModel.swift
+++ b/Client/Frontend/Home/HomepageViewModel.swift
@@ -183,6 +183,12 @@ class HomepageViewModel: FeatureFlaggable {
         }
     }
 
+    func refreshData() {
+        childViewModels.forEach {
+            $0.refreshData()
+        }
+    }
+
     // MARK: - Section ViewModel helper
 
     func getSectionViewModel(shownSection: Int) -> HomepageViewModelProtocol? {

--- a/Client/Frontend/Home/HomepageViewModelProtocol.swift
+++ b/Client/Frontend/Home/HomepageViewModelProtocol.swift
@@ -30,7 +30,7 @@ protocol HomepageViewModelProtocol {
     var shouldShow: Bool { get }
 
     // Refresh data from adaptor to ensure it refresh the right state before laying itself out
-    func refreshData()
+    func refreshData(for traitCollection: UITraitCollection)
 
     // Update section that are privacy sensitive, only implement when needed
     func updatePrivacyConcernedSection(isPrivate: Bool)
@@ -43,7 +43,7 @@ extension HomepageViewModelProtocol {
         return isEnabled && hasData
     }
 
-    func refreshData() {}
+    func refreshData(for traitCollection: UITraitCollection) {}
 
     func updatePrivacyConcernedSection(isPrivate: Bool) {}
 }

--- a/Client/Frontend/Home/HomepageViewModelProtocol.swift
+++ b/Client/Frontend/Home/HomepageViewModelProtocol.swift
@@ -9,9 +9,6 @@ protocol HomepageViewModelProtocol {
 
     var sectionType: HomepageSectionType { get }
 
-    // Trait collection of the section
-    var traitCollection: UITraitCollection? { get }
-
     // Layout section so FirefoxHomeViewController view controller can setup the section
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection
 

--- a/Client/Frontend/Home/HomepageViewModelProtocol.swift
+++ b/Client/Frontend/Home/HomepageViewModelProtocol.swift
@@ -27,7 +27,9 @@ protocol HomepageViewModelProtocol {
     var shouldShow: Bool { get }
 
     // Refresh data from adaptor to ensure it refresh the right state before laying itself out
-    func refreshData(for traitCollection: UITraitCollection)
+    func refreshData(for traitCollection: UITraitCollection,
+                     isPortrait: Bool,
+                     device: UIUserInterfaceIdiom)
 
     // Update section that are privacy sensitive, only implement when needed
     func updatePrivacyConcernedSection(isPrivate: Bool)
@@ -40,7 +42,11 @@ extension HomepageViewModelProtocol {
         return isEnabled && hasData
     }
 
-    func refreshData(for traitCollection: UITraitCollection) {}
-
     func updatePrivacyConcernedSection(isPrivate: Bool) {}
+
+    func refreshData(for traitCollection: UITraitCollection,
+                     isPortrait: Bool = UIWindow.isPortrait,
+                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
+        refreshData(for: traitCollection, isPortrait: isPortrait, device: device)
+    }
 }

--- a/Client/Frontend/Home/HomepageViewModelProtocol.swift
+++ b/Client/Frontend/Home/HomepageViewModelProtocol.swift
@@ -9,10 +9,13 @@ protocol HomepageViewModelProtocol {
 
     var sectionType: HomepageSectionType { get }
 
+    // Trait collection of the section
+    var traitCollection: UITraitCollection? { get }
+
     // Layout section so FirefoxHomeViewController view controller can setup the section
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection
 
-    func numberOfItemsInSection(for traitCollection: UITraitCollection) -> Int
+    func numberOfItemsInSection() -> Int
 
     // The header view model to setup the header for this section
     var headerViewModel: LabelButtonHeaderViewModel { get }
@@ -26,9 +29,8 @@ protocol HomepageViewModelProtocol {
     // Returns true when section has data and is enabled
     var shouldShow: Bool { get }
 
-    // Refresh data after reloadOnRotation, so layout can be adjusted
-    // Can also be used to prepare data for a specific trait collection when UI is ready to show
-    func refreshData(for traitCollection: UITraitCollection)
+    // Refresh data from adaptor to ensure it refresh the right state before laying itself out
+    func refreshData()
 
     // Update section that are privacy sensitive, only implement when needed
     func updatePrivacyConcernedSection(isPrivate: Bool)
@@ -41,7 +43,7 @@ extension HomepageViewModelProtocol {
         return isEnabled && hasData
     }
 
-    func refreshData(for traitCollection: UITraitCollection) {}
+    func refreshData() {}
 
     func updatePrivacyConcernedSection(isPrivate: Bool) {}
 }

--- a/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
+++ b/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
@@ -68,9 +68,8 @@ class JumpBackInDataAdaptorImplementation: JumpBackInDataAdaptor, FeatureFlaggab
         self.dispatchGroup = dispatchGroup
         self.userInteractiveQueue = userInteractiveQueue
 
-        setupNotifications(forObserver: self, observing: [.TabsTrayDidClose,
-                                                          .TopTabsTabClosed,
-                                                          .TopTabsTabSelected,
+        setupNotifications(forObserver: self, observing: [.ShowHomepage,
+                                                          .TabsTrayDidClose,
                                                           .TabsTrayDidSelectHomeTab])
 
         updateData()
@@ -273,9 +272,8 @@ class JumpBackInDataAdaptorImplementation: JumpBackInDataAdaptor, FeatureFlaggab
 extension JumpBackInDataAdaptorImplementation: Notifiable {
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
-        case .TabsTrayDidClose,
-                .TopTabsTabClosed,
-                .TopTabsTabSelected,
+        case .ShowHomepage,
+                .TabsTrayDidClose,
                 .TabsTrayDidSelectHomeTab:
             updateData()
         default: break

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -27,7 +27,6 @@ class JumpBackInViewModel: FeatureFlaggable {
 
     var jumpBackInList = JumpBackInList(group: nil, tabs: [Tab]())
     var mostRecentSyncedTab: JumpBackInSyncedTab?
-    var traitCollection: UITraitCollection?
 
     private lazy var siteImageHelper = SiteImageHelper(profile: profile)
     private var jumpBackInDataAdaptor: JumpBackInDataAdaptor

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -110,9 +110,9 @@ class JumpBackInViewModel: FeatureFlaggable {
         }
     }
 
-    func updateSectionLayout(for traitCollection: UITraitCollection,
-                             isPortrait: Bool = UIWindow.isPortrait,
-                             device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
+    private func updateSectionLayout(for traitCollection: UITraitCollection,
+                                     isPortrait: Bool = UIWindow.isPortrait,
+                                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
         let isPhoneInLandscape = device == .phone && !isPortrait
 
         if hasSyncedTab, traitCollection.horizontalSizeClass == .compact, !isPhoneInLandscape {
@@ -315,8 +315,9 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
         return hasJumpBackIn || hasSyncedTab
     }
 
-    func refreshData(for traitCollection: UITraitCollection) {
-        let device = UIDevice.current.userInterfaceIdiom
+    func refreshData(for traitCollection: UITraitCollection,
+                     isPortrait: Bool = UIWindow.isPortrait,
+                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
         let maxItemToDisplay = sectionLayout.maxItemsToDisplay(
             displayGroup: .jumpBackIn,
             hasAccount: jumpBackInDataAdaptor.hasSyncedTabFeatureEnabled,
@@ -328,8 +329,8 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
         mostRecentSyncedTab = jumpBackInDataAdaptor.getSyncedTabData()
 
         updateSectionLayout(for: traitCollection,
-                            isPortrait: UIWindow.isPortrait,
-                            device: UIDevice.current.userInterfaceIdiom)
+                            isPortrait: isPortrait,
+                            device: device)
     }
 
     func updatePrivacyConcernedSection(isPrivate: Bool) {

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -286,9 +286,7 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
     }
 
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
-        self.traitCollection = traitCollection
         var section: NSCollectionLayoutSection
-
         switch sectionLayout {
         case .compactSyncedTab, .compactJumpBackInAndSyncedTab:
             section = sectionWithSyncedTabCompact(for: traitCollection)
@@ -318,8 +316,7 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
         return hasJumpBackIn || hasSyncedTab
     }
 
-    func refreshData() {
-        guard let traitCollection = traitCollection else { return }
+    func refreshData(for traitCollection: UITraitCollection) {
         let device = UIDevice.current.userInterfaceIdiom
         let maxItemToDisplay = sectionLayout.maxItemsToDisplay(
             displayGroup: .jumpBackIn,

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -204,9 +204,9 @@ private extension JumpBackInViewModel {
 
         // Nested Group (Jump Back In)
         let nestedGroupSize = NSCollectionLayoutSize(widthDimension: groupWidth,
-                                                       heightDimension: .fractionalHeight(1))
+                                                     heightDimension: .fractionalHeight(1))
         let nestedGroup = NSCollectionLayoutGroup.vertical(layoutSize: nestedGroupSize,
-                                                             subitems: [jumpBackInItem, jumpBackInItem])
+                                                           subitems: [jumpBackInItem, jumpBackInItem])
         nestedGroup.interItemSpacing = JumpBackInCell.UX.interItemSpacing
 
         // Main Group

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -27,6 +27,7 @@ class JumpBackInViewModel: FeatureFlaggable {
 
     var jumpBackInList = JumpBackInList(group: nil, tabs: [Tab]())
     var mostRecentSyncedTab: JumpBackInSyncedTab?
+    var traitCollection: UITraitCollection?
 
     private lazy var siteImageHelper = SiteImageHelper(profile: profile)
     private var jumpBackInDataAdaptor: JumpBackInDataAdaptor
@@ -280,16 +281,13 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
         return !isPrivate
     }
 
-    func numberOfItemsInSection(for traitCollection: UITraitCollection) -> Int {
-        refreshData(for: traitCollection)
+    func numberOfItemsInSection() -> Int {
         return jumpBackInList.itemsToDisplay + (hasSyncedTab ? JumpBackInViewModel.UX.maxDisplayedSyncedTabs : 0)
     }
 
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
+        self.traitCollection = traitCollection
         var section: NSCollectionLayoutSection
-        updateSectionLayout(for: traitCollection,
-                            isPortrait: UIWindow.isPortrait,
-                            device: UIDevice.current.userInterfaceIdiom)
 
         switch sectionLayout {
         case .compactSyncedTab, .compactJumpBackInAndSyncedTab:
@@ -320,8 +318,9 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
         return hasJumpBackIn || hasSyncedTab
     }
 
-    func refreshData(for traitCollection: UITraitCollection,
-                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
+    func refreshData() {
+        guard let traitCollection = traitCollection else { return }
+        let device = UIDevice.current.userInterfaceIdiom
         let maxItemToDisplay = sectionLayout.maxItemsToDisplay(
             displayGroup: .jumpBackIn,
             hasAccount: jumpBackInDataAdaptor.hasSyncedTabFeatureEnabled,
@@ -331,6 +330,10 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
 
         jumpBackInList = jumpBackInDataAdaptor.getJumpBackInData()
         mostRecentSyncedTab = jumpBackInDataAdaptor.getSyncedTabData()
+
+        updateSectionLayout(for: traitCollection,
+                            isPortrait: UIWindow.isPortrait,
+                            device: UIDevice.current.userInterfaceIdiom)
     }
 
     func updatePrivacyConcernedSection(isPrivate: Bool) {

--- a/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
+++ b/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
@@ -55,6 +55,10 @@ extension HomeLogoHeaderViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     var isEnabled: Bool {
         return featureFlags.isFeatureEnabled(.wallpapers, checking: .buildOnly)
     }
+
+    func refreshData(for traitCollection: UITraitCollection,
+                     isPortrait: Bool = UIWindow.isPortrait,
+                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {}
 }
 
 extension HomeLogoHeaderViewModel: HomepageSectionHandler {

--- a/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
+++ b/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
@@ -13,6 +13,7 @@ class HomeLogoHeaderViewModel {
 
     private let profile: Profile
     var onTapAction: ((UIButton) -> Void)?
+    var traitCollection: UITraitCollection?
 
     init(profile: Profile) {
         self.profile = profile
@@ -31,6 +32,7 @@ extension HomeLogoHeaderViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
+        self.traitCollection = traitCollection
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                               heightDimension: .estimated(100))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
@@ -48,7 +50,7 @@ extension HomeLogoHeaderViewModel: HomepageViewModelProtocol, FeatureFlaggable {
         return section
     }
 
-    func numberOfItemsInSection(for traitCollection: UITraitCollection) -> Int {
+    func numberOfItemsInSection() -> Int {
         return 1
     }
 

--- a/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
+++ b/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
@@ -13,7 +13,6 @@ class HomeLogoHeaderViewModel {
 
     private let profile: Profile
     var onTapAction: ((UIButton) -> Void)?
-    var traitCollection: UITraitCollection?
 
     init(profile: Profile) {
         self.profile = profile
@@ -32,7 +31,6 @@ extension HomeLogoHeaderViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
-        self.traitCollection = traitCollection
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                               heightDimension: .estimated(100))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)

--- a/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
+++ b/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
@@ -17,6 +17,7 @@ class HomepageMessageCardViewModel: MessageSurfaceProtocol, GleanPlumbMessageMan
     weak var delegate: HomepageDataModelDelegate?
     var message: GleanPlumbMessage?
     var dismissClosure: (() -> Void)?
+    var traitCollection: UITraitCollection?
 
     init(dataAdaptor: MessageCardDataAdaptor) {
         self.dataAdaptor = dataAdaptor
@@ -54,6 +55,7 @@ extension HomepageMessageCardViewModel: HomepageViewModelProtocol {
     }
 
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
+        self.traitCollection = traitCollection
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                               heightDimension: .estimated(180))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
@@ -73,7 +75,7 @@ extension HomepageMessageCardViewModel: HomepageViewModelProtocol {
         return section
     }
 
-    func numberOfItemsInSection(for traitCollection: UITraitCollection) -> Int {
+    func numberOfItemsInSection() -> Int {
         return 1
     }
 

--- a/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
+++ b/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
@@ -17,7 +17,6 @@ class HomepageMessageCardViewModel: MessageSurfaceProtocol, GleanPlumbMessageMan
     weak var delegate: HomepageDataModelDelegate?
     var message: GleanPlumbMessage?
     var dismissClosure: (() -> Void)?
-    var traitCollection: UITraitCollection?
 
     init(dataAdaptor: MessageCardDataAdaptor) {
         self.dataAdaptor = dataAdaptor
@@ -55,7 +54,6 @@ extension HomepageMessageCardViewModel: HomepageViewModelProtocol {
     }
 
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
-        self.traitCollection = traitCollection
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                               heightDimension: .estimated(180))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)

--- a/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
+++ b/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
@@ -88,6 +88,10 @@ extension HomepageMessageCardViewModel: HomepageViewModelProtocol {
     var hasData: Bool {
         return shouldDisplayMessageCard
     }
+
+    func refreshData(for traitCollection: UITraitCollection,
+                     isPortrait: Bool = UIWindow.isPortrait,
+                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {}
 }
 
 // MARK: - HomepageSectionHandler

--- a/Client/Frontend/Home/Pocket/PocketViewModel.swift
+++ b/Client/Frontend/Home/Pocket/PocketViewModel.swift
@@ -19,7 +19,6 @@ class PocketViewModel {
 
     var isZeroSearch: Bool
     private var hasSentPocketSectionEvent = false
-    var traitCollection: UITraitCollection?
 
     var onTapTileAction: ((URL) -> Void)?
     var onLongPressTileAction: ((Site, UIView?) -> Void)?
@@ -123,7 +122,6 @@ extension PocketViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
-        self.traitCollection = traitCollection
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1),
             heightDimension: .estimated(PocketStandardCell.UX.cellHeight)

--- a/Client/Frontend/Home/Pocket/PocketViewModel.swift
+++ b/Client/Frontend/Home/Pocket/PocketViewModel.swift
@@ -174,6 +174,10 @@ extension PocketViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     var hasData: Bool {
         return !pocketStoriesViewModels.isEmpty
     }
+
+    func refreshData(for traitCollection: UITraitCollection,
+                     isPortrait: Bool = UIWindow.isPortrait,
+                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {}
 }
 
 // MARK: FxHomeSectionHandler

--- a/Client/Frontend/Home/Pocket/PocketViewModel.swift
+++ b/Client/Frontend/Home/Pocket/PocketViewModel.swift
@@ -19,6 +19,7 @@ class PocketViewModel {
 
     var isZeroSearch: Bool
     private var hasSentPocketSectionEvent = false
+    var traitCollection: UITraitCollection?
 
     var onTapTileAction: ((URL) -> Void)?
     var onLongPressTileAction: ((Site, UIView?) -> Void)?
@@ -122,6 +123,7 @@ extension PocketViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
+        self.traitCollection = traitCollection
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1),
             heightDimension: .estimated(PocketStandardCell.UX.cellHeight)
@@ -159,7 +161,7 @@ extension PocketViewModel: HomepageViewModelProtocol, FeatureFlaggable {
         return section
     }
 
-    func numberOfItemsInSection(for traitCollection: UITraitCollection) -> Int {
+    func numberOfItemsInSection() -> Int {
         // Including discover more cell
         return !pocketStoriesViewModels.isEmpty ? pocketStoriesViewModels.count + 1 : 0
     }

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
@@ -21,7 +21,6 @@ class RecentlySavedCellViewModel {
     private var recentlySavedDataAdaptor: RecentlySavedDataAdaptor
     private var recentItems = [RecentlySavedItem]()
     var headerButtonAction: ((UIButton) -> Void)?
-    var traitCollection: UITraitCollection?
 
     weak var delegate: HomepageDataModelDelegate?
 
@@ -57,7 +56,6 @@ extension RecentlySavedCellViewModel: HomepageViewModelProtocol, FeatureFlaggabl
     }
 
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
-        self.traitCollection = traitCollection
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .absolute(UX.cellWidth),
             heightDimension: .estimated(UX.cellHeight)

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
@@ -98,6 +98,10 @@ extension RecentlySavedCellViewModel: HomepageViewModelProtocol, FeatureFlaggabl
     var hasData: Bool {
         return !recentItems.isEmpty
     }
+
+    func refreshData(for traitCollection: UITraitCollection,
+                     isPortrait: Bool = UIWindow.isPortrait,
+                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {}
 }
 
 // MARK: FxHomeSectionHandler

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedCellViewModel.swift
@@ -21,6 +21,7 @@ class RecentlySavedCellViewModel {
     private var recentlySavedDataAdaptor: RecentlySavedDataAdaptor
     private var recentItems = [RecentlySavedItem]()
     var headerButtonAction: ((UIButton) -> Void)?
+    var traitCollection: UITraitCollection?
 
     weak var delegate: HomepageDataModelDelegate?
 
@@ -56,6 +57,7 @@ extension RecentlySavedCellViewModel: HomepageViewModelProtocol, FeatureFlaggabl
     }
 
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
+        self.traitCollection = traitCollection
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .absolute(UX.cellWidth),
             heightDimension: .estimated(UX.cellHeight)
@@ -87,7 +89,7 @@ extension RecentlySavedCellViewModel: HomepageViewModelProtocol, FeatureFlaggabl
         return section
     }
 
-    func numberOfItemsInSection(for traitCollection: UITraitCollection) -> Int {
+    func numberOfItemsInSection() -> Int {
         return recentItems.count
     }
 

--- a/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -138,7 +138,6 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
-        self.traitCollection = traitCollection
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1),
             heightDimension: .estimated(UX.cellEstimatedSize.height)
@@ -170,8 +169,7 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
         return !topSites.isEmpty
     }
 
-    func refreshData() {
-        guard let traitCollection = traitCollection else { return }
+    func refreshData(for traitCollection: UITraitCollection) {
         let interface = TopSitesUIInterface(trait: traitCollection)
         let sectionDimension = dimensionManager.getSectionDimension(for: topSites,
                                                                     numberOfRows: topSitesDataAdaptor.numberOfRows,

--- a/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -17,7 +17,6 @@ class TopSitesViewModel {
     var isZeroSearch: Bool
     var tilePressedHandler: ((Site, Bool) -> Void)?
     var tileLongPressedHandler: ((Site, UIView?) -> Void)?
-    var traitCollection: UITraitCollection?
 
     private let profile: Profile
     private var sentImpressionTelemetry = [String: Bool]()

--- a/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -168,7 +168,9 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
         return !topSites.isEmpty
     }
 
-    func refreshData(for traitCollection: UITraitCollection) {
+    func refreshData(for traitCollection: UITraitCollection,
+                     isPortrait: Bool = UIWindow.isPortrait,
+                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
         let interface = TopSitesUIInterface(trait: traitCollection)
         let sectionDimension = dimensionManager.getSectionDimension(for: topSites,
                                                                     numberOfRows: topSitesDataAdaptor.numberOfRows,

--- a/Shared/NotificationConstants.swift
+++ b/Shared/NotificationConstants.swift
@@ -64,9 +64,7 @@ extension Notification.Name {
 
     public static let UpdateLabelOnTabClosed = Notification.Name("UpdateLabelOnTabClosed")
 
-    public static let TopTabsTabClosed = Notification.Name("TopTabsTabClosed")
-
-    public static let TopTabsTabSelected = Notification.Name("TopTabsTabSelected")
+    public static let ShowHomepage = Notification.Name("ShowHomepage")
 
     public static let TabsTrayDidClose = Notification.Name("TabsTrayDidClose")
 

--- a/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -169,7 +169,7 @@ class JumpBackInViewModelTests: XCTestCase {
         trait.overridenHorizontalSizeClass = .compact
         trait.overridenVerticalSizeClass = .regular
 
-        sut.updateSectionLayout(for: trait, isPortrait: true, device: .phone)
+        sut.refreshData(for: trait, isPortrait: true, device: .phone)
         let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
                                                                      hasAccount: false,
                                                                      device: .phone)
@@ -185,8 +185,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .compact
         trait.overridenVerticalSizeClass = .regular
-        sut.refreshData(for: trait)
-        sut.updateSectionLayout(for: trait, isPortrait: false, device: .pad)
+        sut.refreshData(for: trait, isPortrait: false, device: .pad)
         let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
                                                                      hasAccount: true,
                                                                      device: .pad)
@@ -204,8 +203,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .compact
         trait.overridenVerticalSizeClass = .regular
-        sut.refreshData(for: trait)
-        sut.updateSectionLayout(for: trait, isPortrait: false, device: .pad)
+        sut.refreshData(for: trait, isPortrait: false, device: .pad)
         let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
                                                                      hasAccount: true,
                                                                      device: .pad)
@@ -222,8 +220,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
-        sut.refreshData(for: trait)
-        sut.updateSectionLayout(for: trait, isPortrait: true, device: .phone)
+        sut.refreshData(for: trait, isPortrait: true, device: .phone)
         let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
                                                                      hasAccount: true,
                                                                      device: .phone)
@@ -240,8 +237,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
-        sut.refreshData(for: trait)
-        sut.updateSectionLayout(for: trait, isPortrait: true, device: .pad)
+        sut.refreshData(for: trait, isPortrait: true, device: .pad)
         let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
                                                                      hasAccount: true,
                                                                      device: .pad)
@@ -258,8 +254,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
-        sut.refreshData(for: trait)
-        sut.updateSectionLayout(for: trait, isPortrait: true, device: .phone)
+        sut.refreshData(for: trait, isPortrait: true, device: .phone)
         let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
                                                                      hasAccount: true,
                                                                      device: .phone)
@@ -276,8 +271,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
-        sut.refreshData(for: trait)
-        sut.updateSectionLayout(for: trait, isPortrait: true, device: .pad)
+        sut.refreshData(for: trait, isPortrait: true, device: .pad)
         let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
                                                                      hasAccount: true,
                                                                      device: .pad)
@@ -293,8 +287,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
-        sut.refreshData(for: trait)
-        sut.updateSectionLayout(for: trait, isPortrait: true, device: .phone)
+        sut.refreshData(for: trait, isPortrait: true, device: .phone)
         let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
                                                                      hasAccount: true,
                                                                      device: .phone)
@@ -310,8 +303,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
-        sut.refreshData(for: trait)
-        sut.updateSectionLayout(for: trait, isPortrait: true, device: .pad)
+        sut.refreshData(for: trait, isPortrait: true, device: .pad)
         let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
                                                                      hasAccount: true,
                                                                      device: .pad)


### PR DESCRIPTION
# [FXIOS-4520](https://mozilla-hub.atlassian.net/browse/FXIOS-4520) https://github.com/mozilla-mobile/firefox-ios/issues/11227
This PR fixes two possible reasons for crash on the homepage jump back in. Problem 1 is related to problem 2, but was causing it to happen more frequently

### Problem 1
Jump back in section relies on `recentlyAccessedNormalTabs` from tabManager. When we update the tab data, it fetches the `normalTabs` and check their `lastKnownUrl`. If the `lastKnownUrl` is nil, then the tab isn't part of the jump back in data. The thing is, when we delete tabs (which trigger a selection of a new tab if the deleted tab was the selected one) the `lastKnownUrl` can be nil since the session data is being recreated. This means the tab is now not part of the jump back in data anymore. In other words, when we delete tabs rapidly on iPad, we can't update our data rapidly since the tab session data can be nil. One way of solving this is to update the data later when the homepage is asked to be shown. This means we might see some tabs being added into the section once the data is updated, but I'm good with that if it means we're not crashing.

### Problem 2 
Sometimes the section count or number of items in a section was out of sync with the actual data. I.e. the layout was expecting a certain number of sections/cells and the data wasn't corresponding. This inconsistent state was caused by a refresh from the adaptor in the middle of a reload of the collection view. Here was the flow with an example:
- I have 2 jump back in tabs with a homepage
- I delete rapidly all the tabs from the top tabs on iPad
- This triggers a reload of the homepage
- Section layout is called and jump back in still has data at that point (with 1 or 2 tabs depending on the speed we deleted things). The collection view believes it has a jump back in section.
- Number of items from the collection view is called, triggering a refresh of the data with the `traitCollection`. 
- Turns out there was no jump back in tabs anymore after that refresh
- Crash since the collection view expected 1 or 2 tabs within a section that it turns out no longer exists.

The fix for this that I propose is that we call refreshData before calling reloadData. Any reload will have a fixed state throughout it's update. 