### PR TITLE
Bugfix FXIOS-4580 [v105] improve sync upgrade onboarding cards

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -524,9 +524,7 @@ class BrowserViewController: UIViewController {
         super.viewDidAppear(animated)
 
         presentIntroViewController()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-            self.presentUpdateViewController()
-        }
+        presentUpdateViewController()
         screenshotHelper.viewIsVisible = true
 
         if let toast = self.pendingToast {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -521,11 +521,13 @@ class BrowserViewController: UIViewController {
     }
 
     override func viewDidAppear(_ animated: Bool) {
-        presentIntroViewController()
-        presentUpdateViewController()
-        screenshotHelper.viewIsVisible = true
-
         super.viewDidAppear(animated)
+
+        presentIntroViewController()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            self.presentUpdateViewController()
+        }
+        screenshotHelper.viewIsVisible = true
 
         if let toast = self.pendingToast {
             self.pendingToast = nil

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -746,7 +746,7 @@ extension String {
             comment: "Describes the action on the first upgrade page in the Upgrade screen. This string will be on a button so user can continue the Upgrade.",
             lastUpdated: .v106)
         public static let SyncSignTitle = MZLocalizedString(
-            "Upgrade.SyncSign.Description.v106",
+            "Upgrade.SyncSign.Title.v106",
             value: "Switching screens is easier than ever",
             comment: "Title string used to sign in to sync in the Upgrade screens. This screen is shown after user upgrades firefox version",
             lastUpdated: .v106)

--- a/Client/Frontend/Update/UpdateViewController.swift
+++ b/Client/Frontend/Update/UpdateViewController.swift
@@ -245,7 +245,7 @@ extension UpdateViewController: OnboardingCardDelegate {
     func primaryAction(_ cardType: IntroViewModel.InformationCards) {
         switch cardType {
         case .updateWelcome:
-            moveToNextPage(cardType: cardType)
+            showNextPage(cardType)
         case .updateSignSync:
             presentSignToSync()
         default:

--- a/Client/Frontend/Update/UpdateViewModel.swift
+++ b/Client/Frontend/Update/UpdateViewModel.swift
@@ -10,12 +10,16 @@ class UpdateViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
     let profile: Profile
     static let prefsKey: String = PrefsKeys.KeyLastVersionNumber
 
+    lazy var hasSyncableAccount: Bool = {
+        return profile.hasSyncableAccount()
+    }()
+
     var shouldShowSingleCard: Bool {
         return enabledCards.count == 1
     }
 
     var enabledCards: [IntroViewModel.InformationCards] {
-        if profile.hasSyncableAccount() {
+        if hasSyncableAccount {
             return [.updateWelcome]
         }
 

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -77,6 +77,10 @@ features:
         type: Boolean
         default: false
     defaults:
+      - channel: beta
+        value: {
+          "enabled": true
+        }
       - channel: developer
         value: {
           "enabled": true


### PR DESCRIPTION
Issue https://github.com/mozilla-mobile/firefox-ios/issues/11319
Jira [4580](https://mozilla-hub.atlassian.net/browse/FXIOS-4580)

- Enables UpdateViewController in beta channel
- Fix bug on primary button tap when showing only one screen
- Fix UI bug related to the `hasAccount` change in state once the deferred value is filled

This doesn't fix the underlying issue of hasAccount but avoids a bug where the screen will get stuck. During the UX review of the ticket we will discuss the best solution to present this screen and deal with the delay of the account manager being initialized 