### PR TITLE
Add FXIOS-7400 universal link setup for mozilla.org

### DIFF
--- a/Client/Entitlements/FennecApplication.entitlements
+++ b/Client/Entitlements/FennecApplication.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:mozilla.org</string>
+	</array>
 	<key>com.apple.developer.authentication-services.autofill-credential-provider</key>
 	<true/>
 	<key>com.apple.security.application-groups</key>

--- a/Client/Entitlements/FirefoxApplication.entitlements
+++ b/Client/Entitlements/FirefoxApplication.entitlements
@@ -2,12 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.developer.authentication-services.autofill-credential-provider</key>
-    <true/>
-    <key>com.apple.developer.web-browser</key>
-    <true/>
 	<key>aps-environment</key>
 	<string>production</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:mozilla.org</string>
+	</array>
+	<key>com.apple.developer.authentication-services.autofill-credential-provider</key>
+	<true/>
+	<key>com.apple.developer.web-browser</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.mozilla.ios.Firefox</string>

--- a/Client/Entitlements/FirefoxBetaApplication.entitlements
+++ b/Client/Entitlements/FirefoxBetaApplication.entitlements
@@ -2,12 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>production</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:mozilla.org</string>
+	</array>
 	<key>com.apple.developer.authentication-services.autofill-credential-provider</key>
 	<true/>
 	<key>com.apple.developer.web-browser</key>
 	<true/>
-	<key>aps-environment</key>
-	<string>production</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.mozilla.ios.FirefoxBeta</string>


### PR DESCRIPTION
NOTE: This is a test PR for trying out universal links and many such PRs will be merged to FXIOS-4700 branch. 