### PR TITLE
Bugfix FXIOS-4705 [v105] Fix crash on orientation change

### DIFF
--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -222,14 +222,15 @@ class HomepageViewController: UIViewController, HomePanel {
     /// is done with the new trait. On iPad, trait collection doesn't change from portrait to landscape (and vice-versa)
     /// since it's `.regular` on both. We reloadOnRotation from viewWillTransition in that case.
     private func reloadOnRotation() {
-        if let _ = self.presentedViewController as? PhotonActionSheet {
+        if let _ = presentedViewController as? PhotonActionSheet {
             presentedViewController?.dismiss(animated: false, completion: nil)
         }
 
         // Force the entire collectionview to re-layout
+        viewModel.refreshData(for: traitCollection)
         collectionView.collectionViewLayout.invalidateLayout()
         DispatchQueue.main.async {
-            self.reloadView()
+            self.collectionView.reloadData()
         }
     }
 
@@ -614,11 +615,12 @@ extension HomepageViewController: UIPopoverPresentationControllerDelegate {
 extension HomepageViewController: HomepageViewModelDelegate {
     func reloadView() {
         ensureMainThread { [weak self] in
+            // If the view controller is not visible ignore updates
             guard let self = self,
                   self.view.alpha != 0
             else { return }
+
             self.viewModel.refreshData(for: self.traitCollection)
-            self.viewModel.updateEnabledSections()
             self.collectionView.reloadData()
         }
     }

--- a/Client/Frontend/Home/HomepageViewModel.swift
+++ b/Client/Frontend/Home/HomepageViewModel.swift
@@ -184,6 +184,7 @@ class HomepageViewModel: FeatureFlaggable {
     }
 
     func refreshData(for traitCollection: UITraitCollection) {
+        updateEnabledSections()
         childViewModels.forEach {
             $0.refreshData(for: traitCollection)
         }


### PR DESCRIPTION
Invalidating the layout triggers a new pass of the UICollectionViewCompositionalLayout closures for each section so the data needs to be refreshed before the invalidate call or it can get out of sync, especially when an entire section is removed.