### PR TITLE
Refactor FXIOS-4825 [v106] Rename usage of github action repo

### DIFF
--- a/.github/workflows/update-nimbus-experiments.yml
+++ b/.github/workflows/update-nimbus-experiments.yml
@@ -17,7 +17,7 @@ jobs:
           ref: main
       - name: "Update Experiments JSON"
         id: update-experiments-json
-        uses: mozilla-mobile/update-initial-experiments@v1
+        uses: mozilla-mobile/update-experiments@v1
         with:
           repo-path: firefox-ios
           output-path: Client/Experiments/initial_experiments.json


### PR DESCRIPTION
The github action repo for updating the initial experiments is being updated to have a new name.

#11719
https://mozilla-hub.atlassian.net/browse/EXP-2683

Bug to rename the repository: https://bugzilla.mozilla.org/show_bug.cgi?id=1787314