### PR TITLE
Localize FXIOS-4761 [v106] App store warnings

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -3119,6 +3119,23 @@
 		8A04136828258DF600D20B10 /* SponsoredTileTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SponsoredTileTelemetry.swift; sourceTree = "<group>"; };
 		8A04136A2825ABEA00D20B10 /* SponsoredTileTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SponsoredTileTelemetryTests.swift; sourceTree = "<group>"; };
 		8A05123827D17EC3009930CC /* LegacyWallpaperStorageUtility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyWallpaperStorageUtility.swift; sourceTree = "<group>"; };
+		8A05811B28B56B8400FD8D46 /* gu-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "gu-IN"; path = "gu-IN.lproj/WidgetIntents.strings"; sourceTree = "<group>"; };
+		8A05811D28B56BB000FD8D46 /* ga */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ga; path = ga.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A05811F28B56C0B00FD8D46 /* jv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = jv; path = jv.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A05812128B56C1D00FD8D46 /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A05812328B56C3100FD8D46 /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A05812528B56C5900FD8D46 /* ses */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ses; path = ses.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A05812728B56C7200FD8D46 /* lv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lv; path = lv.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A05812928B56C8900FD8D46 /* ms */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ms; path = ms.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A05812B28B56CAC00FD8D46 /* ml */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ml; path = ml.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A05812D28B56CF200FD8D46 /* mr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mr; path = mr.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A05812F28B56D0900FD8D46 /* oc */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = oc; path = oc.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A05813128B56D3500FD8D46 /* or */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = or; path = or.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A05813328B56D5200FD8D46 /* fa */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fa; path = fa.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A05813528B56D7600FD8D46 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A05813728B56D9B00FD8D46 /* ta */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ta; path = ta.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A05813928B56DB900FD8D46 /* bo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bo; path = bo.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A05813B28B56DD700FD8D46 /* uz */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uz; path = uz.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
 		8A07910E278F62F2005529CB /* AdjustHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustHelper.swift; sourceTree = "<group>"; };
 		8A08EC6327EBDCAC00E119C7 /* AdServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdServices.framework; path = System/Library/Frameworks/AdServices.framework; sourceTree = SDKROOT; };
 		8A0F2A7D286DFCC800D84CC6 /* PushRemoteError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushRemoteError.swift; sourceTree = "<group>"; };
@@ -3158,6 +3175,16 @@
 		8A6B77CB2811C468001110D2 /* URLProtocolStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProtocolStub.swift; sourceTree = "<group>"; };
 		8A6B77CD2811CD11001110D2 /* URLCaching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLCaching.swift; sourceTree = "<group>"; };
 		8A7368AC27924AAF005D7704 /* CanRemoveQuickActionBookmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanRemoveQuickActionBookmark.swift; sourceTree = "<group>"; };
+		8A75F1D428B56A2C0054E34D /* af */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A75F1D628B56A6C0054E34D /* anp */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = anp; path = anp.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A75F1D828B56A880054E34D /* an */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = an; path = an.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A75F1DA28B56AA20054E34D /* az */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = az; path = az.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A75F1DC28B56ABF0054E34D /* be */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = be; path = be.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A75F1DE28B56AE00054E34D /* bs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bs; path = bs.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A75F1E028B56AF20054E34D /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A75F1E228B56B090054E34D /* my */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = my; path = my.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A75F1E428B56B1E0054E34D /* fil */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fil; path = fil.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A75F1E628B56B330054E34D /* gl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = gl; path = gl.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
 		8A7653BC28A2C61D00924ABF /* PocketDataAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketDataAdaptor.swift; sourceTree = "<group>"; };
 		8A7653BE28A2C92600924ABF /* PocketStandardCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketStandardCellViewModel.swift; sourceTree = "<group>"; };
 		8A7653C128A2E57D00924ABF /* PocketDataAdaptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketDataAdaptorTests.swift; sourceTree = "<group>"; };
@@ -13142,6 +13169,33 @@
 				D4BF6AA72893DDA6001B5130 /* en-US */,
 				43F2ED6D2897ECB500DF76DA /* et */,
 				43DC31A528B39F100034E6DF /* si */,
+				8A75F1D428B56A2C0054E34D /* af */,
+				8A75F1D628B56A6C0054E34D /* anp */,
+				8A75F1D828B56A880054E34D /* an */,
+				8A75F1DA28B56AA20054E34D /* az */,
+				8A75F1DC28B56ABF0054E34D /* be */,
+				8A75F1DE28B56AE00054E34D /* bs */,
+				8A75F1E028B56AF20054E34D /* bg */,
+				8A75F1E228B56B090054E34D /* my */,
+				8A75F1E428B56B1E0054E34D /* fil */,
+				8A75F1E628B56B330054E34D /* gl */,
+				8A05811B28B56B8400FD8D46 /* gu-IN */,
+				8A05811D28B56BB000FD8D46 /* ga */,
+				8A05811F28B56C0B00FD8D46 /* jv */,
+				8A05812128B56C1D00FD8D46 /* kn */,
+				8A05812328B56C3100FD8D46 /* km */,
+				8A05812528B56C5900FD8D46 /* ses */,
+				8A05812728B56C7200FD8D46 /* lv */,
+				8A05812928B56C8900FD8D46 /* ms */,
+				8A05812B28B56CAC00FD8D46 /* ml */,
+				8A05812D28B56CF200FD8D46 /* mr */,
+				8A05812F28B56D0900FD8D46 /* oc */,
+				8A05813128B56D3500FD8D46 /* or */,
+				8A05813328B56D5200FD8D46 /* fa */,
+				8A05813528B56D7600FD8D46 /* ro */,
+				8A05813728B56D9B00FD8D46 /* ta */,
+				8A05813928B56DB900FD8D46 /* bo */,
+				8A05813B28B56DD700FD8D46 /* uz */,
 			);
 			name = WidgetIntents.intentdefinition;
 			sourceTree = "<group>";

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -3136,6 +3136,11 @@
 		8A05813728B56D9B00FD8D46 /* ta */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ta; path = ta.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
 		8A05813928B56DB900FD8D46 /* bo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bo; path = bo.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
 		8A05813B28B56DD700FD8D46 /* uz */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uz; path = uz.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A05814B28B56DD700FD8D46 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A05815B28B56DD700FD8D46 /* si */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = si; path = si.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A05816B28B56DD700FD8D46 /* hi-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "hi-IN"; path = "hi-IN.lproj/WidgetIntents.strings"; sourceTree = "<group>"; };
+		8A05817B28B56DD700FD8D46 /* ast */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ast; path = ast.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A05818B28B56DD700FD8D46 /* te */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = te; path = te.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
 		8A07910E278F62F2005529CB /* AdjustHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustHelper.swift; sourceTree = "<group>"; };
 		8A08EC6327EBDCAC00E119C7 /* AdServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdServices.framework; path = System/Library/Frameworks/AdServices.framework; sourceTree = SDKROOT; };
 		8A0F2A7D286DFCC800D84CC6 /* PushRemoteError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushRemoteError.swift; sourceTree = "<group>"; };
@@ -13196,6 +13201,11 @@
 				8A05813728B56D9B00FD8D46 /* ta */,
 				8A05813928B56DB900FD8D46 /* bo */,
 				8A05813B28B56DD700FD8D46 /* uz */,
+				8A05814B28B56DD700FD8D46 /* fi */,
+				8A05815B28B56DD700FD8D46 /* si */,
+				8A05816B28B56DD700FD8D46 /* hi-IN */,
+				8A05817B28B56DD700FD8D46 /* ast */,
+				8A05818B28B56DD700FD8D46 /* te */,
 			);
 			name = WidgetIntents.intentdefinition;
 			sourceTree = "<group>";

--- a/WidgetKit/af.lproj/WidgetIntents.strings
+++ b/WidgetKit/af.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/an.lproj/WidgetIntents.strings
+++ b/WidgetKit/an.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/anp.lproj/WidgetIntents.strings
+++ b/WidgetKit/anp.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/ast.lproj/WidgetIntents.strings
+++ b/WidgetKit/ast.lproj/WidgetIntents.strings
@@ -10,3 +10,38 @@
 /* (No Comment) */
 "xRJbBP" = "Busca nueva";
 
+/* (No Comment) */
+"2GqvPe" = "Siirry kopioituun linkkiin";
+
+/* (No Comment) */
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+/* (No Comment) */
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+/* (No Comment) */
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+/* (No Comment) */
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+/* (No Comment) */
+"ctDNmu" = "Quick access to various Firefox actions";
+
+/* (No Comment) */
+"eHmH1H" = "Clear Private Tabs";
+
+/* (No Comment) */
+"eV8mOT" = "Quick Action Type";
+
+/* (No Comment) */
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+/* (No Comment) */
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+/* (No Comment) */
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+/* (No Comment) */
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";

--- a/WidgetKit/az.lproj/WidgetIntents.strings
+++ b/WidgetKit/az.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/be.lproj/WidgetIntents.strings
+++ b/WidgetKit/be.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/bg.lproj/WidgetIntents.strings
+++ b/WidgetKit/bg.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/bo.lproj/WidgetIntents.strings
+++ b/WidgetKit/bo.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/bs.lproj/WidgetIntents.strings
+++ b/WidgetKit/bs.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/fa.lproj/WidgetIntents.strings
+++ b/WidgetKit/fa.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/fi.lproj/WidgetIntents.strings
+++ b/WidgetKit/fi.lproj/WidgetIntents.strings
@@ -1,3 +1,32 @@
-/* (No Comment) */
 "2GqvPe" = "Siirry kopioituun linkkiin";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
 

--- a/WidgetKit/fil.lproj/WidgetIntents.strings
+++ b/WidgetKit/fil.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/ga.lproj/WidgetIntents.strings
+++ b/WidgetKit/ga.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/gl.lproj/WidgetIntents.strings
+++ b/WidgetKit/gl.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/gu-IN.lproj/WidgetIntents.strings
+++ b/WidgetKit/gu-IN.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/hi-IN.lproj/WidgetIntents.strings
+++ b/WidgetKit/hi-IN.lproj/WidgetIntents.strings
@@ -19,3 +19,30 @@
 /* (No Comment) */
 "xRJbBP" = "नयी खोज";
 
+/* (No Comment) */
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+/* (No Comment) */
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+/* (No Comment) */
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+/* (No Comment) */
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+/* (No Comment) */
+"ctDNmu" = "Quick access to various Firefox actions";
+
+/* (No Comment) */
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+/* (No Comment) */
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+/* (No Comment) */
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+/* (No Comment) */
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+

--- a/WidgetKit/jv.lproj/WidgetIntents.strings
+++ b/WidgetKit/jv.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/km.lproj/WidgetIntents.strings
+++ b/WidgetKit/km.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/kn.lproj/WidgetIntents.strings
+++ b/WidgetKit/kn.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/lv.lproj/WidgetIntents.strings
+++ b/WidgetKit/lv.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/ml.lproj/WidgetIntents.strings
+++ b/WidgetKit/ml.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/mr.lproj/WidgetIntents.strings
+++ b/WidgetKit/mr.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/ms.lproj/WidgetIntents.strings
+++ b/WidgetKit/ms.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/my.lproj/WidgetIntents.strings
+++ b/WidgetKit/my.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/oc.lproj/WidgetIntents.strings
+++ b/WidgetKit/oc.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/or.lproj/WidgetIntents.strings
+++ b/WidgetKit/or.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/ro.lproj/WidgetIntents.strings
+++ b/WidgetKit/ro.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/ses.lproj/WidgetIntents.strings
+++ b/WidgetKit/ses.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/ta.lproj/WidgetIntents.strings
+++ b/WidgetKit/ta.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/te.lproj/WidgetIntents.strings
+++ b/WidgetKit/te.lproj/WidgetIntents.strings
@@ -4,3 +4,45 @@
 /* (No Comment) */
 "eHmH1H" = "అంతరంగిక ట్యాబులను తుడిచివేయి";
 
+/* (No Comment) */
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+/* (No Comment) */
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+/* (No Comment) */
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+/* (No Comment) */
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+/* (No Comment) */
+"ctDNmu" = "Quick access to various Firefox actions";
+
+/* (No Comment) */
+"eV8mOT" = "Quick Action Type";
+
+/* (No Comment) */
+"eqyNJg" = "Quick Action";
+
+/* (No Comment) */
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+/* (No Comment) */
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+/* (No Comment) */
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+/* (No Comment) */
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+/* (No Comment) */
+"scEmjs" = "New Private Search";
+
+/* (No Comment) */
+"w9jdPK" = "Quick Action";
+
+/* (No Comment) */
+"xRJbBP" = "New Search";
+

--- a/WidgetKit/uz.lproj/WidgetIntents.strings
+++ b/WidgetKit/uz.lproj/WidgetIntents.strings
@@ -1,0 +1,32 @@
+"2GqvPe" = "Go to Copied Link";
+
+"PzSrmZ-2GqvPe" = "Just to confirm, you wanted ‘Go to Copied Link’?";
+
+"PzSrmZ-eHmH1H" = "Just to confirm, you wanted ‘Clear Private Tabs’?";
+
+"PzSrmZ-scEmjs" = "Just to confirm, you wanted ‘New Private Search’?";
+
+"PzSrmZ-xRJbBP" = "Just to confirm, you wanted ‘New Search’?";
+
+"ctDNmu" = "Quick access to various Firefox actions";
+
+"eHmH1H" = "Clear Private Tabs";
+
+"eV8mOT" = "Quick Action Type";
+
+"eqyNJg" = "Quick Action";
+
+"fi3W24-2GqvPe" = "There are ${count} options matching ‘Go to Copied Link’.";
+
+"fi3W24-eHmH1H" = "There are ${count} options matching ‘Clear Private Tabs’.";
+
+"fi3W24-scEmjs" = "There are ${count} options matching ‘New Private Search’.";
+
+"fi3W24-xRJbBP" = "There are ${count} options matching ‘New Search’.";
+
+"scEmjs" = "New Private Search";
+
+"w9jdPK" = "Quick Action";
+
+"xRJbBP" = "New Search";
+


### PR DESCRIPTION
# [FXIOS-4761](https://mozilla-hub.atlassian.net/browse/FXIOS-4761) https://github.com/mozilla-mobile/firefox-ios/issues/11596
- WidgetKit intent was missing some locales. When we send builds to App store connect, it warns us about those missing locales. 
- Interestingly, some `*.lproj` files for those locales where present but not referenced in Xcode project (for locales fi, si, hi-IN, ast, te)
- Since those locales are added, they will appear as new strings in the next export. Note that the comment explaining those strings are added through the [l10n_comments.txt](https://github.com/mozilla-mobile/firefox-ios/blob/main/l10n_comments.txt) file. That file is then parsed when using the LocalizationTools project

### List of added locales for WidgetKit
- ta: Tamil
- or: Odia
- an: Aragonese
- ms: Malay
- fa: Persian
- bg: Bulgarian
- km: Khmer
- ses: Koyraboro Senni
- gu-IN: Gujarati
- fi: Finnish
- bo: Tibetan
- mr: Marathi
- my: Burmese
- az: Azerbaijani
- ro: Romanian
- be: Belarusian
- ga: Irish
- anp: Angika
- bs: Bosnian
- si Sinhala
- af: Afrikaans
- hi-IN: Hindi
- gl: Galician
- lv: Latvian
- ast: Asturian
- te: Telugu
- uz: Uzbek
- oc: Occitan
- kn: Kannada
- ml: Malayalam
- jv: Javanese
- fil: Filipino