### PR TITLE
Refactor [v106] Replace sut with subject

### DIFF
--- a/Tests/ClientTests/DownloadHelperTests.swift
+++ b/Tests/ClientTests/DownloadHelperTests.swift
@@ -12,17 +12,17 @@ class DownloadHelperTests: XCTestCase {
     func test_init_whenMIMETypeIsNil_initializeCorrectly() {
         let response = anyResponse(mimeType: nil)
 
-        var sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: true, forceDownload: false)
-        XCTAssertNotNil(sut)
+        var subject = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: true, forceDownload: false)
+        XCTAssertNotNil(subject)
 
-        sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: false, forceDownload: true)
-        XCTAssertNotNil(sut)
+        subject = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: false, forceDownload: true)
+        XCTAssertNotNil(subject)
 
-        sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: false, forceDownload: false)
-        XCTAssertNotNil(sut)
+        subject = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: false, forceDownload: false)
+        XCTAssertNotNil(subject)
 
-        sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: true, forceDownload: true)
-        XCTAssertNotNil(sut)
+        subject = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: true, forceDownload: true)
+        XCTAssertNotNil(subject)
     }
 
     func test_init_whenMIMETypeIsNotOctetStream_initializeCorrectly() {
@@ -31,58 +31,58 @@ class DownloadHelperTests: XCTestCase {
 
             let response = anyResponse(mimeType: mimeType)
 
-            var sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: true, forceDownload: false)
-            XCTAssertNil(sut)
+            var subject = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: true, forceDownload: false)
+            XCTAssertNil(subject)
 
-            sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: false, forceDownload: true)
-            XCTAssertNotNil(sut)
+            subject = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: false, forceDownload: true)
+            XCTAssertNotNil(subject)
 
-            sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: false, forceDownload: false)
-            XCTAssertNotNil(sut)
+            subject = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: false, forceDownload: false)
+            XCTAssertNotNil(subject)
 
-            sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: true, forceDownload: true)
-            XCTAssertNotNil(sut)
+            subject = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: true, forceDownload: true)
+            XCTAssertNotNil(subject)
         }
     }
 
     func test_init_whenMIMETypeIsOctetStream_initializeCorrectly() {
         let response = anyResponse(mimeType: MIMEType.OctetStream)
 
-        var sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: true, forceDownload: false)
-        XCTAssertNotNil(sut)
+        var subject = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: true, forceDownload: false)
+        XCTAssertNotNil(subject)
 
-        sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: false, forceDownload: true)
-        XCTAssertNotNil(sut)
+        subject = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: false, forceDownload: true)
+        XCTAssertNotNil(subject)
 
-        sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: true, forceDownload: true)
-        XCTAssertNotNil(sut)
+        subject = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: true, forceDownload: true)
+        XCTAssertNotNil(subject)
 
-        sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: false, forceDownload: false)
-        XCTAssertNotNil(sut)
+        subject = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: false, forceDownload: false)
+        XCTAssertNotNil(subject)
     }
 
     func test_downloadViewModel_whenRequestURLIsWrong_deliversEmptyResult() {
         let request = anyRequest(urlString: "wrong-url.com")
-        let sut = DownloadHelper(request: request, response: anyResponse(mimeType: nil), cookieStore: cookieStore(), canShowInWebView: true, forceDownload: false)
+        let subject = DownloadHelper(request: request, response: anyResponse(mimeType: nil), cookieStore: cookieStore(), canShowInWebView: true, forceDownload: false)
 
-        let downloadViewModel = sut?.downloadViewModel(okAction: { _ in })
+        let downloadViewModel = subject?.downloadViewModel(okAction: { _ in })
 
         XCTAssertNil(downloadViewModel)
     }
 
     func test_downloadViewModel_deliversCorrectTitle() {
         let response = anyResponse(urlString: "http://some-domain.com/some-image.jpg")
-        let sut = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: true, forceDownload: false)
+        let subject = DownloadHelper(request: anyRequest(), response: response, cookieStore: cookieStore(), canShowInWebView: true, forceDownload: false)
 
-        let downloadViewModel = sut?.downloadViewModel(okAction: { _ in })
+        let downloadViewModel = subject?.downloadViewModel(okAction: { _ in })
 
         XCTAssertEqual(downloadViewModel!.title!, "some-image.jpg")
     }
 
     func test_downloadViewModel_deliversCorrectCancelButtonTitle() {
-        let sut = DownloadHelper(request: anyRequest(), response: anyResponse(mimeType: nil), cookieStore: cookieStore(), canShowInWebView: true, forceDownload: false)
+        let subject = DownloadHelper(request: anyRequest(), response: anyResponse(mimeType: nil), cookieStore: cookieStore(), canShowInWebView: true, forceDownload: false)
 
-        let downloadViewModel = sut?.downloadViewModel(okAction: { _ in })
+        let downloadViewModel = subject?.downloadViewModel(okAction: { _ in })
 
         XCTAssertEqual(downloadViewModel!.closeButtonTitle, .CancelString)
     }
@@ -108,7 +108,7 @@ class DownloadHelperTests: XCTestCase {
     private func anyCachePolicy() -> URLRequest.CachePolicy {
         return .useProtocolCachePolicy
     }
-
+    
     private func allMIMETypes() -> [String] {
         return [MIMEType.Bitmap,
                 MIMEType.CSS,

--- a/Tests/ClientTests/Frontend/Browser/TopSitesHelperTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/TopSitesHelperTests.swift
@@ -13,10 +13,10 @@ class TopSitesHelperTests: XCTestCase {
     func testGetTopSites_withError_completesWithZeroSites() {
         let expectation = expectation(description: "Expect top sites to be fetched")
 
-        let sut = TopSitesProviderImplementation(browserHistoryFetcher: BrowserHistoryMock(),
-                                                 prefs: MockProfilePrefs())
+        let subject = TopSitesProviderImplementation(browserHistoryFetcher: BrowserHistoryMock(),
+                                                     prefs: MockProfilePrefs())
 
-        sut.getTopSites { sites in
+        subject.getTopSites { sites in
             guard let sites = sites else {
                 XCTFail("Has no sites")
                 return
@@ -36,10 +36,10 @@ class TopSitesHelperTests: XCTestCase {
         cursor.sites = defaultPinnedSites
         mockHistory.pinnedResponse = Maybe(success: cursor)
 
-        let sut = TopSitesProviderImplementation(browserHistoryFetcher: mockHistory,
-                                                 prefs: MockProfilePrefs())
+        let subject = TopSitesProviderImplementation(browserHistoryFetcher: mockHistory,
+                                                     prefs: MockProfilePrefs())
 
-        sut.getTopSites { sites in
+        subject.getTopSites { sites in
             guard let sites = sites else {
                 XCTFail("Has no sites")
                 return
@@ -59,10 +59,10 @@ class TopSitesHelperTests: XCTestCase {
         cursor.sites = defaultFrecencySites
         mockHistory.frecencyResponse = Maybe(success: cursor)
 
-        let sut = TopSitesProviderImplementation(browserHistoryFetcher: mockHistory,
-                                                 prefs: MockProfilePrefs())
+        let subject = TopSitesProviderImplementation(browserHistoryFetcher: mockHistory,
+                                                     prefs: MockProfilePrefs())
 
-        sut.getTopSites { sites in
+        subject.getTopSites { sites in
             guard let sites = sites else {
                 XCTFail("Has no sites")
                 return
@@ -84,10 +84,10 @@ class TopSitesHelperTests: XCTestCase {
         cursor.sites = sites
         mockHistory.frecencyResponse = Maybe(success: cursor)
 
-        let sut = TopSitesProviderImplementation(browserHistoryFetcher: mockHistory,
-                                                 prefs: MockProfilePrefs())
+        let subject = TopSitesProviderImplementation(browserHistoryFetcher: mockHistory,
+                                                     prefs: MockProfilePrefs())
 
-        sut.getTopSites { sites in
+        subject.getTopSites { sites in
             guard let sites = sites else {
                 XCTFail("Has no sites")
                 return
@@ -108,10 +108,10 @@ class TopSitesHelperTests: XCTestCase {
         cursor.sites = sites
         mockHistory.frecencyResponse = Maybe(success: cursor)
 
-        let sut = TopSitesProviderImplementation(browserHistoryFetcher: mockHistory,
-                                                 prefs: MockProfilePrefs())
+        let subject = TopSitesProviderImplementation(browserHistoryFetcher: mockHistory,
+                                                     prefs: MockProfilePrefs())
 
-        sut.getTopSites { sites in
+        subject.getTopSites { sites in
             guard let sites = sites else {
                 XCTFail("Has no sites")
                 return
@@ -131,10 +131,10 @@ class TopSitesHelperTests: XCTestCase {
         cursor.sites = [Site(url: "https://facebook.com", title: "Facebook")]
         mockHistory.frecencyResponse = Maybe(success: cursor)
 
-        let sut = TopSitesProviderImplementation(browserHistoryFetcher: mockHistory,
-                                                 prefs: MockProfilePrefs())
+        let subject = TopSitesProviderImplementation(browserHistoryFetcher: mockHistory,
+                                                     prefs: MockProfilePrefs())
 
-        sut.getTopSites { sites in
+        subject.getTopSites { sites in
             guard let sites = sites else {
                 XCTFail("Has no sites")
                 return
@@ -154,10 +154,10 @@ class TopSitesHelperTests: XCTestCase {
         cursor.sites = [PinnedSite(site: Site(url: "https://facebook.com", title: "Facebook"))]
         mockHistory.pinnedResponse = Maybe(success: cursor)
 
-        let sut = TopSitesProviderImplementation(browserHistoryFetcher: mockHistory,
-                                                 prefs: MockProfilePrefs())
+        let subject = TopSitesProviderImplementation(browserHistoryFetcher: mockHistory,
+                                                     prefs: MockProfilePrefs())
 
-        sut.getTopSites { sites in
+        subject.getTopSites { sites in
             guard let sites = sites else {
                 XCTFail("Has no sites")
                 return

--- a/Tests/ClientTests/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModelTests.swift
@@ -8,7 +8,7 @@ import MozillaAppServices
 
 class HistoryHighlightsViewModelTests: XCTestCase {
 
-    private var sut: HistoryHighlightsViewModel!
+    private var subject: HistoryHighlightsViewModel!
     private var profile: MockProfile!
     private var tabManager: MockTabManager!
     private var dataAdaptor: MockHistoryHighlightsDataAdaptor!
@@ -34,7 +34,7 @@ class HistoryHighlightsViewModelTests: XCTestCase {
         profile = nil
         tabManager = nil
         dataAdaptor = nil
-        sut = nil
+        subject = nil
         delegate = nil
         telemetry = nil
         urlBar = nil
@@ -44,9 +44,9 @@ class HistoryHighlightsViewModelTests: XCTestCase {
         setupSubject()
         dataAdaptor.mockHistoryItems = [getItemWithTitle(title: "mozilla")]
 
-        sut.didLoadNewData()
+        subject.didLoadNewData()
 
-        XCTAssertEqual(sut.getItemDetailsAt(index: 0)?.displayTitle, "mozilla")
+        XCTAssertEqual(subject.getItemDetailsAt(index: 0)?.displayTitle, "mozilla")
         XCTAssertEqual(delegate.reloadViewCallCount, 1)
     }
 
@@ -54,9 +54,9 @@ class HistoryHighlightsViewModelTests: XCTestCase {
         setupSubject(isPrivate: true)
         dataAdaptor.mockHistoryItems = [getItemWithTitle(title: "mozilla")]
 
-        sut.didLoadNewData()
+        subject.didLoadNewData()
 
-        XCTAssertEqual(sut.getItemDetailsAt(index: 0)?.displayTitle, "mozilla")
+        XCTAssertEqual(subject.getItemDetailsAt(index: 0)?.displayTitle, "mozilla")
         XCTAssertEqual(delegate.reloadViewCallCount, 0)
     }
 
@@ -66,10 +66,10 @@ class HistoryHighlightsViewModelTests: XCTestCase {
                                         getItemWithTitle(title: "two"),
                                         getItemWithTitle(title: "three")]
 
-        sut.didLoadNewData()
+        subject.didLoadNewData()
 
-        XCTAssertEqual(sut.numberOfColumns, 1)
-        XCTAssertEqual(sut.numberOfRows, 3)
+        XCTAssertEqual(subject.numberOfColumns, 1)
+        XCTAssertEqual(subject.numberOfRows, 3)
     }
 
     func testTwoColumns() {
@@ -79,10 +79,10 @@ class HistoryHighlightsViewModelTests: XCTestCase {
                                         getItemWithTitle(title: "three"),
                                         getItemWithTitle(title: "four")]
 
-        sut.didLoadNewData()
+        subject.didLoadNewData()
 
-        XCTAssertEqual(sut.numberOfColumns, 2)
-        XCTAssertEqual(sut.numberOfRows, 3)
+        XCTAssertEqual(subject.numberOfColumns, 2)
+        XCTAssertEqual(subject.numberOfRows, 3)
     }
 
     func testThreeColumns() {
@@ -95,16 +95,16 @@ class HistoryHighlightsViewModelTests: XCTestCase {
                                         getItemWithTitle(title: "six"),
                                         getItemWithTitle(title: "seven")]
 
-        sut.didLoadNewData()
+        subject.didLoadNewData()
 
-        XCTAssertEqual(sut.numberOfColumns, 3)
-        XCTAssertEqual(sut.numberOfRows, 3)
+        XCTAssertEqual(subject.numberOfColumns, 3)
+        XCTAssertEqual(subject.numberOfRows, 3)
     }
 
     func testRecordSectionHasShown() {
         setupSubject()
 
-        sut.recordSectionHasShown()
+        subject.recordSectionHasShown()
 
         XCTAssertEqual(telemetry.recordEventCallCount, 1)
         XCTAssertTrue(telemetry.recordedCategories.contains(.action))
@@ -115,8 +115,8 @@ class HistoryHighlightsViewModelTests: XCTestCase {
     func testRecordSectionHasShownOnlyOnce() {
         setupSubject()
 
-        sut.recordSectionHasShown()
-        sut.recordSectionHasShown()
+        subject.recordSectionHasShown()
+        subject.recordSectionHasShown()
 
         XCTAssertEqual(telemetry.recordEventCallCount, 1)
         XCTAssertTrue(telemetry.recordedCategories.contains(.action))
@@ -128,7 +128,7 @@ class HistoryHighlightsViewModelTests: XCTestCase {
         setupSubject()
         urlBar.inOverlayMode = true
 
-        sut.switchTo(getItemWithTitle(title: "item"))
+        subject.switchTo(getItemWithTitle(title: "item"))
 
         XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 1)
         XCTAssertEqual(telemetry.recordEventCallCount, 1)
@@ -139,7 +139,7 @@ class HistoryHighlightsViewModelTests: XCTestCase {
 
     func testDelete() {
         setupSubject()
-        sut.delete(getItemWithTitle(title: "to-delete"))
+        subject.delete(getItemWithTitle(title: "to-delete"))
 
         XCTAssertEqual(dataAdaptor.deleteCallCount, 1)
     }
@@ -148,9 +148,9 @@ class HistoryHighlightsViewModelTests: XCTestCase {
         setupSubject()
         dataAdaptor.mockHistoryItems = [getItemWithTitle(title: "one"),
                                         getItemWithTitle(title: "two")]
-        sut.didLoadNewData()
+        subject.didLoadNewData()
 
-        XCTAssertEqual(sut.numberOfItemsInSection(), 2)
+        XCTAssertEqual(subject.numberOfItemsInSection(), 2)
     }
 
     func testNumberOfItemsInSection2Column() {
@@ -159,9 +159,9 @@ class HistoryHighlightsViewModelTests: XCTestCase {
                                         getItemWithTitle(title: "two"),
                                         getItemWithTitle(title: "three"),
                                         getItemWithTitle(title: "four")]
-        sut.didLoadNewData()
+        subject.didLoadNewData()
 
-        XCTAssertEqual(sut.numberOfItemsInSection(), 6)
+        XCTAssertEqual(subject.numberOfItemsInSection(), 6)
     }
 
     func testNumberOfItemsInSection3Column() {
@@ -173,9 +173,9 @@ class HistoryHighlightsViewModelTests: XCTestCase {
                                         getItemWithTitle(title: "five"),
                                         getItemWithTitle(title: "six"),
                                         getItemWithTitle(title: "seven")]
-        sut.didLoadNewData()
+        subject.didLoadNewData()
 
-        XCTAssertEqual(sut.numberOfItemsInSection(), 9)
+        XCTAssertEqual(subject.numberOfItemsInSection(), 9)
     }
 
     func testConfigureFillerCell() {
@@ -184,8 +184,8 @@ class HistoryHighlightsViewModelTests: XCTestCase {
                                         getItemWithTitle(title: "two"),
                                         getItemWithTitle(title: "three"),
                                         getItemWithTitle(title: "four")]
-        sut.didLoadNewData()
-        let cell = sut.configure(HistoryHighlightsCell(), at: IndexPath(row: 5, section: 0)) as? HistoryHighlightsCell
+        subject.didLoadNewData()
+        let cell = subject.configure(HistoryHighlightsCell(), at: IndexPath(row: 5, section: 0)) as? HistoryHighlightsCell
 
         XCTAssertNotNil(cell)
         XCTAssertTrue(cell!.isFillerCell)
@@ -194,8 +194,8 @@ class HistoryHighlightsViewModelTests: XCTestCase {
     func testConfigureIndividualCell() {
         setupSubject()
         dataAdaptor.mockHistoryItems = [getItemWithTitle(title: "one")]
-        sut.didLoadNewData()
-        let cell = sut.configure(HistoryHighlightsCell(), at: IndexPath(row: 0, section: 0)) as? HistoryHighlightsCell
+        subject.didLoadNewData()
+        let cell = subject.configure(HistoryHighlightsCell(), at: IndexPath(row: 0, section: 0)) as? HistoryHighlightsCell
 
         XCTAssertNotNil(cell)
         XCTAssertFalse(cell!.isFillerCell)
@@ -208,8 +208,8 @@ class HistoryHighlightsViewModelTests: XCTestCase {
                            timestamp: 0)
 
         dataAdaptor.mockHistoryItems = [item]
-        sut.didLoadNewData()
-        let cell = sut.configure(HistoryHighlightsCell(), at: IndexPath(row: 0, section: 0)) as? HistoryHighlightsCell
+        subject.didLoadNewData()
+        let cell = subject.configure(HistoryHighlightsCell(), at: IndexPath(row: 0, section: 0)) as? HistoryHighlightsCell
 
         XCTAssertNotNil(cell)
         XCTAssertFalse(cell!.isFillerCell)
@@ -220,10 +220,10 @@ class HistoryHighlightsViewModelTests: XCTestCase {
     func testDidSelectItem() {
         setupSubject()
         dataAdaptor.mockHistoryItems = [getItemWithTitle(title: "one")]
-        sut.didLoadNewData()
-        sut.didSelectItem(at: IndexPath(row: 0, section: 0),
-                          homePanelDelegate: nil,
-                          libraryPanelDelegate: nil)
+        subject.didLoadNewData()
+        subject.didSelectItem(at: IndexPath(row: 0, section: 0),
+                              homePanelDelegate: nil,
+                              libraryPanelDelegate: nil)
 
         XCTAssertEqual(telemetry.recordEventCallCount, 1)
         XCTAssertTrue(telemetry.recordedCategories.contains(.action))
@@ -234,7 +234,7 @@ class HistoryHighlightsViewModelTests: XCTestCase {
     // MARK: - Helper methods
 
     private func setupSubject(isPrivate: Bool = false) {
-        sut = HistoryHighlightsViewModel(
+        subject = HistoryHighlightsViewModel(
             with: profile,
             isPrivate: isPrivate,
             tabManager: tabManager,
@@ -242,7 +242,7 @@ class HistoryHighlightsViewModelTests: XCTestCase {
             historyHighlightsDataAdaptor: dataAdaptor,
             dispatchQueue: MockDispatchQueue(),
             telemetry: telemetry)
-        sut.delegate = delegate
+        subject.delegate = delegate
     }
 
     private func getItemWithTitle(title: String) -> HighlightItem {

--- a/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
+++ b/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
@@ -32,9 +32,9 @@ class JumpBackInDataAdaptorTests: XCTestCase {
 
     func testEmptyData_tabTrayGroupsDisabled() {
         FeatureFlagsManager.shared.set(feature: .tabTrayGroups, to: false)
-        let sut = createSut()
-        let jumpBackIn = sut.getJumpBackInData()
-        let synced = sut.getSyncedTabData()
+        let subject = createSubject()
+        let jumpBackIn = subject.getJumpBackInData()
+        let synced = subject.getSyncedTabData()
 
         XCTAssertEqual(jumpBackIn.itemsToDisplay, 0)
         XCTAssertNil(synced)
@@ -48,10 +48,10 @@ class JumpBackInDataAdaptorTests: XCTestCase {
         let tab3 = createTab(profile: mockProfile, urlString: "www.firefox3.com")
         mockTabManager.nextRecentlyAccessedNormalTabs = [tab1, tab2, tab3]
 
-        let sut = createSut()
-        sut.refreshData(maxItemToDisplay: 2)
+        let subject = createSubject()
+        subject.refreshData(maxItemToDisplay: 2)
 
-        let jumpBackIn = sut.getJumpBackInData()
+        let jumpBackIn = subject.getJumpBackInData()
         XCTAssertEqual(jumpBackIn.tabs.count, 2, "iPhone portrait has 2 tabs in it's jumpbackin layout")
         XCTAssertEqual(jumpBackIn.tabs[0], tab1)
         XCTAssertEqual(jumpBackIn.tabs[1], tab2)
@@ -64,10 +64,10 @@ class JumpBackInDataAdaptorTests: XCTestCase {
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         mockTabManager.nextRecentlyAccessedNormalTabs = [tab1]
 
-        let sut = createSut()
-        sut.refreshData(maxItemToDisplay: 2)
+        let subject = createSubject()
+        subject.refreshData(maxItemToDisplay: 2)
 
-        let jumpBackIn = sut.getJumpBackInData()
+        let jumpBackIn = subject.getJumpBackInData()
         XCTAssertEqual(jumpBackIn.tabs.count, 1, "With a max of 2 items, only shows 1 item when only 1 is available")
         XCTAssertEqual(jumpBackIn.tabs[0], tab1)
     }
@@ -81,16 +81,16 @@ class JumpBackInDataAdaptorTests: XCTestCase {
         let tab3 = createTab(profile: mockProfile, urlString: "www.firefox3.com")
         mockTabManager.nextRecentlyAccessedNormalTabs = [tab1, tab2, tab3]
 
-        let sut = createSut()
-        sut.refreshData(maxItemToDisplay: 1)
+        let subject = createSubject()
+        subject.refreshData(maxItemToDisplay: 1)
 
-        let jumpBackIn = sut.getJumpBackInData()
+        let jumpBackIn = subject.getJumpBackInData()
         XCTAssertEqual(jumpBackIn.tabs.count, 1, "iPhone portrait has 1 tab in it's jumpbackin layout")
         XCTAssertEqual(jumpBackIn.tabs[0], tab1)
         XCTAssertFalse(jumpBackIn.tabs.contains(tab2))
         XCTAssertFalse(jumpBackIn.tabs.contains(tab3))
 
-        let syncTab = sut.getSyncedTabData()
+        let syncTab = subject.getSyncedTabData()
         XCTAssertNotNil(syncTab, "iPhone portrait will show 1 sync tab")
     }
 
@@ -101,16 +101,16 @@ class JumpBackInDataAdaptorTests: XCTestCase {
         let tab3 = createTab(profile: mockProfile, urlString: "www.firefox3.com")
         mockTabManager.nextRecentlyAccessedNormalTabs = [tab1, tab2, tab3]
 
-        let sut = createSut()
-        sut.refreshData(maxItemToDisplay: 4)
+        let subject = createSubject()
+        subject.refreshData(maxItemToDisplay: 4)
 
-        let jumpBackIn = sut.getJumpBackInData()
+        let jumpBackIn = subject.getJumpBackInData()
         XCTAssertEqual(jumpBackIn.tabs.count, 3, "iPhone landscape has 3 tabs in it's jumpbackin layout, up until 4")
         XCTAssertEqual(jumpBackIn.tabs[0], tab1)
         XCTAssertEqual(jumpBackIn.tabs[1], tab2)
         XCTAssertEqual(jumpBackIn.tabs[2], tab3)
 
-        let syncTab = sut.getSyncedTabData()
+        let syncTab = subject.getSyncedTabData()
         XCTAssertNil(syncTab)
     }
 
@@ -123,24 +123,24 @@ class JumpBackInDataAdaptorTests: XCTestCase {
         mockProfile.mockClientAndTabs = [ClientAndTabs(client: remoteDesktopClient(),
                                                        tabs: remoteTabs(idRange: 1...3))]
 
-        let sut = createSut()
-        sut.refreshData(maxItemToDisplay: 2)
+        let subject = createSubject()
+        subject.refreshData(maxItemToDisplay: 2)
 
-        let jumpBackIn = sut.getJumpBackInData()
+        let jumpBackIn = subject.getJumpBackInData()
         XCTAssertEqual(jumpBackIn.tabs.count, 2, "iPhone landscape has 2 tabs in it's jumpbackin layout, up until 2")
         XCTAssertEqual(jumpBackIn.tabs[0], tab1)
         XCTAssertEqual(jumpBackIn.tabs[1], tab2)
         XCTAssertFalse(jumpBackIn.tabs.contains(tab3))
 
-        let syncTab = sut.getSyncedTabData()
+        let syncTab = subject.getSyncedTabData()
         XCTAssertNotNil(syncTab, "iPhone landscape will show 1 sync tab")
     }
 
     func testSyncTab_whenNoSyncTabsData_notReturned() {
         FeatureFlagsManager.shared.set(feature: .tabTrayGroups, to: false)
-        let sut = createSut()
+        let subject = createSubject()
 
-        let syncTab = sut.getSyncedTabData()
+        let syncTab = subject.getSyncedTabData()
         XCTAssertNil(syncTab, "No sync tab since there's no remote tabs")
     }
 
@@ -150,9 +150,9 @@ class JumpBackInDataAdaptorTests: XCTestCase {
         mockProfile.mockClientAndTabs = [ClientAndTabs(client: remoteDesktopClient(),
                                                        tabs: remoteTabs(idRange: 1...3))]
         FeatureFlagsManager.shared.set(feature: .tabTrayGroups, to: false)
-        let sut = createSut()
+        let subject = createSubject()
 
-        let syncTab = sut.getSyncedTabData()
+        let syncTab = subject.getSyncedTabData()
         XCTAssertNil(syncTab, "No sync tab since hasSyncableAccount is off")
     }
 
@@ -160,9 +160,9 @@ class JumpBackInDataAdaptorTests: XCTestCase {
         FeatureFlagsManager.shared.set(feature: .tabTrayGroups, to: false)
         mockProfile.hasSyncableAccountMock = false
         mockProfile.mockClientAndTabs = [ClientAndTabs(client: remoteClient, tabs: remoteTabs(idRange: 1...2))]
-        let sut = createSut()
+        let subject = createSubject()
 
-        let syncTab = sut.getSyncedTabData()
+        let syncTab = subject.getSyncedTabData()
         XCTAssertNil(syncTab, "No sync tab since there's no desktop client")
     }
 
@@ -172,9 +172,9 @@ class JumpBackInDataAdaptorTests: XCTestCase {
         let remoteTabs = remoteTabs(idRange: 1...3)
         mockProfile.mockClientAndTabs = [ClientAndTabs(client: remoteClient, tabs: remoteTabs)]
 
-        let sut = createSut()
+        let subject = createSubject()
 
-        let syncTab = sut.getSyncedTabData()
+        let syncTab = subject.getSyncedTabData()
         XCTAssertEqual(syncTab?.client.name, remoteClient.name)
         XCTAssertEqual(syncTab?.tab.title, remoteTabs.last?.title)
         XCTAssertEqual(syncTab?.tab.URL, remoteTabs.last?.URL)
@@ -185,11 +185,11 @@ class JumpBackInDataAdaptorTests: XCTestCase {
         let remoteClient = remoteDesktopClient(name: "Fake Client 2")
         let remoteClientTabs = remoteTabs(idRange: 7...9)
         mockProfile.mockClientAndTabs = [ClientAndTabs(client: remoteDesktopClient(), tabs: remoteTabs(idRange: 1...5)),
-                                     ClientAndTabs(client: remoteClient, tabs: remoteClientTabs)]
+                                         ClientAndTabs(client: remoteClient, tabs: remoteClientTabs)]
 
-        let sut = createSut()
+        let subject = createSubject()
 
-        let syncTab = sut.getSyncedTabData()
+        let syncTab = subject.getSyncedTabData()
         XCTAssertEqual(syncTab?.client.name, remoteClient.name)
         XCTAssertEqual(syncTab?.tab.title, remoteClientTabs.last?.title)
         XCTAssertEqual(syncTab?.tab.URL, remoteClientTabs.last?.URL)
@@ -199,26 +199,26 @@ class JumpBackInDataAdaptorTests: XCTestCase {
 // MARK: Helpers
 extension JumpBackInDataAdaptorTests {
 
-    func createSut(file: StaticString = #file, line: UInt = #line) -> JumpBackInDataAdaptorImplementation {
+    func createSubject(file: StaticString = #file, line: UInt = #line) -> JumpBackInDataAdaptorImplementation {
         let dispatchGroup = MockDispatchGroup()
         let dispatchQueue = MockDispatchQueue()
         let siteImageHelper = SiteImageHelperMock()
         let notificationCenter = SpyNotificationCenter()
 
-        let sut = JumpBackInDataAdaptorImplementation(profile: mockProfile,
-                                                      tabManager: mockTabManager,
-                                                      siteImageHelper: siteImageHelper,
-                                                      dispatchGroup: dispatchGroup,
-                                                      mainQueue: dispatchQueue,
-                                                      userInteractiveQueue: dispatchQueue,
-                                                      notificationCenter: notificationCenter)
+        let subject = JumpBackInDataAdaptorImplementation(profile: mockProfile,
+                                                          tabManager: mockTabManager,
+                                                          siteImageHelper: siteImageHelper,
+                                                          dispatchGroup: dispatchGroup,
+                                                          mainQueue: dispatchQueue,
+                                                          userInteractiveQueue: dispatchQueue,
+                                                          notificationCenter: notificationCenter)
 
-        trackForMemoryLeaks(sut, file: file, line: line)
+        trackForMemoryLeaks(subject, file: file, line: line)
         trackForMemoryLeaks(siteImageHelper, file: file, line: line)
         trackForMemoryLeaks(dispatchGroup, file: file, line: line)
         trackForMemoryLeaks(dispatchQueue, file: file, line: line)
 
-        return sut
+        return subject
     }
 
     func createTab(profile: MockProfile,

--- a/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -44,14 +44,14 @@ class JumpBackInViewModelTests: XCTestCase {
     // MARK: - Switch to group
 
     func test_switchToGroup_noBrowserDelegate_doNothing() {
-        let sut = createSut(addDelegate: false)
+        let subject = createSubject(addDelegate: false)
         let group = ASGroup<Tab>(searchTerm: "", groupedItems: [], timestamp: 0)
         var completionDidRun = false
-        sut.onTapGroup = { tab in
+        subject.onTapGroup = { tab in
             completionDidRun = true
         }
 
-        sut.switchTo(group: group)
+        subject.switchTo(group: group)
 
         XCTAssertFalse(mockBrowserBarViewDelegate.inOverlayMode)
         XCTAssertEqual(mockBrowserBarViewDelegate.leaveOverlayModeCount, 0)
@@ -59,15 +59,15 @@ class JumpBackInViewModelTests: XCTestCase {
     }
 
     func test_switchToGroup_noGroupedItems_doNothing() {
-        let sut = createSut()
+        let subject = createSubject()
         let group = ASGroup<Tab>(searchTerm: "", groupedItems: [], timestamp: 0)
         mockBrowserBarViewDelegate.inOverlayMode = true
         var completionDidRun = false
-        sut.onTapGroup = { tab in
+        subject.onTapGroup = { tab in
             completionDidRun = true
         }
 
-        sut.switchTo(group: group)
+        subject.switchTo(group: group)
 
         XCTAssertTrue(mockBrowserBarViewDelegate.inOverlayMode)
         XCTAssertEqual(mockBrowserBarViewDelegate.leaveOverlayModeCount, 1)
@@ -75,15 +75,15 @@ class JumpBackInViewModelTests: XCTestCase {
     }
 
     func test_switchToGroup_inOverlayMode_leavesOverlayMode() {
-        let sut = createSut()
+        let subject = createSubject()
         let group = ASGroup<Tab>(searchTerm: "", groupedItems: [], timestamp: 0)
         mockBrowserBarViewDelegate.inOverlayMode = true
         var completionDidRun = false
-        sut.onTapGroup = { tab in
+        subject.onTapGroup = { tab in
             completionDidRun = true
         }
 
-        sut.switchTo(group: group)
+        subject.switchTo(group: group)
 
         XCTAssertTrue(mockBrowserBarViewDelegate.inOverlayMode)
         XCTAssertEqual(mockBrowserBarViewDelegate.leaveOverlayModeCount, 1)
@@ -91,16 +91,16 @@ class JumpBackInViewModelTests: XCTestCase {
     }
 
     func test_switchToGroup_callCompletionOnFirstGroupedItem() {
-        let sut = createSut()
+        let subject = createSubject()
         let expectedTab = createTab(profile: mockProfile)
         let group = ASGroup<Tab>(searchTerm: "", groupedItems: [expectedTab], timestamp: 0)
         mockBrowserBarViewDelegate.inOverlayMode = true
         var receivedTab: Tab?
-        sut.onTapGroup = { tab in
+        subject.onTapGroup = { tab in
             receivedTab = tab
         }
 
-        sut.switchTo(group: group)
+        subject.switchTo(group: group)
 
         XCTAssertTrue(mockBrowserBarViewDelegate.inOverlayMode)
         XCTAssertEqual(expectedTab, receivedTab)
@@ -109,11 +109,11 @@ class JumpBackInViewModelTests: XCTestCase {
     // MARK: - Switch to tab
 
     func test_switchToTab_noBrowserDelegate_doNothing() {
-        let sut = createSut()
+        let subject = createSubject()
         let expectedTab = createTab(profile: mockProfile)
-        sut.browserBarViewDelegate = nil
+        subject.browserBarViewDelegate = nil
 
-        sut.switchTo(tab: expectedTab)
+        subject.switchTo(tab: expectedTab)
 
         XCTAssertFalse(mockBrowserBarViewDelegate.inOverlayMode)
         XCTAssertEqual(mockBrowserBarViewDelegate.leaveOverlayModeCount, 0)
@@ -121,11 +121,11 @@ class JumpBackInViewModelTests: XCTestCase {
     }
 
     func test_switchToTab_notInOverlayMode_switchTabs() {
-        let sut = createSut()
+        let subject = createSubject()
         let tab = createTab(profile: mockProfile)
         mockBrowserBarViewDelegate.inOverlayMode = false
 
-        sut.switchTo(tab: tab)
+        subject.switchTo(tab: tab)
 
         XCTAssertFalse(mockBrowserBarViewDelegate.inOverlayMode)
         XCTAssertEqual(mockBrowserBarViewDelegate.leaveOverlayModeCount, 0)
@@ -133,11 +133,11 @@ class JumpBackInViewModelTests: XCTestCase {
     }
 
     func test_switchToTab_inOverlayMode_leaveOverlayMode() {
-        let sut = createSut()
+        let subject = createSubject()
         let tab = createTab(profile: mockProfile)
         mockBrowserBarViewDelegate.inOverlayMode = true
 
-        sut.switchTo(tab: tab)
+        subject.switchTo(tab: tab)
 
         XCTAssertTrue(mockBrowserBarViewDelegate.inOverlayMode)
         XCTAssertEqual(mockBrowserBarViewDelegate.leaveOverlayModeCount, 1)
@@ -145,11 +145,11 @@ class JumpBackInViewModelTests: XCTestCase {
     }
 
     func test_switchToTab_tabManagerSelectsTab() {
-        let sut = createSut()
+        let subject = createSubject()
         let tab1 = createTab(profile: mockProfile)
         mockBrowserBarViewDelegate.inOverlayMode = true
 
-        sut.switchTo(tab: tab1)
+        subject.switchTo(tab: tab1)
 
         XCTAssertTrue(mockBrowserBarViewDelegate.inOverlayMode)
         guard !mockTabManager.lastSelectedTabs.isEmpty else {
@@ -162,40 +162,40 @@ class JumpBackInViewModelTests: XCTestCase {
     // MARK: - Jump back in layout
 
     func testMaxJumpBackInItemsToDisplay_compactJumpBackIn() {
-        let sut = createSut()
+        let subject = createSubject()
 
         // iPhone layout
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .compact
         trait.overridenVerticalSizeClass = .regular
 
-        sut.refreshData(for: trait, isPortrait: true, device: .phone)
-        let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
-                                                                     hasAccount: false,
-                                                                     device: .phone)
+        subject.refreshData(for: trait, isPortrait: true, device: .phone)
+        let jumpBackInItemsMax = subject.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
+                                                                         hasAccount: false,
+                                                                         device: .phone)
         XCTAssertEqual(jumpBackInItemsMax, 2)
-        XCTAssertEqual(sut.sectionLayout, .compactJumpBackIn)
+        XCTAssertEqual(subject.sectionLayout, .compactJumpBackIn)
     }
 
     func testMaxJumpBackInItemsToDisplay_compactSyncedTab() {
-        let sut = createSut()
-        sut.featureFlags.set(feature: .jumpBackInSyncedTab, to: true)
+        let subject = createSubject()
+        subject.featureFlags.set(feature: .jumpBackInSyncedTab, to: true)
         adaptor.syncedTab = JumpBackInSyncedTab(client: remoteClient, tab: remoteTab)
 
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .compact
         trait.overridenVerticalSizeClass = .regular
-        sut.refreshData(for: trait, isPortrait: false, device: .pad)
-        let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
-                                                                     hasAccount: true,
-                                                                     device: .pad)
+        subject.refreshData(for: trait, isPortrait: false, device: .pad)
+        let jumpBackInItemsMax = subject.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
+                                                                         hasAccount: true,
+                                                                         device: .pad)
         XCTAssertEqual(jumpBackInItemsMax, 0)
-        XCTAssertEqual(sut.sectionLayout, .compactSyncedTab)
+        XCTAssertEqual(subject.sectionLayout, .compactSyncedTab)
     }
 
     func testMaxJumpBackInItemsToDisplay_compactJumpBackInAndSyncedTab() {
-        let sut = createSut()
-        sut.featureFlags.set(feature: .jumpBackInSyncedTab, to: true)
+        let subject = createSubject()
+        subject.featureFlags.set(feature: .jumpBackInSyncedTab, to: true)
         adaptor.syncedTab = JumpBackInSyncedTab(client: remoteClient, tab: remoteTab)
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
@@ -203,16 +203,16 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .compact
         trait.overridenVerticalSizeClass = .regular
-        sut.refreshData(for: trait, isPortrait: false, device: .pad)
-        let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
-                                                                     hasAccount: true,
-                                                                     device: .pad)
+        subject.refreshData(for: trait, isPortrait: false, device: .pad)
+        let jumpBackInItemsMax = subject.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
+                                                                         hasAccount: true,
+                                                                         device: .pad)
         XCTAssertEqual(jumpBackInItemsMax, 1)
-        XCTAssertEqual(sut.sectionLayout, .compactJumpBackInAndSyncedTab)
+        XCTAssertEqual(subject.sectionLayout, .compactJumpBackInAndSyncedTab)
     }
 
     func testMaxJumpBackInItemsToDisplay_regularIphone() {
-        let sut = createSut()
+        let subject = createSubject()
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
         adaptor.mockHasSyncedTabFeatureEnabled = false
@@ -220,16 +220,16 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
-        sut.refreshData(for: trait, isPortrait: true, device: .phone)
-        let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
-                                                                     hasAccount: true,
-                                                                     device: .phone)
+        subject.refreshData(for: trait, isPortrait: true, device: .phone)
+        let jumpBackInItemsMax = subject.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
+                                                                         hasAccount: true,
+                                                                         device: .phone)
         XCTAssertEqual(jumpBackInItemsMax, 4)
-        XCTAssertEqual(sut.sectionLayout, .regular)
+        XCTAssertEqual(subject.sectionLayout, .regular)
     }
 
     func testMaxJumpBackInItemsToDisplay_regularIpad() {
-        let sut = createSut()
+        let subject = createSubject()
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
         adaptor.mockHasSyncedTabFeatureEnabled = false
@@ -237,16 +237,16 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
-        sut.refreshData(for: trait, isPortrait: true, device: .pad)
-        let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
-                                                                     hasAccount: true,
-                                                                     device: .pad)
+        subject.refreshData(for: trait, isPortrait: true, device: .pad)
+        let jumpBackInItemsMax = subject.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
+                                                                         hasAccount: true,
+                                                                         device: .pad)
         XCTAssertEqual(jumpBackInItemsMax, 6)
-        XCTAssertEqual(sut.sectionLayout, .regular)
+        XCTAssertEqual(subject.sectionLayout, .regular)
     }
 
     func testMaxJumpBackInItemsToDisplay_regularWithSyncedTabIphone() {
-        let sut = createSut()
+        let subject = createSubject()
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
         adaptor.syncedTab = JumpBackInSyncedTab(client: remoteClient, tab: remoteTab)
@@ -254,16 +254,16 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
-        sut.refreshData(for: trait, isPortrait: true, device: .phone)
-        let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
-                                                                     hasAccount: true,
-                                                                     device: .phone)
+        subject.refreshData(for: trait, isPortrait: true, device: .phone)
+        let jumpBackInItemsMax = subject.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
+                                                                         hasAccount: true,
+                                                                         device: .phone)
         XCTAssertEqual(jumpBackInItemsMax, 2)
-        XCTAssertEqual(sut.sectionLayout, .regularWithSyncedTab)
+        XCTAssertEqual(subject.sectionLayout, .regularWithSyncedTab)
     }
 
     func testMaxJumpBackInItemsToDisplay_regularWithSyncedTabIpad() {
-        let sut = createSut()
+        let subject = createSubject()
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
         adaptor.syncedTab = JumpBackInSyncedTab(client: remoteClient, tab: remoteTab)
@@ -271,48 +271,48 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
-        sut.refreshData(for: trait, isPortrait: true, device: .pad)
-        let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
-                                                                     hasAccount: true,
-                                                                     device: .pad)
+        subject.refreshData(for: trait, isPortrait: true, device: .pad)
+        let jumpBackInItemsMax = subject.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
+                                                                         hasAccount: true,
+                                                                         device: .pad)
         XCTAssertEqual(jumpBackInItemsMax, 4)
-        XCTAssertEqual(sut.sectionLayout, .regularWithSyncedTab)
+        XCTAssertEqual(subject.sectionLayout, .regularWithSyncedTab)
     }
 
     func testMaxJumpBackInItemsToDisplay_regularWithSyncedTabIphone_hasNoSyncedTabFallsIntoRegularLayout() {
-        let sut = createSut()
+        let subject = createSubject()
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
 
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
-        sut.refreshData(for: trait, isPortrait: true, device: .phone)
-        let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
-                                                                     hasAccount: true,
-                                                                     device: .phone)
+        subject.refreshData(for: trait, isPortrait: true, device: .phone)
+        let jumpBackInItemsMax = subject.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
+                                                                         hasAccount: true,
+                                                                         device: .phone)
         XCTAssertEqual(jumpBackInItemsMax, 4)
-        XCTAssertEqual(sut.sectionLayout, .regular)
+        XCTAssertEqual(subject.sectionLayout, .regular)
     }
 
     func testMaxJumpBackInItemsToDisplay_regularWithSyncedTabIpad_hasNoSyncedTabFallsIntoRegularLayout() {
-        let sut = createSut()
+        let subject = createSubject()
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
 
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
-        sut.refreshData(for: trait, isPortrait: true, device: .pad)
-        let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
-                                                                     hasAccount: true,
-                                                                     device: .pad)
+        subject.refreshData(for: trait, isPortrait: true, device: .pad)
+        let jumpBackInItemsMax = subject.sectionLayout.maxItemsToDisplay(displayGroup: .jumpBackIn,
+                                                                         hasAccount: true,
+                                                                         device: .pad)
         XCTAssertEqual(jumpBackInItemsMax, 6)
-        XCTAssertEqual(sut.sectionLayout, .regular)
+        XCTAssertEqual(subject.sectionLayout, .regular)
     }
 
     func testUpdateLayoutSectionBeforeRefreshData() {
-        let sut = createSut()
+        let subject = createSubject()
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         let tab2 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         let tab3 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
@@ -322,110 +322,110 @@ class JumpBackInViewModelTests: XCTestCase {
         let portraitTrait = MockTraitCollection()
         portraitTrait.overridenHorizontalSizeClass = .compact
         portraitTrait.overridenVerticalSizeClass = .regular
-        sut.refreshData(for: portraitTrait, isPortrait: true, device: .phone)
+        subject.refreshData(for: portraitTrait, isPortrait: true, device: .phone)
 
         XCTAssertEqual(adaptor.maxItemToDisplay, 2)
-        XCTAssertEqual(sut.sectionLayout, .compactJumpBackIn)
+        XCTAssertEqual(subject.sectionLayout, .compactJumpBackIn)
 
         // Mock rotation to landscape
         let landscapeTrait = MockTraitCollection()
         landscapeTrait.overridenHorizontalSizeClass = .regular
         landscapeTrait.overridenVerticalSizeClass = .compact
-        sut.refreshData(for: landscapeTrait, isPortrait: false, device: .phone)
+        subject.refreshData(for: landscapeTrait, isPortrait: false, device: .phone)
 
         XCTAssertEqual(adaptor.maxItemToDisplay, 4)
-        XCTAssertEqual(sut.sectionLayout, .regular)
+        XCTAssertEqual(subject.sectionLayout, .regular)
 
         // Go back to portrait
-        sut.refreshData(for: portraitTrait, isPortrait: true, device: .phone)
+        subject.refreshData(for: portraitTrait, isPortrait: true, device: .phone)
         XCTAssertEqual(adaptor.maxItemToDisplay, 2)
-        XCTAssertEqual(sut.sectionLayout, .compactJumpBackIn)
+        XCTAssertEqual(subject.sectionLayout, .compactJumpBackIn)
     }
 
     // MARK: - Sync tab layout
 
     func testMaxDisplayedItemSyncedTab_withAccount() {
-        let sut = createSut()
+        let subject = createSubject()
 
-        let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .syncedTab,
-                                                                     hasAccount: true,
-                                                                     device: .pad)
+        let jumpBackInItemsMax = subject.sectionLayout.maxItemsToDisplay(displayGroup: .syncedTab,
+                                                                         hasAccount: true,
+                                                                         device: .pad)
         XCTAssertEqual(jumpBackInItemsMax, 1)
     }
 
     func testMaxDisplayedItemSyncedTab_withoutAccount() {
-        let sut = createSut()
+        let subject = createSubject()
 
-        let jumpBackInItemsMax = sut.sectionLayout.maxItemsToDisplay(displayGroup: .syncedTab,
-                                                                     hasAccount: false,
-                                                                     device: .pad)
+        let jumpBackInItemsMax = subject.sectionLayout.maxItemsToDisplay(displayGroup: .syncedTab,
+                                                                         hasAccount: false,
+                                                                         device: .pad)
         XCTAssertEqual(jumpBackInItemsMax, 0)
     }
 
     // MARK: Refresh data
 
     func testRefreshData_noData() {
-        let sut = createSut()
-        sut.refreshData(for: MockTraitCollection())
+        let subject = createSubject()
+        subject.refreshData(for: MockTraitCollection())
 
-        XCTAssertEqual(sut.jumpBackInList.tabs.count, 0)
-        XCTAssertNil(sut.mostRecentSyncedTab)
+        XCTAssertEqual(subject.jumpBackInList.tabs.count, 0)
+        XCTAssertNil(subject.mostRecentSyncedTab)
     }
 
     func testRefreshData_jumpBackInList() {
-        let sut = createSut()
+        let subject = createSubject()
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
-        sut.refreshData(for: MockTraitCollection())
+        subject.refreshData(for: MockTraitCollection())
 
-        XCTAssertEqual(sut.jumpBackInList.tabs.count, 1)
-        XCTAssertNil(sut.mostRecentSyncedTab)
+        XCTAssertEqual(subject.jumpBackInList.tabs.count, 1)
+        XCTAssertNil(subject.mostRecentSyncedTab)
     }
 
     func testRefreshData_syncedTab() {
-        let sut = createSut()
+        let subject = createSubject()
         adaptor.syncedTab = JumpBackInSyncedTab(client: remoteClient, tab: remoteTab)
-        sut.refreshData(for: MockTraitCollection())
+        subject.refreshData(for: MockTraitCollection())
 
-        XCTAssertEqual(sut.jumpBackInList.tabs.count, 0)
-        XCTAssertNotNil(sut.mostRecentSyncedTab)
+        XCTAssertEqual(subject.jumpBackInList.tabs.count, 0)
+        XCTAssertNotNil(subject.mostRecentSyncedTab)
     }
 
     // MARK: Did load new data
 
     func testDidLoadNewData_noNewData() {
-        let sut = createSut()
-        sut.didLoadNewData()
+        let subject = createSubject()
+        subject.didLoadNewData()
 
-        XCTAssertEqual(sut.jumpBackInList.tabs.count, 0)
-        XCTAssertNil(sut.mostRecentSyncedTab)
+        XCTAssertEqual(subject.jumpBackInList.tabs.count, 0)
+        XCTAssertNil(subject.mostRecentSyncedTab)
     }
 
     func testDidLoadNewData_jumpBackInList() {
-        let sut = createSut()
+        let subject = createSubject()
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.jumpBackInList = JumpBackInList(group: nil, tabs: [tab1])
-        sut.didLoadNewData()
+        subject.didLoadNewData()
 
-        XCTAssertEqual(sut.jumpBackInList.tabs.count, 1)
-        XCTAssertNil(sut.mostRecentSyncedTab)
+        XCTAssertEqual(subject.jumpBackInList.tabs.count, 1)
+        XCTAssertNil(subject.mostRecentSyncedTab)
     }
 
     func testDidLoadNewData_syncedTab() {
-        let sut = createSut()
+        let subject = createSubject()
         adaptor.syncedTab = JumpBackInSyncedTab(client: remoteClient, tab: remoteTab)
-        sut.didLoadNewData()
+        subject.didLoadNewData()
 
-        XCTAssertEqual(sut.jumpBackInList.tabs.count, 0)
-        XCTAssertNotNil(sut.mostRecentSyncedTab)
+        XCTAssertEqual(subject.jumpBackInList.tabs.count, 0)
+        XCTAssertNotNil(subject.mostRecentSyncedTab)
     }
 }
 
 // MARK: - Helpers
 extension JumpBackInViewModelTests {
 
-    func createSut(addDelegate: Bool = true) -> JumpBackInViewModel {
-        let sut = JumpBackInViewModel(
+    func createSubject(addDelegate: Bool = true) -> JumpBackInViewModel {
+        let subject = JumpBackInViewModel(
             isZeroSearch: false,
             profile: mockProfile,
             isPrivate: false,
@@ -433,12 +433,12 @@ extension JumpBackInViewModelTests {
             adaptor: adaptor
         )
         if addDelegate {
-            sut.browserBarViewDelegate = mockBrowserBarViewDelegate
+            subject.browserBarViewDelegate = mockBrowserBarViewDelegate
         }
 
-        trackForMemoryLeaks(sut)
+        trackForMemoryLeaks(subject)
 
-        return sut
+        return subject
     }
 
     func createTab(profile: MockProfile,

--- a/Tests/ClientTests/Frontend/Home/JumpBackIn/SyncedTabCellTests.swift
+++ b/Tests/ClientTests/Frontend/Home/JumpBackIn/SyncedTabCellTests.swift
@@ -27,14 +27,14 @@ class SyncedTabCellTests: XCTestCase {
             XCTAssertEqual(url, testUrl)
         }
 
-        let sut = SyncedTabCell(frame: CGRect.zero)
-        trackForMemoryLeaks(sut)
+        let subject = SyncedTabCell(frame: CGRect.zero)
+        trackForMemoryLeaks(subject)
 
-        sut.configure(viewModel: viewModel,
-                      onTapShowAllAction: syncedTabsShowAllAction,
-                      onOpenSyncedTabAction: onOpenSyncedTabAction)
+        subject.configure(viewModel: viewModel,
+                          onTapShowAllAction: syncedTabsShowAllAction,
+                          onOpenSyncedTabAction: onOpenSyncedTabAction)
 
-        sut.showAllSyncedTabs(sender: testButton)
-        sut.didTapSyncedTab(UITapGestureRecognizer())
+        subject.showAllSyncedTabs(sender: testButton)
+        subject.didTapSyncedTab(UITapGestureRecognizer())
     }
 }

--- a/Tests/ClientTests/Frontend/Home/LogoHeader/HomeLogoHeaderViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/LogoHeader/HomeLogoHeaderViewModelTests.swift
@@ -20,32 +20,32 @@ class HomeLogoHeaderViewModelTests: XCTestCase, FeatureFlaggable {
     }
 
     func testDefaultHomepageViewModelProtocolValues() {
-        let sut = createSut()
-        XCTAssertEqual(sut.sectionType, .logoHeader)
-        XCTAssertEqual(sut.headerViewModel, LabelButtonHeaderViewModel.emptyHeader)
-        XCTAssertEqual(sut.numberOfItemsInSection(), 1)
-        XCTAssertTrue(sut.isEnabled)
+        let subject = createSubject()
+        XCTAssertEqual(subject.sectionType, .logoHeader)
+        XCTAssertEqual(subject.headerViewModel, LabelButtonHeaderViewModel.emptyHeader)
+        XCTAssertEqual(subject.numberOfItemsInSection(), 1)
+        XCTAssertTrue(subject.isEnabled)
     }
 
     func testConfigureOnTapAction() throws {
-        let sut = createSut()
+        let subject = createSubject()
 
         let cellBeforeConfig = HomeLogoHeaderCell(frame: CGRect.zero)
         XCTAssertNil(cellBeforeConfig.logoButton.touchUpAction)
 
-        sut.onTapAction = { _ in }
-        let cellAfterConfig = try XCTUnwrap(sut.configure(HomeLogoHeaderCell(frame: CGRect.zero),
-                                                          at: IndexPath()) as? HomeLogoHeaderCell)
+        subject.onTapAction = { _ in }
+        let cellAfterConfig = try XCTUnwrap(subject.configure(HomeLogoHeaderCell(frame: CGRect.zero),
+                                                              at: IndexPath()) as? HomeLogoHeaderCell)
         XCTAssertNotNil(cellAfterConfig.logoButton.touchUpAction)
     }
 }
 
 extension HomeLogoHeaderViewModelTests {
 
-    func createSut(file: StaticString = #file, line: UInt = #line) -> HomeLogoHeaderViewModel {
-        let sut = HomeLogoHeaderViewModel(profile: profile)
-        trackForMemoryLeaks(sut, file: file, line: line)
-        return sut
+    func createSubject(file: StaticString = #file, line: UInt = #line) -> HomeLogoHeaderViewModel {
+        let subject = HomeLogoHeaderViewModel(profile: profile)
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
     }
 }
 

--- a/Tests/ClientTests/Frontend/Home/Pocket/PocketDataAdaptorTests.swift
+++ b/Tests/ClientTests/Frontend/Home/Pocket/PocketDataAdaptorTests.swift
@@ -24,8 +24,8 @@ class PocketDataAdaptorTests: XCTestCase {
 
     func testEmptyData() {
         mockPocketAPI = MockPocketAPI(result: .success([]))
-        let sut = createSut()
-        let data = sut.getPocketData()
+        let subject = createSubject()
+        let data = subject.getPocketData()
         XCTAssertEqual(data.count, 0, "Data should be null")
     }
 
@@ -36,15 +36,15 @@ class PocketDataAdaptorTests: XCTestCase {
             .make(title: "feed3"),
         ]
         mockPocketAPI = MockPocketAPI(result: .success(stories))
-        let sut = createSut()
-        let data = sut.getPocketData()
+        let subject = createSubject()
+        let data = subject.getPocketData()
         XCTAssertEqual(data.count, 3, "Data should contain three pocket stories")
     }
 
     func testNotificationUpdatesData() {
         mockPocketAPI = MockPocketAPI(result: .success([]))
         var sentOnce = false
-        let sut = createSut(expectedFulfillmentCount: 2) {
+        let subject = createSubject(expectedFulfillmentCount: 2) {
             guard !sentOnce else { return }
             sentOnce = true
 
@@ -57,31 +57,31 @@ class PocketDataAdaptorTests: XCTestCase {
             self.mockNotificationCenter.post(name: UIApplication.willEnterForegroundNotification)
         }
 
-        let data = sut.getPocketData()
+        let data = subject.getPocketData()
         XCTAssertEqual(data.count, 3, "Data should contain three pocket stories")
     }
 }
 
 // MARK: Helper
 private extension PocketDataAdaptorTests {
-    func createSut(expectedFulfillmentCount: Int = 1,
-                   dataCompletion: (() -> Void)? = nil,
-                   file: StaticString = #file,
-                   line: UInt = #line) -> PocketDataAdaptorImplementation {
+    func createSubject(expectedFulfillmentCount: Int = 1,
+                       dataCompletion: (() -> Void)? = nil,
+                       file: StaticString = #file,
+                       line: UInt = #line) -> PocketDataAdaptorImplementation {
 
         let pocketSponsoredAPI = MockSponsoredPocketAPI(result: .success([]))
 
         let expectation = expectation(description: "Expect pocket adaptor to be created and fetch data")
         expectation.expectedFulfillmentCount = expectedFulfillmentCount
-        let sut = PocketDataAdaptorImplementation(pocketAPI: mockPocketAPI,
-                                                  pocketSponsoredAPI: pocketSponsoredAPI,
-                                                  notificationCenter: mockNotificationCenter) {
+        let subject = PocketDataAdaptorImplementation(pocketAPI: mockPocketAPI,
+                                                      pocketSponsoredAPI: pocketSponsoredAPI,
+                                                      notificationCenter: mockNotificationCenter) {
             expectation.fulfill()
             dataCompletion?()
         }
-        mockNotificationCenter.notifiableListener = sut
-        trackForMemoryLeaks(sut, file: file, line: line)
+        mockNotificationCenter.notifiableListener = subject
+        trackForMemoryLeaks(subject, file: file, line: line)
         wait(for: [expectation], timeout: 1)
-        return sut
+        return subject
     }
 }

--- a/Tests/ClientTests/Frontend/Home/Pocket/PocketStoryProviderTests.swift
+++ b/Tests/ClientTests/Frontend/Home/Pocket/PocketStoryProviderTests.swift
@@ -7,7 +7,7 @@ import Shared
 @testable import Client
 
 class PocketStoryProviderTests: XCTestCase, FeatureFlaggable {
-    var sut: StoryProvider!
+    var subject: StoryProvider!
 
     override func setUp() {
         super.setUp()
@@ -16,7 +16,7 @@ class PocketStoryProviderTests: XCTestCase, FeatureFlaggable {
 
     override func tearDown() {
         super.tearDown()
-        sut = nil
+        subject = nil
     }
 
     func testIfSponsoredAreDisabled_FetchingStories_ReturnsTheNonSponsoredList() async {
@@ -27,12 +27,12 @@ class PocketStoryProviderTests: XCTestCase, FeatureFlaggable {
             .make(title: "feed3"),
         ]
 
-        sut = StoryProvider(
+        subject = StoryProvider(
             pocketAPI: MockPocketAPI(result: .success(stories)),
             pocketSponsoredAPI: MockSponsoredPocketAPI(result: .success([]))
         )
 
-        let fetched = await sut.fetchPocketStories()
+        let fetched = await subject.fetchPocketStories()
         XCTAssertEqual(fetched, stories.map(PocketStory.init))
     }
 
@@ -44,12 +44,12 @@ class PocketStoryProviderTests: XCTestCase, FeatureFlaggable {
             .make(title: "feed3"),
         ]
 
-        sut = StoryProvider(
+        subject = StoryProvider(
             pocketAPI: MockPocketAPI(result: .success(stories)),
             pocketSponsoredAPI: MockSponsoredPocketAPI(result: .success([]))
         )
 
-        let fetched = await sut.fetchPocketStories()
+        let fetched = await subject.fetchPocketStories()
         XCTAssertEqual(fetched, stories.map(PocketStory.init))
     }
 
@@ -67,14 +67,14 @@ class PocketStoryProviderTests: XCTestCase, FeatureFlaggable {
             .make(title: "sponsored3"),
         ]
 
-        sut = StoryProvider(
+        subject = StoryProvider(
             pocketAPI: MockPocketAPI(result: .success(stories)),
             pocketSponsoredAPI: MockSponsoredPocketAPI(result: .success(sponsoredStories)),
             sponsoredIndices: [3, 4, 5]
         )
 
         let expected = (stories.map(PocketStory.init) + sponsoredStories.map(PocketStory.init))
-        let fetched = await sut.fetchPocketStories()
+        let fetched = await subject.fetchPocketStories()
 
         XCTAssertEqual(fetched, expected)
     }
@@ -93,7 +93,7 @@ class PocketStoryProviderTests: XCTestCase, FeatureFlaggable {
             .make(title: "sponsored3"),
         ]
 
-        sut = StoryProvider(
+        subject = StoryProvider(
             pocketAPI: MockPocketAPI(result: .success(stories)),
             pocketSponsoredAPI: MockSponsoredPocketAPI(result: .success(sponsoredStories)),
             sponsoredIndices: [1, 3, 5]
@@ -108,7 +108,7 @@ class PocketStoryProviderTests: XCTestCase, FeatureFlaggable {
             .init(pocketSponsoredStory: .make(title: "sponsored3"))
         ]
 
-        let fetched = await sut.fetchPocketStories()
+        let fetched = await subject.fetchPocketStories()
         XCTAssertEqual(fetched, expected)
     }
 
@@ -127,7 +127,7 @@ class PocketStoryProviderTests: XCTestCase, FeatureFlaggable {
             .make(title: "sponsored5"),
         ]
 
-        sut = StoryProvider(
+        subject = StoryProvider(
             pocketAPI: MockPocketAPI(result: .success(stories)),
             pocketSponsoredAPI: MockSponsoredPocketAPI(result: .success(sponsoredStories)),
             sponsoredIndices: [0, 1]
@@ -140,7 +140,7 @@ class PocketStoryProviderTests: XCTestCase, FeatureFlaggable {
             .init(pocketFeedStory: .make(title: "feed2"))
         ]
 
-        let fetched = await sut.fetchPocketStories()
+        let fetched = await subject.fetchPocketStories()
         XCTAssertEqual(fetched, expected)
     }
 
@@ -154,7 +154,7 @@ class PocketStoryProviderTests: XCTestCase, FeatureFlaggable {
             .make(title: "sponsored5"),
         ]
 
-        sut = StoryProvider(
+        subject = StoryProvider(
             pocketAPI: MockPocketAPI(result: .success([])),
             pocketSponsoredAPI: MockSponsoredPocketAPI(result: .success(sponsoredStories)),
             sponsoredIndices: [0, 1]
@@ -165,7 +165,7 @@ class PocketStoryProviderTests: XCTestCase, FeatureFlaggable {
             .init(pocketSponsoredStory: .make(title: "sponsored2"))
         ]
 
-        let fetched = await sut.fetchPocketStories()
+        let fetched = await subject.fetchPocketStories()
         XCTAssertEqual(fetched, expected)
     }
 
@@ -177,7 +177,7 @@ class PocketStoryProviderTests: XCTestCase, FeatureFlaggable {
             .make(title: "feed3"),
         ]
 
-        sut = StoryProvider(
+        subject = StoryProvider(
             pocketAPI: MockPocketAPI(result: .success(stories)),
             pocketSponsoredAPI: MockSponsoredPocketAPI(result: .failure(TestError.default)),
             sponsoredIndices: [0, 1]
@@ -189,7 +189,7 @@ class PocketStoryProviderTests: XCTestCase, FeatureFlaggable {
             .init(pocketFeedStory: .make(title: "feed3")),
         ]
 
-        let fetched = await sut.fetchPocketStories()
+        let fetched = await subject.fetchPocketStories()
         XCTAssertEqual(fetched.count, 3)
         XCTAssertEqual(fetched, expected)
     }
@@ -202,7 +202,7 @@ class PocketStoryProviderTests: XCTestCase, FeatureFlaggable {
             .make(title: "sponsored3"),
         ]
 
-        sut = StoryProvider(
+        subject = StoryProvider(
             pocketAPI: MockPocketAPI(result: .failure(TestError.default)),
             pocketSponsoredAPI: MockSponsoredPocketAPI(result: .success(stories)),
             sponsoredIndices: [0, 1, 2]
@@ -210,7 +210,7 @@ class PocketStoryProviderTests: XCTestCase, FeatureFlaggable {
 
         let expected: [PocketStory] = stories.map(PocketStory.init)
 
-        let fetched = await sut.fetchPocketStories()
+        let fetched = await subject.fetchPocketStories()
         XCTAssertEqual(fetched, expected)
     }
 
@@ -224,7 +224,7 @@ class PocketStoryProviderTests: XCTestCase, FeatureFlaggable {
             .make(title: "feed5")
         ]
 
-        sut = StoryProvider(
+        subject = StoryProvider(
             pocketAPI: MockPocketAPI(result: .success(stories)),
             pocketSponsoredAPI: MockSponsoredPocketAPI(result: .failure(TestError.default)),
             numberOfPocketStories: 3,
@@ -237,7 +237,7 @@ class PocketStoryProviderTests: XCTestCase, FeatureFlaggable {
             .init(pocketFeedStory: .make(title: "feed3")),
         ]
 
-        let fetched = await sut.fetchPocketStories()
+        let fetched = await subject.fetchPocketStories()
         XCTAssertEqual(fetched.count, 3)
         XCTAssertEqual(fetched, expected)
     }

--- a/Tests/ClientTests/Frontend/Home/Pocket/PocketViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/Pocket/PocketViewModelTests.swift
@@ -28,34 +28,34 @@ final class PocketViewModelTests: XCTestCase, FeatureFlaggable {
     }
 
     func testDefaultPocketViewModelProtocolValues_withEmptyData() {
-        let sut = createSut()
-        XCTAssertEqual(sut.sectionType, .pocket)
-        XCTAssertNotEqual(sut.headerViewModel, LabelButtonHeaderViewModel.emptyHeader)
-        XCTAssertEqual(sut.numberOfItemsInSection(), 0)
-        XCTAssertFalse(sut.hasData)
-        XCTAssertTrue(sut.isEnabled)
+        let subject = createSubject()
+        XCTAssertEqual(subject.sectionType, .pocket)
+        XCTAssertNotEqual(subject.headerViewModel, LabelButtonHeaderViewModel.emptyHeader)
+        XCTAssertEqual(subject.numberOfItemsInSection(), 0)
+        XCTAssertFalse(subject.hasData)
+        XCTAssertTrue(subject.isEnabled)
     }
 
     func testFeatureFlagDisablesSection() {
         featureFlags.set(feature: .pocket, to: false)
-        let sut = createSut()
-        XCTAssertFalse(sut.isEnabled)
+        let subject = createSubject()
+        XCTAssertFalse(subject.isEnabled)
     }
 
     func testRecordSectionHasShown() throws {
         adaptor.pocketStories = createStories(numberOfStories: 1)
-        let sut = createSut()
-        sut.didLoadNewData()
+        let subject = createSubject()
+        subject.didLoadNewData()
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
         collectionView.register(cellType: PocketStandardCell.self)
         XCTAssertNil(GleanMetrics.Pocket.sectionImpressions.testGetValue())
 
-        _ = sut.configure(collectionView, at: IndexPath(item: 0, section: 0))
+        _ = subject.configure(collectionView, at: IndexPath(item: 0, section: 0))
         testCounterMetricRecordingSuccess(metric: GleanMetrics.Pocket.sectionImpressions,
                                           value: 1)
 
         // Calling configure again doesn't add another count
-        _ = sut.configure(collectionView, at: IndexPath(item: 0, section: 0))
+        _ = subject.configure(collectionView, at: IndexPath(item: 0, section: 0))
         testCounterMetricRecordingSuccess(metric: GleanMetrics.Pocket.sectionImpressions,
                                           value: 1)
     }
@@ -63,26 +63,26 @@ final class PocketViewModelTests: XCTestCase, FeatureFlaggable {
     // MARK: - Dimension
 
     func testDimensioniPhoneLandscape() {
-        let sut = createSut()
-        let dimension = sut.getWidthDimension(device: .phone, isLandscape: true)
+        let subject = createSubject()
+        let dimension = subject.getWidthDimension(device: .phone, isLandscape: true)
         XCTAssertEqual(dimension, .fractionalWidth(PocketViewModel.UX.fractionalWidthiPhoneLanscape))
     }
 
     func testDimensioniPhonePortrait() {
-        let sut = createSut()
-        let dimension = sut.getWidthDimension(device: .phone, isLandscape: false)
+        let subject = createSubject()
+        let dimension = subject.getWidthDimension(device: .phone, isLandscape: false)
         XCTAssertEqual(dimension, .fractionalWidth(PocketViewModel.UX.fractionalWidthiPhonePortrait))
     }
 
     func testDimensioniPadPortrait() {
-        let sut = createSut()
-        let dimension = sut.getWidthDimension(device: .pad, isLandscape: false)
+        let subject = createSubject()
+        let dimension = subject.getWidthDimension(device: .pad, isLandscape: false)
         XCTAssertEqual(dimension, .absolute(PocketStandardCell.UX.cellWidth))
     }
 
     func testDimensioniPadLandscape() {
-        let sut = createSut()
-        let dimension = sut.getWidthDimension(device: .pad, isLandscape: true)
+        let subject = createSubject()
+        let dimension = subject.getWidthDimension(device: .pad, isLandscape: true)
         XCTAssertEqual(dimension, .absolute(PocketStandardCell.UX.cellWidth))
     }
 
@@ -90,21 +90,21 @@ final class PocketViewModelTests: XCTestCase, FeatureFlaggable {
 
     func testConfigureStandardCell() throws {
         adaptor.pocketStories = createStories(numberOfStories: 1)
-        let sut = createSut()
-        sut.didLoadNewData()
+        let subject = createSubject()
+        subject.didLoadNewData()
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
         collectionView.register(cellType: PocketStandardCell.self)
 
-        let cell = try XCTUnwrap(sut.configure(collectionView,
-                                               at: IndexPath(item: 0, section: 0)) as? PocketStandardCell)
+        let cell = try XCTUnwrap(subject.configure(collectionView,
+                                                   at: IndexPath(item: 0, section: 0)) as? PocketStandardCell)
         XCTAssertNotNil(cell)
     }
 
     func testClickingStandardCell_recordsTapOnStory() {
         adaptor.pocketStories = createStories(numberOfStories: 1)
-        let sut = createSut()
-        sut.didLoadNewData()
-        sut.didSelectItem(at: IndexPath(item: 0, section: 0), homePanelDelegate: nil, libraryPanelDelegate: nil)
+        let subject = createSubject()
+        subject.didLoadNewData()
+        subject.didSelectItem(at: IndexPath(item: 0, section: 0), homePanelDelegate: nil, libraryPanelDelegate: nil)
 
         testLabeledMetricSuccess(metric: GleanMetrics.Pocket.openStoryOrigin)
         testLabeledMetricSuccess(metric: GleanMetrics.Pocket.openStoryPosition)
@@ -112,49 +112,49 @@ final class PocketViewModelTests: XCTestCase, FeatureFlaggable {
 
     func testClickingStandardCell_callsTapTileAction() {
         adaptor.pocketStories = createStories(numberOfStories: 1)
-        let sut = createSut()
-        sut.didLoadNewData()
-        sut.onTapTileAction = { url in
+        let subject = createSubject()
+        subject.didLoadNewData()
+        subject.onTapTileAction = { url in
             XCTAssertEqual(url.absoluteString, "www.test0.com")
         }
-        sut.didSelectItem(at: IndexPath(item: 0, section: 0),
-                          homePanelDelegate: nil,
-                          libraryPanelDelegate: nil)
+        subject.didSelectItem(at: IndexPath(item: 0, section: 0),
+                              homePanelDelegate: nil,
+                              libraryPanelDelegate: nil)
     }
 
     func testLongPressStandardCell_callsHandleLongPress() {
         adaptor.pocketStories = createStories(numberOfStories: 1)
-        let sut = createSut()
-        sut.didLoadNewData()
-        sut.onLongPressTileAction = { (site, _) in
+        let subject = createSubject()
+        subject.didLoadNewData()
+        subject.onLongPressTileAction = { (site, _) in
             XCTAssertEqual(site.url, "www.test0.com")
             XCTAssertEqual(site.title, "Story 0")
         }
 
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
-        sut.handleLongPress(with: collectionView,
-                            indexPath: IndexPath(item: 0, section: 0))
+        subject.handleLongPress(with: collectionView,
+                                indexPath: IndexPath(item: 0, section: 0))
     }
 
     // MARK: - Discover cell
 
     func testConfigureDiscoverCell() throws {
         adaptor.pocketStories = createStories(numberOfStories: 2)
-        let sut = createSut()
-        sut.didLoadNewData()
+        let subject = createSubject()
+        subject.didLoadNewData()
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
         collectionView.register(cellType: PocketDiscoverCell.self)
 
-        let cell = try XCTUnwrap(sut.configure(collectionView,
-                                               at: IndexPath(item: 2, section: 0)) as? PocketDiscoverCell)
+        let cell = try XCTUnwrap(subject.configure(collectionView,
+                                                   at: IndexPath(item: 2, section: 0)) as? PocketDiscoverCell)
         XCTAssertNotNil(cell)
     }
 
     func testClickingDiscoverCell_recordsTapOnStory() {
         adaptor.pocketStories = createStories(numberOfStories: 1)
-        let sut = createSut()
-        sut.didLoadNewData()
-        sut.didSelectItem(at: IndexPath(item: 1, section: 0), homePanelDelegate: nil, libraryPanelDelegate: nil)
+        let subject = createSubject()
+        subject.didLoadNewData()
+        subject.didSelectItem(at: IndexPath(item: 1, section: 0), homePanelDelegate: nil, libraryPanelDelegate: nil)
 
         testLabeledMetricSuccess(metric: GleanMetrics.Pocket.openStoryOrigin)
         testLabeledMetricSuccess(metric: GleanMetrics.Pocket.openStoryPosition)
@@ -162,28 +162,28 @@ final class PocketViewModelTests: XCTestCase, FeatureFlaggable {
 
     func testClickingDiscoverCell_callsTapTileAction() {
         adaptor.pocketStories = createStories(numberOfStories: 1)
-        let sut = createSut()
-        sut.didLoadNewData()
-        sut.onTapTileAction = { url in
+        let subject = createSubject()
+        subject.didLoadNewData()
+        subject.onTapTileAction = { url in
             XCTAssertEqual(url, PocketProvider.MoreStoriesURL)
         }
-        sut.didSelectItem(at: IndexPath(item: 1, section: 0),
-                          homePanelDelegate: nil,
-                          libraryPanelDelegate: nil)
+        subject.didSelectItem(at: IndexPath(item: 1, section: 0),
+                              homePanelDelegate: nil,
+                              libraryPanelDelegate: nil)
     }
 
     func testLongPressDiscoverCell_callsHandleLongPress() {
         adaptor.pocketStories = createStories(numberOfStories: 1)
-        let sut = createSut()
-        sut.didLoadNewData()
-        sut.onLongPressTileAction = { (site, _) in
+        let subject = createSubject()
+        subject.didLoadNewData()
+        subject.onLongPressTileAction = { (site, _) in
             XCTAssertEqual(site.url, PocketProvider.MoreStoriesURL.absoluteString)
             XCTAssertEqual(site.title, "Discover more")
         }
 
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
-        sut.handleLongPress(with: collectionView,
-                            indexPath: IndexPath(item: 1, section: 0))
+        subject.handleLongPress(with: collectionView,
+                                indexPath: IndexPath(item: 1, section: 0))
     }
 }
 
@@ -212,12 +212,12 @@ extension PocketViewModelTests {
         return stories
     }
 
-    func createSut(isZeroSearch: Bool = true,
-                   file: StaticString = #file,
-                   line: UInt = #line) -> PocketViewModel {
-        let sut = PocketViewModel(pocketDataAdaptor: adaptor, isZeroSearch: isZeroSearch)
-        trackForMemoryLeaks(sut, file: file, line: line)
-        return sut
+    func createSubject(isZeroSearch: Bool = true,
+                       file: StaticString = #file,
+                       line: UInt = #line) -> PocketViewModel {
+        let subject = PocketViewModel(pocketDataAdaptor: adaptor, isZeroSearch: isZeroSearch)
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
     }
 }
 

--- a/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
+++ b/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
@@ -37,55 +37,55 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     }
 
     func testData_whenNotLoaded() {
-        let sut = createSut()
-        let data = sut.getTopSitesData()
+        let subject = createSubject()
+        let data = subject.getTopSitesData()
         XCTAssertEqual(data.count, 11, "Loading data on init, so we get 1 google site, 10 history sites")
     }
 
     func testNumberOfRows_default() {
-        let sut = createSut()
-        XCTAssertEqual(sut.numberOfRows, 2)
+        let subject = createSubject()
+        XCTAssertEqual(subject.numberOfRows, 2)
     }
 
     func testNumberOfRows_userChangedDefault() {
         profile.prefs.setInt(3, forKey: PrefsKeys.NumberOfTopSiteRows)
-        let sut = createSut()
-        XCTAssertEqual(sut.numberOfRows, 3)
+        let subject = createSubject()
+        XCTAssertEqual(subject.numberOfRows, 3)
     }
 
     // MARK: Google top site
 
     func testCalculateTopSitesData_hasGoogleTopSite_googlePrefsNil() {
-        let sut = createSut()
+        let subject = createSubject()
 
-        sut.recalculateTopSiteData(for: 6)
+        subject.recalculateTopSiteData(for: 6)
 
         // We test that without a pref, google is added
-        let data = sut.getTopSitesData()
+        let data = subject.getTopSitesData()
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertTrue(data[0].isGoogleGUID)
     }
 
     func testCalculateTopSitesData_hasGoogleTopSiteWithPinnedCount_googlePrefsNi() {
-        let sut = createSut(addPinnedSiteCount: 3)
+        let subject =createSubject(addPinnedSiteCount: 3)
 
-        sut.recalculateTopSiteData(for: 1)
+        subject.recalculateTopSiteData(for: 1)
 
         // We test that without a pref, google is added even with pinned tiles
-        let data = sut.getTopSitesData()
+        let data = subject.getTopSitesData()
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertTrue(data[0].isGoogleGUID)
     }
 
     func testCalculateTopSitesData_hasNotGoogleTopSite_IfHidden() {
-        let sut = createSut(addPinnedSiteCount: 3)
+        let subject =createSubject(addPinnedSiteCount: 3)
         profile.prefs.setBool(true, forKey: PrefsKeys.GoogleTopSiteAddedKey)
         profile.prefs.setBool(true, forKey: PrefsKeys.GoogleTopSiteHideKey)
 
-        sut.recalculateTopSiteData(for: 1)
+        subject.recalculateTopSiteData(for: 1)
 
         // We test that having more pinned than available tiles, google tile isn't put in
-        let data = sut.getTopSitesData()
+        let data = subject.getTopSitesData()
         XCTAssertFalse(data[0].isGoogleURL)
         XCTAssertFalse(data[0].isGoogleGUID)
     }
@@ -93,11 +93,11 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     // MARK: Pinned site
 
     func testCalculateTopSitesData_pinnedSites() {
-        let sut = createSut(addPinnedSiteCount: 3)
+        let subject =createSubject(addPinnedSiteCount: 3)
 
-        sut.recalculateTopSiteData(for: 6)
+        subject.recalculateTopSiteData(for: 6)
 
-        let data = sut.getTopSitesData()
+        let data = subject.getTopSitesData()
         XCTAssertEqual(data.count, 14)
         XCTAssertTrue(data[0].isPinned)
     }
@@ -110,31 +110,31 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         profile.prefs.setBool(true, forKey: PrefsKeys.GoogleTopSiteHideKey)
 
         let expectedContileResult = ContileResult.success(ContileProviderMock.defaultSuccessData)
-        let sut = createSut(siteCount: 0, expectedContileResult: expectedContileResult)
+        let subject =createSubject(siteCount: 0, expectedContileResult: expectedContileResult)
 
-        let data = sut.getTopSitesData()
+        let data = subject.getTopSitesData()
         XCTAssertNotEqual(data.count, 0)
     }
 
     func testLoadTopSitesData_addSponsoredTile() {
         featureFlags.set(feature: .sponsoredTiles, to: true)
         let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 1)
-        let sut = createSut(expectedContileResult: ContileResult.success(expectedContileResult))
+        let subject =createSubject(expectedContileResult: ContileResult.success(expectedContileResult))
 
-        sut.recalculateTopSiteData(for: 6)
+        subject.recalculateTopSiteData(for: 6)
 
-        let data = sut.getTopSitesData()
+        let data = subject.getTopSitesData()
         XCTAssertEqual(data.count, 12, "Expects 1 google site, 1 contile, 10 history sites")
     }
 
     func testCalculateTopSitesData_addSponsoredTileAfterGoogle() {
         featureFlags.set(feature: .sponsoredTiles, to: true)
         let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 1)
-        let sut = createSut(expectedContileResult: ContileResult.success(expectedContileResult))
+        let subject =createSubject(expectedContileResult: ContileResult.success(expectedContileResult))
 
-        sut.recalculateTopSiteData(for: 6)
+        subject.recalculateTopSiteData(for: 6)
 
-        let data = sut.getTopSitesData()
+        let data = subject.getTopSitesData()
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertTrue(data[1].isSponsoredTile)
         XCTAssertFalse(data[2].isSponsoredTile)
@@ -143,11 +143,11 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     func testCalculateTopSitesData_doesNotAddSponsoredTileIfError() {
         featureFlags.set(feature: .sponsoredTiles, to: true)
         let expectedContileResult = ContileResult.failure(ContileProvider.Error.failure)
-        let sut = createSut(expectedContileResult: expectedContileResult)
+        let subject =createSubject(expectedContileResult: expectedContileResult)
 
-        sut.recalculateTopSiteData(for: 6)
+        subject.recalculateTopSiteData(for: 6)
 
-        let data = sut.getTopSitesData()
+        let data = subject.getTopSitesData()
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertFalse(data[1].isSponsoredTile)
         XCTAssertFalse(data[2].isSponsoredTile)
@@ -156,11 +156,11 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     func testCalculateTopSitesData_doesNotAddSponsoredTileIfSuccessEmpty() {
         featureFlags.set(feature: .sponsoredTiles, to: true)
         let expectedContileResult = ContileResult.success([])
-        let sut = createSut(expectedContileResult: expectedContileResult)
+        let subject =createSubject(expectedContileResult: expectedContileResult)
 
-        sut.recalculateTopSiteData(for: 6)
+        subject.recalculateTopSiteData(for: 6)
 
-        let data = sut.getTopSitesData()
+        let data = subject.getTopSitesData()
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertFalse(data[1].isSponsoredTile)
         XCTAssertFalse(data[2].isSponsoredTile)
@@ -170,10 +170,10 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         featureFlags.set(feature: .sponsoredTiles, to: true)
         // Max contiles is currently at 2, so it should add 2 contiles only
         let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 3)
-        let sut = createSut(expectedContileResult: ContileResult.success(expectedContileResult))
+        let subject =createSubject(expectedContileResult: ContileResult.success(expectedContileResult))
 
-        sut.recalculateTopSiteData(for: 6)
-        let data = sut.getTopSitesData()
+        subject.recalculateTopSiteData(for: 6)
+        let data = subject.getTopSitesData()
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertTrue(data[1].isSponsoredTile)
         XCTAssertTrue(data[2].isSponsoredTile)
@@ -186,10 +186,10 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 1,
                                                                     duplicateFirstTile: true,
                                                                     pinnedDuplicateTile: true)
-        let sut = createSut(addPinnedSiteCount: 1, expectedContileResult: ContileResult.success(expectedContileResult))
-        sut.recalculateTopSiteData(for: 6)
+        let subject =createSubject(addPinnedSiteCount: 1, expectedContileResult: ContileResult.success(expectedContileResult))
+        subject.recalculateTopSiteData(for: 6)
 
-        let data = sut.getTopSitesData()
+        let data = subject.getTopSitesData()
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertFalse(data[1].isSponsoredTile)
         XCTAssertFalse(data[2].isSponsoredTile)
@@ -200,11 +200,11 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
 
         let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 1,
                                                                     duplicateFirstTile: true)
-        let sut = createSut(addPinnedSiteCount: 1, expectedContileResult: ContileResult.success(expectedContileResult))
+        let subject =createSubject(addPinnedSiteCount: 1, expectedContileResult: ContileResult.success(expectedContileResult))
 
-        sut.recalculateTopSiteData(for: 6)
+        subject.recalculateTopSiteData(for: 6)
 
-        let data = sut.getTopSitesData()
+        let data = subject.getTopSitesData()
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertTrue(data[1].isSponsoredTile)
         XCTAssertFalse(data[2].isSponsoredTile)
@@ -216,11 +216,11 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 2,
                                                                     duplicateFirstTile: true,
                                                                     pinnedDuplicateTile: true)
-        let sut = createSut(addPinnedSiteCount: 1, expectedContileResult: ContileResult.success(expectedContileResult))
+        let subject =createSubject(addPinnedSiteCount: 1, expectedContileResult: ContileResult.success(expectedContileResult))
 
-        sut.recalculateTopSiteData(for: 6)
+        subject.recalculateTopSiteData(for: 6)
 
-        let data = sut.getTopSitesData()
+        let data = subject.getTopSitesData()
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertTrue(data[1].isSponsoredTile)
         XCTAssertEqual(data[1].title, ContileProviderMock.defaultSuccessData[0].name)
@@ -231,14 +231,14 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         featureFlags.set(feature: .sponsoredTiles, to: true)
 
         let expectedContileResult = ContileResult.success([])
-        let sut = createSut(addPinnedSiteCount: 12, expectedContileResult: expectedContileResult)
+        let subject =createSubject(addPinnedSiteCount: 12, expectedContileResult: expectedContileResult)
 
         profile.prefs.setBool(true, forKey: PrefsKeys.GoogleTopSiteAddedKey)
         profile.prefs.setBool(true, forKey: PrefsKeys.GoogleTopSiteHideKey)
 
-        sut.recalculateTopSiteData(for: 6)
+        subject.recalculateTopSiteData(for: 6)
 
-        let data = sut.getTopSitesData()
+        let data = subject.getTopSitesData()
         XCTAssertFalse(data[0].isGoogleURL)
         XCTAssertFalse(data[1].isSponsoredTile)
         XCTAssertFalse(data[2].isSponsoredTile)
@@ -248,11 +248,11 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         featureFlags.set(feature: .sponsoredTiles, to: true)
 
         let expectedContileResult = ContileResult.success([])
-        let sut = createSut(addPinnedSiteCount: 11, expectedContileResult: expectedContileResult)
+        let subject =createSubject(addPinnedSiteCount: 11, expectedContileResult: expectedContileResult)
 
-        sut.recalculateTopSiteData(for: 6)
+        subject.recalculateTopSiteData(for: 6)
 
-        let data = sut.getTopSitesData()
+        let data = subject.getTopSitesData()
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertFalse(data[1].isSponsoredTile)
         XCTAssertFalse(data[2].isSponsoredTile)
@@ -261,10 +261,10 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     func testSponsoredTileOrder_emptySites_addsAllContiles() {
         featureFlags.set(feature: .sponsoredTiles, to: true)
         let expectedContileResult = ContileResult.success(ContileProviderMock.defaultSuccessData)
-        let sut = createSut(expectedContileResult: expectedContileResult)
+        let subject =createSubject(expectedContileResult: expectedContileResult)
 
         var sites: [Site] = []
-        sut.addSponsoredTiles(sites: &sites, shouldAddGoogle: true, availableSpaceCount: 10)
+        subject.addSponsoredTiles(sites: &sites, shouldAddGoogle: true, availableSpaceCount: 10)
 
         XCTAssertEqual(sites.count, 2, "Added two contiles")
         XCTAssertEqual(sites[0].title, "Firefox")
@@ -274,10 +274,10 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     func testSponsoredTileOrder_emptySites_addsOneIfGoogleIsThere() {
         featureFlags.set(feature: .sponsoredTiles, to: true)
         let expectedContileResult = ContileResult.success(ContileProviderMock.defaultSuccessData)
-        let sut = createSut(expectedContileResult: expectedContileResult)
+        let subject =createSubject(expectedContileResult: expectedContileResult)
 
         var sites: [Site] = []
-        sut.addSponsoredTiles(sites: &sites, shouldAddGoogle: true, availableSpaceCount: 2)
+        subject.addSponsoredTiles(sites: &sites, shouldAddGoogle: true, availableSpaceCount: 2)
 
         XCTAssertEqual(sites.count, 1, "Added one contile")
         XCTAssertEqual(sites[0].title, "Firefox")
@@ -286,11 +286,11 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     func testSponsoredTileOrder_withSites_addsAllContiles() {
         featureFlags.set(feature: .sponsoredTiles, to: true)
         let expectedContileResult = ContileResult.success(ContileProviderMock.defaultSuccessData)
-        let sut = createSut(expectedContileResult: expectedContileResult)
+        let subject =createSubject(expectedContileResult: expectedContileResult)
 
         var sites: [Site] = [Site(url: "www.test.com", title: "A test"),
                              Site(url: "www.test2.com", title: "A test2")]
-        sut.addSponsoredTiles(sites: &sites, shouldAddGoogle: true, availableSpaceCount: 10)
+        subject.addSponsoredTiles(sites: &sites, shouldAddGoogle: true, availableSpaceCount: 10)
 
         XCTAssertEqual(sites.count, 4, "Added two contiles and two sites")
         XCTAssertEqual(sites[0].title, "Firefox")
@@ -301,10 +301,10 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         featureFlags.set(feature: .sponsoredTiles, to: true)
 
         let expectedContileResult = ContileResult.success(ContileProviderMock.defaultSuccessData)
-        let sut = createSut(expectedContileResult: expectedContileResult)
+        let subject =createSubject(expectedContileResult: expectedContileResult)
 
         var sites: [Site] = []
-        sut.addSponsoredTiles(sites: &sites, shouldAddGoogle: false, availableSpaceCount: 2)
+        subject.addSponsoredTiles(sites: &sites, shouldAddGoogle: false, availableSpaceCount: 2)
 
         XCTAssertEqual(sites.count, 2, "Added two contiles, no Google spot taken")
         XCTAssertEqual(sites[0].title, "Firefox")
@@ -315,10 +315,10 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         featureFlags.set(feature: .sponsoredTiles, to: true)
 
         let expectedContileResult = ContileResult.success(ContileProviderMock.defaultSuccessData)
-        let sut = createSut(expectedContileResult: expectedContileResult)
+        let subject =createSubject(expectedContileResult: expectedContileResult)
 
         var sites: [Site] = []
-        sut.addSponsoredTiles(sites: &sites, shouldAddGoogle: true, availableSpaceCount: 2)
+        subject.addSponsoredTiles(sites: &sites, shouldAddGoogle: true, availableSpaceCount: 2)
 
         XCTAssertEqual(sites.count, 1, "Added only one contile, Google tile count is taken into account")
         XCTAssertEqual(sites[0].title, "Firefox")
@@ -329,11 +329,11 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     // Sponsored > Frequency
     func testDuplicates_SponsoredTileHasPrecedenceOnFrequencyTiles() {
         featureFlags.set(feature: .sponsoredTiles, to: true)
-        let sut = createSut(expectedContileResult: ContileResult.success([ContileProviderMock.duplicateTile]))
+        let subject =createSubject(expectedContileResult: ContileResult.success([ContileProviderMock.duplicateTile]))
 
-        sut.recalculateTopSiteData(for: 6)
+        subject.recalculateTopSiteData(for: 6)
 
-        let data = sut.getTopSitesData()
+        let data = subject.getTopSitesData()
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertEqual(data[1].title, ContileProviderMock.duplicateTile.name)
         XCTAssertTrue(data[1].isSponsoredTile)
@@ -344,12 +344,12 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     func testDuplicates_PinnedTilesHasPrecedenceOnSponsoredTiles() {
         featureFlags.set(feature: .sponsoredTiles, to: true)
 
-        let sut = createSut(addPinnedSiteCount: 1,
-                            expectedContileResult: ContileResult.success([ContileProviderMock.pinnedDuplicateTile]))
+        let subject =createSubject(addPinnedSiteCount: 1,
+                                   expectedContileResult: ContileResult.success([ContileProviderMock.pinnedDuplicateTile]))
 
-        sut.recalculateTopSiteData(for: 6)
+        subject.recalculateTopSiteData(for: 6)
 
-        let data = sut.getTopSitesData()
+        let data = subject.getTopSitesData()
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertFalse(data[1].isSponsoredTile)
         XCTAssertTrue(data[1].isPinned)
@@ -361,11 +361,11 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     func testDuplicates_PinnedTilesHasPrecedenceOnFrequencyTiles() {
         featureFlags.set(feature: .sponsoredTiles, to: true)
         let expectedPinnedURL = String(format: ContileProviderMock.url, "0")
-        let sut = createSut(addPinnedSiteCount: 1, siteCount: 3, duplicatePinnedSiteURL: true)
+        let subject =createSubject(addPinnedSiteCount: 1, siteCount: 3, duplicatePinnedSiteURL: true)
 
-        sut.recalculateTopSiteData(for: 6)
+        subject.recalculateTopSiteData(for: 6)
 
-        let data = sut.getTopSitesData()
+        let data = subject.getTopSitesData()
         XCTAssertEqual(data.count, 4, "Should have 3 sites and 1 pinned")
         XCTAssertTrue(data[0].isGoogleURL)
 
@@ -388,11 +388,11 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     // Pinned vs another Pinned of same domain
     func testDuplicates_PinnedTilesOfSameDomainIsntDeduped() {
         featureFlags.set(feature: .sponsoredTiles, to: true)
-        let sut = createSut(addPinnedSiteCount: 2, siteCount: 0)
+        let subject =createSubject(addPinnedSiteCount: 2, siteCount: 0)
 
-        sut.recalculateTopSiteData(for: 6)
+        subject.recalculateTopSiteData(for: 6)
 
-        let data = sut.getTopSitesData()
+        let data = subject.getTopSitesData()
         XCTAssertEqual(data.count, 3, "Should have google site and 2 pinned sites")
         XCTAssertTrue(data[0].isGoogleURL)
 
@@ -494,12 +494,12 @@ extension ContileProviderMock {
 // MARK: TopSitesManagerTests
 extension TopSitesDataAdaptorTests {
 
-    func createSut(addPinnedSiteCount: Int = 0,
-                   siteCount: Int = 10,
-                   duplicatePinnedSiteURL: Bool = false,
-                   expectedContileResult: ContileResult = .success([]),
-                   file: StaticString = #file,
-                   line: UInt = #line) -> TopSitesDataAdaptorImplementation {
+    func createSubject(addPinnedSiteCount: Int = 0,
+                       siteCount: Int = 10,
+                       duplicatePinnedSiteURL: Bool = false,
+                       expectedContileResult: ContileResult = .success([]),
+                       file: StaticString = #file,
+                       line: UInt = #line) -> TopSitesDataAdaptorImplementation {
 
         let historyStub = TopSiteHistoryManagerStub(profile: profile)
         historyStub.siteCount = siteCount
@@ -511,19 +511,19 @@ extension TopSitesDataAdaptorTests {
         let googleManager = GoogleTopSiteManager(prefs: profile.prefs)
         let dispatchGroup = MockDispatchGroup()
 
-        let sut = TopSitesDataAdaptorImplementation(profile: profile,
-                                                    topSiteHistoryManager: historyStub,
-                                                    googleTopSiteManager: googleManager,
-                                                    contileProvider: contileProviderMock,
-                                                    notificationCenter: notificationCenter,
-                                                    dispatchGroup: dispatchGroup)
+        let subject = TopSitesDataAdaptorImplementation(profile: profile,
+                                                        topSiteHistoryManager: historyStub,
+                                                        googleTopSiteManager: googleManager,
+                                                        contileProvider: contileProviderMock,
+                                                        notificationCenter: notificationCenter,
+                                                        dispatchGroup: dispatchGroup)
 
-        trackForMemoryLeaks(sut, file: file, line: line)
+        trackForMemoryLeaks(subject, file: file, line: line)
         trackForMemoryLeaks(historyStub, file: file, line: line)
         trackForMemoryLeaks(googleManager, file: file, line: line)
         trackForMemoryLeaks(dispatchGroup, file: file, line: line)
 
-        return sut
+        return subject
     }
 }
 

--- a/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDimensionTests.swift
+++ b/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDimensionTests.swift
@@ -10,85 +10,85 @@ import Storage
 class TopSitesDimensionTests: XCTestCase {
 
     func testSectionDimension_portraitIphone_defaultRowNumber() {
-        let sut = createSut()
+        let subject = createSubject()
         let trait = MockTraitCollection()
         let interface = TopSitesUIInterface(isLandscape: false, isIphone: true, trait: trait)
 
-        let dimension = sut.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
+        let dimension = subject.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
         XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
     }
 
     func testSectionDimension_landscapeIphone_defaultRowNumber() {
-        let sut = createSut()
+        let subject = createSubject()
         let trait = MockTraitCollection()
         let interface = TopSitesUIInterface(isLandscape: true, isIphone: true, trait: trait)
 
-        let dimension = sut.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
+        let dimension = subject.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
         XCTAssertEqual(dimension.numberOfTilesPerRow, 8)
     }
 
     func testSectionDimension_portraitiPadRegular_defaultRowNumber() {
-        let sut = createSut()
+        let subject = createSubject()
         let trait = MockTraitCollection()
         let interface = TopSitesUIInterface(isLandscape: false, isIphone: false, trait: trait)
 
-        let dimension = sut.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
+        let dimension = subject.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
         XCTAssertEqual(dimension.numberOfTilesPerRow, 6)
     }
 
     func testSectionDimension_landscapeiPadRegular_defaultRowNumber() {
-        let sut = createSut()
+        let subject = createSubject()
         let trait = MockTraitCollection()
         let interface = TopSitesUIInterface(isLandscape: true, isIphone: false, trait: trait)
 
-        let dimension = sut.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
+        let dimension = subject.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
         XCTAssertEqual(dimension.numberOfTilesPerRow, 8)
     }
 
     func testSectionDimension_portraitiPadCompact_defaultRowNumber() {
-        let sut = createSut()
+        let subject = createSubject()
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .compact
         let interface = TopSitesUIInterface(isLandscape: false, isIphone: false, trait: trait)
 
-        let dimension = sut.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
+        let dimension = subject.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
         XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
     }
 
     func testSectionDimension_landscapeiPadCompact_defaultRowNumber() {
-        let sut = createSut()
+        let subject = createSubject()
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .compact
         let interface = TopSitesUIInterface(isLandscape: true, isIphone: false, trait: trait)
 
-        let dimension = sut.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
+        let dimension = subject.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
         XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
     }
 
     func testSectionDimension_portraitiPadUnspecified_defaultRowNumber() {
-        let sut = createSut()
+        let subject = createSubject()
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .unspecified
         let interface = TopSitesUIInterface(isLandscape: false, isIphone: false, trait: trait)
 
-        let dimension = sut.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
+        let dimension = subject.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
         XCTAssertEqual(dimension.numberOfTilesPerRow, 2)
     }
 
     func testSectionDimension_landscapeiPadUnspecified_defaultRowNumber() {
-        let sut = createSut()
+        let subject = createSubject()
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .unspecified
         let interface = TopSitesUIInterface(isLandscape: true, isIphone: false, trait: trait)
 
-        let dimension = sut.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
+        let dimension = subject.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
         XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
     }
@@ -96,52 +96,52 @@ class TopSitesDimensionTests: XCTestCase {
     // MARK: Section dimension with stubbed data
 
     func testSectionDimension_oneEmptyRow_shouldBeRemoved() {
-        let sut = createSut()
+        let subject = createSubject()
         let trait = MockTraitCollection()
         let interface = TopSitesUIInterface(isLandscape: false, isIphone: true, trait: trait)
 
-        let dimension = sut.getSectionDimension(for: createSites(count: 4), numberOfRows: 2, interface: interface)
+        let dimension = subject.getSectionDimension(for: createSites(count: 4), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 1)
         XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
     }
 
     func testSectionDimension_twoEmptyRow_shouldBeRemoved() {
-        let sut = createSut()
+        let subject = createSubject()
         let trait = MockTraitCollection()
         let interface = TopSitesUIInterface(isLandscape: false, isIphone: true, trait: trait)
 
-        let dimension = sut.getSectionDimension(for: createSites(count: 4), numberOfRows: 3, interface: interface)
+        let dimension = subject.getSectionDimension(for: createSites(count: 4), numberOfRows: 3, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 1)
         XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
     }
 
     func testSectionDimension_noEmptyRow_shouldNotBeRemoved() {
-        let sut = createSut()
+        let subject = createSubject()
         let trait = MockTraitCollection()
         let interface = TopSitesUIInterface(isLandscape: false, isIphone: true, trait: trait)
 
-        let dimension = sut.getSectionDimension(for: createSites(count: 8), numberOfRows: 2, interface: interface)
+        let dimension = subject.getSectionDimension(for: createSites(count: 8), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
         XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
     }
 
     func testSectionDimension_halfFilledRow_shouldNotBeRemoved() {
-        let sut = createSut()
+        let subject = createSubject()
         let trait = MockTraitCollection()
         let interface = TopSitesUIInterface(isLandscape: false, isIphone: true, trait: trait)
 
-        let dimension = sut.getSectionDimension(for: createSites(count: 6), numberOfRows: 2, interface: interface)
+        let dimension = subject.getSectionDimension(for: createSites(count: 6), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
         XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
     }
 }
 
 extension TopSitesDimensionTests {
-    func createSut() -> TopSitesDimension {
-        let sut = TopSitesDimensionImplementation()
-        trackForMemoryLeaks(sut)
+    func createSubject() -> TopSitesDimension {
+        let subject = TopSitesDimensionImplementation()
+        trackForMemoryLeaks(subject)
 
-        return sut
+        return subject
     }
 
     func createSites(count: Int = 30) -> [TopSite] {

--- a/Tests/ClientTests/GleanPlumbMessageManagerTests.swift
+++ b/Tests/ClientTests/GleanPlumbMessageManagerTests.swift
@@ -9,7 +9,7 @@ import Glean
 
 class GleanPlumbMessageManagerTests: XCTestCase {
 
-    var sut: GleanPlumbMessageManager!
+    var subject: GleanPlumbMessageManager!
     var messagingStore: MockGleanPlumbMessageStore!
     let messageId = "testId"
 
@@ -19,34 +19,34 @@ class GleanPlumbMessageManagerTests: XCTestCase {
         Glean.shared.resetGlean(clearStores: true)
         Glean.shared.enableTestingMode()
         messagingStore = MockGleanPlumbMessageStore(messageId: messageId)
-        sut = GleanPlumbMessageManager(messagingStore: messagingStore)
+        subject = GleanPlumbMessageManager(messagingStore: messagingStore)
     }
 
     override func tearDown() {
         super.tearDown()
 
         messagingStore = nil
-        sut = nil
+        subject = nil
     }
 
     func testManagerHasMessage() {
-        let messageForSurface = sut.hasMessage(for: .newTabCard)
+        let messageForSurface = subject.hasMessage(for: .newTabCard)
         XCTAssertTrue(messageForSurface)
     }
 
     func testManagerGetMessage() {
-        guard let message = sut.getNextMessage(for: .newTabCard) else {
+        guard let message = subject.getNextMessage(for: .newTabCard) else {
             XCTFail("Expected to retrieve message")
             return
         }
 
-        sut.onMessageDisplayed(message)
+        subject.onMessageDisplayed(message)
         testEventMetricRecordingSuccess(metric: GleanMetrics.Messaging.shown)
     }
 
     func testManagerOnMessageDisplayed() {
         let message = createMessage(messageId: messageId)
-        sut.onMessageDisplayed(message)
+        subject.onMessageDisplayed(message)
         let messageMetadata = messagingStore.getMessageMetadata(messageId: messageId)
         XCTAssertFalse(messageMetadata.isExpired)
         XCTAssertEqual(messageMetadata.impressions, 1)
@@ -55,7 +55,7 @@ class GleanPlumbMessageManagerTests: XCTestCase {
 
     func testManagerOnMessagePressed() {
         let message = createMessage(messageId: messageId)
-        sut.onMessagePressed(message)
+        subject.onMessagePressed(message)
         let messageMetadata = messagingStore.getMessageMetadata(messageId: messageId)
         XCTAssertTrue(messageMetadata.isExpired)
         testEventMetricRecordingSuccess(metric: GleanMetrics.Messaging.clicked)
@@ -63,7 +63,7 @@ class GleanPlumbMessageManagerTests: XCTestCase {
 
     func testManagerOnMessageDismissed() {
         let message = createMessage(messageId: messageId)
-        sut.onMessageDismissed(message)
+        subject.onMessageDismissed(message)
         let messageMetadata = messagingStore.getMessageMetadata(messageId: messageId)
         XCTAssertEqual(messageMetadata.dismissals, 1)
         XCTAssertTrue(messageMetadata.isExpired)
@@ -103,7 +103,7 @@ class MockGleanPlumbMessageStore: GleanPlumbMessageStoreProtocol {
                                              dismissals: 0,
                                              isExpired: false)
     }
-
+    
     func getMessageMetadata(messageId: String) -> GleanPlumbMessageMetaData {
         return metadata
     }

--- a/Tests/ClientTests/GleanPlumbMessageStoreTests.swift
+++ b/Tests/ClientTests/GleanPlumbMessageStoreTests.swift
@@ -8,24 +8,24 @@ import XCTest
 
 class GleanPlumbMessageStoreTests: XCTestCase {
 
-    var sut: GleanPlumbMessageStore!
+    var subject: GleanPlumbMessageStore!
     let messageId = "testId"
 
     override func setUp() {
         super.setUp()
-        sut = GleanPlumbMessageStore()
+        subject = GleanPlumbMessageStore()
         resetUserDefaults()
     }
 
     override func tearDown() {
         super.tearDown()
         resetUserDefaults()
-        sut = nil
+        subject = nil
     }
 
     func testImpression_OnMessageDisplayed() {
         let message = createMessage(messageId: messageId)
-        sut.onMessageDisplayed(message)
+        subject.onMessageDisplayed(message)
 
         XCTAssertEqual(message.metadata.impressions, 1)
         XCTAssertFalse(message.metadata.isExpired)
@@ -33,8 +33,8 @@ class GleanPlumbMessageStoreTests: XCTestCase {
 
     func testOnMessageExpired_WhenPressed() {
         let message = createMessage(messageId: messageId)
-        sut.onMessageDisplayed(message)
-        sut.onMessagePressed(message)
+        subject.onMessageDisplayed(message)
+        subject.onMessagePressed(message)
 
         XCTAssertEqual(message.metadata.impressions, 1)
         XCTAssertTrue(message.metadata.isExpired)
@@ -42,8 +42,8 @@ class GleanPlumbMessageStoreTests: XCTestCase {
 
     func testOnMessageExpired_WhenDismiss() {
         let message = createMessage(messageId: messageId)
-        sut.onMessageDisplayed(message)
-        sut.onMessageDismissed(message)
+        subject.onMessageDisplayed(message)
+        subject.onMessageDismissed(message)
 
         XCTAssertEqual(message.metadata.impressions, 1)
         XCTAssertTrue(message.metadata.isExpired)
@@ -58,7 +58,7 @@ class GleanPlumbMessageStoreTests: XCTestCase {
                                  action: "MAKE_DEFAULT",
                                  triggers: ["ALWAYS"],
                                  style: styleData,
-                                 metadata: sut.getMessageMetadata(messageId: messageId))
+                                 metadata: subject.getMessageMetadata(messageId: messageId))
     }
 
     private func resetUserDefaults() {

--- a/Tests/ClientTests/HistoryPanelViewModelTests.swift
+++ b/Tests/ClientTests/HistoryPanelViewModelTests.swift
@@ -10,7 +10,7 @@ import Shared
 
 class HistoryPanelViewModelTests: XCTestCase {
 
-    var sut: HistoryPanelViewModel!
+    var subject: HistoryPanelViewModel!
     var profile: MockProfile!
 
     override func setUp() {
@@ -20,7 +20,7 @@ class HistoryPanelViewModelTests: XCTestCase {
 
         ThemeManager.shared.updateProfile(with: profile)
         profile._reopen()
-        sut = HistoryPanelViewModel(profile: profile)
+        subject = HistoryPanelViewModel(profile: profile)
     }
 
     override func tearDown() {
@@ -29,7 +29,7 @@ class HistoryPanelViewModelTests: XCTestCase {
         clear(profile.history)
         profile._shutdown()
         profile = nil
-        sut = nil
+        subject = nil
     }
 
     func testHistorySectionTitle() {
@@ -56,14 +56,14 @@ class HistoryPanelViewModelTests: XCTestCase {
 
         fetchHistory { success in
             XCTAssertTrue(success)
-            XCTAssertNotNil(self.sut.searchTermGroups)
-            XCTAssertFalse(self.sut.groupedSites.isEmpty)
-            XCTAssertFalse(self.sut.visibleSections.isEmpty)
+            XCTAssertNotNil(self.subject.searchTermGroups)
+            XCTAssertFalse(self.subject.groupedSites.isEmpty)
+            XCTAssertFalse(self.subject.visibleSections.isEmpty)
         }
     }
 
     func testFetchHistoryFail_WithFetchInProgress() {
-        sut.isFetchInProgress = true
+        subject.isFetchInProgress = true
 
         fetchHistory { success in
             XCTAssertFalse(success)
@@ -73,7 +73,7 @@ class HistoryPanelViewModelTests: XCTestCase {
     func testPerformSearch_ForNoResults() {
         fetchSearchHistory(searchTerm: "moz") { hasResults in
             XCTAssertFalse(hasResults)
-            XCTAssertEqual(self.sut.searchResultSites.count, 0)
+            XCTAssertEqual(self.subject.searchResultSites.count, 0)
         }
     }
 
@@ -82,99 +82,99 @@ class HistoryPanelViewModelTests: XCTestCase {
 
         fetchSearchHistory(searchTerm: "moz") { hasResults in
             XCTAssertTrue(hasResults)
-            XCTAssertEqual(self.sut.searchResultSites.count, 2)
+            XCTAssertEqual(self.subject.searchResultSites.count, 2)
         }
     }
 
     func testEmptyStateText_ForSearch() {
-        sut.isSearchInProgress = true
-        XCTAssertEqual(sut.emptyStateText, .LibraryPanel.History.NoHistoryResult)
+        subject.isSearchInProgress = true
+        XCTAssertEqual(subject.emptyStateText, .LibraryPanel.History.NoHistoryResult)
     }
 
     func testEmptyStateText_ForHistoryResults() {
-        sut.isSearchInProgress = false
-        XCTAssertEqual(sut.emptyStateText, .HistoryPanelEmptyStateTitle)
+        subject.isSearchInProgress = false
+        XCTAssertEqual(subject.emptyStateText, .HistoryPanelEmptyStateTitle)
     }
 
     func testShouldShowEmptyState_ForEmptySearch() {
         setupSiteVisits()
-        sut.isSearchInProgress = true
+        subject.isSearchInProgress = true
 
         fetchSearchHistory(searchTerm: "") { hasResults in
-            XCTAssertFalse(self.sut.shouldShowEmptyState(searchText: ""))
+            XCTAssertFalse(self.subject.shouldShowEmptyState(searchText: ""))
         }
     }
 
     func testShouldShowEmptyState_ForNoResultSearch() {
         setupSiteVisits()
-        sut.isSearchInProgress = true
+        subject.isSearchInProgress = true
 
         fetchSearchHistory(searchTerm: "ui") { hasResults in
-            XCTAssertTrue(self.sut.shouldShowEmptyState(searchText: "ui"))
+            XCTAssertTrue(self.subject.shouldShowEmptyState(searchText: "ui"))
         }
     }
 
     func testShouldShowEmptyState_ForNoHistory() {
-        sut.isSearchInProgress = false
+        subject.isSearchInProgress = false
 
         fetchHistory { _ in
-            XCTAssertTrue(self.sut.shouldShowEmptyState())
+            XCTAssertTrue(self.subject.shouldShowEmptyState())
         }
     }
 
     func testCollapseSection() {
         setupSiteVisits()
-        XCTAssertTrue(sut.hiddenSections.isEmpty)
+        XCTAssertTrue(subject.hiddenSections.isEmpty)
 
         fetchHistory { _ in
-            self.sut.collapseSection(sectionIndex: 1)
-            XCTAssertEqual(self.sut.hiddenSections.count, 1)
+            self.subject.collapseSection(sectionIndex: 1)
+            XCTAssertEqual(self.subject.hiddenSections.count, 1)
             // Starts at 0, removing the Additional section
-            XCTAssertTrue(self.sut.isSectionCollapsed(sectionIndex: 0))
-            XCTAssertTrue(self.sut.hiddenSections.contains(where: { $0 == .today }))
+            XCTAssertTrue(self.subject.isSectionCollapsed(sectionIndex: 0))
+            XCTAssertTrue(self.subject.hiddenSections.contains(where: { $0 == .today }))
         }
     }
 
     func testExpandSection() {
         setupSiteVisits()
-        XCTAssertTrue(sut.hiddenSections.isEmpty)
+        XCTAssertTrue(subject.hiddenSections.isEmpty)
 
         fetchHistory { _ in
-            self.sut.collapseSection(sectionIndex: 1)
-            XCTAssertEqual(self.sut.hiddenSections.count, 1)
+            self.subject.collapseSection(sectionIndex: 1)
+            XCTAssertEqual(self.subject.hiddenSections.count, 1)
             // Starts at 0, removing the Additional section
-            XCTAssertTrue(self.sut.isSectionCollapsed(sectionIndex: 0))
-            XCTAssertTrue(self.sut.hiddenSections.contains(where: { $0 == .today }))
+            XCTAssertTrue(self.subject.isSectionCollapsed(sectionIndex: 0))
+            XCTAssertTrue(self.subject.hiddenSections.contains(where: { $0 == .today }))
 
-            self.sut.collapseSection(sectionIndex: 1)
-            XCTAssertTrue(self.sut.hiddenSections.isEmpty)
-            XCTAssertFalse(self.sut.isSectionCollapsed(sectionIndex: 1))
+            self.subject.collapseSection(sectionIndex: 1)
+            XCTAssertTrue(self.subject.hiddenSections.isEmpty)
+            XCTAssertFalse(self.subject.isSectionCollapsed(sectionIndex: 1))
         }
     }
 
     func testRemoveAllData() {
         setupSiteVisits()
-        XCTAssertTrue(sut.hiddenSections.isEmpty)
+        XCTAssertTrue(subject.hiddenSections.isEmpty)
 
         fetchHistory { _ in
-            self.sut.removeAllData()
+            self.subject.removeAllData()
 
-            XCTAssertEqual(self.sut.currentFetchOffset, 0)
-            XCTAssertTrue(self.sut.searchTermGroups.isEmpty)
-            XCTAssertTrue(self.sut.groupedSites.isEmpty)
-            XCTAssertTrue(self.sut.visibleSections.isEmpty)
+            XCTAssertEqual(self.subject.currentFetchOffset, 0)
+            XCTAssertTrue(self.subject.searchTermGroups.isEmpty)
+            XCTAssertTrue(self.subject.groupedSites.isEmpty)
+            XCTAssertTrue(self.subject.visibleSections.isEmpty)
         }
     }
 
     func testShouldNotAddGroupToSections() {
         let searchTermGroup = createSearchTermGroup(timestamp: Date().toMicrosecondsSince1970())
-        XCTAssertNil(self.sut.shouldAddGroupToSections(group: searchTermGroup))
+        XCTAssertNil(self.subject.shouldAddGroupToSections(group: searchTermGroup))
     }
 
     func testGroupBelongToSection_ForToday() {
         let searchTermGroup = createSearchTermGroup(timestamp: Date().toMicrosecondsSince1970())
 
-        guard let section = self.sut.groupBelongsToSection(asGroup: searchTermGroup) else {
+        guard let section = self.subject.groupBelongsToSection(asGroup: searchTermGroup) else {
             XCTFail("Expected to return today section")
             return
         }
@@ -186,7 +186,7 @@ class HistoryPanelViewModelTests: XCTestCase {
         let yesterday = Date.yesterday
         let searchTermGroup = createSearchTermGroup(timestamp: yesterday.toMicrosecondsSince1970())
 
-        guard let section = self.sut.groupBelongsToSection(asGroup: searchTermGroup) else {
+        guard let section = self.subject.groupBelongsToSection(asGroup: searchTermGroup) else {
             XCTFail("Expected to return today section")
             return
         }
@@ -198,7 +198,7 @@ class HistoryPanelViewModelTests: XCTestCase {
         let yesterday = Date().lastWeek
         let searchTermGroup = createSearchTermGroup(timestamp: yesterday.toMicrosecondsSince1970())
 
-        guard let section = self.sut.groupBelongsToSection(asGroup: searchTermGroup) else {
+        guard let section = self.subject.groupBelongsToSection(asGroup: searchTermGroup) else {
             XCTFail("Expected to return today section")
             return
         }
@@ -210,7 +210,7 @@ class HistoryPanelViewModelTests: XCTestCase {
         let yesterday = Date().lastTwoWeek
         let searchTermGroup = createSearchTermGroup(timestamp: yesterday.toMicrosecondsSince1970())
 
-        guard let section = self.sut.groupBelongsToSection(asGroup: searchTermGroup) else {
+        guard let section = self.subject.groupBelongsToSection(asGroup: searchTermGroup) else {
             XCTFail("Expected to return today section")
             return
         }
@@ -220,9 +220,9 @@ class HistoryPanelViewModelTests: XCTestCase {
 
     func testShouldAddGroupToSections_ForToday() {
         let searchTermGroup = createSearchTermGroup(timestamp: Date().toMicrosecondsSince1970())
-        sut.visibleSections.append(.today)
+        subject.visibleSections.append(.today)
 
-        guard let section = self.sut.shouldAddGroupToSections(group: searchTermGroup) else {
+        guard let section = self.subject.shouldAddGroupToSections(group: searchTermGroup) else {
             XCTFail("Expected to return today section")
             return
         }
@@ -250,7 +250,7 @@ class HistoryPanelViewModelTests: XCTestCase {
     private func fetchHistory(completion: @escaping (Bool) -> Void) {
         let expectation = self.expectation(description: "Wait for history")
 
-        sut.reloadData { success in
+        subject.reloadData { success in
             XCTAssertNotNil(success)
             completion(success)
             expectation.fulfill()
@@ -263,7 +263,7 @@ class HistoryPanelViewModelTests: XCTestCase {
                                     completion: @escaping (Bool) -> Void) {
         let expectation = self.expectation(description: "Wait for history search")
 
-        sut.performSearch(term: searchTerm) { hasResults in
+        subject.performSearch(term: searchTerm) { hasResults in
             XCTAssertNotNil(hasResults)
             completion(hasResults)
             expectation.fulfill()

--- a/Tests/ClientTests/LibraryViewModelTests.swift
+++ b/Tests/ClientTests/LibraryViewModelTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 class LibraryViewModelTests: XCTestCase {
 
-    private var sut: LibraryViewModel!
+    private var subject: LibraryViewModel!
     private var profile: MockProfile!
     private var tabManager: TabManager!
 
@@ -31,18 +31,18 @@ class LibraryViewModelTests: XCTestCase {
     }
 
     func testInitialState_Init() {
-        sut = LibraryViewModel(withProfile: profile, tabManager: tabManager)
-        sut.selectedPanel = .bookmarks
+        subject = LibraryViewModel(withProfile: profile, tabManager: tabManager)
+        subject.selectedPanel = .bookmarks
 
-        XCTAssertTrue(sut.currentPanelState == .bookmarks(state: .mainView))
-        XCTAssertEqual(sut.panelDescriptors.count, 4)
+        XCTAssertTrue(subject.currentPanelState == .bookmarks(state: .mainView))
+        XCTAssertEqual(subject.panelDescriptors.count, 4)
     }
 
     func testLibraryPanelTitle() {
-        sut = LibraryViewModel(withProfile: profile, tabManager: tabManager)
-        sut.selectedPanel = .bookmarks
+        subject = LibraryViewModel(withProfile: profile, tabManager: tabManager)
+        subject.selectedPanel = .bookmarks
 
-        for panel in sut.panelDescriptors {
+        for panel in subject.panelDescriptors {
             switch panel.panelType {
             case .bookmarks:
                 XCTAssertEqual(panel.panelType.title, .AppMenu.AppMenuBookmarksTitleString)
@@ -60,7 +60,7 @@ class LibraryViewModelTests: XCTestCase {
 
     func testBookmarksButtons_MainFolder() {
         setup(panelType: .bookmarks)
-        guard let panel = sut.currentPanel as? BookmarksPanel else {
+        guard let panel = subject.currentPanel as? BookmarksPanel else {
             XCTFail("Expected bookmark panel")
             return
         }
@@ -73,7 +73,7 @@ class LibraryViewModelTests: XCTestCase {
 
     func testBookmarksButtons_SubFolder() {
         setup(panelType: .bookmarks)
-        guard let panel = sut.currentPanel as? BookmarksPanel else {
+        guard let panel = subject.currentPanel as? BookmarksPanel else {
             XCTFail("Expected bookmark panel")
             return
         }
@@ -88,7 +88,7 @@ class LibraryViewModelTests: XCTestCase {
 
     func testBookmarks_FolderEditMode() {
         setup(panelType: .bookmarks)
-        guard let panel = sut.currentPanel as? BookmarksPanel else {
+        guard let panel = subject.currentPanel as? BookmarksPanel else {
             XCTFail("Expected bookmark panel")
             return
         }
@@ -96,7 +96,7 @@ class LibraryViewModelTests: XCTestCase {
         panel.updatePanelState(newState: .bookmarks(state: .inFolder))
         panel.enableEditMode()
 
-        XCTAssertEqual(sut.currentPanelState, .bookmarks(state: .inFolderEditMode))
+        XCTAssertEqual(subject.currentPanelState, .bookmarks(state: .inFolderEditMode))
         let toolbarItems = panel.bottomToolbarItems
         // We need to account for the flexibleSpace item
         XCTAssertEqual(toolbarItems.count, 3, "Expected Add, Done button and flexibleSpace")
@@ -104,7 +104,7 @@ class LibraryViewModelTests: XCTestCase {
 
     func testBookmarks_ItemEditMode() {
         setup(panelType: .bookmarks)
-        guard let panel = sut.currentPanel as? BookmarksPanel else {
+        guard let panel = subject.currentPanel as? BookmarksPanel else {
             XCTFail("Expected bookmark panel")
             return
         }
@@ -120,7 +120,7 @@ class LibraryViewModelTests: XCTestCase {
 
     func testBookmarks_MainFolderLeavingEdit() {
         setup(panelType: .bookmarks)
-        guard let panel = sut.currentPanel as? BookmarksPanel else {
+        guard let panel = subject.currentPanel as? BookmarksPanel else {
             XCTFail("Expected bookmark panel")
             return
         }
@@ -128,7 +128,7 @@ class LibraryViewModelTests: XCTestCase {
         panel.updatePanelState(newState: .bookmarks(state: .itemEditMode))
         panel.disableEditMode()
 
-        XCTAssertEqual(sut.currentPanelState, .bookmarks(state: .mainView))
+        XCTAssertEqual(subject.currentPanelState, .bookmarks(state: .mainView))
         let toolbarItems = panel.bottomToolbarItems
         // We need to account for the flexibleSpace item
         XCTAssertEqual(toolbarItems.count, 2, "Expected Edit button and flexibleSpace")
@@ -136,7 +136,7 @@ class LibraryViewModelTests: XCTestCase {
 
     func testBookmarksBack_ForInFolder() {
         setup(panelType: .bookmarks)
-        guard let panel = sut.currentPanel as? BookmarksPanel else {
+        guard let panel = subject.currentPanel as? BookmarksPanel else {
             XCTFail("Expected bookmark panel")
             return
         }
@@ -144,7 +144,7 @@ class LibraryViewModelTests: XCTestCase {
         panel.updatePanelState(newState: .bookmarks(state: .inFolder))
         panel.handleLeftTopButton()
 
-        XCTAssertEqual(sut.currentPanelState, .bookmarks(state: .mainView))
+        XCTAssertEqual(subject.currentPanelState, .bookmarks(state: .mainView))
         let toolbarItems = panel.bottomToolbarItems
         // We need to account for the flexibleSpace item
         XCTAssertEqual(toolbarItems.count, 2, "Expected Edit button and flexibleSpace")
@@ -152,7 +152,7 @@ class LibraryViewModelTests: XCTestCase {
 
     func testBookmarksBack_ForItemEditMode() {
         setup(panelType: .bookmarks)
-        guard let panel = sut.currentPanel as? BookmarksPanel else {
+        guard let panel = subject.currentPanel as? BookmarksPanel else {
             XCTFail("Expected bookmark panel")
             return
         }
@@ -160,7 +160,7 @@ class LibraryViewModelTests: XCTestCase {
         panel.updatePanelState(newState: .bookmarks(state: .itemEditMode))
         panel.handleLeftTopButton()
 
-        XCTAssertEqual(sut.currentPanelState, .bookmarks(state: .inFolderEditMode))
+        XCTAssertEqual(subject.currentPanelState, .bookmarks(state: .inFolderEditMode))
         let toolbarItems = panel.bottomToolbarItems
         // We need to account for the flexibleSpace item
         XCTAssertEqual(toolbarItems.count, 3, "Expected Edit button and flexibleSpace")
@@ -168,7 +168,7 @@ class LibraryViewModelTests: XCTestCase {
 
     func testBookmarksShouldDismissOnDone_ForMain() {
         setup(panelType: .bookmarks)
-        guard let panel = sut.currentPanel as? BookmarksPanel else {
+        guard let panel = subject.currentPanel as? BookmarksPanel else {
             XCTFail("Expected history panel")
             return
         }
@@ -179,7 +179,7 @@ class LibraryViewModelTests: XCTestCase {
 
     func testBookmarksShouldDismissOnDone_ForInFolder() {
         setup(panelType: .bookmarks)
-        guard let panel = sut.currentPanel as? BookmarksPanel else {
+        guard let panel = subject.currentPanel as? BookmarksPanel else {
             XCTFail("Expected history panel")
             return
         }
@@ -190,7 +190,7 @@ class LibraryViewModelTests: XCTestCase {
 
     func testBookmarksShouldDismissOnDone_ForFolderEditMode() {
         setup(panelType: .bookmarks)
-        guard let panel = sut.currentPanel as? BookmarksPanel else {
+        guard let panel = subject.currentPanel as? BookmarksPanel else {
             XCTFail("Expected history panel")
             return
         }
@@ -201,7 +201,7 @@ class LibraryViewModelTests: XCTestCase {
 
     func testBookmarksShouldDismissOnDone_ForItemEditMode() {
         setup(panelType: .bookmarks)
-        guard let panel = sut.currentPanel as? BookmarksPanel else {
+        guard let panel = subject.currentPanel as? BookmarksPanel else {
             XCTFail("Expected history panel")
             return
         }
@@ -214,19 +214,19 @@ class LibraryViewModelTests: XCTestCase {
     func testHistoryButtons() {
         setup(panelType: .history)
 
-        guard let panel = sut.currentPanel as? HistoryPanel else {
+        guard let panel = subject.currentPanel as? HistoryPanel else {
             XCTFail("Expected history panel")
             return
         }
 
-        XCTAssertTrue(sut.currentPanelState == .history(state: .mainView))
+        XCTAssertTrue(subject.currentPanelState == .history(state: .mainView))
         // There is 2 flexible space to keep buttons to the left
         XCTAssertEqual(panel.bottomToolbarItems.count, 4, "Expected Delete, Search buttons and 2 flexible spaces")
     }
 
     func testHistorySearch_ForStartSearch() {
         setup(panelType: .history)
-        guard let panel = sut.currentPanel as? HistoryPanel else {
+        guard let panel = subject.currentPanel as? HistoryPanel else {
             XCTFail("Expected history panel")
             return
         }
@@ -234,7 +234,7 @@ class LibraryViewModelTests: XCTestCase {
         panel.updatePanelState(newState: .history(state: .mainView))
         panel.startSearchState()
 
-        XCTAssertEqual(sut.currentPanelState, .history(state: .search))
+        XCTAssertEqual(subject.currentPanelState, .history(state: .search))
         let toolbarItems = panel.bottomToolbarItems
         // We need to account for the flexibleSpace item
         XCTAssertEqual(toolbarItems.count, 4, "Expected Edit button and flexibleSpace")
@@ -242,7 +242,7 @@ class LibraryViewModelTests: XCTestCase {
 
     func testHistorySearch_ForExitSearch() {
         setup(panelType: .history)
-        guard let panel = sut.currentPanel as? HistoryPanel else {
+        guard let panel = subject.currentPanel as? HistoryPanel else {
             XCTFail("Expected history panel")
             return
         }
@@ -250,7 +250,7 @@ class LibraryViewModelTests: XCTestCase {
         panel.updatePanelState(newState: .history(state: .search))
         panel.handleRightTopButton()
 
-        XCTAssertEqual(sut.currentPanelState, .history(state: .mainView))
+        XCTAssertEqual(subject.currentPanelState, .history(state: .mainView))
         let toolbarItems = panel.bottomToolbarItems
         // We need to account for the flexibleSpace item
         XCTAssertEqual(toolbarItems.count, 4, "Expected Edit button and flexibleSpace")
@@ -258,7 +258,7 @@ class LibraryViewModelTests: XCTestCase {
 
     func testHistoryInFolder() {
         setup(panelType: .history)
-        guard let panel = sut.currentPanel as? HistoryPanel else {
+        guard let panel = subject.currentPanel as? HistoryPanel else {
             XCTFail("Expected history panel")
             return
         }
@@ -269,7 +269,7 @@ class LibraryViewModelTests: XCTestCase {
 
     func testHistoryMain_ForBackButtonPress() {
         setup(panelType: .history)
-        guard let panel = sut.currentPanel as? HistoryPanel else {
+        guard let panel = subject.currentPanel as? HistoryPanel else {
             XCTFail("Expected history panel")
             return
         }
@@ -277,7 +277,7 @@ class LibraryViewModelTests: XCTestCase {
         panel.updatePanelState(newState: .history(state: .inFolder))
         panel.handleLeftTopButton()
 
-        XCTAssertEqual(sut.currentPanelState, .history(state: .mainView))
+        XCTAssertEqual(subject.currentPanelState, .history(state: .mainView))
         let toolbarItems = panel.bottomToolbarItems
         // We need to account for the flexibleSpace item
         XCTAssertEqual(toolbarItems.count, 4, "Expected Edit button and flexibleSpace")
@@ -285,7 +285,7 @@ class LibraryViewModelTests: XCTestCase {
 
     func testHistoryShouldDismissOnDone_ForSearch() {
         setup(panelType: .history)
-        guard let panel = sut.currentPanel as? HistoryPanel else {
+        guard let panel = subject.currentPanel as? HistoryPanel else {
             XCTFail("Expected history panel")
             return
         }
@@ -296,7 +296,7 @@ class LibraryViewModelTests: XCTestCase {
 
     func testHistoryShouldDismissOnDone_ForMain() {
         setup(panelType: .history)
-        guard let panel = sut.currentPanel as? HistoryPanel else {
+        guard let panel = subject.currentPanel as? HistoryPanel else {
             XCTFail("Expected history panel")
             return
         }
@@ -307,7 +307,7 @@ class LibraryViewModelTests: XCTestCase {
 
     func testHistoryShouldDismissOnDone_ForInFolder() {
         setup(panelType: .history)
-        guard let panel = sut.currentPanel as? HistoryPanel else {
+        guard let panel = subject.currentPanel as? HistoryPanel else {
             XCTFail("Expected history panel")
             return
         }
@@ -320,19 +320,19 @@ class LibraryViewModelTests: XCTestCase {
     func testReaderPanelButtons() {
         setup(panelType: .readingList)
 
-        guard let panel = sut.currentPanel as? ReadingListPanel else {
+        guard let panel = subject.currentPanel as? ReadingListPanel else {
             XCTFail("Expected reading list panel")
             return
         }
 
-        XCTAssertTrue(sut.currentPanelState == .readingList)
+        XCTAssertTrue(subject.currentPanelState == .readingList)
         XCTAssertTrue(panel.bottomToolbarItems.isEmpty)
     }
 
     func testReaderPanel_ShouldDismissOnDone() {
         setup(panelType: .readingList)
 
-        guard let panel = sut.currentPanel as? ReadingListPanel else {
+        guard let panel = subject.currentPanel as? ReadingListPanel else {
             XCTFail("Expected reading list panel")
             return
         }
@@ -344,19 +344,19 @@ class LibraryViewModelTests: XCTestCase {
     func testDownloadsPanelButtons() {
         setup(panelType: .downloads)
 
-        guard let panel = sut.currentPanel as? DownloadsPanel else {
+        guard let panel = subject.currentPanel as? DownloadsPanel else {
             XCTFail("Expected downloads panel")
             return
         }
 
-        XCTAssertTrue(sut.currentPanelState == .downloads)
+        XCTAssertTrue(subject.currentPanelState == .downloads)
         XCTAssertTrue(panel.bottomToolbarItems.isEmpty)
     }
 
     func testDownloadsPanel_ShouldDismissOnDone() {
         setup(panelType: .downloads)
 
-        guard let panel = sut.currentPanel as? DownloadsPanel else {
+        guard let panel = subject.currentPanel as? DownloadsPanel else {
             XCTFail("Expected reading list panel")
             return
         }
@@ -366,8 +366,8 @@ class LibraryViewModelTests: XCTestCase {
 
     // MARK: - Helper functions
     private func setup(panelType: LibraryPanelType) {
-        sut = LibraryViewModel(withProfile: profile, tabManager: tabManager)
-        sut.selectedPanel = panelType
-        sut.setupNavigationController()
+        subject = LibraryViewModel(withProfile: profile, tabManager: tabManager)
+        subject.selectedPanel = panelType
+        subject.setupNavigationController()
     }
 }

--- a/Tests/ClientTests/LoginsListDataSourceHelperTests.swift
+++ b/Tests/ClientTests/LoginsListDataSourceHelperTests.swift
@@ -10,30 +10,30 @@ import XCTest
 class LoginListDataSourceHelperTests: XCTestCase {
 
     func testSetDomainLookup() {
-        let sut = LoginListDataSourceHelper()
+        let subject = LoginListDataSourceHelper()
         let login = LoginRecord(fromJSONDict: [
             "hostname": "https://example.com/",
             "id": "example"
         ])
-        sut.setDomainLookup([login])
-        XCTAssertNotNil(sut.domainLookup[login.id])
-        XCTAssertEqual(sut.domainLookup[login.id]?.baseDomain, login.hostname.asURL?.baseDomain)
-        XCTAssertEqual(sut.domainLookup[login.id]?.host, login.hostname.asURL?.host)
-        XCTAssertEqual(sut.domainLookup[login.id]?.hostname, login.hostname)
+        subject.setDomainLookup([login])
+        XCTAssertNotNil(subject.domainLookup[login.id])
+        XCTAssertEqual(subject.domainLookup[login.id]?.baseDomain, login.hostname.asURL?.baseDomain)
+        XCTAssertEqual(subject.domainLookup[login.id]?.host, login.hostname.asURL?.host)
+        XCTAssertEqual(subject.domainLookup[login.id]?.hostname, login.hostname)
     }
 
     func testTitleForLogin() {
-        let sut = LoginListDataSourceHelper()
+        let subject = LoginListDataSourceHelper()
         let login = LoginRecord(fromJSONDict: [
             "hostname": "https://example.com/",
             "id": "example"
         ])
-        sut.setDomainLookup([login])
-        XCTAssertEqual(sut.titleForLogin(login), Character("E"))
+        subject.setDomainLookup([login])
+        XCTAssertEqual(subject.titleForLogin(login), Character("E"))
     }
 
     func testSortByDomain() {
-        let sut = LoginListDataSourceHelper()
+        let subject = LoginListDataSourceHelper()
         let apple = LoginRecord(fromJSONDict: [
             "hostname": "https://apple.com/",
             "id": "apple"
@@ -42,15 +42,15 @@ class LoginListDataSourceHelperTests: XCTestCase {
             "hostname": "https://zebra.com/",
             "id": "zebra"
         ])
-        XCTAssertFalse(sut.sortByDomain(apple, loginB: zebra))
+        XCTAssertFalse(subject.sortByDomain(apple, loginB: zebra))
 
-        sut.setDomainLookup([apple, zebra])
-        XCTAssertTrue(sut.sortByDomain(apple, loginB: zebra))
-        XCTAssertFalse(sut.sortByDomain(zebra, loginB: apple))
+        subject.setDomainLookup([apple, zebra])
+        XCTAssertTrue(subject.sortByDomain(apple, loginB: zebra))
+        XCTAssertFalse(subject.sortByDomain(zebra, loginB: apple))
     }
 
     func testComputeSectionsFromLogins() {
-        let sut = LoginListDataSourceHelper()
+        let subject = LoginListDataSourceHelper()
         let apple = LoginRecord(fromJSONDict: [
             "hostname": "https://apple.com/",
             "id": "apple"
@@ -70,9 +70,9 @@ class LoginListDataSourceHelperTests: XCTestCase {
         expected[Character("Z")] = [zebra]
 
         let logins = [apple, appleMusic, zebra]
-        sut.setDomainLookup(logins)
+        subject.setDomainLookup(logins)
         let expectation = expectation(description: "Compute sections from login done")
-        sut.computeSectionsFromLogins(logins).upon { (formattedLoginsMaybe) in
+        subject.computeSectionsFromLogins(logins).upon { (formattedLoginsMaybe) in
             XCTAssertTrue(formattedLoginsMaybe.isSuccess)
             XCTAssertNotNil(formattedLoginsMaybe.successValue)
             let formattedLogins = formattedLoginsMaybe.successValue

--- a/Tests/ClientTests/OnboardingCardViewModelTests.swift
+++ b/Tests/ClientTests/OnboardingCardViewModelTests.swift
@@ -9,7 +9,7 @@ import Glean
 
 class OnboardingCardViewModelTests: XCTestCase {
 
-    var sut: OnboardingCardViewModel!
+    var subject: OnboardingCardViewModel!
 
     override func setUp() {
         super.setUp()
@@ -19,124 +19,124 @@ class OnboardingCardViewModelTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         Glean.shared.resetGlean(clearStores: true)
-        sut = nil
+        subject = nil
     }
 
     func testSendOnboardingCardView_WelcomeCard() {
-        sut = OnboardingCardViewModel(cardType: .welcome,
-                                      infoModel: createInfoModel(),
-                                      isv106Version: false)
-        sut.sendCardViewTelemetry()
+        subject = OnboardingCardViewModel(cardType: .welcome,
+                                          infoModel: createInfoModel(),
+                                          isv106Version: false)
+        subject.sendCardViewTelemetry()
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.cardView)
     }
 
     func testSendOnboardingCardView_WallpaperCard() {
-        sut = OnboardingCardViewModel(cardType: .wallpapers,
-                                      infoModel: createInfoModel(),
-                                      isv106Version: false)
-        sut.sendCardViewTelemetry()
+        subject = OnboardingCardViewModel(cardType: .wallpapers,
+                                          infoModel: createInfoModel(),
+                                          isv106Version: false)
+        subject.sendCardViewTelemetry()
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.cardView)
     }
 
     func testSendOnboardingCardView_SyncCard() {
-        sut = OnboardingCardViewModel(cardType: .signSync,
-                                      infoModel: createInfoModel(),
-                                      isv106Version: false)
-        sut.sendCardViewTelemetry()
+        subject = OnboardingCardViewModel(cardType: .signSync,
+                                          infoModel: createInfoModel(),
+                                          isv106Version: false)
+        subject.sendCardViewTelemetry()
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.cardView)
     }
 
     func testSendUpgradeCardView_WelcomeCard() {
-        sut = OnboardingCardViewModel(cardType: .updateWelcome,
-                                      infoModel: createInfoModel(),
-                                      isv106Version: false)
-        sut.sendCardViewTelemetry()
+        subject = OnboardingCardViewModel(cardType: .updateWelcome,
+                                          infoModel: createInfoModel(),
+                                          isv106Version: false)
+        subject.sendCardViewTelemetry()
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Upgrade.cardView)
     }
 
     func testSendUpgradeCardView_SyncCard() {
-        sut = OnboardingCardViewModel(cardType: .updateSignSync,
-                                      infoModel: createInfoModel(),
-                                      isv106Version: false)
-        sut.sendCardViewTelemetry()
+        subject = OnboardingCardViewModel(cardType: .updateSignSync,
+                                          infoModel: createInfoModel(),
+                                          isv106Version: false)
+        subject.sendCardViewTelemetry()
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Upgrade.cardView)
     }
 
     // MARK: - Primary tap
     func testSendOnboardingPrimaryTap_WelcomeCard() {
-        sut = OnboardingCardViewModel(cardType: .welcome,
-                                      infoModel: createInfoModel(),
-                                      isv106Version: false)
-        sut.sendTelemetryButton(isPrimaryAction: true)
+        subject = OnboardingCardViewModel(cardType: .welcome,
+                                          infoModel: createInfoModel(),
+                                          isv106Version: false)
+        subject.sendTelemetryButton(isPrimaryAction: true)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.primaryButtonTap)
     }
 
     func testSendOnboardingPrimaryTap_WallpaperCard() {
-        sut = OnboardingCardViewModel(cardType: .wallpapers,
-                                      infoModel: createInfoModel(),
-                                      isv106Version: false)
-        sut.sendTelemetryButton(isPrimaryAction: true)
+        subject = OnboardingCardViewModel(cardType: .wallpapers,
+                                          infoModel: createInfoModel(),
+                                          isv106Version: false)
+        subject.sendTelemetryButton(isPrimaryAction: true)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.primaryButtonTap)
     }
 
     func testSendOnboardingPrimaryTap_SyncCard() {
-        sut = OnboardingCardViewModel(cardType: .signSync,
-                                      infoModel: createInfoModel(),
-                                      isv106Version: false)
-        sut.sendTelemetryButton(isPrimaryAction: true)
+        subject = OnboardingCardViewModel(cardType: .signSync,
+                                          infoModel: createInfoModel(),
+                                          isv106Version: false)
+        subject.sendTelemetryButton(isPrimaryAction: true)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.primaryButtonTap)
     }
 
     func testSendUpgradePrimaryTap_WallpaperCard() {
-        sut = OnboardingCardViewModel(cardType: .updateWelcome,
-                                      infoModel: createInfoModel(),
-                                      isv106Version: false)
-        sut.sendTelemetryButton(isPrimaryAction: true)
+        subject = OnboardingCardViewModel(cardType: .updateWelcome,
+                                          infoModel: createInfoModel(),
+                                          isv106Version: false)
+        subject.sendTelemetryButton(isPrimaryAction: true)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Upgrade.primaryButtonTap)
     }
 
     func testSendUpgradePrimaryTap_SyncCard() {
-        sut = OnboardingCardViewModel(cardType: .updateSignSync,
-                                      infoModel: createInfoModel(),
-                                      isv106Version: false)
-        sut.sendTelemetryButton(isPrimaryAction: true)
+        subject = OnboardingCardViewModel(cardType: .updateSignSync,
+                                          infoModel: createInfoModel(),
+                                          isv106Version: false)
+        subject.sendTelemetryButton(isPrimaryAction: true)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Upgrade.primaryButtonTap)
     }
 
     // MARK: - Secondary tap
     func testSendOnboardingSecondaryTap_WallpaperCard() {
-        sut = OnboardingCardViewModel(cardType: .wallpapers,
-                                      infoModel: createInfoModel(),
-                                      isv106Version: false)
-        sut.sendTelemetryButton(isPrimaryAction: false)
+        subject = OnboardingCardViewModel(cardType: .wallpapers,
+                                          infoModel: createInfoModel(),
+                                          isv106Version: false)
+        subject.sendTelemetryButton(isPrimaryAction: false)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.secondaryButtonTap)
     }
 
     func testSendOnboardingSecondaryTap_SyncCard() {
-        sut = OnboardingCardViewModel(cardType: .signSync,
-                                      infoModel: createInfoModel(),
-                                      isv106Version: false)
-        sut.sendTelemetryButton(isPrimaryAction: false)
+        subject = OnboardingCardViewModel(cardType: .signSync,
+                                          infoModel: createInfoModel(),
+                                          isv106Version: false)
+        subject.sendTelemetryButton(isPrimaryAction: false)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.secondaryButtonTap)
     }
 
     func testSendUpgradeSecondaryTap_SyncCard() {
-        sut = OnboardingCardViewModel(cardType: .updateSignSync,
-                                      infoModel: createInfoModel(),
-                                      isv106Version: false)
-        sut.sendTelemetryButton(isPrimaryAction: false)
+        subject = OnboardingCardViewModel(cardType: .updateSignSync,
+                                          infoModel: createInfoModel(),
+                                          isv106Version: false)
+        subject.sendTelemetryButton(isPrimaryAction: false)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Upgrade.secondaryButtonTap)
     }

--- a/Tests/ClientTests/SiteImageHelperTests.swift
+++ b/Tests/ClientTests/SiteImageHelperTests.swift
@@ -138,22 +138,22 @@ class SiteImageHelperTests: XCTestCase {
     }
 
     func test_faviconLoads_completesFromCache() {
-        let sut = createSiteImageHelper()
+        let subject = createSiteImageHelper()
 
         let site = Site(url: "www.a-website.com", title: "Website")
         let expectation = self.expectation(description: "Favicon image is fetched from cache")
-        sut.fetchImageFor(site: site,
-                          imageType: .favicon,
-                          shouldFallback: false,
-                          completion: { image in
+        subject.fetchImageFor(site: site,
+                              imageType: .favicon,
+                              shouldFallback: false,
+                              completion: { image in
             XCTAssertNotNil(image)
 
             // Image is now cached, fake an error to see if it's fetched from cache
-            let sut2 = self.createSiteImageHelper(shouldFaviconSucceeds: false)
-            sut2.fetchImageFor(site: site,
-                               imageType: .favicon,
-                               shouldFallback: false,
-                               completion: { image in
+            let subject2 = self.createSiteImageHelper(shouldFaviconSucceeds: false)
+            subject2.fetchImageFor(site: site,
+                                   imageType: .favicon,
+                                   shouldFallback: false,
+                                   completion: { image in
                 XCTAssertNotNil(image)
                 expectation.fulfill()
             })

--- a/Tests/ClientTests/TabManagerNavDelegateTests.swift
+++ b/Tests/ClientTests/TabManagerNavDelegateTests.swift
@@ -11,130 +11,130 @@ class TabManagerNavDelegateTests: XCTestCase {
     let navigation = WKNavigation()
 
     func test_webViewDidCommit_sendsCorrectMessage() {
-        let sutConstructor = makeSUT()
-        let sut = sutConstructor.sut
-        let delegate1 = sutConstructor.delegate1
-        let delegate2 = sutConstructor.delegate2
+        let subjectConstructor = createSubject()
+        let subject = subjectConstructor.subject
+        let delegate1 = subjectConstructor.delegate1
+        let delegate2 = subjectConstructor.delegate2
 
-        sut.insert(delegate1)
-        sut.insert(delegate2)
-        sut.webView(anyWebView(), didCommit: navigation)
+        subject.insert(delegate1)
+        subject.insert(delegate2)
+        subject.webView(anyWebView(), didCommit: navigation)
 
         XCTAssertEqual(delegate1.receivedMessages, [.webViewDidCommit])
         XCTAssertEqual(delegate2.receivedMessages, [.webViewDidCommit])
     }
 
     func test_webViewDidFail_sendsCorrectMessage() {
-        let sutConstructor = makeSUT()
-        let sut = sutConstructor.sut
-        let delegate1 = sutConstructor.delegate1
-        let delegate2 = sutConstructor.delegate2
+        let subjectConstructor = createSubject()
+        let subject = subjectConstructor.subject
+        let delegate1 = subjectConstructor.delegate1
+        let delegate2 = subjectConstructor.delegate2
 
-        sut.insert(delegate1)
-        sut.insert(delegate2)
-        sut.webView(anyWebView(), didFail: navigation, withError: anyError())
+        subject.insert(delegate1)
+        subject.insert(delegate2)
+        subject.webView(anyWebView(), didFail: navigation, withError: anyError())
 
         XCTAssertEqual(delegate1.receivedMessages, [.webViewDidFail])
         XCTAssertEqual(delegate2.receivedMessages, [.webViewDidFail])
     }
 
     func test_webViewDidFailProvisionalNavigation_sendsCorrectMessage() {
-        let sutConstructor = makeSUT()
-        let sut = sutConstructor.sut
-        let delegate1 = sutConstructor.delegate1
-        let delegate2 = sutConstructor.delegate2
+        let subjectConstructor = createSubject()
+        let subject = subjectConstructor.subject
+        let delegate1 = subjectConstructor.delegate1
+        let delegate2 = subjectConstructor.delegate2
 
-        sut.insert(delegate1)
-        sut.insert(delegate2)
-        sut.webView(anyWebView(), didFailProvisionalNavigation: navigation, withError: anyError())
+        subject.insert(delegate1)
+        subject.insert(delegate2)
+        subject.webView(anyWebView(), didFailProvisionalNavigation: navigation, withError: anyError())
 
         XCTAssertEqual(delegate1.receivedMessages, [.webViewDidFailProvisionalNavigation])
         XCTAssertEqual(delegate2.receivedMessages, [.webViewDidFailProvisionalNavigation])
     }
 
     func test_webViewDidFinish_sendsCorrectMessage() {
-        let sutConstructor = makeSUT()
-        let sut = sutConstructor.sut
-        let delegate1 = sutConstructor.delegate1
-        let delegate2 = sutConstructor.delegate2
+        let subjectConstructor = createSubject()
+        let subject = subjectConstructor.subject
+        let delegate1 = subjectConstructor.delegate1
+        let delegate2 = subjectConstructor.delegate2
 
-        sut.insert(delegate1)
-        sut.insert(delegate2)
-        sut.webView(anyWebView(), didFinish: navigation)
+        subject.insert(delegate1)
+        subject.insert(delegate2)
+        subject.webView(anyWebView(), didFinish: navigation)
 
         XCTAssertEqual(delegate1.receivedMessages, [.webViewDidFinish])
         XCTAssertEqual(delegate2.receivedMessages, [.webViewDidFinish])
     }
 
     func test_webViewWebContentProcessDidTerminate_sendsCorrectMessage() {
-        let sutConstructor = makeSUT()
-        let sut = sutConstructor.sut
-        let delegate1 = sutConstructor.delegate1
-        let delegate2 = sutConstructor.delegate2
+        let subjectConstructor = createSubject()
+        let subject = subjectConstructor.subject
+        let delegate1 = subjectConstructor.delegate1
+        let delegate2 = subjectConstructor.delegate2
 
-        sut.insert(delegate1)
-        sut.insert(delegate2)
-        sut.webViewWebContentProcessDidTerminate(anyWebView())
+        subject.insert(delegate1)
+        subject.insert(delegate2)
+        subject.webViewWebContentProcessDidTerminate(anyWebView())
 
         XCTAssertEqual(delegate1.receivedMessages, [.webViewWebContentProcessDidTerminate])
         XCTAssertEqual(delegate2.receivedMessages, [.webViewWebContentProcessDidTerminate])
     }
 
     func test_webViewDidReceiveServerRedirectForProvisionalNavigation_sendsCorrectMessage() {
-        let sutConstructor = makeSUT()
-        let sut = sutConstructor.sut
-        let delegate1 = sutConstructor.delegate1
-        let delegate2 = sutConstructor.delegate2
+        let subjectConstructor = createSubject()
+        let subject = subjectConstructor.subject
+        let delegate1 = subjectConstructor.delegate1
+        let delegate2 = subjectConstructor.delegate2
 
-        sut.insert(delegate1)
-        sut.insert(delegate2)
-        sut.webView(anyWebView(), didReceiveServerRedirectForProvisionalNavigation: navigation)
+        subject.insert(delegate1)
+        subject.insert(delegate2)
+        subject.webView(anyWebView(), didReceiveServerRedirectForProvisionalNavigation: navigation)
 
         XCTAssertEqual(delegate1.receivedMessages, [.webViewDidReceiveServerRedirectForProvisionalNavigation])
         XCTAssertEqual(delegate2.receivedMessages, [.webViewDidReceiveServerRedirectForProvisionalNavigation])
     }
 
     func test_webViewDidStartProvisionalNavigation_sendsCorrectMessage() {
-        let sutConstructor = makeSUT()
-        let sut = sutConstructor.sut
-        let delegate1 = sutConstructor.delegate1
-        let delegate2 = sutConstructor.delegate2
+        let subjectConstructor = createSubject()
+        let subject = subjectConstructor.subject
+        let delegate1 = subjectConstructor.delegate1
+        let delegate2 = subjectConstructor.delegate2
 
-        sut.insert(delegate1)
-        sut.insert(delegate2)
-        sut.webView(anyWebView(), didStartProvisionalNavigation: navigation)
+        subject.insert(delegate1)
+        subject.insert(delegate2)
+        subject.webView(anyWebView(), didStartProvisionalNavigation: navigation)
 
         XCTAssertEqual(delegate1.receivedMessages, [.webViewDidStartProvisionalNavigation])
         XCTAssertEqual(delegate2.receivedMessages, [.webViewDidStartProvisionalNavigation])
     }
 
     func test_webViewDecidePolicyFor_actionPolicy_sendsCorrectMessage() {
-        let sutConstructor = makeSUT()
-        let sut = sutConstructor.sut
-        let delegate1 = sutConstructor.delegate1
-        let delegate2 = sutConstructor.delegate2
+        let subjectConstructor = createSubject()
+        let subject = subjectConstructor.subject
+        let delegate1 = subjectConstructor.delegate1
+        let delegate2 = subjectConstructor.delegate2
 
-        sut.insert(delegate1)
-        sut.insert(delegate2)
-        sut.webView(anyWebView(),
-                    decidePolicyFor: WKNavigationAction(),
-                    decisionHandler: { _ in })
+        subject.insert(delegate1)
+        subject.insert(delegate2)
+        subject.webView(anyWebView(),
+                        decidePolicyFor: WKNavigationAction(),
+                        decisionHandler: { _ in })
 
         XCTAssertEqual(delegate1.receivedMessages, [.webViewDecidePolicyWithActionPolicy])
         XCTAssertEqual(delegate2.receivedMessages, [.webViewDecidePolicyWithActionPolicy])
     }
 
     func test_webViewDecidePolicyFor_responsePolicy_sendsCorrectMessage() {
-        let sutConstructor = makeSUT()
-        let sut = sutConstructor.sut
-        let delegate1 = sutConstructor.delegate1
-        let delegate2 = sutConstructor.delegate2
+        let subjectConstructor = createSubject()
+        let subject = subjectConstructor.subject
+        let delegate1 = subjectConstructor.delegate1
+        let delegate2 = subjectConstructor.delegate2
 
-        sut.insert(delegate1)
-        sut.insert(delegate2)
-        sut.webView(anyWebView(),
-                    decidePolicyFor: WKNavigationResponse(),
-                    decisionHandler: { _ in })
+        subject.insert(delegate1)
+        subject.insert(delegate2)
+        subject.webView(anyWebView(),
+                        decidePolicyFor: WKNavigationResponse(),
+                        decisionHandler: { _ in })
 
         XCTAssertEqual(delegate1.receivedMessages, [.webViewDecidePolicyWithResponsePolicy])
         XCTAssertEqual(delegate2.receivedMessages, [.webViewDecidePolicyWithResponsePolicy])
@@ -144,22 +144,22 @@ class TabManagerNavDelegateTests: XCTestCase {
 // MARK: - Helpers
 
 private extension TabManagerNavDelegateTests {
-    struct SUT {
-        let sut: TabManagerNavDelegate
+    struct Subject {
+        let subject: TabManagerNavDelegate
         let delegate1: WKNavigationDelegateSpy
         let delegate2: WKNavigationDelegateSpy
     }
 
-    func makeSUT(file: StaticString = #file, line: UInt = #line) -> SUT {
-        let sut = TabManagerNavDelegate()
+    func createSubject(file: StaticString = #file, line: UInt = #line) -> Subject {
+        let subject = TabManagerNavDelegate()
         let delegate1 = WKNavigationDelegateSpy()
         let delegate2 = WKNavigationDelegateSpy()
 
-        trackForMemoryLeaks(sut, file: file, line: line)
+        trackForMemoryLeaks(subject, file: file, line: line)
         trackForMemoryLeaks(delegate1, file: file, line: line)
         trackForMemoryLeaks(delegate2, file: file, line: line)
 
-        return SUT(sut: sut, delegate1: delegate1, delegate2: delegate2)
+        return Subject(subject: subject, delegate1: delegate1, delegate2: delegate2)
     }
 
     func anyWebView() -> WKWebView {
@@ -194,7 +194,7 @@ private class WKNavigationDelegateSpy: NSObject, WKNavigationDelegate {
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         receivedMessages.append(.webViewDidFail)
     }
-
+    
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         receivedMessages.append(.webViewDidFailProvisionalNavigation)
     }

--- a/Tests/ClientTests/Wallpaper/WallpaperCollectionAvailabilityTests.swift
+++ b/Tests/ClientTests/Wallpaper/WallpaperCollectionAvailabilityTests.swift
@@ -10,28 +10,28 @@ import XCTest
 class WallpaperCollectionAvailabilityTests: XCTestCase {
 
     func testFullAvailability() {
-        let sut = WallpaperCollectionAvailability(start: nil, end: nil)
-        XCTAssertTrue(sut.isAvailable, "Wallpaper collection should be available")
+        let subject = WallpaperCollectionAvailability(start: nil, end: nil)
+        XCTAssertTrue(subject.isAvailable, "Wallpaper collection should be available")
     }
 
     func testNoEndDate() {
-        let sut = WallpaperCollectionAvailability(start: Date.yesterday, end: nil)
-        XCTAssertTrue(sut.isAvailable, "Wallpaper collection should be available")
+        let subject = WallpaperCollectionAvailability(start: Date.yesterday, end: nil)
+        XCTAssertTrue(subject.isAvailable, "Wallpaper collection should be available")
     }
 
     func testNoStartDate() {
-        let sut = WallpaperCollectionAvailability(start: nil, end: Date.tomorrow)
-        XCTAssertTrue(sut.isAvailable, "Wallpaper collection should be available")
+        let subject = WallpaperCollectionAvailability(start: nil, end: Date.tomorrow)
+        XCTAssertTrue(subject.isAvailable, "Wallpaper collection should be available")
     }
 
     func testStartDateInFuture() {
-        let sut = WallpaperCollectionAvailability(start: Date.tomorrow, end: nil)
-        XCTAssertFalse(sut.isAvailable, "Wallpaper collection should not be available")
+        let subject = WallpaperCollectionAvailability(start: Date.tomorrow, end: nil)
+        XCTAssertFalse(subject.isAvailable, "Wallpaper collection should not be available")
     }
 
     func testPastEndDate() {
-        let sut = WallpaperCollectionAvailability(start: nil, end: Date.yesterday)
-        XCTAssertFalse(sut.isAvailable, "Wallpaper collection should not be available")
+        let subject = WallpaperCollectionAvailability(start: nil, end: Date.yesterday)
+        XCTAssertFalse(subject.isAvailable, "Wallpaper collection should not be available")
     }
 
 }

--- a/Tests/ClientTests/Wallpaper/WallpaperDataServiceTests.swift
+++ b/Tests/ClientTests/Wallpaper/WallpaperDataServiceTests.swift
@@ -29,10 +29,10 @@ class WallpaperDataServiceTests: XCTestCase, WallpaperTestDataProvider {
         let expectedMetadata = getExpectedMetadata(for: .goodData)
 
         networking.result = .success(data)
-        let sut = WallpaperDataService(with: networking)
+        let subject = WallpaperDataService(with: networking)
 
         do {
-            let actualMetadata = try await sut.getMetadata()
+            let actualMetadata = try await subject.getMetadata()
             XCTAssertEqual(
                 actualMetadata,
                 expectedMetadata,
@@ -47,10 +47,10 @@ class WallpaperDataServiceTests: XCTestCase, WallpaperTestDataProvider {
         let expectedMetadata = getExpectedMetadata(for: .noLearnMoreURL)
 
         networking.result = .success(data)
-        let sut = WallpaperDataService(with: networking)
+        let subject = WallpaperDataService(with: networking)
 
         do {
-            let actualMetadata = try await sut.getMetadata()
+            let actualMetadata = try await subject.getMetadata()
             XCTAssertEqual(
                 actualMetadata,
                 expectedMetadata,
@@ -65,10 +65,10 @@ class WallpaperDataServiceTests: XCTestCase, WallpaperTestDataProvider {
         let expectedMetadata = getExpectedMetadata(for: .noAvailabilityRange)
 
         networking.result = .success(data)
-        let sut = WallpaperDataService(with: networking)
+        let subject = WallpaperDataService(with: networking)
 
         do {
-            let actualMetadata = try await sut.getMetadata()
+            let actualMetadata = try await subject.getMetadata()
             XCTAssertEqual(
                 actualMetadata,
                 expectedMetadata,
@@ -83,10 +83,10 @@ class WallpaperDataServiceTests: XCTestCase, WallpaperTestDataProvider {
         let expectedMetadata = getExpectedMetadata(for: .noLocales)
 
         networking.result = .success(data)
-        let sut = WallpaperDataService(with: networking)
+        let subject = WallpaperDataService(with: networking)
 
         do {
-            let actualMetadata = try await sut.getMetadata()
+            let actualMetadata = try await subject.getMetadata()
             XCTAssertEqual(
                 actualMetadata,
                 expectedMetadata,
@@ -101,10 +101,10 @@ class WallpaperDataServiceTests: XCTestCase, WallpaperTestDataProvider {
         let expectedMetadata = getExpectedMetadata(for: .availabilityStart)
 
         networking.result = .success(data)
-        let sut = WallpaperDataService(with: networking)
+        let subject = WallpaperDataService(with: networking)
 
         do {
-            let actualMetadata = try await sut.getMetadata()
+            let actualMetadata = try await subject.getMetadata()
             XCTAssertEqual(
                 actualMetadata,
                 expectedMetadata,
@@ -119,10 +119,10 @@ class WallpaperDataServiceTests: XCTestCase, WallpaperTestDataProvider {
         let expectedMetadata = getExpectedMetadata(for: .availabilityEnd)
 
         networking.result = .success(data)
-        let sut = WallpaperDataService(with: networking)
+        let subject = WallpaperDataService(with: networking)
 
         do {
-            let actualMetadata = try await sut.getMetadata()
+            let actualMetadata = try await subject.getMetadata()
             XCTAssertEqual(
                 actualMetadata,
                 expectedMetadata,
@@ -136,10 +136,10 @@ class WallpaperDataServiceTests: XCTestCase, WallpaperTestDataProvider {
         let data = getDataFromJSONFile(named: .badLastUpdatedDate)
 
         networking.result = .success(data)
-        let sut = WallpaperDataService(with: networking)
+        let subject = WallpaperDataService(with: networking)
 
         do {
-            _ = try await sut.getMetadata()
+            _ = try await subject.getMetadata()
             XCTFail("We should fail the extraction process")
 
         } catch let error {
@@ -153,10 +153,10 @@ class WallpaperDataServiceTests: XCTestCase, WallpaperTestDataProvider {
         let data = getDataFromJSONFile(named: .badTextColour)
 
         networking.result = .success(data)
-        let sut = WallpaperDataService(with: networking)
+        let subject = WallpaperDataService(with: networking)
 
         do {
-            _ = try await sut.getMetadata()
+            _ = try await subject.getMetadata()
             XCTFail("We should fail the extraction process")
         } catch let error {
             XCTAssertEqual(error.localizedDescription,

--- a/Tests/ClientTests/Wallpaper/WallpaperNetworkingModuleTests.swift
+++ b/Tests/ClientTests/Wallpaper/WallpaperNetworkingModuleTests.swift
@@ -14,9 +14,9 @@ class WallpaperNetworkingModuleTests: XCTestCase, WallpaperTestDataProvider {
         let dataTask = WallpaperURLSessionDataTaskMock()
         let session = WallpaperURLSessionMock(with: nil, response: nil, and: nil)
         session.dataTask = dataTask
-        let sut = WallpaperNetworkingModule(with: session)
+        let subject = WallpaperNetworkingModule(with: session)
 
-        _ = try? await sut.data(from: url)
+        _ = try? await subject.data(from: url)
         XCTAssertTrue(dataTask.resumeWasCalled)
     }
 
@@ -24,10 +24,10 @@ class WallpaperNetworkingModuleTests: XCTestCase, WallpaperTestDataProvider {
         let session = WallpaperURLSessionMock(with: nil,
                                               response: nil,
                                               and: URLError(.cannotConnectToHost))
-        let sut = WallpaperNetworkingModule(with: session)
+        let subject = WallpaperNetworkingModule(with: session)
 
         do {
-            _ = try await sut.data(from: url)
+            _ = try await subject.data(from: url)
             XCTFail("This test should throw an error, but it did not.")
         } catch {
             XCTAssertEqual(error as! URLError,
@@ -40,10 +40,10 @@ class WallpaperNetworkingModuleTests: XCTestCase, WallpaperTestDataProvider {
         let session = WallpaperURLSessionMock(with: nil,
                                               response: response,
                                               and: nil)
-        let sut = WallpaperNetworkingModule(with: session)
+        let subject = WallpaperNetworkingModule(with: session)
 
         do {
-            _ = try await sut.data(from: url)
+            _ = try await subject.data(from: url)
             XCTFail("This test should throw an error, but it did not.")
         } catch {
             XCTAssertEqual(error as! URLError,
@@ -56,10 +56,10 @@ class WallpaperNetworkingModuleTests: XCTestCase, WallpaperTestDataProvider {
         let session = WallpaperURLSessionMock(with: nil,
                                               response: response,
                                               and: nil)
-        let sut = WallpaperNetworkingModule(with: session)
+        let subject = WallpaperNetworkingModule(with: session)
 
         do {
-            _ = try await sut.data(from: url)
+            _ = try await subject.data(from: url)
             XCTFail("This test should throw an error, but it did not.")
         } catch {
             XCTAssertEqual(error as! URLError,
@@ -73,10 +73,10 @@ class WallpaperNetworkingModuleTests: XCTestCase, WallpaperTestDataProvider {
         let session = WallpaperURLSessionMock(with: data,
                                               response: response,
                                               and: nil)
-        let sut = WallpaperNetworkingModule(with: session)
+        let subject = WallpaperNetworkingModule(with: session)
 
         do {
-            let (data, _) = try await sut.data(from: url)
+            let (data, _) = try await subject.data(from: url)
             XCTAssertEqual(data, getDataFromJSONFile(named: .goodData))
         } catch {
             XCTFail("This test should not throw an error, but it did: \(error.localizedDescription)")
@@ -88,10 +88,10 @@ class WallpaperNetworkingModuleTests: XCTestCase, WallpaperTestDataProvider {
         let session = WallpaperURLSessionMock(with: nil,
                                               response: response,
                                               and: nil)
-        let sut = WallpaperNetworkingModule(with: session)
+        let subject = WallpaperNetworkingModule(with: session)
 
         do {
-            _ = try await sut.data(from: url)
+            _ = try await subject.data(from: url)
             XCTFail("This test should throw an error, but it did not.")
         } catch {
             XCTAssertEqual(error as! WallpaperServiceError,

--- a/Tests/ClientTests/Wallpaper/WallpaperURLProviderTests.swift
+++ b/Tests/ClientTests/Wallpaper/WallpaperURLProviderTests.swift
@@ -12,11 +12,11 @@ class WallpaperURLProviderTests: XCTestCase {
     let testURL = WallpaperURLProvider.testURL
 
     func testMetadataURL() {
-        let sut = WallpaperURLProvider()
-        let expectedURL = URL(string: "\(testURL)/metadata/\(sut.currentMetadataEndpoint)/wallpapers.json")
+        let subject = WallpaperURLProvider()
+        let expectedURL = URL(string: "\(testURL)/metadata/\(subject.currentMetadataEndpoint)/wallpapers.json")
 
         do {
-            let actualURL = try sut.url(for: .metadata)
+            let actualURL = try subject.url(for: .metadata)
             XCTAssertEqual(actualURL,
                            expectedURL,
                            "The metadata url builder is returning the wrong url.")
@@ -27,12 +27,12 @@ class WallpaperURLProviderTests: XCTestCase {
     }
 
     func testPathURL() {
-        let sut = WallpaperURLProvider()
+        let subject = WallpaperURLProvider()
         let path = "path/to/image"
         let expectedURL = URL(string: "\(testURL)/\(path).png")
 
         do {
-            let actualURL = try sut.url(for: .imageURL, withComponent: path)
+            let actualURL = try subject.url(for: .imageURL, withComponent: path)
             XCTAssertEqual(actualURL,
                            expectedURL,
                            "The image url builder is returning the wrong url.")


### PR DESCRIPTION
Proposing common standard for testing purpose. Using `subject` instead of `sut` so we don't use acronyms.