### PR TITLE
Bugfix FXIOS-4767 [v105] Make sure we stop CFR timer when homepage is hidden

### DIFF
--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -215,6 +215,7 @@ class HomepageViewController: UIViewController, HomePanel {
     }
 
     func recordHomepageDisappeared() {
+        contextualHintViewController.stopTimer()
         viewModel.recordViewDisappeared()
     }
 


### PR DESCRIPTION
# [FXIOS-4767](https://mozilla-hub.atlassian.net/browse/FXIOS-4767) https://github.com/mozilla-mobile/firefox-ios/issues/11606
As explained in the issue comment, this bug was probably happening more often since we weren't setting the homepage to nil as often as before after merging https://github.com/mozilla-mobile/firefox-ios/pull/11371. One quick way to fix the problem is to make sure that we stop the CFR timer when the homepage is disappearing (controlled through BVC). With this fix, if the homepage is hidden the CFR won't show but it will be asked to popup next time the homepage is shown.