### PR TITLE
Localize FXIOS-4681 [v105] Fix strings with duplicate values

### DIFF
--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -787,7 +787,7 @@
 "Menu.TrackingProtectionWhitelistRemove.Title" = "Enable for this site";
 
 /* The title for the option to view the What's new page. */
-"Menu.WhatsNew.Title" = "What's New";
+"Menu.WhatsNew.Title" = "What’s New";
 
 /* Accessibility label for the navigation toolbar displayed at the bottom of the screen. */
 "Navigation Toolbar" = "Navigation Toolbar";
@@ -1136,7 +1136,7 @@
 "Settings.DisplayTheme.OptionLight" = "Light";
 
 /* Display (theme) settings footer describing how the brightness slider works. */
-"Settings.DisplayTheme.SectionFooter" = "The theme will automatically change based on your display brightness. You can set the threshold where the theme changes. The circle indicates your display's current brightness.";
+"Settings.DisplayTheme.SectionFooter" = "The theme will automatically change based on your display brightness. You can set the threshold where the theme changes. The circle indicates your display’s current brightness.";
 
 /* Switch mode settings section title */
 "Settings.DisplayTheme.SwitchMode.SectionHeader" = "Switch Mode";


### PR DESCRIPTION
Follow-up for #11618 

When running the action, two of the existing string were not changed. In the log there's

```
--- WARNING: Key "Menu.WhatsNew.Title" used with multiple values. Value "What's New" kept. Value "What's New" ignored.

--- WARNING: Key "Settings.DisplayTheme.SectionFooter" used with multiple values. Value "The theme will automatically change based on your display brightness. You can set the threshold where the theme changes. The circle indicates your display's current brightness." kept. Value "The theme will automatically change based on your display brightness. You can set the threshold where the theme changes. The circle indicates your display's current brightness." ignored.
```

Apparently, changing the string in the .swift file is not enough. To make things even more confusing, this is likely caused by me changing `en-US.lproj`, when there's also `en.lproj`. I'm not completely sure that's expected behavior, but 🤷🏼 