### PR TITLE
Add FXIOS-4791 [v106] Add message card tests

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -541,6 +541,7 @@
 		8A6B77CC2811C468001110D2 /* URLProtocolStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6B77CB2811C468001110D2 /* URLProtocolStub.swift */; };
 		8A6B77CE2811CD11001110D2 /* URLCaching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6B77CD2811CD11001110D2 /* URLCaching.swift */; };
 		8A7368AD27924AAF005D7704 /* CanRemoveQuickActionBookmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7368AC27924AAF005D7704 /* CanRemoveQuickActionBookmark.swift */; };
+		8A75F1B828B558E20054E34D /* MessageCardDataAdaptorImplementationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A75F1B728B558E20054E34D /* MessageCardDataAdaptorImplementationTests.swift */; };
 		8A7653BD28A2C61D00924ABF /* PocketDataAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7653BC28A2C61D00924ABF /* PocketDataAdaptor.swift */; };
 		8A7653BF28A2C92600924ABF /* PocketStandardCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7653BE28A2C92600924ABF /* PocketStandardCellViewModel.swift */; };
 		8A7653C228A2E57D00924ABF /* PocketDataAdaptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7653C128A2E57D00924ABF /* PocketDataAdaptorTests.swift */; };
@@ -3156,6 +3157,7 @@
 		8A6B77CB2811C468001110D2 /* URLProtocolStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProtocolStub.swift; sourceTree = "<group>"; };
 		8A6B77CD2811CD11001110D2 /* URLCaching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLCaching.swift; sourceTree = "<group>"; };
 		8A7368AC27924AAF005D7704 /* CanRemoveQuickActionBookmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanRemoveQuickActionBookmark.swift; sourceTree = "<group>"; };
+		8A75F1B728B558E20054E34D /* MessageCardDataAdaptorImplementationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCardDataAdaptorImplementationTests.swift; sourceTree = "<group>"; };
 		8A7653BC28A2C61D00924ABF /* PocketDataAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketDataAdaptor.swift; sourceTree = "<group>"; };
 		8A7653BE28A2C92600924ABF /* PocketStandardCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketStandardCellViewModel.swift; sourceTree = "<group>"; };
 		8A7653C128A2E57D00924ABF /* PocketDataAdaptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketDataAdaptorTests.swift; sourceTree = "<group>"; };
@@ -6140,6 +6142,7 @@
 			isa = PBXGroup;
 			children = (
 				8A32DD4F28B419B300D57C60 /* HomepageMessageCardViewModelTests.swift */,
+				8A75F1B728B558E20054E34D /* MessageCardDataAdaptorImplementationTests.swift */,
 			);
 			path = MessageCard;
 			sourceTree = "<group>";
@@ -10590,6 +10593,7 @@
 				DFA51484276103A000266AA0 /* HistoryHighlightsManagerTests.swift in Sources */,
 				3BFCBF201E04B1C50070C042 /* UIImageViewExtensionsTests.swift in Sources */,
 				8ADAFAC628AEBF6300FFEBE3 /* HomeLogoHeaderViewModelTests.swift in Sources */,
+				8A75F1B828B558E20054E34D /* MessageCardDataAdaptorImplementationTests.swift in Sources */,
 				C889D7CE2858C4B500121E1D /* ContextMenuHelperTests.swift in Sources */,
 				C838FD612899A9BB0068F60B /* WallpaperURLProviderTests.swift in Sources */,
 				8DCD3BCD1ED5B7FA00446D38 /* FxADeepLinkingTests.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -521,6 +521,7 @@
 		8A2D593E27DC0AA100713EC9 /* TopSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2D593D27DC0AA100713EC9 /* TopSite.swift */; };
 		8A3233FC286270CF003E1C33 /* FxBookmarkNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3233FB286270CF003E1C33 /* FxBookmarkNode.swift */; };
 		8A3233FE28627446003E1C33 /* LocalDesktopFolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3233FD28627446003E1C33 /* LocalDesktopFolder.swift */; };
+		8A32DD5028B419B300D57C60 /* HomepageMessageCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A32DD4F28B419B300D57C60 /* HomepageMessageCardViewModelTests.swift */; };
 		8A33221F27DFE318008F809E /* TopSitesDataAdaptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A33221E27DFE318008F809E /* TopSitesDataAdaptorTests.swift */; };
 		8A33222227DFE658008F809E /* NimbusMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A33222127DFE658008F809E /* NimbusMock.swift */; };
 		8A35497227BD672700534A65 /* ToggleSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A35497127BD672700534A65 /* ToggleSwitch.swift */; };
@@ -3135,6 +3136,7 @@
 		8A2D593D27DC0AA100713EC9 /* TopSite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSite.swift; sourceTree = "<group>"; };
 		8A3233FB286270CF003E1C33 /* FxBookmarkNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxBookmarkNode.swift; sourceTree = "<group>"; };
 		8A3233FD28627446003E1C33 /* LocalDesktopFolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDesktopFolder.swift; sourceTree = "<group>"; };
+		8A32DD4F28B419B300D57C60 /* HomepageMessageCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageMessageCardViewModelTests.swift; sourceTree = "<group>"; };
 		8A33221E27DFE318008F809E /* TopSitesDataAdaptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesDataAdaptorTests.swift; sourceTree = "<group>"; };
 		8A33222127DFE658008F809E /* NimbusMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusMock.swift; sourceTree = "<group>"; };
 		8A35497127BD672700534A65 /* ToggleSwitch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleSwitch.swift; sourceTree = "<group>"; };
@@ -6134,6 +6136,14 @@
 			path = Bookmarks;
 			sourceTree = "<group>";
 		};
+		8A32DD4E28B4199E00D57C60 /* MessageCard */ = {
+			isa = PBXGroup;
+			children = (
+				8A32DD4F28B419B300D57C60 /* HomepageMessageCardViewModelTests.swift */,
+			);
+			path = MessageCard;
+			sourceTree = "<group>";
+		};
 		8A33222027DFE64C008F809E /* TestingHelperClasses */ = {
 			isa = PBXGroup;
 			children = (
@@ -7275,6 +7285,7 @@
 		E1AEC16E286E0CF500062E29 /* Home */ = {
 			isa = PBXGroup;
 			children = (
+				8A32DD4E28B4199E00D57C60 /* MessageCard */,
 				8ADAFAC428AEBF5000FFEBE3 /* LogoHeader */,
 				8A7653C028A2E54800924ABF /* Pocket */,
 				5AF6254128A5799D00A90253 /* HistoryHighlights */,
@@ -10589,6 +10600,7 @@
 				8ADED7F0276A7788009C19E6 /* CumulativeDaysOfUseCounterTests.swift in Sources */,
 				E683F0A61E92E0820035D990 /* MockableHistory.swift in Sources */,
 				8A7653C528A2E69100924ABF /* MockPocketAPI.swift in Sources */,
+				8A32DD5028B419B300D57C60 /* HomepageMessageCardViewModelTests.swift in Sources */,
 				8A36AC2C2886F27F00CDC0AD /* MockTabManager.swift in Sources */,
 				5A3A7DD62889CF3D0065F81A /* RecentlySavedDataAdaptorTests.swift in Sources */,
 				8AD08D1727E91AC800B8E907 /* TabsQuantityTelemetryTests.swift in Sources */,

--- a/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -7,14 +7,6 @@ import Foundation
 import MozillaAppServices
 import Shared
 
-protocol GleanPlumbMessageManagable { }
-
-extension GleanPlumbMessageManagable {
-    var messagingManager: GleanPlumbMessageManager {
-        return GleanPlumbMessageManager.shared
-    }
-}
-
 protocol GleanPlumbMessageManagerProtocol {
 
     /// Performs the bookkeeping and preparation of messages for their respective surfaces.

--- a/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
+++ b/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
@@ -11,15 +11,19 @@ protocol MessageSurfaceProtocol {
     func handleMessageDismiss()
 }
 
-class HomepageMessageCardViewModel: MessageSurfaceProtocol, GleanPlumbMessageManagable {
+class HomepageMessageCardViewModel: MessageSurfaceProtocol {
 
     private let dataAdaptor: MessageCardDataAdaptor
+    private let messagingManager: GleanPlumbMessageManagerProtocol
+
     weak var delegate: HomepageDataModelDelegate?
     var message: GleanPlumbMessage?
     var dismissClosure: (() -> Void)?
 
-    init(dataAdaptor: MessageCardDataAdaptor) {
+    init(dataAdaptor: MessageCardDataAdaptor,
+         messagingManager: GleanPlumbMessageManagerProtocol = GleanPlumbMessageManager.shared) {
         self.dataAdaptor = dataAdaptor
+        self.messagingManager = messagingManager
     }
 
     func getMessage(for surface: MessageSurfaceId) -> GleanPlumbMessage? {

--- a/Client/Frontend/Home/MessageCard/MessageCardDataAdaptor.swift
+++ b/Client/Frontend/Home/MessageCard/MessageCardDataAdaptor.swift
@@ -12,14 +12,20 @@ protocol MessageCardDelegate: AnyObject {
     func didLoadNewData()
 }
 
-class MessageCardDataAdaptorImplementation: MessageCardDataAdaptor, GleanPlumbMessageManagable {
+class MessageCardDataAdaptorImplementation: MessageCardDataAdaptor {
+
+    private var message: GleanPlumbMessage?
+    private let messagingManager: GleanPlumbMessageManagerProtocol
 
     weak var delegate: MessageCardDelegate? {
         didSet {
             updateMessage()
         }
     }
-    private var message: GleanPlumbMessage?
+
+    init(messagingManager: GleanPlumbMessageManagerProtocol = GleanPlumbMessageManager.shared) {
+        self.messagingManager = messagingManager
+    }
 
     func getMessageCardData() -> GleanPlumbMessage? {
         return message

--- a/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
@@ -1,0 +1,189 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+
+class HomepageMessageCardViewModelTests: XCTestCase {
+
+    private var adaptor: MockMessageCardDataAdaptor!
+    private var messageManager: MockGleanPlumbMessageManagerProtocol!
+
+    override func setUp() {
+        super.setUp()
+        adaptor = MockMessageCardDataAdaptor()
+        messageManager = MockGleanPlumbMessageManagerProtocol()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        adaptor = nil
+        messageManager = nil
+    }
+
+    func testNilMessage() {
+        let subject = createSubject()
+
+        XCTAssertFalse(subject.hasData)
+        XCTAssertTrue(subject.isEnabled)
+        XCTAssertEqual(subject.headerViewModel, .emptyHeader)
+        XCTAssertEqual(subject.numberOfItemsInSection(), 1)
+        XCTAssertEqual(subject.sectionType, .messageCard)
+        XCTAssertFalse(subject.shouldDisplayMessageCard)
+    }
+
+    func testExpiredMessage() {
+        adaptor.message = createMessage(isExpired: true)
+        let subject = createSubject()
+        subject.didLoadNewData()
+
+        XCTAssertFalse(subject.hasData)
+        XCTAssertTrue(subject.isEnabled)
+        XCTAssertEqual(subject.headerViewModel, .emptyHeader)
+        XCTAssertEqual(subject.numberOfItemsInSection(), 1)
+        XCTAssertEqual(subject.sectionType, .messageCard)
+        XCTAssertFalse(subject.shouldDisplayMessageCard)
+    }
+
+    func testNotExpiredMessage() {
+        adaptor.message = createMessage(isExpired: false)
+        let subject = createSubject()
+        subject.didLoadNewData()
+
+        XCTAssertTrue(subject.hasData)
+        XCTAssertTrue(subject.isEnabled)
+        XCTAssertEqual(subject.headerViewModel, .emptyHeader)
+        XCTAssertEqual(subject.numberOfItemsInSection(), 1)
+        XCTAssertEqual(subject.sectionType, .messageCard)
+        XCTAssertTrue(subject.shouldDisplayMessageCard)
+    }
+
+    func testMessageDisplayed() {
+        adaptor.message = createMessage(isExpired: false)
+        let subject = createSubject()
+        subject.didLoadNewData() // This calls subject.handleMessageDisplayed()
+        subject.dismissClosure = {
+            XCTFail("Should not be called")
+        }
+
+        XCTAssertEqual(messageManager.onMessageDisplayedCalled, 1)
+        XCTAssertEqual(messageManager.onMessagePressedCalled, 0)
+        XCTAssertEqual(messageManager.onMessageDismissedCalled, 0)
+    }
+
+    func testMessagePressed() {
+        adaptor.message = createMessage(isExpired: false)
+        let subject = createSubject()
+        subject.didLoadNewData()
+        subject.dismissClosure = {
+            XCTAssert(true, "Dismiss closure is called")
+        }
+
+        subject.handleMessagePressed()
+        XCTAssertEqual(messageManager.onMessagePressedCalled, 1)
+        XCTAssertEqual(messageManager.onMessageDisplayedCalled, 1, "Displayed through didLoadNewData, needs to be 1")
+        XCTAssertEqual(messageManager.onMessageDismissedCalled, 0)
+    }
+
+    func testMessageDismiss() {
+        adaptor.message = createMessage(isExpired: false)
+        let subject = createSubject()
+        subject.didLoadNewData()
+        subject.dismissClosure = {
+            XCTAssert(true, "Dismiss closure is called")
+        }
+
+        subject.handleMessageDismiss()
+        XCTAssertEqual(messageManager.onMessageDismissedCalled, 1)
+        XCTAssertEqual(messageManager.onMessageDisplayedCalled, 1, "Displayed through didLoadNewData, needs to be 1")
+        XCTAssertEqual(messageManager.onMessagePressedCalled, 0)
+    }
+
+    // TODO:
+    // Laurie - func getMessage(for surface: MessageSurfaceId) -> GleanPlumbMessage? {
+    // Laurie - test configure
+
+    // other file
+    // Laurie - test adaptor
+}
+
+// MARK: - Helpers
+extension HomepageMessageCardViewModelTests {
+
+    func createSubject(file: StaticString = #file,
+                       line: UInt = #line) -> HomepageMessageCardViewModel {
+        let subject = HomepageMessageCardViewModel(dataAdaptor: adaptor,
+                                                   messagingManager: messageManager)
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
+    }
+
+    func createMessage(isExpired: Bool) -> GleanPlumbMessage {
+        let metadata = GleanPlumbMessageMetaData(id: "",
+                                                 impressions: 0,
+                                                 dismissals: 0,
+                                                 isExpired: isExpired)
+
+        return GleanPlumbMessage(id: "12345",
+                                 data: MockMessageDataProtocol(),
+                                 action: "",
+                                 triggers: [],
+                                 style: MockStyleDataProtocol(),
+                                 metadata: metadata)
+    }
+}
+
+// MARK: - MockMessageCardDataAdaptor
+class MockMessageCardDataAdaptor: MessageCardDataAdaptor {
+
+    var message: GleanPlumbMessage?
+
+    func getMessageCardData() -> GleanPlumbMessage? {
+        return message
+    }
+}
+
+// MARK: - MockMessageDataProtocol
+class MockMessageDataProtocol: MessageDataProtocol {
+    var surface: MessageSurfaceId = .newTabCard
+    var isControl: Bool = true
+    var title: String? = "Test"
+    var text: String = "This is a test"
+    var buttonLabel: String?
+}
+
+// MARK: - MockStyleDataProtocol
+class MockStyleDataProtocol: StyleDataProtocol {
+    var priority: Int = 0
+    var maxDisplayCount: Int = 3
+}
+
+// MARK: - MockGleanPlumbMessageManagerProtocol
+class MockGleanPlumbMessageManagerProtocol: GleanPlumbMessageManagerProtocol {
+    func onStartup() {}
+
+    var recordedSurface: MessageSurfaceId?
+    func getNextMessage(for surface: MessageSurfaceId) -> GleanPlumbMessage? {
+        recordedSurface = surface
+        return nil
+    }
+
+    var onMessageDisplayedCalled = 0
+    func onMessageDisplayed(_ message: GleanPlumbMessage) {
+        onMessageDisplayedCalled += 1
+    }
+
+    var onMessagePressedCalled = 0
+    func onMessagePressed(_ message: GleanPlumbMessage) {
+        onMessagePressedCalled += 1
+    }
+
+    var onMessageDismissedCalled = 0
+    func onMessageDismissed(_ message: GleanPlumbMessage) {
+        onMessageDismissedCalled += 1
+    }
+
+    func onMalformedMessage(messageKey: String) {}
+}

--- a/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
@@ -101,12 +101,24 @@ class HomepageMessageCardViewModelTests: XCTestCase {
         XCTAssertEqual(messageManager.onMessagePressedCalled, 0)
     }
 
-    // TODO:
-    // Laurie - func getMessage(for surface: MessageSurfaceId) -> GleanPlumbMessage? {
-    // Laurie - test configure
+    func testConfigureCallsMethod() throws {
+        let subject = createSubject()
+        let cell = SpyHomepageMessageCardCell(frame: .zero)
+        let configuredCell = try XCTUnwrap(subject.configure(cell, at: IndexPath(item: 0, section: 0))) as? SpyHomepageMessageCardCell
+        XCTAssertEqual(configuredCell?.configureCalled, 1)
+    }
 
-    // other file
-    // Laurie - test adaptor
+    func testGetMessageEmpty() {
+        let subject = createSubject()
+        XCTAssertNil(subject.getMessage(for: .newTabCard))
+    }
+
+    func testGetMessageNotEmpty() {
+        adaptor.message = createMessage(isExpired: false)
+        let subject = createSubject()
+        subject.didLoadNewData()
+        XCTAssertNotNil(subject.getMessage(for: .newTabCard))
+    }
 }
 
 // MARK: - Helpers
@@ -164,10 +176,11 @@ class MockStyleDataProtocol: StyleDataProtocol {
 class MockGleanPlumbMessageManagerProtocol: GleanPlumbMessageManagerProtocol {
     func onStartup() {}
 
+    var message: GleanPlumbMessage?
     var recordedSurface: MessageSurfaceId?
     func getNextMessage(for surface: MessageSurfaceId) -> GleanPlumbMessage? {
         recordedSurface = surface
-        return nil
+        return message
     }
 
     var onMessageDisplayedCalled = 0
@@ -186,4 +199,12 @@ class MockGleanPlumbMessageManagerProtocol: GleanPlumbMessageManagerProtocol {
     }
 
     func onMalformedMessage(messageKey: String) {}
+}
+
+// MARK: SpyHomepageMessageCardCell
+class SpyHomepageMessageCardCell: HomepageMessageCardCell {
+    var configureCalled = 0
+    override func configure(viewModel: HomepageMessageCardViewModel) {
+        configureCalled += 1
+    }
 }

--- a/Tests/ClientTests/Frontend/Home/MessageCard/MessageCardDataAdaptorImplementationTests.swift
+++ b/Tests/ClientTests/Frontend/Home/MessageCard/MessageCardDataAdaptorImplementationTests.swift
@@ -1,0 +1,85 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+
+class MessageCardDataAdaptorImplementationTests: XCTestCase {
+
+    private var messageManager: MockGleanPlumbMessageManagerProtocol!
+    private var didLoadNewDataCalled = 0
+
+    override func setUp() {
+        super.setUp()
+        messageManager = MockGleanPlumbMessageManagerProtocol()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        messageManager = nil
+        didLoadNewDataCalled = 0
+    }
+
+    func testEmptyData() {
+        let subject = createSubject()
+        XCTAssertNil(subject.getMessageCardData())
+    }
+
+    func testSettingDelegateUpdateData_noMessage() {
+        let subject = createSubject()
+        subject.delegate = self
+        XCTAssertEqual(didLoadNewDataCalled, 0)
+        XCTAssertNil(subject.getMessageCardData())
+    }
+
+    func testSettingDelegateUpdateData_expiredMessage() {
+        messageManager.message = createMessage(isExpired: true)
+        let subject = createSubject()
+        subject.delegate = self
+        XCTAssertEqual(didLoadNewDataCalled, 0)
+        XCTAssertNil(subject.getMessageCardData())
+    }
+
+    func testSettingDelegateUpdateData_validMessage() {
+        let message = createMessage(isExpired: false)
+        messageManager.message = message
+        let subject = createSubject()
+        subject.delegate = self
+        XCTAssertEqual(didLoadNewDataCalled, 1)
+        XCTAssertNotNil(subject.getMessageCardData())
+        XCTAssertEqual(subject.getMessageCardData()?.id, message.id)
+    }
+}
+
+extension MessageCardDataAdaptorImplementationTests: MessageCardDelegate {
+    func didLoadNewData() {
+        didLoadNewDataCalled += 1
+    }
+}
+
+// MARK: - Helpers
+extension MessageCardDataAdaptorImplementationTests {
+
+    func createSubject(file: StaticString = #file,
+                       line: UInt = #line) -> MessageCardDataAdaptorImplementation {
+        let subject = MessageCardDataAdaptorImplementation(messagingManager: messageManager)
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
+    }
+
+    func createMessage(isExpired: Bool) -> GleanPlumbMessage {
+        let metadata = GleanPlumbMessageMetaData(id: "",
+                                                 impressions: 0,
+                                                 dismissals: 0,
+                                                 isExpired: isExpired)
+
+        return GleanPlumbMessage(id: "12345",
+                                 data: MockMessageDataProtocol(),
+                                 action: "",
+                                 triggers: [],
+                                 style: MockStyleDataProtocol(),
+                                 metadata: metadata)
+    }
+}


### PR DESCRIPTION
# [FXIOS-4791](https://mozilla-hub.atlassian.net/browse/FXIOS-4791) https://github.com/mozilla-mobile/firefox-ios/issues/11647
- Add unit tests for message card
- Remove GleanPlumbMessageManagable to inject dependency instead for tests