### PR TITLE
Bugfix FXIOS-4557 [v105] Normal Tab switches to private browsing after closing the app

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -167,10 +167,6 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
         return eligibleTabs
     }
 
-    var lastSessionWasPrivate: Bool {
-        return UserDefaults.standard.bool(forKey: "wasLastSessionPrivate")
-    }
-
     // MARK: - Initializer
     init(profile: Profile, imageStore: DiskImageStore?) {
 
@@ -880,8 +876,8 @@ extension TabManager {
 
         var tabToSelect = store.restoreStartupTabs(clearPrivateTabs: shouldClearPrivateTabs(),
                                                    tabManager: self)
-        if lastSessionWasPrivate, !(tabToSelect?.isPrivate ?? false) {
-            tabToSelect = addTab(isPrivate: true)
+        if tabToSelect == nil {
+            tabToSelect = addTab()
         }
 
         selectTab(tabToSelect)
@@ -917,7 +913,7 @@ extension TabManager {
         guard !startAtHomeManager.shouldSkipStartHome else { return }
 
         if startAtHomeManager.shouldStartAtHome() {
-            let wasLastSessionPrivate = selectedTab?.isPrivate ?? lastSessionWasPrivate
+            let wasLastSessionPrivate = selectedTab?.isPrivate ?? false
             let scannableTabs = wasLastSessionPrivate ? privateTabs : normalTabs
             let existingHomeTab = startAtHomeManager.scanForExistingHomeTab(in: scannableTabs,
                                                                             with: profile.prefs)


### PR DESCRIPTION
#11292 

The last session being private is no longer required as the mode is dictated by the last selected tab itself (Normal or Private)

Now the app stays in the same mode as it was before. Below is a small demo for Normal mode but this is the same case for Private mode.

https://user-images.githubusercontent.com/8919439/185718545-9304a01c-23ea-4f27-a915-9b3b995feda3.mov


