### PR TITLE
Bugfix FXIOS-4694 [v105] homepage layout bugs

### DIFF
--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -228,7 +228,9 @@ class HomepageViewController: UIViewController, HomePanel {
 
         // Force the entire collectionview to re-layout
         collectionView.collectionViewLayout.invalidateLayout()
-        reloadView()
+        DispatchQueue.main.async {
+            self.reloadView()
+        }
     }
 
     private func adjustPrivacySensitiveSections(notification: Notification) {

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -265,8 +265,7 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
     }
 
     var headerViewModel: LabelButtonHeaderViewModel {
-        return LabelButtonHeaderViewModel(trailingInset: 0,
-                                          title: HomepageSectionType.jumpBackIn.title,
+        return LabelButtonHeaderViewModel(title: HomepageSectionType.jumpBackIn.title,
                                           titleA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.jumpBackIn,
                                           isButtonHidden: false,
                                           buttonTitle: .RecentlySavedShowAllText,
@@ -310,7 +309,7 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
         section.contentInsets = NSDirectionalEdgeInsets(top: 0,
                                                         leading: leadingInset,
                                                         bottom: HomepageViewModel.UX.spacingBetweenSections,
-                                                        trailing: leadingInset)
+                                                        trailing: 0)
         section.interGroupSpacing = JumpBackInCell.UX.interGroupSpacing
 
         return section


### PR DESCRIPTION
This fixes the layout issue where the show more buttons on the homepage don't line up.
It also fixes the issue where the history highlights sections gets a bit messed up when changing the device orientation.

The dispatch async on rotate is a bit inelegant but this is one of 2 options to fix this issue and neither are particularly elegant.
The underlying issue is that Apple don't provide a convenient way to know when a layout pass following a rotation has completed. So when you have a view that sizes itself based on the current size of the screen, or some other characteristic of it's layout then recalculating it at the time `viewWillTransition` happens is not correct because the layout pass has not yet completed. 
The alternative to just dispatching the update to happen at the bottom of the main queue is to have some sort of flag to keep track of that this view needs to be re-calibarated at the end of the next layout pass that is set to true in `viewWillTransition` and then in `viewDidLayoutSubviews` the flag is checked and reset and the update is performed accordingly. I think this option is more clunky but lets discuss if you disagree.