### PR TITLE
Add FXIOS-4683 [v105] first run onboarding update

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		1DFE57FB27B2CB870025DE58 /* HighlightItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFE57FA27B2CB870025DE58 /* HighlightItem.swift */; };
 		1DFE57FD27BADD7D0025DE58 /* HomepageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFE57FC27BADD7C0025DE58 /* HomepageViewModel.swift */; };
 		1DFE57FF27BAE3150025DE58 /* HomepageSectionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFE57FE27BAE3150025DE58 /* HomepageSectionType.swift */; };
+		2109478928AFD24C00B73D44 /* OnboardingViewControllerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2109478828AFD24C00B73D44 /* OnboardingViewControllerProtocol.swift */; };
 		21112968289480630082C08B /* HomepageMessageCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21112967289480630082C08B /* HomepageMessageCardViewModel.swift */; };
 		211F00AC27F4D918001D9189 /* HistoryPanel+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211F00AB27F4D918001D9189 /* HistoryPanel+Search.swift */; };
 		21371FA228A6C4A200BC3F37 /* OnboardingCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21371FA128A6C4A200BC3F37 /* OnboardingCardViewModelTests.swift */; };
@@ -1959,6 +1960,7 @@
 		20C24CE7AEFE559B0B06390C /* nn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nn; path = nn.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		20C6401CAC4ACAA189D446BC /* sq */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sq; path = sq.lproj/Today.strings; sourceTree = "<group>"; };
 		20F2414BA51A5BFAF5098D35 /* bs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bs; path = bs.lproj/Menu.strings; sourceTree = "<group>"; };
+		2109478828AFD24C00B73D44 /* OnboardingViewControllerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewControllerProtocol.swift; sourceTree = "<group>"; };
 		21112967289480630082C08B /* HomepageMessageCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageMessageCardViewModel.swift; sourceTree = "<group>"; };
 		211F00AB27F4D918001D9189 /* HistoryPanel+Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HistoryPanel+Search.swift"; sourceTree = "<group>"; };
 		21371FA128A6C4A200BC3F37 /* OnboardingCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCardViewModelTests.swift; sourceTree = "<group>"; };
@@ -7236,6 +7238,7 @@
 				21B2844928464FF0003EA521 /* OnboardingCardViewModel.swift */,
 				21A7C44F28353D0E0071D996 /* OnboardingCardViewController.swift */,
 				215A5F9E283D38B800FF4053 /* WallpapersCardViewController.swift */,
+				2109478828AFD24C00B73D44 /* OnboardingViewControllerProtocol.swift */,
 			);
 			path = Intro;
 			sourceTree = "<group>";
@@ -9951,6 +9954,7 @@
 				8AD40FD527BB1C1000672675 /* LockButton.swift in Sources */,
 				5F130D2E2483508E00B0F7D0 /* FxAWebViewModel.swift in Sources */,
 				E571EE772875694C0051D9AA /* MockPocketSponsoredStoriesProvider.swift in Sources */,
+				2109478928AFD24C00B73D44 /* OnboardingViewControllerProtocol.swift in Sources */,
 				D0FCF7F51FE45842004A7995 /* UserScriptManager.swift in Sources */,
 				8AB8573027D94CAD0075C173 /* HomepageViewModelProtocol.swift in Sources */,
 				E1877A832875DEDE00F5BDF2 /* SyncedTabCell.swift in Sources */,

--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -122,6 +122,7 @@ public struct AccessibilityIdentifiers {
     }
 
     struct Onboarding {
+        static let backgroundImage = "Onboarding.BackgroundImage"
         static let welcomeCard = "WelcomeCard"
         static let wallpapersCard = "WallpapersCard"
         static let signSyncCard = "SignSyncCard"

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2240,9 +2240,9 @@ extension BrowserViewController {
     private func showProperIntroVC() {
         let introViewModel = IntroViewModel()
         let introViewController = IntroViewController(viewModel: introViewModel, profile: profile)
-        introViewController.didFinishClosure = { controller, _ in
+        introViewController.didFinishClosure = {
             self.profile.prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
-            controller.dismiss(animated: true)
+            introViewController.dismiss(animated: true)
         }
         self.introVCPresentHelper(introViewController: introViewController)
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2224,7 +2224,7 @@ extension BrowserViewController {
 
     private func buildUpdateVC(viewModel: UpdateViewModel, animated: Bool = true) {
         let updateViewController = UpdateViewController(viewModel: viewModel)
-        updateViewController.didFinishClosure = {
+        updateViewController.didFinishFlow = {
             updateViewController.dismiss(animated: true)
         }
 
@@ -2246,7 +2246,7 @@ extension BrowserViewController {
     private func showProperIntroVC() {
         let introViewModel = IntroViewModel()
         let introViewController = IntroViewController(viewModel: introViewModel, profile: profile)
-        introViewController.didFinishClosure = {
+        introViewController.didFinishFlow = {
             self.profile.prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
             introViewController.dismiss(animated: true)
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2216,24 +2216,30 @@ extension BrowserViewController {
     func presentUpdateViewController(_ force: Bool = false, animated: Bool = true) {
         let viewModel = UpdateViewModel(profile: profile)
         if viewModel.shouldShowUpdateSheet(force: force) {
-            let updateViewController = UpdateViewController(viewModel: viewModel)
-            updateViewController.didFinishClosure = {
-                updateViewController.dismiss(animated: true)
+            viewModel.hasSyncableAccount {
+                self.buildUpdateVC(viewModel: viewModel, animated: animated)
             }
+        }
+    }
 
-            if topTabsVisible {
-                updateViewController.preferredContentSize = CGSize(
-                    width: ViewControllerConsts.PreferredSize.UpdateViewController.width,
-                    height: ViewControllerConsts.PreferredSize.UpdateViewController.height)
-                updateViewController.modalPresentationStyle = .formSheet
-            } else {
-                updateViewController.modalPresentationStyle = .fullScreen
-            }
+    private func buildUpdateVC(viewModel: UpdateViewModel, animated: Bool = true) {
+        let updateViewController = UpdateViewController(viewModel: viewModel)
+        updateViewController.didFinishClosure = {
+            updateViewController.dismiss(animated: true)
+        }
 
-            // On iPad we present it modally in a controller
-            present(updateViewController, animated: animated) {
-                self.setupHomepageOnBackground()
-            }
+        if topTabsVisible {
+            updateViewController.preferredContentSize = CGSize(
+                width: ViewControllerConsts.PreferredSize.UpdateViewController.width,
+                height: ViewControllerConsts.PreferredSize.UpdateViewController.height)
+            updateViewController.modalPresentationStyle = .formSheet
+        } else {
+            updateViewController.modalPresentationStyle = .fullScreen
+        }
+
+        // On iPad we present it modally in a controller
+        present(updateViewController, animated: animated) {
+            self.setupHomepageOnBackground()
         }
     }
 

--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -243,3 +243,11 @@ extension IntroViewController {
         return .portrait
     }
 }
+
+// MARK: - NotificationThemeable
+extension IntroViewController: NotificationThemeable {
+    func applyTheme() {
+        pageControl.currentPageIndicatorTintColor = UIColor.theme.homePanel.activityStreamHeaderButton
+        // TODO: Update background color
+    }
+}

--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -12,7 +12,7 @@ class IntroViewController: UIViewController, OnboardingViewControllerProtocol {
     private let profile: Profile
     private var onboardingCards = [OnboardingCardViewController]()
     var notificationCenter: NotificationProtocol = NotificationCenter.default
-    var didFinishClosure: (() -> Void)?
+    var didFinishFlow: (() -> Void)?
 
     struct UX {
         static let closeButtonSize: CGFloat = 44
@@ -120,7 +120,7 @@ class IntroViewController: UIViewController, OnboardingViewControllerProtocol {
             closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonSize),
         ])
 
-        if viewModel.isMROnboardingVersion {
+        if viewModel.isv106Version {
             view.addSubviews(backgroundImageView)
             view.sendSubviewToBack(backgroundImageView)
 
@@ -133,7 +133,7 @@ class IntroViewController: UIViewController, OnboardingViewControllerProtocol {
     }
 
     @objc private func closeOnboarding() {
-        didFinishClosure?()
+        didFinishFlow?()
         viewModel.sendCloseButtonTelemetry(index: pageControl.currentPage)
     }
 
@@ -191,7 +191,7 @@ extension IntroViewController: UIPageViewControllerDataSource, UIPageViewControl
 extension IntroViewController: OnboardingCardDelegate {
     func showNextPage(_ cardType: IntroViewModel.InformationCards) {
         guard cardType != viewModel.enabledCards.last else {
-            self.didFinishClosure?()
+            self.didFinishFlow?()
             return
         }
 

--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -19,6 +19,11 @@ class IntroViewController: UIViewController {
     }
 
     // MARK: - Var related to onboarding
+    private lazy var backgroundImageView: UIImageView = .build { imageView in
+        imageView.image = UIImage(named: ImageIdentifiers.upgradeBackground)
+        imageView.accessibilityIdentifier = AccessibilityIdentifiers.Onboarding.backgroundImage
+    }
+
     private lazy var closeButton: UIButton = .build { button in
         let closeImage = UIImage(named: ImageIdentifiers.closeLargeButton)
         button.setImage(closeImage, for: .normal)
@@ -91,6 +96,7 @@ class IntroViewController: UIViewController {
     }
 
     private func setupLayout() {
+        view.addSubviews(backgroundImageView)
         addChild(pageController)
         view.addSubview(pageController.view)
         pageController.didMove(toParent: self)
@@ -105,7 +111,11 @@ class IntroViewController: UIViewController {
             closeButton.topAnchor.constraint(equalTo: view.topAnchor, constant: UX.closeButtonPadding),
             closeButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -UX.closeButtonPadding),
             closeButton.widthAnchor.constraint(equalToConstant: UX.closeButtonSize),
-            closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonSize)
+            closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonSize),
+
+            backgroundImageView.topAnchor.constraint(equalTo: view.topAnchor),
+            backgroundImageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            backgroundImageView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
     }
 

--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -232,11 +232,15 @@ extension IntroViewController: OnboardingCardDelegate {
                                          action: #selector(dismissSignInViewController))
         singInSyncVC.navigationItem.rightBarButtonItem = buttonItem
         controller = DismissableNavigationViewController(rootViewController: singInSyncVC)
+        controller.onViewDismissed = {
+            self.closeOnboarding()
+        }
         self.present(controller, animated: true)
     }
 
     @objc func dismissSignInViewController() {
         dismiss(animated: true, completion: nil)
+        closeOnboarding()
     }
 }
 

--- a/Client/Frontend/Intro/IntroViewModel.swift
+++ b/Client/Frontend/Intro/IntroViewModel.swift
@@ -44,7 +44,7 @@ struct IntroViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
         }
     }
 
-    var enabledCards: [InformationCards] {
+    var enabledCards: [IntroViewModel.InformationCards] {
         guard let wallpaperVersion: WallpaperVersion = featureFlags.getCustomState(for: .wallpaperVersion) else {
             return [.welcome, .wallpapers, .signSync]
         }

--- a/Client/Frontend/Intro/IntroViewModel.swift
+++ b/Client/Frontend/Intro/IntroViewModel.swift
@@ -44,16 +44,16 @@ struct IntroViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
         }
     }
 
-    var isMROnboardingVersion: Bool {
+    var isv106Version: Bool {
         return featureFlags.isFeatureEnabled(.upgradeOnboarding, checking: .buildOnly)
     }
 
     var enabledCards: [IntroViewModel.InformationCards] {
-        return isMROnboardingVersion ? [ .welcome, .signSync] : [.welcome, .wallpapers, .signSync]
+        return isv106Version ? [ .welcome, .signSync] : [.welcome, .wallpapers, .signSync]
     }
 
     func getInfoModel(cardType: IntroViewModel.InformationCards) -> OnboardingModelProtocol? {
-        switch (cardType, isMROnboardingVersion) {
+        switch (cardType, isv106Version) {
         case (.welcome, false):
             return OnboardingInfoModel(image: UIImage(named: ImageIdentifiers.onboardingWelcome),
                                        title: .CardTitleWelcome,
@@ -99,7 +99,7 @@ struct IntroViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
 
         return OnboardingCardViewModel(cardType: cardType,
                                        infoModel: infoModel,
-                                       isMROnboardingVersion: isMROnboardingVersion)
+                                       isv106Version: isv106Version)
     }
 
     func sendCloseButtonTelemetry(index: Int) {

--- a/Client/Frontend/Intro/IntroViewModel.swift
+++ b/Client/Frontend/Intro/IntroViewModel.swift
@@ -44,36 +44,50 @@ struct IntroViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
         }
     }
 
-    var enabledCards: [IntroViewModel.InformationCards] {
-        guard let wallpaperVersion: WallpaperVersion = featureFlags.getCustomState(for: .wallpaperVersion) else {
-            return [.welcome, .wallpapers, .signSync]
-        }
+    var isMROnboardingVersion: Bool {
+        return featureFlags.isFeatureEnabled(.upgradeOnboarding, checking: .buildOnly)
+    }
 
-        return wallpaperVersion == .v2 ? [ .welcome, .signSync] : [.welcome, .wallpapers, .signSync]
+    var enabledCards: [IntroViewModel.InformationCards] {
+        return isMROnboardingVersion ? [ .welcome, .signSync] : [.welcome, .wallpapers, .signSync]
     }
 
     func getInfoModel(cardType: IntroViewModel.InformationCards) -> OnboardingModelProtocol? {
-        switch cardType {
-        case .welcome:
+        switch (cardType, isMROnboardingVersion) {
+        case (.welcome, false):
             return OnboardingInfoModel(image: UIImage(named: ImageIdentifiers.onboardingWelcome),
                                        title: .CardTitleWelcome,
                                        description: .Onboarding.IntroDescriptionPart2,
                                        primaryAction: .Onboarding.IntroAction,
                                        secondaryAction: nil,
                                        a11yIdRoot: AccessibilityIdentifiers.Onboarding.welcomeCard)
-        case .wallpapers:
+        case (.welcome, true):
+            return OnboardingInfoModel(image: UIImage(named: ImageIdentifiers.onboardingWelcome),
+                                       title: .Onboarding.IntroWelcomeTitle,
+                                       description: .Onboarding.IntroWelcomeDescription,
+                                       primaryAction: .Onboarding.IntroAction,
+                                       secondaryAction: nil,
+                                       a11yIdRoot: AccessibilityIdentifiers.Onboarding.welcomeCard)
+        case (.wallpapers, _):
             return OnboardingInfoModel(image: nil,
                                        title: .Onboarding.WallpaperTitle,
                                        description: nil,
                                        primaryAction: .Onboarding.WallpaperAction,
                                        secondaryAction: .Onboarding.LaterAction,
                                        a11yIdRoot: AccessibilityIdentifiers.Onboarding.wallpapersCard)
-        case .signSync:
+        case (.signSync, false):
             return OnboardingInfoModel(image: UIImage(named: ImageIdentifiers.onboardingSync),
                                        title: .Onboarding.SyncTitle,
                                        description: .Onboarding.SyncDescription,
                                        primaryAction: .Onboarding.SyncAction,
                                        secondaryAction: .WhatsNew.RecentButtonTitle,
+                                       a11yIdRoot: AccessibilityIdentifiers.Onboarding.signSyncCard)
+        case (.signSync, true):
+            return OnboardingInfoModel(image: UIImage(named: ImageIdentifiers.onboardingSync),
+                                       title: .Onboarding.IntroSyncTitle,
+                                       description: .Onboarding.IntroSyncDescription,
+                                       primaryAction: .IntroSignInButtonTitle,
+                                       secondaryAction: .Onboarding.IntroSyncSkipAction,
                                        a11yIdRoot: AccessibilityIdentifiers.Onboarding.signSyncCard)
         default:
             return nil
@@ -83,7 +97,9 @@ struct IntroViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
     func getCardViewModel(cardType: InformationCards) -> OnboardingCardProtocol? {
         guard let infoModel = getInfoModel(cardType: cardType) else { return nil }
 
-        return OnboardingCardViewModel(cardType: cardType, infoModel: infoModel)
+        return OnboardingCardViewModel(cardType: cardType,
+                                       infoModel: infoModel,
+                                       isMROnboardingVersion: isMROnboardingVersion)
     }
 
     func sendCloseButtonTelemetry(index: Int) {

--- a/Client/Frontend/Intro/IntroViewModel.swift
+++ b/Client/Frontend/Intro/IntroViewModel.swift
@@ -83,7 +83,7 @@ struct IntroViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
                                        secondaryAction: .WhatsNew.RecentButtonTitle,
                                        a11yIdRoot: AccessibilityIdentifiers.Onboarding.signSyncCard)
         case (.signSync, true):
-            return OnboardingInfoModel(image: UIImage(named: ImageIdentifiers.onboardingSync),
+            return OnboardingInfoModel(image: nil,
                                        title: .Onboarding.IntroSyncTitle,
                                        description: .Onboarding.IntroSyncDescription,
                                        primaryAction: .IntroSignInButtonTitle,

--- a/Client/Frontend/Intro/OnboardingCardViewController.swift
+++ b/Client/Frontend/Intro/OnboardingCardViewController.swift
@@ -24,7 +24,7 @@ class OnboardingCardViewController: UIViewController {
         static let titleFontSize: CGFloat = 34
         static let descriptionBoldFontSize: CGFloat = 20
         static let descriptionFontSize: CGFloat = 17
-        static let imageViewMaxHeight: CGFloat = 160
+        static let imageViewSize: CGFloat = 109
 
         // small device
         static let smallStackViewSpacing: CGFloat = 8
@@ -159,6 +159,7 @@ class OnboardingCardViewController: UIViewController {
 
         setupView()
         updateLayout()
+        applyTheme()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -221,7 +222,7 @@ class OnboardingCardViewController: UIViewController {
             buttonStackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -UX.stackViewPadding),
             buttonStackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -UX.stackViewPadding),
 
-            imageView.heightAnchor.constraint(equalToConstant: UX.imageViewMaxHeight)
+            imageView.heightAnchor.constraint(equalToConstant: UX.imageViewSize)
         ])
 
         contentStackView.spacing = shouldUseSmallDeviceLayout ? UX.smallStackViewSpacing : UX.stackViewSpacing
@@ -253,10 +254,11 @@ class OnboardingCardViewController: UIViewController {
     }
 
     private func applyTheme() {
-        view.backgroundColor = UIColor.theme.homePanel.panelBackground
+        view.backgroundColor = .clear
         titleLabel.textColor = UIColor.theme.homeTabBanner.textColor
         descriptionLabel.textColor = UIColor.theme.homeTabBanner.textColor
         descriptionBoldLabel.textColor = UIColor.theme.homeTabBanner.textColor
+        primaryButton.backgroundColor = UIColor.theme.homePanel.activityStreamHeaderButton
     }
 
     @objc func primaryAction() {

--- a/Client/Frontend/Intro/OnboardingCardViewController.swift
+++ b/Client/Frontend/Intro/OnboardingCardViewController.swift
@@ -58,7 +58,7 @@ class OnboardingCardViewController: UIViewController {
         stack.axis = .vertical
     }
 
-    private lazy var imageView: UIImageView = .build { imageView in
+    lazy var imageView: UIImageView = .build { imageView in
         imageView.contentMode = .scaleAspectFit
         imageView.accessibilityIdentifier = "\(self.viewModel.infoModel.a11yIdRoot)ImageView"
     }
@@ -221,7 +221,7 @@ class OnboardingCardViewController: UIViewController {
             buttonStackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -UX.stackViewPadding),
             buttonStackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -UX.stackViewPadding),
 
-            imageView.heightAnchor.constraint(lessThanOrEqualToConstant: UX.imageViewMaxHeight).priority(.defaultLow)
+            imageView.heightAnchor.constraint(equalToConstant: UX.imageViewMaxHeight)
         ])
 
         contentStackView.spacing = shouldUseSmallDeviceLayout ? UX.smallStackViewSpacing : UX.stackViewSpacing
@@ -234,11 +234,22 @@ class OnboardingCardViewController: UIViewController {
         descriptionBoldLabel.text = .Onboarding.IntroDescriptionPart1
         descriptionLabel.isHidden = viewModel.infoModel.description?.isEmpty ?? true
         descriptionLabel.text = viewModel.infoModel.description
-        secondaryButton.isHidden = viewModel.infoModel.secondaryAction?.isEmpty ?? true
 
         imageView.image = viewModel.infoModel.image
         primaryButton.setTitle(viewModel.infoModel.primaryAction, for: .normal)
-        secondaryButton.setTitle(viewModel.infoModel.secondaryAction, for: .normal)
+        handleSecondaryButton()
+    }
+
+    private func handleSecondaryButton() {
+        // To keep Title, Description aligned between cards we don't hide the button
+        // we clear the background and make disabled
+        guard let buttonTitle = viewModel.infoModel.secondaryAction else {
+            secondaryButton.isUserInteractionEnabled = false
+            secondaryButton.backgroundColor = .clear
+            return
+        }
+
+        secondaryButton.setTitle(buttonTitle, for: .normal)
     }
 
     private func applyTheme() {

--- a/Client/Frontend/Intro/OnboardingCardViewController.swift
+++ b/Client/Frontend/Intro/OnboardingCardViewController.swift
@@ -144,16 +144,6 @@ class OnboardingCardViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection), LegacyThemeManager.instance.systemThemeIsOn {
-            let userInterfaceStyle = traitCollection.userInterfaceStyle
-            LegacyThemeManager.instance.current = userInterfaceStyle == .dark ? DarkTheme() : NormalTheme()
-            applyTheme()
-        }
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -170,6 +160,8 @@ class OnboardingCardViewController: UIViewController {
     }
 
     func setupView() {
+        view.backgroundColor = .clear
+
         contentStackView.addArrangedSubview(imageView)
         contentStackView.addArrangedSubview(titleLabel)
         contentStackView.addArrangedSubview(descriptionBoldLabel)
@@ -253,12 +245,22 @@ class OnboardingCardViewController: UIViewController {
         secondaryButton.setTitle(buttonTitle, for: .normal)
     }
 
-    private func applyTheme() {
-        view.backgroundColor = .clear
-        titleLabel.textColor = UIColor.theme.homeTabBanner.textColor
-        descriptionLabel.textColor = UIColor.theme.homeTabBanner.textColor
-        descriptionBoldLabel.textColor = UIColor.theme.homeTabBanner.textColor
-        primaryButton.backgroundColor = UIColor.theme.homePanel.activityStreamHeaderButton
+    func applyTheme() {
+        let theme = BuiltinThemeName(rawValue: LegacyThemeManager.instance.current.name) ?? .normal
+
+        if theme == .dark {
+            titleLabel.textColor = .white
+            descriptionLabel.textColor  = .white
+            descriptionBoldLabel.textColor = .white
+            primaryButton.setTitleColor(.black, for: .normal)
+            primaryButton.backgroundColor = UIColor.theme.homePanel.activityStreamHeaderButton
+        } else {
+            titleLabel.textColor = .black
+            descriptionLabel.textColor = .black
+            descriptionBoldLabel.textColor = .black
+            primaryButton.setTitleColor(UIColor.Photon.LightGrey05, for: .normal)
+            primaryButton.backgroundColor = UIColor.Photon.Blue50
+        }
     }
 
     @objc func primaryAction() {

--- a/Client/Frontend/Intro/OnboardingCardViewController.swift
+++ b/Client/Frontend/Intro/OnboardingCardViewController.swift
@@ -230,7 +230,7 @@ class OnboardingCardViewController: UIViewController {
 
     private func updateLayout() {
         titleLabel.text = viewModel.infoModel.title
-        descriptionBoldLabel.isHidden = viewModel.cardType != .welcome
+        descriptionBoldLabel.isHidden = !viewModel.shouldShowDescriptionBold
         descriptionBoldLabel.text = .Onboarding.IntroDescriptionPart1
         descriptionLabel.isHidden = viewModel.infoModel.description?.isEmpty ?? true
         descriptionLabel.text = viewModel.infoModel.description

--- a/Client/Frontend/Intro/OnboardingCardViewModel.swift
+++ b/Client/Frontend/Intro/OnboardingCardViewModel.swift
@@ -20,11 +20,11 @@ struct OnboardingCardViewModel: OnboardingCardProtocol {
 
     init(cardType: IntroViewModel.InformationCards,
          infoModel: OnboardingModelProtocol,
-         isMROnboardingVersion: Bool) {
+         isv106Version: Bool) {
 
         self.cardType = cardType
         self.infoModel = infoModel
-        self.shouldShowDescriptionBold = cardType == .welcome && !isMROnboardingVersion
+        self.shouldShowDescriptionBold = cardType == .welcome && !isv106Version
     }
 
     func sendCardViewTelemetry() {

--- a/Client/Frontend/Intro/OnboardingCardViewModel.swift
+++ b/Client/Frontend/Intro/OnboardingCardViewModel.swift
@@ -6,7 +6,8 @@ import Foundation
 
 protocol OnboardingCardProtocol {
     var cardType: IntroViewModel.InformationCards { get set }
-    var infoModel: OnboardingModelProtocol { get set }
+    var infoModel: OnboardingModelProtocol { get }
+    var shouldShowDescriptionBold: Bool { get }
 
     func sendCardViewTelemetry()
     func sendTelemetryButton(isPrimaryAction: Bool)
@@ -15,12 +16,15 @@ protocol OnboardingCardProtocol {
 struct OnboardingCardViewModel: OnboardingCardProtocol {
     var cardType: IntroViewModel.InformationCards
     var infoModel: OnboardingModelProtocol
+    var shouldShowDescriptionBold: Bool
 
     init(cardType: IntroViewModel.InformationCards,
-         infoModel: OnboardingModelProtocol) {
+         infoModel: OnboardingModelProtocol,
+         isMROnboardingVersion: Bool) {
 
         self.cardType = cardType
         self.infoModel = infoModel
+        self.shouldShowDescriptionBold = cardType == .welcome && !isMROnboardingVersion
     }
 
     func sendCardViewTelemetry() {

--- a/Client/Frontend/Intro/OnboardingViewControllerProtocol.swift
+++ b/Client/Frontend/Intro/OnboardingViewControllerProtocol.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Shared
+
+protocol OnboardingViewControllerProtocol {
+    var didFinishClosure: (() -> Void)? { get }
+
+    func getNextOnboardingCard(index: Int, goForward: Bool) -> OnboardingCardViewController?
+    func moveToNextPage(cardType: IntroViewModel.InformationCards)
+    func getCardIndex(viewController: OnboardingCardViewController) -> Int?
+    func showNextPage(_ cardType: IntroViewModel.InformationCards)
+}
+

--- a/Client/Frontend/Intro/OnboardingViewControllerProtocol.swift
+++ b/Client/Frontend/Intro/OnboardingViewControllerProtocol.swift
@@ -13,4 +13,3 @@ protocol OnboardingViewControllerProtocol {
     func getCardIndex(viewController: OnboardingCardViewController) -> Int?
     func showNextPage(_ cardType: IntroViewModel.InformationCards)
 }
-

--- a/Client/Frontend/Intro/OnboardingViewControllerProtocol.swift
+++ b/Client/Frontend/Intro/OnboardingViewControllerProtocol.swift
@@ -6,7 +6,7 @@ import Foundation
 import Shared
 
 protocol OnboardingViewControllerProtocol {
-    var didFinishClosure: (() -> Void)? { get }
+    var didFinishFlow: (() -> Void)? { get }
 
     func getNextOnboardingCard(index: Int, goForward: Bool) -> OnboardingCardViewController?
     func moveToNextPage(cardType: IntroViewModel.InformationCards)

--- a/Client/Frontend/Intro/WallpapersCardViewController.swift
+++ b/Client/Frontend/Intro/WallpapersCardViewController.swift
@@ -95,6 +95,7 @@ class WallpaperCardViewController: OnboardingCardViewController {
         ])
         view.sendSubviewToBack(wallpaperImageView)
         collectionView.reloadData()
+        imageView.isHidden = true
     }
 
     override func primaryAction() {

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -725,6 +725,31 @@ extension String {
             value: "Sign Up and Log In",
             comment: "Describes an action on the sync onboarding page in our Onboarding screens. This string will be on a button so user can sign up or login directly in the onboarding.",
             lastUpdated: .v102)
+        public static let IntroWelcomeTitle = MZLocalizedString(
+            "Onboarding.Welcome.Title.v106",
+            value: "Welcome to an independent internet",
+            comment: "String used to describes the title of what Firefox is on the welcome onboarding page for 106 version in our Onboarding screens.",
+            lastUpdated: .v106)
+        public static let IntroWelcomeDescription = MZLocalizedString(
+            "Onboarding.Welcome.Description.v106",
+            value: "Firefox puts people over profits and defends your privacy by default.",
+            comment: "String used to describes the description of what Firefox is on the welcome onboarding page for 106 version in our Onboarding screens.",
+            lastUpdated: .v106)
+        public static let IntroSyncTitle = MZLocalizedString(
+            "Onboarding.Sync.Title.v106",
+            value: "Hop from phone to laptop and back",
+            comment: "String used to describes the title of what Firefox is on the Sync onboarding page for 106 version in our Onboarding screens.",
+            lastUpdated: .v106)
+        public static let IntroSyncDescription = MZLocalizedString(
+            "Onboarding.Sync.Description.v106",
+            value: "Grab tabs and passwords from your other devices to pick up where you left off.",
+            comment: "String used to describes the description of what Firefox is on the Sync onboarding page for 106 version in our Onboarding screens.",
+            lastUpdated: .v106)
+        public static let IntroSyncSkipAction = MZLocalizedString(
+            "Onboarding.Sync.Skip.Action.v106",
+            value: "Skip",
+            comment: "String used to describes the option to skip the Sync sign in during onboarding for 106 version in Firefox Onboarding screens.",
+            lastUpdated: .v106)
         public static let WallpaperSelectorTitle = MZLocalizedString(
             "Onboarding.Wallpaper.Title.v106",
             value: "Try a splash of color",

--- a/Client/Frontend/Update/OnboardingViewModel.swift
+++ b/Client/Frontend/Update/OnboardingViewModel.swift
@@ -6,6 +6,7 @@ import Foundation
 
 protocol OnboardingViewModelProtocol {
     var enabledCards: [IntroViewModel.InformationCards] { get }
+    var isMROnboardingVersion: Bool { get }
 
     func getCardViewModel(cardType: IntroViewModel.InformationCards) -> OnboardingCardProtocol?
     func getInfoModel(cardType: IntroViewModel.InformationCards) -> OnboardingModelProtocol?
@@ -28,6 +29,7 @@ extension OnboardingViewModelProtocol {
         guard let infoModel = getInfoModel(cardType: cardType) else { return nil }
 
         return OnboardingCardViewModel(cardType: cardType,
-                                       infoModel: infoModel)
+                                       infoModel: infoModel,
+                                       isMROnboardingVersion: isMROnboardingVersion)
     }
 }

--- a/Client/Frontend/Update/OnboardingViewModel.swift
+++ b/Client/Frontend/Update/OnboardingViewModel.swift
@@ -6,7 +6,7 @@ import Foundation
 
 protocol OnboardingViewModelProtocol {
     var enabledCards: [IntroViewModel.InformationCards] { get }
-    var isMROnboardingVersion: Bool { get }
+    var isv106Version: Bool { get }
 
     func getCardViewModel(cardType: IntroViewModel.InformationCards) -> OnboardingCardProtocol?
     func getInfoModel(cardType: IntroViewModel.InformationCards) -> OnboardingModelProtocol?
@@ -30,6 +30,6 @@ extension OnboardingViewModelProtocol {
 
         return OnboardingCardViewModel(cardType: cardType,
                                        infoModel: infoModel,
-                                       isMROnboardingVersion: isMROnboardingVersion)
+                                       isv106Version: isv106Version)
     }
 }

--- a/Client/Frontend/Update/UpdateViewController.swift
+++ b/Client/Frontend/Update/UpdateViewController.swift
@@ -279,3 +279,12 @@ extension UpdateViewController {
         return .portrait
     }
 }
+
+// MARK: - NotificationThemeable
+extension UpdateViewController: NotificationThemeable {
+    func applyTheme() {
+        // TODO: Update background color
+        // TODO: Check if pageControl exist fist
+        pageControl.currentPageIndicatorTintColor = UIColor.theme.homePanel.activityStreamHeaderButton
+    }
+}

--- a/Client/Frontend/Update/UpdateViewController.swift
+++ b/Client/Frontend/Update/UpdateViewController.swift
@@ -33,7 +33,7 @@ class UpdateViewController: UIViewController, OnboardingViewControllerProtocol {
         let closeImage = UIImage(named: ImageIdentifiers.upgradeCloseButton)
         button.setImage(closeImage, for: .normal)
         button.tintColor = .secondaryLabel
-        button.addTarget(self, action: #selector(self.dismissUpdate), for: .touchUpInside)
+        button.addTarget(self, action: #selector(self.closeUpdate), for: .touchUpInside)
         button.accessibilityIdentifier = AccessibilityIdentifiers.Upgrade.closeButton
     }
 
@@ -71,7 +71,7 @@ class UpdateViewController: UIViewController, OnboardingViewControllerProtocol {
 
         setupView()
         setupNotifications(forObserver: self,
-                                   observing: [.DisplayThemeChanged])
+                           observing: [.DisplayThemeChanged])
         applyTheme()
     }
 
@@ -95,6 +95,7 @@ class UpdateViewController: UIViewController, OnboardingViewControllerProtocol {
         addChild(cardViewController)
         view.addSubview(cardViewController.view)
         cardViewController.didMove(toParent: self)
+        view.bringSubviewToFront(closeButton)
 
         NSLayoutConstraint.activate([
             closeButton.topAnchor.constraint(equalTo: view.topAnchor, constant: UX.closeButtonTopPadding),
@@ -153,7 +154,7 @@ class UpdateViewController: UIViewController, OnboardingViewControllerProtocol {
     }
 
     // Button Actions
-    @objc private func dismissUpdate() {
+    @objc private func closeUpdate() {
         didFinishFlow?()
         viewModel.sendCloseButtonTelemetry(index: pageControl.currentPage)
     }
@@ -199,11 +200,15 @@ class UpdateViewController: UIViewController, OnboardingViewControllerProtocol {
                                          action: #selector(dismissSignInViewController))
         singInSyncVC.navigationItem.rightBarButtonItem = buttonItem
         controller = DismissableNavigationViewController(rootViewController: singInSyncVC)
+        controller.onViewDismissed = {
+            self.closeUpdate()
+        }
         self.present(controller, animated: true)
     }
 
     @objc func dismissSignInViewController() {
-        self.dismiss(animated: true, completion: nil)
+        dismiss(animated: true, completion: nil)
+        closeUpdate()
     }
 }
 

--- a/Client/Frontend/Update/UpdateViewController.swift
+++ b/Client/Frontend/Update/UpdateViewController.swift
@@ -37,7 +37,7 @@ class UpdateViewController: UIViewController, OnboardingViewControllerProtocol {
         imageView.accessibilityIdentifier = AccessibilityIdentifiers.Upgrade.backgroundImage
     }
 
-    internal lazy var closeButton: UIButton = .build { button in
+    private lazy var closeButton: UIButton = .build { button in
         let closeImage = UIImage(named: ImageIdentifiers.upgradeCloseButton)
         button.setImage(closeImage, for: .normal)
         button.tintColor = .secondaryLabel
@@ -103,7 +103,7 @@ class UpdateViewController: UIViewController, OnboardingViewControllerProtocol {
             closeButton.widthAnchor.constraint(equalToConstant: UX.closeButtonSize),
             closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonSize),
 
-            backgroundImageView.topAnchor.constraint(equalTo: view.topAnchor, constant: UX.closeButtonTopPadding),
+            backgroundImageView.topAnchor.constraint(equalTo: view.topAnchor),
             backgroundImageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             backgroundImageView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])

--- a/Client/Frontend/Update/UpdateViewController.swift
+++ b/Client/Frontend/Update/UpdateViewController.swift
@@ -6,15 +6,6 @@ import Foundation
 import UIKit
 import Shared
 
-protocol OnboardingViewControllerProtocol {
-    var didFinishClosure: (() -> Void)? { get }
-
-    func getNextOnboardingCard(index: Int, goForward: Bool) -> OnboardingCardViewController?
-    func moveToNextPage(cardType: IntroViewModel.InformationCards)
-    func getCardIndex(viewController: OnboardingCardViewController) -> Int?
-    func showNextPage(_ cardType: IntroViewModel.InformationCards)
-}
-
 class UpdateViewController: UIViewController, OnboardingViewControllerProtocol {
 
     // Update view UX constants
@@ -288,7 +279,7 @@ extension UpdateViewController {
     }
 }
 
-// MARK: - NotificationThemeable
+// MARK: - NotificationThemeable and Notifiable
 extension UpdateViewController: NotificationThemeable, Notifiable {
 
     func handleNotifications(_ notification: Notification) {

--- a/Client/Frontend/Update/UpdateViewController.swift
+++ b/Client/Frontend/Update/UpdateViewController.swift
@@ -19,7 +19,7 @@ class UpdateViewController: UIViewController, OnboardingViewControllerProtocol {
 
     // Public constants 
     var viewModel: UpdateViewModel
-    var didFinishClosure: (() -> Void)?
+    var didFinishFlow: (() -> Void)?
     private var informationCards = [OnboardingCardViewController]()
     var notificationCenter: NotificationProtocol = NotificationCenter.default
 
@@ -154,7 +154,7 @@ class UpdateViewController: UIViewController, OnboardingViewControllerProtocol {
 
     // Button Actions
     @objc private func dismissUpdate() {
-        didFinishClosure?()
+        didFinishFlow?()
         viewModel.sendCloseButtonTelemetry(index: pageControl.currentPage)
     }
 
@@ -234,7 +234,7 @@ extension UpdateViewController: UIPageViewControllerDataSource, UIPageViewContro
 extension UpdateViewController: OnboardingCardDelegate {
     func showNextPage(_ cardType: IntroViewModel.InformationCards) {
         guard cardType != viewModel.enabledCards.last else {
-            self.didFinishClosure?()
+            self.didFinishFlow?()
             return
         }
 

--- a/Client/Frontend/Update/UpdateViewModel.swift
+++ b/Client/Frontend/Update/UpdateViewModel.swift
@@ -15,7 +15,7 @@ class UpdateViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
         return enabledCards.count == 1
     }
 
-    var isMROnboardingVersion: Bool {
+    var isv106Version: Bool {
         return true
     }
 

--- a/Client/Frontend/Update/UpdateViewModel.swift
+++ b/Client/Frontend/Update/UpdateViewModel.swift
@@ -60,6 +60,8 @@ class UpdateViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
         return false
     }
 
+    // Function added to wait for AccountManager initialization to get
+    // if the user is Sign in with Sync Account to decide which cards to show
     func hasSyncableAccount(completion: @escaping () -> Void) {
         profile.hasSyncAccount { result in
             self.hasSyncableAccount = result

--- a/Client/Frontend/Update/UpdateViewModel.swift
+++ b/Client/Frontend/Update/UpdateViewModel.swift
@@ -9,10 +9,7 @@ class UpdateViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
 
     let profile: Profile
     static let prefsKey: String = PrefsKeys.KeyLastVersionNumber
-
-    lazy var hasSyncableAccount: Bool = {
-        return profile.hasSyncableAccount()
-    }()
+    var hasSyncableAccount: Bool?
 
     var shouldShowSingleCard: Bool {
         return enabledCards.count == 1
@@ -23,7 +20,7 @@ class UpdateViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
     }
 
     var enabledCards: [IntroViewModel.InformationCards] {
-        if hasSyncableAccount {
+        if hasSyncableAccount ?? false {
             return [.updateWelcome]
         }
 
@@ -61,6 +58,15 @@ class UpdateViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
         }
 
         return false
+    }
+
+    func hasSyncableAccount(completion: @escaping () -> Void) {
+        profile.hasSyncAccount { result in
+            self.hasSyncableAccount = result
+            ensureMainThread {
+                completion()
+            }
+        }
     }
 
     func positionForCard(cardType: IntroViewModel.InformationCards) -> Int? {

--- a/Client/Frontend/Update/UpdateViewModel.swift
+++ b/Client/Frontend/Update/UpdateViewModel.swift
@@ -18,6 +18,10 @@ class UpdateViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
         return enabledCards.count == 1
     }
 
+    var isMROnboardingVersion: Bool {
+        return true
+    }
+
     var enabledCards: [IntroViewModel.InformationCards] {
         if hasSyncableAccount {
             return [.updateWelcome]

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -126,6 +126,9 @@ protocol Profile: AnyObject {
     // Similar to <http://stackoverflow.com/questions/26029317/exc-bad-access-when-indirectly-accessing-inherited-member-in-swift>.
     func localName() -> String
 
+    // Async call to wait for result
+    func hasSyncAccount(completion: @escaping (Bool) -> Void)
+
     // Do we have an account at all?
     func hasAccount() -> Bool
 
@@ -627,6 +630,12 @@ open class BrowserProfile: Profile {
 
         return RustLogins(sqlCipherDatabasePath: sqlCipherDatabasePath, databasePath: databasePath)
     }()
+
+    func hasSyncAccount(completion: @escaping (Bool) -> Void) {
+        rustFxA.hasAccount { hasAccount in
+            completion(hasAccount)
+        }
+    }
 
     func hasAccount() -> Bool {
         return rustFxA.hasAccount()

--- a/RustFxA/RustFirefoxAccounts.swift
+++ b/RustFxA/RustFirefoxAccounts.swift
@@ -292,6 +292,12 @@ open class RustFirefoxAccounts {
         MZKeychainWrapper.sharedClientAppContainerKeychain.removeObject(forKey: KeychainKey.apnsToken, withAccessibility: .afterFirstUnlock)
     }
 
+    public func hasAccount(completion: @escaping (Bool) -> Void) {
+        accountManager.uponQueue(.global(qos: .userInitiated)) { manager in
+            completion(manager.hasAccount())
+        }
+    }
+
     public func hasAccount() -> Bool {
         guard let accountManager = accountManager.peek() else { return false }
         return accountManager.hasAccount()

--- a/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/Tests/ClientTests/Mocks/MockProfile.swift
@@ -194,8 +194,12 @@ open class MockProfile: Client.Profile {
         return SQLiteRemoteClientsAndTabs(db: self.db)
     }()
 
+    public func hasSyncAccount(completion: @escaping (Bool) -> Void) {
+        completion(hasSyncableAccountMock)
+    }
+
     public func hasAccount() -> Bool {
-        return true
+        return hasSyncableAccountMock
     }
 
     var hasSyncableAccountMock: Bool = true

--- a/Tests/ClientTests/OnboardingCardViewModelTests.swift
+++ b/Tests/ClientTests/OnboardingCardViewModelTests.swift
@@ -24,7 +24,8 @@ class OnboardingCardViewModelTests: XCTestCase {
 
     func testSendOnboardingCardView_WelcomeCard() {
         sut = OnboardingCardViewModel(cardType: .welcome,
-                                      infoModel: createInfoModel())
+                                      infoModel: createInfoModel(),
+                                      isMROnboardingVersion: false)
         sut.sendCardViewTelemetry()
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.cardView)
@@ -32,7 +33,8 @@ class OnboardingCardViewModelTests: XCTestCase {
 
     func testSendOnboardingCardView_WallpaperCard() {
         sut = OnboardingCardViewModel(cardType: .wallpapers,
-                                      infoModel: createInfoModel())
+                                      infoModel: createInfoModel(),
+                                      isMROnboardingVersion: false)
         sut.sendCardViewTelemetry()
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.cardView)
@@ -40,7 +42,8 @@ class OnboardingCardViewModelTests: XCTestCase {
 
     func testSendOnboardingCardView_SyncCard() {
         sut = OnboardingCardViewModel(cardType: .signSync,
-                                      infoModel: createInfoModel())
+                                      infoModel: createInfoModel(),
+                                      isMROnboardingVersion: false)
         sut.sendCardViewTelemetry()
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.cardView)
@@ -48,7 +51,8 @@ class OnboardingCardViewModelTests: XCTestCase {
 
     func testSendUpgradeCardView_WelcomeCard() {
         sut = OnboardingCardViewModel(cardType: .updateWelcome,
-                                      infoModel: createInfoModel())
+                                      infoModel: createInfoModel(),
+                                      isMROnboardingVersion: false)
         sut.sendCardViewTelemetry()
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Upgrade.cardView)
@@ -56,7 +60,8 @@ class OnboardingCardViewModelTests: XCTestCase {
 
     func testSendUpgradeCardView_SyncCard() {
         sut = OnboardingCardViewModel(cardType: .updateSignSync,
-                                      infoModel: createInfoModel())
+                                      infoModel: createInfoModel(),
+                                      isMROnboardingVersion: false)
         sut.sendCardViewTelemetry()
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Upgrade.cardView)
@@ -65,7 +70,8 @@ class OnboardingCardViewModelTests: XCTestCase {
     // MARK: - Primary tap
     func testSendOnboardingPrimaryTap_WelcomeCard() {
         sut = OnboardingCardViewModel(cardType: .welcome,
-                                      infoModel: createInfoModel())
+                                      infoModel: createInfoModel(),
+                                      isMROnboardingVersion: false)
         sut.sendTelemetryButton(isPrimaryAction: true)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.primaryButtonTap)
@@ -73,7 +79,8 @@ class OnboardingCardViewModelTests: XCTestCase {
 
     func testSendOnboardingPrimaryTap_WallpaperCard() {
         sut = OnboardingCardViewModel(cardType: .wallpapers,
-                                      infoModel: createInfoModel())
+                                      infoModel: createInfoModel(),
+                                      isMROnboardingVersion: false)
         sut.sendTelemetryButton(isPrimaryAction: true)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.primaryButtonTap)
@@ -81,7 +88,8 @@ class OnboardingCardViewModelTests: XCTestCase {
 
     func testSendOnboardingPrimaryTap_SyncCard() {
         sut = OnboardingCardViewModel(cardType: .signSync,
-                                      infoModel: createInfoModel())
+                                      infoModel: createInfoModel(),
+                                      isMROnboardingVersion: false)
         sut.sendTelemetryButton(isPrimaryAction: true)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.primaryButtonTap)
@@ -89,7 +97,8 @@ class OnboardingCardViewModelTests: XCTestCase {
 
     func testSendUpgradePrimaryTap_WallpaperCard() {
         sut = OnboardingCardViewModel(cardType: .updateWelcome,
-                                      infoModel: createInfoModel())
+                                      infoModel: createInfoModel(),
+                                      isMROnboardingVersion: false)
         sut.sendTelemetryButton(isPrimaryAction: true)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Upgrade.primaryButtonTap)
@@ -97,7 +106,8 @@ class OnboardingCardViewModelTests: XCTestCase {
 
     func testSendUpgradePrimaryTap_SyncCard() {
         sut = OnboardingCardViewModel(cardType: .updateSignSync,
-                                      infoModel: createInfoModel())
+                                      infoModel: createInfoModel(),
+                                      isMROnboardingVersion: false)
         sut.sendTelemetryButton(isPrimaryAction: true)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Upgrade.primaryButtonTap)
@@ -106,7 +116,8 @@ class OnboardingCardViewModelTests: XCTestCase {
     // MARK: - Secondary tap
     func testSendOnboardingSecondaryTap_WallpaperCard() {
         sut = OnboardingCardViewModel(cardType: .wallpapers,
-                                      infoModel: createInfoModel())
+                                      infoModel: createInfoModel(),
+                                      isMROnboardingVersion: false)
         sut.sendTelemetryButton(isPrimaryAction: false)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.secondaryButtonTap)
@@ -114,7 +125,8 @@ class OnboardingCardViewModelTests: XCTestCase {
 
     func testSendOnboardingSecondaryTap_SyncCard() {
         sut = OnboardingCardViewModel(cardType: .signSync,
-                                      infoModel: createInfoModel())
+                                      infoModel: createInfoModel(),
+                                      isMROnboardingVersion: false)
         sut.sendTelemetryButton(isPrimaryAction: false)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.secondaryButtonTap)
@@ -122,7 +134,8 @@ class OnboardingCardViewModelTests: XCTestCase {
 
     func testSendUpgradeSecondaryTap_SyncCard() {
         sut = OnboardingCardViewModel(cardType: .updateSignSync,
-                                      infoModel: createInfoModel())
+                                      infoModel: createInfoModel(),
+                                      isMROnboardingVersion: false)
         sut.sendTelemetryButton(isPrimaryAction: false)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Upgrade.secondaryButtonTap)

--- a/Tests/ClientTests/OnboardingCardViewModelTests.swift
+++ b/Tests/ClientTests/OnboardingCardViewModelTests.swift
@@ -25,7 +25,7 @@ class OnboardingCardViewModelTests: XCTestCase {
     func testSendOnboardingCardView_WelcomeCard() {
         sut = OnboardingCardViewModel(cardType: .welcome,
                                       infoModel: createInfoModel(),
-                                      isMROnboardingVersion: false)
+                                      isv106Version: false)
         sut.sendCardViewTelemetry()
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.cardView)
@@ -34,7 +34,7 @@ class OnboardingCardViewModelTests: XCTestCase {
     func testSendOnboardingCardView_WallpaperCard() {
         sut = OnboardingCardViewModel(cardType: .wallpapers,
                                       infoModel: createInfoModel(),
-                                      isMROnboardingVersion: false)
+                                      isv106Version: false)
         sut.sendCardViewTelemetry()
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.cardView)
@@ -43,7 +43,7 @@ class OnboardingCardViewModelTests: XCTestCase {
     func testSendOnboardingCardView_SyncCard() {
         sut = OnboardingCardViewModel(cardType: .signSync,
                                       infoModel: createInfoModel(),
-                                      isMROnboardingVersion: false)
+                                      isv106Version: false)
         sut.sendCardViewTelemetry()
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.cardView)
@@ -52,7 +52,7 @@ class OnboardingCardViewModelTests: XCTestCase {
     func testSendUpgradeCardView_WelcomeCard() {
         sut = OnboardingCardViewModel(cardType: .updateWelcome,
                                       infoModel: createInfoModel(),
-                                      isMROnboardingVersion: false)
+                                      isv106Version: false)
         sut.sendCardViewTelemetry()
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Upgrade.cardView)
@@ -61,7 +61,7 @@ class OnboardingCardViewModelTests: XCTestCase {
     func testSendUpgradeCardView_SyncCard() {
         sut = OnboardingCardViewModel(cardType: .updateSignSync,
                                       infoModel: createInfoModel(),
-                                      isMROnboardingVersion: false)
+                                      isv106Version: false)
         sut.sendCardViewTelemetry()
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Upgrade.cardView)
@@ -71,7 +71,7 @@ class OnboardingCardViewModelTests: XCTestCase {
     func testSendOnboardingPrimaryTap_WelcomeCard() {
         sut = OnboardingCardViewModel(cardType: .welcome,
                                       infoModel: createInfoModel(),
-                                      isMROnboardingVersion: false)
+                                      isv106Version: false)
         sut.sendTelemetryButton(isPrimaryAction: true)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.primaryButtonTap)
@@ -80,7 +80,7 @@ class OnboardingCardViewModelTests: XCTestCase {
     func testSendOnboardingPrimaryTap_WallpaperCard() {
         sut = OnboardingCardViewModel(cardType: .wallpapers,
                                       infoModel: createInfoModel(),
-                                      isMROnboardingVersion: false)
+                                      isv106Version: false)
         sut.sendTelemetryButton(isPrimaryAction: true)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.primaryButtonTap)
@@ -89,7 +89,7 @@ class OnboardingCardViewModelTests: XCTestCase {
     func testSendOnboardingPrimaryTap_SyncCard() {
         sut = OnboardingCardViewModel(cardType: .signSync,
                                       infoModel: createInfoModel(),
-                                      isMROnboardingVersion: false)
+                                      isv106Version: false)
         sut.sendTelemetryButton(isPrimaryAction: true)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.primaryButtonTap)
@@ -98,7 +98,7 @@ class OnboardingCardViewModelTests: XCTestCase {
     func testSendUpgradePrimaryTap_WallpaperCard() {
         sut = OnboardingCardViewModel(cardType: .updateWelcome,
                                       infoModel: createInfoModel(),
-                                      isMROnboardingVersion: false)
+                                      isv106Version: false)
         sut.sendTelemetryButton(isPrimaryAction: true)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Upgrade.primaryButtonTap)
@@ -107,7 +107,7 @@ class OnboardingCardViewModelTests: XCTestCase {
     func testSendUpgradePrimaryTap_SyncCard() {
         sut = OnboardingCardViewModel(cardType: .updateSignSync,
                                       infoModel: createInfoModel(),
-                                      isMROnboardingVersion: false)
+                                      isv106Version: false)
         sut.sendTelemetryButton(isPrimaryAction: true)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Upgrade.primaryButtonTap)
@@ -117,7 +117,7 @@ class OnboardingCardViewModelTests: XCTestCase {
     func testSendOnboardingSecondaryTap_WallpaperCard() {
         sut = OnboardingCardViewModel(cardType: .wallpapers,
                                       infoModel: createInfoModel(),
-                                      isMROnboardingVersion: false)
+                                      isv106Version: false)
         sut.sendTelemetryButton(isPrimaryAction: false)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.secondaryButtonTap)
@@ -126,7 +126,7 @@ class OnboardingCardViewModelTests: XCTestCase {
     func testSendOnboardingSecondaryTap_SyncCard() {
         sut = OnboardingCardViewModel(cardType: .signSync,
                                       infoModel: createInfoModel(),
-                                      isMROnboardingVersion: false)
+                                      isv106Version: false)
         sut.sendTelemetryButton(isPrimaryAction: false)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.secondaryButtonTap)
@@ -135,7 +135,7 @@ class OnboardingCardViewModelTests: XCTestCase {
     func testSendUpgradeSecondaryTap_SyncCard() {
         sut = OnboardingCardViewModel(cardType: .updateSignSync,
                                       infoModel: createInfoModel(),
-                                      isMROnboardingVersion: false)
+                                      isv106Version: false)
         sut.sendTelemetryButton(isPrimaryAction: false)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Upgrade.secondaryButtonTap)

--- a/Tests/ClientTests/UpdateViewModel/UpdateViewModelTests.swift
+++ b/Tests/ClientTests/UpdateViewModel/UpdateViewModelTests.swift
@@ -31,25 +31,43 @@ class UpdateViewModelTests: XCTestCase {
     // MARK: Enable cards
     func testEnabledCards_ForHasSyncAccount() {
         profile.hasSyncableAccountMock = true
-        let enableCards = viewModel.enabledCards
+        let expectation = expectation(description: "The hasAccount var has value")
 
-        XCTAssertEqual(enableCards.count, 1)
-        XCTAssertEqual(enableCards[0], .updateWelcome)
+        viewModel.hasSyncableAccount {
+            let enableCards = self.viewModel.enabledCards
+
+            XCTAssertEqual(enableCards.count, 1)
+            XCTAssertEqual(enableCards[0], .updateWelcome)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 2.0)
     }
 
     func testEnabledCards_ForSyncAccountDisabled() {
         profile.hasSyncableAccountMock = false
-        let enableCards = viewModel.enabledCards
+        let expectation = expectation(description: "The hasAccount var has value")
 
-        XCTAssertEqual(enableCards.count, 2)
-        XCTAssertEqual(enableCards[0], .updateWelcome)
-        XCTAssertEqual(enableCards[1], .updateSignSync)
+        viewModel.hasSyncableAccount {
+            let enableCards = self.viewModel.enabledCards
+
+            XCTAssertEqual(enableCards.count, 2)
+            XCTAssertEqual(enableCards[0], .updateWelcome)
+            XCTAssertEqual(enableCards[1], .updateSignSync)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 2.0)
     }
 
     // MARK: Has Single card
     func testHasSingleCard_ForHasSyncAccount() {
         profile.hasSyncableAccountMock = true
-        XCTAssertEqual(viewModel.shouldShowSingleCard, true)
+        let expectation = expectation(description: "The hasAccount var has value")
+
+        viewModel.hasSyncableAccount {
+            XCTAssertEqual(self.viewModel.shouldShowSingleCard, true)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 2.0)
     }
 
     func testHasSingleCard_ForSyncAccountDisabled() {

--- a/Tests/XCUITests/FirstRunTourTests.swift
+++ b/Tests/XCUITests/FirstRunTourTests.swift
@@ -3,7 +3,6 @@ import XCTest
 class FirstRunTourTests: BaseTestCase {
 
     let onboardingAccessibilityId = [AccessibilityIdentifiers.Onboarding.welcomeCard,
-                                     AccessibilityIdentifiers.Onboarding.wallpapersCard,
                                      AccessibilityIdentifiers.Onboarding.signSyncCard]
     var currentScreen = 0
     var rootA11yId: String {
@@ -20,7 +19,7 @@ class FirstRunTourTests: BaseTestCase {
     func testFirstRunTour() {
         // Complete the First run from first screen to the latest one
         // Check that the first's tour screen is shown as well as all the elements in there
-        waitForExistence(app.staticTexts["Welcome to Firefox"], timeout: 15)
+        waitForExistence(app.staticTexts["Welcome to an independent internet"], timeout: 15)
         XCTAssertTrue(app.buttons["\(rootA11yId)PrimaryButton"].exists)
         XCTAssertTrue(app.buttons["\(AccessibilityIdentifiers.Onboarding.closeButton)"].exists)
         XCTAssertTrue(app.pageIndicators["\(AccessibilityIdentifiers.Onboarding.pageControl)"].exists)
@@ -28,21 +27,13 @@ class FirstRunTourTests: BaseTestCase {
         // Swipe to the second screen
         app.buttons["\(rootA11yId)PrimaryButton"].tap()
         currentScreen += 1
-        waitForExistence(app.staticTexts["Choose a Firefox Wallpaper"])
-        XCTAssertTrue(app.buttons["\(rootA11yId)PrimaryButton"].exists)
-        XCTAssertTrue(app.buttons["\(rootA11yId)SecondaryButton"].exists)
-
-        // Swipe to the third screen
-        app.buttons["\(rootA11yId)SecondaryButton"].tap()
-        currentScreen += 1
-        waitForExistence(app.staticTexts["Sync to Stay In Your Flow"])
+        waitForExistence(app.staticTexts["Hop from phone to laptop and back"])
         XCTAssertTrue(app.buttons["\(rootA11yId)PrimaryButton"].exists)
         XCTAssertTrue(app.buttons["\(rootA11yId)SecondaryButton"].exists)
     }
 
     func testStartBrowsingFromThirdScreen() {
         navigator.goto(FirstRun)
-        goToNextScreen()
         goToNextScreen()
         tapStartBrowsingButton()
     }
@@ -55,11 +46,10 @@ class FirstRunTourTests: BaseTestCase {
 
     func testShowTourFromSettings() {
         goToNextScreen()
-        goToNextScreen()
         tapStartBrowsingButton()
         app.buttons["urlBar-cancel"].tap()
         navigator.goto(ShowTourInSettings)
-        waitForExistence(app.staticTexts["Welcome to Firefox"])
+        waitForExistence(app.staticTexts["Welcome to an independent internet"])
     }
 
     // MARK: Private


### PR DESCRIPTION
Issue #11484 
[Jira](https://mozilla-hub.atlassian.net/browse/FXIOS-4683)

- Add logic to viewModel to support to versions of onboarding
- Remove wallpaper card based on upgrade onboarding feature flag
- Update text for title and description
- Add background illustration just for MR version
- Includes UX review fixes for Update onboarding because it will be needed for this story
- Use async hasAccount to show Update onboarding to show the current number of cards