### PR TITLE
Localize FXIOS-4800 [v106] Remove obsolete strings from AppMenu

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -9,8 +9,6 @@ import Foundation
  Strings with the following IDs may be removed after confirming with Product:
  - `ActivityStream.Pocket.SectionTitle`      --> replaced by `FirefoxHome.Pocket.SectionTitle`
  - `ActivityStream.Pocket.SectionTitle2`    --> replaced by `FirefoxHome.Pocket.SectionTitle`
- - All Strings marked under "unused" in AppMenu struct
- - "HistoryPanel.ClearHistoryMenuTitle" string
  */
 
 // MARK: - Localization bundle setup
@@ -1688,11 +1686,6 @@ extension String {
 
 // MARK: - Clear recent history action menu
 extension String {
-    public static let ClearHistoryMenuTitle = MZLocalizedString(
-        "HistoryPanel.ClearHistoryMenuTitle",
-        value: "Clearing Recent History will remove history, cookies, and other browser data.",
-        comment: "Title for popup action menu to clear recent history.",
-        lastUpdated: .unknown)
     public static let ClearHistoryMenuOptionTheLastHour = MZLocalizedString(
         "HistoryPanel.ClearHistoryMenuOptionTheLastHour",
         value: "The Last Hour",
@@ -2700,12 +2693,6 @@ extension String {
             value: "Copy Link",
             comment: "Label for the button, displayed in the menu, used to copy the current page link to the clipboard.",
             lastUpdated: .unknown)
-        public static let AppMenuAddBookmarkTitleString = MZLocalizedString(
-            "Menu.AddBookmarkAction.Title",
-            tableName: "Menu",
-            value: "Bookmark This Page",
-            comment: "Label for the button, displayed in the menu, used to create a bookmark for the current website.",
-            lastUpdated: .unknown)
         public static let AppMenuFindInPageTitleString = MZLocalizedString(
             "Menu.FindInPageAction.Title",
             tableName: "Menu",
@@ -2741,12 +2728,6 @@ extension String {
             tableName: "Menu",
             value: "Homepage",
             comment: "Label for the button, displayed in the menu, used to navigate to the home page.",
-            lastUpdated: .unknown)
-        public static let AppMenuTopSitesTitleString = MZLocalizedString(
-            "Menu.OpenTopSitesAction.AccessibilityLabel",
-            tableName: "Menu",
-            value: "Top Sites",
-            comment: "Accessibility label for the button, displayed in the menu, used to open the Top Sites home panel.",
             lastUpdated: .unknown)
         public static let AppMenuBookmarksTitleString = MZLocalizedString(
             "Menu.OpenBookmarksAction.AccessibilityLabel.v2",
@@ -2980,60 +2961,6 @@ extension String {
                 comment: "Label for preview action on Tab Tray Tab to send the current link to another device",
                 lastUpdated: .unknown)
         }
-
-        // Unused
-        public static let AppMenuLibraryReloadString = MZLocalizedString(
-            "Menu.Library.Reload",
-            tableName: "Menu",
-            value: "Reload",
-            comment: "Label for the button, displayed in the menu, used to Reload the webpage",
-            lastUpdated: .unknown)
-        public static let AppMenuRecentlySavedTitle = MZLocalizedString(
-            "Menu.RecentlySaved.Title",
-            tableName: "Menu",
-            value: "Recently Saved",
-            comment: "A string used to signify the start of the Recently Saved section in Home Screen.",
-            lastUpdated: .unknown)
-        public static let AppMenuShowTabsTitleString = MZLocalizedString(
-            "Menu.ShowTabs.Title",
-            tableName: "Menu",
-            value: "Show Tabs",
-            comment: "Label for the button, displayed in the menu, used to open the tabs tray",
-            lastUpdated: .unknown)
-        public static let AppMenuCopyURLTitleString = MZLocalizedString(
-            "Menu.CopyAddress.Title",
-            tableName: "Menu",
-            value: "Copy Address",
-            comment: "Label for the button, displayed in the menu, used to copy the page url to the clipboard.",
-            lastUpdated: .unknown)
-        public static let AppMenuTranslatePageTitleString = MZLocalizedString(
-            "Menu.TranslatePageAction.Title",
-            tableName: "Menu",
-            value: "Translate Page",
-            comment: "Label for the button, displayed in the menu, used to translate the current page.",
-            lastUpdated: .unknown)
-        public static let AppMenuScanQRCodeTitleString = MZLocalizedString(
-            "Menu.ScanQRCodeAction.Title",
-            tableName: "Menu",
-            value: "Scan QR Code",
-            comment: "Label for the button, displayed in the menu, used to open the QR code scanner.",
-            lastUpdated: .unknown)
-        public static let AppMenuShowPageSourceString = MZLocalizedString(
-            "Menu.PageSourceAction.Title",
-            tableName: "Menu",
-            value: "View Page Source",
-            comment: "Label for the button, displayed in the menu, used to show the html page source",
-            lastUpdated: .unknown)
-        public static let AppMenuShowImageMode = MZLocalizedString(
-            "Menu.NoImageModeShowImages.Label",
-            value: "Show Images",
-            comment: "Label for the button, displayed in the menu, shows images on the webpage when pressed.",
-            lastUpdated: .unknown)
-        public static let StopReloadPageTitle = MZLocalizedString(
-            "Menu.Library.StopReload",
-            value: "Stop",
-            comment: "Label for the button displayed in the menu used to stop the reload of the webpage",
-            lastUpdated: .unknown)
     }
 }
 

--- a/Shared/en-US.lproj/Localizable.strings
+++ b/Shared/en-US.lproj/Localizable.strings
@@ -394,9 +394,6 @@
 /* Button to perform action to clear history for yesterday and today */
 "HistoryPanel.ClearHistoryMenuOptionTodayAndYesterday" = "Today and Yesterday";
 
-/* Title for popup action menu to clear recent history. */
-"HistoryPanel.ClearHistoryMenuTitle" = "Clearing Recent History will remove history, cookies, and other browser data.";
-
 /* Title for the History Panel empty state. */
 "HistoryPanel.EmptyState.Title" = "Websites you’ve visited recently will show up here.";
 
@@ -569,9 +566,6 @@
 
 /* Description for having strict ETP protection with ITP offered in iOS14+ */
 "Menu.EnhancedTrackingProtectionStrictWithITP.Title" = "Firefox blocks cross-site trackers, social trackers, cryptominers, fingerprinters, and tracking content.";
-
-/* Label for the button displayed in the menu used to stop the reload of the webpage */
-"Menu.Library.StopReload" = "Stop";
 
 /* The title for the button that lets you paste into the location bar */
 "Menu.Paste.Title" = "Paste";

--- a/Shared/en-US.lproj/Menu.strings
+++ b/Shared/en-US.lproj/Menu.strings
@@ -1,17 +1,8 @@
-/* Label for the button, displayed in the menu, used to create a bookmark for the current website. */
-"Menu.AddBookmarkAction.Title" = "Bookmark This Page";
-
 /* Label for the button, displayed in the menu, used to close all tabs currently open. */
 "Menu.CloseAllTabsAction.Title" = "Close All Tabs";
 
-/* Label for the button, displayed in the menu, used to copy the page url to the clipboard. */
-"Menu.CopyAddress.Title" = "Copy Address";
-
 /* Label for the button, displayed in the menu, used to open the toolbar to search for text within the current page. */
 "Menu.FindInPageAction.Title" = "Find in Page";
-
-/* Label for the button, displayed in the menu, used to Reload the webpage */
-"Menu.Library.Reload" = "Reload";
 
 /* Label for the button, displayed in the menu, used to open a new private tab. */
 "Menu.NewPrivateTabAction.Title" = "Open New Private Tab";
@@ -37,26 +28,11 @@
 /* Accessibility label for the button, displayed in the menu, used to open the Synced Tabs home panel. Please keep as short as possible, <15 chars of space available. */
 "Menu.OpenSyncedTabsAction.AccessibilityLabel.v2" = "Synced Tabs";
 
-/* Accessibility label for the button, displayed in the menu, used to open the Top Sites home panel. */
-"Menu.OpenTopSitesAction.AccessibilityLabel" = "Top Sites";
-
-/* Label for the button, displayed in the menu, used to show the html page source */
-"Menu.PageSourceAction.Title" = "View Page Source";
-
-/* Label for the button, displayed in the menu, used to open the QR code scanner. */
-"Menu.ScanQRCodeAction.Title" = "Scan QR Code";
-
 /* Label for the button, displayed in Firefox Home, used to see all Library panels. */
 "Menu.SeeAllAction.Title" = "See All";
 
 /* Label for the button, displayed in the menu, used to open the share dialog. */
 "Menu.SharePageAction.Title" = "Share Page With…";
-
-/* Label for the button, displayed in the menu, used to open the tabs tray */
-"Menu.ShowTabs.Title" = "Show Tabs";
-
-/* Label for the button, displayed in the menu, used to translate the current page. */
-"Menu.TranslatePageAction.Title" = "Translate Page";
 
 /* Label for the button, displayed in the menu, used to request the desktop version of the current website. */
 "Menu.ViewDekstopSiteAction.Title" = "Request Desktop Site";

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -394,9 +394,6 @@
 /* Button to perform action to clear history for yesterday and today */
 "HistoryPanel.ClearHistoryMenuOptionTodayAndYesterday" = "Today and Yesterday";
 
-/* Title for popup action menu to clear recent history. */
-"HistoryPanel.ClearHistoryMenuTitle" = "Clearing Recent History will remove history, cookies, and other browser data.";
-
 /* Title for the History Panel empty state. */
 "HistoryPanel.EmptyState.Title" = "Websites you’ve visited recently will show up here.";
 
@@ -569,9 +566,6 @@
 
 /* Description for having strict ETP protection with ITP offered in iOS14+ */
 "Menu.EnhancedTrackingProtectionStrictWithITP.Title" = "Firefox blocks cross-site trackers, social trackers, cryptominers, fingerprinters, and tracking content.";
-
-/* Label for the button displayed in the menu used to stop the reload of the webpage */
-"Menu.Library.StopReload" = "Stop";
 
 /* The title for the button that lets you paste into the location bar */
 "Menu.Paste.Title" = "Paste";

--- a/Shared/en.lproj/Menu.strings
+++ b/Shared/en.lproj/Menu.strings
@@ -1,17 +1,8 @@
-/* Label for the button, displayed in the menu, used to create a bookmark for the current website. */
-"Menu.AddBookmarkAction.Title" = "Bookmark This Page";
-
 /* Label for the button, displayed in the menu, used to close all tabs currently open. */
 "Menu.CloseAllTabsAction.Title" = "Close All Tabs";
 
-/* Label for the button, displayed in the menu, used to copy the page url to the clipboard. */
-"Menu.CopyAddress.Title" = "Copy Address";
-
 /* Label for the button, displayed in the menu, used to open the toolbar to search for text within the current page. */
 "Menu.FindInPageAction.Title" = "Find in Page";
-
-/* Label for the button, displayed in the menu, used to Reload the webpage */
-"Menu.Library.Reload" = "Reload";
 
 /* Label for the button, displayed in the menu, used to open a new private tab. */
 "Menu.NewPrivateTabAction.Title" = "Open New Private Tab";
@@ -37,26 +28,11 @@
 /* Accessibility label for the button, displayed in the menu, used to open the Synced Tabs home panel. Please keep as short as possible, <15 chars of space available. */
 "Menu.OpenSyncedTabsAction.AccessibilityLabel.v2" = "Synced Tabs";
 
-/* Accessibility label for the button, displayed in the menu, used to open the Top Sites home panel. */
-"Menu.OpenTopSitesAction.AccessibilityLabel" = "Top Sites";
-
-/* Label for the button, displayed in the menu, used to show the html page source */
-"Menu.PageSourceAction.Title" = "View Page Source";
-
-/* Label for the button, displayed in the menu, used to open the QR code scanner. */
-"Menu.ScanQRCodeAction.Title" = "Scan QR Code";
-
 /* Label for the button, displayed in Firefox Home, used to see all Library panels. */
 "Menu.SeeAllAction.Title" = "See All";
 
 /* Label for the button, displayed in the menu, used to open the share dialog. */
 "Menu.SharePageAction.Title" = "Share Page With…";
-
-/* Label for the button, displayed in the menu, used to open the tabs tray */
-"Menu.ShowTabs.Title" = "Show Tabs";
-
-/* Label for the button, displayed in the menu, used to translate the current page. */
-"Menu.TranslatePageAction.Title" = "Translate Page";
 
 /* Label for the button, displayed in the menu, used to request the desktop version of the current website. */
 "Menu.ViewDekstopSiteAction.Title" = "Request Desktop Site";


### PR DESCRIPTION
[FXIOS-4800](https://mozilla-hub.atlassian.net/browse/FXIOS-4800) https://github.com/mozilla-mobile/firefox-ios/issues/11665