### PR TITLE
Add FXIOS-4768 [v105] Add some history highlights tests

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -422,6 +422,9 @@
 		5A3A7DDC2889EC5D0065F81A /* BookmarksHandlerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A3A7DDB2889EC5D0065F81A /* BookmarksHandlerMock.swift */; };
 		5A430D792853DFDD00782BFF /* OrientationLockUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A430D782853DFDD00782BFF /* OrientationLockUtility.swift */; };
 		5A47CFF52860FB8900B2B7BF /* AppLaunchUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A47CFF42860FB8900B2B7BF /* AppLaunchUtil.swift */; };
+		5A9A09D228AFD51900B6F51E /* MockHomepageDataModelDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A9A09D128AFD51900B6F51E /* MockHomepageDataModelDelegate.swift */; };
+		5A9A09D428B01D8700B6F51E /* MockTelemetryWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A9A09D328B01D8700B6F51E /* MockTelemetryWrapper.swift */; };
+		5A9A09D628B01FD500B6F51E /* MockURLBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A9A09D528B01FD500B6F51E /* MockURLBarView.swift */; };
 		5AB4237C28A1947A003BC40C /* MockNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB4237B28A1947A003BC40C /* MockNotificationCenter.swift */; };
 		5AB4237E28A2BA9C003BC40C /* HistoryHighlightsDataAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB4237D28A2BA9C003BC40C /* HistoryHighlightsDataAdaptor.swift */; };
 		5AF6254328A57A4600A90253 /* HistoryHighlightsDataAdaptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF6254228A57A4600A90253 /* HistoryHighlightsDataAdaptorTests.swift */; };
@@ -2641,6 +2644,9 @@
 		5A3A7DDB2889EC5D0065F81A /* BookmarksHandlerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksHandlerMock.swift; sourceTree = "<group>"; };
 		5A430D782853DFDD00782BFF /* OrientationLockUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrientationLockUtility.swift; sourceTree = "<group>"; };
 		5A47CFF42860FB8900B2B7BF /* AppLaunchUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchUtil.swift; sourceTree = "<group>"; };
+		5A9A09D128AFD51900B6F51E /* MockHomepageDataModelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHomepageDataModelDelegate.swift; sourceTree = "<group>"; };
+		5A9A09D328B01D8700B6F51E /* MockTelemetryWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTelemetryWrapper.swift; sourceTree = "<group>"; };
+		5A9A09D528B01FD500B6F51E /* MockURLBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLBarView.swift; sourceTree = "<group>"; };
 		5AB4237B28A1947A003BC40C /* MockNotificationCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockNotificationCenter.swift; sourceTree = "<group>"; };
 		5AB4237D28A2BA9C003BC40C /* HistoryHighlightsDataAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryHighlightsDataAdaptor.swift; sourceTree = "<group>"; };
 		5ABD40B68B3D03806BC6819C /* es-AR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-AR"; path = "es-AR.lproj/LoginManager.strings"; sourceTree = "<group>"; };
@@ -6669,6 +6675,8 @@
 				8AE80BB02891A39F00BC12EA /* SpyNotificationCenter.swift */,
 				8A7653C328A2E68B00924ABF /* MockPocketAPI.swift */,
 				8A2366F928A302E500846D1B /* MockSponsoredPocketAPI.swift */,
+				5A9A09D328B01D8700B6F51E /* MockTelemetryWrapper.swift */,
+				5A9A09D528B01FD500B6F51E /* MockURLBarView.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -7184,6 +7192,7 @@
 				5A3A7DD42889CF140065F81A /* RecentlySaved */,
 				E1AEC171286E0CF500062E29 /* HomepageViewControllerTests.swift */,
 				E1AEC172286E0CF500062E29 /* FirefoxHomeViewModelTests.swift */,
+				5A9A09D128AFD51900B6F51E /* MockHomepageDataModelDelegate.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -10496,11 +10505,13 @@
 				215B458427DA87FC00E5E800 /* TabMetadataManagerTests.swift in Sources */,
 				215349062886007900FADB4D /* GleanPlumbMessageStoreTests.swift in Sources */,
 				0BF42D4F1A7CD09600889E28 /* TestFavicons.swift in Sources */,
+				5A9A09D628B01FD500B6F51E /* MockURLBarView.swift in Sources */,
 				8A33222227DFE658008F809E /* NimbusMock.swift in Sources */,
 				8A8629E72880B7330096DDB1 /* BookmarksPanelTests.swift in Sources */,
 				7BBFEE741BB405D900A305AA /* TabManagerTests.swift in Sources */,
 				39236E721FCC600200A38F1B /* TabEventHandlerTests.swift in Sources */,
 				0BA8964C1A250E6500C1010C /* TestBookmarks.swift in Sources */,
+				5A9A09D428B01D8700B6F51E /* MockTelemetryWrapper.swift in Sources */,
 				D8BA1790206D47830023AC00 /* DeferredTestUtils.swift in Sources */,
 				2F13E79B1AC0C02700D75081 /* StringExtensionsTests.swift in Sources */,
 				CA24B52224ABD7D40093848C /* LoginsListViewModelTests.swift in Sources */,
@@ -10508,6 +10519,7 @@
 				8AE1E1DB27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift in Sources */,
 				CA24B53924ABFE250093848C /* LoginsListSelectionHelperTests.swift in Sources */,
 				2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */,
+				5A9A09D228AFD51900B6F51E /* MockHomepageDataModelDelegate.swift in Sources */,
 				43DF9D992874C0690038F33A /* ImageLoadingHandlerTests.swift in Sources */,
 				D525DFB325FBE5E000B18763 /* TabTests.swift in Sources */,
 				C8E78BDD27F4A1E700C48BAA /* HistoryDeletionUtilityTests.swift in Sources */,

--- a/Client/Application/AppLaunchUtil.swift
+++ b/Client/Application/AppLaunchUtil.swift
@@ -33,7 +33,7 @@ class AppLaunchUtil {
             Logger.browserLogger.deleteOldLogsDownToSizeLimit()
         }
 
-        _ = TelemetryWrapper(profile: profile)
+        TelemetryWrapper.shared.setup(profile: profile)
 
         // Need to get "settings.sendUsageData" this way so that Sentry can be initialized
         // before getting the Profile.

--- a/Client/Protocols/DispatchQueueInterface.swift
+++ b/Client/Protocols/DispatchQueueInterface.swift
@@ -9,6 +9,7 @@ protocol DispatchQueueInterface {
                qos: DispatchQoS,
                flags: DispatchWorkItemFlags,
                execute work: @escaping @convention(block) () -> Void)
+    func ensureMainThread(execute work: @escaping @convention(block) () -> Swift.Void)
 }
 
 extension DispatchQueueInterface {
@@ -22,6 +23,15 @@ extension DispatchQueueInterface {
               execute: work)
     }
 
+    func ensureMainThread(execute work: @escaping @convention(block) () -> Swift.Void) {
+        if Thread.isMainThread {
+            work()
+        } else {
+            DispatchQueue.main.async {
+                work()
+            }
+        }
+    }
 }
 
 extension DispatchQueue: DispatchQueueInterface {}

--- a/Tests/ClientTests/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModelTests.swift
@@ -12,18 +12,20 @@ class HistoryHighlightsViewModelTests: XCTestCase {
     private var profile: MockProfile!
     private var tabManager: MockTabManager!
     private var dataAdaptor: MockHistoryHighlightsDataAdaptor!
+    private var delegate: MockHomepageDataModelDelegate!
+    private var telemetry: MockTelemetryWrapper!
+    private var urlBar: MockURLBarView!
+
     override func setUp() {
         super.setUp()
 
         profile = MockProfile()
+        FeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         tabManager = MockTabManager()
         dataAdaptor = MockHistoryHighlightsDataAdaptor()
-        sut = HistoryHighlightsViewModel(
-            with: profile,
-            isPrivate: false,
-            tabManager: tabManager,
-            urlBar: URLBarView(profile: profile),
-            historyHighlightsDataAdaptor: dataAdaptor)
+        delegate = MockHomepageDataModelDelegate()
+        telemetry = MockTelemetryWrapper()
+        urlBar = MockURLBarView()
     }
 
     override func tearDown() {
@@ -33,19 +35,128 @@ class HistoryHighlightsViewModelTests: XCTestCase {
         tabManager = nil
         dataAdaptor = nil
         sut = nil
+        delegate = nil
+        telemetry = nil
+        urlBar = nil
     }
 
-    func testGetItems_isMozilla() {
-        let item1: HighlightItem = HistoryHighlight(
-            score: 0,
-            placeId: 0,
-            url: "",
-            title: "mozilla",
-            previewImageUrl: "")
-        dataAdaptor.mockHistoryItems = [item1]
+    func testLoadNewDataIsEnabled() {
+        setupSubject()
+        dataAdaptor.mockHistoryItems = [getItemWithTitle(title: "mozilla")]
 
         sut.didLoadNewData()
 
         XCTAssertEqual(sut.getItemDetailsAt(index: 0)?.displayTitle, "mozilla")
+        XCTAssertEqual(delegate.reloadViewCallCount, 1)
+    }
+
+    func testLoadNewDataIsNotEnabled() {
+        setupSubject(isPrivate: true)
+        dataAdaptor.mockHistoryItems = [getItemWithTitle(title: "mozilla")]
+
+        sut.didLoadNewData()
+
+        XCTAssertEqual(sut.getItemDetailsAt(index: 0)?.displayTitle, "mozilla")
+        XCTAssertEqual(delegate.reloadViewCallCount, 0)
+    }
+
+    func testOneColumns() {
+        setupSubject()
+        dataAdaptor.mockHistoryItems = [getItemWithTitle(title: "one"),
+                                        getItemWithTitle(title: "two"),
+                                        getItemWithTitle(title: "three")]
+
+        sut.didLoadNewData()
+
+        XCTAssertEqual(sut.numberOfColumns, 1)
+        XCTAssertEqual(sut.numberOfRows, 3)
+    }
+
+    func testTwoColumns() {
+        setupSubject()
+        dataAdaptor.mockHistoryItems = [getItemWithTitle(title: "one"),
+                                        getItemWithTitle(title: "two"),
+                                        getItemWithTitle(title: "three"),
+                                        getItemWithTitle(title: "four")]
+
+        sut.didLoadNewData()
+
+        XCTAssertEqual(sut.numberOfColumns, 2)
+        XCTAssertEqual(sut.numberOfRows, 3)
+    }
+
+    func testThreeColumns() {
+        setupSubject()
+        dataAdaptor.mockHistoryItems = [getItemWithTitle(title: "one"),
+                                        getItemWithTitle(title: "two"),
+                                        getItemWithTitle(title: "three"),
+                                        getItemWithTitle(title: "four"),
+                                        getItemWithTitle(title: "five"),
+                                        getItemWithTitle(title: "six"),
+                                        getItemWithTitle(title: "seven")]
+
+        sut.didLoadNewData()
+
+        XCTAssertEqual(sut.numberOfColumns, 3)
+        XCTAssertEqual(sut.numberOfRows, 3)
+    }
+
+    func testRecordSectionHasShown() {
+        setupSubject()
+
+        sut.recordSectionHasShown()
+
+        XCTAssertEqual(telemetry.recordEventCallCount, 1)
+        XCTAssertTrue(telemetry.recordedCategories.contains(.action))
+        XCTAssertTrue(telemetry.recordedMethods.contains(.view))
+        XCTAssertTrue(telemetry.recordedObjects.contains(.historyImpressions))
+    }
+
+    func testRecordSectionHasShownOnlyOnce() {
+        setupSubject()
+
+        sut.recordSectionHasShown()
+        sut.recordSectionHasShown()
+
+        XCTAssertEqual(telemetry.recordEventCallCount, 1)
+        XCTAssertTrue(telemetry.recordedCategories.contains(.action))
+        XCTAssertTrue(telemetry.recordedMethods.contains(.view))
+        XCTAssertTrue(telemetry.recordedObjects.contains(.historyImpressions))
+    }
+
+    func testSwitchToWhileInOverlayMode() {
+        setupSubject()
+        urlBar.inOverlayMode = true
+
+        sut.switchTo(getItemWithTitle(title: "item"))
+
+        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 1)
+        XCTAssertEqual(telemetry.recordEventCallCount, 1)
+        XCTAssertTrue(telemetry.recordedCategories.contains(.action))
+        XCTAssertTrue(telemetry.recordedMethods.contains(.tap))
+        XCTAssertTrue(telemetry.recordedObjects.contains(.firefoxHomepage))
+    }
+
+    // MARK: - Helper methods
+
+    private func setupSubject(isPrivate: Bool = false) {
+        sut = HistoryHighlightsViewModel(
+            with: profile,
+            isPrivate: isPrivate,
+            tabManager: tabManager,
+            urlBar: urlBar,
+            historyHighlightsDataAdaptor: dataAdaptor,
+            dispatchQueue: MockDispatchQueue(),
+            telemetry: telemetry)
+        sut.delegate = delegate
+    }
+
+    private func getItemWithTitle(title: String) -> HighlightItem {
+        return HistoryHighlight(
+            score: 0,
+            placeId: 0,
+            url: "",
+            title: title,
+            previewImageUrl: "")
     }
 }

--- a/Tests/ClientTests/Frontend/Home/MockHomepageDataModelDelegate.swift
+++ b/Tests/ClientTests/Frontend/Home/MockHomepageDataModelDelegate.swift
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+class MockHomepageDataModelDelegate: HomepageDataModelDelegate {
+
+    var reloadViewCallCount = 0
+
+    func reloadView() {
+        reloadViewCallCount += 1
+    }
+}

--- a/Tests/ClientTests/Mocks/MockDispatchQueue.swift
+++ b/Tests/ClientTests/Mocks/MockDispatchQueue.swift
@@ -12,4 +12,8 @@ class MockDispatchQueue: DispatchQueueInterface {
                execute work: @escaping @convention(block) () -> Void) {
         work()
     }
+
+    func ensureMainThread(execute work: @escaping () -> Void) {
+        work()
+    }
 }

--- a/Tests/ClientTests/Mocks/MockTelemetryWrapper.swift
+++ b/Tests/ClientTests/Mocks/MockTelemetryWrapper.swift
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+class MockTelemetryWrapper: TelemetryWrapperProtocol {
+
+    var recordEventCallCount = 0
+    var recordedCategories = [TelemetryWrapper.EventCategory]()
+    var recordedMethods = [TelemetryWrapper.EventMethod]()
+    var recordedObjects = [TelemetryWrapper.EventObject]()
+
+    func recordEvent(category: TelemetryWrapper.EventCategory,
+                     method: TelemetryWrapper.EventMethod,
+                     object: TelemetryWrapper.EventObject,
+                     value: TelemetryWrapper.EventValue?,
+                     extras: [String: Any]?) {
+
+        recordEventCallCount += 1
+        recordedCategories.append(category)
+        recordedMethods.append(method)
+        recordedObjects.append(object)
+    }
+}

--- a/Tests/ClientTests/Mocks/MockURLBarView.swift
+++ b/Tests/ClientTests/Mocks/MockURLBarView.swift
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+class MockURLBarView: URLBarViewProtocol {
+    var inOverlayMode = false
+    var leaveOverlayModeCallCount = 0
+
+    func leaveOverlayMode(didCancel cancel: Bool) {
+        leaveOverlayModeCallCount += 1
+    }
+}

--- a/Tests/ClientTests/SponsoredTileTelemetryTests.swift
+++ b/Tests/ClientTests/SponsoredTileTelemetryTests.swift
@@ -38,7 +38,7 @@ class SponsoredTileTelemetryTests: XCTestCase {
     }
 
     func testTelemetryWrapper_setsContextId() {
-        _ = TelemetryWrapper(profile: MockProfile())
+        TelemetryWrapper.shared.setup(profile: MockProfile())
         XCTAssertNotNil(SponsoredTileTelemetry.contextId)
     }
 

--- a/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -257,13 +257,13 @@ class TelemetryWrapperTests: XCTestCase {
 
     func test_backgroundWallpaperMetric_defaultBackgroundIsNotSent() {
         let profile = MockProfile()
-        let wrapper = TelemetryWrapper(profile: profile)
+        TelemetryWrapper.shared.setup(profile: profile)
 
         LegacyWallpaperManager().updateSelectedWallpaperIndex(to: 0)
         XCTAssertEqual(LegacyWallpaperManager().currentWallpaper.type, .defaultBackground)
 
         let fakeNotif = NSNotification(name: UIApplication.didEnterBackgroundNotification, object: nil)
-        wrapper.recordEnteredBackgroundPreferenceMetrics(notification: fakeNotif)
+        TelemetryWrapper.shared.recordEnteredBackgroundPreferenceMetrics(notification: fakeNotif)
 
         testLabeledMetricSuccess(metric: GleanMetrics.WallpaperAnalytics.themedWallpaper)
         let wallpaperName = LegacyWallpaperManager().currentWallpaper.name.lowercased()
@@ -272,13 +272,13 @@ class TelemetryWrapperTests: XCTestCase {
 
     func test_backgroundWallpaperMetric_themedWallpaperIsSent() {
         let profile = MockProfile()
-        let wrapper = TelemetryWrapper(profile: profile)
+        TelemetryWrapper.shared.setup(profile: profile)
 
         LegacyWallpaperManager().updateSelectedWallpaperIndex(to: 1)
         XCTAssertNotEqual(LegacyWallpaperManager().currentWallpaper.type, .defaultBackground)
 
         let fakeNotif = NSNotification(name: UIApplication.didEnterBackgroundNotification, object: nil)
-        wrapper.recordEnteredBackgroundPreferenceMetrics(notification: fakeNotif)
+        TelemetryWrapper.shared.recordEnteredBackgroundPreferenceMetrics(notification: fakeNotif)
 
         testLabeledMetricSuccess(metric: GleanMetrics.WallpaperAnalytics.themedWallpaper)
         let wallpaperName = LegacyWallpaperManager().currentWallpaper.name.lowercased()


### PR DESCRIPTION
The most significant change here is that I updated TelemetryWrapper to be a singleton so that I can mock it from the history highlights view model. I know there is already a convention used to test events but I don't like that it actually talks to the real Telemetry code when all I want to test is if the event was triggered. 