### PR TITLE
Add #11029 [v106]: Page action menu telemetry additions

### DIFF
--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -278,6 +278,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
 
             let shouldFocusLocationField = NewTabAccessors.getNewTabPage(self.profile.prefs) == .blankPage
             self.delegate?.openBlankNewTab(focusLocationField: shouldFocusLocationField, isPrivate: false, searchFor: nil)
+            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .createNewTab)
         }.items
     }
 
@@ -285,6 +286,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
         return SingleActionViewModel(title: .AppMenu.AppMenuHistory,
                                      iconString: ImageIdentifiers.history) { _ in
             self.delegate?.showLibrary(panel: .history)
+            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .viewHistoryPanel)
         }.items
     }
 
@@ -292,6 +294,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
         return SingleActionViewModel(title: .AppMenu.AppMenuDownloads,
                                      iconString: ImageIdentifiers.downloads) { _ in
             self.delegate?.showLibrary(panel: .downloads)
+            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .viewDownloadsPanel)
         }.items
     }
 

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -483,6 +483,9 @@ extension TelemetryWrapper {
         case awesomebarLocation = "awesomebar-position"
         case searchHighlights = "search-highlights"
         case clearSDWebImageCache = "clear-sd-webimage-cache"
+        case viewDownloadsPanel = "view-downloads-panel"
+        case viewHistoryPanel = "view-history-panel"
+        case createNewTab = "create-new-tab"
     }
 
     public enum EventValue: String {
@@ -1051,6 +1054,12 @@ extension TelemetryWrapper {
             GleanMetrics.PageActionMenu.requestDesktopSite.add()
         case (.action, .tap, .requestMobileSite, _, _):
             GleanMetrics.PageActionMenu.requestMobileSite.add()
+        case (.action, .tap, .viewDownloadsPanel, _, _):
+            GleanMetrics.PageActionMenu.viewDownloadsPanel.add()
+        case (.action, .tap, .viewHistoryPanel, _, _):
+            GleanMetrics.PageActionMenu.viewHistoryPanel.add()
+        case (.action, .tap, .createNewTab, _, _):
+            GleanMetrics.PageActionMenu.createNewTab.add()
 
         // MARK: Inactive Tab Tray
         case (.action, .tap, .inactiveTabTray, .openInactiveTab, _):

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -1582,7 +1582,7 @@ page_action_menu:
   create_new_tab:
     type: counter
     description: |
-      Counts the number of timesa user creates a new tab from the
+      Counts the number of times a user creates a new tab from the
       page action menu.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/11029

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -1555,6 +1555,42 @@ page_action_menu:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2023-01-01"
+  view_downloads_panel:
+    type: counter
+    description: |
+      Counts the number of times a user navigates to the downloads panel
+      from the page action menu.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/11029
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/11714
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-01-01"
+  view_history_panel:
+    type: counter
+    description: |
+      Counts the number of times a user navigates to the history panel
+      from the page action menu.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/11029
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/11714
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-01-01"
+  create_new_tab:
+    type: counter
+    description: |
+      Counts the number of timesa user creates a new tab from the
+      page action menu.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/11029
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/11714
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-01-01"
 
 # Pocket
 pocket:

--- a/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -315,6 +315,39 @@ class TelemetryWrapperTests: XCTestCase {
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Awesomebar.searchResultTap)
     }
+
+    // MARK: - Page Action Menu
+
+    func test_createNewTab_GleanIsCalled() {
+        TelemetryWrapper.recordEvent(
+            category: .action,
+            method: .tap,
+            object: .createNewTab
+        )
+
+        testCounterMetricRecordingSuccess(metric: GleanMetrics.PageActionMenu.createNewTab)
+
+    }
+
+    func test_viewHistoryPanel_GleanIsCalled() {
+        TelemetryWrapper.recordEvent(
+            category: .action,
+            method: .tap,
+            object: .viewHistoryPanel
+        )
+
+        testCounterMetricRecordingSuccess(metric: GleanMetrics.PageActionMenu.viewHistoryPanel)
+    }
+
+    func test_viewDownloadsPanel_GleanIsCalled() {
+        TelemetryWrapper.recordEvent(
+            category: .action,
+            method: .tap,
+            object: .viewDownloadsPanel
+        )
+
+        testCounterMetricRecordingSuccess(metric: GleanMetrics.PageActionMenu.viewDownloadsPanel)
+    }
 }
 
 // MARK: - Helper functions to test telemetry


### PR DESCRIPTION
# #11029 | [FXIOS-4401](https://mozilla-hub.atlassian.net/browse/FXIOS-4401)

This PR adds telemetry for three actions in the page action menu. A user can always opt out through settings. 