### PR TITLE
Bump FXIOS-4797 [v106] Upgrade Sentry to 7.23.0

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -16025,7 +16025,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
 				kind = exactVersion;
-				version = 7.9.0;
+				version = 7.23.0;
 			};
 		};
 		4368F83B279669690013419B /* XCRemoteSwiftPackageReference "SnapKit" */ = {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -103,8 +103,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "967f04b3cd6989df3f9ced3060481a21646c146d",
-        "version" : "7.9.0"
+        "revision" : "5bc31fd9bb476539387de7c6ff32acfaf2407157",
+        "version" : "7.23.0"
       }
     },
     {


### PR DESCRIPTION
# [FXIOS-4797](https://mozilla-hub.atlassian.net/browse/FXIOS-4797) https://github.com/mozilla-mobile/firefox-ios/issues/11660
Upgrade Sentry to 7.23.0