### PR TITLE
Refactor [vXXX] These are the changes needed to consume Glean via the A-S megazord

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -319,7 +319,6 @@
 		434E733725EED32E006D3BDE /* BrowserViewController+URLBarDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434E733625EED32E006D3BDE /* BrowserViewController+URLBarDelegate.swift */; };
 		435222C125882E3800FCA5B6 /* WidgetKitTopSiteModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435222C025882E3800FCA5B6 /* WidgetKitTopSiteModel.swift */; };
 		435222C225882E3800FCA5B6 /* WidgetKitTopSiteModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435222C025882E3800FCA5B6 /* WidgetKitTopSiteModel.swift */; };
-		435C85F02788F4D00072B526 /* Glean in Frameworks */ = {isa = PBXBuildFile; productRef = 435C85EF2788F4D00072B526 /* Glean */; };
 		435D660323D793DF0046EFA2 /* OnboardingInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435D660223D793DF0046EFA2 /* OnboardingInfoModel.swift */; };
 		435D660523D794B90046EFA2 /* UpdateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435D660423D794B90046EFA2 /* UpdateViewModel.swift */; };
 		435D7CC5246209AA0043ACB9 /* IntroViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435D7CC4246209AA0043ACB9 /* IntroViewController.swift */; };
@@ -438,7 +437,6 @@
 		5AF6254928A58BB400A90253 /* MockHistoryHighlightsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF6254828A58BB400A90253 /* MockHistoryHighlightsDelegate.swift */; };
 		5F130D2E2483508E00B0F7D0 /* FxAWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F130D2D2483508E00B0F7D0 /* FxAWebViewModel.swift */; };
 		5F97DD5F27FB0FE800AD3C60 /* GleanTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F97DD5E27FB0FE800AD3C60 /* GleanTelemetryTests.swift */; };
-		5FA2233C27F74071005B3D87 /* Glean in Frameworks */ = {isa = PBXBuildFile; productRef = 5FA2233B27F74071005B3D87 /* Glean */; };
 		5FC276552894AEFF00AF2721 /* LibraryPanelHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30B101D1AA7F9C600C01CA3 /* LibraryPanelHelper.swift */; };
 		5FC276562894AF8200AF2721 /* PushClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C22C2C1E897B9A000C0E56 /* PushClientTests.swift */; };
 		5FC276572894AF8C00AF2721 /* PushCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39B0647C1E7ADAC2000BE173 /* PushCryptoTests.swift */; };
@@ -5273,7 +5271,6 @@
 				1B3D99F1270E89D0006E1264 /* Telemetry in Frameworks */,
 				432BD0242790EBD000A0F3C3 /* Adjust in Frameworks */,
 				0B8E0FF41A932BD500161DC3 /* ImageIO.framework in Frameworks */,
-				435C85F02788F4D00072B526 /* Glean in Frameworks */,
 				433F87CE2788EAB600693368 /* GCDWebServers in Frameworks */,
 				7B8A47F61D01D3B400C07734 /* PassKit.framework in Frameworks */,
 				43AFC117279699530039DDF4 /* XCGLogger.framework in Frameworks */,
@@ -5417,7 +5414,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5FA2233C27F74071005B3D87 /* Glean in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8886,7 +8882,6 @@
 			);
 			name = SyncTelemetryTests;
 			packageProductDependencies = (
-				5FA2233B27F74071005B3D87 /* Glean */,
 			);
 			productName = SyncTelemetryTests;
 			productReference = E69DB07D1E97DEA9008A67E6 /* SyncTelemetryTests.xctest */;
@@ -8967,7 +8962,6 @@
 			packageProductDependencies = (
 				1B3D99F0270E89D0006E1264 /* Telemetry */,
 				433F87CD2788EAB600693368 /* GCDWebServers */,
-				435C85EF2788F4D00072B526 /* Glean */,
 				432BD0232790EBD000A0F3C3 /* Adjust */,
 				96C11E952863985E00840E7C /* Dip */,
 			);
@@ -9300,7 +9294,6 @@
 				433F87CC2788EAB600693368 /* XCRemoteSwiftPackageReference "GCDWebServer" */,
 				433F87D12788EF5B00693368 /* XCRemoteSwiftPackageReference "KIF" */,
 				433F87D62788F34500693368 /* XCRemoteSwiftPackageReference "rust-components-swift" */,
-				435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */,
 				432BD0222790EBD000A0F3C3 /* XCRemoteSwiftPackageReference "ios_sdk" */,
 				4368F811279611AC0013419B /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				4368F83B279669690013419B /* XCRemoteSwiftPackageReference "SnapKit" */,
@@ -9714,7 +9707,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "rm -rf .venv; bash $PWD/bin/sdk_generator.sh -g Glean\n";
+			shellScript = "rm -rf .venv; bash $PWD/bin/sdk_generator.sh -g MozillaAppServices\n";
 		};
 		5FA2232C27F6FA69005B3D87 /* Nimbus Feature Manifest Generator Script */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -9756,7 +9749,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "rm -rf .venv; bash $PWD/bin/sdk_generator.sh -g Glean -o $SRCROOT/Sync/Generated\n";
+			shellScript = "rm -rf .venv; bash $PWD/bin/sdk_generator.sh  -g MozillaAppServices -o $SRCROOT/Sync/Generated\n";
 		};
 		C874A4E327F62C5B006F54E5 /* Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -16355,14 +16348,6 @@
 				version = 94.3.0;
 			};
 		};
-		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/mozilla/glean-swift";
-			requirement = {
-				kind = exactVersion;
-				version = 51.4.0;
-			};
-		};
 		4368F811279611AC0013419B /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
@@ -16477,11 +16462,6 @@
 			package = 433F87D12788EF5B00693368 /* XCRemoteSwiftPackageReference "KIF" */;
 			productName = KIF;
 		};
-		435C85EF2788F4D00072B526 /* Glean */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */;
-			productName = Glean;
-		};
 		4368F82A279665370013419B /* Sentry */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 4368F811279611AC0013419B /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
@@ -16520,11 +16500,6 @@
 		43EFA63D2786562600400DF0 /* Places */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Places;
-		};
-		5FA2233B27F74071005B3D87 /* Glean */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */;
-			productName = Glean;
 		};
 		96C11E952863985E00840E7C /* Dip */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -36,15 +36,6 @@
       }
     },
     {
-      "identity" : "glean-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mozilla/glean-swift",
-      "state" : {
-        "revision" : "5aedaf3001cb6c0174179ad97c1d91d2bef4b91d",
-        "version" : "51.4.0"
-      }
-    },
-    {
       "identity" : "ios_sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adjust/ios_sdk.git",

--- a/Client/AdjustHelper.swift
+++ b/Client/AdjustHelper.swift
@@ -5,7 +5,7 @@
 import Foundation
 import Adjust
 import Shared
-import Glean
+import MozillaAppServices
 
 private let log = Logger.browserLogger
 

--- a/Client/AdjustTelemetryHelper.swift
+++ b/Client/AdjustTelemetryHelper.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 import Adjust
-import Glean
+import MozillaAppServices
 
 protocol AdjustTelemetryData {
     var campaign: String? { get set }

--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 import Shared
-import Glean
+import MozillaAppServices
 
 struct FxALaunchParams {
     var query: [String: String]

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -5,7 +5,7 @@
 import Shared
 import Storage
 import Telemetry
-import Glean
+import MozillaAppServices
 
 protocol OnViewDismissable: AnyObject {
     var onViewDismissed: (() -> Void)? { get set }

--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -6,7 +6,7 @@ import Foundation
 import Shared
 import Storage
 import XCGLogger
-import Glean
+import MozillaAppServices
 
 private let log = Logger.browserLogger
 

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -5,7 +5,7 @@
 import UIKit
 import Shared
 import Storage
-import Glean
+import MozillaAppServices
 import Telemetry
 
 private enum SearchListSection: Int, CaseIterable {

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -6,7 +6,7 @@ import Foundation
 import Shared
 import Account
 import LocalAuthentication
-import Glean
+import MozillaAppServices
 
 // This file contains all of the settings available in the main settings screen of the app.
 

--- a/Client/Frontend/Settings/SDWebImageCacheExtension.swift
+++ b/Client/Frontend/Settings/SDWebImageCacheExtension.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import Glean
+import MozillaAppServices
 import SDWebImage
 
 // TODO: This file and all its methods should be removed once we are ready to remove SDWebImage from our app

--- a/Client/Telemetry/AdsTelemetryHelper.swift
+++ b/Client/Telemetry/AdsTelemetryHelper.swift
@@ -5,7 +5,7 @@
 import Foundation
 import Shared
 import WebKit
-import Glean
+import MozillaAppServices
 
 public enum BasicSearchProvider: String {
     case google

--- a/Client/Telemetry/SearchTelemetry.swift
+++ b/Client/Telemetry/SearchTelemetry.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 import WebKit
-import Glean
+import MozillaAppServices
 
 // Search Partner Codes
 // https://docs.google.com/spreadsheets/d/1HMm9UXjfJv-uHhGU1pJlbP4ILkdpSD9w_Fd-3yOd8oY/

--- a/Client/Telemetry/SponsoredTileTelemetry.swift
+++ b/Client/Telemetry/SponsoredTileTelemetry.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import Glean
+import MozillaAppServices
 
 // Telemetry for the Sponsored tiles located in the Top sites on the Firefox home page
 // Using Pings to send the telemetry events

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
-import Glean
+import MozillaAppServices
 import Shared
 import Telemetry
 import Account

--- a/Sync/SyncTelemetryUtils.swift
+++ b/Sync/SyncTelemetryUtils.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
 import UIKit
-import Glean
+import MozillaAppServices
 import Shared
 import Account
 import Storage

--- a/Tests/ClientTests/AdjustTelemetryHelperTests.swift
+++ b/Tests/ClientTests/AdjustTelemetryHelperTests.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
-import Glean
+import MozillaAppServices
 
 @testable import Client
 

--- a/Tests/ClientTests/ContextMenuHelperTests.swift
+++ b/Tests/ClientTests/ContextMenuHelperTests.swift
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Glean
+import MozillaAppServices
 import XCTest
 
 @testable import Client

--- a/Tests/ClientTests/Frontend/Browser/Tab Management/TabsQuantityTelemetryTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/Tab Management/TabsQuantityTelemetryTests.swift
@@ -4,7 +4,7 @@
 
 @testable import Client
 
-import Glean
+import MozillaAppServices
 import XCTest
 
 class TabsQuantityTelemetryTests: XCTestCase {

--- a/Tests/ClientTests/Frontend/Home/Pocket/PocketViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/Pocket/PocketViewModelTests.swift
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Glean
+import MozillaAppServices
 import XCTest
 
 @testable import Client

--- a/Tests/ClientTests/GleanPlumbMessageManagerTests.swift
+++ b/Tests/ClientTests/GleanPlumbMessageManagerTests.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
-import Glean
+import MozillaAppServices
 
 @testable import Client
 

--- a/Tests/ClientTests/GleanTelemetryTests.swift
+++ b/Tests/ClientTests/GleanTelemetryTests.swift
@@ -12,7 +12,7 @@ import MozillaAppServices
 import Foundation
 import XCTest
 
-import Glean
+import MozillaAppServices
 
 class MockSyncDelegate: SyncDelegate {
     func displaySentTab(for url: URL, title: String, from deviceName: String?) {

--- a/Tests/ClientTests/OnboardingCardViewModelTests.swift
+++ b/Tests/ClientTests/OnboardingCardViewModelTests.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
-import Glean
+import MozillaAppServices
 
 @testable import Client
 

--- a/Tests/ClientTests/SponsoredTileTelemetryTests.swift
+++ b/Tests/ClientTests/SponsoredTileTelemetryTests.swift
@@ -4,7 +4,7 @@
 
 @testable import Client
 
-import Glean
+import MozillaAppServices
 import XCTest
 
 class SponsoredTileTelemetryTests: XCTestCase {

--- a/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -4,7 +4,7 @@
 
 @testable import Client
 
-import Glean
+import MozillaAppServices
 import XCTest
 
 class TelemetryWrapperTests: XCTestCase {

--- a/bin/sdk_generator.sh
+++ b/bin/sdk_generator.sh
@@ -25,7 +25,7 @@
 
 set -e
 
-GLEAN_PARSER_VERSION=6.1
+GLEAN_PARSER_VERSION=6.1.2
 
 # CMDNAME is used in the usage text below.
 # shellcheck disable=SC2034


### PR DESCRIPTION
In order for application services components to be able to interact with Glean at the Rust level, Glean must be compiled together with AppServices. This means that Glean will once again ship along with the A-S components via the rust-components-swift repo containing the bundled Swift packages.

This should reduce the overall size impact on the application as well as possibly reduce some dylib loading time, etc.

This shouldn't land until v107 nightly cycle, and depends on [this PR](https://github.com/mozilla/application-services/pull/5009) in application-services, and [this PR](https://github.com/mozilla/rust-components-swift/pull/64) in rust-components-swift