### PR TITLE
Bugfix FXIOS-4778 [v105] Jump back in section layout

### DIFF
--- a/Client/Frontend/Home/JumpBackIn/JumpBackInSectionLayout.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInSectionLayout.swift
@@ -20,7 +20,8 @@ enum JumpBackInSectionLayout: Equatable {
     var widthDimension: NSCollectionLayoutDimension {
         switch self {
         case .compactJumpBackIn, .compactSyncedTab, .compactJumpBackInAndSyncedTab:
-            return .fractionalWidth(1)
+            // When the trailing inset will be handled by the section layout, this can be set to .fractionalWidth(1)
+            return UIDevice.current.userInterfaceIdiom == .pad ? .fractionalWidth(0.95) : .fractionalWidth(0.93)
         case .regular, .regularWithSyncedTab:
             return UIDevice.current.userInterfaceIdiom == .pad ?
                 .fractionalWidth(7.66/24) : .fractionalWidth(7.8/16) // iPad or iPhone in landscape

--- a/Client/Frontend/Home/Pocket/PocketDataAdaptor.swift
+++ b/Client/Frontend/Home/Pocket/PocketDataAdaptor.swift
@@ -37,7 +37,7 @@ class PocketDataAdaptorImplementation: PocketDataAdaptor, FeatureFlaggable {
                                            pocketSponsoredAPI: pocketSponsoredAPI)
         self.dataCompletion = dataCompletion
 
-        setupNotifications(forObserver: self, observing: [UIApplication.willEnterForegroundNotification])
+        setupNotifications(forObserver: self, observing: [UIApplication.didBecomeActiveNotification])
 
         Task {
             await updatePocketSites()


### PR DESCRIPTION
# [FXIOS-4778](https://mozilla-hub.atlassian.net/browse/FXIOS-4778) https://github.com/mozilla-mobile/firefox-ios/issues/11620
- Refresh pocket data a little later to make sure UI is setup (issue was that the UIWindow.isLandscape wasn't proper as we were looking too early, hence we were layout for Landscape instead of Portrait)
- Also fixed a little layout iPhone issue relating to fix https://github.com/mozilla-mobile/firefox-ios/issues/11501, where on iPhone portrait and iPad multitasking the jump back in section missing some space, although the Show all button is now aligned with other sections
![Screen Shot 2022-08-17 at 11 53 31 AM](https://user-images.githubusercontent.com/11338480/185185848-1c2ed8f0-f07f-4a11-bfd3-c7e045cb648b.png)

