### PR TITLE
Add FXIOS-4784 [v105] Add workflow_dispatch to update-nimbus-experiments workflow

### DIFF
--- a/.github/workflows/update-nimbus-experiments.yml
+++ b/.github/workflows/update-nimbus-experiments.yml
@@ -3,6 +3,7 @@ name: "Update Nimbus Experiments"
 on:
   schedule:
     - cron: '*/30 * * * *'
+  workflow_dispatch: {}
 
 jobs:
   update-nimbus-experiments:


### PR DESCRIPTION
Adding `workflow_dispatch` to the `on` block for the `update-nimbus-experiments` workflow. This will allow the job to be manually run, which will be helpful in fast-moving situations. Ideally we won't _need_ to manually run it, but we'd prefer not to be caught in a situation where we want to but can't.

#11630

Example in Fenix:
https://github.com/mozilla-mobile/fenix/blob/main/.github/workflows/update-nimbus-experiments.yml#L10
https://github.com/mozilla-mobile/fenix/actions/workflows/update-nimbus-experiments.yml