### PR TITLE
Bugfix FXIOS-4787 [v105] Update layout of jump back in after rotation

### DIFF
--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -321,6 +321,10 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
     func refreshData(for traitCollection: UITraitCollection,
                      isPortrait: Bool = UIWindow.isPortrait,
                      device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
+        updateSectionLayout(for: traitCollection,
+                            isPortrait: isPortrait,
+                            device: device)
+
         let maxItemToDisplay = sectionLayout.maxItemsToDisplay(
             displayGroup: .jumpBackIn,
             hasAccount: jumpBackInDataAdaptor.hasSyncedTabFeatureEnabled,
@@ -330,10 +334,6 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
 
         jumpBackInList = jumpBackInDataAdaptor.getJumpBackInData()
         mostRecentSyncedTab = jumpBackInDataAdaptor.getSyncedTabData()
-
-        updateSectionLayout(for: traitCollection,
-                            isPortrait: isPortrait,
-                            device: device)
     }
 
     func updatePrivacyConcernedSection(isPrivate: Bool) {

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -321,6 +321,7 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
     func refreshData(for traitCollection: UITraitCollection,
                      isPortrait: Bool = UIWindow.isPortrait,
                      device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
+        getLatestData()
         updateSectionLayout(for: traitCollection,
                             isPortrait: isPortrait,
                             device: device)
@@ -331,7 +332,10 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
             device: device
         )
         jumpBackInDataAdaptor.refreshData(maxItemToDisplay: maxItemToDisplay)
+        getLatestData()
+    }
 
+    private func getLatestData() {
         jumpBackInList = jumpBackInDataAdaptor.getJumpBackInData()
         mostRecentSyncedTab = jumpBackInDataAdaptor.getSyncedTabData()
     }
@@ -402,8 +406,7 @@ extension JumpBackInViewModel: HomepageSectionHandler {
 extension JumpBackInViewModel: JumpBackInDelegate {
     func didLoadNewData() {
         ensureMainThread {
-            self.jumpBackInList = self.jumpBackInDataAdaptor.getJumpBackInData()
-            self.mostRecentSyncedTab = self.jumpBackInDataAdaptor.getSyncedTabData()
+            self.getLatestData()
             guard self.isEnabled else { return }
             self.delegate?.reloadView()
         }

--- a/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -311,6 +311,37 @@ class JumpBackInViewModelTests: XCTestCase {
         XCTAssertEqual(sut.sectionLayout, .regular)
     }
 
+    func testUpdateLayoutSectionBeforeRefreshData() {
+        let sut = createSut()
+        let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
+        let tab2 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
+        let tab3 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
+        adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1, tab2, tab3])
+
+        // Start in portrait
+        let portraitTrait = MockTraitCollection()
+        portraitTrait.overridenHorizontalSizeClass = .compact
+        portraitTrait.overridenVerticalSizeClass = .regular
+        sut.refreshData(for: portraitTrait, isPortrait: true, device: .phone)
+
+        XCTAssertEqual(adaptor.maxItemToDisplay, 2)
+        XCTAssertEqual(sut.sectionLayout, .compactJumpBackIn)
+
+        // Mock rotation to landscape
+        let landscapeTrait = MockTraitCollection()
+        landscapeTrait.overridenHorizontalSizeClass = .regular
+        landscapeTrait.overridenVerticalSizeClass = .compact
+        sut.refreshData(for: landscapeTrait, isPortrait: false, device: .phone)
+
+        XCTAssertEqual(adaptor.maxItemToDisplay, 4)
+        XCTAssertEqual(sut.sectionLayout, .regular)
+
+        // Go back to portrait
+        sut.refreshData(for: portraitTrait, isPortrait: true, device: .phone)
+        XCTAssertEqual(adaptor.maxItemToDisplay, 2)
+        XCTAssertEqual(sut.sectionLayout, .compactJumpBackIn)
+    }
+
     // MARK: - Sync tab layout
 
     func testMaxDisplayedItemSyncedTab_withAccount() {
@@ -467,7 +498,10 @@ class JumpBackInDataAdaptorMock: JumpBackInDataAdaptor {
         return nil
     }
 
-    func refreshData(maxItemToDisplay: Int) {}
+    var maxItemToDisplay: Int = 0
+    func refreshData(maxItemToDisplay: Int) {
+        self.maxItemToDisplay = maxItemToDisplay
+    }
 }
 
 // MARK: - MockBrowserBarViewDelegate


### PR DESCRIPTION
# [FXIOS-4787](https://mozilla-hub.atlassian.net/browse/FXIOS-4787) https://github.com/mozilla-mobile/firefox-ios/issues/11641 
We need to update the section layout before refreshing the data. Add test to capture this so there's no regression there.