### PR TITLE
Refactor FXIOS-4547 [v105] Updated Bing search code for iPad

### DIFF
--- a/Client/Frontend/Browser/OpenSearch.swift
+++ b/Client/Frontend/Browser/OpenSearch.swift
@@ -167,9 +167,11 @@ class OpenSearchEngine: NSObject, NSCoding {
  */
 class OpenSearchParser {
     fileprivate let pluginMode: Bool
+    fileprivate let userInterfaceIdiom: UIUserInterfaceIdiom
 
-    init(pluginMode: Bool) {
+    init(pluginMode: Bool, userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
         self.pluginMode = pluginMode
+        self.userInterfaceIdiom = userInterfaceIdiom
     }
 
     func parse(_ file: String, engineID: String) -> OpenSearchEngine? {
@@ -243,7 +245,7 @@ class OpenSearchParser {
                         }
 
                         // Ref: FXIOS-4547 required us to change partner code (pc) for Bing search on iPad 
-                        if name == "pc", shortName == "Bing", UIDevice.current.userInterfaceIdiom == .pad {
+                        if name == "pc", shortName == "Bing", userInterfaceIdiom == .pad {
                             value = "MOZL"
                         }
 

--- a/Client/Frontend/Browser/OpenSearch.swift
+++ b/Client/Frontend/Browser/OpenSearch.swift
@@ -236,11 +236,17 @@ class OpenSearchParser {
                         }
 
                         let name = paramIndexer.attributes["name"]
-                        let value = paramIndexer.attributes["value"]
+                        var value = paramIndexer.attributes["value"]
                         if name == nil || value == nil {
                             print("Param element must have name and value attributes", terminator: "\n")
                             return nil
                         }
+
+                        // Change partner code (pc) for Bing search on iPad (quick fix)
+                        if name == "pc", shortName == "Bing", UIDevice.current.userInterfaceIdiom == .pad {
+                            value = "MOZL"
+                        }
+
                         template! += name! + "=" + value!
                     }
                 }

--- a/Client/Frontend/Browser/OpenSearch.swift
+++ b/Client/Frontend/Browser/OpenSearch.swift
@@ -242,7 +242,7 @@ class OpenSearchParser {
                             return nil
                         }
 
-                        // Change partner code (pc) for Bing search on iPad (quick fix)
+                        // Ref: FXIOS-4547 required us to change partner code (pc) for Bing search on iPad 
                         if name == "pc", shortName == "Bing", UIDevice.current.userInterfaceIdiom == .pad {
                             value = "MOZL"
                         }

--- a/Tests/ClientTests/SearchTests.swift
+++ b/Tests/ClientTests/SearchTests.swift
@@ -143,6 +143,26 @@ class SearchTests: XCTestCase {
         XCTAssertEqual(searchTerm, yaaniEngine.queryForSearchURL(yaaniSearchURL))
     }
 
+    func testBingParsing_iPhone_hasIphonePartnerCode() {
+        let parser = OpenSearchParser(pluginMode: true, userInterfaceIdiom: .phone)
+        let file = Bundle.main.path(forResource: "bing", ofType: "xml", inDirectory: "SearchPlugins/")
+        let engine: OpenSearchEngine! = parser.parse(file!, engineID: "bing")
+        XCTAssertEqual(engine.shortName, "Bing")
+
+        let containsPartnerCode = engine.searchTemplate.contains("pc=MOZW")
+        XCTAssertTrue(containsPartnerCode)
+    }
+
+    func testBingParsing_iPad_hasIpadPartnerCode() {
+        let parser = OpenSearchParser(pluginMode: true, userInterfaceIdiom: .pad)
+        let file = Bundle.main.path(forResource: "bing", ofType: "xml", inDirectory: "SearchPlugins/")
+        let engine: OpenSearchEngine! = parser.parse(file!, engineID: "bing")
+        XCTAssertEqual(engine.shortName, "Bing")
+
+        let containsPartnerCode = engine.searchTemplate.contains("pc=MOZL")
+        XCTAssertTrue(containsPartnerCode)
+    }
+
     fileprivate func startMockSuggestServer() -> String {
         let webServer: GCDWebServer = GCDWebServer()
 


### PR DESCRIPTION
This is a quick fix and should be revisited to find a better solution if more search engines require iPad specific partner codes.

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-4547)
#11276