### PR TITLE
Localize FXIOS-11707 Add missing es translations to home main menu

### DIFF
--- a/Shared/es.lproj/Localizable.strings
+++ b/Shared/es.lproj/Localizable.strings
@@ -619,8 +619,14 @@
 /* Toast displayed to user after copy url pressed. */
 "Menu.CopyURL.Confirm" = "URL copiada en el portapapeles";
 
+/* Label for the customize homepage button in the menu page. Pressing this button takes users to the settings options, where they can customize the Firefox Home page */
+"Menu.CustomizeHomePage.v99" = "Personalizar página de inicio";
+
 /* Label for the button, displayed in the menu, takes you to to Downloads screen when pressed. */
 "Menu.Downloads.Label" = "Descargas";
+
+/* Label for the help button in the menu page. Pressing this button opens the support page https://support.mozilla.org/en-US/products/ios */
+"Menu.Help.v99" = "Ayuda";
 
 /* Label for the button, displayed in the menu, takes you to to History screen when pressed. */
 "Menu.History.Label" = "Historial";


### PR DESCRIPTION
I noticed there is some missing spanish translations in home main menu. Im curious because this translations are in es-AR, es-MX, etc. But are missing in es.
This solves https://github.com/mozilla-mobile/firefox-ios/issues/11729