### PR TITLE
Bugfix FXIOS-4779 [v105] Make sure we load data when rust places is opened

### DIFF
--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsDataAdaptor.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsDataAdaptor.swift
@@ -36,7 +36,8 @@ class HistoryHighlightsDataAdaptorImplementation: HistoryHighlightsDataAdaptor {
         self.deletionUtility = HistoryDeletionUtility(with: profile)
 
         setupNotifications(forObserver: self,
-                           observing: [.HistoryUpdated])
+                           observing: [.HistoryUpdated,
+                                       .RustPlacesOpened])
         loadHistory()
     }
 
@@ -85,7 +86,8 @@ class HistoryHighlightsDataAdaptorImplementation: HistoryHighlightsDataAdaptor {
 extension HistoryHighlightsDataAdaptorImplementation: Notifiable {
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
-        case .HistoryUpdated:
+        case .HistoryUpdated,
+                .RustPlacesOpened:
             loadHistory()
         default:
             return

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedDataAdaptor.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedDataAdaptor.swift
@@ -42,7 +42,10 @@ class RecentlySavedDataAdaptorImplementation: RecentlySavedDataAdaptor, Notifiab
         self.readingList = readingList
         self.bookmarksHandler = bookmarksHandler
 
-        setupNotifications(forObserver: self, observing: [.ReadingListUpdated, .BookmarksUpdated])
+        setupNotifications(forObserver: self,
+                           observing: [.ReadingListUpdated,
+                                       .BookmarksUpdated,
+                                       .RustPlacesOpened])
 
         getRecentBookmarks()
         getReadingLists()
@@ -119,7 +122,7 @@ class RecentlySavedDataAdaptorImplementation: RecentlySavedDataAdaptor, Notifiab
         switch notification.name {
         case .ReadingListUpdated:
             getReadingLists()
-        case .BookmarksUpdated:
+        case .BookmarksUpdated, .RustPlacesOpened:
             getRecentBookmarks()
         default: break
         }

--- a/Shared/NotificationConstants.swift
+++ b/Shared/NotificationConstants.swift
@@ -38,6 +38,8 @@ extension Notification.Name {
     public static let DatabaseWasClosed = Notification.Name("DatabaseWasClosed")
     public static let DatabaseWasReopened = Notification.Name("DatabaseWasReopened")
 
+    public static let RustPlacesOpened = Notification.Name("RustPlacesOpened")
+
     public static let PasscodeDidChange = Notification.Name("PasscodeDidChange")
 
     public static let PasscodeDidCreate = Notification.Name("PasscodeDidCreate")

--- a/Storage/Rust/RustPlaces.swift
+++ b/Storage/Rust/RustPlaces.swift
@@ -40,6 +40,7 @@ public class RustPlaces: BookmarksHandler {
         do {
             api = try PlacesAPI(path: databasePath)
             isOpen = true
+            notificationCenter.post(name: .RustPlacesOpened, object: nil)
             return nil
         } catch let err as NSError {
             if let placesError = err as? PlacesError {


### PR DESCRIPTION
# [FXIOS-4779](https://mozilla-hub.atlassian.net/browse/FXIOS-4779) https://github.com/mozilla-mobile/firefox-ios/issues/11622
On cold start the homepage data is loading before the rust places is done opening. This means we then never refetch HH or recently saved data since there's no other trigger anymore. This was working before since there was a bunch of updateData triggered, and the RustPlaces was opened at one point in one of those calls. To fix this I make sure we trigger a load data when rust places is opened.