### PR TITLE
Bugfix FXIOS-4520 [v105] Add back TopTabsTabClosed notif since needed

### DIFF
--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -281,6 +281,7 @@ extension TopTabsViewController: TabDisplayer {
 extension TopTabsViewController: TopTabCellDelegate {
     func tabCellDidClose(_ cell: UICollectionViewCell) {
         topTabDisplayManager.closeActionPerformed(forCell: cell)
+        NotificationCenter.default.post(name: .TopTabsTabClosed, object: nil)
     }
 }
 

--- a/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
+++ b/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
@@ -70,7 +70,8 @@ class JumpBackInDataAdaptorImplementation: JumpBackInDataAdaptor, FeatureFlaggab
 
         setupNotifications(forObserver: self, observing: [.ShowHomepage,
                                                           .TabsTrayDidClose,
-                                                          .TabsTrayDidSelectHomeTab])
+                                                          .TabsTrayDidSelectHomeTab,
+                                                          .TopTabsTabClosed])
 
         updateData()
     }
@@ -274,7 +275,8 @@ extension JumpBackInDataAdaptorImplementation: Notifiable {
         switch notification.name {
         case .ShowHomepage,
                 .TabsTrayDidClose,
-                .TabsTrayDidSelectHomeTab:
+                .TabsTrayDidSelectHomeTab,
+                .TopTabsTabClosed:
             updateData()
         default: break
         }

--- a/Shared/NotificationConstants.swift
+++ b/Shared/NotificationConstants.swift
@@ -64,6 +64,8 @@ extension Notification.Name {
 
     public static let UpdateLabelOnTabClosed = Notification.Name("UpdateLabelOnTabClosed")
 
+    public static let TopTabsTabClosed = Notification.Name("TopTabsTabClosed")
+
     public static let ShowHomepage = Notification.Name("ShowHomepage")
 
     public static let TabsTrayDidClose = Notification.Name("TabsTrayDidClose")


### PR DESCRIPTION
# FXIOS-4520
Revert some part of https://github.com/mozilla-mobile/firefox-ios/pull/11605 as turns out it's needed for the following case when closing a tab from top tabs on iPad. The homepage needs to refresh otherwise jump back in tab is still there, accessible and when clicked it will crash.

https://user-images.githubusercontent.com/11338480/185236510-38a66edb-d764-4cc7-a8e7-51d48f16323f.mp4


