### PR TITLE
Bugfix FXIOS-4813 [v105] Remove hack to stop collection view updating

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -912,9 +912,6 @@ class BrowserViewController: UIViewController {
 
         homepageViewController?.applyTheme()
         homepageViewController?.recordHomepageAppeared(isZeroSearch: !inline)
-
-        // Hack to force updates on the view
-        homepageViewController?.view.alpha = 0.001
         homepageViewController?.reloadView()
         NotificationCenter.default.post(name: .ShowHomepage, object: nil)
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -648,8 +648,7 @@ extension HomepageViewController: HomepageViewModelDelegate {
     func reloadView() {
         ensureMainThread { [weak self] in
             // If the view controller is not visible ignore updates
-            guard let self = self,
-                  self.view.alpha != 0
+            guard let self = self
             else { return }
 
             self.viewModel.refreshData(for: self.traitCollection)


### PR DESCRIPTION
# https://github.com/mozilla-mobile/firefox-ios/issues/11696 [FXIOS-4813](https://mozilla-hub.atlassian.net/browse/FXIOS-4813)
I think part of the problem is that we don't have a good understanding of what triggers the closures provided to the UICollectionViewCompositionalLayout. It's not well documented and it fires seemingly randomly.
This instance of the crash seems to occur occasionally when an update to the collection view is ignored because it's not currently visible but the layout closure is fired anyway and since reloadData wasn't called to give the collection view the latest data about how many sections/cells it has the layout closure is trying to make updates to sections or cells that it no longer has data for (in this scenario a tab that no longer exists).

Hopefully we have closed enough of the other gaps that this hack is no longer needed or at the very least it is now causing more issues than it's solving. I'm no longer able to repo the crash on this branch but it was happening intermittently so I can't be sure.