### PR TITLE
Bugfix FXIOS-4085 [v106] Prevent type error when sanitizing content for readermode

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/ReaderMode.js
+++ b/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/ReaderMode.js
@@ -208,6 +208,7 @@ function configureReader() {
 }
 
 function escapeHTML(string) {
+  if (typeof(string) !== 'string') { return ''; }
   return string
     .replace(/\&/g, "&amp;")
     .replace(/\</g, "&lt;")


### PR DESCRIPTION
addresses https://github.com/mozilla-mobile/firefox-ios/issues/10463

Readability mode extracts simplified document content from a page. Attempting to sanitize undefined attributes (title, credits) of a document for this mode could trigger a type error, as these attributes were not guaranteed to be strings.

This patch guarantees that `escapeHTML` will return an empty string if invalid input is given.