### PR TITLE
Bump [v105] upgrade rust components to 94.1.0

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -15645,7 +15645,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 94.0.0;
+				version = 94.1.0;
 			};
 		};
 		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -85,8 +85,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/rust-components-swift.git",
       "state" : {
-        "revision" : "d86f85a1b1ff42c535424d200775bc8638fdb1bf",
-        "version" : "94.0.0"
+        "revision" : "17030432d50699c43a13ec7770dd93f8348b19c1",
+        "version" : "94.1.0"
       }
     },
     {

--- a/bin/nimbus-fml.sh
+++ b/bin/nimbus-fml.sh
@@ -60,7 +60,7 @@ helptext() {
 MANIFEST_PATH=
 OUTPUT_DIR="${SOURCE_ROOT}/${PROJECT}/Generated"
 NAMESPACE=
-AS_VERSION=v93.7.0
+AS_VERSION=v94.1.0
 AS_DOWNLOAD_URL="https://github.com/mozilla/application-services/releases/download/$AS_VERSION"
 FRESHEN_FML=
 


### PR DESCRIPTION
The upgrade from 94.0.1 to 94.1.0 **only** includes a change to emit some telemetry when nimbus is queried before it is initialized. We are hoping we can include this in 105


cc @travis79 


