### PR TITLE
Add #11518 [v105]: Sync timing updated for clients and tabs

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -624,6 +624,7 @@
 		8DCD3BCD1ED5B7FA00446D38 /* FxADeepLinkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DCD3BCC1ED5B7FA00446D38 /* FxADeepLinkingTests.swift */; };
 		9609F4CA26B57CE800F81493 /* Calendar+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609F4C926B57CE800F81493 /* Calendar+Extension.swift */; };
 		9614BF4228A53FDF00D3F7EA /* ContextualHintEligibilityUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9614BF4028A53F7C00D3F7EA /* ContextualHintEligibilityUtilityTests.swift */; };
+		9614BF4428AD1C6700D3F7EA /* AccountSyncHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9614BF4328AD1C6700D3F7EA /* AccountSyncHandler.swift */; };
 		962F394A2672D57A006BDA2A /* RecentItemsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962F39492672D57A006BDA2A /* RecentItemsHelper.swift */; };
 		9636D92827F5D72D00771F5E /* GleanPlumbMessageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9636D92727F5D72D00771F5E /* GleanPlumbMessageManager.swift */; };
 		9636D92A27F767EC00771F5E /* GleanPlumbMessageUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9636D92927F767EC00771F5E /* GleanPlumbMessageUtility.swift */; };
@@ -3220,6 +3221,7 @@
 		95FD4D8DB09F3540CC7651A1 /* fil */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fil; path = fil.lproj/Intro.strings; sourceTree = "<group>"; };
 		9609F4C926B57CE800F81493 /* Calendar+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Calendar+Extension.swift"; sourceTree = "<group>"; };
 		9614BF4028A53F7C00D3F7EA /* ContextualHintEligibilityUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualHintEligibilityUtilityTests.swift; sourceTree = "<group>"; };
+		9614BF4328AD1C6700D3F7EA /* AccountSyncHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSyncHandler.swift; sourceTree = "<group>"; };
 		962A450E9186BF349E535413 /* sat-Olck */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "sat-Olck"; path = "sat-Olck.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		962F39492672D57A006BDA2A /* RecentItemsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentItemsHelper.swift; sourceTree = "<group>"; };
 		9636D92727F5D72D00771F5E /* GleanPlumbMessageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanPlumbMessageManager.swift; sourceTree = "<group>"; };
@@ -5670,6 +5672,7 @@
 				962F39492672D57A006BDA2A /* RecentItemsHelper.swift */,
 				9699F77226F39E5100C5FA47 /* SiteImageHelper.swift */,
 				8A8DDEBE276259A900E7B97A /* RatingPromptManager.swift */,
+				9614BF4328AD1C6700D3F7EA /* AccountSyncHandler.swift */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -10073,6 +10076,7 @@
 				D0C95E0E200FD3B200E4E51C /* PrintHelper.swift in Sources */,
 				EB9854FF2422686F0040F24B /* AppDelegate+PushNotifications.swift in Sources */,
 				DFACBF85277B9B5B003D5F41 /* TopSitesRowCountSettingsController.swift in Sources */,
+				9614BF4428AD1C6700D3F7EA /* AccountSyncHandler.swift in Sources */,
 				E64ED8FA1BC55AE300DAF864 /* UIAlertController+Extension.swift in Sources */,
 				282DA4731A68C1E700A406E2 /* OpenSearch.swift in Sources */,
 				D04CD74B216CF86B004FF5B0 /* DevicePickerViewController.swift in Sources */,

--- a/Client/AccountSyncHandler.swift
+++ b/Client/AccountSyncHandler.swift
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Storage
+
+/// `AccountSyncHandler` exists to observe certain `TabEventLabel` notifications,
+/// and react accordingly.
+class AccountSyncHandler: TabEventHandler, Loggable {
+
+    let throttler = Throttler(seconds: 5.0, on: DispatchQueue.global(qos: .utility))
+    let profile: Profile
+
+    init(with profile: Profile) {
+        self.profile = profile
+
+        register(self, forTabEvents: .didLoadPageMetadata, .didGainFocus)
+    }
+
+    // MARK: - Account Server Sync
+
+    func tab(_ tab: Tab, didLoadPageMetadata metadata: PageMetadata) {
+        performClientsAndTabsSync()
+    }
+
+    func tabDidGainFocus(_ tab: Tab) {
+        performClientsAndTabsSync()
+    }
+
+    /// For Task Continuity, we want tab loads and tab switches to reflect across Synced devices.
+    ///
+    /// To that end, whenever a user's tab finishes loading page metadata or switches to focus on a new tab,
+    /// we trigger a "sync" of tabs. We upload records to the Sync Server from local storage and download
+    /// any records from the Sync server to local storage.
+    ///
+    /// Tabs and clients should stay in sync, so a call to sync tabs will also sync clients.
+    ///
+    /// Make sure there's at least a 5 second difference between Syncs.
+    private func performClientsAndTabsSync() {
+        guard profile.hasSyncableAccount() else { return }
+
+        throttler.throttle { [weak self] in
+            _ = self?.profile.syncManager.syncNamedCollections(why: .user, names: ["tabs"])
+        }
+    }
+
+}

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -176,7 +176,7 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
 
         self.profile = profile
         self.navDelegate = TabManagerNavDelegate()
-        self.tabEventHandlers = TabEventHandlers.create(with: profile.prefs)
+        self.tabEventHandlers = TabEventHandlers.create(with: profile)
 
         self.store = TabManagerStore(imageStore: imageStore, prefs: profile.prefs)
         super.init()

--- a/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
+++ b/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
@@ -224,9 +224,6 @@ class JumpBackInDataAdaptorImplementation: JumpBackInDataAdaptor, FeatureFlaggab
 
         // Get cached tabs
         userInteractiveQueue.async { [weak self] in
-            /// Force an accounts Sync so that we download new records to local storage (also uploads records from local storage to the sync server)
-            _ = self?.profile.syncManager.syncNamedCollections(why: .user, names: ["tabs"])
-
             self?.profile.getCachedClientsAndTabs { [weak self] result in
                 self?.createMostRecentSyncedTab(from: result, completion: completion)
             }

--- a/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
+++ b/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
@@ -224,6 +224,9 @@ class JumpBackInDataAdaptorImplementation: JumpBackInDataAdaptor, FeatureFlaggab
 
         // Get cached tabs
         userInteractiveQueue.async { [weak self] in
+            /// Force an accounts Sync so that we download new records to local storage (also uploads records from local storage to the sync server)
+            _ = self?.profile.syncManager.syncNamedCollections(why: .user, names: ["tabs"])
+
             self?.profile.getCachedClientsAndTabs { [weak self] result in
                 self?.createMostRecentSyncedTab(from: result, completion: completion)
             }

--- a/Client/TabEventHandlers.swift
+++ b/Client/TabEventHandlers.swift
@@ -6,12 +6,18 @@ import Foundation
 import Shared
 
 class TabEventHandlers {
-    static func create(with prefs: Prefs) -> [TabEventHandler] {
+
+    /// Create handlers that observe specified tab events.
+    ///
+    /// For anything that needs to react to tab events notifications (see `TabEventLabel`), the
+    /// pattern is to implement a handler and specify which events to observe.
+    static func create(with profile: Profile) -> [TabEventHandler] {
         let handlers: [TabEventHandler] = [
             FaviconHandler(),
             UserActivityHandler(),
             MetadataParserHelper(),
-            MediaImageLoader(prefs),
+            MediaImageLoader(profile.prefs),
+            AccountSyncHandler(with: profile)
         ]
 
         return handlers


### PR DESCRIPTION
# #11518 | [FXIOS-4709](https://mozilla-hub.atlassian.net/browse/FXIOS-4709)

## Overview
We're updating the triggers for clients and tabs ONLY. Now, in addition to what's there already, we will trigger a sync when a tab finishes loading,  and when a user changes tabs. Syncs are throttled for these two triggers - we want to make sure we give at least 5 seconds between actions that trigger syncs. 

We also sync when JumpBackIn's synced tab needs to appear. We won't wait for that particular sync to complete - it may be better to show stale data than hold UI for a sync call. 